### PR TITLE
[codex] Harden agent completion and skill routing

### DIFF
--- a/conformance/tests/integration/skill_lifecycle_catalog_default.expected
+++ b/conformance/tests/integration/skill_lifecycle_catalog_default.expected
@@ -1,0 +1,1 @@
+[harn] skill_lifecycle_catalog_default tests passed

--- a/conformance/tests/integration/skill_lifecycle_catalog_default.harn
+++ b/conformance/tests/integration/skill_lifecycle_catalog_default.harn
@@ -1,0 +1,36 @@
+/**
+ * The default skill path is agentic catalog routing: expose a bounded
+ * catalog and `load_skill`, then activate/scoped-load a skill only after
+ * the model explicitly asks for it.
+ */
+pipeline test(task) {
+  skill alpha {
+    description "Alpha workflow"
+    when_to_use "Use alpha for alpha-shaped work"
+    prompt "Alpha instructions."
+  }
+  skill beta {
+    description "Beta workflow"
+    when_to_use "Use beta for beta-shaped work"
+    prompt "Beta instructions."
+  }
+  let registry = skill_define(alpha, "beta", skill_find(beta, "beta") ?? {})
+  llm_mock_clear()
+  llm_mock({tool_calls: [{id: "load-alpha", name: "load_skill", arguments: {name: "alpha"}}]})
+  llm_mock({text: "Alpha loaded."})
+  let result = agent_loop(
+    "alpha please",
+    nil,
+    {provider: "mock", tool_format: "native", max_iterations: 2, skills: registry},
+  )
+  assert(result?.status == "done", "catalog-routed loop completes")
+  let calls = llm_mock_calls()
+  assert(len(calls) == 2, "load_skill creates a second model turn")
+  assert(contains(calls[0].system, "## Available skills"), "first turn shows skill catalog")
+  assert(!contains(calls[0].system, "## Active skills"), "catalog does not pre-activate skills")
+  assert(contains(json_stringify(calls[0].tools), "load_skill"), "load_skill is advertised")
+  assert(contains(calls[1].system, "## Active skills"), "loaded skill is active on the next turn")
+  assert(contains(calls[1].system, "Alpha instructions."), "loaded skill prompt is active")
+  assert(!contains(calls[1].system, "## Available skills"), "catalog drops once a skill is active")
+  log("skill_lifecycle_catalog_default tests passed")
+}

--- a/conformance/tests/integration/skill_lifecycle_exact_metadata.expected
+++ b/conformance/tests/integration/skill_lifecycle_exact_metadata.expected
@@ -1,0 +1,1 @@
+[harn] skill_lifecycle_exact_metadata tests passed

--- a/conformance/tests/integration/skill_lifecycle_exact_metadata.harn
+++ b/conformance/tests/integration/skill_lifecycle_exact_metadata.harn
@@ -1,0 +1,47 @@
+/**
+ * Metadata skill matching lives in Harn and uses exact normalized tokens.
+ * It should not activate skills from substring matches or stop words.
+ */
+pipeline test(task) {
+  skill disk_cleanup {
+    description "Clean disk space by deleting caches"
+    when_to_use "Use when the user asks to reclaim disk space"
+    prompt "Remove disk caches carefully."
+  }
+  skill ship {
+    description "Deploy application releases"
+    when_to_use "Use when the user asks to ship or deploy"
+    prompt "Ship the release."
+  }
+  llm_mock_clear()
+  llm_mock({text: "No skill needed."})
+  let generic = agent_loop(
+    "hey wassup? can you help with this?",
+    nil,
+    {provider: "mock", max_iterations: 1, skills: disk_cleanup, skill_match: {strategy: "metadata"}},
+  )
+  assert(generic?.status == "done", "generic prompt completes")
+  assert(
+    !contains(llm_mock_calls()[0].system, "## Active skills"),
+    "generic prompt does not activate cleanup",
+  )
+  llm_mock_clear()
+  llm_mock({text: "No ship skill needed."})
+  let substring = agent_loop(
+    "review membership analytics",
+    nil,
+    {provider: "mock", max_iterations: 1, skills: ship, skill_match: {strategy: "metadata"}},
+  )
+  assert(substring?.status == "done", "substring prompt completes")
+  assert(!contains(llm_mock_calls()[0].system, "## Active skills"), "membership does not match ship")
+  llm_mock_clear()
+  llm_mock({text: "Cleanup skill active."})
+  let explicit_id = agent_loop(
+    "run disk cleanup",
+    nil,
+    {provider: "mock", max_iterations: 1, skills: disk_cleanup, skill_match: {strategy: "metadata"}},
+  )
+  assert(explicit_id?.status == "done", "explicit skill-id prompt completes")
+  assert(contains(llm_mock_calls()[0].system, "disk_cleanup"), "explicit id tokens activate cleanup")
+  log("skill_lifecycle_exact_metadata tests passed")
+}

