### PR TITLE
Add workflow patch proposals + safe Harn function tools (#1423)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,28 @@ condensed series summaries instead of full per-patch history.
   `harn update` now accept `--json`. v1 lockfiles migrate transparently
   on the next install. Documented the cross-repo bump workflow in
   `docs/src/package-authoring.md`. (#1428)
+- **Workflow patch proposals + safe Harn function tools.** Agents can now
+  author bounded, auditable changes to a workflow bundle through a flat
+  patch JSON (`insert_node`, `add_edge`, `upsert_prompt_capsule`,
+  `update_node_policy`, `update_bundle_policy`) instead of regenerating
+  the whole bundle. Three new `harn workflow patch
+  {validate,apply,preview}` subcommands apply the patch to a copy,
+  re-run the bundle validator, emit a structural diff, and reject
+  anything that widens the parent capability ceiling along *tools*,
+  *capabilities*, *side-effect level*, *workspace roots*, *connector
+  scopes*, *command gates*, or *autonomy tier*. `harn workflow
+  function-tools` enumerates an allowlist of read-only / pure-think
+  Harn functions an agent may call from inside the patch loop, each
+  carrying an ACP-aligned `ToolAnnotations` block hosts can wire
+  straight into a model surface. `harn workflow nested-ceiling`
+  exposes the same scanner used internally so hosts can reject nested
+  Harn invocations (workflow bundles, Harn scripts, Burin harness
+  manifests) that would widen the active execution policy. The
+  workflow-authoring skill pack and `docs/src/workflow-bundles.md`
+  cover the contract; a new
+  `crates/harn-cli/tests/workflow_patch_cli.rs` gate exercises the
+  validate / apply / preview / function-tools / nested-ceiling surfaces
+  end-to-end. (#1423)
 - **Python and Go protocol bindings.** Extended
   `harn dump-protocol-artifacts` to emit a stdlib-only Python 3.9+ module
   (`spec/protocol-artifacts/python/harn_protocol.py`) and a Go package

--- a/crates/harn-cli/src/cli/mod.rs
+++ b/crates/harn-cli/src/cli/mod.rs
@@ -155,7 +155,11 @@ pub(crate) use trust::{
 pub(crate) use verify::VerifyArgs;
 pub(crate) use viz::VizArgs;
 pub(crate) use watch::WatchArgs;
-pub(crate) use workflow::{WorkflowArgs, WorkflowCommand};
+pub(crate) use workflow::{
+    WorkflowArgs, WorkflowCommand, WorkflowFunctionToolsArgs, WorkflowNestedCeilingArgs,
+    WorkflowPatchApplyArgs, WorkflowPatchCommand, WorkflowPatchPreviewArgs,
+    WorkflowPatchValidateArgs,
+};
 
 use clap::{Parser, Subcommand};
 

--- a/crates/harn-cli/src/cli/workflow.rs
+++ b/crates/harn-cli/src/cli/workflow.rs
@@ -14,6 +14,15 @@ pub(crate) enum WorkflowCommand {
     Preview(WorkflowPreviewArgs),
     /// Materialize a deterministic local run receipt for a bundle.
     Run(WorkflowRunArgs),
+    /// Apply, validate, or preview an agent-authored workflow patch.
+    #[command(subcommand)]
+    Patch(WorkflowPatchCommand),
+    /// List the safe Harn function tools an agent may call from the
+    /// workflow-patch authoring loop.
+    FunctionTools(WorkflowFunctionToolsArgs),
+    /// Check whether running a target bundle would widen a parent
+    /// capability ceiling.
+    NestedCeiling(WorkflowNestedCeilingArgs),
 }
 
 #[derive(Debug, Args)]
@@ -34,6 +43,91 @@ pub(crate) struct WorkflowPreviewArgs {
     /// Emit Mermaid graph text for quick debugging.
     #[arg(long)]
     pub mermaid: bool,
+    /// Emit JSON.
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum WorkflowPatchCommand {
+    /// Apply, validate, and capability-check a patch without writing
+    /// anything. Emits diagnostics, the structural diff, and the
+    /// capability delta.
+    Validate(WorkflowPatchValidateArgs),
+    /// Apply a patch and write the resulting bundle JSON to disk.
+    Apply(WorkflowPatchApplyArgs),
+    /// Apply a patch in memory and emit the normalized preview of the
+    /// resulting bundle (graph, mermaid, validation).
+    Preview(WorkflowPatchPreviewArgs),
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct WorkflowPatchValidateArgs {
+    /// Portable workflow bundle JSON path.
+    #[arg(long)]
+    pub bundle: String,
+    /// Workflow patch JSON path.
+    #[arg(long)]
+    pub patch: String,
+    /// Optional parent capability policy JSON path. When supplied, the
+    /// patch is rejected if it asks for more than this ceiling.
+    #[arg(long = "parent-ceiling", value_name = "PATH")]
+    pub parent_ceiling: Option<String>,
+    /// Emit JSON.
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct WorkflowPatchApplyArgs {
+    /// Portable workflow bundle JSON path.
+    #[arg(long)]
+    pub bundle: String,
+    /// Workflow patch JSON path.
+    #[arg(long)]
+    pub patch: String,
+    /// Output bundle JSON path.
+    #[arg(long)]
+    pub out: String,
+    /// Optional parent capability policy JSON path; mirrors `validate`.
+    #[arg(long = "parent-ceiling", value_name = "PATH")]
+    pub parent_ceiling: Option<String>,
+    /// Emit JSON.
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct WorkflowPatchPreviewArgs {
+    /// Portable workflow bundle JSON path.
+    #[arg(long)]
+    pub bundle: String,
+    /// Workflow patch JSON path.
+    #[arg(long)]
+    pub patch: String,
+    /// Emit Mermaid graph text instead of JSON.
+    #[arg(long)]
+    pub mermaid: bool,
+    /// Emit JSON.
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct WorkflowFunctionToolsArgs {
+    /// Emit JSON.
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct WorkflowNestedCeilingArgs {
+    /// Portable workflow bundle JSON path.
+    #[arg(long)]
+    pub bundle: String,
+    /// Parent capability policy JSON path.
+    #[arg(long)]
+    pub parent: String,
     /// Emit JSON.
     #[arg(long)]
     pub json: bool,

--- a/crates/harn-cli/src/commands/workflow.rs
+++ b/crates/harn-cli/src/commands/workflow.rs
@@ -1,10 +1,22 @@
 use std::fs;
 use std::path::Path;
 
-use crate::cli::{WorkflowArgs, WorkflowCommand};
+use harn_vm::orchestration::{
+    enforce_nested_invocation_ceiling, load_workflow_bundle, safe_function_tools,
+    validate_workflow_patch, NestedInvocationTarget, SafeFunctionToolDescriptor, WorkflowPatch,
+};
+
+use crate::cli::{
+    WorkflowArgs, WorkflowCommand, WorkflowFunctionToolsArgs, WorkflowNestedCeilingArgs,
+    WorkflowPatchApplyArgs, WorkflowPatchCommand, WorkflowPatchPreviewArgs,
+    WorkflowPatchValidateArgs,
+};
 
 pub(crate) fn handle(args: WorkflowArgs) -> Result<i32, String> {
     match args.command {
+        WorkflowCommand::Patch(command) => handle_patch(command),
+        WorkflowCommand::FunctionTools(args) => handle_function_tools(args),
+        WorkflowCommand::NestedCeiling(args) => handle_nested_ceiling(args),
         WorkflowCommand::Validate(args) => {
             let bundle = harn_vm::orchestration::load_workflow_bundle(Path::new(&args.bundle))
                 .map_err(|error| format!("failed to load workflow bundle: {error}"))?;
@@ -94,4 +106,220 @@ fn validation_error_message(
         lines.push(format!("{}: {}", diagnostic.path, diagnostic.message));
     }
     lines.join("\n")
+}
+
+fn handle_patch(command: WorkflowPatchCommand) -> Result<i32, String> {
+    match command {
+        WorkflowPatchCommand::Validate(args) => handle_patch_validate(args),
+        WorkflowPatchCommand::Apply(args) => handle_patch_apply(args),
+        WorkflowPatchCommand::Preview(args) => handle_patch_preview(args),
+    }
+}
+
+fn handle_patch_validate(args: WorkflowPatchValidateArgs) -> Result<i32, String> {
+    let bundle = load_workflow_bundle(Path::new(&args.bundle))
+        .map_err(|error| format!("failed to load workflow bundle: {error}"))?;
+    let patch = load_patch(&args.patch)?;
+    let parent_ceiling = match args.parent_ceiling.as_deref() {
+        Some(path) => Some(load_capability_policy(path)?),
+        None => None,
+    };
+    let report = validate_workflow_patch(&bundle, &patch, parent_ceiling.as_ref());
+    if args.json {
+        print_json(&report)?;
+    } else {
+        print_patch_report(&report);
+    }
+    Ok(if report.valid { 0 } else { 1 })
+}
+
+fn handle_patch_apply(args: WorkflowPatchApplyArgs) -> Result<i32, String> {
+    let bundle = load_workflow_bundle(Path::new(&args.bundle))
+        .map_err(|error| format!("failed to load workflow bundle: {error}"))?;
+    let patch = load_patch(&args.patch)?;
+    let parent_ceiling = match args.parent_ceiling.as_deref() {
+        Some(path) => Some(load_capability_policy(path)?),
+        None => None,
+    };
+    let report = validate_workflow_patch(&bundle, &patch, parent_ceiling.as_ref());
+    if !report.valid {
+        if args.json {
+            print_json(&report)?;
+        } else {
+            print_patch_report(&report);
+        }
+        return Ok(1);
+    }
+    let patched =
+        harn_vm::orchestration::apply_workflow_patch(&bundle, &patch).map_err(|errors| {
+            errors
+                .iter()
+                .map(|err| format!("{}: {}", err.path, err.message))
+                .collect::<Vec<_>>()
+                .join("\n")
+        })?;
+    let serialized = serde_json::to_string_pretty(&patched)
+        .map_err(|error| format!("failed to serialize patched bundle: {error}"))?;
+    fs::write(&args.out, &serialized)
+        .map_err(|error| format!("failed to write patched bundle {}: {error}", args.out))?;
+    if args.json {
+        print_json(&report)?;
+    } else {
+        println!(
+            "wrote patched workflow bundle {} → {} ({})",
+            patched.id, args.out, report.bundle_validation.graph_digest
+        );
+        print_patch_report(&report);
+    }
+    Ok(0)
+}
+
+fn handle_patch_preview(args: WorkflowPatchPreviewArgs) -> Result<i32, String> {
+    let bundle = load_workflow_bundle(Path::new(&args.bundle))
+        .map_err(|error| format!("failed to load workflow bundle: {error}"))?;
+    let patch = load_patch(&args.patch)?;
+    let report = validate_workflow_patch(&bundle, &patch, None);
+    if args.json {
+        print_json(&report)?;
+    } else if args.mermaid {
+        println!("{}", report.graph_export.mermaid);
+    } else {
+        print_patch_report(&report);
+    }
+    Ok(if report.bundle_validation.valid { 0 } else { 1 })
+}
+
+fn handle_function_tools(args: WorkflowFunctionToolsArgs) -> Result<i32, String> {
+    let descriptors: Vec<SafeFunctionToolDescriptor> = safe_function_tools()
+        .into_iter()
+        .map(|tool| tool.descriptor)
+        .collect();
+    if args.json {
+        print_json(&descriptors)?;
+    } else {
+        for descriptor in &descriptors {
+            println!(
+                "{} ({:?}, {:?})",
+                descriptor.name,
+                descriptor.annotations.kind,
+                descriptor.annotations.side_effect_level,
+            );
+            println!("  {}", descriptor.description);
+        }
+    }
+    Ok(0)
+}
+
+fn handle_nested_ceiling(args: WorkflowNestedCeilingArgs) -> Result<i32, String> {
+    let bundle = load_workflow_bundle(Path::new(&args.bundle))
+        .map_err(|error| format!("failed to load workflow bundle: {error}"))?;
+    let parent = load_capability_policy(&args.parent)?;
+    let report = enforce_nested_invocation_ceiling(
+        &parent,
+        &NestedInvocationTarget::WorkflowBundle(&bundle),
+    );
+    if args.json {
+        print_json(&report)?;
+    } else if report.allowed() {
+        println!(
+            "nested invocation allowed: bundle {} fits inside parent ceiling",
+            report.target_label
+        );
+    } else {
+        println!(
+            "nested invocation rejected: bundle {} widens parent ceiling",
+            report.target_label
+        );
+        for violation in &report.violations {
+            println!("  [{}] {}", violation.kind, violation.detail);
+        }
+    }
+    Ok(if report.allowed() { 0 } else { 1 })
+}
+
+fn load_patch(path: &str) -> Result<WorkflowPatch, String> {
+    let bytes = fs::read(path).map_err(|error| format!("failed to read patch {path}: {error}"))?;
+    serde_json::from_slice(&bytes).map_err(|error| format!("failed to parse patch {path}: {error}"))
+}
+
+fn load_capability_policy(path: &str) -> Result<harn_vm::orchestration::CapabilityPolicy, String> {
+    let bytes =
+        fs::read(path).map_err(|error| format!("failed to read parent ceiling {path}: {error}"))?;
+    serde_json::from_slice(&bytes)
+        .map_err(|error| format!("failed to parse parent ceiling {path}: {error}"))
+}
+
+fn print_patch_report(report: &harn_vm::orchestration::WorkflowPatchValidationReport) {
+    if report.valid {
+        println!(
+            "patch {} applies cleanly to bundle {} ({})",
+            report.patch_id, report.bundle_id, report.bundle_validation.graph_digest
+        );
+    } else {
+        println!(
+            "patch {} cannot apply to bundle {}",
+            report.patch_id, report.bundle_id
+        );
+    }
+    for diagnostic in &report.apply_errors {
+        let op_label = match (&diagnostic.op, diagnostic.op_index) {
+            (Some(op), Some(index)) => format!("[{op} #{index}] "),
+            (Some(op), None) => format!("[{op}] "),
+            _ => String::new(),
+        };
+        println!(
+            "  apply error {op_label}{}: {}",
+            diagnostic.path, diagnostic.message
+        );
+    }
+    for diagnostic in &report.bundle_validation.errors {
+        println!("  bundle error {}: {}", diagnostic.path, diagnostic.message);
+    }
+    for diagnostic in &report.bundle_validation.warnings {
+        println!(
+            "  bundle warning {}: {}",
+            diagnostic.path, diagnostic.message
+        );
+    }
+    if !report.graph_diff.added_nodes.is_empty() {
+        println!(
+            "  added nodes: {}",
+            report.graph_diff.added_nodes.join(", ")
+        );
+    }
+    if !report.graph_diff.added_edges.is_empty() {
+        println!("  added edges:");
+        for edge in &report.graph_diff.added_edges {
+            let branch = edge
+                .branch
+                .as_deref()
+                .map(|b| format!(" [{b}]"))
+                .unwrap_or_default();
+            println!("    {} -> {}{branch}", edge.from, edge.to);
+        }
+    }
+    if !report.graph_diff.updated_nodes.is_empty() {
+        println!(
+            "  updated nodes: {}",
+            report.graph_diff.updated_nodes.join(", ")
+        );
+    }
+    if !report.graph_diff.updated_capsules.is_empty() {
+        println!(
+            "  updated prompt capsules: {}",
+            report.graph_diff.updated_capsules.join(", ")
+        );
+    }
+    if !report.graph_diff.policy_fields_changed.is_empty() {
+        println!(
+            "  policy fields changed: {}",
+            report.graph_diff.policy_fields_changed.join(", ")
+        );
+    }
+    for violation in &report.capability_delta.widening {
+        println!(
+            "  ceiling widening [{}]: {}",
+            violation.kind, violation.detail
+        );
+    }
 }

--- a/crates/harn-cli/tests/workflow_patch_cli.rs
+++ b/crates/harn-cli/tests/workflow_patch_cli.rs
@@ -1,0 +1,256 @@
+//! End-to-end coverage for `harn workflow patch`, `harn workflow function-tools`,
+//! and `harn workflow nested-ceiling` JSON surfaces.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn binary_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_harn"))
+}
+
+fn manifest_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn fixture(path: &str) -> PathBuf {
+    manifest_dir().join("../..").join(path)
+}
+
+fn run_harn(args: &[&str]) -> std::process::Output {
+    Command::new(binary_path())
+        .args(args)
+        .output()
+        .expect("spawn harn")
+}
+
+fn stdout_json(output: &std::process::Output) -> serde_json::Value {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(stdout.trim()).unwrap_or_else(|error| {
+        panic!("stdout is not JSON: {error}\nstdout:\n{stdout}");
+    })
+}
+
+#[test]
+fn workflow_patch_validate_emits_structured_diff_and_capability_delta() {
+    let bundle = fixture("docs/fixtures/workflow-bundles/github-pr-monitor.bundle.json");
+    let patch = fixture("docs/fixtures/workflow-bundles/pr-monitor-verifier.patch.json");
+    let output = run_harn(&[
+        "workflow",
+        "patch",
+        "validate",
+        "--bundle",
+        bundle.to_str().unwrap(),
+        "--patch",
+        patch.to_str().unwrap(),
+        "--json",
+    ]);
+    assert!(output.status.success(), "{output:?}");
+    let report = stdout_json(&output);
+    assert_eq!(report["valid"], serde_json::json!(true));
+    assert_eq!(report["patch_id"], "pr-monitor-verifier-001");
+    let added = report["graph_diff"]["added_nodes"].as_array().unwrap();
+    let added_strings: Vec<String> = added
+        .iter()
+        .map(|value| value.as_str().unwrap().to_string())
+        .collect();
+    assert!(added_strings.contains(&"verify_logs".to_string()));
+    assert!(added_strings.contains(&"repair_logs".to_string()));
+    assert!(report["bundle_validation"]["valid"]
+        .as_bool()
+        .unwrap_or(false));
+    assert!(report["capability_delta"]["widening"]
+        .as_array()
+        .unwrap()
+        .is_empty());
+}
+
+#[test]
+fn workflow_patch_apply_writes_valid_bundle() {
+    let bundle = fixture("docs/fixtures/workflow-bundles/github-pr-monitor.bundle.json");
+    let patch = fixture("docs/fixtures/workflow-bundles/pr-monitor-verifier.patch.json");
+    let temp = tempfile::tempdir().unwrap();
+    let out = temp.path().join("patched.bundle.json");
+    let output = run_harn(&[
+        "workflow",
+        "patch",
+        "apply",
+        "--bundle",
+        bundle.to_str().unwrap(),
+        "--patch",
+        patch.to_str().unwrap(),
+        "--out",
+        out.to_str().unwrap(),
+        "--json",
+    ]);
+    assert!(output.status.success(), "{output:?}");
+    let report = stdout_json(&output);
+    assert_eq!(report["valid"], serde_json::json!(true));
+    let validate = run_harn(&[
+        "workflow",
+        "validate",
+        "--bundle",
+        out.to_str().unwrap(),
+        "--json",
+    ]);
+    assert!(validate.status.success());
+    let validation = stdout_json(&validate);
+    assert_eq!(validation["valid"], serde_json::json!(true));
+}
+
+#[test]
+fn workflow_patch_validate_rejects_widening_against_parent() {
+    let bundle = fixture("docs/fixtures/workflow-bundles/github-pr-monitor.bundle.json");
+    let temp = tempfile::tempdir().unwrap();
+    let patch_path = temp.path().join("widening.patch.json");
+    std::fs::write(
+        &patch_path,
+        r#"{
+            "schema_version": 1,
+            "id": "patch-widen-autonomy",
+            "operations": [
+                {"op": "update_bundle_policy", "policy": {"autonomy_tier": "act_auto"}}
+            ]
+        }"#,
+    )
+    .unwrap();
+    let parent_path = temp.path().join("parent.json");
+    std::fs::write(
+        &parent_path,
+        r#"{
+            "tools": [],
+            "capabilities": {
+                "workspace": ["read_text", "list"],
+                "connector": ["call"],
+                "process": ["exec"]
+            },
+            "side_effect_level": "process_exec"
+        }"#,
+    )
+    .unwrap();
+    let output = run_harn(&[
+        "workflow",
+        "patch",
+        "validate",
+        "--bundle",
+        bundle.to_str().unwrap(),
+        "--patch",
+        patch_path.to_str().unwrap(),
+        "--parent-ceiling",
+        parent_path.to_str().unwrap(),
+        "--json",
+    ]);
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit: {output:?}"
+    );
+    let report = stdout_json(&output);
+    assert_eq!(report["valid"], serde_json::json!(false));
+    let kinds: Vec<String> = report["capability_delta"]["widening"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v["kind"].as_str().unwrap().to_string())
+        .collect();
+    assert!(kinds.contains(&"autonomy_tier".to_string()));
+}
+
+#[test]
+fn workflow_function_tools_lists_safe_descriptors() {
+    let output = run_harn(&["workflow", "function-tools", "--json"]);
+    assert!(output.status.success(), "{output:?}");
+    let descriptors = stdout_json(&output);
+    let array = descriptors.as_array().expect("function-tools is an array");
+    assert!(!array.is_empty());
+    for descriptor in array {
+        let kind = descriptor["annotations"]["kind"].as_str().unwrap();
+        assert!(
+            matches!(kind, "read" | "search" | "think" | "fetch"),
+            "non-read kind in registry: {kind}"
+        );
+        let level = descriptor["annotations"]["side_effect_level"]
+            .as_str()
+            .unwrap();
+        assert!(
+            matches!(level, "none" | "read_only"),
+            "non-readonly: {level}"
+        );
+    }
+    let names: Vec<String> = array
+        .iter()
+        .map(|d| d["name"].as_str().unwrap().to_string())
+        .collect();
+    assert!(names.contains(&"workflow_patch_validate".to_string()));
+    assert!(names.contains(&"workflow_bundle_validate".to_string()));
+    assert!(names.contains(&"workflow_bundle_preview".to_string()));
+}
+
+#[test]
+fn skill_pack_pr_monitor_verifier_patch_validates_against_recipe_bundle() {
+    let bundle = manifest_dir()
+        .join("../..")
+        .join("examples/skill-packs/workflow-authoring/recipes/pr-monitor/bundle.json");
+    let patch = manifest_dir().join("../..").join(
+        "examples/skill-packs/workflow-authoring/recipes/pr-monitor-verifier-patch/patch.json",
+    );
+    let parent = manifest_dir()
+        .join("../..")
+        .join("docs/fixtures/workflow-bundles/parent-act-with-approval.policy.json");
+
+    let output = run_harn(&[
+        "workflow",
+        "patch",
+        "validate",
+        "--bundle",
+        bundle.to_str().unwrap(),
+        "--patch",
+        patch.to_str().unwrap(),
+        "--parent-ceiling",
+        parent.to_str().unwrap(),
+        "--json",
+    ]);
+    assert!(output.status.success(), "{output:?}");
+    let report = stdout_json(&output);
+    assert_eq!(report["valid"], serde_json::json!(true));
+    assert!(report["capability_delta"]["widening"]
+        .as_array()
+        .unwrap()
+        .is_empty());
+    let added: Vec<String> = report["graph_diff"]["added_nodes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect();
+    assert!(added.contains(&"verify_logs".to_string()));
+    assert!(added.contains(&"repair_logs".to_string()));
+}
+
+#[test]
+fn workflow_nested_ceiling_rejects_act_auto_under_read_only_parent() {
+    let bundle = fixture("docs/fixtures/workflow-bundles/github-pr-monitor.bundle.json");
+    let temp = tempfile::tempdir().unwrap();
+    let parent_path = temp.path().join("ro-parent.json");
+    std::fs::write(
+        &parent_path,
+        r#"{
+            "tools": [],
+            "capabilities": {
+                "workspace": ["read_text", "list", "exists"]
+            },
+            "side_effect_level": "read_only"
+        }"#,
+    )
+    .unwrap();
+    let output = run_harn(&[
+        "workflow",
+        "nested-ceiling",
+        "--bundle",
+        bundle.to_str().unwrap(),
+        "--parent",
+        parent_path.to_str().unwrap(),
+        "--json",
+    ]);
+    assert!(!output.status.success(), "{output:?}");
+    let report = stdout_json(&output);
+    assert!(!report["violations"].as_array().unwrap().is_empty());
+}

--- a/crates/harn-vm/src/orchestration/mod.rs
+++ b/crates/harn-vm/src/orchestration/mod.rs
@@ -66,6 +66,18 @@ pub use workflow::*;
 mod workflow_bundle;
 pub use workflow_bundle::*;
 
+mod workflow_patch;
+pub use workflow_patch::*;
+
+mod safe_function_tools;
+pub use safe_function_tools::*;
+
+mod nested_invocation;
+pub use nested_invocation::*;
+
+#[cfg(test)]
+mod workflow_test_fixtures;
+
 mod records;
 pub use records::*;
 

--- a/crates/harn-vm/src/orchestration/nested_invocation.rs
+++ b/crates/harn-vm/src/orchestration/nested_invocation.rs
@@ -1,0 +1,588 @@
+//! Capability-ceiling guard for nested Harn invocations.
+//!
+//! When a script that already runs under a parent execution policy
+//! launches another Harn invocation — `harn run`, `harn workflow run`,
+//! `harn supervisor fire/replay`, or a Burin harness — Harn must scan
+//! the target and reject anything that asks for *more* than the parent
+//! ceiling. This module hosts the scanner: it accepts a parent
+//! [`CapabilityPolicy`] plus a description of the nested target, and
+//! returns the list of dimensions where the target widens the parent.
+//!
+//! The scanner is deliberately conservative: when in doubt about what
+//! the target requests, it errs on the side of "ask for more" so the
+//! parent rejects rather than silently widens. It is the integration
+//! layer's job to wire this into the actual launch points (the `exec`,
+//! `shell`, `host_call` builtins, the workflow CLI, the supervisor
+//! API).
+
+use std::collections::BTreeSet;
+
+use serde::{Deserialize, Serialize};
+
+use super::workflow_bundle::WorkflowBundle;
+use super::workflow_patch::{bundle_capability_ceiling, CapabilityCeilingViolation};
+use super::CapabilityPolicy;
+
+/// One Harn invocation that could be launched from inside another.
+/// Each variant carries the data the scanner needs to project an
+/// effective requested ceiling.
+#[derive(Clone, Debug)]
+pub enum NestedInvocationTarget<'a> {
+    /// A `harn workflow run`-style invocation against a parsed bundle.
+    WorkflowBundle(&'a WorkflowBundle),
+    /// A `harn run`-style invocation against a Harn script source. The
+    /// scanner does a coarse string scan for builtins that require
+    /// elevated capabilities; that is enough to catch the obvious
+    /// widening attempts without forcing the AST into this layer.
+    HarnScript { path: &'a str, source: &'a str },
+    /// A Burin harness manifest. The scanner reads
+    /// `capability_ceiling` and `tools` if present, falling back to
+    /// "request everything" so the parent rejects unstructured
+    /// manifests rather than rubber-stamping them.
+    BurinHarness { manifest: &'a serde_json::Value },
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+pub struct NestedInvocationCeilingReport {
+    pub target_kind: String,
+    pub target_label: String,
+    pub parent: CapabilityPolicy,
+    pub requested: CapabilityPolicy,
+    pub violations: Vec<CapabilityCeilingViolation>,
+}
+
+impl NestedInvocationCeilingReport {
+    pub fn allowed(&self) -> bool {
+        self.violations.is_empty()
+    }
+}
+
+/// Compute the capability ceiling that running `target` would request
+/// of its parent runtime. This mirrors the projection used inside
+/// [`bundle_capability_ceiling`] so workflow bundles and standalone
+/// scripts share one comparison axis.
+pub fn requested_ceiling_for_target(target: &NestedInvocationTarget<'_>) -> CapabilityPolicy {
+    match target {
+        NestedInvocationTarget::WorkflowBundle(bundle) => bundle_capability_ceiling(bundle),
+        NestedInvocationTarget::HarnScript { source, .. } => scan_harn_script_ceiling(source),
+        NestedInvocationTarget::BurinHarness { manifest } => scan_burin_manifest_ceiling(manifest),
+    }
+}
+
+/// Enforce the parent ceiling against a nested invocation target.
+/// Returns a populated report; callers reject the launch if
+/// `report.allowed()` is false.
+pub fn enforce_nested_invocation_ceiling(
+    parent: &CapabilityPolicy,
+    target: &NestedInvocationTarget<'_>,
+) -> NestedInvocationCeilingReport {
+    let requested = requested_ceiling_for_target(target);
+    let violations = collect_violations(parent, &requested);
+    let (kind, label) = match target {
+        NestedInvocationTarget::WorkflowBundle(bundle) => {
+            ("workflow_bundle".to_string(), bundle.id.clone())
+        }
+        NestedInvocationTarget::HarnScript { path, .. } => {
+            ("harn_script".to_string(), path.to_string())
+        }
+        NestedInvocationTarget::BurinHarness { manifest } => {
+            let label = manifest
+                .get("id")
+                .and_then(|value| value.as_str())
+                .unwrap_or("<unknown>")
+                .to_string();
+            ("burin_harness".to_string(), label)
+        }
+    };
+    NestedInvocationCeilingReport {
+        target_kind: kind,
+        target_label: label,
+        parent: parent.clone(),
+        requested,
+        violations,
+    }
+}
+
+fn collect_violations(
+    parent: &CapabilityPolicy,
+    requested: &CapabilityPolicy,
+) -> Vec<CapabilityCeilingViolation> {
+    let mut violations = Vec::new();
+    if !parent.tools.is_empty() {
+        for tool in &requested.tools {
+            if !parent.tools.contains(tool) {
+                violations.push(CapabilityCeilingViolation {
+                    kind: "tool".to_string(),
+                    detail: format!("nested target requests tool '{tool}' outside parent ceiling"),
+                });
+            }
+        }
+    }
+    for (capability, ops) in &requested.capabilities {
+        match parent.capabilities.get(capability) {
+            Some(parent_ops) => {
+                for op in ops {
+                    if !parent_ops.contains(op) {
+                        violations.push(CapabilityCeilingViolation {
+                            kind: "capability".to_string(),
+                            detail: format!(
+                                "nested target requests '{capability}.{op}' outside parent ceiling"
+                            ),
+                        });
+                    }
+                }
+            }
+            None if !parent.capabilities.is_empty() => {
+                violations.push(CapabilityCeilingViolation {
+                    kind: "capability".to_string(),
+                    detail: format!(
+                        "nested target requests capability '{capability}' outside parent ceiling"
+                    ),
+                });
+            }
+            _ => {}
+        }
+    }
+    if let (Some(parent_level), Some(requested_level)) = (
+        parent.side_effect_level.as_deref(),
+        requested.side_effect_level.as_deref(),
+    ) {
+        if rank(requested_level) > rank(parent_level) {
+            violations.push(CapabilityCeilingViolation {
+                kind: "side_effect_level".to_string(),
+                detail: format!(
+                    "nested target requests side_effect_level '{requested_level}' outside parent ceiling '{parent_level}'"
+                ),
+            });
+        }
+    }
+    if !parent.workspace_roots.is_empty() {
+        for root in &requested.workspace_roots {
+            if !parent.workspace_roots.contains(root) {
+                violations.push(CapabilityCeilingViolation {
+                    kind: "workspace_root".to_string(),
+                    detail: format!(
+                        "nested target requests workspace_root '{root}' outside parent allowlist"
+                    ),
+                });
+            }
+        }
+    }
+    violations
+}
+
+fn rank(level: &str) -> usize {
+    match level {
+        "none" => 0,
+        "read_only" => 1,
+        "workspace_write" => 2,
+        "process_exec" => 3,
+        "network" => 4,
+        _ => 5,
+    }
+}
+
+/// Coarse capability projection for a Harn script source. We look for
+/// stdlib builtin tokens (`exec`, `shell`, `http_*`, `write_file`,
+/// `connector_call`, `llm_call`, etc.) and project an `(operation,
+/// side_effect_level)` set that the parent must allow. This is not
+/// type-aware — it intentionally over-includes rather than miss a
+/// widening attempt.
+fn scan_harn_script_ceiling(source: &str) -> CapabilityPolicy {
+    let stripped = strip_comments(source);
+    let mut capabilities: std::collections::BTreeMap<String, BTreeSet<String>> =
+        std::collections::BTreeMap::new();
+    let mut max_side_effect: Option<&'static str> = None;
+
+    for (token, capability, op, side_effect) in BUILTIN_CAPABILITIES {
+        if contains_call(&stripped, token) {
+            capabilities
+                .entry((*capability).to_string())
+                .or_default()
+                .insert((*op).to_string());
+            max_side_effect = match max_side_effect {
+                Some(current) if rank(current) >= rank(side_effect) => Some(current),
+                _ => Some(side_effect),
+            };
+        }
+    }
+
+    CapabilityPolicy {
+        tools: Vec::new(),
+        capabilities: capabilities
+            .into_iter()
+            .map(|(k, v)| (k, v.into_iter().collect()))
+            .collect(),
+        workspace_roots: Vec::new(),
+        side_effect_level: max_side_effect.map(|level| level.to_string()),
+        recursion_limit: None,
+        tool_arg_constraints: Vec::new(),
+        tool_annotations: std::collections::BTreeMap::new(),
+    }
+}
+
+fn scan_burin_manifest_ceiling(manifest: &serde_json::Value) -> CapabilityPolicy {
+    if let Some(ceiling) = manifest.get("capability_ceiling") {
+        if let Ok(parsed) = serde_json::from_value::<CapabilityPolicy>(ceiling.clone()) {
+            return parsed;
+        }
+    }
+    let tools = manifest
+        .get("tools")
+        .and_then(|value| value.as_array())
+        .map(|tools| {
+            tools
+                .iter()
+                .filter_map(|tool| tool.as_str().map(str::to_string))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    CapabilityPolicy {
+        tools,
+        capabilities: std::collections::BTreeMap::new(),
+        workspace_roots: Vec::new(),
+        side_effect_level: Some("network".to_string()),
+        recursion_limit: None,
+        tool_arg_constraints: Vec::new(),
+        tool_annotations: std::collections::BTreeMap::new(),
+    }
+}
+
+/// Strip line/block comments and the contents of string literals so the
+/// builtin scanner only sees actual source identifiers. Quoted text is
+/// replaced with whitespace of the same length to keep byte offsets and
+/// line numbers stable for any future diagnostics.
+fn strip_comments(source: &str) -> String {
+    let mut out = String::with_capacity(source.len());
+    let mut in_block = false;
+    let mut chars = source.chars().peekable();
+    while let Some(c) = chars.next() {
+        if in_block {
+            if c == '*' && matches!(chars.peek(), Some('/')) {
+                chars.next();
+                in_block = false;
+            }
+            continue;
+        }
+        if c == '/' {
+            match chars.peek() {
+                Some('/') => {
+                    for next in chars.by_ref() {
+                        if next == '\n' {
+                            out.push('\n');
+                            break;
+                        }
+                    }
+                    continue;
+                }
+                Some('*') => {
+                    chars.next();
+                    in_block = true;
+                    continue;
+                }
+                _ => {}
+            }
+        }
+        if c == '#' {
+            for next in chars.by_ref() {
+                if next == '\n' {
+                    out.push('\n');
+                    break;
+                }
+            }
+            continue;
+        }
+        if c == '"' || c == '\'' {
+            out.push(' ');
+            let quote = c;
+            while let Some(next) = chars.next() {
+                if next == '\\' {
+                    chars.next();
+                    out.push(' ');
+                    out.push(' ');
+                    continue;
+                }
+                if next == quote {
+                    out.push(' ');
+                    break;
+                }
+                out.push(if next == '\n' { '\n' } else { ' ' });
+            }
+            continue;
+        }
+        out.push(c);
+    }
+    out
+}
+
+fn contains_call(source: &str, token: &str) -> bool {
+    let bytes = source.as_bytes();
+    let needle = token.as_bytes();
+    if bytes.len() < needle.len() + 1 {
+        return false;
+    }
+    let mut start = 0;
+    while let Some(pos) = find_subslice(&bytes[start..], needle) {
+        let absolute = start + pos;
+        let before = if absolute == 0 {
+            None
+        } else {
+            Some(bytes[absolute - 1])
+        };
+        let after = bytes.get(absolute + needle.len()).copied();
+        let valid_before = match before {
+            None => true,
+            Some(c) => !is_identifier_byte(c),
+        };
+        let valid_after = matches!(after, Some(b'(') | Some(b' ') | Some(b'\t'))
+            || matches!(after, Some(b'\n') | Some(b'\r'));
+        if valid_before && valid_after {
+            return true;
+        }
+        start = absolute + needle.len();
+    }
+    false
+}
+
+fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() || haystack.len() < needle.len() {
+        return None;
+    }
+    haystack
+        .windows(needle.len())
+        .position(|window| window == needle)
+}
+
+fn is_identifier_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_'
+}
+
+const BUILTIN_CAPABILITIES: &[(&str, &str, &str, &str)] = &[
+    ("read_file", "workspace", "read_text", "read_only"),
+    ("read_file_result", "workspace", "read_text", "read_only"),
+    ("read_file_bytes", "workspace", "read_text", "read_only"),
+    ("list_dir", "workspace", "list", "read_only"),
+    ("file_exists", "workspace", "exists", "read_only"),
+    ("stat", "workspace", "exists", "read_only"),
+    ("write_file", "workspace", "write_text", "workspace_write"),
+    (
+        "write_file_bytes",
+        "workspace",
+        "write_text",
+        "workspace_write",
+    ),
+    ("append_file", "workspace", "write_text", "workspace_write"),
+    ("mkdir", "workspace", "write_text", "workspace_write"),
+    ("copy_file", "workspace", "write_text", "workspace_write"),
+    ("delete_file", "workspace", "delete", "workspace_write"),
+    ("apply_edit", "workspace", "apply_edit", "workspace_write"),
+    ("exec", "process", "exec", "process_exec"),
+    ("exec_at", "process", "exec", "process_exec"),
+    ("shell", "process", "exec", "process_exec"),
+    ("shell_at", "process", "exec", "process_exec"),
+    ("http_get", "network", "http", "network"),
+    ("http_post", "network", "http", "network"),
+    ("http_put", "network", "http", "network"),
+    ("http_patch", "network", "http", "network"),
+    ("http_delete", "network", "http", "network"),
+    ("http_request", "network", "http", "network"),
+    ("http_download", "network", "http", "network"),
+    ("connector_call", "connector", "call", "network"),
+    ("secret_get", "connector", "secret_get", "read_only"),
+    ("llm_call", "llm", "call", "network"),
+    ("llm_call_safe", "llm", "call", "network"),
+    ("llm_completion", "llm", "call", "network"),
+    ("llm_stream", "llm", "call", "network"),
+    ("agent_loop", "llm", "call", "network"),
+    ("mcp_call", "process", "exec", "process_exec"),
+    ("mcp_connect", "process", "exec", "process_exec"),
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    fn permissive_parent() -> CapabilityPolicy {
+        let mut capabilities = BTreeMap::new();
+        capabilities.insert(
+            "workspace".to_string(),
+            vec!["read_text".to_string(), "list".to_string()],
+        );
+        capabilities.insert("connector".to_string(), vec!["call".to_string()]);
+        capabilities.insert("process".to_string(), vec!["exec".to_string()]);
+        capabilities.insert("network".to_string(), vec!["http".to_string()]);
+        capabilities.insert("llm".to_string(), vec!["call".to_string()]);
+        CapabilityPolicy {
+            tools: Vec::new(),
+            capabilities,
+            workspace_roots: Vec::new(),
+            side_effect_level: Some("network".to_string()),
+            recursion_limit: None,
+            tool_arg_constraints: Vec::new(),
+            tool_annotations: BTreeMap::new(),
+        }
+    }
+
+    fn read_only_parent() -> CapabilityPolicy {
+        let mut capabilities = BTreeMap::new();
+        capabilities.insert(
+            "workspace".to_string(),
+            vec![
+                "read_text".to_string(),
+                "list".to_string(),
+                "exists".to_string(),
+            ],
+        );
+        CapabilityPolicy {
+            tools: Vec::new(),
+            capabilities,
+            workspace_roots: Vec::new(),
+            side_effect_level: Some("read_only".to_string()),
+            recursion_limit: None,
+            tool_arg_constraints: Vec::new(),
+            tool_annotations: BTreeMap::new(),
+        }
+    }
+
+    #[test]
+    fn harn_script_with_only_reads_passes_under_read_only_parent() {
+        let source = r#"
+            let body = read_file("README.md")
+            let exists = file_exists("Cargo.toml")
+        "#;
+        let report = enforce_nested_invocation_ceiling(
+            &read_only_parent(),
+            &NestedInvocationTarget::HarnScript {
+                path: "test.harn",
+                source,
+            },
+        );
+        assert!(report.allowed(), "{report:#?}");
+    }
+
+    #[test]
+    fn harn_script_with_exec_is_rejected_under_read_only_parent() {
+        let source = r#"
+            let result = exec("ls", ["-la"])
+        "#;
+        let report = enforce_nested_invocation_ceiling(
+            &read_only_parent(),
+            &NestedInvocationTarget::HarnScript {
+                path: "exec.harn",
+                source,
+            },
+        );
+        assert!(!report.allowed());
+        let kinds: Vec<&str> = report.violations.iter().map(|v| v.kind.as_str()).collect();
+        assert!(kinds.contains(&"capability"));
+        assert!(kinds.contains(&"side_effect_level"));
+    }
+
+    #[test]
+    fn harn_script_with_http_is_rejected_under_read_only_parent() {
+        let source = r#"
+            http_get("https://example.com")
+        "#;
+        let report = enforce_nested_invocation_ceiling(
+            &read_only_parent(),
+            &NestedInvocationTarget::HarnScript {
+                path: "http.harn",
+                source,
+            },
+        );
+        assert!(!report.allowed());
+    }
+
+    #[test]
+    fn harn_script_keyword_inside_string_does_not_trigger() {
+        let source = r#"
+            let label = "exec is not invoked here"
+            let body = read_file("README.md")
+        "#;
+        let report = enforce_nested_invocation_ceiling(
+            &read_only_parent(),
+            &NestedInvocationTarget::HarnScript {
+                path: "string.harn",
+                source,
+            },
+        );
+        assert!(
+            report.allowed(),
+            "false positive on quoted token: {report:#?}"
+        );
+    }
+
+    #[test]
+    fn harn_script_keyword_in_comment_is_ignored() {
+        let source = r#"
+            // exec("rm -rf /") is what we used to do but no longer
+            let x = read_file("README.md")
+        "#;
+        let report = enforce_nested_invocation_ceiling(
+            &read_only_parent(),
+            &NestedInvocationTarget::HarnScript {
+                path: "comments.harn",
+                source,
+            },
+        );
+        assert!(
+            report.allowed(),
+            "false positive on commented token: {report:#?}"
+        );
+    }
+
+    #[test]
+    fn workflow_bundle_with_act_auto_is_rejected_under_read_only_parent() {
+        let mut bundle = super::super::workflow_test_fixtures::pr_monitor_bundle();
+        bundle.policy.autonomy_tier = "act_auto".to_string();
+        let report = enforce_nested_invocation_ceiling(
+            &read_only_parent(),
+            &NestedInvocationTarget::WorkflowBundle(&bundle),
+        );
+        assert!(!report.allowed());
+    }
+
+    #[test]
+    fn burin_manifest_with_explicit_ceiling_is_used_directly() {
+        let manifest = serde_json::json!({
+            "id": "burin.harness.repair",
+            "capability_ceiling": {
+                "capabilities": {
+                    "workspace": ["read_text"]
+                },
+                "side_effect_level": "read_only"
+            }
+        });
+        let report = enforce_nested_invocation_ceiling(
+            &read_only_parent(),
+            &NestedInvocationTarget::BurinHarness {
+                manifest: &manifest,
+            },
+        );
+        assert!(report.allowed(), "{report:#?}");
+    }
+
+    #[test]
+    fn burin_manifest_without_ceiling_falls_back_to_network_and_is_rejected() {
+        let manifest = serde_json::json!({"id": "burin.harness.unknown"});
+        let report = enforce_nested_invocation_ceiling(
+            &read_only_parent(),
+            &NestedInvocationTarget::BurinHarness {
+                manifest: &manifest,
+            },
+        );
+        assert!(!report.allowed());
+    }
+
+    #[test]
+    fn permissive_parent_accepts_workflow_bundle() {
+        let bundle = super::super::workflow_test_fixtures::pr_monitor_bundle();
+        let report = enforce_nested_invocation_ceiling(
+            &permissive_parent(),
+            &NestedInvocationTarget::WorkflowBundle(&bundle),
+        );
+        assert!(report.allowed(), "{report:#?}");
+    }
+}

--- a/crates/harn-vm/src/orchestration/safe_function_tools.rs
+++ b/crates/harn-vm/src/orchestration/safe_function_tools.rs
@@ -1,0 +1,384 @@
+//! Allowlisted Harn function-to-agent-tool adapter.
+//!
+//! The author of a workflow patch needs *some* deterministic, side-effect-free
+//! way to inspect a bundle, simulate a patch, and ask the validator whether
+//! the result is sane. We deliberately do **not** expose every Harn stdlib
+//! function as a model-callable tool — that would require schema generation,
+//! capability classification, and an audit trail for every entrypoint we ship.
+//!
+//! Instead, this module hosts a small, hand-curated registry of functions
+//! that:
+//!
+//! - have no side effects (Read / Search / Think kinds only),
+//! - have a stable JSON-shaped argument schema we can validate up front,
+//! - declare an explicit ACP-compatible [`ToolAnnotations`] entry,
+//! - dispatch into a deterministic Rust handler in this crate.
+//!
+//! The first version is scoped to the workflow-patch authoring loop: load
+//! a bundle, validate it, preview its graph, and dry-run a patch. Adding
+//! more entries is a deliberate, reviewed change — there is no auto
+//! discovery.
+//!
+//! Hosts surface this registry to a model by enumerating the descriptors,
+//! then dispatch tool calls back through [`SafeFunctionTool::dispatch`].
+//! The execution policy is enforced by the host; this layer only describes
+//! the contract.
+
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use super::workflow_bundle::{
+    load_workflow_bundle, preview_workflow_bundle, validate_workflow_bundle, WorkflowBundle,
+};
+use super::workflow_patch::{bundle_capability_ceiling, validate_workflow_patch, WorkflowPatch};
+use super::CapabilityPolicy;
+use crate::tool_annotations::{SideEffectLevel, ToolAnnotations, ToolArgSchema, ToolKind};
+
+pub const SAFE_FUNCTION_TOOL_SCHEMA_VERSION: u32 = 1;
+
+/// Public descriptor for one safe function tool. Hosts can serialize
+/// these directly into a tool listing surface for an agent.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SafeFunctionToolDescriptor {
+    pub name: String,
+    pub description: String,
+    pub annotations: ToolAnnotations,
+    pub arg_schema: serde_json::Value,
+}
+
+/// Internal registry entry. Splits the descriptor (data the host serializes)
+/// from the dispatch handler (function pointer, not serializable).
+#[derive(Clone)]
+pub struct SafeFunctionTool {
+    pub descriptor: SafeFunctionToolDescriptor,
+    pub dispatch: fn(&serde_json::Value) -> Result<serde_json::Value, SafeFunctionToolError>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SafeFunctionToolError {
+    pub code: String,
+    pub message: String,
+}
+
+impl std::fmt::Display for SafeFunctionToolError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.code, self.message)
+    }
+}
+
+impl std::error::Error for SafeFunctionToolError {}
+
+impl SafeFunctionToolError {
+    pub fn invalid_args(message: impl Into<String>) -> Self {
+        Self {
+            code: "invalid_arguments".to_string(),
+            message: message.into(),
+        }
+    }
+    pub fn io(message: impl Into<String>) -> Self {
+        Self {
+            code: "io_error".to_string(),
+            message: message.into(),
+        }
+    }
+}
+
+/// All currently-allowlisted safe function tools. Hosts that need to
+/// expose a subset can filter by `name`. Adding an entry here is a
+/// deliberate review: the new function must be deterministic, side-
+/// effect-free, and carry an ACP-aligned [`ToolAnnotations`] value.
+pub fn safe_function_tools() -> Vec<SafeFunctionTool> {
+    vec![
+        SafeFunctionTool {
+            descriptor: SafeFunctionToolDescriptor {
+                name: "workflow_bundle_validate".to_string(),
+                description:
+                    "Validate a workflow bundle JSON file at PATH and return the validator report."
+                        .to_string(),
+                annotations: read_only_annotations("workspace", &["read_text"]),
+                arg_schema: bundle_path_schema(),
+            },
+            dispatch: dispatch_workflow_bundle_validate,
+        },
+        SafeFunctionTool {
+            descriptor: SafeFunctionToolDescriptor {
+                name: "workflow_bundle_preview".to_string(),
+                description:
+                    "Preview a workflow bundle: return the normalized graph, validation report, mermaid text, triggers, connectors, and editable fields."
+                        .to_string(),
+                annotations: read_only_annotations("workspace", &["read_text"]),
+                arg_schema: bundle_path_schema(),
+            },
+            dispatch: dispatch_workflow_bundle_preview,
+        },
+        SafeFunctionTool {
+            descriptor: SafeFunctionToolDescriptor {
+                name: "workflow_bundle_capability_ceiling".to_string(),
+                description:
+                    "Compute the capability ceiling that running this bundle would request of its parent runtime."
+                        .to_string(),
+                annotations: think_annotations(),
+                arg_schema: bundle_path_schema(),
+            },
+            dispatch: dispatch_workflow_bundle_capability_ceiling,
+        },
+        SafeFunctionTool {
+            descriptor: SafeFunctionToolDescriptor {
+                name: "workflow_patch_validate".to_string(),
+                description:
+                    "Apply a workflow patch JSON to a bundle in memory, run bundle validation, compute the structural diff and capability delta, and return the report."
+                        .to_string(),
+                annotations: read_only_annotations("workspace", &["read_text"]),
+                arg_schema: patch_validate_schema(),
+            },
+            dispatch: dispatch_workflow_patch_validate,
+        },
+    ]
+}
+
+/// Find a safe function tool by its model-visible name.
+pub fn find_safe_function_tool(name: &str) -> Option<SafeFunctionTool> {
+    safe_function_tools()
+        .into_iter()
+        .find(|tool| tool.descriptor.name == name)
+}
+
+fn read_only_annotations(capability: &str, ops: &[&str]) -> ToolAnnotations {
+    let mut capabilities = std::collections::BTreeMap::new();
+    capabilities.insert(
+        capability.to_string(),
+        ops.iter().map(|s| (*s).to_string()).collect(),
+    );
+    ToolAnnotations {
+        kind: ToolKind::Read,
+        side_effect_level: SideEffectLevel::ReadOnly,
+        arg_schema: ToolArgSchema {
+            path_params: vec!["bundle".to_string()],
+            ..ToolArgSchema::default()
+        },
+        capabilities,
+        emits_artifacts: false,
+        result_readers: Vec::new(),
+        inline_result: true,
+    }
+}
+
+fn think_annotations() -> ToolAnnotations {
+    ToolAnnotations {
+        kind: ToolKind::Think,
+        side_effect_level: SideEffectLevel::ReadOnly,
+        arg_schema: ToolArgSchema {
+            path_params: vec!["bundle".to_string()],
+            ..ToolArgSchema::default()
+        },
+        capabilities: std::collections::BTreeMap::new(),
+        emits_artifacts: false,
+        result_readers: Vec::new(),
+        inline_result: true,
+    }
+}
+
+fn bundle_path_schema() -> serde_json::Value {
+    serde_json::json!({
+        "type": "object",
+        "required": ["bundle"],
+        "additionalProperties": false,
+        "properties": {
+            "bundle": {
+                "type": "string",
+                "description": "Filesystem path to a portable workflow bundle JSON file.",
+            }
+        }
+    })
+}
+
+fn patch_validate_schema() -> serde_json::Value {
+    serde_json::json!({
+        "type": "object",
+        "required": ["bundle", "patch"],
+        "additionalProperties": false,
+        "properties": {
+            "bundle": {
+                "type": "string",
+                "description": "Filesystem path to a portable workflow bundle JSON file.",
+            },
+            "patch": {
+                "description": "Either an inline workflow patch object or a path string to a patch JSON file.",
+                "oneOf": [
+                    { "type": "string" },
+                    { "type": "object" }
+                ]
+            },
+            "parent_ceiling": {
+                "description": "Optional CapabilityPolicy of the executing parent context. The patch is rejected when it widens this ceiling.",
+                "type": "object"
+            }
+        }
+    })
+}
+
+fn dispatch_workflow_bundle_validate(
+    args: &serde_json::Value,
+) -> Result<serde_json::Value, SafeFunctionToolError> {
+    let bundle = load_bundle_arg(args)?;
+    let report = validate_workflow_bundle(&bundle);
+    serde_json::to_value(report).map_err(|err| SafeFunctionToolError::io(err.to_string()))
+}
+
+fn dispatch_workflow_bundle_preview(
+    args: &serde_json::Value,
+) -> Result<serde_json::Value, SafeFunctionToolError> {
+    let bundle = load_bundle_arg(args)?;
+    let preview = preview_workflow_bundle(&bundle);
+    serde_json::to_value(preview).map_err(|err| SafeFunctionToolError::io(err.to_string()))
+}
+
+fn dispatch_workflow_bundle_capability_ceiling(
+    args: &serde_json::Value,
+) -> Result<serde_json::Value, SafeFunctionToolError> {
+    let bundle = load_bundle_arg(args)?;
+    let ceiling = bundle_capability_ceiling(&bundle);
+    serde_json::to_value(ceiling).map_err(|err| SafeFunctionToolError::io(err.to_string()))
+}
+
+fn dispatch_workflow_patch_validate(
+    args: &serde_json::Value,
+) -> Result<serde_json::Value, SafeFunctionToolError> {
+    let bundle = load_bundle_arg(args)?;
+    let patch = load_patch_arg(args)?;
+    let parent_ceiling = match args.get("parent_ceiling") {
+        Some(value) if !value.is_null() => Some(
+            serde_json::from_value::<CapabilityPolicy>(value.clone())
+                .map_err(|err| SafeFunctionToolError::invalid_args(err.to_string()))?,
+        ),
+        _ => None,
+    };
+    let report = validate_workflow_patch(&bundle, &patch, parent_ceiling.as_ref());
+    serde_json::to_value(report).map_err(|err| SafeFunctionToolError::io(err.to_string()))
+}
+
+fn load_bundle_arg(args: &serde_json::Value) -> Result<WorkflowBundle, SafeFunctionToolError> {
+    let path = args
+        .get("bundle")
+        .and_then(|value| value.as_str())
+        .ok_or_else(|| SafeFunctionToolError::invalid_args("bundle must be a string path"))?;
+    load_workflow_bundle(Path::new(path))
+        .map_err(|err| SafeFunctionToolError::io(format!("failed to load bundle {path}: {err}")))
+}
+
+fn load_patch_arg(args: &serde_json::Value) -> Result<WorkflowPatch, SafeFunctionToolError> {
+    let value = args
+        .get("patch")
+        .ok_or_else(|| SafeFunctionToolError::invalid_args("patch is required"))?;
+    let raw = match value {
+        serde_json::Value::String(path) => std::fs::read_to_string(path)
+            .map(|text| serde_json::from_str(&text))
+            .map_err(|err| {
+                SafeFunctionToolError::io(format!("failed to read patch {path}: {err}"))
+            })?
+            .map_err(|err| SafeFunctionToolError::invalid_args(err.to_string()))?,
+        other => serde_json::from_value(other.clone())
+            .map_err(|err| SafeFunctionToolError::invalid_args(err.to_string()))?,
+    };
+    Ok(raw)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registry_entries_are_readonly_or_think_only() {
+        for tool in safe_function_tools() {
+            let kind = tool.descriptor.annotations.kind;
+            assert!(
+                matches!(
+                    kind,
+                    ToolKind::Read | ToolKind::Search | ToolKind::Think | ToolKind::Fetch
+                ),
+                "tool {} has non-read kind {kind:?}",
+                tool.descriptor.name
+            );
+            let level = tool.descriptor.annotations.side_effect_level;
+            assert!(
+                matches!(level, SideEffectLevel::None | SideEffectLevel::ReadOnly),
+                "tool {} has non-readonly side-effect level {level:?}",
+                tool.descriptor.name
+            );
+        }
+    }
+
+    #[test]
+    fn registry_entries_have_object_argument_schemas() {
+        for tool in safe_function_tools() {
+            let schema = &tool.descriptor.arg_schema;
+            assert_eq!(
+                schema.get("type").and_then(|t| t.as_str()),
+                Some("object"),
+                "tool {} arg_schema must declare type=object",
+                tool.descriptor.name,
+            );
+            assert!(
+                schema.get("properties").is_some(),
+                "tool {} arg_schema must declare properties",
+                tool.descriptor.name,
+            );
+        }
+    }
+
+    #[test]
+    fn find_safe_function_tool_returns_none_for_unknown_name() {
+        assert!(find_safe_function_tool("does_not_exist").is_none());
+        assert!(find_safe_function_tool("workflow_bundle_validate").is_some());
+    }
+
+    fn write_pr_monitor_fixture(dir: &std::path::Path) -> std::path::PathBuf {
+        let path = dir.join("pr-monitor.bundle.json");
+        std::fs::write(
+            &path,
+            super::super::workflow_test_fixtures::PR_MONITOR_BUNDLE_JSON,
+        )
+        .unwrap();
+        path
+    }
+
+    #[test]
+    fn dispatch_validate_returns_validator_report() {
+        let temp = tempfile::tempdir().unwrap();
+        let bundle_path = write_pr_monitor_fixture(temp.path());
+        let tool = find_safe_function_tool("workflow_bundle_validate").unwrap();
+        let result = (tool.dispatch)(&serde_json::json!({"bundle": bundle_path})).unwrap();
+        assert_eq!(result["valid"], serde_json::Value::Bool(true));
+        assert_eq!(result["bundle_id"], "github-pr-monitor");
+    }
+
+    #[test]
+    fn dispatch_patch_validate_handles_inline_patch() {
+        let temp = tempfile::tempdir().unwrap();
+        let bundle_path = write_pr_monitor_fixture(temp.path());
+        let tool = find_safe_function_tool("workflow_patch_validate").unwrap();
+        let inline_patch = serde_json::json!({
+            "schema_version": 1,
+            "id": "test-patch",
+            "operations": [
+                { "op": "insert_node", "node_id": "verifier", "node": {"kind": "action", "task_label": "verify"} },
+                { "op": "add_edge", "from": "query_logs", "to": "verifier" }
+            ]
+        });
+        let result = (tool.dispatch)(&serde_json::json!({
+            "bundle": bundle_path,
+            "patch": inline_patch
+        }))
+        .unwrap();
+        assert_eq!(result["valid"], serde_json::Value::Bool(true));
+        assert_eq!(result["patch_id"], "test-patch");
+    }
+
+    #[test]
+    fn dispatch_invalid_arguments_returns_error_code() {
+        let tool = find_safe_function_tool("workflow_bundle_validate").unwrap();
+        let err = (tool.dispatch)(&serde_json::json!({"bundle": 42})).unwrap_err();
+        assert_eq!(err.code, "invalid_arguments");
+    }
+}

--- a/crates/harn-vm/src/orchestration/workflow_patch.rs
+++ b/crates/harn-vm/src/orchestration/workflow_patch.rs
@@ -1,0 +1,1046 @@
+//! Workflow patch proposals: a bounded, auditable contract that lets an
+//! agent author propose changes to a portable [`WorkflowBundle`] without
+//! touching the live runtime.
+//!
+//! The shape is intentionally small. An agent emits a JSON document
+//! describing a sequence of [`WorkflowPatchOperation`]s; Harn applies
+//! them to a copy of the bundle, runs the existing bundle validator,
+//! computes a capability-ceiling delta against the parent execution
+//! policy (when one is supplied), and returns a single
+//! [`WorkflowPatchValidationReport`] the host can render.
+//!
+//! The patch surface deliberately mirrors what the issue calls out:
+//! insert agent / verifier / approval node, update prompt capsule,
+//! update model & tool policy, add edge. Anything not in this list
+//! goes through a normal bundle edit instead — the patch contract is
+//! the meta-programming layer, not a general bundle DSL.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::{Deserialize, Serialize};
+
+use super::workflow::{WorkflowEdge, WorkflowNode};
+use super::workflow_bundle::{
+    preview_workflow_bundle, validate_workflow_bundle, WorkflowBundle, WorkflowBundleGraphExport,
+    WorkflowBundlePolicy, WorkflowBundleValidationReport,
+};
+use super::CapabilityPolicy;
+
+pub const WORKFLOW_PATCH_SCHEMA_VERSION: u32 = 1;
+
+/// A bounded, auditable proposal to mutate a workflow bundle.
+///
+/// Patches are flat lists of [`WorkflowPatchOperation`]s applied in
+/// order. An empty operations list is rejected by [`apply_workflow_patch`]
+/// — silent no-ops would let agents claim work they did not do.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct WorkflowPatch {
+    pub schema_version: u32,
+    pub id: String,
+    pub summary: Option<String>,
+    pub operations: Vec<WorkflowPatchOperation>,
+}
+
+/// Operations are tagged by an external `op` discriminator so handlers
+/// can dispatch on the literal string from JSON.
+///
+/// Only the operations called out in #1423 are exposed: insert node,
+/// add edge, upsert prompt capsule, update node policy, update bundle
+/// policy. New operations require a deliberate contract bump.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "op", rename_all = "snake_case")]
+pub enum WorkflowPatchOperation {
+    /// Insert a new workflow node. Fails if `node_id` already exists or
+    /// is empty. The `node` body uses the same shape as
+    /// `workflow.nodes[k]` in a bundle JSON, with sensible defaults
+    /// applied for unspecified fields.
+    InsertNode {
+        node_id: String,
+        #[serde(default)]
+        node: WorkflowPatchNodeBody,
+    },
+    /// Append an edge to the workflow graph. Fails if either endpoint
+    /// references an unknown node, or if the edge already exists.
+    AddEdge {
+        from: String,
+        to: String,
+        #[serde(default)]
+        branch: Option<String>,
+        #[serde(default)]
+        label: Option<String>,
+    },
+    /// Insert or replace a prompt capsule. The capsule's `node_id` must
+    /// reference a node that exists after all prior patch operations
+    /// have been applied (so an `InsertNode` followed by
+    /// `UpsertPromptCapsule` works).
+    UpsertPromptCapsule {
+        capsule_id: String,
+        capsule: WorkflowPatchPromptCapsuleBody,
+    },
+    /// Merge per-node policy fields onto an existing node. Only the
+    /// fields named on [`WorkflowPatchNodePolicyBody`] can be set —
+    /// arbitrary node fields are intentionally not patchable.
+    UpdateNodePolicy {
+        node_id: String,
+        policy: WorkflowPatchNodePolicyBody,
+    },
+    /// Merge bundle-level policy fields. Mirrors the safe knobs in
+    /// [`WorkflowBundlePolicy`].
+    UpdateBundlePolicy {
+        policy: WorkflowPatchBundlePolicyBody,
+    },
+}
+
+/// Shape used by [`WorkflowPatchOperation::InsertNode`]. Mirrors the
+/// editable fields on [`WorkflowNode`] without exposing every tunable.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct WorkflowPatchNodeBody {
+    pub kind: Option<String>,
+    pub task_label: Option<String>,
+    pub prompt: Option<String>,
+    pub system: Option<String>,
+    pub tools: Option<serde_json::Value>,
+    pub model_policy: Option<serde_json::Value>,
+    pub capability_policy: Option<CapabilityPolicy>,
+    pub approval_policy: Option<serde_json::Value>,
+    pub metadata: BTreeMap<String, serde_json::Value>,
+}
+
+/// Shape used by [`WorkflowPatchOperation::UpdateNodePolicy`]. Each
+/// field maps to the same-named field on [`WorkflowNode`] and is
+/// merged in place (set when `Some`, left alone when `None`).
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct WorkflowPatchNodePolicyBody {
+    pub task_label: Option<String>,
+    pub prompt: Option<String>,
+    pub system: Option<String>,
+    pub tools: Option<serde_json::Value>,
+    pub model_policy: Option<serde_json::Value>,
+    pub capability_policy: Option<CapabilityPolicy>,
+    pub approval_policy: Option<serde_json::Value>,
+}
+
+/// Shape used by [`WorkflowPatchOperation::UpsertPromptCapsule`]. The
+/// patch always sets `id` to match `capsule_id` so the bundle invariant
+/// (`capsule.id == map_key`) holds without callers needing to repeat it.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct WorkflowPatchPromptCapsuleBody {
+    pub node_id: String,
+    pub trigger_id: Option<String>,
+    pub prompt: String,
+    pub system: Option<String>,
+    pub context: BTreeMap<String, serde_json::Value>,
+}
+
+/// Shape used by [`WorkflowPatchOperation::UpdateBundlePolicy`]. Each
+/// field replaces the corresponding [`WorkflowBundlePolicy`] field when
+/// `Some`. The `tool_policy` and `approval_required` lists replace
+/// rather than merge to keep the contract obvious — agents that want a
+/// merge should compute and submit the full list.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct WorkflowPatchBundlePolicyBody {
+    pub autonomy_tier: Option<String>,
+    pub tool_policy: Option<BTreeMap<String, serde_json::Value>>,
+    pub approval_required: Option<Vec<String>>,
+    pub retry: Option<serde_json::Value>,
+    pub catchup: Option<serde_json::Value>,
+}
+
+/// What a host renders when it shows the result of validating a patch.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct WorkflowPatchValidationReport {
+    pub schema_version: u32,
+    pub patch_id: String,
+    pub bundle_id: String,
+    pub valid: bool,
+    pub apply_errors: Vec<WorkflowPatchDiagnostic>,
+    pub bundle_validation: WorkflowBundleValidationReport,
+    pub graph_diff: WorkflowPatchGraphDiff,
+    pub capability_delta: WorkflowPatchCapabilityDelta,
+    pub graph_export: WorkflowBundleGraphExport,
+}
+
+/// One structured failure from applying a patch. The `op_index` lets
+/// the host highlight the offending operation in its review surface.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkflowPatchDiagnostic {
+    pub severity: String,
+    pub op_index: Option<usize>,
+    pub op: Option<String>,
+    pub path: String,
+    pub message: String,
+    pub node_id: Option<String>,
+}
+
+/// Structural diff between the original and patched workflow graph.
+/// Used by host UIs and the patch-authoring skill so a model that
+/// proposes a patch can tell at a glance whether its edit produced the
+/// shape it intended.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkflowPatchGraphDiff {
+    pub added_nodes: Vec<String>,
+    pub added_edges: Vec<WorkflowPatchEdgeRef>,
+    pub updated_nodes: Vec<String>,
+    pub updated_capsules: Vec<String>,
+    pub policy_fields_changed: Vec<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkflowPatchEdgeRef {
+    pub from: String,
+    pub to: String,
+    pub branch: Option<String>,
+    pub label: Option<String>,
+}
+
+/// Capability ceiling delta between the bundle before and after the
+/// patch, optionally compared against a parent execution policy.
+///
+/// `widening` collects every dimension where the patched bundle asks
+/// for *more* than the parent ceiling (or the original bundle, when no
+/// parent is supplied). The patch is rejected when this list is
+/// non-empty — agents must not be able to expand permissions.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+pub struct WorkflowPatchCapabilityDelta {
+    pub before: CapabilityPolicy,
+    pub after: CapabilityPolicy,
+    pub parent: Option<CapabilityPolicy>,
+    pub added_tools: Vec<String>,
+    pub added_capabilities: BTreeMap<String, Vec<String>>,
+    pub raised_side_effect_level: Option<RaisedSideEffectLevel>,
+    pub added_workspace_roots: Vec<String>,
+    pub added_connector_scopes: BTreeMap<String, Vec<String>>,
+    pub added_command_gates: Vec<String>,
+    pub raised_autonomy_tier: Option<RaisedAutonomyTier>,
+    pub widening: Vec<CapabilityCeilingViolation>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RaisedSideEffectLevel {
+    pub from: String,
+    pub to: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RaisedAutonomyTier {
+    pub from: String,
+    pub to: String,
+}
+
+/// One concrete way the patched bundle exceeds the parent ceiling.
+/// `kind` is a stable enum string so hosts can group/explain them.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CapabilityCeilingViolation {
+    pub kind: String,
+    pub detail: String,
+}
+
+/// Apply a patch to a copy of the bundle and return the new bundle.
+/// Fails fast on the first structural error; callers that want richer
+/// diagnostics should prefer [`validate_workflow_patch`].
+pub fn apply_workflow_patch(
+    bundle: &WorkflowBundle,
+    patch: &WorkflowPatch,
+) -> Result<WorkflowBundle, Vec<WorkflowPatchDiagnostic>> {
+    let mut errors = Vec::new();
+    if patch.schema_version != WORKFLOW_PATCH_SCHEMA_VERSION {
+        errors.push(diagnostic_global(format!(
+            "unsupported patch schema_version {}; expected {}",
+            patch.schema_version, WORKFLOW_PATCH_SCHEMA_VERSION
+        )));
+    }
+    if patch.id.trim().is_empty() {
+        errors.push(diagnostic_global("patch id is required".to_string()));
+    }
+    if patch.operations.is_empty() {
+        errors.push(diagnostic_global(
+            "patch contains no operations; refusing to no-op".to_string(),
+        ));
+    }
+    if !errors.is_empty() {
+        return Err(errors);
+    }
+
+    let mut working = bundle.clone();
+    for (index, operation) in patch.operations.iter().enumerate() {
+        if let Err(diag) = apply_operation(&mut working, operation, index) {
+            return Err(vec![diag]);
+        }
+    }
+    Ok(working)
+}
+
+/// Apply + validate + diff + ceiling check, in one pass. The bundle
+/// validator is the source of truth for "is this still a valid bundle?";
+/// this function adds the patch-specific apply errors, the structural
+/// diff, and the capability delta on top.
+pub fn validate_workflow_patch(
+    bundle: &WorkflowBundle,
+    patch: &WorkflowPatch,
+    parent_ceiling: Option<&CapabilityPolicy>,
+) -> WorkflowPatchValidationReport {
+    let before_ceiling = bundle_capability_ceiling(bundle);
+
+    let (patched, apply_errors) = match apply_workflow_patch(bundle, patch) {
+        Ok(patched) => (patched, Vec::new()),
+        Err(errors) => (bundle.clone(), errors),
+    };
+
+    let bundle_validation = validate_workflow_bundle(&patched);
+    let graph_diff = diff_bundle_graph(bundle, &patched, patch);
+    let after_ceiling = bundle_capability_ceiling(&patched);
+    let capability_delta = compute_capability_delta(
+        bundle,
+        &patched,
+        before_ceiling,
+        after_ceiling,
+        parent_ceiling,
+    );
+    let graph_export = preview_workflow_bundle(&patched).graph;
+    let valid =
+        apply_errors.is_empty() && bundle_validation.valid && capability_delta.widening.is_empty();
+
+    WorkflowPatchValidationReport {
+        schema_version: WORKFLOW_PATCH_SCHEMA_VERSION,
+        patch_id: patch.id.clone(),
+        bundle_id: bundle.id.clone(),
+        valid,
+        apply_errors,
+        bundle_validation,
+        graph_diff,
+        capability_delta,
+        graph_export,
+    }
+}
+
+/// Project a bundle's effective capability ceiling. The bundle does
+/// not carry a single capability policy; we compose one from the
+/// per-node `capability_policy` declarations, the bundle-level
+/// `tool_policy` keys, the connector scopes, the autonomy tier, the
+/// `worktree_policy`, and the declared `command_gates`. The result is
+/// what a parent runtime needs to compare against to decide whether
+/// running this bundle would widen its own ceiling.
+pub fn bundle_capability_ceiling(bundle: &WorkflowBundle) -> CapabilityPolicy {
+    let mut tools: BTreeSet<String> = bundle.policy.tool_policy.keys().cloned().collect();
+    let mut capabilities: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    let mut workspace_roots: BTreeSet<String> = BTreeSet::new();
+    let mut max_side_effect: Option<&'static str> = None;
+
+    for node in bundle.workflow.nodes.values() {
+        for tool in &node.capability_policy.tools {
+            tools.insert(tool.clone());
+        }
+        for (capability, ops) in &node.capability_policy.capabilities {
+            let entry = capabilities.entry(capability.clone()).or_default();
+            for op in ops {
+                entry.insert(op.clone());
+            }
+        }
+        for root in &node.capability_policy.workspace_roots {
+            workspace_roots.insert(root.clone());
+        }
+        if let Some(level) = node.capability_policy.side_effect_level.as_deref() {
+            max_side_effect = match max_side_effect {
+                Some(current) if side_effect_rank(current) >= side_effect_rank(level) => {
+                    Some(current)
+                }
+                _ => Some(static_side_effect(level)),
+            };
+        }
+    }
+
+    let autonomy_floor = autonomy_side_effect_floor(&bundle.policy.autonomy_tier);
+    if let Some(floor) = autonomy_floor {
+        max_side_effect = match max_side_effect {
+            Some(current) if side_effect_rank(current) >= side_effect_rank(floor) => Some(current),
+            _ => Some(floor),
+        };
+    }
+
+    if !bundle.connectors.is_empty() {
+        capabilities
+            .entry("connector".to_string())
+            .or_default()
+            .insert("call".to_string());
+    }
+    if !bundle.environment.command_gates.is_empty()
+        || bundle.environment.worktree_policy != "host_managed"
+    {
+        capabilities
+            .entry("process".to_string())
+            .or_default()
+            .insert("exec".to_string());
+        max_side_effect = match max_side_effect {
+            Some(current) if side_effect_rank(current) >= side_effect_rank("process_exec") => {
+                Some(current)
+            }
+            _ => Some("process_exec"),
+        };
+    }
+
+    CapabilityPolicy {
+        tools: tools.into_iter().collect(),
+        capabilities: capabilities
+            .into_iter()
+            .map(|(k, v)| (k, v.into_iter().collect()))
+            .collect(),
+        workspace_roots: workspace_roots.into_iter().collect(),
+        side_effect_level: max_side_effect.map(|level| level.to_string()),
+        recursion_limit: None,
+        tool_arg_constraints: Vec::new(),
+        tool_annotations: BTreeMap::new(),
+    }
+}
+
+fn apply_operation(
+    bundle: &mut WorkflowBundle,
+    operation: &WorkflowPatchOperation,
+    index: usize,
+) -> Result<(), WorkflowPatchDiagnostic> {
+    match operation {
+        WorkflowPatchOperation::InsertNode { node_id, node } => {
+            if node_id.trim().is_empty() {
+                return Err(diagnostic_op(
+                    index,
+                    "insert_node",
+                    "operations".to_string(),
+                    "insert_node node_id is required".to_string(),
+                    None,
+                ));
+            }
+            if bundle.workflow.nodes.contains_key(node_id) {
+                return Err(diagnostic_op(
+                    index,
+                    "insert_node",
+                    format!("workflow.nodes.{node_id}"),
+                    format!("workflow already contains node {node_id}"),
+                    Some(node_id.clone()),
+                ));
+            }
+            let workflow_node = node_body_into_workflow_node(node_id, node);
+            bundle.workflow.nodes.insert(node_id.clone(), workflow_node);
+            if bundle.workflow.entry.is_empty() {
+                bundle.workflow.entry = node_id.clone();
+            }
+            Ok(())
+        }
+        WorkflowPatchOperation::AddEdge {
+            from,
+            to,
+            branch,
+            label,
+        } => {
+            if !bundle.workflow.nodes.contains_key(from) {
+                return Err(diagnostic_op(
+                    index,
+                    "add_edge",
+                    "edges.from".to_string(),
+                    format!("edge.from references unknown node: {from}"),
+                    Some(from.clone()),
+                ));
+            }
+            if !bundle.workflow.nodes.contains_key(to) {
+                return Err(diagnostic_op(
+                    index,
+                    "add_edge",
+                    "edges.to".to_string(),
+                    format!("edge.to references unknown node: {to}"),
+                    Some(to.clone()),
+                ));
+            }
+            let candidate = WorkflowEdge {
+                from: from.clone(),
+                to: to.clone(),
+                branch: branch.clone(),
+                label: label.clone(),
+            };
+            if bundle.workflow.edges.iter().any(|edge| {
+                edge.from == candidate.from
+                    && edge.to == candidate.to
+                    && edge.branch == candidate.branch
+                    && edge.label == candidate.label
+            }) {
+                return Err(diagnostic_op(
+                    index,
+                    "add_edge",
+                    "edges".to_string(),
+                    format!("edge {from} -> {to} already exists"),
+                    Some(from.clone()),
+                ));
+            }
+            bundle.workflow.edges.push(candidate);
+            Ok(())
+        }
+        WorkflowPatchOperation::UpsertPromptCapsule {
+            capsule_id,
+            capsule,
+        } => {
+            if capsule_id.trim().is_empty() {
+                return Err(diagnostic_op(
+                    index,
+                    "upsert_prompt_capsule",
+                    "prompt_capsules".to_string(),
+                    "capsule_id is required".to_string(),
+                    None,
+                ));
+            }
+            if !bundle.workflow.nodes.contains_key(&capsule.node_id) {
+                return Err(diagnostic_op(
+                    index,
+                    "upsert_prompt_capsule",
+                    format!("prompt_capsules.{capsule_id}.node_id"),
+                    format!(
+                        "prompt capsule references unknown node: {}",
+                        capsule.node_id
+                    ),
+                    Some(capsule.node_id.clone()),
+                ));
+            }
+            let existing = bundle
+                .prompt_capsules
+                .values()
+                .find(|other| other.node_id == capsule.node_id && other.id != *capsule_id);
+            if let Some(other) = existing {
+                return Err(diagnostic_op(
+                    index,
+                    "upsert_prompt_capsule",
+                    format!("prompt_capsules.{capsule_id}.node_id"),
+                    format!(
+                        "prompt capsule {capsule_id} would target node {} but capsule {} already targets it",
+                        capsule.node_id, other.id
+                    ),
+                    Some(capsule.node_id.clone()),
+                ));
+            }
+            let capsule_value = super::workflow_bundle::PromptCapsule {
+                id: capsule_id.clone(),
+                node_id: capsule.node_id.clone(),
+                trigger_id: capsule.trigger_id.clone(),
+                prompt: capsule.prompt.clone(),
+                system: capsule.system.clone(),
+                context: capsule.context.clone(),
+            };
+            bundle
+                .prompt_capsules
+                .insert(capsule_id.clone(), capsule_value);
+            Ok(())
+        }
+        WorkflowPatchOperation::UpdateNodePolicy { node_id, policy } => {
+            let Some(node) = bundle.workflow.nodes.get_mut(node_id) else {
+                return Err(diagnostic_op(
+                    index,
+                    "update_node_policy",
+                    format!("workflow.nodes.{node_id}"),
+                    format!("workflow does not contain node {node_id}"),
+                    Some(node_id.clone()),
+                ));
+            };
+            apply_node_policy_body(node, policy).map_err(|message| {
+                diagnostic_op(
+                    index,
+                    "update_node_policy",
+                    format!("workflow.nodes.{node_id}"),
+                    message,
+                    Some(node_id.clone()),
+                )
+            })?;
+            Ok(())
+        }
+        WorkflowPatchOperation::UpdateBundlePolicy { policy } => {
+            apply_bundle_policy_body(&mut bundle.policy, policy).map_err(|message| {
+                diagnostic_op(
+                    index,
+                    "update_bundle_policy",
+                    "policy".to_string(),
+                    message,
+                    None,
+                )
+            })?;
+            Ok(())
+        }
+    }
+}
+
+fn node_body_into_workflow_node(node_id: &str, body: &WorkflowPatchNodeBody) -> WorkflowNode {
+    let mut node = WorkflowNode {
+        id: Some(node_id.to_string()),
+        kind: body
+            .kind
+            .clone()
+            .filter(|kind| !kind.trim().is_empty())
+            .unwrap_or_else(|| "stage".to_string()),
+        ..WorkflowNode::default()
+    };
+    node.task_label = body.task_label.clone();
+    node.prompt = body.prompt.clone();
+    node.system = body.system.clone();
+    if let Some(tools) = &body.tools {
+        node.tools = tools.clone();
+    }
+    if let Some(model_policy) = &body.model_policy {
+        if let Ok(parsed) = serde_json::from_value(model_policy.clone()) {
+            node.model_policy = parsed;
+        }
+    }
+    if let Some(capability_policy) = &body.capability_policy {
+        node.capability_policy = capability_policy.clone();
+    }
+    if let Some(approval_policy) = &body.approval_policy {
+        if let Ok(parsed) = serde_json::from_value(approval_policy.clone()) {
+            node.approval_policy = parsed;
+        }
+    }
+    node.metadata = body.metadata.clone();
+    node
+}
+
+fn apply_node_policy_body(
+    node: &mut WorkflowNode,
+    body: &WorkflowPatchNodePolicyBody,
+) -> Result<(), String> {
+    if let Some(label) = &body.task_label {
+        node.task_label = Some(label.clone());
+    }
+    if let Some(prompt) = &body.prompt {
+        node.prompt = Some(prompt.clone());
+    }
+    if let Some(system) = &body.system {
+        node.system = Some(system.clone());
+    }
+    if let Some(tools) = &body.tools {
+        node.tools = tools.clone();
+    }
+    if let Some(model_policy) = &body.model_policy {
+        node.model_policy = serde_json::from_value(model_policy.clone())
+            .map_err(|error| format!("invalid model_policy: {error}"))?;
+    }
+    if let Some(capability_policy) = &body.capability_policy {
+        node.capability_policy = capability_policy.clone();
+    }
+    if let Some(approval_policy) = &body.approval_policy {
+        node.approval_policy = serde_json::from_value(approval_policy.clone())
+            .map_err(|error| format!("invalid approval_policy: {error}"))?;
+    }
+    Ok(())
+}
+
+fn apply_bundle_policy_body(
+    policy: &mut WorkflowBundlePolicy,
+    body: &WorkflowPatchBundlePolicyBody,
+) -> Result<(), String> {
+    if let Some(autonomy) = &body.autonomy_tier {
+        policy.autonomy_tier = autonomy.clone();
+    }
+    if let Some(tool_policy) = &body.tool_policy {
+        policy.tool_policy = tool_policy.clone();
+    }
+    if let Some(approval_required) = &body.approval_required {
+        policy.approval_required = approval_required.clone();
+    }
+    if let Some(retry) = &body.retry {
+        policy.retry = serde_json::from_value(retry.clone())
+            .map_err(|error| format!("invalid retry: {error}"))?;
+    }
+    if let Some(catchup) = &body.catchup {
+        policy.catchup = serde_json::from_value(catchup.clone())
+            .map_err(|error| format!("invalid catchup: {error}"))?;
+    }
+    Ok(())
+}
+
+fn diff_bundle_graph(
+    before: &WorkflowBundle,
+    after: &WorkflowBundle,
+    patch: &WorkflowPatch,
+) -> WorkflowPatchGraphDiff {
+    let mut diff = WorkflowPatchGraphDiff::default();
+    let before_node_ids: BTreeSet<&String> = before.workflow.nodes.keys().collect();
+    for node_id in after.workflow.nodes.keys() {
+        if !before_node_ids.contains(node_id) {
+            diff.added_nodes.push(node_id.clone());
+        }
+    }
+    let before_edges: BTreeSet<(String, String, Option<String>, Option<String>)> = before
+        .workflow
+        .edges
+        .iter()
+        .map(|edge| {
+            (
+                edge.from.clone(),
+                edge.to.clone(),
+                edge.branch.clone(),
+                edge.label.clone(),
+            )
+        })
+        .collect();
+    for edge in &after.workflow.edges {
+        let key = (
+            edge.from.clone(),
+            edge.to.clone(),
+            edge.branch.clone(),
+            edge.label.clone(),
+        );
+        if !before_edges.contains(&key) {
+            diff.added_edges.push(WorkflowPatchEdgeRef {
+                from: edge.from.clone(),
+                to: edge.to.clone(),
+                branch: edge.branch.clone(),
+                label: edge.label.clone(),
+            });
+        }
+    }
+    for operation in &patch.operations {
+        match operation {
+            WorkflowPatchOperation::UpdateNodePolicy { node_id, .. } => {
+                diff.updated_nodes.push(node_id.clone());
+            }
+            WorkflowPatchOperation::UpsertPromptCapsule { capsule_id, .. } => {
+                diff.updated_capsules.push(capsule_id.clone());
+            }
+            WorkflowPatchOperation::UpdateBundlePolicy { policy } => {
+                if policy.autonomy_tier.is_some() {
+                    diff.policy_fields_changed.push("autonomy_tier".to_string());
+                }
+                if policy.tool_policy.is_some() {
+                    diff.policy_fields_changed.push("tool_policy".to_string());
+                }
+                if policy.approval_required.is_some() {
+                    diff.policy_fields_changed
+                        .push("approval_required".to_string());
+                }
+                if policy.retry.is_some() {
+                    diff.policy_fields_changed.push("retry".to_string());
+                }
+                if policy.catchup.is_some() {
+                    diff.policy_fields_changed.push("catchup".to_string());
+                }
+            }
+            _ => {}
+        }
+    }
+    diff.added_nodes.sort();
+    diff.updated_nodes.sort();
+    diff.updated_nodes.dedup();
+    diff.updated_capsules.sort();
+    diff.updated_capsules.dedup();
+    diff.policy_fields_changed.sort();
+    diff.policy_fields_changed.dedup();
+    diff.added_edges
+        .sort_by(|left, right| (&left.from, &left.to).cmp(&(&right.from, &right.to)));
+    diff
+}
+
+fn compute_capability_delta(
+    before_bundle: &WorkflowBundle,
+    after_bundle: &WorkflowBundle,
+    before: CapabilityPolicy,
+    after: CapabilityPolicy,
+    parent: Option<&CapabilityPolicy>,
+) -> WorkflowPatchCapabilityDelta {
+    let added_tools: Vec<String> = after
+        .tools
+        .iter()
+        .filter(|tool| !before.tools.contains(tool))
+        .cloned()
+        .collect();
+
+    let mut added_capabilities: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for (capability, ops) in &after.capabilities {
+        let before_ops = before
+            .capabilities
+            .get(capability)
+            .cloned()
+            .unwrap_or_default();
+        let added: Vec<String> = ops
+            .iter()
+            .filter(|op| !before_ops.contains(op))
+            .cloned()
+            .collect();
+        if !added.is_empty() {
+            added_capabilities.insert(capability.clone(), added);
+        }
+    }
+
+    let raised_side_effect_level = match (
+        before.side_effect_level.as_deref(),
+        after.side_effect_level.as_deref(),
+    ) {
+        (Some(before_level), Some(after_level))
+            if side_effect_rank(after_level) > side_effect_rank(before_level) =>
+        {
+            Some(RaisedSideEffectLevel {
+                from: before_level.to_string(),
+                to: after_level.to_string(),
+            })
+        }
+        (None, Some(after_level)) => Some(RaisedSideEffectLevel {
+            from: "none".to_string(),
+            to: after_level.to_string(),
+        }),
+        _ => None,
+    };
+
+    let added_workspace_roots: Vec<String> = after
+        .workspace_roots
+        .iter()
+        .filter(|root| !before.workspace_roots.contains(root))
+        .cloned()
+        .collect();
+
+    let mut added_connector_scopes: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    let before_scopes_by_id: BTreeMap<&str, BTreeSet<&str>> = before_bundle
+        .connectors
+        .iter()
+        .map(|connector| {
+            (
+                connector.id.as_str(),
+                connector.scopes.iter().map(String::as_str).collect(),
+            )
+        })
+        .collect();
+    for connector in &after_bundle.connectors {
+        let before_scopes = before_scopes_by_id
+            .get(connector.id.as_str())
+            .cloned()
+            .unwrap_or_default();
+        let added: Vec<String> = connector
+            .scopes
+            .iter()
+            .filter(|scope| !before_scopes.contains(scope.as_str()))
+            .cloned()
+            .collect();
+        if !added.is_empty() {
+            added_connector_scopes.insert(connector.id.clone(), added);
+        }
+    }
+
+    let added_command_gates: Vec<String> = after_bundle
+        .environment
+        .command_gates
+        .iter()
+        .filter(|gate| !before_bundle.environment.command_gates.contains(gate))
+        .cloned()
+        .collect();
+
+    let raised_autonomy_tier = match (
+        before_bundle.policy.autonomy_tier.as_str(),
+        after_bundle.policy.autonomy_tier.as_str(),
+    ) {
+        (before_tier, after_tier) if autonomy_rank(after_tier) > autonomy_rank(before_tier) => {
+            Some(RaisedAutonomyTier {
+                from: before_tier.to_string(),
+                to: after_tier.to_string(),
+            })
+        }
+        _ => None,
+    };
+
+    let widening = match parent {
+        Some(parent) => collect_ceiling_violations(
+            parent,
+            &after,
+            &added_connector_scopes,
+            &added_command_gates,
+            raised_autonomy_tier.as_ref(),
+        ),
+        None => Vec::new(),
+    };
+
+    WorkflowPatchCapabilityDelta {
+        before,
+        after,
+        parent: parent.cloned(),
+        added_tools,
+        added_capabilities,
+        raised_side_effect_level,
+        added_workspace_roots,
+        added_connector_scopes,
+        added_command_gates,
+        raised_autonomy_tier,
+        widening,
+    }
+}
+
+fn collect_ceiling_violations(
+    parent: &CapabilityPolicy,
+    requested: &CapabilityPolicy,
+    added_connector_scopes: &BTreeMap<String, Vec<String>>,
+    added_command_gates: &[String],
+    raised_autonomy_tier: Option<&RaisedAutonomyTier>,
+) -> Vec<CapabilityCeilingViolation> {
+    let mut violations = Vec::new();
+    if !parent.tools.is_empty() {
+        for tool in &requested.tools {
+            if !parent.tools.contains(tool) {
+                violations.push(CapabilityCeilingViolation {
+                    kind: "tool".to_string(),
+                    detail: format!("tool '{tool}' is not in parent tool ceiling"),
+                });
+            }
+        }
+    }
+    for (capability, ops) in &requested.capabilities {
+        match parent.capabilities.get(capability) {
+            Some(parent_ops) => {
+                for op in ops {
+                    if !parent_ops.contains(op) {
+                        violations.push(CapabilityCeilingViolation {
+                            kind: "capability".to_string(),
+                            detail: format!(
+                                "capability '{capability}.{op}' exceeds parent ceiling"
+                            ),
+                        });
+                    }
+                }
+            }
+            None if !parent.capabilities.is_empty() => {
+                violations.push(CapabilityCeilingViolation {
+                    kind: "capability".to_string(),
+                    detail: format!("capability '{capability}' is not in parent ceiling"),
+                });
+            }
+            _ => {}
+        }
+    }
+    if let (Some(parent_level), Some(requested_level)) = (
+        parent.side_effect_level.as_deref(),
+        requested.side_effect_level.as_deref(),
+    ) {
+        if side_effect_rank(requested_level) > side_effect_rank(parent_level) {
+            violations.push(CapabilityCeilingViolation {
+                kind: "side_effect_level".to_string(),
+                detail: format!(
+                    "side_effect_level '{requested_level}' exceeds parent ceiling '{parent_level}'"
+                ),
+            });
+        }
+    }
+    if !parent.workspace_roots.is_empty() {
+        for root in &requested.workspace_roots {
+            if !parent.workspace_roots.contains(root) {
+                violations.push(CapabilityCeilingViolation {
+                    kind: "workspace_root".to_string(),
+                    detail: format!("workspace_root '{root}' exceeds parent allowlist"),
+                });
+            }
+        }
+    }
+    if !added_connector_scopes.is_empty() {
+        let parent_allows_connector_calls = parent
+            .capabilities
+            .get("connector")
+            .is_some_and(|ops| ops.iter().any(|op| op == "call"));
+        if !parent_allows_connector_calls && !parent.capabilities.is_empty() {
+            for (connector_id, scopes) in added_connector_scopes {
+                violations.push(CapabilityCeilingViolation {
+                    kind: "connector_scope".to_string(),
+                    detail: format!(
+                        "connector '{connector_id}' adds scopes {scopes:?} but parent ceiling does not include connector.call"
+                    ),
+                });
+            }
+        }
+    }
+    if !added_command_gates.is_empty() {
+        let parent_allows_exec = parent
+            .capabilities
+            .get("process")
+            .is_some_and(|ops| ops.iter().any(|op| op == "exec"));
+        if !parent_allows_exec && !parent.capabilities.is_empty() {
+            violations.push(CapabilityCeilingViolation {
+                kind: "command_gate".to_string(),
+                detail: format!(
+                    "patch adds command gates {added_command_gates:?} but parent ceiling does not include process.exec"
+                ),
+            });
+        }
+    }
+    if let Some(raised) = raised_autonomy_tier {
+        violations.push(CapabilityCeilingViolation {
+            kind: "autonomy_tier".to_string(),
+            detail: format!(
+                "autonomy_tier raised from '{}' to '{}' — patches must not widen autonomy",
+                raised.from, raised.to
+            ),
+        });
+    }
+    violations
+}
+
+fn side_effect_rank(level: &str) -> usize {
+    match level {
+        "none" => 0,
+        "read_only" => 1,
+        "workspace_write" => 2,
+        "process_exec" => 3,
+        "network" => 4,
+        _ => 5,
+    }
+}
+
+fn static_side_effect(level: &str) -> &'static str {
+    match level {
+        "none" => "none",
+        "read_only" => "read_only",
+        "workspace_write" => "workspace_write",
+        "process_exec" => "process_exec",
+        "network" => "network",
+        _ => "none",
+    }
+}
+
+fn autonomy_rank(tier: &str) -> usize {
+    match tier {
+        "shadow" => 0,
+        "suggest" => 1,
+        "act_with_approval" => 2,
+        "act_auto" => 3,
+        _ => 0,
+    }
+}
+
+fn autonomy_side_effect_floor(tier: &str) -> Option<&'static str> {
+    match tier {
+        "act_auto" => Some("network"),
+        "act_with_approval" => Some("process_exec"),
+        "suggest" => Some("read_only"),
+        _ => None,
+    }
+}
+
+fn diagnostic_op(
+    index: usize,
+    op: &str,
+    path: String,
+    message: String,
+    node_id: Option<String>,
+) -> WorkflowPatchDiagnostic {
+    WorkflowPatchDiagnostic {
+        severity: "error".to_string(),
+        op_index: Some(index),
+        op: Some(op.to_string()),
+        path,
+        message,
+        node_id,
+    }
+}
+
+fn diagnostic_global(message: String) -> WorkflowPatchDiagnostic {
+    WorkflowPatchDiagnostic {
+        severity: "error".to_string(),
+        op_index: None,
+        op: None,
+        path: "patch".to_string(),
+        message,
+        node_id: None,
+    }
+}
+
+#[cfg(test)]
+#[path = "workflow_patch_tests.rs"]
+mod workflow_patch_tests;

