### PR TITLE
[codex] Tighten local-model tool protocol handling

### DIFF
--- a/crates/harn-stdlib/src/stdlib/agent/prompts/tool_contract_text_response_protocol.harn.prompt
+++ b/crates/harn-stdlib/src/stdlib/agent/prompts/tool_contract_text_response_protocol.harn.prompt
@@ -24,12 +24,14 @@ Final user-facing answer. Required when no more tool calls are needed.
 - `<user_response>` is reserved for the final user-facing answer that hosts should surface. Emit it when the user should see a wrap-up or answer, and keep it concise and grounded.
 {{ if done_sentinel }}- `<done>{{ done_sentinel }}</done>` signals task completion. Emit it only after a successful verifying tool call; the runtime rejects it otherwise.
 {{ end }}- Do not prefix calls with labels like `tool_code:`, `python:`, `shell:`, or any language tag, and do not wrap tool calls in Markdown fences.
+{{ if done_sentinel }}- Do not write `<tool_call>{{ done_sentinel }}</tool_call>`; completion sentinels are only valid in `<done>...</done>`.
+{{ end }}
+- Never emit another `<tool_call>` after `<user_response>`. Use `<user_response>` only when the turn is ready to yield a final user-facing answer.
 - {{ if done_sentinel }}Prefer `<tool_call>` over `<assistant_prose>` while work remains. Once no more tool calls are needed, emit `<user_response>...</user_response>` and then `<done>{{ done_sentinel }}</done>`.{{ else }}Once the request is satisfied and no more tool calls are needed, emit `<user_response>...</user_response>` with the final answer and do not include any `<tool_call>` block; that signals completion.{{ end }}
 
-Example of a well-formed response:
+Example tool response:
 
 <assistant_prose>Creating the test file.</assistant_prose>
-<user_response>Created the test file.</user_response>
 <tool_call>
 edit({ action: "create", path: "tests/test_foo.py", content: <<EOF
 def test_foo():
@@ -37,3 +39,9 @@ def test_foo():
 EOF
 })
 </tool_call>
+
+Example final response:
+
+<user_response>Created the test file and verified it.</user_response>
+{{ if done_sentinel }}<done>{{ done_sentinel }}</done>
+{{ end }}

