### PR TITLE
Standardize connector setup/status metadata

### DIFF
--- a/conformance/fixtures/connectors/contract-v1/github/harn.toml
+++ b/conformance/fixtures/connectors/contract-v1/github/harn.toml
@@ -8,6 +8,26 @@ id = "github"
 connector = { harn = "./lib.harn" }
 capabilities = ["webhook", "rate_limit", "pagination", "graphql"]
 
+[providers.setup]
+auth_type = "github-app"
+flow = "browser"
+required_scopes = ["issues:read", "pull_requests:read", "contents:read", "metadata:read"]
+setup_command = ["harn", "connect", "github", "--app-slug", "<github-app-slug>"]
+validation_command = ["harn", "connect", "status", "--connector", "github", "--json"]
+
+[[providers.setup.health_checks]]
+id = "credentials"
+kind = "command"
+command = ["harn", "connect", "status", "--connector", "github", "--json"]
+
+[providers.setup.recovery]
+missing_auth = "Install the GitHub App and store its installation metadata with `harn connect github`."
+expired_credentials = "Regenerate the GitHub App installation token by rerunning connector setup."
+revoked_credentials = "Remove stale GitHub credentials with `harn connect --revoke github`, then reconnect the app."
+missing_scopes = "Reinstall or reconfigure the GitHub App with the permissions listed in required_scopes."
+inaccessible_resource = "Confirm the GitHub App installation can access the target organization or repository."
+transient_provider_outage = "Retry after GitHub or the local credential backend is reachable."
+
 [connector_contract]
 version = 1
 

--- a/conformance/fixtures/connectors/contract-v1/linear/harn.toml
+++ b/conformance/fixtures/connectors/contract-v1/linear/harn.toml
@@ -8,6 +8,26 @@ id = "linear"
 connector = { harn = "./lib.harn" }
 capabilities = ["webhook", "oauth", "rate_limit", "pagination", "graphql"]
 
+[providers.setup]
+auth_type = "oauth2"
+flow = "browser"
+required_scopes = ["read", "write"]
+setup_command = ["harn", "connect", "linear", "--client-id", "<client-id>", "--client-secret", "<client-secret>"]
+validation_command = ["harn", "connect", "status", "--connector", "linear", "--json"]
+
+[[providers.setup.health_checks]]
+id = "credentials"
+kind = "command"
+command = ["harn", "connect", "status", "--connector", "linear", "--json"]
+
+[providers.setup.recovery]
+missing_auth = "Run `harn connect linear` with the Linear OAuth client credentials."
+expired_credentials = "Refresh the Linear OAuth token or reconnect the workspace."
+revoked_credentials = "Remove stale Linear credentials with `harn connect --revoke linear`, then reconnect."
+missing_scopes = "Reconnect Linear with the scopes listed in required_scopes."
+inaccessible_resource = "Confirm the Linear token can access the target workspace, team, or project."
+transient_provider_outage = "Retry after Linear or the local credential backend is reachable."
+
 [connector_contract]
 version = 1
 

--- a/conformance/fixtures/connectors/contract-v1/notion/harn.toml
+++ b/conformance/fixtures/connectors/contract-v1/notion/harn.toml
@@ -8,6 +8,26 @@ id = "notion"
 connector = { harn = "./lib.harn" }
 capabilities = ["webhook", "rate_limit", "pagination"]
 
+[providers.setup]
+auth_type = "oauth2"
+flow = "browser"
+required_scopes = ["read_content", "update_content"]
+setup_command = ["harn", "connect", "notion", "--client-id", "<client-id>", "--client-secret", "<client-secret>"]
+validation_command = ["harn", "connect", "status", "--connector", "notion", "--json"]
+
+[[providers.setup.health_checks]]
+id = "credentials"
+kind = "command"
+command = ["harn", "connect", "status", "--connector", "notion", "--json"]
+
+[providers.setup.recovery]
+missing_auth = "Run `harn connect notion` with the integration OAuth client credentials."
+expired_credentials = "Refresh the Notion OAuth token or reconnect the workspace."
+revoked_credentials = "Remove stale Notion credentials with `harn connect --revoke notion`, then reconnect."
+missing_scopes = "Reconnect Notion with capabilities that cover the pages or databases being used."
+inaccessible_resource = "Share the target Notion page or database with the integration."
+transient_provider_outage = "Retry after Notion or the local credential backend is reachable."
+
 [connector_contract]
 version = 1
 

--- a/conformance/fixtures/connectors/contract-v1/render-logs/harn.toml
+++ b/conformance/fixtures/connectors/contract-v1/render-logs/harn.toml
@@ -1,0 +1,45 @@
+[package]
+name = "harn-render-logs-connector"
+version = "0.1.0"
+repository = "https://github.com/burin-labs/harn-render-logs-connector"
+
+[[providers]]
+id = "render-logs"
+connector = { harn = "./lib.harn" }
+capabilities = ["webhook", "rate_limit", "streaming"]
+
+[providers.setup]
+auth_type = "api-key"
+flow = "api-key"
+required_secrets = ["render/api-key"]
+setup_command = ["harn", "connect", "api-key", "--connector", "render-logs", "--secret-id", "render/api-key"]
+validation_command = ["harn", "connect", "status", "--connector", "render-logs", "--json"]
+
+[[providers.setup.health_checks]]
+id = "api-key"
+kind = "secret"
+secret = "render/api-key"
+
+[providers.setup.recovery]
+missing_auth = "Store a Render API key as render/api-key before enabling log ingestion."
+expired_credentials = "Rotate the Render API key and update render/api-key."
+revoked_credentials = "Replace the revoked Render API key in render/api-key."
+missing_scopes = "Create a Render API key with read access to the services whose logs Harn ingests."
+inaccessible_resource = "Confirm the API key can read the target Render service or log stream."
+transient_provider_outage = "Retry after Render or the local credential backend is reachable."
+
+[connector_contract]
+version = 1
+
+[[connector_contract.fixtures]]
+provider = "render-logs"
+name = "deploy log line"
+kind = "webhook"
+headers = { "content-type" = "application/json", "x-render-delivery" = "delivery-render-1" }
+body_json = { id = "log-1", service_id = "srv-1", deploy_id = "dep-1", stream = "stdout", line = "build completed", timestamp = "2026-05-09T00:00:00Z" }
+expect_type = "event"
+expect_kind = "log.line"
+expect_dedupe_key = "delivery-render-1"
+expect_signature_state = "unsigned"
+expect_payload_contains = { provider = "render-logs", raw = { provider = "render-logs", event = "log.line", service_id = "srv-1", deploy_id = "dep-1", stream = "stdout", line = "build completed" } }
+expect_event_count = 1

