### PR TITLE
Extract unified harn-clock crate (Clock trait + RealClock/PausedClock/RecordedClock)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1770,6 +1770,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "harn-clock"
+version = "0.8.4"
+dependencies = [
+ "async-trait",
+ "parking_lot",
+ "serde",
+ "time",
+ "tokio",
+]
+
+[[package]]
 name = "harn-dap"
 version = "0.8.4"
 dependencies = [
@@ -1972,6 +1983,7 @@ dependencies = [
  "flate2",
  "futures",
  "globset",
+ "harn-clock",
  "harn-lexer",
  "harn-modules",
  "harn-parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 default-members = ["crates/harn-cli"]
 members = [
+    "crates/harn-clock",
     "crates/harn-lexer",
     "crates/harn-parser",
     "crates/harn-ir",

--- a/crates/harn-cli/src/commands/orchestrator/harness.rs
+++ b/crates/harn-cli/src/commands/orchestrator/harness.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use futures::StreamExt;
+use harn_vm::clock::{Clock, RealClock};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value as JsonValue};
 use time::format_description::well_known::Rfc3339;
@@ -93,6 +94,9 @@ pub struct OrchestratorConfig {
     /// When `Some`, installs an observability tracing subscriber.  Tests
     /// should leave this `None` to avoid conflicts with the test runtime.
     pub log_format: Option<harn_vm::observability::otel::LogFormat>,
+    /// Time + sleep substrate. Defaults to [`RealClock`]; tests inject
+    /// [`harn_vm::clock::PausedClock`] via [`OrchestratorConfig::with_clock`].
+    pub clock: Arc<dyn Clock>,
 }
 
 impl OrchestratorConfig {
@@ -113,7 +117,17 @@ impl OrchestratorConfig {
             drain: DrainConfig::default(),
             pump: PumpConfig::default(),
             log_format: None,
+            clock: RealClock::arc(),
         }
+    }
+
+    /// Inject a custom [`Clock`]. Production callers leave the default
+    /// [`RealClock`]; harness-driven tests pass a
+    /// [`harn_vm::clock::PausedClock`] so cron and the dispatcher run on
+    /// virtual time.
+    pub fn with_clock(mut self, clock: Arc<dyn Clock>) -> Self {
+        self.clock = clock;
+        self
     }
 }
 
@@ -476,6 +490,7 @@ async fn orchestrator_lifecycle(
         secret_provider.clone(),
         metrics_registry.clone(),
         &extensions.provider_connectors,
+        config.clock.clone(),
     )
     .await?;
     let route_configs = attach_route_connectors(
@@ -758,6 +773,7 @@ async fn orchestrator_lifecycle(
         secret_provider: &secret_provider,
         metrics_registry: &metrics_registry,
         mcp_service: mcp_service.as_ref(),
+        clock: config.clock.clone(),
         reload_rx: &mut reload_rx,
     };
 
@@ -1734,6 +1750,7 @@ struct RuntimeCtx<'a> {
     secret_provider: &'a Arc<dyn harn_vm::secrets::SecretProvider>,
     metrics_registry: &'a Arc<harn_vm::MetricsRegistry>,
     mcp_service: Option<&'a Arc<crate::commands::mcp::serve::McpOrchestratorService>>,
+    clock: Arc<dyn Clock>,
     #[cfg_attr(not(unix), allow(dead_code))]
     reload_rx: &'a mut mpsc::UnboundedReceiver<AdminReloadRequest>,
 }
@@ -1852,6 +1869,7 @@ async fn reload_manifest(
             ctx.secret_provider.clone(),
             ctx.metrics_registry.clone(),
             &extensions.provider_connectors,
+            ctx.clock.clone(),
         )
         .await?;
         runtime.activations = runtime
@@ -2043,6 +2061,7 @@ async fn initialize_connectors(
     secrets: Arc<dyn harn_vm::secrets::SecretProvider>,
     metrics: Arc<harn_vm::MetricsRegistry>,
     provider_overrides: &[ResolvedProviderConnectorConfig],
+    clock: Arc<dyn Clock>,
 ) -> Result<ConnectorRuntime, OrchestratorError> {
     let mut registry = harn_vm::ConnectorRegistry::default();
     let mut trigger_registry = harn_vm::TriggerRegistry::default();
@@ -2089,7 +2108,7 @@ async fn initialize_connectors(
                 )
                 .into());
             }
-            let connector = connector_for(&provider, kinds);
+            let connector = connector_for(&provider, kinds, clock.clone());
             registry
                 .register(connector)
                 .map_err(|error| error.to_string())?;
@@ -2190,9 +2209,10 @@ fn a2a_push_connector_config(
 fn connector_for(
     provider: &harn_vm::ProviderId,
     kinds: BTreeSet<String>,
+    clock: Arc<dyn Clock>,
 ) -> Box<dyn harn_vm::Connector> {
     match provider.as_str() {
-        "cron" => Box::new(harn_vm::CronConnector::new()),
+        "cron" => Box::new(harn_vm::CronConnector::with_clock(clock)),
         _ => Box::new(PlaceholderConnector::new(provider.clone(), kinds)),
     }
 }

--- a/crates/harn-cli/src/commands/orchestrator/serve.rs
+++ b/crates/harn-cli/src/commands/orchestrator/serve.rs
@@ -48,6 +48,7 @@ pub(crate) async fn run(args: OrchestratorServeArgs) -> Result<(), OrchestratorE
                 .unwrap_or(manifest.orchestrator.pumps.max_outstanding),
         },
         log_format: Some(log_format(args.log_format)),
+        clock: harn_vm::clock::RealClock::arc(),
     };
 
     let harness = OrchestratorHarness::start(config)

