### PR TITLE
Harden local agent convergence paths

### DIFF
--- a/crates/harn-vm/src/llm/agent/completion_judge.rs
+++ b/crates/harn-vm/src/llm/agent/completion_judge.rs
@@ -158,7 +158,7 @@ pub(super) async fn run_completion_judge(
             "reasoning": {"type": ["string", "null"], "maxLength": 2000},
             "feedback": {"type": ["string", "null"], "maxLength": config.max_feedback_chars},
             "next_step": {"type": ["string", "null"], "maxLength": config.max_feedback_chars},
-            "final_response": {"type": ["string", "null"], "maxLength": 2000},
+            "final_response": {"type": ["string", "null"], "maxLength": 20000},
         },
     });
     let options = build_judge_options(config, main_opts);

--- a/crates/harn-vm/src/llm/agent/tests/tool_dispatch_categories.rs
+++ b/crates/harn-vm/src/llm/agent/tests/tool_dispatch_categories.rs
@@ -312,6 +312,64 @@ async fn completion_judge_can_confirm_successful_tool_turn_from_transcript_conte
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn completion_judge_accepts_long_final_response() {
+    let guard = serialize_tests();
+    drain_thread_local_state();
+    reset_llm_mock_state();
+    let temp_file = tempfile::NamedTempFile::new().expect("create temp file");
+    let path = temp_file.path().to_path_buf();
+    std::fs::write(&path, "LONG-ANSWER\n").expect("write temp file");
+    let final_response = format!(
+        "Confirmed LONG-ANSWER. {}",
+        "This sentence keeps a useful but lengthy final answer valid. ".repeat(70)
+    );
+    let judge_json = serde_json::json!({
+        "pass": true,
+        "final_response": final_response,
+    })
+    .to_string();
+
+    crate::llm::mock::push_llm_mock(tool_call_with_text_mock(
+        "I will inspect the file.".to_string(),
+        "read_file",
+        json!({"path": path.to_string_lossy().to_string()}),
+    ));
+    crate::llm::mock::push_llm_mock(text_mock(&judge_json));
+    crate::llm::mock::push_llm_mock(text_mock("unexpected extra turn"));
+
+    let mut opts = base_opts(vec![json!({
+        "role": "user",
+        "content": "Read the validation file and summarize it fully.",
+    })]);
+    opts.native_tools = Some(vec![native_read_file_schema()]);
+    let mut config = base_agent_config();
+    config.persistent = true;
+    config.max_iterations = 3;
+    config.max_verify_attempts = 2;
+    config.tool_format = "native".to_string();
+    config.verify_completion_judge =
+        Some(crate::llm::agent::completion_judge::CompletionJudgeConfig::default());
+    config.session_id = "test-judge-long-final-response".to_string();
+
+    let result = run_agent_loop_internal(&mut opts, config).await.unwrap();
+    let calls = get_llm_mock_calls();
+    assert_eq!(
+        calls.len(),
+        2,
+        "long but valid judge final_response should not be schema-vetoed"
+    );
+    assert_eq!(result["status"], "done");
+    assert_eq!(
+        result["visible_text"].as_str(),
+        Some(final_response.trim_end())
+    );
+
+    std::fs::remove_file(path).ok();
+    reset_llm_mock_state();
+    drop(guard);
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn completion_judge_treats_null_optional_fields_as_absent() {
     let guard = serialize_tests();
     drain_thread_local_state();

--- a/crates/harn-vm/src/llm/structured_envelope.rs
+++ b/crates/harn-vm/src/llm/structured_envelope.rs
@@ -31,7 +31,7 @@ use std::rc::Rc;
 
 use crate::value::{VmError, VmValue};
 
-use super::helpers::extract_llm_options;
+use super::helpers::{extract_llm_options, vm_value_to_json};
 use super::{execute_schema_retry_loop, rewrite_structured_args, SchemaLoopOutcome};
 
 /// Build the `{ok, data, raw_text, error, error_category, attempts,
@@ -52,9 +52,17 @@ pub(crate) async fn run_structured_envelope(
     // `extract_llm_options` runs — repair is a result-envelope
     // configuration knob, not a pass-through provider option.
     let repair_config = take_repair_config(&mut rewritten);
-    let options_dict = rewritten.get(2).and_then(|a| a.as_dict()).cloned();
+    let mut options_dict = rewritten.get(2).and_then(|a| a.as_dict()).cloned();
     let opts = match extract_llm_options(&rewritten) {
         Ok(opts) => opts,
+        Err(err) if is_unsupported_structured_transport_error(&err) => {
+            apply_prompt_mode_structured_transport(&mut rewritten);
+            options_dict = rewritten.get(2).and_then(|a| a.as_dict()).cloned();
+            match extract_llm_options(&rewritten) {
+                Ok(opts) => opts,
+                Err(fallback_err) => return Ok(envelope_from_arg_error(&fallback_err)),
+            }
+        }
         Err(err) => return Ok(envelope_from_arg_error(&err)),
     };
     let provider_hint = opts.provider.clone();
@@ -100,6 +108,44 @@ pub(crate) async fn run_structured_envelope(
         classify_main_failure(&main_outcome),
         false,
     ))
+}
+
+fn is_unsupported_structured_transport_error(err: &VmError) -> bool {
+    let message = err.to_string();
+    message.contains("option `output_format` is not supported")
+        || message.contains("unsupported structured_output strategy")
+}
+
+fn apply_prompt_mode_structured_transport(args: &mut [VmValue]) {
+    let schema = args.get(1).cloned().unwrap_or(VmValue::Nil);
+    if let Some(prompt) = args.get_mut(0).and_then(|value| match value {
+        VmValue::String(text) => Some(text.to_string()),
+        _ => None,
+    }) {
+        args[0] = VmValue::String(Rc::from(prompt_with_schema_contract(&prompt, &schema)));
+    }
+    if let Some(options) = args.get_mut(2) {
+        let mut dict = options.as_dict().cloned().unwrap_or_default();
+        dict.insert(
+            "output_format".to_string(),
+            VmValue::String(Rc::from("text")),
+        );
+        dict.insert(
+            "response_format".to_string(),
+            VmValue::String(Rc::from("text")),
+        );
+        *options = VmValue::Dict(Rc::new(dict));
+    }
+}
+
+fn prompt_with_schema_contract(prompt: &str, schema: &VmValue) -> String {
+    let schema_json = serde_json::to_string_pretty(&vm_value_to_json(schema))
+        .unwrap_or_else(|_| schema.display());
+    format!(
+        "{prompt}\n\n\
+Structured output transport is unavailable for this model. Return ONLY JSON that conforms to this JSON Schema. \
+Do not include prose, markdown fences, or commentary.\n\nJSON Schema:\n{schema_json}"
+    )
 }
 
 fn classify_main_failure(outcome: &SchemaLoopOutcome) -> EnvelopeFailureKind {
@@ -511,5 +557,56 @@ mod tests {
         disabled.insert("enabled".to_string(), VmValue::Bool(false));
         let dict_disabled = parse_repair_value(&VmValue::Dict(Rc::new(disabled))).unwrap();
         assert!(!dict_disabled.enabled);
+    }
+
+    #[test]
+    fn prompt_mode_structured_transport_keeps_harn_side_validation() {
+        let schema = VmValue::Dict(Rc::new(BTreeMap::from([
+            ("type".to_string(), VmValue::String(Rc::from("object"))),
+            (
+                "properties".to_string(),
+                VmValue::Dict(Rc::new(BTreeMap::from([(
+                    "pass".to_string(),
+                    VmValue::Dict(Rc::new(BTreeMap::from([(
+                        "type".to_string(),
+                        VmValue::String(Rc::from("boolean")),
+                    )]))),
+                )]))),
+            ),
+        ])));
+        let options = VmValue::Dict(Rc::new(BTreeMap::from([
+            ("provider".to_string(), VmValue::String(Rc::from("ollama"))),
+            (
+                "model".to_string(),
+                VmValue::String(Rc::from("gemma4-128k:latest")),
+            ),
+        ])));
+        let mut args = crate::llm::rewrite_structured_args(vec![
+            VmValue::String(Rc::from("Return a completion verdict.")),
+            schema,
+            options,
+        ])
+        .unwrap();
+
+        let err = match extract_llm_options(&args) {
+            Ok(_) => panic!("native structured transport should be unsupported"),
+            Err(err) => err,
+        };
+        assert!(is_unsupported_structured_transport_error(&err));
+
+        apply_prompt_mode_structured_transport(&mut args);
+        let opts = extract_llm_options(&args).expect("prompt-mode structured call should parse");
+        assert!(matches!(
+            opts.output_format,
+            crate::llm::api::OutputFormat::Text
+        ));
+        assert!(
+            opts.output_schema.is_some(),
+            "Harn must still validate the model's JSON after prompt-mode fallback"
+        );
+        assert!(opts.messages[0]["content"]
+            .as_str()
+            .unwrap()
+            .contains("Return ONLY JSON that conforms to this JSON Schema"));
     }
 }

--- a/crates/harn-vm/src/llm/tools/contract_prompt.rs
+++ b/crates/harn-vm/src/llm/tools/contract_prompt.rs
@@ -95,18 +95,57 @@ fn render_text_tool_schema(schema: &ToolSchema) -> String {
 
 fn render_compact_text_tool_schema(schema: &ToolSchema) -> String {
     let args_type = build_tool_args_type(&schema.params);
-    let summary = schema
-        .description
-        .split(&['.', '\n'][..])
-        .next()
-        .unwrap_or("")
-        .trim();
+    let summary = compact_schema_summary(&schema.description);
     format!(
         "- `{}({})` — {}\n",
         schema.name,
         args_type.render(),
         summary,
     )
+}
+
+fn compact_schema_summary(description: &str) -> String {
+    let normalized = description.split_whitespace().collect::<Vec<_>>().join(" ");
+    if normalized.is_empty() {
+        return String::new();
+    }
+
+    let mut summary = String::new();
+    let mut sentence_count = 0usize;
+    for sentence in normalized.split_inclusive(&['.', '!', '?'][..]) {
+        let sentence = sentence.trim();
+        if sentence.is_empty() {
+            continue;
+        }
+        if !summary.is_empty() {
+            summary.push(' ');
+        }
+        summary.push_str(sentence);
+        sentence_count += 1;
+        if sentence_count >= 3 || summary.chars().count() >= 360 {
+            break;
+        }
+    }
+    if summary.is_empty() {
+        summary = normalized;
+    }
+
+    let max_chars = 420usize;
+    if summary.chars().count() <= max_chars {
+        return summary;
+    }
+    let mut truncated = summary.chars().take(max_chars).collect::<String>();
+    if let Some((idx, _)) = truncated
+        .char_indices()
+        .rev()
+        .find(|(_, ch)| ch.is_whitespace())
+    {
+        truncated.truncate(idx);
+    }
+    truncated
+        .trim_end_matches(&['.', ',', ';', ':'][..])
+        .to_string()
+        + "..."
 }
 
 /// Build the single-arg TypeScript object type that a tool takes. Each

--- a/crates/harn-vm/src/llm/tools/tests/contract_prompt.rs
+++ b/crates/harn-vm/src/llm/tools/tests/contract_prompt.rs
@@ -219,6 +219,64 @@ fn contract_prompt_includes_tool_examples_before_schemas() {
 }
 
 #[test]
+fn compact_tool_schema_keeps_cross_field_constraints() {
+    let tool = super::vm_dict(&[
+        ("name", super::vm_str("look")),
+        (
+            "description",
+            super::vm_str(
+                "Unified path-centric read/inspect tool. The `full_text` intent requires both `file` and `query`; use `read` with `offset` and `limit` for raw file text.",
+            ),
+        ),
+        ("compact", super::vm_bool(true)),
+        (
+            "parameters",
+            super::vm_dict(&[
+                (
+                    "file",
+                    super::vm_dict(&[
+                        ("type", super::vm_str("string")),
+                        ("required", super::vm_bool(false)),
+                    ]),
+                ),
+                (
+                    "query",
+                    super::vm_dict(&[
+                        ("type", super::vm_str("string")),
+                        ("required", super::vm_bool(false)),
+                    ]),
+                ),
+                (
+                    "intent",
+                    super::vm_dict(&[
+                        ("type", super::vm_str("string")),
+                        ("required", super::vm_bool(false)),
+                    ]),
+                ),
+            ]),
+        ),
+    ]);
+    let tools = super::vm_dict(&[("tools", super::vm_list(vec![tool]))]);
+    let prompt = build_tool_calling_contract_prompt(
+        Some(&tools),
+        None,
+        "text",
+        false,
+        None,
+        false,
+        "##DONE##",
+    );
+    assert!(
+        prompt.contains("full_text` intent requires both `file` and `query`"),
+        "compact schema rendering must not drop cross-field constraints: {prompt}"
+    );
+    assert!(
+        prompt.contains("use `read` with `offset` and `limit`"),
+        "compact schema rendering should keep the immediate recovery path: {prompt}"
+    );
+}
+
+#[test]
 fn contract_prompt_omits_examples_section_when_none() {
     let tools = sample_tool_registry();
     let prompt = build_tool_calling_contract_prompt(


### PR DESCRIPTION
## Summary
- fall back structured result envelopes to prompt-mode JSON when a provider cannot carry native structured output, while keeping Harn-side schema validation and retry behavior
- preserve more compact text-tool description context so cross-field constraints survive in small-model prompts
- allow completion judges to return longer final answers without schema-vetoing successful turns

## Why
Local/cheap models exposed two convergence issues in agent-mode transcripts: compact tool descriptions could drop the recovery-critical parts of a tool contract, and provider-native structured output assumptions could fail before Harn had a chance to validate or repair the response. This keeps those concerns in the Harn abstractions instead of baking provider-specific workaround logic into repo scripts.

## Validation
- cargo fmt --check
- git diff --check
- cargo clippy --workspace --all-targets -- -D warnings
- CARGO_TARGET_DIR=/tmp/harn-agent-convergence-target cargo test -p harn-vm prompt_mode_structured_transport_keeps_harn_side_validation -- --nocapture
- CARGO_TARGET_DIR=/tmp/harn-agent-convergence-target cargo test -p harn-vm completion_judge_accepts_long_final_response -- --nocapture
- CARGO_TARGET_DIR=/tmp/harn-agent-convergence-target cargo test -p harn-vm compact_tool_schema_keeps_cross_field_constraints -- --nocapture
