### PR TITLE
Add tree-of-thoughts stdlib helper

### DIFF
--- a/conformance/tests/integration/llm_tree_of_thoughts.expected
+++ b/conformance/tests/integration/llm_tree_of_thoughts.expected
@@ -1,0 +1,1 @@
+[harn] llm tree_of_thoughts ok

--- a/conformance/tests/integration/llm_tree_of_thoughts.harn
+++ b/conformance/tests/integration/llm_tree_of_thoughts.harn
@@ -1,0 +1,94 @@
+import { tree_of_thoughts } from "std/llm/ensemble"
+
+fn grid_expand(state, k) {
+  let moves = [
+    {name: "right", x: state.x + 1, y: state.y},
+    {name: "up", x: state.x, y: state.y + 1},
+    {name: "left", x: state.x - 1, y: state.y},
+  ]
+  return moves
+    .filter({ move -> move.x >= 0 && move.x <= 2 && move.y >= 0 && move.y <= 2 })
+    .take(k)
+}
+
+fn grid_score(state) {
+  return 10 - abs(2 - state.x) - abs(2 - state.y)
+}
+
+fn grid_done(state) {
+  return state.x == 2 && state.y == 2
+}
+
+pipeline test(task) {
+  let bfs = tree_of_thoughts(
+    {
+      initial_state: {name: "start", x: 0, y: 0},
+      expand: grid_expand,
+      evaluate: grid_score,
+      is_terminal: grid_done,
+      search: "bfs",
+      k: 2,
+      max_depth: 4,
+    },
+  )
+  assert(bfs.ok, "bfs finds the goal")
+  assert_eq(bfs.best_score, 10)
+  assert_eq(bfs.best_path.map({ state -> state.name }), ["start", "right", "right", "up", "up"])
+  assert_eq(bfs.tree.best_id, bfs.best_node.id)
+  let dfs = tree_of_thoughts(
+    {
+      initial_state: {name: "start", x: 0, y: 0},
+      expand: grid_expand,
+      evaluate: grid_score,
+      is_terminal: grid_done,
+      search: "dfs",
+      k: 2,
+      max_depth: 4,
+    },
+  )
+  assert(dfs.ok, "dfs finds the goal")
+  assert_eq(dfs.best_path.map({ state -> state.name }), ["start", "right", "right", "up", "up"])
+  let shallow = tree_of_thoughts(
+    {
+      initial_state: {name: "start", x: 0, y: 0},
+      expand: grid_expand,
+      evaluate: grid_score,
+      is_terminal: grid_done,
+      search: "bfs",
+      k: 2,
+      max_depth: 1,
+    },
+  )
+  assert(!shallow.ok, "max_depth can bound search before a terminal state")
+  assert_eq(shallow.best_path.map({ state -> state.name }), ["start", "right"])
+  assert_eq(shallow.stop_reason, "exhausted")
+  let beam = tree_of_thoughts(
+    {
+      initial_state: {name: "start", x: 0, y: 0},
+      expand: grid_expand,
+      evaluate: grid_score,
+      is_terminal: grid_done,
+      search: "beam",
+      k: 2,
+      beam_width: 1,
+      max_depth: 4,
+    },
+  )
+  assert(beam.ok, "beam keeps the highest-scoring branch")
+  assert_eq(beam.best_path.map({ state -> state.name }), ["start", "right", "right", "up", "up"])
+  let stopped = tree_of_thoughts(
+    {
+      initial_state: {name: "start", x: 0, y: 0},
+      expand: grid_expand,
+      evaluate: grid_score,
+      is_terminal: grid_done,
+      search: "bfs",
+      k: 2,
+      max_depth: 4,
+      stop: { node -> node.depth == 2 },
+    },
+  )
+  assert(!stopped.ok, "stop predicate can end search before a terminal state")
+  assert_eq(stopped.stop_reason, "stop")
+  log("llm tree_of_thoughts ok")
+}

--- a/crates/harn-stdlib/src/stdlib/llm/ensemble.harn
+++ b/crates/harn-stdlib/src/stdlib/llm/ensemble.harn
@@ -974,3 +974,257 @@ pub fn debate(opts) -> DebateResult {
     short_circuit_event_id: short_circuit_event_id,
   }
 }