--- a/crates/harn-vm/src/orchestration/workflow_patch_tests.rs
+++ b/crates/harn-vm/src/orchestration/workflow_patch_tests.rs
@@ -1,0 +1,332 @@
+use std::collections::BTreeMap;
+
+use serde_json::json;
+
+use super::*;
+use crate::orchestration::CapabilityPolicy;
+
+fn fixture_bundle() -> WorkflowBundle {
+    super::super::workflow_test_fixtures::pr_monitor_bundle()
+}
+
+fn parent_ceiling_act_with_approval() -> CapabilityPolicy {
+    let mut capabilities = BTreeMap::new();
+    capabilities.insert("workspace".to_string(), vec!["read_text".to_string()]);
+    capabilities.insert("connector".to_string(), vec!["call".to_string()]);
+    capabilities.insert("process".to_string(), vec!["exec".to_string()]);
+    CapabilityPolicy {
+        tools: vec!["read_file".to_string(), "github_search".to_string()],
+        capabilities,
+        workspace_roots: Vec::new(),
+        side_effect_level: Some("process_exec".to_string()),
+        recursion_limit: None,
+        tool_arg_constraints: Vec::new(),
+        tool_annotations: BTreeMap::new(),
+    }
+}
+
+fn parent_ceiling_read_only() -> CapabilityPolicy {
+    let mut capabilities = BTreeMap::new();
+    capabilities.insert("workspace".to_string(), vec!["read_text".to_string()]);
+    CapabilityPolicy {
+        tools: vec!["read_file".to_string()],
+        capabilities,
+        workspace_roots: Vec::new(),
+        side_effect_level: Some("read_only".to_string()),
+        recursion_limit: None,
+        tool_arg_constraints: Vec::new(),
+        tool_annotations: BTreeMap::new(),
+    }
+}
+
+fn pr_verifier_patch() -> WorkflowPatch {
+    serde_json::from_value(json!({
+        "schema_version": 1,
+        "id": "patch-pr-verifier-001",
+        "summary": "Insert deterministic verifier between query_logs and notify",
+        "operations": [
+            {
+                "op": "insert_node",
+                "node_id": "verify_logs",
+                "node": {
+                    "kind": "action",
+                    "task_label": "Verify summary against deploy logs"
+                }
+            },
+            {
+                "op": "insert_node",
+                "node_id": "repair_logs",
+                "node": {
+                    "kind": "agent",
+                    "task_label": "Repair summary"
+                }
+            },
+            { "op": "add_edge", "from": "query_logs", "to": "verify_logs" },
+            { "op": "add_edge", "from": "verify_logs", "to": "notify", "branch": "verify_pass" },
+            { "op": "add_edge", "from": "verify_logs", "to": "repair_logs", "branch": "verify_fail" },
+            { "op": "add_edge", "from": "repair_logs", "to": "verify_logs" },
+            {
+                "op": "upsert_prompt_capsule",
+                "capsule_id": "verify-logs",
+                "capsule": {
+                    "node_id": "verify_logs",
+                    "prompt": "Confirm the previous summary cites at least one file:line."
+                }
+            }
+        ]
+    }))
+    .expect("patch parses")
+}
+
+#[test]
+fn pr_monitor_verifier_patch_applies_validates_and_diffs() {
+    let bundle = fixture_bundle();
+    let patch = pr_verifier_patch();
+    let report =
+        validate_workflow_patch(&bundle, &patch, Some(&parent_ceiling_act_with_approval()));
+    assert!(report.valid, "report should be valid: {report:#?}");
+    assert!(report.apply_errors.is_empty());
+    assert!(report.bundle_validation.valid);
+    assert_eq!(
+        report.graph_diff.added_nodes,
+        vec!["repair_logs".to_string(), "verify_logs".to_string()]
+    );
+    assert!(report
+        .graph_diff
+        .added_edges
+        .iter()
+        .any(|edge| edge.from == "verify_logs"
+            && edge.to == "notify"
+            && edge.branch.as_deref() == Some("verify_pass")));
+    assert!(report
+        .graph_diff
+        .added_edges
+        .iter()
+        .any(|edge| edge.from == "verify_logs"
+            && edge.to == "repair_logs"
+            && edge.branch.as_deref() == Some("verify_fail")));
+    assert!(report
+        .graph_diff
+        .updated_capsules
+        .contains(&"verify-logs".to_string()));
+    assert!(report.capability_delta.widening.is_empty());
+}
+
+#[test]
+fn empty_operations_are_rejected() {
+    let bundle = fixture_bundle();
+    let patch = WorkflowPatch {
+        schema_version: WORKFLOW_PATCH_SCHEMA_VERSION,
+        id: "patch-noop".to_string(),
+        summary: None,
+        operations: Vec::new(),
+    };
+    let result = apply_workflow_patch(&bundle, &patch);
+    let errors = result.expect_err("empty patch is rejected");
+    assert!(errors
+        .iter()
+        .any(|err| err.message.contains("no operations")));
+}
+
+#[test]
+fn unknown_node_id_in_add_edge_fails() {
+    let bundle = fixture_bundle();
+    let patch = WorkflowPatch {
+        schema_version: WORKFLOW_PATCH_SCHEMA_VERSION,
+        id: "patch-bad-edge".to_string(),
+        summary: None,
+        operations: vec![WorkflowPatchOperation::AddEdge {
+            from: "ingest".to_string(),
+            to: "does_not_exist".to_string(),
+            branch: None,
+            label: None,
+        }],
+    };
+    let report = validate_workflow_patch(&bundle, &patch, None);
+    assert!(!report.valid);
+    assert!(report
+        .apply_errors
+        .iter()
+        .any(|err| err.message.contains("does_not_exist")));
+}
+
+#[test]
+fn duplicate_insert_node_is_rejected() {
+    let bundle = fixture_bundle();
+    let patch = WorkflowPatch {
+        schema_version: WORKFLOW_PATCH_SCHEMA_VERSION,
+        id: "patch-dup".to_string(),
+        summary: None,
+        operations: vec![WorkflowPatchOperation::InsertNode {
+            node_id: "ingest".to_string(),
+            node: WorkflowPatchNodeBody::default(),
+        }],
+    };
+    let report = validate_workflow_patch(&bundle, &patch, None);
+    assert!(!report.valid);
+    assert!(report
+        .apply_errors
+        .iter()
+        .any(|err| err.message.contains("already contains node ingest")));
+}
+
+#[test]
+fn duplicate_edge_is_rejected() {
+    let bundle = fixture_bundle();
+    let patch = WorkflowPatch {
+        schema_version: WORKFLOW_PATCH_SCHEMA_VERSION,
+        id: "patch-dup-edge".to_string(),
+        summary: None,
+        operations: vec![WorkflowPatchOperation::AddEdge {
+            from: "ingest".to_string(),
+            to: "wait_for_deploy".to_string(),
+            branch: None,
+            label: None,
+        }],
+    };
+    let report = validate_workflow_patch(&bundle, &patch, None);
+    assert!(!report.valid);
+    assert!(report
+        .apply_errors
+        .iter()
+        .any(|err| err.message.contains("already exists")));
+}
+
+#[test]
+fn capability_widening_via_node_policy_is_rejected() {
+    let bundle = fixture_bundle();
+    let mut node_capabilities = BTreeMap::new();
+    node_capabilities.insert("process".to_string(), vec!["exec".to_string()]);
+    let node_policy = CapabilityPolicy {
+        tools: vec!["dangerous_exec".to_string()],
+        capabilities: node_capabilities,
+        side_effect_level: Some("process_exec".to_string()),
+        ..CapabilityPolicy::default()
+    };
+
+    let patch = WorkflowPatch {
+        schema_version: WORKFLOW_PATCH_SCHEMA_VERSION,
+        id: "patch-widen".to_string(),
+        summary: None,
+        operations: vec![
+            WorkflowPatchOperation::InsertNode {
+                node_id: "exec_node".to_string(),
+                node: WorkflowPatchNodeBody {
+                    kind: Some("action".to_string()),
+                    task_label: Some("Run exec".to_string()),
+                    capability_policy: Some(node_policy),
+                    ..WorkflowPatchNodeBody::default()
+                },
+            },
+            WorkflowPatchOperation::AddEdge {
+                from: "ingest".to_string(),
+                to: "exec_node".to_string(),
+                branch: None,
+                label: None,
+            },
+        ],
+    };
+    let report = validate_workflow_patch(&bundle, &patch, Some(&parent_ceiling_read_only()));
+    assert!(!report.valid, "widened patch should fail: {report:#?}");
+    assert!(!report.capability_delta.widening.is_empty());
+    let kinds: Vec<&str> = report
+        .capability_delta
+        .widening
+        .iter()
+        .map(|v| v.kind.as_str())
+        .collect();
+    assert!(kinds.contains(&"tool"));
+    assert!(kinds.contains(&"side_effect_level"));
+}
+
+#[test]
+fn raising_autonomy_tier_is_a_widening_violation() {
+    let bundle = fixture_bundle();
+    let patch = WorkflowPatch {
+        schema_version: WORKFLOW_PATCH_SCHEMA_VERSION,
+        id: "patch-raise-autonomy".to_string(),
+        summary: None,
+        operations: vec![WorkflowPatchOperation::UpdateBundlePolicy {
+            policy: WorkflowPatchBundlePolicyBody {
+                autonomy_tier: Some("act_auto".to_string()),
+                ..WorkflowPatchBundlePolicyBody::default()
+            },
+        }],
+    };
+    let report =
+        validate_workflow_patch(&bundle, &patch, Some(&parent_ceiling_act_with_approval()));
+    assert!(!report.valid);
+    assert!(report
+        .capability_delta
+        .widening
+        .iter()
+        .any(|violation| violation.kind == "autonomy_tier"));
+}
+
+#[test]
+fn upsert_prompt_capsule_collision_is_rejected() {
+    let bundle = fixture_bundle();
+    let patch = WorkflowPatch {
+        schema_version: WORKFLOW_PATCH_SCHEMA_VERSION,
+        id: "patch-capsule-collision".to_string(),
+        summary: None,
+        operations: vec![WorkflowPatchOperation::UpsertPromptCapsule {
+            capsule_id: "another-capsule".to_string(),
+            capsule: WorkflowPatchPromptCapsuleBody {
+                node_id: "query_logs".to_string(),
+                prompt: "Override".to_string(),
+                ..WorkflowPatchPromptCapsuleBody::default()
+            },
+        }],
+    };
+    let report = validate_workflow_patch(&bundle, &patch, None);
+    assert!(!report.valid);
+    assert!(report
+        .apply_errors
+        .iter()
+        .any(|err| err.message.contains("already targets")));
+}
+
+#[test]
+fn update_node_policy_succeeds_when_within_ceiling() {
+    let bundle = fixture_bundle();
+    let mut tool_policy = BTreeMap::new();
+    tool_policy.insert("github_search".to_string(), json!({"allowed": true}));
+    let patch = WorkflowPatch {
+        schema_version: WORKFLOW_PATCH_SCHEMA_VERSION,
+        id: "patch-update-policy".to_string(),
+        summary: None,
+        operations: vec![WorkflowPatchOperation::UpdateBundlePolicy {
+            policy: WorkflowPatchBundlePolicyBody {
+                tool_policy: Some(tool_policy),
+                ..WorkflowPatchBundlePolicyBody::default()
+            },
+        }],
+    };
+    let report =
+        validate_workflow_patch(&bundle, &patch, Some(&parent_ceiling_act_with_approval()));
+    assert!(report.valid, "{report:#?}");
+    assert!(report
+        .graph_diff
+        .policy_fields_changed
+        .contains(&"tool_policy".to_string()));
+}
+
+#[test]
+fn bundle_capability_ceiling_includes_connector_call_for_bundles_with_connectors() {
+    let bundle = fixture_bundle();
+    let ceiling = bundle_capability_ceiling(&bundle);
+    let connector_ops = ceiling
+        .capabilities
+        .get("connector")
+        .expect("connector capability is derived from connector requirements");
+    assert!(connector_ops.iter().any(|op| op == "call"));
+}
+
+#[test]
+fn bundle_capability_ceiling_floors_side_effect_to_autonomy_tier() {
+    let mut bundle = fixture_bundle();
+    bundle.policy.autonomy_tier = "act_auto".to_string();
+    let ceiling = bundle_capability_ceiling(&bundle);
+    assert_eq!(ceiling.side_effect_level.as_deref(), Some("network"));
+}

