### PR TITLE
[codex] Build protocol conformance matrix

### DIFF
--- a/conformance/protocols/README.md
+++ b/conformance/protocols/README.md
@@ -1,14 +1,46 @@
 # Protocol conformance fixtures
 
 `harn test protocols` validates checked-in ACP, A2A, and MCP JSON wire fixtures
-against pinned JSON Schema snapshots. This gate is intentionally separate from
+against pinned JSON Schema profiles. This gate is intentionally separate from
 `harn test conformance`, which remains the executable Harn language/runtime
 suite.
 
-The schemas are compact Harn adapter profiles derived from the public protocol
-schemas/specifications cited in each schema file. They pin the protocol surface
-Harn currently emits or accepts and include negative fixtures for unsupported
-versions, missing required fields, and unsupported extension discriminators.
+The schemas are Harn adapter profiles backed by the public protocol schemas and
+specifications cited in each schema file's `x-harn-provenance` block. The
+upstream MCP and A2A JSON schema artifacts are definitions-only, so each Harn
+profile supplies the root over the request, response, notification, metadata,
+and negative-case shapes Harn actually emits or accepts.
+
+Every fixture is a matrix row:
+
+```json
+{
+  "name": "mcp.initialize.2025_11_25",
+  "protocol": "mcp",
+  "schema": "schemas/mcp-2025-11-25.schema.json",
+  "expect": "valid",
+  "documents": [],
+  "matrix": {
+    "version": "2025-11-25",
+    "family": "initialize",
+    "case": "success",
+    "source": {
+      "kind": "official_example",
+      "url": "https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle",
+      "description": "Why this row exists."
+    }
+  }
+}
+```
+
+`matrix.source.kind` is one of:
+
+- `official_example`: derived from an official example or normative schema
+  semantics; `url` is required.
+- `adapter_generated`: generated from Harn adapter code; `generator` is
+  required and should name the focused test that pins the fixture.
+- `hand_authored`: maintained by hand against the pinned schema profile;
+  `description` is required.
 
 Run:
 
@@ -21,3 +53,35 @@ or:
 ```sh
 cargo run --bin harn -- test protocols
 ```
+
+Useful filters:
+
+```sh
+cargo run --bin harn -- test protocols --filter mcp
+cargo run --bin harn -- test protocols --filter 're:^(mcp|a2a)\\.agent_card'
+cargo run --bin harn -- test protocols acp --verbose
+```
+
+## Refreshing profiles
+
+When an upstream protocol version changes:
+
+1. Run the `refresh_command` recorded in the relevant schema's
+   `x-harn-provenance` block and inspect the upstream diff.
+2. Update the Harn profile schema to match the adapter surface for the new
+   version.
+3. Update fixture `matrix.version` values and add success/negative rows for
+   newly supported or intentionally unsupported protocol families.
+4. Run `make protocol-conformance`.
+5. Run the adapter drift tests for any `adapter_generated` fixtures you touched,
+   for example:
+
+```sh
+cargo test -p harn-serve adapter_protocol_fixture_matches_checked_in_matrix
+cargo test -p harn-serve adapter_agent_card_protocol_fixture_matches_checked_in_matrix
+cargo test -p harn-serve protocol_conformance_
+```
+
+Adapter-generated fixture tests print the expected and actual JSON arrays when
+they drift, so CI failures should point directly at the checked-in fixture that
+needs to be refreshed or the adapter behavior that changed unexpectedly.

--- a/conformance/protocols/fixtures/a2a/agent_card.valid.json
+++ b/conformance/protocols/fixtures/a2a/agent_card.valid.json
@@ -16,15 +16,23 @@
           "transport": "JSONRPC"
         }
       ],
-      "version": "0.7.48",
+      "version": "0.8.0",
       "provider": {
         "organization": "Harn",
         "url": "https://harn.dev"
       },
       "securitySchemes": {},
       "security": [],
-      "defaultInputModes": ["application/json", "text/plain", "application/octet-stream"],
-      "defaultOutputModes": ["application/json", "text/plain", "application/octet-stream"],
+      "defaultInputModes": [
+        "application/json",
+        "text/plain",
+        "application/octet-stream"
+      ],
+      "defaultOutputModes": [
+        "application/json",
+        "text/plain",
+        "application/octet-stream"
+      ],
       "capabilities": {
         "streaming": true,
         "pushNotifications": true
@@ -34,14 +42,35 @@
           "id": "review",
           "name": "review",
           "description": "Invoke exported Harn function 'review'.",
-          "tags": ["harn", "function"],
-          "inputModes": ["application/json", "text/plain", "application/octet-stream"],
-          "outputModes": ["application/json", "text/plain", "application/octet-stream"],
+          "tags": [
+            "harn",
+            "function"
+          ],
+          "inputModes": [
+            "application/json",
+            "text/plain",
+            "application/octet-stream"
+          ],
+          "outputModes": [
+            "application/json",
+            "text/plain",
+            "application/octet-stream"
+          ],
           "inputSchema": {
             "type": "object"
           }
         }
       ]
     }
-  ]
+  ],
+  "matrix": {
+    "version": "0.3.0",
+    "family": "agent_card",
+    "case": "success",
+    "source": {
+      "kind": "official_example",
+      "url": "https://a2a-protocol.org/v0.3.0/specification/#55-agentcard-object-structure",
+      "description": "A2A 0.3.0 AgentCard discovery shape with Harn-served skills."
+    }
+  }
 }

--- a/conformance/protocols/fixtures/a2a/agent_card_adapter.valid.json
+++ b/conformance/protocols/fixtures/a2a/agent_card_adapter.valid.json
@@ -1,0 +1,71 @@
+{
+  "name": "a2a.adapter.agent_card.discovery",
+  "protocol": "a2a",
+  "schema": "schemas/a2a-0.3.0.schema.json",
+  "expect": "valid",
+  "documents": [
+    {
+      "protocolVersion": "0.3.0",
+      "name": "server",
+      "description": "Harn peer agent",
+      "url": "http://localhost:8080",
+      "preferredTransport": "JSONRPC",
+      "additionalInterfaces": [
+        {
+          "url": "http://localhost:8080",
+          "transport": "JSONRPC"
+        },
+        {
+          "url": "http://localhost:8080/v1",
+          "transport": "HTTP+JSON"
+        }
+      ],
+      "version": "0.8.0",
+      "provider": {
+        "organization": "Harn",
+        "url": "https://harn.dev"
+      },
+      "securitySchemes": {},
+      "security": [],
+      "supportsAuthenticatedExtendedCard": false,
+      "defaultInputModes": ["application/json", "text/plain", "application/octet-stream"],
+      "defaultOutputModes": ["application/json", "text/plain", "application/octet-stream"],
+      "capabilities": {
+        "streaming": true,
+        "pushNotifications": true
+      },
+      "skills": [
+        {
+          "id": "triage",
+          "name": "triage",
+          "description": "Invoke exported Harn function 'triage'.",
+          "tags": ["harn", "function"],
+          "examples": [],
+          "inputModes": ["application/json", "text/plain", "application/octet-stream"],
+          "outputModes": ["application/json", "text/plain", "application/octet-stream"],
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "task": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "task"
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "matrix": {
+    "version": "0.3.0",
+    "family": "agent_card",
+    "case": "adapter_discovery_success",
+    "source": {
+      "kind": "adapter_generated",
+      "generator": "cargo test -p harn-serve adapters::a2a::tests::adapter_agent_card_protocol_fixture_matches_checked_in_matrix",
+      "description": "Generated from A2aServer::agent_card for a typed exported Harn function."
+    }
+  }
+}

--- a/conformance/protocols/fixtures/a2a/agent_card_legacy_supported_interfaces.invalid.json
+++ b/conformance/protocols/fixtures/a2a/agent_card_legacy_supported_interfaces.invalid.json
@@ -23,11 +23,24 @@
           "protocolVersion": "0.3.0"
         }
       ],
-      "version": "0.7.48",
-      "defaultInputModes": ["application/json"],
-      "defaultOutputModes": ["application/json"],
+      "version": "0.8.0",
+      "defaultInputModes": [
+        "application/json"
+      ],
+      "defaultOutputModes": [
+        "application/json"
+      ],
       "capabilities": {},
       "skills": []
     }
-  ]
+  ],
+  "matrix": {
+    "version": "0.3.0",
+    "family": "agent_card",
+    "case": "negative",
+    "source": {
+      "kind": "hand_authored",
+      "description": "Protocol matrix fixture maintained from the pinned Harn adapter profile and upstream protocol semantics."
+    }
+  }
 }

--- a/conformance/protocols/fixtures/a2a/agent_card_security.valid.json
+++ b/conformance/protocols/fixtures/a2a/agent_card_security.valid.json
@@ -1,0 +1,68 @@
+{
+  "name": "a2a.agent_card.security_schemes",
+  "protocol": "a2a",
+  "schema": "schemas/a2a-0.3.0.schema.json",
+  "expect": "valid",
+  "documents": [
+    {
+      "protocolVersion": "0.3.0",
+      "name": "secured-agent",
+      "description": "Harn peer agent with authenticated extended card support",
+      "url": "https://agent.example.com/a2a",
+      "preferredTransport": "JSONRPC",
+      "additionalInterfaces": [
+        {
+          "url": "https://agent.example.com/a2a",
+          "transport": "JSONRPC"
+        }
+      ],
+      "version": "0.8.0",
+      "provider": {
+        "organization": "Harn"
+      },
+      "securitySchemes": {
+        "apiKey": {
+          "type": "apiKey",
+          "name": "x-harn-api-key",
+          "in": "header"
+        },
+        "bearer": {
+          "type": "http",
+          "scheme": "bearer",
+          "bearerFormat": "JWT"
+        }
+      },
+      "security": [
+        {
+          "apiKey": []
+        },
+        {
+          "bearer": []
+        }
+      ],
+      "supportsAuthenticatedExtendedCard": true,
+      "defaultInputModes": ["application/json"],
+      "defaultOutputModes": ["application/json"],
+      "capabilities": {
+        "streaming": true,
+        "pushNotifications": true
+      },
+      "skills": [
+        {
+          "id": "review",
+          "name": "review",
+          "description": "Review a patch"
+        }
+      ]
+    }
+  ],
+  "matrix": {
+    "version": "0.3.0",
+    "family": "agent_card",
+    "case": "security_schemes_success",
+    "source": {
+      "kind": "hand_authored",
+      "description": "A2A AgentCard security scheme and requirement metadata consumed by Harn extended-card clients."
+    }
+  }
+}

