### PR TITLE
Add hardware-aware model recommendations

### DIFF
--- a/crates/harn-cli/Cargo.toml
+++ b/crates/harn-cli/Cargo.toml
@@ -21,6 +21,7 @@ default-run = "harn"
 # resulting portal-dist/ tree even though it is gitignored.
 include = [
     "src/**/*",
+    "data/**/*",
     "build.rs",
     "Cargo.toml",
     "portal-dist/**/*",

--- a/crates/harn-cli/data/model_recommendations.toml
+++ b/crates/harn-cli/data/model_recommendations.toml
@@ -1,0 +1,170 @@
+# Lookup table keyed by available-RAM bucket, local acceleration, and cloud credential presence.
+# The `$cloud_default` sentinel is resolved to the best configured cloud provider's default model.
+
+[[recommendations]]
+ram_bucket = "lt8"
+gpu = "none"
+has_provider_key = false
+provider = "ollama"
+model_id = "ollama/qwen2.5:3b-instruct"
+
+[[recommendations]]
+ram_bucket = "lt8"
+gpu = "mps"
+has_provider_key = false
+provider = "ollama"
+model_id = "ollama/qwen2.5:3b-instruct"
+
+[[recommendations]]
+ram_bucket = "lt8"
+gpu = "cuda"
+has_provider_key = false
+provider = "ollama"
+model_id = "ollama/qwen2.5:3b-instruct"
+
+[[recommendations]]
+ram_bucket = "8_16"
+gpu = "none"
+has_provider_key = false
+provider = "ollama"
+model_id = "ollama/qwen2.5:7b-instruct"
+
+[[recommendations]]
+ram_bucket = "8_16"
+gpu = "mps"
+has_provider_key = false
+provider = "ollama"
+model_id = "ollama/qwen2.5:7b-instruct"
+
+[[recommendations]]
+ram_bucket = "8_16"
+gpu = "cuda"
+has_provider_key = false
+provider = "ollama"
+model_id = "ollama/qwen2.5:7b-instruct"
+
+[[recommendations]]
+ram_bucket = "16_32"
+gpu = "none"
+has_provider_key = false
+provider = "ollama"
+model_id = "ollama/qwen2.5:7b-instruct"
+
+[[recommendations]]
+ram_bucket = "16_32"
+gpu = "mps"
+has_provider_key = false
+provider = "ollama"
+model_id = "ollama/qwen2.5:14b-instruct"
+
+[[recommendations]]
+ram_bucket = "16_32"
+gpu = "cuda"
+has_provider_key = false
+provider = "ollama"
+model_id = "ollama/qwen2.5:14b-instruct"
+
+[[recommendations]]
+ram_bucket = "32_plus"
+gpu = "none"
+has_provider_key = false
+provider = "ollama"
+model_id = "ollama/qwen2.5:14b-instruct"
+
+[[recommendations]]
+ram_bucket = "32_plus"
+gpu = "mps"
+has_provider_key = false
+provider = "ollama"
+model_id = "ollama/qwen2.5:32b-instruct"
+
+[[recommendations]]
+ram_bucket = "32_plus"
+gpu = "cuda"
+has_provider_key = false
+provider = "ollama"
+model_id = "ollama/qwen2.5:32b-instruct"
+
+[[recommendations]]
+ram_bucket = "lt8"
+gpu = "none"
+has_provider_key = true
+provider = "cloud"
+model_id = "$cloud_default"
+
+[[recommendations]]
+ram_bucket = "lt8"
+gpu = "mps"
+has_provider_key = true
+provider = "cloud"
+model_id = "$cloud_default"
+
+[[recommendations]]
+ram_bucket = "lt8"
+gpu = "cuda"
+has_provider_key = true
+provider = "cloud"
+model_id = "$cloud_default"
+
+[[recommendations]]
+ram_bucket = "8_16"
+gpu = "none"
+has_provider_key = true
+provider = "cloud"
+model_id = "$cloud_default"
+
+[[recommendations]]
+ram_bucket = "8_16"
+gpu = "mps"
+has_provider_key = true
+provider = "cloud"
+model_id = "$cloud_default"
+
+[[recommendations]]
+ram_bucket = "8_16"
+gpu = "cuda"
+has_provider_key = true
+provider = "cloud"
+model_id = "$cloud_default"
+
+[[recommendations]]
+ram_bucket = "16_32"
+gpu = "none"
+has_provider_key = true
+provider = "cloud"
+model_id = "$cloud_default"
+
+[[recommendations]]
+ram_bucket = "16_32"
+gpu = "mps"
+has_provider_key = true
+provider = "cloud"
+model_id = "$cloud_default"
+
+[[recommendations]]
+ram_bucket = "16_32"
+gpu = "cuda"
+has_provider_key = true
+provider = "cloud"
+model_id = "$cloud_default"
+
+[[recommendations]]
+ram_bucket = "32_plus"
+gpu = "none"
+has_provider_key = true
+provider = "cloud"
+model_id = "$cloud_default"
+
+[[recommendations]]
+ram_bucket = "32_plus"
+gpu = "mps"
+has_provider_key = true
+provider = "cloud"
+model_id = "$cloud_default"
+
+[[recommendations]]
+ram_bucket = "32_plus"
+gpu = "cuda"
+has_provider_key = true
+provider = "cloud"
+model_id = "$cloud_default"

--- a/crates/harn-cli/src/cli/mod.rs
+++ b/crates/harn-cli/src/cli/mod.rs
@@ -84,7 +84,9 @@ pub(crate) use merge_captain::{
     MergeCaptainMockCommand, MergeCaptainMockInitArgs, MergeCaptainMockServeArgs,
     MergeCaptainMockStatusArgs, MergeCaptainMockStepArgs, MergeCaptainRunArgs,
 };
-pub(crate) use models::{ModelsArgs, ModelsCommand, ModelsInstallArgs, ModelsListArgs};
+pub(crate) use models::{
+    ModelRecommendArgs, ModelsArgs, ModelsCommand, ModelsInstallArgs, ModelsListArgs,
+};
 pub(crate) use orchestrator::{
     OrchestratorArgs, OrchestratorCommand, OrchestratorDeployArgs, OrchestratorDeployProvider,
     OrchestratorDlqArgs, OrchestratorFireArgs, OrchestratorInspectArgs, OrchestratorLocalArgs,

--- a/crates/harn-cli/src/cli/models.rs
+++ b/crates/harn-cli/src/cli/models.rs
@@ -12,6 +12,8 @@ pub(crate) enum ModelsCommand {
     List(ModelsListArgs),
     /// Pull a model via Ollama.
     Install(ModelsInstallArgs),
+    /// Recommend a starter model for the current machine and credentials.
+    Recommend(ModelRecommendArgs),
 }
 
 #[derive(Debug, Args)]
@@ -37,4 +39,11 @@ pub(crate) struct ModelsInstallArgs {
     /// Optional Ollama keep-alive hint (e.g. `5m`, `1h`).
     #[arg(long = "keep-alive", value_name = "VALUE")]
     pub keep_alive: Option<String>,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct ModelRecommendArgs {
+    /// Emit the recommendation and hardware snapshot as JSON.
+    #[arg(long)]
+    pub json: bool,
 }

--- a/crates/harn-cli/src/cli/tests.rs
+++ b/crates/harn-cli/src/cli/tests.rs
@@ -3,11 +3,11 @@ use std::time::Duration as StdDuration;
 
 use super::{
     CheckOutputFormat, Cli, Command, CompletionShell, ConnectCommand, ConnectorCommand,
-    CrystallizeCommand, FlowArchivistCommand, FlowCommand, McpCommand, OrchestratorCommand,
-    OrchestratorDeployProvider, OrchestratorLogFormat, OrchestratorQueueCommand,
-    OrchestratorTenantCommand, PackageCacheCommand, PackageCommand, PersonaCommand,
-    ProjectTemplate, RunsCommand, SkillCommand, SkillKeyCommand, SkillTrustCommand, SkillsCommand,
-    TraceCommand, TriggerCommand, TrustCommand, TrustOutcomeArg, TrustTierArg,
+    CrystallizeCommand, FlowArchivistCommand, FlowCommand, McpCommand, ModelsCommand,
+    OrchestratorCommand, OrchestratorDeployProvider, OrchestratorLogFormat,
+    OrchestratorQueueCommand, OrchestratorTenantCommand, PackageCacheCommand, PackageCommand,
+    PersonaCommand, ProjectTemplate, RunsCommand, SkillCommand, SkillKeyCommand, SkillTrustCommand,
+    SkillsCommand, TraceCommand, TriggerCommand, TrustCommand, TrustOutcomeArg, TrustTierArg,
 };
 use clap::{CommandFactory, Parser};
 
@@ -1886,6 +1886,19 @@ fn test_completion_scripts_include_subcommands() {
 
     assert!(script.contains("completions"));
     assert!(script.contains("provider-ready"));
+}
+
+#[test]
+fn test_parses_models_recommend_args() {
+    let cli = Cli::parse_from(["harn", "models", "recommend", "--json"]);
+
+    let Command::Models(args) = cli.command.unwrap() else {
+        panic!("expected models command");
+    };
+    let ModelsCommand::Recommend(recommend) = args.command else {
+        panic!("expected models recommend command");
+    };
+    assert!(recommend.json);
 }
 
 #[test]

--- a/crates/harn-cli/src/commands/hardware.rs
+++ b/crates/harn-cli/src/commands/hardware.rs
@@ -1,0 +1,215 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde::Serialize;
+
+const GIB: u64 = 1024 * 1024 * 1024;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct HardwareSnapshot {
+    pub ram: RamSnapshot,
+    pub gpu: GpuSnapshot,
+    pub disk: DiskSnapshot,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct RamSnapshot {
+    pub total_bytes: Option<u64>,
+    pub available_bytes: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct GpuSnapshot {
+    pub kind: GpuKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum GpuKind {
+    None,
+    #[allow(dead_code)]
+    Mps,
+    Cuda,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct DiskSnapshot {
+    pub path: PathBuf,
+    pub free_bytes: Option<u64>,
+}
+
+pub(crate) fn collect_hardware_snapshot() -> HardwareSnapshot {
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    HardwareSnapshot {
+        ram: detect_ram(),
+        gpu: detect_gpu(),
+        disk: detect_disk(&cwd),
+    }
+}
+
+pub(crate) fn bytes_to_gib_rounded(bytes: u64) -> u64 {
+    (bytes + (GIB / 2)) / GIB
+}
+
+pub(crate) fn bytes_to_gib_floor(bytes: u64) -> u64 {
+    bytes / GIB
+}
+
+fn detect_ram() -> RamSnapshot {
+    detect_ram_platform().unwrap_or(RamSnapshot {
+        total_bytes: None,
+        available_bytes: None,
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn detect_ram_platform() -> Option<RamSnapshot> {
+    let text = std::fs::read_to_string("/proc/meminfo").ok()?;
+    parse_linux_meminfo(&text)
+}
+
+#[cfg(target_os = "macos")]
+fn detect_ram_platform() -> Option<RamSnapshot> {
+    let total = command_stdout("sysctl", &["-n", "hw.memsize"])
+        .and_then(|text| text.trim().parse::<u64>().ok());
+    let available = command_stdout("vm_stat", &[]).and_then(|text| parse_macos_vm_stat(&text));
+    Some(RamSnapshot {
+        total_bytes: total,
+        available_bytes: available,
+    })
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn detect_ram_platform() -> Option<RamSnapshot> {
+    None
+}
+
+fn detect_gpu() -> GpuSnapshot {
+    #[cfg(target_os = "macos")]
+    {
+        if Path::new("/System/Library/Frameworks/MetalPerformanceShaders.framework").exists() {
+            return GpuSnapshot { kind: GpuKind::Mps };
+        }
+    }
+
+    if Command::new("nvidia-smi")
+        .arg("-L")
+        .output()
+        .is_ok_and(|output| output.status.success())
+    {
+        return GpuSnapshot {
+            kind: GpuKind::Cuda,
+        };
+    }
+
+    GpuSnapshot {
+        kind: GpuKind::None,
+    }
+}
+
+fn detect_disk(path: &Path) -> DiskSnapshot {
+    DiskSnapshot {
+        path: path.to_path_buf(),
+        free_bytes: fs2::free_space(path).ok(),
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn command_stdout(program: &str, args: &[&str]) -> Option<String> {
+    let output = Command::new(program).args(args).output().ok()?;
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn parse_linux_meminfo(text: &str) -> Option<RamSnapshot> {
+    let mut total_kib = None;
+    let mut available_kib = None;
+    for line in text.lines() {
+        let mut parts = line.split_whitespace();
+        match parts.next() {
+            Some("MemTotal:") => total_kib = parts.next().and_then(|value| value.parse().ok()),
+            Some("MemAvailable:") => {
+                available_kib = parts.next().and_then(|value| value.parse().ok())
+            }
+            _ => {}
+        }
+    }
+    Some(RamSnapshot {
+        total_bytes: total_kib.map(|kib: u64| kib * 1024),
+        available_bytes: available_kib.map(|kib: u64| kib * 1024),
+    })
+}
+
+#[cfg(any(target_os = "macos", test))]
+fn parse_macos_vm_stat(text: &str) -> Option<u64> {
+    let page_size = parse_page_size(text)?;
+    let mut pages = 0u64;
+    for line in text.lines() {
+        let Some((name, value)) = line.split_once(':') else {
+            continue;
+        };
+        if matches!(
+            name.trim(),
+            "Pages free" | "Pages inactive" | "Pages speculative"
+        ) {
+            pages = pages.saturating_add(parse_page_count(value)?);
+        }
+    }
+    Some(pages.saturating_mul(page_size))
+}
+
+#[cfg(any(target_os = "macos", test))]
+fn parse_page_size(text: &str) -> Option<u64> {
+    let first = text.lines().next()?;
+    let start = first.find("page size of ")? + "page size of ".len();
+    let tail = &first[start..];
+    let end = tail.find(" bytes")?;
+    tail[..end].trim().parse().ok()
+}
+
+#[cfg(any(target_os = "macos", test))]
+fn parse_page_count(value: &str) -> Option<u64> {
+    value.trim().trim_end_matches('.').parse().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{bytes_to_gib_rounded, parse_linux_meminfo, parse_macos_vm_stat, RamSnapshot, GIB};
+
+    #[test]
+    fn linux_meminfo_reports_total_and_available_bytes() {
+        let snapshot = parse_linux_meminfo(
+            "MemTotal:       16384000 kB\nMemFree:         1000000 kB\nMemAvailable:    8192000 kB\n",
+        )
+        .expect("meminfo parses");
+        assert_eq!(
+            snapshot,
+            RamSnapshot {
+                total_bytes: Some(16_384_000 * 1024),
+                available_bytes: Some(8_192_000 * 1024),
+            }
+        );
+    }
+
+    #[test]
+    fn macos_vm_stat_counts_reclaimable_pages() {
+        let available = parse_macos_vm_stat(
+            "Mach Virtual Memory Statistics: (page size of 16384 bytes)\n\
+             Pages free:                               10.\n\
+             Pages active:                             20.\n\
+             Pages inactive:                           30.\n\
+             Pages speculative:                        40.\n",
+        )
+        .expect("vm_stat parses");
+        assert_eq!(available, 80 * 16_384);
+    }
+
+    #[test]
+    fn gib_formatting_rounds_to_nearest_gib() {
+        assert_eq!(bytes_to_gib_rounded(8 * GIB), 8);
+        assert_eq!(bytes_to_gib_rounded(8 * GIB + GIB / 2), 9);
+    }
+}

--- a/crates/harn-cli/src/commands/mod.rs
+++ b/crates/harn-cli/src/commands/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod dump_highlight_keywords;
 pub(crate) mod dump_trigger_quickref;
 pub(crate) mod explain;
 pub mod flow;
+pub(crate) mod hardware;
 pub(crate) mod init;
 pub(crate) mod mcp;
 pub(crate) mod merge_captain;

--- a/crates/harn-cli/src/commands/models/mod.rs
+++ b/crates/harn-cli/src/commands/models/mod.rs
@@ -1,10 +1,8 @@
-//! `harn models` — list and install models.
-//!
-//! `recommend` and `test` are deferred to follow-up issues
-//! (see `crates/harn-cli/FOLLOWUPS.md`).
+//! `harn models` — list, install, and recommend models.
 
 pub(crate) mod install;
 pub(crate) mod list;
+pub(crate) mod recommend;
 
 use crate::cli::{ModelsArgs, ModelsCommand};
 
@@ -12,5 +10,6 @@ pub(crate) async fn run(args: ModelsArgs) {
     match args.command {
         ModelsCommand::List(args) => list::run(args).await,
         ModelsCommand::Install(args) => install::run(args).await,
+        ModelsCommand::Recommend(args) => recommend::run(&args),
     }
 }

--- a/crates/harn-cli/src/commands/models/recommend.rs
+++ b/crates/harn-cli/src/commands/models/recommend.rs
@@ -1,0 +1,386 @@
+use std::collections::BTreeSet;
+
+use serde::{Deserialize, Serialize};
+
+use crate::cli::ModelRecommendArgs;
+use crate::commands::hardware::{
+    bytes_to_gib_floor, bytes_to_gib_rounded, collect_hardware_snapshot, GpuKind, HardwareSnapshot,
+};
+
+const RECOMMENDATIONS_TOML: &str = include_str!("../../../data/model_recommendations.toml");
+const CLOUD_DEFAULT_SENTINEL: &str = "$cloud_default";
+const RAM_BUCKETS: [RamBucket; 4] = [
+    RamBucket::Lt8,
+    RamBucket::Between8And16,
+    RamBucket::Between16And32,
+    RamBucket::Plus32,
+];
+const GPU_KEYS: [RecommendationGpu; 3] = [
+    RecommendationGpu::None,
+    RecommendationGpu::Mps,
+    RecommendationGpu::Cuda,
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum RamBucket {
+    Lt8,
+    #[serde(rename = "8_16")]
+    Between8And16,
+    #[serde(rename = "16_32")]
+    Between16And32,
+    #[serde(rename = "32_plus")]
+    Plus32,
+}
+
+impl RamBucket {
+    fn from_available_bytes(bytes: Option<u64>) -> Self {
+        let Some(bytes) = bytes else {
+            return Self::Lt8;
+        };
+        match bytes_to_gib_floor(bytes) {
+            0..=7 => Self::Lt8,
+            8..=15 => Self::Between8And16,
+            16..=31 => Self::Between16And32,
+            _ => Self::Plus32,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Lt8 => "lt8",
+            Self::Between8And16 => "8_16",
+            Self::Between16And32 => "16_32",
+            Self::Plus32 => "32_plus",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum RecommendationGpu {
+    None,
+    Mps,
+    Cuda,
+}
+
+impl RecommendationGpu {
+    fn from_gpu(kind: GpuKind) -> Self {
+        match kind {
+            GpuKind::Mps => Self::Mps,
+            GpuKind::Cuda => Self::Cuda,
+            GpuKind::None => Self::None,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::None => "no GPU acceleration",
+            Self::Mps => "MPS available",
+            Self::Cuda => "CUDA available",
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct RecommendationTable {
+    recommendations: Vec<RecommendationRule>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RecommendationRule {
+    ram_bucket: RamBucket,
+    gpu: RecommendationGpu,
+    has_provider_key: bool,
+    provider: String,
+    model_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CloudModel {
+    provider: String,
+    model_id: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct ModelRecommendation {
+    model_id: String,
+    harn_selector: String,
+    provider: String,
+    rationale: String,
+    ram_bucket: RamBucket,
+    gpu: RecommendationGpu,
+    has_provider_key: bool,
+    hardware: HardwareSnapshot,
+}
+
+pub(crate) fn run(args: &ModelRecommendArgs) {
+    let snapshot = collect_hardware_snapshot();
+    let cloud_model = detect_cloud_model();
+    let has_provider_key = cloud_model.is_some();
+    let recommendation = recommend_model(snapshot, has_provider_key, cloud_model)
+        .unwrap_or_else(|error| crate::command_error(&error));
+
+    if args.json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&recommendation).unwrap_or_else(|error| {
+                crate::command_error(&format!(
+                    "failed to serialize model recommendation: {error}"
+                ))
+            })
+        );
+    } else {
+        println!("{}", recommendation.model_id);
+        println!("{}", recommendation.rationale);
+    }
+}
+
+fn recommend_model(
+    hardware: HardwareSnapshot,
+    has_provider_key: bool,
+    cloud_model: Option<CloudModel>,
+) -> Result<ModelRecommendation, String> {
+    let table = load_recommendation_table()?;
+    validate_recommendation_table(&table)?;
+
+    let ram_bucket = RamBucket::from_available_bytes(hardware.ram.available_bytes);
+    let gpu = RecommendationGpu::from_gpu(hardware.gpu.kind);
+    let rule = table
+        .recommendations
+        .iter()
+        .find(|rule| {
+            rule.ram_bucket == ram_bucket
+                && rule.gpu == gpu
+                && rule.has_provider_key == has_provider_key
+        })
+        .ok_or_else(|| {
+            format!(
+                "no model recommendation for ram_bucket={} gpu={:?} has_provider_key={has_provider_key}",
+                ram_bucket.as_str(),
+                gpu
+            )
+        })?;
+
+    let (provider, model_id) = if rule.model_id == CLOUD_DEFAULT_SENTINEL {
+        let cloud = cloud_model.ok_or_else(|| {
+            "recommendation table requested a cloud default without cloud credentials".to_string()
+        })?;
+        let provider = cloud.provider;
+        (provider.clone(), format!("{}/{}", provider, cloud.model_id))
+    } else {
+        (rule.provider.clone(), rule.model_id.clone())
+    };
+    let harn_selector = harn_selector_for(&provider, &model_id);
+    let rationale = rationale_for(&hardware, gpu, has_provider_key, &model_id);
+
+    Ok(ModelRecommendation {
+        model_id,
+        harn_selector,
+        provider,
+        rationale,
+        ram_bucket,
+        gpu,
+        has_provider_key,
+        hardware,
+    })
+}
+
+fn load_recommendation_table() -> Result<RecommendationTable, String> {
+    toml::from_str(RECOMMENDATIONS_TOML)
+        .map_err(|error| format!("failed to parse model_recommendations.toml: {error}"))
+}
+
+fn validate_recommendation_table(table: &RecommendationTable) -> Result<(), String> {
+    let mut seen = BTreeSet::new();
+    for rule in &table.recommendations {
+        let key = (rule.ram_bucket, rule.gpu, rule.has_provider_key);
+        if !seen.insert(key) {
+            return Err(format!(
+                "duplicate model recommendation for ram_bucket={} gpu={:?} has_provider_key={}",
+                rule.ram_bucket.as_str(),
+                rule.gpu,
+                rule.has_provider_key
+            ));
+        }
+    }
+    let expected_count = RAM_BUCKETS.len() * GPU_KEYS.len() * 2;
+    if seen.len() != expected_count {
+        return Err(format!(
+            "model recommendation table covers {} tuples; expected {expected_count}",
+            seen.len()
+        ));
+    }
+    Ok(())
+}
+
+fn detect_cloud_model() -> Option<CloudModel> {
+    for provider in cloud_provider_candidates() {
+        if cloud_provider_key_available(&provider) {
+            let model_id = cloud_model_for_provider(&provider);
+            return Some(CloudModel { provider, model_id });
+        }
+    }
+    None
+}
+
+fn cloud_provider_candidates() -> Vec<String> {
+    let mut candidates = Vec::new();
+    push_unique(&mut candidates, harn_vm::llm_config::default_provider());
+    for provider in [
+        "anthropic",
+        "openai",
+        "openrouter",
+        "gemini",
+        "together",
+        "groq",
+        "deepseek",
+        "fireworks",
+        "dashscope",
+        "huggingface",
+        "azure_openai",
+    ] {
+        push_unique(&mut candidates, provider.to_string());
+    }
+    let mut provider_names = harn_vm::llm_config::provider_names();
+    provider_names.sort();
+    for provider in provider_names {
+        push_unique(&mut candidates, provider);
+    }
+    candidates
+}
+
+fn push_unique(values: &mut Vec<String>, value: String) {
+    if !values.iter().any(|existing| existing == &value) {
+        values.push(value);
+    }
+}
+
+fn cloud_model_for_provider(provider: &str) -> String {
+    harn_vm::llm::selected_model_for_provider(provider)
+        .or_else(|| harn_vm::llm_config::qc_default_model(provider))
+        .unwrap_or_else(|| harn_vm::llm_config::default_model_for_provider(provider))
+}
+
+fn cloud_provider_key_available(provider: &str) -> bool {
+    let Some(def) = harn_vm::llm_config::provider_config(provider) else {
+        return false;
+    };
+    if def.auth_style == "none" || matches!(def.auth_env, harn_vm::llm_config::AuthEnv::None) {
+        return false;
+    }
+    harn_vm::llm_config::provider_key_available(provider)
+}
+
+fn harn_selector_for(provider: &str, model_id: &str) -> String {
+    if provider == "ollama" {
+        return model_id
+            .strip_prefix("ollama/")
+            .map(|model| format!("ollama:{model}"))
+            .unwrap_or_else(|| model_id.to_string());
+    }
+    model_id
+        .strip_prefix(&format!("{provider}/"))
+        .unwrap_or(model_id)
+        .to_string()
+}
+
+fn rationale_for(
+    hardware: &HardwareSnapshot,
+    gpu: RecommendationGpu,
+    has_provider_key: bool,
+    model_id: &str,
+) -> String {
+    let ram = match hardware.ram.available_bytes {
+        Some(bytes) => format!("{} GB free", bytes_to_gib_rounded(bytes)),
+        None => "unknown free RAM".to_string(),
+    };
+    let creds = if has_provider_key {
+        "cloud creds available"
+    } else {
+        "no cloud creds"
+    };
+    format!("{ram}, {}, {creds} -> {model_id}", gpu.label())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::{
+        harn_selector_for, load_recommendation_table, recommend_model,
+        validate_recommendation_table, CloudModel, GPU_KEYS, RAM_BUCKETS,
+    };
+    use crate::commands::hardware::{
+        DiskSnapshot, GpuKind, GpuSnapshot, HardwareSnapshot, RamSnapshot,
+    };
+
+    const GIB: u64 = 1024 * 1024 * 1024;
+
+    fn snapshot(available_gib: u64, gpu: GpuKind) -> HardwareSnapshot {
+        HardwareSnapshot {
+            ram: RamSnapshot {
+                total_bytes: Some(16 * GIB),
+                available_bytes: Some(available_gib * GIB),
+            },
+            gpu: GpuSnapshot { kind: gpu },
+            disk: DiskSnapshot {
+                path: PathBuf::from("/workspace"),
+                free_bytes: Some(128 * GIB),
+            },
+        }
+    }
+
+    #[test]
+    fn recommendation_table_has_unique_tuple_keys() {
+        let table = load_recommendation_table().expect("table parses");
+        validate_recommendation_table(&table).expect("table is unique");
+        assert_eq!(
+            table.recommendations.len(),
+            RAM_BUCKETS.len() * GPU_KEYS.len() * 2
+        );
+    }
+
+    #[test]
+    fn no_cloud_creds_recommends_ollama_by_ram_and_acceleration() {
+        let recommendation =
+            recommend_model(snapshot(8, GpuKind::Mps), false, None).expect("recommendation");
+        assert_eq!(recommendation.model_id, "ollama/qwen2.5:7b-instruct");
+        assert_eq!(recommendation.harn_selector, "ollama:qwen2.5:7b-instruct");
+        assert_eq!(
+            recommendation.rationale,
+            "8 GB free, MPS available, no cloud creds -> ollama/qwen2.5:7b-instruct"
+        );
+    }
+
+    #[test]
+    fn cloud_creds_resolve_to_best_available_cloud_default() {
+        let recommendation = recommend_model(
+            snapshot(32, GpuKind::Cuda),
+            true,
+            Some(CloudModel {
+                provider: "openai".to_string(),
+                model_id: "gpt-4o-mini".to_string(),
+            }),
+        )
+        .expect("recommendation");
+        assert_eq!(recommendation.model_id, "openai/gpt-4o-mini");
+        assert_eq!(recommendation.harn_selector, "gpt-4o-mini");
+        assert_eq!(recommendation.provider, "openai");
+        assert!(recommendation
+            .rationale
+            .contains("CUDA available, cloud creds available"));
+    }
+
+    #[test]
+    fn harn_selector_normalizes_provider_display_prefixes() {
+        assert_eq!(
+            harn_selector_for("ollama", "ollama/qwen2.5:7b-instruct"),
+            "ollama:qwen2.5:7b-instruct"
+        );
+        assert_eq!(
+            harn_selector_for("openai", "openai/gpt-4o-mini"),
+            "gpt-4o-mini"
+        );
+    }
+}

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -504,7 +504,8 @@ explicit.
 ## harn doctor
 
 Inspect the local environment and report the current Harn setup,
-including the resolved secret-provider chain and keyring health.
+including the hardware snapshot, resolved secret-provider chain, and
+keyring health.
 
 ```bash
 harn doctor
@@ -545,6 +546,20 @@ harn model-info --warm --keep-alive 30m llama3.2
 Ollama readiness failures use stable `readiness.status` values, including
 `daemon_down`, `bad_status`, `invalid_response`, `model_missing`, and
 `warmup_failed`. `--verify` and `--warm` exit non-zero when readiness fails.
+
+## harn models recommend
+
+Recommend a starter model from the local hardware snapshot and configured cloud
+credentials. The command prefers an Ollama model when no cloud provider key is
+set, and emits the selected model plus the one-line rationale.
+
+```bash
+harn models recommend
+harn models recommend --json
+```
+
+The JSON output includes the hardware snapshot used for the lookup: available
+RAM, GPU/MPS acceleration, and free disk space.
 
 ## harn connect
 


### PR DESCRIPTION
## Summary

Closes #1329.

- add `harn models recommend [--json]` with a TOML-backed recommendation table keyed by RAM bucket, GPU acceleration, and cloud credential availability
- add a shared hardware snapshot used by both `harn doctor` and the recommender: available/total RAM, MPS/CUDA acceleration, and free disk
- prefer local Ollama recommendations when no cloud provider key is configured, and resolve cloud recommendations through the configured/default provider when credentials exist
- document the new command and the `doctor` hardware snapshot

## Validation

- `cargo test -p harn-cli --lib`
- `cargo check -p harn-cli`
- `cargo clippy -p harn-cli --all-targets -- -D warnings`
- `make lint-test-patterns`
- `cargo fmt --all --check`
- `cargo run --quiet --bin harn -- models recommend --json` with cloud key env vars unset
- `cargo run --quiet --bin harn -- doctor --no-network | sed -n '1,10p'`
- pre-commit hook: workspace Clippy + markdown lint
- pre-push hook: targeted local checks + markdown lint