### PR TITLE
[tests] Share fixture repo across harn-hostlib git tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -89,18 +89,6 @@ harn-cli-bin = { max-threads = 8 }
 # delayed by neighboring DAP tests. Keep leak failures enabled and remove
 # the concurrency pressure instead.
 harn-dap = { max-threads = 1 }
-# `harn-hostlib`'s `tools_git` integration tests and the
-# `end_to_end_git_via_harn_script` smoke test each call `fixture_repo()`,
-# which spawns ~10 sequential `git` subprocesses (init, three configs, two
-# adds, two commits, one remote add). On Windows, where process creation is
-# expensive and AV scanning of fresh tempdirs adds extra latency, running
-# these tests at full workspace fan-out causes them to starve each other:
-# under load on Windows runners we've seen tests that normally complete in
-# <100ms wall-clock balloon to 48–60+ s and trip nextest's slow-test cap.
-# Throttling concurrency for this small cohort keeps the rest of the suite
-# at full parallelism while preventing the git subprocess fan-out from
-# saturating the runner.
-harn-hostlib-git = { max-threads = 2 }
 
 # Transport-layer LLM tests do real localhost TCP with a 3s accept deadline.
 # They're bounded internally but give them a bit more room than the default
@@ -138,14 +126,6 @@ leak-timeout = { period = "10s", result = "pass" }
 filter = "package(harn-dap)"
 test-group = "harn-dap"
 
-# Throttle the git-subprocess-heavy harn-hostlib tests and give them more
-# headroom before nextest fires the slow-test terminator. See the
-# `harn-hostlib-git` test-group comment above for rationale.
-[[profile.default.overrides]]
-filter = 'package(harn-hostlib) and (binary(tools_git) or test(end_to_end_git_via_harn_script))'
-test-group = "harn-hostlib-git"
-slow-timeout = { period = "30s", terminate-after = 4, grace-period = "10s" }
-
 [[profile.ci.overrides]]
 filter = "package(harn-cli) and kind(test)"
 test-group = "harn-subprocess"
@@ -159,11 +139,6 @@ leak-timeout = { period = "10s", result = "pass" }
 [[profile.ci.overrides]]
 filter = "package(harn-dap)"
 test-group = "harn-dap"
-
-[[profile.ci.overrides]]
-filter = 'package(harn-hostlib) and (binary(tools_git) or test(end_to_end_git_via_harn_script))'
-test-group = "harn-hostlib-git"
-slow-timeout = { period = "60s", terminate-after = 3, grace-period = "15s" }
 
 # Flake-detection profile: zero retries, no fail-fast, tighter slow-test
 # threshold.  Used by the flake-detection CI workflow which runs touched
@@ -197,11 +172,6 @@ leak-timeout = { period = "10s", result = "pass" }
 [[profile.flake-detection.overrides]]
 filter = "package(harn-dap)"
 test-group = "harn-dap"
-
-[[profile.flake-detection.overrides]]
-filter = 'package(harn-hostlib) and (binary(tools_git) or test(end_to_end_git_via_harn_script))'
-test-group = "harn-hostlib-git"
-slow-timeout = { period = "30s", terminate-after = 4, grace-period = "10s" }
 
 # E2E profile overrides: throttle subprocess concurrency the same way the
 # default/ci profiles do so nightly runs stay deterministic.

--- a/crates/harn-hostlib/tests/tools_git.rs
+++ b/crates/harn-hostlib/tests/tools_git.rs
@@ -2,11 +2,20 @@
 //!
 //! These tests require `git` on `$PATH`. CI installs it; local dev usually
 //! has it. If it's missing the tests are skipped via [`ensure_git`].
+//!
+//! Read-only tests share a single fixture repository via [`shared_fixture`]
+//! so the binary spawns ~10 `git` subprocesses at first use instead of ~10
+//! per test (~100+ total). On Windows runners — where process creation is
+//! expensive and AV scanning of fresh tempdirs adds latency — the shared
+//! fixture is what keeps the integration suite fast under load. The single
+//! mutating test (`git_status_reports_dirty_paths`) keeps building its own
+//! repo so it does not pollute the shared one.
 
 use std::collections::BTreeMap;
 use std::path::Path;
 use std::process::Command;
 use std::rc::Rc;
+use std::sync::OnceLock;
 
 use harn_hostlib::tools::permissions;
 use harn_hostlib::{tools::ToolsCapability, BuiltinRegistry, HostlibCapability, HostlibError};
@@ -37,26 +46,47 @@ fn ensure_git() -> bool {
     Command::new("git").arg("--version").output().is_ok()
 }
 
