### PR TITLE
Generalize unified clock to runtime back-offs and fix flake

### DIFF
--- a/crates/harn-cli/src/commands/dump_trigger_quickref.rs
+++ b/crates/harn-cli/src/commands/dump_trigger_quickref.rs
@@ -360,8 +360,37 @@ fn method_summary(provider: &ProviderMetadata) -> String {
 mod tests {
     use super::*;
 
-    #[test]
-    fn generated_quickref_contains_catalog_and_contract() {
+    use crate::package::lock_manifest_provider_schemas;
+
+    /// `collect_manifest_triggers` (in `package::extensions`) installs a
+    /// manifest-derived `ProviderCatalog` into the process-global
+    /// registry. Any test that reads the catalog has to take the same
+    /// `lock_manifest_provider_schemas()` lock those tests use, reset the
+    /// catalog while holding it, and reset again on drop. Otherwise the
+    /// regenerator picks up stray dynamic providers (like the `echo`
+    /// fixtures registered by package tests) and the snapshot diverges
+    /// from the committed file under workspace test ordering.
+    struct CatalogTestScope {
+        _guard: tokio::sync::MutexGuard<'static, ()>,
+    }
+
+    impl CatalogTestScope {
+        async fn new() -> Self {
+            let guard = lock_manifest_provider_schemas().await;
+            harn_vm::reset_provider_catalog();
+            Self { _guard: guard }
+        }
+    }
+
+    impl Drop for CatalogTestScope {
+        fn drop(&mut self) {
+            harn_vm::reset_provider_catalog();
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn generated_quickref_contains_catalog_and_contract() {
+        let _scope = CatalogTestScope::new().await;
         let out = generate_file();
         assert!(out.contains("| `github` | `webhook` | `GitHubEventPayload` | placeholder |"));
         assert!(out.contains("Connector Contract V1"));
@@ -370,8 +399,9 @@ mod tests {
         assert!(out.contains("harn-svn-connector"));
     }
 
-    #[test]
-    fn committed_trigger_quickref_matches_generator() {
+    #[tokio::test(flavor = "current_thread")]
+    async fn committed_trigger_quickref_matches_generator() {
+        let _scope = CatalogTestScope::new().await;
         let manifest_dir = env!("CARGO_MANIFEST_DIR");
         let path = std::path::Path::new(manifest_dir)
             .join("..")

--- a/crates/harn-vm/src/connectors/mod.rs
+++ b/crates/harn-vm/src/connectors/mod.rs
@@ -1635,7 +1635,11 @@ impl RateLimiterFactory {
                 }
                 bucket.wait_duration(self.config)
             };
-            tokio::time::sleep(wait).await;
+            // Honor the unified mock clock so tests that pin time via
+            // `mock_time(...)` don't deadlock here: the bucket reads
+            // `instant_now()` (mocked), and this sleep advances the same
+            // mock instead of waiting on a wall-clock that never moves.
+            clock::sleep(wait).await;
         }
     }
 }

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -66,7 +66,7 @@ pub mod trust_graph;
 pub mod clock_mock {
     pub use crate::triggers::test_util::clock::{
         active_mock_clock, advance, clear_overrides, install_override, instant_now, is_mocked,
-        now_ms, now_utc, ClockInstant, ClockOverrideGuard, MockClock,
+        now_ms, now_utc, sleep, ClockInstant, ClockOverrideGuard, MockClock,
     };
 }
 

--- a/crates/harn-vm/src/llm/agent_observe.rs
+++ b/crates/harn-vm/src/llm/agent_observe.rs
@@ -968,7 +968,7 @@ pub(crate) async fn observed_llm_call(
                     ),
                 );
                 if backoff > 0 {
-                    tokio::time::sleep(std::time::Duration::from_millis(backoff)).await;
+                    crate::clock_mock::sleep(std::time::Duration::from_millis(backoff)).await;
                 }
             }
         }

--- a/crates/harn-vm/src/llm/agent_tools.rs
+++ b/crates/harn-vm/src/llm/agent_tools.rs
@@ -329,7 +329,7 @@ pub(super) async fn dispatch_tool_execution_with_mcp(
             Err(_) if attempt < tool_retries => {
                 attempt += 1;
                 let delay = tool_backoff_ms * (1u64 << attempt.min(5));
-                tokio::time::sleep(tokio::time::Duration::from_millis(delay)).await;
+                crate::clock_mock::sleep(tokio::time::Duration::from_millis(delay)).await;
             }
             Err(_) => break ToolDispatchOutcome { result, executor },
         }

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -2106,7 +2106,7 @@ async fn with_rate_limit_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError>
                         attempt + 1
                     ),
                 );
-                tokio::time::sleep(std::time::Duration::from_millis(backoff_ms)).await;
+                crate::clock_mock::sleep(std::time::Duration::from_millis(backoff_ms)).await;
                 backoff_ms = backoff_ms.saturating_mul(2).min(30_000);
                 attempt += 1;
             }

--- a/crates/harn-vm/src/triggers/dispatcher/flow_control.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/flow_control.rs
@@ -7,7 +7,6 @@ use serde_json::json;
 use time::OffsetDateTime;
 use tokio::sync::{Mutex, Notify};
 
