### PR TITLE
Add bitbucket entry to connector parity matrix

### DIFF
--- a/conformance/fixtures/connectors/contract-v1/bitbucket/harn.toml
+++ b/conformance/fixtures/connectors/contract-v1/bitbucket/harn.toml
@@ -1,0 +1,45 @@
+[package]
+name = "harn-bitbucket-connector"
+version = "0.1.0"
+repository = "https://github.com/burin-labs/harn-bitbucket-connector"
+
+[[providers]]
+id = "bitbucket"
+connector = { harn = "./lib.harn" }
+capabilities = ["webhook", "rate_limit", "pagination"]
+
+[providers.setup]
+auth_type = "api-key"
+flow = "api-key"
+required_secrets = ["bitbucket/api-token", "bitbucket/webhook-secret"]
+setup_command = ["harn", "connect", "bitbucket"]
+validation_command = ["harn", "connect", "status", "--connector", "bitbucket", "--json"]
+
+[[providers.setup.health_checks]]
+id = "credentials"
+kind = "command"
+command = ["harn", "connect", "status", "--connector", "bitbucket", "--json"]
+
+[providers.setup.recovery]
+missing_auth = "Store bitbucket/api-token and bitbucket/webhook-secret before enabling Bitbucket bindings."
+expired_credentials = "Rotate bitbucket/api-token, then rerun the Bitbucket connection validation."
+revoked_credentials = "Replace bitbucket/api-token with an active Bitbucket app password or access token."
+missing_scopes = "Grant repository and pull request scopes required by the configured Bitbucket workflows."
+inaccessible_resource = "Confirm the token can access the target Bitbucket workspace and repository."
+transient_provider_outage = "Retry after Bitbucket API and webhook delivery endpoints are healthy."
+
+[connector_contract]
+version = 1
+
+[[connector_contract.fixtures]]
+provider = "bitbucket"
+name = "pullrequest created webhook"
+kind = "webhook"
+headers = { "X-Event-Key" = "pullrequest:created", "X-Hook-UUID" = "delivery-bb-1", "content-type" = "application/json" }
+body_json = { actor = { display_name = "Ada" }, repository = { full_name = "acme/widgets" }, pullrequest = { id = 42, title = "Improve widgets" } }
+expect_type = "event"
+expect_kind = "pullrequest:created"
+expect_dedupe_key = "delivery-bb-1"
+expect_signature_state = "verified"
+expect_payload_contains = { provider = "bitbucket", raw = { pullrequest = { id = 42, title = "Improve widgets" }, repository = { full_name = "acme/widgets" } } }
+expect_event_count = 1

--- a/conformance/fixtures/connectors/contract-v1/bitbucket/lib.harn
+++ b/conformance/fixtures/connectors/contract-v1/bitbucket/lib.harn
@@ -1,0 +1,42 @@
+pub fn provider_id() {
+  return "bitbucket"
+}
+
+pub fn kinds() {
+  return ["webhook"]
+}
+
+pub fn payload_schema() {
+  return {
+    harn_schema_name: "BitbucketEventPayload",
+    json_schema: {type: "object", additionalProperties: true},
+  }
+}
+
+pub fn init(ctx) {
+  if !ctx.capabilities.metrics_inc {
+    throw "metrics_inc capability missing"
+  }
+}
+
+pub fn activate(bindings) {
+  metrics_inc("bitbucket_contract_activations", len(bindings))
+}
+
+fn header(headers, name) {
+  return headers[name] ?? headers[lowercase(name)] ?? ""
+}
+
+pub fn normalize_inbound(raw) {
+  let body = raw.body_json ?? json_parse(raw.body_text)
+  let event = header(raw.headers, "X-Event-Key")
+  let delivery = header(raw.headers, "X-Hook-UUID")
+  return {
+    type: "event",
+    event: {kind: event, dedupe_key: delivery, payload: body, signature_status: {state: "verified"}},
+  }
+}
+
+pub fn call(method, _args) {
+  throw "method_not_found:" + method
+}

--- a/docs/src/connectors/parity-matrix.md
+++ b/docs/src/connectors/parity-matrix.md
@@ -11,6 +11,7 @@ Regenerate with `make gen-connector-matrix` and verify with `make check-connecto
 
 | Provider | Package | Webhook | OAuth | Rate limit | Pagination | GraphQL | Streaming |
 |---|---|---:|---:|---:|---:|---:|---:|
+| `bitbucket` | [`harn-bitbucket-connector`](https://github.com/burin-labs/harn-bitbucket-connector) | yes | no | yes | yes | no | no |
 | `github` | [`harn-github-connector`](https://github.com/burin-labs/harn-github-connector) | yes | no | yes | yes | yes | no |
 | `linear` | [`harn-linear-connector`](https://github.com/burin-labs/harn-linear-connector) | yes | yes | yes | yes | yes | no |
 | `notion` | [`harn-notion-connector`](https://github.com/burin-labs/harn-notion-connector) | yes | no | yes | yes | no | no |


### PR DESCRIPTION
## Summary

- Adds a contract-v1 fixture and minimal `lib.harn` for the bitbucket provider so the generated parity matrix reflects the connector's baseline.
- Regenerates `docs/src/connectors/parity-matrix.md` (now includes the `bitbucket` row with `webhook`/`rate_limit`/`pagination` checked).

Pairs with [burin-labs/harn-bitbucket-connector#2](https://github.com/burin-labs/harn-bitbucket-connector/issues/2), which brings the connector implementation up to that parity baseline (shared `verify_hmac_signature`, rate-limit retry against `X-RateLimit-*`/`Retry-After`, and `paginate_cursor`-backed `pagination.list`).

## Test plan

- [x] `harn connector check conformance/fixtures/connectors/contract-v1/bitbucket` passes.
- [x] `cargo run -q -p harn-cli -- dump-connector-matrix --check` passes against the regenerated docs.
- [x] All other contract-v1 fixtures continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)