### PR TITLE
[codex] Move heavy CI sweeps off PR path

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
 CHANGELOG.md merge=union
-docs/theme/harn-keywords.js merge=harn-generated
-docs/src/language-spec.md merge=harn-generated
+docs/theme/harn-keywords.js merge=harn-generated eol=lf
+docs/src/language-spec.md merge=harn-generated eol=lf
+docs/llm/harn-triggers-quickref.md eol=lf
+docs/src/provider-matrix.md eol=lf
+docs/src/connectors/parity-matrix.md eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
   merge_group:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.merge_group.head_sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   # sccache is wired in via .cargo/config.toml (rustc-wrapper = "sccache").
@@ -97,27 +104,29 @@ jobs:
     name: Detect code changes
     runs-on: ubuntu-latest
     outputs:
-      rust: ${{ steps.filter.outputs.rust }}
+      windows: ${{ steps.filter.outputs.windows }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - id: filter
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         with:
           filters: |
-            rust:
+            windows:
               - 'crates/**'
               - 'conformance/**'
               - 'Cargo.toml'
               - 'Cargo.lock'
               - '.cargo/**'
               - 'rust-toolchain.toml'
-              - '.github/workflows/ci.yml'
+              - 'Makefile'
+              - 'scripts/**'
+              - '.github/workflows/**'
 
   windows:
     name: Rust on Windows (build + smoke test)
     runs-on: windows-latest
     needs: changes
-    if: needs.changes.outputs.rust == 'true' || github.event_name == 'merge_group' || github.event_name == 'push'
+    if: needs.changes.outputs.windows == 'true' || github.event_name == 'merge_group' || github.event_name == 'push'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -222,9 +231,10 @@ jobs:
             ["GitHub Actions lint"]="${{ needs.actions.result }}"
           )
 
-          # The Windows job is gated on `changes.outputs.rust` and is skipped
-          # on PRs that don't touch Rust/CI. Treat `skipped` as passing here;
-          # only an actual failure should fail the gate.
+          # The Windows job is gated on `changes.outputs.windows` and is skipped
+          # on PRs that don't touch Rust/workflow/platform-sensitive paths.
+          # Treat `skipped` as passing here; only an actual failure should fail
+          # the gate.
           windows_result="${{ needs.windows.result }}"
           echo "Rust on Windows (build + smoke test): $windows_result"
           if [ "$windows_result" != "success" ] && [ "$windows_result" != "skipped" ]; then

--- a/.github/workflows/flake-detection.yml
+++ b/.github/workflows/flake-detection.yml
@@ -1,8 +1,12 @@
 name: Flake detection
 
 on:
-  pull_request:
-  merge_group:
+  schedule:
+    - cron: "30 8 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always
@@ -24,7 +28,6 @@ jobs:
       - name: Detect touched test files
         id: touched
         run: |
-          git fetch origin main --depth=1
           # Match every Rust source file under any workspace crate.
           # The narrower `crates/**/src/**/tests*.rs` glob this replaces
           # silently skipped src/ files containing inline `#[cfg(test)]`
@@ -34,7 +37,18 @@ jobs:
           # `package(<pkg>)`, which now reruns the whole package's
           # tests 50× — the safe default when behavior changes
           # anywhere in a crate could introduce a flake.
