### PR TITLE
Tighten deterministic test practices

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,7 @@ at `.claude/skills/harn-scripting/SKILL.md`.
 - Do not add `std::thread::sleep`, `tokio::time::sleep`, `Instant::now()` polling loops,
   `SystemTime::now()`, or short `recv_timeout` calls to test files. These patterns are banned
   by `make lint-test-patterns`. Use `tokio::time::pause()`/`advance()`, `EventLog::subscribe()`,
-  or `OrchestratorHarness` instead. See `docs/dev/testing.md` for approved patterns and the
+  or `OrchestratorHarness` instead. See `docs/src/dev/testing.md` for approved patterns and the
   opt-out procedure.
 
 ## Generated Files And Sync Rules

--- a/Makefile
+++ b/Makefile
@@ -258,7 +258,7 @@ check-docs-snippets:
 	@./scripts/check_docs_snippets.sh
 
 # Lint test files for wall-clock polling patterns that cause flaky tests.
-# See docs/dev/testing.md for approved alternatives and the opt-out mechanism.
+# See docs/src/dev/testing.md for approved alternatives and the opt-out mechanism.
 lint-test-patterns:
 	@./scripts/lint_test_patterns.sh
 

--- a/conformance/tests/_common.harn
+++ b/conformance/tests/_common.harn
@@ -7,6 +7,7 @@ fn first_group(pattern, text) {
   return matches[0].groups[0]
 }
 
+/** Resolve the built Harn CLI for conformance fixtures that spawn subprocesses. */
 pub fn resolve_harn_bin(repo_root) {
   let env_target_dir = env("CARGO_TARGET_DIR")
   if env_target_dir {
@@ -21,4 +22,66 @@ pub fn resolve_harn_bin(repo_root) {
     }
   }
   return path_join(repo_root, "target/debug/harn")
+}
+
+/** Return whether a subprocess still exists according to the platform shell. */
+pub fn process_alive(pid) {
+  let probe = shell("kill -0 " + pid + " >/dev/null 2>&1")
+  return probe.success
+}
+
+/** Poll a subprocess log for a regex match and return the first capture group. */
+pub fn wait_for_log_match(log_path, pattern) {
+  var attempts = 0
+  while attempts < 300 {
+    if file_exists(log_path) {
+      let log = exec("cat", log_path).stdout
+      let matches = regex_captures(pattern, log)
+      if len(matches) > 0 {
+        return matches[0].groups[0]
+      }
+    }
+    sleep(50ms)
+    attempts = attempts + 1
+  }
+  return nil
+}
+
+/** Poll a subprocess log until it contains the expected text. */
+pub fn wait_for_log_contains(log_path, needle) {
+  var attempts = 0
+  while attempts < 300 {
+    if file_exists(log_path) {
+      let log = exec("cat", log_path).stdout
+      if contains(log, needle) {
+        return true
+      }
+    }
+    sleep(50ms)
+    attempts = attempts + 1
+  }
+  return false
+}
+
+/** Wait for the orchestrator HTTP listener readiness line and return its URL. */
+pub fn wait_for_listener_url(log_path) {
+  return wait_for_log_match(log_path, "\\[harn\\] HTTP listener ready on (\\S+)")
+}
+
+/** Wait for the A2A server readiness line and return its advertised URL. */
+pub fn wait_for_a2a_server_url(log_path) {
+  return wait_for_log_match(log_path, "Harn A2A server listening on (\\S+)")
+}
+
+/** Wait for a subprocess to exit after the test has requested shutdown. */
+pub fn wait_for_exit(pid) {
+  var attempts = 0
+  while attempts < 200 {
+    if !process_alive(pid) {
+      return true
+    }
+    sleep(50ms)
+    attempts = attempts + 1
+  }
+  return false
 }

--- a/conformance/tests/integration/orchestrator_a2a_dispatch_sync.harn
+++ b/conformance/tests/integration/orchestrator_a2a_dispatch_sync.harn
@@ -1,39 +1,10 @@
 import "std/triggers"
 import "../_common"
 
