### PR TITLE
Ship workflow-authoring skill pack and small-model evals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ Pre-0.6 highlights live in [CHANGELOG-pre-0.6.md](CHANGELOG-pre-0.6.md).
 Harn had no external users before 0.6.0, so that archive intentionally keeps
 condensed series summaries instead of full per-patch history.
 
+## Unreleased
+
+### Added
+
+- **Workflow-authoring skill pack and small-model evals.** Added
+  `examples/skill-packs/workflow-authoring/` with a top-level `SKILL.md`,
+  small-model prompting guide, validated PR-monitor and PR-repair recipe
+  bundles, eval cases with structural assertions, and an `eval.harn` driver
+  that feeds a configurable provider through the validate → preview → run
+  pipeline. A new `crates/harn-cli/tests/workflow_authoring_eval.rs`
+  regression gate fails CI when a recipe golden or a case's structural
+  assertions drift.
+
 ## v0.8.4
 
 ### Added

--- a/crates/harn-cli/tests/workflow_authoring_eval.rs
+++ b/crates/harn-cli/tests/workflow_authoring_eval.rs
@@ -1,0 +1,291 @@
+//! Regression gate for the workflow-authoring skill pack.
+//!
+//! Loads every recipe and case under
+//! `examples/skill-packs/workflow-authoring/`, asserts the goldens still
+//! validate / preview / run with a stable graph digest, and checks each
+//! case's structural assertions against its golden bundle. This is the
+//! "validator catches drift in generated Harn" gate from issue #1412 —
+//! adding a new case automatically extends CI coverage.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn binary_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_harn"))
+}
+
+fn skill_pack_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../examples/skill-packs/workflow-authoring")
+}
+
+fn run_harn(args: &[&str]) -> std::process::Output {
+    Command::new(binary_path())
+        .args(args)
+        .output()
+        .expect("spawn harn")
+}
+
+fn stdout_json(output: &std::process::Output) -> serde_json::Value {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(stdout.trim()).unwrap_or_else(|error| {
+        panic!("stdout is not JSON: {error}\nstdout:\n{stdout}");
+    })
+}
+
+fn read_json(path: &Path) -> serde_json::Value {
+    let text = std::fs::read_to_string(path)
+        .unwrap_or_else(|error| panic!("read {}: {error}", path.display()));
+    serde_json::from_str(&text).unwrap_or_else(|error| panic!("parse {}: {error}", path.display()))
+}
+
+fn list_files_with_suffix(dir: &Path, suffix: &str) -> Vec<PathBuf> {
+    let mut out: Vec<PathBuf> = std::fs::read_dir(dir)
+        .unwrap_or_else(|error| panic!("read {}: {error}", dir.display()))
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.is_file()
+                && path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.ends_with(suffix))
+        })
+        .collect();
+    out.sort();
+    out
+}
+
+fn list_recipe_bundles(root: &Path) -> Vec<PathBuf> {
+    let recipes = root.join("recipes");
+    let mut out: Vec<PathBuf> = std::fs::read_dir(&recipes)
+        .unwrap_or_else(|error| panic!("read {}: {error}", recipes.display()))
+        .filter_map(Result::ok)
+        .map(|entry| entry.path().join("bundle.json"))
+        .filter(|path| path.exists())
+        .collect();
+    out.sort();
+    out
+}
+
+#[test]
+fn skill_pack_recipes_validate_preview_and_run() {
+    let root = skill_pack_root();
+    let bundles = list_recipe_bundles(&root);
+    assert!(
+        !bundles.is_empty(),
+        "no recipe bundles found under {}",
+        root.display()
+    );
+
+    for bundle in &bundles {
+        let bundle_arg = bundle.to_str().expect("bundle path is UTF-8");
+
+        let validate = run_harn(&["workflow", "validate", "--bundle", bundle_arg, "--json"]);
+        assert!(
+            validate.status.success(),
+            "validate failed for {}\nstderr: {}",
+            bundle.display(),
+            String::from_utf8_lossy(&validate.stderr)
+        );
+        let validation = stdout_json(&validate);
+        assert_eq!(
+            validation["valid"],
+            serde_json::json!(true),
+            "{} did not validate: {}",
+            bundle.display(),
+            validation
+        );
+        let digest = validation["graph_digest"].as_str().unwrap_or_default();
+        assert!(
+            digest.starts_with("sha256:"),
+            "{} graph_digest missing: {validation}",
+            bundle.display()
+        );
+
+        let preview = run_harn(&["workflow", "preview", "--bundle", bundle_arg, "--json"]);
+        assert!(
+            preview.status.success(),
+            "preview failed for {}\nstderr: {}",
+            bundle.display(),
+            String::from_utf8_lossy(&preview.stderr)
+        );
+        let preview_json = stdout_json(&preview);
+        assert_eq!(preview_json["validation"]["graph_digest"], digest);
+
+        let run = run_harn(&["workflow", "run", "--bundle", bundle_arg, "--json"]);
+        assert!(
+            run.status.success(),
+            "run failed for {}\nstderr: {}",
+            bundle.display(),
+            String::from_utf8_lossy(&run.stderr)
+        );
+        let receipt = stdout_json(&run);
+        assert_eq!(receipt["receipt_type"], "harn.workflow_bundle.run");
+        assert_eq!(receipt["status"], "completed");
+    }
+}
+
+#[test]
+fn skill_pack_cases_match_their_goldens() {
+    let root = skill_pack_root();
+    let cases_dir = root.join("cases");
+    let cases = list_files_with_suffix(&cases_dir, ".case.json");
+    assert!(
+        !cases.is_empty(),
+        "no eval cases found under {}",
+        cases_dir.display()
+    );
+
+    for case_path in &cases {
+        let case = read_json(case_path);
+        let case_id = case["id"]
+            .as_str()
+            .unwrap_or_else(|| panic!("{} missing id", case_path.display()));
+        let golden_rel = case["golden_bundle_path"]
+            .as_str()
+            .unwrap_or_else(|| panic!("{} missing golden_bundle_path", case_path.display()));
+
+        let golden = case_path
+            .parent()
+            .expect("case has parent dir")
+            .join(golden_rel);
+        assert!(
+            golden.exists(),
+            "case {case_id}: golden {} does not exist",
+            golden.display()
+        );
+
+        let bundle = read_json(&golden);
+        let want = case["structural_assertions"]
+            .as_object()
+            .unwrap_or_else(|| panic!("case {case_id}: structural_assertions must be object"));
+
+        for (key, expected) in want {
+            let failure = match key.as_str() {
+                "bundle_id" => mismatch(case_id, "id", &bundle["id"], expected),
+                "workflow_id" => {
+                    mismatch(case_id, "workflow.id", &bundle["workflow"]["id"], expected)
+                }
+                "entry" => mismatch(
+                    case_id,
+                    "workflow.entry",
+                    &bundle["workflow"]["entry"],
+                    expected,
+                ),
+                "autonomy_tier" => mismatch(
+                    case_id,
+                    "policy.autonomy_tier",
+                    &bundle["policy"]["autonomy_tier"],
+                    expected,
+                ),
+                "retry_backoff" => mismatch(
+                    case_id,
+                    "policy.retry.backoff",
+                    &bundle["policy"]["retry"]["backoff"],
+                    expected,
+                ),
+                "catchup_mode" => mismatch(
+                    case_id,
+                    "policy.catchup.mode",
+                    &bundle["policy"]["catchup"]["mode"],
+                    expected,
+                ),
+                "required_worktree_policy" => mismatch(
+                    case_id,
+                    "environment.worktree_policy",
+                    &bundle["environment"]["worktree_policy"],
+                    expected,
+                ),
+                "required_node_ids" => members_present(
+                    case_id,
+                    "workflow.nodes",
+                    expected,
+                    bundle["workflow"]["nodes"]
+                        .as_object()
+                        .map(|map| map.keys().cloned().collect::<Vec<_>>())
+                        .unwrap_or_default(),
+                ),
+                "required_trigger_kinds" => members_present(
+                    case_id,
+                    "triggers[].kind",
+                    expected,
+                    project_strings(&bundle["triggers"], "kind"),
+                ),
+                "required_connector_ids" => members_present(
+                    case_id,
+                    "connectors[].id",
+                    expected,
+                    project_strings(&bundle["connectors"], "id"),
+                ),
+                "required_approval_nodes" => members_present(
+                    case_id,
+                    "policy.approval_required",
+                    expected,
+                    bundle["policy"]["approval_required"]
+                        .as_array()
+                        .map(|items| {
+                            items
+                                .iter()
+                                .filter_map(|v| v.as_str().map(String::from))
+                                .collect()
+                        })
+                        .unwrap_or_default(),
+                ),
+                other => panic!("case {case_id}: unknown structural assertion `{other}`"),
+            };
+            if let Some(message) = failure {
+                panic!("{message}");
+            }
+        }
+    }
+}
+
+fn mismatch(
+    case_id: &str,
+    field: &str,
+    actual: &serde_json::Value,
+    expected: &serde_json::Value,
+) -> Option<String> {
+    if actual == expected {
+        None
+    } else {
+        Some(format!(
+            "case {case_id}: {field} mismatch — expected {expected}, got {actual}"
+        ))
+    }
+}
+
+fn members_present(
+    case_id: &str,
+    field: &str,
+    expected: &serde_json::Value,
+    actual: Vec<String>,
+) -> Option<String> {
+    let required = expected
+        .as_array()
+        .unwrap_or_else(|| panic!("case {case_id}: {field} expected list"));
+    let missing: Vec<String> = required
+        .iter()
+        .filter_map(|value| value.as_str().map(String::from))
+        .filter(|item| !actual.contains(item))
+        .collect();
+    if missing.is_empty() {
+        None
+    } else {
+        Some(format!(
+            "case {case_id}: {field} missing required members {missing:?} (have {actual:?})"
+        ))
+    }
+}
+
+fn project_strings(items: &serde_json::Value, field: &str) -> Vec<String> {
+    items
+        .as_array()
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(|value| value[field].as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default()
+}

--- a/docs/src/workflow-bundles.md
+++ b/docs/src/workflow-bundles.md
@@ -101,3 +101,44 @@ harn workflow run \
 The same bundle and replayed event produce the same receipt bytes, which lets
 Burin compare local executions and later cloud imports against one stable
 artifact.
+
+## Authoring skill pack
+
+The `examples/skill-packs/workflow-authoring/` directory ships a Harn skill
+pack that teaches an agent (including 4–8B local models such as qwen, gemma,
+or llama.cpp) how to author bundles that pass `harn workflow validate`. It
+contains:
+
+- `SKILL.md` — a Claude Code / Agent Skills compatible card the model loads
+  before responding.
+- `prompting.md` — explicit XML output envelope (`<bundle>`, `<rationale>`,
+  `<verify>`), a hard-rule checklist that mirrors the validator, and a
+  validation-and-retry loop.
+- `recipes/{pr-monitor,pr-repair}/bundle.json` — validated golden bundles for
+  the two steel-thread workflows from the parent epic.
+- `cases/*.case.json` — eval cases pinning each prompt to its golden bundle
+  and a list of structural assertions (entry node id, required trigger kinds,
+  required approval nodes, etc.).
+- `eval.harn` — a Harn driver that feeds a case to any provider/model,
+  extracts the `<bundle>` block, runs the validate → preview → run pipeline,
+  and emits a JSON report.
+
+Run the offline eval (no network — replays the golden):
+
+```bash
+harn run examples/skill-packs/workflow-authoring/eval.harn -- \
+  --case examples/skill-packs/workflow-authoring/cases/pr-monitor.case.json
+```
+
+Run a live eval against any provider / model (point `HARN_BIN` at the binary
+under test if it is not on `PATH`):
+
+```bash
+harn run examples/skill-packs/workflow-authoring/eval.harn -- \
+  --case examples/skill-packs/workflow-authoring/cases/pr-monitor.case.json \
+  --provider ollama --model qwen3:4b
+```
+
+`crates/harn-cli/tests/workflow_authoring_eval.rs` is the CI regression gate.
+It validates every recipe golden and every case's structural assertions, so a
+new case automatically extends the gate.

--- a/examples/skill-packs/README.md
+++ b/examples/skill-packs/README.md
@@ -1,0 +1,22 @@
+# Skill packs
+
+This directory hosts curated skill packs — bundled `SKILL.md` cards, prompts,
+recipes, and eval drivers — that an agent can load to author Harn artifacts
+correctly on the first try.
+
+Each subdirectory is self-contained and follows the Anthropic / Claude-Code
+Agent Skills frontmatter format. A pack typically ships:
+
+- `SKILL.md` — the model-loadable skill card.
+- `prompting.md` — output envelope and small-model rules.
+- `recipes/<name>/` — validated worked examples.
+- `cases/*.case.json` — eval cases with structural assertions.
+- `eval.harn` — a Harn driver for live evals against any provider/model.
+
+Packs are paired with Rust regression gates under `crates/harn-cli/tests/`
+that load the recipes/cases and assert they still pass the relevant
+validation pipeline.
+
+| Pack | Purpose |
+|---|---|
+| `workflow-authoring/` | Author portable Harn workflow bundles for PR monitoring, repair, and similar engineering automations. |

--- a/examples/skill-packs/workflow-authoring/SKILL.md
+++ b/examples/skill-packs/workflow-authoring/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: workflow-authoring
+short: Author Harn portable workflow bundles for day-to-day engineering automations.
+description: |
+  Generate, validate, preview, and run portable Harn workflow bundle JSON for
+  monitoring and repairing pull requests, deploys, logs, and other event-driven
+  engineering work. Optimized for smaller models (qwen, gemma, llama.cpp) with
+  explicit XML sections, strict JSON output, and a validation-and-retry loop.
+when-to-use: |
+  Use when the user asks for a durable engineering automation expressed as a
+  Harn workflow bundle: monitor this PR, wait for deploy then query logs,
+  repair failing checks, schedule a recurring health probe, or import a
+  workflow into Burin / a host. Pair with the workflow CLI: `harn workflow
+  validate|preview|run --bundle <path> --json`.
+allowed_tools:
+  - "Bash(harn workflow validate:*)"
+  - "Bash(harn workflow preview:*)"
+  - "Bash(harn workflow run:*)"
+  - "Bash(harn check:*)"
+  - "Read"
+  - "Write"
+  - "Edit"
+---
+
+# Workflow authoring (Harn workflow bundles)
+
+You are authoring a **portable workflow bundle** — a JSON file Harn validates,
+previews, and runs locally. Hosts (Burin TUI/GUI, Harn Cloud importers) consume
+the same bundle without rewriting.
+
+Read **`prompting.md`** in this directory before composing a response. It
+defines the response sections, JSON envelope, and small-model rules. Every
+recipe under `recipes/` is a worked, validated example you can crib from.
+
+## What good output looks like
+
+1. A single `<bundle>` block containing valid JSON for a `WorkflowBundle`.
+2. A short `<rationale>` block (≤ 5 bullets) explaining the trigger, the
+   waitpoints, and the connector requirements.
+3. A `<verify>` block listing the exact commands the user should run:
+
+   ```bash
+   harn workflow validate --bundle out.bundle.json --json
+   harn workflow preview  --bundle out.bundle.json --json
+   harn workflow run      --bundle out.bundle.json --json
+   ```
+
+If validation fails, **read the diagnostic, edit the bundle, and re-validate**.
+Do not invent fields or kinds — the validator's enum lists are the source of
+truth.
+
+## Bundle skeleton
+
+```json
+{
+  "schema_version": 1,
+  "id": "<kebab-case-id>",
+  "name": "<human label>",
+  "version": "1.0.0",
+  "triggers": [
+    { "id": "<trigger-id>", "kind": "github|cron|delay|webhook|mcp|manual",
+      "provider": "github", "events": ["pull_request.opened"],
+      "node_id": "<entry-node-id>" }
+  ],
+  "workflow": {
+    "_type": "workflow_graph",
+    "id": "<graph-id>",
+    "version": 1,
+    "entry": "<entry-node-id>",
+    "nodes": {
+      "<node-id>": { "id": "<node-id>", "kind": "action|waitpoint|notification",
+                     "task_label": "<short label>" }
+    },
+    "edges": [ { "from": "<from-node-id>", "to": "<to-node-id>" } ]
+  },
+  "prompt_capsules": {
+    "<capsule-id>": { "id": "<capsule-id>", "node_id": "<node-id>",
+                      "trigger_id": "<trigger-id>",
+                      "prompt": "<self-contained continuation prompt>" }
+  },
+  "policy": {
+    "autonomy_tier": "shadow|suggest|act_with_approval|act_auto",
+    "retry":   { "max_attempts": 2, "backoff": "exponential" },
+    "catchup": { "mode": "none|latest|all", "max_events": 1 }
+  },
+  "connectors": [
+    { "id": "github", "provider_id": "github",
+      "scopes": ["pull_requests:read", "checks:read"],
+      "setup_required": true, "status_required": true }
+  ],
+  "environment": {
+    "repo_setup_profile": "default",
+    "worktree_policy": "reuse_current|new_worktree|host_managed",
+    "command_gates": ["make test"]
+  }
+}
+```
+
+## Hard rules (validator enforces)
+
+- `schema_version` must be `1`.
+- `id`, `version`, `workflow.id`, `workflow.entry` are non-empty.
+- Every `workflow.nodes[k].id` matches its map key `k`.
+- Every edge endpoint and `trigger.node_id` references an existing node.
+- `policy.autonomy_tier` ∈ `{shadow, suggest, act_with_approval, act_auto}`.
+- `policy.catchup.mode` ∈ `{none, latest, all}`.
+- `policy.retry.max_attempts >= 1`.
+- `environment.worktree_policy` ∈ `{reuse_current, new_worktree, host_managed}`.
+- Trigger kind requirements:
+  - `github` → `provider: "github"` and at least one `events[]`.
+  - `cron` → `schedule`.
+  - `delay` → `delay` (ISO-8601 duration, e.g. `PT10M`).
+  - `webhook` → `webhook_path`.
+  - `mcp` → `mcp_tool`.
+  - `manual` → no extra fields.
+- Every `prompt_capsules[k].id` equals `k` and points at a real node; at most
+  one capsule per node.
+- Every connector that a trigger references via `provider` should appear in
+  `connectors[]` (warning otherwise).
+
+## Node kinds (host vocabulary)
+
+| Kind | Use it for | Notes |
+|---|---|---|
+| `action` | Concrete work (normalize event, query API, run a command). | Default. |
+| `waitpoint` | Pause until an event/delay/approval resumes the workflow. | Pair with a `delay` or matching trigger. |
+| `notification` | Send a user-facing message. | Surface via host UX. |
+| `agent` / `subagent` | Agent-loop stages and delegated workers. | Map to `kind: "agent" \| "subagent"`. |
+| `approval` | HITL gate. | Validator categorizes `approval`/`hitl`. |
+| `connector_call` | Outbound connector method. | Validator categorizes `connector` / `connector_call`. |
+| `terminal` | Explicit success/failure sink. | Optional. |
+
+Anything else is treated as a free-form node kind and rendered as-is — prefer
+the canonical list above.
+
+## Recipes
+
+| Recipe | What it shows |
+|---|---|
+| `recipes/pr-monitor/bundle.json` | GitHub PR open/sync trigger → wait for deploy → log query → notify, with retry+catchup policy and `act_with_approval`. |
+| `recipes/pr-repair/bundle.json` | Periodic + GitHub-failure dual trigger → worktree setup → repair agent stage → approval gate → notify, with autonomous repair policy. |
+
+Run any recipe end-to-end:
+
+```bash
+harn workflow validate --bundle examples/skill-packs/workflow-authoring/recipes/pr-monitor/bundle.json --json
+harn workflow preview  --bundle examples/skill-packs/workflow-authoring/recipes/pr-monitor/bundle.json --mermaid
+harn workflow run      --bundle examples/skill-packs/workflow-authoring/recipes/pr-monitor/bundle.json --json
+```
+
+## Eval harness
+
+`eval.harn` is the local-model authoring eval. Point it at any case in
+`cases/` and any provider/model:
+
+```bash
+harn run examples/skill-packs/workflow-authoring/eval.harn -- \
+  --case cases/pr-monitor.case.json \
+  --provider ollama --model qwen3:4b
+```
+
+The script feeds the case prompts to the model, extracts the `<bundle>` block,
+runs the validate → preview → run pipeline, and prints a JSON report with
+`{validation_passed, preview_passed, run_passed, structural_assertions, ...}`.
+
+`cases/*.golden_bundle` is the canonical expected bundle. The Rust regression
+gate (`crates/harn-cli/tests/workflow_authoring_eval.rs`) loads every case +
+recipe, asserts the goldens validate / preview / run, and asserts the
+structural assertions hold. Add a case → CI catches drift.
+
+## Pointers
+
+- Bundle contract: [`docs/src/workflow-bundles.md`](../../../docs/src/workflow-bundles.md)
+- Trigger / connector providers: [`docs/llm/harn-triggers-quickref.md`](../../../docs/llm/harn-triggers-quickref.md)
+- Supervisor commands: [`docs/src/workflow-supervisor.md`](../../../docs/src/workflow-supervisor.md)
+- Validator source of truth: [`crates/harn-vm/src/orchestration/workflow_bundle.rs`](../../../crates/harn-vm/src/orchestration/workflow_bundle.rs)

--- a/examples/skill-packs/workflow-authoring/cases/pr-monitor.case.json
+++ b/examples/skill-packs/workflow-authoring/cases/pr-monitor.case.json
@@ -1,0 +1,18 @@
+{
+  "id": "pr-monitor",
+  "title": "Author a PR monitor workflow bundle",
+  "system_prompt": "You are authoring a portable Harn workflow bundle. Read the rules in examples/skill-packs/workflow-authoring/prompting.md. Return three blocks in order: <bundle>...</bundle> with valid WorkflowBundle JSON (schema_version: 1), <rationale>...</rationale> with up to 5 bullets, and <verify>...</verify> with the validate/preview/run commands.",
+  "user_prompt": "Create a workflow bundle for monitoring a GitHub pull request:\n- Trigger on pull_request.opened and pull_request.synchronize.\n- After a 10 minute delay, query deploy logs and summarize failures.\n- Notify the requester at the end.\n- Use act_with_approval autonomy and exponential retry.\n- Require the github connector with pull_requests:read and checks:read.\n- Identify the bundle as id=\"pr-monitor\", workflow id \"pr_monitor_workflow\", entry node \"ingest\".",
+  "structural_assertions": {
+    "bundle_id": "pr-monitor",
+    "workflow_id": "pr_monitor_workflow",
+    "entry": "ingest",
+    "required_node_ids": ["ingest", "wait_for_deploy", "query_logs", "notify"],
+    "required_trigger_kinds": ["github", "delay"],
+    "required_connector_ids": ["github"],
+    "autonomy_tier": "act_with_approval",
+    "retry_backoff": "exponential",
+    "catchup_mode": "latest"
+  },
+  "golden_bundle_path": "../recipes/pr-monitor/bundle.json"
+}

--- a/examples/skill-packs/workflow-authoring/cases/pr-repair.case.json
+++ b/examples/skill-packs/workflow-authoring/cases/pr-repair.case.json
@@ -1,0 +1,28 @@
+{
+  "id": "pr-repair",
+  "title": "Author a PR repair workflow bundle",
+  "system_prompt": "You are authoring a portable Harn workflow bundle. Read the rules in examples/skill-packs/workflow-authoring/prompting.md. Return three blocks in order: <bundle>...</bundle> with valid WorkflowBundle JSON (schema_version: 1), <rationale>...</rationale> with up to 5 bullets, and <verify>...</verify> with the validate/preview/run commands.",
+  "user_prompt": "Create a workflow bundle for monitoring and repairing a feature pull request:\n- Trigger on github check_suite.completed and pull_request.synchronize, plus an hourly cron sweep.\n- Workflow: ingest -> open_worktree -> repo_setup -> repair_loop (agent stage) -> verify -> approval -> notify.\n- Add a prompt capsule for the repair_loop node.\n- Autonomy act_with_approval; require approval on repair_loop and verify; exponential retry up to 3 attempts; latest catchup.\n- Require the github connector with pull_requests:read, pull_requests:write, checks:read, contents:write.\n- Use a new worktree; gate make test and make lint.\n- Identify bundle id=\"pr-repair\", workflow id \"pr_repair_workflow\", entry node \"ingest\".",
+  "structural_assertions": {
+    "bundle_id": "pr-repair",
+    "workflow_id": "pr_repair_workflow",
+    "entry": "ingest",
+    "required_node_ids": [
+      "ingest",
+      "open_worktree",
+      "repo_setup",
+      "repair_loop",
+      "verify",
+      "approval",
+      "notify"
+    ],
+    "required_trigger_kinds": ["github", "cron"],
+    "required_connector_ids": ["github"],
+    "autonomy_tier": "act_with_approval",
+    "retry_backoff": "exponential",
+    "catchup_mode": "latest",
+    "required_approval_nodes": ["repair_loop", "verify"],
+    "required_worktree_policy": "new_worktree"
+  },
+  "golden_bundle_path": "../recipes/pr-repair/bundle.json"
+}

--- a/examples/skill-packs/workflow-authoring/eval.harn
+++ b/examples/skill-packs/workflow-authoring/eval.harn
@@ -1,0 +1,215 @@
+/**
+ * Live workflow-authoring eval driver.
+ *
+ * Examples:
+ *
+ *   # Offline (replays the case's golden bundle, no network):
+ *   harn run examples/skill-packs/workflow-authoring/eval.harn -- \
+ *     --case examples/skill-packs/workflow-authoring/cases/pr-monitor.case.json
+ *
+ *   # Live, against a local Ollama model:
+ *   harn run examples/skill-packs/workflow-authoring/eval.harn -- \
+ *     --case examples/skill-packs/workflow-authoring/cases/pr-monitor.case.json \
+ *     --provider ollama --model qwen3:4b
+ *
+ * Always prints a JSON report on stdout. Exits 0 when the produced bundle
+ * validates, previews, runs, and meets every structural assertion in the
+ * case; non-zero otherwise.
+ */
+pipeline default() {
+  let opts = parse_argv(argv)
+  if opts.case == "" {
+    eprint(
+      "usage: harn run eval.harn -- --case <path> [--provider <id>] [--model <name>] [--tmp <dir>]\n",
+    )
+    return 2
+  }
+  let case = json_parse(read_file(opts.case))
+  let case_dir = dirname(opts.case)
+  let golden_path = case_dir + "/" + case.golden_bundle_path
+  let golden_text = read_file(golden_path)
+  var bundle_text = ""
+  if opts.provider == "fake" {
+    bundle_text = golden_text
+  } else {
+    let opts_dict = {provider: opts.provider, model: opts.model, temperature: 0.0, max_tokens: 4000}
+    let response = llm_call(case.user_prompt, case.system_prompt, opts_dict)
+    bundle_text = extract_block(response.text, "bundle")
+    if bundle_text == "" {
+      eprint("eval: model response missing <bundle>...</bundle>\n")
+      return 3
+    }
+  }
+  exec("mkdir", "-p", opts.tmp)
+  let bundle_path = opts.tmp + "/" + case.id + ".bundle.json"
+  write_file(bundle_path, bundle_text)
+  let harn_bin = opts.harn_bin
+  let validate = exec(harn_bin, "workflow", "validate", "--bundle", bundle_path, "--json")
+  let preview = exec(harn_bin, "workflow", "preview", "--bundle", bundle_path, "--json")
+  let runres = exec(harn_bin, "workflow", "run", "--bundle", bundle_path, "--json")
+  let validate_ok = validate.success
+  let preview_ok = preview.success
+  let run_ok = runres.success
+  let assertions = if validate_ok {
+    check_structural_assertions(json_parse(bundle_text), case.structural_assertions)
+  } else {
+    {ok: false, failures: ["bundle did not validate; skipping structural assertions"]}
+  }
+  let report = {
+    case_id: case.id,
+    provider: opts.provider,
+    model: opts.model,
+    bundle_path: bundle_path,
+    validation_passed: validate_ok,
+    preview_passed: preview_ok,
+    run_passed: run_ok,
+    structural_assertions: assertions,
+    validate_stdout: validate.stdout,
+    validate_stderr: validate.stderr,
+  }
+  print(json_stringify(report))
+  print("\n")
+  if validate_ok && preview_ok && run_ok && assertions.ok {
+    return 0
+  }
+  return 1
+}
+
+fn parse_argv(args: list<string>) -> dict {
+  var opts = {
+    case: "",
+    provider: "fake",
+    model: "fake-model",
+    tmp: ".harn-runs/workflow-authoring-eval",
+    harn_bin: env_or("HARN_BIN", "harn"),
+  }
+  var i = 0
+  while i < len(args) {
+    let flag = args[i]
+    let value = if i + 1 < len(args) {
+      args[i + 1]
+    } else {
+      ""
+    }
+    if flag == "--case" {
+      opts.case = value
+      i = i + 2
+    } else if flag == "--provider" {
+      opts.provider = value
+      i = i + 2
+    } else if flag == "--model" {
+      opts.model = value
+      i = i + 2
+    } else if flag == "--tmp" {
+      opts.tmp = value
+      i = i + 2
+    } else if flag == "--harn-bin" {
+      opts.harn_bin = value
+      i = i + 2
+    } else {
+      i = i + 1
+    }
+  }
+  return opts
+}
+
+fn extract_block(text: string, tag: string) -> string {
+  let open = "<" + tag + ">"
+  let close = "</" + tag + ">"
+  let after_open = split(text, open)
+  if len(after_open) < 2 {
+    return ""
+  }
+  let body = split(after_open[1], close)
+  if len(body) < 2 {
+    return ""
+  }
+  return trim(body[0])
+}
+
+fn check_structural_assertions(bundle: dict, want: dict) -> dict {
+  let scalar_failures = check_scalar_fields(bundle, want)
+  let collection_failures = check_collection_fields(bundle, want)
+  let failures = scalar_failures + collection_failures
+  return {ok: len(failures) == 0, failures: failures}
+}
+
+fn check_scalar_fields(bundle: dict, want: dict) -> list<string> {
+  let want_keys = keys(want)
+  var out = []
+  if contains(want_keys, "bundle_id") && bundle.id != want.bundle_id {
+    out = out + ["bundle.id != " + want.bundle_id]
+  }
+  if contains(want_keys, "workflow_id") && bundle.workflow.id != want.workflow_id {
+    out = out + ["workflow.id != " + want.workflow_id]
+  }
+  if contains(want_keys, "entry") && bundle.workflow.entry != want.entry {
+    out = out + ["workflow.entry != " + want.entry]
+  }
+  if contains(want_keys, "autonomy_tier") && bundle.policy.autonomy_tier != want.autonomy_tier {
+    out = out + ["policy.autonomy_tier != " + want.autonomy_tier]
+  }
+  if contains(want_keys, "retry_backoff") && bundle.policy.retry.backoff != want.retry_backoff {
+    out = out + ["policy.retry.backoff != " + want.retry_backoff]
+  }
+  if contains(want_keys, "catchup_mode") && bundle.policy.catchup.mode != want.catchup_mode {
+    out = out + ["policy.catchup.mode != " + want.catchup_mode]
+  }
+  if contains(want_keys, "required_worktree_policy")
+    && bundle.environment.worktree_policy != want.required_worktree_policy {
+    out = out + ["environment.worktree_policy != " + want.required_worktree_policy]
+  }
+  return out
+}
+
+fn check_collection_fields(bundle: dict, want: dict) -> list<string> {
+  let want_keys = keys(want)
+  var out = []
+  if contains(want_keys, "required_node_ids") {
+    out = out
+      + missing_members(want.required_node_ids, keys(bundle.workflow.nodes), "workflow.nodes missing ")
+  }
+  if contains(want_keys, "required_trigger_kinds") {
+    out = out
+      + missing_members(
+      want.required_trigger_kinds,
+      project(bundle.triggers, "kind"),
+      "triggers missing kind ",
+    )
+  }
+  if contains(want_keys, "required_connector_ids") {
+    out = out
+      + missing_members(
+      want.required_connector_ids,
+      project(bundle.connectors, "id"),
+      "connectors missing ",
+    )
+  }
+  if contains(want_keys, "required_approval_nodes") {
+    out = out
+      + missing_members(
+      want.required_approval_nodes,
+      bundle.policy.approval_required,
+      "policy.approval_required missing ",
+    )
+  }
+  return out
+}
+
+fn project(items: list<dict>, field: string) -> list<string> {
+  var out = []
+  for item in items {
+    out = out + [item[field]]
+  }
+  return out
+}
+
+fn missing_members(required: list<string>, present: list<string>, prefix: string) -> list<string> {
+  var out = []
+  for item in required {
+    if !contains(present, item) {
+      out = out + [prefix + item]
+    }
+  }
+  return out
+}

--- a/examples/skill-packs/workflow-authoring/prompting.md
+++ b/examples/skill-packs/workflow-authoring/prompting.md
@@ -1,0 +1,110 @@
+# Workflow-authoring prompting (small-model rules)
+
+This guide is consumed both by humans and by the eval harness. It pins down
+the response shape so a 4–8B local model (qwen, gemma, llama.cpp) can hit the
+validator's enum lists on the first try.
+
+## Output envelope
+
+The model **MUST** return three sections, in this order, each wrapped in a
+single XML-style tag with no surrounding prose. The harness strips everything
+outside these tags before validating.
+
+```text
+<bundle>
+{ ... valid WorkflowBundle JSON ... }
+</bundle>
+
+<rationale>
+- one bullet per design choice
+- ≤ 5 bullets, plain prose, no markdown beyond `-`
+</rationale>
+
+<verify>
+harn workflow validate --bundle out.bundle.json --json
+harn workflow preview  --bundle out.bundle.json --json
+harn workflow run      --bundle out.bundle.json --json
+</verify>
+```
+
+The `<bundle>` block is the **single source of truth**. The other two blocks
+are advisory; the validator never reads them.
+
+## Hard rules for the JSON
+
+These rules collapse the validator's surface area into a checklist. Keep the
+list in front of the model when prompting.
+
+1. `schema_version` is the integer `1`.
+2. Every `id` field is non-empty kebab-case ASCII.
+3. `workflow._type` is `"workflow_graph"` (literal).
+4. `workflow.entry` references a key in `workflow.nodes`.
+5. Every key `k` in `workflow.nodes` matches `workflow.nodes[k].id`.
+6. Every `workflow.edges[].from` and `.to` references a node key.
+7. Every `triggers[].node_id` (when set) references a node key.
+8. Trigger kind ∈ `{github, cron, delay, webhook, mcp, manual}`.
+   - `github` requires `provider: "github"` and ≥ 1 `events`.
+   - `cron` requires `schedule` (5-field cron expression).
+   - `delay` requires `delay` as an ISO-8601 duration (`PT10M`, `PT1H`).
+   - `webhook` requires `webhook_path` (string starting with `/`).
+   - `mcp` requires `mcp_tool` (string).
+   - `manual` requires no extra fields.
+9. `policy.autonomy_tier` ∈ `{shadow, suggest, act_with_approval, act_auto}`.
+10. `policy.retry.max_attempts` ≥ 1; `backoff` is one of
+    `{none, fixed, exponential}`.
+11. `policy.catchup.mode` ∈ `{none, latest, all}`.
+12. `environment.worktree_policy` ∈ `{reuse_current, new_worktree, host_managed}`.
+13. Every `prompt_capsules[k].id == k` and points at a real node.
+    At most one capsule per node.
+14. Every connector that a trigger references via `provider` appears in
+    `connectors[]` (otherwise the validator emits a warning).
+15. Do not invent fields. Unknown top-level fields stay in `metadata`.
+
+## Anti-patterns (small models fall into these)
+
+- **Inventing trigger kinds** (`pull_request`, `schedule`). Use exactly the
+  six kinds in rule 8.
+- **String autonomy tiers in PascalCase / TitleCase.** They are snake_case.
+- **`max_attempts: 0`.** Always ≥ 1.
+- **Mixing capsule keys and ids** (`{ "review": { "id": "review-pr", ... } }`).
+  Keys and ids must match.
+- **Forgetting `_type: "workflow_graph"`.** It is required for parser
+  compatibility with normalized graphs.
+- **Embedding markdown fences inside `<bundle>`.** The block must be raw
+  JSON only.
+
+## Validation-and-retry loop (the harness implements this)
+
+```text
+1. Send the system + user prompt.
+2. Extract <bundle>...</bundle>.
+3. Parse JSON; if it fails, return parse error to the model and retry once.
+4. Run `harn workflow validate --bundle <tmp> --json`.
+5. If invalid, return the diagnostics list to the model and retry once.
+6. Run `harn workflow preview --bundle <tmp> --json` to confirm graph health.
+7. Run `harn workflow run --bundle <tmp> --json` for a deterministic receipt.
+```
+
+Cap the retry count at 1 — a model that misses three of the rules above is
+not reliably authoring this contract and the harness should fail the case.
+
+## System-prompt skeleton
+
+A working system prompt the eval harness uses by default:
+
+```text
+You are authoring a portable Harn workflow bundle. You MUST return
+<bundle>, <rationale>, and <verify> blocks exactly as defined in
+examples/skill-packs/workflow-authoring/prompting.md.
+
+The <bundle> block contains a single JSON document conforming to
+WorkflowBundle (schema_version: 1). Validate against the rules in
+that prompting guide. Use the recipes/ directory as concrete examples.
+```
+
+## Why XML, not Markdown fences
+
+XML-style tags are robust against the model accidentally closing a fenced
+code block early (a common qwen/gemma failure on long JSON). The harness's
+extractor is `r"<bundle>([\s\S]+?)</bundle>"` — a markdown fence inside the
+block is fine, but no nested `</bundle>` is allowed.

--- a/examples/skill-packs/workflow-authoring/recipes/pr-monitor/README.md
+++ b/examples/skill-packs/workflow-authoring/recipes/pr-monitor/README.md
@@ -1,0 +1,32 @@
+# Recipe: PR monitor
+
+Watch a pull request, wait for the deploy that follows the merge, query the
+deploy logs, and notify the requester. Steel-thread #1 from issue #1407.
+
+## Shape
+
+| Element | Value |
+|---|---|
+| Triggers | `github` on `pull_request.opened` + `pull_request.synchronize`; `delay` (`PT10M`) for the log check |
+| Workflow | `ingest` → `wait_for_deploy` → `query_logs` → `notify` |
+| Capsule | `query-logs` continues from the delay trigger with a self-contained prompt |
+| Policy | `act_with_approval`, exponential retry (2), `latest` catchup |
+| Connector | `github` (pull_requests:read, checks:read), setup + status required |
+| Environment | `host_managed` worktree, `make test` gate |
+
+## Run it
+
+```bash
+harn workflow validate --bundle examples/skill-packs/workflow-authoring/recipes/pr-monitor/bundle.json --json
+harn workflow preview  --bundle examples/skill-packs/workflow-authoring/recipes/pr-monitor/bundle.json --mermaid
+harn workflow run      --bundle examples/skill-packs/workflow-authoring/recipes/pr-monitor/bundle.json --json
+```
+
+## Why these choices
+
+- The `delay` trigger pinned to `query_logs` is what makes this a "wake later"
+  workflow — without it the host would have to invent its own scheduler.
+- `act_with_approval` keeps human-in-the-loop on the notify step until a host
+  is comfortable promoting the workflow to `act_auto`.
+- `catchup.mode = "latest"` means a long-paused supervisor only resumes the
+  most recent deploy event instead of replaying every past PR sync.

--- a/examples/skill-packs/workflow-authoring/recipes/pr-monitor/bundle.json
+++ b/examples/skill-packs/workflow-authoring/recipes/pr-monitor/bundle.json
@@ -1,0 +1,82 @@
+{
+  "schema_version": 1,
+  "id": "pr-monitor",
+  "name": "PR monitor",
+  "version": "1.0.0",
+  "triggers": [
+    {
+      "id": "github-pr-updated",
+      "kind": "github",
+      "provider": "github",
+      "events": ["pull_request.opened", "pull_request.synchronize"],
+      "node_id": "ingest"
+    },
+    {
+      "id": "delay-log-check",
+      "kind": "delay",
+      "delay": "PT10M",
+      "node_id": "query_logs"
+    }
+  ],
+  "workflow": {
+    "_type": "workflow_graph",
+    "id": "pr_monitor_workflow",
+    "name": "PR monitor",
+    "version": 1,
+    "entry": "ingest",
+    "nodes": {
+      "ingest": {
+        "id": "ingest",
+        "kind": "action",
+        "task_label": "Normalize PR event"
+      },
+      "wait_for_deploy": {
+        "id": "wait_for_deploy",
+        "kind": "waitpoint",
+        "task_label": "Wait for deploy to complete"
+      },
+      "query_logs": {
+        "id": "query_logs",
+        "kind": "action",
+        "task_label": "Query deploy logs and summarize failures"
+      },
+      "notify": {
+        "id": "notify",
+        "kind": "notification",
+        "task_label": "Notify the requester"
+      }
+    },
+    "edges": [
+      { "from": "ingest", "to": "wait_for_deploy" },
+      { "from": "wait_for_deploy", "to": "query_logs" },
+      { "from": "query_logs", "to": "notify" }
+    ]
+  },
+  "prompt_capsules": {
+    "query-logs": {
+      "id": "query-logs",
+      "node_id": "query_logs",
+      "trigger_id": "delay-log-check",
+      "prompt": "Query deploy logs for the pull request and summarize the top failures with file:line references."
+    }
+  },
+  "policy": {
+    "autonomy_tier": "act_with_approval",
+    "retry": { "max_attempts": 2, "backoff": "exponential" },
+    "catchup": { "mode": "latest", "max_events": 1 }
+  },
+  "connectors": [
+    {
+      "id": "github",
+      "provider_id": "github",
+      "scopes": ["pull_requests:read", "checks:read"],
+      "setup_required": true,
+      "status_required": true
+    }
+  ],
+  "environment": {
+    "repo_setup_profile": "default",
+    "worktree_policy": "host_managed",
+    "command_gates": ["make test"]
+  }
+}

--- a/examples/skill-packs/workflow-authoring/recipes/pr-repair/README.md
+++ b/examples/skill-packs/workflow-authoring/recipes/pr-repair/README.md
@@ -1,0 +1,35 @@
+# Recipe: PR repair
+
+Monitor a feature branch for failing checks and surface a deterministic
+repair attempt under HITL. Steel-thread #2 from issue #1407.
+
+## Shape
+
+| Element | Value |
+|---|---|
+| Triggers | `github` on `check_suite.completed` + `pull_request.synchronize`; `cron` (`0 * * * *`) safety net |
+| Workflow | `ingest` → `open_worktree` → `repo_setup` → `repair_loop` (agent) → `verify` → `approval` → `notify` |
+| Capsule | `repair-loop` ties the agent stage to the GitHub failure trigger |
+| Policy | `act_with_approval`, `approval_required: [repair_loop, verify]`, exponential retry (3), `latest` catchup |
+| Connector | `github` (PR + checks read/write, contents write), setup + status required |
+| Environment | `new_worktree`, gated by `make test` and `make lint` |
+
+## Run it
+
+```bash
+harn workflow validate --bundle examples/skill-packs/workflow-authoring/recipes/pr-repair/bundle.json --json
+harn workflow preview  --bundle examples/skill-packs/workflow-authoring/recipes/pr-repair/bundle.json --mermaid
+harn workflow run      --bundle examples/skill-packs/workflow-authoring/recipes/pr-repair/bundle.json --json
+```
+
+## Why these choices
+
+- Two triggers — GitHub events and an hourly cron sweep — give defense in
+  depth: the cron catches PRs whose webhook delivery dropped.
+- `worktree_policy: "new_worktree"` keeps the user's working tree clean while
+  the repair agent runs.
+- `approval_required` lists the exact node ids the host must escalate, even
+  under `act_with_approval`. This is what lets a host promote individual
+  steps to `act_auto` later without rewriting the bundle.
+- `make test` + `make lint` as gated commands ensure the verify stage runs
+  with the same checks a human would use locally.

--- a/examples/skill-packs/workflow-authoring/recipes/pr-repair/bundle.json
+++ b/examples/skill-packs/workflow-authoring/recipes/pr-repair/bundle.json
@@ -1,0 +1,106 @@
+{
+  "schema_version": 1,
+  "id": "pr-repair",
+  "name": "PR repair",
+  "version": "1.0.0",
+  "triggers": [
+    {
+      "id": "github-checks-failed",
+      "kind": "github",
+      "provider": "github",
+      "events": ["check_suite.completed", "pull_request.synchronize"],
+      "node_id": "ingest"
+    },
+    {
+      "id": "hourly-pr-sweep",
+      "kind": "cron",
+      "schedule": "0 * * * *",
+      "node_id": "ingest"
+    }
+  ],
+  "workflow": {
+    "_type": "workflow_graph",
+    "id": "pr_repair_workflow",
+    "name": "PR repair",
+    "version": 1,
+    "entry": "ingest",
+    "nodes": {
+      "ingest": {
+        "id": "ingest",
+        "kind": "action",
+        "task_label": "Classify failure surface (conflict, lint, test, build)"
+      },
+      "open_worktree": {
+        "id": "open_worktree",
+        "kind": "action",
+        "task_label": "Create or reuse a worktree on the PR branch"
+      },
+      "repo_setup": {
+        "id": "repo_setup",
+        "kind": "action",
+        "task_label": "Run deterministic repo setup"
+      },
+      "repair_loop": {
+        "id": "repair_loop",
+        "kind": "agent",
+        "task_label": "Run repair agent under capability policy"
+      },
+      "verify": {
+        "id": "verify",
+        "kind": "action",
+        "task_label": "Run gated commands and capture receipt"
+      },
+      "approval": {
+        "id": "approval",
+        "kind": "approval",
+        "task_label": "Surface diff + receipt for HITL approval"
+      },
+      "notify": {
+        "id": "notify",
+        "kind": "notification",
+        "task_label": "Notify requester with outcome"
+      }
+    },
+    "edges": [
+      { "from": "ingest", "to": "open_worktree" },
+      { "from": "open_worktree", "to": "repo_setup" },
+      { "from": "repo_setup", "to": "repair_loop" },
+      { "from": "repair_loop", "to": "verify" },
+      { "from": "verify", "to": "approval", "label": "fix proposed" },
+      { "from": "approval", "to": "notify" }
+    ]
+  },
+  "prompt_capsules": {
+    "repair-loop": {
+      "id": "repair-loop",
+      "node_id": "repair_loop",
+      "trigger_id": "github-checks-failed",
+      "prompt": "Repair the PR's failing checks. Make the smallest change that turns red checks green. Use the gated commands to verify. Stop and request approval if a change touches more than the affected files."
+    }
+  },
+  "policy": {
+    "autonomy_tier": "act_with_approval",
+    "approval_required": ["repair_loop", "verify"],
+    "retry": { "max_attempts": 3, "backoff": "exponential" },
+    "catchup": { "mode": "latest", "max_events": 1 }
+  },
+  "connectors": [
+    {
+      "id": "github",
+      "provider_id": "github",
+      "scopes": [
+        "pull_requests:read",
+        "pull_requests:write",
+        "checks:read",
+        "contents:write"
+      ],
+      "setup_required": true,
+      "status_required": true
+    }
+  ],
+  "environment": {
+    "repo_setup_profile": "default",
+    "worktree_policy": "new_worktree",
+    "command_gates": ["make test", "make lint"]
+  }
+}


### PR DESCRIPTION
## Summary
- Add `examples/skill-packs/workflow-authoring/` — a Claude Code / Anthropic Agent Skills compatible card, small-model prompting guide, validated PR-monitor and PR-repair recipe bundles, eval cases with structural assertions, and a Harn driver (`eval.harn`) that feeds a configurable provider through the `validate → preview → run` pipeline.
- Add `crates/harn-cli/tests/workflow_authoring_eval.rs` — regression gate that loads every recipe and case, asserts the goldens still validate / preview / run with stable graph digests, and that each case's structural assertions hold against its golden bundle. Adding a new case automatically extends CI coverage.
- Document the pack and the live + offline eval flows in `docs/src/workflow-bundles.md` and the changelog.

Closes #1412 and closes the `[workflow-driven] Local-first workflow automation substrate` epic #1407 — its other children (#1408, #1409, #1410, #1411) already landed.

## Verification
- `cargo run --bin harn -- workflow validate --bundle examples/skill-packs/workflow-authoring/recipes/{pr-monitor,pr-repair}/bundle.json --json` → both valid with stable `sha256:` graph digests.
- `cargo run --bin harn -- workflow preview --mermaid --bundle …/pr-repair/bundle.json` → rendered graph with triggers, connector binding, catchup/DLQ/terminal nodes.
- `HARN_BIN=$(pwd)/target/debug/harn cargo run --bin harn -- run examples/skill-packs/workflow-authoring/eval.harn -- --case examples/skill-packs/workflow-authoring/cases/pr-{monitor,repair}.case.json` → both pass `{validation_passed, preview_passed, run_passed, structural_assertions.ok}`.
- Live small-model eval: `… eval.harn -- --case …/cases/pr-monitor.case.json --provider ollama --model gemma4:26b` ran end-to-end against the local Ollama. The driver successfully extracted the `<bundle>` block, surfaced the validator's diagnostics for the model's first-pass output, and exited non-zero — exactly the failure mode the eval is designed to catch.
- `cargo test -p harn-cli --test workflow_cli --test workflow_authoring_eval` → 3 passed.
- `make test` → 3462 tests passed, 2 skipped.
- `make conformance` → 931 passed, 0 failed.
- `make lint-md` → 0 errors over 217 files.
- `make lint-test-patterns` → no wall-clock pattern violations.
- `make check-docs-snippets` → 493 checked, 124 skipped, 0 failed.
- `cargo run --bin harn -- check|lint|fmt --check examples/skill-packs/workflow-authoring/eval.harn` → ok / no issues / formatted.
- `git commit` (pre-commit: cargo fmt + workspace clippy + markdown lint) and `git push` (pre-push: workspace tests, markdown lint, harn lint/fmt, conformance fmt, changelog check) both clean.

## Test plan
- [ ] CI green on the PR
- [ ] Author a workflow with `gemma4:26b` (or `qwen3:4b`) via `eval.harn` and confirm the JSON report surfaces validator diagnostics when the model drifts from the prompting rules