### PR TITLE
Add workflow crystallization v2 shadow receipts

### DIFF
--- a/crates/harn-cli/src/cli/crystallize.rs
+++ b/crates/harn-cli/src/cli/crystallize.rs
@@ -47,6 +47,13 @@ pub(crate) struct CrystallizeArgs {
     /// Minimum number of traces that must contain the repeated sequence.
     #[arg(long = "min-examples", default_value_t = 2)]
     pub min_examples: usize,
+    /// Additional trace directory to shadow-run against after mining. May be
+    /// passed more than once for future/holdout fixtures.
+    #[arg(long = "shadow-from", value_name = "TRACE_DIR")]
+    pub shadow_from: Vec<String>,
+    /// Minimum confidence required for promotion metadata to mark a candidate ready.
+    #[arg(long = "promotion-min-confidence", default_value_t = 0.80)]
+    pub promotion_min_confidence: f64,
     /// Override the generated workflow name.
     #[arg(long = "workflow-name", value_name = "NAME")]
     pub workflow_name: Option<String>,

--- a/crates/harn-cli/src/cli/tests.rs
+++ b/crates/harn-cli/src/cli/tests.rs
@@ -434,6 +434,10 @@ fn test_parses_crystallize_args() {
         "harn.eval.toml",
         "--min-examples",
         "5",
+        "--shadow-from",
+        "fixtures/crystallize/holdout",
+        "--promotion-min-confidence",
+        "0.9",
         "--workflow-name",
         "version_bump",
     ]);
@@ -447,6 +451,11 @@ fn test_parses_crystallize_args() {
     assert_eq!(args.report.as_deref(), Some("reports/version_bump.json"));
     assert_eq!(args.eval_pack.as_deref(), Some("harn.eval.toml"));
     assert_eq!(args.min_examples, 5);
+    assert_eq!(
+        args.shadow_from,
+        vec!["fixtures/crystallize/holdout".to_string()]
+    );
+    assert_eq!(args.promotion_min_confidence, 0.9);
     assert_eq!(args.workflow_name.as_deref(), Some("version_bump"));
 }
 

