### PR TITLE
Move workflow context selection into Harn

### DIFF
--- a/conformance/tests/agents/workflow_context_policy.expected
+++ b/conformance/tests/agents/workflow_context_policy.expected
@@ -1,0 +1,9 @@
+summary
+["a"]
+["pin","verify"]
+["dup-high","new-index"]
+true
+true
+true
+true
+true

--- a/conformance/tests/agents/workflow_context_policy.harn
+++ b/conformance/tests/agents/workflow_context_policy.harn
@@ -1,0 +1,72 @@
+import {
+  workflow_select_artifacts,
+  workflow_select_artifacts_adaptive,
+  workflow_select_stage_artifacts,
+  workflow_stage_context_policy,
+} from "std/workflow/context"
+
+fn ids(artifacts) {
+  var out = []
+  for artifact in artifacts {
+    out = out.push(artifact.id)
+  }
+  return out
+}
+
+pipeline default() {
+  let stage_policy = workflow_stage_context_policy({}, {input_kinds: ["summary"]})
+  println(stage_policy.include_kinds[0])
+  let selected = workflow_select_stage_artifacts(
+    {
+      context_policy: {},
+      input_contract: {input_kinds: ["summary"]},
+      artifacts: [
+        {id: "a", kind: "summary", text: "short", priority: 1, estimated_tokens: 5},
+        {id: "b", kind: "workspace_file", text: "file", priority: 100, estimated_tokens: 1},
+      ],
+    },
+  )
+  println(json_stringify(ids(selected.artifacts)))
+  let ordered = workflow_select_artifacts(
+    [
+      {id: "low", kind: "summary", priority: 1, relevance: 1.0, estimated_tokens: 10},
+      {id: "pin", kind: "summary", priority: 0, relevance: 0.0, estimated_tokens: 10},
+      {id: "verify", kind: "verification_result", priority: 2, relevance: 0.1, estimated_tokens: 10},
+    ],
+    {pinned_ids: ["pin"], prioritize_kinds: ["verification_result"], max_artifacts: 2},
+  )
+  println(json_stringify(ids(ordered)))
+  let adaptive = workflow_select_artifacts_adaptive(
+    [
+      {
+        id: "old-index",
+        kind: "summary",
+        text: "same",
+        priority: 1,
+        freshness: "normal",
+        metadata: {evidence_paths: ["src/index.ts"]},
+      },
+      {
+        id: "new-index",
+        kind: "summary",
+        text: "updated src/index.ts",
+        priority: 1,
+        freshness: "fresh",
+        metadata: {changed_paths: ["src/index.ts"]},
+      },
+      {id: "dup-low", kind: "summary", text: "duplicate", priority: 1},
+      {id: "dup-high", kind: "summary", text: "duplicate", priority: 9},
+    ],
+    {},
+  )
+  println(json_stringify(ids(adaptive)))
+  println(!contains(ids(adaptive), "old-index"))
+  println(contains(ids(adaptive), "dup-high"))
+  println(!contains(ids(adaptive), "dup-low"))
+  let oversized = workflow_select_artifacts_adaptive(
+    [{id: "big", kind: "summary", text: "0123456789".repeat(300), estimated_tokens: 1000, priority: 1}],
+    {max_tokens: 400},
+  )
+  println(oversized[0].estimated_tokens == 400)
+  println(len(oversized[0].text) < 3000)
+}

--- a/crates/harn-stdlib/src/lib.rs
+++ b/crates/harn-stdlib/src/lib.rs
@@ -206,6 +206,10 @@ pub const STDLIB_SOURCES: &[StdlibSource] = &[
         source: include_str!("stdlib/workflow/prompts.harn"),
     },
     StdlibSource {
+        module: "workflow/context",
+        source: include_str!("stdlib/workflow/context.harn"),
+    },
+    StdlibSource {
         module: "workflow/execute",
         source: include_str!("stdlib/workflow/execute.harn"),
     },