+/// Build a `repo` argument from a filesystem path. Centralized so every
+/// test gets the same `Path::to_string_lossy` handling on Windows (where
+/// the path renders with backslashes that `git -C` accepts unchanged).
+fn repo_arg(repo: &Path) -> (&'static str, VmValue) {
+    ("repo", vm_string(&repo.to_string_lossy()))
+}
+
+/// Invoke `hostlib_tools_git` with `args`. Wraps the boilerplate every
+/// test would otherwise repeat (build a registry, look up the entry, wrap
+/// args in a Vm dict).
+fn invoke(args: &[(&str, VmValue)]) -> Result<VmValue, HostlibError> {
+    let reg = registry();
+    let entry = reg.find("hostlib_tools_git").unwrap();
+    (entry.handler)(&dict_arg(args))
+}
+
 /// Initialize a tiny git repo with two commits, configured locally so the
 /// test never reads global git config.
 fn fixture_repo() -> TempDir {
     let dir = TempDir::new().unwrap();
-    run_git(dir.path(), &["init", "-q", "-b", "main"]);
-    run_git(dir.path(), &["config", "user.email", "tester@example.com"]);
-    run_git(dir.path(), &["config", "user.name", "Tester"]);
-    run_git(dir.path(), &["config", "commit.gpgsign", "false"]);
+    populate_fixture_repo(dir.path());
+    dir
+}
 
