### PR TITLE
Gate agent completion on required tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ condensed series summaries instead of full per-patch history.
   effort vs. disabled) only when the caller hasn't set one, using
   `provider_capabilities` introspection.
 
+### Fixed
+
+- **Required tool completion gate.** `agent_loop` now treats unsatisfied
+  `require_successful_tools` as an active completion gate: if the model tries
+  to finish early, Harn injects feedback and continues while budget remains,
+  and any terminal missing-required-tools state consistently returns
+  `status = "failed"` / `stop_reason = "missing_required_tools"`.
+
 ## v0.7.60
 
 ### Fixed

--- a/conformance/tests/agents/agent_loop_require_successful_tools.expected
+++ b/conformance/tests/agents/agent_loop_require_successful_tools.expected
@@ -3,3 +3,6 @@ missing_required_tools
 missing_tool
 done
 0
+done
+3
+0

--- a/conformance/tests/agents/agent_loop_require_successful_tools.harn
+++ b/conformance/tests/agents/agent_loop_require_successful_tools.harn
@@ -50,4 +50,24 @@ pipeline main() {
   )
   println(satisfied.status)
   println(len(satisfied.missing_required_tools ?? []))
+  llm_mock_clear()
+  llm_mock({text: "Finished before using the required tool."})
+  llm_mock({tool_calls: [{id: "lookup_3", name: "lookup", arguments: {query: "x"}}]})
+  llm_mock({text: "Finished after using the required tool."})
+  let gated = agent_loop(
+    "Use one tool.",
+    nil,
+    {
+      provider: "mock",
+      tools: tools(),
+      tool_format: "native",
+      loop_until_done: true,
+      max_iterations: 3,
+      max_nudges: 2,
+      require_successful_tools: ["lookup"],
+    },
+  )
+  println(gated.status)
+  println(gated.llm.iterations)
+  println(len(gated.missing_required_tools ?? []))
 }

--- a/crates/harn-stdlib/src/stdlib/agent/loop.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/loop.harn
@@ -259,9 +259,6 @@ fn __enforce_required_successful_tools(result, opts) {
   if len(missing) == 0 {
     return result
   }
-  if result?.status != "done" {
-    return result + {missing_required_tools: missing}
-  }
   return result
     + {
     status: "failed",
@@ -311,6 +308,12 @@ fn __required_tools_missing_list(opts, successful_tools_seen) {
     }
   }
   return missing
+}
+
+fn __required_tools_feedback(missing) {
+  return "Required tool(s) have not succeeded yet: "
+    + join(missing, ", ")
+    + ". Continue working and call the missing required tool(s) before finalizing."
 }
 
 fn __build_loop_state(args) {
@@ -720,11 +723,21 @@ fn __agent_loop_run(message, session, initial_opts) {
             should_continue = true
           }
         }
+        let missing_now = __required_tools_missing_list(opts, successful_tools_seen)
+        if !should_continue && len(missing_now) > 0 {
+          agent_session_inject_feedback(
+            session.session_id,
+            "required_tools",
+            __required_tools_feedback(missing_now),
+          )
+          should_continue = true
+        }
         if !should_continue {
           stop_reason = outcome.stop_reason
           break
         }
       }
+      let missing_required_for_loop = __required_tools_missing_list(opts, successful_tools_seen)
       let loop_state = __snapshot_loop_state(
         {
           iteration: iteration,
@@ -738,7 +751,7 @@ fn __agent_loop_run(message, session, initial_opts) {
           turn_native_fallback_used: fallback_outcome.triggered && fallback_outcome.accepted,
           session_successful: successful_tools_seen,
           session_rejected: rejected_tools_seen,
-          missing_required_tools: __required_tools_missing_list(opts, successful_tools_seen),
+          missing_required_tools: missing_required_for_loop,
           completion_proposed: outcome.kind == "break",
           verdict: verdict_record,
         },


### PR DESCRIPTION
## Summary
- treat unsatisfied `require_successful_tools` as an active completion gate before accepting natural completion
- inject feedback so the model gets another turn to call the missing required tool while budget remains
- consistently fail terminal missing-required-tools outcomes with `stop_reason = "missing_required_tools"`
- add conformance for premature completion followed by required-tool recovery

## Verification
- `CARGO_TARGET_DIR=/tmp/harn-required-tools-gate-target cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/tmp/harn-required-tools-gate-target make fmt-harn`
- `CARGO_TARGET_DIR=/tmp/harn-required-tools-gate-target make lint-harn`
- `CARGO_TARGET_DIR=/tmp/harn-required-tools-gate-target cargo run --quiet --bin harn -- test conformance --filter agent_loop_require_successful_tools`
- `CARGO_TARGET_DIR=/tmp/harn-required-tools-gate-target cargo run --quiet --bin harn -- test conformance --filter agent_loop_loop_control`
- `CARGO_TARGET_DIR=/tmp/harn-required-tools-gate-target cargo run --quiet --bin harn -- test conformance --filter agent_loop_adaptive_budget`
- `CARGO_TARGET_DIR=/tmp/harn-required-tools-gate-target make lint-md`
- `git diff --check`