### PR TITLE
Add review and on-call persona packages

### DIFF
--- a/personas/oncall_captain/README.md
+++ b/personas/oncall_captain/README.md
@@ -1,0 +1,14 @@
+# Oncall Captain Persona
+
+This is the canonical Harn package for `oncall_captain`. Hosts such as
+Burin Code should discover it through `harn persona list --json` and
+`harn persona inspect oncall_captain --json`, then treat the resulting
+manifest as Harn-owned metadata.
+
+## Local Checks
+
+```bash
+cargo run --quiet --bin harn -- persona --manifest personas/oncall_captain/harn.toml inspect oncall_captain --json
+cargo run --quiet --bin harn -- run personas/oncall_captain/manifest.harn
+cargo run --quiet --bin harn -- eval personas/oncall_captain/evals/oncall_captain_smoke.json
+```

--- a/personas/oncall_captain/evals/oncall_captain_smoke.json
+++ b/personas/oncall_captain/evals/oncall_captain_smoke.json
@@ -1,0 +1,11 @@
+{
+  "_type": "eval_suite_manifest",
+  "id": "oncall_captain_smoke",
+  "name": "oncall_captain smoke",
+  "cases": [
+    {
+      "label": "oncall_captain_verification_plan",
+      "run_path": "../runs/oncall_captain_smoke.run.json"
+    }
+  ]
+}

--- a/personas/oncall_captain/fixtures/incident.json
+++ b/personas/oncall_captain/fixtures/incident.json
@@ -1,0 +1,17 @@
+{
+  "event": "pagerduty.incident_triggered",
+  "oncall_captain": {
+    "service": "orchestrator-api",
+    "hypothesis": "a deploy introduced a replay-loop regression",
+    "symptoms": [
+      "pagerduty page",
+      "error-rate spike",
+      "slack escalation"
+    ],
+    "observability_backends": [
+      "mcp:honeycomb",
+      "mcp:splunk"
+    ],
+    "human_owner": "primary-oncall"
+  }
+}

--- a/personas/oncall_captain/harn.toml
+++ b/personas/oncall_captain/harn.toml
@@ -1,0 +1,30 @@
+[package]
+name = "harn-oncall-captain-persona"
+version = "0.1.0"
+
+[[personas]]
+name = "oncall_captain"
+version = "0.1.0"
+description = "Harn-native on-call captain. Builds approval-first incident verification plans, observability checklists, and outcome receipts."
+entry_workflow = "manifest.harn#run"
+tools = ["pagerduty", "slack", "mcp"]
+capabilities = [
+  "interaction.ask",
+  "project.lessons",
+  "runtime.approved_plan",
+  "runtime.dry_run",
+  "runtime.pipeline_input",
+  "runtime.record_run",
+]
+autonomy_tier = "act_with_approval"
+receipt_policy = "required"
+triggers = ["pagerduty.incident_triggered", "slack.oncall_message"]
+schedules = ["*/15 * * * *"]
+handoffs = []
+context_packs = ["oncall_runbook", "service_ownership", "release_policy"]
+evals = ["oncall_captain_smoke"]
+owner = "sre"
+budget = { daily_usd = 8.0, frontier_escalations = 1, max_tokens = 50000, max_runtime_seconds = 900 }
+model_policy = { default_model = "gpt-5.4-mini", escalation_model = "gpt-5.4", fallback_models = ["gpt-5.2"], reasoning_effort = "high" }
+rollout_policy = { mode = "approval_only", percentage = 100, cohorts = ["oncall-captain-v1"] }
+package_source = { package = "harn-oncall-captain-persona", path = "personas/oncall_captain" }

