### PR TITLE
Align ACP initialize capabilities

### DIFF
--- a/crates/harn-cli/src/acp/mod.rs
+++ b/crates/harn-cli/src/acp/mod.rs
@@ -41,7 +41,14 @@ impl AcpRuntimeConfigurator for CliAcpRuntimeConfigurator {
 }
 
 pub(crate) fn server_config(pipeline: Option<String>) -> AcpServerConfig {
-    AcpServerConfig::new(pipeline).with_runtime_configurator(Arc::new(CliAcpRuntimeConfigurator))
+    let extensions = pipeline
+        .as_deref()
+        .map(Path::new)
+        .map(crate::package::load_runtime_extensions)
+        .unwrap_or_default();
+    AcpServerConfig::new(pipeline)
+        .with_runtime_configurator(Arc::new(CliAcpRuntimeConfigurator))
+        .with_llm_overrides(extensions.llm, extensions.capabilities)
 }
 
 pub(crate) async fn run_acp_server(pipeline: Option<&str>) {

--- a/crates/harn-cli/src/commands/orchestrator/listener/tests.rs
+++ b/crates/harn-cli/src/commands/orchestrator/listener/tests.rs
@@ -441,11 +441,26 @@ async fn acp_websocket_requires_configured_bearer_auth() {
             .expect("authorized connect");
     let response = acp_request(&mut socket, 1, "initialize", json!({})).await;
     assert_eq!(response["result"]["agentInfo"]["name"], "harn");
+    assert_eq!(response["result"]["agentCapabilities"]["loadSession"], true);
+    assert_eq!(
+        response["result"]["agentCapabilities"]["mcpCapabilities"],
+        json!({
+            "http": true,
+            "sse": true,
+        })
+    );
+    assert_eq!(
+        response["result"]["agentCapabilities"]["sessionCapabilities"],
+        json!({
+            "list": {},
+        })
+    );
     assert!(
         response["result"]["agentCapabilities"]["sessionCapabilities"]
-            .get("load")
-            .is_some()
+            .get("fork")
+            .is_none()
     );
+    assert_eq!(response["result"]["authMethods"], json!([]));
 
     listener
         .shutdown(Duration::from_secs(5))

--- a/crates/harn-cli/tests/acp_server_cli.rs
+++ b/crates/harn-cli/tests/acp_server_cli.rs
@@ -38,7 +38,7 @@ fn write_fixture(temp: &TempDir) {
         r#"
 pub pipeline main() {
   let sid = agent_session_current_id()
-  assert(sid != nil, "ACP prompt installs the current session id")
+  guard sid != nil else { throw "ACP prompt installs the current session id" }
   if prompt != "snapshot" {
     agent_session_inject(sid, {role: "user", content: prompt})
   }
@@ -150,18 +150,24 @@ fn acp_session_fork_branches_runtime_state_and_dispatches_independently() {
             "params": {}
         }),
     );
+    assert_eq!(init["result"]["agentCapabilities"]["loadSession"], true);
+    assert_eq!(init["result"]["authMethods"], json!([]));
     assert_eq!(
-        init["result"]["agentCapabilities"]["sessionCapabilities"]["fork"],
-        json!({})
+        init["result"]["agentCapabilities"]["mcpCapabilities"],
+        json!({
+            "http": true,
+            "sse": true,
+        })
     );
     assert_eq!(
-        init["result"]["agentCapabilities"]["sessionCapabilities"]["setMode"],
-        json!({})
+        init["result"]["agentCapabilities"]["sessionCapabilities"],
+        json!({
+            "list": {},
+        })
     );
-    assert_eq!(
-        init["result"]["agentCapabilities"]["sessionCapabilities"]["setConfigOption"],
-        json!({})
-    );
+    assert!(init["result"]["agentCapabilities"]["sessionCapabilities"]
+        .get("fork")
+        .is_none());
 
     let (_, created) = send_request(
         &mut stdin,
@@ -190,7 +196,7 @@ fn acp_session_fork_branches_runtime_state_and_dispatches_independently() {
             }
         }),
     );
