### PR TITLE
Move agent ledger shorthand to Harn and make stdlib cache process-wide

### DIFF
--- a/conformance/tests/agents/agent_loop_options.expected
+++ b/conformance/tests/agents/agent_loop_options.expected
@@ -6,3 +6,11 @@ dict
 text
 native
 false
+false
+Build feature
+2
+deliverable-1
+open
+deliverable-3
+explicit
+custom

--- a/conformance/tests/agents/agent_loop_options.harn
+++ b/conformance/tests/agents/agent_loop_options.harn
@@ -13,4 +13,28 @@ pipeline default() {
   let explicit_native = agent_loop_options({provider: "mock", tools: tool_registry(), tool_format: "native"})
   println(explicit_native.tool_format)
   println(contains(explicit_native.keys(), "done_sentinel"))
+  println(contains(no_tools.keys(), "task_ledger"))
+  let shorthand = agent_loop_options(
+    {provider: "mock", root_task: " Build feature ", deliverables: ["Write code", "", "Run tests"]},
+  )
+  println(shorthand.task_ledger.root_task)
+  println(len(shorthand.task_ledger.deliverables))
+  println(shorthand.task_ledger.deliverables[0].id)
+  println(shorthand.task_ledger.deliverables[0].status)
+  println(shorthand.task_ledger.deliverables[1].id)
+  let explicit_ledger = agent_loop_options(
+    {
+      provider: "mock",
+      root_task: "ignored",
+      deliverables: ["ignored"],
+      task_ledger: {
+        root_task: "explicit",
+        deliverables: [{id: "custom", text: "Use caller ledger", status: "done"}],
+        rationale: "caller-owned",
+        observations: ["observed"],
+      },
+    },
+  )
+  println(explicit_ledger.task_ledger.root_task)
+  println(explicit_ledger.task_ledger.deliverables[0].id)
 }

--- a/crates/harn-stdlib/src/stdlib/agent/options.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/options.harn
@@ -48,6 +48,47 @@ fn __client_tool_search_requested(value) {
   return type_of(value) == "dict" && value?.mode == "client"
 }
 