--- a/crates/harn-cli/src/commands/crystallize.rs
+++ b/crates/harn-cli/src/commands/crystallize.rs
@@ -31,11 +31,21 @@ fn run_mine(args: CrystallizeArgs) -> Result<(), String> {
     let trace_dir = PathBuf::from(from);
     let traces = harn_vm::orchestration::load_crystallization_traces_from_dir(&trace_dir)
         .map_err(|error| error.to_string())?;
-    let normalized = traces.clone();
+    let mut bundle_traces = traces.clone();
+    let mut shadow_traces = Vec::new();
+    for shadow_from in &args.shadow_from {
+        let mut loaded =
+            harn_vm::orchestration::load_crystallization_traces_from_dir(Path::new(shadow_from))
+                .map_err(|error| error.to_string())?;
+        bundle_traces.extend(loaded.clone());
+        shadow_traces.append(&mut loaded);
+    }
     let artifacts = harn_vm::orchestration::crystallize_traces(
         traces,
         harn_vm::orchestration::CrystallizeOptions {
             min_examples: args.min_examples,
+            shadow_traces,
+            promotion_min_confidence: args.promotion_min_confidence,
             workflow_name: args.workflow_name.clone(),
             package_name: args.package_name.clone(),
             author: args.author.clone(),
@@ -49,7 +59,7 @@ fn run_mine(args: CrystallizeArgs) -> Result<(), String> {
         Some(
             harn_vm::orchestration::build_crystallization_bundle(
                 artifacts.clone(),
-                &normalized,
+                &bundle_traces,
                 harn_vm::orchestration::BundleOptions {
                     external_key: args.bundle_external_key.clone(),
                     title: args.bundle_title.clone(),
@@ -200,6 +210,7 @@ fn run_ingest(args: CrystallizeIngestArgs) -> Result<(), String> {
             author: args.author.clone(),
             approver: args.approver.clone(),
             eval_pack_link: args.eval_pack.clone(),
+            ..harn_vm::orchestration::CrystallizeOptions::default()
         },
     )
     .map_err(|error| error.to_string())?;

--- a/crates/harn-cli/tests/crystallize_cli.rs
+++ b/crates/harn-cli/tests/crystallize_cli.rs
@@ -18,7 +18,7 @@ use harn_vm::orchestration::{
     build_crystallization_bundle, crystallize_traces, ingest_release_fixture,
     load_crystallization_traces_from_dir, shadow_replay_bundle, validate_crystallization_bundle,
     write_crystallization_artifacts, write_crystallization_bundle, BundleOptions,
-    CrystallizeOptions,
+    CrystallizeOptions, PromotionStatus,
 };
 use serde_json::{json, Value};
 use tempfile::TempDir;
@@ -109,6 +109,14 @@ fn plan_only_trace(idx: usize) -> Value {
     })
 }
 
+fn harn_vm_fixture_dir(relative: &str) -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .join("harn-vm/tests/fixtures")
+        .join(relative)
+}
+
 #[test]
 fn crystallize_version_bump_emits_validatable_bundle() {
     let temp = TempDir::new().unwrap();
@@ -137,6 +145,7 @@ fn crystallize_version_bump_emits_validatable_bundle() {
             author: None,
             approver: None,
             eval_pack_link: Some(eval_pack_path.to_string_lossy().into_owned()),
+            ..CrystallizeOptions::default()
         },
     )
     .expect("crystallize");
@@ -263,6 +272,129 @@ fn crystallize_plan_only_bundle_keeps_plan_only_kind() {
         "validation reported problems: {:#?}",
         validation.problems
     );
+}
+
+#[test]
+fn crystallize_v2_shadow_receipts_promote_only_after_holdout_passes() {
+    let fixture_root = harn_vm_fixture_dir("crystallize_v2_release");
+    let mine_dir = fixture_root.join("mine");
+    let holdout_dir = fixture_root.join("holdout-pass");
+    let temp = TempDir::new().unwrap();
+    let bundle_dir = temp.path().join("bundle");
+
+    let traces = load_crystallization_traces_from_dir(&mine_dir).expect("load mining fixtures");
+    let holdout_traces =
+        load_crystallization_traces_from_dir(&holdout_dir).expect("load holdout fixtures");
+    let mut bundle_traces = traces.clone();
+    bundle_traces.extend(holdout_traces.clone());
+
+    let artifacts = crystallize_traces(
+        traces,
+        CrystallizeOptions {
+            min_examples: 3,
+            shadow_traces: holdout_traces,
+            workflow_name: Some("release_package_maintenance".to_string()),
+            package_name: Some("release-workflows".to_string()),
+            approver: Some("release-lead@example.com".to_string()),
+            ..CrystallizeOptions::default()
+        },
+    )
+    .expect("crystallize");
+
+    let candidate = artifacts.report.candidates.first().expect("candidate");
+    assert!(candidate.shadow.pass);
+    assert_eq!(candidate.examples.len(), 3);
+    assert_eq!(candidate.shadow.compared_traces, 4);
+    assert_eq!(candidate.expected_receipts.len(), 1);
+    assert_eq!(
+        candidate.cluster_key.goal.as_deref(),
+        Some("release package maintenance")
+    );
+    assert!(candidate
+        .cluster_key
+        .tool_sequence
+        .contains(&"git.checkout_branch".to_string()));
+    assert!(candidate
+        .cluster_key
+        .touched_artifact_types
+        .contains(&"file:toml".to_string()));
+    assert_eq!(candidate.promotion.sample_count, 4);
+    assert_eq!(candidate.promotion.source_trace_hashes.len(), 4);
+    assert_eq!(candidate.promotion.shadow_success_count, 4);
+    assert_eq!(candidate.promotion.shadow_failure_count, 0);
+    assert_eq!(candidate.promotion.criteria.status, PromotionStatus::Ready);
+    assert!(candidate.shadow.traces.iter().any(|trace| trace.trace_id
+        == "trace_release_3_holdout"
+        && trace.compared_receipts == 1
+        && trace
+            .replay_oracle
+            .as_ref()
+            .is_some_and(|report| report.passed)));
+
+    let bundle = build_crystallization_bundle(artifacts, &bundle_traces, BundleOptions::default())
+        .expect("build bundle");
+    assert_eq!(bundle.manifest.fixtures.len(), 4);
+    assert_eq!(bundle.manifest.source_trace_hashes.len(), 4);
+    assert_eq!(bundle.manifest.promotion.sample_count, 4);
+    assert_eq!(
+        bundle.manifest.promotion.criteria.status,
+        PromotionStatus::Ready
+    );
+    write_crystallization_bundle(&bundle, &bundle_dir).expect("write bundle");
+
+    let validation = validate_crystallization_bundle(&bundle_dir).expect("validate");
+    assert!(
+        validation.problems.is_empty(),
+        "validation reported problems: {:#?}",
+        validation.problems
+    );
+    let (_, shadow) = shadow_replay_bundle(&bundle_dir).expect("shadow replay");
+    assert!(shadow.pass, "shadow replay failed: {:#?}", shadow.failures);
+    assert_eq!(shadow.compared_traces, 4);
+}
+
+#[test]
+fn crystallize_v2_shadow_receipt_drift_blocks_promotion() {
+    let fixture_root = harn_vm_fixture_dir("crystallize_v2_release");
+    let mine_dir = fixture_root.join("mine");
+    let drift_dir = fixture_root.join("holdout-drift");
+
+    let traces = load_crystallization_traces_from_dir(&mine_dir).expect("load mining fixtures");
+    let drift_traces =
+        load_crystallization_traces_from_dir(&drift_dir).expect("load drift fixtures");
+
+    let artifacts = crystallize_traces(
+        traces,
+        CrystallizeOptions {
+            min_examples: 3,
+            shadow_traces: drift_traces,
+            workflow_name: Some("release_package_maintenance".to_string()),
+            package_name: Some("release-workflows".to_string()),
+            approver: Some("release-lead@example.com".to_string()),
+            ..CrystallizeOptions::default()
+        },
+    )
+    .expect("crystallize");
+
+    assert!(artifacts.report.candidates.is_empty());
+    let rejected = artifacts
+        .report
+        .rejected_candidates
+        .first()
+        .expect("rejected candidate");
+    assert!(!rejected.shadow.pass);
+    assert_eq!(rejected.promotion.criteria.status, PromotionStatus::Blocked);
+    assert_eq!(rejected.promotion.shadow_failure_count, 1);
+    assert!(rejected
+        .promotion
+        .divergence_history
+        .iter()
+        .any(|entry| entry.trace_id == "trace_release_4_holdout_drift"
+            && entry.path.as_deref().unwrap_or("").contains("sha256")));
+    assert!(rejected
+        .rejection_reasons
+        .iter()
+        .any(|reason| reason.contains("trace_release_4_holdout_drift")));
 }
 
 #[test]

--- a/crates/harn-vm/src/orchestration/crystallize.rs
+++ b/crates/harn-vm/src/orchestration/crystallize.rs
@@ -15,11 +15,15 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value as JsonValue};
 use sha2::{Digest, Sha256};
 
-use super::{new_id, now_rfc3339, RunRecord};
+use super::{
+    new_id, now_rfc3339, run_replay_oracle_trace, ReplayAllowlistRule, ReplayExpectation,
+    ReplayFixture, ReplayOracleReport, ReplayOracleTrace, ReplayTraceRun, RunRecord,
+};
 use crate::value::VmError;
 
 const TRACE_SCHEMA_VERSION: u32 = 1;
 const DEFAULT_MIN_EXAMPLES: usize = 2;
+const DEFAULT_PROMOTION_MIN_CONFIDENCE: f64 = 0.80;
 
 /// Stable schema marker for `candidate.json` inside a crystallization
 /// bundle. Cloud importers and other downstream consumers should refuse
@@ -52,6 +56,8 @@ pub struct CrystallizationTrace {
     pub finished_at: Option<String>,
     pub flow: Option<CrystallizationFlowRef>,
     pub actions: Vec<CrystallizationAction>,
+    pub replay_run: Option<ReplayTraceRun>,
+    pub replay_allowlist: Vec<ReplayAllowlistRule>,
     pub usage: CrystallizationUsage,
     pub metadata: BTreeMap<String, JsonValue>,
 }
@@ -188,6 +194,55 @@ pub struct PromotionMetadata {
     pub secrets_required: Vec<String>,
     pub rollback_target: Option<String>,
     pub eval_pack_link: Option<String>,
+    pub sample_count: usize,
+    pub confidence: f64,
+    pub shadow_success_count: usize,
+    pub shadow_failure_count: usize,
+    pub divergence_history: Vec<PromotionDivergenceRecord>,
+    pub approval_history: Vec<PromotionApprovalRecord>,
+    pub criteria: PromotionCriteria,
+    pub estimated_time_token_savings: SavingsEstimate,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct PromotionCriteria {
+    pub min_examples: usize,
+    pub min_confidence: f64,
+    pub requires_shadow_pass: bool,
+    pub requires_no_rejections: bool,
+    pub requires_human_approval: bool,
+    pub approval_reason: Option<String>,
+    pub status: PromotionStatus,
+    pub reasons: Vec<String>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PromotionStatus {
+    #[default]
+    Blocked,
+    NeedsApproval,
+    Ready,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct PromotionDivergenceRecord {
+    pub trace_id: String,
+    pub path: Option<String>,
+    pub message: String,
+    pub left: Option<JsonValue>,
+    pub right: Option<JsonValue>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct PromotionApprovalRecord {
+    pub actor: String,
+    pub decision: String,
+    pub recorded_at: String,
+    pub reason: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
@@ -202,15 +257,18 @@ pub struct SavingsEstimate {
     pub remaining_model_calls: i64,
 }
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
 #[serde(default)]
 pub struct ShadowTraceResult {
     pub trace_id: String,
+    pub source_hash: String,
     pub pass: bool,
     pub details: Vec<String>,
+    pub compared_receipts: usize,
+    pub replay_oracle: Option<ReplayOracleReport>,
 }
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
 #[serde(default)]
 pub struct ShadowRunReport {
     pub pass: bool,
@@ -219,12 +277,22 @@ pub struct ShadowRunReport {
     pub traces: Vec<ShadowTraceResult>,
 }
 
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct WorkflowClusterKey {
+    pub goal: Option<String>,
+    pub tool_sequence: Vec<String>,
+    pub touched_artifact_types: Vec<String>,
+    pub success_criteria: Vec<String>,
+}
+
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
 #[serde(default)]
 pub struct WorkflowCandidate {
     pub id: String,
     pub name: String,
     pub confidence: f64,
+    pub cluster_key: WorkflowClusterKey,
     pub sequence_signature: Vec<String>,
     pub parameters: Vec<WorkflowCandidateParameter>,
     pub steps: Vec<WorkflowCandidateStep>,
@@ -234,6 +302,7 @@ pub struct WorkflowCandidate {
     pub approval_points: Vec<CrystallizationApproval>,
     pub side_effects: Vec<CrystallizationSideEffect>,
     pub expected_outputs: Vec<JsonValue>,
+    pub expected_receipts: Vec<JsonValue>,
     pub warnings: Vec<String>,
     pub rejection_reasons: Vec<String>,
     pub promotion: PromotionMetadata,
@@ -253,6 +322,7 @@ pub struct CrystallizationReport {
     pub version: u32,
     pub generated_at: String,
     pub source_trace_count: usize,
+    pub excluded_trace_count: usize,
     pub selected_candidate_id: Option<String>,
     pub candidates: Vec<WorkflowCandidate>,
     pub rejected_candidates: Vec<WorkflowCandidate>,
@@ -316,6 +386,8 @@ pub struct CrystallizationInputFormat {
 #[derive(Clone, Debug, Default)]
 pub struct CrystallizeOptions {
     pub min_examples: usize,
+    pub shadow_traces: Vec<CrystallizationTrace>,
+    pub promotion_min_confidence: f64,
     pub workflow_name: Option<String>,
     pub package_name: Option<String>,
     pub author: Option<String>,
@@ -342,16 +414,36 @@ pub fn crystallize_traces(
         )));
     }
 
-    let normalized = traces.into_iter().map(normalize_trace).collect::<Vec<_>>();
+    let normalized_all = traces.into_iter().map(normalize_trace).collect::<Vec<_>>();
+    let (normalized, excluded_mining) = partition_mineable_traces(normalized_all);
+    if normalized.len() < min_examples {
+        return Err(VmError::Runtime(format!(
+            "crystallize requires at least {min_examples} eligible traces, got {} (excluded {})",
+            normalized.len(),
+            excluded_mining.len()
+        )));
+    }
+    let (shadow_traces, excluded_shadow) = partition_mineable_traces(
+        options
+            .shadow_traces
+            .iter()
+            .cloned()
+            .map(normalize_trace)
+            .collect(),
+    );
+    let mut shadow_pool = normalized.clone();
+    shadow_pool.extend(shadow_traces);
+
     let mut candidates = mine_candidates(&normalized, min_examples, &options);
     let mut rejected_candidates = Vec::new();
     for candidate in &mut candidates {
-        candidate.shadow = shadow_candidate(candidate, &normalized);
+        candidate.shadow = shadow_candidate(candidate, &shadow_pool);
         if !candidate.shadow.pass {
             candidate
                 .rejection_reasons
                 .extend(candidate.shadow.failures.clone());
         }
+        refresh_promotion_metadata(candidate, min_examples, &options);
     }
 
     let mut accepted = Vec::new();
@@ -380,6 +472,7 @@ pub fn crystallize_traces(
         version: 1,
         generated_at: now_rfc3339(),
         source_trace_count: normalized.len(),
+        excluded_trace_count: excluded_mining.len() + excluded_shadow.len(),
         selected_candidate_id: selected.map(|candidate| candidate.id.clone()),
         candidates: accepted,
         rejected_candidates,
@@ -447,6 +540,7 @@ pub fn synthesize_candidate_from_trace(
             .rejection_reasons
             .extend(candidate.shadow.failures.clone());
     }
+    refresh_promotion_metadata(&mut candidate, 1, &options);
     let (accepted, rejected) = if candidate.is_safe_to_propose() {
         (vec![candidate], Vec::new())
     } else {
@@ -464,6 +558,7 @@ pub fn synthesize_candidate_from_trace(
         version: 1,
         generated_at: now_rfc3339(),
         source_trace_count: 1,
+        excluded_trace_count: 0,
         selected_candidate_id: selected_id,
         candidates: accepted,
         rejected_candidates: rejected,
@@ -617,6 +712,7 @@ fn build_single_trace_candidate(
         .iter()
         .filter_map(|step| step.expected_output.clone())
         .collect::<Vec<_>>();
+    let expected_receipts = expected_receipts_for_examples(std::slice::from_ref(trace), &[(0, 0)]);
 
     let savings = estimate_savings(std::slice::from_ref(trace), &[(0, 0)], &steps);
     let confidence = confidence_for(&[(0, 0)], 1, &steps, true);
@@ -633,6 +729,7 @@ fn build_single_trace_candidate(
         id: stable_candidate_id(&sequence, &example_refs),
         name,
         confidence,
+        cluster_key: cluster_key_for_candidate(std::slice::from_ref(trace), &[(0, 0)], &steps),
         sequence_signature: sequence,
         parameters,
         steps,
@@ -642,6 +739,7 @@ fn build_single_trace_candidate(
         approval_points,
         side_effects,
         expected_outputs,
+        expected_receipts,
         warnings,
         rejection_reasons: Vec::new(),
         promotion: PromotionMetadata {
@@ -658,6 +756,7 @@ fn build_single_trace_candidate(
             secrets_required: required_secrets,
             rollback_target: Some("keep source trace and previous package version".to_string()),
             eval_pack_link: options.eval_pack_link.clone(),
+            ..PromotionMetadata::default()
         },
         savings,
         shadow: ShadowRunReport::default(),
@@ -922,6 +1021,8 @@ fn trace_from_run_record(run: RunRecord) -> CrystallizationTrace {
         started_at: Some(run.started_at.clone()),
         finished_at: run.finished_at.clone(),
         actions,
+        replay_run: run.replay_fixture.as_ref().map(replay_run_from_fixture),
+        replay_allowlist: default_trace_replay_allowlist(),
         usage: run
             .usage
             .map(|usage| CrystallizationUsage {
@@ -935,6 +1036,40 @@ fn trace_from_run_record(run: RunRecord) -> CrystallizationTrace {
         metadata: run.metadata.clone(),
         ..CrystallizationTrace::default()
     }
+}
+
+fn replay_run_from_fixture(fixture: &ReplayFixture) -> ReplayTraceRun {
+    ReplayTraceRun {
+        run_id: fixture.source_run_id.clone(),
+        final_artifacts: fixture
+            .stage_assertions
+            .iter()
+            .map(|assertion| {
+                json!({
+                    "node_id": assertion.node_id.clone(),
+                    "expected_status": assertion.expected_status.clone(),
+                    "expected_outcome": assertion.expected_outcome.clone(),
+                    "expected_branch": assertion.expected_branch.clone(),
+                    "required_artifact_kinds": assertion.required_artifact_kinds.clone(),
+                    "visible_text_contains": assertion.visible_text_contains.clone(),
+                })
+            })
+            .collect(),
+        policy_decisions: vec![json!({
+            "workflow_id": fixture.workflow_id.clone(),
+            "expected_status": fixture.expected_status.clone(),
+            "eval_kind": fixture.eval_kind.clone(),
+        })],
+        ..ReplayTraceRun::default()
+    }
+}
+
+fn default_trace_replay_allowlist() -> Vec<ReplayAllowlistRule> {
+    vec![ReplayAllowlistRule {
+        path: "/run_id".to_string(),
+        reason: "run ids are allocated per execution".to_string(),
+        replacement: None,
+    }]
 }
 
 fn normalize_trace(mut trace: CrystallizationTrace) -> CrystallizationTrace {
@@ -977,6 +1112,90 @@ fn normalize_trace(mut trace: CrystallizationTrace) -> CrystallizationTrace {
         }
     }
     trace
+}
+
+fn partition_mineable_traces(
+    traces: Vec<CrystallizationTrace>,
+) -> (Vec<CrystallizationTrace>, Vec<CrystallizationTrace>) {
+    traces
+        .into_iter()
+        .partition(|trace| trace_is_mineable(trace).is_ok())
+}
+
+fn trace_is_mineable(trace: &CrystallizationTrace) -> Result<(), String> {
+    if metadata_has_unresolved_policy_violation(&trace.metadata) {
+        return Err("trace has unresolved policy violations".to_string());
+    }
+    for action in &trace.actions {
+        if metadata_has_unresolved_policy_violation(&action.metadata) {
+            return Err(format!(
+                "action {} has unresolved policy violations",
+                action.id
+            ));
+        }
+        if action_has_nondeterministic_side_effect(action) {
+            return Err(format!(
+                "action {} has nondeterministic side effects",
+                action.id
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn metadata_has_unresolved_policy_violation(metadata: &BTreeMap<String, JsonValue>) -> bool {
+    for (key, value) in metadata {
+        let lower = key.to_ascii_lowercase();
+        if lower.contains("unresolved_policy_violation")
+            || lower == "policy_violation_unresolved"
+            || lower == "policy_violation"
+        {
+            if value.as_bool() == Some(true) {
+                return true;
+            }
+            if value
+                .as_str()
+                .is_some_and(|text| text.eq_ignore_ascii_case("unresolved"))
+            {
+                return true;
+            }
+            if value.as_array().is_some_and(|items| !items.is_empty()) {
+                return true;
+            }
+        }
+        if lower == "policy_status"
+            && value
+                .as_str()
+                .is_some_and(|text| text.eq_ignore_ascii_case("unresolved"))
+        {
+            return true;
+        }
+    }
+    false
+}
+
+fn action_has_nondeterministic_side_effect(action: &CrystallizationAction) -> bool {
+    if action.side_effects.is_empty() {
+        return false;
+    }
+    if action
+        .metadata
+        .get("nondeterministic_side_effect")
+        .and_then(JsonValue::as_bool)
+        == Some(true)
+    {
+        return true;
+    }
+    if action.deterministic == Some(false) && action.fuzzy.unwrap_or(false) {
+        return true;
+    }
+    action.side_effects.iter().any(|effect| {
+        effect
+            .metadata
+            .get("nondeterministic")
+            .and_then(JsonValue::as_bool)
+            == Some(true)
+    })
 }
 
 fn mine_candidates(
@@ -1128,6 +1347,7 @@ fn mine_candidates(
         .iter()
         .filter_map(|step| step.expected_output.clone())
         .collect::<Vec<_>>();
+    let expected_receipts = expected_receipts_for_examples(traces, &examples);
     let savings = estimate_savings(traces, &examples, &steps);
     let confidence = confidence_for(
         &examples,
@@ -1148,6 +1368,7 @@ fn mine_candidates(
         id: stable_candidate_id(&sequence, &example_refs),
         name,
         confidence,
+        cluster_key: cluster_key_for_candidate(traces, &examples, &steps),
         sequence_signature: sequence,
         parameters,
         steps,
@@ -1157,6 +1378,7 @@ fn mine_candidates(
         approval_points,
         side_effects,
         expected_outputs,
+        expected_receipts,
         warnings,
         rejection_reasons,
         promotion: PromotionMetadata {
@@ -1173,6 +1395,7 @@ fn mine_candidates(
             secrets_required: required_secrets,
             rollback_target: Some("keep source traces and previous package version".to_string()),
             eval_pack_link: options.eval_pack_link.clone(),
+            ..PromotionMetadata::default()
         },
         savings,
         shadow: ShadowRunReport::default(),
@@ -1367,69 +1590,404 @@ fn stable_expected_output(actions: &[&CrystallizationAction]) -> Option<JsonValu
     }
 }
 
+fn expected_receipts_for_examples(
+    traces: &[CrystallizationTrace],
+    examples: &[(usize, usize)],
+) -> Vec<JsonValue> {
+    examples
+        .iter()
+        .find_map(|(trace_index, _)| {
+            traces
+                .get(*trace_index)
+                .and_then(|trace| trace.replay_run.as_ref())
+                .map(|run| run.effect_receipts.clone())
+                .filter(|receipts| !receipts.is_empty())
+        })
+        .unwrap_or_default()
+}
+
+fn cluster_key_for_candidate(
+    traces: &[CrystallizationTrace],
+    examples: &[(usize, usize)],
+    steps: &[WorkflowCandidateStep],
+) -> WorkflowClusterKey {
+    let goal = examples.iter().find_map(|(trace_index, _)| {
+        traces.get(*trace_index).and_then(|trace| {
+            trace
+                .metadata
+                .get("goal")
+                .and_then(JsonValue::as_str)
+                .map(str::to_string)
+                .or_else(|| trace.workflow_id.clone())
+        })
+    });
+    let tool_sequence = steps
+        .iter()
+        .filter(|step| step.kind == "tool_call" || step.kind == "file_mutation")
+        .map(|step| step.name.clone())
+        .collect::<Vec<_>>();
+    let touched_artifact_types = sorted_strings(
+        steps
+            .iter()
+            .flat_map(|step| step.side_effects.iter().map(artifact_type_for_side_effect)),
+    );
+    let success_criteria = sorted_strings(examples.iter().filter_map(|(trace_index, _)| {
+        traces
+            .get(*trace_index)
+            .and_then(|trace| trace.metadata.get("success_criteria"))
+            .and_then(JsonValue::as_str)
+            .map(str::to_string)
+    }));
+
+    WorkflowClusterKey {
+        goal,
+        tool_sequence,
+        touched_artifact_types,
+        success_criteria,
+    }
+}
+
+fn artifact_type_for_side_effect(effect: &CrystallizationSideEffect) -> String {
+    if let Some(kind) = effect
+        .metadata
+        .get("artifact_type")
+        .and_then(JsonValue::as_str)
+        .filter(|kind| !kind.trim().is_empty())
+    {
+        return kind.to_string();
+    }
+    let lower_kind = effect.kind.to_ascii_lowercase();
+    if lower_kind.contains("git") {
+        "git".to_string()
+    } else if lower_kind.contains("file") {
+        Path::new(&effect.target)
+            .extension()
+            .and_then(|ext| ext.to_str())
+            .map(|ext| format!("file:{ext}"))
+            .unwrap_or_else(|| "file".to_string())
+    } else if lower_kind.contains("receipt") {
+        "receipt".to_string()
+    } else if lower_kind.contains("publish") {
+        "package_publish".to_string()
+    } else if !lower_kind.is_empty() {
+        lower_kind
+    } else {
+        "unknown".to_string()
+    }
+}
+
+fn refresh_promotion_metadata(
+    candidate: &mut WorkflowCandidate,
+    min_examples: usize,
+    options: &CrystallizeOptions,
+) {
+    let min_confidence = if options.promotion_min_confidence > 0.0 {
+        options.promotion_min_confidence
+    } else {
+        DEFAULT_PROMOTION_MIN_CONFIDENCE
+    };
+    let shadow_success_count = candidate
+        .shadow
+        .traces
+        .iter()
+        .filter(|trace| trace.pass)
+        .count();
+    let shadow_failure_count = candidate
+        .shadow
+        .traces
+        .len()
+        .saturating_sub(shadow_success_count);
+    let sample_count = candidate
+        .shadow
+        .compared_traces
+        .max(candidate.examples.len());
+    let divergence_history = candidate
+        .shadow
+        .traces
+        .iter()
+        .filter(|trace| !trace.pass)
+        .flat_map(divergence_records_for_shadow_trace)
+        .collect::<Vec<_>>();
+    let source_trace_hashes = sorted_strings(
+        candidate
+            .promotion
+            .source_trace_hashes
+            .iter()
+            .cloned()
+            .chain(
+                candidate
+                    .shadow
+                    .traces
+                    .iter()
+                    .map(|trace| trace.source_hash.clone()),
+            ),
+    );
+    let approval_history = options
+        .approver
+        .as_ref()
+        .filter(|approver| !approver.trim().is_empty())
+        .map(|approver| {
+            vec![PromotionApprovalRecord {
+                actor: approver.clone(),
+                decision: "approved_for_shadow_promotion".to_string(),
+                recorded_at: now_rfc3339(),
+                reason: Some("approver supplied in crystallization options".to_string()),
+            }]
+        })
+        .unwrap_or_default();
+    let mut criteria = PromotionCriteria {
+        min_examples,
+        min_confidence,
+        requires_shadow_pass: true,
+        requires_no_rejections: true,
+        requires_human_approval: true,
+        approval_reason: Some(
+            "workflow candidates start in shadow mode and require explicit human approval before promotion".to_string(),
+        ),
+        ..PromotionCriteria::default()
+    };
+    if sample_count < min_examples {
+        criteria.reasons.push(format!(
+            "sample count {} is below required minimum {min_examples}",
+            sample_count
+        ));
+    }
+    if candidate.confidence < min_confidence {
+        criteria.reasons.push(format!(
+            "confidence {:.2} is below required minimum {:.2}",
+            candidate.confidence, min_confidence
+        ));
+    }
+    if !candidate.shadow.pass {
+        criteria
+            .reasons
+            .push("shadow comparison did not pass".to_string());
+    }
+    if !candidate.rejection_reasons.is_empty() {
+        criteria
+            .reasons
+            .push("candidate has rejection reasons".to_string());
+    }
+    if approval_history.is_empty() {
+        criteria
+            .reasons
+            .push("human approval has not been recorded".to_string());
+    }
+    criteria.status = if !candidate.rejection_reasons.is_empty()
+        || !candidate.shadow.pass
+        || sample_count < min_examples
+        || candidate.confidence < min_confidence
+    {
+        PromotionStatus::Blocked
+    } else if approval_history.is_empty() {
+        PromotionStatus::NeedsApproval
+    } else {
+        PromotionStatus::Ready
+    };
+
+    candidate.promotion.sample_count = sample_count;
+    candidate.promotion.source_trace_hashes = source_trace_hashes;
+    candidate.promotion.confidence = candidate.confidence;
+    candidate.promotion.shadow_success_count = shadow_success_count;
+    candidate.promotion.shadow_failure_count = shadow_failure_count;
+    candidate.promotion.divergence_history = divergence_history;
+    candidate.promotion.approval_history = approval_history;
+    candidate.promotion.criteria = criteria;
+    candidate.promotion.estimated_time_token_savings = candidate.savings.clone();
+}
+
+fn divergence_records_for_shadow_trace(
+    trace: &ShadowTraceResult,
+) -> Vec<PromotionDivergenceRecord> {
+    if let Some(report) = &trace.replay_oracle {
+        if let Some(divergence) = &report.divergence {
+            return vec![PromotionDivergenceRecord {
+                trace_id: trace.trace_id.clone(),
+                path: Some(divergence.path.clone()),
+                message: divergence.message.clone(),
+                left: Some(divergence.left.clone()),
+                right: Some(divergence.right.clone()),
+            }];
+        }
+    }
+    trace
+        .details
+        .iter()
+        .map(|detail| PromotionDivergenceRecord {
+            trace_id: trace.trace_id.clone(),
+            path: None,
+            message: detail.clone(),
+            left: None,
+            right: None,
+        })
+        .collect()
+}
+
 fn shadow_candidate(
     candidate: &WorkflowCandidate,
     traces: &[CrystallizationTrace],
 ) -> ShadowRunReport {
     let mut failures = Vec::new();
     let mut results = Vec::new();
+    let mut compared_trace_ids = BTreeSet::new();
     for example in &candidate.examples {
         let Some(trace) = traces.iter().find(|trace| trace.id == example.trace_id) else {
             failures.push(format!("missing source trace {}", example.trace_id));
             continue;
         };
-        let mut details = Vec::new();
-        let end = example.start_index + candidate.steps.len();
-        if end > trace.actions.len() {
-            details.push("candidate sequence extends past trace action list".to_string());
-        } else {
-            let signatures = trace.actions[example.start_index..end]
-                .iter()
-                .map(action_signature)
-                .collect::<Vec<_>>();
-            if signatures != candidate.sequence_signature {
-                details.push("action sequence signature changed".to_string());
-            }
-            for (offset, step) in candidate.steps.iter().enumerate() {
-                let action = &trace.actions[example.start_index + offset];
-                if sorted_side_effects(action.side_effects.clone()) != step.side_effects {
-                    details.push(format!(
-                        "step {} side effects differ for action {}",
-                        step.index, action.id
-                    ));
-                }
-                if action.approval.as_ref().map(|approval| approval.required)
-                    != step.approval.as_ref().map(|approval| approval.required)
-                {
-                    details.push(format!("step {} approval boundary differs", step.index));
-                }
-                if step.segment == SegmentKind::Deterministic {
-                    if let Some(expected) = &step.expected_output {
-                        let actual = action.observed_output.as_ref().or(action.output.as_ref());
-                        if actual != Some(expected) {
-                            details
-                                .push(format!("step {} deterministic output differs", step.index));
-                        }
-                    }
-                }
-            }
-        }
-        let pass = details.is_empty();
-        if !pass {
+        compared_trace_ids.insert(trace.id.clone());
+        let result = shadow_trace_result(candidate, trace, example.start_index);
+        if !result.pass {
             failures.push(format!("trace {} failed shadow comparison", trace.id));
         }
-        results.push(ShadowTraceResult {
-            trace_id: trace.id.clone(),
-            pass,
-            details,
-        });
+        results.push(result);
     }
+
+    for trace in traces {
+        if compared_trace_ids.contains(&trace.id) {
+            continue;
+        }
+        if let Some(start_index) = find_sequence_start(trace, &candidate.sequence_signature) {
+            compared_trace_ids.insert(trace.id.clone());
+            let result = shadow_trace_result(candidate, trace, start_index);
+            if !result.pass {
+                failures.push(format!("trace {} failed shadow comparison", trace.id));
+            }
+            results.push(result);
+        }
+    }
+
     ShadowRunReport {
         pass: failures.is_empty(),
         compared_traces: results.len(),
         failures,
         traces: results,
     }
+}
+
+fn find_sequence_start(trace: &CrystallizationTrace, sequence: &[String]) -> Option<usize> {
+    if sequence.is_empty() || trace.actions.len() < sequence.len() {
+        return None;
+    }
+    trace
+        .actions
+        .windows(sequence.len())
+        .position(|window| window.iter().map(action_signature).collect::<Vec<_>>() == sequence)
+}
+
+fn shadow_trace_result(
+    candidate: &WorkflowCandidate,
+    trace: &CrystallizationTrace,
+    start_index: usize,
+) -> ShadowTraceResult {
+    let mut details = Vec::new();
+    let end = start_index + candidate.steps.len();
+    if end > trace.actions.len() {
+        details.push("candidate sequence extends past trace action list".to_string());
+    } else {
+        let signatures = trace.actions[start_index..end]
+            .iter()
+            .map(action_signature)
+            .collect::<Vec<_>>();
+        if signatures != candidate.sequence_signature {
+            details.push("action sequence signature changed".to_string());
+        }
+        for (offset, step) in candidate.steps.iter().enumerate() {
+            let action = &trace.actions[start_index + offset];
+            if sorted_side_effects(action.side_effects.clone()) != step.side_effects {
+                details.push(format!(
+                    "step {} side effects differ for action {}",
+                    step.index, action.id
+                ));
+            }
+            if action.approval.as_ref().map(|approval| approval.required)
+                != step.approval.as_ref().map(|approval| approval.required)
+            {
+                details.push(format!("step {} approval boundary differs", step.index));
+            }
+            if step.segment == SegmentKind::Deterministic {
+                if let Some(expected) = &step.expected_output {
+                    let actual = action.observed_output.as_ref().or(action.output.as_ref());
+                    if actual != Some(expected) {
+                        details.push(format!("step {} deterministic output differs", step.index));
+                    }
+                }
+            }
+        }
+    }
+
+    let (replay_oracle, compared_receipts) = replay_oracle_for_shadow(candidate, trace);
+    if let Some(report) = &replay_oracle {
+        if !report.passed {
+            if let Some(divergence) = &report.divergence {
+                details.push(format!(
+                    "receipt replay diverged at {}: {}",
+                    divergence.path, divergence.message
+                ));
+            } else {
+                details.push("receipt replay oracle did not pass".to_string());
+            }
+        }
+    }
+
+    ShadowTraceResult {
+        trace_id: trace.id.clone(),
+        source_hash: trace.source_hash.clone().unwrap_or_default(),
+        pass: details.is_empty(),
+        details,
+        compared_receipts,
+        replay_oracle,
+    }
+}
+
+fn replay_oracle_for_shadow(
+    candidate: &WorkflowCandidate,
+    trace: &CrystallizationTrace,
+) -> (Option<ReplayOracleReport>, usize) {
+    let Some(first_run) = trace.replay_run.as_ref() else {
+        return (None, 0);
+    };
+    if first_run.effect_receipts.is_empty() && candidate.expected_receipts.is_empty() {
+        return (None, 0);
+    }
+    let mut second_run = first_run.clone();
+    second_run.run_id = format!("shadow_{}_{}", candidate.id, trace.id);
+    second_run.effect_receipts = candidate.expected_receipts.clone();
+    let compared_receipts = first_run
+        .effect_receipts
+        .len()
+        .max(second_run.effect_receipts.len());
+    let oracle_trace = ReplayOracleTrace {
+        name: format!("{}_shadow_receipts_{}", candidate.name, trace.id),
+        description: Some(
+            "crystallization shadow receipt comparison using the replay oracle".to_string(),
+        ),
+        expect: ReplayExpectation::Match,
+        allowlist: trace.replay_allowlist.clone(),
+        first_run: first_run.clone(),
+        second_run,
+        ..ReplayOracleTrace::default()
+    };
+    let oracle_name = oracle_trace.name.clone();
+    let second_run_counts = oracle_trace.second_run.counts();
+    let report = match run_replay_oracle_trace(&oracle_trace) {
+        Ok(report) => report,
+        Err(error) => ReplayOracleReport {
+            name: oracle_name,
+            expectation: ReplayExpectation::Match,
+            passed: false,
+            first_run_counts: first_run.counts(),
+            second_run_counts,
+            protocol_fixture_refs: Vec::new(),
+            divergence: Some(super::ReplayDivergence {
+                path: "/".to_string(),
+                left: JsonValue::Null,
+                right: JsonValue::Null,
+                message: error.to_string(),
+            }),
+        },
+    };
+    (Some(report), compared_receipts)
 }
 
 fn estimate_savings(
@@ -1862,7 +2420,7 @@ pub struct BundleFixtureRef {
     pub redacted: bool,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(default)]
 pub struct BundlePromotion {
     pub owner: Option<String>,
@@ -1875,6 +2433,14 @@ pub struct BundlePromotion {
     pub created_at: String,
     pub workflow_version: String,
     pub package_name: String,
+    pub sample_count: usize,
+    pub confidence: f64,
+    pub shadow_success_count: usize,
+    pub shadow_failure_count: usize,
+    pub divergence_history: Vec<PromotionDivergenceRecord>,
+    pub approval_history: Vec<PromotionApprovalRecord>,
+    pub criteria: PromotionCriteria,
+    pub estimated_time_token_savings: SavingsEstimate,
 }
 
 impl Default for BundlePromotion {
@@ -1888,6 +2454,14 @@ impl Default for BundlePromotion {
             created_at: String::new(),
             workflow_version: String::new(),
             package_name: String::new(),
+            sample_count: 0,
+            confidence: 0.0,
+            shadow_success_count: 0,
+            shadow_failure_count: 0,
+            divergence_history: Vec::new(),
+            approval_history: Vec::new(),
+            criteria: PromotionCriteria::default(),
+            estimated_time_token_savings: SavingsEstimate::default(),
         }
     }
 }
@@ -2084,8 +2658,27 @@ pub fn build_crystallization_bundle(
     let mut fixture_refs = Vec::new();
     let mut fixture_payloads = Vec::new();
     if let Some(candidate) = selected {
+        let mut fixture_trace_ids = BTreeSet::new();
         for example in &candidate.examples {
-            let trace = traces.iter().find(|trace| trace.id == example.trace_id);
+            fixture_trace_ids.insert(example.trace_id.clone());
+        }
+        for trace in traces {
+            if find_sequence_start(trace, &candidate.sequence_signature).is_some() {
+                fixture_trace_ids.insert(trace.id.clone());
+            }
+        }
+        for trace_id in fixture_trace_ids {
+            let trace = traces.iter().find(|trace| trace.id == trace_id);
+            let source_hash = trace
+                .and_then(|trace| trace.source_hash.clone())
+                .or_else(|| {
+                    candidate
+                        .examples
+                        .iter()
+                        .find(|example| example.trace_id == trace_id)
+                        .map(|example| example.source_hash.clone())
+                })
+                .unwrap_or_default();
             let fixture_relative = trace.map(|trace| {
                 format!(
                     "{BUNDLE_FIXTURES_DIR}/{}.json",
@@ -2093,8 +2686,8 @@ pub fn build_crystallization_bundle(
                 )
             });
             source_traces.push(BundleSourceTrace {
-                trace_id: example.trace_id.clone(),
-                source_hash: example.source_hash.clone(),
+                trace_id: trace_id.clone(),
+                source_hash: source_hash.clone(),
                 source_url: trace.and_then(|trace| trace.source.clone()),
                 source_receipt_id: trace
                     .and_then(|trace| trace.metadata.get("source_receipt_id"))
@@ -2107,7 +2700,7 @@ pub fn build_crystallization_bundle(
                 fixture_refs.push(BundleFixtureRef {
                     path: fixture_path,
                     trace_id: trace.id.clone(),
-                    source_hash: trace.source_hash.clone().unwrap_or_default(),
+                    source_hash,
                     redacted: true,
                 });
                 fixture_payloads.push(redacted);
@@ -2128,6 +2721,30 @@ pub fn build_crystallization_bundle(
         created_at: now_rfc3339(),
         workflow_version,
         package_name: package_name.clone(),
+        sample_count: selected
+            .map(|candidate| candidate.promotion.sample_count)
+            .unwrap_or_default(),
+        confidence: selected
+            .map(|candidate| candidate.promotion.confidence)
+            .unwrap_or_default(),
+        shadow_success_count: selected
+            .map(|candidate| candidate.promotion.shadow_success_count)
+            .unwrap_or_default(),
+        shadow_failure_count: selected
+            .map(|candidate| candidate.promotion.shadow_failure_count)
+            .unwrap_or_default(),
+        divergence_history: selected
+            .map(|candidate| candidate.promotion.divergence_history.clone())
+            .unwrap_or_default(),
+        approval_history: selected
+            .map(|candidate| candidate.promotion.approval_history.clone())
+            .unwrap_or_default(),
+        criteria: selected
+            .map(|candidate| candidate.promotion.criteria.clone())
+            .unwrap_or_default(),
+        estimated_time_token_savings: selected
+            .map(|candidate| candidate.promotion.estimated_time_token_savings.clone())
+            .unwrap_or_default(),
     };
 
     let redaction = BundleRedactionSummary {
@@ -2603,6 +3220,26 @@ fn redact_trace_for_bundle(trace: &mut CrystallizationTrace) {
     for (_, value) in trace.metadata.iter_mut() {
         redact_bundle_value(value);
     }
+    if let Some(run) = trace.replay_run.as_mut() {
+        redact_replay_run_for_bundle(run);
+    }
+}
+
+fn redact_replay_run_for_bundle(run: &mut ReplayTraceRun) {
+    for value in run
+        .event_log_entries
+        .iter_mut()
+        .chain(run.trigger_firings.iter_mut())
+        .chain(run.llm_interactions.iter_mut())
+        .chain(run.protocol_interactions.iter_mut())
+        .chain(run.approval_interactions.iter_mut())
+        .chain(run.effect_receipts.iter_mut())
+        .chain(run.agent_transcript_deltas.iter_mut())
+        .chain(run.final_artifacts.iter_mut())
+        .chain(run.policy_decisions.iter_mut())
+    {
+        redact_bundle_value(value);
+    }
 }
 
 fn redact_bundle_value(value: &mut JsonValue) {
@@ -2811,6 +3448,29 @@ mod tests {
             .any(|step| step.segment == SegmentKind::Fuzzy));
         assert!(candidate.savings.remaining_model_calls > 0);
         assert!(artifacts.harn_code.contains("TODO: fuzzy segment"));
+    }
+
+    #[test]
+    fn excludes_unresolved_policy_violations_from_mining() {
+        let mut traces = version_traces(2);
+        let mut excluded = version_trace("trace_policy_blocked", "0.7.99", "release-branch", false);
+        excluded
+            .metadata
+            .insert("unresolved_policy_violation".to_string(), json!(true));
+        traces.push(excluded);
+
+        let artifacts = crystallize_traces(
+            traces,
+            CrystallizeOptions {
+                min_examples: 2,
+                ..CrystallizeOptions::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(artifacts.report.source_trace_count, 2);
+        assert_eq!(artifacts.report.excluded_trace_count, 1);
+        assert!(artifacts.report.selected_candidate_id.is_some());
     }
 
     fn plan_only_trace(id: &str, suffix: &str) -> CrystallizationTrace {

--- a/crates/harn-vm/src/orchestration/release_fixture.rs
+++ b/crates/harn-vm/src/orchestration/release_fixture.rs
@@ -280,6 +280,8 @@ pub fn release_fixture_to_trace(fixture: &ReleaseFixture) -> CrystallizationTrac
         finished_at: actions.last().and_then(|action| action.timestamp.clone()),
         flow: None,
         actions,
+        replay_run: None,
+        replay_allowlist: Vec::new(),
         usage: Default::default(),
         metadata,
     }

--- a/crates/harn-vm/tests/fixtures/crystallize_v2_release/holdout-drift/release_4.json
+++ b/crates/harn-vm/tests/fixtures/crystallize_v2_release/holdout-drift/release_4.json
@@ -1,0 +1,84 @@
+{
+  "version": 1,
+  "id": "trace_release_4_holdout_drift",
+  "workflow_id": "release_package_maintenance",
+  "metadata": {
+    "goal": "release package maintenance",
+    "success_criteria": "release manifest receipt matches the dry-run gate"
+  },
+  "replay_allowlist": [
+    {
+      "path": "/run_id",
+      "reason": "run ids are allocated per execution"
+    },
+    {
+      "path": "/effect_receipts/*/receipt_id",
+      "reason": "receipt ids are allocated per execution"
+    }
+  ],
+  "replay_run": {
+    "run_id": "run_release_4",
+    "effect_receipts": [
+      {
+        "receipt_id": "receipt_release_4",
+        "kind": "release_manifest",
+        "path": "release/manifest.json",
+        "sha256": "receipt-drift-release-flow",
+        "mode": "deterministic_substitute"
+      }
+    ]
+  },
+  "actions": [
+    {
+      "id": "trace_release_4-checkout",
+      "kind": "tool_call",
+      "name": "git.checkout_branch",
+      "parameters": {
+        "repo_path": "/work/harn-4",
+        "branch_name": "release-0.8.4"
+      },
+      "side_effects": [
+        {
+          "kind": "git_ref",
+          "target": "release-branch",
+          "capability": "git.write"
+        }
+      ],
+      "capabilities": ["git.write"],
+      "deterministic": true
+    },
+    {
+      "id": "trace_release_4-manifest",
+      "kind": "file_mutation",
+      "name": "update_manifest_version",
+      "parameters": {
+        "version": "0.8.4",
+        "path": "harn.toml"
+      },
+      "inputs": {
+        "path": "harn.toml",
+        "version": "0.8.4"
+      },
+      "side_effects": [
+        {
+          "kind": "file_write",
+          "target": "harn.toml",
+          "capability": "fs.write"
+        }
+      ],
+      "capabilities": ["fs.write"],
+      "deterministic": true
+    },
+    {
+      "id": "trace_release_4-dry-run",
+      "kind": "tool_call",
+      "name": "cargo.package_dry_run",
+      "parameters": {
+        "release_target": "crates.io",
+        "version": "0.8.4"
+      },
+      "capabilities": ["cargo.package"],
+      "deterministic": true
+    }
+  ]
+}

--- a/crates/harn-vm/tests/fixtures/crystallize_v2_release/holdout-pass/release_3.json
+++ b/crates/harn-vm/tests/fixtures/crystallize_v2_release/holdout-pass/release_3.json
@@ -1,0 +1,84 @@
+{
+  "version": 1,
+  "id": "trace_release_3_holdout",
+  "workflow_id": "release_package_maintenance",
+  "metadata": {
+    "goal": "release package maintenance",
+    "success_criteria": "release manifest receipt matches the dry-run gate"
+  },
+  "replay_allowlist": [
+    {
+      "path": "/run_id",
+      "reason": "run ids are allocated per execution"
+    },
+    {
+      "path": "/effect_receipts/*/receipt_id",
+      "reason": "receipt ids are allocated per execution"
+    }
+  ],
+  "replay_run": {
+    "run_id": "run_release_3",
+    "effect_receipts": [
+      {
+        "receipt_id": "receipt_release_3",
+        "kind": "release_manifest",
+        "path": "release/manifest.json",
+        "sha256": "receipt-stable-release-flow",
+        "mode": "deterministic_substitute"
+      }
+    ]
+  },
+  "actions": [
+    {
+      "id": "trace_release_3-checkout",
+      "kind": "tool_call",
+      "name": "git.checkout_branch",
+      "parameters": {
+        "repo_path": "/work/harn-3",
+        "branch_name": "release-0.8.3"
+      },
+      "side_effects": [
+        {
+          "kind": "git_ref",
+          "target": "release-branch",
+          "capability": "git.write"
+        }
+      ],
+      "capabilities": ["git.write"],
+      "deterministic": true
+    },
+    {
+      "id": "trace_release_3-manifest",
+      "kind": "file_mutation",
+      "name": "update_manifest_version",
+      "parameters": {
+        "version": "0.8.3",
+        "path": "harn.toml"
+      },
+      "inputs": {
+        "path": "harn.toml",
+        "version": "0.8.3"
+      },
+      "side_effects": [
+        {
+          "kind": "file_write",
+          "target": "harn.toml",
+          "capability": "fs.write"
+        }
+      ],
+      "capabilities": ["fs.write"],
+      "deterministic": true
+    },
+    {
+      "id": "trace_release_3-dry-run",
+      "kind": "tool_call",
+      "name": "cargo.package_dry_run",
+      "parameters": {
+        "release_target": "crates.io",
+        "version": "0.8.3"
+      },
+      "capabilities": ["cargo.package"],
+      "deterministic": true
+    }
+  ]
+}

--- a/crates/harn-vm/tests/fixtures/crystallize_v2_release/mine/release_0.json
+++ b/crates/harn-vm/tests/fixtures/crystallize_v2_release/mine/release_0.json
@@ -1,0 +1,84 @@
+{
+  "version": 1,
+  "id": "trace_release_0",
+  "workflow_id": "release_package_maintenance",
+  "metadata": {
+    "goal": "release package maintenance",
+    "success_criteria": "release manifest receipt matches the dry-run gate"
+  },
+  "replay_allowlist": [
+    {
+      "path": "/run_id",
+      "reason": "run ids are allocated per execution"
+    },
+    {
+      "path": "/effect_receipts/*/receipt_id",
+      "reason": "receipt ids are allocated per execution"
+    }
+  ],
+  "replay_run": {
+    "run_id": "run_release_0",
+    "effect_receipts": [
+      {
+        "receipt_id": "receipt_release_0",
+        "kind": "release_manifest",
+        "path": "release/manifest.json",
+        "sha256": "receipt-stable-release-flow",
+        "mode": "deterministic_substitute"
+      }
+    ]
+  },
+  "actions": [
+    {
+      "id": "trace_release_0-checkout",
+      "kind": "tool_call",
+      "name": "git.checkout_branch",
+      "parameters": {
+        "repo_path": "/work/harn-0",
+        "branch_name": "release-0.8.0"
+      },
+      "side_effects": [
+        {
+          "kind": "git_ref",
+          "target": "release-branch",
+          "capability": "git.write"
+        }
+      ],
+      "capabilities": ["git.write"],
+      "deterministic": true
+    },
+    {
+      "id": "trace_release_0-manifest",
+      "kind": "file_mutation",
+      "name": "update_manifest_version",
+      "parameters": {
+        "version": "0.8.0",
+        "path": "harn.toml"
+      },
+      "inputs": {
+        "path": "harn.toml",
+        "version": "0.8.0"
+      },
+      "side_effects": [
+        {
+          "kind": "file_write",
+          "target": "harn.toml",
+          "capability": "fs.write"
+        }
+      ],
+      "capabilities": ["fs.write"],
+      "deterministic": true
+    },
+    {
+      "id": "trace_release_0-dry-run",
+      "kind": "tool_call",
+      "name": "cargo.package_dry_run",
+      "parameters": {
+        "release_target": "crates.io",
+        "version": "0.8.0"
+      },
+      "capabilities": ["cargo.package"],
+      "deterministic": true
+    }
+  ]
+}

--- a/crates/harn-vm/tests/fixtures/crystallize_v2_release/mine/release_1.json
+++ b/crates/harn-vm/tests/fixtures/crystallize_v2_release/mine/release_1.json
@@ -1,0 +1,84 @@
+{
+  "version": 1,
+  "id": "trace_release_1",
+  "workflow_id": "release_package_maintenance",
+  "metadata": {
+    "goal": "release package maintenance",
+    "success_criteria": "release manifest receipt matches the dry-run gate"
+  },
+  "replay_allowlist": [
+    {
+      "path": "/run_id",
+      "reason": "run ids are allocated per execution"
+    },
+    {
+      "path": "/effect_receipts/*/receipt_id",
+      "reason": "receipt ids are allocated per execution"
+    }
+  ],
+  "replay_run": {
+    "run_id": "run_release_1",
+    "effect_receipts": [
+      {
+        "receipt_id": "receipt_release_1",
+        "kind": "release_manifest",
+        "path": "release/manifest.json",
+        "sha256": "receipt-stable-release-flow",
+        "mode": "deterministic_substitute"
+      }
+    ]
+  },
+  "actions": [
+    {
+      "id": "trace_release_1-checkout",
+      "kind": "tool_call",
+      "name": "git.checkout_branch",
+      "parameters": {
+        "repo_path": "/work/harn-1",
+        "branch_name": "release-0.8.1"
+      },
+      "side_effects": [
+        {
+          "kind": "git_ref",
+          "target": "release-branch",
+          "capability": "git.write"
+        }
+      ],
+      "capabilities": ["git.write"],
+      "deterministic": true
+    },
+    {
+      "id": "trace_release_1-manifest",
+      "kind": "file_mutation",
+      "name": "update_manifest_version",
+      "parameters": {
+        "version": "0.8.1",
+        "path": "harn.toml"
+      },
+      "inputs": {
+        "path": "harn.toml",
+        "version": "0.8.1"
+      },
+      "side_effects": [
+        {
+          "kind": "file_write",
+          "target": "harn.toml",
+          "capability": "fs.write"
+        }
+      ],
+      "capabilities": ["fs.write"],
+      "deterministic": true
+    },
+    {
+      "id": "trace_release_1-dry-run",
+      "kind": "tool_call",
+      "name": "cargo.package_dry_run",
+      "parameters": {
+        "release_target": "crates.io",
+        "version": "0.8.1"
+      },
+      "capabilities": ["cargo.package"],
+      "deterministic": true
+    }
+  ]
+}

--- a/crates/harn-vm/tests/fixtures/crystallize_v2_release/mine/release_2.json
+++ b/crates/harn-vm/tests/fixtures/crystallize_v2_release/mine/release_2.json
@@ -1,0 +1,84 @@
+{
+  "version": 1,
+  "id": "trace_release_2",
+  "workflow_id": "release_package_maintenance",
+  "metadata": {
+    "goal": "release package maintenance",
+    "success_criteria": "release manifest receipt matches the dry-run gate"
+  },
+  "replay_allowlist": [
+    {
+      "path": "/run_id",
+      "reason": "run ids are allocated per execution"
+    },
+    {
+      "path": "/effect_receipts/*/receipt_id",
+      "reason": "receipt ids are allocated per execution"
+    }
+  ],
+  "replay_run": {
+    "run_id": "run_release_2",
+    "effect_receipts": [
+      {
+        "receipt_id": "receipt_release_2",
+        "kind": "release_manifest",
+        "path": "release/manifest.json",
+        "sha256": "receipt-stable-release-flow",
+        "mode": "deterministic_substitute"
+      }
+    ]
+  },
+  "actions": [
+    {
+      "id": "trace_release_2-checkout",
+      "kind": "tool_call",
+      "name": "git.checkout_branch",
+      "parameters": {
+        "repo_path": "/work/harn-2",
+        "branch_name": "release-0.8.2"
+      },
+      "side_effects": [
+        {
+          "kind": "git_ref",
+          "target": "release-branch",
+          "capability": "git.write"
+        }
+      ],
+      "capabilities": ["git.write"],
+      "deterministic": true
+    },
+    {
+      "id": "trace_release_2-manifest",
+      "kind": "file_mutation",
+      "name": "update_manifest_version",
+      "parameters": {
+        "version": "0.8.2",
+        "path": "harn.toml"
+      },
+      "inputs": {
+        "path": "harn.toml",
+        "version": "0.8.2"
+      },
+      "side_effects": [
+        {
+          "kind": "file_write",
+          "target": "harn.toml",
+          "capability": "fs.write"
+        }
+      ],
+      "capabilities": ["fs.write"],
+      "deterministic": true
+    },
+    {
+      "id": "trace_release_2-dry-run",
+      "kind": "tool_call",
+      "name": "cargo.package_dry_run",
+      "parameters": {
+        "release_target": "crates.io",
+        "version": "0.8.2"
+      },
+      "capabilities": ["cargo.package"],
+      "deterministic": true
+    }
+  ]
+}

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -973,6 +973,7 @@ Mine repeated traces into a reviewable deterministic workflow candidate.
 ```bash
 harn crystallize \
   --from fixtures/crystallize/version-bump \
+  --shadow-from fixtures/crystallize/version-bump-holdout \
   --out workflows/version_bump.harn \
   --report reports/version_bump.crystallize.json \
   --eval-pack evals/version_bump.toml \
@@ -984,7 +985,9 @@ The input directory may contain crystallization trace JSON files or persisted
 Harn workflow run records. The report preserves source trace hashes,
 parameters, side effects, approval points, capability and secret requirements,
 shadow-mode pass/fail details, promotion metadata, and cost/token savings.
-Candidates with divergent side effects are rejected instead of promoted.
+Pass `--shadow-from <TRACE_DIR>` to add future/holdout traces to the shadow
+comparison without using them for mining. Candidates with divergent side
+effects or replay-oracle receipt drift are rejected instead of promoted.
 
 Pass `--bundle <DIR>` to also emit a portable
 `harn.crystallization.candidate.bundle` directory (`candidate.json`,
@@ -1026,6 +1029,21 @@ harn crystallize shadow bundles/version-bump
 
 See [Workflow crystallization](./workflow-crystallization.md) for the trace
 schema, bundle layout, and review loop.
+
+The checked-in release/package-maintenance harness can be run with:
+
+```bash
+harn crystallize \
+  --from crates/harn-vm/tests/fixtures/crystallize_v2_release/mine \
+  --shadow-from crates/harn-vm/tests/fixtures/crystallize_v2_release/holdout-pass \
+  --out /tmp/release_package_maintenance.harn \
+  --report /tmp/release_package_maintenance.report.json \
+  --bundle /tmp/release-package-maintenance \
+  --min-examples 3 \
+  --workflow-name release_package_maintenance \
+  --package-name release-workflows \
+  --approver release-lead@example.com
+```
 
 ## harn trigger cancel
 

--- a/docs/src/workflow-crystallization.md
+++ b/docs/src/workflow-crystallization.md
@@ -68,7 +68,22 @@ costs, timestamps, source hashes, and optional Flow provenance references:
         {"kind": "file_write", "target": "harn.toml", "capability": "fs.write"}
       ]
     }
-  ]
+  ],
+  "replay_allowlist": [
+    {"path": "/run_id", "reason": "run ids are allocated per execution"},
+    {"path": "/effect_receipts/*/receipt_id", "reason": "receipt ids are allocated per execution"}
+  ],
+  "replay_run": {
+    "run_id": "run_release_001",
+    "effect_receipts": [
+      {
+        "receipt_id": "receipt_release_001",
+        "kind": "release_manifest",
+        "path": "release/manifest.json",
+        "sha256": "receipt-stable-release-flow"
+      }
+    ]
+  }
 }
 ```
 
@@ -81,6 +96,7 @@ Run the miner against at least five traces of the same repeated workflow:
 ```bash
 harn crystallize \
   --from fixtures/crystallize/version-bump \
+  --shadow-from fixtures/crystallize/version-bump-holdout \
   --out workflows/version_bump.harn \
   --report reports/version_bump.crystallize.json \
   --eval-pack evals/version_bump.toml \
@@ -92,6 +108,9 @@ harn crystallize \
 The generated workflow is a reviewable skeleton. It contains explicit
 parameters, capability comments, side-effect comments, approval boundaries, and
 TODO comments for fuzzy segments that still require a model or reviewer.
+`--shadow-from` may be passed more than once. These directories are not used for
+mining; they are future/holdout traces that must match before promotion
+metadata can report the candidate as ready.
 
 ```harn
 pipeline version_bump(repo_path, version, branch_name, release_target) {
@@ -109,15 +128,21 @@ The report includes:
 
 - normalized workflow-candidate IR with parameters, constants,
   preconditions, side effects, capabilities, required secrets, approval points,
-  expected outputs, deterministic segments, and fuzzy segments
+  expected outputs, expected receipts, deterministic segments, fuzzy segments,
+  and the recurrence cluster key (goal, tool sequence, touched artifact types,
+  and success criteria)
 - source trace hashes and example action ids for provenance
 - confidence and rejection reasons
-- shadow-mode pass/fail details for every source trace
+- shadow-mode pass/fail details for every source and holdout trace, including
+  replay-oracle receipt comparison reports when `replay_run` is present
 - model calls avoided, token savings, estimated cost savings, wall-clock
   savings, CPU/runtime cost, and remaining model-call requirements
 - promotion metadata: source trace hashes, author, approver, created_at,
   version, package name, capability set, required secrets, rollback target, and
   eval pack link
+- promotion criteria/history: sample count, confidence threshold, shadow pass
+  requirement, approval history, divergence history, and estimated time/token
+  savings
 
 Candidates with divergent side effects stay in `rejected_candidates` and do not
 produce a selected candidate.
@@ -132,8 +157,42 @@ the selected sequence against each source trace:
 - requested side effects
 - approval boundaries
 
+When traces carry `replay_run`, the shadow check also builds a
+`harn.orchestration.replay_trace.v1` comparison and calls the replay oracle from
+`harn orchestrator replay-oracle`. The original run is the first execution; the
+candidate's expected receipts are substituted into the second execution. Any
+meaningful receipt drift is recorded in `promotion.divergence_history` and
+blocks promotion.
+
 This gives Harn Cloud and local reviewers a deterministic pass/fail surface
 before promotion.
+
+## Checked-In V2 Fixture Harness
+
+The repository includes a fixture-driven release/package-maintenance steel
+thread:
+
+```bash
+harn crystallize \
+  --from crates/harn-vm/tests/fixtures/crystallize_v2_release/mine \
+  --shadow-from crates/harn-vm/tests/fixtures/crystallize_v2_release/holdout-pass \
+  --out /tmp/release_package_maintenance.harn \
+  --report /tmp/release_package_maintenance.report.json \
+  --bundle /tmp/release-package-maintenance \
+  --min-examples 3 \
+  --workflow-name release_package_maintenance \
+  --package-name release-workflows \
+  --approver release-lead@example.com
+
+harn crystallize validate /tmp/release-package-maintenance
+harn crystallize shadow /tmp/release-package-maintenance
+```
+
+The sibling
+`crates/harn-vm/tests/fixtures/crystallize_v2_release/holdout-drift` directory
+keeps the same action sequence but changes the receipt hash. Using it as
+`--shadow-from` leaves the candidate in `rejected_candidates` with a replay
+divergence path under `effect_receipts`.
 
 ## Eval Pack
 
@@ -215,7 +274,16 @@ needs to import a candidate directly:
     "rollback_target": "keep source traces and previous package version",
     "created_at": "2026-04-26T12:34:56Z",
     "workflow_version": "0.1.0",
-    "package_name": "release-workflows"
+    "package_name": "release-workflows",
+    "sample_count": 5,
+    "confidence": 0.94,
+    "shadow_success_count": 5,
+    "shadow_failure_count": 0,
+    "divergence_history": [],
+    "approval_history": [
+      {"actor": "lead@example.com", "decision": "approved_for_shadow_promotion"}
+    ],
+    "criteria": {"status": "ready", "min_examples": 5, "min_confidence": 0.8}
   },
   "redaction": {
     "applied": true,


### PR DESCRIPTION
## Summary

- add crystallization v2 recurrence clustering, promotion criteria/history, replay-oracle receipt shadowing, and holdout trace support via `--shadow-from`
- add checked-in release/package-maintenance mining, passing holdout, and drift holdout fixtures
- document the fixture harness and update CLI docs for shadow receipt promotion and rejection behavior

Fixes #1378

## Verification

- `HARN_LLM_CALLS_DISABLED=1 cargo test -p harn-cli --test crystallize_cli`
- `HARN_LLM_CALLS_DISABLED=1 cargo test -p harn-vm orchestration::crystallize`
- `HARN_LLM_CALLS_DISABLED=1 cargo test -p harn-cli cli::tests::test_parses_crystallize_args`
- `HARN_LLM_CALLS_DISABLED=1 cargo clippy -p harn-vm -p harn-cli --all-targets -- -D warnings`
- `HARN_LLM_CALLS_DISABLED=1 cargo run --quiet --bin harn -- orchestrator replay-oracle`
- `npx markdownlint-cli2 docs/src/workflow-crystallization.md docs/src/cli-reference.md`
- documented positive fixture harness: mine + validate + shadow passed
- documented drift fixture harness: mining exited nonzero with rejected candidate and receipt sha divergence
- `HARN_LLM_CALLS_DISABLED=1 make test` (3419 passed, 2 skipped)