--- a/conformance/protocols/fixtures/a2a/message_send_missing_id.invalid.json
+++ b/conformance/protocols/fixtures/a2a/message_send_missing_id.invalid.json
@@ -1,0 +1,33 @@
+{
+  "name": "a2a.message_send.missing_id",
+  "protocol": "a2a",
+  "schema": "schemas/a2a-0.3.0.schema.json",
+  "expect": "invalid",
+  "documents": [
+    {
+      "jsonrpc": "2.0",
+      "method": "message/send",
+      "params": {
+        "message": {
+          "id": "msg-1",
+          "role": "user",
+          "parts": [
+            {
+              "type": "text",
+              "text": "hello"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "matrix": {
+    "version": "0.3.0",
+    "family": "message_send",
+    "case": "malformed_payload_negative",
+    "source": {
+      "kind": "hand_authored",
+      "description": "Negative JSON-RPC request fixture for the required request id field."
+    }
+  }
+}

--- a/conformance/protocols/fixtures/a2a/push_notification_config_crud.valid.json
+++ b/conformance/protocols/fixtures/a2a/push_notification_config_crud.valid.json
@@ -76,5 +76,14 @@
       "id": "push-delete",
       "result": null
     }
-  ]
+  ],
+  "matrix": {
+    "version": "0.3.0",
+    "family": "push_notification_config",
+    "case": "success",
+    "source": {
+      "kind": "hand_authored",
+      "description": "Protocol matrix fixture maintained from the pinned Harn adapter profile and upstream protocol semantics."
+    }
+  }
 }

--- a/conformance/protocols/fixtures/a2a/task_and_stream.valid.json
+++ b/conformance/protocols/fixtures/a2a/task_and_stream.valid.json
@@ -90,5 +90,14 @@
         }
       }
     }
-  ]
+  ],
+  "matrix": {
+    "version": "0.3.0",
+    "family": "task_and_stream",
+    "case": "success",
+    "source": {
+      "kind": "hand_authored",
+      "description": "Protocol matrix fixture maintained from the pinned Harn adapter profile and upstream protocol semantics."
+    }
+  }
 }

--- a/conformance/protocols/fixtures/a2a/unknown_method.invalid.json
+++ b/conformance/protocols/fixtures/a2a/unknown_method.invalid.json
@@ -1,0 +1,25 @@
+{
+  "name": "a2a.jsonrpc.unknown_method",
+  "protocol": "a2a",
+  "schema": "schemas/a2a-0.3.0.schema.json",
+  "expect": "invalid",
+  "documents": [
+    {
+      "jsonrpc": "2.0",
+      "id": "unknown-1",
+      "method": "tasks/teleport",
+      "params": {
+        "id": "task-1"
+      }
+    }
+  ],
+  "matrix": {
+    "version": "0.3.0",
+    "family": "jsonrpc",
+    "case": "unknown_method_negative",
+    "source": {
+      "kind": "hand_authored",
+      "description": "Negative A2A request fixture proving unadvertised JSON-RPC methods are outside the pinned Harn profile."
+    }
+  }
+}

--- a/conformance/protocols/fixtures/a2a/unsupported_protocol_version.invalid.json
+++ b/conformance/protocols/fixtures/a2a/unsupported_protocol_version.invalid.json
@@ -16,13 +16,26 @@
           "transport": "JSONRPC"
         }
       ],
-      "version": "0.7.48",
-      "defaultInputModes": ["application/json"],
-      "defaultOutputModes": ["application/json"],
+      "version": "0.8.0",
+      "defaultInputModes": [
+        "application/json"
+      ],
+      "defaultOutputModes": [
+        "application/json"
+      ],
       "capabilities": {
         "streaming": true
       },
       "skills": []
     }
-  ]
+  ],
+  "matrix": {
+    "version": "0.3.0",
+    "family": "agent_card",
+    "case": "negative",
+    "source": {
+      "kind": "hand_authored",
+      "description": "Protocol matrix fixture maintained from the pinned Harn adapter profile and upstream protocol semantics."
+    }
+  }
 }

--- a/conformance/protocols/fixtures/acp/agent_event_ext_notifications.valid.json
+++ b/conformance/protocols/fixtures/acp/agent_event_ext_notifications.valid.json
@@ -1,0 +1,93 @@
+{
+  "name": "acp.adapter.agent_event_ext_notifications",
+  "protocol": "acp",
+  "schema": "schemas/acp-session-update.schema.json",
+  "expect": "valid",
+  "documents": [
+    {
+      "jsonrpc": "2.0",
+      "method": "_harn/agentEvent",
+      "params": {
+        "iteration": 0,
+        "kind": "turn_start",
+        "sessionId": "session-1"
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "method": "_harn/agentEvent",
+      "params": {
+        "iteration": 0,
+        "kind": "turn_end",
+        "sessionId": "session-1",
+        "turnInfo": {
+          "tool_calls": 2,
+          "tool_names": ["read_file", "grep"]
+        }
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "method": "_harn/agentEvent",
+      "params": {
+        "iteration": 0,
+        "judgeDurationMs": 42,
+        "kind": "judge_decision",
+        "nextStep": "run the verifier",
+        "reasoning": "needs one more concrete action",
+        "sessionId": "session-1",
+        "verdict": "continue"
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "method": "_harn/agentEvent",
+      "params": {
+        "content": "missed required tool call; reissuing",
+        "feedbackKind": "protocol_violation",
+        "kind": "feedback_injected",
+        "sessionId": "session-1"
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "method": "_harn/agentEvent",
+      "params": {
+        "kind": "budget_exhausted",
+        "maxIterations": 8,
+        "sessionId": "session-1"
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "method": "_harn/agentEvent",
+      "params": {
+        "kind": "loop_stuck",
+        "lastIteration": 4,
+        "maxNudges": 3,
+        "sessionId": "session-1",
+        "tailExcerpt": "still thinking..."
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "method": "_harn/agentEvent",
+      "params": {
+        "attempts": 5,
+        "elapsedMs": 12000,
+        "kind": "daemon_watchdog_tripped",
+        "sessionId": "session-1"
+      }
+    }
+  ],
+  "matrix": {
+    "version": "v0.12.2",
+    "family": "agent_event_extension",
+    "case": "adapter_ext_notification_success",
+    "source": {
+      "kind": "adapter_generated",
+      "generator": "cargo test -p harn-serve adapters::acp::events::tests::protocol_conformance_agent_event_fixture_is_adapter_generated",
+      "description": "Generated from AcpAgentEventSink Harn ExtNotification translation."
+    }
+  }
+}

--- a/conformance/protocols/fixtures/acp/jsonrpc_error.valid.json
+++ b/conformance/protocols/fixtures/acp/jsonrpc_error.valid.json
@@ -1,0 +1,28 @@
+{
+  "name": "acp.jsonrpc.error_response",
+  "protocol": "acp",
+  "schema": "schemas/acp-session-update.schema.json",
+  "expect": "valid",
+  "documents": [
+    {
+      "jsonrpc": "2.0",
+      "id": 9,
+      "error": {
+        "code": -32602,
+        "message": "Unknown session: session-missing",
+        "data": {
+          "method": "session/set_mode"
+        }
+      }
+    }
+  ],
+  "matrix": {
+    "version": "v0.12.2",
+    "family": "jsonrpc",
+    "case": "error_response_success",
+    "source": {
+      "kind": "hand_authored",
+      "description": "JSON-RPC error envelope shape used by ACP request handlers."
+    }
+  }
+}

--- a/conformance/protocols/fixtures/acp/session_request_permission.valid.json
+++ b/conformance/protocols/fixtures/acp/session_request_permission.valid.json
@@ -1,0 +1,45 @@
+{
+  "name": "acp.session_request_permission.round_trip",
+  "protocol": "acp",
+  "schema": "schemas/acp-session-update.schema.json",
+  "expect": "valid",
+  "documents": [
+    {
+      "jsonrpc": "2.0",
+      "id": 77,
+      "method": "session/request_permission",
+      "params": {
+        "sessionId": "session-1",
+        "toolCallId": "tool-1",
+        "toolName": "edit",
+        "options": [
+          {
+            "id": "approve",
+            "label": "Approve"
+          },
+          {
+            "id": "deny",
+            "label": "Deny"
+          }
+        ]
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "id": 77,
+      "result": {
+        "outcome": "approved"
+      }
+    }
+  ],
+  "matrix": {
+    "version": "v0.12.2",
+    "family": "session_request_permission",
+    "case": "success",
+    "source": {
+      "kind": "adapter_generated",
+      "generator": "cargo test -p harn-serve adapters::acp::tests::acp_bridge_routes_session_request_permission_response",
+      "description": "Permission request and response shape from AcpBridge::call_client."
+    }
+  }
+}

--- a/conformance/protocols/fixtures/acp/session_update_adapter_standard.valid.json
+++ b/conformance/protocols/fixtures/acp/session_update_adapter_standard.valid.json
@@ -1,0 +1,108 @@
+{
+  "name": "acp.adapter.session_update.standard",
+  "protocol": "acp",
+  "schema": "schemas/acp-session-update.schema.json",
+  "expect": "valid",
+  "documents": [
+    {
+      "jsonrpc": "2.0",
+      "method": "session/update",
+      "params": {
+        "sessionId": "session-1",
+        "update": {
+          "content": {
+            "_meta": {
+              "harn": {
+                "visible_delta": "hello",
+                "visible_text": "hello"
+              }
+            },
+            "text": "hello",
+            "type": "text"
+          },
+          "sessionUpdate": "agent_message_chunk"
+        }
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "method": "session/update",
+      "params": {
+        "sessionId": "session-1",
+        "update": {
+          "content": {
+            "text": "thinking",
+            "type": "text"
+          },
+          "sessionUpdate": "agent_thought_chunk"
+        }
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "method": "session/update",
+      "params": {
+        "sessionId": "session-1",
+        "update": {
+          "kind": "read",
+          "rawInput": {
+            "path": "README.md"
+          },
+          "sessionUpdate": "tool_call",
+          "status": "pending",
+          "title": "read",
+          "toolCallId": "tool-1"
+        }
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "method": "session/update",
+      "params": {
+        "sessionId": "session-1",
+        "update": {
+          "_meta": {
+            "harn": {
+              "durationMs": 7,
+              "executionDurationMs": 5,
+              "executor": "harn_builtin"
+            }
+          },
+          "rawOutput": {
+            "ok": true
+          },
+          "sessionUpdate": "tool_call_update",
+          "status": "completed",
+          "title": "read",
+          "toolCallId": "tool-1"
+        }
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "method": "session/update",
+      "params": {
+        "sessionId": "session-1",
+        "update": {
+          "entries": [
+            {
+              "content": "edit",
+              "status": "pending"
+            }
+          ],
+          "sessionUpdate": "plan"
+        }
+      }
+    }
+  ],
+  "matrix": {
+    "version": "v0.12.2",
+    "family": "session_update",
+    "case": "adapter_standard_success",
+    "source": {
+      "kind": "adapter_generated",
+      "generator": "cargo test -p harn-serve adapters::acp::events::tests::protocol_conformance_standard_session_update_fixture_is_adapter_generated",
+      "description": "Generated from AcpAgentEventSink standard AgentEvent translation."
+    }
+  }
+}

--- a/conformance/protocols/fixtures/acp/session_update_extensions.valid.json
+++ b/conformance/protocols/fixtures/acp/session_update_extensions.valid.json
@@ -54,5 +54,14 @@
         }
       }
     }
-  ]
+  ],
+  "matrix": {
+    "version": "v0.12.2",
+    "family": "session_update",
+    "case": "success",
+    "source": {
+      "kind": "hand_authored",
+      "description": "Protocol matrix fixture maintained from the pinned Harn adapter profile and upstream protocol semantics."
+    }
+  }
 }

--- a/conformance/protocols/fixtures/acp/session_update_missing_session.invalid.json
+++ b/conformance/protocols/fixtures/acp/session_update_missing_session.invalid.json
@@ -17,5 +17,14 @@
         }
       }
     }
-  ]
+  ],
+  "matrix": {
+    "version": "v0.12.2",
+    "family": "session_update",
+    "case": "negative",
+    "source": {
+      "kind": "hand_authored",
+      "description": "Protocol matrix fixture maintained from the pinned Harn adapter profile and upstream protocol semantics."
+    }
+  }
 }

