### PR TITLE
Add per-upstream LLM handler circuit pooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Pre-0.6 highlights live in [CHANGELOG-pre-0.6.md](CHANGELOG-pre-0.6.md).
 Harn had no external users before 0.6.0, so that archive intentionally keeps
 condensed series summaries instead of full per-patch history.
 
+## Unreleased
+
+### Added
+
+- **Per-upstream LLM handler circuit pooling.** `std/llm/handlers` now provides
+  `with_circuit_breaker`, which derives circuit names from each call's
+  `(provider, model)` by default while preserving `name` for intentionally
+  shared circuit state.
+
 ## v0.7.61
 
 ### Added

--- a/conformance/tests/integration/llm_handlers_circuit_breaker_pool.expected
+++ b/conformance/tests/integration/llm_handlers_circuit_breaker_pool.expected
@@ -1,0 +1,16 @@
+server_error
+closed
+server_error
+open
+closed
+healthy
+closed
+circuit_open
+llm:mock:bad-model
+3
+server_error
+circuit_open
+shared-model-circuit
+4
+generic
+open

--- a/conformance/tests/integration/llm_handlers_circuit_breaker_pool.harn
+++ b/conformance/tests/integration/llm_handlers_circuit_breaker_pool.harn
@@ -1,0 +1,60 @@
+import { with_circuit_breaker } from "std/llm/handlers"
+
+pipeline default() {
+  llm_mock_clear()
+  let raw_handler = fn(call) { return llm_call(call.prompt, call?.system, call.opts) }
+  let pooled = with_circuit_breaker(raw_handler, {threshold: 2, reset_ms: 60000})
+  let bad_call = {prompt: "bad route", system: nil, opts: {provider: "mock", model: "bad-model", llm_retries: 0}}
+  let good_call = {prompt: "good route", system: nil, opts: {provider: "mock", model: "good-model", llm_retries: 0}}
+  llm_mock({error: {category: "server_error", message: "bad model failed once"}})
+  try {
+    pooled(bad_call)
+  } catch (e1) {
+    println(error_category(e1))
+  }
+  println(circuit_check("llm:mock:bad-model"))
+  llm_mock({error: {category: "server_error", message: "bad model failed twice"}})
+  try {
+    pooled(bad_call)
+  } catch (e2) {
+    println(error_category(e2))
+  }
+  println(circuit_check("llm:mock:bad-model"))
+  println(circuit_check("llm:mock:good-model"))
+  llm_mock({text: "healthy"})
+  println(pooled(good_call).text)
+  println(circuit_check("llm:mock:good-model"))
+  try {
+    pooled(bad_call)
+  } catch (e3) {
+    println(e3.category)
+    println(e3.circuit)
+  }
+  println(len(llm_mock_calls()))
+  let shared = with_circuit_breaker(raw_handler, {name: "shared-model-circuit", threshold: 1, reset_ms: 60000})
+  llm_mock({error: {category: "server_error", message: "shared circuit failed"}})
+  try {
+    shared(bad_call)
+  } catch (e4) {
+    println(error_category(e4))
+  }
+  try {
+    shared(good_call)
+  } catch (e5) {
+    println(e5.category)
+    println(e5.circuit)
+  }
+  println(len(llm_mock_calls()))
+  let unset = with_circuit_breaker(
+    fn(_call) {
+      throw "missing route failed"
+    },
+    {threshold: 1, reset_ms: 60000},
+  )
+  try {
+    unset({prompt: "missing route", opts: {}})
+  } catch (e6) {
+    println(error_category(e6))
+  }
+  println(circuit_check("llm:<unset>:<unset>"))
+}

--- a/crates/harn-stdlib/src/lib.rs
+++ b/crates/harn-stdlib/src/lib.rs
@@ -122,6 +122,10 @@ pub const STDLIB_SOURCES: &[StdlibSource] = &[
         source: include_str!("stdlib/llm/media.harn"),
     },
     StdlibSource {
+        module: "llm/handlers",
+        source: include_str!("stdlib/llm/handlers.harn"),
+    },
+    StdlibSource {
         module: "agent/options",
         source: include_str!("stdlib/agent/options.harn"),
     },