--- a/crates/harn-stdlib/src/stdlib/workflow/context.harn
+++ b/crates/harn-stdlib/src/stdlib/workflow/context.harn
@@ -1,0 +1,324 @@
+fn __workflow_list(value) {
+  if type_of(value) == "list" {
+    return value
+  }
+  return []
+}
+
+fn __workflow_contains(values, value) {
+  return contains(__workflow_list(values), value)
+}
+
+fn __workflow_num(value, fallback = 0) {
+  if type_of(value) == "int" || type_of(value) == "float" {
+    return value
+  }
+  return fallback
+}
+
+fn __workflow_freshness_rank(value) {
+  if value == "stale" {
+    return 0
+  }
+  if value == "normal" || value == nil {
+    return 1
+  }
+  if value == "fresh" {
+    return 2
+  }
+  if value == "live" {
+    return 3
+  }
+  return 1
+}
+
+fn __workflow_metadata_string_list(artifact, key) {
+  let metadata = artifact?.metadata ?? {}
+  let raw = metadata[key]
+  var out = []
+  for item in __workflow_list(raw) {
+    if type_of(item) == "string" && trim(item) != "" {
+      out = out.push(trim(item))
+    }
+  }
+  return out
+}
+
+fn __workflow_push_unique(values, value) {
+  if __workflow_contains(values, value) {
+    return values
+  }
+  return values.push(value)
+}
+
+fn __workflow_fresh_changed_paths(artifacts) {
+  var paths = []
+  for artifact in artifacts {
+    if __workflow_freshness_rank(artifact?.freshness) >= 2 {
+      for path in __workflow_metadata_string_list(artifact, "changed_paths") {
+        paths = __workflow_push_unique(paths, path)
+      }
+    }
+  }
+  return paths
+}
+
+fn __workflow_artifact_has_stale_evidence(artifact, fresh_changed_paths) {
+  let evidence_paths = __workflow_metadata_string_list(artifact, "evidence_paths")
+  if len(evidence_paths) == 0 {
+    return false
+  }
+  if __workflow_freshness_rank(artifact?.freshness) >= 2 {
+    return false
+  }
+  for path in evidence_paths {
+    if __workflow_contains(fresh_changed_paths, path) {
+      return true
+    }
+  }
+  return false
+}
+
+fn __workflow_drop_stale_evidence_artifacts(artifacts) {
+  let fresh_changed_paths = __workflow_fresh_changed_paths(artifacts)
+  if len(fresh_changed_paths) == 0 {
+    return artifacts
+  }
+  var out = []
+  for artifact in artifacts {
+    if !__workflow_artifact_has_stale_evidence(artifact, fresh_changed_paths) {
+      out = out.push(artifact)
+    }
+  }
+  return out
+}
+
+fn __workflow_artifact_text(artifact) {
+  if artifact?.text == nil {
+    return ""
+  }
+  return artifact.text
+}
+
+fn __workflow_artifact_priority(artifact) {
+  return __workflow_num(artifact?.priority, 0)
+}
+
+fn __workflow_dedup_artifacts(artifacts) {
+  var out = []
+  for artifact in artifacts {
+    let text = __workflow_artifact_text(artifact)
+    if text == "" {
+      out = out.push(artifact)
+      continue
+    }
+    var next = []
+    var replaced = false
+    for existing in out {
+      if !replaced && __workflow_artifact_text(existing) == text {
+        if __workflow_artifact_priority(artifact) > __workflow_artifact_priority(existing) {
+          next = next.push(artifact)
+        } else {
+          next = next.push(existing)
+        }
+        replaced = true
+      } else {
+        next = next.push(existing)
+      }
+    }
+    if !replaced {
+      next = next.push(artifact)
+    }
+    out = next
+  }
+  return out
+}
+
+fn __workflow_microcompact_text(text, max_chars) {
+  if len(text) <= max_chars || max_chars < 200 {
+    return text
+  }
+  let keep = floor(max_chars / 2)
+  let tail_start = max(len(text) - keep, 0)
+  let head = text.substring(0, keep)
+  let tail = text.substring(tail_start, len(text))
+  let snipped = len(text) - len(head) - len(tail)
+  return head + "\n\n[... " + to_string(snipped) + " characters snipped ...]\n\n" + tail
+}
+
+fn __workflow_microcompact_artifact(artifact, cap_tokens) {
+  let estimated = __workflow_num(artifact?.estimated_tokens, 0)
+  let max_chars = cap_tokens * 4
+  if estimated <= cap_tokens * 2 || max_chars < 200 || artifact?.text == nil {
+    return artifact
+  }
+  if len(artifact.text) <= max_chars {
+    return artifact
+  }
+  return artifact
+    + {text: __workflow_microcompact_text(artifact.text, max_chars), estimated_tokens: cap_tokens}
+}
+
+fn __workflow_microcompact_artifacts(artifacts, policy) {
+  if policy?.max_tokens == nil || len(artifacts) == 0 {
+    return artifacts
+  }
+  let count = max(len(artifacts), 1)
+  let max_tokens = policy.max_tokens
+  let per_artifact_budget = floor(max_tokens / count)
+  let cap = min(max(per_artifact_budget, 500), max_tokens)
+  var out = []
+  for artifact in artifacts {
+    out = out.push(__workflow_microcompact_artifact(artifact, cap))
+  }
+  return out
+}
+
+fn __workflow_artifact_matches_policy(artifact, policy) {
+  let include_kinds = __workflow_list(policy?.include_kinds)
+  let exclude_kinds = __workflow_list(policy?.exclude_kinds)
+  let include_stages = __workflow_list(policy?.include_stages)
+  if len(include_kinds) > 0 && !__workflow_contains(include_kinds, artifact?.kind) {
+    return false
+  }
+  if __workflow_contains(exclude_kinds, artifact?.kind) {
+    return false
+  }
+  if len(include_stages) > 0 && !__workflow_contains(include_stages, artifact?.stage) {
+    return false
+  }
+  return true
+}
+
+fn __workflow_artifact_precedes(left, right, policy) {
+  let pinned_ids = __workflow_list(policy?.pinned_ids)
+  let left_pinned = __workflow_contains(pinned_ids, left?.id)
+  let right_pinned = __workflow_contains(pinned_ids, right?.id)
+  if left_pinned != right_pinned {
+    return left_pinned
+  }
+  let prioritize_kinds = __workflow_list(policy?.prioritize_kinds)
+  let left_kind = __workflow_contains(prioritize_kinds, left?.kind)
+  let right_kind = __workflow_contains(prioritize_kinds, right?.kind)
+  if left_kind != right_kind {
+    return left_kind
+  }
+  let left_priority = __workflow_artifact_priority(left)
+  let right_priority = __workflow_artifact_priority(right)
+  if left_priority != right_priority {
+    return left_priority > right_priority
+  }
+  if policy?.prefer_fresh {
+    let left_fresh = __workflow_freshness_rank(left?.freshness)
+    let right_fresh = __workflow_freshness_rank(right?.freshness)
+    if left_fresh != right_fresh {
+      return left_fresh > right_fresh
+    }
+  }
+  if policy?.prefer_recent {
+    let left_created = to_string(left?.created_at ?? "")
+    let right_created = to_string(right?.created_at ?? "")
+    if left_created != right_created {
+      return left_created > right_created
+    }
+  }
+  let left_relevance = __workflow_num(left?.relevance, 0)
+  let right_relevance = __workflow_num(right?.relevance, 0)
+  if left_relevance != right_relevance {
+    return left_relevance > right_relevance
+  }
+  let left_tokens = __workflow_num(left?.estimated_tokens, 999999999)
+  let right_tokens = __workflow_num(right?.estimated_tokens, 999999999)
+  if left_tokens != right_tokens {
+    return left_tokens < right_tokens
+  }
+  return false
+}
+
+fn __workflow_insert_artifact_sorted(sorted, artifact, policy) {
+  var out = []
+  var inserted = false
+  for existing in sorted {
+    if !inserted && __workflow_artifact_precedes(artifact, existing, policy) {
+      out = out.push(artifact)
+      inserted = true
+    }
+    out = out.push(existing)
+  }
+  if !inserted {
+    out = out.push(artifact)
+  }
+  return out
+}
+
+fn __workflow_sort_artifacts(artifacts, policy) {
+  var sorted = []
+  for artifact in artifacts {
+    sorted = __workflow_insert_artifact_sorted(sorted, artifact, policy)
+  }
+  return sorted
+}
+
+/** workflow_stage_context_policy. */
+pub fn workflow_stage_context_policy(context_policy = nil, input_contract = nil) {
+  let policy = context_policy ?? {}
+  if len(__workflow_list(policy?.include_kinds)) > 0 {
+    return policy
+  }
+  let input_kinds = __workflow_list(input_contract?.input_kinds)
+  if len(input_kinds) == 0 {
+    return policy
+  }
+  return policy + {include_kinds: input_kinds}
+}
+
+/** workflow_select_artifacts. */
+pub fn workflow_select_artifacts(artifacts = nil, policy = nil) {
+  let opts = policy ?? {}
+  var candidates = []
+  for artifact in __workflow_list(artifacts) {
+    if __workflow_artifact_matches_policy(artifact, opts) {
+      candidates = candidates.push(artifact)
+    }
+  }
+  let sorted = __workflow_sort_artifacts(candidates, opts)
+  let reserve_tokens = __workflow_num(opts?.reserve_tokens, 0)
+  let max_tokens = if opts?.max_tokens == nil {
+    nil
+  } else {
+    max(__workflow_num(opts.max_tokens, 0) - reserve_tokens, 0)
+  }
+  var used_tokens = 0
+  var selected = []
+  for artifact in sorted {
+    if opts?.max_artifacts != nil && len(selected) >= opts.max_artifacts {
+      break
+    }
+    let next_tokens = __workflow_num(artifact?.estimated_tokens, 0)
+    if max_tokens != nil && used_tokens + next_tokens > max_tokens {
+      continue
+    }
+    used_tokens = used_tokens + next_tokens
+    selected = selected.push(artifact)
+  }
+  return selected
+}
+
+/** workflow_select_artifacts_adaptive. */
+pub fn workflow_select_artifacts_adaptive(artifacts = nil, policy = nil) {
+  let opts = policy ?? {}
+  let fresh = __workflow_drop_stale_evidence_artifacts(__workflow_list(artifacts))
+  let deduped = __workflow_dedup_artifacts(fresh)
+  let compacted = __workflow_microcompact_artifacts(deduped, opts)
+  return workflow_select_artifacts(compacted, opts)
+}
+
+/** workflow_select_stage_artifacts. */
+pub fn workflow_select_stage_artifacts(config = nil) {
+  let opts = config ?? {}
+  let policy = workflow_stage_context_policy(opts?.context_policy ?? {}, opts?.input_contract ?? {})
+  return {
+    context_policy: policy,
+    artifacts: workflow_select_artifacts_adaptive(opts?.artifacts ?? [], policy),
+  }
+}