--- a/crates/harn-clock/Cargo.toml
+++ b/crates/harn-clock/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "harn-clock"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Unified time + sleep abstraction for the Harn runtime, CLI, triggers, cron, and harn-cloud."
+
+[dependencies]
+async-trait = "0.1"
+parking_lot = "0.12"
+serde = { version = "1", features = ["derive"] }
+time = { version = "0.3", features = ["formatting", "parsing", "serde", "macros"] }
+tokio = { version = "1", features = ["rt", "sync", "time"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt", "test-util", "time"] }

--- a/crates/harn-clock/src/lib.rs
+++ b/crates/harn-clock/src/lib.rs
@@ -1,0 +1,418 @@
+//! Unified `Clock` trait for the Harn runtime.
+//!
+//! Production code that needs the current time, monotonic measurement, or a
+//! cancellable sleep takes an `Arc<dyn Clock>` and reads through it. Real
+//! deployments wire [`RealClock`]; tests substitute [`PausedClock`] to drive
+//! virtual time deterministically; recording layers wrap any inner clock with
+//! [`RecordedClock`] to capture every observation for replay.
+//!
+//! See `docs/src/dev/testing.md` for usage patterns.
+
+use std::fmt;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use parking_lot::Mutex;
+use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
+use tokio::sync::Notify;
+
+/// Unified clock abstraction.
+///
+/// All time observations and sleeps in production-facing Harn code should
+/// route through a `Clock`. Cron, the trigger dispatcher, the stdlib
+/// `now_ms` / `sleep_ms` builtins, and the `OrchestratorHarness` all accept
+/// `Arc<dyn Clock>` so test harnesses can swap in [`PausedClock`].
+#[async_trait]
+pub trait Clock: Send + Sync + fmt::Debug {
+    /// Current wall-clock UTC time.
+    fn now_utc(&self) -> OffsetDateTime;
+
+    /// Monotonic milliseconds since an implementation-defined origin.
+    ///
+    /// Required to be non-decreasing across calls on the same `Clock`
+    /// instance. Used by the stdlib `monotonic_ms` / `elapsed` builtins and
+    /// any code measuring durations across operations.
+    fn monotonic_ms(&self) -> i64;
+
+    /// Sleep for `duration`. No-op when `duration` is zero.
+    async fn sleep(&self, duration: Duration);
+
+    /// Sleep until the wall-clock UTC `deadline`. No-op if `deadline` is in
+    /// the past.
+    async fn sleep_until_utc(&self, deadline: OffsetDateTime);
+}
+
+/// Convenience: current wall-clock millis since UNIX_EPOCH.
+pub fn now_wall_ms(clock: &dyn Clock) -> i64 {
+    let ts = clock.now_utc();
+    let nanos = ts.unix_timestamp_nanos();
+    (nanos / 1_000_000) as i64
+}
+
+// ── Real clock ─────────────────────────────────────────────────────────────────
+
+/// Production clock. Reads `OffsetDateTime::now_utc()` and
+/// `tokio::time::sleep`. Honors `tokio::time::pause()` for sleep-driven
+/// scheduling but `now_utc` always returns true wall time.
+pub struct RealClock {
+    monotonic_origin: tokio::time::Instant,
+}
+
+impl Default for RealClock {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Debug for RealClock {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RealClock").finish()
+    }
+}
+
+impl RealClock {
+    pub fn new() -> Self {
+        Self {
+            monotonic_origin: tokio::time::Instant::now(),
+        }
+    }
+
+    /// Convenience: wrap in an `Arc` for handing to consumers.
+    pub fn arc() -> Arc<dyn Clock> {
+        Arc::new(Self::new())
+    }
+}
+
+#[async_trait]
+impl Clock for RealClock {
+    fn now_utc(&self) -> OffsetDateTime {
+        OffsetDateTime::now_utc()
+    }
+
+    fn monotonic_ms(&self) -> i64 {
+        let elapsed = tokio::time::Instant::now().saturating_duration_since(self.monotonic_origin);
+        elapsed.as_millis() as i64
+    }
+
+    async fn sleep(&self, duration: Duration) {
+        if duration.is_zero() {
+            return;
+        }
+        tokio::time::sleep(duration).await;
+    }
+
+    async fn sleep_until_utc(&self, deadline: OffsetDateTime) {
+        let now = self.now_utc();
+        if deadline <= now {
+            return;
+        }
+        let delta = deadline - now;
+        let Ok(duration) = Duration::try_from(delta) else {
+            return;
+        };
+        tokio::time::sleep(duration).await;
+    }
+}
+
+// ── Paused clock ───────────────────────────────────────────────────────────────
+
+/// Fully-virtual clock for tests.
+///
+/// Stores its own wall-clock cursor and a monotonic counter. Sleeps suspend on
+/// an internal `Notify` and wake when [`PausedClock::advance`] or
+/// [`PausedClock::set`] crosses the deadline. No tokio-runtime cooperation is
+/// required: `PausedClock` works inside `current_thread`, `multi_thread`, and
+/// `start_paused` runtimes equally well.
+///
+/// Pairs with `tokio::time::pause()` for tests that mix this clock with code
+/// that uses `tokio::time::sleep` directly (e.g. `tokio::time::timeout`).
+pub struct PausedClock {
+    state: Mutex<PausedState>,
+    notify: Notify,
+}
+
+struct PausedState {
+    wall: OffsetDateTime,
+    monotonic: Duration,
+}
+
+impl fmt::Debug for PausedClock {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let state = self.state.lock();
+        f.debug_struct("PausedClock")
+            .field("wall", &state.wall)
+            .field("monotonic_ms", &state.monotonic.as_millis())
+            .finish()
+    }
+}
+
+impl PausedClock {
+    /// Build a paused clock pinned at `origin`.
+    pub fn new(origin: OffsetDateTime) -> Arc<Self> {
+        Arc::new(Self {
+            state: Mutex::new(PausedState {
+                wall: origin,
+                monotonic: Duration::ZERO,
+            }),
+            notify: Notify::new(),
+        })
+    }
+
+    /// Advance wall + monotonic by `duration` and wake any sleepers whose
+    /// deadlines are now in the past.
+    pub fn advance(&self, duration: Duration) {
+        let delta = match time::Duration::try_from(duration) {
+            Ok(value) => value,
+            Err(_) => return,
+        };
+        {
+            let mut state = self.state.lock();
+            state.wall += delta;
+            state.monotonic = state.monotonic.saturating_add(duration);
+        }
+        self.notify.notify_waiters();
+    }
+
+    /// Advance using a `time::Duration`. Negative durations are clamped to zero.
+    pub fn advance_time(&self, duration: time::Duration) {
+        let Ok(positive) = Duration::try_from(duration) else {
+            return;
+        };
+        self.advance(positive);
+    }
+
+    /// Step `ticks` times by `tick`, notifying sleepers between every step so
+    /// tasks observing intermediate wake-ups see each notification.
+    pub fn advance_ticks(&self, ticks: u32, tick: Duration) {
+        for _ in 0..ticks {
+            self.advance(tick);
+        }
+    }
+
+    /// Pin the wall clock to `wall`. Monotonic counter advances by the
+    /// (signed) delta, never moving backwards.
+    pub fn set(&self, wall: OffsetDateTime) {
+        {
+            let mut state = self.state.lock();
+            let delta = wall - state.wall;
+            state.wall = wall;
+            if delta.is_positive() {
+                if let Ok(positive) = Duration::try_from(delta) {
+                    state.monotonic = state.monotonic.saturating_add(positive);
+                }
+            }
+        }
+        self.notify.notify_waiters();
+    }
+}
+
+#[async_trait]
+impl Clock for PausedClock {
+    fn now_utc(&self) -> OffsetDateTime {
+        self.state.lock().wall
+    }
+
+    fn monotonic_ms(&self) -> i64 {
+        self.state.lock().monotonic.as_millis() as i64
+    }
+
+    async fn sleep(&self, duration: Duration) {
+        if duration.is_zero() {
+            return;
+        }
+        let deadline = self.state.lock().wall
+            + time::Duration::try_from(duration).unwrap_or(time::Duration::ZERO);
+        self.sleep_until_utc(deadline).await;
+    }
+
+    async fn sleep_until_utc(&self, deadline: OffsetDateTime) {
+        loop {
+            let notified = self.notify.notified();
+            if self.state.lock().wall >= deadline {
+                return;
+            }
+            notified.await;
+        }
+    }
+}
+
+// ── Recorded clock ─────────────────────────────────────────────────────────────
+
+/// Single observation captured by [`RecordedClock`].
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ClockEvent {
+    NowUtc { wall_ns: i128 },
+    MonotonicMs { value: i64 },
+    Sleep { duration_ms: u64 },
+    SleepUntil { wall_ns: i128 },
+}
+
+/// In-memory append-only log of clock observations.
+#[derive(Debug, Default)]
+pub struct ClockEventLog {
+    events: Mutex<Vec<ClockEvent>>,
+}
+
+impl ClockEventLog {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Append an event. Called from `RecordedClock`; tests can also seed
+    /// expected events when building a replay oracle.
+    pub fn push(&self, event: ClockEvent) {
+        self.events.lock().push(event);
+    }
+
+    /// Snapshot of events recorded so far.
+    pub fn snapshot(&self) -> Vec<ClockEvent> {
+        self.events.lock().clone()
+    }
+
+    /// Number of events recorded.
+    pub fn len(&self) -> usize {
+        self.events.lock().len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// Wraps an inner [`Clock`] and records every observation to a
+/// [`ClockEventLog`].
+///
+/// The recording is the substrate the testbench replay/recording feature
+/// (#1441) builds on. It is deliberately scoped to the clock surface; other
+/// I/O substrates record separately.
+pub struct RecordedClock {
+    inner: Arc<dyn Clock>,
+    log: Arc<ClockEventLog>,
+}
+
+impl fmt::Debug for RecordedClock {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RecordedClock")
+            .field("inner", &self.inner)
+            .field("events", &self.log.len())
+            .finish()
+    }
+}
+
+impl RecordedClock {
+    pub fn new(inner: Arc<dyn Clock>, log: Arc<ClockEventLog>) -> Self {
+        Self { inner, log }
+    }
+
+    pub fn log(&self) -> Arc<ClockEventLog> {
+        self.log.clone()
+    }
+}
+
+#[async_trait]
+impl Clock for RecordedClock {
+    fn now_utc(&self) -> OffsetDateTime {
+        let value = self.inner.now_utc();
+        self.log.push(ClockEvent::NowUtc {
+            wall_ns: value.unix_timestamp_nanos(),
+        });
+        value
+    }
+
+    fn monotonic_ms(&self) -> i64 {
+        let value = self.inner.monotonic_ms();
+        self.log.push(ClockEvent::MonotonicMs { value });
+        value
+    }
+
+    async fn sleep(&self, duration: Duration) {
+        self.log.push(ClockEvent::Sleep {
+            duration_ms: duration.as_millis() as u64,
+        });
+        self.inner.sleep(duration).await;
+    }
+
+    async fn sleep_until_utc(&self, deadline: OffsetDateTime) {
+        self.log.push(ClockEvent::SleepUntil {
+            wall_ns: deadline.unix_timestamp_nanos(),
+        });
+        self.inner.sleep_until_utc(deadline).await;
+    }
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn epoch() -> OffsetDateTime {
+        OffsetDateTime::from_unix_timestamp(1_700_000_000).unwrap()
+    }
+
+    #[tokio::test]
+    async fn real_clock_returns_increasing_monotonic() {
+        let clock = RealClock::new();
+        let a = clock.monotonic_ms();
+        tokio::task::yield_now().await;
+        let b = clock.monotonic_ms();
+        assert!(b >= a, "monotonic must not move backwards");
+    }
+
+    #[tokio::test]
+    async fn paused_clock_pins_wall_and_monotonic_until_advanced() {
+        let clock = PausedClock::new(epoch());
+        assert_eq!(clock.now_utc(), epoch());
+        assert_eq!(clock.monotonic_ms(), 0);
+        clock.advance(Duration::from_millis(250));
+        assert_eq!(clock.monotonic_ms(), 250);
+        assert_eq!(clock.now_utc(), epoch() + time::Duration::milliseconds(250));
+    }
+
+    #[tokio::test]
+    async fn paused_clock_sleep_resumes_after_advance() {
+        let clock = PausedClock::new(epoch());
+        let clock_for_sleep = clock.clone();
+        let task = tokio::spawn(async move {
+            clock_for_sleep.sleep(Duration::from_secs(5)).await;
+        });
+        tokio::task::yield_now().await;
+        assert!(!task.is_finished(), "sleep should still be pending");
+        clock.advance(Duration::from_secs(10));
+        task.await.expect("sleep task panicked");
+    }
+
+    #[tokio::test]
+    async fn paused_clock_sleep_until_returns_immediately_for_past_deadline() {
+        let clock = PausedClock::new(epoch());
+        clock.advance(Duration::from_secs(60));
+        clock.sleep_until_utc(epoch()).await;
+    }
+
+    #[tokio::test]
+    async fn recorded_clock_appends_one_event_per_call() {
+        let log = Arc::new(ClockEventLog::new());
+        let clock = RecordedClock::new(PausedClock::new(epoch()), log.clone());
+        let _ = clock.now_utc();
+        let _ = clock.monotonic_ms();
+        clock.sleep(Duration::ZERO).await;
+        clock.sleep_until_utc(epoch()).await;
+        let events = log.snapshot();
+        assert_eq!(events.len(), 4);
+        assert!(matches!(events[0], ClockEvent::NowUtc { .. }));
+        assert!(matches!(events[1], ClockEvent::MonotonicMs { .. }));
+        assert!(matches!(events[2], ClockEvent::Sleep { duration_ms: 0 }));
+        assert!(matches!(events[3], ClockEvent::SleepUntil { .. }));
+    }
+
+    #[tokio::test]
+    async fn now_wall_ms_helper_matches_clock_observation() {
+        let clock = PausedClock::new(epoch());
+        let observed = now_wall_ms(clock.as_ref());
+        let expected = epoch().unix_timestamp_nanos() / 1_000_000;
+        assert_eq!(observed, expected as i64);
+    }
+}

--- a/crates/harn-vm/Cargo.toml
+++ b/crates/harn-vm/Cargo.toml
@@ -19,6 +19,7 @@ otel = [
 ]
 
 [dependencies]
+harn-clock = { path = "../harn-clock", version = "0.8" }
 harn-lexer = { path = "../harn-lexer", version = "0.8" }
 harn-modules = { path = "../harn-modules", version = "0.8" }
 harn-parser = { path = "../harn-parser", version = "0.8" }

--- a/crates/harn-vm/src/connectors/cron/mod.rs
+++ b/crates/harn-vm/src/connectors/cron/mod.rs
@@ -3,6 +3,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration as StdDuration;
 
 use async_trait::async_trait;
+use harn_clock::{Clock, RealClock};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value as JsonValue};
 use time::OffsetDateTime;
@@ -19,7 +20,7 @@ use crate::triggers::{
     DEFAULT_INBOX_RETENTION_DAYS,
 };
 
-use self::scheduler::{run_tick_loop, Clock, CronSchedule, RealClock, ShutdownSignal, TickHandler};
+use self::scheduler::{run_tick_loop, CronSchedule, ShutdownSignal, TickHandler};
 use self::state::{CronStateStore, PersistedCronState};
 
 pub(crate) mod scheduler;
@@ -54,10 +55,12 @@ pub struct CronConnector {
 
 impl CronConnector {
     pub fn new() -> Self {
-        Self::with_clock(Arc::new(RealClock))
+        Self::with_clock(Arc::new(RealClock::new()))
     }
 
-    pub(crate) fn with_clock(clock: Arc<dyn Clock>) -> Self {
+    /// Build a connector backed by an injected clock. Production callers use
+    /// [`harn_clock::RealClock`]; tests use [`harn_clock::PausedClock`].
+    pub fn with_clock(clock: Arc<dyn Clock>) -> Self {
         Self {
             provider_id: ProviderId::from("cron"),
             kinds: vec![TriggerKind::from("cron")],
@@ -177,7 +180,7 @@ impl Connector for CronConnector {
                 .load(&trigger.trigger_id)
                 .await?
                 .map(|state| state.last_fired_at);
-            let now = clock.now();
+            let now = clock.now_utc();
             let catchup_ticks = match trigger.catchup_mode {
                 CatchupMode::Skip => Vec::new(),
                 CatchupMode::All => trigger.schedule.due_ticks_between(last_fired, now)?,

--- a/crates/harn-vm/src/connectors/cron/scheduler.rs
+++ b/crates/harn-vm/src/connectors/cron/scheduler.rs
@@ -6,11 +6,11 @@ use chrono::{DateTime, Duration as ChronoDuration, TimeZone, Utc};
 use chrono_tz::Tz;
 use croner::Cron;
 use futures::pin_mut;
+use harn_clock::Clock;
 use time::OffsetDateTime;
 use tokio::sync::Notify;
 
 use crate::connectors::ConnectorError;
-use crate::triggers::test_util::clock;
 
 #[derive(Clone, Debug)]
 pub(crate) struct CronSchedule {
@@ -115,34 +115,6 @@ fn chrono_to_offset<TzImpl: TimeZone>(
 }
 
 #[async_trait]
-pub(crate) trait Clock: Send + Sync {
-    fn now(&self) -> OffsetDateTime;
-    async fn sleep_until(&self, deadline: OffsetDateTime);
-}
-
-#[derive(Debug, Default)]
-pub(crate) struct RealClock;
-
-#[async_trait]
-impl Clock for RealClock {
-    fn now(&self) -> OffsetDateTime {
-        clock::now_utc()
-    }
-
-    async fn sleep_until(&self, deadline: OffsetDateTime) {
-        let now = self.now();
-        if deadline <= now {
-            return;
-        }
-        let wait = deadline - now;
-        let Ok(wait) = wait.try_into() else {
-            return;
-        };
-        tokio::time::sleep(wait).await;
-    }
-}
-
-#[async_trait]
 pub(crate) trait TickHandler: Send + Sync {
     async fn on_tick(&self, tick_at: OffsetDateTime, catchup: bool) -> Result<(), ConnectorError>;
 }
@@ -189,8 +161,8 @@ pub(crate) async fn run_tick_loop(
             return Ok(());
         }
         let next_tick = schedule.next_tick_after(cursor)?;
-        if next_tick > clock.now() {
-            let sleep = clock.sleep_until(next_tick);
+        if next_tick > clock.now_utc() {
+            let sleep = clock.sleep_until_utc(next_tick);
             pin_mut!(sleep);
             tokio::select! {
                 _ = &mut sleep => {}
@@ -200,7 +172,7 @@ pub(crate) async fn run_tick_loop(
         if shutdown.is_stopped() {
             return Ok(());
         }
-        let now = clock.now();
+        let now = clock.now_utc();
         let due = schedule.due_ticks_between(Some(cursor), now)?;
         if due.is_empty() {
             cursor = now;

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -1,6 +1,11 @@
 #![recursion_limit = "256"]
 #![allow(clippy::result_large_err, clippy::cloned_ref_to_slice_refs)]
 
+/// Re-export of the unified clock substrate so downstream crates (CLI,
+/// orchestrator, harn-cloud) can depend on a single canonical `Clock`
+/// trait without each adding `harn-clock` as a direct dependency.
+pub use harn_clock as clock;
+
 pub mod a2a;
 pub mod agent_events;
 pub mod agent_sessions;

--- a/crates/harn-vm/src/triggers/dispatcher/mod.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/mod.rs
@@ -3762,7 +3762,7 @@ fn tenant_id(event: &TriggerEvent) -> Option<&str> {
 }
 
 fn current_unix_ms() -> i64 {
-    unix_ms(time::OffsetDateTime::now_utc())
+    unix_ms(crate::triggers::test_util::clock::now_utc())
 }
 
 fn unix_ms(timestamp: time::OffsetDateTime) -> i64 {
@@ -3873,13 +3873,13 @@ fn maybe_fail_before_outbox() {
 }
 
 fn now_rfc3339() -> String {
-    time::OffsetDateTime::now_utc()
+    crate::triggers::test_util::clock::now_utc()
         .format(&time::format_description::well_known::Rfc3339)
         .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_string())
 }
 
 fn next_budget_reset_rfc3339(binding: &TriggerBinding) -> String {
-    let now = time::OffsetDateTime::now_utc();
+    let now = crate::triggers::test_util::clock::now_utc();
     let reset = if binding.hourly_cost_usd.is_some() {
         let next_hour = (now.unix_timestamp() / 3_600 + 1) * 3_600;
         time::OffsetDateTime::from_unix_timestamp(next_hour).unwrap_or(now)
@@ -3893,7 +3893,7 @@ fn next_budget_reset_rfc3339(binding: &TriggerBinding) -> String {
 }
 
 fn now_unix_ms() -> i64 {
-    (time::OffsetDateTime::now_utc().unix_timestamp_nanos() / 1_000_000) as i64
+    (crate::triggers::test_util::clock::now_utc().unix_timestamp_nanos() / 1_000_000) as i64
 }
 
 fn cancelled_dispatch_outcome(

--- a/crates/harn-vm/src/triggers/test_util/clock.rs
+++ b/crates/harn-vm/src/triggers/test_util/clock.rs
@@ -1,4 +1,5 @@
-//! Single source of truth for clock mocking across the VM.
+//! Single source of truth for clock mocking across the VM, built on the
+//! unified [`harn_clock::Clock`] trait.
 //!
 //! This module owns the thread-local "mock clock" stack consulted by
 //! every time-sensitive subsystem: stdlib `now_ms` / `monotonic_ms` /
@@ -9,17 +10,16 @@
 //!
 //! The lives-in-`triggers/` path is historical — the abstraction is now
 //! crate-wide and re-exported as `harn_vm::clock_mock` for callers
-//! outside the trigger subsystem.
+//! outside the trigger subsystem. New runtime code that needs an
+//! injectable clock should accept `Arc<dyn harn_clock::Clock>` directly.
 
 use std::cell::RefCell;
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, OnceLock};
 use std::time::{Duration as StdDuration, Instant};
 
 use async_trait::async_trait;
+use harn_clock::Clock;
 use time::OffsetDateTime;
-use tokio::sync::Notify;
-
-use crate::connectors::cron::scheduler::Clock;
 
 thread_local! {
     static MOCK_CLOCK_STACK: RefCell<Vec<Arc<MockClock>>> = const { RefCell::new(Vec::new()) };
@@ -30,6 +30,9 @@ fn process_start() -> &'static Instant {
     PROCESS_START.get_or_init(Instant::now)
 }
 
+/// Monotonic instant snapshot with millisecond resolution. Compares cheaply,
+/// serialises by value, and abstracts whether it came from a paused clock or
+/// the real OS monotonic source.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ClockInstant(StdDuration);
 
@@ -53,19 +56,22 @@ impl Drop for ClockOverrideGuard {
     }
 }
 
+/// Test-facing wrapper around [`harn_clock::PausedClock`].
+///
+/// Provides the sync ergonomics (`set_sync`, `advance_std_sync`) that
+/// stdlib builtins call without a runtime, plus async aliases (`set`,
+/// `advance`, `advance_std`, `advance_ticks`) that the trigger/cron tests
+/// were written against. Implements [`harn_clock::Clock`] so it can also
+/// be handed directly to consumers that take `Arc<dyn Clock>`.
 #[derive(Debug)]
 pub struct MockClock {
-    now: Mutex<OffsetDateTime>,
-    monotonic: Mutex<StdDuration>,
-    notify: Notify,
+    inner: Arc<harn_clock::PausedClock>,
 }
 
 impl MockClock {
     pub fn new(now: OffsetDateTime) -> Arc<Self> {
         Arc::new(Self {
-            now: Mutex::new(now),
-            monotonic: Mutex::new(StdDuration::ZERO),
-            notify: Notify::new(),
+            inner: harn_clock::PausedClock::new(now),
         })
     }
 
@@ -78,94 +84,70 @@ impl MockClock {
     }
 
     pub fn monotonic_now(&self) -> ClockInstant {
-        ClockInstant(
-            *self
-                .monotonic
-                .lock()
-                .expect("mock clock monotonic mutex poisoned"),
-        )
+        ClockInstant(StdDuration::from_millis(
+            self.inner.monotonic_ms().max(0) as u64
+        ))
     }
 
     /// Wall clock in millis since `UNIX_EPOCH`.
     pub fn now_wall_ms(&self) -> i64 {
-        self.now().unix_timestamp_nanos() as i64 / 1_000_000
+        self.now_utc().unix_timestamp_nanos() as i64 / 1_000_000
     }
 
     /// Monotonic millis since this clock was created.
     pub fn now_monotonic_ms(&self) -> i64 {
-        self.monotonic_now().as_millis() as i64
+        self.inner.monotonic_ms()
     }
 
-    /// Synchronous form of [`set`]. Notifying waiters is itself a sync
-    /// operation, so we expose this to callers (stdlib builtins, sync
-    /// test helpers) that cannot await.
+    /// Pin the wall clock to `now` (sync). Sleepers waiting for a deadline
+    /// that has now passed are released.
     pub fn set_sync(&self, now: OffsetDateTime) {
-        let mut wall = self.now.lock().expect("mock clock mutex poisoned");
-        let previous = *wall;
-        *wall = now;
-        drop(wall);
-
-        if now > previous {
-            let delta = now - previous;
-            if let Ok(delta) = TryInto::<StdDuration>::try_into(delta) {
-                let mut monotonic = self
-                    .monotonic
-                    .lock()
-                    .expect("mock clock monotonic mutex poisoned");
-                *monotonic += delta;
-            }
-        }
-
-        self.notify.notify_waiters();
+        self.inner.set(now);
     }
 
-    /// Synchronous form of [`advance_std`].
+    /// Advance the clock by `duration` (sync).
     pub fn advance_std_sync(&self, duration: StdDuration) {
-        if duration.is_zero() {
-            self.notify.notify_waiters();
-            return;
-        }
-        let delta =
-            time::Duration::try_from(duration).expect("std duration should fit in time::Duration");
-        let next = *self.now.lock().expect("mock clock mutex poisoned") + delta;
-        self.set_sync(next);
+        self.inner.advance(duration);
     }
 
+    /// Async alias for [`set_sync`]. Kept so existing trigger/cron tests
+    /// (which were written under the old async API) continue to compile.
     pub async fn set(&self, now: OffsetDateTime) {
-        self.set_sync(now);
+        self.inner.set(now);
     }
 
+    /// Advance by a `time::Duration`. Negative values are clamped to zero.
     pub async fn advance(&self, duration: time::Duration) {
-        let Ok(delta) = TryInto::<StdDuration>::try_into(duration) else {
-            return;
-        };
-        self.advance_std_sync(delta);
+        self.inner.advance_time(duration);
     }
 
+    /// Advance by a `std::time::Duration`.
     pub async fn advance_std(&self, duration: StdDuration) {
-        self.advance_std_sync(duration);
+        self.inner.advance(duration);
     }
 
+    /// Step `ticks` times by `tick`, notifying sleepers between every step.
     pub async fn advance_ticks(&self, ticks: u32, tick: StdDuration) {
-        for _ in 0..ticks {
-            self.advance_std_sync(tick);
-        }
+        self.inner.advance_ticks(ticks, tick);
     }
 }
 
 #[async_trait]
 impl Clock for MockClock {
-    fn now(&self) -> OffsetDateTime {
-        *self.now.lock().expect("mock clock mutex poisoned")
+    fn now_utc(&self) -> OffsetDateTime {
+        self.inner.now_utc()
     }
 
-    async fn sleep_until(&self, deadline: OffsetDateTime) {
-        loop {
-            if *self.now.lock().expect("mock clock mutex poisoned") >= deadline {
-                return;
-            }
-            self.notify.notified().await;
-        }
+    fn monotonic_ms(&self) -> i64 {
+        self.inner.monotonic_ms()
+    }
+
+    async fn sleep(&self, duration: StdDuration) {
+        self.inner.sleep(duration).await;
+    }
+
+    async fn sleep_until_utc(&self, deadline: OffsetDateTime) {
+        self.inner.sleep_until_utc(deadline).await;
     }
 }
 
@@ -195,7 +177,7 @@ pub fn clear_overrides() {
 
 pub fn now_utc() -> OffsetDateTime {
     active_mock_clock()
-        .map(|clock| clock.now())
+        .map(|clock| clock.now_utc())
         .unwrap_or_else(OffsetDateTime::now_utc)
 }
 
@@ -234,8 +216,7 @@ pub async fn sleep(duration: StdDuration) {
         return;
     }
     if let Some(mock) = active_mock_clock() {
-        let next = mock.now() + time::Duration::try_from(duration).unwrap_or_default();
-        mock.sleep_until(next).await;
+        mock.sleep(duration).await;
         return;
     }
     tokio::time::sleep(duration).await;

--- a/docs/src/dev/testing.md
+++ b/docs/src/dev/testing.md
@@ -21,6 +21,63 @@ enforces that new test code does not reintroduce these patterns.
 
 ## Approved patterns
 
+### `harn_clock::Clock` injection (preferred for runtime code)
+
+The unified `harn_clock::Clock` trait is the canonical way to read time and
+sleep in Harn runtime code. Cron, the trigger dispatcher, the stdlib
+`now_ms` / `monotonic_ms` / `sleep_ms` builtins, the `OrchestratorHarness`,
+and (via re-export) every downstream crate route through it.
+
+```rust
+use std::sync::Arc;
+use std::time::Duration;
+use harn_clock::Clock;
+
+struct Worker {
+    clock: Arc<dyn Clock>,
+}
+
+impl Worker {
+    async fn poll_until(&self, deadline_ms: i64) {
+        while self.clock.now_utc().unix_timestamp_nanos() / 1_000_000 < deadline_ms {
+            self.clock.sleep(Duration::from_millis(50)).await;
+        }
+    }
+}
+```
+
+Tests substitute `harn_clock::PausedClock` to drive virtual time
+deterministically — see the `MockClock` section below for the existing trigger
+test surface or use `PausedClock` directly:
+
+```rust
+use harn_clock::{Clock, PausedClock};
+
+#[tokio::test]
+async fn worker_resumes_after_advance() {
+    let clock = PausedClock::new(time::OffsetDateTime::now_utc());
+    let worker = Worker { clock: clock.clone() as Arc<dyn Clock> };
+    let task = tokio::spawn(async move { worker.poll_until(/* future ms */ ...).await });
+    clock.advance(Duration::from_secs(60));
+    task.await.unwrap();
+}
+```
+
+`PausedClock` works in both `current_thread` and `multi_thread` runtimes and
+does not require `start_paused = true`. `RecordedClock` wraps any inner clock
+and captures every observation to a `ClockEventLog`, which is the substrate
+the recording/replay child issue (#1441) builds on.
+
+For runtime code that needs `tokio::time::sleep` directly (e.g. `timeout`),
+combine `PausedClock` with `tokio::time::pause()` so both surfaces freeze
+together.
+
+The lint at `scripts/lint_test_patterns.sh` forbids new wall-clock reads in
+non-test files under `crates/harn-vm/src/` and `crates/harn-cli/src/` outside
+the explicit `NON_TEST_WALL_CLOCK_ALLOWLIST`. The allowlist freezes existing
+sites as gradual cleanup; new files must accept `Arc<dyn Clock>` instead of
+calling `OffsetDateTime::now_utc()` / `Instant::now()` directly.
+
 ### `tokio::time::pause()` and `advance()`
 
 For tests that need to simulate time passing, use Tokio's paused-time runtime.
@@ -87,6 +144,18 @@ For tests that need the orchestrator running but do not need real subprocesses,
 use `OrchestratorHarness` from the test-util crate. It boots the orchestrator
 in-process with an injectable clock and exposes event subscriptions so tests can
 wait deterministically.
+
+Pass a custom clock via `OrchestratorConfig::with_clock(...)`:
+
+```rust
+let clock = harn_vm::clock::PausedClock::new(time::OffsetDateTime::now_utc());
+let config = OrchestratorConfig::for_test(manifest, state_dir).with_clock(clock.clone());
+let harness = OrchestratorHarness::start(config).await?;
+clock.advance(Duration::from_secs(60));
+```
+
+Cron and trigger-dispatch logic inside the harness then run on the injected
+virtual clock.
 
 ### `MockProcess`
 

--- a/scripts/lint_test_patterns.sh
+++ b/scripts/lint_test_patterns.sh
@@ -316,6 +316,160 @@ while IFS= read -r file; do
 done < "$HARN_TEST_FILES_TMP"
 
 # ---------------------------------------------------------------------------
+# Non-test wall-clock reads (#1439)
+#
+# Runtime code that reads `SystemTime::now()`, `OffsetDateTime::now_utc()`,
+# `Instant::now()`, or `chrono::Utc::now()` directly cannot be virtualised by
+# the testbench `Clock` substrate (`harn_clock::Clock`). New runtime code
+# should accept an `Arc<dyn Clock>` and read time through it, leaving the
+# direct host-clock APIs to `RealClock` impls and known-good logging /
+# observability sites.
+#
+# The allowlist below freezes the file inventory as of #1439. Existing files
+# may keep their direct reads (tracked as gradual cleanup), but adding new
+# files with direct reads requires either (a) routing time through a `Clock`
+# or (b) appending the file to the allowlist with a one-line justification.
+# ---------------------------------------------------------------------------
+
+echo "--- Non-test wall-clock reads (harn-vm/harn-cli runtime) ---"
+
+# Files allowed to read host time directly. Each entry is a runtime site
+# where the host wall clock is the *source of truth* — observability
+# timestamps, OAuth/JWT claim issuance, retry-after parsing, real-time
+# logging, etc. — or where Clock injection is tracked as gradual cleanup
+# under the testbench epic (#1438). Drop entries as call sites migrate to
+# `Arc<dyn Clock>`.
+NON_TEST_WALL_CLOCK_ALLOWLIST=(
+  "crates/harn-cli/src/commands/agents_conformance.rs"
+  "crates/harn-cli/src/commands/bench.rs"
+  "crates/harn-cli/src/commands/connect.rs"
+  "crates/harn-cli/src/commands/connector.rs"
+  "crates/harn-cli/src/commands/explain.rs"
+  "crates/harn-cli/src/commands/flow.rs"
+  "crates/harn-cli/src/commands/mcp/mod.rs"
+  "crates/harn-cli/src/commands/mcp/oauth_resource.rs"
+  "crates/harn-cli/src/commands/mcp/serve.rs"
+  "crates/harn-cli/src/commands/orchestrator/common.rs"
+  "crates/harn-cli/src/commands/orchestrator/harness.rs"
+  "crates/harn-cli/src/commands/orchestrator/inspect_data.rs"
+  "crates/harn-cli/src/commands/orchestrator/listener/acp_hub.rs"
+  "crates/harn-cli/src/commands/orchestrator/listener/routes.rs"
+  "crates/harn-cli/src/commands/orchestrator/listener/routes/ingest.rs"
+  "crates/harn-cli/src/commands/orchestrator/queue.rs"
+  "crates/harn-cli/src/commands/orchestrator/reload.rs"
+  "crates/harn-cli/src/commands/orchestrator/stats.rs"
+  "crates/harn-cli/src/commands/orchestrator/supervisor_state.rs"
+  "crates/harn-cli/src/commands/portal/dlq.rs"
+  "crates/harn-cli/src/commands/portal/run_analysis.rs"
+  "crates/harn-cli/src/commands/portal/util.rs"
+  "crates/harn-cli/src/commands/run.rs"
+  "crates/harn-cli/src/commands/supervisor.rs"
+  "crates/harn-cli/src/commands/test.rs"
+  "crates/harn-cli/src/commands/trigger/ops.rs"
+  "crates/harn-cli/src/commands/trigger/replay.rs"
+  "crates/harn-cli/src/package/registry.rs"
+  "crates/harn-cli/src/skill_provenance.rs"
+  "crates/harn-cli/src/test_runner.rs"
+  "crates/harn-vm/src/a2a/mod.rs"
+  "crates/harn-vm/src/agent_events.rs"
+  "crates/harn-vm/src/agent_sessions.rs"
+  "crates/harn-vm/src/connectors/a2a_push/mod.rs"
+  "crates/harn-vm/src/connectors/harn_module.rs"
+  "crates/harn-vm/src/connectors/shared.rs"
+  "crates/harn-vm/src/corrections/mod.rs"
+  "crates/harn-vm/src/event_log/mod.rs"
+  "crates/harn-vm/src/flow/atom.rs"
+  "crates/harn-vm/src/flow/fixer.rs"
+  "crates/harn-vm/src/flow/predicates/executor.rs"
+  "crates/harn-vm/src/http/client.rs"
+  "crates/harn-vm/src/http/streaming/websocket.rs"
+  "crates/harn-vm/src/llm/agent_observe.rs"
+  "crates/harn-vm/src/llm/agent_runtime.rs"
+  "crates/harn-vm/src/llm/api/partial_tool_args.rs"
+  "crates/harn-vm/src/llm/api/transport.rs"
+  "crates/harn-vm/src/llm/autonomy_budget.rs"
+  "crates/harn-vm/src/llm/cache.rs"
+  "crates/harn-vm/src/llm/mod.rs"
+  "crates/harn-vm/src/llm/model_test.rs"
+  "crates/harn-vm/src/llm/providers/vertex.rs"
+  "crates/harn-vm/src/llm/rate_limit.rs"
+  "crates/harn-vm/src/llm/stream.rs"
+  "crates/harn-vm/src/mcp_card.rs"
+  "crates/harn-vm/src/mcp_registry.rs"
+  "crates/harn-vm/src/metadata.rs"
+  "crates/harn-vm/src/orchestration/command_policy.rs"
+  "crates/harn-vm/src/orchestration/merge_captain_iteration.rs"
+  "crates/harn-vm/src/orchestration/mod.rs"
+  "crates/harn-vm/src/orchestration/playground/fake_server.rs"
+  "crates/harn-vm/src/orchestration/playground/step.rs"
+  "crates/harn-vm/src/personas.rs"
+  "crates/harn-vm/src/provenance/mod.rs"
+  "crates/harn-vm/src/sessions/mod.rs"
+  "crates/harn-vm/src/stdlib/agent_state.rs"
+  # stdlib/clock.rs is itself the canonical wall-clock reader for Harn
+  # scripts; the SystemTime::now reads are the fallback when no mock is
+  # active. Routing through Clock would create a cycle.
+  "crates/harn-vm/src/stdlib/clock.rs"
+  "crates/harn-vm/src/stdlib/agent_state/backend.rs"
+  "crates/harn-vm/src/stdlib/agents_daemon.rs"
+  "crates/harn-vm/src/stdlib/agents_workers/execution.rs"
+  "crates/harn-vm/src/stdlib/concurrency.rs"
+  "crates/harn-vm/src/stdlib/cookies.rs"
+  "crates/harn-vm/src/stdlib/fs.rs"
+  "crates/harn-vm/src/stdlib/hitl.rs"
+  "crates/harn-vm/src/stdlib/host.rs"
+  "crates/harn-vm/src/stdlib/logging.rs"
+  "crates/harn-vm/src/stdlib/long_running.rs"
+  "crates/harn-vm/src/stdlib/memory.rs"
+  "crates/harn-vm/src/stdlib/monitors.rs"
+  "crates/harn-vm/src/stdlib/process.rs"
+  "crates/harn-vm/src/stdlib/supervisor.rs"
+  "crates/harn-vm/src/stdlib/tracing.rs"
+  "crates/harn-vm/src/stdlib/triggers_stdlib.rs"
+  "crates/harn-vm/src/stdlib/waitpoint.rs"
+  "crates/harn-vm/src/stdlib/waitpoints.rs"
+  "crates/harn-vm/src/stdlib/workflow_messages.rs"
+  "crates/harn-vm/src/synchronization.rs"
+  "crates/harn-vm/src/tenant.rs"
+  "crates/harn-vm/src/tracing.rs"
+  "crates/harn-vm/src/triggers/dispatcher/circuits.rs"
+  "crates/harn-vm/src/triggers/dispatcher/mod.rs"
+  "crates/harn-vm/src/triggers/dispatcher/predicate_eval.rs"
+  "crates/harn-vm/src/triggers/event.rs"
+  "crates/harn-vm/src/triggers/inbox.rs"
+  "crates/harn-vm/src/triggers/registry.rs"
+  "crates/harn-vm/src/triggers/scheduler.rs"
+  "crates/harn-vm/src/triggers/test_util/clock.rs"
+  "crates/harn-vm/src/triggers/test_util/mod.rs"
+  "crates/harn-vm/src/triggers/webhook_intake.rs"
+  "crates/harn-vm/src/triggers/worker_queue.rs"
+  "crates/harn-vm/src/trust_graph.rs"
+  "crates/harn-vm/src/vm/execution.rs"
+  "crates/harn-vm/src/vm/iter.rs"
+  "crates/harn-vm/src/vm/ops/parallel.rs"
+  "crates/harn-vm/src/waitpoints.rs"
+)
+
+NON_TEST_RUNTIME_FILES_TMP="$(mktemp)"
+trap 'rm -f "$TEST_FILES_TMP" "$HARN_TEST_FILES_TMP" "$NON_TEST_RUNTIME_FILES_TMP"' EXIT
+{
+  find crates/harn-vm/src crates/harn-cli/src -type f -name "*.rs" \
+    ! -path "*/tests/*" \
+    ! -name "tests.rs" \
+    ! -name "tests_*.rs"
+} | sort -u > "$NON_TEST_RUNTIME_FILES_TMP"
+
+while IFS= read -r file; do
+  in_allowlist "$file" NON_TEST_WALL_CLOCK_ALLOWLIST && continue
+  while IFS= read -r hit; do
+    [[ -z "$hit" ]] && continue
+    echo "  $hit"
+    echo "    hint: route time reads through an injected harn_clock::Clock; if the host wall clock is the source of truth (observability, JWT claim, retry-after, etc.), append this file to NON_TEST_WALL_CLOCK_ALLOWLIST in scripts/lint_test_patterns.sh with a one-line justification."
+    violations=$((violations + 1))
+  done < <(grep -n -E 'SystemTime::now\(\)|chrono::Utc::now\(\)|chrono::Local::now\(\)|Instant::now\(\)|OffsetDateTime::now_utc\(\)' "$file" 2>/dev/null || true)
+done < "$NON_TEST_RUNTIME_FILES_TMP"
+
+# ---------------------------------------------------------------------------
 echo
 if (( violations > 0 )); then
   echo "FAIL: $violations wall-clock pattern violation(s) found in test files."


### PR DESCRIPTION
## Summary

Closes [#1439](https://github.com/burin-labs/harn/issues/1439). Builds on [#1446](https://github.com/burin-labs/harn/pull/1446) and [#1449](https://github.com/burin-labs/harn/pull/1449), which collapsed the stdlib + dispatcher mock-clock thread-locals onto one source of truth. This PR adds the trait extraction half of that epic: a new `harn-clock` crate with a single canonical `Clock` trait, three impls, and a recording substrate ready for the testbench replay child issue (#1441).

- **`harn-clock` crate** under `crates/harn-clock/` exposes `Clock` (`now_utc`, `monotonic_ms`, `sleep`, `sleep_until_utc`), `RealClock` (production default), `PausedClock` (fully-virtual; works in both single- and multi-thread runtimes without `start_paused`), and `RecordedClock` + `ClockEventLog` (wraps any inner clock and records every observation for the future replay tape).
- **Cron scheduler** drops its local `Clock` trait and imports `harn_clock::Clock`. `CronConnector::with_clock` is now public so external callers can inject a clock.
- **`triggers::test_util::clock::MockClock`** is now a thin wrapper over `harn_clock::PausedClock`. It keeps both the sync (`set_sync`, `advance_std_sync`, `at_wall_ms`, `now_wall_ms`, `now_monotonic_ms`) and async (`set`, `advance`, `advance_std`, `advance_ticks`) ergonomics so the existing trigger/cron tests and stdlib builtins compile unchanged. It also implements `harn_clock::Clock`, so it can be handed directly to consumers that take `Arc<dyn Clock>`.
- **`OrchestratorHarness`** gains `OrchestratorConfig::with_clock(...)` (default `RealClock`). The harness threads the injected clock into `CronConnector::with_clock(...)` so cron firings inside a harness-driven test run on virtual time.
- **Stdlib `now_ms` / `monotonic_ms` / `sleep_ms` / `mock_time` / `advance_time` / `unmock_time` builtins** continue to share the same crate-wide mock stack as the trigger dispatcher (re-exported as `harn_vm::clock_mock` from #1446); my changes only add the `harn_clock`-based unified trait alongside, with `harn_vm::clock` re-exporting `harn_clock` for downstream crates.
- **Lint**: `scripts/lint_test_patterns.sh` gains a new section that forbids new un-injected wall-clock reads (`SystemTime::now`, `OffsetDateTime::now_utc`, `Instant::now`, `chrono::Utc::now`) in non-test files under `crates/harn-vm/src/` and `crates/harn-cli/src/`, with the existing 104 call sites listed in `NON_TEST_WALL_CLOCK_ALLOWLIST` as gradual cleanup. New files must accept `Arc<dyn Clock>` instead.
- **Docs**: `docs/src/dev/testing.md` adds a `harn_clock::Clock` injection section (preferred for new runtime code) and documents the `OrchestratorConfig::with_clock(...)` plumbing.

## Acceptance criteria status (per #1439)

- [x] `harn-clock` crate compiles and is depended on by `harn-vm` (re-exported as `harn_vm::clock` for `harn-cli`). harn-cloud-side adoption tracked in burin-labs/harn-cloud#189.
- [x] `rg 'trait Clock' crates/` returns one definition (`crates/harn-clock/src/lib.rs`).
- [x] Every cron, trigger-dispatch, and stdlib code path reads time through `Clock` (cron via `harn_clock::Clock`; dispatcher and stdlib via the unified mock stack from #1446).
- [x] `make test` passes (3491 tests). `make lint-test-patterns` passes including the expanded non-test rule.
- [x] No production behavior change. `harn run` and `harn portal` use `RealClock` and look identical.
- [x] [#1427](https://github.com/burin-labs/harn/issues/1427) closed (already closed by #1446).

## Test plan

- [x] `cargo test --workspace` — 3491 tests passing
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check --all` clean
- [x] `bash scripts/lint_test_patterns.sh` clean (catches the new file gate)
- [x] `make all` (skipping portal-check which requires `npm install`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)