### PR TITLE
Add VmEnv closure clone benchmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,7 @@ agent_loop(task, sys, {
   llm_caller: with_retry(default_llm_caller(), {max_attempts: 4}),
 })
 ```
+
 ## Unreleased
 
 ### Added
@@ -161,7 +162,6 @@ agent_loop(task, sys, {
   non-interactive setup flow that detects provider credentials, local Ollama,
   free disk space, and local GPU availability, then writes starter
   `providers.toml`, `harn.toml`, and `.env` files.
-## Unreleased
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2018,6 +2018,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "harn-vm-perf"
+version = "0.0.0"
+dependencies = [
+ "criterion",
+ "harn-vm",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "crates/harn-lint",
     "crates/harn-hostlib",
     "perf/llm",
+    "perf/vm",
 ]
 # Build harn-wasm separately: cd crates/harn-wasm && wasm-pack build
 exclude = ["crates/harn-wasm"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup install-hooks configure-merge-drivers build build-release check fmt fmt-harn fmt-harn-fix lint lint-md lint-actions lint-harn spec-lint test test-e2e test-cargo test-fast conformance protocol-conformance bench-vm bench-llm all release-gate portal portal-check portal-demo gen-highlight check-highlight gen-trigger-quickref check-trigger-quickref gen-provider-matrix check-provider-matrix gen-connector-matrix check-connector-matrix check-trigger-examples check-docs-snippets sync-language-spec check-language-spec lint-test-patterns check-receipt-structs lint-no-rust-prompt-prose lint-no-xfail-regression
+.PHONY: setup install-hooks configure-merge-drivers build build-release check fmt fmt-harn fmt-harn-fix lint lint-md lint-actions lint-harn spec-lint test test-e2e test-cargo test-fast conformance protocol-conformance bench-vm bench-vm-clone bench-llm all release-gate portal portal-check portal-demo gen-highlight check-highlight gen-trigger-quickref check-trigger-quickref gen-provider-matrix check-provider-matrix gen-connector-matrix check-connector-matrix check-trigger-examples check-docs-snippets sync-language-spec check-language-spec lint-test-patterns check-receipt-structs lint-no-rust-prompt-prose lint-no-xfail-regression
 
 # Full quality check: format first, then lint/test in parallel.
 # Usage: make all -j       (parallel checks after formatting)
@@ -74,6 +74,9 @@ protocol-conformance:
 
 bench-vm:
 	./scripts/bench_vm.sh
+
+bench-vm-clone:
+	cargo bench -p harn-vm-perf --bench bench_vmenv_clone -- --output-format bencher
 
 bench-llm:
 	cargo bench -p harn-llm-perf --bench bench_llm_options_roundtrip -- --output-format bencher

--- a/crates/harn-cli/src/commands/doctor.rs
+++ b/crates/harn-cli/src/commands/doctor.rs
@@ -398,7 +398,6 @@ fn detect_ram_gb() -> Option<u64> {
         for line in text.lines() {
             if let Some(rest) = line.strip_prefix("MemTotal:") {
                 let kb: u64 = rest
-                    .trim()
                     .split_whitespace()
                     .next()
                     .and_then(|n| n.parse().ok())?;

--- a/crates/harn-vm/Cargo.toml
+++ b/crates/harn-vm/Cargo.toml
@@ -10,6 +10,7 @@ description = "Async bytecode virtual machine for the Harn programming language"
 [features]
 default = []
 llm-bench-internals = []
+vm-bench-internals = []
 otel = [
     "dep:opentelemetry",
     "dep:opentelemetry_sdk",

--- a/crates/harn-vm/src/bench_internals.rs
+++ b/crates/harn-vm/src/bench_internals.rs
@@ -1,0 +1,87 @@
+use std::rc::Rc;
+
+use crate::{Chunk, CompiledFunction, Vm, VmClosure, VmEnv, VmValue};
+
+pub const VMENV_CAPTURE_COUNTS: [usize; 4] = [0, 5, 25, 100];
+
+pub struct NonModuleClosureCallFixture {
+    capture_count: usize,
+    last_capture_name: Option<String>,
+    caller_env: VmEnv,
+    closure: VmClosure,
+}
+
+impl NonModuleClosureCallFixture {
+    pub fn new(capture_count: usize) -> Self {
+        let nested_inner = synthetic_closure("nested_inner", VmEnv::new());
+
+        let mut caller_env = VmEnv::new();
+        caller_env
+            .define(
+                "nested_inner",
+                VmValue::Closure(Rc::new(nested_inner.clone())),
+                false,
+            )
+            .expect("synthetic caller closure binding should be valid");
+
+        let mut closure_env = VmEnv::new();
+        for index in 0..capture_count {
+            closure_env
+                .define(
+                    &format!("captured_{index:03}"),
+                    VmValue::Int(index as i64),
+                    false,
+                )
+                .expect("synthetic captured binding should be valid");
+        }
+
+        let closure = synthetic_closure(&format!("capture_{capture_count:03}"), closure_env);
+        Self {
+            capture_count,
+            last_capture_name: capture_count
+                .checked_sub(1)
+                .map(|index| format!("captured_{index:03}")),
+            caller_env,
+            closure,
+        }
+    }
+
+    pub fn capture_count(&self) -> usize {
+        self.capture_count
+    }
+
+    pub fn invoke(&self) -> usize {
+        let env = Vm::closure_call_env(&self.caller_env, &self.closure);
+        let mut score = env.scope_depth();
+        if let Some(name) = self.last_capture_name.as_deref() {
+            if let Some(VmValue::Int(value)) = env.get(name) {
+                score += value as usize;
+            }
+        }
+        if matches!(env.get("nested_inner"), Some(VmValue::Closure(_))) {
+            score += 1;
+        }
+        score
+    }
+}
+
+fn synthetic_closure(name: &str, env: VmEnv) -> VmClosure {
+    let func = CompiledFunction {
+        name: name.to_string(),
+        type_params: Vec::new(),
+        nominal_type_names: Vec::new(),
+        params: Vec::new(),
+        default_start: None,
+        chunk: Rc::new(Chunk::new()),
+        is_generator: false,
+        is_stream: false,
+        has_rest_param: false,
+    };
+    VmClosure {
+        func: Rc::new(func),
+        env,
+        source_dir: None,
+        module_functions: None,
+        module_state: None,
+    }
+}

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -229,6 +229,10 @@ pub use trust_graph::{
 pub use value::*;
 pub use vm::*;
 
+#[cfg(feature = "vm-bench-internals")]
+#[doc(hidden)]
+pub mod bench_internals;
+
 /// Lex, parse, type-check, and compile source to bytecode in one call.
 /// Bails on the first type error. For callers that need diagnostics
 /// rather than early exit, use `harn_parser::check_source` directly

--- a/perf/vm/Cargo.toml
+++ b/perf/vm/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "harn-vm-perf"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+harn-vm = { path = "../../crates/harn-vm", features = ["vm-bench-internals"] }
+
+[dev-dependencies]
+criterion = "0.8"
+
+[[bench]]
+name = "bench_vmenv_clone"
+path = "bench_vmenv_clone.rs"
+harness = false

--- a/perf/vm/README.md
+++ b/perf/vm/README.md
@@ -28,6 +28,16 @@ To compare against the checked-in local baseline:
 full suite passes. The comparison column uses the baseline table's
 `mean_avg_ms` value.
 
+The Criterion VM clone-on-call probe is separate from the fixture runner:
+
+```bash
+cargo bench -p harn-vm-perf --bench bench_vmenv_clone
+```
+
+It measures the internal non-module closure call environment path at 0, 5, 25,
+and 100 captured names. Criterion reports time per call; the benchmark also
+prints allocation operations per call for each capture count.
+
 This suite is intentionally not part of `make all`; local CPU load, thermal
 state, and target cache state are too noisy for a default correctness gate. For
 before/after VM optimization work, run the suite several times on the same

--- a/perf/vm/bench_vmenv_clone.rs
+++ b/perf/vm/bench_vmenv_clone.rs
@@ -1,0 +1,80 @@
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::hint::black_box;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use harn_vm::bench_internals::{NonModuleClosureCallFixture, VMENV_CAPTURE_COUNTS};
+
+struct CountingAllocator;
+
+static COUNT_ALLOCATIONS: AtomicBool = AtomicBool::new(false);
+static ALLOCATION_CALLS: AtomicU64 = AtomicU64::new(0);
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        if COUNT_ALLOCATIONS.load(Ordering::Relaxed) {
+            ALLOCATION_CALLS.fetch_add(1, Ordering::Relaxed);
+        }
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        if COUNT_ALLOCATIONS.load(Ordering::Relaxed) {
+            ALLOCATION_CALLS.fetch_add(1, Ordering::Relaxed);
+        }
+        unsafe { System.alloc_zeroed(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        if COUNT_ALLOCATIONS.load(Ordering::Relaxed) {
+            ALLOCATION_CALLS.fetch_add(1, Ordering::Relaxed);
+        }
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+}
+
+#[global_allocator]
+static GLOBAL: CountingAllocator = CountingAllocator;
+
+fn allocations_per_call(fixture: &NonModuleClosureCallFixture, iterations: u64) -> f64 {
+    ALLOCATION_CALLS.store(0, Ordering::Relaxed);
+    COUNT_ALLOCATIONS.store(true, Ordering::Relaxed);
+    for _ in 0..iterations {
+        black_box(fixture.invoke());
+    }
+    COUNT_ALLOCATIONS.store(false, Ordering::Relaxed);
+    ALLOCATION_CALLS.load(Ordering::Relaxed) as f64 / iterations as f64
+}
+
+fn bench_vmenv_clone(c: &mut Criterion) {
+    let fixtures = VMENV_CAPTURE_COUNTS
+        .into_iter()
+        .map(NonModuleClosureCallFixture::new)
+        .collect::<Vec<_>>();
+
+    let mut group = c.benchmark_group("vmenv_non_module_closure_call");
+    for fixture in &fixtures {
+        let allocs_per_call = allocations_per_call(fixture, 10_000);
+        eprintln!(
+            "vmenv_non_module_closure_call/captures_{:03}: {:.2} allocations/call",
+            fixture.capture_count(),
+            allocs_per_call
+        );
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("captures_{:03}", fixture.capture_count())),
+            fixture,
+            |b, fixture| {
+                b.iter(|| black_box(fixture.invoke()));
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_vmenv_clone);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary
- add a feature-gated VM benchmark fixture for the non-module closure call env path
- add `perf/vm/bench_vmenv_clone.rs` with Criterion timing and allocation-count reporting
- wire `perf/vm` into the workspace and document the new `make bench-vm-clone` path
- fix two rebased CI issues: a newer Clippy `trim_split_whitespace` warning in `harn doctor` and adjacent `CHANGELOG.md` markdown headings

Closes #1337

## Verification
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 "**/*.md"`
- `CARGO_TARGET_DIR=/tmp/harn-1337-target cargo check -p harn-vm-perf --benches`
- `CARGO_TARGET_DIR=/tmp/harn-1337-target HARN_LLM_CALLS_DISABLED=1 cargo clippy -p harn-vm-perf --benches -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/harn-1337-target HARN_LLM_CALLS_DISABLED=1 cargo clippy -p harn-cli --lib -- -D warnings`
- pre-commit hook: workspace clippy, markdown, actions, generated highlight check
- pre-push hook: targeted local checks, markdown, generated highlight check
- `CARGO_TARGET_DIR=/tmp/harn-1337-target cargo bench -p harn-vm-perf --bench bench_vmenv_clone -- --sample-size 10 --warm-up-time 0.3 --measurement-time 1.0`

## Benchmark Report
| Captured names | Time/call | Allocations/call |
| ---: | ---: | ---: |
| 0 | 65.12 ns | 3.00 |
| 5 | 220.66 ns | 8.00 |
| 25 | 769.36 ns | 32.00 |
| 100 | 2.6013 µs | 119.00 |

The 25-capture case is below the issue threshold of 1 µs/call, so I did not open a follow-up optimization issue.