### PR TITLE
Move workflow stage prompt prep into Harn

### DIFF
--- a/conformance/tests/agents/workflow_prompt_prepare.expected
+++ b/conformance/tests/agents/workflow_prompt_prepare.expected
@@ -1,0 +1,13 @@
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+override

--- a/conformance/tests/agents/workflow_prompt_prepare.harn
+++ b/conformance/tests/agents/workflow_prompt_prepare.harn
@@ -1,0 +1,58 @@
+import {
+  workflow_prepare_stage_prompt,
+  workflow_render_artifacts_context,
+  workflow_render_verification_context,
+} from "std/workflow/prompts"
+
+pipeline default() {
+  let artifacts = [
+    {
+      id: "artifact-1",
+      kind: "workspace_file",
+      title: "src/main.rs",
+      text: "fn main() {}",
+      source: "stage<a>",
+      freshness: "fresh&ready",
+      priority: 7,
+    },
+  ]
+  let xml_context = workflow_render_artifacts_context(artifacts, {})
+  println(contains(xml_context, "<title>src/main.rs</title>"))
+  println(contains(xml_context, "<source>stage&lt;a&gt;</source>"))
+  println(contains(xml_context, "<freshness>fresh&amp;ready</freshness>"))
+  println(contains(xml_context, "fn main() {}"))
+  let json_context = workflow_render_artifacts_context(
+    [{id: "artifact-2", kind: "summary", data: {b: 2, a: 1}}],
+    {render: "json"},
+  )
+  println(contains(json_context, "\"text\":\"{"))
+  let verification = workflow_render_verification_context(
+    [
+      {
+        source_node: "build",
+        required_identifiers: ["rate<Limit"],
+        checks: [{kind: "command", value: "cargo test", note: "must pass"}],
+      },
+    ],
+  )
+  println(contains(verification, "<source_node>build</source_node>"))
+  println(contains(verification, "- rate&lt;Limit"))
+  println(contains(verification, "- command: cargo test (must pass)"))
+  let prepared = workflow_prepare_stage_prompt(
+    {
+      task: "  Ship it  ",
+      task_label: "  Implement <X>  ",
+      artifacts: artifacts,
+      context_policy: {},
+      verification_contracts: [],
+    },
+  )
+  println(contains(prepared.prompt, "<label>Implement &lt;X&gt;</label>"))
+  println(contains(prepared.prompt, "Ship it"))
+  println(prepared.rendered_context == xml_context)
+  println(prepared.rendered_verification == "")
+  let prepared_override = workflow_prepare_stage_prompt(
+    {task: "Task", rendered_context: "override", verification_contracts: []},
+  )
+  println(prepared_override.rendered_context)
+}

--- a/crates/harn-stdlib/src/stdlib/agent/prompts/protocol_violation_feedback.harn.prompt
+++ b/crates/harn-stdlib/src/stdlib/agent/prompts/protocol_violation_feedback.harn.prompt
@@ -8,4 +8,4 @@ Re-emit using only these top-level tags, separated by whitespace:
 <tool_call>
 name({ key: value })
 </tool_call>
-{{ done_line }}Nothing outside these tags is accepted. Do not paste source code, diffs, JSON, or command output as prose. Wrap each action in its own `<tool_call>` block.
+{{ done_line }}Nothing outside these tags is accepted. Do not paste source code, diffs, JSON, or command output as prose. Wrap each action in its own `<tool_call>` block. Do not nest or repeat `<tool_call>` tags; after `<tool_call>`, the next non-whitespace text must be the tool name.

