### PR TITLE
[codex] Add std/llm prompt optimization

### DIFF
--- a/conformance/tests/integration/llm_optimize_prompt.expected
+++ b/conformance/tests/integration/llm_optimize_prompt.expected
@@ -1,0 +1,14 @@
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true

--- a/conformance/tests/integration/llm_optimize_prompt.harn
+++ b/conformance/tests/integration/llm_optimize_prompt.harn
@@ -1,0 +1,55 @@
+import { parallel_judge } from "std/llm/judge"
+import { optimize_prompt } from "std/llm/optimize"
+import { propose_instructions } from "std/llm/refine"
+
+pipeline default() {
+  let judged = parallel_judge("Prompt", [{id: "one"}], { _ctx -> 0.5 })
+  println(judged.best.score == 0.5)
+  let explicit = propose_instructions("Base", {instruction_proposals: "Tighten the answer."})
+  println(explicit[0] == "Base")
+  println(explicit[1] == "Tighten the answer.")
+  llm_mock_clear()
+  llm_mock({text: "{\"instructions\":[\"Plan first.\",\"Plan first.\"]}"})
+  let proposed = propose_instructions(
+    "Base",
+    {provider: "mock", proposal_count: 2, system: "Proposal sys", schema_retries: 0, repair: false},
+  )
+  println(proposed[0] == "Base")
+  println(proposed[1] == "Plan first.")
+  println(len(proposed) == 2)
+  println(llm_mock_calls()[0].system == "Proposal sys")
+  let result = optimize_prompt(
+    {
+      base_prompt: "Answer the question.",
+      eval_set: [{id: "add", input: "2 + 2", expected: "4"}, {id: "mul", input: "3 * 3", expected: "9"}],
+      metric: { ctx ->
+        var score = 0.0
+        if contains(lowercase(ctx.prompt), "calculate") {
+          score = score + 0.7
+        }
+        if len(ctx.candidate.demos) > 0 {
+          score = score + 0.3
+        }
+        if contains(lowercase(ctx.prompt), "verbose") {
+          score = score - 0.5
+        }
+        return {score: score, reason: ctx.case.id}
+      },
+      trials: 4,
+      budget: {max_concurrent: 2},
+      instruction_proposals: [
+        "Answer the question.",
+        "Calculate carefully and answer only with the result.",
+        "Be verbose and explain every intermediate thought.",
+      ],
+      demos: [[], [{input: "1 + 1", output: "2"}]],
+    },
+  )
+  println(result.best_score == 1.0)
+  println(contains(result.best_prompt, "Calculate carefully"))
+  println(len(result.trace) == 4)
+  println(result.trace[0].candidate.instruction == "Answer the question.")
+  println(result.trace[-1].acquisition.kind == "expected_improvement")
+  println(result.trace[-1].case_scores[0].case_id == "add")
+  println(result.ranked[0].score == 1.0)
+}

--- a/crates/harn-stdlib/src/lib.rs
+++ b/crates/harn-stdlib/src/lib.rs
@@ -126,6 +126,18 @@ pub const STDLIB_SOURCES: &[StdlibSource] = &[
         source: include_str!("stdlib/agent/options.harn"),
     },
     StdlibSource {
+        module: "llm/judge",
+        source: include_str!("stdlib/llm/judge.harn"),
+    },
+    StdlibSource {
+        module: "llm/refine",
+        source: include_str!("stdlib/llm/refine.harn"),
+    },
+    StdlibSource {
+        module: "llm/optimize",
+        source: include_str!("stdlib/llm/optimize.harn"),
+    },
+    StdlibSource {
         module: "agent/events",
         source: include_str!("stdlib/agent/events.harn"),
     },
