### PR TITLE
[codex] Support list ternary branches

### DIFF
--- a/conformance/tests/language/ternary_list_branches.expected
+++ b/conformance/tests/language/ternary_list_branches.expected
@@ -1,0 +1,8 @@
+2
+--repo
+burin-labs/harn
+thread
+0
+2
+2
+10

--- a/conformance/tests/language/ternary_list_branches.harn
+++ b/conformance/tests/language/ternary_list_branches.harn
@@ -1,0 +1,17 @@
+pipeline default() {
+  let repo = "burin-labs/harn"
+  let repo_args = repo ? ["--repo", repo] : []
+  println(len(repo_args))
+  println(repo_args[0])
+  println(repo_args[1])
+  let selected = repo ? ["steel", "thread"][1] : "none"
+  println(selected)
+  let missing = nil
+  let missing_args = missing ? ["--repo", missing] : []
+  println(len(missing_args))
+  let nested = true ? [1, true ? [2] : []] : []
+  println(len(nested))
+  println(nested[1][0])
+  let xs = [10, 20]
+  println(xs?[0])
+}

--- a/crates/harn-fmt/src/tests.rs
+++ b/crates/harn-fmt/src/tests.rs
@@ -148,6 +148,18 @@ fn test_format_binary_ops() {
 }
 
 #[test]
