### PR TITLE
Add shell completion generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -606,6 +606,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "660c0520455b1013b9bcb0393d5f643d7e4454fb69c915b8d6d2aa0e9a45acc3"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1703,6 +1712,7 @@ dependencies = [
  "base64",
  "chrono-tz",
  "clap",
+ "clap_complete",
  "croner",
  "ed25519-dalek",
  "fs2",

--- a/README.md
+++ b/README.md
@@ -35,6 +35,20 @@ cd harn
 cargo install --path crates/harn-cli
 ```
 
+Shell completions:
+
+```bash
+mkdir -p ~/.local/share/bash-completion/completions
+harn completions bash > ~/.local/share/bash-completion/completions/harn
+
+mkdir -p ~/.zfunc
+harn completions zsh > ~/.zfunc/_harn
+# Add to ~/.zshrc if needed: fpath=(~/.zfunc $fpath); autoload -Uz compinit; compinit
+
+mkdir -p ~/.config/fish/completions
+harn completions fish > ~/.config/fish/completions/harn.fish
+```
+
 Container image:
 
 ```bash

--- a/crates/harn-cli/Cargo.toml
+++ b/crates/harn-cli/Cargo.toml
@@ -62,7 +62,8 @@ rand = "0.10"
 regex = "1"
 jsonschema = { version = "0.46.3", default-features = false }
 jsonwebtoken = { version = "9", default-features = false, features = ["use_pem"] }
-clap = { version = "4", features = ["derive", "env"] }
+clap = { version = "4", features = ["derive", "env", "string"] }
+clap_complete = "4"
 tower = { version = "0.5", features = ["util"] }
 time = { version = "0.3", features = ["formatting", "parsing"] }
 tempfile = "3"

--- a/crates/harn-cli/src/cli/completions.rs
+++ b/crates/harn-cli/src/cli/completions.rs
@@ -1,0 +1,25 @@
+use clap::{Args, ValueEnum};
+
+#[derive(Debug, Args)]
+pub(crate) struct CompletionsArgs {
+    /// Shell to generate completions for.
+    #[arg(value_enum)]
+    pub shell: CompletionShell,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub(crate) enum CompletionShell {
+    Bash,
+    Zsh,
+    Fish,
+}
+
+impl From<CompletionShell> for clap_complete::Shell {
+    fn from(shell: CompletionShell) -> Self {
+        match shell {
+            CompletionShell::Bash => Self::Bash,
+            CompletionShell::Zsh => Self::Zsh,
+            CompletionShell::Fish => Self::Fish,
+        }
+    }
+}

--- a/crates/harn-cli/src/cli/connector.rs
+++ b/crates/harn-cli/src/cli/connector.rs
@@ -1,5 +1,7 @@
 use clap::{Args, Subcommand};
 
+use super::util::trigger_provider_completion_parser;
+
 #[derive(Debug, Args)]
 pub(crate) struct ConnectorArgs {
     #[command(subcommand)]
@@ -19,7 +21,12 @@ pub(crate) struct ConnectorCheckArgs {
     /// Package directory, harn.toml, or file under the package to check.
     pub package: String,
     /// Restrict the check to one provider id. Repeatable.
-    #[arg(long = "provider", value_name = "ID")]
+    #[arg(
+        long = "provider",
+        value_name = "ID",
+        value_parser = trigger_provider_completion_parser(),
+        hide_possible_values = true
+    )]
     pub providers: Vec<String>,
     /// Run poll bindings long enough to execute the first poll_tick.
     #[arg(long = "run-poll-tick")]
@@ -35,7 +42,12 @@ pub(crate) struct ConnectorTestArgs {
     #[arg(default_value = ".")]
     pub package: String,
     /// Restrict the gate to one provider id. Repeatable.
-    #[arg(long = "provider", value_name = "ID")]
+    #[arg(
+        long = "provider",
+        value_name = "ID",
+        value_parser = trigger_provider_completion_parser(),
+        hide_possible_values = true
+    )]
     pub providers: Vec<String>,
     /// Run poll bindings long enough to execute the first poll_tick.
     #[arg(long = "run-poll-tick")]

--- a/crates/harn-cli/src/cli/mod.rs
+++ b/crates/harn-cli/src/cli/mod.rs
@@ -12,6 +12,7 @@
 
 mod bench;
 mod check;
+mod completions;
 mod connect;
 mod connector;
 mod contracts;
@@ -46,6 +47,7 @@ mod watch;
 
 pub(crate) use bench::BenchArgs;
 pub(crate) use check::{CheckArgs, CheckOutputFormat};
+pub(crate) use completions::{CompletionShell, CompletionsArgs};
 pub(crate) use connect::{
     ConnectArgs, ConnectCommand, ConnectGenericArgs, ConnectGithubArgs, ConnectLinearArgs,
     ConnectOAuthArgs,
@@ -228,6 +230,8 @@ SCRIPTING
     TrustGraph(TrustArgs),
     /// Verify a signed Harn provenance receipt.
     Verify(VerifyArgs),
+    /// Print shell completion script to stdout.
+    Completions(CompletionsArgs),
     /// Start the orchestrator process that hosts triggers and connector dispatch.
     Orchestrator(OrchestratorArgs),
     /// Run a pipeline against a Harn-native host module for fast iteration.

--- a/crates/harn-cli/src/cli/persona.rs
+++ b/crates/harn-cli/src/cli/persona.rs
@@ -2,6 +2,8 @@ use std::path::PathBuf;
 
 use clap::{Args, Subcommand, ValueEnum};
 
+use super::util::trigger_provider_completion_parser;
+
 #[derive(Debug, Args)]
 pub(crate) struct PersonaArgs {
     #[command(subcommand)]
@@ -168,7 +170,11 @@ pub(crate) struct PersonaTriggerArgs {
     /// Persona name to wake from an external trigger.
     pub name: String,
     /// Provider name, for example github, linear, slack, or webhook.
-    #[arg(long)]
+    #[arg(
+        long,
+        value_parser = trigger_provider_completion_parser(),
+        hide_possible_values = true
+    )]
     pub provider: String,
     /// Provider event kind, for example pull_request, check_run, issue, or message.
     #[arg(long)]

--- a/crates/harn-cli/src/cli/provider.rs
+++ b/crates/harn-cli/src/cli/provider.rs
@@ -1,5 +1,7 @@
 use clap::{ArgAction, Args};
 
+use super::util::{llm_model_completion_parser, llm_provider_completion_parser};
+
 #[derive(Debug, Args)]
 pub(crate) struct ModelInfoArgs {
     /// Verify provider-local readiness for the resolved model when supported.
@@ -12,6 +14,10 @@ pub(crate) struct ModelInfoArgs {
     #[arg(long = "keep-alive", value_name = "VALUE")]
     pub keep_alive: Option<String>,
     /// Model alias or provider-native model id.
+    #[arg(
+        value_parser = llm_model_completion_parser(),
+        hide_possible_values = true
+    )]
     pub model: String,
 }
 
@@ -25,9 +31,17 @@ pub(crate) struct ProviderCatalogArgs {
 #[derive(Debug, Args)]
 pub(crate) struct ProviderReadyArgs {
     /// Provider id from Harn provider config, for example mlx or local.
+    #[arg(
+        value_parser = llm_provider_completion_parser(),
+        hide_possible_values = true
+    )]
     pub provider: String,
     /// Model alias or provider-native model id to require in /models.
-    #[arg(long)]
+    #[arg(
+        long,
+        value_parser = llm_model_completion_parser(),
+        hide_possible_values = true
+    )]
     pub model: Option<String>,
     /// Override the configured provider base URL for this probe.
     #[arg(long = "base-url")]