+fn __task_ledger_deliverable_text(value) {
+  let text = if type_of(value) == "string" {
+    value
+  } else {
+    to_string(value)
+  }
+  return trim(text)
+}
+
+fn __task_ledger_from_shorthand(opts) {
+  let root_task = trim(opts?.root_task ?? "")
+  var deliverables = []
+  let shorthand = opts?.deliverables
+  if type_of(shorthand) == "list" {
+    for (index, item) in iter(shorthand).enumerate() {
+      let text = __task_ledger_deliverable_text(item)
+      if text != "" {
+        deliverables = deliverables
+          .push(
+          {id: "deliverable-" + to_string(index + 1), text: text, status: "open", note: nil},
+        )
+      }
+    }
+  }
+  if root_task == "" && len(deliverables) == 0 {
+    return nil
+  }
+  return {root_task: root_task, deliverables: deliverables, rationale: "", observations: []}
+}
+
+fn __with_task_ledger_shorthand(opts) {
+  if __has_key(opts, "task_ledger") {
+    return opts
+  }
+  let ledger = __task_ledger_from_shorthand(opts)
+  if ledger == nil {
+    return opts
+  }
+  return opts + {task_ledger: ledger}
+}
+
 /** agent_loop_options. */
 pub fn agent_loop_options(options = nil) {
   var opts = options ?? {}
@@ -68,5 +109,6 @@ pub fn agent_loop_options(options = nil) {
   if __has_key(opts, "done_judge") {
     opts = opts + {done_judge: __completion_judge_defaults(opts?.done_judge)}
   }
+  opts = __with_task_ledger_shorthand(opts)
   return opts
 }

--- a/crates/harn-vm/src/chunk.rs
+++ b/crates/harn-vm/src/chunk.rs
@@ -486,6 +486,32 @@ pub struct Chunk {
 pub type ChunkRef = Rc<Chunk>;
 pub type CompiledFunctionRef = Rc<CompiledFunction>;
 
+#[derive(Debug, Clone)]
+pub(crate) struct CachedChunk {
+    code: Vec<u8>,
+    constants: Vec<Constant>,
+    lines: Vec<u32>,
+    columns: Vec<u32>,
+    source_file: Option<String>,
+    current_col: u32,
+    functions: Vec<CachedCompiledFunction>,
+    inline_cache_slots: BTreeMap<usize, usize>,
+    local_slots: Vec<LocalSlotInfo>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CachedCompiledFunction {
+    name: String,
+    type_params: Vec<String>,
+    nominal_type_names: Vec<String>,
+    params: Vec<ParamSlot>,
+    default_start: Option<usize>,
+    chunk: CachedChunk,
+    is_generator: bool,
+    is_stream: bool,
+    has_rest_param: bool,
+}
+
 /// One parameter slot of a compiled user-defined function. Carries the
 /// declared name, the (optional) declared type expression, and a flag
 /// for whether a default value was provided. The runtime consults the
@@ -567,17 +593,31 @@ impl CompiledFunction {
         self.nominal_type_names.iter().any(|ty| ty == name)
     }
 
-    pub(crate) fn fresh_runtime_clone(&self) -> Self {
-        Self {
+    pub(crate) fn freeze_for_cache(&self) -> CachedCompiledFunction {
+        CachedCompiledFunction {
             name: self.name.clone(),
             type_params: self.type_params.clone(),
             nominal_type_names: self.nominal_type_names.clone(),
             params: self.params.clone(),
             default_start: self.default_start,
-            chunk: Rc::new(self.chunk.fresh_runtime_clone()),
+            chunk: self.chunk.freeze_for_cache(),
             is_generator: self.is_generator,
             is_stream: self.is_stream,
             has_rest_param: self.has_rest_param,
+        }
+    }
+
+    pub(crate) fn from_cached(cached: &CachedCompiledFunction) -> Self {
+        Self {
+            name: cached.name.clone(),
+            type_params: cached.type_params.clone(),
+            nominal_type_names: cached.nominal_type_names.clone(),
+            params: cached.params.clone(),
+            default_start: cached.default_start,
+            chunk: Rc::new(Chunk::from_cached(&cached.chunk)),
+            is_generator: cached.is_generator,
+            is_stream: cached.is_stream,
+            has_rest_param: cached.has_rest_param,
         }
     }
 }
@@ -784,9 +824,8 @@ impl Chunk {
         }
     }
 
-    pub(crate) fn fresh_runtime_clone(&self) -> Self {
-        let inline_cache_count = self.inline_cache_slots.len();
-        Self {
+    pub(crate) fn freeze_for_cache(&self) -> CachedChunk {
+        CachedChunk {
             code: self.code.clone(),
             constants: self.constants.clone(),
             lines: self.lines.clone(),
@@ -796,14 +835,33 @@ impl Chunk {
             functions: self
                 .functions
                 .iter()
-                .map(|function| Rc::new(function.fresh_runtime_clone()))
+                .map(|function| function.freeze_for_cache())
                 .collect(),
             inline_cache_slots: self.inline_cache_slots.clone(),
+            local_slots: self.local_slots.clone(),
+        }
+    }
+
+    pub(crate) fn from_cached(cached: &CachedChunk) -> Self {
+        let inline_cache_count = cached.inline_cache_slots.len();
+        Self {
+            code: cached.code.clone(),
+            constants: cached.constants.clone(),
+            lines: cached.lines.clone(),
+            columns: cached.columns.clone(),
+            source_file: cached.source_file.clone(),
+            current_col: cached.current_col,
+            functions: cached
+                .functions
+                .iter()
+                .map(|function| Rc::new(CompiledFunction::from_cached(function)))
+                .collect(),
+            inline_cache_slots: cached.inline_cache_slots.clone(),
             inline_caches: Rc::new(RefCell::new(vec![
                 InlineCacheEntry::Empty;
                 inline_cache_count
             ])),
-            local_slots: self.local_slots.clone(),
+            local_slots: cached.local_slots.clone(),
         }
     }
 

--- a/crates/harn-vm/src/llm/agent_config.rs
+++ b/crates/harn-vm/src/llm/agent_config.rs
@@ -168,10 +168,10 @@ pub struct AgentLoopConfig {
     /// via `agent_subscribe(session_id, closure)` from inside the
     /// pipeline receive the same events (registry is keyed on session id).
     pub event_sink: Option<Arc<dyn AgentEventSink>>,
-    /// Optional initial task ledger. When populated (typically from a
-    /// prior planning stage's `tasks` array or a caller-supplied
-    /// deliverables list), the ledger is rendered into each turn's
-    /// prompt and gates `<done>` until resolved. See `llm/ledger.rs`.
+    /// Optional initial task ledger. When populated, the ledger is
+    /// rendered into each turn's prompt and gates `<done>` until resolved.
+    /// Public shorthand normalization is owned by std/agent/options.harn;
+    /// this config only carries the typed ledger shape.
     pub task_ledger: crate::llm::ledger::TaskLedger,
     /// Optional Harn closure called after each tool turn. Receives a
     /// dict of turn metadata (`tool_results`, `successful_tool_names`,
@@ -753,50 +753,19 @@ pub fn register_agent_inject_feedback(vm: &mut Vm) {
     });
 }
 
-/// Extract an initial task ledger from agent_loop options. Accepts:
-///
-/// - `task_ledger: { root_task, deliverables: [...], rationale, ... }` verbatim
-/// - `deliverables: ["task A", "task B"]` as shorthand for seeding
-/// - `root_task: "..."` standalone to record the original user ask
-///
-/// Unrecognised shapes fall through to an empty ledger (the loop runs
-/// un-gated, which is correct for trivial one-shots).
 fn parse_task_ledger_from_options(
     options: &Option<std::collections::BTreeMap<String, VmValue>>,
 ) -> crate::llm::ledger::TaskLedger {
-    use crate::llm::ledger::{Deliverable, DeliverableStatus, TaskLedger};
-
     let Some(opts) = options.as_ref() else {
-        return TaskLedger::default();
+        return crate::llm::ledger::TaskLedger::default();
     };
     if let Some(explicit) = opts.get("task_ledger") {
         let json = crate::llm::helpers::vm_value_to_json(explicit);
-        if let Ok(parsed) = serde_json::from_value::<TaskLedger>(json) {
+        if let Ok(parsed) = serde_json::from_value::<crate::llm::ledger::TaskLedger>(json) {
             return parsed;
         }
     }
-    let mut ledger = TaskLedger::default();
-    if let Some(VmValue::String(s)) = opts.get("root_task") {
-        ledger.root_task = s.trim().to_string();
-    }
-    if let Some(deliverables) = opts.get("deliverables").and_then(|v| match v {
-        VmValue::List(items) => Some(items.clone()),
-        _ => None,
-    }) {
-        for (idx, item) in deliverables.iter().enumerate() {
-            let text = item.display().trim().to_string();
-            if text.is_empty() {
-                continue;
-            }
-            ledger.deliverables.push(Deliverable {
-                id: format!("deliverable-{}", idx + 1),
-                text,
-                status: DeliverableStatus::Open,
-                note: None,
-            });
-        }
-    }
-    ledger
+    crate::llm::ledger::TaskLedger::default()
 }
 
 /// Register a bridge-aware `llm_call` that emits call_start/call_end notifications.

--- a/crates/harn-vm/src/vm/modules.rs
+++ b/crates/harn-vm/src/vm/modules.rs
@@ -5,8 +5,9 @@ use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::rc::Rc;
+use std::sync::{Arc, Mutex, OnceLock};
 
-use crate::chunk::{Chunk, CompiledFunction};
+use crate::chunk::{CachedChunk, CachedCompiledFunction, Chunk, CompiledFunction};
 use crate::value::{ModuleFunctionRegistry, VmClosure, VmEnv, VmError, VmValue};
 
 use super::{ScopeSpan, Vm};
@@ -21,24 +22,26 @@ struct ModuleImportSpec {
 #[derive(Clone)]
 struct CompiledStdlibModule {
     imports: Vec<ModuleImportSpec>,
-    init_chunk: Option<Chunk>,
-    functions: BTreeMap<String, CompiledFunction>,
+    init_chunk: Option<CachedChunk>,
+    functions: BTreeMap<String, CachedCompiledFunction>,
     public_names: HashSet<String>,
 }
 
-thread_local! {
-    static STDLIB_MODULE_ARTIFACT_CACHE: RefCell<BTreeMap<String, Rc<CompiledStdlibModule>>> =
-        const { RefCell::new(BTreeMap::new()) };
+static STDLIB_MODULE_ARTIFACT_CACHE: OnceLock<Mutex<BTreeMap<String, Arc<CompiledStdlibModule>>>> =
+    OnceLock::new();
+
+fn stdlib_module_artifact_cache() -> &'static Mutex<BTreeMap<String, Arc<CompiledStdlibModule>>> {
+    STDLIB_MODULE_ARTIFACT_CACHE.get_or_init(|| Mutex::new(BTreeMap::new()))
 }
 
 #[cfg(test)]
 fn reset_stdlib_module_artifact_cache() {
-    STDLIB_MODULE_ARTIFACT_CACHE.with(|cache| cache.borrow_mut().clear());
+    stdlib_module_artifact_cache().lock().unwrap().clear();
 }
 
 #[cfg(test)]
 fn stdlib_module_artifact_cache_len() -> usize {
-    STDLIB_MODULE_ARTIFACT_CACHE.with(|cache| cache.borrow().len())
+    stdlib_module_artifact_cache().lock().unwrap().len()
 }
 
 #[derive(Clone)]
@@ -73,18 +76,21 @@ fn stdlib_module_artifact(
     module: &str,
     synthetic: &Path,
     source: &str,
-) -> Result<Rc<CompiledStdlibModule>, VmError> {
+) -> Result<Arc<CompiledStdlibModule>, VmError> {
     let key = stdlib_artifact_cache_key(module, source);
-    if let Some(cached) =
-        STDLIB_MODULE_ARTIFACT_CACHE.with(|cache| cache.borrow().get(&key).cloned())
     {
-        return Ok(cached);
+        let cache = stdlib_module_artifact_cache().lock().unwrap();
+        if let Some(cached) = cache.get(&key) {
+            return Ok(Arc::clone(cached));
+        }
     }
 
-    let compiled = Rc::new(compile_stdlib_module_artifact(synthetic, source)?);
-    STDLIB_MODULE_ARTIFACT_CACHE.with(|cache| {
-        cache.borrow_mut().insert(key, Rc::clone(&compiled));
-    });
+    let compiled = Arc::new(compile_stdlib_module_artifact(synthetic, source)?);
+    let mut cache = stdlib_module_artifact_cache().lock().unwrap();
+    if let Some(cached) = cache.get(&key) {
+        return Ok(Arc::clone(cached));
+    }
+    cache.insert(key, Arc::clone(&compiled));
     Ok(compiled)
 }
 
@@ -141,7 +147,8 @@ fn compile_stdlib_module_artifact(
         Some(
             crate::Compiler::new()
                 .compile(&init_nodes)
-                .map_err(|e| VmError::Runtime(format!("Import init compile error: {e}")))?,
+                .map_err(|e| VmError::Runtime(format!("Import init compile error: {e}")))?
+                .freeze_for_cache(),
         )
     };
 
@@ -169,7 +176,7 @@ fn compile_stdlib_module_artifact(
         let func_chunk = compiler
             .compile_fn_body(type_params, params, body, module_source_file.clone())
             .map_err(|e| VmError::Runtime(format!("Import compile error: {e}")))?;
-        functions.insert(name.clone(), func_chunk);
+        functions.insert(name.clone(), func_chunk.freeze_for_cache());
         if *is_pub {
             public_names.insert(name.clone());
         }
@@ -256,7 +263,7 @@ impl Vm {
         let module_state: crate::value::ModuleState = {
             let mut init_env = self.env.clone();
             if let Some(init_chunk) = &artifact.init_chunk {
-                let fresh_init_chunk = init_chunk.fresh_runtime_clone();
+                let fresh_init_chunk = Chunk::from_cached(init_chunk);
                 let saved_env = std::mem::replace(&mut self.env, init_env);
                 let saved_frames = std::mem::take(&mut self.frames);
                 let saved_handlers = std::mem::take(&mut self.exception_handlers);
@@ -280,7 +287,7 @@ impl Vm {
 
         for (name, compiled) in &artifact.functions {
             let closure = Rc::new(VmClosure {
-                func: Rc::new(compiled.fresh_runtime_clone()),
+                func: Rc::new(CompiledFunction::from_cached(compiled)),
                 env: module_env.clone(),
                 source_dir: None,
                 module_functions: Some(Rc::clone(&registry)),
@@ -794,25 +801,44 @@ impl Vm {
 #[cfg(test)]
 mod tests {
     use std::rc::Rc;
+    use std::sync::{Mutex, MutexGuard, OnceLock};
 
     use super::*;
 
-    #[tokio::test(flavor = "current_thread")]
-    async fn stdlib_artifact_cache_reuses_compilation_with_fresh_vm_state() {
-        reset_stdlib_module_artifact_cache();
+    static CACHE_TEST_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
-        let mut first_vm = Vm::new();
-        let first_exports = first_vm
-            .load_module_exports_from_import("std/agent/prompts")
-            .await
-            .expect("first stdlib import succeeds");
+    fn cache_test_guard() -> MutexGuard<'static, ()> {
+        CACHE_TEST_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap()
+    }
+
+    #[test]
+    fn stdlib_artifact_cache_reuses_compilation_with_fresh_vm_state() {
+        let _guard = cache_test_guard();
+        reset_stdlib_module_artifact_cache();
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime builds");
+
+        let first_exports = runtime.block_on(async {
+            let mut first_vm = Vm::new();
+            first_vm
+                .load_module_exports_from_import("std/agent/prompts")
+                .await
+                .expect("first stdlib import succeeds")
+        });
         assert_eq!(stdlib_module_artifact_cache_len(), 1);
 
-        let mut second_vm = Vm::new();
-        let second_exports = second_vm
-            .load_module_exports_from_import("std/agent/prompts")
-            .await
-            .expect("second stdlib import succeeds");
+        let second_exports = runtime.block_on(async {
+            let mut second_vm = Vm::new();
+            second_vm
+                .load_module_exports_from_import("std/agent/prompts")
+                .await
+                .expect("second stdlib import succeeds")
+        });
         assert_eq!(stdlib_module_artifact_cache_len(), 1);
 
         let first = first_exports
@@ -829,5 +855,38 @@ mod tests {
             first.module_state.as_ref().expect("first module state"),
             second.module_state.as_ref().expect("second module state")
         ));
+    }
+
+    #[test]
+    fn stdlib_artifact_cache_is_process_wide_across_threads() {
+        let _guard = cache_test_guard();
+        reset_stdlib_module_artifact_cache();
+
+        let handle = std::thread::spawn(|| {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("runtime builds");
+            runtime.block_on(async {
+                let mut vm = Vm::new();
+                vm.load_module_exports_from_import("std/agent/prompts")
+                    .await
+                    .expect("thread stdlib import succeeds");
+            });
+        });
+        handle.join().expect("thread joins");
+        assert_eq!(stdlib_module_artifact_cache_len(), 1);
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime builds");
+        runtime.block_on(async {
+            let mut vm = Vm::new();
+            vm.load_module_exports_from_import("std/agent/prompts")
+                .await
+                .expect("main-thread stdlib import succeeds");
+        });
+        assert_eq!(stdlib_module_artifact_cache_len(), 1);
     }
 }

--- a/crates/harn-vm/tests/orchestration_cutover.rs
+++ b/crates/harn-vm/tests/orchestration_cutover.rs
@@ -2,6 +2,7 @@ const LLM_MOD_RS: &str = include_str!("../src/llm/mod.rs");
 const AGENT_CONFIG_RS: &str = include_str!("../src/llm/agent_config.rs");
 const WORKFLOW_REGISTER_RS: &str = include_str!("../src/stdlib/workflow/register.rs");
 const AGENT_LOOP_HARN: &str = include_str!("../../harn-stdlib/src/stdlib/agent/loop.harn");
+const AGENT_OPTIONS_HARN: &str = include_str!("../../harn-stdlib/src/stdlib/agent/options.harn");
 const AGENT_TURN_HARN: &str = include_str!("../../harn-stdlib/src/stdlib/agent/turn.harn");
 const WORKFLOW_EXECUTE_HARN: &str =
     include_str!("../../harn-stdlib/src/stdlib/workflow/execute.harn");
@@ -30,6 +31,12 @@ fn public_orchestration_entrypoints_dispatch_through_harn_stdlib() {
     assert!(
         !AGENT_CONFIG_RS.contains("agent_loop_profile_defaults(&options, \"agent_loop\")"),
         "public agent_loop profile/default policy belongs in std/agent/options.harn"
+    );
+    assert!(
+        !AGENT_CONFIG_RS.contains("opts.get(\"root_task\")")
+            && !AGENT_CONFIG_RS.contains("opts.get(\"deliverables\")")
+            && AGENT_OPTIONS_HARN.contains("__with_task_ledger_shorthand"),
+        "public task-ledger shorthand belongs in std/agent/options.harn"
     );
     assert!(
         LLM_MOD_RS.contains("__host_agent_capture_events")


### PR DESCRIPTION
## Summary

- Moves public `agent_loop` task-ledger shorthand normalization for `root_task` and `deliverables` into `std/agent/options.harn`; Rust now only consumes the explicit typed `task_ledger` shape.
- Adds a cutover ratchet so the shorthand cannot drift back into `agent_config.rs`.
- Replaces the thread-local stdlib artifact cache with a process-wide frozen bytecode template cache keyed by module name and embedded source hash, while thawing fresh runtime chunks, closure envs, and module state per VM.

Closes #1202.
Part of #1197 and #1203.

## Verification

- Rebased cleanly on `origin/main` after #1212 merged at `6cab7eadc8efebfef8c3a97fba19d33637d4f523`.
- `CARGO_TARGET_DIR=/tmp/harn-1197-target cargo run --quiet --bin harn -- test conformance --filter agent_loop_options`
- `CARGO_TARGET_DIR=/tmp/harn-1197-target cargo test -p harn-vm vm::modules`
- `CARGO_TARGET_DIR=/tmp/harn-1197-target cargo test -p harn-vm vm::tests_debug`
- `CARGO_TARGET_DIR=/tmp/harn-1197-target cargo test -p harn-vm stdlib`
- `CARGO_TARGET_DIR=/tmp/harn-1197-target cargo test -p harn-vm --test orchestration_cutover`
- Pre-push hook passed.