### PR TITLE
[agent] Re-enable manifest + scoped command policy hook conformance

### DIFF
--- a/conformance/tests/integration/manifest_hooks_runtime/main.harn
+++ b/conformance/tests/integration/manifest_hooks_runtime/main.harn
@@ -1,4 +1,3 @@
-/** @xfail: agent hooks not yet wired through Harn loop — tracked in burin-labs/harn#1236 */
 pipeline default() {
   llm_mock_clear()
   var registry = tool_registry()

--- a/conformance/tests/runtime/command_policy_hooks.harn
+++ b/conformance/tests/runtime/command_policy_hooks.harn
@@ -1,4 +1,3 @@
-/** @xfail: agent hooks not yet wired through Harn loop — tracked in burin-labs/harn#1236 */
 pipeline default() {
   let root = path_join(temp_dir(), "harn_command_policy_hooks")
   if file_exists(root) {


### PR DESCRIPTION
## Summary

- Drop `@xfail` markers from `conformance/tests/integration/manifest_hooks_runtime/main.harn` and `conformance/tests/runtime/command_policy_hooks.harn` — both paths are already wired through the Harn-driven agent loop:
  - Pre/post manifest tool hooks: `host_agent_dispatch_tool_call_impl` calls `crate::orchestration::run_pre_tool_hooks` and `run_post_tool_hooks` (`crates/harn-vm/src/llm/mod.rs:1447,1493`).
  - Scoped command policies: `agent_session_host::install_session_policies` pushes the per-session `command_policy` and pops on finalize (`crates/harn-vm/src/llm/agent_session_host.rs:670-676,693-695`).
- Closes #1243 (parent epic #1197).

## Test plan

- [x] `cargo run --bin harn -- test conformance --filter manifest_hooks_runtime`
- [x] `cargo run --bin harn -- test conformance --filter command_policy_hooks`
- [x] Full `make all` (workspace tests + conformance + harn lint/format + portal lint/build + docs snippets + ratchets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)