### PR TITLE
[codex] Tighten nested text tool tag guidance

### DIFF
--- a/crates/harn-stdlib/src/stdlib/agent/prompts/protocol_violation_feedback.harn.prompt
+++ b/crates/harn-stdlib/src/stdlib/agent/prompts/protocol_violation_feedback.harn.prompt
@@ -8,4 +8,4 @@ Re-emit using only these top-level tags, separated by whitespace:
 <tool_call>
 name({ key: value })
 </tool_call>
-{{ done_line }}Nothing outside these tags is accepted. Do not paste source code, diffs, JSON, or command output as prose. Wrap each action in its own `<tool_call>` block.
+{{ done_line }}Nothing outside these tags is accepted. Do not paste source code, diffs, JSON, or command output as prose. Wrap each action in its own `<tool_call>` block. Do not nest or repeat `<tool_call>` tags; after `<tool_call>`, the next non-whitespace text must be the tool name.

--- a/crates/harn-stdlib/src/stdlib/agent/prompts/tool_contract_text_response_protocol.harn.prompt
+++ b/crates/harn-stdlib/src/stdlib/agent/prompts/tool_contract_text_response_protocol.harn.prompt
@@ -20,6 +20,7 @@ Final user-facing answer. Required when no more tool calls are needed.
 
 - No text, code, diffs, JSON, or reasoning outside these tags. Any stray content is rejected with structured feedback.
 - `<tool_call>` wraps exactly one bare call `name({ key: value })`. Do not quote or JSON-encode the call. Use heredoc `<<TAG` ... `TAG` for multiline string fields: raw content, no escaping. Place TAG at the start of the closing line; closing punctuation like `},` may follow on that same line.
+- Do not nest or repeat `<tool_call>` tags. After `<tool_call>`, the next non-whitespace text must be the tool name, not another `<tool_call>`.
 - `<assistant_prose>` is optional and must be brief. Never paste source code, file contents, command transcripts, or long plans here; wrap those in the relevant tool call instead.
 - `<user_response>` is reserved for the final user-facing answer that hosts should surface. Emit it when the user should see a wrap-up or answer, and keep it concise and grounded.
 {{ if done_sentinel }}- `<done>{{ done_sentinel }}</done>` signals task completion. Emit it only after a successful verifying tool call; the runtime rejects it otherwise.

--- a/crates/harn-vm/src/llm/tools/tests/contract_prompt.rs
+++ b/crates/harn-vm/src/llm/tools/tests/contract_prompt.rs
@@ -61,6 +61,7 @@ fn contract_prompt_help_block_documents_tagged_protocol() {
     assert!(help.contains("<done>##DONE##</done>"));
     assert!(help.contains("name({ key: value })"));
     assert!(help.contains("heredoc"));
+    assert!(help.contains("Do not nest or repeat `<tool_call>` tags"));
     assert!(help.contains("Do not write `<tool_call>##DONE##</tool_call>`"));
     assert!(help.contains("Never emit another `<tool_call>` after `<user_response>`"));
     let example_tool = help.find("Example tool response:").unwrap();
@@ -103,6 +104,7 @@ fn protocol_repair_feedback_uses_shared_prompt_asset() {
     assert!(feedback.contains("- Stray text outside response tags."));
     assert!(feedback.contains("<done>##DONE##</done>"));
     assert!(feedback.contains("name({ key: value })"));
+    assert!(feedback.contains("Do not nest or repeat `<tool_call>` tags"));
 
     let opt_out = text_response_protocol_repair_feedback(&["bad".to_string()], "");
     assert!(!opt_out.contains("<done>"));


### PR DESCRIPTION
## Summary

- tell text-mode models not to nest or repeat `<tool_call>` tags inside tool-call blocks
- include the same corrective rule in protocol-violation feedback
- cover both rendered prompt assets in contract prompt tests

## Validation

- `CARGO_TARGET_DIR=/tmp/harn-target-text-tool-contract cargo test -p harn-vm llm::tools::tests::contract_prompt -- --nocapture`
- pre-commit hook: rustfmt, workspace clippy, generated highlight keywords
- pre-push hook: targeted package checks and generated highlight keyword check
