### PR TITLE
Publish release on tag push so commit-pinned releases ship from the tag

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,39 +1,42 @@
 name: Publish release
 
-# Fires whenever main has tag drift — i.e. Cargo.toml's workspace version
-# is ahead of the latest `vX.Y.Z` git tag. Runs ./scripts/release_ship.sh
-# --finalize, which dry-run publishes, tags, publishes to crates.io, and
-# creates/updates the GitHub release. The tag push (under the
-# harn-release-bot App identity) cascades to build-release-binaries.yml
-# for binary tarballs + multi-arch container.
+# Fires on three triggers:
 #
-# In the consolidated release flow, the human's "Release vX.Y.Z" PR
-# carries both the changelog content AND the Cargo.toml bump. Once it
-# lands, this workflow detects the resulting tag drift and ships
-# vX.Y.Z without a second PR.
+#   1. push to a `vX.Y.Z` tag — the canonical "tag is truth" path. The
+#      bump-fleet `release_harn.harn` harness pushes the tag at the
+#      pinned release commit BEFORE the Release PR merges; this trigger
+#      ships crates.io and the GitHub release from that exact commit,
+#      independent of whatever lands on main between PR-open and merge.
+#      The tag push (under the harn-release-bot App identity) also
+#      cascades to build-release-binaries.yml for tarballs + container.
+#
+#   2. push to main — legacy/recovery drift path. If Cargo.toml's
+#      workspace version is ahead of the latest `vX.Y.Z` tag the
+#      workflow tags HEAD and publishes from there. Under the new
+#      tag-first flow this trigger usually no-ops (the tag was pushed
+#      pre-merge so post-merge main's Cargo.toml already matches the
+#      tag); it remains as the safety net for releases authored without
+#      release_harn.harn (or for an old client that doesn't push tags).
+#
+#   3. workflow_dispatch — manual recovery for the partial-failure case
+#      (tag pushed but crates.io publish was incomplete). With no
+#      drift, dispatch checks out the existing release tag so crates.io,
+#      release notes, and the git tag stay tied to the same commit.
+#      release_ship.sh's per-crate publish skips already-published
+#      crates so manual re-fire is idempotent.
+#
+# Runs ./scripts/release_ship.sh --finalize, which dry-run publishes,
+# tags (no-op if already at HEAD), publishes to crates.io, and
+# creates/updates the GitHub release.
 #
 # Audit is skipped by default (RELEASE_FINALIZE_REAUDIT=0): the
 # merge-queue CI of the just-landed Release PR ran the same gates a
 # few minutes ago. Set the env var or pass `--reaudit` (workflow input
 # `reaudit: true`) to opt back in for paranoid local runs.
-#
-# Tag-drift detection (vs. the older "head commit starts with 'Bump
-# version to '" trigger) means this workflow auto-recovers when an
-# earlier finalize run failed BEFORE pushing the tag. Any subsequent
-# push to main will see drift still present and re-run publish. Once
-# the latest tag matches Cargo.toml's workspace version, drift goes
-# away and push-triggered runs no-op.
-#
-# workflow_dispatch is the recovery path for the one residual case:
-# failure AFTER tag push but BEFORE crates.io publish completed (drift
-# is gone but publish state is partial). Manual recovery checks out the
-# existing release tag when there is no drift, so crates.io, release
-# notes, and the git tag all stay tied to the same commit even if main
-# has moved on. release_ship.sh's per-crate fallback skips
-# already-published, so manual re-fire is idempotent.
 on:
   push:
     branches: [main]
+    tags: ['v*']
   workflow_dispatch:
     inputs:
       bootstrap_new_crates:
