### PR TITLE
Release v0.7.59

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ Pre-0.6 highlights live in [CHANGELOG-pre-0.6.md](CHANGELOG-pre-0.6.md).
 Harn had no external users before 0.6.0, so that archive intentionally keeps
 condensed series summaries instead of full per-patch history.
 
+## v0.7.59
+
+### Added
+
+- **Categorical timing breakdown for `harn run`.** Added `--profile` support that
+  reports categorical performance metrics, including a new `profile` crate and
+  CLI integration for detailed runtime insights.
+- **`pr-finish-pass` skill and slash command.** Introduced a new skill and
+  associated slash commands for Claude Code and Codex to streamline PR
+  finishing workflows.
+- **Agent loop policy scoping to tool dispatch.** Refined the Harn agent loop
+  to scope policies specifically to tool dispatch, adding conformance tests
+  for loop unwinding, prefill feedback, and worker policies.
+
+### Changed
+
+- **Agent loop policy enforcement.** Updated the Harn stdlib and VM orchestration
+  to enforce agent loop policies during tool dispatch, improving safety and
+  control over agent behavior.
+
 ## v0.7.58
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1695,7 +1695,7 @@ dependencies = [
 
 [[package]]
 name = "harn-cli"
-version = "0.7.58"
+version = "0.7.59"
 dependencies = [
  "async-trait",
  "axum",
@@ -1748,7 +1748,7 @@ dependencies = [
 
 [[package]]
 name = "harn-dap"
-version = "0.7.58"
+version = "0.7.59"
 dependencies = [
  "harn-modules",
  "harn-parser",
@@ -1761,7 +1761,7 @@ dependencies = [
 
 [[package]]
 name = "harn-fmt"
-version = "0.7.58"
+version = "0.7.59"
 dependencies = [
  "harn-lexer",
  "harn-parser",
@@ -1769,7 +1769,7 @@ dependencies = [
 
 [[package]]
 name = "harn-hostlib"
-version = "0.7.58"
+version = "0.7.59"
 dependencies = [
  "anyhow",
  "base64",
@@ -1820,7 +1820,7 @@ dependencies = [
 
 [[package]]
 name = "harn-ir"
-version = "0.7.58"
+version = "0.7.59"
 dependencies = [
  "harn-lexer",
  "harn-parser",
@@ -1828,11 +1828,11 @@ dependencies = [
 
 [[package]]
 name = "harn-lexer"
-version = "0.7.58"
+version = "0.7.59"
 
 [[package]]
 name = "harn-lint"
-version = "0.7.58"
+version = "0.7.59"
 dependencies = [
  "harn-lexer",
  "harn-modules",
@@ -1842,7 +1842,7 @@ dependencies = [
 
 [[package]]
 name = "harn-lsp"
-version = "0.7.58"
+version = "0.7.59"
 dependencies = [
  "harn-fmt",
  "harn-ir",
@@ -1857,7 +1857,7 @@ dependencies = [
 
 [[package]]
 name = "harn-modules"
-version = "0.7.58"
+version = "0.7.59"
 dependencies = [
  "croner",
  "harn-lexer",
@@ -1870,7 +1870,7 @@ dependencies = [
 
 [[package]]
 name = "harn-parser"
-version = "0.7.58"
+version = "0.7.59"
 dependencies = [
  "harn-lexer",
  "yansi",
@@ -1878,7 +1878,7 @@ dependencies = [
 
 [[package]]
 name = "harn-serve"
-version = "0.7.58"
+version = "0.7.59"
 dependencies = [
  "async-trait",
  "axum",
@@ -1907,11 +1907,11 @@ dependencies = [
 
 [[package]]
 name = "harn-stdlib"
-version = "0.7.58"
+version = "0.7.59"
 
 [[package]]
 name = "harn-vm"
-version = "0.7.58"
+version = "0.7.59"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = ["crates/harn-wasm"]
 resolver = "2"
 
 [workspace.package]
-version = "0.7.58"
+version = "0.7.59"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/burin-labs/harn"


### PR DESCRIPTION
Release v0.7.59

This PR was prepared by `release_harn.harn` from a fresh release snapshot.
The harness verified this branch already had the target Cargo version, release branch name, and top CHANGELOG entry before the PR handoff.

## Post-prepare summary

- Version: `0.7.58` -> `0.7.59`
- Branch: `release/v0.7.59` targeting `main`
- Latest tag used for release delta: `v0.7.58`
- Changed files: `CHANGELOG.md, Cargo.lock, Cargo.toml`
- Deterministic findings: none

## Changelog section

```markdown
### Added

- **Categorical timing breakdown for `harn run`.** Added `--profile` support that
  reports categorical performance metrics, including a new `profile` crate and
  CLI integration for detailed runtime insights.
- **`pr-finish-pass` skill and slash command.** Introduced a new skill and
  associated slash commands for Claude Code and Codex to streamline PR
  finishing workflows.
- **Agent loop policy scoping to tool dispatch.** Refined the Harn agent loop
  to scope policies specifically to tool dispatch, adding conformance tests
  for loop unwinding, prefill feedback, and worker policies.

### Changed

- **Agent loop policy enforcement.** Updated the Harn stdlib and VM orchestration
  to enforce agent loop policies during tool dispatch, improving safety and
  control over agent behavior.
```

## Commits covered

```text
c92f14c6 Release v0.7.59
1c38c10d Scope agent loop policies to tool dispatch (#1310)
95f75804 Add harn run --profile categorical timing breakdown (#1309)
1ed9b902 Add pr-finish-pass skill / slash command (#1308)
```

## Execution transcript

| Step | Status | Classification |
|------|--------|----------------|
| `prepare-already-complete` | ok | `ok` |
| `release-markdown-lint` | ok | `ok` |
| `commit-already-complete` | ok | `ok` |
| `fetch-base` | ok | `ok` |
| `rebase-base` | ok | `ok` |
| `push` | ok | `ok` |
| `find-existing-pr` | ok | `ok` |
| `refresh-existing-pr-body` | ok | `ok` |
| `inspect-auto-merge` | ok | `ok` |
| `auto-merge` | ok | `ok` |

## Agent artifacts

- Audit JSONL transcript: `/Users/ksinder/projects/harn-bump-fleet/.harn-runs/release-harn/019dfe7b-1e28-74c0-b175-fdd7c26a93a0/agent-llm/llm_transcript.jsonl`
- Draft changelog: `/Users/ksinder/projects/harn-bump-fleet/.harn-runs/release-harn/019dfe7b-1e28-74c0-b175-fdd7c26a93a0/agent-draft-changelog.md`
- Agent validation findings: none

Generated by `release_harn.harn`.
