### PR TITLE
Scope agent loop policies to tool dispatch

### DIFF
--- a/conformance/tests/agents/agent_loop_policy_unwind.expected
+++ b/conformance/tests/agents/agent_loop_policy_unwind.expected
@@ -1,0 +1,3 @@
+true
+true
+done

--- a/conformance/tests/agents/agent_loop_policy_unwind.harn
+++ b/conformance/tests/agents/agent_loop_policy_unwind.harn
@@ -1,0 +1,31 @@
+import { agent_session_finalize } from "std/agent/state"
+
+pipeline main(task) {
+  let failed = try {
+    agent_loop(
+      "This loop should fail during bootstrap",
+      nil,
+      {
+        provider: "mock",
+        session_id: "failed-bootstrap-cleanup",
+        max_iterations: 1,
+        mcp_servers: "not-a-server-list",
+      },
+    )
+  }
+  println(is_err(failed))
+  let stale_finalize = try {
+    agent_session_finalize(
+      "failed-bootstrap-cleanup",
+      {final_status: "done", stop_reason: "test", iterations: 0},
+    )
+  }
+  println(is_err(stale_finalize))
+  llm_mock({text: "<done>##DONE##</done>"})
+  let result = agent_loop(
+    "A later loop should not inherit failed-loop state",
+    nil,
+    {provider: "mock", max_iterations: 1},
+  )
+  println(result.status)
+}

--- a/conformance/tests/agents/agent_prefill_feedback.expected
+++ b/conformance/tests/agents/agent_prefill_feedback.expected
@@ -1,0 +1,4 @@
+assistant
+true
+assistant
+true

--- a/conformance/tests/agents/agent_prefill_feedback.harn
+++ b/conformance/tests/agents/agent_prefill_feedback.harn
@@ -1,0 +1,22 @@
+import {
+  agent_session_finalize,
+  agent_session_init,
+  agent_session_inject_feedback,
+} from "std/agent/state"
+
+pipeline main(task) {
+  let public_session = agent_session_open("prefill-feedback-public")
+  agent_inject_feedback(public_session, "prefill_assistant", "<done>##DONE##</done>")
+  let public_messages = agent_session_snapshot(public_session).messages
+  println(public_messages[0].role)
+  println(!contains(public_messages[0].content, "runtime_feedback"))
+  let control = agent_session_init("task", nil, {provider: "mock", session_id: "prefill-feedback-host"})
+  agent_session_inject_feedback(control.session_id, "prefill_assistant", "<done>##DONE##</done>")
+  let host_messages = agent_session_snapshot(control.session_id).messages
+  println(host_messages[1].role)
+  println(!contains(host_messages[1].content, "runtime_feedback"))
+  agent_session_finalize(
+    control.session_id,
+    {final_status: "done", stop_reason: "test", iterations: 0},
+  )
+}

--- a/conformance/tests/agents/agent_worker_policy.expected
+++ b/conformance/tests/agents/agent_worker_policy.expected
@@ -1,3 +1,6 @@
 true
 true
 true
+true
+true
+true

