### PR TITLE
[acp] Replay session history on load

### DIFF
--- a/crates/harn-cli/src/acp/mod.rs
+++ b/crates/harn-cli/src/acp/mod.rs
@@ -52,6 +52,18 @@ pub(crate) fn server_config(pipeline: Option<String>) -> AcpServerConfig {
 }
 
 pub(crate) async fn run_acp_server(pipeline: Option<&str>) {
+    if harn_vm::event_log::active_event_log().is_none() {
+        let base_dir = pipeline
+            .map(Path::new)
+            .and_then(Path::parent)
+            .unwrap_or_else(|| Path::new("."));
+        if let Err(error) = harn_vm::event_log::install_default_for_base_dir(base_dir) {
+            eprintln!(
+                "[harn] ACP session replay disabled: failed to initialize EventLog for {}: {error}",
+                base_dir.display()
+            );
+        }
+    }
     harn_serve::run_acp_server(server_config(pipeline.map(str::to_string))).await;
 }
 

--- a/crates/harn-serve/src/adapters/acp/events.rs
+++ b/crates/harn-serve/src/adapters/acp/events.rs
@@ -11,11 +11,22 @@ use super::AcpOutput;
 /// to serialize notifications without the full AcpBridge.
 pub(super) struct AcpAgentEventSink {
     output: AcpOutput,
+    replayed: bool,
 }
 
 impl AcpAgentEventSink {
     pub(super) fn new(output: AcpOutput) -> Self {
-        Self { output }
+        Self {
+            output,
+            replayed: false,
+        }
+    }
+
+    pub(super) fn for_replay(output: AcpOutput) -> Self {
+        Self {
+            output,
+            replayed: true,
+        }
     }
 
     fn write_notification(&self, params: serde_json::Value) {
@@ -28,12 +39,18 @@ impl AcpAgentEventSink {
     /// the canonical `session/update` discriminator has no slot for the
     /// event being surfaced — currently the pipeline-loop milestones
     /// emitted via `_harn/agentEvent`.
-    fn write_jsonrpc_notification(&self, method: &str, params: serde_json::Value) {
-        let notification = serde_json::json!({
+    fn write_jsonrpc_notification(&self, method: &str, mut params: serde_json::Value) {
+        if self.replayed {
+            mark_replayed_params(method, &mut params);
+        }
+        let mut notification = serde_json::json!({
             "jsonrpc": "2.0",
             "method": method,
             "params": params,
         });
+        if self.replayed {
+            notification["_harn"] = serde_json::json!({"replayed": true});
+        }
         if let Ok(line) = serde_json::to_string(&notification) {
             self.output.write_line(&line);
         }
@@ -93,6 +110,22 @@ impl AcpAgentEventSink {
         harn_meta: serde_json::Map<String, serde_json::Value>,
     ) {
         merge_harn_meta(update, harn_meta);
+    }
+}
+
+fn mark_replayed_params(method: &str, params: &mut serde_json::Value) {
+    if method == "session/update" {
+        if let Some(update) = params.get_mut("update") {
+            let mut harn_meta = serde_json::Map::new();
+            harn_meta.insert("replayed".to_string(), serde_json::Value::Bool(true));
+            merge_harn_meta(update, harn_meta);
+        }
+        return;
+    }
+    if method.starts_with('_') {
+        if let Some(obj) = params.as_object_mut() {
+            obj.insert("replayed".to_string(), serde_json::Value::Bool(true));
+        }
     }
 }
 

--- a/crates/harn-serve/src/adapters/acp/mod.rs
+++ b/crates/harn-serve/src/adapters/acp/mod.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use async_trait::async_trait;
-use harn_vm::agent_events::{clear_session_sinks, register_sink};
+use harn_vm::agent_events::{clear_session_sinks, register_sink, AgentEventSink};
 use harn_vm::visible_text::{sanitize_visible_assistant_text, VisibleTextState};
 use tokio::io::AsyncBufReadExt;
 use tokio::sync::{mpsc, oneshot, Mutex, Notify};
@@ -1195,7 +1195,11 @@ impl AcpServer {
         let sid = session_id.clone();
 
         // Translate AgentEvents into ACP session/update notifications so
-        // the client observes tool lifecycle on the wire.
+        // the client observes tool lifecycle on the wire. The event-log
+        // sink is reinstalled here because prompt teardown clears all
+        // per-session transport sinks after each turn.
+        clear_session_sinks(&session_id);
+        harn_vm::agent_sessions::register_event_log_sink(&session_id);
         register_sink(
             session_id.clone(),
             Arc::new(AcpAgentEventSink::new(output.clone())),
@@ -1522,7 +1526,7 @@ impl AcpServer {
         }
     }
 
-    fn handle_session_load(&mut self, id: &serde_json::Value, params: &serde_json::Value) {
+    async fn handle_session_load(&mut self, id: &serde_json::Value, params: &serde_json::Value) {
         let Some(session_id) = params
             .get("sessionId")
             .or_else(|| params.get("session_id"))
@@ -1548,13 +1552,42 @@ impl AcpServer {
             session_value["_meta"] = serde_json::Value::Object(session.info.meta.clone());
         }
 
+        let replay_events =
+            match harn_vm::orchestration::load_agent_session_replay_events(session_id).await {
+                Ok(events) => events,
+                Err(error) => {
+                    self.send_error(
+                        id,
+                        -32000,
+                        &format!("Failed to replay session {session_id}: {error}"),
+                    );
+                    return;
+                }
+            };
+        let replay_sink = AcpAgentEventSink::for_replay(self.output.clone());
+        for replay_event in &replay_events {
+            replay_sink.handle_event(&replay_event.event);
+        }
+        let replayed: Vec<serde_json::Value> = replay_events
+            .iter()
+            .map(|event| {
+                serde_json::json!({
+                    "eventId": event.event_id,
+                    "type": serde_json::to_value(&event.event)
+                        .ok()
+                        .and_then(|value| value.get("type").cloned())
+                        .unwrap_or(serde_json::Value::Null),
+                })
+            })
+            .collect();
+
         self.send_response(
             id,
             serde_json::json!({
                 "session": session_value,
                 "modes": modes::session_mode_state(&session.current_mode_id),
                 "configOptions": modes::config_options_state(&session.current_mode_id),
-                "replayed": [],
+                "replayed": replayed,
             }),
         );
     }
@@ -1701,7 +1734,7 @@ impl AcpServer {
                 self.handle_session_new(&id, &params);
             }
             "session/load" => {
-                self.handle_session_load(&id, &params);
+                self.handle_session_load(&id, &params).await;
             }
             "session/fork" => {
                 self.handle_session_fork(&id, &params);
@@ -3201,6 +3234,88 @@ mod tests {
             .expect("available modes")
             .iter()
             .any(|m| m["id"] == "architect"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn acp_session_load_replays_persisted_agent_events() {
+        harn_vm::event_log::reset_active_event_log();
+        let _log = harn_vm::event_log::install_memory_for_current_thread(64);
+
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut server =
+            AcpServer::new_with_output(AcpServerConfig::new(None), AcpOutput::Channel(tx));
+
+        server
+            .handle_incoming_message(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "session/new",
+                "params": {"cwd": "."},
+            }))
+            .await;
+        let created = recv_json(&mut rx).await;
+        let session_id = created["result"]["sessionId"]
+            .as_str()
+            .expect("session id")
+            .to_string();
+
+        harn_vm::agent_events::emit_event(&harn_vm::agent_events::AgentEvent::AgentMessageChunk {
+            session_id: session_id.clone(),
+            content: "replay me".to_string(),
+        });
+        harn_vm::agent_events::emit_event(&harn_vm::agent_events::AgentEvent::Plan {
+            session_id: session_id.clone(),
+            plan: serde_json::json!([{"content": "do the thing", "status": "pending"}]),
+        });
+        tokio::task::yield_now().await;
+
+        server
+            .handle_incoming_message(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "session/load",
+                "params": {"sessionId": session_id},
+            }))
+            .await;
+
+        let message_replay = recv_json(&mut rx).await;
+        assert_eq!(message_replay["method"], "session/update");
+        assert_eq!(
+            message_replay["params"]["update"]["sessionUpdate"],
+            "agent_message_chunk"
+        );
+        assert_eq!(
+            message_replay["params"]["update"]["content"]["text"],
+            "replay me"
+        );
+        assert_eq!(message_replay["_harn"]["replayed"], true);
+        assert_eq!(
+            message_replay["params"]["update"]["_meta"]["harn"]["replayed"],
+            true
+        );
+
+        let plan_replay = recv_json(&mut rx).await;
+        assert_eq!(plan_replay["method"], "session/update");
+        assert_eq!(plan_replay["params"]["update"]["sessionUpdate"], "plan");
+        assert_eq!(plan_replay["_harn"]["replayed"], true);
+        assert_eq!(
+            plan_replay["params"]["update"]["_meta"]["harn"]["replayed"],
+            true
+        );
+
+        let loaded = recv_json(&mut rx).await;
+        assert_eq!(loaded["id"], 2);
+        assert_eq!(loaded["result"]["replayed"].as_array().unwrap().len(), 2);
+        assert_eq!(
+            loaded["result"]["replayed"][0]["type"],
+            "agent_message_chunk"
+        );
+        assert_eq!(loaded["result"]["replayed"][1]["type"], "plan");
+
+        harn_vm::agent_events::clear_session_sinks(
+            created["result"]["sessionId"].as_str().unwrap(),
+        );
+        harn_vm::event_log::reset_active_event_log();
     }
 
     /// Setting a valid mode ack's with an empty result and emits a

--- a/crates/harn-vm/src/agent_sessions.rs
+++ b/crates/harn-vm/src/agent_sessions.rs
@@ -286,6 +286,10 @@ fn try_register_event_log(session_id: &str) {
     }
 }
 
+pub fn register_event_log_sink(session_id: &str) {
+    try_register_event_log(session_id);
+}
+
 pub fn close(id: &str) {
     SESSIONS.with(|s| {
         s.borrow_mut().remove(id);

--- a/crates/harn-vm/src/orchestration/records.rs
+++ b/crates/harn-vm/src/orchestration/records.rs
@@ -13,8 +13,10 @@ use super::{
     ContextPackSuggestionOptions, FrictionEvent, HandoffArtifact, PersonaEvalLadderManifest,
     PersonaEvalLadderReport,
 };
+use crate::agent_events::AgentEvent;
 use crate::event_log::{
-    active_event_log, AnyEventLog, EventLog, LogEvent as EventLogRecord, Topic,
+    active_event_log, sanitize_topic_component, AnyEventLog, EventId, EventLog,
+    LogEvent as EventLogRecord, Topic,
 };
 use crate::llm::vm_value_to_json;
 use crate::triggers::{SignatureStatus, TriggerEvent};
@@ -894,6 +896,58 @@ fn read_topic_records(
         records.extend(batch);
     }
     records
+}
+
+#[derive(Clone, Debug)]
+pub struct AgentSessionReplayEvent {
+    pub event_id: EventId,
+    pub event: AgentEvent,
+}
+
+pub async fn load_agent_session_replay_events(
+    session_id: &str,
+) -> Result<Vec<AgentSessionReplayEvent>, VmError> {
+    let Some(log) = active_event_log() else {
+        return Ok(Vec::new());
+    };
+    let topic = Topic::new(format!(
+        "observability.agent_events.{}",
+        sanitize_topic_component(session_id)
+    ))
+    .map_err(|error| VmError::Runtime(format!("failed to build agent event topic: {error}")))?;
+
+    let mut events = Vec::new();
+    let mut from = None;
+    loop {
+        let batch = log.read_range(&topic, from, 1024).await.map_err(|error| {
+            VmError::Runtime(format!(
+                "failed to read agent event replay topic {}: {error}",
+                topic.as_str()
+            ))
+        })?;
+        let batch_len = batch.len();
+        for (event_id, record) in batch {
+            from = Some(event_id);
+            if record.headers.get("session_id").map(String::as_str) != Some(session_id) {
+                continue;
+            }
+            let Some(event_value) = record.payload.get("event").cloned() else {
+                continue;
+            };
+            let event = serde_json::from_value::<AgentEvent>(event_value).map_err(|error| {
+                VmError::Runtime(format!(
+                    "failed to decode agent event replay record {event_id}: {error}"
+                ))
+            })?;
+            if event.session_id() == session_id {
+                events.push(AgentSessionReplayEvent { event_id, event });
+            }
+        }
+        if batch_len < 1024 {
+            break;
+        }
+    }
+    Ok(events)
 }
 
 fn merge_hitl_questions_from_active_log(run: &mut RunRecord) {


### PR DESCRIPTION
## Summary
- replay persisted ACP agent events as `session/update` notifications during `session/load`
- mark replayed notifications with Harn replay metadata and return replayed event summaries
- ensure `harn serve acp` installs an EventLog and per-turn prompt setup restores the persistent EventLog sink

Fixes #902

## Verification
- cargo test -p harn-serve acp_session_load -- --nocapture
- cargo test -p harn-serve adapters::acp::events::tests -- --nocapture
- cargo check -p harn-cli
- pre-commit hook: cargo clippy --workspace --all-targets -- -D warnings
- pre-push hook: targeted local checks