### PR TITLE
Fix workflow LLM policy ceilings

### DIFF
--- a/crates/harn-vm/src/connectors/harn_module.rs
+++ b/crates/harn-vm/src/connectors/harn_module.rs
@@ -2107,7 +2107,7 @@ pub fn normalize_inbound(_raw) {
   return {type: "reject", status: 400}
 }
 "#,
-                "LLM/network ceiling",
+                "llm.call ceiling",
             ),
             (
                 "file",

--- a/crates/harn-vm/src/orchestration/policy/mod.rs
+++ b/crates/harn-vm/src/orchestration/policy/mod.rs
@@ -269,10 +269,9 @@ pub fn enforce_current_policy_for_builtin(name: &str, args: &[VmValue]) -> Resul
         }
         "llm_call" | "llm_call_safe" | "llm_completion" | "llm_stream" | "llm_stream_call"
         | "llm_healthcheck" | "agent_loop"
-            if !policy_allows_capability(&policy, "llm", "call")
-                || !policy_allows_side_effect(&policy, "network") =>
+            if !policy_allows_capability(&policy, "llm", "call") =>
         {
-            return reject_policy(format!("builtin '{name}' exceeds LLM/network ceiling"));
+            return reject_policy(format!("builtin '{name}' exceeds llm.call ceiling"));
         }
         "connector_call"
             if !policy_allows_capability(&policy, "connector", "call")

--- a/crates/harn-vm/src/orchestration/tests.rs
+++ b/crates/harn-vm/src/orchestration/tests.rs
@@ -1129,6 +1129,30 @@ fn execution_policy_rejects_process_exec_when_read_only() {
 }
 
 #[test]
+fn execution_policy_allows_llm_call_under_read_only_side_effect_ceiling() {
+    push_execution_policy(CapabilityPolicy {
+        side_effect_level: Some("read_only".to_string()),
+        capabilities: BTreeMap::from([("llm".to_string(), vec!["call".to_string()])]),
+        ..Default::default()
+    });
+    let result = enforce_current_policy_for_builtin("llm_call", &[]);
+    pop_execution_policy();
+    assert!(result.is_ok());
+}
+
+#[test]
+fn execution_policy_rejects_llm_call_without_llm_capability() {
+    push_execution_policy(CapabilityPolicy {
+        side_effect_level: Some("network".to_string()),
+        capabilities: BTreeMap::from([("workspace".to_string(), vec!["read_text".to_string()])]),
+        ..Default::default()
+    });
+    let result = enforce_current_policy_for_builtin("llm_call", &[]);
+    pop_execution_policy();
+    assert!(result.is_err());
+}
+
+#[test]
 fn reset_thread_local_state_clears_execution_policy_stack() {
     push_execution_policy(CapabilityPolicy {
         side_effect_level: Some("read_only".to_string()),

--- a/crates/harn-vm/src/tool_surface.rs
+++ b/crates/harn-vm/src/tool_surface.rs
@@ -286,12 +286,20 @@ pub fn tool_capability_policy_from_spec(value: &serde_json::Value) -> Capability
             entry.sort();
         }
     }
-    let side_effect_level = max_side_effect_level(
-        tool_annotations
-            .values()
-            .map(|annotations| annotations.side_effect_level.as_str().to_string())
-            .filter(|level| level != "none"),
-    );
+    if !capabilities.is_empty() {
+        let entry = capabilities.entry("llm".to_string()).or_default();
+        let op = "call".to_string();
+        if !entry.contains(&op) {
+            entry.push(op);
+            entry.sort();
+        }
+    }
+    let side_effect_levels: Vec<String> = tool_annotations
+        .values()
+        .map(|annotations| annotations.side_effect_level.as_str().to_string())
+        .filter(|level| level != "none")
+        .collect();
+    let side_effect_level = max_side_effect_level(side_effect_levels.into_iter());
     CapabilityPolicy {
         tools,
         capabilities,
@@ -1207,6 +1215,56 @@ mod tests {
             emits_artifacts: true,
             ..ToolAnnotations::default()
         }
+    }
+
+    #[test]
+    fn tool_policy_preserves_agent_loop_transport_ceiling() {
+        let mut annotations = ToolAnnotations {
+            kind: ToolKind::Search,
+            side_effect_level: SideEffectLevel::ReadOnly,
+            ..ToolAnnotations::default()
+        };
+        annotations
+            .capabilities
+            .insert("workspace".into(), vec!["read_text".into()]);
+        let policy = tool_capability_policy_from_spec(&serde_json::json!({
+            "_type": "tool_registry",
+            "tools": [
+                {
+                    "name": "look",
+                    "parameters": {"type": "object"},
+                    "policy": annotations
+                }
+            ]
+        }));
+
+        assert_eq!(policy.tools, vec!["look".to_string()]);
+        assert_eq!(policy.side_effect_level.as_deref(), Some("read_only"));
+        assert!(policy
+            .capabilities
+            .get("llm")
+            .is_some_and(|ops| ops.contains(&"call".to_string())));
+        assert!(policy
+            .capabilities
+            .get("workspace")
+            .is_some_and(|ops| ops.contains(&"read_text".to_string())));
+    }
+
+    #[test]
+    fn tool_policy_without_capabilities_keeps_capability_ceiling_unspecified() {
+        let policy = tool_capability_policy_from_spec(&serde_json::json!({
+            "_type": "tool_registry",
+            "tools": [
+                {
+                    "name": "look",
+                    "parameters": {"type": "object"}
+                }
+            ]
+        }));
+
+        assert_eq!(policy.tools, vec!["look".to_string()]);
+        assert!(policy.capabilities.is_empty());
+        assert!(policy.side_effect_level.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- treat `llm.call` as the policy control for LLM transport instead of also requiring a `network` side-effect ceiling
- keep derived tool-surface policies from stripping LLM transport permission when tools declare their own capabilities
- add VM regression coverage for read-only LLM calls and tool-derived capability policy shape

## Why
Workflow stages can be read-only, workspace-write, or process-exec while still needing to call a model. Conflating the model transport with the stage's tool side-effect ceiling made read/write workflow stages reject `llm_call` before the model could act.

## Verification
- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/tmp/harn-target-hotfix cargo test -p harn-vm --lib`
- Built `harn` from this branch and verified Burin's `test_capability_scope.harn` passes against the fixed binary.
