### PR TITLE
Add orchestration hook dispatch benchmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,10 +96,21 @@ condensed series summaries instead of full per-patch history.
   provider with `with_retry`-wrapped `default_llm_caller`.
 - **`harn doctor --json`.** Doctor now also checks Ollama, hardware,
   Harn version, and prints a "Next step" suggestion.
+- **Orchestration hook dispatch benchmark.** Added `harn-orchestration-perf`
+  and `make bench-orchestration` to measure no-op VM lifecycle hook fanout
+  costs across 1, 8, 32, and 128 trigger-shaped events.
 - **Lint rule `deprecated_llm_options`.** Warns on `llm_retries` /
   `llm_backoff_ms` in dict literals passed to `llm_call` /
   `llm_call_safe` / `llm_call_structured` / `llm_call_structured_result` /
   `agent_loop`.
+- **`harn quickstart` setup wizard (#1331).** Added an interactive and
+  non-interactive setup flow that detects provider credentials, local Ollama,
+  free disk space, and local GPU availability, then writes starter
+  `providers.toml`, `harn.toml`, and `.env` files.
+- **Tiktoken-grade token counting.** Added `tiktoken_count_tokens(text, model)`
+  and `std/llm/budget` helpers so budget checks use exact OpenAI tiktoken
+  counts when available, labeled tiktoken approximations for Claude/Gemini
+  model families, and the heuristic fallback only for unknown model IDs.
 
 ### Changed
 
@@ -107,6 +118,9 @@ condensed series summaries instead of full per-patch history.
 - Improved no-providers-configured error message names every supported
   env var dynamically and points at `harn doctor` and (when available)
   `harn models recommend`.
+- **`std/async` predicate retry rename.** Renamed `retry_with_backoff` to
+  `retry_predicate_with_backoff` and removed the old export, with lint autofix
+  support for stale call sites.
 
 ### Deprecated
 
@@ -153,25 +167,6 @@ agent_loop(task, sys, {
   llm_caller: with_retry(default_llm_caller(), {max_attempts: 4}),
 })
 ```
-
-## Unreleased
-
-### Added
-
-- **`harn quickstart` setup wizard (#1331).** Added an interactive and
-  non-interactive setup flow that detects provider credentials, local Ollama,
-  free disk space, and local GPU availability, then writes starter
-  `providers.toml`, `harn.toml`, and `.env` files.
-
-### Changed
-
-- **`std/async` predicate retry rename.** Renamed `retry_with_backoff` to
-  `retry_predicate_with_backoff` and removed the old export, with lint autofix
-  support for stale call sites.
-- **Tiktoken-grade token counting.** Added `tiktoken_count_tokens(text, model)`
-  and `std/llm/budget` helpers so budget checks use exact OpenAI tiktoken
-  counts when available, labeled tiktoken approximations for Claude/Gemini
-  model families, and the heuristic fallback only for unknown model IDs.
 
 ## v0.7.61
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1900,6 +1900,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "harn-orchestration-perf"
+version = "0.0.0"
+dependencies = [
+ "criterion",
+ "futures",
+ "harn-vm",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "harn-parser"
 version = "0.7.62"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "crates/harn-hostlib",
     "perf/llm",
     "perf/vm",
+    "perf/orchestration",
 ]
 # Build harn-wasm separately: cd crates/harn-wasm && wasm-pack build
 exclude = ["crates/harn-wasm"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup install-hooks configure-merge-drivers build build-release check fmt fmt-harn fmt-harn-fix lint lint-md lint-actions lint-harn spec-lint test test-e2e test-cargo test-fast conformance protocol-conformance bench-vm bench-vm-clone bench-llm all release-gate portal portal-check portal-demo gen-highlight check-highlight gen-trigger-quickref check-trigger-quickref gen-provider-matrix check-provider-matrix gen-connector-matrix check-connector-matrix check-trigger-examples check-docs-snippets sync-language-spec check-language-spec lint-test-patterns check-receipt-structs lint-no-rust-prompt-prose lint-no-xfail-regression
+.PHONY: setup install-hooks configure-merge-drivers build build-release check fmt fmt-harn fmt-harn-fix lint lint-md lint-actions lint-harn spec-lint test test-e2e test-cargo test-fast conformance protocol-conformance bench-vm bench-vm-clone bench-llm bench-orchestration all release-gate portal portal-check portal-demo gen-highlight check-highlight gen-trigger-quickref check-trigger-quickref gen-provider-matrix check-provider-matrix gen-connector-matrix check-connector-matrix check-trigger-examples check-docs-snippets sync-language-spec check-language-spec lint-test-patterns check-receipt-structs lint-no-rust-prompt-prose lint-no-xfail-regression
 
 # Full quality check: format first, then lint/test in parallel.
 # Usage: make all -j       (parallel checks after formatting)
@@ -80,6 +80,9 @@ bench-vm-clone:
 
 bench-llm:
 	cargo bench -p harn-llm-perf --bench bench_llm_options_roundtrip -- --output-format bencher
+
+bench-orchestration:
+	cargo bench -p harn-orchestration-perf --bench bench_hook_dispatch -- --output-format bencher
 
 # Lint markdown files
 lint-md:

--- a/perf/orchestration/Cargo.toml
+++ b/perf/orchestration/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "harn-orchestration-perf"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+futures = "0.3"
+harn-vm = { path = "../../crates/harn-vm" }
+serde_json = "1"
+tokio = { version = "1", features = ["rt", "time"] }
+
+[dev-dependencies]
+criterion = "0.8"
+
+[[bench]]
+name = "bench_hook_dispatch"
+path = "bench_hook_dispatch.rs"
+harness = false

--- a/perf/orchestration/bench_hook_dispatch.rs
+++ b/perf/orchestration/bench_hook_dispatch.rs
@@ -1,0 +1,191 @@
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::hint::black_box;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::time::Instant;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use futures::future::join_all;
+use harn_vm::orchestration::{
+    clear_runtime_hooks, matching_vm_lifecycle_hooks, register_vm_hook, run_lifecycle_hooks,
+    HookEvent,
+};
+use harn_vm::{install_async_builtin_child_vm, register_vm_stdlib, reset_thread_local_state, Vm};
+use serde_json::{json, Value as JsonValue};
+use tokio::runtime::{Builder, Runtime};
+
+const FANOUTS: [usize; 4] = [1, 8, 32, 128];
+const HOOK_EVENT: HookEvent = HookEvent::PreAgentTurn;
+
+static TRACK_ALLOCATIONS: AtomicBool = AtomicBool::new(false);
+static ALLOCATION_COUNT: AtomicU64 = AtomicU64::new(0);
+static ALLOCATED_BYTES: AtomicU64 = AtomicU64::new(0);
+
+struct CountingAllocator;
+
+#[global_allocator]
+static GLOBAL_ALLOCATOR: CountingAllocator = CountingAllocator;
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        // SAFETY: This allocator only observes calls before delegating to the system allocator.
+        let ptr = unsafe { System.alloc(layout) };
+        record_allocation(ptr, layout.size());
+        ptr
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        // SAFETY: This allocator only observes calls before delegating to the system allocator.
+        let ptr = unsafe { System.alloc_zeroed(layout) };
+        record_allocation(ptr, layout.size());
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        // SAFETY: The pointer and layout are passed through unchanged from the allocator caller.
+        unsafe { System.dealloc(ptr, layout) };
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        // SAFETY: The pointer, layout, and new size are passed through unchanged.
+        let ptr = unsafe { System.realloc(ptr, layout, new_size) };
+        record_allocation(ptr, new_size);
+        ptr
+    }
+}
+
+fn record_allocation(ptr: *mut u8, bytes: usize) {
+    if !ptr.is_null() && TRACK_ALLOCATIONS.load(Ordering::Relaxed) {
+        ALLOCATION_COUNT.fetch_add(1, Ordering::Relaxed);
+        ALLOCATED_BYTES.fetch_add(bytes as u64, Ordering::Relaxed);
+    }
+}
+
+#[derive(Clone)]
+struct HookDispatchFixture {
+    fanout: usize,
+    payloads: Vec<JsonValue>,
+}
+
+fn runtime() -> Runtime {
+    Builder::new_current_thread()
+        .enable_time()
+        .build()
+        .expect("benchmark runtime")
+}
+
+fn install_noop_hook(runtime: &Runtime) -> Vm {
+    reset_thread_local_state();
+    clear_runtime_hooks();
+
+    let mut vm = Vm::new();
+    register_vm_stdlib(&mut vm);
+    let exports = runtime
+        .block_on(vm.load_module_exports_from_source(
+            "perf/orchestration/noop_hook.harn",
+            "pub fn noop(event) {\n  return nil\n}\n",
+        ))
+        .expect("compile noop hook");
+    let closure = exports.get("noop").expect("noop export").clone();
+    register_vm_hook(HOOK_EVENT, "*", "bench::noop", closure);
+    vm
+}
+
+fn payload(index: usize) -> JsonValue {
+    json!({
+        "event": "trigger.dispatch",
+        "target": format!("trigger.script_{index:03}"),
+        "trigger": {
+            "provider": if index % 2 == 0 { "cron" } else { "webhook" },
+            "kind": if index % 2 == 0 { "schedule.tick" } else { "github.issue" },
+            "dedupe_key": format!("bench-delivery-{index:03}"),
+        },
+        "script": {
+            "path": format!("scripts/bench_{index:03}.harn"),
+        },
+    })
+}
+
+fn fixture(fanout: usize) -> HookDispatchFixture {
+    let payloads: Vec<JsonValue> = (0..fanout).map(payload).collect();
+    for payload in &payloads {
+        assert_eq!(
+            matching_vm_lifecycle_hooks(HOOK_EVENT, payload).len(),
+            1,
+            "benchmark fixture should dispatch each trigger payload into one hook"
+        );
+    }
+    HookDispatchFixture { fanout, payloads }
+}
+
+async fn dispatch_fanout(payloads: &[JsonValue]) {
+    let results = join_all(
+        payloads
+            .iter()
+            .map(|payload| run_lifecycle_hooks(HOOK_EVENT, payload)),
+    )
+    .await;
+
+    for result in results {
+        result.expect("noop hook dispatch should succeed");
+    }
+}
+
+fn measure_once(runtime: &Runtime, fixture: &HookDispatchFixture) {
+    runtime.block_on(dispatch_fanout(&fixture.payloads));
+
+    let started = Instant::now();
+    runtime.block_on(dispatch_fanout(&fixture.payloads));
+    let elapsed = started.elapsed();
+
+    ALLOCATION_COUNT.store(0, Ordering::Relaxed);
+    ALLOCATED_BYTES.store(0, Ordering::Relaxed);
+    TRACK_ALLOCATIONS.store(true, Ordering::Relaxed);
+    runtime.block_on(dispatch_fanout(&fixture.payloads));
+    TRACK_ALLOCATIONS.store(false, Ordering::Relaxed);
+
+    let hook_count = fixture.fanout as f64;
+    let elapsed_ns = elapsed.as_nanos() as f64;
+    let allocations = ALLOCATION_COUNT.load(Ordering::Relaxed) as f64;
+    let allocated_bytes = ALLOCATED_BYTES.load(Ordering::Relaxed) as f64;
+    eprintln!(
+        "hook_dispatch/fanout_{:03} sample: {:.1} ns/event, {:.1} ns/hook, {:.2} allocations/event, {:.1} allocated bytes/event",
+        fixture.fanout,
+        elapsed_ns / hook_count,
+        elapsed_ns / hook_count,
+        allocations / hook_count,
+        allocated_bytes / hook_count
+    );
+}
+
+fn bench_hook_dispatch(c: &mut Criterion) {
+    let runtime = runtime();
+    let vm = install_noop_hook(&runtime);
+    let _vm_context = install_async_builtin_child_vm(vm);
+
+    let fixtures: Vec<HookDispatchFixture> = FANOUTS.into_iter().map(fixture).collect();
+    for fixture in &fixtures {
+        measure_once(&runtime, fixture);
+    }
+
+    let mut group = c.benchmark_group("hook_dispatch/noop_lifecycle_hook");
+    for fixture in &fixtures {
+        group.throughput(Throughput::Elements(fixture.fanout as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("fanout_{:03}", fixture.fanout)),
+            fixture,
+            |b, fixture| {
+                b.iter(|| {
+                    runtime.block_on(dispatch_fanout(black_box(&fixture.payloads)));
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(20);
+    targets = bench_hook_dispatch
+}
+criterion_main!(benches);


### PR DESCRIPTION
## Summary
- Add `harn-orchestration-perf`, a Criterion perf package for runtime lifecycle hook dispatch.
- Benchmark no-op VM lifecycle hook fanout at 1, 8, 32, and 128 simultaneous trigger-shaped events.
- Print sampled `ns/event`, `ns/hook`, allocations/event, and allocated bytes/event, and expose `make bench-orchestration`.
- Fold duplicated changelog fragments from the moving mainline into `v0.8.0` so markdown lint stays green.

## Baseline
Post-rebase run:

```text
hook_dispatch/fanout_001 sample: 117042.0 ns/event, 117042.0 ns/hook, 3176.00 allocations/event, 407637.0 allocated bytes/event
hook_dispatch/fanout_008 sample: 88192.6 ns/event, 88192.6 ns/hook, 3174.25 allocations/event, 407637.0 allocated bytes/event
hook_dispatch/fanout_032 sample: 90191.4 ns/event, 90191.4 ns/hook, 3175.19 allocations/event, 407799.2 allocated bytes/event
hook_dispatch/fanout_128 sample: 96348.0 ns/event, 96348.0 ns/hook, 3175.06 allocations/event, 407773.6 allocated bytes/event

test hook_dispatch/noop_lifecycle_hook/fanout_001 ... bench:      75,279 ns/iter (+/- 1,655)
test hook_dispatch/noop_lifecycle_hook/fanout_008 ... bench:     599,663 ns/iter (+/- 6,396)
test hook_dispatch/noop_lifecycle_hook/fanout_032 ... bench:   2,773,139 ns/iter (+/- 142,827)
test hook_dispatch/noop_lifecycle_hook/fanout_128 ... bench:   9,770,984 ns/iter (+/- 240,042)
```

Opened follow-up optimization issue #1358 because the sampled `fanout_001` report crosses the 100 us/hook threshold and allocation rate is high.

## Verification
- `cargo fmt --check`
- `npx markdownlint-cli2 "**/*.md"`
- `CARGO_TARGET_DIR=/tmp/harn-target-1338 cargo check -p harn-orchestration-perf --benches`
- `CARGO_TARGET_DIR=/tmp/harn-target-1338 cargo test -p harn-orchestration-perf`
- `CARGO_TARGET_DIR=/tmp/harn-target-1338 cargo clippy -p harn-orchestration-perf --all-targets -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/harn-target-1338 make lint`
- `CARGO_TARGET_DIR=/tmp/harn-target-1338 cargo bench -p harn-orchestration-perf --bench bench_hook_dispatch -- --output-format bencher`
- `git diff --check origin/main...HEAD`

Closes #1338.