### PR TITLE
Tighten agent prompt overrides

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,12 +103,10 @@ lint-harn:
 	workers=$$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 8); \
 	tmp=$$(mktemp -d); \
 	status=0; \
-	find conformance/tests -name '*.harn' -print0 | while IFS= read -r -d '' f; do \
-		error_file="$${f%.harn}.error"; \
-		[ -f "$$error_file" ] && continue; \
-		printf '%s\0' "$$f"; \
-	done | \
+	find conformance/tests -name '*.harn' -print0 | \
 		TMP_RESULTS="$$tmp" xargs -0 -P "$$workers" -I{} sh -c '\
+			error_file="$${1%.harn}.error"; \
+			[ -f "$$error_file" ] && exit 0; \
 			output=$$("$$0" check "$$1" 2>&1); \
 			if echo "$$output" | grep -qE "^.+: (warning|error)\["; then \
 				printf "%s\n" "$$output" | grep -v ": ok$$" > "$$TMP_RESULTS/$$(basename "$$1").out"; \

--- a/conformance/tests/agents/agent_loop_inline_user_response_placeholder.expected
+++ b/conformance/tests/agents/agent_loop_inline_user_response_placeholder.expected
@@ -1,0 +1,5 @@
+done
+Remember `<user_response>...</user_response>` is only an example wrapper.
+Audit: actual final answer.
+Remember `<user_response>...</user_response>` is only an example wrapper.
+Audit: actual final answer.

--- a/conformance/tests/agents/agent_loop_inline_user_response_placeholder.harn
+++ b/conformance/tests/agents/agent_loop_inline_user_response_placeholder.harn
@@ -1,0 +1,16 @@
+pipeline default() {
+  llm_mock_clear()
+  llm_mock(
+    {
+      text: "Remember `<user_response>...</user_response>` is only an example wrapper.\nAudit: actual final answer.",
+    },
+  )
+  let result = agent_loop(
+    "Finish with a visible answer.",
+    nil,
+    {provider: "mock", loop_until_done: false, max_iterations: 1},
+  )
+  println(result.status)
+  println(result.visible_text)
+  println(result.text)
+}

--- a/conformance/tests/agents/agent_loop_native_done_sentinel.expected
+++ b/conformance/tests/agents/agent_loop_native_done_sentinel.expected
@@ -6,3 +6,4 @@ true
 true
 true
 true
+true

--- a/conformance/tests/agents/agent_loop_native_done_sentinel.harn
+++ b/conformance/tests/agents/agent_loop_native_done_sentinel.harn
@@ -42,4 +42,5 @@ pipeline main() {
   println(contains(calls[0].system, "##DONE##"))
   println(contains(calls[1].system, "##DONE##"))
   println(contains(calls[2].system, "##DONE##"))
+  println(!contains(calls[0].system, "<user_response>"))
 }

--- a/conformance/tests/agents/agent_loop_native_natural_completion.expected
+++ b/conformance/tests/agents/agent_loop_native_natural_completion.expected
@@ -5,3 +5,7 @@ Release notes are ready.
 true
 true
 true
+true
+true
+true
+true

--- a/conformance/tests/agents/agent_loop_native_natural_completion.harn
+++ b/conformance/tests/agents/agent_loop_native_natural_completion.harn
@@ -38,5 +38,17 @@ pipeline main() {
   println(len(calls))
   println(!contains(calls[0].system, "##DONE##"))
   println(!contains(calls[1].system, "##DONE##"))
+  println(!contains(calls[0].system, "<user_response>"))
+  println(contains(calls[0].system, "provider's native tool-calling channel"))
   println(contains(json_stringify(calls[1].messages), "evidence for release"))
+  llm_mock_clear()
+  llm_mock({text: "Plain final answer."})
+  agent_loop(
+    "Finish without tools.",
+    nil,
+    {provider: "mock", tools: tool_registry(), tool_format: "native", max_iterations: 1},
+  )
+  let empty_calls = llm_mock_calls()
+  println(!contains(empty_calls[0].system, "Native tool protocol"))
+  println(!contains(empty_calls[0].system, "<user_response>"))
 }

--- a/conformance/tests/autonomy/autonomy_tiers_side_effects.harn
+++ b/conformance/tests/autonomy/autonomy_tiers_side_effects.harn
@@ -68,7 +68,7 @@ pipeline test(task) {
   let scoped_agent = "autonomy-scoped-" + unique
   let scoped_path = path_join(".harn", "autonomy_tier_scoped_" + unique + ".txt")
   with_autonomy_policy(
-    {agent_id: scoped_agent, autonomy_tier: "act_auto", action_tiers: {["fs.write"]: "shadow"}},
+    {agent_id: scoped_agent, autonomy_tier: "act_auto", action_tiers: {"fs.write": "shadow"}},
     fn() { write_file(scoped_path, "scoped") },
   )
   let scoped_records: list<TrustRecord> = trust_query({agent: scoped_agent, action: "fs.write", tier: "shadow"})

--- a/conformance/tests/collections/dotted_dict_keys.expected
+++ b/conformance/tests/collections/dotted_dict_keys.expected
@@ -1,0 +1,3 @@
+[harn] x
+[harn] y
+[harn] {"a.b.c":"x","k":"y"}

--- a/conformance/tests/collections/dotted_dict_keys.harn
+++ b/conformance/tests/collections/dotted_dict_keys.harn
@@ -1,0 +1,8 @@
+pipeline test(task) {
+  var d = {}
+  d["a.b.c"] = "x"
+  d.k = "y"
+  log(d["a.b.c"])
+  log(d.k)
+  log(json_stringify(d))
+}

--- a/conformance/tests/collections/quoted_dict_keys.harn
+++ b/conformance/tests/collections/quoted_dict_keys.harn
@@ -8,7 +8,7 @@ pipeline default() {
   println(mixed.unquoted)
   println(mixed.quoted)
   // Quoted keys with special characters
-  let special = {["content-type"]: "json", ["x-api-key"]: "abc"}
+  let special = {"content-type": "json", "x-api-key": "abc"}
   println(special["content-type"])
   println(special["x-api-key"])
 }

--- a/conformance/tests/integration/agent_prompt_overrides_and_timestamps.harn
+++ b/conformance/tests/integration/agent_prompt_overrides_and_timestamps.harn
@@ -1,3 +1,5 @@
+import { agent_prompt_overrides } from "std/agent/prompts"
+
 pipeline test(task) {
   llm_mock_clear()
   llm_mock({text: "<done>##DONE##</done>"})
@@ -9,13 +11,61 @@ pipeline test(task) {
       loop_until_done: true,
       max_iterations: 2,
       timestamp_messages: true,
-      prompts: {["agent.loop_contract"]: {text: "CUSTOM LOOP CONTRACT {{ done_sentinel }}"}},
+      prompts: {"agent.loop_contract": {text: "CUSTOM LOOP CONTRACT {{ done_sentinel }}"}},
     },
   )
   let calls = llm_mock_calls()
   assert(contains(calls[0].system, "CUSTOM LOOP CONTRACT ##DONE##"), "prompt override rendered")
   assert(!contains(calls[0].system, "Keep working until"), "default loop prompt was replaced")
   assert(contains(calls[0].messages[0].content, "[harn timestamp:"), "message timestamp visible")
+  let bad_override = try {
+    agent_loop(
+      "bad prompt id",
+      "Base system.",
+      {
+        provider: "mock",
+        loop_until_done: true,
+        max_iterations: 1,
+        prompts: {"agent.loop_contractt": {text: "typo"}},
+      },
+    )
+  }
+  assert(is_err(bad_override), "unknown prompt id rejected")
+  assert(
+    contains(to_string(unwrap_err(bad_override)), "unknown prompt id"),
+    "unknown prompt id diagnostic",
+  )
+  llm_mock_clear()
+  llm_mock({text: "<done>##DONE##</done>"})
+  let typed_prompt_values = {loop_contract: {text: "TYPED LOOP CONTRACT {{ done_sentinel }}"}}
+  let typed_prompt_options = agent_prompt_overrides(typed_prompt_values)
+  agent_loop(
+    "typed override",
+    "Base system.",
+    typed_prompt_options
+      + {provider: "mock", loop_until_done: true, max_iterations: 1},
+  )
+  let typed_calls = llm_mock_calls()
+  assert(
+    contains(typed_calls[0].system, "TYPED LOOP CONTRACT ##DONE##"),
+    "typed prompt helper rendered",
+  )
+  llm_mock_clear()
+  llm_mock({text: "<user_response>turn done</user_response>\n<done>##DONE##</done>"})
+  llm_mock({text: "{\"verdict\":\"done\",\"reasoning\":\"turn complete\"}"})
+  agent_turn(
+    "turn preamble override",
+    {
+      provider: "mock",
+      max_iterations: 2,
+      prompts: {"agent.turn_preamble": {text: "CUSTOM TURN PREAMBLE"}},
+    },
+  )
+  let turn_calls = llm_mock_calls()
+  assert(
+    contains(turn_calls[0].system, "CUSTOM TURN PREAMBLE"),
+    "agent_turn preamble override rendered",
+  )
   llm_mock_clear()
   var tools = tool_registry()
   tools = tool_define(
@@ -35,11 +85,21 @@ pipeline test(task) {
       loop_until_done: true,
       max_iterations: 1,
       done_judge: nil,
+      turn_policy: {require_action_or_yield: true},
+      prompts: {"agent.tool_contract_action_text": {text: "CUSTOM TEXT ACTION {{ done_sentinel }}"}},
     },
   )
   let text_contract = llm_mock_calls()[0].system
   assert(contains(text_contract, "name({ key: value })"), "text tool syntax is Harn-call shaped")
   assert(contains(text_contract, "### greet"), "Harn-rendered tool listing included")
+  assert(
+    contains(text_contract, "CUSTOM TEXT ACTION ##DONE##"),
+    "text tool contract fragment override rendered",
+  )
+  assert(
+    !contains(text_contract, "This turn is action-gated"),
+    "default text action fragment was replaced",
+  )
   assert(!contains(text_contract, "{\"name\": \"tool_name\""), "legacy JSON tool syntax removed")
   log("agent_prompt_overrides_and_timestamps tests passed")
 }