--- a/crates/harn-stdlib/src/stdlib/agent/prompts/tool_contract_text_response_protocol.harn.prompt
+++ b/crates/harn-stdlib/src/stdlib/agent/prompts/tool_contract_text_response_protocol.harn.prompt
@@ -20,6 +20,7 @@ Final user-facing answer. Required when no more tool calls are needed.
 
 - No text, code, diffs, JSON, or reasoning outside these tags. Any stray content is rejected with structured feedback.
 - `<tool_call>` wraps exactly one bare call `name({ key: value })`. Do not quote or JSON-encode the call. Use heredoc `<<TAG` ... `TAG` for multiline string fields: raw content, no escaping. Place TAG at the start of the closing line; closing punctuation like `},` may follow on that same line.
+- Do not nest or repeat `<tool_call>` tags. After `<tool_call>`, the next non-whitespace text must be the tool name, not another `<tool_call>`.
 - `<assistant_prose>` is optional and must be brief. Never paste source code, file contents, command transcripts, or long plans here; wrap those in the relevant tool call instead.
 - `<user_response>` is reserved for the final user-facing answer that hosts should surface. Emit it when the user should see a wrap-up or answer, and keep it concise and grounded.
 {{ if done_sentinel }}- `<done>{{ done_sentinel }}</done>` signals task completion. Emit it only after a successful verifying tool call; the runtime rejects it otherwise.

