### PR TITLE
Add orchestrator replay determinism oracle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
-.PHONY: setup install-hooks configure-merge-drivers build build-release check fmt fmt-harn fmt-harn-fix lint lint-md lint-actions lint-harn spec-lint test test-e2e test-cargo test-fast conformance protocol-conformance bench-vm bench-vm-clone bench-llm bench-orchestration all release-gate portal portal-check portal-demo gen-highlight check-highlight gen-trigger-quickref check-trigger-quickref gen-provider-matrix check-provider-matrix gen-connector-matrix check-connector-matrix check-trigger-examples check-docs-snippets sync-language-spec check-language-spec lint-test-patterns check-receipt-structs lint-no-rust-prompt-prose lint-no-xfail-regression
+.PHONY: setup install-hooks configure-merge-drivers build build-release check fmt fmt-harn fmt-harn-fix lint lint-md lint-actions lint-harn spec-lint test test-e2e test-cargo test-fast conformance protocol-conformance replay-oracle bench-vm bench-vm-clone bench-llm bench-orchestration all release-gate portal portal-check portal-demo gen-highlight check-highlight gen-trigger-quickref check-trigger-quickref gen-provider-matrix check-provider-matrix gen-connector-matrix check-connector-matrix check-trigger-examples check-docs-snippets sync-language-spec check-language-spec lint-test-patterns check-receipt-structs lint-no-rust-prompt-prose lint-no-xfail-regression
 
 # Full quality check: format first, then lint/test in parallel.
 # Usage: make all -j       (parallel checks after formatting)
 #        make all           (sequential, also works)
 all: fmt
-	$(MAKE) lint lint-md lint-actions lint-harn spec-lint fmt-harn test conformance protocol-conformance check-highlight check-language-spec check-trigger-quickref check-provider-matrix check-connector-matrix check-trigger-examples check-docs-snippets lint-test-patterns check-receipt-structs portal-check
+	$(MAKE) lint lint-md lint-actions lint-harn spec-lint fmt-harn test conformance protocol-conformance replay-oracle check-highlight check-language-spec check-trigger-quickref check-provider-matrix check-connector-matrix check-trigger-examples check-docs-snippets lint-test-patterns check-receipt-structs portal-check
 
 check: all
 
@@ -71,6 +71,9 @@ conformance:
 
 protocol-conformance:
 	HARN_LLM_CALLS_DISABLED=1 cargo run --bin harn -- test protocols
+
+replay-oracle:
+	HARN_LLM_CALLS_DISABLED=1 cargo run --bin harn -- orchestrator replay-oracle
 
 bench-vm:
 	./scripts/bench_vm.sh

--- a/conformance/replay-oracle/README.md
+++ b/conformance/replay-oracle/README.md
@@ -1,0 +1,44 @@
+# Replay oracle fixtures
+
+`harn orchestrator replay-oracle` validates canonical replay determinism
+fixtures for full orchestration traces. Each fixture stores two observed runs
+of the same logical trace and compares canonicalized streams for meaningful
+drift.
+
+The trace schema is `harn.orchestration.replay_trace.v1`. A fixture contains:
+
+- `event_log_entries`
+- `trigger_firings`
+- `llm_interactions`
+- `protocol_interactions`
+- `approval_interactions`
+- `effect_receipts`
+- `agent_transcript_deltas`
+- `final_artifacts`
+- `policy_decisions`
+
+Nondeterministic fields must be named explicitly in `allowlist` using
+JSON-pointer-like paths. `*` matches every array element or object value. Common
+allowlisted fields are EventLog offsets, timestamps, generated request ids,
+latency, and model token accounting.
+
+Run:
+
+```sh
+cargo run --bin harn -- orchestrator replay-oracle
+```
+
+or:
+
+```sh
+make replay-oracle
+```
+
+To prove drift fails loudly, run the mutation fixture directly:
+
+```sh
+cargo run --bin harn -- orchestrator replay-oracle \
+  conformance/replay-oracle/mutations/meaningful_drift.invalid.json
+```
+
+The command exits non-zero and prints the first divergent canonical path.

--- a/conformance/replay-oracle/fixtures/approval_tool_call.valid.json
+++ b/conformance/replay-oracle/fixtures/approval_tool_call.valid.json
@@ -1,0 +1,97 @@
+{
+  "schema_version": "harn.orchestration.replay_trace.v1",
+  "name": "handler_permission_approved_tool_call",
+  "description": "Handler pauses for a HITL approval boundary, receives an ACP permission response, then records a deterministic file-effect receipt.",
+  "expect": "match",
+  "protocol_fixture_refs": [
+    "conformance/protocols/fixtures/acp/session_request_permission.valid.json"
+  ],
+  "allowlist": [
+    {"path": "/run_id", "reason": "run ids are allocated per execution"},
+    {"path": "/event_log_entries/*/event_id", "reason": "EventLog offsets are backend-local"},
+    {"path": "/event_log_entries/*/occurred_at_ms", "reason": "append timestamps are wall-clock observations"},
+    {"path": "/event_log_entries/*/payload/event_id", "reason": "TriggerEvent ids are generated per intake"},
+    {"path": "/approval_interactions/*/request_id", "reason": "approval request ids are generated per pause"},
+    {"path": "/approval_interactions/*/prompted_at_ms", "reason": "approval prompt time is wall-clock data"},
+    {"path": "/approval_interactions/*/responded_at_ms", "reason": "approval response time is wall-clock data"},
+    {"path": "/effect_receipts/*/receipt_id", "reason": "receipt ids are generated per side-effect record"},
+    {"path": "/policy_decisions/*/decision_id", "reason": "policy decision ids are generated per evaluation"},
+    {"path": "/protocol_interactions/*/latency_ms", "reason": "host adapter latency is wall-clock data"}
+  ],
+  "first_run": {
+    "run_id": "run_live_hitl_tool",
+    "event_log_entries": [
+      {
+        "event_id": 51,
+        "topic": "hitl.approvals",
+        "kind": "approval_requested",
+        "occurred_at_ms": 1770000000500,
+        "payload": {"event_id": "trigger_evt_live_hitl", "action": "write_file", "status": "waiting"}
+      },
+      {
+        "event_id": 52,
+        "topic": "trigger.outbox",
+        "kind": "dispatch_succeeded",
+        "occurred_at_ms": 1770000000600,
+        "payload": {"event_id": "trigger_evt_live_hitl", "binding_id": "approved-write", "result": {"status": "written"}}
+      }
+    ],
+    "protocol_interactions": [
+      {
+        "protocol": "acp",
+        "boundary": "session/request_permission",
+        "fixture_ref": "conformance/protocols/fixtures/acp/session_request_permission.valid.json",
+        "request": {"method": "session/request_permission", "action": "write_file", "resource": "notes/triage.md"},
+        "response": {"outcome": "approved", "reviewer": "operator"},
+        "latency_ms": 42
+      }
+    ],
+    "approval_interactions": [
+      {"request_id": "approval_live_01", "principal": "agent:triage", "action": "write_file", "prompted_at_ms": 1770000000510, "response": "approved", "responded_at_ms": 1770000000540, "reviewer": "operator"}
+    ],
+    "effect_receipts": [
+      {"receipt_id": "receipt_live_hitl", "kind": "file_write", "path": "notes/triage.md", "sha256": "1dc0c9e3cb7f5a12e47d5fd979c6df1ac11dc1a1cc7b9b61b76f338deafd0f25", "substitute": false}
+    ],
+    "policy_decisions": [
+      {"decision_id": "policy_live_hitl", "capability": "fs.write", "decision": "allow_after_approval", "approval_required": true}
+    ]
+  },
+  "second_run": {
+    "run_id": "run_replay_hitl_tool",
+    "event_log_entries": [
+      {
+        "event_id": 61,
+        "topic": "hitl.approvals",
+        "kind": "approval_requested",
+        "occurred_at_ms": 1770001000500,
+        "payload": {"event_id": "trigger_evt_replay_hitl", "action": "write_file", "status": "waiting"}
+      },
+      {
+        "event_id": 62,
+        "topic": "trigger.outbox",
+        "kind": "dispatch_succeeded",
+        "occurred_at_ms": 1770001000600,
+        "payload": {"event_id": "trigger_evt_replay_hitl", "binding_id": "approved-write", "result": {"status": "written"}}
+      }
+    ],
+    "protocol_interactions": [
+      {
+        "protocol": "acp",
+        "boundary": "session/request_permission",
+        "fixture_ref": "conformance/protocols/fixtures/acp/session_request_permission.valid.json",
+        "request": {"method": "session/request_permission", "action": "write_file", "resource": "notes/triage.md"},
+        "response": {"outcome": "approved", "reviewer": "operator"},
+        "latency_ms": 7
+      }
+    ],
+    "approval_interactions": [
+      {"request_id": "approval_replay_01", "principal": "agent:triage", "action": "write_file", "prompted_at_ms": 1770001000510, "response": "approved", "responded_at_ms": 1770001000540, "reviewer": "operator"}
+    ],
+    "effect_receipts": [
+      {"receipt_id": "receipt_replay_hitl", "kind": "file_write", "path": "notes/triage.md", "sha256": "1dc0c9e3cb7f5a12e47d5fd979c6df1ac11dc1a1cc7b9b61b76f338deafd0f25", "substitute": false}
+    ],
+    "policy_decisions": [
+      {"decision_id": "policy_replay_hitl", "capability": "fs.write", "decision": "allow_after_approval", "approval_required": true}
+    ]
+  }
+}