--- a/crates/harn-cli/src/cli/tests.rs
+++ b/crates/harn-cli/src/cli/tests.rs
@@ -2,14 +2,14 @@ use std::path::PathBuf;
 use std::time::Duration as StdDuration;
 
 use super::{
-    CheckOutputFormat, Cli, Command, ConnectCommand, ConnectorCommand, CrystallizeCommand,
-    FlowArchivistCommand, FlowCommand, McpCommand, OrchestratorCommand, OrchestratorDeployProvider,
-    OrchestratorLogFormat, OrchestratorQueueCommand, OrchestratorTenantCommand,
-    PackageCacheCommand, PackageCommand, PersonaCommand, ProjectTemplate, RunsCommand,
-    SkillCommand, SkillKeyCommand, SkillTrustCommand, SkillsCommand, TraceCommand, TriggerCommand,
-    TrustCommand, TrustOutcomeArg, TrustTierArg,
+    CheckOutputFormat, Cli, Command, CompletionShell, ConnectCommand, ConnectorCommand,
+    CrystallizeCommand, FlowArchivistCommand, FlowCommand, McpCommand, OrchestratorCommand,
+    OrchestratorDeployProvider, OrchestratorLogFormat, OrchestratorQueueCommand,
+    OrchestratorTenantCommand, PackageCacheCommand, PackageCommand, PersonaCommand,
+    ProjectTemplate, RunsCommand, SkillCommand, SkillKeyCommand, SkillTrustCommand, SkillsCommand,
+    TraceCommand, TriggerCommand, TrustCommand, TrustOutcomeArg, TrustTierArg,
 };
