### PR TITLE
[vm] Wire per-agent permissions through Harn agent loop (#1239)

### DIFF
--- a/conformance/errors/semantic/tool_arg_constraint_rejection.harn
+++ b/conformance/errors/semantic/tool_arg_constraint_rejection.harn
@@ -1,6 +1,3 @@
-/**
- * @xfail: agent_loop `policy.tool_arg_constraints` not yet honored by Harn-driven loop — tracked in burin-labs/harn#1236
- */
 fn list_tools() {
   var tools = tool_registry()
   tools = tool_define(

--- a/conformance/tests/agents/agent_worker_policy.harn
+++ b/conformance/tests/agents/agent_worker_policy.harn
@@ -1,6 +1,3 @@
-/**
- * @xfail: per-agent permissions + sub-agent intersection not yet wired — tracked in burin-labs/harn#1239
- */
 fn write_tools() {
   var tools = tool_registry()
   tools = tool_define(

--- a/conformance/tests/agents/per_agent_permissions_dynamic.harn
+++ b/conformance/tests/agents/per_agent_permissions_dynamic.harn
@@ -1,6 +1,3 @@
-/**
- * @xfail: per-agent permissions + sub-agent intersection not yet wired — tracked in burin-labs/harn#1239
- */
 fn note_tools() {
   var tools = tool_registry()
   tools = tool_define(

--- a/conformance/tests/agents/per_agent_permissions_escalation.harn
+++ b/conformance/tests/agents/per_agent_permissions_escalation.harn
@@ -1,6 +1,3 @@
-/**
- * @xfail: per-agent permissions + sub-agent intersection not yet wired — tracked in burin-labs/harn#1239
- */
 fn write_tools() {
   var tools = tool_registry()
   tools = tool_define(

--- a/conformance/tests/agents/spawn_agent_permissions.harn
+++ b/conformance/tests/agents/spawn_agent_permissions.harn
@@ -1,4 +1,3 @@
-// @xfail: per-agent permissions + sub-agent intersection not yet wired — tracked in burin-labs/harn#1239
 import "std/agents"
 
 fn write_tools() {

--- a/conformance/tests/agents/sub_agent_permissions_intersection.harn
+++ b/conformance/tests/agents/sub_agent_permissions_intersection.harn
@@ -1,6 +1,3 @@
-/**
- * @xfail: per-agent permissions + sub-agent intersection not yet wired — tracked in burin-labs/harn#1239
- */
 fn write_tools() {
   var tools = tool_registry()
   tools = tool_define(

--- a/conformance/tests/integration/approval_policy_auto_deny.harn
+++ b/conformance/tests/integration/approval_policy_auto_deny.harn
@@ -1,6 +1,3 @@
-/**
- * @xfail: per-agent permissions + sub-agent intersection not yet wired — tracked in burin-labs/harn#1239
- */
 fn write_tools() {
   var tools = tool_registry()
   tools = tool_define(

--- a/crates/harn-vm/src/agent_sessions.rs
+++ b/crates/harn-vm/src/agent_sessions.rs
@@ -449,14 +449,17 @@ pub fn inject_message(id: &str, message: VmValue) -> Result<(), String> {
             Some(VmValue::List(list)) => list.iter().cloned().collect(),
             _ => Vec::new(),
         };
-        messages.push(VmValue::Dict(Rc::new(msg_dict)));
+        let mut events: Vec<VmValue> = match dict.get("events") {
+            Some(VmValue::List(list)) => list.iter().cloned().collect(),
+            _ => crate::llm::helpers::transcript_events_from_messages(&messages),
+        };
+        let new_message = VmValue::Dict(Rc::new(msg_dict));
+        events.push(crate::llm::helpers::transcript_event_from_message(
+            &new_message,
+        ));
+        messages.push(new_message);
         let mut next = dict;
-        next.insert(
-            "events".to_string(),
-            VmValue::List(Rc::new(
-                crate::llm::helpers::transcript_events_from_messages(&messages),
-            )),
-        );
+        next.insert("events".to_string(), VmValue::List(Rc::new(events)));
         next.insert("messages".to_string(), VmValue::List(Rc::new(messages)));
         state.transcript = VmValue::Dict(Rc::new(next));
         state.last_accessed = Instant::now();

--- a/crates/harn-vm/src/llm/agent_session_host.rs
+++ b/crates/harn-vm/src/llm/agent_session_host.rs
@@ -10,11 +10,16 @@ use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::rc::Rc;
 
+use crate::orchestration::{
+    pop_approval_policy, pop_execution_policy, push_approval_policy, push_command_policy,
+    push_execution_policy, CapabilityPolicy, ToolApprovalPolicy,
+};
 use crate::stdlib::registration::{register_builtin_group, BuiltinGroup, SyncBuiltin};
 use crate::value::{VmError, VmValue};
 use crate::vm::{Vm, VmBuiltinArity, VmBuiltinMetadata};
 
 use super::cost::calculate_cost_for_provider;
+use super::permissions;
 
 const HOST_SESSION_INIT: &str = "__host_agent_session_init";
 const HOST_SESSION_FINALIZE: &str = "__host_agent_session_finalize";
@@ -46,8 +51,8 @@ struct AgentHostSession {
     output_tokens: i64,
     active_skills: Vec<String>,
     tool_calls: Vec<serde_json::Value>,
-    successful_tools: Vec<serde_json::Value>,
-    rejected_tools: Vec<serde_json::Value>,
+    successful_tools: Vec<String>,
+    rejected_tools: Vec<String>,
     tool_mode: String,
     started_at: String,
     /// Iteration cap from `agent_loop(options.max_iterations)`. Captured
@@ -60,6 +65,20 @@ struct AgentHostSession {
     /// the last call truncated due to its `max_tokens` parameter) and
     /// `refusal` (Anthropic refusal stop_reason).
     last_llm_stop_reason: Option<String>,
+    installed_policies: InstalledPolicies,
+}
+
+/// Tracks which scoped policy stacks were pushed during session init so
+/// finalize can pop them in reverse order. The agent loop honours
+/// per-agent ceilings by intersecting outer policies with the requested
+/// per-agent ones before pushing — so child sub-agents never widen
+/// permissions beyond their parents.
+#[derive(Default)]
+struct InstalledPolicies {
+    pushed_execution: bool,
+    pushed_approval: bool,
+    pushed_command: bool,
+    pushed_permissions: bool,
 }
 
 thread_local! {
@@ -149,6 +168,8 @@ async fn host_agent_session_init(args: Vec<VmValue>) -> Result<VmValue, VmError>
         .unwrap_or(20)
         .max(0);
 
+    let installed_policies = install_session_policies(&opts_map)?;
+
     let session = AgentHostSession {
         session_id: resolved.clone(),
         task: message.clone(),
@@ -164,6 +185,7 @@ async fn host_agent_session_init(args: Vec<VmValue>) -> Result<VmValue, VmError>
         started_at: now_id(),
         max_iterations,
         last_llm_stop_reason: None,
+        installed_policies,
     };
 
     AGENT_HOST_SESSIONS.with(|sessions| {
@@ -212,6 +234,10 @@ async fn host_agent_session_finalize(args: Vec<VmValue>) -> Result<VmValue, VmEr
                 "{HOST_SESSION_FINALIZE}: unknown session `{session_id}`"
             ))
         })?;
+    // Unwind the per-agent policy stacks pushed in init, in reverse
+    // order — outer scopes (workflow stage, parent agent) survive intact.
+    release_session_policies(&session.installed_policies);
+    permissions::clear_session_grants(&session_id);
     // Pair with the push in init so subsequent loops see the right stack.
     crate::agent_sessions::pop_current_session();
     // Fire registered session-end hooks (e.g. cancelling orphaned
@@ -384,22 +410,24 @@ fn host_agent_session_record_tool_results_builtin(
     let mut successful = Vec::new();
     let mut rejected = Vec::new();
     for result in list_items(&results_value).iter() {
-        let name = dict_get(result, "name")
+        let name = dict_get(result, "tool_name")
+            .or_else(|| dict_get(result, "name"))
             .map(|v| v.display())
             .unwrap_or_default();
         let observation = dict_get(result, "observation")
+            .or_else(|| dict_get(result, "rendered_result"))
             .or_else(|| dict_get(result, "output"))
             .or_else(|| dict_get(result, "content"))
             .map(|v| v.display())
             .unwrap_or_default();
-        let success = dict_get(result, "success")
+        let ok = dict_get(result, "ok")
+            .or_else(|| dict_get(result, "success"))
             .map(|v| matches!(v, VmValue::Bool(true)))
             .unwrap_or(true);
-        let summary = serde_json::json!({"name": name, "observation": observation});
-        if success {
-            successful.push(summary);
+        if ok {
+            successful.push(name.clone());
         } else {
-            rejected.push(summary);
+            rejected.push(name.clone());
         }
         let mut msg = BTreeMap::new();
         msg.insert("role".to_string(), VmValue::String(Rc::from("tool")));
@@ -592,6 +620,109 @@ fn host_agent_build_turn_system_builtin(
         }
     }
     Ok(VmValue::String(Rc::from(parts.join("\n\n"))))
+}
+
+/// Install per-agent execution / approval / command / dynamic permission
+/// policies onto the thread-local stacks for the lifetime of this agent
+/// session. Each scope intersects with the currently-active outer policy
+/// (when any) so a sub-agent cannot widen its parent's ceiling — only
+/// narrow it. Dynamic permissions are stack-checked, so push as-is and
+/// rely on the dispatch path to honour every active scope.
+///
+/// On any failure the partially-pushed stacks are unwound before
+/// returning, so the caller never has to worry about leaked policy
+/// state.
+fn install_session_policies(
+    opts_map: &BTreeMap<String, VmValue>,
+) -> Result<InstalledPolicies, VmError> {
+    let mut installed = InstalledPolicies::default();
+    match install_session_policies_inner(opts_map, &mut installed) {
+        Ok(()) => Ok(installed),
+        Err(error) => {
+            release_session_policies(&installed);
+            Err(error)
+        }
+    }
+}
+
+fn install_session_policies_inner(
+    opts_map: &BTreeMap<String, VmValue>,
+    installed: &mut InstalledPolicies,
+) -> Result<(), VmError> {
+    if let Some(requested) = parse_capability_policy(opts_map.get("policy"))? {
+        let effective = match crate::orchestration::current_execution_policy() {
+            Some(outer) => outer.intersect(&requested).map_err(VmError::Runtime)?,
+            None => requested,
+        };
+        push_execution_policy(effective);
+        installed.pushed_execution = true;
+    }
+
+    if let Some(requested) = parse_approval_policy(opts_map.get("approval_policy"))? {
+        let effective = match crate::orchestration::current_approval_policy() {
+            Some(outer) => outer.intersect(&requested),
+            None => requested,
+        };
+        push_approval_policy(effective);
+        installed.pushed_approval = true;
+    }
+
+    if let Some(policy) = crate::orchestration::parse_command_policy_value(
+        opts_map.get("command_policy"),
+        "agent_loop.command_policy",
+    )? {
+        push_command_policy(policy);
+        installed.pushed_command = true;
+    }
+
+    if let Some(permissions) = permissions::parse_dynamic_permission_policy(
+        opts_map.get("permissions"),
+        "agent_loop.permissions",
+    )? {
+        permissions::push_dynamic_permission_policy(permissions);
+        installed.pushed_permissions = true;
+    }
+
+    Ok(())
+}
+
+fn release_session_policies(installed: &InstalledPolicies) {
+    if installed.pushed_permissions {
+        permissions::pop_dynamic_permission_policy();
+    }
+    if installed.pushed_command {
+        crate::orchestration::pop_command_policy();
+    }
+    if installed.pushed_approval {
+        pop_approval_policy();
+    }
+    if installed.pushed_execution {
+        pop_execution_policy();
+    }
+}
+
+fn parse_capability_policy(value: Option<&VmValue>) -> Result<Option<CapabilityPolicy>, VmError> {
+    let Some(value) = value else { return Ok(None) };
+    if matches!(value, VmValue::Nil) {
+        return Ok(None);
+    }
+    serde_json::from_value::<CapabilityPolicy>(crate::llm::vm_value_to_json(value))
+        .map(Some)
+        .map_err(|error| VmError::Runtime(format!("agent_loop.policy: invalid policy: {error}")))
+}
+
+fn parse_approval_policy(value: Option<&VmValue>) -> Result<Option<ToolApprovalPolicy>, VmError> {
+    let Some(value) = value else { return Ok(None) };
+    if matches!(value, VmValue::Nil) {
+        return Ok(None);
+    }
+    serde_json::from_value::<ToolApprovalPolicy>(crate::llm::vm_value_to_json(value))
+        .map(Some)
+        .map_err(|error| {
+            VmError::Runtime(format!(
+                "agent_loop.approval_policy: invalid policy: {error}"
+            ))
+        })
 }
 
 const HOST_SESSION_PRIMITIVES_SYNC: &[SyncBuiltin] = &[

--- a/crates/harn-vm/src/llm/helpers/mod.rs
+++ b/crates/harn-vm/src/llm/helpers/mod.rs
@@ -23,8 +23,8 @@ pub(crate) use provider::{
 pub(crate) use transcript::{
     is_transcript_value, new_transcript_with, new_transcript_with_events,
     normalize_transcript_asset, transcript_asset_list, transcript_event,
-    transcript_events_from_messages, transcript_id, transcript_message_list,
-    transcript_summary_text, transcript_to_vm_with_events,
+    transcript_event_from_message, transcript_events_from_messages, transcript_id,
+    transcript_message_list, transcript_summary_text, transcript_to_vm_with_events,
 };
 
 pub(super) const TRANSCRIPT_TYPE: &str = "transcript";

--- a/crates/harn-vm/src/llm/helpers/transcript.rs
+++ b/crates/harn-vm/src/llm/helpers/transcript.rs
@@ -103,7 +103,7 @@ pub(crate) fn new_transcript_with_events(
     VmValue::Dict(Rc::new(transcript))
 }
 
-fn transcript_event_from_message(message: &VmValue) -> VmValue {
+pub(crate) fn transcript_event_from_message(message: &VmValue) -> VmValue {
     let dict = message.as_dict().cloned().unwrap_or_default();
     let role = dict
         .get("role")

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -1047,6 +1047,26 @@ fn agent_primitive_call_json(args: &[VmValue]) -> Result<serde_json::Value, VmEr
     }
 }
 
+/// Append a `PermissionGrant` / `PermissionDeny` / `PermissionEscalation`
+/// event to the live transcript for the named session, when one exists.
+/// Silent no-op for sessions that haven't been opened (e.g. raw
+/// dispatcher calls outside an agent loop).
+fn emit_permission_event(
+    session_id: &str,
+    kind: &str,
+    tool_name: &str,
+    tool_args: &serde_json::Value,
+    reason: &str,
+    escalated: bool,
+) {
+    if !crate::agent_sessions::exists(session_id) {
+        return;
+    }
+    let event =
+        permissions::permission_transcript_event(kind, tool_name, tool_args, reason, escalated);
+    let _ = crate::agent_sessions::append_event(session_id, event);
+}
+
 fn agent_primitive_denied_tool(
     tool_name: &str,
     tool_args: &serde_json::Value,
@@ -1211,26 +1231,73 @@ async fn host_agent_dispatch_tool_call_impl(args: Vec<VmValue>) -> Result<VmValu
             )
         })
     {
+        let reason = error.to_string();
+        emit_permission_event(
+            &session_id,
+            "PermissionDeny",
+            &tool_name,
+            &tool_args,
+            &reason,
+            false,
+        );
         return Ok(json_to_vm_value(&agent_primitive_denied_tool(
             &tool_name,
             &tool_args,
-            error.to_string(),
+            reason,
             crate::agent_events::ToolCallErrorCategory::PermissionDenied,
         )));
     }
 
-    let mut permission_grants = std::collections::BTreeSet::new();
-    if let Some(permission) = permissions::check_dynamic_permission(
+    let mut permission_grants = permissions::take_session_grants(&session_id);
+    let permission_outcome = permissions::check_dynamic_permission(
         &mut permission_grants,
         &tool_name,
         &tool_args,
         &session_id,
     )
-    .await?
-    {
+    .await?;
+    permissions::store_session_grants(&session_id, permission_grants);
+    if let Some(permission) = permission_outcome {
         match permission {
-            permissions::PermissionCheck::Granted => {}
-            permissions::PermissionCheck::Denied { reason, .. } => {
+            permissions::PermissionCheck::Granted { reason, escalated } => {
+                if escalated {
+                    emit_permission_event(
+                        &session_id,
+                        "PermissionEscalation",
+                        &tool_name,
+                        &tool_args,
+                        &reason,
+                        true,
+                    );
+                }
+                emit_permission_event(
+                    &session_id,
+                    "PermissionGrant",
+                    &tool_name,
+                    &tool_args,
+                    &reason,
+                    escalated,
+                );
+            }
+            permissions::PermissionCheck::Denied { reason, escalated } => {
+                if escalated {
+                    emit_permission_event(
+                        &session_id,
+                        "PermissionEscalation",
+                        &tool_name,
+                        &tool_args,
+                        &reason,
+                        true,
+                    );
+                }
+                emit_permission_event(
+                    &session_id,
+                    "PermissionDeny",
+                    &tool_name,
+                    &tool_args,
+                    &reason,
+                    escalated,
+                );
                 return Ok(json_to_vm_value(&agent_primitive_denied_tool(
                     &tool_name,
                     &tool_args,
@@ -1247,6 +1314,14 @@ async fn host_agent_dispatch_tool_call_impl(args: Vec<VmValue>) -> Result<VmValu
     match approval {
         None | Some(crate::orchestration::ToolApprovalDecision::AutoApproved) => {}
         Some(crate::orchestration::ToolApprovalDecision::AutoDenied { reason }) => {
+            emit_permission_event(
+                &session_id,
+                "PermissionDeny",
+                &tool_name,
+                &tool_args,
+                &reason,
+                false,
+            );
             return Ok(json_to_vm_value(&agent_primitive_denied_tool(
                 &tool_name,
                 &tool_args,
@@ -1256,10 +1331,19 @@ async fn host_agent_dispatch_tool_call_impl(args: Vec<VmValue>) -> Result<VmValu
         }
         Some(crate::orchestration::ToolApprovalDecision::RequiresHostApproval) => {
             let Some(bridge) = bridge.as_ref() else {
+                let reason = "approval required but no host bridge is available";
+                emit_permission_event(
+                    &session_id,
+                    "PermissionDeny",
+                    &tool_name,
+                    &tool_args,
+                    reason,
+                    false,
+                );
                 return Ok(json_to_vm_value(&agent_primitive_denied_tool(
                     &tool_name,
                     &tool_args,
-                    "approval required but no host bridge is available",
+                    reason,
                     crate::agent_events::ToolCallErrorCategory::PermissionDenied,
                 )));
             };
@@ -1309,11 +1393,27 @@ async fn host_agent_dispatch_tool_call_impl(args: Vec<VmValue>) -> Result<VmValu
                             tool_args = new_args.clone();
                         }
                         approval_status = Some("host_granted");
+                        emit_permission_event(
+                            &session_id,
+                            "PermissionGrant",
+                            &tool_name,
+                            &tool_args,
+                            "host approved tool call",
+                            true,
+                        );
                     } else {
                         let reason = response
                             .get("reason")
                             .and_then(|value| value.as_str())
                             .unwrap_or("host did not grant approval");
+                        emit_permission_event(
+                            &session_id,
+                            "PermissionDeny",
+                            &tool_name,
+                            &tool_args,
+                            reason,
+                            true,
+                        );
                         return Ok(json_to_vm_value(&agent_primitive_denied_tool(
                             &tool_name,
                             &tool_args,
@@ -1323,10 +1423,20 @@ async fn host_agent_dispatch_tool_call_impl(args: Vec<VmValue>) -> Result<VmValu
                     }
                 }
                 Err(_) => {
+                    let reason =
+                        "approval request failed or host does not implement session/request_permission";
+                    emit_permission_event(
+                        &session_id,
+                        "PermissionDeny",
+                        &tool_name,
+                        &tool_args,
+                        reason,
+                        true,
+                    );
                     return Ok(json_to_vm_value(&agent_primitive_denied_tool(
                         &tool_name,
                         &tool_args,
-                        "approval request failed or host does not implement session/request_permission",
+                        reason,
                         crate::agent_events::ToolCallErrorCategory::PermissionDenied,
                     )));
                 }

--- a/crates/harn-vm/src/llm/permissions.rs
+++ b/crates/harn-vm/src/llm/permissions.rs
@@ -33,12 +33,62 @@ enum PermissionMatcher {
 }
 
 pub(crate) enum PermissionCheck {
-    Granted,
+    Granted { reason: String, escalated: bool },
     Denied { reason: String, escalated: bool },
+}
+
+/// Build the transcript event that callers append to a session when a
+/// dynamic permission rule grants, denies, or escalates a tool call.
+pub(crate) fn permission_transcript_event(
+    kind: &str,
+    tool_name: &str,
+    args: &serde_json::Value,
+    reason: &str,
+    escalated: bool,
+) -> VmValue {
+    crate::llm::helpers::transcript_event(
+        kind,
+        "tool",
+        "internal",
+        reason,
+        Some(serde_json::json!({
+            "tool_name": tool_name,
+            "arguments": args,
+            "reason": reason,
+            "escalated": escalated,
+        })),
+    )
 }
 
 thread_local! {
     static DYNAMIC_PERMISSION_STACK: RefCell<Vec<DynamicPermissionPolicy>> = const { RefCell::new(Vec::new()) };
+    static SESSION_PERMISSION_GRANTS: RefCell<BTreeMap<String, BTreeSet<String>>> = const {
+        RefCell::new(BTreeMap::new())
+    };
+}
+
+/// Pull the per-session "session"-scoped grant cache out of the store
+/// for the duration of a single dispatch. Pair with [`store_session_grants`].
+/// Caching across dispatch calls within a session ensures an
+/// `on_escalation` callback returning `{grant: "session"}` only fires
+/// once per session.
+pub(crate) fn take_session_grants(session_id: &str) -> BTreeSet<String> {
+    SESSION_PERMISSION_GRANTS
+        .with(|store| store.borrow_mut().remove(session_id).unwrap_or_default())
+}
+
+pub(crate) fn store_session_grants(session_id: &str, grants: BTreeSet<String>) {
+    SESSION_PERMISSION_GRANTS.with(|store| {
+        store.borrow_mut().insert(session_id.to_string(), grants);
+    });
+}
+
+/// Drop the session-scoped permission grant cache for a session, e.g. on
+/// agent loop finalize.
+pub(crate) fn clear_session_grants(session_id: &str) {
+    SESSION_PERMISSION_GRANTS.with(|store| {
+        store.borrow_mut().remove(session_id);
+    });
 }
 
 pub(crate) fn push_dynamic_permission_policy(policy: DynamicPermissionPolicy) {
@@ -212,7 +262,7 @@ pub(crate) async fn check_dynamic_permission(
             PermissionCheck::Denied { reason, escalated } => {
                 return Ok(Some(PermissionCheck::Denied { reason, escalated }));
             }
-            grant @ PermissionCheck::Granted => {
+            grant @ PermissionCheck::Granted { .. } => {
                 grant_result = Some(grant);
             }
         }
@@ -230,7 +280,15 @@ async fn check_one_dynamic_permission(
 ) -> Result<PermissionCheck, VmError> {
     let grant_key = session_grant_key(scope_index, tool_name, args);
     if session_grants.contains(&grant_key) {
-        return Ok(PermissionCheck::Granted);
+        // Cached session grant: the escalation callback already fired
+        // (and was logged) the first time; subsequent calls only emit a
+        // PermissionGrant.
+        return Ok(PermissionCheck::Granted {
+            reason: format!(
+                "permission granted by prior session-scoped escalation for tool '{tool_name}'"
+            ),
+            escalated: false,
+        });
     }
 
     let denied = first_matching_rule(&policy.deny, tool_name, args).await?;
@@ -252,7 +310,14 @@ async fn check_one_dynamic_permission(
     };
 
     let Some(reason) = denial_reason else {
-        return Ok(PermissionCheck::Granted);
+        let allow_reason = match allowed {
+            Some(Some(pattern)) => format!("permission granted by allow rule: {pattern}"),
+            Some(None) | None => format!("permission granted for tool '{tool_name}'"),
+        };
+        return Ok(PermissionCheck::Granted {
+            reason: allow_reason,
+            escalated: false,
+        });
     };
 
     let Some(on_escalation) = policy.on_escalation.as_ref() else {
@@ -269,7 +334,11 @@ async fn check_one_dynamic_permission(
         if matches!(response.scope, GrantScope::Session) {
             session_grants.insert(grant_key);
         }
-        Ok(PermissionCheck::Granted)
+        let grant_reason = response.reason.unwrap_or(reason);
+        Ok(PermissionCheck::Granted {
+            reason: grant_reason,
+            escalated: true,
+        })
     } else {
         Ok(PermissionCheck::Denied {
             reason: response

--- a/crates/harn-vm/src/stdlib/agents_sub_agent.rs
+++ b/crates/harn-vm/src/stdlib/agents_sub_agent.rs
@@ -344,32 +344,20 @@ fn permission_denied_from_transcript(transcript: &VmValue) -> Option<(String, St
             _ => None,
         })?;
     for event in events.iter().rev() {
-        let dict = event.as_dict()?;
-        let rejected = dict
-            .get("metadata")
-            .and_then(|value| value.as_dict())
-            .and_then(|metadata| metadata.get("rejected"))
-            .is_some_and(|value| value.is_truthy());
-        if !rejected {
+        let Some(dict) = event.as_dict() else {
             continue;
-        }
-        let text = dict
-            .get("text")
-            .map(|value| value.display())
-            .unwrap_or_default();
-        let json = crate::stdlib::json::extract_json_from_text(&text);
-        let payload = serde_json::from_str::<serde_json::Value>(&json).ok()?;
-        if payload.get("error").and_then(|value| value.as_str()) == Some("permission_denied") {
-            let tool = payload
-                .get("tool")
-                .and_then(|value| value.as_str())
-                .unwrap_or_default()
-                .to_string();
-            let reason = payload
-                .get("reason")
-                .and_then(|value| value.as_str())
-                .unwrap_or("permission denied")
-                .to_string();
+        };
+        let kind = dict.get("kind").map(VmValue::display).unwrap_or_default();
+        if kind == "PermissionDeny" {
+            let metadata = dict.get("metadata").and_then(|v| v.as_dict());
+            let tool = metadata
+                .and_then(|m| m.get("tool_name"))
+                .map(VmValue::display)
+                .unwrap_or_default();
+            let reason = metadata
+                .and_then(|m| m.get("reason"))
+                .map(VmValue::display)
+                .unwrap_or_else(|| "permission denied".to_string());
             return Some((tool, reason));
         }
     }


### PR DESCRIPTION
## Summary

Closes #1239. The Harn-driven agent loop (#1234) dropped per-agent execution policies, approval policies, command policies, and dynamic permissions. This PR restores them by installing each onto the existing thread-local stacks during `__host_agent_session_init` and unwinding on finalize.

- **Intersection on push** — execution and approval policies intersect with the currently-active outer scope, so sub-agents can only narrow (never widen) their parent's ceiling. Dynamic permissions are stack-checked at dispatch time, so we just push and rely on the stack walk for natural intersection.
- **Partial-install safety** — if any policy fails to parse/intersect, previously-pushed scopes unwind before the error returns.
- **Session-scoped grants** persist across dispatch calls, keyed by `session_id`. An `on_escalation` callback returning `{grant: "session"}` now only fires its escalation once per session.
- **Permission events** — dispatch emits `PermissionGrant` / `PermissionDeny` / `PermissionEscalation` transcript events for capability-ceiling, dynamic-permission, and approval-policy decisions.
- **`inject_message`** switches to append-only event semantics, so direct `append_event` calls (the new permission events) survive subsequent message injection.
- **`record_tool_results`** reads the new dispatch result shape (`tool_name`, `ok`) and records just tool names in `successful` / `rejected`, matching the legacy contract that conformance tests assert against.
- **`permission_denied_from_transcript`** keys off `kind == "PermissionDeny"` instead of a metadata-rejected flag.

Removes `@xfail` markers from eight owned conformance tests (all now passing): `per_agent_permissions_dynamic`, `per_agent_permissions_escalation`, `spawn_agent_permissions`, `sub_agent_permissions_intersection`, `agent_worker_policy`, `approval_policy_auto_deny`, `tool_arg_constraint_rejection`.

## Test plan

- [x] `cargo run --bin harn -- test conformance --filter "per_agent_permissions|spawn_agent_permissions|sub_agent_permissions|approval_policy_auto_deny|agent_worker_policy|tool_arg_constraint_rejection"` (7/7 pass)
- [x] `cargo run --bin harn -- test conformance` (783 passed, 0 failed, 38 skipped)
- [x] `cargo nextest run -p harn-vm` (1696 passed, 4 skipped)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --all -- --check` (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)