### PR TITLE
[codex] Keep workflow prompt tests in Harn layer

### DIFF
--- a/crates/harn-vm/src/llm/config_builtins.rs
+++ b/crates/harn-vm/src/llm/config_builtins.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 use crate::llm_config;
 use crate::stdlib::json_to_vm_value;
 use crate::stdlib::registration::{
-    boxed_async_builtin, register_builtin_groups, AsyncBuiltin, BuiltinGroup, SyncBuiltin,
+    async_builtin, register_builtin_groups, AsyncBuiltin, BuiltinGroup, SyncBuiltin,
 };
 use crate::value::{VmError, VmValue};
 use crate::vm::{Vm, VmBuiltinArity};
@@ -92,12 +92,10 @@ const LLM_RATE_LIMIT_SYNC_BUILTINS: &[SyncBuiltin] =
         .doc("Set, query, or clear per-provider requests-per-minute rate limits.")];
 
 const LLM_CONFIG_ASYNC_BUILTINS: &[AsyncBuiltin] =
-    &[AsyncBuiltin::new("llm_healthcheck", |args| {
-        boxed_async_builtin(llm_healthcheck_builtin(args))
-    })
-    .signature("llm_healthcheck(provider_or_options?, options?)")
-    .arity(VmBuiltinArity::Range { min: 0, max: 2 })
-    .doc("Validate provider health, API key reachability, and optional model readiness.")];
+    &[async_builtin!("llm_healthcheck", llm_healthcheck_builtin)
+        .signature("llm_healthcheck(provider_or_options?, options?)")
+        .arity(VmBuiltinArity::Range { min: 0, max: 2 })
+        .doc("Validate provider health, API key reachability, and optional model readiness.")];
 
 const LLM_CONFIG_BUILTINS: BuiltinGroup<'static> = BuiltinGroup::new()
     .category("llm.config")

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -153,8 +153,8 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use crate::stdlib::registration::{
-    boxed_async_builtin, register_builtin_group, register_builtin_groups, AsyncBuiltin,
-    BuiltinGroup, SyncBuiltin,
+    async_builtin, register_builtin_group, register_builtin_groups, AsyncBuiltin, BuiltinGroup,
+    SyncBuiltin,
 };
 use crate::stdlib::{json_to_vm_value, schema_result_value};
 use crate::value::{VmChannelHandle, VmError, VmStream, VmStreamCancel, VmValue};