-          TOUCHED=$(git diff --name-only origin/main...HEAD -- \
+          if [[ "${{ github.event_name }}" == "schedule" ]]; then
+            BASE=$(git rev-list -n 1 --before='24 hours ago' HEAD || true)
+            if [[ -z "$BASE" ]]; then
+              BASE=$(git rev-list --max-parents=0 HEAD | tail -n 1)
+            fi
+            RANGE="$BASE...HEAD"
+          else
+            git fetch origin main --depth=1
+            RANGE="origin/main...HEAD"
+          fi
+          echo "Diff range: $RANGE"
+          TOUCHED=$(git diff --name-only "$RANGE" -- \
             'crates/**/*.rs' | tr '\n' ' ')
           FILTER=""
           if [[ -n "${TOUCHED// }" ]]; then

--- a/.github/workflows/thread-parity.yml
+++ b/.github/workflows/thread-parity.yml
@@ -1,8 +1,12 @@
 name: Thread-count parity
 
 on:
-  pull_request:
-  merge_group:
+  schedule:
+    - cron: "0 9 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/windows-nightly.yml
+++ b/.github/workflows/windows-nightly.yml
@@ -23,6 +23,9 @@ on:
     - cron: "0 7 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"

--- a/Makefile
+++ b/Makefile
@@ -190,13 +190,7 @@ sync-language-spec:
 # spec/HARN_SPEC.md. `make sync-language-spec` fixes it.
 check-language-spec:
 	@echo "=== Checking docs/src/language-spec.md is up to date ==="
-	@./scripts/sync_language_spec.sh
-	@if ! git diff --quiet --exit-code -- docs/src/language-spec.md; then \
-		echo "error: docs/src/language-spec.md is stale relative to spec/HARN_SPEC.md" >&2; \
-		echo "hint: run 'make sync-language-spec' and commit the result" >&2; \
-		git diff --stat -- docs/src/language-spec.md >&2; \
-		exit 1; \
-	fi
+	@./scripts/sync_language_spec.sh --check
 	@echo "    Language spec mirror OK."
 
 # Regenerate the LLM trigger quickref from the live ProviderCatalog metadata.
@@ -220,7 +214,7 @@ check-provider-matrix:
 	tmp=$$(mktemp); \
 	trap 'rm -f "$$tmp"' EXIT; \
 	cargo run --quiet -p harn-cli -- check --provider-matrix --format markdown > "$$tmp"; \
-	if ! cmp -s "$$tmp" docs/src/provider-matrix.md; then \
+	if ! python3 scripts/compare_generated_text.py docs/src/provider-matrix.md "$$tmp"; then \
 		echo "error: docs/src/provider-matrix.md is stale relative to capabilities.toml" >&2; \
 		echo "hint: run 'make gen-provider-matrix' and commit the result" >&2; \
 		diff -u docs/src/provider-matrix.md "$$tmp" >&2 || true; \

--- a/crates/harn-cli/src/commands/check/connector_matrix.rs
+++ b/crates/harn-cli/src/commands/check/connector_matrix.rs
@@ -50,7 +50,7 @@ pub(crate) fn run_docs(output_path: &str, sources: &[String], check_only: bool) 
                 process::exit(1);
             }
         };
-        if existing != generated {
+        if normalize_line_endings(&existing) != normalize_line_endings(&generated) {
             eprintln!(
                 "error: {} is stale relative to the connector capability matrix.",
                 path.display()
@@ -102,6 +102,10 @@ pub(crate) fn generate_markdown(rows: &[ConnectorCapabilityMatrixRow]) -> String
         ));
     }
     out
+}
+
+fn normalize_line_endings(text: &str) -> String {
+    text.replace("\r\n", "\n").replace('\r', "\n")
 }
 
 fn load_rows_for_cli(targets: &[String]) -> Vec<ConnectorCapabilityMatrixRow> {
@@ -459,6 +463,17 @@ capabilities = { webhook = true, oauth = true, rate_limit = true }
         ));
         assert!(
             markdown.contains("| `acme` | `harn-acme-connector` | yes | no | yes | no | no | no |")
+        );
+    }
+
+    #[test]
+    fn generated_markdown_comparison_ignores_platform_line_endings() {
+        let generated = "# Connector Parity Matrix\n\n| Provider |\n";
+        let on_disk = generated.replace('\n', "\r\n");
+
+        assert_eq!(
+            normalize_line_endings(&on_disk),
+            normalize_line_endings(generated)
         );
     }
 }

--- a/crates/harn-cli/src/commands/dump_highlight_keywords.rs
+++ b/crates/harn-cli/src/commands/dump_highlight_keywords.rs
@@ -44,7 +44,7 @@ pub(crate) fn run(output_path: &str, check_only: bool) {
                 process::exit(1);
             }
         };
