### PR TITLE
Scope tool-surface alias prompt warnings

### DIFF
--- a/crates/harn-vm/src/llm/tools/contract_prompt.rs
+++ b/crates/harn-vm/src/llm/tools/contract_prompt.rs
@@ -1,6 +1,7 @@
 use super::collect::{collect_tool_schemas_with_registry, ToolSchema};
 use super::params::ToolParamSchema;
 use super::type_expr::{ObjectField, TypeExpr};
+use super::{TEXT_TOOL_CALL_CLOSE, TEXT_TOOL_CALL_OPEN};
 use crate::value::VmValue;
 
 /// Build a runtime-owned tool-calling contract prompt.
@@ -183,9 +184,9 @@ pub(crate) fn text_response_protocol_help(done_sentinel: &str) -> String {
 
 Every response must be a sequence of these tags, with only whitespace between them:
 
-<tool_call>
+{TEXT_TOOL_CALL_OPEN}
 name({{ key: value }})
-</tool_call>
+{TEXT_TOOL_CALL_CLOSE}
 
 <assistant_prose>
 Short narration. Optional.
@@ -198,7 +199,7 @@ Final user-facing answer. Required when no more tool calls are needed.
 {done_block_line}Rules the runtime enforces:
 
 - No text, code, diffs, JSON, or reasoning outside these tags. Any stray content is rejected with structured feedback.
-- `<tool_call>` wraps exactly one bare call `name({{ key: value }})`. Do not quote or JSON-encode the call. Use heredoc `<<TAG` ... `TAG` for multiline string fields — raw content, no escaping. Place TAG at the start of the closing line; closing punctuation like `}},` may follow on that same line.
+- `{TEXT_TOOL_CALL_OPEN}` wraps exactly one bare call `name({{ key: value }})`. Do not quote or JSON-encode the call. Use heredoc `<<TAG` ... `TAG` for multiline string fields — raw content, no escaping. Place TAG at the start of the closing line; closing punctuation like `}},` may follow on that same line.
 - `<assistant_prose>` is optional and must be brief. Never paste source code, file contents, command transcripts, or long plans here — wrap those in the relevant tool call instead.
 - `<user_response>` is reserved for the final user-facing answer that hosts should surface. Emit it when the user should see a wrap-up or answer, and keep it concise and grounded.
 {done_rule_line}- Do not prefix calls with labels like `tool_code:`, `python:`, `shell:`, or any language tag, and do not wrap tool calls in Markdown fences.
@@ -208,13 +209,13 @@ Example of a well-formed response:
 
 <assistant_prose>Creating the test file.</assistant_prose>
 <user_response>Created the test file.</user_response>
-<tool_call>
+{TEXT_TOOL_CALL_OPEN}
 edit({{ action: \"create\", path: \"tests/test_foo.py\", content: <<EOF
 def test_foo():
     assert foo() == 42
 EOF
 }})
-</tool_call>
+{TEXT_TOOL_CALL_CLOSE}
 "
     )
 }
@@ -269,7 +270,7 @@ pub(crate) fn text_action_gated_clause(done_sentinel: &str) -> String {
     };
     format!(
         "\nThis turn is action-gated. If tools are available, open your response \
-         with a tool call (`<tool_call>...</tool_call>`), not prose. Do not emit \
+         with a tool call (`{TEXT_TOOL_CALL_OPEN}...{TEXT_TOOL_CALL_CLOSE}`), not prose. Do not emit \
          raw source code, diffs, JSON{sentinel_clause} before the first tool call.\n"
     )
 }

--- a/crates/harn-vm/src/llm/tools/mod.rs
+++ b/crates/harn-vm/src/llm/tools/mod.rs
@@ -7,6 +7,7 @@ mod messages;
 mod native;
 mod params;
 mod parse;
+mod protocol;
 mod ts_value_parser;
 mod type_expr;
 
