### PR TITLE
[codex] Keep packaged Harn crates self-contained

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,8 @@ jobs:
         with:
           components: rustfmt
       - run: make fmt-check
-      - name: Check canonical stdlib package
-        run: cargo package -p harn-stdlib --allow-dirty --no-verify
+      - name: Check published crate packages
+        run: ./scripts/verify_crate_packages.sh
 
   lint-md:
     name: Markdown lint

--- a/crates/harn-vm/src/orchestration/playground/scenarios.rs
+++ b/crates/harn-vm/src/orchestration/playground/scenarios.rs
@@ -1,8 +1,8 @@
 //! Built-in scenario manifests for the Merge Captain mock-repos
-//! playground (#1020). These are the canonical seed manifests checked
-//! into `examples/merge_captain/scenarios/` and embedded into the
-//! binary via `include_str!` so `harn merge-captain mock init --scenario
-//! <name>` works without requiring an examples/ checkout at runtime.
+//! playground (#1020). These seed manifests are embedded from the
+//! crate source tree so published crates are self-contained and
+//! `harn merge-captain mock init --scenario <name>` works without
+//! requiring an examples/ checkout at runtime.
 
 use std::path::Path;
 
@@ -10,12 +10,9 @@ use crate::value::VmError;
 
 use super::manifest::ScenarioManifest;
 
-const THREE_REPO_BASIC: &str =
-    include_str!("../../../../../examples/merge_captain/scenarios/three_repo_basic.json");
-const SINGLE_GREEN: &str =
-    include_str!("../../../../../examples/merge_captain/scenarios/single_green.json");
-const FORCE_PUSH_DRILL: &str =
-    include_str!("../../../../../examples/merge_captain/scenarios/force_push_drill.json");
+const THREE_REPO_BASIC: &str = include_str!("scenarios/three_repo_basic.json");
+const SINGLE_GREEN: &str = include_str!("scenarios/single_green.json");
+const FORCE_PUSH_DRILL: &str = include_str!("scenarios/force_push_drill.json");
 
 pub fn builtin_scenario_names() -> Vec<&'static str> {
     vec!["three_repo_basic", "single_green", "force_push_drill"]
@@ -44,6 +41,28 @@ mod tests {
     fn every_builtin_parses_and_validates() {
         for name in builtin_scenario_names() {
             load_builtin(name).unwrap_or_else(|e| panic!("scenario {name}: {e}"));
+        }
+    }
+
+    #[test]
+    fn embedded_scenarios_match_workspace_examples_when_available() {
+        let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let workspace_examples = manifest_dir.join("../../examples/merge_captain/scenarios");
+        if !workspace_examples.exists() {
+            return;
+        }
+
+        for (name, embedded) in [
+            ("three_repo_basic", THREE_REPO_BASIC),
+            ("single_green", SINGLE_GREEN),
+            ("force_push_drill", FORCE_PUSH_DRILL),
+        ] {
+            let source = std::fs::read_to_string(workspace_examples.join(format!("{name}.json")))
+                .unwrap_or_else(|e| panic!("failed to read workspace scenario {name}: {e}"));
+            assert_eq!(
+                embedded, source,
+                "embedded scenario {name} drifted from examples/merge_captain/scenarios"
+            );
         }
     }
 }

--- a/crates/harn-vm/src/orchestration/playground/scenarios/force_push_drill.json
+++ b/crates/harn-vm/src/orchestration/playground/scenarios/force_push_drill.json
@@ -1,0 +1,54 @@
+{
+  "_type": "merge_captain_playground_scenario",
+  "scenario": "force_push_drill",
+  "description": "Drill for force-with-lease handling: a PR whose author force-pushes mid-sweep. Captain should observe a head_sha change and re-verify checks.",
+  "owner": "burin-labs",
+  "repos": [
+    {
+      "name": "drill",
+      "default_branch": "main",
+      "files": {
+        "README.md": "# drill\n",
+        "src/lib.rs": "pub fn drill() -> i32 { 0 }\n"
+      },
+      "branches": [
+        {
+          "name": "feature/work-in-progress",
+          "files_set": {
+            "src/lib.rs": "pub fn drill() -> i32 { 1 }\n"
+          },
+          "commit_message": "feat(drill): wip"
+        }
+      ]
+    }
+  ],
+  "pull_requests": [
+    {
+      "repo": "drill",
+      "number": 42,
+      "title": "drill: wip",
+      "body": "Author keeps force-pushing.",
+      "state": "open",
+      "head_branch": "feature/work-in-progress",
+      "base_branch": "main",
+      "user": "carol",
+      "labels": [],
+      "checks": [
+        {"name": "ci", "status": "in_progress"}
+      ],
+      "mergeable": null,
+      "mergeable_state": "unknown"
+    }
+  ],
+  "steps": [
+    {
+      "name": "force_push_passing_v2",
+      "description": "Author force-pushes a v2 of the change and CI runs to green.",
+      "actions": [
+        {"kind": "force_push_author", "repo": "drill", "branch": "feature/work-in-progress", "files_set": {"src/lib.rs": "pub fn drill() -> i32 { 2 }\n"}, "commit_message": "feat(drill): v2"},
+        {"kind": "set_check", "repo": "drill", "pr_number": 42, "name": "ci", "status": "completed", "conclusion": "success"},
+        {"kind": "set_mergeability", "repo": "drill", "pr_number": 42, "mergeable": true, "mergeable_state": "clean"}
+      ]
+    }
+  ]
+}

