### PR TITLE
[codex] Move parse guidance prose into prompt asset

### DIFF
--- a/crates/harn-stdlib/src/stdlib/agent/prompts/parse_guidance.harn.prompt
+++ b/crates/harn-stdlib/src/stdlib/agent/prompts/parse_guidance.harn.prompt
@@ -1,4 +1,6 @@
-Your tool call could not be parsed: {{ error_summary }}{{ partial_note }}
+Your tool call could not be parsed: {{ error_summary }}{{ if has_partial_success }}
+
+(The other {{ parsed_call_count }} tool call(s) in this turn parsed successfully and were dispatched; the errors above describe only the malformed ones, which were dropped.){{ end }}
 
 Use heredoc syntax for multiline content. It requires no escaping:
 

--- a/crates/harn-vm/src/llm/agent/llm_call.rs
+++ b/crates/harn-vm/src/llm/agent/llm_call.rs
@@ -374,24 +374,18 @@ pub(super) async fn run_llm_call(
                         calls.len(),
                     ),
                 );
-                let partial_note = if calls.is_empty() {
-                    String::new()
-                } else {
-                    format!(
-                        "\n\n(The other {} tool call(s) in this turn parsed \
-                         successfully and were dispatched; the errors above \
-                         describe only the malformed ones, which were dropped.)",
-                        calls.len()
-                    )
-                };
                 let mut bindings = BTreeMap::new();
                 bindings.insert(
                     "error_summary".to_string(),
                     VmValue::String(Rc::from(error_summary)),
                 );
                 bindings.insert(
-                    "partial_note".to_string(),
-                    VmValue::String(Rc::from(partial_note)),
+                    "has_partial_success".to_string(),
+                    VmValue::Bool(!calls.is_empty()),
+                );
+                bindings.insert(
+                    "parsed_call_count".to_string(),
+                    VmValue::Int(calls.len() as i64),
                 );
                 let feedback = crate::stdlib::template::render_stdlib_prompt_asset(
                     "agent/prompts/parse_guidance.harn.prompt",


### PR DESCRIPTION
## Summary
- move the parse-guidance partial-success note from Rust string assembly into the stdlib prompt asset
- keep Rust responsible only for structured prompt bindings

## Validation
- cargo fmt --all
- cargo check -p harn-vm --tests
- make check-rust-prompt-prose
- pre-commit hook
- pre-push hook