### PR TITLE
[codex] Declare stdlib entrypoints from Harn sources

### DIFF
--- a/crates/harn-stdlib/src/lib.rs
+++ b/crates/harn-stdlib/src/lib.rs
@@ -26,6 +26,12 @@ pub struct StdlibPublicFunction {
     pub doc: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StdlibEntrypointModule {
+    pub import_path: String,
+    pub category: String,
+}
+
 pub const STDLIB_SOURCES: &[StdlibSource] = &[
     StdlibSource {
         module: "text",
@@ -374,6 +380,35 @@ pub fn public_functions_for_module(module: &str) -> Vec<StdlibPublicFunction> {
     public_functions_from_source(source)
 }
 
+pub fn entrypoint_modules() -> Vec<StdlibEntrypointModule> {
+    STDLIB_SOURCES
+        .iter()
+        .filter_map(|entry| {
+            entrypoint_category_from_source(entry.source).map(|category| StdlibEntrypointModule {
+                import_path: format!("std/{}", entry.module),
+                category,
+            })
+        })
+        .collect()
+}
+
+fn entrypoint_category_from_source(source: &str) -> Option<String> {
+    for line in source.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        if let Some(category) = line.strip_prefix("// @harn-entrypoint-category ") {
+            let category = category.trim();
+            return (!category.is_empty()).then(|| category.to_string());
+        }
+        if !line.starts_with("//") {
+            return None;
+        }
+    }
+    None
+}
+
 fn public_functions_from_source(source: &str) -> Vec<StdlibPublicFunction> {
     let mut out = Vec::new();
     let mut doc: Option<String> = None;
@@ -507,8 +542,8 @@ mod tests {
     use std::collections::BTreeSet;
 
     use super::{
-        get_stdlib_prompt_asset, get_stdlib_source, public_functions_for_module,
-        STDLIB_PROMPT_ASSETS, STDLIB_SOURCES,
+        entrypoint_modules, get_stdlib_prompt_asset, get_stdlib_source,
+        public_functions_for_module, STDLIB_PROMPT_ASSETS, STDLIB_SOURCES,
     };
 
     #[test]
@@ -595,5 +630,22 @@ mod tests {
         );
         assert_eq!(exports[0].required_params, 2);
         assert_eq!(exports[0].total_params, 4);
+    }
+
+    #[test]
+    fn harn_entrypoint_catalog_is_declared_by_stdlib_sources() {
+        let modules = entrypoint_modules();
+        let entries = modules
+            .iter()
+            .map(|module| (module.import_path.as_str(), module.category.as_str()))
+            .collect::<BTreeSet<_>>();
+        for entry in [
+            ("std/agent/loop", "agent.stdlib"),
+            ("std/agent/turn", "agent.stdlib"),
+            ("std/agent/primitives", "agent.stdlib"),
+            ("std/workflow/execute", "workflow.stdlib"),
+        ] {
+            assert!(entries.contains(&entry), "{entry:?} should be declared");
+        }
     }
 }

--- a/crates/harn-stdlib/src/stdlib/agent/loop.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/loop.harn
@@ -1,3 +1,4 @@
+// @harn-entrypoint-category agent.stdlib
 import { agent_loop_options } from "std/agent/options"
 
 /** agent_loop. */

--- a/crates/harn-stdlib/src/stdlib/agent/primitives.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/primitives.harn
@@ -1,3 +1,4 @@
+// @harn-entrypoint-category agent.stdlib
 /** agent_llm_turn. */
 pub fn agent_llm_turn(prompt, system = nil, options = nil) {
   return llm_call(prompt, system, options ?? {})

--- a/crates/harn-stdlib/src/stdlib/agent/turn.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/turn.harn
@@ -1,3 +1,4 @@
+// @harn-entrypoint-category agent.stdlib
 import { agent_capture_events } from "std/agent/events"
 import { agent_loop } from "std/agent/loop"
 import { agent_loop_options } from "std/agent/options"

--- a/crates/harn-stdlib/src/stdlib/workflow/execute.harn
+++ b/crates/harn-stdlib/src/stdlib/workflow/execute.harn
@@ -1,3 +1,4 @@
+// @harn-entrypoint-category workflow.stdlib
 import "std/workflow/prompts"
 
 /** workflow_execute. */

--- a/crates/harn-vm/src/llm/agent_config.rs
+++ b/crates/harn-vm/src/llm/agent_config.rs
@@ -5,7 +5,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use crate::agent_events::AgentEventSink;
-use crate::stdlib::harn_entry::{register_harn_module_entrypoints, HarnEntrypointModule};
+use crate::stdlib::harn_entry::register_harn_entrypoint_category;
 use crate::stdlib::registration::{register_builtin_group, BuiltinGroup, SyncBuiltin};
 use crate::value::{VmError, VmValue};
 use crate::vm::{Vm, VmBuiltinArity, VmBuiltinMetadata};
@@ -28,11 +28,7 @@ const DEFAULT_AGENT_LOOP_TOOL_RETRIES: i64 = 0;
 const DEFAULT_AGENT_LOOP_SCHEMA_RETRIES: i64 = 0;
 const HOST_LLM_SESSION_RUN_BUILTIN: &str = "__host_llm_session_run";
 
-const AGENT_STDLIB_ENTRYPOINT_MODULES: &[HarnEntrypointModule] = &[
-    HarnEntrypointModule::new("std/agent/loop", "agent.stdlib"),
-    HarnEntrypointModule::new("std/agent/turn", "agent.stdlib"),
-    HarnEntrypointModule::new("std/agent/primitives", "agent.stdlib"),
-];
+const AGENT_STDLIB_ENTRYPOINT_CATEGORY: &str = "agent.stdlib";
 
 const AGENT_CONTROL_PRIMITIVES: &[SyncBuiltin] = &[
     SyncBuiltin::new("agent_subscribe", agent_subscribe_builtin)
@@ -639,12 +635,12 @@ fn register_llm_turn_loop_driver(vm: &mut Vm, bridge: Option<Rc<crate::bridge::H
 
 pub(crate) fn register_agent_loop(vm: &mut Vm) {
     register_llm_turn_loop_driver(vm, None);
-    register_harn_module_entrypoints(vm, AGENT_STDLIB_ENTRYPOINT_MODULES);
+    register_harn_entrypoint_category(vm, AGENT_STDLIB_ENTRYPOINT_CATEGORY);
 }
 
 pub fn register_agent_loop_with_bridge(vm: &mut Vm, bridge: Rc<crate::bridge::HostBridge>) {
     register_llm_turn_loop_driver(vm, Some(bridge));
-    register_harn_module_entrypoints(vm, AGENT_STDLIB_ENTRYPOINT_MODULES);
+    register_harn_entrypoint_category(vm, AGENT_STDLIB_ENTRYPOINT_CATEGORY);
 }
 
 pub(crate) fn register_agent_control_primitives(vm: &mut Vm) {

--- a/crates/harn-vm/src/stdlib/harn_entry.rs
+++ b/crates/harn-vm/src/stdlib/harn_entry.rs
@@ -3,23 +3,11 @@
 use crate::value::{VmError, VmValue};
 use crate::vm::{Vm, VmBuiltinArity, VmBuiltinMetadata};
 
-#[derive(Clone, Copy, Debug)]
-pub(crate) struct HarnEntrypointModule {
-    pub import_path: &'static str,
-    pub category: &'static str,
-}
-
-impl HarnEntrypointModule {
-    pub(crate) const fn new(import_path: &'static str, category: &'static str) -> Self {
-        Self {
-            import_path,
-            category,
+pub(crate) fn register_harn_entrypoint_category(vm: &mut Vm, category: &str) {
+    for module in harn_stdlib::entrypoint_modules() {
+        if module.category != category {
+            continue;
         }
-    }
-}
-
-pub(crate) fn register_harn_module_entrypoints(vm: &mut Vm, modules: &[HarnEntrypointModule]) {
-    for module in modules {
         let Some(module_name) = module.import_path.strip_prefix("std/") else {
             continue;
         };
@@ -27,11 +15,11 @@ pub(crate) fn register_harn_module_entrypoints(vm: &mut Vm, modules: &[HarnEntry
             let arity = arity_for_export(&export);
             let entrypoint = HarnEntrypoint {
                 public_name: export.name.clone(),
-                import_path: module.import_path.to_string(),
+                import_path: module.import_path.clone(),
                 export_name: export.name,
                 signature: export.signature,
                 arity,
-                category: module.category.to_string(),
+                category: module.category.clone(),
                 doc: export.doc,
             };
             entrypoint.register(vm);

--- a/crates/harn-vm/src/stdlib/workflow/register.rs
+++ b/crates/harn-vm/src/stdlib/workflow/register.rs
@@ -11,7 +11,7 @@ use crate::orchestration::{
     RunStageRecord, RunTransitionRecord, WorkflowEdge, WorkflowGraph, WorkflowSkillContext,
     WorkflowSkillContextGuard,
 };
-use crate::stdlib::harn_entry::{register_harn_module_entrypoints, HarnEntrypointModule};
+use crate::stdlib::harn_entry::register_harn_entrypoint_category;
 use crate::stdlib::registration::{
     async_builtin, register_builtin_group, AsyncBuiltin, BuiltinGroup, SyncBuiltin,
 };
@@ -33,10 +33,7 @@ use super::policy::{
 use super::stage::{execute_stage_attempts, replay_stage};
 use super::usage::{llm_usage_delta, llm_usage_snapshot};
 
-const WORKFLOW_STDLIB_ENTRYPOINT_MODULES: &[HarnEntrypointModule] = &[HarnEntrypointModule::new(
-    "std/workflow/execute",
-    "workflow.stdlib",
-)];
+const WORKFLOW_STDLIB_ENTRYPOINT_CATEGORY: &str = "workflow.stdlib";
 const HOST_WORKFLOW_GRAPH_RUN_BUILTIN: &str = "__host_workflow_graph_run";
 type PostHookFn = Rc<dyn Fn(&str, &str) -> crate::orchestration::PostToolAction>;
 
@@ -794,7 +791,7 @@ pub(in crate::stdlib) async fn execute_workflow(
 
 pub(crate) fn register_workflow_builtins(vm: &mut Vm) {
     register_builtin_group(vm, WORKFLOW_PRIMITIVES);
-    register_harn_module_entrypoints(vm, WORKFLOW_STDLIB_ENTRYPOINT_MODULES);
+    register_harn_entrypoint_category(vm, WORKFLOW_STDLIB_ENTRYPOINT_CATEGORY);
 }
 
 fn workflow_graph_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {


### PR DESCRIPTION
## Summary
- declare Harn stdlib entrypoint categories in the source files that own each facade
- have harn-stdlib discover the entrypoint catalog from those declarations
- register VM stdlib entrypoints by category instead of hardcoded Rust module names

## Validation
- pre-push targeted checks passed after rebase