@@ -1453,109 +1453,96 @@ const LLM_TRACE_SYNC_PRIMITIVES: &[SyncBuiltin] = &[
 ];
 
 const AGENT_HOST_ASYNC_PRIMITIVES: &[AsyncBuiltin] = &[
-    AsyncBuiltin::new("__host_agent_capture_events", |args| {
-        boxed_async_builtin(host_agent_capture_events_impl(args))
-    })
+    async_builtin!(
+        "__host_agent_capture_events",
+        host_agent_capture_events_impl
+    )
     .signature("__host_agent_capture_events(session_id, body)")
     .arity(VmBuiltinArity::Exact(2))
     .doc("Capture agent events emitted while executing a Harn closure."),
-    AsyncBuiltin::new("__host_agent_parse_tool_calls", |args| {
-        boxed_async_builtin(host_agent_parse_tool_calls_impl(args))
-    })
+    async_builtin!(
+        "__host_agent_parse_tool_calls",
+        host_agent_parse_tool_calls_impl
+    )
     .signature("__host_agent_parse_tool_calls(text, tools?)")
     .arity(VmBuiltinArity::Range { min: 1, max: 2 })
     .doc("Parse model text into normalized agent tool-call records."),
-    AsyncBuiltin::new("__host_agent_dispatch_tool_call", |args| {
-        boxed_async_builtin(host_agent_dispatch_tool_call_impl(args))
-    })
+    async_builtin!(
+        "__host_agent_dispatch_tool_call",
+        host_agent_dispatch_tool_call_impl
+    )
     .signature("__host_agent_dispatch_tool_call(call, tools?, options?)")
     .arity(VmBuiltinArity::Range { min: 1, max: 3 })
     .doc("Dispatch one normalized agent tool call through the host tool runtime."),
-    AsyncBuiltin::new("__host_agent_dispatch_tool_batch", |args| {
-        boxed_async_builtin(host_agent_dispatch_tool_batch_impl(args))
-    })
+    async_builtin!(
+        "__host_agent_dispatch_tool_batch",
+        host_agent_dispatch_tool_batch_impl
+    )
     .signature("__host_agent_dispatch_tool_batch(calls, tools?, options?)")
     .arity(VmBuiltinArity::Range { min: 1, max: 3 })
     .doc("Dispatch a batch of normalized agent tool calls through the host tool runtime."),
 ];
 
 const LLM_HOST_CORE_ASYNC_PRIMITIVES: &[AsyncBuiltin] = &[
-    AsyncBuiltin::new("__cost_route", |args| {
-        boxed_async_builtin(cost_route::cost_route_impl(args))
-    })
-    .signature("__cost_route(options)")
-    .arity(VmBuiltinArity::Range { min: 0, max: 1 })
-    .doc("Route an LLM request by cost and capability metadata."),
-    AsyncBuiltin::new("llm_call", |args| boxed_async_builtin(llm_call_impl(args)))
+    async_builtin!("__cost_route", cost_route::cost_route_impl)
+        .signature("__cost_route(options)")
+        .arity(VmBuiltinArity::Range { min: 0, max: 1 })
+        .doc("Route an LLM request by cost and capability metadata."),
+    async_builtin!("llm_call", llm_call_impl)
         .signature("llm_call(prompt, system?, options?)")
         .arity(VmBuiltinArity::Range { min: 1, max: 3 })
         .doc("Execute one LLM call and return the normalized Harn result dict."),
-    AsyncBuiltin::new("llm_stream_call", |args| {
-        boxed_async_builtin(llm_stream_call_impl(args))
-    })
-    .signature("llm_stream_call(prompt, system?, options?)")
-    .arity(VmBuiltinArity::Range { min: 1, max: 3 })
-    .doc("Execute one streaming LLM call and return the normalized Harn result dict."),
-    AsyncBuiltin::new("llm_call_safe", |args| {
-        boxed_async_builtin(llm_call_safe_builtin(args))
-    })
-    .signature("llm_call_safe(prompt, system?, options?)")
-    .arity(VmBuiltinArity::Range { min: 1, max: 3 })
-    .doc("Execute one LLM call and return a non-throwing safe envelope."),
+    async_builtin!("llm_stream_call", llm_stream_call_impl)
+        .signature("llm_stream_call(prompt, system?, options?)")
+        .arity(VmBuiltinArity::Range { min: 1, max: 3 })
+        .doc("Execute one streaming LLM call and return the normalized Harn result dict."),
+    async_builtin!("llm_call_safe", llm_call_safe_builtin)
+        .signature("llm_call_safe(prompt, system?, options?)")
+        .arity(VmBuiltinArity::Range { min: 1, max: 3 })
+        .doc("Execute one LLM call and return a non-throwing safe envelope."),
 ];
 
 const LLM_STRUCTURED_ASYNC_PRIMITIVES: &[AsyncBuiltin] = &[
-    AsyncBuiltin::new("llm_call_structured", |args| {
-        boxed_async_builtin(llm_call_structured_builtin(args))
-    })
-    .signature("llm_call_structured(prompt, schema, options?)")
-    .arity(VmBuiltinArity::Range { min: 2, max: 3 })
-    .doc("Call an LLM for JSON data and return parsed schema-valid data."),
-    AsyncBuiltin::new("llm_call_structured_safe", |args| {
-        boxed_async_builtin(llm_call_structured_safe_builtin(args))
-    })
-    .signature("llm_call_structured_safe(prompt, schema, options?)")
-    .arity(VmBuiltinArity::Range { min: 2, max: 3 })
-    .doc("Call an LLM for JSON data and return a non-throwing schema envelope."),
-    AsyncBuiltin::new("llm_call_structured_result", |args| {
-        boxed_async_builtin(llm_call_structured_result_builtin(args))
-    })
+    async_builtin!("llm_call_structured", llm_call_structured_builtin)
+        .signature("llm_call_structured(prompt, schema, options?)")
+        .arity(VmBuiltinArity::Range { min: 2, max: 3 })
+        .doc("Call an LLM for JSON data and return parsed schema-valid data."),
+    async_builtin!("llm_call_structured_safe", llm_call_structured_safe_builtin)
+        .signature("llm_call_structured_safe(prompt, schema, options?)")
+        .arity(VmBuiltinArity::Range { min: 2, max: 3 })
+        .doc("Call an LLM for JSON data and return a non-throwing schema envelope."),
+    async_builtin!(
+        "llm_call_structured_result",
+        llm_call_structured_result_builtin
+    )
     .signature("llm_call_structured_result(prompt, schema, options?)")
     .arity(VmBuiltinArity::Range { min: 2, max: 3 })
     .doc("Call an LLM for JSON data and return a diagnostic structured-output envelope."),
 ];
 
-const SCHEMA_RECOVERY_ASYNC_PRIMITIVES: &[AsyncBuiltin] =
-    &[AsyncBuiltin::new("schema_recover", |args| {
-        boxed_async_builtin(schema_recover_builtin(args))
-    })
-    .signature("schema_recover(text, schema, options?)")
-    .arity(VmBuiltinArity::Range { min: 2, max: 3 })
-    .doc(
-        "Recover malformed JSON text against a schema using deterministic and optional LLM repair.",
-    )];
+const SCHEMA_RECOVERY_ASYNC_PRIMITIVES: &[AsyncBuiltin] = &[async_builtin!(
+    "schema_recover",
+    schema_recover_builtin
+)
+.signature("schema_recover(text, schema, options?)")
+.arity(VmBuiltinArity::Range { min: 2, max: 3 })
+.doc("Recover malformed JSON text against a schema using deterministic and optional LLM repair.")];
 
 const LLM_RATE_LIMIT_ASYNC_PRIMITIVES: &[AsyncBuiltin] =