--- a/conformance/tests/integration/http_server_stdlib.harn
+++ b/conformance/tests/integration/http_server_stdlib.harn
@@ -6,7 +6,7 @@ pipeline default() {
     server,
     { response, _req ->
       let prior = response.headers["x-order"] ?? ""
-      response + {headers: response.headers + {["x-order"]: prior + ",after-a"}}
+      response + {headers: response.headers + {"x-order": prior + ",after-a"}}
     },
   )
   http_server_after(
@@ -14,7 +14,7 @@ pipeline default() {
     { response, _req ->
       let prior = response.headers["x-order"] ?? ""
       response
-        + {headers: response.headers + {["x-order"]: prior + ",after-b", ["x-after"]: "after-b"}}
+        + {headers: response.headers + {"x-order": prior + ",after-b", "x-after": "after-b"}}
     },
   )
   http_server_route(
@@ -30,7 +30,7 @@ pipeline default() {
       assert(req.client_ip == "203.0.113.7", "client IP metadata")
       http_response_json(
         {accepted: req.path_params.trigger, tenant: req.path_params.tenant},
-        {status: 202, headers: {["x-handler"]: "ok", ["x-order"]: req.order + ",handler"}},
+        {status: 202, headers: {"x-handler": "ok", "x-order": req.order + ",handler"}},
       )
     },
     {max_body_bytes: 64},
@@ -40,7 +40,7 @@ pipeline default() {
     {
       method: "post",
       path: "/hooks/acme/push?mode=fast",
-      headers: {["X-Signature"]: "sig"},
+      headers: {"X-Signature": "sig"},
       body: "{\"ok\":true}",
       client_ip: "203.0.113.7",
     },

--- a/conformance/tests/integration/orchestrator_auth_middleware.harn
+++ b/conformance/tests/integration/orchestrator_auth_middleware.harn
@@ -58,7 +58,7 @@ pipeline test(task) {
   let url = wait_for_listener_url(path_join(root, "orchestrator.log"))
   assert(url != nil, "listener URL did not appear in log")
   let body = "{\"kind\":\"a2a.task.received\",\"task\":{\"id\":\"task-123\"}}"
-  let json_headers = {["Content-Type"]: "application/json"}
+  let json_headers = {"Content-Type": "application/json"}
   let unauth = http_request("POST", url + "/a2a/review", {body: body, headers: json_headers})
   println(unauth.status == 401)
   let ts = to_string(to_int(timestamp()))
@@ -68,7 +68,7 @@ pipeline test(task) {
     {
       body: body,
       headers: {
-        ["Content-Type"]: "application/json",
+        "Content-Type": "application/json",
         Authorization: "HMAC-SHA256 timestamp=" + ts + ",signature=AAAAAAAAAAAAAAAAAAAAAA==",
       },
     },
@@ -77,7 +77,7 @@ pipeline test(task) {
   let bearer = http_request(
     "POST",
     url + "/a2a/review",
-    {body: body, headers: {["Content-Type"]: "application/json", Authorization: "Bearer test-key-2"}},
+    {body: body, headers: {"Content-Type": "application/json", Authorization: "Bearer test-key-2"}},
   )
   println(bearer.status == 200)
   let _ = shell("kill -TERM " + pid)

--- a/conformance/tests/integration/orchestrator_recover_stranded_envelopes.harn
+++ b/conformance/tests/integration/orchestrator_recover_stranded_envelopes.harn
@@ -106,7 +106,7 @@ pipeline test(task) {
     crash_url + "/a2a/review",
     {
       body: "{\"kind\":\"a2a.task.received\",\"task\":{\"id\":\"task-242\"}}",
-      headers: {["Content-Type"]: "application/json", Authorization: "Bearer test-key"},
+      headers: {"Content-Type": "application/json", Authorization: "Bearer test-key"},
     },
   )
   println(response.status == 200 && wait_for_exit(crash_pid))

--- a/conformance/tests/integration/skill_lifecycle_flags.harn
+++ b/conformance/tests/integration/skill_lifecycle_flags.harn
@@ -24,7 +24,7 @@ pipeline test(task) {
       when_to_use: "User requests a credential rotation",
       prompt: "Never execute without manual approval.",
       allowed_tools: ["rotate"],
-      ["disable-model-invocation"]: true,
+      "disable-model-invocation": true,
     },
   )
   llm_mock({text: "Nothing to do."})

--- a/conformance/tests/runtime/http_mock.harn
+++ b/conformance/tests/runtime/http_mock.harn
@@ -19,7 +19,7 @@ pipeline test(task) {
   let post_resp = http_post(
     "https://api.example.com/items",
     "{\"name\": \"test\"}",
-    {headers: {Authorization: "Bearer test-token", ["Content-Type"]: "application/json"}},
+    {headers: {Authorization: "Bearer test-token", "Content-Type": "application/json"}},
   )
   assert_eq(post_resp.status, 201)
   log("post status: " + to_string(post_resp.status))

--- a/conformance/tests/runtime/http_retry_after_header.harn
+++ b/conformance/tests/runtime/http_retry_after_header.harn
@@ -2,7 +2,7 @@ pipeline test(task) {
   http_mock(
     "GET",
     "https://api.example.com/retry-after",
-    {responses: [{status: 429, headers: {["retry-after"]: "0"}}, {status: 200, body: "ok"}]},
+    {responses: [{status: 429, headers: {"retry-after": "0"}}, {status: 200, body: "ok"}]},
   )
   let resp = http_get("https://api.example.com/retry-after", {retry: {max: 1, backoff_ms: 0}})
   let calls = http_mock_calls()

--- a/conformance/tests/stdlib/graphql_sdk.harn
+++ b/conformance/tests/stdlib/graphql_sdk.harn
@@ -39,7 +39,7 @@ pipeline test(task) {
     {
       status: 200,
       body: json_stringify({data: {viewer: {id: "user-1", name: "Ada"}}, extensions: {cost: 1}}),
-      headers: {["X-Complexity"]: "7", ["X-RateLimit-Requests-Remaining"]: "49", ["X-Request-Id"]: "req-1"},
+      headers: {"X-Complexity": "7", "X-RateLimit-Requests-Remaining": "49", "X-Request-Id": "req-1"},
     },
   )
   let envelope = graphql_execute_operation(

--- a/conformance/tests/stdlib/http_builtin_signatures.harn
+++ b/conformance/tests/stdlib/http_builtin_signatures.harn
@@ -4,12 +4,12 @@ pipeline test(task) {
   http_mock(
     "GET",
     "https://api.example.com/stream",
-    {status: 206, body: "abcdef", headers: {["content-type"]: "application/octet-stream"}},
+    {status: 206, body: "abcdef", headers: {"content-type": "application/octet-stream"}},
   )
   http_mock(
     "GET",
     "https://api.example.com/download",
-    {status: 200, body: "payload", headers: {["content-type"]: "text/plain"}},
+    {status: 200, body: "payload", headers: {"content-type": "text/plain"}},
   )
   let get_resp: dict = http_get("https://api.example.com/users")
   let post_resp: dict = http_post("https://api.example.com/users", "{}")

--- a/conformance/tests/stdlib/http_mock_calls_headers.harn
+++ b/conformance/tests/stdlib/http_mock_calls_headers.harn
@@ -8,7 +8,7 @@ pipeline test(task) {
   let get_resp = http_get(
     "https://api.example.com/items",
     {
-      headers: {Authorization: "Bearer secret-token", ["X-Api-Key"]: "header-secret", Accept: "application/json"},
+      headers: {Authorization: "Bearer secret-token", "X-Api-Key": "header-secret", Accept: "application/json"},
       query: {api_key: "secret", limit: 2},
     },
   )
@@ -28,7 +28,7 @@ pipeline test(task) {
   let post_resp = http_post(
     "https://api.example.com/items",
     "{\"name\":\"Ada\"}",
-    {headers: {Cookie: "sid=session-secret", ["Content-Type"]: "application/json"}},
+    {headers: {Cookie: "sid=session-secret", "Content-Type": "application/json"}},
   )
   assert_eq(post_resp.status, 201)
   let with_sensitive = http_mock_calls({include_sensitive: true})

--- a/conformance/tests/stdlib/http_stream_download.harn
+++ b/conformance/tests/stdlib/http_stream_download.harn
@@ -2,7 +2,7 @@ pipeline default() {
   http_mock(
     "GET",
     "https://api.example.com/stream",
-    {status: 200, body: "stream-body", headers: {["x-test"]: "yes"}},
+    {status: 200, body: "stream-body", headers: {"x-test": "yes"}},
   )
   let stream = http_stream_open("https://api.example.com/stream")
   let info = http_stream_info(stream)

--- a/conformance/tests/stdlib/multipart_builtins.harn
+++ b/conformance/tests/stdlib/multipart_builtins.harn
@@ -7,7 +7,7 @@ pipeline test(task) {
         filename: "report.bin",
         content_type: "application/octet-stream",
         content: bytes_from_hex("000102ff"),
-        headers: {["X-Test-Header"]: "fixture"},
+        headers: {"X-Test-Header": "fixture"},
       },
     ],
   )

--- a/conformance/tests/triggers/webhook_intake_multi_path_isolation.harn
+++ b/conformance/tests/triggers/webhook_intake_multi_path_isolation.harn
@@ -27,19 +27,11 @@ pipeline test(task) {
   let sig_b = "sha256=" + hmac_sha256("secret-b", body)
   let outcome_a = webhook_intake_feed(
     "intake-a",
-    {
-      headers: {["x-a-signature"]: sig_a, ["x-a-delivery"]: "shared-delivery"},
-      body: body,
-      path: "/hooks/a",
-    },
+    {headers: {"x-a-signature": sig_a, "x-a-delivery": "shared-delivery"}, body: body, path: "/hooks/a"},
   )
   let outcome_b = webhook_intake_feed(
     "intake-b",
-    {
-      headers: {["x-b-signature"]: sig_b, ["x-b-delivery"]: "shared-delivery"},
-      body: body,
-      path: "/hooks/b",
-    },
+    {headers: {"x-b-signature": sig_b, "x-b-delivery": "shared-delivery"}, body: body, path: "/hooks/b"},
   )
   println(outcome_a.status == "accepted")
   println(outcome_b.status == "accepted")
@@ -47,7 +39,7 @@ pipeline test(task) {
   let mismatched = webhook_intake_feed(
     "intake-a",
     {
-      headers: {["x-a-signature"]: sig_a, ["x-a-delivery"]: "delivery-other"},
+      headers: {"x-a-signature": sig_a, "x-a-delivery": "delivery-other"},
       body: body,
       path: "/hooks/wrong",
     },
@@ -56,11 +48,7 @@ pipeline test(task) {
   // Wrong-secret signature is rejected (cross-intake leakage).
   let cross = webhook_intake_feed(
     "intake-a",
-    {
-      headers: {["x-a-signature"]: sig_b, ["x-a-delivery"]: "delivery-cross"},
-      body: body,
-      path: "/hooks/a",
-    },
+    {headers: {"x-a-signature": sig_b, "x-a-delivery": "delivery-cross"}, body: body, path: "/hooks/a"},
   )
   println(cross.status == "rejected")
 }

--- a/conformance/tests/triggers/webhook_intake_round_trip.harn
+++ b/conformance/tests/triggers/webhook_intake_round_trip.harn
@@ -17,7 +17,7 @@ pipeline test(task) {
   let accepted = webhook_intake_feed(
     "round-trip",
     {
-      headers: {["x-hub-signature-256"]: signature, ["x-github-delivery"]: "delivery-1"},
+      headers: {"x-hub-signature-256": signature, "x-github-delivery": "delivery-1"},
       body: body,
       path: "/hooks/foo",
     },
@@ -28,7 +28,7 @@ pipeline test(task) {
   let dup = webhook_intake_feed(
     "round-trip",
     {
-      headers: {["x-hub-signature-256"]: signature, ["x-github-delivery"]: "delivery-1"},
+      headers: {"x-hub-signature-256": signature, "x-github-delivery": "delivery-1"},
       body: body,
       path: "/hooks/foo",
     },
@@ -38,7 +38,7 @@ pipeline test(task) {
   let bad = webhook_intake_feed(
     "round-trip",
     {
-      headers: {["x-hub-signature-256"]: "sha256=deadbeef", ["x-github-delivery"]: "delivery-2"},
+      headers: {"x-hub-signature-256": "sha256=deadbeef", "x-github-delivery": "delivery-2"},
       body: body,
       path: "/hooks/foo",
     },

--- a/conformance/tests/triggers/webhook_intake_sha1_legacy.harn
+++ b/conformance/tests/triggers/webhook_intake_sha1_legacy.harn
@@ -16,17 +16,14 @@ pipeline test(task) {
   let signature = "sha1=" + hmac_sha1("legacy-secret", body)
   let outcome = webhook_intake_feed(
     "legacy-sha1",
-    {headers: {["x-hub-signature"]: signature, ["x-legacy-delivery"]: "legacy-1"}, body: body},
+    {headers: {"x-hub-signature": signature, "x-legacy-delivery": "legacy-1"}, body: body},
   )
   println(outcome.status == "accepted")
   // SHA-256 signature against a SHA-1 intake is rejected (mismatch).
   let wrong = webhook_intake_feed(
     "legacy-sha1",
     {
-      headers: {
-        ["x-hub-signature"]: "sha1=" + hmac_sha256("legacy-secret", body),
-        ["x-legacy-delivery"]: "legacy-2",
-      },
+      headers: {"x-hub-signature": "sha1=" + hmac_sha256("legacy-secret", body), "x-legacy-delivery": "legacy-2"},
       body: body,
     },
   )

--- a/crates/harn-fmt/src/formatter/expressions.rs
+++ b/crates/harn-fmt/src/formatter/expressions.rs
@@ -686,6 +686,7 @@ impl Formatter<'_> {
     fn format_dict_key(&self, node: &SNode, indent: usize) -> String {
         match &node.node {
             Node::StringLiteral(s) if is_identifier(s) => s.clone(),
+            Node::StringLiteral(s) => format!("\"{}\"", escape_string(s)),
             _ => format!("[{}]", self.format_expr(node, indent)),
         }
     }

--- a/crates/harn-fmt/src/tests.rs
+++ b/crates/harn-fmt/src/tests.rs
@@ -95,6 +95,16 @@ fn test_roundtrip_computed_dict_key() {
 }
 
 #[test]
+fn test_format_literal_dict_keys() {
+    let source = r#"pipeline default(task) {
+  let d = {["a.b.c"]: "x", k: "y", ["with space"]: 1}
+}"#;
+    let result = format_source(source).unwrap();
+    assert!(result.contains(r#"{"a.b.c": "x", k: "y", "with space": 1}"#));
+    assert_roundtrip(source);
+}
+
+#[test]
 fn test_roundtrip_interface() {
     assert_roundtrip(
         "interface Printable {\n  fn to_display() -> string\n}\npipeline default(task) { log(1) }",

--- a/crates/harn-stdlib/src/stdlib/agent/daemon.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/daemon.harn
@@ -1,4 +1,5 @@
 // @harn-entrypoint-category agent.stdlib
+import { daemon_timer_feedback_prompt, daemon_watch_feedback_prompt } from "std/agent/prompts"
 import { agent_session_inject_feedback } from "std/agent/state"
 
 fn __daemon_compaction_summary(opts) {
@@ -22,6 +23,28 @@ fn __daemon_compaction_summary(opts) {
   return nil
 }
 
+fn __agent_daemon_feedback(wake, opts) {
+  if wake?.reason == "timer" {
+    return {kind: wake?.feedback_kind ?? "timer", text: daemon_timer_feedback_prompt(opts)}
+  }
+  if wake?.reason == "watch" || wake?.changed_paths != nil {
+    let changed_paths = wake?.changed_paths ?? []
+    let changed_paths_text = if type_of(changed_paths) == "list" {
+      join(changed_paths, ", ")
+    } else {
+      to_string(changed_paths)
+    }
+    return {
+      kind: wake?.feedback_kind ?? wake?.reason ?? "daemon",
+      text: daemon_watch_feedback_prompt({changed_paths: changed_paths_text}, opts),
+    }
+  }
+  if wake?.feedback != nil {
+    return {kind: wake?.feedback_kind ?? wake?.reason ?? "daemon", text: wake.feedback}
+  }
+  return nil
+}
+
 /** agent_daemon_snapshot. */
 pub fn agent_daemon_snapshot(session, opts, daemon_state = "idle", iteration = 0) {
   let summary = __daemon_compaction_summary(opts)
@@ -40,12 +63,9 @@ pub fn agent_daemon_step(session, opts, iteration) {
   while wake?.reason == nil && timeout > 0 {
     wake = __host_agent_daemon_wait(session.session_id, timeout)
   }
-  if wake?.feedback != nil {
-    agent_session_inject_feedback(
-      session.session_id,
-      wake?.feedback_kind ?? wake?.reason ?? "daemon",
-      wake.feedback,
-    )
+  let feedback = __agent_daemon_feedback(wake, opts)
+  if feedback != nil {
+    agent_session_inject_feedback(session.session_id, feedback.kind, feedback.text)
   }
   return {snapshot: snapshot, wake: wake}
 }

--- a/crates/harn-stdlib/src/stdlib/agent/preflight.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/preflight.harn
@@ -27,6 +27,23 @@ fn __agent_tool_format(opts) {
   return "text"
 }
 
+fn __agent_has_tools(opts) {
+  let registry = opts?.tools
+  if registry == nil {
+    return false
+  }
+  if type_of(registry) == "list" {
+    return len(registry) > 0
+  }
+  if type_of(registry) == "dict" {
+    let tools = registry?.tools
+    if type_of(tools) == "list" {
+      return len(tools) > 0
+    }
+  }
+  return true
+}
+
 fn __agent_loop_contract_prompt(opts) {
   let sentinel = __agent_done_sentinel(opts)
   let loop_until_done = opts?.loop_until_done ?? false
@@ -38,7 +55,7 @@ fn __agent_loop_contract_prompt(opts) {
     {
       loop_until_done: loop_until_done,
       exit_when_verified: opts?.exit_when_verified ?? false,
-      has_tools: opts?.tools != nil,
+      has_tools: __agent_has_tools(opts),
       native_mode: mode == "native",
       native_done: mode == "native",
       sentinel_active: sentinel != nil,
@@ -49,7 +66,7 @@ fn __agent_loop_contract_prompt(opts) {
 }
 
 fn __agent_native_tool_contract_prompt(opts) {
-  if opts?.tools == nil || __agent_tool_format(opts) != "native" {
+  if !__agent_has_tools(opts) || __agent_tool_format(opts) != "native" {
     return ""
   }
   return render_agent_prompt_id(

--- a/crates/harn-stdlib/src/stdlib/agent/preflight.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/preflight.harn
@@ -106,18 +106,28 @@ fn __agent_text_tool_contract_prompt(opts) {
     return ""
   }
   let turn_policy = opts?.turn_policy ?? {}
+  let done_sentinel = __agent_done_sentinel(opts)
   return render_agent_prompt_id(
     "agent.tool_contract_text",
     {
       mode: "text",
       native_mode: false,
       require_action: turn_policy?.require_action_or_yield ?? opts?.require_action_or_yield ?? false,
-      done_sentinel: __agent_done_sentinel(opts),
+      done_sentinel: done_sentinel,
       include_task_ledger_help: opts?.task_ledger != nil,
       tool_examples: turn_policy?.tool_examples ?? opts?.tool_examples ?? "",
       shared_types: opts?.shared_types ?? "",
       expanded_schemas: __agent_tool_listing_prompt(opts.tools),
       compact_schemas: "",
+      native_contract: render_agent_prompt_id("agent.tool_contract_native", {done_sentinel: done_sentinel}, opts),
+      action_native_contract: render_agent_prompt_id("agent.tool_contract_action_native", {done_sentinel: done_sentinel}, opts),
+      task_ledger_contract: render_agent_prompt_id("agent.tool_contract_task_ledger", {done_sentinel: done_sentinel}, opts),
+      text_response_protocol: render_agent_prompt_id(
+        "agent.tool_contract_text_response_protocol",
+        {done_sentinel: done_sentinel},
+        opts,
+      ),
+      action_text_contract: render_agent_prompt_id("agent.tool_contract_action_text", {done_sentinel: done_sentinel}, opts),
     },
     opts,
   )

--- a/crates/harn-stdlib/src/stdlib/agent/prompts.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/prompts.harn
@@ -1,16 +1,153 @@
+type AgentPromptId = "agent.action_required_feedback" | "agent.action_turn_nudge" | "agent.completion_judge_feedback" | "agent.completion_judge_system" | "agent.completion_judge_user" | "agent.daemon_timer_feedback" | "agent.daemon_watch_feedback" | "agent.default_nudge" | "agent.deferred_tool_listing" | "agent.loop_contract" | "agent.native_tool_contract_feedback" | "agent.parse_guidance" | "agent.protocol_violation_feedback" | "agent.tool_contract_action_native" | "agent.tool_contract_action_text" | "agent.tool_contract_deferred_tools" | "agent.tool_contract_native" | "agent.tool_contract_task_ledger" | "agent.tool_contract_text" | "agent.tool_contract_text_response_protocol" | "agent.turn_preamble" | "agent.verification_gate_feedback"
+
+type AgentPromptEntry = string | {path: string} | {text: string} | fn(dict) -> string
+
+type AgentPromptOverrides = {
+  action_required_feedback?: AgentPromptEntry,
+  action_turn_nudge?: AgentPromptEntry,
+  completion_judge_feedback?: AgentPromptEntry,
+  completion_judge_system?: AgentPromptEntry,
+  completion_judge_user?: AgentPromptEntry,
+  daemon_timer_feedback?: AgentPromptEntry,
+  daemon_watch_feedback?: AgentPromptEntry,
+  default_nudge?: AgentPromptEntry,
+  deferred_tool_listing?: AgentPromptEntry,
+  loop_contract?: AgentPromptEntry,
+  native_tool_contract_feedback?: AgentPromptEntry,
+  parse_guidance?: AgentPromptEntry,
+  protocol_violation_feedback?: AgentPromptEntry,
+  tool_contract_action_native?: AgentPromptEntry,
+  tool_contract_action_text?: AgentPromptEntry,
+  tool_contract_deferred_tools?: AgentPromptEntry,
+  tool_contract_native?: AgentPromptEntry,
+  tool_contract_task_ledger?: AgentPromptEntry,
+  tool_contract_text?: AgentPromptEntry,
+  tool_contract_text_response_protocol?: AgentPromptEntry,
+  turn_preamble?: AgentPromptEntry,
+  verification_gate_feedback?: AgentPromptEntry,
+}
+
+fn __agent_prompt_ids() {
+  return [
+    "agent.action_required_feedback",
+    "agent.action_turn_nudge",
+    "agent.completion_judge_feedback",
+    "agent.completion_judge_system",
+    "agent.completion_judge_user",
+    "agent.daemon_timer_feedback",
+    "agent.daemon_watch_feedback",
+    "agent.default_nudge",
+    "agent.deferred_tool_listing",
+    "agent.loop_contract",
+    "agent.native_tool_contract_feedback",
+    "agent.parse_guidance",
+    "agent.protocol_violation_feedback",
+    "agent.tool_contract_action_native",
+    "agent.tool_contract_action_text",
+    "agent.tool_contract_deferred_tools",
+    "agent.tool_contract_native",
+    "agent.tool_contract_task_ledger",
+    "agent.tool_contract_text",
+    "agent.tool_contract_text_response_protocol",
+    "agent.turn_preamble",
+    "agent.verification_gate_feedback",
+  ]
+}
+
 fn __agent_default_prompt_catalog() {
   return {
-    ["agent.action_turn_nudge"]: "action_turn_nudge.harn.prompt",
-    ["agent.loop_contract"]: "loop_until_done_system.harn.prompt",
-    ["agent.default_nudge"]: "default_nudge.harn.prompt",
-    ["agent.completion_judge_system"]: "completion_judge_default.harn.prompt",
-    ["agent.completion_judge_feedback"]: "completion_judge_feedback_fallback.harn.prompt",
-    ["agent.completion_judge_user"]: "completion_judge_user.harn.prompt",
-    ["agent.native_tool_contract_feedback"]: "native_tool_contract_feedback.harn.prompt",
-    ["agent.turn_preamble"]: "agent_turn_preamble.harn.prompt",
-    ["agent.tool_contract_native"]: "tool_contract_native.harn.prompt",
-    ["agent.tool_contract_text"]: "tool_contract_text.harn.prompt",
+    "agent.action_required_feedback": "action_required_feedback.harn.prompt",
+    "agent.action_turn_nudge": "action_turn_nudge.harn.prompt",
+    "agent.completion_judge_feedback": "completion_judge_feedback_fallback.harn.prompt",
+    "agent.completion_judge_system": "completion_judge_default.harn.prompt",
+    "agent.completion_judge_user": "completion_judge_user.harn.prompt",
+    "agent.daemon_timer_feedback": "daemon_timer_feedback.harn.prompt",
+    "agent.daemon_watch_feedback": "daemon_watch_feedback.harn.prompt",
+    "agent.default_nudge": "default_nudge.harn.prompt",
+    "agent.deferred_tool_listing": "deferred_tool_listing.harn.prompt",
+    "agent.loop_contract": "loop_until_done_system.harn.prompt",
+    "agent.native_tool_contract_feedback": "native_tool_contract_feedback.harn.prompt",
+    "agent.parse_guidance": "parse_guidance.harn.prompt",
+    "agent.protocol_violation_feedback": "protocol_violation_feedback.harn.prompt",
+    "agent.tool_contract_action_native": "tool_contract_action_native.harn.prompt",
+    "agent.tool_contract_action_text": "tool_contract_action_text.harn.prompt",
+    "agent.tool_contract_deferred_tools": "tool_contract_deferred_tools.harn.prompt",
+    "agent.tool_contract_native": "tool_contract_native.harn.prompt",
+    "agent.tool_contract_task_ledger": "tool_contract_task_ledger.harn.prompt",
+    "agent.tool_contract_text": "tool_contract_text.harn.prompt",
+    "agent.tool_contract_text_response_protocol": "tool_contract_text_response_protocol.harn.prompt",
+    "agent.turn_preamble": "agent_turn_preamble.harn.prompt",
+    "agent.verification_gate_feedback": "verification_gate_feedback.harn.prompt",
   }
+}
+
+fn __agent_prompt_expected_ids() {
+  return join(__agent_prompt_ids(), ", ")
+}
+
+fn __agent_is_known_prompt_id(id) {
+  return contains(__agent_prompt_ids(), id)
+}
+
+fn __agent_validate_prompt_entry(id, entry) {
+  let entry_type = type_of(entry)
+  if entry_type == "string" || entry_type == "closure" {
+    return entry
+  }
+  if entry_type != "dict" {
+    throw "agent_prompt_catalog: prompt override " + id
+      + " must be a path string, closure, {text}, or {path}"
+  }
+  for key in entry.keys() {
+    if !contains(["path", "text"], key) {
+      throw "agent_prompt_catalog: prompt override " + id + " has unknown entry key '" + key
+        + "'; expected text or path"
+    }
+  }
+  let has_text = entry?.text != nil
+  let has_path = entry?.path != nil
+  if has_text && has_path {
+    throw "agent_prompt_catalog: prompt override " + id + " must set only one of text or path"
+  }
+  if !has_text && !has_path {
+    throw "agent_prompt_catalog: prompt override " + id + " must set text or path"
+  }
+  if has_text && type_of(entry.text) != "string" {
+    throw "agent_prompt_catalog: prompt override " + id + ".text must be a string"
+  }
+  if has_path && type_of(entry.path) != "string" {
+    throw "agent_prompt_catalog: prompt override " + id + ".path must be a string"
+  }
+  return entry
+}
+
+fn __agent_validate_prompt_overrides(overrides) {
+  if overrides == nil {
+    return {}
+  }
+  if type_of(overrides) != "dict" {
+    throw "agent_prompt_catalog: prompt overrides must be a dict keyed by logical prompt id"
+  }
+  for id in overrides.keys() {
+    if !__agent_is_known_prompt_id(id) {
+      throw "agent_prompt_catalog: unknown prompt id " + id + "; expected one of: "
+        + __agent_prompt_expected_ids()
+    }
+    __agent_validate_prompt_entry(id, overrides[id])
+  }
+  return overrides
+}
+
+fn __agent_options_are_direct_prompt_catalog(options) {
+  if type_of(options) != "dict" {
+    return false
+  }
+  for key in options.keys() {
+    if __agent_is_known_prompt_id(key) || starts_with(key, "agent.") {
+      return true
+    }
+  }
+  return false
 }
 
 fn __agent_prompt_overrides(options = nil) {
@@ -20,7 +157,111 @@ fn __agent_prompt_overrides(options = nil) {
   if type_of(options) != "dict" {
     return {}
   }
-  return options?.prompts ?? options?.prompt_overrides ?? options
+  if options?.prompts != nil {
+    return __agent_validate_prompt_overrides(options.prompts)
+  }
+  if options?.prompt_overrides != nil {
+    return __agent_validate_prompt_overrides(options.prompt_overrides)
+  }
+  if __agent_options_are_direct_prompt_catalog(options) {
+    return __agent_validate_prompt_overrides(options)
+  }
+  return {}
+}
+
+fn __agent_add_prompt_override(out, id, entry) {
+  if entry == nil {
+    return out
+  }
+  return out + {[id]: entry}
+}
+
+/** agent_prompt_ids lists every logical prompt id accepted by the agent prompt catalog. */
+pub fn agent_prompt_ids() -> list<string> {
+  return __agent_prompt_ids()
+}
+
+/** agent_prompt_text creates an inline text prompt override entry. */
+pub fn agent_prompt_text(text: string) -> AgentPromptEntry {
+  return {text: text}
+}
+
+/** agent_prompt_path creates a prompt asset path override entry. */
+pub fn agent_prompt_path(path: string) -> AgentPromptEntry {
+  return {path: path}
+}
+
+/** agent_prompt_override_map converts typed prompt overrides into the logical prompt-id map. */
+pub fn agent_prompt_override_map(overrides: AgentPromptOverrides) -> dict {
+  var out = {}
+  out = __agent_add_prompt_override(
+    out,
+    "agent.action_required_feedback",
+    overrides.action_required_feedback,
+  )
+  out = __agent_add_prompt_override(out, "agent.action_turn_nudge", overrides.action_turn_nudge)
+  out = __agent_add_prompt_override(
+    out,
+    "agent.completion_judge_feedback",
+    overrides.completion_judge_feedback,
+  )
+  out = __agent_add_prompt_override(out, "agent.completion_judge_system", overrides.completion_judge_system)
+  out = __agent_add_prompt_override(out, "agent.completion_judge_user", overrides.completion_judge_user)
+  out = __agent_add_prompt_override(out, "agent.daemon_timer_feedback", overrides.daemon_timer_feedback)
+  out = __agent_add_prompt_override(out, "agent.daemon_watch_feedback", overrides.daemon_watch_feedback)
+  out = __agent_add_prompt_override(out, "agent.default_nudge", overrides.default_nudge)
+  out = __agent_add_prompt_override(out, "agent.deferred_tool_listing", overrides.deferred_tool_listing)
+  out = __agent_add_prompt_override(out, "agent.loop_contract", overrides.loop_contract)
+  out = __agent_add_prompt_override(
+    out,
+    "agent.native_tool_contract_feedback",
+    overrides.native_tool_contract_feedback,
+  )
+  out = __agent_add_prompt_override(out, "agent.parse_guidance", overrides.parse_guidance)
+  out = __agent_add_prompt_override(
+    out,
+    "agent.protocol_violation_feedback",
+    overrides.protocol_violation_feedback,
+  )
+  out = __agent_add_prompt_override(
+    out,
+    "agent.tool_contract_action_native",
+    overrides.tool_contract_action_native,
+  )
+  out = __agent_add_prompt_override(
+    out,
+    "agent.tool_contract_action_text",
+    overrides.tool_contract_action_text,
+  )
+  out = __agent_add_prompt_override(
+    out,
+    "agent.tool_contract_deferred_tools",
+    overrides.tool_contract_deferred_tools,
+  )
+  out = __agent_add_prompt_override(out, "agent.tool_contract_native", overrides.tool_contract_native)
+  out = __agent_add_prompt_override(
+    out,
+    "agent.tool_contract_task_ledger",
+    overrides.tool_contract_task_ledger,
+  )
+  out = __agent_add_prompt_override(out, "agent.tool_contract_text", overrides.tool_contract_text)
+  out = __agent_add_prompt_override(
+    out,
+    "agent.tool_contract_text_response_protocol",
+    overrides.tool_contract_text_response_protocol,
+  )
+  out = __agent_add_prompt_override(out, "agent.turn_preamble", overrides.turn_preamble)
+  out = __agent_add_prompt_override(
+    out,
+    "agent.verification_gate_feedback",
+    overrides.verification_gate_feedback,
+  )
+  return __agent_validate_prompt_overrides(out)
+}
+
+/** agent_prompt_overrides wraps typed prompt overrides for direct use in agent-loop options. */
+pub fn agent_prompt_overrides(overrides: AgentPromptOverrides) -> dict {
+  return {prompts: agent_prompt_override_map(overrides)}
 }
 
 /** agent_prompt_catalog returns the logical prompt-id map used by the agent stdlib. */
@@ -32,19 +273,20 @@ fn __agent_render_prompt_entry(entry, bindings) {
   if type_of(entry) == "closure" {
     return entry(bindings ?? {})
   }
-  if type_of(entry) == "dict" {
-    if entry?.text != nil {
-      return render_string(entry.text, bindings ?? {})
+  var prompt_entry = entry
+  if type_of(prompt_entry) == "dict" {
+    if prompt_entry?.text != nil {
+      return render_string(prompt_entry.text, bindings ?? {})
     }
-    entry = entry?.path
+    prompt_entry = prompt_entry?.path
   }
-  if type_of(entry) != "string" {
-    throw "render_agent_prompt_id: prompt entry must be a path string, closure, or {path|text}"
+  if type_of(prompt_entry) != "string" {
+    throw "render_agent_prompt_id: prompt entry must be a path string, closure, {path}, or {text}"
   }
-  let path = if starts_with(entry, "std/") {
-    entry
+  let path = if starts_with(prompt_entry, "std/") {
+    prompt_entry
   } else {
-    "std/agent/prompts/" + entry
+    "std/agent/prompts/" + prompt_entry
   }
   return render_prompt(path, bindings ?? {})
 }
@@ -62,6 +304,11 @@ pub fn render_agent_prompt_id(id, bindings = nil, options = nil) {
 /** render_agent_prompt renders a std agent prompt asset by filename/path. */
 pub fn render_agent_prompt(path, bindings = nil) {
   return __agent_render_prompt_entry(path, bindings ?? {})
+}
+
+/** action_required_feedback_prompt. */
+pub fn action_required_feedback_prompt(bindings, options = nil) {
+  return render_agent_prompt_id("agent.action_required_feedback", bindings, options)
 }
 
 /** action_turn_nudge_prompt. */
@@ -94,12 +341,77 @@ pub fn completion_judge_user_prompt(bindings, options = nil) {
   return render_agent_prompt_id("agent.completion_judge_user", bindings, options)
 }
 
+/** daemon_timer_feedback_prompt. */
+pub fn daemon_timer_feedback_prompt(options = nil) {
+  return render_agent_prompt_id("agent.daemon_timer_feedback", {}, options)
+}
+
+/** daemon_watch_feedback_prompt. */
+pub fn daemon_watch_feedback_prompt(bindings, options = nil) {
+  return render_agent_prompt_id("agent.daemon_watch_feedback", bindings, options)
+}
+
+/** deferred_tool_listing_prompt. */
+pub fn deferred_tool_listing_prompt(bindings, options = nil) {
+  return render_agent_prompt_id("agent.deferred_tool_listing", bindings, options)
+}
+
 /** native_tool_contract_feedback_prompt. */
 pub fn native_tool_contract_feedback_prompt(bindings, options = nil) {
   return render_agent_prompt_id("agent.native_tool_contract_feedback", bindings, options)
 }
 
+/** parse_guidance_prompt. */
+pub fn parse_guidance_prompt(bindings, options = nil) {
+  return render_agent_prompt_id("agent.parse_guidance", bindings, options)
+}
+
+/** protocol_violation_feedback_prompt. */
+pub fn protocol_violation_feedback_prompt(bindings, options = nil) {
+  return render_agent_prompt_id("agent.protocol_violation_feedback", bindings, options)
+}
+
+/** tool_contract_action_native_prompt. */
+pub fn tool_contract_action_native_prompt(bindings, options = nil) {
+  return render_agent_prompt_id("agent.tool_contract_action_native", bindings, options)
+}
+
+/** tool_contract_action_text_prompt. */
+pub fn tool_contract_action_text_prompt(bindings, options = nil) {
+  return render_agent_prompt_id("agent.tool_contract_action_text", bindings, options)
+}
+
+/** tool_contract_deferred_tools_prompt. */
+pub fn tool_contract_deferred_tools_prompt(bindings, options = nil) {
+  return render_agent_prompt_id("agent.tool_contract_deferred_tools", bindings, options)
+}
+
+/** tool_contract_native_prompt. */
+pub fn tool_contract_native_prompt(bindings, options = nil) {
+  return render_agent_prompt_id("agent.tool_contract_native", bindings, options)
+}
+
+/** tool_contract_task_ledger_prompt. */
+pub fn tool_contract_task_ledger_prompt(bindings, options = nil) {
+  return render_agent_prompt_id("agent.tool_contract_task_ledger", bindings, options)
+}
+
+/** tool_contract_text_prompt. */
+pub fn tool_contract_text_prompt(bindings, options = nil) {
+  return render_agent_prompt_id("agent.tool_contract_text", bindings, options)
+}
+
+/** tool_contract_text_response_protocol_prompt. */
+pub fn tool_contract_text_response_protocol_prompt(bindings, options = nil) {
+  return render_agent_prompt_id("agent.tool_contract_text_response_protocol", bindings, options)
+}
+
 /** agent_turn_preamble_prompt. */
 pub fn agent_turn_preamble_prompt(options = nil) {
   return render_agent_prompt_id("agent.turn_preamble", {}, options)
+}
+
+/** verification_gate_feedback_prompt. */
+pub fn verification_gate_feedback_prompt(bindings, options = nil) {
+  return render_agent_prompt_id("agent.verification_gate_feedback", bindings, options)
 }

--- a/crates/harn-stdlib/src/stdlib/agent/prompts/tool_contract_native.harn.prompt
+++ b/crates/harn-stdlib/src/stdlib/agent/prompts/tool_contract_native.harn.prompt
@@ -4,5 +4,5 @@ The provider exposes tool definitions outside this prompt.
 
 - Invoke tools only through the provider's native tool-calling channel.
 - The current workflow/system prompt may mention only the tool names available for this stage; do not assume tools from earlier stages remain available.
-- Do not write text-mode tool tags, bare `name({ ... })` calls, Markdown code fences, or JSON tool-call envelopes in assistant text.
-- Keep assistant prose short and operational. If you emit a final user-facing answer, wrap it in `<user_response>...</user_response>`. {{ if done_sentinel }}When the task is complete and no more tool calls are needed, include `{{ done_sentinel }}` exactly once in assistant text.{{ else }}When the task is complete and no more tool calls are needed, emit your final user-facing answer in `<user_response>...</user_response>` or plain assistant text and stop calling tools; that signals completion.{{ end }}
+- Do not write tool-call syntax by hand in assistant text, including text-mode tags, function-call snippets, Markdown code fences, or JSON tool-call envelopes.
+- Keep assistant prose short and operational. {{ if done_sentinel }}When the task is complete and no more tool calls are needed, include `{{ done_sentinel }}` exactly once in assistant text.{{ else }}When the task is complete and no more tool calls are needed, give the final user-facing answer as plain assistant text and stop calling tools; that signals completion.{{ end }}

--- a/crates/harn-stdlib/src/stdlib/agent/prompts/tool_contract_text.harn.prompt
+++ b/crates/harn-stdlib/src/stdlib/agent/prompts/tool_contract_text.harn.prompt
@@ -2,19 +2,19 @@
 
 Active mode: `{{ mode }}`. Follow this runtime-owned contract even if older prompt text suggests another tool syntax.
 
-{{ if native_mode }}{{ include "tool_contract_native.harn.prompt" }}{{ if require_action }}
-{{ include "tool_contract_action_native.harn.prompt" }}
+{{ if native_mode }}{{ native_contract }}{{ if require_action }}
+{{ action_native_contract }}
 {{ end }}{{ if include_task_ledger_help }}
-{{ include "tool_contract_task_ledger.harn.prompt" }}
-{{ end }}{{ else }}{{ include "tool_contract_text_response_protocol.harn.prompt" }}{{ if require_action }}
-{{ include "tool_contract_action_text.harn.prompt" }}
+{{ task_ledger_contract }}
+{{ end }}{{ else }}{{ text_response_protocol }}{{ if require_action }}
+{{ action_text_contract }}
 {{ end }}{{ if tool_examples }}
 ## Tool call examples
 
 {{ tool_examples }}
 
 {{ end }}{{ if include_task_ledger_help }}
-{{ include "tool_contract_task_ledger.harn.prompt" }}
+{{ task_ledger_contract }}
 {{ end }}{{ if shared_types }}
 ## Shared types
 

--- a/crates/harn-stdlib/src/stdlib/agent/turn.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/turn.harn
@@ -4,8 +4,8 @@ import { agent_loop } from "std/agent/loop"
 import { agent_loop_options } from "std/agent/options"
 import { agent_turn_preamble_prompt } from "std/agent/prompts"
 
-fn __agent_turn_system(user_system) {
-  let preamble = agent_turn_preamble_prompt()
+fn __agent_turn_system(user_system, opts = nil) {
+  let preamble = agent_turn_preamble_prompt(opts)
   if user_system == nil || user_system == "" {
     return preamble
   }
@@ -120,7 +120,7 @@ pub fn agent_turn(prompt, options = nil) {
   let loop_opts = __agent_turn_options(opts)
   let captured = agent_capture_events(
     loop_opts.session_id,
-    fn() { return agent_loop(prompt, __agent_turn_system(opts?.system), loop_opts) },
+    fn() { return agent_loop(prompt, __agent_turn_system(opts?.system, loop_opts), loop_opts) },
   )
   let result = captured.result
   if type_of(result) != "dict" {

--- a/crates/harn-stdlib/src/stdlib/stdlib_connectors_shared.harn
+++ b/crates/harn-stdlib/src/stdlib/stdlib_connectors_shared.harn
@@ -69,7 +69,7 @@ pub fn oauth2_token_refresh(client_id, client_secret, refresh_token, token_url, 
     ),
   )
   let headers = merge(
-    {Accept: "application/json", ["Content-Type"]: "application/x-www-form-urlencoded"},
+    {Accept: "application/json", "Content-Type": "application/x-www-form-urlencoded"},
     opts.headers ?? {},
   )
   let response = http_post(token_url, __form_body(params), {headers: headers})

--- a/crates/harn-stdlib/src/stdlib/stdlib_graphql.harn
+++ b/crates/harn-stdlib/src/stdlib/stdlib_graphql.harn
@@ -99,10 +99,7 @@ pub fn graphql_introspection_query() {
 
 /** graphql_auth_headers. */
 pub fn graphql_auth_headers(auth = nil, extra_headers = nil) {
-  var headers = {
-    ["Content-Type"]: "application/json",
-    Accept: "application/graphql-response+json, application/json",
-  }
+  var headers = {"Content-Type": "application/json", Accept: "application/graphql-response+json, application/json"}
   if auth != nil {
     if type_of(auth) == "string" {
       headers = merge(headers, {Authorization: "Bearer " + auth})

--- a/crates/harn-vm/src/llm/tools/parse/tagged.rs
+++ b/crates/harn-vm/src/llm/tools/parse/tagged.rs
@@ -84,6 +84,21 @@ pub(crate) fn parse_text_tool_calls_with_tools(
             continue;
         }
 
+        if !is_top_level_tag_position(src, cursor) || inside_markdown_fence(src, cursor) {
+            let start = cursor;
+            while cursor < bytes.len() && bytes[cursor] != b'\n' {
+                cursor += 1;
+            }
+            report_stray(
+                &src[start..cursor],
+                &mut violations,
+                tools_val,
+                &mut calls,
+                &mut canonical_parts,
+            );
+            continue;
+        }
+
         if let Some((body, after)) = match_block(src, cursor, TEXT_TOOL_CALL_TAG)
             .or_else(|| match_block(src, cursor, TEXT_TOOL_CALL_TAG_COMPACT))
         {
@@ -271,6 +286,26 @@ fn try_parse_angle_wrapped_call(
         "arguments": arguments,
     });
     Some((call, end))
+}
+
+fn is_top_level_tag_position(src: &str, cursor: usize) -> bool {
+    let line_start = src[..cursor].rfind('\n').map(|idx| idx + 1).unwrap_or(0);
+    src[line_start..cursor]
+        .chars()
+        .all(|ch| matches!(ch, ' ' | '\t' | '\r'))
+}
+
+fn inside_markdown_fence(src: &str, cursor: usize) -> bool {
+    let mut count = 0;
+    let mut scan = 0;
+    while scan < cursor {
+        let Some(pos) = src[scan..cursor].find("```") else {
+            break;
+        };
+        count += 1;
+        scan += pos + 3;
+    }
+    count % 2 == 1
 }
 
 /// Report stray text that sits outside any recognized top-level tag.

--- a/crates/harn-vm/src/llm/tools/tests/validation_and_tagged.rs
+++ b/crates/harn-vm/src/llm/tools/tests/validation_and_tagged.rs
@@ -262,6 +262,33 @@ fn tagged_parser_accepts_user_response_tag() {
 }
 
 #[test]
+fn tagged_parser_ignores_inline_user_response_placeholder() {
+    let tools = sample_tool_registry();
+    let text =
+        "Use `<user_response>...</user_response>` as the wrapper.\nActual answer in plain prose.";
+    let result = parse_text_tool_calls_with_tools(text, Some(&tools));
+    assert_eq!(result.user_response, None);
+    assert_eq!(result.prose, "");
+    assert!(
+        result
+            .violations
+            .iter()
+            .any(|violation| violation.contains("Stray text outside response tags")),
+        "inline placeholder should be stray prose, not a user response: {:?}",
+        result.violations
+    );
+}
+
+#[test]
+fn tagged_parser_ignores_user_response_inside_markdown_fence() {
+    let tools = sample_tool_registry();
+    let text = "```xml\n<user_response>example only</user_response>\n```\n<user_response>Visible answer.</user_response>";
+    let result = parse_text_tool_calls_with_tools(text, Some(&tools));
+    assert_eq!(result.user_response.as_deref(), Some("Visible answer."));
+    assert_eq!(result.prose, "Visible answer.");
+}
+
+#[test]
 fn tagged_parser_flags_empty_done_block() {
     let tools = sample_tool_registry();
     let text = "<tool_call>\nedit({ action: \"create\", path: \"a.rs\", content: \"x\" })\n</tool_call>\n<done></done>";

--- a/crates/harn-vm/src/stdlib/fs.rs
+++ b/crates/harn-vm/src/stdlib/fs.rs
@@ -826,10 +826,8 @@ mod tests {
         )
         .unwrap()
         .display();
-        assert!(
-            source.contains("{{ include \"tool_contract_text_response_protocol.harn.prompt\" }}")
-        );
-        assert!(source.contains("{{ include \"tool_contract_native.harn.prompt\" }}"));
+        assert!(source.contains("{{ text_response_protocol }}"));
+        assert!(source.contains("{{ native_contract }}"));
     }
 
     #[test]

--- a/crates/harn-vm/src/stdlib/template/tests.rs
+++ b/crates/harn-vm/src/stdlib/template/tests.rs
@@ -306,13 +306,20 @@ fn stdlib_prompt_asset_renders_and_includes_embedded_partial() {
 fn stdlib_prompt_provenance_uses_stable_template_uris() {
     let asset =
         TemplateAsset::render_target("std/agent/prompts/tool_contract_text.harn.prompt").unwrap();
-    let (out, spans) = render_asset_with_provenance_result(&asset, Some(&dict(&[])), true).unwrap();
+    let bindings = dict(&[
+        ("mode", s("text")),
+        ("text_response_protocol", s("rendered response protocol")),
+        ("expanded_schemas", s("rendered schemas")),
+    ]);
+    let (out, spans) = render_asset_with_provenance_result(&asset, Some(&bindings), true).unwrap();
     assert!(out.contains("## Tool Calling Contract"));
+    assert!(out.contains("rendered response protocol"));
     assert!(spans
         .iter()
         .any(|span| span.template_uri == "std://agent/prompts/tool_contract_text.harn.prompt"));
-    assert!(spans.iter().any(|span| span.template_uri
-        == "std://agent/prompts/tool_contract_text_response_protocol.harn.prompt"));
+    assert!(spans
+        .iter()
+        .any(|span| span.bound_value.as_deref() == Some("rendered response protocol")));
 }
 
 #[test]

--- a/crates/harn-vm/src/visible_text.rs
+++ b/crates/harn-vm/src/visible_text.rs
@@ -57,7 +57,7 @@ fn internal_block_patterns() -> &'static [Regex] {
 fn assistant_prose_regex() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
     RE.get_or_init(|| {
-        Regex::new(r"(?s)<assistant_?prose>\s*(.*?)\s*</assistant_?prose>")
+        Regex::new(r"(?ms)^[ \t]*<assistant_?prose>\s*(.*?)\s*</assistant_?prose>")
             .expect("valid assistant_prose regex")
     })
 }
@@ -65,14 +65,42 @@ fn assistant_prose_regex() -> &'static Regex {
 fn user_response_regex() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
     RE.get_or_init(|| {
-        Regex::new(r"(?s)<user_?response>\s*(.*?)\s*</user_?response>")
+        Regex::new(r"(?ms)^[ \t]*<user_?response>\s*(.*?)\s*</user_?response>")
             .expect("valid user_response regex")
     })
+}
+
+fn inside_markdown_fence(text: &str, idx: usize) -> bool {
+    let mut count = 0;
+    let mut cursor = 0;
+    while cursor < idx {
+        let Some(pos) = text[cursor..idx].find("```") else {
+            break;
+        };
+        count += 1;
+        cursor += pos + 3;
+    }
+    count % 2 == 1
+}
+
+fn is_top_level_tag_position(text: &str, idx: usize) -> bool {
+    let line_start = text[..idx].rfind('\n').map(|pos| pos + 1).unwrap_or(0);
+    text[line_start..idx]
+        .chars()
+        .all(|ch| matches!(ch, ' ' | '\t' | '\r'))
+}
+
+fn is_protocol_tag_position(text: &str, idx: usize) -> bool {
+    is_top_level_tag_position(text, idx) && !inside_markdown_fence(text, idx)
 }
 
 fn extract_user_response(text: &str) -> Option<String> {
     let sections: Vec<String> = user_response_regex()
         .captures_iter(text)
+        .filter(|caps| {
+            caps.get(0)
+                .is_some_and(|m| is_protocol_tag_position(text, m.start()))
+        })
         .filter_map(|caps| caps.get(1).map(|m| m.as_str().trim().to_string()))
         .filter(|section| !section.is_empty())
         .collect();
@@ -83,6 +111,26 @@ fn extract_user_response(text: &str) -> Option<String> {
     }
 }
 
+fn unwrap_assistant_prose(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut last = 0;
+    for caps in assistant_prose_regex().captures_iter(text) {
+        let Some(block) = caps.get(0) else {
+            continue;
+        };
+        if !is_protocol_tag_position(text, block.start()) {
+            continue;
+        }
+        out.push_str(&text[last..block.start()]);
+        if let Some(body) = caps.get(1) {
+            out.push_str(body.as_str().trim());
+        }
+        last = block.end();
+    }
+    out.push_str(&text[last..]);
+    out
+}
+
 /// Strip the wrapper tags around `<assistant_prose>` blocks so the
 /// surfaced visible text reads as plain narration. When a
 /// `<user_response>` block is present, it becomes the authoritative
@@ -91,7 +139,7 @@ fn extract_visible_prose(text: &str) -> String {
     if let Some(user_response) = extract_user_response(text) {
         return user_response;
     }
-    assistant_prose_regex().replace_all(text, "$1").to_string()
+    unwrap_assistant_prose(text)
 }
 
 fn json_fence_regex() -> &'static Regex {
@@ -203,35 +251,35 @@ fn strip_unclosed_internal_blocks(text: &str) -> String {
 
     if let Some(open_idx) = text.rfind(TEXT_TOOL_CALL_OPEN) {
         let close_idx = text.rfind(TEXT_TOOL_CALL_CLOSE);
-        if close_idx.is_none_or(|idx| idx < open_idx) {
+        if is_protocol_tag_position(text, open_idx) && close_idx.is_none_or(|idx| idx < open_idx) {
             return text[..open_idx].to_string();
         }
     }
 
     if let Some(open_idx) = text.rfind(TEXT_TOOL_CALL_OPEN_COMPACT) {
         let close_idx = text.rfind(TEXT_TOOL_CALL_CLOSE_COMPACT);
-        if close_idx.is_none_or(|idx| idx < open_idx) {
+        if is_protocol_tag_position(text, open_idx) && close_idx.is_none_or(|idx| idx < open_idx) {
             return text[..open_idx].to_string();
         }
     }
 
     if let Some(open_idx) = text.rfind("<done>") {
         let close_idx = text.rfind("</done>");
-        if close_idx.is_none_or(|idx| idx < open_idx) {
+        if is_protocol_tag_position(text, open_idx) && close_idx.is_none_or(|idx| idx < open_idx) {
             return text[..open_idx].to_string();
         }
     }
 
     if let Some(open_idx) = text.rfind("<user_response>") {
         let close_idx = text.rfind("</user_response>");
-        if close_idx.is_none_or(|idx| idx < open_idx) {
+        if is_protocol_tag_position(text, open_idx) && close_idx.is_none_or(|idx| idx < open_idx) {
             return text[..open_idx].to_string();
         }
     }
 
     if let Some(open_idx) = text.rfind("<userresponse>") {
         let close_idx = text.rfind("</userresponse>");
-        if close_idx.is_none_or(|idx| idx < open_idx) {
+        if is_protocol_tag_position(text, open_idx) && close_idx.is_none_or(|idx| idx < open_idx) {
             return text[..open_idx].to_string();
         }
     }
@@ -245,7 +293,7 @@ fn strip_unclosed_internal_blocks(text: &str) -> String {
 
     if let Some(open_idx) = text.rfind("<tool_result") {
         let close_idx = text.rfind("</tool_result>");
-        if close_idx.is_none_or(|idx| idx < open_idx) {
+        if is_protocol_tag_position(text, open_idx) && close_idx.is_none_or(|idx| idx < open_idx) {
             return text[..open_idx].to_string();
         }
     }
@@ -285,7 +333,9 @@ fn strip_partial_marker_suffix(text: &str) -> String {
         for len in (1..marker.len()).rev() {
             let prefix = &marker[..len];
             if let Some(stripped) = text.strip_suffix(prefix) {
-                return stripped.to_string();
+                if is_protocol_tag_position(text, stripped.len()) {
+                    return stripped.to_string();
+                }
             }
         }
     }
@@ -420,5 +470,38 @@ mod tests {
             sanitize_visible_assistant_text("A tool call summary is fine.", false),
             "A tool call summary is fine."
         );
+    }
+
+    #[test]
+    fn sanitize_ignores_inline_user_response_placeholder() {
+        let raw = "Wrap final answers in `<user_response>...</user_response>`.\nAudit: real answer";
+        assert_eq!(sanitize_visible_assistant_text(raw, false), raw);
+    }
+
+    #[test]
+    fn sanitize_prefers_top_level_user_response_over_inline_placeholder() {
+        let raw =
+            "Remember `<user_response>...</user_response>` is the wrapper.\n<user_response>Visible answer.</user_response>";
+        assert_eq!(
+            sanitize_visible_assistant_text(raw, false),
+            "Visible answer."
+        );
+    }
+
+    #[test]
+    fn sanitize_ignores_user_response_inside_markdown_fence() {
+        let raw = "```xml\n<user_response>example only</user_response>\n```\nFinal plain answer.";
+        assert_eq!(sanitize_visible_assistant_text(raw, false), raw);
+    }
+
+    #[test]
+    fn sanitize_partial_keeps_inline_protocol_prefixes() {
+        let raw = "Mention `<user_resp";
+        assert_eq!(sanitize_visible_assistant_text(raw, true), raw);
+    }
+
+    #[test]
+    fn sanitize_partial_hides_top_level_protocol_prefixes() {
+        assert_eq!(sanitize_visible_assistant_text("<user_resp", true), "");
     }
 }

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -608,8 +608,10 @@ arg_element        ::= '...' expression | expression
 ```
 
 Dict keys written as bare identifiers are converted to string literals
-(e.g., `{name: "x"}` becomes `{"name": "x"}`).
-Computed keys use bracket syntax: `{[expr]: value}`.
+(e.g., `{name: "x"}` becomes `{"name": "x"}`). String-literal keys may contain
+dots or other non-identifier characters; the formatter keeps identifier string
+keys bare and keeps non-identifier string keys quoted (for example,
+`{"a.b.c": "x", k: "y"}`). Computed keys use bracket syntax: `{[expr]: value}`.
 
 ## Operator precedence table
 

--- a/docs/src/llm/agent_loop.md
+++ b/docs/src/llm/agent_loop.md
@@ -134,7 +134,7 @@ Same as `llm_call`, plus additional options:
 | `context_filter` | closure | nil | Alias for `context_callback` |
 | `timestamp_messages` | bool | `false` | Decorate prompt-visible transcript messages with the current harness timestamp before each LLM call without mutating the stored transcript |
 | `message_decorator` | closure | nil | Per-message hook called as `message_decorator(message, context)` before each LLM call. The context includes `session_id`, `iteration`, `index`, and `timestamp` |
-| `prompts` / `prompt_overrides` | dict | nil | Override logical agent prompt ids such as `agent.loop_contract`, `agent.tool_contract_text`, and `agent.completion_judge_system` with a prompt asset path, `{text}`, `{path}`, or render closure |
+| `prompts` / `prompt_overrides` | dict | nil | Override validated logical agent prompt ids such as `agent.loop_contract`, `agent.tool_contract_text`, and `agent.completion_judge_system` with a prompt asset path, `{text}`, `{path}`, or render closure. Unknown ids are rejected. For typo-resistant authoring, pass the typed override shape through `agent_prompt_overrides(...)` from `std/agent/prompts` |
 | `post_turn_callback` | closure | nil | Hook called after each turn. Receives turn metadata and may inject a message, request an immediate stage stop, or merge next-turn options such as `llm_options: {tool_choice: "none"}` |
 | `verify_completion` | closure | nil | Hook called when the loop is about to stop naturally. Return `nil`/`true` to accept the stop or feedback text to veto and continue |
 | `verify_completion_judge` | bool/dict | nil | Built-in structured judge for any natural stop. `true` uses defaults; a dict may set `provider`, `model`, `system`, and `feedback_fallback` |

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -606,8 +606,10 @@ arg_element        ::= '...' expression | expression
 ```
 
 Dict keys written as bare identifiers are converted to string literals
-(e.g., `{name: "x"}` becomes `{"name": "x"}`).
-Computed keys use bracket syntax: `{[expr]: value}`.
+(e.g., `{name: "x"}` becomes `{"name": "x"}`). String-literal keys may contain
+dots or other non-identifier characters; the formatter keeps identifier string
+keys bare and keeps non-identifier string keys quoted (for example,
+`{"a.b.c": "x", k: "y"}`). Computed keys use bracket syntax: `{[expr]: value}`.
 
 ## Operator precedence table
 


### PR DESCRIPTION
## Summary
- format non-identifier string dict keys as quoted literal keys and add dotted-key conformance coverage
- expand and validate the agent prompt override catalog, including typed override helper shapes and all embedded agent prompt fragments
- route composite/daemon/agent_turn prompts through the catalog so fragment overrides take effect

## Verification
- cargo test -p harn-fmt
- cargo test -p harn-stdlib
- cargo test -p harn-vm stdlib_prompt
- harn conformance: dotted_dict_keys, agent_prompt_overrides_and_timestamps, agent_daemon_mode, agent_turn
- harn fmt/check on touched Harn files
- git diff --check
- pre-commit and pre-push hooks