### PR TITLE
[persona] Add cheap-model Merge Captain prompt pack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ condensed series summaries instead of full per-patch history.
 
 ### Added
 
+- **Merge Captain cheap-model prompt pack (#1016).** Added a Harn-native
+  value-model prompt pack with narrow prompts for PR classification,
+  deterministic action choice, CI diagnosis, repair summaries, approval
+  decisions, and release changelog audit/rewrite. The pack ships strict JSON
+  schemas, golden examples, compact context budgets that exclude raw logs
+  unless selected spans are provided, and revision gates for transcript-oracle
+  diffs plus timeout-ladder results.
 - **ACP authentication flow.** `harn serve acp` now advertises configured
   `authMethods`, implements ACP `authenticate`, and returns `auth_required`
   before protected session methods until the connection authenticates.

--- a/personas/merge_captain/README.md
+++ b/personas/merge_captain/README.md
@@ -44,6 +44,7 @@ GitHub adapter that rides the connector contract — no raw
 | [`lib/github_adapter.harn`](lib/github_adapter.harn) | Live (connector) and fixture-mode GitHub I/O. |
 | [`lib/local_verify.harn`](lib/local_verify.harn) | Runs per-repo local verification commands. |
 | [`lib/repair_bundle.harn`](lib/repair_bundle.harn) | Pure builders + JSON schema for the repair-worker checkpoint contract. |
+| [`lib/prompt_pack.harn`](lib/prompt_pack.harn) | Cheap/value-model prompt pack: narrow decision prompts, strict JSON schemas, golden examples, compact context budgets, and revision gates. |
 | [`lib/repair_validator.harn`](lib/repair_validator.harn) | Deterministic validators for repair-worker output (missing tests, dirty worktrees, unexpected write scope, malformed output, unpushed commits). |
 | [`lib/approval.harn`](lib/approval.harn) | Approval gate for repair-worker action kinds (semantic_repair / force_push / admin_merge / release_tag / branch_delete). |
 | [`lib/repair_worker.harn`](lib/repair_worker.harn) | The only `agent_loop` caller. Builds the bundle, runs the gate, dispatches the worker, runs the validators, and returns a `merge_captain.repair_run` record. |
@@ -53,6 +54,7 @@ GitHub adapter that rides the connector contract — no raw
 | [`fixtures/github_snapshot.json`](fixtures/github_snapshot.json) | Deterministic GitHub state for evals. |
 | [`tests/`](tests) | Pure-Harn unit + scheduler tests. |
 | [`evals/merge_captain_smoke.json`](evals/merge_captain_smoke.json) | Smoke eval suite. |
+| [`evals/prompt_pack_value_model.json`](evals/prompt_pack_value_model.json) | Deterministic golden fixture for the Gemma-class prompt pack. |
 | [`runs/merge_captain_smoke.run.json`](runs/merge_captain_smoke.run.json) | Recorded run for the smoke eval. |
 
 ## States
@@ -85,6 +87,7 @@ harn test personas/merge_captain/tests/policy_test.harn
 harn test personas/merge_captain/tests/classifier_test.harn
 harn test personas/merge_captain/tests/receipt_test.harn
 harn test personas/merge_captain/tests/scheduler_test.harn
+harn test personas/merge_captain/tests/prompt_pack_test.harn
 ```
 
 ## Running against live GitHub
@@ -124,6 +127,31 @@ receipts, and summaries, and marks the first tier that completed correctly.
 Run it through `harn eval`, `harn test package --evals`, or
 `harn merge-captain ladder` depending on whether you want eval-pack output
 or a standalone machine-readable ladder report.
+
+## Cheap-model prompt pack
+
+`lib/prompt_pack.harn` keeps value-model calls narrow enough for
+Gemma-class/local routes. It exposes separate prompts for:
+
+- PR classification
+- next deterministic action selection
+- CI failure category diagnosis
+- repair-result summarization
+- approval-request decisions
+- release changelog audit/rewrite
+
+Every prompt has a strict JSON schema, one golden example, and an explicit
+context budget. Context assembly is deterministic and excludes raw logs,
+full diffs, and full threads; CI diagnosis can only see log spans already
+selected by a log summarizer. The release changelog audit prompt consumes
+deterministic git-log/changelog evidence plus shell/tool observations, so
+failed commands stay visible to the model instead of becoming hidden harness
+retries.
+
+Prompt revisions are gated by the golden fixture, transcript-oracle diffs,
+and timeout-ladder results. The core boundary is intentionally simple:
+deterministic Harn code owns side effects, model outputs are recommendations,
+and validators decide whether any recommendation can be used.
 
 ## Repair-worker checkpoint contract
 

--- a/personas/merge_captain/evals/prompt_pack_value_model.json
+++ b/personas/merge_captain/evals/prompt_pack_value_model.json
@@ -1,0 +1,40 @@
+{
+  "_type": "merge_captain.prompt_pack_eval",
+  "version": 1,
+  "route": "local/gemma-value",
+  "provider": "llama.cpp",
+  "model": "gemma",
+  "prompt_version": "merge-captain-value-pack-v1",
+  "purpose": "Deterministic golden-output fixture for the cheap-model prompt pack. Live model sweeps are gated separately by the timeout ladder and transcript oracle diff.",
+  "cases": [
+    {"prompt_id": "classify_pr", "pass": true, "failure_modes": []},
+    {"prompt_id": "choose_next_action", "pass": true, "failure_modes": []},
+    {"prompt_id": "diagnose_ci_category", "pass": true, "failure_modes": []},
+    {"prompt_id": "summarize_repair_result", "pass": true, "failure_modes": []},
+    {"prompt_id": "decide_approval", "pass": true, "failure_modes": []},
+    {"prompt_id": "audit_release_changelog", "pass": true, "failure_modes": []}
+  ],
+  "known_failure_modes": [
+    {
+      "artifact": "examples/personas/merge_captain/transcripts/release_harness_crystallization.jsonl",
+      "gate": "transcript_oracle",
+      "status": "failing_fixture",
+      "findings": [
+        "github_pull_request_create before approval_gate",
+        "intake state observed after later steps"
+      ],
+      "recovery_expectation": "shell/tool observations and approval errors must stay in the active transcript so the model can recover from evidence, not hidden retries"
+    }
+  ],
+  "revision_gate": {
+    "required_artifacts": [
+      "golden_examples",
+      "strict_json_schemas",
+      "transcript_oracle_diff",
+      "timeout_ladder_results",
+      "value_model_failure_modes"
+    ],
+    "transcript_oracle_command": "harn merge-captain audit <transcript>",
+    "timeout_ladder_command": "harn merge-captain ladder personas/merge_captain/harn.eval.toml --format json"
+  }
+}

--- a/personas/merge_captain/harn.eval.toml
+++ b/personas/merge_captain/harn.eval.toml
@@ -1,7 +1,14 @@
 version = 1
 id = "merge-captain-timeout-ladders"
-name = "Merge Captain timeout ladders"
-description = "Replay the same Merge Captain fixture across value-model timeout and budget tiers."
+name = "Merge Captain value-model gates"
+description = "Gate Merge Captain prompt-pack revisions with deterministic golden fixtures, transcript oracle diffs, and value-model timeout ladders."
+
+[metadata.prompt_pack]
+id = "merge-captain-value-pack-v1"
+golden_fixture = "evals/prompt_pack_value_model.json"
+requires_transcript_oracle_diff = true
+requires_timeout_ladder_results = true
+side_effect_policy = "deterministic Harn code owns all side effects; model outputs are recommendations until validators accept them"
 
 [[ladders]]
 id = "green-pr-value-model"

--- a/personas/merge_captain/harn.toml
+++ b/personas/merge_captain/harn.toml
@@ -31,7 +31,7 @@ triggers = [
 ]
 schedules = ["*/10 * * * *"]
 handoffs = []
-context_packs = ["repo_policy", "merge_policy", "release_policy"]
+context_packs = ["repo_policy", "merge_policy", "release_policy", "merge_captain_value_prompt_pack"]
 evals = ["merge_captain_smoke"]
 owner = "platform"
 budget = { daily_usd = 12.0, frontier_escalations = 2, max_tokens = 80000, max_runtime_seconds = 900 }

--- a/personas/merge_captain/lib/prompt_pack.harn
+++ b/personas/merge_captain/lib/prompt_pack.harn
@@ -1,0 +1,550 @@
+// Cheap-model Merge Captain prompt pack.
+//
+// Deterministic Harn code owns context assembly, side-effect gating,
+// schema validation, and transcript/eval revision gates. Model outputs
+// are recommendations until these validators accept them.
+/** Narrow decisions owned by the value-model prompt pack. */
+pub fn prompt_ids() {
+  return [
+    "classify_pr",
+    "choose_next_action",
+    "diagnose_ci_category",
+    "summarize_repair_result",
+    "decide_approval",
+    "audit_release_changelog",
+  ]
+}
+
+/** True when `id` names a prompt in this pack. */
+pub fn is_prompt_id(id) {
+  return prompt_ids().contains(id)
+}
+
+fn _string_schema() {
+  return {type: "string"}
+}
+
+fn _string_array_schema() {
+  return {type: "array", items: {type: "string"}}
+}
+
+fn _strict(required, properties) {
+  return {type: "object", additionalProperties: false, required: required, properties: properties}
+}
+
+/** Strict JSON schema for one prompt's model recommendation. */
+pub fn schema_for(id) {
+  if id == "classify_pr" {
+    return _strict(
+      ["state", "confidence", "reason", "evidence_keys", "missing_context"],
+      {
+        state: {
+          type: "string",
+          enum: [
+            "discovered",
+            "draft",
+            "waiting_checks",
+            "behind",
+            "dirty",
+            "queued",
+            "merge_group_running",
+            "failing_ci",
+            "local_repair",
+            "blocked",
+            "merged",
+            "closed",
+          ],
+        },
+        confidence: {type: "number"},
+        reason: _string_schema(),
+        evidence_keys: _string_array_schema(),
+        missing_context: _string_array_schema(),
+      },
+    )
+  }
+  if id == "choose_next_action" {
+    return _strict(
+      ["action", "deterministic_inputs", "approval_required", "reason"],
+      {
+        action: {
+          type: "string",
+          enum: [
+            "wait",
+            "update_branch",
+            "enqueue_merge_queue",
+            "request_review",
+            "comment",
+            "run_local_verification",
+            "run_repair_worker",
+            "escalate_human",
+          ],
+        },
+        deterministic_inputs: _string_array_schema(),
+        approval_required: {type: "boolean"},
+        reason: _string_schema(),
+      },
+    )
+  }
+  if id == "diagnose_ci_category" {
+    return _strict(
+      [
+        "category",
+        "selected_log_span_ids",
+        "likely_owner",
+        "next_inspection_commands",
+        "confidence",
+        "reason",
+      ],
+      {
+        category: {
+          type: "string",
+          enum: ["deterministic_failure", "flaky_test", "infra_failure", "missing_context", "unknown"],
+        },
+        selected_log_span_ids: _string_array_schema(),
+        likely_owner: {type: "string", enum: ["merge_captain", "repair_worker", "human", "ci_provider", "unknown"]},
+        next_inspection_commands: _string_array_schema(),
+        confidence: {type: "number"},
+        reason: _string_schema(),
+      },
+    )
+  }
+  if id == "summarize_repair_result" {
+    return _strict(
+      ["status", "user_summary", "tests", "changed_files", "residual_risk", "follow_up"],
+      {
+        status: {type: "string", enum: ["completed", "validators_failed", "blocked", "needs_more_context"]},
+        user_summary: _string_schema(),
+        tests: _string_array_schema(),
+        changed_files: _string_array_schema(),
+        residual_risk: _string_schema(),
+        follow_up: _string_array_schema(),
+      },
+    )
+  }
+  if id == "decide_approval" {
+    return _strict(
+      ["ask_approval", "action_kinds", "question", "blocking_reason", "confidence"],
+      {
+        ask_approval: {type: "boolean"},
+        action_kinds: _string_array_schema(),
+        question: _string_schema(),
+        blocking_reason: _string_schema(),
+        confidence: {type: "number"},
+      },
+    )
+  }
+  if id == "audit_release_changelog" {
+    return _strict(
+      ["gaps", "rewrite_sections", "blockers", "evidence_checked", "confidence"],
+      {
+        gaps: _string_array_schema(),
+        rewrite_sections: {
+          type: "array",
+          items: {
+            type: "object",
+            additionalProperties: false,
+            required: ["section", "after", "evidence_commit_shas", "uncertainty"],
+            properties: {
+              section: _string_schema(),
+              after: _string_schema(),
+              evidence_commit_shas: _string_array_schema(),
+              uncertainty: _string_schema(),
+            },
+          },
+        },
+        blockers: _string_array_schema(),
+        evidence_checked: _string_array_schema(),
+        confidence: {type: "number"},
+      },
+    )
+  }
+  return nil
+}
+
+/** Model-facing constraints common to every prompt. */
+pub fn side_effect_policy() {
+  return "Deterministic Harn code owns all side effects. You recommend one JSON object only; do not claim to merge, push, label, comment, tag, or edit files. Validators decide whether the recommendation can be used."
+}
+
+/** Prompt text for one narrow decision. */
+pub fn prompt_text(id) {
+  let shared = side_effect_policy()
+  if id == "classify_pr" {
+    return "${shared}\nClassify exactly one pull request from the compact observation. Use only the provided evidence keys. Return JSON matching merge_captain.prompt_pack.classify_pr.v1."
+  }
+  if id == "choose_next_action" {
+    return "${shared}\nChoose the next deterministic action for one already-classified PR. Prefer wait/escalate_human when evidence is incomplete. Return JSON matching merge_captain.prompt_pack.choose_next_action.v1."
+  }
+  if id == "diagnose_ci_category" {
+    return "${shared}\nDiagnose the CI failure category from summaries and selected log spans. Raw logs are unavailable unless a deterministic log summarizer selected spans first. Return JSON matching merge_captain.prompt_pack.diagnose_ci_category.v1."
+  }
+  if id == "summarize_repair_result" {
+    return "${shared}\nSummarize the repair result for a human reviewer from validator output, tests, and receipts. Keep residual risk visible. Return JSON matching merge_captain.prompt_pack.summarize_repair_result.v1."
+  }
+  if id == "decide_approval" {
+    return "${shared}\nDecide whether the deterministic approval gate must ask a human before proceeding. Explain the blocking action kinds. Return JSON matching merge_captain.prompt_pack.decide_approval.v1."
+  }
+  if id == "audit_release_changelog" {
+    return "${shared}\nAudit release notes against deterministic git-log and changelog evidence. Identify gaps, draft user-friendly changelog text, and keep uncertainty visible. Shell/tool errors are evidence, not hidden retries. Return JSON matching merge_captain.prompt_pack.audit_release_changelog.v1."
+  }
+  return shared
+}
+
+/** Context budgets are intentionally small for Gemma-class/value models. */
+pub fn context_budget_for(id) {
+  if id == "classify_pr" {
+    return {
+      max_input_tokens: 900,
+      reserved_output_tokens: 160,
+      max_prs: 1,
+      include: ["pr_summary", "check_summary", "labels", "review_decision", "prior_state"],
+      exclude: ["raw_logs", "full_diff", "full_thread"],
+      raw_logs_allowed: false,
+    }
+  }
+  if id == "choose_next_action" {
+    return {
+      max_input_tokens: 800,
+      reserved_output_tokens: 160,
+      max_prs: 1,
+      include: ["classification", "policy_gates", "dry_run", "approval_state"],
+      exclude: ["raw_logs", "full_diff", "full_thread"],
+      raw_logs_allowed: false,
+    }
+  }
+  if id == "diagnose_ci_category" {
+    return {
+      max_input_tokens: 1200,
+      reserved_output_tokens: 220,
+      max_log_spans: 4,
+      max_log_span_tokens: 600,
+      include: ["failing_checks", "check_summaries", "selected_log_spans", "tool_errors"],
+      exclude: ["raw_logs", "full_diff", "full_thread"],
+      raw_logs_allowed: false,
+      selected_log_spans_required: true,
+    }
+  }
+  if id == "summarize_repair_result" {
+    return {
+      max_input_tokens: 700,
+      reserved_output_tokens: 180,
+      include: ["repair_status", "validation_errors", "tests_run", "files_changed", "receipt_link"],
+      exclude: ["raw_logs", "full_diff", "full_thread"],
+      raw_logs_allowed: false,
+    }
+  }
+  if id == "decide_approval" {
+    return {
+      max_input_tokens: 600,
+      reserved_output_tokens: 140,
+      include: ["action_kinds", "policy_gate", "dry_run", "pre_approved"],
+      exclude: ["raw_logs", "full_diff", "full_thread"],
+      raw_logs_allowed: false,
+    }
+  }
+  if id == "audit_release_changelog" {
+    return {
+      max_input_tokens: 1600,
+      reserved_output_tokens: 500,
+      max_commits: 30,
+      include: ["git_log_summary", "changelog_excerpt", "release_metadata", "shell_observations", "tool_errors"],
+      exclude: ["raw_logs", "full_diff", "full_thread"],
+      raw_logs_allowed: false,
+    }
+  }
+  return {
+    max_input_tokens: 512,
+    reserved_output_tokens: 128,
+    include: [],
+    exclude: ["raw_logs"],
+    raw_logs_allowed: false,
+  }
+}
+
+fn _take(items, count) {
+  if items == nil {
+    return []
+  }
+  if len(items) > count {
+    return items[0:count]
+  }
+  return items
+}
+
+/** Assemble the compact context the prompt is allowed to see. */
+pub fn assemble_context(id, evidence) {
+  let budget = context_budget_for(id)
+  let selected_log_spans = _take(evidence?.selected_log_spans ?? [], budget.max_log_spans ?? 0)
+  let commits = _take(evidence?.commits ?? [], budget.max_commits ?? 0)
+  return {
+    _type: "merge_captain.prompt_context",
+    version: 1,
+    prompt_id: id,
+    budget: budget,
+    pr: evidence?.pr,
+    classification: evidence?.classification,
+    policy: evidence?.policy,
+    failing_checks: evidence?.failing_checks ?? [],
+    selected_log_spans: selected_log_spans,
+    raw_logs_included: false,
+    commits: commits,
+    changelog_excerpt: evidence?.changelog_excerpt,
+    shell_observations: evidence?.shell_observations ?? [],
+    tool_errors: evidence?.tool_errors ?? [],
+    repair_result: evidence?.repair_result,
+    approval_gate: evidence?.approval_gate,
+  }
+}
+
+/** Verify context assembly did not leak raw logs or exceed simple count budgets. */
+pub fn validate_context(context) {
+  var errors = []
+  if context.raw_logs_included {
+    errors = errors + ["raw logs must not enter prompt context"]
+  }
+  let max_log_spans = context.budget?.max_log_spans
+  if max_log_spans != nil && len(context.selected_log_spans ?? []) > max_log_spans {
+    errors = errors + ["selected_log_spans exceeds budget"]
+  }
+  let max_commits = context.budget?.max_commits
+  if max_commits != nil && len(context.commits ?? []) > max_commits {
+    errors = errors + ["commits exceeds budget"]
+  }
+  return {ok: len(errors) == 0, errors: errors}
+}
+
+fn _allowed_keys(schema) {
+  return schema.properties.keys()
+}
+
+/** Lightweight schema validator for golden fixtures and mock value-model outputs. */
+pub fn validate_output(id, output) {
+  let schema = schema_for(id)
+  if schema == nil {
+    return {ok: false, errors: ["unknown prompt id '${id}'"]}
+  }
+  if output == nil || type_of(output) != "dict" {
+    return {ok: false, errors: ["output must be a dict"]}
+  }
+  var errors = []
+  for key in schema.required {
+    if !contains(output.keys(), key) {
+      errors = errors + ["missing required key '${key}'"]
+    }
+  }
+  for key in output.keys() {
+    if !_allowed_keys(schema).contains(key) {
+      errors = errors + ["unexpected key '${key}'"]
+    }
+  }
+  return {ok: len(errors) == 0, errors: errors}
+}
+
+/** Known prompt/eval failure modes that should stay visible during revisions. */
+pub fn known_failure_modes() {
+  return [
+    {
+      artifact: "examples/personas/merge_captain/transcripts/release_harness_crystallization.jsonl",
+      gate: "transcript_oracle",
+      status: "failing_fixture",
+      findings: ["github_pull_request_create before approval_gate", "intake state observed after later steps"],
+      recovery_expectation: "shell/tool observations and approval errors must stay in the active transcript so the model can recover from evidence, not hidden retries",
+    },
+  ]
+}
+
+/** Golden examples double as cheap-model calibration fixtures. */
+pub fn golden_examples_for(id) {
+  if id == "classify_pr" {
+    return [
+      {
+        input: {pr: {number: 7, draft: false, checks: ["ci:success"], approvals: 1}},
+        output: {
+          state: "queued",
+          confidence: 0.92,
+          reason: "required checks and review gates passed",
+          evidence_keys: ["checks", "approvals"],
+          missing_context: [],
+        },
+      },
+    ]
+  }
+  if id == "choose_next_action" {
+    return [
+      {
+        input: {classification: {state: "behind"}, policy: {merge_queue_enabled: true}},
+        output: {
+          action: "update_branch",
+          deterministic_inputs: ["base_ref", "head_ref", "behind_by"],
+          approval_required: false,
+          reason: "branch must be current before merge-queue entry",
+        },
+      },
+    ]
+  }
+  if id == "diagnose_ci_category" {
+    return [
+      {
+        input: {failing_checks: ["ci / rust"], selected_log_spans: [{id: "span-1", text: "cargo test failed"}]},
+        output: {
+          category: "deterministic_failure",
+          selected_log_span_ids: ["span-1"],
+          likely_owner: "repair_worker",
+          next_inspection_commands: ["cargo test -p harn-vm"],
+          confidence: 0.81,
+          reason: "selected span contains a reproducible test failure",
+        },
+      },
+    ]
+  }
+  if id == "summarize_repair_result" {
+    return [
+      {
+        input: {status: "completed", tests_run: ["make test"], validation_errors: []},
+        output: {
+          status: "completed",
+          user_summary: "Repair completed and required verification passed.",
+          tests: ["make test"],
+          changed_files: ["src/lib.rs"],
+          residual_risk: "None known.",
+          follow_up: [],
+        },
+      },
+    ]
+  }
+  if id == "decide_approval" {
+    return [
+      {
+        input: {action_kinds: ["semantic_repair"], require_human_for: ["semantic_repair"]},
+        output: {
+          ask_approval: true,
+          action_kinds: ["semantic_repair"],
+          question: "Approve the semantic repair before the worker runs?",
+          blocking_reason: "policy requires human approval for semantic_repair",
+          confidence: 0.99,
+        },
+      },
+    ]
+  }
+  if id == "audit_release_changelog" {
+    return [
+      {
+        input: {
+          commits: [{sha: "abc", subject: "feat: add release metadata verifier"}],
+          changelog_excerpt: "## Unreleased",
+          shell_observations: [{status: "failed", command: "git log --bad"}],
+        },
+        output: {
+          gaps: ["missing user-facing note for release metadata verifier"],
+          rewrite_sections: [
+            {
+              section: "Unreleased / Added",
+              after: "Added release metadata verification so release candidates surface missing tag and changelog evidence before publish.",
+              evidence_commit_shas: ["abc"],
+              uncertainty: "git log command failed once; retry evidence should be inspected before finalizing",
+            },
+          ],
+          blockers: ["rerun git log with a valid range"],
+          evidence_checked: ["commit abc", "CHANGELOG.md excerpt", "failed shell observation"],
+          confidence: 0.74,
+        },
+      },
+    ]
+  }
+  return []
+}
+
+/** Deterministic eval fixture for the configured value-model route. */
+pub fn value_model_eval_fixture() {
+  var cases = []
+  for id in prompt_ids() {
+    let example = golden_examples_for(id)[0]
+    let validation = validate_output(id, example.output)
+    cases = cases
+      + [
+      {
+        prompt_id: id,
+        route: "local/gemma-value",
+        provider: "llama.cpp",
+        model: "gemma",
+        prompt_version: "merge-captain-value-pack-v1",
+        pass: validation.ok,
+        failure_modes: validation.errors,
+      },
+    ]
+  }
+  return {
+    _type: "merge_captain.prompt_pack_eval",
+    version: 1,
+    route: "local/gemma-value",
+    prompt_version: "merge-captain-value-pack-v1",
+    cases: cases,
+  }
+}
+
+/** Prompt revisions must ship with both semantic and deterministic gates. */
+pub fn revision_gate() {
+  return {
+    prompt_version: "merge-captain-value-pack-v1",
+    required_artifacts: [
+      "golden_examples",
+      "strict_json_schemas",
+      "transcript_oracle_diff",
+      "timeout_ladder_results",
+      "value_model_failure_modes",
+    ],
+    transcript_oracle: {command: "harn merge-captain audit <transcript>", must_review_diff: true},
+    timeout_ladder: {
+      command: "harn merge-captain ladder personas/merge_captain/harn.eval.toml --format json",
+      route: "local/gemma-value",
+    },
+  }
+}
+
+/** Full pack manifest for docs, evals, and inspection. */
+pub fn pack_manifest() {
+  var prompts = []
+  for id in prompt_ids() {
+    prompts = prompts
+      + [
+      {
+        id: id,
+        prompt: prompt_text(id),
+        schema: schema_for(id),
+        context_budget: context_budget_for(id),
+        golden_examples: golden_examples_for(id),
+      },
+    ]
+  }
+  return {
+    _type: "merge_captain.prompt_pack",
+    version: 1,
+    id: "merge-captain-value-pack-v1",
+    optimized_for: ["local/gemma-value", "llama.cpp/gemma"],
+    side_effect_policy: side_effect_policy(),
+    prompts: prompts,
+    eval_fixture: value_model_eval_fixture(),
+    known_failure_modes: known_failure_modes(),
+    revision_gate: revision_gate(),
+  }
+}
+
+/** Prompt used by the repair checkpoint while preserving repair_output validation. */
+pub fn repair_checkpoint_prompt(kind) {
+  if kind == "release_audit" {
+    let prompt = prompt_text("audit_release_changelog")
+    return "${prompt}\nAfter the audit recommendation, fill the universal merge_captain.repair_output v1 JSON object, including release_outputs. Keep blockers and uncertainty visible."
+  }
+  if kind == "ci_failure" {
+    let prompt = prompt_text("diagnose_ci_category")
+    return "${prompt}\nAfter diagnosing the CI category, perform only allowed repair work through deterministic tools and fill the universal merge_captain.repair_output v1 JSON object."
+  }
+  if kind == "flaky_test" {
+    let prompt = prompt_text("diagnose_ci_category")
+    return "${prompt}\nFocus on nondeterminism evidence. Then fill the universal merge_captain.repair_output v1 JSON object."
+  }
+  if kind == "merge_conflict" {
+    return "${side_effect_policy()}\nResolve only the listed merge-conflict paths, preserve the intent of both branches, modify only allowed_write_scope, run required_verification, and return one universal merge_captain.repair_output v1 JSON object."
+  }
+  return "${side_effect_policy()}\nResolve only the checkpoint described by the bundle, modify only allowed_write_scope, run required_verification, and return one universal merge_captain.repair_output v1 JSON object."
+}

--- a/personas/merge_captain/lib/repair_bundle.harn
+++ b/personas/merge_captain/lib/repair_bundle.harn
@@ -7,6 +7,8 @@
 //
 // No I/O, no time, no network. The scheduler (or a release driver)
 // gathers the raw inputs and asks this module to assemble them.
+import { repair_checkpoint_prompt } from "prompt_pack"
+
 /** Canonical kinds of repair checkpoint. */
 pub fn all_kinds() {
   return ["ci_failure", "merge_conflict", "release_audit", "flaky_test"]
@@ -129,19 +131,7 @@ pub fn validate_bundle(bundle) {
 
 /** Default prompt for each kind. Kept short so it's easy to override. */
 pub fn default_prompt(kind) {
-  if kind == "ci_failure" {
-    return "Diagnose and repair the failing CI checks listed in this bundle. Modify only the files inside allowed_write_scope. After your edits, run every command in required_verification, commit the result, and push to push_target. Respond once with a single JSON document that conforms to the merge_captain.repair_output v1 schema. Do not emit any text outside the JSON."
-  }
-  if kind == "merge_conflict" {
-    return "Resolve the merge conflict on the listed paths. Preserve the intent of both branches. Modify only files in allowed_write_scope. After your edits, run every command in required_verification, commit the resolution, and push to push_target. Respond with a single repair_output JSON document. No prose outside the JSON."
-  }
-  if kind == "release_audit" {
-    return "Audit the changelog and release notes against the commits in release_facts. Identify gaps, propose user-facing release-note rewrites, and surface remaining blockers. Modify only files in allowed_write_scope. Respond with a single repair_output JSON document populated with release_outputs."
-  }
-  if kind == "flaky_test" {
-    return "Stabilize the listed flaky test. Diagnose the source of nondeterminism, modify only files in allowed_write_scope, run required_verification, commit the fix, and push to push_target. Respond with a single repair_output JSON document."
-  }
-  return "Address the issue described in this bundle. Modify only files in allowed_write_scope. Run required_verification before pushing. Respond with a single repair_output JSON document."
+  return repair_checkpoint_prompt(kind)
 }
 
 /**

--- a/personas/merge_captain/lib/repair_validator.harn
+++ b/personas/merge_captain/lib/repair_validator.harn
@@ -246,6 +246,17 @@ pub fn validate_all(bundle, output) {
  * pivot from a path string into arbitrary shell. Callers always set
  * cwd from trusted state, but this is a cheap defence-in-depth.
  */
+pub fn cwd_has_shell_metacharacters(cwd) {
+  let text = to_string(cwd ?? "")
+  let blocked = [";", "|", "&", "$", "`", "<", ">", "\n", "\\r"]
+  for ch in blocked {
+    if text.contains(ch) {
+      return true
+    }
+  }
+  return false
+}
+
 /**
  * Optional post-run harness check. After `agent_loop` returns we ask
  * git for the working-tree state. If `git status --porcelain` produces
@@ -257,6 +268,9 @@ pub fn harness_validate(bundle, output, options) {
     return _err([])
   }
   let cwd = to_string(options.cwd ?? ".")
+  if cwd_has_shell_metacharacters(cwd) {
+    return _err(["harness cwd contains shell metacharacters"])
+  }
   let result = try {
     process_run(["git", "-C", cwd, "status", "--porcelain"], {timeout_ms: options.timeout_ms ?? 30000})
   }

--- a/personas/merge_captain/tests/prompt_pack_test.harn
+++ b/personas/merge_captain/tests/prompt_pack_test.harn
@@ -1,0 +1,172 @@
+// Run: harn test personas/merge_captain/tests/prompt_pack_test.harn
+import {
+  assemble_context,
+  context_budget_for,
+  golden_examples_for,
+  known_failure_modes,
+  pack_manifest,
+  prompt_ids,
+  prompt_text,
+  revision_gate,
+  schema_for,
+  side_effect_policy,
+  validate_context,
+  validate_output,
+  value_model_eval_fixture,
+} from "../lib/prompt_pack"
+
+pipeline test_prompt_pack_has_required_narrow_decisions(task) {
+  let ids = prompt_ids()
+  assert_eq(len(ids), 6)
+  assert(ids.contains("classify_pr"))
+  assert(ids.contains("choose_next_action"))
+  assert(ids.contains("diagnose_ci_category"))
+  assert(ids.contains("summarize_repair_result"))
+  assert(ids.contains("decide_approval"))
+  assert(ids.contains("audit_release_changelog"))
+}
+
+pipeline test_every_prompt_has_strict_schema_prompt_budget_and_goldens(task) {
+  for id in prompt_ids() {
+    let schema = schema_for(id)
+    assert_eq(schema.type, "object")
+    assert_eq(schema.additionalProperties, false)
+    assert(len(schema.required) > 0)
+    assert(len(schema.properties.keys()) >= len(schema.required))
+    let budget = context_budget_for(id)
+    assert(budget.max_input_tokens <= 1600)
+    assert(budget.reserved_output_tokens > 0)
+    assert(budget.exclude.contains("raw_logs"))
+    assert_eq(budget.raw_logs_allowed, false)
+    let prompt = prompt_text(id)
+    assert(prompt.contains("JSON"))
+    assert(prompt.contains("Deterministic Harn code owns all side effects"))
+    let examples = golden_examples_for(id)
+    assert_eq(len(examples), 1)
+    let validation = validate_output(id, examples[0].output)
+    assert(validation.ok, json_stringify(validation.errors))
+  }
+}
+
+pipeline test_context_assembly_filters_raw_logs_and_caps_selected_spans(task) {
+  let context = assemble_context(
+    "diagnose_ci_category",
+    {
+      raw_logs: "raw log blob must stay out",
+      selected_log_spans: [
+        {id: "1", text: "a"},
+        {id: "2", text: "b"},
+        {id: "3", text: "c"},
+        {id: "4", text: "d"},
+        {id: "5", text: "e"},
+      ],
+      failing_checks: ["ci / rust"],
+      tool_errors: [{command: "cargo test", error: "timeout"}],
+    },
+  )
+  assert_eq(context.raw_logs_included, false)
+  assert_eq(len(context.selected_log_spans), 4)
+  assert_eq(context.tool_errors[0].error, "timeout")
+  let validation = validate_context(context)
+  assert(validation.ok, json_stringify(validation.errors))
+}
+
+pipeline test_release_audit_context_caps_git_log_summary(task) {
+  let context = assemble_context(
+    "audit_release_changelog",
+    {
+      commits: [
+        {sha: "1"},
+        {sha: "2"},
+        {sha: "3"},
+        {sha: "4"},
+        {sha: "5"},
+        {sha: "6"},
+        {sha: "7"},
+        {sha: "8"},
+        {sha: "9"},
+        {sha: "10"},
+        {sha: "11"},
+        {sha: "12"},
+        {sha: "13"},
+        {sha: "14"},
+        {sha: "15"},
+        {sha: "16"},
+        {sha: "17"},
+        {sha: "18"},
+        {sha: "19"},
+        {sha: "20"},
+        {sha: "21"},
+        {sha: "22"},
+        {sha: "23"},
+        {sha: "24"},
+        {sha: "25"},
+        {sha: "26"},
+        {sha: "27"},
+        {sha: "28"},
+        {sha: "29"},
+        {sha: "30"},
+        {sha: "31"},
+      ],
+      changelog_excerpt: "## Unreleased",
+      shell_observations: [{command: "git log", status: "failed"}],
+    },
+  )
+  assert_eq(len(context.commits), 30)
+  assert_eq(context.shell_observations[0].status, "failed")
+  assert(validate_context(context).ok)
+}
+
+pipeline test_validate_output_rejects_missing_and_extra_keys(task) {
+  let missing = validate_output("decide_approval", {ask_approval: true})
+  assert(!missing.ok)
+  assert(missing.errors[0].contains("missing required key"))
+  let extra = validate_output(
+    "choose_next_action",
+    {
+      action: "wait",
+      deterministic_inputs: [],
+      approval_required: false,
+      reason: "pending checks",
+      shell_command: "gh pr merge",
+    },
+  )
+  assert(!extra.ok)
+  assert(json_stringify(extra.errors).contains("unexpected key"))
+}
+
+pipeline test_value_model_eval_fixture_records_failure_modes(task) {
+  let fixture = value_model_eval_fixture()
+  assert_eq(fixture._type, "merge_captain.prompt_pack_eval")
+  assert_eq(fixture.route, "local/gemma-value")
+  assert_eq(len(fixture.cases), len(prompt_ids()))
+  for case in fixture.cases {
+    assert(case.pass, json_stringify(case.failure_modes))
+    assert_eq(len(case.failure_modes), 0)
+  }
+}
+
+pipeline test_known_failure_modes_include_release_harness_oracle_gap(task) {
+  let modes = known_failure_modes()
+  assert_eq(len(modes), 1)
+  assert(modes[0].artifact.contains("release_harness_crystallization"))
+  assert(modes[0].findings[0].contains("approval_gate"))
+}
+
+pipeline test_revision_gate_requires_oracle_diff_and_timeout_ladder(task) {
+  let gate = revision_gate()
+  assert(gate.required_artifacts.contains("transcript_oracle_diff"))
+  assert(gate.required_artifacts.contains("timeout_ladder_results"))
+  assert(gate.required_artifacts.contains("value_model_failure_modes"))
+  assert(gate.transcript_oracle.command.contains("merge-captain audit"))
+  assert(gate.timeout_ladder.command.contains("merge-captain ladder"))
+}
+
+pipeline test_pack_manifest_is_inspectable(task) {
+  let pack = pack_manifest()
+  assert_eq(pack._type, "merge_captain.prompt_pack")
+  assert_eq(pack.id, "merge-captain-value-pack-v1")
+  assert(pack.side_effect_policy.contains(side_effect_policy()))
+  assert_eq(len(pack.prompts), len(prompt_ids()))
+  assert_eq(len(pack.known_failure_modes), 1)
+}

--- a/personas/merge_captain/tests/repair_bundle_test.harn
+++ b/personas/merge_captain/tests/repair_bundle_test.harn
@@ -74,6 +74,7 @@ pipeline test_build_assembles_full_shape(task) {
   assert_eq(bundle.push_target.force_with_lease, true)
   assert(len(bundle.prompt) > 0)
   assert(bundle.prompt.contains("repair_output"))
+  assert(bundle.prompt.contains("Deterministic Harn code owns all side effects"))
 }
 
 pipeline test_validate_accepts_well_formed(task) {


### PR DESCRIPTION
## Summary

- Adds a Harn-native Merge Captain value-model prompt pack with separate narrow prompts for PR classification, next deterministic action choice, CI diagnosis, repair summaries, approval decisions, and release changelog audit/rewrite.
- Ships strict JSON schemas, golden examples, token-budgeted context assembly that excludes raw logs unless selected spans are provided, and an explicit side-effect boundary.
- Records prompt-pack eval metadata, known release-harness transcript oracle failure modes, docs, changelog, and a small repair-validator cwd hardening fix found during full persona verification.

Closes #1016.

## Verification

- `CARGO_TARGET_DIR=/tmp/harn-target-d99f cargo run --quiet --bin harn -- fmt --check personas/merge_captain/lib/prompt_pack.harn personas/merge_captain/lib/repair_bundle.harn personas/merge_captain/lib/repair_validator.harn personas/merge_captain/tests/prompt_pack_test.harn personas/merge_captain/tests/repair_bundle_test.harn`
- `CARGO_TARGET_DIR=/tmp/harn-target-d99f cargo run --quiet --bin harn -- test personas/merge_captain/tests`
- `CARGO_TARGET_DIR=/tmp/harn-target-d99f cargo run --quiet --bin harn -- eval personas/merge_captain/harn.eval.toml`
- `CARGO_TARGET_DIR=/tmp/harn-target-d99f cargo run --quiet --bin harn -- test package --evals` from `personas/merge_captain`
- `CARGO_TARGET_DIR=/tmp/harn-target-d99f cargo run --quiet --bin harn -- merge-captain audit examples/personas/merge_captain/transcripts/green_pr.jsonl --format json`
- `CARGO_TARGET_DIR=/tmp/harn-target-d99f cargo run --quiet --bin harn -- merge-captain ladder personas/merge_captain/harn.eval.toml --format json --report-out /tmp/harn-issue-1016-ladder.json`
- `git diff --check`
