### PR TITLE
[acp] Return canonical stop-reasons from session/prompt

### DIFF
--- a/conformance/tests/integration/agent_loop_acp_stop_reason.expected
+++ b/conformance/tests/integration/agent_loop_acp_stop_reason.expected
@@ -1,0 +1,5 @@
+end_turn
+max_tokens
+max_tokens
+refusal
+max_turn_requests

--- a/conformance/tests/integration/agent_loop_acp_stop_reason.harn
+++ b/conformance/tests/integration/agent_loop_acp_stop_reason.harn
@@ -1,0 +1,38 @@
+/**
+ * agent_loop reports a canonical ACP `stopReason` (end_turn / max_tokens
+ * / max_turn_requests / refusal) on its result dict via `acp_stop_reason`.
+ * The ACP adapter consumes this field through `bridge.take_prompt_stop_reason()`
+ * to fill `session/prompt`'s `stopReason` per the protocol at
+ * https://agentclientprotocol.com/protocol/prompt-turn.
+ */
+pipeline default() {
+  // Natural completion → end_turn.
+  llm_mock_clear()
+  llm_mock({text: "all done"})
+  let normal = agent_loop("hi", nil, {provider: "mock"})
+  println(normal.acp_stop_reason)
+  // Provider truncated the response → max_tokens.
+  llm_mock_clear()
+  llm_mock({text: "truncated", stop_reason: "max_tokens"})
+  let truncated = agent_loop("hi", nil, {provider: "mock"})
+  println(truncated.acp_stop_reason)
+  // OpenAI-style finish_reason "length" maps to the same canonical value.
+  llm_mock_clear()
+  llm_mock({text: "truncated", stop_reason: "length"})
+  let length = agent_loop("hi", nil, {provider: "mock"})
+  println(length.acp_stop_reason)
+  // Anthropic refusal → refusal.
+  llm_mock_clear()
+  llm_mock({text: "I cannot assist with that.", stop_reason: "refusal"})
+  let refused = agent_loop("hi", nil, {provider: "mock"})
+  println(refused.acp_stop_reason)
+  // Iteration cap → max_turn_requests. Persistent + text-only keeps the
+  // loop going until max_iterations, which the loop reports as
+  // budget_exhausted; finalize maps that to max_turn_requests when the
+  // iteration count matches the configured cap.
+  llm_mock_clear()
+  llm_mock({text: "still working"})
+  llm_mock({text: "still working"})
+  let capped = agent_loop("hi", nil, {provider: "mock", persistent: true, max_iterations: 1})
+  println(capped.acp_stop_reason)
+}

--- a/crates/harn-cli/src/commands/orchestrator/listener/tests.rs
+++ b/crates/harn-cli/src/commands/orchestrator/listener/tests.rs
@@ -500,7 +500,7 @@ async fn acp_websocket_parallel_clients_get_distinct_sessions_and_can_load_activ
         }),
     )
     .await;
-    assert_eq!(prompted["result"]["stopReason"], "completed");
+    assert_eq!(prompted["result"]["stopReason"], "end_turn");
 
     listener
         .shutdown(Duration::from_secs(5))
@@ -624,7 +624,7 @@ async fn acp_websocket_reconnect_replays_pending_host_request_and_completes_prom
                 assert_eq!(message["result"]["session"]["sessionId"], json!(session_id));
                 saw_load_response = true;
             } else if message.get("id").and_then(JsonValue::as_u64) == Some(2) {
-                assert_eq!(message["result"]["stopReason"], json!("completed"));
+                assert_eq!(message["result"]["stopReason"], json!("end_turn"));
                 saw_prompt_response = true;
             }
         }

