### PR TITLE
Allow imports in `harn run -e`

### DIFF
--- a/crates/harn-cli/src/commands/run.rs
+++ b/crates/harn-cli/src/commands/run.rs
@@ -110,6 +110,101 @@ fn typecheck_with_imports(
     checker.check_with_source(program, source)
 }
 
+/// Build the wrapped source and temp file backing a `harn run -e` invocation.
+///
+/// `import` is a top-level declaration in Harn, so the leading prefix of
+/// import lines (with surrounding blanks/comments) is hoisted out of the
+/// `pipeline main(task) { ... }` wrapper. The temp file is created in the
+/// current working directory so relative imports (`import "./lib"`) and
+/// `harn.toml` discovery resolve against the user's project, not the
+/// system temp dir. If the CWD is unwritable we fall back to the system
+/// temp dir with a stderr warning — pure-expression `-e` still works,
+/// but relative imports will fail to resolve.
+pub(crate) fn prepare_eval_temp_file(
+    code: &str,
+) -> Result<(String, tempfile::NamedTempFile), String> {
+    let (header, body) = split_eval_header(code);
+    let wrapped = if header.is_empty() {
+        format!("pipeline main(task) {{\n{body}\n}}")
+    } else {
+        format!("{header}\npipeline main(task) {{\n{body}\n}}")
+    };
+
+    let tmp = create_eval_temp_file()?;
+    Ok((wrapped, tmp))
+}
+
+/// Try to place the `-e` temp file in the current working directory so
+/// relative imports and `harn.toml` discovery resolve against the user's
+/// project. Fall back to the system temp dir on failure (with a warning),
+/// so pure-expression `-e` keeps working in read-only contexts.
+fn create_eval_temp_file() -> Result<tempfile::NamedTempFile, String> {
+    if let Some(dir) = std::env::current_dir().ok().as_deref() {
+        // Hidden prefix on Unix so editors / tree-walkers are less likely
+        // to pick the file up during its short lifetime.
+        match tempfile::Builder::new()
+            .prefix(".harn-eval-")
+            .suffix(".harn")
+            .tempfile_in(dir)
+        {
+            Ok(tmp) => return Ok(tmp),
+            Err(error) => eprintln!(
+                "warning: harn run -e: could not create temp file in {}: {error}; \
+                 relative imports will not resolve",
+                dir.display()
+            ),
+        }
+    }
+    tempfile::Builder::new()
+        .prefix("harn-eval-")
+        .suffix(".harn")
+        .tempfile()
+        .map_err(|e| format!("failed to create temp file for -e: {e}"))
+}
+
+/// Split the `-e` input into a header (top-level imports + leading
+/// blanks/comments) and a body (everything else, to be wrapped in
+/// `pipeline main(task)`). The header may be empty.
+///
+/// Lines whose first non-whitespace token is `import` or `pub import`
+/// are treated as imports. Scanning stops at the first non-blank,
+/// non-comment, non-import line.
+fn split_eval_header(code: &str) -> (String, String) {
+    let mut header_end = 0usize;
+    let mut last_kept = 0usize;
+    for (idx, line) in code.lines().enumerate() {
+        let trimmed = line.trim_start();
+        if trimmed.is_empty() || trimmed.starts_with("//") {
+            header_end = idx + 1;
+            continue;
+        }
+        let is_import = trimmed.starts_with("import ")
+            || trimmed.starts_with("import\t")
+            || trimmed.starts_with("import\"")
+            || trimmed.starts_with("pub import ")
+            || trimmed.starts_with("pub import\t");
+        if is_import {
+            header_end = idx + 1;
+            last_kept = idx + 1;
+        } else {
+            break;
+        }
+    }
+    if last_kept == 0 {
+        return (String::new(), code.to_string());
+    }
+    let mut header_lines: Vec<&str> = Vec::new();
+    let mut body_lines: Vec<&str> = Vec::new();
+    for (idx, line) in code.lines().enumerate() {
+        if idx < header_end {
+            header_lines.push(line);
+        } else {
+            body_lines.push(line);
+        }
+    }
+    (header_lines.join("\n"), body_lines.join("\n"))
+}
+
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub enum CliLlmMockMode {
     #[default]
@@ -1419,8 +1514,44 @@ pub(crate) async fn run_watch(path: &str, denied_builtins: HashSet<String>) {
 
 #[cfg(test)]
 mod tests {
-    use super::{execute_run, CliLlmMockMode, RunProfileOptions, StdoutPassthroughGuard};
+    use super::{
+        execute_run, split_eval_header, CliLlmMockMode, RunProfileOptions, StdoutPassthroughGuard,
+    };
     use std::collections::HashSet;
+
+    #[test]
+    fn split_eval_header_no_imports_returns_full_body() {
+        let (header, body) = split_eval_header("println(1 + 2)");
+        assert_eq!(header, "");
+        assert_eq!(body, "println(1 + 2)");
+    }
+
+    #[test]
+    fn split_eval_header_lifts_leading_imports() {
+        let code = "import \"./lib\"\nimport { x } from \"std/math\"\nprintln(x)";
+        let (header, body) = split_eval_header(code);
+        assert_eq!(header, "import \"./lib\"\nimport { x } from \"std/math\"");
+        assert_eq!(body, "println(x)");
+    }
+
+    #[test]
+    fn split_eval_header_keeps_pub_import_and_comments_in_header() {
+        let code = "// header comment\npub import { y } from \"./lib\"\n\nfoo()";
+        let (header, body) = split_eval_header(code);
+        assert_eq!(
+            header,
+            "// header comment\npub import { y } from \"./lib\"\n"
+        );
+        assert_eq!(body, "foo()");
+    }
+
+    #[test]
+    fn split_eval_header_does_not_lift_imports_after_other_statements() {
+        let code = "let a = 1\nimport \"./lib\"";
+        let (header, body) = split_eval_header(code);
+        assert_eq!(header, "");
+        assert_eq!(body, "let a = 1\nimport \"./lib\"");
+    }
 
     #[test]
     fn stdout_passthrough_guard_restores_previous_state() {

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -133,18 +133,8 @@ async fn async_main() {
 
             match (args.eval.as_deref(), args.file.as_deref()) {
                 (Some(code), None) => {
-                    let wrapped = format!("pipeline main(task) {{\n{code}\n}}");
-                    // Unique filename avoids collisions between concurrent
-                    // `harn run -e` invocations; Drop guards cleanup on
-                    // panic. The `.harn` suffix keeps tree-sitter and
-                    // pipeline dispatch matching on extension.
-                    let tmp = tempfile::Builder::new()
-                        .prefix("harn-eval-")
-                        .suffix(".harn")
-                        .tempfile()
-                        .unwrap_or_else(|e| {
-                            command_error(&format!("failed to create temp file for -e: {e}"))
-                        });
+                    let (wrapped, tmp) = commands::run::prepare_eval_temp_file(code)
+                        .unwrap_or_else(|e| command_error(&e));
                     let tmp_path: PathBuf = tmp.path().to_path_buf();
                     fs::write(&tmp_path, &wrapped).unwrap_or_else(|e| {
                         command_error(&format!("failed to write temp file for -e: {e}"))

--- a/crates/harn-cli/tests/run_eval_imports.rs
+++ b/crates/harn-cli/tests/run_eval_imports.rs
@@ -1,0 +1,107 @@
+//! End-to-end coverage for `harn run -e` with module imports.
+//!
+//! `-e` wraps the snippet in `pipeline main(task) { ... }`, but `import`
+//! is a top-level Harn declaration so leading `import` lines are
+//! hoisted out of the wrapper. The temp file backing `-e` is also
+//! placed in the current working directory so relative imports resolve
+//! against the user's project root rather than the system temp dir.
+
+mod test_util;
+
+use std::fs;
+
+use tempfile::TempDir;
+use test_util::process::harn_e2e_command;
+
+#[ignore = "binary surface — moves to slow E2E/smoke job (issue #1069)"]
+#[test]
+fn eval_supports_stdlib_import() {
+    let temp = TempDir::new().unwrap();
+    let out = harn_e2e_command()
+        .current_dir(temp.path())
+        .args(["run", "-e", "import \"std/triggers\"\nprintln(\"ok\")"])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stdout={}, stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("ok"),
+        "stdout did not contain 'ok': {}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}
+
+#[ignore = "binary surface — moves to slow E2E/smoke job (issue #1069)"]
+#[test]
+fn eval_supports_relative_import_against_cwd() {
+    let temp = TempDir::new().unwrap();
+    fs::write(
+        temp.path().join("lib.harn"),
+        "pub fn answer() {\n  return 42\n}\n",
+    )
+    .unwrap();
+
+    let out = harn_e2e_command()
+        .current_dir(temp.path())
+        .args(["run", "-e", "import \"./lib\"\nprintln(answer())"])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stdout={}, stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("42"),
+        "stdout did not contain '42': {}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}
+
+#[ignore = "binary surface — moves to slow E2E/smoke job (issue #1069)"]
+#[test]
+fn eval_pure_expression_still_works() {
+    let temp = TempDir::new().unwrap();
+    let out = harn_e2e_command()
+        .current_dir(temp.path())
+        .args(["run", "-e", "println(1 + 2)"])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stdout={}, stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains('3'),
+        "stdout did not contain '3': {}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}
+
+#[ignore = "binary surface — moves to slow E2E/smoke job (issue #1069)"]
+#[test]
+fn eval_pipeline_return_sets_exit_code() {
+    let temp = TempDir::new().unwrap();
+    let out = harn_e2e_command()
+        .current_dir(temp.path())
+        .args(["run", "-e", "return 7"])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(7),
+        "stdout={}, stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -22,7 +22,14 @@ load `docs/llm/harn-triggers-quickref.md`.
   (pipeline mode — `compile_top_level_declarations` runs first, then
   the pipeline body) or be a bare script with top-level statements.
 - Run: `harn run script.harn`.
-- Inline: `harn run -e 'println("hi")'`.
+- Inline: `harn run -e 'println("hi")'`. The snippet is wrapped in
+  `pipeline main(task) { ... }`; leading `import "..."` /
+  `import { x } from "..."` / `pub import { x } from "..."` lines are
+  hoisted out of the wrapper. The temp file lives in the current
+  directory so relative imports (`import "./lib"`) and `harn.toml`
+  discovery resolve against your project, e.g.
+  `harn run -e $'import "./lib"\nprintln(answer())'`. Imports must come
+  first — interleaved imports are not lifted.
 - Shebang: a `#!/usr/bin/env harn` line at byte offset 0 of a `.harn`
   file is skipped by the lexer, so executables on PATH can `chmod +x`
   scripts and run them directly.

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -36,8 +36,21 @@ Before starting the VM, `harn run <file>` builds the cross-module
 graph for the entry file. When all imports resolve, unknown call
 targets produce a static error and the VM is never started — the same
 `call target ... is not defined or imported` message you see from
-`harn check`. The inline `-e <code>` form has no importing file and
-therefore skips the cross-module check.
+`harn check`.
+
+The inline `-e <code>` form is wrapped in `pipeline main(task) { ... }`
+and run as a temp file in the current directory, so:
+
+- Leading `import "..."` (and `pub import { ... } from "..."`) lines
+  are hoisted out of the wrapper. They must come first; imports that
+  appear after another statement are not lifted.
+- Relative imports resolve against the working directory:
+  `harn run -e $'import "./lib"\nprintln(answer())'` looks for
+  `./lib.harn` next to where you invoked `harn`.
+- Stdlib imports (`import "std/..."`) work the same as in a file.
+- A read-only working directory falls back to the system temp dir;
+  pure-expression `-e` still works there but relative imports won't
+  resolve.
 
 When `--attest` is present, Harn records run start/finish events in an
 EventLog, stamps each record with `prev_hash` and `record_hash` provenance

--- a/scripts/lint_test_patterns.sh
+++ b/scripts/lint_test_patterns.sh
@@ -96,6 +96,7 @@ is_e2e_subprocess_path() {
     crates/harn-cli/tests/mcp_server_cli.rs | \
     crates/harn-cli/tests/orchestrator_cli.rs | \
     crates/harn-cli/tests/persona_cli.rs | \
+    crates/harn-cli/tests/run_eval_imports.rs | \
     crates/harn-cli/tests/run_exit_codes.rs | \
     crates/harn-cli/tests/trigger_replay_cli.rs | \
     crates/harn-cli/tests/orchestrator_http.rs | \


### PR DESCRIPTION
## Summary
- Hoist leading `import` / `pub import` lines out of the `pipeline main(task) { ... }` wrapper that `-e` uses, so snippets like `harn run -e $'import "./lib"\nprintln(answer())'` actually parse.
- Place the `-e` temp file in the current working directory (hidden `.harn-eval-*` prefix) so relative imports and `harn.toml` discovery resolve against the user's project rather than the system temp dir. Stdlib imports work transparently.
- Read-only CWD falls back to the system temp dir with a stderr warning; pure-expression `-e` keeps working there.
- Docs updated in `docs/src/cli-reference.md` and `docs/llm/harn-quickref.md`.

## Test plan
- [x] `cargo test -p harn-cli --lib commands::run::tests` (4 new unit tests for `split_eval_header`)
- [x] `cargo test -p harn-cli --test run_eval_imports -- --ignored` (4 new integration tests: stdlib import, relative import, pure-expression regression, exit-code-from-return regression)
- [x] `cargo clippy -p harn-cli --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `make lint-test-patterns` (added new test file to E2E allowlist)
- [x] `make lint-md`
- [x] `./scripts/check_docs_snippets.sh`
- [x] Manual smoke from a scratch dir: relative import, stdlib import, pure expression, exit-code return all behave as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)