### PR TITLE
Harden persona runtime status

### DIFF
--- a/crates/harn-cli/portal/src/lib/api.test.ts
+++ b/crates/harn-cli/portal/src/lib/api.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest"
 
-import { fetchRunCompare } from "./api"
+import { fetchPersonaStatus, fetchRunCompare } from "./api"
 
 describe("fetchRunCompare", () => {
   it("surfaces JSON error payloads", async () => {
@@ -15,6 +15,22 @@ describe("fetchRunCompare", () => {
 
     await expect(fetchRunCompare("left", "right")).rejects.toThrow(
       "Request failed: 400 bad compare input",
+    )
+  })
+})
+
+describe("fetchPersonaStatus", () => {
+  it("encodes name and deterministic status timestamp", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ name: "merge_captain", state: "paused" }),
+    })
+    vi.stubGlobal("fetch", fetchMock)
+
+    await fetchPersonaStatus("merge captain", "2026-04-24T12:00:00Z")
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/persona/status?name=merge+captain&at=2026-04-24T12%3A00%3A00Z",
     )
   })
 })

--- a/crates/harn-cli/portal/src/lib/api.ts
+++ b/crates/harn-cli/portal/src/lib/api.ts
@@ -8,6 +8,8 @@ import type {
   PortalLaunchJobList,
   PortalLlmOptions,
   PortalMeta,
+  PersonaManifestSummary,
+  PersonaStatus,
   PortalLaunchTargetList,
   PortalListResponse,
   PortalRunDetail,
@@ -70,6 +72,18 @@ export function fetchRuns(params?: {
 
 export function fetchPortalMeta(): Promise<PortalMeta> {
   return fetchJson<PortalMeta>("/api/meta")
+}
+
+export function fetchPersonas(): Promise<PersonaManifestSummary[]> {
+  return fetchJson<PersonaManifestSummary[]>("/api/personas")
+}
+
+export function fetchPersonaStatus(name: string, at?: string): Promise<PersonaStatus> {
+  const search = new URLSearchParams({ name })
+  if (at) {
+    search.set("at", at)
+  }
+  return fetchJson<PersonaStatus>(`/api/persona/status?${search}`)
 }
 
 export function fetchHighlightKeywords(): Promise<PortalHighlightKeywords> {

--- a/crates/harn-cli/portal/src/types.ts
+++ b/crates/harn-cli/portal/src/types.ts
@@ -95,6 +95,118 @@ export type PortalMeta = {
   run_dir: string
 }
 
+export type PersonaManifestSummary = {
+  name: string
+  version: string | null
+  description: string
+  entry_workflow: string
+  tools: string[]
+  capabilities: string[]
+  autonomy_tier: string
+  receipt_policy: string
+  triggers: string[]
+  schedules: string[]
+  model_policy: Record<string, unknown>
+  budget: Record<string, unknown>
+  handoffs: string[]
+  context_packs: string[]
+  evals: string[]
+  manifest_path: string
+}
+
+export type PersonaLifecycleState =
+  | "inactive"
+  | "starting"
+  | "idle"
+  | "running"
+  | "paused"
+  | "draining"
+  | "failed"
+  | "disabled"
+
+export type PersonaLease = {
+  id: string
+  holder: string
+  work_key: string
+  acquired_at_ms: number
+  expires_at_ms: number
+}
+
+export type PersonaAssignmentStatus = {
+  work_key: string
+  lease_id: string
+  holder: string
+  acquired_at: string
+  expires_at: string
+}
+
+export type PersonaBudgetStatus = {
+  daily_usd: number | null
+  hourly_usd: number | null
+  run_usd: number | null
+  max_tokens: number | null
+  spent_today_usd: number
+  spent_this_hour_usd: number
+  spent_last_run_usd: number
+  tokens_today: number
+  remaining_today_usd: number | null
+  remaining_hour_usd: number | null
+  exhausted: boolean
+  reason: string | null
+  last_receipt_id: string | null
+}
+
+export type PersonaQueuedWork = {
+  work_key: string
+  provider: string
+  kind: string
+  queued_at: string
+  reason: string
+  source_event_id: string | null
+  metadata: Record<string, string>
+}
+
+export type PersonaHandoffInboxItem = {
+  work_key: string
+  handoff_id: string | null
+  handoff_kind: string | null
+  source_persona: string | null
+  task: string | null
+  queued_at: string
+  reason: string
+}
+
+export type PersonaValueReceipt = {
+  kind: string
+  run_id: string | null
+  occurred_at: string
+  paid_cost_usd: number
+  avoided_cost_usd: number
+  deterministic_steps: number
+  llm_steps: number
+  metadata: unknown
+}
+
+export type PersonaStatus = {
+  name: string
+  template_ref: string | null
+  state: PersonaLifecycleState
+  entry_workflow: string
+  role: string
+  current_assignment: PersonaAssignmentStatus | null
+  last_run: string | null
+  next_scheduled_run: string | null
+  active_lease: PersonaLease | null
+  budget: PersonaBudgetStatus
+  last_error: string | null
+  queued_events: number
+  queued_work: PersonaQueuedWork[]
+  handoff_inbox: PersonaHandoffInboxItem[]
+  value_receipts: PersonaValueReceipt[]
+  disabled_events: number
+  paused_event_policy: string
+}
+
 export type PortalHighlightKeywords = {
   keyword: string[]
   literal: string[]

--- a/crates/harn-cli/src/cli/portal.rs
+++ b/crates/harn-cli/src/cli/portal.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use clap::{ArgAction, Args};
 
 #[derive(Debug, Args)]
@@ -5,6 +7,12 @@ pub(crate) struct PortalArgs {
     /// Directory containing persisted run records.
     #[arg(long, default_value = ".harn-runs")]
     pub dir: String,
+    /// Explicit harn.toml path or directory for persona catalog APIs.
+    #[arg(long, value_name = "PATH")]
+    pub manifest: Option<PathBuf>,
+    /// Directory used for durable persona runtime state.
+    #[arg(long, value_name = "DIR", default_value = ".harn/personas")]
+    pub persona_state_dir: PathBuf,
     /// Host interface to bind.
     #[arg(long, default_value = "127.0.0.1")]
     pub host: String,

--- a/crates/harn-cli/src/commands/persona.rs
+++ b/crates/harn-cli/src/commands/persona.rs
@@ -624,8 +624,21 @@ fn print_status(status: &harn_vm::PersonaStatus, json: bool) {
         return;
     }
     println!("persona:        {}", status.name);
+    println!(
+        "template_ref:   {}",
+        status.template_ref.as_deref().unwrap_or("-")
+    );
     println!("state:          {}", status.state.as_str());
     println!("entry_workflow: {}", status.entry_workflow);
+    println!("role:           {}", status.role);
+    println!(
+        "assignment:     {}",
+        status
+            .current_assignment
+            .as_ref()
+            .map(|assignment| assignment.work_key.as_str())
+            .unwrap_or("-")
+    );
     println!(
         "last_run:       {}",
         status.last_run.as_deref().unwrap_or("-")
@@ -635,6 +648,21 @@ fn print_status(status: &harn_vm::PersonaStatus, json: bool) {
         status.next_scheduled_run.as_deref().unwrap_or("-")
     );
     println!("queued_events:  {}", status.queued_events);
+    if !status.handoff_inbox.is_empty() {
+        println!("handoffs:");
+        for handoff in &status.handoff_inbox {
+            println!(
+                "  - {} kind={} from={} task={}",
+                handoff
+                    .handoff_id
+                    .as_deref()
+                    .unwrap_or(handoff.work_key.as_str()),
+                handoff.handoff_kind.as_deref().unwrap_or("-"),
+                handoff.source_persona.as_deref().unwrap_or("-"),
+                handoff.task.as_deref().unwrap_or("-")
+            );
+        }
+    }
     println!(
         "active_lease:   {}",
         status
@@ -652,6 +680,14 @@ fn print_status(status: &harn_vm::PersonaStatus, json: bool) {
             .map(|value| format!("${value:.4}"))
             .unwrap_or_else(|| "-".to_string())
     );
+    if let Some(receipt) = status.value_receipts.last() {
+        println!(
+            "last_receipt:   {} paid=${:.4} avoided=${:.4}",
+            receipt.kind.as_str(),
+            receipt.paid_cost_usd,
+            receipt.avoided_cost_usd
+        );
+    }
     if let Some(error) = &status.last_error {
         println!("last_error:     {error}");
     }

--- a/crates/harn-cli/src/commands/portal/handlers/mod.rs
+++ b/crates/harn-cli/src/commands/portal/handlers/mod.rs
@@ -3,5 +3,6 @@ pub(super) mod costs;
 pub(super) mod dlq;
 pub(super) mod launch;
 pub(super) mod meta;
+pub(super) mod personas;
 pub(super) mod runs;
 pub(super) mod trust;

--- a/crates/harn-cli/src/commands/portal/handlers/personas.rs
+++ b/crates/harn-cli/src/commands/portal/handlers/personas.rs
@@ -1,0 +1,36 @@
+use std::sync::Arc;
+
+use axum::extract::{Query, State};
+use axum::http::StatusCode;
+use axum::Json;
+
+use crate::commands::persona;
+use crate::commands::portal::errors::{bad_request_error, internal_error};
+use crate::commands::portal::query::{ErrorResponse, PersonaStatusQuery};
+use crate::commands::portal::state::PortalState;
+
+pub(crate) async fn list_personas_handler(
+    State(state): State<Arc<PortalState>>,
+) -> Result<Json<Vec<serde_json::Value>>, (StatusCode, Json<ErrorResponse>)> {
+    persona::list_payload(state.persona_manifest.as_deref())
+        .map(Json)
+        .map_err(internal_error)
+}
+
+pub(crate) async fn persona_status_handler(
+    State(state): State<Arc<PortalState>>,
+    Query(query): Query<PersonaStatusQuery>,
+) -> Result<Json<harn_vm::PersonaStatus>, (StatusCode, Json<ErrorResponse>)> {
+    if query.name.trim().is_empty() {
+        return Err(bad_request_error("persona status requires non-empty name"));
+    }
+    persona::status_payload(
+        state.persona_manifest.as_deref(),
+        &state.persona_state_dir,
+        &query.name,
+        query.at.as_deref(),
+    )
+    .await
+    .map(Json)
+    .map_err(internal_error)
+}

--- a/crates/harn-cli/src/commands/portal/mod.rs
+++ b/crates/harn-cli/src/commands/portal/mod.rs
@@ -24,7 +24,14 @@ use tokio::sync::Mutex;
 use self::router::build_router;
 use self::state::PortalState;
 
-pub(crate) async fn run_portal(dir: &str, host: &str, port: u16, open_browser: bool) {
+pub(crate) async fn run_portal(
+    dir: &str,
+    manifest: Option<PathBuf>,
+    persona_state_dir: PathBuf,
+    host: &str,
+    port: u16,
+    open_browser: bool,
+) {
     let run_dir = PathBuf::from(dir);
     let workspace_root = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
     let event_log = harn_vm::event_log::install_default_for_base_dir(&workspace_root).ok();
@@ -40,6 +47,8 @@ pub(crate) async fn run_portal(dir: &str, host: &str, port: u16, open_browser: b
     let state = Arc::new(PortalState {
         run_dir: run_dir.clone(),
         workspace_root,
+        persona_manifest: manifest,
+        persona_state_dir,
         event_log,
         launch_program,
         launch_jobs: Arc::new(Mutex::new(HashMap::new())),

--- a/crates/harn-cli/src/commands/portal/query.rs
+++ b/crates/harn-cli/src/commands/portal/query.rs
@@ -33,6 +33,12 @@ pub(super) struct TrustGraphQuery {
     pub(super) grouped_by_trace: Option<bool>,
 }
 
+#[derive(Debug, Deserialize)]
+pub(super) struct PersonaStatusQuery {
+    pub(super) name: String,
+    pub(super) at: Option<String>,
+}
+
 #[derive(Debug, Serialize)]
 pub(super) struct ErrorResponse {
     pub(super) error: String,

--- a/crates/harn-cli/src/commands/portal/router.rs
+++ b/crates/harn-cli/src/commands/portal/router.rs
@@ -15,6 +15,7 @@ use super::handlers::launch::{
     trigger_replay_handler,
 };
 use super::handlers::meta::{highlight_keywords_handler, llm_options_handler, portal_meta_handler};
+use super::handlers::personas::{list_personas_handler, persona_status_handler};
 use super::handlers::runs::{action_graph_stream_handler, list_runs_handler, run_detail_handler};
 use super::handlers::trust::trust_graph_handler;
 use super::state::PortalState;
@@ -28,6 +29,8 @@ pub(super) fn build_router(state: Arc<PortalState>) -> Router {
         .route("/api/llm/options", get(llm_options_handler))
         .route("/api/costs", get(cost_report_handler))
         .route("/api/runs", get(list_runs_handler))
+        .route("/api/personas", get(list_personas_handler))
+        .route("/api/persona/status", get(persona_status_handler))
         .route("/api/trust-graph", get(trust_graph_handler))
         .route("/api/run", get(run_detail_handler))
         .route(

--- a/crates/harn-cli/src/commands/portal/state.rs
+++ b/crates/harn-cli/src/commands/portal/state.rs
@@ -11,6 +11,8 @@ use harn_vm::event_log::AnyEventLog;
 pub(super) struct PortalState {
     pub(super) run_dir: PathBuf,
     pub(super) workspace_root: PathBuf,
+    pub(super) persona_manifest: Option<PathBuf>,
+    pub(super) persona_state_dir: PathBuf,
     pub(super) event_log: Option<Arc<AnyEventLog>>,
     pub(super) launch_program: PathBuf,
     pub(super) launch_jobs: Arc<Mutex<HashMap<String, PortalLaunchJob>>>,

--- a/crates/harn-cli/src/commands/portal/tests.rs
+++ b/crates/harn-cli/src/commands/portal/tests.rs
@@ -9,6 +9,8 @@ use harn_vm::event_log::{EventLog, LogEvent, Topic};
 use tokio::sync::Mutex;
 use tower::util::ServiceExt;
 
+use crate::commands::persona;
+
 use super::dto::{PortalLaunchRequest, PortalRunDiff, PortalRunSummary};
 use super::launch::{
     build_launch_env, materialize_launch_target, scan_launch_targets, validate_launch_request,
@@ -27,6 +29,8 @@ fn test_portal_state(run_dir: &Path) -> Arc<PortalState> {
     Arc::new(PortalState {
         run_dir: run_dir.to_path_buf(),
         workspace_root: run_dir.to_path_buf(),
+        persona_manifest: None,
+        persona_state_dir: run_dir.join(".harn/personas"),
         event_log: None,
         launch_program: PathBuf::from("harn"),
         launch_jobs: Arc::new(Mutex::new(HashMap::new())),
@@ -40,7 +44,25 @@ fn test_portal_state_with_event_log(
     Arc::new(PortalState {
         run_dir: run_dir.to_path_buf(),
         workspace_root: run_dir.to_path_buf(),
+        persona_manifest: None,
+        persona_state_dir: run_dir.join(".harn/personas"),
         event_log: Some(event_log),
+        launch_program: PathBuf::from("harn"),
+        launch_jobs: Arc::new(Mutex::new(HashMap::new())),
+    })
+}
+
+fn test_portal_state_with_personas(
+    run_dir: &Path,
+    manifest: PathBuf,
+    persona_state_dir: PathBuf,
+) -> Arc<PortalState> {
+    Arc::new(PortalState {
+        run_dir: run_dir.to_path_buf(),
+        workspace_root: run_dir.to_path_buf(),
+        persona_manifest: Some(manifest),
+        persona_state_dir,
+        event_log: None,
         launch_program: PathBuf::from("harn"),
         launch_jobs: Arc::new(Mutex::new(HashMap::new())),
     })
@@ -306,6 +328,62 @@ async fn api_runs_returns_json() {
         .unwrap();
 
     assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn api_personas_exposes_runtime_status() {
+    let temp = tempfile::tempdir().unwrap();
+    let manifest = temp.path().join("harn.toml");
+    fs::write(
+        &manifest,
+        r#"
+[[personas]]
+name = "merge_captain"
+description = "Owns merge readiness."
+entry_workflow = "workflows/merge.harn#run"
+tools = ["github"]
+capabilities = ["git.get_diff"]
+autonomy_tier = "act_with_approval"
+receipt_policy = "required"
+triggers = ["github.pr_opened"]
+budget = { daily_usd = 1.0, run_usd = 1.0 }
+"#,
+    )
+    .unwrap();
+    let state_dir = temp.path().join(".harn/personas");
+    persona::pause_payload(
+        Some(&manifest),
+        &state_dir,
+        "merge_captain",
+        Some("2026-04-24T12:00:00Z"),
+    )
+    .await
+    .unwrap();
+
+    let app = build_router(test_portal_state_with_personas(
+        temp.path(),
+        manifest,
+        state_dir,
+    ));
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/persona/status?name=merge_captain&at=2026-04-24T12:00:01Z")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let payload: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(payload["name"], "merge_captain");
+    assert_eq!(payload["state"], "paused");
+    assert_eq!(payload["role"], "merge_captain");
+    assert_eq!(payload["budget"]["daily_usd"], 1.0);
 }
 
 #[tokio::test]

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -632,7 +632,15 @@ async fn async_main() {
             commands::run::run_watch(&args.file, denied).await;
         }
         Command::Portal(args) => {
-            commands::portal::run_portal(&args.dir, &args.host, args.port, args.open).await
+            commands::portal::run_portal(
+                &args.dir,
+                args.manifest,
+                args.persona_state_dir,
+                &args.host,
+                args.port,
+                args.open,
+            )
+            .await
         }
         Command::Trigger(args) => {
             if let Err(error) = commands::trigger::handle(args).await {

--- a/crates/harn-cli/tests/persona_cli.rs
+++ b/crates/harn-cli/tests/persona_cli.rs
@@ -351,6 +351,8 @@ async fn persona_runtime_status_tick_and_budget_are_persisted() {
         .await
         .expect("initial status");
     assert_eq!(status.state.as_str(), "idle");
+    assert_eq!(status.role, "merge_captain");
+    assert!(status.template_ref.is_none());
     assert_eq!(status.queued_events, 0);
     assert_eq!(status.budget.daily_usd, Some(20.0));
 
@@ -387,6 +389,9 @@ async fn persona_runtime_status_tick_and_budget_are_persisted() {
     assert_eq!(status.last_run.as_deref(), Some("2026-04-24T12:30:00Z"));
     assert_eq!(status.budget.spent_today_usd, 0.25);
     assert_eq!(status.budget.tokens_today, 12);
+    assert_eq!(status.value_receipts.len(), 2);
+    assert_eq!(status.value_receipts[0].kind.as_str(), "run_started");
+    assert_eq!(status.value_receipts[1].kind.as_str(), "run_completed");
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -395,9 +400,14 @@ async fn persona_pause_resume_disable_trigger_controls_are_durable() {
     let manifest = manifest_path(&temp);
     let state_dir = temp.path().join(".harn-personas-test");
 
-    let _ = persona::pause_payload(Some(&manifest), &state_dir, "merge_captain", None)
-        .await
-        .expect("pause");
+    let _ = persona::pause_payload(
+        Some(&manifest),
+        &state_dir,
+        "merge_captain",
+        Some("2026-04-24T12:00:00Z"),
+    )
+    .await
+    .expect("pause");
 
     let receipt = persona::trigger_payload(
         Some(&manifest),
@@ -409,7 +419,7 @@ async fn persona_pause_resume_disable_trigger_controls_are_durable() {
             "repository=burin-labs/harn".to_string(),
             "number=462".to_string(),
         ],
-        None,
+        Some("2026-04-24T12:00:01Z"),
         0.0,
         0,
     )
@@ -417,16 +427,73 @@ async fn persona_pause_resume_disable_trigger_controls_are_durable() {
     .expect("trigger while paused");
     assert_eq!(receipt.status, "queued");
     assert_eq!(receipt.work_key, "github:burin-labs/harn:pr:462");
+    let queued = persona::status_payload(
+        Some(&manifest),
+        &state_dir,
+        "merge_captain",
+        Some("2026-04-24T12:00:02Z"),
+    )
+    .await
+    .expect("queued status");
+    assert_eq!(queued.queued_events, 1);
+    assert_eq!(queued.queued_work[0].provider, "github");
+    assert!(queued.current_assignment.is_none());
 
-    let resumed = persona::resume_payload(Some(&manifest), &state_dir, "merge_captain", None)
-        .await
-        .expect("resume");
+    let handoff = persona::trigger_payload(
+        Some(&manifest),
+        &state_dir,
+        "merge_captain",
+        "handoff",
+        "review",
+        &[
+            "dedupe_key=handoff-1379".to_string(),
+            "handoff_id=handoff-1379".to_string(),
+            "handoff_kind=merge_receipt".to_string(),
+            "source_persona=review_captain".to_string(),
+            "task=Review durable persona receipt".to_string(),
+        ],
+        Some("2026-04-24T12:00:03Z"),
+        0.0,
+        0,
+    )
+    .await
+    .expect("handoff while paused");
+    assert_eq!(handoff.status, "queued");
+    let queued = persona::status_payload(
+        Some(&manifest),
+        &state_dir,
+        "merge_captain",
+        Some("2026-04-24T12:00:04Z"),
+    )
+    .await
+    .expect("queued handoff status");
+    assert_eq!(queued.queued_events, 2);
+    assert_eq!(queued.handoff_inbox.len(), 1);
+    assert_eq!(
+        queued.handoff_inbox[0].handoff_kind.as_deref(),
+        Some("merge_receipt")
+    );
+
+    let resumed = persona::resume_payload(
+        Some(&manifest),
+        &state_dir,
+        "merge_captain",
+        Some("2026-04-24T12:01:00Z"),
+    )
+    .await
+    .expect("resume");
     assert_eq!(resumed.state.as_str(), "idle");
     assert_eq!(resumed.queued_events, 0);
+    assert!(resumed.handoff_inbox.is_empty());
 
-    let _ = persona::disable_payload(Some(&manifest), &state_dir, "merge_captain", None)
-        .await
-        .expect("disable");
+    let _ = persona::disable_payload(
+        Some(&manifest),
+        &state_dir,
+        "merge_captain",
+        Some("2026-04-24T12:02:00Z"),
+    )
+    .await
+    .expect("disable");
 
     let receipt = persona::trigger_payload(
         Some(&manifest),
@@ -438,7 +505,7 @@ async fn persona_pause_resume_disable_trigger_controls_are_durable() {
             "channel=C123".to_string(),
             "ts=1713988800.000100".to_string(),
         ],
-        None,
+        Some("2026-04-24T12:02:01Z"),
         0.0,
         0,
     )
@@ -476,7 +543,7 @@ budget = { daily_usd = 0.01, run_usd = 0.01, max_tokens = 10 }
             "repository=burin-labs/harn".to_string(),
             "check_name=ci".to_string(),
         ],
-        None,
+        Some("2026-04-24T12:00:00Z"),
         0.02,
         1,
     )
@@ -488,11 +555,19 @@ budget = { daily_usd = 0.01, run_usd = 0.01, max_tokens = 10 }
         .as_deref()
         .is_some_and(|message| message.contains("run_usd")));
 
-    let status = persona::status_payload(Some(&manifest), &state_dir, "merge_captain", None)
-        .await
-        .expect("status after exhaustion");
+    let status = persona::status_payload(
+        Some(&manifest),
+        &state_dir,
+        "merge_captain",
+        Some("2026-04-24T12:00:01Z"),
+    )
+    .await
+    .expect("status after exhaustion");
     assert!(status
         .last_error
         .as_deref()
         .is_some_and(|message| message.contains("run_usd")));
+    assert!(status.budget.exhausted);
+    assert_eq!(status.budget.reason.as_deref(), Some("run_usd"));
+    assert!(status.budget.last_receipt_id.is_some());
 }

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -129,10 +129,11 @@ pub use personas::{
     disable_persona, fire_schedule as fire_persona_schedule, fire_trigger as fire_persona_trigger,
     format_ms as format_persona_ms, now_ms as persona_now_ms, parse_rfc3339_ms as parse_persona_ms,
     pause_persona, persona_status, record_persona_spend, register_persona_value_sink,
-    resume_persona, PersonaBudgetPolicy, PersonaBudgetStatus, PersonaLease, PersonaLifecycleState,
+    resume_persona, PersonaAssignmentStatus, PersonaBudgetPolicy, PersonaBudgetStatus,
+    PersonaHandoffInboxItem, PersonaLease, PersonaLifecycleState, PersonaQueuedWork,
     PersonaRunCost, PersonaRunReceipt, PersonaRuntimeBinding, PersonaStatus,
-    PersonaTriggerEnvelope, PersonaValueEvent, PersonaValueEventKind, PersonaValueSink,
-    PersonaValueSinkRegistration, PERSONA_RUNTIME_TOPIC,
+    PersonaTriggerEnvelope, PersonaValueEvent, PersonaValueEventKind, PersonaValueReceipt,
+    PersonaValueSink, PersonaValueSinkRegistration, PERSONA_RUNTIME_TOPIC,
 };
 pub use provenance::{
     build_signed_receipt, load_or_generate_agent_signing_key, verify_receipt, ProvenanceReceipt,

--- a/crates/harn-vm/src/orchestration/records.rs
+++ b/crates/harn-vm/src/orchestration/records.rs
@@ -19,6 +19,10 @@ use crate::event_log::{
     LogEvent as EventLogRecord, Topic,
 };
 use crate::llm::vm_value_to_json;
+use crate::personas::{
+    PersonaAssignmentStatus, PersonaBudgetStatus, PersonaHandoffInboxItem, PersonaQueuedWork,
+    PersonaStatus, PersonaValueReceipt,
+};
 use crate::triggers::{SignatureStatus, TriggerEvent};
 use crate::value::{VmError, VmValue};
 
@@ -594,6 +598,42 @@ pub struct RunHitlQuestionRecord {
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
 #[serde(default)]
+pub struct RunPersonaRuntimeRecord {
+    pub name: String,
+    pub role: String,
+    pub template_ref: Option<String>,
+    pub state: String,
+    pub entry_workflow: String,
+    pub current_assignment: Option<PersonaAssignmentStatus>,
+    pub queued_work: Vec<PersonaQueuedWork>,
+    pub handoff_inbox: Vec<PersonaHandoffInboxItem>,
+    pub budget: PersonaBudgetStatus,
+    pub value_receipts: Vec<PersonaValueReceipt>,
+    pub last_run: Option<String>,
+    pub last_error: Option<String>,
+}
+
+impl From<&PersonaStatus> for RunPersonaRuntimeRecord {
+    fn from(status: &PersonaStatus) -> Self {
+        Self {
+            name: status.name.clone(),
+            role: status.role.clone(),
+            template_ref: status.template_ref.clone(),
+            state: status.state.as_str().to_string(),
+            entry_workflow: status.entry_workflow.clone(),
+            current_assignment: status.current_assignment.clone(),
+            queued_work: status.queued_work.clone(),
+            handoff_inbox: status.handoff_inbox.clone(),
+            budget: status.budget.clone(),
+            value_receipts: status.value_receipts.clone(),
+            last_run: status.last_run.clone(),
+            last_error: status.last_error.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
 pub struct RunRecord {
     #[serde(rename = "_type")]
     pub type_name: String,
@@ -623,6 +663,7 @@ pub struct RunRecord {
     pub trace_spans: Vec<RunTraceSpanRecord>,
     pub tool_recordings: Vec<ToolCallRecord>,
     pub hitl_questions: Vec<RunHitlQuestionRecord>,
+    pub persona_runtime: Vec<RunPersonaRuntimeRecord>,
     pub metadata: BTreeMap<String, serde_json::Value>,
     pub persisted_path: Option<String>,
 }

--- a/crates/harn-vm/src/orchestration/replay_oracle.rs
+++ b/crates/harn-vm/src/orchestration/replay_oracle.rs
@@ -60,6 +60,7 @@ pub struct ReplayTraceRun {
     pub protocol_interactions: Vec<JsonValue>,
     pub approval_interactions: Vec<JsonValue>,
     pub effect_receipts: Vec<JsonValue>,
+    pub persona_runtime_states: Vec<JsonValue>,
     pub agent_transcript_deltas: Vec<JsonValue>,
     pub final_artifacts: Vec<JsonValue>,
     pub policy_decisions: Vec<JsonValue>,
@@ -74,6 +75,7 @@ impl ReplayTraceRun {
             protocol_interactions: self.protocol_interactions.len(),
             approval_interactions: self.approval_interactions.len(),
             effect_receipts: self.effect_receipts.len(),
+            persona_runtime_states: self.persona_runtime_states.len(),
             agent_transcript_deltas: self.agent_transcript_deltas.len(),
             final_artifacts: self.final_artifacts.len(),
             policy_decisions: self.policy_decisions.len(),
@@ -90,6 +92,7 @@ pub struct ReplayTraceRunCounts {
     pub protocol_interactions: usize,
     pub approval_interactions: usize,
     pub effect_receipts: usize,
+    pub persona_runtime_states: usize,
     pub agent_transcript_deltas: usize,
     pub final_artifacts: usize,
     pub policy_decisions: usize,
@@ -242,6 +245,7 @@ fn trace_material_count(run: &ReplayTraceRun) -> usize {
         + counts.protocol_interactions
         + counts.approval_interactions
         + counts.effect_receipts
+        + counts.persona_runtime_states
         + counts.agent_transcript_deltas
         + counts.final_artifacts
         + counts.policy_decisions
@@ -515,6 +519,24 @@ mod tests {
         let report = run_replay_oracle_trace(&base_trace()).expect("oracle succeeds");
         assert!(report.passed, "{report:?}");
         assert_eq!(report.divergence, None);
+    }
+
+    #[test]
+    fn persona_runtime_states_are_first_class_replay_material() {
+        let mut trace = base_trace();
+        trace.first_run.persona_runtime_states = vec![json!({
+            "name": "merge_captain",
+            "state": "idle",
+            "queued_work": [],
+            "handoff_inbox": [],
+            "budget": {"spent_today_usd": 0.01},
+        })];
+        trace.second_run.persona_runtime_states = trace.first_run.persona_runtime_states.clone();
+
+        let report = run_replay_oracle_trace(&trace).expect("oracle succeeds");
+
+        assert!(report.passed, "{report:?}");
+        assert_eq!(report.first_run_counts.persona_runtime_states, 1);
     }
 
     #[test]

--- a/crates/harn-vm/src/orchestration/tests.rs
+++ b/crates/harn-vm/src/orchestration/tests.rs
@@ -267,6 +267,7 @@ fn replay_fixture_round_trip_passes() {
         trace_spans: vec![],
         tool_recordings: vec![],
         hitl_questions: vec![],
+        persona_runtime: vec![],
         metadata: BTreeMap::new(),
         persisted_path: None,
     };

--- a/crates/harn-vm/src/personas.rs
+++ b/crates/harn-vm/src/personas.rs
@@ -96,16 +96,72 @@ pub struct PersonaBudgetStatus {
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct PersonaStatus {
     pub name: String,
+    #[serde(default)]
+    pub template_ref: Option<String>,
     pub state: PersonaLifecycleState,
     pub entry_workflow: String,
+    #[serde(default)]
+    pub role: String,
+    #[serde(default)]
+    pub current_assignment: Option<PersonaAssignmentStatus>,
     pub last_run: Option<String>,
     pub next_scheduled_run: Option<String>,
     pub active_lease: Option<PersonaLease>,
     pub budget: PersonaBudgetStatus,
     pub last_error: Option<String>,
     pub queued_events: usize,
+    #[serde(default)]
+    pub queued_work: Vec<PersonaQueuedWork>,
+    #[serde(default)]
+    pub handoff_inbox: Vec<PersonaHandoffInboxItem>,
+    #[serde(default)]
+    pub value_receipts: Vec<PersonaValueReceipt>,
     pub disabled_events: usize,
     pub paused_event_policy: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct PersonaAssignmentStatus {
+    pub work_key: String,
+    pub lease_id: String,
+    pub holder: String,
+    pub acquired_at: String,
+    pub expires_at: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct PersonaQueuedWork {
+    pub work_key: String,
+    pub provider: String,
+    pub kind: String,
+    pub queued_at: String,
+    pub reason: String,
+    pub source_event_id: Option<String>,
+    #[serde(default)]
+    pub metadata: BTreeMap<String, String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct PersonaHandoffInboxItem {
+    pub work_key: String,
+    pub handoff_id: Option<String>,
+    pub handoff_kind: Option<String>,
+    pub source_persona: Option<String>,
+    pub task: Option<String>,
+    pub queued_at: String,
+    pub reason: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct PersonaValueReceipt {
+    pub kind: PersonaValueEventKind,
+    pub run_id: Option<Uuid>,
+    pub occurred_at: String,
+    pub paid_cost_usd: f64,
+    pub avoided_cost_usd: f64,
+    pub deterministic_steps: i64,
+    pub llm_steps: i64,
+    pub metadata: serde_json::Value,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
@@ -244,6 +300,8 @@ pub async fn persona_status(
     let mut budget_receipt = None;
     let mut budget_exhaustion_reason = None;
     let mut spent = Vec::<(i64, f64, u64)>::new();
+    let mut queued_work = BTreeMap::<String, PersonaQueuedWork>::new();
+    let mut value_receipts = Vec::<PersonaValueReceipt>::new();
 
     for (_, event) in events {
         match event.kind.as_str() {
@@ -312,6 +370,9 @@ pub async fn persona_status(
                 {
                     queued.insert(work_key.to_string());
                 }
+                if let Some(item) = queued_work_from_event(&event)? {
+                    queued_work.insert(item.work_key.clone(), item);
+                }
             }
             "persona.trigger.dead_lettered" => disabled_events += 1,
             "persona.budget.recorded" => {
@@ -349,6 +410,11 @@ pub async fn persona_status(
                     .and_then(serde_json::Value::as_str)
                     .map(ToString::to_string);
             }
+            kind if kind.starts_with("persona.value.") => {
+                if let Some(receipt) = value_receipt_from_event(&event)? {
+                    value_receipts.push(receipt);
+                }
+            }
             _ => {}
         }
     }
@@ -366,6 +432,12 @@ pub async fn persona_status(
     }
 
     queued.retain(|work_key| !completed.contains(work_key));
+    queued_work.retain(|work_key, _| !completed.contains(work_key));
+    let queued_work = queued_work.into_values().collect::<Vec<_>>();
+    let handoff_inbox = queued_work
+        .iter()
+        .filter_map(handoff_inbox_item)
+        .collect::<Vec<_>>();
 
     let mut budget = budget_status(&binding.budget, &spent, now_ms);
     if budget.reason.is_none() {
@@ -378,16 +450,24 @@ pub async fn persona_status(
         budget.last_receipt_id = budget_receipt;
     }
 
+    let current_assignment = active_lease.as_ref().map(assignment_status_from_lease);
+
     Ok(PersonaStatus {
         name: binding.name.clone(),
+        template_ref: binding.template_ref.clone(),
         state,
         entry_workflow: binding.entry_workflow.clone(),
+        role: binding.name.clone(),
+        current_assignment,
         last_run: last_run_ms.map(format_ms),
         next_scheduled_run: next_scheduled_run(binding, last_run_ms, now_ms),
         active_lease,
         budget,
         last_error,
         queued_events: queued.len(),
+        queued_work,
+        handoff_inbox,
+        value_receipts,
         disabled_events,
         paused_event_policy: "queue_then_drain_on_resume".to_string(),
     })
@@ -423,8 +503,7 @@ pub async fn resume_persona(
     )
     .await?;
     let queued = queued_events(log, &binding.name).await?;
-    for envelope in queued {
-        let cost = PersonaRunCost::default();
+    for (envelope, cost) in queued {
         let _ = run_for_envelope(log, binding, envelope, cost, now_ms).await?;
     }
     persona_status(log, binding, now_ms).await
@@ -532,6 +611,7 @@ async fn run_for_envelope(
                 json!({
                     "work_key": envelope.subject_key,
                     "envelope": envelope,
+                    "cost": cost,
                     "reason": "paused",
                 }),
                 now_ms,
@@ -981,9 +1061,9 @@ fn normalize_trigger_envelope(
 async fn queued_events(
     log: &Arc<AnyEventLog>,
     persona: &str,
-) -> Result<Vec<PersonaTriggerEnvelope>, String> {
+) -> Result<Vec<(PersonaTriggerEnvelope, PersonaRunCost)>, String> {
     let events = read_persona_events(log, persona).await?;
-    let mut queued = BTreeMap::<String, PersonaTriggerEnvelope>::new();
+    let mut queued = BTreeMap::<String, (PersonaTriggerEnvelope, PersonaRunCost)>::new();
     let mut completed = BTreeSet::<String>::new();
     for (_, event) in events {
         match event.kind.as_str() {
@@ -993,7 +1073,15 @@ async fn queued_events(
                 };
                 let envelope: PersonaTriggerEnvelope =
                     serde_json::from_value(envelope.clone()).map_err(|error| error.to_string())?;
-                queued.insert(envelope.subject_key.clone(), envelope);
+                let cost = event
+                    .payload
+                    .get("cost")
+                    .cloned()
+                    .map(serde_json::from_value::<PersonaRunCost>)
+                    .transpose()
+                    .map_err(|error| error.to_string())?
+                    .unwrap_or_default();
+                queued.insert(envelope.subject_key.clone(), (envelope, cost));
             }
             "persona.run.completed" => {
                 if let Some(work_key) = event
@@ -1009,6 +1097,76 @@ async fn queued_events(
     }
     queued.retain(|work_key, _| !completed.contains(work_key));
     Ok(queued.into_values().collect())
+}
+
+fn assignment_status_from_lease(lease: &PersonaLease) -> PersonaAssignmentStatus {
+    PersonaAssignmentStatus {
+        work_key: lease.work_key.clone(),
+        lease_id: lease.id.clone(),
+        holder: lease.holder.clone(),
+        acquired_at: format_ms(lease.acquired_at_ms),
+        expires_at: format_ms(lease.expires_at_ms),
+    }
+}
+
+fn queued_work_from_event(event: &LogEvent) -> Result<Option<PersonaQueuedWork>, String> {
+    let Some(envelope) = event.payload.get("envelope") else {
+        return Ok(None);
+    };
+    let envelope: PersonaTriggerEnvelope =
+        serde_json::from_value(envelope.clone()).map_err(|error| error.to_string())?;
+    Ok(Some(PersonaQueuedWork {
+        work_key: envelope.subject_key,
+        provider: envelope.provider,
+        kind: envelope.kind,
+        queued_at: format_ms(event.occurred_at_ms),
+        reason: event
+            .payload
+            .get("reason")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("queued")
+            .to_string(),
+        source_event_id: envelope.source_event_id,
+        metadata: envelope.metadata,
+    }))
+}
+
+fn handoff_inbox_item(work: &PersonaQueuedWork) -> Option<PersonaHandoffInboxItem> {
+    if work.provider != "handoff" && !work.metadata.contains_key("handoff_id") {
+        return None;
+    }
+    Some(PersonaHandoffInboxItem {
+        work_key: work.work_key.clone(),
+        handoff_id: work.metadata.get("handoff_id").cloned(),
+        handoff_kind: work
+            .metadata
+            .get("handoff_kind")
+            .or_else(|| work.metadata.get("kind"))
+            .cloned(),
+        source_persona: work.metadata.get("source_persona").cloned(),
+        task: work.metadata.get("task").cloned(),
+        queued_at: work.queued_at.clone(),
+        reason: work.reason.clone(),
+    })
+}
+
+fn value_receipt_from_event(event: &LogEvent) -> Result<Option<PersonaValueReceipt>, String> {
+    let Ok(value_event) = serde_json::from_value::<PersonaValueEvent>(event.payload.clone()) else {
+        return Ok(None);
+    };
+    Ok(Some(PersonaValueReceipt {
+        kind: value_event.kind,
+        run_id: value_event.run_id,
+        occurred_at: value_event
+            .occurred_at
+            .format(&Rfc3339)
+            .map_err(|error| error.to_string())?,
+        paid_cost_usd: value_event.paid_cost_usd,
+        avoided_cost_usd: value_event.avoided_cost_usd,
+        deterministic_steps: value_event.deterministic_steps,
+        llm_steps: value_event.llm_steps,
+        metadata: value_event.metadata,
+    }))
 }
 
 async fn work_completed(
@@ -1376,6 +1534,43 @@ mod tests {
         let status = resume_persona(&log, &binding, now + 1000).await.unwrap();
         assert_eq!(status.state, PersonaLifecycleState::Idle);
         assert_eq!(status.queued_events, 0);
+    }
+
+    #[tokio::test]
+    async fn resumed_queued_work_reuses_original_budget_cost() {
+        let log = log();
+        let mut binding = binding();
+        binding.budget.run_usd = Some(0.01);
+        let now = parse_rfc3339_ms("2026-04-24T12:00:00Z").unwrap();
+        pause_persona(&log, &binding, now).await.unwrap();
+        let queued = fire_trigger(
+            &log,
+            &binding,
+            "github",
+            "pull_request",
+            BTreeMap::from([
+                ("repository".to_string(), "burin-labs/harn".to_string()),
+                ("number".to_string(), "1379".to_string()),
+            ]),
+            PersonaRunCost {
+                cost_usd: 0.02,
+                tokens: 1,
+                ..Default::default()
+            },
+            now + 1,
+        )
+        .await
+        .unwrap();
+        assert_eq!(queued.status, "queued");
+
+        let status = resume_persona(&log, &binding, now + 2).await.unwrap();
+
+        assert_eq!(status.budget.reason.as_deref(), Some("run_usd"));
+        assert!(status
+            .last_error
+            .as_deref()
+            .is_some_and(|error| error.contains("run_usd")));
+        assert_eq!(status.queued_events, 1);
     }
 
     #[tokio::test]

--- a/crates/harn-vm/src/stdlib/workflow/register.rs
+++ b/crates/harn-vm/src/stdlib/workflow/register.rs
@@ -574,6 +574,7 @@ fn prepare_workflow_state(
         trace_spans: Vec::new(),
         tool_recordings: Vec::new(),
         hitl_questions: Vec::new(),
+        persona_runtime: Vec::new(),
         metadata: BTreeMap::new(),
         persisted_path: None,
     });

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -745,6 +745,7 @@ Launch the local Harn observability portal for persisted runs.
 ```bash
 harn portal
 harn portal --dir runs/archive
+harn portal --manifest examples/personas/harn.toml --persona-state-dir .harn/personas
 harn portal --host 0.0.0.0 --port 4900
 harn portal --open false
 ```

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -4619,7 +4619,8 @@ through the same canonical validator. Persona `triggers` install manifest
 trigger bindings whose handler kind is `persona`; explicit `[[triggers]]`
 entries may also use `handler = "persona://<name>"`.
 `harn persona status <name> --json` exposes stable runtime state including
-lifecycle state, active lease, last run, next scheduled run, budget status, and
+lifecycle state, current assignment, active lease, last run, next scheduled run,
+queued work, typed handoff inbox summaries, budget status, value receipts, and
 last error. `pause` queues later events, `resume` drains queued events under
 leases, and `disable` records later events as dead-lettered.
 

--- a/docs/src/personas.md
+++ b/docs/src/personas.md
@@ -178,7 +178,14 @@ status query replays those records and returns stable JSON with:
 - `last_run` and `next_scheduled_run`
 - active lease id, holder, work key, acquisition time, and expiry
 - budget limits, spend, token usage, exhaustion reason, and last receipt id
-- queued event count, disabled/dead-lettered event count, and last error
+- queued work details, typed handoff inbox summaries, value receipts,
+  disabled/dead-lettered event count, and last error
+
+Persisted run records can also carry `persona_runtime[]` snapshots so
+orchestration records, portal views, and replay oracle fixtures can compare
+persona state without scraping transcript prose. Replay oracle traces expose the
+same material as `persona_runtime_states[]`; use that bucket for lifecycle,
+budget, handoff, and receipt assertions that must remain deterministic.
 
 Leases are single-writer. A persona run acquires one active lease for the
 normalized work key and records a conflict instead of processing duplicate work
@@ -241,7 +248,9 @@ That means template packs should stay honest about missing platform scope:
 
 - schedule bindings can be fired and recorded, but deployment-specific
   long-running wake loops still belong to the orchestrator/host
-- handoffs validate now but are not typed persona-runtime dispatch yet
+- Harn core owns typed handoff artifacts and runtime inbox visibility; coding
+  heuristics such as PR triage strategy, repository conventions, and review
+  taste belong in a Burin-specific persona package
 - backend-specific systems such as Honeycomb and Splunk should be expressed
   through current tool wiring such as MCP rather than invented manifest fields
 

--- a/docs/src/portal.md
+++ b/docs/src/portal.md
@@ -30,6 +30,8 @@ By default the portal:
 
 - serves from `http://127.0.0.1:4721`
 - watches `.harn-runs`
+- reads persona manifests from the nearest `harn.toml`
+- reads persona runtime state from `.harn/personas`
 - opens a browser automatically
 
 For a fresh source checkout, the simplest local setup is:
@@ -54,6 +56,7 @@ Useful flags:
 
 ```bash
 harn portal --dir runs/archive
+harn portal --manifest examples/personas/harn.toml --persona-state-dir .harn/personas
 harn portal --host 0.0.0.0 --port 4900
 harn portal --open false
 ```

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -4617,7 +4617,8 @@ through the same canonical validator. Persona `triggers` install manifest
 trigger bindings whose handler kind is `persona`; explicit `[[triggers]]`
 entries may also use `handler = "persona://<name>"`.
 `harn persona status <name> --json` exposes stable runtime state including
-lifecycle state, active lease, last run, next scheduled run, budget status, and
+lifecycle state, current assignment, active lease, last run, next scheduled run,
+queued work, typed handoff inbox summaries, budget status, value receipts, and
 last error. `pause` queues later events, `resume` drains queued events under
 leases, and `disable` records later events as dead-lettered.
 


### PR DESCRIPTION
## Summary

- Extends persona runtime status with durable role/template state, current assignment, queued work, typed handoff inbox summaries, and value receipts.
- Preserves queued trigger cost across pause/resume drains so budget enforcement remains deterministic after resume.
- Adds first-class persona runtime snapshots to run records and replay oracle trace material.
- Exposes read-only persona catalog/status APIs through the portal and adds matching frontend API types/helpers.
- Updates persona/portal docs and regenerated the language spec mirror.

Fixes #1379.

## Verification

- `CARGO_TARGET_DIR=/tmp/harn-target-1379 cargo test -p harn-vm personas`
- `CARGO_TARGET_DIR=/tmp/harn-target-1379 cargo test -p harn-cli --test persona_cli`
- `CARGO_TARGET_DIR=/tmp/harn-target-1379 cargo test -p harn-cli commands::portal`
- `CARGO_TARGET_DIR=/tmp/harn-target-1379 cargo test -p harn-vm orchestration::replay_oracle`
- `CARGO_TARGET_DIR=/tmp/harn-target-1379 cargo run --quiet --bin harn -- test conformance --filter handoff_artifacts`
- `npm run portal:test`
- `npm run portal:build`
- `npm run portal:lint`
- `make check-docs-snippets`
- pre-commit hook: `cargo clippy --workspace --all-targets -- -D warnings`, markdown lint, generated language spec/highlight sync, portal lint
- pre-push hook: targeted local checks, markdown lint, generated language spec/highlight sync, portal lint
