### PR TITLE
[codex] Add persona crystallization proposals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ condensed series summaries instead of full per-patch history.
 
 ### Added
 
+- **Persona-aware crystallization proposals (#1080).** `std/personas/prelude`
+  now includes `persona_crystallization_candidates(...)` and
+  `persona_crystallization_bundle(...)` for mining successful repair-worker
+  receipts after the hosted-history gate. The helper emits the existing
+  `harn.crystallization.candidate.bundle` shape with matched traces, shadow
+  comparison, savings estimates, and a literal Harn `@step` patch for persona
+  package review.
 - **Skill provenance endorsement chains (#933).** Skill signatures now use
   `harn-skill-sig/v2` with an author signature plus one or more trusted
   endorsement signatures. Added `harn skill endorse`, `harn skill who-signed`,

--- a/conformance/tests/concurrency/supervisor_restart_window.harn
+++ b/conformance/tests/concurrency/supervisor_restart_window.harn
@@ -20,8 +20,12 @@ pipeline default() {
       ],
     },
   )
-  sleep(30ms)
-  let state = supervisor_state(sup)
+  var state = supervisor_state(sup)
+  let deadline_ms = timestamp() * 1000 + 250
+  while state.status != "completed" && timestamp() * 1000 < deadline_ms {
+    sleep(5ms)
+    state = supervisor_state(sup)
+  }
   println(atomic_get(starts))
   println(state.status)
   println(state.children[0].status)

--- a/conformance/tests/personas/prelude_persona_crystallization.expected
+++ b/conformance/tests/personas/prelude_persona_crystallization.expected
@@ -1,0 +1,11 @@
+gated
+0
+harn.crystallization.candidate.bundle
+candidate
+3
+true
+3
+merge-captain-workflows
+true
+true
+1

--- a/conformance/tests/personas/prelude_persona_crystallization.harn
+++ b/conformance/tests/personas/prelude_persona_crystallization.harn
@@ -1,0 +1,64 @@
+import {
+  persona_crystallization_bundle,
+  persona_crystallization_candidates,
+} from "std/personas/prelude"
+
+fn repair_run(id, repo, status = "completed") {
+  return {
+    _type: "merge_captain.repair_run",
+    id: id,
+    persona: "merge_captain",
+    status: status,
+    trace_id: id + "-trace",
+    bundle: {
+      kind: "ci_failure",
+      repo: repo,
+      failing_checks: ["ci / rust"],
+      allowed_write_scope: ["crates/harn-vm/**"],
+      required_verification: [{name: "vm", command: "cargo test -p harn-vm"}],
+    },
+    output: {
+      diagnosis: "retry-safe deterministic validator drift",
+      files_changed: [{path: "crates/harn-vm/src/lib.rs", action: "modified"}],
+      tests_run: [{name: "vm", command: "cargo test -p harn-vm", status: "ok"}],
+      commits_created: [{sha: "abc123", subject: "fix validator drift"}],
+      push_result: {pushed: true, ref: "origin/fix", sha: "abc123", force_with_lease: true},
+      residual_risk: "low",
+    },
+    downstream_action: "enqueue_merge_queue",
+    agent_loop: {model_calls: 1, input_tokens: 100, output_tokens: 20, cost_usd: 0.01, wall_ms: 5000},
+    validation_errors: [],
+  }
+}
+
+pipeline test(task) {
+  let gated = persona_crystallization_candidates(
+    [
+      repair_run("r1", "burin-labs/harn"),
+      repair_run("r2", "burin-labs/harn"),
+      repair_run("r3", "burin-labs/harn"),
+    ],
+    {hosted_history_days: 30},
+  )
+  println(gated.status)
+  println(len(gated.candidates))
+  let history = [
+    repair_run("r1", "burin-labs/harn"),
+    repair_run("r2", "burin-labs/harn"),
+    repair_run("r3", "burin-labs/harn"),
+    repair_run("bad", "burin-labs/harn", "validators_failed"),
+  ]
+  let bundle = persona_crystallization_bundle(
+    history,
+    {hosted_history_days: 91, min_examples: 3, package_name: "merge-captain-workflows"},
+  )
+  println(bundle.schema)
+  println(bundle.kind)
+  println(len(bundle.source_traces))
+  println(bundle.shadow.pass)
+  println(bundle.savings.model_calls_avoided)
+  println(bundle.workflow.package_name)
+  println(bundle.patch.contains("@step"))
+  println(bundle.patch.contains("dispatch"))
+  println(len(bundle.report.rejected))
+}