-    assert_eq!(alpha_response["result"]["stopReason"], "completed");
+    assert_eq!(alpha_response["result"]["stopReason"], "end_turn");
     let alpha_summary = latest_prompt_summary(&alpha_notifications, &session_id);
     assert_eq!(alpha_summary["len"], 1);
 
@@ -207,7 +213,7 @@ fn acp_session_fork_branches_runtime_state_and_dispatches_independently() {
             }
         }),
     );
-    assert_eq!(beta_response["result"]["stopReason"], "completed");
+    assert_eq!(beta_response["result"]["stopReason"], "end_turn");
     let beta_summary = latest_prompt_summary(&beta_notifications, &session_id);
     assert_eq!(beta_summary["len"], 2);
     assert_eq!(beta_summary["messages"][0]["content"], "alpha");
@@ -292,7 +298,7 @@ fn acp_session_fork_branches_runtime_state_and_dispatches_independently() {
             }
         }),
     );
-    assert_eq!(child_response["result"]["stopReason"], "completed");
+    assert_eq!(child_response["result"]["stopReason"], "end_turn");
     assert!(child_notifications.iter().all(|message| {
         message["method"] != "session/update" || message["params"]["sessionId"] == branch_id
     }));
@@ -316,7 +322,7 @@ fn acp_session_fork_branches_runtime_state_and_dispatches_independently() {
             }
         }),
     );
-    assert_eq!(parent_response["result"]["stopReason"], "completed");
+    assert_eq!(parent_response["result"]["stopReason"], "end_turn");
     let parent_summary = latest_prompt_summary(&parent_notifications, &session_id);
     assert_eq!(parent_summary["len"], 2);
     assert_eq!(parent_summary["messages"][0]["content"], "alpha");
@@ -333,6 +339,14 @@ fn serve_acp_stdio_runs_packaged_adapter() {
     let _guard = lock_acp_cli_tests();
     let temp = TempDir::new().unwrap();
     write_fixture(&temp);
+    write_file(
+        temp.path(),
+        "harn.toml",
+        r#"
+[llm]
+default_provider = "openai"
+"#,
+    );
 
     let mut child = harn_e2e_command()
         .current_dir(temp.path())
@@ -359,6 +373,14 @@ fn serve_acp_stdio_runs_packaged_adapter() {
         }),
     );
     assert_eq!(init["result"]["agentInfo"]["name"], "harn");
+    assert_eq!(
+        init["result"]["agentCapabilities"]["promptCapabilities"],
+        json!({
+            "image": true,
+            "audio": true,
+            "embeddedContext": false,
+        })
+    );
 
     let (_, created) = send_request(
         &mut stdin,
@@ -387,7 +409,7 @@ fn serve_acp_stdio_runs_packaged_adapter() {
             }
         }),
     );
-    assert_eq!(response["result"]["stopReason"], "completed");
+    assert_eq!(response["result"]["stopReason"], "end_turn");
     let summary = latest_prompt_summary(&notifications, &session_id);
     assert_eq!(summary["messages"][0]["content"], "packaged");
 

--- a/crates/harn-serve/src/adapters/acp/mod.rs
+++ b/crates/harn-serve/src/adapters/acp/mod.rs
@@ -126,6 +126,73 @@ fn harn_acp_extension_meta() -> serde_json::Value {
     })
 }
 