--- a/conformance/fixtures/connectors/contract-v1/render-logs/lib.harn
+++ b/conformance/fixtures/connectors/contract-v1/render-logs/lib.harn
@@ -1,0 +1,41 @@
+/** Return the provider id declared by this connector fixture. */
+pub fn provider_id() {
+  return "render-logs"
+}
+
+/** Return the inbound kinds exercised by this connector fixture. */
+pub fn kinds() {
+  return ["webhook", "stream"]
+}
+
+/** Return the provider payload schema advertised to hosts. */
+pub fn payload_schema() {
+  return {harn_schema_name: "RenderLogPayload", json_schema: {type: "object", additionalProperties: true}}
+}
+
+/** Normalize one Render-style log delivery into a Harn trigger event. */
+pub fn normalize_inbound(raw) {
+  let body = raw.body_json ?? json_parse(raw.body_text)
+  return {
+    type: "event",
+    event: {
+      kind: "log.line",
+      dedupe_key: raw.headers["x-render-delivery"] ?? body.id,
+      payload: {
+        provider: "render-logs",
+        event: "log.line",
+        service_id: body.service_id,
+        deploy_id: body.deploy_id,
+        stream: body.stream,
+        line: body.line,
+        timestamp: body.timestamp,
+      },
+      signature_status: {state: "unsigned"},
+    },
+  }
+}
+
+/** Reject outbound methods that this fixture does not implement. */
+pub fn call(method, _args) {
+  throw "method_not_found:" + method
+}

--- a/conformance/fixtures/connectors/contract-v1/slack/harn.toml
+++ b/conformance/fixtures/connectors/contract-v1/slack/harn.toml
@@ -8,6 +8,26 @@ id = "slack"
 connector = { harn = "./lib.harn" }
 capabilities = ["webhook", "rate_limit", "pagination"]
 
+[providers.setup]
+auth_type = "oauth2"
+flow = "browser"
+required_scopes = ["app_mentions:read", "channels:history", "chat:write"]
+setup_command = ["harn", "connect", "slack", "--client-id", "<client-id>", "--client-secret", "<client-secret>"]
+validation_command = ["harn", "connect", "status", "--connector", "slack", "--json"]
+
+[[providers.setup.health_checks]]
+id = "credentials"
+kind = "command"
+command = ["harn", "connect", "status", "--connector", "slack", "--json"]
+
+[providers.setup.recovery]
+missing_auth = "Run `harn connect slack` with the app client credentials."
+expired_credentials = "Refresh the Slack OAuth token or reconnect the workspace."
+revoked_credentials = "Remove stale Slack credentials with `harn connect --revoke slack`, then reconnect."
+missing_scopes = "Reinstall the Slack app with the scopes listed in required_scopes."
+inaccessible_resource = "Confirm the Slack app is installed in the target workspace and channel."
+transient_provider_outage = "Retry after Slack or the local credential backend is reachable."
+
 [connector_contract]
 version = 1
 

--- a/crates/harn-cli/src/cli/connect.rs
+++ b/crates/harn-cli/src/cli/connect.rs
@@ -28,6 +28,12 @@ pub(crate) struct ConnectArgs {
 
 #[derive(Debug, Subcommand)]
 pub(crate) enum ConnectCommand {
+    /// Report whether connector packages are installed and usable.
+    Status(ConnectStatusArgs),
+    /// Emit the generic host setup plan for a connector.
+    SetupPlan(ConnectSetupPlanArgs),
+    /// Store an API-key style connector secret.
+    ApiKey(ConnectApiKeyArgs),
     /// Capture GitHub App installation metadata and optional app secrets.
     Github(ConnectGithubArgs),
     /// Authorize Linear using OAuth, or register a webhook when --url is supplied.
@@ -41,6 +47,51 @@ pub(crate) enum ConnectCommand {
     /// Authorize a provider registered in harn.toml [[providers]] metadata.
     #[command(external_subcommand)]
     Provider(Vec<String>),
+}
+
+#[derive(Debug, Args, Clone)]
+pub(crate) struct ConnectApiKeyArgs {
+    /// Connector id that owns the API key.
+    #[arg(long = "connector", value_name = "ID")]
+    pub connector: String,
+    /// Secret id to store, in namespace/name form.
+    #[arg(long = "secret-id", value_name = "ID")]
+    pub secret_id: String,
+    /// Inline API key value. Prefer --value-file or prompt input in shared shells.
+    #[arg(long, conflicts_with = "value_file")]
+    pub value: Option<String>,
+    /// File containing the API key value.
+    #[arg(long = "value-file", conflicts_with = "value")]
+    pub value_file: Option<PathBuf>,
+    /// Optional scope string associated with this key.
+    #[arg(long = "scopes")]
+    pub scopes: Option<String>,
+    /// Emit machine-readable JSON instead of a human summary.
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args, Clone)]
+pub(crate) struct ConnectStatusArgs {
+    /// Restrict status to one connector id.
+    #[arg(long = "connector", value_name = "ID")]
+    pub connector: Option<String>,
+    /// Execute declared health-check commands in addition to local credential checks.
+    #[arg(long = "run-health-checks")]
+    pub run_health_checks: bool,
+    /// Emit machine-readable JSON instead of a human summary.
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args, Clone)]
+pub(crate) struct ConnectSetupPlanArgs {
+    /// Connector id to plan setup for.
+    #[arg(long = "connector", value_name = "ID")]
+    pub connector: String,
+    /// Emit machine-readable JSON instead of a human summary.
+    #[arg(long)]
+    pub json: bool,
 }
 
 #[derive(Debug, Args)]

