### PR TITLE
Make publish release recovery tag-aware

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -21,12 +21,16 @@ name: Publish release
 # version to '" trigger) means this workflow auto-recovers when an
 # earlier finalize run failed BEFORE pushing the tag. Any subsequent
 # push to main will see drift still present and re-run publish. Once
-# the tag exists at HEAD, drift goes away and the job no-ops.
+# the latest tag matches Cargo.toml's workspace version, drift goes
+# away and push-triggered runs no-op.
 #
 # workflow_dispatch is the recovery path for the one residual case:
 # failure AFTER tag push but BEFORE crates.io publish completed (drift
-# is gone but publish state is partial). release_ship.sh's per-crate
-# fallback skips already-published, so manual re-fire is idempotent.
+# is gone but publish state is partial). Manual recovery checks out the
+# existing release tag when there is no drift, so crates.io, release
+# notes, and the git tag all stay tied to the same commit even if main
+# has moved on. release_ship.sh's per-crate fallback skips
+# already-published, so manual re-fire is idempotent.
 on:
   push:
     branches: [main]
@@ -78,6 +82,7 @@ jobs:
       drift: ${{ steps.check.outputs.drift }}
       cargo_version: ${{ steps.check.outputs.cargo_version }}
       latest_tag: ${{ steps.check.outputs.latest_tag }}
+      publish_ref: ${{ steps.check.outputs.publish_ref }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -103,10 +108,16 @@ jobs:
             DRIFT=false
             echo "::notice::Cargo.toml=$CARGO_VERSION matches latest tag $LATEST_TAG → no-op."
           fi
+          PUBLISH_REF=main
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "$DRIFT" == "false" && -n "$LATEST_TAG" ]]; then
+            PUBLISH_REF="$LATEST_TAG"
+            echo "::notice::Manual recovery has no tag drift; publishing from existing tag $LATEST_TAG instead of current main."
+          fi
           {
             echo "drift=$DRIFT"
             echo "cargo_version=$CARGO_VERSION"
             echo "latest_tag=$LATEST_TAG"
+            echo "publish_ref=$PUBLISH_REF"
           } >> "$GITHUB_OUTPUT"
 
   publish:
@@ -136,6 +147,17 @@ jobs:
           # Persist the App token in .git/config so the later `git push`
           # in release_ship.sh --finalize uses it for the tag push.
           token: ${{ steps.app-token.outputs.token }}
+
+      - name: Select publish ref
+        run: |
+          set -euo pipefail
+          cp scripts/release_ship.sh "$RUNNER_TEMP/release_ship.sh"
+          publish_ref="${{ needs.detect-drift.outputs.publish_ref }}"
+          if [[ "$publish_ref" != "main" ]]; then
+            git fetch --force --tags origin
+            git switch --detach "$publish_ref"
+          fi
+          echo "Publishing from $(git rev-parse --short HEAD) ($publish_ref)"
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
@@ -209,4 +231,4 @@ jobs:
           if [[ "${{ inputs.skip_dry_run }}" == "true" ]]; then
             args+=(--skip-dry-run)
           fi
-          ./scripts/release_ship.sh "${args[@]}"
+          HARN_RELEASE_ROOT="$PWD" bash "$RUNNER_TEMP/release_ship.sh" "${args[@]}"

--- a/scripts/release_ship.sh
+++ b/scripts/release_ship.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT_DIR="${HARN_RELEASE_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 cd "$ROOT_DIR"
 
 # ── Timing instrumentation ──────────────────────────────────────────────
@@ -131,6 +131,12 @@ FINALIZE MODE
   5. Renders changelog-backed release notes.
   6. Creates/updates a GitHub release with the rendered notes.
 
+  Manual recovery after a tag was already pushed may run from a
+  detached HEAD at vX.Y.Z. In that case finalize skips the main
+  fast-forward check and publishes the already-tagged commit, keeping
+  crates.io content, release notes, and the tag aligned even if main
+  has moved on.
+
   Set RELEASE_FINALIZE_REAUDIT=1 (or pass --reaudit) to opt back into
   the full release-gate audit before finalizing — useful when running
   --finalize locally after manual repo edits.
@@ -254,6 +260,30 @@ sync_base_branch() {
     echo "hint: re-trigger publish-release.yml — it'll detect drift for the new version"
     exit 1
   fi
+}
+
+require_existing_release_tag_checkout() {
+  local version="$1"
+  local tag="v$version"
+  local branch
+  branch="$(git branch --show-current)"
+  if [[ -n "$branch" ]]; then
+    echo "error: release_ship.sh --finalize must run from $BASE_BRANCH or detached at $tag; current branch is $branch"
+    exit 1
+  fi
+  if ! git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
+    echo "error: release_ship.sh --finalize is detached, but $tag does not exist locally"
+    exit 1
+  fi
+  local tag_commit head_commit
+  tag_commit="$(git rev-list -n 1 "$tag")"
+  head_commit="$(git rev-parse HEAD)"
+  if [[ "$tag_commit" != "$head_commit" ]]; then
+    echo "error: release_ship.sh --finalize is detached at $head_commit, but $tag points to $tag_commit"
+    echo "hint: checkout $BASE_BRANCH for a normal finalize, or checkout $tag for manual tag-publish recovery"
+    exit 1
+  fi
+  echo "Finalize recovery from existing tag $tag at $head_commit"
 }
 
 require_release_branch() {
@@ -573,7 +603,11 @@ if [[ "$MODE" == "prepare-here" ]]; then
 elif [[ "$MODE" == "finalize" ]]; then
   require_clean_tree
   EXPECTED_VERSION="$(current_version)"
-  sync_base_branch "$BASE_BRANCH"
+  if [[ "$(git branch --show-current)" == "$BASE_BRANCH" ]]; then
+    sync_base_branch "$BASE_BRANCH"
+  else
+    require_existing_release_tag_checkout "$EXPECTED_VERSION"
+  fi
   # Trust the merge-queue CI by default; opt-in re-audit via env var or
   # --reaudit flag.
   if [[ "${RELEASE_FINALIZE_REAUDIT:-0}" != "1" ]]; then


### PR DESCRIPTION
## Summary
- publish manual no-drift recovery from the existing release tag instead of current main
- keep the fixed release automation script from main while switching the workspace to the tag for publishing
- allow release_ship.sh --finalize from a detached existing release tag

## Verification
- bash -n scripts/release_ship.sh
- actionlint .github/workflows/publish-release.yml
- make lint-actions
- git diff --check
- simulated workflow_dispatch no-drift publish_ref selection
- simulated clean detached v0.7.57 worktree guard conditions