### PR TITLE
Release v0.7.60

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ Pre-0.6 highlights live in [CHANGELOG-pre-0.6.md](CHANGELOG-pre-0.6.md).
 Harn had no external users before 0.6.0, so that archive intentionally keeps
 condensed series summaries instead of full per-patch history.
 
+## v0.7.60
+
+### Fixed
+
+- **Workflow LLM policy ceilings.** Fix an over-restrictive policy ceiling so that
+  LLM operations such as `llm_call` and `agent_loop` require only the
+  `llm.call` capability, not `side_effect=network`. Workflow stages with
+  read-only, workspace-write, or process-exec tool ceilings can now call the
+  configured LLM. Tool-derived policies with no capability annotations now leave
+  capability ceilings unspecified instead of narrowing custom node capabilities.
+
 ## v0.7.59
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1695,7 +1695,7 @@ dependencies = [
 
 [[package]]
 name = "harn-cli"
-version = "0.7.59"
+version = "0.7.60"
 dependencies = [
  "async-trait",
  "axum",
@@ -1748,7 +1748,7 @@ dependencies = [
 
 [[package]]
 name = "harn-dap"
-version = "0.7.59"
+version = "0.7.60"
 dependencies = [
  "harn-modules",
  "harn-parser",
@@ -1761,7 +1761,7 @@ dependencies = [
 
 [[package]]
 name = "harn-fmt"
-version = "0.7.59"
+version = "0.7.60"
 dependencies = [
  "harn-lexer",
  "harn-parser",
@@ -1769,7 +1769,7 @@ dependencies = [
 
 [[package]]
 name = "harn-hostlib"
-version = "0.7.59"
+version = "0.7.60"
 dependencies = [
  "anyhow",
  "base64",
@@ -1820,7 +1820,7 @@ dependencies = [
 
 [[package]]
 name = "harn-ir"
-version = "0.7.59"
+version = "0.7.60"
 dependencies = [
  "harn-lexer",
  "harn-parser",
@@ -1828,11 +1828,11 @@ dependencies = [
 
 [[package]]
 name = "harn-lexer"
-version = "0.7.59"
+version = "0.7.60"
 
 [[package]]
 name = "harn-lint"
-version = "0.7.59"
+version = "0.7.60"
 dependencies = [
  "harn-lexer",
  "harn-modules",
@@ -1842,7 +1842,7 @@ dependencies = [
 
 [[package]]
 name = "harn-lsp"
-version = "0.7.59"
+version = "0.7.60"
 dependencies = [
  "harn-fmt",
  "harn-ir",
@@ -1857,7 +1857,7 @@ dependencies = [
 
 [[package]]
 name = "harn-modules"
-version = "0.7.59"
+version = "0.7.60"
 dependencies = [
  "croner",
  "harn-lexer",
@@ -1870,7 +1870,7 @@ dependencies = [
 
 [[package]]
 name = "harn-parser"
-version = "0.7.59"
+version = "0.7.60"
 dependencies = [
  "harn-lexer",
  "yansi",
@@ -1878,7 +1878,7 @@ dependencies = [
 
 [[package]]
 name = "harn-serve"
-version = "0.7.59"
+version = "0.7.60"
 dependencies = [
  "async-trait",
  "axum",
@@ -1907,11 +1907,11 @@ dependencies = [
 
 [[package]]
 name = "harn-stdlib"
-version = "0.7.59"
+version = "0.7.60"
 
 [[package]]
 name = "harn-vm"
-version = "0.7.59"
+version = "0.7.60"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = ["crates/harn-wasm"]
 resolver = "2"
 
 [workspace.package]
-version = "0.7.59"
+version = "0.7.60"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/burin-labs/harn"


### PR DESCRIPTION
Release v0.7.60

This PR was prepared by `release_harn.harn` from a fresh release snapshot.
The harness generated the release content through `scripts/release_ship.sh --prepare` before the PR handoff.

## Post-prepare summary

- Version: `0.7.59` -> `0.7.60`
- Branch: `release/v0.7.60` targeting `main`
- Latest tag used for release delta: `v0.7.59`
- Changed files: `CHANGELOG.md, Cargo.lock, Cargo.toml`
- Deterministic findings: none

## Changelog section

```markdown
### Fixed

- **Workflow LLM policy ceilings.** Fix an over-restrictive policy ceiling so that
  LLM operations such as `llm_call` and `agent_loop` require only the
  `llm.call` capability, not `side_effect=network`. Workflow stages with
  read-only, workspace-write, or process-exec tool ceilings can now call the
  configured LLM. Tool-derived policies with no capability annotations now leave
  capability ceilings unspecified instead of narrowing custom node capabilities.
```

## Commits covered

```text
a1c1ed76 Fix workflow LLM policy ceilings (#1312)
```

## Execution transcript

| Step | Status | Classification |
|------|--------|----------------|
| `fetch-origin` | ok | `ok` |
| `sync-base` | ok | `ok` |
| `reset-release-branch-to-base` | ok | `ok` |
| `draft-release-notes` | ok | `ok` |
| `prepare` | ok | `ok` |
| `release-markdown-lint` | ok | `ok` |
| `stage-tracked-release-content` | ok | `ok` |
| `commit` | ok | `ok` |
| `fetch-base` | ok | `ok` |
| `rebase-base` | ok | `ok` |
| `push` | ok | `ok` |
| `find-existing-pr` | ok | `ok` |
| `create-pr` | ok | `ok` |
| `inspect-auto-merge` | ok | `ok` |
| `auto-merge` | ok | `ok` |

## Agent artifacts

- Audit JSONL transcript: `/Users/ksinder/projects/harn-bump-fleet/.harn-runs/release-harn/019dfedf-b37b-7151-873b-4a5005583bae/agent-llm/llm_transcript.jsonl`
- Draft changelog: `/Users/ksinder/projects/harn-bump-fleet/.harn-runs/release-harn/019dfedf-b37b-7151-873b-4a5005583bae/agent-draft-changelog.md`
- Agent validation findings: none

Generated by `release_harn.harn`.