@@ -36,6 +37,11 @@ pub(crate) use parse::parse_text_tool_calls_with_tools;
 pub(crate) use parse::StreamingToolCallDetector;
 #[cfg(test)]
 pub(crate) use parse::{parse_bare_calls_in_body, parse_native_json_tool_calls};
+pub(crate) use protocol::{
+    text_tool_call_block, text_tool_call_tag_pairs, TEXT_TOOL_CALL_CLOSE,
+    TEXT_TOOL_CALL_CLOSE_COMPACT, TEXT_TOOL_CALL_OPEN, TEXT_TOOL_CALL_OPEN_COMPACT,
+    TEXT_TOOL_CALL_TAG, TEXT_TOOL_CALL_TAG_COMPACT,
+};
 
 #[cfg(test)]
 mod tests;

--- a/crates/harn-vm/src/llm/tools/parse/streaming.rs
+++ b/crates/harn-vm/src/llm/tools/parse/streaming.rs
@@ -37,12 +37,11 @@ use std::collections::BTreeSet;
 
 use crate::agent_events::{AgentEvent, ToolCallErrorCategory, ToolCallStatus};
 
+use super::super::{
+    TEXT_TOOL_CALL_CLOSE, TEXT_TOOL_CALL_CLOSE_COMPACT, TEXT_TOOL_CALL_OPEN,
+    TEXT_TOOL_CALL_OPEN_COMPACT,
+};
 use super::syntax::{ident_length, parse_ts_call_from};
-
-const TAGGED_OPEN: &str = "<tool_call>";
-const TAGGED_CLOSE: &str = "</tool_call>";
-const TAGGED_OPEN_COMPACT: &str = "<toolcall>";
-const TAGGED_CLOSE_COMPACT: &str = "</toolcall>";
 
 /// Streaming candidate detector for text-mode tool calls.
 ///
