### PR TITLE
Release v0.7.57

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,65 @@ Pre-0.6 highlights live in [CHANGELOG-pre-0.6.md](CHANGELOG-pre-0.6.md).
 Harn had no external users before 0.6.0, so that archive intentionally keeps
 condensed series summaries instead of full per-patch history.
 
-## Unreleased
+## v0.7.57
 
 ### Added
 
-- **Generic `agent_turn` wrapper and sentinel judge.** New
-  `agent_turn(prompt, opts?)` wraps the common single-request agent shape with
-  generic progress guidance, a persistent completion sentinel, mandatory
-  sentinel judging, and compact `iterations` / `judge_decisions` summaries.
-  `agent_loop` also accepts `done_judge: true` or a policy dict to run the
-  same structured judge only after the done sentinel is emitted.
+- **Persona orchestration prelude.** New `std/personas/prelude` helpers provide reusable,
+  receipt-friendly workflow patterns: `verify_then_act`, `bounded_loop`,
+  `cheap_classify_then_escalate`, `parallel_sweep_with_circuit_breaker`,
+  `with_audit_receipt`, and `with_approval_gate`. The helpers share a structured
+  `{ok, status, result, error, receipt}` envelope and are documented in
+  `docs/src/personas/prelude.md`.
+- **A2A push notification auth.** The A2A adapter now verifies inbound push webhooks and can
+  register authenticated outbound push callbacks. Supported callback schemes include Bearer,
+  Basic, API key, OAuth2 client credentials, OpenID Connect ID tokens with JWKS validation,
+  and mTLS.
+- **MCP resource subscriptions.** Harn MCP servers now advertise and handle
+  `resources/subscribe` and `resources/unsubscribe`, including subscription tracking and
+  update notifications for resource-aware clients.
+- **Generic `agent_turn` wrapper and sentinel judge.** New `agent_turn(prompt, opts?)`
+  wraps the single-turn agent pattern with progress guidance, completion-sentinel judging,
+  and compact iteration/judge summaries. `agent_loop` also accepts `done_judge: true` or a
+  judge policy dict.
+- **Type-aware `unnecessary-safe-navigation` diagnostics.** The typechecker now warns and
+  offers fixes when `?.`, `?.method(...)`, or `?[]` is used on a receiver known to be
+  non-optional.
+- **List literals in ternary branches.** Ternary arms can now be list literals without
+  extra grouping, e.g. `condition ? [a, b] : [c]`.
+- **`unnecessary-parentheses` lint.** `harn lint` now warns on parentheses around a single
+  value expression when those parentheses are not required by call, declaration, or
+  precedence context.
+
+### Changed
+
+- **Unified static and runtime typechecking.** Builtin signatures now flow through one
+  parser-side registry for static checks and VM call-boundary validation. This tightens
+  arity/type behavior and removes legacy drift between compile-time and runtime errors; code
+  that relied on missing arguments being silently treated as `nil` should make defaults
+  explicit.
+- **Canonical `harn-stdlib` crate.** Standard-library `.harn` sources moved out of
+  `harn-modules` into a new dependency-free `crates/harn-stdlib` catalog crate. Public
+  `std/...` imports continue to resolve, while `harn-modules` and `harn-vm` delegate source
+  lookup to the shared catalog.
+- **ACP agent event coverage.** Agent loop lifecycle events such as `BudgetExhausted`,
+  `LoopStuck`, and `DaemonWatchdogTripped` are now bridged as `_harn/agentEvent`
+  `ExtNotification`s with advertised capability metadata.
+- **CI sweep placement.** Heavy flake-detection and thread-parity sweeps moved off the PR
+  path to scheduled/manual workflows, while the retained PR checks keep the faster smoke and
+  portability coverage.
+
+### Fixed
+
+- **Tool-surface alias warnings.** Deprecated argument alias diagnostics are scoped to the
+  matching tool call instead of scanning all prompt text, eliminating false positives across
+  unrelated tool surfaces.
+- **Release binary workflow idempotency.** `build-release-binaries.yml` now runs on tag push
+  or manual dispatch and checks existing release assets/container tags before rebuilding,
+  with a `force_rebuild` escape hatch for recovery.
+- **Windows and generated-text portability in CI.** The release-window CI changes also fixed
+  path separator, CRLF, and generated text comparison issues in the retained Windows smoke
+  and spec sync jobs.
 
 ## v0.7.56
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1684,7 +1684,7 @@ dependencies = [
 
 [[package]]
 name = "harn-cli"
-version = "0.7.56"
+version = "0.7.57"
 dependencies = [
  "async-trait",
  "axum",
@@ -1737,7 +1737,7 @@ dependencies = [
 
 [[package]]
 name = "harn-dap"
-version = "0.7.56"
+version = "0.7.57"
 dependencies = [
  "harn-modules",
  "harn-parser",
@@ -1750,7 +1750,7 @@ dependencies = [
 
 [[package]]
 name = "harn-fmt"
-version = "0.7.56"
+version = "0.7.57"
 dependencies = [
  "harn-lexer",
  "harn-parser",
@@ -1758,7 +1758,7 @@ dependencies = [
 
 [[package]]
 name = "harn-hostlib"
-version = "0.7.56"
+version = "0.7.57"
 dependencies = [
  "anyhow",
  "base64",
@@ -1809,7 +1809,7 @@ dependencies = [
 
 [[package]]
 name = "harn-ir"
-version = "0.7.56"
+version = "0.7.57"
 dependencies = [
  "harn-lexer",
  "harn-parser",
@@ -1817,11 +1817,11 @@ dependencies = [
 
 [[package]]
 name = "harn-lexer"
-version = "0.7.56"
+version = "0.7.57"
 
 [[package]]
 name = "harn-lint"
-version = "0.7.56"
+version = "0.7.57"
 dependencies = [
  "harn-lexer",
  "harn-modules",
@@ -1831,7 +1831,7 @@ dependencies = [
 
 [[package]]
 name = "harn-lsp"
-version = "0.7.56"
+version = "0.7.57"
 dependencies = [
  "harn-fmt",
  "harn-ir",
@@ -1845,7 +1845,7 @@ dependencies = [
 
 [[package]]
 name = "harn-modules"
-version = "0.7.56"
+version = "0.7.57"
 dependencies = [
  "croner",
  "harn-lexer",
@@ -1858,7 +1858,7 @@ dependencies = [
 
 [[package]]
 name = "harn-parser"
-version = "0.7.56"
+version = "0.7.57"
 dependencies = [
  "harn-lexer",
  "yansi",
@@ -1866,7 +1866,7 @@ dependencies = [
 
 [[package]]
 name = "harn-serve"
-version = "0.7.56"
+version = "0.7.57"
 dependencies = [
  "async-trait",
  "axum",
@@ -1895,11 +1895,11 @@ dependencies = [
 
 [[package]]
 name = "harn-stdlib"
-version = "0.7.56"
+version = "0.7.57"
 
 [[package]]
 name = "harn-vm"
-version = "0.7.56"
+version = "0.7.57"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = ["crates/harn-wasm"]
 resolver = "2"
 
 [workspace.package]
-version = "0.7.56"
+version = "0.7.57"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/burin-labs/harn"


### PR DESCRIPTION
Release v0.7.57

This PR was prepared by `release_harn.harn` from a fresh release snapshot.
The harness verified this branch already had the target Cargo version, release branch name, and top CHANGELOG entry before the PR handoff.

## Post-prepare summary

- Version: `0.7.56` -> `0.7.57`
- Branch: `release/v0.7.57` targeting `main`
- Latest tag used for release delta: `v0.7.56`
- Changed files: `CHANGELOG.md, Cargo.lock, Cargo.toml`
- Deterministic findings: none

## Changelog section

```markdown
### Added

- **Persona orchestration prelude.** New `std/personas/prelude` helpers provide reusable,
  receipt-friendly workflow patterns: `verify_then_act`, `bounded_loop`,
  `cheap_classify_then_escalate`, `parallel_sweep_with_circuit_breaker`,
  `with_audit_receipt`, and `with_approval_gate`. The helpers share a structured
  `{ok, status, result, error, receipt}` envelope and are documented in
  `docs/src/personas/prelude.md`.
- **A2A push notification auth.** The A2A adapter now verifies inbound push webhooks and can
  register authenticated outbound push callbacks. Supported callback schemes include Bearer,
  Basic, API key, OAuth2 client credentials, OpenID Connect ID tokens with JWKS validation,
  and mTLS.
- **MCP resource subscriptions.** Harn MCP servers now advertise and handle
  `resources/subscribe` and `resources/unsubscribe`, including subscription tracking and
  update notifications for resource-aware clients.
- **Generic `agent_turn` wrapper and sentinel judge.** New `agent_turn(prompt, opts?)`
  wraps the single-turn agent pattern with progress guidance, completion-sentinel judging,
  and compact iteration/judge summaries. `agent_loop` also accepts `done_judge: true` or a
  judge policy dict.
- **Type-aware `unnecessary-safe-navigation` diagnostics.** The typechecker now warns and
  offers fixes when `?.`, `?.method(...)`, or `?[]` is used on a receiver known to be
  non-optional.
- **List literals in ternary branches.** Ternary arms can now be list literals without
  extra grouping, e.g. `condition ? [a, b] : [c]`.
- **`unnecessary-parentheses` lint.** `harn lint` now warns on parentheses around a single
  value expression when those parentheses are not required by call, declaration, or
  precedence context.

### Changed

- **Unified static and runtime typechecking.** Builtin signatures now flow through one
  parser-side registry for static checks and VM call-boundary validation. This tightens
  arity/type behavior and removes legacy drift between compile-time and runtime errors; code
  that relied on missing arguments being silently treated as `nil` should make defaults
  explicit.
- **Canonical `harn-stdlib` crate.** Standard-library `.harn` sources moved out of
  `harn-modules` into a new dependency-free `crates/harn-stdlib` catalog crate. Public
  `std/...` imports continue to resolve, while `harn-modules` and `harn-vm` delegate source
  lookup to the shared catalog.
- **ACP agent event coverage.** Agent loop lifecycle events such as `BudgetExhausted`,
  `LoopStuck`, and `DaemonWatchdogTripped` are now bridged as `_harn/agentEvent`
  `ExtNotification`s with advertised capability metadata.
- **CI sweep placement.** Heavy flake-detection and thread-parity sweeps moved off the PR
  path to scheduled/manual workflows, while the retained PR checks keep the faster smoke and
  portability coverage.

### Fixed

- **Tool-surface alias warnings.** Deprecated argument alias diagnostics are scoped to the
  matching tool call instead of scanning all prompt text, eliminating false positives across
  unrelated tool surfaces.
- **Release binary workflow idempotency.** `build-release-binaries.yml` now runs on tag push
  or manual dispatch and checks existing release assets/container tags before rebuilding,
  with a `force_rebuild` escape hatch for recovery.
- **Windows and generated-text portability in CI.** The release-window CI changes also fixed
  path separator, CRLF, and generated text comparison issues in the retained Windows smoke
  and spec sync jobs.
```

## Commits covered

```text
6e603077 (HEAD -> release/v0.7.57, origin/release/v0.7.57) Release v0.7.57
549ea6aa (origin/main, origin/HEAD, main) Scope tool-surface alias prompt warnings (#1196)
cd658348 [codex] Make release binary workflow idempotent (#1195)
6ae6c2de [codex] Add type-aware safe-navigation lint (#1194)
597e21d0 Add persona orchestration prelude (#1192)
22391225 [codex] Support list ternary branches (#1193)
b50671d0 Add generic agent turn judge (#1191)
ebc484c7 [codex] Move heavy CI sweeps off PR path (#1190)
1b8dea6a [codex] Add canonical harn-stdlib catalog (#1189)
f18c4bae [codex] Implement A2A push auth schemes (#1187)
c93f63b0 Implement MCP resource subscriptions (#1188)
4e2f2223 [codex] Unify static and runtime typechecking (#1184)
```

## Execution transcript

| Step | Status | Classification |
|------|--------|----------------|
| `prepare-already-complete` | ok | `ok` |
| `commit-already-complete` | ok | `ok` |
| `fetch-base` | ok | `ok` |
| `rebase-base` | ok | `ok` |
| `push-already-complete` | ok | `ok` |
| `find-existing-pr` | ok | `ok` |
| `refresh-existing-pr-body` | ok | `ok` |
| `auto-merge` | ok | `ok` |

## Agent artifacts

- Audit JSONL transcript: `not generated`
- Draft changelog: ``
- Agent validation findings: none

Generated by `release_harn.harn`.