--- a/personas/oncall_captain/manifest.harn
+++ b/personas/oncall_captain/manifest.harn
@@ -1,0 +1,105 @@
+// Oncall Captain entry pipeline.
+//
+// This package is the canonical Harn home for the incident-response
+// persona Burin surfaces in its persona manager. The default run is a
+// deterministic plan generator and never touches live incident systems.
+import { runtime_pipeline_input } from "std/runtime"
+
+@persona(name: "oncall_captain", description: "Harn-native incident verification captain.", tools: [pagerduty, slack, mcp], autonomy: act_with_approval, receipts: required, triggers: [pagerduty.incident_triggered, slack.oncall_message])
+/** Static persona graph used by `harn persona inspect` to expose Oncall Captain's durable steps. */
+pub fn oncall_captain_persona(ctx) {
+  let input = resolve_incident_input_step(ctx)
+  let signals = collect_incident_signals_step(input)
+  let plan = build_verification_plan_step(signals)
+  let gated = require_human_approval_step(plan)
+  let receipt = emit_incident_receipt_step(gated)
+  return summarize_incident_step(receipt)
+}
+
+@step(name: "resolve_incident_input", receipt: audit, error_boundary: fail)
+fn resolve_incident_input_step(ctx) {
+  return ctx
+}
+
+@step(name: "collect_incident_signals", receipt: audit, error_boundary: continue, retry: {max_attempts: 2})
+fn collect_incident_signals_step(ctx) {
+  return ctx
+}
+
+@step(name: "build_verification_plan", model: "gpt-5.4-mini", receipt: audit, error_boundary: escalate)
+fn build_verification_plan_step(ctx) {
+  return ctx
+}
+
+@step(name: "require_human_approval", approval: required, receipt: audit, error_boundary: fail)
+fn require_human_approval_step(ctx) {
+  return ctx
+}
+
+@step(name: "emit_incident_receipt", receipt: audit, error_boundary: fail)
+fn emit_incident_receipt_step(ctx) {
+  return ctx
+}
+
+@step(name: "summarize_incident", receipt: audit, error_boundary: fail)
+fn summarize_incident_step(ctx) {
+  return ctx
+}
+
+fn _default_incident() {
+  return {
+    service: "orchestrator-api",
+    hypothesis: "a deploy introduced a replay-loop regression",
+    symptoms: ["pagerduty page", "error-rate spike", "slack escalation"],
+    observability_backends: ["mcp:honeycomb", "mcp:splunk"],
+    human_owner: "primary-oncall",
+  }
+}
+
+fn _resolve_incident() {
+  let attempt = try {
+    runtime_pipeline_input()
+  }
+  let provided = if is_ok(attempt) {
+    unwrap(attempt) ?? {}
+  } else {
+    {}
+  }
+  let incident = provided.oncall_captain ?? provided
+  let defaults = _default_incident()
+  return {
+    service: incident.service ?? defaults.service,
+    hypothesis: incident.hypothesis ?? defaults.hypothesis,
+    symptoms: incident.symptoms ?? defaults.symptoms,
+    observability_backends: incident.observability_backends ?? defaults.observability_backends,
+    human_owner: incident.human_owner ?? defaults.human_owner,
+  }
+}
+
+pipeline run(task) {
+  let incident = _resolve_incident()
+  let result = {
+    persona: "oncall_captain",
+    execution_mode: "dry_run",
+    approval_required: true,
+    service: incident.service,
+    summary: "verification plan for ${incident.service}",
+    plan: [
+      "Check the current deploy and the most recent rollback candidate.",
+      "Query observability backends through MCP before proposing side effects.",
+      "Record whether the hypothesis is confirmed, disproven, or unresolved.",
+    ],
+    status: "unresolved",
+    receipt: {
+      kind: "incident_receipt",
+      outcome: "unresolved",
+      hypothesis: incident.hypothesis,
+      symptoms: incident.symptoms,
+      backends: incident.observability_backends,
+      owner: incident.human_owner,
+    },
+    handoff: "review_captain",
+  }
+  println(json_stringify(result))
+  return result
+}