@@ -408,17 +407,17 @@ impl StreamingToolCallDetector {
 }
 
 fn tagged_open_at(rest: &str) -> Option<(&'static str, &'static str)> {
-    if rest.starts_with(TAGGED_OPEN) {
-        Some((TAGGED_OPEN, TAGGED_CLOSE))
-    } else if rest.starts_with(TAGGED_OPEN_COMPACT) {
-        Some((TAGGED_OPEN_COMPACT, TAGGED_CLOSE_COMPACT))
+    if rest.starts_with(TEXT_TOOL_CALL_OPEN) {
+        Some((TEXT_TOOL_CALL_OPEN, TEXT_TOOL_CALL_CLOSE))
+    } else if rest.starts_with(TEXT_TOOL_CALL_OPEN_COMPACT) {
+        Some((TEXT_TOOL_CALL_OPEN_COMPACT, TEXT_TOOL_CALL_CLOSE_COMPACT))
     } else {
         None
     }
 }
 
 fn is_partial_tagged_open(rest: &str) -> bool {
-    TAGGED_OPEN.starts_with(rest) || TAGGED_OPEN_COMPACT.starts_with(rest)
+    TEXT_TOOL_CALL_OPEN.starts_with(rest) || TEXT_TOOL_CALL_OPEN_COMPACT.starts_with(rest)
 }
 
 fn promote_event(

--- a/crates/harn-vm/src/llm/tools/parse/tagged.rs
+++ b/crates/harn-vm/src/llm/tools/parse/tagged.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeSet;
 
+use super::super::{text_tool_call_block, TEXT_TOOL_CALL_TAG, TEXT_TOOL_CALL_TAG_COMPACT};
 use super::bare::parse_bare_calls_in_body;
 use super::syntax::{
     ident_length, match_block, parse_ts_call_from, preview_str, render_canonical_call,
@@ -83,8 +84,8 @@ pub(crate) fn parse_text_tool_calls_with_tools(
             continue;
         }
 
-        if let Some((body, after)) =
-            match_block(src, cursor, "tool_call").or_else(|| match_block(src, cursor, "toolcall"))
+        if let Some((body, after)) = match_block(src, cursor, TEXT_TOOL_CALL_TAG)
+            .or_else(|| match_block(src, cursor, TEXT_TOOL_CALL_TAG_COMPACT))
         {
             match parse_single_tool_call(body, tools_val) {
                 Ok(call) => {
@@ -97,10 +98,8 @@ pub(crate) fn parse_text_tool_calls_with_tools(
                         .get("arguments")
                         .cloned()
                         .unwrap_or(serde_json::json!({}));
-                    canonical_parts.push(format!(
-                        "<tool_call>\n{}\n</tool_call>",
-                        render_canonical_call(&name, &args)
-                    ));
+                    canonical_parts
+                        .push(text_tool_call_block(&render_canonical_call(&name, &args)));
                     calls.push(call);
                 }
                 Err(msg) => errors.push(msg),
@@ -152,10 +151,7 @@ pub(crate) fn parse_text_tool_calls_with_tools(
                 .get("arguments")
                 .cloned()
                 .unwrap_or(serde_json::json!({}));
-            canonical_parts.push(format!(
-                "<tool_call>\n{}\n</tool_call>",
-                render_canonical_call(&name, &args)
-            ));
+            canonical_parts.push(text_tool_call_block(&render_canonical_call(&name, &args)));
             calls.push(call);
             violations.push(format!(
                 "Tool call `{name}` was emitted as `<{name}(...)>` instead of \
@@ -316,10 +312,7 @@ fn report_stray(
                 .get("arguments")
                 .cloned()
                 .unwrap_or(serde_json::json!({}));
-            canonical_parts.push(format!(
-                "<tool_call>\n{}\n</tool_call>",
-                render_canonical_call(&name, &args)
-            ));
+            canonical_parts.push(text_tool_call_block(&render_canonical_call(&name, &args)));
             calls.push(call.clone());
         }
         violations.push(format!(

--- a/crates/harn-vm/src/llm/tools/protocol.rs
+++ b/crates/harn-vm/src/llm/tools/protocol.rs
@@ -1,0 +1,17 @@
+pub(crate) const TEXT_TOOL_CALL_TAG: &str = "tool_call";
+pub(crate) const TEXT_TOOL_CALL_TAG_COMPACT: &str = "toolcall";
+pub(crate) const TEXT_TOOL_CALL_OPEN: &str = "<tool_call>";
+pub(crate) const TEXT_TOOL_CALL_CLOSE: &str = "</tool_call>";
+pub(crate) const TEXT_TOOL_CALL_OPEN_COMPACT: &str = "<toolcall>";
+pub(crate) const TEXT_TOOL_CALL_CLOSE_COMPACT: &str = "</toolcall>";
+
+pub(crate) fn text_tool_call_block(body: &str) -> String {
+    format!("{TEXT_TOOL_CALL_OPEN}\n{body}\n{TEXT_TOOL_CALL_CLOSE}")
+}
+
+pub(crate) fn text_tool_call_tag_pairs() -> [(&'static str, &'static str); 2] {
+    [
+        (TEXT_TOOL_CALL_OPEN, TEXT_TOOL_CALL_CLOSE),
+        (TEXT_TOOL_CALL_OPEN_COMPACT, TEXT_TOOL_CALL_CLOSE_COMPACT),
+    ]
+}

--- a/crates/harn-vm/src/stdlib/tools.rs
+++ b/crates/harn-vm/src/stdlib/tools.rs
@@ -2,10 +2,10 @@ use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::rc::Rc;
 
+use crate::llm::tools::{TEXT_TOOL_CALL_CLOSE, TEXT_TOOL_CALL_OPEN};
+use crate::schema::json_to_vm_value;
 use crate::value::{VmClosure, VmEnv, VmError, VmValue};
 use crate::vm::Vm;
-
-use crate::schema::json_to_vm_value;
 
 thread_local! {
     /// The tool registry bound to the current execution scope. Populated
@@ -713,14 +713,14 @@ pub(crate) fn register_tool_builtins(vm: &mut Vm) {
         let mut results = Vec::new();
         let mut search_from = 0;
 
-        while let Some(start) = text[search_from..].find("<tool_call>") {
-            let abs_start = search_from + start + "<tool_call>".len();
-            if let Some(end) = text[abs_start..].find("</tool_call>") {
+        while let Some(start) = text[search_from..].find(TEXT_TOOL_CALL_OPEN) {
+            let abs_start = search_from + start + TEXT_TOOL_CALL_OPEN.len();
+            if let Some(end) = text[abs_start..].find(TEXT_TOOL_CALL_CLOSE) {
                 let json_str = text[abs_start..abs_start + end].trim();
                 if let Ok(jv) = serde_json::from_str::<serde_json::Value>(json_str) {
                     results.push(json_to_vm_value(&jv));
                 }
-                search_from = abs_start + end + "</tool_call>".len();
+                search_from = abs_start + end + TEXT_TOOL_CALL_CLOSE.len();
             } else {
                 break;
             }
@@ -774,7 +774,9 @@ pub(crate) fn register_tool_builtins(vm: &mut Vm) {
 
         let mut prompt = String::from("# Available Tools\n\n");
         prompt.push_str("You have access to the following tools. To use a tool, output a tool call in this exact format:\n\n");
-        prompt.push_str("<tool_call>{\"name\": \"tool_name\", \"arguments\": {\"param\": \"value\"}}</tool_call>\n\n");
+        prompt.push_str(&format!(
+            "{TEXT_TOOL_CALL_OPEN}{{\"name\": \"tool_name\", \"arguments\": {{\"param\": \"value\"}}}}{TEXT_TOOL_CALL_CLOSE}\n\n"
+        ));
         prompt.push_str("You may make multiple tool calls in a single response. Wait for tool results before proceeding.\n\n");
         prompt.push_str("## Tools\n\n");
 

--- a/crates/harn-vm/src/tool_surface.rs
+++ b/crates/harn-vm/src/tool_surface.rs
@@ -8,6 +8,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use serde::{Deserialize, Serialize};
 
+use crate::llm::tools::text_tool_call_tag_pairs;
 use crate::orchestration::{CapabilityPolicy, ToolApprovalPolicy};
 use crate::tool_annotations::{SideEffectLevel, ToolAnnotations, ToolKind};
 use crate::value::VmValue;
@@ -591,29 +592,32 @@ fn validate_prompt_references(
         .chain(active_names.iter().cloned())
         .collect::<BTreeSet<_>>();
     for text in &input.prompt_texts {
-        for name in prompt_tool_references(text) {
-            if !known_names.contains(&name) && looks_like_tool_name(&name) {
+        let binding_text = prompt_binding_text(text);
+        let calls = prompt_tool_calls(&binding_text);
+        for call in &calls {
+            let name = call.name;
+            if !known_names.contains(name) && looks_like_tool_name(name) {
                 diagnostics.push(
                     ToolSurfaceDiagnostic::warning(
                         "TOOL_SURFACE_UNKNOWN_PROMPT_TOOL",
                         format!("prompt references tool '{name}' which is not active"),
                     )
-                    .with_tool(name.clone())
+                    .with_tool(name.to_string())
                     .with_field("prompt"),
                 );
                 continue;
             }
-            if known_names.contains(&name) && !active_names.contains(&name) {
+            if known_names.contains(name) && !active_names.contains(name) {
                 diagnostics.push(
                     ToolSurfaceDiagnostic::warning(
                         "TOOL_SURFACE_PROMPT_TOOL_NOT_IN_POLICY",
                         format!("prompt references tool '{name}' outside the active policy"),
                     )
-                    .with_tool(name.clone())
+                    .with_tool(name.to_string())
                     .with_field("prompt"),
                 );
             }
-            if deferred.contains(&name) && !input.tool_search_active {
+            if deferred.contains(name) && !input.tool_search_active {
                 diagnostics.push(
                     ToolSurfaceDiagnostic::warning(
                         "TOOL_SURFACE_DEFERRED_TOOL_PROMPT_REFERENCE",
@@ -621,7 +625,7 @@ fn validate_prompt_references(
                             "prompt references deferred tool '{name}' but tool_search is not active"
                         ),
                     )
-                    .with_tool(name.clone())
+                    .with_tool(name.to_string())
                     .with_field("prompt"),
                 );
             }
@@ -631,7 +635,10 @@ fn validate_prompt_references(
                 continue;
             };
             for (alias, canonical) in &annotations.arg_schema.arg_aliases {
-                if contains_token(text, alias) {
+                if calls
+                    .iter()
+                    .any(|call| call.name == entry.name && contains_token(call.text, alias))
+                {
                     diagnostics.push(
                         ToolSurfaceDiagnostic::warning(
                             "TOOL_SURFACE_DEPRECATED_ARG_ALIAS",
@@ -647,6 +654,107 @@ fn validate_prompt_references(
             }
         }
     }
+}
+
+struct PromptToolCall<'a> {
+    name: &'a str,
+    text: &'a str,
+}
+
+fn prompt_tool_calls(text: &str) -> Vec<PromptToolCall<'_>> {
+    let mut calls = Vec::new();
+    let bytes = text.as_bytes();
+    let mut i = 0usize;
+    while i < bytes.len() {
+        if let Some((open_tag, close_tag)) = text_tool_call_tag_pairs()
+            .into_iter()
+            .find(|(open_tag, _)| bytes[i..].starts_with(open_tag.as_bytes()))
+        {
+            let call_start = i;
+            i += open_tag.len();
+            while i < bytes.len() && bytes[i].is_ascii_whitespace() {
+                i += 1;
+            }
+            let name_start = i;
+            while i < bytes.len() && is_ident_byte(bytes[i]) {
+                i += 1;
+            }
+            if i > name_start {
+                let call_end = text[i..]
+                    .find(close_tag)
+                    .map(|offset| i + offset + close_tag.len())
+                    .unwrap_or(i);
+                calls.push(PromptToolCall {
+                    name: &text[name_start..i],
+                    text: &text[call_start..call_end],
+                });
+                i = call_end;
+            }
+            continue;
+        }
+
+        if !is_ident_start(bytes[i]) {
+            i += 1;
+            continue;
+        }
+
+        let start = i;
+        i += 1;
+        while i < bytes.len() && is_ident_byte(bytes[i]) {
+            i += 1;
+        }
+
+        let name = &text[start..i];
+        let mut j = i;
+        while j < bytes.len() && bytes[j].is_ascii_whitespace() {
+            j += 1;
+        }
+        if j < bytes.len() && bytes[j] == b'(' && !prompt_ref_stopword(name) {
+            let end = prompt_call_end(bytes, j);
+            calls.push(PromptToolCall {
+                name,
+                text: &text[start..end],
+            });
+            i = end;
+            continue;
+        }
+    }
+    calls
+}
+
+fn prompt_call_end(bytes: &[u8], open_index: usize) -> usize {
+    let mut depth = 0usize;
+    let mut quote = None;
+    let mut escaped = false;
+    let mut i = open_index;
+    while i < bytes.len() {
+        let byte = bytes[i];
+        if let Some(quote_byte) = quote {
+            if escaped {
+                escaped = false;
+            } else if byte == b'\\' {
+                escaped = true;
+            } else if byte == quote_byte {
+                quote = None;
+            }
+            i += 1;
+            continue;
+        }
+
+        match byte {
+            b'\'' | b'"' | b'`' => quote = Some(byte),
+            b'(' => depth += 1,
+            b')' => {
+                depth = depth.saturating_sub(1);
+                if depth == 0 {
+                    return i + 1;
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    bytes.len()
 }
 
 fn validate_side_effect_ceiling(
@@ -690,43 +798,10 @@ fn validate_side_effect_ceiling(
 
 pub fn prompt_tool_references(text: &str) -> BTreeSet<String> {
     let text = prompt_binding_text(text);
-    let mut names = BTreeSet::new();
-    let bytes = text.as_bytes();
-    let mut i = 0usize;
-    while i < bytes.len() {
-        if bytes[i..].starts_with(b"<tool_call>") {
-            i += "<tool_call>".len();
-            while i < bytes.len() && bytes[i].is_ascii_whitespace() {
-                i += 1;
-            }
-            let start = i;
-            while i < bytes.len() && is_ident_byte(bytes[i]) {
-                i += 1;
-            }
-            if i > start {
-                names.insert(text[start..i].to_string());
-            }
-            continue;
-        }
-        if is_ident_start(bytes[i]) {
-            let start = i;
-            i += 1;
-            while i < bytes.len() && is_ident_byte(bytes[i]) {
-                i += 1;
-            }
-            let name = &text[start..i];
-            let mut j = i;
-            while j < bytes.len() && bytes[j].is_ascii_whitespace() {
-                j += 1;
-            }
-            if j < bytes.len() && bytes[j] == b'(' && !prompt_ref_stopword(name) {
-                names.insert(name.to_string());
-            }
-            continue;
-        }
-        i += 1;
-    }
-    names
+    prompt_tool_calls(&text)
+        .into_iter()
+        .map(|call| call.name.to_string())
+        .collect()
 }
 
 fn prompt_binding_text(text: &str) -> String {
@@ -1031,9 +1106,102 @@ mod tests {
     }
 
     #[test]
+    fn deprecated_alias_warnings_are_scoped_to_matching_tool_calls() {
+        let mut edit_annotations = ToolAnnotations::default();
+        edit_annotations
+            .arg_schema
+            .arg_aliases
+            .insert("file".into(), "path".into());
+        let mut look_annotations = ToolAnnotations::default();
+        look_annotations
+            .arg_schema
+            .arg_aliases
+            .insert("path".into(), "file".into());
+
+        let report = validate_tool_surface(&ToolSurfaceInput {
+            native_tools: Some(vec![
+                serde_json::json!({
+                    "name": "edit",
+                    "parameters": {"type": "object"},
+                    "annotations": edit_annotations,
+                }),
+                serde_json::json!({
+                    "name": "look",
+                    "parameters": {"type": "object"},
+                    "annotations": look_annotations,
+                }),
+            ]),
+            prompt_texts: vec![
+                "Use edit({ path: \"src/main.rs\", action: \"replace\" }) before look({ file: \"src/main.rs\" }).".into(),
+            ],
+            ..ToolSurfaceInput::default()
+        });
+
+        assert!(!report
+            .diagnostics
+            .iter()
+            .any(|d| d.code == "TOOL_SURFACE_DEPRECATED_ARG_ALIAS"));
+    }
+
+    #[test]
+    fn deprecated_alias_warnings_still_report_matching_multiline_calls() {
+        let mut annotations = ToolAnnotations::default();
+        annotations
+            .arg_schema
+            .arg_aliases
+            .insert("file".into(), "path".into());
+
+        let report = validate_tool_surface(&ToolSurfaceInput {
+            native_tools: Some(vec![serde_json::json!({
+                "name": "edit",
+                "parameters": {"type": "object"},
+                "annotations": annotations,
+            })]),
+            prompt_texts: vec!["Use edit({\n  file: \"src/main.rs\"\n}) once.".into()],
+            ..ToolSurfaceInput::default()
+        });
+
+        assert!(report
+            .diagnostics
+            .iter()
+            .any(|d| d.code == "TOOL_SURFACE_DEPRECATED_ARG_ALIAS"));
+    }
+
+    #[test]
+    fn deprecated_alias_warnings_report_tagged_text_mode_calls() {
+        let mut annotations = ToolAnnotations::default();
+        annotations
+            .arg_schema
+            .arg_aliases
+            .insert("file".into(), "path".into());
+
+        let report = validate_tool_surface(&ToolSurfaceInput {
+            native_tools: Some(vec![serde_json::json!({
+                "name": "edit",
+                "parameters": {"type": "object"},
+                "annotations": annotations,
+            })]),
+            prompt_texts: vec!["<tool_call>\nedit({ file: \"src/main.rs\" })\n</tool_call>".into()],
+            ..ToolSurfaceInput::default()
+        });
+
+        assert!(report
+            .diagnostics
+            .iter()
+            .any(|d| d.code == "TOOL_SURFACE_DEPRECATED_ARG_ALIAS"));
+    }
+
+    #[test]
     fn prompt_reference_scanner_tolerates_non_ascii_text() {
         let references = prompt_tool_references("Résumé: use run_command({command: \"test\"})");
         assert!(references.contains("run_command"));
+    }
+
+    #[test]
+    fn prompt_reference_scanner_reads_tagged_text_mode_calls() {
+        let references =
+            prompt_tool_references("<tool_call>\nrun({ command: \"cargo test\" })\n</tool_call>");
+        assert!(references.contains("run"));
     }
 
     #[test]

--- a/crates/harn-vm/src/visible_text.rs
+++ b/crates/harn-vm/src/visible_text.rs
@@ -1,6 +1,10 @@
 use std::collections::BTreeSet;
 use std::sync::OnceLock;
 
+use crate::llm::tools::{
+    TEXT_TOOL_CALL_CLOSE, TEXT_TOOL_CALL_CLOSE_COMPACT, TEXT_TOOL_CALL_OPEN,
+    TEXT_TOOL_CALL_OPEN_COMPACT,
+};
 use regex::Regex;
 
 #[derive(Default, Clone, Debug, PartialEq, Eq)]
@@ -196,15 +200,15 @@ fn strip_unclosed_internal_blocks(text: &str) -> String {
         }
     }
 
-    if let Some(open_idx) = text.rfind("<tool_call>") {
-        let close_idx = text.rfind("</tool_call>");
+    if let Some(open_idx) = text.rfind(TEXT_TOOL_CALL_OPEN) {
+        let close_idx = text.rfind(TEXT_TOOL_CALL_CLOSE);
         if close_idx.is_none_or(|idx| idx < open_idx) {
             return text[..open_idx].to_string();
         }
     }
 
-    if let Some(open_idx) = text.rfind("<toolcall>") {
-        let close_idx = text.rfind("</toolcall>");
+    if let Some(open_idx) = text.rfind(TEXT_TOOL_CALL_OPEN_COMPACT) {
+        let close_idx = text.rfind(TEXT_TOOL_CALL_CLOSE_COMPACT);
         if close_idx.is_none_or(|idx| idx < open_idx) {
             return text[..open_idx].to_string();
         }
@@ -263,8 +267,8 @@ fn strip_inline_internal_planning_json(text: &str, partial: bool) -> String {
 fn strip_partial_marker_suffix(text: &str) -> String {
     const MARKERS: [&str; 13] = [
         "<|tool_call|>",
-        "<tool_call>",
-        "<toolcall>",
+        TEXT_TOOL_CALL_OPEN,
+        TEXT_TOOL_CALL_OPEN_COMPACT,
         "<assistant_prose>",
         "<assistantprose>",
         "<user_response>",


### PR DESCRIPTION
## Summary
- Scope deprecated-argument-alias prompt diagnostics to matching tool calls instead of scanning all prompt text globally.
- Consolidate text-mode tool-call XML markers into one shared Harn VM protocol module and reuse them across parsing, streaming detection, stdlib helpers, visible-text filtering, and tool-surface validation.
- Add focused coverage for native-style prompt calls and tagged text-mode prompt calls so alias warnings work in both modes without false positives across tools.

## Validation
- `cargo fmt --all --check`
- `CARGO_TARGET_DIR=/tmp/harn-target-main-alias-fix cargo test -p harn-vm tool_surface -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-main-alias-fix cargo test -p harn-vm tool_call -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-main-alias-fix cargo test -p harn-vm visible_text -- --nocapture`
- pre-commit hook: `cargo clippy --workspace --all-targets -- -D warnings`
- pre-push hook targeted checks
