### PR TITLE
Fix summary preset tool_choice default

### DIFF
--- a/conformance/tests/agents/agent_preset_audit_summary.expected
+++ b/conformance/tests/agents/agent_preset_audit_summary.expected
@@ -6,5 +6,8 @@ done
 Just a summary.
 1
 done
+Local summary.
+true
+done
 adaptive
 true

--- a/conformance/tests/agents/agent_preset_audit_summary.harn
+++ b/conformance/tests/agents/agent_preset_audit_summary.harn
@@ -36,6 +36,15 @@ pipeline default() {
   println(summary.status)
   println(summary.text)
   println(summary.llm.iterations)
+  // summary_agent should not inject native-tool options when it has no tools.
+  // This keeps local/Ollama-style providers without native tool support usable.
+  llm_mock_clear()
+  llm_mock({text: "Local summary."})
+  let local_summary = summary_agent("Summarize locally.", {provider: "mock", model: "mystery-model-7b"})
+  println(local_summary.status)
+  println(local_summary.text)
+  let summary_calls = llm_mock_calls()
+  println(summary_calls[0]?.tool_choice == nil)
   // repair_agent: tool-using with adaptive budget defaults; ends on natural
   // user_response.
   llm_mock_clear()

--- a/conformance/tests/agents/agent_preset_options.expected
+++ b/conformance/tests/agents/agent_preset_options.expected
@@ -8,7 +8,7 @@ false
 1
 true
 completer
-none
+true
 fixed
 1
 1

--- a/conformance/tests/agents/agent_preset_options.harn
+++ b/conformance/tests/agents/agent_preset_options.harn
@@ -13,7 +13,7 @@ pipeline default() {
   println(audit?.thinking == nil)
   let summary = agent_preset("summary")
   println(summary.profile)
-  println(summary.tool_choice)
+  println(summary?.tool_choice == nil)
   println(summary.iteration_budget.mode)
   println(summary.iteration_budget.initial)
   println(summary.iteration_budget.max)

--- a/crates/harn-stdlib/src/stdlib/agent/presets.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/presets.harn
@@ -160,13 +160,7 @@ fn __turn_policy_for_kind(kind, opts) {
 }
 
 fn __summary_defaults(opts) {
-  var defaults = {profile: "completer", loop_until_done: false, done_sentinel: nil, done_judge: nil, max_nudges: 0}
-  if !__has_key(opts, "tools") || opts?.tools == nil {
-    defaults = defaults + {tool_choice: "none"}
-  } else if !__has_key(opts, "tool_choice") {
-    defaults = defaults + {tool_choice: "none"}
-  }
-  return defaults
+  return {profile: "completer", loop_until_done: false, done_sentinel: nil, done_judge: nil, max_nudges: 0}
 }
 
 fn __verify_defaults() {


### PR DESCRIPTION
## Summary
- Stop `summary_agent` / the `summary` preset from injecting `tool_choice: "none"` by default.
- Preserve explicit caller-provided `tool_choice`, but avoid sending native-tool options for no-tool summaries.
- Add conformance coverage for a no-native-tools local/mock model so summaries remain usable on Ollama-style providers.

## Why
`tool_choice: "none"` is still a native-tool option. Providers/models without native tool support reject it before the summary prompt can run, which made downstream callers report misleading format failures. The simpler default is to omit tool options unless the caller explicitly asks for them.

## Validation
- `CARGO_TARGET_DIR=/tmp/harn-summary-tool-choice-target cargo run --bin harn -- fmt --check crates/harn-stdlib/src/stdlib/agent/presets.harn conformance/tests/agents/agent_preset_options.harn conformance/tests/agents/agent_preset_audit_summary.harn`
- `/tmp/harn-summary-tool-choice-target/debug/harn check crates/harn-stdlib/src/stdlib/agent/presets.harn conformance/tests/agents/agent_preset_options.harn conformance/tests/agents/agent_preset_audit_summary.harn`
- `HARN_LLM_CALLS_DISABLED=1 /tmp/harn-summary-tool-choice-target/debug/harn test conformance tests/agents/agent_preset_options.harn`
- `HARN_LLM_CALLS_DISABLED=1 /tmp/harn-summary-tool-choice-target/debug/harn test conformance tests/agents/agent_preset_audit_summary.harn`
- `/tmp/harn-summary-tool-choice-target/debug/harn lint crates/harn-stdlib/src/stdlib/agent/presets.harn conformance/tests/agents/agent_preset_options.harn conformance/tests/agents/agent_preset_audit_summary.harn`
- `HARN_LLM_CALLS_DISABLED=1 /tmp/harn-summary-tool-choice-target/debug/harn test conformance tests/agents`
- `CARGO_TARGET_DIR=/tmp/harn-summary-tool-choice-target cargo test -p harn-vm unsupported_capability_options_error_with_provider_matrix_hint`
- `CARGO_TARGET_DIR=/tmp/harn-summary-tool-choice-target cargo test -p harn-stdlib`
- `git diff --check`