### PR TITLE
Add persistent LLM response cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ condensed series summaries instead of full per-patch history.
   `with_circuit_breaker`, which derives circuit names from each call's
   `(provider, model)` by default while preserving `name` for intentionally
   shared circuit state.
+- **Persistent LLM response caching (#1322).** Added `std/cache` and
+  `std/llm/handlers.with_cache` with sqlite and filesystem backends,
+  content-addressed LLM keys, TTL, LRU eviction, and default bypass for calls
+  that include tools.
 
 ## v0.7.61
 

--- a/conformance/tests/integration/llm_handlers_with_cache.expected
+++ b/conformance/tests/integration/llm_handlers_with_cache.expected
@@ -1,0 +1,10 @@
+true
+cached answer
+cached answer
+true
+true
+fresh answer
+true
+fs cached
+fs cached
+true

--- a/conformance/tests/integration/llm_handlers_with_cache.harn
+++ b/conformance/tests/integration/llm_handlers_with_cache.harn
@@ -1,0 +1,39 @@
+import { cache_clear } from "std/cache"
+import { llm_cache_key, with_cache } from "std/llm/handlers"
+
+pipeline default() {
+  let store = {
+    backend: "sqlite",
+    namespace: "with-cache-" + uuid(),
+    path: path_join(temp_dir(), "harn-with-cache-sqlite-" + uuid() + ".sqlite"),
+  }
+  cache_clear({store: store})
+  llm_mock_clear()
+  llm_mock({text: "cached answer", model: "mock-model", provider: "mock"})
+  llm_mock({text: "fresh answer", model: "mock-model", provider: "mock"})
+  let opts = {provider: "mock", model: "mock-model", store: store, stream: false}
+  println(llm_cache_key("same prompt", "same system", opts).starts_with("sha256:"))
+  let first = with_cache("same prompt", "same system", opts)
+  let second = with_cache("same prompt", "same system", opts)
+  println(first.text)
+  println(second.text)
+  println(json_stringify(first) == json_stringify(second))
+  println(len(llm_mock_calls()) == 1)
+  let skipped = with_cache("same prompt", "same system", opts + {tools: []})
+  println(skipped.text)
+  println(len(llm_mock_calls()) == 2)
+  let fs_store = {
+    backend: "fs",
+    namespace: "with-cache-fs-" + uuid(),
+    path: path_join(temp_dir(), "harn-with-cache-fs-" + uuid()),
+  }
+  llm_mock_clear()
+  llm_mock({text: "fs cached", model: "mock-model", provider: "mock"})
+  llm_mock({text: "fs fresh", model: "mock-model", provider: "mock"})
+  let fs_opts = {provider: "mock", model: "mock-model", store: fs_store, stream: false}
+  let fs_first = with_cache("fs prompt", nil, fs_opts)
+  let fs_second = with_cache("fs prompt", nil, fs_opts)
+  println(fs_first.text)
+  println(fs_second.text)
+  println(len(llm_mock_calls()) == 1)
+}

--- a/crates/harn-parser/src/builtin_signatures/signatures/stdlib.rs
+++ b/crates/harn-parser/src/builtin_signatures/signatures/stdlib.rs
@@ -15,10 +15,53 @@ const TY_DURATION_OR_INT: Ty = Ty::Union(&[TY_DURATION, TY_INT]);
 
 pub(crate) const SIGNATURES: &[BuiltinSignature] = &[
     BuiltinSignature {
+        name: "__cache_clear",
+        params: &[Param::optional("options", TY_DICT_OR_NIL)],
+        returns: TY_NIL,
+        type_params: &[],
+        has_rest: false,
+        where_clauses: &[],
+    },
+    BuiltinSignature {
+        name: "__cache_get",
+        params: &[
+            Param::new("key", TY_STRING),
+            Param::optional("options", TY_DICT_OR_NIL),
+        ],
+        returns: TY_DICT,
+        type_params: &[],
+        has_rest: false,
+        where_clauses: &[],
+    },
+    BuiltinSignature {
+        name: "__cache_put",
+        params: &[
+            Param::new("key", TY_STRING),
+            Param::new("value", TY_ANY),
+            Param::optional("options", TY_DICT_OR_NIL),
+        ],
+        returns: TY_DICT,
+        type_params: &[],
+        has_rest: false,
+        where_clauses: &[],
+    },
+    BuiltinSignature {
         name: "__files_upload",
         params: &[
             Param::new("path", TY_STRING),
             Param::new("provider", TY_STRING),
+        ],
+        returns: TY_STRING,
+        type_params: &[],
+        has_rest: false,
+        where_clauses: &[],
+    },
+    BuiltinSignature {
+        name: "__llm_cache_key",
+        params: &[
+            Param::new("prompt", TY_ANY),
+            Param::optional("system", TY_ANY),
+            Param::optional("options", TY_DICT_OR_NIL),
         ],
         returns: TY_STRING,
         type_params: &[],

--- a/crates/harn-stdlib/src/lib.rs
+++ b/crates/harn-stdlib/src/lib.rs
@@ -54,6 +54,10 @@ pub const STDLIB_SOURCES: &[StdlibSource] = &[
         source: include_str!("stdlib/stdlib_json.harn"),
     },
     StdlibSource {
+        module: "cache",
+        source: include_str!("stdlib/stdlib_cache.harn"),
+    },
+    StdlibSource {
         module: "tools",
         source: include_str!("stdlib/stdlib_tools.harn"),
     },

--- a/crates/harn-stdlib/src/stdlib/llm/handlers.harn
+++ b/crates/harn-stdlib/src/stdlib/llm/handlers.harn
@@ -1,4 +1,6 @@
 /** std/llm/handlers — small middleware helpers for LLM call handlers. */
+import { cache_get, cache_put } from "std/cache"
+
 var __llm_handler_circuits = []
 
 fn __llm_handler_is_callable(value) -> bool {
@@ -30,6 +32,36 @@ fn __circuit_open_error(call, name) {
     provider: opts?.provider ?? "<unset>",
     model: opts?.model ?? "<unset>",
     circuit: name,
+  }
+}
+
+fn __llm_handler_should_skip_cache(prompt, system, opts) -> bool {
+  let predicate = opts?.skip_when
+  if predicate == nil {
+    return opts?.tools != nil
+  }
+  if __llm_handler_is_callable(predicate) {
+    return predicate({prompt: prompt, system: system, options: opts}) ? true : false
+  }
+  return predicate ? true : false
+}
+
+fn __llm_handler_cache_options(opts) -> dict {
+  var ttl = opts?.ttl
+  if ttl == nil && opts?.ttl_seconds == nil && opts?.max_age_seconds == nil {
+    ttl = "10m"
+  }
+  return {
+    store: opts?.store ?? "llm.with_cache",
+    backend: opts?.backend,
+    namespace: opts?.namespace,
+    name: opts?.name,
+    path: opts?.path,
+    cache_dir: opts?.cache_dir,
+    ttl: ttl,
+    ttl_seconds: opts?.ttl_seconds,
+    max_age_seconds: opts?.max_age_seconds,
+    max_entries: opts?.max_entries ?? 256,
   }
 }
 
@@ -66,4 +98,31 @@ pub fn with_circuit_breaker(handler, options = nil) {
     circuit_record_success(name)
     return result
   }
+}
+
+/** llm_cache_key returns the canonical sha256 cache key used by with_cache. */
+pub fn llm_cache_key(prompt, system = nil, options = nil) -> string {
+  return __llm_cache_key(prompt, system, options ?? {})
+}
+
+/**
+ * with_cache executes llm_call behind a persistent content-addressed cache.
+ *
+ * Cache identity is based on prompt, system, provider, model, temperature,
+ * top_p, and max_tokens. By default calls with tools are not cached.
+ */
+pub fn with_cache(prompt, system = nil, options = nil) -> dict {
+  let opts = options ?? {}
+  if __llm_handler_should_skip_cache(prompt, system, opts) {
+    return llm_call(prompt, system, opts)
+  }
+  let key = llm_cache_key(prompt, system, opts)
+  let cache_options = __llm_handler_cache_options(opts)
+  let cached = cache_get(key, cache_options)
+  if cached.hit {
+    return cached.value
+  }
+  let result = llm_call(prompt, system, opts)
+  cache_put(key, result, cache_options)
+  return result
 }

--- a/crates/harn-stdlib/src/stdlib/stdlib_cache.harn
+++ b/crates/harn-stdlib/src/stdlib/stdlib_cache.harn
@@ -1,0 +1,15 @@
+// std/cache: Persistent cache helpers.
+/** cache_get returns {hit: bool, value?} for a persistent cache key. */
+pub fn cache_get(key: string, options = nil) -> dict {
+  return __cache_get(key, options ?? {})
+}
+
+/** cache_put stores value under key with the configured TTL and LRU policy. */
+pub fn cache_put(key: string, value, options = nil) -> dict {
+  return __cache_put(key, value, options ?? {})
+}
+
+/** cache_clear removes all entries in the configured cache namespace. */
+pub fn cache_clear(options = nil) {
+  return __cache_clear(options ?? {})
+}

--- a/crates/harn-vm/src/llm/cache.rs
+++ b/crates/harn-vm/src/llm/cache.rs
@@ -1,0 +1,736 @@
+//! Persistent cache primitives used by `std/cache` and LLM wrappers.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::rc::Rc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use rusqlite::{params, Connection, OptionalExtension};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::stdlib::registration::{register_builtin_group, BuiltinGroup, SyncBuiltin};
+use crate::value::{VmError, VmValue};
+use crate::vm::{Vm, VmBuiltinArity};
+
+const DEFAULT_NAMESPACE: &str = "default";
+const DEFAULT_TTL_SECONDS: u64 = 600;
+const DEFAULT_MAX_ENTRIES: usize = 256;
+const SQLITE_CREATE_TABLE: &str = concat!(
+    "CREATE TABLE IF NOT EXISTS cache_entries (",
+    "namespace TEXT NOT NULL,",
+    "cache_key TEXT NOT NULL,",
+    "value_json TEXT NOT NULL,",
+    "created_at_ms INTEGER NOT NULL,",
+    "expires_at_ms INTEGER,",
+    "last_accessed_ms INTEGER NOT NULL,",
+    "PRIMARY KEY(namespace, cache_key)",
+    ");",
+);
+const SQLITE_CREATE_LRU_INDEX: &str = concat!(
+    "CREATE INDEX IF NOT EXISTS idx_cache_entries_lru ",
+    "ON cache_entries(namespace, last_accessed_ms);",
+);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CacheBackend {
+    Sqlite,
+    Fs,
+}
+
+#[derive(Clone, Debug)]
+struct CacheOptions {
+    backend: CacheBackend,
+    namespace: String,
+    path: PathBuf,
+    ttl_seconds: u64,
+    max_entries: usize,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct CacheRecord {
+    key: String,
+    value: serde_json::Value,
+    created_at_ms: i64,
+    expires_at_ms: Option<i64>,
+    last_accessed_ms: i64,
+}
+
+impl CacheRecord {
+    fn new(key: &str, value: serde_json::Value, now_ms: i64, ttl_seconds: u64) -> Self {
+        Self {
+            key: key.to_string(),
+            value,
+            created_at_ms: now_ms,
+            expires_at_ms: Some(now_ms.saturating_add(ttl_ms(ttl_seconds))),
+            last_accessed_ms: now_ms,
+        }
+    }
+
+    fn is_expired(&self, now_ms: i64) -> bool {
+        self.expires_at_ms
+            .is_some_and(|expires_at_ms| expires_at_ms <= now_ms)
+    }
+}
+
+pub(crate) fn register_cache_builtins(vm: &mut Vm) {
+    register_builtin_group(
+        vm,
+        BuiltinGroup::new()
+            .category("cache")
+            .sync(CACHE_SYNC_PRIMITIVES),
+    );
+}
+
+const CACHE_SYNC_PRIMITIVES: &[SyncBuiltin] = &[
+    SyncBuiltin::new("__cache_get", cache_get_builtin)
+        .signature("__cache_get(key, options?)")
+        .arity(VmBuiltinArity::Range { min: 1, max: 2 })
+        .doc("Return a persistent cache hit envelope for key."),
+    SyncBuiltin::new("__cache_put", cache_put_builtin)
+        .signature("__cache_put(key, value, options?)")
+        .arity(VmBuiltinArity::Range { min: 2, max: 3 })
+        .doc("Persist a cache value with TTL and LRU eviction."),
+    SyncBuiltin::new("__cache_clear", cache_clear_builtin)
+        .signature("__cache_clear(options?)")
+        .arity(VmBuiltinArity::Range { min: 0, max: 1 })
+        .doc("Clear one persistent cache namespace."),
+    SyncBuiltin::new("__llm_cache_key", llm_cache_key_builtin)
+        .signature("__llm_cache_key(prompt, system?, options?)")
+        .arity(VmBuiltinArity::Range { min: 1, max: 3 })
+        .doc("Derive the canonical LLM with_cache key."),
+];
+
+fn cache_get_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    let key = required_string_arg(args, 0, "__cache_get(key, options?)")?;
+    let options = parse_cache_options(args.get(1))?;
+    let hit = cache_get_at(&options, &key, now_ms()?)?;
+
+    let mut envelope = BTreeMap::new();
+    envelope.insert("hit".to_string(), VmValue::Bool(hit.is_some()));
+    if let Some(value) = hit {
+        envelope.insert("value".to_string(), crate::stdlib::json_to_vm_value(&value));
+    }
+    Ok(VmValue::Dict(Rc::new(envelope)))
+}
+
+fn cache_put_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    let key = required_string_arg(args, 0, "__cache_put(key, value, options?)")?;
+    let value = args.get(1).ok_or_else(|| {
+        VmError::Runtime("__cache_put(key, value, options?): value is required".to_string())
+    })?;
+    let options = parse_cache_options(args.get(2))?;
+    cache_put_at(
+        &options,
+        &key,
+        super::helpers::vm_value_to_json(value),
+        now_ms()?,
+    )?;
+
+    let mut envelope = BTreeMap::new();
+    envelope.insert("stored".to_string(), VmValue::Bool(true));
+    envelope.insert("key".to_string(), VmValue::String(Rc::from(key)));
+    Ok(VmValue::Dict(Rc::new(envelope)))
+}
+
+fn cache_clear_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    let options = parse_cache_options(args.first())?;
+    match options.backend {
+        CacheBackend::Sqlite => sqlite_clear(&options)?,
+        CacheBackend::Fs => fs_clear(&options)?,
+    }
+    Ok(VmValue::Nil)
+}
+
+fn llm_cache_key_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    let explicit_options = match args.get(2) {
+        Some(VmValue::Dict(dict)) => Some((**dict).clone()),
+        Some(VmValue::Nil) | None => None,
+        Some(other) => {
+            return Err(VmError::Runtime(format!(
+                "__llm_cache_key(prompt, system?, options?): options must be a dict; got {}",
+                other.type_name()
+            )))
+        }
+    };
+    let options = super::cost_route::merge_context_options(explicit_options);
+
+    let provider = super::helpers::vm_resolve_provider(&options);
+    let model = super::helpers::vm_resolve_model(&options, &provider);
+    let model_defaults = crate::llm_config::model_params(&model);
+    let default_float =
+        |key: &str| -> Option<f64> { model_defaults.get(key).and_then(|v| v.as_float()) };
+
+    let max_tokens = super::helpers::opt_int(&options, "max_tokens").unwrap_or(16384);
+    let temperature =
+        super::helpers::opt_float(&options, "temperature").or_else(|| default_float("temperature"));
+    let top_p = super::helpers::opt_float(&options, "top_p").or_else(|| default_float("top_p"));
+
+    let prompt = args
+        .first()
+        .map(super::helpers::vm_value_to_json)
+        .unwrap_or(serde_json::Value::Null);
+    let system = args
+        .get(1)
+        .map(super::helpers::vm_value_to_json)
+        .unwrap_or(serde_json::Value::Null);
+
+    let mut identity = BTreeMap::new();
+    identity.insert("max_tokens", serde_json::json!(max_tokens));
+    identity.insert("model", serde_json::Value::String(model));
+    identity.insert("prompt", prompt);
+    identity.insert("provider", serde_json::Value::String(provider));
+    identity.insert("system", system);
+    identity.insert("temperature", json_float_or_null(temperature));
+    identity.insert("top_p", json_float_or_null(top_p));
+
+    let canonical = canonical_json_bytes(&serde_json::to_value(identity).map_err(|error| {
+        VmError::Runtime(format!(
+            "__llm_cache_key: failed to encode identity: {error}"
+        ))
+    })?)?;
+    let digest = Sha256::digest(&canonical);
+    Ok(VmValue::String(Rc::from(format!(
+        "sha256:{}",
+        hex::encode(digest)
+    ))))
+}
+
+fn cache_get_at(
+    options: &CacheOptions,
+    key: &str,
+    now_ms: i64,
+) -> Result<Option<serde_json::Value>, VmError> {
+    match options.backend {
+        CacheBackend::Sqlite => sqlite_get(options, key, now_ms),
+        CacheBackend::Fs => fs_get(options, key, now_ms),
+    }
+}
+
+fn cache_put_at(
+    options: &CacheOptions,
+    key: &str,
+    value: serde_json::Value,
+    now_ms: i64,
+) -> Result<(), VmError> {
+    match options.backend {
+        CacheBackend::Sqlite => sqlite_put(options, key, value, now_ms),
+        CacheBackend::Fs => fs_put(options, key, value, now_ms),
+    }
+}
+
+fn parse_cache_options(value: Option<&VmValue>) -> Result<CacheOptions, VmError> {
+    let dict = match value {
+        Some(VmValue::Dict(dict)) => Some(&**dict),
+        Some(VmValue::Nil) | None => None,
+        Some(other) => {
+            return Err(VmError::Runtime(format!(
+                "cache options must be a dict or nil; got {}",
+                other.type_name()
+            )))
+        }
+    };
+
+    let store_dict = match dict.and_then(|dict| dict.get("store")) {
+        Some(VmValue::Dict(store)) => Some(&**store),
+        Some(VmValue::String(_)) | Some(VmValue::Nil) | None => None,
+        Some(other) => {
+            return Err(VmError::Runtime(format!(
+                "cache options.store must be a string, dict, or nil; got {}",
+                other.type_name()
+            )))
+        }
+    };
+
+    let backend = read_string_field(store_dict, "backend")
+        .or_else(|| read_string_field(dict, "backend"))
+        .map(|backend| parse_backend(&backend))
+        .transpose()?
+        .unwrap_or(CacheBackend::Sqlite);
+
+    let namespace = read_string_field(store_dict, "namespace")
+        .or_else(|| read_string_field(store_dict, "name"))
+        .or_else(|| match dict.and_then(|dict| dict.get("store")) {
+            Some(VmValue::String(name)) => Some(name.to_string()),
+            _ => None,
+        })
+        .or_else(|| read_string_field(dict, "namespace"))
+        .or_else(|| read_string_field(dict, "name"))
+        .unwrap_or_else(|| DEFAULT_NAMESPACE.to_string());
+
+    let path = read_string_field(store_dict, "path")
+        .or_else(|| read_string_field(store_dict, "cache_dir"))
+        .or_else(|| read_string_field(dict, "path"))
+        .or_else(|| read_string_field(dict, "cache_dir"))
+        .map(resolve_cache_path)
+        .unwrap_or_else(|| default_cache_path(backend));
+
+    let ttl_seconds = read_duration_field(store_dict, "ttl")
+        .transpose()?
+        .or(read_duration_field(store_dict, "ttl_seconds").transpose()?)
+        .or(read_duration_field(dict, "ttl").transpose()?)
+        .or(read_duration_field(dict, "ttl_seconds").transpose()?)
+        .or(read_duration_field(dict, "max_age_seconds").transpose()?)
+        .unwrap_or(DEFAULT_TTL_SECONDS);
+
+    let max_entries = read_usize_field(store_dict, "max_entries")
+        .transpose()?
+        .or(read_usize_field(dict, "max_entries").transpose()?)
+        .unwrap_or(DEFAULT_MAX_ENTRIES)
+        .clamp(1, 100_000);
+
+    Ok(CacheOptions {
+        backend,
+        namespace: sanitize_namespace(&namespace),
+        path,
+        ttl_seconds,
+        max_entries,
+    })
+}
+
+fn parse_backend(value: &str) -> Result<CacheBackend, VmError> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "" | "sqlite" => Ok(CacheBackend::Sqlite),
+        "fs" | "file" | "files" => Ok(CacheBackend::Fs),
+        other => Err(VmError::Runtime(format!(
+            "cache backend must be \"sqlite\" or \"fs\"; got {other:?}"
+        ))),
+    }
+}
+
+fn read_string_field(dict: Option<&BTreeMap<String, VmValue>>, key: &str) -> Option<String> {
+    dict.and_then(|dict| dict.get(key))
+        .and_then(|value| match value {
+            VmValue::String(text) if !text.is_empty() => Some(text.to_string()),
+            _ => None,
+        })
+}
+
+fn read_duration_field(
+    dict: Option<&BTreeMap<String, VmValue>>,
+    key: &str,
+) -> Option<Result<u64, VmError>> {
+    dict.and_then(|dict| dict.get(key))
+        .and_then(|value| match value {
+            VmValue::Nil => None,
+            VmValue::Int(seconds) => Some(Ok((*seconds).max(0) as u64)),
+            VmValue::Float(seconds) => Some(Ok(seconds.max(0.0) as u64)),
+            VmValue::String(text) => Some(parse_duration_seconds(text)),
+            other => Some(Err(VmError::Runtime(format!(
+                "cache option {key} must be seconds or a duration string; got {}",
+                other.type_name()
+            )))),
+        })
+}
+
+fn read_usize_field(
+    dict: Option<&BTreeMap<String, VmValue>>,
+    key: &str,
+) -> Option<Result<usize, VmError>> {
+    dict.and_then(|dict| dict.get(key))
+        .and_then(|value| match value {
+            VmValue::Nil => None,
+            VmValue::Int(value) => Some(Ok((*value).max(1) as usize)),
+            other => Some(Err(VmError::Runtime(format!(
+                "cache option {key} must be an int; got {}",
+                other.type_name()
+            )))),
+        })
+}
+
+fn parse_duration_seconds(text: &str) -> Result<u64, VmError> {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return Ok(DEFAULT_TTL_SECONDS);
+    }
+    if let Ok(seconds) = trimmed.parse::<u64>() {
+        return Ok(seconds);
+    }
+    let lower = trimmed.to_ascii_lowercase();
+    for (suffix, multiplier) in [
+        ("secs", 1.0),
+        ("sec", 1.0),
+        ("ms", 1.0 / 1000.0),
+        ("mins", 60.0),
+        ("min", 60.0),
+        ("hrs", 3600.0),
+        ("hr", 3600.0),
+        ("s", 1.0),
+        ("m", 60.0),
+        ("h", 3600.0),
+        ("d", 86_400.0),
+    ] {
+        if let Some(number) = lower.strip_suffix(suffix) {
+            let value = number.trim().parse::<f64>().map_err(|_| {
+                VmError::Runtime(format!("cache duration {text:?} has an invalid number"))
+            })?;
+            return Ok((value.max(0.0) * multiplier).ceil() as u64);
+        }
+    }
+    Err(VmError::Runtime(format!(
+        "cache duration {text:?} must use ms, s, m, h, or d"
+    )))
+}
+
+fn ttl_ms(ttl_seconds: u64) -> i64 {
+    let max_safe_seconds = (i64::MAX as u64) / 1000;
+    ttl_seconds.min(max_safe_seconds).saturating_mul(1000) as i64
+}
+
+fn default_cache_path(backend: CacheBackend) -> PathBuf {
+    let root = crate::runtime_paths::state_root(&crate::stdlib::process::runtime_root_base())
+        .join("cache");
+    match backend {
+        CacheBackend::Sqlite => root.join("llm.sqlite"),
+        CacheBackend::Fs => root.join("llm"),
+    }
+}
+
+fn resolve_cache_path(path: String) -> PathBuf {
+    let candidate = PathBuf::from(path);
+    if candidate.is_absolute() {
+        candidate
+    } else {
+        crate::stdlib::process::resolve_source_relative_path(&candidate.to_string_lossy())
+    }
+}
+
+fn sanitize_namespace(namespace: &str) -> String {
+    let mut out = String::with_capacity(namespace.len());
+    for ch in namespace.chars() {
+        if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.') {
+            out.push(ch);
+        } else {
+            out.push('_');
+        }
+    }
+    if out.is_empty() {
+        DEFAULT_NAMESPACE.to_string()
+    } else {
+        out
+    }
+}
+
+fn required_string_arg(args: &[VmValue], index: usize, signature: &str) -> Result<String, VmError> {
+    match args.get(index) {
+        Some(VmValue::String(text)) if !text.is_empty() => Ok(text.to_string()),
+        Some(other) => Err(VmError::Runtime(format!(
+            "{signature}: argument {} must be a non-empty string; got {}",
+            index + 1,
+            other.type_name()
+        ))),
+        None => Err(VmError::Runtime(format!(
+            "{signature}: argument {} is required",
+            index + 1
+        ))),
+    }
+}
+
+fn now_ms() -> Result<i64, VmError> {
+    let duration = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|error| VmError::Runtime(format!("cache clock error: {error}")))?;
+    Ok(duration.as_millis().min(i64::MAX as u128) as i64)
+}
+
+fn sqlite_connection(path: &Path) -> Result<Connection, VmError> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|error| {
+            VmError::Runtime(format!(
+                "cache sqlite: failed to create {}: {error}",
+                parent.display()
+            ))
+        })?;
+    }
+    let conn = Connection::open(path).map_err(sqlite_error)?;
+    conn.busy_timeout(Duration::from_secs(5))
+        .map_err(sqlite_error)?;
+    conn.execute_batch(SQLITE_CREATE_TABLE)
+        .map_err(sqlite_error)?;
+    conn.execute_batch(SQLITE_CREATE_LRU_INDEX)
+        .map_err(sqlite_error)?;
+    Ok(conn)
+}
+
+fn sqlite_get(
+    options: &CacheOptions,
+    key: &str,
+    now_ms: i64,
+) -> Result<Option<serde_json::Value>, VmError> {
+    let mut conn = sqlite_connection(&options.path)?;
+    let tx = conn.transaction().map_err(sqlite_error)?;
+    let row: Option<(String, Option<i64>)> = tx
+        .query_row(
+            "SELECT value_json, expires_at_ms FROM cache_entries WHERE namespace = ?1 AND cache_key = ?2",
+            params![&options.namespace, key],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .optional()
+        .map_err(sqlite_error)?;
+    let Some((value_json, expires_at_ms)) = row else {
+        return Ok(None);
+    };
+    if expires_at_ms.is_some_and(|expires_at_ms| expires_at_ms <= now_ms) {
+        tx.execute(
+            "DELETE FROM cache_entries WHERE namespace = ?1 AND cache_key = ?2",
+            params![&options.namespace, key],
+        )
+        .map_err(sqlite_error)?;
+        tx.commit().map_err(sqlite_error)?;
+        return Ok(None);
+    }
+    let value = match serde_json::from_str(&value_json) {
+        Ok(value) => value,
+        Err(_) => {
+            tx.execute(
+                "DELETE FROM cache_entries WHERE namespace = ?1 AND cache_key = ?2",
+                params![&options.namespace, key],
+            )
+            .map_err(sqlite_error)?;
+            tx.commit().map_err(sqlite_error)?;
+            return Ok(None);
+        }
+    };
+    tx.execute(
+        "UPDATE cache_entries SET last_accessed_ms = ?3 WHERE namespace = ?1 AND cache_key = ?2",
+        params![&options.namespace, key, now_ms],
+    )
+    .map_err(sqlite_error)?;
+    tx.commit().map_err(sqlite_error)?;
+    Ok(Some(value))
+}
+
+fn sqlite_put(
+    options: &CacheOptions,
+    key: &str,
+    value: serde_json::Value,
+    now_ms: i64,
+) -> Result<(), VmError> {
+    let mut conn = sqlite_connection(&options.path)?;
+    let tx = conn.transaction().map_err(sqlite_error)?;
+    let record = CacheRecord::new(key, value, now_ms, options.ttl_seconds);
+    let value_json = serde_json::to_string(&record.value).map_err(|error| {
+        VmError::Runtime(format!("cache sqlite: failed to encode value: {error}"))
+    })?;
+    tx.execute(
+        "INSERT OR REPLACE INTO cache_entries
+         (namespace, cache_key, value_json, created_at_ms, expires_at_ms, last_accessed_ms)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        params![
+            &options.namespace,
+            record.key,
+            value_json,
+            record.created_at_ms,
+            record.expires_at_ms,
+            record.last_accessed_ms
+        ],
+    )
+    .map_err(sqlite_error)?;
+    sqlite_evict(&tx, options, now_ms)?;
+    tx.commit().map_err(sqlite_error)
+}
+
+fn sqlite_evict(conn: &Connection, options: &CacheOptions, now_ms: i64) -> Result<(), VmError> {
+    conn.execute(
+        "DELETE FROM cache_entries WHERE namespace = ?1 AND expires_at_ms IS NOT NULL AND expires_at_ms <= ?2",
+        params![&options.namespace, now_ms],
+    )
+    .map_err(sqlite_error)?;
+
+    let count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM cache_entries WHERE namespace = ?1",
+            params![&options.namespace],
+            |row| row.get(0),
+        )
+        .map_err(sqlite_error)?;
+    let excess = (count as usize).saturating_sub(options.max_entries);
+    if excess == 0 {
+        return Ok(());
+    }
+    let keys = {
+        let mut stmt = conn
+            .prepare(
+                "SELECT cache_key FROM cache_entries
+                 WHERE namespace = ?1
+                 ORDER BY last_accessed_ms ASC, created_at_ms ASC
+                 LIMIT ?2",
+            )
+            .map_err(sqlite_error)?;
+        let keys = stmt
+            .query_map(params![&options.namespace, excess as i64], |row| {
+                row.get::<_, String>(0)
+            })
+            .map_err(sqlite_error)?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(sqlite_error)?;
+        keys
+    };
+    for key in keys {
+        conn.execute(
+            "DELETE FROM cache_entries WHERE namespace = ?1 AND cache_key = ?2",
+            params![&options.namespace, key],
+        )
+        .map_err(sqlite_error)?;
+    }
+    Ok(())
+}
+
+fn sqlite_clear(options: &CacheOptions) -> Result<(), VmError> {
+    let mut conn = sqlite_connection(&options.path)?;
+    let tx = conn.transaction().map_err(sqlite_error)?;
+    tx.execute(
+        "DELETE FROM cache_entries WHERE namespace = ?1",
+        params![&options.namespace],
+    )
+    .map_err(sqlite_error)?;
+    tx.commit().map_err(sqlite_error)
+}
+
+fn sqlite_error(error: rusqlite::Error) -> VmError {
+    VmError::Runtime(format!("cache sqlite error: {error}"))
+}
+
+fn fs_key_path(options: &CacheOptions, key: &str) -> PathBuf {
+    options
+        .path
+        .join(&options.namespace)
+        .join(format!("{}.json", sha256_hex(key.as_bytes())))
+}
+
+fn fs_get(
+    options: &CacheOptions,
+    key: &str,
+    now_ms: i64,
+) -> Result<Option<serde_json::Value>, VmError> {
+    let path = fs_key_path(options, key);
+    let Ok(contents) = std::fs::read_to_string(&path) else {
+        return Ok(None);
+    };
+    let Ok(mut record) = serde_json::from_str::<CacheRecord>(&contents) else {
+        let _ = std::fs::remove_file(path);
+        return Ok(None);
+    };
+    if record.key != key || record.is_expired(now_ms) {
+        let _ = std::fs::remove_file(path);
+        return Ok(None);
+    }
+    record.last_accessed_ms = now_ms;
+    write_fs_record(&path, &record)?;
+    Ok(Some(record.value))
+}
+
+fn fs_put(
+    options: &CacheOptions,
+    key: &str,
+    value: serde_json::Value,
+    now_ms: i64,
+) -> Result<(), VmError> {
+    let path = fs_key_path(options, key);
+    let record = CacheRecord::new(key, value, now_ms, options.ttl_seconds);
+    write_fs_record(&path, &record)?;
+    fs_evict(options, now_ms)
+}
+
+fn fs_evict(options: &CacheOptions, now_ms: i64) -> Result<(), VmError> {
+    let dir = options.path.join(&options.namespace);
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return Ok(());
+    };
+    let mut live = Vec::new();
+    for entry in entries {
+        let entry = entry.map_err(|error| {
+            VmError::Runtime(format!(
+                "cache fs: failed to read {}: {error}",
+                dir.display()
+            ))
+        })?;
+        let path = entry.path();
+        if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+            continue;
+        }
+        let Ok(contents) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let Ok(record) = serde_json::from_str::<CacheRecord>(&contents) else {
+            let _ = std::fs::remove_file(path);
+            continue;
+        };
+        if record.is_expired(now_ms) {
+            let _ = std::fs::remove_file(path);
+        } else {
+            live.push((path, record.last_accessed_ms, record.created_at_ms));
+        }
+    }
+    let excess = live.len().saturating_sub(options.max_entries);
+    if excess == 0 {
+        return Ok(());
+    }
+    live.sort_by_key(|(_, last_accessed_ms, created_at_ms)| (*last_accessed_ms, *created_at_ms));
+    for (path, _, _) in live.into_iter().take(excess) {
+        let _ = std::fs::remove_file(path);
+    }
+    Ok(())
+}
+
+fn fs_clear(options: &CacheOptions) -> Result<(), VmError> {
+    let dir = options.path.join(&options.namespace);
+    match std::fs::remove_dir_all(&dir) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(VmError::Runtime(format!(
+            "cache fs: failed to clear {}: {error}",
+            dir.display()
+        ))),
+    }
+}
+
+fn write_fs_record(path: &Path, record: &CacheRecord) -> Result<(), VmError> {
+    let serialized = serde_json::to_vec_pretty(record)
+        .map_err(|error| VmError::Runtime(format!("cache fs: failed to encode record: {error}")))?;
+    crate::atomic_io::atomic_write(path, &serialized).map_err(|error| {
+        VmError::Runtime(format!(
+            "cache fs: failed to write {}: {error}",
+            path.display()
+        ))
+    })
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    hex::encode(Sha256::digest(bytes))
+}
+
+fn json_float_or_null(value: Option<f64>) -> serde_json::Value {
+    value
+        .and_then(serde_json::Number::from_f64)
+        .map(serde_json::Value::Number)
+        .unwrap_or(serde_json::Value::Null)
+}
+
+fn canonical_json_bytes(value: &serde_json::Value) -> Result<Vec<u8>, VmError> {
+    serde_json::to_vec(&canonicalize_json_value(value)).map_err(|error| {
+        VmError::Runtime(format!("failed to encode canonical cache JSON: {error}"))
+    })
+}
+
+fn canonicalize_json_value(value: &serde_json::Value) -> serde_json::Value {
+    match value {
+        serde_json::Value::Array(items) => {
+            serde_json::Value::Array(items.iter().map(canonicalize_json_value).collect())
+        }
+        serde_json::Value::Object(map) => {
+            let mut keys = map.keys().collect::<Vec<_>>();
+            keys.sort();
+            let mut out = serde_json::Map::new();
+            for key in keys {
+                out.insert(key.clone(), canonicalize_json_value(&map[key]));
+            }
+            serde_json::Value::Object(out)
+        }
+        other => other.clone(),
+    }
+}
+
+#[cfg(test)]
+#[path = "cache_tests.rs"]
+mod tests;