-    std::fs::write(dir.path().join("a.txt"), "first\n").unwrap();
-    run_git(dir.path(), &["add", "a.txt"]);
-    run_git(dir.path(), &["commit", "-q", "-m", "first commit"]);
+fn populate_fixture_repo(repo: &Path) {
+    run_git(repo, &["init", "-q", "-b", "main"]);
+    run_git(repo, &["config", "user.email", "tester@example.com"]);
+    run_git(repo, &["config", "user.name", "Tester"]);
+    run_git(repo, &["config", "commit.gpgsign", "false"]);
 
-    std::fs::write(dir.path().join("a.txt"), "first\nsecond\n").unwrap();
-    std::fs::write(dir.path().join("b.txt"), "new file\n").unwrap();
-    run_git(dir.path(), &["add", "a.txt", "b.txt"]);
-    run_git(dir.path(), &["commit", "-q", "-m", "second commit"]);
+    std::fs::write(repo.join("a.txt"), "first\n").unwrap();
+    run_git(repo, &["add", "a.txt"]);
+    run_git(repo, &["commit", "-q", "-m", "first commit"]);
+
+    std::fs::write(repo.join("a.txt"), "first\nsecond\n").unwrap();
+    std::fs::write(repo.join("b.txt"), "new file\n").unwrap();
+    run_git(repo, &["add", "a.txt", "b.txt"]);
+    run_git(repo, &["commit", "-q", "-m", "second commit"]);
 
     run_git(
-        dir.path(),
+        repo,
         &[
             "remote",
             "add",
@@ -64,8 +94,26 @@ fn fixture_repo() -> TempDir {
             "https://example.invalid/repo.git",
         ],
     );
+}
 
-    dir
+/// Shared, lazily-initialized fixture repo for tests that only read git
+/// state. The `TempDir` lives in a static `OnceLock` and is built once per
+/// test binary on first use — subsequent callers reuse it.
+///
+/// Mutating tests (currently `git_status_reports_dirty_paths`) must keep
+/// using [`fixture_repo`] so they do not leak dirty-tree state into other
+/// tests. `OnceLock<TempDir>` is never dropped on normal process exit,
+/// which means the directory persists until the OS cleans `$TMPDIR` —
+/// matching how unshared `TempDir`s are cleaned up if a test panics.
+fn shared_fixture() -> &'static Path {
+    static FIXTURE: OnceLock<TempDir> = OnceLock::new();
+    FIXTURE
+        .get_or_init(|| {
+            let dir = TempDir::new().unwrap();
+            populate_fixture_repo(dir.path());
+            dir
+        })
+        .path()
 }
 
 fn run_git(repo: &Path, args: &[&str]) {
@@ -120,14 +168,7 @@ fn git_log_returns_structured_entries() {
         eprintln!("skipping: git not installed");
         return;
     }
-    let repo = fixture_repo();
-    let reg = registry();
-    let entry = reg.find("hostlib_tools_git").unwrap();
-    let result = (entry.handler)(&dict_arg(&[
-        ("operation", vm_string("log")),
-        ("repo", vm_string(&repo.path().to_string_lossy())),
-    ]))
-    .unwrap();
+    let result = invoke(&[("operation", vm_string("log")), repo_arg(shared_fixture())]).unwrap();
     let data = dict_get(&result, "data");
     let commits = list_of(data);
     assert_eq!(commits.len(), 2);
@@ -146,14 +187,11 @@ fn git_log_max_count_limits_results() {
     if !ensure_git() {
         return;
     }
-    let repo = fixture_repo();
-    let reg = registry();
-    let entry = reg.find("hostlib_tools_git").unwrap();
-    let result = (entry.handler)(&dict_arg(&[
+    let result = invoke(&[
         ("operation", vm_string("log")),
-        ("repo", vm_string(&repo.path().to_string_lossy())),
+        repo_arg(shared_fixture()),
         ("max_count", VmValue::Int(1)),
-    ]))
+    ])
     .unwrap();
     let data = dict_get(&result, "data");
     assert_eq!(list_of(data).len(), 1);
@@ -164,16 +202,14 @@ fn git_status_reports_dirty_paths() {
     if !ensure_git() {
         return;
     }
+    // The only mutating test in this binary: it writes an untracked file
+    // before calling status. Use a fresh, isolated repo so the dirty
+    // state never leaks into the [`shared_fixture`] used by the read-only
+    // tests above and below.
     let repo = fixture_repo();
     std::fs::write(repo.path().join("c.txt"), "untracked\n").unwrap();
 
-    let reg = registry();
-    let entry = reg.find("hostlib_tools_git").unwrap();
-    let result = (entry.handler)(&dict_arg(&[
-        ("operation", vm_string("status")),
-        ("repo", vm_string(&repo.path().to_string_lossy())),
-    ]))
-    .unwrap();
+    let result = invoke(&[("operation", vm_string("status")), repo_arg(repo.path())]).unwrap();
     let data = dict_get(&result, "data");
     let entries = list_of(data);
     assert!(entries.iter().any(|e| match dict_get(e, "path") {
@@ -187,13 +223,10 @@ fn git_current_branch_returns_main() {
     if !ensure_git() {
         return;
     }
-    let repo = fixture_repo();
-    let reg = registry();
-    let entry = reg.find("hostlib_tools_git").unwrap();
-    let result = (entry.handler)(&dict_arg(&[
+    let result = invoke(&[
         ("operation", vm_string("current_branch")),
-        ("repo", vm_string(&repo.path().to_string_lossy())),
-    ]))
+        repo_arg(shared_fixture()),
+    ])
     .unwrap();
     let data = dict_get(&result, "data");
     if let VmValue::String(s) = data {
@@ -208,13 +241,10 @@ fn git_remote_list_returns_origin() {
     if !ensure_git() {
         return;
     }
-    let repo = fixture_repo();
-    let reg = registry();
-    let entry = reg.find("hostlib_tools_git").unwrap();
-    let result = (entry.handler)(&dict_arg(&[
+    let result = invoke(&[
         ("operation", vm_string("remote_list")),
-        ("repo", vm_string(&repo.path().to_string_lossy())),
-    ]))
+        repo_arg(shared_fixture()),
+    ])
     .unwrap();
     let data = dict_get(&result, "data");
     let remotes = list_of(data);
@@ -233,14 +263,11 @@ fn git_blame_returns_authors_per_line() {
     if !ensure_git() {
         return;
     }
-    let repo = fixture_repo();
-    let reg = registry();
-    let entry = reg.find("hostlib_tools_git").unwrap();
-    let result = (entry.handler)(&dict_arg(&[
+    let result = invoke(&[
         ("operation", vm_string("blame")),
-        ("repo", vm_string(&repo.path().to_string_lossy())),
+        repo_arg(shared_fixture()),
         ("path", vm_string("a.txt")),
-    ]))
+    ])
     .unwrap();
     let data = dict_get(&result, "data");
     let lines = list_of(data);
@@ -259,14 +286,11 @@ fn git_show_emits_patch_text() {
     if !ensure_git() {
         return;
     }
-    let repo = fixture_repo();
-    let reg = registry();
-    let entry = reg.find("hostlib_tools_git").unwrap();
-    let result = (entry.handler)(&dict_arg(&[
+    let result = invoke(&[
         ("operation", vm_string("show")),
-        ("repo", vm_string(&repo.path().to_string_lossy())),
+        repo_arg(shared_fixture()),
         ("rev", vm_string("HEAD")),
-    ]))
+    ])
     .unwrap();
     let data = dict_get(&result, "data");
     if let VmValue::String(s) = data {
@@ -282,14 +306,7 @@ fn git_diff_handles_clean_repo() {
     if !ensure_git() {
         return;
     }
-    let repo = fixture_repo();
-    let reg = registry();
-    let entry = reg.find("hostlib_tools_git").unwrap();
-    let result = (entry.handler)(&dict_arg(&[
-        ("operation", vm_string("diff")),
-        ("repo", vm_string(&repo.path().to_string_lossy())),
-    ]))
-    .unwrap();
+    let result = invoke(&[("operation", vm_string("diff")), repo_arg(shared_fixture())]).unwrap();
     let data = dict_get(&result, "data");
     if let VmValue::String(s) = data {
         assert!(s.is_empty(), "expected empty diff, got `{s}`");
@@ -301,13 +318,10 @@ fn git_branch_list_returns_main() {
     if !ensure_git() {
         return;
     }
-    let repo = fixture_repo();
-    let reg = registry();
-    let entry = reg.find("hostlib_tools_git").unwrap();
-    let result = (entry.handler)(&dict_arg(&[
+    let result = invoke(&[
         ("operation", vm_string("branch_list")),
-        ("repo", vm_string(&repo.path().to_string_lossy())),
-    ]))
+        repo_arg(shared_fixture()),
+    ])
     .unwrap();
     let data = dict_get(&result, "data");
     let branches = list_of(data);
@@ -322,14 +336,11 @@ fn git_rejects_flag_lookalike_revs() {
     if !ensure_git() {
         return;
     }
-    let repo = fixture_repo();
-    let reg = registry();
-    let entry = reg.find("hostlib_tools_git").unwrap();
-    let err = (entry.handler)(&dict_arg(&[
+    let err = invoke(&[
         ("operation", vm_string("show")),
-        ("repo", vm_string(&repo.path().to_string_lossy())),
+        repo_arg(shared_fixture()),
         ("rev", vm_string("--exec=rm")),
-    ]))
+    ])
     .unwrap_err();
     assert!(matches!(
         err,


### PR DESCRIPTION
## Summary

Structural follow-up to #1233 (which patched a Windows CI git-fixture timeout with a tactical nextest throttle). Replaces per-test `fixture_repo()` calls in `harn-hostlib/tests/tools_git.rs` with a `OnceLock<TempDir>`-backed `shared_fixture()` for the nine read-only tests. The single mutating test (`git_status_reports_dirty_paths`) keeps building its own repo so it can't pollute the shared one.

- **Before**: each of ~10 tests spawned ~10 sequential `git` subprocesses (~100 spawns per binary). On Windows runners under load, four tests ran concurrently and tripped the 60s slow-test cap.
- **After**: ~10 git spawns total on first use, reused by all read-only tests. Locally under `cargo nextest run` all 13 tests in the binary finish in 0.32s.

The tactical throttle (test-group + slow-timeout overrides for `harn-hostlib-git` across default/ci/flake-detection profiles) is now redundant, so this PR also reverts that piece of `.config/nextest.toml` from #1233.

### Robustness

- `OnceLock::get_or_init` is thread-safe and panic-retryable, so concurrent first-touches and a panicking init both behave correctly.
- `populate_fixture_repo` is shared between `fixture_repo()` (per-test) and `shared_fixture()` (binary-static), so both paths build identical state.
- `Path::to_string_lossy` via the new `repo_arg` helper handles Windows backslash paths uniformly.
- `git` config commands and arguments are platform-agnostic; no Windows-specific quirks are introduced.
- Static `OnceLock<TempDir>` is never dropped on process exit, so the tempdir persists until the OS cleans `$TMPDIR` — same outcome as a per-test `TempDir` that leaks on panic.

### Drive-by DRY

- `populate_fixture_repo` — single source of truth for fixture state.
- `repo_arg(repo: &Path)` — centralizes the `("repo", vm_string(&repo.to_string_lossy()))` boilerplate that was repeated 10×.
- `invoke(args)` — removes the `let reg = registry(); let entry = reg.find(...).unwrap(); (entry.handler)(&dict_arg(...))` boilerplate that was repeated 12×.

### Audit findings (skipped here)

I scanned the workspace for similar fixture-rebuild / wall-clock-polling patterns. The closest match (`harn-hostlib/tests/scanner_e2e.rs`) rebuilds a tempdir fixture per test but uses `fs::write` only — Windows file I/O at that scale isn't the bottleneck git subprocess fan-out is. Other long-running tests (`orchestrator_cli.rs` polling loops, `harn-cli` subprocess tests) live behind the explicit slow E2E suite or are already throttled. No other tests warranted the same treatment in this PR.

## Test plan

- [x] `cargo test -p harn-hostlib --test tools_git` — 13 passed, 0.14s
- [x] `cargo test -p harn-hostlib --test smoke_harn_script` — 4 passed, 0.10s
- [x] `cargo nextest run -p harn-hostlib --test tools_git` — 13 passed, 0.32s wall (verifies parallel race on `OnceLock` init)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (via pre-commit) — clean
- [ ] CI on Windows confirms the structural fix holds without the test-group throttle

🤖 Generated with [Claude Code](https://claude.com/claude-code)