### PR TITLE
Add persona scaffolder and doctor

### DIFF
--- a/conformance/tests/cli/persona_scaffolder.expected
+++ b/conformance/tests/cli/persona_scaffolder.expected
@@ -1,0 +1,11 @@
+true
+true
+true
+true
+true
+true
+true
+true
+my_release_captain
+true
+true

--- a/conformance/tests/cli/persona_scaffolder.harn
+++ b/conformance/tests/cli/persona_scaffolder.harn
@@ -1,0 +1,32 @@
+import "../_common"
+
+pipeline default() {
+  let repo_root = exec("git", "rev-parse", "--show-toplevel").stdout.trim()
+  let harn_bin = env_or("HARN_CONFORMANCE_HARN_BIN", resolve_harn_bin(repo_root))
+  let root = path_join(temp_dir(), "harn_persona_scaffolder_" + uuid_v7())
+  mkdir(root)
+  let created = exec_at(
+    root,
+    harn_bin,
+    "persona",
+    "new",
+    "my_release_captain",
+    "--template",
+    "deterministic-sweeper",
+  )
+  println(created.success)
+  let persona_dir = path_join(root, "personas/my_release_captain")
+  println(file_exists(path_join(persona_dir, "harn.toml")))
+  println(file_exists(path_join(persona_dir, "src/my_release_captain.harn")))
+  println(file_exists(path_join(persona_dir, "tests/my_release_captain_smoke.harn")))
+  println(file_exists(path_join(persona_dir, "tests/my_release_captain_smoke.expected")))
+  println(file_exists(path_join(persona_dir, "fixtures/happy_path.json")))
+  println(file_exists(path_join(persona_dir, "evals/smoke.eval.json")))
+  let doctor = exec_at(root, harn_bin, "persona", "doctor", "my_release_captain", "--json")
+  println(doctor.success)
+  let report = json_parse(doctor.stdout)
+  println(report.persona)
+  println(len(report.checks) >= 6)
+  let smoke = exec_at(persona_dir, harn_bin, "test", "tests/my_release_captain_smoke.harn")
+  println(smoke.success)
+}

--- a/crates/harn-cli/src/cli/mod.rs
+++ b/crates/harn-cli/src/cli/mod.rs
@@ -95,8 +95,9 @@ pub(crate) use package::{
     RemoveArgs, UpdateArgs,
 };
 pub(crate) use persona::{
-    PersonaArgs, PersonaCheckArgs, PersonaCommand, PersonaControlArgs, PersonaInspectArgs,
-    PersonaListArgs, PersonaSpendArgs, PersonaStatusArgs, PersonaTickArgs, PersonaTriggerArgs,
+    PersonaArgs, PersonaCheckArgs, PersonaCommand, PersonaControlArgs, PersonaDoctorArgs,
+    PersonaInspectArgs, PersonaListArgs, PersonaNewArgs, PersonaSpendArgs, PersonaStatusArgs,
+    PersonaTemplateKind, PersonaTickArgs, PersonaTriggerArgs,
 };
 pub(crate) use playground::PlaygroundArgs;
 pub(crate) use portal::PortalArgs;