-    &[AsyncBuiltin::new("with_rate_limit", |args| {
-        boxed_async_builtin(with_rate_limit_builtin(args))
-    })
-    .signature("with_rate_limit(provider, callback, options?)")
-    .arity(VmBuiltinArity::Range { min: 2, max: 3 })
-    .doc("Run a closure behind the provider rate limiter with retryable-error backoff.")];
+    &[async_builtin!("with_rate_limit", with_rate_limit_builtin)
+        .signature("with_rate_limit(provider, callback, options?)")
+        .arity(VmBuiltinArity::Range { min: 2, max: 3 })
+        .doc("Run a closure behind the provider rate limiter with retryable-error backoff.")];
 
 const LLM_HOST_COMPLETION_ASYNC_PRIMITIVES: &[AsyncBuiltin] = &[
-    AsyncBuiltin::new("llm_completion", |args| {
-        boxed_async_builtin(llm_completion_builtin(args))
-    })
-    .signature("llm_completion(prefix, suffix?, system?, options?)")
-    .arity(VmBuiltinArity::Range { min: 1, max: 4 })
-    .doc("Execute a fill-in-the-middle LLM completion request."),
-    AsyncBuiltin::new("llm_stream", |args| {
-        boxed_async_builtin(llm_stream_builtin(args))
-    })
-    .signature("llm_stream(prompt, system?, options?)")
-    .arity(VmBuiltinArity::Range { min: 1, max: 3 })
-    .doc("Execute a legacy channel-based streaming LLM request."),
+    async_builtin!("llm_completion", llm_completion_builtin)
+        .signature("llm_completion(prefix, suffix?, system?, options?)")
+        .arity(VmBuiltinArity::Range { min: 1, max: 4 })
+        .doc("Execute a fill-in-the-middle LLM completion request."),
+    async_builtin!("llm_stream", llm_stream_builtin)
+        .signature("llm_stream(prompt, system?, options?)")
+        .arity(VmBuiltinArity::Range { min: 1, max: 3 })
+        .doc("Execute a legacy channel-based streaming LLM request."),
 ];
 
 const LLM_MOCK_SYNC_PRIMITIVES: &[SyncBuiltin] = &[

--- a/crates/harn-vm/src/stdlib/agent_sessions.rs
+++ b/crates/harn-vm/src/stdlib/agent_sessions.rs
@@ -10,7 +10,7 @@ use std::rc::Rc;
 
 use crate::agent_sessions;
 use crate::stdlib::registration::{
-    boxed_async_builtin, register_builtin_group, AsyncBuiltin, BuiltinGroup, SyncBuiltin,
+    async_builtin, register_builtin_group, AsyncBuiltin, BuiltinGroup, SyncBuiltin,
 };
 use crate::value::{VmError, VmValue};
 use crate::vm::{Vm, VmBuiltinArity};
@@ -85,12 +85,12 @@ const AGENT_SESSION_SYNC_PRIMITIVES: &[SyncBuiltin] = &[
 ];
 
 const AGENT_SESSION_ASYNC_PRIMITIVES: &[AsyncBuiltin] =
-    &[AsyncBuiltin::new("agent_session_compact", |args| {
-        boxed_async_builtin(agent_session_compact_builtin(args))
-    })
-    .signature("agent_session_compact(id, opts?)")
-    .arity(VmBuiltinArity::Range { min: 1, max: 2 })
-    .doc("Compact an agent session transcript with the host compaction runtime.")];
+    &[
+        async_builtin!("agent_session_compact", agent_session_compact_builtin)
+            .signature("agent_session_compact(id, opts?)")
+            .arity(VmBuiltinArity::Range { min: 1, max: 2 })
+            .doc("Compact an agent session transcript with the host compaction runtime."),
+    ];
 
 const AGENT_SESSION_PRIMITIVES: BuiltinGroup<'static> = BuiltinGroup::new()
     .category("agent.session")

--- a/crates/harn-vm/src/stdlib/agents.rs
+++ b/crates/harn-vm/src/stdlib/agents.rs
@@ -29,7 +29,7 @@ use self::agents_workers::{
 };
 use self::sub_agent::{execute_sub_agent, parse_sub_agent_request};
 use crate::stdlib::registration::{
-    boxed_async_builtin, register_builtin_group, AsyncBuiltin, BuiltinGroup, SyncBuiltin,
+    async_builtin, register_builtin_group, AsyncBuiltin, BuiltinGroup, SyncBuiltin,
 };
 use crate::value::{VmError, VmValue};
 use crate::vm::{Vm, VmBuiltinArity};
@@ -58,42 +58,30 @@ const AGENT_SYNC_PRIMITIVES: &[SyncBuiltin] = &[
 ];
 
 const AGENT_ASYNC_PRIMITIVES: &[AsyncBuiltin] = &[
-    AsyncBuiltin::new("sub_agent_run", |args| {
-        boxed_async_builtin(sub_agent_run_builtin(args))
-    })
-    .signature("sub_agent_run(config)")
-    .arity(VmBuiltinArity::Exact(1))
-    .doc("Run or spawn a sub-agent worker."),
-    AsyncBuiltin::new("spawn_agent", |args| {
-        boxed_async_builtin(spawn_agent_builtin(args))
-    })
-    .signature("spawn_agent(config)")
-    .arity(VmBuiltinArity::Exact(1))
-    .doc("Spawn a workflow, stage, or sub-agent worker."),
-    AsyncBuiltin::new("send_input", |args| {
-        boxed_async_builtin(send_input_builtin(args))
-    })
-    .signature("send_input(worker, task)")
-    .arity(VmBuiltinArity::Exact(2))
-    .doc("Resume a stopped worker with new task input."),
-    AsyncBuiltin::new("worker_trigger", |args| {
-        boxed_async_builtin(worker_trigger_builtin(args))
-    })
-    .signature("worker_trigger(worker, payload)")
-    .arity(VmBuiltinArity::Exact(2))
-    .doc("Trigger an awaiting retriggerable worker."),
-    AsyncBuiltin::new("wait_agent", |args| {
-        boxed_async_builtin(wait_agent_builtin(args))
-    })
-    .signature("wait_agent(worker_or_workers)")
-    .arity(VmBuiltinArity::Exact(1))
-    .doc("Wait for one or more workers to reach a terminal state."),
-    AsyncBuiltin::new("close_agent", |args| {
-        boxed_async_builtin(close_agent_builtin(args))
-    })
-    .signature("close_agent(worker)")
-    .arity(VmBuiltinArity::Exact(1))
-    .doc("Cancel a worker and emit the cancellation lifecycle event."),
+    async_builtin!("sub_agent_run", sub_agent_run_builtin)
+        .signature("sub_agent_run(config)")
+        .arity(VmBuiltinArity::Exact(1))
+        .doc("Run or spawn a sub-agent worker."),
+    async_builtin!("spawn_agent", spawn_agent_builtin)
+        .signature("spawn_agent(config)")
+        .arity(VmBuiltinArity::Exact(1))
+        .doc("Spawn a workflow, stage, or sub-agent worker."),
+    async_builtin!("send_input", send_input_builtin)
+        .signature("send_input(worker, task)")
+        .arity(VmBuiltinArity::Exact(2))
+        .doc("Resume a stopped worker with new task input."),
+    async_builtin!("worker_trigger", worker_trigger_builtin)
+        .signature("worker_trigger(worker, payload)")
+        .arity(VmBuiltinArity::Exact(2))
+        .doc("Trigger an awaiting retriggerable worker."),
+    async_builtin!("wait_agent", wait_agent_builtin)
+        .signature("wait_agent(worker_or_workers)")
+        .arity(VmBuiltinArity::Exact(1))
+        .doc("Wait for one or more workers to reach a terminal state."),
+    async_builtin!("close_agent", close_agent_builtin)
+        .signature("close_agent(worker)")
+        .arity(VmBuiltinArity::Exact(1))
+        .doc("Cancel a worker and emit the cancellation lifecycle event."),
 ];
 
 const AGENT_PRIMITIVES: BuiltinGroup<'static> = BuiltinGroup::new()

--- a/crates/harn-vm/src/stdlib/agents_daemon.rs
+++ b/crates/harn-vm/src/stdlib/agents_daemon.rs
@@ -10,7 +10,7 @@ use crate::bridge::HostBridge;
 use crate::llm::daemon::{load_snapshot, DaemonSnapshot};
 use crate::orchestration::DaemonEventKindRecord;
 use crate::stdlib::registration::{
-    boxed_async_builtin, register_builtin_group, AsyncBuiltin, BuiltinGroup, SyncBuiltin,
+    async_builtin, register_builtin_group, AsyncBuiltin, BuiltinGroup, SyncBuiltin,
 };
 use crate::value::{VmError, VmValue};
 use crate::vm::{Vm, VmBuiltinArity};
@@ -28,30 +28,22 @@ const DAEMON_SYNC_PRIMITIVES: &[SyncBuiltin] =
         .doc("Refresh and return a daemon snapshot with queued event state.")];
 
 const DAEMON_ASYNC_PRIMITIVES: &[AsyncBuiltin] = &[
-    AsyncBuiltin::new("daemon_spawn", |args| {
-        boxed_async_builtin(daemon_spawn_builtin(args))
-    })
-    .signature("daemon_spawn(config)")
-    .arity(VmBuiltinArity::Exact(1))
-    .doc("Spawn a persistent daemon agent worker."),
-    AsyncBuiltin::new("daemon_trigger", |args| {
-        boxed_async_builtin(daemon_trigger_builtin(args))
-    })
-    .signature("daemon_trigger(handle, payload)")
-    .arity(VmBuiltinArity::Exact(2))
-    .doc("Queue an event payload for a running daemon."),
-    AsyncBuiltin::new("daemon_stop", |args| {
-        boxed_async_builtin(daemon_stop_builtin(args))
-    })
-    .signature("daemon_stop(handle)")
-    .arity(VmBuiltinArity::Exact(1))
-    .doc("Stop a running daemon and persist its latest snapshot."),
-    AsyncBuiltin::new("daemon_resume", |args| {
-        boxed_async_builtin(daemon_resume_builtin(args))
-    })
-    .signature("daemon_resume(path)")
-    .arity(VmBuiltinArity::Exact(1))
-    .doc("Resume a daemon from persisted state."),
+    async_builtin!("daemon_spawn", daemon_spawn_builtin)
+        .signature("daemon_spawn(config)")
+        .arity(VmBuiltinArity::Exact(1))
+        .doc("Spawn a persistent daemon agent worker."),
+    async_builtin!("daemon_trigger", daemon_trigger_builtin)
+        .signature("daemon_trigger(handle, payload)")
+        .arity(VmBuiltinArity::Exact(2))
+        .doc("Queue an event payload for a running daemon."),
+    async_builtin!("daemon_stop", daemon_stop_builtin)
+        .signature("daemon_stop(handle)")
+        .arity(VmBuiltinArity::Exact(1))
+        .doc("Stop a running daemon and persist its latest snapshot."),
+    async_builtin!("daemon_resume", daemon_resume_builtin)
+        .signature("daemon_resume(path)")
+        .arity(VmBuiltinArity::Exact(1))
+        .doc("Resume a daemon from persisted state."),
 ];
 
 const DAEMON_PRIMITIVES: BuiltinGroup<'static> = BuiltinGroup::new()

