### PR TITLE
[codex] Add agent reasoning runtime profiles

### DIFF
--- a/conformance/tests/agents/agent_basic.harn
+++ b/conformance/tests/agents/agent_basic.harn
@@ -5,7 +5,7 @@ fn agent_tools() {
     "read",
     "Read a file",
     {
-      handler: { args -> "" },
+      handler: { _args -> "" },
       parameters: {path: {type: "string", description: "Path to read"}},
       returns: {type: "string"},
     },
@@ -15,7 +15,7 @@ fn agent_tools() {
     "search",
     "Search project files",
     {
-      handler: { args -> "" },
+      handler: { _args -> "" },
       parameters: {
         pattern: {type: "string", description: "Pattern to search"},
         file_glob: {type: "string", description: "Optional file glob", required: false},
@@ -35,6 +35,9 @@ pipeline test(task) {
       provider: "mock",
       model: "test-model",
       max_iterations: 5,
+      reasoning_policy: "auto",
+      reasoning_scale: "large",
+      reasoning_task: "code",
       tools: agent_tools(),
     },
   )
@@ -54,5 +57,8 @@ pipeline test(task) {
   assert(cfg.options.provider == "mock", "should have provider in options")
   assert(cfg.options.model == "test-model", "should have model in options")
   assert(cfg.options.max_iterations == 5, "should have max_iterations in options")
+  assert(cfg.options.reasoning_policy == "auto", "should have reasoning_policy in options")
+  assert(cfg.options.reasoning_scale == "large", "should have reasoning_scale in options")
+  assert(cfg.options.reasoning_task == "code", "should have reasoning_task in options")
   log("agent tests passed")
 }

--- a/conformance/tests/agents/agent_loop_done_judge_fail_open.expected
+++ b/conformance/tests/agents/agent_loop_done_judge_fail_open.expected
@@ -1,0 +1,4 @@
+done
+The answer is 4.
+1
+2

--- a/conformance/tests/agents/agent_loop_done_judge_fail_open.harn
+++ b/conformance/tests/agents/agent_loop_done_judge_fail_open.harn
@@ -1,0 +1,14 @@
+pipeline default() {
+  llm_mock_clear()
+  llm_mock({text: "<user_response>The answer is 4.</user_response>\n<done>##DONE##</done>"})
+  llm_mock({error: {category: "generic", message: "structured output is unavailable"}})
+  let result = agent_loop(
+    "What is 2 + 2?",
+    nil,
+    {provider: "mock", loop_until_done: true, max_iterations: 2, done_judge: {fail_open_on_error: true}},
+  )
+  println(result.status)
+  println(result.visible_text)
+  println(result.llm.iterations)
+  println(len(llm_mock_calls()))
+}

--- a/conformance/tests/agents/agent_runtime_features.harn
+++ b/conformance/tests/agents/agent_runtime_features.harn
@@ -46,13 +46,14 @@ pipeline test(task) {
     {role: "assistant", content: "We should isolate the lexer first."},
     {role: "user", content: "Then update the diagnostics."},
   ]
-  let llm_compacted = transcript_auto_compact(base_messages, {provider: "mock", keep_last: 1})
+  let llm_compacted = transcript_auto_compact(base_messages, {provider: "mock", keep_last: 1, token_threshold: 1})
   println(len(llm_compacted))
   println(llm_compacted[0].content.contains("auto-compacted"))
   let custom_compacted = transcript_auto_compact(
     base_messages,
     {
       keep_last: 1,
+      token_threshold: 1,
       compact_strategy: "custom",
       compact_callback: { archived -> {summary: "custom compact " + to_string(len(archived))} },
     },

--- a/conformance/tests/integration/skill_lifecycle_manual.expected
+++ b/conformance/tests/integration/skill_lifecycle_manual.expected
@@ -1,0 +1,1 @@
+[harn] skill_lifecycle_manual tests passed

--- a/conformance/tests/integration/skill_lifecycle_manual.harn
+++ b/conformance/tests/integration/skill_lifecycle_manual.harn
@@ -1,0 +1,46 @@
+/**
+ * `skill_match: {strategy: "manual"}` lets a host render its own compact
+ * skill cards while still giving the model the `load_skill` tool for the
+ * supplied registry. Harn must not add its catalog prompt until the model
+ * explicitly loads a skill.
+ */
+pipeline test(task) {
+  skill alpha {
+    description "Alpha workflow"
+    when_to_use "Use alpha for alpha-shaped work"
+    prompt "Alpha instructions."
+  }
+  skill beta {
+    description "Beta workflow"
+    when_to_use "Use beta for beta-shaped work"
+    prompt "Beta instructions."
+  }
+  let registry = skill_define(alpha, "beta", skill_find(beta, "beta") ?? {})
+  llm_mock_clear()
+  llm_mock({tool_calls: [{id: "load-alpha", name: "load_skill", arguments: {name: "alpha"}}]})
+  llm_mock({text: "Alpha loaded."})
+  let result = agent_loop(
+    "alpha please",
+    "Host-rendered cards mention `alpha`.",
+    {
+      provider: "mock",
+      tool_format: "native",
+      max_iterations: 2,
+      skills: registry,
+      skill_match: {strategy: "manual"},
+    },
+  )
+  assert(result?.status == "done", "manual skill loop completes")
+  let calls = llm_mock_calls()
+  assert(len(calls) == 2, "load_skill creates a second model turn")
+  assert(!contains(calls[0].system, "## Available skills"), "manual strategy suppresses catalog")
+  assert(
+    !contains(calls[0].system, "## Active skills"),
+    "manual strategy does not pre-activate skills",
+  )
+  assert(contains(json_stringify(calls[0].tools), "load_skill"), "load_skill is still advertised")
+  assert(contains(calls[1].system, "## Active skills"), "loaded skill is active on the next turn")
+  assert(contains(calls[1].system, "Alpha instructions."), "loaded skill prompt is active")
+  assert(!contains(calls[1].system, "## Available skills"), "manual strategy never adds the catalog")
+  log("skill_lifecycle_manual tests passed")
+}

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -1037,6 +1037,9 @@ async fn print_model_info(args: &ModelInfoArgs) -> bool {
         harn_vm::llm::fetch_provider_max_context(&resolved.provider, &resolved.id, &api_key).await;
     let readiness = local_openai_readiness(&resolved.provider, &resolved.id, &api_key).await;
     let catalog = harn_vm::llm_config::model_catalog_entry(&resolved.id);
+    let runtime_context_window = catalog
+        .as_ref()
+        .and_then(|entry| entry.runtime_context_window);
     let capabilities = harn_vm::llm::capabilities::lookup(&resolved.provider, &resolved.id);
     let mut payload = serde_json::json!({
         "alias": args.model,
@@ -1047,6 +1050,7 @@ async fn print_model_info(args: &ModelInfoArgs) -> bool {
         "tier": resolved.tier,
         "api_key_set": api_key_set,
         "context_window": context_window,
+        "runtime_context_window": runtime_context_window,
         "readiness": readiness,
         "catalog": catalog,
         "capabilities": {
@@ -1173,6 +1177,7 @@ fn print_provider_catalog(available_only: bool) {
                 "name": model.name,
                 "provider": model.provider,
                 "context_window": model.context_window,
+                "runtime_context_window": model.runtime_context_window,
                 "stream_timeout": model.stream_timeout,
                 "capabilities": model.capabilities,
                 "pricing": model.pricing,

--- a/crates/harn-stdlib/src/stdlib/agent/judge.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/judge.harn
@@ -70,7 +70,7 @@ fn __judge_invoke_structured(judge_cfg, opts, payload) {
     properties: {
       verdict: {type: "string", description: "Use `done` or `continue`."},
       reasoning: {type: "string"},
-      next_step: {type: "any"},
+      next_step: {type: "string"},
     },
     required: ["verdict"],
   }
@@ -92,6 +92,16 @@ fn __judge_invoke_structured(judge_cfg, opts, payload) {
   let checkpoint = agent_typed_output_checkpoint("agent.completion_judge", user, schema, llm_opts)
   let duration_ms = monotonic_ms() - started
   if !checkpoint.ok {
+    if judge_cfg?.fail_open_on_error ?? judge_cfg?.fail_open ?? false {
+      return {
+        vetoed: false,
+        verdict: "done",
+        reasoning: checkpoint.error,
+        next_step: "",
+        judge_duration_ms: duration_ms,
+        typed_checkpoint: checkpoint,
+      }
+    }
     return {
       vetoed: true,
       feedback: checkpoint.error,

--- a/crates/harn-stdlib/src/stdlib/agent/skills.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/skills.harn
@@ -195,6 +195,11 @@ fn __match_strategy(opts) {
   return __match_config(opts)?.strategy ?? "catalog"
 }
 
+fn __match_strategy_manual(opts) {
+  let strategy = __match_strategy(opts)
+  return strategy == "manual" || strategy == "none"
+}
+
 fn __match_top_n(opts) {
   let value = __match_config(opts)?.top_n
   if type_of(value) == "int" && value > 0 {
@@ -616,6 +621,9 @@ pub fn agent_skills_match(session, opts, iteration) {
   }
   let tool_opts = __with_load_skill_tool(session, opts)
   let prev = __active_from_ids(registry, agent_session_active_skills(session.session_id) ?? [])
+  if __match_strategy_manual(opts) {
+    return __opts_with_active_skills(tool_opts, registry, prev)
+  }
   if __match_strategy(opts) == "catalog" {
     return __opts_with_active_skills(tool_opts, registry, prev)
   }

--- a/crates/harn-stdlib/src/stdlib/agent/user.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/user.harn
@@ -2,6 +2,7 @@
 import { agent_read_tools } from "std/agent/host_tools"
 import { render_agent_prompt } from "std/agent/prompts"
 import { agent_emit_event, agent_session_messages } from "std/agent/state"
+import { pick_keys } from "std/collections"
 import { safe_parse } from "std/json"
 
 fn __sim_user_string(value) {
@@ -473,13 +474,29 @@ fn __agentic_user_prompt(answerer, payload) {
 }
 
 fn __agentic_user_base_llm_options(answerer) {
-  var opts = answerer?.llm_options ?? {}
-  for key in ["provider", "model", "temperature", "top_p", "max_tokens", "seed", "api_base", "api_key"] {
-    if answerer[key] != nil {
-      opts[key] = answerer[key]
-    }
-  }
-  return opts
+  let opts = answerer?.llm_options ?? {}
+  return opts + pick_keys(answerer, __agentic_user_llm_option_keys(), {drop_nil: true})
+}
+
+fn __agentic_user_llm_option_keys() {
+  return [
+    "provider",
+    "model",
+    "model_tier",
+    "temperature",
+    "top_p",
+    "max_tokens",
+    "seed",
+    "api_base",
+    "api_key",
+    "thinking",
+    "reasoning_effort",
+    "reasoning_policy",
+    "thinking_policy",
+    "reasoning_scale",
+    "problem_scale",
+    "reasoning_task",
+  ]
 }
 
 fn __agentic_user_remaining_llm_calls(answerer) {
@@ -576,14 +593,6 @@ pub fn agentic_user(task_or_config, behavior = nil, tools = nil, model = nil, op
     behavior: config?.behavior ?? "",
     tools: config?.tools,
     tool_format: config?.tool_format,
-    provider: config?.provider,
-    model: config?.model,
-    temperature: config?.temperature,
-    top_p: config?.top_p,
-    max_tokens: config?.max_tokens,
-    seed: config?.seed,
-    api_base: config?.api_base,
-    api_key: config?.api_key,
     llm_options: config?.llm_options ?? {},
     max_replies: config?.max_replies ?? 5,
     max_llm_calls: config?.max_llm_calls ?? 8,
@@ -596,6 +605,7 @@ pub fn agentic_user(task_or_config, behavior = nil, tools = nil, model = nil, op
     session_id: config?.session_id,
     state: state,
   }
+    + pick_keys(config, __agentic_user_llm_option_keys(), {drop_nil: true})
   answerer["respond"] = { payload -> __agentic_user_respond(answerer, payload) }
   return answerer
 }

--- a/crates/harn-stdlib/src/stdlib/agent/workers.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/workers.harn
@@ -1,14 +1,29 @@
 // @harn-entrypoint-category agent.stdlib
-import { filter_nil } from "std/collections"
+import { filter_nil, pick_keys } from "std/collections"
 
 fn __agent_option_keys() {
   return [
     "provider",
     "model",
+    "model_tier",
+    "temperature",
+    "top_p",
+    "top_k",
+    "max_tokens",
     "thinking",
+    "reasoning_effort",
+    "reasoning_policy",
+    "thinking_policy",
+    "reasoning_scale",
+    "problem_scale",
+    "reasoning_task",
     "tools",
     "max_iterations",
+    "max_nudges",
+    "nudge",
+    "turn_policy",
     "tool_format",
+    "native_tool_fallback",
     "structural_experiment",
     "context_callback",
     "context_filter",
@@ -42,12 +57,7 @@ pub fn agent_config(agent, prompt) {
   if type_of(agent) != "dict" || agent?._type != "agent" {
     throw "agent_config: first argument must be an agent (created with agent())"
   }
-  var options = {}
-  for key in __agent_option_keys() {
-    if agent[key] != nil {
-      options = options + {[key]: agent[key]}
-    }
-  }
+  let options = pick_keys(agent, __agent_option_keys(), {drop_nil: true})
   return {prompt: prompt, system: agent?.system, options: options}
 }
 

--- a/crates/harn-stdlib/src/stdlib/llm/budget.harn
+++ b/crates/harn-stdlib/src/stdlib/llm/budget.harn
@@ -79,8 +79,10 @@ pub fn estimate_text_tokens_detail(text, model = nil) {
 }
 
 /**
- * Look up the context window for a model. Falls back to 8192 if the catalog
- * has no entry. Returns int.
+ * Look up the effective runtime context window for a model. Configurable local
+ * providers may advertise a larger `context_window` while setting
+ * `runtime_context_window` to the safer default currently being served.
+ * Falls back to 8192 if the catalog has no entry. Returns int.
  */
 pub fn context_window_for(model) {
   let info = try {
@@ -97,7 +99,7 @@ pub fn context_window_for(model) {
   if type_of(catalog) != "dict" {
     return 8192
   }
-  let cw = catalog?.context_window
+  let cw = catalog?.runtime_context_window ?? catalog?.context_window
   if cw == nil {
     return 8192
   }

--- a/crates/harn-vm/src/llm/agent_observe.rs
+++ b/crates/harn-vm/src/llm/agent_observe.rs
@@ -447,7 +447,7 @@ pub(super) fn dump_llm_request(
             super::api::ThinkingConfig::Effort { level } => serde_json::json!({
                 "mode": "effort",
                 "level": level.as_str(),
-                "enabled": true,
+                "enabled": *level != super::api::ReasoningEffort::None,
                 "budget_tokens": serde_json::Value::Null,
             }),
         },

--- a/crates/harn-vm/src/llm/api/ollama.rs
+++ b/crates/harn-vm/src/llm/api/ollama.rs
@@ -220,7 +220,10 @@ fn num_ctx_from_model_catalog(model: Option<&str>) -> Option<u64> {
         return None;
     }
     let entry = crate::llm_config::model_catalog_entry(model)?;
-    (entry.context_window > 0).then_some(entry.context_window)
+    entry
+        .runtime_context_window
+        .filter(|window| *window > 0)
+        .or_else(|| (entry.context_window > 0).then_some(entry.context_window))
 }
 
 fn keep_alive_from_env() -> Option<Value> {
@@ -726,6 +729,7 @@ mod tests {
                 name: "Qwen Test".to_string(),
                 provider: "ollama".to_string(),
                 context_window: 100_000,
+                runtime_context_window: None,
                 stream_timeout: None,
                 capabilities: vec![],
                 pricing: None,
@@ -814,6 +818,7 @@ mod tests {
                 name: "Qwen Test".to_string(),
                 provider: "ollama".to_string(),
                 context_window: 100_000,
+                runtime_context_window: Some(32_768),
                 stream_timeout: None,
                 capabilities: vec![],
                 pricing: None,
@@ -826,7 +831,7 @@ mod tests {
             "options": {"temperature": 0.1}
         });
         apply_ollama_runtime_settings(&mut body, None);
-        assert_eq!(body["options"]["num_ctx"], serde_json::json!(100000));
+        assert_eq!(body["options"]["num_ctx"], serde_json::json!(32768));
         assert_eq!(body["options"]["temperature"], serde_json::json!(0.1));
 
         crate::llm_config::clear_user_overrides();

--- a/crates/harn-vm/src/llm/capabilities.rs
+++ b/crates/harn-vm/src/llm/capabilities.rs
@@ -770,7 +770,7 @@ anthropic_beta_features = ["fine-grained-tool-streaming-2025-05-14"]
         reset();
         for (provider, model) in [
             ("openrouter", "qwen/qwen3.6-plus"),
-            ("together", "Qwen/Qwen3.6-35B-A3B"),
+            ("together", "Qwen/Qwen3.6-Plus"),
             ("huggingface", "Qwen/Qwen3.6-35B-A3B"),
             ("fireworks", "accounts/fireworks/models/qwen3p6-plus"),
             ("dashscope", "qwen3.6-plus"),
@@ -792,6 +792,32 @@ anthropic_beta_features = ["fine-grained-tool-streaming-2025-05-14"]
             assert_ne!(
                 caps.server_parser, "ollama_qwen3coder",
                 "{provider}/{model}: only Ollama routes through the qwen3coder response parser"
+            );
+        }
+    }
+
+    #[test]
+    fn qwen_coder_models_do_not_claim_thinking_modes() {
+        reset();
+        for (provider, model) in [
+            ("together", "Qwen/Qwen3-Coder-Next-FP8"),
+            ("together", "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8"),
+            ("openrouter", "qwen/qwen3-coder-next"),
+            ("huggingface", "Qwen/Qwen3-Coder-Next"),
+        ] {
+            let caps = lookup(provider, model);
+            assert!(caps.native_tools, "{provider}/{model}: native_tools");
+            assert!(
+                caps.thinking_modes.is_empty(),
+                "{provider}/{model}: coder models are non-thinking routes"
+            );
+            assert!(
+                !caps.preserve_thinking,
+                "{provider}/{model}: preserve_thinking must stay off"
+            );
+            assert!(
+                caps.thinking_disable_directive.is_none(),
+                "{provider}/{model}: no /no_think shim should be needed"
             );
         }
     }

--- a/crates/harn-vm/src/llm/capabilities.toml
+++ b/crates/harn-vm/src/llm/capabilities.toml
@@ -681,6 +681,15 @@ text_tool_wire_format_supported = true
 thinking_disable_directive = "/no_think"
 
 [[provider.openrouter]]
+model_match = "qwen/qwen3-coder*"
+native_tools = true
+structured_output = "native"
+server_parser = "none"
+honors_chat_template_kwargs = false
+recommended_endpoint = "/v1/chat/completions"
+text_tool_wire_format_supported = true
+
+[[provider.openrouter]]
 model_match = "qwen/*"
 native_tools = true
 structured_output = "native"
@@ -706,6 +715,15 @@ text_tool_wire_format_supported = true
 thinking_disable_directive = "/no_think"
 
 [[provider.huggingface]]
+model_match = "qwen/qwen3-coder*"
+native_tools = true
+structured_output = "native"
+server_parser = "none"
+honors_chat_template_kwargs = true
+recommended_endpoint = "/v1/chat/completions"
+text_tool_wire_format_supported = true
+
+[[provider.huggingface]]
 model_match = "qwen/*"
 native_tools = true
 structured_output = "native"
@@ -727,6 +745,15 @@ honors_chat_template_kwargs = true
 recommended_endpoint = "/v1/chat/completions"
 text_tool_wire_format_supported = true
 thinking_disable_directive = "/no_think"
+
+[[provider.together]]
+model_match = "qwen/qwen3-coder*"
+native_tools = true
+structured_output = "native"
+server_parser = "none"
+honors_chat_template_kwargs = true
+recommended_endpoint = "/v1/chat/completions"
+text_tool_wire_format_supported = true
 
 [[provider.together]]
 model_match = "qwen/*"

--- a/crates/harn-vm/src/llm/config_builtins.rs
+++ b/crates/harn-vm/src/llm/config_builtins.rs
@@ -754,6 +754,13 @@ fn model_def_to_vm_value(id: &str, model: &llm_config::ModelDef) -> VmValue {
         VmValue::Int(model.context_window as i64),
     );
     dict.insert(
+        "runtime_context_window".to_string(),
+        model
+            .runtime_context_window
+            .map(|window| VmValue::Int(window as i64))
+            .unwrap_or(VmValue::Nil),
+    );
+    dict.insert(
         "stream_timeout".to_string(),
         model
             .stream_timeout

--- a/crates/harn-vm/src/llm/cost.rs
+++ b/crates/harn-vm/src/llm/cost.rs
@@ -646,6 +646,7 @@ mod tests {
                 name: "Test GPT-4o Mini".to_string(),
                 provider: "openai".to_string(),
                 context_window: 128_000,
+                runtime_context_window: None,
                 stream_timeout: None,
                 capabilities: Vec::new(),
                 pricing: Some(crate::llm_config::ModelPricing {

--- a/crates/harn-vm/src/llm/helpers/options.rs
+++ b/crates/harn-vm/src/llm/helpers/options.rs
@@ -958,8 +958,14 @@ pub(crate) fn extract_llm_options(
     } else {
         parse_thinking_option(options.as_ref())?
     };
+    let reasoning_effort_requires_provider_support = matches!(
+        thinking,
+        crate::llm::api::ThinkingConfig::Effort { level }
+            if level != crate::llm::api::ReasoningEffort::None
+    );
     if enforce_capability_gates
         && thinking_from_reasoning_effort
+        && reasoning_effort_requires_provider_support
         && !caps.reasoning_effort_supported
     {
         return Err(unsupported_option_error(
@@ -2420,6 +2426,38 @@ mod routing_tests {
                 crate::llm::api::ThinkingConfig::Effort { level: expected }
             );
         }
+    }
+
+    #[test]
+    fn standalone_reasoning_effort_none_disables_thinking_without_effort_capability() {
+        let options = BTreeMap::from([
+            (
+                "provider".to_string(),
+                VmValue::String(Rc::from("local".to_string())),
+            ),
+            (
+                "model".to_string(),
+                VmValue::String(Rc::from("no-effort-model".to_string())),
+            ),
+            (
+                "reasoning_effort".to_string(),
+                VmValue::String(Rc::from("none".to_string())),
+            ),
+        ]);
+
+        let opts = extract_llm_options(&[
+            VmValue::String(Rc::from("hello".to_string())),
+            VmValue::Nil,
+            VmValue::Dict(Rc::new(options)),
+        ])
+        .expect("reasoning_effort none should be universally accepted");
+
+        assert_eq!(
+            opts.thinking,
+            crate::llm::api::ThinkingConfig::Effort {
+                level: crate::llm::api::ReasoningEffort::None
+            }
+        );
     }
 
     #[test]

--- a/crates/harn-vm/src/llm_config.rs
+++ b/crates/harn-vm/src/llm_config.rs
@@ -212,6 +212,8 @@ pub struct ModelDef {
     pub provider: String,
     pub context_window: u64,
     #[serde(default)]
+    pub runtime_context_window: Option<u64>,
+    #[serde(default)]
     pub stream_timeout: Option<f64>,
     #[serde(default)]
     pub capabilities: Vec<String>,
@@ -1594,6 +1596,7 @@ fn default_config() -> ProvidersConfig {
                 name: "Claude Sonnet 4".to_string(),
                 provider: "anthropic".to_string(),
                 context_window: 200_000,
+                runtime_context_window: None,
                 stream_timeout: None,
                 capabilities: vec![
                     "tools".to_string(),
@@ -1615,6 +1618,7 @@ fn default_config() -> ProvidersConfig {
                 name: "GPT-4o Mini".to_string(),
                 provider: "openai".to_string(),
                 context_window: 128_000,
+                runtime_context_window: None,
                 stream_timeout: None,
                 capabilities: vec!["tools".to_string(), "streaming".to_string()],
                 pricing: Some(ModelPricing {
@@ -1631,6 +1635,7 @@ fn default_config() -> ProvidersConfig {
                 name: "Qwen3.5 9B".to_string(),
                 provider: "openrouter".to_string(),
                 context_window: 131_072,
+                runtime_context_window: None,
                 stream_timeout: None,
                 capabilities: vec!["tools".to_string(), "streaming".to_string()],
                 pricing: None,
@@ -1642,6 +1647,7 @@ fn default_config() -> ProvidersConfig {
                 name: "Llama 3.2".to_string(),
                 provider: "ollama".to_string(),
                 context_window: 32_000,
+                runtime_context_window: None,
                 stream_timeout: Some(300.0),
                 capabilities: vec!["tools".to_string(), "streaming".to_string()],
                 pricing: None,
@@ -2008,6 +2014,7 @@ mod tests {
                 name: "Acme Fast".to_string(),
                 provider: "acme".to_string(),
                 context_window: 65_536,
+                runtime_context_window: None,
                 stream_timeout: Some(42.0),
                 capabilities: vec!["tools".to_string(), "streaming".to_string()],
                 pricing: Some(ModelPricing {

--- a/crates/harn-vm/src/orchestration/compaction.rs
+++ b/crates/harn-vm/src/orchestration/compaction.rs
@@ -581,6 +581,9 @@ pub(crate) async fn auto_compact_messages(
     config: &AutoCompactConfig,
     llm_opts: Option<&crate::llm::api::LlmCallOptions>,
 ) -> Result<Option<String>, VmError> {
+    if config.token_threshold > 0 && estimate_message_tokens(messages) <= config.token_threshold {
+        return Ok(None);
+    }
     if messages.len() <= config.keep_first.saturating_add(config.keep_last) {
         return Ok(None);
     }
@@ -752,6 +755,7 @@ mod tests {
             serde_json::json!({"role": "tool", "tool_call_id": "call_1", "content": "file"}),
         ];
         let config = AutoCompactConfig {
+            token_threshold: 1,
             keep_last: 2,
             ..Default::default()
         };

--- a/crates/harn-vm/src/orchestration/tests.rs
+++ b/crates/harn-vm/src/orchestration/tests.rs
@@ -1420,6 +1420,7 @@ fn auto_compact_messages_reduces_count() {
         &mut messages,
         &AutoCompactConfig {
             compact_strategy: CompactStrategy::Truncate,
+            token_threshold: 1,
             keep_last: 6,
             ..Default::default()
         },
@@ -1457,6 +1458,29 @@ fn auto_compact_noop_when_under_threshold() {
 }
 
 #[test]
+fn auto_compact_noop_when_message_tokens_under_threshold() {
+    let mut messages: Vec<serde_json::Value> = (0..20)
+        .map(|i| serde_json::json!({"role": "user", "content": format!("short message {i}")}))
+        .collect();
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let compacted = runtime.block_on(auto_compact_messages(
+        &mut messages,
+        &AutoCompactConfig {
+            compact_strategy: CompactStrategy::Truncate,
+            token_threshold: 48_000,
+            keep_last: 6,
+            ..Default::default()
+        },
+        None,
+    ));
+    assert!(compacted.unwrap().is_none());
+    assert_eq!(messages.len(), 20);
+}
+
+#[test]
 fn observation_mask_preserves_errors_masks_verbose_output() {
     let verbose_lines: Vec<String> = (0..60)
         .map(|i| format!("// source line {} of the generated file", i))
@@ -1483,6 +1507,7 @@ fn observation_mask_preserves_errors_masks_verbose_output() {
         &mut messages,
         &AutoCompactConfig {
             compact_strategy: CompactStrategy::ObservationMask,
+            token_threshold: 1,
             keep_last: 2,
             ..Default::default()
         },

--- a/crates/harn-vm/src/stdlib/agents_workers/policy.rs
+++ b/crates/harn-vm/src/stdlib/agents_workers/policy.rs
@@ -219,6 +219,7 @@ pub(in super::super) async fn compact_worker_transcript(
         .map(crate::llm::helpers::vm_value_to_json)
         .collect::<Vec<_>>();
     let config = crate::orchestration::AutoCompactConfig {
+        token_threshold: 1,
         keep_last: 2,
         compact_strategy: crate::orchestration::CompactStrategy::Truncate,
         hard_limit_tokens: None,

--- a/crates/harn-vm/src/stdlib/host.rs
+++ b/crates/harn-vm/src/stdlib/host.rs
@@ -525,6 +525,16 @@ pub(crate) async fn dispatch_host_operation(
         return mocked;
     }
 
+    if (capability, operation) == ("process", "exec") {
+        let caller = serde_json::json!({
+            "surface": "host_call",
+            "capability": "process",
+            "operation": "exec",
+            "session_id": crate::llm::current_agent_session_id(),
+        });
+        return dispatch_process_exec_with_policy(params, caller).await;
+    }
+
     let bridge = HOST_CALL_BRIDGE.with(|b| b.borrow().clone());
     if let Some(bridge) = bridge {
         if let Some(value) = bridge.dispatch(capability, operation, params)? {
@@ -532,16 +542,15 @@ pub(crate) async fn dispatch_host_operation(
         }
     }
 
+    dispatch_builtin_host_operation(capability, operation, params).await
+}
+
+async fn dispatch_builtin_host_operation(
+    capability: &str,
+    operation: &str,
+    params: &BTreeMap<String, VmValue>,
+) -> Result<VmValue, VmError> {
     match (capability, operation) {
-        ("process", "exec") => {
-            let caller = serde_json::json!({
-                "surface": "host_call",
-                "capability": "process",
-                "operation": "exec",
-                "session_id": crate::llm::current_agent_session_id(),
-            });
-            dispatch_process_exec(params, caller).await
-        }
         ("process", "list_shells") => Ok(crate::shells::list_shells_vm_value()),
         ("process", "get_default_shell") => Ok(crate::shells::default_shell_vm_value()),
         ("process", "set_default_shell") => crate::shells::set_default_shell_vm_value(params),
@@ -602,6 +611,13 @@ pub(crate) async fn dispatch_process_exec(
     params: &BTreeMap<String, VmValue>,
     caller: serde_json::Value,
 ) -> Result<VmValue, VmError> {
+    dispatch_process_exec_with_policy(params, caller).await
+}
+
+async fn dispatch_process_exec_with_policy(
+    params: &BTreeMap<String, VmValue>,
+    caller: serde_json::Value,
+) -> Result<VmValue, VmError> {
     let (params, command_policy_context, command_policy_decisions) =
         match crate::orchestration::run_command_policy_preflight(params, caller).await? {
             crate::orchestration::CommandPolicyPreflight::Proceed {
@@ -620,20 +636,43 @@ pub(crate) async fn dispatch_process_exec(
                 ));
             }
         };
-    let (program, args) = process_exec_argv(&params)?;
-    let timeout_ms = optional_i64(&params, "timeout")
-        .or_else(|| optional_i64(&params, "timeout_ms"))
+
+    let bridge = HOST_CALL_BRIDGE.with(|b| b.borrow().clone());
+    if let Some(bridge) = bridge {
+        if let Some(value) = bridge.dispatch("process", "exec", &params)? {
+            return crate::orchestration::run_command_policy_postflight(
+                &params,
+                value,
+                command_policy_context,
+                command_policy_decisions,
+            )
+            .await;
+        }
+    }
+
+    dispatch_process_exec_after_policy(&params, command_policy_context, command_policy_decisions)
+        .await
+}
+
+async fn dispatch_process_exec_after_policy(
+    params: &BTreeMap<String, VmValue>,
+    command_policy_context: JsonValue,
+    command_policy_decisions: Vec<crate::orchestration::CommandPolicyDecision>,
+) -> Result<VmValue, VmError> {
+    let (program, args) = process_exec_argv(params)?;
+    let timeout_ms = optional_i64(params, "timeout")
+        .or_else(|| optional_i64(params, "timeout_ms"))
         .filter(|value| *value > 0)
         .map(|value| value as u64);
     let mut cmd = crate::process_sandbox::tokio_command_for(&program, &args)
         .map_err(|e| VmError::Runtime(format!("host_call process.exec sandbox setup: {e}")))?;
-    if let Some(cwd) = optional_string(&params, "cwd") {
+    if let Some(cwd) = optional_string(params, "cwd") {
         crate::process_sandbox::enforce_process_cwd(std::path::Path::new(&cwd))
             .map_err(|e| VmError::Runtime(format!("host_call process.exec cwd: {e}")))?;
         cmd.current_dir(cwd);
     }
-    if let Some(env) = optional_string_dict(&params, "env")? {
-        let env_mode = optional_string(&params, "env_mode");
+    if let Some(env) = optional_string_dict(params, "env")? {
+        let env_mode = optional_string(params, "env_mode");
         if env_mode.as_deref().unwrap_or("replace") == "replace" {
             cmd.env_clear();
         }
@@ -646,7 +685,7 @@ pub(crate) async fn dispatch_process_exec(
     // selectively unset (e.g. the git stdlib strips `GIT_*` so its
     // operations are self-contained even when Harn is invoked from
     // inside a git hook that sets `GIT_DIR`).
-    if let Some(env_remove) = optional_string_list(&params, "env_remove") {
+    if let Some(env_remove) = optional_string_list(params, "env_remove") {
         for key in env_remove {
             cmd.env_remove(key);
         }
@@ -686,7 +725,7 @@ pub(crate) async fn dispatch_process_exec(
                     timed_out: true,
                 });
                 return crate::orchestration::run_command_policy_postflight(
-                    &params,
+                    params,
                     response,
                     command_policy_context,
                     command_policy_decisions,
@@ -715,7 +754,7 @@ pub(crate) async fn dispatch_process_exec(
         timed_out,
     });
     crate::orchestration::run_command_policy_postflight(
-        &params,
+        params,
         response,
         command_policy_context,
         command_policy_decisions,
@@ -1000,10 +1039,11 @@ async fn host_tool_call_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> 
 #[cfg(test)]
 mod tests {
     use super::{
-        capability_manifest_with_mocks, clear_host_call_bridge, dispatch_host_tool_call,
-        dispatch_host_tool_list, dispatch_mock_host_call, push_host_mock, reset_host_state,
-        set_host_call_bridge, HostCallBridge, HostMock,
+        capability_manifest_with_mocks, clear_host_call_bridge, dispatch_host_operation,
+        dispatch_host_tool_call, dispatch_host_tool_list, dispatch_mock_host_call, push_host_mock,
+        reset_host_state, set_host_call_bridge, HostCallBridge, HostMock,
     };
+    use std::cell::Cell;
     use std::collections::BTreeMap;
     use std::rc::Rc;
 
@@ -1156,6 +1196,32 @@ mod tests {
         }
     }
 
+    struct CountingProcessExecBridge {
+        calls: Rc<Cell<usize>>,
+    }
+
+    impl HostCallBridge for CountingProcessExecBridge {
+        fn dispatch(
+            &self,
+            capability: &str,
+            operation: &str,
+            _params: &BTreeMap<String, VmValue>,
+        ) -> Result<Option<VmValue>, VmError> {
+            if (capability, operation) != ("process", "exec") {
+                return Ok(None);
+            }
+            self.calls.set(self.calls.get() + 1);
+            Ok(Some(VmValue::Dict(Rc::new(BTreeMap::from([
+                (
+                    "status".to_string(),
+                    VmValue::String(Rc::from("completed".to_string())),
+                ),
+                ("exit_code".to_string(), VmValue::Int(0)),
+                ("success".to_string(), VmValue::Bool(true)),
+            ])))))
+        }
+    }
+
     fn run_host_async_test<F, Fut>(test: F)
     where
         F: FnOnce() -> Fut,
@@ -1202,6 +1268,56 @@ mod tests {
                 .expect("tool call");
             clear_host_call_bridge();
             assert_eq!(value.display(), "read:README.md");
+        });
+    }
+
+    #[test]
+    fn process_exec_bridge_is_gated_by_command_policy() {
+        run_host_async_test(|| async {
+            crate::orchestration::clear_command_policies();
+            let calls = Rc::new(Cell::new(0));
+            set_host_call_bridge(Rc::new(CountingProcessExecBridge {
+                calls: calls.clone(),
+            }));
+            crate::orchestration::push_command_policy(crate::orchestration::CommandPolicy {
+                tools: vec!["run".to_string()],
+                workspace_roots: Vec::new(),
+                default_shell_mode: "shell".to_string(),
+                deny_patterns: vec!["cat *".to_string()],
+                require_approval: Default::default(),
+                pre: None,
+                post: None,
+                allow_recursive: false,
+            });
+
+            let result = dispatch_host_operation(
+                "process",
+                "exec",
+                &BTreeMap::from([
+                    ("mode".to_string(), VmValue::String(Rc::from("shell"))),
+                    (
+                        "command".to_string(),
+                        VmValue::String(Rc::from("cat Cargo.toml")),
+                    ),
+                ]),
+            )
+            .await
+            .expect("process.exec result");
+
+            crate::orchestration::clear_command_policies();
+            clear_host_call_bridge();
+
+            assert_eq!(calls.get(), 0, "blocked command must not reach host bridge");
+            let result = result.as_dict().expect("blocked result dict");
+            assert_eq!(result.get("status").unwrap().display(), "blocked");
+            assert!(
+                result
+                    .get("reason")
+                    .map(VmValue::display)
+                    .unwrap_or_default()
+                    .contains("cat *"),
+                "blocked result should name the matched policy pattern"
+            );
         });
     }
 

--- a/crates/harn-vm/src/stdlib/workflow/register.rs
+++ b/crates/harn-vm/src/stdlib/workflow/register.rs
@@ -2188,9 +2188,17 @@ async fn transcript_auto_compact_builtin(args: Vec<VmValue>) -> Result<VmValue, 
     let mut config = crate::orchestration::AutoCompactConfig::default();
     if let Some(v) = options
         .as_ref()
-        .and_then(|o| o.get("compact_threshold"))
+        .and_then(|o| o.get("keep_first"))
         .and_then(|v| v.as_int())
     {
+        config.keep_first = v.max(0) as usize;
+    }
+    let threshold = options.as_ref().and_then(|o| {
+        o.get("token_threshold")
+            .or_else(|| o.get("compact_threshold"))
+            .and_then(|v| v.as_int())
+    });
+    if let Some(v) = threshold {
         config.token_threshold = v.max(0) as usize;
     }
     if let Some(v) = options
@@ -2207,12 +2215,35 @@ async fn transcript_auto_compact_builtin(args: Vec<VmValue>) -> Result<VmValue, 
     {
         config.keep_last = v.max(0) as usize;
     }
+    if let Some(v) = options
+        .as_ref()
+        .and_then(|o| o.get("hard_limit_tokens"))
+        .and_then(|v| v.as_int())
+    {
+        config.hard_limit_tokens = Some(v.max(0) as usize);
+    }
     if let Some(strategy) = options
         .as_ref()
         .and_then(|o| o.get("compact_strategy"))
         .map(|v| v.display())
     {
         config.compact_strategy = crate::orchestration::parse_compact_strategy(&strategy)?;
+    }
+    if let Some(strategy) = options
+        .as_ref()
+        .and_then(|o| o.get("hard_limit_strategy"))
+        .map(|v| v.display())
+    {
+        config.hard_limit_strategy = crate::orchestration::parse_compact_strategy(&strategy)?;
+    }
+    if let Some(prompt) = options
+        .as_ref()
+        .and_then(|o| o.get("summarize_prompt"))
+        .map(|v| v.display())
+    {
+        if !prompt.is_empty() {
+            config.summarize_prompt = Some(prompt);
+        }
     }
     if let Some(callback) = options.as_ref().and_then(|o| o.get("compact_callback")) {
         config.custom_compactor = Some(callback.clone());

--- a/docs/src/provider-matrix.md
+++ b/docs/src/provider-matrix.md
@@ -41,6 +41,7 @@ Regenerate with `make gen-provider-matrix` and verify with `make check-provider-
 | `gemini` | `gemini-*` | no | yes | yes | yes | yes | yes | no | no | no |
 | `gemini` | `models/gemini-*` | no | yes | yes | yes | yes | yes | no | no | no |
 | `huggingface` | `qwen/qwen3.6*` | `enabled` | no | no | no | yes | no | `native` | yes | no |
+| `huggingface` | `qwen/qwen3-coder*` | no | no | no | no | yes | no | `native` | yes | no |
 | `huggingface` | `qwen/*` | `enabled` | no | no | no | yes | no | `native` | yes | no |
 | `huggingface` | `deepseek-ai/deepseek-v3*` | `enabled` | no | no | no | yes | no | `native` | yes | yes |
 | `llamacpp` | `*qwen3.6*` | `enabled` | no | no | no | yes | no | `native` | yes | no |
@@ -74,11 +75,13 @@ Regenerate with `make gen-provider-matrix` and verify with `make check-provider-
 | `openai` | `openai/o3*` | `effort` | no | no | no | yes | no | `native` | yes | no |
 | `openai` | `openai/o4*` | `effort` | yes | no | no | yes | no | `native` | yes | no |
 | `openrouter` | `qwen/qwen3.6*` | `enabled,effort` | no | no | no | yes | no | `native` | yes | no |
+| `openrouter` | `qwen/qwen3-coder*` | no | no | no | no | yes | no | `native` | yes | no |
 | `openrouter` | `qwen/*` | `enabled,effort` | no | no | no | yes | no | `native` | yes | no |
 | `openrouter` | `deepseek/deepseek-v3*` | `enabled,effort` | no | no | no | yes | no | `native` | yes | yes |
 | `openrouter` | `google/gemini-2.5*` | `enabled,effort` | yes | yes | yes | yes | no | `native` | yes | yes |
 | `openrouter` | `google/gemma-4*` | no | no | no | no | yes | no | `native` | yes | no |
 | `together` | `qwen/qwen3.6*` | `enabled` | no | no | no | yes | no | `native` | yes | no |
+| `together` | `qwen/qwen3-coder*` | no | no | no | no | yes | no | `native` | yes | no |
 | `together` | `qwen/*` | `enabled` | no | no | no | yes | no | `native` | yes | no |
 | `together` | `deepseek-ai/deepseek-v3*` | `enabled` | no | no | no | yes | no | `native` | yes | yes |
 | `together` | `openai/gpt-oss-*` | `effort` | no | no | no | yes | no | `native` | no | no |


### PR DESCRIPTION
## Summary

Adds Harn runtime support for provider-neutral agent reasoning profiles and dynamic local runtime context windows.

- Adds `runtime_context_window` to model catalog APIs and uses it for Ollama/local context budgeting.
- Lets explicit `reasoning_effort: \"none\"` disable thinking even on providers without effort support, and fixes transcript metadata for disabled effort mode.
- Adds manual skill matching for host-managed skill activation, fail-open completion judge handling for provider errors, and command-policy gating before host-bridged `process.exec`.
- Tightens stdlib agent option plumbing with shared key picking instead of repetitive option unpacking.
- Extends transcript compaction controls with thresholds and hard-limit options.

## Validation

- `cargo fmt --check`
- `cargo check -p harn-vm -p harn-cli`
- `cargo test -p harn-vm standalone_reasoning_effort --lib`
- `cargo test -p harn-vm auto_compact --lib`
- `cargo test -p harn-vm llm::api::ollama --lib`
- `cargo test -p harn-vm llm::capabilities --lib`
- `cargo test -p harn-vm stdlib::host::tests::process_exec_bridge_is_gated_by_command_policy --lib`
- `harn test conformance --filter agent_basic`
- `harn test conformance --filter skill_lifecycle_manual`
- `harn test conformance --filter skill_lifecycle_catalog_default`
- `harn test conformance --filter agent_loop_done_judge`
- pre-commit hook: clippy/ratchets/highlight sync
- pre-push hook: targeted checks, Harn fmt/lint, highlight drift

## Downstream

Burin Code changes are staged in a separate branch and should land after this Harn change is released and `.harn-version` is bumped.