--- a/personas/oncall_captain/runs/oncall_captain_smoke.run.json
+++ b/personas/oncall_captain/runs/oncall_captain_smoke.run.json
@@ -1,0 +1,58 @@
+{
+  "_type": "run_record",
+  "id": "oncall-captain-smoke",
+  "workflow_id": "run",
+  "workflow_name": "oncall_captain",
+  "task": "persona smoke",
+  "status": "completed",
+  "started_at": "2026-04-22T00:00:00Z",
+  "finished_at": "2026-04-22T00:00:01Z",
+  "stages": [
+    {
+      "id": "stage_1",
+      "node_id": "run",
+      "kind": "stage",
+      "status": "completed",
+      "outcome": "success",
+      "started_at": "2026-04-22T00:00:00Z",
+      "finished_at": "2026-04-22T00:00:01Z",
+      "visible_text": "oncall_captain produced a verification plan for orchestrator-api and left side effects pending approval"
+    }
+  ],
+  "completed_nodes": [
+    "run"
+  ],
+  "policy": {
+    "tools": [],
+    "capabilities": {},
+    "workspace_roots": [],
+    "side_effect_level": "read_only",
+    "recursion_limit": null,
+    "tool_arg_constraints": [],
+    "tool_annotations": {}
+  },
+  "metadata": {
+    "persona": "oncall_captain",
+    "fixture": "fixtures/incident.json",
+    "dry_run": true,
+    "approval_required": true
+  },
+  "replay_fixture": {
+    "_type": "replay_fixture",
+    "id": "oncall-captain-smoke-fixture",
+    "source_run_id": "oncall-captain-smoke",
+    "workflow_id": "run",
+    "workflow_name": "oncall_captain",
+    "created_at": "2026-04-22T00:00:01Z",
+    "expected_status": "completed",
+    "stage_assertions": [
+      {
+        "node_id": "run",
+        "expected_status": "completed",
+        "expected_outcome": "success",
+        "required_artifact_kinds": [],
+        "visible_text_contains": "verification plan"
+      }
+    ]
+  }
+}

--- a/personas/review_captain/README.md
+++ b/personas/review_captain/README.md
@@ -1,0 +1,14 @@
+# Review Captain Persona
+
+This is the canonical Harn package for `review_captain`. Hosts such as
+Burin Code should discover it through `harn persona list --json` and
+`harn persona inspect review_captain --json`, then treat the resulting
+manifest as Harn-owned metadata.
+
+## Local Checks
+
+```bash
+cargo run --quiet --bin harn -- persona --manifest personas/review_captain/harn.toml inspect review_captain --json
+cargo run --quiet --bin harn -- run personas/review_captain/manifest.harn
+cargo run --quiet --bin harn -- eval personas/review_captain/evals/review_captain_smoke.json
+```

--- a/personas/review_captain/evals/review_captain_smoke.json
+++ b/personas/review_captain/evals/review_captain_smoke.json
@@ -1,0 +1,11 @@
+{
+  "_type": "eval_suite_manifest",
+  "id": "review_captain_smoke",
+  "name": "review_captain smoke",
+  "cases": [
+    {
+      "label": "review_captain_structured_receipt",
+      "run_path": "../runs/review_captain_smoke.run.json"
+    }
+  ]
+}

--- a/personas/review_captain/fixtures/handoff.json
+++ b/personas/review_captain/fixtures/handoff.json
@@ -1,0 +1,17 @@
+{
+  "event": "github.review_requested",
+  "review_captain": {
+    "repo": "burin-labs/harn",
+    "pr_number": 463,
+    "changed_files": [
+      "personas/review_captain/harn.toml",
+      "personas/review_captain/manifest.harn"
+    ],
+    "missing_tests": [
+      "persona smoke run"
+    ],
+    "risky_paths": [
+      "personas/review_captain/harn.toml"
+    ]
+  }
+}