--- a/conformance/replay-oracle/fixtures/failed_tool_retry_dlq.valid.json
+++ b/conformance/replay-oracle/fixtures/failed_tool_retry_dlq.valid.json
@@ -1,0 +1,114 @@
+{
+  "schema_version": "harn.orchestration.replay_trace.v1",
+  "name": "failed_tool_retry_dead_letter_path",
+  "description": "A tool failure retries once, records deterministic failure receipts, and lands in the trigger DLQ with stable policy decisions.",
+  "expect": "match",
+  "protocol_fixture_refs": [
+    "conformance/protocols/fixtures/mcp/tools_resources_prompts.valid.json"
+  ],
+  "allowlist": [
+    {"path": "/run_id", "reason": "run ids are allocated per execution"},
+    {"path": "/event_log_entries/*/event_id", "reason": "EventLog offsets are backend-local"},
+    {"path": "/event_log_entries/*/occurred_at_ms", "reason": "append timestamps are wall-clock observations"},
+    {"path": "/event_log_entries/*/payload/event_id", "reason": "TriggerEvent ids are generated per intake"},
+    {"path": "/trigger_firings/*/event_id", "reason": "TriggerEvent ids are generated per intake"},
+    {"path": "/trigger_firings/*/trace_id", "reason": "trace ids are generated per execution"},
+    {"path": "/protocol_interactions/*/latency_ms", "reason": "tool adapter latency is wall-clock data"},
+    {"path": "/effect_receipts/*/receipt_id", "reason": "receipt ids are generated per side-effect record"},
+    {"path": "/effect_receipts/*/started_at_ms", "reason": "tool start time is wall-clock data"},
+    {"path": "/effect_receipts/*/completed_at_ms", "reason": "tool completion time is wall-clock data"},
+    {"path": "/policy_decisions/*/decision_id", "reason": "policy decision ids are generated per evaluation"}
+  ],
+  "first_run": {
+    "run_id": "run_live_retry_dlq",
+    "event_log_entries": [
+      {
+        "event_id": 91,
+        "topic": "trigger.attempts",
+        "kind": "dispatch_failed",
+        "occurred_at_ms": 1770000000900,
+        "payload": {"event_id": "trigger_evt_live_retry", "binding_id": "retry-dlq", "attempt": 1, "error_class": "permission_denied"}
+      },
+      {
+        "event_id": 92,
+        "topic": "trigger.attempts",
+        "kind": "dispatch_failed",
+        "occurred_at_ms": 1770000001000,
+        "payload": {"event_id": "trigger_evt_live_retry", "binding_id": "retry-dlq", "attempt": 2, "error_class": "permission_denied"}
+      },
+      {
+        "event_id": 93,
+        "topic": "trigger.dlq",
+        "kind": "dlq_entry",
+        "occurred_at_ms": 1770000001100,
+        "payload": {"event_id": "trigger_evt_live_retry", "binding_id": "retry-dlq", "attempts": 2, "final_error_class": "permission_denied"}
+      }
+    ],
+    "trigger_firings": [
+      {"binding_id": "retry-dlq", "event_id": "trigger_evt_live_retry", "trace_id": "trace_live_retry", "handler_kind": "mcp", "decision": "dlq"}
+    ],
+    "protocol_interactions": [
+      {
+        "protocol": "mcp",
+        "boundary": "tools/call",
+        "fixture_ref": "conformance/protocols/fixtures/mcp/tools_resources_prompts.valid.json",
+        "request": {"method": "tools/call", "tool": "dangerous_delete", "arguments_sha256": "a36e5a9f4af3eebf2ed893807628d7f5b62f9ccad39171cc88d85f5e32274f52"},
+        "response": {"isError": true, "error": "permission_denied"},
+        "latency_ms": 63
+      }
+    ],
+    "effect_receipts": [
+      {"receipt_id": "receipt_live_retry_1", "kind": "tool_error", "tool": "dangerous_delete", "attempt": 1, "started_at_ms": 1770000000910, "completed_at_ms": 1770000000920, "error_class": "permission_denied"},
+      {"receipt_id": "receipt_live_retry_2", "kind": "tool_error", "tool": "dangerous_delete", "attempt": 2, "started_at_ms": 1770000001010, "completed_at_ms": 1770000001020, "error_class": "permission_denied"}
+    ],
+    "policy_decisions": [
+      {"decision_id": "policy_live_retry", "capability": "mcp.tools.call", "decision": "deny", "reason": "forbidden destructive tool"}
+    ]
+  },
+  "second_run": {
+    "run_id": "run_replay_retry_dlq",
+    "event_log_entries": [
+      {
+        "event_id": 101,
+        "topic": "trigger.attempts",
+        "kind": "dispatch_failed",
+        "occurred_at_ms": 1770001000900,
+        "payload": {"event_id": "trigger_evt_replay_retry", "binding_id": "retry-dlq", "attempt": 1, "error_class": "permission_denied"}
+      },
+      {
+        "event_id": 102,
+        "topic": "trigger.attempts",
+        "kind": "dispatch_failed",
+        "occurred_at_ms": 1770001001000,
+        "payload": {"event_id": "trigger_evt_replay_retry", "binding_id": "retry-dlq", "attempt": 2, "error_class": "permission_denied"}
+      },
+      {
+        "event_id": 103,
+        "topic": "trigger.dlq",
+        "kind": "dlq_entry",
+        "occurred_at_ms": 1770001001100,
+        "payload": {"event_id": "trigger_evt_replay_retry", "binding_id": "retry-dlq", "attempts": 2, "final_error_class": "permission_denied"}
+      }
+    ],
+    "trigger_firings": [
+      {"binding_id": "retry-dlq", "event_id": "trigger_evt_replay_retry", "trace_id": "trace_replay_retry", "handler_kind": "mcp", "decision": "dlq"}
+    ],
+    "protocol_interactions": [
+      {
+        "protocol": "mcp",
+        "boundary": "tools/call",
+        "fixture_ref": "conformance/protocols/fixtures/mcp/tools_resources_prompts.valid.json",
+        "request": {"method": "tools/call", "tool": "dangerous_delete", "arguments_sha256": "a36e5a9f4af3eebf2ed893807628d7f5b62f9ccad39171cc88d85f5e32274f52"},
+        "response": {"isError": true, "error": "permission_denied"},
+        "latency_ms": 8
+      }
+    ],
+    "effect_receipts": [
+      {"receipt_id": "receipt_replay_retry_1", "kind": "tool_error", "tool": "dangerous_delete", "attempt": 1, "started_at_ms": 1770001000910, "completed_at_ms": 1770001000920, "error_class": "permission_denied"},
+      {"receipt_id": "receipt_replay_retry_2", "kind": "tool_error", "tool": "dangerous_delete", "attempt": 2, "started_at_ms": 1770001001010, "completed_at_ms": 1770001001020, "error_class": "permission_denied"}
+    ],
+    "policy_decisions": [
+      {"decision_id": "policy_replay_retry", "capability": "mcp.tools.call", "decision": "deny", "reason": "forbidden destructive tool"}
+    ]
+  }
+}

