### PR TITLE
[codex] Honor post-turn options in agent stuck guard

### DIFF
--- a/conformance/tests/agents/agent_runtime_features.expected
+++ b/conformance/tests/agents/agent_runtime_features.expected
@@ -13,3 +13,6 @@ true
 true
 true
 true
+true
+true
+true

--- a/conformance/tests/agents/agent_runtime_features.harn
+++ b/conformance/tests/agents/agent_runtime_features.harn
@@ -128,4 +128,34 @@ pipeline test(task) {
   println(second_call.contains("rejected=0"))
   println(hook_calls[1].tool_choice == "none")
   println(second_call.contains("finalize now"))
+  llm_mock_clear()
+  llm_mock({text: "", tool_calls: [{id: "hook_2", name: "list_directory", arguments: {path: "."}}]})
+  llm_mock({text: "Final answer after clearing tools."})
+  let final_tools = tool_registry()
+  let cleared_final = agent_loop(
+    "Inspect the workspace",
+    "You are helpful",
+    {
+      provider: "mock",
+      tools: list_tools(),
+      tool_format: "native",
+      persistent: true,
+      max_iterations: 3,
+      max_nudges: 0,
+      post_turn_callback: { info ->
+        if len(info?.successful_tool_names ?? []) > 0 {
+          return {
+            message: "finalize without tools",
+            llm_options: {tool_choice: "none", tools: final_tools},
+            next_options: {tools: final_tools, persistent: false, max_nudges: 0},
+          }
+        }
+        return nil
+      },
+    },
+  )
+  let cleared_calls = llm_mock_calls()
+  println(cleared_final?.status == "done")
+  println(cleared_final?.llm?.iterations == 2)
+  println(len(cleared_calls[1]?.tools ?? []) == 0)
 }

--- a/crates/harn-stdlib/src/stdlib/agent/loop.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/loop.harn
@@ -292,8 +292,6 @@ pub fn agent_loop(message, system_prompt = nil, options = nil) {
   var rejected_tools_seen = []
   let max_verify_attempts = opts?.max_verify_attempts ?? 20
   let max_iterations = opts?.max_iterations ?? 50
-  let max_nudges = opts?.max_nudges ?? 8
-  let persistent = opts?.persistent ?? false
   while iteration < max_iterations {
     if agent_budget_pre_call_blocked(session, opts) {
       final_status = "budget_exhausted"
@@ -357,7 +355,9 @@ pub fn agent_loop(message, system_prompt = nil, options = nil) {
       break
     }
     consecutive_text_only = __next_text_only_count(tool_count, consecutive_text_only)
-    if persistent && tool_count == 0 && consecutive_text_only > max_nudges {
+    let turn_persistent = turn_opts?.persistent ?? false
+    let turn_max_nudges = turn_opts?.max_nudges ?? 8
+    if turn_persistent && tool_count == 0 && consecutive_text_only > turn_max_nudges {
       final_status = "stuck"
       stop_reason = "max_nudges"
       break


### PR DESCRIPTION
## Summary
- Recompute `persistent` and `max_nudges` from each turn's current agent-loop options before applying the stuck guard.
- Add conformance coverage for a post-turn callback that clears tools, sets `tool_choice: "none"`, disables persistence, and expects a normal final text turn.

## Root Cause
`agent_loop` captured `persistent` and `max_nudges` before entering the loop. When a post-turn callback returned `next_options` for a final prose turn, the next provider request used the updated options, but the stuck guard still evaluated the original values and could mark a successful final answer as `stuck`.

## Validation
- `CARGO_TARGET_DIR=/tmp/harn-target-main cargo run --quiet --bin harn -- test conformance --filter agent_runtime_features`
- `CARGO_TARGET_DIR=/tmp/harn-target-main cargo run --quiet --bin harn -- fmt --check crates/harn-stdlib/src/stdlib/agent/loop.harn conformance/tests/agents/agent_runtime_features.harn`
- `CARGO_TARGET_DIR=/tmp/harn-target-main cargo run --quiet --bin harn -- check conformance/tests/agents/agent_runtime_features.harn`
- `CARGO_TARGET_DIR=/tmp/harn-target-main make fmt-harn`
- `CARGO_TARGET_DIR=/tmp/harn-target-main make lint-harn`
- `CARGO_TARGET_DIR=/tmp/harn-target-main make conformance`
- `CARGO_TARGET_DIR=/tmp/harn-target-main make test`
