### PR TITLE
[codex] Implement MCP completion support

### DIFF
--- a/crates/harn-cli/src/commands/mcp/prompts.rs
+++ b/crates/harn-cli/src/commands/mcp/prompts.rs
@@ -29,6 +29,7 @@ struct FilePromptArgument {
     name: String,
     description: Option<String>,
     required: bool,
+    suggestions: Vec<String>,
 }
 
 #[derive(Clone, Debug)]
@@ -61,6 +62,8 @@ struct PromptArgumentFrontMatter {
     description: Option<String>,
     #[serde(default = "default_required")]
     required: bool,
+    #[serde(default, alias = "completions", alias = "values")]
+    suggestions: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -143,6 +146,28 @@ impl FilePromptCatalog {
             .find(|prompt| prompt.name == name)
             .ok_or_else(|| format!("Unknown prompt: {name}"))?;
         prompt.render(arguments)
+    }
+
+    pub(crate) fn complete(
+        &self,
+        name: &str,
+        argument_name: &str,
+        value: &str,
+    ) -> Result<JsonValue, String> {
+        let prompt = self
+            .prompts
+            .iter()
+            .find(|prompt| prompt.name == name)
+            .ok_or_else(|| format!("Unknown prompt: {name}"))?;
+        let argument = prompt
+            .arguments
+            .iter()
+            .find(|argument| argument.name == argument_name)
+            .ok_or_else(|| format!("Unknown prompt argument: {argument_name}"))?;
+        Ok(harn_vm::mcp_protocol::completion_payload(
+            argument.suggestions.clone(),
+            value,
+        ))
     }
 }
 
@@ -282,6 +307,7 @@ fn load_prompt_file(
                 name: argument.name,
                 description: argument.description,
                 required: argument.required,
+                suggestions: argument.suggestions,
             })
             .collect()
     };
@@ -415,6 +441,7 @@ fn infer_arguments(body: &str) -> Vec<FilePromptArgument> {
             name,
             description: None,
             required: true,
+            suggestions: Vec::new(),
         })
         .collect()
 }

--- a/crates/harn-cli/src/commands/mcp/serve.rs
+++ b/crates/harn-cli/src/commands/mcp/serve.rs
@@ -496,6 +496,9 @@ impl McpOrchestratorService {
             "resources/templates/list" => self.handle_resource_templates_list(id, &params),
             "prompts/list" => self.handle_prompts_list(id, &params),
             "prompts/get" => self.handle_prompts_get(id, &params),
+            mcp_protocol::METHOD_COMPLETION_COMPLETE => {
+                self.handle_completion_complete(id, &params)
+            }
             _ if mcp_protocol::unsupported_latest_spec_method(method).is_some() => {
                 mcp_protocol::unsupported_latest_spec_method_response(id, method)
                     .expect("checked unsupported MCP method")
@@ -554,6 +557,7 @@ impl McpOrchestratorService {
                     "prompts": { "listChanged": true },
                     "logging": {},
                     "tasks": mcp_protocol::tasks_capability(),
+                    "completions": mcp_protocol::completions_capability(),
                 },
                 "serverInfo": {
                     "name": "harn-orchestrator",
@@ -598,6 +602,54 @@ impl McpOrchestratorService {
                 harn_vm::jsonrpc::error_response(id, -32602, &error)
             }
             Err(error) => harn_vm::jsonrpc::error_response(id, -32603, &error),
+        }
+    }
+
+    fn handle_completion_complete(&self, id: JsonValue, params: &JsonValue) -> JsonValue {
+        let Some(ref_type) = params.pointer("/ref/type").and_then(JsonValue::as_str) else {
+            return harn_vm::jsonrpc::error_response(id, -32602, "completion ref.type is required");
+        };
+        match ref_type {
+            "ref/prompt" => self.handle_prompt_completion(id, params),
+            "ref/resource" => {
+                harn_vm::jsonrpc::error_response(id, -32602, "Unknown resource template")
+            }
+            other => harn_vm::jsonrpc::error_response(
+                id,
+                -32602,
+                &format!("Unsupported completion ref.type: {other}"),
+            ),
+        }
+    }
+
+    fn handle_prompt_completion(&self, id: JsonValue, params: &JsonValue) -> JsonValue {
+        let name = params
+            .pointer("/ref/name")
+            .and_then(JsonValue::as_str)
+            .unwrap_or_default();
+        let Some(argument_name) = params
+            .pointer("/argument/name")
+            .and_then(JsonValue::as_str)
+            .filter(|value| !value.is_empty())
+        else {
+            return harn_vm::jsonrpc::error_response(
+                id,
+                -32602,
+                "completion argument.name is required",
+            );
+        };
+        let value = params
+            .pointer("/argument/value")
+            .and_then(JsonValue::as_str)
+            .unwrap_or_default();
+        let result = self
+            .prompt_catalog
+            .lock()
+            .expect("prompt catalog poisoned")
+            .complete(name, argument_name, value);
+        match result {
+            Ok(completion) => harn_vm::jsonrpc::response(id, json!({ "completion": completion })),
+            Err(error) => harn_vm::jsonrpc::error_response(id, -32602, &error),
         }
     }
 
@@ -3510,8 +3562,12 @@ images = [{ path = "pixel.png", mime_type = "image/png" }]
 name = "code"
 description = "Code to review"
 required = true
+[[arguments]]
+name = "language"
+required = false
+suggestions = ["rust", "ruby", "typescript"]
 ---
-Review this: {{ code }}
+Review this {{ language }}: {{ code }}
 "#,
         );
         let service = McpOrchestratorService::new(&fixture_args(&temp)).unwrap();