--- a/crates/harn-vm/src/orchestration/playground/scenarios/single_green.json
+++ b/crates/harn-vm/src/orchestration/playground/scenarios/single_green.json
@@ -1,0 +1,52 @@
+{
+  "_type": "merge_captain_playground_scenario",
+  "scenario": "single_green",
+  "description": "Smallest possible scenario — one repo, one green PR. Use as a sanity check that the playground init succeeds end-to-end.",
+  "owner": "burin-labs",
+  "repos": [
+    {
+      "name": "solo",
+      "default_branch": "main",
+      "files": {
+        "README.md": "# solo\n",
+        "src/lib.rs": "pub fn solo() -> i32 { 0 }\n"
+      },
+      "branches": [
+        {
+          "name": "feature/tiny",
+          "files_set": {
+            "src/lib.rs": "pub fn solo() -> i32 { 1 }\n"
+          },
+          "commit_message": "feat(solo): bump return"
+        }
+      ]
+    }
+  ],
+  "pull_requests": [
+    {
+      "repo": "solo",
+      "number": 1,
+      "title": "solo: bump return",
+      "body": "",
+      "state": "open",
+      "head_branch": "feature/tiny",
+      "base_branch": "main",
+      "user": "alice",
+      "labels": ["ready-to-merge"],
+      "checks": [
+        {"name": "ci", "status": "completed", "conclusion": "success"}
+      ],
+      "mergeable": true,
+      "mergeable_state": "clean"
+    }
+  ],
+  "steps": [
+    {
+      "name": "merge",
+      "description": "Merge the PR.",
+      "actions": [
+        {"kind": "merge_pull_request", "repo": "solo", "pr_number": 1}
+      ]
+    }
+  ]
+}

--- a/crates/harn-vm/src/orchestration/playground/scenarios/three_repo_basic.json
+++ b/crates/harn-vm/src/orchestration/playground/scenarios/three_repo_basic.json
@@ -1,0 +1,155 @@
+{
+  "_type": "merge_captain_playground_scenario",
+  "scenario": "three_repo_basic",
+  "description": "Three repos with the canonical PR states the Merge Captain has to reason about: green-ready, behind-base, lockfile-conflict, failing-CI. Use as the default playground for brute-force tuning.",
+  "owner": "burin-labs",
+  "repos": [
+    {
+      "name": "alpha",
+      "default_branch": "main",
+      "files": {
+        "README.md": "# alpha\n\nMerge Captain playground seed for the green-ready PR.\n",
+        "src/lib.rs": "pub fn alpha() -> &'static str { \"alpha\" }\n"
+      },
+      "branches": [
+        {
+          "name": "feature/green-ready",
+          "files_set": {
+            "src/lib.rs": "pub fn alpha() -> &'static str { \"alpha\" }\npub fn alpha2() -> &'static str { \"alpha2\" }\n"
+          },
+          "commit_message": "feat(alpha): add alpha2"
+        }
+      ]
+    },
+    {
+      "name": "beta",
+      "default_branch": "main",
+      "files": {
+        "README.md": "# beta\n\nMerge Captain playground seed for the behind-base + lockfile PR.\n",
+        "Cargo.toml": "[package]\nname = \"beta\"\nversion = \"0.1.0\"\n",
+        "Cargo.lock": "# Lockfile v3\n[[package]]\nname = \"beta\"\nversion = \"0.1.0\"\n"
+      },
+      "default_branch_extra_commits": [
+        {
+          "message": "chore(beta): bump deps on main",
+          "files_set": {
+            "Cargo.lock": "# Lockfile v3\n[[package]]\nname = \"beta\"\nversion = \"0.1.1\"\n"
+          }
+        }
+      ],
+      "branches": [
+        {
+          "name": "feature/behind-base",
+          "fork_before_extra_commits": true,
+          "files_set": {
+            "Cargo.lock": "# Lockfile v3\n[[package]]\nname = \"beta\"\nversion = \"0.1.0\"\n[[package]]\nname = \"beta-dep\"\nversion = \"0.1.0\"\n",
+            "src/lib.rs": "pub fn beta() -> &'static str { \"beta\" }\n"
+          },
+          "commit_message": "feat(beta): add beta-dep before main bumped"
+        }
+      ]
+    },
+    {
+      "name": "gamma",
+      "default_branch": "main",
+      "files": {
+        "README.md": "# gamma\n\nMerge Captain playground seed for the failing-CI PR.\n",
+        "src/main.rs": "fn main() { println!(\"hi\"); }\n"
+      },
+      "branches": [
+        {
+          "name": "feature/failing-ci",
+          "files_set": {
+            "src/main.rs": "fn main() { println!(\"oops\")  // syntax error\n}\n"
+          },
+          "commit_message": "feat(gamma): wire new entrypoint"
+        }
+      ]
+    }
+  ],
+  "pull_requests": [
+    {
+      "repo": "alpha",
+      "number": 101,
+      "title": "alpha: add alpha2",
+      "body": "Adds a tiny helper. Should sail through.",
+      "state": "open",
+      "head_branch": "feature/green-ready",
+      "base_branch": "main",
+      "user": "alice",
+      "labels": ["ready-to-merge"],
+      "checks": [
+        {"name": "ci", "status": "completed", "conclusion": "success"},
+        {"name": "lint", "status": "completed", "conclusion": "success"}
+      ],
+      "mergeable": true,
+      "mergeable_state": "clean"
+    },
+    {
+      "repo": "beta",
+      "number": 202,
+      "title": "beta: introduce beta-dep",
+      "body": "Predates the main lockfile bump — captain should flag and rebase.",
+      "state": "open",
+      "head_branch": "feature/behind-base",
+      "base_branch": "main",
+      "user": "bob",
+      "labels": ["needs-rebase"],
+      "checks": [
+        {"name": "ci", "status": "completed", "conclusion": "success"}
+      ],
+      "mergeable": false,
+      "mergeable_state": "behind"
+    },
+    {
+      "repo": "gamma",
+      "number": 303,
+      "title": "gamma: rewrite entrypoint",
+      "body": "CI is failing — captain should hand off to the author.",
+      "state": "open",
+      "head_branch": "feature/failing-ci",
+      "base_branch": "main",
+      "user": "carol",
+      "labels": [],
+      "checks": [
+        {"name": "ci", "status": "completed", "conclusion": "failure", "details_url": "https://example.invalid/ci/303"}
+      ],
+      "mergeable": true,
+      "mergeable_state": "unstable"
+    }
+  ],
+  "steps": [
+    {
+      "name": "alpha_pass_to_merge_queue",
+      "description": "Promote the green-ready PR through the merge queue.",
+      "actions": [
+        {"kind": "set_merge_queue_status", "repo": "alpha", "pr_number": 101, "status": "queued"},
+        {"kind": "set_merge_queue_status", "repo": "alpha", "pr_number": 101, "status": "merged"},
+        {"kind": "merge_pull_request", "repo": "alpha", "pr_number": 101, "merge_method": "queue"}
+      ]
+    },
+    {
+      "name": "beta_advance_main",
+      "description": "Land another commit on main so the behind-base PR's mergeable_state stays behind.",
+      "actions": [
+        {"kind": "advance_base", "repo": "beta", "files_set": {"Cargo.lock": "# Lockfile v3\n[[package]]\nname = \"beta\"\nversion = \"0.1.2\"\n"}, "commit_message": "chore(beta): another lockfile bump"}
+      ]
+    },
+    {
+      "name": "gamma_force_push_fix",
+      "description": "Author force-pushes a corrected entrypoint and CI flips green.",
+      "actions": [
+        {"kind": "force_push_author", "repo": "gamma", "branch": "feature/failing-ci", "files_set": {"src/main.rs": "fn main() { println!(\"hi\"); }\n"}, "commit_message": "fix(gamma): repair entrypoint"},
+        {"kind": "set_check", "repo": "gamma", "pr_number": 303, "name": "ci", "status": "completed", "conclusion": "success"},
+        {"kind": "set_mergeability", "repo": "gamma", "pr_number": 303, "mergeable": true, "mergeable_state": "clean"}
+      ]
+    },
+    {
+      "name": "advance_clock_one_minute",
+      "description": "Advance the playground clock by 60 seconds. Useful for steady-state tests of staleness.",
+      "actions": [
+        {"kind": "advance_time_ms", "ms": 60000}
+      ]
+    }
+  ]
+}