-use crate::connectors::cron::scheduler::Clock;
 use crate::event_log::{
     sanitize_topic_component, AnyEventLog, EventLog, LogError, LogEvent, Topic,
 };
@@ -94,7 +93,7 @@ impl FlowControlManager {
             json!({"gate": gate, "token": token}),
         )
         .await?;
-        sleep_duration(period).await;
+        clock::sleep(period).await;
         let latest = {
             let state = self.state.lock().await;
             state.debounce_latest.get(gate).copied()
@@ -178,7 +177,7 @@ impl FlowControlManager {
                         json!({"gate": gate, "delay_ms": delay.as_millis()}),
                     )
                     .await?;
-                    sleep_duration(delay).await;
+                    clock::sleep(delay).await;
                 }
                 None => {
                     self.append_event(
@@ -433,25 +432,12 @@ fn trim_window(hits: &mut VecDeque<OffsetDateTime>, now: OffsetDateTime, period:
     }
 }
 
-async fn sleep_duration(duration: Duration) {
-    if duration.is_zero() {
-        return;
-    }
-    if let Some(mock_clock) = clock::active_mock_clock() {
-        mock_clock
-            .sleep_until(clock::now_utc() + time::Duration::try_from(duration).unwrap_or_default())
-            .await;
-    } else {
-        tokio::time::sleep(duration).await;
-    }
-}
-
 async fn sleep_until(deadline: OffsetDateTime) {
     let now = clock::now_utc();
     if deadline <= now {
         return;
     }
     if let Ok(duration) = (deadline - now).try_into() {
-        sleep_duration(duration).await;
+        clock::sleep(duration).await;
     }
 }

--- a/crates/harn-vm/src/triggers/test_util/clock.rs
+++ b/crates/harn-vm/src/triggers/test_util/clock.rs
@@ -216,3 +216,27 @@ pub fn advance(duration: StdDuration) {
         clock.advance_std_sync(duration);
     }
 }
+
+/// Sleep for `duration`, honoring the unified mock clock.
+///
+/// When a `MockClock` override is installed the sleep advances the mock
+/// instantly and returns — the same semantics scripts get from
+/// `mock_time(...)` + `sleep(...)`. When no mock is installed the call
+/// falls through to `tokio::time::sleep`, which is itself virtualized
+/// inside a `#[tokio::test(start_paused = true)]` runtime.
+///
+/// Production runtime code that needs to back off (rate limiters,
+/// retry loops, the trigger dispatcher's flow-control window) should
+/// route through this helper so a single Rust test can pin time across
+/// both Harn and Rust layers.
+pub async fn sleep(duration: StdDuration) {
+    if duration.is_zero() {
+        return;
+    }
+    if let Some(mock) = active_mock_clock() {
+        let next = mock.now() + time::Duration::try_from(duration).unwrap_or_default();
+        mock.sleep_until(next).await;
+        return;
+    }
+    tokio::time::sleep(duration).await;
+}


### PR DESCRIPTION
## Summary

Follow-up to [#1446](https://github.com/burin-labs/harn/pull/1446) (closes [#1427](https://github.com/burin-labs/harn/issues/1427)). Generalizes the unified mock clock to additional runtime back-off paths and fixes a pre-existing test-isolation flake noticed during that work.

## Changes

- **One canonical sleep helper.** Promotes the trigger dispatcher's local `sleep_duration` to [\`clock_mock::sleep\`](crates/harn-vm/src/triggers/test_util/clock.rs). It honors the unified mock (advances instantly when installed, otherwise falls through to \`tokio::time::sleep\` so paused-time tests still work). The dispatcher now calls the shared helper instead of carrying its own copy.
- **Connector rate limiter.** [\`RateLimiterFactory::acquire\`](crates/harn-vm/src/connectors/mod.rs) reads the mocked \`instant_now()\` for capacity checks but used to sleep on real wall-clock — under \`mock_time(...)\` it would deadlock against a frozen monotonic clock. Now routes through \`clock_mock::sleep\`.
- **LLM retry / rate-limit / tool-dispatch back-offs.** [\`agent_observe\`](crates/harn-vm/src/llm/agent_observe.rs), [\`agent_tools\`](crates/harn-vm/src/llm/agent_tools.rs), and [\`with_rate_limit\`](crates/harn-vm/src/llm/mod.rs) all sleep through the unified clock now, so a single \`mock_time(...)\` pin covers an entire LLM agent loop.
- **Flake fix.** [\`commands::dump_trigger_quickref\`](crates/harn-cli/src/commands/dump_trigger_quickref.rs) tests now take the same \`lock_manifest_provider_schemas()\` lock that \`collect_manifest_triggers\` mutators use, and reset the \`ProviderCatalog\` before reading and on drop. \`collect_manifest_triggers\` mutates the process-global catalog via \`install_provider_catalog\`, so under workspace test ordering the regenerator picked up dynamic \`echo\` providers registered by manifest tests and the snapshot diverged from the committed file.

## Test plan

- [x] \`make test\` — 3485/3485 passing under nextest
- [x] \`make conformance\` — 933/933 passing
- [x] \`make lint\` (clippy \`-D warnings\`) clean
- [x] \`make lint-test-patterns\` clean
- [x] \`cargo test -p harn-cli --lib\` runs the dump_trigger_quickref tests with other manifest tests in the same binary; both pass on multiple sequential runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)