@@ -93,11 +96,37 @@ jobs:
 
       - name: Compare Cargo.toml workspace version to latest vX.Y.Z tag
         id: check
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_TYPE: ${{ github.ref_type }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
           set -euo pipefail
           CARGO_VERSION="$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')"
           LATEST_TAG="$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -1)"
           LATEST_VERSION="${LATEST_TAG#v}"
+
+          # Tag-push trigger ("tag is truth"). The release harness pushed
+          # vX.Y.Z at the pinned commit before the Release PR merged.
+          # Skip drift detection — we know what we're publishing — and
+          # check out the tag in the publish job.
+          if [[ "$EVENT_NAME" == "push" && "$REF_TYPE" == "tag" ]]; then
+            if [[ ! "$REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "::error::Tag push for non-vX.Y.Z tag: $REF_NAME"
+              exit 1
+            fi
+            PUBLISH_REF="$REF_NAME"
+            DRIFT=true
+            echo "::notice::Tag push: publishing from $PUBLISH_REF (skipping drift detection)."
+            {
+              echo "drift=$DRIFT"
+              echo "cargo_version=${REF_NAME#v}"
+              echo "latest_tag=$REF_NAME"
+              echo "publish_ref=$PUBLISH_REF"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           if [[ -z "$LATEST_TAG" ]]; then
             DRIFT=true
             echo "::notice::No vX.Y.Z tags exist yet; treating Cargo.toml=$CARGO_VERSION as drift (first release)."
@@ -109,7 +138,7 @@ jobs:
             echo "::notice::Cargo.toml=$CARGO_VERSION matches latest tag $LATEST_TAG → no-op."
           fi
           PUBLISH_REF=main
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "$DRIFT" == "false" && -n "$LATEST_TAG" ]]; then
+          if [[ "$EVENT_NAME" == "workflow_dispatch" && "$DRIFT" == "false" && -n "$LATEST_TAG" ]]; then
             PUBLISH_REF="$LATEST_TAG"
             echo "::notice::Manual recovery has no tag drift; publishing from existing tag $LATEST_TAG instead of current main."
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,19 @@ condensed series summaries instead of full per-patch history.
   [docs/src/dev/platform-compatibility.md](docs/src/dev/platform-compatibility.md)
   with a per-capability support matrix and rationale for the
   Windows-deferred features (POSIX-signal drain, `unveil`/`pledge`).
+- **Tag-first publish trigger.** `publish-release.yml` now also fires
+  on `push: tags: ['v*']`, in addition to the existing `push: main`
+  drift trigger. Detect-drift recognizes the tag-push event and sets
+  `publish_ref=$tag, drift=true` so the publish job checks out the
+  tagged commit (detached) and ships from there. Lets the bump-fleet
+  `release_harn.harn` harness push `vX.Y.Z` at a pinned commit BEFORE
+  the Release PR merges — what gets shipped to crates.io and the
+  GitHub release is anchored to that exact commit, and commits that
+  land on `main` between PR-open and merge cannot leak into the
+  published artifact. The `push: main` drift trigger remains as the
+  legacy/recovery path for releases authored without the harness;
+  workflow_dispatch with no drift still recovers from an existing
+  tag.
 
 ### Fixed
 

--- a/scripts/release_ship.sh
+++ b/scripts/release_ship.sh
@@ -69,8 +69,9 @@ Merge-queue-safe release sequence for a prepared Harn release.
 DEFAULT FLOW (one human PR, then bot finalizes)
 ==============================================================================
 
-  1. Branch off main and write the release content:
-       git checkout -b release/vX.Y.Z
+  1. Branch off main at a frozen commit (release_harn.harn does this
+     automatically) and write the release content:
+       git checkout -b release/vX.Y.Z <pin-sha>
        # author code/docs changes
        # add `## vX.Y.Z` heading at the top of CHANGELOG.md
 
@@ -81,14 +82,22 @@ DEFAULT FLOW (one human PR, then bot finalizes)
      everything ready for a single commit:
        ./scripts/release_ship.sh --prepare --bump patch
 
-  4. Commit + push + open PR (one commit, one PR for the whole release):
+  4. Commit + push + tag + push tag + open PR. The release_harn.harn
+     harness orchestrates these in order so the tag is on origin BEFORE
+     the PR is opened:
        git commit -m "Release vX.Y.Z"
        git push -u origin release/vX.Y.Z
+       git tag -a vX.Y.Z -m "Release vX.Y.Z"
+       git push origin vX.Y.Z              # ← triggers publish-release.yml
        gh pr create
 
-  5. Land the PR through the merge queue. Walk away — the Finalize
-     Release workflow auto-fires on tag drift, tags vX.Y.Z, publishes
-     to crates.io, and creates the GitHub release. No second PR.
+  5. publish-release.yml fires on the tag push, checks out the tagged
+     commit (detached), and finalizes — crates.io publish, GitHub
+     release, build-release-binaries cascade — all from the pinned
+     commit. The Release PR remains as paperwork; auto-merge can land
+     it whenever, even if main has moved on. The post-merge push to
+     main no-ops (no drift, since Cargo.toml on main now matches the
+     tag).
 
 ==============================================================================
 PREPARE MODE
@@ -124,18 +133,30 @@ FINALIZE MODE
   highlight + language-spec sync checks, docs-snippets, trigger
   quickref + examples, verify_release_metadata, portal lint+build).
 
+  Two checkout shapes are supported, picked automatically:
+
+    a. Detached at vX.Y.Z (the canonical "tag is truth" path) — fired
+       by publish-release.yml on tag push, OR a local recovery run
+       after manually `git checkout v0.7.53`. Skips the main
+       fast-forward and publishes the already-tagged commit, so
+       crates.io content, release notes, and the tag stay aligned
+       even if main has moved on.
+
+    b. On main with drift — legacy/recovery path. Fast-forwards local
+       main, tags HEAD as vX.Y.Z (must match Cargo.toml's workspace
+       version), pushes the tag, and publishes. Used when a release
+       was authored without release_harn.harn or the tag-push trigger
+       failed and we're recovering via push:main drift.
+
+  Steps in either case:
+
   1. Builds the portal frontend (needed for the cargo-publish include).
   2. Runs the publish dry-run as a quick pre-publish sanity check.
-  3. Creates and pushes tag vX.Y.Z from main.
-  4. Runs cargo publish to upload crates to crates.io.
-  5. Renders changelog-backed release notes.
-  6. Creates/updates a GitHub release with the rendered notes.
-
-  Manual recovery after a tag was already pushed may run from a
-  detached HEAD at vX.Y.Z. In that case finalize skips the main
-  fast-forward check and publishes the already-tagged commit, keeping
-  crates.io content, release notes, and the tag aligned even if main
-  has moved on.
+  3. Creates the tag vX.Y.Z at HEAD (no-op if it already exists at HEAD).
+  4. Pushes the tag (no-op if origin already has it).
+  5. Runs cargo publish to upload crates to crates.io.
+  6. Renders changelog-backed release notes.
+  7. Creates/updates a GitHub release with the rendered notes.
 
   Set RELEASE_FINALIZE_REAUDIT=1 (or pass --reaudit) to opt back into
   the full release-gate audit before finalizing — useful when running


### PR DESCRIPTION
## Summary

- `publish-release.yml` now also fires on `push: tags: ['v*']`.
- `detect-drift` handles the tag-push event by setting `publish_ref=$tag, drift=true` (skipping drift detection — we know what we're publishing).
- The publish job's existing `Select publish ref` step + `release_ship.sh --finalize`'s detached-HEAD-at-tag path already handle the rest, so no Rust/script logic changes are needed.
- `release_ship.sh` help text + `CHANGELOG.md` document the new tag-first flow.

Pairs with **burin-labs/harn-bump-fleet#feature/release-pin-to-commit** (`release_harn.harn` pushes the tag at the pinned release commit before the Release PR merges). Once both land, what reaches crates.io and the GitHub release is anchored to the pinned commit; commits landing on `main` between PR-open and merge cannot leak into the published artifact. The `push: main` drift trigger remains as the legacy/recovery path; `workflow_dispatch` with no drift still recovers from an existing tag.

## Test plan

- [x] `actionlint .github/workflows/*.yml` clean
- [x] `bash -n scripts/release_ship.sh` clean
- [x] `make lint-md` clean (CHANGELOG entry within line limits)
- [x] `python3 scripts/verify_release_metadata.py` clean
- [ ] Tag-push trigger end-to-end via real release after this lands (the bump-fleet PR will exercise it)
- [ ] Verify post-merge `push: main` no-ops when tag already exists at matching version (existing drift logic; covered by next release)