### PR TITLE
Implement skill matching primitive

### DIFF
--- a/conformance/tests/integration/skill_lifecycle_flags.harn
+++ b/conformance/tests/integration/skill_lifecycle_flags.harn
@@ -1,4 +1,3 @@
-// @xfail: skill matching/scoring not yet a primitive — tracked in burin-labs/harn#1240
 /**
  * Skills & Tool Vault phase 3 (harn#74): flag honouring.
  *

--- a/conformance/tests/integration/skill_lifecycle_metadata.harn
+++ b/conformance/tests/integration/skill_lifecycle_metadata.harn
@@ -1,4 +1,3 @@
-// @xfail: skill matching/scoring not yet a primitive — tracked in burin-labs/harn#1240
 /**
  * Skills & Tool Vault phase 3 (harn#74): agent_loop lifecycle
  * integration for the `skills:` option with the default "metadata"

--- a/conformance/tests/integration/skill_lifecycle_namespace_scope.harn
+++ b/conformance/tests/integration/skill_lifecycle_namespace_scope.harn
@@ -1,4 +1,3 @@
-// @xfail: skill matching/scoring not yet a primitive — tracked in burin-labs/harn#1240
 /**
  * harn v0.7.20 Gap 3: `namespace:<tag>` entries in a skill's
  * `allowed_tools` list match any tool declared with that namespace,

--- a/conformance/tests/integration/skill_lifecycle_paths.harn
+++ b/conformance/tests/integration/skill_lifecycle_paths.harn
@@ -1,4 +1,3 @@
-// @xfail: skill matching/scoring not yet a primitive — tracked in burin-labs/harn#1240
 /**
  * Skills & Tool Vault phase 3 (harn#74): `paths:` auto-trigger.
  *

--- a/conformance/tests/integration/skill_lifecycle_reassess.harn
+++ b/conformance/tests/integration/skill_lifecycle_reassess.harn
@@ -1,4 +1,3 @@
-// @xfail: skill matching/scoring not yet a primitive — tracked in burin-labs/harn#1240
 /**
  * Skills & Tool Vault phase 3 (harn#74): `sticky: false` triggers
  * the reassess phase before each turn, swapping skills when later

--- a/conformance/tests/integration/skill_lifecycle_session_resume.harn
+++ b/conformance/tests/integration/skill_lifecycle_session_resume.harn
@@ -1,5 +1,4 @@
 /**
- * @xfail: skill matching/scoring not yet a primitive — tracked in burin-labs/harn#1240
  * Skills & Tool Vault phase 3 (harn#74): session-resume restores
  * the last active skill when the user re-enters a named session.
  *

--- a/conformance/tests/integration/skill_lifecycle_workflow.harn
+++ b/conformance/tests/integration/skill_lifecycle_workflow.harn
@@ -1,4 +1,3 @@
-// @xfail: skill matching/scoring not yet a primitive — tracked in burin-labs/harn#1240
 /**
  * harn v0.7.20 Gap 2: `skills:` / `skill_match:` pass through
  * `workflow_execute` to every per-node agent loop. Mirrors

--- a/conformance/tests/integration/skills_load_skill_errors/main.harn
+++ b/conformance/tests/integration/skills_load_skill_errors/main.harn
@@ -1,4 +1,3 @@
-/** @xfail: skill matching/scoring not yet a primitive — tracked in burin-labs/harn#1240 */
 pipeline test(task) {
   llm_mock_clear()
   let catalog = render_always_on_catalog(skills_catalog_entries(skills), 2000)

--- a/conformance/tests/integration/skills_load_skill_roundtrip/main.harn
+++ b/conformance/tests/integration/skills_load_skill_roundtrip/main.harn
@@ -1,4 +1,3 @@
-/** @xfail: skill matching/scoring not yet a primitive — tracked in burin-labs/harn#1240 */
 pipeline test(task) {
   llm_mock_clear()
   var tools = tool_registry()

--- a/conformance/tests/skills/load_skill_accepts_valid_signature.harn
+++ b/conformance/tests/skills/load_skill_accepts_valid_signature.harn
@@ -1,4 +1,3 @@
-/** @xfail: skill matching/scoring not yet a primitive — tracked in burin-labs/harn#1240 */
 pipeline test(task) {
   llm_mock_clear()
   let catalog = render_always_on_catalog(skills_catalog_entries(skills), 2000)

--- a/conformance/tests/skills/load_skill_rejects_unsigned_when_required.harn
+++ b/conformance/tests/skills/load_skill_rejects_unsigned_when_required.harn
@@ -1,4 +1,3 @@
-/** @xfail: skill matching/scoring not yet a primitive — tracked in burin-labs/harn#1240 */
 pipeline test(task) {
   llm_mock_clear()
   let catalog = render_always_on_catalog(skills_catalog_entries(skills), 2000)

--- a/conformance/tests/stdlib/workflow_sub_agent_skill_context.harn
+++ b/conformance/tests/stdlib/workflow_sub_agent_skill_context.harn
@@ -1,4 +1,3 @@
-/** @xfail: skill matching/scoring not yet a primitive — tracked in burin-labs/harn#1240 */
 fn child_tools() {
   var tools = tool_registry()
   tools = tool_define(

--- a/crates/harn-parser/src/builtin_signatures/signatures/integrations.rs
+++ b/crates/harn-parser/src/builtin_signatures/signatures/integrations.rs
@@ -667,7 +667,7 @@ pub(crate) const SIGNATURES: &[BuiltinSignature] = &[
     },
     BuiltinSignature {
         name: "load_skill",
-        params: &[Param::new("name", TY_STRING)],
+        params: &[Param::new("request", TY_STRING_OR_DICT)],
         returns: TY_STRING,
         type_params: &[],
         has_rest: false,

--- a/crates/harn-stdlib/src/stdlib/agent/loop.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/loop.harn
@@ -34,20 +34,21 @@ pub fn agent_loop(message, system_prompt = nil, options = nil) {
       final_status = "budget_exhausted"
       break
     }
-    agent_skills_match(session, opts, iteration)
-    agent_autocompact_if_needed(session, opts)
+    let turn_index = iteration
+    let turn_opts = agent_skills_match(session, opts, iteration)
+    agent_autocompact_if_needed(session, turn_opts)
     let pending = agent_session_drain_feedback(session.session_id)
     for note in pending {
       agent_session_inject_feedback(session.session_id, note.kind, note.content)
     }
-    let turn_system = agent_build_turn_system(session, opts, iteration)
-    let turn_messages = agent_build_turn_messages(session, opts, iteration)
-    let base_opts = opts?.llm_options ?? opts ?? {}
+    let turn_system = agent_build_turn_system(session, turn_opts, iteration)
+    let turn_messages = agent_build_turn_messages(session, turn_opts, iteration)
+    let base_opts = turn_opts?.llm_options ?? turn_opts ?? {}
     let llm_opts = base_opts + {messages: turn_messages, session_id: session.session_id}
     let llm_result = llm_call(message, turn_system, llm_opts)
     iteration = iteration + 1
     let raw_text = llm_result?.text ?? ""
-    let parsed = agent_parse_tool_calls(raw_text, opts?.tools)
+    let parsed = agent_parse_tool_calls(raw_text, turn_opts?.tools)
     let visible_text = if parsed?.user_response != nil && parsed.user_response != "" {
       parsed.user_response
     } else {
@@ -69,8 +70,8 @@ pub fn agent_loop(message, system_prompt = nil, options = nil) {
     if len(tool_calls) > 0 {
       dispatch = agent_dispatch_tool_batch(
         tool_calls,
-        opts?.tools,
-        {session_id: session.session_id, tool_format: opts.tool_format},
+        turn_opts?.tools,
+        {session_id: session.session_id, tool_format: turn_opts.tool_format},
       )
       agent_session_record_tool_results(session.session_id, dispatch)
     }
@@ -83,8 +84,8 @@ pub fn agent_loop(message, system_prompt = nil, options = nil) {
       session,
       normalized + {parsed_done_marker: parsed?.done_marker ?? ""},
       dispatch,
-      opts,
-      iteration,
+      turn_opts,
+      turn_index,
     )
     if outcome.kind == "continue" {
       continue
@@ -96,7 +97,7 @@ pub fn agent_loop(message, system_prompt = nil, options = nil) {
         stop_reason = outcome.stop_reason
         break
       }
-      let verdict = agent_verify_or_continue(session, opts, outcome.stop_reason, llm_result.text)
+      let verdict = agent_verify_or_continue(session, turn_opts, outcome.stop_reason, llm_result.text)
       if verdict.vetoed {
         verify_attempts = verify_attempts + 1
         continue

--- a/crates/harn-stdlib/src/stdlib/agent/skills.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/skills.harn
@@ -1,44 +1,328 @@
-import { agent_session_active_skills, agent_session_set_active_skills } from "std/agent/state"
+import {
+  agent_session_active_skills,
+  agent_session_messages,
+  agent_session_record_skill_event,
+  agent_session_set_active_skills,
+} from "std/agent/state"
 
-fn __skills_should_match(opts, iteration) {
-  let cfg = opts?.skill_match ?? {}
-  let sticky = cfg?.sticky ?? true
-  if iteration == 0 {
-    return true
+fn __skills_registry(opts) {
+  let registry = opts?.skill_registry ?? opts?.skills
+  if type_of(registry) == "list" {
+    return {_type: "skill_registry", skills: registry}
   }
-  return !sticky
+  return registry
 }
 
-fn __skills_active_changed(prev, next) {
-  if len(prev) != len(next) {
-    return true
+fn __skills_entries(registry) {
+  if registry == nil {
+    return []
   }
-  for (index, item) in iter(next).enumerate() {
-    if prev[index]?.id != item?.id {
+  return registry?.skills ?? []
+}
+
+fn __skill_id(entry) {
+  return entry?.id ?? entry?.name ?? ""
+}
+
+fn __skill_find(registry, id) {
+  for entry in __skills_entries(registry) {
+    if __skill_id(entry) == id {
+      return entry
+    }
+  }
+  return nil
+}
+
+fn __skill_ids(entries) {
+  var ids = []
+  for entry in entries {
+    let id = __skill_id(entry)
+    if id != "" {
+      ids = ids.push(id)
+    }
+  }
+  return ids
+}
+
+fn __tool_registry_has(registry, name) {
+  if type_of(registry) != "dict" {
+    return false
+  }
+  for tool_entry in registry?.tools ?? [] {
+    if __tool_name(tool_entry) == name {
       return true
     }
   }
   return false
 }
 
-/** agent_skills_match. */
-pub fn agent_skills_match(session, opts, iteration) {
-  let registry = opts?.skill_registry
-  if registry == nil || len(registry) == 0 {
-    return nil
+fn __with_load_skill_tool(session, opts) {
+  let existing = opts?.tools
+  let registry = if type_of(existing) == "dict" {
+    existing
+  } else {
+    tool_registry()
   }
-  if !__skills_should_match(opts, iteration) {
-    return nil
+  if __tool_registry_has(registry, "load_skill") {
+    return opts + {tools: registry}
   }
-  let scored = __host_skill_score(
-    {task: session?.task ?? "", working_files: opts?.working_files ?? [], iteration: iteration},
+  let next_registry = tool_define(
     registry,
-    opts?.skill_match ?? {},
+    "load_skill",
+    "Load the full instructions for a skill from the active skill catalog",
+    {
+      parameters: {
+        name: {type: "string", description: "Skill id from the catalog"},
+        require_signature: {
+          type: "boolean",
+          description: "Reject the skill unless provenance shows a trusted signature",
+          required: false,
+        },
+      },
+      handler: { args -> load_skill(args + {session_id: session.session_id}) },
+    },
   )
-  let active = scored?.active ?? []
-  let prev = agent_session_active_skills(session.session_id) ?? []
-  if __skills_active_changed(prev, active) {
-    agent_session_set_active_skills(session.session_id, active)
+  return opts + {tools: next_registry}
+}
+
+fn __skills_same_ids(prev, next) {
+  let prev_ids = __skill_ids(prev)
+  let next_ids = __skill_ids(next)
+  if len(prev_ids) != len(next_ids) {
+    return false
+  }
+  for (index, id) in iter(next_ids).enumerate() {
+    if prev_ids[index] != id {
+      return false
+    }
+  }
+  return true
+}
+
+fn __active_from_ids(registry, ids) {
+  var active = []
+  for item in ids {
+    let id = item?.id ?? item?.name ?? item
+    let entry = __skill_find(registry, id)
+    if entry != nil {
+      active = active.push(entry + {id: id})
+    }
   }
   return active
+}
+
+fn __latest_user_text(session) {
+  var latest = session?.task ?? ""
+  for message in agent_session_messages(session.session_id) {
+    if message?.role == "user" {
+      latest = message?.content ?? latest
+    }
+  }
+  return latest
+}
+
+fn __match_config(opts) {
+  return opts?.skill_match ?? {}
+}
+
+fn __match_strategy(opts) {
+  return __match_config(opts)?.strategy ?? "metadata"
+}
+
+fn __match_top_n(opts) {
+  let value = __match_config(opts)?.top_n
+  if type_of(value) == "int" && value > 0 {
+    return value
+  }
+  return 1
+}
+
+fn __match_sticky(opts) {
+  let value = __match_config(opts)?.sticky
+  if type_of(value) == "bool" {
+    return value
+  }
+  return true
+}
+
+fn __score_candidates(session, registry, opts, iteration) {
+  return __host_skill_score(
+    {task: __latest_user_text(session), working_files: opts?.working_files ?? [], iteration: iteration},
+    registry,
+    __match_config(opts),
+  )?.scored
+    ?? []
+}
+
+fn __top_active_from_scores(registry, scored, opts) {
+  var active = []
+  let top_n = __match_top_n(opts)
+  let strategy = __match_strategy(opts)
+  for candidate in scored {
+    if len(active) >= top_n {
+      break
+    }
+    let score = candidate?.score ?? 0.0
+    if score <= 0.0 && strategy == "metadata" {
+      continue
+    }
+    let id = candidate?.id ?? candidate?.name ?? ""
+    let entry = __skill_find(registry, id)
+    if entry != nil {
+      active = active.push(entry + {id: id, score: score, trigger: candidate?.trigger ?? candidate?.reason ?? ""})
+    }
+  }
+  return active
+}
+
+fn __record_matched(session, opts, iteration, scored) {
+  agent_session_record_skill_event(
+    session.session_id,
+    "skill_matched",
+    {
+      strategy: __match_strategy(opts),
+      iteration: iteration,
+      reassess: iteration > 0,
+      candidates: scored,
+      working_files: opts?.working_files ?? [],
+    },
+  )
+}
+
+fn __record_deactivations(session, prev, next, iteration) {
+  let next_ids = __skill_ids(next)
+  for entry in prev {
+    let id = __skill_id(entry)
+    if id != "" && !contains(next_ids, id) {
+      agent_session_record_skill_event(
+        session.session_id,
+        "skill_deactivated",
+        {name: id, id: id, iteration: iteration},
+      )
+    }
+  }
+}
+
+fn __record_activations(session, prev, next, iteration) {
+  let prev_ids = __skill_ids(prev)
+  for entry in next {
+    let id = __skill_id(entry)
+    if id == "" || contains(prev_ids, id) {
+      continue
+    }
+    agent_session_record_skill_event(
+      session.session_id,
+      "skill_activated",
+      {
+        name: id,
+        id: id,
+        description: entry?.description ?? "",
+        iteration: iteration,
+        score: entry?.score ?? 0.0,
+        trigger: entry?.trigger ?? "",
+        allowed_tools: entry?.allowed_tools ?? [],
+      },
+    )
+    if len(entry?.allowed_tools ?? []) > 0 {
+      agent_session_record_skill_event(
+        session.session_id,
+        "skill_scope_tools",
+        {name: id, id: id, allowed_tools: entry.allowed_tools},
+      )
+    }
+  }
+}
+
+fn __allowed_union(active) {
+  var allowed = []
+  for active_entry in active {
+    for allowed_entry in active_entry?.allowed_tools ?? [] {
+      if !contains(allowed, allowed_entry) {
+        allowed = allowed.push(allowed_entry)
+      }
+    }
+  }
+  return allowed
+}
+
+fn __tool_name(tool_entry) {
+  return tool_entry?.name ?? tool_entry?.function?.name ?? ""
+}
+
+fn __tool_namespace(tool_entry) {
+  return tool_entry?.namespace ?? tool_entry?.function?.namespace ?? ""
+}
+
+fn __allowed_matches_tool(entry, tool_entry) {
+  if entry == "*" {
+    return true
+  }
+  let name = __tool_name(tool_entry)
+  if entry == name {
+    return true
+  }
+  if starts_with(entry, "namespace:") {
+    return substring(entry, len("namespace:")) == __tool_namespace(tool_entry)
+  }
+  return false
+}
+
+fn __skill_scoped_tools(opts, active) {
+  let allowed = __allowed_union(active)
+  if len(allowed) == 0 || contains(allowed, "*") {
+    return opts?.tools
+  }
+  let registry = opts?.tools
+  if type_of(registry) != "dict" {
+    return registry
+  }
+  var kept = []
+  for tool_entry in registry?.tools ?? [] {
+    if __tool_name(tool_entry) == "load_skill" {
+      kept = kept.push(tool_entry)
+      continue
+    }
+    var keep = false
+    for entry in allowed {
+      if __allowed_matches_tool(entry, tool_entry) {
+        keep = true
+        break
+      }
+    }
+    if keep {
+      kept = kept.push(tool_entry)
+    }
+  }
+  return registry + {tools: kept}
+}
+
+fn __opts_with_active_skills(opts, active) {
+  let scoped_tools = __skill_scoped_tools(opts, active)
+  var next = opts + {active_skills: active}
+  if scoped_tools != nil {
+    next = next + {tools: scoped_tools}
+  }
+  return next
+}
+
+/** agent_skills_match. */
+pub fn agent_skills_match(session, opts, iteration) {
+  let registry = __skills_registry(opts)
+  if registry == nil || len(__skills_entries(registry)) == 0 {
+    return opts
+  }
+  let tool_opts = __with_load_skill_tool(session, opts)
+  let prev = __active_from_ids(registry, agent_session_active_skills(session.session_id) ?? [])
+  if __match_sticky(opts) && len(prev) > 0 {
+    return __opts_with_active_skills(tool_opts, prev)
+  }
+  let scored = __score_candidates(session, registry, tool_opts, iteration)
+  __record_matched(session, tool_opts, iteration, scored)
+  let active = __top_active_from_scores(registry, scored, tool_opts)
+  if !__skills_same_ids(prev, active) {
+    __record_deactivations(session, prev, active, iteration)
+    __record_activations(session, prev, active, iteration)
+    agent_session_set_active_skills(session.session_id, active)
+  }
+  return __opts_with_active_skills(tool_opts, active)
 }

--- a/crates/harn-stdlib/src/stdlib/agent/state.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/state.harn
@@ -55,3 +55,8 @@ pub fn agent_session_set_active_skills(session_id, skills) {
 pub fn agent_session_active_skills(session_id) {
   return __host_agent_session_active_skills(session_id)
 }
+
+/** agent_session_record_skill_event. */
+pub fn agent_session_record_skill_event(session_id, kind, metadata) {
+  return __host_agent_session_record_skill_event(session_id, kind, metadata)
+}

--- a/crates/harn-vm/src/llm/agent_session_host.rs
+++ b/crates/harn-vm/src/llm/agent_session_host.rs
@@ -10,6 +10,7 @@ use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::rc::Rc;
 
+use crate::agent_events::AgentEvent;
 use crate::orchestration::{
     pop_approval_policy, pop_execution_policy, push_approval_policy, push_command_policy,
     push_execution_policy, CapabilityPolicy, ToolApprovalPolicy,
@@ -32,6 +33,7 @@ const HOST_SESSION_TOTALS: &str = "__host_agent_session_totals";
 const HOST_SESSION_INJECT_FEEDBACK: &str = "__host_agent_session_inject_feedback";
 const HOST_SESSION_SET_ACTIVE_SKILLS: &str = "__host_agent_session_set_active_skills";
 const HOST_SESSION_ACTIVE_SKILLS: &str = "__host_agent_session_active_skills";
+const HOST_SESSION_RECORD_SKILL_EVENT: &str = "__host_agent_session_record_skill_event";
 const HOST_SESSION_COMPACT: &str = "__host_agent_session_compact_if_needed";
 const HOST_SKILL_SCORE: &str = "__host_skill_score";
 const HOST_BUDGET_PRE_CALL: &str = "__host_agent_budget_pre_call_blocked";
@@ -170,6 +172,8 @@ async fn host_agent_session_init(args: Vec<VmValue>) -> Result<VmValue, VmError>
 
     let installed_policies = install_session_policies(&opts_map)?;
 
+    let persisted_active_skills = crate::agent_sessions::active_skills(&resolved);
+
     let session = AgentHostSession {
         session_id: resolved.clone(),
         task: message.clone(),
@@ -177,7 +181,7 @@ async fn host_agent_session_init(args: Vec<VmValue>) -> Result<VmValue, VmError>
         cost_used: 0.0,
         input_tokens: 0,
         output_tokens: 0,
-        active_skills: Vec::new(),
+        active_skills: persisted_active_skills,
         tool_calls: Vec::new(),
         successful_tools: Vec::new(),
         rejected_tools: Vec::new(),
@@ -550,9 +554,10 @@ fn host_agent_session_set_active_skills_builtin(
         .filter_map(|v| dict_get(v, "id").map(|v| v.display()))
         .collect();
     with_session(&session_id, HOST_SESSION_SET_ACTIVE_SKILLS, |session| {
-        session.active_skills = ids;
+        session.active_skills = ids.clone();
         Ok(())
     })?;
+    crate::agent_sessions::set_active_skills(&session_id, ids);
     Ok(VmValue::Nil)
 }
 
@@ -575,6 +580,84 @@ fn host_agent_session_active_skills_builtin(
     Ok(VmValue::List(Rc::new(list)))
 }
 
+fn host_agent_session_record_skill_event_builtin(
+    args: &[VmValue],
+    _out: &mut String,
+) -> Result<VmValue, VmError> {
+    let session_id = args.first().map(|v| v.display()).unwrap_or_default();
+    let kind = args.get(1).map(|v| v.display()).unwrap_or_default();
+    let metadata = args.get(2).cloned().unwrap_or(VmValue::Nil);
+    if session_id.is_empty() || kind.is_empty() {
+        return Ok(VmValue::Nil);
+    }
+    let metadata_json = vm_to_json(&metadata);
+    let text = metadata_json
+        .get("name")
+        .and_then(|value| value.as_str())
+        .unwrap_or("")
+        .to_string();
+    let event = super::helpers::transcript_event(
+        &kind,
+        "system",
+        "internal",
+        &text,
+        Some(metadata_json.clone()),
+    );
+    let _ = crate::agent_sessions::append_event(&session_id, event);
+
+    let name = metadata_json
+        .get("name")
+        .and_then(|value| value.as_str())
+        .unwrap_or("")
+        .to_string();
+    let iteration = metadata_json
+        .get("iteration")
+        .and_then(|value| value.as_u64())
+        .unwrap_or(0) as usize;
+    match kind.as_str() {
+        "skill_activated" if !name.is_empty() => {
+            let reason = metadata_json
+                .get("trigger")
+                .or_else(|| metadata_json.get("reason"))
+                .and_then(|value| value.as_str())
+                .unwrap_or("")
+                .to_string();
+            super::agent_runtime::emit_agent_event_sync(&AgentEvent::SkillActivated {
+                session_id,
+                skill_name: name,
+                iteration,
+                reason,
+            });
+        }
+        "skill_deactivated" if !name.is_empty() => {
+            super::agent_runtime::emit_agent_event_sync(&AgentEvent::SkillDeactivated {
+                session_id,
+                skill_name: name,
+                iteration,
+            });
+        }
+        "skill_scope_tools" if !name.is_empty() => {
+            let allowed_tools = metadata_json
+                .get("allowed_tools")
+                .and_then(|value| value.as_array())
+                .map(|values| {
+                    values
+                        .iter()
+                        .filter_map(|value| value.as_str().map(str::to_string))
+                        .collect()
+                })
+                .unwrap_or_default();
+            super::agent_runtime::emit_agent_event_sync(&AgentEvent::SkillScopeTools {
+                session_id,
+                skill_name: name,
+                allowed_tools,
+            });
+        }
+        _ => {}
+    }
+    Ok(VmValue::Nil)
+}
+
 fn host_agent_session_compact_builtin(
     _args: &[VmValue],
     _out: &mut String,
@@ -582,11 +665,17 @@ fn host_agent_session_compact_builtin(
     Ok(VmValue::Nil)
 }
 
-async fn host_skill_score(_args: Vec<VmValue>) -> Result<VmValue, VmError> {
-    let mut out = BTreeMap::new();
-    out.insert("scored".to_string(), VmValue::List(Rc::new(Vec::new())));
-    out.insert("active".to_string(), VmValue::List(Rc::new(Vec::new())));
-    Ok(VmValue::Dict(Rc::new(out)))
+async fn host_skill_score(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+    let context = args.first().cloned().unwrap_or(VmValue::Nil);
+    let registry = args.get(1).cloned().unwrap_or(VmValue::Nil);
+    let options = args.get(2).cloned().unwrap_or(VmValue::Nil);
+    super::skill_score::score_skill_registry(
+        &context,
+        &registry,
+        &options,
+        super::current_host_bridge(),
+    )
+    .await
 }
 
 fn host_agent_budget_pre_call_builtin(
@@ -608,6 +697,9 @@ fn host_agent_build_turn_system_builtin(
             parts.push(system);
         }
     }
+    if let Some(skill_prompt) = render_active_skill_prompt(opts_map.get("active_skills")) {
+        parts.push(skill_prompt);
+    }
     if opts_map.contains_key("tools") {
         let tool_format = opt_str(&opts_map, "tool_format").unwrap_or_else(|| "text".to_string());
         if tool_format != "native" {
@@ -620,6 +712,70 @@ fn host_agent_build_turn_system_builtin(
         }
     }
     Ok(VmValue::String(Rc::from(parts.join("\n\n"))))
+}
+
+fn render_active_skill_prompt(value: Option<&VmValue>) -> Option<String> {
+    let active = match value {
+        Some(VmValue::List(list)) => list,
+        _ => return None,
+    };
+    if active.is_empty() {
+        return None;
+    }
+    let mut out = String::from("## Active skills\n");
+    for skill in active.iter() {
+        let Some(dict) = skill.as_dict() else {
+            continue;
+        };
+        let name = dict
+            .get("id")
+            .or_else(|| dict.get("name"))
+            .map(VmValue::display);
+        let Some(name) = name.filter(|name| !name.is_empty()) else {
+            continue;
+        };
+        out.push_str(&format!("\n### {name}\n"));
+        if let Some(description) = dict
+            .get("description")
+            .map(VmValue::display)
+            .filter(|text| !text.trim().is_empty())
+        {
+            out.push_str(description.trim());
+            out.push('\n');
+        }
+        if let Some(when_to_use) = dict
+            .get("when_to_use")
+            .map(VmValue::display)
+            .filter(|text| !text.trim().is_empty())
+        {
+            out.push_str("When to use: ");
+            out.push_str(when_to_use.trim());
+            out.push('\n');
+        }
+        let allowed_tools = match dict.get("allowed_tools") {
+            Some(VmValue::List(list)) => list
+                .iter()
+                .map(VmValue::display)
+                .filter(|text| !text.is_empty())
+                .collect::<Vec<_>>(),
+            _ => Vec::new(),
+        };
+        if !allowed_tools.is_empty() {
+            out.push_str("Scoped tools: ");
+            out.push_str(&allowed_tools.join(", "));
+            out.push('\n');
+        }
+        if let Some(prompt) = dict
+            .get("prompt")
+            .map(VmValue::display)
+            .filter(|text| !text.trim().is_empty())
+        {
+            out.push('\n');
+            out.push_str(prompt.trim());
+            out.push('\n');
+        }
+    }
+    Some(out)
 }
 
 /// Install per-agent execution / approval / command / dynamic permission
@@ -783,6 +939,13 @@ const HOST_SESSION_PRIMITIVES_SYNC: &[SyncBuiltin] = &[
     .signature("__host_agent_session_active_skills(session_id)")
     .arity(VmBuiltinArity::Exact(1))
     .doc("Return the session's active skill list."),
+    SyncBuiltin::new(
+        HOST_SESSION_RECORD_SKILL_EVENT,
+        host_agent_session_record_skill_event_builtin,
+    )
+    .signature("__host_agent_session_record_skill_event(session_id, kind, metadata)")
+    .arity(VmBuiltinArity::Exact(3))
+    .doc("Append a skill lifecycle event and notify live agent-event sinks."),
     SyncBuiltin::new(HOST_SESSION_COMPACT, host_agent_session_compact_builtin)
         .signature("__host_agent_session_compact_if_needed(session_id, options)")
         .arity(VmBuiltinArity::Exact(2))
@@ -826,7 +989,7 @@ pub fn register_agent_session_host_primitives(vm: &mut Vm) {
         .signature_static("__host_skill_score(context, registry, options)")
         .arity(VmBuiltinArity::Exact(3))
         .category_static("agent.host")
-        .doc_static("Score skills against the current task context (stub returning empty).");
+        .doc_static("Score skills against the current task context.");
     vm.register_async_builtin_with_metadata(skill_score, |args| {
         Box::pin(async move { host_skill_score(args).await })
     });

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -31,6 +31,7 @@ pub(crate) mod permissions;
 pub mod plan;
 pub mod readiness;
 pub(crate) mod schema_recover;
+pub(crate) mod skill_score;
 pub(crate) mod structural_experiments;
 pub(crate) mod structured_envelope;
 mod transcript_stats;

--- a/crates/harn-vm/src/llm/skill_score.rs
+++ b/crates/harn-vm/src/llm/skill_score.rs
@@ -1,0 +1,454 @@
+//! Side-effect-free skill scoring for the Harn-driven agent loop.
+//!
+//! Activation, sticky reuse, prompt composition, and tool-surface policy
+//! live in `std/agent/skills.harn`. This module only turns a task context
+//! plus a skill registry into ranked score records.
+
+use std::collections::BTreeMap;
+use std::rc::Rc;
+
+use crate::bridge::HostBridge;
+use crate::value::{VmError, VmValue};
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+enum SkillMatchStrategy {
+    #[default]
+    Metadata,
+    Host,
+    Embedding,
+}
+
+impl SkillMatchStrategy {
+    fn parse(value: Option<&VmValue>) -> Self {
+        let Some(value) = value else {
+            return Self::Metadata;
+        };
+        match value.display().trim().to_ascii_lowercase().as_str() {
+            "host" => Self::Host,
+            "embedding" => Self::Embedding,
+            "metadata" | "" => Self::Metadata,
+            other => {
+                crate::events::log_warn(
+                    "agent.skill_score",
+                    &format!("unknown strategy '{other}', falling back to 'metadata'"),
+                );
+                Self::Metadata
+            }
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Metadata => "metadata",
+            Self::Host => "host",
+            Self::Embedding => "embedding",
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct SkillCandidate {
+    id: String,
+    score: f64,
+    trigger: String,
+}
+
+pub(crate) async fn score_skill_registry(
+    context: &VmValue,
+    registry: &VmValue,
+    options: &VmValue,
+    bridge: Option<Rc<HostBridge>>,
+) -> Result<VmValue, VmError> {
+    let skills: Vec<VmValue> = extract_skills(registry)
+        .into_iter()
+        .filter(|skill| !skill_disabled_for_model(skill))
+        .collect();
+    let options = options.as_dict().cloned().unwrap_or_default();
+    let strategy = SkillMatchStrategy::parse(options.get("strategy"));
+    let task = context
+        .as_dict()
+        .and_then(|dict| dict.get("task"))
+        .map(VmValue::display)
+        .unwrap_or_default();
+    let working_files = list_strings(context.as_dict().and_then(|dict| dict.get("working_files")));
+
+    let scored = match strategy {
+        SkillMatchStrategy::Metadata => score_metadata(&skills, &task, &working_files),
+        SkillMatchStrategy::Host | SkillMatchStrategy::Embedding => {
+            match score_via_bridge(bridge.as_deref(), &skills, &task, &working_files, strategy)
+                .await
+            {
+                Ok(scored) => scored,
+                Err(error) => {
+                    crate::events::log_warn(
+                        "agent.skill_score",
+                        &format!(
+                            "{} strategy failed: {error}; falling back to metadata scoring",
+                            strategy.as_str()
+                        ),
+                    );
+                    score_metadata(&skills, &task, &working_files)
+                }
+            }
+        }
+    };
+
+    let scored_values = scored.into_iter().map(candidate_to_vm).collect();
+    Ok(VmValue::Dict(Rc::new(BTreeMap::from([(
+        "scored".to_string(),
+        VmValue::List(Rc::new(scored_values)),
+    )]))))
+}
+
+fn candidate_to_vm(candidate: SkillCandidate) -> VmValue {
+    VmValue::Dict(Rc::new(BTreeMap::from([
+        (
+            "id".to_string(),
+            VmValue::String(Rc::from(candidate.id.clone())),
+        ),
+        ("name".to_string(), VmValue::String(Rc::from(candidate.id))),
+        ("score".to_string(), VmValue::Float(candidate.score)),
+        (
+            "trigger".to_string(),
+            VmValue::String(Rc::from(candidate.trigger.clone())),
+        ),
+        (
+            "reason".to_string(),
+            VmValue::String(Rc::from(candidate.trigger)),
+        ),
+    ])))
+}
+
+fn extract_skills(registry: &VmValue) -> Vec<VmValue> {
+    let Some(dict) = registry.as_dict() else {
+        return Vec::new();
+    };
+    match dict.get("skills") {
+        Some(VmValue::List(list)) => list.iter().cloned().collect(),
+        _ => Vec::new(),
+    }
+}
+
+fn list_strings(value: Option<&VmValue>) -> Vec<String> {
+    match value {
+        Some(VmValue::List(list)) => list
+            .iter()
+            .map(VmValue::display)
+            .filter(|text| !text.is_empty())
+            .collect(),
+        Some(VmValue::String(text)) if !text.is_empty() => vec![text.to_string()],
+        _ => Vec::new(),
+    }
+}
+
+fn skill_disabled_for_model(skill: &VmValue) -> bool {
+    let Some(dict) = skill.as_dict() else {
+        return false;
+    };
+    matches!(
+        dict.get("disable-model-invocation")
+            .or_else(|| dict.get("disable_model_invocation")),
+        Some(VmValue::Bool(true))
+    )
+}
+
+fn score_metadata(skills: &[VmValue], task: &str, working_files: &[String]) -> Vec<SkillCandidate> {
+    let tokens = tokenize_lower(task);
+    let lower_task = task.to_lowercase();
+    let mut candidates = Vec::new();
+    for skill in skills {
+        if skill_disabled_for_model(skill) {
+            continue;
+        }
+        let Some(dict) = skill.as_dict() else {
+            continue;
+        };
+        let id = dict.get("name").map(VmValue::display).unwrap_or_default();
+        if id.is_empty() {
+            continue;
+        }
+        let description = dict
+            .get("description")
+            .map(VmValue::display)
+            .unwrap_or_default();
+        let when_to_use = dict
+            .get("when_to_use")
+            .map(VmValue::display)
+            .unwrap_or_default();
+        let paths = list_strings(dict.get("paths"));
+
+        let mut score = 0.0_f64;
+        let mut triggers = Vec::new();
+        let keyword_hits =
+            count_term_hits(&tokens, &description) + count_term_hits(&tokens, &when_to_use);
+        if keyword_hits > 0 {
+            let bm25 = (keyword_hits as f64) / (keyword_hits as f64 + 1.5);
+            score += bm25;
+            triggers.push(format!("{keyword_hits} keyword hit(s)"));
+        }
+        if lower_task.contains(&id.to_lowercase()) {
+            score += 2.0;
+            triggers.push(format!("task mentions '{id}'"));
+        }
+        let path_hits = count_path_hits(&paths, working_files);
+        if path_hits > 0 {
+            score += 1.5 * (path_hits as f64);
+            triggers.push(format!("{path_hits} path glob(s) matched"));
+        }
+        if score > 0.0 {
+            candidates.push(SkillCandidate {
+                id,
+                score,
+                trigger: triggers.join("; "),
+            });
+        }
+    }
+    candidates.sort_by(|left, right| {
+        right
+            .score
+            .partial_cmp(&left.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| left.id.cmp(&right.id))
+    });
+    candidates
+}
+
+fn tokenize_lower(text: &str) -> Vec<String> {
+    text.split(|c: char| !c.is_alphanumeric())
+        .filter(|token| token.len() > 2)
+        .map(str::to_lowercase)
+        .collect()
+}
+
+fn count_term_hits(terms: &[String], haystack: &str) -> usize {
+    if terms.is_empty() || haystack.is_empty() {
+        return 0;
+    }
+    let lower = haystack.to_lowercase();
+    terms
+        .iter()
+        .filter(|term| lower.contains(term.as_str()))
+        .count()
+}
+
+fn count_path_hits(patterns: &[String], working_files: &[String]) -> usize {
+    let mut hits = 0;
+    for pattern in patterns {
+        for file in working_files {
+            if glob_match(pattern, file) {
+                hits += 1;
+                break;
+            }
+        }
+    }
+    hits
+}
+
+fn glob_match(pattern: &str, path: &str) -> bool {
+    glob_match_inner(pattern.as_bytes(), 0, path.as_bytes(), 0)
+}
+
+fn glob_match_inner(pattern: &[u8], mut pi: usize, path: &[u8], si: usize) -> bool {
+    let mut si = si;
+    while pi < pattern.len() {
+        match pattern[pi] {
+            b'*' => {
+                let double = pi + 1 < pattern.len() && pattern[pi + 1] == b'*';
+                let next_pi = if double { pi + 2 } else { pi + 1 };
+                let next_pi = if double && next_pi < pattern.len() && pattern[next_pi] == b'/' {
+                    next_pi + 1
+                } else {
+                    next_pi
+                };
+                if next_pi >= pattern.len() {
+                    return double || !path[si..].contains(&b'/');
+                }
+                for try_si in si..=path.len() {
+                    if !double && path[si..try_si].contains(&b'/') {
+                        break;
+                    }
+                    if glob_match_inner(pattern, next_pi, path, try_si) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+            b'?' => {
+                if si >= path.len() || path[si] == b'/' {
+                    return false;
+                }
+                pi += 1;
+                si += 1;
+            }
+            expected => {
+                if si >= path.len() || path[si] != expected {
+                    return false;
+                }
+                pi += 1;
+                si += 1;
+            }
+        }
+    }
+    si == path.len()
+}
+
+async fn score_via_bridge(
+    bridge: Option<&HostBridge>,
+    skills: &[VmValue],
+    task: &str,
+    working_files: &[String],
+    strategy: SkillMatchStrategy,
+) -> Result<Vec<SkillCandidate>, VmError> {
+    let Some(bridge) = bridge else {
+        return Err(VmError::Runtime(
+            "skill scoring strategy requires a host bridge".to_string(),
+        ));
+    };
+    let candidates: Vec<serde_json::Value> = skills
+        .iter()
+        .filter_map(VmValue::as_dict)
+        .map(|dict| {
+            serde_json::json!({
+                "name": dict.get("name").map(VmValue::display).unwrap_or_default(),
+                "description": dict.get("description").map(VmValue::display).unwrap_or_default(),
+                "when_to_use": dict.get("when_to_use").map(VmValue::display).unwrap_or_default(),
+                "paths": list_strings(dict.get("paths")),
+            })
+        })
+        .collect();
+    let response = bridge
+        .call(
+            "skill/match",
+            serde_json::json!({
+                "strategy": strategy.as_str(),
+                "prompt": task,
+                "task": task,
+                "working_files": working_files,
+                "candidates": candidates,
+            }),
+        )
+        .await?;
+    let list = response
+        .get("matches")
+        .or_else(|| response.get("skills"))
+        .or_else(|| {
+            response
+                .get("result")
+                .and_then(|result| result.get("matches"))
+        })
+        .cloned()
+        .or_else(|| response.is_array().then_some(response))
+        .unwrap_or_else(|| serde_json::Value::Array(Vec::new()));
+    let mut out = Vec::new();
+    for entry in list.as_array().cloned().unwrap_or_default() {
+        let id = entry
+            .get("id")
+            .or_else(|| entry.get("name"))
+            .and_then(|value| value.as_str())
+            .unwrap_or("")
+            .to_string();
+        if id.is_empty() {
+            continue;
+        }
+        let score = entry
+            .get("score")
+            .and_then(|value| value.as_f64())
+            .unwrap_or(1.0);
+        let trigger = entry
+            .get("trigger")
+            .or_else(|| entry.get("reason"))
+            .and_then(|value| value.as_str())
+            .unwrap_or("host match")
+            .to_string();
+        out.push(SkillCandidate { id, score, trigger });
+    }
+    out.sort_by(|left, right| {
+        right
+            .score
+            .partial_cmp(&left.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| left.id.cmp(&right.id))
+    });
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn skill(fields: &[(&str, VmValue)]) -> VmValue {
+        VmValue::Dict(Rc::new(
+            fields
+                .iter()
+                .map(|(key, value)| ((*key).to_string(), value.clone()))
+                .collect(),
+        ))
+    }
+
+    #[test]
+    fn metadata_ranks_keyword_matches() {
+        let ranked = score_metadata(
+            &[
+                skill(&[
+                    ("name", VmValue::String(Rc::from("deploy"))),
+                    (
+                        "description",
+                        VmValue::String(Rc::from("Deploy application releases")),
+                    ),
+                    (
+                        "when_to_use",
+                        VmValue::String(Rc::from("User asks to ship or deploy")),
+                    ),
+                ]),
+                skill(&[
+                    ("name", VmValue::String(Rc::from("metrics"))),
+                    (
+                        "description",
+                        VmValue::String(Rc::from("Inspect dashboards")),
+                    ),
+                ]),
+            ],
+            "please deploy the service",
+            &[],
+        );
+        assert_eq!(ranked[0].id, "deploy");
+    }
+
+    #[test]
+    fn path_globs_match_working_files() {
+        let ranked = score_metadata(
+            &[skill(&[
+                ("name", VmValue::String(Rc::from("infra"))),
+                ("description", VmValue::String(Rc::from("Infrastructure"))),
+                (
+                    "paths",
+                    VmValue::List(Rc::new(vec![
+                        VmValue::String(Rc::from("infra/**")),
+                        VmValue::String(Rc::from("Dockerfile")),
+                    ])),
+                ),
+            ])],
+            "unrelated",
+            &["infra/terraform/main.tf".to_string()],
+        );
+        assert_eq!(ranked.len(), 1);
+        assert!(ranked[0].trigger.contains("path"));
+    }
+
+    #[test]
+    fn disabled_skills_are_hidden_from_metadata_scoring() {
+        let ranked = score_metadata(
+            &[skill(&[
+                ("name", VmValue::String(Rc::from("secret"))),
+                (
+                    "description",
+                    VmValue::String(Rc::from("Rotate database credentials")),
+                ),
+                ("disable-model-invocation", VmValue::Bool(true)),
+            ])],
+            "rotate database credentials",
+            &[],
+        );
+        assert!(ranked.is_empty());
+    }
+}

--- a/crates/harn-vm/src/orchestration/workflow.rs
+++ b/crates/harn-vm/src/orchestration/workflow.rs
@@ -1030,6 +1030,18 @@ fn workflow_stage_agent_loop_options(
 ) -> Result<BTreeMap<String, VmValue>, VmError> {
     let mut options = stage_agent_options.agent_loop_options_vm_dict();
     merge_raw_model_policy_options(&mut options, node);
+    if let Some(context) = crate::orchestration::current_workflow_skill_context() {
+        if !options.contains_key("skills") {
+            if let Some(registry) = context.registry {
+                options.insert("skills".to_string(), registry);
+            }
+        }
+        if !options.contains_key("skill_match") {
+            if let Some(match_config) = context.match_config {
+                options.insert("skill_match".to_string(), match_config);
+            }
+        }
+    }
     preserve_nested_command_policy(&mut options, node);
     add_workflow_agent_compaction_options(&mut options, node);
     add_stage_tools_option(&mut options, tools_value, tool_names);

--- a/crates/harn-vm/src/skills/mod.rs
+++ b/crates/harn-vm/src/skills/mod.rs
@@ -27,8 +27,9 @@ pub use discovery::{DiscoveryOptions, DiscoveryReport, LayeredDiscovery, Shadowe
 pub use frontmatter::{parse_frontmatter, split_frontmatter, ParsedFrontmatter, SkillManifest};
 pub use runtime::{
     clear_current_skill_registry, current_skill_registry, install_current_skill_registry,
-    load_bound_skill_by_name, load_skill_from_registry, resolve_skill_entry, skill_entry_id,
-    vm_error as skill_vm_error, BoundSkillRegistry, LoadedSkill, SkillFetcher,
+    load_bound_skill_by_name, load_bound_skill_by_name_with_options, load_skill_from_registry,
+    resolve_skill_entry, skill_entry_id, tool_rejected_error, vm_error as skill_vm_error,
+    BoundSkillRegistry, LoadSkillOptions, LoadedSkill, SkillFetcher,
 };
 pub use source::{
     skill_entry_to_vm, skill_manifest_ref_to_vm, FsSkillSource, HostSkillSource, Layer, Skill,

--- a/crates/harn-vm/src/skills/runtime.rs
+++ b/crates/harn-vm/src/skills/runtime.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use std::rc::Rc;
 use std::sync::Arc;
 
-use crate::value::{VmError, VmValue};
+use crate::value::{ErrorCategory, VmError, VmValue};
 
 use super::{skill_entry_to_vm, substitute_skill_body, Skill, SubstitutionContext};
 
@@ -19,6 +19,13 @@ pub struct LoadedSkill {
     pub id: String,
     pub entry: BTreeMap<String, VmValue>,
     pub rendered_body: String,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct LoadSkillOptions {
+    pub session_id: Option<String>,
+    pub require_signature: bool,
+    pub model_invocation: bool,
 }
 
 thread_local! {
@@ -87,7 +94,7 @@ pub fn resolve_skill_entry(
 
     match bare_matches.len() {
         1 => Ok(bare_matches.remove(0)),
-        0 => Err(format!("skill '{target}' not found")),
+        0 => Err(format!("skill_not_found: skill '{target}' not found")),
         _ => Err(format!(
             "skill '{target}' is ambiguous; use the fully qualified id from the catalog"
         )),
@@ -139,7 +146,13 @@ fn hydrate_skill_entry(
 
     let loaded = fetcher(&skill_id)?;
     match skill_entry_to_vm(&loaded) {
-        VmValue::Dict(dict) => Ok((*dict).clone()),
+        VmValue::Dict(dict) => {
+            let mut hydrated = (*dict).clone();
+            for (key, value) in entry {
+                hydrated.entry(key).or_insert(value);
+            }
+            Ok(hydrated)
+        }
         _ => Err(format!(
             "{builtin_name}: failed to hydrate skill '{skill_id}'"
         )),
@@ -166,17 +179,31 @@ pub fn load_bound_skill_by_name(
     requested: &str,
     session_id: Option<&str>,
 ) -> Result<LoadedSkill, String> {
+    load_bound_skill_by_name_with_options(
+        requested,
+        LoadSkillOptions {
+            session_id: session_id.map(str::to_string),
+            require_signature: false,
+            model_invocation: false,
+        },
+    )
+}
+
+pub fn load_bound_skill_by_name_with_options(
+    requested: &str,
+    options: LoadSkillOptions,
+) -> Result<LoadedSkill, String> {
     let Some(binding) = current_skill_registry() else {
         return Err(
             "load_skill: no skill registry is bound to this scope. Start the VM with discovered skills first."
                 .to_string(),
         );
     };
-    load_skill_from_registry(
+    load_skill_from_registry_with_options(
         &binding.registry,
         Some(&binding.fetcher),
         requested,
-        session_id,
+        options,
         "load_skill",
     )
 }
@@ -188,10 +215,52 @@ pub fn load_skill_from_registry(
     session_id: Option<&str>,
     builtin_name: &str,
 ) -> Result<LoadedSkill, String> {
+    load_skill_from_registry_with_options(
+        registry,
+        fetcher,
+        requested,
+        LoadSkillOptions {
+            session_id: session_id.map(str::to_string),
+            require_signature: false,
+            model_invocation: false,
+        },
+        builtin_name,
+    )
+}
+
+pub fn load_skill_from_registry_with_options(
+    registry: &VmValue,
+    fetcher: Option<&SkillFetcher>,
+    requested: &str,
+    options: LoadSkillOptions,
+    builtin_name: &str,
+) -> Result<LoadedSkill, String> {
     let entry = resolve_skill_entry(registry, requested, builtin_name)?;
-    let entry = hydrate_skill_entry(entry, fetcher, builtin_name)?;
     let id = skill_entry_id(&entry);
-    let rendered_body = render_skill_entry(&entry, session_id);
+    if options.model_invocation && vm_bool_field(&entry, "disable_model_invocation") {
+        return Err(format!(
+            "skill_model_invocation_disabled: skill '{id}' cannot be loaded by a model"
+        ));
+    }
+    let require_signature = options.require_signature || vm_bool_field(&entry, "require_signature");
+    if require_signature {
+        let signed = vm_provenance_bool(&entry, "signed");
+        let trusted = vm_provenance_bool(&entry, "trusted");
+        if !signed || !trusted {
+            record_skill_loaded_event(
+                options.session_id.as_deref(),
+                &id,
+                &entry,
+                Some("UnsignedSkillError"),
+            );
+            return Err(format!(
+                "UnsignedSkillError: skill '{id}' requires a trusted signature"
+            ));
+        }
+    }
+    let entry = hydrate_skill_entry(entry, fetcher, builtin_name)?;
+    record_skill_loaded_event(options.session_id.as_deref(), &id, &entry, None);
+    let rendered_body = render_skill_entry(&entry, options.session_id.as_deref());
     Ok(LoadedSkill {
         id,
         entry,
@@ -199,6 +268,70 @@ pub fn load_skill_from_registry(
     })
 }
 
+fn vm_bool_field(entry: &BTreeMap<String, VmValue>, key: &str) -> bool {
+    matches!(entry.get(key), Some(VmValue::Bool(true)))
+}
+
+fn vm_provenance(entry: &BTreeMap<String, VmValue>) -> Option<&BTreeMap<String, VmValue>> {
+    entry.get("provenance").and_then(VmValue::as_dict)
+}
+
+fn vm_provenance_bool(entry: &BTreeMap<String, VmValue>, key: &str) -> bool {
+    vm_provenance(entry)
+        .and_then(|provenance| provenance.get(key))
+        .is_some_and(|value| matches!(value, VmValue::Bool(true)))
+}
+
+fn record_skill_loaded_event(
+    session_id: Option<&str>,
+    skill_id: &str,
+    entry: &BTreeMap<String, VmValue>,
+    error: Option<&str>,
+) {
+    let Some(session_id) = session_id.filter(|value| !value.is_empty()) else {
+        return;
+    };
+    let provenance = vm_provenance(entry);
+    let signed = provenance
+        .and_then(|metadata| metadata.get("signed"))
+        .is_some_and(|value| matches!(value, VmValue::Bool(true)));
+    let trusted = provenance
+        .and_then(|metadata| metadata.get("trusted"))
+        .is_some_and(|value| matches!(value, VmValue::Bool(true)));
+    let mut metadata = serde_json::Map::new();
+    metadata.insert("skill_id".to_string(), serde_json::json!(skill_id));
+    metadata.insert("signed".to_string(), serde_json::json!(signed));
+    metadata.insert("trusted".to_string(), serde_json::json!(trusted));
+    if let Some(provenance) = provenance {
+        for key in ["status", "signer_fingerprint", "skill_sha256"] {
+            if let Some(value) = provenance.get(key) {
+                metadata.insert(key.to_string(), crate::llm::vm_value_to_json(value));
+            }
+        }
+    }
+    if let Some(error) = error {
+        metadata.insert("error".to_string(), serde_json::json!(error));
+    }
+    let event = crate::llm::helpers::transcript_event(
+        "skill.loaded",
+        "system",
+        "internal",
+        &match error {
+            Some(error) => format!("Skill load blocked for {skill_id}: {error}"),
+            None => format!("Loaded skill {skill_id}"),
+        },
+        Some(serde_json::Value::Object(metadata)),
+    );
+    let _ = crate::agent_sessions::append_event(session_id, event);
+}
+
 pub fn vm_error(message: impl Into<String>) -> VmError {
     VmError::Thrown(VmValue::String(Rc::from(message.into())))
+}
+
+pub fn tool_rejected_error(message: impl Into<String>) -> VmError {
+    VmError::CategorizedError {
+        message: message.into(),
+        category: ErrorCategory::ToolRejected,
+    }
 }

--- a/crates/harn-vm/src/stdlib/agents_sub_agent.rs
+++ b/crates/harn-vm/src/stdlib/agents_sub_agent.rs
@@ -157,6 +157,18 @@ pub(super) fn parse_sub_agent_request(args: &[VmValue]) -> Result<ParsedSubAgent
         .unwrap_or_else(|| format!("sub_agent_session_{}", uuid::Uuid::now_v7()));
 
     let mut options = raw_options.clone();
+    if let Some(context) = crate::orchestration::current_workflow_skill_context() {
+        if !options.contains_key("skills") {
+            if let Some(registry) = context.registry {
+                options.insert("skills".to_string(), registry);
+            }
+        }
+        if !options.contains_key("skill_match") {
+            if let Some(match_config) = context.match_config {
+                options.insert("skill_match".to_string(), match_config);
+            }
+        }
+    }
     for key in [
         "background",
         "carry",

--- a/crates/harn-vm/src/stdlib/skills.rs
+++ b/crates/harn-vm/src/stdlib/skills.rs
@@ -627,26 +627,22 @@ pub(crate) fn register_skill_builtins(vm: &mut Vm) {
     });
 
     vm.register_async_builtin("load_skill", |args| async move {
-        let requested = match args.first() {
-            Some(VmValue::String(name)) if !name.is_empty() => name.to_string(),
-            Some(value) => {
-                let rendered = value.display();
-                if rendered.is_empty() {
-                    return Err(crate::skills::skill_vm_error(
-                        "load_skill: requires a non-empty skill name",
-                    ));
-                }
-                rendered
-            }
-            None => {
-                return Err(crate::skills::skill_vm_error(
-                    "load_skill: requires a non-empty skill name",
-                ));
-            }
-        };
-        let session_id = std::env::var("HARN_SESSION_ID").ok();
-        let loaded = crate::skills::load_bound_skill_by_name(&requested, session_id.as_deref())
-            .map_err(crate::skills::skill_vm_error)?;
+        let (requested, inline_options) = parse_load_skill_request(args.first())?;
+        let call_options = parse_load_skill_options(args.get(1))?;
+        let session_id = call_options
+            .session_id
+            .or(inline_options.session_id)
+            .or_else(|| std::env::var("HARN_SESSION_ID").ok());
+        let loaded = crate::skills::load_bound_skill_by_name_with_options(
+            &requested,
+            crate::skills::LoadSkillOptions {
+                session_id,
+                require_signature: call_options.require_signature
+                    || inline_options.require_signature,
+                model_invocation: true,
+            },
+        )
+        .map_err(crate::skills::tool_rejected_error)?;
         Ok(VmValue::String(Rc::from(loaded.rendered_body.as_str())))
     });
 
@@ -663,6 +659,69 @@ pub(crate) fn register_skill_builtins(vm: &mut Vm) {
         let count = vm_get_skills(registry).len();
         Ok(VmValue::Int(count as i64))
     });
+}
+
+fn parse_load_skill_request(
+    value: Option<&VmValue>,
+) -> Result<(String, crate::skills::LoadSkillOptions), VmError> {
+    let Some(value) = value else {
+        return Err(crate::skills::skill_vm_error(
+            "load_skill: requires a non-empty skill name",
+        ));
+    };
+    let options = parse_load_skill_options(Some(value))?;
+    let requested = match value {
+        VmValue::Dict(map) => map
+            .get("name")
+            .or_else(|| map.get("id"))
+            .map(|value| value.display())
+            .unwrap_or_default(),
+        VmValue::String(name) => name.to_string(),
+        other => other.display(),
+    };
+    if requested.is_empty() {
+        return Err(crate::skills::skill_vm_error(
+            "load_skill: requires a non-empty skill name",
+        ));
+    }
+    Ok((requested, options))
+}
+
+fn parse_load_skill_options(
+    value: Option<&VmValue>,
+) -> Result<crate::skills::LoadSkillOptions, VmError> {
+    let mut options = crate::skills::LoadSkillOptions::default();
+    let Some(value) = value else {
+        return Ok(options);
+    };
+    let VmValue::Dict(map) = value else {
+        return Ok(options);
+    };
+    if let Some(value) = map.get("require_signature") {
+        match value {
+            VmValue::Bool(flag) => options.require_signature = *flag,
+            VmValue::Nil => {}
+            _ => {
+                return Err(crate::skills::skill_vm_error(
+                    "load_skill: require_signature must be a bool",
+                ));
+            }
+        }
+    }
+    if let Some(value) = map.get("session_id") {
+        match value {
+            VmValue::String(session_id) if !session_id.is_empty() => {
+                options.session_id = Some(session_id.to_string());
+            }
+            VmValue::String(_) | VmValue::Nil => {}
+            _ => {
+                return Err(crate::skills::skill_vm_error(
+                    "load_skill: session_id must be a string",
+                ));
+            }
+        }
+    }
+    Ok(options)
 }
 
 #[cfg(test)]

--- a/crates/harn-vm/tests/builtin_registry_alignment.rs
+++ b/crates/harn-vm/tests/builtin_registry_alignment.rs
@@ -105,6 +105,7 @@ const RUNTIME_ONLY_EXCEPTIONS: &[&str] = &[
     "__host_agent_session_inject_feedback",
     "__host_agent_session_messages",
     "__host_agent_session_record_assistant",
+    "__host_agent_session_record_skill_event",
     "__host_agent_session_record_tool_results",
     "__host_agent_session_record_usage",
     "__host_agent_session_set_active_skills",


### PR DESCRIPTION
## Summary
- replace the skill scoring stub with a Rust primitive that ranks metadata/path matches and delegates host/embedding strategies through the bridge with metadata fallback
- move lifecycle policy into Harn: sticky/top-N activation, scoped tool filtering, active-skill prompts, and load_skill tool injection
- enforce model load_skill gating for disabled/unsigned skills, emit skill.loaded provenance records, and propagate workflow/sub-agent skill context
- remove the issue-owned xfail markers

Closes #1240

## Verification
- cargo check -p harn-vm --tests
- cargo test -p harn-vm skill_score -- --nocapture
- cargo test -p harn-vm --test builtin_registry_alignment -- --nocapture
- cargo run --quiet --bin harn -- test conformance --filter skill_lifecycle
- cargo run --quiet --bin harn -- test conformance --filter load_skill
- cargo run --quiet --bin harn -- test conformance --filter workflow_sub_agent_skill_context
- pre-commit hook
- pre-push hook