### PR TITLE
Make package and listener tests hermetic

### DIFF
--- a/crates/harn-cli/src/commands/orchestrator/listener/acp_hub.rs
+++ b/crates/harn-cli/src/commands/orchestrator/listener/acp_hub.rs
@@ -21,7 +21,7 @@ const ACP_TOPIC_PREFIX: &str = "acp.session";
 const ACP_PING_INTERVAL: Duration = Duration::from_secs(30);
 const ACP_PONG_TIMEOUT: Duration = Duration::from_secs(10);
 pub(super) const ACP_RETAINED_SESSION_SECS_ENV: &str = "HARN_ACP_WS_RETAIN_SECS";
-const ACP_DEFAULT_RETAINED_SESSION_SECS: u64 = 5 * 60;
+pub(super) const ACP_DEFAULT_RETAINED_SESSION_SECS: u64 = 5 * 60;
 const ACP_REPLAY_BUFFER_LIMIT: usize = 4096;
 
 #[derive(Clone)]

--- a/crates/harn-cli/src/commands/orchestrator/listener/core.rs
+++ b/crates/harn-cli/src/commands/orchestrator/listener/core.rs
@@ -19,8 +19,8 @@ use super::acp_hub::{
 };
 use super::admin::{admin_reload_endpoint, AdminReloadHandle, AdminReloadState, ADMIN_RELOAD_PATH};
 use super::routes::{
-    ingest_trigger, test_file_from_env, ListenerAuth, RouteConfig, RouteRegistry, TestRequestGate,
-    TriggerMetricSnapshot, PENDING_TOPIC,
+    ingest_trigger, test_file_from_env, IngestBackpressureConfig, ListenerAuth, ListenerAuthConfig,
+    RouteConfig, RouteRegistry, TestRequestGate, TriggerMetricSnapshot, PENDING_TOPIC,
 };
 use crate::commands::orchestrator::errors::OrchestratorError;
 use crate::commands::orchestrator::origin_guard::{enforce_allowed_origin, OriginAllowList};