--- a/crates/harn-vm/src/stdlib/host.rs
+++ b/crates/harn-vm/src/stdlib/host.rs
@@ -6,7 +6,7 @@ use std::time::Instant;
 use serde_json::Value as JsonValue;
 
 use crate::stdlib::registration::{
-    boxed_async_builtin, register_builtin_group, AsyncBuiltin, BuiltinGroup, SyncBuiltin,
+    async_builtin, register_builtin_group, AsyncBuiltin, BuiltinGroup, SyncBuiltin,
 };
 use crate::value::{values_equal, VmError, VmValue};
 use crate::vm::clone_async_builtin_child_vm;
@@ -44,24 +44,18 @@ const HOST_SYNC_PRIMITIVES: &[SyncBuiltin] = &[
 ];
 
 const HOST_ASYNC_PRIMITIVES: &[AsyncBuiltin] = &[
-    AsyncBuiltin::new("host_call", |args| {
-        boxed_async_builtin(host_call_builtin(args))
-    })
-    .signature("host_call(name, args)")
-    .arity(VmBuiltinArity::Range { min: 1, max: 2 })
-    .doc("Invoke a host capability operation by capability.operation name."),
-    AsyncBuiltin::new("host_tool_list", |args| {
-        boxed_async_builtin(host_tool_list_builtin(args))
-    })
-    .signature("host_tool_list()")
-    .arity(VmBuiltinArity::Exact(0))
-    .doc("List host tools exposed by the active bridge."),
-    AsyncBuiltin::new("host_tool_call", |args| {
-        boxed_async_builtin(host_tool_call_builtin(args))
-    })
-    .signature("host_tool_call(name, args?)")
-    .arity(VmBuiltinArity::Range { min: 1, max: 2 })
-    .doc("Call a host tool exposed by the active bridge."),
+    async_builtin!("host_call", host_call_builtin)
+        .signature("host_call(name, args)")
+        .arity(VmBuiltinArity::Range { min: 1, max: 2 })
+        .doc("Invoke a host capability operation by capability.operation name."),
+    async_builtin!("host_tool_list", host_tool_list_builtin)
+        .signature("host_tool_list()")
+        .arity(VmBuiltinArity::Exact(0))
+        .doc("List host tools exposed by the active bridge."),
+    async_builtin!("host_tool_call", host_tool_call_builtin)
+        .signature("host_tool_call(name, args?)")
+        .arity(VmBuiltinArity::Range { min: 1, max: 2 })
+        .doc("Call a host tool exposed by the active bridge."),
 ];
 
 const HOST_PRIMITIVES: BuiltinGroup<'static> = BuiltinGroup::new()