-use clap::Parser;
+use clap::{CommandFactory, Parser};
 
 #[test]
 fn test_parses_conformance_target_selection() {
@@ -1786,6 +1786,72 @@ fn test_parses_provider_ready_args() {
     assert_eq!(args.model.as_deref(), Some("mlx-qwen36-27b"));
     assert_eq!(args.base_url.as_deref(), Some("http://127.0.0.1:8002"));
     assert!(args.json);
+}
+
+#[test]
+fn test_parses_completions_args() {
+    let cli = Cli::parse_from(["harn", "completions", "zsh"]);
+
+    let Command::Completions(args) = cli.command.unwrap() else {
+        panic!("expected completions command");
+    };
+    assert_eq!(args.shell, CompletionShell::Zsh);
+}
+
+#[test]
+fn test_provider_model_completion_candidates_stay_permissive() {
+    let cli = Cli::parse_from([
+        "harn",
+        "provider-ready",
+        "custom-provider",
+        "--model",
+        "vendor/custom-model",
+    ]);
+    let Command::ProviderReady(args) = cli.command.unwrap() else {
+        panic!("expected provider-ready command");
+    };
+    assert_eq!(args.provider, "custom-provider");
+    assert_eq!(args.model.as_deref(), Some("vendor/custom-model"));
+
+    let command = Cli::command();
+    let provider_ready = command
+        .find_subcommand("provider-ready")
+        .expect("provider-ready subcommand");
+    let provider_values: Vec<_> = provider_ready
+        .get_arguments()
+        .find(|arg| arg.get_id() == "provider")
+        .expect("provider argument")
+        .get_possible_values()
+        .into_iter()
+        .map(|value| value.get_name().to_string())
+        .collect();
+    assert!(provider_values.iter().any(|value| value == "openai"));
+
+    let model_values: Vec<_> = provider_ready
+        .get_arguments()
+        .find(|arg| arg.get_id() == "model")
+        .expect("model argument")
+        .get_possible_values()
+        .into_iter()
+        .map(|value| value.get_name().to_string())
+        .collect();
+    assert!(model_values.iter().any(|value| value == "gpt-4o-mini"));
+}
+
+#[test]
+fn test_completion_scripts_include_subcommands() {
+    let mut command = Cli::command();
+    let mut output = Vec::new();
+    clap_complete::generate(
+        clap_complete::Shell::Bash,
+        &mut command,
+        "harn",
+        &mut output,
+    );
+    let script = String::from_utf8(output).expect("completion script should be utf-8");
+
+    assert!(script.contains("completions"));
+    assert!(script.contains("provider-ready"));
 }
 
 #[test]

--- a/crates/harn-cli/src/cli/util.rs
+++ b/crates/harn-cli/src/cli/util.rs
@@ -1,4 +1,72 @@
+use std::collections::BTreeSet;
+use std::ffi::OsStr;
 use std::time::Duration as StdDuration;
+
+use clap::builder::{PossibleValue, StringValueParser, TypedValueParser};
+
+#[derive(Clone)]
+pub(crate) struct CompletionValueParser {
+    candidates: fn() -> Vec<String>,
+}
+
+impl CompletionValueParser {
+    fn new(candidates: fn() -> Vec<String>) -> Self {
+        Self { candidates }
+    }
+}
+
+impl TypedValueParser for CompletionValueParser {
+    type Value = String;
+
+    fn parse_ref(
+        &self,
+        cmd: &clap::Command,
+        arg: Option<&clap::Arg>,
+        value: &OsStr,
+    ) -> Result<Self::Value, clap::Error> {
+        StringValueParser::new().parse_ref(cmd, arg, value)
+    }
+
+    fn possible_values(&self) -> Option<Box<dyn Iterator<Item = PossibleValue> + '_>> {
+        let values = (self.candidates)().into_iter().map(PossibleValue::new);
+        Some(Box::new(values))
+    }
+}
+
+pub(crate) fn llm_provider_completion_parser() -> CompletionValueParser {
+    CompletionValueParser::new(llm_provider_candidates)
+}
+
+pub(crate) fn llm_model_completion_parser() -> CompletionValueParser {
+    CompletionValueParser::new(llm_model_candidates)
+}
+
+pub(crate) fn trigger_provider_completion_parser() -> CompletionValueParser {
+    CompletionValueParser::new(trigger_provider_candidates)
+}
+
+fn llm_provider_candidates() -> Vec<String> {
+    harn_vm::llm_config::provider_names()
+}
+
+fn llm_model_candidates() -> Vec<String> {
+    let mut candidates: BTreeSet<String> = harn_vm::llm_config::known_model_names()
+        .into_iter()
+        .collect();
+    candidates.extend(
+        harn_vm::llm_config::model_catalog_entries()
+            .into_iter()
+            .map(|(id, _model)| id),
+    );
+    candidates.into_iter().collect()
+}
+
+fn trigger_provider_candidates() -> Vec<String> {
+    harn_vm::registered_provider_metadata()
+        .into_iter()
+        .map(|metadata| metadata.provider)
+        .collect()
+}
 
 pub(crate) fn parse_duration_arg(raw: &str) -> Result<StdDuration, String> {
     let raw = raw.trim();

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -19,9 +19,9 @@ use std::sync::Arc;
 use std::{env, fs, process, thread};
 
 use cli::{
-    Cli, Command, MergeCaptainCommand, MergeCaptainMockCommand, ModelInfoArgs, PackageCacheCommand,
-    PackageCommand, PersonaCommand, RunsCommand, ServeCommand, SkillCommand, SkillKeyCommand,
-    SkillTrustCommand, SkillsCommand,
+    Cli, Command, CompletionShell, MergeCaptainCommand, MergeCaptainMockCommand, ModelInfoArgs,
+    PackageCacheCommand, PackageCommand, PersonaCommand, RunsCommand, ServeCommand, SkillCommand,
+    SkillKeyCommand, SkillTrustCommand, SkillsCommand,
 };
 use harn_lexer::Lexer;
 use harn_parser::{DiagnosticSeverity, Parser, TypeChecker};
@@ -636,6 +636,7 @@ async fn async_main() {
                 process::exit(1);
             }
         }
