### PR TITLE
Add harn models test smoke command

### DIFF
--- a/crates/harn-cli/src/cli/mod.rs
+++ b/crates/harn-cli/src/cli/mod.rs
@@ -87,6 +87,7 @@ pub(crate) use merge_captain::{
 };
 pub(crate) use models::{
     ModelRecommendArgs, ModelsArgs, ModelsCommand, ModelsInstallArgs, ModelsListArgs,
+    ModelsTestArgs,
 };
 pub(crate) use orchestrator::{
     OrchestratorArgs, OrchestratorCommand, OrchestratorDeployArgs, OrchestratorDeployProvider,
@@ -283,13 +284,12 @@ SCRIPTING
     MergeCaptain(MergeCaptainArgs),
     /// Print resolved metadata for a model alias or model id as JSON.
     ModelInfo(ModelInfoArgs),
+    /// List, install, recommend, and test configured LLM models.
+    Models(ModelsArgs),
     /// Print the provider/model catalog Harn loaded as JSON.
     ProviderCatalog(ProviderCatalogArgs),
     /// Probe a provider's /models endpoint and optionally verify a served model.
     ProviderReady(ProviderReadyArgs),
-    /// List or install LLM models. Convenience wrapper around the catalog
-    /// and (for `install`) Ollama.
-    Models(ModelsArgs),
     /// One-shot agent_loop with a prompt. Routes through the configured
     /// provider (or `HARN_LLM_PROVIDER=mock` for offline use).
     #[command(name = "try")]

--- a/crates/harn-cli/src/cli/models.rs
+++ b/crates/harn-cli/src/cli/models.rs
@@ -14,6 +14,8 @@ pub(crate) enum ModelsCommand {
     Install(ModelsInstallArgs),
     /// Recommend a starter model for the current machine and credentials.
     Recommend(ModelRecommendArgs),
+    /// Round-trip a small prompt through a model and report timing, tokens, and cost.
+    Test(ModelsTestArgs),
 }
 
 #[derive(Debug, Args)]
@@ -45,5 +47,20 @@ pub(crate) struct ModelsInstallArgs {
 pub(crate) struct ModelRecommendArgs {
     /// Emit the recommendation and hardware snapshot as JSON.
     #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct ModelsTestArgs {
+    /// Model alias or provider-native model id.
+    pub model: String,
+    /// Prompt text to send to the model.
+    #[arg(long, default_value = "Reply with the word pong.")]
+    pub prompt: String,
+    /// Provider id to use instead of inferring one from the model selector.
+    #[arg(long)]
+    pub provider: Option<String>,
+    /// Emit a structured JSON result.
+    #[arg(long, default_value_t = false)]
     pub json: bool,
 }

--- a/crates/harn-cli/src/cli/tests.rs
+++ b/crates/harn-cli/src/cli/tests.rs
@@ -1802,6 +1802,32 @@ fn test_parses_model_info_args() {
 }
 
 #[test]
+fn test_parses_models_test_args() {
+    let cli = Cli::parse_from([
+        "harn",
+        "models",
+        "test",
+        "qwen3:30b",
+        "--provider",
+        "ollama",
+        "--prompt",
+        "say pong",
+        "--json",
+    ]);
+
+    let Command::Models(args) = cli.command.unwrap() else {
+        panic!("expected models command");
+    };
+    let ModelsCommand::Test(args) = args.command else {
+        panic!("expected models test command");
+    };
+    assert_eq!(args.model, "qwen3:30b");
+    assert_eq!(args.provider.as_deref(), Some("ollama"));
+    assert_eq!(args.prompt, "say pong");
+    assert!(args.json);
+}
+
+#[test]
 fn test_parses_provider_catalog_args() {
     let cli = Cli::parse_from(["harn", "provider-catalog", "--available-only"]);
 

--- a/crates/harn-cli/src/commands/models/mod.rs
+++ b/crates/harn-cli/src/commands/models/mod.rs
@@ -1,8 +1,9 @@
-//! `harn models` — list, install, and recommend models.
+//! `harn models` — list, install, recommend, and test models.
 
 pub(crate) mod install;
 pub(crate) mod list;
 pub(crate) mod recommend;
+pub(crate) mod test;
 
 use crate::cli::{ModelsArgs, ModelsCommand};
 
@@ -11,5 +12,6 @@ pub(crate) async fn run(args: ModelsArgs) {
         ModelsCommand::List(args) => list::run(args).await,
         ModelsCommand::Install(args) => install::run(args).await,
         ModelsCommand::Recommend(args) => recommend::run(&args),
+        ModelsCommand::Test(args) => test::run(&args).await,
     }
 }

--- a/crates/harn-cli/src/commands/models/test.rs
+++ b/crates/harn-cli/src/commands/models/test.rs
@@ -1,0 +1,45 @@
+use std::process;
+
+use crate::cli::ModelsTestArgs;
+
+pub(crate) async fn run(args: &ModelsTestArgs) {
+    let result = harn_vm::llm::run_model_smoke_test(harn_vm::llm::ModelSmokeTestOptions {
+        model: args.model.clone(),
+        provider: args.provider.clone(),
+        prompt: args.prompt.clone(),
+    })
+    .await;
+
+    match result {
+        Ok(result) if args.json => match serde_json::to_string_pretty(&result) {
+            Ok(payload) => println!("{payload}"),
+            Err(error) => {
+                crate::command_error(&format!("failed to serialize model test result: {error}"))
+            }
+        },
+        Ok(result) => {
+            let first_token = result
+                .first_token_ms
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "-".to_string());
+            println!(
+                "model_id={} provider={} latency_ms={} first_token_ms={} input_tokens={} output_tokens={} estimated_cost_usd={:.6}",
+                result.model_id,
+                result.provider,
+                result.latency_ms,
+                first_token,
+                result.input_tokens,
+                result.output_tokens,
+                result.estimated_cost_usd
+            );
+        }
+        Err(error) if args.json => {
+            println!("{}", serde_json::json!({ "ok": false, "error": error }));
+            process::exit(1);
+        }
+        Err(error) => {
+            eprintln!("{error}");
+            process::exit(1);
+        }
+    }
+}

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -29,6 +29,7 @@ pub(crate) mod daemon;
 pub(crate) mod fake;
 pub(crate) mod helpers;
 pub(crate) mod mock;
+mod model_test;
 pub(crate) mod permissions;
 pub mod plan;
 pub mod readiness;
@@ -496,6 +497,7 @@ pub use self::mock::{
     clear_cli_llm_mock_mode, enable_cli_llm_mock_recording, install_cli_llm_mocks, set_replay_mode,
     take_cli_llm_recordings, LlmMock, LlmReplayMode, MockError,
 };
+pub use self::model_test::{run_model_smoke_test, ModelSmokeTestOptions, ModelSmokeTestResult};
 pub use self::trace::{
     agent_trace_summary, enable_tracing, peek_agent_trace, peek_trace, peek_trace_summary,
     take_agent_trace, take_trace, AgentTraceEvent, LlmTraceEntry,

--- a/crates/harn-vm/src/llm/model_test.rs
+++ b/crates/harn-vm/src/llm/model_test.rs
@@ -1,0 +1,169 @@
+use std::time::Instant;
+
+use serde::Serialize;
+
+use super::api::{
+    vm_call_llm_full_streaming, LlmCallOptions, LlmRoutePolicy, OutputFormat, ThinkingConfig,
+};
+use crate::value::{VmError, VmValue};
+
+const SMOKE_TEST_MAX_TOKENS: i64 = 32;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ModelSmokeTestOptions {
+    pub model: String,
+    pub provider: Option<String>,
+    pub prompt: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct ModelSmokeTestResult {
+    pub model_id: String,
+    pub provider: String,
+    pub latency_ms: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub first_token_ms: Option<u64>,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub estimated_cost_usd: f64,
+}
+
+pub async fn run_model_smoke_test(
+    options: ModelSmokeTestOptions,
+) -> Result<ModelSmokeTestResult, String> {
+    super::provider::register_default_providers();
+
+    let resolved = crate::llm_config::resolve_model_info(&options.model);
+    let model_id = resolved.id;
+    let provider = options
+        .provider
+        .as_deref()
+        .map(str::trim)
+        .filter(|provider| !provider.is_empty())
+        .map(str::to_string)
+        .unwrap_or(resolved.provider);
+    let api_key = super::helpers::resolve_api_key(&provider).map_err(vm_error_message)?;
+
+    if let Some(def) = crate::llm_config::provider_config(&provider) {
+        if super::supports_model_readiness_probe(&def) {
+            let readiness =
+                super::probe_openai_compatible_model(&provider, &model_id, &api_key).await;
+            if readiness.category == "model_missing" || readiness.category == "invalid_url" {
+                return Err(readiness.message);
+            }
+        }
+    }
+
+    let opts = LlmCallOptions {
+        provider: provider.clone(),
+        model: model_id.clone(),
+        api_key,
+        route_policy: LlmRoutePolicy::Manual,
+        fallback_chain: Vec::new(),
+        route_fallbacks: Vec::new(),
+        routing_decision: None,
+        session_id: None,
+        messages: vec![serde_json::json!({
+            "role": "user",
+            "content": options.prompt,
+        })],
+        system: None,
+        transcript_summary: None,
+        max_tokens: SMOKE_TEST_MAX_TOKENS,
+        temperature: None,
+        top_p: None,
+        top_k: None,
+        logprobs: false,
+        top_logprobs: None,
+        stop: None,
+        seed: None,
+        frequency_penalty: None,
+        presence_penalty: None,
+        output_format: OutputFormat::Text,
+        response_format: None,
+        json_schema: None,
+        output_schema: None,
+        output_validation: None,
+        thinking: ThinkingConfig::Disabled,
+        anthropic_beta_features: Vec::new(),
+        vision: false,
+        tools: None,
+        native_tools: None,
+        tool_choice: None,
+        tool_search: None,
+        cache: false,
+        timeout: None,
+        idle_timeout: None,
+        stream: true,
+        provider_overrides: None,
+        budget: None,
+        prefill: None,
+        structural_experiment: None,
+        applied_structural_experiment: None,
+    };
+
+    let (delta_tx, mut delta_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+    let started = Instant::now();
+    let first_delta = tokio::spawn(async move { delta_rx.recv().await.map(|_| started.elapsed()) });
+    let result = vm_call_llm_full_streaming(&opts, delta_tx)
+        .await
+        .map_err(vm_error_message);
+    let latency_ms = duration_ms(started.elapsed());
+    let first_token_ms = first_delta.await.ok().flatten().map(duration_ms);
+    let result = result?;
+
+    Ok(ModelSmokeTestResult {
+        model_id: result.model.clone(),
+        provider: result.provider.clone(),
+        latency_ms,
+        first_token_ms,
+        input_tokens: result.input_tokens,
+        output_tokens: result.output_tokens,
+        estimated_cost_usd: super::calculate_cost_for_provider(
+            &result.provider,
+            &result.model,
+            result.input_tokens,
+            result.output_tokens,
+        ),
+    })
+}
+
+fn duration_ms(duration: std::time::Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+}
+
+fn vm_error_message(error: VmError) -> String {
+    match error {
+        VmError::CategorizedError { message, .. } => message,
+        VmError::Thrown(VmValue::String(message)) => message.to_string(),
+        VmError::Thrown(VmValue::Dict(dict)) => dict
+            .get("message")
+            .map(VmValue::display)
+            .unwrap_or_else(|| VmError::Thrown(VmValue::Dict(dict)).to_string()),
+        other => other.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{run_model_smoke_test, ModelSmokeTestOptions};
+
+    #[tokio::test]
+    async fn mock_provider_smoke_test_reports_timing_tokens_and_cost() {
+        crate::llm::reset_llm_state();
+        let result = run_model_smoke_test(ModelSmokeTestOptions {
+            model: "mock".to_string(),
+            provider: Some("mock".to_string()),
+            prompt: "ping".to_string(),
+        })
+        .await
+        .expect("mock provider smoke test should not require network");
+
+        assert_eq!(result.model_id, "mock");
+        assert_eq!(result.provider, "mock");
+        assert_eq!(result.input_tokens, 4);
+        assert_eq!(result.output_tokens, 30);
+        assert_eq!(result.estimated_cost_usd, 0.0);
+        assert!(result.first_token_ms.is_some());
+    }
+}

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -558,6 +558,21 @@ unparsable model listings, and missing models. It does not run local launcher
 scripts; host applications that auto-start local servers should report launch
 failures themselves and then call this probe again.
 
+## harn models test
+
+Round-trip a small prompt through one resolved model and report model id,
+provider, latency, first streamed delta timing, token usage, and estimated
+cost.
+
+```bash
+harn models test gpt-4o-mini --prompt "Reply with pong."
+harn models test qwen3:30b --provider ollama --json
+```
+
+`--provider` bypasses provider inference for the model selector. The command
+uses the configured provider client path, so it also respects provider
+credentials, base URL overrides, and `HARN_LLM_CALLS_DISABLED`.
+
 ## harn model-info
 
 Print resolved model metadata as JSON. For Ollama models, `--verify` probes


### PR DESCRIPTION
## Summary

- Add `harn models test <model>` with `--prompt`, `--provider`, and `--json` flags.
- Add a VM-level model smoke-test helper that resolves provider/model, opportunistically reuses OpenAI-compatible `/models` readiness probes, streams a small chat completion, and reports latency, first streamed delta timing, token usage, and estimated cost.
- Document the new CLI command and cover the mock provider path with focused tests.

Closes #1330.

## Verification

- `cargo fmt --check`
- `cargo test -p harn-vm llm::model_test::tests::mock_provider_smoke_test_reports_timing_tokens_and_cost`
- `cargo test -p harn-cli cli::tests::test_parses_models_test_args`
- `cargo test -p harn-cli --lib`
- `cargo clippy -p harn-vm -p harn-cli --all-targets -- -D warnings`
- `make lint-test-patterns`
- `make lint-md`
- `cargo run --quiet --bin harn -- models test mock --provider mock --prompt ping --json`
- `cargo run --quiet --bin harn -- models test mock --provider mock --prompt ping`
- pre-commit hook: workspace clippy + markdown
- pre-push hook: targeted local checks + markdown