--- a/conformance/tests/agents/agent_worker_policy.harn
+++ b/conformance/tests/agents/agent_worker_policy.harn
@@ -5,7 +5,7 @@ fn write_tools() {
     "write_note",
     "Write a note",
     {
-      handler: { args -> "" },
+      handler: { _args -> "" },
       parameters: {path: {type: "string", description: "Path to write"}},
       returns: {type: "string"},
     },
@@ -29,4 +29,19 @@ pipeline main() {
   let transcript = json_stringify(transcript_messages(denied?.transcript))
   println(transcript.contains("permission_denied"))
   println(transcript.contains("write_note"))
+  let read_only_denied = agent_loop(
+    "Try to write a note",
+    "You are helpful",
+    {
+      provider: "mock",
+      tools: write_tools(),
+      tool_format: "native",
+      max_iterations: 1,
+      policy: {tools: ["read_only"], capabilities: {workspace: ["read_text"]}, side_effect_level: "read_only"},
+    },
+  )
+  println(read_only_denied?.tools?.rejected[0] == "write_note")
+  let read_only_transcript = json_stringify(transcript_messages(read_only_denied?.transcript))
+  println(read_only_transcript.contains("permission_denied"))
+  println(read_only_transcript.contains("write_note"))
 }

--- a/crates/harn-stdlib/src/stdlib/agent/loop.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/loop.harn
@@ -118,7 +118,14 @@ fn __dispatch_tool_calls(session_id, tool_calls, turn_opts) {
   let dispatch = agent_dispatch_tool_batch(
     tool_calls,
     turn_opts?.tools,
-    {session_id: session_id, tool_format: turn_opts.tool_format},
+    {
+      session_id: session_id,
+      tool_format: turn_opts.tool_format,
+      policy: turn_opts?.policy,
+      approval_policy: turn_opts?.approval_policy,
+      command_policy: turn_opts?.command_policy,
+      permissions: turn_opts?.permissions,
+    },
   )
   agent_session_record_tool_results(session_id, dispatch)
   return {
@@ -265,6 +272,154 @@ fn __enforce_required_successful_tools(result, opts) {
   }
 }
 
+fn __agent_loop_finalize_failed(session, iteration) {
+  try {
+    agent_session_finalize(
+      session.session_id,
+      {final_status: "failed", stop_reason: "error", iterations: iteration},
+    )
+  } catch (e) {
+  }
+}
+
+fn __agent_loop_run(message, session, initial_opts) {
+  var opts = initial_opts
+  var iteration = 0
+  var session_finalized = false
+  let run = try {
+    opts = agent_mcp_bootstrap_if_needed(session, opts)
+    var stop_reason = nil
+    var final_status = ""
+    var verify_attempts = 0
+    var consecutive_text_only = 0
+    var fallback_index = 0
+    var successful_tools_seen = []
+    var rejected_tools_seen = []
+    let max_verify_attempts = opts?.max_verify_attempts ?? 20
+    let max_iterations = opts?.max_iterations ?? 50
+    while iteration < max_iterations {
+      if agent_budget_pre_call_blocked(session, opts) {
+        final_status = "budget_exhausted"
+        break
+      }
+      let turn_index = iteration
+      agent_emit_event(session.session_id, "turn_start", {iteration: turn_index + 1})
+      var turn_opts = agent_skills_match(session, opts, turn_index)
+      turn_opts = agent_tool_search_inject_if_needed(turn_opts)
+      agent_autocompact_if_needed(session, turn_opts)
+      let pending = agent_session_drain_feedback(session.session_id)
+      for note in pending {
+        agent_session_inject_feedback(session.session_id, note.kind, note.content)
+      }
+      let turn_system = agent_build_turn_system(session, turn_opts, turn_index)
+      let turn_messages = agent_build_turn_messages(session, turn_opts, turn_index)
+      let llm_overrides = turn_opts?.llm_options ?? {}
+      let base_opts = turn_opts + llm_overrides
+      let llm_opts = base_opts
+        + {messages: turn_messages, session_id: session.session_id, tool_format: turn_opts.tool_format}
+      let call = __invoke_llm(message, turn_system, llm_opts)
+      if !call.ok {
+        final_status = call.status
+        break
+      }
+      let llm_result = call.value
+      iteration = iteration + 1
+      let raw_text = llm_result?.text ?? ""
+      let parsed = agent_parse_tool_calls(raw_text, turn_opts?.tools)
+      let visible_text = __visible_text(parsed, raw_text)
+      let normalized = llm_result + {text: visible_text, visible_text: visible_text}
+      agent_session_record_assistant(session.session_id, normalized)
+      let fallback_outcome = __detect_native_fallback(
+        llm_result,
+        parsed,
+        turn_opts,
+        fallback_index,
+        session.session_id,
+        turn_index,
+      )
+      fallback_index = fallback_outcome.fallback_index
+      let tool_calls = if fallback_outcome.triggered {
+        fallback_outcome.calls
+      } else {
+        __resolve_tool_calls(llm_result, parsed)
+      }
+      let dispatched = __dispatch_tool_calls(session.session_id, tool_calls, turn_opts)
+      let dispatch = dispatched.dispatch
+      opts = __sync_tool_search_state(opts, dispatched.turn_opts)
+      successful_tools_seen = __merge_tool_names(successful_tools_seen, __tool_names_by_status(dispatch, true))
+      rejected_tools_seen = __merge_tool_names(rejected_tools_seen, __tool_names_by_status(dispatch, false))
+      let totals = agent_session_record_usage(session.session_id, llm_result)
+      let tool_count = len(tool_calls)
+      agent_emit_event(
+        session.session_id,
+        "turn_end",
+        {iteration: turn_index + 1, turn_info: {tool_count: tool_count, text: visible_text}},
+      )
+      if agent_budget_post_call_blocked(totals, turn_opts) {
+        final_status = "budget_exhausted"
+        break
+      }
+      consecutive_text_only = __next_text_only_count(tool_count, consecutive_text_only)
+      let turn_max_nudges = turn_opts?.max_nudges ?? 8
+      let turn_loop_until_done = turn_opts?.loop_until_done ?? false
+      if turn_loop_until_done && tool_count == 0 && consecutive_text_only > turn_max_nudges {
+        final_status = "stuck"
+        stop_reason = "max_nudges"
+        break
+      }
+      let post_turn_opts = turn_opts
+        + {_session_successful_tools: successful_tools_seen, _session_rejected_tools: rejected_tools_seen}
+      let outcome = agent_compute_post_turn(
+        session,
+        normalized + {raw_text: raw_text, parsed_done_marker: parsed?.done_marker ?? ""},
+        dispatch,
+        post_turn_opts,
+        turn_index,
+      )
+      opts = __apply_post_turn_options(opts, outcome)
+      if outcome.kind == "continue" {
+        if opts?.daemon && len(tool_calls) == 0 {
+          agent_daemon_step(session, opts, iteration)
+        }
+        continue
+      }
+      if outcome.needs_verify {
+        if verify_attempts >= max_verify_attempts {
+          final_status = "verify_exhausted"
+          stop_reason = outcome.stop_reason
+          break
+        }
+        let verdict = agent_verify_or_continue(session, turn_opts, outcome.stop_reason, llm_result.text, turn_index)
+        if verdict.vetoed {
+          verify_attempts = verify_attempts + 1
+          continue
+        }
+      }
+      stop_reason = outcome.stop_reason
+      break
+    }
+    if final_status == "" && iteration >= max_iterations && stop_reason == nil {
+      final_status = "budget_exhausted"
+    }
+    if opts?.daemon && final_status != "" {
+      agent_daemon_snapshot(session, opts, final_status, iteration)
+    }
+    let result = agent_session_finalize(
+      session.session_id,
+      {final_status: final_status, stop_reason: stop_reason ?? "", iterations: iteration},
+    )
+    session_finalized = true
+    __enforce_required_successful_tools(result, opts)
+  }
+  if is_err(run) {
+    if !session_finalized {
+      __agent_loop_finalize_failed(session, iteration)
+    }
+    throw unwrap_err(run)
+  }
+  return unwrap(run)
+}
+
 /** agent_loop. */
 pub fn agent_loop(message, system_prompt = nil, options = nil) {
   var opts = agent_loop_options(options)
@@ -281,127 +436,5 @@ pub fn agent_loop(message, system_prompt = nil, options = nil) {
     } catch (e) {
     }
   }
-  opts = agent_mcp_bootstrap_if_needed(session, opts)
-  var iteration = 0
-  var stop_reason = nil
-  var final_status = ""
-  var verify_attempts = 0
-  var consecutive_text_only = 0
-  var fallback_index = 0
-  var successful_tools_seen = []
-  var rejected_tools_seen = []
-  let max_verify_attempts = opts?.max_verify_attempts ?? 20
-  let max_iterations = opts?.max_iterations ?? 50
-  while iteration < max_iterations {
-    if agent_budget_pre_call_blocked(session, opts) {
-      final_status = "budget_exhausted"
-      break
-    }
-    let turn_index = iteration
-    agent_emit_event(session.session_id, "turn_start", {iteration: turn_index + 1})
-    var turn_opts = agent_skills_match(session, opts, turn_index)
-    turn_opts = agent_tool_search_inject_if_needed(turn_opts)
-    agent_autocompact_if_needed(session, turn_opts)
-    let pending = agent_session_drain_feedback(session.session_id)
-    for note in pending {
-      agent_session_inject_feedback(session.session_id, note.kind, note.content)
-    }
-    let turn_system = agent_build_turn_system(session, turn_opts, turn_index)
-    let turn_messages = agent_build_turn_messages(session, turn_opts, turn_index)
-    let llm_overrides = turn_opts?.llm_options ?? {}
-    let base_opts = turn_opts + llm_overrides
-    let llm_opts = base_opts
-      + {messages: turn_messages, session_id: session.session_id, tool_format: turn_opts.tool_format}
-    let call = __invoke_llm(message, turn_system, llm_opts)
-    if !call.ok {
-      final_status = call.status
-      break
-    }
-    let llm_result = call.value
-    iteration = iteration + 1
-    let raw_text = llm_result?.text ?? ""
-    let parsed = agent_parse_tool_calls(raw_text, turn_opts?.tools)
-    let visible_text = __visible_text(parsed, raw_text)
-    let normalized = llm_result + {text: visible_text, visible_text: visible_text}
-    agent_session_record_assistant(session.session_id, normalized)
-    let fallback_outcome = __detect_native_fallback(
-      llm_result,
-      parsed,
-      turn_opts,
-      fallback_index,
-      session.session_id,
-      turn_index,
-    )
-    fallback_index = fallback_outcome.fallback_index
-    let tool_calls = if fallback_outcome.triggered {
-      fallback_outcome.calls
-    } else {
-      __resolve_tool_calls(llm_result, parsed)
-    }
-    let dispatched = __dispatch_tool_calls(session.session_id, tool_calls, turn_opts)
-    let dispatch = dispatched.dispatch
-    opts = __sync_tool_search_state(opts, dispatched.turn_opts)
-    successful_tools_seen = __merge_tool_names(successful_tools_seen, __tool_names_by_status(dispatch, true))
-    rejected_tools_seen = __merge_tool_names(rejected_tools_seen, __tool_names_by_status(dispatch, false))
-    let totals = agent_session_record_usage(session.session_id, llm_result)
-    let tool_count = len(tool_calls)
-    agent_emit_event(
-      session.session_id,
-      "turn_end",
-      {iteration: turn_index + 1, turn_info: {tool_count: tool_count, text: visible_text}},
-    )
-    if agent_budget_post_call_blocked(totals, turn_opts) {
-      final_status = "budget_exhausted"
-      break
-    }
-    consecutive_text_only = __next_text_only_count(tool_count, consecutive_text_only)
-    let turn_max_nudges = turn_opts?.max_nudges ?? 8
-    let turn_loop_until_done = turn_opts?.loop_until_done ?? false
-    if turn_loop_until_done && tool_count == 0 && consecutive_text_only > turn_max_nudges {
-      final_status = "stuck"
-      stop_reason = "max_nudges"
-      break
-    }
-    let post_turn_opts = turn_opts
-      + {_session_successful_tools: successful_tools_seen, _session_rejected_tools: rejected_tools_seen}
-    let outcome = agent_compute_post_turn(
-      session,
-      normalized + {raw_text: raw_text, parsed_done_marker: parsed?.done_marker ?? ""},
-      dispatch,
-      post_turn_opts,
-      turn_index,
-    )
-    opts = __apply_post_turn_options(opts, outcome)
-    if outcome.kind == "continue" {
-      if opts?.daemon && len(tool_calls) == 0 {
-        agent_daemon_step(session, opts, iteration)
-      }
-      continue
-    }
-    if outcome.needs_verify {
-      if verify_attempts >= max_verify_attempts {
-        final_status = "verify_exhausted"
-        stop_reason = outcome.stop_reason
-        break
-      }
-      let verdict = agent_verify_or_continue(session, turn_opts, outcome.stop_reason, llm_result.text, turn_index)
-      if verdict.vetoed {
-        verify_attempts = verify_attempts + 1
-        continue
-      }
-    }
-    stop_reason = outcome.stop_reason
-    break
-  }
-  if final_status == "" && iteration >= max_iterations && stop_reason == nil {
-    final_status = "budget_exhausted"
-  }
-  if opts?.daemon && final_status != "" {
-    agent_daemon_snapshot(session, opts, final_status, iteration)
-  }
-  let result = agent_session_finalize(
-    session.session_id,
-    {final_status: final_status, stop_reason: stop_reason ?? "", iterations: iteration},
-  )
-  return __enforce_required_successful_tools(result, opts)
+  return __agent_loop_run(message, session, opts)
 }

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -302,6 +302,8 @@ pub fn reset_thread_local_state() {
     stdlib::reset_stdlib_state();
     connectors::clear_active_connector_clients();
     orchestration::clear_runtime_hooks();
+    orchestration::clear_execution_policy_stacks();
+    orchestration::clear_command_policies();
     triggers::clear_dispatcher_state();
     triggers::clear_trigger_registry();
     events::reset_event_sinks();

--- a/crates/harn-vm/src/llm/agent_config.rs
+++ b/crates/harn-vm/src/llm/agent_config.rs
@@ -17,6 +17,7 @@ use super::helpers::{
 use super::tools::build_assistant_response_message;
 
 const AGENT_STDLIB_ENTRYPOINT_CATEGORY: &str = "agent.stdlib";
+const PREFILL_ASSISTANT_FEEDBACK_KIND: &str = "prefill_assistant";
 
 const AGENT_CONTROL_PRIMITIVES: &[SyncBuiltin] = &[
     SyncBuiltin::new("agent_subscribe", agent_subscribe_builtin)
@@ -32,6 +33,22 @@ const AGENT_CONTROL_PRIMITIVES: &[SyncBuiltin] = &[
 const AGENT_CONTROL_GROUP: BuiltinGroup<'static> = BuiltinGroup::new()
     .category("agent.host")
     .sync(AGENT_CONTROL_PRIMITIVES);
+
+pub(crate) fn agent_feedback_message(kind: &str, content: &str) -> VmValue {
+    let mut msg = std::collections::BTreeMap::new();
+    if kind == PREFILL_ASSISTANT_FEEDBACK_KIND {
+        msg.insert("role".to_string(), VmValue::String(Rc::from("assistant")));
+        msg.insert(
+            "content".to_string(),
+            VmValue::String(Rc::from(content.to_string())),
+        );
+        return VmValue::Dict(Rc::new(msg));
+    }
+    let body = format!("<runtime_feedback kind=\"{kind}\">\n{content}\n</runtime_feedback>");
+    msg.insert("role".to_string(), VmValue::String(Rc::from("user")));
+    msg.insert("content".to_string(), VmValue::String(Rc::from(body)));
+    VmValue::Dict(Rc::new(msg))
+}
 
 pub(crate) fn agent_loop_result_from_llm(
     result: &super::api::LlmResult,
@@ -301,11 +318,8 @@ fn agent_inject_feedback_builtin(args: &[VmValue], _out: &mut String) -> Result<
             ))
         }
     };
-    let body = format!("<runtime_feedback kind=\"{kind}\">\n{content}\n</runtime_feedback>");
-    let mut msg = std::collections::BTreeMap::new();
-    msg.insert("role".to_string(), VmValue::String(Rc::from("user")));
-    msg.insert("content".to_string(), VmValue::String(Rc::from(body)));
-    let _ = crate::agent_sessions::inject_message(&session_id, VmValue::Dict(Rc::new(msg)));
+    let _ =
+        crate::agent_sessions::inject_message(&session_id, agent_feedback_message(&kind, &content));
     Ok(VmValue::Nil)
 }
 

--- a/crates/harn-vm/src/llm/agent_session_host.rs
+++ b/crates/harn-vm/src/llm/agent_session_host.rs
@@ -84,14 +84,13 @@ struct AgentHostSession {
     /// the last call truncated due to its `max_tokens` parameter) and
     /// `refusal` (Anthropic refusal stop_reason).
     last_llm_stop_reason: Option<String>,
-    installed_policies: InstalledPolicies,
 }
 
-/// Tracks which scoped policy stacks were pushed during session init so
-/// finalize can pop them in reverse order. The agent loop honours
-/// per-agent ceilings by intersecting outer policies with the requested
-/// per-agent ones before pushing — so child sub-agents never widen
-/// permissions beyond their parents.
+/// Tracks which scoped policy stacks were pushed for a guarded tool
+/// dispatch so `Drop` can pop them in reverse order. The agent loop
+/// honours per-agent ceilings by intersecting outer policies with the
+/// requested per-agent ones before pushing, so child sub-agents never
+/// widen permissions beyond their parents.
 #[derive(Default)]
 struct InstalledPolicies {
     pushed_execution: bool,
@@ -100,9 +99,23 @@ struct InstalledPolicies {
     pushed_permissions: bool,
 }
 
+pub(crate) struct SessionPolicyGuard {
+    installed: InstalledPolicies,
+}
+
+impl Drop for SessionPolicyGuard {
+    fn drop(&mut self) {
+        release_session_policies(&self.installed);
+    }
+}
+
 thread_local! {
     static AGENT_HOST_SESSIONS: RefCell<BTreeMap<String, AgentHostSession>> =
         const { RefCell::new(BTreeMap::new()) };
+}
+
+pub(crate) fn reset_agent_session_host_state() {
+    AGENT_HOST_SESSIONS.with(|sessions| sessions.borrow_mut().clear());
 }
 
 fn with_session<R>(
@@ -207,7 +220,6 @@ async fn host_agent_session_init(args: Vec<VmValue>) -> Result<VmValue, VmError>
         None => 0,
     };
 
-    let installed_policies = install_session_policies(&opts_map)?;
     if let Some(config) = autonomy_budget.as_ref() {
         super::autonomy_budget::note_decision(config);
     }
@@ -248,7 +260,6 @@ async fn host_agent_session_init(args: Vec<VmValue>) -> Result<VmValue, VmError>
         daemon_idle_backoff_ms: 100,
         host_bridge,
         last_llm_stop_reason: None,
-        installed_policies,
     };
 
     AGENT_HOST_SESSIONS.with(|sessions| {
@@ -353,9 +364,6 @@ async fn host_agent_session_finalize(args: Vec<VmValue>) -> Result<VmValue, VmEr
                 "{HOST_SESSION_FINALIZE}: unknown session `{session_id}`"
             ))
         })?;
