### PR TITLE
[codex] Move workflow stage options into Harn

### DIFF
--- a/conformance/tests/agents/workflow_stage_options.expected
+++ b/conformance/tests/agents/workflow_stage_options.expected
@@ -1,0 +1,14 @@
+native
+true
+mock
+native
+4
+stage-1
+allow_once
+DONE
+true
+edit
+native
+native
+false
+16

--- a/conformance/tests/agents/workflow_stage_options.harn
+++ b/conformance/tests/agents/workflow_stage_options.harn
@@ -1,0 +1,50 @@
+import { workflow_stage_agent_options } from "std/workflow/options"
+
+pipeline default() {
+  let explicit = workflow_stage_agent_options(
+    {
+      mode: "agent",
+      has_tools: true,
+      session_id: "stage-1",
+      done_sentinel: "DONE",
+      exit_when_verified: true,
+      model_policy: {
+        provider: "mock",
+        model: "mock-model",
+        tool_format: " native ",
+        max_iterations: 4,
+        max_nudges: 1,
+        nudge: "use a tool",
+        native_tool_fallback: "allow_once",
+        tool_examples: "example",
+        stop_after_successful_tools: ["edit"],
+        require_successful_tools: ["test"],
+      },
+      host: {env_tool_format: "text", default_tool_format: "text"},
+    },
+  )
+  println(explicit.tool_format)
+  println(explicit.run_agent_loop)
+  println(explicit.llm_options.provider)
+  println(explicit.llm_options.tool_format)
+  println(explicit.agent_loop_options.max_iterations)
+  println(explicit.agent_loop_options.session_id)
+  println(explicit.agent_loop_options.native_tool_fallback)
+  println(explicit.agent_loop_options.done_sentinel)
+  println(explicit.agent_loop_options.exit_when_verified)
+  println(explicit.agent_loop_options.stop_after_successful_tools[0])
+  let env = workflow_stage_agent_options(
+    {
+      has_tools: true,
+      model_policy: {tool_format: "   "},
+      host: {env_tool_format: "native", default_tool_format: "text"},
+    },
+  )
+  println(env.tool_format)
+  let defaulted = workflow_stage_agent_options(
+    {has_tools: false, model_policy: {}, host: {env_tool_format: "", default_tool_format: "native"}},
+  )
+  println(defaulted.tool_format)
+  println(defaulted.run_agent_loop)
+  println(defaulted.agent_loop_options.max_iterations)
+}

--- a/crates/harn-stdlib/src/lib.rs
+++ b/crates/harn-stdlib/src/lib.rs
@@ -210,6 +210,10 @@ pub const STDLIB_SOURCES: &[StdlibSource] = &[
         source: include_str!("stdlib/workflow/context.harn"),
     },
     StdlibSource {
+        module: "workflow/options",
+        source: include_str!("stdlib/workflow/options.harn"),
+    },
+    StdlibSource {
         module: "workflow/execute",
         source: include_str!("stdlib/workflow/execute.harn"),
     },