--- a/crates/harn-vm/src/llm/cache_tests.rs
+++ b/crates/harn-vm/src/llm/cache_tests.rs
@@ -1,0 +1,123 @@
+use std::path::PathBuf;
+
+use rusqlite::params;
+
+use super::*;
+
+fn sqlite_options(path: PathBuf) -> CacheOptions {
+    CacheOptions {
+        backend: CacheBackend::Sqlite,
+        namespace: "test".to_string(),
+        path,
+        ttl_seconds: 60,
+        max_entries: 2,
+    }
+}
+
+#[test]
+fn sqlite_cache_hits_update_lru_and_evict_oldest() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let options = sqlite_options(dir.path().join("cache.sqlite"));
+
+    cache_put_at(&options, "a", serde_json::json!({"value": "a"}), 1_000).unwrap();
+    cache_put_at(&options, "b", serde_json::json!({"value": "b"}), 2_000).unwrap();
+    assert_eq!(
+        cache_get_at(&options, "a", 3_000).unwrap(),
+        Some(serde_json::json!({"value": "a"}))
+    );
+    cache_put_at(&options, "c", serde_json::json!({"value": "c"}), 4_000).unwrap();
+
+    assert_eq!(cache_get_at(&options, "b", 5_000).unwrap(), None);
+    assert!(cache_get_at(&options, "a", 5_000).unwrap().is_some());
+    assert!(cache_get_at(&options, "c", 5_000).unwrap().is_some());
+}
+
+#[test]
+fn sqlite_cache_expires_entries() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut options = sqlite_options(dir.path().join("cache.sqlite"));
+    options.ttl_seconds = 1;
+
+    cache_put_at(&options, "a", serde_json::json!("cached"), 1_000).unwrap();
+
+    assert_eq!(
+        cache_get_at(&options, "a", 1_999).unwrap(),
+        Some(serde_json::json!("cached"))
+    );
+    assert_eq!(cache_get_at(&options, "a", 2_000).unwrap(), None);
+}
+
+#[test]
+fn fs_cache_hits_and_evicts_oldest() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let options = CacheOptions {
+        backend: CacheBackend::Fs,
+        namespace: "test".to_string(),
+        path: dir.path().join("fs-cache"),
+        ttl_seconds: 60,
+        max_entries: 1,
+    };
+
+    cache_put_at(&options, "a", serde_json::json!({"value": "a"}), 1_000).unwrap();
+    assert_eq!(
+        cache_get_at(&options, "a", 2_000).unwrap(),
+        Some(serde_json::json!({"value": "a"}))
+    );
+    cache_put_at(&options, "b", serde_json::json!({"value": "b"}), 3_000).unwrap();
+
+    assert_eq!(cache_get_at(&options, "a", 4_000).unwrap(), None);
+    assert_eq!(
+        cache_get_at(&options, "b", 4_000).unwrap(),
+        Some(serde_json::json!({"value": "b"}))
+    );
+}
+
+#[test]
+fn corrupt_cache_entries_are_misses() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let sqlite = sqlite_options(dir.path().join("cache.sqlite"));
+    {
+        let conn = sqlite_connection(&sqlite.path).unwrap();
+        conn.execute(
+            "INSERT INTO cache_entries
+             (namespace, cache_key, value_json, created_at_ms, expires_at_ms, last_accessed_ms)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params!["test", "bad", "{not json", 1_000, 61_000, 1_000],
+        )
+        .unwrap();
+    }
+    assert_eq!(cache_get_at(&sqlite, "bad", 2_000).unwrap(), None);
+    assert_eq!(cache_get_at(&sqlite, "bad", 2_000).unwrap(), None);
+
+    let fs = CacheOptions {
+        backend: CacheBackend::Fs,
+        namespace: "test".to_string(),
+        path: dir.path().join("fs-cache"),
+        ttl_seconds: 60,
+        max_entries: 1,
+    };
+    let path = fs_key_path(&fs, "bad");
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(&path, b"{not json").unwrap();
+
+    assert_eq!(cache_get_at(&fs, "bad", 2_000).unwrap(), None);
+    assert!(!path.exists());
+}
+
+#[test]
+fn canonical_json_sorts_nested_object_keys() {
+    let first = serde_json::json!({"b": 2, "a": {"d": 4, "c": 3}});
+    let second = serde_json::json!({"a": {"c": 3, "d": 4}, "b": 2});
+
+    assert_eq!(
+        canonical_json_bytes(&first).unwrap(),
+        canonical_json_bytes(&second).unwrap()
+    );
+}
+
+#[test]
+fn cache_record_large_ttl_saturates_forward() {
+    let record = CacheRecord::new("a", serde_json::json!(true), 1_000, u64::MAX);
+
+    assert_eq!(record.expires_at_ms, Some(i64::MAX));
+}

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -18,6 +18,7 @@ mod agent_session_host;
 mod agent_tools;
 pub(crate) mod api;
 pub(crate) mod autonomy_budget;