@@ -3529,6 +3585,26 @@ Review this: {{ code }}
             prompts["result"]["prompts"][0]["arguments"][0]["description"],
             json!("Code to review")
         );
+
+        let completion = service
+            .handle_request(
+                &mut session,
+                harn_vm::jsonrpc::request(
+                    19,
+                    mcp_protocol::METHOD_COMPLETION_COMPLETE,
+                    json!({
+                        "ref": {"type": "ref/prompt", "name": "review"},
+                        "argument": {"name": "language", "value": "ru"},
+                    }),
+                ),
+            )
+            .await;
+        assert_eq!(
+            completion["result"]["completion"]["values"],
+            json!(["ruby", "rust"])
+        );
+        assert_eq!(completion["result"]["completion"]["total"], json!(2));
+        assert_eq!(completion["result"]["completion"]["hasMore"], json!(false));
 
         let missing = service
             .handle_request(

--- a/crates/harn-cli/tests/harn_serve_mcp_cli.rs
+++ b/crates/harn-cli/tests/harn_serve_mcp_cli.rs
@@ -92,13 +92,17 @@ pipeline main(task) {
     name: "Config",
     description: "Config values",
     mime_type: "text/plain",
+    completions: {key: {values: ["name"], complete: { request -> ["version"] }}},
     handler: { args -> "value:" + args.key }
   })
 
   mcp_prompt({
     name: "review",
     description: "Review prompt",
-    arguments: [{name: "code", required: true}],
+    arguments: [
+      {name: "code", required: true},
+      {name: "language", required: false, suggestions: ["rust", "ruby", "typescript"]},
+    ],
     handler: { args -> "Review this: " + args.code }
   })
 }
@@ -456,6 +460,42 @@ fn serve_mcp_stdio_exposes_script_registered_surface() {
         json!({"jsonrpc": "2.0", "id": 5, "method": "prompts/list", "params": {}}),
     );
     assert_eq!(prompts["result"]["prompts"][0]["name"], "review");
+
+    let prompt_completion = send_stdio_request(
+        &mut stdin,
+        &rx,
+        json!({
+            "jsonrpc": "2.0",
+            "id": 16,
+            "method": "completion/complete",
+            "params": {
+                "ref": {"type": "ref/prompt", "name": "review"},
+                "argument": {"name": "language", "value": "ru"}
+            }
+        }),
+    );
+    assert_eq!(
+        prompt_completion["result"]["completion"]["values"],
+        json!(["ruby", "rust"])
+    );
+
+    let resource_completion = send_stdio_request(
+        &mut stdin,
+        &rx,
+        json!({
+            "jsonrpc": "2.0",
+            "id": 17,
+            "method": "completion/complete",
+            "params": {
+                "ref": {"type": "ref/resource", "uri": "config://{key}"},
+                "argument": {"name": "key", "value": "ver"}
+            }
+        }),
+    );
+    assert_eq!(
+        resource_completion["result"]["completion"]["values"],
+        json!(["version"])
+    );
 
     let prompt = send_stdio_request(
         &mut stdin,

--- a/crates/harn-serve/src/adapters/mcp.rs
+++ b/crates/harn-serve/src/adapters/mcp.rs
@@ -411,6 +411,9 @@ impl McpServer {
                 -32602,
                 "Unknown prompt",
             )),