--- a/crates/harn-vm/src/stdlib/registration.rs
+++ b/crates/harn-vm/src/stdlib/registration.rs
@@ -123,6 +123,16 @@ where
     Box::pin(future)
 }
 
+macro_rules! async_builtin {
+    ($name:expr, $handler:path) => {
+        $crate::stdlib::registration::AsyncBuiltin::new($name, |args| {
+            $crate::stdlib::registration::boxed_async_builtin($handler(args))
+        })
+    };
+}
+
+pub(crate) use async_builtin;
+
 #[derive(Clone, Copy)]
 pub(crate) struct BuiltinGroup<'a> {
     category: Option<&'static str>,

--- a/crates/harn-vm/src/stdlib/workflow/register.rs
+++ b/crates/harn-vm/src/stdlib/workflow/register.rs
@@ -13,7 +13,7 @@ use crate::orchestration::{
 };
 use crate::stdlib::harn_entry::{register_harn_module_entrypoints, HarnEntrypointModule};
 use crate::stdlib::registration::{
-    boxed_async_builtin, register_builtin_group, AsyncBuiltin, BuiltinGroup, SyncBuiltin,
+    async_builtin, register_builtin_group, AsyncBuiltin, BuiltinGroup, SyncBuiltin,
 };
 use crate::value::{VmError, VmValue};
 use crate::vm::{Vm, VmBuiltinArity};