--- a/personas/review_captain/harn.toml
+++ b/personas/review_captain/harn.toml
@@ -1,0 +1,29 @@
+[package]
+name = "harn-review-captain-persona"
+version = "0.1.0"
+
+[[personas]]
+name = "review_captain"
+version = "0.1.0"
+description = "Harn-native review captain. Produces deterministic review receipts, missing-test checks, and approval-ready follow-up handoff summaries."
+entry_workflow = "manifest.harn#run"
+tools = ["github", "mcp"]
+capabilities = [
+  "git.get_diff",
+  "project.scan",
+  "runtime.dry_run",
+  "runtime.pipeline_input",
+  "runtime.record_run",
+]
+autonomy_tier = "suggest"
+receipt_policy = "required"
+triggers = ["github.review_requested", "github.pull_request_synchronized"]
+schedules = ["0 */2 * * *"]
+handoffs = []
+context_packs = ["repo_policy", "review_policy"]
+evals = ["review_captain_smoke"]
+owner = "engineering"
+budget = { daily_usd = 4.0, frontier_escalations = 1, max_tokens = 40000, max_runtime_seconds = 300 }
+model_policy = { default_model = "gpt-5.4-mini", escalation_model = "gpt-5.4", fallback_models = ["gpt-5.2"], reasoning_effort = "medium" }
+rollout_policy = { mode = "approval_only", percentage = 100, cohorts = ["review-captain-v1"] }
+package_source = { package = "harn-review-captain-persona", path = "personas/review_captain" }

--- a/personas/review_captain/manifest.harn
+++ b/personas/review_captain/manifest.harn
@@ -1,0 +1,106 @@
+// Review Captain entry pipeline.
+//
+// This package is the canonical Harn home for the review persona Burin
+// surfaces in its persona manager. The workflow remains deterministic by
+// default so local smoke runs do not require live GitHub credentials.
+import { runtime_pipeline_input } from "std/runtime"
+
+@persona(name: "review_captain", description: "Harn-native review quality captain.", tools: [github], autonomy: suggest, receipts: required, triggers: [github.review_requested, github.pull_request_synchronized])
+/** Static persona graph used by `harn persona inspect` to expose Review Captain's durable steps. */
+pub fn review_captain_persona(ctx) {
+  let input = resolve_review_input_step(ctx)
+  let diff = collect_review_context_step(input)
+  let verdict = classify_review_risk_step(diff)
+  let receipt = emit_review_receipt_step({input: input, verdict: verdict})
+  return summarize_review_step(receipt)
+}
+
+@step(name: "resolve_review_input", receipt: audit, error_boundary: fail)
+fn resolve_review_input_step(ctx) {
+  return ctx
+}
+
+@step(name: "collect_review_context", receipt: audit, error_boundary: fail)
+fn collect_review_context_step(ctx) {
+  return ctx
+}
+
+@step(name: "classify_review_risk", model: "gpt-5.4-mini", receipt: audit, error_boundary: escalate)
+fn classify_review_risk_step(ctx) {
+  return ctx
+}
+
+@step(name: "emit_review_receipt", receipt: audit, error_boundary: fail)
+fn emit_review_receipt_step(ctx) {
+  return ctx
+}
+
+@step(name: "summarize_review", receipt: audit, error_boundary: fail)
+fn summarize_review_step(ctx) {
+  return ctx
+}
+
+fn _default_review() {
+  return {
+    repo: "burin-labs/harn",
+    pr_number: 463,
+    changed_files: ["personas/review_captain/harn.toml", "personas/review_captain/manifest.harn"],
+    missing_tests: ["persona smoke run"],
+    risky_paths: ["personas/review_captain/harn.toml"],
+  }
+}
+
+fn _resolve_review() {
+  let attempt = try {
+    runtime_pipeline_input()
+  }
+  let provided = if is_ok(attempt) {
+    unwrap(attempt) ?? {}
+  } else {
+    {}
+  }
+  let review = provided.review_captain ?? provided
+  let defaults = _default_review()
+  return {
+    repo: review.repo ?? defaults.repo,
+    pr_number: review.pr_number ?? defaults.pr_number,
+    changed_files: review.changed_files ?? defaults.changed_files,
+    missing_tests: review.missing_tests ?? defaults.missing_tests,
+    risky_paths: review.risky_paths ?? defaults.risky_paths,
+  }
+}
+
+fn _review_verdict(review) {
+  if len(review.missing_tests) > 0 || len(review.risky_paths) > 0 {
+    return "needs_follow_up"
+  }
+  return "low_risk"
+}
+
+pipeline run(task) {
+  let review = _resolve_review()
+  let verdict = _review_verdict(review)
+  let result = {
+    persona: "review_captain",
+    execution_mode: "dry_run",
+    approval_required: false,
+    repo: review.repo,
+    pr_number: review.pr_number,
+    summary: "structured review receipt for PR #${review.pr_number}",
+    focus: ["regressions", "missing tests", "risky diffs"],
+    receipt: {
+      kind: "review_receipt",
+      verdict: verdict,
+      missing_tests: review.missing_tests,
+      risky_paths: review.risky_paths,
+      changed_files: review.changed_files,
+    },
+    handoff: if verdict == "needs_follow_up" {
+      "merge_captain"
+    } else {
+      nil
+    },
+  }
+  println(json_stringify(result))
+  return result
+}

