### PR TITLE
[codex] Preserve rich native tool schemas

### DIFF
--- a/crates/harn-vm/src/llm/tools/json_schema.rs
+++ b/crates/harn-vm/src/llm/tools/json_schema.rs
@@ -178,17 +178,16 @@ pub(super) fn vm_build_json_schema(
 
     if let Some(params) = params {
         for (name, type_val) in params {
-            let type_str = type_val.display();
-            let json_type = match type_str.as_str() {
-                "int" | "integer" => "integer",
-                "float" | "number" => "number",
-                "bool" | "boolean" => "boolean",
-                "list" | "array" => "array",
-                "dict" | "object" => "object",
-                _ => "string",
-            };
-            properties.insert(name.clone(), serde_json::json!({"type": json_type}));
-            required.push(serde_json::Value::String(name.clone()));
+            let (mut schema, is_required) = vm_param_to_json_schema(type_val);
+            if let Some(obj) = schema.as_object_mut() {
+                if matches!(obj.get("required"), Some(serde_json::Value::Bool(_))) {
+                    obj.remove("required");
+                }
+            }
+            properties.insert(name.clone(), schema);
+            if is_required {
+                required.push(serde_json::Value::String(name.clone()));
+            }
         }
     }
 
@@ -198,4 +197,66 @@ pub(super) fn vm_build_json_schema(
         "required": required,
         "additionalProperties": false,
     })
