### PR TITLE
Move client tool search into stdlib

### DIFF
--- a/conformance/tests/integration/tool_search_client_bm25.harn
+++ b/conformance/tests/integration/tool_search_client_bm25.harn
@@ -1,7 +1,6 @@
-// @xfail: tool-search client + tool_search_query events not yet emitted by Harn loop — tracked in burin-labs/harn#1236
 /**
- * Tool Vault phase 2 (harn#70): client-executed `tool_search` fallback
- * with the BM25 strategy, exercised in text-mode (mock provider).
+ * Client-executed `tool_search` fallback with the BM25 strategy,
+ * exercised in text-mode (mock provider).
  *
  * Validates the full lifecycle:
  *   1. Options parsing injects the synthetic `__harn_tool_search` tool

--- a/conformance/tests/integration/tool_search_client_bm25_events.harn
+++ b/conformance/tests/integration/tool_search_client_bm25_events.harn
@@ -1,4 +1,3 @@
-// @xfail: tool-search client + tool_search_query events not yet emitted by Harn loop — tracked in burin-labs/harn#1236
 /**
  * harn v0.7.20 Gap 1: promote `tool_search_query` / `tool_search_result`
  * to canonical `AgentEvent` variants so ACP / agent_subscribe consumers

--- a/conformance/tests/integration/tool_search_client_options.harn
+++ b/conformance/tests/integration/tool_search_client_options.harn
@@ -1,8 +1,6 @@
-// @xfail: tool-search client + tool_search_query events not yet emitted by Harn loop — tracked in burin-labs/harn#1236
 /**
- * Tool Vault phase 2 (harn#70): advanced client-mode options —
- * `mode: "client"`, `budget_tokens` cap with oldest-eviction, and the
- * `name` override for the synthetic tool.
+ * Advanced client-mode options: explicit local fallback, budgeted
+ * promotion with oldest-eviction, and a custom synthetic tool name.
  */
 pipeline test(task) {
   // ---------- Explicit mode:"client" + custom tool name ----------
@@ -109,8 +107,8 @@ pipeline test(task) {
       max_iterations: 5,
     },
   )
-  // Explicit `mode: "client"` — mock now spoofs native tool_search
-  // for its default Claude model after harn#71.
+  // Explicit `mode: "client"` keeps this test on the local fallback
+  // even when the mock provider uses a native-capable default model.
   // After three turns: gamma promoted, alpha+beta evicted.
   let calls2 = llm_mock_calls()
   let last_system = calls2[len(calls2) - 1].system

--- a/conformance/tests/integration/tool_search_client_regex.harn
+++ b/conformance/tests/integration/tool_search_client_regex.harn
@@ -1,9 +1,8 @@
-// @xfail: tool-search client + tool_search_query events not yet emitted by Harn loop — tracked in burin-labs/harn#1236
 /**
- * Tool Vault phase 2 (harn#70): client-executed `tool_search` fallback
- * with the regex strategy. Variant = regex → the model is shown a
- * regex-flavoured prompt and the dispatch path runs Rust's `regex`
- * crate (case-insensitive, no backreferences/lookaround).
+ * Client-executed `tool_search` fallback with the regex strategy.
+ * Variant = regex means the model is shown a regex-flavoured prompt
+ * and the dispatch path runs Rust's `regex` crate (case-insensitive,
+ * no backreferences/lookaround).
  */
 pipeline test(task) {
   llm_mock_clear()
@@ -64,9 +63,8 @@ pipeline test(task) {
       max_iterations: 5,
     },
   )
-  // Explicit `mode: "client"` — mock spoofs native tool_search for
-  // Claude 4.0+ / GPT 5.4+ default models after harn#71, so
-  // client-mode tests must opt into the client path explicitly.
+  // Explicit `mode: "client"` keeps this test on the local fallback
+  // even when the mock provider uses a native-capable default model.
   let events = transcript_events(result?.transcript)
   var found_regex_strategy = false
   var promoted_edit = false

--- a/crates/harn-stdlib/src/lib.rs
+++ b/crates/harn-stdlib/src/lib.rs
@@ -126,6 +126,10 @@ pub const STDLIB_SOURCES: &[StdlibSource] = &[
         source: include_str!("stdlib/agent/loop.harn"),
     },
     StdlibSource {
+        module: "agent/tool_search",
+        source: include_str!("stdlib/agent/tool_search.harn"),
+    },
+    StdlibSource {
         module: "agent/turn",
         source: include_str!("stdlib/agent/turn.harn"),
     },

--- a/crates/harn-stdlib/src/stdlib/agent/loop.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/loop.harn
@@ -19,6 +19,11 @@ import {
   agent_session_record_tool_results,
   agent_session_record_usage,
 } from "std/agent/state"