-    // Unwind the per-agent policy stacks pushed in init, in reverse
-    // order — outer scopes (workflow stage, parent agent) survive intact.
-    release_session_policies(&session.installed_policies);
     permissions::clear_session_grants(&session_id);
     if session.pushed_transcript_dir {
         super::agent_observe::pop_llm_transcript_dir();
@@ -820,11 +828,10 @@ fn host_agent_session_inject_feedback_builtin(
     let session_id = args.first().map(|v| v.display()).unwrap_or_default();
     let kind = args.get(1).map(|v| v.display()).unwrap_or_default();
     let content = args.get(2).map(|v| v.display()).unwrap_or_default();
-    let body = format!("<runtime_feedback kind=\"{kind}\">\n{content}\n</runtime_feedback>");
-    let mut msg = BTreeMap::new();
-    msg.insert("role".to_string(), VmValue::String(Rc::from("user")));
-    msg.insert("content".to_string(), VmValue::String(Rc::from(body)));
-    let _ = crate::agent_sessions::inject_message(&session_id, VmValue::Dict(Rc::new(msg)));
+    let _ = crate::agent_sessions::inject_message(
+        &session_id,
+        super::agent_config::agent_feedback_message(&kind, &content),
+    );
     Ok(VmValue::Nil)
 }
 
@@ -1455,21 +1462,21 @@ async fn host_autonomy_budget_check(args: Vec<VmValue>) -> Result<VmValue, VmErr
 }
 
 /// Install per-agent execution / approval / command / dynamic permission
