### PR TITLE
[codex] Fix Ollama tool history replay

### DIFF
--- a/crates/harn-vm/src/llm/tools/messages.rs
+++ b/crates/harn-vm/src/llm/tools/messages.rs
@@ -26,20 +26,21 @@ pub(crate) fn build_assistant_tool_message(
         }
         serde_json::json!({"role": "assistant", "content": content})
     } else if is_ollama {
-        // Modern Ollama chat validates replayed tool-call history using
-        // the OpenAI-compatible string-encoded `function.arguments`
-        // shape. Keeping the history shape consistent also prevents
-        // local Qwen runs from failing on the second iteration.
+        // Ollama's chat API uses the OpenAI-style `function` envelope but
+        // keeps `arguments` as a JSON object. Replaying OpenAI's
+        // string-encoded arguments trips Ollama's template parser on the
+        // next turn.
         let calls: Vec<serde_json::Value> = tool_calls
             .iter()
             .enumerate()
             .map(|(idx, tc)| {
                 serde_json::json!({
+                    "id": tc["id"],
                     "type": "function",
                     "function": {
                         "index": idx,
                         "name": tc["name"],
-                        "arguments": serde_json::to_string(&tc["arguments"]).unwrap_or_default(),
+                        "arguments": tc["arguments"],
                     }
                 })
             })

--- a/crates/harn-vm/src/llm/tools/tests/heredoc_and_messages.rs
+++ b/crates/harn-vm/src/llm/tools/tests/heredoc_and_messages.rs
@@ -643,7 +643,7 @@ fn assistant_tool_message_includes_empty_content_for_openai_style() {
 }
 
 #[test]
-fn assistant_tool_message_uses_ollama_openai_compatible_arguments() {
+fn assistant_tool_message_uses_ollama_native_arguments() {
     let message = build_assistant_tool_message(
         "",
         &[json!({
@@ -656,11 +656,12 @@ fn assistant_tool_message_uses_ollama_openai_compatible_arguments() {
 
     assert_eq!(message["role"], "assistant");
     assert!(message.get("content").is_none());
+    assert_eq!(message["tool_calls"][0]["id"], "call_001");
     assert_eq!(message["tool_calls"][0]["type"], "function");
     assert_eq!(message["tool_calls"][0]["function"]["name"], "read");
     assert_eq!(
-        message["tool_calls"][0]["function"]["arguments"],
-        "{\"path\":\"main.rs\"}"
+        message["tool_calls"][0]["function"]["arguments"]["path"],
+        "main.rs"
     );
 }
 


### PR DESCRIPTION
## Summary

Fixes Ollama-specific replay of native tool-call history.

## Details

Ollama returns tool call arguments as JSON objects and expects the same shape when assistant tool-call history is replayed. Harn was replaying the OpenAI string-encoded `function.arguments` shape on the Ollama path, which can trip Ollama's chat template parser on follow-up turns.

## Validation

- `cargo fmt --check`
- `cargo test -p harn-vm assistant_tool_message_uses_ollama_native_arguments`
- `cargo test -p harn-vm llm::agent_session_host::tests::`
- `cargo test -p harn-vm transcript_dir_option_overrides_env_until_popped`
- pre-commit full clippy gate
- pre-push targeted local checks