--- a/crates/harn-stdlib/src/stdlib/stdlib_personas_prelude.harn
+++ b/crates/harn-stdlib/src/stdlib/stdlib_personas_prelude.harn
@@ -719,3 +719,330 @@ pub fn with_approval_gate(approval_kind, step_fn, options = nil) {
     }
   }
 }
+
+fn __prelude_persona_repair_record(entry) {
+  return entry?.repair_run ?? entry
+}
+
+fn __prelude_persona_repair_status(record) -> string {
+  return lowercase(to_string(record?.status ?? ""))
+}
+
+fn __prelude_persona_repair_succeeded(record) -> bool {
+  let status = __prelude_persona_repair_status(record)
+  let validation_errors = record?.validation_errors ?? []
+  return (status == "completed" || status == "success") && len(validation_errors) == 0
+}
+
+fn __prelude_persona_repair_persona(record, opts) -> string {
+  return to_string(
+    record?.persona
+      ?? record?.parent_receipt_ref?.persona
+      ?? record?.bundle?.persona
+      ?? opts?.persona
+      ?? "persona",
+  )
+}
+
+fn __prelude_persona_downstream_action(record) -> string {
+  return to_string(
+    record?.downstream_action
+      ?? record?.next_action
+      ?? record?.merge_receipt?.action
+      ?? record?.receipt?.action
+      ?? record?.parent_receipt_ref?.next_action
+      ?? "unknown",
+  )
+}
+
+fn __prelude_persona_input_shape(record) {
+  let bundle = record?.bundle ?? {}
+  return {
+    kind: bundle?.kind ?? record?.kind ?? "repair",
+    repo: bundle?.repo ?? record?.repo ?? "",
+    conflict_paths: bundle?.conflict_paths ?? [],
+    failing_checks: bundle?.failing_checks ?? [],
+    allowed_write_scope: bundle?.allowed_write_scope ?? [],
+    required_verification: bundle?.required_verification ?? [],
+    release_facts: bundle?.release_facts,
+    extra_context: bundle?.extra_context ?? {},
+  }
+}
+
+fn __prelude_persona_output_shape(record) {
+  let output = record?.output ?? {}
+  let push = output?.push_result
+  return {
+    diagnosis: output?.diagnosis ?? "",
+    files_changed: output?.files_changed ?? [],
+    tests_run: output?.tests_run ?? [],
+    commits_created: (output?.commits_created ?? []).map({ commit -> return {subject: commit?.subject ?? ""} }),
+    push_result: if push == nil {
+      nil
+    } else {
+      {pushed: push?.pushed ?? false, ref: push?.ref ?? "", force_with_lease: push?.force_with_lease}
+    },
+    residual_risk: output?.residual_risk ?? "",
+    release_outputs: output?.release_outputs,
+  }
+}
+
+fn __prelude_persona_pattern_key(record, opts) -> string {
+  let seed = {
+    persona: __prelude_persona_repair_persona(record, opts),
+    worker: record?.worker ?? record?.agent ?? "repair_worker",
+    input_digest: __prelude_digest(__prelude_persona_input_shape(record)),
+    output_digest: __prelude_digest(__prelude_persona_output_shape(record)),
+    downstream_action: __prelude_persona_downstream_action(record),
+  }
+  return "persona-pattern-" + substring(sha256(json_stringify(seed)), 0, 16)
+}
+
+fn __prelude_persona_pattern_example(record, index, opts) {
+  let trace_id = record?.trace_id
+    ?? record?.parent_receipt_ref?.sweep_id
+    ?? record?.bundle?.parent?.sweep_id
+    ?? ("repair-trace-" + to_string(index + 1))
+  return {
+    trace_id: to_string(trace_id),
+    source_hash: record?.source_hash ?? __prelude_digest(record),
+    receipt_id: record?.id ?? record?.receipt_id,
+    persona: __prelude_persona_repair_persona(record, opts),
+    repair_kind: __prelude_persona_input_shape(record).kind,
+    downstream_action: __prelude_persona_downstream_action(record),
+    input_digest: __prelude_digest(__prelude_persona_input_shape(record)),
+    output_digest: __prelude_digest(__prelude_persona_output_shape(record)),
+  }
+}
+
+fn __prelude_persona_identifier(value) -> string {
+  var clean = regex_replace("[^A-Za-z0-9_]+", "_", lowercase(trim(to_string(value ?? "repair"))))
+  clean = regex_replace("^_+|_+$", "", clean)
+  if clean == "" {
+    return "repair"
+  }
+  if regex_match("^[0-9]", clean) != nil {
+    clean = "step_" + clean
+  }
+  return clean
+}
+
+fn __prelude_persona_patch_for_group(group, opts) -> string {
+  let persona = __prelude_persona_identifier(group.persona)
+  let kind = __prelude_persona_identifier(group.repair_kind)
+  let downstream = __prelude_persona_identifier(group.downstream_action)
+  let step_name = opts?.step_name ?? "crystallized_${persona}_${kind}_${downstream}"
+  let function_name = opts?.function_name ?? (step_name + "_step")
+  let key = group.key
+  let input_digest = group.input_digest
+  let output_digest = group.output_digest
+  let action = group.downstream_action
+  let anchor_step = opts?.anchor_step ?? "dispatch_repair_workers"
+  return "// Insert after persona step: ${anchor_step}\n@step(name: \"${step_name}\", receipt: audit, error_boundary: fail)\nfn ${function_name}(ctx) {\n  return {\n    _type: \"harn.persona.crystallized_repair.v1\",\n    pattern_key: \"${key}\",\n    status: \"matched\",\n    input_digest: \"${input_digest}\",\n    output_digest: \"${output_digest}\",\n    downstream_action: \"${action}\",\n    context: ctx,\n  }\n}"
+}
+
+fn __prelude_persona_candidate(group, opts) {
+  let step_name = opts?.step_name
+    ?? "crystallized_${__prelude_persona_identifier(group.persona)}_${__prelude_persona_identifier(group.repair_kind)}_${__prelude_persona_identifier(group.downstream_action)}"
+  let package_name = opts?.package_name ?? "${__prelude_persona_identifier(group.persona)}-workflows"
+  let model_calls = group.model_calls
+  let input_tokens = group.input_tokens
+  let output_tokens = group.output_tokens
+  let cost_usd = group.cost_usd
+  let wall_ms = group.wall_ms
+  let patch = __prelude_persona_patch_for_group(group, opts + {step_name: step_name})
+  return {
+    id: "candidate-" + substring(sha256(group.key), 0, 16),
+    name: step_name,
+    confidence: 0.9,
+    examples: group.examples,
+    repair_kind: group.repair_kind,
+    downstream_action: group.downstream_action,
+    deterministic_step: {
+      name: step_name,
+      anchor_step: opts?.anchor_step ?? "dispatch_repair_workers",
+      patch: patch,
+      input_digest: group.input_digest,
+      output_digest: group.output_digest,
+    },
+    savings: {
+      model_calls_avoided: model_calls,
+      input_tokens_avoided: input_tokens,
+      output_tokens_avoided: output_tokens,
+      estimated_cost_usd_avoided: cost_usd,
+      wall_ms_avoided: wall_ms,
+      cpu_runtime_cost_usd: 0.0,
+      remaining_model_calls: 0,
+    },
+    shadow: {
+      pass: true,
+      compared_traces: group.count,
+      failures: [],
+      traces: group.examples
+        .map(
+        { example -> return {trace_id: example.trace_id, pass: true, details: ["exact input/output/downstream recurrence"]} },
+      ),
+    },
+    promotion: {
+      package_name: package_name,
+      workflow_version: opts?.workflow_version ?? "0.1.0",
+      rollout_policy: opts?.rollout_policy ?? "shadow_then_canary",
+      rollback_target: "remove the promoted @step and fall back to repair_worker",
+      approver: opts?.approver,
+      author: opts?.author,
+    },
+  }
+}
+
+/**
+ * Mine successful repair-worker records for exact repeated
+ * input/output/downstream patterns that are safe to propose as a
+ * deterministic persona `@step`.
+ */
+pub fn persona_crystallization_candidates(history, options = nil) {
+  let opts = options ?? {}
+  let min_examples = opts?.min_examples ?? 3
+  let hosted_history_days = opts?.hosted_history_days ?? 0
+  let min_hosted_history_days = opts?.min_hosted_history_days ?? 90
+  if hosted_history_days < min_hosted_history_days {
+    return {
+      ok: false,
+      status: "gated",
+      candidates: [],
+      rejected: [],
+      observed_records: len(history ?? []),
+      min_examples: min_examples,
+      hosted_history_days: hosted_history_days,
+      min_hosted_history_days: min_hosted_history_days,
+      warnings: ["persona crystallization requires hosted-run history before promotion"],
+    }
+  }
+  var groups = {}
+  var order = []
+  var rejected = []
+  var index = 0
+  for entry in history ?? [] {
+    let record = __prelude_persona_repair_record(entry)
+    if !__prelude_persona_repair_succeeded(record) {
+      rejected = rejected + [{index: index, reason: "repair run did not complete cleanly"}]
+      index += 1
+      continue
+    }
+    let key = __prelude_persona_pattern_key(record, opts)
+    if groups[key] == nil {
+      let input_shape = __prelude_persona_input_shape(record)
+      groups[key] = {
+        key: key,
+        count: 0,
+        examples: [],
+        persona: __prelude_persona_repair_persona(record, opts),
+        repair_kind: input_shape.kind,
+        downstream_action: __prelude_persona_downstream_action(record),
+        input_digest: __prelude_digest(input_shape),
+        output_digest: __prelude_digest(__prelude_persona_output_shape(record)),
+        model_calls: 0,
+        input_tokens: 0,
+        output_tokens: 0,
+        cost_usd: 0.0,
+        wall_ms: 0,
+      }
+      order = order + [key]
+    }
+    let group = groups[key]
+    let model_calls_inc = record?.agent_loop?.model_calls ?? record?.agent_loop?.llm?.iterations ?? 1
+    let input_tokens_inc = record?.agent_loop?.input_tokens ?? record?.agent_loop?.llm?.input_tokens ?? 0
+    let output_tokens_inc = record?.agent_loop?.output_tokens ?? record?.agent_loop?.llm?.output_tokens ?? 0
+    let cost_usd_inc = record?.agent_loop?.cost_usd ?? 0.0
+    let wall_ms_inc = record?.agent_loop?.wall_ms ?? record?.duration_ms ?? 0
+    groups[key] = group
+      + {
+      count: group.count + 1,
+      examples: group.examples + [__prelude_persona_pattern_example(record, index, opts)],
+      model_calls: group.model_calls + model_calls_inc,
+      input_tokens: group.input_tokens + input_tokens_inc,
+      output_tokens: group.output_tokens + output_tokens_inc,
+      cost_usd: group.cost_usd + cost_usd_inc,
+      wall_ms: group.wall_ms + wall_ms_inc,
+    }
+    index += 1
+  }
+  var candidates = []
+  for key in order {
+    let group = groups[key]
+    if group.count >= min_examples {
+      candidates = candidates + [__prelude_persona_candidate(group, opts)]
+    } else {
+      rejected = rejected + [{pattern_key: key, reason: "fewer than min_examples", examples: group.count}]
+    }
+  }
+  return {
+    ok: len(candidates) > 0,
+    status: if len(candidates) > 0 {
+      "candidate"
+    } else {
+      "no_candidate"
+    },
+    candidates: candidates,
+    rejected: rejected,
+    observed_records: len(history ?? []),
+    min_examples: min_examples,
+    hosted_history_days: hosted_history_days,
+    min_hosted_history_days: min_hosted_history_days,
+    warnings: [],
+  }
+}
+
+/**
+ * Return a `harn.crystallization.candidate.bundle`-shaped proposal for
+ * the strongest persona recurrence candidate. The patch is Harn source
+ * that reviewers can apply to the persona package after shadow/eval review.
+ */
+pub fn persona_crystallization_bundle(history, options = nil) {
+  let opts = options ?? {}
+  let report = persona_crystallization_candidates(history, opts)
+  if !report.ok {
+    return {
+      schema: "harn.crystallization.candidate.bundle",
+      schema_version: 1,
+      kind: "rejected",
+      candidate_id: nil,
+      title: "persona crystallization candidate",
+      report: report,
+      warnings: report.warnings,
+    }
+  }
+  var candidate = report.candidates[0]
+  for current in report.candidates {
+    if len(current.examples) > len(candidate.examples)
+      || (len(current.examples) == len(candidate.examples)
+      && current.savings.model_calls_avoided > candidate.savings.model_calls_avoided) {
+      candidate = current
+    }
+  }
+  return {
+    schema: "harn.crystallization.candidate.bundle",
+    schema_version: 1,
+    kind: "candidate",
+    candidate_id: candidate.id,
+    title: candidate.name,
+    workflow: {
+      path: "workflow.harn",
+      name: candidate.name,
+      package_name: candidate.promotion.package_name,
+      package_version: candidate.promotion.workflow_version,
+    },
+    source_traces: candidate.examples,
+    deterministic_steps: [candidate.deterministic_step],
+    fuzzy_steps: [],
+    side_effects: [],
+    capabilities: [],
+    required_secrets: [],
+    savings: candidate.savings,
+    shadow: candidate.shadow,
+    eval_pack: {path: "harn.eval.toml", link: opts?.eval_pack_link},
+    promotion: candidate.promotion,
+    patch: candidate.deterministic_step.patch,
+    report: report,
+    warnings: [],
+  }
+}

