### PR TITLE
Release v0.7.62

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Pre-0.6 highlights live in [CHANGELOG-pre-0.6.md](CHANGELOG-pre-0.6.md).
 Harn had no external users before 0.6.0, so that archive intentionally keeps
 condensed series summaries instead of full per-patch history.
 
-## Unreleased
+## v0.7.62
 
 ### Added
 
@@ -18,6 +18,35 @@ condensed series summaries instead of full per-patch history.
   `std/llm/handlers.with_cache` with sqlite and filesystem backends,
   content-addressed LLM keys, TTL, LRU eviction, and default bypass for calls
   that include tools.
+- **Ollama provider config seeding.** `harn-cli` now automatically seeds Ollama
+  provider configuration on the first LLM run, simplifying setup for new
+  environments.
+- **Prompt optimization helpers in `std/llm`.** New `judge`, `refine`, and
+  `optimize` helpers support iterative prompt improvement flows with
+  conformance coverage and docs.
+- **Adaptive debate stopping for LLM ensembles.** `std/llm/ensemble` now
+  supports fixed-round and adaptive stopping policies for multi-call ensemble
+  workflows.
+- **LLM reranking helpers.** Added `std/llm/rerank` and VM/provider plumbing for
+  pairwise reranking workflows, including prompt assets, mocks, conformance
+  coverage, and docs.
+- **Shell completion generation.** Added `harn` shell completion generation
+  support (bash, zsh, fish) to streamline CLI usage in interactive shells.
+- **Chat project template.** New `harn init` chat project template provides a
+  pre-configured starter for building chat-based agent applications.
+- **Imports in `harn run -e`.** The `-e` flag now supports module imports,
+  enabling more complex inline script composition via `harn run -e`.
+- **Stream `harn run` stdout.** `harn run` now streams stdout to the terminal
+  during execution, providing real-time feedback for long-running agent runs.
+- **LLM options roundtrip benchmark.** Added a benchmark package for measuring
+  LLM options serialization and package-verification coverage for the new perf
+  crate.
+
+### Fixed
+
+- **Summary preset `tool_choice` default.** Fixed the default `tool_choice`
+  behavior for summary presets in the agent stdlib, ensuring correct tool
+  selection in audit summaries.
 
 ## v0.7.61
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1704,7 +1704,7 @@ dependencies = [
 
 [[package]]
 name = "harn-cli"
-version = "0.7.61"
+version = "0.7.62"
 dependencies = [
  "async-trait",
  "axum",
@@ -1758,7 +1758,7 @@ dependencies = [
 
 [[package]]
 name = "harn-dap"
-version = "0.7.61"
+version = "0.7.62"
 dependencies = [
  "harn-modules",
  "harn-parser",
@@ -1771,7 +1771,7 @@ dependencies = [
 
 [[package]]
 name = "harn-fmt"
-version = "0.7.61"
+version = "0.7.62"
 dependencies = [
  "harn-lexer",
  "harn-parser",
@@ -1779,7 +1779,7 @@ dependencies = [
 
 [[package]]
 name = "harn-hostlib"
-version = "0.7.61"
+version = "0.7.62"
 dependencies = [
  "anyhow",
  "base64",
@@ -1830,7 +1830,7 @@ dependencies = [
 
 [[package]]
 name = "harn-ir"
-version = "0.7.61"
+version = "0.7.62"
 dependencies = [
  "harn-lexer",
  "harn-parser",
@@ -1838,11 +1838,11 @@ dependencies = [
 
 [[package]]
 name = "harn-lexer"
-version = "0.7.61"
+version = "0.7.62"
 
 [[package]]
 name = "harn-lint"
-version = "0.7.61"
+version = "0.7.62"
 dependencies = [
  "harn-lexer",
  "harn-modules",
@@ -1860,7 +1860,7 @@ dependencies = [
 
 [[package]]
 name = "harn-lsp"
-version = "0.7.61"
+version = "0.7.62"
 dependencies = [
  "harn-fmt",
  "harn-ir",
@@ -1875,7 +1875,7 @@ dependencies = [
 
 [[package]]
 name = "harn-modules"
-version = "0.7.61"
+version = "0.7.62"
 dependencies = [
  "croner",
  "harn-lexer",
@@ -1888,7 +1888,7 @@ dependencies = [
 
 [[package]]
 name = "harn-parser"
-version = "0.7.61"
+version = "0.7.62"
 dependencies = [
  "harn-lexer",
  "yansi",
@@ -1896,7 +1896,7 @@ dependencies = [
 
 [[package]]
 name = "harn-serve"
-version = "0.7.61"
+version = "0.7.62"
 dependencies = [
  "async-trait",
  "axum",
@@ -1925,11 +1925,11 @@ dependencies = [
 
 [[package]]
 name = "harn-stdlib"
-version = "0.7.61"
+version = "0.7.62"
 
 [[package]]
 name = "harn-vm"
-version = "0.7.61"
+version = "0.7.62"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude = ["crates/harn-wasm"]
 resolver = "2"
 
 [workspace.package]
-version = "0.7.61"
+version = "0.7.62"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/burin-labs/harn"


### PR DESCRIPTION
Release v0.7.62

This PR was prepared by `release_harn.harn` from current `main`, then amended to include release-note entries for commits that landed while the release gate and merge queue were running.

## Summary

- Version: `0.7.61` -> `0.7.62`
- Branch: `release/v0.7.62` targeting `main`
- Latest tag used for release delta: `v0.7.61`
- Changed files: `CHANGELOG.md`, `Cargo.lock`, `Cargo.toml`

## Changelog section

```markdown
### Added

- **Per-upstream LLM handler circuit pooling.** `std/llm/handlers` now provides
  `with_circuit_breaker`, which derives circuit names from each call's
  `(provider, model)` by default while preserving `name` for intentionally
  shared circuit state.
- **Persistent LLM response caching (#1322).** Added `std/cache` and
  `std/llm/handlers.with_cache` with sqlite and filesystem backends,
  content-addressed LLM keys, TTL, LRU eviction, and default bypass for calls
  that include tools.
- **Ollama provider config seeding.** `harn-cli` now automatically seeds Ollama
  provider configuration on the first LLM run, simplifying setup for new
  environments.
- **Prompt optimization helpers in `std/llm`.** New `judge`, `refine`, and
  `optimize` helpers support iterative prompt improvement flows with
  conformance coverage and docs.
- **Adaptive debate stopping for LLM ensembles.** `std/llm/ensemble` now
  supports fixed-round and adaptive stopping policies for multi-call ensemble
  workflows.
- **LLM reranking helpers.** Added `std/llm/rerank` and VM/provider plumbing for
  pairwise reranking workflows, including prompt assets, mocks, conformance
  coverage, and docs.
- **Shell completion generation.** Added `harn` shell completion generation
  support (bash, zsh, fish) to streamline CLI usage in interactive shells.
- **Chat project template.** New `harn init` chat project template provides a
  pre-configured starter for building chat-based agent applications.
- **Imports in `harn run -e`.** The `-e` flag now supports module imports,
  enabling more complex inline script composition via `harn run -e`.
- **Stream `harn run` stdout.** `harn run` now streams stdout to the terminal
  during execution, providing real-time feedback for long-running agent runs.
- **LLM options roundtrip benchmark.** Added a benchmark package for measuring
  LLM options serialization and package-verification coverage for the new perf
  crate.

### Fixed

- **Summary preset `tool_choice` default.** Fixed the default `tool_choice`
  behavior for summary presets in the agent stdlib, ensuring correct tool
  selection in audit summaries.
```

## Commits covered

```text
1a4ea7ae Add LLM reranking stdlib helpers (#1356)
85a350e5 Add persistent LLM response cache (#1354)
4bbe6d4e Add adaptive debate stability stop (#1350)
c9718226 [codex] Add std/llm prompt optimization (#1344)
f5641695 perf/llm: add options roundtrip benchmark (#1353)
e7c4b3f1 Seed Ollama provider config on first LLM run (#1355)
3afad459 Add shell completion generation (#1348)
6c76872a Add chat project template (#1346)
35adde7e Add per-upstream LLM handler circuit pooling (#1340)
e552bebc Allow imports in `harn run -e` (#1320)
d9f64aad [codex] Stream harn run stdout during execution (#1319)
585ec870 Fix summary preset tool_choice default (#1318)
```

Generated by `release_harn.harn`; final notes amended after the merge queue advanced during the release handoff.
