### PR TITLE
Fix tree-sitter parsing for A2A regex fixtures

### DIFF
--- a/conformance/tests/integration/orchestrator_a2a_dispatch_sync.harn
+++ b/conformance/tests/integration/orchestrator_a2a_dispatch_sync.harn
@@ -22,7 +22,7 @@ pipeline test(task) {
   assert(pid != "", "missing A2A receiver pid")
   let receiver_url = wait_for_a2a_server_url(path_join(root, "receiver.log"))
   assert(receiver_url != nil, "A2A receiver did not start")
-  let port_matches = regex_captures(":(\\d+)$", receiver_url)
+  let port_matches = regex_captures(r":(\d+)$", receiver_url)
   assert(len(port_matches) == 1, "A2A receiver URL did not include a port: " + receiver_url)
   let port = port_matches[0].groups[0]
   let trigger_id = "github-a2a-review-" + unique

--- a/conformance/tests/observability/action_graph_dispatcher_node_kinds.harn
+++ b/conformance/tests/observability/action_graph_dispatcher_node_kinds.harn
@@ -58,7 +58,7 @@ pipeline test(task) {
   assert(pid != "", "missing A2A receiver pid")
   let receiver_url = wait_for_a2a_server_url(path_join(root, "receiver.log"))
   assert(receiver_url != nil, "A2A receiver did not start")
-  let port_matches = regex_captures(":(\\d+)$", receiver_url)
+  let port_matches = regex_captures(r":(\d+)$", receiver_url)
   assert(len(port_matches) == 1, "A2A receiver URL did not include a port: " + receiver_url)
   let port = port_matches[0].groups[0]
   let local_trace = "trace-graph-local-" + unique


### PR DESCRIPTION
## Summary
- Use raw Harn regex strings for A2A receiver port extraction fixtures
- Keeps VM parsing behavior unchanged while allowing the tree-sitter parse sweep to parse the files cleanly

## Validation
- harn check conformance/tests/integration/orchestrator_a2a_dispatch_sync.harn conformance/tests/observability/action_graph_dispatcher_node_kinds.harn
- tree-sitter-harn/scripts/tree-sitter-cli.sh parse --quiet --lib-path tree-sitter-harn/harn.dylib --lang-name harn conformance/tests/integration/orchestrator_a2a_dispatch_sync.harn conformance/tests/observability/action_graph_dispatcher_node_kinds.harn
- ./scripts/verify_tree_sitter_parse.py --strict
- git diff --check