+fn test_format_ternary_list_branch() {
+    let source = r#"pipeline default() {
+  let args = repo ? ["--repo", repo] : []
+  let first = xs?[0]
+}"#;
+    let result = format_source(source).unwrap();
+    assert!(result.contains(r#"repo ? ["--repo", repo] : []"#));
+    assert!(result.contains("xs?[0]"));
+    assert_roundtrip(source);
+}
+
+#[test]
 fn test_format_pipe_placeholder_patterns() {
     let source = r#"pipeline default(task) {
   let words = "hello world" |> split(_, " ")

--- a/crates/harn-lint/src/linter.rs
+++ b/crates/harn-lint/src/linter.rs
@@ -19,6 +19,7 @@ use crate::rules::blank_lines::check_blank_line_between_items;
 use crate::rules::import_order::check_import_order;
 use crate::rules::optional_shorthand::check_prefer_optional_shorthand;
 use crate::rules::trailing_comma::check_trailing_comma;
+use crate::rules::unnecessary_parentheses::check_unnecessary_parentheses;
 
 mod walk;
 
@@ -1131,6 +1132,7 @@ impl<'a> Linter<'a> {
             check_trailing_comma(src, &mut self.diagnostics);
             check_import_order(src, nodes, &mut self.diagnostics);
             check_prefer_optional_shorthand(src, nodes, &mut self.diagnostics);
+            check_unnecessary_parentheses(src, nodes, &mut self.diagnostics);
         }
         for node in nodes {
             self.lint_node(node);

--- a/crates/harn-lint/src/rules/ast_walk.rs
+++ b/crates/harn-lint/src/rules/ast_walk.rs
@@ -1,0 +1,336 @@
+//! Shared AST traversal helpers for source-aware lint rules.
+
+use std::collections::HashSet;
+
+use harn_parser::{AttributeArg, BindingPattern, DictEntry, MatchArm, Node, SNode, SelectCase};
+
+pub(crate) fn collect_expression_spans(
+    program: &[SNode],
+    mut include: impl FnMut(&Node) -> bool,
+) -> HashSet<(usize, usize)> {
+    let mut spans = HashSet::new();
+    for node in program {
+        visit_node(node, &mut spans, &mut include);
+    }
+    spans
+}
+
+fn visit_node(
+    node: &SNode,
+    spans: &mut HashSet<(usize, usize)>,
+    include: &mut impl FnMut(&Node) -> bool,
+) {
+    if include(&node.node) {
+        spans.insert((node.span.start, node.span.end));
+    }
+
+    match &node.node {
+        Node::AttributedDecl { attributes, inner } => {
+            for attr in attributes {
+                for arg in &attr.args {
+                    visit_attribute_arg(arg, spans, include);
+                }
+            }
+            visit_node(inner, spans, include);
+        }
+        Node::Pipeline { body, .. } | Node::OverrideDecl { body, .. } => {
+            visit_nodes(body, spans, include);
+        }
+        Node::LetBinding { pattern, value, .. } | Node::VarBinding { pattern, value, .. } => {
+            visit_binding_pattern(pattern, spans, include);
+            visit_node(value, spans, include);
+        }
+        Node::EnumDecl { .. }
+        | Node::StructDecl { .. }
+        | Node::InterfaceDecl { .. }
+        | Node::ImportDecl { .. }
+        | Node::SelectiveImport { .. }
+        | Node::TypeDecl { .. }
+        | Node::BreakStmt
+        | Node::ContinueStmt => {}
+        Node::ImplBlock { methods, .. } => visit_nodes(methods, spans, include),
+        Node::IfElse {
+            condition,
+            then_body,
+            else_body,
+        } => {
+            visit_node(condition, spans, include);
+            visit_nodes(then_body, spans, include);
+            if let Some(body) = else_body {
+                visit_nodes(body, spans, include);
+            }
+        }
+        Node::ForIn {
+            pattern,
+            iterable,
+            body,
+        } => {
+            visit_binding_pattern(pattern, spans, include);
+            visit_node(iterable, spans, include);
+            visit_nodes(body, spans, include);
+        }
+        Node::MatchExpr { value, arms } => {
+            visit_node(value, spans, include);
+            for arm in arms {
+                visit_match_arm(arm, spans, include);
+            }
+        }
+        Node::WhileLoop { condition, body } => {
+            visit_node(condition, spans, include);
+            visit_nodes(body, spans, include);
+        }
+        Node::Retry { count, body } => {
+            visit_node(count, spans, include);
+            visit_nodes(body, spans, include);
+        }
+        Node::CostRoute { options, body } => {
+            visit_option_values(options, spans, include);
+            visit_nodes(body, spans, include);
+        }
+        Node::ReturnStmt { value } | Node::YieldExpr { value } => {
+            if let Some(value) = value {
+                visit_node(value, spans, include);
+            }
+        }
+        Node::TryCatch {
+            body,
+            catch_body,
+            finally_body,
+            ..
+        } => {
+            visit_nodes(body, spans, include);
+            visit_nodes(catch_body, spans, include);
+            if let Some(body) = finally_body {
+                visit_nodes(body, spans, include);
+            }
+        }
+        Node::TryExpr { body }
+        | Node::SpawnExpr { body }
+        | Node::DeferStmt { body }
+        | Node::MutexBlock { body }
+        | Node::Block(body)
+        | Node::Closure { body, .. } => visit_nodes(body, spans, include),
+        Node::FnDecl { body, .. } | Node::ToolDecl { body, .. } => {
+            visit_nodes(body, spans, include);
+        }
+        Node::SkillDecl { fields, .. } => visit_field_values(fields, spans, include),
+        Node::EvalPackDecl {
+            fields,
+            body,
+            summarize,
+            ..
+        } => {
+            visit_field_values(fields, spans, include);
+            visit_nodes(body, spans, include);
+            if let Some(body) = summarize {
+                visit_nodes(body, spans, include);
+            }
+        }
+        Node::RangeExpr { start, end, .. } => {
+            visit_node(start, spans, include);
+            visit_node(end, spans, include);
+        }
+        Node::GuardStmt {
+            condition,
+            else_body,
+        } => {
+            visit_node(condition, spans, include);
+            visit_nodes(else_body, spans, include);
+        }
+        Node::RequireStmt { condition, message } => {
+            visit_node(condition, spans, include);
+            if let Some(message) = message {
+                visit_node(message, spans, include);
+            }
+        }
+        Node::DeadlineBlock { duration, body } => {
+            visit_node(duration, spans, include);
+            visit_nodes(body, spans, include);
+        }
+        Node::EmitExpr { value }
+        | Node::ThrowStmt { value }
+        | Node::Spread(value)
+        | Node::TryOperator { operand: value }
+        | Node::TryStar { operand: value }
+        | Node::UnaryOp { operand: value, .. } => visit_node(value, spans, include),
+        Node::HitlExpr { args, .. } => {
+            for arg in args {
+                visit_node(&arg.value, spans, include);
+            }
+        }
+        Node::Parallel {
+            expr,
+            body,
+            options,
+            ..
+        } => {
+            visit_node(expr, spans, include);
+            visit_option_values(options, spans, include);
+            visit_nodes(body, spans, include);
+        }
+        Node::SelectExpr {
+            cases,
+            timeout,
+            default_body,
+        } => {
+            for case in cases {
+                visit_select_case(case, spans, include);
+            }
+            if let Some((duration, body)) = timeout {
+                visit_node(duration, spans, include);
+                visit_nodes(body, spans, include);
+            }
+            if let Some(body) = default_body {
+                visit_nodes(body, spans, include);
+            }
+        }
+        Node::FunctionCall { args, .. } | Node::EnumConstruct { args, .. } => {
+            visit_nodes(args, spans, include);
+        }
+        Node::MethodCall { object, args, .. } | Node::OptionalMethodCall { object, args, .. } => {
+            visit_node(object, spans, include);
+            visit_nodes(args, spans, include);
+        }
+        Node::PropertyAccess { object, .. } | Node::OptionalPropertyAccess { object, .. } => {
+            visit_node(object, spans, include);
+        }
+        Node::SubscriptAccess { object, index }
+        | Node::OptionalSubscriptAccess { object, index } => {
+            visit_node(object, spans, include);
+            visit_node(index, spans, include);
+        }
+        Node::SliceAccess { object, start, end } => {
+            visit_node(object, spans, include);
+            if let Some(start) = start {
+                visit_node(start, spans, include);
+            }
+            if let Some(end) = end {
+                visit_node(end, spans, include);
+            }
+        }
+        Node::BinaryOp { left, right, .. } => {
+            visit_node(left, spans, include);
+            visit_node(right, spans, include);
+        }
+        Node::Ternary {
+            condition,
+            true_expr,
+            false_expr,
+        } => {
+            visit_node(condition, spans, include);
+            visit_node(true_expr, spans, include);
+            visit_node(false_expr, spans, include);
+        }
+        Node::Assignment { target, value, .. } => {
+            visit_node(target, spans, include);
+            visit_node(value, spans, include);
+        }
+        Node::StructConstruct { fields, .. } | Node::DictLiteral(fields) => {
+            visit_dict_entries(fields, spans, include);
+        }
+        Node::ListLiteral(items) | Node::OrPattern(items) => visit_nodes(items, spans, include),
+        Node::InterpolatedString(_)
+        | Node::StringLiteral(_)
+        | Node::RawStringLiteral(_)
+        | Node::IntLiteral(_)
+        | Node::FloatLiteral(_)
+        | Node::BoolLiteral(_)
+        | Node::NilLiteral
+        | Node::Identifier(_)
+        | Node::DurationLiteral(_) => {}
+    }
+}
+
+fn visit_nodes(
+    nodes: &[SNode],
+    spans: &mut HashSet<(usize, usize)>,
+    include: &mut impl FnMut(&Node) -> bool,
+) {
+    for node in nodes {
+        visit_node(node, spans, include);
+    }
+}
+
+fn visit_attribute_arg(
+    arg: &AttributeArg,
+    spans: &mut HashSet<(usize, usize)>,
+    include: &mut impl FnMut(&Node) -> bool,
+) {
+    visit_node(&arg.value, spans, include);
+}
+
+fn visit_dict_entries(
+    entries: &[DictEntry],
+    spans: &mut HashSet<(usize, usize)>,
+    include: &mut impl FnMut(&Node) -> bool,
+) {
+    for entry in entries {
+        visit_node(&entry.key, spans, include);
+        visit_node(&entry.value, spans, include);
+    }
+}
+
+fn visit_field_values(
+    fields: &[(String, SNode)],
+    spans: &mut HashSet<(usize, usize)>,
+    include: &mut impl FnMut(&Node) -> bool,
+) {
+    for (_, value) in fields {
+        visit_node(value, spans, include);
+    }
+}
+
+fn visit_option_values(
+    options: &[(String, SNode)],
+    spans: &mut HashSet<(usize, usize)>,
+    include: &mut impl FnMut(&Node) -> bool,
+) {
+    for (_, value) in options {
+        visit_node(value, spans, include);
+    }
+}
+
+fn visit_match_arm(
+    arm: &MatchArm,
+    spans: &mut HashSet<(usize, usize)>,
+    include: &mut impl FnMut(&Node) -> bool,
+) {
+    visit_node(&arm.pattern, spans, include);
+    if let Some(guard) = &arm.guard {
+        visit_node(guard, spans, include);
+    }
+    visit_nodes(&arm.body, spans, include);
+}
+
+fn visit_select_case(
+    case: &SelectCase,
+    spans: &mut HashSet<(usize, usize)>,
+    include: &mut impl FnMut(&Node) -> bool,
+) {
+    visit_node(&case.channel, spans, include);
+    visit_nodes(&case.body, spans, include);
+}
+
+fn visit_binding_pattern(
+    pattern: &BindingPattern,
+    spans: &mut HashSet<(usize, usize)>,
+    include: &mut impl FnMut(&Node) -> bool,
+) {
+    match pattern {
+        BindingPattern::Identifier(_) | BindingPattern::Pair(_, _) => {}
+        BindingPattern::Dict(fields) => {
+            for field in fields {
+                if let Some(default) = &field.default_value {
+                    visit_node(default, spans, include);
+                }
+            }
+        }
+        BindingPattern::List(items) => {
+            for item in items {
+                if let Some(default) = &item.default_value {
+                    visit_node(default, spans, include);
+                }
+            }
+        }
+    }
+}

--- a/crates/harn-lint/src/rules/mod.rs
+++ b/crates/harn-lint/src/rules/mod.rs
@@ -4,8 +4,10 @@
 //! [`Linter::lint_program`][crate::linter::Linter::lint_program] stays
 //! legible.
 
+pub(crate) mod ast_walk;
 pub(crate) mod blank_lines;
 pub(crate) mod file_header;
 pub(crate) mod import_order;
 pub(crate) mod optional_shorthand;
 pub(crate) mod trailing_comma;
+pub(crate) mod unnecessary_parentheses;

--- a/crates/harn-lint/src/rules/unnecessary_parentheses.rs
+++ b/crates/harn-lint/src/rules/unnecessary_parentheses.rs
@@ -1,0 +1,174 @@
+//! `unnecessary-parentheses` rule: parentheses around a single value
+//! expression add noise and can hide places where the grammar now accepts
+//! the direct form.
+
+use std::collections::HashSet;
+
+use harn_lexer::{FixEdit, Span, Token, TokenKind};
+use harn_parser::{Node, SNode};
+
+use crate::diagnostic::{LintDiagnostic, LintSeverity};
+use crate::rules::ast_walk::collect_expression_spans;
+
+pub(crate) fn check_unnecessary_parentheses(
+    source: &str,
+    program: &[SNode],
+    diagnostics: &mut Vec<LintDiagnostic>,
+) {
+    let mut lexer = harn_lexer::Lexer::new(source);
+    let Ok(tokens) = lexer.tokenize_with_comments() else {
+        return;
+    };
+
+    let value_spans = collect_single_value_spans(program);
+    if value_spans.is_empty() {
+        return;
+    }
+
+    let mut paren_stack = Vec::new();
+    for (idx, token) in tokens.iter().enumerate() {
+        match token.kind {
+            TokenKind::LParen => paren_stack.push(idx),
+            TokenKind::RParen => {
+                let Some(open_idx) = paren_stack.pop() else {
+                    continue;
+                };
+                if let Some((open_span, close_span)) =
+                    pair_wraps_single_value(source, &tokens, open_idx, idx, &value_spans)
+                {
+                    let open = &tokens[open_idx];
+                    diagnostics.push(LintDiagnostic {
+                        rule: "unnecessary-parentheses",
+                        message: "unnecessary parentheses around a single value".to_string(),
+                        span: Span::merge(open.span, token.span),
+                        severity: LintSeverity::Warning,
+                        suggestion: Some("remove the parentheses".to_string()),
+                        fix: Some(vec![
+                            FixEdit {
+                                span: open_span,
+                                replacement: String::new(),
+                            },
+                            FixEdit {
+                                span: close_span,
+                                replacement: String::new(),
+                            },
+                        ]),
+                    });
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn pair_wraps_single_value(
+    source: &str,
+    tokens: &[Token],
+    open_idx: usize,
+    close_idx: usize,
+    value_spans: &HashSet<(usize, usize)>,
+) -> Option<(Span, Span)> {
+    if opening_is_required_by_context(tokens, open_idx) {
+        return None;
+    }
+
+    let open = &tokens[open_idx];
+    let close = &tokens[close_idx];
+    let inner_start = trim_ascii_whitespace_forward(source, open.span.end, close.span.start)?;
+    let inner_end = trim_ascii_whitespace_backward(source, inner_start, close.span.start);
+
+    value_spans.contains(&(inner_start, inner_end)).then(|| {
+        (
+            span_from_offsets(source, open.span.start, inner_start),
+            span_from_offsets(source, inner_end, close.span.end),
+        )
+    })
+}
+
+fn opening_is_required_by_context(tokens: &[Token], open_idx: usize) -> bool {
+    previous_meaningful_kind(tokens, open_idx).is_some_and(|kind| {
+        matches!(
+            kind,
+            TokenKind::Identifier(_)
+                | TokenKind::RParen
+                | TokenKind::RBracket
+                | TokenKind::RBrace
+                | TokenKind::Gt
+                | TokenKind::Fn
+                | TokenKind::RequestApproval
+                | TokenKind::DualControl
+                | TokenKind::AskUser
+                | TokenKind::EscalateTo
+        )
+    })
+}
+
+fn previous_meaningful_kind(tokens: &[Token], before_idx: usize) -> Option<&TokenKind> {
+    tokens[..before_idx]
+        .iter()
+        .rev()
+        .find(|token| !is_trivia(&token.kind))
+        .map(|token| &token.kind)
+}
+
+fn is_trivia(kind: &TokenKind) -> bool {
+    matches!(
+        kind,
+        TokenKind::Newline | TokenKind::LineComment { .. } | TokenKind::BlockComment { .. }
+    )
+}
+
+fn trim_ascii_whitespace_forward(source: &str, start: usize, end: usize) -> Option<usize> {
+    let mut pos = start;
+    while pos < end && source.as_bytes()[pos].is_ascii_whitespace() {
+        pos += 1;
+    }
+    (pos < end).then_some(pos)
+}
+
+fn trim_ascii_whitespace_backward(source: &str, start: usize, end: usize) -> usize {
+    let mut pos = end;
+    while pos > start && source.as_bytes()[pos - 1].is_ascii_whitespace() {
+        pos -= 1;
+    }
+    pos
+}
+
+fn span_from_offsets(source: &str, start: usize, end: usize) -> Span {
+    let line = source[..start].bytes().filter(|b| *b == b'\n').count() + 1;
+    let line_start = source[..start].rfind('\n').map(|idx| idx + 1).unwrap_or(0);
+    Span::with_offsets(start, end, line, start - line_start + 1)
+}
+
+fn collect_single_value_spans(program: &[SNode]) -> HashSet<(usize, usize)> {
+    collect_expression_spans(program, is_single_value_expr)
+}
+
+fn is_single_value_expr(node: &Node) -> bool {
+    matches!(
+        node,
+        Node::FunctionCall { .. }
+            | Node::MethodCall { .. }
+            | Node::OptionalMethodCall { .. }
+            | Node::PropertyAccess { .. }
+            | Node::OptionalPropertyAccess { .. }
+            | Node::SubscriptAccess { .. }
+            | Node::OptionalSubscriptAccess { .. }
+            | Node::SliceAccess { .. }
+            | Node::EnumConstruct { .. }
+            | Node::StructConstruct { .. }
+            | Node::HitlExpr { .. }
+            | Node::ListLiteral(_)
+            | Node::DictLiteral(_)
+            | Node::TryOperator { .. }
+            | Node::InterpolatedString(_)
+            | Node::StringLiteral(_)
+            | Node::RawStringLiteral(_)
+            | Node::IntLiteral(_)
+            | Node::FloatLiteral(_)
+            | Node::BoolLiteral(_)
+            | Node::NilLiteral
+            | Node::Identifier(_)
+            | Node::DurationLiteral(_)
+    )
+}

--- a/crates/harn-lint/src/tests/mod.rs
+++ b/crates/harn-lint/src/tests/mod.rs
@@ -96,6 +96,7 @@ mod redundant_nil_ternary;
 mod secret_scan_rules;
 mod shadowing;
 mod unnecessary_cast;
+mod unnecessary_parentheses;
 mod unreachable;
 mod unused;
 mod unused_function;

--- a/crates/harn-lint/src/tests/unnecessary_parentheses.rs
+++ b/crates/harn-lint/src/tests/unnecessary_parentheses.rs
@@ -1,0 +1,81 @@
+//! `unnecessary-parentheses` — removes grouping around one value when
+//! the parens are not part of a call, declaration, or precedence boundary.
+
+use super::*;
+
+#[test]
+fn test_unnecessary_parentheses_autofixes_ternary_list_branch() {
+    let source = r#"pipeline default() {
+  let args = repo ? (["--repo", repo]) : []
+}
+"#;
+    let diags = lint_source(source);
+    assert_eq!(
+        count_rule(&diags, "unnecessary-parentheses"),
+        1,
+        "expected unnecessary-parentheses, got: {diags:?}"
+    );
+    let fixed = apply_fixes(source, &diags);
+    assert!(
+        fixed.contains(r#"repo ? ["--repo", repo] : []"#),
+        "expected autofix to unwrap list branch, got: {fixed}"
+    );
+}
+
+#[test]
+fn test_unnecessary_parentheses_autofixes_simple_return_value() {
+    let source = r#"fn repo_arg(repo) {
+  return ( repo )
+}
+"#;
+    let diags = lint_source(source);
+    assert_eq!(count_rule(&diags, "unnecessary-parentheses"), 1);
+    let fixed = apply_fixes(source, &diags);
+    assert_eq!(fixed, "fn repo_arg(repo) {\n  return repo\n}\n");
+}
+
+#[test]
+fn test_unnecessary_parentheses_ignores_call_and_decl_parens() {
+    let source = r#"fn repo_arg(repo) {
+  log(repo)
+}
+"#;
+    let diags = lint_source(source);
+    assert!(
+        !has_rule(&diags, "unnecessary-parentheses"),
+        "function declaration and call parens must not fire, got: {diags:?}"
+    );
+}
+
+#[test]
+fn test_unnecessary_parentheses_ignores_precedence_grouping() {
+    let source = r#"pipeline default() {
+  let x = a * (b + c)
+  let y = (a || b) && c
+}
+"#;
+    let diags = lint_source(source);
+    assert!(
+        !has_rule(&diags, "unnecessary-parentheses"),
+        "precedence-preserving parens must not fire, got: {diags:?}"
+    );
+}
+
+#[test]
+fn test_unnecessary_parentheses_only_unwraps_inner_nested_pair() {
+    let source = r#"pipeline default() {
+  let repo = ((name))
+}
+"#;
+    let diags = lint_source(source);
+    assert_eq!(
+        count_rule(&diags, "unnecessary-parentheses"),
+        1,
+        "only the inner parens should be fixed in one pass, got: {diags:?}"
+    );
+    let fixed = apply_fixes(source, &diags);
+    assert!(
+        fixed.contains("(name)"),
+        "expected one parenthesis layer to remain for the next lint pass, got: {fixed}"
+    );
+}

--- a/crates/harn-parser/src/parser/expressions.rs
+++ b/crates/harn-parser/src/parser/expressions.rs
@@ -66,9 +66,9 @@ impl Parser {
         }
         let start = condition.span;
         self.advance(); // skip ?
-        let true_val = self.parse_logical_or()?;
+        let true_val = self.parse_ternary()?;
         self.consume(&TokenKind::Colon, ":")?;
-        let false_val = self.parse_logical_or()?;
+        let false_val = self.parse_ternary()?;
         Ok(spanned(
             Node::Ternary {
                 condition: Box::new(condition),
@@ -503,14 +503,10 @@ impl Parser {
             } else if self.check(&TokenKind::Question) {
                 // Disambiguate `?[index]` (optional subscript), `expr?`
                 // (postfix try), and `expr ? a : b` (ternary).
-                //
-                // Optional subscript wins eagerly when the next token is `[`
-                // because `cond ? [a, b, c] : ...` is rare and writing it as
-                // `cond ? ([a, b, c]) : ...` is a fine workaround, while
-                // `obj?[k]` is the natural way to chain into a list/dict.
-                let next_pos = self.pos + 1;
-                let next_kind = self.tokens.get(next_pos).map(|t| &t.kind);
-                if matches!(next_kind, Some(TokenKind::LBracket)) {
+                if self.question_starts_ternary_branch() {
+                    break;
+                }
+                if matches!(self.peek_kind_at(1), Some(TokenKind::LBracket)) {
                     let start = expr.span;
                     self.advance(); // consume ?
                     self.advance(); // consume [
@@ -524,30 +520,6 @@ impl Parser {
                         Span::merge(start, self.prev_span()),
                     );
                     continue;
-                }
-                // Postfix try `expr?` vs ternary `expr ? a : b`: if the next
-                // token could start a ternary branch, let parse_ternary
-                // handle the `?`.
-                let is_ternary = next_kind.is_some_and(|kind| {
-                    matches!(
-                        kind,
-                        TokenKind::Identifier(_)
-                            | TokenKind::IntLiteral(_)
-                            | TokenKind::FloatLiteral(_)
-                            | TokenKind::StringLiteral(_)
-                            | TokenKind::InterpolatedString(_)
-                            | TokenKind::True
-                            | TokenKind::False
-                            | TokenKind::Nil
-                            | TokenKind::LParen
-                            | TokenKind::LBrace
-                            | TokenKind::Not
-                            | TokenKind::Minus
-                            | TokenKind::Fn
-                    )
-                });
-                if is_ternary {
-                    break;
                 }
                 let start = expr.span;
                 self.advance();
@@ -563,6 +535,114 @@ impl Parser {
         }
 
         Ok(expr)
+    }
+
+    fn question_starts_ternary_branch(&self) -> bool {
+        self.peek_kind_at(1)
+            .is_some_and(Self::token_starts_ternary_branch)
+            && self.question_has_top_level_ternary_colon()
+    }
+
+    fn token_starts_ternary_branch(kind: &TokenKind) -> bool {
+        matches!(
+            kind,
+            TokenKind::Identifier(_)
+                | TokenKind::IntLiteral(_)
+                | TokenKind::FloatLiteral(_)
+                | TokenKind::StringLiteral(_)
+                | TokenKind::RawStringLiteral(_)
+                | TokenKind::InterpolatedString(_)
+                | TokenKind::True
+                | TokenKind::False
+                | TokenKind::Nil
+                | TokenKind::LParen
+                | TokenKind::LBracket
+                | TokenKind::LBrace
+                | TokenKind::Not
+                | TokenKind::Minus
+                | TokenKind::Fn
+                | TokenKind::If
+                | TokenKind::Match
+                | TokenKind::Try
+                | TokenKind::Spawn
+                | TokenKind::Parallel
+                | TokenKind::Retry
+                | TokenKind::Deadline
+                | TokenKind::RequestApproval
+                | TokenKind::DualControl
+                | TokenKind::AskUser
+                | TokenKind::EscalateTo
+                | TokenKind::DurationLiteral(_)
+        )
+    }
+
+    fn question_has_top_level_ternary_colon(&self) -> bool {
+        let mut delimiter_depth = 0usize;
+        for (pos, token) in self.tokens.iter().enumerate().skip(self.pos + 1) {
+            if delimiter_depth == 0 {
+                match token.kind {
+                    TokenKind::Colon => return true,
+                    TokenKind::Newline => {
+                        if self.next_non_newline_continues_ternary_branch(pos + 1) {
+                            continue;
+                        }
+                        return false;
+                    }
+                    TokenKind::RParen
+                    | TokenKind::RBracket
+                    | TokenKind::RBrace
+                    | TokenKind::Eof => {
+                        return false;
+                    }
+                    _ => {}
+                }
+            }
+
+            match token.kind {
+                TokenKind::LParen | TokenKind::LBracket | TokenKind::LBrace => {
+                    delimiter_depth += 1;
+                }
+                TokenKind::RParen | TokenKind::RBracket | TokenKind::RBrace => {
+                    delimiter_depth = delimiter_depth.saturating_sub(1);
+                }
+                TokenKind::Eof => return false,
+                _ => {}
+            }
+        }
+        false
+    }
+
+    fn next_non_newline_continues_ternary_branch(&self, start_pos: usize) -> bool {
+        let Some(kind) = self
+            .tokens
+            .iter()
+            .skip(start_pos)
+            .find(|token| token.kind != TokenKind::Newline)
+            .map(|token| &token.kind)
+        else {
+            return false;
+        };
+        matches!(
+            kind,
+            TokenKind::Colon
+                | TokenKind::Plus
+                | TokenKind::Star
+                | TokenKind::Slash
+                | TokenKind::Percent
+                | TokenKind::Pow
+                | TokenKind::And
+                | TokenKind::Or
+                | TokenKind::Eq
+                | TokenKind::Neq
+                | TokenKind::Lt
+                | TokenKind::Gt
+                | TokenKind::Lte
+                | TokenKind::Gte
+                | TokenKind::NilCoal
+                | TokenKind::Pipe
+                | TokenKind::Dot
+                | TokenKind::QuestionDot
+        )
     }
 
     pub(super) fn parse_primary(&mut self) -> Result<SNode, ParserError> {

--- a/crates/harn-parser/src/parser/mod.rs
+++ b/crates/harn-parser/src/parser/mod.rs
@@ -104,6 +104,54 @@ pipeline p() {
     }
 
     #[test]
+    fn parses_list_literals_as_ternary_branches_without_breaking_optional_subscript() {
+        let source = r#"
+let repo_args = repo ? ["--repo", repo] : []
+let selected = repo ? ["--repo", repo][0] : "none"
+let nested = true ? [1, true ? [2] : []] : []
+let first = xs?[0]
+"#;
+
+        let program = parse_source(source).expect("should parse");
+        let Node::LetBinding { value, .. } = &program[0].node else {
+            panic!("expected let binding");
+        };
+        let Node::Ternary {
+            true_expr,
+            false_expr,
+            ..
+        } = &value.node
+        else {
+            panic!("expected ternary");
+        };
+        assert!(matches!(&true_expr.node, Node::ListLiteral(items) if items.len() == 2));
+        assert!(matches!(&false_expr.node, Node::ListLiteral(items) if items.is_empty()));
+
+        let Node::LetBinding { value, .. } = &program[1].node else {
+            panic!("expected let binding");
+        };
+        assert!(matches!(&value.node, Node::Ternary { true_expr, .. }
+            if matches!(&true_expr.node, Node::SubscriptAccess { object, .. }
+                if matches!(&object.node, Node::ListLiteral(_)))));
+
+        let Node::LetBinding { value, .. } = &program[2].node else {
+            panic!("expected let binding");
+        };
+        assert!(matches!(&value.node, Node::Ternary { true_expr, .. }
+            if matches!(&true_expr.node, Node::ListLiteral(_))));
+
+        let Node::LetBinding { value, .. } = &program[3].node else {
+            panic!("expected let binding");
+        };
+        assert!(matches!(
+            &value.node,
+            Node::OptionalSubscriptAccess { object, index }
+                if matches!(&object.node, Node::Identifier(name) if name == "xs")
+                    && matches!(&index.node, Node::IntLiteral(0))
+        ));
+    }
+
+    #[test]
     fn parses_public_declarations_and_generic_interfaces() {
         let source = r#"
 pub pipeline build(task) extends base {

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -281,7 +281,7 @@ Pass `--fix` to automatically apply safe fixes (e.g., `var` → `let` for
 never-reassigned bindings, boolean comparison simplification, unused import
 removal, string interpolation conversion, `let`-then-`return` simplification,
 and removing redundant `clone()`/`to_string(...)`/`to_int(...)`/`to_list(...)`
-wrappers):
+wrappers or unnecessary parentheses around single values):
 
 ```bash
 harn lint --fix main.harn

--- a/docs/src/editor-integration.md
+++ b/docs/src/editor-integration.md
@@ -55,7 +55,7 @@ over stdin/stdout using the Language Server Protocol.
 | **Document symbols** | Outline view of pipelines, functions, structs, enums |
 | **Workspace symbols** | Cross-file search for pipelines and functions |
 | **Semantic tokens** | Fine-grained syntax highlighting for keywords, types, functions, parameters, enums, and more |
-| **Code actions** | Per-diagnostic quick fixes for lint warnings (`var`→`let`, boolean simplification, unused-import removal, string-interpolation conversion, unnecessary-cast removal) and type errors. A bulk `source.fixAll.harn` action applies every available autofix in the document at once — wire it into `editor.codeActionsOnSave` to autofix on save. |
+| **Code actions** | Per-diagnostic quick fixes for lint warnings (`var`→`let`, boolean simplification, unused-import removal, string-interpolation conversion, unnecessary-cast removal, unnecessary-parentheses removal) and type errors. A bulk `source.fixAll.harn` action applies every available autofix in the document at once — wire it into `editor.codeActionsOnSave` to autofix on save. |
 | **Rename** | Rename symbols across the document |
 | **Document formatting** | Delegates to `harn-fmt` for format-on-save support |
 | **On-type formatting** | Reuses `harn-fmt` after semicolons and closing braces for format-as-you-type |
@@ -146,7 +146,8 @@ interpolated `llm_call` system prompts, and unnecessary conversion calls
 (`to_string("hi")`, `to_int(42)`, etc.). With `--fix`, the linter
 automatically rewrites fixable issues (e.g., `var` → `let`, boolean
 comparison simplification, `let`-then-`return` simplification, redundant
-clone removal, unused import removal, unnecessary-cast removal). The same fixes
+clone removal, unused import removal, unnecessary-cast removal, unnecessary
+parentheses removal). The same fixes
 are surfaced through the LSP as both
 per-diagnostic quick-fixes and a bulk `source.fixAll.harn` code action
 suitable for `editor.codeActionsOnSave`.

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -529,7 +529,7 @@ followed by `=`.
 expression         ::= pipe_expr
 pipe_expr          ::= range_expr ('|>' range_expr)*
 range_expr         ::= ternary_expr ['to' ternary_expr ['exclusive']]
-ternary_expr       ::= logical_or ['?' logical_or ':' logical_or]
+ternary_expr       ::= logical_or ['?' ternary_expr ':' ternary_expr]
 logical_or         ::= logical_and ('||' logical_and)*
 logical_and        ::= equality ('&&' equality)*
 equality           ::= comparison (('==' | '!=') comparison)*
@@ -2377,6 +2377,9 @@ to a non-Result value produces a type error at runtime.
 Disambiguation: when the parser sees `expr?`, it distinguishes between the
 postfix `?` (Result propagation) and the ternary `? :` operator by checking
 whether the token following `?` could start a ternary branch expression.
+For `expr?[...]`, optional subscript is used unless the `?` is followed by a
+valid branch expression and a top-level ternary `:`. For example,
+`repo ? ["--repo", repo] : []` parses as a ternary without extra parentheses.
 
 ### Pattern matching on Result
 

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -527,7 +527,7 @@ followed by `=`.
 expression         ::= pipe_expr
 pipe_expr          ::= range_expr ('|>' range_expr)*
 range_expr         ::= ternary_expr ['to' ternary_expr ['exclusive']]
-ternary_expr       ::= logical_or ['?' logical_or ':' logical_or]
+ternary_expr       ::= logical_or ['?' ternary_expr ':' ternary_expr]
 logical_or         ::= logical_and ('||' logical_and)*
 logical_and        ::= equality ('&&' equality)*
 equality           ::= comparison (('==' | '!=') comparison)*
@@ -2375,6 +2375,9 @@ to a non-Result value produces a type error at runtime.
 Disambiguation: when the parser sees `expr?`, it distinguishes between the
 postfix `?` (Result propagation) and the ternary `? :` operator by checking
 whether the token following `?` could start a ternary branch expression.
+For `expr?[...]`, optional subscript is used unless the `?` is followed by a
+valid branch expression and a top-level ternary `:`. For example,
+`repo ? ["--repo", repo] : []` parses as a ternary without extra parentheses.
 
 ### Pattern matching on Result
 

--- a/tree-sitter-harn/test/corpus/expressions.txt
+++ b/tree-sitter-harn/test/corpus/expressions.txt
@@ -33,6 +33,40 @@ pipeline test(task) {
             (identifier)))))))
 
 ==================
+Ternary List Branches
+==================
+
+pipeline test() {
+  let args = repo ? ["--repo", repo] : []
+  let selected = repo ? ["--repo", repo][0] : "none"
+}
+
+---
+
+(source_file
+  (pipeline_declaration
+    name: (identifier)
+    (block
+      (let_binding
+        name: (identifier)
+        value: (ternary_expression
+          (identifier)
+          (list_literal
+            (string_literal)
+            (identifier))
+          (list_literal)))
+      (let_binding
+        name: (identifier)
+        value: (ternary_expression
+          (identifier)
+          (subscript_expression
+            object: (list_literal
+              (string_literal)
+              (identifier))
+            (integer_literal))
+          (string_literal))))))
+
+==================
 Comparison With Identifier LHS
 ==================
 


### PR DESCRIPTION
## Summary

- Allows ternary branches to start with list literals without parenthesizing them, including postfix access such as `repo ? ["--repo", repo][0] : "none"`.
- Makes ternary parsing right-associative per the spec and documents the optional-subscript disambiguation.
- Adds the autofixing `unnecessary-parentheses` lint rule for single-value expressions, with shared AST span traversal for source-aware lint rules.
- Adds parser, formatter, lint, conformance, docs, and tree-sitter coverage.

## Root Cause

`parse_postfix` previously gave `?[...]` optional-subscript precedence whenever `[` followed `?`, so `repo ? ["--repo", repo] : []` was parsed as `repo?[...]` and failed before ternary parsing could see the branch. The true and false arms were also parsed with `parse_logical_or`, which made nested ternaries in branches less consistent with the grammar.

## Validation

- Pre-commit hook: Rust formatting, staged Harn formatting/linting, workspace clippy, spec sync, markdown lint
- Pre-push hook: targeted package checks, affected Harn formatting/linting, markdown lint, language spec mirror
- `CARGO_TARGET_DIR=/tmp/harn-array-ternary-target cargo test -p harn-parser -p harn-lint -p harn-fmt -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-array-ternary-target cargo run --quiet --bin harn -- test conformance --filter ternary_list_branches`
- `make lint-harn CARGO_TARGET_DIR=/tmp/harn-array-ternary-target`
- `make fmt-harn CARGO_TARGET_DIR=/tmp/harn-array-ternary-target`
- `make check-docs-snippets CARGO_TARGET_DIR=/tmp/harn-array-ternary-target`
- `(cd tree-sitter-harn && npm test)`
- CLI smoke test: `harn lint --fix` rewrites `repo ? ( ["--repo", repo] ) : []` to `repo ? ["--repo", repo] : []`