--- a/crates/harn-stdlib/src/stdlib/workflow/prompts.harn
+++ b/crates/harn-stdlib/src/stdlib/workflow/prompts.harn
@@ -12,3 +12,177 @@ pub fn workflow_stage_prompt(bindings) {
 pub fn workflow_verification_context_intro() {
   return render_workflow_prompt_asset("verification_context_intro.harn.prompt", {})
 }
+
+fn __workflow_escape_prompt_text(text) {
+  return to_string(text ?? "").replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+}
+
+fn __workflow_artifact_title(artifact) {
+  let title = artifact?.title
+  if title != nil {
+    return title
+  }
+  return to_string(artifact?.kind ?? "") + " " + to_string(artifact?.id ?? "")
+}
+
+fn __workflow_artifact_body(artifact) {
+  let text = artifact?.text
+  if text != nil {
+    return text
+  }
+  let data = artifact?.data
+  if data != nil {
+    return json_stringify(data)
+  }
+  return ""
+}
+
+fn __workflow_render_artifact_xml(artifact) {
+  let title = __workflow_artifact_title(artifact)
+  let source = artifact?.source ?? "unknown"
+  let freshness = artifact?.freshness ?? "normal"
+  return "<artifact>\n"
+    + "<title>"
+    + __workflow_escape_prompt_text(title)
+    + "</title>\n"
+    + "<kind>"
+    + __workflow_escape_prompt_text(artifact?.kind ?? "")
+    + "</kind>\n"
+    + "<source>"
+    + __workflow_escape_prompt_text(source)
+    + "</source>\n"
+    + "<freshness>"
+    + __workflow_escape_prompt_text(freshness)
+    + "</freshness>\n"
+    + "<priority>"
+    + to_string(artifact?.priority ?? 0)
+    + "</priority>\n"
+    + "<body>\n"
+    + __workflow_artifact_body(artifact)
+    + "\n</body>\n"
+    + "</artifact>"
+}
+
+fn __workflow_render_artifact_json(artifact) {
+  return json_stringify(
+    {
+      id: artifact?.id,
+      kind: artifact?.kind,
+      title: __workflow_artifact_title(artifact),
+      source: artifact?.source,
+      freshness: artifact?.freshness,
+      priority: artifact?.priority,
+      text: __workflow_artifact_body(artifact),
+    },
+  )
+}
+
+/** workflow_render_artifacts_context. */
+pub fn workflow_render_artifacts_context(artifacts = nil, policy = nil) {
+  let render = policy?.render
+  var parts = []
+  for artifact in artifacts ?? [] {
+    if render == "json" {
+      parts = parts.push(__workflow_render_artifact_json(artifact))
+    } else {
+      parts = parts.push(__workflow_render_artifact_xml(artifact))
+    }
+  }
+  return join(parts, "\n\n")
+}
+
+fn __workflow_push_optional_field(out, name, value) {
+  if value == nil {
+    return out
+  }
+  return out + "<" + name + ">" + __workflow_escape_prompt_text(value) + "</" + name + ">\n"
+}
+
+fn __workflow_push_int_field(out, name, value) {
+  if value == nil {
+    return out
+  }
+  return out + "<" + name + ">" + to_string(value) + "</" + name + ">\n"
+}
+
+fn __workflow_push_string_list(out, name, values) {
+  if len(values ?? []) == 0 {
+    return out
+  }
+  var result = out + "<" + name + ">\n"
+  for value in values {
+    result = result + "- " + __workflow_escape_prompt_text(value) + "\n"
+  }
+  return result + "</" + name + ">\n"
+}
+
+fn __workflow_push_checks(out, checks) {
+  if len(checks ?? []) == 0 {
+    return out
+  }
+  var result = out + "<checks>\n"
+  for check in checks {
+    result = result + "- " + __workflow_escape_prompt_text(check?.kind ?? "")
+      + ": "
+      + __workflow_escape_prompt_text(check?.value ?? "")
+    if check?.note != nil {
+      result = result + " (" + __workflow_escape_prompt_text(check.note) + ")"
+    }
+    result = result + "\n"
+  }
+  return result + "</checks>\n"
+}
+
+fn __workflow_render_contract(contract) {
+  var out = "\n<contract>\n"
+  out = __workflow_push_optional_field(out, "source_node", contract?.source_node)
+  out = __workflow_push_optional_field(out, "summary", contract?.summary)
+  out = __workflow_push_optional_field(out, "command", contract?.command)
+  out = __workflow_push_int_field(out, "expect_status", contract?.expect_status)
+  out = __workflow_push_optional_field(out, "assert_text", contract?.assert_text)
+  out = __workflow_push_optional_field(out, "expect_text", contract?.expect_text)
+  out = __workflow_push_string_list(out, "required_identifiers", contract?.required_identifiers ?? [])
+  out = __workflow_push_string_list(out, "required_paths", contract?.required_paths ?? [])
+  out = __workflow_push_string_list(out, "required_text", contract?.required_text ?? [])
+  out = __workflow_push_checks(out, contract?.checks ?? [])
+  out = __workflow_push_string_list(out, "notes", contract?.notes ?? [])
+  return out + "</contract>"
+}
+
+/** workflow_render_verification_context. */
+pub fn workflow_render_verification_context(contracts = nil) {
+  if len(contracts ?? []) == 0 {
+    return ""
+  }
+  var out = workflow_verification_context_intro() + "\n"
+  for contract in contracts {
+    out = out + __workflow_render_contract(contract)
+  }
+  return out
+}
+
+fn __workflow_stage_label(label) {
+  let trimmed = trim(label ?? "")
+  if trimmed == "" {
+    return "Task"
+  }
+  return trimmed
+}
+
+/** workflow_prepare_stage_prompt. */
+pub fn workflow_prepare_stage_prompt(config = nil) {
+  let opts = config ?? {}
+  let rendered_context = opts?.rendered_context
+    ?? workflow_render_artifacts_context(opts?.artifacts ?? [], opts?.context_policy ?? {})
+  let rendered_verification = opts?.rendered_verification
+    ?? workflow_render_verification_context(opts?.verification_contracts ?? [])
+  let prompt = workflow_stage_prompt(
+    {
+      label: __workflow_escape_prompt_text(__workflow_stage_label(opts?.task_label)),
+      instructions: trim(opts?.task ?? ""),
+      verification: trim(rendered_verification),
+      context: trim(rendered_context),
+    },
+  )
+  return {prompt: prompt, rendered_context: rendered_context, rendered_verification: rendered_verification}
+}

--- a/crates/harn-vm/src/llm/tools/tests/contract_prompt.rs
+++ b/crates/harn-vm/src/llm/tools/tests/contract_prompt.rs
@@ -61,6 +61,7 @@ fn contract_prompt_help_block_documents_tagged_protocol() {
     assert!(help.contains("<done>##DONE##</done>"));
     assert!(help.contains("name({ key: value })"));
     assert!(help.contains("heredoc"));
+    assert!(help.contains("Do not nest or repeat `<tool_call>` tags"));
     assert!(help.contains("Do not write `<tool_call>##DONE##</tool_call>`"));
     assert!(help.contains("Never emit another `<tool_call>` after `<user_response>`"));
     let example_tool = help.find("Example tool response:").unwrap();
@@ -103,6 +104,7 @@ fn protocol_repair_feedback_uses_shared_prompt_asset() {
     assert!(feedback.contains("- Stray text outside response tags."));
     assert!(feedback.contains("<done>##DONE##</done>"));
     assert!(feedback.contains("name({ key: value })"));
+    assert!(feedback.contains("Do not nest or repeat `<tool_call>` tags"));
 
     let opt_out = text_response_protocol_repair_feedback(&["bad".to_string()], "");
     assert!(!opt_out.contains("<done>"));

--- a/crates/harn-vm/src/orchestration/artifacts.rs
+++ b/crates/harn-vm/src/orchestration/artifacts.rs
@@ -1,11 +1,8 @@
 //! Artifact types, normalization, selection, and context rendering.
 
 use std::collections::{BTreeMap, BTreeSet};
-use std::rc::Rc;
 
 use serde::{Deserialize, Serialize};
-
-use crate::value::VmValue;
 
 use super::{
     handoff_artifact_record, handoff_from_json_value, microcompact_tool_output, new_id,
@@ -350,140 +347,70 @@ pub fn render_artifacts_context(artifacts: &[ArtifactRecord], policy: &ContextPo
     parts.join("\n\n")
 }
 
-pub fn render_workflow_prompt(
-    task: &str,
-    task_label: Option<&str>,
-    rendered_verification: &str,
-    rendered_context: &str,
-) -> String {
-    let label = task_label
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .unwrap_or("Task");
-    let mut bindings = BTreeMap::new();
-    bindings.insert(
-        "label".to_string(),
-        VmValue::String(Rc::from(escape_prompt_text(label))),
-    );
-    bindings.insert(
-        "instructions".to_string(),
-        VmValue::String(Rc::from(task.trim().to_string())),
-    );
-    bindings.insert(
-        "verification".to_string(),
-        VmValue::String(Rc::from(rendered_verification.trim().to_string())),
-    );
-    bindings.insert(
-        "context".to_string(),
-        VmValue::String(Rc::from(rendered_context.trim().to_string())),
-    );
-    crate::stdlib::template::render_stdlib_prompt_asset(
-        "workflow/prompts/stage.harn.prompt",
-        Some(&bindings),
-    )
-    .unwrap_or_else(|error| format!("workflow stage prompt render error: {error}"))
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PreparedWorkflowStagePrompt {
+    pub prompt: String,
+    pub rendered_context: String,
+    pub rendered_verification: String,
 }
 
-pub fn render_verification_context(contracts: &[VerificationContract]) -> String {
-    if contracts.is_empty() {
-        return String::new();
-    }
+pub async fn prepare_workflow_stage_prompt(
+    task: &str,
+    task_label: Option<&str>,
+    artifacts: &[ArtifactRecord],
+    context_policy: &ContextPolicy,
+    rendered_context: Option<&str>,
+    verification_contracts: &[VerificationContract],
+) -> Result<PreparedWorkflowStagePrompt, crate::value::VmError> {
+    let payload = serde_json::json!({
+        "task": task,
+        "task_label": task_label,
+        "artifacts": artifacts,
+        "context_policy": context_policy,
+        "rendered_context": rendered_context,
+        "verification_contracts": verification_contracts,
+    });
+    let config = crate::stdlib::json_to_vm_value(&payload);
+    let mut vm = crate::vm::Vm::new();
+    crate::stdlib::register_core_stdlib(&mut vm);
+    let exports = vm
+        .load_module_exports_from_import("std/workflow/prompts")
+        .await?;
+    let prepare = exports
+        .get("workflow_prepare_stage_prompt")
+        .cloned()
+        .ok_or_else(|| {
+            crate::value::VmError::Runtime(
+                "std/workflow/prompts missing workflow_prepare_stage_prompt export".to_string(),
+            )
+        })?;
+    let prepared = vm.call_closure_pub(&prepare, &[config]).await?;
+    let prepared = crate::llm::vm_value_to_json(&prepared);
+    let prepared = prepared.as_object().ok_or_else(|| {
+        crate::value::VmError::Runtime(
+            "workflow_prepare_stage_prompt must return a dict".to_string(),
+        )
+    })?;
+    Ok(PreparedWorkflowStagePrompt {
+        prompt: workflow_prompt_string_field(prepared, "prompt")?,
+        rendered_context: workflow_prompt_string_field(prepared, "rendered_context")?,
+        rendered_verification: workflow_prompt_string_field(prepared, "rendered_verification")?,
+    })
+}
 
-    let mut out = crate::stdlib::template::render_stdlib_prompt_asset(
-        "workflow/prompts/verification_context_intro.harn.prompt",
-        None,
-    )
-    .unwrap_or_else(|error| format!("workflow verification prompt render error: {error}"));
-    out.push('\n');
-
-    for contract in contracts {
-        out.push_str("\n<contract>\n");
-        if let Some(source_node) = contract.source_node.as_deref() {
-            out.push_str("<source_node>");
-            out.push_str(&escape_prompt_text(source_node));
-            out.push_str("</source_node>\n");
-        }
-        if let Some(summary) = contract.summary.as_deref() {
-            out.push_str("<summary>");
-            out.push_str(&escape_prompt_text(summary));
-            out.push_str("</summary>\n");
-        }
-        if let Some(command) = contract.command.as_deref() {
-            out.push_str("<command>");
-            out.push_str(&escape_prompt_text(command));
-            out.push_str("</command>\n");
-        }
-        if let Some(expect_status) = contract.expect_status {
-            out.push_str("<expect_status>");
-            out.push_str(&expect_status.to_string());
-            out.push_str("</expect_status>\n");
-        }
-        if let Some(assert_text) = contract.assert_text.as_deref() {
-            out.push_str("<assert_text>");
-            out.push_str(&escape_prompt_text(assert_text));
-            out.push_str("</assert_text>\n");
-        }
-        if let Some(expect_text) = contract.expect_text.as_deref() {
-            out.push_str("<expect_text>");
-            out.push_str(&escape_prompt_text(expect_text));
-            out.push_str("</expect_text>\n");
-        }
-        if !contract.required_identifiers.is_empty() {
-            out.push_str("<required_identifiers>\n");
-            for value in &contract.required_identifiers {
-                out.push_str("- ");
-                out.push_str(&escape_prompt_text(value));
-                out.push('\n');
-            }
-            out.push_str("</required_identifiers>\n");
-        }
-        if !contract.required_paths.is_empty() {
-            out.push_str("<required_paths>\n");
-            for value in &contract.required_paths {
-                out.push_str("- ");
-                out.push_str(&escape_prompt_text(value));
-                out.push('\n');
-            }
-            out.push_str("</required_paths>\n");
-        }
-        if !contract.required_text.is_empty() {
-            out.push_str("<required_text>\n");
-            for value in &contract.required_text {
-                out.push_str("- ");
-                out.push_str(&escape_prompt_text(value));
-                out.push('\n');
-            }
-            out.push_str("</required_text>\n");
-        }
-        if !contract.checks.is_empty() {
-            out.push_str("<checks>\n");
-            for check in &contract.checks {
-                out.push_str("- ");
-                out.push_str(&escape_prompt_text(&check.kind));
-                out.push_str(": ");
-                out.push_str(&escape_prompt_text(&check.value));
-                if let Some(note) = check.note.as_deref() {
-                    out.push_str(" (");
-                    out.push_str(&escape_prompt_text(note));
-                    out.push(')');
-                }
-                out.push('\n');
-            }
-            out.push_str("</checks>\n");
-        }
-        if !contract.notes.is_empty() {
-            out.push_str("<notes>\n");
-            for note in &contract.notes {
-                out.push_str("- ");
-                out.push_str(&escape_prompt_text(note));
-                out.push('\n');
-            }
-            out.push_str("</notes>\n");
-        }
-        out.push_str("</contract>");
-    }
-
-    out
+fn workflow_prompt_string_field(
+    value: &serde_json::Map<String, serde_json::Value>,
+    field: &str,
+) -> Result<String, crate::value::VmError> {
+    value
+        .get(field)
+        .and_then(serde_json::Value::as_str)
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| {
+            crate::value::VmError::Runtime(format!(
+                "workflow_prepare_stage_prompt must return string field '{field}'"
+            ))
+        })
 }
 
 fn escape_prompt_text(text: &str) -> String {

--- a/crates/harn-vm/src/orchestration/workflow.rs
+++ b/crates/harn-vm/src/orchestration/workflow.rs
@@ -1256,15 +1256,14 @@ pub async fn execute_stage_node(
         selection_policy.include_kinds = node.input_contract.input_kinds.clone();
     }
     let selected = super::select_artifacts_adaptive(artifacts.to_vec(), &selection_policy);
-    let rendered_context = if let Some(assembler) = node.raw_context_assembler.as_ref() {
+    let rendered_context_override = if let Some(assembler) = node.raw_context_assembler.as_ref() {
         let assembled =
             crate::stdlib::assemble::assemble_from_options(&selected, assembler).await?;
-        super::render_assembled_chunks(&assembled)
+        Some(super::render_assembled_chunks(&assembled))
     } else {
-        super::render_artifacts_context(&selected, &node.context_policy)
+        None
     };
     let verification_contracts = super::stage_verification_contracts(node_id, node)?;
-    let rendered_verification = super::render_verification_context(&verification_contracts);
     let stage_session_id = resolve_node_session_id(node);
     if node.input_contract.require_transcript && !crate::agent_sessions::exists(&stage_session_id) {
         return Err(VmError::Runtime(format!(
@@ -1287,12 +1286,18 @@ pub async fn execute_stage_node(
             )));
         }
     }
-    let prompt = super::render_workflow_prompt(
+    let prepared_prompt = super::prepare_workflow_stage_prompt(
         task,
         node.task_label.as_deref(),
-        &rendered_verification,
-        &rendered_context,
-    );
+        &selected,
+        &node.context_policy,
+        rendered_context_override.as_deref(),
+        &verification_contracts,
+    )
+    .await?;
+    let prompt = prepared_prompt.prompt;
+    let rendered_context = prepared_prompt.rendered_context;
+    let rendered_verification = prepared_prompt.rendered_verification;
 
     // Precedence for the tool-calling contract format:
     //   1. explicit `model_policy.tool_format` on the node

--- a/crates/harn-vm/src/stdlib/workflow/tests.rs
+++ b/crates/harn-vm/src/stdlib/workflow/tests.rs
@@ -3,10 +3,10 @@ use super::map::{execute_join_policy, LocalTask};
 use super::register::execute_workflow;
 use super::stage::{classify_stage_outcome, execute_stage_attempts, replay_stage};
 use crate::orchestration::{
-    inject_workflow_verification_contracts, render_artifacts_context, render_workflow_prompt,
-    save_run_record, workflow_verification_contracts, RunChildRecord, RunExecutionRecord,
-    RunRecord, RunStageRecord, VerificationContract, VerificationRequirement, WorkflowEdge,
-    WorkflowGraph, WorkflowNode,
+    inject_workflow_verification_contracts, prepare_workflow_stage_prompt,
+    render_artifacts_context, save_run_record, workflow_verification_contracts, ContextPolicy,
+    RunChildRecord, RunExecutionRecord, RunRecord, RunStageRecord, VerificationContract,
+    VerificationRequirement, WorkflowEdge, WorkflowGraph, WorkflowNode,
 };
 use crate::tracing::{set_tracing_enabled, span_end, span_start, SpanKind};
 use crate::value::VmValue;
@@ -183,14 +183,19 @@ fn snapshot_trace_spans_returns_completed_trace_tree() {
     set_tracing_enabled(false);
 }
 
-#[test]
-fn render_workflow_prompt_puts_task_before_context() {
-    let prompt = render_workflow_prompt(
+#[tokio::test(flavor = "current_thread")]
+async fn prepare_workflow_stage_prompt_puts_task_before_context() {
+    let prepared = prepare_workflow_stage_prompt(
         "Create the missing test file with one edit call.",
         Some("Create Required Outputs"),
-        "",
-        "<artifact>\n<title>tests/unit/test_example.py</title>\n<body>\npass\n</body>\n</artifact>",
-    );
+        &[],
+        &ContextPolicy::default(),
+        Some("<artifact>\n<title>tests/unit/test_example.py</title>\n<body>\npass\n</body>\n</artifact>"),
+        &[],
+    )
+    .await
+    .expect("workflow stage prompt renders");
+    let prompt = prepared.prompt;
     let task_index = prompt
         .find("<workflow_task>")
         .expect("workflow task block should exist");
@@ -210,14 +215,25 @@ fn render_workflow_prompt_puts_task_before_context() {
     );
 }
 
-#[test]
-fn render_workflow_prompt_places_verification_before_context() {
-    let prompt = render_workflow_prompt(
+#[tokio::test(flavor = "current_thread")]
+async fn prepare_workflow_stage_prompt_places_verification_before_context() {
+    let contracts = vec![VerificationContract {
+        required_identifiers: vec!["rateLimit".to_string()],
+        ..Default::default()
+    }];
+    let prepared = prepare_workflow_stage_prompt(
         "Implement the verifier-exact wiring.",
         Some("Implement"),
-        "<contract>\n<required_identifiers>\n- rateLimit\n</required_identifiers>\n</contract>",
-        "<artifact>\n<title>src/server.ts</title>\n<body>\nexisting code\n</body>\n</artifact>",
-    );
+        &[],
+        &ContextPolicy::default(),
+        Some(
+            "<artifact>\n<title>src/server.ts</title>\n<body>\nexisting code\n</body>\n</artifact>",
+        ),
+        &contracts,
+    )
+    .await
+    .expect("workflow stage prompt renders");
+    let prompt = prepared.prompt;
 
     let verification_index = prompt
         .find("<workflow_verification>")
@@ -232,14 +248,19 @@ fn render_workflow_prompt_places_verification_before_context() {
     assert!(prompt.contains("rateLimit"));
 }
 
-#[test]
-fn render_workflow_prompt_makes_current_stage_scope_authoritative() {
-    let prompt = render_workflow_prompt(
+#[tokio::test(flavor = "current_thread")]
+async fn prepare_workflow_stage_prompt_makes_current_stage_scope_authoritative() {
+    let prepared = prepare_workflow_stage_prompt(
         "Only update src/current.ts.",
         Some("Execute Current Batch"),
-        "",
-        "<artifact>\n<title>Action graph</title>\n<body>\nFuture step: run final verification\n</body>\n</artifact>",
-    );
+        &[],
+        &ContextPolicy::default(),
+        Some("<artifact>\n<title>Action graph</title>\n<body>\nFuture step: run final verification\n</body>\n</artifact>"),
+        &[],
+    )
+    .await
+    .expect("workflow stage prompt renders");
+    let prompt = prepared.prompt;
 
     assert!(prompt.contains("Treat `<workflow_context>` as supporting evidence"));
     assert!(prompt.contains("do only what the current workflow task and system prompt authorize"));

--- a/crates/harn-vm/tests/orchestration_cutover.rs
+++ b/crates/harn-vm/tests/orchestration_cutover.rs
@@ -6,8 +6,11 @@ const AGENT_OPTIONS_HARN: &str = include_str!("../../harn-stdlib/src/stdlib/agen
 const AGENT_TURN_HARN: &str = include_str!("../../harn-stdlib/src/stdlib/agent/turn.harn");
 const WORKFLOW_EXECUTE_HARN: &str =
     include_str!("../../harn-stdlib/src/stdlib/workflow/execute.harn");
+const WORKFLOW_PROMPTS_HARN: &str =
+    include_str!("../../harn-stdlib/src/stdlib/workflow/prompts.harn");
 const CONTRACT_PROMPT_RS: &str = include_str!("../src/llm/tools/contract_prompt.rs");
 const WORKFLOW_ARTIFACTS_RS: &str = include_str!("../src/orchestration/artifacts.rs");
+const WORKFLOW_RS: &str = include_str!("../src/orchestration/workflow.rs");
 
 #[test]
 fn public_orchestration_entrypoints_dispatch_through_harn_stdlib() {
@@ -47,6 +50,16 @@ fn public_orchestration_entrypoints_dispatch_through_harn_stdlib() {
         WORKFLOW_REGISTER_RS.contains("__host_workflow_graph_run")
             && WORKFLOW_EXECUTE_HARN.contains("__host_workflow_graph_run"),
         "the Harn workflow facade should call only the host workflow graph primitive"
+    );
+    assert!(
+        WORKFLOW_RS.contains("prepare_workflow_stage_prompt(")
+            && WORKFLOW_PROMPTS_HARN.contains("workflow_prepare_stage_prompt"),
+        "workflow stage prompt preparation belongs in std/workflow/prompts.harn"
+    );
+    assert!(
+        !WORKFLOW_ARTIFACTS_RS.contains("pub fn render_workflow_prompt")
+            && !WORKFLOW_ARTIFACTS_RS.contains("pub fn render_verification_context"),
+        "workflow stage and verification prompt renderers must not move back into Rust"
     );
 }
 


### PR DESCRIPTION
## Summary

- Moves workflow stage artifact-context rendering, verification-context rendering, and final stage prompt binding into `std/workflow/prompts.harn`.
- Routes Rust `execute_stage_node` through `workflow_prepare_stage_prompt`, leaving Rust with selected artifacts, optional assembled-context override, verification contracts, and the host execution boundary.
- Removes the old Rust workflow stage/verification prompt renderers and adds cutover ratchets plus conformance coverage for the Harn helpers.

Part of #1197 and #1204.
Stacked on top of queued #1213 and #1214; rebase onto `main` once the queue lands.

## Verification

- `CARGO_TARGET_DIR=/tmp/harn-1197-target cargo run --quiet --bin harn -- test conformance --filter workflow_prompt_prepare`
- `CARGO_TARGET_DIR=/tmp/harn-1197-target cargo run --quiet --bin harn -- test conformance --filter workflow`
- `CARGO_TARGET_DIR=/tmp/harn-1197-target cargo test -p harn-vm prepare_workflow_stage_prompt -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-1197-target cargo test -p harn-vm stdlib::agents::workflow::tests`
- `CARGO_TARGET_DIR=/tmp/harn-1197-target cargo test -p harn-vm --test orchestration_cutover`
- `CARGO_TARGET_DIR=/tmp/harn-1197-target make fmt-harn`
- `CARGO_TARGET_DIR=/tmp/harn-1197-target make lint-harn`
- Pre-commit hook passed.
- Pre-push hook passed.
