### PR TITLE
Release v0.7.58

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,57 +6,87 @@ Pre-0.6 highlights live in [CHANGELOG-pre-0.6.md](CHANGELOG-pre-0.6.md).
 Harn had no external users before 0.6.0, so that archive intentionally keeps
 condensed series summaries instead of full per-patch history.
 
-## Unreleased
+## v0.7.58
 
 ### Added
 
-- **Persona-aware crystallization proposals (#1080).** `std/personas/prelude`
-  now includes `persona_crystallization_candidates(...)` and
+- **Persona-aware crystallization proposals.** `std/personas/prelude` now
+  includes `persona_crystallization_candidates(...)` and
   `persona_crystallization_bundle(...)` for mining successful repair-worker
   receipts after the hosted-history gate. The helper emits the existing
   `harn.crystallization.candidate.bundle` shape with matched traces, shadow
   comparison, savings estimates, and a literal Harn `@step` patch for persona
   package review.
-- **Skill provenance endorsement chains (#933).** Skill signatures now use
+- **Skill provenance endorsement chains.** Skill signatures now use
   `harn-skill-sig/v2` with an author signature plus one or more trusted
   endorsement signatures. Added `harn skill endorse`, `harn skill who-signed`,
-  Harn-visible `skill_who_signed(...)` registry queries, and transcript metadata
-  that exposes signer trust-policy inputs for `trust.query`.
-- **Merge Captain cheap-model prompt pack (#1016).** Added a Harn-native
-  value-model prompt pack with narrow prompts for PR classification,
-  deterministic action choice, CI diagnosis, repair summaries, approval
-  decisions, and release changelog audit/rewrite. The pack ships strict JSON
-  schemas, golden examples, compact context budgets that exclude raw logs
-  unless selected spans are provided, and revision gates for transcript-oracle
-  diffs plus timeout-ladder results.
+  Harn-visible `skill_who_signed(...)` registry queries, and transcript
+  metadata that exposes signer trust-policy inputs for `trust.query`.
+- **Merge Captain cheap-model prompt pack.** Added a Harn-native value-model
+  prompt pack with narrow prompts for PR classification, deterministic action
+  choice, CI diagnosis, repair summaries, approval decisions, and release
+  changelog audit/rewrite. The pack ships strict JSON schemas, golden examples,
+  compact context budgets that exclude raw logs unless selected spans are
+  provided, and revision gates for transcript-oracle diffs plus
+  timeout-ladder results.
 - **ACP authentication flow.** `harn serve acp` now advertises configured
   `authMethods`, implements ACP `authenticate`, and returns `auth_required`
   before protected session methods until the connection authenticates.
-- **A2A canonical HTTP+JSON/REST binding.** The A2A server now exposes the spec-blessed
-  REST surface under `/v1` (`POST /v1/message:send`, `POST /v1/message:stream`,
-  `GET /v1/tasks/{id}`, `POST /v1/tasks/{id}:cancel`, `POST /v1/tasks/{id}:subscribe`,
-  push-notification-config CRUD under `/v1/tasks/{id}/pushNotificationConfigs`, and
-  `GET /v1/card`). The agent card advertises both `JSONRPC` and `HTTP+JSON` transports
-  in `additionalInterfaces`. The previous non-canonical paths (`/message/send`,
-  `/message/stream`, `/tasks/send`, `/tasks/send_and_wait`, `/tasks/cancel`,
-  `/tasks/resubscribe`) keep working for one minor cycle and now emit a `Deprecation`
-  header pointing at the canonical replacement.
-- **MCP logging notifications.** `harn mcp serve` now forwards Harn's structured audit
-  and observability event-log streams (signature-verify, secret-scan, egress, trigger
-  operations, DLQ, action graph) as MCP `notifications/message` per the
-  [MCP logging spec](https://modelcontextprotocol.io/specification/2025-11-25/server/utilities/logging).
-  `logging/setLevel` is now honored per session and filters notifications by severity;
-  events can override the assigned level via a `severity` header.
-- **MCP `notifications/progress` from long-running tools.** Tool handlers
-  can call the new `mcp_report_progress(progress, opts?)` builtin to
-  emit `notifications/progress` updates for the in-flight call. The
-  builtin no-ops when the client did not opt in via
-  `_meta.progressToken`, so scripts can sprinkle it without preflight
-  checks. Both stdio and HTTP MCP transports thread the token through
-  to script-defined tools (`mcp_tools`) and exported-function tools
-  (`harn serve mcp <script>`). The orchestrator-mode
-  `harn.trigger.fire` tool also emits its own milestones (loading
-  runtime, preparing event, firing trigger, complete). Closes #885.
+- **A2A canonical HTTP+JSON/REST binding.** The A2A server now exposes the
+  spec-blessed REST surface under `/v1` (`POST /v1/message:send`, `POST
+  /v1/message:stream`, `GET /v1/tasks/{id}`, `POST /v1/tasks/{id}:cancel`,
+  `POST /v1/tasks/{id}:subscribe`, push-notification-config CRUD under
+  `/v1/tasks/{id}/pushNotificationConfigs`, and `GET /v1/card`). The agent card
+  advertises both `JSONRPC` and `HTTP+JSON` transports in `additionalInterfaces`.
+  The previous non-canonical paths (`/message/send`, `/message/stream`,
+  `/tasks/send`, `/tasks/send_and_wait`, `/tasks/cancel`,
+  `/tasks/resubscribe`) keep working for one minor cycle and now emit a
+  `Deprecation` header pointing at the canonical replacement.
+- **MCP logging notifications.** `harn mcp serve` now forwards Harn's structured
+  audit and observability event-log streams (signature-verify, secret-scan,
+  egress, trigger operations, DLQ, action graph) as MCP `notifications/message`
+  per the MCP logging spec. `logging/setLevel` is now honored per session and
+  filters notifications by severity; events can override the assigned level via
+  a `severity` header.
+- **MCP `notifications/progress` from long-running tools.** Tool handlers can
+  call the new `mcp_report_progress(progress, opts?)` builtin to emit
+  `notifications/progress` updates for the in-flight call. The builtin no-ops
+  when the client did not opt in via `_meta.progressToken`, so scripts can
+  sprinkle it without preflight checks. Both stdio and HTTP MCP transports
+  thread the token through to script-defined tools (`mcp_tools`) and
+  exported-function tools (`harn serve mcp SCRIPT`). The orchestrator-mode
+  `harn.trigger.fire` tool also emits its own milestones (loading runtime,
+  preparing event, firing trigger, complete).
+
+### Changed
+
+- **Agent loop orchestration core.** Overhauled the agent orchestration core,
+  moving sub-agent request shaping into Harn stdlib and wire-turn/judge events,
+  tool_format claim, and option validation. The agent loop now honors post-turn
+  options in the stuck guard and exposes Merge Captain persona steps. Client
+  tool search is moved into stdlib, and workflow stage execution primitives are
+  split for better modularity.
+- **Agent prompt overrides.** Tightened agent prompt overrides to ensure
+  consistent behavior across sessions. Updated prompt assets and validation
+  logic in the VM to reflect stricter constraints on tool contracts and native
+  completions.
+- **Persona steel-thread conformance.** Added a conformance harness for persona
+  steel-thread scenarios, including deploy, merge, and release captain tests.
+  This ensures persona lifecycle hooks and autonomy tiers are enforced
+  correctly under VM constraints.
+- **VM and stdlib refactoring.** Moved remaining Rust-owned prompt prose into
+  stdlib assets, deleted legacy Rust agent orchestration modules, and wired
+  per-agent permissions through the Harn agent loop. The parse guidance prose is
+  now in a prompt asset, and workflow stage options are moved into Harn.
+
+### Fixed
+
+- **Ollama tool history replay.** Fixed issues with Ollama tool history replay
+  to ensure accurate state restoration during agent turns.
+- **Native tool history replay.** Fixed native tool history replay to maintain
+  consistency in tool execution traces.
+- **Harn orchestration boundary.** Polished the Harn orchestration boundary to
+  ensure clean separation between the VM and stdlib components.
 
 ## v0.7.57
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1695,7 +1695,7 @@ dependencies = [
 
 [[package]]
 name = "harn-cli"
-version = "0.7.57"
+version = "0.7.58"
 dependencies = [
  "async-trait",
  "axum",
@@ -1748,7 +1748,7 @@ dependencies = [
 
 [[package]]
 name = "harn-dap"
-version = "0.7.57"
+version = "0.7.58"
 dependencies = [
  "harn-modules",
  "harn-parser",
@@ -1761,7 +1761,7 @@ dependencies = [
 
 [[package]]
 name = "harn-fmt"
-version = "0.7.57"
+version = "0.7.58"
 dependencies = [
  "harn-lexer",
  "harn-parser",
@@ -1769,7 +1769,7 @@ dependencies = [
 
 [[package]]
 name = "harn-hostlib"
-version = "0.7.57"
+version = "0.7.58"
 dependencies = [
  "anyhow",
  "base64",
@@ -1820,7 +1820,7 @@ dependencies = [
 
 [[package]]
 name = "harn-ir"
-version = "0.7.57"
+version = "0.7.58"
 dependencies = [
  "harn-lexer",
  "harn-parser",
@@ -1828,11 +1828,11 @@ dependencies = [
 
 [[package]]
 name = "harn-lexer"
-version = "0.7.57"
+version = "0.7.58"
 
 [[package]]
 name = "harn-lint"
-version = "0.7.57"
+version = "0.7.58"
 dependencies = [
  "harn-lexer",
  "harn-modules",
@@ -1842,7 +1842,7 @@ dependencies = [
 
 [[package]]
 name = "harn-lsp"
-version = "0.7.57"
+version = "0.7.58"
 dependencies = [
  "harn-fmt",
  "harn-ir",
@@ -1857,7 +1857,7 @@ dependencies = [
 
 [[package]]
 name = "harn-modules"
-version = "0.7.57"
+version = "0.7.58"
 dependencies = [
  "croner",
  "harn-lexer",
@@ -1870,7 +1870,7 @@ dependencies = [
 
 [[package]]
 name = "harn-parser"
-version = "0.7.57"
+version = "0.7.58"
 dependencies = [
  "harn-lexer",
  "yansi",
@@ -1878,7 +1878,7 @@ dependencies = [
 
 [[package]]
 name = "harn-serve"
-version = "0.7.57"
+version = "0.7.58"
 dependencies = [
  "async-trait",
  "axum",
@@ -1907,11 +1907,11 @@ dependencies = [
 
 [[package]]
 name = "harn-stdlib"
-version = "0.7.57"
+version = "0.7.58"
 
 [[package]]
 name = "harn-vm"
-version = "0.7.57"
+version = "0.7.58"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = ["crates/harn-wasm"]
 resolver = "2"
 
 [workspace.package]
-version = "0.7.57"
+version = "0.7.58"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/burin-labs/harn"


### PR DESCRIPTION
Release v0.7.58

This PR was prepared by `release_harn.harn` from a fresh release snapshot.
The harness generated the release content through `scripts/release_ship.sh --prepare` before the PR handoff.

## Post-prepare summary

- Version: `0.7.57` -> `0.7.58`
- Branch: `release/v0.7.58` targeting `main`
- Latest tag used for release delta: `v0.7.57`
- Changed files: `CHANGELOG.md, Cargo.lock, Cargo.toml`
- Deterministic findings: none

## Changelog section

```markdown
### Added

- **Persona-aware crystallization proposals.** `std/personas/prelude` now
  includes `persona_crystallization_candidates(...)` and
  `persona_crystallization_bundle(...)` for mining successful repair-worker
  receipts after the hosted-history gate. The helper emits the existing
  `harn.crystallization.candidate.bundle` shape with matched traces, shadow
  comparison, savings estimates, and a literal Harn `@step` patch for persona
  package review.
- **Skill provenance endorsement chains.** Skill signatures now use
  `harn-skill-sig/v2` with an author signature plus one or more trusted
  endorsement signatures. Added `harn skill endorse`, `harn skill who-signed`,
  Harn-visible `skill_who_signed(...)` registry queries, and transcript
  metadata that exposes signer trust-policy inputs for `trust.query`.
- **Merge Captain cheap-model prompt pack.** Added a Harn-native value-model
  prompt pack with narrow prompts for PR classification, deterministic action
  choice, CI diagnosis, repair summaries, approval decisions, and release
  changelog audit/rewrite. The pack ships strict JSON schemas, golden examples,
  compact context budgets that exclude raw logs unless selected spans are
  provided, and revision gates for transcript-oracle diffs plus
  timeout-ladder results.
- **ACP authentication flow.** `harn serve acp` now advertises configured
  `authMethods`, implements ACP `authenticate`, and returns `auth_required`
  before protected session methods until the connection authenticates.
- **A2A canonical HTTP+JSON/REST binding.** The A2A server now exposes the
  spec-blessed REST surface under `/v1` (`POST /v1/message:send`, `POST
  /v1/message:stream`, `GET /v1/tasks/{id}`, `POST /v1/tasks/{id}:cancel`,
  `POST /v1/tasks/{id}:subscribe`, push-notification-config CRUD under
  `/v1/tasks/{id}/pushNotificationConfigs`, and `GET /v1/card`). The agent card
  advertises both `JSONRPC` and `HTTP+JSON` transports in `additionalInterfaces`.
  The previous non-canonical paths (`/message/send`, `/message/stream`,
  `/tasks/send`, `/tasks/send_and_wait`, `/tasks/cancel`,
  `/tasks/resubscribe`) keep working for one minor cycle and now emit a
  `Deprecation` header pointing at the canonical replacement.
- **MCP logging notifications.** `harn mcp serve` now forwards Harn's structured
  audit and observability event-log streams (signature-verify, secret-scan,
  egress, trigger operations, DLQ, action graph) as MCP `notifications/message`
  per the MCP logging spec. `logging/setLevel` is now honored per session and
  filters notifications by severity; events can override the assigned level via
  a `severity` header.
- **MCP `notifications/progress` from long-running tools.** Tool handlers can
  call the new `mcp_report_progress(progress, opts?)` builtin to emit
  `notifications/progress` updates for the in-flight call. The builtin no-ops
  when the client did not opt in via `_meta.progressToken`, so scripts can
  sprinkle it without preflight checks. Both stdio and HTTP MCP transports
  thread the token through to script-defined tools (`mcp_tools`) and
  exported-function tools (`harn serve mcp SCRIPT`). The orchestrator-mode
  `harn.trigger.fire` tool also emits its own milestones (loading runtime,
  preparing event, firing trigger, complete).

### Changed

- **Agent loop orchestration core.** Overhauled the agent orchestration core,
  moving sub-agent request shaping into Harn stdlib and wire-turn/judge events,
  tool_format claim, and option validation. The agent loop now honors post-turn
  options in the stuck guard and exposes Merge Captain persona steps. Client
  tool search is moved into stdlib, and workflow stage execution primitives are
  split for better modularity.
- **Agent prompt overrides.** Tightened agent prompt overrides to ensure
  consistent behavior across sessions. Updated prompt assets and validation
  logic in the VM to reflect stricter constraints on tool contracts and native
  completions.
- **Persona steel-thread conformance.** Added a conformance harness for persona
  steel-thread scenarios, including deploy, merge, and release captain tests.
  This ensures persona lifecycle hooks and autonomy tiers are enforced
  correctly under VM constraints.
- **VM and stdlib refactoring.** Moved remaining Rust-owned prompt prose into
  stdlib assets, deleted legacy Rust agent orchestration modules, and wired
  per-agent permissions through the Harn agent loop. The parse guidance prose is
  now in a prompt asset, and workflow stage options are moved into Harn.

### Fixed

- **Ollama tool history replay.** Fixed issues with Ollama tool history replay
  to ensure accurate state restoration during agent turns.
- **Native tool history replay.** Fixed native tool history replay to maintain
  consistency in tool execution traces.
- **Harn orchestration boundary.** Polished the Harn orchestration boundary to
  ensure clean separation between the VM and stdlib components.
```

## Commits covered

```text
23a8855c Tighten agent prompt overrides (#1307)
d80d2a87 Move sub-agent request shaping into Harn stdlib (#1306)
3aa20e7f Add persona steel-thread conformance harness (#1305)
71f3ea85 [codex] Add persona crystallization proposals (#1304)
102b4323 [codex] Keep packaged Harn crates self-contained (#1303)
92b8c232 [codex] overhaul agent orchestration core (#1301)
e44465de [codex] Honor post-turn options in agent stuck guard (#1302)
88900845 Expose Merge Captain persona steps (#1298)
47b60050 [codex] Improve native agent loop tooling (#1299)
24279e8c Implement handoff route runtime (#1297)
84c35f70 Add persona scaffolder and doctor (#1296)
7a21b311 Add VM-enforced graduated autonomy tiers (#1294)
50a3dca1 Add persona lifecycle hooks (#1295)
f6744b1c connector: finish pure-Harn provider cutover (#1291)
8a463131 Add strict typed-output checkpoints (#1293)
65ca8949 [codex] Fix Ollama tool history replay (#1292)
39cc90d3 Add endorsed skill provenance chains (#1290)
a6c5f50d [codex] Add Merge Captain iteration harness (#1289)
fc0ec2ff [codex] Fix native tool history replay (#1288)
a098cc07 [codex] Polish Harn orchestration boundary (#1287)
f56402e6 Move client tool search into stdlib (#1286)
8f195110 [persona] Add cheap-model Merge Captain prompt pack (#1285)
01aa36e5 [agent] Wire turn/judge events, tool_format claim, option validation (#1280)
0f88c074 [acp] Implement authenticate flow (#1283)
82ebeea6 Wire daemon and autonomy budget into agent loop (#1275)
69241126 Split workflow stage execution primitive (#1284)
fd80df7c [acp] Replay session history on load (#1282)
afebc7b7 [codex] Add CI ratchets for prompt prose and xfail count (#1281)
042be6bb [agent] Bootstrap MCP servers from the Harn loop (#1238) (#1279)
cae68904 [agent] Re-enable manifest + scoped command policy hook conformance (#1278)
00f6c49b Implement skill matching primitive (#1277)
ceeb9b5a [workflow] Move map fanout into Harn (#1276)
7472bb3c Align ACP initialize capabilities (#1274)
6296cf05 [harn-cli] Drive admin.rs reload+request waits off events; tighten lint regex (#1248)
0489aecc Replace pump marker files with lifecycle events (#1272)
e7505afe [acp] Preserve multimodal prompt blocks (#1273)
bb738ced Bump rcgen from 0.13.2 to 0.14.7 (#1264)
6dc3937e Bump typescript in /crates/harn-cli/portal (#1260)
1c153361 Emit pump metrics lifecycle events (#1271)
ceb11533 [codex] Replace CLI prewarm polling loop (#1270)
c9368032 [vm] Wire per-agent permissions through Harn agent loop (#1239) (#1269)
ccf3a5b6 [vm] Move remaining Rust-owned prompt prose into stdlib assets (#1199) (#1268)
991e236e [acp] Return canonical stop-reasons from session/prompt (#1249)
78d0dcfe Bump taiki-e/install-action from 2.75.19 to 2.76.0 (#1261)
0676822a Bump tokio from 1.52.1 to 1.52.2 (#1259)
4c113fca Bump jsdom in /crates/harn-cli/portal (#1258)
f7b7e7d4 Bump eslint in /crates/harn-cli/portal (#1257)
4408be94 Bump DavidAnson/markdownlint-cli2-action from 23.0.0 to 23.1.0 (#1262)
2d57cdf8 Bump react-intl in /crates/harn-cli/portal (#1255)
d0406c3d Bump actions/upload-artifact from 5 to 7 (#1252)
aca2beaa Bump @redocly/cli in / (#1253)
4191c0eb Bump rustls from 0.23.38 to 0.23.40 (#1263)
a16e0668 Bump webbrowser from 1.2.0 to 1.2.1 (#1256)
a3bf7c4f Bump criterion from 0.7.0 to 0.8.2 (#1254)
f480dc4d [vm] Delete legacy Rust agent orchestration modules (#1200) (#1251)
8f1566f8 [harn-cli] Drop dead test infra from test_util/timing.rs (#1250)
3ab72201 [a2a] Surface tool/script outputs as Artifact objects (#892) (#1247)
5cae6e2c [harn-cli] Drop 25ms polling from MCP subprocess test helpers (#1246)
91bfdcff [harn-cli] Drive orchestrator_cli waits off lifecycle events (#1245)
1d70de32 [tests] Share fixture repo across harn-hostlib git tests (#1242)
9fa5cbe4 Emit notifications/progress from MCP tool handlers (#1241)
e0e202d2 Move agent loop orchestration into Harn (epic #1197) (#1234)
ff3a5558 [mcp] Emit notifications/message for harn audit/log stream (#1233)
c2ea2633 [a2a] Implement canonical HTTP+JSON/REST transport binding (#1232)
26ae0d87 [codex] Run workflow stage agents through Harn agent loop (#1231)
19463227 [codex] Route stdlib re-entry through live Harn exports (#1229)
127b74ba [codex] Add agent turn observability hooks (#1230)
0b3ee644 [codex] Move orchestration loops into Harn stdlib (#1228)
485b1338 Harden local agent convergence paths (#1227)
1bb027a7 [codex] Declare stdlib entrypoints from Harn sources (#1226)
024f0615 [codex] Move parse guidance prose into prompt asset (#1225)
4cd80f3d [codex] Keep workflow prompt tests in Harn layer (#1224)
161b31c7 [codex] Consolidate builtin registration groups (#1223)
3120ce91 [codex] Move workflow orchestration policy into Harn stdlib (#1222)
07d7f817 [codex] Implement MCP completion support (#1221)
8c6088d4 [codex] Migrate LLM config builtins to registration DSL (#1220)
81ebbd8f [codex] Move workflow stage options into Harn (#1218)
15848417 [codex] Add stdlib builtin registration DSL (#1217)
38c36c6d Move workflow context selection into Harn (#1216)
65ddc069 Move workflow stage prompt prep into Harn (#1215)
```

## Execution transcript

| Step | Status | Classification |
|------|--------|----------------|
| `fetch-origin` | ok | `ok` |
| `sync-base` | ok | `ok` |
| `reset-release-branch-to-base` | ok | `ok` |
| `draft-release-notes` | ok | `ok` |
| `prepare` | ok | `ok` |
| `release-markdown-lint` | failed (2) | `generated_markdown_lint_failed` |
| `agent-recovery-advice-release-markdown-lint` | ok | `ok` |
| `release-markdown-lint-after-agent-repair` | ok | `ok` |
| `stage-tracked-release-content` | ok | `ok` |
| `commit` | ok | `ok` |
| `fetch-base` | ok | `ok` |
| `rebase-base` | ok | `ok` |
| `push` | ok | `ok` |
| `find-existing-pr` | ok | `ok` |
| `refresh-existing-pr-body` | ok | `ok` |
| `inspect-auto-merge` | ok | `ok` |
| `auto-merge-already-enabled` | ok | `ok` |

## Agent artifacts

- Audit JSONL transcript: `/Users/ksinder/projects/harn-bump-fleet/.harn-runs/release-harn/019dfde6-bea7-7ce0-b452-115c25c6047e/agent-llm/llm_transcript.jsonl`
- Draft changelog: `/Users/ksinder/projects/harn-bump-fleet/.harn-runs/release-harn/019dfde6-bea7-7ce0-b452-115c25c6047e/agent-draft-changelog.md`
- Agent validation findings: none

Generated by `release_harn.harn`.
