### PR TITLE
[codex] Implement A2A push auth schemes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1876,6 +1876,7 @@ dependencies = [
  "harn-vm",
  "hex",
  "hmac 0.13.0",
+ "jsonwebtoken",
  "rcgen",
  "reqwest",
  "rustls",

--- a/crates/harn-hostlib/README.md
+++ b/crates/harn-hostlib/README.md
@@ -155,6 +155,12 @@ a token-budgeted text repo map. Two builtins:
   — refresh the snapshot. Falls back to a full rescan when the snapshot is
   missing or the diff exceeds ~30% of the workspace.
 
+The Rust scanner API routes Git-backed file discovery and churn scoring through
+`GitCapabilities`. The default hostlib builtin uses the Git CLI only when the
+scan root is inside a worktree; embedders and tests can supply a mock capability
+with `scan_project_with_git` when they need deterministic scanner behavior
+without depending on ambient checkout state.
+
 Unlike the `tools/` surface, the scanner is **not** gated by
 `hostlib_enable("tools:deterministic")`: producing a `ScanResult` is a
 read-only operation that doesn't mutate user state and the snapshot file

--- a/crates/harn-hostlib/src/scanner/discover.rs
+++ b/crates/harn-hostlib/src/scanner/discover.rs
@@ -3,18 +3,19 @@
 //!
 //! Discovery semantics:
 //!
-//! 1. Try `git ls-files --cached --others --exclude-standard` (so the file
+//! 1. Ask the scanner's [`GitCapabilities`](super::GitCapabilities) for
+//!    `git ls-files --cached --others --exclude-standard` data (so the file
 //!    set matches `git status` perfectly when run inside a checkout).
-//! 2. Fall back to a `walkdir`/`ignore` walk that honors `.gitignore` and
-//!    the [`super::extensions::EXCLUDED_DIRS`] table.
+//! 2. Fall back to a `walkdir`/`ignore` walk when Git data is unavailable.
+//!    The fallback honors `.gitignore` and the
+//!    [`super::extensions::EXCLUDED_DIRS`] table.
 //! 3. Filter to source extensions and de-duplicate.
 
-use std::path::{Path, PathBuf};
-use std::process::Command;
-
 use ignore::WalkBuilder;
+use std::path::{Path, PathBuf};
 
 use crate::scanner::extensions::{is_excluded_dir, should_include, should_traverse};
+use crate::scanner::GitCapabilities;
 
 /// One discovered file. Paths are stored side-by-side because the scanner
 /// reads each file by absolute path but stores everything under
@@ -29,11 +30,12 @@ pub struct DiscoveredFile {
 
 /// Run discovery against `root`. Returns deterministic, alphabetically
 /// sorted entries.
-pub fn discover_files(root: &Path, opts: DiscoverOptions) -> Vec<DiscoveredFile> {
-    let mut files = git_ls_files(root).unwrap_or_default();
-    if files.is_empty() {
-        files = walk_files(root, opts);
-    }
+pub fn discover_files(
+    root: &Path,
+    opts: DiscoverOptions,
+    git: &dyn GitCapabilities,
+) -> Vec<DiscoveredFile> {
+    let mut files = git_ls_files(root, git).unwrap_or_else(|| walk_files(root, opts));
     files.retain(|entry| should_include(&entry.relative_path));
     files.sort_by(|a, b| a.relative_path.cmp(&b.relative_path));
     files.dedup_by(|a, b| a.relative_path == b.relative_path);
@@ -58,41 +60,27 @@ impl Default for DiscoverOptions {
     }
 }
 
-fn git_ls_files(root: &Path) -> Option<Vec<DiscoveredFile>> {
-    let mut cmd = Command::new("git");
-    super::strip_ambient_git_env(&mut cmd);
-    let output = cmd
-        .args([
-            "-C",
-            root.to_str()?,
-            "ls-files",
-            "--cached",
-            "--others",
-            "--exclude-standard",
-        ])
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    let stdout = String::from_utf8(output.stdout).ok()?;
+fn git_ls_files(root: &Path, git: &dyn GitCapabilities) -> Option<Vec<DiscoveredFile>> {
+    let paths = git.list_files(root)?;
     let mut entries = Vec::new();
-    for line in stdout.lines() {
-        if line.is_empty() {
+    let mut saw_path = false;
+    for path in paths {
+        if path.is_empty() {
             continue;
         }
-        if !should_traverse(line) {
+        saw_path = true;
+        if !should_traverse(&path) {
             continue;
         }
         entries.push(DiscoveredFile {
-            relative_path: line.to_string(),
-            absolute_path: root.join(line),
+            absolute_path: root.join(&path),
+            relative_path: path,
         });
     }
-    if entries.is_empty() {
-        None
-    } else {
+    if saw_path {
         Some(entries)
+    } else {
+        None
     }
 }
 
@@ -161,10 +149,52 @@ mod tests {
         fs::write(root.join("README.md"), "# hi").unwrap();
         fs::write(root.join("node_modules/foo/bar.js"), "x").unwrap();
 
-        let files = discover_files(root, DiscoverOptions::default());
+        let files = discover_files(root, DiscoverOptions::default(), &NoGit);
         let names: Vec<_> = files.iter().map(|f| f.relative_path.as_str()).collect();
         assert!(names.contains(&"src/main.rs"));
         assert!(names.contains(&"README.md"));
         assert!(!names.iter().any(|n| n.starts_with("node_modules")));
+    }
+
+    #[test]
+    fn git_file_list_comes_from_injected_capability() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        fs::create_dir_all(root.join("src")).unwrap();
+        fs::write(root.join("src/tracked.rs"), "fn tracked() {}\n").unwrap();
+        fs::write(root.join("src/unlisted.rs"), "fn unlisted() {}\n").unwrap();
+
+        let git = MockGit {
+            files: vec!["src/tracked.rs".to_string()],
+        };
+        let files = discover_files(root, DiscoverOptions::default(), &git);
+        let names: Vec<_> = files.iter().map(|f| f.relative_path.as_str()).collect();
+        assert_eq!(names, vec!["src/tracked.rs"]);
+    }
+
+    struct NoGit;
+
+    impl GitCapabilities for NoGit {
+        fn list_files(&self, _root: &Path) -> Option<Vec<String>> {
+            None
+        }
+
+        fn churn_scores(&self, _root: &Path) -> std::collections::BTreeMap<String, f64> {
+            std::collections::BTreeMap::new()
+        }
+    }
+
+    struct MockGit {
+        files: Vec<String>,
+    }
+
+    impl GitCapabilities for MockGit {
+        fn list_files(&self, _root: &Path) -> Option<Vec<String>> {
+            Some(self.files.clone())
+        }
+
+        fn churn_scores(&self, _root: &Path) -> std::collections::BTreeMap<String, f64> {
+            std::collections::BTreeMap::new()
+        }
     }
 }

--- a/crates/harn-hostlib/src/scanner/git.rs
+++ b/crates/harn-hostlib/src/scanner/git.rs
@@ -1,0 +1,130 @@
+//! Git-backed scanner inputs.
+//!
+//! The scanner core consumes Git through this capability boundary so tests
+//! can exercise tracked-file and churn behavior without depending on the
+//! ambient checkout, Git hooks, fsmonitor, or hook-time environment state.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::process::Command;
+
+/// Git data needed by the scanner.
+pub trait GitCapabilities {
+    /// Return tracked and untracked file paths relative to `root`.
+    fn list_files(&self, root: &Path) -> Option<Vec<String>>;
+
+    /// Return normalized 0..1 churn scores keyed by paths relative to `root`.
+    fn churn_scores(&self, root: &Path) -> BTreeMap<String, f64>;
+}
+
+/// Production [`GitCapabilities`] implementation backed by the `git` CLI.
+#[derive(Debug, Default)]
+pub struct CliGitCapabilities;
+
+impl GitCapabilities for CliGitCapabilities {
+    fn list_files(&self, root: &Path) -> Option<Vec<String>> {
+        if !has_git_repository_marker(root) {
+            return None;
+        }
+
+        let mut cmd = Command::new("git");
+        super::strip_ambient_git_env(&mut cmd);
+        let output = cmd
+            .args([
+                "-C",
+                root.to_str()?,
+                "ls-files",
+                "--cached",
+                "--others",
+                "--exclude-standard",
+            ])
+            .output()
+            .ok()?;
+        if !output.status.success() {
+            return None;
+        }
+        let stdout = String::from_utf8(output.stdout).ok()?;
+        let entries: Vec<String> = stdout
+            .lines()
+            .filter(|line| !line.is_empty())
+            .map(str::to_string)
+            .collect();
+        if entries.is_empty() {
+            None
+        } else {
+            Some(entries)
+        }
+    }
+
+    fn churn_scores(&self, root: &Path) -> BTreeMap<String, f64> {
+        if !has_git_repository_marker(root) {
+            return BTreeMap::new();
+        }
+
+        let mut cmd = Command::new("git");
+        super::strip_ambient_git_env(&mut cmd);
+        let output = cmd
+            .args([
+                "-C",
+                match root.to_str() {
+                    Some(s) => s,
+                    None => return BTreeMap::new(),
+                },
+                "log",
+                "--since=90.days",
+                "--name-only",
+                "--pretty=format:",
+            ])
+            .output();
+        let output = match output {
+            Ok(o) if o.status.success() => o,
+            _ => return BTreeMap::new(),
+        };
+        let stdout = match String::from_utf8(output.stdout) {
+            Ok(s) => s,
+            Err(_) => return BTreeMap::new(),
+        };
+
+        let mut counts: BTreeMap<String, usize> = BTreeMap::new();
+        for line in stdout.lines() {
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            *counts.entry(trimmed.to_string()).or_insert(0) += 1;
+        }
+
+        let max = counts.values().copied().max().unwrap_or(1).max(1) as f64;
+        counts
+            .into_iter()
+            .map(|(file, count)| (file, count as f64 / max))
+            .collect()
+    }
+}
+
+/// Returns true when `root` is inside a Git worktree based on local marker files.
+///
+/// This deliberately avoids shelling out to `git rev-parse`: the default
+/// capability uses this predicate to decide whether spawning Git is appropriate.
+fn has_git_repository_marker(root: &Path) -> bool {
+    root.ancestors().any(|dir| dir.join(".git").exists())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn marker_detection_handles_plain_and_worktree_git_markers() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+
+        assert!(!has_git_repository_marker(root));
+
+        fs::write(root.join(".git"), "gitdir: /tmp/example\n").unwrap();
+        assert!(has_git_repository_marker(root));
+        assert!(has_git_repository_marker(&root.join("nested")));
+    }
+}

--- a/crates/harn-hostlib/src/scanner/mod.rs
+++ b/crates/harn-hostlib/src/scanner/mod.rs
@@ -31,6 +31,7 @@ mod commands;
 mod discover;
 mod extensions;
 mod folders;
+mod git;
 mod imports;
 mod result;
 mod scoring;
@@ -49,6 +50,7 @@ fn strip_ambient_git_env(cmd: &mut Command) {
     }
 }
 
+pub use git::GitCapabilities;
 pub use result::{
     DependencyEdge, FileRecord, FolderRecord, LanguageStat, ProjectMetadata, ScanDelta, ScanResult,
     SubProject, SymbolKind, SymbolRecord,
@@ -115,12 +117,25 @@ impl Default for ScanProjectOptions {
 
 /// Run a full scan of `root`, persist a snapshot, and return the result.
 pub fn scan_project(root: &Path, opts: ScanProjectOptions) -> ScanResult {
+    scan_project_with_git(root, opts, &git::CliGitCapabilities)
+}
+
+/// Run a full scan using caller-supplied Git data.
+///
+/// Embedders normally call [`scan_project`]. Tests and hosts that already
+/// virtualize Git can use this entry point to keep scanner behavior
+/// deterministic without depending on ambient process state.
+pub fn scan_project_with_git(
+    root: &Path,
+    opts: ScanProjectOptions,
+    git: &dyn GitCapabilities,
+) -> ScanResult {
     let canonical = canonicalize(root);
     let discover_opts = discover::DiscoverOptions {
         include_hidden: opts.include_hidden,
         respect_gitignore: opts.respect_gitignore,
     };
-    let mut discovered = discover::discover_files(&canonical, discover_opts);
+    let mut discovered = discover::discover_files(&canonical, discover_opts, git);
     let truncated = if opts.max_files > 0 && discovered.len() > opts.max_files {
         discovered.truncate(opts.max_files);
         true
@@ -133,7 +148,7 @@ pub fn scan_project(root: &Path, opts: ScanProjectOptions) -> ScanResult {
     scoring::compute_reference_counts(&mut symbols, &files);
 
     if opts.include_git_history {
-        let churn = scoring::compute_churn_scores(&canonical);
+        let churn = git.churn_scores(&canonical);
         scoring::apply_churn(&mut files, &churn);
     }
     scoring::compute_importance_scores(&mut symbols, &files);
@@ -188,6 +203,16 @@ pub fn scan_incremental(
     explicit_changed: Option<&[String]>,
     opts: ScanProjectOptions,
 ) -> IncrementalScan {
+    scan_incremental_with_git(token, explicit_changed, opts, &git::CliGitCapabilities)
+}
+
+/// Refresh a snapshot using caller-supplied Git data.
+pub fn scan_incremental_with_git(
+    token: &str,
+    explicit_changed: Option<&[String]>,
+    opts: ScanProjectOptions,
+    git: &dyn GitCapabilities,
+) -> IncrementalScan {
     let root = snapshot::token_to_root(token);
     let canonical = canonicalize(&root);
 
@@ -195,7 +220,7 @@ pub fn scan_incremental(
     let cached = match cached {
         Some(c) => c,
         None => {
-            let result = scan_project(&canonical, opts);
+            let result = scan_project_with_git(&canonical, opts, git);
             return IncrementalScan {
                 result,
                 delta: ScanDelta {
@@ -210,7 +235,7 @@ pub fn scan_incremental(
         include_hidden: opts.include_hidden,
         respect_gitignore: opts.respect_gitignore,
     };
-    let mut current = discover::discover_files(&canonical, discover_opts);
+    let mut current = discover::discover_files(&canonical, discover_opts, git);
     if opts.max_files > 0 && current.len() > opts.max_files {
         current.truncate(opts.max_files);
     }
@@ -221,7 +246,7 @@ pub fn scan_incremental(
         total > 0 && (delta.added.len() + delta.modified.len()) * 10 > total * 3;
 
     if needs_full_rescan {
-        let result = scan_project(&canonical, opts);
+        let result = scan_project_with_git(&canonical, opts, git);
         return IncrementalScan {
             result,
             delta: ScanDelta {
@@ -280,7 +305,7 @@ pub fn scan_incremental(
 
     scoring::compute_reference_counts(&mut symbols, &files);
     if opts.include_git_history {
-        let churn = scoring::compute_churn_scores(&canonical);
+        let churn = git.churn_scores(&canonical);
         scoring::apply_churn(&mut files, &churn);
     }
     scoring::compute_importance_scores(&mut symbols, &files);
@@ -520,7 +545,13 @@ fn parse_options(
     let include_hidden = optional_bool(builtin, dict, "include_hidden", false)?;
     let respect_gitignore = optional_bool(builtin, dict, "respect_gitignore", true)?;
     let max_files = optional_int(builtin, dict, "max_files", 0)?;
-    let include_git_history = optional_bool(builtin, dict, "include_git_history", true)?;
+    let include_git_history_default = builtin == SCAN_PROJECT_BUILTIN;
+    let include_git_history = optional_bool(
+        builtin,
+        dict,
+        "include_git_history",
+        include_git_history_default,
+    )?;
     let repo_map_token_budget = optional_int(builtin, dict, "repo_map_token_budget", 1200)?;
     if max_files < 0 {
         return Err(HostlibError::InvalidParameter {
@@ -730,4 +761,20 @@ fn delta_to_value(delta: &ScanDelta) -> VmValue {
         ("removed", VmValue::List(Rc::new(removed))),
         ("full_rescan", VmValue::Bool(delta.full_rescan)),
     ])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builtin_option_defaults_match_request_schemas() {
+        let dict = std::collections::BTreeMap::new();
+
+        let scan_project = parse_options(SCAN_PROJECT_BUILTIN, &dict).unwrap();
+        let scan_incremental = parse_options(SCAN_INCREMENTAL_BUILTIN, &dict).unwrap();
+
+        assert!(scan_project.include_git_history);
+        assert!(!scan_incremental.include_git_history);
+    }
 }

--- a/crates/harn-hostlib/src/scanner/scoring.rs
+++ b/crates/harn-hostlib/src/scanner/scoring.rs
@@ -14,8 +14,6 @@
 //! compatibility tests.
 
 use std::collections::{BTreeMap, HashSet};
-use std::path::Path;
-use std::process::Command;
 
 use crate::scanner::result::{FileRecord, SymbolRecord};
 
@@ -49,51 +47,6 @@ pub fn compute_reference_counts(symbols: &mut [SymbolRecord], files: &[FileRecor
     for sym in symbols.iter_mut() {
         sym.reference_count = ref_counts.get(&sym.name).copied().unwrap_or(0);
     }
-}
-
-/// Compute per-file churn scores from the last 90 days of git history.
-/// Returns the mapping; callers apply it to [`FileRecord::churn_score`].
-/// Returns an empty map if `git` is unavailable, the call fails, or the
-/// repo has no commits in the window.
-pub fn compute_churn_scores(root: &Path) -> BTreeMap<String, f64> {
-    let mut cmd = Command::new("git");
-    super::strip_ambient_git_env(&mut cmd);
-    let output = cmd
-        .args([
-            "-C",
-            match root.to_str() {
-                Some(s) => s,
-                None => return BTreeMap::new(),
-            },
-            "log",
-            "--since=90.days",
-            "--name-only",
-            "--pretty=format:",
-        ])
-        .output();
-    let output = match output {
-        Ok(o) if o.status.success() => o,
-        _ => return BTreeMap::new(),
-    };
-    let stdout = match String::from_utf8(output.stdout) {
-        Ok(s) => s,
-        Err(_) => return BTreeMap::new(),
-    };
-
-    let mut counts: BTreeMap<String, usize> = BTreeMap::new();
-    for line in stdout.lines() {
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        *counts.entry(trimmed.to_string()).or_insert(0) += 1;
-    }
-
-    let max = counts.values().copied().max().unwrap_or(1).max(1) as f64;
-    counts
-        .into_iter()
-        .map(|(file, count)| (file, count as f64 / max))
-        .collect()
 }
 
 /// Apply the churn map to a slice of file records (mutates in place).

--- a/crates/harn-hostlib/tests/scanner_e2e.rs
+++ b/crates/harn-hostlib/tests/scanner_e2e.rs
@@ -17,7 +17,8 @@ use std::path::Path;
 use std::time::SystemTime;
 
 use harn_hostlib::scanner::{
-    scan_incremental, scan_project, FileRecord, ScanProjectOptions, SymbolKind,
+    scan_incremental, scan_project, scan_project_with_git, FileRecord, GitCapabilities,
+    ScanProjectOptions, SymbolKind,
 };
 use tempfile::tempdir;
 
@@ -130,6 +131,22 @@ fn touch_after(path: &Path, base: SystemTime) {
     let _ = filetime::set_file_mtime(path, filetime::FileTime::from_system_time(new_mtime));
 }
 
+#[derive(Default)]
+struct MockGit {
+    files: Option<Vec<String>>,
+    churn: std::collections::BTreeMap<String, f64>,
+}
+
+impl GitCapabilities for MockGit {
+    fn list_files(&self, _root: &Path) -> Option<Vec<String>> {
+        self.files.clone()
+    }
+
+    fn churn_scores(&self, _root: &Path) -> std::collections::BTreeMap<String, f64> {
+        self.churn.clone()
+    }
+}
+
 #[test]
 fn scan_project_emits_full_result_shape() {
     let tmp = tempdir().unwrap();
@@ -232,6 +249,35 @@ fn scan_project_emits_full_result_shape() {
     // Snapshot persisted at the canonical location.
     let snapshot_path = tmp.path().join(".harn/hostlib/scanner-snapshot.json");
     assert!(snapshot_path.exists());
+}
+
+#[test]
+fn scan_project_uses_injected_git_capabilities() {
+    let tmp = tempdir().unwrap();
+    build_fixture(tmp.path());
+
+    let git = MockGit {
+        files: Some(vec![
+            "Cargo.toml".to_string(),
+            "src/main.rs".to_string(),
+            "src/routes/accounts.rs".to_string(),
+            "target/debug/junk.txt".to_string(),
+        ]),
+        churn: [("src/main.rs".to_string(), 0.75)].into_iter().collect(),
+    };
+    let result = scan_project_with_git(tmp.path(), ScanProjectOptions::default(), &git);
+    let paths: Vec<&str> = result
+        .files
+        .iter()
+        .map(|f| f.relative_path.as_str())
+        .collect();
+
+    assert_eq!(
+        paths,
+        vec!["Cargo.toml", "src/main.rs", "src/routes/accounts.rs"]
+    );
+    let main = find_file(&result.files, "src/main.rs").unwrap();
+    assert_eq!(main.churn_score, 0.75);
 }
 
 fn project_name(root: &Path) -> String {
@@ -341,38 +387,43 @@ fn symbol_records_carry_canonical_kind() {
 }
 
 #[test]
-fn scan_project_self_smoke_test() {
-    // Scanning the harn workspace itself exercises the same surface end
-    // to end against real-world content: mixed Rust, TypeScript, markdown,
-    // a real `.gitignore`, and a real Cargo workspace. The assertions stay
-    // conservative so the test catches shape regressions without becoming
-    // a performance benchmark.
-    let manifest_dir = env!("CARGO_MANIFEST_DIR");
-    let workspace_root = Path::new(manifest_dir)
-        .parent()
-        .and_then(|p| p.parent())
-        .expect("manifest dir lives two levels under workspace root");
-
-    let opts = ScanProjectOptions {
-        // Don't shell out to git here — keeps the test hermetic across hosts.
-        include_git_history: false,
-        ..ScanProjectOptions::default()
-    };
-
-    let result = scan_project(workspace_root, opts);
-
-    assert!(!result.files.is_empty(), "harn workspace should have files");
-    assert!(
-        !result.symbols.is_empty(),
-        "harn workspace should have symbols"
+fn scan_project_workspace_shape_smoke_test() {
+    let tmp = tempdir().unwrap();
+    build_fixture(tmp.path());
+    write(
+        tmp.path(),
+        ".github/workflows/ci.yml",
+        "name: ci\non: [push]\njobs:\n  test:\n    runs-on: ubuntu-latest\n",
+    );
+    write(
+        tmp.path(),
+        "docs/src/language-spec.md",
+        "# Language Spec\n\n```harn\nfn main() { 1 }\n```\n",
+    );
+    write(
+        tmp.path(),
+        "crates/harn-hostlib/src/lib.rs",
+        "pub mod scanner;\npub fn install() {}\n",
     );
 
-    // Wall-clock budgets here flake on shared CI under load. Performance
-    // characterization belongs in `cargo bench`, not in correctness tests.
-    // The file-count + symbol-count invariants above already catch shape
-    // regressions.
+    let result = scan_project_with_git(
+        tmp.path(),
+        ScanProjectOptions {
+            include_git_history: false,
+            ..ScanProjectOptions::default()
+        },
+        &MockGit::default(),
+    );
 
-    // Sanity: well-known top-level files show up.
+    assert!(
+        !result.files.is_empty(),
+        "workspace fixture should have files"
+    );
+    assert!(
+        !result.symbols.is_empty(),
+        "workspace fixture should have symbols"
+    );
+
     let names: Vec<&str> = result
         .files
         .iter()
@@ -381,15 +432,3 @@ fn scan_project_self_smoke_test() {
     assert!(names.iter().any(|n| n.ends_with("Cargo.toml")));
     assert!(names.iter().any(|n| n.contains("crates/harn-hostlib")));
 }
-
-// Earlier drafts of this suite included a
-// `scan_project_handles_empty_directory_gracefully` test that scanned a
-// fresh `tempfile::tempdir()` and asserted the result was empty. It was
-// removed because it flaked under heavy `cargo nextest run --workspace`
-// load — `tempfile::tempdir()` resolves through `/var/folders/.../T/`
-// on macOS, and another concurrent test occasionally raced with us by
-// touching files under that tree before our scan ran. The empty-input
-// contract is still exercised: `scan_project_truncates_to_max_files`
-// touches `max_files=2` against the small fixture, and the
-// incremental-scan tests verify behavior on dirs with zero hits in the
-// `delta` block.

--- a/crates/harn-serve/Cargo.toml
+++ b/crates/harn-serve/Cargo.toml
@@ -30,5 +30,6 @@ uuid = { version = "1", features = ["v4", "v7"] }
 
 [dev-dependencies]
 hex = "0.4"
+jsonwebtoken = { version = "9", default-features = false, features = ["use_pem"] }
 tempfile = "3"
 tower = { version = "0.5", features = ["util"] }

--- a/crates/harn-serve/src/adapters/a2a.rs
+++ b/crates/harn-serve/src/adapters/a2a.rs
@@ -3,6 +3,7 @@ use std::convert::Infallible;
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
+use std::time::Duration as StdDuration;
 
 use axum::body::Bytes;
 use axum::extract::State;
@@ -14,6 +15,7 @@ use axum::{Json, Router};
 use base64::Engine;
 use futures::channel::mpsc::{unbounded, UnboundedReceiver, UnboundedSender};
 use futures::StreamExt;
+use harn_vm::connectors::{JwtKeySource, JwtVerificationOptions};
 use harn_vm::event_log::{AnyEventLog, EventLog, LogEvent, Topic};
 use hmac::{Hmac, KeyInit, Mac};
 use serde_json::{json, Value as JsonValue};
@@ -1116,37 +1118,507 @@ impl A2aServer {
             return;
         }
         tokio::spawn(async move {
-            let client = reqwest::Client::new();
-            let payload = json!({ "statusUpdate": task });
-            for config in configs {
-                let Some(url) = config.get("url").and_then(JsonValue::as_str) else {
-                    continue;
-                };
-                let mut request = client
-                    .post(url)
-                    .header(reqwest::header::CONTENT_TYPE, "application/a2a+json")
-                    .json(&payload);
-                if let Some(token) = config.get("token").and_then(JsonValue::as_str) {
-                    request = request.bearer_auth(token);
-                } else if let Some(auth) = config.get("authentication") {
-                    if let Some(scheme) = auth.get("scheme").and_then(JsonValue::as_str) {
-                        let credentials = auth
-                            .get("credentials")
-                            .and_then(JsonValue::as_str)
-                            .unwrap_or_default();
-                        if !credentials.is_empty() {
-                            request = request.header(
-                                reqwest::header::AUTHORIZATION,
-                                format!("{scheme} {credentials}"),
-                            );
-                        }
-                    }
+            for result in deliver_push_configs(configs, task).await {
+                if let Err(error) = result {
+                    tracing::warn!(
+                        target: "harn_serve::a2a",
+                        %error,
+                        "failed to deliver A2A push notification"
+                    );
                 }
-                let _ = request.send().await;
             }
         });
     }
 }
+
+async fn deliver_push_configs(
+    configs: Vec<JsonValue>,
+    task: JsonValue,
+) -> Vec<Result<(), PushDeliveryError>> {
+    let mut results = Vec::with_capacity(configs.len());
+    for config in configs {
+        results.push(deliver_push_config(&config, &task).await);
+    }
+    results
+}
+
+async fn deliver_push_config(
+    config: &JsonValue,
+    task: &JsonValue,
+) -> Result<(), PushDeliveryError> {
+    let url = config
+        .get("url")
+        .and_then(JsonValue::as_str)
+        .filter(|url| !url.trim().is_empty())
+        .ok_or_else(|| PushDeliveryError::Config("push config missing url".to_string()))?;
+    if let Some(error) = harn_vm::egress::connector_error_for_url("a2a_push_delivery", url) {
+        return Err(PushDeliveryError::Egress(error.to_string()));
+    }
+
+    let auth = config.get("authentication");
+    let client = push_http_client(auth).await?;
+    let payload = json!({ "statusUpdate": task });
+    let task_id = task
+        .get("id")
+        .or_else(|| task.get("taskId"))
+        .and_then(JsonValue::as_str)
+        .unwrap_or_default();
+    let mut request = client
+        .post(url)
+        .header(reqwest::header::CONTENT_TYPE, "application/a2a+json")
+        .json(&payload);
+    request = apply_push_auth(request, &client, config, auth, task_id, url).await?;
+    request
+        .send()
+        .await
+        .map_err(|error| PushDeliveryError::Http(format!("send push notification: {error}")))?
+        .error_for_status()
+        .map_err(|error| PushDeliveryError::Http(format!("push notification rejected: {error}")))?;
+    Ok(())
+}
+
+async fn push_http_client(auth: Option<&JsonValue>) -> Result<reqwest::Client, PushDeliveryError> {
+    let mut builder = reqwest::Client::builder()
+        .user_agent("harn-a2a-push")
+        .timeout(StdDuration::from_secs(20))
+        .redirect(reqwest::redirect::Policy::custom(|attempt| {
+            if attempt.previous().len() >= 5 {
+                attempt.error("too many redirects")
+            } else if harn_vm::egress::redirect_url_allowed(
+                "a2a_push_delivery_redirect",
+                attempt.url().as_str(),
+            ) {
+                attempt.follow()
+            } else {
+                attempt.error("egress policy blocked redirect target")
+            }
+        }));
+
+    if let Some(auth) = auth {
+        if let Some(ca_path) = string_field(auth, &["ca_cert", "caCert", "ca_bundle", "caBundle"]) {
+            let pem = tokio::fs::read(ca_path).await.map_err(|error| {
+                PushDeliveryError::Config(format!("read mTLS CA bundle {ca_path}: {error}"))
+            })?;
+            match reqwest::Certificate::from_pem_bundle(&pem) {
+                Ok(certs) => {
+                    for cert in certs {
+                        builder = builder.add_root_certificate(cert);
+                    }
+                }
+                Err(_) => {
+                    let cert = reqwest::Certificate::from_pem(&pem).map_err(|error| {
+                        PushDeliveryError::Config(format!(
+                            "parse mTLS CA bundle {ca_path}: {error}"
+                        ))
+                    })?;
+                    builder = builder.add_root_certificate(cert);
+                }
+            }
+        }
+        if authentication_schemes(auth).iter().any(|scheme| {
+            matches!(
+                scheme.as_str(),
+                "mtls" | "mutualtls" | "mutual-tls" | "mutual_tls"
+            )
+        }) {
+            builder = builder.identity(push_client_identity(auth).await?);
+        }
+    }
+
+    builder
+        .build()
+        .map_err(|error| PushDeliveryError::Config(format!("build push HTTP client: {error}")))
+}
+
+async fn apply_push_auth(
+    mut request: reqwest::RequestBuilder,
+    client: &reqwest::Client,
+    config: &JsonValue,
+    auth: Option<&JsonValue>,
+    task_id: &str,
+    webhook_url: &str,
+) -> Result<reqwest::RequestBuilder, PushDeliveryError> {
+    let Some(auth) = auth else {
+        if let Some(token) = config.get("token").and_then(JsonValue::as_str) {
+            return Ok(request.bearer_auth(token));
+        }
+        return Ok(request);
+    };
+
+    for scheme in authentication_schemes(auth) {
+        match scheme.as_str() {
+            "bearer" | "bearertoken" | "bearer-token" => {
+                let token = string_field(auth, &["credentials", "token", "access_token"])
+                    .or_else(|| config.get("token").and_then(JsonValue::as_str))
+                    .ok_or_else(|| {
+                        PushDeliveryError::Config(
+                            "Bearer push authentication requires credentials".to_string(),
+                        )
+                    })?;
+                return Ok(request.bearer_auth(token));
+            }
+            "basic" => {
+                if let Some(credentials) = string_field(auth, &["credentials"]) {
+                    return Ok(request.header(
+                        reqwest::header::AUTHORIZATION,
+                        format!("Basic {credentials}"),
+                    ));
+                }
+                let username = required_string(auth, &["username", "client_id", "clientId"])?;
+                let password =
+                    required_string(auth, &["password", "client_secret", "clientSecret"])?;
+                let encoded = base64::engine::general_purpose::STANDARD
+                    .encode(format!("{username}:{password}"));
+                return Ok(
+                    request.header(reqwest::header::AUTHORIZATION, format!("Basic {encoded}"))
+                );
+            }
+            "apikey" | "api-key" | "api_key" => {
+                let header = string_field(auth, &["header", "name"]).unwrap_or("X-API-Key");
+                let value = required_string(auth, &["credentials", "value", "token"])?;
+                return Ok(request.header(header, value));
+            }
+            "oauth2" | "oauth" => {
+                let token = fetch_oauth2_access_token(client, auth).await?;
+                return Ok(request.bearer_auth(token));
+            }
+            "openidconnect" | "openid-connect" | "oidc" => {
+                let token = fetch_oidc_id_token(client, auth, webhook_url).await?;
+                return Ok(request.bearer_auth(token));
+            }
+            "mtls" | "mutualtls" | "mutual-tls" | "mutual_tls" => {}
+            other => {
+                let credentials = string_field(auth, &["credentials"]).ok_or_else(|| {
+                    PushDeliveryError::Config(format!(
+                        "push authentication scheme `{other}` requires credentials"
+                    ))
+                })?;
+                request = request.header(
+                    reqwest::header::AUTHORIZATION,
+                    format!("{other} {credentials}"),
+                );
+                return Ok(request);
+            }
+        }
+    }
+
+    if let Some(token) = config.get("token").and_then(JsonValue::as_str) {
+        return Ok(request.header("X-A2A-Token", token));
+    }
+    if !task_id.is_empty() {
+        return Ok(request.header("X-A2A-Task-ID", task_id));
+    }
+    Ok(request)
+}
+
+async fn fetch_oauth2_access_token(
+    client: &reqwest::Client,
+    auth: &JsonValue,
+) -> Result<String, PushDeliveryError> {
+    let token_url = required_string(
+        auth,
+        &["token_url", "tokenUrl", "token_endpoint", "tokenEndpoint"],
+    )?;
+    if let Some(error) = harn_vm::egress::connector_error_for_url("a2a_push_oauth_token", token_url)
+    {
+        return Err(PushDeliveryError::Egress(error.to_string()));
+    }
+    let client_id = required_string(auth, &["client_id", "clientId"])?;
+    let client_secret = string_field(auth, &["client_secret", "clientSecret"]);
+    let mut form = vec![("grant_type".to_string(), "client_credentials".to_string())];
+    if let Some(scope) = scope_string(auth) {
+        form.push(("scope".to_string(), scope));
+    }
+    if let Some(audience) = string_field(auth, &["audience", "aud"]) {
+        form.push(("audience".to_string(), audience.to_string()));
+    }
+    if client_secret.is_none() {
+        form.push(("client_id".to_string(), client_id.to_string()));
+    }
+    let mut request = client.post(token_url).form(&form);
+    if let Some(secret) = client_secret {
+        request = request.basic_auth(client_id, Some(secret));
+    }
+    let response = request
+        .send()
+        .await
+        .map_err(|error| PushDeliveryError::Http(format!("fetch OAuth2 token: {error}")))?
+        .error_for_status()
+        .map_err(|error| {
+            PushDeliveryError::Http(format!("OAuth2 token endpoint rejected request: {error}"))
+        })?
+        .json::<JsonValue>()
+        .await
+        .map_err(|error| {
+            PushDeliveryError::Http(format!("decode OAuth2 token response: {error}"))
+        })?;
+    let token_type = response
+        .get("token_type")
+        .and_then(JsonValue::as_str)
+        .unwrap_or("Bearer");
+    if !token_type.eq_ignore_ascii_case("bearer") {
+        return Err(PushDeliveryError::Config(format!(
+            "unsupported OAuth2 token_type `{token_type}`"
+        )));
+    }
+    response
+        .get("access_token")
+        .and_then(JsonValue::as_str)
+        .filter(|token| !token.is_empty())
+        .map(str::to_string)
+        .ok_or_else(|| {
+            PushDeliveryError::Http("OAuth2 token response missing access_token".to_string())
+        })
+}
+
+async fn fetch_oidc_id_token(
+    client: &reqwest::Client,
+    auth: &JsonValue,
+    webhook_url: &str,
+) -> Result<String, PushDeliveryError> {
+    let metadata = oidc_metadata(client, auth).await?;
+    let token = fetch_oauth2_token_response(client, auth, &metadata.token_endpoint).await?;
+    let id_token = token
+        .get("id_token")
+        .and_then(JsonValue::as_str)
+        .filter(|token| !token.is_empty())
+        .ok_or_else(|| {
+            PushDeliveryError::Http("OIDC token response missing id_token".to_string())
+        })?;
+    let issuer = string_field(auth, &["issuer", "iss"]).unwrap_or(&metadata.issuer);
+    let audience = string_field(auth, &["audience", "aud"])
+        .or_else(|| string_field(auth, &["client_id", "clientId"]))
+        .unwrap_or(webhook_url);
+    harn_vm::connectors::verify_jwt_json(
+        client,
+        id_token,
+        JwtKeySource::Url(&metadata.jwks_uri),
+        &JwtVerificationOptions::default()
+            .with_issuer(issuer)
+            .with_audience(audience)
+            .require_spec_claims(["exp", "iss", "aud"])
+            .with_egress_label("a2a_push_oidc_jwks"),
+    )
+    .await
+    .map_err(|error| PushDeliveryError::Auth(format!("validate OIDC ID token: {error}")))?;
+    Ok(id_token.to_string())
+}
+
+async fn fetch_oauth2_token_response(
+    client: &reqwest::Client,
+    auth: &JsonValue,
+    token_url: &str,
+) -> Result<JsonValue, PushDeliveryError> {
+    if let Some(error) = harn_vm::egress::connector_error_for_url("a2a_push_oidc_token", token_url)
+    {
+        return Err(PushDeliveryError::Egress(error.to_string()));
+    }
+    let client_id = required_string(auth, &["client_id", "clientId"])?;
+    let client_secret = string_field(auth, &["client_secret", "clientSecret"]);
+    let mut form = vec![("grant_type".to_string(), "client_credentials".to_string())];
+    if let Some(scope) = scope_string(auth) {
+        form.push(("scope".to_string(), scope));
+    }
+    if client_secret.is_none() {
+        form.push(("client_id".to_string(), client_id.to_string()));
+    }
+    let mut request = client.post(token_url).form(&form);
+    if let Some(secret) = client_secret {
+        request = request.basic_auth(client_id, Some(secret));
+    }
+    request
+        .send()
+        .await
+        .map_err(|error| PushDeliveryError::Http(format!("fetch OIDC token: {error}")))?
+        .error_for_status()
+        .map_err(|error| {
+            PushDeliveryError::Http(format!("OIDC token endpoint rejected request: {error}"))
+        })?
+        .json::<JsonValue>()
+        .await
+        .map_err(|error| PushDeliveryError::Http(format!("decode OIDC token response: {error}")))
+}
+
+#[derive(Clone, Debug)]
+struct OidcMetadata {
+    issuer: String,
+    token_endpoint: String,
+    jwks_uri: String,
+}
+
+async fn oidc_metadata(
+    client: &reqwest::Client,
+    auth: &JsonValue,
+) -> Result<OidcMetadata, PushDeliveryError> {
+    if let (Some(token_endpoint), Some(jwks_uri)) = (
+        string_field(
+            auth,
+            &["token_url", "tokenUrl", "token_endpoint", "tokenEndpoint"],
+        ),
+        string_field(auth, &["jwks_url", "jwksUrl", "jwks_uri", "jwksUri"]),
+    ) {
+        let issuer = required_string(auth, &["issuer", "iss"])?;
+        return Ok(OidcMetadata {
+            issuer: issuer.to_string(),
+            token_endpoint: token_endpoint.to_string(),
+            jwks_uri: jwks_uri.to_string(),
+        });
+    }
+    let discovery_url = string_field(
+        auth,
+        &[
+            "discovery_url",
+            "discoveryUrl",
+            "openid_configuration_url",
+            "openidConfigurationUrl",
+        ],
+    )
+    .map(str::to_string)
+    .or_else(|| {
+        string_field(auth, &["issuer", "iss"]).map(|issuer| {
+            format!(
+                "{}/.well-known/openid-configuration",
+                issuer.trim_end_matches('/')
+            )
+        })
+    })
+    .ok_or_else(|| {
+        PushDeliveryError::Config(
+            "OIDC push authentication requires discovery_url or token/jwks URLs".to_string(),
+        )
+    })?;
+    if let Some(error) =
+        harn_vm::egress::connector_error_for_url("a2a_push_oidc_discovery", &discovery_url)
+    {
+        return Err(PushDeliveryError::Egress(error.to_string()));
+    }
+    let metadata = client
+        .get(&discovery_url)
+        .send()
+        .await
+        .map_err(|error| PushDeliveryError::Http(format!("fetch OIDC metadata: {error}")))?
+        .error_for_status()
+        .map_err(|error| {
+            PushDeliveryError::Http(format!("OIDC metadata endpoint rejected request: {error}"))
+        })?
+        .json::<JsonValue>()
+        .await
+        .map_err(|error| PushDeliveryError::Http(format!("decode OIDC metadata: {error}")))?;
+    Ok(OidcMetadata {
+        issuer: metadata
+            .get("issuer")
+            .and_then(JsonValue::as_str)
+            .filter(|issuer| !issuer.trim().is_empty())
+            .ok_or_else(|| PushDeliveryError::Http("OIDC metadata missing issuer".to_string()))?
+            .to_string(),
+        token_endpoint: metadata
+            .get("token_endpoint")
+            .and_then(JsonValue::as_str)
+            .ok_or_else(|| {
+                PushDeliveryError::Http("OIDC metadata missing token_endpoint".to_string())
+            })?
+            .to_string(),
+        jwks_uri: metadata
+            .get("jwks_uri")
+            .and_then(JsonValue::as_str)
+            .ok_or_else(|| PushDeliveryError::Http("OIDC metadata missing jwks_uri".to_string()))?
+            .to_string(),
+    })
+}
+
+async fn push_client_identity(auth: &JsonValue) -> Result<reqwest::Identity, PushDeliveryError> {
+    if let Some(identity_path) = string_field(auth, &["client_identity", "clientIdentity"]) {
+        let bytes = tokio::fs::read(identity_path).await.map_err(|error| {
+            PushDeliveryError::Config(format!("read mTLS identity {identity_path}: {error}"))
+        })?;
+        return reqwest::Identity::from_pem(&bytes).map_err(|error| {
+            PushDeliveryError::Config(format!("parse mTLS identity {identity_path}: {error}"))
+        });
+    }
+    let cert_path = required_string(auth, &["client_cert", "clientCert", "cert"])?;
+    let key_path = required_string(auth, &["client_key", "clientKey", "key"])?;
+    let mut identity_pem = tokio::fs::read(cert_path).await.map_err(|error| {
+        PushDeliveryError::Config(format!("read mTLS client cert {cert_path}: {error}"))
+    })?;
+    let key = tokio::fs::read(key_path).await.map_err(|error| {
+        PushDeliveryError::Config(format!("read mTLS client key {key_path}: {error}"))
+    })?;
+    identity_pem.extend_from_slice(b"\n");
+    identity_pem.extend_from_slice(&key);
+    reqwest::Identity::from_pem(&identity_pem)
+        .map_err(|error| PushDeliveryError::Config(format!("parse mTLS identity: {error}")))
+}
+
+fn authentication_schemes(auth: &JsonValue) -> Vec<String> {
+    let mut schemes = Vec::new();
+    if let Some(values) = auth.get("schemes").and_then(JsonValue::as_array) {
+        schemes.extend(values.iter().filter_map(JsonValue::as_str));
+    }
+    if let Some(scheme) = auth.get("scheme").and_then(JsonValue::as_str) {
+        schemes.push(scheme);
+    }
+    if let Some(kind) = auth.get("type").and_then(JsonValue::as_str) {
+        schemes.push(kind);
+    }
+    schemes
+        .into_iter()
+        .map(|scheme| scheme.replace([' ', '_'], "").to_ascii_lowercase())
+        .collect()
+}
+
+fn string_field<'a>(value: &'a JsonValue, names: &[&str]) -> Option<&'a str> {
+    names
+        .iter()
+        .find_map(|name| value.get(*name).and_then(JsonValue::as_str))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+fn required_string<'a>(value: &'a JsonValue, names: &[&str]) -> Result<&'a str, PushDeliveryError> {
+    string_field(value, names).ok_or_else(|| {
+        PushDeliveryError::Config(format!(
+            "missing required push authentication field `{}`",
+            names[0]
+        ))
+    })
+}
+
+fn scope_string(auth: &JsonValue) -> Option<String> {
+    if let Some(scope) = string_field(auth, &["scope"]) {
+        return Some(scope.to_string());
+    }
+    auth.get("scopes")
+        .and_then(JsonValue::as_array)
+        .map(|scopes| {
+            scopes
+                .iter()
+                .filter_map(JsonValue::as_str)
+                .collect::<Vec<_>>()
+                .join(" ")
+        })
+        .filter(|scope| !scope.is_empty())
+}
+
+#[derive(Debug)]
+enum PushDeliveryError {
+    Auth(String),
+    Config(String),
+    Egress(String),
+    Http(String),
+}
+
+impl std::fmt::Display for PushDeliveryError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Auth(message)
+            | Self::Config(message)
+            | Self::Egress(message)
+            | Self::Http(message) => f.write_str(message),
+        }
+    }
+}
+
+impl std::error::Error for PushDeliveryError {}
 
 #[async_trait::async_trait(?Send)]
 impl TransportAdapter for A2aServer {
@@ -2543,6 +3015,11 @@ mod tests {
     use crate::{DispatchCore, DispatchCoreConfig};
     use axum::body::{to_bytes, Body};
     use axum::http::Request;
+    use axum::routing::any;
+    use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
+    use std::net::TcpListener;
+    use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+    use std::sync::Once;
     use tower::ServiceExt;
 
     fn test_server(source: &str) -> (tempfile::TempDir, Arc<A2aServer>) {
@@ -2551,6 +3028,525 @@ mod tests {
         std::fs::write(&script, source).expect("write script");
         let core = DispatchCore::new(DispatchCoreConfig::for_script(&script)).expect("core");
         (dir, Arc::new(A2aServer::new(A2aServerConfig::new(core))))
+    }
+
+    #[derive(Clone, Debug)]
+    struct MockRequest {
+        path: String,
+        headers: BTreeMap<String, String>,
+        body: String,
+    }
+
+    #[derive(Clone)]
+    struct MockState {
+        requests: Arc<Mutex<Vec<MockRequest>>>,
+        handler: Arc<dyn Fn(MockRequest) -> Response + Send + Sync>,
+    }
+
+    struct MockServer {
+        base_url: String,
+        requests: Arc<Mutex<Vec<MockRequest>>>,
+        task: tokio::task::JoinHandle<()>,
+    }
+
+    impl Drop for MockServer {
+        fn drop(&mut self) {
+            self.task.abort();
+        }
+    }
+
+    async fn start_mock_server(
+        handler: impl Fn(MockRequest) -> Response + Send + Sync + 'static,
+    ) -> MockServer {
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let state = MockState {
+            requests: requests.clone(),
+            handler: Arc::new(handler),
+        };
+        let app = Router::new()
+            .route("/{*path}", any(mock_handler))
+            .with_state(state);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind mock server");
+        let addr = listener.local_addr().expect("mock addr");
+        let task = tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        MockServer {
+            base_url: format!("http://{addr}"),
+            requests,
+            task,
+        }
+    }
+
+    async fn mock_handler(
+        axum::extract::State(state): axum::extract::State<MockState>,
+        method: Method,
+        uri: axum::http::Uri,
+        headers: HeaderMap,
+        body: Bytes,
+    ) -> Response {
+        let headers = headers
+            .iter()
+            .filter_map(|(name, value)| {
+                value
+                    .to_str()
+                    .ok()
+                    .map(|value| (name.as_str().to_ascii_lowercase(), value.to_string()))
+            })
+            .collect::<BTreeMap<_, _>>();
+        let body = String::from_utf8(body.to_vec()).expect("utf8 request body");
+        let request = MockRequest {
+            path: format!("{} {}", method.as_str(), uri.path()),
+            headers,
+            body,
+        };
+        state
+            .requests
+            .lock()
+            .expect("mock requests poisoned")
+            .push(request.clone());
+        (state.handler)(request)
+    }
+
+    fn ok_json(value: JsonValue) -> Response {
+        Json(value).into_response()
+    }
+
+    fn status_text(status: StatusCode, body: &'static str) -> Response {
+        (status, body).into_response()
+    }
+
+    fn hs_jwks(kid: &str, secret: &str) -> JsonValue {
+        json!({
+            "keys": [{
+                "kty": "oct",
+                "kid": kid,
+                "alg": "HS256",
+                "k": base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(secret)
+            }]
+        })
+    }
+
+    fn oidc_id_token(kid: &str, secret: &[u8], issuer: &str, audience: &str, exp: i64) -> String {
+        let mut header = Header::new(Algorithm::HS256);
+        header.kid = Some(kid.to_string());
+        encode(
+            &header,
+            &json!({
+                "iss": issuer,
+                "aud": audience,
+                "sub": "push-sender",
+                "iat": 1_700_000_000,
+                "exp": exp,
+            }),
+            &EncodingKey::from_secret(secret),
+        )
+        .expect("encode id token")
+    }
+
+    fn install_rustls_provider() {
+        static INSTALL: Once = Once::new();
+        INSTALL.call_once(|| {
+            let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+        });
+    }
+
+    #[tokio::test]
+    async fn push_delivery_uses_oauth2_client_credentials_token() {
+        let server = start_mock_server(|request| match request.path.as_str() {
+            "POST /token" => {
+                assert_eq!(
+                    request.headers.get("authorization").map(String::as_str),
+                    Some("Basic cHVzaC1jbGllbnQ6c2VjcmV0")
+                );
+                assert!(request.body.contains("grant_type=client_credentials"));
+                assert!(request.body.contains("scope=push.write"));
+                ok_json(json!({
+                    "access_token": "oauth-access",
+                    "token_type": "Bearer",
+                    "expires_in": 300,
+                }))
+            }
+            "POST /push" => {
+                assert_eq!(
+                    request.headers.get("authorization").map(String::as_str),
+                    Some("Bearer oauth-access")
+                );
+                assert!(request.body.contains("statusUpdate"));
+                status_text(StatusCode::OK, "ok")
+            }
+            _ => status_text(StatusCode::NOT_FOUND, "not found"),
+        })
+        .await;
+        let task = json!({"id": "task-oauth", "status": {"state": "completed"}});
+        let config = json!({
+            "url": format!("{}/push", server.base_url),
+            "authentication": {
+                "schemes": ["OAuth2"],
+                "token_url": format!("{}/token", server.base_url),
+                "client_id": "push-client",
+                "client_secret": "secret",
+                "scope": "push.write"
+            }
+        });
+
+        let results = deliver_push_configs(vec![config], task).await;
+        assert!(results.into_iter().all(|result| result.is_ok()));
+        let requests = server.requests.lock().expect("requests").clone();
+        assert_eq!(
+            requests
+                .iter()
+                .map(|req| req.path.as_str())
+                .collect::<Vec<_>>(),
+            ["POST /token", "POST /push"]
+        );
+    }
+
+    #[tokio::test]
+    async fn push_delivery_supports_static_http_auth_schemes() {
+        let server = start_mock_server(|request| match request.path.as_str() {
+            "POST /bearer" => {
+                assert_eq!(
+                    request.headers.get("authorization").map(String::as_str),
+                    Some("Bearer bearer-secret")
+                );
+                status_text(StatusCode::OK, "ok")
+            }
+            "POST /basic" => {
+                assert_eq!(
+                    request.headers.get("authorization").map(String::as_str),
+                    Some("Basic dXNlcjpwYXNz")
+                );
+                status_text(StatusCode::OK, "ok")
+            }
+            "POST /api-key" => {
+                assert_eq!(
+                    request.headers.get("x-api-key").map(String::as_str),
+                    Some("api-secret")
+                );
+                status_text(StatusCode::OK, "ok")
+            }
+            _ => status_text(StatusCode::NOT_FOUND, "not found"),
+        })
+        .await;
+        let task = json!({"id": "task-static-auth", "status": {"state": "completed"}});
+        let configs = vec![
+            json!({
+                "url": format!("{}/bearer", server.base_url),
+                "authentication": {"schemes": ["Bearer"], "credentials": "bearer-secret"}
+            }),
+            json!({
+                "url": format!("{}/basic", server.base_url),
+                "authentication": {"schemes": ["Basic"], "username": "user", "password": "pass"}
+            }),
+            json!({
+                "url": format!("{}/api-key", server.base_url),
+                "authentication": {"schemes": ["ApiKey"], "credentials": "api-secret"}
+            }),
+        ];
+
+        let results = deliver_push_configs(configs, task).await;
+        assert!(results.into_iter().all(|result| result.is_ok()));
+        let requests = server.requests.lock().expect("requests").clone();
+        assert_eq!(
+            requests
+                .iter()
+                .map(|req| req.path.as_str())
+                .collect::<Vec<_>>(),
+            ["POST /bearer", "POST /basic", "POST /api-key"]
+        );
+    }
+
+    #[tokio::test]
+    async fn push_delivery_validates_oidc_id_token_before_callback() {
+        let token = oidc_id_token(
+            "oidc-key",
+            b"secret",
+            "https://issuer.example",
+            "push-client",
+            4_102_444_800,
+        );
+        let server = start_mock_server(move |request| match request.path.as_str() {
+            "POST /token" => ok_json(json!({
+                "access_token": "opaque",
+                "id_token": token.clone(),
+                "token_type": "Bearer",
+            })),
+            "GET /jwks" => ok_json(hs_jwks("oidc-key", "secret")),
+            "POST /push" => {
+                assert!(request
+                    .headers
+                    .get("authorization")
+                    .is_some_and(|value| value.starts_with("Bearer ")));
+                status_text(StatusCode::OK, "ok")
+            }
+            _ => status_text(StatusCode::NOT_FOUND, "not found"),
+        })
+        .await;
+        let task = json!({"id": "task-oidc", "status": {"state": "completed"}});
+        let config = json!({
+            "url": format!("{}/push", server.base_url),
+            "authentication": {
+                "schemes": ["OpenIDConnect"],
+                "token_url": format!("{}/token", server.base_url),
+                "jwks_url": format!("{}/jwks", server.base_url),
+                "issuer": "https://issuer.example",
+                "client_id": "push-client",
+                "client_secret": "secret"
+            }
+        });
+
+        let results = deliver_push_configs(vec![config], task).await;
+        assert!(results.into_iter().all(|result| result.is_ok()));
+        let requests = server.requests.lock().expect("requests").clone();
+        assert_eq!(
+            requests
+                .iter()
+                .map(|req| req.path.as_str())
+                .collect::<Vec<_>>(),
+            ["POST /token", "GET /jwks", "POST /push"]
+        );
+    }
+
+    #[tokio::test]
+    async fn push_delivery_rejects_oidc_bad_signature_without_callback() {
+        let token = oidc_id_token(
+            "oidc-bad",
+            b"real-secret",
+            "https://issuer.example",
+            "push-client",
+            4_102_444_800,
+        );
+        let server = start_mock_server(move |request| match request.path.as_str() {
+            "POST /token" => ok_json(json!({
+                "id_token": token.clone(),
+                "token_type": "Bearer",
+            })),
+            "GET /jwks" => ok_json(hs_jwks("oidc-bad", "wrong-secret")),
+            "POST /push" => status_text(StatusCode::INTERNAL_SERVER_ERROR, "unexpected callback"),
+            _ => status_text(StatusCode::NOT_FOUND, "not found"),
+        })
+        .await;
+        let task = json!({"id": "task-oidc-bad-signature", "status": {"state": "completed"}});
+        let config = json!({
+            "url": format!("{}/push", server.base_url),
+            "authentication": {
+                "schemes": ["oidc"],
+                "token_url": format!("{}/token", server.base_url),
+                "jwks_url": format!("{}/jwks", server.base_url),
+                "issuer": "https://issuer.example",
+                "client_id": "push-client"
+            }
+        });
+
+        let results = deliver_push_configs(vec![config], task).await;
+        let error = results
+            .into_iter()
+            .next()
+            .expect("result")
+            .expect_err("bad signature");
+        assert!(
+            error.to_string().contains("validate OIDC ID token"),
+            "{error}"
+        );
+        let requests = server.requests.lock().expect("requests").clone();
+        assert_eq!(
+            requests
+                .iter()
+                .map(|req| req.path.as_str())
+                .collect::<Vec<_>>(),
+            ["POST /token", "GET /jwks"]
+        );
+    }
+
+    #[tokio::test]
+    async fn push_delivery_rejects_expired_oidc_id_token_without_callback() {
+        let token = oidc_id_token(
+            "oidc-expired",
+            b"expired",
+            "https://issuer.example",
+            "push-client",
+            1,
+        );
+        let server = start_mock_server(move |request| match request.path.as_str() {
+            "POST /token" => ok_json(json!({
+                "id_token": token.clone(),
+                "token_type": "Bearer",
+            })),
+            "GET /jwks" => ok_json(hs_jwks("oidc-expired", "expired")),
+            "POST /push" => status_text(StatusCode::INTERNAL_SERVER_ERROR, "unexpected callback"),
+            _ => status_text(StatusCode::NOT_FOUND, "not found"),
+        })
+        .await;
+        let task = json!({"id": "task-oidc-expired", "status": {"state": "completed"}});
+        let config = json!({
+            "url": format!("{}/push", server.base_url),
+            "authentication": {
+                "schemes": ["oidc"],
+                "token_url": format!("{}/token", server.base_url),
+                "jwks_url": format!("{}/jwks", server.base_url),
+                "issuer": "https://issuer.example",
+                "client_id": "push-client"
+            }
+        });
+
+        let results = deliver_push_configs(vec![config], task).await;
+        let error = results
+            .into_iter()
+            .next()
+            .expect("result")
+            .expect_err("expired token");
+        assert!(
+            error.to_string().contains("validate OIDC ID token"),
+            "{error}"
+        );
+        let requests = server.requests.lock().expect("requests").clone();
+        assert_eq!(
+            requests
+                .iter()
+                .map(|req| req.path.as_str())
+                .collect::<Vec<_>>(),
+            ["POST /token", "GET /jwks"]
+        );
+    }
+
+    #[tokio::test]
+    async fn push_delivery_refetches_jwks_when_oidc_kid_rotates() {
+        let fetches = Arc::new(AtomicUsize::new(0));
+        let fetches_for_handler = fetches.clone();
+        let first = oidc_id_token(
+            "old-key",
+            b"old",
+            "https://issuer.example",
+            "push-client",
+            4_102_444_800,
+        );
+        let second = oidc_id_token(
+            "new-key",
+            b"new",
+            "https://issuer.example",
+            "push-client",
+            4_102_444_800,
+        );
+        let token_index = Arc::new(AtomicUsize::new(0));
+        let token_index_for_handler = token_index.clone();
+        let server = start_mock_server(move |request| match request.path.as_str() {
+            "POST /token" => {
+                let index = token_index_for_handler.fetch_add(1, AtomicOrdering::SeqCst);
+                ok_json(json!({
+                    "id_token": if index == 0 { first.clone() } else { second.clone() },
+                    "token_type": "Bearer",
+                }))
+            }
+            "GET /jwks" => {
+                let index = fetches_for_handler.fetch_add(1, AtomicOrdering::SeqCst);
+                if index == 0 {
+                    ok_json(hs_jwks("old-key", "old"))
+                } else {
+                    ok_json(hs_jwks("new-key", "new"))
+                }
+            }
+            "POST /push" => status_text(StatusCode::OK, "ok"),
+            _ => status_text(StatusCode::NOT_FOUND, "not found"),
+        })
+        .await;
+        let config = json!({
+            "url": format!("{}/push", server.base_url),
+            "authentication": {
+                "schemes": ["oidc"],
+                "token_url": format!("{}/token", server.base_url),
+                "jwks_url": format!("{}/jwks", server.base_url),
+                "issuer": "https://issuer.example",
+                "client_id": "push-client"
+            }
+        });
+
+        for task_id in ["task-rotated-1", "task-rotated-2"] {
+            let results = deliver_push_configs(
+                vec![config.clone()],
+                json!({"id": task_id, "status": {"state": "completed"}}),
+            )
+            .await;
+            assert!(results.into_iter().all(|result| result.is_ok()));
+        }
+        assert_eq!(fetches.load(AtomicOrdering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn push_delivery_loads_mtls_client_cert_and_key() {
+        install_rustls_provider();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let server_cert =
+            rcgen::generate_simple_self_signed(vec!["localhost".to_string()]).expect("server cert");
+        let client_cert = rcgen::generate_simple_self_signed(vec!["harn-push-client".to_string()])
+            .expect("client cert");
+        let server_cert_path = temp.path().join("server-cert.pem");
+        let client_cert_path = temp.path().join("client-cert.pem");
+        let client_key_path = temp.path().join("client-key.pem");
+        std::fs::write(&server_cert_path, server_cert.cert.pem()).expect("server cert file");
+        std::fs::write(&client_cert_path, client_cert.cert.pem()).expect("client cert file");
+        std::fs::write(&client_key_path, client_cert.key_pair.serialize_pem())
+            .expect("client key file");
+
+        let mut client_roots = rustls::RootCertStore::empty();
+        client_roots
+            .add(client_cert.cert.der().clone())
+            .expect("client root");
+        let verifier = rustls::server::WebPkiClientVerifier::builder(Arc::new(client_roots))
+            .build()
+            .expect("client verifier");
+        let server_config = Arc::new(
+            rustls::ServerConfig::builder()
+                .with_client_cert_verifier(verifier)
+                .with_single_cert(
+                    vec![server_cert.cert.der().clone()],
+                    rustls::pki_types::PrivatePkcs8KeyDer::from(
+                        server_cert.key_pair.serialize_der(),
+                    )
+                    .into(),
+                )
+                .expect("server config"),
+        );
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind mtls server");
+        let port = listener.local_addr().expect("addr").port();
+        let thread = std::thread::spawn(move || {
+            use std::io::{Read as _, Write as _};
+
+            let (tcp, _) = listener.accept().expect("accept mtls");
+            let conn = rustls::ServerConnection::new(server_config).expect("server conn");
+            let mut stream = rustls::StreamOwned::new(conn, tcp);
+            let mut request = Vec::new();
+            let mut buffer = [0u8; 512];
+            while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+                let read = stream.read(&mut buffer).expect("read mtls request");
+                assert_ne!(read, 0, "client closed before request headers");
+                request.extend_from_slice(&buffer[..read]);
+            }
+            assert!(stream
+                .conn
+                .peer_certificates()
+                .is_some_and(|certs| !certs.is_empty()));
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\ncontent-length: 2\r\n\r\nok")
+                .expect("write response");
+        });
+
+        let task = json!({"id": "task-mtls", "status": {"state": "completed"}});
+        let config = json!({
+            "url": format!("https://localhost:{port}/push"),
+            "authentication": {
+                "schemes": ["mTLS"],
+                "client_cert": client_cert_path.display().to_string(),
+                "client_key": client_key_path.display().to_string(),
+                "ca_cert": server_cert_path.display().to_string()
+            }
+        });
+
+        let results = deliver_push_configs(vec![config], task).await;
+        assert!(results.into_iter().all(|result| result.is_ok()));
+        thread.join().expect("mtls server thread");
     }
 
     fn assert_current_agent_card_shape(card: &JsonValue, public_url: &str) {

--- a/crates/harn-vm/src/connectors/shared.rs
+++ b/crates/harn-vm/src/connectors/shared.rs
@@ -155,18 +155,14 @@ where
 {
     let header = decode_header(token)
         .map_err(|error| ConnectorError::invalid_signature(error.to_string()))?;
-    let jwks = resolve_jwks(http, source, options).await?;
-    let jwk = match header.kid.as_deref() {
-        Some(kid) => jwks.find(kid).ok_or_else(|| {
-            ConnectorError::invalid_signature(format!("JWT kid `{kid}` was not found in JWKS"))
-        })?,
-        None if jwks.keys.len() == 1 => &jwks.keys[0],
-        None => {
-            return Err(ConnectorError::invalid_signature(
-                "JWT missing kid and JWKS contains multiple keys",
-            ))
+    let jwks = resolve_jwks(http, source.clone(), options).await?;
+    let jwks = match (source, header.kid.as_deref()) {
+        (JwtKeySource::Url(jwks_url), Some(kid)) if jwks.find(kid).is_none() => {
+            fetch_uncached_jwks(http, jwks_url, options).await?
         }
+        _ => jwks,
     };
+    let jwk = jwk_for_header(&jwks, header.kid.as_deref())?;
     let key = DecodingKey::from_jwk(jwk)
         .map_err(|error| ConnectorError::invalid_signature(error.to_string()))?;
     let mut validation = Validation::new(header.alg);
@@ -189,6 +185,21 @@ where
         .map_err(|error| ConnectorError::invalid_signature(error.to_string()))
 }
 
+fn jwk_for_header<'a>(
+    jwks: &'a JwkSet,
+    kid: Option<&str>,
+) -> Result<&'a jsonwebtoken::jwk::Jwk, ConnectorError> {
+    match kid {
+        Some(kid) => jwks.find(kid).ok_or_else(|| {
+            ConnectorError::invalid_signature(format!("JWT kid `{kid}` was not found in JWKS"))
+        }),
+        None if jwks.keys.len() == 1 => Ok(&jwks.keys[0]),
+        None => Err(ConnectorError::invalid_signature(
+            "JWT missing kid and JWKS contains multiple keys",
+        )),
+    }
+}
+
 pub async fn verify_jwt_json(
     http: &reqwest::Client,
     token: &str,
@@ -206,6 +217,14 @@ async fn fetch_cached_jwks(
     if let Some(cached) = cached_jwks(jwks_url, options.jwks_cache_ttl) {
         return Ok(cached);
     }
+    fetch_uncached_jwks(http, jwks_url, options).await
+}
+
+async fn fetch_uncached_jwks(
+    http: &reqwest::Client,
+    jwks_url: &str,
+    options: &JwtVerificationOptions,
+) -> Result<JwkSet, ConnectorError> {
     if let Some(error) = crate::egress::connector_error_for_url(options.egress_label, jwks_url) {
         return Err(error);
     }

--- a/docs/src/connectors/a2a-push.md
+++ b/docs/src/connectors/a2a-push.md
@@ -83,6 +83,38 @@ The built-in `harn serve a2a` adapter advertises push notification
 support, stores push configs, and posts `statusUpdate` payloads to each
 configured webhook when an asynchronous task completes or fails.
 
+`pushNotificationConfig.authentication` is honored when the remote
+webhook declares how Harn should authenticate the callback:
+
+```json
+{
+  "url": "https://client.example/a2a/push",
+  "authentication": {
+    "schemes": ["OAuth2"],
+    "token_url": "https://idp.example/oauth/token",
+    "client_id": "harn-a2a",
+    "client_secret": "${secret}",
+    "scope": "push.write"
+  }
+}
+```
+
+Supported schemes:
+
+- `Bearer`: sends `Authorization: Bearer <credentials>`.
+- `Basic`: sends `Authorization: Basic <credentials>`, or builds the
+  value from `username`/`password`.
+- `ApiKey`: sends `credentials` in `X-API-Key` by default, or in the
+  configured `header`.
+- `OAuth2`: uses client credentials at `token_url` and sends the
+  returned bearer `access_token`.
+- `OpenIDConnect` / `oidc`: uses client credentials, requires an
+  `id_token`, validates it against `issuer`, `client_id`/`audience`,
+  and `jwks_url`, then sends it as a bearer credential. JWKS are cached
+  and refreshed when a token arrives with a rotated `kid`.
+- `mTLS`: loads `client_cert` plus `client_key`, or `client_identity`,
+  and may use `ca_cert` for private webhook CAs.
+
 Legacy `a2a-push` routes without `[triggers.a2a_push]` keep the older
 orchestrator listener auth: `HARN_ORCHESTRATOR_API_KEYS` plus
 `HARN_ORCHESTRATOR_HMAC_SECRET`.


### PR DESCRIPTION
## Summary

Closes #893.

- implements declarative A2A push notification auth for API key, Basic, Bearer, OAuth2 client credentials, OIDC ID token validation, and mTLS certificate presentation
- validates outbound egress for push endpoints, OAuth/OIDC discovery/token/JWKS URLs, redirects, custom CA bundles, and client identities
- refetches remote JWKS once on unknown `kid` so OIDC key rotation works without waiting for the cache TTL
- documents supported push auth fields and expected behavior
- makes scanner Git file discovery and churn scoring injectable through `GitCapabilities`, replacing ambient-workspace scanner smoke coverage with hermetic fixture coverage

## Validation

- `CARGO_TARGET_DIR=/tmp/harn-target-issue-893 cargo check -p harn-serve`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-893 cargo test -p harn-serve push_delivery`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-893 cargo test -p harn-serve adapters::a2a`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-893 cargo test -p harn-serve`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-893 cargo test -p harn-vm jwt_claims_verify_against_inline_jwks`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-893 cargo check --workspace`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-893 cargo clippy -p harn-vm -p harn-serve --all-targets -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-893 cargo clippy -p harn-hostlib --all-targets -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-893 cargo nextest run -p harn-hostlib --no-capture` (327 passed, leak detection active)
- `git diff --check`
- pre-commit hook: rustfmt, workspace clippy, markdownlint
- pre-push hook after rebase: 3336 nextest tests, affected Harn fmt/lint, markdownlint, language spec mirror

## Notes

The original transient nextest leak surfaced in `harn-hostlib::scanner_e2e scan_project_emits_full_result_shape`. The root weakness was scanner tests and production scanner internals coupling Git-backed discovery/churn to ambient checkout behavior. This branch now routes those Git inputs through an explicit capability boundary and verifies the intended behavior with mock Git data, while the default CLI-backed implementation remains available for normal scans inside real worktrees.