### PR TITLE
Add persona steel-thread conformance harness

### DIFF
--- a/conformance/tests/personas/persona_steel_thread_deploy_captain.expected
+++ b/conformance/tests/personas/persona_steel_thread_deploy_captain.expected
@@ -1,0 +1,2 @@
+persona_steel_thread deploy
+true

--- a/conformance/tests/personas/persona_steel_thread_deploy_captain.harn
+++ b/conformance/tests/personas/persona_steel_thread_deploy_captain.harn
@@ -1,0 +1,107 @@
+import { with_audit_receipt } from "std/personas/prelude"
+import {
+  assert_golden_transcript,
+  assert_receipt_field,
+  assert_step_emitted,
+  assert_step_received,
+  assert_steps_ran,
+  step_assertions_begin,
+  step_assertions_end,
+} from "std/testing"
+
+fn deploy_receipt(step, result) {
+  let wrapped = with_audit_receipt(
+    fn() { return result },
+    {persona: "deploy_captain", step: step, started_at: "2026-01-01T00:00:00Z"},
+  )
+  return wrapped()
+}
+
+@persona(name: "deploy_captain")
+fn deploy_captain(ctx) {
+  let merged = wait_for_pr_merged(ctx)
+  let staging = deploy_to_staging(merged.result)
+  let smoke = smoke_test(staging.result)
+  let promoted = promote_production(smoke.result)
+  return {merged: merged, staging: staging, smoke: smoke, promoted: promoted}
+}
+
+@step(name: "wait_for_pr_merged")
+fn wait_for_pr_merged(ctx) {
+  return deploy_receipt(
+    "wait_for_pr_merged",
+    {repo: ctx.repo, pr: ctx.pr, wait_source: "github.pull_request_merged", polls: 2, merged: true},
+  )
+}
+
+@step(name: "deploy_to_staging")
+fn deploy_to_staging(pr_state) {
+  return deploy_receipt(
+    "deploy_to_staging",
+    {
+      environment: "staging",
+      pr: pr_state.pr,
+      deployment_id: "dep-staging-" + to_string(pr_state.pr),
+      side_effect: "planned",
+    },
+  )
+}
+
+@step(name: "smoke_test")
+fn smoke_test(deployment) {
+  return deploy_receipt(
+    "smoke_test",
+    {
+      deployment_id: deployment.deployment_id,
+      checks: ["http_200", "migration_status", "error_budget"],
+      passed: true,
+    },
+  )
+}
+
+@step(name: "promote_production")
+fn promote_production(smoke) {
+  return deploy_receipt(
+    "promote_production",
+    {
+      deployment_id: smoke.deployment_id,
+      environment: "production",
+      promoted: smoke.passed,
+      approval_boundary: "act_with_approval",
+    },
+  )
+}
+
+pipeline test() {
+  step_assertions_begin("deploy_captain")
+  let result = deploy_captain({repo: "burin-labs/harn", pr: 1078})
+  assert_steps_ran(["wait_for_pr_merged", "deploy_to_staging", "smoke_test", "promote_production"])
+  assert_step_received("wait_for_pr_merged", { event -> event.args[0].pr == 1078 })
+  assert_step_emitted(
+    "wait_for_pr_merged",
+    { event -> event.output.result.polls == 2 && event.output.result.merged },
+  )
+  assert_step_emitted("promote_production", { event -> event.output.result.promoted })
+  assert_receipt_field(result.promoted.receipt, "/status", "success")
+  assert_golden_transcript(
+    {
+      persona: "deploy_captain",
+      events: [
+        {step: "wait_for_pr_merged", payload: {wait_source: "github.pull_request_merged", polls: 2}},
+        {step: "deploy_to_staging", payload: {environment: "staging"}},
+        {step: "promote_production", payload: {environment: "production", promoted: true}},
+      ],
+    },
+    {
+      persona: "deploy_captain",
+      events: [
+        {step: "wait_for_pr_merged", payload: result.merged.result, observed_at_ms: 1},
+        {step: "deploy_to_staging", payload: result.staging.result},
+        {step: "promote_production", payload: result.promoted.result},
+      ],
+    },
+  )
+  step_assertions_end()
+  println("persona_steel_thread deploy")
+  println(result.promoted.result.promoted)
+}