--- a/crates/harn-vm/src/orchestration/workflow_test_fixtures.rs
+++ b/crates/harn-vm/src/orchestration/workflow_test_fixtures.rs
@@ -1,0 +1,157 @@
+//! Inline workflow bundle fixtures shared across `harn-vm` tests.
+//!
+//! Tests in this crate must not `include_str!` outside the crate root —
+//! `cargo package` rejects it because the included file is not part of
+//! the published tarball. The canonical user-facing fixture lives at
+//! `docs/fixtures/workflow-bundles/github-pr-monitor.bundle.json`; we
+//! duplicate it here as a string constant so in-crate tests stay
+//! self-contained.
+//!
+//! `tests::pr_monitor_fixture_matches_canonical_docs_fixture` is the
+//! drift guard: it lives in the workspace test suite (not in the
+//! published crate), reads the canonical docs file at test time, and
+//! asserts byte-equality after JSON normalization. Touching either
+//! copy without updating the other breaks CI.
+
+use super::workflow_bundle::WorkflowBundle;
+
+pub(crate) const PR_MONITOR_BUNDLE_JSON: &str = r#"{
+  "schema_version": 1,
+  "id": "github-pr-monitor",
+  "name": "GitHub PR monitor",
+  "version": "1.0.0",
+  "triggers": [
+    {
+      "id": "github-pr-updated",
+      "kind": "github",
+      "provider": "github",
+      "events": ["pull_request.opened", "pull_request.synchronize"],
+      "node_id": "ingest"
+    },
+    {
+      "id": "delay-log-check",
+      "kind": "delay",
+      "delay": "PT10M",
+      "node_id": "query_logs"
+    }
+  ],
+  "workflow": {
+    "_type": "workflow_graph",
+    "id": "pr_monitor_workflow",
+    "name": "PR monitor",
+    "version": 1,
+    "entry": "ingest",
+    "nodes": {
+      "ingest": {
+        "id": "ingest",
+        "kind": "action",
+        "task_label": "Normalize PR event"
+      },
+      "wait_for_deploy": {
+        "id": "wait_for_deploy",
+        "kind": "waitpoint",
+        "task_label": "Wait for deploy"
+      },
+      "query_logs": {
+        "id": "query_logs",
+        "kind": "action",
+        "task_label": "Query logs"
+      },
+      "notify": {
+        "id": "notify",
+        "kind": "notification",
+        "task_label": "Notify user"
+      }
+    },
+    "edges": [
+      {
+        "from": "ingest",
+        "to": "wait_for_deploy"
+      },
+      {
+        "from": "wait_for_deploy",
+        "to": "query_logs"
+      },
+      {
+        "from": "query_logs",
+        "to": "notify"
+      }
+    ]
+  },
+  "prompt_capsules": {
+    "query-logs": {
+      "id": "query-logs",
+      "node_id": "query_logs",
+      "trigger_id": "delay-log-check",
+      "prompt": "Query deploy logs for the pull request and summarize failures."
+    }
+  },
+  "policy": {
+    "autonomy_tier": "act_with_approval",
+    "retry": {
+      "max_attempts": 2,
+      "backoff": "exponential"
+    },
+    "catchup": {
+      "mode": "latest",
+      "max_events": 1
+    }
+  },
+  "connectors": [
+    {
+      "id": "github",
+      "provider_id": "github",
+      "scopes": ["pull_requests:read", "checks:read"],
+      "setup_required": true,
+      "status_required": true
+    }
+  ],
+  "environment": {
+    "repo_setup_profile": "default",
+    "worktree_policy": "host_managed",
+    "command_gates": ["make test"]
+  },
+  "receipts": {
+    "run_id": "bundle_run_pr_monitor_fixture",
+    "event_ids": ["github:event:42"],
+    "workflow_version": 1
+  }
+}"#;
+
+pub(crate) fn pr_monitor_bundle() -> WorkflowBundle {
+    serde_json::from_str(PR_MONITOR_BUNDLE_JSON).expect("PR monitor fixture parses")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Drift guard: the in-crate fixture must stay byte-equal (after
+    /// JSON normalization) to the canonical user-facing fixture under
+    /// `docs/fixtures/`. The canonical file is what the workflow-authoring
+    /// skill pack and the CLI tests reference; duplicating its content
+    /// here is only safe if the two stay in sync.
+    #[test]
+    fn pr_monitor_fixture_matches_canonical_docs_fixture() {
+        let canonical_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../docs/fixtures/workflow-bundles/github-pr-monitor.bundle.json");
+        if !canonical_path.exists() {
+            // The published crate is unpacked outside the workspace; the
+            // docs/ tree is not part of the tarball. Skip the drift
+            // check in that environment — workspace CI runs it.
+            return;
+        }
+        let canonical_text = std::fs::read_to_string(&canonical_path)
+            .unwrap_or_else(|err| panic!("read {}: {err}", canonical_path.display()));
+        let canonical: serde_json::Value =
+            serde_json::from_str(&canonical_text).expect("canonical fixture parses");
+        let inline: serde_json::Value =
+            serde_json::from_str(PR_MONITOR_BUNDLE_JSON).expect("inline fixture parses");
+        assert_eq!(
+            canonical,
+            inline,
+            "in-crate PR monitor fixture has drifted from {}",
+            canonical_path.display()
+        );
+    }
+}

--- a/docs/fixtures/workflow-bundles/parent-act-with-approval.policy.json
+++ b/docs/fixtures/workflow-bundles/parent-act-with-approval.policy.json
@@ -1,0 +1,10 @@
+{
+  "tools": [],
+  "capabilities": {
+    "workspace": ["read_text", "list", "exists"],
+    "connector": ["call"],
+    "process": ["exec"],
+    "llm": ["call"]
+  },
+  "side_effect_level": "process_exec"
+}

--- a/docs/fixtures/workflow-bundles/pr-monitor-verifier.patch.json
+++ b/docs/fixtures/workflow-bundles/pr-monitor-verifier.patch.json
@@ -1,0 +1,53 @@
+{
+  "schema_version": 1,
+  "id": "pr-monitor-verifier-001",
+  "summary": "Insert a deterministic verifier node between query_logs and notify, with a repair branch back to verify on failure.",
+  "operations": [
+    {
+      "op": "insert_node",
+      "node_id": "verify_logs",
+      "node": {
+        "kind": "action",
+        "task_label": "Verify summary cites file:line and an error string"
+      }
+    },
+    {
+      "op": "insert_node",
+      "node_id": "repair_logs",
+      "node": {
+        "kind": "agent",
+        "task_label": "Repair summary if verification failed"
+      }
+    },
+    {
+      "op": "add_edge",
+      "from": "query_logs",
+      "to": "verify_logs"
+    },
+    {
+      "op": "add_edge",
+      "from": "verify_logs",
+      "to": "notify",
+      "branch": "verify_pass"
+    },
+    {
+      "op": "add_edge",
+      "from": "verify_logs",
+      "to": "repair_logs",
+      "branch": "verify_fail"
+    },
+    {
+      "op": "add_edge",
+      "from": "repair_logs",
+      "to": "verify_logs"
+    },
+    {
+      "op": "upsert_prompt_capsule",
+      "capsule_id": "verify-logs",
+      "capsule": {
+        "node_id": "verify_logs",
+        "prompt": "Confirm the previous summary cites at least one file:line reference and one error string from the deploy logs."
+      }
+    }
+  ]
+}

--- a/docs/src/workflow-bundles.md
+++ b/docs/src/workflow-bundles.md
@@ -147,3 +147,81 @@ harn run examples/skill-packs/workflow-authoring/eval.harn -- \
 `crates/harn-cli/tests/workflow_authoring_eval.rs` is the CI regression gate.
 It validates every recipe golden and every case's structural assertions, so a
 new case automatically extends the gate.
+
+## Workflow patch proposals
+
+Once a bundle exists, agents can propose **bounded, auditable edits** with a
+workflow patch instead of regenerating the whole bundle. A patch is a flat
+list of operations Harn applies to a copy of the bundle, then re-runs the
+validator and computes a structural diff plus a capability-ceiling delta.
+The patch contract is intentionally small — each op maps directly onto an
+"insert a verifier here" or "narrow this node's tool policy" intent.
+
+| `op` | What it does |
+|---|---|
+| `insert_node` | Inserts a workflow node (`agent`, `action`, `approval`, `notification`, …). |
+| `add_edge` | Adds an edge between two existing nodes. |
+| `upsert_prompt_capsule` | Inserts or replaces a prompt capsule for a node. |
+| `update_node_policy` | Patches `task_label` / `prompt` / `system` / `tools` / `model_policy` / `capability_policy` / `approval_policy` on an existing node. |
+| `update_bundle_policy` | Patches `autonomy_tier` / `tool_policy` / `approval_required` / `retry` / `catchup` at the bundle level. |
+
+```bash
+harn workflow patch validate \
+  --bundle docs/fixtures/workflow-bundles/github-pr-monitor.bundle.json \
+  --patch  docs/fixtures/workflow-bundles/pr-monitor-verifier.patch.json \
+  --parent-ceiling docs/fixtures/workflow-bundles/parent-act-with-approval.policy.json \
+  --json
+
+harn workflow patch apply --bundle ... --patch ... --out ...
+harn workflow patch preview --bundle ... --patch ... --mermaid
+```
+
+Failure modes the validator enforces:
+
+- Empty `operations` list (patches must do something — silent no-ops are
+  rejected).
+- Duplicate `insert_node` ids; unknown endpoints in `add_edge`; duplicate
+  edges; collisions on `upsert_prompt_capsule.node_id`.
+- Any patch that **widens** the parent ceiling along *tools*,
+  *capabilities*, *side-effect level*, *workspace roots*, *connector scopes*,
+  *command gates*, or *autonomy tier*. Each violation lands in the report's
+  `capability_delta.widening` array with a stable `kind` discriminator.
+
+### Safe Harn function tools
+
+`harn workflow function-tools --json` enumerates the allowlisted Harn
+functions an agent may call from inside the patch-authoring loop. Each
+descriptor carries an ACP-aligned `ToolAnnotations` block (kind +
+side-effect level + capability requirements) so a host can wire the tool
+straight into a model surface. The current allowlist is read-only or
+pure-think only:
+
+- `workflow_bundle_validate` / `workflow_bundle_preview` /
+  `workflow_bundle_capability_ceiling` — inspect a bundle on disk.
+- `workflow_patch_validate` — apply + validate a patch in memory and return
+  the report.
+
+Adding a function to the allowlist is a deliberate, reviewed change in
+`crates/harn-vm/src/orchestration/safe_function_tools.rs`. Anything outside
+the list is not exposed to agents.
+
+### Nested invocation ceiling
+
+When a script or host launches another Harn invocation (`harn run`,
+`harn workflow run`, `harn supervisor fire/replay`, a Burin harness),
+Harn projects the target's requested ceiling and rejects launches that
+would widen the parent's. `harn workflow nested-ceiling --bundle <path>
+--parent <policy>` exposes the same scanner so hosts can sanity-check
+before launch:
+
+```bash
+harn workflow nested-ceiling \
+  --bundle docs/fixtures/workflow-bundles/github-pr-monitor.bundle.json \
+  --parent docs/fixtures/workflow-bundles/parent-act-with-approval.policy.json
+```
+
+The scanner also accepts a Harn script source (token-level capability
+projection) and a Burin harness manifest (explicit `capability_ceiling`
+block, falling back to "request everything" if the manifest is silent —
+silence is treated as the most invasive request, so the parent rejects
+rather than rubber-stamps).

--- a/examples/skill-packs/workflow-authoring/SKILL.md
+++ b/examples/skill-packs/workflow-authoring/SKILL.md
@@ -16,6 +16,9 @@ allowed_tools:
   - "Bash(harn workflow validate:*)"
   - "Bash(harn workflow preview:*)"
   - "Bash(harn workflow run:*)"
+  - "Bash(harn workflow patch:*)"
+  - "Bash(harn workflow function-tools:*)"
+  - "Bash(harn workflow nested-ceiling:*)"
   - "Bash(harn check:*)"
   - "Read"
   - "Write"
@@ -168,9 +171,85 @@ gate (`crates/harn-cli/tests/workflow_authoring_eval.rs`) loads every case +
 recipe, asserts the goldens validate / preview / run, and asserts the
 structural assertions hold. Add a case → CI catches drift.
 
+## Workflow patch authoring
+
+When the user wants to **modify** an existing bundle (insert a verifier
+between two stages, add an approval gate, narrow a node's tool policy),
+emit a **workflow patch** instead of rewriting the bundle. Patches are
+auditable JSON: Harn applies them to a copy of the bundle, runs the
+validator, computes a structural diff, and rejects anything that widens
+the parent capability ceiling.
+
+```bash
+harn workflow patch validate \
+    --bundle pr-monitor.bundle.json \
+    --patch  pr-verifier.patch.json \
+    --parent-ceiling /path/to/parent.json --json
+harn workflow patch apply --bundle ... --patch ... --out ... --json
+harn workflow patch preview --bundle ... --patch ... --mermaid
+```
+
+The patch JSON is a flat list of operations:
+
+| `op` | Purpose | Required fields |
+|---|---|---|
+| `insert_node` | Add a workflow node (agent, verifier, approval, notification). | `node_id`, optional `node` body |
+| `add_edge` | Connect two existing nodes. | `from`, `to`, optional `branch`, `label` |
+| `upsert_prompt_capsule` | Insert or replace a prompt capsule for a node. | `capsule_id`, `capsule.{node_id, prompt}` |
+| `update_node_policy` | Patch a node's `task_label` / `prompt` / `system` / `tools` / `model_policy` / `capability_policy` / `approval_policy`. | `node_id`, `policy.<field>` |
+| `update_bundle_policy` | Patch bundle-level `autonomy_tier` / `tool_policy` / `approval_required` / `retry` / `catchup`. | `policy.<field>` |
+
+**Hard rules — the validator enforces them:**
+
+- The patch must declare `schema_version: 1` and a non-empty `id`.
+- An empty `operations` list is rejected (patches must do something).
+- `insert_node` fails on a duplicate id; `add_edge` fails on a duplicate
+  edge or unknown endpoint; `upsert_prompt_capsule` fails when another
+  capsule already targets the same node.
+- A patched bundle that widens any of `tools`, `capabilities`,
+  `side_effect_level`, `workspace_roots`, connector scopes, command
+  gates, or `autonomy_tier` against `--parent-ceiling` is rejected with
+  per-dimension `widening` violations. **Patches never expand
+  permissions.**
+
+Worked example: `recipes/pr-monitor-verifier-patch/patch.json` inserts
+a deterministic verifier and a repair branch into the PR-monitor recipe
+and validates against the canonical fixture.
+
+## Safe Harn function tools
+
+`harn workflow function-tools --json` lists the allowlisted Harn
+functions an agent may call from inside the patch-authoring loop. Every
+descriptor is read-only or pure-think with an ACP-aligned
+`ToolAnnotations` block: hosts can wire them straight into a model's
+tool surface without auditing each one separately. The current
+allowlist:
+
+- `workflow_bundle_validate` — validate a bundle JSON file at a path.
+- `workflow_bundle_preview` — normalized graph + mermaid + editable fields.
+- `workflow_bundle_capability_ceiling` — capability ceiling the bundle would request.
+- `workflow_patch_validate` — apply + validate a patch in memory and return the report.
+
+Adding a function to this list is a deliberate, reviewed change in
+`crates/harn-vm/src/orchestration/safe_function_tools.rs`. The default
+posture is "not exposed."
+
+## Nested invocation ceiling
+
+When a Harn script under an active execution policy launches another
+Harn invocation (`harn run`, `harn workflow run`, `harn supervisor
+fire/replay`, a Burin harness), the parent must scan the target and
+reject anything that asks for more than its own ceiling.
+`harn workflow nested-ceiling --bundle <path> --parent <policy>` exposes
+the same scanner used internally so hosts can sanity-check before
+launching.
+
 ## Pointers
 
 - Bundle contract: [`docs/src/workflow-bundles.md`](../../../docs/src/workflow-bundles.md)
 - Trigger / connector providers: [`docs/llm/harn-triggers-quickref.md`](../../../docs/llm/harn-triggers-quickref.md)
 - Supervisor commands: [`docs/src/workflow-supervisor.md`](../../../docs/src/workflow-supervisor.md)
 - Validator source of truth: [`crates/harn-vm/src/orchestration/workflow_bundle.rs`](../../../crates/harn-vm/src/orchestration/workflow_bundle.rs)
+- Patch contract source: [`crates/harn-vm/src/orchestration/workflow_patch.rs`](../../../crates/harn-vm/src/orchestration/workflow_patch.rs)
+- Safe function-tool allowlist: [`crates/harn-vm/src/orchestration/safe_function_tools.rs`](../../../crates/harn-vm/src/orchestration/safe_function_tools.rs)
+- Nested invocation guard: [`crates/harn-vm/src/orchestration/nested_invocation.rs`](../../../crates/harn-vm/src/orchestration/nested_invocation.rs)

--- a/examples/skill-packs/workflow-authoring/prompting.md
+++ b/examples/skill-packs/workflow-authoring/prompting.md
@@ -102,6 +102,49 @@ WorkflowBundle (schema_version: 1). Validate against the rules in
 that prompting guide. Use the recipes/ directory as concrete examples.
 ```
 
+## Workflow patches (modifying an existing bundle)
+
+When the user asks to **modify** a bundle that already exists (insert a
+verifier, narrow a node's tool policy, add an approval gate, add a repair
+branch), respond with a **patch** instead of a fresh bundle. The patch
+envelope mirrors the bundle envelope — three XML-style sections — but the
+JSON inside `<bundle>` is replaced with `<patch>`:
+
+```text
+<patch>
+{
+  "schema_version": 1,
+  "id": "kebab-case-patch-id",
+  "summary": "<one short sentence>",
+  "operations": [ ... ]
+}
+</patch>
+
+<rationale>
+- one bullet per operation
+- ≤ 5 bullets, plain prose
+</rationale>
+
+<verify>
+harn workflow patch validate --bundle in.bundle.json --patch out.patch.json --json
+harn workflow patch preview  --bundle in.bundle.json --patch out.patch.json --mermaid
+harn workflow patch apply    --bundle in.bundle.json --patch out.patch.json --out patched.bundle.json
+</verify>
+```
+
+Hard rules for patches (the validator enforces them):
+
+- `operations` must not be empty (a no-op patch is rejected).
+- `insert_node` must use a fresh `node_id`; `add_edge` endpoints must
+  exist (insert nodes first if needed); `upsert_prompt_capsule.node_id`
+  must already exist *after* prior ops apply.
+- Never raise `policy.autonomy_tier`, `side_effect_level`, the per-node
+  `capability_policy.tools`, or any `capability_policy.capabilities` that
+  the parent ceiling does not already grant. The validator returns a
+  per-dimension `widening` list when this happens — fix the patch by
+  either narrowing the request or redirecting the work to a node the
+  parent already trusts.
+
 ## Why XML, not Markdown fences
 
 XML-style tags are robust against the model accidentally closing a fenced

--- a/examples/skill-packs/workflow-authoring/recipes/pr-monitor-verifier-patch/README.md
+++ b/examples/skill-packs/workflow-authoring/recipes/pr-monitor-verifier-patch/README.md
@@ -1,0 +1,56 @@
+# PR-monitor verifier patch
+
+Worked example of a workflow patch that **modifies an existing bundle**
+rather than rewriting it. Apply on top of the PR-monitor recipe to
+insert a deterministic verifier between `query_logs` and `notify`, plus
+a repair branch that loops back to verify on failure.
+
+## What the patch does
+
+| Op | Effect |
+|---|---|
+| `insert_node verify_logs`  | Adds an `action` node that asserts the previous summary cites file:line + an error string. |
+| `insert_node repair_logs`  | Adds an `agent` node that fixes the summary if verification fails. |
+| `add_edge query_logs -> verify_logs` | Routes the existing query output through the new verifier. |
+| `add_edge verify_logs -> notify [verify_pass]` | On success, hand off to the existing notification node. |
+| `add_edge verify_logs -> repair_logs [verify_fail]` | On failure, run the repair agent. |
+| `add_edge repair_logs -> verify_logs` | Loop back to re-verify the repair output. |
+| `upsert_prompt_capsule verify-logs` | Attach the verifier's prompt capsule. |
+
+## Run it
+
+```bash
+harn workflow patch validate \
+    --bundle ../pr-monitor/bundle.json \
+    --patch  patch.json \
+    --json
+
+harn workflow patch apply \
+    --bundle ../pr-monitor/bundle.json \
+    --patch  patch.json \
+    --out    /tmp/pr-monitor-with-verifier.bundle.json
+harn workflow validate --bundle /tmp/pr-monitor-with-verifier.bundle.json
+```
+
+The validator should report the patched bundle as valid; the structural
+diff should list `verify_logs` and `repair_logs` as added nodes plus
+the four new edges; and `capability_delta.widening` should be empty
+(this patch only adds nodes/edges, it does not raise the autonomy tier
+or expand any capability).
+
+## Capability ceiling
+
+To verify that this patch does *not* widen the parent ceiling, supply a
+`--parent-ceiling` JSON file that describes the active execution
+policy:
+
+```bash
+harn workflow patch validate \
+    --bundle ../pr-monitor/bundle.json \
+    --patch  patch.json \
+    --parent-ceiling ../../../../docs/fixtures/workflow-bundles/parent-act-with-approval.policy.json \
+    --json
+```
+
+(See the workflow-authoring SKILL.md "Workflow patch authoring"
+section for the full contract.)

--- a/examples/skill-packs/workflow-authoring/recipes/pr-monitor-verifier-patch/patch.json
+++ b/examples/skill-packs/workflow-authoring/recipes/pr-monitor-verifier-patch/patch.json
@@ -1,0 +1,53 @@
+{
+  "schema_version": 1,
+  "id": "pr-monitor-verifier-001",
+  "summary": "Insert a deterministic verifier between query_logs and notify, with a repair branch back to verify on failure.",
+  "operations": [
+    {
+      "op": "insert_node",
+      "node_id": "verify_logs",
+      "node": {
+        "kind": "action",
+        "task_label": "Verify summary cites file:line and an error string"
+      }
+    },
+    {
+      "op": "insert_node",
+      "node_id": "repair_logs",
+      "node": {
+        "kind": "agent",
+        "task_label": "Repair summary if verification failed"
+      }
+    },
+    {
+      "op": "add_edge",
+      "from": "query_logs",
+      "to": "verify_logs"
+    },
+    {
+      "op": "add_edge",
+      "from": "verify_logs",
+      "to": "notify",
+      "branch": "verify_pass"
+    },
+    {
+      "op": "add_edge",
+      "from": "verify_logs",
+      "to": "repair_logs",
+      "branch": "verify_fail"
+    },
+    {
+      "op": "add_edge",
+      "from": "repair_logs",
+      "to": "verify_logs"
+    },
+    {
+      "op": "upsert_prompt_capsule",
+      "capsule_id": "verify-logs",
+      "capsule": {
+        "node_id": "verify_logs",
+        "prompt": "Confirm the previous summary cites at least one file:line reference and one error string from the deploy logs."
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Lets an agent author **bounded, auditable changes** to a workflow bundle through a flat patch JSON instead of regenerating the bundle. Harn applies the patch to a copy, re-runs the validator, computes a structural diff and a capability-ceiling delta, and rejects anything that widens the parent ceiling along *tools*, *capabilities*, *side-effect level*, *workspace roots*, *connector scopes*, *command gates*, or *autonomy tier*.

Closes #1423.

## What changed

- **Patch contract** (`crates/harn-vm/src/orchestration/workflow_patch.rs`) — `WorkflowPatch` JSON with five op variants: `insert_node`, `add_edge`, `upsert_prompt_capsule`, `update_node_policy`, `update_bundle_policy`. Apply + validate are pure functions; the result is a single `WorkflowPatchValidationReport` with apply errors, the existing bundle validation, the structural diff, the capability delta, and the normalized graph export.

- **Bundle capability ceiling projection** — `bundle_capability_ceiling()` composes a single `CapabilityPolicy` from per-node `capability_policy` declarations, bundle-level `tool_policy` keys, connector scopes, the autonomy tier (which acts as a side-effect floor), and the worktree/command-gate environment. This is the projection the comparison axis uses.

- **Allowlisted function-tool adapter** (`crates/harn-vm/src/orchestration/safe_function_tools.rs`) — read-only / pure-think Harn functions an agent may call from inside the patch loop. Each entry carries an ACP-aligned `ToolAnnotations` block (kind + side-effect level + capabilities + arg schema) hosts can wire straight into a model surface. Initial entries: `workflow_bundle_validate`, `workflow_bundle_preview`, `workflow_bundle_capability_ceiling`, `workflow_patch_validate`. Adding a new entry is a deliberate, reviewed change.

- **Nested invocation ceiling** (`crates/harn-vm/src/orchestration/nested_invocation.rs`) — `enforce_nested_invocation_ceiling(parent, target)` projects the requested ceiling for a nested launch and returns the per-dimension widening list. Three target shapes: workflow bundle (uses the bundle projection above), Harn script source (token-level scan that strips comments + string literals to avoid false positives), and Burin harness manifest (explicit `capability_ceiling` block, falling back to "request network" when the manifest is silent so silence cannot rubber-stamp).

- **CLI surfaces** — `harn workflow patch {validate,apply,preview} --bundle X --patch Y [--parent-ceiling Z] [--json]`, `harn workflow function-tools [--json]`, `harn workflow nested-ceiling --bundle X --parent Y [--json]`.

- **Skill pack** — `examples/skill-packs/workflow-authoring/SKILL.md` and `prompting.md` cover the patch contract; `recipes/pr-monitor-verifier-patch/` is the worked PR-monitor verifier insertion fixture from the issue.

- **Docs + changelog** — `docs/src/workflow-bundles.md` documents the patch contract, the safe-function-tool allowlist, and the nested-ceiling guard. `CHANGELOG.md` calls out the surfaces.

## Test plan

- [x] 11 patch contract unit tests (insert/edge/capsule/policy ops + ceiling widening + duplicate rejection + capsule collisions).
- [x] 6 safe-function-tool tests (registry is read-only / pure-think only, every entry has an object schema, dispatch happy path + invalid args).
- [x] 9 nested-invocation tests (workflow bundle, Harn script, Burin manifest; comment + string-literal false-positive guards).
- [x] 6 CLI integration tests (`workflow_patch_cli.rs`) exercising validate / apply / preview / function-tools / nested-ceiling JSON surfaces and the PR-monitor verifier recipe end-to-end.
- [x] `make test` (3522 tests, 0 failures), `cargo fmt --all -- --check`, `cargo clippy -p harn-vm -p harn-cli --all-targets` clean, `make lint-test-patterns`, `make lint-md`, `make check-docs-snippets`, `cargo test -p harn-cli --test workflow_authoring_eval` (existing skill-pack regression still green).
- [x] Manually exercised: `harn workflow patch validate/apply/preview/--json`, `harn workflow function-tools --json`, `harn workflow nested-ceiling --bundle ... --parent ...` against the new fixture.

## Notes

- The patch contract intentionally exposes semantic operations (insert this node, add this edge, narrow this policy) instead of a generic JSON-pointer surgery surface. New ops require a deliberate contract bump — the patch layer is the meta-programming entrypoint, not a general bundle DSL.
- The `--parent-ceiling` argument is the integration point for parent execution policies. Subagent code that already calls `CapabilityPolicy::intersect()` can pass the intersected policy here so an agent-authored patch is rejected exactly when the parent would reject the same surface.