--- a/crates/harn-vm/src/llm/agent/llm_call.rs
+++ b/crates/harn-vm/src/llm/agent/llm_call.rs
@@ -466,27 +466,10 @@ pub(super) async fn run_llm_call(
         );
     }
     if should_inject_protocol_feedback {
-        let done_line = if ctx.done_sentinel.is_empty() {
-            String::new()
-        } else {
-            format!("<done>{}</done>\n", ctx.done_sentinel)
-        };
-        let mut bindings = BTreeMap::new();
-        bindings.insert(
-            "violations".to_string(),
-            VmValue::String(Rc::from(protocol_violations.join("\n- "))),
+        let feedback = crate::llm::tools::text_response_protocol_repair_feedback(
+            &protocol_violations,
+            ctx.done_sentinel,
         );
-        bindings.insert(
-            "done_line".to_string(),
-            VmValue::String(Rc::from(done_line)),
-        );
-        let feedback = crate::stdlib::template::render_stdlib_prompt_asset(
-            "agent/prompts/protocol_violation_feedback.harn.prompt",
-            Some(&bindings),
-        )
-        .unwrap_or_else(|error| {
-            format!("protocol violation feedback prompt render error: {error}")
-        });
         append_message_to_contexts(
             &mut state.visible_messages,
             &mut state.recorded_messages,

--- a/crates/harn-vm/src/llm/api/context_window.rs
+++ b/crates/harn-vm/src/llm/api/context_window.rs
@@ -114,7 +114,10 @@ async fn fetch_ollama_context_window(model: &str, base_url: &str) -> Option<usiz
     {
         return Some(n as usize);
     }
-    Some(super::ollama::ollama_runtime_settings_from_env().num_ctx as usize)
+    Some(
+        super::ollama::OllamaRuntimeSettings::from_env_overrides_and_model(None, Some(model))
+            .num_ctx as usize,
+    )
 }
 
 /// Fetch context window from an OpenAI-compatible `/models` endpoint.

--- a/crates/harn-vm/src/llm/api/ollama.rs
+++ b/crates/harn-vm/src/llm/api/ollama.rs
@@ -103,9 +103,14 @@ impl OllamaRuntimeSettings {
     }
 
     pub fn from_env_and_overrides(overrides: Option<&Value>) -> Self {
+        Self::from_env_overrides_and_model(overrides, None)
+    }
+
+    pub fn from_env_overrides_and_model(overrides: Option<&Value>, model: Option<&str>) -> Self {
         Self {
             num_ctx: num_ctx_from_overrides(overrides)
                 .or_else(num_ctx_from_env)
+                .or_else(|| num_ctx_from_model_catalog(model))
                 .unwrap_or(OLLAMA_DEFAULT_NUM_CTX),
             keep_alive: keep_alive_from_overrides(overrides)
                 .or_else(keep_alive_from_env)
@@ -140,7 +145,7 @@ pub(crate) fn ollama_unload_grace_duration_from_env() -> Duration {
 }
 
 pub async fn warm_ollama_model(model: &str, base_url: Option<&str>) -> Result<(), String> {
-    let settings = OllamaRuntimeSettings::from_env();
+    let settings = OllamaRuntimeSettings::from_env_overrides_and_model(None, Some(model));
     warm_ollama_model_with_settings(model, base_url, &settings).await
 }
 
@@ -174,6 +179,7 @@ pub(crate) fn apply_ollama_runtime_settings(body: &mut Value, overrides: Option<
     if explicit_num_ctx.is_some() || body.pointer("/options/num_ctx").is_none() {
         let num_ctx = explicit_num_ctx
             .or_else(num_ctx_from_env)
+            .or_else(|| num_ctx_from_model_catalog(body.get("model").and_then(Value::as_str)))
             .unwrap_or(OLLAMA_DEFAULT_NUM_CTX);
         ensure_options_object(body).insert("num_ctx".to_string(), serde_json::json!(num_ctx));
     }
@@ -206,6 +212,15 @@ fn num_ctx_from_env() -> Option<u64> {
     OLLAMA_NUM_CTX_ENV_KEYS
         .iter()
         .find_map(|key| std::env::var(key).ok().and_then(|raw| parse_num_ctx(&raw)))
+}
+
+fn num_ctx_from_model_catalog(model: Option<&str>) -> Option<u64> {
+    let model = model?.trim();
+    if model.is_empty() {
+        return None;
+    }
+    let entry = crate::llm_config::model_catalog_entry(model)?;
+    (entry.context_window > 0).then_some(entry.context_window)
 }
 
 fn keep_alive_from_env() -> Option<Value> {
@@ -694,6 +709,49 @@ mod tests {
     }
 
     #[test]
+    fn runtime_settings_use_catalog_context_after_env_and_overrides() {
+        let _guard = env_lock().lock().expect("env lock");
+        let _env = [
+            ScopedEnvVar::remove("HARN_OLLAMA_NUM_CTX"),
+            ScopedEnvVar::remove("OLLAMA_CONTEXT_LENGTH"),
+            ScopedEnvVar::remove("OLLAMA_NUM_CTX"),
+            ScopedEnvVar::remove("HARN_OLLAMA_KEEP_ALIVE"),
+            ScopedEnvVar::remove("OLLAMA_KEEP_ALIVE"),
+        ];
+        crate::llm_config::clear_user_overrides();
+        let mut overlay = crate::llm_config::ProvidersConfig::default();
+        overlay.models.insert(
+            "qwen-test".to_string(),
+            crate::llm_config::ModelDef {
+                name: "Qwen Test".to_string(),
+                provider: "ollama".to_string(),
+                context_window: 100_000,
+                stream_timeout: None,
+                capabilities: vec![],
+                pricing: None,
+            },
+        );
+        crate::llm_config::set_user_overrides(Some(overlay));
+
+        let settings = OllamaRuntimeSettings::from_env_overrides_and_model(None, Some("qwen-test"));
+        assert_eq!(settings.num_ctx, 100_000);
+
+        let env = ScopedEnvVar::set("HARN_OLLAMA_NUM_CTX", "65536");
+        let settings = OllamaRuntimeSettings::from_env_overrides_and_model(None, Some("qwen-test"));
+        assert_eq!(settings.num_ctx, 65_536);
+        drop(env);
+
+        let overrides = serde_json::json!({"num_ctx": 8192});
+        let settings = OllamaRuntimeSettings::from_env_overrides_and_model(
+            Some(&overrides),
+            Some("qwen-test"),
+        );
+        assert_eq!(settings.num_ctx, 8_192);
+
+        crate::llm_config::clear_user_overrides();
+    }
+
+    #[test]
     fn provider_overrides_beat_env_and_normalize_keep_alive() {
         let _guard = env_lock().lock().expect("env lock");
         let _env = [
@@ -736,6 +794,42 @@ mod tests {
         assert_eq!(body["keep_alive"], serde_json::json!("30m"));
         assert_eq!(body["think"], serde_json::json!(true));
         assert!(body.get("num_ctx").is_none());
+    }
+
+    #[test]
+    fn apply_runtime_settings_uses_catalog_context_when_body_has_model() {
+        let _guard = env_lock().lock().expect("env lock");
+        let _env = [
+            ScopedEnvVar::remove("HARN_OLLAMA_NUM_CTX"),
+            ScopedEnvVar::remove("OLLAMA_CONTEXT_LENGTH"),
+            ScopedEnvVar::remove("OLLAMA_NUM_CTX"),
+            ScopedEnvVar::remove("HARN_OLLAMA_KEEP_ALIVE"),
+            ScopedEnvVar::remove("OLLAMA_KEEP_ALIVE"),
+        ];
+        crate::llm_config::clear_user_overrides();
+        let mut overlay = crate::llm_config::ProvidersConfig::default();
+        overlay.models.insert(
+            "qwen-test".to_string(),
+            crate::llm_config::ModelDef {
+                name: "Qwen Test".to_string(),
+                provider: "ollama".to_string(),
+                context_window: 100_000,
+                stream_timeout: None,
+                capabilities: vec![],
+                pricing: None,
+            },
+        );
+        crate::llm_config::set_user_overrides(Some(overlay));
+
+        let mut body = serde_json::json!({
+            "model": "qwen-test",
+            "options": {"temperature": 0.1}
+        });
+        apply_ollama_runtime_settings(&mut body, None);
+        assert_eq!(body["options"]["num_ctx"], serde_json::json!(100000));
+        assert_eq!(body["options"]["temperature"], serde_json::json!(0.1));
+
+        crate::llm_config::clear_user_overrides();
     }
 
     #[test]

--- a/crates/harn-vm/src/llm/tools/contract_prompt.rs
+++ b/crates/harn-vm/src/llm/tools/contract_prompt.rs
@@ -145,3 +145,23 @@ pub(crate) fn text_response_protocol_help(done_sentinel: &str) -> String {
     )
     .unwrap_or_else(|error| format!("Response protocol prompt render error: {error}"))
 }
+
+pub(crate) fn text_response_protocol_repair_feedback(
+    protocol_violations: &[String],
+    done_sentinel: &str,
+) -> String {
+    let done_line = if done_sentinel.is_empty() {
+        String::new()
+    } else {
+        format!("<done>{done_sentinel}</done>\n")
+    };
+    let violations = protocol_violations.join("\n- ");
+    let mut bindings = BTreeMap::new();
+    bindings.insert("violations".to_string(), vm_string(&violations));
+    bindings.insert("done_line".to_string(), vm_string(&done_line));
+    crate::stdlib::template::render_stdlib_prompt_asset(
+        "agent/prompts/protocol_violation_feedback.harn.prompt",
+        Some(&bindings),
+    )
+    .unwrap_or_else(|error| format!("protocol violation feedback prompt render error: {error}"))
+}

--- a/crates/harn-vm/src/llm/tools/mod.rs
+++ b/crates/harn-vm/src/llm/tools/mod.rs
@@ -19,6 +19,7 @@ pub(crate) use components::ComponentRegistry;
 pub(crate) use contract_prompt::build_tool_calling_contract_prompt;
 #[cfg(test)]
 pub(crate) use contract_prompt::text_response_protocol_help;
+pub(crate) use contract_prompt::text_response_protocol_repair_feedback;
 pub(crate) use handle_local::{handle_tool_locally, is_vm_stdlib_short_circuit};
 #[cfg(test)]
 pub(crate) use json_schema::json_schema_to_type_expr;

--- a/crates/harn-vm/src/llm/tools/tests/contract_prompt.rs
+++ b/crates/harn-vm/src/llm/tools/tests/contract_prompt.rs
@@ -1,6 +1,7 @@
 use super::{
     build_tool_calling_contract_prompt, collect_tool_schemas_with_registry, json,
-    normalize_tool_args, sample_tool_registry, text_response_protocol_help, ComponentRegistry,
+    normalize_tool_args, sample_tool_registry, text_response_protocol_help,
+    text_response_protocol_repair_feedback, ComponentRegistry,
 };
 
 #[test]
@@ -60,6 +61,13 @@ fn contract_prompt_help_block_documents_tagged_protocol() {
     assert!(help.contains("<done>##DONE##</done>"));
     assert!(help.contains("name({ key: value })"));
     assert!(help.contains("heredoc"));
+    assert!(help.contains("Do not write `<tool_call>##DONE##</tool_call>`"));
+    assert!(help.contains("Never emit another `<tool_call>` after `<user_response>`"));
+    let example_tool = help.find("Example tool response:").unwrap();
+    let example_final = help.find("Example final response:").unwrap();
+    assert!(example_tool < example_final);
+    let tool_example = &help[example_tool..example_final];
+    assert!(!tool_example.contains("<user_response>"));
     // Legacy bare-call phrasing must not regress.
     assert!(!help.contains("contains no tool calls"));
     assert!(!help.contains("```call"));
@@ -79,6 +87,26 @@ fn contract_prompt_help_block_documents_tagged_protocol() {
     let custom = text_response_protocol_help("STOP");
     assert!(custom.contains("<done>STOP</done>"));
     assert!(!custom.contains("##DONE##"));
+}
+
+#[test]
+fn protocol_repair_feedback_uses_shared_prompt_asset() {
+    let feedback = text_response_protocol_repair_feedback(
+        &[
+            "Unknown top-level tag \"<tool_call>\".".to_string(),
+            "Stray text outside response tags.".to_string(),
+        ],
+        "##DONE##",
+    );
+    assert!(feedback.contains("violated the tagged response protocol"));
+    assert!(feedback.contains("- Unknown top-level tag \"<tool_call>\"."));
+    assert!(feedback.contains("- Stray text outside response tags."));
+    assert!(feedback.contains("<done>##DONE##</done>"));
+    assert!(feedback.contains("name({ key: value })"));
+
+    let opt_out = text_response_protocol_repair_feedback(&["bad".to_string()], "");
+    assert!(!opt_out.contains("<done>"));
+    assert!(!opt_out.contains("##DONE##"));
 }
 
 #[test]

--- a/crates/harn-vm/src/llm/tools/tests/mod.rs
+++ b/crates/harn-vm/src/llm/tools/tests/mod.rs
@@ -13,8 +13,9 @@ pub(super) use super::{
     build_assistant_tool_message, build_tool_calling_contract_prompt, build_tool_result_message,
     collect_tool_schemas, collect_tool_schemas_with_registry, extract_deferred_tool_names,
     normalize_tool_args, parse_bare_calls_in_body, parse_native_json_tool_calls,
-    parse_text_tool_calls_with_tools, text_response_protocol_help, validate_tool_args,
-    vm_tools_to_native, ComponentRegistry,
+    parse_text_tool_calls_with_tools, text_response_protocol_help,
+    text_response_protocol_repair_feedback, validate_tool_args, vm_tools_to_native,
+    ComponentRegistry,
 };
 pub(super) use crate::value::VmValue;
 pub(super) use serde_json::json;


### PR DESCRIPTION
## Summary

- route tagged-response protocol repair through the shared stdlib prompt asset instead of inline Rust prompt prose
- strengthen the text-mode response protocol examples so final answers do not appear before tool calls
- use model catalog context windows as the Ollama `num_ctx` fallback for warmup, runtime settings, and context-window detection

## Validation

- `CARGO_TARGET_DIR=/tmp/harn-target-text-tool-contract cargo test -p harn-vm llm::tools::tests::contract_prompt -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-text-tool-contract cargo test -p harn-vm llm::api::ollama -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-text-tool-contract cargo test -p harn-stdlib`
- `CARGO_TARGET_DIR=/tmp/harn-target-text-tool-contract cargo check -p harn-vm`
- pre-commit hook: rustfmt, workspace clippy, generated highlight keywords
- pre-push hook: targeted package checks and generated highlight keyword check