--- a/crates/harn-cli/src/cli/mod.rs
+++ b/crates/harn-cli/src/cli/mod.rs
@@ -52,8 +52,8 @@ pub(crate) use bench::BenchArgs;
 pub(crate) use check::{CheckArgs, CheckOutputFormat};
 pub(crate) use completions::{CompletionShell, CompletionsArgs};
 pub(crate) use connect::{
-    ConnectArgs, ConnectCommand, ConnectGenericArgs, ConnectGithubArgs, ConnectLinearArgs,
-    ConnectOAuthArgs,
+    ConnectApiKeyArgs, ConnectArgs, ConnectCommand, ConnectGenericArgs, ConnectGithubArgs,
+    ConnectLinearArgs, ConnectOAuthArgs, ConnectSetupPlanArgs, ConnectStatusArgs,
 };
 pub(crate) use connector::{
     ConnectorArgs, ConnectorCheckArgs, ConnectorCommand, ConnectorTestArgs,

--- a/crates/harn-cli/src/commands/connect.rs
+++ b/crates/harn-cli/src/commands/connect.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeSet;
 use std::io::{Read, Write};
 use std::net::TcpListener;
 use std::path::{Path, PathBuf};
+use std::process::Command as ProcessCommand;
 use std::time::{Duration, Instant};
 
 use base64::Engine;
@@ -12,10 +13,10 @@ use sha2::{Digest, Sha256};
 use url::Url;
 
 use crate::cli::{
-    ConnectArgs, ConnectCommand, ConnectGenericArgs, ConnectGithubArgs, ConnectLinearArgs,
-    ConnectOAuthArgs,
+    ConnectApiKeyArgs, ConnectArgs, ConnectCommand, ConnectGenericArgs, ConnectGithubArgs,
+    ConnectLinearArgs, ConnectOAuthArgs, ConnectSetupPlanArgs, ConnectStatusArgs,
 };
-use crate::package::{self, ProviderOAuthManifest};
+use crate::package::{self, ConnectorRecoveryCopy, ProviderOAuthManifest};
 use harn_vm::secrets::{KeyringSecretProvider, SecretBytes, SecretId, SecretProvider};
 
 const MANIFEST: &str = "harn.toml";
@@ -132,6 +133,75 @@ struct TokenResponse {
     _extra: serde_json::Map<String, JsonValue>,
 }
 
+#[derive(Clone, Debug, Serialize)]
+struct ConnectStatusReport {
+    schema_version: u32,
+    manifest: Option<String>,
+    connectors: Vec<ConnectorStatus>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct ConnectorStatus {
+    id: String,
+    installed: bool,
+    usable: bool,
+    status: String,
+    reason: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    auth_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    flow: Option<String>,
+    required_scopes: Vec<String>,
+    missing_scopes: Vec<String>,
+    required_secrets: Vec<String>,
+    missing_secrets: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    secret_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    expires_at_unix: Option<i64>,
+    health_checks: Vec<ConnectorHealthStatus>,
+    recovery: ConnectorRecoveryCopy,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct ConnectorHealthStatus {
+    id: String,
+    kind: String,
+    status: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    detail: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct ConnectSetupPlan {
+    schema_version: u32,
+    connector: String,
+    installed: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    manifest: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    auth_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    flow: Option<String>,
+    required_scopes: Vec<String>,
+    required_secrets: Vec<String>,
+    setup_command: Vec<String>,
+    validation_command: Vec<String>,
+    health_checks: Vec<package::ConnectorHealthCheckManifest>,
+    recovery: ConnectorRecoveryCopy,
+    steps: Vec<ConnectSetupStep>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct ConnectSetupStep {
+    id: String,
+    title: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    command: Vec<String>,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    body: String,
+}
+
 pub(crate) async fn run_connect(args: ConnectArgs) {
     if let Err(error) = run_connect_inner(args).await {
         eprintln!("error: {error}");
@@ -147,7 +217,7 @@ async fn run_connect_inner(args: ConnectArgs) -> Result<(), String> {
         + args.command.is_some() as u8;
     if actions != 1 {
         return Err(
-            "choose exactly one connect action: a provider subcommand, --generic, --list, --revoke, or --refresh"
+            "choose exactly one connect action: status, setup-plan, api-key, a provider subcommand, --generic, --list, --revoke, or --refresh"
                 .to_string(),
         );
     }
@@ -186,6 +256,18 @@ async fn run_connect_inner(args: ConnectArgs) -> Result<(), String> {
 
     let json_output = args.json;
     match args.command.expect("validated one command action") {
+        ConnectCommand::Status(mut status) => {
+            status.json |= json_output;
+            run_connect_status(&status).await
+        }
+        ConnectCommand::SetupPlan(mut setup_plan) => {
+            setup_plan.json |= json_output;
+            run_connect_setup_plan(&setup_plan)
+        }
+        ConnectCommand::ApiKey(mut api_key) => {
+            api_key.json |= json_output;
+            run_connect_api_key(&api_key).await
+        }
         ConnectCommand::Github(args) => run_connect_github(&args).await,
         ConnectCommand::Linear(args) if args.url.is_some() => run_connect_linear(&args).await,
         ConnectCommand::Linear(args) => run_connect_linear_oauth(&args).await,
@@ -311,6 +393,533 @@ fn parse_external_provider_connect(
         .map_err(|error| error.render().to_string())?;
     parsed.oauth.json |= json_output;
     Ok(parsed)
+}
+
+async fn run_connect_status(args: &ConnectStatusArgs) -> Result<(), String> {
+    let report = connect_status_report(args).await?;
+    if args.json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&report)
+                .map_err(|error| format!("failed to encode JSON output: {error}"))?
+        );
+    } else if report.connectors.is_empty() {
+        println!("No connector providers declared in the nearest harn.toml.");
+    } else {
+        for status in &report.connectors {
+            println!(
+                "{}\t{}\tusable={}\t{}",
+                status.id, status.status, status.usable, status.reason
+            );
+        }
+    }
+    Ok(())
+}
+
+fn run_connect_setup_plan(args: &ConnectSetupPlanArgs) -> Result<(), String> {
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let plan = connect_setup_plan_at(&args.connector, &cwd)?;
+    if args.json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&plan)
+                .map_err(|error| format!("failed to encode JSON output: {error}"))?
+        );
+    } else {
+        println!("Connector: {}", plan.connector);
+        println!("Installed: {}", plan.installed);
+        if let Some(auth_type) = plan.auth_type.as_deref() {
+            println!("Auth: {auth_type}");
+        }
+        for step in &plan.steps {
+            println!("- {}", step.title);
+            if !step.command.is_empty() {
+                println!("  {}", step.command.join(" "));
+            }
+            if !step.body.is_empty() {
+                println!("  {}", step.body);
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn run_connect_api_key(args: &ConnectApiKeyArgs) -> Result<(), String> {
+    let secret_id = parse_secret_id(&args.secret_id).ok_or_else(|| {
+        format!(
+            "invalid secret id `{}`; expected namespace/name",
+            args.secret_id
+        )
+    })?;
+    let value = match (args.value.as_ref(), args.value_file.as_ref()) {
+        (Some(value), None) => value.as_bytes().to_vec(),
+        (None, Some(path)) => std::fs::read(path)
+            .map_err(|error| format!("failed to read API key file {}: {error}", path.display()))?,
+        (None, None) => rpassword::prompt_password("API key: ")
+            .map_err(|error| format!("failed to read API key: {error}"))?
+            .into_bytes(),
+        _ => unreachable!("clap enforces API key value conflicts"),
+    };
+    let provider = connect_secret_provider()?;
+    provider
+        .put(&secret_id, SecretBytes::from(value))
+        .await
+        .map_err(|error| format!("failed to store {secret_id}: {error}"))?;
+    upsert_index_entry(
+        &provider,
+        ConnectIndexEntry {
+            provider: args.connector.clone(),
+            kind: "api-key".to_string(),
+            secret_id: secret_id.to_string(),
+            expires_at_unix: None,
+            scopes: args.scopes.clone(),
+            connected_at_unix: current_unix_timestamp(),
+            last_used_at_unix: None,
+        },
+    )
+    .await?;
+
+    if args.json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&json!({
+                "provider": args.connector,
+                "kind": "api-key",
+                "secret_id": secret_id.to_string(),
+                "scopes": args.scopes,
+            }))
+            .map_err(|error| format!("failed to encode JSON output: {error}"))?
+        );
+    } else {
+        println!("Stored API key for {} as {}.", args.connector, secret_id);
+    }
+    Ok(())
+}
+
+async fn connect_status_report(args: &ConnectStatusArgs) -> Result<ConnectStatusReport, String> {
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let extensions = package::try_load_runtime_extensions(&cwd)?;
+    let provider = connect_secret_provider()?;
+    let (index, credential_backend_error) = match load_connect_index(&provider).await {
+        Ok(index) => (index, None),
+        Err(error) => (ConnectIndex::default(), Some(error)),
+    };
+    let now = current_unix_timestamp();
+    let manifest = extensions
+        .root_manifest_path
+        .as_ref()
+        .map(|path| path.display().to_string());
+
+    let connectors = if let Some(connector) = args.connector.as_deref() {
+        let config = extensions
+            .provider_connectors
+            .iter()
+            .find(|entry| entry.id.as_str() == connector);
+        vec![
+            connector_status(
+                connector,
+                config,
+                &provider,
+                &index,
+                now,
+                args.run_health_checks,
+                credential_backend_error.as_deref(),
+            )
+            .await,
+        ]
+    } else {
+        let mut connectors = Vec::new();
+        for config in &extensions.provider_connectors {
+            connectors.push(
+                connector_status(
+                    config.id.as_str(),
+                    Some(config),
+                    &provider,
+                    &index,
+                    now,
+                    args.run_health_checks,
+                    credential_backend_error.as_deref(),
+                )
+                .await,
+            );
+        }
+        connectors.sort_by(|left, right| left.id.cmp(&right.id));
+        connectors
+    };
+
+    Ok(ConnectStatusReport {
+        schema_version: 1,
+        manifest,
+        connectors,
+    })
+}
+
+async fn connector_status(
+    connector_id: &str,
+    config: Option<&package::ResolvedProviderConnectorConfig>,
+    provider: &dyn SecretProvider,
+    index: &ConnectIndex,
+    now: i64,
+    run_health_checks: bool,
+    credential_backend_error: Option<&str>,
+) -> ConnectorStatus {
+    let Some(config) = config else {
+        return missing_install_status(connector_id);
+    };
+    let setup = config.setup.clone().unwrap_or_default();
+    let auth_type = setup.auth_type.clone();
+    let flow = setup.flow.clone();
+    let recovery = setup.recovery.clone();
+    let required_scopes = setup.required_scopes.clone();
+    let required_secrets = setup.required_secrets.clone();
+    let entry = index
+        .providers
+        .iter()
+        .find(|entry| entry.provider == connector_id);
+    let mut health_checks = Vec::new();
+    let mut missing_secrets = Vec::new();
+    let mut status = "healthy".to_string();
+    let mut reason = "connector is installed and credentials are present".to_string();
+
+    if let Some(error) = credential_backend_error {
+        status = "transient_provider_outage".to_string();
+        reason = format!("credential backend was unavailable: {error}");
+    }
+
+    if status == "healthy"
+        && auth_type.as_deref().is_some_and(|kind| kind != "none")
+        && entry.is_none()
+        && required_secrets.is_empty()
+    {
+        status = "missing_auth".to_string();
+        reason = format!("no stored credentials found for connector '{connector_id}'");
+    }
+
+    let secret_id = entry.map(|entry| entry.secret_id.clone());
+    let expires_at_unix = entry.and_then(|entry| entry.expires_at_unix);
+    if status == "healthy" {
+        if let Some(expires_at) = expires_at_unix {
+            if expires_at <= now {
+                status = "expired_credentials".to_string();
+                reason = "stored credentials are expired".to_string();
+            }
+        }
+    }
+    if status == "healthy" {
+        if let Some(entry) = entry {
+            match parse_secret_id(&entry.secret_id) {
+                Some(id) => match provider.get(&id).await {
+                    Ok(_) => {}
+                    Err(harn_vm::secrets::SecretError::NotFound { .. }) => {
+                        status = "revoked_credentials".to_string();
+                        reason = format!(
+                            "credential index points at missing secret '{}'",
+                            entry.secret_id
+                        );
+                    }
+                    Err(error) => {
+                        status = "transient_provider_outage".to_string();
+                        reason = format!("credential backend was unavailable: {error}");
+                    }
+                },
+                None => {
+                    status = "revoked_credentials".to_string();
+                    reason = format!(
+                        "credential index contains invalid secret id '{}'",
+                        entry.secret_id
+                    );
+                }
+            }
+        }
+    }
+
+    if status == "healthy" {
+        for secret in &required_secrets {
+            match parse_secret_id(secret) {
+                Some(id) => match provider.get(&id).await {
+                    Ok(_) => health_checks.push(ConnectorHealthStatus {
+                        id: format!("secret:{secret}"),
+                        kind: "secret".to_string(),
+                        status: "pass".to_string(),
+                        detail: String::new(),
+                    }),
+                    Err(harn_vm::secrets::SecretError::NotFound { .. }) => {
+                        missing_secrets.push(secret.clone());
+                        health_checks.push(ConnectorHealthStatus {
+                            id: format!("secret:{secret}"),
+                            kind: "secret".to_string(),
+                            status: "fail".to_string(),
+                            detail: "missing secret".to_string(),
+                        });
+                    }
+                    Err(error) => {
+                        status = "transient_provider_outage".to_string();
+                        reason = format!("credential backend was unavailable: {error}");
+                        health_checks.push(ConnectorHealthStatus {
+                            id: format!("secret:{secret}"),
+                            kind: "secret".to_string(),
+                            status: "fail".to_string(),
+                            detail: error.to_string(),
+                        });
+                    }
+                },
+                None => {
+                    missing_secrets.push(secret.clone());
+                    health_checks.push(ConnectorHealthStatus {
+                        id: format!("secret:{secret}"),
+                        kind: "secret".to_string(),
+                        status: "fail".to_string(),
+                        detail: "invalid secret id".to_string(),
+                    });
+                }
+            }
+        }
+        if !missing_secrets.is_empty() && status == "healthy" {
+            status = "missing_auth".to_string();
+            reason = format!("missing required secrets: {}", missing_secrets.join(", "));
+        }
+    }
+
+    let missing_scopes = missing_required_scopes(
+        &required_scopes,
+        entry.and_then(|entry| entry.scopes.as_deref()),
+    );
+    if status == "healthy" && !missing_scopes.is_empty() {
+        status = "missing_scopes".to_string();
+        reason = format!(
+            "stored credentials are missing scopes: {}",
+            missing_scopes.join(", ")
+        );
+    }
+
+    if run_health_checks && status == "healthy" {
+        for check in &setup.health_checks {
+            let check_status = run_manifest_health_check(check);
+            if check_status.status == "inaccessible_resource"
+                || check_status.status == "transient_provider_outage"
+            {
+                status = check_status.status.clone();
+                reason = check_status.detail.clone();
+            }
+            health_checks.push(check_status);
+        }
+    }
+
+    ConnectorStatus {
+        id: connector_id.to_string(),
+        installed: true,
+        usable: status == "healthy",
+        status,
+        reason,
+        auth_type,
+        flow,
+        required_scopes,
+        missing_scopes,
+        required_secrets,
+        missing_secrets,
+        secret_id,
+        expires_at_unix,
+        health_checks,
+        recovery,
+    }
+}
+
+fn missing_install_status(connector_id: &str) -> ConnectorStatus {
+    ConnectorStatus {
+        id: connector_id.to_string(),
+        installed: false,
+        usable: false,
+        status: "missing_install".to_string(),
+        reason: format!("connector '{connector_id}' is not declared in the nearest harn.toml"),
+        auth_type: None,
+        flow: None,
+        required_scopes: Vec::new(),
+        missing_scopes: Vec::new(),
+        required_secrets: Vec::new(),
+        missing_secrets: Vec::new(),
+        secret_id: None,
+        expires_at_unix: None,
+        health_checks: Vec::new(),
+        recovery: ConnectorRecoveryCopy {
+            missing_install: Some(format!(
+                "Add a package or [[providers]] entry for connector '{connector_id}'."
+            )),
+            ..ConnectorRecoveryCopy::default()
+        },
+    }
+}
+
+fn connect_setup_plan_at(connector_id: &str, cwd: &Path) -> Result<ConnectSetupPlan, String> {
+    let extensions = package::try_load_runtime_extensions(cwd)?;
+    let manifest = extensions
+        .root_manifest_path
+        .as_ref()
+        .map(|path| path.display().to_string());
+    let Some(config) = extensions
+        .provider_connectors
+        .iter()
+        .find(|entry| entry.id.as_str() == connector_id)
+    else {
+        return Ok(ConnectSetupPlan {
+            schema_version: 1,
+            connector: connector_id.to_string(),
+            installed: false,
+            manifest,
+            auth_type: None,
+            flow: None,
+            required_scopes: Vec::new(),
+            required_secrets: Vec::new(),
+            setup_command: Vec::new(),
+            validation_command: vec![
+                "harn".to_string(),
+                "connect".to_string(),
+                "status".to_string(),
+                "--connector".to_string(),
+                connector_id.to_string(),
+                "--json".to_string(),
+            ],
+            health_checks: Vec::new(),
+            recovery: ConnectorRecoveryCopy {
+                missing_install: Some(format!(
+                    "Install a package that declares [[providers]] id = \"{connector_id}\"."
+                )),
+                ..ConnectorRecoveryCopy::default()
+            },
+            steps: vec![ConnectSetupStep {
+                id: "install".to_string(),
+                title: "Install connector package".to_string(),
+                command: Vec::new(),
+                body: format!(
+                    "Add a dependency and [[providers]] entry for connector '{connector_id}'."
+                ),
+            }],
+        });
+    };
+    let setup = config.setup.clone().unwrap_or_default();
+    let mut steps = Vec::new();
+    if let Some(copy) = setup.recovery.missing_install.as_ref() {
+        steps.push(ConnectSetupStep {
+            id: "install".to_string(),
+            title: "Install connector package".to_string(),
+            command: Vec::new(),
+            body: copy.clone(),
+        });
+    }
+    steps.push(ConnectSetupStep {
+        id: "authorize".to_string(),
+        title: "Authorize connector".to_string(),
+        command: setup.setup_command.clone(),
+        body: setup.recovery.missing_auth.clone().unwrap_or_default(),
+    });
+    steps.push(ConnectSetupStep {
+        id: "validate".to_string(),
+        title: "Validate connector status".to_string(),
+        command: setup.validation_command.clone(),
+        body: String::new(),
+    });
+
+    Ok(ConnectSetupPlan {
+        schema_version: 1,
+        connector: connector_id.to_string(),
+        installed: true,
+        manifest,
+        auth_type: setup.auth_type,
+        flow: setup.flow,
+        required_scopes: setup.required_scopes,
+        required_secrets: setup.required_secrets,
+        setup_command: setup.setup_command,
+        validation_command: setup.validation_command,
+        health_checks: setup.health_checks,
+        recovery: setup.recovery,
+        steps,
+    })
+}
+
+fn missing_required_scopes(required: &[String], actual: Option<&str>) -> Vec<String> {
+    let actual = actual
+        .unwrap_or_default()
+        .split(|ch: char| ch.is_ascii_whitespace() || ch == ',')
+        .filter(|scope| !scope.trim().is_empty())
+        .map(str::trim)
+        .collect::<BTreeSet<_>>();
+    required
+        .iter()
+        .filter(|scope| !actual.contains(scope.trim()))
+        .cloned()
+        .collect()
+}
+
+fn run_manifest_health_check(
+    check: &package::ConnectorHealthCheckManifest,
+) -> ConnectorHealthStatus {
+    if check.kind == "secret" {
+        return ConnectorHealthStatus {
+            id: check.id.clone(),
+            kind: check.kind.clone(),
+            status: "skipped".to_string(),
+            detail: "secret checks are evaluated before command health checks".to_string(),
+        };
+    }
+    if check.kind != "command" {
+        return ConnectorHealthStatus {
+            id: check.id.clone(),
+            kind: check.kind.clone(),
+            status: "skipped".to_string(),
+            detail: "only command health checks are executable by harn connect status".to_string(),
+        };
+    }
+    let Some((program, args)) = check.command.split_first() else {
+        return ConnectorHealthStatus {
+            id: check.id.clone(),
+            kind: check.kind.clone(),
+            status: "transient_provider_outage".to_string(),
+            detail: "command health check is empty".to_string(),
+        };
+    };
+    let output = ProcessCommand::new(program).args(args).output();
+    match output {
+        Ok(output) if output.status.success() => ConnectorHealthStatus {
+            id: check.id.clone(),
+            kind: check.kind.clone(),
+            status: "pass".to_string(),
+            detail: String::from_utf8_lossy(&output.stdout).trim().to_string(),
+        },
+        Ok(output) => {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let declared_status = serde_json::from_str::<JsonValue>(stdout.trim())
+                .ok()
+                .and_then(|value| {
+                    value
+                        .get("status")
+                        .and_then(JsonValue::as_str)
+                        .map(str::to_string)
+                })
+                .filter(|status| {
+                    matches!(
+                        status.as_str(),
+                        "inaccessible_resource" | "transient_provider_outage"
+                    )
+                })
+                .unwrap_or_else(|| "transient_provider_outage".to_string());
+            ConnectorHealthStatus {
+                id: check.id.clone(),
+                kind: check.kind.clone(),
+                status: declared_status,
+                detail: if stderr.trim().is_empty() {
+                    stdout.trim().to_string()
+                } else {
+                    stderr.trim().to_string()
+                },
+            }
+        }
+        Err(error) => ConnectorHealthStatus {
+            id: check.id.clone(),
+            kind: check.kind.clone(),
+            status: "transient_provider_outage".to_string(),
+            detail: format!("failed to run health check command: {error}"),
+        },
+    }
 }
 
 fn registered_provider_oauth(provider: &str) -> Result<Option<ProviderOAuthManifest>, String> {
@@ -854,7 +1463,20 @@ async fn run_connect_list(json_output: bool) -> Result<(), String> {
 
 async fn run_connect_revoke(provider_name: &str, json_output: bool) -> Result<(), String> {
     let provider = connect_secret_provider()?;
+    let indexed_secret = load_connect_index(&provider).await.ok().and_then(|index| {
+        index
+            .providers
+            .into_iter()
+            .find(|entry| entry.provider == provider_name)
+            .and_then(|entry| parse_secret_id(&entry.secret_id))
+    });
     for id in connector_secret_ids(provider_name) {
+        provider
+            .delete(&id)
+            .await
+            .map_err(|error| format!("failed to delete {id}: {error}"))?;
+    }
+    if let Some(id) = indexed_secret {
         provider
             .delete(&id)
             .await
@@ -1754,6 +2376,29 @@ mod tests {
     use std::sync::{Arc, Barrier};
     use std::thread;
 
+    fn status_config(
+        setup: package::ProviderSetupManifest,
+    ) -> package::ResolvedProviderConnectorConfig {
+        package::ResolvedProviderConnectorConfig {
+            id: harn_vm::ProviderId::from("github"),
+            manifest_dir: PathBuf::from("/tmp"),
+            connector: package::ResolvedProviderConnectorKind::Harn {
+                module: "./lib.harn".to_string(),
+            },
+            oauth: None,
+            setup: Some(setup),
+        }
+    }
+
+    fn oauth_setup() -> package::ProviderSetupManifest {
+        package::ProviderSetupManifest {
+            auth_type: Some("oauth2".to_string()),
+            flow: Some("browser".to_string()),
+            required_scopes: vec!["issues:read".to_string(), "pull_requests:read".to_string()],
+            ..package::ProviderSetupManifest::default()
+        }
+    }
+
     #[test]
     fn derives_linear_resource_types_from_trigger_events() {
         let manifest = package::ResolvedTriggerConfig {
@@ -1867,6 +2512,110 @@ mod tests {
         );
         assert!(request.no_open);
         assert!(request.json);
+    }
+
+    #[test]
+    fn missing_required_scopes_splits_oauth_scope_strings() {
+        let required = vec![
+            "issues:read".to_string(),
+            "pull_requests:read".to_string(),
+            "contents:read".to_string(),
+        ];
+        assert_eq!(
+            missing_required_scopes(
+                &required,
+                Some("issues:read,pull_requests:read metadata:read")
+            ),
+            vec!["contents:read".to_string()]
+        );
+    }
+
+    #[test]
+    fn setup_plan_for_missing_connector_is_host_renderable() {
+        let dir = tempfile::tempdir().unwrap();
+        let plan = connect_setup_plan_at("github", dir.path()).expect("setup plan");
+
+        assert_eq!(plan.connector, "github");
+        assert!(!plan.installed);
+        assert_eq!(plan.validation_command[0], "harn");
+        assert_eq!(plan.steps[0].id, "install");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn status_reports_missing_auth_without_credentials() {
+        let secrets = harn_vm::connectors::testkit::MemorySecretProvider::empty();
+        let index = ConnectIndex::default();
+        let config = status_config(oauth_setup());
+        let status =
+            connector_status("github", Some(&config), &secrets, &index, 100, false, None).await;
+
+        assert_eq!(status.status, "missing_auth");
+        assert!(!status.usable);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn status_reports_expired_credentials_before_scope_checks() {
+        let secrets = harn_vm::connectors::testkit::MemorySecretProvider::empty();
+        let index = ConnectIndex {
+            providers: vec![ConnectIndexEntry {
+                provider: "github".to_string(),
+                kind: "oauth".to_string(),
+                secret_id: "github/access-token".to_string(),
+                expires_at_unix: Some(99),
+                scopes: Some("issues:read".to_string()),
+                connected_at_unix: 1,
+                last_used_at_unix: None,
+            }],
+        };
+        let config = status_config(oauth_setup());
+        let status =
+            connector_status("github", Some(&config), &secrets, &index, 100, false, None).await;
+
+        assert_eq!(status.status, "expired_credentials");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn status_reports_revoked_credentials_when_index_secret_is_missing() {
+        let secrets = harn_vm::connectors::testkit::MemorySecretProvider::empty();
+        let index = ConnectIndex {
+            providers: vec![ConnectIndexEntry {
+                provider: "github".to_string(),
+                kind: "oauth".to_string(),
+                secret_id: "github/access-token".to_string(),
+                expires_at_unix: None,
+                scopes: Some("issues:read pull_requests:read".to_string()),
+                connected_at_unix: 1,
+                last_used_at_unix: None,
+            }],
+        };
+        let config = status_config(oauth_setup());
+        let status =
+            connector_status("github", Some(&config), &secrets, &index, 100, false, None).await;
+
+        assert_eq!(status.status, "revoked_credentials");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn status_reports_missing_scopes_after_secret_checks_pass() {
+        let secrets = harn_vm::connectors::testkit::MemorySecretProvider::empty()
+            .with_secret(SecretId::new("github", "access-token"), "token");
+        let index = ConnectIndex {
+            providers: vec![ConnectIndexEntry {
+                provider: "github".to_string(),
+                kind: "oauth".to_string(),
+                secret_id: "github/access-token".to_string(),
+                expires_at_unix: None,
+                scopes: Some("issues:read".to_string()),
+                connected_at_unix: 1,
+                last_used_at_unix: None,
+            }],
+        };
+        let config = status_config(oauth_setup());
+        let status =
+            connector_status("github", Some(&config), &secrets, &index, 100, false, None).await;
+
+        assert_eq!(status.status, "missing_scopes");
+        assert_eq!(status.missing_scopes, vec!["pull_requests:read"]);
     }
 
     #[test]

--- a/crates/harn-cli/src/commands/connector.rs
+++ b/crates/harn-cli/src/commands/connector.rs
@@ -155,6 +155,7 @@ pub(crate) async fn check_connector_package(
             }
             continue;
         };
+        validate_setup_metadata(provider.id.as_str(), provider.setup.as_ref(), &mut failures);
 
         match check_one_connector(
             provider.id.clone(),
@@ -363,6 +364,11 @@ fn validate_connector_package_metadata(anchor: &Path) -> ConnectorGateCheck {
                     )),
                     ResolvedProviderConnectorKind::Invalid(message) => failures.push(message.clone()),
                 }
+                validate_setup_metadata(
+                    provider.id.as_str(),
+                    provider.setup.as_ref(),
+                    &mut failures,
+                );
             }
             if !package_dir.join("README.md").is_file() {
                 failures.push("README.md is required".to_string());
@@ -385,6 +391,123 @@ fn validate_connector_package_metadata(anchor: &Path) -> ConnectorGateCheck {
 fn require_metadata_field(value: Option<&str>, field: &str, failures: &mut Vec<String>) {
     if value.is_none_or(|value| value.trim().is_empty()) {
         failures.push(format!("{field} is required"));
+    }
+}
+
+fn validate_setup_metadata(
+    provider_id: &str,
+    setup: Option<&package::ProviderSetupManifest>,
+    failures: &mut Vec<String>,
+) {
+    let Some(setup) = setup else {
+        failures.push(format!(
+            "provider '{provider_id}' must declare setup metadata"
+        ));
+        return;
+    };
+    if setup.auth_type.as_deref().is_none_or(str::is_empty) {
+        failures.push(format!(
+            "provider '{provider_id}' setup.auth_type is required"
+        ));
+    }
+    if setup.flow.as_deref().is_none_or(str::is_empty) {
+        failures.push(format!("provider '{provider_id}' setup.flow is required"));
+    }
+    if setup.setup_command.is_empty() {
+        failures.push(format!(
+            "provider '{provider_id}' setup.setup_command is required"
+        ));
+    }
+    if setup.validation_command.is_empty() {
+        failures.push(format!(
+            "provider '{provider_id}' setup.validation_command is required"
+        ));
+    }
+    if setup.health_checks.is_empty() {
+        failures.push(format!(
+            "provider '{provider_id}' setup.health_checks must include at least one health check"
+        ));
+    }
+    for scope in &setup.required_scopes {
+        if scope.trim().is_empty() {
+            failures.push(format!(
+                "provider '{provider_id}' setup.required_scopes cannot include empty values"
+            ));
+        }
+    }
+    for secret in &setup.required_secrets {
+        if secret.split_once('/').is_none() {
+            failures.push(format!(
+                "provider '{provider_id}' setup.required_secrets entry '{secret}' must use namespace/name form"
+            ));
+        }
+    }
+    validate_recovery_copy(provider_id, &setup.recovery, failures);
+    for check in &setup.health_checks {
+        if check.id.trim().is_empty() {
+            failures.push(format!(
+                "provider '{provider_id}' setup health check id is required"
+            ));
+        }
+        match check.kind.as_str() {
+            "secret" if check.secret.as_deref().is_none_or(str::is_empty) => {
+                failures.push(format!(
+                    "provider '{provider_id}' secret health check '{}' must set secret",
+                    check.id
+                ));
+            }
+            "command" if check.command.is_empty() => {
+                failures.push(format!(
+                    "provider '{provider_id}' command health check '{}' must set command",
+                    check.id
+                ));
+            }
+            "http" | "mcp" | "resource" if check.url.as_deref().is_none_or(str::is_empty) => {
+                failures.push(format!(
+                    "provider '{provider_id}' {} health check '{}' must set url",
+                    check.kind, check.id
+                ));
+            }
+            "secret" | "command" | "http" | "mcp" | "resource" => {}
+            other => failures.push(format!(
+                "provider '{provider_id}' setup health check '{}' uses unsupported kind '{other}'",
+                check.id
+            )),
+        }
+    }
+}
+
+fn validate_recovery_copy(
+    provider_id: &str,
+    recovery: &package::ConnectorRecoveryCopy,
+    failures: &mut Vec<String>,
+) {
+    let required = [
+        ("missing_auth", recovery.missing_auth.as_deref()),
+        (
+            "expired_credentials",
+            recovery.expired_credentials.as_deref(),
+        ),
+        (
+            "revoked_credentials",
+            recovery.revoked_credentials.as_deref(),
+        ),
+        ("missing_scopes", recovery.missing_scopes.as_deref()),
+        (
+            "inaccessible_resource",
+            recovery.inaccessible_resource.as_deref(),
+        ),
+        (
+            "transient_provider_outage",
+            recovery.transient_provider_outage.as_deref(),
+        ),
+    ];
+    for (field, value) in required {
+        if value.is_none_or(|value| value.trim().is_empty()) {
+            failures.push(format!(
+                "provider '{provider_id}' setup.recovery.{field} is required"
+            ));
+        }
     }
 }
 
@@ -1533,6 +1656,27 @@ version = "0.1.0"
 [[providers]]
 id = "echo"
 connector = {{ harn = "./lib.harn" }}
+
+[providers.setup]
+auth_type = "api-key"
+flow = "api-key"
+required_secrets = ["echo/api-token"]
+setup_command = ["harn", "connect", "echo"]
+validation_command = ["harn", "connect", "status", "--connector", "echo", "--json"]
+
+[[providers.setup.health_checks]]
+id = "api-token"
+kind = "secret"
+secret = "echo/api-token"
+
+[providers.setup.recovery]
+missing_auth = "Store echo/api-token."
+expired_credentials = "Rotate echo/api-token."
+revoked_credentials = "Replace echo/api-token."
+missing_scopes = "Use an API key with the required scopes."
+inaccessible_resource = "Grant access to the target echo resource."
+transient_provider_outage = "Retry after the provider is reachable."
+
 {manifest_tail}
 "#
             ),
@@ -1670,6 +1814,39 @@ pub fn normalize_inbound(_raw) {
             .await
             .unwrap_err();
         assert!(error.contains("payload_schema() must return { harn_schema_name, json_schema? }"));
+    }
+
+    #[tokio::test]
+    async fn connector_check_rejects_missing_setup_metadata() {
+        let _guard = connector_check_test_guard().await;
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("harn.toml"),
+            r#"
+[package]
+name = "contract-test"
+version = "0.1.0"
+
+[[providers]]
+id = "echo"
+connector = { harn = "./lib.harn" }
+"#,
+        )
+        .unwrap();
+        fs::write(
+            dir.path().join("lib.harn"),
+            r#"
+pub fn provider_id() { return "echo" }
+pub fn kinds() { return ["webhook"] }
+pub fn payload_schema() { return "EchoEventPayload" }
+pub fn normalize_inbound(_raw) { return {type: "reject", status: 400} }
+"#,
+        )
+        .unwrap();
+        let error = check_connector_package(&check_args(dir.path()))
+            .await
+            .unwrap_err();
+        assert!(error.contains("provider 'echo' must declare setup metadata"));
     }
 
     #[tokio::test]

--- a/crates/harn-cli/src/package/manifest.rs
+++ b/crates/harn-cli/src/package/manifest.rs
@@ -797,6 +797,8 @@ pub struct ProviderManifestEntry {
     #[serde(default)]
     pub oauth: Option<ProviderOAuthManifest>,
     #[serde(default)]
+    pub setup: Option<ProviderSetupManifest>,
+    #[serde(default)]
     pub capabilities: ConnectorCapabilities,
 }
 
@@ -826,6 +828,58 @@ pub struct ProviderOAuthManifest {
     pub client_secret: Option<String>,
     #[serde(default, alias = "token_auth_method", alias = "token-auth-method")]
     pub token_endpoint_auth_method: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct ProviderSetupManifest {
+    #[serde(default, alias = "auth-type")]
+    pub auth_type: Option<String>,
+    #[serde(default)]
+    pub flow: Option<String>,
+    #[serde(default, alias = "required-scopes", alias = "scopes")]
+    pub required_scopes: Vec<String>,
+    #[serde(default, alias = "required-secrets")]
+    pub required_secrets: Vec<String>,
+    #[serde(default, alias = "setup-command")]
+    pub setup_command: Vec<String>,
+    #[serde(default, alias = "validation-command")]
+    pub validation_command: Vec<String>,
+    #[serde(default, alias = "health-checks")]
+    pub health_checks: Vec<ConnectorHealthCheckManifest>,
+    #[serde(default)]
+    pub recovery: ConnectorRecoveryCopy,
+    #[serde(flatten, default)]
+    pub extra: BTreeMap<String, toml::Value>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConnectorHealthCheckManifest {
+    pub id: String,
+    pub kind: String,
+    #[serde(default)]
+    pub command: Vec<String>,
+    #[serde(default)]
+    pub secret: Option<String>,
+    #[serde(default)]
+    pub url: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConnectorRecoveryCopy {
+    #[serde(default, alias = "missing-install")]
+    pub missing_install: Option<String>,
+    #[serde(default, alias = "missing-auth")]
+    pub missing_auth: Option<String>,
+    #[serde(default, alias = "expired-credentials")]
+    pub expired_credentials: Option<String>,
+    #[serde(default, alias = "revoked-credentials")]
+    pub revoked_credentials: Option<String>,
+    #[serde(default, alias = "missing-scopes")]
+    pub missing_scopes: Option<String>,
+    #[serde(default, alias = "inaccessible-resource")]
+    pub inaccessible_resource: Option<String>,
+    #[serde(default, alias = "transient-provider-outage")]
+    pub transient_provider_outage: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize)]
@@ -984,6 +1038,7 @@ pub struct ResolvedProviderConnectorConfig {
     pub manifest_dir: PathBuf,
     pub connector: ResolvedProviderConnectorKind,
     pub oauth: Option<ProviderOAuthManifest>,
+    pub setup: Option<ProviderSetupManifest>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/harn-cli/src/package/validation.rs
+++ b/crates/harn-cli/src/package/validation.rs
@@ -261,6 +261,7 @@ pub(crate) fn resolved_provider_connectors_from_manifest(
                 manifest_dir: manifest_dir.to_path_buf(),
                 connector,
                 oauth: provider.oauth.clone(),
+                setup: provider.setup.clone(),
             }
         })
         .collect()

--- a/docs/src/connectors/authoring.md
+++ b/docs/src/connectors/authoring.md
@@ -337,6 +337,45 @@ Fixture fields:
 Use `--provider <id>` to check one provider from a multi-provider package and
 `--json` for machine-readable CI output.
 
+Connector packages must also declare setup metadata on each `[[providers]]`
+entry so GUI, TUI, and CLI hosts can render the same Connect/Fix experience
+without provider-specific code:
+
+```toml
+[[providers]]
+id = "example"
+connector = { harn = "./lib.harn" }
+capabilities = ["webhook", "oauth"]
+
+[providers.setup]
+auth_type = "oauth2"
+flow = "browser"
+required_scopes = ["example.read", "example.write"]
+required_secrets = []
+setup_command = ["harn", "connect", "example"]
+validation_command = ["harn", "connect", "status", "--connector", "example", "--json"]
+
+[[providers.setup.health_checks]]
+id = "credentials"
+kind = "command"
+command = ["harn", "connect", "status", "--connector", "example", "--json"]
+
+[providers.setup.recovery]
+missing_auth = "Run `harn connect example`."
+expired_credentials = "Refresh or reconnect the OAuth token."
+revoked_credentials = "Revoke the stale local token, then reconnect."
+missing_scopes = "Reconnect with the scopes listed in required_scopes."
+inaccessible_resource = "Grant the connector access to the requested resource."
+transient_provider_outage = "Retry after the provider or credential backend recovers."
+```
+
+`auth_type` names the credential family (`oauth2`, `device-code`, `api-key`,
+`github-app`, or `none`) and `flow` names the host interaction. `health_checks`
+can be `secret`, `command`, `http`, `mcp`, or `resource`; only `secret` and
+`command` are evaluated by `harn connect status`, while the remaining kinds are
+declared for hosts and provider-specific validators. `harn connector check`
+fails when setup metadata is missing or malformed.
+
 Minimal example:
 
 ```harn

--- a/docs/src/connectors/catalog.md
+++ b/docs/src/connectors/catalog.md
@@ -189,7 +189,8 @@ A community connector is any Harn package that:
 2. Provides a `[[providers]]` manifest entry with `connector = { harn = ... }`.
 3. Exports `provider_id`, `kinds`, `payload_schema`, and the relevant
    `normalize_inbound`, `poll_tick`, or `call` exports.
-4. Ships deterministic `[connector_contract]` fixtures and passes
+4. Declares provider-scoped `setup` metadata for generic host setup/status UI.
+5. Ships deterministic `[connector_contract]` fixtures and passes
    `harn connector test .`.
 
 Minimal package shape:
@@ -207,6 +208,26 @@ default = "src/lib.harn"
 id = "acme"
 connector = { harn = "src/lib.harn" }
 capabilities = ["webhook"]
+
+[providers.setup]
+auth_type = "api-key"
+flow = "api-key"
+required_secrets = ["acme/api-key"]
+setup_command = ["harn", "connect", "api-key", "--connector", "acme", "--secret-id", "acme/api-key"]
+validation_command = ["harn", "connect", "status", "--connector", "acme", "--json"]
+
+[[providers.setup.health_checks]]
+id = "api-key"
+kind = "secret"
+secret = "acme/api-key"
+
+[providers.setup.recovery]
+missing_auth = "Store an Acme API key as acme/api-key."
+expired_credentials = "Rotate the Acme API key."
+revoked_credentials = "Replace the revoked Acme API key."
+missing_scopes = "Create an Acme API key with the required scopes."
+inaccessible_resource = "Grant the API key access to the target Acme resource."
+transient_provider_outage = "Retry after Acme or the credential backend recovers."
 
 [connector_contract]
 version = 1

--- a/docs/src/connectors/parity-matrix.md
+++ b/docs/src/connectors/parity-matrix.md
@@ -14,4 +14,5 @@ Regenerate with `make gen-connector-matrix` and verify with `make check-connecto
 | `github` | [`harn-github-connector`](https://github.com/burin-labs/harn-github-connector) | yes | no | yes | yes | yes | no |
 | `linear` | [`harn-linear-connector`](https://github.com/burin-labs/harn-linear-connector) | yes | yes | yes | yes | yes | no |
 | `notion` | [`harn-notion-connector`](https://github.com/burin-labs/harn-notion-connector) | yes | no | yes | yes | no | no |
+| `render-logs` | [`harn-render-logs-connector`](https://github.com/burin-labs/harn-render-logs-connector) | yes | no | yes | no | no | yes |
 | `slack` | [`harn-slack-connector`](https://github.com/burin-labs/harn-slack-connector) | yes | no | yes | yes | no | no |

--- a/docs/src/orchestrator/oauth.md
+++ b/docs/src/orchestrator/oauth.md
@@ -47,6 +47,42 @@ oauth = {
 }
 ```
 
+Hosts use the same metadata for generic setup and repair UI. Every connector
+package should declare a `setup` table on its `[[providers]]` entry:
+
+```toml
+[[providers]]
+id = "acme"
+connector = { harn = ".harn/packages/acme-connector/lib.harn" }
+capabilities = ["webhook", "oauth"]
+
+[providers.setup]
+auth_type = "oauth2"
+flow = "browser"
+required_scopes = ["mcp.read", "mcp.write"]
+setup_command = ["harn", "connect", "acme"]
+validation_command = ["harn", "connect", "status", "--connector", "acme", "--json"]
+
+[[providers.setup.health_checks]]
+id = "credentials"
+kind = "command"
+command = ["harn", "connect", "status", "--connector", "acme", "--json"]
+
+[providers.setup.recovery]
+missing_auth = "Run `harn connect acme`."
+expired_credentials = "Refresh or reconnect the OAuth token."
+revoked_credentials = "Revoke the stale local token, then reconnect."
+missing_scopes = "Reconnect with the scopes listed in required_scopes."
+inaccessible_resource = "Grant the connector access to the requested resource."
+transient_provider_outage = "Retry after the provider or credential backend recovers."
+```
+
+`harn connect setup-plan --connector <id> --json` emits a host-renderable plan.
+`harn connect status --connector <id> --json` reports one of `healthy`,
+`missing_install`, `missing_auth`, `expired_credentials`,
+`revoked_credentials`, `missing_scopes`, `inaccessible_resource`, or
+`transient_provider_outage`.
+
 When endpoints are not supplied, Harn discovers protected-resource metadata,
 then authorization-server metadata. If the server advertises dynamic client
 registration and no `--client-id` is supplied, Harn registers a loopback client


### PR DESCRIPTION
## Summary
- add provider setup metadata for auth type, flow, required scopes/secrets, validation commands, health checks, and recovery copy
- add `harn connect status --json`, `harn connect setup-plan --connector ... --json`, and generic `harn connect api-key` setup support
- validate setup metadata in connector package checks and add GitHub plus Render-log style fixtures/docs

Closes #1409

## Verification
- `cargo test -p harn-cli commands::connect::tests:: --lib`
- `cargo test -p harn-cli commands::connector::tests:: --lib`
- `cargo check -p harn-cli`
- `harn dump-connector-matrix --check`
- `harn connector check` over every `conformance/fixtures/connectors/contract-v1/*` package
- pre-commit and pre-push hooks passed