--- a/conformance/protocols/fixtures/acp/session_update_standard.valid.json
+++ b/conformance/protocols/fixtures/acp/session_update_standard.valid.json
@@ -112,5 +112,15 @@
         }
       }
     }
-  ]
+  ],
+  "matrix": {
+    "version": "v0.12.2",
+    "family": "session_update",
+    "case": "success",
+    "source": {
+      "kind": "official_example",
+      "url": "https://agentclientprotocol.com/protocol/schema",
+      "description": "Canonical ACP session/update discriminators represented in the upstream v0.12.2 schema."
+    }
+  }
 }

--- a/conformance/protocols/fixtures/acp/session_update_tool_call_harn_meta.valid.json
+++ b/conformance/protocols/fixtures/acp/session_update_tool_call_harn_meta.valid.json
@@ -57,5 +57,14 @@
         }
       }
     }
-  ]
+  ],
+  "matrix": {
+    "version": "v0.12.2",
+    "family": "session_update",
+    "case": "success",
+    "source": {
+      "kind": "hand_authored",
+      "description": "Protocol matrix fixture maintained from the pinned Harn adapter profile and upstream protocol semantics."
+    }
+  }
 }

--- a/conformance/protocols/fixtures/acp/session_update_tool_call_legacy_top_level_harn_fields.invalid.json
+++ b/conformance/protocols/fixtures/acp/session_update_tool_call_legacy_top_level_harn_fields.invalid.json
@@ -23,5 +23,14 @@
         }
       }
     }
-  ]
+  ],
+  "matrix": {
+    "version": "v0.12.2",
+    "family": "session_update",
+    "case": "negative",
+    "source": {
+      "kind": "hand_authored",
+      "description": "Protocol matrix fixture maintained from the pinned Harn adapter profile and upstream protocol semantics."
+    }
+  }
 }

--- a/conformance/protocols/fixtures/acp/session_update_unknown_extension.invalid.json
+++ b/conformance/protocols/fixtures/acp/session_update_unknown_extension.invalid.json
@@ -15,5 +15,14 @@
         }
       }
     }
-  ]
+  ],
+  "matrix": {
+    "version": "v0.12.2",
+    "family": "session_update",
+    "case": "negative",
+    "source": {
+      "kind": "hand_authored",
+      "description": "Protocol matrix fixture maintained from the pinned Harn adapter profile and upstream protocol semantics."
+    }
+  }
 }

--- a/conformance/protocols/fixtures/mcp/adapter_initialize_tools_resources.valid.json
+++ b/conformance/protocols/fixtures/mcp/adapter_initialize_tools_resources.valid.json
@@ -1,0 +1,138 @@
+{
+  "name": "mcp.adapter.initialize_tools_resources",
+  "protocol": "mcp",
+  "schema": "schemas/mcp-2025-11-25.schema.json",
+  "expect": "valid",
+  "documents": [
+    {
+      "jsonrpc": "2.0",
+      "id": 1,
+      "method": "initialize",
+      "params": {
+        "protocolVersion": "2025-11-25",
+        "capabilities": {},
+        "clientInfo": {
+          "name": "fixture-client",
+          "version": "1"
+        }
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "id": 1,
+      "result": {
+        "protocolVersion": "2025-11-25",
+        "capabilities": {
+          "tools": {},
+          "resources": {},
+          "logging": {},
+          "completions": {}
+        },
+        "serverInfo": {
+          "name": "server",
+          "version": "0.8.0",
+          "card": {
+            "name": "fixture-card",
+            "version": "1"
+          }
+        }
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "method": "notifications/initialized",
+      "params": {}
+    },
+    {
+      "jsonrpc": "2.0",
+      "id": 2,
+      "method": "tools/list",
+      "params": {}
+    },
+    {
+      "jsonrpc": "2.0",
+      "id": 2,
+      "result": {
+        "tools": [
+          {
+            "name": "greet",
+            "title": "greet",
+            "description": "Invoke exported Harn function 'greet'.",
+            "annotations": {
+              "title": "greet",
+              "readOnlyHint": false,
+              "destructiveHint": true,
+              "idempotentHint": false,
+              "openWorldHint": true
+            },
+            "inputSchema": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ]
+            },
+            "outputSchema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "id": 3,
+      "method": "resources/list",
+      "params": {}
+    },
+    {
+      "jsonrpc": "2.0",
+      "id": 3,
+      "result": {
+        "resources": [
+          {
+            "uri": "well-known://mcp-card",
+            "name": "Server Card",
+            "description": "MCP Server Card advertising this server's identity and capabilities",
+            "mimeType": "application/json"
+          }
+        ]
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "id": 4,
+      "method": "resources/read",
+      "params": {
+        "uri": "well-known://mcp-card"
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "id": 4,
+      "result": {
+        "contents": [
+          {
+            "uri": "well-known://mcp-card",
+            "text": "{\"name\":\"fixture-card\",\"version\":\"1\"}",
+            "mimeType": "application/json"
+          }
+        ]
+      }
+    }
+  ],
+  "matrix": {
+    "version": "2025-11-25",
+    "family": "adapter",
+    "case": "initialize_tools_resources_success",
+    "source": {
+      "kind": "adapter_generated",
+      "generator": "cargo test -p harn-serve adapters::mcp::tests::adapter_protocol_fixture_matches_checked_in_matrix",
+      "description": "Generated from McpServer initialize, tools/list, resources/list, and resources/read adapter code."
+    }
+  }
+}

--- a/conformance/protocols/fixtures/mcp/completion_logging_boundaries.valid.json
+++ b/conformance/protocols/fixtures/mcp/completion_logging_boundaries.valid.json
@@ -1,0 +1,67 @@
+{
+  "name": "mcp.completion_logging.boundaries",
+  "protocol": "mcp",
+  "schema": "schemas/mcp-2025-11-25.schema.json",
+  "expect": "valid",
+  "documents": [
+    {
+      "jsonrpc": "2.0",
+      "id": "complete-1",
+      "method": "completion/complete",
+      "params": {
+        "ref": {
+          "type": "ref/prompt",
+          "name": "review"
+        },
+        "argument": {
+          "name": "diff",
+          "value": "src/"
+        }
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "id": "complete-1",
+      "result": {
+        "completion": {
+          "values": ["src/lib.rs", "src/main.rs"],
+          "total": 2,
+          "hasMore": false
+        }
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "id": "log-1",
+      "method": "logging/setLevel",
+      "params": {
+        "level": "info"
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "id": "log-1",
+      "result": {}
+    },
+    {
+      "jsonrpc": "2.0",
+      "method": "notifications/message",
+      "params": {
+        "level": "notice",
+        "logger": "harn",
+        "data": {
+          "message": "tool finished"
+        }
+      }
+    }
+  ],
+  "matrix": {
+    "version": "2025-11-25",
+    "family": "completion_logging",
+    "case": "success",
+    "source": {
+      "kind": "hand_authored",
+      "description": "MCP completion and logging utility shapes from the 2025-11-25 schema semantics."
+    }
+  }
+}

--- a/conformance/protocols/fixtures/mcp/initialize.valid.json
+++ b/conformance/protocols/fixtures/mcp/initialize.valid.json
@@ -30,7 +30,7 @@
         },
         "serverInfo": {
           "name": "harn",
-          "version": "0.7.48"
+          "version": "0.8.0"
         }
       }
     },
@@ -39,5 +39,15 @@
       "method": "notifications/initialized",
       "params": {}
     }
-  ]
+  ],
+  "matrix": {
+    "version": "2025-11-25",
+    "family": "initialize",
+    "case": "success",
+    "source": {
+      "kind": "official_example",
+      "url": "https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle",
+      "description": "Lifecycle initialize exchange following the MCP 2025-11-25 specification semantics."
+    }
+  }
 }

--- a/conformance/protocols/fixtures/mcp/initialize_unsupported_version.invalid.json
+++ b/conformance/protocols/fixtures/mcp/initialize_unsupported_version.invalid.json
@@ -17,5 +17,14 @@
         }
       }
     }
