### PR TITLE
Release v0.7.61

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Pre-0.6 highlights live in [CHANGELOG-pre-0.6.md](CHANGELOG-pre-0.6.md).
 Harn had no external users before 0.6.0, so that archive intentionally keeps
 condensed series summaries instead of full per-patch history.
 
-## Unreleased
+## v0.7.61
 
 ### Added
 
@@ -27,6 +27,9 @@ condensed series summaries instead of full per-patch history.
   `thinking`. Presets pick a provider-aware `thinking` mode (adaptive vs.
   effort vs. disabled) only when the caller hasn't set one, using
   `provider_capabilities` introspection.
+- **`std/command` step runner.** New `stdlib_command.harn` provides a reusable
+  command-step primitive for harness scripts, with conformance tests covering
+  basic execution and retry logic.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1695,7 +1695,7 @@ dependencies = [
 
 [[package]]
 name = "harn-cli"
-version = "0.7.60"
+version = "0.7.61"
 dependencies = [
  "async-trait",
  "axum",
@@ -1748,7 +1748,7 @@ dependencies = [
 
 [[package]]
 name = "harn-dap"
-version = "0.7.60"
+version = "0.7.61"
 dependencies = [
  "harn-modules",
  "harn-parser",
@@ -1761,7 +1761,7 @@ dependencies = [
 
 [[package]]
 name = "harn-fmt"
-version = "0.7.60"
+version = "0.7.61"
 dependencies = [
  "harn-lexer",
  "harn-parser",
@@ -1769,7 +1769,7 @@ dependencies = [
 
 [[package]]
 name = "harn-hostlib"
-version = "0.7.60"
+version = "0.7.61"
 dependencies = [
  "anyhow",
  "base64",
@@ -1820,7 +1820,7 @@ dependencies = [
 
 [[package]]
 name = "harn-ir"
-version = "0.7.60"
+version = "0.7.61"
 dependencies = [
  "harn-lexer",
  "harn-parser",
@@ -1828,11 +1828,11 @@ dependencies = [
 
 [[package]]
 name = "harn-lexer"
-version = "0.7.60"
+version = "0.7.61"
 
 [[package]]
 name = "harn-lint"
-version = "0.7.60"
+version = "0.7.61"
 dependencies = [
  "harn-lexer",
  "harn-modules",
@@ -1842,7 +1842,7 @@ dependencies = [
 
 [[package]]
 name = "harn-lsp"
-version = "0.7.60"
+version = "0.7.61"
 dependencies = [
  "harn-fmt",
  "harn-ir",
@@ -1857,7 +1857,7 @@ dependencies = [
 
 [[package]]
 name = "harn-modules"
-version = "0.7.60"
+version = "0.7.61"
 dependencies = [
  "croner",
  "harn-lexer",
@@ -1870,7 +1870,7 @@ dependencies = [
 
 [[package]]
 name = "harn-parser"
-version = "0.7.60"
+version = "0.7.61"
 dependencies = [
  "harn-lexer",
  "yansi",
@@ -1878,7 +1878,7 @@ dependencies = [
 
 [[package]]
 name = "harn-serve"
-version = "0.7.60"
+version = "0.7.61"
 dependencies = [
  "async-trait",
  "axum",
@@ -1907,11 +1907,11 @@ dependencies = [
 
 [[package]]
 name = "harn-stdlib"
-version = "0.7.60"
+version = "0.7.61"
 
 [[package]]
 name = "harn-vm"
-version = "0.7.60"
+version = "0.7.61"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = ["crates/harn-wasm"]
 resolver = "2"
 
 [workspace.package]
-version = "0.7.60"
+version = "0.7.61"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/burin-labs/harn"


### PR DESCRIPTION
Release v0.7.61

This PR was prepared by `release_harn.harn` from a fresh release snapshot.
The harness generated the release content through `scripts/release_ship.sh --prepare` before the PR handoff.

## Post-prepare summary

- Version: `0.7.60` -> `0.7.61`
- Branch: `release/v0.7.61` targeting `main`
- Latest tag used for release delta: `v0.7.60`
- Changed files: `CHANGELOG.md, Cargo.lock, Cargo.toml`
- Deterministic findings: none

## Changelog section

```markdown
### Added

- **Adaptive iteration budgeting and `loop_control` policy on `agent_loop`.**
  `iteration_budget: {mode, initial, max, extend_by}` lets a loop start with a
  small cap and extend it transparently when there's evidence of progress;
  pass `loop_control: { state -> ... }` for a fully custom policy that sees a
  stable normalized loop-state snapshot (`budget`, `turn`, `session`,
  `completion`, `progress`) and returns `nil`, `{action: "extend"}`, or
  `{action: "stop"}`. `max_iterations` keeps working as a fixed cap. Decisions
  are surfaced under `result.adaptive_budget` and as `LoopControlDecision`
  events on the live event stream / ACP wire.
- **Generic role presets in `std/agent/presets`.** `agent_preset(kind,
  options?)`, `agent_budget(...)`, and `audit_agent` / `repair_agent` /
  `summary_agent` / `verify_agent` package the common harness shapes (audit /
  repair / summary / verify) so scripts don't have to hand-tune
  `max_iterations`, `max_nudges`, `done_sentinel`, `done_judge`, or
  `thinking`. Presets pick a provider-aware `thinking` mode (adaptive vs.
  effort vs. disabled) only when the caller hasn't set one, using
  `provider_capabilities` introspection.
- **`std/command` step runner.** New `stdlib_command.harn` provides a reusable
  command-step primitive for harness scripts, with conformance tests covering
  basic execution and retry logic.

### Fixed

- **Required tool completion gate.** `agent_loop` now treats unsatisfied
  `require_successful_tools` as an active completion gate: if the model tries
  to finish early, Harn injects feedback and continues while budget remains,
  and any terminal missing-required-tools state consistently returns
  `status = "failed"` / `stop_reason = "missing_required_tools"`.
```

## Commits covered

```text
0b37ee82 Gate agent completion on required tools (#1316)
db21f392 Adaptive iteration budget + agent role presets (#1315)
c6092a6a [codex] add std command step runner (#1314)
```

## Execution transcript

| Step | Status | Classification |
|------|--------|----------------|
| `fetch-origin` | ok | `ok` |
| `sync-base` | ok | `ok` |
| `create-release-branch-from-base` | ok | `ok` |
| `draft-release-notes` | ok | `ok` |
| `prepare` | ok | `ok` |
| `release-markdown-lint` | ok | `ok` |
| `stage-tracked-release-content` | ok | `ok` |
| `commit` | ok | `ok` |
| `fetch-base` | ok | `ok` |
| `rebase-base` | ok | `ok` |
| `push` | ok | `ok` |
| `find-existing-pr` | ok | `ok` |
| `create-pr` | ok | `ok` |
| `inspect-auto-merge` | ok | `ok` |
| `auto-merge` | ok | `ok` |

## Agent artifacts

- Audit JSONL transcript: `/Users/ksinder/projects/harn-bump-fleet/.harn-runs/release-harn/019e0016-d9af-77b0-ae6f-8264e7a19ee4/agent-llm/llm_transcript.jsonl`
- Draft changelog: `/Users/ksinder/projects/harn-bump-fleet/.harn-runs/release-harn/019e0016-d9af-77b0-ae6f-8264e7a19ee4/agent-draft-changelog.md`
- Agent validation findings: none

Generated by `release_harn.harn`.
