### PR TITLE
Support multimodal agent session input

### DIFF
--- a/crates/harn-vm/src/llm/agent_session_host.rs
+++ b/crates/harn-vm/src/llm/agent_session_host.rs
@@ -182,6 +182,15 @@ fn opt_json(map: &BTreeMap<String, VmValue>, key: &str) -> Option<serde_json::Va
         .map(vm_to_json)
 }
 
+fn initial_user_content(
+    opts_map: &BTreeMap<String, VmValue>,
+    fallback_message: &str,
+) -> serde_json::Value {
+    opt_json(opts_map, "initial_user_content")
+        .or_else(|| opt_json(opts_map, "initial_message_content"))
+        .unwrap_or_else(|| serde_json::Value::String(fallback_message.to_string()))
+}
+
 fn now_id() -> String {
     uuid::Uuid::now_v7().to_string()
 }
@@ -219,7 +228,10 @@ async fn host_agent_session_init(args: Vec<VmValue>) -> Result<VmValue, VmError>
             .map_err(VmError::Runtime)?;
     }
 
-    let user_msg = serde_json::json!({"role": "user", "content": message});
+    let user_msg = serde_json::json!({
+        "role": "user",
+        "content": initial_user_content(&opts_map, &message),
+    });
     let _ = crate::agent_sessions::inject_message(&resolved, json_to_vm(&user_msg));
 
     let max_iterations = opt_int(&opts_map, "max_iterations").unwrap_or(50).max(1);
@@ -1792,9 +1804,10 @@ mod tests {
     use serde_json::json;
 
     use super::{
-        assistant_message_from_llm_result, canonical_acp_stop_reason, last_assistant_text,
-        tool_result_message_for_provider, vm_to_json,
+        assistant_message_from_llm_result, canonical_acp_stop_reason, initial_user_content,
+        last_assistant_text, tool_result_message_for_provider, vm_to_json,
     };
+    use std::collections::BTreeMap;
 
     #[test]
     fn native_tool_calls_replay_with_openai_wire_shape() {
@@ -1816,6 +1829,38 @@ mod tests {
         assert_eq!(
             message["tool_calls"][0]["function"]["arguments"],
             r#"{"command":"git status --short"}"#
+        );
+    }
+
+    #[test]
+    fn initial_user_content_preserves_multimodal_blocks() {
+        let mut opts = BTreeMap::new();
+        opts.insert(
+            "initial_user_content".to_string(),
+            crate::stdlib::json_to_vm_value(&json!([
+                {"type": "text", "text": "Describe this image."},
+                {
+                    "type": "image",
+                    "media_type": "image/png",
+                    "base64": "aGVsbG8="
+                }
+            ])),
+        );
+
+        let content = initial_user_content(&opts, "Describe this image.");
+
+        assert_eq!(content[0]["type"], "text");
+        assert_eq!(content[1]["type"], "image");
+        assert_eq!(content[1]["base64"], "aGVsbG8=");
+    }
+
+    #[test]
+    fn initial_user_content_falls_back_to_text_message() {
+        let opts = BTreeMap::new();
+
+        assert_eq!(
+            initial_user_content(&opts, "hello"),
+            serde_json::Value::String("hello".to_string())
         );
     }
 

--- a/crates/harn-vm/src/llm/capabilities.rs
+++ b/crates/harn-vm/src/llm/capabilities.rs
@@ -696,6 +696,8 @@ anthropic_beta_features = ["fine-grained-tool-streaming-2025-05-14"]
         assert!(lookup("gemini", "gemini-2.5-flash").audio);
         assert!(lookup("gemini", "gemini-2.5-flash").pdf);
         assert!(lookup("ollama", "llava:latest").vision_supported);
+        assert!(lookup("ollama", "gemma4:26b").vision_supported);
+        assert!(lookup("ollama", "gemma4-128k:latest").vision_supported);
         assert!(!lookup("openai", "gpt-3.5-turbo").vision_supported);
         assert!(!lookup("ollama", "qwen3.5:35b-a3b-coding-nvfp4").vision_supported);
     }

--- a/crates/harn-vm/src/llm/capabilities.toml
+++ b/crates/harn-vm/src/llm/capabilities.toml
@@ -493,6 +493,10 @@ model_match = "gemma3*"
 vision_supported = true
 
 [[provider.ollama]]
+model_match = "gemma4*"
+vision_supported = true
+
+[[provider.ollama]]
 model_match = "qwen3.6*"
 native_tools = true
 structured_output = "format_kw"

--- a/crates/harn-vm/src/stdlib/workflow_messages.rs
+++ b/crates/harn-vm/src/stdlib/workflow_messages.rs
@@ -306,6 +306,13 @@ fn workflow_status_json(
     })
 }
 
