### PR TITLE
Reduce VM hot-path allocations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2034,6 +2034,7 @@ version = "0.0.0"
 dependencies = [
  "criterion",
  "harn-vm",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/harn-vm/src/chunk.rs
+++ b/crates/harn-vm/src/chunk.rs
@@ -382,10 +382,10 @@ pub enum Constant {
 /// Monomorphic inline-cache state for bytecode instructions that repeatedly
 /// resolve the same property or builtin method. Cache guards are intentionally
 /// conservative: each entry is tied to the instruction's name constant index
-/// and a single receiver variant. Harn collection values are immutable or
-/// copy-on-write at the VM level, so list/string/pair/range/set/dict receiver
-/// kind caches do not need invalidation; dynamic dict fields and struct fields
-/// are left on the generic path until they have stable layout metadata.
+/// and a single receiver shape. Harn collection values are immutable or
+/// copy-on-write at the VM level, so receiver-kind caches do not need
+/// invalidation. Struct field caches guard on the field name at the cached
+/// slot before reading the indexed field.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum InlineCacheEntry {
     Empty,
@@ -400,8 +400,10 @@ pub(crate) enum InlineCacheEntry {
     },
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum PropertyCacheTarget {
+    DictField(Rc<str>),
+    StructField { field_name: Rc<str>, index: usize },
     ListCount,
     ListEmpty,
     ListFirst,

--- a/crates/harn-vm/src/llm/agent_runtime.rs
+++ b/crates/harn-vm/src/llm/agent_runtime.rs
@@ -126,6 +126,7 @@ pub(crate) async fn emit_agent_event(event: &AgentEvent) {
         return;
     }
     let payload = serde_json::to_value(event).unwrap_or(serde_json::Value::Null);
+    let arg = crate::stdlib::json_to_vm_value(&payload);
     for closure in subscribers {
         let VmValue::Closure(closure) = closure else {
             continue;
@@ -133,10 +134,9 @@ pub(crate) async fn emit_agent_event(event: &AgentEvent) {
         let Some(mut vm) = crate::vm::clone_async_builtin_child_vm() else {
             continue;
         };
-        let arg = crate::stdlib::json_to_vm_value(&payload);
         // Log but don't propagate: one broken subscriber must not tear
         // down the agent loop.
-        if let Err(err) = vm.call_closure_pub(&closure, &[arg]).await {
+        if let Err(err) = vm.call_closure_pub(&closure, &[arg.clone()]).await {
             crate::events::log_warn(
                 "agent.subscriber",
                 &format!(

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -171,7 +171,6 @@ use crate::value::{VmChannelHandle, VmError, VmStream, VmStreamCancel, VmValue};
 use crate::vm::{Vm, VmBuiltinArity};
 
 use self::api::{vm_build_llm_result, vm_call_completion_full};
-use self::helpers::{opt_int, opt_str};
 use self::stream::vm_stream_llm;
 use self::trace::emit_agent_event;
 use self::trace::trace_llm_call;
@@ -1058,13 +1057,28 @@ fn agent_primitive_tools_arg(
     }
 }
 
-fn agent_primitive_options_arg(
-    args: &[VmValue],
-    index: usize,
+fn agent_primitive_tools_value_arg(
+    value: Option<VmValue>,
+    label: &str,
+) -> Result<Option<VmValue>, VmError> {
+    match value {
+        Some(VmValue::Nil) | None => Ok(crate::stdlib::tools::current_tool_registry()),
+        Some(value @ VmValue::Dict(_)) => Ok(Some(value)),
+        Some(other) => Err(VmError::Runtime(format!(
+            "{label}: tools must be a tool registry dict or nil; got {}",
+            other.type_name()
+        ))),
+    }
+}
+
+fn agent_primitive_options_value_arg(
+    value: Option<VmValue>,
     label: &str,
 ) -> Result<std::collections::BTreeMap<String, VmValue>, VmError> {
-    match args.get(index) {
-        Some(VmValue::Dict(options)) => Ok(options.as_ref().clone()),
+    match value {
+        Some(VmValue::Dict(options)) => {
+            Ok(Rc::try_unwrap(options).unwrap_or_else(|options| options.as_ref().clone()))
+        }
         Some(VmValue::Nil) | None => Ok(std::collections::BTreeMap::new()),
         Some(other) => Err(VmError::Runtime(format!(
             "{label}: options must be a dict or nil; got {}",
@@ -1073,17 +1087,21 @@ fn agent_primitive_options_arg(
     }
 }
 
-fn agent_primitive_call_json(args: &[VmValue]) -> Result<serde_json::Value, VmError> {
-    match args.first() {
-        Some(VmValue::Dict(_)) => Ok(helpers::vm_value_to_json(args.first().unwrap())),
-        Some(other) => Err(VmError::Runtime(format!(
-            "__host_agent_dispatch_tool_call(call, tools?, options?): call must be a dict; got {}",
-            other.type_name()
-        ))),
-        None => Err(VmError::Runtime(
-            "__host_agent_dispatch_tool_call(call, tools?, options?): missing call".to_string(),
-        )),
+fn agent_primitive_option_str(
+    options: &std::collections::BTreeMap<String, VmValue>,
+    key: &str,
+) -> Option<String> {
+    match options.get(key)? {
+        VmValue::Nil => None,
+        value => Some(value.display()),
     }
+}
+
+fn agent_primitive_option_int(
+    options: &std::collections::BTreeMap<String, VmValue>,
+    key: &str,
+) -> Option<i64> {
+    options.get(key)?.as_int()
 }
 
 /// Append a `PermissionGrant` / `PermissionDeny` / `PermissionEscalation`
@@ -1127,18 +1145,6 @@ fn agent_primitive_denied_tool(
         "error_category": category.as_str(),
         "executor": null,
     })
-}
-
-fn agent_primitive_tool_name(call: &serde_json::Value) -> Result<String, VmError> {
-    call.get("name")
-        .and_then(|value| value.as_str())
-        .filter(|name| !name.trim().is_empty())
-        .map(str::to_string)
-        .ok_or_else(|| {
-            VmError::Runtime(
-                "__host_agent_dispatch_tool_call: call.name must be a non-empty string".to_string(),
-            )
-        })
 }
 
 fn agent_primitive_call_name(call: &VmValue) -> Option<String> {
@@ -1185,8 +1191,11 @@ async fn host_agent_parse_tool_calls_impl(args: Vec<VmValue>) -> Result<VmValue,
 }
 
 async fn host_agent_dispatch_tool_batch_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
-    let calls = match args.first() {
-        Some(VmValue::List(calls)) => calls.as_ref().clone(),
+    let mut args = args.into_iter();
+    let calls = match args.next() {
+        Some(VmValue::List(calls)) => {
+            Rc::try_unwrap(calls).unwrap_or_else(|calls| calls.as_ref().clone())
+        }
         Some(other) => {
             return Err(VmError::Runtime(format!(
                 "__host_agent_dispatch_tool_batch(calls, tools?, options?): calls must be a list; got {}",
@@ -1200,12 +1209,9 @@ async fn host_agent_dispatch_tool_batch_impl(args: Vec<VmValue>) -> Result<VmVal
             ))
         }
     };
-    let tools = args.get(1).cloned().unwrap_or(VmValue::Nil);
-    let options = VmValue::Dict(Rc::new(agent_primitive_options_arg(
-        &args,
-        2,
-        "__host_agent_dispatch_tool_batch",
-    )?));
+    let tools = agent_primitive_tools_value_arg(args.next(), "__host_agent_dispatch_tool_batch")?;
+    let options =
+        agent_primitive_options_value_arg(args.next(), "__host_agent_dispatch_tool_batch")?;
     let ro_prefix_len = calls
         .iter()
         .position(|call| !agent_primitive_call_is_read_only(call))
@@ -1213,9 +1219,10 @@ async fn host_agent_dispatch_tool_batch_impl(args: Vec<VmValue>) -> Result<VmVal
 
     let mut results: Vec<Option<VmValue>> = vec![None; calls.len()];
     if ro_prefix_len >= 2 {
-        let futures = calls[..ro_prefix_len].iter().cloned().map(|call| {
-            host_agent_dispatch_tool_call_impl(vec![call, tools.clone(), options.clone()])
-        });
+        let futures = calls[..ro_prefix_len]
+            .iter()
+            .cloned()
+            .map(|call| host_agent_dispatch_tool_call(call, tools.as_ref(), &options));
         for (index, result) in futures::future::join_all(futures)
             .await
             .into_iter()
@@ -1229,9 +1236,7 @@ async fn host_agent_dispatch_tool_batch_impl(args: Vec<VmValue>) -> Result<VmVal
         if results[index].is_some() {
             continue;
         }
-        results[index] = Some(
-            host_agent_dispatch_tool_call_impl(vec![call, tools.clone(), options.clone()]).await?,
-        );
+        results[index] = Some(host_agent_dispatch_tool_call(call, tools.as_ref(), &options).await?);
     }
 
     Ok(VmValue::List(Rc::new(
@@ -1243,26 +1248,60 @@ async fn host_agent_dispatch_tool_batch_impl(args: Vec<VmValue>) -> Result<VmVal
 }
 
 async fn host_agent_dispatch_tool_call_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
-    let call = agent_primitive_call_json(&args)?;
-    let tools = agent_primitive_tools_arg(&args, 1, "__host_agent_dispatch_tool_call")?;
-    let options = agent_primitive_options_arg(&args, 2, "__host_agent_dispatch_tool_call")?;
-    let options_ref = Some(options.clone());
-    let tool_name = agent_primitive_tool_name(&call)?;
-    let tool_id = call
-        .get("id")
-        .and_then(|value| value.as_str())
-        .unwrap_or("")
-        .to_string();
-    let mut tool_args = tools::normalize_tool_args(&tool_name, &call["arguments"]);
-    let session_id = opt_str(&options_ref, "session_id")
+    let mut args = args.into_iter();
+    let call = args.next().ok_or_else(|| {
+        VmError::Runtime(
+            "__host_agent_dispatch_tool_call(call, tools?, options?): missing call".to_string(),
+        )
+    })?;
+    let tools = agent_primitive_tools_value_arg(args.next(), "__host_agent_dispatch_tool_call")?;
+    let options =
+        agent_primitive_options_value_arg(args.next(), "__host_agent_dispatch_tool_call")?;
+    host_agent_dispatch_tool_call(call, tools.as_ref(), &options).await
+}
+
+async fn host_agent_dispatch_tool_call(
+    call: VmValue,
+    tools: Option<&VmValue>,
+    options: &std::collections::BTreeMap<String, VmValue>,
+) -> Result<VmValue, VmError> {
+    let call = match call {
+        VmValue::Dict(call) => call,
+        other => {
+            return Err(VmError::Runtime(format!(
+            "__host_agent_dispatch_tool_call(call, tools?, options?): call must be a dict; got {}",
+            other.type_name()
+        )))
+        }
+    };
+    let tool_name = match call.get("name") {
+        Some(VmValue::String(name)) if !name.trim().is_empty() => name.to_string(),
+        _ => {
+            return Err(VmError::Runtime(
+                "__host_agent_dispatch_tool_call: call.name must be a non-empty string".to_string(),
+            ))
+        }
+    };
+    let tool_id = match call.get("id") {
+        Some(VmValue::String(id)) => id.to_string(),
+        _ => String::new(),
+    };
+    let raw_args = call
+        .get("arguments")
+        .map(helpers::vm_value_to_json)
+        .unwrap_or(serde_json::Value::Null);
+    let mut tool_args = tools::normalize_tool_args(&tool_name, &raw_args);
+    let session_id = agent_primitive_option_str(options, "session_id")
         .or_else(current_agent_session_id)
         .unwrap_or_else(|| format!("agent_primitive_session_{}", uuid::Uuid::now_v7()));
-    let tool_retries = opt_int(&options_ref, "tool_retries").unwrap_or(0).max(0) as usize;
-    let tool_backoff_ms = opt_int(&options_ref, "tool_backoff_ms")
+    let tool_retries = agent_primitive_option_int(options, "tool_retries")
+        .unwrap_or(0)
+        .max(0) as usize;
+    let tool_backoff_ms = agent_primitive_option_int(options, "tool_backoff_ms")
         .unwrap_or(1000)
         .max(1) as u64;
     let bridge = current_host_bridge();
-    let _policy_guard = agent_session_host::install_session_policy_guard(&options)?;
+    let _policy_guard = agent_session_host::install_session_policy_guard(options)?;
 
     if let Err(error) =
         crate::orchestration::enforce_current_policy_for_tool(&tool_name).and_then(|_| {
@@ -1508,7 +1547,7 @@ async fn host_agent_dispatch_tool_call_impl(args: Vec<VmValue>) -> Result<VmValu
         }
     }
 
-    let tool_schemas = tools::collect_tool_schemas(tools.as_ref(), None);
+    let tool_schemas = tools::collect_tool_schemas(tools, None);
     if let Err(message) = tools::validate_tool_args(&tool_name, &tool_args, &tool_schemas) {
         return Ok(json_to_vm_value(&agent_primitive_denied_tool(
             &tool_name,
@@ -1524,7 +1563,7 @@ async fn host_agent_dispatch_tool_call_impl(args: Vec<VmValue>) -> Result<VmValu
     let session_mcp = {
         use std::collections::BTreeMap;
         let mut clients: BTreeMap<String, crate::mcp::VmMcpClientHandle> = BTreeMap::new();
-        if let Some(server_name) = agent_tools::mcp_server_for_tool(tools.as_ref(), &tool_name) {
+        if let Some(server_name) = agent_tools::mcp_server_for_tool(tools, &tool_name) {
             if let Some(handle) = agent_runtime::session_mcp_client(&session_id, &server_name) {
                 clients.insert(server_name, handle);
             }
@@ -1539,7 +1578,7 @@ async fn host_agent_dispatch_tool_call_impl(args: Vec<VmValue>) -> Result<VmValu
     let outcome = agent_tools::dispatch_tool_execution_with_mcp(
         &tool_name,
         &tool_args,
-        tools.as_ref(),
+        tools,
         mcp_clients_ref,
         bridge.as_ref(),
         tool_retries,

--- a/crates/harn-vm/src/value/env.rs
+++ b/crates/harn-vm/src/value/env.rs
@@ -95,6 +95,13 @@ impl VmEnv {
         None
     }
 
+    pub(crate) fn contains(&self, name: &str) -> bool {
+        self.scopes
+            .iter()
+            .rev()
+            .any(|scope| scope.vars.contains_key(name))
+    }
+
     pub fn define(&mut self, name: &str, value: VmValue, mutable: bool) -> Result<(), VmError> {
         if let Some(scope) = self.scopes.last_mut() {
             if let Some((_, existing_mutable)) = scope.vars.get(name) {

--- a/crates/harn-vm/src/vm/methods/dict.rs
+++ b/crates/harn-vm/src/vm/methods/dict.rs
@@ -38,6 +38,12 @@ impl crate::vm::Vm {
             ))),
             "merge" => {
                 if let Some(VmValue::Dict(other)) = args.first() {
+                    if map.is_empty() {
+                        return Ok(VmValue::Dict(Rc::clone(other)));
+                    }
+                    if other.is_empty() {
+                        return Ok(VmValue::Dict(Rc::clone(map)));
+                    }
                     let mut result = (**map).clone();
                     result.extend(other.iter().map(|(k, v)| (k.clone(), v.clone())));
                     Ok(VmValue::Dict(Rc::new(result)))

--- a/crates/harn-vm/src/vm/ops/arithmetic.rs
+++ b/crates/harn-vm/src/vm/ops/arithmetic.rs
@@ -143,29 +143,57 @@ impl super::super::Vm {
     }
 
     fn add(&self, a: VmValue, b: VmValue) -> Result<VmValue, VmError> {
-        match (&a, &b) {
-            (VmValue::Int(x), VmValue::Int(y)) => Ok(VmValue::Int(x.wrapping_add(*y))),
+        match (a, b) {
+            (VmValue::Int(x), VmValue::Int(y)) => Ok(VmValue::Int(x.wrapping_add(y))),
             (VmValue::Float(x), VmValue::Float(y)) => Ok(VmValue::Float(x + y)),
-            (VmValue::Int(x), VmValue::Float(y)) => Ok(VmValue::Float(*x as f64 + y)),
-            (VmValue::Float(x), VmValue::Int(y)) => Ok(VmValue::Float(x + *y as f64)),
+            (VmValue::Int(x), VmValue::Float(y)) => Ok(VmValue::Float(x as f64 + y)),
+            (VmValue::Float(x), VmValue::Int(y)) => Ok(VmValue::Float(x + y as f64)),
             (VmValue::String(x), VmValue::String(y)) => {
+                if x.is_empty() {
+                    return Ok(VmValue::String(y));
+                }
+                if y.is_empty() {
+                    return Ok(VmValue::String(x));
+                }
                 let mut s = String::with_capacity(x.len() + y.len());
-                s.push_str(x);
-                s.push_str(y);
+                s.push_str(&x);
+                s.push_str(&y);
                 Ok(VmValue::String(Rc::from(s)))
             }
             (VmValue::List(x), VmValue::List(y)) => {
-                let mut result = Vec::with_capacity(x.len() + y.len());
-                result.extend(x.iter().cloned());
-                result.extend(y.iter().cloned());
+                if x.is_empty() {
+                    return Ok(VmValue::List(y));
+                }
+                if y.is_empty() {
+                    return Ok(VmValue::List(x));
+                }
+                let y_len = y.len();
+                let mut result = Rc::try_unwrap(x).unwrap_or_else(|items| items.as_ref().clone());
+                result.reserve(y_len);
+                match Rc::try_unwrap(y) {
+                    Ok(items) => result.extend(items),
+                    Err(items) => result.extend(items.iter().cloned()),
+                }
                 Ok(VmValue::List(Rc::new(result)))
             }
             (VmValue::Dict(x), VmValue::Dict(y)) => {
-                let mut result = (**x).clone();
-                result.extend(y.iter().map(|(k, v)| (k.clone(), v.clone())));
+                if x.is_empty() {
+                    return Ok(VmValue::Dict(y));
+                }
+                if y.is_empty() {
+                    return Ok(VmValue::Dict(x));
+                }
+                let mut result =
+                    Rc::try_unwrap(x).unwrap_or_else(|entries| entries.as_ref().clone());
+                match Rc::try_unwrap(y) {
+                    Ok(entries) => result.extend(entries),
+                    Err(entries) => {
+                        result.extend(entries.iter().map(|(k, v)| (k.clone(), v.clone())))
+                    }
+                }
                 Ok(VmValue::Dict(Rc::new(result)))
             }
-            _ => Err(VmError::TypeError(format!(
+            (a, b) => Err(VmError::TypeError(format!(
                 "Cannot add {} and {}",
                 a.type_name(),
                 b.type_name()

--- a/crates/harn-vm/src/vm/ops/collections.rs
+++ b/crates/harn-vm/src/vm/ops/collections.rs
@@ -5,6 +5,53 @@ use crate::chunk::{InlineCacheEntry, PropertyCacheTarget};
 use crate::value::{VmError, VmValue};
 
 impl super::super::Vm {
+    fn char_to_value(ch: char) -> VmValue {
+        let mut buffer = [0; 4];
+        VmValue::String(Rc::from(ch.encode_utf8(&mut buffer)))
+    }
+
+    fn index_from_end(index: i64) -> Option<usize> {
+        index
+            .checked_neg()?
+            .checked_sub(1)
+            .and_then(|offset| usize::try_from(offset).ok())
+    }
+
+    fn string_index(s: &str, index: i64) -> VmValue {
+        if s.is_ascii() {
+            let pos = if index < 0 {
+                Self::index_from_end(index)
+                    .and_then(|offset| offset.checked_add(1))
+                    .and_then(|distance| s.len().checked_sub(distance))
+            } else {
+                usize::try_from(index).ok()
+            };
+            return pos
+                .and_then(|pos| s.as_bytes().get(pos))
+                .map(|byte| Self::char_to_value(*byte as char))
+                .unwrap_or(VmValue::Nil);
+        }
+
+        if index < 0 {
+            let Some(index) = Self::index_from_end(index) else {
+                return VmValue::Nil;
+            };
+            return s
+                .chars()
+                .rev()
+                .nth(index)
+                .map(Self::char_to_value)
+                .unwrap_or(VmValue::Nil);
+        }
+        s.chars()
+            .nth(match usize::try_from(index) {
+                Ok(index) => index,
+                Err(_) => return VmValue::Nil,
+            })
+            .map(Self::char_to_value)
+            .unwrap_or(VmValue::Nil)
+    }
+
     fn try_cached_property(
         cache: &InlineCacheEntry,
         name_idx: u16,
@@ -22,6 +69,29 @@ impl super::super::Vm {
         }
 
         match (target, obj) {
+            (PropertyCacheTarget::DictField(name), VmValue::Dict(map)) => {
+                Some(map.get(name.as_ref()).cloned().unwrap_or(VmValue::Nil))
+            }
+            (
+                PropertyCacheTarget::StructField { field_name, index },
+                VmValue::StructInstance { layout, fields },
+            ) => {
+                if layout
+                    .field_names()
+                    .get(*index)
+                    .is_some_and(|candidate| candidate.as_str() == field_name.as_ref())
+                {
+                    Some(
+                        fields
+                            .get(*index)
+                            .and_then(Option::as_ref)
+                            .cloned()
+                            .unwrap_or(VmValue::Nil),
+                    )
+                } else {
+                    None
+                }
+            }
             (PropertyCacheTarget::ListCount, VmValue::List(items)) => {
                 Some(VmValue::Int(items.len() as i64))
             }
@@ -43,7 +113,7 @@ impl super::super::Vm {
             (PropertyCacheTarget::PairFirst, VmValue::Pair(p)) => Some(p.0.clone()),
             (PropertyCacheTarget::PairSecond, VmValue::Pair(p)) => Some(p.1.clone()),
             (PropertyCacheTarget::EnumVariant, VmValue::EnumVariant { variant, .. }) => {
-                Some(VmValue::String(Rc::from(variant.as_ref())))
+                Some(VmValue::String(Rc::clone(variant)))
             }
             (PropertyCacheTarget::EnumFields, VmValue::EnumVariant { fields, .. }) => {
                 Some(VmValue::List(fields.clone()))
@@ -54,6 +124,15 @@ impl super::super::Vm {
 
     fn property_cache_target(obj: &VmValue, name: &str) -> Option<PropertyCacheTarget> {
         match obj {
+            VmValue::Dict(_) => Some(PropertyCacheTarget::DictField(Rc::from(name))),
+            VmValue::StructInstance { layout, .. } => {
+                layout
+                    .field_index(name)
+                    .map(|index| PropertyCacheTarget::StructField {
+                        field_name: Rc::from(name),
+                        index,
+                    })
+            }
             VmValue::List(_) => match name {
                 "count" => Some(PropertyCacheTarget::ListCount),
                 "empty" => Some(PropertyCacheTarget::ListEmpty),
@@ -99,7 +178,7 @@ impl super::super::Vm {
             VmValue::EnumVariant {
                 variant, fields, ..
             } => match name {
-                "variant" => VmValue::String(Rc::from(variant.as_ref())),
+                "variant" => VmValue::String(Rc::clone(variant)),
                 "fields" => VmValue::List(fields.clone()),
                 _ => VmValue::Nil,
             },
@@ -150,10 +229,10 @@ impl super::super::Vm {
             .stack
             .split_off(self.stack.len().saturating_sub(count * 2));
         let mut map = BTreeMap::new();
-        for pair in pairs.chunks(2) {
-            if pair.len() == 2 {
-                let key = pair[0].display();
-                map.insert(key, pair[1].clone());
+        let mut pairs = pairs.into_iter();
+        while let Some(key) = pairs.next() {
+            if let Some(value) = pairs.next() {
+                map.insert(key.display(), value);
             }
         }
         self.stack.push(VmValue::Dict(Rc::new(map)));
@@ -179,6 +258,9 @@ impl super::super::Vm {
                     items.get(*i as usize).cloned().unwrap_or(VmValue::Nil)
                 }
             }
+            (VmValue::Dict(map), VmValue::String(key)) => {
+                map.get(key.as_ref()).cloned().unwrap_or(VmValue::Nil)
+            }
             (VmValue::Dict(map), _) => map.get(&idx.display()).cloned().unwrap_or(VmValue::Nil),
             (VmValue::Range(r), VmValue::Int(i)) => {
                 let len = r.len();
@@ -192,25 +274,7 @@ impl super::super::Vm {
                     }
                 }
             }
-            (VmValue::String(s), VmValue::Int(i)) => {
-                if *i < 0 {
-                    let count = s.chars().count() as i64;
-                    let pos = count + *i;
-                    if pos < 0 {
-                        VmValue::Nil
-                    } else {
-                        s.chars()
-                            .nth(pos as usize)
-                            .map(|c| VmValue::String(Rc::from(c.to_string())))
-                            .unwrap_or(VmValue::Nil)
-                    }
-                } else {
-                    s.chars()
-                        .nth(*i as usize)
-                        .map(|c| VmValue::String(Rc::from(c.to_string())))
-                        .unwrap_or(VmValue::Nil)
-                }
-            }
+            (VmValue::String(s), VmValue::Int(i)) => Self::string_index(s, *i),
             _ => {
                 return Err(VmError::TypeError(format!(
                     "cannot index into {} with {}",
@@ -352,15 +416,16 @@ impl super::super::Vm {
         } else if let Some(result) = Self::try_cached_property(&cache_entry, name_idx, &obj) {
             self.stack.push(result);
         } else {
-            let name = {
+            let (result, target) = {
                 let frame = self.frames.last().unwrap();
-                Self::const_string(&frame.chunk.constants[name_idx as usize])?
+                let name = Self::const_str(&frame.chunk.constants[name_idx as usize])?;
+                (
+                    Self::resolve_property(&obj, name, optional)?,
+                    Self::property_cache_target(&obj, name),
+                )
             };
-            let result = Self::resolve_property(&obj, &name, optional)?;
 
-            if let (Some(slot), Some(target)) =
-                (cache_slot, Self::property_cache_target(&obj, &name))
-            {
+            if let (Some(slot), Some(target)) = (cache_slot, target) {
                 let frame = self.frames.last().unwrap();
                 frame
                     .chunk

--- a/crates/harn-vm/src/vm/scope.rs
+++ b/crates/harn-vm/src/vm/scope.rs
@@ -44,7 +44,7 @@ impl Vm {
         // without leaking caller-local data into the callee.
         for scope in &caller_env.scopes {
             for (name, (val, mutable)) in &scope.vars {
-                if matches!(val, VmValue::Closure(_)) && call_env.get(name).is_none() {
+                if matches!(val, VmValue::Closure(_)) && !call_env.contains(name) {
                     let _ = call_env.define(name, val.clone(), *mutable);
                 }
             }

--- a/crates/harn-vm/src/vm/state.rs
+++ b/crates/harn-vm/src/vm/state.rs
@@ -283,36 +283,28 @@ impl Vm {
     }
 
     pub(crate) fn sync_current_frame_locals_to_env(&mut self) {
-        let Some(frame) = self.frames.last_mut() else {
+        let frames = &mut self.frames;
+        let env = &mut self.env;
+        let Some(frame) = frames.last_mut() else {
             return;
         };
         let local_scope_base = frame.local_scope_base;
         let local_scope_depth = frame.local_scope_depth;
-        let entries = frame
+        for (slot, info) in frame
             .local_slots
             .iter_mut()
             .zip(frame.chunk.local_slots.iter())
-            .filter_map(|(slot, info)| {
-                if slot.initialized && !slot.synced && info.scope_depth <= local_scope_depth {
-                    slot.synced = true;
-                    Some((
-                        local_scope_base + info.scope_depth,
-                        info.name.clone(),
-                        slot.value.clone(),
-                        info.mutable,
-                    ))
-                } else {
-                    None
+        {
+            if slot.initialized && !slot.synced && info.scope_depth <= local_scope_depth {
+                slot.synced = true;
+                let scope_idx = local_scope_base + info.scope_depth;
+                while env.scopes.len() <= scope_idx {
+                    env.push_scope();
                 }
-            })
-            .collect::<Vec<_>>();
-        for (scope_idx, name, value, mutable) in entries {
-            while self.env.scopes.len() <= scope_idx {
-                self.env.push_scope();
+                env.scopes[scope_idx]
+                    .vars
+                    .insert(info.name.clone(), (slot.value.clone(), info.mutable));
             }
-            self.env.scopes[scope_idx]
-                .vars
-                .insert(name, (value, mutable));
         }
     }
 
@@ -333,7 +325,7 @@ impl Vm {
             .zip(frame.chunk.local_slots.iter())
             .filter(|(slot, info)| slot.initialized && info.scope_depth <= frame.local_scope_depth)
         {
-            if matches!(slot.value, VmValue::Closure(_)) && call_env.get(&info.name).is_none() {
+            if matches!(slot.value, VmValue::Closure(_)) && !call_env.contains(&info.name) {
                 let _ = call_env.define(&info.name, slot.value.clone(), info.mutable);
             }
         }
@@ -610,6 +602,13 @@ impl Vm {
     pub(crate) fn const_string(c: &Constant) -> Result<String, VmError> {
         match c {
             Constant::String(s) => Ok(s.clone()),
+            _ => Err(VmError::TypeError("expected string constant".into())),
+        }
+    }
+
+    pub(crate) fn const_str(c: &Constant) -> Result<&str, VmError> {
+        match c {
+            Constant::String(s) => Ok(s.as_str()),
             _ => Err(VmError::TypeError("expected string constant".into())),
         }
     }

--- a/crates/harn-vm/src/vm/tests_runtime.rs
+++ b/crates/harn-vm/src/vm/tests_runtime.rs
@@ -534,8 +534,17 @@ match x { "a" -> { log("first") } "b" -> { log("second") } "c" -> { log("third")
 
 #[test]
 fn test_subscript() {
-    let out = run_output("pipeline t(task) { let arr = [10, 20, 30]\nlog(arr[1]) }");
-    assert_eq!(out, "[harn] 20");
+    let out = run_output(
+        r#"pipeline t(task) {
+let arr = [10, 20, 30]
+let dict = {name: "harn"}
+log(arr[1])
+log(dict["name"])
+log("abc"[1])
+log("éx"[-1])
+}"#,
+    );
+    assert_eq!(out, "[harn] 20\n[harn] harn\n[harn] b\n[harn] x");
 }
 
 #[test]
@@ -615,6 +624,50 @@ log(total)
                 target: PropertyCacheTarget::PairSecond,
                 ..
             }
+        )),
+        "{entries:?}"
+    );
+}
+
+#[test]
+fn test_inline_cache_warms_dict_and_struct_property_sites() {
+    let (chunk, out, _) = run_harn_with_chunk(
+        r#"pipeline t(task) {
+struct Point {
+  x: int
+  y: int
+}
+let record = {hot: 7}
+let point = Point {x: 2, y: 3}
+var i = 0
+var total = 0
+while i < 3 {
+  total = total + record.hot + point.y
+  i = i + 1
+}
+log(total)
+}"#,
+    );
+
+    assert_eq!(out.trim_end(), "[harn] 30");
+    let entries = chunk.inline_cache_entries();
+    assert!(
+        entries.iter().any(|entry| matches!(
+            entry,
+            InlineCacheEntry::Property {
+                target: PropertyCacheTarget::DictField(name),
+                ..
+            } if name.as_ref() == "hot"
+        )),
+        "{entries:?}"
+    );
+    assert!(
+        entries.iter().any(|entry| matches!(
+            entry,
+            InlineCacheEntry::Property {
+                target: PropertyCacheTarget::StructField { field_name, index },
+                ..
+            } if field_name.as_ref() == "y" && *index == 1
         )),
         "{entries:?}"
     );

--- a/perf/vm/Cargo.toml
+++ b/perf/vm/Cargo.toml
@@ -9,8 +9,14 @@ harn-vm = { path = "../../crates/harn-vm", features = ["vm-bench-internals"] }
 
 [dev-dependencies]
 criterion = "0.8"
+tokio = { version = "1", features = ["rt", "time"] }
 
 [[bench]]
 name = "bench_vmenv_clone"
 path = "bench_vmenv_clone.rs"
+harness = false
+
+[[bench]]
+name = "bench_vm_fixtures"
+path = "bench_vm_fixtures.rs"
 harness = false

--- a/perf/vm/README.md
+++ b/perf/vm/README.md
@@ -38,6 +38,15 @@ It measures the internal non-module closure call environment path at 0, 5, 25,
 and 100 captured names. Criterion reports time per call; the benchmark also
 prints allocation operations per call for each capture count.
 
+The fixture suite also has an allocation-counting Criterion harness:
+
+```bash
+cargo bench -p harn-vm-perf --bench bench_vm_fixtures
+```
+
+It runs the checked-in `.harn` fixtures in-process and prints allocation
+operations and allocated bytes per fixture run.
+
 This suite is intentionally not part of `make all`; local CPU load, thermal
 state, and target cache state are too noisy for a default correctness gate. For
 before/after VM optimization work, run the suite several times on the same

--- a/perf/vm/agent_tool_dispatch.harn
+++ b/perf/vm/agent_tool_dispatch.harn
@@ -1,0 +1,56 @@
+fn bench_tools() {
+  var tools = tool_registry()
+  tools = tool_define(
+    tools,
+    "read",
+    "Read a synthetic path",
+    {
+      handler: { args -> "read " + args.path + ":" + to_string(args.line) },
+      parameters: {path: {type: "string"}, line: {type: "integer"}},
+      returns: {type: "string"},
+      annotations: {kind: "read"},
+    },
+  )
+  tools = tool_define(
+    tools,
+    "summarize",
+    "Summarize a synthetic blob",
+    {
+      handler: { args -> args.title + ":" + to_string(len(args.body)) },
+      parameters: {title: {type: "string"}, body: {type: "string"}},
+      returns: {type: "string"},
+      annotations: {kind: "read"},
+    },
+  )
+  return tools
+}
+
+pipeline default(task) {
+  let tools = bench_tools()
+  let calls = [
+    {id: "read-001", name: "read", arguments: {path: "src/a.harn", line: 1}},
+    {id: "read-002", name: "read", arguments: {path: "src/b.harn", line: 21}},
+    {id: "read-003", name: "read", arguments: {path: "src/c.harn", line: 55}},
+    {id: "summary-001", name: "summarize", arguments: {title: "alpha", body: "abcdefghij"}},
+    {id: "summary-002", name: "summarize", arguments: {title: "beta", body: "klmnopqrst"}},
+    {id: "read-004", name: "read", arguments: {path: "src/d.harn", line: 89}},
+  ]
+  var iteration = 0
+  var total = 0
+  while iteration < 500 {
+    let results = agent_dispatch_tool_batch(
+      calls,
+      tools,
+      {session_id: "bench-agent-tool-dispatch", tool_retries: 0, tool_backoff_ms: 1},
+    )
+    for result in results {
+      if result.ok {
+        total = total + len(result.rendered_result)
+      }
+    }
+    iteration = iteration + 1
+  }
+  if total < 0 {
+    log("unreachable")
+  }
+}

--- a/perf/vm/bench_vm_fixtures.rs
+++ b/perf/vm/bench_vm_fixtures.rs
@@ -1,0 +1,171 @@
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::hint::black_box;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use tokio::runtime::{Builder, Runtime};
+
+const FIXTURES: &[&str] = &[
+    "agent_tool_dispatch.harn",
+    "arithmetic_loop.harn",
+    "comparison_loop.harn",
+    "dict_property_read.harn",
+    "function_call_loop.harn",
+    "list_iteration.harn",
+    "list_map_filter.harn",
+    "local_variable_lookup.harn",
+    "method_call_dispatch.harn",
+    "recursive_countdown.harn",
+    "string_interpolation_loop.harn",
+    "struct_field_read.harn",
+];
+
+static TRACK_ALLOCATIONS: AtomicBool = AtomicBool::new(false);
+static ALLOCATION_COUNT: AtomicU64 = AtomicU64::new(0);
+static ALLOCATED_BYTES: AtomicU64 = AtomicU64::new(0);
+
+struct CountingAllocator;
+
+#[global_allocator]
+static GLOBAL_ALLOCATOR: CountingAllocator = CountingAllocator;
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ptr = unsafe { System.alloc(layout) };
+        record_allocation(ptr, layout.size());
+        ptr
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        let ptr = unsafe { System.alloc_zeroed(layout) };
+        record_allocation(ptr, layout.size());
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) };
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let ptr = unsafe { System.realloc(ptr, layout, new_size) };
+        record_allocation(ptr, new_size);
+        ptr
+    }
+}
+
+fn record_allocation(ptr: *mut u8, bytes: usize) {
+    if !ptr.is_null() && TRACK_ALLOCATIONS.load(Ordering::Relaxed) {
+        ALLOCATION_COUNT.fetch_add(1, Ordering::Relaxed);
+        ALLOCATED_BYTES.fetch_add(bytes as u64, Ordering::Relaxed);
+    }
+}
+
+struct Fixture {
+    name: String,
+    path: PathBuf,
+    source: String,
+    chunk: harn_vm::Chunk,
+}
+
+fn runtime() -> Runtime {
+    Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("benchmark runtime")
+}
+
+fn load_fixture(name: &str) -> Fixture {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(name);
+    let source = std::fs::read_to_string(&path).expect("benchmark fixture should be readable");
+    let chunk = harn_vm::compile_source(&source).expect("benchmark fixture should compile");
+    Fixture {
+        name: name.trim_end_matches(".harn").to_string(),
+        path,
+        source,
+        chunk,
+    }
+}
+
+fn setup_vm(fixture: &Fixture) -> harn_vm::Vm {
+    harn_vm::reset_thread_local_state();
+    let mut vm = harn_vm::Vm::new();
+    harn_vm::register_vm_stdlib(&mut vm);
+    vm.set_source_info(&fixture.path.to_string_lossy(), &fixture.source);
+    if let Some(parent) = fixture.path.parent() {
+        vm.set_source_dir(parent);
+    }
+    vm
+}
+
+fn execute_fixture(runtime: &Runtime, fixture: &Fixture, mut vm: harn_vm::Vm) {
+    runtime.block_on(async {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let result = vm.execute(&fixture.chunk).await;
+                black_box(result.expect("benchmark fixture should execute"));
+            })
+            .await;
+    });
+}
+
+fn allocation_stats_per_run(runtime: &Runtime, fixture: &Fixture, samples: u64) -> (f64, f64) {
+    ALLOCATION_COUNT.store(0, Ordering::Relaxed);
+    ALLOCATED_BYTES.store(0, Ordering::Relaxed);
+    for _ in 0..samples {
+        let vm = setup_vm(fixture);
+        TRACK_ALLOCATIONS.store(true, Ordering::Relaxed);
+        execute_fixture(runtime, fixture, vm);
+        TRACK_ALLOCATIONS.store(false, Ordering::Relaxed);
+    }
+    (
+        ALLOCATION_COUNT.load(Ordering::Relaxed) as f64 / samples as f64,
+        ALLOCATED_BYTES.load(Ordering::Relaxed) as f64 / samples as f64,
+    )
+}
+
+fn timed_runs(runtime: &Runtime, fixture: &Fixture, iterations: u64) -> Duration {
+    let mut total = Duration::ZERO;
+    for _ in 0..iterations {
+        let vm = setup_vm(fixture);
+        let started = Instant::now();
+        execute_fixture(runtime, fixture, vm);
+        total += started.elapsed();
+    }
+    total
+}
+
+fn bench_vm_fixtures(c: &mut Criterion) {
+    let runtime = runtime();
+    let fixtures = FIXTURES
+        .iter()
+        .map(|name| load_fixture(name))
+        .collect::<Vec<_>>();
+
+    let mut group = c.benchmark_group("vm_fixtures");
+    for fixture in &fixtures {
+        let (allocations, allocated_bytes) = allocation_stats_per_run(&runtime, fixture, 10);
+        eprintln!(
+            "vm_fixtures/{}: {:.2} allocations/run, {:.1} allocated bytes/run",
+            fixture.name, allocations, allocated_bytes
+        );
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(&fixture.name),
+            fixture,
+            |b, fixture| {
+                b.iter_custom(|iterations| timed_runs(&runtime, black_box(fixture), iterations));
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(10);
+    targets = bench_vm_fixtures
+}
+criterion_main!(benches);


### PR DESCRIPTION
## Summary

Closes #1376.

- Add dict-field and guarded struct-field inline cache targets, plus lower-allocation string/dict/list hot paths.
- Move tool dispatch parsing onto borrowed/moved VM values so batches avoid rebuilding args/tools/options for every call.
- Add an allocation-counting VM fixture Criterion harness and a deterministic `agent_tool_dispatch` fixture.

## Benchmarks

`origin/main` baseline was measured in `/tmp/harn-1376-before` at `f965d27c` with `scripts/bench_vm.sh --iterations 5`. The final branch was measured after rebasing on `origin/main` with `scripts/bench_vm.sh --no-build --iterations 5` after an incremental release rebuild.

| fixture | baseline avg ms | branch avg ms | delta |
| --- | ---: | ---: | ---: |
| dict_property_read | 75.11 | 70.36 | -6.3% |
| struct_field_read | 80.30 | 76.75 | -4.4% |
| list_map_filter | 316.08 | 293.57 | -7.1% |
| function_call_loop | 75.34 | 72.91 | -3.2% |
| method_call_dispatch | 56.22 | 55.58 | -1.1% |
| agent_tool_dispatch | n/a | 48.34 | new fixture |

Allocation harness, using the same `bench_vm_fixtures` code copied into the temporary baseline worktree for an apples-to-apples measurement:

| fixture | allocations/run | allocated bytes/run |
| --- | ---: | ---: |
| dict_property_read | 1,200,044 -> 750,044 (-37.5%) | 4,956,835 -> 2,856,842 (-42.4%) |
| struct_field_read | 1,350,069 -> 900,069 (-33.3%) | 3,758,284 -> 3,308,291 (-12.0%) |
| agent_tool_dispatch | 1,596,103 -> 1,538,602 (-3.6%) | 267,247,815 -> 260,668,616 (-2.5%) |

The existing `bench_vmenv_clone` closure-env allocation counts are unchanged: captures 0/5/25/100 remain 3/8/32/119 allocations per call.

## Verification

- Pre-commit hook: Rust fmt, Harn fmt/lint, clippy `--workspace --all-targets -D warnings`, markdownlint, ratchets.
- Pre-push hook: targeted package checks, affected Harn fmt/lint, markdownlint.
- `CARGO_TARGET_DIR=/tmp/harn-1376-target make test` (3,418 passed, 2 skipped).
- `CARGO_TARGET_DIR=/tmp/harn-1376-target cargo run --quiet --bin harn -- check perf/vm/agent_tool_dispatch.harn`.
- `CARGO_TARGET_DIR=/tmp/harn-1376-target cargo run --quiet --bin harn -- test conformance --filter agent_primitives_one_turn`.
- `CARGO_TARGET_DIR=/tmp/harn-1376-target cargo run --quiet --bin harn -- test conformance --filter agent_host_tools`.
- `CARGO_TARGET_DIR=/tmp/harn-1376-target cargo run --quiet --bin harn -- test conformance --filter tool_hooks`.
- `CARGO_TARGET_DIR=/tmp/harn-1376-after-target cargo bench -p harn-vm-perf --bench bench_vm_fixtures -- --output-format bencher`.
- `CARGO_TARGET_DIR=/tmp/harn-1376-after-target cargo bench -p harn-vm-perf --bench bench_vmenv_clone -- --output-format bencher`.
