### PR TITLE
[codex] Add type-aware safe-navigation lint

### DIFF
--- a/crates/harn-cli/src/commands/check/check_cmd.rs
+++ b/crates/harn-cli/src/commands/check/check_cmd.rs
@@ -32,6 +32,9 @@ pub(crate) fn check_file_inner(
     }
     let type_diagnostics = checker.check_with_source(&program, &source);
     for diag in &type_diagnostics {
+        if harn_lint::type_diagnostic_lint_disabled(diag, &config.disable_rules) {
+            continue;
+        }
         match diag.severity {
             DiagnosticSeverity::Error => has_error = true,
             DiagnosticSeverity::Warning => has_warning = true,

--- a/crates/harn-cli/src/commands/check/lint.rs
+++ b/crates/harn-cli/src/commands/check/lint.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use std::process;
 
 use harn_lint::LintSeverity;
-use harn_parser::TypeChecker;
+use harn_parser::{TypeChecker, TypeDiagnostic};
 
 use crate::package::CheckConfig;
 use crate::parse_source_file;
@@ -28,7 +28,7 @@ pub(crate) fn lint_file_inner(
         complexity_threshold,
         persona_step_allowlist,
     };
-    let diagnostics = harn_lint::lint_with_module_graph(
+    let mut diagnostics = harn_lint::lint_with_module_graph(
         &program,
         &config.disable_rules,
         Some(&source),
@@ -37,6 +37,11 @@ pub(crate) fn lint_file_inner(
         path,
         &options,
     );
+    let type_diags = type_check_for_lint(path, config, module_graph, &program, &source);
+    diagnostics.extend(harn_lint::lint_diagnostics_from_type_diagnostics(
+        &type_diags,
+        &config.disable_rules,
+    ));
 
     if diagnostics.is_empty() {
         println!("{path_str}: no issues found");
@@ -84,19 +89,17 @@ pub(crate) fn lint_fix_file(
         &options,
     );
 
-    let mut checker = TypeChecker::with_strict_types(config.strict_types);
-    if let Some(imported) = module_graph.imported_names_for_file(path) {
-        checker = checker.with_imported_names(imported);
-    }
-    if let Some(imported) = module_graph.imported_type_declarations_for_file(path) {
-        checker = checker.with_imported_type_decls(imported);
-    }
-    let type_diags = checker.check_with_source(&program, &source);
+    let type_diags = type_check_for_lint(path, config, module_graph, &program, &source);
 
     let mut edits: Vec<&harn_lexer::FixEdit> = lint_diags
         .iter()
         .filter_map(|d| d.fix.as_ref())
-        .chain(type_diags.iter().filter_map(|d| d.fix.as_ref()))
+        .chain(
+            type_diags
+                .iter()
+                .filter(|d| !harn_lint::type_diagnostic_lint_disabled(d, &config.disable_rules))
+                .filter_map(|d| d.fix.as_ref()),
+        )
         .flatten()
         .collect();
 
@@ -134,7 +137,7 @@ pub(crate) fn lint_fix_file(
     println!("{path_str}: applied {applied} fix(es)");
 
     let (source2, program2) = parse_source_file(&path_str);
-    let remaining = harn_lint::lint_with_module_graph(
+    let mut remaining = harn_lint::lint_with_module_graph(
         &program2,
         &config.disable_rules,
         Some(&source2),
@@ -143,9 +146,31 @@ pub(crate) fn lint_fix_file(
         path,
         &options,
     );
+    let type_remaining = type_check_for_lint(path, config, module_graph, &program2, &source2);
+    remaining.extend(harn_lint::lint_diagnostics_from_type_diagnostics(
+        &type_remaining,
+        &config.disable_rules,
+    ));
     if !remaining.is_empty() {
-        print_lint_diagnostics(&path_str, &source, &remaining);
+        print_lint_diagnostics(&path_str, &source2, &remaining);
     }
 
     applied
+}
+
+fn type_check_for_lint(
+    path: &Path,
+    config: &CheckConfig,
+    module_graph: &harn_modules::ModuleGraph,
+    program: &[harn_parser::SNode],
+    source: &str,
+) -> Vec<TypeDiagnostic> {
+    let mut checker = TypeChecker::with_strict_types(config.strict_types);
+    if let Some(imported) = module_graph.imported_names_for_file(path) {
+        checker = checker.with_imported_names(imported);
+    }
+    if let Some(imported) = module_graph.imported_type_declarations_for_file(path) {
+        checker = checker.with_imported_type_decls(imported);
+    }
+    checker.check_with_source(program, source)
 }

--- a/crates/harn-cli/src/commands/check/tests.rs
+++ b/crates/harn-cli/src/commands/check/tests.rs
@@ -13,6 +13,7 @@ use super::check_cmd::check_file_inner;
 use super::config::collect_harn_targets;
 use super::config::{build_module_graph, collect_cross_file_imports};
 use super::host_capabilities::parse_host_capability_value;
+use super::lint::lint_file_inner;
 use super::preflight::{collect_preflight_diagnostics, is_preflight_allowed};
 
 fn parse_program(source: &str) -> Vec<SNode> {
@@ -1193,4 +1194,39 @@ pub fn exposed() -> string {
         "expected missing-harndoc warning, got: {:?}",
         diagnostics.iter().map(|d| &d.rule).collect::<Vec<_>>()
     );
+}
+
+#[test]
+fn lint_file_inner_reports_type_aware_lint_rules() {
+    let dir = unique_temp_dir("harn-lint-type-aware");
+    std::fs::create_dir_all(&dir).unwrap();
+    let file = dir.join("main.harn");
+    std::fs::write(
+        &file,
+        r#"
+type User = {name: string}
+pipeline main(task) {
+  let user: User = {name: "Ada"}
+  println(user?.name)
+}
+"#,
+    )
+    .unwrap();
+    let files = vec![file.clone()];
+    let module_graph = build_module_graph(&files);
+    let cross_file_imports = collect_cross_file_imports(&module_graph);
+    let outcome = lint_file_inner(
+        &file,
+        &CheckConfig::default(),
+        &cross_file_imports,
+        &module_graph,
+        false,
+        None,
+        &[],
+    );
+    assert!(
+        outcome.has_warning,
+        "type-aware lint should surface through `harn lint`"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
 }

--- a/crates/harn-lint/src/lib.rs
+++ b/crates/harn-lint/src/lib.rs
@@ -155,13 +155,61 @@ fn lint_full(
         linter
             .diagnostics
             .into_iter()
-            .filter(|d| {
-                !disabled_rules
-                    .iter()
-                    .any(|r| rule_matches_disabled(d.rule, r))
-            })
+            .filter(|d| !rule_disabled(d.rule, disabled_rules))
             .collect()
     }
+}
+
+/// Convert type-checker diagnostics tagged as lint rules into ordinary
+/// lint diagnostics so CLI/editor callers can share rule filtering,
+/// rendering, and autofix plumbing.
+pub fn lint_diagnostics_from_type_diagnostics(
+    diagnostics: &[harn_parser::TypeDiagnostic],
+    disabled_rules: &[String],
+) -> Vec<LintDiagnostic> {
+    diagnostics
+        .iter()
+        .filter_map(type_diagnostic_as_lint)
+        .filter(|diagnostic| !rule_disabled(diagnostic.rule, disabled_rules))
+        .collect()
+}
+
+/// Returns true when a type diagnostic is a lint diagnostic disabled by
+/// the caller's lint configuration.
+pub fn type_diagnostic_lint_disabled(
+    diagnostic: &harn_parser::TypeDiagnostic,
+    disabled_rules: &[String],
+) -> bool {
+    type_diagnostic_lint_rule(diagnostic).is_some_and(|rule| rule_disabled(rule, disabled_rules))
+}
+
+fn type_diagnostic_as_lint(diagnostic: &harn_parser::TypeDiagnostic) -> Option<LintDiagnostic> {
+    let rule = type_diagnostic_lint_rule(diagnostic)?;
+    let span = diagnostic.span?;
+    Some(LintDiagnostic {
+        rule,
+        message: diagnostic.message.clone(),
+        span,
+        severity: match diagnostic.severity {
+            harn_parser::DiagnosticSeverity::Warning => LintSeverity::Warning,
+            harn_parser::DiagnosticSeverity::Error => LintSeverity::Error,
+        },
+        suggestion: diagnostic.help.clone(),
+        fix: diagnostic.fix.clone(),
+    })
+}
+
+fn type_diagnostic_lint_rule(diagnostic: &harn_parser::TypeDiagnostic) -> Option<&'static str> {
+    match &diagnostic.details {
+        Some(harn_parser::DiagnosticDetails::LintRule { rule }) => Some(*rule),
+        _ => None,
+    }
+}
+
+fn rule_disabled(rule: &str, disabled_rules: &[String]) -> bool {
+    disabled_rules
+        .iter()
+        .any(|disabled| rule_matches_disabled(rule, disabled))
 }
 
 fn rule_matches_disabled(rule: &str, disabled: &str) -> bool {

--- a/crates/harn-lint/src/linter.rs
+++ b/crates/harn-lint/src/linter.rs
@@ -12,7 +12,9 @@ use harn_parser::{BindingPattern, Node, SNode, TypeExpr, TypedParam};
 use crate::complexity::cyclomatic_complexity;
 use crate::decls::{Declaration, FnDeclaration, ImportInfo, ParamDeclaration, TypeDeclaration};
 use crate::diagnostic::{LintDiagnostic, LintSeverity, DEFAULT_COMPLEXITY_THRESHOLD};
-use crate::fixes::{append_sink_fix, remove_method_call_wrapper_fix, simple_ident_rename_fix};
+use crate::fixes::{
+    append_sink_fix, is_pure_expression, remove_method_call_wrapper_fix, simple_ident_rename_fix,
+};
 use crate::harndoc::check_legacy_doc_comments;
 use crate::naming::{is_pascal_case, is_snake_case, to_pascal_case, to_snake_case};
 use crate::rules::blank_lines::check_blank_line_between_items;
@@ -330,6 +332,34 @@ impl<'a> Linter<'a> {
                 matches!(name.as_str(), "iter")
             }
             _ => false,
+        }
+    }
+
+    pub(super) fn constant_logical_reduction(
+        op: &str,
+        left: &SNode,
+        right: &SNode,
+    ) -> Option<(String, &'static str)> {
+        match (op, &left.node, &right.node) {
+            ("||", Node::BoolLiteral(true), _) => Some((
+                "`true || expr` always evaluates to `true`; the right side is unreachable"
+                    .to_string(),
+                "true",
+            )),
+            ("||", _, Node::BoolLiteral(true)) if is_pure_expression(&left.node) => Some((
+                "`expr || true` always evaluates to `true`".to_string(),
+                "true",
+            )),
+            ("&&", Node::BoolLiteral(false), _) => Some((
+                "`false && expr` always evaluates to `false`; the right side is unreachable"
+                    .to_string(),
+                "false",
+            )),
+            ("&&", _, Node::BoolLiteral(false)) if is_pure_expression(&left.node) => Some((
+                "`expr && false` always evaluates to `false`".to_string(),
+                "false",
+            )),
+            _ => None,
         }
     }
 

--- a/crates/harn-lint/src/linter/walk.rs
+++ b/crates/harn-lint/src/linter/walk.rs
@@ -428,6 +428,21 @@ impl<'a> Linter<'a> {
             }
 
             Node::BinaryOp { op, left, right } => {
+                if let Some((message, replacement)) =
+                    Self::constant_logical_reduction(op, left, right)
+                {
+                    self.diagnostics.push(LintDiagnostic {
+                        rule: "constant-logical-operand",
+                        message,
+                        span: snode.span,
+                        severity: LintSeverity::Warning,
+                        suggestion: Some(format!("replace this expression with `{replacement}`")),
+                        fix: Some(vec![FixEdit {
+                            span: snode.span,
+                            replacement: replacement.to_string(),
+                        }]),
+                    });
+                }
                 let is_pointless_self_comparison = (op == "==" || op == "!=")
                     && left.node == right.node
                     && is_pure_expression(&left.node);

--- a/crates/harn-lint/src/tests/boolean_patterns.rs
+++ b/crates/harn-lint/src/tests/boolean_patterns.rs
@@ -1,6 +1,6 @@
 //! Boolean-shape lint rules: `comparison-to-bool`,
-//! `unnecessary-else-return`, `duplicate-match-arm`, plus the
-//! comparison-to-bool autofix variants.
+//! `constant-logical-operand`, `unnecessary-else-return`,
+//! `duplicate-match-arm`, plus autofix variants.
 
 use super::*;
 
@@ -49,6 +49,41 @@ if x == 1 { log("one") }
     assert!(
         !has_rule(&diags, "comparison-to-bool"),
         "should not trigger for non-bool comparison: {diags:?}"
+    );
+}
+
+#[test]
+fn test_constant_logical_operand_autofix() {
+    let source = "pipeline default(task) {\n  let x = true\n  let a = x || true\n  let b = x && false\n  log(a)\n  log(b)\n}";
+    let diags = lint_source(source);
+    assert_eq!(count_rule(&diags, "constant-logical-operand"), 2);
+    let result = apply_fixes(source, &diags);
+    assert!(
+        result.contains("let a = true") && result.contains("let b = false"),
+        "expected constants, got: {result}"
+    );
+}
+
+#[test]
+fn test_constant_logical_operand_does_not_drop_impure_left_side() {
+    let source = "pipeline default(task) {\n  let a = expensive() || true\n  let b = expensive() && false\n  log(a)\n  log(b)\n}";
+    let diags = lint_source(source);
+    assert_eq!(
+        count_rule(&diags, "constant-logical-operand"),
+        0,
+        "impure left sides must not be removed: {diags:?}"
+    );
+}
+
+#[test]
+fn test_leading_logical_constants_autofix_even_with_impure_right_side() {
+    let source = "pipeline default(task) {\n  let a = true || expensive()\n  let b = false && expensive()\n  log(a)\n  log(b)\n}";
+    let diags = lint_source(source);
+    assert_eq!(count_rule(&diags, "constant-logical-operand"), 2);
+    let result = apply_fixes(source, &diags);
+    assert!(
+        result.contains("let a = true") && result.contains("let b = false"),
+        "right sides are unreachable, got: {result}"
     );
 }
 

--- a/crates/harn-parser/src/diagnostic.rs
+++ b/crates/harn-parser/src/diagnostic.rs
@@ -234,6 +234,7 @@ pub fn render_type_diagnostic(
             label: &related.message,
         })
         .collect::<Vec<_>>();
+    let primary_label = type_diagnostic_primary_label(diag);
     match &diag.span {
         Some(span) => render_diagnostic_with_related(
             source,
@@ -241,7 +242,7 @@ pub fn render_type_diagnostic(
             span,
             severity,
             &diag.message,
-            type_diagnostic_primary_label(diag),
+            primary_label.as_deref(),
             diag.help.as_deref(),
             &related,
         ),
@@ -249,13 +250,15 @@ pub fn render_type_diagnostic(
     }
 }
 
-fn type_diagnostic_primary_label(
-    diag: &crate::typechecker::TypeDiagnostic,
-) -> Option<&'static str> {
-    if diag.message.contains("expected ") && diag.message.contains("found ") {
-        Some("found this type")
-    } else {
-        None
+fn type_diagnostic_primary_label(diag: &crate::typechecker::TypeDiagnostic) -> Option<String> {
+    match &diag.details {
+        Some(crate::typechecker::DiagnosticDetails::LintRule { rule }) => {
+            Some(format!("lint[{rule}]"))
+        }
+        Some(crate::typechecker::DiagnosticDetails::TypeMismatch) => {
+            Some("found this type".to_string())
+        }
+        _ => None,
     }
 }
 

--- a/crates/harn-parser/src/typechecker/inference/expressions.rs
+++ b/crates/harn-parser/src/typechecker/inference/expressions.rs
@@ -14,11 +14,20 @@ use std::collections::BTreeMap;
 
 use crate::ast::*;
 use crate::builtin_signatures;
+use harn_lexer::{FixEdit, Span};
 
 use super::super::binary_ops::infer_binary_op_type;
 use super::super::scope::{builtin_return_type, InferredType, TypeScope};
 use super::super::union::simplify_union;
 use super::super::TypeChecker;
+
+const UNNECESSARY_SAFE_NAVIGATION_RULE: &str = "unnecessary-safe-navigation";
+
+enum SafeNavigationKind<'a> {
+    Subscript,
+    Property(&'a str),
+    Method,
+}
 
 impl TypeChecker {
     pub(in crate::typechecker) fn infer_try_error_type(
@@ -483,76 +492,17 @@ impl TypeChecker {
             }
 
             Node::PropertyAccess { object, property } => {
-                // EnumName.Variant → infer as the enum type
-                if let Node::Identifier(name) = &object.node {
-                    if let Some(enum_info) = scope.get_enum(name) {
-                        return Some(self.infer_enum_type(name, enum_info, property, &[], scope));
-                    }
-                }
-                // .variant on an enum value → string
-                if property == "variant" {
-                    let obj_type = self.infer_type(object, scope);
-                    if let Some(name) = obj_type.as_ref().and_then(Self::base_type_name) {
-                        if scope.get_enum(name).is_some() {
-                            return Some(TypeExpr::Named("string".into()));
-                        }
-                    }
-                }
-                // Shape field access: obj.field → field type
-                let obj_type = self.infer_type(object, scope);
-                // Pair<K, V> has `.first` and `.second` accessors.
-                if let Some(TypeExpr::Applied { name, args }) = &obj_type {
-                    if name == "Pair" && args.len() == 2 {
-                        if property == "first" {
-                            return Some(args[0].clone());
-                        } else if property == "second" {
-                            return Some(args[1].clone());
-                        }
-                    }
-                }
-                if let Some(TypeExpr::Shape(fields)) = &obj_type {
-                    if let Some(field) = fields.iter().find(|f| f.name == *property) {
-                        return Some(field.type_expr.clone());
-                    }
-                }
-                // Intersection field access: an `A & B` value has every
-                // field that A or B has. Look up the property in each
-                // component and return the first match.
-                if let Some(TypeExpr::Intersection(members)) = &obj_type {
-                    for member in members {
-                        if let TypeExpr::Shape(fields) = member {
-                            if let Some(field) = fields.iter().find(|f| f.name == *property) {
-                                return Some(field.type_expr.clone());
-                            }
-                        }
-                    }
-                }
-                None
+                self.infer_property_access_type(object, property, scope, false)
+            }
+            Node::OptionalPropertyAccess { object, property } => {
+                self.infer_property_access_type(object, property, scope, true)
             }
 
             Node::SubscriptAccess { object, index } => {
-                let obj_type = self.infer_type(object, scope);
-                match &obj_type {
-                    Some(TypeExpr::List(inner)) => Some(*inner.clone()),
-                    Some(TypeExpr::DictType(_, v)) => Some(*v.clone()),
-                    Some(TypeExpr::Shape(fields)) => {
-                        // If index is a string literal, look up the field type
-                        if let Node::StringLiteral(key) = &index.node {
-                            fields
-                                .iter()
-                                .find(|f| &f.name == key)
-                                .map(|f| f.type_expr.clone())
-                        } else {
-                            None
-                        }
-                    }
-                    Some(TypeExpr::Named(n)) if n == "list" => None,
-                    Some(TypeExpr::Named(n)) if n == "dict" => None,
-                    Some(TypeExpr::Named(n)) if n == "string" => {
-                        Some(TypeExpr::Named("string".into()))
-                    }
-                    _ => None,
-                }
+                self.infer_subscript_access_type(object, index, scope, false)
+            }
+            Node::OptionalSubscriptAccess { object, index } => {
+                self.infer_subscript_access_type(object, index, scope, true)
             }
             Node::SliceAccess { object, .. } => {
                 // Slicing a list returns the same list type; slicing a string returns string
@@ -576,6 +526,7 @@ impl TypeChecker {
                 method,
                 args,
             } => {
+                let optional_access = matches!(&snode.node, Node::OptionalMethodCall { .. });
                 if let Node::Identifier(name) = &object.node {
                     if let Some(enum_info) = scope.get_enum(name) {
                         return Some(self.infer_enum_type(name, enum_info, method, args, scope));
@@ -602,6 +553,11 @@ impl TypeChecker {
                     }
                 }
                 let obj_type = self.infer_type(object, scope);
+                let include_optional_nil = optional_access
+                    && obj_type
+                        .as_ref()
+                        .is_some_and(|ty| self.type_may_include_nil(ty, scope));
+                let result = |ty| Self::optional_method_result_type(ty, include_optional_nil);
                 // Iter<T> receiver: combinators preserve or transform T; sinks
                 // materialize. This must come before the shared-method match
                 // below so `.map` / `.filter` / etc. on an iter return Iter,
@@ -618,47 +574,50 @@ impl TypeChecker {
                     };
                     let iter_of = |ty: TypeExpr| TypeExpr::Iter(Box::new(ty));
                     match method.as_str() {
-                        "iter" => return Some(iter_of(t)),
+                        "iter" => return Some(result(iter_of(t))),
                         "map" | "flat_map" => {
                             // Closure-return inference is not threaded here;
                             // fall back to a coarse `iter<any>` — matches the
                             // list-return style the rest of the checker uses.
-                            return Some(TypeExpr::Named("iter".into()));
+                            return Some(result(TypeExpr::Named("iter".into())));
                         }
                         "filter" | "take" | "skip" | "take_while" | "skip_while" => {
-                            return Some(iter_of(t));
+                            return Some(result(iter_of(t)));
                         }
                         "zip" => {
-                            return Some(iter_of(pair(t, TypeExpr::Named("any".into()))));
+                            return Some(result(iter_of(pair(t, TypeExpr::Named("any".into())))));
                         }
                         "enumerate" => {
-                            return Some(iter_of(pair(TypeExpr::Named("int".into()), t)));
+                            return Some(result(iter_of(pair(TypeExpr::Named("int".into()), t))));
                         }
-                        "chain" => return Some(iter_of(t)),
+                        "chain" => return Some(result(iter_of(t))),
                         "chunks" | "windows" => {
-                            return Some(iter_of(TypeExpr::List(Box::new(t))));
+                            return Some(result(iter_of(TypeExpr::List(Box::new(t)))));
                         }
                         // Sinks
-                        "to_list" => return Some(TypeExpr::List(Box::new(t))),
+                        "to_list" => return Some(result(TypeExpr::List(Box::new(t)))),
                         "to_set" => {
-                            return Some(TypeExpr::Applied {
+                            return Some(result(TypeExpr::Applied {
                                 name: "set".into(),
                                 args: vec![t],
-                            })
+                            }))
                         }
-                        "to_dict" => return Some(TypeExpr::Named("dict".into())),
-                        "count" => return Some(TypeExpr::Named("int".into())),
+                        "to_dict" => return Some(result(TypeExpr::Named("dict".into()))),
+                        "count" => return Some(result(TypeExpr::Named("int".into()))),
                         "sum" => {
-                            return Some(TypeExpr::Union(vec![
+                            return Some(result(TypeExpr::Union(vec![
                                 TypeExpr::Named("int".into()),
                                 TypeExpr::Named("float".into()),
-                            ]))
+                            ])))
                         }
                         "min" | "max" | "first" | "last" | "find" => {
-                            return Some(TypeExpr::Union(vec![t, TypeExpr::Named("nil".into())]));
+                            return Some(result(TypeExpr::Union(vec![
+                                t,
+                                TypeExpr::Named("nil".into()),
+                            ])));
                         }
-                        "any" | "all" => return Some(TypeExpr::Named("bool".into())),
-                        "for_each" => return Some(TypeExpr::Named("nil".into())),
+                        "any" | "all" => return Some(result(TypeExpr::Named("bool".into()))),
+                        "for_each" => return Some(result(TypeExpr::Named("nil".into()))),
                         "reduce" => return None,
                         _ => {}
                     }
@@ -670,21 +629,21 @@ impl TypeChecker {
                 if method == "iter" {
                     match &obj_type {
                         Some(TypeExpr::List(inner)) => {
-                            return Some(TypeExpr::Iter(Box::new((**inner).clone())));
+                            return Some(result(TypeExpr::Iter(Box::new((**inner).clone()))));
                         }
                         Some(TypeExpr::Generator(inner)) | Some(TypeExpr::Stream(inner)) => {
-                            return Some(TypeExpr::Iter(Box::new((**inner).clone())));
+                            return Some(result(TypeExpr::Iter(Box::new((**inner).clone()))));
                         }
                         Some(TypeExpr::DictType(k, v)) => {
-                            return Some(TypeExpr::Iter(Box::new(TypeExpr::Applied {
+                            return Some(result(TypeExpr::Iter(Box::new(TypeExpr::Applied {
                                 name: "Pair".into(),
                                 args: vec![(**k).clone(), (**v).clone()],
-                            })));
+                            }))));
                         }
                         Some(TypeExpr::Named(n))
                             if n == "list" || n == "dict" || n == "set" || n == "string" =>
                         {
-                            return Some(TypeExpr::Named("iter".into()));
+                            return Some(result(TypeExpr::Named("iter".into())));
                         }
                         _ => {}
                     }
@@ -695,52 +654,52 @@ impl TypeChecker {
                 match method.as_str() {
                     // Shared: bool-returning methods
                     "contains" | "starts_with" | "ends_with" | "empty" | "has" | "any" | "all" => {
-                        Some(TypeExpr::Named("bool".into()))
+                        Some(result(TypeExpr::Named("bool".into())))
                     }
                     // Shared: int-returning methods
-                    "count" | "index_of" => Some(TypeExpr::Named("int".into())),
+                    "count" | "index_of" => Some(result(TypeExpr::Named("int".into()))),
                     // String methods
                     "trim" | "lowercase" | "uppercase" | "reverse" | "replace" | "substring"
                     | "pad_left" | "pad_right" | "repeat" | "join" => {
-                        Some(TypeExpr::Named("string".into()))
+                        Some(result(TypeExpr::Named("string".into())))
                     }
-                    "split" | "chars" => Some(TypeExpr::Named("list".into())),
+                    "split" | "chars" => Some(result(TypeExpr::Named("list".into()))),
                     // filter returns dict for dicts, list for lists
                     "filter" => {
                         if is_dict {
-                            Some(TypeExpr::Named("dict".into()))
+                            Some(result(TypeExpr::Named("dict".into())))
                         } else {
-                            Some(TypeExpr::Named("list".into()))
+                            Some(result(TypeExpr::Named("list".into())))
                         }
                     }
                     // List methods
-                    "map" | "flat_map" | "sort" => Some(TypeExpr::Named("list".into())),
+                    "map" | "flat_map" | "sort" => Some(result(TypeExpr::Named("list".into()))),
                     "window" | "each_cons" | "sliding_window" => match &obj_type {
-                        Some(TypeExpr::List(inner)) => Some(TypeExpr::List(Box::new(
+                        Some(TypeExpr::List(inner)) => Some(result(TypeExpr::List(Box::new(
                             TypeExpr::List(Box::new((**inner).clone())),
-                        ))),
-                        _ => Some(TypeExpr::Named("list".into())),
+                        )))),
+                        _ => Some(result(TypeExpr::Named("list".into()))),
                     },
                     "reduce" | "find" | "first" | "last" => None,
                     // Dict methods
-                    "keys" | "values" | "entries" => Some(TypeExpr::Named("list".into())),
+                    "keys" | "values" | "entries" => Some(result(TypeExpr::Named("list".into()))),
                     "merge" | "map_values" | "rekey" | "map_keys" => {
                         // Rekey/map_keys transform keys; resulting dict still keys-by-string.
                         // Preserve the value-type parameter when known so downstream code can
                         // still rely on dict<string, V> typing after a key-rename.
                         if let Some(TypeExpr::DictType(_, v)) = &obj_type {
-                            Some(TypeExpr::DictType(
+                            Some(result(TypeExpr::DictType(
                                 Box::new(TypeExpr::Named("string".into())),
                                 v.clone(),
-                            ))
+                            )))
                         } else {
-                            Some(TypeExpr::Named("dict".into()))
+                            Some(result(TypeExpr::Named("dict".into())))
                         }
                     }
                     // Conversions
-                    "to_string" => Some(TypeExpr::Named("string".into())),
-                    "to_int" => Some(TypeExpr::Named("int".into())),
-                    "to_float" => Some(TypeExpr::Named("float".into())),
+                    "to_string" => Some(result(TypeExpr::Named("string".into()))),
+                    "to_int" => Some(result(TypeExpr::Named("int".into()))),
+                    "to_float" => Some(result(TypeExpr::Named("float".into()))),
                     _ => None,
                 }
             }
@@ -834,6 +793,395 @@ impl TypeChecker {
                 .map(|struct_info| self.infer_struct_type(struct_name, struct_info, fields, scope)),
 
             _ => None,
+        }
+    }
+
+    fn infer_property_access_type(
+        &self,
+        object: &SNode,
+        property: &str,
+        scope: &TypeScope,
+        optional: bool,
+    ) -> InferredType {
+        if !optional {
+            // EnumName.Variant -> infer as the enum type.
+            if let Node::Identifier(name) = &object.node {
+                if let Some(enum_info) = scope.get_enum(name) {
+                    return Some(self.infer_enum_type(name, enum_info, property, &[], scope));
+                }
+            }
+        }
+        let obj_type = self.infer_type(object, scope)?;
+        self.infer_property_type_from_type(&obj_type, property, scope, optional)
+    }
+
+    fn infer_property_type_from_type(
+        &self,
+        ty: &TypeExpr,
+        property: &str,
+        scope: &TypeScope,
+        optional: bool,
+    ) -> InferredType {
+        let ty = self.resolve_alias(ty, scope);
+        match &ty {
+            TypeExpr::Named(name) if name == "nil" => {
+                optional.then(|| TypeExpr::Named("nil".into()))
+            }
+            TypeExpr::Named(name) if name == "list" => {
+                Self::list_property_type(None, property, optional)
+            }
+            TypeExpr::Named(name) if name == "string" => {
+                Self::string_property_type(property, optional)
+            }
+            TypeExpr::Named(name) if name == "dict" => None,
+            TypeExpr::Named(name) if scope.get_struct(name).is_some() => {
+                self.struct_property_type(name, &[], property, scope, optional)
+            }
+            TypeExpr::Named(name) if scope.get_enum(name).is_some() => {
+                Self::enum_property_type(property, optional)
+            }
+            TypeExpr::Union(members) => {
+                let mut inferred = Vec::new();
+                for member in members {
+                    if let Some(member_type) =
+                        self.infer_property_type_from_type(member, property, scope, optional)
+                    {
+                        inferred.push(member_type);
+                    } else if optional {
+                        inferred.push(TypeExpr::Named("nil".into()));
+                    }
+                }
+                (!inferred.is_empty()).then(|| simplify_union(inferred))
+            }
+            TypeExpr::Intersection(members) => {
+                for member in members {
+                    if let Some(member_type) =
+                        self.infer_property_type_from_type(member, property, scope, optional)
+                    {
+                        return Some(member_type);
+                    }
+                }
+                optional.then(|| TypeExpr::Named("nil".into()))
+            }
+            TypeExpr::Shape(fields) => Self::shape_property_type(fields, property, optional),
+            TypeExpr::List(inner) => {
+                Self::list_property_type(Some(inner.as_ref()), property, optional)
+            }
+            TypeExpr::DictType(_, value) => Some(*value.clone()),
+            TypeExpr::Applied { name, args } if name == "Pair" && args.len() == 2 => match property
+            {
+                "first" => Some(args[0].clone()),
+                "second" => Some(args[1].clone()),
+                _ if optional => Some(TypeExpr::Named("nil".into())),
+                _ => None,
+            },
+            TypeExpr::Applied { name, args } if scope.get_struct(name).is_some() => {
+                self.struct_property_type(name, args, property, scope, optional)
+            }
+            TypeExpr::Applied { name, .. } if scope.get_enum(name).is_some() => {
+                Self::enum_property_type(property, optional)
+            }
+            _ if optional => Some(TypeExpr::Named("nil".into())),
+            _ => None,
+        }
+    }
+
+    fn infer_subscript_access_type(
+        &self,
+        object: &SNode,
+        index: &SNode,
+        scope: &TypeScope,
+        optional: bool,
+    ) -> InferredType {
+        let obj_type = self.infer_type(object, scope)?;
+        self.infer_subscript_type_from_type(&obj_type, index, scope, optional)
+    }
+
+    fn infer_subscript_type_from_type(
+        &self,
+        ty: &TypeExpr,
+        index: &SNode,
+        scope: &TypeScope,
+        optional: bool,
+    ) -> InferredType {
+        let ty = self.resolve_alias(ty, scope);
+        match &ty {
+            TypeExpr::Named(name) if name == "nil" => {
+                optional.then(|| TypeExpr::Named("nil".into()))
+            }
+            TypeExpr::Union(members) => {
+                let mut inferred = Vec::new();
+                for member in members {
+                    if let Some(member_type) =
+                        self.infer_subscript_type_from_type(member, index, scope, optional)
+                    {
+                        inferred.push(member_type);
+                    }
+                }
+                (!inferred.is_empty()).then(|| simplify_union(inferred))
+            }
+            TypeExpr::List(inner) => Some(*inner.clone()),
+            TypeExpr::DictType(_, value) => Some(*value.clone()),
+            TypeExpr::Shape(fields) => {
+                if let Node::StringLiteral(key) = &index.node {
+                    Self::shape_property_type(fields, key, false)
+                } else {
+                    None
+                }
+            }
+            TypeExpr::Named(name) if name == "string" => Some(TypeExpr::Named("string".into())),
+            _ => None,
+        }
+    }
+
+    fn shape_property_type(
+        fields: &[ShapeField],
+        property: &str,
+        optional_access: bool,
+    ) -> InferredType {
+        let Some(field) = fields.iter().find(|field| field.name == property) else {
+            return optional_access.then(|| TypeExpr::Named("nil".into()));
+        };
+        Some(if field.optional {
+            simplify_union(vec![field.type_expr.clone(), TypeExpr::Named("nil".into())])
+        } else {
+            field.type_expr.clone()
+        })
+    }
+
+    fn list_property_type(
+        item_type: Option<&TypeExpr>,
+        property: &str,
+        optional_access: bool,
+    ) -> InferredType {
+        match property {
+            "count" => Some(TypeExpr::Named("int".into())),
+            "empty" => Some(TypeExpr::Named("bool".into())),
+            "first" | "last" => item_type
+                .map(|inner| simplify_union(vec![inner.clone(), TypeExpr::Named("nil".into())])),
+            _ if optional_access => Some(TypeExpr::Named("nil".into())),
+            _ => None,
+        }
+    }
+
+    fn string_property_type(property: &str, optional_access: bool) -> InferredType {
+        match property {
+            "count" => Some(TypeExpr::Named("int".into())),
+            "empty" => Some(TypeExpr::Named("bool".into())),
+            _ if optional_access => Some(TypeExpr::Named("nil".into())),
+            _ => None,
+        }
+    }
+
+    fn enum_property_type(property: &str, optional_access: bool) -> InferredType {
+        match property {
+            "variant" => Some(TypeExpr::Named("string".into())),
+            "fields" => Some(TypeExpr::Named("list".into())),
+            _ if optional_access => Some(TypeExpr::Named("nil".into())),
+            _ => None,
+        }
+    }
+
+    fn struct_property_type(
+        &self,
+        name: &str,
+        args: &[TypeExpr],
+        property: &str,
+        scope: &TypeScope,
+        optional_access: bool,
+    ) -> InferredType {
+        let struct_info = scope.get_struct(name)?;
+        let Some(field) = struct_info
+            .fields
+            .iter()
+            .find(|field| field.name == property)
+        else {
+            return optional_access.then(|| TypeExpr::Named("nil".into()));
+        };
+        let mut field_type = field.type_expr.clone()?;
+        if struct_info.type_params.len() == args.len() {
+            let bindings = struct_info
+                .type_params
+                .iter()
+                .map(|param| param.name.clone())
+                .zip(args.iter().cloned())
+                .collect::<BTreeMap<_, _>>();
+            field_type = Self::apply_type_bindings(&field_type, &bindings);
+        }
+        Some(if field.optional {
+            simplify_union(vec![field_type, TypeExpr::Named("nil".into())])
+        } else {
+            field_type
+        })
+    }
+
+    pub(in crate::typechecker) fn check_unnecessary_safe_property_access(
+        &mut self,
+        snode: &SNode,
+        object: &SNode,
+        property: &str,
+        scope: &TypeScope,
+    ) {
+        let Some(receiver_type) = self.infer_type(object, scope) else {
+            return;
+        };
+        if !self.type_is_provably_non_nil(&receiver_type, scope) {
+            return;
+        }
+        if !self.regular_property_access_is_safe(&receiver_type, property, scope) {
+            return;
+        }
+        self.emit_unnecessary_safe_navigation(
+            snode,
+            object,
+            SafeNavigationKind::Property(property),
+        );
+    }
+
+    pub(in crate::typechecker) fn check_unnecessary_safe_method_call(
+        &mut self,
+        snode: &SNode,
+        object: &SNode,
+        scope: &TypeScope,
+    ) {
+        let Some(receiver_type) = self.infer_type(object, scope) else {
+            return;
+        };
+        if self.type_is_provably_non_nil(&receiver_type, scope) {
+            self.emit_unnecessary_safe_navigation(snode, object, SafeNavigationKind::Method);
+        }
+    }
+
+    pub(in crate::typechecker) fn check_unnecessary_safe_subscript_access(
+        &mut self,
+        snode: &SNode,
+        object: &SNode,
+        scope: &TypeScope,
+    ) {
+        let Some(receiver_type) = self.infer_type(object, scope) else {
+            return;
+        };
+        if self.type_is_provably_non_nil(&receiver_type, scope) {
+            self.emit_unnecessary_safe_navigation(snode, object, SafeNavigationKind::Subscript);
+        }
+    }
+
+    fn emit_unnecessary_safe_navigation(
+        &mut self,
+        snode: &SNode,
+        object: &SNode,
+        kind: SafeNavigationKind<'_>,
+    ) {
+        let Some(fix) = self.safe_navigation_fix(snode.span, object, &kind) else {
+            return;
+        };
+        let span = fix[0].span;
+        let access = match kind {
+            SafeNavigationKind::Property(property) => format!("`?.{property}`"),
+            SafeNavigationKind::Method => "safe method call".to_string(),
+            SafeNavigationKind::Subscript => "`?[]`".to_string(),
+        };
+        self.lint_warning_at_with_fix(
+            UNNECESSARY_SAFE_NAVIGATION_RULE,
+            format!("{access} is unnecessary because the receiver cannot be nil"),
+            span,
+            "use ordinary access on non-optional receivers".to_string(),
+            fix,
+        );
+    }
+
+    fn safe_navigation_fix(
+        &self,
+        span: Span,
+        object: &SNode,
+        kind: &SafeNavigationKind<'_>,
+    ) -> Option<Vec<FixEdit>> {
+        let source = self.source.as_deref()?;
+        let search_start = object.span.end.min(span.end);
+        let search_end = span.end.min(source.len());
+        let region = source.get(search_start..search_end)?;
+        let (relative_start, len, replacement) = match kind {
+            SafeNavigationKind::Property(_) | SafeNavigationKind::Method => {
+                (region.find("?.")?, 2, ".")
+            }
+            SafeNavigationKind::Subscript => (region.find("?[")?, 1, ""),
+        };
+        let start = search_start + relative_start;
+        let end = start + len;
+        Some(vec![FixEdit {
+            span: Self::source_span_for_offsets(source, start, end),
+            replacement: replacement.to_string(),
+        }])
+    }
+
+    fn source_span_for_offsets(source: &str, start: usize, end: usize) -> Span {
+        let prefix = &source[..start.min(source.len())];
+        let line = prefix.bytes().filter(|byte| *byte == b'\n').count() + 1;
+        let line_start = prefix.rfind('\n').map(|offset| offset + 1).unwrap_or(0);
+        Span::with_offsets(start, end, line, start - line_start + 1)
+    }
+
+    fn optional_method_result_type(ty: TypeExpr, include_nil: bool) -> TypeExpr {
+        if include_nil {
+            simplify_union(vec![ty, TypeExpr::Named("nil".into())])
+        } else {
+            ty
+        }
+    }
+
+    fn type_may_include_nil(&self, ty: &TypeExpr, scope: &TypeScope) -> bool {
+        let ty = self.resolve_alias(ty, scope);
+        match &ty {
+            TypeExpr::Named(name) if name == "nil" => true,
+            TypeExpr::Union(members) => members
+                .iter()
+                .any(|member| self.type_may_include_nil(member, scope)),
+            _ => false,
+        }
+    }
+
+    fn type_is_provably_non_nil(&self, ty: &TypeExpr, scope: &TypeScope) -> bool {
+        let ty = self.resolve_alias(ty, scope);
+        match &ty {
+            TypeExpr::Named(name) if matches!(name.as_str(), "nil" | "any" | "unknown" | "_") => {
+                false
+            }
+            TypeExpr::Named(name) if scope.is_generic_type_param(name) => false,
+            TypeExpr::Union(members) => members
+                .iter()
+                .all(|member| self.type_is_provably_non_nil(member, scope)),
+            TypeExpr::Never => false,
+            _ => true,
+        }
+    }
+
+    fn regular_property_access_is_safe(
+        &self,
+        ty: &TypeExpr,
+        property: &str,
+        scope: &TypeScope,
+    ) -> bool {
+        let ty = self.resolve_alias(ty, scope);
+        match &ty {
+            TypeExpr::Union(members) => members
+                .iter()
+                .all(|member| self.regular_property_access_is_safe(member, property, scope)),
+            TypeExpr::Intersection(members) => members
+                .iter()
+                .any(|member| self.regular_property_access_is_safe(member, property, scope)),
+            TypeExpr::Shape(_) | TypeExpr::DictType(_, _) | TypeExpr::List(_) => true,
+            TypeExpr::Named(name) if name == "list" || name == "dict" || name == "string" => true,
+            TypeExpr::Named(name) if name == "Pair" => matches!(property, "first" | "second"),
+            TypeExpr::Named(name) => {
+                scope.get_struct(name).is_some() || scope.get_enum(name).is_some()
+            }
+            TypeExpr::Applied { name, .. } if name == "Pair" => {
+                matches!(property, "first" | "second")
+            }
+            TypeExpr::Applied { name, .. } => {
+                scope.get_struct(name).is_some() || scope.get_enum(name).is_some()
+            }
+            _ => false,
         }
     }
 

--- a/crates/harn-parser/src/typechecker/inference/expressions.rs
+++ b/crates/harn-parser/src/typechecker/inference/expressions.rs
@@ -827,6 +827,12 @@ impl TypeChecker {
             TypeExpr::Named(name) if name == "nil" => {
                 optional.then(|| TypeExpr::Named("nil".into()))
             }
+            TypeExpr::Named(name)
+                if matches!(name.as_str(), "any" | "unknown" | "_")
+                    || scope.is_generic_type_param(name) =>
+            {
+                None
+            }
             TypeExpr::Named(name) if name == "list" => {
                 Self::list_property_type(None, property, optional)
             }
@@ -843,12 +849,18 @@ impl TypeChecker {
             TypeExpr::Union(members) => {
                 let mut inferred = Vec::new();
                 for member in members {
-                    if let Some(member_type) =
+                    if self.type_is_nil(member, scope) {
+                        if optional {
+                            inferred.push(TypeExpr::Named("nil".into()));
+                        } else {
+                            return None;
+                        }
+                    } else if let Some(member_type) =
                         self.infer_property_type_from_type(member, property, scope, optional)
                     {
                         inferred.push(member_type);
-                    } else if optional {
-                        inferred.push(TypeExpr::Named("nil".into()));
+                    } else {
+                        return None;
                     }
                 }
                 (!inferred.is_empty()).then(|| simplify_union(inferred))
@@ -909,13 +921,27 @@ impl TypeChecker {
             TypeExpr::Named(name) if name == "nil" => {
                 optional.then(|| TypeExpr::Named("nil".into()))
             }
+            TypeExpr::Named(name)
+                if matches!(name.as_str(), "any" | "unknown" | "_")
+                    || scope.is_generic_type_param(name) =>
+            {
+                None
+            }
             TypeExpr::Union(members) => {
                 let mut inferred = Vec::new();
                 for member in members {
-                    if let Some(member_type) =
+                    if self.type_is_nil(member, scope) {
+                        if optional {
+                            inferred.push(TypeExpr::Named("nil".into()));
+                        } else {
+                            return None;
+                        }
+                    } else if let Some(member_type) =
                         self.infer_subscript_type_from_type(member, index, scope, optional)
                     {
                         inferred.push(member_type);
+                    } else {
+                        return None;
                     }
                 }
                 (!inferred.is_empty()).then(|| simplify_union(inferred))
@@ -1129,6 +1155,10 @@ impl TypeChecker {
         }
     }
 
+    fn type_is_nil(&self, ty: &TypeExpr, scope: &TypeScope) -> bool {
+        matches!(self.resolve_alias(ty, scope), TypeExpr::Named(name) if name == "nil")
+    }
+
     fn type_may_include_nil(&self, ty: &TypeExpr, scope: &TypeScope) -> bool {
         let ty = self.resolve_alias(ty, scope);
         match &ty {
@@ -1169,17 +1199,35 @@ impl TypeChecker {
             TypeExpr::Intersection(members) => members
                 .iter()
                 .any(|member| self.regular_property_access_is_safe(member, property, scope)),
-            TypeExpr::Shape(_) | TypeExpr::DictType(_, _) | TypeExpr::List(_) => true,
-            TypeExpr::Named(name) if name == "list" || name == "dict" || name == "string" => true,
+            TypeExpr::Shape(fields) => fields.iter().any(|field| field.name == property),
+            TypeExpr::DictType(_, _) => false,
+            TypeExpr::List(inner) => {
+                Self::list_property_type(Some(inner), property, false).is_some()
+            }
+            TypeExpr::Named(name) if name == "list" => {
+                Self::list_property_type(None, property, false).is_some()
+            }
+            TypeExpr::Named(name) if name == "dict" => false,
+            TypeExpr::Named(name) if name == "string" => {
+                Self::string_property_type(property, false).is_some()
+            }
             TypeExpr::Named(name) if name == "Pair" => matches!(property, "first" | "second"),
             TypeExpr::Named(name) => {
-                scope.get_struct(name).is_some() || scope.get_enum(name).is_some()
+                scope
+                    .get_struct(name)
+                    .is_some_and(|info| info.fields.iter().any(|field| field.name == property))
+                    || (scope.get_enum(name).is_some()
+                        && Self::enum_property_type(property, false).is_some())
             }
             TypeExpr::Applied { name, .. } if name == "Pair" => {
                 matches!(property, "first" | "second")
             }
             TypeExpr::Applied { name, .. } => {
-                scope.get_struct(name).is_some() || scope.get_enum(name).is_some()
+                scope
+                    .get_struct(name)
+                    .is_some_and(|info| info.fields.iter().any(|field| field.name == property))
+                    || (scope.get_enum(name).is_some()
+                        && Self::enum_property_type(property, false).is_some())
             }
             _ => false,
         }

--- a/crates/harn-parser/src/typechecker/inference/statements.rs
+++ b/crates/harn-parser/src/typechecker/inference/statements.rs
@@ -30,6 +30,28 @@ use super::super::union::{
 use super::super::{InlayHintInfo, TypeChecker};
 use super::flow::{pattern_alternatives, resolve_union_shape_members};
 
+#[derive(Clone, Copy)]
+enum UntypedAccessKind {
+    Property,
+    Subscript,
+}
+
+impl UntypedAccessKind {
+    fn direct_label(self) -> &'static str {
+        match self {
+            Self::Property => "Direct property access",
+            Self::Subscript => "Direct subscript access",
+        }
+    }
+
+    fn variable_label(self) -> &'static str {
+        match self {
+            Self::Property => "Accessing property",
+            Self::Subscript => "Subscript access",
+        }
+    }
+}
+
 impl TypeChecker {
     pub(in crate::typechecker) fn check_block(&mut self, stmts: &[SNode], scope: &mut TypeScope) {
         let mut definitely_exited = false;
@@ -120,6 +142,76 @@ impl TypeChecker {
                 TypeExpr::Union(widened)
             }
             other => TypeExpr::Union(vec![other.clone(), TypeExpr::Named("nil".into())]),
+        }
+    }
+
+    fn check_generic_method_bound(
+        &mut self,
+        object: &SNode,
+        method: &str,
+        scope: &TypeScope,
+        span: Span,
+    ) {
+        let Some(TypeExpr::Named(type_name)) = self.infer_type(object, scope) else {
+            return;
+        };
+        if !scope.is_generic_type_param(&type_name) {
+            return;
+        }
+        let Some(iface_name) = scope.get_where_constraint(&type_name) else {
+            return;
+        };
+        let Some(iface_methods) = scope.get_interface(iface_name) else {
+            return;
+        };
+        if iface_methods.methods.iter().any(|m| m.name == method) {
+            return;
+        }
+        self.warning_at(
+            format!(
+                "Method '{}' not found in interface '{}' (constraint on '{}')",
+                method, iface_name, type_name
+            ),
+            span,
+        );
+    }
+
+    fn check_strict_untyped_access(
+        &mut self,
+        object: &SNode,
+        scope: &TypeScope,
+        span: Span,
+        kind: UntypedAccessKind,
+    ) {
+        if !self.strict_types {
+            return;
+        }
+        if let Node::FunctionCall { name, args, .. } = &object.node {
+            if builtin_signatures::is_untyped_boundary_source(name) {
+                let has_schema = (name == "llm_call" || name == "llm_completion")
+                    && Self::llm_call_has_typed_schema_option(args, scope);
+                if !has_schema {
+                    self.warning_at_with_help(
+                        format!("{} on unvalidated `{}()` result", kind.direct_label(), name),
+                        span,
+                        "assign to a variable and validate with schema_expect() or a type annotation first".to_string(),
+                    );
+                }
+            }
+        }
+        if let Node::Identifier(name) = &object.node {
+            if let Some(source) = scope.is_untyped_source(name) {
+                self.warning_at_with_help(
+                    format!(
+                        "{} on unvalidated value '{}' from `{}`",
+                        kind.variable_label(),
+                        name,
+                        source
+                    ),
+                    span,
+                    "validate with schema_expect(), schema_is() in an if-condition, or add a shape type annotation".to_string(),
+                );
+            }
         }
     }
 
@@ -934,107 +1026,43 @@ impl TypeChecker {
                 method,
                 args,
                 ..
-            }
-            | Node::OptionalMethodCall {
-                object,
-                method,
-                args,
-                ..
             } => {
                 self.check_node(object, scope);
                 for arg in args {
                     self.check_node(arg, scope);
                 }
-                // Definition-site generic checking: if the object's type is a
-                // constrained generic param (where T: Interface), verify the
-                // method exists in the bound interface.
-                if let Some(TypeExpr::Named(type_name)) = self.infer_type(object, scope) {
-                    if scope.is_generic_type_param(&type_name) {
-                        if let Some(iface_name) = scope.get_where_constraint(&type_name) {
-                            if let Some(iface_methods) = scope.get_interface(iface_name) {
-                                let has_method =
-                                    iface_methods.methods.iter().any(|m| m.name == *method);
-                                if !has_method {
-                                    self.warning_at(
-                                        format!(
-                                            "Method '{}' not found in interface '{}' (constraint on '{}')",
-                                            method, iface_name, type_name
-                                        ),
-                                        span,
-                                    );
-                                }
-                            }
-                        }
-                    }
-                }
+                self.check_generic_method_bound(object, method, scope, span);
             }
-            Node::PropertyAccess { object, .. } | Node::OptionalPropertyAccess { object, .. } => {
-                if self.strict_types {
-                    // Direct property access on boundary function result
-                    if let Node::FunctionCall { name, args, .. } = &object.node {
-                        if builtin_signatures::is_untyped_boundary_source(name) {
-                            let has_schema = (name == "llm_call" || name == "llm_completion")
-                                && Self::llm_call_has_typed_schema_option(args, scope);
-                            if !has_schema {
-                                self.warning_at_with_help(
-                                    format!(
-                                        "Direct property access on unvalidated `{}()` result",
-                                        name
-                                    ),
-                                    span,
-                                    "assign to a variable and validate with schema_expect() or a type annotation first".to_string(),
-                                );
-                            }
-                        }
-                    }
-                    // Property access on known untyped variable
-                    if let Node::Identifier(name) = &object.node {
-                        if let Some(source) = scope.is_untyped_source(name) {
-                            self.warning_at_with_help(
-                                format!(
-                                    "Accessing property on unvalidated value '{}' from `{}`",
-                                    name, source
-                                ),
-                                span,
-                                "validate with schema_expect(), schema_is() in an if-condition, or add a shape type annotation".to_string(),
-                            );
-                        }
-                    }
+            Node::OptionalMethodCall {
+                object,
+                method,
+                args,
+                ..
+            } => {
+                self.check_unnecessary_safe_method_call(snode, object, scope);
+                self.check_node(object, scope);
+                for arg in args {
+                    self.check_node(arg, scope);
                 }
+                self.check_generic_method_bound(object, method, scope, span);
+            }
+            Node::PropertyAccess { object, .. } => {
+                self.check_strict_untyped_access(object, scope, span, UntypedAccessKind::Property);
                 self.check_node(object, scope);
             }
-            Node::SubscriptAccess { object, index }
-            | Node::OptionalSubscriptAccess { object, index } => {
-                if self.strict_types {
-                    if let Node::FunctionCall { name, args, .. } = &object.node {
-                        if builtin_signatures::is_untyped_boundary_source(name) {
-                            let has_schema = (name == "llm_call" || name == "llm_completion")
-                                && Self::llm_call_has_typed_schema_option(args, scope);
-                            if !has_schema {
-                                self.warning_at_with_help(
-                                    format!(
-                                        "Direct subscript access on unvalidated `{}()` result",
-                                        name
-                                    ),
-                                    span,
-                                    "assign to a variable and validate with schema_expect() or a type annotation first".to_string(),
-                                );
-                            }
-                        }
-                    }
-                    if let Node::Identifier(name) = &object.node {
-                        if let Some(source) = scope.is_untyped_source(name) {
-                            self.warning_at_with_help(
-                                format!(
-                                    "Subscript access on unvalidated value '{}' from `{}`",
-                                    name, source
-                                ),
-                                span,
-                                "validate with schema_expect(), schema_is() in an if-condition, or add a shape type annotation".to_string(),
-                            );
-                        }
-                    }
-                }
+            Node::OptionalPropertyAccess { object, property } => {
+                self.check_unnecessary_safe_property_access(snode, object, property, scope);
+                self.check_strict_untyped_access(object, scope, span, UntypedAccessKind::Property);
+                self.check_node(object, scope);
+            }
+            Node::SubscriptAccess { object, index } => {
+                self.check_strict_untyped_access(object, scope, span, UntypedAccessKind::Subscript);
+                self.check_node(object, scope);
+                self.check_node(index, scope);
+            }
+            Node::OptionalSubscriptAccess { object, index } => {
+                self.check_unnecessary_safe_subscript_access(snode, object, scope);
+                self.check_strict_untyped_access(object, scope, span, UntypedAccessKind::Subscript);
                 self.check_node(object, scope);
                 self.check_node(index, scope);
             }

--- a/crates/harn-parser/src/typechecker/mod.rs
+++ b/crates/harn-parser/src/typechecker/mod.rs
@@ -59,6 +59,9 @@ pub struct RelatedDiagnostic {
 /// variant without parsing the error string.
 #[derive(Debug, Clone)]
 pub enum DiagnosticDetails {
+    /// A concrete expected/found mismatch. Renderers can use this to
+    /// provide stable labels without scraping human-readable text.
+    TypeMismatch,
     /// A `match` expression with missing variant coverage. `missing`
     /// holds the formatted literal values of each uncovered variant
     /// (quoted for strings, bare for ints), ready to drop into a new
@@ -66,6 +69,11 @@ pub enum DiagnosticDetails {
     /// expression, so a code-action can locate the closing `}` by
     /// reading the source at `span.end`.
     NonExhaustiveMatch { missing: Vec<String> },
+    /// A type-aware lint diagnostic. These diagnostics are produced by
+    /// the type checker because the rule depends on flow-sensitive type
+    /// information, but `harn lint` should surface and filter them like
+    /// ordinary lint rules.
+    LintRule { rule: &'static str },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -349,7 +357,7 @@ impl TypeChecker {
             help: coercion_suggestion(expected, actual, value_span, self.source.as_deref()),
             related,
             fix: None,
-            details: None,
+            details: Some(DiagnosticDetails::TypeMismatch),
         });
     }
 
@@ -436,6 +444,25 @@ impl TypeChecker {
             related: Vec::new(),
             fix: None,
             details: None,
+        });
+    }
+
+    pub(in crate::typechecker) fn lint_warning_at_with_fix(
+        &mut self,
+        rule: &'static str,
+        message: String,
+        span: Span,
+        help: String,
+        fix: Vec<FixEdit>,
+    ) {
+        self.diagnostics.push(TypeDiagnostic {
+            message,
+            severity: DiagnosticSeverity::Warning,
+            span: Some(span),
+            help: Some(help),
+            related: Vec::new(),
+            fix: Some(fix),
+            details: Some(DiagnosticDetails::LintRule { rule }),
         });
     }
 }

--- a/crates/harn-parser/src/typechecker/tests/typing.rs
+++ b/crates/harn-parser/src/typechecker/tests/typing.rs
@@ -164,6 +164,10 @@ pipeline t(task) {
   log(maybe?.name)
   let n: int = 42
   log(n?.missing)
+  let broad: dict = {}
+  log(broad?.dynamic_field)
+  let union_value: dict | list = broad
+  log(union_value?.dynamic_field)
 }
 "#,
     );
@@ -210,6 +214,23 @@ pipeline t(task) {
         fixes,
         vec![".", "", "."],
         "got diagnostics: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn test_optional_access_on_dynamic_dict_union_stays_unknown() {
+    let errs = errors(
+        r#"
+pipeline t(task) {
+  fn needs_string(target: string) {}
+  let worker_summary: dict | list = {}
+  needs_string(worker_summary?.snapshot_path)
+}
+"#,
+    );
+    assert!(
+        errs.is_empty(),
+        "dynamic dict access should not collapse to nil: {errs:?}"
     );
 }
 

--- a/crates/harn-parser/src/typechecker/tests/typing.rs
+++ b/crates/harn-parser/src/typechecker/tests/typing.rs
@@ -1,6 +1,7 @@
 //! Basic typing: literals, fn / pipeline signatures, generics, type aliases, variance.
 
 use super::*;
+use crate::DiagnosticDetails;
 
 #[test]
 fn test_no_errors_for_untyped_code() {
@@ -115,6 +116,115 @@ fn test_rest_param_binding_is_list_of_declared_type() {
     let values: list<int> = nums
   }
 }"#,
+    );
+    assert!(errs.is_empty(), "unexpected errors: {errs:?}");
+}
+
+#[test]
+fn test_unnecessary_safe_navigation_warns_on_non_nil_receiver() {
+    let diagnostics = check_source_with_source(
+        r#"
+type User = {name: string, email: string}
+pipeline t(task) {
+  let user: User = {name: "Ada", email: "ada@example.com"}
+  log(user?.name)
+  log(user?.email)
+}
+"#,
+    );
+    let safe_nav = diagnostics
+        .iter()
+        .filter(|diagnostic| {
+            matches!(
+                &diagnostic.details,
+                Some(DiagnosticDetails::LintRule { rule })
+                    if *rule == "unnecessary-safe-navigation"
+            )
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(safe_nav.len(), 2, "got diagnostics: {diagnostics:?}");
+    assert!(
+        safe_nav.iter().all(|diagnostic| {
+            diagnostic
+                .fix
+                .as_ref()
+                .is_some_and(|fix| fix.len() == 1 && fix[0].replacement == ".")
+        }),
+        "expected dot fixes: {safe_nav:?}"
+    );
+}
+
+#[test]
+fn test_unnecessary_safe_navigation_respects_nullable_and_unsupported_property() {
+    let diagnostics = check_source_with_source(
+        r#"
+type User = {name: string}
+pipeline t(task) {
+  let maybe: User? = nil
+  log(maybe?.name)
+  let n: int = 42
+  log(n?.missing)
+}
+"#,
+    );
+    assert!(
+        diagnostics.iter().all(|diagnostic| !matches!(
+            &diagnostic.details,
+            Some(DiagnosticDetails::LintRule { rule })
+                if *rule == "unnecessary-safe-navigation"
+        )),
+        "nullable receivers and unsupported optional property access must not warn: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn test_unnecessary_safe_navigation_uses_flow_narrowing_and_handles_postfix_forms() {
+    let diagnostics = check_source_with_source(
+        r#"
+type User = {name: string}
+pipeline t(task) {
+  let maybe: User? = {name: "Ada"}
+  if maybe != nil {
+    log(maybe?.name)
+  }
+  let names: list<string> = ["Ada"]
+  log(names?[0])
+  log("Ada"?.lowercase())
+}
+"#,
+    );
+    let fixes = diagnostics
+        .iter()
+        .filter_map(|diagnostic| match &diagnostic.details {
+            Some(DiagnosticDetails::LintRule { rule })
+                if *rule == "unnecessary-safe-navigation" =>
+            {
+                diagnostic.fix.as_ref()
+            }
+            _ => None,
+        })
+        .flatten()
+        .map(|fix| fix.replacement.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        fixes,
+        vec![".", "", "."],
+        "got diagnostics: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn test_optional_access_infers_nil_when_receiver_is_nullable() {
+    let errs = errors(
+        r#"
+type User = {name: string}
+pipeline t(task) {
+  let maybe: User? = nil
+  let name: string? = maybe?.name
+  let lowered: string? = maybe?.name?.lowercase()
+  let contains_a: bool? = maybe?.name?.contains("a")
+}
+"#,
     );
     assert!(errs.is_empty(), "unexpected errors: {errs:?}");
 }


### PR DESCRIPTION
## Summary

- Adds a type-aware `unnecessary-safe-navigation` lint with autofixes for non-null receivers across `?.`, `?.method(...)`, and `?[]`.
- Threads type-checker lint diagnostics through `harn lint`, `lint --fix`, and `harn check` rule filtering without scraping diagnostic messages.
- Adds `constant-logical-operand` autofixes for boolean short-circuit constants such as `true || expr`, `expr || true`, `false && expr`, and `expr && false` when the rewrite does not drop a reachable impure left side.
- Improves optional property/subscript/method type inference so nullable receivers propagate `nil` consistently.

## Notes

`||` and `&&` in Harn return booleans, so string fallback expressions like `"" || "fallback"` are not rewritten as fallback values.

## Validation

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings` via pre-commit hook
- `cargo test -p harn-parser -p harn-lint`
- `cargo test -p harn-cli lint_file_inner_reports_type_aware_lint_rules -- --nocapture`
- `cargo run --quiet --bin harn -- test conformance --filter optional_method_call`
- `harn lint` / `harn lint --fix` smoke test on a temporary script under `target/`
- repo pre-push targeted checks
