### PR TITLE
[codex] Rename std async predicate retry helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,13 @@ agent_loop(task, sys, {
   non-interactive setup flow that detects provider credentials, local Ollama,
   free disk space, and local GPU availability, then writes starter
   `providers.toml`, `harn.toml`, and `.env` files.
+## Unreleased
+
+### Changed
+
+- **`std/async` predicate retry rename.** Renamed `retry_with_backoff` to
+  `retry_predicate_with_backoff` and removed the old export, with lint autofix
+  support for stale call sites.
 
 ## v0.7.61
 

--- a/conformance/tests/stdlib/stdlib_async_retry_predicate.expected
+++ b/conformance/tests/stdlib/stdlib_async_retry_predicate.expected
@@ -1,0 +1,4 @@
+true
+ready
+false
+exhausted

--- a/conformance/tests/stdlib/stdlib_async_retry_predicate.harn
+++ b/conformance/tests/stdlib/stdlib_async_retry_predicate.harn
@@ -1,0 +1,10 @@
+import { retry_predicate_with_backoff } from "std/async"
+
+pipeline default() {
+  let ok = retry_predicate_with_backoff(1, 0, fn() { return "ready" })
+  let exhausted = retry_predicate_with_backoff(2, 0, fn() { return false })
+  println(is_ok(ok))
+  println(unwrap(ok))
+  println(is_ok(exhausted))
+  println(unwrap_err(exhausted))
+}

--- a/conformance/tests/stdlib/stdlib_async_retry_with_backoff_removed.error
+++ b/conformance/tests/stdlib/stdlib_async_retry_with_backoff_removed.error
@@ -1,0 +1,1 @@
+did you mean `retry_predicate_with_backoff`

--- a/conformance/tests/stdlib/stdlib_async_retry_with_backoff_removed.harn
+++ b/conformance/tests/stdlib/stdlib_async_retry_with_backoff_removed.harn
@@ -1,0 +1,5 @@
+import { retry_with_backoff } from "std/async"
+
+pipeline default() {
+  retry_with_backoff(1, 0, fn() { return true })
+}

--- a/crates/harn-lint/src/fixes.rs
+++ b/crates/harn-lint/src/fixes.rs
@@ -61,6 +61,39 @@ pub(crate) fn simple_ident_rename_fix(
     }])
 }
 
+/// Replace the first identifier occurrence of `old` inside `span`.
+pub(crate) fn replace_identifier_text_fix(
+    source: Option<&str>,
+    span: Span,
+    old: &str,
+    new: &str,
+) -> Option<Vec<FixEdit>> {
+    let src = source?;
+    let region = src.get(span.start..span.end)?;
+    let offset = find_identifier_offset(region, old)?;
+    let start = span.start + offset;
+    Some(vec![FixEdit {
+        span: Span::with_offsets(start, start + old.len(), span.line, span.column + offset),
+        replacement: new.to_string(),
+    }])
+}
+
+fn find_identifier_offset(region: &str, name: &str) -> Option<usize> {
+    region.match_indices(name).find_map(|(offset, _)| {
+        let before_ok = offset == 0
+            || !region
+                .as_bytes()
+                .get(offset.wrapping_sub(1))
+                .is_some_and(|byte| is_ident_byte(*byte));
+        let end = offset + name.len();
+        let after_ok = region
+            .as_bytes()
+            .get(end)
+            .is_none_or(|byte| !is_ident_byte(*byte));
+        (before_ok && after_ok).then_some(offset)
+    })
+}
+
 /// Replace an unnecessary conversion call (e.g. `to_string("hi")`) with
 /// the inner expression's source text. The outer call's span is replaced
 /// verbatim with the inner span's source slice, so formatting and any

--- a/crates/harn-lint/src/linter.rs
+++ b/crates/harn-lint/src/linter.rs
@@ -6,14 +6,15 @@
 use std::collections::{HashMap, HashSet};
 
 use harn_lexer::{FixEdit, Span};