+fn non_empty_env(name: &str) -> Option<String> {
+    std::env::var(name)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn configured_llm_route_for_capabilities() -> (String, String) {
+    let provider = non_empty_env("HARN_LLM_PROVIDER")
+        .filter(|provider| !provider.eq_ignore_ascii_case("auto"))
+        .or_else(|| {
+            if std::env::var("LOCAL_LLM_BASE_URL").is_ok()
+                && (non_empty_env("HARN_LLM_MODEL").is_some()
+                    || non_empty_env("LOCAL_LLM_MODEL").is_some())
+            {
+                Some("local".to_string())
+            } else {
+                None
+            }
+        })
+        .or_else(|| {
+            non_empty_env("HARN_LLM_MODEL").map(|model| {
+                let resolved = harn_vm::llm_config::resolve_model_info(&model);
+                resolved.provider
+            })
+        })
+        .unwrap_or_else(harn_vm::llm_config::default_provider);
+
+    let raw_model = non_empty_env("HARN_LLM_MODEL").or_else(|| {
+        if provider == "local" {
+            non_empty_env("LOCAL_LLM_MODEL")
+        } else {
+            None
+        }
+    });
+    let model = raw_model
+        .map(|model| harn_vm::llm_config::resolve_model(&model).0)
+        .unwrap_or_else(|| harn_vm::llm_config::default_model_for_provider(&provider));
+
+    (provider, model)
+}
+
+fn acp_prompt_capabilities() -> serde_json::Value {
+    let (provider, model) = configured_llm_route_for_capabilities();
+    let capabilities = harn_vm::llm::capabilities::lookup(&provider, &model);
+    serde_json::json!({
+        "image": capabilities.vision || capabilities.vision_supported,
+        "audio": capabilities.audio,
+        "embeddedContext": capabilities.pdf || capabilities.files_api_supported,
+    })
+}
+
+fn acp_agent_capabilities() -> serde_json::Value {
+    serde_json::json!({
+        "_meta": harn_acp_extension_meta(),
+        "loadSession": true,
+        "promptCapabilities": acp_prompt_capabilities(),
+        "mcpCapabilities": {
+            "http": true,
+            "sse": true,
+        },
+        "sessionCapabilities": {
+            "list": {},
+        },
+    })
+}
+
 fn verbose_bridge_logs_enabled() -> bool {
     matches!(
         std::env::var("HARN_ACP_VERBOSE").ok().as_deref(),
@@ -255,6 +322,8 @@ pub struct AcpServerConfig {
     pub pipeline: Option<String>,
     pub auth_policy: AuthPolicy,
     pub runtime_configurator: Arc<dyn AcpRuntimeConfigurator>,
+    pub llm_config_overrides: Option<harn_vm::llm_config::ProvidersConfig>,
+    pub llm_capability_overrides: Option<harn_vm::llm::capabilities::CapabilitiesFile>,
 }
 
 impl AcpServerConfig {
@@ -263,6 +332,8 @@ impl AcpServerConfig {
             pipeline,
             auth_policy: AuthPolicy::allow_all(),
             runtime_configurator: Arc::new(NoopAcpRuntimeConfigurator),
+            llm_config_overrides: None,
+            llm_capability_overrides: None,
         }
     }
 
@@ -280,6 +351,16 @@ impl AcpServerConfig {
 
     pub fn with_auth_policy(mut self, auth_policy: AuthPolicy) -> Self {
         self.auth_policy = auth_policy;
+        self
+    }
+
+    pub fn with_llm_overrides(
+        mut self,
+        llm_config: Option<harn_vm::llm_config::ProvidersConfig>,
+        llm_capabilities: Option<harn_vm::llm::capabilities::CapabilitiesFile>,
+    ) -> Self {
+        self.llm_config_overrides = llm_config;
+        self.llm_capability_overrides = llm_capabilities;
         self
     }
 }
@@ -651,6 +732,9 @@ impl AcpServer {
     }
 
     fn new_with_output(config: AcpServerConfig, output: AcpOutput) -> Self {
+        harn_vm::llm_config::set_user_overrides(config.llm_config_overrides.clone());
+        harn_vm::llm::capabilities::set_user_overrides(config.llm_capability_overrides.clone());
+
         Self {
             descriptor: AdapterDescriptor {
                 id: "acp".to_string(),
@@ -754,24 +838,12 @@ impl AcpServer {
             id,
             serde_json::json!({
                 "protocolVersion": 1,
-                "agentCapabilities": {
-                    "_meta": harn_acp_extension_meta(),
-                    "promptCapabilities": {
-                        "audio": true,
-                        "embeddedContext": true,
-                        "image": true,
-                    },
-                    "sessionCapabilities": {
-                        "fork": {},
-                        "load": {},
-                        "setConfigOption": {},
-                        "setMode": {},
-                    },
-                },
+                "agentCapabilities": acp_agent_capabilities(),
                 "agentInfo": {
                     "name": "harn",
                     "version": env!("CARGO_PKG_VERSION"),
                 },
+                "authMethods": [],
             }),
         );
     }
@@ -2031,6 +2103,7 @@ pub async fn run_acp_server(config: AcpServerConfig) {
 mod tests {
     use super::builtins::normalize_host_capability_manifest;
     use super::{
+        acp_agent_capabilities, configured_llm_route_for_capabilities,
         sanitize_visible_assistant_text, AcpBridge, AcpOutput, AcpServer, AcpServerConfig,
         SessionCancellation, ACP_SCHEMA_COMPATIBILITY, HARN_AGENT_EVENT_KINDS,
         HARN_AGENT_EVENT_METHOD, HARN_SESSION_UPDATE_EXTENSIONS,
@@ -2042,8 +2115,39 @@ mod tests {
     use std::collections::{BTreeMap, BTreeSet};
     use std::rc::Rc;
     use std::sync::atomic::{AtomicU64, Ordering};
-    use std::sync::Mutex;
+    use std::sync::{Mutex, OnceLock};
     use tokio::sync::mpsc;
+
+    fn acp_env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    struct EnvSnapshot {
+        saved: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl EnvSnapshot {
+        fn capture(names: &[&'static str]) -> Self {
+            Self {
+                saved: names
+                    .iter()
+                    .map(|name| (*name, std::env::var(name).ok()))
+                    .collect(),
+            }
+        }
+    }
+
+    impl Drop for EnvSnapshot {
+        fn drop(&mut self) {
+            for (name, value) in self.saved.drain(..) {
+                match value {
+                    Some(value) => std::env::set_var(name, value),
+                    None => std::env::remove_var(name),
+                }
+            }
+        }
+    }
 
     async fn recv_json(rx: &mut mpsc::UnboundedReceiver<String>) -> serde_json::Value {
         let line = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
@@ -2220,6 +2324,88 @@ mod tests {
         assert_eq!(sanitize_visible_assistant_text(raw, false), raw);
     }
 
+    #[test]
+    fn acp_agent_capabilities_use_canonical_initialize_shape() {
+        let _guard = acp_env_lock().lock().unwrap();
+        let _env = EnvSnapshot::capture(&[
+            "HARN_LLM_PROVIDER",
+            "HARN_LLM_MODEL",
+            "LOCAL_LLM_BASE_URL",
+            "LOCAL_LLM_MODEL",
+            "MLX_MODEL_ID",
+        ]);
+        std::env::set_var("HARN_LLM_PROVIDER", "openai");
+        std::env::remove_var("HARN_LLM_MODEL");
+        std::env::remove_var("LOCAL_LLM_BASE_URL");
+        std::env::remove_var("LOCAL_LLM_MODEL");
+        std::env::remove_var("MLX_MODEL_ID");
+
+        let capabilities = acp_agent_capabilities();
+
+        assert_eq!(
+            configured_llm_route_for_capabilities(),
+            ("openai".into(), "gpt-4o".into())
+        );
+        assert_eq!(capabilities["loadSession"], true);
+        assert_eq!(
+            capabilities["promptCapabilities"],
+            serde_json::json!({
+                "image": true,
+                "audio": true,
+                "embeddedContext": false,
+            })
+        );
+        assert_eq!(
+            capabilities["mcpCapabilities"],
+            serde_json::json!({
+                "http": true,
+                "sse": true,
+            })
+        );
+        assert_eq!(
+            capabilities["sessionCapabilities"],
+            serde_json::json!({
+                "list": {},
+            })
+        );
+        assert!(
+            capabilities["sessionCapabilities"].get("fork").is_none(),
+            "Harn-only session/fork must not be advertised as an ACP SessionCapability"
+        );
+    }
+
+    #[test]
+    fn acp_prompt_capabilities_follow_configured_model_aliases() {
+        let _guard = acp_env_lock().lock().unwrap();
+        let _env = EnvSnapshot::capture(&[
+            "HARN_LLM_PROVIDER",
+            "HARN_LLM_MODEL",
+            "LOCAL_LLM_BASE_URL",
+            "LOCAL_LLM_MODEL",
+            "MLX_MODEL_ID",
+        ]);
+        std::env::remove_var("HARN_LLM_PROVIDER");
+        std::env::set_var("HARN_LLM_MODEL", "frontier");
+        std::env::remove_var("LOCAL_LLM_BASE_URL");
+        std::env::remove_var("LOCAL_LLM_MODEL");
+        std::env::remove_var("MLX_MODEL_ID");
+
+        let capabilities = acp_agent_capabilities();
+
+        assert_eq!(
+            configured_llm_route_for_capabilities(),
+            ("anthropic".into(), "claude-sonnet-4-20250514".into())
+        );
+        assert_eq!(
+            capabilities["promptCapabilities"],
+            serde_json::json!({
+                "image": true,
+                "audio": true,
+                "embeddedContext": true,
+            })
+        );
+    }
+
     #[tokio::test(flavor = "current_thread")]
     async fn acp_server_handles_session_flow_and_prompt_updates() {
         let local = tokio::task::LocalSet::new();
@@ -2243,6 +2429,45 @@ mod tests {
                 let initialize = recv_json(&mut response_rx).await;
                 assert_eq!(initialize["id"], 1);
                 assert_eq!(initialize["result"]["agentInfo"]["name"], "harn");
+                assert_eq!(initialize["result"]["authMethods"], serde_json::json!([]));
+                assert_eq!(
+                    initialize["result"]["agentCapabilities"]["loadSession"],
+                    true
+                );
+                assert_eq!(
+                    initialize["result"]["agentCapabilities"]["sessionCapabilities"],
+                    serde_json::json!({
+                        "list": {},
+                    })
+                );
+                assert!(
+                    initialize["result"]["agentCapabilities"]["sessionCapabilities"]
+                        .get("fork")
+                        .is_none(),
+                    "initialize must not advertise Harn-only session/fork as an ACP SessionCapability"
+                );
+                assert_eq!(
+                    initialize["result"]["agentCapabilities"]["mcpCapabilities"],
+                    serde_json::json!({
+                        "http": true,
+                        "sse": true,
+                    })
+                );
+                assert!(
+                    initialize["result"]["agentCapabilities"]["promptCapabilities"]
+                        ["image"]
+                        .is_boolean()
+                );
+                assert!(
+                    initialize["result"]["agentCapabilities"]["promptCapabilities"]
+                        ["audio"]
+                        .is_boolean()
+                );
+                assert!(
+                    initialize["result"]["agentCapabilities"]["promptCapabilities"]
+                        ["embeddedContext"]
+                        .is_boolean()
+                );
                 assert_eq!(
                     initialize["result"]["agentCapabilities"]["_meta"]["harn"]
                         ["schemaCompatibility"],
@@ -2273,14 +2498,6 @@ mod tests {
                     initialize["result"]["agentCapabilities"]["_meta"]["harn"]
                         ["toolLifecycleExtensionFields"],
                     serde_json::json!(HARN_TOOL_LIFECYCLE_EXTENSION_FIELDS)
-                );
-                assert_eq!(
-                    initialize["result"]["agentCapabilities"]["promptCapabilities"],
-                    serde_json::json!({
-                        "audio": true,
-                        "embeddedContext": true,
-                        "image": true,
-                    })
                 );
 
                 request_tx

--- a/crates/harn-vm/src/llm/helpers/provider.rs
+++ b/crates/harn-vm/src/llm/helpers/provider.rs
@@ -341,17 +341,7 @@ pub(crate) fn vm_resolve_model(
             return resolved;
         }
     }
-    match provider {
-        "local" => std::env::var("LOCAL_LLM_MODEL")
-            .or_else(|_| std::env::var("HARN_LLM_MODEL"))
-            .unwrap_or_else(|_| "gpt-4o".to_string()),
-        "mlx" => std::env::var("MLX_MODEL_ID")
-            .unwrap_or_else(|_| "unsloth/Qwen3.6-27B-UD-MLX-4bit".to_string()),
-        "openai" => "gpt-4o".to_string(),
-        "ollama" => "llama3.2".to_string(),
-        "openrouter" => "anthropic/claude-sonnet-4.6".to_string(),
-        _ => "claude-sonnet-4-20250514".to_string(),
-    }
+    llm_config::default_model_for_provider(provider)
 }
 
 pub fn resolve_api_key(provider: &str) -> Result<String, VmError> {

--- a/crates/harn-vm/src/llm_config.rs
+++ b/crates/harn-vm/src/llm_config.rs
@@ -574,6 +574,20 @@ pub fn qc_default_model(provider: &str) -> Option<String> {
         })
 }
 
+pub fn default_model_for_provider(provider: &str) -> String {
+    match provider {
+        "local" => std::env::var("LOCAL_LLM_MODEL")
+            .or_else(|_| std::env::var("HARN_LLM_MODEL"))
+            .unwrap_or_else(|_| "gpt-4o".to_string()),
+        "mlx" => std::env::var("MLX_MODEL_ID")
+            .unwrap_or_else(|_| "unsloth/Qwen3.6-27B-UD-MLX-4bit".to_string()),
+        "openai" => "gpt-4o".to_string(),
+        "ollama" => "llama3.2".to_string(),
+        "openrouter" => "anthropic/claude-sonnet-4.6".to_string(),
+        _ => "claude-sonnet-4-20250514".to_string(),
+    }
+}
+
 pub fn qc_defaults() -> BTreeMap<String, String> {
     effective_config().qc_defaults
 }

--- a/docs/src/mcp-and-acp.md
+++ b/docs/src/mcp-and-acp.md
@@ -475,9 +475,11 @@ the session's configured working directory, so they operate on the same durable
 `.harn/workflows/<workflowId>/state.json` tree that the in-language builtins
 use.
 
-Harn advertises `agentCapabilities.sessionCapabilities.fork = {}` during
-`initialize`, so ACP clients can gate `session/fork` the same way they do
-other unstable session lifecycle methods.
+During `initialize`, Harn keeps the public `agentCapabilities` object aligned
+with upstream ACP: `loadSession`, `promptCapabilities`, `mcpCapabilities`, and
+the canonical `sessionCapabilities.list` flag are advertised in their upstream
+locations. Harn-only methods such as `session/fork` remain documented
+extensions instead of being inserted into upstream `sessionCapabilities`.
 
 ### Session Forking
 


### PR DESCRIPTION
## Summary
- Align ACP initialize agentCapabilities with the current ACP shape: top-level loadSession, provider-derived promptCapabilities, mcpCapabilities, canonical sessionCapabilities.list, and authMethods.
- Thread manifest LLM and capability overrides into AcpServerConfig so initialize reflects the configured provider on the ACP server thread.
- Update ACP docs and CLI/server smoke tests, including stale smoke fixture expectations.

Closes #899

## Verification
- cargo fmt --check
- git diff --check
- CARGO_TARGET_DIR=/tmp/harn-899-target cargo check -p harn-serve -p harn-cli
- CARGO_TARGET_DIR=/tmp/harn-899-target cargo test -p harn-serve adapters::acp::tests --lib
- CARGO_TARGET_DIR=/tmp/harn-899-target cargo test -p harn-cli acp_websocket_requires_configured_bearer_auth
- CARGO_TARGET_DIR=/tmp/harn-899-target cargo test -p harn-cli --test acp_server_cli acp_session_fork_branches_runtime_state_and_dispatches_independently -- --ignored
- CARGO_TARGET_DIR=/tmp/harn-899-target cargo test -p harn-cli --test acp_server_cli serve_acp_stdio_runs_packaged_adapter -- --ignored
- pre-commit hook: rustfmt, clippy, markdown lint
- pre-push hook: targeted local checks and markdown lint