### PR TITLE
[codex] Consolidate builtin registration groups

### DIFF
--- a/crates/harn-vm/src/llm/agent_config.rs
+++ b/crates/harn-vm/src/llm/agent_config.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use crate::agent_events::AgentEventSink;
 use crate::stdlib::harn_entry::{register_harn_module_entrypoints, HarnEntrypointModule};
-use crate::stdlib::registration::{register_sync_builtins, SyncBuiltin};
+use crate::stdlib::registration::{register_builtin_group, BuiltinGroup, SyncBuiltin};
 use crate::value::{VmError, VmValue};
 use crate::vm::{Vm, VmBuiltinArity, VmBuiltinMetadata};
 
@@ -38,14 +38,16 @@ const AGENT_CONTROL_PRIMITIVES: &[SyncBuiltin] = &[
     SyncBuiltin::new("agent_subscribe", agent_subscribe_builtin)
         .signature("agent_subscribe(session_id, callback)")
         .arity(VmBuiltinArity::Exact(2))
-        .category("agent.host")
         .doc("Subscribe a Harn callback to events for an agent session."),
     SyncBuiltin::new("agent_inject_feedback", agent_inject_feedback_builtin)
         .signature("agent_inject_feedback(session_id, kind, content)")
         .arity(VmBuiltinArity::Exact(3))
-        .category("agent.host")
         .doc("Inject pending feedback into an agent session."),
 ];