--- a/crates/harn-stdlib/src/stdlib/workflow/options.harn
+++ b/crates/harn-stdlib/src/stdlib/workflow/options.harn
@@ -1,0 +1,109 @@
+fn __workflow_non_empty_string(value) {
+  if type_of(value) != "string" {
+    return nil
+  }
+  let trimmed = trim(value)
+  if trimmed == "" {
+    return nil
+  }
+  return trimmed
+}
+
+fn __workflow_stage_tool_format(model_policy, host) {
+  let explicit = __workflow_non_empty_string(model_policy?.tool_format)
+  if explicit != nil {
+    return explicit
+  }
+  let env = __workflow_non_empty_string(host?.env_tool_format)
+  if env != nil {
+    return env
+  }
+  let default_format = __workflow_non_empty_string(host?.default_tool_format)
+  if default_format != nil {
+    return default_format
+  }
+  return "text"
+}
+
+fn __workflow_native_tool_fallback(value) {
+  let policy = __workflow_non_empty_string(value)
+  if policy != nil {
+    return policy
+  }
+  return "reject"
+}
+
+fn __workflow_add_model_option(options, model_policy, key) {
+  let value = model_policy[key]
+  if value == nil {
+    return options
+  }
+  return options + {[key]: value}
+}
+
+fn __workflow_llm_options(config, model_policy, tool_format) {
+  var options = {tool_format: tool_format}
+  if __workflow_non_empty_string(config?.session_id) != nil {
+    options = options + {session_id: __workflow_non_empty_string(config?.session_id)}
+  }
+  options = __workflow_add_model_option(options, model_policy, "provider")
+  options = __workflow_add_model_option(options, model_policy, "model")
+  options = __workflow_add_model_option(options, model_policy, "model_tier")
+  options = __workflow_add_model_option(options, model_policy, "temperature")
+  options = __workflow_add_model_option(options, model_policy, "max_tokens")
+  return options
+}
+
+fn __workflow_add_loop_option(options, model_policy, key) {
+  let value = model_policy[key]
+  if value == nil {
+    return options
+  }
+  return options + {[key]: value}
+}
+
+fn __workflow_agent_loop_options(config, model_policy, tool_format) {
+  var options = {
+    persistent: true,
+    max_iterations: model_policy?.max_iterations ?? 16,
+    max_nudges: model_policy?.max_nudges ?? 3,
+    tool_retries: 0,
+    tool_backoff_ms: 1000,
+    schema_retries: 0,
+    tool_format: tool_format,
+    native_tool_fallback: __workflow_native_tool_fallback(model_policy?.native_tool_fallback),
+    daemon: false,
+    llm_retries: 2,
+    llm_backoff_ms: 2000,
+    exit_when_verified: config?.exit_when_verified ?? false,
+    loop_detect_warn: 2,
+    loop_detect_block: 3,
+    loop_detect_skip: 4,
+  }
+  if __workflow_non_empty_string(config?.session_id) != nil {
+    options = options + {session_id: __workflow_non_empty_string(config?.session_id)}
+  }
+  if config?.done_sentinel != nil {
+    options = options + {done_sentinel: config?.done_sentinel}
+  }
+  options = __workflow_add_loop_option(options, model_policy, "nudge")
+  options = __workflow_add_loop_option(options, model_policy, "tool_examples")
+  options = __workflow_add_loop_option(options, model_policy, "turn_policy")
+  options = __workflow_add_loop_option(options, model_policy, "stop_after_successful_tools")
+  options = __workflow_add_loop_option(options, model_policy, "require_successful_tools")
+  return options
+}
+
+/** workflow_stage_agent_options. */
+pub fn workflow_stage_agent_options(config = nil) {
+  let cfg = config ?? {}
+  let model_policy = cfg?.model_policy ?? {}
+  let host = cfg?.host ?? {}
+  let tool_format = __workflow_stage_tool_format(model_policy, host)
+  return {
+    run_agent_loop: cfg?.mode == "agent" || cfg?.has_tools,
+    tool_format: tool_format,
+    llm_options: __workflow_llm_options(cfg, model_policy, tool_format),
+    agent_loop_options: __workflow_agent_loop_options(cfg, model_policy, tool_format),
+  }
+}

--- a/crates/harn-vm/src/orchestration/artifacts.rs
+++ b/crates/harn-vm/src/orchestration/artifacts.rs
@@ -5,9 +5,9 @@ use std::collections::{BTreeMap, BTreeSet};
 use serde::{Deserialize, Serialize};
 
 use super::{
-    handoff_artifact_record, handoff_from_json_value, microcompact_tool_output, new_id,
-    normalize_handoff_artifact_json, now_rfc3339, ContextPolicy, StageContract,
-    VerificationContract,
+    call_workflow_stdlib_function, handoff_artifact_record, handoff_from_json_value,
+    microcompact_tool_output, new_id, normalize_handoff_artifact_json, now_rfc3339, ContextPolicy,
+    StageContract, VerificationContract,
 };
 
 /// Snip an artifact's text to fit within a token budget.
@@ -346,20 +346,6 @@ pub fn render_artifacts_context(artifacts: &[ArtifactRecord], policy: &ContextPo
         }
     }
     parts.join("\n\n")
