### PR TITLE
[codex] Export normalized workflow bundle graphs

### DIFF
--- a/crates/harn-cli/src/cli/workflow.rs
+++ b/crates/harn-cli/src/cli/workflow.rs
@@ -31,6 +31,9 @@ pub(crate) struct WorkflowPreviewArgs {
     /// Portable workflow bundle JSON path.
     #[arg(long)]
     pub bundle: String,
+    /// Emit Mermaid graph text for quick debugging.
+    #[arg(long)]
+    pub mermaid: bool,
     /// Emit JSON.
     #[arg(long)]
     pub json: bool,

--- a/crates/harn-cli/src/commands/workflow.rs
+++ b/crates/harn-cli/src/commands/workflow.rs
@@ -33,6 +33,8 @@ pub(crate) fn handle(args: WorkflowArgs) -> Result<i32, String> {
             let preview = harn_vm::orchestration::preview_workflow_bundle(&bundle);
             if args.json {
                 print_json(&preview)?;
+            } else if args.mermaid {
+                println!("{}", preview.mermaid);
             } else {
                 println!(
                     "workflow bundle {} graph {}",

--- a/crates/harn-vm/src/orchestration/workflow_bundle.rs
+++ b/crates/harn-vm/src/orchestration/workflow_bundle.rs
@@ -176,6 +176,8 @@ pub struct WorkflowBundlePreview {
     pub workflow_version: usize,
     pub graph_digest: String,
     pub validation: WorkflowBundleValidationReport,
+    pub graph: WorkflowBundleGraphExport,
+    pub mermaid: String,
     pub triggers: Vec<WorkflowBundleTrigger>,
     pub connectors: Vec<ConnectorRequirement>,
     pub environment: EnvironmentRequirements,
@@ -191,6 +193,57 @@ pub struct WorkflowBundlePreviewNode {
     pub prompt_capsule: Option<String>,
     pub trigger_ids: Vec<String>,
     pub outgoing: Vec<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct WorkflowBundleGraphExport {
+    pub schema_version: u32,
+    pub graph_id: String,
+    pub graph_digest: String,
+    pub nodes: Vec<WorkflowBundleGraphNode>,
+    pub edges: Vec<WorkflowBundleGraphEdge>,
+    pub diagnostics: Vec<WorkflowBundleGraphDiagnostic>,
+    pub editable_fields: Vec<WorkflowBundleEditableField>,
+    pub mermaid: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct WorkflowBundleGraphNode {
+    pub id: String,
+    pub node_type: String,
+    pub label: String,
+    pub workflow_node_id: Option<String>,
+    pub trigger_id: Option<String>,
+    pub connector_id: Option<String>,
+    pub editable_fields: Vec<WorkflowBundleEditableField>,
+    pub metadata: BTreeMap<String, serde_json::Value>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkflowBundleGraphEdge {
+    pub from: String,
+    pub to: String,
+    pub label: Option<String>,
+    pub branch: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkflowBundleGraphDiagnostic {
+    pub severity: String,
+    pub path: String,
+    pub message: String,
+    pub node_id: Option<String>,
+    pub graph_node_id: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkflowBundleEditableField {
+    pub id: String,
+    pub label: String,
+    pub json_pointer: String,
+    pub value_type: String,
+    pub required: bool,
+    pub enum_values: Vec<String>,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -293,10 +346,12 @@ pub fn validate_workflow_bundle(bundle: &WorkflowBundle) -> WorkflowBundleValida
 
     let graph_report = validate_workflow(&canonical, None);
     for error in graph_report.errors {
-        push_error(&mut report, "workflow", error, None);
+        let node_id = workflow_diagnostic_node_id(&error, &canonical);
+        push_error(&mut report, "workflow", error, node_id);
     }
     for warning in graph_report.warnings {
-        push_warning(&mut report, "workflow", warning, None);
+        let node_id = workflow_diagnostic_node_id(&warning, &canonical);
+        push_warning(&mut report, "workflow", warning, node_id);
     }
 
     if let Some(expected) = bundle.receipts.graph_digest.as_deref() {
@@ -331,6 +386,8 @@ pub fn validate_workflow_bundle(bundle: &WorkflowBundle) -> WorkflowBundleValida
 pub fn preview_workflow_bundle(bundle: &WorkflowBundle) -> WorkflowBundlePreview {
     let canonical = canonical_workflow_graph(&bundle.workflow);
     let validation = validate_workflow_bundle(bundle);
+    let graph = export_workflow_bundle_graph(bundle, &validation);
+    let mermaid = graph.mermaid.clone();
     let triggers_by_node = triggers_by_node(bundle);
     let capsules_by_node = capsules_by_node(bundle);
     let mut nodes = Vec::new();
@@ -362,11 +419,267 @@ pub fn preview_workflow_bundle(bundle: &WorkflowBundle) -> WorkflowBundlePreview
         workflow_version: canonical.version,
         graph_digest: validation.graph_digest.clone(),
         validation,
+        graph,
+        mermaid,
         triggers: bundle.triggers.clone(),
         connectors: bundle.connectors.clone(),
         environment: bundle.environment.clone(),
         nodes,
         edges: sorted_edges(&canonical),
+    }
+}
+
+pub fn export_workflow_bundle_graph(
+    bundle: &WorkflowBundle,
+    validation: &WorkflowBundleValidationReport,
+) -> WorkflowBundleGraphExport {
+    let canonical = canonical_workflow_graph(&bundle.workflow);
+    let mut nodes = Vec::new();
+    let mut edges = Vec::new();
+    let mut editable_fields = Vec::new();
+    let capsules_by_node = capsules_by_node(bundle);
+    let catchup_enabled = bundle.policy.catchup.mode != "none";
+    let retry_can_dlq = bundle.policy.retry.max_attempts > 1;
+
+    for (index, connector) in bundle.connectors.iter().enumerate() {
+        let node_fields = connector_editable_fields(index, connector);
+        editable_fields.extend(node_fields.clone());
+        nodes.push(WorkflowBundleGraphNode {
+            id: connector_graph_id(&connector.id),
+            node_type: "connector_call".to_string(),
+            label: connector_label(connector),
+            workflow_node_id: None,
+            trigger_id: None,
+            connector_id: Some(connector.id.clone()),
+            editable_fields: node_fields,
+            metadata: BTreeMap::from([
+                (
+                    "provider_id".to_string(),
+                    serde_json::json!(connector.provider_id),
+                ),
+                ("scopes".to_string(), serde_json::json!(connector.scopes)),
+            ]),
+        });
+    }
+
+    let catchup_fields = catchup_editable_fields();
+    let retry_fields = retry_editable_fields();
+    if catchup_enabled {
+        let node_fields = catchup_fields.clone();
+        editable_fields.extend(node_fields.clone());
+        nodes.push(WorkflowBundleGraphNode {
+            id: catchup_graph_id(),
+            node_type: "catchup".to_string(),
+            label: "Catch up".to_string(),
+            workflow_node_id: None,
+            trigger_id: None,
+            connector_id: None,
+            editable_fields: node_fields,
+            metadata: BTreeMap::from([(
+                "mode".to_string(),
+                serde_json::json!(bundle.policy.catchup.mode),
+            )]),
+        });
+    } else {
+        editable_fields.extend(catchup_fields);
+    }
+    if retry_can_dlq {
+        let node_fields = retry_fields.clone();
+        editable_fields.extend(node_fields.clone());
+        nodes.push(WorkflowBundleGraphNode {
+            id: dlq_graph_id(),
+            node_type: "dlq".to_string(),
+            label: "Dead letter queue".to_string(),
+            workflow_node_id: None,
+            trigger_id: None,
+            connector_id: None,
+            editable_fields: node_fields,
+            metadata: BTreeMap::from([(
+                "max_attempts".to_string(),
+                serde_json::json!(bundle.policy.retry.max_attempts),
+            )]),
+        });
+    } else {
+        editable_fields.extend(retry_fields);
+    }
+
+    for (index, trigger) in bundle.triggers.iter().enumerate() {
+        let node_fields = trigger_editable_fields(index, trigger);
+        editable_fields.extend(node_fields.clone());
+        nodes.push(WorkflowBundleGraphNode {
+            id: trigger_graph_id(&trigger.id),
+            node_type: "trigger".to_string(),
+            label: trigger_label(trigger),
+            workflow_node_id: trigger.node_id.clone(),
+            trigger_id: Some(trigger.id.clone()),
+            connector_id: None,
+            editable_fields: node_fields,
+            metadata: BTreeMap::from([
+                ("kind".to_string(), serde_json::json!(trigger.kind)),
+                ("provider".to_string(), serde_json::json!(trigger.provider)),
+                ("events".to_string(), serde_json::json!(trigger.events)),
+            ]),
+        });
+        if let Some(provider) = trigger.provider.as_deref() {
+            if let Some(connector) = bundle
+                .connectors
+                .iter()
+                .find(|connector| connector.provider_id == provider || connector.id == provider)
+            {
+                edges.push(WorkflowBundleGraphEdge {
+                    from: connector_graph_id(&connector.id),
+                    to: trigger_graph_id(&trigger.id),
+                    label: Some("binds".to_string()),
+                    branch: None,
+                });
+            }
+        }
+        let target = trigger
+            .node_id
+            .clone()
+            .unwrap_or_else(|| canonical.entry.clone());
+        if catchup_enabled {
+            edges.push(WorkflowBundleGraphEdge {
+                from: trigger_graph_id(&trigger.id),
+                to: catchup_graph_id(),
+                label: Some(bundle.policy.catchup.mode.clone()),
+                branch: Some("catchup".to_string()),
+            });
+            edges.push(WorkflowBundleGraphEdge {
+                from: catchup_graph_id(),
+                to: workflow_graph_id(&target),
+                label: Some("dispatch".to_string()),
+                branch: None,
+            });
+        } else {
+            edges.push(WorkflowBundleGraphEdge {
+                from: trigger_graph_id(&trigger.id),
+                to: workflow_graph_id(&target),
+                label: Some("dispatch".to_string()),
+                branch: None,
+            });
+        }
+    }
+
+    for (node_id, node) in &canonical.nodes {
+        let capsule_id = capsules_by_node.get(node_id);
+        let node_fields = workflow_node_editable_fields(node_id, capsule_id);
+        editable_fields.extend(node_fields.clone());
+        nodes.push(WorkflowBundleGraphNode {
+            id: workflow_graph_id(node_id),
+            node_type: workflow_node_type(&node.kind),
+            label: workflow_node_label(node_id, node),
+            workflow_node_id: Some(node_id.clone()),
+            trigger_id: None,
+            connector_id: None,
+            editable_fields: node_fields,
+            metadata: BTreeMap::from([
+                ("kind".to_string(), serde_json::json!(node.kind)),
+                ("task_label".to_string(), serde_json::json!(node.task_label)),
+                (
+                    "prompt_capsule".to_string(),
+                    serde_json::json!(capsule_id.cloned()),
+                ),
+            ]),
+        });
+    }
+
+    for edge in sorted_edges(&canonical) {
+        edges.push(WorkflowBundleGraphEdge {
+            from: workflow_graph_id(&edge.from),
+            to: workflow_graph_id(&edge.to),
+            label: edge.label.clone(),
+            branch: edge.branch.clone(),
+        });
+    }
+
+    let outgoing: BTreeSet<&str> = canonical
+        .edges
+        .iter()
+        .map(|edge| edge.from.as_str())
+        .collect();
+    for node_id in canonical.nodes.keys() {
+        if !outgoing.contains(node_id.as_str()) {
+            edges.push(WorkflowBundleGraphEdge {
+                from: workflow_graph_id(node_id),
+                to: terminal_completed_graph_id(),
+                label: Some("completed".to_string()),
+                branch: Some("completed".to_string()),
+            });
+        }
+        if retry_can_dlq {
+            edges.push(WorkflowBundleGraphEdge {
+                from: workflow_graph_id(node_id),
+                to: dlq_graph_id(),
+                label: Some("retry exhausted".to_string()),
+                branch: Some("failed".to_string()),
+            });
+        }
+    }
+
+    nodes.push(WorkflowBundleGraphNode {
+        id: terminal_completed_graph_id(),
+        node_type: "terminal".to_string(),
+        label: "Completed".to_string(),
+        workflow_node_id: None,
+        trigger_id: None,
+        connector_id: None,
+        editable_fields: Vec::new(),
+        metadata: BTreeMap::from([("status".to_string(), serde_json::json!("completed"))]),
+    });
+    nodes.push(WorkflowBundleGraphNode {
+        id: terminal_failed_graph_id(),
+        node_type: "terminal".to_string(),
+        label: "Failed".to_string(),
+        workflow_node_id: None,
+        trigger_id: None,
+        connector_id: None,
+        editable_fields: Vec::new(),
+        metadata: BTreeMap::from([("status".to_string(), serde_json::json!("failed"))]),
+    });
+    if retry_can_dlq {
+        edges.push(WorkflowBundleGraphEdge {
+            from: dlq_graph_id(),
+            to: terminal_failed_graph_id(),
+            label: Some("failed".to_string()),
+            branch: Some("failed".to_string()),
+        });
+    }
+
+    nodes.sort_by(|left, right| left.id.cmp(&right.id));
+    edges.sort_by(|left, right| {
+        (&left.from, &left.to, &left.branch, &left.label).cmp(&(
+            &right.from,
+            &right.to,
+            &right.branch,
+            &right.label,
+        ))
+    });
+    editable_fields.sort_by(|left, right| left.id.cmp(&right.id));
+
+    let diagnostics = validation
+        .errors
+        .iter()
+        .chain(validation.warnings.iter())
+        .map(|diagnostic| WorkflowBundleGraphDiagnostic {
+            severity: diagnostic.severity.clone(),
+            path: diagnostic.path.clone(),
+            message: diagnostic.message.clone(),
+            node_id: diagnostic.node_id.clone(),
+            graph_node_id: diagnostic.node_id.as_deref().map(workflow_graph_id),
+        })
+        .collect::<Vec<_>>();
+    let mermaid = render_workflow_bundle_mermaid(&nodes, &edges);
+
+    WorkflowBundleGraphExport {
+        schema_version: WORKFLOW_BUNDLE_SCHEMA_VERSION,
+        graph_id: canonical.id,
+        graph_digest: validation.graph_digest.clone(),
+        nodes,
+        edges,
+        diagnostics,
+        editable_fields,
+        mermaid,
     }
 }
 
@@ -807,6 +1120,420 @@ fn validate_environment(bundle: &WorkflowBundle, report: &mut WorkflowBundleVali
             None,
         );
     }
+}
+
+fn workflow_diagnostic_node_id(message: &str, graph: &WorkflowGraph) -> Option<String> {
+    for prefix in [
+        "node is unreachable: ",
+        "edge.from references unknown node: ",
+        "edge.to references unknown node: ",
+        "entry node does not exist: ",
+    ] {
+        if let Some(node_id) = message.strip_prefix(prefix) {
+            return Some(node_id.to_string());
+        }
+    }
+    if let Some(rest) = message.strip_prefix("node ") {
+        if let Some((node_id, _)) = rest.split_once(':') {
+            return Some(node_id.to_string());
+        }
+    }
+    graph
+        .nodes
+        .keys()
+        .find(|node_id| message.contains(&format!("node {node_id}:")))
+        .cloned()
+}
+
+fn workflow_graph_id(node_id: &str) -> String {
+    format!("node/{node_id}")
+}
+
+fn trigger_graph_id(trigger_id: &str) -> String {
+    format!("trigger/{trigger_id}")
+}
+
+fn connector_graph_id(connector_id: &str) -> String {
+    format!("connector/{connector_id}")
+}
+
+fn catchup_graph_id() -> String {
+    "policy/catchup".to_string()
+}
+
+fn dlq_graph_id() -> String {
+    "policy/dlq".to_string()
+}
+
+fn terminal_completed_graph_id() -> String {
+    "terminal/completed".to_string()
+}
+
+fn terminal_failed_graph_id() -> String {
+    "terminal/failed".to_string()
+}
+
+fn workflow_node_type(kind: &str) -> String {
+    match kind {
+        "action" => "action",
+        "stage" | "agent" => "agent",
+        "subagent" | "worker" => "subagent",
+        "wait" | "waitpoint" | "delay" => "wait",
+        "approval" | "hitl" => "approval",
+        "connector" | "connector_call" => "connector_call",
+        "notification" | "notify" => "notification",
+        "terminal" | "success" | "failure" => "terminal",
+        other if other.trim().is_empty() => "agent",
+        other => other,
+    }
+    .to_string()
+}
+
+fn workflow_node_label(node_id: &str, node: &super::WorkflowNode) -> String {
+    node.task_label
+        .clone()
+        .or_else(|| node.prompt.clone())
+        .map(|label| label.trim().to_string())
+        .filter(|label| !label.is_empty())
+        .unwrap_or_else(|| node_id.to_string())
+}
+
+fn trigger_label(trigger: &WorkflowBundleTrigger) -> String {
+    if !trigger.events.is_empty() {
+        format!("{}: {}", trigger.kind, trigger.events.join(", "))
+    } else if let Some(schedule) = trigger.schedule.as_deref() {
+        format!("cron: {schedule}")
+    } else if let Some(delay) = trigger.delay.as_deref() {
+        format!("delay: {delay}")
+    } else {
+        trigger.id.clone()
+    }
+}
+
+fn connector_label(connector: &ConnectorRequirement) -> String {
+    if connector.provider_id.is_empty() || connector.provider_id == connector.id {
+        connector.id.clone()
+    } else {
+        format!("{} ({})", connector.id, connector.provider_id)
+    }
+}
+
+fn editable_field(
+    id: impl Into<String>,
+    label: impl Into<String>,
+    json_pointer: impl Into<String>,
+    value_type: impl Into<String>,
+    required: bool,
+    enum_values: &[&str],
+) -> WorkflowBundleEditableField {
+    WorkflowBundleEditableField {
+        id: id.into(),
+        label: label.into(),
+        json_pointer: json_pointer.into(),
+        value_type: value_type.into(),
+        required,
+        enum_values: enum_values
+            .iter()
+            .map(|value| (*value).to_string())
+            .collect(),
+    }
+}
+
+fn json_pointer_segment(value: &str) -> String {
+    value.replace('~', "~0").replace('/', "~1")
+}
+
+fn trigger_editable_fields(
+    index: usize,
+    trigger: &WorkflowBundleTrigger,
+) -> Vec<WorkflowBundleEditableField> {
+    let base = format!("/triggers/{index}");
+    let mut fields = vec![
+        editable_field(
+            format!("trigger.{}.kind", trigger.id),
+            "Trigger kind",
+            format!("{base}/kind"),
+            "enum",
+            true,
+            &["github", "cron", "delay", "manual", "webhook", "mcp"],
+        ),
+        editable_field(
+            format!("trigger.{}.node_id", trigger.id),
+            "Target node",
+            format!("{base}/node_id"),
+            "string",
+            false,
+            &[],
+        ),
+    ];
+    if trigger.provider.is_some() || trigger.kind == "github" {
+        fields.push(editable_field(
+            format!("trigger.{}.provider", trigger.id),
+            "Provider",
+            format!("{base}/provider"),
+            "string",
+            trigger.kind == "github",
+            &[],
+        ));
+    }
+    for (field, label, value_type) in [
+        ("events", "Events", "list"),
+        ("schedule", "Schedule", "string"),
+        ("delay", "Delay", "string"),
+        ("webhook_path", "Webhook path", "string"),
+        ("mcp_tool", "MCP tool", "string"),
+        ("resume_key", "Resume key", "string"),
+        ("metadata", "Metadata", "object"),
+    ] {
+        fields.push(editable_field(
+            format!("trigger.{}.{}", trigger.id, field),
+            label,
+            format!("{base}/{field}"),
+            value_type,
+            false,
+            &[],
+        ));
+    }
+    fields
+}
+
+fn workflow_node_editable_fields(
+    node_id: &str,
+    capsule_id: Option<&String>,
+) -> Vec<WorkflowBundleEditableField> {
+    let escaped_node = json_pointer_segment(node_id);
+    let mut fields = vec![
+        editable_field(
+            format!("workflow.{node_id}.task_label"),
+            "Task label",
+            format!("/workflow/nodes/{escaped_node}/task_label"),
+            "string",
+            false,
+            &[],
+        ),
+        editable_field(
+            format!("workflow.{node_id}.prompt"),
+            "Prompt",
+            format!("/workflow/nodes/{escaped_node}/prompt"),
+            "string",
+            false,
+            &[],
+        ),
+        editable_field(
+            format!("workflow.{node_id}.system"),
+            "System prompt",
+            format!("/workflow/nodes/{escaped_node}/system"),
+            "string",
+            false,
+            &[],
+        ),
+        editable_field(
+            format!("workflow.{node_id}.model_policy"),
+            "Model policy",
+            format!("/workflow/nodes/{escaped_node}/model_policy"),
+            "object",
+            false,
+            &[],
+        ),
+        editable_field(
+            format!("workflow.{node_id}.tools"),
+            "Tool policy",
+            format!("/workflow/nodes/{escaped_node}/tools"),
+            "any",
+            false,
+            &[],
+        ),
+        editable_field(
+            format!("workflow.{node_id}.capability_policy"),
+            "Capability policy",
+            format!("/workflow/nodes/{escaped_node}/capability_policy"),
+            "object",
+            false,
+            &[],
+        ),
+        editable_field(
+            format!("workflow.{node_id}.approval_policy"),
+            "Approval policy",
+            format!("/workflow/nodes/{escaped_node}/approval_policy"),
+            "object",
+            false,
+            &[],
+        ),
+        editable_field(
+            format!("workflow.{node_id}.retry_policy"),
+            "Retry policy",
+            format!("/workflow/nodes/{escaped_node}/retry_policy"),
+            "object",
+            false,
+            &[],
+        ),
+    ];
+    if let Some(capsule_id) = capsule_id {
+        let escaped_capsule = json_pointer_segment(capsule_id);
+        fields.extend([
+            editable_field(
+                format!("prompt_capsule.{capsule_id}.prompt"),
+                "Prompt capsule",
+                format!("/prompt_capsules/{escaped_capsule}/prompt"),
+                "string",
+                true,
+                &[],
+            ),
+            editable_field(
+                format!("prompt_capsule.{capsule_id}.system"),
+                "Prompt capsule system",
+                format!("/prompt_capsules/{escaped_capsule}/system"),
+                "string",
+                false,
+                &[],
+            ),
+            editable_field(
+                format!("prompt_capsule.{capsule_id}.context"),
+                "Prompt capsule context",
+                format!("/prompt_capsules/{escaped_capsule}/context"),
+                "object",
+                false,
+                &[],
+            ),
+            editable_field(
+                format!("prompt_capsule.{capsule_id}.trigger_id"),
+                "Prompt capsule trigger",
+                format!("/prompt_capsules/{escaped_capsule}/trigger_id"),
+                "string",
+                false,
+                &[],
+            ),
+        ]);
+    }
+    fields
+}
+
+fn connector_editable_fields(
+    index: usize,
+    connector: &ConnectorRequirement,
+) -> Vec<WorkflowBundleEditableField> {
+    let base = format!("/connectors/{index}");
+    [
+        ("id", "Connector id", "string", true),
+        ("provider_id", "Provider id", "string", true),
+        ("scopes", "Scopes", "list", false),
+        ("setup_required", "Setup required", "bool", false),
+        ("status_required", "Status required", "bool", false),
+    ]
+    .into_iter()
+    .map(|(field, label, value_type, required)| {
+        editable_field(
+            format!("connector.{}.{}", connector.id, field),
+            label,
+            format!("{base}/{field}"),
+            value_type,
+            required,
+            &[],
+        )
+    })
+    .collect()
+}
+
+fn retry_editable_fields() -> Vec<WorkflowBundleEditableField> {
+    vec![
+        editable_field(
+            "policy.retry.max_attempts",
+            "Retry attempts",
+            "/policy/retry/max_attempts",
+            "integer",
+            true,
+            &[],
+        ),
+        editable_field(
+            "policy.retry.backoff",
+            "Retry backoff",
+            "/policy/retry/backoff",
+            "string",
+            true,
+            &[],
+        ),
+    ]
+}
+
+fn catchup_editable_fields() -> Vec<WorkflowBundleEditableField> {
+    vec![
+        editable_field(
+            "policy.catchup.mode",
+            "Catchup mode",
+            "/policy/catchup/mode",
+            "enum",
+            true,
+            &["none", "latest", "all"],
+        ),
+        editable_field(
+            "policy.catchup.max_events",
+            "Catchup max events",
+            "/policy/catchup/max_events",
+            "integer",
+            false,
+            &[],
+        ),
+    ]
+}
+
+fn render_workflow_bundle_mermaid(
+    nodes: &[WorkflowBundleGraphNode],
+    edges: &[WorkflowBundleGraphEdge],
+) -> String {
+    let mut lines = vec!["flowchart TD".to_string()];
+    for node in nodes {
+        lines.push(format!(
+            "  {}[\"{}\"]",
+            mermaid_id(&node.id),
+            mermaid_label(&format!("{}: {}", node.node_type, node.label))
+        ));
+    }
+    for edge in edges {
+        let label = edge
+            .label
+            .as_deref()
+            .or(edge.branch.as_deref())
+            .map(mermaid_label);
+        match label {
+            Some(label) if !label.is_empty() => lines.push(format!(
+                "  {} -->|{}| {}",
+                mermaid_id(&edge.from),
+                label,
+                mermaid_id(&edge.to)
+            )),
+            _ => lines.push(format!(
+                "  {} --> {}",
+                mermaid_id(&edge.from),
+                mermaid_id(&edge.to)
+            )),
+        }
+    }
+    lines.join("\n")
+}
+
+fn mermaid_id(value: &str) -> String {
+    let digest = Sha256::digest(value.as_bytes());
+    let suffix = digest
+        .iter()
+        .take(4)
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    let mut out = format!("n_{suffix}_");
+    for ch in value.chars() {
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch);
+        } else {
+            out.push('_');
+        }
+    }
+    out
+}
+
+fn mermaid_label(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', " ")
 }
 
 fn triggers_by_node(bundle: &WorkflowBundle) -> BTreeMap<String, Vec<String>> {

--- a/crates/harn-vm/src/orchestration/workflow_bundle_tests.rs
+++ b/crates/harn-vm/src/orchestration/workflow_bundle_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::orchestration::{WorkflowEdge, WorkflowNode};
 
 fn fixture_bundle() -> WorkflowBundle {
     serde_json::from_str(
@@ -108,6 +109,18 @@ fn fixture_bundle() -> WorkflowBundle {
     .unwrap()
 }
 
+fn graph_node_types(preview: &WorkflowBundlePreview) -> Vec<String> {
+    let mut types = preview
+        .graph
+        .nodes
+        .iter()
+        .map(|node| node.node_type.clone())
+        .collect::<Vec<_>>();
+    types.sort();
+    types.dedup();
+    types
+}
+
 #[test]
 fn validates_fixture_bundle_and_previews_graph() {
     let bundle = fixture_bundle();
@@ -122,6 +135,33 @@ fn validates_fixture_bundle_and_previews_graph() {
         preview.nodes[2].prompt_capsule.as_deref(),
         Some("query-logs")
     );
+    assert!(preview.mermaid.starts_with("flowchart TD"));
+    assert_eq!(preview.mermaid, preview.graph.mermaid);
+    let node_types = graph_node_types(&preview);
+    for expected in [
+        "action",
+        "catchup",
+        "connector_call",
+        "dlq",
+        "notification",
+        "terminal",
+        "trigger",
+        "wait",
+    ] {
+        assert!(
+            node_types.contains(&expected.to_string()),
+            "{node_types:#?}"
+        );
+    }
+    assert!(preview
+        .graph
+        .edges
+        .iter()
+        .any(|edge| { edge.from == "trigger/github-pr-updated" && edge.to == "policy/catchup" }));
+    assert!(preview.graph.editable_fields.iter().any(|field| {
+        field.id == "prompt_capsule.query-logs.prompt"
+            && field.json_pointer == "/prompt_capsules/query-logs/prompt"
+    }));
 }
 
 #[test]
@@ -149,6 +189,193 @@ fn rejects_unstable_or_unknown_bundle_references() {
         .errors
         .iter()
         .any(|diagnostic| diagnostic.path == "policy.catchup.mode"));
+}
+
+#[test]
+fn graph_export_covers_agent_approval_connector_and_terminal_nodes() {
+    let mut bundle = fixture_bundle();
+    bundle.workflow.nodes.insert(
+        "repair".to_string(),
+        WorkflowNode {
+            id: Some("repair".to_string()),
+            kind: "agent".to_string(),
+            task_label: Some("Repair PR".to_string()),
+            ..WorkflowNode::default()
+        },
+    );
+    bundle.workflow.nodes.insert(
+        "delegate".to_string(),
+        WorkflowNode {
+            id: Some("delegate".to_string()),
+            kind: "subagent".to_string(),
+            task_label: Some("Delegate log review".to_string()),
+            ..WorkflowNode::default()
+        },
+    );
+    bundle.workflow.nodes.insert(
+        "approve".to_string(),
+        WorkflowNode {
+            id: Some("approve".to_string()),
+            kind: "approval".to_string(),
+            task_label: Some("Approve deploy action".to_string()),
+            ..WorkflowNode::default()
+        },
+    );
+    bundle.workflow.nodes.insert(
+        "call_render".to_string(),
+        WorkflowNode {
+            id: Some("call_render".to_string()),
+            kind: "connector_call".to_string(),
+            task_label: Some("Query deployment provider".to_string()),
+            ..WorkflowNode::default()
+        },
+    );
+    bundle.workflow.edges.extend([
+        WorkflowEdge {
+            from: "notify".to_string(),
+            to: "repair".to_string(),
+            branch: Some("failed".to_string()),
+            label: None,
+        },
+        WorkflowEdge {
+            from: "repair".to_string(),
+            to: "delegate".to_string(),
+            branch: None,
+            label: None,
+        },
+        WorkflowEdge {
+            from: "delegate".to_string(),
+            to: "approve".to_string(),
+            branch: None,
+            label: None,
+        },
+        WorkflowEdge {
+            from: "approve".to_string(),
+            to: "call_render".to_string(),
+            branch: None,
+            label: None,
+        },
+    ]);
+
+    let preview = preview_workflow_bundle(&bundle);
+    assert!(preview.validation.valid, "{:#?}", preview.validation);
+    let node_types = graph_node_types(&preview);
+    for expected in [
+        "agent",
+        "subagent",
+        "approval",
+        "connector_call",
+        "terminal",
+    ] {
+        assert!(
+            node_types.contains(&expected.to_string()),
+            "{node_types:#?}"
+        );
+    }
+}
+
+#[test]
+fn graph_diagnostics_include_node_ids_for_gui_annotation() {
+    let mut bundle = fixture_bundle();
+    bundle.workflow.nodes.insert(
+        "orphan".to_string(),
+        WorkflowNode {
+            id: Some("orphan".to_string()),
+            kind: "action".to_string(),
+            task_label: Some("Unreachable node".to_string()),
+            ..WorkflowNode::default()
+        },
+    );
+    bundle.workflow.edges.push(WorkflowEdge {
+        from: "missing".to_string(),
+        to: "notify".to_string(),
+        branch: None,
+        label: None,
+    });
+
+    let preview = preview_workflow_bundle(&bundle);
+    assert!(!preview.validation.valid);
+    assert!(
+        preview.graph.diagnostics.iter().any(|diagnostic| {
+            diagnostic.node_id.as_deref() == Some("orphan")
+                && diagnostic.graph_node_id.as_deref() == Some("node/orphan")
+        }),
+        "{:#?}",
+        preview.graph.diagnostics
+    );
+    assert!(
+        preview.graph.diagnostics.iter().any(|diagnostic| {
+            diagnostic.node_id.as_deref() == Some("missing")
+                && diagnostic.graph_node_id.as_deref() == Some("node/missing")
+        }),
+        "{:#?}",
+        preview.graph.diagnostics
+    );
+}
+
+#[test]
+fn editable_field_pointers_round_trip_supported_surfaces() {
+    let bundle = fixture_bundle();
+    let preview = preview_workflow_bundle(&bundle);
+    let mut value = serde_json::to_value(&bundle).unwrap();
+    let edits = [
+        (
+            "trigger.github-pr-updated.events",
+            serde_json::json!(["pull_request.closed"]),
+        ),
+        (
+            "prompt_capsule.query-logs.prompt",
+            serde_json::json!("Check deployment logs and report only actionable failures."),
+        ),
+        (
+            "workflow.query_logs.model_policy",
+            serde_json::json!({"provider": "mock", "model": "cheap-local"}),
+        ),
+        (
+            "workflow.query_logs.tools",
+            serde_json::json!([{"name": "render.logs.query"}]),
+        ),
+        ("policy.retry.max_attempts", serde_json::json!(3)),
+        ("policy.catchup.mode", serde_json::json!("all")),
+        (
+            "connector.github.provider_id",
+            serde_json::json!("github-enterprise"),
+        ),
+    ];
+
+    for (field_id, replacement) in edits {
+        let pointer = preview
+            .graph
+            .editable_fields
+            .iter()
+            .find(|field| field.id == field_id)
+            .unwrap_or_else(|| panic!("missing editable field {field_id}"))
+            .json_pointer
+            .clone();
+        *value
+            .pointer_mut(&pointer)
+            .unwrap_or_else(|| panic!("missing JSON pointer {pointer}")) = replacement;
+    }
+
+    let edited: WorkflowBundle = serde_json::from_value(value).unwrap();
+    assert_eq!(
+        edited.triggers[0].events,
+        vec!["pull_request.closed".to_string()]
+    );
+    assert_eq!(edited.policy.retry.max_attempts, 3);
+    assert_eq!(edited.policy.catchup.mode, "all");
+    assert_eq!(edited.connectors[0].provider_id, "github-enterprise");
+    assert_eq!(
+        edited.workflow.nodes["query_logs"]
+            .model_policy
+            .provider
+            .as_deref(),
+        Some("mock")
+    );
+    assert_eq!(
+        edited.prompt_capsules["query-logs"].prompt,
+        "Check deployment logs and report only actionable failures."
+    );
 }
 
 #[test]

--- a/docs/src/workflow-bundles.md
+++ b/docs/src/workflow-bundles.md
@@ -10,6 +10,7 @@ The canonical on-disk format is JSON. The current schema version is `1`.
 ```bash
 harn workflow validate --bundle docs/fixtures/workflow-bundles/github-pr-monitor.bundle.json --json
 harn workflow preview --bundle docs/fixtures/workflow-bundles/github-pr-monitor.bundle.json --json
+harn workflow preview --bundle docs/fixtures/workflow-bundles/github-pr-monitor.bundle.json --mermaid
 harn workflow run --bundle docs/fixtures/workflow-bundles/github-pr-monitor.bundle.json --json
 ```
 
@@ -57,11 +58,22 @@ before committing autonomous resources:
 - trigger declarations
 - connector requirements
 - environment requirements
-- node summaries with outgoing edges, trigger ids, and prompt capsule ids
-- canonical edges
+- normalized `graph.nodes` for triggers, actions, agents/subagents, waits,
+  approvals, connector calls, notifications, catchup/DLQ branches, and terminal
+  states
+- normalized `graph.edges` connecting connector bindings, trigger dispatch,
+  workflow control flow, catchup, DLQ, and terminal outcomes
+- node-scoped `graph.diagnostics` so hosts can annotate the exact workflow node
+  instead of showing opaque bundle errors
+- `graph.editable_fields` JSON pointers for trigger config, prompt capsules,
+  model/tool/approval/retry policy, catchup policy, and connector binding
+  surfaces
+- `graph.mermaid` plus the top-level `mermaid` string for a low-cost debug
+  rendering
 
-This is intentionally compact. Rich visual editing metadata is layered on top of
-the same bundle and graph contract.
+JSON is the product contract. `--mermaid` prints only the Mermaid view for
+quick debugging and docs snippets; hosts should use `--json` for editing and
+validation.
 
 ## Local run receipts
 


### PR DESCRIPTION
Closes #1411

## Summary
- add a normalized workflow bundle graph export to preview JSON, including graph nodes/edges, node-scoped diagnostics, editable field metadata, and embedded Mermaid
- add `harn workflow preview --mermaid` for a debug diagram view
- cover graph snapshots, editable field round-trip pointers, and invalid bundle node diagnostics in workflow bundle tests
- document the JSON graph contract and Mermaid debug output

## Verification
- `cargo fmt`
- pre-commit hook: workspace clippy with `-D warnings` and markdown lint
- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/tmp/harn-target-issue-1411 cargo test -p harn-vm workflow_bundle -- --nocapture`
- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/tmp/harn-target-issue-1411 cargo check -p harn-cli`
- `cargo run --quiet --bin harn -- workflow preview --bundle docs/fixtures/workflow-bundles/github-pr-monitor.bundle.json --json | jq -r ...`
- `cargo run --quiet --bin harn -- workflow preview --bundle docs/fixtures/workflow-bundles/github-pr-monitor.bundle.json --mermaid | sed -n '1,4p'`\n- `HARN_BIN=/var/folders/1h/v3ltwjgn6h79_77xhvgxwgm80000gn/T/harn-target/2f1b-harn/debug/harn make check-docs-snippets`\n- `git diff --check`\n- pre-push targeted local checks and markdown lint\n\nNote: two intermediate reruns failed due local disk exhaustion while rebuilding a temporary Cargo target, and were rerun successfully after removing only the task-local target and using the configured per-worktree target.