### PR TITLE
Add harn quickstart setup wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,14 @@ agent_loop(task, sys, {
   llm_caller: with_retry(default_llm_caller(), {max_attempts: 4}),
 })
 ```
+## Unreleased
+
+### Added
+
+- **`harn quickstart` setup wizard (#1331).** Added an interactive and
+  non-interactive setup flow that detects provider credentials, local Ollama,
+  free disk space, and local GPU availability, then writes starter
+  `providers.toml`, `harn.toml`, and `.env` files.
 
 ## v0.7.61
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1738,6 +1738,7 @@ dependencies = [
  "reedline",
  "regex",
  "reqwest",
+ "rpassword",
  "rustls",
  "serde",
  "serde_json",
@@ -3752,6 +3753,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpassword"
+version = "7.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ac5b223d9738ef56e0b98305410be40fa0941bf6036c56f1506751e43552d64"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rsqlite-vfs"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3759,6 +3771,16 @@ checksum = "a8a1f2315036ef6b1fbacd1972e8ee7688030b0a2121edfc2a6550febd41574d"
 dependencies = [
  "hashbrown 0.16.1",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ harn orchestrator deploy --provider fly --manifest ./harn.toml --build
 ```bash
 harn new my-project --template agent
 cd my-project
+harn quickstart --non-interactive
+source .env
 harn doctor --no-network
 harn run main.harn
 harn test tests/

--- a/crates/harn-cli/Cargo.toml
+++ b/crates/harn-cli/Cargo.toml
@@ -65,6 +65,7 @@ jsonschema = { version = "0.46.3", default-features = false }
 jsonwebtoken = { version = "9", default-features = false, features = ["use_pem"] }
 clap = { version = "4", features = ["derive", "env", "string"] }
 clap_complete = "4"
+rpassword = "7"
 tower = { version = "0.5", features = ["util"] }
 time = { version = "0.3", features = ["formatting", "parsing"] }
 tempfile = "3"

--- a/crates/harn-cli/src/cli/mod.rs
+++ b/crates/harn-cli/src/cli/mod.rs
@@ -32,6 +32,7 @@ mod persona;
 mod playground;
 mod portal;
 mod provider;
+mod quickstart;
 mod run;
 mod runs;
 mod serve;