@@ -135,18 +135,17 @@ const WORKFLOW_SYNC_PRIMITIVES: &[SyncBuiltin] = &[
 ];
 
 const WORKFLOW_ASYNC_PRIMITIVES: &[AsyncBuiltin] = &[
-    AsyncBuiltin::new(HOST_WORKFLOW_GRAPH_RUN_BUILTIN, |args| {
-        boxed_async_builtin(host_workflow_graph_run_builtin(args))
-    })
+    async_builtin!(
+        HOST_WORKFLOW_GRAPH_RUN_BUILTIN,
+        host_workflow_graph_run_builtin
+    )
     .signature("__host_workflow_graph_run(task, graph, artifacts?, options?)")
     .arity(VmBuiltinArity::Range { min: 2, max: 4 })
     .doc("Execute the low-level workflow graph primitive used by Harn stdlib workflow facades."),
-    AsyncBuiltin::new("transcript_auto_compact", |args| {
-        boxed_async_builtin(transcript_auto_compact_builtin(args))
-    })
-    .signature("transcript_auto_compact(messages, options?)")
-    .arity(VmBuiltinArity::Range { min: 1, max: 2 })
-    .doc("Apply the workflow/agent transcript auto-compaction primitive to a message list."),
+    async_builtin!("transcript_auto_compact", transcript_auto_compact_builtin)
+        .signature("transcript_auto_compact(messages, options?)")
+        .arity(VmBuiltinArity::Range { min: 1, max: 2 })
+        .doc("Apply the workflow/agent transcript auto-compaction primitive to a message list."),
 ];
 
 const WORKFLOW_PRIMITIVES: BuiltinGroup<'static> = BuiltinGroup::new()

--- a/crates/harn-vm/src/stdlib/workflow/tests.rs
+++ b/crates/harn-vm/src/stdlib/workflow/tests.rs
@@ -1,11 +1,10 @@
 use super::artifact::{load_run_tree, snapshot_trace_spans};
 use super::map::{execute_join_tasks, LocalTask};
-use super::register::execute_workflow;
 use super::stage::{execute_stage_attempts, replay_stage};
 use crate::orchestration::{
-    inject_workflow_verification_contracts, save_run_record, workflow_verification_contracts,
-    RunChildRecord, RunExecutionRecord, RunRecord, RunStageRecord, VerificationContract,
-    VerificationRequirement, WorkflowEdge, WorkflowGraph, WorkflowNode,
+    save_run_record, stage_verification_contracts, verification_contract_from_verify,
+    workflow_verification_contracts, RunChildRecord, RunExecutionRecord, RunRecord, RunStageRecord,
+    VerificationContract, WorkflowGraph, WorkflowNode,
 };
 use crate::tracing::{set_tracing_enabled, span_end, span_start, SpanKind};
 use crate::value::VmValue;
@@ -300,140 +299,13 @@ fn workflow_verification_contracts_collect_exact_requirements() {
     );
 }
 