+
+fn __tot_is_callable(value) {
+  let kind = type_of(value)
+  return kind == "function" || kind == "closure" || kind == "fn"
+}
+
+fn __tot_is_number(value) {
+  let kind = type_of(value)
+  return kind == "int" || kind == "float"
+}
+
+fn __tot_require_callable(opts, name) {
+  let value = opts[name]
+  require __tot_is_callable(value), "tree_of_thoughts: opts." + name + " must be callable"
+  return value
+}
+
+fn __tot_require_positive_int(value, label) {
+  require __tot_is_number(value), "tree_of_thoughts: " + label + " must be numeric"
+  require floor(value) == value, "tree_of_thoughts: " + label + " must be an integer"
+  require value >= 1, "tree_of_thoughts: " + label + " must be at least 1"
+  return to_int(value)
+}
+
+fn __tot_require_non_negative_int(value, label) {
+  require __tot_is_number(value), "tree_of_thoughts: " + label + " must be numeric"
+  require floor(value) == value, "tree_of_thoughts: " + label + " must be an integer"
+  require value >= 0, "tree_of_thoughts: " + label + " must be non-negative"
+  return to_int(value)
+}
+
+fn __tot_score(evaluate, state) {
+  let score = evaluate(state)
+  require __tot_is_number(score), "tree_of_thoughts: evaluate(state) must return a number"
+  return score
+}
+
+fn __tot_terminal(is_terminal, state) {
+  let terminal = is_terminal(state)
+  require type_of(terminal) == "bool", "tree_of_thoughts: is_terminal(state) must return a bool"
+  return terminal
+}
+
+fn __tot_stop(stop, node) {
+  if stop == nil {
+    return false
+  }
+  let should_stop = stop(node)
+  require type_of(should_stop) == "bool", "tree_of_thoughts: stop(node) must return a bool"
+  return should_stop
+}
+
+fn __tot_node(id, parent_id, state, path, depth, score, terminal) {
+  return {
+    id: id,
+    parent_id: parent_id,
+    state: state,
+    path: path,
+    depth: depth,
+    score: score,
+    terminal: terminal,
+  }
+}
+
+fn __tot_better_terminal(best_terminal, candidate) {
+  return candidate.terminal && (best_terminal == nil || candidate.score > best_terminal.score)
+}
+
+fn __tot_better_seen(best_seen, candidate) {
+  return best_seen == nil || candidate.score > best_seen.score
+}
+
+fn __tot_update_best(best, node) {
+  var best_terminal = best.terminal
+  var best_seen = best.seen
+  if __tot_better_terminal(best_terminal, node) {
+    best_terminal = node
+  }
+  if __tot_better_seen(best_seen, node) {
+    best_seen = node
+  }
+  return {terminal: best_terminal, seen: best_seen}
+}
+
+fn __tot_top(nodes, limit) {
+  return nodes.sort_by({ node -> 0 - node.score }).take(limit)
+}
+
+fn __tot_children(parent, expand, evaluate, is_terminal, k, next_id) {
+  let expanded = expand(parent.state, k)
+  require type_of(expanded) == "list", "tree_of_thoughts: expand(state, k) must return a list"
+  var children = []
+  var idx = 0
+  let limit = if len(expanded) < k {
+    len(expanded)
+  } else {
+    k
+  }
+  while idx < limit {
+    let state = expanded[idx]
+    let node = __tot_node(
+      next_id + idx,
+      parent.id,
+      state,
+      parent.path.push(state),
+      parent.depth + 1,
+      __tot_score(evaluate, state),
+      __tot_terminal(is_terminal, state),
+    )
+    children = children.push(node)
+    idx = idx + 1
+  }
+  return children
+}
+
+fn __tot_finalize(search, k, max_depth, beam_width, nodes, best, stop_reason) {
+  let best_node = best.terminal ?? best.seen
+  let reason = if stop_reason != nil {
+    stop_reason
+  } else {
+    if best.terminal != nil {
+      "terminal"
+    } else {
+      "exhausted"
+    }
+  }
+  return {
+    ok: best.terminal != nil,
+    best_path: best_node?.path ?? [],
+    best_score: best_node?.score,
+    best_node: best_node,
+    stop_reason: reason,
+    tree: {
+      root_id: 0,
+      best_id: best_node?.id,
+      nodes: nodes,
+      search: search,
+      k: k,
+      max_depth: max_depth,
+      beam_width: beam_width,
+    },
+  }
+}
+
+fn __tot_search_frontier(
+  search,
+  root,
+  expand,
+  evaluate,
+  is_terminal,
+  stop,
+  k,
+  max_depth,
+  beam_width,
+) {
+  var nodes = [root]
+  var frontier = [root]
+  var next_id = 1
+  var best = __tot_update_best({terminal: nil, seen: nil}, root)
+  var stop_reason = nil
+  while len(frontier) > 0 && stop_reason == nil {
+    let current = if search == "dfs" {
+      frontier.last()
+    } else {
+      frontier[0]
+    }
+    frontier = if search == "dfs" {
+      frontier.pop()
+    } else {
+      frontier.slice(1)
+    }
+    if __tot_stop(stop, current) {
+      stop_reason = "stop"
+    } else if !current.terminal && current.depth < max_depth {
+      let children = __tot_children(current, expand, evaluate, is_terminal, k, next_id)
+      next_id = next_id + len(children)
+      for child in children {
+        nodes = nodes.push(child)
+        best = __tot_update_best(best, child)
+      }
+      if search == "bfs" {
+        for child in children {
+          frontier = frontier.push(child)
+        }
+      }
+      if search == "dfs" {
+        frontier = frontier + children.reverse()
+      }
+    }
+  }
+  return __tot_finalize(search, k, max_depth, beam_width, nodes, best, stop_reason)
+}
+
+fn __tot_search_beam(root, expand, evaluate, is_terminal, stop, k, max_depth, beam_width) {
+  var nodes = [root]
+  var beam = [root]
+  var next_id = 1
+  var best = __tot_update_best({terminal: nil, seen: nil}, root)
+  var stop_reason = nil
+  var depth = 0
+  while len(beam) > 0 && depth < max_depth && stop_reason == nil {
+    var candidates = []
+    for current in beam {
+      if stop_reason == nil {
+        if __tot_stop(stop, current) {
+          stop_reason = "stop"
+        } else if !current.terminal && current.depth < max_depth {
+          let children = __tot_children(current, expand, evaluate, is_terminal, k, next_id)
+          next_id = next_id + len(children)
+          for child in children {
+            nodes = nodes.push(child)
+            candidates = candidates.push(child)
+            best = __tot_update_best(best, child)
+          }
+        }
+      }
+    }
+    beam = __tot_top(candidates, beam_width)
+    depth = depth + 1
+  }
+  return __tot_finalize("beam", k, max_depth, beam_width, nodes, best, stop_reason)
+}
+
+/** tree_of_thoughts searches explicitly expanded reasoning states with BFS, DFS, or beam search. */
+pub fn tree_of_thoughts(opts) {
+  require type_of(opts) == "dict", "tree_of_thoughts: opts must be a dict"
+  require opts.has("initial_state"), "tree_of_thoughts: opts.initial_state is required"
+  let expand = __tot_require_callable(opts, "expand")
+  let evaluate = __tot_require_callable(opts, "evaluate")
+  let is_terminal = __tot_require_callable(opts, "is_terminal")
+  let stop = opts?.stop
+  if stop != nil {
+    require __tot_is_callable(stop), "tree_of_thoughts: opts.stop must be callable"
+  }
+  let search = opts?.search ?? "bfs"
+  require search == "bfs" || search == "dfs" || search == "beam", "tree_of_thoughts: opts.search must be \"bfs\", \"dfs\", or \"beam\""
+  let k = __tot_require_positive_int(opts?.k ?? 1, "opts.k")
+  let max_depth = __tot_require_non_negative_int(opts?.max_depth ?? 8, "opts.max_depth")
+  let beam_width = __tot_require_positive_int(opts?.beam_width ?? k, "opts.beam_width")
+  let initial_state = opts.initial_state
+  let root = __tot_node(
+    0,
+    nil,
+    initial_state,
+    [initial_state],
+    0,
+    __tot_score(evaluate, initial_state),
+    __tot_terminal(is_terminal, initial_state),
+  )
+  if search == "beam" {
+    return __tot_search_beam(root, expand, evaluate, is_terminal, stop, k, max_depth, beam_width)
+  }
+  return __tot_search_frontier(search, root, expand, evaluate, is_terminal, stop, k, max_depth, beam_width)
+}

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -33,6 +33,7 @@
   - [Prompt optimization](./llm/optimize.md)
   - [Composable callers and middleware](./stdlib/llm-handlers.md)
   - [Tools, Tool Vault, and MCP](./llm/tools.md)
