### PR TITLE
Add chat project template

### DIFF
--- a/crates/harn-cli/src/cli/init.rs
+++ b/crates/harn-cli/src/cli/init.rs
@@ -13,6 +13,7 @@ pub(crate) struct InitArgs {
 pub(crate) enum ProjectTemplate {
     Basic,
     Agent,
+    Chat,
     #[value(name = "mcp-server")]
     McpServer,
     Eval,

--- a/crates/harn-cli/src/cli/tests.rs
+++ b/crates/harn-cli/src/cli/tests.rs
@@ -1348,6 +1348,17 @@ fn test_parses_pipeline_lab_template() {
 }
 
 #[test]
+fn test_parses_chat_template() {
+    let cli = Cli::parse_from(["harn", "new", "chat-demo", "--template", "chat"]);
+
+    let Command::New(args) = cli.command.unwrap() else {
+        panic!("expected new command");
+    };
+    assert_eq!(args.first.as_deref(), Some("chat-demo"));
+    assert_eq!(args.template, Some(ProjectTemplate::Chat));
+}
+
+#[test]
 fn test_parses_playground_args() {
     let cli = Cli::parse_from([
         "harn",

--- a/crates/harn-cli/src/commands/init.rs
+++ b/crates/harn-cli/src/commands/init.rs
@@ -65,6 +65,9 @@ pub(crate) fn init_project(name: Option<&str>, template: ProjectTemplate) {
             println!("  harn run main.harn       # run the program");
             println!("  harn test tests/         # run the tests");
         }
+        ProjectTemplate::Chat => {
+            println!("  harn run main.harn       # run the program");
+        }
         ProjectTemplate::McpServer => {
             println!("  harn serve mcp main.harn # expose the starter MCP server");
         }
@@ -200,6 +203,104 @@ pipeline test_add(task) {
 }
 "###
                 .to_string(),
+            ),
+        ],
+        ProjectTemplate::Chat => vec![
+            (
+                "harn.toml",
+                format!(
+                    r#"[package]
+name = "{project_name}"
+version = "0.1.0"
+
+[dependencies]
+
+[llm.aliases]
+chat = {{ id = "llama3.2", provider = "ollama" }}
+"#
+                ),
+            ),
+            (
+                "main.harn",
+                r#"fn build_chat_prompt(history, message) {
+  if history == "" {
+    return "User: " + message
+  }
+  return history + "\nUser: " + message
+}
+
+fn stream_reply(prompt, system, options) {
+  var answer = ""
+  let chunks = llm_stream_call(prompt, system, options)
+  for chunk in chunks {
+    print(chunk.visible_delta)
+    answer = chunk.partial
+  }
+  println("")
+  return answer
+}
+
+pipeline default(task) {
+  let system = env_or("HARN_CHAT_SYSTEM", "You are a concise, helpful assistant.")
+  let model = env_or("HARN_CHAT_MODEL", "chat")
+  let options = {model: model, max_tokens: 2048, temperature: 0.7}
+  var history = ""
+  println("Harn chat. Type /clear to reset history or /exit to quit.")
+  while true {
+    print("you> ")
+    let raw = read_line()
+    if raw == nil {
+      break
+    }
+    let message = trim(raw)
+    if message == "" {
+      continue
+    }
+    if message == "/exit" || message == "/quit" {
+      break
+    }
+    if message == "/clear" {
+      history = ""
+      println("history cleared")
+      continue
+    }
+    let prompt = build_chat_prompt(history, message)
+    print("assistant> ")
+    let answer = stream_reply(prompt, system, options)
+    history = prompt + "\nAssistant: " + answer + "\n"
+  }
+}
+"#
+                .to_string(),
+            ),
+            (
+                "README.md",
+                format!(
+                    r#"# {project_name}
+
+Streaming chat starter for Harn.
+
+## Provider
+
+`harn.toml` defines a `chat` model alias backed by Ollama's `llama3.2` model:
+
+```toml
+[llm.aliases]
+chat = {{ id = "llama3.2", provider = "ollama" }}
+```
+
+Edit that alias to use any configured provider, or set `HARN_CHAT_MODEL` when
+running the project.
+
+## Run
+
+```bash
+harn run main.harn
+```
+
+Inside the chat loop, type `/clear` to reset local history and `/exit` to quit.
+"#
+                ),
             ),
         ],
         ProjectTemplate::McpServer => vec![
@@ -683,6 +784,10 @@ mod tests {
         let mcp = template_files("sample", ProjectTemplate::McpServer);
         assert!(mcp.iter().any(|(path, _)| *path == "main.harn"));
 
+        let chat = template_files("sample", ProjectTemplate::Chat);
+        assert!(chat.iter().any(|(path, _)| *path == "main.harn"));
+        assert!(chat.iter().any(|(path, _)| *path == "README.md"));
+
         let eval = template_files("sample", ProjectTemplate::Eval);
         assert!(eval.iter().any(|(path, _)| *path == "eval-suite.json"));
 
@@ -702,6 +807,22 @@ mod tests {
         assert!(connector
             .iter()
             .any(|(path, _)| *path == "connectors/echo.harn"));
+    }
+
+    #[test]
+    fn chat_template_wires_streaming_loop_to_configured_alias() {
+        let files = template_files("sample", ProjectTemplate::Chat);
+        let content = |path: &str| {
+            files
+                .iter()
+                .find_map(|(candidate, content)| (*candidate == path).then_some(content.as_str()))
+                .unwrap_or_else(|| panic!("missing {path}"))
+        };
+
+        assert!(content("main.harn").contains("llm_stream_call(prompt, system, options)"));
+        assert!(content("main.harn").contains("read_line()"));
+        assert!(content("harn.toml").contains(r#"chat = { id = "llama3.2", provider = "ollama" }"#));
+        toml::from_str::<toml::Value>(content("harn.toml")).expect("chat manifest is valid TOML");
     }
 
     #[test]

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -455,12 +455,15 @@ harn init --template eval
 ## harn new
 
 Scaffold a new project from a starter template. Supported templates are
-`basic`, `agent`, `mcp-server`, and `eval`.
+`basic`, `agent`, `chat`, `mcp-server`, `eval`, `pipeline-lab`, `package`, and
+`connector`.
 
 ```bash
 harn new my-agent --template agent
+harn new my-chat --template chat
 harn new local-mcp --template mcp-server
 harn new eval-suite --template eval
+harn new package my-lib
 ```
 
 `harn init` and `harn new` share the same scaffolding engine. Use `init` for

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -115,6 +115,18 @@ for the selected template. Run it with:
 harn run main.harn
 ```
 
+For a streaming local chat loop, use the chat starter:
+
+```bash
+harn new my-chat --template chat
+cd my-chat
+harn run main.harn
+```
+
+The generated `harn.toml` points the `chat` model alias at Ollama by default.
+Edit the alias or set `HARN_CHAT_MODEL` to use another configured provider.
+See [LLM providers](./llm/providers.md) for provider setup.
+
 ## Remote MCP quick start
 
 If you want to use a cloud MCP server such as Notion, authorize it once with


### PR DESCRIPTION
## Summary

- Add `chat` as a `harn new --template` starter.
- Scaffold a streaming `llm_stream_call` REPL loop with `harn.toml` model alias wiring and README guidance.
- Cross-link the chat starter from getting started docs and refresh the CLI template list.

Closes #1332.

## Verification

- `CARGO_TARGET_DIR=/tmp/harn-target-099b-1332 cargo test -p harn-cli --lib commands::init::tests`
- `CARGO_TARGET_DIR=/tmp/harn-target-099b-1332 cargo test -p harn-cli --lib test_parses_chat_template`
- `CARGO_TARGET_DIR=/tmp/harn-target-099b-1332 cargo clippy -p harn-cli --lib -- -D warnings`
- `npx markdownlint-cli2 docs/src/getting-started.md docs/src/cli-reference.md`
- `CARGO_TARGET_DIR=/tmp/harn-target-099b-1332 make check-docs-snippets`
- Scaffold smoke: `harn new /tmp/.../my-chat --template chat`, then `harn check main.harn`, `harn fmt --check main.harn`, `harn lint main.harn`
- Mock chat smoke: `printf 'hello\n/exit\n' | HARN_LLM_PROVIDER=mock HARN_CHAT_MODEL=mock harn run main.harn`
- Pre-commit hook: Rust fmt, clippy workspace/all-targets, markdown lint
- Pre-push hook: targeted local checks and markdown lint