--- a/docs/src/personas/prelude.md
+++ b/docs/src/personas/prelude.md
@@ -16,6 +16,8 @@ import {
   parallel_sweep_with_circuit_breaker,
   with_audit_receipt,
   with_approval_gate,
+  persona_crystallization_candidates,
+  persona_crystallization_bundle,
 } from "std/personas/prelude"
 ```
 
@@ -74,3 +76,21 @@ wrapper that requires an approval before running `step_fn`. Pass a recorded
 runtime for one; without either, the wrapper returns `status: "suspended"` and
 does not block indefinitely. Denied approvals return `status: "denied"` with
 the approval recorded in the receipt.
+
+`persona_crystallization_candidates(history, options?)` scans successful
+repair-worker records for exact recurrence: the same persona, repair-worker
+input shape, repair-worker output shape, and downstream action. It defaults to
+`min_examples: 3` and `min_hosted_history_days: 90`, so short local fixtures
+return `status: "gated"` instead of pretending they are production signal.
+Callers can pass `hosted_history_days` from their hosted history query, plus
+`persona`, `package_name`, `author`, `approver`, and `rollout_policy` metadata.
+
+`persona_crystallization_bundle(history, options?)` wraps the strongest
+candidate in the existing
+`harn.crystallization.candidate.bundle`-shaped envelope. The bundle includes
+the matched source traces, a deterministic shadow comparison over the exact
+recurrence set, savings estimates from the avoided repair-worker model calls,
+and a literal Harn `@step` patch that reviewers can apply to the persona
+package after eval review. The helper does not edit files or mutate a persona;
+promotion still goes through review, shadow/eval gates, human approval, and a
+normal package PR.

--- a/docs/src/workflow-crystallization.md
+++ b/docs/src/workflow-crystallization.md
@@ -364,6 +364,51 @@ candidate steps generated for `agent_recovery_advice` events carry an
 boundary so hosts must not re-run a failing step without a human
 acknowledging the advice.
 
+## Persona-aware crystallization
+
+Generic crystallization mines repeated traces. Persona-aware crystallization is
+the narrower loop for durable personas that repeatedly call a repair-worker for
+the same shape of problem. The stdlib helper
+`persona_crystallization_bundle(history, options?)` lives in
+`std/personas/prelude` and keeps recurrence selection in Harn orchestration:
+Rust provides receipt/run history, bundle validation, diff, and replay
+primitives, while Harn persona code decides whether a recurring worker result
+should become a deterministic `@step`.
+
+The helper is deliberately conservative. It proposes only exact recurrence:
+
+- same persona and repair worker
+- same repair-worker input shape
+- same repair-worker output shape
+- same downstream action
+- at least `min_examples` successful records
+- at least `min_hosted_history_days` of hosted history, defaulting to 90 days
+
+When the gate passes, the returned proposal uses the existing
+`harn.crystallization.candidate.bundle` shape. It includes source trace
+references, a deterministic shadow comparison over the matched records, savings
+from avoided repair-worker model calls, and a literal Harn `@step` patch. The
+patch is review material, not an automatic mutation: promotion still runs
+historical shadow fixtures, eval-pack delta, human approval, a package version
+bump, and a normal PR against the persona package.
+
+```harn
+import { persona_crystallization_bundle } from "std/personas/prelude"
+
+pipeline propose_persona_step(repair_runs) {
+  return persona_crystallization_bundle(
+    repair_runs,
+    {
+      persona: "merge_captain",
+      hosted_history_days: 91,
+      min_examples: 3,
+      package_name: "merge-captain-workflows",
+      approver: "release-lead@example.com",
+    },
+  )
+}
+```
+
 ### Out of scope here
 
 This subcommand is intentionally a one-shot ingest path. It does not:
@@ -374,7 +419,5 @@ This subcommand is intentionally a one-shot ingest path. It does not:
 - introduce a new workflow loader or Burin UI mechanism (Burin local
   loading lives in
   [burin-code#516](https://github.com/burin-labs/burin-code/issues/516)),
-- host a tenant candidate inbox (that lives in
-  [harn-cloud#145](https://github.com/burin-labs/harn-cloud/issues/145)),
-- or mine across many production histories (that lives in
-  [harn#1080](https://github.com/burin-labs/harn/issues/1080)).
+- or host a tenant candidate inbox (that lives in
+  [harn-cloud#145](https://github.com/burin-labs/harn-cloud/issues/145)).


### PR DESCRIPTION
## Summary

- add `std/personas/prelude` helpers for persona-aware repair-worker recurrence mining
- emit `harn.crystallization.candidate.bundle`-shaped proposals with matched traces, shadow comparison, savings, and a literal Harn `@step` patch
- document the persona-aware crystallization path and tighten the supervisor restart-window conformance test away from a fixed sleep

Closes #1080.

## Verification

- `CARGO_TARGET_DIR=/tmp/harn-target-issue1080 cargo run --quiet --bin harn -- test conformance --filter prelude_persona_crystallization`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue1080 make fmt-harn`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue1080 make lint-harn`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue1080 make check-docs-snippets`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue1080 cargo test -p harn-stdlib`
- `HARN_LLM_CALLS_DISABLED=1 CARGO_TARGET_DIR=/tmp/harn-target-issue1080 cargo run --quiet --bin harn -- test conformance`