--- a/conformance/replay-oracle/fixtures/llm_predicate_handler.valid.json
+++ b/conformance/replay-oracle/fixtures/llm_predicate_handler.valid.json
@@ -1,0 +1,91 @@
+{
+  "schema_version": "harn.orchestration.replay_trace.v1",
+  "name": "trigger_llm_predicate_handler",
+  "description": "A trigger predicate uses a deterministic LLM cache key before dispatching the handler.",
+  "expect": "match",
+  "allowlist": [
+    {"path": "/run_id", "reason": "run ids are allocated per execution"},
+    {"path": "/event_log_entries/*/event_id", "reason": "EventLog offsets are backend-local"},
+    {"path": "/event_log_entries/*/occurred_at_ms", "reason": "append timestamps are wall-clock observations"},
+    {"path": "/event_log_entries/*/payload/event_id", "reason": "TriggerEvent ids are generated per intake"},
+    {"path": "/trigger_firings/*/event_id", "reason": "TriggerEvent ids are generated per intake"},
+    {"path": "/trigger_firings/*/trace_id", "reason": "trace ids are generated per execution"},
+    {"path": "/llm_interactions/*/request_id", "reason": "provider request ids are generated per call"},
+    {"path": "/llm_interactions/*/latency_ms", "reason": "model latency is a wall-clock observation"},
+    {"path": "/llm_interactions/*/usage", "reason": "token accounting can vary across provider reports for the same cached semantic result"}
+  ],
+  "first_run": {
+    "run_id": "run_live_llm_predicate",
+    "event_log_entries": [
+      {
+        "event_id": 31,
+        "topic": "trigger.attempts",
+        "kind": "predicate_evaluated",
+        "occurred_at_ms": 1770000000300,
+        "payload": {"event_id": "trigger_evt_live_llm", "binding_id": "llm-predicate", "predicate": "llm_gate", "decision": "allow"}
+      },
+      {
+        "event_id": 32,
+        "topic": "trigger.outbox",
+        "kind": "dispatch_succeeded",
+        "occurred_at_ms": 1770000000400,
+        "payload": {"event_id": "trigger_evt_live_llm", "binding_id": "llm-predicate", "result": {"priority": "p1", "route": "incident-review"}}
+      }
+    ],
+    "trigger_firings": [
+      {"binding_id": "llm-predicate", "event_id": "trigger_evt_live_llm", "trace_id": "trace_live_llm", "handler_kind": "harn", "decision": "dispatched"}
+    ],
+    "llm_interactions": [
+      {
+        "request_id": "chatcmpl-live-llm",
+        "cache_key": "sha256:llm-predicate:issue-42:v1",
+        "provider": "mock",
+        "model": "deterministic-fixture",
+        "messages_sha256": "9d6a2ea25cdb0f7e54a79b4211b3df6b2a59431f99f715b6571d8cb01c505d79",
+        "response": {"allow": true, "priority": "p1"},
+        "usage": {"input_tokens": 105, "output_tokens": 12},
+        "latency_ms": 18
+      }
+    ],
+    "policy_decisions": [
+      {"decision_id": "predicate-allow", "kind": "predicate", "decision": "allow", "reason": "cached semantic classification"}
+    ]
+  },
+  "second_run": {
+    "run_id": "run_replay_llm_predicate",
+    "event_log_entries": [
+      {
+        "event_id": 41,
+        "topic": "trigger.attempts",
+        "kind": "predicate_evaluated",
+        "occurred_at_ms": 1770001000300,
+        "payload": {"event_id": "trigger_evt_replay_llm", "binding_id": "llm-predicate", "predicate": "llm_gate", "decision": "allow"}
+      },
+      {
+        "event_id": 42,
+        "topic": "trigger.outbox",
+        "kind": "dispatch_succeeded",
+        "occurred_at_ms": 1770001000400,
+        "payload": {"event_id": "trigger_evt_replay_llm", "binding_id": "llm-predicate", "result": {"priority": "p1", "route": "incident-review"}}
+      }
+    ],
+    "trigger_firings": [
+      {"binding_id": "llm-predicate", "event_id": "trigger_evt_replay_llm", "trace_id": "trace_replay_llm", "handler_kind": "harn", "decision": "dispatched"}
+    ],
+    "llm_interactions": [
+      {
+        "request_id": "chatcmpl-replay-llm",
+        "cache_key": "sha256:llm-predicate:issue-42:v1",
+        "provider": "mock",
+        "model": "deterministic-fixture",
+        "messages_sha256": "9d6a2ea25cdb0f7e54a79b4211b3df6b2a59431f99f715b6571d8cb01c505d79",
+        "response": {"allow": true, "priority": "p1"},
+        "usage": {"input_tokens": 103, "output_tokens": 13},
+        "latency_ms": 4
+      }
+    ],
+    "policy_decisions": [
+      {"decision_id": "predicate-allow", "kind": "predicate", "decision": "allow", "reason": "cached semantic classification"}
+    ]
+  }
+}

--- a/conformance/replay-oracle/fixtures/simple_trigger_local_handler.valid.json
+++ b/conformance/replay-oracle/fixtures/simple_trigger_local_handler.valid.json
@@ -1,0 +1,65 @@
+{
+  "schema_version": "harn.orchestration.replay_trace.v1",
+  "name": "simple_trigger_local_handler",
+  "description": "Trigger dispatch to an in-process Harn handler with a deterministic local receipt.",
+  "expect": "match",
+  "allowlist": [
+    {"path": "/run_id", "reason": "run ids are allocated per execution"},
+    {"path": "/event_log_entries/*/event_id", "reason": "EventLog offsets are backend-local"},
+    {"path": "/event_log_entries/*/occurred_at_ms", "reason": "append timestamps are wall-clock observations"},
+    {"path": "/event_log_entries/*/payload/event_id", "reason": "TriggerEvent ids are generated per intake"},
+    {"path": "/trigger_firings/*/event_id", "reason": "TriggerEvent ids are generated per intake"},
+    {"path": "/trigger_firings/*/trace_id", "reason": "trace ids are generated per execution"},
+    {"path": "/effect_receipts/*/receipt_id", "reason": "receipt ids are generated per side-effect record"}
+  ],
+  "first_run": {
+    "run_id": "run_live_simple_01",
+    "event_log_entries": [
+      {
+        "event_id": 11,
+        "topic": "orchestrator.triggers.pending",
+        "kind": "event_ingested",
+        "occurred_at_ms": 1770000000100,
+        "payload": {"event_id": "trigger_evt_live_simple", "binding_id": "simple-local", "provider": "github", "kind": "issues.opened"}
+      },
+      {
+        "event_id": 12,
+        "topic": "trigger.outbox",
+        "kind": "dispatch_succeeded",
+        "occurred_at_ms": 1770000000200,
+        "payload": {"event_id": "trigger_evt_live_simple", "binding_id": "simple-local", "handler": "handlers::on_issue", "result": {"status": "triaged", "labels": ["needs-owner"]}}
+      }
+    ],
+    "trigger_firings": [
+      {"binding_id": "simple-local", "event_id": "trigger_evt_live_simple", "trace_id": "trace_live_simple", "handler_kind": "harn", "decision": "dispatched"}
+    ],
+    "effect_receipts": [
+      {"receipt_id": "receipt_live_simple", "kind": "file_substitute", "path": "artifacts/simple-local.json", "sha256": "0f44d61f92bb64e4c8e48f4a2d876e79380f5c1e49a68d116a6f3ec8fbf6bd2e", "mode": "deterministic_substitute"}
+    ]
+  },
+  "second_run": {
+    "run_id": "run_replay_simple_01",
+    "event_log_entries": [
+      {
+        "event_id": 21,
+        "topic": "orchestrator.triggers.pending",
+        "kind": "event_ingested",
+        "occurred_at_ms": 1770001000100,
+        "payload": {"event_id": "trigger_evt_replay_simple", "binding_id": "simple-local", "provider": "github", "kind": "issues.opened"}
+      },
+      {
+        "event_id": 22,
+        "topic": "trigger.outbox",
+        "kind": "dispatch_succeeded",
+        "occurred_at_ms": 1770001000200,
+        "payload": {"event_id": "trigger_evt_replay_simple", "binding_id": "simple-local", "handler": "handlers::on_issue", "result": {"status": "triaged", "labels": ["needs-owner"]}}
+      }
+    ],
+    "trigger_firings": [
+      {"binding_id": "simple-local", "event_id": "trigger_evt_replay_simple", "trace_id": "trace_replay_simple", "handler_kind": "harn", "decision": "dispatched"}
+    ],
+    "effect_receipts": [
+      {"receipt_id": "receipt_replay_simple", "kind": "file_substitute", "path": "artifacts/simple-local.json", "sha256": "0f44d61f92bb64e4c8e48f4a2d876e79380f5c1e49a68d116a6f3ec8fbf6bd2e", "mode": "deterministic_substitute"}
+    ]
+  }
+}