+
+const AGENT_CONTROL_GROUP: BuiltinGroup<'static> = BuiltinGroup::new()
+    .category("agent.host")
+    .sync(AGENT_CONTROL_PRIMITIVES);
 
 #[derive(Clone)]
 pub struct AgentLoopConfig {
@@ -646,7 +648,7 @@ pub fn register_agent_loop_with_bridge(vm: &mut Vm, bridge: Rc<crate::bridge::Ho
 }
 
 pub(crate) fn register_agent_control_primitives(vm: &mut Vm) {
-    register_sync_builtins(vm, AGENT_CONTROL_PRIMITIVES);
+    register_builtin_group(vm, AGENT_CONTROL_GROUP);
 }
 
 fn agent_subscribe_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {

--- a/crates/harn-vm/src/llm/config_builtins.rs
+++ b/crates/harn-vm/src/llm/config_builtins.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 use crate::llm_config;
 use crate::stdlib::json_to_vm_value;
 use crate::stdlib::registration::{
-    boxed_async_builtin, register_async_builtins, register_sync_builtins, AsyncBuiltin, SyncBuiltin,
+    boxed_async_builtin, register_builtin_groups, AsyncBuiltin, BuiltinGroup, SyncBuiltin,
 };
 use crate::value::{VmError, VmValue};
 use crate::vm::{Vm, VmBuiltinArity};
@@ -13,15 +13,13 @@ use super::helpers::vm_value_to_json;
 
 /// Register config-based LLM builtins (llm_infer_provider, llm_resolve_model, etc.).
 pub(crate) fn register_config_builtins(vm: &mut Vm) {
-    register_sync_builtins(vm, LLM_CONFIG_SYNC_BUILTINS);
-    register_async_builtins(vm, LLM_CONFIG_ASYNC_BUILTINS);
+    register_builtin_groups(vm, LLM_CONFIG_GROUPS);
 }
 
 const LLM_CONFIG_SYNC_BUILTINS: &[SyncBuiltin] = &[
     SyncBuiltin::new("provider_capabilities", provider_capabilities_builtin)
         .signature("provider_capabilities(provider, model?)")
         .arity(VmBuiltinArity::Range { min: 1, max: 2 })
-        .category("llm.config")
         .doc("Return provider/model capability metadata from the loaded capability matrix."),
     SyncBuiltin::new(
         "provider_capabilities_install",
@@ -29,7 +27,6 @@ const LLM_CONFIG_SYNC_BUILTINS: &[SyncBuiltin] = &[
     )
     .signature("provider_capabilities_install(toml_src)")
     .arity(VmBuiltinArity::Exact(1))
-    .category("llm.config")
     .doc("Install raw TOML capability overrides for provider/model capability lookup."),
     SyncBuiltin::new(
         "provider_capabilities_clear",
@@ -37,74 +34,62 @@ const LLM_CONFIG_SYNC_BUILTINS: &[SyncBuiltin] = &[
     )
     .signature("provider_capabilities_clear()")
     .arity(VmBuiltinArity::Exact(0))
-    .category("llm.config")
     .doc("Clear installed provider/model capability overrides."),
     SyncBuiltin::new("llm_infer_provider", llm_infer_provider_builtin)
         .signature("llm_infer_provider(model_id)")
         .arity(VmBuiltinArity::Exact(1))
-        .category("llm.config")
         .doc("Infer the configured provider name for a model identifier."),
     SyncBuiltin::new("llm_model_tier", llm_model_tier_builtin)
         .signature("llm_model_tier(model_id)")
         .arity(VmBuiltinArity::Exact(1))
-        .category("llm.config")
         .doc("Return the configured capability tier for a model identifier."),
     SyncBuiltin::new("llm_resolve_model", llm_resolve_model_builtin)
         .signature("llm_resolve_model(alias)")
         .arity(VmBuiltinArity::Exact(1))
-        .category("llm.config")
         .doc("Resolve a model alias or selector to full model metadata."),
     SyncBuiltin::new("llm_model_info", llm_model_info_builtin)
         .signature("llm_model_info(selector)")
         .arity(VmBuiltinArity::Exact(1))
-        .category("llm.config")
         .doc("Return catalog metadata for a resolved model selector."),
     SyncBuiltin::new("llm_known_models", llm_known_models_builtin)
         .signature("llm_known_models()")
         .arity(VmBuiltinArity::Exact(0))
-        .category("llm.config")
         .doc("List configured model alias names."),
     SyncBuiltin::new("llm_available_providers", llm_available_providers_builtin)
         .signature("llm_available_providers()")
         .arity(VmBuiltinArity::Exact(0))
-        .category("llm.config")
         .doc("List providers usable in the current environment."),
     SyncBuiltin::new("llm_qc_default_model", llm_qc_default_model_builtin)
         .signature("llm_qc_default_model(provider)")
         .arity(VmBuiltinArity::Exact(1))
-        .category("llm.config")
         .doc("Return the configured cheap QC/repair model for a provider."),
     SyncBuiltin::new("llm_provider_catalog", llm_provider_catalog_builtin)
         .signature("llm_provider_catalog()")
         .arity(VmBuiltinArity::Exact(0))
-        .category("llm.config")
         .doc("Return the loaded provider, alias, model, pricing, and availability catalog."),
     SyncBuiltin::new("llm_pick_model", llm_pick_model_builtin)
         .signature("llm_pick_model(target, options?)")
         .arity(VmBuiltinArity::Range { min: 1, max: 2 })
-        .category("llm.config")
         .doc("Resolve a model alias or tier to an `{id, provider, tier}` dict."),
     SyncBuiltin::new("llm_providers", llm_providers_builtin)
         .signature("llm_providers()")
         .arity(VmBuiltinArity::Exact(0))
-        .category("llm.config")
         .doc("List all configured and runtime-registered LLM provider names."),
     SyncBuiltin::new("provider_register", provider_register_builtin)
         .signature("provider_register(name)")
         .arity(VmBuiltinArity::Exact(1))
-        .category("llm.config")
         .doc("Register a custom OpenAI-compatible provider name for runtime dispatch."),
     SyncBuiltin::new("llm_config", llm_config_builtin)
         .signature("llm_config(provider?)")
         .arity(VmBuiltinArity::Range { min: 0, max: 1 })
-        .category("llm.config")
         .doc("Return configured provider settings, or all provider settings when no provider is passed."),
-    SyncBuiltin::new("llm_rate_limit", llm_rate_limit_builtin)
+];
+
+const LLM_RATE_LIMIT_SYNC_BUILTINS: &[SyncBuiltin] =
+    &[SyncBuiltin::new("llm_rate_limit", llm_rate_limit_builtin)
         .signature("llm_rate_limit(provider, options?)")
         .arity(VmBuiltinArity::Range { min: 1, max: 2 })
-        .category("llm.rate_limit")
-        .doc("Set, query, or clear per-provider requests-per-minute rate limits."),
-];
+        .doc("Set, query, or clear per-provider requests-per-minute rate limits.")];
 
 const LLM_CONFIG_ASYNC_BUILTINS: &[AsyncBuiltin] =
     &[AsyncBuiltin::new("llm_healthcheck", |args| {
@@ -112,8 +97,18 @@ const LLM_CONFIG_ASYNC_BUILTINS: &[AsyncBuiltin] =
     })
     .signature("llm_healthcheck(provider_or_options?, options?)")
     .arity(VmBuiltinArity::Range { min: 0, max: 2 })
-    .category("llm.config")
     .doc("Validate provider health, API key reachability, and optional model readiness.")];
+
+const LLM_CONFIG_BUILTINS: BuiltinGroup<'static> = BuiltinGroup::new()
+    .category("llm.config")
+    .sync(LLM_CONFIG_SYNC_BUILTINS)
+    .async_(LLM_CONFIG_ASYNC_BUILTINS);
+
+const LLM_RATE_LIMIT_BUILTINS: BuiltinGroup<'static> = BuiltinGroup::new()
+    .category("llm.rate_limit")
+    .sync(LLM_RATE_LIMIT_SYNC_BUILTINS);
+
+const LLM_CONFIG_GROUPS: &[BuiltinGroup<'static>] = &[LLM_CONFIG_BUILTINS, LLM_RATE_LIMIT_BUILTINS];
 
 fn provider_capabilities_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
     let provider = args.first().map(|a| a.display()).unwrap_or_default();

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -153,7 +153,8 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use crate::stdlib::registration::{
-    boxed_async_builtin, register_async_builtins, register_sync_builtins, AsyncBuiltin, SyncBuiltin,
+    boxed_async_builtin, register_builtin_group, register_builtin_groups, AsyncBuiltin,
+    BuiltinGroup, SyncBuiltin,
 };
 use crate::stdlib::{json_to_vm_value, schema_result_value};
 use crate::value::{VmChannelHandle, VmError, VmStream, VmStreamCancel, VmValue};
@@ -1440,124 +1441,120 @@ async fn host_agent_dispatch_tool_call_impl(args: Vec<VmValue>) -> Result<VmValu
     }
 }
 
-const LLM_SYNC_PRIMITIVES: &[SyncBuiltin] = &[
+const LLM_TRACE_SYNC_PRIMITIVES: &[SyncBuiltin] = &[
     SyncBuiltin::new("agent_trace", agent_trace_builtin)
         .signature("agent_trace()")
         .arity(VmBuiltinArity::Exact(0))
-        .category("agent.trace")
         .doc("Return captured agent trace events for the current process."),
     SyncBuiltin::new("agent_trace_summary", agent_trace_summary_builtin)
         .signature("agent_trace_summary()")
         .arity(VmBuiltinArity::Exact(0))
-        .category("agent.trace")
         .doc("Return a summarized view of captured agent trace events."),
 ];
 
-const LLM_ASYNC_PRIMITIVES: &[AsyncBuiltin] = &[
+const AGENT_HOST_ASYNC_PRIMITIVES: &[AsyncBuiltin] = &[
     AsyncBuiltin::new("__host_agent_capture_events", |args| {
         boxed_async_builtin(host_agent_capture_events_impl(args))
     })
     .signature("__host_agent_capture_events(session_id, body)")
     .arity(VmBuiltinArity::Exact(2))
-    .category("agent.host")
     .doc("Capture agent events emitted while executing a Harn closure."),
     AsyncBuiltin::new("__host_agent_parse_tool_calls", |args| {
         boxed_async_builtin(host_agent_parse_tool_calls_impl(args))
     })
     .signature("__host_agent_parse_tool_calls(text, tools?)")
     .arity(VmBuiltinArity::Range { min: 1, max: 2 })
-    .category("agent.host")
     .doc("Parse model text into normalized agent tool-call records."),
     AsyncBuiltin::new("__host_agent_dispatch_tool_call", |args| {
         boxed_async_builtin(host_agent_dispatch_tool_call_impl(args))
     })
     .signature("__host_agent_dispatch_tool_call(call, tools?, options?)")
     .arity(VmBuiltinArity::Range { min: 1, max: 3 })
-    .category("agent.host")
     .doc("Dispatch one normalized agent tool call through the host tool runtime."),
     AsyncBuiltin::new("__host_agent_dispatch_tool_batch", |args| {
         boxed_async_builtin(host_agent_dispatch_tool_batch_impl(args))
     })
     .signature("__host_agent_dispatch_tool_batch(calls, tools?, options?)")
     .arity(VmBuiltinArity::Range { min: 1, max: 3 })
-    .category("agent.host")
     .doc("Dispatch a batch of normalized agent tool calls through the host tool runtime."),
+];
+
+const LLM_HOST_CORE_ASYNC_PRIMITIVES: &[AsyncBuiltin] = &[
     AsyncBuiltin::new("__cost_route", |args| {
         boxed_async_builtin(cost_route::cost_route_impl(args))
     })
     .signature("__cost_route(options)")
     .arity(VmBuiltinArity::Range { min: 0, max: 1 })
-    .category("llm.host")
     .doc("Route an LLM request by cost and capability metadata."),
     AsyncBuiltin::new("llm_call", |args| boxed_async_builtin(llm_call_impl(args)))
         .signature("llm_call(prompt, system?, options?)")
         .arity(VmBuiltinArity::Range { min: 1, max: 3 })
-        .category("llm.host")
         .doc("Execute one LLM call and return the normalized Harn result dict."),
     AsyncBuiltin::new("llm_stream_call", |args| {
         boxed_async_builtin(llm_stream_call_impl(args))
     })
     .signature("llm_stream_call(prompt, system?, options?)")
     .arity(VmBuiltinArity::Range { min: 1, max: 3 })
-    .category("llm.host")
     .doc("Execute one streaming LLM call and return the normalized Harn result dict."),
     AsyncBuiltin::new("llm_call_safe", |args| {
         boxed_async_builtin(llm_call_safe_builtin(args))
     })
     .signature("llm_call_safe(prompt, system?, options?)")
     .arity(VmBuiltinArity::Range { min: 1, max: 3 })
-    .category("llm.host")
     .doc("Execute one LLM call and return a non-throwing safe envelope."),
+];
+
+const LLM_STRUCTURED_ASYNC_PRIMITIVES: &[AsyncBuiltin] = &[
     AsyncBuiltin::new("llm_call_structured", |args| {
         boxed_async_builtin(llm_call_structured_builtin(args))
     })
     .signature("llm_call_structured(prompt, schema, options?)")
     .arity(VmBuiltinArity::Range { min: 2, max: 3 })
-    .category("llm.structured")
     .doc("Call an LLM for JSON data and return parsed schema-valid data."),
     AsyncBuiltin::new("llm_call_structured_safe", |args| {
         boxed_async_builtin(llm_call_structured_safe_builtin(args))
     })
     .signature("llm_call_structured_safe(prompt, schema, options?)")
     .arity(VmBuiltinArity::Range { min: 2, max: 3 })
-    .category("llm.structured")
     .doc("Call an LLM for JSON data and return a non-throwing schema envelope."),
     AsyncBuiltin::new("llm_call_structured_result", |args| {
         boxed_async_builtin(llm_call_structured_result_builtin(args))
     })
     .signature("llm_call_structured_result(prompt, schema, options?)")
     .arity(VmBuiltinArity::Range { min: 2, max: 3 })
-    .category("llm.structured")
     .doc("Call an LLM for JSON data and return a diagnostic structured-output envelope."),
-    AsyncBuiltin::new("schema_recover", |args| {
+];
+
+const SCHEMA_RECOVERY_ASYNC_PRIMITIVES: &[AsyncBuiltin] =
+    &[AsyncBuiltin::new("schema_recover", |args| {
         boxed_async_builtin(schema_recover_builtin(args))
     })
     .signature("schema_recover(text, schema, options?)")
     .arity(VmBuiltinArity::Range { min: 2, max: 3 })
-    .category("schema.recovery")
     .doc(
         "Recover malformed JSON text against a schema using deterministic and optional LLM repair.",
-    ),
-    AsyncBuiltin::new("with_rate_limit", |args| {
+    )];
+
+const LLM_RATE_LIMIT_ASYNC_PRIMITIVES: &[AsyncBuiltin] =
+    &[AsyncBuiltin::new("with_rate_limit", |args| {
         boxed_async_builtin(with_rate_limit_builtin(args))
     })
     .signature("with_rate_limit(provider, callback, options?)")
     .arity(VmBuiltinArity::Range { min: 2, max: 3 })
-    .category("llm.rate_limit")
-    .doc("Run a closure behind the provider rate limiter with retryable-error backoff."),
+    .doc("Run a closure behind the provider rate limiter with retryable-error backoff.")];
+
+const LLM_HOST_COMPLETION_ASYNC_PRIMITIVES: &[AsyncBuiltin] = &[
     AsyncBuiltin::new("llm_completion", |args| {
         boxed_async_builtin(llm_completion_builtin(args))
     })
     .signature("llm_completion(prefix, suffix?, system?, options?)")
     .arity(VmBuiltinArity::Range { min: 1, max: 4 })
-    .category("llm.host")
     .doc("Execute a fill-in-the-middle LLM completion request."),
     AsyncBuiltin::new("llm_stream", |args| {
         boxed_async_builtin(llm_stream_builtin(args))
     })
     .signature("llm_stream(prompt, system?, options?)")
     .arity(VmBuiltinArity::Range { min: 1, max: 3 })
-    .category("llm.host")
     .doc("Execute a legacy channel-based streaming LLM request."),
 ];
 
@@ -1565,29 +1562,52 @@ const LLM_MOCK_SYNC_PRIMITIVES: &[SyncBuiltin] = &[
     SyncBuiltin::new("llm_mock", llm_mock_builtin)
         .signature("llm_mock(config)")
         .arity(VmBuiltinArity::Exact(1))
-        .category("llm.mock")
         .doc("Register a deterministic LLM mock response for tests."),
     SyncBuiltin::new("llm_mock_calls", llm_mock_calls_builtin)
         .signature("llm_mock_calls()")
         .arity(VmBuiltinArity::Exact(0))
-        .category("llm.mock")
         .doc("Return recorded LLM mock calls."),
     SyncBuiltin::new("llm_mock_clear", llm_mock_clear_builtin)
         .signature("llm_mock_clear()")
         .arity(VmBuiltinArity::Exact(0))
-        .category("llm.mock")
         .doc("Clear deterministic LLM mocks and recorded calls."),
     SyncBuiltin::new("llm_mock_push_scope", llm_mock_push_scope_builtin)
         .signature("llm_mock_push_scope()")
         .arity(VmBuiltinArity::Exact(0))
-        .category("llm.mock")
         .doc("Push an isolated LLM mock scope."),
     SyncBuiltin::new("llm_mock_pop_scope", llm_mock_pop_scope_builtin)
         .signature("llm_mock_pop_scope()")
         .arity(VmBuiltinArity::Exact(0))
-        .category("llm.mock")
         .doc("Pop the current isolated LLM mock scope."),
 ];
+
+const LLM_RUNTIME_PRIMITIVE_GROUPS: &[BuiltinGroup<'static>] = &[
+    BuiltinGroup::new()
+        .category("agent.trace")
+        .sync(LLM_TRACE_SYNC_PRIMITIVES),
+    BuiltinGroup::new()
+        .category("agent.host")
+        .async_(AGENT_HOST_ASYNC_PRIMITIVES),
+    BuiltinGroup::new()
+        .category("llm.host")
+        .async_(LLM_HOST_CORE_ASYNC_PRIMITIVES),
+    BuiltinGroup::new()
+        .category("llm.structured")
+        .async_(LLM_STRUCTURED_ASYNC_PRIMITIVES),
+    BuiltinGroup::new()
+        .category("schema.recovery")
+        .async_(SCHEMA_RECOVERY_ASYNC_PRIMITIVES),
+    BuiltinGroup::new()
+        .category("llm.rate_limit")
+        .async_(LLM_RATE_LIMIT_ASYNC_PRIMITIVES),
+    BuiltinGroup::new()
+        .category("llm.host")
+        .async_(LLM_HOST_COMPLETION_ASYNC_PRIMITIVES),
+];
+
+const LLM_MOCK_PRIMITIVES: BuiltinGroup<'static> = BuiltinGroup::new()
+    .category("llm.mock")
+    .sync(LLM_MOCK_SYNC_PRIMITIVES);
 
 async fn llm_call_safe_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     match llm_call_impl(args).await {
@@ -1743,8 +1763,7 @@ fn agent_trace_summary_builtin(_args: &[VmValue], _out: &mut String) -> Result<V
 pub fn register_llm_builtins(vm: &mut Vm) {
     rate_limit::init_from_config();
     agent_config::register_agent_control_primitives(vm);
-    register_sync_builtins(vm, LLM_SYNC_PRIMITIVES);
-    register_async_builtins(vm, LLM_ASYNC_PRIMITIVES);
+    register_builtin_groups(vm, LLM_RUNTIME_PRIMITIVE_GROUPS);
     agent_config::register_agent_loop(vm);
 
     conversation::register_conversation_builtins(vm);
@@ -1756,7 +1775,7 @@ pub fn register_llm_builtins(vm: &mut Vm) {
 
 /// Register llm_mock / llm_mock_calls / llm_mock_clear builtins.
 fn register_llm_mock_builtins(vm: &mut Vm) {
-    register_sync_builtins(vm, LLM_MOCK_SYNC_PRIMITIVES);
+    register_builtin_group(vm, LLM_MOCK_PRIMITIVES);
 }
 
 fn llm_mock_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {

--- a/crates/harn-vm/src/stdlib/agent_sessions.rs
+++ b/crates/harn-vm/src/stdlib/agent_sessions.rs
@@ -10,46 +10,39 @@ use std::rc::Rc;
 
 use crate::agent_sessions;
 use crate::stdlib::registration::{
-    boxed_async_builtin, register_async_builtins, register_sync_builtins, AsyncBuiltin, SyncBuiltin,
+    boxed_async_builtin, register_builtin_group, AsyncBuiltin, BuiltinGroup, SyncBuiltin,
 };
 use crate::value::{VmError, VmValue};
 use crate::vm::{Vm, VmBuiltinArity};
 
 pub fn register_agent_session_builtins(vm: &mut Vm) {
-    register_sync_builtins(vm, AGENT_SESSION_SYNC_PRIMITIVES);
-    register_async_builtins(vm, AGENT_SESSION_ASYNC_PRIMITIVES);
+    register_builtin_group(vm, AGENT_SESSION_PRIMITIVES);
 }
 
 const AGENT_SESSION_SYNC_PRIMITIVES: &[SyncBuiltin] = &[
     SyncBuiltin::new("agent_session_open", agent_session_open_builtin)
         .signature("agent_session_open(id?)")
         .arity(VmBuiltinArity::Range { min: 0, max: 1 })
-        .category("agent.session")
         .doc("Open or create a first-class agent session."),
     SyncBuiltin::new("agent_session_exists", agent_session_exists_builtin)
         .signature("agent_session_exists(id)")
         .arity(VmBuiltinArity::Exact(1))
-        .category("agent.session")
         .doc("Return whether an agent session exists."),
     SyncBuiltin::new("agent_session_length", agent_session_length_builtin)
         .signature("agent_session_length(id)")
         .arity(VmBuiltinArity::Exact(1))
-        .category("agent.session")
         .doc("Return the number of messages in an agent session."),
     SyncBuiltin::new("agent_session_snapshot", agent_session_snapshot_builtin)
         .signature("agent_session_snapshot(id)")
         .arity(VmBuiltinArity::Exact(1))
-        .category("agent.session")
         .doc("Return the current transcript snapshot for an agent session."),
     SyncBuiltin::new("agent_session_ancestry", agent_session_ancestry_builtin)
         .signature("agent_session_ancestry(id)")
         .arity(VmBuiltinArity::Exact(1))
-        .category("agent.session")
         .doc("Return parent, child, and root lineage for an agent session."),
     SyncBuiltin::new("agent_session_current_id", agent_session_current_id_builtin)
         .signature("agent_session_current_id()")
         .arity(VmBuiltinArity::Exact(0))
-        .category("agent.session")
         .doc("Return the innermost active agent session id."),
     SyncBuiltin::new(
         "agent_session_tool_format",
@@ -57,7 +50,6 @@ const AGENT_SESSION_SYNC_PRIMITIVES: &[SyncBuiltin] = &[
     )
     .signature("agent_session_tool_format(id)")
     .arity(VmBuiltinArity::Exact(1))
-    .category("agent.session")
     .doc("Return the claimed tool format for an agent session."),
     SyncBuiltin::new(
         "agent_session_claim_tool_format",
@@ -65,37 +57,30 @@ const AGENT_SESSION_SYNC_PRIMITIVES: &[SyncBuiltin] = &[
     )
     .signature("agent_session_claim_tool_format(id, tool_format)")
     .arity(VmBuiltinArity::Exact(2))
-    .category("agent.session")
     .doc("Claim the tool format for an agent session."),
     SyncBuiltin::new("agent_session_reset", agent_session_reset_builtin)
         .signature("agent_session_reset(id)")
         .arity(VmBuiltinArity::Exact(1))
-        .category("agent.session")
         .doc("Reset an agent session transcript."),
     SyncBuiltin::new("agent_session_fork", agent_session_fork_builtin)
         .signature("agent_session_fork(src, dst?)")
         .arity(VmBuiltinArity::Range { min: 1, max: 2 })
-        .category("agent.session")
         .doc("Fork an agent session transcript."),
     SyncBuiltin::new("agent_session_fork_at", agent_session_fork_at_builtin)
         .signature("agent_session_fork_at(src, keep_first, dst?)")
         .arity(VmBuiltinArity::Range { min: 2, max: 3 })
-        .category("agent.session")
         .doc("Fork an agent session at a message boundary."),
     SyncBuiltin::new("agent_session_close", agent_session_close_builtin)
         .signature("agent_session_close(id)")
         .arity(VmBuiltinArity::Exact(1))
-        .category("agent.session")
         .doc("Close an agent session."),
     SyncBuiltin::new("agent_session_trim", agent_session_trim_builtin)
         .signature("agent_session_trim(id, keep_last)")
         .arity(VmBuiltinArity::Exact(2))
-        .category("agent.session")
         .doc("Trim an agent session to the last N messages."),
     SyncBuiltin::new("agent_session_inject", agent_session_inject_builtin)
         .signature("agent_session_inject(id, message)")
         .arity(VmBuiltinArity::Exact(2))
-        .category("agent.session")
         .doc("Inject one message into an agent session."),
 ];
 
@@ -105,8 +90,12 @@ const AGENT_SESSION_ASYNC_PRIMITIVES: &[AsyncBuiltin] =
     })
     .signature("agent_session_compact(id, opts?)")
     .arity(VmBuiltinArity::Range { min: 1, max: 2 })
-    .category("agent.session")
     .doc("Compact an agent session transcript with the host compaction runtime.")];
+
+const AGENT_SESSION_PRIMITIVES: BuiltinGroup<'static> = BuiltinGroup::new()
+    .category("agent.session")
+    .sync(AGENT_SESSION_SYNC_PRIMITIVES)
+    .async_(AGENT_SESSION_ASYNC_PRIMITIVES);
 
 fn err(msg: impl Into<String>) -> VmError {
     VmError::Thrown(VmValue::String(Rc::from(msg.into())))

--- a/crates/harn-vm/src/stdlib/agents.rs
+++ b/crates/harn-vm/src/stdlib/agents.rs
@@ -29,7 +29,7 @@ use self::agents_workers::{
 };
 use self::sub_agent::{execute_sub_agent, parse_sub_agent_request};
 use crate::stdlib::registration::{
-    boxed_async_builtin, register_async_builtins, register_sync_builtins, AsyncBuiltin, SyncBuiltin,
+    boxed_async_builtin, register_builtin_group, AsyncBuiltin, BuiltinGroup, SyncBuiltin,
 };
 use crate::value::{VmError, VmValue};
 use crate::vm::{Vm, VmBuiltinArity};
@@ -38,27 +38,22 @@ const AGENT_SYNC_PRIMITIVES: &[SyncBuiltin] = &[
     SyncBuiltin::new("agent", agent_builtin)
         .signature("agent(name, config?)")
         .arity(VmBuiltinArity::Range { min: 1, max: 2 })
-        .category("agent.worker")
         .doc("Build a low-level agent spec dict."),
     SyncBuiltin::new("agent_config", agent_config_builtin)
         .signature("agent_config(agent, prompt)")
         .arity(VmBuiltinArity::Exact(2))
-        .category("agent.worker")
         .doc("Build low-level agent prompt/system/options config."),
     SyncBuiltin::new("agent_name", agent_name_builtin)
         .signature("agent_name(agent)")
         .arity(VmBuiltinArity::Exact(1))
-        .category("agent.worker")
         .doc("Read an agent spec name."),
     SyncBuiltin::new("resume_agent", resume_agent_builtin)
         .signature("resume_agent(worker_or_snapshot)")
         .arity(VmBuiltinArity::Exact(1))
-        .category("agent.worker")
         .doc("Resume a persisted worker into the local worker registry."),
     SyncBuiltin::new("list_agents", list_agents_builtin)
         .signature("list_agents()")
         .arity(VmBuiltinArity::Exact(0))
-        .category("agent.worker")
         .doc("List local worker summaries."),
 ];
 
@@ -68,44 +63,43 @@ const AGENT_ASYNC_PRIMITIVES: &[AsyncBuiltin] = &[
     })
     .signature("sub_agent_run(config)")
     .arity(VmBuiltinArity::Exact(1))
-    .category("agent.worker")
     .doc("Run or spawn a sub-agent worker."),
     AsyncBuiltin::new("spawn_agent", |args| {
         boxed_async_builtin(spawn_agent_builtin(args))
     })
     .signature("spawn_agent(config)")
     .arity(VmBuiltinArity::Exact(1))
-    .category("agent.worker")
     .doc("Spawn a workflow, stage, or sub-agent worker."),
     AsyncBuiltin::new("send_input", |args| {
         boxed_async_builtin(send_input_builtin(args))
     })
     .signature("send_input(worker, task)")
     .arity(VmBuiltinArity::Exact(2))
-    .category("agent.worker")
     .doc("Resume a stopped worker with new task input."),
     AsyncBuiltin::new("worker_trigger", |args| {
         boxed_async_builtin(worker_trigger_builtin(args))
     })
     .signature("worker_trigger(worker, payload)")
     .arity(VmBuiltinArity::Exact(2))
-    .category("agent.worker")
     .doc("Trigger an awaiting retriggerable worker."),
     AsyncBuiltin::new("wait_agent", |args| {
         boxed_async_builtin(wait_agent_builtin(args))
     })
     .signature("wait_agent(worker_or_workers)")
     .arity(VmBuiltinArity::Exact(1))
-    .category("agent.worker")
     .doc("Wait for one or more workers to reach a terminal state."),
     AsyncBuiltin::new("close_agent", |args| {
         boxed_async_builtin(close_agent_builtin(args))
     })
     .signature("close_agent(worker)")
     .arity(VmBuiltinArity::Exact(1))
-    .category("agent.worker")
     .doc("Cancel a worker and emit the cancellation lifecycle event."),
 ];
+
+const AGENT_PRIMITIVES: BuiltinGroup<'static> = BuiltinGroup::new()
+    .category("agent.worker")
+    .sync(AGENT_SYNC_PRIMITIVES)
+    .async_(AGENT_ASYNC_PRIMITIVES);
 
 pub(crate) use self::records::{parse_artifact_list, parse_context_policy};
 fn to_vm<T: serde::Serialize>(value: &T) -> Result<VmValue, VmError> {
@@ -226,8 +220,7 @@ async fn wait_for_worker_terminal(
 }
 
 pub(crate) fn register_agent_builtins(vm: &mut Vm) {
-    register_sync_builtins(vm, AGENT_SYNC_PRIMITIVES);
-    register_async_builtins(vm, AGENT_ASYNC_PRIMITIVES);
+    register_builtin_group(vm, AGENT_PRIMITIVES);
     records::register_record_builtins(vm);
     workflow::register_workflow_builtins(vm);
 }

--- a/crates/harn-vm/src/stdlib/agents_daemon.rs
+++ b/crates/harn-vm/src/stdlib/agents_daemon.rs
@@ -10,7 +10,7 @@ use crate::bridge::HostBridge;
 use crate::llm::daemon::{load_snapshot, DaemonSnapshot};
 use crate::orchestration::DaemonEventKindRecord;
 use crate::stdlib::registration::{
-    boxed_async_builtin, register_async_builtins, register_sync_builtins, AsyncBuiltin, SyncBuiltin,
+    boxed_async_builtin, register_builtin_group, AsyncBuiltin, BuiltinGroup, SyncBuiltin,
 };
 use crate::value::{VmError, VmValue};
 use crate::vm::{Vm, VmBuiltinArity};
@@ -25,7 +25,6 @@ const DAEMON_SYNC_PRIMITIVES: &[SyncBuiltin] =
     &[SyncBuiltin::new("daemon_snapshot", daemon_snapshot_builtin)
         .signature("daemon_snapshot(handle)")
         .arity(VmBuiltinArity::Exact(1))
-        .category("agent.daemon")
         .doc("Refresh and return a daemon snapshot with queued event state.")];
 
 const DAEMON_ASYNC_PRIMITIVES: &[AsyncBuiltin] = &[
@@ -34,30 +33,31 @@ const DAEMON_ASYNC_PRIMITIVES: &[AsyncBuiltin] = &[
     })
     .signature("daemon_spawn(config)")
     .arity(VmBuiltinArity::Exact(1))
-    .category("agent.daemon")
     .doc("Spawn a persistent daemon agent worker."),
     AsyncBuiltin::new("daemon_trigger", |args| {
         boxed_async_builtin(daemon_trigger_builtin(args))
     })
     .signature("daemon_trigger(handle, payload)")
     .arity(VmBuiltinArity::Exact(2))
-    .category("agent.daemon")
     .doc("Queue an event payload for a running daemon."),
     AsyncBuiltin::new("daemon_stop", |args| {
         boxed_async_builtin(daemon_stop_builtin(args))
     })
     .signature("daemon_stop(handle)")
     .arity(VmBuiltinArity::Exact(1))
-    .category("agent.daemon")
     .doc("Stop a running daemon and persist its latest snapshot."),
     AsyncBuiltin::new("daemon_resume", |args| {
         boxed_async_builtin(daemon_resume_builtin(args))
     })
     .signature("daemon_resume(path)")
     .arity(VmBuiltinArity::Exact(1))
-    .category("agent.daemon")
     .doc("Resume a daemon from persisted state."),
 ];
+
+const DAEMON_PRIMITIVES: BuiltinGroup<'static> = BuiltinGroup::new()
+    .category("agent.daemon")
+    .sync(DAEMON_SYNC_PRIMITIVES)
+    .async_(DAEMON_ASYNC_PRIMITIVES);
 
 fn default_event_queue_capacity() -> usize {
     DEFAULT_EVENT_QUEUE_CAPACITY
@@ -135,8 +135,7 @@ thread_local! {
 }
 
 pub fn register_daemon_builtins(vm: &mut Vm) {
-    register_sync_builtins(vm, DAEMON_SYNC_PRIMITIVES);
-    register_async_builtins(vm, DAEMON_ASYNC_PRIMITIVES);
+    register_builtin_group(vm, DAEMON_PRIMITIVES);
 }
 
 async fn daemon_spawn_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {

--- a/crates/harn-vm/src/stdlib/host.rs
+++ b/crates/harn-vm/src/stdlib/host.rs
@@ -6,7 +6,7 @@ use std::time::Instant;
 use serde_json::Value as JsonValue;
 
 use crate::stdlib::registration::{
-    boxed_async_builtin, register_async_builtins, register_sync_builtins, AsyncBuiltin, SyncBuiltin,
+    boxed_async_builtin, register_builtin_group, AsyncBuiltin, BuiltinGroup, SyncBuiltin,
 };
 use crate::value::{values_equal, VmError, VmValue};
 use crate::vm::clone_async_builtin_child_vm;
@@ -16,37 +16,30 @@ const HOST_SYNC_PRIMITIVES: &[SyncBuiltin] = &[
     SyncBuiltin::new("host_mock", host_mock_builtin)
         .signature("host_mock(capability, op, response_or_config, params?)")
         .arity(VmBuiltinArity::Range { min: 3, max: 4 })
-        .category("host")
         .doc("Register a typed host mock for tests."),
     SyncBuiltin::new("host_mock_clear", host_mock_clear_builtin)
         .signature("host_mock_clear()")
         .arity(VmBuiltinArity::Exact(0))
-        .category("host")
         .doc("Clear typed host mocks and recorded calls."),
     SyncBuiltin::new("host_mock_calls", host_mock_calls_builtin)
         .signature("host_mock_calls()")
         .arity(VmBuiltinArity::Exact(0))
-        .category("host")
         .doc("Return typed host mock invocations."),
     SyncBuiltin::new("host_mock_push_scope", host_mock_push_scope_builtin)
         .signature("host_mock_push_scope()")
         .arity(VmBuiltinArity::Exact(0))
-        .category("host")
         .doc("Push an isolated host mock scope."),
     SyncBuiltin::new("host_mock_pop_scope", host_mock_pop_scope_builtin)
         .signature("host_mock_pop_scope()")
         .arity(VmBuiltinArity::Exact(0))
-        .category("host")
         .doc("Pop the current isolated host mock scope."),
     SyncBuiltin::new("host_capabilities", host_capabilities_builtin)
         .signature("host_capabilities()")
         .arity(VmBuiltinArity::Exact(0))
-        .category("host")
         .doc("Return the typed host capability manifest."),
     SyncBuiltin::new("host_has", host_has_builtin)
         .signature("host_has(capability, op?)")
         .arity(VmBuiltinArity::Range { min: 1, max: 2 })
-        .category("host")
         .doc("Return whether a host capability or operation is available."),
 ];
 
@@ -56,23 +49,25 @@ const HOST_ASYNC_PRIMITIVES: &[AsyncBuiltin] = &[
     })
     .signature("host_call(name, args)")
     .arity(VmBuiltinArity::Range { min: 1, max: 2 })
-    .category("host")
     .doc("Invoke a host capability operation by capability.operation name."),
     AsyncBuiltin::new("host_tool_list", |args| {
         boxed_async_builtin(host_tool_list_builtin(args))
     })
     .signature("host_tool_list()")
     .arity(VmBuiltinArity::Exact(0))
-    .category("host")
     .doc("List host tools exposed by the active bridge."),
     AsyncBuiltin::new("host_tool_call", |args| {
         boxed_async_builtin(host_tool_call_builtin(args))
     })
     .signature("host_tool_call(name, args?)")
     .arity(VmBuiltinArity::Range { min: 1, max: 2 })
-    .category("host")
     .doc("Call a host tool exposed by the active bridge."),
 ];
+
+const HOST_PRIMITIVES: BuiltinGroup<'static> = BuiltinGroup::new()
+    .category("host")
+    .sync(HOST_SYNC_PRIMITIVES)
+    .async_(HOST_ASYNC_PRIMITIVES);
 
 #[derive(Clone)]
 struct HostMock {
@@ -910,8 +905,7 @@ fn vm_string(value: &VmValue) -> Option<&str> {
 }
 
 pub(crate) fn register_host_builtins(vm: &mut Vm) {
-    register_sync_builtins(vm, HOST_SYNC_PRIMITIVES);
-    register_async_builtins(vm, HOST_ASYNC_PRIMITIVES);
+    register_builtin_group(vm, HOST_PRIMITIVES);
 }
 
 fn host_mock_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {

--- a/crates/harn-vm/src/stdlib/registration.rs
+++ b/crates/harn-vm/src/stdlib/registration.rs
@@ -15,7 +15,6 @@ pub(crate) struct SyncBuiltin {
     name: &'static str,
     signature: Option<&'static str>,
     arity: Option<VmBuiltinArity>,
-    category: Option<&'static str>,
     doc: Option<&'static str>,
     handler: SyncBuiltinHandler,
 }
@@ -26,7 +25,6 @@ impl SyncBuiltin {
             name,
             signature: None,
             arity: None,
-            category: None,
             doc: None,
             handler,
         }
@@ -42,17 +40,12 @@ impl SyncBuiltin {
         self
     }
 
-    pub(crate) const fn category(mut self, category: &'static str) -> Self {
-        self.category = Some(category);
-        self
-    }
-
     pub(crate) const fn doc(mut self, doc: &'static str) -> Self {
         self.doc = Some(doc);
         self
     }
 
-    fn metadata(&self) -> VmBuiltinMetadata {
+    fn metadata(&self, default_category: Option<&'static str>) -> VmBuiltinMetadata {
         let mut metadata = VmBuiltinMetadata::sync_static(self.name);
         if let Some(signature) = self.signature {
             metadata = metadata.signature_static(signature);
@@ -60,7 +53,7 @@ impl SyncBuiltin {
         if let Some(arity) = self.arity {
             metadata = metadata.arity(arity);
         }
-        if let Some(category) = self.category {
+        if let Some(category) = default_category {
             metadata = metadata.category_static(category);
         }
         if let Some(doc) = self.doc {
@@ -75,7 +68,6 @@ pub(crate) struct AsyncBuiltin {
     name: &'static str,
     signature: Option<&'static str>,
     arity: Option<VmBuiltinArity>,
-    category: Option<&'static str>,
     doc: Option<&'static str>,
     handler: AsyncBuiltinHandler,
 }
@@ -86,7 +78,6 @@ impl AsyncBuiltin {
             name,
             signature: None,
             arity: None,
-            category: None,
             doc: None,
             handler,
         }
@@ -102,17 +93,12 @@ impl AsyncBuiltin {
         self
     }
 
-    pub(crate) const fn category(mut self, category: &'static str) -> Self {
-        self.category = Some(category);
-        self
-    }
-
     pub(crate) const fn doc(mut self, doc: &'static str) -> Self {
         self.doc = Some(doc);
         self
     }
 
-    fn metadata(&self) -> VmBuiltinMetadata {
+    fn metadata(&self, default_category: Option<&'static str>) -> VmBuiltinMetadata {
         let mut metadata = VmBuiltinMetadata::async_static(self.name);
         if let Some(signature) = self.signature {
             metadata = metadata.signature_static(signature);
@@ -120,7 +106,7 @@ impl AsyncBuiltin {
         if let Some(arity) = self.arity {
             metadata = metadata.arity(arity);
         }
-        if let Some(category) = self.category {
+        if let Some(category) = default_category {
             metadata = metadata.category_static(category);
         }
         if let Some(doc) = self.doc {
@@ -137,14 +123,49 @@ where
     Box::pin(future)
 }
 
-pub(crate) fn register_sync_builtins(vm: &mut Vm, builtins: &[SyncBuiltin]) {
-    for builtin in builtins {
-        vm.register_builtin_with_metadata(builtin.metadata(), builtin.handler);
+#[derive(Clone, Copy)]
+pub(crate) struct BuiltinGroup<'a> {
+    category: Option<&'static str>,
+    sync: &'a [SyncBuiltin],
+    async_: &'a [AsyncBuiltin],
+}
+
+impl<'a> BuiltinGroup<'a> {
+    pub(crate) const fn new() -> Self {
+        Self {
+            category: None,
+            sync: &[],
+            async_: &[],
+        }
+    }
+
+    pub(crate) const fn category(mut self, category: &'static str) -> Self {
+        self.category = Some(category);
+        self
+    }
+
+    pub(crate) const fn sync(mut self, builtins: &'a [SyncBuiltin]) -> Self {
+        self.sync = builtins;
+        self
+    }
+
+    pub(crate) const fn async_(mut self, builtins: &'a [AsyncBuiltin]) -> Self {
+        self.async_ = builtins;
+        self
     }
 }
 
-pub(crate) fn register_async_builtins(vm: &mut Vm, builtins: &[AsyncBuiltin]) {
-    for builtin in builtins {
-        vm.register_async_builtin_with_metadata(builtin.metadata(), builtin.handler);
+pub(crate) fn register_builtin_group(vm: &mut Vm, group: BuiltinGroup<'_>) {
+    for builtin in group.sync {
+        vm.register_builtin_with_metadata(builtin.metadata(group.category), builtin.handler);
+    }
+    for builtin in group.async_ {
+        vm.register_async_builtin_with_metadata(builtin.metadata(group.category), builtin.handler);
+    }
+}
+
+pub(crate) fn register_builtin_groups(vm: &mut Vm, groups: &[BuiltinGroup<'_>]) {
+    for group in groups {
+        register_builtin_group(vm, *group);
     }
 }

--- a/crates/harn-vm/src/stdlib/workflow/register.rs
+++ b/crates/harn-vm/src/stdlib/workflow/register.rs
@@ -13,7 +13,7 @@ use crate::orchestration::{
 };
 use crate::stdlib::harn_entry::{register_harn_module_entrypoints, HarnEntrypointModule};
 use crate::stdlib::registration::{
-    boxed_async_builtin, register_async_builtins, register_sync_builtins, AsyncBuiltin, SyncBuiltin,
+    boxed_async_builtin, register_builtin_group, AsyncBuiltin, BuiltinGroup, SyncBuiltin,
 };
 use crate::value::{VmError, VmValue};
 use crate::vm::{Vm, VmBuiltinArity};
@@ -44,42 +44,34 @@ const WORKFLOW_SYNC_PRIMITIVES: &[SyncBuiltin] = &[
     SyncBuiltin::new("workflow_graph", workflow_graph_builtin)
         .signature("workflow_graph(input?)")
         .arity(VmBuiltinArity::Range { min: 0, max: 1 })
-        .category("workflow.host")
         .doc("Normalize a workflow value and return the canonical workflow graph dict."),
     SyncBuiltin::new("workflow_validate", workflow_validate_builtin)
         .signature("workflow_validate(input?, ceiling?)")
         .arity(VmBuiltinArity::Range { min: 0, max: 2 })
-        .category("workflow.host")
         .doc("Validate a workflow graph against a capability policy ceiling."),
     SyncBuiltin::new("workflow_inspect", workflow_inspect_builtin)
         .signature("workflow_inspect(input?, ceiling?)")
         .arity(VmBuiltinArity::Range { min: 0, max: 2 })
-        .category("workflow.host")
         .doc("Return normalized workflow graph shape and validation details."),
     SyncBuiltin::new("workflow_policy_report", workflow_policy_report_builtin)
         .signature("workflow_policy_report(graph, ceiling?)")
         .arity(VmBuiltinArity::Range { min: 1, max: 2 })
-        .category("workflow.host")
         .doc("Report workflow and node policies against an effective ceiling."),
     SyncBuiltin::new("workflow_clone", workflow_clone_builtin)
         .signature("workflow_clone(graph)")
         .arity(VmBuiltinArity::Exact(1))
-        .category("workflow.host")
         .doc("Clone a workflow graph and append audit metadata."),
     SyncBuiltin::new("workflow_insert_node", workflow_insert_node_builtin)
         .signature("workflow_insert_node(graph, node, edge?)")
         .arity(VmBuiltinArity::Range { min: 2, max: 3 })
-        .category("workflow.host")
         .doc("Insert a node and optional edge into a workflow graph."),
     SyncBuiltin::new("workflow_replace_node", workflow_replace_node_builtin)
         .signature("workflow_replace_node(graph, node_id, node)")
         .arity(VmBuiltinArity::Exact(3))
-        .category("workflow.host")
         .doc("Replace one node in a workflow graph."),
     SyncBuiltin::new("workflow_rewire", workflow_rewire_builtin)
         .signature("workflow_rewire(graph, from, to, branch?)")
         .arity(VmBuiltinArity::Range { min: 3, max: 4 })
-        .category("workflow.host")
         .doc("Replace outgoing edge wiring for one workflow graph node."),
     SyncBuiltin::new(
         "workflow_set_model_policy",
@@ -87,7 +79,6 @@ const WORKFLOW_SYNC_PRIMITIVES: &[SyncBuiltin] = &[
     )
     .signature("workflow_set_model_policy(graph, node_id, policy)")
     .arity(VmBuiltinArity::Exact(3))
-    .category("workflow.host")
     .doc("Set one node's model policy."),
     SyncBuiltin::new(
         "workflow_set_context_policy",
@@ -95,7 +86,6 @@ const WORKFLOW_SYNC_PRIMITIVES: &[SyncBuiltin] = &[
     )
     .signature("workflow_set_context_policy(graph, node_id, policy)")
     .arity(VmBuiltinArity::Exact(3))
-    .category("workflow.host")
     .doc("Set one node's context policy."),
     SyncBuiltin::new(
         "workflow_set_auto_compact",
@@ -103,7 +93,6 @@ const WORKFLOW_SYNC_PRIMITIVES: &[SyncBuiltin] = &[
     )
     .signature("workflow_set_auto_compact(graph, node_id, policy)")
     .arity(VmBuiltinArity::Exact(3))
-    .category("workflow.host")
     .doc("Set one node's auto-compaction policy."),
     SyncBuiltin::new(
         "workflow_set_output_visibility",
@@ -111,27 +100,22 @@ const WORKFLOW_SYNC_PRIMITIVES: &[SyncBuiltin] = &[
     )
     .signature("workflow_set_output_visibility(graph, node_id, visibility)")
     .arity(VmBuiltinArity::Exact(3))
-    .category("workflow.host")
     .doc("Set one node's output visibility policy."),
     SyncBuiltin::new("workflow_diff", workflow_diff_builtin)
         .signature("workflow_diff(left, right)")
         .arity(VmBuiltinArity::Exact(2))
-        .category("workflow.host")
         .doc("Compare two workflow graph values for canonical JSON changes."),
     SyncBuiltin::new("workflow_commit", workflow_commit_builtin)
         .signature("workflow_commit(graph, reason?)")
         .arity(VmBuiltinArity::Range { min: 1, max: 2 })
-        .category("workflow.host")
         .doc("Validate and commit workflow graph audit metadata."),
     SyncBuiltin::new("register_tool_hook", register_tool_hook_builtin)
         .signature("register_tool_hook(config?)")
         .arity(VmBuiltinArity::Range { min: 0, max: 1 })
-        .category("workflow.host")
         .doc("Register low-level pre/post tool hooks for workflow execution."),
     SyncBuiltin::new("clear_tool_hooks", clear_tool_hooks_builtin)
         .signature("clear_tool_hooks()")
         .arity(VmBuiltinArity::Exact(0))
-        .category("workflow.host")
         .doc("Clear registered low-level workflow tool hooks."),
     SyncBuiltin::new(
         "select_artifacts_adaptive",
@@ -139,17 +123,14 @@ const WORKFLOW_SYNC_PRIMITIVES: &[SyncBuiltin] = &[
     )
     .signature("select_artifacts_adaptive(artifacts?, policy?)")
     .arity(VmBuiltinArity::Range { min: 0, max: 2 })
-    .category("workflow.host")
     .doc("Select workflow artifacts according to a context policy."),
     SyncBuiltin::new("estimate_tokens", estimate_tokens_builtin)
         .signature("estimate_tokens(messages?)")
         .arity(VmBuiltinArity::Range { min: 0, max: 1 })
-        .category("workflow.host")
         .doc("Estimate tokens for a list of message objects."),
     SyncBuiltin::new("microcompact", microcompact_builtin)
         .signature("microcompact(text, max_chars?)")
         .arity(VmBuiltinArity::Range { min: 1, max: 2 })
-        .category("workflow.host")
         .doc("Compact long tool output with the host microcompaction primitive."),
 ];
 
@@ -159,16 +140,19 @@ const WORKFLOW_ASYNC_PRIMITIVES: &[AsyncBuiltin] = &[
     })
     .signature("__host_workflow_graph_run(task, graph, artifacts?, options?)")
     .arity(VmBuiltinArity::Range { min: 2, max: 4 })
-    .category("workflow.host")
     .doc("Execute the low-level workflow graph primitive used by Harn stdlib workflow facades."),
     AsyncBuiltin::new("transcript_auto_compact", |args| {
         boxed_async_builtin(transcript_auto_compact_builtin(args))
     })
     .signature("transcript_auto_compact(messages, options?)")
     .arity(VmBuiltinArity::Range { min: 1, max: 2 })
-    .category("workflow.host")
     .doc("Apply the workflow/agent transcript auto-compaction primitive to a message list."),
 ];
+
+const WORKFLOW_PRIMITIVES: BuiltinGroup<'static> = BuiltinGroup::new()
+    .category("workflow.host")
+    .sync(WORKFLOW_SYNC_PRIMITIVES)
+    .async_(WORKFLOW_ASYNC_PRIMITIVES);
 
 #[derive(Debug, serde::Deserialize)]
 struct WorkflowJoinReadiness {
@@ -810,8 +794,7 @@ pub(in crate::stdlib) async fn execute_workflow(
 }
 
 pub(crate) fn register_workflow_builtins(vm: &mut Vm) {
-    register_sync_builtins(vm, WORKFLOW_SYNC_PRIMITIVES);
-    register_async_builtins(vm, WORKFLOW_ASYNC_PRIMITIVES);
+    register_builtin_group(vm, WORKFLOW_PRIMITIVES);
     register_harn_module_entrypoints(vm, WORKFLOW_STDLIB_ENTRYPOINT_MODULES);
 }
 

--- a/crates/harn-vm/src/stdlib/workflow_messages.rs
+++ b/crates/harn-vm/src/stdlib/workflow_messages.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::stdlib::process::runtime_root_base;
 use crate::stdlib::registration::{
-    boxed_async_builtin, register_async_builtins, register_sync_builtins, AsyncBuiltin, SyncBuiltin,
+    boxed_async_builtin, register_builtin_group, AsyncBuiltin, BuiltinGroup, SyncBuiltin,
 };
 use crate::value::{VmError, VmValue};
 use crate::vm::{Vm, VmBuiltinArity};
@@ -19,52 +19,42 @@ const WORKFLOW_MESSAGE_SYNC_PRIMITIVES: &[SyncBuiltin] = &[
     SyncBuiltin::new("workflow.signal", workflow_signal_builtin)
         .signature("workflow.signal(target, name, payload?)")
         .arity(VmBuiltinArity::Range { min: 2, max: 3 })
-        .category("workflow.messages")
         .doc("Enqueue a workflow signal message."),
     SyncBuiltin::new("workflow.query", workflow_query_builtin)
         .signature("workflow.query(target, name)")
         .arity(VmBuiltinArity::Exact(2))
-        .category("workflow.messages")
         .doc("Read the latest published workflow query value."),
     SyncBuiltin::new("workflow.publish_query", workflow_publish_query_builtin)
         .signature("workflow.publish_query(target, name, value?)")
         .arity(VmBuiltinArity::Range { min: 2, max: 3 })
-        .category("workflow.messages")
         .doc("Publish a workflow query value."),
     SyncBuiltin::new("workflow.receive", workflow_receive_builtin)
         .signature("workflow.receive(target)")
         .arity(VmBuiltinArity::Exact(1))
-        .category("workflow.messages")
         .doc("Receive the next workflow mailbox message."),
     SyncBuiltin::new("workflow.respond_update", workflow_respond_update_builtin)
         .signature("workflow.respond_update(target, request_id, value?, name?)")
         .arity(VmBuiltinArity::Range { min: 2, max: 4 })
-        .category("workflow.messages")
         .doc("Respond to a pending workflow update request."),
     SyncBuiltin::new("workflow.pause", workflow_pause_builtin)
         .signature("workflow.pause(target)")
         .arity(VmBuiltinArity::Exact(1))
-        .category("workflow.messages")
         .doc("Pause a workflow mailbox."),
     SyncBuiltin::new("workflow.resume", workflow_resume_builtin)
         .signature("workflow.resume(target)")
         .arity(VmBuiltinArity::Exact(1))
-        .category("workflow.messages")
         .doc("Resume a workflow mailbox."),
     SyncBuiltin::new("workflow.status", workflow_status_builtin)
         .signature("workflow.status(target)")
         .arity(VmBuiltinArity::Exact(1))
-        .category("workflow.messages")
         .doc("Return workflow mailbox status."),
     SyncBuiltin::new("workflow.continue_as_new", workflow_continue_as_new_builtin)
         .signature("workflow.continue_as_new(target)")
         .arity(VmBuiltinArity::Exact(1))
-        .category("workflow.messages")
         .doc("Advance a workflow mailbox generation."),
     SyncBuiltin::new("continue_as_new", continue_as_new_builtin)
         .signature("continue_as_new(target)")
         .arity(VmBuiltinArity::Exact(1))
-        .category("workflow.messages")
         .doc("Advance a workflow mailbox generation."),
 ];
 
@@ -74,8 +64,12 @@ const WORKFLOW_MESSAGE_ASYNC_PRIMITIVES: &[AsyncBuiltin] =
     })
     .signature("workflow.update(target, name, payload?, options?)")
     .arity(VmBuiltinArity::Range { min: 2, max: 4 })
-    .category("workflow.messages")
     .doc("Enqueue a workflow update and wait for a response.")];
+
+const WORKFLOW_MESSAGE_PRIMITIVES: BuiltinGroup<'static> = BuiltinGroup::new()
+    .category("workflow.messages")
+    .sync(WORKFLOW_MESSAGE_SYNC_PRIMITIVES)
+    .async_(WORKFLOW_MESSAGE_ASYNC_PRIMITIVES);
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct WorkflowMessageRecord {
@@ -538,8 +532,7 @@ pub(crate) fn register_workflow_message_builtins(vm: &mut Vm) {
         ]))),
     );
 
-    register_sync_builtins(vm, WORKFLOW_MESSAGE_SYNC_PRIMITIVES);
-    register_async_builtins(vm, WORKFLOW_MESSAGE_ASYNC_PRIMITIVES);
+    register_builtin_group(vm, WORKFLOW_MESSAGE_PRIMITIVES);
 }
 
 fn workflow_signal_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {


### PR DESCRIPTION
## Summary

- add grouped builtin registration so host primitive categories are declared once per capability surface
- migrate agent, workflow, session, host, daemon, workflow-message, and LLM registration tables onto the grouped DSL
- remove the older split sync/async registration helpers after all callers move to grouped registration

## Validation

- cargo check -p harn-vm --tests
- pre-commit hook: Rust fmt, workspace clippy, generated highlight sync
- pre-push hook: targeted package checks, generated highlight drift check