### PR TITLE
Optimize lifecycle hook dispatch

### DIFF
--- a/crates/harn-vm/src/orchestration/hooks.rs
+++ b/crates/harn-vm/src/orchestration/hooks.rs
@@ -131,16 +131,58 @@ impl std::fmt::Debug for ToolHook {
 #[derive(Clone)]
 enum PatternMatcher {
     ToolNameGlob(String),
-    EventExpression(String),
+    EventExpression {
+        source: String,
+        expression: EventPatternExpression,
+    },
+}
+
+#[derive(Clone)]
+enum EventPatternExpression {
+    MatchAll,
+    NeverMatch,
+    Regex { path: String, regex: Regex },
+    Equals { path: String, value: String },
+    NotEquals { path: String, value: String },
+    PathTruthy(String),
+    ToolNameGlob(String),
 }
 
 impl std::fmt::Debug for PatternMatcher {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::ToolNameGlob(pattern) => f.debug_tuple("ToolNameGlob").field(pattern).finish(),
-            Self::EventExpression(pattern) => {
-                f.debug_tuple("EventExpression").field(pattern).finish()
-            }
+            Self::EventExpression { source, expression } => f
+                .debug_struct("EventExpression")
+                .field("source", source)
+                .field("expression", expression)
+                .finish(),
+        }
+    }
+}
+
+impl std::fmt::Debug for EventPatternExpression {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MatchAll => f.write_str("MatchAll"),
+            Self::NeverMatch => f.write_str("NeverMatch"),
+            Self::Regex { path, regex } => f
+                .debug_struct("Regex")
+                .field("path", path)
+                .field("regex", &regex.as_str())
+                .finish(),
+            Self::Equals { path, value } => f
+                .debug_struct("Equals")
+                .field("path", path)
+                .field("value", value)
+                .finish(),
+            Self::NotEquals { path, value } => f
+                .debug_struct("NotEquals")
+                .field("path", path)
+                .field("value", value)
+                .finish(),
+            Self::PathTruthy(path) => f.debug_tuple("PathTruthy").field(path).finish(),
+            Self::ToolNameGlob(pattern) => f.debug_tuple("ToolNameGlob").field(pattern).finish(),
         }
     }
 }