-  ]
+  ],
+  "matrix": {
+    "version": "2025-11-25",
+    "family": "initialize",
+    "case": "negative",
+    "source": {
+      "kind": "hand_authored",
+      "description": "Protocol matrix fixture maintained from the pinned Harn adapter profile and upstream protocol semantics."
+    }
+  }
 }

--- a/conformance/protocols/fixtures/mcp/protected_resource_metadata.valid.json
+++ b/conformance/protocols/fixtures/mcp/protected_resource_metadata.valid.json
@@ -1,0 +1,30 @@
+{
+  "name": "mcp.auth.protected_resource_metadata",
+  "protocol": "mcp",
+  "schema": "schemas/mcp-2025-11-25.schema.json",
+  "expect": "valid",
+  "documents": [
+    {
+      "resource": "https://harn.example/mcp",
+      "authorization_servers": [
+        "https://auth.example"
+      ],
+      "bearer_methods_supported": [
+        "header"
+      ],
+      "scopes_supported": [
+        "mcp:tools",
+        "mcp:resources"
+      ]
+    }
+  ],
+  "matrix": {
+    "version": "2025-11-25",
+    "family": "auth",
+    "case": "protected_resource_metadata_success",
+    "source": {
+      "kind": "hand_authored",
+      "description": "Protected Resource Metadata document emitted by Harn MCP OAuth resource-server support."
+    }
+  }
+}

--- a/conformance/protocols/fixtures/mcp/sampling_elicitation_boundaries.valid.json
+++ b/conformance/protocols/fixtures/mcp/sampling_elicitation_boundaries.valid.json
@@ -1,0 +1,78 @@
+{
+  "name": "mcp.sampling_elicitation.boundaries",
+  "protocol": "mcp",
+  "schema": "schemas/mcp-2025-11-25.schema.json",
+  "expect": "valid",
+  "documents": [
+    {
+      "jsonrpc": "2.0",
+      "id": "sample-1",
+      "method": "sampling/createMessage",
+      "params": {
+        "messages": [
+          {
+            "role": "user",
+            "content": {
+              "type": "text",
+              "text": "Summarize this patch."
+            }
+          }
+        ],
+        "systemPrompt": "Stay concise.",
+        "maxTokens": 128,
+        "metadata": {
+          "server": "fixture"
+        }
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "id": "sample-1",
+      "result": {
+        "role": "assistant",
+        "content": {
+          "type": "text",
+          "text": "Patch summarized."
+        },
+        "model": "local-fixture",
+        "stopReason": "endTurn"
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "id": "elicit-1",
+      "method": "elicitation/create",
+      "params": {
+        "message": "Approve writing files?",
+        "requestedSchema": {
+          "type": "object",
+          "properties": {
+            "approved": {
+              "type": "boolean"
+            }
+          },
+          "required": ["approved"]
+        }
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "id": "elicit-1",
+      "result": {
+        "action": "accept",
+        "content": {
+          "approved": true
+        }
+      }
+    }
+  ],
+  "matrix": {
+    "version": "2025-11-25",
+    "family": "sampling_elicitation",
+    "case": "success",
+    "source": {
+      "kind": "hand_authored",
+      "description": "Client-bound MCP sampling and elicitation envelopes used at Harn's host-approval boundary."
+    }
+  }
+}

--- a/conformance/protocols/fixtures/mcp/tools_call_forbidden_task_augmentation.invalid.json
+++ b/conformance/protocols/fixtures/mcp/tools_call_forbidden_task_augmentation.invalid.json
@@ -1,0 +1,31 @@
+{
+  "name": "mcp.tools_call.forbidden_task_augmentation",
+  "protocol": "mcp",
+  "schema": "schemas/mcp-2025-11-25.schema.json",
+  "expect": "invalid",
+  "documents": [
+    {
+      "jsonrpc": "2.0",
+      "id": "tool-1",
+      "method": "tools/call",
+      "params": {
+        "name": "greet",
+        "arguments": {
+          "name": "Ada"
+        },
+        "task": {
+          "title": "Run asynchronously"
+        }
+      }
+    }
+  ],
+  "matrix": {
+    "version": "2025-11-25",
+    "family": "tools_call",
+    "case": "forbidden_capability_negative",
+    "source": {
+      "kind": "hand_authored",
+      "description": "Negative fixture for Harn's explicit MCP task-augmentation rejection."
+    }
+  }
+}

--- a/conformance/protocols/fixtures/mcp/tools_missing_jsonrpc.invalid.json
+++ b/conformance/protocols/fixtures/mcp/tools_missing_jsonrpc.invalid.json
@@ -9,5 +9,14 @@
       "method": "tools/list",
       "params": {}
     }
-  ]
+  ],
+  "matrix": {
+    "version": "2025-11-25",
+    "family": "tools_list",
+    "case": "negative",
+    "source": {
+      "kind": "hand_authored",
+      "description": "Protocol matrix fixture maintained from the pinned Harn adapter profile and upstream protocol semantics."
+    }
+  }
 }

--- a/conformance/protocols/fixtures/mcp/tools_resources_prompts.valid.json
+++ b/conformance/protocols/fixtures/mcp/tools_resources_prompts.valid.json
@@ -77,5 +77,14 @@
         ]
       }
     }
-  ]
+  ],
+  "matrix": {
+    "version": "2025-11-25",
+    "family": "tools_resources_prompts",
+    "case": "success",
+    "source": {
+      "kind": "hand_authored",
+      "description": "Protocol matrix fixture maintained from the pinned Harn adapter profile and upstream protocol semantics."
+    }
+  }
 }

--- a/conformance/protocols/fixtures/mcp/unknown_method.invalid.json
+++ b/conformance/protocols/fixtures/mcp/unknown_method.invalid.json
@@ -1,0 +1,23 @@
+{
+  "name": "mcp.jsonrpc.unknown_method",
+  "protocol": "mcp",
+  "schema": "schemas/mcp-2025-11-25.schema.json",
+  "expect": "invalid",
+  "documents": [
+    {
+      "jsonrpc": "2.0",
+      "id": "unknown-1",
+      "method": "tools/delete_everything",
+      "params": {}
+    }
+  ],
+  "matrix": {
+    "version": "2025-11-25",
+    "family": "jsonrpc",
+    "case": "unknown_method_negative",
+    "source": {
+      "kind": "hand_authored",
+      "description": "Negative MCP request fixture proving unadvertised methods are outside the pinned Harn profile."
+    }
+  }
+}

--- a/conformance/protocols/schemas/a2a-0.3.0.schema.json
+++ b/conformance/protocols/schemas/a2a-0.3.0.schema.json
@@ -2,7 +2,16 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://harnlang.com/conformance/protocols/a2a-0.3.0.schema.json",
   "title": "Harn A2A 0.3.0 adapter profile",
-  "description": "Pinned profile derived from the A2A v0.3.0 specification and a2aproject/A2A specification/a2a.proto for the JSON-RPC/card/task surface Harn serves.",
+  "description": "Pinned Harn adapter profile derived from the A2A v0.3.0 specification and a2aproject/A2A JSON schema for the JSON-RPC/card/task surface Harn serves.",
+  "x-harn-provenance": {
+    "protocol": "a2a",
+    "upstream_version": "0.3.0",
+    "upstream_source_url": "https://raw.githubusercontent.com/a2aproject/A2A/v0.3.0/specification/json/a2a.json",
+    "upstream_spec_url": "https://a2a-protocol.org/v0.3.0/specification",
+    "retrieved_at": "2026-05-08",
+    "refresh_command": "curl -fsSL https://raw.githubusercontent.com/a2aproject/A2A/v0.3.0/specification/json/a2a.json",
+    "profile_note": "The upstream JSON schema is definitions-only; this profile supplies a root over Harn-served agent cards, JSON-RPC messages, task events, push config payloads, and security metadata."
+  },
   "anyOf": [
     { "$ref": "#/$defs/AgentCard" },
     { "$ref": "#/$defs/JsonRpcRequest" },
@@ -44,8 +53,14 @@
           "type": "array",
           "items": { "$ref": "#/$defs/AgentSkill" }
         },
-        "securitySchemes": { "type": "object" },
-        "security": { "type": "array" },
+        "securitySchemes": {
+          "type": "object",
+          "additionalProperties": { "$ref": "#/$defs/SecurityScheme" }
+        },
+        "security": {
+          "type": "array",
+          "items": { "type": "object" }
+        },
         "defaultInputModes": {
           "type": "array",
           "items": { "type": "string" }
@@ -257,9 +272,9 @@
             "failed",
             "canceled",
             "cancelled",
-            "input_required",
+            "input-required",
             "rejected",
-            "auth_required"
+            "auth-required"
           ]
         },
         "message": { "$ref": "#/$defs/Message" },
@@ -348,6 +363,23 @@
           }
         }
       ]
