### PR TITLE
[harn-cli] Drive orchestrator_cli waits off lifecycle events

### DIFF
--- a/crates/harn-cli/tests/orchestrator_cli.rs
+++ b/crates/harn-cli/tests/orchestrator_cli.rs
@@ -193,20 +193,26 @@ async fn wait_for_consumer_cursor(
     at_least: u64,
 ) {
     let topic = Topic::new(topic_name).unwrap();
-    let consumer = ConsumerId::new(consumer).unwrap();
-    let deadline = tokio::time::Instant::now() + EVENT_FAIL_FAST_TIMEOUT;
-    while tokio::time::Instant::now() < deadline {
-        let cursor = event_log
-            .consumer_cursor(&topic, &consumer)
-            .await
-            .unwrap()
-            .unwrap_or(0);
-        if cursor >= at_least {
-            return;
-        }
-        tokio::time::sleep(Duration::from_millis(25)).await;
+    let consumer_id = ConsumerId::new(consumer).unwrap();
+    let cursor = event_log
+        .consumer_cursor(&topic, &consumer_id)
+        .await
+        .unwrap()
+        .unwrap_or(0);
+    if cursor >= at_least {
+        return;
     }
-    panic!("timed out waiting for consumer cursor {consumer} on {topic_name} to reach {at_least}");
+    let topic_owned = topic_name.to_string();
+    await_topic_event(event_log, "orchestrator.lifecycle", move |event| {
+        event.kind == "pump_acked"
+            && event.payload.get("topic").and_then(|v| v.as_str()) == Some(topic_owned.as_str())
+            && event
+                .payload
+                .get("cursor")
+                .and_then(|v| v.as_u64())
+                .is_some_and(|c| c >= at_least)
+    })
+    .await;
 }
 
 fn open_state_event_log(state_dir: &Path) -> Arc<AnyEventLog> {
@@ -243,23 +249,24 @@ async fn wait_for_metrics_contains(
     base_url: &str,
     needles: &[&str],
 ) -> String {
-    let deadline = tokio::time::Instant::now() + EVENT_FAIL_FAST_TIMEOUT;
-    let mut last = String::new();
-    while tokio::time::Instant::now() < deadline {
-        last = client
-            .get(format!("{base_url}/metrics"))
-            .send()
-            .await
-            .unwrap()
-            .text()
-            .await
-            .unwrap();
-        if needles.iter().all(|needle| last.contains(needle)) {
-            return last;
+    let url = format!("{base_url}/metrics");
+    let last = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+    let last_capture = last.clone();
+    let result = tokio::time::timeout(EVENT_FAIL_FAST_TIMEOUT, async move {
+        loop {
+            let body = client.get(&url).send().await.unwrap().text().await.unwrap();
+            if needles.iter().all(|needle| body.contains(needle)) {
+                return body;
+            }
+            *last_capture.lock().unwrap() = body;
+            tokio::time::sleep(Duration::from_millis(25)).await;
         }
-        tokio::time::sleep(Duration::from_millis(25)).await;
-    }
-    panic!("timed out waiting for metrics samples {needles:?}; last={last}");
+    })
+    .await;
+    result.unwrap_or_else(|_| {
+        let snapshot = last.lock().unwrap().clone();
+        panic!("timed out waiting for metrics samples {needles:?}; last={snapshot}")
+    })
 }
 
 fn run_harn_with_env(temp: &TempDir, args: &[&str], envs: &[(&str, &str)]) -> Output {
@@ -1115,13 +1122,11 @@ pub fn on_task(event: TriggerEvent) -> dict {
 }
 
 async fn wait_for_path_async(path: &Path) {
-    let deadline = tokio::time::Instant::now() + EVENT_FAIL_FAST_TIMEOUT;
-    while !path.exists() {
-        assert!(
-            tokio::time::Instant::now() < deadline,
-            "timed out waiting for path {}",
-            path.display()
-        );
-        tokio::time::sleep(Duration::from_millis(25)).await;
-    }
+    tokio::time::timeout(EVENT_FAIL_FAST_TIMEOUT, async {
+        while !path.exists() {
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("timed out waiting for path {}", path.display()));
 }

--- a/scripts/lint_test_patterns.sh
+++ b/scripts/lint_test_patterns.sh
@@ -49,7 +49,6 @@ TOKIO_SLEEP_ALLOWLIST=(
 # real process output; they will be refactored by Tier 1A/1B of #1057.
 INSTANT_NOW_WHILE_ALLOWLIST=(
   "crates/harn-vm/src/triggers/dispatcher/tests/retry.rs"
-  "crates/harn-cli/tests/orchestrator_cli.rs"
   "crates/harn-cli/tests/orchestrator_inbox_dedupe.rs"
   "crates/harn-cli/tests/orchestrator_http/support.rs"
   "crates/harn-cli/tests/orchestrator_http/admin.rs"


### PR DESCRIPTION
## Summary

Continues the test-flakiness cleanup from #1233 (tactical nextest throttle) and #1242 (shared-fixture refactor in `tools_git.rs`). Targets the wall-clock polling helpers in `crates/harn-cli/tests/orchestrator_cli.rs` flagged as pre-existing tech debt in `scripts/lint_test_patterns.sh`.

- **`wait_for_consumer_cursor`** is now event-driven. The orchestrator's inbox/topic pumps emit a `pump_acked` `orchestrator.lifecycle` event with a `cursor` payload field synchronously after `EventLog::ack` (see `crates/harn-cli/src/commands/orchestrator/harness.rs:1180–1189`). The helper subscribes from start-of-log, race-checks the existing cursor first, then matches the predicate against the lifecycle stream — no more wall-clock polling.
- **`wait_for_metrics_contains`** still polls `/metrics` (the `harn_orchestrator_pump_backlog` gauge has no event signal — it's repainted on the pump's 25 ms backpressure tick). Replaces the `Instant::now()` deadline loop with a `tokio::time::timeout` ceiling, matching the approved pattern in `docs/dev/testing.md`.
- **`wait_for_path_async`** has the same shape — file-marker polling has no event equivalent, so we keep the `tokio::time::sleep` tick but wrap it in `tokio::time::timeout`.
- Drops `crates/harn-cli/tests/orchestrator_cli.rs` from `INSTANT_NOW_WHILE_ALLOWLIST` in `scripts/lint_test_patterns.sh`. The `TOKIO_SLEEP_ALLOWLIST` entry stays — the metrics/marker waits are real wall-clock polls with no event-driven alternative without intrusive production hooks.

## Why it's robust cross-platform

- The `pump_acked` lifecycle event is emitted by the orchestrator regardless of platform.
- Both remaining sleep+timeout helpers use `tokio::time::*` (monotonic-clock-based, no wall-clock skew).
- No path-only `/`-separator assumptions; helpers operate on `Path` and event payloads.

## Test plan

- [x] `cargo test -p harn-cli --test orchestrator_cli` — 6/6 passed (3 ignored, expected — pending #1069 E2E lane).
- [x] `cargo nextest run -p harn-cli --test orchestrator_cli --profile e2e` — 6/6 passed in 2.88 s, parallel-safe.
- [x] `bash scripts/lint_test_patterns.sh` — passes after dropping the allowlist entry.
- [x] Pre-commit: rustfmt + clippy --workspace --all-targets -D warnings, all green.
- [x] Pre-push: workspace tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)