--- a/crates/harn-serve/src/adapters/acp/mod.rs
+++ b/crates/harn-serve/src/adapters/acp/mod.rs
@@ -927,6 +927,7 @@ impl AcpServer {
         let id_owned = id.clone();
         let send_output = self.output.clone();
         let _mode_guard = modes::ModePolicyGuard::enter(&current_mode_id);
+        let host_bridge_for_response = host_bridge.clone();
         let result = execute::execute_chunk(
             chunk,
             bridge.clone(),
@@ -951,10 +952,17 @@ impl AcpServer {
                 if !output.is_empty() {
                     bridge.send_update(&output);
                 }
+                let stop_reason = if cancellation.cancelled.load(Ordering::SeqCst) {
+                    "cancelled".to_string()
+                } else {
+                    host_bridge_for_response
+                        .take_prompt_stop_reason()
+                        .unwrap_or_else(|| "end_turn".to_string())
+                };
                 send_json_response(
                     &send_output,
                     &id_owned,
-                    serde_json::json!({"stopReason": "completed"}),
+                    serde_json::json!({"stopReason": stop_reason}),
                 );
             }
             Err(e) => {
@@ -2036,7 +2044,7 @@ mod tests {
                         saw_update = true;
                     }
                     if message["id"] == 4 {
-                        assert_eq!(message["result"]["stopReason"], "completed");
+                        assert_eq!(message["result"]["stopReason"], "end_turn");
                         saw_completed = true;
                         break;
                     }
@@ -2909,7 +2917,7 @@ mod tests {
                         continue;
                     }
                     if message["id"] == 3 {
-                        assert_eq!(message["result"]["stopReason"], "completed");
+                        assert_eq!(message["result"]["stopReason"], "end_turn");
                         saw_completed = true;
                         break;
                     }
@@ -3090,7 +3098,7 @@ mod tests {
                         );
                     }
                     if message["id"] == 2 {
-                        assert_eq!(message["result"]["stopReason"], "completed");
+                        assert_eq!(message["result"]["stopReason"], "end_turn");
                         saw_completed = true;
                         break;
                     }
@@ -3182,7 +3190,7 @@ mod tests {
                         }
                     }
                     if message["id"] == 2 {
-                        assert_eq!(message["result"]["stopReason"], "completed");
+                        assert_eq!(message["result"]["stopReason"], "end_turn");
                         break;
                     }
                 }
@@ -3357,7 +3365,7 @@ mod tests {
                         saw_beta_chunk = true;
                     }
                     if message["id"] == 2 {
-                        assert_eq!(message["result"]["stopReason"], "completed");
+                        assert_eq!(message["result"]["stopReason"], "end_turn");
                         break;
                     }
                 }