+    },
+    "SecurityScheme": {
+      "type": "object",
+      "required": ["type"],
+      "additionalProperties": true,
+      "properties": {
+        "type": {
+          "enum": ["apiKey", "http", "oauth2", "openIdConnect", "mutualTLS"]
+        },
+        "description": { "type": "string" },
+        "name": { "type": "string" },
+        "in": { "enum": ["query", "header", "cookie"] },
+        "scheme": { "type": "string" },
+        "bearerFormat": { "type": "string" },
+        "flows": { "type": "object" },
+        "openIdConnectUrl": { "type": "string" }
+      }
     },
     "TaskEvent": {
       "oneOf": [

--- a/conformance/protocols/schemas/acp-session-update.schema.json
+++ b/conformance/protocols/schemas/acp-session-update.schema.json
@@ -1,17 +1,125 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://harnlang.com/conformance/protocols/acp-session-update.schema.json",
-  "title": "Harn ACP session/update profile",
-  "description": "Pinned profile derived from agentclientprotocol/agent-client-protocol schema v0.12.2 plus Harn-advertised session/update extensions.",
-  "type": "object",
-  "required": ["jsonrpc", "method", "params"],
-  "additionalProperties": true,
-  "properties": {
-    "jsonrpc": { "const": "2.0" },
-    "method": { "const": "session/update" },
-    "params": { "$ref": "#/$defs/SessionUpdateParams" }
+  "title": "Harn ACP v0.12.2 adapter profile",
+  "description": "Pinned Harn adapter profile derived from agentclientprotocol/agent-client-protocol schema v0.12.2 plus Harn-advertised ACP extensions.",
+  "x-harn-provenance": {
+    "protocol": "acp",
+    "upstream_version": "v0.12.2",
+    "upstream_source_url": "https://raw.githubusercontent.com/agentclientprotocol/agent-client-protocol/v0.12.2/schema/schema.json",
+    "upstream_spec_url": "https://agentclientprotocol.com/protocol/schema",
+    "retrieved_at": "2026-05-08",
+    "refresh_command": "curl -fsSL https://raw.githubusercontent.com/agentclientprotocol/agent-client-protocol/v0.12.2/schema/schema.json",
+    "profile_note": "The profile roots the ACP request, response, session/update notification, and Harn extension notification shapes this adapter emits or accepts."
   },
+  "oneOf": [
+    { "$ref": "#/$defs/SessionUpdateNotification" },
+    { "$ref": "#/$defs/SessionRequestPermissionRequest" },
+    { "$ref": "#/$defs/HarnAgentEventNotification" },
+    { "$ref": "#/$defs/JsonRpcResultResponse" },
+    { "$ref": "#/$defs/JsonRpcErrorResponse" }
+  ],
   "$defs": {
+    "SessionUpdateNotification": {
+      "type": "object",
+      "required": ["jsonrpc", "method", "params"],
+      "additionalProperties": true,
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "method": { "const": "session/update" },
+        "params": { "$ref": "#/$defs/SessionUpdateParams" }
+      }
+    },
+    "JsonRpcRequestBase": {
+      "type": "object",
+      "required": ["jsonrpc", "id", "method"],
+      "additionalProperties": true,
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "id": { "type": ["string", "integer"] },
+        "params": { "type": "object" }
+      }
+    },
+    "SessionRequestPermissionRequest": {
+      "allOf": [
+        { "$ref": "#/$defs/JsonRpcRequestBase" },
+        {
+          "type": "object",
+          "required": ["params"],
+          "properties": {
+            "method": { "const": "session/request_permission" },
+            "params": {
+              "type": "object",
+              "required": ["sessionId"],
+              "additionalProperties": true,
+              "properties": {
+                "sessionId": { "type": "string", "minLength": 1 },
+                "toolCallId": { "type": "string", "minLength": 1 },
+                "toolName": { "type": "string", "minLength": 1 },
+                "options": { "type": "array" }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "HarnAgentEventNotification": {
+      "type": "object",
+      "required": ["jsonrpc", "method", "params"],
+      "additionalProperties": true,
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "method": { "const": "_harn/agentEvent" },
+        "params": {
+          "type": "object",
+          "required": ["sessionId", "kind"],
+          "additionalProperties": true,
+          "properties": {
+            "sessionId": { "type": "string", "minLength": 1 },
+            "kind": {
+              "enum": [
+                "budget_exhausted",
+                "daemon_watchdog_tripped",
+                "feedback_injected",
+                "judge_decision",
+                "loop_stuck",
+                "turn_end",
+                "turn_start"
+              ]
+            }
+          }
+        }
+      }
+    },
+    "JsonRpcResultResponse": {
+      "type": "object",
+      "required": ["jsonrpc", "id", "result"],
+      "additionalProperties": true,
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "id": { "type": ["string", "integer"] },
+        "result": { "type": "object" }
+      }
+    },
+    "JsonRpcErrorResponse": {
+      "type": "object",
+      "required": ["jsonrpc", "id", "error"],
+      "additionalProperties": true,
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "id": { "type": ["string", "integer", "null"] },
+        "error": {
+          "type": "object",
+          "required": ["code", "message"],
+          "additionalProperties": true,
+          "properties": {
+            "code": { "type": "integer" },
+            "message": { "type": "string" },
+            "data": {}
+          }
+        }
+      }
+    },
     "SessionUpdateParams": {
       "type": "object",
       "required": ["sessionId", "update"],
@@ -40,7 +148,8 @@
         { "$ref": "#/$defs/TranscriptCompacted" },
         { "$ref": "#/$defs/Handoff" },
         { "$ref": "#/$defs/FsWatch" },
-        { "$ref": "#/$defs/WorkerUpdate" }
+        { "$ref": "#/$defs/WorkerUpdate" },
+        { "$ref": "#/$defs/HarnExtensionUpdate" }
       ]
     },
     "ContentBlock": {
@@ -118,6 +227,17 @@
       "additionalProperties": true,
       "properties": {
         "harn": { "$ref": "#/$defs/HarnToolLifecycleMeta" }
+      }
+    },
+    "HarnExtensionMeta": {
+      "type": "object",
+      "required": ["harn"],
+      "additionalProperties": true,
+      "properties": {
+        "harn": {
+          "type": "object",
+          "additionalProperties": true
+        }
       }
     },
     "HarnToolLifecycleMeta": {
@@ -302,6 +422,32 @@
         "event": { "type": "string", "minLength": 1 },
         "status": { "type": "string", "minLength": 1 },
         "terminal": { "type": "boolean" }
+      }
+    },
+    "HarnExtensionUpdate": {
+      "type": "object",
+      "required": ["sessionUpdate", "_meta"],
+      "additionalProperties": true,
+      "properties": {
+        "sessionUpdate": {
+          "enum": [
+            "available_commands_update",
+            "fs_watch",
+            "handoff",
+            "hitl_request",
+            "hitl_resolved",
+            "log",
+            "progress",
+            "skill_activated",
+            "skill_deactivated",
+            "skill_scope_tools",
+            "tool_search_query",
+            "tool_search_result",
+            "transcript_compacted",
+            "worker_update"
+          ]
+        },
+        "_meta": { "$ref": "#/$defs/HarnExtensionMeta" }
       }
     }
   }

--- a/conformance/protocols/schemas/mcp-2025-11-25.schema.json
+++ b/conformance/protocols/schemas/mcp-2025-11-25.schema.json
@@ -2,16 +2,34 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://harnlang.com/conformance/protocols/mcp-2025-11-25.schema.json",
   "title": "Harn MCP 2025-11-25 adapter profile",
-  "description": "Pinned profile derived from modelcontextprotocol/modelcontextprotocol schema/2025-11-25/schema.json for initialize, tools, resources, and prompts.",
+  "description": "Pinned Harn adapter profile derived from modelcontextprotocol/modelcontextprotocol schema/2025-11-25/schema.json for the MCP 2025-11-25 wire surface Harn emits or accepts.",
+  "x-harn-provenance": {
+    "protocol": "mcp",
+    "upstream_version": "2025-11-25",
+    "upstream_source_url": "https://raw.githubusercontent.com/modelcontextprotocol/modelcontextprotocol/main/schema/2025-11-25/schema.json",
+    "upstream_spec_url": "https://modelcontextprotocol.io/specification/2025-11-25",
+    "retrieved_at": "2026-05-08",
+    "refresh_command": "curl -fsSL https://raw.githubusercontent.com/modelcontextprotocol/modelcontextprotocol/main/schema/2025-11-25/schema.json",
+    "profile_note": "The upstream schema is definitions-only; this profile supplies a root over the Harn-supported MCP request, response, notification, and protected-resource metadata shapes."
+  },
   "oneOf": [
     { "$ref": "#/$defs/InitializeRequest" },
     { "$ref": "#/$defs/ListToolsRequest" },
+    { "$ref": "#/$defs/CallToolRequest" },
     { "$ref": "#/$defs/ListResourcesRequest" },
+    { "$ref": "#/$defs/ReadResourceRequest" },
     { "$ref": "#/$defs/ListResourceTemplatesRequest" },
     { "$ref": "#/$defs/ListPromptsRequest" },
+    { "$ref": "#/$defs/GetPromptRequest" },
+    { "$ref": "#/$defs/CompleteRequest" },
+    { "$ref": "#/$defs/LoggingSetLevelRequest" },
+    { "$ref": "#/$defs/SamplingCreateMessageRequest" },
+    { "$ref": "#/$defs/ElicitationCreateRequest" },
     { "$ref": "#/$defs/JsonRpcResultResponse" },
     { "$ref": "#/$defs/JsonRpcErrorResponse" },
-    { "$ref": "#/$defs/InitializedNotification" }
+    { "$ref": "#/$defs/InitializedNotification" },
+    { "$ref": "#/$defs/LoggingMessageNotification" },
+    { "$ref": "#/$defs/ProtectedResourceMetadata" }
   ],
   "$defs": {
     "RequestId": {
@@ -60,6 +78,29 @@
         }
       ]
     },
+    "CallToolRequest": {
+      "allOf": [
+        { "$ref": "#/$defs/JsonRpcRequestBase" },
+        {
+          "type": "object",
+          "required": ["params"],
+          "properties": {
+            "method": { "const": "tools/call" },
+            "params": {
+              "type": "object",
+              "required": ["name"],
+              "additionalProperties": true,
+              "not": { "required": ["task"] },
+              "properties": {
+                "name": { "type": "string", "minLength": 1 },
+                "arguments": { "type": "object" },
+                "_meta": { "type": "object" }
+              }
+            }
+          }
+        }
+      ]
+    },
     "ListResourcesRequest": {
       "allOf": [
         { "$ref": "#/$defs/JsonRpcRequestBase" },
@@ -67,6 +108,26 @@
           "type": "object",
           "properties": {
             "method": { "const": "resources/list" }
+          }
+        }
+      ]
+    },
+    "ReadResourceRequest": {
+      "allOf": [
+        { "$ref": "#/$defs/JsonRpcRequestBase" },
+        {
+          "type": "object",
+          "required": ["params"],
+          "properties": {
+            "method": { "const": "resources/read" },
+            "params": {
+              "type": "object",
+              "required": ["uri"],
+              "additionalProperties": true,
+              "properties": {
+                "uri": { "type": "string", "minLength": 1 }
+              }
+            }
           }
         }
       ]
@@ -93,6 +154,131 @@
         }
       ]
     },