--- a/crates/harn-vm/src/receipts/mod.rs
+++ b/crates/harn-vm/src/receipts/mod.rs
@@ -7,7 +7,7 @@ use time::OffsetDateTime;
 
 pub const RECEIPT_SCHEMA_ID: &str = "https://harnlang.com/schemas/receipt.v1.json";
 pub const RECEIPT_SCHEMA_VERSION: &str = "harn.receipt.v1";
-pub const RECEIPT_SCHEMA_JSON: &str = include_str!("../../../../docs/schemas/receipt.v1.json");
+pub const RECEIPT_SCHEMA_JSON: &str = include_str!("receipt.v1.json");
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(default)]
@@ -294,6 +294,21 @@ mod tests {
             .as_array()
             .unwrap()
             .contains(&json!("receipt_only")));
+    }
+
+    #[test]
+    fn embedded_receipt_schema_matches_workspace_docs_when_available() {
+        let docs_schema = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../docs/schemas/receipt.v1.json");
+        if !docs_schema.exists() {
+            return;
+        }
+        let source = std::fs::read_to_string(&docs_schema)
+            .unwrap_or_else(|e| panic!("failed to read {}: {e}", docs_schema.display()));
+        assert_eq!(
+            RECEIPT_SCHEMA_JSON, source,
+            "embedded receipt schema drifted from docs/schemas/receipt.v1.json"
+        );
     }
 
     #[test]

--- a/crates/harn-vm/src/receipts/receipt.v1.json
+++ b/crates/harn-vm/src/receipts/receipt.v1.json
@@ -1,0 +1,145 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/receipt.v1.json",
+  "title": "Harn Receipt Envelope v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "id",
+    "parent_run_id",
+    "persona",
+    "step",
+    "trace_id",
+    "started_at",
+    "completed_at",
+    "status",
+    "inputs_digest",
+    "outputs_digest",
+    "model_calls",
+    "tool_calls",
+    "cost_usd",
+    "approvals",
+    "handoffs",
+    "side_effects",
+    "error",
+    "redaction_class",
+    "metadata"
+  ],
+  "properties": {
+    "schema": {
+      "const": "harn.receipt.v1",
+      "description": "Stable discriminator for the canonical Harn receipt envelope."
+    },
+    "id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "parent_run_id": {
+      "type": ["string", "null"]
+    },
+    "persona": {
+      "type": "string",
+      "minLength": 1
+    },
+    "step": {
+      "type": ["string", "null"]
+    },
+    "trace_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "started_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "completed_at": {
+      "type": ["string", "null"],
+      "format": "date-time"
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "accepted",
+        "running",
+        "success",
+        "noop",
+        "failure",
+        "denied",
+        "duplicate",
+        "cancelled"
+      ]
+    },
+    "inputs_digest": {
+      "$ref": "#/$defs/nullable_digest"
+    },
+    "outputs_digest": {
+      "$ref": "#/$defs/nullable_digest"
+    },
+    "model_calls": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/payload_object"
+      }
+    },
+    "tool_calls": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/payload_object"
+      }
+    },
+    "cost_usd": {
+      "type": "number",
+      "minimum": 0
+    },
+    "approvals": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/payload_object"
+      }
+    },
+    "handoffs": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/payload_object"
+      }
+    },
+    "side_effects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/payload_object"
+      }
+    },
+    "error": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/payload_object"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "redaction_class": {
+      "type": "string",
+      "enum": ["public", "internal", "receipt_only", "secret"]
+    },
+    "metadata": {
+      "$ref": "#/$defs/metadata"
+    }
+  },
+  "$defs": {
+    "metadata": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "nullable_digest": {
+      "type": ["string", "null"],
+      "description": "Digest of the corresponding payload, formatted as algorithm:value such as sha256:abc123."
+    },
+    "payload_object": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  }
+}

