### PR TITLE
[codex] Harden agent completion and skill scoring

### DIFF
--- a/crates/harn-stdlib/src/stdlib/agent/judge.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/judge.harn
@@ -75,13 +75,18 @@ fn __judge_invoke_structured(judge_cfg, opts, payload) {
     required: ["verdict"],
   }
   let base = opts?.llm_options ?? {}
-  let llm_opts = base
+  var llm_opts = base
     + {
     model: judge_cfg?.model ?? opts?.model,
     provider: judge_cfg?.provider ?? opts?.provider,
     output_schema: schema,
     session_id: payload.session_id,
     system: system,
+  }
+  for key in ["temperature", "max_tokens", "top_p", "tool_format", "reasoning_effort"] {
+    if judge_cfg[key] != nil {
+      llm_opts[key] = judge_cfg[key]
+    }
   }
   let started = monotonic_ms()
   let checkpoint = agent_typed_output_checkpoint("agent.completion_judge", user, schema, llm_opts)

--- a/crates/harn-stdlib/src/stdlib/agent/postturn.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/postturn.harn
@@ -76,12 +76,22 @@ fn __interpret_verdict(verdict) {
   }
   if type_of(verdict) == "dict" {
     let stop = verdict?.stop ?? false
+    let base_llm_options = if type_of(verdict?.llm_options) == "dict" {
+      verdict.llm_options
+    } else {
+      {}
+    }
+    let llm_options = if verdict?.prefill != nil && verdict?.prefill != "" {
+      base_llm_options + {prefill: verdict?.prefill}
+    } else {
+      verdict?.llm_options
+    }
     return {
       kind: "rich",
       stop: stop,
       message: verdict?.message,
       next_options: verdict?.next_options,
-      llm_options: verdict?.llm_options,
+      llm_options: llm_options,
     }
   }
   return {kind: "none"}
@@ -123,6 +133,35 @@ fn __native_tool_text_completion(opts, has_tool_calls, text) {
     return false
   }
   return trim(text) != ""
+}
+
+fn __post_turn_verdict_result(session, opts, verdict) {
+  if verdict.kind == "stop" {
+    return {kind: "break", stop_reason: "post_turn_stop", needs_verify: opts?.verify_completion != nil}
+  }
+  if verdict.kind == "inject" {
+    agent_session_inject_feedback(session.session_id, "post_turn", verdict.message)
+    return {kind: "continue"}
+  }
+  if verdict.kind != "rich" {
+    return nil
+  }
+  if verdict.message != nil {
+    agent_session_inject_feedback(session.session_id, "post_turn", verdict.message)
+  }
+  if verdict.stop {
+    return {
+      kind: "break",
+      stop_reason: "post_turn_stop",
+      needs_verify: opts?.verify_completion != nil,
+      next_options: verdict?.next_options,
+      llm_options: verdict?.llm_options,
+    }
+  }
+  if verdict.message != nil || verdict?.next_options != nil || verdict?.llm_options != nil {
+    return {kind: "continue", next_options: verdict?.next_options, llm_options: verdict?.llm_options}
+  }
+  return nil
 }
 
 /** agent_extract_tool_calls. */
@@ -173,28 +212,12 @@ pub fn agent_compute_post_turn(session, llm_result, dispatch, opts, iteration) {
     visible_text: text,
   }
   let verdict = __post_turn_callback_verdict(opts, payload)
