### PR TITLE
[agent] Bootstrap MCP servers from the Harn loop (#1238)

### DIFF
--- a/conformance/tests/integration/agent_loop_mcp_http_elicit.harn
+++ b/conformance/tests/integration/agent_loop_mcp_http_elicit.harn
@@ -1,4 +1,3 @@
-// @xfail: MCP bootstrap not yet wired through Harn loop — tracked in burin-labs/harn#1238
 import { process_shell } from "std/runtime"
 
 fn wait_for_file(path, attempts) {

--- a/conformance/tests/integration/agent_loop_mcp_servers.harn
+++ b/conformance/tests/integration/agent_loop_mcp_servers.harn
@@ -1,4 +1,3 @@
-// @xfail: MCP bootstrap not yet wired through Harn loop — tracked in burin-labs/harn#1238
 import { process_shell } from "std/runtime"
 
 fn wait_for_file(path, attempts) {

--- a/crates/harn-stdlib/src/lib.rs
+++ b/crates/harn-stdlib/src/lib.rs
@@ -146,6 +146,10 @@ pub const STDLIB_SOURCES: &[StdlibSource] = &[
         source: include_str!("stdlib/agent/autocompact.harn"),
     },
     StdlibSource {
+        module: "agent/mcp",
+        source: include_str!("stdlib/agent/mcp.harn"),
+    },
+    StdlibSource {
         module: "agent/budget",
         source: include_str!("stdlib/agent/budget.harn"),
     },

--- a/crates/harn-stdlib/src/stdlib/agent/loop.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/loop.harn
@@ -2,6 +2,7 @@
 import { agent_autocompact_if_needed } from "std/agent/autocompact"
 import { agent_budget_post_call_blocked, agent_budget_pre_call_blocked } from "std/agent/budget"
 import { agent_verify_or_continue } from "std/agent/judge"
+import { agent_mcp_bootstrap_if_needed } from "std/agent/mcp"
 import { agent_loop_options } from "std/agent/options"
 import { agent_compute_post_turn } from "std/agent/postturn"
 import { agent_build_turn_messages, agent_build_turn_system } from "std/agent/preflight"
@@ -18,11 +19,12 @@ import {
 
 /** agent_loop. */
 pub fn agent_loop(message, system_prompt = nil, options = nil) {
-  let opts = agent_loop_options(options)
+  var opts = agent_loop_options(options)
   let session = agent_session_init(message, system_prompt, opts)
   if session?.done {
     return session.result
   }
+  opts = agent_mcp_bootstrap_if_needed(session, opts)
   var iteration = 0
   var stop_reason = nil
   var final_status = ""
@@ -108,8 +110,10 @@ pub fn agent_loop(message, system_prompt = nil, options = nil) {
   if final_status == "" && iteration >= max_iterations && stop_reason == nil {
     final_status = "budget_exhausted"
   }
-  return agent_session_finalize(
+  let result = agent_session_finalize(
     session.session_id,
     {final_status: final_status, stop_reason: stop_reason ?? "", iterations: iteration},
   )
+  __host_mcp_disconnect(session.session_id)
+  return result
 }

--- a/crates/harn-stdlib/src/stdlib/agent/mcp.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/mcp.harn
@@ -1,0 +1,19 @@
+/** agent_mcp_bootstrap_if_needed. */
+pub fn agent_mcp_bootstrap_if_needed(session, opts) {
+  let specs = opts?.mcp_servers
+  if specs == nil || len(specs) == 0 {
+    return opts
+  }
+  let result = __host_mcp_bootstrap(session.session_id, specs)
+  if len(result.tools_added) == 0 {
+    return opts
+  }
+  let existing = opts?.tools
+  let existing_tools = if existing?._type == "tool_registry" {
+    existing?.tools ?? []
+  } else {
+    []
+  }
+  let reg = {_type: "tool_registry", tools: existing_tools + result.tools_added}
+  return opts + {tools: reg}
+}

--- a/crates/harn-vm/src/llm/agent_runtime.rs
+++ b/crates/harn-vm/src/llm/agent_runtime.rs
@@ -8,11 +8,13 @@
 //! channel for the active session id and bridge.
 
 use std::cell::RefCell;
+use std::collections::BTreeMap;
 use std::rc::Rc;
 use std::sync::{Arc, Condvar, LazyLock, Mutex};
 use std::time::Duration;
 
 use crate::agent_events::{self, AgentEvent, AgentEventSink};
+use crate::mcp::VmMcpClientHandle;
 use crate::value::VmValue;
 
 /// Boxed session-end hook: receives a `session_id` string.
@@ -51,6 +53,9 @@ static GLOBAL_PENDING_FEEDBACK_CV: LazyLock<Condvar> = LazyLock::new(Condvar::ne
 /// session (e.g. cancelling orphaned long-running handles).
 static SESSION_END_HOOKS: LazyLock<Mutex<Vec<SessionEndHook>>> =
     LazyLock::new(|| Mutex::new(Vec::new()));
+
+static SESSION_MCP_CLIENTS: LazyLock<Mutex<BTreeMap<String, BTreeMap<String, VmMcpClientHandle>>>> =
+    LazyLock::new(|| Mutex::new(BTreeMap::new()));
 
 /// RAII guard that pushes a per-loop event sink onto the
 /// `CURRENT_LOOP_SINKS` stack and pops it on drop.
@@ -258,4 +263,30 @@ pub(crate) fn current_host_bridge() -> Option<Rc<crate::bridge::HostBridge>> {
 /// `host_agent_session_init` / popped by `host_agent_session_finalize`.
 pub fn current_agent_session_id() -> Option<String> {
     crate::agent_sessions::current_session_id()
+}
+
+pub(crate) fn install_session_mcp_clients(
+    session_id: &str,
+    clients: BTreeMap<String, VmMcpClientHandle>,
+) {
+    if let Ok(mut map) = SESSION_MCP_CLIENTS.lock() {
+        map.insert(session_id.to_string(), clients);
+    }
+}
+
+pub(crate) fn take_session_mcp_clients(
+    session_id: &str,
+) -> Option<BTreeMap<String, VmMcpClientHandle>> {
+    SESSION_MCP_CLIENTS
+        .lock()
+        .ok()
+        .and_then(|mut map| map.remove(session_id))
+}
+
+pub(crate) fn session_mcp_client(session_id: &str, server_name: &str) -> Option<VmMcpClientHandle> {
+    SESSION_MCP_CLIENTS.lock().ok().and_then(|map| {
+        map.get(session_id)
+            .and_then(|clients| clients.get(server_name))
+            .cloned()
+    })
 }

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -1470,11 +1470,27 @@ async fn host_agent_dispatch_tool_call_impl(args: Vec<VmValue>) -> Result<VmValu
     }
 
     let started = std::time::Instant::now();
+    // Session-scoped MCP clients (from opts.mcp_servers) bypass the bridge.
+    let session_mcp = {
+        use std::collections::BTreeMap;
+        let mut clients: BTreeMap<String, crate::mcp::VmMcpClientHandle> = BTreeMap::new();
+        if let Some(server_name) = agent_tools::mcp_server_for_tool(tools.as_ref(), &tool_name) {
+            if let Some(handle) = agent_runtime::session_mcp_client(&session_id, &server_name) {
+                clients.insert(server_name, handle);
+            }
+        }
+        clients
+    };
+    let mcp_clients_ref = if session_mcp.is_empty() {
+        None
+    } else {
+        Some(&session_mcp)
+    };
     let outcome = agent_tools::dispatch_tool_execution_with_mcp(
         &tool_name,
         &tool_args,
         tools.as_ref(),
-        None,
+        mcp_clients_ref,
         bridge.as_ref(),
         tool_retries,
         tool_backoff_ms,
@@ -1546,6 +1562,140 @@ const LLM_TRACE_SYNC_PRIMITIVES: &[SyncBuiltin] = &[
         .doc("Return a summarized view of captured agent trace events."),
 ];
 
+async fn host_mcp_bootstrap_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+    use std::collections::BTreeMap;
+
+    let session_id = match args.first() {
+        Some(VmValue::String(s)) => s.to_string(),
+        Some(other) => {
+            return Err(VmError::Runtime(format!(
+                "__host_mcp_bootstrap(session_id, specs): session_id must be a string; got {}",
+                other.type_name()
+            )))
+        }
+        None => {
+            return Err(VmError::Runtime(
+                "__host_mcp_bootstrap(session_id, specs): missing session_id".to_string(),
+            ))
+        }
+    };
+
+    let specs_val = args.get(1).cloned().unwrap_or(VmValue::Nil);
+    let specs_list: Vec<serde_json::Value> = match &specs_val {
+        VmValue::List(list) => list.iter().map(crate::mcp::vm_value_to_serde).collect(),
+        VmValue::Nil => Vec::new(),
+        other => {
+            return Err(VmError::Runtime(format!(
+                "__host_mcp_bootstrap(session_id, specs): specs must be a list; got {}",
+                other.type_name()
+            )))
+        }
+    };
+
+    let mut clients: BTreeMap<String, crate::mcp::VmMcpClientHandle> = BTreeMap::new();
+    let mut tools_added: Vec<serde_json::Value> = Vec::new();
+    let mut errors: Vec<serde_json::Value> = Vec::new();
+
+    for spec in &specs_list {
+        let server_name = spec
+            .get("name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        if server_name.is_empty() {
+            errors.push(serde_json::json!({"error": "mcp_servers entry missing 'name'"}));
+            continue;
+        }
+
+        match crate::mcp::connect_mcp_server_from_json(spec).await {
+            Err(e) => {
+                errors.push(serde_json::json!({
+                    "server": server_name,
+                    "error": e.to_string(),
+                }));
+            }
+            Ok(handle) => {
+                let list_result = handle.call("tools/list", serde_json::json!({})).await;
+                match list_result {
+                    Err(e) => {
+                        errors.push(serde_json::json!({
+                            "server": server_name,
+                            "error": format!("tools/list failed: {e}"),
+                        }));
+                    }
+                    Ok(result) => {
+                        let raw_tools = result
+                            .get("tools")
+                            .and_then(|t| t.as_array())
+                            .cloned()
+                            .unwrap_or_default();
+                        for mut tool in raw_tools {
+                            if let Some(obj) = tool.as_object_mut() {
+                                let original_name = obj
+                                    .get("name")
+                                    .and_then(|v| v.as_str())
+                                    .unwrap_or("")
+                                    .to_string();
+                                let prefixed_name = format!("{server_name}__{original_name}");
+                                // Namespace to avoid conflicts between servers.
+                                obj.insert("name".into(), serde_json::Value::String(prefixed_name));
+                                obj.insert(
+                                    "executor".into(),
+                                    serde_json::Value::String("mcp_server".into()),
+                                );
+                                obj.insert(
+                                    "mcp_server".into(),
+                                    serde_json::Value::String(server_name.clone()),
+                                );
+                                obj.insert(
+                                    "_mcp_server".into(),
+                                    serde_json::Value::String(server_name.clone()),
+                                );
+                                obj.insert(
+                                    "_mcp_tool_name".into(),
+                                    serde_json::Value::String(original_name),
+                                );
+                            }
+                            tools_added.push(tool);
+                        }
+                        clients.insert(server_name, handle);
+                    }
+                }
+            }
+        }
+    }
+
+    agent_runtime::install_session_mcp_clients(&session_id, clients);
+
+    Ok(json_to_vm_value(&serde_json::json!({
+        "tools_added": tools_added,
+        "errors": errors,
+    })))
+}
+
+async fn host_mcp_disconnect_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+    let session_id = match args.first() {
+        Some(VmValue::String(s)) => s.to_string(),
+        Some(other) => {
+            return Err(VmError::Runtime(format!(
+                "__host_mcp_disconnect(session_id): session_id must be a string; got {}",
+                other.type_name()
+            )))
+        }
+        None => String::new(),
+    };
+
+    if !session_id.is_empty() {
+        if let Some(clients) = agent_runtime::take_session_mcp_clients(&session_id) {
+            for handle in clients.values() {
+                let _ = handle.disconnect().await;
+            }
+        }
+    }
+
+    Ok(VmValue::Bool(true))
+}
+
 const AGENT_HOST_ASYNC_PRIMITIVES: &[AsyncBuiltin] = &[
     async_builtin!(
         "__host_agent_capture_events",
@@ -1575,6 +1725,21 @@ const AGENT_HOST_ASYNC_PRIMITIVES: &[AsyncBuiltin] = &[
     .signature("__host_agent_dispatch_tool_batch(calls, tools?, options?)")
     .arity(VmBuiltinArity::Range { min: 1, max: 3 })
     .doc("Dispatch a batch of normalized agent tool calls through the host tool runtime."),
+    async_builtin!("__host_mcp_bootstrap", host_mcp_bootstrap_impl)
+        .signature("__host_mcp_bootstrap(session_id, specs)")
+        .arity(VmBuiltinArity::Range { min: 1, max: 2 })
+        .doc(
+            "Connect to each MCP server in specs, list their tools (prefixed with \
+             server_name__), store handles keyed by session_id, and return \
+             {tools_added, errors}.",
+        ),
+    async_builtin!("__host_mcp_disconnect", host_mcp_disconnect_impl)
+        .signature("__host_mcp_disconnect(session_id)")
+        .arity(VmBuiltinArity::Exact(1))
+        .doc(
+            "Disconnect all MCP clients installed for session_id and remove them \
+             from the session registry.",
+        ),
 ];
 
 const LLM_HOST_CORE_ASYNC_PRIMITIVES: &[AsyncBuiltin] = &[

--- a/crates/harn-vm/tests/builtin_registry_alignment.rs
+++ b/crates/harn-vm/tests/builtin_registry_alignment.rs
@@ -109,6 +109,8 @@ const RUNTIME_ONLY_EXCEPTIONS: &[&str] = &[
     "__host_agent_session_record_usage",
     "__host_agent_session_set_active_skills",
     "__host_agent_session_totals",
+    "__host_mcp_bootstrap",
+    "__host_mcp_disconnect",
     "__host_skill_score",
     "__host_sub_agent_run",
     "__host_worker_close",


### PR DESCRIPTION
## Summary

Closes #1238.

After the legacy Rust `AgentLoopRunState` was retired in #1234, MCP server bootstrap was not wired into the new Harn-stdlib loop. This PR restores the functionality end-to-end:

- Adds `__host_mcp_bootstrap(session_id, specs)` and `__host_mcp_disconnect(session_id)` async host primitives. Bootstrap connects each server, lists its tools (prefixing as `server_name__tool_name` to avoid cross-server collisions), injects `executor: "mcp_server"` routing annotations, stores handles in a per-session registry keyed by session ID, and returns `{tools_added, errors}`.
- `__host_agent_dispatch_tool_call` now resolves the session-scoped MCP client handle via the per-session registry and passes it to `dispatch_tool_execution_with_mcp`, so MCP tool calls bypass the host bridge when a direct handle is available.
- Adds `crates/harn-stdlib/src/stdlib/agent/mcp.harn` (`agent_mcp_bootstrap_if_needed`) and wires it into `std/agent/loop.harn` immediately after `agent_session_init`. Disconnect runs unconditionally after `agent_session_finalize`.
- Activates the two previously-`@xfail`'d conformance tests: `agent_loop_mcp_servers` and `agent_loop_mcp_http_elicit`.

## Test plan

- [x] `cargo run --bin harn -- test conformance --filter agent_loop_mcp_servers` — PASS
- [x] `cargo run --bin harn -- test conformance --filter agent_loop_mcp_http_elicit` — PASS
- [x] Full conformance suite: 786 passed, 0 failed, 36 skipped
- [x] `make test` — all Rust unit tests pass
- [x] `make all` (via pre-push hook) — clippy, formatting, lint, keyword drift all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)