--- a/crates/harn-vm/src/trust_graph.rs
+++ b/crates/harn-vm/src/trust_graph.rs
@@ -903,17 +903,16 @@ mod tests {
     use time::Duration;
 
     const RECORD_SCHEMA_JSON: &str =
-        include_str!("../../../opentrustgraph-spec/schemas/trust-record.v0.schema.json");
-    const CHAIN_SCHEMA_JSON: &str =
-        include_str!("../../../opentrustgraph-spec/schemas/trust-chain.v0.schema.json");
+        include_str!("trust_graph/schemas/trust-record.v0.schema.json");
+    const CHAIN_SCHEMA_JSON: &str = include_str!("trust_graph/schemas/trust-chain.v0.schema.json");
     const VALID_DECISION_CHAIN_JSON: &str =
-        include_str!("../../../opentrustgraph-spec/fixtures/valid/decision-chain.json");
+        include_str!("trust_graph/fixtures/valid/decision-chain.json");
     const VALID_TIER_TRANSITION_JSON: &str =
-        include_str!("../../../opentrustgraph-spec/fixtures/valid/tier-transition.json");
+        include_str!("trust_graph/fixtures/valid/tier-transition.json");
     const INVALID_TAMPERED_CHAIN_JSON: &str =
-        include_str!("../../../opentrustgraph-spec/fixtures/invalid/tampered-chain.json");
+        include_str!("trust_graph/fixtures/invalid/tampered-chain.json");
     const INVALID_MISSING_APPROVAL_JSON: &str =
-        include_str!("../../../opentrustgraph-spec/fixtures/invalid/missing-approval.json");
+        include_str!("trust_graph/fixtures/invalid/missing-approval.json");
 
     #[derive(Debug, serde::Deserialize)]
     struct TrustChainFixture {
@@ -930,6 +929,44 @@ mod tests {
         verified: bool,
         generated_at: String,
         producer: BTreeMap<String, serde_json::Value>,
+    }
+
+    #[test]
+    fn embedded_trust_graph_fixtures_match_workspace_spec_when_available() {
+        let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+        let spec_dir = manifest_dir.join("../../opentrustgraph-spec");
+        if !spec_dir.exists() {
+            return;
+        }
+
+        for (relative, embedded) in [
+            ("schemas/trust-record.v0.schema.json", RECORD_SCHEMA_JSON),
+            ("schemas/trust-chain.v0.schema.json", CHAIN_SCHEMA_JSON),
+            (
+                "fixtures/valid/decision-chain.json",
+                VALID_DECISION_CHAIN_JSON,
+            ),
+            (
+                "fixtures/valid/tier-transition.json",
+                VALID_TIER_TRANSITION_JSON,
+            ),
+            (
+                "fixtures/invalid/tampered-chain.json",
+                INVALID_TAMPERED_CHAIN_JSON,
+            ),
+            (
+                "fixtures/invalid/missing-approval.json",
+                INVALID_MISSING_APPROVAL_JSON,
+            ),
+        ] {
+            let source = std::fs::read_to_string(spec_dir.join(relative)).unwrap_or_else(|e| {
+                panic!("failed to read opentrustgraph fixture {relative}: {e}")
+            });
+            assert_eq!(
+                embedded, source,
+                "embedded trust graph fixture {relative} drifted from opentrustgraph-spec"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/harn-vm/src/trust_graph/fixtures/invalid/missing-approval.json
+++ b/crates/harn-vm/src/trust_graph/fixtures/invalid/missing-approval.json
@@ -1,0 +1,39 @@
+{
+  "schema": "opentrustgraph-chain/v0",
+  "chain": {
+    "topic": "trust_graph",
+    "total": 1,
+    "root_hash": "sha256:bc337327340a47fa65876090ed7e73218259cb91ca04b9a027670a6bcb9ea5ad",
+    "verified": false,
+    "generated_at": "2026-04-19T20:01:00Z",
+    "producer": {
+      "name": "harn",
+      "version": "0.7.x"
+    }
+  },
+  "records": [
+    {
+      "schema": "opentrustgraph/v0",
+      "record_id": "01966f4c-2000-7763-9b4b-d2bfe8050001",
+      "agent": "deploy-agent",
+      "action": "deploy.prod",
+      "approver": null,
+      "outcome": "success",
+      "trace_id": "trace_missing_approval_01",
+      "autonomy_tier": "act_with_approval",
+      "timestamp": "2026-04-19T20:00:00Z",
+      "cost_usd": 0.21,
+      "chain_index": 1,
+      "previous_hash": null,
+      "entry_hash": "sha256:bc337327340a47fa65876090ed7e73218259cb91ca04b9a027670a6bcb9ea5ad",
+      "metadata": {
+        "approval": {
+          "required": true,
+          "quorum": 1,
+          "signatures": []
+        },
+        "provider": "github"
+      }
+    }
+  ]
+}

--- a/crates/harn-vm/src/trust_graph/fixtures/invalid/tampered-chain.json
+++ b/crates/harn-vm/src/trust_graph/fixtures/invalid/tampered-chain.json
@@ -1,0 +1,54 @@
+{
+  "schema": "opentrustgraph-chain/v0",
+  "chain": {
+    "topic": "trust_graph",
+    "total": 2,
+    "root_hash": "sha256:13f9bf66cea6d09b868318afd40dad1fa6acb35994f64ab3fffcc57d30658c41",
+    "verified": false,
+    "generated_at": "2026-04-19T18:45:00Z",
+    "producer": {
+      "name": "harn",
+      "version": "0.7.x"
+    }
+  },
+  "records": [
+    {
+      "schema": "opentrustgraph/v0",
+      "record_id": "01966f4c-0f31-7b5d-b44b-f7f8e7e1d384",
+      "agent": "github-triage-bot",
+      "action": "github.issue.opened",
+      "approver": null,
+      "outcome": "success",
+      "trace_id": "trace_valid_01",
+      "autonomy_tier": "suggest",
+      "timestamp": "2026-04-19T18:42:11Z",
+      "cost_usd": null,
+      "chain_index": 1,
+      "previous_hash": null,
+      "entry_hash": "sha256:84facae7d56fd304e040ea18d80bd019e274ad86ddd5a4d732f3ac3d984c48ec",
+      "metadata": {
+        "provider": "github"
+      }
+    },
+    {
+      "schema": "opentrustgraph/v0",
+      "record_id": "01966f4c-0f32-7d37-b443-d72dd96f0f4f",
+      "agent": "github-triage-bot",
+      "action": "trust.promote",
+      "approver": "maintainer-1",
+      "outcome": "success",
+      "trace_id": "trace_valid_02",
+      "autonomy_tier": "act_auto",
+      "timestamp": "2026-04-19T18:43:02Z",
+      "cost_usd": null,
+      "chain_index": 2,
+      "previous_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+      "entry_hash": "sha256:13f9bf66cea6d09b868318afd40dad1fa6acb35994f64ab3fffcc57d30658c41",
+      "metadata": {
+        "control": true,
+        "from_tier": "suggest",
+        "to_tier": "act_auto"
+      }
+    }
+  ]
+}

--- a/crates/harn-vm/src/trust_graph/fixtures/valid/decision-chain.json
+++ b/crates/harn-vm/src/trust_graph/fixtures/valid/decision-chain.json
@@ -1,0 +1,54 @@
+{
+  "schema": "opentrustgraph-chain/v0",
+  "chain": {
+    "topic": "trust_graph",
+    "total": 2,
+    "root_hash": "sha256:6bb2b155ba07c67443c881f2d9dd954083bb44542df81520db1490fcbfdd5bf9",
+    "verified": true,
+    "generated_at": "2026-04-19T18:45:00Z",
+    "producer": {
+      "name": "harn",
+      "version": "0.7.x"
+    }
+  },
+  "records": [
+    {
+      "schema": "opentrustgraph/v0",
+      "record_id": "01966f4c-0f31-7b5d-b44b-f7f8e7e1d384",
+      "agent": "github-triage-bot",
+      "action": "github.issue.opened",
+      "approver": null,
+      "outcome": "success",
+      "trace_id": "trace_valid_01",
+      "autonomy_tier": "suggest",
+      "timestamp": "2026-04-19T18:42:11Z",
+      "cost_usd": null,
+      "chain_index": 1,
+      "previous_hash": null,
+      "entry_hash": "sha256:84facae7d56fd304e040ea18d80bd019e274ad86ddd5a4d732f3ac3d984c48ec",
+      "metadata": {
+        "provider": "github"
+      }
+    },
+    {
+      "schema": "opentrustgraph/v0",
+      "record_id": "01966f4c-0f32-7d37-b443-d72dd96f0f4f",
+      "agent": "github-triage-bot",
+      "action": "trust.promote",
+      "approver": "maintainer-1",
+      "outcome": "success",
+      "trace_id": "trace_valid_02",
+      "autonomy_tier": "act_auto",
+      "timestamp": "2026-04-19T18:43:02Z",
+      "cost_usd": null,
+      "chain_index": 2,
+      "previous_hash": "sha256:84facae7d56fd304e040ea18d80bd019e274ad86ddd5a4d732f3ac3d984c48ec",
+      "entry_hash": "sha256:6bb2b155ba07c67443c881f2d9dd954083bb44542df81520db1490fcbfdd5bf9",
+      "metadata": {
+        "control": true,
+        "from_tier": "suggest",
+        "to_tier": "act_auto"
+      }
+    }
+  ]
+}

--- a/crates/harn-vm/src/trust_graph/fixtures/valid/tier-transition.json
+++ b/crates/harn-vm/src/trust_graph/fixtures/valid/tier-transition.json
@@ -1,0 +1,95 @@
+{
+  "schema": "opentrustgraph-chain/v0",
+  "chain": {
+    "topic": "trust_graph",
+    "total": 3,
+    "root_hash": "sha256:e1ca0fc25124ed404fb05d31a468d4ddb33fab3325f86a58ad4068671188b57a",
+    "verified": true,
+    "generated_at": "2026-04-19T19:03:00Z",
+    "producer": {
+      "name": "harn",
+      "version": "0.7.x"
+    }
+  },
+  "records": [
+    {
+      "schema": "opentrustgraph/v0",
+      "record_id": "01966f4c-1000-78a1-91d6-407b18572001",
+      "agent": "deploy-agent",
+      "action": "deploy.preview",
+      "approver": null,
+      "outcome": "denied",
+      "trace_id": "trace_tier_01",
+      "autonomy_tier": "shadow",
+      "timestamp": "2026-04-19T19:00:00Z",
+      "cost_usd": null,
+      "chain_index": 1,
+      "previous_hash": null,
+      "entry_hash": "sha256:12fd52408e6feb50e7bbaa2d308ee4896464264a7e59893e40142cdc649cf654",
+      "metadata": {
+        "terminal_status": "blocked",
+        "reason": "shadow tier blocks direct mutation"
+      }
+    },
+    {
+      "schema": "opentrustgraph/v0",
+      "record_id": "01966f4c-1001-71da-9e75-e5b339a30002",
+      "agent": "deploy-agent",
+      "action": "trust.promote",
+      "approver": "ops-lead",
+      "outcome": "success",
+      "trace_id": "trace_tier_02",
+      "autonomy_tier": "act_with_approval",
+      "timestamp": "2026-04-19T19:01:00Z",
+      "cost_usd": null,
+      "chain_index": 2,
+      "previous_hash": "sha256:12fd52408e6feb50e7bbaa2d308ee4896464264a7e59893e40142cdc649cf654",
+      "entry_hash": "sha256:51af6fa6f2cc790749d6c892939a27e43d10ac191fa8d42ae611a5ade0d01813",
+      "metadata": {
+        "control": true,
+        "from_tier": "shadow",
+        "to_tier": "act_with_approval",
+        "approval": {
+          "required": true,
+          "quorum": 1,
+          "signatures": [
+            {
+              "reviewer": "ops-lead",
+              "signed_at": "2026-04-19T19:00:59Z",
+              "signature": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "schema": "opentrustgraph/v0",
+      "record_id": "01966f4c-1002-765e-a26e-17403bc70003",
+      "agent": "deploy-agent",
+      "action": "deploy.preview",
+      "approver": "ops-lead",
+      "outcome": "success",
+      "trace_id": "trace_tier_03",
+      "autonomy_tier": "act_with_approval",
+      "timestamp": "2026-04-19T19:02:00Z",
+      "cost_usd": 0.034,
+      "chain_index": 3,
+      "previous_hash": "sha256:51af6fa6f2cc790749d6c892939a27e43d10ac191fa8d42ae611a5ade0d01813",
+      "entry_hash": "sha256:e1ca0fc25124ed404fb05d31a468d4ddb33fab3325f86a58ad4068671188b57a",
+      "metadata": {
+        "provider": "github",
+        "approval": {
+          "required": true,
+          "quorum": 1,
+          "signatures": [
+            {
+              "reviewer": "ops-lead",
+              "signed_at": "2026-04-19T19:01:58Z",
+              "signature": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/crates/harn-vm/src/trust_graph/schemas/trust-chain.v0.schema.json
+++ b/crates/harn-vm/src/trust_graph/schemas/trust-chain.v0.schema.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/opentrustgraph/v0/trust-chain.schema.json",
+  "title": "OpenTrustGraph TrustChainExport",
+  "description": "Ordered OpenTrustGraph records plus chain verification metadata.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "chain", "records"],
+  "properties": {
+    "schema": {
+      "const": "opentrustgraph-chain/v0"
+    },
+    "chain": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "topic",
+        "total",
+        "root_hash",
+        "verified",
+        "generated_at",
+        "producer"
+      ],
+      "properties": {
+        "topic": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Canonical event-log topic or exported stream name."
+        },
+        "total": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of records in this ordered export."
+        },
+        "root_hash": {
+          "type": ["string", "null"],
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "description": "The final record's entry_hash, or null for an empty export."
+        },
+        "verified": {
+          "type": "boolean",
+          "description": "Whether the producer verified record contracts, required approval evidence, record hashes, and hash linkage before export."
+        },
+        "generated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "producer": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["name", "version"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "minLength": 1
+            },
+            "version": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    },
+    "records": {
+      "type": "array",
+      "items": {
+        "$ref": "trust-record.v0.schema.json"
+      }
+    }
+  }
+}

--- a/crates/harn-vm/src/trust_graph/schemas/trust-record.v0.schema.json
+++ b/crates/harn-vm/src/trust_graph/schemas/trust-record.v0.schema.json
@@ -1,0 +1,168 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/opentrustgraph/v0/trust-record.schema.json",
+  "title": "OpenTrustGraph TrustRecord",
+  "description": "One autonomy, approval, or control-plane event in an append-only OpenTrustGraph chain.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "record_id",
+    "agent",
+    "action",
+    "outcome",
+    "trace_id",
+    "autonomy_tier",
+    "timestamp",
+    "chain_index",
+    "previous_hash",
+    "entry_hash",
+    "metadata"
+  ],
+  "properties": {
+    "schema": {
+      "const": "opentrustgraph/v0"
+    },
+    "record_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Globally unique record id. UUIDv7 is recommended."
+    },
+    "agent": {
+      "type": "string",
+      "minLength": 1
+    },
+    "action": {
+      "type": "string",
+      "minLength": 1
+    },
+    "approver": {
+      "type": ["string", "null"],
+      "minLength": 1,
+      "description": "Actor that satisfied the approval gate, or null when no approval gate applied."
+    },
+    "outcome": {
+      "type": "string",
+      "enum": ["success", "failure", "denied", "timeout"]
+    },
+    "trace_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "autonomy_tier": {
+      "type": "string",
+      "enum": ["shadow", "suggest", "act_with_approval", "act_auto"]
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "cost_usd": {
+      "type": ["number", "null"],
+      "minimum": 0
+    },
+    "chain_index": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "previous_hash": {
+      "type": ["string", "null"],
+      "pattern": "^(sha256:[0-9a-f]{64})$"
+    },
+    "entry_hash": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "metadata": {
+      "type": "object",
+      "description": "Runtime-specific detail bag. Consumers must preserve unknown keys."
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "outcome": {
+            "const": "success"
+          },
+          "autonomy_tier": {
+            "const": "act_with_approval"
+          },
+          "metadata": {
+            "type": "object",
+            "properties": {
+              "approval": {
+                "type": "object",
+                "properties": {
+                  "required": {
+                    "const": true
+                  }
+                },
+                "required": ["required"]
+              }
+            },
+            "required": ["approval"]
+          }
+        },
+        "required": ["outcome", "autonomy_tier", "metadata"]
+      },
+      "then": {
+        "properties": {
+          "approver": {
+            "type": "string",
+            "minLength": 1
+          },
+          "metadata": {
+            "type": "object",
+            "properties": {
+              "approval": {
+                "$ref": "#/$defs/approvalReceipt"
+              }
+            },
+            "required": ["approval"]
+          }
+        },
+        "required": ["approver"]
+      }
+    }
+  ],
+  "$defs": {
+    "approvalReceipt": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["required", "quorum", "signatures"],
+      "properties": {
+        "required": {
+          "const": true
+        },
+        "quorum": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "signatures": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": true,
+            "required": ["reviewer", "signed_at", "signature"],
+            "properties": {
+              "reviewer": {
+                "type": "string",
+                "minLength": 1
+              },
+              "signed_at": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "signature": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/verify_crate_packages.sh
+++ b/scripts/verify_crate_packages.sh
@@ -5,29 +5,19 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
 VERIFY_CLI=0
-SKIP_CLI=0
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --verify-cli)
       VERIFY_CLI=1
       shift
       ;;
-    --skip-cli)
-      SKIP_CLI=1
-      shift
-      ;;
     *)
       echo "error: unknown arg: $1" >&2
-      echo "usage: ./scripts/verify_crate_packages.sh [--verify-cli|--skip-cli]" >&2
+      echo "usage: ./scripts/verify_crate_packages.sh [--verify-cli]" >&2
       exit 1
       ;;
   esac
 done
-
-if [[ "$VERIFY_CLI" -eq 1 && "$SKIP_CLI" -eq 1 ]]; then
-  echo "error: --verify-cli and --skip-cli are mutually exclusive" >&2
-  exit 1
-fi
 
 metadata="$(cargo metadata --format-version 1 --no-deps)"
 target_dir="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["target_directory"])' <<<"$metadata")"
@@ -39,9 +29,146 @@ modules_version="$(
   python3 -c 'import json,sys; print(next(p["version"] for p in json.load(sys.stdin)["packages"] if p["name"] == "harn-modules"))' \
     <<<"$metadata"
 )"
+vm_version="$(
+  python3 -c 'import json,sys; print(next(p["version"] for p in json.load(sys.stdin)["packages"] if p["name"] == "harn-vm"))' \
+    <<<"$metadata"
+)"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+metadata_file="$tmp/cargo-metadata.json"
+printf '%s\n' "$metadata" >"$metadata_file"
+
+# Verify the candidate workspace as a coherent publish set instead of
+# resolving intra-Harn dependencies to whatever versions are already on
+# crates.io. That catches package-only failures without needing a prior
+# bootstrap publish for newly split crates.
+local_harn_patches=()
+while IFS=$'\t' read -r crate manifest_path; do
+  crate_dir="$(cd "$(dirname "$manifest_path")" && pwd)"
+  local_harn_patches+=(--config "patch.crates-io.$crate.path=\"$crate_dir\"")
+done < <(
+  python3 - "$metadata_file" <<'PY'
+import json
+import pathlib
+import sys
+
+metadata = json.loads(pathlib.Path(sys.argv[1]).read_text())
+members = set(metadata["workspace_members"])
+for package in sorted(metadata["packages"], key=lambda p: p["name"]):
+    if package["id"] in members and package["name"].startswith("harn-"):
+        print(f'{package["name"]}\t{package["manifest_path"]}')
+PY
+)
+
+package_version() {
+  local crate="$1"
+  python3 - "$crate" "$metadata_file" <<'PY'
+import json
+import sys
+import pathlib
+
+crate = sys.argv[1]
+metadata = json.loads(pathlib.Path(sys.argv[2]).read_text())
+print(next(p["version"] for p in metadata["packages"] if p["name"] == crate))
+PY
+}
+
+inspect_packaged_includes() {
+  local package_dir="$1"
+  local crate="$2"
+  python3 - "$package_dir" "$crate" <<'PY'
+import ast
+import pathlib
+import re
+import sys
+
+root = pathlib.Path(sys.argv[1]).resolve()
+crate = sys.argv[2]
+errors = []
+normal = re.compile(r'include_(?:str|bytes)!\s*\(\s*"((?:\\.|[^"\\])*)"\s*\)', re.S)
+raw = re.compile(r'include_(?:str|bytes)!\s*\(\s*r(?P<hashes>#*)"(?P<path>.*?)"(?P=hashes)\s*\)', re.S)
+
+for source in sorted(root.rglob("*.rs")):
+    text = source.read_text()
+    matches = []
+    for match in normal.finditer(text):
+        try:
+            relative = ast.literal_eval('"' + match.group(1) + '"')
+        except Exception as exc:
+            errors.append(f"{source.relative_to(root)}: cannot decode include path: {exc}")
+            continue
+        matches.append(relative)
+    matches.extend(match.group("path") for match in raw.finditer(text))
+
+    for relative in matches:
+        if pathlib.PurePosixPath(relative).is_absolute():
+            errors.append(f"{source.relative_to(root)}: absolute include path {relative!r}")
+            continue
+        target = (source.parent / relative).resolve()
+        if not target.exists():
+            errors.append(f"{source.relative_to(root)}: missing include target {relative!r}")
+            continue
+        try:
+            target.relative_to(root)
+        except ValueError:
+            errors.append(f"{source.relative_to(root)}: include target escapes package: {relative!r}")
+
+if errors:
+    print(f"error: packaged {crate} has invalid include_str!/include_bytes! paths:", file=sys.stderr)
+    for error in errors:
+        print(f"  - {error}", file=sys.stderr)
+    raise SystemExit(1)
+PY
+}
+
+extract_package() {
+  local crate="$1"
+  local version="$2"
+  local crate_archive="$target_dir/package/$crate-$version.crate"
+  if [[ ! -f "$crate_archive" ]]; then
+    echo "error: expected package archive missing: $crate_archive" >&2
+    exit 1
+  fi
+  rm -rf "$tmp/$crate-$version"
+  tar -xzf "$crate_archive" -C "$tmp"
+  inspect_packaged_includes "$tmp/$crate-$version" "$crate"
+}
+
+package_and_inspect_no_verify() {
+  local crate="$1"
+  local version
+  version="$(package_version "$crate")"
+  echo "=== Package $crate ==="
+  cargo package -p "$crate" --allow-dirty --no-verify "${local_harn_patches[@]}"
+  extract_package "$crate" "$version"
+}
+
+echo "=== Package and inspect baseline crates ==="
+while IFS= read -r crate; do
+  case "$crate" in
+    harn-stdlib|harn-modules|harn-hostlib|harn-vm|harn-cli)
+      ;;
+    *)
+      package_and_inspect_no_verify "$crate"
+      ;;
+  esac
+done < <(
+  python3 - "$metadata_file" <<'PY'
+import json
+import sys
+import pathlib
+
+metadata = json.loads(pathlib.Path(sys.argv[1]).read_text())
+members = set(metadata["workspace_members"])
+for package in sorted(metadata["packages"], key=lambda p: p["name"]):
+    if package["id"] in members:
+        print(package["name"])
+PY
+)
 
 echo "=== Package harn-stdlib ==="
-cargo package -p harn-stdlib --allow-dirty
+cargo package -p harn-stdlib --allow-dirty "${local_harn_patches[@]}"
 
 stdlib_crate="$target_dir/package/harn-stdlib-$stdlib_version.crate"
 if [[ ! -f "$stdlib_crate" ]]; then
@@ -49,11 +176,9 @@ if [[ ! -f "$stdlib_crate" ]]; then
   exit 1
 fi
 
-tmp="$(mktemp -d)"
-trap 'rm -rf "$tmp"' EXIT
-
 tar -xzf "$stdlib_crate" -C "$tmp"
 stdlib_pkg="$tmp/harn-stdlib-$stdlib_version"
+inspect_packaged_includes "$stdlib_pkg" "harn-stdlib"
 
 echo "=== Inspect harn-stdlib package contents ==="
 while IFS= read -r source; do
@@ -77,40 +202,33 @@ fi
 echo "=== Check extracted harn-stdlib package ==="
 CARGO_TARGET_DIR="$tmp/target-stdlib" cargo check --manifest-path "$stdlib_pkg/Cargo.toml"
 
-# `harn-stdlib` is a new workspace dependency. Until the first release that
-# publishes it, packages that depend on it cannot resolve their registry
-# dependency during `cargo package`. Keep checking the owner crate above in
-# bootstrap mode; after harn-stdlib exists on crates.io this consumer package
-# check resumes.
-if [[ "${HARN_BOOTSTRAP_NEW_CRATES:-0}" == "1" || "$SKIP_CLI" -eq 1 ]]; then
-  echo "=== Skip harn-modules package check (bootstrap mode) ==="
-else
-  echo "=== Package harn-modules ==="
-  cargo package -p harn-modules --allow-dirty --no-verify
+echo "=== Package harn-modules ==="
+cargo package -p harn-modules --allow-dirty --no-verify "${local_harn_patches[@]}"
 
-  modules_crate="$target_dir/package/harn-modules-$modules_version.crate"
-  if [[ ! -f "$modules_crate" ]]; then
-    echo "error: expected package archive missing: $modules_crate" >&2
-    exit 1
-  fi
-
-  tar -xzf "$modules_crate" -C "$tmp"
-  modules_pkg="$tmp/harn-modules-$modules_version"
-
-  echo "=== Inspect harn-modules package stdlib use ==="
-  if [[ -e "$modules_pkg/src/stdlib" ]]; then
-    echo "error: packaged harn-modules still contains a mirrored src/stdlib tree" >&2
-    exit 1
-  fi
-
-  if grep -R '\.\./harn-\(vm\|stdlib\)' "$modules_pkg/src" >/dev/null; then
-    echo "error: packaged harn-modules contains workspace-relative stdlib includes" >&2
-    exit 1
-  fi
-
-  echo "=== Check extracted harn-modules package ==="
-  CARGO_TARGET_DIR="$tmp/target-modules" cargo check --manifest-path "$modules_pkg/Cargo.toml"
+modules_crate="$target_dir/package/harn-modules-$modules_version.crate"
+if [[ ! -f "$modules_crate" ]]; then
+  echo "error: expected package archive missing: $modules_crate" >&2
+  exit 1
 fi
+
+tar -xzf "$modules_crate" -C "$tmp"
+modules_pkg="$tmp/harn-modules-$modules_version"
+inspect_packaged_includes "$modules_pkg" "harn-modules"
+
+echo "=== Inspect harn-modules package stdlib use ==="
+if [[ -e "$modules_pkg/src/stdlib" ]]; then
+  echo "error: packaged harn-modules still contains a mirrored src/stdlib tree" >&2
+  exit 1
+fi
+
+if grep -R '\.\./harn-\(vm\|stdlib\)' "$modules_pkg/src" >/dev/null; then
+  echo "error: packaged harn-modules contains workspace-relative stdlib includes" >&2
+  exit 1
+fi
+
+echo "=== Check extracted harn-modules package ==="
+CARGO_TARGET_DIR="$tmp/target-modules" \
+  cargo check --manifest-path "$modules_pkg/Cargo.toml" "${local_harn_patches[@]}"
 
 # `harn-hostlib` is a workspace path dep of `harn-cli`. Verifying it
 # packages cleanly here (a) catches scaffold issues for the crate on its
@@ -118,29 +236,26 @@ fi
 # above. The check is independent of the harn-cli step below — packaging
 # harn-hostlib does not preempt cargo's "must exist on crates.io" lookup
 # for harn-cli's version requirement on harn-hostlib.
-echo "=== Package harn-hostlib ==="
-cargo package -p harn-hostlib --allow-dirty --no-verify
+package_and_inspect_no_verify harn-hostlib
 
-# `cargo package -p harn-cli` resolves harn-cli's path deps against
-# crates.io to validate the version requirement that cargo will publish.
-# When a workspace crate (e.g. harn-stdlib or harn-hostlib) was just added and has never
-# been published, that lookup fails with "no matching package named X
-# found" — even with --no-verify, which only skips the staged build, not
-# dependency resolution. Set HARN_BOOTSTRAP_NEW_CRATES=1 (or pass
-# --skip-cli) on the first release that ships such a crate; the real
-# `cargo publish --workspace` later will still order intra-workspace
-# deps correctly. See harn#609 for the full story.
-if [[ "${HARN_BOOTSTRAP_NEW_CRATES:-0}" == "1" || "$SKIP_CLI" -eq 1 ]]; then
-  echo "=== Skip harn-cli package check (bootstrap mode) ==="
-  echo "Package verification complete (skipped harn-cli for new-crate bootstrap)"
-  exit 0
-fi
+# `harn-vm` embeds runtime fixtures and schemas. Build the packaged crate
+# instead of only creating the tarball so workspace-relative `include_str!`
+# references fail here, before a broken crate reaches crates.io.
+echo "=== Package harn-vm ==="
+cargo package -p harn-vm --allow-dirty --no-verify "${local_harn_patches[@]}"
+extract_package harn-vm "$vm_version"
+vm_pkg="$tmp/harn-vm-$vm_version"
+
+echo "=== Check extracted harn-vm package ==="
+CARGO_TARGET_DIR="$tmp/target-vm" \
+  cargo check --manifest-path "$vm_pkg/Cargo.toml" "${local_harn_patches[@]}"
 
 echo "=== Package harn-cli ==="
 if [[ "$VERIFY_CLI" -eq 1 ]]; then
-  cargo package -p harn-cli --allow-dirty
+  cargo package -p harn-cli --allow-dirty "${local_harn_patches[@]}"
 else
-  cargo package -p harn-cli --allow-dirty --no-verify
+  cargo package -p harn-cli --allow-dirty --no-verify "${local_harn_patches[@]}"
 fi
+extract_package harn-cli "$(package_version harn-cli)"
 
 echo "Package verification complete"


### PR DESCRIPTION
## Summary
- make `harn-vm` packaged sources self-contained by embedding runtime scenarios, receipt schema, and trust graph schemas/fixtures inside the crate package
- expand `scripts/verify_crate_packages.sh` to package/inspect every workspace crate and reject missing or package-escaping `include_str!`/`include_bytes!` targets
- add CI coverage for package verification so crates.io-only install failures are caught before release

## Validation
- `bash -n scripts/verify_crate_packages.sh`
- `actionlint .github/workflows/ci.yml`
- `cargo fmt --all -- --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/tmp/harn-target-package ./scripts/verify_crate_packages.sh`
- `CARGO_TARGET_DIR=/tmp/harn-target-package ./scripts/verify_crate_packages.sh --verify-cli`
- `CARGO_TARGET_DIR=/tmp/harn-target-main cargo test -p harn-vm embedded_`
- pre-push hook: targeted Rust checks, affected Harn fmt/lint, markdown lint, generated-doc/highlight checks