-  if verdict.kind == "stop" {
-    return {kind: "break", stop_reason: "post_turn_stop", needs_verify: opts?.verify_completion != nil}
+  let verdict_result = __post_turn_verdict_result(session, opts, verdict)
+  if verdict_result != nil {
+    return verdict_result
   }
-  if verdict.kind == "inject" {
-    agent_session_inject_feedback(session.session_id, "post_turn", verdict.message)
-    return {kind: "continue"}
-  }
-  if verdict.kind == "rich" && verdict.message != nil {
-    agent_session_inject_feedback(session.session_id, "post_turn", verdict.message)
-  }
-  if verdict.kind == "rich" && verdict.stop {
-    return {
-      kind: "break",
-      stop_reason: "post_turn_stop",
-      needs_verify: opts?.verify_completion != nil,
-      next_options: verdict?.next_options,
-      llm_options: verdict?.llm_options,
-    }
-  }
-  if verdict.kind == "rich"
-    && (verdict.message != nil || verdict?.next_options != nil || verdict?.llm_options != nil) {
-    return {kind: "continue", next_options: verdict?.next_options, llm_options: verdict?.llm_options}
+  if !has_tool_calls && trim(text) != "" && opts?.done_judge != nil {
+    return {kind: "break", stop_reason: "natural", needs_verify: true}
   }
   if __native_tool_text_completion(opts, has_tool_calls, text) {
     return {

--- a/crates/harn-vm/src/llm/api/context_window.rs
+++ b/crates/harn-vm/src/llm/api/context_window.rs
@@ -196,6 +196,7 @@ async fn fetch_provider_max_context_uncached(
         "local"
             | "openai"
             | "mlx"
+            | "llamacpp"
             | "vllm"
             | "groq"
             | "together"

--- a/crates/harn-vm/src/llm/skill_score.rs
+++ b/crates/harn-vm/src/llm/skill_score.rs
@@ -4,7 +4,7 @@
 //! live in `std/agent/skills.harn`. This module only turns a task context
 //! plus a skill registry into ranked score records.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::rc::Rc;
 
 use crate::bridge::HostBridge;
@@ -52,6 +52,13 @@ struct SkillCandidate {
     score: f64,
     trigger: String,
 }
+
+const SKILL_SCORE_STOP_WORDS: &[&str] = &[
+    "able", "about", "add", "after", "all", "and", "any", "are", "ask", "can", "code", "create",
+    "does", "file", "for", "from", "has", "have", "how", "into", "its", "make", "more", "need",
+    "not", "one", "only", "other", "read", "run", "task", "test", "that", "the", "then", "this",
+    "tool", "use", "user", "when", "with", "work", "write", "you", "your",
+];
 
 pub(crate) async fn score_skill_registry(
     context: &VmValue,
@@ -181,7 +188,7 @@ fn score_metadata(skills: &[VmValue], task: &str, working_files: &[String]) -> V
         let mut triggers = Vec::new();
         let keyword_hits =
             count_term_hits(&tokens, &description) + count_term_hits(&tokens, &when_to_use);
-        if keyword_hits > 0 {
+        if keyword_hits >= 2 {
             let bm25 = (keyword_hits as f64) / (keyword_hits as f64 + 1.5);
             score += bm25;
             triggers.push(format!("{keyword_hits} keyword hit(s)"));
@@ -215,19 +222,27 @@ fn score_metadata(skills: &[VmValue], task: &str, working_files: &[String]) -> V
 
 fn tokenize_lower(text: &str) -> Vec<String> {
     text.split(|c: char| !c.is_alphanumeric())
-        .filter(|token| token.len() > 2)
         .map(str::to_lowercase)
+        .filter(|token| token.len() > 2 && !is_skill_score_stop_word(token))
         .collect()
+}
+
+fn tokenize_lower_set(text: &str) -> BTreeSet<String> {
+    tokenize_lower(text).into_iter().collect()
+}
+
+fn is_skill_score_stop_word(token: &str) -> bool {
+    SKILL_SCORE_STOP_WORDS.contains(&token)
 }
 
 fn count_term_hits(terms: &[String], haystack: &str) -> usize {
     if terms.is_empty() || haystack.is_empty() {
         return 0;
     }
-    let lower = haystack.to_lowercase();
+    let haystack_terms = tokenize_lower_set(haystack);
     terms
         .iter()
-        .filter(|term| lower.contains(term.as_str()))
+        .filter(|term| haystack_terms.contains(term.as_str()))
         .count()
 }
 
@@ -412,6 +427,42 @@ mod tests {
             &[],
         );
         assert_eq!(ranked[0].id, "deploy");
+    }
+
+    #[test]
+    fn metadata_ignores_stop_words_and_substrings() {
+        let ranked = score_metadata(
+            &[skill(&[
+                ("name", VmValue::String(Rc::from("disk-cleanup"))),
+                (
+                    "description",
+                    VmValue::String(Rc::from("Clean disk space by deleting caches")),
+                ),
+                (
+                    "when_to_use",
+                    VmValue::String(Rc::from("Use when the user asks to reclaim disk space")),
+                ),
+            ])],
+            "hey wassup? can you help with this?",
+            &[],
+        );
+        assert!(ranked.is_empty());
+    }
+
+    #[test]
+    fn metadata_requires_exact_keyword_tokens() {
+        let ranked = score_metadata(
+            &[skill(&[
+                ("name", VmValue::String(Rc::from("disk-cleanup"))),
+                (
+                    "description",
+                    VmValue::String(Rc::from("Clean disk space by deleting caches")),
+                ),
+            ])],
+            "please discuss clean architecture",
+            &[],
+        );
+        assert!(ranked.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- carry post-turn prefill/options into completion-judge calls and let natural plain-text replies break for done-judge verification instead of forcing another agent iteration
- pass bounded judge LLM options through structured judge calls so completion checks can stay short
- tighten skill metadata scoring to exact keyword hits, ignore stop words, and require multiple metadata hits so generic prompts do not activate unrelated skills like `disk-cleanup`
- add llama.cpp context-window discovery to OpenAI-compatible provider metadata

## Validation
- `cargo fmt`
- `CARGO_TARGET_DIR=/tmp/harn-target-tui-polish cargo test -p harn-vm skill_score`
- `CARGO_TARGET_DIR=/tmp/harn-target-tui-polish cargo run -p harn-cli --bin harn -- check crates/harn-stdlib/src/stdlib/agent/judge.harn crates/harn-stdlib/src/stdlib/agent/postturn.harn`
- pre-commit hook passed, including Rust formatting, Harn formatting/lint, clippy, ratchets, and generated highlight keyword checks
- pre-push hook passed, including targeted local checks, affected Harn formatting/lint, and generated highlight keyword checks