@@ -682,6 +686,7 @@ mod tests {
             "context",
             "command",
             "waitpoint",
+            "llm/handlers",
             "personas/prelude",
             "agent/host_tools",
             "connectors/shared",

--- a/crates/harn-stdlib/src/stdlib/llm/handlers.harn
+++ b/crates/harn-stdlib/src/stdlib/llm/handlers.harn
@@ -1,0 +1,69 @@
+/** std/llm/handlers — small middleware helpers for LLM call handlers. */
+var __llm_handler_circuits = []
+
+fn __llm_handler_is_callable(value) -> bool {
+  let kind = type_of(value)
+  return kind == "function" || kind == "closure" || kind == "fn"
+}
+
+fn __circuit_name_for(call) -> string {
+  let opts = call?.opts ?? {}
+  let provider = to_string(opts?.provider ?? "<unset>")
+  let model = to_string(opts?.model ?? "<unset>")
+  return "llm:" + provider + ":" + model
+}
+
+fn __ensure_llm_handler_circuit(name, threshold, reset_ms) {
+  if !contains(__llm_handler_circuits, name) {
+    circuit_breaker(name, threshold, reset_ms)
+    __llm_handler_circuits = __llm_handler_circuits + [name]
+  }
+}
+
+fn __circuit_open_error(call, name) {
+  let opts = call?.opts ?? {}
+  return {
+    kind: "terminal",
+    reason: "circuit_open",
+    category: "circuit_open",
+    message: "circuit open: " + name,
+    provider: opts?.provider ?? "<unset>",
+    model: opts?.model ?? "<unset>",
+    circuit: name,
+  }
+}
+
+/**
+ * Wrap an LLM call handler with circuit-breaker protection.
+ *
+ * By default each invocation uses a circuit derived from the call's
+ * `(opts.provider, opts.model)` pair, so one failing upstream cannot poison
+ * other models routed through the same wrapper. Pass `name` to intentionally
+ * share one circuit across calls.
+ */
+pub fn with_circuit_breaker(handler, options = nil) {
+  if !__llm_handler_is_callable(handler) {
+    throw "with_circuit_breaker: handler must be callable"
+  }
+  let opts = options ?? {}
+  let threshold = opts?.threshold ?? 5
+  let reset_ms = opts?.reset_ms ?? 30000
+  return fn(call) {
+    let name = opts?.name ?? __circuit_name_for(call)
+    __ensure_llm_handler_circuit(name, threshold, reset_ms)
+    let state = circuit_check(name)
+    if state == "open" {
+      throw __circuit_open_error(call, name)
+    }
+    let outcome = try {
+      handler(call)
+    }
+    if is_err(outcome) {
+      circuit_record_failure(name)
+      throw unwrap_err(outcome)
+    }
+    let result = unwrap(outcome)
+    circuit_record_success(name)
+    return result
+  }
+}

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -27,6 +27,7 @@
 
 - [LLM and agents](./llm-and-agents.md)
   - [LLM calls](./llm/llm_call.md)
+  - [LLM handler helpers](./llm/handlers.md)
   - [Agent loops](./llm/agent_loop.md)
   - [Tools, Tool Vault, and MCP](./llm/tools.md)
   - [Streaming and transcripts](./llm/streaming.md)

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -373,6 +373,8 @@ Imports starting with `std/` load embedded stdlib modules:
 - `import "std/postgres"` — Postgres persistence helpers (pg_pool,
   pg_connect, pg_query, pg_query_one, pg_execute, pg_transaction, pg_close,
   pg_mock_pool, pg_mock_calls)
+- `import "std/llm/handlers"` — LLM call-handler middleware
+  (with_circuit_breaker)
 - `import "std/personas/prelude"` — reusable persona orchestration helpers
   (verify_then_act, bounded_loop, cheap_classify_then_escalate,
   parallel_sweep_with_circuit_breaker, with_audit_receipt,

--- a/docs/src/llm/handlers.md
+++ b/docs/src/llm/handlers.md
@@ -1,0 +1,30 @@
+# LLM handler helpers
+
+`std/llm/handlers` provides small middleware helpers for call handlers that
+accept a call dict such as `{prompt, system, opts}`.
+
+```harn
+import { with_circuit_breaker } from "std/llm/handlers"
+
+pipeline default() {
+  let raw_handler = fn(call) {
+    return llm_call(call.prompt, call?.system, call.opts)
+  }
+  let pooled = with_circuit_breaker(raw_handler)
+  let shared = with_circuit_breaker(raw_handler, {name: "primary-llm", threshold: 3})
+}
+```
+
+`with_circuit_breaker(handler, options?)` uses a circuit named from each call's
+`opts.provider` and `opts.model`, falling back to `"<unset>"` for missing
+fields. A failing upstream therefore opens only its own circuit even when many
+models share the same wrapper. Pass `name` when a caller deliberately wants one
+shared circuit.
+
+Options:
+
+| Option | Default | Description |
+|---|---:|---|
+| `name` | derived | Manual circuit name for shared state |
+| `threshold` | `5` | Consecutive failures before the circuit opens |
+| `reset_ms` | `30000` | Time before `circuit_check` reports `half_open` |

--- a/docs/src/modules.md
+++ b/docs/src/modules.md
@@ -580,6 +580,14 @@ Helpers for isolated git worktree execution built on `exec_at(...)` and
 | `worktree_diff(path, base_ref?)` | Render diff output for the worktree |
 | `worktree_shell(path, script)` | Run an arbitrary shell command inside the worktree |
 
+### std/llm/handlers
+
+Middleware helpers for LLM call handlers:
+
+| Function | Description |
+|---|---|
+| `with_circuit_breaker(handler, options?)` | Wrap a call handler with per-`(provider, model)` circuit-breaker pooling, or pass `name` to share one circuit |
+
 ### std/personas/prelude
 
 Reusable orchestration primitives for durable persona workflows. See

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -371,6 +371,8 @@ Imports starting with `std/` load embedded stdlib modules:
 - `import "std/postgres"` — Postgres persistence helpers (pg_pool,
   pg_connect, pg_query, pg_query_one, pg_execute, pg_transaction, pg_close,
   pg_mock_pool, pg_mock_calls)
+- `import "std/llm/handlers"` — LLM call-handler middleware
+  (with_circuit_breaker)
 - `import "std/personas/prelude"` — reusable persona orchestration helpers
   (verify_then_act, bounded_loop, cheap_classify_then_escalate,
   parallel_sweep_with_circuit_breaker, with_audit_receipt,


### PR DESCRIPTION
## Summary
- Add `std/llm/handlers` with `with_circuit_breaker` middleware for LLM call handlers.
- Derive default circuit names from each call's `(opts.provider, opts.model)`, falling back to `"<unset>"` when absent.
- Preserve manual shared-state behavior through `options.name`, with docs, module catalog entries, changelog notes, and conformance coverage.

Closes #1321.

## Verification
- `cargo test -p harn-stdlib`
- `cargo clippy -p harn-stdlib --all-targets -- -D warnings`
- `cargo run --quiet --bin harn -- test conformance --filter llm_handlers_circuit_breaker_pool`
- `harn fmt --check crates/harn-stdlib/src/stdlib/llm/handlers.harn conformance/tests/integration/llm_handlers_circuit_breaker_pool.harn`
- `harn check conformance/tests/integration/llm_handlers_circuit_breaker_pool.harn`
- `./scripts/check_docs_snippets.sh`
- `make check-language-spec`
- `make lint-test-patterns`
- pre-commit hook
- pre-push hook