-/// policies onto the thread-local stacks for the lifetime of this agent
-/// session. Each scope intersects with the currently-active outer policy
-/// (when any) so a sub-agent cannot widen its parent's ceiling — only
-/// narrow it. Dynamic permissions are stack-checked, so push as-is and
-/// rely on the dispatch path to honour every active scope.
+/// policies onto the thread-local stacks for the lifetime of a guarded
+/// tool dispatch. Each scope intersects with the currently-active outer
+/// policy (when any) so a sub-agent cannot widen its parent's ceiling —
+/// only narrow it. Dynamic permissions are stack-checked, so push as-is
+/// and rely on the dispatch path to honour every active scope.
 ///
 /// On any failure the partially-pushed stacks are unwound before
 /// returning, so the caller never has to worry about leaked policy
 /// state.
-fn install_session_policies(
+pub(crate) fn install_session_policy_guard(
     opts_map: &BTreeMap<String, VmValue>,
-) -> Result<InstalledPolicies, VmError> {
+) -> Result<SessionPolicyGuard, VmError> {
     let mut installed = InstalledPolicies::default();
     match install_session_policies_inner(opts_map, &mut installed) {
-        Ok(()) => Ok(installed),
+        Ok(()) => Ok(SessionPolicyGuard { installed }),
         Err(error) => {
             release_session_policies(&installed);
             Err(error)

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -480,6 +480,8 @@ pub fn reset_llm_state() {
     rate_limit::reset_rate_limit_state();
     mock::reset_llm_mock_state();
     autonomy_budget::reset_autonomy_budget_state();
+    agent_session_host::reset_agent_session_host_state();
+    permissions::clear_dynamic_permission_state();
     trigger_predicate::reset_trigger_predicate_state();
     capabilities::clear_user_overrides();
     // Per-`@step` registry, active stack, and completed-step log are
@@ -1227,6 +1229,7 @@ async fn host_agent_dispatch_tool_call_impl(args: Vec<VmValue>) -> Result<VmValu
         .unwrap_or(1000)
         .max(1) as u64;
     let bridge = current_host_bridge();
+    let _policy_guard = agent_session_host::install_session_policy_guard(&options)?;
 
     if let Err(error) =
         crate::orchestration::enforce_current_policy_for_tool(&tool_name).and_then(|_| {

--- a/crates/harn-vm/src/llm/permissions.rs
+++ b/crates/harn-vm/src/llm/permissions.rs
@@ -101,6 +101,11 @@ pub(crate) fn pop_dynamic_permission_policy() {
     });
 }
 
+pub(crate) fn clear_dynamic_permission_state() {
+    DYNAMIC_PERMISSION_STACK.with(|stack| stack.borrow_mut().clear());
+    SESSION_PERMISSION_GRANTS.with(|store| store.borrow_mut().clear());
+}
+
 pub(crate) fn current_dynamic_permission_policies() -> Vec<DynamicPermissionPolicy> {
     DYNAMIC_PERMISSION_STACK.with(|stack| stack.borrow().clone())
 }

--- a/crates/harn-vm/src/orchestration/command_policy.rs
+++ b/crates/harn-vm/src/orchestration/command_policy.rs
@@ -101,6 +101,9 @@ pub fn parse_command_policy_value(
     let Some(value) = value else {
         return Ok(None);
     };
+    if matches!(value, VmValue::Nil) {
+        return Ok(None);
+    }
     let Some(map) = value.as_dict() else {
         return Err(VmError::Runtime(format!(
             "{label}: command_policy must be a dict"

--- a/crates/harn-vm/src/orchestration/policy/mod.rs
+++ b/crates/harn-vm/src/orchestration/policy/mod.rs
@@ -38,6 +38,12 @@ pub fn pop_execution_policy() {
     });
 }
 
+pub fn clear_execution_policy_stacks() {
+    EXECUTION_POLICY_STACK.with(|stack| stack.borrow_mut().clear());
+    EXECUTION_APPROVAL_POLICY_STACK.with(|stack| stack.borrow_mut().clear());
+    TRUSTED_BRIDGE_CALL_DEPTH.with(|depth| *depth.borrow_mut() = 0);
+}
+
 pub fn current_execution_policy() -> Option<CapabilityPolicy> {
     EXECUTION_POLICY_STACK.with(|stack| stack.borrow().last().cloned())
 }

--- a/crates/harn-vm/src/orchestration/tests.rs
+++ b/crates/harn-vm/src/orchestration/tests.rs
@@ -1129,6 +1129,18 @@ fn execution_policy_rejects_process_exec_when_read_only() {
 }
 
 #[test]
+fn reset_thread_local_state_clears_execution_policy_stack() {
+    push_execution_policy(CapabilityPolicy {
+        side_effect_level: Some("read_only".to_string()),
+        capabilities: BTreeMap::from([("workspace".to_string(), vec!["read_text".to_string()])]),
+        ..Default::default()
+    });
+    assert!(current_execution_policy().is_some());
+    crate::reset_thread_local_state();
+    assert!(current_execution_policy().is_none());
+}
+
+#[test]
 fn execution_policy_rejects_unlisted_tool() {
     push_execution_policy(CapabilityPolicy {
         tools: vec!["read".to_string()],


### PR DESCRIPTION
## Summary

- Refactor `agent_loop` so initialized host sessions are finalized even when bootstrap or turn setup fails.
- Pass agent loop policy, approval, command, and dynamic permission options into tool dispatch and install those scopes only around guarded dispatch calls.
- Treat `prefill_assistant` feedback as assistant context instead of runtime-feedback user text.
- Clear agent session, dynamic permission, execution policy, and command policy state during VM resets.
- Add conformance coverage for failed-loop cleanup, prefill feedback shape, and read-only worker policy dispatch.

## Root Cause

Agent-loop policy options were being installed at session initialization time. That constrained the model planning call itself, not just tool dispatch, which made read-only worker loops unable to make useful LLM progress before tools were evaluated. Failed setup paths also skipped normal session finalization, leaving host-session state around until broader process reset.

## Validation

- `cargo fmt --check`
- `harn fmt --check crates/harn-stdlib/src/stdlib/agent/loop.harn conformance/tests/agents/agent_worker_policy.harn conformance/tests/agents/agent_loop_policy_unwind.harn conformance/tests/agents/agent_prefill_feedback.harn`
- `harn lint crates/harn-stdlib/src/stdlib/agent/loop.harn`
- `harn test conformance --filter agent_worker_policy --verbose`
- `harn test conformance --filter agent_loop_policy_unwind --verbose`
- `harn test conformance --filter agent_prefill_feedback --verbose`
- `harn test conformance tests/agents --filter agent_loop --verbose`
- `HARN_LLM_CALLS_DISABLED=1 cargo test -p harn-vm -p harn-stdlib`