@@ -3372,6 +3380,124 @@ mod tests {
 
                 drop(request_tx);
                 server.await.expect("ACP channel server task");
+            })
+            .await;
+    }
+
+    /// `session/prompt` returns the canonical ACP `stopReason` rather
+    /// than Harn's internal "completed" / "cancelled" pair. This drives
+    /// each branch of the mapping in `agent_session_host::canonical_acp_stop_reason`
+    /// through a real ACP roundtrip with `provider: "mock"` so the
+    /// adapter and the agent loop's finalize stay aligned with the
+    /// canonical enum at <https://agentclientprotocol.com/protocol/prompt-turn>.
+    async fn run_acp_agent_loop_prompt(prompt_body: &str) -> serde_json::Value {
+        let (request_tx, mut response_rx, server, session_id) = start_acp_channel_session().await;
+
+        // `agent_loop` requires the LLM/network capability ceiling.
+        // The default `ask` mode clamps to read-only; switch to `code`
+        // (`ActAuto` autonomy tier) so the test can exercise the loop.
+        request_tx
+            .send(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "session/set_mode",
+                "params": {"sessionId": session_id, "modeId": "code"},
+            }))
+            .expect("send session/set_mode");
+        let _ack = recv_json(&mut response_rx).await;
+        let _notification = recv_json(&mut response_rx).await;
+
+        request_tx
+            .send(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "session/prompt",
+                "params": {
+                    "sessionId": session_id,
+                    "prompt": [{"type": "text", "text": prompt_body}],
+                },
+            }))
+            .expect("send session/prompt");
+
+        let mut stop_reason = serde_json::Value::Null;
+        for _ in 0..64 {
+            let message = recv_json(&mut response_rx).await;
+            if message["method"] == "host/capabilities" {
+                request_tx
+                    .send(serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": message["id"].clone(),
+                        "result": {},
+                    }))
+                    .expect("send host capabilities response");
+                continue;
+            }
+            if message["id"] == 3 {
+                stop_reason = message["result"]["stopReason"].clone();
+                break;
+            }
+        }
+        drop(request_tx);
+        server.await.expect("ACP channel server task");
+        stop_reason
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn acp_session_prompt_reports_end_turn_when_loop_finishes_naturally() {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let body = "llm_mock_clear()\n\
+                            llm_mock({text: \"all done\"})\n\
+                            agent_loop(\"hello\", nil, {provider: \"mock\"})";
+                let stop_reason = run_acp_agent_loop_prompt(body).await;
+                assert_eq!(stop_reason, "end_turn");
+            })
+            .await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn acp_session_prompt_reports_max_tokens_from_provider_signal() {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let body = "llm_mock_clear()\n\
+                            llm_mock({text: \"truncated\", stop_reason: \"max_tokens\"})\n\
+                            agent_loop(\"hello\", nil, {provider: \"mock\"})";
+                let stop_reason = run_acp_agent_loop_prompt(body).await;
+                assert_eq!(stop_reason, "max_tokens");
+            })
+            .await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn acp_session_prompt_reports_refusal_from_provider_signal() {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let body = "llm_mock_clear()\n\
+                            llm_mock({text: \"I cannot assist with that.\", stop_reason: \"refusal\"})\n\
+                            agent_loop(\"hello\", nil, {provider: \"mock\"})";
+                let stop_reason = run_acp_agent_loop_prompt(body).await;
+                assert_eq!(stop_reason, "refusal");
+            })
+            .await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn acp_session_prompt_reports_max_turn_requests_when_iteration_cap_hit() {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                // `persistent: true` keeps the loop iterating on a
+                // text-only mock turn, and `max_iterations: 1` forces
+                // the cap to fire on iteration 1 → ACP `max_turn_requests`.
+                let body = "llm_mock_clear()\n\
+                            llm_mock({text: \"still working\"})\n\
+                            llm_mock({text: \"still working\"})\n\
+                            agent_loop(\"hello\", nil, {provider: \"mock\", persistent: true, max_iterations: 1})";
+                let stop_reason = run_acp_agent_loop_prompt(body).await;
+                assert_eq!(stop_reason, "max_turn_requests");
             })
             .await;
     }