--- a/conformance/tests/personas/persona_steel_thread_merge_captain.expected
+++ b/conformance/tests/personas/persona_steel_thread_merge_captain.expected
@@ -1,0 +1,2 @@
+persona_steel_thread merge
+true

--- a/conformance/tests/personas/persona_steel_thread_merge_captain.harn
+++ b/conformance/tests/personas/persona_steel_thread_merge_captain.harn
@@ -1,0 +1,143 @@
+import { handoff_artifact, workflow_result_run } from "std/agents"
+import { handoff_routed } from "std/handoffs"
+import { with_audit_receipt } from "std/personas/prelude"
+import {
+  assert_handoff_emitted,
+  assert_receipt_field,
+  assert_step_emitted,
+  assert_step_received,
+  assert_steps_ran,
+  step_assertions_begin,
+  step_assertions_end,
+} from "std/testing"
+
+fn merge_routes() {
+  return [
+    {
+      id: "semantic-conflict-review",
+      kind: "semantic_conflict_ticket",
+      from: "merge_captain",
+      route: [{target: "review_captain", when: "always"}],
+    },
+  ]
+}
+
+fn pr_variants() {
+  var prs = []
+  var n = 1
+  while n <= 50 {
+    prs = prs
+      .push(
+      {
+        number: n,
+        draft: n % 5 == 0,
+        checks: if n % 7 == 0 {
+          "failing"
+        } else {
+          "green"
+        },
+        conflict: n % 11 == 0,
+      },
+    )
+    n += 1
+  }
+  return prs
+}
+
+@persona(name: "merge_captain")
+fn merge_captain(ctx) {
+  let prs = fetch_open_prs(ctx)
+  var merged = []
+  var handoffs = []
+  for pr in prs {
+    let decision = classify_pr(pr)
+    if decision.action == "admin_merge" {
+      let receipt = admin_merge(pr)
+      merged = merged.push(receipt.result.number)
+    } else if decision.action == "handoff" {
+      handoffs = handoffs.push(semantic_conflict_ticket(pr))
+    }
+  }
+  let run = finalize_merge_sweep(handoffs)
+  return {merged: merged, handoffs: handoffs, run: run}
+}
+
+@step(name: "fetch_open_prs")
+fn fetch_open_prs(ctx) {
+  return ctx.prs
+}
+
+@step(name: "classify_pr")
+fn classify_pr(pr) {
+  if pr.draft || pr.checks != "green" {
+    return {action: "wait", reason: "not mergeable", number: pr.number}
+  }
+  if pr.conflict {
+    return {action: "handoff", reason: "semantic conflict", number: pr.number}
+  }
+  return {action: "admin_merge", reason: "green", number: pr.number}
+}
+
+@step(name: "admin_merge")
+fn admin_merge(pr) {
+  let wrapped = with_audit_receipt(
+    fn() { return {number: pr.number, method: "admin", side_effect: "planned"} },
+    {persona: "merge_captain", step: "admin_merge", started_at: "2026-01-01T00:00:00Z"},
+  )
+  return wrapped()
+}
+
+@step(name: "semantic_conflict_ticket")
+fn semantic_conflict_ticket(pr) {
+  return handoff_routed(
+    {
+      id: "semantic-conflict-" + to_string(pr.number),
+      kind: "semantic_conflict_ticket",
+      source_persona: "merge_captain",
+      task: "Review semantic conflict before merge",
+      reason: "PR #" + to_string(pr.number) + " needs human review",
+      requested_capabilities: ["review"],
+      allowed_side_effects: ["comment_on_pr"],
+    },
+    merge_routes(),
+    {},
+  )
+}
+
+@step(name: "finalize_merge_sweep")
+fn finalize_merge_sweep(handoffs) {
+  return workflow_result_run(
+    "merge captain steel thread",
+    "merge_captain",
+    {visible_text: "merge sweep complete"},
+    handoffs.map({ item -> handoff_artifact(item) }),
+    {},
+  )
+}
+
+pipeline test() {
+  let green = {number: 42, draft: false, checks: "green", conflict: false}
+  step_assertions_begin("merge_captain")
+  let happy = merge_captain({prs: [green]})
+  assert_steps_ran(["fetch_open_prs", "classify_pr", "admin_merge", "finalize_merge_sweep"])
+  assert_step_received("classify_pr", { event -> event.args[0].number == 42 })
+  assert_step_emitted("admin_merge", { event -> event.output.receipt.status == "success" })
+  assert_receipt_field(assert_step_emitted("admin_merge").output.receipt, "/status", "success")
+  assert_eq(happy.merged, [42])
+  step_assertions_begin("merge_captain")
+  let conflicted = merge_captain({prs: [{number: 43, draft: false, checks: "green", conflict: true}]})
+  assert_steps_ran(
+    ["fetch_open_prs", "classify_pr", "semantic_conflict_ticket", "finalize_merge_sweep"],
+  )
+  assert_handoff_emitted(conflicted.run, "semantic_conflict_ticket", "review_captain")
+  step_assertions_begin("merge_captain")
+  let variants = merge_captain({prs: pr_variants()})
+  for pr in pr_variants() {
+    if pr.draft {
+      assert(!contains(variants.merged, pr.number), "draft PR was admin-merged")
+    }
+  }
+  step_assertions_end()
+  println("persona_steel_thread merge")
+  println(len(variants.merged) > 0)
+}