+        Command::Completions(args) => print_completions(args.shell),
         Command::Orchestrator(args) => {
             if let Err(error) = commands::orchestrator::handle(args).await {
                 eprintln!("error: {error}");
@@ -929,6 +930,12 @@ async fn async_main() {
             commands::check::connector_matrix::run_docs(&args.output, &args.sources, args.check);
         }
     }
+}
+
+fn print_completions(shell: CompletionShell) {
+    let mut command = Cli::command();
+    let shell = clap_complete::Shell::from(shell);
+    clap_complete::generate(shell, &mut command, "harn", &mut std::io::stdout());
 }
 
 fn normalize_serve_args(mut raw_args: Vec<String>) -> Vec<String> {

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -58,6 +58,19 @@ Verification recomputes the EventLog record chain, the receipt event root, the
 receipt hash, and the Ed25519 signature. It exits non-zero if any receipt event
 or signature material has been changed.
 
+## harn completions
+
+Print shell completion scripts.
+
+```bash
+harn completions bash
+harn completions zsh
+harn completions fish
+```
+
+Generated completions include subcommands plus static candidates for known
+provider and model values.
+
 ## harn playground
 
 Run a pipeline against a Harn-native host module for fast local iteration.

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -32,6 +32,20 @@ Verify the installation:
 harn version
 ```
 
+Optional shell completions:
+
+```bash
+mkdir -p ~/.local/share/bash-completion/completions
+harn completions bash > ~/.local/share/bash-completion/completions/harn
+
+mkdir -p ~/.zfunc
+harn completions zsh > ~/.zfunc/_harn
+# Add to ~/.zshrc if needed: fpath=(~/.zfunc $fpath); autoload -Uz compinit; compinit
+
+mkdir -p ~/.config/fish/completions
+harn completions fish > ~/.config/fish/completions/harn.fish
+```
+
 ## Your first program
 
 Create a file called `hello.harn`:


### PR DESCRIPTION
## Summary
- add `harn completions <bash|zsh|fish>` using `clap_complete`
- advertise known provider/model candidates to completions while keeping custom strings valid
- document completion install paths in README, getting started, and CLI reference

Closes #1334

## Verification
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-1334 cargo test -p harn-cli --lib`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-1334 cargo clippy -p harn-cli --all-targets -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-1334 make check-docs-snippets`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-1334 cargo run -p harn-cli --quiet -- completions bash | rg 'provider-ready|completions|gpt-4o-mini|openai'`\n- `CARGO_TARGET_DIR=/tmp/harn-target-issue-1334 cargo run -p harn-cli --quiet -- completions zsh | rg 'provider-ready|completions|gpt-4o-mini|openai'`\n- `CARGO_TARGET_DIR=/tmp/harn-target-issue-1334 cargo run -p harn-cli --quiet -- completions fish | rg 'provider-ready|completions|gpt-4o-mini|openai'`\n- pre-commit hook\n- pre-push hook