### PR TITLE
[harn-cli] Drop 25ms polling from MCP subprocess test helpers

### DIFF
--- a/crates/harn-cli/tests/harn_serve_mcp_cli.rs
+++ b/crates/harn-cli/tests/harn_serve_mcp_cli.rs
@@ -139,14 +139,18 @@ where
 {
     let deadline = Instant::now() + timeout;
     let mut observed: Vec<JsonValue> = Vec::new();
-    while Instant::now() < deadline {
-        match rx.recv_timeout(Duration::from_millis(25)) {
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        match rx.recv_timeout(remaining) {
             Ok(message) if predicate(&message) => return message,
             Ok(message) => {
                 observed.push(message);
                 continue;
             }
-            Err(mpsc::RecvTimeoutError::Timeout) => continue,
+            Err(mpsc::RecvTimeoutError::Timeout) => break,
             Err(error) => panic!("stdout reader disconnected: {error}"),
         }
     }

--- a/crates/harn-cli/tests/support/mcp.rs
+++ b/crates/harn-cli/tests/support/mcp.rs
@@ -10,8 +10,6 @@ use std::time::{Duration, Instant};
 
 pub use process::HarnProcessTestNoLock;
 
-const MCP_LOG_RECV_INTERVAL: Duration = Duration::from_millis(25);
-
 #[allow(dead_code)]
 pub fn lock_mcp_process_tests() -> HarnProcessTestNoLock {
     // The cross-process lock that this used to acquire was retired in favor
@@ -47,8 +45,12 @@ pub fn wait_for_child_log_suffix(
 ) -> String {
     let deadline = Instant::now() + timeout;
     let mut observed = Vec::new();
-    while Instant::now() < deadline {
-        match rx.recv_timeout(MCP_LOG_RECV_INTERVAL) {
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        match rx.recv_timeout(remaining) {
             Ok(line) if line.contains(needle) => {
                 return line
                     .split(needle)
@@ -58,7 +60,7 @@ pub fn wait_for_child_log_suffix(
                     .to_string();
             }
             Ok(line) => observed.push(line),
-            Err(mpsc::RecvTimeoutError::Timeout) => continue,
+            Err(mpsc::RecvTimeoutError::Timeout) => break,
             Err(mpsc::RecvTimeoutError::Disconnected) => {
                 panic!(
                     "{label} stderr stream closed before readiness log `{needle}` appeared\nstderr={}",

--- a/scripts/lint_test_patterns.sh
+++ b/scripts/lint_test_patterns.sh
@@ -54,8 +54,6 @@ INSTANT_NOW_WHILE_ALLOWLIST=(
   "crates/harn-cli/tests/orchestrator_http/support.rs"
   "crates/harn-cli/tests/orchestrator_http/admin.rs"
   "crates/harn-cli/tests/orchestrator_http/observability.rs"
-  "crates/harn-cli/tests/harn_serve_mcp_cli.rs"
-  "crates/harn-cli/tests/support/mcp.rs"
   "crates/harn-cli/tests/support/mod.rs"
   "crates/harn-cli/tests/test_util/process.rs"
 )
@@ -72,11 +70,9 @@ SYSTEM_TIME_ALLOWLIST=(
 )
 
 # recv_timeout with an explicit sub-second Duration literal.
-# Named-constant variants (for example MCP_LOG_RECV_INTERVAL) are not caught here
-# because the constant value cannot be resolved by a static text search.
-RECV_TIMEOUT_MILLIS_ALLOWLIST=(
-  "crates/harn-cli/tests/harn_serve_mcp_cli.rs"
-)
+# Named-constant variants are not caught here because the constant value
+# cannot be resolved by a static text search.
+RECV_TIMEOUT_MILLIS_ALLOWLIST=()
 
 # ---------------------------------------------------------------------------
 # Helpers


### PR DESCRIPTION
## Summary

Continues the test-flakiness cleanup from #1233 / #1242 / #1245.

`recv_until` (in `crates/harn-cli/tests/harn_serve_mcp_cli.rs`) and `wait_for_child_log_suffix` (in `crates/harn-cli/tests/support/mcp.rs`) were each polling their `mpsc::Receiver` every 25 ms inside an `Instant::now()` deadline loop. After each non-matching observation, the next inspection had to wait for the next 25 ms tick — `recv_timeout` already supports a long blocking wait, so the polling was pure overhead.

Replace both with a single bounded `recv_timeout(remaining)` per attempt: after each non-matching message, recompute `remaining` from the absolute deadline and call `recv_timeout` again. The receiver now blocks until the next message or the deadline — no wall-clock spinning, identical external behavior.

This drops:

- `crates/harn-cli/tests/harn_serve_mcp_cli.rs` from `INSTANT_NOW_WHILE_ALLOWLIST` and `RECV_TIMEOUT_MILLIS_ALLOWLIST`
- `crates/harn-cli/tests/support/mcp.rs` from `INSTANT_NOW_WHILE_ALLOWLIST`

`RECV_TIMEOUT_MILLIS_ALLOWLIST` is now empty.

## Why it's robust cross-platform

- `mpsc::Receiver::recv_timeout` is a portable stdlib primitive on Unix and Windows.
- No subprocess-handling change — the existing `std::thread::spawn` line readers feed the same channel.
- Only timing semantics change (one bounded recv vs. polling); all match logic is preserved.

## Test plan

- [x] `cargo test -p harn-cli --test harn_serve_mcp_cli -- --ignored` — 4/4 passed in 3.38 s. (All four are `#[ignore]`d behind issue #1069's slow E2E lane; explicit `--ignored` exercises them.)
- [x] `cargo test -p harn-cli --test mcp_server_cli -- --ignored` — 2/2 passed in 3.18 s. (`wait_for_child_log_suffix` is also used here.)
- [x] `bash scripts/lint_test_patterns.sh` — passes with the allowlist trimmed.
- [x] Pre-commit: rustfmt + clippy --workspace --all-targets -D warnings, all green.
- [x] Pre-push: workspace tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)