### PR TITLE
[codex] Stream harn run stdout during execution

### DIFF
--- a/crates/harn-cli/src/commands/run.rs
+++ b/crates/harn-cli/src/commands/run.rs
@@ -511,6 +511,7 @@ pub(crate) async fn run_file_with_skill_dirs(
     // Graceful shutdown: flush run records before exit on SIGINT/SIGTERM.
     let cancelled = install_signal_shutdown_handler();
 
+    let _stdout_passthrough = StdoutPassthroughGuard::enable();
     let outcome = execute_run(
         path,
         trace,
@@ -523,8 +524,8 @@ pub(crate) async fn run_file_with_skill_dirs(
     )
     .await;
 
-    // Drain stderr before stdout so users see diagnostics first when streams
-    // interleave on the terminal.
+    // `harn run` streams normal program stdout during execution. Any stdout
+    // left here came from older capture paths, so flush it after diagnostics.
     if !outcome.stderr.is_empty() {
         io::stderr().write_all(outcome.stderr.as_bytes()).ok();
     }
@@ -538,6 +539,24 @@ pub(crate) async fn run_file_with_skill_dirs(
     }
     if exit_code != 0 {
         process::exit(exit_code);
+    }
+}
+
+struct StdoutPassthroughGuard {
+    previous: bool,
+}
+
+impl StdoutPassthroughGuard {
+    fn enable() -> Self {
+        Self {
+            previous: harn_vm::set_stdout_passthrough(true),
+        }
+    }
+}
+
+impl Drop for StdoutPassthroughGuard {
+    fn drop(&mut self) {
+        harn_vm::set_stdout_passthrough(self.previous);
     }
 }
 
@@ -1400,8 +1419,18 @@ pub(crate) async fn run_watch(path: &str, denied_builtins: HashSet<String>) {
 
 #[cfg(test)]
 mod tests {
-    use super::{execute_run, CliLlmMockMode, RunProfileOptions};
+    use super::{execute_run, CliLlmMockMode, RunProfileOptions, StdoutPassthroughGuard};
     use std::collections::HashSet;
+
+    #[test]
+    fn stdout_passthrough_guard_restores_previous_state() {
+        let original = harn_vm::set_stdout_passthrough(false);
+        {
+            let _guard = StdoutPassthroughGuard::enable();
+            assert!(harn_vm::set_stdout_passthrough(true));
+        }
+        assert!(!harn_vm::set_stdout_passthrough(original));
+    }
 
     #[cfg(feature = "hostlib")]
     #[tokio::test]

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -148,7 +148,7 @@ pub use stdlib::hitl::{
     HITL_DUAL_CONTROL_TOPIC, HITL_ESCALATIONS_TOPIC, HITL_QUESTIONS_TOPIC,
 };
 pub use stdlib::host::{clear_host_call_bridge, set_host_call_bridge, HostCallBridge};
-pub use stdlib::io::take_stderr_buffer;
+pub use stdlib::io::{set_stdout_passthrough, take_stderr_buffer};
 pub use stdlib::long_running::cancel_handle as cancel_long_running_handle;
 pub use stdlib::secret_scan::{
     append_secret_scan_audit, audit_secret_scan_active, scan_content as secret_scan_content,

--- a/crates/harn-vm/src/stdlib/io.rs
+++ b/crates/harn-vm/src/stdlib/io.rs
@@ -28,6 +28,7 @@ thread_local! {
     static STDIN_LINES: RefCell<Option<Vec<String>>> = const { RefCell::new(None) };
     static STDERR_BUFFER: RefCell<String> = const { RefCell::new(String::new()) };
     static STDERR_CAPTURING: RefCell<bool> = const { RefCell::new(false) };
+    static STDOUT_PASSTHROUGH: RefCell<bool> = const { RefCell::new(false) };
     static TTY_MOCK: RefCell<TtyMock> = const { RefCell::new(TtyMock { stdin: None, stdout: None, stderr: None }) };
     static COLOR_MODE: RefCell<ColorMode> = const { RefCell::new(ColorMode::Auto) };
 }
@@ -38,8 +39,23 @@ pub(crate) fn reset_io_state() {
     STDIN_LINES.with(|s| *s.borrow_mut() = None);
     STDERR_BUFFER.with(|s| s.borrow_mut().clear());
     STDERR_CAPTURING.with(|s| *s.borrow_mut() = false);
+    STDOUT_PASSTHROUGH.with(|s| *s.borrow_mut() = false);
     TTY_MOCK.with(|t| *t.borrow_mut() = TtyMock::default());
     COLOR_MODE.with(|m| *m.borrow_mut() = ColorMode::Auto);
+}
+
+/// Enable or disable direct stdout writes for CLI-style runs.
+///
+/// The VM normally captures stdout in-memory so tests and embedding callers
+/// can inspect it after execution. Interactive CLI programs need prompts to
+/// appear before `read_line()` blocks, so `harn run` enables this mode and
+/// streams `print`/`println`/`log` immediately.
+pub fn set_stdout_passthrough(enabled: bool) -> bool {
+    STDOUT_PASSTHROUGH.with(|state| {
+        let previous = *state.borrow();
+        *state.borrow_mut() = enabled;
+        previous
+    })
 }
 
 /// Drain and return the buffered stderr output. The CLI flushes this to
@@ -57,6 +73,20 @@ fn write_stderr(line: &str) {
         // accumulated before capture toggled, but normally nothing does.
         let _ = std::io::stderr().write_all(line.as_bytes());
     }
+}
+
+fn write_stdout(out: &mut String, text: &str) {
+    if stdout_passthrough_enabled() {
+        let mut stdout = std::io::stdout().lock();
+        let _ = stdout.write_all(text.as_bytes());
+        let _ = stdout.flush();
+    } else {
+        out.push_str(text);
+    }
+}
+
+fn stdout_passthrough_enabled() -> bool {
+    STDOUT_PASSTHROUGH.with(|state| *state.borrow())
 }
 
 fn read_stdin_all_real() -> Option<String> {
@@ -141,17 +171,17 @@ fn ansi_enabled_for_stream(stream: &str) -> bool {
 pub(crate) fn register_io_builtins(vm: &mut Vm) {
     vm.register_builtin("log", |args, out| {
         let msg = args.first().map(|a| a.display()).unwrap_or_default();
-        out.push_str(&format!("[harn] {msg}\n"));
+        write_stdout(out, &format!("[harn] {msg}\n"));
         Ok(VmValue::Nil)
     });
     vm.register_builtin("print", |args, out| {
         let msg = args.first().map(|a| a.display()).unwrap_or_default();
-        out.push_str(&msg);
+        write_stdout(out, &msg);
         Ok(VmValue::Nil)
     });
     vm.register_builtin("println", |args, out| {
         let msg = args.first().map(|a| a.display()).unwrap_or_default();
-        out.push_str(&format!("{msg}\n"));
+        write_stdout(out, &format!("{msg}\n"));
         Ok(VmValue::Nil)
     });
 
@@ -354,7 +384,7 @@ pub(crate) fn register_io_builtins(vm: &mut Vm) {
 
     vm.register_builtin("prompt_user", |args, out| {
         let msg = args.first().map(|a| a.display()).unwrap_or_default();
-        out.push_str(&msg);
+        write_stdout(out, &msg);
         let mut input = String::new();
         if std::io::stdin().lock().read_line(&mut input).is_ok() {
             Ok(VmValue::String(Rc::from(input.trim_end())))
@@ -400,7 +430,7 @@ pub(crate) fn register_io_builtins(vm: &mut Vm) {
     // Standalone mode writes a structured log line; bridge/ACP mode overrides
     // this to emit structured notifications.
     vm.register_builtin("progress", |args, out| {
-        out.push_str(&render_progress_line(args));
+        write_stdout(out, &render_progress_line(args));
         Ok(VmValue::Nil)
     });
 
@@ -409,12 +439,13 @@ pub(crate) fn register_io_builtins(vm: &mut Vm) {
         let value = args.get(1).cloned().unwrap_or(VmValue::Nil);
         let json_val = super::logging::vm_value_to_json_fragment(&value);
         let ts = super::logging::vm_format_timestamp_utc();
-        out.push_str(&format!(
+        let line = format!(
             "{{\"ts\":{},\"key\":{},\"value\":{}}}\n",
             vm_escape_json_str_quoted(&ts),
             vm_escape_json_str_quoted(&key),
             json_val,
-        ));
+        );
+        write_stdout(out, &line);
         Ok(VmValue::Nil)
     });
 }
@@ -517,7 +548,7 @@ fn vm_write_log(level: &str, level_num: u8, args: &[VmValue], out: &mut String) 
         }
     });
     let line = vm_build_log_line(level, &msg, fields);
-    out.push_str(&line);
+    write_stdout(out, &line);
 }
 
 fn ansi_colorize(text: &str, name: &str) -> String {
@@ -550,7 +581,22 @@ mod tests {
 
     use crate::value::VmValue;
 
-    use super::{render_progress_bar, render_progress_line, spinner_frame};
+    use super::{
+        render_progress_bar, render_progress_line, reset_io_state, set_stdout_passthrough,
+        spinner_frame, stdout_passthrough_enabled,
+    };
+
+    #[test]
+    fn stdout_passthrough_state_toggles() {
+        reset_io_state();
+
+        assert!(!stdout_passthrough_enabled());
+        assert!(!set_stdout_passthrough(true));
+        assert!(stdout_passthrough_enabled());
+
+        assert!(set_stdout_passthrough(false));
+        assert!(!stdout_passthrough_enabled());
+    }
 
     #[test]
     fn progress_bar_mode_renders_hash_bar() {


### PR DESCRIPTION
## Summary

- Stream `harn run` stdout-producing builtins directly during CLI execution.
- Preserve in-memory stdout capture for embedded `execute_run()` callers and tests.
- Add cheap deterministic coverage for the stdout passthrough state and CLI guard restoration.

## Root Cause

`harn run` executed programs with VM stdout captured until the run completed, while `read_line()` read directly from real stdin. Interactive scripts could therefore block waiting for input before their prompt had been flushed to the terminal.

## Validation

- `cargo test -p harn-vm --lib stdout_passthrough_state_toggles`
- `cargo test -p harn-cli --lib stdout_passthrough_guard_restores_previous_state`
- `cargo test -p harn-cli --lib execute_run_installs_hostlib_gate`
- `cargo check -p harn-cli`
- Manual TTY check: `harn run -e 'print("prompt > "); let line = read_line(); println("got ${line}")'` showed `prompt > ` before input.