+            mcp_protocol::METHOD_COMPLETION_COMPLETE => ImmediateResult::Response(
+                harn_vm::jsonrpc::error_response(id, -32602, "Unknown completion reference"),
+            ),
             _ if mcp_protocol::unsupported_latest_spec_method(method).is_some() => {
                 ImmediateResult::Response(
                     mcp_protocol::unsupported_latest_spec_method_response(id, method)
@@ -468,6 +471,10 @@ impl McpServer {
             capabilities.insert("resources".to_string(), json!({}));
         }
         capabilities.insert("logging".to_string(), json!({}));
+        capabilities.insert(
+            "completions".to_string(),
+            mcp_protocol::completions_capability(),
+        );
 
         let mut server_info = json!({
             "name": self.server_name,

--- a/crates/harn-vm/src/mcp_protocol.rs
+++ b/crates/harn-vm/src/mcp_protocol.rs
@@ -7,6 +7,7 @@ pub const METHOD_TASKS_GET: &str = "tasks/get";
 pub const METHOD_TASKS_RESULT: &str = "tasks/result";
 pub const METHOD_TASKS_LIST: &str = "tasks/list";
 pub const METHOD_TASKS_CANCEL: &str = "tasks/cancel";
+pub const METHOD_COMPLETION_COMPLETE: &str = "completion/complete";
 pub const METHOD_TASK_STATUS_NOTIFICATION: &str = "notifications/tasks/status";
 pub const METHOD_ROOTS_LIST: &str = "roots/list";
 pub const METHOD_ROOTS_LIST_CHANGED_NOTIFICATION: &str = "notifications/roots/list_changed";
@@ -31,12 +32,6 @@ pub struct UnsupportedMcpMethod {
 }
 
 pub const UNSUPPORTED_LATEST_SPEC_METHODS: &[UnsupportedMcpMethod] = &[
-    UnsupportedMcpMethod {
-        method: "completion/complete",
-        feature: "completions",
-        role: "server",
-        reason: "Harn does not expose prompt or resource-template argument completion.",
-    },
     // `sampling/createMessage` (client) is supported — handled in
     // `mcp::handle_inbound_client_request` via
     // `mcp_sampling::dispatch_inbound_sampling`, which routes the
@@ -52,6 +47,8 @@ pub const UNSUPPORTED_LATEST_SPEC_METHODS: &[UnsupportedMcpMethod] = &[
     // inbound server-to-client root discovery requests. It is intentionally
     // omitted from this gap list.
 ];
+
+pub const MCP_COMPLETION_MAX_VALUES: usize = 100;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum McpTaskStatus {
@@ -163,6 +160,58 @@ pub fn tasks_capability() -> JsonValue {
     })
 }
 
+pub fn completions_capability() -> JsonValue {
+    json!({})
+}
+
+pub fn completion_result(
+    id: impl Into<JsonValue>,
+    candidates: Vec<String>,
+    value: &str,
+) -> JsonValue {
+    crate::jsonrpc::response(
+        id,
+        json!({ "completion": completion_payload(candidates, value) }),
+    )
+}
+
+pub fn completion_payload(candidates: Vec<String>, value: &str) -> JsonValue {
+    let needle = value.to_ascii_lowercase();
+    let mut seen = std::collections::BTreeSet::new();
+    let mut ranked = candidates
+        .into_iter()
+        .filter_map(|candidate| {
+            let candidate = candidate.trim().to_string();
+            if candidate.is_empty() || !seen.insert(candidate.clone()) {
+                return None;
+            }
+            let haystack = candidate.to_ascii_lowercase();
+            if !needle.is_empty() && !haystack.contains(&needle) {
+                return None;
+            }
+            let rank = if needle.is_empty() || haystack.starts_with(&needle) {
+                0
+            } else {
+                1
+            };
+            Some((rank, haystack, candidate))
+        })
+        .collect::<Vec<_>>();
+    ranked.sort_by(|left, right| left.0.cmp(&right.0).then_with(|| left.1.cmp(&right.1)));
+
+    let total = ranked.len();
+    let values = ranked
+        .into_iter()
+        .take(MCP_COMPLETION_MAX_VALUES)
+        .map(|(_, _, candidate)| candidate)
+        .collect::<Vec<_>>();
+    json!({
+        "values": values,
+        "total": total,
+        "hasMore": total > MCP_COMPLETION_MAX_VALUES,
+    })
+}
+
 pub fn tool_execution(task_support: McpToolTaskSupport) -> JsonValue {
     json!({
         "taskSupport": task_support.as_str(),
@@ -243,13 +292,24 @@ mod tests {
     use super::*;
 
     #[test]
-    fn latest_spec_gap_methods_are_explicit() {
-        let method = "completion/complete";
-        let response = unsupported_latest_spec_method_response(json!(1), method)
-            .expect("expected explicit unsupported method");
-        assert_eq!(response["error"]["code"], json!(-32601));
-        assert_eq!(response["error"]["data"]["method"], json!(method));
-        assert_eq!(response["error"]["data"]["status"], json!("unsupported"));
+    fn completion_complete_is_no_longer_in_the_unsupported_gap_list() {
+        assert!(unsupported_latest_spec_method(METHOD_COMPLETION_COMPLETE).is_none());
+        let response = completion_result(
+            json!(1),
+            vec![
+                "typescript".to_string(),
+                "rust".to_string(),
+                "ruby".to_string(),
+                "rust".to_string(),
+            ],
+            "ru",
+        );
+        assert_eq!(
+            response["result"]["completion"]["values"],
+            json!(["ruby", "rust"])
+        );
+        assert_eq!(response["result"]["completion"]["total"], json!(2));
+        assert_eq!(response["result"]["completion"]["hasMore"], json!(false));
     }
 
     #[test]

--- a/crates/harn-vm/src/mcp_server/defs.rs
+++ b/crates/harn-vm/src/mcp_server/defs.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use crate::value::VmClosure;
 
 /// A tool extracted from a Harn tool_registry, ready to serve over MCP.
@@ -29,7 +31,15 @@ pub struct McpResourceTemplateDef {
     pub title: Option<String>,
     pub description: Option<String>,
     pub mime_type: Option<String>,
+    pub completions: BTreeMap<String, McpCompletionSource>,
     pub handler: VmClosure,
+}
+
+/// Static or computed suggestions for a prompt/resource-template argument.
+#[derive(Default)]
+pub struct McpCompletionSource {
+    pub values: Vec<String>,
+    pub handler: Option<VmClosure>,
 }
 
 /// A prompt argument definition.
@@ -37,6 +47,7 @@ pub struct McpPromptArgDef {
     pub name: String,
     pub description: Option<String>,
     pub required: bool,
+    pub completion: Option<McpCompletionSource>,
 }
 
 /// A prompt template to serve over MCP.

--- a/crates/harn-vm/src/mcp_server/mod.rs
+++ b/crates/harn-vm/src/mcp_server/mod.rs
@@ -18,7 +18,10 @@ mod uri;
 mod tests;
 
 const PROTOCOL_VERSION: &str = "2025-11-25";
-pub use defs::{McpPromptArgDef, McpPromptDef, McpResourceDef, McpResourceTemplateDef, McpToolDef};
+pub use defs::{
+    McpCompletionSource, McpPromptArgDef, McpPromptDef, McpResourceDef, McpResourceTemplateDef,
+    McpToolDef,
+};
 pub use register::{
     register_mcp_server_builtins, take_mcp_serve_prompts, take_mcp_serve_registry,
     take_mcp_serve_resource_templates, take_mcp_serve_resources,

--- a/crates/harn-vm/src/mcp_server/register.rs
+++ b/crates/harn-vm/src/mcp_server/register.rs
@@ -1,4 +1,5 @@
 use std::cell::RefCell;
+use std::collections::BTreeMap;
 use std::rc::Rc;
 
 use serde_json::Value as JsonValue;
@@ -7,7 +8,9 @@ use crate::mcp_elicit::current_bus;
 use crate::value::{VmError, VmValue};
 use crate::vm::Vm;
 
-use super::defs::{McpPromptArgDef, McpPromptDef, McpResourceDef, McpResourceTemplateDef};
+use super::defs::{
+    McpCompletionSource, McpPromptArgDef, McpPromptDef, McpResourceDef, McpResourceTemplateDef,
+};
 
 thread_local! {
     /// Stores the tool registry set by `mcp_tools` / `mcp_serve`.
@@ -125,6 +128,9 @@ pub fn register_mcp_server_builtins(vm: &mut Vm) {
                 ));
             }
         };
+        let completions = completion_sources_from_dict(
+            dict.get("completions").or_else(|| dict.get("suggestions")),
+        );
 
         MCP_SERVE_RESOURCE_TEMPLATES.with(|cell| {
             cell.borrow_mut().push(McpResourceTemplateDef {
@@ -133,6 +139,7 @@ pub fn register_mcp_server_builtins(vm: &mut Vm) {
                 title,
                 description,
                 mime_type,
+                completions,
                 handler,
             });
         });
@@ -177,6 +184,7 @@ pub fn register_mcp_server_builtins(vm: &mut Vm) {
                                 name: d.get("name").map(|v| v.display()).unwrap_or_default(),
                                 description: d.get("description").map(|v| v.display()),
                                 required: matches!(d.get("required"), Some(VmValue::Bool(true))),
+                                completion: completion_source_from_argument_dict(d),
                             })
                         } else {
                             None
@@ -251,6 +259,68 @@ pub fn register_mcp_server_builtins(vm: &mut Vm) {
 
         bus.elicit(message, requested_schema_json).await
     });
+}
+
+fn completion_sources_from_dict(value: Option<&VmValue>) -> BTreeMap<String, McpCompletionSource> {
+    let Some(VmValue::Dict(sources)) = value else {
+        return BTreeMap::new();
+    };
+    sources
+        .iter()
+        .filter_map(|(name, value)| {
+            completion_source_from_value(value).map(|source| (name.clone(), source))
+        })
+        .collect()
+}
+
+fn completion_source_from_argument_dict(
+    dict: &BTreeMap<String, VmValue>,
+) -> Option<McpCompletionSource> {
+    let mut source = McpCompletionSource::default();
+    for key in ["suggestions", "completions", "values"] {
+        if let Some(value) = dict.get(key) {
+            source.values.extend(completion_values_from_value(value));
+        }
+    }
+    for key in ["complete", "completion", "handler"] {
+        if let Some(VmValue::Closure(closure)) = dict.get(key) {
+            source.handler = Some((**closure).clone());
+            break;
+        }
+    }
+    (!source.values.is_empty() || source.handler.is_some()).then_some(source)
+}
+
+fn completion_source_from_value(value: &VmValue) -> Option<McpCompletionSource> {
+    match value {
+        VmValue::Closure(closure) => Some(McpCompletionSource {
+            values: Vec::new(),
+            handler: Some((**closure).clone()),
+        }),
+        VmValue::Dict(dict) => completion_source_from_argument_dict(dict),
+        _ => {
+            let values = completion_values_from_value(value);
+            (!values.is_empty()).then_some(McpCompletionSource {
+                values,
+                handler: None,
+            })
+        }
+    }
+}
+
+fn completion_values_from_value(value: &VmValue) -> Vec<String> {
+    match value {
+        VmValue::List(items) => items.iter().map(completion_value_to_string).collect(),
+        VmValue::String(value) => vec![value.to_string()],
+        _ => Vec::new(),
+    }
+}
+
+fn completion_value_to_string(value: &VmValue) -> String {
+    match value {
+        VmValue::String(value) => value.to_string(),
+        _ => value.display(),
+    }
 }
 
 // Thread-local accessors used by the CLI after pipeline execution.

--- a/crates/harn-vm/src/mcp_server/server.rs
+++ b/crates/harn-vm/src/mcp_server/server.rs
@@ -8,9 +8,11 @@ use crate::stdlib::json_to_vm_value;
 use crate::value::VmError;
 use crate::vm::Vm;
 
-use super::convert::{prompt_value_to_messages, vm_value_to_content};
-use super::defs::{McpPromptDef, McpResourceDef, McpResourceTemplateDef, McpToolDef};
-use super::uri::match_uri_template;
+use super::convert::{prompt_value_to_messages, vm_value_to_content, vm_value_to_json};
+use super::defs::{
+    McpCompletionSource, McpPromptDef, McpResourceDef, McpResourceTemplateDef, McpToolDef,
+};
+use super::uri::{match_uri_template, uri_template_variables};
 use super::PROTOCOL_VERSION;
 
 /// MCP server that exposes Harn tools, resources, and prompts over MCP JSON-RPC.
@@ -173,6 +175,9 @@ impl McpServer {
             "resources/templates/list" => self.handle_resource_templates_list(&id, &params),
             "prompts/list" => self.handle_prompts_list(&id, &params),
             "prompts/get" => self.handle_prompts_get(&id, &params, vm).await,
+            crate::mcp_protocol::METHOD_COMPLETION_COMPLETE => {
+                self.handle_completion_complete(&id, &params, vm).await
+            }
             _ if crate::mcp_protocol::unsupported_latest_spec_method(method).is_some() => {
                 crate::mcp_protocol::unsupported_latest_spec_method_response(id.clone(), method)
                     .expect("checked unsupported MCP method")
@@ -207,6 +212,10 @@ impl McpServer {
         }
         capabilities.insert("logging".into(), serde_json::json!({}));
         capabilities.insert("tasks".into(), crate::mcp_protocol::tasks_capability());
+        capabilities.insert(
+            "completions".into(),
+            crate::mcp_protocol::completions_capability(),
+        );
         // Always advertise elicitation: any registered tool may decide
         // at runtime whether to call `mcp_elicit(...)`, so capability
         // negotiation can't be tied to a static check.
@@ -721,5 +730,184 @@ impl McpServer {
                 "error": { "code": -32603, "message": format!("{e}") }
             }),
         }
+    }
+
+    async fn handle_completion_complete(
+        &self,
+        id: &serde_json::Value,
+        params: &serde_json::Value,
+        vm: &mut Vm,
+    ) -> serde_json::Value {
+        let Some(ref_type) = params.pointer("/ref/type").and_then(|value| value.as_str()) else {
+            return crate::jsonrpc::error_response(
+                id.clone(),
+                -32602,
+                "completion ref.type is required",
+            );
+        };
+        match ref_type {
+            "ref/prompt" => self.complete_prompt_argument(id, params, vm).await,
+            "ref/resource" => {
+                self.complete_resource_template_argument(id, params, vm)
+                    .await
+            }
+            other => crate::jsonrpc::error_response(
+                id.clone(),
+                -32602,
+                &format!("Unsupported completion ref.type: {other}"),
+            ),
+        }
+    }
+
+    async fn complete_prompt_argument(
+        &self,
+        id: &serde_json::Value,
+        params: &serde_json::Value,
+        vm: &mut Vm,
+    ) -> serde_json::Value {
+        let name = params
+            .pointer("/ref/name")
+            .and_then(|value| value.as_str())
+            .unwrap_or("");
+        let argument_name = match completion_argument_name(params) {
+            Ok(name) => name,
+            Err(error) => return crate::jsonrpc::error_response(id.clone(), -32602, &error),
+        };
+        let value = completion_argument_value(params);
+        let prompt = match self.prompts.iter().find(|prompt| prompt.name == name) {
+            Some(prompt) => prompt,
+            None => {
+                return crate::jsonrpc::error_response(
+                    id.clone(),
+                    -32602,
+                    &format!("Unknown prompt: {name}"),
+                );
+            }
+        };
+        let Some(argument) = prompt
+            .arguments
+            .as_deref()
+            .unwrap_or_default()
+            .iter()
+            .find(|argument| argument.name == argument_name)
+        else {
+            return crate::jsonrpc::error_response(
+                id.clone(),
+                -32602,
+                &format!("Unknown prompt argument: {argument_name}"),
+            );
+        };
+        let candidates =
+            match completion_source_candidates(argument.completion.as_ref(), params, vm).await {
+                Ok(candidates) => candidates,
+                Err(error) => return crate::jsonrpc::error_response(id.clone(), -32603, &error),
+            };
+        crate::mcp_protocol::completion_result(id.clone(), candidates, value)
+    }
+
+    async fn complete_resource_template_argument(
+        &self,
+        id: &serde_json::Value,
+        params: &serde_json::Value,
+        vm: &mut Vm,
+    ) -> serde_json::Value {
+        let uri = params
+            .pointer("/ref/uri")
+            .and_then(|value| value.as_str())
+            .unwrap_or("");
+        let argument_name = match completion_argument_name(params) {
+            Ok(name) => name,
+            Err(error) => return crate::jsonrpc::error_response(id.clone(), -32602, &error),
+        };
+        let value = completion_argument_value(params);
+        let template = match self
+            .resource_templates
+            .iter()
+            .find(|template| template.uri_template == uri)
+        {
+            Some(template) => template,
+            None => {
+                return crate::jsonrpc::error_response(
+                    id.clone(),
+                    -32602,
+                    &format!("Unknown resource template: {uri}"),
+                );
+            }
+        };
+        if !uri_template_variables(&template.uri_template)
+            .iter()
+            .any(|name| name == argument_name)
+        {
+            return crate::jsonrpc::error_response(
+                id.clone(),
+                -32602,
+                &format!("Unknown resource template argument: {argument_name}"),
+            );
+        }
+        let candidates =
+            match completion_source_candidates(template.completions.get(argument_name), params, vm)
+                .await
+            {
+                Ok(candidates) => candidates,
+                Err(error) => return crate::jsonrpc::error_response(id.clone(), -32603, &error),
+            };
+        crate::mcp_protocol::completion_result(id.clone(), candidates, value)
+    }
+}
+
+fn completion_argument_name(params: &serde_json::Value) -> Result<&str, String> {
+    params
+        .pointer("/argument/name")
+        .and_then(|value| value.as_str())
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "completion argument.name is required".to_string())
+}
+
+fn completion_argument_value(params: &serde_json::Value) -> &str {
+    params
+        .pointer("/argument/value")
+        .and_then(|value| value.as_str())
+        .unwrap_or_default()
+}
+
+async fn completion_source_candidates(
+    source: Option<&McpCompletionSource>,
+    params: &serde_json::Value,
+    vm: &mut Vm,
+) -> Result<Vec<String>, String> {
+    let Some(source) = source else {
+        return Ok(Vec::new());
+    };
+    let mut candidates = source.values.clone();
+    if let Some(handler) = source.handler.as_ref() {
+        let request = json_to_vm_value(params);
+        let value = vm
+            .call_closure_pub(handler, &[request])
+            .await
+            .map_err(|error| format!("{error}"))?;
+        candidates.extend(completion_candidates_from_json(&vm_value_to_json(&value)));
+    }
+    Ok(candidates)
+}
+
+fn completion_candidates_from_json(value: &serde_json::Value) -> Vec<String> {
+    match value {
+        serde_json::Value::Array(items) => {
+            items.iter().filter_map(json_completion_string).collect()
+        }
+        serde_json::Value::Object(map) => map
+            .get("values")
+            .or_else(|| map.get("completion").and_then(|value| value.get("values")))
+            .map(completion_candidates_from_json)
+            .unwrap_or_default(),
+        _ => json_completion_string(value).into_iter().collect(),
+    }
+}
+
+fn json_completion_string(value: &serde_json::Value) -> Option<String> {
+    match value {
+        serde_json::Value::String(value) => Some(value.clone()),
+        serde_json::Value::Number(_) | serde_json::Value::Bool(_) => Some(value.to_string()),
+        _ => None,
     }
 }

--- a/crates/harn-vm/src/mcp_server/tests.rs
+++ b/crates/harn-vm/src/mcp_server/tests.rs
@@ -5,11 +5,33 @@ use crate::chunk::{Chunk, CompiledFunction};
 use crate::value::{VmClosure, VmEnv, VmValue};
 
 use super::convert::{annotations_to_json, prompt_value_to_messages};
-use super::defs::McpResourceDef;
+use super::defs::{
+    McpCompletionSource, McpPromptArgDef, McpPromptDef, McpResourceDef, McpResourceTemplateDef,
+};
 use super::tool_registry_to_mcp_tools;
 use super::tools_schema::params_to_json_schema;
 use super::uri::match_uri_template;
 use super::McpServer;
+
+fn empty_closure(name: &str) -> VmClosure {
+    VmClosure {
+        func: Rc::new(CompiledFunction {
+            name: name.to_string(),
+            type_params: Vec::new(),
+            nominal_type_names: Vec::new(),
+            params: Vec::new(),
+            default_start: None,
+            chunk: Rc::new(Chunk::new()),
+            is_generator: false,
+            is_stream: false,
+            has_rest_param: false,
+        }),
+        env: VmEnv::new(),
+        source_dir: None,
+        module_functions: None,
+        module_state: None,
+    }
+}
 
 #[test]
 fn test_params_to_json_schema_empty() {
@@ -70,23 +92,7 @@ fn test_tool_registry_to_mcp_tools_empty() {
 
 #[test]
 fn test_tool_registry_to_mcp_tools_preserves_metadata() {
-    let handler = VmValue::Closure(Rc::new(VmClosure {
-        func: Rc::new(CompiledFunction {
-            name: "echo".to_string(),
-            type_params: Vec::new(),
-            nominal_type_names: Vec::new(),
-            params: Vec::new(),
-            default_start: None,
-            chunk: Rc::new(Chunk::new()),
-            is_generator: false,
-            is_stream: false,
-            has_rest_param: false,
-        }),
-        env: VmEnv::new(),
-        source_dir: None,
-        module_functions: None,
-        module_state: None,
-    }));
+    let handler = VmValue::Closure(Rc::new(empty_closure("echo")));
 
     let mut annotations = BTreeMap::new();
     annotations.insert("readOnlyHint".into(), VmValue::Bool(true));
@@ -373,6 +379,107 @@ async fn server_advertises_elicitation_capability() {
     assert!(
         response["result"]["capabilities"]["elicitation"].is_object(),
         "expected elicitation capability, got {response:?}"
+    );
+}
+
+#[tokio::test]
+async fn server_completion_complete_returns_prompt_and_resource_suggestions() {
+    let mut resource_completions = BTreeMap::new();
+    resource_completions.insert(
+        "key".to_string(),
+        McpCompletionSource {
+            values: vec!["name".to_string(), "version".to_string()],
+            handler: None,
+        },
+    );
+    let server = McpServer::new(
+        "test".to_string(),
+        Vec::new(),
+        Vec::new(),
+        vec![McpResourceTemplateDef {
+            uri_template: "config://{key}".to_string(),
+            name: "Configuration".to_string(),
+            title: None,
+            description: None,
+            mime_type: Some("text/plain".to_string()),
+            completions: resource_completions,
+            handler: empty_closure("resource"),
+        }],
+        vec![McpPromptDef {
+            name: "review".to_string(),
+            title: None,
+            description: None,
+            arguments: Some(vec![McpPromptArgDef {
+                name: "language".to_string(),
+                description: None,
+                required: false,
+                completion: Some(McpCompletionSource {
+                    values: vec![
+                        "rust".to_string(),
+                        "ruby".to_string(),
+                        "typescript".to_string(),
+                    ],
+                    handler: None,
+                }),
+            }]),
+            handler: empty_closure("prompt"),
+        }],
+    );
+    let mut vm = crate::Vm::new();
+
+    let init = server
+        .handle_json_rpc(
+            crate::jsonrpc::request(1, "initialize", serde_json::json!({})),
+            &mut vm,
+        )
+        .await
+        .expect("response");
+    assert!(init["result"]["capabilities"]["completions"].is_object());
+
+    let prompt = server
+        .handle_json_rpc(
+            crate::jsonrpc::request(
+                2,
+                crate::mcp_protocol::METHOD_COMPLETION_COMPLETE,
+                serde_json::json!({
+                    "ref": {"type": "ref/prompt", "name": "review"},
+                    "argument": {"name": "language", "value": "ru"},
+                }),
+            ),
+            &mut vm,
+        )
+        .await
+        .expect("response");
+    assert_eq!(
+        prompt["result"]["completion"]["values"],
+        serde_json::json!(["ruby", "rust"])
+    );
+    assert_eq!(
+        prompt["result"]["completion"]["total"],
+        serde_json::json!(2)
+    );
+    assert_eq!(
+        prompt["result"]["completion"]["hasMore"],
+        serde_json::json!(false)
+    );
+
+    let resource = server
+        .handle_json_rpc(
+            crate::jsonrpc::request(
+                3,
+                crate::mcp_protocol::METHOD_COMPLETION_COMPLETE,
+                serde_json::json!({
+                    "ref": {"type": "ref/resource", "uri": "config://{key}"},
+                    "argument": {"name": "key", "value": "ver"},
+                }),
+            ),
+            &mut vm,
+        )
+        .await
+        .expect("response");
+    assert_eq!(
+        resource["result"]["completion"]["values"],
+        serde_json::json!(["version"])
     );
 }
 

--- a/crates/harn-vm/src/mcp_server/uri.rs
+++ b/crates/harn-vm/src/mcp_server/uri.rs
@@ -55,3 +55,20 @@ pub(super) fn match_uri_template(
         None
     }
 }
+
+pub(super) fn uri_template_variables(template: &str) -> Vec<String> {
+    let mut variables = Vec::new();
+    let mut cursor = template;
+    while let Some(open) = cursor.find('{') {
+        cursor = &cursor[open + 1..];
+        let Some(close) = cursor.find('}') else {
+            break;
+        };
+        let name = cursor[..close].trim();
+        if !name.is_empty() && !variables.iter().any(|variable| variable == name) {
+            variables.push(name.to_string());
+        }
+        cursor = &cursor[close + 1..];
+    }
+    variables
+}

--- a/docs/src/builtins.md
+++ b/docs/src/builtins.md
@@ -1972,8 +1972,8 @@ tool registry dict.
 | `tool_synthesis_clear()` | — | nil | Clear the current run's synthesized tool cache |
 | `mcp_tools(registry)` | registry: dict | nil | Register tools for MCP serving |
 | `mcp_resource(config)` | config: dict | nil | Register a static resource (`{uri, name, text, description?, mime_type?}`) |
-| `mcp_resource_template(config)` | config: dict | nil | Register a resource template (`{uri_template, name, handler, description?, mime_type?}`) |
-| `mcp_prompt(config)` | config: dict | nil | Register a prompt (`{name, handler, description?, arguments?}`) |
+| `mcp_resource_template(config)` | config: dict | nil | Register a resource template (`{uri_template, name, handler, description?, mime_type?, completions?}`); `completions` maps URI variable names to static suggestion lists or completion closures |
+| `mcp_prompt(config)` | config: dict | nil | Register a prompt (`{name, handler, description?, arguments?}`); prompt arguments may include `suggestions`/`completions` or a `complete` closure for MCP `completion/complete` |
 
 `tool_synthesize(config)` is the guarded natural-language tool bootstrapper. It
 returns a callable closure and pins the synthesis in an in-memory cache keyed by

--- a/docs/src/mcp-server.md
+++ b/docs/src/mcp-server.md
@@ -293,12 +293,18 @@ description = "Review code"
 name = "code"
 description = "Code to review"
 required = true
+[[arguments]]
+name = "language"
+required = false
+suggestions = ["rust", "typescript", "python"]
 ---
 Review this:
 {{ code }}
 ```
 
 `prompts/get` renders the template with the supplied `arguments` object.
+`completion/complete` uses the optional `suggestions`/`completions` list on
+front-matter arguments when a client asks for prompt argument completions.
 The server advertises `tools.listChanged`, `resources.listChanged`, and
 `prompts.listChanged`. It emits the corresponding `notifications/*/list_changed`
 messages when watched manifest, prompt, lockfile, or package metadata changes.
@@ -325,8 +331,8 @@ clients accept inbound sampling — see the
 | `resources/subscribe`, `resources/unsubscribe` | Supported for EventLog topic resources; updates emit `notifications/resources/updated` |
 | `prompts/list` | Supported for `.harn.prompt` files in the project and prompt-library packages |
 | `prompts/get` | Supported; renders prompt templates with supplied arguments |
+| `completion/complete` | Supported for prompt arguments with front-matter suggestions |
 | `elicitation/create` | Supported on script-driven `harn run --serve mcp` surfaces via the `mcp_elicit(...)` builtin (see [Elicitation](#elicitation)). The orchestrator-mode tool catalog does not currently issue elicitations. |
-| `completion/complete` | Explicitly unsupported |
 | `roots/list` | Explicitly unsupported |
 | `sampling/createMessage` | Server-initiated sampling against the connected client is not emitted by the orchestrator catalog. Harn-as-MCP-client *does* accept inbound `sampling/createMessage` (routed to `llm_call` via the host bridge) — see the [client matrix](mcp-and-acp.html#mcp-client-support-matrix). |
 | `tasks/get`, `tasks/result`, `tasks/list`, `tasks/cancel` | Explicitly unsupported |

--- a/docs/src/tutorial-mcp-server.md
+++ b/docs/src/tutorial-mcp-server.md
@@ -59,6 +59,7 @@ pipeline main(task) {
     uri_template: "config://{key}",
     name: "Configuration values",
     mime_type: "text/plain",
+    completions: { key: ["name", "version"] },
     handler: { args ->
       if args.key == "version" {
         "0.6.0"
@@ -86,7 +87,11 @@ pipeline main(task) {
     description: "Review code for correctness and maintainability",
     arguments: [
       { name: "code", description: "The code to review", required: true },
-      { name: "language", description: "Programming language" }
+      {
+        name: "language",
+        description: "Programming language",
+        suggestions: ["rust", "typescript", "python"]
+      }
     ],
     handler: { args ->
       let lang = args.language ?? "unknown"


### PR DESCRIPTION
## Summary

- Implement MCP `completion/complete` and advertise the `completions` capability.
- Add completion sources for file-backed `.harn.prompt` arguments, Harn-registered prompt arguments, and URI template variables.
- Support static suggestions and Harn completion closures, with ranked/capped MCP response shaping.
- Update MCP docs and script-surface smoke coverage.

Closes #878

## Verification

- `cargo check -p harn-vm -p harn-cli -p harn-serve`
- `cargo test -p harn-vm completion_complete`
- `cargo test -p harn-cli commands::mcp::serve::tests::file_backed_prompts_list_render_and_notify_changes`
- `cargo test -p harn-cli --test harn_serve_mcp_cli serve_mcp_stdio_exposes_script_registered_surface -- --ignored --exact`
- pre-commit hook: `cargo clippy --workspace --all-targets -- -D warnings`, markdownlint
- pre-push hook: targeted local checks, markdownlint