+}
+
+fn vm_param_to_json_schema(value: &VmValue) -> (serde_json::Value, bool) {
+    match value {
+        VmValue::String(type_name) => (
+            serde_json::json!({"type": harn_type_to_json_schema(type_name)}),
+            true,
+        ),
+        VmValue::Dict(dict) => {
+            let mut json = super::super::vm_value_to_json(value);
+            normalize_json_schema_types(&mut json);
+            let is_required = dict
+                .get("required")
+                .and_then(|value| match value {
+                    VmValue::Bool(required) => Some(*required),
+                    _ => None,
+                })
+                .unwrap_or(true)
+                && !dict.contains_key("default");
+            (json, is_required)
+        }
+        _ => (serde_json::json!({"type": "string"}), true),
+    }
+}
+
+fn normalize_json_schema_types(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::Object(obj) => {
+            if let Some(serde_json::Value::String(kind)) = obj.get_mut("type") {
+                *kind = harn_type_to_json_schema(kind).to_string();
+            }
+            if let Some(serde_json::Value::Array(values)) = obj.get_mut("type") {
+                for value in values {
+                    if let serde_json::Value::String(kind) = value {
+                        *kind = harn_type_to_json_schema(kind).to_string();
+                    }
+                }
+            }
+            for child in obj.values_mut() {
+                normalize_json_schema_types(child);
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for item in items {
+                normalize_json_schema_types(item);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn harn_type_to_json_schema(harn_type: &str) -> &str {
+    match harn_type {
+        "str" | "string" => "string",
+        "int" | "integer" => "integer",
+        "long" | "float" | "double" | "number" => "number",
+        "bool" | "boolean" => "boolean",
+        "nil" | "null" | "none" => "null",
+        "list" | "array" | "unknown[]" => "array",
+        "dict" | "map" | "object" => "object",
+        _ => "string",
+    }
 }

--- a/crates/harn-vm/src/llm/tools/tests/native_tools.rs
+++ b/crates/harn-vm/src/llm/tools/tests/native_tools.rs
@@ -1,6 +1,6 @@
 use super::{
     apply_tool_search_native_injection, defer_loading_registry, extract_deferred_tool_names, json,
-    vm_bool, vm_dict, vm_list, vm_str, vm_tools_to_native,
+    sample_tool_registry, vm_bool, vm_dict, vm_list, vm_str, vm_tools_to_native,
 };
 use std::collections::BTreeMap;
 use std::rc::Rc;
@@ -80,6 +80,123 @@ fn vm_tools_to_native_emits_defer_loading_for_openai_compat() {
             .get("defer_loading")
             .and_then(|value| value.as_bool()),
         Some(true)
+    );
+}
+
+#[test]
+fn vm_tools_to_native_preserves_rich_parameter_schema_for_openai_compat() {
+    let registry = sample_tool_registry();
+    let tools = vm_tools_to_native(&registry, "openai").expect("openai native tools");
+    let edit = tools
+        .iter()
+        .find(|tool| {
+            tool.get("function")
+                .and_then(|function| function.get("name"))
+                .and_then(|value| value.as_str())
+                == Some("edit")
+        })
+        .expect("edit tool present");
+
+    let parameters = &edit["function"]["parameters"];
+    let properties = parameters["properties"]
+        .as_object()
+        .expect("properties object");
+
+    assert_eq!(properties["action"]["type"].as_str(), Some("string"));
+    assert_eq!(
+        properties["action"]["enum"],
+        json!(["create", "patch", "replace_body"])
+    );
+    assert_eq!(
+        properties["path"]["description"].as_str(),
+        Some("Repo-relative path.")
+    );
+    assert_eq!(properties["ops"]["type"].as_str(), Some("array"));
+    assert_eq!(properties["content"]["type"].as_str(), Some("string"));
+    assert!(
+        properties["content"].get("required").is_none(),
+        "per-property Harn `required` marker must not leak into JSON Schema"
+    );
+    assert_eq!(parameters["required"], json!(["action", "path"]));
+}
+
+#[test]
+fn vm_tools_to_native_normalizes_nested_harn_type_aliases() {
+    let mut params = BTreeMap::new();
+    params.insert(
+        "filters".to_string(),
+        vm_dict(&[
+            ("type", vm_str("dict")),
+            (
+                "properties",
+                vm_dict(&[
+                    ("enabled", vm_dict(&[("type", vm_str("bool"))])),
+                    (
+                        "scores",
+                        vm_dict(&[
+                            ("type", vm_str("list")),
+                            ("items", vm_dict(&[("type", vm_str("int"))])),
+                        ]),
+                    ),
+                ]),
+            ),
+        ]),
+    );
+    let tool = vm_dict(&[
+        ("name", vm_str("rank")),
+        ("description", vm_str("Rank results")),
+        ("parameters", super::VmValue::Dict(Rc::new(params))),
+    ]);
+    let registry = vm_list(vec![tool]);
+
+    let tools = vm_tools_to_native(&registry, "openai").expect("openai native tools");
+    let filters = &tools[0]["function"]["parameters"]["properties"]["filters"];
+    assert_eq!(filters["type"].as_str(), Some("object"));
+    assert_eq!(
+        filters["properties"]["enabled"]["type"].as_str(),
+        Some("boolean")
+    );
+    assert_eq!(
+        filters["properties"]["scores"]["type"].as_str(),
+        Some("array")
+    );
+    assert_eq!(
+        filters["properties"]["scores"]["items"]["type"].as_str(),
+        Some("integer")
+    );
+}
+
+#[test]
+fn vm_tools_to_native_preserves_json_schema_required_arrays() {
+    let mut params = BTreeMap::new();
+    params.insert(
+        "payload".to_string(),
+        vm_dict(&[
+            ("type", vm_str("dict")),
+            (
+                "properties",
+                vm_dict(&[
+                    ("id", vm_dict(&[("type", vm_str("str"))])),
+                    ("count", vm_dict(&[("type", vm_str("int"))])),
+                ]),
+            ),
+            ("required", vm_list(vec![vm_str("id")])),
+        ]),
+    );
+    let tool = vm_dict(&[
+        ("name", vm_str("submit")),
+        ("description", vm_str("Submit payload")),
+        ("parameters", super::VmValue::Dict(Rc::new(params))),
+    ]);
+    let registry = vm_list(vec![tool]);
+
+    let tools = vm_tools_to_native(&registry, "openai").expect("openai native tools");
+    let payload = &tools[0]["function"]["parameters"]["properties"]["payload"];
+    assert_eq!(payload["type"].as_str(), Some("object"));
+    assert_eq!(payload["required"], json!(["id"]));
+    assert_eq!(
+        payload["properties"]["count"]["type"].as_str(),
+        Some("integer")
     );
 }
 


### PR DESCRIPTION
## Summary
- preserve rich VmValue tool parameter schemas when building native provider payloads
- keep descriptions, enums, defaults, optional markers, and nested JSON Schema metadata instead of collapsing dict schemas to strings
- normalize Harn type aliases recursively for OpenAI-compatible native schemas

## Root Cause
Native provider payloads were built through a separate path from transcript/tool-schema logging. The transcript path preserved rich schemas, but vm_tools_to_native collapsed dict parameter definitions through display(), which marked optional params as required and turned structured params into string schemas.

## Validation
- cargo fmt --package harn-vm
- CARGO_TARGET_DIR=/tmp/harn-target-tool-schema cargo test -p harn-vm llm::tools::tests::native_tools -- --nocapture
- CARGO_TARGET_DIR=/tmp/harn-target-tool-schema cargo test -p harn-vm llm::tools::tests -- --nocapture
- pre-commit clippy hook
- pre-push targeted local checks