--- a/conformance/tests/integration/skill_lifecycle_flags.harn
+++ b/conformance/tests/integration/skill_lifecycle_flags.harn
@@ -31,7 +31,7 @@ pipeline test(task) {
   let result = agent_loop(
     "Please rotate the staging credentials for me",
     nil,
-    {provider: "mock", max_iterations: 1, skills: guarded},
+    {provider: "mock", max_iterations: 1, skills: guarded, skill_match: {strategy: "metadata"}},
   )
   let events = transcript_events(result?.transcript)
   var activated = 0

--- a/conformance/tests/integration/skill_lifecycle_metadata.harn
+++ b/conformance/tests/integration/skill_lifecycle_metadata.harn
@@ -1,6 +1,6 @@
 /**
  * Skills & Tool Vault phase 3 (harn#74): agent_loop lifecycle
- * integration for the `skills:` option with the default "metadata"
+ * integration for the explicit `skill_match: {strategy: "metadata"}`
  * matcher.
  *
  * Validates the full life cycle:
@@ -49,7 +49,14 @@ pipeline test(task) {
   let result = agent_loop(
     "Ship the new release to production",
     "You are a staff deploy engineer.",
-    {provider: "mock", tools: tools, tool_format: "native", max_iterations: 1, skills: registry},
+    {
+      provider: "mock",
+      tools: tools,
+      tool_format: "native",
+      max_iterations: 1,
+      skills: registry,
+      skill_match: {strategy: "metadata"},
+    },
   )
   assert(result?.status == "done", "agent loop completes")
   // The system prompt on turn 1 carries the active-skill body.

--- a/conformance/tests/integration/skill_lifecycle_namespace_scope.harn
+++ b/conformance/tests/integration/skill_lifecycle_namespace_scope.harn
@@ -41,7 +41,14 @@ pipeline test(task) {
   let result = agent_loop(
     "Investigate the auth flow",
     "You are a code explorer.",
-    {provider: "mock", tools: tools, tool_format: "native", max_iterations: 1, skills: explorer},
+    {
+      provider: "mock",
+      tools: tools,
+      tool_format: "native",
+      max_iterations: 1,
+      skills: explorer,
+      skill_match: {strategy: "metadata"},
+    },
   )
   assert(result?.status == "done", "agent loop completes")
   let calls = llm_mock_calls()

--- a/conformance/tests/integration/skill_lifecycle_paths.harn
+++ b/conformance/tests/integration/skill_lifecycle_paths.harn
@@ -25,6 +25,7 @@ pipeline test(task) {
       provider: "mock",
       max_iterations: 1,
       skills: registry,
+      skill_match: {strategy: "metadata"},
       working_files: ["infra/terraform/cluster.tf", "README.md"],
     },
   )

--- a/conformance/tests/integration/skill_lifecycle_session_resume.harn
+++ b/conformance/tests/integration/skill_lifecycle_session_resume.harn
@@ -19,7 +19,13 @@ pipeline test(task) {
   let r1 = agent_loop(
     "please handle this task carefully",
     nil,
-    {provider: "mock", max_iterations: 1, skills: sticky_skill, session_id: sid},
+    {
+      provider: "mock",
+      max_iterations: 1,
+      skills: sticky_skill,
+      session_id: sid,
+      skill_match: {strategy: "metadata"},
+    },
   )
   assert(r1?.status == "done", "first run completes")
   // Second invocation under the same session id: the matcher still
@@ -30,7 +36,13 @@ pipeline test(task) {
   let r2 = agent_loop(
     "continue",
     nil,
-    {provider: "mock", max_iterations: 1, skills: sticky_skill, session_id: sid},
+    {
+      provider: "mock",
+      max_iterations: 1,
+      skills: sticky_skill,
+      session_id: sid,
+      skill_match: {strategy: "metadata"},
+    },
   )
   assert(r2?.status == "done", "resume run completes")
   // The second run's system prompt still mentions the skill body.

--- a/crates/harn-stdlib/src/stdlib/agent/judge.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/judge.harn
@@ -75,13 +75,18 @@ fn __judge_invoke_structured(judge_cfg, opts, payload) {
     required: ["verdict"],
   }
   let base = opts?.llm_options ?? {}
-  let llm_opts = base
+  var llm_opts = base
     + {
     model: judge_cfg?.model ?? opts?.model,
     provider: judge_cfg?.provider ?? opts?.provider,
     output_schema: schema,
     session_id: payload.session_id,
     system: system,
+  }
+  for key in ["temperature", "max_tokens", "top_p", "tool_format", "reasoning_effort"] {
+    if judge_cfg[key] != nil {
+      llm_opts[key] = judge_cfg[key]
+    }
   }
   let started = monotonic_ms()
   let checkpoint = agent_typed_output_checkpoint("agent.completion_judge", user, schema, llm_opts)

--- a/crates/harn-stdlib/src/stdlib/agent/postturn.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/postturn.harn
@@ -76,12 +76,22 @@ fn __interpret_verdict(verdict) {
   }
   if type_of(verdict) == "dict" {
     let stop = verdict?.stop ?? false
+    let base_llm_options = if type_of(verdict?.llm_options) == "dict" {
+      verdict.llm_options
+    } else {
+      {}
+    }
+    let llm_options = if verdict?.prefill != nil && verdict?.prefill != "" {
+      base_llm_options + {prefill: verdict?.prefill}
+    } else {
+      verdict?.llm_options
+    }
     return {
       kind: "rich",
       stop: stop,
       message: verdict?.message,
       next_options: verdict?.next_options,
-      llm_options: verdict?.llm_options,
+      llm_options: llm_options,
     }
   }
   return {kind: "none"}
@@ -123,6 +133,35 @@ fn __native_tool_text_completion(opts, has_tool_calls, text) {
     return false
   }
   return trim(text) != ""
+}
+
+fn __post_turn_verdict_result(session, opts, verdict) {
+  if verdict.kind == "stop" {
+    return {kind: "break", stop_reason: "post_turn_stop", needs_verify: opts?.verify_completion != nil}
+  }
+  if verdict.kind == "inject" {
+    agent_session_inject_feedback(session.session_id, "post_turn", verdict.message)
+    return {kind: "continue"}
+  }
+  if verdict.kind != "rich" {
+    return nil
+  }
+  if verdict.message != nil {
+    agent_session_inject_feedback(session.session_id, "post_turn", verdict.message)
+  }
+  if verdict.stop {
+    return {
+      kind: "break",
+      stop_reason: "post_turn_stop",
+      needs_verify: opts?.verify_completion != nil,
+      next_options: verdict?.next_options,
+      llm_options: verdict?.llm_options,
+    }
+  }
+  if verdict.message != nil || verdict?.next_options != nil || verdict?.llm_options != nil {
+    return {kind: "continue", next_options: verdict?.next_options, llm_options: verdict?.llm_options}
+  }
+  return nil
 }
 
 /** agent_extract_tool_calls. */
@@ -173,28 +212,12 @@ pub fn agent_compute_post_turn(session, llm_result, dispatch, opts, iteration) {
     visible_text: text,
   }
   let verdict = __post_turn_callback_verdict(opts, payload)
-  if verdict.kind == "stop" {
-    return {kind: "break", stop_reason: "post_turn_stop", needs_verify: opts?.verify_completion != nil}
+  let verdict_result = __post_turn_verdict_result(session, opts, verdict)
+  if verdict_result != nil {
+    return verdict_result
   }
-  if verdict.kind == "inject" {
-    agent_session_inject_feedback(session.session_id, "post_turn", verdict.message)
-    return {kind: "continue"}
-  }
-  if verdict.kind == "rich" && verdict.message != nil {
-    agent_session_inject_feedback(session.session_id, "post_turn", verdict.message)
-  }
-  if verdict.kind == "rich" && verdict.stop {
-    return {
-      kind: "break",
-      stop_reason: "post_turn_stop",
-      needs_verify: opts?.verify_completion != nil,
-      next_options: verdict?.next_options,
-      llm_options: verdict?.llm_options,
-    }
-  }
-  if verdict.kind == "rich"
-    && (verdict.message != nil || verdict?.next_options != nil || verdict?.llm_options != nil) {
-    return {kind: "continue", next_options: verdict?.next_options, llm_options: verdict?.llm_options}
+  if !has_tool_calls && trim(text) != "" && opts?.done_judge != nil {
+    return {kind: "break", stop_reason: "natural", needs_verify: true}
   }
   if __native_tool_text_completion(opts, has_tool_calls, text) {
     return {

--- a/crates/harn-stdlib/src/stdlib/agent/preflight.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/preflight.harn
@@ -306,6 +306,10 @@ pub fn agent_build_turn_system(session, opts, iteration) {
   if active_skill_prompt != "" {
     parts = parts.push(active_skill_prompt)
   }
+  let skill_catalog_prompt = trim(opts?.skill_catalog_prompt ?? "")
+  if skill_catalog_prompt != "" {
+    parts = parts.push(skill_catalog_prompt)
+  }
   let loop_contract = __agent_loop_contract_prompt(opts)
   if loop_contract != "" {
     parts = parts.push(loop_contract)

--- a/crates/harn-stdlib/src/stdlib/agent/skills.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/skills.harn
@@ -56,6 +56,72 @@ fn __tool_registry_has(registry, name) {
   return false
 }
 
+fn __render_loaded_skill(entry, request) {
+  let rendered = try {
+    skill_render(entry, request?.arguments ?? request?.args ?? [])
+  }
+  if !is_err(rendered) {
+    let body = trim(unwrap(rendered))
+    if body != "" {
+      return body
+    }
+  }
+  var out = "### " + __skill_id(entry) + "\n"
+  let description = trim(entry?.description ?? "")
+  if description != "" {
+    out = out + description + "\n"
+  }
+  let when_to_use = trim(entry?.when_to_use ?? "")
+  if when_to_use != "" {
+    out = out + "When to use: " + when_to_use + "\n"
+  }
+  let allowed = entry?.allowed_tools ?? []
+  if len(allowed) > 0 {
+    out = out + "Scoped tools: " + join(allowed, ", ") + "\n"
+  }
+  let prompt = trim(entry?.prompt ?? "")
+  if prompt != "" {
+    out = out + "\n" + prompt + "\n"
+  }
+  return trim(out)
+}
+
+fn __load_skill_for_session(session, opts, args) {
+  let request = if type_of(args) == "dict" {
+    args
+  } else {
+    {name: args}
+  }
+  let registry = __skills_registry(opts)
+  let id = request?.name ?? ""
+  let entry = __skill_find(registry, id)
+  let require_signature = request?.require_signature ?? false || entry?.require_signature ?? false
+  if entry == nil || require_signature {
+    return load_skill(request + {session_id: session.session_id})
+  }
+  if __skill_model_invocation_disabled(entry) {
+    throw "skill_model_invocation_disabled: skill '" + id + "' cannot be loaded by a model"
+  }
+  let loaded = try {
+    load_skill(request + {session_id: session.session_id})
+  }
+  let body = if is_err(loaded) {
+    __render_loaded_skill(entry, request)
+  } else {
+    unwrap(loaded)
+  }
+  if entry != nil {
+    let prev = __active_from_ids(registry, agent_session_active_skills(session.session_id) ?? [])
+    var next = prev
+    if !contains(__skill_ids(prev), id) {
+      next = next.push(entry + {id: id, score: 1.0, trigger: "load_skill"})
+      __record_activations(session, prev, next, 0)
+      agent_session_set_active_skills(session.session_id, next)
+    }
+  }
+  return body
+}
+
 fn __with_load_skill_tool(session, opts) {
   let existing = opts?.tools
   let registry = if type_of(existing) == "dict" {
@@ -79,7 +145,7 @@ fn __with_load_skill_tool(session, opts) {
           required: false,
         },
       },
-      handler: { args -> load_skill(args + {session_id: session.session_id}) },
+      handler: { args -> __load_skill_for_session(session, opts, args) },
     },
   )
   return opts + {tools: next_registry}
@@ -126,7 +192,7 @@ fn __match_config(opts) {
 }
 
 fn __match_strategy(opts) {
-  return __match_config(opts)?.strategy ?? "metadata"
+  return __match_config(opts)?.strategy ?? "catalog"
 }
 
 fn __match_top_n(opts) {
@@ -145,13 +211,246 @@ fn __match_sticky(opts) {
   return true
 }
 
+fn __skill_catalog_limit(opts) {
+  let value = __match_config(opts)?.catalog_limit ?? opts?.skill_catalog_limit ?? 12
+  if type_of(value) == "int" && value > 0 {
+    return value
+  }
+  return 12
+}
+
+fn __skill_catalog_budget(opts) {
+  let value = __match_config(opts)?.catalog_budget ?? opts?.skill_catalog_budget ?? 2000
+  if type_of(value) == "int" && value > 0 {
+    return value
+  }
+  return 2000
+}
+
+fn __skill_catalog_always(opts) {
+  let value = __match_config(opts)?.catalog_always ?? opts?.skill_catalog_always
+  if type_of(value) == "bool" {
+    return value
+  }
+  return false
+}
+
+fn __skill_catalog_prompt(registry, opts, active) {
+  if __match_strategy(opts) != "catalog" {
+    return ""
+  }
+  if len(active ?? []) > 0 && !__skill_catalog_always(opts) {
+    return ""
+  }
+  let entries = skills_catalog_entries({_type: "skill_registry", skills: __matchable_skill_entries(registry)})
+  if len(entries) == 0 {
+    return ""
+  }
+  return render_always_on_catalog(entries.take(__skill_catalog_limit(opts)), __skill_catalog_budget(opts))
+}
+
+fn __skill_model_invocation_disabled(entry) {
+  return entry["disable-model-invocation"] ?? false || entry?.disable_model_invocation ?? false
+}
+
+fn __matchable_skill_entries(registry) {
+  var entries = []
+  for entry in __skills_entries(registry) {
+    if !__skill_model_invocation_disabled(entry) {
+      entries = entries.push(entry)
+    }
+  }
+  return entries
+}
+
+fn __skill_score_stop_words() {
+  return [
+    "able",
+    "about",
+    "add",
+    "after",
+    "all",
+    "and",
+    "any",
+    "are",
+    "ask",
+    "can",
+    "clean",
+    "code",
+    "create",
+    "does",
+    "file",
+    "for",
+    "from",
+    "has",
+    "have",
+    "how",
+    "into",
+    "its",
+    "make",
+    "more",
+    "need",
+    "not",
+    "one",
+    "only",
+    "other",
+    "read",
+    "run",
+    "space",
+    "task",
+    "test",
+    "that",
+    "the",
+    "then",
+    "this",
+    "tool",
+    "use",
+    "user",
+    "when",
+    "with",
+    "work",
+    "write",
+    "you",
+    "your",
+  ]
+}
+
+fn __skill_score_tokens(text) {
+  let normalized = regex_replace("[^A-Za-z0-9]+", " ", lowercase(to_string(text ?? "")))
+  let stop_words = __skill_score_stop_words()
+  var out = []
+  for raw in split(trim(normalized), " ") {
+    let token = trim(raw)
+    if len(token) > 2 && !contains(stop_words, token) && !contains(out, token) {
+      out = out.push(token)
+    }
+  }
+  return out
+}
+
+fn __skill_score_term_hits(query_tokens, text) {
+  let haystack_tokens = __skill_score_tokens(text)
+  var hits = 0
+  for token in query_tokens {
+    if contains(haystack_tokens, token) {
+      hits = hits + 1
+    }
+  }
+  return hits
+}
+
+fn __skill_score_id_match(query_tokens, id) {
+  let id_tokens = __skill_score_tokens(id)
+  if len(id_tokens) == 0 {
+    return false
+  }
+  for token in id_tokens {
+    if !contains(query_tokens, token) {
+      return false
+    }
+  }
+  return true
+}
+
+fn __skill_score_glob_match(pattern, path) {
+  let glob = to_string(pattern ?? "")
+  let value = to_string(path ?? "")
+  if glob == "" || value == "" {
+    return false
+  }
+  if glob == value {
+    return true
+  }
+  if !contains(glob, "*") {
+    return false
+  }
+  let parts = split(glob, "*")
+  var cursor = 0
+  for (index, part) in iter(parts).enumerate() {
+    if part == "" {
+      continue
+    }
+    let rest = substring(value, cursor)
+    let offset = rest.index_of(part)
+    if offset < 0 {
+      return false
+    }
+    if index == 0 && !starts_with(glob, "*") && offset != 0 {
+      return false
+    }
+    cursor = cursor + offset + len(part)
+  }
+  let last = parts[len(parts) - 1]
+  return last == "" || ends_with(value, last)
+}
+
+fn __skill_score_path_hits(patterns, working_files) {
+  var hits = 0
+  for pattern in patterns ?? [] {
+    for file in working_files ?? [] {
+      if __skill_score_glob_match(pattern, file) {
+        hits = hits + 1
+        break
+      }
+    }
+  }
+  return hits
+}
+
+fn __skill_score_metadata(context, registry) {
+  let query_tokens = __skill_score_tokens(context?.task ?? "")
+  let working_files = context?.working_files ?? []
+  var scored = []
+  for entry in __matchable_skill_entries(registry) {
+    let id = __skill_id(entry)
+    if id == "" {
+      continue
+    }
+    let keyword_hits = __skill_score_term_hits(query_tokens, entry?.description ?? "")
+      + __skill_score_term_hits(query_tokens, entry?.when_to_use ?? "")
+    let id_match = __skill_score_id_match(query_tokens, id)
+    let path_hits = __skill_score_path_hits(entry?.paths ?? [], working_files)
+    var score = 0.0
+    var triggers = []
+    if keyword_hits > 0 {
+      score = score + keyword_hits / (keyword_hits + 1.5)
+      triggers = triggers.push(to_string(keyword_hits) + " keyword hit(s)")
+    }
+    if id_match {
+      score = score + 2.0
+      triggers = triggers.push("task mentions '" + id + "'")
+    }
+    if path_hits > 0 {
+      score = score + 1.5 * path_hits
+      triggers = triggers.push(to_string(path_hits) + " path glob(s) matched")
+    }
+    if score > 0.0 {
+      scored = scored
+        .push(
+        {id: id, name: id, score: score, trigger: join(triggers, "; "), reason: join(triggers, "; ")},
+      )
+    }
+  }
+  return scored.sort_by({ candidate -> 0 - candidate.score })
+}
+
+fn __host_skill_score_candidates(context, registry, opts) {
+  let matchable = {_type: "skill_registry", skills: __matchable_skill_entries(registry)}
+  let outcome = try {
+    __host_skill_score(context, matchable, __match_config(opts))
+  }
+  if is_err(outcome) {
+    return __skill_score_metadata(context, registry)
+  }
+  return unwrap(outcome)?.scored ?? []
+}
+
 fn __score_candidates(session, registry, opts, iteration) {
-  return __host_skill_score(
-    {task: __latest_user_text(session), working_files: opts?.working_files ?? [], iteration: iteration},
-    registry,
-    __match_config(opts),
-  )?.scored
-    ?? []
+  let context = {task: __latest_user_text(session), working_files: opts?.working_files ?? [], iteration: iteration}
+  if __match_strategy(opts) == "metadata" {
+    return __skill_score_metadata(context, registry)
+  }
+  return __host_skill_score_candidates(context, registry, opts)
 }
 
 fn __top_active_from_scores(registry, scored, opts) {
@@ -296,11 +595,15 @@ fn __skill_scoped_tools(opts, active) {
   return registry + {tools: kept}
 }
 
-fn __opts_with_active_skills(opts, active) {
+fn __opts_with_active_skills(opts, registry, active) {
   let scoped_tools = __skill_scoped_tools(opts, active)
   var next = opts + {active_skills: active}
   if scoped_tools != nil {
     next = next + {tools: scoped_tools}
+  }
+  let catalog_prompt = __skill_catalog_prompt(registry, opts, active)
+  if catalog_prompt != "" {
+    next = next + {skill_catalog_prompt: catalog_prompt}
   }
   return next
 }
@@ -313,8 +616,11 @@ pub fn agent_skills_match(session, opts, iteration) {
   }
   let tool_opts = __with_load_skill_tool(session, opts)
   let prev = __active_from_ids(registry, agent_session_active_skills(session.session_id) ?? [])
+  if __match_strategy(opts) == "catalog" {
+    return __opts_with_active_skills(tool_opts, registry, prev)
+  }
   if __match_sticky(opts) && len(prev) > 0 {
-    return __opts_with_active_skills(tool_opts, prev)
+    return __opts_with_active_skills(tool_opts, registry, prev)
   }
   let scored = __score_candidates(session, registry, tool_opts, iteration)
   __record_matched(session, tool_opts, iteration, scored)
@@ -324,5 +630,5 @@ pub fn agent_skills_match(session, opts, iteration) {
     __record_activations(session, prev, active, iteration)
     agent_session_set_active_skills(session.session_id, active)
   }
-  return __opts_with_active_skills(tool_opts, active)
+  return __opts_with_active_skills(tool_opts, registry, active)
 }

--- a/crates/harn-vm/src/llm/api/context_window.rs
+++ b/crates/harn-vm/src/llm/api/context_window.rs
@@ -196,6 +196,7 @@ async fn fetch_provider_max_context_uncached(
         "local"
             | "openai"
             | "mlx"
+            | "llamacpp"
             | "vllm"
             | "groq"
             | "together"

--- a/crates/harn-vm/src/llm/skill_score.rs
+++ b/crates/harn-vm/src/llm/skill_score.rs
@@ -1,8 +1,8 @@
-//! Side-effect-free skill scoring for the Harn-driven agent loop.
+//! Bridge-backed skill scoring for the Harn-driven agent loop.
 //!
-//! Activation, sticky reuse, prompt composition, and tool-surface policy
-//! live in `std/agent/skills.harn`. This module only turns a task context
-//! plus a skill registry into ranked score records.
+//! Activation, metadata matching, sticky reuse, prompt composition, and
+//! tool-surface policy live in `std/agent/skills.harn`. This module is the
+//! primitive host/embedding bridge adapter for semantic matchers.
 
 use std::collections::BTreeMap;
 use std::rc::Rc;
@@ -10,36 +10,33 @@ use std::rc::Rc;
 use crate::bridge::HostBridge;
 use crate::value::{VmError, VmValue};
 
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum SkillMatchStrategy {
-    #[default]
-    Metadata,
     Host,
     Embedding,
 }
 
 impl SkillMatchStrategy {
-    fn parse(value: Option<&VmValue>) -> Self {
-        let Some(value) = value else {
-            return Self::Metadata;
-        };
-        match value.display().trim().to_ascii_lowercase().as_str() {
-            "host" => Self::Host,
-            "embedding" => Self::Embedding,
-            "metadata" | "" => Self::Metadata,
-            other => {
-                crate::events::log_warn(
-                    "agent.skill_score",
-                    &format!("unknown strategy '{other}', falling back to 'metadata'"),
-                );
-                Self::Metadata
-            }
+    fn parse(value: Option<&VmValue>) -> Result<Self, VmError> {
+        let strategy = value
+            .map(VmValue::display)
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase();
+        match strategy.as_str() {
+            "host" => Ok(Self::Host),
+            "embedding" => Ok(Self::Embedding),
+            "metadata" | "" => Err(VmError::Runtime(
+                "metadata skill scoring is implemented in std/agent/skills.harn".to_string(),
+            )),
+            other => Err(VmError::Runtime(format!(
+                "unknown skill scoring strategy '{other}'"
+            ))),
         }
     }
 
     fn as_str(self) -> &'static str {
         match self {
-            Self::Metadata => "metadata",
             Self::Host => "host",
             Self::Embedding => "embedding",
         }
@@ -59,12 +56,9 @@ pub(crate) async fn score_skill_registry(
     options: &VmValue,
     bridge: Option<Rc<HostBridge>>,
 ) -> Result<VmValue, VmError> {
-    let skills: Vec<VmValue> = extract_skills(registry)
-        .into_iter()
-        .filter(|skill| !skill_disabled_for_model(skill))
-        .collect();
+    let skills = extract_skills(registry);
     let options = options.as_dict().cloned().unwrap_or_default();
-    let strategy = SkillMatchStrategy::parse(options.get("strategy"));
+    let strategy = SkillMatchStrategy::parse(options.get("strategy"))?;
     let task = context
         .as_dict()
         .and_then(|dict| dict.get("task"))
@@ -72,26 +66,8 @@ pub(crate) async fn score_skill_registry(
         .unwrap_or_default();
     let working_files = list_strings(context.as_dict().and_then(|dict| dict.get("working_files")));
 
-    let scored = match strategy {
-        SkillMatchStrategy::Metadata => score_metadata(&skills, &task, &working_files),
-        SkillMatchStrategy::Host | SkillMatchStrategy::Embedding => {
-            match score_via_bridge(bridge.as_deref(), &skills, &task, &working_files, strategy)
-                .await
-            {
-                Ok(scored) => scored,
-                Err(error) => {
-                    crate::events::log_warn(
-                        "agent.skill_score",
-                        &format!(
-                            "{} strategy failed: {error}; falling back to metadata scoring",
-                            strategy.as_str()
-                        ),
-                    );
-                    score_metadata(&skills, &task, &working_files)
-                }
-            }
-        }
-    };
+    let scored =
+        score_via_bridge(bridge.as_deref(), &skills, &task, &working_files, strategy).await?;
 
     let scored_values = scored.into_iter().map(candidate_to_vm).collect();
     Ok(VmValue::Dict(Rc::new(BTreeMap::from([(
@@ -139,157 +115,6 @@ fn list_strings(value: Option<&VmValue>) -> Vec<String> {
         Some(VmValue::String(text)) if !text.is_empty() => vec![text.to_string()],
         _ => Vec::new(),
     }
-}
-
-fn skill_disabled_for_model(skill: &VmValue) -> bool {
-    let Some(dict) = skill.as_dict() else {
-        return false;
-    };
-    matches!(
-        dict.get("disable-model-invocation")
-            .or_else(|| dict.get("disable_model_invocation")),
-        Some(VmValue::Bool(true))
-    )
-}
-
-fn score_metadata(skills: &[VmValue], task: &str, working_files: &[String]) -> Vec<SkillCandidate> {
-    let tokens = tokenize_lower(task);
-    let lower_task = task.to_lowercase();
-    let mut candidates = Vec::new();
-    for skill in skills {
-        if skill_disabled_for_model(skill) {
-            continue;
-        }
-        let Some(dict) = skill.as_dict() else {
-            continue;
-        };
-        let id = dict.get("name").map(VmValue::display).unwrap_or_default();
-        if id.is_empty() {
-            continue;
-        }
-        let description = dict
-            .get("description")
-            .map(VmValue::display)
-            .unwrap_or_default();
-        let when_to_use = dict
-            .get("when_to_use")
-            .map(VmValue::display)
-            .unwrap_or_default();
-        let paths = list_strings(dict.get("paths"));
-
-        let mut score = 0.0_f64;
-        let mut triggers = Vec::new();
-        let keyword_hits =
-            count_term_hits(&tokens, &description) + count_term_hits(&tokens, &when_to_use);
-        if keyword_hits > 0 {
-            let bm25 = (keyword_hits as f64) / (keyword_hits as f64 + 1.5);
-            score += bm25;
-            triggers.push(format!("{keyword_hits} keyword hit(s)"));
-        }
-        if lower_task.contains(&id.to_lowercase()) {
-            score += 2.0;
-            triggers.push(format!("task mentions '{id}'"));
-        }
-        let path_hits = count_path_hits(&paths, working_files);
-        if path_hits > 0 {
-            score += 1.5 * (path_hits as f64);
-            triggers.push(format!("{path_hits} path glob(s) matched"));
-        }
-        if score > 0.0 {
-            candidates.push(SkillCandidate {
-                id,
-                score,
-                trigger: triggers.join("; "),
-            });
-        }
-    }
-    candidates.sort_by(|left, right| {
-        right
-            .score
-            .partial_cmp(&left.score)
-            .unwrap_or(std::cmp::Ordering::Equal)
-            .then_with(|| left.id.cmp(&right.id))
-    });
-    candidates
-}
-
-fn tokenize_lower(text: &str) -> Vec<String> {
-    text.split(|c: char| !c.is_alphanumeric())
-        .filter(|token| token.len() > 2)
-        .map(str::to_lowercase)
-        .collect()
-}
-
-fn count_term_hits(terms: &[String], haystack: &str) -> usize {
-    if terms.is_empty() || haystack.is_empty() {
-        return 0;
-    }
-    let lower = haystack.to_lowercase();
-    terms
-        .iter()
-        .filter(|term| lower.contains(term.as_str()))
-        .count()
-}
-
-fn count_path_hits(patterns: &[String], working_files: &[String]) -> usize {
-    let mut hits = 0;
-    for pattern in patterns {
-        for file in working_files {
-            if glob_match(pattern, file) {
-                hits += 1;
-                break;
-            }
-        }
-    }
-    hits
-}
-
-fn glob_match(pattern: &str, path: &str) -> bool {
-    glob_match_inner(pattern.as_bytes(), 0, path.as_bytes(), 0)
-}
-
-fn glob_match_inner(pattern: &[u8], mut pi: usize, path: &[u8], si: usize) -> bool {
-    let mut si = si;
-    while pi < pattern.len() {
-        match pattern[pi] {
-            b'*' => {
-                let double = pi + 1 < pattern.len() && pattern[pi + 1] == b'*';
-                let next_pi = if double { pi + 2 } else { pi + 1 };
-                let next_pi = if double && next_pi < pattern.len() && pattern[next_pi] == b'/' {
-                    next_pi + 1
-                } else {
-                    next_pi
-                };
-                if next_pi >= pattern.len() {
-                    return double || !path[si..].contains(&b'/');
-                }
-                for try_si in si..=path.len() {
-                    if !double && path[si..try_si].contains(&b'/') {
-                        break;
-                    }
-                    if glob_match_inner(pattern, next_pi, path, try_si) {
-                        return true;
-                    }
-                }
-                return false;
-            }
-            b'?' => {
-                if si >= path.len() || path[si] == b'/' {
-                    return false;
-                }
-                pi += 1;
-                si += 1;
-            }
-            expected => {
-                if si >= path.len() || path[si] != expected {
-                    return false;
-                }
-                pi += 1;
-                si += 1;
-            }
-        }
-    }
-    si == path.len()
 }
 
 async fn score_via_bridge(
@@ -370,85 +195,4 @@ async fn score_via_bridge(
             .then_with(|| left.id.cmp(&right.id))
     });
     Ok(out)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn skill(fields: &[(&str, VmValue)]) -> VmValue {
-        VmValue::Dict(Rc::new(
-            fields
-                .iter()
-                .map(|(key, value)| ((*key).to_string(), value.clone()))
-                .collect(),
-        ))
-    }
-
-    #[test]
-    fn metadata_ranks_keyword_matches() {
-        let ranked = score_metadata(
-            &[
-                skill(&[
-                    ("name", VmValue::String(Rc::from("deploy"))),
-                    (
-                        "description",
-                        VmValue::String(Rc::from("Deploy application releases")),
-                    ),
-                    (
-                        "when_to_use",
-                        VmValue::String(Rc::from("User asks to ship or deploy")),
-                    ),
-                ]),
-                skill(&[
-                    ("name", VmValue::String(Rc::from("metrics"))),
-                    (
-                        "description",
-                        VmValue::String(Rc::from("Inspect dashboards")),
-                    ),
-                ]),
-            ],
-            "please deploy the service",
-            &[],
-        );
-        assert_eq!(ranked[0].id, "deploy");
-    }
-
-    #[test]
-    fn path_globs_match_working_files() {
-        let ranked = score_metadata(
-            &[skill(&[
-                ("name", VmValue::String(Rc::from("infra"))),
-                ("description", VmValue::String(Rc::from("Infrastructure"))),
-                (
-                    "paths",
-                    VmValue::List(Rc::new(vec![
-                        VmValue::String(Rc::from("infra/**")),
-                        VmValue::String(Rc::from("Dockerfile")),
-                    ])),
-                ),
-            ])],
-            "unrelated",
-            &["infra/terraform/main.tf".to_string()],
-        );
-        assert_eq!(ranked.len(), 1);
-        assert!(ranked[0].trigger.contains("path"));
-    }
-
-    #[test]
-    fn disabled_skills_are_hidden_from_metadata_scoring() {
-        let ranked = score_metadata(
-            &[skill(&[
-                ("name", VmValue::String(Rc::from("secret"))),
-                (
-                    "description",
-                    VmValue::String(Rc::from("Rotate database credentials")),
-                ),
-                ("disable-model-invocation", VmValue::Bool(true)),
-            ])],
-            "rotate database credentials",
-            &[],
-        );
-        assert!(ranked.is_empty());
-    }
 }


### PR DESCRIPTION
## Summary
- carry post-turn prefill/options into completion-judge calls and let natural plain-text replies break for done-judge verification instead of forcing another agent iteration
- pass bounded judge LLM options through structured judge calls so completion checks stay short
- default agent skill handling to catalog routing: expose a bounded skill catalog plus `load_skill`, then activate scoped skill instructions only after the model explicitly requests them
- move deterministic metadata skill matching into `std/agent/skills.harn` as an explicit opt-in strategy and leave Rust as the host/embedding score adapter
- keep exact-token metadata matching for legacy/explicit flows so generic prompts and substring overlap do not activate unrelated skills like `disk-cleanup`
- add llama.cpp context-window discovery to OpenAI-compatible provider metadata

Supersedes closed PR #1402, which GitHub would not reopen after its failing commit was amended.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/tmp/harn-target-tui-polish cargo test -p harn-vm skill_score`
- `CARGO_TARGET_DIR=/tmp/harn-target-tui-polish cargo run -p harn-cli --bin harn -- check crates/harn-stdlib/src/stdlib/agent/skills.harn crates/harn-stdlib/src/stdlib/agent/preflight.harn crates/harn-stdlib/src/stdlib/agent/judge.harn crates/harn-stdlib/src/stdlib/agent/postturn.harn`
- targeted conformance tests for skill lifecycle/catalog/metadata/resume/scoping/sub-agent flows
- `CARGO_TARGET_DIR=/tmp/harn-target-tui-polish HARN_LLM_CALLS_DISABLED=1 cargo run --bin harn -- test conformance` (921 passed)
- pre-commit hook passed, including Rust formatting, Harn formatting/lint, clippy, ratchets, and generated highlight keyword checks
- pre-push hook passed, including targeted local checks, affected Harn formatting/lint, and generated highlight keyword checks
