### PR TITLE
[harn-cli] Drive admin.rs reload+request waits off events; tighten lint regex

### DIFF
--- a/crates/harn-cli/tests/orchestrator_http/admin.rs
+++ b/crates/harn-cli/tests/orchestrator_http/admin.rs
@@ -153,25 +153,30 @@ async fn watch_mode_reloads_manifest_changes() {
     let mut auth_headers = json_headers();
     auth_headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer reload-key"));
 
-    let deadline = tokio::time::Instant::now() + EVENT_FAIL_FAST_TIMEOUT;
-    loop {
-        let response = client
-            .post(format!("{base_url}/a2a/review-watch"))
-            .headers(auth_headers.clone())
-            .body(br#"{"kind":"a2a.task.received","task":{"id":"task-watch"}}"#.to_vec())
-            .send()
-            .await
-            .unwrap();
-        if response.status() == StatusCode::OK {
-            break;
-        }
-        assert_eq!(response.status(), StatusCode::NOT_FOUND);
-        assert!(
-            tokio::time::Instant::now() < deadline,
-            "watch reload never applied"
-        );
-        tokio::time::sleep(Duration::from_millis(25)).await;
-    }
+    // The notify-driven manifest watcher emits a `reload_succeeded`
+    // event on `orchestrator.manifest` once the new route is live;
+    // that is exactly the signal HTTP requests would otherwise have
+    // to discover by retrying.
+    await_topic_event(&harness.event_log(), "orchestrator.manifest", |event| {
+        event.kind == "reload_succeeded"
+            && event.payload["summary"]["modified"]
+                .as_array()
+                .is_some_and(|modified| {
+                    modified
+                        .iter()
+                        .any(|item| item.as_str() == Some("incoming-review-task"))
+                })
+    })
+    .await;
+
+    let response = client
+        .post(format!("{base_url}/a2a/review-watch"))
+        .headers(auth_headers.clone())
+        .body(br#"{"kind":"a2a.task.received","task":{"id":"task-watch"}}"#.to_vec())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
 
     let retired = client
         .post(format!("{base_url}/a2a/review"))
@@ -395,14 +400,7 @@ async fn graceful_shutdown_waits_for_in_flight_request() {
         async move { client.post(url).headers(headers).body(body).send().await }
     });
 
-    let entry_deadline = tokio::time::Instant::now() + EVENT_FAIL_FAST_TIMEOUT;
-    while !request_entered_path.exists() {
-        assert!(
-            tokio::time::Instant::now() < entry_deadline,
-            "timed out waiting for request to enter handler"
-        );
-        tokio::time::sleep(Duration::from_millis(25)).await;
-    }
+    wait_for_path(&request_entered_path).await;
 
     let _ = shutdown_trigger.send(true);
     fs::write(&request_release_path, b"release").unwrap();

--- a/crates/harn-cli/tests/orchestrator_http/support.rs
+++ b/crates/harn-cli/tests/orchestrator_http/support.rs
@@ -603,6 +603,24 @@ pub(super) async fn await_pump_dispatch_count(harness: &OrchestratorHarness, cou
     .unwrap_or_else(|_| panic!("timed out waiting for {count} pump dispatches; got {total}"));
 }
 
+/// Wait until `path` exists, polling at the approved cadence. The
+/// orchestrator emits filesystem markers via the
+/// `HARN_ORCHESTRATOR_TEST_*_FILE` env hooks for tests that need to
+/// gate on handler-side state for which there is no lifecycle event
+/// (e.g. a request has entered the handler body). Wrapping the poll
+/// in [`tokio::time::timeout`] gives the same fail-fast ceiling as
+/// [`await_topic_event`] without the wall-clock deadline pattern the
+/// lint forbids.
+pub(super) async fn wait_for_path(path: &Path) {
+    tokio::time::timeout(EVENT_FAIL_FAST_TIMEOUT, async {
+        while !path.exists() {
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("timed out waiting for path {}", path.display()));
+}
+
 /// Read the on-disk state snapshot. The harness writes this file at
 /// startup, during drain, and on shutdown — so callers should either
 /// shut down the harness first or wait for the relevant lifecycle

--- a/scripts/lint_test_patterns.sh
+++ b/scripts/lint_test_patterns.sh
@@ -32,35 +32,29 @@ THREAD_SLEEP_ALLOWLIST=(
   "crates/harn-hostlib/tests/process_tools.rs"
 )
 
-# tokio::time::sleep in test files (outside start_paused = true tests)
-# Legitimate uses: connector integration tests polling real async state.
+# tokio::time::sleep in test files (outside start_paused = true tests).
+# Legitimate uses:
+#   - `orchestration/tests.rs`: paired with `start_paused = true`,
+#     drives advanced timers explicitly.
+#   - `orchestrator_http/support.rs`: `wait_for_path` polls a real
+#     filesystem marker written by handler-side code where no
+#     event signal is available; bounded with `tokio::time::timeout`.
 TOKIO_SLEEP_ALLOWLIST=(
-  "crates/harn-vm/src/connectors/notion/tests.rs"
-  "crates/harn-vm/src/connectors/linear/tests.rs"
-  "crates/harn-vm/src/triggers/dispatcher/tests/retry.rs"
   "crates/harn-vm/src/orchestration/tests.rs"
-  "crates/harn-cli/tests/orchestrator_http/admin.rs"
+  "crates/harn-cli/tests/orchestrator_http/support.rs"
 )
 
-# Instant::now() in a while-loop condition — wall-clock polling.
-# All entries below are subprocess/orchestrator integration tests that poll
-# real process output; they will be refactored by Tier 1A/1B of #1057.
-INSTANT_NOW_WHILE_ALLOWLIST=(
-  "crates/harn-vm/src/triggers/dispatcher/tests/retry.rs"
-  "crates/harn-cli/tests/orchestrator_inbox_dedupe.rs"
-  "crates/harn-cli/tests/orchestrator_http/support.rs"
-  "crates/harn-cli/tests/orchestrator_http/admin.rs"
-  "crates/harn-cli/tests/orchestrator_http/observability.rs"
-  "crates/harn-cli/tests/support/mod.rs"
+# Wall-clock `Instant::now() < deadline` comparisons inside any loop or
+# guard.
+INSTANT_NOW_DEADLINE_ALLOWLIST=(
 )
 
 # SystemTime::now() in test files — use injected clock / MockClock instead.
 # Remaining entries: legitimate fixture-setup uses against real OS time
 # (httpdate Retry-After parsing, real-mtime touch fixtures, tempdir
-# nano-suffix uniqueness, prompt-template `now_ms()` round-trip).
+# nano-suffix uniqueness).
 SYSTEM_TIME_ALLOWLIST=(
   "crates/harn-vm/src/http/tests.rs"
-  "crates/harn-vm/src/stdlib/template/tests.rs"
   "crates/harn-hostlib/tests/scanner_e2e.rs"
   "crates/harn-cli/src/commands/check/tests.rs"
 )
@@ -165,11 +159,14 @@ check_pattern \
   TOKIO_SLEEP_ALLOWLIST \
   "Use tokio::time::pause() + advance() in a #[tokio::test(start_paused = true)] context."
 
-echo "--- Instant::now() in while-loop (wall-clock poll) ---"
+echo "--- Instant::now() deadline comparison (wall-clock poll) ---"
+# Catches `Instant::now() < deadline`, `>= deadline`, etc. — the smell is
+# the comparison itself, regardless of whether it sits inside a `while`,
+# a `loop`, or an `assert!` macro inside a loop body.
 check_pattern \
-  "while.*Instant::now\|while.*std::time::Instant::now" \
-  INSTANT_NOW_WHILE_ALLOWLIST \
-  "Subscribe to an EventLog channel or use a deterministic OrchestratorHarness instead."
+  "Instant::now() *[<>]" \
+  INSTANT_NOW_DEADLINE_ALLOWLIST \
+  "Subscribe to an EventLog channel, use OrchestratorHarness, or wrap a poll in tokio::time::timeout instead."
 
 echo "--- SystemTime::now() in tests ---"
 check_pattern \


### PR DESCRIPTION
Stacks on #1245 / #1246. Drives orchestrator_http/admin.rs polling loops off events: watch_mode_reloads_manifest_changes now subscribes to orchestrator.manifest::reload_succeeded; graceful_shutdown_waits_for_in_flight_request uses shared wait_for_path helper. Tightens lint regex from while.*Instant::now to Instant::now() *[<>] to catch loop and assert! bodies. Audits and purges stale allowlist entries (Harn-script sleep, missing files, no-longer-present patterns). Renames INSTANT_NOW_WHILE_ALLOWLIST -> INSTANT_NOW_DEADLINE_ALLOWLIST. 23/23 e2e tests pass, 6/6 ignored MCP tests pass.