-        if existing != generated {
+        if normalize_line_endings(&existing) != normalize_line_endings(&generated) {
             eprintln!(
                 "error: {} is stale relative to the lexer/stdlib.",
                 path.display()
@@ -114,6 +114,10 @@ fn generate_file() -> String {
     )
 }
 
+fn normalize_line_endings(text: &str) -> String {
+    text.replace("\r\n", "\n").replace('\r', "\n")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -158,9 +162,21 @@ mod tests {
         });
         let generated = generate_file();
         assert_eq!(
-            on_disk, generated,
+            normalize_line_endings(&on_disk),
+            normalize_line_endings(&generated),
             "docs/theme/harn-keywords.js is stale relative to the lexer/stdlib.\n\
              Run `make gen-highlight` to regenerate."
+        );
+    }
+
+    #[test]
+    fn generated_file_comparison_ignores_platform_line_endings() {
+        let generated = "window.__HARN_KEYWORDS = {};\n";
+        let on_disk = generated.replace('\n', "\r\n");
+
+        assert_eq!(
+            normalize_line_endings(&on_disk),
+            normalize_line_endings(generated)
         );
     }
 

--- a/crates/harn-cli/src/commands/dump_trigger_quickref.rs
+++ b/crates/harn-cli/src/commands/dump_trigger_quickref.rs
@@ -95,7 +95,7 @@ pub(crate) fn run(output_path: &str, check_only: bool) {
                 process::exit(1);
             }
         };
-        if existing != generated {
+        if normalize_line_endings(&existing) != normalize_line_endings(&generated) {
             eprintln!(
                 "error: {} is stale relative to the trigger provider catalog.",
                 path.display()
@@ -250,6 +250,10 @@ return { status: outcome.status == \"rejected\" ? 401 : 202 }\n\
     out
 }
 
+fn normalize_line_endings(text: &str) -> String {
+    text.replace("\r\n", "\n").replace('\r', "\n")
+}
+
 fn provider_row(provider: &ProviderMetadata) -> String {
     format!(
         "| `{}` | {} | `{}` | {} | {} | {} | {} |\n",
@@ -384,9 +388,21 @@ mod tests {
         });
         let generated = generate_file();
         assert_eq!(
-            on_disk, generated,
+            normalize_line_endings(&on_disk),
+            normalize_line_endings(&generated),
             "docs/llm/harn-triggers-quickref.md is stale relative to the trigger provider catalog.\n\
              Run `make gen-trigger-quickref` to regenerate."
+        );
+    }
+
+    #[test]
+    fn generated_quickref_comparison_ignores_platform_line_endings() {
+        let generated = "# Harn Trigger Quick Reference\n\n| Provider |\n";
+        let on_disk = generated.replace('\n', "\r\n");
+
+        assert_eq!(
+            normalize_line_endings(&on_disk),
+            normalize_line_endings(generated)
         );
     }
 }

--- a/crates/harn-cli/src/commands/portal/launch.rs
+++ b/crates/harn-cli/src/commands/portal/launch.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeMap, HashSet};
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 
 use axum::http::StatusCode;
@@ -479,14 +479,38 @@ fn collect_launch_targets(
         } else if path.extension().is_some_and(|ext| ext == "harn") {
             let relative = path
                 .strip_prefix(workspace_root)
-                .map_err(|error| format!("failed to relativize {}: {error}", path.display()))?
-                .display()
-                .to_string();
+                .map_err(|error| format!("failed to relativize {}: {error}", path.display()))?;
             out.push(PortalLaunchTarget {
-                path: relative,
+                path: logical_path(relative),
                 group: group.to_string(),
             });
         }
     }
     Ok(())