+  - [LLM ensemble helpers](./llm/ensemble.md)
   - [Streaming and transcripts](./llm/streaming.md)
   - [LLM providers](./llm/providers.md)
   - [Provider capability matrix](./provider-matrix.md)

--- a/docs/src/llm-and-agents.md
+++ b/docs/src/llm-and-agents.md
@@ -12,6 +12,7 @@ is the map; the detailed references now live in focused pages.
 | [LLM reranking](./llm/rerank.md) | Pairwise candidate ranking and token-logprob self-certainty |
 | [`agent_loop`](./llm/agent_loop.md) | Loop-until-done agents, profiles, daemon loops, skills, and delegated workers |
 | [Tools](./llm/tools.md) | Typed tools, Tool Vault progressive disclosure, and MCP server tools |
+| [LLM ensemble helpers](./llm/ensemble.md) | Deterministic search helpers such as `tree_of_thoughts(...)` |
 | [Streaming](./llm/streaming.md) | `llm_stream`, `llm_stream_call`, partial deltas, transcripts, workflow sessions, and token usage summaries |
 | [Providers](./llm/providers.md) | Provider setup, API details, local servers, enterprise cloud providers, and capability overrides |
 

--- a/docs/src/llm/ensemble.md
+++ b/docs/src/llm/ensemble.md
@@ -1,0 +1,64 @@
+# LLM ensemble helpers
+
+`std/llm/ensemble` contains deterministic orchestration helpers for search
+patterns around model calls. The helpers are plain Harn functions, so tests can
+mock or replace expansion and scoring without touching provider transport.
+
+## tree_of_thoughts
+
+`tree_of_thoughts(opts)` runs bounded Tree-of-Thoughts search over caller-defined
+states. It supports breadth-first, depth-first, and beam search.
+
+```harn
+import { tree_of_thoughts } from "std/llm/ensemble"
+
+let result = tree_of_thoughts({
+  initial_state: {steps: [], value: 0},
+  search: "beam",
+  k: 3,
+  beam_width: 2,
+  max_depth: 4,
+  expand: { state, k ->
+    return [
+      {steps: state.steps.push("+1"), value: state.value + 1},
+      {steps: state.steps.push("+2"), value: state.value + 2},
+      {steps: state.steps.push("+3"), value: state.value + 3},
+    ].take(k)
+  },
+  evaluate: { state -> state.value },
+  is_terminal: { state -> state.value >= 7 },
+})
+
+if result.ok {
+  println(result.best_path.last().steps)
+}
+```
+
+### Options
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `initial_state` | any | required | Root search state |
+| `expand` | closure | required | Called as `expand(state, k)` and must return a list of next states |
+| `evaluate` | closure | required | Called as `evaluate(state)` and must return an int or float score; higher is better |
+| `is_terminal` | closure | required | Called as `is_terminal(state)` and must return a bool |
+| `search` | string | `"bfs"` | One of `"bfs"`, `"dfs"`, or `"beam"` |
+| `k` | int | `1` | Maximum number of expanded states consumed per node |
+| `beam_width` | int | `k` | Number of candidates retained at each beam-search depth |
+| `max_depth` | int | `8` | Maximum child depth to expand |
+| `stop` | closure | nil | Optional `stop(node) -> bool` predicate for ending search early |
+
+### Return value
+
+The result is a dict with:
+
+| Field | Description |
+|---|---|
+| `ok` | True when at least one terminal state was found |
+| `best_path` | List of states from the root to the best terminal state, or the best explored state when no terminal was found |
+| `best_score` | Score for `best_path`'s final state |
+| `best_node` | Node dict for the selected state |
+| `stop_reason` | `"terminal"`, `"stop"`, or `"exhausted"` |
+| `tree` | Flat tree metadata: `{root_id, best_id, nodes, search, k, max_depth, beam_width}` |
+
+Each tree node is `{id, parent_id, state, path, depth, score, terminal}`.


### PR DESCRIPTION
## Summary

- Add `std/llm/ensemble.tree_of_thoughts(...)` with BFS, DFS, and beam search over caller-provided expansion/evaluation/terminal closures.
- Return best terminal path metadata plus a flat parent-linked search tree, with max-depth and optional stop-predicate handling.
- Add conformance coverage for BFS, DFS, beam width, max-depth, and stop behavior, plus docs for the new helper.

Closes #1323.

## Verification

- `cargo test -p harn-stdlib`
- `cargo run --quiet --bin harn -- test conformance conformance/tests/integration/llm_tree_of_thoughts.harn`
- `cargo fmt --all -- --check`
- `make fmt-harn`
- `make check-docs-snippets`
- `make conformance` (857 passed)
- `make lint-harn`
- pre-commit hooks: Rust fmt, staged Harn fmt/lint, clippy, generated highlight check, markdown lint
- pre-push hooks: targeted local checks, affected Harn fmt/lint, markdown lint, generated highlight check