### PR TITLE
Emit pump metrics lifecycle events

### DIFF
--- a/crates/harn-cli/src/commands/orchestrator/harness.rs
+++ b/crates/harn-cli/src/commands/orchestrator/harness.rs
@@ -851,6 +851,8 @@ struct PumpHandle {
 impl PumpHandle {
     async fn drain(
         self,
+        log: &Arc<AnyEventLog>,
+        topic_name: &str,
         up_to: u64,
         config: DrainConfig,
         overall_deadline: tokio::time::Instant,
@@ -864,6 +866,17 @@ impl PumpHandle {
             config,
             deadline: drain_deadline,
         }));
+        append_pump_lifecycle_event(
+            log,
+            "pump_drain_requested",
+            json!({
+                "topic": topic_name,
+                "up_to": up_to,
+                "max_items": config.max_items,
+                "deadline_secs": config.deadline.as_secs(),
+            }),
+        )
+        .await?;
         if let Some(path) = pump_test_draining_file() {
             mark_test_file(&path).await?;
         }
@@ -986,7 +999,6 @@ fn spawn_inbox_pump(
     let inbox_task_release_file = inbox_task_test_release_file();
     let (mode_tx, mut mode_rx) = watch::channel(PumpMode::Running);
     let join = tokio::task::spawn_local(async move {
-        metrics_registry.set_orchestrator_pump_outstanding(topic.as_str(), 0);
         let start_from = event_log
             .consumer_cursor(&topic, &consumer)
             .await
@@ -1004,7 +1016,7 @@ fn spawn_inbox_pump(
             last_seen: start_from.unwrap_or(0),
             processed: 0,
         };
-        record_pump_backlog(&metrics_registry, &event_log, &topic, stats.last_seen).await;
+        record_pump_metrics(&metrics_registry, &event_log, &topic, stats.last_seen, 0).await?;
         let mut drain_progress = None;
         let mut tasks = JoinSet::new();
 
@@ -1050,8 +1062,14 @@ fn spawn_inbox_pump(
                 joined = tasks.join_next(), if !tasks.is_empty() => {
                     match joined {
                         Some(Ok(())) => {
-                            metrics_registry
-                                .set_orchestrator_pump_outstanding(topic.as_str(), tasks.len());
+                            record_pump_metrics(
+                                &metrics_registry,
+                                &event_log,
+                                &topic,
+                                stats.last_seen,
+                                tasks.len(),
+                            )
+                            .await?;
                         }
                         Some(Err(error)) => {
                             return Err(format!("inbox dispatch task join failed: {error}").into());
@@ -1060,7 +1078,7 @@ fn spawn_inbox_pump(
                     }
                 }
                 _ = tokio::time::sleep(Duration::from_millis(25)), if tasks.len() >= pump_config.max_outstanding => {
-                    record_pump_backlog(&metrics_registry, &event_log, &topic, stats.last_seen).await;
+                    record_pump_metrics(&metrics_registry, &event_log, &topic, stats.last_seen, tasks.len()).await?;
                 }
                 received = stream.next(), if tasks.len() < pump_config.max_outstanding => {
                     let Some(received) = received else {
@@ -1074,7 +1092,7 @@ fn spawn_inbox_pump(
                             .ack(&topic, &consumer, event_id)
                             .await
                             .map_err(|error| format!("failed to ack topic pump cursor for {topic}: {error}"))?;
-                        record_pump_backlog(&metrics_registry, &event_log, &topic, stats.last_seen).await;
+                        record_pump_metrics(&metrics_registry, &event_log, &topic, stats.last_seen, tasks.len()).await?;
                         continue;
                     }
                     append_pump_lifecycle_event(
@@ -1187,15 +1205,21 @@ fn spawn_inbox_pump(
                         }),
                     )
                     .await?;
-                    metrics_registry.set_orchestrator_pump_outstanding(topic.as_str(), tasks.len());
-                    record_pump_backlog(&metrics_registry, &event_log, &topic, stats.last_seen).await;
+                    record_pump_metrics(&metrics_registry, &event_log, &topic, stats.last_seen, tasks.len()).await?;
                 }
             }
         }
 
         while let Some(joined) = tasks.join_next().await {
             joined.map_err(|error| format!("inbox dispatch task join failed: {error}"))?;
-            metrics_registry.set_orchestrator_pump_outstanding(topic.as_str(), tasks.len());
+            record_pump_metrics(
+                &metrics_registry,
+                &event_log,
+                &topic,
+                stats.last_seen,
+                tasks.len(),
+            )
+            .await?;
         }
 
         Ok(drain_progress
@@ -1315,7 +1339,6 @@ where
     let test_waiting_file = pump_test_waiting_file();
     let (mode_tx, mut mode_rx) = watch::channel(PumpMode::Running);
     let join = tokio::task::spawn_local(async move {
-        metrics_registry.set_orchestrator_pump_outstanding(topic.as_str(), 0);
         let start_from = event_log
             .consumer_cursor(&topic, &consumer)
             .await
@@ -1333,7 +1356,7 @@ where
             last_seen: start_from.unwrap_or(0),
             processed: 0,
         };
-        record_pump_backlog(&metrics_registry, &event_log, &topic, stats.last_seen).await;
+        record_pump_metrics(&metrics_registry, &event_log, &topic, stats.last_seen, 0).await?;
         let mut drain_progress = None;
         loop {
             if let Some(progress) = drain_progress {
@@ -1378,7 +1401,7 @@ where
                     };
                     let (event_id, logged) = received
                         .map_err(|error| format!("topic pump read failed for {topic}: {error}"))?;
-                    metrics_registry.set_orchestrator_pump_outstanding(topic.as_str(), 1);
+                    record_pump_metrics(&metrics_registry, &event_log, &topic, stats.last_seen, 1).await?;
                     metrics_registry.record_orchestrator_pump_admission_delay(
                         topic.as_str(),
                         admission_delay(logged.occurred_at_ms),
@@ -1398,8 +1421,7 @@ where
                         .ack(&topic, &consumer, event_id)
                         .await
                         .map_err(|error| format!("failed to ack topic pump cursor for {topic}: {error}"))?;
-                    metrics_registry.set_orchestrator_pump_outstanding(topic.as_str(), 0);
-                    record_pump_backlog(&metrics_registry, &event_log, &topic, stats.last_seen).await;
+                    record_pump_metrics(&metrics_registry, &event_log, &topic, stats.last_seen, 0).await?;
                 }
             }
         }
@@ -1508,6 +1530,8 @@ async fn graceful_shutdown(
     }
     let waitpoint_stats = waitpoint_pump
         .drain(
+            ctx.event_log,
+            harn_vm::WAITPOINT_RESUME_TOPIC,
             topic_latest_id(ctx.event_log, harn_vm::WAITPOINT_RESUME_TOPIC).await?,
             ctx.drain_config,
             deadline,
@@ -1522,6 +1546,8 @@ async fn graceful_shutdown(
     .await?;
     let waitpoint_cancel_stats = waitpoint_cancel_pump
         .drain(
+            ctx.event_log,
+            harn_vm::TRIGGER_CANCEL_REQUESTS_TOPIC,
             topic_latest_id(ctx.event_log, harn_vm::TRIGGER_CANCEL_REQUESTS_TOPIC).await?,
             ctx.drain_config,
             deadline,
@@ -2424,14 +2450,29 @@ async fn append_manifest_event(
         })
 }
 
-async fn record_pump_backlog(
+async fn record_pump_metrics(
     metrics: &harn_vm::MetricsRegistry,
     log: &Arc<AnyEventLog>,
     topic: &harn_vm::event_log::Topic,
     last_seen: u64,
-) {
+    outstanding: usize,
+) -> Result<(), OrchestratorError> {
     let latest = log.latest(topic).await.ok().flatten().unwrap_or(last_seen);
-    metrics.set_orchestrator_pump_backlog(topic.as_str(), latest.saturating_sub(last_seen));
+    let backlog = latest.saturating_sub(last_seen);
+    metrics.set_orchestrator_pump_outstanding(topic.as_str(), outstanding);
+    metrics.set_orchestrator_pump_backlog(topic.as_str(), backlog);
+    append_pump_lifecycle_event(
+        log,
+        "pump_metrics_recorded",
+        json!({
+            "topic": topic.as_str(),
+            "latest": latest,
+            "last_seen": last_seen,
+            "backlog": backlog,
+            "outstanding": outstanding,
+        }),
+    )
+    .await
 }
 
 fn admission_delay(occurred_at_ms: i64) -> Duration {
@@ -2509,7 +2550,12 @@ async fn drain_pump_best_effort(
         .unwrap_or(0);
     let budget = remaining_budget(overall_deadline);
 
-    match tokio::time::timeout(budget, pump.drain(up_to, config, overall_deadline)).await {
+    match tokio::time::timeout(
+        budget,
+        pump.drain(log, topic_name, up_to, config, overall_deadline),
+    )
+    .await
+    {
         Ok(Ok(report)) => Ok(report),
         Ok(Err(error)) => {
             eprintln!("[harn] warning: pump drain error for {topic_name}: {error}");

--- a/crates/harn-cli/tests/orchestrator_cli.rs
+++ b/crates/harn-cli/tests/orchestrator_cli.rs
@@ -244,29 +244,41 @@ fn bearer_headers() -> HeaderMap {
     headers
 }
 
-async fn wait_for_metrics_contains(
-    client: &reqwest::Client,
-    base_url: &str,
-    needles: &[&str],
-) -> String {
-    let url = format!("{base_url}/metrics");
-    let last = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
-    let last_capture = last.clone();
-    let result = tokio::time::timeout(EVENT_FAIL_FAST_TIMEOUT, async move {
-        loop {
-            let body = client.get(&url).send().await.unwrap().text().await.unwrap();
-            if needles.iter().all(|needle| body.contains(needle)) {
-                return body;
-            }
-            *last_capture.lock().unwrap() = body;
-            tokio::time::sleep(Duration::from_millis(25)).await;
-        }
+async fn await_pump_metrics_recorded(
+    event_log: &Arc<AnyEventLog>,
+    topic: &str,
+    backlog: Option<u64>,
+    outstanding: u64,
+) -> LogEvent {
+    let topic = topic.to_string();
+    await_topic_event(event_log, "orchestrator.lifecycle", move |event| {
+        event.kind == "pump_metrics_recorded"
+            && event.payload.get("topic").and_then(|value| value.as_str()) == Some(topic.as_str())
+            && backlog.is_none_or(|expected| {
+                event
+                    .payload
+                    .get("backlog")
+                    .and_then(|value| value.as_u64())
+                    == Some(expected)
+            })
+            && event
+                .payload
+                .get("outstanding")
+                .and_then(|value| value.as_u64())
+                == Some(outstanding)
     })
-    .await;
-    result.unwrap_or_else(|_| {
-        let snapshot = last.lock().unwrap().clone();
-        panic!("timed out waiting for metrics samples {needles:?}; last={snapshot}")
-    })
+    .await
+}
+
+async fn scrape_metrics_once(client: &reqwest::Client, base_url: &str) -> String {
+    client
+        .get(format!("{base_url}/metrics"))
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap()
 }
 
 fn run_harn_with_env(temp: &TempDir, args: &[&str], envs: &[(&str, &str)]) -> Output {
@@ -714,15 +726,22 @@ pub fn on_task(event: TriggerEvent) -> string {
         "second inbox event was acked before admission"
     );
 
-    let _metrics = wait_for_metrics_contains(
-        &client,
-        &base_url,
-        &[
-            "harn_orchestrator_pump_outstanding{topic=\"trigger.inbox.envelopes\"} 1",
-            "harn_orchestrator_pump_backlog{topic=\"trigger.inbox.envelopes\"} 1",
-        ],
+    await_pump_metrics_recorded(
+        &event_log,
+        harn_vm::TRIGGER_INBOX_ENVELOPES_TOPIC,
+        Some(1),
+        1,
     )
     .await;
+    let metrics = scrape_metrics_once(&client, &base_url).await;
+    assert!(
+        metrics.contains("harn_orchestrator_pump_outstanding"),
+        "metrics={metrics}"
+    );
+    assert!(
+        metrics.contains("harn_orchestrator_pump_backlog"),
+        "metrics={metrics}"
+    );
 
     let _ = shutdown_trigger.send(true);
     fs::write(&inbox_release_file, b"release").unwrap();
@@ -847,11 +866,7 @@ async fn bounded_pump_drain_truncates_and_replays_remaining_backlog_after_restar
 
     let temp = TempDir::new().unwrap();
     let pump_release_file = temp.path().join("release-pending-pump");
-    let pump_waiting_file = temp.path().join("pending-pump-waiting");
-    let pump_draining_file = temp.path().join("pending-pump-draining");
     let pump_release_value = pump_release_file.to_string_lossy().into_owned();
-    let pump_waiting_value = pump_waiting_file.to_string_lossy().into_owned();
-    let pump_draining_value = pump_draining_file.to_string_lossy().into_owned();
     write_file(
         temp.path(),
         "harn.toml",
@@ -891,14 +906,6 @@ pub fn on_task(event: TriggerEvent) -> string {
             "HARN_TEST_ORCHESTRATOR_PUMP_RELEASE_FILE",
             pump_release_value.as_str(),
         ),
-        (
-            "HARN_TEST_ORCHESTRATOR_PUMP_WAITING_FILE",
-            pump_waiting_value.as_str(),
-        ),
-        (
-            "HARN_TEST_ORCHESTRATOR_PUMP_DRAINING_FILE",
-            pump_draining_value.as_str(),
-        ),
     ])
     .await;
     let harness = start_harness_with(&temp, |mut config| {
@@ -908,6 +915,7 @@ pub fn on_task(event: TriggerEvent) -> string {
     })
     .await;
     let base_url = harness.listener_url().to_string();
+    let first_event_log = harness.event_log();
     let shutdown_trigger = harness.shutdown_trigger();
 
     let client = reqwest::Client::new();
@@ -926,9 +934,14 @@ pub fn on_task(event: TriggerEvent) -> string {
         assert_eq!(response.status(), reqwest::StatusCode::OK);
     }
 
-    wait_for_path_async(&pump_waiting_file).await;
+    await_pump_metrics_recorded(&first_event_log, "orchestrator.triggers.pending", None, 1).await;
     let _ = shutdown_trigger.send(true);
-    wait_for_path_async(&pump_draining_file).await;
+    await_topic_event(&first_event_log, "orchestrator.lifecycle", |event| {
+        event.kind == "pump_drain_requested"
+            && event.payload.get("topic").and_then(|value| value.as_str())
+                == Some("orchestrator.triggers.pending")
+    })
+    .await;
     fs::write(&pump_release_file, b"release").unwrap();
     shutdown(harness).await;
 
@@ -1119,14 +1132,4 @@ pub fn on_task(event: TriggerEvent) -> dict {
     );
     assert_eq!(drain_json["summary"]["ready"], serde_json::json!(0));
     assert_eq!(drain_json["summary"]["responses"], serde_json::json!(1));
-}
-
-async fn wait_for_path_async(path: &Path) {
-    tokio::time::timeout(EVENT_FAIL_FAST_TIMEOUT, async {
-        while !path.exists() {
-            tokio::time::sleep(Duration::from_millis(25)).await;
-        }
-    })
-    .await
-    .unwrap_or_else(|_| panic!("timed out waiting for path {}", path.display()));
 }

--- a/scripts/lint_test_patterns.sh
+++ b/scripts/lint_test_patterns.sh
@@ -40,7 +40,6 @@ TOKIO_SLEEP_ALLOWLIST=(
   "crates/harn-vm/src/connectors/linear/tests.rs"
   "crates/harn-vm/src/triggers/dispatcher/tests/retry.rs"
   "crates/harn-vm/src/orchestration/tests.rs"
-  "crates/harn-cli/tests/orchestrator_cli.rs"
   "crates/harn-cli/tests/orchestrator_http/admin.rs"
 )
 


### PR DESCRIPTION
## Summary
- Emit `pump_metrics_recorded` lifecycle events from the pump metrics update path, including topic, cursor, backlog, and outstanding counts.
- Emit `pump_drain_requested` when a pump drain has been signaled so tests can wait on lifecycle state instead of filesystem polling.
- Replace the orchestrator CLI metrics scrape polling with event-log assertions, keep `/metrics` as a one-shot registry smoke check, and remove `orchestrator_cli.rs` from the tokio sleep allowlist.

## Verification
- `make lint-test-patterns`
- `CARGO_TARGET_DIR=/tmp/codex-harn-1265-target cargo test -p harn-cli --test orchestrator_cli -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/codex-harn-1265-target cargo clippy -p harn-cli --tests --no-deps`
- pre-commit hook: `cargo clippy --workspace --all-targets -- -D warnings`
- pre-push hook targeted checks

Note: the issue's exact `cargo nextest run -p harn-cli --profile e2e --run-ignored ignored-only orchestrator_cli` command currently exits with no tests selected under the repo's e2e profile.

Closes #1265