--- a/crates/harn-cli/src/cli/persona.rs
+++ b/crates/harn-cli/src/cli/persona.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use clap::{Args, Subcommand};
+use clap::{Args, Subcommand, ValueEnum};
 
 #[derive(Debug, Args)]
 pub(crate) struct PersonaArgs {
@@ -21,6 +21,10 @@ pub(crate) struct PersonaArgs {
 
 #[derive(Debug, Subcommand)]
 pub(crate) enum PersonaCommand {
+    /// Scaffold a new Harn-first persona package from a template.
+    New(PersonaNewArgs),
+    /// Validate a persona package end-to-end.
+    Doctor(PersonaDoctorArgs),
     /// Validate a persona manifest with the canonical harn-modules schema.
     Check(PersonaCheckArgs),
     /// List personas declared in the resolved harn.toml.
@@ -41,6 +45,53 @@ pub(crate) enum PersonaCommand {
     Trigger(PersonaTriggerArgs),
     /// Record an expensive-work budget receipt for a persona.
     Spend(PersonaSpendArgs),
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct PersonaNewArgs {
+    /// Persona package name, for example `my_release_captain`.
+    pub name: String,
+    /// Persona control-flow template.
+    #[arg(long, value_enum)]
+    pub template: PersonaTemplateKind,
+    /// Directory under which the persona package is created.
+    #[arg(long, value_name = "DIR", default_value = "personas")]
+    pub output_root: PathBuf,
+    /// Replace an existing generated package.
+    #[arg(long)]
+    pub force: bool,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct PersonaDoctorArgs {
+    /// Persona name or package directory to validate.
+    pub name: String,
+    /// Emit a stable JSON report instead of a human-readable table.
+    #[arg(long)]
+    pub json: bool,
+    /// Test timeout for the smoke suite.
+    #[arg(long, default_value_t = 10_000)]
+    pub timeout_ms: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub(crate) enum PersonaTemplateKind {
+    #[value(name = "deterministic-sweeper")]
+    DeterministicSweeper,
+    #[value(name = "hybrid-classify-then-act")]
+    HybridClassifyThenAct,
+    #[value(name = "frontier-judgment-loop")]
+    FrontierJudgmentLoop,
+}
+
+impl PersonaTemplateKind {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::DeterministicSweeper => "deterministic-sweeper",
+            Self::HybridClassifyThenAct => "hybrid-classify-then-act",
+            Self::FrontierJudgmentLoop => "frontier-judgment-loop",
+        }
+    }
 }
 
 #[derive(Debug, Args)]

--- a/crates/harn-cli/src/commands/mod.rs
+++ b/crates/harn-cli/src/commands/mod.rs
@@ -16,6 +16,8 @@ pub(crate) mod merge_captain;
 pub(crate) mod merge_captain_mock;
 pub mod orchestrator;
 pub mod persona;
+pub mod persona_doctor;
+pub mod persona_scaffold;
 pub mod playground;
 pub(crate) mod portal;
 pub(crate) mod protocol_conformance;

--- a/crates/harn-cli/src/commands/persona_doctor.rs
+++ b/crates/harn-cli/src/commands/persona_doctor.rs
@@ -1,0 +1,536 @@
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use harn_lint::LintSeverity;
+use serde::Serialize;
+
+use crate::cli::PersonaDoctorArgs;
+use crate::package::{self, PersonaManifestEntry, ResolvedPersonaManifest};
+use crate::test_runner;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DoctorStatus {
+    Green,
+    Yellow,
+    Red,
+}
+
+impl DoctorStatus {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Green => "green",
+            Self::Yellow => "yellow",
+            Self::Red => "red",
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct DoctorCheck {
+    pub name: String,
+    pub status: DoctorStatus,
+    pub message: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PersonaDoctorReport {
+    pub persona: String,
+    pub manifest_path: PathBuf,
+    pub checks: Vec<DoctorCheck>,
+}
+
+impl PersonaDoctorReport {
+    fn has_red(&self) -> bool {
+        self.checks
+            .iter()
+            .any(|check| check.status == DoctorStatus::Red)
+    }
+}
+
+pub(crate) async fn run_doctor(
+    manifest_arg: Option<&Path>,
+    args: &PersonaDoctorArgs,
+) -> Result<(), String> {
+    let report = doctor_report(manifest_arg, args).await;
+    match report {
+        Ok(report) => {
+            if args.json {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&report)
+                        .map_err(|error| format!("failed to serialize doctor report: {error}"))?
+                );
+            } else {
+                print_report(&report);
+            }
+            Ok(())
+        }
+        Err(error_report) => {
+            if args.json {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&error_report)
+                        .map_err(|error| format!("failed to serialize doctor report: {error}"))?
+                );
+            } else {
+                print_report(&error_report);
+            }
+            Err("persona doctor found red checks".to_string())
+        }
+    }
+}
+
+pub(crate) async fn doctor_report(
+    manifest_arg: Option<&Path>,
+    args: &PersonaDoctorArgs,
+) -> Result<PersonaDoctorReport, PersonaDoctorReport> {
+    let manifest_path = resolve_manifest_path(manifest_arg, &args.name);
+    let mut checks = Vec::new();
+    let catalog = match package::load_personas_from_manifest_path(&manifest_path) {
+        Ok(catalog) => {
+            checks.push(check(
+                "manifest",
+                DoctorStatus::Green,
+                format!("{} validates", catalog.manifest_path.display()),
+            ));
+            catalog
+        }
+        Err(errors) => {
+            checks.push(check(
+                "manifest",
+                DoctorStatus::Red,
+                errors
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect::<Vec<_>>()
+                    .join("; "),
+            ));
+            return Err(PersonaDoctorReport {
+                persona: args.name.clone(),
+                manifest_path,
+                checks,
+            });
+        }
+    };
+
+    let Some(persona) = catalog
+        .personas
+        .iter()
+        .find(|persona| persona.name.as_deref() == Some(args.name.as_str()))
+        .or_else(|| {
+            catalog
+                .personas
+                .iter()
+                .find(|persona| persona.name.as_deref() == Some(path_name(&args.name).as_str()))
+        })
+    else {
+        checks.push(check(
+            "manifest-persona",
+            DoctorStatus::Red,
+            format!(
+                "persona '{}' not found in {}",
+                args.name,
+                catalog.manifest_path.display()
+            ),
+        ));
+        return Err(PersonaDoctorReport {
+            persona: args.name.clone(),
+            manifest_path: catalog.manifest_path,
+            checks,
+        });
+    };
+    let persona_name = persona.name.clone().unwrap_or_else(|| args.name.clone());
+
+    let entry_source = resolve_entry_source(&catalog, persona);
+    checks.push(source_shape_check(&entry_source));
+    checks.push(lint_check(&catalog, &entry_source));
+    checks.push(prompt_asset_check(&catalog, &entry_source));
+    checks.push(step_metadata_check(persona));
+    checks.push(cost_check(persona));
+    checks.push(smoke_check(&catalog, &persona_name, args.timeout_ms).await);
+
+    let report = PersonaDoctorReport {
+        persona: persona_name,
+        manifest_path: catalog.manifest_path,
+        checks,
+    };
+    if report.has_red() {
+        Err(report)
+    } else {
+        Ok(report)
+    }
+}
+
+pub async fn doctor_report_for_persona(
+    manifest_arg: Option<&Path>,
+    name: &str,
+    timeout_ms: u64,
+) -> Result<PersonaDoctorReport, PersonaDoctorReport> {
+    let args = PersonaDoctorArgs {
+        name: name.to_string(),
+        json: false,
+        timeout_ms,
+    };
+    doctor_report(manifest_arg, &args).await
+}
+
+fn print_report(report: &PersonaDoctorReport) {
+    println!(
+        "persona doctor: {} ({})",
+        report.persona,
+        report.manifest_path.display()
+    );
+    for check in &report.checks {
+        println!(
+            "  {:<6} {:<20} {}",
+            check.status.label(),
+            check.name,
+            check.message
+        );
+    }
+}
+
+fn check(name: &str, status: DoctorStatus, message: impl Into<String>) -> DoctorCheck {
+    DoctorCheck {
+        name: name.to_string(),
+        status,
+        message: message.into(),
+    }
+}
+
+fn resolve_manifest_path(manifest_arg: Option<&Path>, name: &str) -> PathBuf {
+    if let Some(path) = manifest_arg {
+        return path.to_path_buf();
+    }
+    let raw = PathBuf::from(name);
+    if raw.is_dir() {
+        let manifest = raw.join("harn.toml");
+        if manifest.exists() {
+            return manifest;
+        }
+    }
+    if raw.is_file() {
+        return raw;
+    }
+    let normalized = name.replace('-', "_");
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    for candidate in [
+        cwd.join("personas").join(&normalized).join("harn.toml"),
+        cwd.join(&normalized).join("harn.toml"),
+    ] {
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+    PathBuf::from("harn.toml")
+}
+
+fn path_name(value: &str) -> String {
+    Path::new(value)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(value)
+        .replace('-', "_")
+}
+
+fn resolve_entry_source(
+    catalog: &ResolvedPersonaManifest,
+    persona: &PersonaManifestEntry,
+) -> Option<PathBuf> {
+    let entry = persona.entry_workflow.as_deref()?;
+    let (path, _) = entry.split_once('#')?;
+    Some(catalog.manifest_dir.join(path))
+}
+
+fn source_shape_check(entry_source: &Option<PathBuf>) -> DoctorCheck {
+    let Some(path) = entry_source else {
+        return check(
+            "entry-source",
+            DoctorStatus::Red,
+            "entry_workflow must point at a .harn file with #run",
+        );
+    };
+    match fs::read_to_string(path) {
+        Ok(source) => {
+            let banned = [
+                "__host_agent",
+                "workflow_stage_agent_loop",
+                "harn_vm::",
+                "RustAgent",
+            ];
+            if let Some(token) = banned.iter().find(|token| source.contains(**token)) {
+                return check(
+                    "entry-source",
+                    DoctorStatus::Red,
+                    format!(
+                        "{} references removed/private runtime token {token}",
+                        path.display()
+                    ),
+                );
+            }
+            if !source.contains("@persona") {
+                return check(
+                    "entry-source",
+                    DoctorStatus::Red,
+                    format!("{} does not declare @persona", path.display()),
+                );
+            }
+            check(
+                "entry-source",
+                DoctorStatus::Green,
+                format!("{} is Harn-first and declares @persona", path.display()),
+            )
+        }
+        Err(error) => check(
+            "entry-source",
+            DoctorStatus::Red,
+            format!("failed to read {}: {error}", path.display()),
+        ),
+    }
+}
+
+fn lint_check(catalog: &ResolvedPersonaManifest, entry_source: &Option<PathBuf>) -> DoctorCheck {
+    let Some(path) = entry_source else {
+        return check("lint", DoctorStatus::Red, "entry source unavailable");
+    };
+    let source = match fs::read_to_string(path) {
+        Ok(source) => source,
+        Err(error) => {
+            return check(
+                "lint",
+                DoctorStatus::Red,
+                format!("failed to read {}: {error}", path.display()),
+            )
+        }
+    };
+    let program = match harn_parser::parse_source(&source) {
+        Ok(program) => program,
+        Err(error) => return check("lint", DoctorStatus::Red, error.to_string()),
+    };
+    let files = collect_package_harn_files(&catalog.manifest_dir);
+    let module_graph = crate::commands::check::build_module_graph(&files);
+    let options = harn_lint::LintOptions {
+        file_path: Some(path),
+        require_file_header: false,
+        complexity_threshold: None,
+        persona_step_allowlist: &[],
+    };
+    let diagnostics = harn_lint::lint_with_module_graph(
+        &program,
+        &[],
+        Some(&source),
+        &HashSet::new(),
+        &module_graph,
+        path,
+        &options,
+    );
+    if diagnostics.is_empty() {
+        return check("lint", DoctorStatus::Green, "no issues found");
+    }
+    let red = diagnostics.iter().any(|diag| {
+        diag.severity == LintSeverity::Error || diag.rule == "persona-body-must-call-steps"
+    });
+    let status = if red {
+        DoctorStatus::Red
+    } else {
+        DoctorStatus::Yellow
+    };
+    let summary = diagnostics
+        .iter()
+        .take(3)
+        .map(|diag| format!("{}: {}", diag.rule, diag.message))
+        .collect::<Vec<_>>()
+        .join("; ");
+    check("lint", status, summary)
+}
+
+fn prompt_asset_check(
+    catalog: &ResolvedPersonaManifest,
+    entry_source: &Option<PathBuf>,
+) -> DoctorCheck {
+    let prompt_dir = catalog.manifest_dir.join("prompts");
+    let prompt_files = collect_prompt_files(&prompt_dir);
+    if prompt_files.is_empty() {
+        return check(
+            "prompt-assets",
+            DoctorStatus::Yellow,
+            "no .harn.prompt assets found",
+        );
+    }
+    for path in &prompt_files {
+        let source = match fs::read_to_string(path) {
+            Ok(source) => source,
+            Err(error) => {
+                return check(
+                    "prompt-assets",
+                    DoctorStatus::Red,
+                    format!("failed to read {}: {error}", path.display()),
+                )
+            }
+        };
+        if let Err(error) = harn_vm::stdlib::template::validate_template_syntax(&source) {
+            return check(
+                "prompt-assets",
+                DoctorStatus::Red,
+                format!("{}: {error}", path.display()),
+            );
+        }
+    }
+    let uses_prompt_asset = entry_source
+        .as_ref()
+        .and_then(|path| fs::read_to_string(path).ok())
+        .is_some_and(|source| source.contains("render_prompt(") || source.contains("render("));
+    let status = if uses_prompt_asset {
+        DoctorStatus::Green
+    } else {
+        DoctorStatus::Yellow
+    };
+    check(
+        "prompt-assets",
+        status,
+        format!("{} prompt asset(s) validate", prompt_files.len()),
+    )
+}
+
+fn step_metadata_check(persona: &PersonaManifestEntry) -> DoctorCheck {
+    if persona.steps.is_empty() {
+        return check(
+            "step-metadata",
+            DoctorStatus::Red,
+            "entry source did not expose typed @step metadata",
+        );
+    }
+    let missing_receipt = persona
+        .steps
+        .iter()
+        .filter(|step| step.receipt.as_deref().unwrap_or_default().is_empty())
+        .count();
+    if missing_receipt > 0 {
+        return check(
+            "step-metadata",
+            DoctorStatus::Yellow,
+            format!(
+                "{} step(s) found, {missing_receipt} without explicit receipt policy",
+                persona.steps.len()
+            ),
+        );
+    }
+    check(
+        "step-metadata",
+        DoctorStatus::Green,
+        format!("{} typed step(s) found", persona.steps.len()),
+    )
+}
+
+fn cost_check(persona: &PersonaManifestEntry) -> DoctorCheck {
+    let step_token_budget: u64 = persona
+        .steps
+        .iter()
+        .filter_map(|step| step.budget.as_ref()?.max_tokens)
+        .sum();
+    let Some(max_tokens) = persona.budget.max_tokens else {
+        return check(
+            "cost-budget",
+            DoctorStatus::Yellow,
+            "manifest has no max_tokens budget",
+        );
+    };
+    if step_token_budget == 0 {
+        return check(
+            "cost-budget",
+            DoctorStatus::Yellow,
+            format!("manifest max_tokens={max_tokens}, no per-step token budgets"),
+        );
+    }
+    if step_token_budget > max_tokens {
+        return check(
+            "cost-budget",
+            DoctorStatus::Red,
+            format!("per-step max_tokens sum {step_token_budget} exceeds manifest max_tokens {max_tokens}"),
+        );
+    }
+    check(
+        "cost-budget",
+        DoctorStatus::Green,
+        format!(
+            "per-step max_tokens sum {step_token_budget} within manifest max_tokens {max_tokens}"
+        ),
+    )
+}
+
+async fn smoke_check(
+    catalog: &ResolvedPersonaManifest,
+    persona_name: &str,
+    timeout_ms: u64,
+) -> DoctorCheck {
+    let test_path = catalog
+        .manifest_dir
+        .join("tests")
+        .join(format!("{persona_name}_smoke.harn"));
+    if !test_path.exists() {
+        return check(
+            "smoke-test",
+            DoctorStatus::Yellow,
+            format!("{} not found", test_path.display()),
+        );
+    }
+    let summary = test_runner::run_tests(&test_path, None, timeout_ms, false).await;
+    if summary.failed > 0 {
+        let first_error = summary
+            .results
+            .iter()
+            .find(|result| !result.passed)
+            .and_then(|result| result.error.as_deref())
+            .unwrap_or("smoke test failed");
+        return check(
+            "smoke-test",
+            DoctorStatus::Red,
+            format!("{first_error} ({} failed)", summary.failed),
+        );
+    }
+    if summary.total == 0 {
+        return check(
+            "smoke-test",
+            DoctorStatus::Yellow,
+            "no test pipelines found",
+        );
+    }
+    check(
+        "smoke-test",
+        DoctorStatus::Green,
+        format!("{} smoke test(s) passed", summary.passed),
+    )
+}
+
+fn collect_package_harn_files(dir: &Path) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    crate::commands::collect_harn_files(dir, &mut files);
+    files
+}
+
+fn collect_prompt_files(dir: &Path) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    collect_prompt_files_inner(dir, &mut files);
+    files.sort();
+    files
+}
+
+fn collect_prompt_files_inner(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.filter_map(Result::ok) {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_prompt_files_inner(&path, out);
+        } else if path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.ends_with(".harn.prompt"))
+        {
+            out.push(path);
+        }
+    }
+}