--- a/conformance/replay-oracle/fixtures/worker_a2a_path.valid.json
+++ b/conformance/replay-oracle/fixtures/worker_a2a_path.valid.json
@@ -1,0 +1,103 @@
+{
+  "schema_version": "harn.orchestration.replay_trace.v1",
+  "name": "handler_delegated_worker_a2a_path",
+  "description": "Handler delegates to a worker and crosses an A2A adapter boundary while preserving transcript deltas and final artifact semantics.",
+  "expect": "match",
+  "protocol_fixture_refs": [
+    "conformance/protocols/fixtures/a2a/task_and_stream.valid.json"
+  ],
+  "allowlist": [
+    {"path": "/run_id", "reason": "run ids are allocated per execution"},
+    {"path": "/event_log_entries/*/event_id", "reason": "EventLog offsets are backend-local"},
+    {"path": "/event_log_entries/*/occurred_at_ms", "reason": "append timestamps are wall-clock observations"},
+    {"path": "/event_log_entries/*/payload/event_id", "reason": "TriggerEvent ids are generated per intake"},
+    {"path": "/trigger_firings/*/event_id", "reason": "TriggerEvent ids are generated per intake"},
+    {"path": "/trigger_firings/*/trace_id", "reason": "trace ids are generated per execution"},
+    {"path": "/protocol_interactions/*/latency_ms", "reason": "remote protocol latency is wall-clock data"},
+    {"path": "/agent_transcript_deltas/*/delta_id", "reason": "transcript delta ids are generated per append"},
+    {"path": "/final_artifacts/*/artifact_id", "reason": "artifact ids are generated per run"},
+    {"path": "/effect_receipts/*/receipt_id", "reason": "receipt ids are generated per side-effect record"}
+  ],
+  "first_run": {
+    "run_id": "run_live_worker_a2a",
+    "event_log_entries": [
+      {
+        "event_id": 71,
+        "topic": "worker.queue.triage",
+        "kind": "worker_enqueued",
+        "occurred_at_ms": 1770000000700,
+        "payload": {"event_id": "trigger_evt_live_worker", "queue": "triage", "task": "summarize incident"}
+      },
+      {
+        "event_id": 72,
+        "topic": "trigger.outbox",
+        "kind": "dispatch_succeeded",
+        "occurred_at_ms": 1770000000800,
+        "payload": {"event_id": "trigger_evt_live_worker", "binding_id": "worker-a2a", "result": {"worker_status": "completed"}}
+      }
+    ],
+    "trigger_firings": [
+      {"binding_id": "worker-a2a", "event_id": "trigger_evt_live_worker", "trace_id": "trace_live_worker", "handler_kind": "worker", "decision": "enqueued"}
+    ],
+    "protocol_interactions": [
+      {
+        "protocol": "a2a",
+        "boundary": "message/send",
+        "fixture_ref": "conformance/protocols/fixtures/a2a/task_and_stream.valid.json",
+        "request": {"method": "message/send", "task": "summarize incident", "agent": "triage-worker"},
+        "response": {"task_id": "task-deterministic", "state": "completed"},
+        "latency_ms": 55
+      }
+    ],
+    "effect_receipts": [
+      {"receipt_id": "receipt_live_worker_network", "kind": "network_substitute", "target": "a2a://triage-worker", "response_sha256": "bc5120d4928578c106a17f0503c7c50e114961ab35feb2c11cc790bf09d82d5f"}
+    ],
+    "agent_transcript_deltas": [
+      {"delta_id": "delta_live_worker_1", "agent": "triage-worker", "role": "assistant", "content_sha256": "6f1da4f4e6dbf0752c4713084ed4c35800e7dc7555d79a3176d86f2a08809d33"}
+    ],
+    "final_artifacts": [
+      {"artifact_id": "artifact_live_worker", "kind": "summary", "path": "artifacts/incident-summary.md", "sha256": "e9d71f5ee7c92d6dc9e92ffdad17b8bd49418f98fe23f6f61f9ce311ade0c7b7"}
+    ]
+  },
+  "second_run": {
+    "run_id": "run_replay_worker_a2a",
+    "event_log_entries": [
+      {
+        "event_id": 81,
+        "topic": "worker.queue.triage",
+        "kind": "worker_enqueued",
+        "occurred_at_ms": 1770001000700,
+        "payload": {"event_id": "trigger_evt_replay_worker", "queue": "triage", "task": "summarize incident"}
+      },
+      {
+        "event_id": 82,
+        "topic": "trigger.outbox",
+        "kind": "dispatch_succeeded",
+        "occurred_at_ms": 1770001000800,
+        "payload": {"event_id": "trigger_evt_replay_worker", "binding_id": "worker-a2a", "result": {"worker_status": "completed"}}
+      }
+    ],
+    "trigger_firings": [
+      {"binding_id": "worker-a2a", "event_id": "trigger_evt_replay_worker", "trace_id": "trace_replay_worker", "handler_kind": "worker", "decision": "enqueued"}
+    ],
+    "protocol_interactions": [
+      {
+        "protocol": "a2a",
+        "boundary": "message/send",
+        "fixture_ref": "conformance/protocols/fixtures/a2a/task_and_stream.valid.json",
+        "request": {"method": "message/send", "task": "summarize incident", "agent": "triage-worker"},
+        "response": {"task_id": "task-deterministic", "state": "completed"},
+        "latency_ms": 9
+      }
+    ],
+    "effect_receipts": [
+      {"receipt_id": "receipt_replay_worker_network", "kind": "network_substitute", "target": "a2a://triage-worker", "response_sha256": "bc5120d4928578c106a17f0503c7c50e114961ab35feb2c11cc790bf09d82d5f"}
+    ],
+    "agent_transcript_deltas": [
+      {"delta_id": "delta_replay_worker_1", "agent": "triage-worker", "role": "assistant", "content_sha256": "6f1da4f4e6dbf0752c4713084ed4c35800e7dc7555d79a3176d86f2a08809d33"}
+    ],
+    "final_artifacts": [
+      {"artifact_id": "artifact_replay_worker", "kind": "summary", "path": "artifacts/incident-summary.md", "sha256": "e9d71f5ee7c92d6dc9e92ffdad17b8bd49418f98fe23f6f61f9ce311ade0c7b7"}
+    ]
+  }
+}

--- a/conformance/replay-oracle/mutations/meaningful_drift.invalid.json
+++ b/conformance/replay-oracle/mutations/meaningful_drift.invalid.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": "harn.orchestration.replay_trace.v1",
+  "name": "meaningful_dispatch_drift_mutation",
+  "description": "Mutation fixture used to prove the oracle fails loudly when canonical replay output drifts.",
+  "expect": "match",
+  "allowlist": [
+    {"path": "/run_id", "reason": "run ids are allocated per execution"},
+    {"path": "/event_log_entries/*/event_id", "reason": "EventLog offsets are backend-local"},
+    {"path": "/event_log_entries/*/occurred_at_ms", "reason": "append timestamps are wall-clock observations"}
+  ],
+  "first_run": {
+    "run_id": "run_live_mutation",
+    "event_log_entries": [
+      {
+        "event_id": 201,
+        "topic": "trigger.outbox",
+        "kind": "dispatch_succeeded",
+        "occurred_at_ms": 1770000001200,
+        "payload": {"binding_id": "mutation", "result": {"status": "dispatched"}}
+      }
+    ]
+  },
+  "second_run": {
+    "run_id": "run_replay_mutation",
+    "event_log_entries": [
+      {
+        "event_id": 301,
+        "topic": "trigger.outbox",
+        "kind": "dispatch_succeeded",
+        "occurred_at_ms": 1770001001200,
+        "payload": {"binding_id": "mutation", "result": {"status": "dlq"}}
+      }
+    ]
+  }
+}