@@ -49,6 +49,67 @@ pub(crate) struct ListenerConfig {
 impl ListenerConfig {
     pub(crate) fn max_body_bytes_or_default(max_body_bytes: Option<usize>) -> usize {
         max_body_bytes.unwrap_or(DEFAULT_MAX_BODY_BYTES)
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct ListenerRuntimeEnv {
+    auth: ListenerAuthConfig,
+    request_gate: TestRequestGate,
+    acp_retained_session_duration: Duration,
+    ingest_backpressure: IngestBackpressureConfig,
+}
+
+impl ListenerRuntimeEnv {
+    pub(crate) fn from_env() -> Self {
+        Self {
+            auth: ListenerAuthConfig::from_env(),
+            request_gate: TestRequestGate {
+                entered_file: test_file_from_env(REQUEST_ENTERED_FILE_ENV),
+                release_file: test_file_from_env(REQUEST_RELEASE_FILE_ENV),
+            },
+            acp_retained_session_duration: acp_retained_session_duration_from_env(),
+            ingest_backpressure: IngestBackpressureConfig::from_env(),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn for_test() -> Self {
+        Self {
+            auth: ListenerAuthConfig::default(),
+            request_gate: TestRequestGate::default(),
+            acp_retained_session_duration: Duration::from_secs(
+                super::acp_hub::ACP_DEFAULT_RETAINED_SESSION_SECS,
+            ),
+            ingest_backpressure: IngestBackpressureConfig::default(),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_api_key(mut self, api_key: impl Into<String>) -> Self {
+        self.auth = self.auth.with_api_key(api_key);
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_request_gate(mut self, request_gate: TestRequestGate) -> Self {
+        self.request_gate = request_gate;
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_acp_retained_session_duration(mut self, duration: Duration) -> Self {
+        self.acp_retained_session_duration = duration;
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_ingest_backpressure(
+        mut self,
+        ingest_backpressure: IngestBackpressureConfig,
+    ) -> Self {
+        self.ingest_backpressure = ingest_backpressure;
+        self
     }
 }
 
@@ -81,6 +142,13 @@ impl ListenerReadiness {
 
 impl ListenerRuntime {
     pub(crate) async fn start(config: ListenerConfig) -> Result<Self, OrchestratorError> {
+        Self::start_with_env(config, ListenerRuntimeEnv::from_env()).await
+    }
+
+    pub(crate) async fn start_with_env(
+        config: ListenerConfig,
+        runtime_env: ListenerRuntimeEnv,
+    ) -> Result<Self, OrchestratorError> {
         let pending_topic =
             Topic::new(PENDING_TOPIC).map_err(|error| format!("invalid pending topic: {error}"))?;
         let inbox_metrics = Arc::new(harn_vm::MetricsRegistry::default());
@@ -93,14 +161,12 @@ impl ListenerRuntime {
             .routes
             .iter()
             .any(|route| route.auth_mode.requires_credentials());
-        let auth = Arc::new(ListenerAuth::from_env(
+        let auth = Arc::new(ListenerAuth::from_config(
             requires_auth,
             config.session_store.clone(),
+            runtime_env.auth.clone(),
         )?);
-        let request_gate = TestRequestGate {
-            entered_file: test_file_from_env(REQUEST_ENTERED_FILE_ENV),
-            release_file: test_file_from_env(REQUEST_RELEASE_FILE_ENV),
-        };
+        let request_gate = runtime_env.request_gate.clone();
         let origin_state = Arc::new(config.allowed_origins.clone());
         let admin_state = config.admin_reload.clone().map(|reload| {
             Arc::new(AdminReloadState {
@@ -111,7 +177,7 @@ impl ListenerRuntime {
         });
         let acp_hub = AcpWebSocketHub::new(
             config.event_log.clone(),
-            acp_retained_session_duration_from_env(),
+            runtime_env.acp_retained_session_duration,
         );
         let acp_hub_sweeper = acp_hub.clone();
         tokio::spawn(async move {
@@ -131,6 +197,7 @@ impl ListenerRuntime {
             config.metrics_registry.clone(),
             auth.clone(),
             pending_topic.clone(),
+            runtime_env.ingest_backpressure,
             request_gate,
             config.tenant_store.clone(),
         )?);

--- a/crates/harn-cli/src/commands/orchestrator/listener/mod.rs
+++ b/crates/harn-cli/src/commands/orchestrator/listener/mod.rs
@@ -4,10 +4,13 @@ mod core;
 mod routes;
 
 pub(crate) use admin::{AdminReloadHandle, AdminReloadRequest};
+#[cfg(test)]
+pub(crate) use core::ListenerRuntimeEnv;
 pub(crate) use core::{ListenerConfig, ListenerRuntime};
 #[allow(unused_imports)]
 pub(crate) use routes::{
-    AuthMode, ListenerAuth, RouteConfig, SignatureMode, TriggerMetricSnapshot,
+    AuthMode, IngestBackpressureConfig, ListenerAuth, ListenerAuthConfig, RouteConfig,
+    SignatureMode, TestRequestGate, TriggerMetricSnapshot,
 };
 
 #[cfg(test)]

--- a/crates/harn-cli/src/commands/orchestrator/listener/routes.rs
+++ b/crates/harn-cli/src/commands/orchestrator/listener/routes.rs
@@ -203,9 +203,9 @@ struct TenantRequestScope {
 }
 
 #[derive(Clone, Default)]
-pub(super) struct TestRequestGate {
-    pub(super) entered_file: Option<PathBuf>,
-    pub(super) release_file: Option<PathBuf>,
+pub(crate) struct TestRequestGate {
+    pub(crate) entered_file: Option<PathBuf>,
+    pub(crate) release_file: Option<PathBuf>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -244,13 +244,14 @@ impl RouteRegistry {
         metrics_registry: Arc<harn_vm::MetricsRegistry>,
         auth: Arc<ListenerAuth>,
         pending_topic: Topic,
+        ingest_backpressure: IngestBackpressureConfig,
         request_gate: TestRequestGate,
         tenant_store: Option<Arc<harn_vm::TenantStore>>,
     ) -> Result<Self, OrchestratorError> {
         let registry = Self {
             routes_by_path: RwLock::new(BTreeMap::new()),
             metrics_by_trigger_id: Mutex::new(BTreeMap::new()),
-            ingest_backpressure: IngestBackpressure::from_env(),
+            ingest_backpressure: IngestBackpressure::new(ingest_backpressure),
             event_log,
             inbox,
             secrets,
@@ -355,10 +356,10 @@ struct IngestBackpressure {
 }
 
 #[derive(Clone, Copy, Debug)]
-struct IngestBackpressureConfig {
-    global_capacity: u32,
-    per_source_capacity: u32,
-    refill_per_sec: u32,
+pub(crate) struct IngestBackpressureConfig {
+    pub(crate) global_capacity: u32,
+    pub(crate) per_source_capacity: u32,
+    pub(crate) refill_per_sec: u32,
 }
 
 #[derive(Debug)]
@@ -374,21 +375,6 @@ struct IngestBucket {
 }
 
 impl IngestBackpressure {
-    fn from_env() -> Self {
-        let config = IngestBackpressureConfig {
-            global_capacity: read_u32_env(
-                INGEST_GLOBAL_CAPACITY_ENV,
-                DEFAULT_INGEST_GLOBAL_CAPACITY,
-            ),
-            per_source_capacity: read_u32_env(
-                INGEST_PER_SOURCE_CAPACITY_ENV,
-                DEFAULT_INGEST_PER_SOURCE_CAPACITY,
-            ),
-            refill_per_sec: read_u32_env(INGEST_REFILL_PER_SEC_ENV, DEFAULT_INGEST_REFILL_PER_SEC),
-        };
-        Self::new(config)
-    }
-
     fn new(config: IngestBackpressureConfig) -> Self {
         let config = IngestBackpressureConfig {
             global_capacity: config.global_capacity.max(1),
@@ -448,6 +434,32 @@ impl IngestBackpressure {
                 state.global.retry_after(self.config.refill_per_sec),
                 source_retry_after,
             ))
+        }
+    }
+}
+
+impl Default for IngestBackpressureConfig {
+    fn default() -> Self {
+        Self {
+            global_capacity: DEFAULT_INGEST_GLOBAL_CAPACITY,
+            per_source_capacity: DEFAULT_INGEST_PER_SOURCE_CAPACITY,
+            refill_per_sec: DEFAULT_INGEST_REFILL_PER_SEC,
+        }
+    }
+}
+
+impl IngestBackpressureConfig {
+    pub(crate) fn from_env() -> Self {
+        Self {
+            global_capacity: read_u32_env(
+                INGEST_GLOBAL_CAPACITY_ENV,
+                DEFAULT_INGEST_GLOBAL_CAPACITY,
+            ),
+            per_source_capacity: read_u32_env(
+                INGEST_PER_SOURCE_CAPACITY_ENV,
+                DEFAULT_INGEST_PER_SOURCE_CAPACITY,
+            ),
+            refill_per_sec: read_u32_env(INGEST_REFILL_PER_SEC_ENV, DEFAULT_INGEST_REFILL_PER_SEC),
         }
     }
 }
@@ -985,18 +997,14 @@ fn parse_secret_id(raw: Option<&str>) -> Option<SecretId> {
     Some(SecretId::new(namespace, name).with_version(version))
 }
 
-#[derive(Clone, Default)]
-pub(crate) struct ListenerAuth {
+#[derive(Clone, Debug, Default)]
+pub(crate) struct ListenerAuthConfig {
     api_keys: Vec<String>,
     hmac_secret: Option<String>,
-    session_store: Option<Arc<harn_vm::SessionStore>>,
 }
 
-impl ListenerAuth {
-    pub(crate) fn from_env(
-        required: bool,
-        session_store: Option<Arc<harn_vm::SessionStore>>,
-    ) -> Result<Self, OrchestratorError> {
+impl ListenerAuthConfig {
+    pub(crate) fn from_env() -> Self {
         let api_keys = std::env::var(API_KEYS_ENV)
             .ok()
             .map(|value| {
@@ -1012,13 +1020,45 @@ impl ListenerAuth {
             .ok()
             .map(|value| value.trim().to_string())
             .filter(|value| !value.is_empty());
+        Self {
+            api_keys,
+            hmac_secret,
+        }
+    }
 
-        if required && api_keys.is_empty() && session_store.is_none() {
+    #[cfg(test)]
+    pub(crate) fn with_api_key(mut self, api_key: impl Into<String>) -> Self {
+        self.api_keys.push(api_key.into());
+        self
+    }
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct ListenerAuth {
+    api_keys: Vec<String>,
+    hmac_secret: Option<String>,
+    session_store: Option<Arc<harn_vm::SessionStore>>,
+}
+
+impl ListenerAuth {
+    pub(crate) fn from_env(
+        required: bool,
+        session_store: Option<Arc<harn_vm::SessionStore>>,
+    ) -> Result<Self, OrchestratorError> {
+        Self::from_config(required, session_store, ListenerAuthConfig::from_env())
+    }
+
+    pub(crate) fn from_config(
+        required: bool,
+        session_store: Option<Arc<harn_vm::SessionStore>>,
+        config: ListenerAuthConfig,
+    ) -> Result<Self, OrchestratorError> {
+        if required && config.api_keys.is_empty() && session_store.is_none() {
             return Err(format!(
                 "{API_KEYS_ENV} must contain at least one API key or a session store must be configured when authenticated routes are configured"
             ).into());
         }
-        if required && hmac_secret.is_none() && session_store.is_none() {
+        if required && config.hmac_secret.is_none() && session_store.is_none() {
             return Err(format!(
                 "{HMAC_SECRET_ENV} must be set or a session store must be configured when authenticated routes are configured"
             )
@@ -1026,8 +1066,8 @@ impl ListenerAuth {
         }
 
         Ok(Self {
-            api_keys,
-            hmac_secret,
+            api_keys: config.api_keys,
+            hmac_secret: config.hmac_secret,
             session_store,
         })
     }

--- a/crates/harn-cli/src/commands/orchestrator/listener/tests.rs
+++ b/crates/harn-cli/src/commands/orchestrator/listener/tests.rs
@@ -7,12 +7,9 @@ use axum::http::{header, StatusCode};
 use futures::{SinkExt, StreamExt};
 use serde_json::{json, Value as JsonValue};
 
-use super::acp_hub::{ACP_PATH, ACP_RETAINED_SESSION_SECS_ENV};
-use super::core::{DEFAULT_MAX_BODY_BYTES, REQUEST_ENTERED_FILE_ENV, REQUEST_RELEASE_FILE_ENV};
-use super::routes::{
-    wait_for_test_release_file, API_KEYS_ENV, HMAC_SECRET_ENV, INGEST_GLOBAL_CAPACITY_ENV,
-    INGEST_PER_SOURCE_CAPACITY_ENV, INGEST_REFILL_PER_SEC_ENV, PENDING_TOPIC,
-};
+use super::acp_hub::ACP_PATH;
+use super::core::DEFAULT_MAX_BODY_BYTES;
+use super::routes::{wait_for_test_release_file, PENDING_TOPIC};
 use harn_vm::event_log::{
     install_default_for_base_dir, reset_active_event_log, AnyEventLog, EventLog, Topic,
 };
@@ -297,24 +294,33 @@ async fn send_acp_response(
 }
 
 async fn start_acp_test_listener() -> (ListenerRuntime, Arc<AnyEventLog>, TempDir) {
+    start_acp_test_listener_with_env(ListenerRuntimeEnv::for_test()).await
+}
+
+async fn start_acp_test_listener_with_env(
+    runtime_env: ListenerRuntimeEnv,
+) -> (ListenerRuntime, Arc<AnyEventLog>, TempDir) {
     let dir = tempdir().expect("tempdir");
     let log = install_default_for_base_dir(dir.path()).expect("install event log");
-    let listener = ListenerRuntime::start(ListenerConfig {
-        bind: "127.0.0.1:0".parse().expect("bind addr"),
-        tls: None,
-        event_log: log.clone(),
-        secrets: Arc::new(harn_vm::secrets::EnvSecretProvider::new(
-            "harn/listener-test",
-        )),
-        allowed_origins: OriginAllowList::wildcard(),
-        max_body_bytes: DEFAULT_MAX_BODY_BYTES,
-        metrics_registry: Arc::new(harn_vm::MetricsRegistry::default()),
-        admin_reload: None,
-        mcp_router: None,
-        routes: Vec::new(),
-        tenant_store: None,
-        session_store: None,
-    })
+    let listener = ListenerRuntime::start_with_env(
+        ListenerConfig {
+            bind: "127.0.0.1:0".parse().expect("bind addr"),
+            tls: None,
+            event_log: log.clone(),
+            secrets: Arc::new(harn_vm::secrets::EnvSecretProvider::new(
+                "harn/listener-test",
+            )),
+            allowed_origins: OriginAllowList::wildcard(),
+            max_body_bytes: DEFAULT_MAX_BODY_BYTES,
+            metrics_registry: Arc::new(harn_vm::MetricsRegistry::default()),
+            admin_reload: None,
+            mcp_router: None,
+            routes: Vec::new(),
+            tenant_store: None,
+            session_store: None,
+        },
+        runtime_env,
+    )
     .await
     .expect("start listener");
     (listener, log, dir)
@@ -378,8 +384,6 @@ async fn readyz_tracks_listener_readiness_gate() {
 #[tokio::test(flavor = "current_thread")]
 async fn listener_auth_accepts_durable_session_bearer() {
     let _guard = lock_harn_state();
-    std::env::remove_var(API_KEYS_ENV);
-    std::env::remove_var(HMAC_SECRET_ENV);
     let session_id = "harn_sess_listener_abcdefghijklmnopqrstuvwxyz0123456789";
     let log = Arc::new(AnyEventLog::Memory(
         harn_vm::event_log::MemoryEventLog::new(32),
@@ -402,8 +406,12 @@ async fn listener_auth_accepts_durable_session_bearer() {
         .await
         .expect("create durable session");
 
-    let auth =
-        ListenerAuth::from_env(true, Some(session_store.clone())).expect("session auth config");
+    let auth = ListenerAuth::from_config(
+        true,
+        Some(session_store.clone()),
+        ListenerAuthConfig::default(),
+    )
+    .expect("session auth config");
     assert!(auth.has_credentials());
     let mut headers = BTreeMap::new();
     headers.insert("authorization".to_string(), format!("Bearer {session_id}"));
@@ -417,18 +425,17 @@ async fn listener_auth_accepts_durable_session_bearer() {
         .expect("get touched session")
         .expect("session remains active");
     assert!(touched.last_seen_at > created_at);
-    std::env::remove_var(API_KEYS_ENV);
-    std::env::remove_var(HMAC_SECRET_ENV);
 }
 
 #[tokio::test(flavor = "current_thread")]
 async fn acp_websocket_requires_configured_bearer_auth() {
     let _guard = lock_harn_state();
     reset_active_event_log();
-    std::env::set_var(API_KEYS_ENV, "ws-test-key");
-    std::env::remove_var(HMAC_SECRET_ENV);
 
-    let (listener, _log, _dir) = start_acp_test_listener().await;
+    let (listener, _log, _dir) = start_acp_test_listener_with_env(
+        ListenerRuntimeEnv::for_test().with_api_key("ws-test-key"),
+    )
+    .await;
 
     let unauthorized =
         tokio_tungstenite::connect_async(format!("ws://{}{}", listener.local_addr(), ACP_PATH))
@@ -466,7 +473,6 @@ async fn acp_websocket_requires_configured_bearer_auth() {
         .shutdown(Duration::from_secs(5))
         .await
         .expect("shutdown listener");
-    std::env::remove_var(API_KEYS_ENV);
     reset_active_event_log();
 }
 
@@ -474,10 +480,11 @@ async fn acp_websocket_requires_configured_bearer_auth() {
 async fn acp_websocket_parallel_clients_get_distinct_sessions_and_can_load_active_session() {
     let _guard = lock_harn_state();
     reset_active_event_log();
-    std::env::set_var(API_KEYS_ENV, "ws-test-key");
-    std::env::remove_var(HMAC_SECRET_ENV);
 
-    let (listener, _log, _dir) = start_acp_test_listener().await;
+    let (listener, _log, _dir) = start_acp_test_listener_with_env(
+        ListenerRuntimeEnv::for_test().with_api_key("ws-test-key"),
+    )
+    .await;
 
     let (first, second) = tokio::join!(
         new_acp_session(listener.local_addr()),
@@ -521,7 +528,6 @@ async fn acp_websocket_parallel_clients_get_distinct_sessions_and_can_load_activ
         .shutdown(Duration::from_secs(5))
         .await
         .expect("shutdown listener");
-    std::env::remove_var(API_KEYS_ENV);
     reset_active_event_log();
 }
 
@@ -529,10 +535,11 @@ async fn acp_websocket_parallel_clients_get_distinct_sessions_and_can_load_activ
 async fn acp_websocket_rejects_duplicate_attach_to_live_session() {
     let _guard = lock_harn_state();
     reset_active_event_log();
-    std::env::set_var(API_KEYS_ENV, "ws-test-key");
-    std::env::remove_var(HMAC_SECRET_ENV);
 
-    let (listener, _log, _dir) = start_acp_test_listener().await;
+    let (listener, _log, _dir) = start_acp_test_listener_with_env(
+        ListenerRuntimeEnv::for_test().with_api_key("ws-test-key"),
+    )
+    .await;
     let (mut first_socket, _) =
         tokio_tungstenite::connect_async(authorized_acp_request(listener.local_addr()))
             .await
@@ -560,7 +567,6 @@ async fn acp_websocket_rejects_duplicate_attach_to_live_session() {
         .shutdown(Duration::from_secs(5))
         .await
         .expect("shutdown listener");
-    std::env::remove_var(API_KEYS_ENV);
     reset_active_event_log();
 }
 
@@ -568,10 +574,11 @@ async fn acp_websocket_rejects_duplicate_attach_to_live_session() {
 async fn acp_websocket_reconnect_replays_pending_host_request_and_completes_prompt() {
     let _guard = lock_harn_state();
     reset_active_event_log();
-    std::env::set_var(API_KEYS_ENV, "ws-test-key");
-    std::env::remove_var(HMAC_SECRET_ENV);
 
-    let (listener, _log, _dir) = start_acp_test_listener().await;
+    let (listener, _log, _dir) = start_acp_test_listener_with_env(
+        ListenerRuntimeEnv::for_test().with_api_key("ws-test-key"),
+    )
+    .await;
     let (mut socket, _) =
         tokio_tungstenite::connect_async(authorized_acp_request(listener.local_addr()))
             .await
@@ -651,7 +658,6 @@ async fn acp_websocket_reconnect_replays_pending_host_request_and_completes_prom
         .shutdown(Duration::from_secs(5))
         .await
         .expect("shutdown listener");
-    std::env::remove_var(API_KEYS_ENV);
     reset_active_event_log();
 }
 
@@ -659,11 +665,13 @@ async fn acp_websocket_reconnect_replays_pending_host_request_and_completes_prom
 async fn acp_websocket_replays_serialized_events_after_worker_expiry() {
     let _guard = lock_harn_state();
     reset_active_event_log();
-    std::env::set_var(API_KEYS_ENV, "ws-test-key");
-    std::env::remove_var(HMAC_SECRET_ENV);
-    std::env::set_var(ACP_RETAINED_SESSION_SECS_ENV, "0");
 
-    let (listener, _log, _dir) = start_acp_test_listener().await;
+    let (listener, _log, _dir) = start_acp_test_listener_with_env(
+        ListenerRuntimeEnv::for_test()
+            .with_api_key("ws-test-key")
+            .with_acp_retained_session_duration(Duration::ZERO),
+    )
+    .await;
     let (mut socket, _) =
         tokio_tungstenite::connect_async(authorized_acp_request(listener.local_addr()))
             .await
@@ -719,8 +727,6 @@ async fn acp_websocket_replays_serialized_events_after_worker_expiry() {
         .shutdown(Duration::from_secs(5))
         .await
         .expect("shutdown listener");
-    std::env::remove_var(API_KEYS_ENV);
-    std::env::remove_var(ACP_RETAINED_SESSION_SECS_ENV);
     reset_active_event_log();
 }
 
@@ -739,24 +745,28 @@ async fn reload_swaps_routes_without_losing_inflight_request() {
 
     let request_entered_path = dir.path().join("request-entered");
     let request_release_path = dir.path().join("request-release");
-    std::env::set_var(REQUEST_ENTERED_FILE_ENV, &request_entered_path);
-    std::env::set_var(REQUEST_RELEASE_FILE_ENV, &request_release_path);
-    let listener = ListenerRuntime::start(ListenerConfig {
-        bind: "127.0.0.1:0".parse().expect("bind addr"),
-        tls: None,
-        event_log: log.clone(),
-        secrets: Arc::new(harn_vm::secrets::EnvSecretProvider::new(
-            "harn/listener-test",
-        )),
-        allowed_origins: OriginAllowList::wildcard(),
-        max_body_bytes: DEFAULT_MAX_BODY_BYTES,
-        metrics_registry: Arc::new(harn_vm::MetricsRegistry::default()),
-        admin_reload: None,
-        mcp_router: None,
-        routes: vec![route("/a2a/v1", 1)],
-        tenant_store: None,
-        session_store: None,
-    })
+    let listener = ListenerRuntime::start_with_env(
+        ListenerConfig {
+            bind: "127.0.0.1:0".parse().expect("bind addr"),
+            tls: None,
+            event_log: log.clone(),
+            secrets: Arc::new(harn_vm::secrets::EnvSecretProvider::new(
+                "harn/listener-test",
+            )),
+            allowed_origins: OriginAllowList::wildcard(),
+            max_body_bytes: DEFAULT_MAX_BODY_BYTES,
+            metrics_registry: Arc::new(harn_vm::MetricsRegistry::default()),
+            admin_reload: None,
+            mcp_router: None,
+            routes: vec![route("/a2a/v1", 1)],
+            tenant_store: None,
+            session_store: None,
+        },
+        ListenerRuntimeEnv::for_test().with_request_gate(TestRequestGate {
+            entered_file: Some(request_entered_path.clone()),
+            release_file: Some(request_release_path.clone()),
+        }),
+    )
     .await
     .expect("start listener");
 
@@ -846,8 +856,6 @@ async fn reload_swaps_routes_without_losing_inflight_request() {
         .shutdown(Duration::from_secs(5))
         .await
         .expect("shutdown listener");
-    std::env::remove_var(REQUEST_ENTERED_FILE_ENV);
-    std::env::remove_var(REQUEST_RELEASE_FILE_ENV);
     reset_active_event_log();
     harn_vm::clear_trigger_registry();
 }
@@ -858,23 +866,26 @@ async fn webhook_first_delivery_is_appended() {
     reset_active_event_log();
     let dir = tempdir().expect("tempdir");
     let log = install_default_for_base_dir(dir.path()).expect("install event log");
-    let listener = ListenerRuntime::start(ListenerConfig {
-        bind: "127.0.0.1:0".parse().expect("bind addr"),
-        tls: None,
-        event_log: log.clone(),
-        secrets: Arc::new(StaticSecretProvider {
-            secret_id: SecretId::new("github", "test-signing-secret"),
-            secret: "topsecret".to_string(),
-        }),
-        allowed_origins: OriginAllowList::wildcard(),
-        max_body_bytes: DEFAULT_MAX_BODY_BYTES,
-        metrics_registry: Arc::new(harn_vm::MetricsRegistry::default()),
-        admin_reload: None,
-        mcp_router: None,
-        routes: vec![webhook_route("/hooks/github")],
-        tenant_store: None,
-        session_store: None,
-    })
+    let listener = ListenerRuntime::start_with_env(
+        ListenerConfig {
+            bind: "127.0.0.1:0".parse().expect("bind addr"),
+            tls: None,
+            event_log: log.clone(),
+            secrets: Arc::new(StaticSecretProvider {
+                secret_id: SecretId::new("github", "test-signing-secret"),
+                secret: "topsecret".to_string(),
+            }),
+            allowed_origins: OriginAllowList::wildcard(),
+            max_body_bytes: DEFAULT_MAX_BODY_BYTES,
+            metrics_registry: Arc::new(harn_vm::MetricsRegistry::default()),
+            admin_reload: None,
+            mcp_router: None,
+            routes: vec![webhook_route("/hooks/github")],
+            tenant_store: None,
+            session_store: None,
+        },
+        ListenerRuntimeEnv::for_test(),
+    )
     .await
     .expect("start listener");
 
@@ -920,30 +931,34 @@ async fn webhook_first_delivery_is_appended() {
 async fn webhook_ingest_saturation_returns_retry_after() {
     let _guard = lock_harn_state();
     reset_active_event_log();
-    std::env::set_var(INGEST_PER_SOURCE_CAPACITY_ENV, "1");
-    std::env::set_var(INGEST_GLOBAL_CAPACITY_ENV, "100");
-    std::env::set_var(INGEST_REFILL_PER_SEC_ENV, "1");
 
     let dir = tempdir().expect("tempdir");
     let log = install_default_for_base_dir(dir.path()).expect("install event log");
     let metrics = Arc::new(harn_vm::MetricsRegistry::default());
-    let listener = ListenerRuntime::start(ListenerConfig {
-        bind: "127.0.0.1:0".parse().expect("bind addr"),
-        tls: None,
-        event_log: log.clone(),
-        secrets: Arc::new(StaticSecretProvider {
-            secret_id: SecretId::new("github", "test-signing-secret"),
-            secret: "topsecret".to_string(),
+    let listener = ListenerRuntime::start_with_env(
+        ListenerConfig {
+            bind: "127.0.0.1:0".parse().expect("bind addr"),
+            tls: None,
+            event_log: log.clone(),
+            secrets: Arc::new(StaticSecretProvider {
+                secret_id: SecretId::new("github", "test-signing-secret"),
+                secret: "topsecret".to_string(),
+            }),
+            allowed_origins: OriginAllowList::wildcard(),
+            max_body_bytes: DEFAULT_MAX_BODY_BYTES,
+            metrics_registry: metrics.clone(),
+            admin_reload: None,
+            mcp_router: None,
+            routes: vec![webhook_route("/hooks/github")],
+            tenant_store: None,
+            session_store: None,
+        },
+        ListenerRuntimeEnv::for_test().with_ingest_backpressure(IngestBackpressureConfig {
+            global_capacity: 100,
+            per_source_capacity: 1,
+            refill_per_sec: 1,
         }),
-        allowed_origins: OriginAllowList::wildcard(),
-        max_body_bytes: DEFAULT_MAX_BODY_BYTES,
-        metrics_registry: metrics.clone(),
-        admin_reload: None,
-        mcp_router: None,
-        routes: vec![webhook_route("/hooks/github")],
-        tenant_store: None,
-        session_store: None,
-    })
+    )
     .await
     .expect("start listener");
 
@@ -993,9 +1008,6 @@ async fn webhook_ingest_saturation_returns_retry_after() {
         .shutdown(Duration::from_secs(5))
         .await
         .expect("shutdown listener");
-    std::env::remove_var(INGEST_PER_SOURCE_CAPACITY_ENV);
-    std::env::remove_var(INGEST_GLOBAL_CAPACITY_ENV);
-    std::env::remove_var(INGEST_REFILL_PER_SEC_ENV);
     reset_active_event_log();
 }
 
@@ -1005,23 +1017,26 @@ async fn webhook_duplicate_delivery_is_dropped() {
     reset_active_event_log();
     let dir = tempdir().expect("tempdir");
     let log = install_default_for_base_dir(dir.path()).expect("install event log");
-    let listener = ListenerRuntime::start(ListenerConfig {
-        bind: "127.0.0.1:0".parse().expect("bind addr"),
-        tls: None,
-        event_log: log.clone(),
-        secrets: Arc::new(StaticSecretProvider {
-            secret_id: SecretId::new("github", "test-signing-secret"),
-            secret: "topsecret".to_string(),
-        }),
-        allowed_origins: OriginAllowList::wildcard(),
-        max_body_bytes: DEFAULT_MAX_BODY_BYTES,
-        metrics_registry: Arc::new(harn_vm::MetricsRegistry::default()),
-        admin_reload: None,
-        mcp_router: None,
-        routes: vec![webhook_route("/hooks/github")],
-        tenant_store: None,
-        session_store: None,
-    })
+    let listener = ListenerRuntime::start_with_env(
+        ListenerConfig {
+            bind: "127.0.0.1:0".parse().expect("bind addr"),
+            tls: None,
+            event_log: log.clone(),
+            secrets: Arc::new(StaticSecretProvider {
+                secret_id: SecretId::new("github", "test-signing-secret"),
+                secret: "topsecret".to_string(),
+            }),
+            allowed_origins: OriginAllowList::wildcard(),
+            max_body_bytes: DEFAULT_MAX_BODY_BYTES,
+            metrics_registry: Arc::new(harn_vm::MetricsRegistry::default()),
+            admin_reload: None,
+            mcp_router: None,
+            routes: vec![webhook_route("/hooks/github")],
+            tenant_store: None,
+            session_store: None,
+        },
+        ListenerRuntimeEnv::for_test(),
+    )
     .await
     .expect("start listener");
 
@@ -1078,23 +1093,26 @@ async fn webhook_dedupe_claim_uses_route_retention_days() {
     let log = install_default_for_base_dir(dir.path()).expect("install event log");
     let mut route = webhook_route("/hooks/github");
     route.dedupe_retention_days = 3;
-    let listener = ListenerRuntime::start(ListenerConfig {
-        bind: "127.0.0.1:0".parse().expect("bind addr"),
-        tls: None,
-        event_log: log.clone(),
-        secrets: Arc::new(StaticSecretProvider {
-            secret_id: SecretId::new("github", "test-signing-secret"),
-            secret: "topsecret".to_string(),
-        }),
-        allowed_origins: OriginAllowList::wildcard(),
-        max_body_bytes: DEFAULT_MAX_BODY_BYTES,
-        metrics_registry: Arc::new(harn_vm::MetricsRegistry::default()),
-        admin_reload: None,
-        mcp_router: None,
-        routes: vec![route],
-        tenant_store: None,
-        session_store: None,
-    })
+    let listener = ListenerRuntime::start_with_env(
+        ListenerConfig {
+            bind: "127.0.0.1:0".parse().expect("bind addr"),
+            tls: None,
+            event_log: log.clone(),
+            secrets: Arc::new(StaticSecretProvider {
+                secret_id: SecretId::new("github", "test-signing-secret"),
+                secret: "topsecret".to_string(),
+            }),
+            allowed_origins: OriginAllowList::wildcard(),
+            max_body_bytes: DEFAULT_MAX_BODY_BYTES,
+            metrics_registry: Arc::new(harn_vm::MetricsRegistry::default()),
+            admin_reload: None,
+            mcp_router: None,
+            routes: vec![route],
+            tenant_store: None,
+            session_store: None,
+        },
+        ListenerRuntimeEnv::for_test(),
+    )
     .await
     .expect("start listener");
 

--- a/crates/harn-cli/src/package/lockfile.rs
+++ b/crates/harn-cli/src/package/lockfile.rs
@@ -249,6 +249,7 @@ pub(crate) fn enqueue_manifest_dependencies(
 }
 
 pub(crate) fn build_lockfile(
+    workspace: &PackageWorkspace,
     ctx: &ManifestContext,
     existing: Option<&LockFile>,
     refresh_alias: Option<&str>,
@@ -306,7 +307,8 @@ pub(crate) fn build_lockfile(
                         .commit
                         .as_deref()
                         .ok_or_else(|| format!("missing locked commit for {alias}"))?;
-                    entry.content_hash = Some(ensure_git_cache_populated(
+                    entry.content_hash = Some(ensure_git_cache_populated_in(
+                        workspace,
                         url,
                         &entry.source,
                         commit,
@@ -326,7 +328,8 @@ pub(crate) fn build_lockfile(
                         .content_hash
                         .as_deref()
                         .ok_or_else(|| format!("missing content hash for {alias}"))?;
-                    ensure_git_cache_populated(
+                    ensure_git_cache_populated_in(
+                        workspace,
                         url,
                         &entry.source,
                         commit,
@@ -335,7 +338,7 @@ pub(crate) fn build_lockfile(
                         offline,
                     )?;
                     if inserted {
-                        let cache_dir = git_cache_dir(&entry.source, commit)?;
+                        let cache_dir = git_cache_dir_in(workspace, &entry.source, commit)?;
                         if let Some(manifest) = read_package_manifest_from_dir(&cache_dir)? {
                             enqueue_manifest_dependencies(
                                 &mut pending,
@@ -401,7 +404,8 @@ pub(crate) fn build_lockfile(
             let source = format!("git+{normalized_url}");
             let commit =
                 resolve_git_commit(&normalized_url, dependency.rev(), dependency.branch())?;
-            let content_hash = ensure_git_cache_populated(
+            let content_hash = ensure_git_cache_populated_in(
+                workspace,
                 &normalized_url,
                 &source,
                 &commit,
@@ -418,7 +422,7 @@ pub(crate) fn build_lockfile(
             };
             let inserted = replace_lock_entry(&mut lock, entry)?;
             if inserted {
-                let cache_dir = git_cache_dir(&source, &commit)?;
+                let cache_dir = git_cache_dir_in(workspace, &source, &commit)?;
                 if let Some(manifest) = read_package_manifest_from_dir(&cache_dir)? {
                     enqueue_manifest_dependencies(&mut pending, manifest, cache_dir, alias, true);
                 }
@@ -432,6 +436,7 @@ pub(crate) fn build_lockfile(
 }
 
 pub(crate) fn materialize_dependencies_from_lock(
+    workspace: &PackageWorkspace,
     ctx: &ManifestContext,
     lock: &LockFile,
     refetch: Option<&str>,
@@ -463,7 +468,8 @@ pub(crate) fn materialize_dependencies_from_lock(
         let source = entry.source.clone();
         let url = source.trim_start_matches("git+");
         let refetch_this = refetch == Some("all") || refetch == Some(alias.as_str());
-        ensure_git_cache_populated(
+        ensure_git_cache_populated_in(
+            workspace,
             url,
             &source,
             commit,
@@ -471,7 +477,7 @@ pub(crate) fn materialize_dependencies_from_lock(
             refetch_this,
             offline,
         )?;
-        let cache_dir = git_cache_dir(&source, commit)?;
+        let cache_dir = git_cache_dir_in(workspace, &source, commit)?;
         let dest_dir = packages_dir.join(alias);
         if !dest_dir.exists() || !materialized_hash_matches(&dest_dir, expected_hash) {
             remove_materialized_package(&packages_dir, alias)?;
@@ -521,7 +527,8 @@ pub fn ensure_dependencies_materialized(anchor: &Path) -> Result<(), PackageErro
         )
     })?;
     validate_lock_matches_manifest(&ctx, &lock)?;
-    materialize_dependencies_from_lock(&ctx, &lock, None, false)?;
+    let workspace = PackageWorkspace::from_current_dir()?;
+    materialize_dependencies_from_lock(&workspace, &ctx, &lock, None, false)?;
     Ok(())
 }
 
@@ -661,7 +668,21 @@ pub(crate) fn install_packages_impl(
     refetch: Option<&str>,
     offline: bool,
 ) -> Result<usize, PackageError> {
-    let ctx = load_current_manifest_context()?;
+    install_packages_in(
+        &PackageWorkspace::from_current_dir()?,
+        frozen,
+        refetch,
+        offline,
+    )
+}
+
+pub(crate) fn install_packages_in(
+    workspace: &PackageWorkspace,
+    frozen: bool,
+    refetch: Option<&str>,
+    offline: bool,
+) -> Result<usize, PackageError> {
+    let ctx = workspace.load_manifest_context()?;
     let existing = LockFile::load(&ctx.lock_path())?;
     if ctx.manifest.dependencies.is_empty() {
         if !frozen {
@@ -675,6 +696,7 @@ pub(crate) fn install_packages_impl(
     }
 
     let desired = build_lockfile(
+        workspace,
         &ctx,
         existing.as_ref(),
         None,
@@ -689,7 +711,7 @@ pub(crate) fn install_packages_impl(
     } else {
         desired.save(&ctx.lock_path())?;
     }
-    materialize_dependencies_from_lock(&ctx, &desired, refetch, offline)
+    materialize_dependencies_from_lock(workspace, &ctx, &desired, refetch, offline)
 }
 
 pub fn install_packages(frozen: bool, refetch: Option<&str>, offline: bool) {
@@ -705,9 +727,10 @@ pub fn install_packages(frozen: bool, refetch: Option<&str>, offline: bool) {
 
 pub fn lock_packages() {
     let result = (|| -> Result<usize, PackageError> {
-        let ctx = load_current_manifest_context()?;
+        let workspace = PackageWorkspace::from_current_dir()?;
+        let ctx = workspace.load_manifest_context()?;
         let existing = LockFile::load(&ctx.lock_path())?;
-        let lock = build_lockfile(&ctx, existing.as_ref(), None, true, true, false)?;
+        let lock = build_lockfile(&workspace, &ctx, existing.as_ref(), None, true, true, false)?;
         lock.save(&ctx.lock_path())?;
         Ok(lock.packages.len())
     })();
@@ -722,25 +745,36 @@ pub fn lock_packages() {
 }
 
 pub fn update_packages(alias: Option<&str>, all: bool) {
+    let result = PackageWorkspace::from_current_dir()
+        .and_then(|workspace| update_packages_in(&workspace, alias, all));
+    print_update_packages_result(result);
+}
+
+pub(crate) fn update_packages_in(
+    workspace: &PackageWorkspace,
+    alias: Option<&str>,
+    all: bool,
+) -> Result<usize, PackageError> {
     if !all && alias.is_none() {
-        eprintln!("error: specify a dependency alias or pass --all");
-        process::exit(1);
+        return Err("specify a dependency alias or pass --all"
+            .to_string()
+            .into());
     }
 
-    let result = (|| -> Result<usize, PackageError> {
-        let ctx = load_current_manifest_context()?;
-        if let Some(alias) = alias {
-            validate_package_alias(alias)?;
-            if !ctx.manifest.dependencies.contains_key(alias) {
-                return Err(format!("{alias} is not present in [dependencies]").into());
-            }
+    let ctx = workspace.load_manifest_context()?;
+    if let Some(alias) = alias {
+        validate_package_alias(alias)?;
+        if !ctx.manifest.dependencies.contains_key(alias) {
+            return Err(format!("{alias} is not present in [dependencies]").into());
         }
-        let existing = LockFile::load(&ctx.lock_path())?;
-        let lock = build_lockfile(&ctx, existing.as_ref(), alias, all, true, false)?;
-        lock.save(&ctx.lock_path())?;
-        materialize_dependencies_from_lock(&ctx, &lock, None, false)
-    })();
+    }
+    let existing = LockFile::load(&ctx.lock_path())?;
+    let lock = build_lockfile(workspace, &ctx, existing.as_ref(), alias, all, true, false)?;
+    lock.save(&ctx.lock_path())?;
+    materialize_dependencies_from_lock(workspace, &ctx, &lock, None, false)
+}
 
+fn print_update_packages_result(result: Result<usize, PackageError>) {
     match result {
         Ok(installed) => println!("Updated {installed} package(s)."),
         Err(error) => {
@@ -751,20 +785,29 @@ pub fn update_packages(alias: Option<&str>, all: bool) {
 }
 
 pub fn remove_package(alias: &str) {
-    let result = (|| -> Result<bool, PackageError> {
-        validate_package_alias(alias)?;
-        let ctx = load_current_manifest_context()?;
-        let removed = remove_dependency_from_manifest(&ctx.manifest_path(), alias)?;
-        if !removed {
-            return Ok(false);
-        }
-        let mut lock = LockFile::load(&ctx.lock_path())?.unwrap_or_default();
-        lock.remove(alias);
-        lock.save(&ctx.lock_path())?;
-        remove_materialized_package(&ctx.packages_dir(), alias)?;
-        Ok(true)
-    })();
+    let result = PackageWorkspace::from_current_dir()
+        .and_then(|workspace| remove_package_in(&workspace, alias));
+    print_remove_package_result(alias, result);
+}
 
+pub(crate) fn remove_package_in(
+    workspace: &PackageWorkspace,
+    alias: &str,
+) -> Result<bool, PackageError> {
+    validate_package_alias(alias)?;
+    let ctx = workspace.load_manifest_context()?;
+    let removed = remove_dependency_from_manifest(&ctx.manifest_path(), alias)?;
+    if !removed {
+        return Ok(false);
+    }
+    let mut lock = LockFile::load(&ctx.lock_path())?.unwrap_or_default();
+    lock.remove(alias);
+    lock.save(&ctx.lock_path())?;
+    remove_materialized_package(&ctx.packages_dir(), alias)?;
+    Ok(true)
+}
+
+fn print_remove_package_result(alias: &str, result: Result<bool, PackageError>) {
     match result {
         Ok(true) => println!("Removed {alias} from {MANIFEST} and {LOCK_FILE}."),
         Ok(false) => {
@@ -778,6 +821,20 @@ pub fn remove_package(alias: &str) {
     }
 }
 
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct AddPackageRequest<'a> {
+    name_or_spec: &'a str,
+    alias: Option<&'a str>,
+    git_url: Option<&'a str>,
+    tag: Option<&'a str>,
+    rev: Option<&'a str>,
+    branch: Option<&'a str>,
+    local_path: Option<&'a str>,
+    registry: Option<&'a str>,
+}
+
+#[cfg(test)]
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn normalize_add_request(
     name_or_spec: &str,
     alias: Option<&str>,
@@ -788,6 +845,36 @@ pub(crate) fn normalize_add_request(
     local_path: Option<&str>,
     registry: Option<&str>,
 ) -> Result<(String, Dependency), PackageError> {
+    normalize_add_request_in(
+        &PackageWorkspace::from_current_dir()?,
+        AddPackageRequest {
+            name_or_spec,
+            alias,
+            git_url,
+            tag,
+            rev,
+            branch,
+            local_path,
+            registry,
+        },
+    )
+}
+
+pub(crate) fn normalize_add_request_in(
+    workspace: &PackageWorkspace,
+    request: AddPackageRequest<'_>,
+) -> Result<(String, Dependency), PackageError> {
+    let AddPackageRequest {
+        name_or_spec,
+        alias,
+        git_url,
+        tag,
+        rev,
+        branch,
+        local_path,
+        registry,
+    } = request;
+
     if local_path.is_some() && (rev.is_some() || tag.is_some() || branch.is_some()) {
         return Err("path dependencies do not accept --rev, --tag, or --branch"
             .to_string()
@@ -818,7 +905,7 @@ pub(crate) fn normalize_add_request(
             ));
         }
         if parse_registry_package_spec(name_or_spec).is_some() {
-            return registry_dependency_from_spec(name_or_spec, alias, registry);
+            return registry_dependency_from_spec_in(workspace, name_or_spec, alias, registry);
         }
     }
     if git_url.is_some() || local_path.is_some() {
@@ -926,11 +1013,9 @@ pub fn add_package_with_registry(
     local_path: Option<&str>,
     registry: Option<&str>,
 ) {
-    let result = (|| -> Result<(String, usize), PackageError> {
-        let manifest_path = std::env::current_dir()
-            .map_err(|error| format!("failed to read cwd: {error}"))?
-            .join(MANIFEST);
-        let (alias, dependency) = normalize_add_request(
+    let result = PackageWorkspace::from_current_dir().and_then(|workspace| {
+        add_package_to(
+            &workspace,
             name_or_spec,
             alias,
             git_url,
@@ -939,11 +1024,8 @@ pub fn add_package_with_registry(
             branch,
             local_path,
             registry,
-        )?;
-        upsert_dependency_in_manifest(&manifest_path, &alias, &dependency)?;
-        let installed = install_packages_impl(false, None, false)?;
-        Ok((alias, installed))
-    })();
+        )
+    });
 
     match result {
         Ok((alias, installed)) => {
@@ -955,6 +1037,37 @@ pub fn add_package_with_registry(
             process::exit(1);
         }
     }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn add_package_to(
+    workspace: &PackageWorkspace,
+    name_or_spec: &str,
+    alias: Option<&str>,
+    git_url: Option<&str>,
+    tag: Option<&str>,
+    rev: Option<&str>,
+    branch: Option<&str>,
+    local_path: Option<&str>,
+    registry: Option<&str>,
+) -> Result<(String, usize), PackageError> {
+    let manifest_path = workspace.manifest_dir().join(MANIFEST);
+    let (alias, dependency) = normalize_add_request_in(
+        workspace,
+        AddPackageRequest {
+            name_or_spec,
+            alias,
+            git_url,
+            tag,
+            rev,
+            branch,
+            local_path,
+            registry,
+        },
+    )?;
+    upsert_dependency_in_manifest(&manifest_path, &alias, &dependency)?;
+    let installed = install_packages_in(workspace, false, None, false)?;
+    Ok((alias, installed))
 }
 
 #[cfg(test)]
@@ -986,7 +1099,7 @@ mod tests {
         let (_repo_tmp, repo, _branch) = create_git_package_repo();
         let project_tmp = tempfile::tempdir().unwrap();
         let root = project_tmp.path();
-        let cache_dir = root.join(".cache");
+        let workspace = TestWorkspace::new(root);
         fs::create_dir_all(root.join(".git")).unwrap();
         fs::write(
             root.join(MANIFEST),
@@ -998,33 +1111,42 @@ mod tests {
         )
         .unwrap();
 
-        with_test_env(root, &cache_dir, || {
-            let spec = format!("{}@v1.0.0", repo.display());
-            add_package(&spec, None, None, None, None, None, None);
+        let spec = format!("{}@v1.0.0", repo.display());
+        add_package_to(
+            workspace.env(),
+            &spec,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
 
-            let alias = "acme-lib";
-            let manifest = fs::read_to_string(root.join(MANIFEST)).unwrap();
-            assert!(manifest.contains("acme-lib"));
-            assert!(manifest.contains("rev = \"v1.0.0\""));
+        let alias = "acme-lib";
+        let manifest = fs::read_to_string(root.join(MANIFEST)).unwrap();
+        assert!(manifest.contains("acme-lib"));
+        assert!(manifest.contains("rev = \"v1.0.0\""));
 
-            let lock = LockFile::load(&root.join(LOCK_FILE)).unwrap().unwrap();
-            let entry = lock.find(alias).unwrap();
-            assert_eq!(lock.version, LOCK_FILE_VERSION);
-            assert!(entry.source.starts_with("git+file://"));
-            assert!(entry.commit.as_deref().is_some_and(is_full_git_sha));
-            assert!(entry
-                .content_hash
-                .as_deref()
-                .is_some_and(|hash| hash.starts_with("sha256:")));
-            assert!(root.join(PKG_DIR).join(alias).join("lib.harn").is_file());
+        let lock = LockFile::load(&root.join(LOCK_FILE)).unwrap().unwrap();
+        let entry = lock.find(alias).unwrap();
+        assert_eq!(lock.version, LOCK_FILE_VERSION);
+        assert!(entry.source.starts_with("git+file://"));
+        assert!(entry.commit.as_deref().is_some_and(is_full_git_sha));
+        assert!(entry
+            .content_hash
+            .as_deref()
+            .is_some_and(|hash| hash.starts_with("sha256:")));
+        assert!(root.join(PKG_DIR).join(alias).join("lib.harn").is_file());
 
-            remove_package(alias);
-            let updated_manifest = fs::read_to_string(root.join(MANIFEST)).unwrap();
-            assert!(!updated_manifest.contains("acme-lib ="));
-            let updated_lock = LockFile::load(&root.join(LOCK_FILE)).unwrap().unwrap();
-            assert!(updated_lock.find(alias).is_none());
-            assert!(!root.join(PKG_DIR).join(alias).exists());
-        });
+        remove_package_in(workspace.env(), alias).unwrap();
+        let updated_manifest = fs::read_to_string(root.join(MANIFEST)).unwrap();
+        assert!(!updated_manifest.contains("acme-lib ="));
+        let updated_lock = LockFile::load(&root.join(LOCK_FILE)).unwrap().unwrap();
+        assert!(updated_lock.find(alias).is_none());
+        assert!(!root.join(PKG_DIR).join(alias).exists());
     }
 
     #[test]
@@ -1032,7 +1154,7 @@ mod tests {
         let (_repo_tmp, repo, branch) = create_git_package_repo();
         let project_tmp = tempfile::tempdir().unwrap();
         let root = project_tmp.path();
-        let cache_dir = root.join(".cache");
+        let workspace = TestWorkspace::new(root);
         fs::create_dir_all(root.join(".git")).unwrap();
         let git = normalize_git_url(repo.to_string_lossy().as_ref()).unwrap();
         fs::write(
@@ -1050,31 +1172,29 @@ mod tests {
         )
         .unwrap();
 
-        with_test_env(root, &cache_dir, || {
-            let installed = install_packages_impl(false, None, false).unwrap();
-            assert_eq!(installed, 1);
-            let first_lock = LockFile::load(&root.join(LOCK_FILE)).unwrap().unwrap();
-            let first_commit = first_lock
-                .find("acme-lib")
-                .and_then(|entry| entry.commit.clone())
-                .unwrap();
-
-            fs::write(
-                repo.join("lib.harn"),
-                "pub fn value() -> string { return \"v2\" }\n",
-            )
+        let installed = install_packages_in(workspace.env(), false, None, false).unwrap();
+        assert_eq!(installed, 1);
+        let first_lock = LockFile::load(&root.join(LOCK_FILE)).unwrap().unwrap();
+        let first_commit = first_lock
+            .find("acme-lib")
+            .and_then(|entry| entry.commit.clone())
             .unwrap();
-            run_git(&repo, &["add", "."]);
-            run_git(&repo, &["commit", "-m", "update"]);
 
-            update_packages(Some("acme-lib"), false);
-            let second_lock = LockFile::load(&root.join(LOCK_FILE)).unwrap().unwrap();
-            let second_commit = second_lock
-                .find("acme-lib")
-                .and_then(|entry| entry.commit.clone())
-                .unwrap();
-            assert_ne!(first_commit, second_commit);
-        });
+        fs::write(
+            repo.join("lib.harn"),
+            "pub fn value() -> string { return \"v2\" }\n",
+        )
+        .unwrap();
+        run_git(&repo, &["add", "."]);
+        run_git(&repo, &["commit", "-m", "update"]);
+
+        update_packages_in(workspace.env(), Some("acme-lib"), false).unwrap();
+        let second_lock = LockFile::load(&root.join(LOCK_FILE)).unwrap().unwrap();
+        let second_commit = second_lock
+            .find("acme-lib")
+            .and_then(|entry| entry.commit.clone())
+            .unwrap();
+        assert_ne!(first_commit, second_commit);
     }
 
     #[test]
@@ -1099,7 +1219,7 @@ mod tests {
 
         let project_tmp = tempfile::tempdir().unwrap();
         let root = project_tmp.path();
-        let cache_dir = root.join(".cache");
+        let workspace = TestWorkspace::new(root);
         fs::create_dir_all(root.join(".git")).unwrap();
         fs::write(
             root.join(MANIFEST),
@@ -1111,77 +1231,77 @@ mod tests {
         )
         .unwrap();
 
-        with_test_env(root, &cache_dir, || {
-            add_package(
-                dependency_root.to_string_lossy().as_ref(),
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-            );
+        add_package_to(
+            workspace.env(),
+            dependency_root.to_string_lossy().as_ref(),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
 
-            let manifest = fs::read_to_string(root.join(MANIFEST)).unwrap();
-            assert!(
-                manifest.contains("openapi = { path = "),
-                "manifest should use package.name as alias: {manifest}"
-            );
-            let lock = LockFile::load(&root.join(LOCK_FILE)).unwrap().unwrap();
-            let entry = lock.find("openapi").expect("openapi lock entry");
-            assert!(entry.source.starts_with("path+file://"));
-            let materialized = root.join(PKG_DIR).join("openapi");
-            assert!(materialized.join("lib.harn").is_file());
+        let manifest = fs::read_to_string(root.join(MANIFEST)).unwrap();
+        assert!(
+            manifest.contains("openapi = { path = "),
+            "manifest should use package.name as alias: {manifest}"
+        );
+        let lock = LockFile::load(&root.join(LOCK_FILE)).unwrap().unwrap();
+        let entry = lock.find("openapi").expect("openapi lock entry");
+        assert!(entry.source.starts_with("path+file://"));
+        let materialized = root.join(PKG_DIR).join("openapi");
+        assert!(materialized.join("lib.harn").is_file());
 
-            #[cfg(unix)]
-            assert!(
-                fs::symlink_metadata(&materialized)
-                    .unwrap()
-                    .file_type()
-                    .is_symlink(),
-                "path dependencies should be live-linked on Unix"
-            );
-
-            #[cfg(windows)]
-            let materialized_is_link = fs::symlink_metadata(&materialized)
+        #[cfg(unix)]
+        assert!(
+            fs::symlink_metadata(&materialized)
                 .unwrap()
                 .file_type()
-                .is_symlink();
+                .is_symlink(),
+            "path dependencies should be live-linked on Unix"
+        );
 
-            fs::write(
-                dependency_root.join("lib.harn"),
-                "pub fn version() -> string { return \"v2\" }\n",
-            )
-            .unwrap();
-            #[cfg(unix)]
-            {
-                let live_source = fs::read_to_string(materialized.join("lib.harn")).unwrap();
+        #[cfg(windows)]
+        let materialized_is_link = fs::symlink_metadata(&materialized)
+            .unwrap()
+            .file_type()
+            .is_symlink();
+
+        fs::write(
+            dependency_root.join("lib.harn"),
+            "pub fn version() -> string { return \"v2\" }\n",
+        )
+        .unwrap();
+        #[cfg(unix)]
+        {
+            let live_source = fs::read_to_string(materialized.join("lib.harn")).unwrap();
+            assert!(
+                live_source.contains("v2"),
+                "materialized path dependency should reflect sibling repo edits"
+            );
+        }
+        #[cfg(windows)]
+        {
+            let materialized_source = fs::read_to_string(materialized.join("lib.harn")).unwrap();
+            if materialized_is_link {
                 assert!(
-                    live_source.contains("v2"),
-                    "materialized path dependency should reflect sibling repo edits"
+                    materialized_source.contains("v2"),
+                    "Windows path dependency symlink should reflect sibling repo edits"
+                );
+            } else {
+                assert!(
+                    materialized_source.contains("v1"),
+                    "Windows path dependency copy fallback should keep the copied contents"
                 );
             }
-            #[cfg(windows)]
-            {
-                let materialized_source =
-                    fs::read_to_string(materialized.join("lib.harn")).unwrap();
-                if materialized_is_link {
-                    assert!(
-                        materialized_source.contains("v2"),
-                        "Windows path dependency symlink should reflect sibling repo edits"
-                    );
-                } else {
-                    assert!(
-                        materialized_source.contains("v1"),
-                        "Windows path dependency copy fallback should keep the copied contents"
-                    );
-                }
-            }
+        }
 
-            remove_package("openapi");
-            assert!(!materialized.exists());
-            assert!(dependency_root.join("lib.harn").exists());
-        });
+        remove_package_in(workspace.env(), "openapi").unwrap();
+        assert!(!materialized.exists());
+        assert!(dependency_root.join("lib.harn").exists());
     }
 
     #[test]
@@ -1189,7 +1309,7 @@ mod tests {
         let (_repo_tmp, repo, _branch) = create_git_package_repo();
         let project_tmp = tempfile::tempdir().unwrap();
         let root = project_tmp.path();
-        let cache_dir = root.join(".cache");
+        let workspace = TestWorkspace::new(root);
         fs::create_dir_all(root.join(".git")).unwrap();
         let git = normalize_git_url(repo.to_string_lossy().as_ref()).unwrap();
         fs::write(
@@ -1207,10 +1327,8 @@ mod tests {
         )
         .unwrap();
 
-        with_test_env(root, &cache_dir, || {
-            let error = install_packages_impl(true, None, false).unwrap_err();
-            assert!(error.to_string().contains(LOCK_FILE));
-        });
+        let error = install_packages_in(workspace.env(), true, None, false).unwrap_err();
+        assert!(error.to_string().contains(LOCK_FILE));
     }
 
     #[test]
@@ -1218,7 +1336,7 @@ mod tests {
         let (_repo_tmp, repo, _branch) = create_git_package_repo();
         let project_tmp = tempfile::tempdir().unwrap();
         let root = project_tmp.path();
-        let cache_dir = root.join(".cache");
+        let workspace = TestWorkspace::new(root);
         fs::create_dir_all(root.join(".git")).unwrap();
         let git = normalize_git_url(repo.to_string_lossy().as_ref()).unwrap();
         fs::write(
@@ -1236,20 +1354,18 @@ mod tests {
         )
         .unwrap();
 
-        with_test_env(root, &cache_dir, || {
-            let installed = install_packages_impl(false, None, false).unwrap();
-            assert_eq!(installed, 1);
-            fs::remove_dir_all(root.join(PKG_DIR)).unwrap();
-            fs::remove_dir_all(&repo).unwrap();
+        let installed = install_packages_in(workspace.env(), false, None, false).unwrap();
+        assert_eq!(installed, 1);
+        fs::remove_dir_all(root.join(PKG_DIR)).unwrap();
+        fs::remove_dir_all(&repo).unwrap();
 
-            let installed = install_packages_impl(true, None, true).unwrap();
-            assert_eq!(installed, 1);
-            assert!(root
-                .join(PKG_DIR)
-                .join("acme-lib")
-                .join("lib.harn")
-                .is_file());
-        });
+        let installed = install_packages_in(workspace.env(), true, None, true).unwrap();
+        assert_eq!(installed, 1);
+        assert!(root
+            .join(PKG_DIR)
+            .join("acme-lib")
+            .join("lib.harn")
+            .is_file());
     }
 
     #[test]
@@ -1257,7 +1373,8 @@ mod tests {
         let (_repo_tmp, repo, _branch) = create_git_package_repo();
         let project_tmp = tempfile::tempdir().unwrap();
         let root = project_tmp.path();
-        let cache_dir = root.join(".cache");
+        let workspace = TestWorkspace::new(root);
+        let cache_dir = workspace.cache_dir();
         fs::create_dir_all(root.join(".git")).unwrap();
         let git = normalize_git_url(repo.to_string_lossy().as_ref()).unwrap();
         fs::write(
@@ -1275,12 +1392,10 @@ mod tests {
         )
         .unwrap();
 
-        with_test_env(root, &cache_dir, || {
-            install_packages_impl(false, None, false).unwrap();
-            fs::remove_dir_all(cache_dir.join("git")).unwrap();
-            let error = install_packages_impl(true, None, true).unwrap_err();
-            assert!(error.to_string().contains("offline mode"));
-        });
+        install_packages_in(workspace.env(), false, None, false).unwrap();
+        fs::remove_dir_all(cache_dir.join("git")).unwrap();
+        let error = install_packages_in(workspace.env(), true, None, true).unwrap_err();
+        assert!(error.to_string().contains("offline mode"));
     }
 
     #[test]
@@ -1347,7 +1462,7 @@ mod tests {
 
         let project_tmp = tempfile::tempdir().unwrap();
         let root = project_tmp.path();
-        let cache_dir = root.join(".cache");
+        let workspace = TestWorkspace::new(root);
         fs::create_dir_all(root.join(".git")).unwrap();
         let connector_git = normalize_git_url(connector_repo.to_string_lossy().as_ref()).unwrap();
         fs::write(
@@ -1365,36 +1480,34 @@ mod tests {
         )
         .unwrap();
 
-        with_test_env(root, &cache_dir, || {
-            let installed = install_packages_impl(false, None, false).unwrap();
-            assert_eq!(installed, 2);
+        let installed = install_packages_in(workspace.env(), false, None, false).unwrap();
+        assert_eq!(installed, 2);
 
-            let lock = LockFile::load(&root.join(LOCK_FILE)).unwrap().unwrap();
-            assert!(lock.find("notion-connector-harn").is_some());
-            assert!(lock.find("notion-sdk-harn").is_some());
-            assert!(root
-                .join(PKG_DIR)
-                .join("notion-connector-harn")
-                .join("lib.harn")
-                .is_file());
-            assert!(root
-                .join(PKG_DIR)
-                .join("notion-sdk-harn")
-                .join("lib.harn")
-                .is_file());
+        let lock = LockFile::load(&root.join(LOCK_FILE)).unwrap().unwrap();
+        assert!(lock.find("notion-connector-harn").is_some());
+        assert!(lock.find("notion-sdk-harn").is_some());
+        assert!(root
+            .join(PKG_DIR)
+            .join("notion-connector-harn")
+            .join("lib.harn")
+            .is_file());
+        assert!(root
+            .join(PKG_DIR)
+            .join("notion-sdk-harn")
+            .join("lib.harn")
+            .is_file());
 
-            let mut vm = test_vm();
-            let exports = futures::executor::block_on(
-                vm.load_module_exports(
-                    &root
-                        .join(PKG_DIR)
-                        .join("notion-connector-harn")
-                        .join("lib.harn"),
-                ),
-            )
-            .expect("transitive import should load from the workspace package root");
-            assert!(exports.contains_key("connector_value"));
-        });
+        let mut vm = test_vm();
+        let exports = futures::executor::block_on(
+            vm.load_module_exports(
+                &root
+                    .join(PKG_DIR)
+                    .join("notion-connector-harn")
+                    .join("lib.harn"),
+            ),
+        )
+        .expect("transitive import should load from the workspace package root");
+        assert!(exports.contains_key("connector_value"));
     }
 
     #[test]
@@ -1412,7 +1525,7 @@ mod tests {
 
         let project_tmp = tempfile::tempdir().unwrap();
         let root = project_tmp.path();
-        let cache_dir = root.join(".cache");
+        let workspace = TestWorkspace::new(root);
         fs::create_dir_all(root.join(".git")).unwrap();
         let connector_git = normalize_git_url(connector_repo.to_string_lossy().as_ref()).unwrap();
         fs::write(
@@ -1430,12 +1543,10 @@ mod tests {
         )
         .unwrap();
 
-        with_test_env(root, &cache_dir, || {
-            let error = install_packages_impl(false, None, false).unwrap_err();
-            assert!(error
-                .to_string()
-                .contains("path dependencies are not supported inside git-installed packages"));
-        });
+        let error = install_packages_in(workspace.env(), false, None, false).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("path dependencies are not supported inside git-installed packages"));
     }
 
     #[test]
@@ -1513,6 +1624,7 @@ mod tests {
             manifest,
             dir: tmp.path().to_path_buf(),
         };
+        let workspace = TestWorkspace::new(tmp.path());
         let lock = LockFile {
             version: LOCK_FILE_VERSION,
             packages: vec![LockEntry {
@@ -1524,7 +1636,8 @@ mod tests {
             }],
         };
 
-        let error = materialize_dependencies_from_lock(&ctx, &lock, None, false).unwrap_err();
+        let error = materialize_dependencies_from_lock(workspace.env(), &ctx, &lock, None, false)
+            .unwrap_err();
         assert!(error.to_string().contains("invalid dependency alias"));
         assert!(
             victim.join("keep.txt").exists(),

--- a/crates/harn-cli/src/package/manifest.rs
+++ b/crates/harn-cli/src/package/manifest.rs
@@ -1259,12 +1259,126 @@ impl ManifestContext {
     }
 }
 
-pub(crate) fn load_current_manifest_context() -> Result<ManifestContext, PackageError> {
-    let dir = std::env::current_dir()
-        .map_err(|error| PackageError::Manifest(format!("failed to read cwd: {error}")))?;
-    let manifest_path = dir.join(MANIFEST);
-    let manifest = read_manifest_from_path(&manifest_path)?;
-    Ok(ManifestContext { manifest, dir })
+#[derive(Debug, Clone)]
+pub(crate) struct PackageWorkspace {
+    manifest_dir: PathBuf,
+    cache_dir: Option<PathBuf>,
+    registry_source: Option<String>,
+    read_process_env: bool,
+}
+
+impl PackageWorkspace {
+    pub(crate) fn from_current_dir() -> Result<Self, PackageError> {
+        let manifest_dir = std::env::current_dir()
+            .map_err(|error| PackageError::Manifest(format!("failed to read cwd: {error}")))?;
+        Ok(Self {
+            manifest_dir,
+            cache_dir: None,
+            registry_source: None,
+            read_process_env: true,
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn for_test(
+        manifest_dir: impl Into<PathBuf>,
+        cache_dir: impl Into<PathBuf>,
+    ) -> Self {
+        Self {
+            manifest_dir: manifest_dir.into(),
+            cache_dir: Some(cache_dir.into()),
+            registry_source: None,
+            read_process_env: false,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_registry_source(mut self, source: impl Into<String>) -> Self {
+        self.registry_source = Some(source.into());
+        self
+    }
+
+    pub(crate) fn manifest_dir(&self) -> &Path {
+        &self.manifest_dir
+    }
+
+    pub(crate) fn load_manifest_context(&self) -> Result<ManifestContext, PackageError> {
+        let manifest_path = self.manifest_dir.join(MANIFEST);
+        let manifest = read_manifest_from_path(&manifest_path)?;
+        Ok(ManifestContext {
+            manifest,
+            dir: self.manifest_dir.clone(),
+        })
+    }
+
+    pub(crate) fn cache_root(&self) -> Result<PathBuf, PackageError> {
+        if let Some(cache_dir) = &self.cache_dir {
+            return Ok(cache_dir.clone());
+        }
+        if self.read_process_env {
+            if let Ok(value) = std::env::var(HARN_CACHE_DIR_ENV) {
+                if !value.trim().is_empty() {
+                    return Ok(PathBuf::from(value));
+                }
+            }
+        }
+
+        let home = std::env::var_os("HOME")
+            .map(PathBuf::from)
+            .ok_or_else(|| "HOME is not set and HARN_CACHE_DIR was not provided".to_string())?;
+        if cfg!(target_os = "macos") {
+            return Ok(home.join("Library/Caches/harn"));
+        }
+        if let Some(xdg) = std::env::var_os("XDG_CACHE_HOME") {
+            return Ok(PathBuf::from(xdg).join("harn"));
+        }
+        Ok(home.join(".cache/harn"))
+    }
+
+    pub(crate) fn resolve_registry_source(
+        &self,
+        explicit: Option<&str>,
+    ) -> Result<String, PackageError> {
+        if let Some(explicit) = explicit.map(str::trim).filter(|value| !value.is_empty()) {
+            return Ok(explicit.to_string());
+        }
+        if let Some(source) = self
+            .registry_source
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            if Url::parse(source).is_ok() || PathBuf::from(source).is_absolute() {
+                return Ok(source.to_string());
+            }
+            return Ok(self.manifest_dir.join(source).display().to_string());
+        }
+        if self.read_process_env {
+            if let Ok(value) = std::env::var(HARN_PACKAGE_REGISTRY_ENV) {
+                let value = value.trim();
+                if !value.is_empty() {
+                    return Ok(value.to_string());
+                }
+            }
+        }
+
+        if let Some((manifest, manifest_dir)) = find_nearest_manifest(&self.manifest_dir) {
+            if let Some(raw) = manifest
+                .registry
+                .url
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+            {
+                if Url::parse(raw).is_ok() || PathBuf::from(raw).is_absolute() {
+                    return Ok(raw.to_string());
+                }
+                return Ok(manifest_dir.join(raw).display().to_string());
+            }
+        }
+
+        Ok(DEFAULT_PACKAGE_REGISTRY_URL.to_string())
+    }
 }
 
 #[cfg(test)]

--- a/crates/harn-cli/src/package/registry.rs
+++ b/crates/harn-cli/src/package/registry.rs
@@ -88,22 +88,7 @@ pub(crate) fn ensure_git_available() -> Result<(), PackageError> {
 }
 
 pub(crate) fn cache_root() -> Result<PathBuf, PackageError> {
-    if let Ok(value) = std::env::var(HARN_CACHE_DIR_ENV) {
-        if !value.trim().is_empty() {
-            return Ok(PathBuf::from(value));
-        }
-    }
-
-    let home = std::env::var_os("HOME")
-        .map(PathBuf::from)
-        .ok_or_else(|| "HOME is not set and HARN_CACHE_DIR was not provided".to_string())?;
-    if cfg!(target_os = "macos") {
-        return Ok(home.join("Library/Caches/harn"));
-    }
-    if let Some(xdg) = std::env::var_os("XDG_CACHE_HOME") {
-        return Ok(PathBuf::from(xdg).join("harn"));
-    }
-    Ok(home.join(".cache/harn"))
+    PackageWorkspace::from_current_dir()?.cache_root()
 }
 
 pub(crate) fn sha256_hex(bytes: impl AsRef<[u8]>) -> String {
@@ -121,21 +106,35 @@ pub(crate) fn hex_bytes(bytes: impl AsRef<[u8]>) -> String {
     out
 }
 
-pub(crate) fn git_cache_dir(source: &str, commit: &str) -> Result<PathBuf, PackageError> {
-    Ok(cache_root()?
+pub(crate) fn git_cache_dir_in(
+    workspace: &PackageWorkspace,
+    source: &str,
+    commit: &str,
+) -> Result<PathBuf, PackageError> {
+    Ok(workspace
+        .cache_root()?
         .join("git")
         .join(sha256_hex(source))
         .join(commit))
 }
 
-pub(crate) fn git_cache_lock_path(source: &str, commit: &str) -> Result<PathBuf, PackageError> {
-    Ok(cache_root()?
+pub(crate) fn git_cache_lock_path_in(
+    workspace: &PackageWorkspace,
+    source: &str,
+    commit: &str,
+) -> Result<PathBuf, PackageError> {
+    Ok(workspace
+        .cache_root()?
         .join("locks")
         .join(format!("{}-{commit}.lock", sha256_hex(source))))
 }
 
-pub(crate) fn acquire_git_cache_lock(source: &str, commit: &str) -> Result<File, PackageError> {
-    let path = git_cache_lock_path(source, commit)?;
+pub(crate) fn acquire_git_cache_lock_in(
+    workspace: &PackageWorkspace,
+    source: &str,
+    commit: &str,
+) -> Result<File, PackageError> {
+    let path = git_cache_lock_path_in(workspace, source, commit)?;
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)
             .map_err(|error| format!("failed to create {}: {error}", parent.display()))?;
@@ -548,33 +547,7 @@ pub(crate) fn read_registry_source(source: &str) -> Result<String, PackageError>
 pub(crate) fn resolve_configured_registry_source(
     explicit: Option<&str>,
 ) -> Result<String, PackageError> {
-    if let Some(explicit) = explicit.map(str::trim).filter(|value| !value.is_empty()) {
-        return Ok(explicit.to_string());
-    }
-    if let Ok(value) = std::env::var(HARN_PACKAGE_REGISTRY_ENV) {
-        let value = value.trim();
-        if !value.is_empty() {
-            return Ok(value.to_string());
-        }
-    }
-
-    let cwd = std::env::current_dir().map_err(|error| format!("failed to read cwd: {error}"))?;
-    if let Some((manifest, manifest_dir)) = find_nearest_manifest(&cwd) {
-        if let Some(raw) = manifest
-            .registry
-            .url
-            .as_deref()
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-        {
-            if Url::parse(raw).is_ok() || PathBuf::from(raw).is_absolute() {
-                return Ok(raw.to_string());
-            }
-            return Ok(manifest_dir.join(raw).display().to_string());
-        }
-    }
-
-    Ok(DEFAULT_PACKAGE_REGISTRY_URL.to_string())
+    PackageWorkspace::from_current_dir()?.resolve_registry_source(explicit)
 }
 
 pub(crate) fn is_valid_registry_segment(segment: &str) -> bool {
@@ -711,10 +684,11 @@ pub(crate) fn validate_package_registry_index(
     Ok(())
 }
 
-pub(crate) fn load_package_registry(
+pub(crate) fn load_package_registry_in(
+    workspace: &PackageWorkspace,
     explicit: Option<&str>,
 ) -> Result<(String, PackageRegistryIndex), PackageError> {
-    let source = resolve_configured_registry_source(explicit)?;
+    let source = workspace.resolve_registry_source(explicit)?;
     let content = read_registry_source(&source)?;
     let index = parse_package_registry_index(&source, &content)?;
     Ok((source, index))
@@ -778,7 +752,15 @@ pub(crate) fn search_package_registry_impl(
     query: Option<&str>,
     registry: Option<&str>,
 ) -> Result<Vec<RegistryPackage>, PackageError> {
-    let (_, index) = load_package_registry(registry)?;
+    search_package_registry_in(&PackageWorkspace::from_current_dir()?, query, registry)
+}
+
+pub(crate) fn search_package_registry_in(
+    workspace: &PackageWorkspace,
+    query: Option<&str>,
+    registry: Option<&str>,
+) -> Result<Vec<RegistryPackage>, PackageError> {
+    let (_, index) = load_package_registry_in(workspace, registry)?;
     Ok(index
         .packages
         .into_iter()
@@ -790,17 +772,26 @@ pub(crate) fn package_registry_info_impl(
     spec: &str,
     registry: Option<&str>,
 ) -> Result<RegistryPackageInfo, PackageError> {
+    package_registry_info_in(&PackageWorkspace::from_current_dir()?, spec, registry)
+}
+
+pub(crate) fn package_registry_info_in(
+    workspace: &PackageWorkspace,
+    spec: &str,
+    registry: Option<&str>,
+) -> Result<RegistryPackageInfo, PackageError> {
     let Some((name, version)) = parse_registry_package_spec(spec) else {
         return Err(format!(
             "invalid registry package name '{spec}'; use names like @burin/notion-sdk or acme-lib"
         )
         .into());
     };
-    let (_, index) = load_package_registry(registry)?;
+    let (_, index) = load_package_registry_in(workspace, registry)?;
     find_registry_package_version(&index, name, version)
 }
 
-pub(crate) fn registry_dependency_from_spec(
+pub(crate) fn registry_dependency_from_spec_in(
+    workspace: &PackageWorkspace,
     spec: &str,
     alias: Option<&str>,
     registry: Option<&str>,
@@ -811,7 +802,7 @@ pub(crate) fn registry_dependency_from_spec(
         )
         .into());
     };
-    let info = package_registry_info_impl(&format!("{name}@{version}"), registry)?;
+    let info = package_registry_info_in(workspace, &format!("{name}@{version}"), registry)?;
     let selected = info
         .selected_version
         .ok_or_else(|| format!("package registry does not contain {name}@{version}"))?;
@@ -1141,7 +1132,8 @@ pub(crate) fn unique_temp_dir(base: &Path, label: &str) -> Result<PathBuf, Packa
     .into())
 }
 
-pub(crate) fn ensure_git_cache_populated(
+pub(crate) fn ensure_git_cache_populated_in(
+    workspace: &PackageWorkspace,
     url: &str,
     source: &str,
     commit: &str,
@@ -1149,8 +1141,8 @@ pub(crate) fn ensure_git_cache_populated(
     refetch: bool,
     offline: bool,
 ) -> Result<String, PackageError> {
-    let cache_dir = git_cache_dir(source, commit)?;
-    let _lock = acquire_git_cache_lock(source, commit)?;
+    let cache_dir = git_cache_dir_in(workspace, source, commit)?;
+    let _lock = acquire_git_cache_lock_in(workspace, source, commit)?;
     if refetch && cache_dir.exists() {
         fs::remove_dir_all(&cache_dir)
             .map_err(|error| format!("failed to remove {}: {error}", cache_dir.display()))?;
@@ -1221,12 +1213,18 @@ pub(crate) struct PackageCacheEntry {
     metadata: Option<PackageCacheMetadata>,
 }
 
-pub(crate) fn git_cache_root() -> Result<PathBuf, PackageError> {
-    Ok(cache_root()?.join("git"))
+pub(crate) fn git_cache_root_in(workspace: &PackageWorkspace) -> Result<PathBuf, PackageError> {
+    Ok(workspace.cache_root()?.join("git"))
 }
 
 pub(crate) fn discover_git_cache_entries() -> Result<Vec<PackageCacheEntry>, PackageError> {
-    let root = git_cache_root()?;
+    discover_git_cache_entries_in(&PackageWorkspace::from_current_dir()?)
+}
+
+pub(crate) fn discover_git_cache_entries_in(
+    workspace: &PackageWorkspace,
+) -> Result<Vec<PackageCacheEntry>, PackageError> {
+    let root = git_cache_root_in(workspace)?;
     let mut entries = Vec::new();
     let source_dirs = match fs::read_dir(&root) {
         Ok(source_dirs) => source_dirs,
@@ -1279,7 +1277,10 @@ pub(crate) fn discover_git_cache_entries() -> Result<Vec<PackageCacheEntry>, Pac
     Ok(entries)
 }
 
-pub(crate) fn locked_git_cache_paths(lock: &LockFile) -> Result<HashSet<PathBuf>, PackageError> {
+pub(crate) fn locked_git_cache_paths_in(
+    workspace: &PackageWorkspace,
+    lock: &LockFile,
+) -> Result<HashSet<PathBuf>, PackageError> {
     let mut keep = HashSet::new();
     for entry in &lock.packages {
         validate_package_alias(&entry.name)?;
@@ -1290,12 +1291,15 @@ pub(crate) fn locked_git_cache_paths(lock: &LockFile) -> Result<HashSet<PathBuf>
             .commit
             .as_deref()
             .ok_or_else(|| format!("missing locked commit for {}", entry.name))?;
-        keep.insert(git_cache_dir(&entry.source, commit)?);
+        keep.insert(git_cache_dir_in(workspace, &entry.source, commit)?);
     }
     Ok(keep)
 }
 
-pub(crate) fn verify_lock_entry_cache(entry: &LockEntry) -> Result<bool, PackageError> {
+pub(crate) fn verify_lock_entry_cache_in(
+    workspace: &PackageWorkspace,
+    entry: &LockEntry,
+) -> Result<bool, PackageError> {
     validate_package_alias(&entry.name)?;
     if !entry.source.starts_with("git+") {
         if entry.source.starts_with("path+") {
@@ -1319,7 +1323,7 @@ pub(crate) fn verify_lock_entry_cache(entry: &LockEntry) -> Result<bool, Package
         .content_hash
         .as_deref()
         .ok_or_else(|| format!("missing content hash for {}", entry.name))?;
-    let cache_dir = git_cache_dir(&entry.source, commit)?;
+    let cache_dir = git_cache_dir_in(workspace, &entry.source, commit)?;
     if !cache_dir.is_dir() {
         return Err(format!(
             "package cache entry for {} is missing: {}",
@@ -1392,13 +1396,20 @@ pub(crate) fn verify_materialized_lock_entry(
 }
 
 pub(crate) fn verify_package_cache_impl(materialized: bool) -> Result<usize, PackageError> {
-    let ctx = load_current_manifest_context()?;
+    verify_package_cache_in(&PackageWorkspace::from_current_dir()?, materialized)
+}
+
+pub(crate) fn verify_package_cache_in(
+    workspace: &PackageWorkspace,
+    materialized: bool,
+) -> Result<usize, PackageError> {
+    let ctx = workspace.load_manifest_context()?;
     let lock = LockFile::load(&ctx.lock_path())?
         .ok_or_else(|| format!("{} is missing", ctx.lock_path().display()))?;
     validate_lock_matches_manifest(&ctx, &lock)?;
     let mut verified = 0usize;
     for entry in &lock.packages {
-        if verify_lock_entry_cache(entry)? {
+        if verify_lock_entry_cache_in(workspace, entry)? {
             verified += 1;
         }
         if materialized && verify_materialized_lock_entry(&ctx, entry)? {
@@ -1409,12 +1420,19 @@ pub(crate) fn verify_package_cache_impl(materialized: bool) -> Result<usize, Pac
 }
 
 pub(crate) fn clean_package_cache_impl(all: bool) -> Result<usize, PackageError> {
-    let entries = discover_git_cache_entries()?;
+    clean_package_cache_in(&PackageWorkspace::from_current_dir()?, all)
+}
+
+pub(crate) fn clean_package_cache_in(
+    workspace: &PackageWorkspace,
+    all: bool,
+) -> Result<usize, PackageError> {
+    let entries = discover_git_cache_entries_in(workspace)?;
     if entries.is_empty() {
         return Ok(0);
     }
     if all {
-        let root = cache_root()?;
+        let root = workspace.cache_root()?;
         for child in ["git", "locks"] {
             let path = root.join(child);
             if path.exists() {
@@ -1425,7 +1443,7 @@ pub(crate) fn clean_package_cache_impl(all: bool) -> Result<usize, PackageError>
         return Ok(entries.len());
     }
 
-    let ctx = load_current_manifest_context()?;
+    let ctx = workspace.load_manifest_context()?;
     let lock = LockFile::load(&ctx.lock_path())?.ok_or_else(|| {
         format!(
             "{} is missing; pass --all to clean every cache entry",
@@ -1433,7 +1451,7 @@ pub(crate) fn clean_package_cache_impl(all: bool) -> Result<usize, PackageError>
         )
     })?;
     validate_lock_matches_manifest(&ctx, &lock)?;
-    let keep = locked_git_cache_paths(&lock)?;
+    let keep = locked_git_cache_paths_in(workspace, &lock)?;
     let mut removed = 0usize;
     for entry in entries {
         if keep.contains(&entry.path) {
@@ -1673,7 +1691,7 @@ mod tests {
         let (_repo_tmp, repo, _branch) = create_git_package_repo();
         let project_tmp = tempfile::tempdir().unwrap();
         let root = project_tmp.path();
-        let cache_dir = root.join(".cache");
+        let workspace = TestWorkspace::new(root);
         fs::create_dir_all(root.join(".git")).unwrap();
         let git = normalize_git_url(repo.to_string_lossy().as_ref()).unwrap();
         fs::write(
@@ -1691,20 +1709,23 @@ mod tests {
         )
         .unwrap();
 
-        with_test_env(root, &cache_dir, || {
-            install_packages_impl(false, None, false).unwrap();
-            let lock = LockFile::load(&root.join(LOCK_FILE)).unwrap().unwrap();
-            let entry = lock.find("acme-lib").unwrap();
-            let cache_dir = git_cache_dir(&entry.source, entry.commit.as_deref().unwrap()).unwrap();
-            fs::write(
-                cache_dir.join("lib.harn"),
-                "pub fn value() { return \"pwned\" }\n",
-            )
-            .unwrap();
+        install_packages_in(workspace.env(), false, None, false).unwrap();
+        let lock = LockFile::load(&root.join(LOCK_FILE)).unwrap().unwrap();
+        let entry = lock.find("acme-lib").unwrap();
+        let cache_dir = git_cache_dir_in(
+            workspace.env(),
+            &entry.source,
+            entry.commit.as_deref().unwrap(),
+        )
+        .unwrap();
+        fs::write(
+            cache_dir.join("lib.harn"),
+            "pub fn value() { return \"pwned\" }\n",
+        )
+        .unwrap();
 
-            let error = verify_package_cache_impl(false).unwrap_err();
-            assert!(error.to_string().contains("content hash mismatch"));
-        });
+        let error = verify_package_cache_in(workspace.env(), false).unwrap_err();
+        assert!(error.to_string().contains("content hash mismatch"));
     }
 
     #[test]
@@ -1712,7 +1733,7 @@ mod tests {
         let (_repo_tmp, repo, _branch) = create_git_package_repo();
         let project_tmp = tempfile::tempdir().unwrap();
         let root = project_tmp.path();
-        let cache_dir = root.join(".cache");
+        let workspace = TestWorkspace::new(root);
         fs::create_dir_all(root.join(".git")).unwrap();
         let git = normalize_git_url(repo.to_string_lossy().as_ref()).unwrap();
         fs::write(
@@ -1730,14 +1751,19 @@ mod tests {
         )
         .unwrap();
 
-        with_test_env(root, &cache_dir, || {
-            install_packages_impl(false, None, false).unwrap();
-            assert_eq!(discover_git_cache_entries().unwrap().len(), 1);
+        install_packages_in(workspace.env(), false, None, false).unwrap();
+        assert_eq!(
+            discover_git_cache_entries_in(workspace.env())
+                .unwrap()
+                .len(),
+            1
+        );
 
-            let removed = clean_package_cache_impl(true).unwrap();
-            assert_eq!(removed, 1);
-            assert!(discover_git_cache_entries().unwrap().is_empty());
-        });
+        let removed = clean_package_cache_in(workspace.env(), true).unwrap();
+        assert_eq!(removed, 1);
+        assert!(discover_git_cache_entries_in(workspace.env())
+            .unwrap()
+            .is_empty());
     }
 
     #[test]
@@ -1745,7 +1771,7 @@ mod tests {
         let (_repo_tmp, repo, _branch) = create_git_package_repo();
         let project_tmp = tempfile::tempdir().unwrap();
         let root = project_tmp.path();
-        let cache_dir = root.join(".cache");
+        let workspace = TestWorkspace::new(root);
         let registry_path = root.join("index.toml");
         let git = normalize_git_url(repo.to_string_lossy().as_ref()).unwrap();
         write_package_registry_index(&registry_path, "@burin/acme-lib", &git, "acme-lib");
@@ -1760,27 +1786,34 @@ mod tests {
         )
         .unwrap();
 
-        with_test_env(root, &cache_dir, || {
-            let matches = search_package_registry_impl(Some("acme"), Some("index.toml")).unwrap();
-            assert_eq!(matches.len(), 1);
-            assert_eq!(matches[0].name, "@burin/acme-lib");
-            assert_eq!(
-                matches[0].harn.as_deref(),
-                Some(crate::package::current_harn_range_example().as_str())
-            );
-            assert_eq!(matches[0].connector_contract.as_deref(), Some("v1"));
-            assert_eq!(matches[0].exports, vec!["lib"]);
+        let matches = search_package_registry_in(
+            workspace.env(),
+            Some("acme"),
+            Some(registry_path.to_string_lossy().as_ref()),
+        )
+        .unwrap();
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].name, "@burin/acme-lib");
+        assert_eq!(
+            matches[0].harn.as_deref(),
+            Some(crate::package::current_harn_range_example().as_str())
+        );
+        assert_eq!(matches[0].connector_contract.as_deref(), Some("v1"));
+        assert_eq!(matches[0].exports, vec!["lib"]);
 
-            let info =
-                package_registry_info_impl("@burin/acme-lib@1.0.0", Some("index.toml")).unwrap();
-            assert_eq!(info.package.license.as_deref(), Some("MIT OR Apache-2.0"));
-            assert_eq!(
-                info.selected_version
-                    .as_ref()
-                    .map(|version| version.git.as_str()),
-                Some(git.as_str())
-            );
-        });
+        let info = package_registry_info_in(
+            workspace.env(),
+            "@burin/acme-lib@1.0.0",
+            Some(registry_path.to_string_lossy().as_ref()),
+        )
+        .unwrap();
+        assert_eq!(info.package.license.as_deref(), Some("MIT OR Apache-2.0"));
+        assert_eq!(
+            info.selected_version
+                .as_ref()
+                .map(|version| version.git.as_str()),
+            Some(git.as_str())
+        );
     }
 
     #[test]
@@ -1788,8 +1821,9 @@ mod tests {
         let (_repo_tmp, repo, _branch) = create_git_package_repo();
         let project_tmp = tempfile::tempdir().unwrap();
         let root = project_tmp.path();
-        let cache_dir = root.join(".cache");
         let registry_path = root.join("index.toml");
+        let workspace =
+            TestWorkspace::new(root).with_registry_source(registry_path.display().to_string());
         let git = normalize_git_url(repo.to_string_lossy().as_ref()).unwrap();
         write_package_registry_index(&registry_path, "@burin/acme-lib", &git, "acme-lib");
         fs::create_dir_all(root.join(".git")).unwrap();
@@ -1803,26 +1837,34 @@ mod tests {
         )
         .unwrap();
 
-        with_test_env(root, &cache_dir, || {
-            std::env::set_var(HARN_PACKAGE_REGISTRY_ENV, "index.toml");
-            add_package("@burin/acme-lib@1.0.0", None, None, None, None, None, None);
+        add_package_to(
+            workspace.env(),
+            "@burin/acme-lib@1.0.0",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
 
-            let manifest = fs::read_to_string(root.join(MANIFEST)).unwrap();
-            assert!(
-                manifest.contains(&format!(
-                    "acme-lib = {{ git = \"{git}\", rev = \"v1.0.0\" }}"
-                )),
-                "registry install should write the same dependency line as a direct git add: {manifest}"
-            );
-            let lock = LockFile::load(&root.join(LOCK_FILE)).unwrap().unwrap();
-            let entry = lock.find("acme-lib").unwrap();
-            assert_eq!(entry.source, format!("git+{git}"));
-            assert!(root
-                .join(PKG_DIR)
-                .join("acme-lib")
-                .join("lib.harn")
-                .is_file());
-        });
+        let manifest = fs::read_to_string(root.join(MANIFEST)).unwrap();
+        assert!(
+            manifest.contains(&format!(
+                "acme-lib = {{ git = \"{git}\", rev = \"v1.0.0\" }}"
+            )),
+            "registry install should write the same dependency line as a direct git add: {manifest}"
+        );
+        let lock = LockFile::load(&root.join(LOCK_FILE)).unwrap().unwrap();
+        let entry = lock.find("acme-lib").unwrap();
+        assert_eq!(entry.source, format!("git+{git}"));
+        assert!(root
+            .join(PKG_DIR)
+            .join("acme-lib")
+            .join("lib.harn")
+            .is_file());
     }
 
     #[test]

--- a/crates/harn-cli/src/package/test_support.rs
+++ b/crates/harn-cli/src/package/test_support.rs
@@ -1,6 +1,5 @@
 use super::*;
 use serde::{Deserialize, Serialize};
-use tokio::sync::MutexGuard;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub(crate) struct TriggerTables {
@@ -12,6 +11,32 @@ pub(crate) fn test_vm() -> harn_vm::Vm {
     let mut vm = harn_vm::Vm::new();
     harn_vm::register_vm_stdlib(&mut vm);
     vm
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct TestWorkspace {
+    env: PackageWorkspace,
+}
+
+impl TestWorkspace {
+    pub(crate) fn new(root: &Path) -> Self {
+        Self {
+            env: PackageWorkspace::for_test(root, root.join(".cache")),
+        }
+    }
+
+    pub(crate) fn with_registry_source(mut self, source: impl Into<String>) -> Self {
+        self.env = self.env.with_registry_source(source);
+        self
+    }
+
+    pub(crate) fn env(&self) -> &PackageWorkspace {
+        &self.env
+    }
+
+    pub(crate) fn cache_dir(&self) -> PathBuf {
+        self.env.cache_root().expect("test cache root")
+    }
 }
 
 pub(crate) fn write_trigger_project(
@@ -27,48 +52,6 @@ pub(crate) fn write_trigger_project(
     let harn_file = root.join("main.harn");
     fs::write(&harn_file, "pipeline main() {}\n").unwrap();
     harn_file
-}
-
-struct TestEnvGuard {
-    previous_cwd: PathBuf,
-    previous_cache: Option<std::ffi::OsString>,
-    previous_registry: Option<std::ffi::OsString>,
-    _cwd_lock: MutexGuard<'static, ()>,
-    _env_lock: MutexGuard<'static, ()>,
-}
-
-impl Drop for TestEnvGuard {
-    fn drop(&mut self) {
-        std::env::set_current_dir(&self.previous_cwd).unwrap();
-        if let Some(value) = self.previous_cache.clone() {
-            std::env::set_var(HARN_CACHE_DIR_ENV, value);
-        } else {
-            std::env::remove_var(HARN_CACHE_DIR_ENV);
-        }
-        if let Some(value) = self.previous_registry.clone() {
-            std::env::set_var(HARN_PACKAGE_REGISTRY_ENV, value);
-        } else {
-            std::env::remove_var(HARN_PACKAGE_REGISTRY_ENV);
-        }
-    }
-}
-
-pub(crate) fn with_test_env<T>(cwd: &Path, cache_dir: &Path, f: impl FnOnce() -> T) -> T {
-    let cwd_lock = crate::tests::common::cwd_lock::lock_cwd();
-    let env_lock = crate::tests::common::env_lock::lock_env().blocking_lock();
-    let guard = TestEnvGuard {
-        previous_cwd: std::env::current_dir().unwrap(),
-        previous_cache: std::env::var_os(HARN_CACHE_DIR_ENV),
-        previous_registry: std::env::var_os(HARN_PACKAGE_REGISTRY_ENV),
-        _cwd_lock: cwd_lock,
-        _env_lock: env_lock,
-    };
-    std::env::set_current_dir(cwd).unwrap();
-    std::env::set_var(HARN_CACHE_DIR_ENV, cache_dir);
-    std::env::remove_var(HARN_PACKAGE_REGISTRY_ENV);
-    let result = f();
-    drop(guard);
-    result
 }
 
 pub(crate) fn run_git(repo: &Path, args: &[&str]) -> String {


### PR DESCRIPTION
## Summary
- add explicit PackageWorkspace context for package manifests, cache roots, registry sources, and package operations
- replace package test cwd/env mutation helpers with TestWorkspace fixtures
- inject listener runtime auth, request-gate, ACP retention, and ingest backpressure config into orchestrator tests instead of mutating process env

Closes #1374

## Verification
- cargo fmt
- CARGO_TARGET_DIR=/tmp/harn-target-1374 cargo check -p harn-cli
- CARGO_TARGET_DIR=/tmp/harn-target-1374 cargo nextest run -p harn-cli package:: --status-level fail
- CARGO_TARGET_DIR=/tmp/harn-target-1374 cargo nextest run -p harn-cli commands::orchestrator::listener::tests:: --status-level fail
- CARGO_TARGET_DIR=/tmp/harn-target-1374 cargo nextest run -p harn-cli commands::orchestrator::harness::tests:: --status-level fail
- CARGO_TARGET_DIR=/tmp/harn-target-1374 cargo nextest run -p harn-cli --status-level fail
- CARGO_TARGET_DIR=/tmp/harn-target-1374 cargo clippy -p harn-cli --all-targets -- -D warnings
- CARGO_TARGET_DIR=/tmp/harn-target-1374 make test
- git diff --check
- pre-commit hook: cargo clippy --workspace --all-targets -- -D warnings
- pre-push hook targeted local checks