@@ -227,7 +269,7 @@ pub fn register_vm_hook(
     RUNTIME_HOOKS.with(|hooks| {
         hooks.borrow_mut().push(RuntimeHook {
             event,
-            matcher: PatternMatcher::EventExpression(pattern.into()),
+            matcher: compile_event_pattern(pattern.into()),
             handler: RuntimeHookHandler::Vm {
                 handler_name: handler_name.into(),
                 closure,
@@ -298,8 +340,45 @@ fn strip_quoted(value: &str) -> &str {
         .unwrap_or(value.trim())
 }
 
-fn expression_matches(pattern: &str, payload: &serde_json::Value) -> bool {
-    let pattern = pattern.trim();
+fn compile_event_pattern(pattern: String) -> PatternMatcher {
+    let trimmed = pattern.trim();
+    let expression = if trimmed.is_empty() || trimmed == "*" {
+        EventPatternExpression::MatchAll
+    } else if let Some((lhs, rhs)) = trimmed.split_once("=~") {
+        match Regex::new(strip_quoted(rhs)) {
+            Ok(regex) => EventPatternExpression::Regex {
+                path: lhs.trim().to_string(),
+                regex,
+            },
+            Err(_) => EventPatternExpression::NeverMatch,
+        }
+    } else if let Some((lhs, rhs)) = trimmed.split_once("==") {
+        EventPatternExpression::Equals {
+            path: lhs.trim().to_string(),
+            value: strip_quoted(rhs).to_string(),
+        }
+    } else if let Some((lhs, rhs)) = trimmed.split_once("!=") {
+        EventPatternExpression::NotEquals {
+            path: lhs.trim().to_string(),
+            value: strip_quoted(rhs).to_string(),
+        }
+    } else if trimmed.contains('.') {
+        EventPatternExpression::PathTruthy(trimmed.to_string())
+    } else {
+        EventPatternExpression::ToolNameGlob(trimmed.to_string())
+    };
+    PatternMatcher::EventExpression {
+        source: pattern,
+        expression,
+    }
+}
+
+fn expression_matches(
+    source: &str,
+    expression: &EventPatternExpression,
+    payload: &serde_json::Value,
+) -> bool {
+    let pattern = source.trim();
     if pattern.is_empty() || pattern == "*" {
         return true;
     }
@@ -308,26 +387,27 @@ fn expression_matches(pattern: &str, payload: &serde_json::Value) -> bool {
             return true;
         }
     }
-    if let Some((lhs, rhs)) = pattern.split_once("=~") {
-        let value = value_to_pattern_string(value_at_path(payload, lhs.trim()));
-        let regex = strip_quoted(rhs);
-        return Regex::new(regex).is_ok_and(|compiled| compiled.is_match(&value));
+    match expression {
+        EventPatternExpression::MatchAll => true,
+        EventPatternExpression::NeverMatch => false,
+        EventPatternExpression::Regex { path, regex } => {
+            let value = value_to_pattern_string(value_at_path(payload, path));
+            regex.is_match(&value)
+        }
+        EventPatternExpression::Equals { path, value } => {
+            value_to_pattern_string(value_at_path(payload, path)) == *value
+        }
+        EventPatternExpression::NotEquals { path, value } => {
+            value_to_pattern_string(value_at_path(payload, path)) != *value
+        }
+        EventPatternExpression::PathTruthy(path) => {
+            value_at_path(payload, path).is_some_and(value_truthy)
+        }
+        EventPatternExpression::ToolNameGlob(pattern) => glob_match(
+            pattern,
+            &value_to_pattern_string(value_at_path(payload, "tool.name")),
+        ),
     }
-    if let Some((lhs, rhs)) = pattern.split_once("==") {
-        let value = value_to_pattern_string(value_at_path(payload, lhs.trim()));
-        return value == strip_quoted(rhs);
-    }
-    if let Some((lhs, rhs)) = pattern.split_once("!=") {
-        let value = value_to_pattern_string(value_at_path(payload, lhs.trim()));
-        return value != strip_quoted(rhs);
-    }
-    if pattern.contains('.') {
-        return value_at_path(payload, pattern).is_some_and(value_truthy);
-    }
-    glob_match(
-        pattern,
-        &value_to_pattern_string(value_at_path(payload, "tool.name")),
-    )
 }
 
 fn hook_matches(hook: &RuntimeHook, tool_name: Option<&str>, payload: &serde_json::Value) -> bool {
@@ -335,8 +415,21 @@ fn hook_matches(hook: &RuntimeHook, tool_name: Option<&str>, payload: &serde_jso
         PatternMatcher::ToolNameGlob(pattern) => {
             tool_name.is_some_and(|candidate| glob_match(pattern, candidate))
         }
-        PatternMatcher::EventExpression(pattern) => expression_matches(pattern, payload),
+        PatternMatcher::EventExpression { source, expression } => {
+            expression_matches(source, expression, payload)
+        }
     }
+}
+
+fn runtime_hooks_for_event(event: HookEvent) -> Vec<RuntimeHook> {
+    RUNTIME_HOOKS.with(|hooks| {
+        hooks
+            .borrow()
+            .iter()
+            .filter(|hook| hook.event == event)
+            .cloned()
+            .collect()
+    })
 }
 
 async fn invoke_vm_hook(
@@ -350,6 +443,22 @@ async fn invoke_vm_hook(
     };
     let arg = crate::stdlib::json_to_vm_value(payload);
     vm.call_closure_pub(closure, &[arg]).await
+}
+
+async fn invoke_vm_lifecycle_hooks(
+    closures: Vec<Rc<VmClosure>>,
+    payload: &serde_json::Value,
+) -> Result<(), VmError> {
+    let Some(mut vm) = crate::vm::clone_async_builtin_child_vm() else {
+        return Err(VmError::Runtime(
+            "runtime hook requires an async builtin VM context".to_string(),
+        ));
+    };
+    let arg = crate::stdlib::json_to_vm_value(payload);
+    for closure in closures {
+        let _ = vm.call_closure_pub(&closure, &[arg.clone()]).await?;
+    }
+    Ok(())
 }
 
 fn parse_pre_tool_result(value: VmValue) -> Result<PreToolAction, VmError> {
@@ -393,26 +502,34 @@ pub async fn run_pre_tool_hooks(
     tool_name: &str,
     args: &serde_json::Value,
 ) -> Result<PreToolAction, VmError> {
-    let hooks = RUNTIME_HOOKS.with(|hooks| hooks.borrow().clone());
+    let hooks = runtime_hooks_for_event(HookEvent::PreToolUse);
     let mut current_args = args.clone();
-    for hook in hooks
-        .iter()
-        .filter(|hook| hook.event == HookEvent::PreToolUse)
-    {
-        let payload = serde_json::json!({
-            "event": HookEvent::PreToolUse.as_str(),
-            "tool": {
-                "name": tool_name,
-                "args": current_args.clone(),
-            },
-        });
-        if !hook_matches(hook, Some(tool_name), &payload) {
+    for hook in &hooks {
+        let payload = if matches!(hook.matcher, PatternMatcher::EventExpression { .. }) {
+            Some(serde_json::json!({
+                "event": HookEvent::PreToolUse.as_str(),
+                "tool": {
+                    "name": tool_name,
+                    "args": current_args.clone(),
+                },
+            }))
+        } else {
+            None
+        };
+        if !hook_matches(
+            hook,
+            Some(tool_name),
+            payload.as_ref().unwrap_or(&serde_json::Value::Null),
+        ) {
             continue;
         }
         let action = match &hook.handler {
             RuntimeHookHandler::NativePreTool(pre) => pre(tool_name, &current_args),
             RuntimeHookHandler::Vm { closure, .. } => {
-                parse_pre_tool_result(invoke_vm_hook(closure, &payload).await?)?
+                let payload = payload.as_ref().ok_or_else(|| {
+                    VmError::Runtime("VM PreToolUse hook requires an event payload".to_string())
+                })?;
+                parse_pre_tool_result(invoke_vm_hook(closure, payload).await?)?
             }
             RuntimeHookHandler::NativePostTool(_) => continue,
         };
@@ -437,29 +554,37 @@ pub async fn run_post_tool_hooks(
     args: &serde_json::Value,
     result: &str,
 ) -> Result<String, VmError> {
-    let hooks = RUNTIME_HOOKS.with(|hooks| hooks.borrow().clone());
+    let hooks = runtime_hooks_for_event(HookEvent::PostToolUse);
     let mut current = result.to_string();
-    for hook in hooks
-        .iter()
-        .filter(|hook| hook.event == HookEvent::PostToolUse)
-    {
-        let payload = serde_json::json!({
-            "event": HookEvent::PostToolUse.as_str(),
-            "tool": {
-                "name": tool_name,
-                "args": args,
-            },
-            "result": {
-                "text": current.clone(),
-            },
-        });
-        if !hook_matches(hook, Some(tool_name), &payload) {
+    for hook in &hooks {
+        let payload = if matches!(hook.matcher, PatternMatcher::EventExpression { .. }) {
+            Some(serde_json::json!({
+                "event": HookEvent::PostToolUse.as_str(),
+                "tool": {
+                    "name": tool_name,
+                    "args": args,
+                },
+                "result": {
+                    "text": current.clone(),
+                },
+            }))
+        } else {
+            None
+        };
+        if !hook_matches(
+            hook,
+            Some(tool_name),
+            payload.as_ref().unwrap_or(&serde_json::Value::Null),
+        ) {
             continue;
         }
         let action = match &hook.handler {
             RuntimeHookHandler::NativePostTool(post) => post(tool_name, &current),
             RuntimeHookHandler::Vm { closure, .. } => {
-                parse_post_tool_result(invoke_vm_hook(closure, &payload).await?)?
+                let payload = payload.as_ref().ok_or_else(|| {
+                    VmError::Runtime("VM PostToolUse hook requires an event payload".to_string())
+                })?;
+                parse_post_tool_result(invoke_vm_hook(closure, payload).await?)?
             }
             RuntimeHookHandler::NativePreTool(_) => continue,
         };
@@ -477,32 +602,39 @@ pub async fn run_lifecycle_hooks(
     event: HookEvent,
     payload: &serde_json::Value,
 ) -> Result<(), VmError> {
-    let hooks = RUNTIME_HOOKS.with(|hooks| hooks.borrow().clone());
-    for hook in hooks.iter().filter(|hook| hook.event == event) {
-        if !hook_matches(hook, None, payload) {
-            continue;
-        }
-        if let RuntimeHookHandler::Vm { closure, .. } = &hook.handler {
-            let _ = invoke_vm_hook(closure, payload).await?;
-        }
+    let closures = matching_vm_lifecycle_closures(event, payload);
+    if closures.is_empty() {
+        return Ok(());
     }
-    Ok(())
+    invoke_vm_lifecycle_hooks(closures, payload).await
 }
 
 pub fn matching_vm_lifecycle_hooks(
     event: HookEvent,
     payload: &serde_json::Value,
 ) -> Vec<VmLifecycleHookInvocation> {
-    let hooks = RUNTIME_HOOKS.with(|hooks| hooks.borrow().clone());
-    hooks
-        .iter()
-        .filter(|hook| hook.event == event)
-        .filter(|hook| hook_matches(hook, None, payload))
-        .filter_map(|hook| match &hook.handler {
-            RuntimeHookHandler::Vm { closure, .. } => Some(VmLifecycleHookInvocation {
-                closure: closure.clone(),
-            }),
-            RuntimeHookHandler::NativePreTool(_) | RuntimeHookHandler::NativePostTool(_) => None,
-        })
+    matching_vm_lifecycle_closures(event, payload)
+        .into_iter()
+        .map(|closure| VmLifecycleHookInvocation { closure })
         .collect()
+}
+
+fn matching_vm_lifecycle_closures(
+    event: HookEvent,
+    payload: &serde_json::Value,
+) -> Vec<Rc<VmClosure>> {
+    RUNTIME_HOOKS.with(|hooks| {
+        hooks
+            .borrow()
+            .iter()
+            .filter(|hook| hook.event == event)
+            .filter(|hook| hook_matches(hook, None, payload))
+            .filter_map(|hook| match &hook.handler {
+                RuntimeHookHandler::Vm { closure, .. } => Some(Rc::clone(closure)),
+                RuntimeHookHandler::NativePreTool(_) | RuntimeHookHandler::NativePostTool(_) => {
+                    None
+                }
+            })
+            .collect()
+    })
 }

--- a/crates/harn-vm/src/orchestration/tests.rs
+++ b/crates/harn-vm/src/orchestration/tests.rs
@@ -1299,6 +1299,56 @@ async fn unmatched_hook_pattern_does_not_fire() {
     assert!(matches!(result, PreToolAction::Allow));
 }
 
+#[tokio::test(flavor = "current_thread")]
+async fn lifecycle_hook_patterns_match_payload_shapes() {
+    clear_runtime_hooks();
+
+    let mut vm = crate::Vm::new();
+    crate::register_vm_stdlib(&mut vm);
+    let exports = vm
+        .load_module_exports_from_source(
+            "orchestration/tests/noop_hook.harn",
+            "pub fn noop(event) { return nil }\n",
+        )
+        .await
+        .expect("compile noop hook");
+    let closure = exports.get("noop").expect("noop export").clone();
+
+    for pattern in [
+        "trigger.script_*",
+        "trigger.provider == 'cron'",
+        "trigger.kind =~ '^schedule'",
+        "trigger.provider != 'webhook'",
+        "script.path",
+        "trigger.kind =~ '['",
+    ] {
+        register_vm_hook(
+            HookEvent::PreAgentTurn,
+            pattern,
+            format!("test::{pattern}"),
+            Rc::clone(&closure),
+        );
+    }
+
+    let payload = serde_json::json!({
+        "target": "trigger.script_001",
+        "trigger": {
+            "provider": "cron",
+            "kind": "schedule.tick",
+        },
+        "script": {
+            "path": "scripts/bench_001.harn",
+        },
+    });
+
+    assert_eq!(
+        matching_vm_lifecycle_hooks(HookEvent::PreAgentTurn, &payload).len(),
+        5,
+        "valid glob, equality, regex, inequality, and truthy-path patterns should match"
+    );
+    clear_runtime_hooks();
+}
+
 #[test]
 fn glob_match_patterns() {
     assert!(glob_match("*", "anything"));

--- a/crates/harn-vm/src/stdlib/workflow_messages.rs
+++ b/crates/harn-vm/src/stdlib/workflow_messages.rs
@@ -729,13 +729,24 @@ mod tests {
             .await
         });
 
-        tokio::time::sleep(StdDuration::from_millis(50)).await;
         let target = WorkflowTarget {
             workflow_id: workflow_id.to_string(),
             base_dir: base_dir.clone(),
         };
-        let mut state = load_state(&target).expect("load state");
-        let message = state.mailbox.pop_front().expect("queued update");
+        let mut state = None;
+        let mut message = None;
+        for _ in 0..100 {
+            if let Ok(mut loaded) = load_state(&target) {
+                if let Some(queued) = loaded.mailbox.pop_front() {
+                    state = Some(loaded);
+                    message = Some(queued);
+                    break;
+                }
+            }
+            tokio::task::yield_now().await;
+        }
+        let mut state = state.expect("load state with queued update");
+        let message = message.expect("queued update");
         assert_eq!(message.kind, "update");
         state.responses.insert(
             message.request_id.clone().expect("request id"),
@@ -747,6 +758,7 @@ mod tests {
             },
         );
         save_state(&target, &state).expect("save response");
+        tokio::time::advance(StdDuration::from_millis(UPDATE_POLL_INTERVAL_MS)).await;
 
         let result = task.await.expect("join").expect("update result");
         assert_eq!(result, serde_json::json!({"ok": true}));

--- a/crates/harn-vm/src/vm/dispatch.rs
+++ b/crates/harn-vm/src/vm/dispatch.rs
@@ -16,12 +16,12 @@ impl Vm {
         }
         if let Some(existing) = self.builtins_by_id.get(&id) {
             if existing.name.as_ref() != name {
-                self.builtins_by_id.remove(&id);
-                self.builtin_id_collisions.insert(id);
+                Rc::make_mut(&mut self.builtins_by_id).remove(&id);
+                Rc::make_mut(&mut self.builtin_id_collisions).insert(id);
                 return;
             }
         }
-        self.builtins_by_id.insert(
+        Rc::make_mut(&mut self.builtins_by_id).insert(
             id,
             VmBuiltinEntry {
                 name: Rc::from(name),
@@ -42,7 +42,7 @@ impl Vm {
                 .get(&id)
                 .is_some_and(|entry| entry.name.as_ref() == name)
             {
-                self.builtins_by_id.remove(&id);
+                Rc::make_mut(&mut self.builtins_by_id).remove(&id);
             }
         }
     }
@@ -52,8 +52,8 @@ impl Vm {
     where
         F: Fn(&[VmValue], &mut String) -> Result<VmValue, VmError> + 'static,
     {
-        self.builtins.insert(name.to_string(), Rc::new(f));
-        self.builtin_metadata
+        Rc::make_mut(&mut self.builtins).insert(name.to_string(), Rc::new(f));
+        Rc::make_mut(&mut self.builtin_metadata)
             .insert(name.to_string(), VmBuiltinMetadata::sync(name.to_string()));
         self.refresh_builtin_id(name);
     }
@@ -64,22 +64,22 @@ impl Vm {
         F: Fn(&[VmValue], &mut String) -> Result<VmValue, VmError> + 'static,
     {
         let name = metadata.name().to_string();
-        self.builtins.insert(name.clone(), Rc::new(f));
-        self.builtin_metadata
+        Rc::make_mut(&mut self.builtins).insert(name.clone(), Rc::new(f));
+        Rc::make_mut(&mut self.builtin_metadata)
             .insert(name.clone(), metadata.with_kind(VmBuiltinKind::Sync));
         self.refresh_builtin_id(&name);
     }
 
     /// Remove a sync builtin (so an async version can take precedence).
     pub fn unregister_builtin(&mut self, name: &str) {
-        self.builtins.remove(name);
+        Rc::make_mut(&mut self.builtins).remove(name);
         if self.async_builtins.contains_key(name) {
-            self.builtin_metadata.insert(
+            Rc::make_mut(&mut self.builtin_metadata).insert(
                 name.to_string(),
                 VmBuiltinMetadata::async_builtin(name.to_string()),
             );
         } else {
-            self.builtin_metadata.remove(name);
+            Rc::make_mut(&mut self.builtin_metadata).remove(name);
         }
         self.refresh_builtin_id(name);
     }
@@ -90,9 +90,9 @@ impl Vm {
         F: Fn(Vec<VmValue>) -> Fut + 'static,
         Fut: Future<Output = Result<VmValue, VmError>> + 'static,
     {
-        self.async_builtins
+        Rc::make_mut(&mut self.async_builtins)
             .insert(name.to_string(), Rc::new(move |args| Box::pin(f(args))));
-        self.builtin_metadata.insert(
+        Rc::make_mut(&mut self.builtin_metadata).insert(
             name.to_string(),
             VmBuiltinMetadata::async_builtin(name.to_string()),
         );
@@ -109,9 +109,9 @@ impl Vm {
         Fut: Future<Output = Result<VmValue, VmError>> + 'static,
     {
         let name = metadata.name().to_string();
-        self.async_builtins
+        Rc::make_mut(&mut self.async_builtins)
             .insert(name.clone(), Rc::new(move |args| Box::pin(f(args))));
-        self.builtin_metadata
+        Rc::make_mut(&mut self.builtin_metadata)
             .insert(name.clone(), metadata.with_kind(VmBuiltinKind::Async));
         self.refresh_builtin_id(&name);
     }

--- a/crates/harn-vm/src/vm/modules.rs
+++ b/crates/harn-vm/src/vm/modules.rs
@@ -199,8 +199,7 @@ impl Vm {
         if let Some(loaded) = self.module_cache.get(&synthetic).cloned() {
             return Ok(loaded);
         }
-        self.source_cache
-            .insert(synthetic.clone(), source.to_string());
+        Rc::make_mut(&mut self.source_cache).insert(synthetic.clone(), source.to_string());
 
         let mut lexer = harn_lexer::Lexer::new(source);
         let tokens = lexer.tokenize().map_err(|e| {
@@ -219,7 +218,7 @@ impl Vm {
             .import_declarations(&program, None, Some(&synthetic))
             .await?;
         self.imported_paths.pop();
-        self.module_cache.insert(synthetic, loaded.clone());
+        Rc::make_mut(&mut self.module_cache).insert(synthetic, loaded.clone());
         Ok(loaded)
     }
 
@@ -232,8 +231,7 @@ impl Vm {
         if let Some(loaded) = self.module_cache.get(&synthetic).cloned() {
             return Ok(loaded);
         }
-        self.source_cache
-            .insert(synthetic.clone(), source.to_string());
+        Rc::make_mut(&mut self.source_cache).insert(synthetic.clone(), source.to_string());
 
         let artifact = stdlib_module_artifact(module, &synthetic, source)?;
         self.imported_paths.push(synthetic.clone());
@@ -241,7 +239,7 @@ impl Vm {
             .instantiate_stdlib_module(&synthetic, artifact.as_ref())
             .await?;
         self.imported_paths.pop();
-        self.module_cache.insert(synthetic, loaded.clone());
+        Rc::make_mut(&mut self.module_cache).insert(synthetic, loaded.clone());
         Ok(loaded)
     }
 
@@ -434,8 +432,8 @@ impl Vm {
                     file_path.display()
                 ))
             })?;
-            self.source_cache.insert(canonical.clone(), source.clone());
-            self.source_cache.insert(file_path.clone(), source.clone());
+            Rc::make_mut(&mut self.source_cache).insert(canonical.clone(), source.clone());
+            Rc::make_mut(&mut self.source_cache).insert(file_path.clone(), source.clone());
 
             let mut lexer = harn_lexer::Lexer::new(&source);
             let tokens = lexer
@@ -450,7 +448,7 @@ impl Vm {
                 .import_declarations(&program, Some(&file_path), Some(&file_path))
                 .await?;
             self.imported_paths.pop();
-            self.module_cache.insert(canonical.clone(), loaded.clone());
+            Rc::make_mut(&mut self.module_cache).insert(canonical.clone(), loaded.clone());
             self.export_loaded_module(&canonical, &loaded, selected_names)?;
 
             Ok(())

--- a/crates/harn-vm/src/vm/ops/stack.rs
+++ b/crates/harn-vm/src/vm/ops/stack.rs
@@ -66,7 +66,7 @@ impl super::super::Vm {
                 .push(VmValue::BuiltinRef(Rc::from(name.as_str())));
         } else {
             let mut all_vars = self.visible_variables();
-            for (k, v) in &self.globals {
+            for (k, v) in self.globals.iter() {
                 all_vars.entry(k.clone()).or_insert_with(|| v.clone());
             }
             // Include builtin names so typos on builtin refs get suggestions.

--- a/crates/harn-vm/src/vm/state.rs
+++ b/crates/harn-vm/src/vm/state.rs
@@ -135,15 +135,15 @@ pub struct Vm {
     pub(crate) stack: Vec<VmValue>,
     pub(crate) env: VmEnv,
     pub(crate) output: String,
-    pub(crate) builtins: BTreeMap<String, VmBuiltinFn>,
-    pub(crate) async_builtins: BTreeMap<String, VmAsyncBuiltinFn>,
-    pub(crate) builtin_metadata: BTreeMap<String, VmBuiltinMetadata>,
+    pub(crate) builtins: Rc<BTreeMap<String, VmBuiltinFn>>,
+    pub(crate) async_builtins: Rc<BTreeMap<String, VmAsyncBuiltinFn>>,
+    pub(crate) builtin_metadata: Rc<BTreeMap<String, VmBuiltinMetadata>>,
     /// Numeric side index for builtins. Name-keyed maps remain authoritative;
     /// this index is the hot path for direct builtin bytecode and callback refs.
-    pub(crate) builtins_by_id: BTreeMap<BuiltinId, VmBuiltinEntry>,
+    pub(crate) builtins_by_id: Rc<BTreeMap<BuiltinId, VmBuiltinEntry>>,
     /// IDs with detected name collisions. Collided names safely fall back to
     /// the authoritative name-keyed lookup path.
-    pub(crate) builtin_id_collisions: HashSet<BuiltinId>,
+    pub(crate) builtin_id_collisions: Rc<HashSet<BuiltinId>>,
     /// Iterator state for for-in loops.
     pub(crate) iterators: Vec<IterState>,
     /// Call frame stack.
@@ -195,9 +195,9 @@ pub struct Vm {
     /// Modules currently being imported (cycle prevention).
     pub(crate) imported_paths: Vec<std::path::PathBuf>,
     /// Loaded module cache keyed by canonical or synthetic module path.
-    pub(crate) module_cache: BTreeMap<std::path::PathBuf, LoadedModule>,
+    pub(crate) module_cache: Rc<BTreeMap<std::path::PathBuf, LoadedModule>>,
     /// Source text keyed by canonical or synthetic module path for debugger retrieval.
-    pub(crate) source_cache: BTreeMap<std::path::PathBuf, String>,
+    pub(crate) source_cache: Rc<BTreeMap<std::path::PathBuf, String>>,
     /// Source file path for error reporting.
     pub(crate) source_file: Option<String>,
     /// Source text for error reporting.
@@ -205,7 +205,7 @@ pub struct Vm {
     /// Optional bridge for delegating unknown builtins in bridge mode.
     pub(crate) bridge: Option<Rc<crate::bridge::HostBridge>>,
     /// Builtins denied by sandbox mode (`--deny` / `--allow` flags).
-    pub(crate) denied_builtins: HashSet<String>,
+    pub(crate) denied_builtins: Rc<HashSet<String>>,
     /// Cancellation token for cooperative graceful shutdown (set by parent).
     pub(crate) cancel_token: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
     /// Remaining instruction-boundary checks before a requested host
@@ -223,7 +223,7 @@ pub struct Vm {
     pub(crate) project_root: Option<std::path::PathBuf>,
     /// Global constants (e.g. `pi`, `e`). Checked as a fallback in `GetVar`
     /// after the environment, so user-defined variables can shadow them.
-    pub(crate) globals: BTreeMap<String, VmValue>,
+    pub(crate) globals: Rc<BTreeMap<String, VmValue>>,
     /// Optional debugger hook invoked when execution advances to a new source line.
     pub(crate) debug_hook: Option<Box<DebugHook>>,
 }
@@ -383,11 +383,11 @@ impl Vm {
             stack: Vec::with_capacity(256),
             env: VmEnv::new(),
             output: String::new(),
-            builtins: BTreeMap::new(),
-            async_builtins: BTreeMap::new(),
-            builtin_metadata: BTreeMap::new(),
-            builtins_by_id: BTreeMap::new(),
-            builtin_id_collisions: HashSet::new(),
+            builtins: Rc::new(BTreeMap::new()),
+            async_builtins: Rc::new(BTreeMap::new()),
+            builtin_metadata: Rc::new(BTreeMap::new()),
+            builtins_by_id: Rc::new(BTreeMap::new()),
+            builtin_id_collisions: Rc::new(HashSet::new()),
             iterators: Vec::new(),
             frames: Vec::new(),
             exception_handlers: Vec::new(),
@@ -408,18 +408,18 @@ impl Vm {
             last_line: 0,
             source_dir: None,
             imported_paths: Vec::new(),
-            module_cache: BTreeMap::new(),
-            source_cache: BTreeMap::new(),
+            module_cache: Rc::new(BTreeMap::new()),
+            source_cache: Rc::new(BTreeMap::new()),
             source_file: None,
             source_text: None,
             bridge: None,
-            denied_builtins: HashSet::new(),
+            denied_builtins: Rc::new(HashSet::new()),
             cancel_token: None,
             cancel_grace_instructions_remaining: None,
             error_stack_trace: Vec::new(),
             yield_sender: None,
             project_root: None,
-            globals: BTreeMap::new(),
+            globals: Rc::new(BTreeMap::new()),
             debug_hook: None,
         }
     }
@@ -432,14 +432,14 @@ impl Vm {
     /// Set builtins that are denied in sandbox mode.
     /// When called, the given builtin names will produce a permission error.
     pub fn set_denied_builtins(&mut self, denied: HashSet<String>) {
-        self.denied_builtins = denied;
+        self.denied_builtins = Rc::new(denied);
     }
 
     /// Set source info for error reporting (file path and source text).
     pub fn set_source_info(&mut self, file: &str, text: &str) {
         self.source_file = Some(file.to_string());
         self.source_text = Some(text.to_string());
-        self.source_cache
+        Rc::make_mut(&mut self.source_cache)
             .insert(std::path::PathBuf::from(file), text.to_string());
     }
 
@@ -476,11 +476,11 @@ impl Vm {
             stack: Vec::with_capacity(64),
             env: self.env.clone(),
             output: String::new(),
-            builtins: self.builtins.clone(),
-            async_builtins: self.async_builtins.clone(),
-            builtin_metadata: self.builtin_metadata.clone(),
-            builtins_by_id: self.builtins_by_id.clone(),
-            builtin_id_collisions: self.builtin_id_collisions.clone(),
+            builtins: Rc::clone(&self.builtins),
+            async_builtins: Rc::clone(&self.async_builtins),
+            builtin_metadata: Rc::clone(&self.builtin_metadata),
+            builtins_by_id: Rc::clone(&self.builtins_by_id),
+            builtin_id_collisions: Rc::clone(&self.builtin_id_collisions),
             iterators: Vec::new(),
             frames: Vec::new(),
             exception_handlers: Vec::new(),
@@ -501,18 +501,18 @@ impl Vm {
             last_line: 0,
             source_dir: self.source_dir.clone(),
             imported_paths: Vec::new(),
-            module_cache: self.module_cache.clone(),
-            source_cache: self.source_cache.clone(),
+            module_cache: Rc::clone(&self.module_cache),
+            source_cache: Rc::clone(&self.source_cache),
             source_file: self.source_file.clone(),
             source_text: self.source_text.clone(),
             bridge: self.bridge.clone(),
-            denied_builtins: self.denied_builtins.clone(),
+            denied_builtins: Rc::clone(&self.denied_builtins),
             cancel_token: self.cancel_token.clone(),
             cancel_grace_instructions_remaining: None,
             error_stack_trace: Vec::new(),
             yield_sender: None,
             project_root: self.project_root.clone(),
-            globals: self.globals.clone(),
+            globals: Rc::clone(&self.globals),
             debug_hook: None,
         }
     }
@@ -577,7 +577,7 @@ impl Vm {
     /// Set a global constant (e.g. `pi`, `e`).
     /// Stored separately from the environment so user-defined variables can shadow them.
     pub fn set_global(&mut self, name: &str, value: VmValue) {
-        self.globals.insert(name.to_string(), value);
+        Rc::make_mut(&mut self.globals).insert(name.to_string(), value);
     }
 
     /// Get the captured output.


### PR DESCRIPTION
## Summary

- compile lifecycle hook event patterns at registration, including regex/equality/path matchers
- avoid cloning the full hook registry and reuse one child VM plus one converted payload for matching lifecycle hook fanout
- make child VM read-mostly state copy-on-write so hook closure dispatch no longer deep-clones builtin/module/global maps
- add lifecycle hook pattern coverage for glob, equality, regex, inequality, truthy path, and invalid regex behavior

## Verification

- `cargo fmt --check`
- `CARGO_TARGET_DIR=/tmp/harn-target-1358 cargo check -p harn-vm`
- `CARGO_TARGET_DIR=/tmp/harn-target-1358 cargo test -p harn-vm hook`
- pre-commit hook: `cargo clippy --workspace --all-targets -- -D warnings`
- pre-push hook targeted checks
- `CARGO_TARGET_DIR=/tmp/harn-target-1358 cargo bench -p harn-orchestration-perf --bench bench_hook_dispatch -- --output-format bencher`

Benchmark sample after optimization:

```text
hook_dispatch/fanout_001 sample: 2417.0 ns/event, 2417.0 ns/hook, 37.00 allocations/event, 12744.0 allocated bytes/event
hook_dispatch/fanout_008 sample: 1203.1 ns/event, 1203.1 ns/hook, 35.25 allocations/event, 12744.0 allocated bytes/event
hook_dispatch/fanout_032 sample: 1166.7 ns/event, 1166.7 ns/hook, 36.19 allocations/event, 12902.8 allocated bytes/event
hook_dispatch/fanout_128 sample: 1132.2 ns/event, 1132.2 ns/hook, 36.06 allocations/event, 12879.7 allocated bytes/event

test hook_dispatch/noop_lifecycle_hook/fanout_001 ... bench:       1,269 ns/iter (+/- 74)
test hook_dispatch/noop_lifecycle_hook/fanout_008 ... bench:      11,131 ns/iter (+/- 857)
test hook_dispatch/noop_lifecycle_hook/fanout_032 ... bench:      42,305 ns/iter (+/- 2,820)
test hook_dispatch/noop_lifecycle_hook/fanout_128 ... bench:     145,663 ns/iter (+/- 3,213)
```

Closes #1358.