+}
+
+fn logical_path(path: &Path) -> String {
+    path.components()
+        .filter_map(|component| match component {
+            Component::Normal(part) => Some(part.to_string_lossy().into_owned()),
+            Component::CurDir => None,
+            Component::ParentDir => Some("..".to_string()),
+            Component::RootDir | Component::Prefix(_) => {
+                Some(component.as_os_str().to_string_lossy().into_owned())
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn logical_path_uses_slashes_for_native_launch_paths() {
+        let path = Path::new("examples").join("nested").join("demo.harn");
+
+        assert_eq!(logical_path(&path), "examples/nested/demo.harn");
+    }
 }

--- a/crates/harn-cli/src/commands/test.rs
+++ b/crates/harn-cli/src/commands/test.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::process;
 
 use regex::Regex;
@@ -35,6 +35,20 @@ fn normalize_output_line(line: &str) -> String {
         }
     }
     line.to_string()
+}
+
+fn logical_path(path: &Path) -> String {
+    path.components()
+        .filter_map(|component| match component {
+            Component::Normal(part) => Some(part.to_string_lossy().into_owned()),
+            Component::CurDir => None,
+            Component::ParentDir => Some("..".to_string()),
+            Component::RootDir | Component::Prefix(_) => {
+                Some(component.as_os_str().to_string_lossy().into_owned())
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("/")
 }
 
 /// Produce a simple line diff between expected and actual.
@@ -242,11 +256,8 @@ pub(crate) async fn run_conformance_tests(
         let expected_file = harn_file.with_extension("expected");
         let error_file = harn_file.with_extension("error");
 
-        let rel_path = harn_file
-            .strip_prefix(&suite_root)
-            .unwrap_or(harn_file)
-            .display()
-            .to_string();
+        let rel_path = harn_file.strip_prefix(&suite_root).unwrap_or(harn_file);
+        let rel_path = logical_path(rel_path);
 
         // Filter syntax: `re:<regex>`, `foo|bar` (OR), `*_runtime*` (glob),
         // or plain substring match.
@@ -859,11 +870,8 @@ pub(crate) async fn run_conformance_determinism_tests(
     let mut errors = Vec::new();
 
     for path in files {
-        let rel_path = path
-            .strip_prefix(&suite_root)
-            .unwrap_or(&path)
-            .display()
-            .to_string();
+        let rel_path = path.strip_prefix(&suite_root).unwrap_or(&path);
+        let rel_path = logical_path(rel_path);
         if let Some(pattern) = filter {
             let matched = if let Some(re_pat) = pattern.strip_prefix("re:") {
                 Regex::new(re_pat).is_ok_and(|re| re.is_match(&rel_path))
@@ -967,7 +975,7 @@ pub(crate) async fn run_watch_tests(
 
 #[cfg(test)]
 mod tests {
-    use super::{collect_harn_files_sorted, resolve_conformance_selection};
+    use super::{collect_harn_files_sorted, logical_path, resolve_conformance_selection};
     use std::fs;
     use std::path::{Path, PathBuf};
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -1024,12 +1032,7 @@ mod tests {
         let files = collect_harn_files_sorted(&temp.path().join("suite"));
         let relative: Vec<String> = files
             .iter()
-            .map(|path| {
-                path.strip_prefix(temp.path())
-                    .unwrap()
-                    .display()
-                    .to_string()
-            })
+            .map(|path| logical_path(path.strip_prefix(temp.path()).unwrap()))
             .collect();
 
         assert_eq!(
@@ -1040,6 +1043,13 @@ mod tests {
                 "suite/zeta.harn"
             ]
         );
+    }
+
+    #[test]
+    fn logical_path_uses_slashes_for_native_test_paths() {
+        let path = Path::new("suite").join("nested").join("beta.harn");
+
+        assert_eq!(logical_path(&path), "suite/nested/beta.harn");
     }
 
     #[test]

--- a/crates/harn-cli/src/package/lockfile.rs
+++ b/crates/harn-cli/src/package/lockfile.rs
@@ -1142,6 +1142,12 @@ mod tests {
                 "path dependencies should be live-linked on Unix"
             );
 
+            #[cfg(windows)]
+            let materialized_is_link = fs::symlink_metadata(&materialized)
+                .unwrap()
+                .file_type()
+                .is_symlink();
+
             fs::write(
                 dependency_root.join("lib.harn"),
                 "pub fn version() -> string { return \"v2\" }\n",
@@ -1154,6 +1160,22 @@ mod tests {
                     live_source.contains("v2"),
                     "materialized path dependency should reflect sibling repo edits"
                 );
+            }
+            #[cfg(windows)]
+            {
+                let materialized_source =
+                    fs::read_to_string(materialized.join("lib.harn")).unwrap();
+                if materialized_is_link {
+                    assert!(
+                        materialized_source.contains("v2"),
+                        "Windows path dependency symlink should reflect sibling repo edits"
+                    );
+                } else {
+                    assert!(
+                        materialized_source.contains("v1"),
+                        "Windows path dependency copy fallback should keep the copied contents"
+                    );
+                }
             }
 
             remove_package("openapi");

--- a/crates/harn-cli/src/package/registry.rs
+++ b/crates/harn-cli/src/package/registry.rs
@@ -331,35 +331,50 @@ pub(crate) fn remove_materialized_package(
     packages_dir: &Path,
     alias: &str,
 ) -> Result<(), PackageError> {
-    let dir = packages_dir.join(alias);
-    match fs::symlink_metadata(&dir) {
-        Ok(metadata) if metadata.file_type().is_symlink() || metadata.is_file() => {
-            fs::remove_file(&dir)
-                .map_err(|error| format!("failed to remove {}: {error}", dir.display()))?;
-        }
-        Ok(metadata) if metadata.is_dir() => {
-            fs::remove_dir_all(&dir)
-                .map_err(|error| format!("failed to remove {}: {error}", dir.display()))?;
-        }
-        Ok(_) => {}
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-        Err(error) => return Err(format!("failed to stat {}: {error}", dir.display()).into()),
-    }
-    let file = packages_dir.join(format!("{alias}.harn"));
-    match fs::symlink_metadata(&file) {
-        Ok(metadata) if metadata.file_type().is_symlink() || metadata.is_file() => {
-            fs::remove_file(&file)
-                .map_err(|error| format!("failed to remove {}: {error}", file.display()))?;
-        }
-        Ok(metadata) if metadata.is_dir() => {
-            fs::remove_dir_all(&file)
-                .map_err(|error| format!("failed to remove {}: {error}", file.display()))?;
-        }
-        Ok(_) => {}
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-        Err(error) => return Err(format!("failed to stat {}: {error}", file.display()).into()),
-    }
+    remove_materialized_path(&packages_dir.join(alias))?;
+    remove_materialized_path(&packages_dir.join(format!("{alias}.harn")))?;
     Ok(())
+}
+
+fn remove_materialized_path(path: &Path) -> Result<(), PackageError> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if is_link_like(&metadata) => remove_link_like_path(path)
+            .map_err(|error| format!("failed to remove {}: {error}", path.display()).into()),
+        Ok(metadata) if metadata.is_file() => fs::remove_file(path)
+            .map_err(|error| format!("failed to remove {}: {error}", path.display()).into()),
+        Ok(metadata) if metadata.is_dir() => fs::remove_dir_all(path)
+            .map_err(|error| format!("failed to remove {}: {error}", path.display()).into()),
+        Ok(_) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(format!("failed to stat {}: {error}", path.display()).into()),
+    }
+}
+
+fn is_link_like(metadata: &fs::Metadata) -> bool {
+    metadata.file_type().is_symlink() || is_windows_reparse_point(metadata)
+}
+
+#[cfg(windows)]
+fn is_windows_reparse_point(metadata: &fs::Metadata) -> bool {
+    use std::os::windows::fs::MetadataExt;
+
+    const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x400;
+    metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
+}
+
+#[cfg(not(windows))]
+fn is_windows_reparse_point(_metadata: &fs::Metadata) -> bool {
+    false
+}
+
+fn remove_link_like_path(path: &Path) -> std::io::Result<()> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(file_error) => match fs::remove_dir(path) {
+            Ok(()) => Ok(()),
+            Err(_) => Err(file_error),
+        },
+    }
 }
 
 #[cfg(unix)]
@@ -1628,6 +1643,29 @@ mod tests {
         fs::write(root.join(CONTENT_HASH_FILE), "changed\n").unwrap();
         let second = compute_content_hash(root).unwrap();
         assert_eq!(first, second);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn remove_materialized_package_unlinks_directory_symlink_without_touching_source() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("source");
+        let packages = tmp.path().join(".harn/packages");
+        fs::create_dir_all(&source).unwrap();
+        fs::create_dir_all(&packages).unwrap();
+        fs::write(
+            source.join("lib.harn"),
+            "pub fn value() -> number { return 1 }\n",
+        )
+        .unwrap();
+
+        let materialized = packages.join("acme");
+        std::os::unix::fs::symlink(&source, &materialized).unwrap();
+
+        remove_materialized_package(&packages, "acme").unwrap();
+
+        assert!(!materialized.exists());
+        assert!(source.join("lib.harn").is_file());
     }
 
     #[test]

--- a/crates/harn-cli/src/package/skills.rs
+++ b/crates/harn-cli/src/package/skills.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::path::Component;
 
 /// Resolved `[skills]` section plus the directory the manifest came
 /// from. Paths in `skills.paths` are joined against `manifest_dir`;
@@ -72,45 +73,52 @@ pub fn resolve_skills_paths(cfg: &ResolvedSkillsConfig) -> Vec<PathBuf> {
 }
 
 pub(crate) fn expand_single_star_glob(path: &Path) -> Vec<PathBuf> {
-    let as_str = path.to_string_lossy().to_string();
-    if !as_str.contains('*') {
+    if !path
+        .components()
+        .any(|component| matches!(component, Component::Normal(name) if name == OsStr::new("*")))
+    {
         return vec![path.to_path_buf()];
     }
-    let components: Vec<&str> = as_str.split('/').collect();
+
     let mut results: Vec<PathBuf> = vec![PathBuf::new()];
-    for comp in components {
+    for component in path.components() {
         let mut next: Vec<PathBuf> = Vec::new();
-        if comp == "*" {
-            for parent in &results {
-                if let Ok(entries) = fs::read_dir(parent) {
-                    for entry in entries.flatten() {
-                        let path = entry.path();
-                        if path.is_dir() {
-                            next.push(path);
+        match component {
+            Component::Normal(name) if name == OsStr::new("*") => {
+                for parent in &results {
+                    if let Ok(entries) = fs::read_dir(parent) {
+                        for entry in entries.flatten() {
+                            let path = entry.path();
+                            if path.is_dir() {
+                                next.push(path);
+                            }
                         }
                     }
                 }
             }
-        } else if comp.is_empty() {
-            for parent in &results {
-                if parent.as_os_str().is_empty() {
-                    next.push(PathBuf::from("/"));
-                } else {
-                    next.push(parent.clone());
-                }
-            }
-        } else {
-            for parent in &results {
-                let joined = parent.join(comp);
-                // Filter branches whose literal suffix does not exist on
-                // disk so downstream FS sources don't iterate over phantom
-                // directories (one Rust round-trip cheaper than discovering
-                // them at load time).
-                if joined.exists() || parent.as_os_str().is_empty() {
-                    next.push(joined);
+            _ => {
+                for parent in &results {
+                    let mut joined = parent.clone();
+                    joined.push(component.as_os_str());
+                    // Filter branches whose literal suffix does not exist on
+                    // disk so downstream FS sources don't iterate over phantom
+                    // directories (one Rust round-trip cheaper than discovering
+                    // them at load time). Roots and prefixes are kept even
+                    // though existence checks on incomplete Windows paths such
+                    // as `C:` are not meaningful.
+                    if joined.exists()
+                        || parent.as_os_str().is_empty()
+                        || matches!(
+                            component,
+                            Component::Prefix(_) | Component::RootDir | Component::CurDir
+                        )
+                    {
+                        next.push(joined);
+                    }
                 }
             }
         }
+        next.sort();
         results = next;
     }
     results
@@ -201,6 +209,29 @@ mod tests {
 
         let raw = root.join("packages").join("*").join("skills");
         let expanded = expand_single_star_glob(&raw);
-        assert_eq!(expanded.len(), 2);
+        let expanded: Vec<_> = expanded
+            .iter()
+            .map(|path| {
+                path.strip_prefix(root)
+                    .unwrap()
+                    .components()
+                    .map(|component| component.as_os_str().to_string_lossy())
+                    .collect::<Vec<_>>()
+                    .join("/")
+            })
+            .collect();
+
+        assert_eq!(
+            expanded,
+            vec!["packages/pkg-a/skills", "packages/pkg-b/skills"]
+        );
+    }
+
+    #[test]
+    fn expand_single_star_glob_leaves_non_glob_paths_unchanged() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("packages").join("pkg-a").join("skills");
+
+        assert_eq!(expand_single_star_glob(&path), vec![path]);
     }
 }

--- a/crates/harn-vm/src/stdlib/path.rs
+++ b/crates/harn-vm/src/stdlib/path.rs
@@ -383,6 +383,10 @@ mod tests {
         assert_eq!(normalize("/"), "/");
         assert_eq!(normalize("/a/b/../c"), "/a/c");
         assert_eq!(normalize("a\\b\\c"), "a/b/c");
+        assert_eq!(
+            normalize("C:\\repo\\pkg\\..\\main.harn"),
+            "C:/repo/main.harn"
+        );
     }
 
     #[test]

--- a/scripts/compare_generated_text.py
+++ b/scripts/compare_generated_text.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""Compare generated text files while ignoring platform line endings."""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+
+def normalize(text: str) -> str:
+    return text.replace("\r\n", "\n").replace("\r", "\n")
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print(
+            "usage: compare_generated_text.py <committed> <generated>",
+            file=sys.stderr,
+        )
+        return 2
+
+    committed = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+    generated = pathlib.Path(sys.argv[2]).read_text(encoding="utf-8")
+    return 0 if normalize(committed) == normalize(generated) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sync_language_spec.sh
+++ b/scripts/sync_language_spec.sh
@@ -4,14 +4,35 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SRC="$ROOT_DIR/spec/HARN_SPEC.md"
 DST="$ROOT_DIR/docs/src/language-spec.md"
+MODE="${1:-write}"
 
 if [[ ! -f "$SRC" ]]; then
   echo "error: missing $SRC" >&2
   exit 1
 fi
 
-{
+emit_spec() {
   echo "<!-- Generated from spec/HARN_SPEC.md by scripts/sync_language_spec.sh -->"
   echo ""
   cat "$SRC"
-} >"$DST"
+}
+
+case "$MODE" in
+  --check)
+    TMP="$(mktemp)"
+    trap 'rm -f "$TMP"' EXIT
+    emit_spec >"$TMP"
+    if ! python3 "$ROOT_DIR/scripts/compare_generated_text.py" "$DST" "$TMP"; then
+      echo "error: docs/src/language-spec.md is stale relative to spec/HARN_SPEC.md" >&2
+      echo "hint: run 'make sync-language-spec' and commit the result" >&2
+      exit 1
+    fi
+    ;;
+  write)
+    emit_spec >"$DST"
+    ;;
+  *)
+    echo "usage: $0 [--check]" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## Summary

Move the expensive reliability sweeps out of PR and merge-queue CI while keeping `CI status` as the required mergeability gate. This keeps the full safety net available through scheduled and manual runs, and restores the optional Windows nightly by fixing the portability failures that were already known.

## What changed

- `Flake detection` and `Thread-count parity` now run on schedule/manual dispatch instead of every PR and merge queue entry.
- `CI` now has least-privilege `contents: read` permissions and cancels stale PR runs through workflow-level concurrency.
- The Windows smoke job remains part of `CI status`, but only runs for Rust/workflow/platform-sensitive changes, merge queue, and pushes to `main`.
- Windows portability fixes cover path separator assertions, `skills.paths` one-star glob expansion, portal launch target paths, CRLF-tolerant generated-file checks, and local package materialization cleanup.
- Added cheap regression coverage around path normalization, line-ending normalization, glob expansion, and symlink cleanup.

## Expected CI impact

This removes roughly 14 minutes of flake reruns and roughly 3-4 minutes of thread-count parity work from normal PR and merge-queue capacity. The required gate stays `CI status`; the heavy sweeps still run from scheduled/manual workflows.

## Windows failure analysis

The failures were from a few concrete portability bugs: tests comparing native display paths against slash paths, generated-file checks comparing raw CRLF text, globbing that split `Path::to_string_lossy()` on `/`, and materialized path dependency cleanup that was fragile around directory symlinks/reparse-point style links.

## Verification

- `cargo test -p harn-cli package::skills::tests::expand_single_star_glob_handles_packages_pattern`
- `cargo test -p harn-cli commands::test::tests::collect_harn_files_sorted_descends_and_sorts`
- `cargo test -p harn-cli commands::portal::tests::scan_launch_targets_finds_harn_files`
- `cargo test -p harn-cli package::lockfile::tests::add_positional_local_path_dependency_uses_manifest_name_and_live_link`
- `cargo test -p harn-cli line_endings`
- `cargo test -p harn-cli logical_path_uses_slashes`
- `cargo test -p harn-cli remove_materialized_package_unlinks`
- `cargo test -p harn-cli expand_single_star_glob`
- `cargo test -p harn-vm normalize_collapses_dot_dot`
- `make lint-actions`
- `make check-language-spec`
- `make check-provider-matrix`
- `make check-connector-matrix`
- `make check-highlight`
- `make check-trigger-quickref`
- `HARN_LLM_CALLS_DISABLED=1 make test` (3349 passed)