@@ -109,6 +110,7 @@ pub(crate) use persona::{
 pub(crate) use playground::PlaygroundArgs;
 pub(crate) use portal::PortalArgs;
 pub(crate) use provider::{ModelInfoArgs, ProviderCatalogArgs, ProviderReadyArgs};
+pub(crate) use quickstart::QuickstartArgs;
 pub(crate) use run::RunArgs;
 pub(crate) use runs::{EvalArgs, ReplayArgs, RunsArgs, RunsCommand};
 pub(crate) use serve::{
@@ -209,6 +211,8 @@ SCRIPTING
     /// permissions on `~/.harn`, and project manifest health. Reports
     /// each check as ok/warn/fail with a suggested fix.
     Doctor(DoctorArgs),
+    /// Configure a starter Harn project and LLM provider settings.
+    Quickstart(QuickstartArgs),
     /// Register outbound connector resources with a provider.
     Connect(Box<ConnectArgs>),
     /// Validate pure-Harn connector packages against the connector contract.

--- a/crates/harn-cli/src/cli/quickstart.rs
+++ b/crates/harn-cli/src/cli/quickstart.rs
@@ -1,0 +1,14 @@
+use clap::{ArgAction, Args};
+
+#[derive(Debug, Args)]
+pub(crate) struct QuickstartArgs {
+    /// Run with deterministic defaults and do not prompt.
+    #[arg(long = "non-interactive", default_value_t = false, action = ArgAction::SetTrue)]
+    pub non_interactive: bool,
+    /// Provider to configure, for example anthropic, openai, or ollama.
+    #[arg(long)]
+    pub provider: Option<String>,
+    /// Default model or model alias to write into starter config.
+    #[arg(long)]
+    pub model: Option<String>,
+}

--- a/crates/harn-cli/src/cli/tests.rs
+++ b/crates/harn-cli/src/cli/tests.rs
@@ -1902,6 +1902,26 @@ fn test_parses_models_recommend_args() {
 }
 
 #[test]
+fn test_parses_quickstart_args() {
+    let cli = Cli::parse_from([
+        "harn",
+        "quickstart",
+        "--non-interactive",
+        "--provider",
+        "ollama",
+        "--model",
+        "qwen2.5-coder:latest",
+    ]);
+
+    let Command::Quickstart(args) = cli.command.unwrap() else {
+        panic!("expected quickstart command");
+    };
+    assert!(args.non_interactive);
+    assert_eq!(args.provider.as_deref(), Some("ollama"));
+    assert_eq!(args.model.as_deref(), Some("qwen2.5-coder:latest"));
+}
+
+#[test]
 fn test_parses_check_provider_matrix_args() {
     let cli = Cli::parse_from([
         "harn",

--- a/crates/harn-cli/src/commands/mod.rs
+++ b/crates/harn-cli/src/commands/mod.rs
@@ -23,6 +23,7 @@ pub mod persona_scaffold;
 pub mod playground;
 pub(crate) mod portal;
 pub(crate) mod protocol_conformance;
+pub(crate) mod quickstart;
 pub(crate) mod repl;
 pub mod run;
 pub(crate) mod serve;

--- a/crates/harn-cli/src/commands/quickstart.rs
+++ b/crates/harn-cli/src/commands/quickstart.rs
@@ -1,0 +1,939 @@
+use std::collections::BTreeSet;
+use std::env;
+use std::io::IsTerminal;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::Duration;
+
+use crate::cli::QuickstartArgs;
+
+const QUICKSTART_ALIAS: &str = "quickstart";
+const PREFERRED_PROVIDERS: &[&str] = &[
+    "ollama",
+    "anthropic",
+    "openai",
+    "openrouter",
+    "gemini",
+    "together",
+    "huggingface",
+    "local",
+    "mlx",
+];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ProviderChoice {
+    name: String,
+    model: String,
+    auth_envs: Vec<String>,
+    auth_available: bool,
+}
+
+impl ProviderChoice {
+    fn needs_key(&self) -> bool {
+        !self.auth_envs.is_empty() && !self.auth_available
+    }
+
+    fn primary_auth_env(&self) -> Option<&str> {
+        self.auth_envs.first().map(String::as_str)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ProviderSelection {
+    provider: String,
+    model: String,
+    auth_env: Option<String>,
+    api_key: Option<String>,
+    write_placeholder_key: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct OllamaProbe {
+    reachable: bool,
+    status: String,
+    message: String,
+    available_models: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DiskProbe {
+    available_kib: Option<u64>,
+    detail: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct GpuProbe {
+    detected: bool,
+    detail: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct QuickstartPaths {
+    cwd: PathBuf,
+    harn_toml: PathBuf,
+    env_file: PathBuf,
+    providers_toml: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct FileAction {
+    path: PathBuf,
+    status: &'static str,
+    detail: String,
+}
+
+pub(crate) async fn run_quickstart(args: &QuickstartArgs) -> Result<(), String> {
+    let cwd = env::current_dir().map_err(|error| format!("failed to read cwd: {error}"))?;
+    let paths = QuickstartPaths {
+        harn_toml: cwd.join("harn.toml"),
+        env_file: cwd.join(".env"),
+        providers_toml: providers_config_path(),
+        cwd,
+    };
+
+    let ollama = probe_ollama(args.model.as_deref()).await;
+    let disk = detect_disk_space(&paths.cwd);
+    let gpu = detect_gpu();
+    let choices = provider_choices(args.model.as_deref(), &ollama);
+    print_probe_report(&paths, &choices, &ollama, &disk, &gpu);
+
+    let can_prompt = !args.non_interactive && std::io::stdin().is_terminal();
+    let selection = if can_prompt {
+        choose_interactive(args, &choices, &ollama)?
+    } else {
+        choose_non_interactive(args, &choices, &ollama)?
+    };
+
+    let actions = write_quickstart_files(&paths, &selection)?;
+    print_completion(&selection, &actions);
+    Ok(())
+}
+
+async fn probe_ollama(model: Option<&str>) -> OllamaProbe {
+    let selected_model = model
+        .filter(|value| !value.trim().is_empty())
+        .map(|value| value.trim().to_string())
+        .unwrap_or_else(|| harn_vm::llm_config::default_model_for_provider("ollama"));
+    let mut options = harn_vm::llm::OllamaReadinessOptions::new(selected_model);
+    options.tags_timeout = Duration::from_secs(2);
+    let result = harn_vm::llm::ollama_readiness(options).await;
+    let reachable = result.http_status.is_some()
+        || matches!(
+            result.status.as_str(),
+            "ok" | "model_missing" | "warmup_failed"
+        );
+    OllamaProbe {
+        reachable,
+        status: result.status,
+        message: result.message,
+        available_models: result.available_models,
+    }
+}
+
+fn provider_choices(model: Option<&str>, ollama: &OllamaProbe) -> Vec<ProviderChoice> {
+    let mut names: BTreeSet<String> = PREFERRED_PROVIDERS
+        .iter()
+        .filter(|name| harn_vm::llm_config::provider_config(name).is_some())
+        .map(|name| (*name).to_string())
+        .collect();
+    for name in harn_vm::llm_config::provider_names() {
+        names.insert(name);
+    }
+
+    let mut choices: Vec<_> = names
+        .into_iter()
+        .filter_map(|name| provider_choice(&name, model, ollama))
+        .collect();
+    choices.sort_by_key(|choice| {
+        PREFERRED_PROVIDERS
+            .iter()
+            .position(|name| *name == choice.name)
+            .unwrap_or(PREFERRED_PROVIDERS.len())
+    });
+    choices
+}
+
+fn provider_choice(
+    name: &str,
+    model: Option<&str>,
+    ollama: &OllamaProbe,
+) -> Option<ProviderChoice> {
+    let def = harn_vm::llm_config::provider_config(name)?;
+    let auth_envs = harn_vm::llm_config::auth_env_names(&def.auth_env);
+    let auth_available = auth_envs.is_empty()
+        || auth_envs.iter().any(|name| {
+            env::var(name)
+                .ok()
+                .is_some_and(|value| !value.trim().is_empty())
+        });
+    Some(ProviderChoice {
+        name: name.to_string(),
+        model: default_model_for_choice(name, model, ollama),
+        auth_envs,
+        auth_available,
+    })
+}
+
+fn default_model_for_choice(provider: &str, model: Option<&str>, ollama: &OllamaProbe) -> String {
+    if let Some(model) = model.filter(|value| !value.trim().is_empty()) {
+        return model.trim().to_string();
+    }
+    if provider == "ollama" {
+        if let Some(model) = ollama.available_models.first() {
+            return model.clone();
+        }
+    }
+    harn_vm::llm_config::default_model_for_provider(provider)
+}
+
+fn choose_non_interactive(
+    args: &QuickstartArgs,
+    choices: &[ProviderChoice],
+    ollama: &OllamaProbe,
+) -> Result<ProviderSelection, String> {
+    let choice = if let Some(provider) = args.provider.as_deref() {
+        let provider = provider.trim();
+        choices
+            .iter()
+            .find(|choice| choice.name == provider)
+            .ok_or_else(|| format!("unknown provider '{provider}'"))?
+    } else {
+        choices
+            .iter()
+            .find(|choice| !choice.auth_envs.is_empty() && choice.auth_available)
+            .or_else(|| {
+                ollama
+                    .reachable
+                    .then(|| choices.iter().find(|choice| choice.name == "ollama"))
+                    .flatten()
+            })
+            .or_else(|| {
+                env::var("LOCAL_LLM_BASE_URL")
+                    .ok()
+                    .filter(|value| !value.trim().is_empty())
+                    .and_then(|_| choices.iter().find(|choice| choice.name == "local"))
+            })
+            .or_else(|| choices.iter().find(|choice| choice.name == "anthropic"))
+            .ok_or_else(|| "no configurable providers found".to_string())?
+    };
+    Ok(selection_from_choice(choice, None))
+}
+
+fn choose_interactive(
+    args: &QuickstartArgs,
+    choices: &[ProviderChoice],
+    ollama: &OllamaProbe,
+) -> Result<ProviderSelection, String> {
+    let choice = if let Some(provider) = args.provider.as_deref() {
+        let provider = provider.trim();
+        choices
+            .iter()
+            .find(|choice| choice.name == provider)
+            .ok_or_else(|| format!("unknown provider '{provider}'"))?
+    } else {
+        println!();
+        println!("Choose a provider:");
+        for (idx, choice) in choices.iter().enumerate() {
+            println!("  {}) {}", idx + 1, format_choice(choice, ollama));
+        }
+        let default = default_choice_index(choices, ollama);
+        let answer = read_line(&format!("provider [{}]", default + 1))?;
+        let selected = if answer.trim().is_empty() {
+            default
+        } else {
+            answer
+                .trim()
+                .parse::<usize>()
+                .ok()
+                .and_then(|value| value.checked_sub(1))
+                .filter(|idx| *idx < choices.len())
+                .ok_or_else(|| format!("provider choice must be 1-{}", choices.len()))?
+        };
+        &choices[selected]
+    };
+
+    let mut model = choice.model.clone();
+    if choice.name == "ollama" && args.model.is_none() && !ollama.available_models.is_empty() {
+        println!();
+        println!("Choose an Ollama model:");
+        for (idx, model) in ollama.available_models.iter().enumerate() {
+            println!("  {}) {model}", idx + 1);
+        }
+        let answer = read_line("model [1]")?;
+        if !answer.trim().is_empty() {
+            let selected = answer
+                .trim()
+                .parse::<usize>()
+                .ok()
+                .and_then(|value| value.checked_sub(1))
+                .filter(|idx| *idx < ollama.available_models.len())
+                .ok_or_else(|| {
+                    format!(
+                        "Ollama model choice must be 1-{}",
+                        ollama.available_models.len()
+                    )
+                })?;
+            model = ollama.available_models[selected].clone();
+        }
+    } else if args.model.is_none() {
+        let answer = read_line(&format!("model [{}]", choice.model))?;
+        if !answer.trim().is_empty() {
+            model = answer.trim().to_string();
+        }
+    }
+
+    let mut api_key = None;
+    if choice.needs_key() {
+        if let Some(env_name) = choice.primary_auth_env() {
+            println!();
+            println!("{env_name} is not set.");
+            let prompt = format!("Enter {env_name} for .env, or leave blank for a placeholder: ");
+            let entered = rpassword::prompt_password(prompt)
+                .map_err(|error| format!("failed to read API key: {error}"))?;
+            if !entered.trim().is_empty() {
+                api_key = Some(entered.trim().to_string());
+            }
+        }
+    }
+
+    let mut selection = selection_from_choice(choice, api_key);
+    selection.model = model;
+    Ok(selection)
+}
+
+fn selection_from_choice(choice: &ProviderChoice, api_key: Option<String>) -> ProviderSelection {
+    let auth_env = choice.primary_auth_env().map(str::to_string);
+    ProviderSelection {
+        provider: choice.name.clone(),
+        model: choice.model.clone(),
+        auth_env,
+        write_placeholder_key: choice.needs_key() && api_key.is_none(),
+        api_key,
+    }
+}
+
+fn default_choice_index(choices: &[ProviderChoice], ollama: &OllamaProbe) -> usize {
+    choices
+        .iter()
+        .position(|choice| !choice.auth_envs.is_empty() && choice.auth_available)
+        .or_else(|| {
+            ollama
+                .reachable
+                .then(|| choices.iter().position(|choice| choice.name == "ollama"))
+                .flatten()
+        })
+        .or_else(|| {
+            env::var("LOCAL_LLM_BASE_URL")
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+                .and_then(|_| choices.iter().position(|choice| choice.name == "local"))
+        })
+        .or_else(|| choices.iter().position(|choice| choice.name == "anthropic"))
+        .unwrap_or(0)
+}
+
+fn read_line(prompt_label: &str) -> Result<String, String> {
+    use reedline::{DefaultPrompt, DefaultPromptSegment, Reedline, Signal};
+
+    let mut editor = Reedline::create();
+    let prompt = DefaultPrompt::new(
+        DefaultPromptSegment::Basic(prompt_label.to_string()),
+        DefaultPromptSegment::Empty,
+    );
+    match editor.read_line(&prompt) {
+        Ok(Signal::Success(line)) => Ok(line),
+        Ok(Signal::CtrlC | Signal::CtrlD) => Err("quickstart cancelled".to_string()),
+        Ok(_) => Err("quickstart input was not accepted".to_string()),
+        Err(error) => Err(format!("failed to read input: {error}")),
+    }
+}
+
+fn write_quickstart_files(
+    paths: &QuickstartPaths,
+    selection: &ProviderSelection,
+) -> Result<Vec<FileAction>, String> {
+    validate_existing_harn_toml(&paths.harn_toml)?;
+    Ok(vec![
+        write_providers_toml(&paths.providers_toml, selection)?,
+        write_or_update_harn_toml(paths, selection)?,
+        write_or_update_env_file(&paths.env_file, selection)?,
+    ])
+}
+
+fn validate_existing_harn_toml(path: &Path) -> Result<(), String> {
+    if !path.exists() {
+        return Ok(());
+    }
+    let existing = std::fs::read_to_string(path)
+        .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
+    toml::from_str::<toml::Value>(&existing)
+        .map(|_| ())
+        .map_err(|error| format!("{} is not valid TOML: {error}", path.display()))
+}
+
+fn write_providers_toml(path: &Path, selection: &ProviderSelection) -> Result<FileAction, String> {
+    if path.exists() {
+        return Ok(FileAction {
+            path: path.to_path_buf(),
+            status: "skip",
+            detail: "already exists".to_string(),
+        });
+    }
+
+    let content = render_providers_toml(selection);
+    harn_vm::atomic_io::atomic_write(path, content.as_bytes())
+        .map_err(|error| format!("failed to write {}: {error}", path.display()))?;
+    Ok(FileAction {
+        path: path.to_path_buf(),
+        status: "create",
+        detail: "starter provider overlay".to_string(),
+    })
+}
+
+fn write_or_update_harn_toml(
+    paths: &QuickstartPaths,
+    selection: &ProviderSelection,
+) -> Result<FileAction, String> {
+    let path = &paths.harn_toml;
+    if !path.exists() {
+        let project_name = paths
+            .cwd
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("harn-project");
+        let content = render_new_harn_toml(project_name, selection);
+        harn_vm::atomic_io::atomic_write(path, content.as_bytes())
+            .map_err(|error| format!("failed to write {}: {error}", path.display()))?;
+        return Ok(FileAction {
+            path: path.to_path_buf(),
+            status: "create",
+            detail: "starter project manifest".to_string(),
+        });
+    }
+
+    let existing = std::fs::read_to_string(path)
+        .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
+    let parsed = toml::from_str::<toml::Value>(&existing)
+        .map_err(|error| format!("{} is not valid TOML: {error}", path.display()))?;
+    if parsed.get("llm").is_some() {
+        return Ok(FileAction {
+            path: path.to_path_buf(),
+            status: "skip",
+            detail: "already has [llm] config".to_string(),
+        });
+    }
+
+    let mut content = existing;
+    if !content.ends_with('\n') {
+        content.push('\n');
+    }
+    content.push('\n');
+    content.push_str(&render_harn_llm_section(selection));
+    harn_vm::atomic_io::atomic_write(path, content.as_bytes())
+        .map_err(|error| format!("failed to update {}: {error}", path.display()))?;
+    Ok(FileAction {
+        path: path.to_path_buf(),
+        status: "update",
+        detail: "added [llm] defaults".to_string(),
+    })
+}
+
+fn write_or_update_env_file(
+    path: &Path,
+    selection: &ProviderSelection,
+) -> Result<FileAction, String> {
+    let existing = match std::fs::read_to_string(path) {
+        Ok(content) => content,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(error) => return Err(format!("failed to read {}: {error}", path.display())),
+    };
+    let content = merge_env_file(&existing, selection);
+    if content == existing {
+        return Ok(FileAction {
+            path: path.to_path_buf(),
+            status: "skip",
+            detail: "already has quickstart env keys".to_string(),
+        });
+    }
+    harn_vm::atomic_io::atomic_write(path, content.as_bytes())
+        .map_err(|error| format!("failed to write {}: {error}", path.display()))?;
+    Ok(FileAction {
+        path: path.to_path_buf(),
+        status: if existing.is_empty() {
+            "create"
+        } else {
+            "update"
+        },
+        detail: "starter environment file".to_string(),
+    })
+}
+
+fn render_providers_toml(selection: &ProviderSelection) -> String {
+    format!(
+        "# Generated by harn quickstart. Harn merges this file over built-in provider definitions.\n\
+         default_provider = {}\n\n\
+         [aliases]\n\
+         {} = {{ id = {}, provider = {} }}\n",
+        toml_quote(&selection.provider),
+        QUICKSTART_ALIAS,
+        toml_quote(&selection.model),
+        toml_quote(&selection.provider)
+    )
+}
+
+fn render_new_harn_toml(project_name: &str, selection: &ProviderSelection) -> String {
+    format!(
+        "[package]\n\
+         name = {}\n\
+         version = \"0.1.0\"\n\n\
+         [dependencies]\n\n\
+         {}",
+        toml_quote(project_name),
+        render_harn_llm_section(selection)
+    )
+}
+
+fn render_harn_llm_section(selection: &ProviderSelection) -> String {
+    format!(
+        "[llm]\n\
+         default_provider = {}\n\n\
+         [llm.aliases]\n\
+         {} = {{ id = {}, provider = {} }}\n",
+        toml_quote(&selection.provider),
+        QUICKSTART_ALIAS,
+        toml_quote(&selection.model),
+        toml_quote(&selection.provider)
+    )
+}
+
+fn merge_env_file(existing: &str, selection: &ProviderSelection) -> String {
+    let mut content = existing.to_string();
+    if !content.is_empty() && !content.ends_with('\n') {
+        content.push('\n');
+    }
+
+    let mut additions = Vec::new();
+    push_env_if_missing(
+        existing,
+        &mut additions,
+        "HARN_LLM_PROVIDER",
+        &selection.provider,
+        false,
+    );
+    push_env_if_missing(
+        existing,
+        &mut additions,
+        "HARN_LLM_MODEL",
+        &selection.model,
+        false,
+    );
+    if let Some(env_name) = selection.auth_env.as_deref() {
+        if let Some(api_key) = selection.api_key.as_deref() {
+            push_env_if_missing(existing, &mut additions, env_name, api_key, false);
+        } else if selection.write_placeholder_key {
+            push_env_if_missing(existing, &mut additions, env_name, "replace-me", true);
+        }
+    }
+
+    if additions.is_empty() {
+        return content;
+    }
+    if !content.is_empty() {
+        content.push('\n');
+    }
+    content.push_str("# Harn quickstart\n");
+    for line in additions {
+        content.push_str(&line);
+        content.push('\n');
+    }
+    content
+}
+
+fn push_env_if_missing(
+    existing: &str,
+    additions: &mut Vec<String>,
+    key: &str,
+    value: &str,
+    commented: bool,
+) {
+    if env_file_has_key(existing, key) {
+        return;
+    }
+    let assignment = format!("{key}={}", shell_quote(value));
+    if commented {
+        additions.push(format!("# {assignment}"));
+    } else {
+        additions.push(assignment);
+    }
+}
+
+fn env_file_has_key(existing: &str, key: &str) -> bool {
+    existing.lines().any(|line| {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with('#') {
+            return false;
+        }
+        trimmed
+            .strip_prefix("export ")
+            .unwrap_or(trimmed)
+            .starts_with(&format!("{key}="))
+    })
+}
+
+fn providers_config_path() -> PathBuf {
+    env::var_os("HARN_PROVIDERS_CONFIG")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| {
+            env::var_os("HOME").map(|home| {
+                PathBuf::from(home)
+                    .join(".config")
+                    .join("harn")
+                    .join("providers.toml")
+            })
+        })
+        .unwrap_or_else(|| PathBuf::from(".config/harn/providers.toml"))
+}
+
+fn print_probe_report(
+    paths: &QuickstartPaths,
+    choices: &[ProviderChoice],
+    ollama: &OllamaProbe,
+    disk: &DiskProbe,
+    gpu: &GpuProbe,
+) {
+    println!("Harn quickstart");
+    println!();
+    println!("Detected:");
+    println!("  providers.toml  {}", paths.providers_toml.display());
+    println!("  harn.toml       {}", paths.harn_toml.display());
+    println!("  .env            {}", paths.env_file.display());
+    println!("  ollama          {}", ollama.message);
+    println!("  disk            {}", disk.detail);
+    println!("  gpu             {}", gpu.detail);
+    println!();
+    println!("Credentials:");
+    for choice in choices.iter().filter(|choice| !choice.auth_envs.is_empty()) {
+        let status = if choice.auth_available {
+            "set"
+        } else {
+            "missing"
+        };
+        println!(
+            "  {:<12} {:<8} {}",
+            choice.name,
+            status,
+            choice.auth_envs.join(", ")
+        );
+    }
+}
+
+fn print_completion(selection: &ProviderSelection, actions: &[FileAction]) {
+    println!();
+    println!(
+        "Configured provider={} model={}",
+        selection.provider, selection.model
+    );
+    for action in actions {
+        println!(
+            "  {:<6} {:<52} {}",
+            action.status,
+            action.path.display(),
+            action.detail
+        );
+    }
+    println!();
+    println!("Next:");
+    println!("  source .env");
+    println!("  harn doctor --no-network");
+}
+
+fn format_choice(choice: &ProviderChoice, ollama: &OllamaProbe) -> String {
+    let auth = if choice.auth_envs.is_empty() {
+        "no API key required".to_string()
+    } else if choice.auth_available {
+        format!("{} set", choice.auth_envs.join("/"))
+    } else {
+        format!("{} missing", choice.auth_envs.join("/"))
+    };
+    let extra = if choice.name == "ollama" {
+        if ollama.reachable {
+            ", daemon reachable"
+        } else {
+            ", daemon not reachable"
+        }
+    } else {
+        ""
+    };
+    format!("{} (model {}, {auth}{extra})", choice.name, choice.model)
+}
+
+fn detect_disk_space(path: &Path) -> DiskProbe {
+    let output = Command::new("df").arg("-Pk").arg(path).output();
+    match output {
+        Ok(output) if output.status.success() => {
+            let text = String::from_utf8_lossy(&output.stdout);
+            if let Some(kib) = parse_df_available_kib(&text) {
+                DiskProbe {
+                    available_kib: Some(kib),
+                    detail: format!("{:.1} GiB available at {}", kib_to_gib(kib), path.display()),
+                }
+            } else {
+                DiskProbe {
+                    available_kib: None,
+                    detail: "could not parse df output".to_string(),
+                }
+            }
+        }
+        Ok(output) => DiskProbe {
+            available_kib: None,
+            detail: format!("df exited with {}", output.status),
+        },
+        Err(error) => DiskProbe {
+            available_kib: None,
+            detail: format!("df not available: {error}"),
+        },
+    }
+}
+
+fn parse_df_available_kib(output: &str) -> Option<u64> {
+    output.lines().skip(1).find_map(|line| {
+        let columns: Vec<&str> = line.split_whitespace().collect();
+        columns.get(3).and_then(|value| value.parse::<u64>().ok())
+    })
+}
+
+fn kib_to_gib(kib: u64) -> f64 {
+    kib as f64 / 1024.0 / 1024.0
+}
+
+fn detect_gpu() -> GpuProbe {
+    if let Ok(value) = env::var("CUDA_VISIBLE_DEVICES") {
+        let trimmed = value.trim();
+        if !trimmed.is_empty() && trimmed != "-1" {
+            return GpuProbe {
+                detected: true,
+                detail: format!("CUDA_VISIBLE_DEVICES={trimmed}"),
+            };
+        }
+    }
+    if let Ok(output) = Command::new("nvidia-smi").arg("-L").output() {
+        if output.status.success() {
+            let detail = String::from_utf8_lossy(&output.stdout)
+                .lines()
+                .next()
+                .unwrap_or("NVIDIA GPU detected")
+                .to_string();
+            if !detail.trim().is_empty() {
+                return GpuProbe {
+                    detected: true,
+                    detail,
+                };
+            }
+        }
+    }
+    if apple_silicon_detected() {
+        return GpuProbe {
+            detected: true,
+            detail: "Apple Silicon GPU available".to_string(),
+        };
+    }
+    GpuProbe {
+        detected: false,
+        detail: "no local GPU detected".to_string(),
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn apple_silicon_detected() -> bool {
+    Command::new("sysctl")
+        .args(["-n", "hw.optional.arm64"])
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .map(|output| String::from_utf8_lossy(&output.stdout).trim() == "1")
+        .unwrap_or(false)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn apple_silicon_detected() -> bool {
+    false
+}
+
+fn toml_quote(value: &str) -> String {
+    let mut out = String::from("\"");
+    for ch in value.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            _ => out.push(ch),
+        }
+    }
+    out.push('"');
+    out
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\"'\"'"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn selection(provider: &str, model: &str) -> ProviderSelection {
+        ProviderSelection {
+            provider: provider.to_string(),
+            model: model.to_string(),
+            auth_env: Some("ANTHROPIC_API_KEY".to_string()),
+            api_key: None,
+            write_placeholder_key: true,
+        }
+    }
+
+    #[test]
+    fn renders_starter_provider_overlay() {
+        let rendered = render_providers_toml(&selection("ollama", "qwen2.5-coder:latest"));
+        let parsed: toml::Value = toml::from_str(&rendered).unwrap();
+        assert_eq!(parsed["default_provider"].as_str(), Some("ollama"));
+        assert_eq!(
+            parsed["aliases"][QUICKSTART_ALIAS]["id"].as_str(),
+            Some("qwen2.5-coder:latest")
+        );
+    }
+
+    #[test]
+    fn appends_missing_env_values_without_overwriting_existing_keys() {
+        let existing = "HARN_LLM_PROVIDER='openai'\n";
+        let merged = merge_env_file(existing, &selection("anthropic", "claude-sonnet-4"));
+        assert!(merged.contains("HARN_LLM_PROVIDER='openai'"));
+        assert!(merged.contains("HARN_LLM_MODEL='claude-sonnet-4'"));
+        assert!(merged.contains("# ANTHROPIC_API_KEY='replace-me'"));
+        assert_eq!(merged.matches("HARN_LLM_PROVIDER=").count(), 1);
+    }
+
+    #[test]
+    fn detects_env_keys_with_export_prefix() {
+        assert!(env_file_has_key(
+            "export OPENAI_API_KEY='sk-test'\n",
+            "OPENAI_API_KEY"
+        ));
+        assert!(!env_file_has_key(
+            "# OPENAI_API_KEY='sk-test'\n",
+            "OPENAI_API_KEY"
+        ));
+    }
+
+    #[test]
+    fn parses_df_available_column() {
+        let output = "Filesystem 1024-blocks Used Available Capacity Mounted on\n/dev/disk 100 10 90 10% /\n";
+        assert_eq!(parse_df_available_kib(output), Some(90));
+    }
+
+    #[test]
+    fn non_interactive_prefers_available_remote_provider() {
+        let choices = vec![
+            ProviderChoice {
+                name: "ollama".to_string(),
+                model: "llama3.2".to_string(),
+                auth_envs: Vec::new(),
+                auth_available: true,
+            },
+            ProviderChoice {
+                name: "anthropic".to_string(),
+                model: "claude-sonnet-4-20250514".to_string(),
+                auth_envs: vec!["ANTHROPIC_API_KEY".to_string()],
+                auth_available: true,
+            },
+        ];
+        let args = QuickstartArgs {
+            non_interactive: true,
+            provider: None,
+            model: None,
+        };
+        let selected = choose_non_interactive(
+            &args,
+            &choices,
+            &OllamaProbe {
+                reachable: true,
+                status: "ok".to_string(),
+                message: "ok".to_string(),
+                available_models: vec!["llama3.2".to_string()],
+            },
+        )
+        .unwrap();
+        assert_eq!(selected.provider, "anthropic");
+    }
+
+    #[test]
+    fn interactive_default_prefers_available_remote_provider() {
+        let choices = vec![
+            ProviderChoice {
+                name: "ollama".to_string(),
+                model: "llama3.2".to_string(),
+                auth_envs: Vec::new(),
+                auth_available: true,
+            },
+            ProviderChoice {
+                name: "anthropic".to_string(),
+                model: "claude-sonnet-4-20250514".to_string(),
+                auth_envs: vec!["ANTHROPIC_API_KEY".to_string()],
+                auth_available: true,
+            },
+        ];
+        let default = default_choice_index(
+            &choices,
+            &OllamaProbe {
+                reachable: true,
+                status: "ok".to_string(),
+                message: "ok".to_string(),
+                available_models: vec!["llama3.2".to_string()],
+            },
+        );
+        assert_eq!(choices[default].name, "anthropic");
+    }
+
+    #[test]
+    fn non_interactive_uses_reachable_ollama_before_unprobed_keyless_providers() {
+        let choices = vec![
+            ProviderChoice {
+                name: "ollama".to_string(),
+                model: "qwen3.6:latest".to_string(),
+                auth_envs: Vec::new(),
+                auth_available: true,
+            },
+            ProviderChoice {
+                name: "anthropic".to_string(),
+                model: "claude-sonnet-4-20250514".to_string(),
+                auth_envs: vec!["ANTHROPIC_API_KEY".to_string()],
+                auth_available: false,
+            },
+            ProviderChoice {
+                name: "local".to_string(),
+                model: "gpt-4o".to_string(),
+                auth_envs: Vec::new(),
+                auth_available: true,
+            },
+        ];
+        let args = QuickstartArgs {
+            non_interactive: true,
+            provider: None,
+            model: None,
+        };
+        let selected = choose_non_interactive(
+            &args,
+            &choices,
+            &OllamaProbe {
+                reachable: true,
+                status: "ok".to_string(),
+                message: "ok".to_string(),
+                available_models: vec!["qwen3.6:latest".to_string()],
+            },
+        )
+        .unwrap();
+        assert_eq!(selected.provider, "ollama");
+    }
+}

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -586,6 +586,11 @@ async fn async_main() {
         }
         Command::Models(args) => commands::models::run(args).await,
         Command::Try(args) => commands::try_cmd::run(args).await,
+        Command::Quickstart(args) => {
+            if let Err(error) = commands::quickstart::run_quickstart(&args).await {
+                command_error(&error);
+            }
+        }
         Command::Serve(args) => match args.command {
             ServeCommand::Acp(args) => {
                 if let Err(error) = commands::serve::run_acp_server(&args).await {

--- a/crates/harn-vm/src/llm_config.rs
+++ b/crates/harn-vm/src/llm_config.rs
@@ -1629,6 +1629,13 @@ fn default_config() -> ProvidersConfig {
 }
 
 #[cfg(test)]
+fn merge_global_config(overlay: ProvidersConfig) -> ProvidersConfig {
+    let mut config = default_config();
+    config.merge_from(&overlay);
+    config
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
 
@@ -1758,6 +1765,29 @@ mod tests {
         assert!(names.contains(&"bedrock".to_string()));
         assert!(names.contains(&"azure_openai".to_string()));
         assert!(names.contains(&"vertex".to_string()));
+    }
+
+    #[test]
+    fn global_provider_file_is_an_overlay_on_builtin_defaults() {
+        let mut overlay = ProvidersConfig {
+            default_provider: Some("ollama".to_string()),
+            ..Default::default()
+        };
+        overlay.aliases.insert(
+            "quickstart".to_string(),
+            AliasDef {
+                id: "llama3.2".to_string(),
+                provider: "ollama".to_string(),
+                tool_format: None,
+            },
+        );
+
+        let merged = merge_global_config(overlay);
+
+        assert_eq!(merged.default_provider.as_deref(), Some("ollama"));
+        assert!(merged.providers.contains_key("anthropic"));
+        assert!(merged.providers.contains_key("ollama"));
+        assert_eq!(merged.aliases["quickstart"].id, "llama3.2");
     }
 
     #[test]

--- a/docs/src/builtins.md
+++ b/docs/src/builtins.md
@@ -1577,8 +1577,9 @@ are configured via a TOML file. The VM searches for config in this order:
 3. Installed package `[llm]` tables in `.harn/packages/*/harn.toml`
 4. The nearest project `harn.toml` `[llm]` table
 
-The `[llm]` section uses the same schema as `providers.toml`, so project and
-package manifests can ship provider adapters declaratively:
+The files in steps 2-4 are overlays on the built-in defaults. The `[llm]`
+section uses the same schema as `providers.toml`, so project and package
+manifests can ship provider adapters declaratively:
 
 ```toml
 [llm.providers.anthropic]

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -501,6 +501,26 @@ harn new package my-lib
 the default quick-start flow and `new` when you want the template choice to be
 explicit.
 
+## harn quickstart
+
+Inspect local provider readiness and write starter LLM configuration.
+
+```bash
+harn quickstart
+harn quickstart --non-interactive
+harn quickstart --non-interactive --provider ollama --model llama3.2
+```
+
+Quickstart reports existing provider credentials, Ollama reachability, free disk
+space, and GPU detection. It creates or updates:
+
+- `~/.config/harn/providers.toml` or `HARN_PROVIDERS_CONFIG` when set
+- `harn.toml` in the current directory
+- `.env` in the current directory
+
+Run `source .env` before invoking Harn if you want the shell to use the selected
+provider/model defaults.
+
 ## harn doctor
 
 Inspect the local environment and report the current Harn setup,

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -81,7 +81,22 @@ user's request when Harn is used as an agent backend.
 
 ## Calling an LLM
 
-Harn has native LLM support. Set your API key and call a model directly:
+Harn has native LLM support. Run quickstart to inspect available provider
+credentials, local Ollama status, disk space, and GPU availability, then write
+starter `harn.toml`, `providers.toml`, and `.env` files:
+
+```bash
+harn quickstart
+source .env
+```
+
+For CI or scripts, use deterministic defaults:
+
+```bash
+harn quickstart --non-interactive --provider ollama --model llama3.2
+```
+
+You can also set an API key yourself and call a model directly:
 
 ```bash
 export ANTHROPIC_API_KEY=sk-ant-...
@@ -132,6 +147,8 @@ Scaffold a new project with `harn init` or pick a starter with `harn new`:
 ```bash
 harn new my-agent --template agent
 cd my-agent
+harn quickstart --non-interactive
+source .env
 harn doctor --no-network
 ```
 

--- a/docs/src/llm/providers.md
+++ b/docs/src/llm/providers.md
@@ -7,6 +7,10 @@ HuggingFace, Bedrock, Azure OpenAI, Vertex AI, and local OpenAI-compatible
 servers. Set the appropriate environment variable to authenticate or point
 Harn at an endpoint:
 
+Run `harn quickstart` to detect existing credentials, local Ollama, free disk
+space, and GPU availability, then write starter `providers.toml`, `harn.toml`,
+and `.env` files.
+
 For model-specific feature support, see the generated
 [provider capability matrix](../provider-matrix.md).
 
@@ -193,8 +197,10 @@ Load order is:
 3. installed package `[llm]` tables from `.harn/packages/*/harn.toml`
 4. the root project's `[llm]` table
 
-That gives packages a stable, declarative way to ship provider adapters
-and model aliases without editing Rust-side registration code.
+The provider files in steps 2-4 are overlays, so a starter file can set
+`default_provider` or aliases without copying every built-in provider
+definition. That gives packages a stable, declarative way to ship provider
+adapters and model aliases without editing Rust-side registration code.
 
 ## Provider API details
 


### PR DESCRIPTION
## Summary

- Add `harn quickstart` with interactive and `--non-interactive` setup flows.
- Detect provider credentials, Ollama reachability, disk space, and local GPU availability.
- Write starter provider overlay, project `[llm]` config, and `.env` defaults without overwriting existing keys.
- Treat global `providers.toml` as an overlay on built-in provider definitions so quickstart can write a compact starter file.

Closes #1331.

## Validation

- `cargo test -p harn-cli quickstart --lib`
- `cargo test -p harn-vm global_provider_file_is_an_overlay_on_builtin_defaults --lib`
- `cargo fmt --check`
- `cargo build --bin harn`
- throwaway HOME/project smoke: `harn quickstart --non-interactive --provider ollama --model llama3.2`
- throwaway HOME/project smoke: `harn provider-catalog --available-only` after generated provider overlay
- pre-commit hook: Rust fmt, workspace clippy, markdown lint
- pre-push hook: targeted local checks, markdown lint, changelog retroactive check