+import {
+  agent_tool_search_emit_queries,
+  agent_tool_search_inject_if_needed,
+  agent_tool_search_record_results,
+} from "std/agent/tool_search"
 
 fn __invoke_llm(message, turn_system, llm_opts) {
   let result = try {
@@ -138,7 +143,8 @@ pub fn agent_loop(message, system_prompt = nil, options = nil) {
     }
     let turn_index = iteration
     agent_emit_event(session.session_id, "turn_start", {iteration: turn_index + 1})
-    let turn_opts = agent_skills_match(session, opts, turn_index)
+    var turn_opts = agent_skills_match(session, opts, turn_index)
+    turn_opts = agent_tool_search_inject_if_needed(turn_opts)
     agent_autocompact_if_needed(session, turn_opts)
     let pending = agent_session_drain_feedback(session.session_id)
     for note in pending {
@@ -177,12 +183,17 @@ pub fn agent_loop(message, system_prompt = nil, options = nil) {
     }
     var dispatch = nil
     if len(tool_calls) > 0 {
+      agent_tool_search_emit_queries(session.session_id, tool_calls, turn_opts)
       dispatch = agent_dispatch_tool_batch(
         tool_calls,
         turn_opts?.tools,
         {session_id: session.session_id, tool_format: turn_opts.tool_format},
       )
       agent_session_record_tool_results(session.session_id, dispatch)
+      let updated_turn_opts = agent_tool_search_record_results(session.session_id, tool_calls, dispatch, turn_opts)
+      if updated_turn_opts?._tool_search_client != nil {
+        opts = opts + {_tool_search_client: updated_turn_opts._tool_search_client}
+      }
     }
     let totals = agent_session_record_usage(session.session_id, llm_result)
     let tool_count = len(tool_calls)

--- a/crates/harn-stdlib/src/stdlib/agent/preflight.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/preflight.harn
@@ -2,7 +2,11 @@ import { agent_session_messages } from "std/agent/state"
 
 /** agent_build_turn_system. */
 pub fn agent_build_turn_system(session, opts, iteration) {
-  return __host_agent_build_turn_system(session.session_id, opts, iteration)
+  let base = __host_agent_build_turn_system(session.session_id, opts, iteration)
+  if opts?.tools == nil || opts?.tool_format == "native" {
+    return base
+  }
+  return base + "\n\n" + tool_prompt(opts.tools)
 }
 
 /** agent_build_turn_messages. */

--- a/crates/harn-stdlib/src/stdlib/agent/tool_search.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/tool_search.harn
@@ -1,0 +1,286 @@
+import { agent_emit_event } from "std/agent/state"
+
+fn __tool_search_config(value) {
+  if value == nil {
+    return nil
+  }
+  if type_of(value) == "bool" {
+    if !value {
+      return nil
+    }
+    return {variant: "bm25", mode: "auto", strategy: "bm25", name: "__harn_tool_search", always_loaded: []}
+  }
+  if type_of(value) == "string" {
+    return {variant: value, mode: "auto", strategy: value, name: "__harn_tool_search", always_loaded: []}
+  }
+  if type_of(value) != "dict" {
+    return nil
+  }
+  let variant = value?.variant ?? "bm25"
+  return {
+    variant: variant,
+    mode: value?.mode ?? "auto",
+    strategy: value?.strategy ?? variant,
+    name: value?.name ?? "__harn_tool_search",
+    always_loaded: value?.always_loaded ?? [],
+    budget_tokens: value?.budget_tokens,
+  }
+}
+
+fn __tool_search_client_requested(opts) {
+  let cfg = __tool_search_config(opts?.tool_search)
+  return cfg != nil && cfg.mode == "client"
+}
+
+fn __tool_search_tools(registry) {
+  if type_of(registry) == "dict" {
+    return registry?.tools ?? []
+  }
+  if type_of(registry) == "list" {
+    return registry
+  }
+  return []
+}
+
+fn __tool_search_registry_like(registry, tools) {
+  if type_of(registry) == "dict" {
+    return registry + {tools: tools}
+  }
+  return {tools: tools}
+}
+
+fn __tool_search_contains(list, name) {
+  for item in list {
+    if item == name {
+      return true
+    }
+  }
+  return false
+}
+
+fn __tool_search_find_tool(tools, name) {
+  for entry in tools {
+    if entry?.name == name {
+      return entry
+    }
+  }
+  return nil
+}
+
+fn __tool_search_estimate_tokens(entry) {
+  return len(json_stringify(entry)) / 4 + 1
+}
+
+fn __tool_search_strategy(cfg) {
+  let strategy = cfg?.strategy ?? cfg?.variant ?? "bm25"
+  if strategy != "bm25" && strategy != "regex" {
+    throw "tool_search.strategy: Harn client mode currently supports \"bm25\" or \"regex\""
+  }
+  return strategy
+}
+
+fn __tool_search_description(strategy) {
+  if strategy == "regex" {
+    return "Search for deferred tools. Pass `query` as a case-insensitive regex. The result is JSON with `tool_names` in rank order; only those tools will be visible next turn."
+  }
+  return "Search for deferred tools. Pass `query` as natural-language keywords. The result is JSON with `tool_names` in rank order; only those tools will be visible next turn."
+}
+
+fn __tool_search_run(args, state) {
+  let query = args?.query ?? ""
+  let ranked = __host_tool_search_score(
+    query,
+    state.deferred_registry,
+    {strategy: state.strategy, variant: state.variant},
+  )
+  var names = []
+  for hit in ranked {
+    names = names.push(hit.tool_name)
+  }
+  let diagnostic = if len(names) == 0 {
+    "no deferred tools matched the query; try broader terms"
+  } else {
+    nil
+  }
+  return json_stringify({tool_names: names, ranked: ranked, diagnostic: diagnostic})
+}
+
+fn __tool_search_synthetic_tool(registry, state) {
+  return tool_define(
+    registry,
+    state.name,
+    __tool_search_description(state.strategy),
+    {
+      parameters: {query: {type: "string", description: "Search query for deferred tools"}},
+      handler: { args -> __tool_search_run(args, state) },
+    },
+  )
+}
+
+fn __tool_search_initial_state(opts) {
+  let cfg = __tool_search_config(opts?.tool_search)
+  let source_tools = __tool_search_tools(opts?.tools)
+  var eager = []
+  var deferred = []
+  for entry in source_tools {
+    let name = entry?.name ?? ""
+    let pinned = __tool_search_contains(cfg.always_loaded, name)
+    if entry?.defer_loading && !pinned {
+      deferred = deferred.push(entry)
+    } else {
+      eager = eager.push(entry)
+    }
+  }
+  if len(source_tools) > 0 && len(eager) == 0 {
+    throw "tool_search: all tools have defer_loading set. At least one tool must be non-deferred so the model has somewhere to start."
+  }
+  return {
+    enabled: true,
+    name: cfg.name,
+    variant: cfg.variant,
+    strategy: __tool_search_strategy(cfg),
+    budget_tokens: cfg.budget_tokens,
+    original_registry: opts?.tools,
+    eager_tools: eager,
+    deferred_tools: deferred,
+    deferred_registry: __tool_search_registry_like(opts?.tools, deferred),
+    promoted: [],
+  }
+}
+
+fn __tool_search_build_tools(opts, state) {
+  var visible = []
+  for entry in state.eager_tools {
+    visible = visible.push(entry)
+  }
+  for name in state.promoted {
+    let entry = __tool_search_find_tool(state.deferred_tools, name)
+    if entry != nil {
+      visible = visible.push(entry)
+    }
+  }
+  let registry = __tool_search_registry_like(state.original_registry, visible)
+  return __tool_search_synthetic_tool(registry, state)
+}
+
+/** agent_tool_search_inject_if_needed. */
+pub fn agent_tool_search_inject_if_needed(opts) {
+  if !__tool_search_client_requested(opts) {
+    return opts
+  }
+  let state = opts?._tool_search_client ?? __tool_search_initial_state(opts)
+  return opts + {_tool_search_client: state, tools: __tool_search_build_tools(opts, state)}
+}
+
+fn __tool_search_call_id(call) {
+  return call?.id ?? call?.tool_call_id ?? ""
+}
+
+/** agent_tool_search_emit_queries. */
+pub fn agent_tool_search_emit_queries(session_id, tool_calls, opts) {
+  let state = opts?._tool_search_client
+  if state == nil {
+    return
+  }
+  for call in tool_calls {
+    if call?.name == state.name {
+      agent_emit_event(
+        session_id,
+        "tool_search_query",
+        {
+          tool_use_id: __tool_search_call_id(call),
+          name: "tool_search_tool_" + state.variant,
+          query: call?.arguments ?? {},
+          strategy: state.strategy,
+          mode: "client",
+        },
+      )
+    }
+  }
+}
+
+fn __tool_search_parse_result(result) {
+  if type_of(result) == "dict" {
+    return result
+  }
+  if type_of(result) == "string" {
+    let parsed = try {
+      json_parse(result)
+    }
+    if is_ok(parsed) {
+      return unwrap(parsed)
+    }
+  }
+  return {tool_names: []}
+}
+
+fn __tool_search_apply_budget(state, names) {
+  var promoted = state.promoted
+  for name in names {
+    if !__tool_search_contains(promoted, name)
+      && __tool_search_find_tool(state.deferred_tools, name) != nil {
+      promoted = promoted.push(name)
+    }
+  }
+  let budget = state?.budget_tokens
+  if budget == nil {
+    return state + {promoted: promoted}
+  }
+  var total = 0
+  var kept = []
+  for name in promoted {
+    let entry = __tool_search_find_tool(state.deferred_tools, name)
+    if entry != nil {
+      let estimate = __tool_search_estimate_tokens(entry)
+      while total + estimate > budget && len(kept) > 0 {
+        let evicted = kept[0]
+        let evicted_tool = __tool_search_find_tool(state.deferred_tools, evicted)
+        total = total - __tool_search_estimate_tokens(evicted_tool)
+        kept = kept.slice(1)
+      }
+      if estimate <= budget {
+        kept = kept.push(name)
+        total = total + estimate
+      }
+    }
+  }
+  return state + {promoted: kept}
+}
+
+fn __tool_search_promoted_names(state, names) {
+  var out = []
+  for name in names {
+    if __tool_search_contains(state.promoted, name) {
+      out = out.push(name)
+    }
+  }
+  return out
+}
+
+/** agent_tool_search_record_results. */
+pub fn agent_tool_search_record_results(session_id, tool_calls, dispatch, opts) {
+  var state = opts?._tool_search_client
+  if state == nil {
+    return opts
+  }
+  for (index, call) in iter(tool_calls).enumerate() {
+    if call?.name != state.name {
+      continue
+    }
+    let result = __tool_search_parse_result(dispatch[index]?.result)
+    let names = result?.tool_names ?? []
+    state = __tool_search_apply_budget(state, names)
+    let promoted = __tool_search_promoted_names(state, names)
+    agent_emit_event(
+      session_id,
+      "tool_search_result",
+      {
+        tool_use_id: __tool_search_call_id(call),
+        promoted: promoted,
+        strategy: state.strategy,
+        mode: "client",
+      },
+    )
+  }
+  return opts + {_tool_search_client: state}
+}

--- a/crates/harn-vm/src/llm/agent_session_host.rs
+++ b/crates/harn-vm/src/llm/agent_session_host.rs
@@ -913,7 +913,7 @@ fn host_agent_budget_pre_call_builtin(
     Ok(VmValue::Bool(false))
 }
 
-fn host_agent_emit_event_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+async fn host_agent_emit_event(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     let session_id = match args.first() {
         Some(VmValue::String(s)) if !s.is_empty() => s.to_string(),
         _ => {
@@ -933,7 +933,20 @@ fn host_agent_emit_event_builtin(args: &[VmValue], _out: &mut String) -> Result<
     let payload_value = args.get(2).cloned().unwrap_or(VmValue::Nil);
     let payload = vm_to_json(&payload_value);
     let event = build_agent_event(&session_id, &event_type, &payload)?;
-    crate::llm::agent_runtime::emit_agent_event_sync(&event);
+    if matches!(
+        event_type.as_str(),
+        "tool_search_query" | "tool_search_result"
+    ) {
+        let role = if event_type == "tool_search_result" {
+            "tool"
+        } else {
+            "assistant"
+        };
+        let transcript_event =
+            super::helpers::transcript_event(&event_type, role, "internal", "", Some(payload));
+        let _ = crate::agent_sessions::append_event(&session_id, transcript_event);
+    }
+    crate::llm::agent_runtime::emit_agent_event(&event).await;
     Ok(VmValue::Nil)
 }
 
@@ -991,6 +1004,36 @@ fn build_agent_event(
                 .and_then(|v| v.as_u64())
                 .unwrap_or(0),
         }),
+        "tool_search_query" => Ok(AgentEvent::ToolSearchQuery {
+            session_id: session_id.to_string(),
+            tool_use_id: get_string("tool_use_id"),
+            name: get_string("name"),
+            query: payload_obj
+                .and_then(|m| m.get("query"))
+                .cloned()
+                .unwrap_or(serde_json::Value::Null),
+            strategy: get_string("strategy"),
+            mode: get_string("mode"),
+        }),
+        "tool_search_result" => {
+            let promoted = payload_obj
+                .and_then(|m| m.get("promoted"))
+                .and_then(|v| v.as_array())
+                .map(|items| {
+                    items
+                        .iter()
+                        .filter_map(|item| item.as_str().map(str::to_string))
+                        .collect()
+                })
+                .unwrap_or_default();
+            Ok(AgentEvent::ToolSearchResult {
+                session_id: session_id.to_string(),
+                tool_use_id: get_string("tool_use_id"),
+                promoted,
+                strategy: get_string("strategy"),
+                mode: get_string("mode"),
+            })
+        }
         other => Err(VmError::Runtime(format!(
             "{HOST_AGENT_EMIT_EVENT}: unsupported event type `{other}`"
         ))),
@@ -1609,10 +1652,6 @@ const HOST_SESSION_PRIMITIVES_SYNC: &[SyncBuiltin] = &[
     .signature("__host_agent_session_claim_tool_format(session_id, tool_format)")
     .arity(VmBuiltinArity::Exact(2))
     .doc("Claim the session's tool_format contract; rejects mid-session changes."),
-    SyncBuiltin::new(HOST_AGENT_EMIT_EVENT, host_agent_emit_event_builtin)
-        .signature("__host_agent_emit_event(session_id, event_type, payload)")
-        .arity(VmBuiltinArity::Exact(3))
-        .doc("Emit a `turn_start`, `turn_end`, or `judge_decision` agent event."),
     SyncBuiltin::new(
         HOST_AGENT_RECORD_NATIVE_TOOL_FALLBACK,
         host_agent_record_native_tool_fallback_builtin,
@@ -1652,6 +1691,15 @@ pub fn register_agent_session_host_primitives(vm: &mut Vm) {
         .doc_static("Tear down a Harn-driven agent session and emit the final result dict.");
     vm.register_async_builtin_with_metadata(finalize, |args| {
         Box::pin(async move { host_agent_session_finalize(args).await })
+    });
+
+    let emit_event = VmBuiltinMetadata::async_static(HOST_AGENT_EMIT_EVENT)
+        .signature_static("__host_agent_emit_event(session_id, event_type, payload)")
+        .arity(VmBuiltinArity::Exact(3))
+        .category_static("agent.host")
+        .doc_static("Emit an agent event and record transcript-backed event types.");
+    vm.register_async_builtin_with_metadata(emit_event, |args| {
+        Box::pin(async move { host_agent_emit_event(args).await })
     });
 
     let skill_score = VmBuiltinMetadata::async_static(HOST_SKILL_SCORE)

--- a/crates/harn-vm/src/llm/api.rs
+++ b/crates/harn-vm/src/llm/api.rs
@@ -47,8 +47,7 @@ pub(crate) use openai_normalize::normalize_openai_style_messages;
 pub(crate) use options::{
     push_unique_anthropic_beta_feature, DeltaSender, LlmCallOptions, LlmRequestPayload,
     LlmRouteAlternative, LlmRouteFallback, LlmRoutePolicy, LlmRoutingDecision, OutputFormat,
-    ReasoningEffort, ThinkingConfig, ToolSearchConfig, ToolSearchMode, ToolSearchStrategy,
-    ToolSearchVariant,
+    ReasoningEffort, ThinkingConfig, ToolSearchConfig, ToolSearchMode, ToolSearchVariant,
 };
 pub use readiness::{
     probe_openai_compatible_model, selected_model_for_provider, supports_model_readiness_probe,

--- a/crates/harn-vm/src/llm/api/options.rs
+++ b/crates/harn-vm/src/llm/api/options.rs
@@ -77,9 +77,9 @@ impl OutputFormat {
     }
 }
 
-/// Which tool-search variant to use. Two shapes today, matching the two
-/// Anthropic variants (also reused as the mental model for the OpenAI path
-/// landing in harn#71). Scripts write the lower-case short name.
+/// Which tool-search variant to use. Two shapes today, matching the
+/// Anthropic variants and reused as the local fallback's scoring modes.
+/// Scripts write the lower-case short name.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum ToolSearchVariant {
     /// BM25 / natural-language queries. Default when the user wrote just
@@ -98,51 +98,16 @@ impl ToolSearchVariant {
     }
 }
 
-/// Implementation of the client-executed tool-search fallback (harn#70).
-/// Only consulted when `ToolSearchMode::Client` resolves (either
-/// explicit or via auto-fallback when the provider lacks native
-/// support). Orthogonal to `ToolSearchVariant`: a user can ask for
-/// `variant: bm25` (the model sees the BM25-style tool) and
-/// `strategy: semantic` (the host runs embedding search under the
-/// hood).
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum ToolSearchStrategy {
-    /// In-tree BM25 over the deferred tool corpus. **Default.**
-    Bm25,
-    /// In-tree regex over the deferred tool corpus (case-insensitive).
-    Regex,
-    /// Delegated to the host via the `tool_search/query` bridge RPC so
-    /// integrators can wire embeddings without Harn depending on ML
-    /// crates.
-    Semantic,
-    /// Pure host-side implementation; the VM just round-trips the query
-    /// and promotes whatever names the host returns.
-    Host,
-}
-
-impl ToolSearchStrategy {
-    /// Default strategy for a given variant when the user did not
-    /// specify one explicitly. Native-facing variant leaks into the
-    /// client path as a sensible default: `variant: regex` users
-    /// probably want regex semantics in the fallback too.
-    pub(crate) fn default_for_variant(variant: ToolSearchVariant) -> Self {
-        match variant {
-            ToolSearchVariant::Bm25 => ToolSearchStrategy::Bm25,
-            ToolSearchVariant::Regex => ToolSearchStrategy::Regex,
-        }
-    }
-}
-
 /// How to resolve `tool_search` against the active provider.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum ToolSearchMode {
     /// Auto-select: native if the provider supports it, client-executed
-    /// fallback otherwise (harn#70). Default.
+    /// fallback otherwise. Default.
     Auto,
     /// Force the provider's native mechanism; error if unsupported.
     Native,
-    /// Force client-executed fallback even when native is available.
-    /// Currently errors with a pointer to harn#70 until the fallback lands.
+    /// Force the Harn stdlib client-executed fallback even when native is
+    /// available.
     Client,
 }
 
@@ -153,28 +118,6 @@ pub(crate) enum ToolSearchMode {
 pub(crate) struct ToolSearchConfig {
     pub variant: ToolSearchVariant,
     pub mode: ToolSearchMode,
-    /// Tool names that must remain eager even when `defer_loading: true`
-    /// is otherwise set on them. Useful for a "safety net" a skill wants
-    /// always available regardless of the tool-search index's decisions.
-    /// Only consumed by the client-executed path — for the native
-    /// Anthropic path, eagerness is already controlled per-tool via
-    /// `defer_loading`.
-    pub always_loaded: Vec<String>,
-    /// Client-mode implementation strategy. When unset, defaults to
-    /// `ToolSearchStrategy::default_for_variant(variant)`.
-    pub strategy: Option<ToolSearchStrategy>,
-    /// Override for the synthetic tool's name. Default
-    /// `__harn_tool_search`. Lets skills with a brand-specific vocabulary
-    /// name the tool something the model will understand out of the
-    /// box (`find_tool`, `discover_tool`, etc.).
-    pub name: Option<String>,
-    /// Canonical native-shape JSON for every tool that had
-    /// `defer_loading: true` at option-parse time, keyed by tool name.
-    /// Populated by `apply_tool_search_client_injection` and later
-    /// drained by `AgentLoopState::new` when it builds the per-loop
-    /// client state. Never populated for native mode — the provider
-    /// handles deferral server-side.
-    pub deferred_bodies: std::collections::BTreeMap<String, serde_json::Value>,
 }
 
 impl ToolSearchConfig {
@@ -183,24 +126,7 @@ impl ToolSearchConfig {
         Self {
             variant: ToolSearchVariant::Bm25,
             mode: ToolSearchMode::Auto,
-            always_loaded: Vec::new(),
-            strategy: None,
-            name: None,
-            deferred_bodies: std::collections::BTreeMap::new(),
         }
-    }
-
-    /// Resolve the effective strategy, falling back to the variant
-    /// default when the user left `strategy` unset.
-    pub(crate) fn effective_strategy(&self) -> ToolSearchStrategy {
-        self.strategy
-            .unwrap_or_else(|| ToolSearchStrategy::default_for_variant(self.variant))
-    }
-
-    /// Resolve the synthetic tool's name. Default matches the spec's
-    /// proposed `__harn_tool_search` sentinel.
-    pub(crate) fn effective_name(&self) -> &str {
-        self.name.as_deref().unwrap_or("__harn_tool_search")
     }
 }
 
@@ -334,10 +260,10 @@ pub(crate) struct LlmCallOptions {
     /// extractor resolves this against the active provider's capability
     /// matrix and, for native-supporting providers, prepends a
     /// `tool_search_tool_*_20251119` meta-tool to `native_tools`. For
-    /// client-executed mode (harn#70) this carries the config forward
-    /// into the agent-loop fallback. See [`ToolSearchConfig`].
+    /// client-executed mode this carries the config forward into the
+    /// agent-loop fallback. See [`ToolSearchConfig`].
     #[allow(dead_code)] // consumed by the options extractor; persisted for transcript /
-    // replay fidelity and harn#70's client-executed loop
+    // replay fidelity and the client-executed agent loop
     pub tool_search: Option<ToolSearchConfig>,
 
     // --- Caching ---

--- a/crates/harn-vm/src/llm/helpers/options.rs
+++ b/crates/harn-vm/src/llm/helpers/options.rs
@@ -372,9 +372,8 @@ fn resolve_route_policy(
 
 /// Three-way resolution of `tool_search.mode` against the provider's
 /// native capability. Kept as a private enum so the option-parse path
-/// reads linearly; the `Client` variant feeds the harn#70 fallback
-/// injection, the `Native` variant feeds the phase-1 Anthropic path
-/// (and phase-2 OpenAI path via harn#71).
+/// reads linearly; the `Client` variant leaves the fallback to the Harn
+/// agent loop, and the `Native` variant feeds provider-native injection.
 enum ToolSearchResolution {
     Native,
     Client,
@@ -869,7 +868,7 @@ pub(crate) fn extract_llm_options(
     // tool_search option parsing: three shapes accepted.
     //   - shorthand string: "bm25" | "regex" (mode: auto)
     //   - bool: true (defaults to bm25/auto), false (no tool_search)
-    //   - dict: { variant, mode, always_loaded }
+    //   - dict: { variant, mode, strategy, always_loaded, name }
     // Unset / false / nil all leave tool_search absent — tools ship eagerly.
     let mut tool_search = parse_tool_search_option(options.as_ref())?;
 
@@ -878,9 +877,9 @@ pub(crate) fn extract_llm_options(
         // possible outcomes:
         //   - native: prepend the provider's meta-tool (Anthropic path
         //     for Claude 4.0+; OpenAI Responses-API path for GPT 5.4+).
-        //   - client: keep native_tools as-is so the agent loop can
-        //     strip deferred tools per-turn and inject the synthetic
-        //     `__harn_tool_search` dispatchable.
+        //   - client: leave the provider payload alone; the Harn stdlib
+        //     agent loop filters deferred tools, injects the synthetic
+        //     search tool, and emits client-mode events.
         //   - error: explicit native mode on a provider that cannot
         //     satisfy it.
         let native_variants = provider_tool_search_variants(&provider, &model);
@@ -990,9 +989,8 @@ pub(crate) fn extract_llm_options(
                         // they meant "let OpenAI handle the search on
                         // their side" — the hosted mode. Users who want
                         // Harn to execute the search locally should
-                        // write `mode: "client"`, which flows through
-                        // the harn#70 synthetic-tool path below (same
-                        // ergonomics across every provider).
+                        // write `mode: "client"` for the stdlib agent
+                        // loop fallback.
                         crate::llm::tools::apply_tool_search_native_injection_typed(
                             &mut native_tools,
                             shape,
@@ -1002,59 +1000,7 @@ pub(crate) fn extract_llm_options(
                     }
                 }
             }
-            ToolSearchResolution::Client => {
-                // Client mode: capture the deferred tool bodies into
-                // cfg.deferred_bodies (so the agent loop can re-surface
-                // them), inject the synthetic search tool, and hide the
-                // deferred tools from the initial payload. The agent
-                // loop is responsible for promoting hits back onto
-                // `opts.native_tools` across turns; for single-shot
-                // `llm_call` the model still sees the synthetic tool
-                // but without multi-turn continuity it degrades to one
-                // query + one batch of suggestions.
-                if let Some(list) = native_tools.as_ref() {
-                    for tool in list {
-                        let is_deferred = tool
-                            .get("defer_loading")
-                            .and_then(|v| v.as_bool())
-                            .unwrap_or(false);
-                        if !is_deferred {
-                            continue;
-                        }
-                        let name = tool
-                            .get("name")
-                            .and_then(|v| v.as_str())
-                            .or_else(|| {
-                                tool.get("function")
-                                    .and_then(|f| f.get("name"))
-                                    .and_then(|v| v.as_str())
-                            })
-                            .unwrap_or("")
-                            .to_string();
-                        if name.is_empty() {
-                            continue;
-                        }
-                        // Strip `defer_loading` from the stored copy —
-                        // providers that don't support the flag will
-                        // reject it when the tool is later promoted.
-                        let mut cloned = tool.clone();
-                        if let Some(obj) = cloned.as_object_mut() {
-                            obj.remove("defer_loading");
-                        }
-                        if let Some(function) =
-                            cloned.get_mut("function").and_then(|v| v.as_object_mut())
-                        {
-                            function.remove("defer_loading");
-                        }
-                        cfg.deferred_bodies.insert(name, cloned);
-                    }
-                }
-                crate::llm::tools::apply_tool_search_client_injection(
-                    &mut native_tools,
-                    &provider,
-                    cfg,
-                );
-            }
+            ToolSearchResolution::Client => {}
         }
     }
 
@@ -1409,13 +1355,11 @@ fn validate_anthropic_beta_feature_name(feature: &str) -> Result<(), VmError> {
 ///   - `nil` / absent / `false` → None (no tool_search engaged)
 ///   - `true` → default (bm25 + auto)
 ///   - `"bm25"` | `"regex"` → that variant + auto
-///   - `{ variant?, mode?, always_loaded? }` → explicit
+///   - `{ variant?, mode?, strategy?, always_loaded?, name? }` → explicit
 fn parse_tool_search_option(
     options: Option<&BTreeMap<String, VmValue>>,
 ) -> Result<Option<crate::llm::api::ToolSearchConfig>, VmError> {
-    use crate::llm::api::{
-        ToolSearchConfig, ToolSearchMode, ToolSearchStrategy, ToolSearchVariant,
-    };
+    use crate::llm::api::{ToolSearchConfig, ToolSearchMode, ToolSearchVariant};
 
     let raw = match options.and_then(|o| o.get("tool_search")) {
         Some(v) => v,
@@ -1443,16 +1387,11 @@ fn parse_tool_search_option(
             )))),
         }
     };
-    let strategy_from_short = |s: &str| -> Result<ToolSearchStrategy, VmError> {
+    let validate_strategy = |s: &str| -> Result<(), VmError> {
         match s {
-            "bm25" => Ok(ToolSearchStrategy::Bm25),
-            "regex" => Ok(ToolSearchStrategy::Regex),
-            "semantic" => Ok(ToolSearchStrategy::Semantic),
-            "host" => Ok(ToolSearchStrategy::Host),
+            "bm25" | "regex" => Ok(()),
             other => Err(VmError::Thrown(VmValue::String(std::rc::Rc::from(
-                format!(
-                "tool_search.strategy: expected \"bm25\" | \"regex\" | \"semantic\" | \"host\", got \"{other}\""
-            ),
+                format!("tool_search.strategy: expected \"bm25\" | \"regex\", got \"{other}\""),
             )))),
         }
     };
@@ -1464,10 +1403,6 @@ fn parse_tool_search_option(
         VmValue::String(s) => Ok(Some(ToolSearchConfig {
             variant: variant_from_short(s.as_ref())?,
             mode: ToolSearchMode::Auto,
-            always_loaded: Vec::new(),
-            strategy: None,
-            name: None,
-            deferred_bodies: std::collections::BTreeMap::new(),
         })),
         VmValue::Dict(d) => {
             let variant = match d.get("variant") {
@@ -1488,25 +1423,24 @@ fn parse_tool_search_option(
                 }
                 None => ToolSearchMode::Auto,
             };
-            let always_loaded = match d.get("always_loaded") {
-                Some(VmValue::List(list)) => list.iter().map(|v| v.display()).collect(),
+            match d.get("always_loaded") {
+                Some(VmValue::List(_)) | None => {}
                 Some(_) => {
                     return Err(VmError::Thrown(VmValue::String(std::rc::Rc::from(
                         "tool_search.always_loaded: expected a list of tool names",
                     ))));
                 }
-                None => Vec::new(),
             };
-            let strategy = match d.get("strategy") {
-                Some(VmValue::String(s)) => Some(strategy_from_short(s.as_ref())?),
+            match d.get("strategy") {
+                Some(VmValue::String(s)) => validate_strategy(s.as_ref())?,
                 Some(_) => {
                     return Err(VmError::Thrown(VmValue::String(std::rc::Rc::from(
                         "tool_search.strategy: expected a string",
                     ))));
                 }
-                None => None,
+                None => {}
             };
-            let name = match d.get("name") {
+            match d.get("name") {
                 Some(VmValue::String(s)) => {
                     let s = s.as_ref().trim();
                     if s.is_empty() {
@@ -1522,14 +1456,7 @@ fn parse_tool_search_option(
                     ))));
                 }
             };
-            Ok(Some(ToolSearchConfig {
-                variant,
-                mode,
-                always_loaded,
-                strategy,
-                name,
-                deferred_bodies: std::collections::BTreeMap::new(),
-            }))
+            Ok(Some(ToolSearchConfig { variant, mode }))
         }
         _ => Err(VmError::Thrown(VmValue::String(std::rc::Rc::from(
             "tool_search: expected bool, string (\"bm25\"/\"regex\"), or dict \

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -35,6 +35,7 @@ pub(crate) mod schema_recover;
 pub(crate) mod skill_score;
 pub(crate) mod structural_experiments;
 pub(crate) mod structured_envelope;
+mod tool_search_score;
 mod transcript_stats;
 
 use std::sync::OnceLock;
@@ -1830,6 +1831,48 @@ const LLM_MOCK_SYNC_PRIMITIVES: &[SyncBuiltin] = &[
         .doc("Pop the current isolated LLM mock scope."),
 ];
 
+fn host_tool_search_score_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    let query = match args.first() {
+        Some(VmValue::String(s)) => s.to_string(),
+        Some(other) => {
+            return Err(VmError::Runtime(format!(
+                "__host_tool_search_score(query, registry, opts): query must be a string; got {}",
+                other.type_name()
+            )))
+        }
+        None => String::new(),
+    };
+    let registry = args
+        .get(1)
+        .map(helpers::vm_value_to_json)
+        .unwrap_or(serde_json::Value::Null);
+    let opts = args
+        .get(2)
+        .map(helpers::vm_value_to_json)
+        .unwrap_or(serde_json::Value::Null);
+    let ranked = tool_search_score::score_tools(&query, &registry, &opts);
+    Ok(crate::stdlib::json_to_vm_value(&serde_json::Value::Array(
+        ranked
+            .into_iter()
+            .map(|item| {
+                serde_json::json!({
+                    "tool_name": item.tool_name,
+                    "score": item.score,
+                    "snippet": item.snippet,
+                })
+            })
+            .collect(),
+    )))
+}
+
+const LLM_TOOL_SEARCH_SYNC_PRIMITIVES: &[SyncBuiltin] =
+    &[
+        SyncBuiltin::new("__host_tool_search_score", host_tool_search_score_builtin)
+            .signature("__host_tool_search_score(query, registry, opts)")
+            .arity(VmBuiltinArity::Range { min: 2, max: 3 })
+            .doc("Rank a tool registry for Harn-managed client-mode tool search."),
+    ];
+
 const LLM_RUNTIME_PRIMITIVE_GROUPS: &[BuiltinGroup<'static>] = &[
     BuiltinGroup::new()
         .category("agent.trace")
@@ -1852,6 +1895,9 @@ const LLM_RUNTIME_PRIMITIVE_GROUPS: &[BuiltinGroup<'static>] = &[
     BuiltinGroup::new()
         .category("llm.host")
         .async_(LLM_HOST_COMPLETION_ASYNC_PRIMITIVES),
+    BuiltinGroup::new()
+        .category("agent.host")
+        .sync(LLM_TOOL_SEARCH_SYNC_PRIMITIVES),
 ];
 
 const LLM_MOCK_PRIMITIVES: BuiltinGroup<'static> = BuiltinGroup::new()

--- a/crates/harn-vm/src/llm/tool_search_score.rs
+++ b/crates/harn-vm/src/llm/tool_search_score.rs
@@ -1,0 +1,296 @@
+//! Pure ranking primitive for Harn-managed client-mode tool search.
+//!
+//! The agent loop owns when the synthetic search tool is shown, when events
+//! are emitted, and which tools get promoted. Rust only ranks a static tool
+//! registry for a query so the scoring math stays shared and testable.
+
+use std::collections::HashMap;
+
+use regex::RegexBuilder;
+
+const K1: f64 = 1.5;
+const B: f64 = 0.75;
+const DEFAULT_MAX_RESULTS: usize = 20;
+
+#[derive(Clone, Debug)]
+struct Candidate {
+    name: String,
+    description: String,
+    param_text: Vec<String>,
+}
+
+impl Candidate {
+    fn corpus_text(&self) -> String {
+        let mut out = String::new();
+        out.push_str(&self.name);
+        out.push(' ');
+        out.push_str(&self.description);
+        for param in &self.param_text {
+            out.push(' ');
+            out.push_str(param);
+        }
+        out
+    }
+
+    fn snippet(&self) -> String {
+        if !self.description.trim().is_empty() {
+            return self.description.trim().to_string();
+        }
+        self.param_text.first().cloned().unwrap_or_default()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct RankedTool {
+    pub(crate) tool_name: String,
+    pub(crate) score: f64,
+    pub(crate) snippet: String,
+}
+
+pub(crate) fn score_tools(
+    query: &str,
+    registry: &serde_json::Value,
+    opts: &serde_json::Value,
+) -> Vec<RankedTool> {
+    let query = query.trim();
+    if query.is_empty() {
+        return Vec::new();
+    }
+    let max_results = opts
+        .get("max_results")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(DEFAULT_MAX_RESULTS as u64)
+        .max(1) as usize;
+    let strategy = opts
+        .get("strategy")
+        .and_then(serde_json::Value::as_str)
+        .or_else(|| opts.get("variant").and_then(serde_json::Value::as_str))
+        .unwrap_or("bm25");
+    let candidates = candidates_from_registry(registry);
+    match strategy {
+        "regex" => score_regex(query, &candidates, max_results),
+        _ => score_bm25(query, &candidates, max_results),
+    }
+}
+
+fn candidates_from_registry(registry: &serde_json::Value) -> Vec<Candidate> {
+    let tools = registry
+        .get("tools")
+        .and_then(serde_json::Value::as_array)
+        .or_else(|| registry.as_array());
+    tools
+        .into_iter()
+        .flatten()
+        .filter_map(candidate_from_entry)
+        .collect()
+}
+
+fn candidate_from_entry(tool: &serde_json::Value) -> Option<Candidate> {
+    if let Some(function) = tool.get("function") {
+        let name = function.get("name")?.as_str()?.to_string();
+        let description = function
+            .get("description")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        let param_text = extract_param_text(function.get("parameters"));
+        return Some(Candidate {
+            name,
+            description,
+            param_text,
+        });
+    }
+
+    let name = tool.get("name")?.as_str()?.to_string();
+    let description = tool
+        .get("description")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    let param_text =
+        extract_param_text(tool.get("input_schema").or_else(|| tool.get("parameters")));
+    Some(Candidate {
+        name,
+        description,
+        param_text,
+    })
+}
+
+fn extract_param_text(schema: Option<&serde_json::Value>) -> Vec<String> {
+    let Some(properties) = schema
+        .and_then(|schema| schema.get("properties").or(Some(schema)))
+        .and_then(serde_json::Value::as_object)
+    else {
+        return Vec::new();
+    };
+    properties
+        .iter()
+        .map(|(name, prop)| {
+            let description = prop
+                .get("description")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default();
+            if description.is_empty() {
+                name.clone()
+            } else {
+                format!("{name}: {description}")
+            }
+        })
+        .collect()
+}
+
+fn score_bm25(query: &str, candidates: &[Candidate], max_results: usize) -> Vec<RankedTool> {
+    let query_tokens = tokenize(query);
+    if query_tokens.is_empty() || candidates.is_empty() {
+        return Vec::new();
+    }
+    let docs: Vec<Vec<String>> = candidates
+        .iter()
+        .map(|candidate| tokenize(&candidate.corpus_text()))
+        .collect();
+    let n = docs.len() as f64;
+    let avgdl = docs.iter().map(Vec::len).sum::<usize>() as f64 / n.max(1.0);
+    let mut df: HashMap<&str, usize> = HashMap::new();
+    for token in &query_tokens {
+        let token_ref = token.as_str();
+        if df.contains_key(token_ref) {
+            continue;
+        }
+        let count = docs
+            .iter()
+            .filter(|doc| doc.iter().any(|item| item == token_ref))
+            .count();
+        df.insert(token_ref, count);
+    }
+
+    let mut scored: Vec<(usize, f64)> = docs
+        .iter()
+        .enumerate()
+        .map(|(index, doc)| {
+            let dl = doc.len() as f64;
+            let mut term_counts: HashMap<&str, usize> = HashMap::new();
+            for token in doc {
+                *term_counts.entry(token.as_str()).or_insert(0) += 1;
+            }
+            let mut score = 0.0;
+            for query_token in &query_tokens {
+                let n_qi = *df.get(query_token.as_str()).unwrap_or(&0) as f64;
+                if n_qi == 0.0 {
+                    continue;
+                }
+                let f = *term_counts.get(query_token.as_str()).unwrap_or(&0) as f64;
+                if f == 0.0 {
+                    continue;
+                }
+                let idf = ((n - n_qi + 0.5) / (n_qi + 0.5) + 1.0).ln();
+                let norm = 1.0 - B + B * (dl / avgdl.max(1e-9));
+                score += idf * ((f * (K1 + 1.0)) / (f + K1 * norm));
+            }
+            (index, score)
+        })
+        .filter(|(_, score)| *score > 0.0)
+        .collect();
+
+    scored.sort_by(|a, b| {
+        b.1.partial_cmp(&a.1)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| candidates[a.0].name.cmp(&candidates[b.0].name))
+    });
+    scored.truncate(max_results);
+    scored
+        .into_iter()
+        .map(|(index, score)| ranked(&candidates[index], score))
+        .collect()
+}
+
+fn score_regex(pattern: &str, candidates: &[Candidate], max_results: usize) -> Vec<RankedTool> {
+    let Ok(regex) = RegexBuilder::new(pattern)
+        .case_insensitive(true)
+        .size_limit(1 << 20)
+        .build()
+    else {
+        return Vec::new();
+    };
+    let mut scored: Vec<(usize, f64)> = candidates
+        .iter()
+        .enumerate()
+        .filter_map(|(index, candidate)| {
+            let count = regex.find_iter(&candidate.corpus_text()).count();
+            (count > 0).then_some((index, count as f64))
+        })
+        .collect();
+    scored.sort_by(|a, b| {
+        b.1.partial_cmp(&a.1)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| candidates[a.0].name.cmp(&candidates[b.0].name))
+    });
+    scored.truncate(max_results);
+    scored
+        .into_iter()
+        .map(|(index, score)| ranked(&candidates[index], score))
+        .collect()
+}
+
+fn ranked(candidate: &Candidate, score: f64) -> RankedTool {
+    RankedTool {
+        tool_name: candidate.name.clone(),
+        score,
+        snippet: candidate.snippet(),
+    }
+}
+
+fn tokenize(text: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut current = String::new();
+    for ch in text.chars() {
+        if ch.is_alphanumeric() {
+            for lower in ch.to_lowercase() {
+                current.push(lower);
+            }
+        } else if !current.is_empty() {
+            out.push(std::mem::take(&mut current));
+        }
+    }
+    if !current.is_empty() {
+        out.push(current);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bm25_ranks_deferred_registry_entries() {
+        let registry = serde_json::json!({
+            "tools": [
+                {"name": "deploy_service", "description": "Deploy production", "parameters": {}},
+                {"name": "query_metrics", "description": "Read dashboards", "parameters": {}}
+            ]
+        });
+        let ranked = score_tools(
+            "deploy",
+            &registry,
+            &serde_json::json!({"strategy": "bm25"}),
+        );
+        assert_eq!(ranked[0].tool_name, "deploy_service");
+    }
+
+    #[test]
+    fn regex_uses_same_candidate_corpus() {
+        let registry = serde_json::json!({
+            "tools": [
+                {"name": "edit_file", "description": "Edit file", "parameters": {}},
+                {"name": "run_shell", "description": "Run command", "parameters": {}}
+            ]
+        });
+        let ranked = score_tools(
+            "edit|create",
+            &registry,
+            &serde_json::json!({"strategy": "regex"}),
+        );
+        assert_eq!(ranked.len(), 1);
+        assert_eq!(ranked[0].tool_name, "edit_file");
+    }
+}

--- a/crates/harn-vm/src/llm/tools/mod.rs
+++ b/crates/harn-vm/src/llm/tools/mod.rs
@@ -18,8 +18,7 @@ pub(crate) use messages::{build_assistant_response_message, normalize_tool_args}
 #[cfg(test)]
 pub(crate) use native::apply_tool_search_native_injection;
 pub(crate) use native::{
-    apply_tool_search_client_injection, apply_tool_search_native_injection_typed,
-    extract_deferred_tool_names, vm_tools_to_native,
+    apply_tool_search_native_injection_typed, extract_deferred_tool_names, vm_tools_to_native,
 };
 pub(crate) use parse::parse_text_tool_calls_with_tools;
 pub(crate) use parse::StreamingToolCallDetector;

--- a/crates/harn-vm/src/llm/tools/native.rs
+++ b/crates/harn-vm/src/llm/tools/native.rs
@@ -93,10 +93,9 @@ pub(crate) fn vm_tools_to_native(
                     }
                     if defer_loading {
                         // Record the flag on the Harn-side wrapper so
-                        // harn#71 (OpenAI Responses tool_search) and
-                        // harn#70 (client-executed fallback) can read it
-                        // without re-walking the VmValue tree. Non-
-                        // OpenAI OpenAI-compat providers that don't
+                        // native and client-executed tool-search paths
+                        // can read it without re-walking the VmValue
+                        // tree. Non-OpenAI OpenAI-compat providers that don't
                         // understand `defer_loading` today will return an
                         // error when the user explicitly requests
                         // tool_search — the capability gate in options.rs
@@ -166,146 +165,6 @@ pub(crate) fn extract_deferred_tool_names(native_tools: &[serde_json::Value]) ->
 /// No-ops if `native_tools` is `None` (no tools passed = no search to
 /// do). The meta-tool itself never has `defer_loading` — that's a hard
 /// requirement of Anthropic's API and we match it here.
-/// When `tool_search` resolves to client mode (harn#70), inject the
-/// synthetic `__harn_tool_search` dispatchable tool *and* strip the
-/// deferred tools from the outgoing payload. Promoted tools are
-/// restored turn-by-turn by the agent loop's
-/// `refresh_client_mode_tool_payload` helper; this function handles the
-/// initial turn only.
-///
-/// Why strip deferred tools here: the whole point of progressive
-/// disclosure is that the model doesn't see deferred schemas until the
-/// search tool surfaces them. If we left them in `native_tools` the
-/// token savings would be zero.
-///
-/// Safe no-op if `native_tools` is `None` — the user passed no tools
-/// so there is nothing to search.
-pub(crate) fn apply_tool_search_client_injection(
-    native_tools: &mut Option<Vec<serde_json::Value>>,
-    provider: &str,
-    cfg: &super::super::api::ToolSearchConfig,
-) {
-    let Some(list) = native_tools.as_mut() else {
-        return;
-    };
-    let always_loaded: std::collections::BTreeSet<&str> =
-        cfg.always_loaded.iter().map(String::as_str).collect();
-
-    // Filter out deferred tools whose names aren't pinned via
-    // `always_loaded`. They'll be re-added to the payload lazily when
-    // the model's `__harn_tool_search` call promotes them.
-    list.retain(|tool| {
-        let is_deferred = tool
-            .get("defer_loading")
-            .and_then(|value| value.as_bool())
-            .unwrap_or(false);
-        if !is_deferred {
-            return true;
-        }
-        // Anthropic shape: `name` at top level; OpenAI shape:
-        // `function.name` nested.
-        let name = tool
-            .get("name")
-            .and_then(|value| value.as_str())
-            .or_else(|| {
-                tool.get("function")
-                    .and_then(|function| function.get("name"))
-                    .and_then(|value| value.as_str())
-            })
-            .unwrap_or("");
-        always_loaded.contains(name)
-    });
-
-    // Clear any remaining `defer_loading: true` flags on pinned tools —
-    // the provider's API doesn't know about it in client mode and may
-    // reject unknown fields (OpenAI compat is strict).
-    for tool in list.iter_mut() {
-        if let Some(obj) = tool.as_object_mut() {
-            obj.remove("defer_loading");
-        }
-        if let Some(function) = tool
-            .get_mut("function")
-            .and_then(|value| value.as_object_mut())
-        {
-            function.remove("defer_loading");
-        }
-    }
-
-    // Prepend the synthetic search tool so it's visible even on strict
-    // providers that truncate long tool lists. Name can be overridden
-    // via `tool_search.name`.
-    let synthetic = build_client_search_tool_schema(provider, cfg);
-    list.insert(0, synthetic);
-}
-
-/// Shape the synthetic `__harn_tool_search` schema for the provider's
-/// API style. Deliberately minimal: one required `query` string. The
-/// model figures out whether it should phrase the query as natural
-/// language (BM25) or a regex by reading the description.
-pub(crate) fn build_client_search_tool_schema(
-    provider: &str,
-    cfg: &super::super::api::ToolSearchConfig,
-) -> serde_json::Value {
-    let name = cfg.effective_name().to_string();
-    let strategy = cfg.effective_strategy();
-    let description = match strategy {
-        super::super::api::ToolSearchStrategy::Regex => {
-            "Search for tools you need. Pass `query` as a case-insensitive regex \
-             (Rust `regex` crate syntax — no lookaround, no backreferences). \
-             The tool returns `{ \"tool_names\": [...] }`; only the returned \
-             tools will be available to call in the next turn."
-        }
-        super::super::api::ToolSearchStrategy::Bm25 => {
-            "Search for tools you need. Pass `query` as natural-language \
-             keywords (BM25). The tool returns `{ \"tool_names\": [...] }`; \
-             only the returned tools will be available to call in the next turn. \
-             Cast a wider net if the first search returns nothing useful."
-        }
-        super::super::api::ToolSearchStrategy::Semantic => {
-            "Search for tools you need. Pass `query` as a natural-language \
-             description; a semantic / embedding index returns the best matches \
-             as `{ \"tool_names\": [...] }`. Only the returned tools will be \
-             available to call in the next turn."
-        }
-        super::super::api::ToolSearchStrategy::Host => {
-            "Search for tools you need. Pass `query` as the host expects it; \
-             the host returns `{ \"tool_names\": [...] }`. Only the returned \
-             tools will be available to call in the next turn."
-        }
-    };
-
-    let input_schema = serde_json::json!({
-        "type": "object",
-        "properties": {
-            "query": {
-                "type": "string",
-                "description": "Search query (keywords for BM25/semantic, regex for regex variant).",
-            }
-        },
-        "required": ["query"],
-        "additionalProperties": false,
-    });
-
-    let is_anthropic_style =
-        super::super::helpers::ResolvedProvider::resolve(provider).is_anthropic_style;
-    if is_anthropic_style {
-        serde_json::json!({
-            "name": name,
-            "description": description,
-            "input_schema": input_schema,
-        })
-    } else {
-        serde_json::json!({
-            "type": "function",
-            "function": {
-                "name": name,
-                "description": description,
-                "parameters": input_schema,
-            }
-        })
-    }
-}
-
 #[cfg(test)]
 pub(crate) fn apply_tool_search_native_injection(
     native_tools: &mut Option<Vec<serde_json::Value>>,
@@ -353,8 +212,8 @@ pub(crate) fn apply_tool_search_native_injection_typed(
             prepend_meta_tool(native_tools, meta);
         }
         NativeToolSearchShape::OpenAi => {
-            // OpenAI Responses-API shape (harn#71). The meta-tool goes
-            // at the front of the tools array and carries a `mode`
+            // OpenAI Responses-API shape. The meta-tool goes at the
+            // front of the tools array and carries a `mode`
             // field ("hosted"/"client"). Deferred tools get
             // `defer_loading: true` set at the wrapper level in
             // `vm_tools_to_native`; the model sees only stub schemas

--- a/crates/harn-vm/tests/builtin_registry_alignment.rs
+++ b/crates/harn-vm/tests/builtin_registry_alignment.rs
@@ -121,6 +121,7 @@ const RUNTIME_ONLY_EXCEPTIONS: &[&str] = &[
     "__host_mcp_bootstrap",
     "__host_mcp_disconnect",
     "__host_skill_score",
+    "__host_tool_search_score",
     "__host_sub_agent_run",
     "__host_worker_close",
     "__host_worker_list",


### PR DESCRIPTION
Closes #1244.

## What changed
- Added a Harn stdlib client-mode tool-search helper that injects the synthetic search tool, manages promoted deferred tools, applies the promotion budget, and emits `tool_search_query` / `tool_search_result` events.
- Added `__host_tool_search_score(query, registry, opts)` as the remaining Rust scoring primitive for BM25 and regex ranking.
- Removed the Rust-side client synthetic-tool injection path and un-xfailed the four client tool-search conformance tests.

## Validation
- `CARGO_TARGET_DIR=/tmp/harn-target-1244 cargo check -p harn-vm`
- `CARGO_TARGET_DIR=/tmp/harn-target-1244 cargo test -p harn-vm tool_search -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-1244 cargo run --quiet --bin harn -- test conformance --filter tool_search_client`
- `CARGO_TARGET_DIR=/tmp/harn-target-1244 cargo run --quiet --bin harn -- test conformance --filter tool_search`
- pre-commit hook: Harn format/lint, workspace clippy, ratchets, highlight keyword sync
- pre-push hook: targeted local checks, affected Harn format/lint, highlight keyword check