### PR TITLE
[codex] Add agent turn observability hooks

### DIFF
--- a/crates/harn-vm/src/llm/agent/mod.rs
+++ b/crates/harn-vm/src/llm/agent/mod.rs
@@ -664,7 +664,9 @@ impl AgentLoopRunState {
                 // done" gets one more turn instead of yielding to the
                 // caller. Bounded by max_verify_attempts to prevent a
                 // buggy judge from holding the loop open.
-                let done_judge_applies = stop_reason == "sentinel" && done_judge.is_some();
+                let done_judge_applies = done_judge.is_some()
+                    && (stop_reason == "sentinel"
+                        || (stop_reason == "natural" && done_sentinel.is_empty()));
                 if verify_completion.is_some()
                     || verify_completion_judge.is_some()
                     || done_judge_applies
@@ -710,7 +712,7 @@ impl AgentLoopRunState {
                             .await?;
                         }
                     }
-                    if !veto && stop_reason == "sentinel" {
+                    if !veto && done_judge_applies {
                         if let Some(judge) = done_judge.as_ref() {
                             veto = completion_judge::run_completion_judge(
                                 &mut self.state,

--- a/crates/harn-vm/src/llm/agent/tests/transcript.rs
+++ b/crates/harn-vm/src/llm/agent/tests/transcript.rs
@@ -320,6 +320,46 @@ async fn agent_loop_option_writes_llm_transcript_jsonl() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn agent_loop_verbose_transcript_includes_request_snapshot_when_enabled() {
+    reset_llm_mock_state();
+    let dir = std::env::temp_dir().join(format!(
+        "harn-agent-loop-verbose-transcript-{}",
+        uuid::Uuid::now_v7()
+    ));
+    let mut opts = base_opts(vec![serde_json::json!({
+        "role": "user",
+        "content": "write a verbose transcript sidecar",
+    })]);
+    opts.system = Some("diagnostic system prompt".to_string());
+    let mut config = base_agent_config();
+    config.llm_transcript_dir = Some(dir.to_string_lossy().into_owned());
+
+    unsafe { std::env::set_var("HARN_LLM_TRANSCRIPT_VERBOSE", "1") };
+    let result = run_agent_loop_internal(&mut opts, config).await.unwrap();
+    unsafe { std::env::remove_var("HARN_LLM_TRANSCRIPT_VERBOSE") };
+    assert_eq!(result["status"], "done");
+
+    let transcript_path = dir.join("llm_transcript.jsonl");
+    let transcript = std::fs::read_to_string(&transcript_path)
+        .unwrap_or_else(|e| panic!("read {}: {e}", transcript_path.display()));
+    assert!(
+        transcript.contains("\"request_snapshot\""),
+        "verbose request snapshot missing from transcript:\n{transcript}"
+    );
+    assert!(
+        transcript.contains("diagnostic system prompt"),
+        "verbose request snapshot should include exact system prompt:\n{transcript}"
+    );
+    assert!(
+        transcript.contains("write a verbose transcript sidecar"),
+        "verbose request snapshot should include exact message list:\n{transcript}"
+    );
+
+    let _ = std::fs::remove_dir_all(dir);
+    reset_llm_mock_state();
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn daemon_timer_wake_persists_snapshot_and_compacts_on_idle() {
     let dir = std::env::temp_dir().join(format!("harn-agent-daemon-{}", uuid::Uuid::now_v7()));
     std::fs::create_dir_all(&dir).unwrap();
@@ -923,6 +963,86 @@ async fn done_judge_does_not_run_on_plain_natural_stop() {
         Some("A plain one-shot answer.")
     );
     assert_eq!(get_llm_mock_calls().len(), 1);
+    reset_llm_mock_state();
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn done_judge_can_verify_natural_stop_when_done_sentinel_is_disabled() {
+    use crate::agent_events::{AgentEvent, AgentEventSink};
+
+    #[derive(Clone)]
+    struct CapturingSink(Arc<Mutex<Vec<AgentEvent>>>);
+    impl AgentEventSink for CapturingSink {
+        fn handle_event(&self, event: &AgentEvent) {
+            self.0.lock().unwrap().push(event.clone());
+        }
+    }
+
+    reset_llm_mock_state();
+    for text in [
+        "Done.",
+        "{\"verdict\":\"continue\",\"reasoning\":\"answer is too thin\",\"next_step\":\"Give the actual answer before yielding.\"}",
+        "The answer is 4.",
+        "{\"verdict\":\"done\",\"reasoning\":\"the answer is now explicit\"}",
+    ] {
+        crate::llm::mock::push_llm_mock(crate::llm::mock::LlmMock {
+            text: text.to_string(),
+            tool_calls: Vec::new(),
+            match_pattern: None,
+            consume_on_match: true,
+            input_tokens: None,
+            output_tokens: None,
+            cache_read_tokens: None,
+            cache_write_tokens: None,
+            thinking: None,
+            thinking_summary: None,
+            stop_reason: None,
+            model: "mock".to_string(),
+            provider: None,
+            blocks: None,
+            error: None,
+        });
+    }
+
+    let captured = Arc::new(Mutex::new(Vec::new()));
+    let mut opts = base_opts(vec![serde_json::json!({
+        "role": "user",
+        "content": "What is 2 + 2?",
+    })]);
+    let mut config = base_agent_config();
+    config.persistent = false;
+    config.max_iterations = 3;
+    config.max_verify_attempts = 3;
+    config.done_sentinel = Some(String::new());
+    config.done_judge = Some(crate::llm::agent::completion_judge::CompletionJudgeConfig::default());
+    config.event_sink = Some(Arc::new(CapturingSink(captured.clone())));
+
+    let result = run_agent_loop_internal(&mut opts, config).await.unwrap();
+    assert_eq!(result["status"], "done");
+    assert_eq!(result["llm"]["iterations"].as_u64(), Some(2));
+    assert_eq!(result["visible_text"].as_str(), Some("The answer is 4."));
+
+    let decisions: Vec<(String, Option<String>)> = captured
+        .lock()
+        .unwrap()
+        .iter()
+        .filter_map(|event| match event {
+            AgentEvent::JudgeDecision {
+                verdict, next_step, ..
+            } => Some((verdict.clone(), next_step.clone())),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        decisions,
+        vec![
+            (
+                "continue".to_string(),
+                Some("Give the actual answer before yielding.".to_string())
+            ),
+            ("done".to_string(), None),
+        ]
+    );
     reset_llm_mock_state();
 }
 

--- a/crates/harn-vm/src/llm/agent_observe.rs
+++ b/crates/harn-vm/src/llm/agent_observe.rs
@@ -22,6 +22,9 @@
 //!   tool_format, max_tokens, temperature, tool_choice}` — slim metadata
 //!   for a single model call. No `messages`, `system`, or `tool_schemas`
 //!   fields; those are reconstructable from prior events.
+//!   Set `HARN_LLM_TRANSCRIPT_VERBOSE=1` to include a `request_snapshot`
+//!   object with the exact system prompt, message list, and tool schemas
+//!   attached to each request for debugging provider-context issues.
 //! - `provider_call_response` `{call_id, iteration, model, text,
 //!   tool_calls, input_tokens, output_tokens, cache_*, thinking,
 //!   response_ms}` — slim response metadata.
@@ -105,6 +108,16 @@ fn hash_json(value: &serde_json::Value) -> u64 {
     // Dedup only needs intra-process stability; built-in key ordering is fine.
     let encoded = serde_json::to_string(value).unwrap_or_default();
     hash_str(&encoded)
+}
+
+fn verbose_llm_transcript_enabled() -> bool {
+    std::env::var("HARN_LLM_TRANSCRIPT_VERBOSE")
+        .ok()
+        .map(|value| {
+            let normalized = value.trim().to_ascii_lowercase();
+            matches!(normalized.as_str(), "1" | "true" | "yes" | "on" | "full")
+        })
+        .unwrap_or(false)
 }
 
 /// Clear the dedup state. Call at the start of a new stage so the first
@@ -467,7 +480,7 @@ pub(super) fn dump_llm_request(
             "alternatives": decision.alternatives.clone(),
         }));
     }
-    append_llm_transcript_entry(&serde_json::json!({
+    let mut request_event = serde_json::json!({
         "type": "provider_call_request",
         "iteration": iteration,
         "call_id": call_id,
@@ -508,7 +521,16 @@ pub(super) fn dump_llm_request(
         "route_policy": opts.route_policy.as_label(),
         "fallback_chain": opts.fallback_chain.clone(),
         "routing_decision": opts.routing_decision.clone(),
-    }));
+    });
+    if verbose_llm_transcript_enabled() {
+        request_event["request_snapshot"] = serde_json::json!({
+            "system": opts.system,
+            "messages": opts.messages,
+            "tool_schemas": tool_schemas,
+            "native_tools": opts.native_tools,
+        });
+    }
+    append_llm_transcript_entry(&request_event);
 }
 
 pub(super) fn dump_llm_response(


### PR DESCRIPTION
## Summary

- adds opt-in verbose LLM transcript request snapshots for provider-context debugging
- lets `done_judge` validate natural assistant stops when the done sentinel is explicitly disabled
- covers both paths with focused harn-vm tests

## Validation

- `cargo fmt --check`
- `CARGO_TARGET_DIR=/tmp/harn-agent-observe-target cargo test -p harn-vm done_judge -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-agent-observe-target cargo test -p harn-vm agent_loop_verbose_transcript_includes_request_snapshot_when_enabled -- --nocapture`
- pre-commit clippy hook
- pre-push targeted local checks