-#[tokio::test(flavor = "current_thread", start_paused = true)]
-async fn workflow_execute_injects_verify_contract_into_act_prompt() {
+#[test]
+fn verification_contract_loads_file_relative_to_execution_context() {
     crate::reset_thread_local_state();
-    crate::llm::mock::push_llm_mock(crate::llm::mock::LlmMock {
-        text: "done".to_string(),
-        tool_calls: Vec::new(),
-        match_pattern: None,
-        consume_on_match: false,
-        input_tokens: None,
-        output_tokens: None,
-        cache_read_tokens: None,
-        cache_write_tokens: None,
-        thinking: None,
-        thinking_summary: None,
-        stop_reason: None,
-        model: "mock-model".to_string(),
-        provider: Some("mock".to_string()),
-        blocks: None,
-        error: None,
-    });
-
-    let temp_dir = std::env::temp_dir().join(format!("harn-issue-126-{}", uuid::Uuid::now_v7()));
-    std::fs::create_dir_all(&temp_dir).expect("temp dir");
-    let persist_path = temp_dir.join("run.json");
-
-    let graph = WorkflowGraph {
-        type_name: "workflow_graph".to_string(),
-        id: "wf".to_string(),
-        entry: "act".to_string(),
-        nodes: BTreeMap::from([
-            (
-                "act".to_string(),
-                WorkflowNode {
-                    id: Some("act".to_string()),
-                    kind: "stage".to_string(),
-                    mode: Some("llm".to_string()),
-                    model_policy: crate::orchestration::ModelPolicy {
-                        provider: Some("mock".to_string()),
-                        ..Default::default()
-                    },
-                    ..Default::default()
-                },
-            ),
-            (
-                "verify".to_string(),
-                WorkflowNode {
-                    id: Some("verify".to_string()),
-                    kind: "verify".to_string(),
-                    verify: Some(serde_json::json!({
-                        "command": "echo ok",
-                        "expect_status": 0,
-                        "required_identifiers": ["rateLimit"],
-                        "required_text": ["app.use(rateLimit)"],
-                    })),
-                    output_contract: crate::orchestration::StageContract {
-                        output_kinds: vec!["verification_result".to_string()],
-                        ..Default::default()
-                    },
-                    ..Default::default()
-                },
-            ),
-        ]),
-        edges: vec![WorkflowEdge {
-            from: "act".to_string(),
-            to: "verify".to_string(),
-            branch: None,
-            label: None,
-        }],
-        ..Default::default()
-    };
-
-    let result = execute_workflow(
-        "Implement the verifier-exact middleware.".to_string(),
-        graph,
-        Vec::new(),
-        BTreeMap::from([
-            (
-                "persist_path".to_string(),
-                crate::value::VmValue::String(Rc::from(
-                    persist_path.to_string_lossy().into_owned(),
-                )),
-            ),
-            ("max_steps".to_string(), crate::value::VmValue::Int(2)),
-        ]),
-    )
-    .await
-    .expect("workflow executes");
-
-    let run_value = result
-        .as_dict()
-        .and_then(|value| value.get("run"))
-        .cloned()
-        .expect("workflow envelope run");
-    let run = crate::orchestration::normalize_run_record(&run_value).expect("run record");
-    let act_stage = run
-        .stages
-        .iter()
-        .find(|stage| stage.node_id == "act")
-        .expect("act stage");
-    let prompt = act_stage
-        .metadata
-        .get("prompt")
-        .and_then(|value| value.as_str())
-        .expect("prompt metadata");
-    assert!(prompt.contains("<workflow_verification>"));
-    assert!(prompt.contains("rateLimit"));
-    assert!(prompt.contains("app.use(rateLimit)"));
-
-    let _ = std::fs::remove_dir_all(&temp_dir);
-}
-
-#[tokio::test(flavor = "current_thread", start_paused = true)]
-async fn stage_prompt_loads_contract_file_relative_to_execution_context() {
-    crate::reset_thread_local_state();
-    crate::llm::mock::push_llm_mock(crate::llm::mock::LlmMock {
-        text: "done".to_string(),
-        tool_calls: Vec::new(),
-        match_pattern: None,
-        consume_on_match: false,
-        input_tokens: None,
-        output_tokens: None,
-        cache_read_tokens: None,
-        cache_write_tokens: None,
-        thinking: None,
-        thinking_summary: None,
-        stop_reason: None,
-        model: "mock-model".to_string(),
-        provider: Some("mock".to_string()),
-        blocks: None,
-        error: None,
-    });
-
-    let temp_dir =
-        std::env::temp_dir().join(format!("harn-issue-126-file-{}", uuid::Uuid::now_v7()));
+    let temp_dir = std::env::temp_dir().join(format!(
+        "harn-verification-contract-{}",
+        uuid::Uuid::now_v7()
+    ));
     std::fs::create_dir_all(&temp_dir).expect("temp dir");
     let contract_path = temp_dir.join("verify.contract.json");
     std::fs::write(
@@ -453,108 +325,58 @@ async fn stage_prompt_loads_contract_file_relative_to_execution_context() {
         ..Default::default()
     }));
 
-    let mut node = WorkflowNode {
-        id: Some("act".to_string()),
-        kind: "stage".to_string(),
-        mode: Some("llm".to_string()),
-        model_policy: crate::orchestration::ModelPolicy {
-            provider: Some("mock".to_string()),
-            ..Default::default()
-        },
-        verify: Some(serde_json::json!({
+    let contract = verification_contract_from_verify(
+        "act",
+        Some(&serde_json::json!({
             "contract_path": "verify.contract.json",
         })),
-        ..Default::default()
-    };
-    inject_workflow_verification_contracts(
-        &mut node,
-        &[VerificationContract {
-            source_node: Some("verify".to_string()),
-            checks: vec![VerificationRequirement {
-                kind: "identifier".to_string(),
-                value: "rateLimit".to_string(),
-                note: Some("Use the exact exported name.".to_string()),
-            }],
-            ..Default::default()
-        }],
-    );
+    )
+    .expect("contract loads")
+    .expect("contract");
 
-    let executed = execute_stage_attempts("Implement the middleware.", "act", &node, &[], None)
-        .await
-        .expect("stage executes");
-    let prompt = executed
-        .result
-        .get("prompt")
-        .and_then(|value| value.as_str())
-        .expect("prompt");
-    assert!(prompt.contains("rateLimit"));
-    assert!(prompt.contains("src/middleware/rateLimit.ts"));
-    assert!(prompt.contains("app.use(rateLimit)"));
+    assert_eq!(contract.source_node.as_deref(), Some("act"));
+    assert_eq!(contract.required_identifiers, vec!["rateLimit"]);
+    assert_eq!(contract.required_paths, vec!["src/middleware/rateLimit.ts"]);
+    assert_eq!(contract.required_text, vec!["app.use(rateLimit)"]);
 
     crate::reset_thread_local_state();
     let _ = std::fs::remove_dir_all(&temp_dir);
 }
 
-#[tokio::test(flavor = "current_thread", start_paused = true)]
-async fn stage_prompt_can_scope_verification_to_local_contract_only() {
+#[test]
+fn stage_verification_contracts_can_scope_to_local_contract_only() {
     crate::reset_thread_local_state();
-    crate::llm::mock::push_llm_mock(crate::llm::mock::LlmMock {
-        text: "done".to_string(),
-        tool_calls: Vec::new(),
-        match_pattern: None,
-        consume_on_match: false,
-        input_tokens: None,
-        output_tokens: None,
-        cache_read_tokens: None,
-        cache_write_tokens: None,
-        thinking: None,
-        thinking_summary: None,
-        stop_reason: None,
-        model: "mock-model".to_string(),
-        provider: Some("mock".to_string()),
-        blocks: None,
-        error: None,
-    });
 
-    let mut node = WorkflowNode {
+    let node = WorkflowNode {
         id: Some("act".to_string()),
         kind: "stage".to_string(),
-        mode: Some("llm".to_string()),
-        model_policy: crate::orchestration::ModelPolicy {
-            provider: Some("mock".to_string()),
-            ..Default::default()
-        },
         verify: Some(serde_json::json!({
             "required_paths": ["src/current.ts"],
             "notes": ["Only the current batch path is in scope."],
         })),
-        metadata: BTreeMap::from([(
-            crate::orchestration::WORKFLOW_VERIFICATION_SCOPE_METADATA_KEY.to_string(),
-            serde_json::json!("local_only"),
-        )]),
+        metadata: BTreeMap::from([
+            (
+                crate::orchestration::WORKFLOW_VERIFICATION_SCOPE_METADATA_KEY.to_string(),
+                serde_json::json!("local_only"),
+            ),
+            (
+                crate::orchestration::WORKFLOW_VERIFICATION_CONTRACTS_METADATA_KEY.to_string(),
+                serde_json::to_value(vec![VerificationContract {
+                    source_node: Some("final_verify".to_string()),
+                    required_paths: vec!["src/future.ts".to_string()],
+                    required_text: vec!["futureOnly".to_string()],
+                    ..Default::default()
+                }])
+                .expect("contract metadata"),
+            ),
+        ]),
         ..Default::default()
     };
-    inject_workflow_verification_contracts(
-        &mut node,
-        &[VerificationContract {
-            source_node: Some("final_verify".to_string()),
-            required_paths: vec!["src/future.ts".to_string()],
-            required_text: vec!["futureOnly".to_string()],
-            ..Default::default()
-        }],
-    );
+    let contracts = stage_verification_contracts("act", &node).expect("contracts");
 
-    let executed = execute_stage_attempts("Only update src/current.ts.", "act", &node, &[], None)
-        .await
-        .expect("stage executes");
-    let prompt = executed
-        .result
-        .get("prompt")
-        .and_then(|value| value.as_str())
-        .expect("prompt");
-    assert!(prompt.contains("src/current.ts"));
-    assert!(!prompt.contains("src/future.ts"));
-    assert!(!prompt.contains("futureOnly"));
+    assert_eq!(contracts.len(), 1);
+    assert_eq!(contracts[0].required_paths, vec!["src/current.ts"]);
+    assert!(contracts[0].required_text.is_empty());
 }
 
 fn base_workflow_node_with_raw_auto_compact(raw: BTreeMap<String, VmValue>) -> WorkflowNode {

--- a/crates/harn-vm/src/stdlib/workflow_messages.rs
+++ b/crates/harn-vm/src/stdlib/workflow_messages.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::stdlib::process::runtime_root_base;
 use crate::stdlib::registration::{
-    boxed_async_builtin, register_builtin_group, AsyncBuiltin, BuiltinGroup, SyncBuiltin,
+    async_builtin, register_builtin_group, AsyncBuiltin, BuiltinGroup, SyncBuiltin,
 };
 use crate::value::{VmError, VmValue};
 use crate::vm::{Vm, VmBuiltinArity};
@@ -59,12 +59,10 @@ const WORKFLOW_MESSAGE_SYNC_PRIMITIVES: &[SyncBuiltin] = &[
 ];
 
 const WORKFLOW_MESSAGE_ASYNC_PRIMITIVES: &[AsyncBuiltin] =
-    &[AsyncBuiltin::new("workflow.update", |args| {
-        boxed_async_builtin(workflow_update_builtin(args))
-    })
-    .signature("workflow.update(target, name, payload?, options?)")
-    .arity(VmBuiltinArity::Range { min: 2, max: 4 })
-    .doc("Enqueue a workflow update and wait for a response.")];
+    &[async_builtin!("workflow.update", workflow_update_builtin)
+        .signature("workflow.update(target, name, payload?, options?)")
+        .arity(VmBuiltinArity::Range { min: 2, max: 4 })
+        .doc("Enqueue a workflow update and wait for a response.")];
 
 const WORKFLOW_MESSAGE_PRIMITIVES: BuiltinGroup<'static> = BuiltinGroup::new()
     .category("workflow.messages")


### PR DESCRIPTION
## Summary

- remove Rust tests that run mocked workflow stages just to assert prompt text snippets
- keep Rust coverage focused on the Rust-owned verification-contract boundary: file loading and local/global contract selection
- leave prompt rendering expectations in the Harn conformance fixture where the prompt composition now lives

## Validation

- cargo check -p harn-vm --tests
- pre-commit hook: Rust fmt, workspace clippy, generated highlight sync
- pre-push hook: targeted package checks, generated highlight drift check