--- a/conformance/tests/personas/persona_steel_thread_release_captain.expected
+++ b/conformance/tests/personas/persona_steel_thread_release_captain.expected
@@ -1,0 +1,2 @@
+persona_steel_thread release
+true

--- a/conformance/tests/personas/persona_steel_thread_release_captain.harn
+++ b/conformance/tests/personas/persona_steel_thread_release_captain.harn
@@ -1,0 +1,178 @@
+import { with_audit_receipt } from "std/personas/prelude"
+import { prompt_fragment, prompt_library, prompt_library_payload } from "std/prompt_library"
+import {
+  assert_golden_transcript,
+  assert_receipt_field,
+  assert_step_emitted,
+  assert_step_received,
+  assert_steps_ran,
+  step_assertions_begin,
+  step_assertions_end,
+} from "std/testing"
+
+fn release_receipt(step, result) {
+  let wrapped = with_audit_receipt(
+    fn() { return result },
+    {persona: "release_captain", step: step, started_at: "2026-01-01T00:00:00Z"},
+  )
+  return wrapped()
+}
+
+@persona(name: "release_captain")
+fn release_captain(fixture) {
+  let branch = setup_branch(fixture)
+  let stash = stash_dirty_worktree(branch.result)
+  let changelog = analyze_changelog(stash.result)
+  let notes = rewrite_release_notes(changelog.result)
+  let recovered = recover_shell_error({step: "cargo publish --dry-run", stderr: "network unavailable"})
+  let pr = plan_release_pr(notes.result + {recovery: recovered.result})
+  let merge = enable_auto_merge(pr.result)
+  return {
+    branch: branch,
+    stash: stash,
+    changelog: changelog,
+    notes: notes,
+    recovery: recovered,
+    pr: pr,
+    auto_merge: merge,
+  }
+}
+
+@step(name: "setup_branch")
+fn setup_branch(fixture) {
+  return release_receipt(
+    "setup_branch",
+    {
+      repo: fixture.repo,
+      from: fixture.starting_branch,
+      to: fixture.release_branch,
+      mode: "fake_git",
+      side_effect: "planned",
+    },
+  )
+}
+
+@step(name: "stash_dirty_worktree")
+fn stash_dirty_worktree(branch) {
+  return release_receipt(
+    "stash_dirty_worktree",
+    {stashed: true, branch: branch.to, unstash_policy: "restore_after_plan"},
+  )
+}
+
+@step(name: "analyze_changelog")
+fn analyze_changelog(state) {
+  return release_receipt(
+    "analyze_changelog",
+    {
+      branch: state.branch,
+      latest_tag: "v0.7.55",
+      missing_entries: ["fix release harness fixture ingest"],
+      deterministic: true,
+    },
+  )
+}
+
+@step(name: "rewrite_release_notes")
+fn rewrite_release_notes(changelog) {
+  let library = prompt_library(
+    [
+      prompt_fragment(
+        "release-note-rewrite",
+        "Rewrite {{count}} changelog entries for maintainers.",
+        {path: "prompts/release-note-rewrite.harn.prompt", provenance: "release-harness-fixture"},
+      ),
+    ],
+  )
+  let payload = prompt_library_payload(library, "release-note-rewrite", {count: len(changelog.missing_entries)})
+  return release_receipt(
+    "rewrite_release_notes",
+    {text: payload.text, prompt: payload, agentic_checkpoint: true, review_required: true},
+  )
+}
+
+@step(name: "recover_shell_error")
+fn recover_shell_error(error) {
+  return release_receipt(
+    "recover_shell_error",
+    {
+      failed_step: error.step,
+      stderr_digest: "sha256:" + sha256(error.stderr),
+      fed_back_to_model_context: true,
+      advice: "retry after network recovers; do not tag or publish in shadow mode",
+    },
+  )
+}
+
+@step(name: "plan_release_pr")
+fn plan_release_pr(notes) {
+  return release_receipt(
+    "plan_release_pr",
+    {
+      title: "Release v0.7.56",
+      body: notes.text,
+      auto_merge_requested: true,
+      safe_side_effects: ["create_pr_plan"],
+    },
+  )
+}
+
+@step(name: "enable_auto_merge")
+fn enable_auto_merge(pr) {
+  return release_receipt(
+    "enable_auto_merge",
+    {title: pr.title, status: "planned", live_github_side_effects: false},
+  )
+}
+
+pipeline test() {
+  step_assertions_begin("release_captain")
+  let result = release_captain(
+    {repo: "burin-labs/harn", starting_branch: "feature/release", release_branch: "release/0.7.x"},
+  )
+  assert_steps_ran(
+    [
+      "setup_branch",
+      "stash_dirty_worktree",
+      "analyze_changelog",
+      "rewrite_release_notes",
+      "recover_shell_error",
+      "plan_release_pr",
+      "enable_auto_merge",
+    ],
+  )
+  assert_step_received(
+    "setup_branch",
+    { event -> event.args[0].starting_branch == "feature/release" },
+  )
+  assert_step_emitted(
+    "rewrite_release_notes",
+    { event -> event.output.result.prompt.provenance == "release-harness-fixture" },
+  )
+  assert_step_emitted(
+    "recover_shell_error",
+    { event -> event.output.result.fed_back_to_model_context },
+  )
+  assert_receipt_field(result.auto_merge.receipt, "/status", "success")
+  assert_golden_transcript(
+    {
+      persona: "release_captain",
+      steps: [
+        {name: "setup_branch", elapsed_ms: "<ms>"},
+        {name: "rewrite_release_notes", payload: {prompt: {provenance: "release-harness-fixture"}}},
+        {name: "enable_auto_merge", payload: {live_github_side_effects: false}},
+      ],
+    },
+    {
+      persona: "release_captain",
+      steps: [
+        {name: "setup_branch", elapsed_ms: 12, extra: "ignored"},
+        {name: "rewrite_release_notes", payload: result.notes.result},
+        {name: "enable_auto_merge", payload: result.auto_merge.result},
+      ],
+    },
+  )
+  step_assertions_end()
+  println("persona_steel_thread release")
+  println(result.pr.result.auto_merge_requested)
+}