--- a/crates/harn-vm/src/bridge.rs
+++ b/crates/harn-vm/src/bridge.rs
@@ -71,6 +71,12 @@ pub struct HostBridge {
     skills_reload_requested: Arc<AtomicBool>,
     /// Whether the current daemon-mode agent loop is blocked in idle wait.
     daemon_idle: Arc<AtomicBool>,
+    /// Canonical ACP `stopReason` recorded by the most recent `agent_loop`
+    /// finalize during this prompt. Read once by the ACP adapter when the
+    /// pipeline returns and populated by `host_agent_session_finalize`.
+    /// Pipelines that don't run an agent loop leave this `None`, in which
+    /// case the adapter falls back to `end_turn`.
+    prompt_stop_reason: std::sync::Mutex<Option<String>>,
     /// Per-call visible assistant text state for call_progress notifications.
     visible_call_states: std::sync::Mutex<HashMap<String, VisibleTextState>>,
     /// Whether an LLM call's deltas should be exposed to end users while streaming.
@@ -335,6 +341,7 @@ impl HostBridge {
             resume_requested,
             skills_reload_requested,
             daemon_idle,
+            prompt_stop_reason: std::sync::Mutex::new(None),
             visible_call_states: std::sync::Mutex::new(HashMap::new()),
             visible_call_streams: std::sync::Mutex::new(HashMap::new()),
             in_process: None,
@@ -372,6 +379,7 @@ impl HostBridge {
             resume_requested: Arc::new(AtomicBool::new(false)),
             skills_reload_requested: Arc::new(AtomicBool::new(false)),
             daemon_idle: Arc::new(AtomicBool::new(false)),
+            prompt_stop_reason: std::sync::Mutex::new(None),
             visible_call_states: std::sync::Mutex::new(HashMap::new()),
             visible_call_streams: std::sync::Mutex::new(HashMap::new()),
             in_process: None,
@@ -393,6 +401,7 @@ impl HostBridge {
             resume_requested: Arc::new(AtomicBool::new(false)),
             skills_reload_requested: Arc::new(AtomicBool::new(false)),
             daemon_idle: Arc::new(AtomicBool::new(false)),
+            prompt_stop_reason: std::sync::Mutex::new(None),
             visible_call_states: std::sync::Mutex::new(HashMap::new()),
             visible_call_streams: std::sync::Mutex::new(HashMap::new()),
             in_process: Some(InProcessHost {
@@ -532,6 +541,28 @@ impl HostBridge {
 
     pub fn is_daemon_idle(&self) -> bool {
         self.daemon_idle.load(Ordering::SeqCst)
+    }
+
+    /// Record the canonical ACP `stopReason` for the current prompt. The
+    /// last writer wins, which matches the semantic that an outer
+    /// `agent_loop` (the one whose result the user observes) always
+    /// finalizes after any inner loops it spawned.
+    pub fn set_prompt_stop_reason(&self, reason: &str) {
+        *self
+            .prompt_stop_reason
+            .lock()
+            .unwrap_or_else(|e| e.into_inner()) = Some(reason.to_string());
+    }
+
+    /// Consume any prompt stop reason recorded during this prompt. The
+    /// ACP adapter calls this once after the pipeline returns; pipelines
+    /// that didn't run an `agent_loop` see `None` and the adapter falls
+    /// back to `end_turn`.
+    pub fn take_prompt_stop_reason(&self) -> Option<String> {
+        self.prompt_stop_reason
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .take()
     }
 
     /// Consume any pending `skills/update` signal the host has sent.

--- a/crates/harn-vm/src/llm/agent_session_host.rs
+++ b/crates/harn-vm/src/llm/agent_session_host.rs
@@ -50,6 +50,16 @@ struct AgentHostSession {
     rejected_tools: Vec<serde_json::Value>,
     tool_mode: String,
     started_at: String,
+    /// Iteration cap from `agent_loop(options.max_iterations)`. Captured
+    /// here so finalize can disambiguate `final_status == "budget_exhausted"`
+    /// caused by hitting the cap (→ ACP `max_turn_requests`) from other
+    /// budget paths.
+    max_iterations: i64,
+    /// Provider-reported `stop_reason` from the most recent `llm_call`
+    /// in this loop. Used by finalize to detect ACP `max_tokens` (when
+    /// the last call truncated due to its `max_tokens` parameter) and
+    /// `refusal` (Anthropic refusal stop_reason).
+    last_llm_stop_reason: Option<String>,
 }
 
 thread_local! {
@@ -152,6 +162,8 @@ async fn host_agent_session_init(args: Vec<VmValue>) -> Result<VmValue, VmError>
         rejected_tools: Vec::new(),
         tool_mode: String::new(),
         started_at: now_id(),
+        max_iterations,
+        last_llm_stop_reason: None,
     };
 
     AGENT_HOST_SESSIONS.with(|sessions| {
@@ -219,10 +231,24 @@ async fn host_agent_session_finalize(args: Vec<VmValue>) -> Result<VmValue, VmEr
 
     let iterations = opt_int(&status_dict, "iterations").unwrap_or(0);
     let tool_mode = opt_str(&status_dict, "tool_mode").unwrap_or(session.tool_mode);
+    let acp_stop_reason = canonical_acp_stop_reason(
+        &final_status,
+        iterations,
+        session.max_iterations,
+        session.last_llm_stop_reason.as_deref(),
+    );
+    // Surface the canonical reason to the host bridge so an outer ACP
+    // adapter can populate `session/prompt`'s `stopReason`. The bridge
+    // is opt-in: pipelines that don't run under ACP simply leave the
+    // slot unset.
+    if let Some(bridge) = super::agent::current_host_bridge() {
+        bridge.set_prompt_stop_reason(acp_stop_reason);
+    }
     let result = serde_json::json!({
         "status": if final_status.is_empty() { "done" } else { final_status.as_str() },
         "final_status": final_status,
         "stop_reason": stop_reason,
+        "acp_stop_reason": acp_stop_reason,
         "text": visible_text,
         "visible_text": visible_text,
         "private_reasoning": serde_json::Value::Null,
@@ -247,6 +273,42 @@ async fn host_agent_session_finalize(args: Vec<VmValue>) -> Result<VmValue, VmEr
         "task": session.task,
     });
     Ok(json_to_vm(&result))
+}
+
+/// Map an agent-loop terminal state to the canonical ACP `stopReason`
+/// enumeration documented at <https://agentclientprotocol.com/protocol/prompt-turn>.
+///
+/// ACP defines five values: `end_turn`, `max_tokens`, `max_turn_requests`,
+/// `refusal`, and `cancelled`. `cancelled` is decided one layer up by the
+/// adapter (it observes the cancel notification directly) so this
+/// function only chooses among the other four.
+///
+/// Precedence: a loop that ran out of turn budget overrides any
+/// per-call signal — the caller stopped the agent before the model
+/// could refuse or truncate again. When the loop exited cleanly we fall
+/// through to the most recent provider stop_reason.
+pub(crate) fn canonical_acp_stop_reason(
+    final_status: &str,
+    iterations: i64,
+    max_iterations: i64,
+    last_llm_stop_reason: Option<&str>,
+) -> &'static str {
+    if final_status == "budget_exhausted" {
+        if max_iterations > 0 && iterations >= max_iterations {
+            return "max_turn_requests";
+        }
+        // Token / cost / autonomy budgets all cap how many requests the
+        // loop will issue, so they collapse to the same canonical
+        // reason. ACP's `max_tokens` is reserved for a single response
+        // truncated by the provider's `max_tokens` parameter.
+        return "max_turn_requests";
+    }
+    match last_llm_stop_reason {
+        Some(reason) if reason.eq_ignore_ascii_case("max_tokens") => "max_tokens",
+        Some(reason) if reason.eq_ignore_ascii_case("length") => "max_tokens",
+        Some(reason) if reason.eq_ignore_ascii_case("refusal") => "refusal",
+        _ => "end_turn",
+    }
 }
 
 fn last_assistant_text(snapshot: &VmValue) -> Option<String> {
@@ -386,6 +448,10 @@ fn host_agent_session_record_usage_builtin(
         .map(|v| v.display())
         .unwrap_or_default();
     let cost = calculate_cost_for_provider(&provider, &model, input_tokens, output_tokens);
+    let stop_reason = match dict_get(&llm_result, "stop_reason") {
+        Some(VmValue::String(s)) if !s.is_empty() => Some(s.to_string()),
+        _ => None,
+    };
 
     let totals = with_session(&session_id, HOST_SESSION_RECORD_USAGE, |session| {
         session.tokens_used = session
@@ -395,6 +461,9 @@ fn host_agent_session_record_usage_builtin(
         session.input_tokens = session.input_tokens.saturating_add(input_tokens);
         session.output_tokens = session.output_tokens.saturating_add(output_tokens);
         session.cost_used += cost;
+        if stop_reason.is_some() {
+            session.last_llm_stop_reason = stop_reason.clone();
+        }
         Ok((session.tokens_used, session.cost_used))
     })?;
     let mut out = BTreeMap::new();
@@ -630,4 +699,88 @@ pub fn register_agent_session_host_primitives(vm: &mut Vm) {
     vm.register_async_builtin_with_metadata(skill_score, |args| {
         Box::pin(async move { host_skill_score(args).await })
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::canonical_acp_stop_reason;
+
+    #[test]
+    fn iteration_cap_maps_to_max_turn_requests() {
+        assert_eq!(
+            canonical_acp_stop_reason("budget_exhausted", 5, 5, None),
+            "max_turn_requests"
+        );
+        assert_eq!(
+            canonical_acp_stop_reason("budget_exhausted", 6, 5, Some("end_turn")),
+            "max_turn_requests"
+        );
+    }
+
+    #[test]
+    fn other_budget_paths_also_map_to_max_turn_requests() {
+        // Token / cost / autonomy budgets all stop the loop short, so
+        // they share the canonical ACP reason even when iterations are
+        // below the cap.
+        assert_eq!(
+            canonical_acp_stop_reason("budget_exhausted", 2, 50, Some("end_turn")),
+            "max_turn_requests"
+        );
+    }
+
+    #[test]
+    fn provider_max_tokens_promoted_when_loop_clean() {
+        assert_eq!(
+            canonical_acp_stop_reason("done", 1, 50, Some("max_tokens")),
+            "max_tokens"
+        );
+        // OpenAI flavor.
+        assert_eq!(
+            canonical_acp_stop_reason("done", 1, 50, Some("length")),
+            "max_tokens"
+        );
+        // Case-insensitive on the provider value.
+        assert_eq!(
+            canonical_acp_stop_reason("done", 1, 50, Some("MAX_TOKENS")),
+            "max_tokens"
+        );
+    }
+
+    #[test]
+    fn anthropic_refusal_stop_reason_maps_to_refusal() {
+        assert_eq!(
+            canonical_acp_stop_reason("done", 1, 50, Some("refusal")),
+            "refusal"
+        );
+    }
+
+    #[test]
+    fn natural_completion_maps_to_end_turn() {
+        assert_eq!(
+            canonical_acp_stop_reason("done", 1, 50, Some("end_turn")),
+            "end_turn"
+        );
+        assert_eq!(canonical_acp_stop_reason("", 1, 50, None), "end_turn");
+        // Anthropic `tool_use` is normal mid-turn behavior; if it
+        // somehow surfaced as the last call's stop_reason (loop ended
+        // before the next turn ran), it still represents a clean stop.
+        assert_eq!(
+            canonical_acp_stop_reason("done", 1, 50, Some("tool_use")),
+            "end_turn"
+        );
+    }
+
+    #[test]
+    fn budget_exhausted_overrides_provider_signal() {
+        // The loop ran out of budget before the model could refuse or
+        // truncate again, so loop-level cap wins.
+        assert_eq!(
+            canonical_acp_stop_reason("budget_exhausted", 50, 50, Some("max_tokens")),
+            "max_turn_requests"
+        );
+        assert_eq!(
+            canonical_acp_stop_reason("budget_exhausted", 50, 50, Some("refusal")),
+            "max_turn_requests"
+        );
+    }
 }

--- a/crates/harn-vm/src/llm/agent_session_host.rs
+++ b/crates/harn-vm/src/llm/agent_session_host.rs
@@ -241,7 +241,7 @@ async fn host_agent_session_finalize(args: Vec<VmValue>) -> Result<VmValue, VmEr
     // adapter can populate `session/prompt`'s `stopReason`. The bridge
     // is opt-in: pipelines that don't run under ACP simply leave the
     // slot unset.
-    if let Some(bridge) = super::agent::current_host_bridge() {
+    if let Some(bridge) = super::agent_runtime::current_host_bridge() {
         bridge.set_prompt_stop_reason(acp_stop_reason);
     }
     let result = serde_json::json!({


### PR DESCRIPTION
## Summary

- Maps agent-loop terminal conditions to the canonical ACP `stopReason` enumeration: `end_turn`, `max_tokens`, `max_turn_requests`, `refusal`, `cancelled`. Replaces the non-canonical `completed` / `cancelled` pair the adapter previously returned.
- Surfaces the canonical reason through a new `HostBridge.prompt_stop_reason` slot that `host_agent_session_finalize` writes during `agent_loop` teardown; the ACP adapter consumes it once after the pipeline returns. Pipelines that don't run an `agent_loop` fall back to `end_turn` (or `cancelled` when the cancel notification fired).
- Tracks the last LLM `stop_reason` and `max_iterations` on `AgentHostSession` so finalize can disambiguate `budget_exhausted` (iteration / token / cost cap → `max_turn_requests`) from a truncated final response (`max_tokens`/`length` → `max_tokens`) and an Anthropic `refusal`.

Closes #898 — spec reference: <https://agentclientprotocol.com/protocol/prompt-turn>.

## Test plan

- [x] `cargo test -p harn-vm --lib` (1825 passed)
- [x] `cargo test -p harn-serve --lib` (130 passed, including 4 new ACP integration tests for each canonical stop reason)
- [x] `cargo run --bin harn -- test conformance` (776 passed, including new `agent_loop_acp_stop_reason` covering all five mapping branches)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`, `harn fmt --check`, `harn lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)