@@ -684,6 +696,9 @@ mod tests {
             "waitpoint",
             "personas/prelude",
             "agent/host_tools",
+            "llm/optimize",
+            "llm/judge",
+            "llm/refine",
             "connectors/shared",
             "connectors/github",
             "connectors/linear",

--- a/crates/harn-stdlib/src/stdlib/llm/judge.harn
+++ b/crates/harn-stdlib/src/stdlib/llm/judge.harn
@@ -1,0 +1,141 @@
+fn __as_candidate(value, index) {
+  if type_of(value) == "string" {
+    return {index: index, prompt: value, instruction: value, demos: []}
+  }
+  require type_of(value) == "dict", "parallel_judge: candidates must be strings or dicts"
+  let instruction = value?.instruction ?? value?.prompt ?? ""
+  let prompt = value?.prompt ?? instruction
+  return value
+    + {index: value?.index ?? index, prompt: prompt, instruction: instruction, demos: value?.demos ?? []}
+}
+
+fn __candidate_rows(candidates) {
+  let candidate_list = if type_of(candidates) == "list" {
+    candidates
+  } else {
+    [candidates]
+  }
+  require len(candidate_list) > 0, "parallel_judge: candidates must not be empty"
+  var rows = []
+  var idx = 0
+  while idx < len(candidate_list) {
+    rows = rows.push({index: idx, candidate: __as_candidate(candidate_list[idx], idx)})
+    idx = idx + 1
+  }
+  return rows
+}
+
+fn __case_rows(eval_set) {
+  require type_of(eval_set) == "list", "parallel_judge: eval_set must be a list"
+  require len(eval_set) > 0, "parallel_judge: eval_set must not be empty"
+  var rows = []
+  var idx = 0
+  while idx < len(eval_set) {
+    rows = rows.push({index: idx, case: eval_set[idx]})
+    idx = idx + 1
+  }
+  return rows
+}
+
+fn __case_id(case, index) {
+  if type_of(case) == "dict" && case?.id != nil {
+    return case.id
+  }
+  return "case-" + to_string(index)
+}
+
+fn __score_value(value) {
+  let raw = if type_of(value) == "dict" {
+    value?.score
+  } else {
+    value
+  }
+  let score = to_float(raw)
+  require score != nil, "parallel_judge: metric must return a numeric score or {score}"
+  return score
+}
+
+fn __score_case(candidate, case, case_index, candidate_index, metric) {
+  let output = metric(
+    {
+      prompt: candidate.prompt,
+      candidate: candidate,
+      case: case,
+      case_index: case_index,
+      candidate_index: candidate_index,
+    },
+  )
+  return {
+    case_id: __case_id(case, case_index),
+    case_index: case_index,
+    score: __score_value(output),
+    output: output,
+  }
+}
+
+fn __mean_case_score(case_scores) {
+  var total = 0.0
+  for row in case_scores {
+    total = total + row.score
+  }
+  return total / (len(case_scores) * 1.0)
+}
+
+fn __insert_ranked(ranked, entry) {
+  var out = []
+  var inserted = false
+  for existing in ranked {
+    if !inserted && entry.score > existing.score {
+      out = out.push(entry)
+      inserted = true
+    }
+    out = out.push(existing)
+  }
+  if !inserted {
+    out = out.push(entry)
+  }
+  return out
+}
+
+fn __rank(entries) {
+  var ranked = []
+  for entry in entries {
+    ranked = __insert_ranked(ranked, entry)
+  }
+  return ranked
+}
+
+/** Score candidate prompts against an eval set, evaluating cases in parallel. */
+pub fn parallel_judge(candidates, eval_set, metric, options = nil) {
+  require metric != nil, "parallel_judge: metric closure is required"
+  let candidate_rows = __candidate_rows(candidates)
+  let case_rows = __case_rows(eval_set)
+  let _max_concurrent = options?.max_concurrent ?? options?.budget?.max_concurrent
+  var scored = []
+  for row in candidate_rows {
+    let candidate = row.candidate
+    let case_scores = parallel each case_rows with { max_concurrent: _max_concurrent } { case_row ->
+      __score_case(candidate, case_row.case, case_row.index, row.index, metric)
+    }
+    scored = scored
+      .push(
+      {
+        index: row.index,
+        candidate: candidate,
+        prompt: candidate.prompt,
+        score: __mean_case_score(case_scores),
+        case_scores: case_scores,
+      },
+    )
+  }
+  let ranked = __rank(scored)
+  return {
+    ranked: ranked,
+    scores: scored,
+    best: if len(ranked) > 0 {
+      ranked[0]
+    } else {
+      nil
+    },
+  }
+}

--- a/crates/harn-stdlib/src/stdlib/llm/optimize.harn
+++ b/crates/harn-stdlib/src/stdlib/llm/optimize.harn
@@ -1,0 +1,301 @@
+import { parallel_judge } from "std/llm/judge"
+import { propose_instructions } from "std/llm/refine"
+
+fn __require_config(config) {
+  require type_of(config) == "dict", "optimize_prompt: config must be a dict"
+  require type_of(config?.base_prompt) == "string", "optimize_prompt: base_prompt must be a string"
+  require type_of(config?.eval_set) == "list", "optimize_prompt: eval_set must be a list"
+  require len(config.eval_set) > 0, "optimize_prompt: eval_set must not be empty"
+  require config?.metric != nil, "optimize_prompt: metric closure is required"
+  return config
+}
+
+fn __positive_int(value, fallback, label) {
+  let raw = value ?? fallback
+  let n = to_int(raw)
+  require n != nil && n > 0, label + " must be a positive integer"
+  return n
+}
+
+fn __demo_sets(config) {
+  let demos = config?.demo_sets ?? config?.demos
+  if demos == nil {
+    return [[]]
+  }
+  require type_of(demos) == "list", "optimize_prompt: demos must be a list"
+  if len(demos) == 0 {
+    return [[]]
+  }
+  if type_of(demos[0]) == "list" {
+    return demos
+  }
+  return [demos]
+}
+
+fn __demo_text(demo) {
+  if type_of(demo) == "string" {
+    return demo
+  }
+  if type_of(demo) == "dict" {
+    if demo?.input != nil && demo?.output != nil {
+      return "Input: " + to_string(demo.input) + "\nOutput: " + to_string(demo.output)
+    }
+    if demo?.question != nil && demo?.answer != nil {
+      return "Question: " + to_string(demo.question) + "\nAnswer: " + to_string(demo.answer)
+    }
+  }
+  return json_stringify(demo)
+}
+
+fn __render_prompt(base_prompt, instruction, demos) {
+  var parts = []
+  let instruction_text = trim(instruction ?? "")
+  let base_text = trim(base_prompt)
+  if instruction_text != "" {
+    parts = parts.push(instruction_text)
+  }
+  if base_text != "" && base_text != instruction_text {
+    parts = parts.push(base_text)
+  }
+  if len(demos) > 0 {
+    var rendered = []
+    for demo in demos {
+      rendered = rendered.push(__demo_text(demo))
+    }
+    parts = parts.push("Examples:\n" + join(rendered, "\n\n"))
+  }
+  return join(parts, "\n\n")
+}
+
+fn __candidate_space(config) {
+  let instructions = propose_instructions(config.base_prompt, config)
+  let demo_sets = __demo_sets(config)
+  var candidates = []
+  var idx = 0
+  for instruction in instructions {
+    for demos in demo_sets {
+      candidates = candidates
+        .push(
+        {
+          index: idx,
+          instruction: instruction,
+          demos: demos,
+          prompt: __render_prompt(config.base_prompt, instruction, demos),
+        },
+      )
+      idx = idx + 1
+    }
+  }
+  return candidates
+}
+
+fn __exploration(config) {
+  let value = to_float(config?.acquisition?.exploration ?? config?.exploration ?? 0.25)
+  require value != nil, "optimize_prompt: acquisition.exploration must be numeric"
+  return value
+}
+
+fn __judge_options(config) {
+  return config?.budget ?? {} + config?.judge ?? {}
+}
+
+fn __trial_limit(config, candidate_count) {
+  var limit = __positive_int(config?.trials, candidate_count, "optimize_prompt: trials")
+  if config?.budget?.max_trials != nil {
+    let max_trials = __positive_int(config.budget.max_trials, limit, "optimize_prompt: budget.max_trials")
+    if max_trials < limit {
+      limit = max_trials
+    }
+  }
+  if config?.budget?.max_evaluations != nil {
+    let max_evals = __positive_int(
+      config.budget.max_evaluations,
+      len(config.eval_set),
+      "optimize_prompt: budget.max_evaluations",
+    )
+    let eval_trials = to_int(floor(max_evals / len(config.eval_set)))
+    if eval_trials < limit {
+      limit = eval_trials
+    }
+  }
+  if limit > candidate_count {
+    limit = candidate_count
+  }
+  require limit > 0, "optimize_prompt: budget leaves no eval trials"
+  return limit
+}
+
+fn __words(text) {
+  let normalized = regex_replace("[^A-Za-z0-9_]+", " ", lowercase(to_string(text)))
+  return split(trim(normalized), " ").filter({ word -> word != "" })
+}
+
+fn __text_similarity(a, b) {
+  let left = __words(a)
+  let right = __words(b)
+  if len(left) == 0 || len(right) == 0 {
+    return 0.0
+  }
+  var common = 0
+  for word in left {
+    if right.contains(word) {
+      common = common + 1
+    }
+  }
+  let denom = if len(left) > len(right) {
+    len(left)
+  } else {
+    len(right)
+  }
+  return common / (denom * 1.0)
+}
+
+fn __candidate_similarity(candidate, observed) {
+  var similarity = __text_similarity(candidate.instruction, observed.candidate.instruction)
+  if len(candidate.demos) == len(observed.candidate.demos) {
+    similarity = similarity + 0.2
+  }
+  if similarity > 1.0 {
+    return 1.0
+  }
+  return similarity
+}
+
+fn __acquisition(candidate, observations, best_score, exploration) {
+  if len(observations) == 0 {
+    return {
+      kind: "expected_improvement",
+      predicted_mean: 0.0,
+      uncertainty: 1.0,
+      expected_improvement: exploration,
+      value: exploration,
+    }
+  }
+  var weighted = 0.0
+  var weight_total = 0.0
+  for observed in observations {
+    let weight = 0.05 + __candidate_similarity(candidate, observed)
+    weighted = weighted + weight * observed.score
+    weight_total = weight_total + weight
+  }
+  let predicted = weighted / weight_total
+  let uncertainty = 1.0 / (1.0 + weight_total)
+  let expected = predicted - best_score + exploration * uncertainty
+  return {
+    kind: "expected_improvement",
+    predicted_mean: predicted,
+    uncertainty: uncertainty,
+    expected_improvement: expected,
+    value: expected,
+  }
+}
+
+fn __next_candidate(candidates, observed_indexes, observations, best_score, exploration) {
+  var selected = nil
+  var selected_acquisition = nil
+  for candidate in candidates {
+    if !observed_indexes.contains(candidate.index) {
+      let acquisition = __acquisition(candidate, observations, best_score, exploration)
+      if selected == nil || acquisition.value > selected_acquisition.value {
+        selected = candidate
+        selected_acquisition = acquisition
+      }
+    }
+  }
+  return {candidate: selected, acquisition: selected_acquisition}
+}
+
+fn __insert_ranked(ranked, entry) {
+  var out = []
+  var inserted = false
+  for existing in ranked {
+    if !inserted && entry.score > existing.score {
+      out = out.push(entry)
+      inserted = true
+    }
+    out = out.push(existing)
+  }
+  if !inserted {
+    out = out.push(entry)
+  }
+  return out
+}
+
+fn __rank_observations(observations) {
+  var ranked = []
+  for observation in observations {
+    ranked = __insert_ranked(
+      ranked,
+      {
+        trial: observation.trial,
+        candidate: observation.candidate,
+        prompt: observation.candidate.prompt,
+        score: observation.score,
+        case_scores: observation.case_scores,
+      },
+    )
+  }
+  return ranked
+}
+
+/** Optimize a prompt over instruction/demo candidates using deterministic acquisition search. */
+pub fn optimize_prompt(config) {
+  let cfg = __require_config(config)
+  let candidates = __candidate_space(cfg)
+  require len(candidates) > 0, "optimize_prompt: no candidate prompts generated"
+  let trials = __trial_limit(cfg, len(candidates))
+  let exploration = __exploration(cfg)
+  let judge_options = __judge_options(cfg)
+  var observed_indexes = []
+  var observations = []
+  var trace = []
+  var best = nil
+  var best_score = 0.0
+  var trial = 0
+  while trial < trials {
+    let picked = if trial == 0 {
+      {
+        candidate: candidates[0],
+        acquisition: {
+          kind: "expected_improvement",
+          predicted_mean: 0.0,
+          uncertainty: 1.0,
+          expected_improvement: exploration,
+          value: exploration,
+          seed: true,
+        },
+      }
+    } else {
+      __next_candidate(candidates, observed_indexes, observations, best_score, exploration)
+    }
+    if picked.candidate == nil {
+      break
+    }
+    let judged = parallel_judge([picked.candidate], cfg.eval_set, cfg.metric, judge_options)
+    let score = judged.scores[0].score
+    let observation = {
+      trial: trial,
+      candidate: picked.candidate,
+      score: score,
+      acquisition: picked.acquisition,
+      case_scores: judged.scores[0].case_scores,
+    }
+    observations = observations.push(observation)
+    observed_indexes = observed_indexes.push(picked.candidate.index)
+    trace = trace.push(observation)
+    if best == nil || score > best.score {
+      best = observation
+      best_score = score
+    }
+    trial = trial + 1
+  }
+  let ranked = __rank_observations(observations)
+  return {
+    best_prompt: best.candidate.prompt,
+    best_score: best.score,
+    best_candidate: best.candidate,
+    trace: trace,
+    ranked: ranked,
+    candidates: candidates,
+  }
+}

--- a/crates/harn-stdlib/src/stdlib/llm/refine.harn
+++ b/crates/harn-stdlib/src/stdlib/llm/refine.harn
@@ -1,0 +1,139 @@
+fn __copy_llm_option(current, opts, key) {
+  var out = current
+  if opts != nil && opts[key] != nil {
+    out[key] = opts[key]
+  }
+  return out
+}
+
+fn __llm_options(options) {
+  let opts = options?.llm ?? options?.llm_options ?? options ?? {}
+  var out = {}
+  for key in [
+    "provider",
+    "model",
+    "model_tier",
+    "temperature",
+    "top_p",
+    "top_k",
+    "max_tokens",
+    "frequency_penalty",
+    "presence_penalty",
+    "seed",
+    "stop",
+    "timeout",
+    "system",
+    "response_format",
+    "output_format",
+    "output_validation",
+    "schema_retries",
+    "retries",
+    "repair",
+    "thinking",
+    "interleaved_thinking",
+    "anthropic_beta_features",
+    "vision",
+    "tools",
+    "tool_choice",
+    "tool_search",
+    "budget",
+    "cache",
+    "stream",
+    "messages",
+    "structural_experiment",
+    "transcript",
+    "llm_retries",
+    "llm_backoff_ms",
+  ] {
+    out = __copy_llm_option(out, opts, key)
+  }
+  return out
+}
+
+fn __dedupe_strings(values) {
+  var seen = []
+  var out = []
+  for value in values {
+    if value != nil {
+      let text = trim(to_string(value))
+      if text != "" && !seen.contains(text) {
+        seen = seen.push(text)
+        out = out.push(text)
+      }
+    }
+  }
+  return out
+}
+
+fn __string_values(value) {
+  if value == nil {
+    return []
+  }
+  if type_of(value) == "list" {
+    return value
+  }
+  return [value]
+}
+
+fn __configured_proposals(options) {
+  return options?.instruction_proposals ?? options?.proposals ?? options?.instructions
+}
+
+fn __proposal_prompt(base_prompt, count) {
+  return "Propose "
+    + to_string(count)
+    + " concise alternative task instructions for this base prompt. Return JSON only.\n\nBase prompt:\n"
+    + base_prompt
+}
+
+fn __refine_prompt(base_prompt) {
+  return "Rewrite this task instruction to be more precise. Return JSON only.\n\nInstruction:\n"
+    + base_prompt
+}
+
+/** Rewrite one prompt instruction with a closure, configured proposal, or structured LLM call. */
+pub fn refine_prompt(base_prompt, options = nil) {
+  require type_of(base_prompt) == "string", "refine_prompt: base_prompt must be a string"
+  if options?.refine != nil {
+    return trim(to_string(options.refine({base_prompt: base_prompt, options: options})))
+  }
+  let configured = __configured_proposals(options)
+  if configured != nil {
+    let proposals = __dedupe_strings(__string_values(configured))
+    if len(proposals) > 0 {
+      return proposals[0]
+    }
+  }
+  let schema = {type: "object", required: ["instruction"], properties: {instruction: {type: "string"}}}
+  let result = llm_call_structured_result(__refine_prompt(base_prompt), schema, __llm_options(options))
+  if result.ok {
+    return trim(result.data.instruction)
+  }
+  throw "refine_prompt: " + to_string(result.error ?? "LLM refinement failed")
+}
+
+/** Generate instruction proposals for prompt search. */
+pub fn propose_instructions(base_prompt, options = nil) {
+  require type_of(base_prompt) == "string", "propose_instructions: base_prompt must be a string"
+  if options?.proposal_fn != nil {
+    return __dedupe_strings(
+      [base_prompt]
+        + __string_values(options.proposal_fn({base_prompt: base_prompt, options: options})),
+    )
+  }
+  let configured = __configured_proposals(options)
+  if configured != nil {
+    return __dedupe_strings([base_prompt] + __string_values(configured))
+  }
+  let count = options?.proposal_count ?? options?.count ?? options?.trials ?? 4
+  let schema = {
+    type: "object",
+    required: ["instructions"],
+    properties: {instructions: {type: "array", items: {type: "string"}}},
+  }
+  let result = llm_call_structured_result(__proposal_prompt(base_prompt, count), schema, __llm_options(options))
+  if result.ok {
+    return __dedupe_strings([base_prompt] + result.data.instructions)
+  }
+  throw "propose_instructions: " + to_string(result.error ?? "LLM instruction proposal failed")
+}

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -28,6 +28,7 @@
 - [LLM and agents](./llm-and-agents.md)
   - [LLM calls](./llm/llm_call.md)
   - [Agent loops](./llm/agent_loop.md)
+  - [Prompt optimization](./llm/optimize.md)
   - [Tools, Tool Vault, and MCP](./llm/tools.md)
   - [Streaming and transcripts](./llm/streaming.md)
   - [LLM providers](./llm/providers.md)

--- a/docs/src/llm/optimize.md
+++ b/docs/src/llm/optimize.md
@@ -1,0 +1,58 @@
+# Prompt optimization
+
+`std/llm/optimize` provides a deterministic prompt-search loop for tuning an
+instruction against an eval set:
+
+```harn
+import { optimize_prompt } from "std/llm/optimize"
+
+pipeline default() {
+  let result = optimize_prompt({
+    base_prompt: "Answer the question.",
+    eval_set: [
+      {id: "add", input: "2 + 2", expected: "4"},
+      {id: "mul", input: "3 * 3", expected: "9"},
+    ],
+    metric: { ctx ->
+      if contains(lowercase(ctx.prompt), "calculate") {
+        return 1.0
+      }
+      return 0.0
+    },
+    trials: 4,
+    instruction_proposals: [
+      "Answer the question.",
+      "Calculate carefully and answer only with the result.",
+    ],
+  })
+
+  println(result.best_prompt)
+  println(result.best_score)
+}
+```
+
+The optimizer searches over `(instruction, demos)` candidates. Instruction
+proposals come from `std/llm/refine` via `propose_instructions(...)`; callers can
+pass `instruction_proposals`, `proposal_fn`, or LLM options for structured
+proposal generation. Eval scoring is delegated to `parallel_judge(...)` from
+`std/llm/judge`, so each candidate's eval cases can run concurrently.
+
+`optimize_prompt(config)` returns:
+
+| Field | Description |
+|---|---|
+| `best_prompt` | Rendered prompt for the best observed candidate |
+| `best_score` | Mean eval-set score for `best_prompt` |
+| `best_candidate` | `{instruction, demos, prompt, index}` for the winning candidate |
+| `trace` | Trial-by-trial observations, case scores, and acquisition metadata |
+| `ranked` | Observed candidates sorted by score |
+| `candidates` | Full discrete candidate space considered for search |
+
+The acquisition loop is intentionally inspectable. It evaluates a seed candidate
+first, then selects unobserved candidates using an expected-improvement score
+derived from a small similarity-weighted surrogate over prior observations.
+
+`budget.max_concurrent` caps parallel eval cases. `budget.max_trials` and
+`budget.max_evaluations` cap the total search. For conformance and local tests,
+use explicit `instruction_proposals` and a deterministic metric closure to avoid
+real LLM calls.


### PR DESCRIPTION
## Summary
- add std/llm/refine instruction proposal helpers and std/llm/judge parallel eval-set scoring
- add std/llm/optimize with deterministic expected-improvement search over instruction/demo candidates
- document prompt optimization and cover the synthetic no-real-LLM steel thread

Closes #1326

## Verification
- CARGO_TARGET_DIR=/tmp/harn-issue-1326-target HARN_LLM_CALLS_DISABLED=1 cargo run --quiet --bin harn -- test conformance --filter llm_optimize_prompt
- CARGO_TARGET_DIR=/tmp/harn-issue-1326-target HARN_LLM_CALLS_DISABLED=1 cargo run --quiet --bin harn -- check crates/harn-stdlib/src/stdlib/llm/judge.harn crates/harn-stdlib/src/stdlib/llm/refine.harn crates/harn-stdlib/src/stdlib/llm/optimize.harn conformance/tests/integration/llm_optimize_prompt.harn
- CARGO_TARGET_DIR=/tmp/harn-issue-1326-target cargo test -p harn-stdlib
- CARGO_TARGET_DIR=/tmp/harn-issue-1326-target cargo clippy -p harn-stdlib --all-targets -- -D warnings
- CARGO_TARGET_DIR=/tmp/harn-issue-1326-target cargo fmt --all -- --check
- CARGO_TARGET_DIR=/tmp/harn-issue-1326-target make fmt-harn
- CARGO_TARGET_DIR=/tmp/harn-issue-1326-target HARN_LLM_CALLS_DISABLED=1 make lint-harn
- CARGO_TARGET_DIR=/tmp/harn-issue-1326-target HARN_LLM_CALLS_DISABLED=1 make conformance
- CARGO_TARGET_DIR=/tmp/harn-issue-1326-target make check-highlight
- CARGO_TARGET_DIR=/tmp/harn-issue-1326-target ./scripts/check_docs_snippets.sh
- npx markdownlint-cli2 docs/src/llm/optimize.md docs/src/SUMMARY.md
- git diff --check

Pre-commit and pre-push hooks also passed.