-fn wait_for_log_line(log_path, needle) {
-  var attempts = 0
-  while attempts < 200 {
-    if file_exists(log_path) {
-      let log = exec("cat", log_path).stdout
-      if contains(log, needle) {
-        return true
-      }
-    }
-    sleep(50ms)
-    attempts = attempts + 1
-  }
-  return false
-}
-
-fn wait_for_exit(pid) {
-  var attempts = 0
-  while attempts < 100 {
-    let probe = shell("kill -0 " + pid + " >/dev/null 2>&1")
-    if !probe.success {
-      return true
-    }
-    sleep(50ms)
-    attempts = attempts + 1
-  }
-  return false
-}
-
 pipeline test(task) {
   let unique = to_string(to_int(timestamp())) + "-" + to_string(random_int(100000, 999999))
   let root = path_join(temp_dir(), "harn-a2a-dispatch-" + unique)
   mkdir(root)
-  let port = random_int(20000, 45000)
   write_file(
     path_join(root, "receiver.harn"),
     "pipeline default(task) {\n  let envelope = json_parse(task)\n  println(json_stringify({trace_id: envelope.event.trace_id, target_agent: envelope.target_agent}))\n}\n",
@@ -43,19 +14,17 @@ pipeline test(task) {
   assert(file_exists(harn_bin), "missing built harn binary at " + harn_bin)
   let start = shell_at(
     root,
-    "nohup " + harn_bin + " serve --port " + to_string(port)
+    "nohup " + harn_bin + " serve --port 0"
       + " receiver.harn >receiver.log 2>&1 </dev/null & echo $!",
   )
   let pid = start.stdout.trim()
   assert(start.success, "failed to start A2A receiver")
   assert(pid != "", "missing A2A receiver pid")
-  assert(
-    wait_for_log_line(
-      path_join(root, "receiver.log"),
-      "Harn A2A server listening on http://localhost:" + to_string(port),
-    ),
-    "A2A receiver did not start",
-  )
+  let receiver_url = wait_for_a2a_server_url(path_join(root, "receiver.log"))
+  assert(receiver_url != nil, "A2A receiver did not start")
+  let port_matches = regex_captures(":(\\d+)$", receiver_url)
+  assert(len(port_matches) == 1, "A2A receiver URL did not include a port: " + receiver_url)
+  let port = port_matches[0].groups[0]
   let trigger_id = "github-a2a-review-" + unique
   let trace_id = "trace-a2a-" + unique
   let handle: TriggerHandle = trigger_register(
@@ -63,7 +32,7 @@ pipeline test(task) {
       id: trigger_id,
       kind: "issue.opened",
       provider: "github",
-      handler: "a2a://127.0.0.1:" + to_string(port) + "/triage",
+      handler: "a2a://127.0.0.1:" + port + "/triage",
       allow_cleartext: true,
       when: nil,
       retry: {max: 1, backoff: "immediate"},

--- a/conformance/tests/integration/orchestrator_auth_middleware.harn
+++ b/conformance/tests/integration/orchestrator_auth_middleware.harn
@@ -1,37 +1,5 @@
 import "../_common"
 
-fn wait_for_listener_url(log_path) {
-  var attempts = 0
-  var url = nil
-  while attempts < 200 && !url {
-    if file_exists(log_path) {
-      let log = exec("cat", log_path).stdout
-      let matches = regex_captures("\\[harn\\] HTTP listener ready on (\\S+)", log)
-      if len(matches) > 0 {
-        url = matches[0].groups[0]
-      }
-    }
-    if !url {
-      sleep(50ms)
-      attempts = attempts + 1
-    }
-  }
-  return url
-}
-
-fn wait_for_exit(pid) {
-  var attempts = 0
-  while attempts < 100 {
-    let probe = shell("kill -0 " + pid + " >/dev/null 2>&1")
-    if !probe.success {
-      return true
-    }
-    sleep(50ms)
-    attempts = attempts + 1
-  }
-  return false
-}
-
 pipeline test(task) {
   let root = path_join(temp_dir(), "harn-orchestrator-auth-" + uuid())
   mkdir(root)

--- a/conformance/tests/integration/orchestrator_cli_commands.harn
+++ b/conformance/tests/integration/orchestrator_cli_commands.harn
@@ -1,49 +1,4 @@
-fn wait_for_listener_url(log_path) {
-  var attempts = 0
-  var url = nil
-  while attempts < 300 && !url {
-    if file_exists(log_path) {
-      let log = exec("cat", log_path).stdout
-      let matches = regex_captures("\\[harn\\] HTTP listener ready on (\\S+)", log)
-      if len(matches) > 0 {
-        url = matches[0].groups[0]
-      }
-    }
-    if !url {
-      sleep(50ms)
-      attempts = attempts + 1
-    }
-  }
-  return url
-}
-
-fn wait_for_log_contains(log_path, needle) {
-  var attempts = 0
-  while attempts < 300 {
-    if file_exists(log_path) {
-      let log = exec("cat", log_path).stdout
-      if contains(log, needle) {
-        return true
-      }
-    }
-    sleep(50ms)
-    attempts = attempts + 1
-  }
-  return false
-}
-
-fn wait_for_exit(pid) {
-  var attempts = 0
-  while attempts < 200 {
-    let probe = shell("kill -0 " + pid + " >/dev/null 2>&1")
-    if !probe.success {
-      return true
-    }
-    sleep(50ms)
-    attempts = attempts + 1
-  }
-  return false
-}
+import "../_common"
 
 fn first_group(pattern, text) {
   let matches = regex_captures(pattern, text)
@@ -51,22 +6,6 @@ fn first_group(pattern, text) {
     return nil
   }
   return matches[0].groups[0]
-}
-
-fn resolve_harn_bin(repo_root) {
-  let env_target_dir = env("CARGO_TARGET_DIR")
-  if env_target_dir {
-    return path_join(env_target_dir, "debug/harn")
-  }
-  let cargo_config = path_join(repo_root, ".cargo/config.toml")
-  if file_exists(cargo_config) {
-    let config = exec("cat", cargo_config).stdout
-    let configured = first_group("target-dir = \\\"([^\\\"]+)\\\"", config)
-    if configured {
-      return path_join(configured, "debug/harn")
-    }
-  }
-  return path_join(repo_root, "target/debug/harn")
 }
 
 pipeline test(task) {

--- a/conformance/tests/integration/orchestrator_recover_stranded_envelopes.harn
+++ b/conformance/tests/integration/orchestrator_recover_stranded_envelopes.harn
@@ -1,26 +1,4 @@
-fn wait_for_listener_url(log_path) {
-  var attempts = 0
-  var url = nil
-  while attempts < 300 && !url {
-    if file_exists(log_path) {
-      let log = exec("cat", log_path).stdout
-      let matches = regex_captures("\\[harn\\] HTTP listener ready on (\\S+)", log)
-      if len(matches) > 0 {
-        url = matches[0].groups[0]
-      }
-    }
-    if !url {
-      sleep(50ms)
-      attempts = attempts + 1
-    }
-  }
-  return url
-}
-
-fn process_alive(pid) {
-  let probe = shell("kill -0 " + pid + " >/dev/null 2>&1")
-  return probe.success
-}
+import "../_common"
 
 fn wait_for_readyz(url, pid) {
   var attempts = 0
@@ -38,42 +16,6 @@ fn wait_for_readyz(url, pid) {
     attempts = attempts + 1
   }
   return false
-}
-
-fn wait_for_exit(pid) {
-  var attempts = 0
-  while attempts < 200 {
-    if !process_alive(pid) {
-      return true
-    }
-    sleep(50ms)
-    attempts = attempts + 1
-  }
-  return false
-}
-
-fn first_group(pattern, text) {
-  let matches = regex_captures(pattern, text)
-  if len(matches) == 0 {
-    return nil
-  }
-  return matches[0].groups[0]
-}
-
-fn resolve_harn_bin(repo_root) {
-  let env_target_dir = env("CARGO_TARGET_DIR")
-  if env_target_dir {
-    return path_join(env_target_dir, "debug/harn")
-  }
-  let cargo_config = path_join(repo_root, ".cargo/config.toml")
-  if file_exists(cargo_config) {
-    let config = exec("cat", cargo_config).stdout
-    let configured = first_group("target-dir = \\\"([^\\\"]+)\\\"", config)
-    if configured {
-      return path_join(configured, "debug/harn")
-    }
-  }
-  return path_join(repo_root, "target/debug/harn")
 }
 
 pipeline test(task) {

--- a/conformance/tests/observability/action_graph_dispatcher_node_kinds.harn
+++ b/conformance/tests/observability/action_graph_dispatcher_node_kinds.harn
@@ -1,34 +1,6 @@
 import "std/triggers"
 import "../_common"
 
-fn wait_for_log_line(log_path, needle) {
-  var attempts = 0
-  while attempts < 200 {
-    if file_exists(log_path) {
-      let log = exec("cat", log_path).stdout
-      if contains(log, needle) {
-        return true
-      }
-    }
-    sleep(50ms)
-    attempts = attempts + 1
-  }
-  return false
-}
-
-fn wait_for_exit(pid) {
-  var attempts = 0
-  while attempts < 100 {
-    let probe = shell("kill -0 " + pid + " >/dev/null 2>&1")
-    if !probe.success {
-      return true
-    }
-    sleep(50ms)
-    attempts = attempts + 1
-  }
-  return false
-}
-
 fn pass_when(event: TriggerEvent) -> bool {
   return true
 }
@@ -44,7 +16,7 @@ fn failing_handler(event: TriggerEvent) -> any {
 fn action_graph_has_node(trace_id: string, kind: string) -> bool {
   let records: list<TriggerActionGraphEvent> = trigger_inspect_action_graph(trace_id)
   for entry in records {
-    for node in entry?.payload?.observability?.action_graph_nodes ?? [] {
+    for node in entry.payload?.observability?.action_graph_nodes ?? [] {
       if node?.trace_id == trace_id && node?.kind == kind {
         return true
       }
@@ -56,7 +28,7 @@ fn action_graph_has_node(trace_id: string, kind: string) -> bool {
 fn action_graph_has_edge(trace_id: string, kind: string) -> bool {
   let records: list<TriggerActionGraphEvent> = trigger_inspect_action_graph(trace_id)
   for entry in records {
-    for edge in entry?.payload?.observability?.action_graph_edges ?? [] {
+    for edge in entry.payload?.observability?.action_graph_edges ?? [] {
       if edge?.kind == kind {
         return true
       }
@@ -69,7 +41,6 @@ pipeline test(task) {
   let unique = to_string(to_int(timestamp())) + "-" + to_string(random_int(100000, 999999))
   let root = path_join(temp_dir(), "harn-action-graph-dispatcher-" + unique)
   mkdir(root)
-  let port = random_int(20000, 45000)
   write_file(
     path_join(root, "receiver.harn"),
     "pipeline default(task) {\n  let envelope = json_parse(task)\n  println(json_stringify({trace_id: envelope.event.trace_id, target_agent: envelope.target_agent}))\n}\n",
@@ -79,19 +50,17 @@ pipeline test(task) {
   assert(file_exists(harn_bin), "missing built harn binary at " + harn_bin)
   let start = shell_at(
     root,
-    "nohup " + harn_bin + " serve --port " + to_string(port)
+    "nohup " + harn_bin + " serve --port 0"
       + " receiver.harn >receiver.log 2>&1 </dev/null & echo $!",
   )
   let pid = start.stdout.trim()
   assert(start.success, "failed to start A2A receiver")
   assert(pid != "", "missing A2A receiver pid")
-  assert(
-    wait_for_log_line(
-      path_join(root, "receiver.log"),
-      "Harn A2A server listening on http://localhost:" + to_string(port),
-    ),
-    "A2A receiver did not start",
-  )
+  let receiver_url = wait_for_a2a_server_url(path_join(root, "receiver.log"))
+  assert(receiver_url != nil, "A2A receiver did not start")
+  let port_matches = regex_captures(":(\\d+)$", receiver_url)
+  assert(len(port_matches) == 1, "A2A receiver URL did not include a port: " + receiver_url)
+  let port = port_matches[0].groups[0]
   let local_trace = "trace-graph-local-" + unique
   let worker_trace = "trace-graph-worker-" + unique
   let retry_trace = "trace-graph-retry-" + unique
@@ -152,7 +121,7 @@ pipeline test(task) {
       id: "graph-a2a-" + unique,
       kind: "issue.opened",
       provider: "github",
-      handler: "a2a://127.0.0.1:" + to_string(port) + "/triage",
+      handler: "a2a://127.0.0.1:" + port + "/triage",
       allow_cleartext: true,
       when: nil,
       retry: {max: 1, backoff: "immediate"},

--- a/crates/harn-cli/src/skill_loader.rs
+++ b/crates/harn-cli/src/skill_loader.rs
@@ -381,6 +381,7 @@ mod tests {
     use super::*;
     use std::fs;
 
+    use crate::env_guard::ScopedEnvVar;
     use crate::skill_provenance;
     use crate::tests::common::{cwd_lock::lock_cwd, env_lock::lock_env};
 
@@ -392,6 +393,10 @@ mod tests {
             format!("---\nname: {name}\nshort: {name} short card\n---\n{body}"),
         )
         .unwrap();
+    }
+
+    fn set_home(path: &Path) -> ScopedEnvVar {
+        ScopedEnvVar::set("HOME", path.to_str().unwrap())
     }
 
     #[test]
@@ -452,7 +457,7 @@ mod tests {
         let _cwd = lock_cwd();
         let _env = lock_env().blocking_lock();
         let tmp = tempfile::tempdir().unwrap();
-        std::env::set_var("HOME", tmp.path());
+        let _home = set_home(tmp.path());
 
         let skill_dir = tmp.path().join("deploy");
         fs::create_dir_all(&skill_dir).unwrap();
@@ -511,7 +516,7 @@ mod tests {
         let _cwd = lock_cwd();
         let _env = lock_env().blocking_lock();
         let tmp = tempfile::tempdir().unwrap();
-        std::env::set_var("HOME", tmp.path());
+        let _home = set_home(tmp.path());
 
         let skill_dir = tmp.path().join("deploy");
         fs::create_dir_all(&skill_dir).unwrap();

--- a/crates/harn-cli/src/skill_provenance.rs
+++ b/crates/harn-cli/src/skill_provenance.rs
@@ -763,6 +763,7 @@ mod tests {
     use super::*;
     use std::fs;
 
+    use crate::env_guard::ScopedEnvVar;
     use crate::tests::common::{cwd_lock::lock_cwd, env_lock::lock_env};
 
     fn write_skill(path: &Path, body: &str) {
@@ -770,12 +771,16 @@ mod tests {
         fs::write(path, body).unwrap();
     }
 
+    fn set_home(path: &Path) -> ScopedEnvVar {
+        ScopedEnvVar::set("HOME", path.to_str().unwrap())
+    }
+
     #[test]
     fn keygen_sign_and_verify_roundtrip() {
         let _cwd = lock_cwd();
         let _env = lock_env().blocking_lock();
         let tmp = tempfile::tempdir().unwrap();
-        std::env::set_var("HOME", tmp.path());
+        let _home = set_home(tmp.path());
 
         let skill = tmp.path().join("skill").join("SKILL.md");
         write_skill(&skill, "---\nname: deploy\n---\nship it\n");
@@ -804,7 +809,7 @@ mod tests {
         let _cwd = lock_cwd();
         let _env = lock_env().blocking_lock();
         let tmp = tempfile::tempdir().unwrap();
-        std::env::set_var("HOME", tmp.path());
+        let _home = set_home(tmp.path());
 
         let skill = tmp.path().join("skill").join("SKILL.md");
         write_skill(&skill, "---\nname: deploy\n---\nship it\n");
@@ -825,7 +830,7 @@ mod tests {
         let _cwd = lock_cwd();
         let _env = lock_env().blocking_lock();
         let tmp = tempfile::tempdir().unwrap();
-        std::env::set_var("HOME", tmp.path());
+        let _home = set_home(tmp.path());
 
         let skill = tmp.path().join("skill").join("SKILL.md");
         write_skill(&skill, "---\nname: deploy\n---\nship it\n");
@@ -851,7 +856,7 @@ mod tests {
         let _cwd = lock_cwd();
         let _env = lock_env().blocking_lock();
         let tmp = tempfile::tempdir().unwrap();
-        std::env::set_var("HOME", tmp.path());
+        let _home = set_home(tmp.path());
 
         let skill = tmp.path().join("skill").join("SKILL.md");
         write_skill(&skill, "---\nname: deploy\n---\nship it\n");
@@ -871,7 +876,7 @@ mod tests {
         let _cwd = lock_cwd();
         let _env = lock_env().blocking_lock();
         let tmp = tempfile::tempdir().unwrap();
-        std::env::set_var("HOME", tmp.path());
+        let _home = set_home(tmp.path());
 
         let skill = tmp.path().join("skill").join("SKILL.md");
         write_skill(&skill, "---\nname: deploy\n---\nship it\n");
@@ -909,7 +914,7 @@ mod tests {
         let _cwd = lock_cwd();
         let _env = lock_env().blocking_lock();
         let tmp = tempfile::tempdir().unwrap();
-        std::env::set_var("HOME", tmp.path());
+        let _home = set_home(tmp.path());
 
         let skill = tmp.path().join("skill").join("SKILL.md");
         write_skill(&skill, "---\nname: deploy\n---\nship it\n");

--- a/crates/harn-vm/src/http/client.rs
+++ b/crates/harn-vm/src/http/client.rs
@@ -859,7 +859,7 @@ fn should_retry_transport(
         && (error.is_timeout() || error.is_connect())
 }
 
-pub(super) fn parse_retry_after_value(value: &str) -> Option<Duration> {
+pub(super) fn parse_retry_after_value_at(value: &str, now: SystemTime) -> Option<Duration> {
     let value = value.trim();
     if value.is_empty() {
         return None;
@@ -875,13 +875,17 @@ pub(super) fn parse_retry_after_value(value: &str) -> Option<Duration> {
 
     if let Ok(target) = httpdate::parse_http_date(value) {
         let millis = target
-            .duration_since(SystemTime::now())
+            .duration_since(now)
             .map(|delta| delta.as_millis() as u64)
             .unwrap_or(0);
         return Some(Duration::from_millis(millis.min(MAX_RETRY_DELAY_MS)));
     }
 
     None
+}
+
+pub(super) fn parse_retry_after_value(value: &str) -> Option<Duration> {
+    parse_retry_after_value_at(value, SystemTime::now())
 }
 
 fn parse_retry_after_header(value: &reqwest::header::HeaderValue) -> Option<Duration> {

--- a/crates/harn-vm/src/http/tests.rs
+++ b/crates/harn-vm/src/http/tests.rs
@@ -23,7 +23,7 @@ use std::io::{Read, Write};
 use std::net::TcpListener;
 use std::rc::Rc;
 use std::sync::{Arc, Once};
-use std::time::{Duration, SystemTime};
+use std::time::{Duration, UNIX_EPOCH};
 use tempfile::TempDir;
 use x509_parser::prelude::{FromDer, X509Certificate};
 
@@ -41,10 +41,11 @@ fn parses_retry_after_delta_seconds() {
 
 #[test]
 fn parses_retry_after_http_date() {
-    let header = httpdate::fmt_http_date(SystemTime::now() + Duration::from_secs(2));
-    let parsed = parse_retry_after_value(&header).expect("http-date should parse");
-    assert!(parsed <= Duration::from_secs(2));
-    assert!(parsed <= Duration::from_secs(60));
+    let now = UNIX_EPOCH + Duration::from_secs(1_700_000_000);
+    let header = httpdate::fmt_http_date(now + Duration::from_secs(2));
+    let parsed =
+        super::client::parse_retry_after_value_at(&header, now).expect("http-date should parse");
+    assert_eq!(parsed, Duration::from_secs(2));
 }
 
 #[test]

--- a/crates/harn-vm/src/llm/tools/tests/heredoc_and_messages.rs
+++ b/crates/harn-vm/src/llm/tools/tests/heredoc_and_messages.rs
@@ -689,10 +689,8 @@ fn read_file_offset_and_limit() {
     use super::super::handle_tool_locally;
     use std::io::Write;
 
-    // Create a temp file with numbered lines.
-    let dir = std::env::temp_dir().join("harn_test_read_file_offset");
-    let _ = std::fs::create_dir_all(&dir);
-    let path = dir.join("test_offset.txt");
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("test_offset.txt");
     {
         let mut f = std::fs::File::create(&path).unwrap();
         for i in 1..=20 {
@@ -724,8 +722,4 @@ fn read_file_offset_and_limit() {
     let result =
         handle_tool_locally("read_file", &json!({"path": path_str, "offset": 100})).unwrap();
     assert!(!result.contains("line"), "no content past end");
-
-    // Clean up.
-    let _ = std::fs::remove_file(&path);
-    let _ = std::fs::remove_dir(&dir);
 }

--- a/docs/src/dev/testing.md
+++ b/docs/src/dev/testing.md
@@ -98,7 +98,8 @@ It exposes a synchronous control channel so the test drives process state
 
 The following patterns are banned in test files by `make lint-test-patterns`.
 The script searches files under `crates/**/tests/**/*.rs`,
-`crates/**/src/**/tests.rs`, and `crates/**/src/**/tests_*.rs`.
+`crates/**/src/**/tests.rs`, `crates/**/src/**/tests_*.rs`, and
+`conformance/tests/**/*.harn`.
 
 | Pattern | Why it is banned | Approved alternative |
 |---|---|---|
@@ -107,6 +108,8 @@ The script searches files under `crates/**/tests/**/*.rs`,
 | `while … Instant::now()` | Wall-clock polling loop; flaky under load | `EventLog::subscribe()` + `timeout` |
 | `SystemTime::now()` in tests | Real wall-clock timestamp; non-reproducible | `MockClock` or injected timestamp |
 | `recv_timeout(Duration::from_millis(…))` | Busy-wait with a short literal timeout | `tokio::time::timeout` with event channel |
+| copied conformance subprocess wait helpers | Drifts retry ceilings and diagnostics between fixtures | import `conformance/tests/_common.harn` |
+| `random_int(20000, 45000)` for server ports | Races with other tests and local services | bind port `0` and read the readiness log |
 
 ## Opting out
 

--- a/editors/vscode/test/lsp-surface.test.js
+++ b/editors/vscode/test/lsp-surface.test.js
@@ -4,6 +4,7 @@ const os = require("node:os");
 const path = require("node:path");
 const { spawn, spawnSync } = require("node:child_process");
 const test = require("node:test");
+const { pathToFileURL } = require("node:url");
 
 class LspClient {
   constructor(server) {
@@ -120,11 +121,26 @@ function repoRoot() {
 }
 
 function fileUri(filePath) {
-  return `file://${filePath}`;
+  return pathToFileURL(filePath).toString();
 }
 
 function buildLspBinary(root) {
-  const env = { ...process.env, HARN_LLM_CALLS_DISABLED: "1" };
+  if (process.env.HARN_LSP_BIN) {
+    assert.ok(
+      fs.existsSync(process.env.HARN_LSP_BIN),
+      `HARN_LSP_BIN does not exist: ${process.env.HARN_LSP_BIN}`
+    );
+    return { binary: process.env.HARN_LSP_BIN, targetDir: undefined };
+  }
+
+  const targetDir = process.env.CARGO_TARGET_DIR
+    ? process.env.CARGO_TARGET_DIR
+    : fs.mkdtempSync(path.join(os.tmpdir(), "harn-lsp-target-"));
+  const env = {
+    ...process.env,
+    CARGO_TARGET_DIR: targetDir,
+    HARN_LLM_CALLS_DISABLED: "1",
+  };
   const build = spawnSync(
     "cargo",
     ["build", "--quiet", "-p", "harn-lsp", "--bin", "harn-lsp"],
@@ -140,11 +156,8 @@ function buildLspBinary(root) {
     `cargo build failed\nstdout:\n${build.stdout}\nstderr:\n${build.stderr}`
   );
 
-  const targetDir = process.env.CARGO_TARGET_DIR
-    ? process.env.CARGO_TARGET_DIR
-    : path.join(root, "target");
   const exe = process.platform === "win32" ? "harn-lsp.exe" : "harn-lsp";
-  return path.join(targetDir, "debug", exe);
+  return { binary: path.join(targetDir, "debug", exe), targetDir };
 }
 
 function positionOf(source, needle) {
@@ -160,7 +173,7 @@ function positionOf(source, needle) {
 
 test("VS Code-facing LSP surface supports on-type formatting, folding, and call hierarchy", async (t) => {
   const root = repoRoot();
-  const lspBinary = buildLspBinary(root);
+  const { binary: lspBinary, targetDir } = buildLspBinary(root);
   const server = spawn(lspBinary, [], {
     cwd: root,
     env: { ...process.env, HARN_LLM_CALLS_DISABLED: "1" },
@@ -169,6 +182,9 @@ test("VS Code-facing LSP surface supports on-type formatting, folding, and call 
   const client = new LspClient(server);
   t.after(async () => {
     await client.stop();
+    if (targetDir && !process.env.CARGO_TARGET_DIR) {
+      fs.rmSync(targetDir, { recursive: true, force: true });
+    }
   });
 
   const initialize = await client.request("initialize", {

--- a/scripts/lint_test_patterns.sh
+++ b/scripts/lint_test_patterns.sh
@@ -64,6 +64,13 @@ SYSTEM_TIME_ALLOWLIST=(
 # cannot be resolved by a static text search.
 RECV_TIMEOUT_MILLIS_ALLOWLIST=()
 
+# Conformance tests that exercise real subprocesses should share the bounded
+# polling helpers from `conformance/tests/_common.harn` instead of copying
+# ad hoc loops into each fixture.
+CONFORMANCE_HELPER_ALLOWLIST=(
+  "conformance/tests/_common.harn"
+)
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -114,7 +121,8 @@ is_e2e_subprocess_path() {
 
 # Collect test file paths into a temp file so we can reuse the list.
 TEST_FILES_TMP="$(mktemp)"
-trap 'rm -f "$TEST_FILES_TMP"' EXIT
+HARN_TEST_FILES_TMP="$(mktemp)"
+trap 'rm -f "$TEST_FILES_TMP" "$HARN_TEST_FILES_TMP"' EXIT
 
 {
   # crates/**/tests/**/*.rs — any depth under a tests/ directory
@@ -122,6 +130,8 @@ trap 'rm -f "$TEST_FILES_TMP"' EXIT
   # crates/**/src/**/tests.rs and tests_*.rs — inline test modules
   find crates -type f \( -name "tests.rs" -o -name "tests_*.rs" \) -path "*/src/*"
 } | sort -u > "$TEST_FILES_TMP"
+
+find conformance/tests -type f -name "*.harn" | sort -u > "$HARN_TEST_FILES_TMP"
 
 # check_pattern PATTERN ALLOWLIST_VAR SUGGESTION
 #   Greps PATTERN across test files, skipping allowlisted files.
@@ -213,12 +223,42 @@ while IFS= read -r file; do
   done < <(grep -n "spawn_orchestrator(" "$file" 2>/dev/null || true)
 done < "$TEST_FILES_TMP"
 
+echo "--- copied conformance subprocess wait helpers ---"
+check_harn_helper_pattern() {
+  local pattern="$1"
+  local suggestion="$2"
+
+  while IFS= read -r file; do
+    in_allowlist "$file" CONFORMANCE_HELPER_ALLOWLIST && continue
+    while IFS= read -r hit; do
+      [[ -z "$hit" ]] && continue
+      echo "  $hit"
+      echo "    hint: $suggestion"
+      violations=$((violations + 1))
+    done < <(grep -n -- "$pattern" "$file" 2>/dev/null || true)
+  done < "$HARN_TEST_FILES_TMP"
+}
+
+check_harn_helper_pattern \
+  "^fn wait_for_listener_url\|^fn wait_for_a2a_server_url\|^fn wait_for_log_line\|^fn wait_for_exit" \
+  "Import the shared helper from conformance/tests/_common.harn so retry ceilings stay consistent."
+
+echo "--- random fixed-port conformance server allocation ---"
+while IFS= read -r file; do
+  while IFS= read -r hit; do
+    [[ -z "$hit" ]] && continue
+    echo "  $hit"
+    echo "    hint: Bind test servers to port 0 and read the selected port from the readiness log."
+    violations=$((violations + 1))
+  done < <(grep -n "random_int(20000, 45000)" "$file" 2>/dev/null || true)
+done < "$HARN_TEST_FILES_TMP"
+
 # ---------------------------------------------------------------------------
 echo
 if (( violations > 0 )); then
   echo "FAIL: $violations wall-clock pattern violation(s) found in test files."
   echo
-  echo "Forbidden patterns cause flaky tests. See docs/dev/testing.md for"
+  echo "Forbidden patterns cause flaky tests. See docs/src/dev/testing.md for"
   echo "approved alternatives and how to opt out with reviewer justification."
   exit 1
 else

--- a/tree-sitter-harn/scripts/tree-sitter-cli.sh
+++ b/tree-sitter-harn/scripts/tree-sitter-cli.sh
@@ -28,12 +28,9 @@ export XDG_CONFIG_HOME="$CONFIG_ROOT"
 CLI_BIN="$GRAMMAR_DIR/node_modules/.bin/tree-sitter"
 
 if [[ ! -x "$CLI_BIN" ]]; then
-  echo "bootstrapping tree-sitter-harn npm dependencies" >&2
-  if [[ -f "$GRAMMAR_DIR/package-lock.json" ]]; then
-    (cd "$GRAMMAR_DIR" && npm ci)
-  else
-    (cd "$GRAMMAR_DIR" && npm install)
-  fi
+  echo "missing tree-sitter CLI at $CLI_BIN" >&2
+  echo "run \`cd tree-sitter-harn && npm ci\` before grammar build/test commands" >&2
+  exit 1
 fi
 
 exec "$CLI_BIN" "$@"


### PR DESCRIPTION
## Summary
- centralize conformance subprocess wait helpers and switch A2A fixtures to ephemeral ports
- make retry-after date parsing testable without wall-clock time and restore HOME mutations with scoped guards
- tighten test-pattern lint/docs, VS Code LSP harness paths/build isolation, and tree-sitter dependency behavior

## Verification
- cargo fmt --all
- cargo clippy -p harn-vm -p harn-cli --tests -- -D warnings
- pre-commit hook: cargo clippy --workspace --all-targets -- -D warnings, markdownlint, actionlint
- pre-push targeted local checks
- ./scripts/lint_test_patterns.sh
- node --test editors/vscode/test/lsp-surface.test.js
- cd tree-sitter-harn && npm test
- cargo test -p harn-vm parses_retry_after_http_date -- --nocapture
- cargo test -p harn-vm read_file_offset_and_limit -- --nocapture
- cargo test -p harn-cli skill_loader::tests -- --nocapture
- cargo test -p harn-cli skill_provenance::tests -- --nocapture
- harn conformance filters: orchestrator_a2a_dispatch_sync, action_graph_dispatcher_node_kinds, orchestrator_auth_middleware, orchestrator_cli_commands, orchestrator_recover_stranded_envelopes