--- a/conformance/tests/stdlib/stdlib_testing_host_mock.harn
+++ b/conformance/tests/stdlib/stdlib_testing_host_mock.harn
@@ -1,6 +1,7 @@
 import {
   assert_host_call_count,
   assert_host_called,
+  assert_no_host_calls,
   clear_host_mocks,
   host_call_count,
   host_call_count_for,
@@ -14,6 +15,7 @@ import {
 
 pipeline test(task) {
   clear_host_mocks()
+  assert_no_host_calls()
   mock_host_result("workspace", "read_text", "hello", {path: "note.txt"})
   mock_host_response(
     "project",
@@ -30,12 +32,12 @@ pipeline test(task) {
   assert_eq(facts?.value, "facts")
   assert(is_err(denied))
   assert(host_was_called("workspace", "read_text", {path: "note.txt"}))
-  assert_host_called("project", "metadata_get", {namespace: "facts"}, nil)
+  assert_host_called("project", "metadata_get", {namespace: "facts"})
   assert_eq(host_call_count(), 3)
   assert_eq(host_call_count_for("project", "metadata_get"), 1)
   assert_eq(host_call_count_for("project", "metadata_set"), 1)
   assert_eq(len(host_calls()), 3)
   assert_eq(len(host_calls_for("project", "metadata_get")), 1)
-  assert_host_call_count(1, "workspace", "read_text", nil)
+  assert_host_call_count(1, "workspace", "read_text")
   println("ok")
 }

--- a/conformance/tests/stdlib/testing_step_assertions.expected
+++ b/conformance/tests/stdlib/testing_step_assertions.expected
@@ -1,0 +1,1 @@
+testing_step_assertions ok

--- a/conformance/tests/stdlib/testing_step_assertions.harn
+++ b/conformance/tests/stdlib/testing_step_assertions.harn
@@ -1,0 +1,48 @@
+import { with_audit_receipt } from "std/personas/prelude"
+import {
+  assert_golden_transcript,
+  assert_receipt_field,
+  assert_step_emitted,
+  assert_step_received,
+  assert_steps_ran,
+  step_assertions_begin,
+  step_assertions_end,
+} from "std/testing"
+
+@persona(name: "test_captain")
+fn test_captain(ctx) {
+  return checked_step(ctx)
+}
+
+@step(name: "checked_step")
+fn checked_step(ctx) {
+  let wrapped = with_audit_receipt(
+    fn() { return {value: ctx.value + ":done"} },
+    {persona: "test_captain", step: "checked_step", started_at: "2026-01-01T00:00:00Z"},
+  )
+  return wrapped()
+}
+
+pipeline test() {
+  step_assertions_begin("test_captain")
+  let result = test_captain({value: "input"})
+  assert_steps_ran(["checked_step"])
+  assert_step_received("checked_step", { event -> event.args[0].value == "input" })
+  assert_step_emitted("checked_step", { event -> event.output.result.value == "input:done" })
+  assert_receipt_field(result.receipt, "/status", "success")
+  assert_golden_transcript(
+    {events: [{type: "step", elapsed_ms: "<ms>", id: "<uuid>", payload: {value: "input:done"}}]},
+    {
+      events: [
+        {
+          type: "step",
+          elapsed_ms: 17,
+          id: "123e4567-e89b-12d3-a456-426614174000",
+          payload: {value: "input:done", extra: true},
+        },
+      ],
+    },
+  )
+  step_assertions_end()
+  println("testing_step_assertions ok")
+}

--- a/crates/harn-stdlib/src/stdlib/stdlib_testing.harn
+++ b/crates/harn-stdlib/src/stdlib/stdlib_testing.harn
@@ -1,4 +1,6 @@
 /** std/testing — helpers for writing Harn tests. */
+var __testing_step_events = []
+
 fn params_subset_match(expected, actual) {
   if expected == nil {
     return true
@@ -73,7 +75,7 @@ pub fn host_was_called(cap: string, op: string, expected_params) -> bool {
 }
 
 /** assert_host_called. */
-pub fn assert_host_called(cap: string, op: string, params, message) {
+pub fn assert_host_called(cap: string, op: string, params = nil, message = nil) {
   if host_was_called(cap, op, params) {
     return nil
   }
@@ -82,14 +84,23 @@ pub fn assert_host_called(cap: string, op: string, params, message) {
   } else {
     "Expected host call " + cap + "." + op + " with params " + to_string(params) + " to be recorded"
   }
-  return assert(false, message ?? default_message)
+  require false, message ?? default_message
+  return nil
 }
 
 /** assert_host_call_count. */
-pub fn assert_host_call_count(expected_count: int, cap: string, op: string, message) {
+pub fn assert_host_call_count(expected_count: int, cap: string, op: string, message = nil) {
   let actual_count = host_call_count_for(cap, op)
   let default_message = "Expected " + to_string(expected_count) + " host calls, got " + to_string(actual_count)
-  return assert_eq(actual_count, expected_count, message ?? default_message)
+  require actual_count == expected_count, message ?? default_message
+  return actual_count
+}
+
+/** assert_no_host_calls. */
+pub fn assert_no_host_calls(message = nil) {
+  let actual_count = host_call_count()
+  require actual_count == 0, message ?? "Expected no host calls, got " + to_string(actual_count)
+  return actual_count
 }
 
 /**
@@ -139,6 +150,107 @@ pub fn with_host_mocks(mocks, body) {
     host_mock_pop_scope()
     throw e
   }
+}
+
+fn __testing_is_callable(value) -> bool {
+  let kind = type_of(value)
+  return kind == "function" || kind == "closure" || kind == "fn"
+}
+
+fn __testing_step_event_record(ctx) {
+  var record = {
+    event: ctx?.event,
+    target: ctx?.target,
+    persona: ctx?.persona,
+    step_name: ctx?.step?.name,
+    function: ctx?.step?.function,
+    args: ctx?.step?.args ?? [],
+  }
+  if ctx?.output != nil {
+    record = record + {output: ctx.output}
+  }
+  return record
+}
+
+fn __testing_step_events_for(kind) {
+  var out = []
+  for event in __testing_step_events {
+    if event.event == kind {
+      out = out.push(event)
+    }
+  }
+  return out
+}
+
+fn __testing_event_matches(candidate, predicate) -> bool {
+  if predicate == nil {
+    return true
+  }
+  if __testing_is_callable(predicate) {
+    return predicate(candidate)
+  }
+  if type_of(predicate) == "dict" {
+    return params_subset_match(predicate, candidate)
+  }
+  return candidate == predicate
+}
+
+fn __testing_handoff_target_matches(handoff, target) -> bool {
+  if target == nil {
+    return true
+  }
+  let resolved = handoff?.target_persona_or_human ?? {}
+  return resolved?.id == target
+    || resolved?.label == target
+    || resolved?.kind == target
+    || handoff?.target == target
+    || handoff?.target_persona == target
+}
+
+fn __testing_golden_match(expected, actual) -> bool {
+  if expected == "<ms>" {
+    let kind = type_of(actual)
+    return kind == "int" || kind == "float"
+      || (kind == "string" && len(regex_captures("^[0-9]+$", actual)) == 1)
+  }
+  if expected == "<uuid>" {
+    return type_of(actual) == "string"
+      && len(
+      regex_captures(
+        "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+        actual,
+      ),
+    )
+      == 1
+  }
+  if expected == "<any>" {
+    return actual != nil
+  }
+  if type_of(expected) != type_of(actual) {
+    return false
+  }
+  if type_of(expected) == "dict" {
+    for entry in entries(expected) {
+      if !__testing_golden_match(entry.value, actual[entry.key]) {
+        return false
+      }
+    }
+    return true
+  }
+  if type_of(expected) == "list" {
+    if len(expected) != len(actual) {
+      return false
+    }
+    var idx = 0
+    while idx < len(expected) {
+      if !__testing_golden_match(expected[idx], actual[idx]) {
+        return false
+      }
+      idx += 1
+    }
+    return true
+  }
+  return expected == actual
 }
 
 /** llm_calls. Returns the LLM mock call log for the current scope. */
@@ -214,4 +326,121 @@ pub fn with_mocks(config, body) {
     host_mock_pop_scope()
     throw e
   }
+}
+
+/** Clear recorded persona step events. */
+pub fn step_events_clear() {
+  __testing_step_events = []
+  return nil
+}
+
+/** Return recorded PreStep/PostStep payloads captured by step_assertions_begin. */
+pub fn step_events() {
+  return __testing_step_events
+}
+
+/**
+ * Start recording persona step hook payloads for Harn-level tests.
+ *
+ * This resets existing persona hooks because the helper owns the hook
+ * registrations during a conformance fixture. Register any fixture-specific
+ * hooks after calling this helper.
+ */
+pub fn step_assertions_begin(persona_pattern = "*") {
+  clear_persona_hooks()
+  step_events_clear()
+  register_persona_hook(
+    persona_pattern,
+    "PreStep",
+    { ctx ->
+      __testing_step_events = __testing_step_events.push(__testing_step_event_record(ctx))
+      return nil
+    },
+  )
+  register_persona_hook(
+    persona_pattern,
+    "PostStep",
+    { ctx ->
+      __testing_step_events = __testing_step_events.push(__testing_step_event_record(ctx))
+      return nil
+    },
+  )
+  return nil
+}
+
+/** Stop recording persona step hook payloads. */
+pub fn step_assertions_end() {
+  clear_persona_hooks()
+  return nil
+}
+
+/** Assert the exact ordered list of @step names that ran. */
+pub fn assert_steps_ran(expected_names, message = nil) {
+  var actual = []
+  for event in __testing_step_events_for("PreStep") {
+    actual = actual.push(event.step_name)
+  }
+  for name in expected_names {
+    require contains(actual, name), message ?? "step '" + name + "' not callable: not annotated `@step`"
+  }
+  require actual == expected_names, message ?? "step order mismatch"
+  return actual
+}
+
+/** Assert that a step received an input matching a closure, dict subset, or value. */
+pub fn assert_step_received(step_name, predicate = nil, message = nil) {
+  for event in __testing_step_events_for("PreStep") {
+    if event.step_name == step_name && __testing_event_matches(event, predicate) {
+      return event
+    }
+  }
+  require false, message ?? "step '" + step_name + "' did not receive the expected input"
+  return nil
+}
+
+/** Assert that a step emitted an output matching a closure, dict subset, or value. */
+pub fn assert_step_emitted(step_name, predicate = nil, message = nil) {
+  for event in __testing_step_events_for("PostStep") {
+    if event.step_name == step_name && __testing_event_matches(event, predicate) {
+      return event
+    }
+  }
+  require false, message ?? "step '" + step_name + "' did not emit the expected output"
+  return nil
+}
+
+/** Assert that a handoff list or run record contains a handoff of kind and optional target. */
+pub fn assert_handoff_emitted(source, handoff_kind, target = nil) {
+  let handoffs = source?.handoffs ?? source
+  for item in handoffs ?? [] {
+    if item?.kind == handoff_kind && __testing_handoff_target_matches(item, target) {
+      return item
+    }
+  }
+  let suffix = if target == nil {
+    ""
+  } else {
+    " to " + to_string(target)
+  }
+  require false, "handoff '" + handoff_kind + "'" + suffix + " was not emitted"
+  return nil
+}
+
+/** Assert an RFC 6901 JSON Pointer field inside a receipt or envelope. */
+pub fn assert_receipt_field(receipt, path, value) {
+  let actual = json_pointer(receipt, path)
+  require actual == value, "receipt field " + path + " mismatch"
+  return actual
+}
+
+/**
+ * Assert a structured golden against an actual transcript-like value.
+ *
+ * The expected value may contain `<ms>`, `<uuid>`, or `<any>` sentinel strings.
+ * Dict expected values are subset matches so tests can preserve the payload
+ * fields that matter without pinning every implementation detail.
+ */
+pub fn assert_golden_transcript(expected, actual, message = nil) {
+  require __testing_golden_match(expected, actual), message ?? "golden transcript mismatch"
+  return actual
 }

--- a/docs/src/builtins.md
+++ b/docs/src/builtins.md
@@ -1326,6 +1326,13 @@ let result = try { host_call("project.scan", {}) }
 assert(is_err(result))
 ```
 
+`std/testing` also includes persona steel-thread assertions:
+`step_assertions_begin`, `step_events`, `assert_steps_ran`,
+`assert_step_received`, `assert_step_emitted`, `assert_handoff_emitted`,
+`assert_receipt_field`, and `assert_golden_transcript`. These helpers record
+existing `PreStep` / `PostStep` hook payloads and assert Harn-level step,
+handoff, receipt, and structured transcript boundaries.
+
 ## Git Stdlib
 
 The `git` namespace provides typed local repository operations over the

--- a/docs/src/testing.md
+++ b/docs/src/testing.md
@@ -89,9 +89,28 @@ import { mock_host_result, assert_host_called, clear_host_mocks } from "std/test
 |----------|-------------|
 | `host_calls()` | Return all recorded host calls |
 | `host_calls_for(cap, op)` | Return calls for a specific capability/operation |
+| `host_call_count()` / `host_call_count_for(cap, op)` | Return recorded host call counts |
 | `assert_host_called(cap, op, params?)` | Assert a host call was made |
-| `assert_host_call_count(cap, op, expected_count)` | Assert exact call count |
+| `assert_host_call_count(expected_count, cap, op)` | Assert exact call count |
 | `assert_no_host_calls()` | Assert no host calls were made |
+
+### Persona step assertions
+
+Persona steel-thread tests can assert Harn orchestration boundaries without
+depending on Rust internals. `step_assertions_begin(pattern?)` installs
+`PreStep` / `PostStep` hooks for matching personas and records the hook
+payloads until `step_assertions_end()`.
+
+| Helper | Description |
+|----------|-------------|
+| `step_assertions_begin(persona_pattern?)` | Clear persona hooks and start recording matching step payloads |
+| `step_events()` / `step_events_clear()` | Inspect or reset captured step payloads |
+| `assert_steps_ran(names)` | Assert the exact ordered list of `@step` names |
+| `assert_step_received(step, predicate?)` | Assert a `PreStep` payload matched a closure, dict subset, or value |
+| `assert_step_emitted(step, predicate?)` | Assert a `PostStep` payload matched a closure, dict subset, or value |
+| `assert_handoff_emitted(source, kind, target?)` | Assert a run record or handoff list contains a typed handoff |
+| `assert_receipt_field(receipt, pointer, value)` | Assert an RFC 6901 JSON Pointer field in a receipt |
+| `assert_golden_transcript(expected, actual)` | Structured subset matcher with `<ms>`, `<uuid>`, and `<any>` sentinels |
 
 ### Example
 


### PR DESCRIPTION
## Summary
- add std/testing persona step assertion helpers for step order, step inputs/outputs, handoffs, receipts, and structured golden transcript matching
- add merge/release/deploy captain steel-thread conformance fixtures over Harn-level orchestration boundaries
- document the testing helpers and clean up std/testing host assertion docs/API coverage

Closes #1078

## Verification
- CARGO_TARGET_DIR=/tmp/harn-target-1078 cargo run --bin harn -- test conformance
- CARGO_TARGET_DIR=/tmp/harn-target-1078 cargo run --bin harn -- lint crates/harn-stdlib/src/stdlib/stdlib_testing.harn conformance/tests/stdlib/stdlib_testing_host_mock.harn conformance/tests/stdlib/testing_step_assertions.harn conformance/tests/personas/persona_steel_thread_merge_captain.harn conformance/tests/personas/persona_steel_thread_release_captain.harn conformance/tests/personas/persona_steel_thread_deploy_captain.harn
- CARGO_TARGET_DIR=/tmp/harn-target-1078 cargo run --bin harn -- fmt --check crates/harn-stdlib/src/stdlib/stdlib_testing.harn conformance/tests/stdlib/stdlib_testing_host_mock.harn conformance/tests/stdlib/testing_step_assertions.harn conformance/tests/personas/persona_steel_thread_merge_captain.harn conformance/tests/personas/persona_steel_thread_release_captain.harn conformance/tests/personas/persona_steel_thread_deploy_captain.harn
- CARGO_TARGET_DIR=/tmp/harn-target-1078 cargo test -p harn-vm step_runtime
- CARGO_TARGET_DIR=/tmp/harn-target-1078 cargo test -p harn-vm receipts
- git diff --check