--- a/crates/harn-cli/src/commands/persona_scaffold.rs
+++ b/crates/harn-cli/src/commands/persona_scaffold.rs
@@ -1,0 +1,536 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::cli::{PersonaNewArgs, PersonaTemplateKind};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PersonaScaffoldResult {
+    pub root: PathBuf,
+    pub files: Vec<PathBuf>,
+}
+
+#[derive(Clone, Copy)]
+struct TemplateFile {
+    relative_path: &'static str,
+    content: &'static str,
+}
+
+const TEMPLATE_FILES: &[TemplateFile] = &[
+    TemplateFile {
+        relative_path: "harn.toml",
+        content: HARN_TOML_TEMPLATE,
+    },
+    TemplateFile {
+        relative_path: "src/{{persona_name}}.harn",
+        content: SOURCE_TEMPLATE,
+    },
+    TemplateFile {
+        relative_path: "tests/{{persona_name}}_smoke.harn",
+        content: SMOKE_TEST_TEMPLATE,
+    },
+    TemplateFile {
+        relative_path: "tests/{{persona_name}}_smoke.expected",
+        content: SMOKE_EXPECTED_TEMPLATE,
+    },
+    TemplateFile {
+        relative_path: "fixtures/happy_path.json",
+        content: FIXTURE_TEMPLATE,
+    },
+    TemplateFile {
+        relative_path: "prompts/system.harn.prompt",
+        content: PROMPT_TEMPLATE,
+    },
+    TemplateFile {
+        relative_path: "evals/smoke.eval.json",
+        content: EVAL_TEMPLATE,
+    },
+    TemplateFile {
+        relative_path: "README.md",
+        content: README_TEMPLATE,
+    },
+];
+
+const HARN_TOML_TEMPLATE: &str = r#"[package]
+name = "harn-{{package_slug}}-persona"
+version = "0.1.0"
+description = "{{persona_title}} persona scaffold."
+
+[[personas]]
+name = "{{persona_name}}"
+version = "0.1.0"
+description = "{{persona_title}} persona scaffold generated from the {{template_kind}} template."
+entry_workflow = "src/{{persona_name}}.harn#run"
+tools = {{tools}}
+capabilities = {{capabilities}}
+autonomy_tier = "{{autonomy_tier}}"
+receipt_policy = "required"
+triggers = {{triggers}}
+schedules = []
+handoffs = []
+context_packs = ["repo_policy"]
+evals = ["smoke"]
+owner = "platform"
+budget = {{budget}}
+model_policy = {{model_policy}}
+rollout_policy = { mode = "approval_only", percentage = 100, cohorts = ["scaffold"] }
+package_source = { package = "harn-{{package_slug}}-persona", path = "." }
+"#;
+
+const SOURCE_TEMPLATE: &str = r#"import { bounded_loop, cheap_classify_then_escalate, with_audit_receipt } from "std/personas/prelude"
+
+@persona(
+  name: "{{persona_name}}",
+  description: "{{persona_title}} persona scaffold generated from the {{template_kind}} template.",
+  tools: {{tools_symbols}},
+  capabilities: {{capabilities}},
+  autonomy: "{{autonomy_tier}}",
+  receipts: "required",
+)
+/** Run the scaffolded persona DAG. */
+pub fn {{persona_ident}}(task) {
+{{persona_body}}
+}
+
+{{steps}}
+
+pipeline run(task) {
+  return {{persona_ident}}(task)
+}
+"#;
+
+const SMOKE_TEST_TEMPLATE: &str = r#"import { {{persona_ident}} } from "../src/{{persona_name}}"
+
+pipeline test_{{persona_ident}}_smoke(task) {
+  llm_mock_clear()
+{{llm_mocks}}
+  let fixture = json_parse(read_file("../fixtures/happy_path.json"))
+  let result = {{persona_ident}}({
+    fixture: fixture,
+    started_at: "2026-05-05T00:00:00Z",
+    completed_at: "2026-05-05T00:00:00Z",
+  })
+  assert_eq(result.ok, true)
+  assert_eq(result.receipt.schema, "harn.receipt.v1")
+{{smoke_assertions}}
+  println(result.ok)
+  println(result.receipt.schema)
+}
+"#;
+
+const SMOKE_EXPECTED_TEMPLATE: &str = r#"true
+harn.receipt.v1
+"#;
+
+const FIXTURE_TEMPLATE: &str = r#"{
+  "items": [
+    {"id": "demo-1", "title": "First scaffolded work item", "risk": "low"},
+    {"id": "demo-2", "title": "Second scaffolded work item", "risk": "medium"}
+  ],
+  "request": "Decide the next safe action for this persona package."
+}
+"#;
+
+const PROMPT_TEMPLATE: &str = r#"You are {{persona_title}}, a Harn persona.
+
+Use the fixture request and typed step metadata to produce a bounded, auditable decision.
+
+Persona: {{persona_name}}
+Template: {{template_kind}}
+Request: {{request}}
+"#;
+
+const EVAL_TEMPLATE: &str = r#"{
+  "_type": "eval_pack_manifest",
+  "id": "{{persona_name}}-smoke",
+  "persona": "{{persona_name}}",
+  "fixtures": ["fixtures/happy_path.json"],
+  "metrics": [
+    {"name": "smoke_passed", "kind": "boolean"}
+  ]
+}
+"#;
+
+const README_TEMPLATE: &str = r#"# {{persona_title}}
+
+Generated from the `{{template_kind}}` persona template.
+
+## Validate
+
+```bash
+harn persona doctor {{persona_name}}
+```
+
+## Run The Smoke Test
+
+```bash
+harn test tests/{{persona_name}}_smoke.harn
+```
+
+## Package Layout
+
+- `harn.toml` declares the durable persona manifest and budget/model defaults.
+- `src/{{persona_name}}.harn` contains the `@persona` function and typed `@step` DAG skeleton.
+- `prompts/system.harn.prompt` keeps model-facing instructions as a prompt asset.
+- `fixtures/happy_path.json`, `tests/{{persona_name}}_smoke.harn`, and `tests/{{persona_name}}_smoke.expected` form the first eval-ready fixture pair.
+"#;
+
+pub(crate) fn scaffold_persona(args: &PersonaNewArgs) -> Result<PersonaScaffoldResult, String> {
+    let name = normalize_name(&args.name)?;
+    let target_root = args.output_root.join(&name);
+    if target_root.exists() {
+        if !args.force {
+            return Err(format!(
+                "{} already exists; pass --force to replace generated files",
+                target_root.display()
+            ));
+        }
+        fs::remove_dir_all(&target_root).map_err(|error| {
+            format!(
+                "failed to remove existing persona package {}: {error}",
+                target_root.display()
+            )
+        })?;
+    }
+
+    let vars = TemplateVars::new(&name, args.template);
+    let mut files = Vec::new();
+    for template in TEMPLATE_FILES {
+        let relative = render(template.relative_path, &vars);
+        let path = target_root.join(relative);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .map_err(|error| format!("failed to create {}: {error}", parent.display()))?;
+        }
+        let content = render(template.content, &vars);
+        fs::write(&path, content)
+            .map_err(|error| format!("failed to write {}: {error}", path.display()))?;
+        files.push(path);
+    }
+
+    Ok(PersonaScaffoldResult {
+        root: target_root,
+        files,
+    })
+}
+
+pub fn scaffold_persona_package(
+    name: &str,
+    template: &str,
+    output_root: &Path,
+    force: bool,
+) -> Result<PersonaScaffoldResult, String> {
+    let args = PersonaNewArgs {
+        name: name.to_string(),
+        template: parse_template_kind(template)?,
+        output_root: output_root.to_path_buf(),
+        force,
+    };
+    scaffold_persona(&args)
+}
+
+pub(crate) fn run_new(args: &PersonaNewArgs) -> Result<(), String> {
+    let result = scaffold_persona(args)?;
+    println!("created persona package {}", result.root.display());
+    for file in &result.files {
+        println!("  create {}", file.display());
+    }
+    println!();
+    println!("  harn persona doctor {}", normalize_name(&args.name)?);
+    Ok(())
+}
+
+fn normalize_name(raw: &str) -> Result<String, String> {
+    let name = raw.trim().replace('-', "_");
+    if !valid_identifier(&name) {
+        return Err(format!(
+            "persona name must be an identifier-like token, got {raw:?}"
+        ));
+    }
+    Ok(name)
+}
+
+fn valid_identifier(value: &str) -> bool {
+    let mut chars = value.chars();
+    match chars.next() {
+        Some(ch) if ch == '_' || ch.is_ascii_alphabetic() => {}
+        _ => return false,
+    }
+    chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+}
+
+fn parse_template_kind(value: &str) -> Result<PersonaTemplateKind, String> {
+    match value {
+        "deterministic-sweeper" => Ok(PersonaTemplateKind::DeterministicSweeper),
+        "hybrid-classify-then-act" => Ok(PersonaTemplateKind::HybridClassifyThenAct),
+        "frontier-judgment-loop" => Ok(PersonaTemplateKind::FrontierJudgmentLoop),
+        _ => Err(format!("unknown persona template {value:?}")),
+    }
+}
+
+fn to_title(name: &str) -> String {
+    name.split('_')
+        .filter(|part| !part.is_empty())
+        .map(|part| {
+            let mut chars = part.chars();
+            match chars.next() {
+                Some(first) => format!("{}{}", first.to_ascii_uppercase(), chars.as_str()),
+                None => String::new(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn to_package_slug(name: &str) -> String {
+    name.replace('_', "-")
+}
+
+struct TemplateVars {
+    persona_name: String,
+    persona_ident: String,
+    persona_title: String,
+    package_slug: String,
+    template_kind: &'static str,
+    tools: &'static str,
+    tools_symbols: &'static str,
+    capabilities: &'static str,
+    autonomy_tier: &'static str,
+    triggers: &'static str,
+    budget: &'static str,
+    model_policy: &'static str,
+    persona_body: &'static str,
+    steps: &'static str,
+    llm_mocks: &'static str,
+    smoke_assertions: &'static str,
+}
+
+impl TemplateVars {
+    fn new(name: &str, kind: PersonaTemplateKind) -> Self {
+        let shape = TemplateShape::for_kind(kind);
+        Self {
+            persona_name: name.to_string(),
+            persona_ident: name.to_string(),
+            persona_title: to_title(name),
+            package_slug: to_package_slug(name),
+            template_kind: kind.as_str(),
+            tools: shape.tools,
+            tools_symbols: shape.tools_symbols,
+            capabilities: shape.capabilities,
+            autonomy_tier: shape.autonomy_tier,
+            triggers: shape.triggers,
+            budget: shape.budget,
+            model_policy: shape.model_policy,
+            persona_body: shape.persona_body,
+            steps: shape.steps,
+            llm_mocks: shape.llm_mocks,
+            smoke_assertions: shape.smoke_assertions,
+        }
+    }
+}
+
+struct TemplateShape {
+    tools: &'static str,
+    tools_symbols: &'static str,
+    capabilities: &'static str,
+    autonomy_tier: &'static str,
+    triggers: &'static str,
+    budget: &'static str,
+    model_policy: &'static str,
+    persona_body: &'static str,
+    steps: &'static str,
+    llm_mocks: &'static str,
+    smoke_assertions: &'static str,
+}
+
+impl TemplateShape {
+    fn for_kind(kind: PersonaTemplateKind) -> Self {
+        match kind {
+            PersonaTemplateKind::DeterministicSweeper => Self {
+                tools: r#"["github"]"#,
+                tools_symbols: "[github]",
+                capabilities: r#"["project.test_commands", "runtime.record_run"]"#,
+                autonomy_tier: "act_with_approval",
+                triggers: r#"["github.pr_opened"]"#,
+                budget: "{ daily_usd = 2.0, run_usd = 0.05, max_tokens = 10000, max_runtime_seconds = 120 }",
+                model_policy: r#"{ default_model = "mock", escalation_model = "mock", fallback_models = ["mock"], reasoning_effort = "low" }"#,
+                persona_body: "  return drain_queue(task)",
+                steps: DETERMINISTIC_STEPS,
+                llm_mocks: "",
+                smoke_assertions: "  assert_eq(result.status, \"completed\")\n  assert_eq(len(result.state.processed), 2)",
+            },
+            PersonaTemplateKind::HybridClassifyThenAct => Self {
+                tools: r#"["github", "mcp"]"#,
+                tools_symbols: "[github, mcp]",
+                capabilities: r#"["project.scan", "runtime.record_run"]"#,
+                autonomy_tier: "act_with_approval",
+                triggers: r#"["github.issue_opened"]"#,
+                budget: "{ daily_usd = 3.0, run_usd = 0.10, frontier_escalations = 1, max_tokens = 16000, max_runtime_seconds = 180 }",
+                model_policy: r#"{ default_model = "mock", escalation_model = "mock", fallback_models = ["mock"], reasoning_effort = "medium" }"#,
+                persona_body: "  let classified = classify_request(task)\n  return act_on_classification(classified)",
+                steps: HYBRID_STEPS,
+                llm_mocks: "",
+                smoke_assertions: "  assert_eq(result.status, \"success\")\n  assert_eq(result.result.action, \"draft_plan\")",
+            },
+            PersonaTemplateKind::FrontierJudgmentLoop => Self {
+                tools: r#"["github", "mcp"]"#,
+                tools_symbols: "[github, mcp]",
+                capabilities: r#"["project.scan", "runtime.record_run", "interaction.ask"]"#,
+                autonomy_tier: "suggest",
+                triggers: r#"["manual.review_requested"]"#,
+                budget: "{ daily_usd = 5.0, run_usd = 0.25, frontier_escalations = 2, max_tokens = 24000, max_runtime_seconds = 300 }",
+                model_policy: r#"{ default_model = "mock", escalation_model = "mock", fallback_models = ["mock"], reasoning_effort = "medium" }"#,
+                persona_body: "  return judge_until_confident(task)",
+                steps: FRONTIER_STEPS,
+                llm_mocks: "  llm_mock({text: \"{\\\"decision\\\": \\\"ship\\\", \\\"confidence\\\": 0.92, \\\"rationale\\\": \\\"fixture is low risk\\\"}\"})",
+                smoke_assertions: "  assert_eq(result.status, \"completed\")\n  assert_eq(result.state.decision, \"ship\")",
+            },
+        }
+    }
+}
+
+const DETERMINISTIC_STEPS: &str = r#"@step(name: "drain_queue", receipt: audit, error_boundary: fail, budget: {max_tokens: 1000})
+fn drain_queue(task) {
+  let fixture = task?.fixture ?? {items: []}
+  let prompt = render_prompt("../prompts/system.harn.prompt", {
+    persona_name: "{{persona_name}}",
+    template_kind: "{{template_kind}}",
+    request: fixture?.request ?? "drain queued work",
+  },)
+  return bounded_loop(
+    {remaining: fixture.items, processed: []},
+    fn(state) {
+      if len(state.remaining) == 0 {
+        return {state: state, progress: false, done: true}
+      }
+      let item = state.remaining[0]
+      let rest = state.remaining[1:]
+      return {
+        state: {remaining: rest, processed: state.processed + [item]},
+        progress: true,
+        done: len(rest) == 0,
+      }
+    },
+    {
+      persona: "{{persona_name}}",
+      step: "drain_queue",
+      started_at: task?.started_at,
+      completed_at: task?.completed_at,
+      max_iterations: 20,
+      progress_required: true,
+      metadata: {prompt_digest: sha256(prompt)},
+    },
+  )
+}"#;
+
+const HYBRID_STEPS: &str = r#"@step(name: "classify_request", model: "mock", receipt: audit, error_boundary: escalate, budget: {max_tokens: 2000})
+fn classify_request(task) {
+  let fixture = task?.fixture ?? {}
+  let prompt = render_prompt("../prompts/system.harn.prompt", {
+    persona_name: "{{persona_name}}",
+    template_kind: "{{template_kind}}",
+    request: fixture?.request ?? "classify requested work",
+  },)
+  return cheap_classify_then_escalate(
+    fixture,
+    fn(input) { return {label: "needs_plan", confidence: 0.62, item_count: len(input?.items ?? [])} },
+    fn(input) { return {label: "draft_plan", confidence: 0.91, item_count: len(input?.items ?? [])} },
+    fn(result) { return result.confidence < 0.7 || result.label == "needs_plan" },
+    {
+      persona: "{{persona_name}}",
+      step: "classify_request",
+      started_at: task?.started_at,
+      completed_at: task?.completed_at,
+      min_confidence: 0.7,
+      metadata: {prompt_digest: sha256(prompt)},
+    },
+  )
+}
+
+@step(name: "act_on_classification", receipt: audit, error_boundary: fail, budget: {max_tokens: 1000})
+fn act_on_classification(classified) {
+  let wrapped = with_audit_receipt(
+    fn() {
+      return {
+        action: classified.result.label,
+        escalated: classified.escalated,
+        confidence: classified.result.confidence,
+      }
+    },
+    {persona: "{{persona_name}}", step: "act_on_classification"},
+  )
+  return wrapped()
+}"#;
+
+const FRONTIER_STEPS: &str = r#"@step(name: "judge_until_confident", model: "mock", receipt: audit, error_boundary: escalate, retry: {max_attempts: 2}, budget: {max_tokens: 4000})
+fn judge_until_confident(task) {
+  let fixture = task?.fixture ?? {}
+  let schema = {
+    type: "object",
+    required: ["decision", "confidence", "rationale"],
+    properties: {
+      decision: {type: "string"},
+      confidence: {type: "number"},
+      rationale: {type: "string"},
+    },
+  }
+  return bounded_loop(
+    {decision: nil, confidence: 0.0, attempts: 0},
+    fn(state) {
+      let prompt = render_prompt("../prompts/system.harn.prompt", {
+        persona_name: "{{persona_name}}",
+        template_kind: "{{template_kind}}",
+        request: fixture?.request ?? "review",
+      },)
+      let result = llm_call_structured_safe(prompt, schema, {
+        provider: "mock",
+        model: "mock",
+        retries: 0,
+      })
+      if !result.ok {
+        return {
+          state: state + {attempts: state.attempts + 1, error: result.error},
+          progress: true,
+          done: state.attempts + 1 >= 2,
+        }
+      }
+      return {
+        state: result.data + {attempts: state.attempts + 1},
+        progress: true,
+        done: result.data.confidence >= 0.8,
+      }
+    },
+    {
+      persona: "{{persona_name}}",
+      step: "judge_until_confident",
+      started_at: task?.started_at,
+      completed_at: task?.completed_at,
+      max_iterations: 2,
+      progress_required: true,
+    },
+  )
+}"#;
+
+fn render(template: &str, vars: &TemplateVars) -> String {
+    template
+        .replace("{{persona_body}}", vars.persona_body)
+        .replace("{{steps}}", vars.steps)
+        .replace("{{llm_mocks}}", vars.llm_mocks)
+        .replace("{{smoke_assertions}}", vars.smoke_assertions)
+        .replace("{{persona_name}}", &vars.persona_name)
+        .replace("{{persona_ident}}", &vars.persona_ident)
+        .replace("{{persona_title}}", &vars.persona_title)
+        .replace("{{package_slug}}", &vars.package_slug)
+        .replace("{{template_kind}}", vars.template_kind)
+        .replace("{{tools}}", vars.tools)
+        .replace("{{tools_symbols}}", vars.tools_symbols)
+        .replace("{{capabilities}}", vars.capabilities)
+        .replace("{{autonomy_tier}}", vars.autonomy_tier)
+        .replace("{{triggers}}", vars.triggers)
+        .replace("{{budget}}", vars.budget)
+        .replace("{{model_policy}}", vars.model_policy)
+}
+
+#[allow(dead_code)]
+pub(crate) fn template_dir_for_docs(kind: PersonaTemplateKind) -> PathBuf {
+    Path::new("personas").join("_templates").join(kind.as_str())
+}

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -774,6 +774,20 @@ async fn async_main() {
             }
         },
         Command::Persona(args) => match args.command {
+            PersonaCommand::New(new) => {
+                if let Err(error) = commands::persona_scaffold::run_new(&new) {
+                    eprintln!("error: {error}");
+                    process::exit(1);
+                }
+            }
+            PersonaCommand::Doctor(doctor) => {
+                if let Err(error) =
+                    commands::persona_doctor::run_doctor(args.manifest.as_deref(), &doctor).await
+                {
+                    eprintln!("error: {error}");
+                    process::exit(1);
+                }
+            }
             PersonaCommand::Check(check) => {
                 commands::persona::run_check(args.manifest.as_deref(), &check)
             }

--- a/crates/harn-cli/tests/persona_cli.rs
+++ b/crates/harn-cli/tests/persona_cli.rs
@@ -10,7 +10,7 @@
 use std::fs;
 use std::path::Path;
 
-use harn_cli::commands::persona;
+use harn_cli::commands::{persona, persona_doctor, persona_scaffold};
 use tempfile::TempDir;
 
 fn write_manifest(body: &str) -> TempDir {
@@ -258,6 +258,58 @@ fn persona_manifest_flag_loads_fixer_persona() {
     assert_eq!(persona["triggers"][0], "invariant.blocked_with_remediation");
     assert_eq!(persona["entry_workflow"], "manifest.harn#run");
     assert_eq!(persona["receipt_policy"], "required");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn persona_scaffolder_creates_doctor_clean_package() {
+    for template in [
+        "deterministic-sweeper",
+        "hybrid-classify-then-act",
+        "frontier-judgment-loop",
+    ] {
+        let temp = TempDir::new().unwrap();
+        let result = persona_scaffold::scaffold_persona_package(
+            "my_release_captain",
+            template,
+            &temp.path().join("personas"),
+            false,
+        )
+        .expect("scaffold persona");
+        assert!(result.root.join("harn.toml").exists());
+        assert!(result.root.join("src/my_release_captain.harn").exists());
+        assert!(result
+            .root
+            .join("tests/my_release_captain_smoke.harn")
+            .exists());
+        assert!(result
+            .root
+            .join("tests/my_release_captain_smoke.expected")
+            .exists());
+        assert!(result.root.join("fixtures/happy_path.json").exists());
+        assert!(result.root.join("prompts/system.harn.prompt").exists());
+        assert!(result.root.join("evals/smoke.eval.json").exists());
+
+        let manifest = result.root.join("harn.toml");
+        let persona =
+            persona::inspect_payload(Some(&manifest), "my_release_captain").expect("inspect");
+        assert_eq!(persona["name"], "my_release_captain");
+        assert!(!persona["steps"].as_array().unwrap().is_empty());
+
+        let report = persona_doctor::doctor_report_for_persona(
+            Some(&manifest),
+            "my_release_captain",
+            10_000,
+        )
+        .await
+        .expect("doctor report");
+        assert!(
+            report
+                .checks
+                .iter()
+                .all(|check| check.status != persona_doctor::DoctorStatus::Red),
+            "unexpected red check in {template:?}: {report:#?}"
+        );
+    }
 }
 
 #[test]

--- a/personas/_templates/README.md
+++ b/personas/_templates/README.md
@@ -1,0 +1,12 @@
+# Persona Templates
+
+These packages mirror the built-in `harn persona new --template <kind>` layouts.
+They are intentionally Harn-first: each template centers an `@persona` function,
+typed `@step` metadata, prompt assets, a fixture pair, and a smoke test.
+
+The CLI applies the same placeholder vocabulary when scaffolding:
+
+- `{{persona_name}}`
+- `{{persona_ident}}`
+- `{{persona_title}}`
+- `{{template_kind}}`

--- a/personas/_templates/deterministic-sweeper/evals/smoke.eval.json
+++ b/personas/_templates/deterministic-sweeper/evals/smoke.eval.json
@@ -1,0 +1,9 @@
+{
+  "_type": "eval_pack_manifest",
+  "id": "template-persona-smoke",
+  "persona": "template_persona",
+  "fixtures": ["fixtures/happy_path.json"],
+  "metrics": [
+    {"name": "smoke_passed", "kind": "boolean"}
+  ]
+}

--- a/personas/_templates/deterministic-sweeper/fixtures/happy_path.json
+++ b/personas/_templates/deterministic-sweeper/fixtures/happy_path.json
@@ -1,0 +1,7 @@
+{
+  "items": [
+    {"id": "demo-1", "title": "First scaffolded work item", "risk": "low"},
+    {"id": "demo-2", "title": "Second scaffolded work item", "risk": "medium"}
+  ],
+  "request": "Decide the next safe action for this persona package."
+}

--- a/personas/_templates/deterministic-sweeper/harn.toml
+++ b/personas/_templates/deterministic-sweeper/harn.toml
@@ -1,0 +1,17 @@
+[package]
+name = "harn-persona-template-deterministic-sweeper"
+version = "0.1.0"
+description = "Template package for deterministic sweeper personas."
+
+[[personas]]
+name = "template_persona"
+version = "0.1.0"
+description = "Deterministic sweeper template persona."
+entry_workflow = "src/template_persona.harn#run"
+tools = ["github"]
+capabilities = ["project.test_commands", "runtime.record_run"]
+autonomy_tier = "act_with_approval"
+receipt_policy = "required"
+triggers = ["github.pr_opened"]
+budget = { daily_usd = 2.0, run_usd = 0.05, max_tokens = 10000, max_runtime_seconds = 120 }
+model_policy = { default_model = "mock", escalation_model = "mock", fallback_models = ["mock"], reasoning_effort = "low" }

--- a/personas/_templates/deterministic-sweeper/prompts/system.harn.prompt
+++ b/personas/_templates/deterministic-sweeper/prompts/system.harn.prompt
@@ -1,0 +1,3 @@
+You are {{persona_name}}, a deterministic Harn sweeper persona.
+
+Process each queued item once, emit receipts, and stop when no work remains.

--- a/personas/_templates/deterministic-sweeper/src/template_persona.harn
+++ b/personas/_templates/deterministic-sweeper/src/template_persona.harn
@@ -1,0 +1,45 @@
+import { bounded_loop } from "std/personas/prelude"
+
+@persona(name: "template_persona", description: "Deterministic sweeper template persona.", tools: [github], capabilities: ["project.test_commands", "runtime.record_run"], autonomy: "act_with_approval", receipts: "required")
+/** Run the deterministic sweeper template DAG. */
+pub fn template_persona(task) {
+  return drain_queue(task)
+}
+
+@step(name: "drain_queue", receipt: audit, error_boundary: fail, budget: {max_tokens: 1000})
+fn drain_queue(task) {
+  let fixture = task?.fixture ?? {items: []}
+  let prompt = render_prompt(
+    "../prompts/system.harn.prompt",
+    {
+      persona_name: "template_persona",
+      template_kind: "deterministic-sweeper",
+      request: fixture?.request ?? "drain queued work",
+    },
+  )
+  return bounded_loop(
+    {remaining: fixture.items, processed: []},
+    fn(state) {
+      if len(state.remaining) == 0 {
+        return {state: state, progress: false, done: true}
+      }
+      let rest = state.remaining[1:]
+      return {
+        state: {remaining: rest, processed: state.processed + [state.remaining[0]]},
+        progress: true,
+        done: len(rest) == 0,
+      }
+    },
+    {
+      persona: "template_persona",
+      step: "drain_queue",
+      max_iterations: 20,
+      progress_required: true,
+      metadata: {prompt_digest: sha256(prompt)},
+    },
+  )
+}
+
+pipeline run(task) {
+  return template_persona(task)
+}

--- a/personas/_templates/deterministic-sweeper/tests/template_persona_smoke.expected
+++ b/personas/_templates/deterministic-sweeper/tests/template_persona_smoke.expected
@@ -1,0 +1,2 @@
+true
+harn.receipt.v1

--- a/personas/_templates/deterministic-sweeper/tests/template_persona_smoke.harn
+++ b/personas/_templates/deterministic-sweeper/tests/template_persona_smoke.harn
@@ -1,0 +1,11 @@
+import { template_persona } from "../src/template_persona"
+
+pipeline test_template_persona_smoke(task) {
+  let fixture = json_parse(read_file("../fixtures/happy_path.json"))
+  let result = template_persona({fixture: fixture})
+  assert_eq(result.status, "completed")
+  assert_eq(len(result.state.processed), 2)
+  assert_eq(result.receipt.schema, "harn.receipt.v1")
+  println(true)
+  println(result.receipt.schema)
+}

--- a/personas/_templates/frontier-judgment-loop/evals/smoke.eval.json
+++ b/personas/_templates/frontier-judgment-loop/evals/smoke.eval.json
@@ -1,0 +1,9 @@
+{
+  "_type": "eval_pack_manifest",
+  "id": "template-persona-smoke",
+  "persona": "template_persona",
+  "fixtures": ["fixtures/happy_path.json"],
+  "metrics": [
+    {"name": "smoke_passed", "kind": "boolean"}
+  ]
+}

--- a/personas/_templates/frontier-judgment-loop/fixtures/happy_path.json
+++ b/personas/_templates/frontier-judgment-loop/fixtures/happy_path.json
@@ -1,0 +1,7 @@
+{
+  "items": [
+    {"id": "demo-1", "title": "First scaffolded work item", "risk": "low"},
+    {"id": "demo-2", "title": "Second scaffolded work item", "risk": "medium"}
+  ],
+  "request": "Decide the next safe action for this persona package."
+}

--- a/personas/_templates/frontier-judgment-loop/harn.toml
+++ b/personas/_templates/frontier-judgment-loop/harn.toml
@@ -1,0 +1,17 @@
+[package]
+name = "harn-persona-template-frontier-judgment-loop"
+version = "0.1.0"
+description = "Template package for bounded frontier-judgment personas."
+
+[[personas]]
+name = "template_persona"
+version = "0.1.0"
+description = "Frontier judgment loop template persona."
+entry_workflow = "src/template_persona.harn#run"
+tools = ["github", "mcp"]
+capabilities = ["project.scan", "runtime.record_run", "interaction.ask"]
+autonomy_tier = "suggest"
+receipt_policy = "required"
+triggers = ["manual.review_requested"]
+budget = { daily_usd = 5.0, run_usd = 0.25, frontier_escalations = 2, max_tokens = 24000, max_runtime_seconds = 300 }
+model_policy = { default_model = "mock", escalation_model = "mock", fallback_models = ["mock"], reasoning_effort = "medium" }

--- a/personas/_templates/frontier-judgment-loop/prompts/system.harn.prompt
+++ b/personas/_templates/frontier-judgment-loop/prompts/system.harn.prompt
@@ -1,0 +1,6 @@
+You are {{persona_name}}, a Harn persona.
+
+Use the fixture request and typed step metadata to produce a bounded, auditable decision.
+
+Template: {{template_kind}}
+Request: {{request}}

--- a/personas/_templates/frontier-judgment-loop/src/template_persona.harn
+++ b/personas/_templates/frontier-judgment-loop/src/template_persona.harn
@@ -1,0 +1,46 @@
+import { bounded_loop } from "std/personas/prelude"
+
+@persona(name: "template_persona", description: "Frontier judgment loop template persona.", tools: [github, mcp], capabilities: ["project.scan", "runtime.record_run", "interaction.ask"], autonomy: "suggest", receipts: "required")
+/** Run the frontier judgment loop template DAG. */
+pub fn template_persona(task) {
+  return judge_until_confident(task)
+}
+
+@step(name: "judge_until_confident", model: "mock", receipt: audit, error_boundary: escalate, retry: {max_attempts: 2}, budget: {max_tokens: 4000})
+fn judge_until_confident(task) {
+  let fixture = task?.fixture ?? {}
+  let schema = {
+    type: "object",
+    required: ["decision", "confidence", "rationale"],
+    properties: {decision: {type: "string"}, confidence: {type: "number"}, rationale: {type: "string"}},
+  }
+  return bounded_loop(
+    {decision: nil, confidence: 0.0, attempts: 0},
+    fn(state) {
+      let prompt = render_prompt(
+        "../prompts/system.harn.prompt",
+        {
+          persona_name: "template_persona",
+          template_kind: "frontier-judgment-loop",
+          request: fixture?.request ?? "review",
+        },
+      )
+      let result = llm_call_structured_safe(prompt, schema, {provider: "mock", model: "mock", retries: 0})
+      return {
+        state: result.data + {attempts: state.attempts + 1},
+        progress: result.ok,
+        done: result.ok && result.data.confidence >= 0.8,
+      }
+    },
+    {
+      persona: "template_persona",
+      step: "judge_until_confident",
+      max_iterations: 2,
+      progress_required: true,
+    },
+  )
+}
+
+pipeline run(task) {
+  return template_persona(task)
+}

--- a/personas/_templates/frontier-judgment-loop/tests/template_persona_smoke.expected
+++ b/personas/_templates/frontier-judgment-loop/tests/template_persona_smoke.expected
@@ -1,0 +1,2 @@
+true
+harn.receipt.v1

--- a/personas/_templates/frontier-judgment-loop/tests/template_persona_smoke.harn
+++ b/personas/_templates/frontier-judgment-loop/tests/template_persona_smoke.harn
@@ -1,0 +1,15 @@
+import { template_persona } from "../src/template_persona"
+
+pipeline test_template_persona_smoke(task) {
+  llm_mock_clear()
+  llm_mock(
+    {text: "{\"decision\": \"ship\", \"confidence\": 0.92, \"rationale\": \"fixture is low risk\"}"},
+  )
+  let fixture = json_parse(read_file("../fixtures/happy_path.json"))
+  let result = template_persona({fixture: fixture})
+  assert_eq(result.status, "completed")
+  assert_eq(result.state.decision, "ship")
+  assert_eq(result.receipt.schema, "harn.receipt.v1")
+  println(true)
+  println(result.receipt.schema)
+}

--- a/personas/_templates/hybrid-classify-then-act/evals/smoke.eval.json
+++ b/personas/_templates/hybrid-classify-then-act/evals/smoke.eval.json
@@ -1,0 +1,9 @@
+{
+  "_type": "eval_pack_manifest",
+  "id": "template-persona-smoke",
+  "persona": "template_persona",
+  "fixtures": ["fixtures/happy_path.json"],
+  "metrics": [
+    {"name": "smoke_passed", "kind": "boolean"}
+  ]
+}

--- a/personas/_templates/hybrid-classify-then-act/fixtures/happy_path.json
+++ b/personas/_templates/hybrid-classify-then-act/fixtures/happy_path.json
@@ -1,0 +1,7 @@
+{
+  "items": [
+    {"id": "demo-1", "title": "First scaffolded work item", "risk": "low"},
+    {"id": "demo-2", "title": "Second scaffolded work item", "risk": "medium"}
+  ],
+  "request": "Decide the next safe action for this persona package."
+}

--- a/personas/_templates/hybrid-classify-then-act/harn.toml
+++ b/personas/_templates/hybrid-classify-then-act/harn.toml
@@ -1,0 +1,17 @@
+[package]
+name = "harn-persona-template-hybrid-classify-then-act"
+version = "0.1.0"
+description = "Template package for cheap classify, escalation, then action personas."
+
+[[personas]]
+name = "template_persona"
+version = "0.1.0"
+description = "Hybrid classify-then-act template persona."
+entry_workflow = "src/template_persona.harn#run"
+tools = ["github", "mcp"]
+capabilities = ["project.scan", "runtime.record_run"]
+autonomy_tier = "act_with_approval"
+receipt_policy = "required"
+triggers = ["github.issue_opened"]
+budget = { daily_usd = 3.0, run_usd = 0.10, frontier_escalations = 1, max_tokens = 16000, max_runtime_seconds = 180 }
+model_policy = { default_model = "mock", escalation_model = "mock", fallback_models = ["mock"], reasoning_effort = "medium" }

--- a/personas/_templates/hybrid-classify-then-act/prompts/system.harn.prompt
+++ b/personas/_templates/hybrid-classify-then-act/prompts/system.harn.prompt
@@ -1,0 +1,3 @@
+You are {{persona_name}}, a Harn classify-then-act persona.
+
+Classify cheaply first, escalate low-confidence cases, and emit an auditable action receipt.

--- a/personas/_templates/hybrid-classify-then-act/src/template_persona.harn
+++ b/personas/_templates/hybrid-classify-then-act/src/template_persona.harn
@@ -1,0 +1,50 @@
+import { cheap_classify_then_escalate, with_audit_receipt } from "std/personas/prelude"
+
+@persona(name: "template_persona", description: "Hybrid classify-then-act template persona.", tools: [github, mcp], capabilities: ["project.scan", "runtime.record_run"], autonomy: "act_with_approval", receipts: "required")
+/** Run the hybrid classify-then-act template DAG. */
+pub fn template_persona(task) {
+  let classified = classify_request(task)
+  return act_on_classification(classified)
+}
+
+@step(name: "classify_request", model: "mock", receipt: audit, error_boundary: escalate, budget: {max_tokens: 2000})
+fn classify_request(task) {
+  let fixture = task?.fixture ?? {}
+  let prompt = render_prompt(
+    "../prompts/system.harn.prompt",
+    {
+      persona_name: "template_persona",
+      template_kind: "hybrid-classify-then-act",
+      request: fixture?.request ?? "classify requested work",
+    },
+  )
+  return cheap_classify_then_escalate(
+    fixture,
+    fn(input) { return {label: "needs_plan", confidence: 0.62, item_count: len(input?.items ?? [])} },
+    fn(input) { return {label: "draft_plan", confidence: 0.91, item_count: len(input?.items ?? [])} },
+    fn(result) { return result.confidence < 0.7 || result.label == "needs_plan" },
+    {
+      persona: "template_persona",
+      step: "classify_request",
+      min_confidence: 0.7,
+      metadata: {prompt_digest: sha256(prompt)},
+    },
+  )
+}
+
+@step(name: "act_on_classification", receipt: audit, error_boundary: fail, budget: {max_tokens: 1000})
+fn act_on_classification(classified) {
+  let wrapped = with_audit_receipt(
+    fn() { return {
+      action: classified.result.label,
+      escalated: classified.escalated,
+      confidence: classified.result.confidence,
+    } },
+    {persona: "template_persona", step: "act_on_classification"},
+  )
+  return wrapped()
+}
+
+pipeline run(task) {
+  return template_persona(task)
+}

--- a/personas/_templates/hybrid-classify-then-act/tests/template_persona_smoke.expected
+++ b/personas/_templates/hybrid-classify-then-act/tests/template_persona_smoke.expected
@@ -1,0 +1,2 @@
+true
+harn.receipt.v1

--- a/personas/_templates/hybrid-classify-then-act/tests/template_persona_smoke.harn
+++ b/personas/_templates/hybrid-classify-then-act/tests/template_persona_smoke.harn
@@ -1,0 +1,11 @@
+import { template_persona } from "../src/template_persona"
+
+pipeline test_template_persona_smoke(task) {
+  let fixture = json_parse(read_file("../fixtures/happy_path.json"))
+  let result = template_persona({fixture: fixture})
+  assert_eq(result.status, "success")
+  assert_eq(result.result.action, "draft_plan")
+  assert_eq(result.receipt.schema, "harn.receipt.v1")
+  println(true)
+  println(result.receipt.schema)
+}


### PR DESCRIPTION
## Summary
- add `harn persona new <name> --template <kind>` for deterministic, hybrid, and frontier persona scaffolds
- add `harn persona doctor <name>` with manifest, source, lint, prompt asset, step metadata, budget, and smoke-test checks
- add checked-in template packages plus conformance coverage for the CLI scaffolder steel thread

Closes #1079

## Verification
- `cargo test -p harn-cli --test persona_cli`
- `cargo run -p harn-cli --bin harn -- test conformance --filter cli/persona_scaffolder --timeout 20000`
- `cargo check -p harn-cli`
- `cargo clippy -p harn-cli --all-targets -- -D warnings`
- template `harn persona doctor ... --json` for all three checked-in templates
- pre-commit hook
- pre-push hook