### PR TITLE
[vm] Move remaining Rust-owned prompt prose into stdlib assets (#1199)

### DIFF
--- a/crates/harn-stdlib/src/lib.rs
+++ b/crates/harn-stdlib/src/lib.rs
@@ -379,6 +379,26 @@ pub const STDLIB_PROMPT_ASSETS: &[StdlibPromptAsset] = &[
         source: include_str!("stdlib/llm/prompts/completion_fallback_user.harn.prompt"),
     },
     StdlibPromptAsset {
+        path: "llm/prompts/transcript_summarize_user.harn.prompt",
+        source: include_str!("stdlib/llm/prompts/transcript_summarize_user.harn.prompt"),
+    },
+    StdlibPromptAsset {
+        path: "llm/prompts/structural_chain_of_draft.harn.prompt",
+        source: include_str!("stdlib/llm/prompts/structural_chain_of_draft.harn.prompt"),
+    },
+    StdlibPromptAsset {
+        path: "llm/prompts/schema_recover_repair.harn.prompt",
+        source: include_str!("stdlib/llm/prompts/schema_recover_repair.harn.prompt"),
+    },
+    StdlibPromptAsset {
+        path: "llm/prompts/structured_envelope_schema_contract.harn.prompt",
+        source: include_str!("stdlib/llm/prompts/structured_envelope_schema_contract.harn.prompt"),
+    },
+    StdlibPromptAsset {
+        path: "llm/prompts/structured_envelope_repair.harn.prompt",
+        source: include_str!("stdlib/llm/prompts/structured_envelope_repair.harn.prompt"),
+    },
+    StdlibPromptAsset {
         path: "workflow/prompts/stage.harn.prompt",
         source: include_str!("stdlib/workflow/prompts/stage.harn.prompt"),
     },

--- a/crates/harn-stdlib/src/stdlib/llm/prompts/schema_recover_repair.harn.prompt
+++ b/crates/harn-stdlib/src/stdlib/llm/prompts/schema_recover_repair.harn.prompt
@@ -1,0 +1,9 @@
+The following text was supposed to be JSON conforming to the schema below, but it failed validation. Repair it and respond with ONLY the corrected JSON — no prose, no markdown fences, no commentary.
+
+Target schema:
+{{ schema_text }}
+
+Original text:
+{{ raw_text }}
+
+Reply with valid JSON only.

--- a/crates/harn-stdlib/src/stdlib/llm/prompts/structural_chain_of_draft.harn.prompt
+++ b/crates/harn-stdlib/src/stdlib/llm/prompts/structural_chain_of_draft.harn.prompt
@@ -1,0 +1,3 @@
+{{ content }}
+
+Before the final answer, emit a terse scratch draft inside <draft>...</draft>. After the draft block, provide the final answer outside those tags.

--- a/crates/harn-stdlib/src/stdlib/llm/prompts/structured_envelope_repair.harn.prompt
+++ b/crates/harn-stdlib/src/stdlib/llm/prompts/structured_envelope_repair.harn.prompt
@@ -1,0 +1,8 @@
+The following text was supposed to be JSON conforming to the configured schema, but it failed validation. Repair it and respond with ONLY the corrected JSON — no prose, no markdown fences, no commentary.
+
+Validation errors: {{ errors_line }}
+
+Original text:
+{{ raw_text }}
+
+Reply with valid JSON only.

--- a/crates/harn-stdlib/src/stdlib/llm/prompts/structured_envelope_schema_contract.harn.prompt
+++ b/crates/harn-stdlib/src/stdlib/llm/prompts/structured_envelope_schema_contract.harn.prompt
@@ -1,0 +1,6 @@
+{{ prompt }}
+
+Structured output transport is unavailable for this model. Return ONLY JSON that conforms to this JSON Schema. Do not include prose, markdown fences, or commentary.
+
+JSON Schema:
+{{ schema_json }}

--- a/crates/harn-stdlib/src/stdlib/llm/prompts/transcript_summarize_user.harn.prompt
+++ b/crates/harn-stdlib/src/stdlib/llm/prompts/transcript_summarize_user.harn.prompt
@@ -1,0 +1,4 @@
+{{ if prompt }}{{ prompt }}{{ else }}Summarize this conversation for a follow-on agent. Preserve goals, constraints, decisions, unresolved questions, and concrete next actions. Be concise but complete.{{ end }}
+
+Conversation:
+{{ formatted }}

--- a/crates/harn-vm/src/llm/conversation.rs
+++ b/crates/harn-vm/src/llm/conversation.rs
@@ -325,14 +325,12 @@ pub(crate) fn register_conversation_builtins(vm: &mut Vm) {
             .and_then(|v| v.as_int())
             .unwrap_or(6)
             .max(0) as usize;
-        let prompt = args
+        let prompt_override = args
             .get(1)
             .and_then(|v| v.as_dict())
             .and_then(|d| d.get("prompt"))
             .map(|v| v.display())
-            .unwrap_or_else(|| {
-                "Summarize this conversation for a follow-on agent. Preserve goals, constraints, decisions, unresolved questions, and concrete next actions. Be concise but complete.".to_string()
-            });
+            .unwrap_or_default();
 
         let messages = transcript_message_list(transcript)?;
         let formatted = messages
@@ -352,9 +350,22 @@ pub(crate) fn register_conversation_builtins(vm: &mut Vm) {
             .collect::<Vec<_>>()
             .join("\n");
 
+        let mut bindings = BTreeMap::new();
+        bindings.insert(
+            "prompt".to_string(),
+            VmValue::String(Rc::from(prompt_override)),
+        );
+        bindings.insert(
+            "formatted".to_string(),
+            VmValue::String(Rc::from(formatted)),
+        );
+        let user_message = crate::stdlib::template::render_stdlib_prompt_asset(
+            "llm/prompts/transcript_summarize_user.harn.prompt",
+            Some(&bindings),
+        )?;
         opts.messages = vec![serde_json::json!({
             "role": "user",
-            "content": format!("{prompt}\n\nConversation:\n{formatted}"),
+            "content": user_message,
         })];
 
         let result = super::api::vm_call_llm_full(&opts).await?;
@@ -366,7 +377,9 @@ pub(crate) fn register_conversation_builtins(vm: &mut Vm) {
             .into_iter()
             .rev()
             .collect::<Vec<_>>();
-        let archived_count = transcript_message_list(transcript)?.len().saturating_sub(retained.len());
+        let archived_count = transcript_message_list(transcript)?
+            .len()
+            .saturating_sub(retained.len());
         let mut compacted = match rebuild_transcript(
             transcript,
             retained,
@@ -378,7 +391,10 @@ pub(crate) fn register_conversation_builtins(vm: &mut Vm) {
             VmValue::Dict(d) => (*d).clone(),
             _ => BTreeMap::new(),
         };
-        compacted.insert("archived_messages".to_string(), VmValue::Int(archived_count as i64));
+        compacted.insert(
+            "archived_messages".to_string(),
+            VmValue::Int(archived_count as i64),
+        );
         Ok(VmValue::Dict(Rc::new(compacted)))
     });
 

--- a/crates/harn-vm/src/llm/schema_recover.rs
+++ b/crates/harn-vm/src/llm/schema_recover.rs
@@ -583,16 +583,20 @@ async fn run_llm_repair(
 
 fn build_repair_prompt(raw_text: &str, schema: &VmValue) -> String {
     let schema_text = schema_to_compact_json(schema);
-    let mut s = String::from(
-        "The following text was supposed to be JSON conforming to the schema below, but it failed validation. \
-Repair it and respond with ONLY the corrected JSON — no prose, no markdown fences, no commentary.\n\n",
+    let mut bindings = BTreeMap::new();
+    bindings.insert(
+        "schema_text".to_string(),
+        VmValue::String(Rc::from(schema_text)),
     );
-    s.push_str("Target schema:\n");
-    s.push_str(&schema_text);
-    s.push_str("\n\nOriginal text:\n");
-    s.push_str(raw_text);
-    s.push_str("\n\nReply with valid JSON only.");
-    s
+    bindings.insert(
+        "raw_text".to_string(),
+        VmValue::String(Rc::from(raw_text.to_string())),
+    );
+    crate::stdlib::template::render_stdlib_prompt_asset(
+        "llm/prompts/schema_recover_repair.harn.prompt",
+        Some(&bindings),
+    )
+    .expect("schema_recover_repair.harn.prompt is embedded and must render")
 }
 
 fn schema_to_compact_json(schema: &VmValue) -> String {

--- a/crates/harn-vm/src/llm/structural_experiments.rs
+++ b/crates/harn-vm/src/llm/structural_experiments.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::rc::Rc;
 
 use crate::value::{VmError, VmValue};
 
@@ -442,12 +443,14 @@ fn apply_builtin_experiment(
         BuiltInStructuralExperiment::ChainOfDraft => {
             if let Some(index) = latest_string_user_message_index(&messages) {
                 if let Some(content) = message_text(&messages[index]).map(str::to_string) {
-                    set_message_text(
-                        &mut messages[index],
-                        format!(
-                            "{content}\n\nBefore the final answer, emit a terse scratch draft inside <draft>...</draft>. After the draft block, provide the final answer outside those tags."
-                        ),
-                    );
+                    let mut bindings = BTreeMap::new();
+                    bindings.insert("content".to_string(), VmValue::String(Rc::from(content)));
+                    let rendered = crate::stdlib::template::render_stdlib_prompt_asset(
+                        "llm/prompts/structural_chain_of_draft.harn.prompt",
+                        Some(&bindings),
+                    )
+                    .expect("structural_chain_of_draft.harn.prompt is embedded and must render");
+                    set_message_text(&mut messages[index], rendered);
                 }
             }
         }
@@ -539,6 +542,22 @@ mod tests {
         assert!(content.contains("alpha"));
         assert!(content.contains("beta"));
         assert!(content.contains("gamma"));
+    }
+
+    #[test]
+    fn chain_of_draft_appends_scaffold_from_asset() {
+        let (messages, _system) = apply_builtin_experiment(
+            &BuiltInStructuralExperiment::ChainOfDraft,
+            vec![serde_json::json!({
+                "role": "user",
+                "content": "what is 17 * 23?"
+            })],
+            None,
+        );
+        let content = messages[0]["content"].as_str().expect("content");
+        assert!(content.starts_with("what is 17 * 23?"));
+        assert!(content.contains("<draft>"));
+        assert!(content.contains("scratch draft"));
     }
 
     #[test]

--- a/crates/harn-vm/src/llm/structured_envelope.rs
+++ b/crates/harn-vm/src/llm/structured_envelope.rs
@@ -141,11 +141,20 @@ fn apply_prompt_mode_structured_transport(args: &mut [VmValue]) {
 fn prompt_with_schema_contract(prompt: &str, schema: &VmValue) -> String {
     let schema_json = serde_json::to_string_pretty(&vm_value_to_json(schema))
         .unwrap_or_else(|_| schema.display());
-    format!(
-        "{prompt}\n\n\
-Structured output transport is unavailable for this model. Return ONLY JSON that conforms to this JSON Schema. \
-Do not include prose, markdown fences, or commentary.\n\nJSON Schema:\n{schema_json}"
+    let mut bindings = BTreeMap::new();
+    bindings.insert(
+        "prompt".to_string(),
+        VmValue::String(Rc::from(prompt.to_string())),
+    );
+    bindings.insert(
+        "schema_json".to_string(),
+        VmValue::String(Rc::from(schema_json)),
+    );
+    crate::stdlib::template::render_stdlib_prompt_asset(
+        "llm/prompts/structured_envelope_schema_contract.harn.prompt",
+        Some(&bindings),
     )
+    .expect("structured_envelope_schema_contract.harn.prompt is embedded and must render")
 }
 
 fn classify_main_failure(outcome: &SchemaLoopOutcome) -> EnvelopeFailureKind {
@@ -238,16 +247,20 @@ fn build_repair_prompt(raw_text: &str, errors: &[String]) -> String {
     } else {
         errors.join("; ")
     };
-    let mut s = String::from(
-        "The following text was supposed to be JSON conforming to the configured schema, but it failed validation. \
-Repair it and respond with ONLY the corrected JSON — no prose, no markdown fences, no commentary.\n\n",
+    let mut bindings = BTreeMap::new();
+    bindings.insert(
+        "errors_line".to_string(),
+        VmValue::String(Rc::from(errors_line)),
     );
-    s.push_str("Validation errors: ");
-    s.push_str(&errors_line);
-    s.push_str("\n\nOriginal text:\n");
-    s.push_str(raw_text);
-    s.push_str("\n\nReply with valid JSON only.");
-    s
+    bindings.insert(
+        "raw_text".to_string(),
+        VmValue::String(Rc::from(raw_text.to_string())),
+    );
+    crate::stdlib::template::render_stdlib_prompt_asset(
+        "llm/prompts/structured_envelope_repair.harn.prompt",
+        Some(&bindings),
+    )
+    .expect("structured_envelope_repair.harn.prompt is embedded and must render")
 }
 
 fn merge_repair_options(

--- a/scripts/check_rust_prompt_prose.py
+++ b/scripts/check_rust_prompt_prose.py
@@ -13,8 +13,11 @@ from pathlib import Path
 
 
 PROTECTED_PATHS = [
-    Path("crates/harn-vm/src/llm/agent"),
     Path("crates/harn-vm/src/llm/tools"),
+    Path("crates/harn-vm/src/llm/conversation.rs"),
+    Path("crates/harn-vm/src/llm/structural_experiments.rs"),
+    Path("crates/harn-vm/src/llm/schema_recover.rs"),
+    Path("crates/harn-vm/src/llm/structured_envelope.rs"),
     Path("crates/harn-vm/src/orchestration/workflow.rs"),
     Path("crates/harn-vm/src/orchestration/artifacts.rs"),
     Path("crates/harn-vm/src/orchestration/compaction.rs"),


### PR DESCRIPTION
Closes #1199.

## Summary

The audit `rg -nP "\".{200,}\"" crates/harn-vm/src/{llm,orchestration}` caught five model-facing prompt strings the prior cutover (#1234, #1224, #1225, #1226) had missed. Each one now renders from a `.harn.prompt` asset under `crates/harn-stdlib/src/stdlib/llm/prompts/`:

- `llm/conversation.rs::transcript_summarize` — default summarize prompt + user-message body wrapper
- `llm/structural_experiments.rs::ChainOfDraft` — `<draft>` scaffold prefix appended to the user message
- `llm/schema_recover.rs::build_repair_prompt` — schema-recover repair instruction
- `llm/structured_envelope.rs::prompt_with_schema_contract` — JSON-mode unavailable contract
- `llm/structured_envelope.rs::build_repair_prompt` — structured-envelope repair instruction

Also extends `scripts/check_rust_prompt_prose.py` to cover those four files (and drops the stale `llm/agent` reference removed in #1200) so the ratchet reliably guards against regressions in the migrated paths.

## Audit verification per the issue's acceptance criteria

```
$ rg -nP "\".{200,}\"" crates/harn-vm/src/llm crates/harn-vm/src/orchestration
crates/harn-vm/src/orchestration/policy/types.rs:78:  # internal warning to policy authors, not LLM-facing
crates/harn-vm/src/orchestration/tests.rs:613-614:    # test fixture JSON
crates/harn-vm/src/llm/tools/tests/heredoc_and_messages.rs:514:  # test fixture JSON
```

Items 3-5 of the issue's "Concrete work" section: confirmed `compaction.rs::DEFAULT_COMPACTION_PROMPT` already routes through the prompt-asset path (#1234), `orchestration/artifacts.rs` workflow guidance already renders from `std/workflow/prompts`, and `llm/api/completion.rs` FIM-fallback was already migrated to `llm/prompts/completion_fallback_*.harn.prompt`.

## Test plan

- [x] `cargo test -p harn-vm --lib` (1662 passed)
- [x] `cargo test -p harn-stdlib --lib` (8 passed)
- [x] `cargo run --bin harn -- test conformance` (776 passed)
- [x] `python3 scripts/check_rust_prompt_prose.py --self-test && python3 scripts/check_rust_prompt_prose.py`
- [x] Added `chain_of_draft_appends_scaffold_from_asset` unit test that exercises the new asset path

🤖 Generated with [Claude Code](https://claude.com/claude-code)