+fn target_for_base(base_dir: &Path, workflow_id: &str) -> WorkflowTarget {
+    WorkflowTarget {
+        workflow_id: sanitize_workflow_id(workflow_id),
+        base_dir: base_dir.to_path_buf(),
+    }
+}
+
 fn enqueue_message(
     target: &WorkflowTarget,
     kind: &str,
@@ -314,6 +321,22 @@ fn enqueue_message(
     request_id: Option<String>,
 ) -> Result<serde_json::Value, String> {
     let mut state = load_state(target)?;
+    let message = push_message(&mut state, kind, name, payload, request_id);
+    save_state(target, &state)?;
+    Ok(serde_json::json!({
+        "workflow_id": target.workflow_id,
+        "message": message,
+        "status": workflow_status_json(target, &state),
+    }))
+}
+
+fn push_message(
+    state: &mut WorkflowMailboxState,
+    kind: &str,
+    name: &str,
+    payload: serde_json::Value,
+    request_id: Option<String>,
+) -> WorkflowMessageRecord {
     state.next_seq += 1;
     let message = WorkflowMessageRecord {
         seq: state.next_seq,
@@ -324,12 +347,16 @@ fn enqueue_message(
         enqueued_at: now_rfc3339(),
     };
     state.mailbox.push_back(message.clone());
-    save_state(target, &state)?;
-    Ok(serde_json::json!({
-        "workflow_id": target.workflow_id,
-        "message": message,
-        "status": workflow_status_json(target, &state),
-    }))
+    message
+}
+
+fn receive_message(target: &WorkflowTarget) -> Result<Option<WorkflowMessageRecord>, String> {
+    let mut state = load_state(target)?;
+    let message = state.mailbox.pop_front();
+    if message.is_some() {
+        save_state(target, &state)?;
+    }
+    Ok(message)
 }
 
 pub fn workflow_signal_for_base(
@@ -338,10 +365,7 @@ pub fn workflow_signal_for_base(
     name: &str,
     payload: serde_json::Value,
 ) -> Result<serde_json::Value, String> {
-    let target = WorkflowTarget {
-        workflow_id: sanitize_workflow_id(workflow_id),
-        base_dir: base_dir.to_path_buf(),
-    };
+    let target = target_for_base(base_dir, workflow_id);
     enqueue_message(&target, "signal", name, payload, None)
 }
 
@@ -350,10 +374,7 @@ pub fn workflow_query_for_base(
     workflow_id: &str,
     name: &str,
 ) -> Result<serde_json::Value, String> {
-    let target = WorkflowTarget {
-        workflow_id: sanitize_workflow_id(workflow_id),
-        base_dir: base_dir.to_path_buf(),
-    };
+    let target = target_for_base(base_dir, workflow_id);
     let state = load_state(&target)?;
     Ok(state
         .queries
@@ -368,10 +389,7 @@ pub fn workflow_publish_query_for_base(
     name: &str,
     value: serde_json::Value,
 ) -> Result<serde_json::Value, String> {
-    let target = WorkflowTarget {
-        workflow_id: sanitize_workflow_id(workflow_id),
-        base_dir: base_dir.to_path_buf(),
-    };
+    let target = target_for_base(base_dir, workflow_id);
     let mut state = load_state(&target)?;
     state.queries.insert(
         name.to_string(),
@@ -388,21 +406,10 @@ pub fn workflow_pause_for_base(
     base_dir: &Path,
     workflow_id: &str,
 ) -> Result<serde_json::Value, String> {
-    let target = WorkflowTarget {
-        workflow_id: sanitize_workflow_id(workflow_id),
-        base_dir: base_dir.to_path_buf(),
-    };
+    let target = target_for_base(base_dir, workflow_id);
     let mut state = load_state(&target)?;
     state.paused = true;
-    state.next_seq += 1;
-    state.mailbox.push_back(WorkflowMessageRecord {
-        seq: state.next_seq,
-        kind: "control".to_string(),
-        name: "pause".to_string(),
-        request_id: None,
-        payload: serde_json::json!({}),
-        enqueued_at: now_rfc3339(),
-    });
+    push_message(&mut state, "control", "pause", serde_json::json!({}), None);
     save_state(&target, &state)?;
     Ok(workflow_status_json(&target, &state))
 }
@@ -411,21 +418,10 @@ pub fn workflow_resume_for_base(
     base_dir: &Path,
     workflow_id: &str,
 ) -> Result<serde_json::Value, String> {
-    let target = WorkflowTarget {
-        workflow_id: sanitize_workflow_id(workflow_id),
-        base_dir: base_dir.to_path_buf(),
-    };
+    let target = target_for_base(base_dir, workflow_id);
     let mut state = load_state(&target)?;
     state.paused = false;
-    state.next_seq += 1;
-    state.mailbox.push_back(WorkflowMessageRecord {
-        seq: state.next_seq,
-        kind: "control".to_string(),
-        name: "resume".to_string(),
-        request_id: None,
-        payload: serde_json::json!({}),
-        enqueued_at: now_rfc3339(),
-    });
+    push_message(&mut state, "control", "resume", serde_json::json!({}), None);
     save_state(&target, &state)?;
     Ok(workflow_status_json(&target, &state))
 }
@@ -437,18 +433,31 @@ pub async fn workflow_update_for_base(
     payload: serde_json::Value,
     timeout: StdDuration,
 ) -> Result<serde_json::Value, String> {
-    let target = WorkflowTarget {
-        workflow_id: sanitize_workflow_id(workflow_id),
-        base_dir: base_dir.to_path_buf(),
-    };
+    let target = target_for_base(base_dir, workflow_id);
+    let request_id = enqueue_update_request(&target, name, payload)?;
+    wait_for_update_response(&target, name, &request_id, timeout).await
+}
+
+fn enqueue_update_request(
+    target: &WorkflowTarget,
+    name: &str,
+    payload: serde_json::Value,
+) -> Result<String, String> {
     let request_id = uuid::Uuid::now_v7().to_string();
-    enqueue_message(&target, "update", name, payload, Some(request_id.clone()))?;
-    let started = std::time::Instant::now();
-    while started.elapsed() <= timeout {
-        if let Ok(state) = load_state(&target) {
-            if let Some(response) = state.responses.get(&request_id) {
-                return Ok(response.value.clone());
-            }
+    enqueue_message(target, "update", name, payload, Some(request_id.clone()))?;
+    Ok(request_id)
+}
+
+async fn wait_for_update_response(
+    target: &WorkflowTarget,
+    name: &str,
+    request_id: &str,
+    timeout: StdDuration,
+) -> Result<serde_json::Value, String> {
+    let deadline = tokio::time::Instant::now() + timeout;
+    while tokio::time::Instant::now() <= deadline {
+        if let Ok(Some(value)) = update_response_value(target, request_id) {
+            return Ok(value);
         }
         tokio::time::sleep(StdDuration::from_millis(UPDATE_POLL_INTERVAL_MS)).await;
     }
@@ -458,6 +467,16 @@ pub async fn workflow_update_for_base(
     ))
 }
 
+fn update_response_value(
+    target: &WorkflowTarget,
+    request_id: &str,
+) -> Result<Option<serde_json::Value>, String> {
+    Ok(load_state(target)?
+        .responses
+        .get(request_id)
+        .map(|response| response.value.clone()))
+}
+
 pub fn workflow_respond_update_for_base(
     base_dir: &Path,
     workflow_id: &str,
@@ -465,11 +484,17 @@ pub fn workflow_respond_update_for_base(
     name: Option<&str>,
     value: serde_json::Value,
 ) -> Result<serde_json::Value, String> {
-    let target = WorkflowTarget {
-        workflow_id: sanitize_workflow_id(workflow_id),
-        base_dir: base_dir.to_path_buf(),
-    };
-    let mut state = load_state(&target)?;
+    let target = target_for_base(base_dir, workflow_id);
+    record_update_response(&target, request_id, name, value)
+}
+
+fn record_update_response(
+    target: &WorkflowTarget,
+    request_id: &str,
+    name: Option<&str>,
+    value: serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let mut state = load_state(target)?;
     state.responses.insert(
         request_id.to_string(),
         WorkflowUpdateResponseRecord {
@@ -479,8 +504,8 @@ pub fn workflow_respond_update_for_base(
             responded_at: now_rfc3339(),
         },
     );
-    save_state(&target, &state)?;
-    Ok(workflow_status_json(&target, &state))
+    save_state(target, &state)?;
+    Ok(workflow_status_json(target, &state))
 }
 
 pub(crate) fn register_workflow_message_builtins(vm: &mut Vm) {
@@ -615,11 +640,9 @@ fn workflow_publish_query_builtin(args: &[VmValue], _out: &mut String) -> Result
 
 fn workflow_receive_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
     let target = parse_target_vm(args.first(), None, "workflow.receive")?;
-    let mut state = load_state(&target).map_err(VmError::Runtime)?;
-    let Some(message) = state.mailbox.pop_front() else {
+    let Some(message) = receive_message(&target).map_err(VmError::Runtime)? else {
         return Ok(VmValue::Nil);
     };
-    save_state(&target, &state).map_err(VmError::Runtime)?;
     Ok(crate::stdlib::json_to_vm_value(&serde_json::json!({
         "workflow_id": target.workflow_id,
         "seq": message.seq,
@@ -711,56 +734,53 @@ fn continue_as_new_for_label(args: &[VmValue], label: &str) -> Result<VmValue, V
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::task::Poll;
 
     #[tokio::test(start_paused = true)]
     async fn update_round_trip_waits_for_response() {
         let dir = tempfile::tempdir().expect("tempdir");
         let workflow_id = "wf-update";
         let base_dir = dir.path().to_path_buf();
-        let base_dir_clone = base_dir.clone();
-        let task = tokio::spawn(async move {
-            workflow_update_for_base(
-                &base_dir_clone,
-                workflow_id,
-                "adjust_budget",
-                serde_json::json!({"max_usd": 10}),
-                StdDuration::from_millis(500),
-            )
-            .await
-        });
+        let target = target_for_base(&base_dir, workflow_id);
+        let request_id =
+            enqueue_update_request(&target, "adjust_budget", serde_json::json!({"max_usd": 10}))
+                .expect("enqueue update");
 
-        let target = WorkflowTarget {
-            workflow_id: workflow_id.to_string(),
-            base_dir: base_dir.clone(),
-        };
-        let mut state = None;
-        let mut message = None;
-        for _ in 0..100 {
-            if let Ok(mut loaded) = load_state(&target) {
-                if let Some(queued) = loaded.mailbox.pop_front() {
-                    state = Some(loaded);
-                    message = Some(queued);
-                    break;
-                }
-            }
-            tokio::task::yield_now().await;
-        }
-        let mut state = state.expect("load state with queued update");
-        let message = message.expect("queued update");
+        let message = receive_message(&target)
+            .expect("receive queued update")
+            .expect("queued update");
         assert_eq!(message.kind, "update");
-        state.responses.insert(
-            message.request_id.clone().expect("request id"),
-            WorkflowUpdateResponseRecord {
-                request_id: message.request_id.expect("request id"),
-                name: Some(message.name.clone()),
-                value: serde_json::json!({"ok": true}),
-                responded_at: now_rfc3339(),
-            },
+        assert_eq!(message.name, "adjust_budget");
+        assert_eq!(message.request_id.as_deref(), Some(request_id.as_str()));
+        assert_eq!(
+            update_response_value(&target, &request_id).expect("read response"),
+            None
         );
-        save_state(&target, &state).expect("save response");
+
+        let waiter = wait_for_update_response(
+            &target,
+            "adjust_budget",
+            &request_id,
+            StdDuration::from_millis(500),
+        );
+        tokio::pin!(waiter);
+        assert!(matches!(futures::poll!(&mut waiter), Poll::Pending));
+
+        workflow_respond_update_for_base(
+            &base_dir,
+            workflow_id,
+            &request_id,
+            Some("adjust_budget"),
+            serde_json::json!({"ok": true}),
+        )
+        .expect("save response");
+        assert_eq!(
+            update_response_value(&target, &request_id).expect("read response"),
+            Some(serde_json::json!({"ok": true}))
+        );
         tokio::time::advance(StdDuration::from_millis(UPDATE_POLL_INTERVAL_MS)).await;
 
-        let result = task.await.expect("join").expect("update result");
+        let result = waiter.await.expect("update result");
         assert_eq!(result, serde_json::json!({"ok": true}));
     }
 

--- a/docs/src/provider-matrix.md
+++ b/docs/src/provider-matrix.md
@@ -54,6 +54,7 @@ Regenerate with `make gen-provider-matrix` and verify with `make check-provider-
 | `ollama` | `bakllava*` | no | yes | no | no | yes | no | no | no | no |
 | `ollama` | `llama3.2-vision*` | no | yes | no | no | yes | no | no | no | no |
 | `ollama` | `gemma3*` | no | yes | no | no | yes | no | no | no | no |
+| `ollama` | `gemma4*` | no | yes | no | no | yes | no | no | no | no |
 | `ollama` | `qwen3.6*` | `enabled` | no | no | no | yes | no | `format_kw` | yes | no |
 | `ollama` | `qwen3*` | `enabled` | no | no | no | yes | no | `format_kw` | yes | no |
 | `openai` | `gpt-4o*` | no | yes | yes | no | yes | no | `native` | yes | no |


### PR DESCRIPTION
## Summary
- Preserve structured initial user content in Harn agent sessions so ACP multimodal prompt blocks reach the agent transcript.
- Mark Ollama Gemma 4 routes as vision-capable in the Harn capability matrix.
- Add unit coverage for multimodal initial content and Gemma 4 vision capability.

## Validation
- cargo fmt --check --package harn-vm
- cargo test -p harn-vm initial_user_content --lib
- cargo test -p harn-vm vision_capability_gates_known_multimodal_models --lib
- cargo build -p harn-cli --bin harn
- pre-commit/pre-push hooks ran clippy and ratchets successfully