### PR TITLE
[codex] Fix Ollama tool argument replay

### DIFF
--- a/crates/harn-vm/src/llm/tools/messages.rs
+++ b/crates/harn-vm/src/llm/tools/messages.rs
@@ -27,9 +27,7 @@ pub(crate) fn build_assistant_tool_message(
         serde_json::json!({"role": "assistant", "content": content})
     } else if is_ollama {
         // Ollama's chat API uses the OpenAI-style `function` envelope but
-        // keeps `arguments` as a JSON object. Replaying OpenAI's
-        // string-encoded arguments trips Ollama's template parser on the
-        // next turn.
+        // its request schema expects `function.arguments` to be a string.
         let calls: Vec<serde_json::Value> = tool_calls
             .iter()
             .enumerate()
@@ -40,7 +38,7 @@ pub(crate) fn build_assistant_tool_message(
                     "function": {
                         "index": idx,
                         "name": tc["name"],
-                        "arguments": tc["arguments"],
+                        "arguments": serde_json::to_string(&tc["arguments"]).unwrap_or_default(),
                     }
                 })
             })

--- a/crates/harn-vm/src/llm/tools/tests/heredoc_and_messages.rs
+++ b/crates/harn-vm/src/llm/tools/tests/heredoc_and_messages.rs
@@ -643,7 +643,7 @@ fn assistant_tool_message_includes_empty_content_for_openai_style() {
 }
 
 #[test]
-fn assistant_tool_message_uses_ollama_native_arguments() {
+fn assistant_tool_message_stringifies_ollama_arguments() {
     let message = build_assistant_tool_message(
         "",
         &[json!({
@@ -659,10 +659,12 @@ fn assistant_tool_message_uses_ollama_native_arguments() {
     assert_eq!(message["tool_calls"][0]["id"], "call_001");
     assert_eq!(message["tool_calls"][0]["type"], "function");
     assert_eq!(message["tool_calls"][0]["function"]["name"], "read");
-    assert_eq!(
-        message["tool_calls"][0]["function"]["arguments"]["path"],
-        "main.rs"
-    );
+    let arguments = message["tool_calls"][0]["function"]["arguments"]
+        .as_str()
+        .expect("ollama tool arguments should be a JSON string");
+    let parsed_arguments: serde_json::Value =
+        serde_json::from_str(arguments).expect("ollama tool arguments should parse as JSON");
+    assert_eq!(parsed_arguments["path"], "main.rs");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- stringify replayed Ollama assistant tool-call arguments so `/api/chat` receives `function.arguments` as the string type its Go schema expects
- update the Harn VM tool-message test to pin the Ollama wire shape while preserving parsed argument content

## Root Cause
Harn stored parsed tool-call arguments as structured JSON and replayed them back into Ollama assistant history as an object. Ollama rejects that request shape with `cannot unmarshal object into Go struct field .messages.tool_calls.function.arguments of type string`.

## Validation
- `CARGO_TARGET_DIR=/tmp/codex-harn-tool-args-target cargo test -p harn-vm assistant_tool_message`
- `cargo fmt --all --check`
- pre-commit hook: `cargo clippy --workspace --all-targets -- -D warnings`
- pre-push hook targeted checks