+    "GetPromptRequest": {
+      "allOf": [
+        { "$ref": "#/$defs/JsonRpcRequestBase" },
+        {
+          "type": "object",
+          "required": ["params"],
+          "properties": {
+            "method": { "const": "prompts/get" },
+            "params": {
+              "type": "object",
+              "required": ["name"],
+              "additionalProperties": true,
+              "properties": {
+                "name": { "type": "string", "minLength": 1 },
+                "arguments": { "type": "object" }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "CompleteRequest": {
+      "allOf": [
+        { "$ref": "#/$defs/JsonRpcRequestBase" },
+        {
+          "type": "object",
+          "required": ["params"],
+          "properties": {
+            "method": { "const": "completion/complete" },
+            "params": {
+              "type": "object",
+              "required": ["ref", "argument"],
+              "additionalProperties": true,
+              "properties": {
+                "ref": { "type": "object" },
+                "argument": {
+                  "type": "object",
+                  "required": ["name", "value"],
+                  "additionalProperties": true,
+                  "properties": {
+                    "name": { "type": "string", "minLength": 1 },
+                    "value": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "LoggingSetLevelRequest": {
+      "allOf": [
+        { "$ref": "#/$defs/JsonRpcRequestBase" },
+        {
+          "type": "object",
+          "required": ["params"],
+          "properties": {
+            "method": { "const": "logging/setLevel" },
+            "params": {
+              "type": "object",
+              "required": ["level"],
+              "additionalProperties": true,
+              "properties": {
+                "level": { "$ref": "#/$defs/LoggingLevel" }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "SamplingCreateMessageRequest": {
+      "allOf": [
+        { "$ref": "#/$defs/JsonRpcRequestBase" },
+        {
+          "type": "object",
+          "required": ["params"],
+          "properties": {
+            "method": { "const": "sampling/createMessage" },
+            "params": {
+              "type": "object",
+              "required": ["messages", "maxTokens"],
+              "additionalProperties": true,
+              "properties": {
+                "messages": {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": { "$ref": "#/$defs/SamplingMessage" }
+                },
+                "maxTokens": { "type": "integer", "minimum": 1 },
+                "systemPrompt": { "type": "string" },
+                "metadata": { "type": "object" }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "ElicitationCreateRequest": {
+      "allOf": [
+        { "$ref": "#/$defs/JsonRpcRequestBase" },
+        {
+          "type": "object",
+          "required": ["params"],
+          "properties": {
+            "method": { "const": "elicitation/create" },
+            "params": {
+              "type": "object",
+              "required": ["message", "requestedSchema"],
+              "additionalProperties": true,
+              "properties": {
+                "message": { "type": "string", "minLength": 1 },
+                "requestedSchema": {
+                  "type": "object",
+                  "required": ["type"],
+                  "properties": {
+                    "type": { "const": "object" }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
     "InitializedNotification": {
       "type": "object",
       "required": ["jsonrpc", "method"],
@@ -101,6 +287,25 @@
         "jsonrpc": { "const": "2.0" },
         "method": { "const": "notifications/initialized" },
         "params": { "type": "object" }
+      }
+    },
+    "LoggingMessageNotification": {
+      "type": "object",
+      "required": ["jsonrpc", "method", "params"],
+      "additionalProperties": true,
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "method": { "const": "notifications/message" },
+        "params": {
+          "type": "object",
+          "required": ["level", "data"],
+          "additionalProperties": true,
+          "properties": {
+            "level": { "$ref": "#/$defs/LoggingLevel" },
+            "logger": { "type": "string" },
+            "data": {}
+          }
+        }
       }
     },
     "JsonRpcResultResponse": {
@@ -115,8 +320,15 @@
             { "$ref": "#/$defs/InitializeResult" },
             { "$ref": "#/$defs/ListToolsResult" },
             { "$ref": "#/$defs/ListResourcesResult" },
+            { "$ref": "#/$defs/ReadResourceResult" },
             { "$ref": "#/$defs/ListResourceTemplatesResult" },
-            { "$ref": "#/$defs/ListPromptsResult" }
+            { "$ref": "#/$defs/ListPromptsResult" },
+            { "$ref": "#/$defs/GetPromptResult" },
+            { "$ref": "#/$defs/CallToolResult" },
+            { "$ref": "#/$defs/CompleteResult" },
+            { "$ref": "#/$defs/SamplingCreateMessageResult" },
+            { "$ref": "#/$defs/ElicitationResult" },
+            { "$ref": "#/$defs/EmptyResult" }
           ]
         }
       }
@@ -165,7 +377,8 @@
         "tools": { "type": "object" },
         "resources": { "type": "object" },
         "prompts": { "type": "object" },
-        "logging": { "type": "object" }
+        "logging": { "type": "object" },
+        "completions": { "type": "object" }
       }
     },
     "ListToolsResult": {
@@ -217,6 +430,17 @@
         "nextCursor": { "type": "string" }
       }
     },
+    "ReadResourceResult": {
+      "type": "object",
+      "required": ["contents"],
+      "additionalProperties": true,
+      "properties": {
+        "contents": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/ResourceContents" }
+        }
+      }
+    },
     "Resource": {
       "type": "object",
       "required": ["uri", "name"],
@@ -226,6 +450,17 @@
         "name": { "type": "string", "minLength": 1 },
         "title": { "type": "string" },
         "description": { "type": "string" },
+        "mimeType": { "type": "string" }
+      }
+    },
+    "ResourceContents": {
+      "type": "object",
+      "required": ["uri"],
+      "additionalProperties": true,
+      "properties": {
+        "uri": { "type": "string", "minLength": 1 },
+        "text": { "type": "string" },
+        "blob": { "type": "string" },
         "mimeType": { "type": "string" }
       }
     },
@@ -264,6 +499,136 @@
         "arguments": {
           "type": "array",
           "items": { "type": "object" }
+        }
+      }
+    },
+    "GetPromptResult": {
+      "type": "object",
+      "required": ["messages"],
+      "additionalProperties": true,
+      "properties": {
+        "description": { "type": "string" },
+        "messages": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/PromptMessage" }
+        }
+      }
+    },
+    "PromptMessage": {
+      "type": "object",
+      "required": ["role", "content"],
+      "additionalProperties": true,
+      "properties": {
+        "role": { "enum": ["user", "assistant"] },
+        "content": { "$ref": "#/$defs/ContentBlock" }
+      }
+    },
+    "SamplingMessage": {
+      "type": "object",
+      "required": ["role", "content"],
+      "additionalProperties": true,
+      "properties": {
+        "role": { "enum": ["user", "assistant", "system"] },
+        "content": {
+          "oneOf": [
+            { "$ref": "#/$defs/ContentBlock" },
+            {
+              "type": "array",
+              "items": { "$ref": "#/$defs/ContentBlock" }
+            }
+          ]
+        }
+      }
+    },
+    "ContentBlock": {
+      "type": "object",
+      "required": ["type"],
+      "additionalProperties": true,
+      "properties": {
+        "type": { "enum": ["text", "image", "audio", "resource", "resource_link"] },
+        "text": { "type": "string" },
+        "data": { "type": "string" },
+        "mimeType": { "type": "string" }
+      }
+    },
+    "CallToolResult": {
+      "type": "object",
+      "required": ["content"],
+      "additionalProperties": true,
+      "properties": {
+        "content": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/ContentBlock" }
+        },
+        "structuredContent": {},
+        "isError": { "type": "boolean" }
+      }
+    },
+    "CompleteResult": {
+      "type": "object",
+      "required": ["completion"],
+      "additionalProperties": true,
+      "properties": {
+        "completion": {
+          "type": "object",
+          "required": ["values"],
+          "additionalProperties": true,
+          "properties": {
+            "values": {
+              "type": "array",
+              "items": { "type": "string" }
+            },
+            "total": { "type": "integer", "minimum": 0 },
+            "hasMore": { "type": "boolean" }
+          }
+        }
+      }
+    },
+    "SamplingCreateMessageResult": {
+      "type": "object",
+      "required": ["role", "content", "model"],
+      "additionalProperties": true,
+      "properties": {
+        "role": { "const": "assistant" },
+        "content": { "$ref": "#/$defs/ContentBlock" },
+        "model": { "type": "string", "minLength": 1 },
+        "stopReason": { "type": "string" }
+      }
+    },
+    "ElicitationResult": {
+      "type": "object",
+      "required": ["action"],
+      "additionalProperties": true,
+      "properties": {
+        "action": { "enum": ["accept", "decline", "cancel"] },
+        "content": { "type": "object" }
+      }
+    },
+    "EmptyResult": {
+      "type": "object",
+      "maxProperties": 0
+    },
+    "LoggingLevel": {
+      "enum": ["debug", "info", "notice", "warning", "error", "critical", "alert", "emergency"]
+    },
+    "ProtectedResourceMetadata": {
+      "type": "object",
+      "required": ["resource", "authorization_servers", "bearer_methods_supported"],
+      "additionalProperties": true,
+      "properties": {
+        "resource": { "type": "string", "minLength": 1 },
+        "authorization_servers": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "bearer_methods_supported": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "scopes_supported": {
+          "type": "array",
+          "items": { "type": "string" }
         }
       }
     }

--- a/crates/harn-cli/src/commands/protocol_conformance.rs
+++ b/crates/harn-cli/src/commands/protocol_conformance.rs
@@ -19,9 +19,46 @@ struct ProtocolFixture {
     name: String,
     protocol: String,
     schema: String,
+    matrix: FixtureMatrix,
     #[serde(default)]
     expect: FixtureExpectation,
     documents: Vec<Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FixtureMatrix {
+    version: String,
+    family: String,
+    case: String,
+    source: FixtureSource,
+}
+
+#[derive(Debug, Deserialize)]
+struct FixtureSource {
+    kind: FixtureSourceKind,
+    #[serde(default)]
+    url: Option<String>,
+    #[serde(default)]
+    generator: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+}
+
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum FixtureSourceKind {
+    OfficialExample,
+    AdapterGenerated,
+    HandAuthored,
+}
+
+struct SchemaProvenance {
+    protocol: String,
+    upstream_version: String,
+    upstream_source_url: String,
+    upstream_spec_url: String,
+    retrieved_at: String,
+    refresh_command: String,
 }
 
 #[derive(Debug, Default)]
@@ -134,7 +171,12 @@ fn resolve_fixture_files(root: &Path, selection: Option<&str>) -> Result<Vec<Pat
             if raw.is_absolute() || raw.starts_with(root) {
                 raw
             } else {
-                root.join(raw)
+                let candidate = root.join(&raw);
+                if candidate.exists() {
+                    candidate
+                } else {
+                    fixture_root.join(raw)
+                }
             }
         }
         None => fixture_root,
@@ -200,7 +242,57 @@ fn read_fixture(path: &Path) -> Result<ProtocolFixture, String> {
     if fixture.documents.is_empty() {
         return Err("fixture must contain at least one document".to_string());
     }
+    validate_fixture_metadata(&fixture)?;
     Ok(fixture)
+}
+
+fn validate_fixture_metadata(fixture: &ProtocolFixture) -> Result<(), String> {
+    ensure_nonempty("name", &fixture.name)?;
+    ensure_nonempty("protocol", &fixture.protocol)?;
+    ensure_nonempty("schema", &fixture.schema)?;
+    ensure_nonempty("matrix.version", &fixture.matrix.version)?;
+    ensure_nonempty("matrix.family", &fixture.matrix.family)?;
+    ensure_nonempty("matrix.case", &fixture.matrix.case)?;
+    match fixture.protocol.as_str() {
+        "mcp" | "acp" | "a2a" => {}
+        other => {
+            return Err(format!(
+                "protocol must be one of mcp/acp/a2a, got {other:?}"
+            ))
+        }
+    }
+    match fixture.matrix.source.kind {
+        FixtureSourceKind::OfficialExample => {
+            let url = fixture.matrix.source.url.as_deref().unwrap_or_default();
+            ensure_nonempty("matrix.source.url", url)?;
+        }
+        FixtureSourceKind::AdapterGenerated => {
+            let generator = fixture
+                .matrix
+                .source
+                .generator
+                .as_deref()
+                .unwrap_or_default();
+            ensure_nonempty("matrix.source.generator", generator)?;
+        }
+        FixtureSourceKind::HandAuthored => {
+            let description = fixture
+                .matrix
+                .source
+                .description
+                .as_deref()
+                .unwrap_or_default();
+            ensure_nonempty("matrix.source.description", description)?;
+        }
+    }
+    Ok(())
+}
+
+fn ensure_nonempty(field: &str, value: &str) -> Result<(), String> {
+    if value.trim().is_empty() {
+        return Err(format!("{field} must be a non-empty string"));
+    }
+    Ok(())
 }
 
 fn matches_filter(filter: Option<&str>, fixture: &ProtocolFixture, relative_path: &str) -> bool {
@@ -211,11 +303,17 @@ fn matches_filter(filter: Option<&str>, fixture: &ProtocolFixture, relative_path
         return Regex::new(pattern).is_ok_and(|regex| {
             regex.is_match(&fixture.name)
                 || regex.is_match(&fixture.protocol)
+                || regex.is_match(&fixture.matrix.version)
+                || regex.is_match(&fixture.matrix.family)
+                || regex.is_match(&fixture.matrix.case)
                 || regex.is_match(relative_path)
         });
     }
     fixture.name.contains(filter)
         || fixture.protocol.contains(filter)
+        || fixture.matrix.version.contains(filter)
+        || fixture.matrix.family.contains(filter)
+        || fixture.matrix.case.contains(filter)
         || relative_path.contains(filter)
 }
 
@@ -225,6 +323,7 @@ fn run_fixture(root: &Path, fixture_path: &Path, fixture: &ProtocolFixture) -> R
         .map_err(|error| format!("failed to read schema {}: {error}", schema_path.display()))?;
     let schema: Value = serde_json::from_str(&schema_text)
         .map_err(|error| format!("invalid schema JSON {}: {error}", schema_path.display()))?;
+    validate_schema_provenance(&schema, fixture, &schema_path)?;
     jsonschema::draft202012::meta::validate(&schema).map_err(|error| {
         format!(
             "schema {} is not valid JSON Schema 2020-12: {error}",
@@ -261,6 +360,63 @@ fn run_fixture(root: &Path, fixture_path: &Path, fixture: &ProtocolFixture) -> R
     Ok(())
 }
 
+fn validate_schema_provenance(
+    schema: &Value,
+    fixture: &ProtocolFixture,
+    schema_path: &Path,
+) -> Result<(), String> {
+    let provenance = schema_provenance(schema).ok_or_else(|| {
+        format!(
+            "schema {} must define x-harn-provenance with upstream source, version, date, and refresh command",
+            schema_path.display()
+        )
+    })?;
+    if provenance.protocol != fixture.protocol {
+        return Err(format!(
+            "schema {} declares protocol {:?} but fixture {:?} uses {:?}",
+            schema_path.display(),
+            provenance.protocol,
+            fixture.name,
+            fixture.protocol
+        ));
+    }
+    if provenance.upstream_version != fixture.matrix.version {
+        return Err(format!(
+            "schema {} declares upstream version {:?} but fixture {:?} is matrix version {:?}",
+            schema_path.display(),
+            provenance.upstream_version,
+            fixture.name,
+            fixture.matrix.version
+        ));
+    }
+    ensure_nonempty(
+        "x-harn-provenance.upstream_source_url",
+        &provenance.upstream_source_url,
+    )?;
+    ensure_nonempty(
+        "x-harn-provenance.upstream_spec_url",
+        &provenance.upstream_spec_url,
+    )?;
+    ensure_nonempty("x-harn-provenance.retrieved_at", &provenance.retrieved_at)?;
+    ensure_nonempty(
+        "x-harn-provenance.refresh_command",
+        &provenance.refresh_command,
+    )?;
+    Ok(())
+}
+
+fn schema_provenance(schema: &Value) -> Option<SchemaProvenance> {
+    let object = schema.get("x-harn-provenance")?.as_object()?;
+    Some(SchemaProvenance {
+        protocol: object.get("protocol")?.as_str()?.to_string(),
+        upstream_version: object.get("upstream_version")?.as_str()?.to_string(),
+        upstream_source_url: object.get("upstream_source_url")?.as_str()?.to_string(),
+        upstream_spec_url: object.get("upstream_spec_url")?.as_str()?.to_string(),
+        retrieved_at: object.get("retrieved_at")?.as_str()?.to_string(),
+        refresh_command: object.get("refresh_command")?.as_str()?.to_string(),
+    })
+}
+
 fn resolve_schema_path(root: &Path, fixture_path: &Path, schema: &str) -> Result<PathBuf, String> {
     let raw = PathBuf::from(schema);
     let path = if raw.is_absolute() || raw.starts_with(root) {
@@ -275,7 +431,10 @@ fn resolve_schema_path(root: &Path, fixture_path: &Path, schema: &str) -> Result
 
 #[cfg(test)]
 mod tests {
-    use super::{run_protocol_conformance_inner, FixtureExpectation, ProtocolFixture};
+    use super::{
+        run_protocol_conformance_inner, validate_fixture_metadata, FixtureExpectation,
+        ProtocolFixture,
+    };
 
     #[test]
     fn expectation_defaults_to_valid() {
@@ -284,11 +443,41 @@ mod tests {
               "name": "sample",
               "protocol": "mcp",
               "schema": "schemas/mcp-2025-11-25.schema.json",
+              "matrix": {
+                "version": "2025-11-25",
+                "family": "initialize",
+                "case": "success",
+                "source": {
+                  "kind": "hand_authored",
+                  "description": "unit-test fixture metadata"
+                }
+              },
               "documents": [{}]
             }"#,
         )
         .unwrap();
         assert_eq!(fixture.expect, FixtureExpectation::Valid);
+    }
+
+    #[test]
+    fn adapter_generated_fixtures_must_name_generator() {
+        let fixture: ProtocolFixture = serde_json::from_str(
+            r#"{
+              "name": "sample",
+              "protocol": "mcp",
+              "schema": "schemas/mcp-2025-11-25.schema.json",
+              "matrix": {
+                "version": "2025-11-25",
+                "family": "initialize",
+                "case": "success",
+                "source": {"kind": "adapter_generated"}
+              },
+              "documents": [{}]
+            }"#,
+        )
+        .unwrap();
+        let error = validate_fixture_metadata(&fixture).expect_err("missing generator should fail");
+        assert!(error.contains("matrix.source.generator"));
     }
 
     #[test]
@@ -298,6 +487,6 @@ mod tests {
             .join("conformance/protocols");
         let report = run_protocol_conformance_inner(&root, None, None, false);
         assert_eq!(report.failed, 0, "{:#?}", report.errors);
-        assert!(report.passed >= 6);
+        assert!(report.passed >= 25);
     }
 }

--- a/crates/harn-serve/src/adapters/a2a.rs
+++ b/crates/harn-serve/src/adapters/a2a.rs
@@ -4021,6 +4021,22 @@ pub fn triage(task: string) -> string {
     }
 
     #[tokio::test]
+    async fn adapter_agent_card_protocol_fixture_matches_checked_in_matrix() {
+        let (_dir, server) = test_server(
+            r#"
+pub fn triage(task: string) -> string {
+  return task
+}
+"#,
+        );
+        let actual = vec![server.agent_card("http://localhost:8080")];
+        crate::protocol_fixture_tests::assert_fixture_documents_match(
+            "conformance/protocols/fixtures/a2a/agent_card_adapter.valid.json",
+            actual,
+        );
+    }
+
+    #[tokio::test]
     async fn discovery_paths_serve_current_agent_card_shape() {
         let (_dir, server) = test_server(
             r#"
@@ -4112,9 +4128,8 @@ pub fn triage(task: string) -> string {
     async fn unknown_a2a_version_header_no_longer_rejects_request() {
         // Per A2A 0.3.0, version negotiation happens through AgentCard
         // discovery; the request header is non-canonical. A request that
-        // carries an unknown `a2a-version` value must still dispatch — we
-        // only log a soft-deprecation warning. The previous behavior
-        // returned JSON-RPC `-32009 VersionNotSupportedError`.
+        // carries an unknown `a2a-version` value must still dispatch; the
+        // adapter records only a soft-deprecation warning.
         let (_dir, server) = test_server(
             r#"
 pub fn triage(task: string) -> string {

--- a/crates/harn-serve/src/adapters/acp/events.rs
+++ b/crates/harn-serve/src/adapters/acp/events.rs
@@ -663,8 +663,8 @@ impl AgentEventSink for AcpAgentEventSink {
             // and inventing a new one would crash strict client decoders;
             // a `_`-prefixed JSON-RPC method is the spec-blessed path
             // for genuinely new events. Clients that don't know the method
-            // SHOULD ignore it (per the spec); burin-code subscribes via
-            // the `extensionMethods` advertisement in `agentCapabilities._meta.harn`.
+            // SHOULD ignore it (per the spec); clients that do know it
+            // discover the contract through `agentCapabilities._meta.harn`.
             AgentEvent::TurnStart {
                 session_id,
                 iteration,
@@ -1032,6 +1032,15 @@ mod tests {
         }
     }
 
+    #[tokio::test(flavor = "current_thread")]
+    async fn protocol_conformance_standard_session_update_fixture_is_adapter_generated() {
+        let actual = collect_notifications(standard_fixture_events()).await;
+        crate::protocol_fixture_tests::assert_fixture_documents_match(
+            "conformance/protocols/fixtures/acp/session_update_adapter_standard.valid.json",
+            actual,
+        );
+    }
+
     fn agent_event_ext_fixture_events() -> Vec<AgentEvent> {
         vec![
             AgentEvent::TurnStart {
@@ -1081,7 +1090,7 @@ mod tests {
     /// channel via `_harn/agentEvent`. The fixture pins the wire shape
     /// per kind so any drift in field names (e.g. snake_case vs.
     /// camelCase) or payload structure trips a build-time failure
-    /// rather than silently breaking burin-code's decoder. Every kind
+    /// rather than silently breaking downstream client decoders. Every kind
     /// in the fixture must also appear in `HARN_AGENT_EVENT_KINDS` so
     /// the capability advertisement stays honest.
     #[tokio::test(flavor = "current_thread")]
@@ -1113,6 +1122,15 @@ mod tests {
                  cannot subscribe to undocumented kinds"
             );
         }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn protocol_conformance_agent_event_fixture_is_adapter_generated() {
+        let actual = collect_notifications(agent_event_ext_fixture_events()).await;
+        crate::protocol_fixture_tests::assert_fixture_documents_match(
+            "conformance/protocols/fixtures/acp/agent_event_ext_notifications.valid.json",
+            actual,
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/harn-serve/src/adapters/acp/mod.rs
+++ b/crates/harn-serve/src/adapters/acp/mod.rs
@@ -2757,7 +2757,7 @@ mod tests {
                 assert!(
                     agent_event_method.is_object(),
                     "agent capabilities must advertise the {HARN_AGENT_EVENT_METHOD} \
-                     ExtNotification method so burin-code can subscribe — got: {agent_event_method}"
+                     ExtNotification method for clients that support it; got: {agent_event_method}"
                 );
                 assert_eq!(
                     agent_event_method["kinds"],
@@ -3050,6 +3050,10 @@ mod tests {
                 "sessionId": "session-1",
                 "toolCallId": "tool-1",
                 "toolName": "edit",
+                "options": [
+                    {"id": "approve", "label": "Approve"},
+                    {"id": "deny", "label": "Deny"}
+                ]
             }),
         );
         tokio::pin!(call);
@@ -3061,14 +3065,18 @@ mod tests {
         assert_eq!(outgoing["id"], 77);
         assert_eq!(outgoing["method"], "session/request_permission");
 
+        let response = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 77,
+            "result": {"outcome": "approved"},
+        });
+        crate::protocol_fixture_tests::assert_fixture_documents_match(
+            "conformance/protocols/fixtures/acp/session_request_permission.valid.json",
+            vec![outgoing, response.clone()],
+        );
+
         let mut server = server;
-        server
-            .handle_incoming_message(serde_json::json!({
-                "jsonrpc": "2.0",
-                "id": 77,
-                "result": {"outcome": "approved"},
-            }))
-            .await;
+        server.handle_incoming_message(response).await;
         let result = call.await.expect("permission response");
         assert_eq!(result["outcome"], "approved");
     }

--- a/crates/harn-serve/src/adapters/mcp.rs
+++ b/crates/harn-serve/src/adapters/mcp.rs
@@ -1338,6 +1338,73 @@ pub fn greet(name: string) -> string {
     }
 
     #[tokio::test]
+    async fn adapter_protocol_fixture_matches_checked_in_matrix() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let script = dir.path().join("server.harn");
+        std::fs::write(
+            &script,
+            r#"
+pub fn greet(name: string) -> string {
+  return name
+}
+"#,
+        )
+        .expect("write script");
+        let core = DispatchCore::new(DispatchCoreConfig::for_script(&script)).expect("core");
+        let server = McpServer::new(
+            McpServerConfig::new(core)
+                .with_server_card(json!({"name": "fixture-card", "version": "1"})),
+        );
+        let session = SharedSession::new();
+
+        let initialize = harn_vm::jsonrpc::request(
+            1,
+            "initialize",
+            json!({
+                "protocolVersion": MCP_PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {"name": "fixture-client", "version": "1"}
+            }),
+        );
+        let tools_list = harn_vm::jsonrpc::request(2, "tools/list", json!({}));
+        let resources_list = harn_vm::jsonrpc::request(3, "resources/list", json!({}));
+        let resources_read =
+            harn_vm::jsonrpc::request(4, "resources/read", json!({"uri": "well-known://mcp-card"}));
+
+        let actual = vec![
+            initialize.clone(),
+            mcp_response(&server, initialize, session.clone()).await,
+            harn_vm::jsonrpc::notification("notifications/initialized", json!({})),
+            tools_list.clone(),
+            mcp_response(&server, tools_list, session.clone()).await,
+            resources_list.clone(),
+            mcp_response(&server, resources_list, session.clone()).await,
+            resources_read.clone(),
+            mcp_response(&server, resources_read, session).await,
+        ];
+        crate::protocol_fixture_tests::assert_fixture_documents_match(
+            "conformance/protocols/fixtures/mcp/adapter_initialize_tools_resources.valid.json",
+            actual,
+        );
+    }
+
+    async fn mcp_response(
+        server: &McpServer,
+        request: JsonValue,
+        session: SharedSession,
+    ) -> JsonValue {
+        match server
+            .process_message(request, session, AuthRequest::default())
+            .await
+        {
+            ImmediateResult::Response(response) => response,
+            ImmediateResult::Accepted | ImmediateResult::Stream(_) => {
+                panic!("expected MCP JSON-RPC response")
+            }
+        }
+    }
+
+    #[tokio::test]
     async fn latest_spec_gap_methods_return_explicit_json_rpc_errors() {
         let dir = tempfile::tempdir().expect("tempdir");
         let script = dir.path().join("server.harn");

--- a/crates/harn-serve/src/lib.rs
+++ b/crates/harn-serve/src/lib.rs
@@ -6,6 +6,8 @@ mod auth;
 mod core;
 mod error;
 mod exports;
+#[cfg(test)]
+mod protocol_fixture_tests;
 mod replay;
 pub mod tls;
 

--- a/crates/harn-serve/src/protocol_fixture_tests.rs
+++ b/crates/harn-serve/src/protocol_fixture_tests.rs
@@ -1,0 +1,29 @@
+use serde_json::Value;
+use std::{fs, path::Path};
+
+pub(crate) fn assert_fixture_documents_match(fixture_name: &str, actual: Vec<Value>) {
+    let fixture_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join(fixture_name);
+    let fixture_json = fs::read_to_string(&fixture_path).unwrap_or_else(|error| {
+        panic!(
+            "failed to read protocol fixture {}: {error}",
+            fixture_path.display()
+        )
+    });
+    let fixture: Value = serde_json::from_str(&fixture_json).expect("protocol fixture json");
+    let expected = fixture
+        .get("documents")
+        .and_then(Value::as_array)
+        .expect("protocol fixture documents")
+        .clone();
+    let expected_value = Value::Array(expected);
+    let actual_value = Value::Array(actual);
+    if actual_value != expected_value {
+        panic!(
+            "protocol fixture drifted: {fixture_name}\nexpected:\n{}\nactual:\n{}",
+            serde_json::to_string_pretty(&expected_value).expect("expected json"),
+            serde_json::to_string_pretty(&actual_value).expect("actual json")
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Closes #1368.

- expands MCP, ACP, and A2A protocol conformance fixtures into a 29-row matrix with required version/family/case/source metadata
- adds schema provenance blocks with upstream source/spec URLs, retrieved dates, and refresh commands
- adds adapter-derived drift tests for MCP initialize/tools/resources, ACP session/update and agent events, ACP permission request/response, and A2A agent card discovery
- documents the matrix format, filtering, refresh flow, and adapter fixture checks

## Validation

- `HARN_LLM_CALLS_DISABLED=1 CARGO_TARGET_DIR=/tmp/harn-7505-protocol-target make protocol-conformance`
- `CARGO_TARGET_DIR=/tmp/harn-7505-serve-target cargo test -p harn-serve protocol_ -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-7505-serve-permission-target cargo test -p harn-serve adapters::acp::tests::acp_bridge_routes_session_request_permission_response -- --nocapture`
- `HARN_LLM_CALLS_DISABLED=1 CARGO_TARGET_DIR=/tmp/harn-7505-cli-target cargo clippy -p harn-cli -p harn-serve --all-targets -- -D warnings`
- `make lint-test-patterns`
- `npx markdownlint-cli2 conformance/protocols/README.md`
- pre-commit hook: workspace clippy, CI ratchets, full markdown lint
- pre-push hook: targeted local checks and full markdown lint

I also intentionally drifted an adapter-derived A2A fixture locally before restoring it to verify the fixture mismatch failure prints expected and actual JSON arrays.