### PR TITLE
Fix token budget nil estimate

### DIFF
--- a/conformance/tests/stdlib/llm_budget_token_counts.harn
+++ b/conformance/tests/stdlib/llm_budget_token_counts.harn
@@ -35,5 +35,7 @@ pipeline test(task) {
   assert_eq(unknown.encoder, nil)
   assert_eq(unknown.source, "heuristic")
   assert(!unknown.known_model_family, "unknown model falls back to heuristic")
+  assert_eq(estimate_text_tokens(nil, "gpt-4"), 0)
+  assert_eq(estimate_text_tokens_detail(nil, "unknown-local-model").tokens, 0)
   log("llm_budget_token_counts tests passed")
 }

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -357,6 +357,8 @@ Imports starting with `std/` load embedded stdlib modules:
   parse_float_or)
 - `import "std/collections"` — collection utilities (filter_nil, store_stale,
   store_refresh)
+- `import "std/async"` — polling and retry helpers (wait_for, retry_until,
+  retry_predicate_with_backoff, circuit_call)
 - `import "std/vision"` — deterministic OCR helpers (`ocr(image, options?)`)
 - `import "std/prompt_library"` — reusable prompt fragments, cache metadata,
   tenant-scoped k-means hotspot proposals, and review-queue records


### PR DESCRIPTION
## Summary
- normalize nil text inputs to the empty string before model-aware token counting
- cover nil inputs for both direct and detailed std/llm/budget token estimates
- refresh the generated language-spec mirror that current main had left stale
- reorder existing CHANGELOG sections so semver metadata validation sees v0.8.0 before v0.7.62

## Validation
- /tmp/harn-stdlib-git-target/debug/harn check crates/harn-stdlib/src/stdlib/llm/budget.harn conformance/tests/integration/llm_budget_estimate_tokens.harn conformance/tests/stdlib/llm_budget_token_counts.harn
- /tmp/harn-stdlib-git-target/debug/harn lint crates/harn-stdlib/src/stdlib/llm/budget.harn conformance/tests/integration/llm_budget_estimate_tokens.harn conformance/tests/stdlib/llm_budget_token_counts.harn
- /tmp/harn-stdlib-git-target/debug/harn fmt --check crates/harn-stdlib/src/stdlib/llm/budget.harn conformance/tests/integration/llm_budget_estimate_tokens.harn conformance/tests/stdlib/llm_budget_token_counts.harn
- CARGO_TARGET_DIR=/tmp/harn-stdlib-git-target HARN_LLM_CALLS_DISABLED=1 cargo run --bin harn -- test conformance --filter llm_budget_estimate_tokens
- CARGO_TARGET_DIR=/tmp/harn-stdlib-git-target HARN_LLM_CALLS_DISABLED=1 cargo run --bin harn -- test conformance --filter llm_budget_token_counts
- CARGO_TARGET_DIR=/tmp/harn-stdlib-git-target HARN_LLM_CALLS_DISABLED=1 make conformance
- CARGO_TARGET_DIR=/tmp/harn-stdlib-git-target cargo test -p harn-cli cli::tests::test_parses_try_command -- --nocapture
- CARGO_TARGET_DIR=/tmp/harn-stdlib-git-target cargo clippy --workspace --all-targets -- -D warnings
- CARGO_TARGET_DIR=/tmp/harn-stdlib-git-target make check-language-spec
- python3 scripts/verify_release_metadata.py
- python3 scripts/check_changelog_no_retroactive_edits.py
- npx markdownlint-cli2 CHANGELOG.md docs/src/language-spec.md
- cargo fmt --check
- git diff --check