+mod cache;
 pub mod capabilities;
 mod config_builtins;
 pub(crate) mod content;
@@ -2187,6 +2188,7 @@ pub fn register_llm_builtins(vm: &mut Vm) {
     agent_session_host::register_agent_session_host_primitives(vm);
 
     conversation::register_conversation_builtins(vm);
+    cache::register_cache_builtins(vm);
     config_builtins::register_config_builtins(vm);
     cost::register_cost_builtins(vm);
     register_llm_mock_builtins(vm);

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -3286,6 +3286,35 @@ Without `prefer`, `fallback_strategy: cheapest_first` and
 `cheapest_over_quality(quality)` / `fastest_over_quality(quality)` policy,
 using `quality` or `min_quality` when present and `mid` otherwise.
 
+For call sites that want Harn-managed response reuse, `std/llm/handlers`
+exports `with_cache(prompt, system?, options?)`. It returns the same envelope as
+`llm_call`, but first checks a persistent content-addressed cache. The key is
+`sha256:` plus canonical JSON over `{prompt, system, provider, model,
+temperature, top_p, max_tokens}` after provider/model defaults resolve. Cache
+storage defaults to a sqlite store under Harn state with namespace
+`llm.with_cache`, a 10-minute TTL, and LRU eviction at 256 entries. Calls with
+`options.tools != nil` bypass the cache by default because tool results can
+carry side effects; callers may set `skip_when` to a bool or predicate closure
+to override that policy.
+
+```harn
+import { with_cache } from "std/llm/handlers"
+
+let r = with_cache("Summarize this file", nil, {
+  provider: "anthropic",
+  model: "claude-haiku-4-5",
+  store: {backend: "fs", namespace: "summaries"},
+  ttl: "10m",
+  max_entries: 256,
+})
+```
+
+`std/cache` exposes the underlying `{hit, value?}` primitive with
+`cache_get(key, options?)`, `cache_put(key, value, options?)`, and
+`cache_clear(options?)`. Cache options accept either `store: "namespace"` or
+`store: {backend: "sqlite"|"fs", namespace?, path?}` plus `ttl`,
+`ttl_seconds`, `max_age_seconds`, and `max_entries`.
+
 The emitted schema follows canonical JSON-Schema conventions (objects
 with `properties`/`required`, arrays with `items`, literal unions as
 `{type, enum}`) so it is compatible with structured-output validators

--- a/docs/src/llm/llm_call.md
+++ b/docs/src/llm/llm_call.md
@@ -133,6 +133,30 @@ as both LLM content and deterministic `vision_ocr(...)` context.
 | `transcript` | dict | nil | Continue from a previous transcript; prompt is appended as the next user turn |
 | `model_tier` | string | nil | Resolve a configured tier alias such as `"small"`, `"mid"`, or `"frontier"` |
 
+The `cache` option above enables provider-side prompt caching when a provider
+supports it. It does not memoize full LLM responses. For Harn-owned response
+caching, import `with_cache` from `std/llm/handlers`:
+
+```harn
+import { with_cache } from "std/llm/handlers"
+
+let result = with_cache("Summarize this file", nil, {
+  provider: "anthropic",
+  model: "claude-haiku-4-5",
+  store: {backend: "sqlite", namespace: "summaries"},
+  ttl: "10m",
+  max_entries: 256,
+})
+```
+
+`with_cache` returns the same envelope as `llm_call`. Its key is
+content-addressed as `sha256:` over canonical JSON for `{prompt, system,
+provider, model, temperature, top_p, max_tokens}` after defaults resolve. The
+default store is sqlite under Harn state, namespace `llm.with_cache`, TTL 10
+minutes, and LRU size 256. Use `store: {backend: "fs", namespace, path?}` for
+one-file-per-entry storage. Calls with `tools` bypass the cache by default;
+set `skip_when` to a bool or predicate closure to override that policy.
+
 Provider-specific overrides can be passed as sub-dicts:
 
 ```harn

--- a/docs/src/modules.md
+++ b/docs/src/modules.md
@@ -79,8 +79,9 @@ code or inside any pipeline.
 
 `import "std/..."` is only needed for the Harn-written helper modules
 described below (`std/text`, `std/json`, `std/math`, `std/collections`,
-`std/path`, `std/vision`, `std/context`, `std/agent_state`, `std/agents`,
-`std/runtime`, `std/command`, `std/review`, `std/experiments`,
+`std/path`, `std/cache`, `std/llm/handlers`, `std/vision`, `std/context`,
+`std/agent_state`, `std/agents`, `std/runtime`, `std/command`, `std/review`,
+`std/experiments`,
 `std/project`, `std/memory`, `std/prompt_library`, `std/monitors`,
 `std/worktree`, `std/checkpoint`, `std/personas/prelude`,
 `std/connectors/shared`, and provider-specific `std/connectors/...` modules).
@@ -100,6 +101,8 @@ import "std/math"
 import "std/path"
 import "std/vision"
 import "std/json"
+import "std/cache"
+import "std/llm/handlers"
 import "std/context"
 import "std/agent_state"
 import "std/agents"
@@ -319,6 +322,36 @@ let merged = merge({a: 1}, {b: 2})    // {a: 1, b: 2}
 let subset = pick({a: 1, b: 2, c: 3}, ["a", "c"])  // {a: 1, c: 3}
 let rest = omit({a: 1, b: 2, c: 3}, ["b"])          // {a: 1, c: 3}
 ```
+
+### std/cache
+
+Persistent cache helpers backed by sqlite or filesystem storage:
+
+| Function | Description |
+|---|---|
+| `cache_get(key, options?)` | Return `{hit: bool, value?}` for a persistent cache key |
+| `cache_put(key, value, options?)` | Store a value with TTL and LRU eviction |
+| `cache_clear(options?)` | Remove all entries in the configured namespace |
+
+Options accept `store: "namespace"` or
+`store: {backend: "sqlite"|"fs", namespace?, path?}`, plus `ttl`,
+`ttl_seconds`, `max_age_seconds`, and `max_entries`.
+
+### std/llm/handlers
+
+LLM call wrappers and middleware helpers:
+
+| Function | Description |
+|---|---|
+| `llm_cache_key(prompt, system?, options?)` | Derive the canonical `sha256:` key for a cached LLM call |
+| `with_cache(prompt, system?, options?)` | Return a cached `llm_call` envelope when available, otherwise call and store the response |
+| `with_circuit_breaker(handler, options?)` | Wrap a call handler with per-`(provider, model)` circuit-breaker pooling, or pass `name` to share one circuit |
+
+`with_cache` keys `{prompt, system, provider, model, temperature, top_p,
+max_tokens}` after defaults resolve. Its default store is sqlite namespace
+`llm.with_cache` with TTL `10m` and LRU size 256. Calls with `tools` bypass the
+cache by default; set `skip_when` to a bool or predicate closure to override
+that policy.
 
 ### std/context
 
@@ -579,14 +612,6 @@ Helpers for isolated git worktree execution built on `exec_at(...)` and
 | `worktree_status(path)` | Run `git status --short --branch` in the worktree |
 | `worktree_diff(path, base_ref?)` | Render diff output for the worktree |
 | `worktree_shell(path, script)` | Run an arbitrary shell command inside the worktree |
-
-### std/llm/handlers
-
-Middleware helpers for LLM call handlers:
-
-| Function | Description |
-|---|---|
-| `with_circuit_breaker(handler, options?)` | Wrap a call handler with per-`(provider, model)` circuit-breaker pooling, or pass `name` to share one circuit |
 
 ### std/personas/prelude
 

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -3284,6 +3284,35 @@ Without `prefer`, `fallback_strategy: cheapest_first` and
 `cheapest_over_quality(quality)` / `fastest_over_quality(quality)` policy,
 using `quality` or `min_quality` when present and `mid` otherwise.
 
+For call sites that want Harn-managed response reuse, `std/llm/handlers`
+exports `with_cache(prompt, system?, options?)`. It returns the same envelope as
+`llm_call`, but first checks a persistent content-addressed cache. The key is
+`sha256:` plus canonical JSON over `{prompt, system, provider, model,
+temperature, top_p, max_tokens}` after provider/model defaults resolve. Cache
+storage defaults to a sqlite store under Harn state with namespace
+`llm.with_cache`, a 10-minute TTL, and LRU eviction at 256 entries. Calls with
+`options.tools != nil` bypass the cache by default because tool results can
+carry side effects; callers may set `skip_when` to a bool or predicate closure
+to override that policy.
+
+```harn
+import { with_cache } from "std/llm/handlers"
+
+let r = with_cache("Summarize this file", nil, {
+  provider: "anthropic",
+  model: "claude-haiku-4-5",
+  store: {backend: "fs", namespace: "summaries"},
+  ttl: "10m",
+  max_entries: 256,
+})
+```
+
+`std/cache` exposes the underlying `{hit, value?}` primitive with
+`cache_get(key, options?)`, `cache_put(key, value, options?)`, and
+`cache_clear(options?)`. Cache options accept either `store: "namespace"` or
+`store: {backend: "sqlite"|"fs", namespace?, path?}` plus `ttl`,
+`ttl_seconds`, `max_age_seconds`, and `max_entries`.
+
 The emitted schema follows canonical JSON-Schema conventions (objects
 with `properties`/`required`, arrays with `items`, literal unions as
 `{type, enum}`) so it is compatible with structured-output validators


### PR DESCRIPTION
## Summary
- add std/cache backed by sqlite or filesystem storage with TTL, LRU eviction, namespace/path options, and corrupt-entry miss handling
- add std/llm/handlers.with_cache plus llm_cache_key for content-addressed LLM response caching with default tool-call bypass
- document the new modules and persistent cache behavior, and add conformance coverage for sqlite, fs, and tool bypass

## Verification
- cargo test -p harn-vm llm::cache --lib
- cargo check --workspace
- cargo run --bin harn -- test conformance --filter llm_handlers_with_cache
- make check-docs-snippets
- make fmt-harn lint-harn
- make lint-test-patterns
- pre-commit hook
- pre-push hook

Closes #1322