### PR TITLE
Release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Pre-0.6 highlights live in [CHANGELOG-pre-0.6.md](CHANGELOG-pre-0.6.md).
 Harn had no external users before 0.6.0, so that archive intentionally keeps
 condensed series summaries instead of full per-patch history.
 
-## Unreleased
+## v0.8.0
 
 ### Added
 
@@ -27,10 +27,6 @@ condensed series summaries instead of full per-patch history.
   `tool_call_audit` AgentEvent for live ACP/A2A consumers. See
   [`docs/src/stdlib/tool-middleware.md`](docs/src/stdlib/tool-middleware.md)
   for the full reference.
-
-## v0.8.0
-
-### Added
 
 - **`llm_caller` seam on `agent_loop`.** New option accepts a closure
   with the canonical shape `fn(call) -> {ok, value | status, error?}`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1715,7 +1715,7 @@ dependencies = [
 
 [[package]]
 name = "harn-cli"
-version = "0.7.62"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -1771,7 +1771,7 @@ dependencies = [
 
 [[package]]
 name = "harn-dap"
-version = "0.7.62"
+version = "0.8.0"
 dependencies = [
  "harn-modules",
  "harn-parser",
@@ -1784,7 +1784,7 @@ dependencies = [
 
 [[package]]
 name = "harn-fmt"
-version = "0.7.62"
+version = "0.8.0"
 dependencies = [
  "harn-lexer",
  "harn-parser",
@@ -1792,7 +1792,7 @@ dependencies = [
 
 [[package]]
 name = "harn-hostlib"
-version = "0.7.62"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -1843,7 +1843,7 @@ dependencies = [
 
 [[package]]
 name = "harn-ir"
-version = "0.7.62"
+version = "0.8.0"
 dependencies = [
  "harn-lexer",
  "harn-parser",
@@ -1851,11 +1851,11 @@ dependencies = [
 
 [[package]]
 name = "harn-lexer"
-version = "0.7.62"
+version = "0.8.0"
 
 [[package]]
 name = "harn-lint"
-version = "0.7.62"
+version = "0.8.0"
 dependencies = [
  "harn-lexer",
  "harn-modules",
@@ -1873,7 +1873,7 @@ dependencies = [
 
 [[package]]
 name = "harn-lsp"
-version = "0.7.62"
+version = "0.8.0"
 dependencies = [
  "harn-fmt",
  "harn-ir",
@@ -1888,7 +1888,7 @@ dependencies = [
 
 [[package]]
 name = "harn-modules"
-version = "0.7.62"
+version = "0.8.0"
 dependencies = [
  "croner",
  "harn-lexer",
@@ -1912,7 +1912,7 @@ dependencies = [
 
 [[package]]
 name = "harn-parser"
-version = "0.7.62"
+version = "0.8.0"
 dependencies = [
  "harn-lexer",
  "yansi",
@@ -1920,7 +1920,7 @@ dependencies = [
 
 [[package]]
 name = "harn-serve"
-version = "0.7.62"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -1949,11 +1949,11 @@ dependencies = [
 
 [[package]]
 name = "harn-stdlib"
-version = "0.7.62"
+version = "0.8.0"
 
 [[package]]
 name = "harn-vm"
-version = "0.7.62"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ exclude = ["crates/harn-wasm"]
 resolver = "2"
 
 [workspace.package]
-version = "0.7.62"
+version = "0.8.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/burin-labs/harn"

--- a/crates/harn-cli/Cargo.toml
+++ b/crates/harn-cli/Cargo.toml
@@ -32,15 +32,15 @@ name = "harn"
 path = "src/main.rs"
 
 [dependencies]
-harn-lexer = { path = "../harn-lexer", version = "0.7" }
-harn-parser = { path = "../harn-parser", version = "0.7" }
-harn-ir = { path = "../harn-ir", version = "0.7" }
-harn-vm = { path = "../harn-vm", version = "0.7", features = ["otel"] }
-harn-hostlib = { path = "../harn-hostlib", version = "0.7", optional = true }
-harn-lint = { path = "../harn-lint", version = "0.7" }
-harn-modules = { path = "../harn-modules", version = "0.7" }
-harn-fmt = { path = "../harn-fmt", version = "0.7" }
-harn-serve = { path = "../harn-serve", version = "0.7" }
+harn-lexer = { path = "../harn-lexer", version = "0.8" }
+harn-parser = { path = "../harn-parser", version = "0.8" }
+harn-ir = { path = "../harn-ir", version = "0.8" }
+harn-vm = { path = "../harn-vm", version = "0.8", features = ["otel"] }
+harn-hostlib = { path = "../harn-hostlib", version = "0.8", optional = true }
+harn-lint = { path = "../harn-lint", version = "0.8" }
+harn-modules = { path = "../harn-modules", version = "0.8" }
+harn-fmt = { path = "../harn-fmt", version = "0.8" }
+harn-serve = { path = "../harn-serve", version = "0.8" }
 async-trait = "0.1"
 axum = { version = "0.8", features = ["ws"] }
 axum-server = { version = "0.8", features = ["tls-rustls"] }

--- a/crates/harn-cli/src/commands/init.rs
+++ b/crates/harn-cli/src/commands/init.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use std::process;
 
 use crate::cli::{NewArgs, ProjectTemplate};
+use crate::package::current_harn_range_example;
 
 pub(crate) fn resolve_new_args(
     args: &NewArgs,
@@ -107,6 +108,7 @@ fn write_if_new(path: &Path, content: &str) {
 }
 
 fn template_files(project_name: &str, template: ProjectTemplate) -> Vec<(&'static str, String)> {
+    let harn_range = current_harn_range_example();
     let manifest = format!(
         r#"[package]
 name = "{project_name}"
@@ -457,7 +459,7 @@ version = "0.1.0"
 description = "Reusable Harn package."
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/OWNER/{project_name}"
-harn = ">=0.7,<0.8"
+harn = "{harn_range}"
 docs_url = "docs/api.md"
 
 [exports]
@@ -579,7 +581,7 @@ version = "0.1.0"
 description = "Pure-Harn connector package."
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/OWNER/{project_name}"
-harn = ">=0.7,<0.8"
+harn = "{harn_range}"
 docs_url = "docs/api.md"
 
 [exports]
@@ -764,6 +766,7 @@ pub fn normalize_inbound(raw)
 mod tests {
     use super::{resolve_new_args, template_files};
     use crate::cli::{NewArgs, ProjectTemplate};
+    use crate::package::current_harn_range_example;
 
     #[test]
     fn basic_template_keeps_library_layout() {
@@ -802,11 +805,19 @@ mod tests {
         assert!(package
             .iter()
             .any(|(path, _)| *path == ".github/workflows/harn-package.yml"));
+        assert!(package.iter().any(|(path, content)| {
+            *path == "harn.toml"
+                && content.contains(&format!("harn = \"{}\"", current_harn_range_example()))
+        }));
 
         let connector = template_files("sample", ProjectTemplate::Connector);
         assert!(connector
             .iter()
             .any(|(path, _)| *path == "connectors/echo.harn"));
+        assert!(connector.iter().any(|(path, content)| {
+            *path == "harn.toml"
+                && content.contains(&format!("harn = \"{}\"", current_harn_range_example()))
+        }));
     }
 
     #[test]

--- a/crates/harn-cli/src/package/package_ops.rs
+++ b/crates/harn-cli/src/package/package_ops.rs
@@ -198,13 +198,18 @@ pub(crate) fn check_package_impl(
             &mut errors,
             "[package].harn",
             format!(
-                "unsupported Harn version range '{range}'; include the current 0.7 line, for example >=0.7,<0.8"
+                "unsupported Harn version range '{range}'; include the current {} line, for example {}",
+                current_harn_line_label(),
+                current_harn_range_example()
             ),
         ),
         None => push_error(
             &mut errors,
             "[package].harn",
-            "missing Harn compatibility metadata; add harn = \">=0.7,<0.8\"",
+            format!(
+                "missing Harn compatibility metadata; add harn = \"{}\"",
+                current_harn_range_example()
+            ),
         ),
     }
 
@@ -679,6 +684,22 @@ pub(crate) fn supports_current_harn(range: &str) -> bool {
     saw_constraint && lower_ok && upper_ok
 }
 
+pub(crate) fn current_harn_range_example() -> String {
+    let current = env!("CARGO_PKG_VERSION");
+    let Some((major, minor)) = parse_major_minor(current) else {
+        return ">=0.7,<0.8".to_string();
+    };
+    format!(">={major}.{minor},<{major}.{}", minor + 1)
+}
+
+pub(crate) fn current_harn_line_label() -> String {
+    let current = env!("CARGO_PKG_VERSION");
+    let Some((major, minor)) = parse_major_minor(current) else {
+        return "0.7".to_string();
+    };
+    format!("{major}.{minor}")
+}
+
 pub(crate) fn parse_major_minor(raw: &str) -> Option<(u64, u64)> {
     let raw = raw.trim().trim_start_matches('v');
     let mut parts = raw.split('.');
@@ -857,7 +878,7 @@ mod tests {
     description = "Acme helpers"
     license = "MIT"
     repository = "https://github.com/acme/acme-lib"
-    harn = ">=0.8,<0.9"
+    harn = ">=999.0,<999.1"
     docs_url = "docs/api.md"
 
     [exports]

--- a/crates/harn-cli/src/package/registry.rs
+++ b/crates/harn-cli/src/package/registry.rs
@@ -1764,7 +1764,10 @@ mod tests {
             let matches = search_package_registry_impl(Some("acme"), Some("index.toml")).unwrap();
             assert_eq!(matches.len(), 1);
             assert_eq!(matches[0].name, "@burin/acme-lib");
-            assert_eq!(matches[0].harn.as_deref(), Some(">=0.7,<0.8"));
+            assert_eq!(
+                matches[0].harn.as_deref(),
+                Some(crate::package::current_harn_range_example().as_str())
+            );
             assert_eq!(matches[0].connector_contract.as_deref(), Some("v1"));
             assert_eq!(matches[0].exports, vec!["lib"]);
 

--- a/crates/harn-cli/src/package/test_support.rs
+++ b/crates/harn-cli/src/package/test_support.rs
@@ -149,6 +149,7 @@ pub(crate) fn write_package_registry_index(
     git: &str,
     package_name: &str,
 ) {
+    let harn_range = crate::package::current_harn_range_example();
     fs::write(
         path,
         format!(
@@ -160,7 +161,7 @@ name = "{registry_name}"
 description = "Acme package for registry tests"
 repository = "{git}"
 license = "MIT OR Apache-2.0"
-harn = ">=0.7,<0.8"
+harn = "{harn_range}"
 exports = ["lib"]
 connector_contract = "v1"
 docs_url = "https://docs.example.test/acme"
@@ -207,22 +208,25 @@ json_schema: {{
 pub(crate) fn write_publishable_package(root: &Path) {
     fs::create_dir_all(root.join("lib")).unwrap();
     fs::create_dir_all(root.join("docs")).unwrap();
+    let harn_range = crate::package::current_harn_range_example();
     fs::write(
         root.join(MANIFEST),
-        r#"[package]
+        format!(
+            r#"[package]
 name = "acme-lib"
 version = "0.1.0"
 description = "Acme helpers"
 license = "MIT"
 repository = "https://github.com/acme/acme-lib"
-harn = ">=0.7,<0.8"
+harn = "{harn_range}"
 docs_url = "docs/api.md"
 
 [exports]
 lib = "lib/main.harn"
 
 [dependencies]
-"#,
+"#
+        ),
     )
     .unwrap();
     fs::write(

--- a/crates/harn-dap/Cargo.toml
+++ b/crates/harn-dap/Cargo.toml
@@ -12,9 +12,9 @@ name = "harn-dap"
 path = "src/main.rs"
 
 [dependencies]
-harn-modules = { path = "../harn-modules", version = "0.7" }
-harn-parser = { path = "../harn-parser", version = "0.7" }
-harn-vm = { path = "../harn-vm", version = "0.7" }
+harn-modules = { path = "../harn-modules", version = "0.8" }
+harn-parser = { path = "../harn-parser", version = "0.8" }
+harn-vm = { path = "../harn-vm", version = "0.8" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt"] }

--- a/crates/harn-fmt/Cargo.toml
+++ b/crates/harn-fmt/Cargo.toml
@@ -8,5 +8,5 @@ homepage.workspace = true
 description = "Code formatter for the Harn programming language"
 
 [dependencies]
-harn-lexer = { path = "../harn-lexer", version = "0.7" }
-harn-parser = { path = "../harn-parser", version = "0.7" }
+harn-lexer = { path = "../harn-lexer", version = "0.8" }
+harn-parser = { path = "../harn-parser", version = "0.8" }

--- a/crates/harn-hostlib/Cargo.toml
+++ b/crates/harn-hostlib/Cargo.toml
@@ -17,7 +17,7 @@ include = [
 ]
 
 [dependencies]
-harn-vm = { path = "../harn-vm", version = "0.7" }
+harn-vm = { path = "../harn-vm", version = "0.8" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.11"
@@ -80,8 +80,8 @@ tempfile = "3"
 serde_json = "1"
 filetime = "0.2"
 criterion = "0.8"
-harn-lexer = { path = "../harn-lexer", version = "0.7" }
-harn-parser = { path = "../harn-parser", version = "0.7" }
+harn-lexer = { path = "../harn-lexer", version = "0.8" }
+harn-parser = { path = "../harn-parser", version = "0.8" }
 
 [[bench]]
 name = "ast_parse"

--- a/crates/harn-ir/Cargo.toml
+++ b/crates/harn-ir/Cargo.toml
@@ -8,5 +8,5 @@ homepage.workspace = true
 description = "CFG and invariant analysis for the Harn programming language"
 
 [dependencies]
-harn-lexer = { path = "../harn-lexer", version = "0.7" }
-harn-parser = { path = "../harn-parser", version = "0.7" }
+harn-lexer = { path = "../harn-lexer", version = "0.8" }
+harn-parser = { path = "../harn-parser", version = "0.8" }

--- a/crates/harn-lint/Cargo.toml
+++ b/crates/harn-lint/Cargo.toml
@@ -8,7 +8,7 @@ homepage.workspace = true
 description = "Linter for the Harn programming language"
 
 [dependencies]
-harn-lexer = { path = "../harn-lexer", version = "0.7" }
-harn-parser = { path = "../harn-parser", version = "0.7" }
-harn-vm = { path = "../harn-vm", version = "0.7" }
-harn-modules = { path = "../harn-modules", version = "0.7" }
+harn-lexer = { path = "../harn-lexer", version = "0.8" }
+harn-parser = { path = "../harn-parser", version = "0.8" }
+harn-vm = { path = "../harn-vm", version = "0.8" }
+harn-modules = { path = "../harn-modules", version = "0.8" }

--- a/crates/harn-lsp/Cargo.toml
+++ b/crates/harn-lsp/Cargo.toml
@@ -12,12 +12,12 @@ name = "harn-lsp"
 path = "src/main.rs"
 
 [dependencies]
-harn-lexer = { path = "../harn-lexer", version = "0.7" }
-harn-parser = { path = "../harn-parser", version = "0.7" }
-harn-ir = { path = "../harn-ir", version = "0.7" }
-harn-lint = { path = "../harn-lint", version = "0.7" }
-harn-modules = { path = "../harn-modules", version = "0.7" }
-harn-fmt = { path = "../harn-fmt", version = "0.7" }
-harn-vm = { path = "../harn-vm", version = "0.7" }
+harn-lexer = { path = "../harn-lexer", version = "0.8" }
+harn-parser = { path = "../harn-parser", version = "0.8" }
+harn-ir = { path = "../harn-ir", version = "0.8" }
+harn-lint = { path = "../harn-lint", version = "0.8" }
+harn-modules = { path = "../harn-modules", version = "0.8" }
+harn-fmt = { path = "../harn-fmt", version = "0.8" }
+harn-vm = { path = "../harn-vm", version = "0.8" }
 tower-lsp = "0.20"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "io-std"] }

--- a/crates/harn-modules/Cargo.toml
+++ b/crates/harn-modules/Cargo.toml
@@ -13,9 +13,9 @@ include = [
 
 [dependencies]
 croner = "3.0.1"
-harn-lexer = { path = "../harn-lexer", version = "0.7" }
-harn-parser = { path = "../harn-parser", version = "0.7" }
-harn-stdlib = { path = "../harn-stdlib", version = "0.7" }
+harn-lexer = { path = "../harn-lexer", version = "0.8" }
+harn-parser = { path = "../harn-parser", version = "0.8" }
+harn-stdlib = { path = "../harn-stdlib", version = "0.8" }
 serde = { version = "1", features = ["derive"] }
 toml = "1.1"
 

--- a/crates/harn-parser/Cargo.toml
+++ b/crates/harn-parser/Cargo.toml
@@ -8,5 +8,5 @@ homepage.workspace = true
 description = "Parser, AST, and type checker for the Harn programming language"
 
 [dependencies]
-harn-lexer = { path = "../harn-lexer", version = "0.7" }
+harn-lexer = { path = "../harn-lexer", version = "0.8" }
 yansi = "1"

--- a/crates/harn-serve/Cargo.toml
+++ b/crates/harn-serve/Cargo.toml
@@ -13,8 +13,8 @@ axum = "0.8"
 axum-server = { version = "0.8", features = ["tls-rustls"] }
 base64 = "0.22"
 futures = "0.3"
-harn-parser = { path = "../harn-parser", version = "0.7" }
-harn-vm = { path = "../harn-vm", version = "0.7" }
+harn-parser = { path = "../harn-parser", version = "0.8" }
+harn-vm = { path = "../harn-vm", version = "0.8" }
 hmac = "0.13"
 rcgen = "0.14"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/crates/harn-vm/Cargo.toml
+++ b/crates/harn-vm/Cargo.toml
@@ -19,10 +19,10 @@ otel = [
 ]
 
 [dependencies]
-harn-lexer = { path = "../harn-lexer", version = "0.7" }
-harn-modules = { path = "../harn-modules", version = "0.7" }
-harn-parser = { path = "../harn-parser", version = "0.7" }
-harn-stdlib = { path = "../harn-stdlib", version = "0.7" }
+harn-lexer = { path = "../harn-lexer", version = "0.8" }
+harn-modules = { path = "../harn-modules", version = "0.8" }
+harn-parser = { path = "../harn-parser", version = "0.8" }
+harn-stdlib = { path = "../harn-stdlib", version = "0.8" }
 async-trait = "0.1"
 chrono = "0.4"
 chrono-tz = "0.10.4"

--- a/crates/harn-wasm/Cargo.toml
+++ b/crates/harn-wasm/Cargo.toml
@@ -11,8 +11,8 @@ description = "WebAssembly target for the Harn programming language playground"
 crate-type = ["cdylib"]
 
 [dependencies]
-harn-lexer = { path = "../harn-lexer", version = "0.7" }
-harn-parser = { path = "../harn-parser", version = "0.7" }
-harn-fmt = { path = "../harn-fmt", version = "0.7" }
+harn-lexer = { path = "../harn-lexer", version = "0.8" }
+harn-parser = { path = "../harn-parser", version = "0.8" }
+harn-fmt = { path = "../harn-fmt", version = "0.8" }
 wasm-bindgen = "0.2"
 serde_json = "1"

--- a/docs/src/package-authoring.md
+++ b/docs/src/package-authoring.md
@@ -72,7 +72,7 @@ version = "0.1.0"
 description = "Reusable Harn helpers."
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/acme/acme-tools"
-harn = ">=0.7,<0.8"
+harn = ">=0.8,<0.9"
 docs_url = "docs/api.md"
 
 [exports]


### PR DESCRIPTION
Release v0.8.0

This PR was prepared by `release_harn.harn` from a fresh release snapshot.
The harness generated the release content through `scripts/release_ship.sh --prepare` before the PR handoff.

## Post-prepare summary

- Version: `0.7.62` -> `0.8.0`
- Branch: `release/v0.8.0` targeting `main`
- Latest tag used for release delta: `v0.7.62`
- Changed files: `CHANGELOG.md, Cargo.lock, Cargo.toml, crates/harn-cli/Cargo.toml, crates/harn-dap/Cargo.toml, crates/harn-fmt/Cargo.toml, crates/harn-hostlib/Cargo.toml, crates/harn-ir/Cargo.toml, crates/harn-lint/Cargo.toml, crates/harn-lsp/Cargo.toml, crates/harn-modules/Cargo.toml, crates/harn-parser/Cargo.toml, crates/harn-serve/Cargo.toml, crates/harn-vm/Cargo.toml, crates/harn-wasm/Cargo.toml`
- Deterministic findings: none

## Changelog section

```markdown
### Added

- **Composable tool middleware (`std/llm/tool_middleware`).** New parallel
  seam to `llm_caller`: `agent_loop` now accepts a `tool_caller:` closure that
  wraps every tool dispatch (across all executors — `harn`, `host_bridge`,
  `mcp_server`, `provider_native`). Paired with a schema-time decorator
  (`tools_use_middleware(registry, transform)` + `tool_inject_param`) so
  middleware can also augment the tool schemas the model sees. Ships
  `compose_tool_callers([..])`, `default_tool_caller()`, and a bundled
  middleware library: `with_required_reason` (force a `reason` arg on every
  tool call and surface it as a user-facing summary), `with_audit_log`,
  `with_consent`, `with_dry_run`, `with_redaction`, `with_idempotency`,
  `with_rate_limit`, `with_telemetry`, and `with_summary`. Middleware-attached
  audit metadata rides on the dispatch result `audit` field (free-form dict
  aligned with A2A `metadata` / ACP `kind` / OpenAI `summary_text` / OTel
  `gen_ai.tool.description` conventions) and is also fanned out as a new
  `tool_call_audit` AgentEvent for live ACP/A2A consumers. See
  [`docs/src/stdlib/tool-middleware.md`](docs/src/stdlib/tool-middleware.md)
  for the full reference.

- **`llm_caller` seam on `agent_loop`.** New option accepts a closure
  with the canonical shape `fn(call) -> {ok, value | status, error?}`
  that owns each turn's `llm_call(...)`. The loop validates the
  envelope shape, threads `_turn_iteration` through `call.turn`, and
  rejects writes to underscore-prefixed runtime-private keys.
- **`std/llm/handlers`.** Composable middleware: `default_llm_caller`,
  `with_retry`, `with_fallback`, `with_shadow`, `with_prompt_rewrite`,
  `with_logging`, `with_budget`, `with_cache`, `with_circuit_breaker`,
  `compose([...])`. `compose` takes a single list (Harn does not yet
  support user-defined variadics).
- **`std/llm/ensemble`.** `best_of_n`, `self_consistency`,
  `parallel_judge`, `debate`. Cites Wang et al. 2022
  (arxiv:2203.11171) and Du et al. 2023 (arxiv:2305.14325).
- **`std/llm/refine`.** `refine_prompt`, `refine_caller` —
  meta-prompt-based prompt rewriting with a `DIFF:` summary trailer.
  Best-effort session cache (Harn closures capture by value).
- **`std/llm/budget`.** `estimate_text_tokens` (heuristic; not named
  `estimate_tokens` to avoid colliding with the workflow builtin),
  `context_window_for`, `recommend_max_output_tokens`,
  `budget_summary`, `fits_in_context`.
- **`std/llm/defaults`.** `pack_for(opts)` and convenience wrappers
  (`pack_chat`, `pack_agent`, `pack_refine`, `pack_judge`,
  `pack_summarize`, `pack_code`, `pack_json`). Calibrated for
  Anthropic Sonnet/Opus/Haiku 4.x, OpenAI GPT-5/5.5/4o/4.1, Gemini
  2.5 Pro/Flash, Ollama Qwen3/Llama 3.x.
- **`std/llm/safe`.** `safe_call`, `safe_field`, `dict_get_ci`,
  `with_case_insensitive_keys`, `structured_envelope_or_default`,
  `judge_payload`, `verdict_normalize`, `schema_retry_nudge_for`.
- **`std/llm/prompts`.** `system_prelude`, `tool_use_prelude`,
  `structured_output_preface`.
- **`std/llm/catalog`.** `model_info(selector)`,
  `resolved_options(opts)`, `has_capability(model, cap)`,
  `family_of(model_id)`. Harn-side names are deliberately shorter than
  the underlying builtins to avoid shadowing.
- **New Rust builtins.** `llm_resolved_options(opts)`,
  `llm_model_defaults(model_id)`. `llm_model_info(model_id)` already
  existed and is reused. Implemented in
  `crates/harn-vm/src/llm/config_builtins.rs`.
- **`harn models list [--provider NAME] [--json] [--installed-only]`.**
- **`harn models install <model> [--yes] [--keep-alive VALUE]`.**
- **`harn try "<prompt>"`.** One-shot prompt against the configured
  provider with `with_retry`-wrapped `default_llm_caller`.
- **`harn doctor --json`.** Doctor now also checks Ollama, hardware,
  Harn version, and prints a "Next step" suggestion.
- **Orchestration hook dispatch benchmark.** Added `harn-orchestration-perf`
  and `make bench-orchestration` to measure no-op VM lifecycle hook fanout
  costs across 1, 8, 32, and 128 trigger-shaped events.
- **Lint rule `deprecated_llm_options`.** Warns on `llm_retries` /
  `llm_backoff_ms` in dict literals passed to `llm_call` /
  `llm_call_safe` / `llm_call_structured` / `llm_call_structured_result` /
  `agent_loop`.
- **`harn quickstart` setup wizard (#1331).** Added an interactive and
  non-interactive setup flow that detects provider credentials, local Ollama,
  free disk space, and local GPU availability, then writes starter
  `providers.toml`, `harn.toml`, and `.env` files.
- **Tiktoken-grade token counting.** Added `tiktoken_count_tokens(text, model)`
  and `std/llm/budget` helpers so budget checks use exact OpenAI tiktoken
  counts when available, labeled tiktoken approximations for Claude/Gemini
  model families, and the heuristic fallback only for unknown model IDs.

### Changed

- `harn doctor` output splits credentials and network checks.
- Improved no-providers-configured error message names every supported
  env var dynamically and points at `harn doctor` and (when available)
  `harn models recommend`.
- **`std/async` predicate retry rename.** Renamed `retry_with_backoff` to
  `retry_predicate_with_backoff` and removed the old export, with lint autofix
  support for stale call sites.

### Deprecated

- `llm_retries` and `llm_backoff_ms` on `llm_call` family + `agent_loop`
  — still functional in v0.8.x, removed in v0.9.0. Replace with
  `with_retry(default_llm_caller(), {max_attempts: K + 1})` from
  `std/llm/handlers`. `harn lint` warns on deprecated usage (rule:
  `deprecated_llm_options`).
- `llm_options` patch field on `post_turn_callback` outcomes —
  soft-deprecated; emits one event per session when used. Replace by
  wrapping `llm_caller` with a per-turn opts mutator (e.g.
  `with_prompt_rewrite`).

### Migration

`llm_retries: K` historically meant **K retries after the first
attempt** = K + 1 total attempts. `with_retry`'s `max_attempts: N`
counts **total attempts**. Adjust the number when migrating.

Before:

```harn,ignore
llm_call(prompt, sys, {llm_retries: 3, llm_backoff_ms: 250})
```

After:

```harn,ignore
import {default_llm_caller, with_retry} from "std/llm/handlers"

let caller = with_retry(default_llm_caller(), {
  max_attempts: 4,        // NOTE: total attempts; llm_retries: 3 == 4 attempts
  base_ms: 250,
  backoff: "exponential",
})
caller({prompt: prompt, system: sys, opts: {},
        turn: {iteration: 0, session_id: "", attempt: 1}})
```

Or pass through the new `llm_caller:` option on `agent_loop`:

```harn,ignore
agent_loop(task, sys, {
  llm_caller: with_retry(default_llm_caller(), {max_attempts: 4}),
})
```
```

## Commits covered

```text
e1f8ca97 Fix changelog version ordering
160de434 Fix token budget nil estimate (#1363)
18bcd819 Add composable tool middleware (std/llm/tool_middleware) (#1362)
d9f232f2 Fix harn try parser test (#1361)
6f6733fe Fix orchestration benchmark clippy lint
c52458bb Add orchestration hook dispatch benchmark (#1360)
3b742b07 Add std/git local tool wrappers (#1359)
9de5d633 Add VmEnv closure clone benchmark (#1357)
3846cf27 [codex] Add tiktoken-grade token budgeting (#1352)
a306075b Add harn models test smoke command (#1351)
47430621 [codex] Rename std async predicate retry helper (#1349)
7534f0b3 [codex] Add harn run explain-cost (#1347)
99ca3aca Add harn quickstart setup wizard (#1345)
7f255e68 Add hardware-aware model recommendations (#1342)
e3432fb2 Add tree-of-thoughts stdlib helper (#1341)
47246ddb Composable LLM callers, std/llm/*, model packs, getting-started polish (#1339)
```

## Execution transcript

| Step | Status | Classification |
|------|--------|----------------|
| `fetch-origin` | ok | `ok` |
| `sync-base` | ok | `ok` |
| `reset-release-branch-to-base` | ok | `ok` |
| `draft-release-notes` | ok | `ok` |
| `prepare` | ok | `ok` |
| `release-markdown-lint` | ok | `ok` |
| `stage-tracked-release-content` | ok | `ok` |
| `commit` | ok | `ok` |
| `fetch-base` | ok | `ok` |
| `rebase-base` | ok | `ok` |
| `push` | ok | `ok` |
| `find-existing-pr` | ok | `ok` |
| `create-pr` | ok | `ok` |
| `inspect-auto-merge` | ok | `ok` |
| `auto-merge` | ok | `ok` |

## Agent artifacts

- Audit JSONL transcript: `/Users/ksinder/projects/harn-bump-fleet/.harn-runs/release-harn/019e0535-6429-77d3-8667-d5c6233a40ed/agent-llm/llm_transcript.jsonl`
- Draft changelog: `/Users/ksinder/projects/harn-bump-fleet/.harn-runs/release-harn/019e0535-6429-77d3-8667-d5c6233a40ed/agent-draft-changelog.md`
- Agent validation findings: none

Generated by `release_harn.harn`.
