### PR TITLE
Add harn run --profile categorical timing breakdown

### DIFF
--- a/crates/harn-cli/src/cli/run.rs
+++ b/crates/harn-cli/src/cli/run.rs
@@ -5,6 +5,14 @@ pub(crate) struct RunArgs {
     /// Print the LLM trace summary after execution.
     #[arg(long)]
     pub trace: bool,
+    /// Print a categorical timing breakdown after execution (LLM vs tools
+    /// vs steps vs VM/residual). Implies tracing instrumentation; OK to
+    /// combine with `--trace`.
+    #[arg(long)]
+    pub profile: bool,
+    /// Write the profile rollup as JSON to the given path. Implies `--profile`.
+    #[arg(long = "profile-json", value_name = "PATH")]
+    pub profile_json: Option<String>,
     /// Deny specific builtins as a comma-separated list.
     #[arg(long, conflicts_with = "allow")]
     pub deny: Option<String>,

--- a/crates/harn-cli/src/commands/run.rs
+++ b/crates/harn-cli/src/commands/run.rs
@@ -128,6 +128,22 @@ pub struct RunAttestationOptions {
     pub agent_id: Option<String>,
 }
 
+/// Opt-in profiling. When `text` is true the run prints a categorical
+/// breakdown to stderr after execution; when `json_path` is set the same
+/// rollup is serialized to that path. Either flag enables span tracing
+/// (i.e. `harn_vm::tracing::set_tracing_enabled(true)`).
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct RunProfileOptions {
+    pub text: bool,
+    pub json_path: Option<PathBuf>,
+}
+
+impl RunProfileOptions {
+    pub fn is_enabled(&self) -> bool {
+        self.text || self.json_path.is_some()
+    }
+}
+
 /// Captured outcome of an in-process `execute_run` invocation. Tests use this
 /// instead of spawning the `harn` binary; the binary entry point translates
 /// it into real stdout/stderr writes + `process::exit`.
@@ -467,6 +483,7 @@ pub(crate) async fn run_file(
     script_argv: Vec<String>,
     llm_mock_mode: CliLlmMockMode,
     attestation: Option<RunAttestationOptions>,
+    profile: RunProfileOptions,
 ) {
     run_file_with_skill_dirs(
         path,
@@ -476,6 +493,7 @@ pub(crate) async fn run_file(
         Vec::new(),
         llm_mock_mode,
         attestation,
+        profile,
     )
     .await;
 }
@@ -488,6 +506,7 @@ pub(crate) async fn run_file_with_skill_dirs(
     skill_dirs_raw: Vec<String>,
     llm_mock_mode: CliLlmMockMode,
     attestation: Option<RunAttestationOptions>,
+    profile: RunProfileOptions,
 ) {
     // Graceful shutdown: flush run records before exit on SIGINT/SIGTERM.
     let cancelled = install_signal_shutdown_handler();
@@ -500,6 +519,7 @@ pub(crate) async fn run_file_with_skill_dirs(
         skill_dirs_raw,
         llm_mock_mode,
         attestation,
+        profile,
     )
     .await;
 
@@ -563,6 +583,7 @@ pub async fn execute_run(
     skill_dirs_raw: Vec<String>,
     llm_mock_mode: CliLlmMockMode,
     attestation: Option<RunAttestationOptions>,
+    profile: RunProfileOptions,
 ) -> RunOutcome {
     let mut stderr = String::new();
     let mut stdout = String::new();
@@ -600,6 +621,9 @@ pub async fn execute_run(
 
     if trace {
         harn_vm::llm::enable_tracing();
+    }
+    if profile.is_enabled() {
+        harn_vm::tracing::set_tracing_enabled(true);
     }
     if let Err(error) = install_cli_llm_mock_mode(&llm_mock_mode) {
         stderr.push_str(&format!("error: {error}\n"));
@@ -765,6 +789,11 @@ pub async fn execute_run(
             if trace {
                 stderr.push_str(&render_trace_summary());
             }
+            if profile.is_enabled() {
+                if let Err(error) = render_and_persist_profile(&profile, &mut stderr) {
+                    stderr.push_str(&format!("warning: failed to write profile: {error}\n"));
+                }
+            }
             if exit_code != 0 {
                 stderr.push_str(&render_return_value_error(&return_value));
             }
@@ -776,6 +805,11 @@ pub async fn execute_run(
         }
         Err(rendered_error) => {
             stderr.push_str(&rendered_error);
+            if profile.is_enabled() {
+                if let Err(error) = render_and_persist_profile(&profile, &mut stderr) {
+                    stderr.push_str(&format!("warning: failed to write profile: {error}\n"));
+                }
+            }
             RunOutcome {
                 stdout,
                 stderr,
@@ -783,6 +817,29 @@ pub async fn execute_run(
             }
         }
     }
+}
+
+fn render_and_persist_profile(
+    options: &RunProfileOptions,
+    stderr: &mut String,
+) -> Result<(), String> {
+    let spans = harn_vm::tracing::peek_spans();
+    let profile = harn_vm::profile::build(&spans);
+    if options.text {
+        stderr.push_str(&harn_vm::profile::render(&profile));
+    }
+    if let Some(path) = options.json_path.as_ref() {
+        if let Some(parent) = path.parent() {
+            if !parent.as_os_str().is_empty() {
+                fs::create_dir_all(parent)
+                    .map_err(|error| format!("create {}: {error}", parent.display()))?;
+            }
+        }
+        let json = serde_json::to_string_pretty(&profile)
+            .map_err(|error| format!("serialize profile: {error}"))?;
+        fs::write(path, json).map_err(|error| format!("write {}: {error}", path.display()))?;
+    }
+    Ok(())
 }
 
 async fn append_run_provenance_event(
@@ -1279,6 +1336,7 @@ pub(crate) async fn run_watch(path: &str, denied_builtins: HashSet<String>) {
         Vec::new(),
         CliLlmMockMode::Off,
         None,
+        RunProfileOptions::default(),
     )
     .await;
 
@@ -1334,6 +1392,7 @@ pub(crate) async fn run_watch(path: &str, denied_builtins: HashSet<String>) {
             Vec::new(),
             CliLlmMockMode::Off,
             None,
+            RunProfileOptions::default(),
         )
         .await;
     }
@@ -1341,7 +1400,7 @@ pub(crate) async fn run_watch(path: &str, denied_builtins: HashSet<String>) {
 
 #[cfg(test)]
 mod tests {
-    use super::{execute_run, CliLlmMockMode};
+    use super::{execute_run, CliLlmMockMode, RunProfileOptions};
     use std::collections::HashSet;
 
     #[cfg(feature = "hostlib")]
@@ -1367,6 +1426,7 @@ pipeline main() {
             Vec::new(),
             CliLlmMockMode::Off,
             None,
+            RunProfileOptions::default(),
         )
         .await;
 
@@ -1411,6 +1471,7 @@ pipeline main() {
             Vec::new(),
             CliLlmMockMode::Off,
             None,
+            RunProfileOptions::default(),
         )
         .await;
 

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -72,6 +72,7 @@ async fn async_main() {
             Vec::new(),
             commands::run::CliLlmMockMode::Off,
             None,
+            commands::run::RunProfileOptions::default(),
         )
         .await;
         return;
@@ -125,6 +126,10 @@ async fn async_main() {
                 receipt_out: args.receipt_out.as_ref().map(PathBuf::from),
                 agent_id: args.attest_agent.clone(),
             });
+            let profile_options = commands::run::RunProfileOptions {
+                text: args.profile,
+                json_path: args.profile_json.as_ref().map(PathBuf::from),
+            };
 
             match (args.eval.as_deref(), args.file.as_deref()) {
                 (Some(code), None) => {
@@ -153,6 +158,7 @@ async fn async_main() {
                         args.skill_dir.clone(),
                         llm_mock_mode.clone(),
                         attestation.clone(),
+                        profile_options.clone(),
                     )
                     .await;
                     drop(tmp);
@@ -166,6 +172,7 @@ async fn async_main() {
                         args.skill_dir.clone(),
                         llm_mock_mode,
                         attestation,
+                        profile_options,
                     )
                     .await
                 }

--- a/crates/harn-cli/tests/burin_mini_playground.rs
+++ b/crates/harn-cli/tests/burin_mini_playground.rs
@@ -19,7 +19,7 @@ use std::path::{Path, PathBuf};
 use std::thread;
 
 use harn_cli::commands::playground::{execute_playground_inputs, PlaygroundInputs};
-use harn_cli::commands::run::{execute_run, CliLlmMockMode, RunOutcome};
+use harn_cli::commands::run::{execute_run, CliLlmMockMode, RunOutcome, RunProfileOptions};
 use harn_cli::tests::common::{cwd_lock, env_lock};
 use tempfile::TempDir;
 
@@ -490,6 +490,7 @@ fn burin_mini_semantic_evaluator_heuristic_passes_for_rate_limit_fixture() {
             Vec::new(),
             CliLlmMockMode::Off,
             None,
+            RunProfileOptions::default(),
         )
         .await;
         std::env::remove_var("BURIN_MINI_SEMANTIC_EVAL_MODE");

--- a/crates/harn-cli/tests/llm_mock_cli.rs
+++ b/crates/harn-cli/tests/llm_mock_cli.rs
@@ -21,7 +21,7 @@ use std::path::{Path, PathBuf};
 use std::thread;
 
 use harn_cli::commands::playground::{execute_playground_inputs, PlaygroundInputs};
-use harn_cli::commands::run::{execute_run, CliLlmMockMode, RunOutcome};
+use harn_cli::commands::run::{execute_run, CliLlmMockMode, RunOutcome, RunProfileOptions};
 use harn_cli::tests::common::{cwd_lock, env_lock};
 use tempfile::TempDir;
 
@@ -88,6 +88,7 @@ fn run_harn_in_process(
             Vec::new(),
             llm_mock_mode,
             None,
+            RunProfileOptions::default(),
         )
         .await;
         for (key, prev) in originals.iter().rev() {

--- a/crates/harn-cli/tests/profile.rs
+++ b/crates/harn-cli/tests/profile.rs
@@ -1,0 +1,244 @@
+#![recursion_limit = "256"]
+
+//! Integration coverage for `harn run --profile` / `harn run --profile-json`.
+//!
+//! Runs a tiny self-contained script (no real LLM calls) through
+//! `execute_run` with profiling enabled and asserts that:
+//!   1. the text profile renders to stderr
+//!   2. the JSON profile is written to disk and round-trips into `RunProfile`
+//!   3. the `pipeline` span at the root has a wall time
+//!
+//! Stays away from `llm_call` so this test doesn't need network or mock
+//! fixtures — the categorical buckets just won't include `llm_call` here.
+
+use std::collections::HashSet;
+use std::fs;
+use std::thread;
+
+use harn_cli::commands::run::{execute_run, CliLlmMockMode, RunOutcome, RunProfileOptions};
+use harn_cli::tests::common::{cwd_lock, env_lock};
+use harn_vm::profile::RunProfile;
+use tempfile::TempDir;
+
+fn run_in_harn_runtime<F, Fut, R>(future_factory: F) -> R
+where
+    F: FnOnce() -> Fut + Send + 'static,
+    Fut: std::future::Future<Output = R>,
+    R: Send + 'static,
+{
+    let handle = thread::Builder::new()
+        .name("harn-cli-profile-test".to_string())
+        .stack_size(harn_cli::CLI_RUNTIME_STACK_SIZE)
+        .spawn(move || {
+            let runtime = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()
+                .expect("build runtime");
+            let local = tokio::task::LocalSet::new();
+            local.block_on(&runtime, future_factory())
+        })
+        .expect("spawn test thread");
+    handle.join().expect("join test thread")
+}
+
+#[test]
+fn profile_text_and_json_roundtrip() {
+    let tempdir = TempDir::new().expect("temp dir");
+    let script = tempdir.path().join("script.harn");
+    fs::write(
+        &script,
+        r#"
+pipeline main() {
+  println("hello")
+}
+"#,
+    )
+    .expect("write script");
+    let json_path = tempdir.path().join("profile.json");
+
+    let outcome: RunOutcome = run_in_harn_runtime({
+        let script = script.clone();
+        let json_path = json_path.clone();
+        move || async move {
+            let _env_guard = env_lock::lock_env().lock().await;
+            let _cwd_guard = cwd_lock::lock_cwd_async().await;
+            harn_vm::reset_thread_local_state();
+            execute_run(
+                &script.to_string_lossy(),
+                false,
+                HashSet::new(),
+                Vec::new(),
+                Vec::new(),
+                CliLlmMockMode::Off,
+                None,
+                RunProfileOptions {
+                    text: true,
+                    json_path: Some(json_path.clone()),
+                },
+            )
+            .await
+        }
+    });
+
+    assert_eq!(outcome.exit_code, 0, "stderr:\n{}", outcome.stderr);
+    assert!(outcome.stdout.contains("hello"));
+    assert!(
+        outcome.stderr.contains("Run profile"),
+        "stderr should include text profile, got:\n{}",
+        outcome.stderr
+    );
+    assert!(
+        outcome.stderr.contains("vm/residual"),
+        "stderr should include residual bucket, got:\n{}",
+        outcome.stderr
+    );
+
+    let json = fs::read_to_string(&json_path).expect("read profile.json");
+    let profile: RunProfile = serde_json::from_str(&json).expect("parse profile.json");
+    // Wall time can be 0 for trivial scripts (sub-ms). What we care
+    // about is that the JSON round-tripped into the canonical struct.
+    // No @step blocks in the script, so steps must be empty.
+    assert!(
+        profile.steps.is_empty(),
+        "unexpected steps: {:?}",
+        profile.steps
+    );
+    assert!(
+        profile.top_llm_calls.is_empty(),
+        "no llm_call expected: {:?}",
+        profile.top_llm_calls
+    );
+}
+
+#[test]
+fn profile_records_step_spans_and_attributes_llm_to_step() {
+    let tempdir = TempDir::new().expect("temp dir");
+    let script = tempdir.path().join("step_script.harn");
+    fs::write(
+        &script,
+        r#"
+fn classify(ctx) -> string {
+  let r = llm_call("classify ${ctx}", nil, {provider: "mock"})
+  return r.text
+}
+
+@step(name: "classify_step", model: "claude-haiku-4-5", error_boundary: fail)
+fn classify_step(ctx) -> string {
+  return classify(ctx)
+}
+
+pipeline main() {
+  llm_mock_clear()
+  llm_mock({
+    match: "classify*",
+    consume_match: false,
+    text: "ok",
+    input_tokens: 5,
+    output_tokens: 3,
+    model: "claude-haiku-4-5",
+  })
+  let out = classify_step("input")
+  println(out)
+}
+"#,
+    )
+    .expect("write script");
+    let json_path = tempdir.path().join("step_profile.json");
+
+    let outcome: RunOutcome = run_in_harn_runtime({
+        let script = script.clone();
+        let json_path = json_path.clone();
+        move || async move {
+            let _env_guard = env_lock::lock_env().lock().await;
+            let _cwd_guard = cwd_lock::lock_cwd_async().await;
+            harn_vm::reset_thread_local_state();
+            execute_run(
+                &script.to_string_lossy(),
+                false,
+                HashSet::new(),
+                Vec::new(),
+                Vec::new(),
+                CliLlmMockMode::Off,
+                None,
+                RunProfileOptions {
+                    text: true,
+                    json_path: Some(json_path.clone()),
+                },
+            )
+            .await
+        }
+    });
+
+    assert_eq!(outcome.exit_code, 0, "stderr:\n{}", outcome.stderr);
+    let profile: RunProfile =
+        serde_json::from_str(&fs::read_to_string(&json_path).expect("read profile.json"))
+            .expect("parse profile.json");
+
+    // The @step block must produce a step summary.
+    assert_eq!(
+        profile.steps.len(),
+        1,
+        "expected exactly one step span, got: {:?}",
+        profile.steps
+    );
+    assert_eq!(profile.steps[0].name, "classify_step");
+    assert_eq!(profile.steps[0].llm_calls, 1);
+
+    // The llm_call must be attributed to the enclosing step.
+    assert_eq!(profile.top_llm_calls.len(), 1);
+    assert_eq!(
+        profile.top_llm_calls[0].step.as_deref(),
+        Some("classify_step"),
+        "llm_call should attribute to enclosing step: {:?}",
+        profile.top_llm_calls[0]
+    );
+
+    // The text output must mention the per-step section.
+    assert!(
+        outcome.stderr.contains("Per-@step:"),
+        "stderr should include Per-@step section, got:\n{}",
+        outcome.stderr
+    );
+}
+
+#[test]
+fn profile_disabled_means_no_stderr_section() {
+    let tempdir = TempDir::new().expect("temp dir");
+    let script = tempdir.path().join("script.harn");
+    fs::write(
+        &script,
+        r#"
+pipeline main() {
+  println("hi")
+}
+"#,
+    )
+    .expect("write script");
+
+    let outcome: RunOutcome = run_in_harn_runtime({
+        let script = script.clone();
+        move || async move {
+            let _env_guard = env_lock::lock_env().lock().await;
+            let _cwd_guard = cwd_lock::lock_cwd_async().await;
+            harn_vm::reset_thread_local_state();
+            execute_run(
+                &script.to_string_lossy(),
+                false,
+                HashSet::new(),
+                Vec::new(),
+                Vec::new(),
+                CliLlmMockMode::Off,
+                None,
+                RunProfileOptions::default(),
+            )
+            .await
+        }
+    });
+
+    assert_eq!(outcome.exit_code, 0, "stderr:\n{}", outcome.stderr);
+    assert!(
+        !outcome.stderr.contains("Run profile"),
+        "did not expect profile output without flag, got:\n{}",
+        outcome.stderr
+    );
+}

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -34,6 +34,7 @@ pub mod observability;
 pub mod orchestration;
 pub mod personas;
 pub mod process_sandbox;
+pub mod profile;
 pub mod provenance;
 pub mod receipts;
 pub mod record_filter;

--- a/crates/harn-vm/src/profile.rs
+++ b/crates/harn-vm/src/profile.rs
@@ -1,0 +1,465 @@
+//! Categorical profile rollup over completed [`crate::tracing::Span`]s.
+//!
+//! Turns the raw span tree (parent/child, kinds, durations) into a digestible
+//! "where did the time go?" answer for harness writers. This module owns no
+//! state of its own — it consumes the snapshot returned by
+//! [`crate::tracing::peek_spans`] and folds it into a [`RunProfile`] that
+//! callers can render to text or serialize to JSON.
+//!
+//! Top-level wall time and residual ("VM / script overhead") are computed
+//! by summing only spans whose parent is the pipeline root (or `None`),
+//! so nested LLM/tool work isn't double-counted under both its category
+//! and its containing step.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::tracing::Span;
+
+/// Top-N to surface in the rendered profile. Kept small so the stderr
+/// summary stays scannable.
+const TOP_N: usize = 5;
+
+/// Aggregate breakdown of one run's spans.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct RunProfile {
+    pub total_wall_ms: u64,
+    pub by_kind: Vec<KindBucket>,
+    pub residual_ms: u64,
+    pub top_llm_calls: Vec<SpanRef>,
+    pub top_tool_calls: Vec<SpanRef>,
+    pub steps: Vec<StepSummary>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct KindBucket {
+    pub kind: String,
+    pub total_ms: u64,
+    pub count: u64,
+    pub pct_of_wall: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct SpanRef {
+    pub span_id: u64,
+    pub kind: String,
+    pub name: String,
+    pub duration_ms: u64,
+    pub step: Option<String>,
+    pub model: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct StepSummary {
+    pub name: String,
+    pub duration_ms: u64,
+    pub llm_ms: u64,
+    pub tool_ms: u64,
+    pub other_ms: u64,
+    pub llm_calls: u64,
+    pub tool_calls: u64,
+}
+
+/// Build a profile from a slice of completed spans. Designed to be called
+/// post-run with `crate::tracing::peek_spans()`. Pure function — does not
+/// touch globals.
+pub fn build(spans: &[Span]) -> RunProfile {
+    if spans.is_empty() {
+        return RunProfile::default();
+    }
+
+    // The pipeline root is conventionally the only top-level span. If a
+    // run somehow produced multiple, we sum them — accurate for total
+    // wall time, just unusual.
+    let total_wall_ms: u64 = spans
+        .iter()
+        .filter(|s| s.parent_id.is_none())
+        .map(|s| s.duration_ms)
+        .sum();
+
+    let by_kind = bucket_by_kind(spans, total_wall_ms);
+
+    // Residual = wall - sum of "real work" categories at the top level.
+    // Imports/parallel/spawn count as work too; the category buckets cover
+    // them so we just subtract everything that was already accounted for
+    // at depth 1.
+    let depth1_total: u64 = spans
+        .iter()
+        .filter(|s| matches!(s.parent_id, Some(pid) if is_pipeline_root(spans, pid)))
+        .map(|s| s.duration_ms)
+        .sum();
+    let residual_ms = total_wall_ms.saturating_sub(depth1_total);
+
+    let top_llm_calls = top_n_by_duration(spans, "llm_call");
+    let top_tool_calls = top_n_by_duration(spans, "tool_call");
+    let steps = build_step_summaries(spans);
+
+    RunProfile {
+        total_wall_ms,
+        by_kind,
+        residual_ms,
+        top_llm_calls,
+        top_tool_calls,
+        steps,
+    }
+}
+
+fn is_pipeline_root(spans: &[Span], id: u64) -> bool {
+    spans
+        .iter()
+        .find(|s| s.span_id == id)
+        .map(|s| s.parent_id.is_none())
+        .unwrap_or(false)
+}
+
+fn bucket_by_kind(spans: &[Span], total_wall_ms: u64) -> Vec<KindBucket> {
+    // Sum per kind across ALL spans of that kind (any depth). This is
+    // the user's mental model of "how much LLM time was there in this
+    // run?" — overlapping/nested doesn't matter because LLM calls are
+    // leaves.
+    let mut totals: BTreeMap<String, (u64, u64)> = BTreeMap::new();
+    for span in spans {
+        if span.parent_id.is_none() {
+            // Skip the synthetic pipeline span; it's the wall-time
+            // denominator, not a category bucket.
+            continue;
+        }
+        let entry = totals.entry(span.kind.as_str().to_string()).or_default();
+        entry.0 += span.duration_ms;
+        entry.1 += 1;
+    }
+    let mut buckets: Vec<KindBucket> = totals
+        .into_iter()
+        .map(|(kind, (total_ms, count))| KindBucket {
+            kind,
+            total_ms,
+            count,
+            pct_of_wall: pct(total_ms, total_wall_ms),
+        })
+        .collect();
+    buckets.sort_by_key(|bucket| std::cmp::Reverse(bucket.total_ms));
+    buckets
+}
+
+fn top_n_by_duration(spans: &[Span], kind: &str) -> Vec<SpanRef> {
+    let mut matches: Vec<&Span> = spans.iter().filter(|s| s.kind.as_str() == kind).collect();
+    matches.sort_by_key(|span| std::cmp::Reverse(span.duration_ms));
+    matches
+        .into_iter()
+        .take(TOP_N)
+        .map(|span| SpanRef {
+            span_id: span.span_id,
+            kind: span.kind.as_str().to_string(),
+            name: span.name.clone(),
+            duration_ms: span.duration_ms,
+            step: enclosing_step_name(spans, span.parent_id),
+            model: span
+                .metadata
+                .get("model")
+                .and_then(|v| v.as_str())
+                .map(str::to_string),
+        })
+        .collect()
+}
+
+fn enclosing_step_name(spans: &[Span], mut parent_id: Option<u64>) -> Option<String> {
+    while let Some(pid) = parent_id {
+        let parent = spans.iter().find(|s| s.span_id == pid)?;
+        if parent.kind.as_str() == "step" {
+            return Some(parent.name.clone());
+        }
+        parent_id = parent.parent_id;
+    }
+    None
+}
+
+fn build_step_summaries(spans: &[Span]) -> Vec<StepSummary> {
+    let mut steps: Vec<StepSummary> = Vec::new();
+    for step_span in spans.iter().filter(|s| s.kind.as_str() == "step") {
+        let mut summary = StepSummary {
+            name: step_span.name.clone(),
+            duration_ms: step_span.duration_ms,
+            ..StepSummary::default()
+        };
+        for descendant in descendants(spans, step_span.span_id) {
+            match descendant.kind.as_str() {
+                "llm_call" => {
+                    summary.llm_ms += descendant.duration_ms;
+                    summary.llm_calls += 1;
+                }
+                "tool_call" => {
+                    summary.tool_ms += descendant.duration_ms;
+                    summary.tool_calls += 1;
+                }
+                _ => {}
+            }
+        }
+        // "other" approximates VM + script overhead inside the step.
+        // LLM/tool durations can overlap (parallel calls), so clamp at 0.
+        summary.other_ms = summary
+            .duration_ms
+            .saturating_sub(summary.llm_ms.saturating_add(summary.tool_ms));
+        steps.push(summary);
+    }
+    steps.sort_by_key(|summary| std::cmp::Reverse(summary.duration_ms));
+    steps
+}
+
+fn descendants(spans: &[Span], root: u64) -> Vec<&Span> {
+    let mut out = Vec::new();
+    let mut frontier = vec![root];
+    while let Some(parent) = frontier.pop() {
+        for span in spans {
+            if span.parent_id == Some(parent) {
+                out.push(span);
+                frontier.push(span.span_id);
+            }
+        }
+    }
+    out
+}
+
+fn pct(part: u64, whole: u64) -> f64 {
+    if whole == 0 {
+        0.0
+    } else {
+        (part as f64 / whole as f64) * 100.0
+    }
+}
+
+/// Render a profile to a human-readable string suitable for stderr after
+/// a `harn run --profile` invocation. ANSI-styled to match the existing
+/// `--trace` output.
+pub fn render(profile: &RunProfile) -> String {
+    use std::fmt::Write;
+    let mut out = String::new();
+    let _ = writeln!(out, "\n\x1b[2m─── Run profile ───\x1b[0m");
+    let _ = writeln!(
+        out,
+        "  Total wall time: {}",
+        format_secs(profile.total_wall_ms)
+    );
+    let _ = writeln!(out, "\n  By category:");
+    for bucket in &profile.by_kind {
+        let _ = writeln!(
+            out,
+            "    {:<14} {:>10}  {:>5.1}%   ({} call{})",
+            bucket.kind,
+            format_secs(bucket.total_ms),
+            bucket.pct_of_wall,
+            bucket.count,
+            if bucket.count == 1 { "" } else { "s" },
+        );
+    }
+    let _ = writeln!(
+        out,
+        "    {:<14} {:>10}  {:>5.1}%",
+        "vm/residual",
+        format_secs(profile.residual_ms),
+        pct(profile.residual_ms, profile.total_wall_ms),
+    );
+    if !profile.top_llm_calls.is_empty() {
+        let _ = writeln!(out, "\n  Top LLM calls:");
+        for span in &profile.top_llm_calls {
+            let model = span.model.as_deref().unwrap_or(&span.name);
+            let step = span
+                .step
+                .as_deref()
+                .map(|s| format!("  step={s}"))
+                .unwrap_or_default();
+            let _ = writeln!(
+                out,
+                "    #{:<4} {:<24} {:>10}{}",
+                span.span_id,
+                model,
+                format_secs(span.duration_ms),
+                step,
+            );
+        }
+    }
+    if !profile.top_tool_calls.is_empty() {
+        let _ = writeln!(out, "\n  Top tool calls:");
+        for span in &profile.top_tool_calls {
+            let step = span
+                .step
+                .as_deref()
+                .map(|s| format!("  step={s}"))
+                .unwrap_or_default();
+            let _ = writeln!(
+                out,
+                "    #{:<4} {:<24} {:>10}{}",
+                span.span_id,
+                span.name,
+                format_secs(span.duration_ms),
+                step,
+            );
+        }
+    }
+    if !profile.steps.is_empty() {
+        let _ = writeln!(out, "\n  Per-@step:");
+        for step in &profile.steps {
+            let _ = writeln!(
+                out,
+                "    {:<20} {:>10}   (LLM {} · tools {} · other {})",
+                step.name,
+                format_secs(step.duration_ms),
+                format_secs(step.llm_ms),
+                format_secs(step.tool_ms),
+                format_secs(step.other_ms),
+            );
+        }
+    }
+    out
+}
+
+fn format_secs(ms: u64) -> String {
+    if ms < 1000 {
+        format!("{} ms", ms)
+    } else {
+        format!("{:.3} s", ms as f64 / 1000.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tracing::SpanKind;
+
+    fn span(span_id: u64, parent_id: Option<u64>, kind: SpanKind, name: &str, dur: u64) -> Span {
+        Span {
+            span_id,
+            parent_id,
+            kind,
+            name: name.into(),
+            start_ms: 0,
+            duration_ms: dur,
+            metadata: BTreeMap::new(),
+        }
+    }
+
+    fn span_with_meta(
+        span_id: u64,
+        parent_id: Option<u64>,
+        kind: SpanKind,
+        name: &str,
+        dur: u64,
+        meta: &[(&str, serde_json::Value)],
+    ) -> Span {
+        let mut s = span(span_id, parent_id, kind, name, dur);
+        for (k, v) in meta {
+            s.metadata.insert((*k).to_string(), v.clone());
+        }
+        s
+    }
+
+    #[test]
+    fn empty_spans_yield_default_profile() {
+        let profile = build(&[]);
+        assert_eq!(profile.total_wall_ms, 0);
+        assert!(profile.by_kind.is_empty());
+        assert_eq!(profile.residual_ms, 0);
+    }
+
+    #[test]
+    fn buckets_are_sorted_descending_by_total() {
+        let spans = vec![
+            span(1, None, SpanKind::Pipeline, "main", 1000),
+            span(2, Some(1), SpanKind::LlmCall, "llm_call", 600),
+            span(3, Some(1), SpanKind::ToolCall, "mcp_call", 250),
+            span(4, Some(1), SpanKind::ToolCall, "mcp_call", 50),
+        ];
+        let profile = build(&spans);
+        assert_eq!(profile.total_wall_ms, 1000);
+        assert_eq!(profile.by_kind[0].kind, "llm_call");
+        assert_eq!(profile.by_kind[0].total_ms, 600);
+        assert_eq!(profile.by_kind[1].kind, "tool_call");
+        assert_eq!(profile.by_kind[1].total_ms, 300);
+        assert_eq!(profile.by_kind[1].count, 2);
+        // 1000 wall - (600 + 300) depth-1 = 100 ms residual
+        assert_eq!(profile.residual_ms, 100);
+    }
+
+    #[test]
+    fn nested_spans_do_not_double_count_residual() {
+        // Pipeline (1000ms) > Step (800ms) > LlmCall (700ms)
+        // Depth-1 sum = 800 (the step), residual = 200, NOT 1000-700-800.
+        let spans = vec![
+            span(1, None, SpanKind::Pipeline, "main", 1000),
+            span(2, Some(1), SpanKind::Step, "research", 800),
+            span(3, Some(2), SpanKind::LlmCall, "llm_call", 700),
+        ];
+        let profile = build(&spans);
+        assert_eq!(profile.total_wall_ms, 1000);
+        assert_eq!(profile.residual_ms, 200);
+    }
+
+    #[test]
+    fn step_summaries_split_llm_tool_other() {
+        let spans = vec![
+            span(1, None, SpanKind::Pipeline, "main", 2000),
+            span(2, Some(1), SpanKind::Step, "research", 1500),
+            span(3, Some(2), SpanKind::LlmCall, "llm_call", 900),
+            span(4, Some(2), SpanKind::ToolCall, "mcp_call", 400),
+        ];
+        let profile = build(&spans);
+        assert_eq!(profile.steps.len(), 1);
+        let step = &profile.steps[0];
+        assert_eq!(step.name, "research");
+        assert_eq!(step.duration_ms, 1500);
+        assert_eq!(step.llm_ms, 900);
+        assert_eq!(step.tool_ms, 400);
+        assert_eq!(step.other_ms, 200);
+        assert_eq!(step.llm_calls, 1);
+        assert_eq!(step.tool_calls, 1);
+    }
+
+    #[test]
+    fn top_llm_calls_attribute_enclosing_step_and_model() {
+        let spans = vec![
+            span(1, None, SpanKind::Pipeline, "main", 2000),
+            span(2, Some(1), SpanKind::Step, "research", 1500),
+            span_with_meta(
+                3,
+                Some(2),
+                SpanKind::LlmCall,
+                "llm_call",
+                900,
+                &[("model", serde_json::json!("claude-sonnet-4-6"))],
+            ),
+            span(4, Some(1), SpanKind::LlmCall, "llm_call", 100),
+        ];
+        let profile = build(&spans);
+        assert_eq!(profile.top_llm_calls.len(), 2);
+        assert_eq!(profile.top_llm_calls[0].duration_ms, 900);
+        assert_eq!(profile.top_llm_calls[0].step.as_deref(), Some("research"));
+        assert_eq!(
+            profile.top_llm_calls[0].model.as_deref(),
+            Some("claude-sonnet-4-6")
+        );
+        assert!(profile.top_llm_calls[1].step.is_none());
+    }
+
+    #[test]
+    fn render_produces_nonempty_output_for_real_run() {
+        let spans = vec![
+            span(1, None, SpanKind::Pipeline, "main", 1000),
+            span(2, Some(1), SpanKind::LlmCall, "llm_call", 700),
+        ];
+        let rendered = render(&build(&spans));
+        assert!(rendered.contains("Run profile"));
+        assert!(rendered.contains("llm_call"));
+        assert!(rendered.contains("vm/residual"));
+    }
+
+    #[test]
+    fn render_for_empty_profile_still_produces_header() {
+        // When --profile was requested but no spans landed, we still
+        // render the header + a zero-everything residual line — the
+        // user explicitly asked for output and an empty string would
+        // look like the flag did nothing.
+        let rendered = render(&RunProfile::default());
+        assert!(rendered.contains("Run profile"));
+        assert!(rendered.contains("vm/residual"));
+    }
+}

--- a/crates/harn-vm/src/step_runtime.rs
+++ b/crates/harn-vm/src/step_runtime.rs
@@ -85,6 +85,10 @@ pub struct ActiveStep {
     pub cost_usd: f64,
     pub llm_calls: u32,
     pub last_model: Option<String>,
+    /// Tracing span id opened when the step's frame was pushed; ended on
+    /// completion. 0 when tracing was disabled at push time, in which
+    /// case `span_end` is a no-op anyway.
+    pub span_id: u64,
 }
 
 impl ActiveStep {
@@ -93,6 +97,7 @@ impl ActiveStep {
         definition: Rc<StepDefinition>,
         persona: Option<String>,
         args: Vec<VmValue>,
+        span_id: u64,
     ) -> Self {
         Self {
             frame_depth,
@@ -104,6 +109,7 @@ impl ActiveStep {
             cost_usd: 0.0,
             llm_calls: 0,
             last_model: None,
+            span_id,
         }
     }
 
@@ -425,12 +431,29 @@ pub fn maybe_push_active_step(function_name: &str, frame_depth: usize, args: &[V
         return false;
     };
     let persona = current_persona_name();
+    let span_id =
+        crate::tracing::span_start(crate::tracing::SpanKind::Step, definition.name.clone());
+    if let Some(persona_name) = persona.as_deref() {
+        crate::tracing::span_set_metadata(
+            span_id,
+            "persona",
+            serde_json::Value::String(persona_name.to_string()),
+        );
+    }
+    if let Some(model) = definition.model.as_deref() {
+        crate::tracing::span_set_metadata(
+            span_id,
+            "model",
+            serde_json::Value::String(model.to_string()),
+        );
+    }
     STEP_STACK.with(|stack| {
         stack.borrow_mut().push(ActiveStep::new(
             frame_depth,
             definition,
             persona,
             args.to_vec(),
+            span_id,
         ));
     });
     true
@@ -509,6 +532,34 @@ pub fn pop_and_record(current_frame_depth: usize, status: &str, error: Option<St
 }
 
 fn finish_step(step: ActiveStep, status: &str, error: Option<String>) {
+    crate::tracing::span_set_metadata(
+        step.span_id,
+        "status",
+        serde_json::Value::String(status.to_string()),
+    );
+    crate::tracing::span_set_metadata(
+        step.span_id,
+        "llm_calls",
+        serde_json::Value::Number(step.llm_calls.into()),
+    );
+    crate::tracing::span_set_metadata(
+        step.span_id,
+        "input_tokens",
+        serde_json::Value::Number(step.input_tokens.into()),
+    );
+    crate::tracing::span_set_metadata(
+        step.span_id,
+        "output_tokens",
+        serde_json::Value::Number(step.output_tokens.into()),
+    );
+    if let Some(cost_n) = serde_json::Number::from_f64(step.cost_usd) {
+        crate::tracing::span_set_metadata(
+            step.span_id,
+            "cost_usd",
+            serde_json::Value::Number(cost_n),
+        );
+    }
+    crate::tracing::span_end(step.span_id);
     let summary = CompletedStep {
         name: step.definition.name.clone(),
         function: step.definition.function.clone(),

--- a/crates/harn-vm/src/tracing.rs
+++ b/crates/harn-vm/src/tracing.rs
@@ -24,6 +24,8 @@ pub enum SpanKind {
     Import,
     Parallel,
     Spawn,
+    /// A `@step`-annotated function while its frame is on the call stack.
+    Step,
 }
 
 impl SpanKind {
@@ -36,6 +38,7 @@ impl SpanKind {
             Self::Import => "import",
             Self::Parallel => "parallel",
             Self::Spawn => "spawn",
+            Self::Step => "step",
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds an opt-in `harn run --profile` flag that prints a categorical timing breakdown after a run, so harness writers can finally see *where the time went* — LLM vs tools vs steps vs VM residual — without grepping `.harn-runs/*.json` by hand.

Built on the existing `harn_vm::tracing::SpanCollector` (already wired through dispatch, parallel, imports). The only new instrumentation is a `SpanKind::Step` that opens when an `@step` frame is pushed and ends on completion, so LLM and tool spans nest naturally inside their enclosing step.

The new `harn_vm::profile` module folds `peek_spans()` into a `RunProfile` with text + JSON renderers.

Sample output for a two-step script with LLM mocks:

```
─── Run profile ───
  Total wall time: 22 ms

  By category:
    llm_call            21 ms   95.5%   (2 calls)
    step                21 ms   95.5%   (2 calls)
    vm/residual          1 ms    4.5%

  Top LLM calls:
    #3    claude-haiku-4-5              20 ms  step=classify_step
    #5    claude-sonnet-4-6              1 ms  step=judge_step

  Per-@step:
    classify_step             20 ms   (LLM 20 ms · tools 0 ms · other 0 ms)
    judge_step                 1 ms   (LLM 1 ms · tools 0 ms · other 0 ms)
```

## Surface

- `harn run <file> --profile` — text rollup to stderr, alongside `--trace` if both are set.
- `harn run <file> --profile-json <PATH>` — same data serialized to disk for tooling.
- Either flag flips on `harn_vm::tracing::set_tracing_enabled(true)` for the run.

## Why this lives where it does

- `harn_vm::profile` is a pure rollup over `Span` slices — no globals, easy to test.
- `SpanKind::Step` was added to `tracing.rs` because the `step_runtime` lifecycle is the natural open/close point; the resulting tree gives free LLM/tool attribution to the enclosing step.
- The CLI plumbing follows the existing `RunAttestationOptions` pattern (`RunProfileOptions` struct threaded through `run_file` → `run_file_with_skill_dirs` → `execute_run`).

## Test plan

- [x] 7 unit tests in `harn_vm::profile` (synthetic span trees, double-count guard, residual, step attribution, render shape)
- [x] 3 integration tests in `crates/harn-cli/tests/profile.rs` (text+JSON roundtrip; `@step` span with mock LLM; profile disabled means no stderr section)
- [x] `make test` (3295 tests pass)
- [x] Manual: ran a two-step script with `--profile`, `--profile-json`, and `--profile --trace` combined — output matches the sample above
- [x] `cargo clippy -p harn-vm -p harn-cli --tests --no-deps -- -D warnings` clean
- [x] `cargo fmt --check` clean

## Out of scope (follow-ups)

- Per-HTTP-attempt breakdown for retries / fallbacks (today aggregated into `response_ms`).
- Per-iteration timing inside `parallel each` (covered in aggregate by the parent span).
- Sub-agent breakdown surfaced to the parent profile (today the sub-agent's spans live in its own session; cross-session join is a bigger lift).
- Portal flamegraph already consumes `RunTraceSpanRecord`; the new `Step` spans flow through unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)