--- a/personas/review_captain/runs/review_captain_smoke.run.json
+++ b/personas/review_captain/runs/review_captain_smoke.run.json
@@ -1,0 +1,57 @@
+{
+  "_type": "run_record",
+  "id": "review-captain-smoke",
+  "workflow_id": "run",
+  "workflow_name": "review_captain",
+  "task": "persona smoke",
+  "status": "completed",
+  "started_at": "2026-04-22T00:00:00Z",
+  "finished_at": "2026-04-22T00:00:01Z",
+  "stages": [
+    {
+      "id": "stage_1",
+      "node_id": "run",
+      "kind": "stage",
+      "status": "completed",
+      "outcome": "success",
+      "started_at": "2026-04-22T00:00:00Z",
+      "finished_at": "2026-04-22T00:00:01Z",
+      "visible_text": "review_captain emitted a structured review receipt for PR #463"
+    }
+  ],
+  "completed_nodes": [
+    "run"
+  ],
+  "policy": {
+    "tools": [],
+    "capabilities": {},
+    "workspace_roots": [],
+    "side_effect_level": "read_only",
+    "recursion_limit": null,
+    "tool_arg_constraints": [],
+    "tool_annotations": {}
+  },
+  "metadata": {
+    "persona": "review_captain",
+    "fixture": "fixtures/handoff.json",
+    "dry_run": true
+  },
+  "replay_fixture": {
+    "_type": "replay_fixture",
+    "id": "review-captain-smoke-fixture",
+    "source_run_id": "review-captain-smoke",
+    "workflow_id": "run",
+    "workflow_name": "review_captain",
+    "created_at": "2026-04-22T00:00:01Z",
+    "expected_status": "completed",
+    "stage_assertions": [
+      {
+        "node_id": "run",
+        "expected_status": "completed",
+        "expected_outcome": "success",
+        "required_artifact_kinds": [],
+        "visible_text_contains": "structured review receipt"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Adds Harn-native `review_captain` and `oncall_captain` persona packages beside the existing persona package surface.

- defines package manifests with persona metadata, tools, autonomy, triggers, budgets, model policy, rollout policy, and eval references
- adds deterministic `manifest.harn` dry-run pipelines with `@persona` and `@step` metadata for inspect/list consumers
- adds smoke fixtures, run records, eval definitions, and short package READMEs

This supports burin-labs/burin-code#501 by moving Burin's seeded review/on-call persona definitions into Harn.

## Verification

- `cargo test -p harn-cli --test persona_cli`
- `cargo run --quiet --bin harn -- fmt --check personas/review_captain personas/oncall_captain`
- `cargo run --quiet --bin harn -- persona --manifest personas/review_captain/harn.toml check --json`
- `cargo run --quiet --bin harn -- persona --manifest personas/oncall_captain/harn.toml check --json`
- `cargo run --quiet --bin harn -- run personas/review_captain/manifest.harn`
- `cargo run --quiet --bin harn -- run personas/oncall_captain/manifest.harn`
- `cargo run --quiet --bin harn -- eval personas/review_captain/evals/review_captain_smoke.json`
- `cargo run --quiet --bin harn -- eval personas/oncall_captain/evals/oncall_captain_smoke.json`
- Harn pre-commit and pre-push hooks