-use harn_parser::diagnostic::find_closest_match;
+use harn_parser::diagnostic::{find_closest_match, renamed_stdlib_symbol};
 use harn_parser::{BindingPattern, Node, SNode, TypeExpr, TypedParam};
 
 use crate::complexity::cyclomatic_complexity;
 use crate::decls::{Declaration, FnDeclaration, ImportInfo, ParamDeclaration, TypeDeclaration};
 use crate::diagnostic::{LintDiagnostic, LintSeverity, DEFAULT_COMPLEXITY_THRESHOLD};
 use crate::fixes::{
-    append_sink_fix, is_pure_expression, remove_method_call_wrapper_fix, simple_ident_rename_fix,
+    append_sink_fix, is_pure_expression, remove_method_call_wrapper_fix,
+    replace_identifier_text_fix, simple_ident_rename_fix,
 };
 use crate::harndoc::check_legacy_doc_comments;
 use crate::naming::{is_pascal_case, is_snake_case, to_pascal_case, to_snake_case};
@@ -180,6 +181,20 @@ impl<'a> Linter<'a> {
 
     pub(super) fn is_approval_record_builtin(name: &str) -> bool {
         name == "request_approval"
+    }
+
+    pub(super) fn check_renamed_stdlib_symbol(&mut self, name: &str, span: Span) {
+        let Some(replacement) = renamed_stdlib_symbol(name) else {
+            return;
+        };
+        self.diagnostics.push(LintDiagnostic {
+            rule: "renamed-stdlib-symbol",
+            message: format!("`{name}` was renamed to `{replacement}`"),
+            span,
+            severity: LintSeverity::Warning,
+            suggestion: Some(format!("replace `{name}` with `{replacement}`")),
+            fix: replace_identifier_text_fix(self.source, span, name, replacement),
+        });
     }
 
     /// Score the body of a function/tool and emit a

--- a/crates/harn-lint/src/linter/walk.rs
+++ b/crates/harn-lint/src/linter/walk.rs
@@ -270,11 +270,13 @@ impl<'a> Linter<'a> {
             }
 
             Node::Identifier(name) => {
+                self.check_renamed_stdlib_symbol(name, snode.span);
                 self.references.insert(name.clone());
                 self.function_references.insert(name.clone());
             }
 
             Node::FunctionCall { name, args, .. } => {
+                self.check_renamed_stdlib_symbol(name, snode.span);
                 self.references.insert(name.clone());
                 self.function_references.insert(name.clone());
                 self.function_calls.push((name.clone(), snode.span));
@@ -1081,6 +1083,7 @@ impl<'a> Linter<'a> {
             }
             Node::SelectiveImport { names, is_pub, .. } => {
                 for name in names {
+                    self.check_renamed_stdlib_symbol(name, snode.span);
                     self.known_functions.insert(name.clone());
                 }
                 self.imports.push(ImportInfo {

--- a/crates/harn-lint/src/tests/imports.rs
+++ b/crates/harn-lint/src/tests/imports.rs
@@ -120,3 +120,27 @@ fn test_hostlib_prefix_skips_undefined_function_warning() {
         "hostlib_-prefixed calls should not raise undefined-function, got: {diags:?}"
     );
 }
+
+#[test]
+fn renamed_stdlib_symbol_warns_and_fixes_selective_import_and_call() {
+    let source = "import { retry_with_backoff } from \"std/async\"\n\npipeline default() {\n  retry_with_backoff(1, 0, fn() { return true })\n}\n";
+    let diags = lint_source(source);
+    assert_eq!(
+        count_rule(&diags, "renamed-stdlib-symbol"),
+        2,
+        "expected import and call rename diagnostics, got: {diags:?}"
+    );
+    let fixed = apply_fixes(source, &diags);
+    assert!(
+        fixed.contains("import { retry_predicate_with_backoff } from \"std/async\""),
+        "expected import rename, got: {fixed}"
+    );
+    assert!(
+        fixed.contains("retry_predicate_with_backoff(1, 0"),
+        "expected call rename, got: {fixed}"
+    );
+    assert!(
+        !fixed.contains("retry_with_backoff"),
+        "old name should be fully removed, got: {fixed}"
+    );
+}

--- a/crates/harn-parser/src/diagnostic.rs
+++ b/crates/harn-parser/src/diagnostic.rs
@@ -92,6 +92,14 @@ pub fn find_closest_match<'a>(
         .filter(|c| edit_distance(name, c) <= max_dist && *c != name)
 }
 
+/// Return the replacement for stdlib symbols that were directly renamed.
+pub fn renamed_stdlib_symbol(name: &str) -> Option<&'static str> {
+    match name {
+        "retry_with_backoff" => Some("retry_predicate_with_backoff"),
+        _ => None,
+    }
+}
+
 /// Render a Rust-style diagnostic message.
 ///
 /// Example output:

--- a/crates/harn-parser/src/typechecker/inference/calls.rs
+++ b/crates/harn-parser/src/typechecker/inference/calls.rs
@@ -872,12 +872,16 @@ impl TypeChecker {
                     .chain(scope.all_fn_names())
                     .chain(imported.iter().cloned())
                     .collect();
-                let suggestion = crate::diagnostic::find_closest_match(
-                    name,
-                    candidates.iter().map(|s| s.as_str()),
-                    2,
-                )
-                .map(|c| c.to_string());
+                let suggestion = crate::diagnostic::renamed_stdlib_symbol(name)
+                    .map(str::to_string)
+                    .or_else(|| {
+                        crate::diagnostic::find_closest_match(
+                            name,
+                            candidates.iter().map(|s| s.as_str()),
+                            2,
+                        )
+                        .map(|c| c.to_string())
+                    });
                 // Fold the suggestion into the message so callers that
                 // only surface `diag.message` (like `harn run` / the
                 // conformance runner) still see the "did you mean"

--- a/crates/harn-parser/src/typechecker/tests/strict_types.rs
+++ b/crates/harn-parser/src/typechecker/tests/strict_types.rs
@@ -261,6 +261,24 @@ fn test_cross_module_imported_call_is_allowed() {
 }
 
 #[test]
+fn test_renamed_stdlib_call_suggests_replacement() {
+    let diags = check_source_with_imports(
+        r#"pipeline t(task) { retry_with_backoff(1, 0, fn() { return true }) }"#,
+        &["retry_predicate_with_backoff"],
+    );
+    let errs: Vec<&String> = diags
+        .iter()
+        .filter(|d| d.severity == DiagnosticSeverity::Error)
+        .map(|d| &d.message)
+        .collect();
+    assert!(
+        errs.iter()
+            .any(|m| m.contains("did you mean `retry_predicate_with_backoff`")),
+        "expected renamed stdlib suggestion, got: {errs:?}"
+    );
+}
+
+#[test]
 fn test_cross_module_local_fn_not_flagged() {
     let diags = check_source_with_imports(
         r#"fn local_fn() { 42 }

--- a/crates/harn-stdlib/src/lib.rs
+++ b/crates/harn-stdlib/src/lib.rs
@@ -803,6 +803,22 @@ mod tests {
     }
 
     #[test]
+    fn async_stdlib_exports_predicate_backoff_name_only() {
+        let exports = public_functions_for_module("async")
+            .into_iter()
+            .map(|function| function.name)
+            .collect::<BTreeSet<_>>();
+        assert!(
+            exports.contains("retry_predicate_with_backoff"),
+            "std/async should export retry_predicate_with_backoff"
+        );
+        assert!(
+            !exports.contains("retry_with_backoff"),
+            "std/async should not retain the old retry_with_backoff export"
+        );
+    }
+
+    #[test]
     fn harn_entrypoint_catalog_is_declared_by_stdlib_sources() {
         let modules = entrypoint_modules();
         let entries = modules

--- a/crates/harn-stdlib/src/stdlib/stdlib_async.harn
+++ b/crates/harn-stdlib/src/stdlib/stdlib_async.harn
@@ -44,11 +44,11 @@ pub fn retry_until(max_attempts, predicate) {
   return Err("exhausted")
 }
 
-// retry_with_backoff(max_attempts, base_ms, predicate) -> Result
+// retry_predicate_with_backoff(max_attempts, base_ms, predicate) -> Result
 // Calls predicate() with exponential backoff (base_ms * 2^attempt).
 // Returns Ok(value) on first truthy result, or Err("exhausted").
-/** retry_with_backoff. */
-pub fn retry_with_backoff(max_attempts, base_ms, predicate) {
+/** retry_predicate_with_backoff. */
+pub fn retry_predicate_with_backoff(max_attempts, base_ms, predicate) {
   var attempt = 0
   while attempt < max_attempts {
     let value = predicate()

--- a/docs/src/modules.md
+++ b/docs/src/modules.md
@@ -95,24 +95,36 @@ Harn includes built-in modules that are compiled into the interpreter.
 Import them with the `std/` prefix:
 
 ```harn
-import "std/text"
-import "std/collections"
-import "std/math"
-import "std/path"
-import "std/vision"
-import "std/json"
-import "std/cache"
-import "std/llm/handlers"
-import "std/context"
 import "std/agent_state"
 import "std/agents"
+import "std/async"
+import { retry_predicate_with_backoff } from "std/async"
+import "std/cache"
+import "std/collections"
+import "std/connectors/shared"
+import "std/context"
+import "std/experiments"
+import "std/json"
+import "std/math"
+import "std/monitors"
+import "std/path"
+import "std/personas/prelude"
 import "std/prompt_library"
 import "std/review"
-import "std/experiments"
-import "std/monitors"
-import "std/personas/prelude"
-import "std/connectors/shared"
+import "std/text"
+import "std/vision"
 ```
+
+### std/async
+
+Polling and retry helpers for closure-shaped conditions:
+
+| Function | Description |
+|---|---|
+| `wait_for(timeout_ms, interval_ms, predicate)` | Poll `predicate()` until it returns a truthy value or the timeout expires |
+| `retry_until(max_attempts, predicate)` | Retry `predicate()` without delay until it returns a truthy value or attempts are exhausted |
+| `retry_predicate_with_backoff(max_attempts, base_ms, predicate)` | Retry `predicate()` with exponential backoff between attempts |
+| `circuit_call(name, closure)` | Run `closure()` only while the named circuit breaker allows calls, recording success or failure |
 
 ### std/connectors/shared
 

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -355,6 +355,8 @@ Imports starting with `std/` load embedded stdlib modules:
   parse_float_or)
 - `import "std/collections"` — collection utilities (filter_nil, store_stale,
   store_refresh)
+- `import "std/async"` — polling and retry helpers (wait_for, retry_until,
+  retry_predicate_with_backoff, circuit_call)
 - `import "std/vision"` — deterministic OCR helpers (`ocr(image, options?)`)
 - `import "std/prompt_library"` — reusable prompt fragments, cache metadata,
   tenant-scoped k-means hotspot proposals, and review-queue records


### PR DESCRIPTION
## Summary
- Directly rename `std/async::retry_with_backoff` to `retry_predicate_with_backoff` with no alias shim.
- Add stale-name lint/autofix diagnostics plus type-checker rename suggestions.
- Update conformance, spec/docs, and changelog coverage for the new stdlib surface.

## Verification
- `CARGO_TARGET_DIR=/tmp/harn-target-1328 cargo test -p harn-stdlib -p harn-parser -p harn-lint`
- `CARGO_TARGET_DIR=/tmp/harn-target-1328 cargo check --workspace`
- `CARGO_TARGET_DIR=/tmp/harn-target-1328 make lint-harn`
- `CARGO_TARGET_DIR=/tmp/harn-target-1328 make fmt-harn`
- `make lint-test-patterns`
- `CARGO_TARGET_DIR=/tmp/harn-target-1328 make check-docs-snippets`
- `CARGO_TARGET_DIR=/tmp/harn-target-1328 make conformance`

Closes #1328