--- a/crates/harn-cli/src/cli/mod.rs
+++ b/crates/harn-cli/src/cli/mod.rs
@@ -95,9 +95,10 @@ pub(crate) use orchestrator::{
     OrchestratorLogFormat, OrchestratorQueueArgs, OrchestratorQueueCommand,
     OrchestratorQueueDrainArgs, OrchestratorQueueLsArgs, OrchestratorQueuePurgeArgs,
     OrchestratorRecoverArgs, OrchestratorReloadArgs, OrchestratorReplayArgs,
-    OrchestratorResumeArgs, OrchestratorServeArgs, OrchestratorStatsArgs, OrchestratorTenantArgs,
-    OrchestratorTenantCommand, OrchestratorTenantCreateArgs, OrchestratorTenantDeleteArgs,
-    OrchestratorTenantLsArgs, OrchestratorTenantSuspendArgs,
+    OrchestratorReplayOracleArgs, OrchestratorResumeArgs, OrchestratorServeArgs,
+    OrchestratorStatsArgs, OrchestratorTenantArgs, OrchestratorTenantCommand,
+    OrchestratorTenantCreateArgs, OrchestratorTenantDeleteArgs, OrchestratorTenantLsArgs,
+    OrchestratorTenantSuspendArgs,
 };
 pub(crate) use package::{
     AddArgs, InstallArgs, PackageArgs, PackageCacheCommand, PackageCommand, PublishArgs,

--- a/crates/harn-cli/src/cli/orchestrator.rs
+++ b/crates/harn-cli/src/cli/orchestrator.rs
@@ -50,6 +50,8 @@ pub(crate) enum OrchestratorCommand {
     Fire(OrchestratorFireArgs),
     /// Replay orchestrator events.
     Replay(OrchestratorReplayArgs),
+    /// Run canonical replay determinism oracle fixtures.
+    ReplayOracle(OrchestratorReplayOracleArgs),
     /// Resume a paused HITL escalation by accepting its request id.
     Resume(OrchestratorResumeArgs),
     /// Inspect the dead-letter queue.
@@ -373,6 +375,19 @@ pub(crate) struct OrchestratorReplayArgs {
     pub local: OrchestratorLocalArgs,
     /// Previously recorded event id to replay.
     pub event_id: String,
+    /// Emit JSON instead of human-readable output.
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct OrchestratorReplayOracleArgs {
+    /// Fixture file or directory to run. Defaults to the checked-in replay oracle fixtures.
+    #[arg(value_name = "PATH")]
+    pub selection: Option<PathBuf>,
+    /// Run only fixtures whose name, path, or protocol fixture refs contain this substring.
+    #[arg(long, value_name = "TEXT")]
+    pub filter: Option<String>,
     /// Emit JSON instead of human-readable output.
     #[arg(long)]
     pub json: bool,

--- a/crates/harn-cli/src/commands/orchestrator/mod.rs
+++ b/crates/harn-cli/src/commands/orchestrator/mod.rs
@@ -12,6 +12,7 @@ mod queue;
 mod recover;
 mod reload;
 mod replay;
+mod replay_oracle;
 mod resume;
 pub(crate) mod role;
 mod serve;
@@ -33,6 +34,9 @@ pub(crate) async fn handle(args: OrchestratorArgs) -> OrchestratorResult<()> {
         OrchestratorCommand::Stats(stats_args) => stats::run(stats_args).await,
         OrchestratorCommand::Fire(fire_args) => fire::run(fire_args).await,
         OrchestratorCommand::Replay(replay_args) => replay::run(replay_args).await,
+        OrchestratorCommand::ReplayOracle(replay_oracle_args) => {
+            replay_oracle::run(replay_oracle_args).await
+        }
         OrchestratorCommand::Resume(resume_args) => resume::run(resume_args).await,
         OrchestratorCommand::Dlq(dlq_args) => dlq::run(dlq_args).await,
         OrchestratorCommand::Queue(queue_args) => queue::run(queue_args).await,

--- a/crates/harn-cli/src/commands/orchestrator/replay_oracle.rs
+++ b/crates/harn-cli/src/commands/orchestrator/replay_oracle.rs
@@ -1,0 +1,339 @@
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+
+use super::common::print_json;
+use super::errors::OrchestratorError;
+use crate::cli::OrchestratorReplayOracleArgs;
+
+#[derive(Debug, Serialize)]
+struct ReplayOracleSuiteReport {
+    passed: usize,
+    failed: usize,
+    skipped: usize,
+    fixtures: Vec<ReplayOracleFixtureOutcome>,
+}
+
+#[derive(Debug, Serialize)]
+struct ReplayOracleFixtureOutcome {
+    path: String,
+    name: Option<String>,
+    passed: bool,
+    expectation: Option<harn_vm::ReplayExpectation>,
+    error: Option<String>,
+    divergence: Option<harn_vm::ReplayDivergence>,
+    first_run_counts: Option<harn_vm::ReplayTraceRunCounts>,
+    second_run_counts: Option<harn_vm::ReplayTraceRunCounts>,
+    protocol_fixture_refs: Vec<String>,
+}
+
+pub(super) async fn run(args: OrchestratorReplayOracleArgs) -> Result<(), OrchestratorError> {
+    let repo_root = discover_repo_root().unwrap_or_else(|| PathBuf::from("."));
+    let selection = resolve_selection_path(args.selection, &repo_root);
+    let fixtures = resolve_fixture_files(&selection)?;
+    let mut report = ReplayOracleSuiteReport {
+        passed: 0,
+        failed: 0,
+        skipped: 0,
+        fixtures: Vec::new(),
+    };
+
+    for fixture_path in fixtures {
+        let display_path = display_path(&fixture_path);
+        let trace = match read_trace_fixture(&fixture_path) {
+            Ok(trace) => trace,
+            Err(error) => {
+                report.failed += 1;
+                if !args.json {
+                    println!("  \x1b[31mFAIL\x1b[0m  {display_path}");
+                }
+                report.fixtures.push(ReplayOracleFixtureOutcome {
+                    path: display_path,
+                    name: None,
+                    passed: false,
+                    expectation: None,
+                    error: Some(error),
+                    divergence: None,
+                    first_run_counts: None,
+                    second_run_counts: None,
+                    protocol_fixture_refs: Vec::new(),
+                });
+                continue;
+            }
+        };
+
+        if !matches_filter(args.filter.as_deref(), &display_path, &trace) {
+            report.skipped += 1;
+            continue;
+        }
+
+        let protocol_ref_error =
+            validate_protocol_fixture_refs(&repo_root, &trace.protocol_fixture_refs)
+                .err()
+                .map(|error| format!("{}: {error}", trace.name));
+        let trace_report = match protocol_ref_error {
+            Some(error) => Err(error),
+            None => harn_vm::run_replay_oracle_trace(&trace).map_err(|error| error.to_string()),
+        };
+
+        match trace_report {
+            Ok(trace_report) if trace_report.passed => {
+                report.passed += 1;
+                if !args.json {
+                    println!("  \x1b[32mPASS\x1b[0m  {}", trace_report.name);
+                }
+                report.fixtures.push(ReplayOracleFixtureOutcome {
+                    path: display_path,
+                    name: Some(trace_report.name),
+                    passed: true,
+                    expectation: Some(trace_report.expectation),
+                    error: None,
+                    divergence: trace_report.divergence,
+                    first_run_counts: Some(trace_report.first_run_counts),
+                    second_run_counts: Some(trace_report.second_run_counts),
+                    protocol_fixture_refs: trace_report.protocol_fixture_refs,
+                });
+            }
+            Ok(trace_report) => {
+                report.failed += 1;
+                if !args.json {
+                    println!("  \x1b[31mFAIL\x1b[0m  {}", trace_report.name);
+                    if let Some(divergence) = &trace_report.divergence {
+                        print_divergence(divergence);
+                    } else {
+                        println!("    expected drift, but canonical replay runs matched");
+                    }
+                }
+                report.fixtures.push(ReplayOracleFixtureOutcome {
+                    path: display_path,
+                    name: Some(trace_report.name),
+                    passed: false,
+                    expectation: Some(trace_report.expectation),
+                    error: None,
+                    divergence: trace_report.divergence,
+                    first_run_counts: Some(trace_report.first_run_counts),
+                    second_run_counts: Some(trace_report.second_run_counts),
+                    protocol_fixture_refs: trace_report.protocol_fixture_refs,
+                });
+            }
+            Err(error) => {
+                report.failed += 1;
+                if !args.json {
+                    println!("  \x1b[31mFAIL\x1b[0m  {}", trace.name);
+                    println!("    {error}");
+                }
+                report.fixtures.push(ReplayOracleFixtureOutcome {
+                    path: display_path,
+                    name: Some(trace.name),
+                    passed: false,
+                    expectation: Some(trace.expect),
+                    error: Some(error),
+                    divergence: None,
+                    first_run_counts: None,
+                    second_run_counts: None,
+                    protocol_fixture_refs: trace.protocol_fixture_refs,
+                });
+            }
+        }
+    }
+
+    if args.json {
+        print_json(&report)?;
+    }
+
+    if report.failed > 0 {
+        return Err(OrchestratorError::Replay(format!(
+            "Replay oracle failed: {} passed, {} failed, {} skipped",
+            report.passed, report.failed, report.skipped
+        )));
+    }
+
+    if !args.json {
+        println!(
+            "Replay oracle passed: {} passed, {} skipped",
+            report.passed, report.skipped
+        );
+    }
+    Ok(())
+}
+
+fn resolve_selection_path(selection: Option<PathBuf>, repo_root: &Path) -> PathBuf {
+    match selection {
+        Some(selection) if selection.exists() || selection.is_absolute() => selection,
+        Some(selection) => repo_root.join(selection),
+        None => repo_root.join("conformance/replay-oracle/fixtures"),
+    }
+}
+
+fn resolve_fixture_files(selection: &Path) -> Result<Vec<PathBuf>, OrchestratorError> {
+    if !selection.exists() {
+        return Err(OrchestratorError::Replay(format!(
+            "replay oracle target not found: {}",
+            selection.display()
+        )));
+    }
+    let mut files = Vec::new();
+    collect_json_files(selection, &mut files);
+    if files.is_empty() {
+        return Err(OrchestratorError::Replay(format!(
+            "no replay oracle JSON fixtures found under {}",
+            selection.display()
+        )));
+    }
+    Ok(files)
+}
+
+fn collect_json_files(path: &Path, out: &mut Vec<PathBuf>) {
+    if path.is_file() {
+        if path.extension().is_some_and(|ext| ext == "json") {
+            out.push(path.to_path_buf());
+        }
+        return;
+    }
+    let Ok(entries) = std::fs::read_dir(path) else {
+        return;
+    };
+    let mut entries = entries.filter_map(Result::ok).collect::<Vec<_>>();
+    entries.sort_by_key(|entry| entry.path());
+    for entry in entries {
+        collect_json_files(&entry.path(), out);
+    }
+}
+
+fn read_trace_fixture(path: &Path) -> Result<harn_vm::ReplayOracleTrace, String> {
+    let text = std::fs::read_to_string(path)
+        .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
+    serde_json::from_str(&text)
+        .map_err(|error| format!("invalid replay trace JSON in {}: {error}", path.display()))
+}
+
+fn validate_protocol_fixture_refs(repo_root: &Path, refs: &[String]) -> Result<(), String> {
+    for fixture_ref in refs {
+        if !fixture_ref.starts_with("conformance/protocols/fixtures/") {
+            return Err(format!(
+                "protocol fixture ref must point under conformance/protocols/fixtures: {fixture_ref}"
+            ));
+        }
+        let path = Path::new(fixture_ref);
+        if path.is_absolute() {
+            return Err(format!(
+                "protocol fixture ref must be repo-relative: {fixture_ref}"
+            ));
+        }
+        let candidate = repo_root.join(path);
+        if !candidate.is_file() {
+            return Err(format!(
+                "protocol fixture ref not found: {}",
+                candidate.display()
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn matches_filter(
+    filter: Option<&str>,
+    display_path: &str,
+    trace: &harn_vm::ReplayOracleTrace,
+) -> bool {
+    let Some(filter) = filter else {
+        return true;
+    };
+    trace.name.contains(filter)
+        || display_path.contains(filter)
+        || trace
+            .protocol_fixture_refs
+            .iter()
+            .any(|fixture_ref| fixture_ref.contains(filter))
+}
+
+fn discover_repo_root() -> Option<PathBuf> {
+    let cwd = std::env::current_dir().ok()?;
+    for ancestor in cwd.ancestors() {
+        if ancestor.join("Cargo.toml").is_file() && ancestor.join("conformance").is_dir() {
+            return Some(ancestor.to_path_buf());
+        }
+    }
+    None
+}
+
+fn display_path(path: &Path) -> String {
+    discover_repo_root()
+        .and_then(|root| path.strip_prefix(root).ok().map(Path::to_path_buf))
+        .unwrap_or_else(|| path.to_path_buf())
+        .components()
+        .map(|component| component.as_os_str().to_string_lossy())
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+fn print_divergence(divergence: &harn_vm::ReplayDivergence) {
+    println!("    first divergence at {}", divergence.path);
+    println!("    left: {}", compact_json(&divergence.left));
+    println!("    right: {}", compact_json(&divergence.right));
+}
+
+fn compact_json(value: &serde_json::Value) -> String {
+    serde_json::to_string(value).unwrap_or_else(|_| "<unprintable>".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn filter_matches_trace_name_path_or_protocol_ref() {
+        let trace = harn_vm::ReplayOracleTrace {
+            name: "handler_to_a2a_worker".to_string(),
+            protocol_fixture_refs: vec![
+                "conformance/protocols/fixtures/a2a/task_and_stream.valid.json".to_string(),
+            ],
+            ..harn_vm::ReplayOracleTrace::default()
+        };
+
+        assert!(matches_filter(
+            Some("a2a_worker"),
+            "fixtures/worker.json",
+            &trace
+        ));
+        assert!(matches_filter(
+            Some("worker.json"),
+            "fixtures/worker.json",
+            &trace
+        ));
+        assert!(matches_filter(
+            Some("task_and_stream"),
+            "fixtures/worker.json",
+            &trace
+        ));
+        assert!(!matches_filter(Some("mcp"), "fixtures/worker.json", &trace));
+    }
+
+    #[test]
+    fn protocol_refs_must_use_checked_in_protocol_matrix() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(temp.path().join("conformance/protocols/fixtures/acp")).unwrap();
+        std::fs::write(
+            temp.path()
+                .join("conformance/protocols/fixtures/acp/session.valid.json"),
+            "{}",
+        )
+        .unwrap();
+
+        assert!(validate_protocol_fixture_refs(
+            temp.path(),
+            &["conformance/protocols/fixtures/acp/session.valid.json".to_string()]
+        )
+        .is_ok());
+        assert!(validate_protocol_fixture_refs(
+            temp.path(),
+            &["conformance/replay-oracle/not-protocol.json".to_string()]
+        )
+        .is_err());
+        assert!(validate_protocol_fixture_refs(
+            temp.path(),
+            &["conformance/protocols/fixtures/acp/missing.json".to_string()]
+        )
+        .is_err());
+    }
+}

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -117,6 +117,11 @@ pub use mcp_server::{
 };
 pub use metadata::{register_metadata_builtins, register_scan_builtins};
 pub use orchestration::{
+    canonicalize_run, first_divergence, run_replay_oracle_trace, ReplayAllowlistRule,
+    ReplayDivergence, ReplayExpectation, ReplayOracleError, ReplayOracleReport, ReplayOracleTrace,
+    ReplayTraceRun, ReplayTraceRunCounts, REPLAY_TRACE_SCHEMA_VERSION,
+};
+pub use orchestration::{
     install_handoff_routes, snapshot_handoff_routes, HandoffRouteConfig,
     HandoffRouteDecisionRecord, HandoffRouteTargetConfig,
 };

--- a/crates/harn-vm/src/orchestration/mod.rs
+++ b/crates/harn-vm/src/orchestration/mod.rs
@@ -51,6 +51,9 @@ pub use crystallize::*;
 mod release_fixture;
 pub use release_fixture::*;
 
+mod replay_oracle;
+pub use replay_oracle::*;
+
 mod policy;
 pub use policy::*;
 

--- a/crates/harn-vm/src/orchestration/replay_oracle.rs
+++ b/crates/harn-vm/src/orchestration/replay_oracle.rs
@@ -1,0 +1,559 @@
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value as JsonValue};
+use std::collections::BTreeSet;
+use std::fmt;
+
+pub const REPLAY_TRACE_SCHEMA_VERSION: &str = "harn.orchestration.replay_trace.v1";
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct ReplayOracleTrace {
+    pub schema_version: String,
+    pub name: String,
+    pub description: Option<String>,
+    pub expect: ReplayExpectation,
+    pub protocol_fixture_refs: Vec<String>,
+    pub allowlist: Vec<ReplayAllowlistRule>,
+    pub first_run: ReplayTraceRun,
+    pub second_run: ReplayTraceRun,
+}
+
+impl Default for ReplayOracleTrace {
+    fn default() -> Self {
+        Self {
+            schema_version: REPLAY_TRACE_SCHEMA_VERSION.to_string(),
+            name: String::new(),
+            description: None,
+            expect: ReplayExpectation::Match,
+            protocol_fixture_refs: Vec::new(),
+            allowlist: Vec::new(),
+            first_run: ReplayTraceRun::default(),
+            second_run: ReplayTraceRun::default(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ReplayExpectation {
+    #[default]
+    Match,
+    Drift,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct ReplayAllowlistRule {
+    /// JSON-pointer-like path. `*` matches every array element or object value.
+    pub path: String,
+    pub reason: String,
+    pub replacement: Option<JsonValue>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct ReplayTraceRun {
+    pub run_id: String,
+    pub event_log_entries: Vec<JsonValue>,
+    pub trigger_firings: Vec<JsonValue>,
+    pub llm_interactions: Vec<JsonValue>,
+    pub protocol_interactions: Vec<JsonValue>,
+    pub approval_interactions: Vec<JsonValue>,
+    pub effect_receipts: Vec<JsonValue>,
+    pub agent_transcript_deltas: Vec<JsonValue>,
+    pub final_artifacts: Vec<JsonValue>,
+    pub policy_decisions: Vec<JsonValue>,
+}
+
+impl ReplayTraceRun {
+    pub fn counts(&self) -> ReplayTraceRunCounts {
+        ReplayTraceRunCounts {
+            event_log_entries: self.event_log_entries.len(),
+            trigger_firings: self.trigger_firings.len(),
+            llm_interactions: self.llm_interactions.len(),
+            protocol_interactions: self.protocol_interactions.len(),
+            approval_interactions: self.approval_interactions.len(),
+            effect_receipts: self.effect_receipts.len(),
+            agent_transcript_deltas: self.agent_transcript_deltas.len(),
+            final_artifacts: self.final_artifacts.len(),
+            policy_decisions: self.policy_decisions.len(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct ReplayTraceRunCounts {
+    pub event_log_entries: usize,
+    pub trigger_firings: usize,
+    pub llm_interactions: usize,
+    pub protocol_interactions: usize,
+    pub approval_interactions: usize,
+    pub effect_receipts: usize,
+    pub agent_transcript_deltas: usize,
+    pub final_artifacts: usize,
+    pub policy_decisions: usize,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct ReplayOracleReport {
+    pub name: String,
+    pub expectation: ReplayExpectation,
+    pub passed: bool,
+    pub first_run_counts: ReplayTraceRunCounts,
+    pub second_run_counts: ReplayTraceRunCounts,
+    pub protocol_fixture_refs: Vec<String>,
+    pub divergence: Option<ReplayDivergence>,
+}
+
+impl Default for ReplayOracleReport {
+    fn default() -> Self {
+        Self {
+            name: String::new(),
+            expectation: ReplayExpectation::Match,
+            passed: false,
+            first_run_counts: ReplayTraceRunCounts::default(),
+            second_run_counts: ReplayTraceRunCounts::default(),
+            protocol_fixture_refs: Vec::new(),
+            divergence: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct ReplayDivergence {
+    pub path: String,
+    pub left: JsonValue,
+    pub right: JsonValue,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReplayOracleError {
+    InvalidTrace(String),
+    InvalidAllowlistPath(String),
+    AllowlistPathMissing(String),
+    Serialization(String),
+}
+
+impl fmt::Display for ReplayOracleError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidTrace(message)
+            | Self::InvalidAllowlistPath(message)
+            | Self::AllowlistPathMissing(message)
+            | Self::Serialization(message) => message.fmt(f),
+        }
+    }
+}
+
+impl std::error::Error for ReplayOracleError {}
+
+pub fn run_replay_oracle_trace(
+    trace: &ReplayOracleTrace,
+) -> Result<ReplayOracleReport, ReplayOracleError> {
+    validate_trace(trace)?;
+    let first_run_counts = trace.first_run.counts();
+    let second_run_counts = trace.second_run.counts();
+    let first = canonicalize_run(&trace.first_run, &trace.allowlist)?;
+    let second = canonicalize_run(&trace.second_run, &trace.allowlist)?;
+    let divergence = first_divergence(&first, &second);
+    let passed = match (trace.expect, divergence.is_some()) {
+        (ReplayExpectation::Match, false) => true,
+        (ReplayExpectation::Match, true) => false,
+        (ReplayExpectation::Drift, true) => true,
+        (ReplayExpectation::Drift, false) => false,
+    };
+
+    Ok(ReplayOracleReport {
+        name: trace.name.clone(),
+        expectation: trace.expect,
+        passed,
+        first_run_counts,
+        second_run_counts,
+        protocol_fixture_refs: trace.protocol_fixture_refs.clone(),
+        divergence,
+    })
+}
+
+pub fn canonicalize_run(
+    run: &ReplayTraceRun,
+    allowlist: &[ReplayAllowlistRule],
+) -> Result<JsonValue, ReplayOracleError> {
+    let mut value = serde_json::to_value(run)
+        .map_err(|error| ReplayOracleError::Serialization(error.to_string()))?;
+    for rule in allowlist {
+        apply_allowlist_rule(&mut value, rule)?;
+    }
+    Ok(value)
+}
+
+pub fn first_divergence(left: &JsonValue, right: &JsonValue) -> Option<ReplayDivergence> {
+    first_divergence_at(left, right, String::new())
+}
+
+fn validate_trace(trace: &ReplayOracleTrace) -> Result<(), ReplayOracleError> {
+    if trace.schema_version != REPLAY_TRACE_SCHEMA_VERSION {
+        return Err(ReplayOracleError::InvalidTrace(format!(
+            "unsupported replay trace schema_version {:?}; expected {REPLAY_TRACE_SCHEMA_VERSION}",
+            trace.schema_version
+        )));
+    }
+    if trace.name.trim().is_empty() {
+        return Err(ReplayOracleError::InvalidTrace(
+            "replay trace name cannot be empty".to_string(),
+        ));
+    }
+    if trace.first_run.run_id.trim().is_empty() || trace.second_run.run_id.trim().is_empty() {
+        return Err(ReplayOracleError::InvalidTrace(format!(
+            "{} must include run ids for both replay executions",
+            trace.name
+        )));
+    }
+    if trace_material_count(&trace.first_run) == 0 || trace_material_count(&trace.second_run) == 0 {
+        return Err(ReplayOracleError::InvalidTrace(format!(
+            "{} must include replay trace material for both executions",
+            trace.name
+        )));
+    }
+    for rule in &trace.allowlist {
+        if rule.path.trim().is_empty() {
+            return Err(ReplayOracleError::InvalidAllowlistPath(
+                "allowlist path cannot be empty".to_string(),
+            ));
+        }
+        if rule.reason.trim().is_empty() {
+            return Err(ReplayOracleError::InvalidAllowlistPath(format!(
+                "allowlist path {} must explain why the field is nondeterministic",
+                rule.path
+            )));
+        }
+        parse_pointer_path(&rule.path)?;
+    }
+    Ok(())
+}
+
+fn trace_material_count(run: &ReplayTraceRun) -> usize {
+    let counts = run.counts();
+    counts.event_log_entries
+        + counts.trigger_firings
+        + counts.llm_interactions
+        + counts.protocol_interactions
+        + counts.approval_interactions
+        + counts.effect_receipts
+        + counts.agent_transcript_deltas
+        + counts.final_artifacts
+        + counts.policy_decisions
+}
+
+fn apply_allowlist_rule(
+    value: &mut JsonValue,
+    rule: &ReplayAllowlistRule,
+) -> Result<(), ReplayOracleError> {
+    let segments = parse_pointer_path(&rule.path)?;
+    let replacement = rule.replacement.clone().unwrap_or_else(|| {
+        json!({
+            "$harn_replay_allowlisted": rule.path,
+        })
+    });
+    let replaced = replace_matching_paths(value, &segments, &replacement);
+    if replaced == 0 {
+        return Err(ReplayOracleError::AllowlistPathMissing(format!(
+            "allowlist path {} did not match any replay field",
+            rule.path
+        )));
+    }
+    Ok(())
+}
+
+fn parse_pointer_path(path: &str) -> Result<Vec<String>, ReplayOracleError> {
+    if path == "/" {
+        return Err(ReplayOracleError::InvalidAllowlistPath(
+            "allowlist path cannot replace the whole run".to_string(),
+        ));
+    }
+    if !path.starts_with('/') {
+        return Err(ReplayOracleError::InvalidAllowlistPath(format!(
+            "allowlist path {path:?} must start with '/'"
+        )));
+    }
+    path.split('/')
+        .skip(1)
+        .map(|segment| {
+            if segment.is_empty() {
+                return Err(ReplayOracleError::InvalidAllowlistPath(format!(
+                    "allowlist path {path:?} contains an empty segment"
+                )));
+            }
+            Ok(segment.replace("~1", "/").replace("~0", "~"))
+        })
+        .collect()
+}
+
+fn replace_matching_paths(
+    value: &mut JsonValue,
+    segments: &[String],
+    replacement: &JsonValue,
+) -> usize {
+    if segments.is_empty() {
+        *value = replacement.clone();
+        return 1;
+    }
+
+    let head = segments[0].as_str();
+    let tail = &segments[1..];
+    if head == "*" {
+        return match value {
+            JsonValue::Array(items) => items
+                .iter_mut()
+                .map(|item| replace_matching_paths(item, tail, replacement))
+                .sum(),
+            JsonValue::Object(map) => map
+                .values_mut()
+                .map(|item| replace_matching_paths(item, tail, replacement))
+                .sum(),
+            _ => 0,
+        };
+    }
+
+    match value {
+        JsonValue::Object(map) => map
+            .get_mut(head)
+            .map(|child| replace_matching_paths(child, tail, replacement))
+            .unwrap_or(0),
+        JsonValue::Array(items) => head
+            .parse::<usize>()
+            .ok()
+            .and_then(|index| items.get_mut(index))
+            .map(|child| replace_matching_paths(child, tail, replacement))
+            .unwrap_or(0),
+        _ => 0,
+    }
+}
+
+fn first_divergence_at(
+    left: &JsonValue,
+    right: &JsonValue,
+    path: String,
+) -> Option<ReplayDivergence> {
+    if left == right {
+        return None;
+    }
+    match (left, right) {
+        (JsonValue::Object(left_map), JsonValue::Object(right_map)) => {
+            let keys = left_map
+                .keys()
+                .chain(right_map.keys())
+                .cloned()
+                .collect::<BTreeSet<_>>();
+            for key in keys {
+                let next_path = pointer_child(&path, &key);
+                match (left_map.get(&key), right_map.get(&key)) {
+                    (Some(left_child), Some(right_child)) => {
+                        if let Some(divergence) =
+                            first_divergence_at(left_child, right_child, next_path)
+                        {
+                            return Some(divergence);
+                        }
+                    }
+                    (Some(left_child), None) => {
+                        return Some(divergence(
+                            next_path,
+                            left_child.clone(),
+                            JsonValue::Null,
+                            "right run is missing this field",
+                        ));
+                    }
+                    (None, Some(right_child)) => {
+                        return Some(divergence(
+                            next_path,
+                            JsonValue::Null,
+                            right_child.clone(),
+                            "left run is missing this field",
+                        ));
+                    }
+                    (None, None) => {}
+                }
+            }
+            Some(divergence(
+                display_path(&path),
+                left.clone(),
+                right.clone(),
+                "objects differ",
+            ))
+        }
+        (JsonValue::Array(left_items), JsonValue::Array(right_items)) => {
+            for index in 0..left_items.len().max(right_items.len()) {
+                let next_path = pointer_child(&path, &index.to_string());
+                match (left_items.get(index), right_items.get(index)) {
+                    (Some(left_child), Some(right_child)) => {
+                        if let Some(divergence) =
+                            first_divergence_at(left_child, right_child, next_path)
+                        {
+                            return Some(divergence);
+                        }
+                    }
+                    (Some(left_child), None) => {
+                        return Some(divergence(
+                            next_path,
+                            left_child.clone(),
+                            JsonValue::Null,
+                            "right run is missing this array element",
+                        ));
+                    }
+                    (None, Some(right_child)) => {
+                        return Some(divergence(
+                            next_path,
+                            JsonValue::Null,
+                            right_child.clone(),
+                            "left run is missing this array element",
+                        ));
+                    }
+                    (None, None) => {}
+                }
+            }
+            Some(divergence(
+                display_path(&path),
+                left.clone(),
+                right.clone(),
+                "arrays differ",
+            ))
+        }
+        _ => Some(divergence(
+            display_path(&path),
+            left.clone(),
+            right.clone(),
+            "values differ",
+        )),
+    }
+}
+
+fn pointer_child(parent: &str, child: &str) -> String {
+    let escaped = child.replace('~', "~0").replace('/', "~1");
+    if parent.is_empty() {
+        format!("/{escaped}")
+    } else {
+        format!("{parent}/{escaped}")
+    }
+}
+
+fn display_path(path: &str) -> String {
+    if path.is_empty() {
+        "/".to_string()
+    } else {
+        path.to_string()
+    }
+}
+
+fn divergence(
+    path: String,
+    left: JsonValue,
+    right: JsonValue,
+    message: impl Into<String>,
+) -> ReplayDivergence {
+    ReplayDivergence {
+        path,
+        left,
+        right,
+        message: message.into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base_trace() -> ReplayOracleTrace {
+        ReplayOracleTrace {
+            name: "fixture".to_string(),
+            allowlist: vec![
+                ReplayAllowlistRule {
+                    path: "/run_id".to_string(),
+                    reason: "run ids are allocated per execution".to_string(),
+                    replacement: Some(JsonValue::String("<run-id>".to_string())),
+                },
+                ReplayAllowlistRule {
+                    path: "/event_log_entries/*/event_id".to_string(),
+                    reason: "event log offsets are backend-local".to_string(),
+                    replacement: Some(JsonValue::String("<event-id>".to_string())),
+                },
+                ReplayAllowlistRule {
+                    path: "/event_log_entries/*/occurred_at_ms".to_string(),
+                    reason: "append timestamps are wall-clock observations".to_string(),
+                    replacement: Some(JsonValue::String("<timestamp-ms>".to_string())),
+                },
+            ],
+            first_run: ReplayTraceRun {
+                run_id: "run-a".to_string(),
+                event_log_entries: vec![json!({
+                    "event_id": 10,
+                    "topic": "trigger.outbox",
+                    "kind": "dispatch_succeeded",
+                    "occurred_at_ms": 1000,
+                    "payload": {"binding_id": "demo", "status": "dispatched"}
+                })],
+                ..ReplayTraceRun::default()
+            },
+            second_run: ReplayTraceRun {
+                run_id: "run-b".to_string(),
+                event_log_entries: vec![json!({
+                    "event_id": 42,
+                    "topic": "trigger.outbox",
+                    "kind": "dispatch_succeeded",
+                    "occurred_at_ms": 2000,
+                    "payload": {"binding_id": "demo", "status": "dispatched"}
+                })],
+                ..ReplayTraceRun::default()
+            },
+            ..ReplayOracleTrace::default()
+        }
+    }
+
+    #[test]
+    fn canonical_comparison_allows_explicit_nondeterministic_fields() {
+        let report = run_replay_oracle_trace(&base_trace()).expect("oracle succeeds");
+        assert!(report.passed, "{report:?}");
+        assert_eq!(report.divergence, None);
+    }
+
+    #[test]
+    fn meaningful_drift_reports_first_divergent_path() {
+        let mut trace = base_trace();
+        trace.second_run.event_log_entries[0]["payload"]["status"] = json!("dlq");
+
+        let report = run_replay_oracle_trace(&trace).expect("oracle succeeds");
+
+        assert!(!report.passed);
+        let divergence = report.divergence.expect("drift is reported");
+        assert_eq!(divergence.path, "/event_log_entries/0/payload/status");
+        assert_eq!(divergence.left, json!("dispatched"));
+        assert_eq!(divergence.right, json!("dlq"));
+    }
+
+    #[test]
+    fn expected_drift_fixture_passes_only_when_drift_is_detected() {
+        let mut trace = base_trace();
+        trace.expect = ReplayExpectation::Drift;
+        trace.second_run.event_log_entries[0]["payload"]["status"] = json!("dlq");
+
+        let report = run_replay_oracle_trace(&trace).expect("oracle succeeds");
+
+        assert!(report.passed);
+        assert!(report.divergence.is_some());
+    }
+
+    #[test]
+    fn allowlist_paths_must_match_real_fields() {
+        let mut trace = base_trace();
+        trace.allowlist.push(ReplayAllowlistRule {
+            path: "/llm_interactions/*/latency_ms".to_string(),
+            reason: "latency is nondeterministic".to_string(),
+            replacement: None,
+        });
+
+        let error = run_replay_oracle_trace(&trace).expect_err("missing path should fail");
+
+        assert!(matches!(error, ReplayOracleError::AllowlistPathMissing(_)));
+    }
+}

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -843,6 +843,9 @@ harn orchestrator fire <trigger-id> --payload event.json
 # Replay a historical event through the dispatcher.
 harn orchestrator replay <event-id>
 
+# Run replay determinism oracle fixtures.
+harn orchestrator replay-oracle
+
 # Inspect the dead-letter queue.
 harn orchestrator dlq list
 harn orchestrator dlq --replay <event-id>

--- a/docs/src/orchestrator.md
+++ b/docs/src/orchestrator.md
@@ -161,6 +161,34 @@ Recovery reuses the normal `trigger_replay(...)` path, so replayed
 envelopes still flow through the dispatcher's retry policy and DLQ
 handling instead of using a special bypass path.
 
+## Replay Oracle
+
+Use `replay-oracle` to validate checked-in end-to-end replay determinism
+fixtures:
+
+```bash
+harn orchestrator replay-oracle
+```
+
+The oracle reads `conformance/replay-oracle/fixtures` by default. Each fixture
+contains two observed runs for the same logical orchestration trace and compares
+canonicalized EventLog entries, trigger firings, LLM cache material,
+MCP/ACP/A2A interactions, HITL approvals, effect receipts, agent transcript
+deltas, final artifacts, and policy decisions. Fixtures must name
+nondeterministic fields explicitly in `allowlist`; timestamps, generated ids,
+latency, and provider token accounting are not ignored unless the fixture says
+why.
+
+To run one fixture or subtree:
+
+```bash
+harn orchestrator replay-oracle conformance/replay-oracle/fixtures/approval_tool_call.valid.json
+```
+
+On meaningful drift the command exits non-zero and prints the first divergent
+canonical path with left/right values. `make replay-oracle` runs the default
+fixture set and is included in `make all`.
+
 ## HTTP Listener
 
 The orchestrator listener assembles routes from `[[triggers]]` entries


### PR DESCRIPTION
## Summary

Closes #1370.

Adds a reusable `harn.orchestration.replay_trace.v1` trace format and replay oracle comparator that canonicalizes two recorded orchestration executions, applies explicit nondeterminism allowlists, and reports the first meaningful divergence.

Adds `harn orchestrator replay-oracle` plus `make replay-oracle`, checked-in oracle fixtures for the requested trigger, LLM predicate, HITL/tool, worker/A2A, and retry/DLQ paths, and a mutation fixture that proves drift fails loudly.

Documents the command and fixture format in the orchestrator docs and replay oracle README.

## Verification

- `HARN_LLM_CALLS_DISABLED=1 cargo check -p harn-vm -p harn-cli`
- `HARN_LLM_CALLS_DISABLED=1 cargo test -p harn-vm replay_oracle`
- `HARN_LLM_CALLS_DISABLED=1 cargo test -p harn-cli replay_oracle`
- `HARN_LLM_CALLS_DISABLED=1 make replay-oracle`
- `HARN_LLM_CALLS_DISABLED=1 cargo run --bin harn -- orchestrator replay-oracle conformance/replay-oracle/mutations/meaningful_drift.invalid.json` exits non-zero with `/event_log_entries/0/payload/result/status`
- `HARN_LLM_CALLS_DISABLED=1 cargo run --bin harn -- test protocols acp/session_request_permission.valid.json`
- `HARN_LLM_CALLS_DISABLED=1 cargo run --bin harn -- test protocols a2a/task_and_stream.valid.json`
- `HARN_LLM_CALLS_DISABLED=1 cargo run --bin harn -- test protocols mcp/tools_resources_prompts.valid.json`
- pre-commit hook: rustfmt, clippy workspace, CI ratchets, highlight sync, markdown, actionlint
- pre-push hook: targeted local checks, markdown, actionlint, highlight drift