--- a/crates/harn-vm/src/orchestration/artifacts.rs
+++ b/crates/harn-vm/src/orchestration/artifacts.rs
@@ -6,7 +6,8 @@ use serde::{Deserialize, Serialize};
 
 use super::{
     handoff_artifact_record, handoff_from_json_value, microcompact_tool_output, new_id,
-    normalize_handoff_artifact_json, now_rfc3339, ContextPolicy, VerificationContract,
+    normalize_handoff_artifact_json, now_rfc3339, ContextPolicy, StageContract,
+    VerificationContract,
 };
 
 /// Snip an artifact's text to fit within a token budget.
@@ -347,6 +348,58 @@ pub fn render_artifacts_context(artifacts: &[ArtifactRecord], policy: &ContextPo
     parts.join("\n\n")
 }
 
+async fn call_workflow_stdlib_function(
+    module: &str,
+    function: &str,
+    args: &[crate::value::VmValue],
+) -> Result<crate::value::VmValue, crate::value::VmError> {
+    let mut vm = crate::vm::Vm::new();
+    crate::stdlib::register_core_stdlib(&mut vm);
+    let exports = vm.load_module_exports_from_import(module).await?;
+    let closure = exports.get(function).cloned().ok_or_else(|| {
+        crate::value::VmError::Runtime(format!("{module} missing {function} export"))
+    })?;
+    vm.call_closure_pub(&closure, args).await
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct SelectedWorkflowStageArtifacts {
+    pub artifacts: Vec<ArtifactRecord>,
+    pub context_policy: ContextPolicy,
+}
+
+pub async fn select_workflow_stage_artifacts(
+    artifacts: &[ArtifactRecord],
+    context_policy: &ContextPolicy,
+    input_contract: &StageContract,
+) -> Result<SelectedWorkflowStageArtifacts, crate::value::VmError> {
+    let payload = serde_json::json!({
+        "artifacts": artifacts,
+        "context_policy": context_policy,
+        "input_contract": input_contract,
+    });
+    let config = crate::stdlib::json_to_vm_value(&payload);
+    let selected = call_workflow_stdlib_function(
+        "std/workflow/context",
+        "workflow_select_stage_artifacts",
+        &[config],
+    )
+    .await?;
+    let selected_json = crate::llm::vm_value_to_json(&selected);
+    let mut selected: SelectedWorkflowStageArtifacts = serde_json::from_value(selected_json)
+        .map_err(|error| {
+            crate::value::VmError::Runtime(format!(
+                "workflow_select_stage_artifacts returned invalid shape: {error}"
+            ))
+        })?;
+    selected.artifacts = selected
+        .artifacts
+        .into_iter()
+        .map(ArtifactRecord::normalize)
+        .collect();
+    Ok(selected)
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PreparedWorkflowStagePrompt {
     pub prompt: String,
@@ -371,20 +424,12 @@ pub async fn prepare_workflow_stage_prompt(
         "verification_contracts": verification_contracts,
     });
     let config = crate::stdlib::json_to_vm_value(&payload);
-    let mut vm = crate::vm::Vm::new();
-    crate::stdlib::register_core_stdlib(&mut vm);
-    let exports = vm
-        .load_module_exports_from_import("std/workflow/prompts")
-        .await?;
-    let prepare = exports
-        .get("workflow_prepare_stage_prompt")
-        .cloned()
-        .ok_or_else(|| {
-            crate::value::VmError::Runtime(
-                "std/workflow/prompts missing workflow_prepare_stage_prompt export".to_string(),
-            )
-        })?;
-    let prepared = vm.call_closure_pub(&prepare, &[config]).await?;
+    let prepared = call_workflow_stdlib_function(
+        "std/workflow/prompts",
+        "workflow_prepare_stage_prompt",
+        &[config],
+    )
+    .await?;
     let prepared = crate::llm::vm_value_to_json(&prepared);
     let prepared = prepared.as_object().ok_or_else(|| {
         crate::value::VmError::Runtime(

--- a/crates/harn-vm/src/orchestration/workflow.rs
+++ b/crates/harn-vm/src/orchestration/workflow.rs
@@ -1251,11 +1251,14 @@ pub async fn execute_stage_node(
     task: &str,
     artifacts: &[ArtifactRecord],
 ) -> Result<(serde_json::Value, Vec<ArtifactRecord>, Option<VmValue>), VmError> {
-    let mut selection_policy = node.context_policy.clone();
-    if selection_policy.include_kinds.is_empty() && !node.input_contract.input_kinds.is_empty() {
-        selection_policy.include_kinds = node.input_contract.input_kinds.clone();
-    }
-    let selected = super::select_artifacts_adaptive(artifacts.to_vec(), &selection_policy);
+    let selected_stage = super::select_workflow_stage_artifacts(
+        artifacts,
+        &node.context_policy,
+        &node.input_contract,
+    )
+    .await?;
+    let selected = selected_stage.artifacts;
+    let context_policy = selected_stage.context_policy;
     let rendered_context_override = if let Some(assembler) = node.raw_context_assembler.as_ref() {
         let assembled =
             crate::stdlib::assemble::assemble_from_options(&selected, assembler).await?;
@@ -1290,7 +1293,7 @@ pub async fn execute_stage_node(
         task,
         node.task_label.as_deref(),
         &selected,
-        &node.context_policy,
+        &context_policy,
         rendered_context_override.as_deref(),
         &verification_contracts,
     )

--- a/crates/harn-vm/src/stdlib/workflow/tests.rs
+++ b/crates/harn-vm/src/stdlib/workflow/tests.rs
@@ -4,9 +4,10 @@ use super::register::execute_workflow;
 use super::stage::{classify_stage_outcome, execute_stage_attempts, replay_stage};
 use crate::orchestration::{
     inject_workflow_verification_contracts, prepare_workflow_stage_prompt,
-    render_artifacts_context, save_run_record, workflow_verification_contracts, ContextPolicy,
-    RunChildRecord, RunExecutionRecord, RunRecord, RunStageRecord, VerificationContract,
-    VerificationRequirement, WorkflowEdge, WorkflowGraph, WorkflowNode,
+    render_artifacts_context, save_run_record, select_workflow_stage_artifacts,
+    workflow_verification_contracts, ContextPolicy, RunChildRecord, RunExecutionRecord, RunRecord,
+    RunStageRecord, VerificationContract, VerificationRequirement, WorkflowEdge, WorkflowGraph,
+    WorkflowNode,
 };
 use crate::tracing::{set_tracing_enabled, span_end, span_start, SpanKind};
 use crate::value::VmValue;
@@ -283,6 +284,60 @@ fn render_artifacts_context_uses_structured_artifact_blocks() {
     assert!(rendered.contains("<artifact>"));
     assert!(rendered.contains("<title>tests/unit/test_example.py</title>"));
     assert!(rendered.contains("<body>\ndef test_example():"));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn select_workflow_stage_artifacts_applies_input_kind_fallback_in_harn() {
+    let mut node = WorkflowNode::default();
+    node.input_contract.input_kinds = vec!["summary".to_string()];
+    let artifacts = vec![
+        crate::orchestration::ArtifactRecord {
+            id: "summary".to_string(),
+            kind: "summary".to_string(),
+            text: Some("summary".to_string()),
+            ..Default::default()
+        },
+        crate::orchestration::ArtifactRecord {
+            id: "file".to_string(),
+            kind: "workspace_file".to_string(),
+            text: Some("file".to_string()),
+            ..Default::default()
+        },
+    ];
+    let selected =
+        select_workflow_stage_artifacts(&artifacts, &node.context_policy, &node.input_contract)
+            .await
+            .expect("stage artifact selector runs");
+    assert_eq!(selected.context_policy.include_kinds, vec!["summary"]);
+    assert_eq!(selected.artifacts.len(), 1);
+    assert_eq!(selected.artifacts[0].id, "summary");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn select_workflow_stage_artifacts_keeps_highest_priority_duplicate_text() {
+    let node = WorkflowNode::default();
+    let artifacts = vec![
+        crate::orchestration::ArtifactRecord {
+            id: "low".to_string(),
+            kind: "summary".to_string(),
+            text: Some("same".to_string()),
+            priority: Some(1),
+            ..Default::default()
+        },
+        crate::orchestration::ArtifactRecord {
+            id: "high".to_string(),
+            kind: "summary".to_string(),
+            text: Some("same".to_string()),
+            priority: Some(10),
+            ..Default::default()
+        },
+    ];
+    let selected =
+        select_workflow_stage_artifacts(&artifacts, &node.context_policy, &node.input_contract)
+            .await
+            .expect("stage artifact selector runs");
+    assert_eq!(selected.artifacts.len(), 1);
+    assert_eq!(selected.artifacts[0].id, "high");
 }
 
 #[tokio::test(flavor = "current_thread", start_paused = true)]

--- a/crates/harn-vm/tests/orchestration_cutover.rs
+++ b/crates/harn-vm/tests/orchestration_cutover.rs
@@ -6,6 +6,8 @@ const AGENT_OPTIONS_HARN: &str = include_str!("../../harn-stdlib/src/stdlib/agen
 const AGENT_TURN_HARN: &str = include_str!("../../harn-stdlib/src/stdlib/agent/turn.harn");
 const WORKFLOW_EXECUTE_HARN: &str =
     include_str!("../../harn-stdlib/src/stdlib/workflow/execute.harn");
+const WORKFLOW_CONTEXT_HARN: &str =
+    include_str!("../../harn-stdlib/src/stdlib/workflow/context.harn");
 const WORKFLOW_PROMPTS_HARN: &str =
     include_str!("../../harn-stdlib/src/stdlib/workflow/prompts.harn");
 const CONTRACT_PROMPT_RS: &str = include_str!("../src/llm/tools/contract_prompt.rs");
@@ -60,6 +62,16 @@ fn public_orchestration_entrypoints_dispatch_through_harn_stdlib() {
         !WORKFLOW_ARTIFACTS_RS.contains("pub fn render_workflow_prompt")
             && !WORKFLOW_ARTIFACTS_RS.contains("pub fn render_verification_context"),
         "workflow stage and verification prompt renderers must not move back into Rust"
+    );
+    assert!(
+        WORKFLOW_RS.contains("select_workflow_stage_artifacts(")
+            && WORKFLOW_CONTEXT_HARN.contains("workflow_select_stage_artifacts"),
+        "workflow stage artifact selection policy belongs in std/workflow/context.harn"
+    );
+    assert!(
+        !WORKFLOW_RS.contains("selection_policy.include_kinds")
+            && !WORKFLOW_RS.contains("select_artifacts_adaptive(artifacts.to_vec()"),
+        "workflow.rs should not own stage artifact-selection policy"
     );
 }
 


### PR DESCRIPTION
## Summary

- Adds `std/workflow/context.harn` for Harn-owned stage context policy normalization and adaptive artifact selection.
- Routes Rust stage execution through `workflow_select_stage_artifacts`, removing the `input_contract.input_kinds` fallback and adaptive selection policy from `workflow.rs`.
- Covers stale evidence pruning, duplicate text priority, budget compaction, stage input-kind fallback, and adds ratchets so stage selection policy does not move back into Rust.

Part of #1197 and #1204.
Stacked on #1215.

## Verification

- `CARGO_TARGET_DIR=/tmp/harn-1197-target cargo run --quiet --bin harn -- test conformance --filter workflow_context_policy`
- `CARGO_TARGET_DIR=/tmp/harn-1197-target cargo run --quiet --bin harn -- test conformance --filter workflow`
- `CARGO_TARGET_DIR=/tmp/harn-1197-target cargo test -p harn-vm select_workflow_stage_artifacts -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-1197-target cargo test -p harn-vm stdlib::agents::workflow::tests`
- `CARGO_TARGET_DIR=/tmp/harn-1197-target cargo test -p harn-vm orchestration::tests`
- `CARGO_TARGET_DIR=/tmp/harn-1197-target cargo test -p harn-vm --test orchestration_cutover`
- `CARGO_TARGET_DIR=/tmp/harn-1197-target make fmt-harn`
- `CARGO_TARGET_DIR=/tmp/harn-1197-target make lint-harn`
- Pre-commit hook passed.
- Pre-push hook passed.