-}
-
-async fn call_workflow_stdlib_function(
-    module: &str,
-    function: &str,
-    args: &[crate::value::VmValue],
-) -> Result<crate::value::VmValue, crate::value::VmError> {
-    let mut vm = crate::vm::Vm::new();
-    crate::stdlib::register_core_stdlib(&mut vm);
-    let exports = vm.load_module_exports_from_import(module).await?;
-    let closure = exports.get(function).cloned().ok_or_else(|| {
-        crate::value::VmError::Runtime(format!("{module} missing {function} export"))
-    })?;
-    vm.call_closure_pub(&closure, args).await
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq)]

--- a/crates/harn-vm/src/orchestration/mod.rs
+++ b/crates/harn-vm/src/orchestration/mod.rs
@@ -33,6 +33,9 @@ pub use command_policy::*;
 mod compaction;
 pub use compaction::*;
 
+mod stdlib_bridge;
+pub(crate) use stdlib_bridge::*;
+
 mod artifacts;
 pub use artifacts::*;
 
@@ -53,6 +56,9 @@ pub use release_fixture::*;
 
 mod policy;
 pub use policy::*;
+
+mod stage_options;
+pub use stage_options::*;
 
 mod workflow;
 pub use workflow::*;

--- a/crates/harn-vm/src/orchestration/policy/types.rs
+++ b/crates/harn-vm/src/orchestration/policy/types.rs
@@ -376,8 +376,8 @@ pub struct ModelPolicy {
     /// `"native"` routes user tools through the provider's native
     /// function-call channel; `"text"` embeds the `<tool_call>` contract
     /// prompt. Mirrors the top-level `agent_loop(..., {tool_format: ...})`
-    /// option. When `None`, the workflow falls back to `HARN_AGENT_TOOL_FORMAT`
-    /// env / the provider-model default.
+    /// option. When `None`, std/workflow/options.harn composes the fallback
+    /// from host-provided env/default facts.
     pub tool_format: Option<String>,
     /// Policy for native-tool stages when a provider emits text-mode
     /// `<tool_call>` output instead of native tool calls.

--- a/crates/harn-vm/src/orchestration/stage_options.rs
+++ b/crates/harn-vm/src/orchestration/stage_options.rs
@@ -1,0 +1,97 @@
+use std::collections::BTreeMap;
+
+use serde::Deserialize;
+
+use super::WorkflowNode;
+use crate::value::{VmError, VmValue};
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct WorkflowStageAgentOptions {
+    pub run_agent_loop: bool,
+    pub tool_format: String,
+    pub llm_options: BTreeMap<String, serde_json::Value>,
+    pub agent_loop_options: BTreeMap<String, serde_json::Value>,
+}
+
+impl WorkflowStageAgentOptions {
+    pub fn llm_options_vm_dict(&self) -> BTreeMap<String, VmValue> {
+        json_map_to_vm_dict(&self.llm_options)
+    }
+
+    pub fn agent_loop_options_vm_dict(&self) -> BTreeMap<String, VmValue> {
+        json_map_to_vm_dict(&self.agent_loop_options)
+    }
+}
+
+pub async fn prepare_workflow_stage_agent_options(
+    node: &WorkflowNode,
+    session_id: &str,
+    has_tools: bool,
+) -> Result<WorkflowStageAgentOptions, VmError> {
+    let model_policy = serde_json::to_value(&node.model_policy).map_err(|error| {
+        VmError::Runtime(format!("workflow stage model_policy encode error: {error}"))
+    })?;
+    let payload = serde_json::json!({
+        "kind": node.kind,
+        "mode": node.mode,
+        "has_tools": has_tools,
+        "session_id": session_id,
+        "done_sentinel": node.done_sentinel,
+        "exit_when_verified": node.exit_when_verified,
+        "model_policy": model_policy,
+        "host": {
+            "env_tool_format": non_empty_env("HARN_AGENT_TOOL_FORMAT"),
+            "default_tool_format": default_stage_tool_format(&node.model_policy),
+        },
+    });
+    let prepared = super::call_workflow_stdlib_function(
+        "std/workflow/options",
+        "workflow_stage_agent_options",
+        &[crate::stdlib::json_to_vm_value(&payload)],
+    )
+    .await?;
+    let prepared = crate::llm::vm_value_to_json(&prepared);
+    let prepared: WorkflowStageAgentOptions =
+        serde_json::from_value(prepared).map_err(|error| {
+            VmError::Runtime(format!(
+                "workflow_stage_agent_options returned invalid shape: {error}"
+            ))
+        })?;
+    if prepared.tool_format.trim().is_empty() {
+        return Err(VmError::Runtime(
+            "workflow_stage_agent_options returned empty tool_format".to_string(),
+        ));
+    }
+    Ok(prepared)
+}
+
+fn json_map_to_vm_dict(map: &BTreeMap<String, serde_json::Value>) -> BTreeMap<String, VmValue> {
+    map.iter()
+        .map(|(key, value)| (key.clone(), crate::stdlib::json_to_vm_value(value)))
+        .collect()
+}
+
+fn non_empty_env(key: &str) -> Option<String> {
+    std::env::var(key)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn default_stage_tool_format(model_policy: &super::ModelPolicy) -> String {
+    let model = model_policy
+        .model
+        .as_ref()
+        .filter(|value| !value.trim().is_empty())
+        .cloned()
+        .or_else(|| non_empty_env("HARN_LLM_MODEL"))
+        .unwrap_or_default();
+    let provider = model_policy
+        .provider
+        .as_ref()
+        .filter(|value| !value.trim().is_empty())
+        .cloned()
+        .or_else(|| non_empty_env("HARN_LLM_PROVIDER"))
+        .unwrap_or_default();
+    crate::llm_config::default_tool_format(&model, &provider)
+}

--- a/crates/harn-vm/src/orchestration/stdlib_bridge.rs
+++ b/crates/harn-vm/src/orchestration/stdlib_bridge.rs
@@ -1,0 +1,16 @@
+use crate::value::{VmError, VmValue};
+
+pub(crate) async fn call_workflow_stdlib_function(
+    module: &str,
+    function: &str,
+    args: &[VmValue],
+) -> Result<VmValue, VmError> {
+    let mut vm = crate::vm::Vm::new();
+    crate::stdlib::register_core_stdlib(&mut vm);
+    let exports = vm.load_module_exports_from_import(module).await?;
+    let closure = exports
+        .get(function)
+        .cloned()
+        .ok_or_else(|| VmError::Runtime(format!("{module} missing {function} export")))?;
+    vm.call_closure_pub(&closure, args).await
+}

--- a/crates/harn-vm/src/orchestration/workflow.rs
+++ b/crates/harn-vm/src/orchestration/workflow.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use super::{
     new_id, now_rfc3339, redact_transcript_visibility, ArtifactRecord, AutoCompactPolicy,
     BranchSemantics, CapabilityPolicy, ContextPolicy, EscalationPolicy, JoinPolicy, MapPolicy,
-    ModelPolicy, ReducePolicy, RetryPolicy, StageContract,
+    ModelPolicy, NativeToolFallbackPolicy, ReducePolicy, RetryPolicy, StageContract,
 };
 use crate::llm::{extract_llm_options, vm_call_llm_full, vm_value_to_json};
 use crate::tool_annotations::{SideEffectLevel, ToolAnnotations, ToolArgSchema, ToolKind};
@@ -1245,6 +1245,22 @@ pub(crate) async fn resolve_stage_auto_compact(
     Ok(Some(ac))
 }
 
+fn parse_native_tool_fallback_option(
+    options: &Option<BTreeMap<String, VmValue>>,
+) -> Result<NativeToolFallbackPolicy, VmError> {
+    crate::llm::helpers::opt_str(options, "native_tool_fallback")
+        .map(|value| {
+            NativeToolFallbackPolicy::parse(&value).ok_or_else(|| {
+                VmError::Runtime(format!(
+                    "workflow_stage_agent_options: native_tool_fallback must be one of \
+                     allow, allow_once, reject; got `{value}`"
+                ))
+            })
+        })
+        .transpose()
+        .map(|value| value.unwrap_or_default())
+}
+
 pub async fn execute_stage_node(
     node_id: &str,
     node: &WorkflowNode,
@@ -1302,28 +1318,14 @@ pub async fn execute_stage_node(
     let rendered_context = prepared_prompt.rendered_context;
     let rendered_verification = prepared_prompt.rendered_verification;
 
-    // Precedence for the tool-calling contract format:
-    //   1. explicit `model_policy.tool_format` on the node
-    //   2. `HARN_AGENT_TOOL_FORMAT` env override
-    //   3. provider/model default
-    // Mirrors the top-level agent_loop / llm_call resolution so workflow
-    // authors can pin `tool_format: "native"` per-stage and have it
-    // reach the inner agent loop.
-    let tool_format = node
-        .model_policy
-        .tool_format
-        .clone()
-        .filter(|value| !value.trim().is_empty())
-        .or_else(|| {
-            std::env::var("HARN_AGENT_TOOL_FORMAT")
-                .ok()
-                .filter(|value| !value.trim().is_empty())
-        })
-        .unwrap_or_else(|| {
-            let model = std::env::var("HARN_LLM_MODEL").unwrap_or_default();
-            let provider = std::env::var("HARN_LLM_PROVIDER").unwrap_or_default();
-            crate::llm_config::default_tool_format(&model, &provider)
-        });
+    let tool_names = workflow_tool_names(&node.tools);
+    let stage_agent_options = super::prepare_workflow_stage_agent_options(
+        node,
+        &stage_session_id,
+        !tool_names.is_empty(),
+    )
+    .await?;
+    let tool_format = stage_agent_options.tool_format.clone();
     let mut llm_result = if node.kind == "verify" {
         if let Some(command) = node
             .verify
@@ -1380,32 +1382,7 @@ pub async fn execute_stage_node(
             })
         }
     } else {
-        let mut options = BTreeMap::new();
-        if let Some(provider) = &node.model_policy.provider {
-            options.insert(
-                "provider".to_string(),
-                VmValue::String(Rc::from(provider.clone())),
-            );
-        }
-        if let Some(model) = &node.model_policy.model {
-            options.insert(
-                "model".to_string(),
-                VmValue::String(Rc::from(model.clone())),
-            );
-        }
-        if let Some(model_tier) = &node.model_policy.model_tier {
-            options.insert(
-                "model_tier".to_string(),
-                VmValue::String(Rc::from(model_tier.clone())),
-            );
-        }
-        if let Some(temperature) = node.model_policy.temperature {
-            options.insert("temperature".to_string(), VmValue::Float(temperature));
-        }
-        if let Some(max_tokens) = node.model_policy.max_tokens {
-            options.insert("max_tokens".to_string(), VmValue::Int(max_tokens));
-        }
-        let tool_names = workflow_tool_names(&node.tools);
+        let mut options = stage_agent_options.llm_options_vm_dict();
         let tools_value = node.raw_tools.clone().or_else(|| {
             if matches!(node.tools, serde_json::Value::Null) {
                 None
@@ -1416,10 +1393,6 @@ pub async fn execute_stage_node(
         if tools_value.is_some() && !tool_names.is_empty() {
             options.insert("tools".to_string(), tools_value.unwrap_or(VmValue::Nil));
         }
-        options.insert(
-            "session_id".to_string(),
-            VmValue::String(Rc::from(stage_session_id.clone())),
-        );
 
         let args = vec![
             VmValue::String(Rc::from(prompt.clone())),
@@ -1433,7 +1406,8 @@ pub async fn execute_stage_node(
         let auto_compact = resolve_stage_auto_compact(node, &opts).await?;
         let budget = opts.budget.clone();
 
-        if node.mode.as_deref() == Some("agent") || !tool_names.is_empty() {
+        if stage_agent_options.run_agent_loop {
+            let agent_loop_options = Some(stage_agent_options.agent_loop_options_vm_dict());
             let tool_policy = workflow_tool_policy_from_tools(&node.tools);
             let effective_policy = tool_policy
                 .intersect(&node.capability_policy)
@@ -1448,15 +1422,32 @@ pub async fn execute_stage_node(
             crate::llm::run_agent_loop_internal(
                 &mut opts,
                 crate::llm::AgentLoopConfig {
-                    persistent: true,
-                    max_iterations: node.model_policy.max_iterations.unwrap_or(16),
-                    max_nudges: node.model_policy.max_nudges.unwrap_or(3),
-                    nudge: node.model_policy.nudge.clone(),
-                    done_sentinel: node.done_sentinel.clone(),
+                    persistent: crate::llm::helpers::opt_bool(&agent_loop_options, "persistent"),
+                    max_iterations: crate::llm::helpers::opt_int(
+                        &agent_loop_options,
+                        "max_iterations",
+                    )
+                    .unwrap_or(16) as usize,
+                    max_nudges: crate::llm::helpers::opt_int(&agent_loop_options, "max_nudges")
+                        .unwrap_or(3) as usize,
+                    nudge: crate::llm::helpers::opt_str(&agent_loop_options, "nudge"),
+                    done_sentinel: crate::llm::helpers::opt_str(
+                        &agent_loop_options,
+                        "done_sentinel",
+                    ),
                     break_unless_phase: None,
-                    tool_retries: 0,
-                    tool_backoff_ms: 1000,
-                    schema_retries: 0,
+                    tool_retries: crate::llm::helpers::opt_int(&agent_loop_options, "tool_retries")
+                        .unwrap_or(0) as usize,
+                    tool_backoff_ms: crate::llm::helpers::opt_int(
+                        &agent_loop_options,
+                        "tool_backoff_ms",
+                    )
+                    .unwrap_or(1000) as u64,
+                    schema_retries: crate::llm::helpers::opt_int(
+                        &agent_loop_options,
+                        "schema_retries",
+                    )
+                    .unwrap_or(0) as usize,
                     schema_retry_nudge: crate::llm::parse_schema_nudge(
                         &node
                             .raw_model_policy
@@ -1464,8 +1455,9 @@ pub async fn execute_stage_node(
                             .and_then(|value| value.as_dict())
                             .cloned(),
                     ),
-                    tool_format: tool_format.clone(),
-                    native_tool_fallback: node.model_policy.native_tool_fallback,
+                    tool_format: crate::llm::helpers::opt_str(&agent_loop_options, "tool_format")
+                        .unwrap_or_else(|| tool_format.clone()),
+                    native_tool_fallback: parse_native_tool_fallback_option(&agent_loop_options)?,
                     auto_compact,
                     policy: Some(effective_policy),
                     command_policy: crate::orchestration::parse_command_policy_value(
@@ -1485,23 +1477,53 @@ pub async fn execute_stage_node(
                     )?,
                     permissions,
                     approval_policy: Some(node.approval_policy.clone()),
-                    daemon: false,
+                    daemon: crate::llm::helpers::opt_bool(&agent_loop_options, "daemon"),
                     daemon_config: Default::default(),
-                    llm_retries: 2,
-                    llm_backoff_ms: 2000,
+                    llm_retries: crate::llm::helpers::opt_int(&agent_loop_options, "llm_retries")
+                        .unwrap_or(2) as usize,
+                    llm_backoff_ms: crate::llm::helpers::opt_int(
+                        &agent_loop_options,
+                        "llm_backoff_ms",
+                    )
+                    .unwrap_or(2000) as u64,
                     token_budget: None,
                     budget,
-                    exit_when_verified: node.exit_when_verified,
-                    loop_detect_warn: 2,
-                    loop_detect_block: 3,
-                    loop_detect_skip: 4,
-                    tool_examples: node.model_policy.tool_examples.clone(),
-                    turn_policy: node.model_policy.turn_policy.clone(),
-                    stop_after_successful_tools: node
-                        .model_policy
-                        .stop_after_successful_tools
-                        .clone(),
-                    require_successful_tools: node.model_policy.require_successful_tools.clone(),
+                    exit_when_verified: crate::llm::helpers::opt_bool(
+                        &agent_loop_options,
+                        "exit_when_verified",
+                    ),
+                    loop_detect_warn: crate::llm::helpers::opt_int(
+                        &agent_loop_options,
+                        "loop_detect_warn",
+                    )
+                    .unwrap_or(2) as usize,
+                    loop_detect_block: crate::llm::helpers::opt_int(
+                        &agent_loop_options,
+                        "loop_detect_block",
+                    )
+                    .unwrap_or(3) as usize,
+                    loop_detect_skip: crate::llm::helpers::opt_int(
+                        &agent_loop_options,
+                        "loop_detect_skip",
+                    )
+                    .unwrap_or(4) as usize,
+                    tool_examples: crate::llm::helpers::opt_str(
+                        &agent_loop_options,
+                        "tool_examples",
+                    ),
+                    turn_policy: agent_loop_options
+                        .as_ref()
+                        .and_then(|options| options.get("turn_policy"))
+                        .map(crate::llm::helpers::vm_value_to_json)
+                        .and_then(|json| serde_json::from_value(json).ok()),
+                    stop_after_successful_tools: crate::llm::helpers::opt_str_list(
+                        &agent_loop_options,
+                        "stop_after_successful_tools",
+                    ),
+                    require_successful_tools: crate::llm::helpers::opt_str_list(
+                        &agent_loop_options,
+                        "require_successful_tools",
+                    ),
                     // Use the same session id resolved for the stage so
                     // agent_subscribe handlers keyed on it, and session
                     // storage lookups in the agent loop, stay consistent.

--- a/crates/harn-vm/src/stdlib/workflow/tests.rs
+++ b/crates/harn-vm/src/stdlib/workflow/tests.rs
@@ -3,11 +3,11 @@ use super::map::{execute_join_policy, LocalTask};
 use super::register::execute_workflow;
 use super::stage::{classify_stage_outcome, execute_stage_attempts, replay_stage};
 use crate::orchestration::{
-    inject_workflow_verification_contracts, prepare_workflow_stage_prompt,
-    render_artifacts_context, save_run_record, select_workflow_stage_artifacts,
-    workflow_verification_contracts, ContextPolicy, RunChildRecord, RunExecutionRecord, RunRecord,
-    RunStageRecord, VerificationContract, VerificationRequirement, WorkflowEdge, WorkflowGraph,
-    WorkflowNode,
+    inject_workflow_verification_contracts, prepare_workflow_stage_agent_options,
+    prepare_workflow_stage_prompt, render_artifacts_context, save_run_record,
+    select_workflow_stage_artifacts, workflow_verification_contracts, ContextPolicy,
+    RunChildRecord, RunExecutionRecord, RunRecord, RunStageRecord, VerificationContract,
+    VerificationRequirement, WorkflowEdge, WorkflowGraph, WorkflowNode,
 };
 use crate::tracing::{set_tracing_enabled, span_end, span_start, SpanKind};
 use crate::value::VmValue;
@@ -284,6 +284,50 @@ fn render_artifacts_context_uses_structured_artifact_blocks() {
     assert!(rendered.contains("<artifact>"));
     assert!(rendered.contains("<title>tests/unit/test_example.py</title>"));
     assert!(rendered.contains("<body>\ndef test_example():"));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn prepare_workflow_stage_agent_options_runs_policy_in_harn() {
+    let mut node = WorkflowNode {
+        mode: Some("agent".to_string()),
+        done_sentinel: Some("DONE".to_string()),
+        exit_when_verified: true,
+        ..Default::default()
+    };
+    node.model_policy.tool_format = Some(" native ".to_string());
+    node.model_policy.max_iterations = Some(4);
+    node.model_policy.max_nudges = Some(1);
+    node.model_policy.nudge = Some("use a tool".to_string());
+    node.model_policy.native_tool_fallback =
+        crate::orchestration::NativeToolFallbackPolicy::AllowOnce;
+    node.model_policy.tool_examples = Some("example".to_string());
+    node.model_policy.stop_after_successful_tools = Some(vec!["edit".to_string()]);
+    node.model_policy.require_successful_tools = Some(vec!["test".to_string()]);
+
+    let prepared = prepare_workflow_stage_agent_options(&node, "stage-session", true)
+        .await
+        .expect("workflow stage options compose");
+    assert!(prepared.run_agent_loop);
+    assert_eq!(prepared.tool_format, "native");
+    assert_eq!(prepared.llm_options["session_id"], "stage-session");
+    assert_eq!(prepared.llm_options["tool_format"], "native");
+    assert_eq!(prepared.agent_loop_options["max_iterations"], 4);
+    assert_eq!(prepared.agent_loop_options["max_nudges"], 1);
+    assert_eq!(prepared.agent_loop_options["nudge"], "use a tool");
+    assert_eq!(
+        prepared.agent_loop_options["native_tool_fallback"],
+        "allow_once"
+    );
+    assert_eq!(prepared.agent_loop_options["done_sentinel"], "DONE");
+    assert_eq!(prepared.agent_loop_options["exit_when_verified"], true);
+    assert_eq!(
+        prepared.agent_loop_options["stop_after_successful_tools"][0],
+        "edit"
+    );
+    assert_eq!(
+        prepared.agent_loop_options["require_successful_tools"][0],
+        "test"
+    );
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/crates/harn-vm/tests/orchestration_cutover.rs
+++ b/crates/harn-vm/tests/orchestration_cutover.rs
@@ -8,6 +8,8 @@ const WORKFLOW_EXECUTE_HARN: &str =
     include_str!("../../harn-stdlib/src/stdlib/workflow/execute.harn");
 const WORKFLOW_CONTEXT_HARN: &str =
     include_str!("../../harn-stdlib/src/stdlib/workflow/context.harn");
+const WORKFLOW_OPTIONS_HARN: &str =
+    include_str!("../../harn-stdlib/src/stdlib/workflow/options.harn");
 const WORKFLOW_PROMPTS_HARN: &str =
     include_str!("../../harn-stdlib/src/stdlib/workflow/prompts.harn");
 const CONTRACT_PROMPT_RS: &str = include_str!("../src/llm/tools/contract_prompt.rs");
@@ -129,6 +131,19 @@ fn public_orchestration_entrypoints_dispatch_through_harn_stdlib() {
         !WORKFLOW_RS.contains("selection_policy.include_kinds")
             && !WORKFLOW_RS.contains("select_artifacts_adaptive(artifacts.to_vec()"),
         "workflow.rs should not own stage artifact-selection policy"
+    );
+    assert!(
+        WORKFLOW_RS.contains("prepare_workflow_stage_agent_options(")
+            && WORKFLOW_OPTIONS_HARN.contains("workflow_stage_agent_options"),
+        "workflow stage agent option composition belongs in std/workflow/options.harn"
+    );
+    assert!(
+        !WORKFLOW_RS.contains("HARN_AGENT_TOOL_FORMAT")
+            && !WORKFLOW_RS.contains("default_tool_format(&model, &provider)")
+            && !WORKFLOW_RS
+                .contains("max_iterations: node.model_policy.max_iterations.unwrap_or(16)")
+            && !WORKFLOW_RS.contains("max_nudges: node.model_policy.max_nudges.unwrap_or(3)"),
+        "workflow.rs should not own stage tool-format/default loop policy"
     );
 }
 


### PR DESCRIPTION
## Summary
- moves workflow stage tool-format/default loop option composition into `std/workflow/options.harn`
- adds a small Rust bridge that passes host facts to Harn and leaves Rust responsible for security parsing, closures, and final host execution wiring
- adds conformance/unit coverage plus cutover ratchets so this policy does not move back into `workflow.rs`

## Validation
- `CARGO_TARGET_DIR=/tmp/harn-1197-target cargo check -p harn-vm`
- `CARGO_TARGET_DIR=/tmp/harn-1197-target cargo run --quiet --bin harn -- test conformance --filter workflow`
- `CARGO_TARGET_DIR=/tmp/harn-1197-target cargo test -p harn-vm stdlib::agents::workflow::tests -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-1197-target cargo test -p harn-vm --test orchestration_cutover`
- `CARGO_TARGET_DIR=/tmp/harn-1197-target cargo test -p harn-vm --test builtin_registry_alignment`
- `CARGO_TARGET_DIR=/tmp/harn-1197-target make fmt-harn`
- `CARGO_TARGET_DIR=/tmp/harn-1197-target make lint-harn`
