### PR TITLE
perf/llm: add options roundtrip benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1841,6 +1841,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "harn-llm-perf"
+version = "0.0.0"
+dependencies = [
+ "criterion",
+ "harn-vm",
+]
+
+[[package]]
 name = "harn-lsp"
 version = "0.7.61"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "crates/harn-fmt",
     "crates/harn-lint",
     "crates/harn-hostlib",
+    "perf/llm",
 ]
 # Build harn-wasm separately: cd crates/harn-wasm && wasm-pack build
 exclude = ["crates/harn-wasm"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup install-hooks configure-merge-drivers build build-release check fmt fmt-harn fmt-harn-fix lint lint-md lint-actions lint-harn spec-lint test test-e2e test-cargo test-fast conformance protocol-conformance bench-vm all release-gate portal portal-check portal-demo gen-highlight check-highlight gen-trigger-quickref check-trigger-quickref gen-provider-matrix check-provider-matrix gen-connector-matrix check-connector-matrix check-trigger-examples check-docs-snippets sync-language-spec check-language-spec lint-test-patterns check-receipt-structs lint-no-rust-prompt-prose lint-no-xfail-regression
+.PHONY: setup install-hooks configure-merge-drivers build build-release check fmt fmt-harn fmt-harn-fix lint lint-md lint-actions lint-harn spec-lint test test-e2e test-cargo test-fast conformance protocol-conformance bench-vm bench-llm all release-gate portal portal-check portal-demo gen-highlight check-highlight gen-trigger-quickref check-trigger-quickref gen-provider-matrix check-provider-matrix gen-connector-matrix check-connector-matrix check-trigger-examples check-docs-snippets sync-language-spec check-language-spec lint-test-patterns check-receipt-structs lint-no-rust-prompt-prose lint-no-xfail-regression
 
 # Full quality check: format first, then lint/test in parallel.
 # Usage: make all -j       (parallel checks after formatting)
@@ -74,6 +74,9 @@ protocol-conformance:
 
 bench-vm:
 	./scripts/bench_vm.sh
+
+bench-llm:
+	cargo bench -p harn-llm-perf --bench bench_llm_options_roundtrip -- --output-format bencher
 
 # Lint markdown files
 lint-md:

--- a/crates/harn-vm/Cargo.toml
+++ b/crates/harn-vm/Cargo.toml
@@ -9,6 +9,7 @@ description = "Async bytecode virtual machine for the Harn programming language"
 
 [features]
 default = []
+llm-bench-internals = []
 otel = [
     "dep:opentelemetry",
     "dep:opentelemetry_sdk",

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -169,6 +169,25 @@ pub use self::api::{
     OllamaWarmupResult,
 };
 
+#[cfg(feature = "llm-bench-internals")]
+#[doc(hidden)]
+pub mod bench_internals {
+    use super::*;
+
+    pub fn llm_options_roundtrip_probe(
+        args: &[VmValue],
+        options: &Option<std::collections::BTreeMap<String, VmValue>>,
+    ) -> Result<usize, VmError> {
+        let resolved_provider = helpers::vm_resolve_provider(options);
+        let extracted = extract_llm_options(args)?;
+        let pricing_per_1k = cost::pricing_per_1k_for(&extracted.provider, &extracted.model);
+        Ok(resolved_provider.len()
+            + extracted.provider.len()
+            + extracted.model.len()
+            + usize::from(pricing_per_1k.is_some()))
+    }
+}
+
 pub fn install_current_host_bridge(bridge: Rc<crate::bridge::HostBridge>) {
     agent_runtime::install_current_host_bridge(bridge);
 }

--- a/perf/llm/Cargo.toml
+++ b/perf/llm/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "harn-llm-perf"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+harn-vm = { path = "../../crates/harn-vm", features = ["llm-bench-internals"] }
+
+[dev-dependencies]
+criterion = "0.8"
+
+[[bench]]
+name = "bench_llm_options_roundtrip"
+path = "bench_llm_options_roundtrip.rs"
+harness = false

--- a/perf/llm/README.md
+++ b/perf/llm/README.md
@@ -1,0 +1,20 @@
+# LLM microbenchmarks
+
+This directory contains opt-in Criterion benchmarks for LLM runtime hot paths.
+
+Run the options roundtrip benchmark:
+
+```bash
+make bench-llm
+```
+
+Or run the Criterion target directly:
+
+```bash
+cargo bench -p harn-llm-perf --bench bench_llm_options_roundtrip -- --output-format bencher
+```
+
+`llm_options_roundtrip` measures the existing option extraction path for
+representative option dicts with 1, 5, 25, and 100 top-level keys. Criterion
+reports per-call timing as `ns/iter`. Set a per-run `CARGO_TARGET_DIR` when
+running benchmarks from multiple worktrees.

--- a/perf/llm/bench_llm_options_roundtrip.rs
+++ b/perf/llm/bench_llm_options_roundtrip.rs
@@ -1,0 +1,110 @@
+use std::collections::BTreeMap;
+use std::hint::black_box;
+use std::rc::Rc;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use harn_vm::llm::bench_internals::llm_options_roundtrip_probe;
+use harn_vm::VmValue;
+
+const KEY_COUNTS: [usize; 4] = [1, 5, 25, 100];
+
+struct Fixture {
+    key_count: usize,
+    args: Vec<VmValue>,
+    options: Option<BTreeMap<String, VmValue>>,
+}
+
+fn string(value: &str) -> VmValue {
+    VmValue::String(Rc::from(value))
+}
+
+fn dict(entries: BTreeMap<String, VmValue>) -> VmValue {
+    VmValue::Dict(Rc::new(entries))
+}
+
+fn override_value(index: usize) -> VmValue {
+    match index % 5 {
+        0 => VmValue::Int(index as i64),
+        1 => VmValue::Float(index as f64 / 10.0),
+        2 => string(&format!("value-{index:03}")),
+        3 => VmValue::Bool(index.is_multiple_of(2)),
+        _ => VmValue::List(Rc::new(vec![
+            string("nested"),
+            VmValue::Int(index as i64),
+            VmValue::Bool(true),
+        ])),
+    }
+}
+
+fn provider_overrides() -> VmValue {
+    let mut overrides = BTreeMap::new();
+    overrides.insert("override_000".to_string(), override_value(0));
+    dict(overrides)
+}
+
+fn build_options(key_count: usize) -> BTreeMap<String, VmValue> {
+    let mut options = BTreeMap::new();
+    options.insert("provider".to_string(), string("mock"));
+
+    if key_count >= 2 {
+        options.insert("model".to_string(), string("gpt-4o-mini"));
+    }
+    if key_count >= 3 {
+        options.insert("stream".to_string(), VmValue::Bool(false));
+    }
+    if key_count >= 4 {
+        options.insert("max_tokens".to_string(), VmValue::Int(512));
+    }
+    if key_count >= 5 {
+        options.insert("mock".to_string(), provider_overrides());
+    }
+
+    while options.len() < key_count {
+        let index = options.len();
+        options.insert(format!("passthrough_{index:03}"), override_value(index));
+    }
+
+    options
+}
+
+fn fixture(key_count: usize) -> Fixture {
+    let options = build_options(key_count);
+    let args = vec![
+        string("Summarize the benchmark fixture."),
+        VmValue::Nil,
+        dict(options.clone()),
+    ];
+    Fixture {
+        key_count,
+        args,
+        options: Some(options),
+    }
+}
+
+fn bench_llm_options_roundtrip(c: &mut Criterion) {
+    let fixtures: Vec<Fixture> = KEY_COUNTS.into_iter().map(fixture).collect();
+    let mut group = c.benchmark_group("llm_options_roundtrip");
+
+    for fixture in &fixtures {
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("keys_{:03}", fixture.key_count)),
+            fixture,
+            |b, fixture| {
+                b.iter(|| {
+                    black_box(
+                        llm_options_roundtrip_probe(
+                            black_box(&fixture.args),
+                            black_box(&fixture.options),
+                        )
+                        .expect("benchmark fixture should parse"),
+                    )
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_llm_options_roundtrip);
+criterion_main!(benches);

--- a/scripts/verify_crate_packages.sh
+++ b/scripts/verify_crate_packages.sh
@@ -56,7 +56,11 @@ import sys
 metadata = json.loads(pathlib.Path(sys.argv[1]).read_text())
 members = set(metadata["workspace_members"])
 for package in sorted(metadata["packages"], key=lambda p: p["name"]):
-    if package["id"] in members and package["name"].startswith("harn-"):
+    if (
+        package["id"] in members
+        and package["name"].startswith("harn-")
+        and package.get("publish") != []
+    ):
         print(f'{package["name"]}\t{package["manifest_path"]}')
 PY
 )
@@ -162,7 +166,7 @@ import pathlib
 metadata = json.loads(pathlib.Path(sys.argv[1]).read_text())
 members = set(metadata["workspace_members"])
 for package in sorted(metadata["packages"], key=lambda p: p["name"]):
-    if package["id"] in members:
+    if package["id"] in members and package.get("publish") != []:
         print(package["name"])
 PY
 )


### PR DESCRIPTION
## Summary
- add an unpublished `harn-llm-perf` workspace package for opt-in LLM Criterion benchmarks
- add `perf/llm/bench_llm_options_roundtrip.rs` covering 1, 5, 25, and 100 top-level option keys
- wire `make bench-llm` to emit Criterion bencher output as `ns/iter`

Closes #1336.

## Verification
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-1336 cargo check -p harn-llm-perf --bench bench_llm_options_roundtrip`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-1336 cargo check -p harn-vm`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-1336 cargo clippy -p harn-llm-perf --bench bench_llm_options_roundtrip -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-1336 cargo clippy -p harn-vm --all-targets -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-1336 make bench-llm`
- `cargo package -p harn-vm --allow-dirty --no-verify`
- pre-commit hook: workspace clippy, markdownlint, actionlint
- pre-push hook: targeted local checks, markdownlint