### PR TITLE
Add unified event tape and fidelity oracle for testbench replay

### DIFF
--- a/crates/harn-cli/src/cli/mod.rs
+++ b/crates/harn-cli/src/cli/mod.rs
@@ -140,7 +140,7 @@ pub(crate) use supervisor::{
 };
 pub(crate) use test::TestArgs;
 pub(crate) use test_bench::{
-    TestBenchArgs, TestBenchCommand, TestBenchReplayArgs, TestBenchRunArgs,
+    TestBenchArgs, TestBenchCommand, TestBenchFidelityArgs, TestBenchReplayArgs, TestBenchRunArgs,
 };
 pub(crate) use trace::{TraceArgs, TraceCommand, TraceImportArgs};
 pub(crate) use trigger::{TriggerArgs, TriggerCancelArgs, TriggerCommand, TriggerReplayArgs};

--- a/crates/harn-cli/src/cli/test_bench.rs
+++ b/crates/harn-cli/src/cli/test_bench.rs
@@ -15,6 +15,10 @@ pub(crate) enum TestBenchCommand {
     /// Replay a previously recorded subprocess tape against a script
     /// and assert the run produces a byte-identical tape.
     Replay(TestBenchReplayArgs),
+    /// Score replay fidelity. Pass two recorded tapes to diff them, or
+    /// pass `--against <tape> <script>` to re-run the script and compare
+    /// the new tape against the recorded one.
+    Fidelity(TestBenchFidelityArgs),
 }
 
 #[derive(Debug, Args, Clone)]
@@ -81,6 +85,12 @@ pub(crate) struct TestBenchRunArgs {
     /// path. Requires `--fs-overlay`.
     #[arg(long = "emit-diff", value_name = "PATH", requires = "fs_overlay")]
     pub emit_diff: Option<String>,
+    /// Emit a unified event tape (clock reads, sleeps, LLM calls, FS
+    /// writes, subprocess spawns) to `PATH`. Large payloads spill to a
+    /// content-addressed sidecar at `PATH.cas/`. Documented in
+    /// `docs/src/dev/tape-format.md`.
+    #[arg(long = "emit-tape", value_name = "PATH")]
+    pub emit_tape: Option<String>,
     /// Positional script arguments. Pass after `--`:
     /// `harn test-bench run script.harn -- a b c`.
     #[arg(last = true)]
@@ -106,6 +116,47 @@ pub(crate) struct TestBenchReplayArgs {
     /// Filesystem overlay root for replay (matches the run-side flag).
     #[arg(long = "fs-overlay", value_name = "DIR")]
     pub fs_overlay: Option<String>,
+    /// Emit a fresh unified event tape during replay so a fidelity diff
+    /// against the recorded tape is one command away.
+    #[arg(long = "emit-tape", value_name = "PATH")]
+    pub emit_tape: Option<String>,
+    #[arg(last = true)]
+    pub argv: Vec<String>,
+}
+
+#[derive(Debug, Args, Clone)]
+pub(crate) struct TestBenchFidelityArgs {
+    /// Two-tape diff form: pass the recorded tape here and the replay
+    /// tape as the second positional. Re-run-and-diff form: pass the
+    /// recorded tape via `--against` and the .harn script here.
+    pub primary: String,
+    /// Replay tape to diff against `primary`. Required unless
+    /// `--against` is set.
+    pub replay: Option<String>,
+    /// Recorded tape to re-run a script against. When set, `primary`
+    /// is treated as the .harn script path and the runner re-executes
+    /// it under testbench replay before computing fidelity.
+    #[arg(long = "against", value_name = "PATH")]
+    pub against: Option<String>,
+    /// `byte-identical` (default), `semantic`, or `outcome`. See
+    /// `docs/src/dev/tape-format.md` for the per-mode semantics.
+    #[arg(long = "mode", default_value = "byte-identical", value_name = "MODE")]
+    pub mode: String,
+    /// Write the structured fidelity report (JSON) to this path.
+    /// Defaults to stdout.
+    #[arg(long = "report", value_name = "PATH")]
+    pub report: Option<String>,
+    /// Filesystem overlay root used when re-running the script under
+    /// `--against`. Ignored without `--against`.
+    #[arg(long = "fs-overlay", value_name = "DIR")]
+    pub fs_overlay: Option<String>,
+    /// Pin the mock clock to this UNIX-epoch millisecond value when
+    /// re-running under `--against`. Defaults to the recorded tape's
+    /// `started_at_unix_ms`.
+    #[arg(long = "start-at", value_name = "UNIX_MS")]
+    pub start_at_ms: Option<i64>,
+    /// Positional script arguments forwarded to the replayed script
+    /// under `--against`. Pass after `--`.
     #[arg(last = true)]
     pub argv: Vec<String>,
 }

--- a/crates/harn-cli/src/commands/test_bench.rs
+++ b/crates/harn-cli/src/commands/test_bench.rs
@@ -9,15 +9,18 @@
 
 use std::collections::HashSet;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process;
 
+use harn_vm::testbench::fidelity::{compare, FidelityMode, FidelityReport};
 use harn_vm::testbench::overlay_fs::{render_unified_diff, DiffEntry, DiffKind};
+use harn_vm::testbench::tape::EventTape;
 use harn_vm::testbench::{
-    ClockConfig, FilesystemConfig, LlmConfig, NetworkConfig, SubprocessConfig, Testbench,
+    ClockConfig, FilesystemConfig, LlmConfig, NetworkConfig, SubprocessConfig, TapeConfig,
+    Testbench,
 };
 
-use crate::cli::{TestBenchCommand, TestBenchReplayArgs, TestBenchRunArgs};
+use crate::cli::{TestBenchCommand, TestBenchFidelityArgs, TestBenchReplayArgs, TestBenchRunArgs};
 use crate::commands::run::{execute_run, CliLlmMockMode, RunOutcome, RunProfileOptions};
 
 /// Default starting point for `--clock paused` runs. Picked to be
@@ -26,10 +29,19 @@ use crate::commands::run::{execute_run, CliLlmMockMode, RunOutcome, RunProfileOp
 /// 2026-01-01T00:00:00Z.
 const DEFAULT_TESTBENCH_START_MS: i64 = 1_767_225_600_000;
 
+/// Where the replay tape used by `harn test-bench fidelity` came from.
+enum ReplaySource {
+    /// Re-run the script under `--against` and emit a fresh tape.
+    ReRun,
+    /// Load an existing tape from disk.
+    Tape(String),
+}
+
 pub(crate) async fn run(command: TestBenchCommand) {
     let outcome = match command {
         TestBenchCommand::Run(args) => run_args(args).await,
         TestBenchCommand::Replay(args) => replay_args(args).await,
+        TestBenchCommand::Fidelity(args) => fidelity_args(args).await,
     };
     flush_outcome(outcome);
 }
@@ -98,6 +110,13 @@ async fn run_args(args: TestBenchRunArgs) -> RunOutcome {
             finalize.recorded_subprocesses.len()
         ));
     }
+    if let Some(tape) = finalize.tape.as_ref() {
+        outcome.stderr.push_str(&format!(
+            "[testbench] emitted unified tape with {} record(s) to {}.\n",
+            tape.records,
+            tape.path.display(),
+        ));
+    }
     outcome
 }
 
@@ -114,9 +133,114 @@ async fn replay_args(args: TestBenchReplayArgs) -> RunOutcome {
         network: "deny".to_string(),
         allow_host: Vec::new(),
         emit_diff: None,
+        emit_tape: args.emit_tape.clone(),
         argv: args.argv.clone(),
     };
     run_args(derived).await
+}
+
+async fn fidelity_args(args: TestBenchFidelityArgs) -> RunOutcome {
+    let mode = match FidelityMode::parse(&args.mode) {
+        Ok(mode) => mode,
+        Err(error) => return error_outcome(error),
+    };
+
+    let (recorded_path, replay_source) = match (&args.against, &args.replay) {
+        (Some(recorded), _) => (recorded.clone(), ReplaySource::ReRun),
+        (None, Some(replay)) => (args.primary.clone(), ReplaySource::Tape(replay.clone())),
+        (None, None) => {
+            return error_outcome(
+                "expected either two tape paths or `--against <tape> <script>`".to_string(),
+            )
+        }
+    };
+
+    let recorded = match EventTape::load(Path::new(&recorded_path)) {
+        Ok(tape) => tape,
+        Err(error) => return error_outcome(format!("load recorded tape: {error}")),
+    };
+
+    let (replay, mut prelude) = match replay_source {
+        ReplaySource::ReRun => {
+            let temp = match tempfile::tempdir() {
+                Ok(dir) => dir,
+                Err(error) => return error_outcome(format!("create temp tape dir: {error}")),
+            };
+            let replay_tape_path = temp.path().join("replay.tape");
+            let start_at = args
+                .start_at_ms
+                .or(recorded.header.started_at_unix_ms)
+                .unwrap_or(DEFAULT_TESTBENCH_START_MS);
+            let derived = TestBenchRunArgs {
+                file: args.primary.clone(),
+                start_at_ms: Some(start_at),
+                clock: "paused".to_string(),
+                llm_fixture: None,
+                llm_record: None,
+                fs_overlay: args.fs_overlay.clone(),
+                process_replay: None,
+                process_record: None,
+                network: "deny".to_string(),
+                allow_host: Vec::new(),
+                emit_diff: None,
+                emit_tape: Some(replay_tape_path.to_string_lossy().into_owned()),
+                argv: args.argv.clone(),
+            };
+            let inner = run_args(derived).await;
+            match EventTape::load(&replay_tape_path) {
+                Ok(tape) => (tape, inner),
+                Err(error) => return append_error(inner, format!("load replay tape: {error}")),
+            }
+        }
+        ReplaySource::Tape(path) => match EventTape::load(Path::new(&path)) {
+            Ok(tape) => (tape, RunOutcome::default()),
+            Err(error) => return error_outcome(format!("load replay tape: {error}")),
+        },
+    };
+
+    let report = compare(&recorded, &replay, mode);
+    let json = match serde_json::to_string_pretty(&report) {
+        Ok(json) => json,
+        Err(error) => return append_error(prelude, format!("serialize fidelity report: {error}")),
+    };
+    if let Some(path) = args.report.as_ref() {
+        if let Err(error) = persist_fidelity_report(&json, Path::new(path)) {
+            return append_error(prelude, format!("write fidelity report: {error}"));
+        }
+        prelude.stderr.push_str(&format!(
+            "[testbench] fidelity report written to {path} (mode={:?}, score={:.4}, divergences={})\n",
+            report.mode,
+            report.score,
+            report.divergences.len(),
+        ));
+    } else {
+        prelude.stdout.push_str(&json);
+        prelude.stdout.push('\n');
+    }
+    if !report.divergences.is_empty() {
+        prelude.exit_code = prelude.exit_code.max(report_exit_code(&report));
+    }
+    prelude
+}
+
+fn report_exit_code(report: &FidelityReport) -> i32 {
+    // Exit non-zero on any divergence so CI gates can rely on the
+    // status code without parsing JSON.
+    if report.divergences.is_empty() {
+        0
+    } else {
+        2
+    }
+}
+
+fn persist_fidelity_report(json: &str, path: &Path) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent)
+                .map_err(|error| format!("mkdir {}: {error}", parent.display()))?;
+        }
+    }
+    fs::write(path, json).map_err(|error| format!("write {}: {error}", path.display()))
 }
 
 fn build_testbench(args: &TestBenchRunArgs) -> Result<Testbench, String> {
@@ -167,12 +291,22 @@ fn build_testbench(args: &TestBenchRunArgs) -> Result<Testbench, String> {
         other => return Err(format!("--network must be `deny` or `real`, got `{other}`")),
     };
 
+    let tape = match &args.emit_tape {
+        None => TapeConfig::Off,
+        Some(path) => TapeConfig::Emit {
+            path: PathBuf::from(path),
+            argv: args.argv.clone(),
+            script_path: Some(args.file.clone()),
+        },
+    };
+
     Ok(Testbench {
         clock,
         llm,
         filesystem,
         subprocess,
         network,
+        tape,
     })
 }
 

--- a/crates/harn-cli/tests/test_bench_cli.rs
+++ b/crates/harn-cli/tests/test_bench_cli.rs
@@ -15,10 +15,12 @@ use std::thread;
 
 use harn_cli::commands::run::{execute_run, CliLlmMockMode, RunOutcome, RunProfileOptions};
 use harn_cli::tests::common::{cwd_lock, env_lock};
+use harn_vm::testbench::fidelity::{compare, FidelityMode};
 use harn_vm::testbench::overlay_fs::{DiffKind, OverlayFs};
 use harn_vm::testbench::process_tape::{
     install_process_tape, ProcessTape, ProcessTapeMode, TapeEntry,
 };
+use harn_vm::testbench::tape::{EventTape, TapeRecordKind};
 use harn_vm::testbench::Testbench;
 use tempfile::TempDir;
 
@@ -64,7 +66,7 @@ fn run_under_testbench(
         std::env::set_current_dir(&cwd).expect("set cwd to test workspace");
 
         let bench = configure();
-        let _session = bench.activate().expect("activate testbench");
+        let session = bench.activate().expect("activate testbench");
 
         let outcome = execute_run(
             &script.to_string_lossy(),
@@ -77,6 +79,13 @@ fn run_under_testbench(
             RunProfileOptions::default(),
         )
         .await;
+
+        // Flush any recorded artifacts (process tape, unified tape) the
+        // run produced. `finalize` is the single mutator that persists;
+        // leaving the session to drop on its own is fine for axes that
+        // only need teardown, but tests asserting on emitted files must
+        // call this explicitly.
+        let _ = session.finalize();
 
         if let Some(prev) = original_cwd {
             let _ = std::env::set_current_dir(prev);
@@ -292,4 +301,152 @@ fn process_tape_persist_and_load_round_trip() {
     .expect("replay should succeed");
     assert!(String::from_utf8_lossy(&output.stdout).contains("hello-tape"));
     assert!(replay_tape.fully_consumed());
+}
+
+#[test]
+fn unified_tape_byte_identical_round_trip() {
+    // Acceptance criterion #1 from #1441: emit a tape, replay it, score
+    // byte-identical fidelity. Same script under the same paused clock
+    // produces a tape that byte-matches itself.
+    let temp = TempDir::new().unwrap();
+    let script = write_file(
+        temp.path(),
+        "tape.harn",
+        r#"
+pipeline default() {
+  let start = now_ms()
+  sleep(50)
+  write_file("snapshot.txt", "checkpoint at ${now_ms() - start}ms")
+}
+"#,
+    );
+
+    let workspace_a = temp.path().to_path_buf();
+    let workspace_b = temp.path().to_path_buf();
+    let script_clone = script.clone();
+    let tape_a = temp.path().join("a.tape");
+    let tape_b = temp.path().join("b.tape");
+    let tape_a_for_a = tape_a.clone();
+    let tape_b_for_b = tape_b.clone();
+
+    let outcome_a = run_under_testbench(workspace_a.clone(), script.clone(), move || {
+        Testbench::builder()
+            .paused_clock_at_ms(1_700_000_000_000)
+            .fs_overlay(workspace_a)
+            .emit_tape_for(
+                tape_a_for_a,
+                Some(script_clone.to_string_lossy().into_owned()),
+                Vec::new(),
+            )
+            .build()
+    });
+    assert_eq!(outcome_a.exit_code, 0, "stderr: {}", outcome_a.stderr);
+
+    let script_clone_b = script.clone();
+    let outcome_b = run_under_testbench(workspace_b.clone(), script.clone(), move || {
+        Testbench::builder()
+            .paused_clock_at_ms(1_700_000_000_000)
+            .fs_overlay(workspace_b)
+            .emit_tape_for(
+                tape_b_for_b,
+                Some(script_clone_b.to_string_lossy().into_owned()),
+                Vec::new(),
+            )
+            .build()
+    });
+    assert_eq!(outcome_b.exit_code, 0, "stderr: {}", outcome_b.stderr);
+
+    let recorded = EventTape::load(&tape_a).expect("load tape a");
+    let replay = EventTape::load(&tape_b).expect("load tape b");
+    assert!(
+        !recorded.records.is_empty(),
+        "tape captured nothing: {:?}",
+        recorded.records
+    );
+
+    let report = compare(&recorded, &replay, FidelityMode::ByteIdentical);
+    assert!(
+        report.is_byte_identical(),
+        "byte-identical replay diverged: {report:?}"
+    );
+    assert_eq!(report.score, 1.0);
+}
+
+#[test]
+fn unified_tape_flags_unpinned_clock_divergence() {
+    // Acceptance criterion #5: deliberately introduce a wall-clock read
+    // in a script and confirm the tape captures it AND the oracle flags
+    // the divergence between two runs that observed different times.
+    let temp = TempDir::new().unwrap();
+    let script = write_file(
+        temp.path(),
+        "drifty.harn",
+        r#"
+pipeline default() {
+  println("now=${now_ms()}")
+}
+"#,
+    );
+
+    let workspace_a = temp.path().to_path_buf();
+    let workspace_b = temp.path().to_path_buf();
+    let script_clone_a = script.clone();
+    let script_clone_b = script.clone();
+    let tape_a = temp.path().join("drift_a.tape");
+    let tape_b = temp.path().join("drift_b.tape");
+    let tape_a_for_a = tape_a.clone();
+    let tape_b_for_b = tape_b.clone();
+
+    // Run twice with *different* pinned clocks so the recorded
+    // ClockRead values diverge across the two tapes.
+    let outcome_a = run_under_testbench(workspace_a.clone(), script.clone(), move || {
+        Testbench::builder()
+            .paused_clock_at_ms(1_700_000_000_000)
+            .emit_tape_for(
+                tape_a_for_a,
+                Some(script_clone_a.to_string_lossy().into_owned()),
+                Vec::new(),
+            )
+            .build()
+    });
+    assert_eq!(outcome_a.exit_code, 0, "stderr: {}", outcome_a.stderr);
+
+    let outcome_b = run_under_testbench(workspace_b.clone(), script.clone(), move || {
+        Testbench::builder()
+            .paused_clock_at_ms(1_700_000_999_999)
+            .emit_tape_for(
+                tape_b_for_b,
+                Some(script_clone_b.to_string_lossy().into_owned()),
+                Vec::new(),
+            )
+            .build()
+    });
+    assert_eq!(outcome_b.exit_code, 0, "stderr: {}", outcome_b.stderr);
+
+    let tape_a_loaded = EventTape::load(&tape_a).expect("load drift_a");
+    let tape_b_loaded = EventTape::load(&tape_b).expect("load drift_b");
+
+    // The tapes must contain a ClockRead — proves capture.
+    assert!(
+        tape_a_loaded
+            .records
+            .iter()
+            .any(|r| matches!(r.kind, TapeRecordKind::ClockRead { .. })),
+        "drift_a tape missing ClockRead record"
+    );
+
+    // The oracle must flag the divergence under byte-identical mode.
+    let report = compare(&tape_a_loaded, &tape_b_loaded, FidelityMode::ByteIdentical);
+    assert!(
+        !report.is_byte_identical(),
+        "oracle failed to flag clock drift: {report:?}"
+    );
+    assert!(
+        report
+            .divergences
+            .iter()
+            .any(|d| d.category == "clock_read_value"),
+        "expected a clock_read_value divergence, got: {:?}",
+        report.divergences
+    );
 }

--- a/crates/harn-vm/src/llm/mock.rs
+++ b/crates/harn-vm/src/llm/mock.rs
@@ -425,6 +425,7 @@ fn try_match_cli_mock(match_text: &str) -> Option<Result<LlmResult, VmError>> {
 }
 
 pub(crate) fn record_cli_llm_result(result: &LlmResult) {
+    record_unified_tape_llm_call(result);
     if !CLI_LLM_MOCK_MODE.with(|mode| *mode.borrow() == CliLlmMockMode::Record) {
         return;
     }
@@ -447,6 +448,45 @@ pub(crate) fn record_cli_llm_result(result: &LlmResult) {
             logprobs: result.logprobs.clone(),
             error: None,
         });
+    });
+}
+
+/// Append an `LlmCall` record to the unified-tape recorder when one is
+/// active. The request digest is built from the most recently recorded
+/// `LlmMockCall` so the same hashing surface used for fixture matching
+/// drives the fidelity oracle's request comparison; falls back to a
+/// hash of the response text alone when no matching call is on record
+/// (e.g. when `record_llm_mock_call` was bypassed).
+fn record_unified_tape_llm_call(result: &LlmResult) {
+    if crate::testbench::tape::active_recorder().is_none() {
+        return;
+    }
+    let response_json = serde_json::to_vec(result).unwrap_or_else(|_| Vec::new());
+    let request_digest = LLM_MOCK_CALLS
+        .with(|calls| calls.borrow().last().cloned())
+        .map(|call| {
+            let serialized = serde_json::to_vec(&serde_json::json!({
+                "messages": call.messages,
+                "system": call.system,
+                "tools": call.tools,
+                "tool_choice": call.tool_choice,
+                "thinking": call.thinking,
+                "model": result.model,
+            }))
+            .unwrap_or_default();
+            crate::testbench::tape::content_hash(&serialized)
+        })
+        .unwrap_or_else(|| {
+            // Fall back to hashing the response — keeps fidelity comparable
+            // across runs even when the request surface wasn't captured.
+            crate::testbench::tape::content_hash(result.text.as_bytes())
+        });
+    crate::testbench::tape::with_active_recorder(|recorder| {
+        let response = recorder.payload_from_bytes(response_json);
+        Some(crate::testbench::tape::TapeRecordKind::LlmCall {
+            request_digest,
+            response,
+        })
     });
 }
 

--- a/crates/harn-vm/src/stdlib/clock.rs
+++ b/crates/harn-vm/src/stdlib/clock.rs
@@ -13,6 +13,7 @@ use std::sync::OnceLock;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use crate::clock_mock;
+use crate::testbench::tape::{self as tape, ClockSource, TapeRecordKind};
 use crate::value::{VmError, VmValue};
 use crate::vm::Vm;
 
@@ -40,9 +41,11 @@ fn real_monotonic_ms() -> i64 {
 /// Current wall-clock time in milliseconds since UNIX_EPOCH.
 /// Honors the active mock if one is installed.
 pub fn now_wall_ms() -> i64 {
-    clock_mock::active_mock_clock()
+    let value = clock_mock::active_mock_clock()
         .map(|c| c.now_wall_ms())
-        .unwrap_or_else(real_wall_ms)
+        .unwrap_or_else(real_wall_ms);
+    record_clock_read(ClockSource::Wall, value);
+    value
 }
 
 /// Current wall-clock time in seconds (with fractional part).
@@ -53,9 +56,15 @@ pub fn now_wall_seconds() -> f64 {
 /// Monotonic milliseconds. Honors the active mock; otherwise returns
 /// elapsed millis since process start.
 pub fn now_monotonic_ms() -> i64 {
-    clock_mock::active_mock_clock()
+    let value = clock_mock::active_mock_clock()
         .map(|c| c.now_monotonic_ms())
-        .unwrap_or_else(real_monotonic_ms)
+        .unwrap_or_else(real_monotonic_ms);
+    record_clock_read(ClockSource::Monotonic, value);
+    value
+}
+
+fn record_clock_read(source: ClockSource, value_ms: i64) {
+    tape::with_active_recorder(|_recorder| Some(TapeRecordKind::ClockRead { source, value_ms }));
 }
 
 /// Whether a clock mock is currently active.
@@ -70,6 +79,11 @@ pub fn advance(ms: i64) {
         return;
     }
     clock_mock::advance(Duration::from_millis(ms as u64));
+    tape::with_active_recorder(|_recorder| {
+        Some(TapeRecordKind::ClockSleep {
+            duration_ms: ms as u64,
+        })
+    });
 }
 
 fn push_mock(wall_ms: i64) {

--- a/crates/harn-vm/src/testbench/fidelity.rs
+++ b/crates/harn-vm/src/testbench/fidelity.rs
@@ -1,0 +1,734 @@
+//! Replay fidelity oracle.
+//!
+//! Compares two [`EventTape`]s and emits a structured [`FidelityReport`]
+//! listing every diverging record. The oracle drives the
+//! `harn test-bench fidelity` CLI subcommand and is the artifact behind
+//! [harn-cloud#19][cloud19]'s "byte-for-byte vs. semantic" leaderboard
+//! metric.
+//!
+//! [cloud19]: https://github.com/burin-labs/harn-cloud/issues/19
+//!
+//! # Modes
+//!
+//! - **`ByteIdentical`** (strictest). Every record must match position,
+//!   kind, and content hash. The mode CI uses to gate "this PR did not
+//!   regress replay determinism".
+//!
+//! - **`Semantic`**. Ignores diffs that are non-meaningful by
+//!   construction: monotonic-only sequence numbers, virtual-time stamps
+//!   that drift only because of paused-clock rounding, and recorded
+//!   `monotonic_ms` deltas. Content hashes still gate every payload, so
+//!   anything user-visible must still match.
+//!
+//! - **`Outcome`** (loosest). Compares only the script's externally
+//!   observable result: the final FS write set (overlay diff), the exit
+//!   status of the last subprocess, and the count of LLM calls. Useful
+//!   for stochastic LLM runs where intermediate token streams legitimately
+//!   diverge between record and replay.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use super::tape::{EventTape, TapeRecord, TapeRecordKind};
+
+/// Strictness of the comparison. The CLI surface picks one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FidelityMode {
+    ByteIdentical,
+    Semantic,
+    Outcome,
+}
+
+impl FidelityMode {
+    pub fn parse(label: &str) -> Result<Self, String> {
+        match label {
+            "byte" | "byte-identical" | "byte_identical" => Ok(Self::ByteIdentical),
+            "semantic" => Ok(Self::Semantic),
+            "outcome" => Ok(Self::Outcome),
+            other => Err(format!(
+                "unknown fidelity mode `{other}` — expected `byte-identical`, `semantic`, or `outcome`"
+            )),
+        }
+    }
+}
+
+/// Structured comparison result. Emitted as JSON by the CLI; consumed by
+/// CI gates and by the public leaderboard.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct FidelityReport {
+    pub mode: FidelityMode,
+    /// Number of records compared on the recorded side. Lets a consumer
+    /// distinguish "100% match over 0 records" from "100% over 1000".
+    pub recorded_records: usize,
+    /// Number of records compared on the replay side.
+    pub replay_records: usize,
+    /// Records where one side had an event the other did not, or where
+    /// the same-position record had different content. Stable order so
+    /// CI snapshots are deterministic.
+    pub divergences: Vec<Divergence>,
+    /// 0.0–1.0. Defined as `1 - (divergences / max(records, 1))` for
+    /// strict modes; in outcome mode it's `1.0` iff zero divergences.
+    pub score: f32,
+}
+
+impl FidelityReport {
+    pub fn is_byte_identical(&self) -> bool {
+        self.divergences.is_empty()
+    }
+}
+
+/// Single divergence between two tapes. Records are paired by sequence
+/// number for byte-identical / semantic modes; outcome mode emits one
+/// of these per outcome facet that disagreed.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Divergence {
+    /// Logical sequence number of the diverging record (`None` when the
+    /// divergence is an outcome facet, e.g. exit code).
+    pub seq: Option<u64>,
+    /// Short tag used by tooling to group divergences (`clock_sleep`,
+    /// `process_stdout_hash`, `outcome_exit_code`, …).
+    pub category: String,
+    /// Human-readable explanation. Stable phrasing — CI snapshot tests
+    /// match on substrings.
+    pub message: String,
+}
+
+/// Compare two tapes under `mode`.
+pub fn compare(recorded: &EventTape, replay: &EventTape, mode: FidelityMode) -> FidelityReport {
+    let divergences = match mode {
+        FidelityMode::ByteIdentical => compare_record_by_record(recorded, replay, true),
+        FidelityMode::Semantic => compare_record_by_record(recorded, replay, false),
+        FidelityMode::Outcome => compare_outcome(recorded, replay),
+    };
+    let baseline = recorded.records.len().max(replay.records.len()).max(1);
+    let score = match mode {
+        FidelityMode::ByteIdentical | FidelityMode::Semantic => {
+            1.0 - (divergences.len() as f32 / baseline as f32).min(1.0)
+        }
+        FidelityMode::Outcome => {
+            if divergences.is_empty() {
+                1.0
+            } else {
+                0.0
+            }
+        }
+    };
+    FidelityReport {
+        mode,
+        recorded_records: recorded.records.len(),
+        replay_records: replay.records.len(),
+        divergences,
+        score,
+    }
+}
+
+fn compare_record_by_record(
+    recorded: &EventTape,
+    replay: &EventTape,
+    byte_strict: bool,
+) -> Vec<Divergence> {
+    let mut out = Vec::new();
+    let max = recorded.records.len().max(replay.records.len());
+    for idx in 0..max {
+        match (recorded.records.get(idx), replay.records.get(idx)) {
+            (Some(rec), Some(rep)) => compare_pair(rec, rep, byte_strict, &mut out),
+            (Some(rec), None) => out.push(Divergence {
+                seq: Some(rec.seq),
+                category: "missing_in_replay".to_string(),
+                message: format!(
+                    "replay tape ended at #{idx}; recorded had {} more record(s)",
+                    recorded.records.len() - idx
+                ),
+            }),
+            (None, Some(rep)) => out.push(Divergence {
+                seq: Some(rep.seq),
+                category: "missing_in_recorded".to_string(),
+                message: format!(
+                    "replay produced an extra record at #{idx} (kind={})",
+                    record_kind_tag(&rep.kind)
+                ),
+            }),
+            (None, None) => break,
+        }
+    }
+    out
+}
+
+fn compare_pair(
+    recorded: &TapeRecord,
+    replay: &TapeRecord,
+    byte_strict: bool,
+    out: &mut Vec<Divergence>,
+) {
+    if record_kind_tag(&recorded.kind) != record_kind_tag(&replay.kind) {
+        out.push(Divergence {
+            seq: Some(recorded.seq),
+            category: "kind_mismatch".to_string(),
+            message: format!(
+                "record kind diverged: recorded={} replay={}",
+                record_kind_tag(&recorded.kind),
+                record_kind_tag(&replay.kind),
+            ),
+        });
+        return;
+    }
+    if byte_strict && recorded.virtual_time_ms != replay.virtual_time_ms {
+        out.push(Divergence {
+            seq: Some(recorded.seq),
+            category: "virtual_time_drift".to_string(),
+            message: format!(
+                "virtual_time_ms diverged: recorded={} replay={}",
+                recorded.virtual_time_ms, replay.virtual_time_ms,
+            ),
+        });
+    }
+    if byte_strict && recorded.monotonic_ms != replay.monotonic_ms {
+        out.push(Divergence {
+            seq: Some(recorded.seq),
+            category: "monotonic_drift".to_string(),
+            message: format!(
+                "monotonic_ms diverged: recorded={} replay={}",
+                recorded.monotonic_ms, replay.monotonic_ms,
+            ),
+        });
+    }
+    compare_kind(&recorded.kind, &replay.kind, recorded.seq, byte_strict, out);
+}
+
+fn compare_kind(
+    recorded: &TapeRecordKind,
+    replay: &TapeRecordKind,
+    seq: u64,
+    byte_strict: bool,
+    out: &mut Vec<Divergence>,
+) {
+    use TapeRecordKind::*;
+    match (recorded, replay) {
+        (
+            ClockRead {
+                source: r_source,
+                value_ms: r_val,
+            },
+            ClockRead {
+                source: p_source,
+                value_ms: p_val,
+            },
+        ) => {
+            if r_source != p_source {
+                out.push(Divergence {
+                    seq: Some(seq),
+                    category: "clock_read_source".to_string(),
+                    message: format!(
+                        "clock_read source diverged: recorded={r_source:?} replay={p_source:?}"
+                    ),
+                });
+            }
+            if r_val != p_val {
+                out.push(Divergence {
+                    seq: Some(seq),
+                    category: "clock_read_value".to_string(),
+                    message: format!(
+                        "clock_read value_ms diverged: recorded={r_val} replay={p_val}"
+                    ),
+                });
+            }
+        }
+        (
+            ClockSleep {
+                duration_ms: recorded_dur,
+            },
+            ClockSleep {
+                duration_ms: replay_dur,
+            },
+        ) => {
+            if recorded_dur != replay_dur {
+                out.push(Divergence {
+                    seq: Some(seq),
+                    category: "clock_sleep_duration".to_string(),
+                    message: format!(
+                        "sleep duration diverged: recorded={recorded_dur}ms replay={replay_dur}ms"
+                    ),
+                });
+            }
+        }
+        (
+            LlmCall {
+                request_digest: recorded_req,
+                response: recorded_res,
+            },
+            LlmCall {
+                request_digest: replay_req,
+                response: replay_res,
+            },
+        ) => {
+            if recorded_req != replay_req {
+                out.push(Divergence {
+                    seq: Some(seq),
+                    category: "llm_request_digest".to_string(),
+                    message: format!(
+                        "LLM request digest diverged: recorded={recorded_req} replay={replay_req}"
+                    ),
+                });
+            }
+            if recorded_res.content_hash() != replay_res.content_hash() {
+                out.push(Divergence {
+                    seq: Some(seq),
+                    category: "llm_response_hash".to_string(),
+                    message: format!(
+                        "LLM response hash diverged: recorded={} replay={}",
+                        recorded_res.content_hash(),
+                        replay_res.content_hash(),
+                    ),
+                });
+            }
+        }
+        (
+            FileRead {
+                path: rp,
+                content_hash: rh,
+                len_bytes: rl,
+            },
+            FileRead {
+                path: pp,
+                content_hash: ph,
+                len_bytes: pl,
+            },
+        ) => compare_file(seq, "file_read", rp, rh, *rl, pp, ph, *pl, byte_strict, out),
+        (
+            FileWrite {
+                path: rp,
+                content_hash: rh,
+                len_bytes: rl,
+            },
+            FileWrite {
+                path: pp,
+                content_hash: ph,
+                len_bytes: pl,
+            },
+        ) => compare_file(
+            seq,
+            "file_write",
+            rp,
+            rh,
+            *rl,
+            pp,
+            ph,
+            *pl,
+            byte_strict,
+            out,
+        ),
+        (FileDelete { path: rp }, FileDelete { path: pp }) => {
+            if rp != pp {
+                out.push(Divergence {
+                    seq: Some(seq),
+                    category: "file_delete_path".to_string(),
+                    message: format!("file_delete path diverged: recorded={rp} replay={pp}"),
+                });
+            }
+        }
+        (
+            ProcessSpawn {
+                program: r_program,
+                args: r_args,
+                cwd: r_cwd,
+                exit_code: r_exit,
+                duration_ms: r_dur,
+                stdout_payload: r_stdout,
+                stderr_payload: r_stderr,
+            },
+            ProcessSpawn {
+                program: p_program,
+                args: p_args,
+                cwd: p_cwd,
+                exit_code: p_exit,
+                duration_ms: p_dur,
+                stdout_payload: p_stdout,
+                stderr_payload: p_stderr,
+            },
+        ) => {
+            if r_program != p_program {
+                out.push(Divergence {
+                    seq: Some(seq),
+                    category: "process_program".to_string(),
+                    message: format!(
+                        "subprocess program diverged: recorded={r_program} replay={p_program}"
+                    ),
+                });
+            }
+            if r_args != p_args {
+                out.push(Divergence {
+                    seq: Some(seq),
+                    category: "process_args".to_string(),
+                    message: format!(
+                        "subprocess args diverged: recorded={r_args:?} replay={p_args:?}"
+                    ),
+                });
+            }
+            if r_cwd != p_cwd {
+                out.push(Divergence {
+                    seq: Some(seq),
+                    category: "process_cwd".to_string(),
+                    message: format!(
+                        "subprocess cwd diverged: recorded={r_cwd:?} replay={p_cwd:?}"
+                    ),
+                });
+            }
+            if r_exit != p_exit {
+                out.push(Divergence {
+                    seq: Some(seq),
+                    category: "process_exit_code".to_string(),
+                    message: format!(
+                        "subprocess exit code diverged: recorded={r_exit} replay={p_exit}"
+                    ),
+                });
+            }
+            if byte_strict && r_dur != p_dur {
+                out.push(Divergence {
+                    seq: Some(seq),
+                    category: "process_duration".to_string(),
+                    message: format!(
+                        "subprocess duration diverged: recorded={r_dur}ms replay={p_dur}ms"
+                    ),
+                });
+            }
+            if r_stdout.content_hash() != p_stdout.content_hash() {
+                out.push(Divergence {
+                    seq: Some(seq),
+                    category: "process_stdout_hash".to_string(),
+                    message: format!(
+                        "subprocess stdout hash diverged: recorded={} replay={}",
+                        r_stdout.content_hash(),
+                        p_stdout.content_hash(),
+                    ),
+                });
+            }
+            if r_stderr.content_hash() != p_stderr.content_hash() {
+                out.push(Divergence {
+                    seq: Some(seq),
+                    category: "process_stderr_hash".to_string(),
+                    message: format!(
+                        "subprocess stderr hash diverged: recorded={} replay={}",
+                        r_stderr.content_hash(),
+                        p_stderr.content_hash(),
+                    ),
+                });
+            }
+        }
+        (Unknown, _) | (_, Unknown) => out.push(Divergence {
+            seq: Some(seq),
+            category: "unknown_kind".to_string(),
+            message: "encountered an unknown record kind — produced by a newer harn-vm version"
+                .to_string(),
+        }),
+        // Kind tag matched at the top of `compare_pair`; reaching here
+        // means a new variant was added without extending this match.
+        // Surface a structured divergence rather than panicking so older
+        // CI runners stay functional after a tape-format upgrade.
+        _ => out.push(Divergence {
+            seq: Some(seq),
+            category: "comparator_gap".to_string(),
+            message: format!(
+                "no comparator wired for record kind `{}`",
+                record_kind_tag(recorded)
+            ),
+        }),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn compare_file(
+    seq: u64,
+    category: &str,
+    recorded_path: &str,
+    recorded_hash: &str,
+    recorded_len: u64,
+    replay_path: &str,
+    replay_hash: &str,
+    replay_len: u64,
+    byte_strict: bool,
+    out: &mut Vec<Divergence>,
+) {
+    if recorded_path != replay_path {
+        out.push(Divergence {
+            seq: Some(seq),
+            category: format!("{category}_path"),
+            message: format!(
+                "{category} path diverged: recorded={recorded_path} replay={replay_path}"
+            ),
+        });
+    }
+    if recorded_hash != replay_hash {
+        out.push(Divergence {
+            seq: Some(seq),
+            category: format!("{category}_hash"),
+            message: format!(
+                "{category} content hash diverged: recorded={recorded_hash} replay={replay_hash}"
+            ),
+        });
+    }
+    if byte_strict && recorded_len != replay_len {
+        out.push(Divergence {
+            seq: Some(seq),
+            category: format!("{category}_len"),
+            message: format!(
+                "{category} length diverged: recorded={recorded_len} replay={replay_len}"
+            ),
+        });
+    }
+}
+
+fn compare_outcome(recorded: &EventTape, replay: &EventTape) -> Vec<Divergence> {
+    let mut out = Vec::new();
+
+    let recorded_writes = collect_final_writes(recorded);
+    let replay_writes = collect_final_writes(replay);
+    if recorded_writes != replay_writes {
+        let recorded_paths: Vec<&String> = recorded_writes.keys().collect();
+        let replay_paths: Vec<&String> = replay_writes.keys().collect();
+        out.push(Divergence {
+            seq: None,
+            category: "outcome_fs_diff".to_string(),
+            message: format!(
+                "final FS write set diverged: recorded={recorded_paths:?} replay={replay_paths:?}"
+            ),
+        });
+    }
+
+    let recorded_exit = last_process_exit(recorded);
+    let replay_exit = last_process_exit(replay);
+    if recorded_exit != replay_exit {
+        out.push(Divergence {
+            seq: None,
+            category: "outcome_exit_code".to_string(),
+            message: format!(
+                "last subprocess exit code diverged: recorded={recorded_exit:?} replay={replay_exit:?}"
+            ),
+        });
+    }
+
+    let recorded_llm = count_llm_calls(recorded);
+    let replay_llm = count_llm_calls(replay);
+    if recorded_llm != replay_llm {
+        out.push(Divergence {
+            seq: None,
+            category: "outcome_llm_call_count".to_string(),
+            message: format!(
+                "LLM call count diverged: recorded={recorded_llm} replay={replay_llm}"
+            ),
+        });
+    }
+    out
+}
+
+fn collect_final_writes(tape: &EventTape) -> BTreeMap<String, Option<String>> {
+    let mut state: BTreeMap<String, Option<String>> = BTreeMap::new();
+    for record in &tape.records {
+        match &record.kind {
+            TapeRecordKind::FileWrite {
+                path, content_hash, ..
+            } => {
+                state.insert(path.clone(), Some(content_hash.clone()));
+            }
+            TapeRecordKind::FileDelete { path } => {
+                state.insert(path.clone(), None);
+            }
+            _ => {}
+        }
+    }
+    state
+}
+
+fn last_process_exit(tape: &EventTape) -> Option<i32> {
+    tape.records
+        .iter()
+        .rev()
+        .find_map(|record| match &record.kind {
+            TapeRecordKind::ProcessSpawn { exit_code, .. } => Some(*exit_code),
+            _ => None,
+        })
+}
+
+fn count_llm_calls(tape: &EventTape) -> usize {
+    tape.records
+        .iter()
+        .filter(|record| matches!(record.kind, TapeRecordKind::LlmCall { .. }))
+        .count()
+}
+
+fn record_kind_tag(kind: &TapeRecordKind) -> &'static str {
+    match kind {
+        TapeRecordKind::ClockRead { .. } => "clock_read",
+        TapeRecordKind::ClockSleep { .. } => "clock_sleep",
+        TapeRecordKind::LlmCall { .. } => "llm_call",
+        TapeRecordKind::FileRead { .. } => "file_read",
+        TapeRecordKind::FileWrite { .. } => "file_write",
+        TapeRecordKind::FileDelete { .. } => "file_delete",
+        TapeRecordKind::ProcessSpawn { .. } => "process_spawn",
+        TapeRecordKind::Unknown => "unknown",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testbench::tape::{TapeHeader, TapePayload, TapeRecord};
+
+    fn empty_tape() -> EventTape {
+        EventTape::new(TapeHeader::current(None, None, Vec::new()))
+    }
+
+    fn record(seq: u64, kind: TapeRecordKind) -> TapeRecord {
+        TapeRecord {
+            seq,
+            virtual_time_ms: 0,
+            monotonic_ms: 0,
+            kind,
+        }
+    }
+
+    #[test]
+    fn byte_identical_matches_when_records_align() {
+        let mut a = empty_tape();
+        let mut b = empty_tape();
+        a.records
+            .push(record(0, TapeRecordKind::ClockSleep { duration_ms: 5 }));
+        b.records
+            .push(record(0, TapeRecordKind::ClockSleep { duration_ms: 5 }));
+        let report = compare(&a, &b, FidelityMode::ByteIdentical);
+        assert!(report.is_byte_identical(), "{report:?}");
+        assert_eq!(report.score, 1.0);
+    }
+
+    #[test]
+    fn byte_identical_flags_a_drifted_clock_read() {
+        // Acceptance criterion: deliberately introduce a wall-clock
+        // divergence and confirm the oracle flags it.
+        let mut a = empty_tape();
+        let mut b = empty_tape();
+        a.records
+            .push(record(0, TapeRecordKind::ClockSleep { duration_ms: 5 }));
+        b.records
+            .push(record(0, TapeRecordKind::ClockSleep { duration_ms: 7 }));
+        let report = compare(&a, &b, FidelityMode::ByteIdentical);
+        assert_eq!(report.divergences.len(), 1);
+        assert_eq!(report.divergences[0].category, "clock_sleep_duration");
+    }
+
+    #[test]
+    fn semantic_mode_ignores_pure_timing_drift() {
+        let mut a = empty_tape();
+        let mut b = empty_tape();
+        let make = |seq: u64, vt: i64| TapeRecord {
+            seq,
+            virtual_time_ms: vt,
+            monotonic_ms: vt,
+            kind: TapeRecordKind::FileWrite {
+                path: "/tmp/out.txt".to_string(),
+                content_hash: "abc".to_string(),
+                len_bytes: 3,
+            },
+        };
+        a.records.push(make(0, 0));
+        b.records.push(make(0, 1)); // virtual time drifted by 1ms
+        let strict = compare(&a, &b, FidelityMode::ByteIdentical);
+        assert!(!strict.is_byte_identical());
+        let semantic = compare(&a, &b, FidelityMode::Semantic);
+        assert!(
+            semantic.is_byte_identical(),
+            "semantic should not flag pure timing drift, got {semantic:?}"
+        );
+    }
+
+    #[test]
+    fn outcome_mode_only_compares_final_writes_and_exit() {
+        let mut a = empty_tape();
+        let mut b = empty_tape();
+        // Both end with the same final FS state but take different paths.
+        a.records.push(record(
+            0,
+            TapeRecordKind::FileWrite {
+                path: "/tmp/a".to_string(),
+                content_hash: "h1".to_string(),
+                len_bytes: 1,
+            },
+        ));
+        a.records
+            .push(record(1, TapeRecordKind::ClockSleep { duration_ms: 1000 }));
+        b.records
+            .push(record(0, TapeRecordKind::ClockSleep { duration_ms: 50 }));
+        b.records.push(record(
+            1,
+            TapeRecordKind::FileWrite {
+                path: "/tmp/a".to_string(),
+                content_hash: "h1".to_string(),
+                len_bytes: 1,
+            },
+        ));
+        let report = compare(&a, &b, FidelityMode::Outcome);
+        assert!(
+            report.divergences.is_empty(),
+            "outcome mode should ignore intermediate diffs, got {report:?}"
+        );
+        assert_eq!(report.score, 1.0);
+    }
+
+    #[test]
+    fn outcome_mode_flags_exit_code_drift() {
+        let mut a = empty_tape();
+        let mut b = empty_tape();
+        let payload = TapePayload::Inline {
+            content_hash: "ehash".to_string(),
+            text: String::new(),
+        };
+        a.records.push(record(
+            0,
+            TapeRecordKind::ProcessSpawn {
+                program: "git".to_string(),
+                args: Vec::new(),
+                cwd: None,
+                exit_code: 0,
+                duration_ms: 1,
+                stdout_payload: payload.clone(),
+                stderr_payload: payload.clone(),
+            },
+        ));
+        b.records.push(record(
+            0,
+            TapeRecordKind::ProcessSpawn {
+                program: "git".to_string(),
+                args: Vec::new(),
+                cwd: None,
+                exit_code: 1,
+                duration_ms: 1,
+                stdout_payload: payload.clone(),
+                stderr_payload: payload,
+            },
+        ));
+        let report = compare(&a, &b, FidelityMode::Outcome);
+        assert_eq!(report.divergences.len(), 1);
+        assert_eq!(report.divergences[0].category, "outcome_exit_code");
+    }
+
+    #[test]
+    fn parse_mode_accepts_aliases() {
+        assert_eq!(
+            FidelityMode::parse("byte").unwrap(),
+            FidelityMode::ByteIdentical
+        );
+        assert_eq!(
+            FidelityMode::parse("byte-identical").unwrap(),
+            FidelityMode::ByteIdentical
+        );
+        assert_eq!(
+            FidelityMode::parse("semantic").unwrap(),
+            FidelityMode::Semantic
+        );
+        assert_eq!(
+            FidelityMode::parse("outcome").unwrap(),
+            FidelityMode::Outcome
+        );
+        assert!(FidelityMode::parse("nope").is_err());
+    }
+}

--- a/crates/harn-vm/src/testbench/mod.rs
+++ b/crates/harn-vm/src/testbench/mod.rs
@@ -36,8 +36,10 @@
 //! the destination. The deny pass routes through [`crate::egress`], the
 //! same policy engine production uses.
 
+pub mod fidelity;
 pub mod overlay_fs;
 pub mod process_tape;
+pub mod tape;
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -47,6 +49,7 @@ use crate::egress::reset_egress_policy_for_host;
 
 use overlay_fs::{install_overlay, OverlayFs, OverlayFsGuard};
 use process_tape::{install_process_tape, ProcessTape, ProcessTapeGuard, ProcessTapeMode};
+use tape::{install_recorder, TapeHeader, TapeRecorder, TapeRecorderGuard};
 
 /// Declarative configuration for [`Testbench::activate`]. Every axis is
 /// optional so callers can compose only the surfaces they need.
@@ -57,6 +60,7 @@ pub struct Testbench {
     pub filesystem: FilesystemConfig,
     pub subprocess: SubprocessConfig,
     pub network: NetworkConfig,
+    pub tape: TapeConfig,
 }
 
 /// Configures the unified mock clock. Defaults to the runtime's real
@@ -130,6 +134,27 @@ pub enum NetworkConfig {
     },
 }
 
+/// Unified-tape configuration. Recording is opt-in: `Off` (the default)
+/// installs nothing and pays nothing in production; `Emit { path }`
+/// installs a [`tape::TapeRecorder`] consulted by every host-capability
+/// axis, then persists the result to `path` (plus `path.cas/` for large
+/// payloads) when [`TestbenchSession::finalize`] runs.
+#[derive(Debug, Default, Clone)]
+pub enum TapeConfig {
+    #[default]
+    Off,
+    Emit {
+        path: PathBuf,
+        /// Argv forwarded to the script after `--`. Captured in the tape
+        /// header so two tapes that differ only in argv are
+        /// distinguishable.
+        argv: Vec<String>,
+        /// Path to the `.harn` script. Informational only; used to
+        /// populate the tape header so consumers can attribute records.
+        script_path: Option<String>,
+    },
+}
+
 impl Testbench {
     /// Convenience: construct a builder.
     pub fn builder() -> TestbenchBuilder {
@@ -198,6 +223,29 @@ impl TestbenchBuilder {
         self
     }
 
+    pub fn emit_tape(mut self, path: impl Into<PathBuf>) -> Self {
+        self.bench.tape = TapeConfig::Emit {
+            path: path.into(),
+            argv: Vec::new(),
+            script_path: None,
+        };
+        self
+    }
+
+    pub fn emit_tape_for(
+        mut self,
+        path: impl Into<PathBuf>,
+        script_path: Option<String>,
+        argv: Vec<String>,
+    ) -> Self {
+        self.bench.tape = TapeConfig::Emit {
+            path: path.into(),
+            argv,
+            script_path,
+        };
+        self
+    }
+
     pub fn build(self) -> Testbench {
         self.bench
     }
@@ -210,8 +258,14 @@ pub struct TestbenchSession {
     _clock: Option<ClockOverrideGuard>,
     _process: Option<ProcessTapeGuard>,
     _overlay: Option<OverlayFsGuard>,
+    _recorder: Option<TapeRecorderGuard>,
     process_tape: Option<Arc<ProcessTape>>,
     overlay: Option<Arc<OverlayFs>>,
+    recorder: Option<Arc<TapeRecorder>>,
+    tape_path: Option<PathBuf>,
+    tape_started_at_unix_ms: Option<i64>,
+    tape_script_path: Option<String>,
+    tape_argv: Vec<String>,
     subprocess_mode: ProcessTapeMode,
     subprocess_tape_path: Option<PathBuf>,
     /// Saved env state (`HARN_EGRESS_DEFAULT`, `_ALLOW`, `_DENY`) for
@@ -229,11 +283,12 @@ struct SavedEgressEnv {
 
 impl TestbenchSession {
     fn install(bench: Testbench) -> Result<Self, TestbenchError> {
-        let clock_guard = match bench.clock {
-            ClockConfig::Real => None,
-            ClockConfig::Paused { starting_at_ms } => {
-                Some(install_override(MockClock::at_wall_ms(starting_at_ms)))
-            }
+        let (clock_guard, started_at_unix_ms) = match bench.clock {
+            ClockConfig::Real => (None, None),
+            ClockConfig::Paused { starting_at_ms } => (
+                Some(install_override(MockClock::at_wall_ms(starting_at_ms))),
+                Some(starting_at_ms),
+            ),
         };
 
         // LLM state is *not* installed here — the caller owns the
@@ -299,12 +354,37 @@ impl TestbenchSession {
             }
         };
 
+        let (recorder, recorder_guard, tape_path, tape_argv, tape_script_path) = match bench.tape {
+            TapeConfig::Off => (None, None, None, Vec::new(), None),
+            TapeConfig::Emit {
+                path,
+                argv,
+                script_path,
+            } => {
+                let recorder = Arc::new(TapeRecorder::new());
+                let guard = install_recorder(Arc::clone(&recorder));
+                (
+                    Some(Arc::clone(&recorder)),
+                    Some(guard),
+                    Some(path),
+                    argv,
+                    script_path,
+                )
+            }
+        };
+
         Ok(Self {
             _clock: clock_guard,
             _process: process_guard,
             _overlay: overlay_guard,
+            _recorder: recorder_guard,
             process_tape,
             overlay,
+            recorder,
+            tape_path,
+            tape_started_at_unix_ms: started_at_unix_ms,
+            tape_script_path,
+            tape_argv,
             subprocess_mode,
             subprocess_tape_path,
             saved_egress_env,
@@ -332,6 +412,11 @@ impl TestbenchSession {
         self.process_tape.as_ref()
     }
 
+    /// Reference to the active tape recorder (if any).
+    pub fn tape_recorder(&self) -> Option<&Arc<TapeRecorder>> {
+        self.recorder.as_ref()
+    }
+
     /// Persist the recorded subprocess tape (if recording) and return
     /// the filesystem diff (if an overlay is active). Tearing down the
     /// session via [`Drop`] will not persist; call this explicitly to
@@ -356,10 +441,25 @@ impl TestbenchSession {
         } else {
             Vec::new()
         };
+        let mut emitted_tape = None;
+        if let (Some(recorder), Some(path)) = (self.recorder.as_ref(), self.tape_path.as_ref()) {
+            let header = TapeHeader::current(
+                self.tape_started_at_unix_ms,
+                self.tape_script_path.clone(),
+                self.tape_argv.clone(),
+            );
+            let tape = recorder.snapshot(header);
+            tape.persist(path).map_err(TestbenchError::Tape)?;
+            emitted_tape = Some(EmittedTape {
+                path: path.clone(),
+                records: tape.records.len(),
+            });
+        }
         // The Drop impl undoes mocks regardless of finalize success.
         Ok(TestbenchFinalize {
             fs_diff: diff,
             recorded_subprocesses: recorded,
+            tape: emitted_tape,
         })
     }
 }
@@ -390,18 +490,28 @@ fn restore_env(key: &str, prior: Option<String>) {
 pub struct TestbenchFinalize {
     pub fs_diff: Vec<overlay_fs::DiffEntry>,
     pub recorded_subprocesses: Vec<process_tape::TapeEntry>,
+    pub tape: Option<EmittedTape>,
+}
+
+/// Summary metadata for a unified tape that was emitted at finalize-time.
+#[derive(Debug, Clone)]
+pub struct EmittedTape {
+    pub path: PathBuf,
+    pub records: usize,
 }
 
 /// Errors surfaced when activating or finalizing a testbench session.
 #[derive(Debug)]
 pub enum TestbenchError {
     Subprocess(String),
+    Tape(String),
 }
 
 impl std::fmt::Display for TestbenchError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Subprocess(msg) => write!(f, "testbench subprocess: {msg}"),
+            Self::Tape(msg) => write!(f, "testbench tape: {msg}"),
         }
     }
 }

--- a/crates/harn-vm/src/testbench/overlay_fs.rs
+++ b/crates/harn-vm/src/testbench/overlay_fs.rs
@@ -18,6 +18,8 @@ use std::collections::BTreeMap;
 use std::path::{Component, Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
+use crate::testbench::tape::{self, TapeRecordKind};
+
 /// One change in the overlay's write layer relative to the underlying
 /// tree.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -428,39 +430,103 @@ pub fn active_overlay() -> Option<Arc<OverlayFs>> {
 
 /// Helpers for fs builtins. Each helper falls through to `std::fs` when
 /// no overlay is active, keeping the testbench opt-in.
+///
+/// Every successful read/write/delete also pushes a [`TapeRecordKind`]
+/// into the active unified-tape recorder when one is installed, so the
+/// fidelity oracle can compare FS effects across runs even when the
+/// per-axis overlay diff is identical (the order in which writes land
+/// also matters for replay determinism).
 pub mod helpers {
     use super::*;
 
+    fn record_file_read(path: &Path, bytes: &[u8]) {
+        // Skip the hash + path stringification when no recorder is
+        // installed — the fast path is the production path.
+        if tape::active_recorder().is_none() {
+            return;
+        }
+        let path_str = path.to_string_lossy().into_owned();
+        let len = bytes.len() as u64;
+        let hash = tape::content_hash(bytes);
+        tape::with_active_recorder(|_recorder| {
+            Some(TapeRecordKind::FileRead {
+                path: path_str,
+                content_hash: hash,
+                len_bytes: len,
+            })
+        });
+    }
+
+    fn record_file_write(path: &Path, bytes: &[u8]) {
+        if tape::active_recorder().is_none() {
+            return;
+        }
+        let path_str = path.to_string_lossy().into_owned();
+        let len = bytes.len() as u64;
+        let hash = tape::content_hash(bytes);
+        tape::with_active_recorder(|_recorder| {
+            Some(TapeRecordKind::FileWrite {
+                path: path_str,
+                content_hash: hash,
+                len_bytes: len,
+            })
+        });
+    }
+
+    fn record_file_delete(path: &Path) {
+        if tape::active_recorder().is_none() {
+            return;
+        }
+        let path_str = path.to_string_lossy().into_owned();
+        tape::with_active_recorder(|_recorder| Some(TapeRecordKind::FileDelete { path: path_str }));
+    }
+
     pub fn read(path: &Path) -> std::io::Result<Vec<u8>> {
-        match active_overlay() {
+        let result = match active_overlay() {
             Some(overlay) => overlay.read(path),
             None => std::fs::read(path),
+        };
+        if let Ok(bytes) = result.as_ref() {
+            record_file_read(path, bytes);
         }
+        result
     }
 
     pub fn read_to_string(path: &Path) -> std::io::Result<String> {
-        match active_overlay() {
+        let result = match active_overlay() {
             Some(overlay) => overlay.read_to_string(path),
             None => std::fs::read_to_string(path),
+        };
+        if let Ok(text) = result.as_ref() {
+            record_file_read(path, text.as_bytes());
         }
+        result
     }
 
     pub fn write(path: &Path, contents: &[u8]) -> std::io::Result<()> {
-        match active_overlay() {
+        let result = match active_overlay() {
             Some(overlay) => overlay.write(path, contents),
             None => std::fs::write(path, contents),
+        };
+        if result.is_ok() {
+            record_file_write(path, contents);
         }
+        result
     }
 
     pub fn append(path: &Path, contents: &[u8]) -> std::io::Result<()> {
-        match active_overlay() {
+        let result = match active_overlay() {
             Some(overlay) => overlay.append(path, contents),
             None => std::fs::OpenOptions::new()
                 .create(true)
                 .append(true)
                 .open(path)
                 .and_then(|mut file| std::io::Write::write_all(&mut file, contents)),
+        };
+        if result.is_ok() {
+            record_file_write(path, contents);
         }
+        result
     }
 
     pub fn exists(path: &Path) -> bool {
@@ -471,10 +537,14 @@ pub mod helpers {
     }
 
     pub fn remove_file(path: &Path) -> std::io::Result<()> {
-        match active_overlay() {
+        let result = match active_overlay() {
             Some(overlay) => overlay.remove_file(path),
             None => std::fs::remove_file(path),
+        };
+        if result.is_ok() {
+            record_file_delete(path);
         }
+        result
     }
 
     pub fn create_dir_all(path: &Path) -> std::io::Result<()> {

--- a/crates/harn-vm/src/testbench/process_tape.rs
+++ b/crates/harn-vm/src/testbench/process_tape.rs
@@ -29,6 +29,7 @@ use std::time::Duration;
 use serde::{Deserialize, Serialize};
 
 use crate::clock_mock;
+use crate::testbench::tape::{self, TapeRecordKind};
 
 /// Whether the active tape is recording new entries or replaying an
 /// existing tape.
@@ -223,10 +224,27 @@ pub fn intercept_spawn(
             if entry.duration_ms > 0 {
                 clock_mock::advance(Duration::from_millis(entry.duration_ms));
             }
+            record_unified_spawn(&entry);
             Ok(synthesize_output(&entry))
         }
         Err(err) => Err(err),
     })
+}
+
+fn record_unified_spawn(entry: &TapeEntry) {
+    tape::with_active_recorder(|recorder| {
+        let stdout_payload = recorder.payload_from_bytes(entry.stdout.as_bytes().to_vec());
+        let stderr_payload = recorder.payload_from_bytes(entry.stderr.as_bytes().to_vec());
+        Some(TapeRecordKind::ProcessSpawn {
+            program: entry.program.clone(),
+            args: entry.args.clone(),
+            cwd: entry.cwd.clone(),
+            exit_code: entry.exit_code,
+            duration_ms: entry.duration_ms,
+            stdout_payload,
+            stderr_payload,
+        })
+    });
 }
 
 /// Begin recording a subprocess invocation. Returns `Some(span)` when a
@@ -278,6 +296,7 @@ impl RecordingSpan {
             exit_code: output.status.code().unwrap_or(-1),
             duration_ms: duration.as_millis().min(u64::MAX as u128) as u64,
         };
+        record_unified_spawn(&entry);
         self.tape.record_entry(entry);
     }
 }

--- a/crates/harn-vm/src/testbench/tape.rs
+++ b/crates/harn-vm/src/testbench/tape.rs
@@ -1,0 +1,667 @@
+//! Unified event tape for the testbench.
+//!
+//! A tape is the canonical artifact behind `harn test-bench --emit-tape`.
+//! Every non-deterministic input the script consumed — clock advances,
+//! LLM responses, FS reads/writes, subprocess spawns — lands as a typed
+//! [`TapeRecord`] with a logical sequence number and a virtual-time
+//! stamp. The tape is what the [`fidelity`] oracle compares; it is what
+//! `harn test-bench replay` reads to drive a deterministic re-run.
+//!
+//! [`fidelity`]: super::fidelity
+//!
+//! ## File layout
+//!
+//! ```text
+//! tape.tape       # NDJSON: one header line + one record line per event
+//! tape.cas/       # content-addressed sidecar (BLAKE3 hex names)
+//! ```
+//!
+//! Small payloads are serialized inline. Anything over [`MAX_INLINE_BYTES`]
+//! lands in `tape.cas/<blake3>` and the record carries `{"cas": "<blake3>"}`.
+//! That keeps the main stream diffable when the only thing that changes
+//! is a multi-MB LLM response.
+//!
+//! ## Versioning
+//!
+//! Every tape carries a `version` integer in its header. The current
+//! schema is [`TAPE_FORMAT_VERSION`]. Loaders accept anything `<=` the
+//! current version and emit a structured error for newer tapes; this
+//! gives us room to add record kinds (under `#[serde(other)]`) without
+//! silently breaking older runners.
+//!
+//! ## Recording
+//!
+//! Recording is opt-in: the testbench installs a thread-local
+//! [`TapeRecorder`] when `Testbench::tape = TapeConfig::Emit { path }`.
+//! Every host-capability axis that already has a record path
+//! ([`super::process_tape`], [`super::overlay_fs`], [`crate::llm::mock`],
+//! [`crate::clock_mock`]) calls into this module to push a record. When
+//! no recorder is installed, the helpers are no-ops — production code
+//! pays nothing.
+
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+use serde::{Deserialize, Serialize};
+
+use crate::clock_mock;
+
+/// Format version of the on-disk tape representation. Bump on any
+/// breaking change. Loaders refuse tapes with a higher version.
+pub const TAPE_FORMAT_VERSION: u32 = 1;
+
+/// Records whose serialized payload exceeds this size are spilled into
+/// the content-addressed sidecar. Picked to be larger than typical
+/// stdout/file-read sizes but smaller than full LLM responses, so the
+/// main NDJSON stream stays diffable.
+pub const MAX_INLINE_BYTES: usize = 4 * 1024;
+
+/// Header line written first in every tape file. Captures the metadata a
+/// fidelity-checker needs to interpret the records that follow.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TapeHeader {
+    pub version: u32,
+    /// Crate version of the producer (`harn-vm` `CARGO_PKG_VERSION`).
+    /// Surfaced so a fidelity report can attribute divergences across
+    /// runtime upgrades.
+    pub harn_version: String,
+    /// UNIX-epoch milliseconds the script was launched at — i.e. the
+    /// initial value of the testbench's paused clock. `null` when the
+    /// run used the real clock.
+    #[serde(default)]
+    pub started_at_unix_ms: Option<i64>,
+    /// Path passed to `harn test-bench run`. Informational only; replays
+    /// resolve scripts via the CLI argument, not this field.
+    #[serde(default)]
+    pub script_path: Option<String>,
+    /// Positional arguments forwarded to the script (post `--`). Captured
+    /// so two re-runs that differ only in argv are distinguishable.
+    #[serde(default)]
+    pub argv: Vec<String>,
+}
+
+impl TapeHeader {
+    pub fn current(
+        started_at_unix_ms: Option<i64>,
+        script_path: Option<String>,
+        argv: Vec<String>,
+    ) -> Self {
+        Self {
+            version: TAPE_FORMAT_VERSION,
+            harn_version: env!("CARGO_PKG_VERSION").to_string(),
+            started_at_unix_ms,
+            script_path,
+            argv,
+        }
+    }
+}
+
+/// One on-disk line of the tape. Wrapping the header and record kinds
+/// behind a single tagged enum lets us write the whole file as
+/// homogeneous NDJSON.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum TapeLine {
+    Header(TapeHeader),
+    Record(TapeRecord),
+}
+
+/// One captured non-deterministic event. The variant carries the record
+/// payload; the wrapping [`TapeRecord`] adds the metadata every variant
+/// shares.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TapeRecord {
+    /// Monotonic logical sequence number assigned at record time.
+    pub seq: u64,
+    /// Wall-clock value (UNIX-epoch ms) observed at record time. Reads
+    /// from the unified mock clock when one is installed.
+    pub virtual_time_ms: i64,
+    /// Monotonic ms since the testbench was activated. Independent of
+    /// `virtual_time_ms` so a paused clock that never advances still
+    /// produces an ordered stream.
+    pub monotonic_ms: i64,
+    /// The actual event.
+    pub kind: TapeRecordKind,
+}
+
+/// Discriminated union of every record kind the v1 tape captures. New
+/// kinds can be added without breaking older readers (`serde(other)`
+/// support is intentional — unknown variants surface as
+/// [`TapeRecordKind::Unknown`] so a fidelity check still runs).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum TapeRecordKind {
+    /// Script read the wall-clock or monotonic clock. The captured value
+    /// is what the script actually saw, so a re-run that drifts (e.g.
+    /// because the operator forgot `--clock paused`) produces a
+    /// different content hash and the fidelity oracle flags it.
+    ClockRead { source: ClockSource, value_ms: i64 },
+    /// Script slept (or otherwise advanced the unified mock clock) by
+    /// `duration_ms`. The recorded virtual time is post-advance.
+    ClockSleep { duration_ms: u64 },
+    /// LLM call. `request_digest` is a deterministic hash of the call's
+    /// matchable surface (messages + system + tools + tool_choice +
+    /// thinking). `response` is the recorded mock — inline JSON for
+    /// small payloads, a CAS reference for large ones.
+    LlmCall {
+        request_digest: String,
+        response: TapePayload,
+    },
+    /// Filesystem read against the testbench overlay. The content hash
+    /// lets fidelity checks reason about read consistency without
+    /// inlining every byte.
+    FileRead {
+        path: String,
+        content_hash: String,
+        len_bytes: u64,
+    },
+    /// Filesystem write into the testbench overlay.
+    FileWrite {
+        path: String,
+        content_hash: String,
+        len_bytes: u64,
+    },
+    /// Filesystem delete in the overlay layer.
+    FileDelete { path: String },
+    /// Subprocess spawn captured by [`super::process_tape`]. Stdout and
+    /// stderr are stored under `stdout_payload`/`stderr_payload` so the
+    /// large blobs land in CAS rather than the NDJSON line.
+    ProcessSpawn {
+        program: String,
+        args: Vec<String>,
+        cwd: Option<String>,
+        exit_code: i32,
+        duration_ms: u64,
+        stdout_payload: TapePayload,
+        stderr_payload: TapePayload,
+    },
+    /// Catch-all for record kinds emitted by a newer producer. Lets
+    /// older fidelity checkers compare what they understand and flag
+    /// the rest as `Unknown` divergence rather than refusing to load.
+    #[serde(other)]
+    Unknown,
+}
+
+/// Which face of the unified clock the script read. Captured so a
+/// fidelity report can attribute drift back to the right axis.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ClockSource {
+    Wall,
+    Monotonic,
+}
+
+/// On-disk representation of a record payload. Inline for small values,
+/// CAS-by-hash for anything over [`MAX_INLINE_BYTES`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum TapePayload {
+    /// Inline UTF-8 text payload. Carries a content hash so a fidelity
+    /// check can compare without re-hashing.
+    Inline { content_hash: String, text: String },
+    /// CAS-stored payload. The bytes live at `<tape>.cas/<content_hash>`.
+    Cas {
+        content_hash: String,
+        len_bytes: u64,
+    },
+}
+
+impl TapePayload {
+    pub fn content_hash(&self) -> &str {
+        match self {
+            Self::Inline { content_hash, .. } | Self::Cas { content_hash, .. } => content_hash,
+        }
+    }
+
+    pub fn len_bytes(&self) -> u64 {
+        match self {
+            Self::Inline { text, .. } => text.len() as u64,
+            Self::Cas { len_bytes, .. } => *len_bytes,
+        }
+    }
+}
+
+/// Compute a stable BLAKE3 hex digest for a byte slice. Centralized so
+/// every record path keys CAS lookups identically.
+pub fn content_hash(bytes: &[u8]) -> String {
+    blake3::hash(bytes).to_hex().to_string()
+}
+
+/// Build a [`TapePayload`] from raw bytes, spilling to the sidecar map
+/// when the body is large enough to clutter the NDJSON.
+fn build_payload(bytes: Vec<u8>, cas: &mut BTreeMap<String, Vec<u8>>) -> TapePayload {
+    let hash = content_hash(&bytes);
+    if bytes.len() > MAX_INLINE_BYTES {
+        let len_bytes = bytes.len() as u64;
+        cas.entry(hash.clone()).or_insert(bytes);
+        TapePayload::Cas {
+            content_hash: hash,
+            len_bytes,
+        }
+    } else {
+        let text = match String::from_utf8(bytes) {
+            Ok(text) => text,
+            Err(error) => {
+                // Non-utf8 bytes still need to round-trip. Stash the raw
+                // bytes in CAS and inline a sentinel so a fidelity diff
+                // is still meaningful.
+                let bytes = error.into_bytes();
+                let len_bytes = bytes.len() as u64;
+                cas.entry(hash.clone()).or_insert(bytes);
+                return TapePayload::Cas {
+                    content_hash: hash,
+                    len_bytes,
+                };
+            }
+        };
+        TapePayload::Inline {
+            content_hash: hash,
+            text,
+        }
+    }
+}
+
+/// In-memory tape: header + ordered record list + sidecar bytes pending
+/// flush to disk. Built by [`TapeRecorder`] during a record run; loaded
+/// by [`EventTape::load`] for replay or fidelity comparison.
+#[derive(Debug, Clone)]
+pub struct EventTape {
+    pub header: TapeHeader,
+    pub records: Vec<TapeRecord>,
+    /// Content-addressed bodies. Populated either by the recorder (in
+    /// memory until [`EventTape::persist`]) or by [`EventTape::load`]
+    /// (read back from `<tape>.cas/`).
+    cas: BTreeMap<String, Vec<u8>>,
+}
+
+impl EventTape {
+    pub fn new(header: TapeHeader) -> Self {
+        Self {
+            header,
+            records: Vec::new(),
+            cas: BTreeMap::new(),
+        }
+    }
+
+    /// Resolve a payload to its full bytes. Inline payloads return their
+    /// text; CAS payloads look up the sidecar.
+    pub fn resolve_payload(&self, payload: &TapePayload) -> Result<Vec<u8>, String> {
+        match payload {
+            TapePayload::Inline { text, .. } => Ok(text.as_bytes().to_vec()),
+            TapePayload::Cas { content_hash, .. } => self
+                .cas
+                .get(content_hash)
+                .cloned()
+                .ok_or_else(|| format!("tape CAS missing entry for {content_hash}")),
+        }
+    }
+
+    /// Total CAS payload count. Useful for diagnostics and tests.
+    pub fn cas_len(&self) -> usize {
+        self.cas.len()
+    }
+
+    /// Persist the tape (NDJSON + sidecar) to `path`. The sidecar lives
+    /// at `<path>.cas/`; the parent directory is created if needed.
+    pub fn persist(&self, path: &Path) -> Result<(), String> {
+        if let Some(parent) = path.parent() {
+            if !parent.as_os_str().is_empty() {
+                std::fs::create_dir_all(parent)
+                    .map_err(|err| format!("mkdir {}: {err}", parent.display()))?;
+            }
+        }
+
+        let mut body = String::new();
+        let header_line = serde_json::to_string(&TapeLine::Header(self.header.clone()))
+            .map_err(|err| format!("serialize tape header: {err}"))?;
+        body.push_str(&header_line);
+        body.push('\n');
+        for record in &self.records {
+            let line = serde_json::to_string(&TapeLine::Record(record.clone()))
+                .map_err(|err| format!("serialize tape record: {err}"))?;
+            body.push_str(&line);
+            body.push('\n');
+        }
+        std::fs::write(path, body).map_err(|err| format!("write {}: {err}", path.display()))?;
+
+        if !self.cas.is_empty() {
+            let cas_dir = cas_dir_for(path);
+            std::fs::create_dir_all(&cas_dir)
+                .map_err(|err| format!("mkdir {}: {err}", cas_dir.display()))?;
+            for (hash, bytes) in &self.cas {
+                let entry = cas_dir.join(hash);
+                std::fs::write(&entry, bytes)
+                    .map_err(|err| format!("write {}: {err}", entry.display()))?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Load a tape from `path`. Reads the NDJSON body and lazily fetches
+    /// any referenced CAS entries from `<path>.cas/`.
+    pub fn load(path: &Path) -> Result<Self, String> {
+        let body = std::fs::read_to_string(path)
+            .map_err(|err| format!("read {}: {err}", path.display()))?;
+        let mut lines = body.lines();
+        let first_line = lines
+            .next()
+            .ok_or_else(|| format!("empty tape file: {}", path.display()))?;
+        let header_line: TapeLine = serde_json::from_str(first_line)
+            .map_err(|err| format!("parse tape header in {}: {err}", path.display()))?;
+        let header = match header_line {
+            TapeLine::Header(header) => header,
+            TapeLine::Record(_) => {
+                return Err(format!(
+                    "tape {} is missing its header (first line is a record)",
+                    path.display()
+                ))
+            }
+        };
+        if header.version > TAPE_FORMAT_VERSION {
+            return Err(format!(
+                "tape {} declares version {} but this runtime supports up to {TAPE_FORMAT_VERSION}",
+                path.display(),
+                header.version
+            ));
+        }
+        let mut records = Vec::new();
+        for (idx, line) in lines.enumerate() {
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let parsed: TapeLine = serde_json::from_str(trimmed).map_err(|err| {
+                format!(
+                    "parse tape record at line {} in {}: {err}",
+                    idx + 2,
+                    path.display()
+                )
+            })?;
+            match parsed {
+                TapeLine::Record(record) => records.push(record),
+                TapeLine::Header(_) => {
+                    return Err(format!(
+                        "tape {} contains a second header at line {}",
+                        path.display(),
+                        idx + 2
+                    ))
+                }
+            }
+        }
+
+        let mut cas = BTreeMap::new();
+        let cas_dir = cas_dir_for(path);
+        if cas_dir.is_dir() {
+            for record in &records {
+                visit_payloads(&record.kind, |payload| {
+                    if let TapePayload::Cas { content_hash, .. } = payload {
+                        if cas.contains_key(content_hash) {
+                            return;
+                        }
+                        let entry = cas_dir.join(content_hash);
+                        if let Ok(bytes) = std::fs::read(&entry) {
+                            cas.insert(content_hash.clone(), bytes);
+                        }
+                    }
+                });
+            }
+        }
+        Ok(Self {
+            header,
+            records,
+            cas,
+        })
+    }
+}
+
+fn cas_dir_for(tape_path: &Path) -> PathBuf {
+    let mut buf = tape_path.as_os_str().to_owned();
+    buf.push(".cas");
+    PathBuf::from(buf)
+}
+
+fn visit_payloads(kind: &TapeRecordKind, mut visit: impl FnMut(&TapePayload)) {
+    match kind {
+        TapeRecordKind::LlmCall { response, .. } => visit(response),
+        TapeRecordKind::ProcessSpawn {
+            stdout_payload,
+            stderr_payload,
+            ..
+        } => {
+            visit(stdout_payload);
+            visit(stderr_payload);
+        }
+        TapeRecordKind::ClockRead { .. }
+        | TapeRecordKind::ClockSleep { .. }
+        | TapeRecordKind::FileRead { .. }
+        | TapeRecordKind::FileWrite { .. }
+        | TapeRecordKind::FileDelete { .. }
+        | TapeRecordKind::Unknown => {}
+    }
+}
+
+/// Recorder consulted by every host-capability axis. When installed as
+/// the [`active_recorder`], each axis's record path also pushes a
+/// [`TapeRecord`] here so the unified tape stays in sync without
+/// re-routing every capability through this module.
+#[derive(Debug)]
+pub struct TapeRecorder {
+    next_seq: AtomicU64,
+    started_at: clock_mock::ClockInstant,
+    inner: Mutex<RecorderInner>,
+}
+
+#[derive(Debug, Default)]
+struct RecorderInner {
+    records: Vec<TapeRecord>,
+    cas: BTreeMap<String, Vec<u8>>,
+}
+
+impl Default for TapeRecorder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TapeRecorder {
+    pub fn new() -> Self {
+        Self {
+            next_seq: AtomicU64::new(0),
+            started_at: clock_mock::instant_now(),
+            inner: Mutex::new(RecorderInner::default()),
+        }
+    }
+
+    /// Append a record built from `kind`. The recorder stamps the seq
+    /// number and timing metadata; callers only worry about the payload.
+    pub fn record(&self, kind: TapeRecordKind) {
+        let seq = self.next_seq.fetch_add(1, Ordering::SeqCst);
+        let virtual_time_ms = clock_mock::now_ms();
+        let monotonic_ms = clock_mock::instant_now()
+            .duration_since(self.started_at)
+            .as_millis()
+            .min(i64::MAX as u128) as i64;
+        let record = TapeRecord {
+            seq,
+            virtual_time_ms,
+            monotonic_ms,
+            kind,
+        };
+        self.inner
+            .lock()
+            .expect("tape recorder mutex poisoned")
+            .records
+            .push(record);
+    }
+
+    /// Convenience wrapper: build a [`TapePayload`] from `bytes` (spilling
+    /// to CAS as needed) and register the bytes for persistence. Used by
+    /// axes that have raw bodies on hand (subprocess stdout, LLM
+    /// response JSON, file content).
+    pub fn payload_from_bytes(&self, bytes: Vec<u8>) -> TapePayload {
+        let mut inner = self.inner.lock().expect("tape recorder mutex poisoned");
+        build_payload(bytes, &mut inner.cas)
+    }
+
+    /// Snapshot the tape into a self-contained [`EventTape`]. Consumes
+    /// the recorder's CAS by `clone()` so a recorder can be sampled
+    /// mid-run for diagnostics — production callers usually move into
+    /// `into_tape` instead.
+    pub fn snapshot(&self, header: TapeHeader) -> EventTape {
+        let inner = self.inner.lock().expect("tape recorder mutex poisoned");
+        EventTape {
+            header,
+            records: inner.records.clone(),
+            cas: inner.cas.clone(),
+        }
+    }
+}
+
+thread_local! {
+    static ACTIVE_RECORDER: RefCell<Option<Arc<TapeRecorder>>> = const { RefCell::new(None) };
+}
+
+/// RAII guard returned by [`install_recorder`]. Restores the previous
+/// recorder (if any) on drop so nested testbench sessions stay sane.
+pub struct TapeRecorderGuard {
+    previous: Option<Arc<TapeRecorder>>,
+}
+
+impl Drop for TapeRecorderGuard {
+    fn drop(&mut self) {
+        let prev = self.previous.take();
+        ACTIVE_RECORDER.with(|slot| {
+            *slot.borrow_mut() = prev;
+        });
+    }
+}
+
+pub fn install_recorder(recorder: Arc<TapeRecorder>) -> TapeRecorderGuard {
+    let previous = ACTIVE_RECORDER.with(|slot| slot.replace(Some(recorder)));
+    TapeRecorderGuard { previous }
+}
+
+/// Currently installed recorder, if any. Production callers stay
+/// untouched because nothing installs a recorder outside testbench mode.
+pub fn active_recorder() -> Option<Arc<TapeRecorder>> {
+    ACTIVE_RECORDER.with(|slot| slot.borrow().clone())
+}
+
+/// Push a record if a recorder is active. The closure is only evaluated
+/// when recording is on, so the per-axis hooks pay nothing in production.
+pub fn with_active_recorder<F>(build: F)
+where
+    F: FnOnce(&Arc<TapeRecorder>) -> Option<TapeRecordKind>,
+{
+    let Some(recorder) = active_recorder() else {
+        return;
+    };
+    if let Some(kind) = build(&recorder) {
+        recorder.record(kind);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn small_record(seq: u64, dur: u64) -> TapeRecord {
+        TapeRecord {
+            seq,
+            virtual_time_ms: seq as i64 * 1000,
+            monotonic_ms: seq as i64 * 1000,
+            kind: TapeRecordKind::ClockSleep { duration_ms: dur },
+        }
+    }
+
+    #[test]
+    fn round_trip_inline_records() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("run.tape");
+        let mut tape = EventTape::new(TapeHeader::current(
+            Some(1_700_000_000_000),
+            Some("script.harn".to_string()),
+            vec!["a".into()],
+        ));
+        tape.records.push(small_record(0, 250));
+        tape.records.push(small_record(1, 750));
+        tape.persist(&path).unwrap();
+
+        let loaded = EventTape::load(&path).unwrap();
+        assert_eq!(loaded.header.version, TAPE_FORMAT_VERSION);
+        assert_eq!(loaded.header.argv, vec!["a".to_string()]);
+        assert_eq!(loaded.records.len(), 2);
+        match &loaded.records[0].kind {
+            TapeRecordKind::ClockSleep { duration_ms } => assert_eq!(*duration_ms, 250),
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn large_payloads_spill_to_cas_and_round_trip() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("run.tape");
+        let mut tape = EventTape::new(TapeHeader::current(None, None, Vec::new()));
+        let big = vec![b'x'; MAX_INLINE_BYTES + 32];
+        let payload = build_payload(big.clone(), &mut tape.cas);
+        let hash = payload.content_hash().to_string();
+        let kind = TapeRecordKind::ProcessSpawn {
+            program: "/bin/echo".to_string(),
+            args: vec!["x".to_string()],
+            cwd: None,
+            exit_code: 0,
+            duration_ms: 1,
+            stdout_payload: payload,
+            stderr_payload: build_payload(Vec::new(), &mut tape.cas),
+        };
+        tape.records.push(TapeRecord {
+            seq: 0,
+            virtual_time_ms: 0,
+            monotonic_ms: 0,
+            kind,
+        });
+        tape.persist(&path).unwrap();
+
+        // CAS sidecar exists.
+        assert!(path.with_extension("tape.cas").exists() || cas_dir_for(&path).exists());
+        let cas_dir = cas_dir_for(&path);
+        assert!(cas_dir.join(&hash).exists());
+
+        let loaded = EventTape::load(&path).unwrap();
+        let resolved = match &loaded.records[0].kind {
+            TapeRecordKind::ProcessSpawn { stdout_payload, .. } => {
+                loaded.resolve_payload(stdout_payload).unwrap()
+            }
+            other => panic!("unexpected: {other:?}"),
+        };
+        assert_eq!(resolved.len(), big.len());
+    }
+
+    #[test]
+    fn rejects_newer_version() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("future.tape");
+        std::fs::write(
+            &path,
+            r#"{"type":"header","version":99,"harn_version":"x","started_at_unix_ms":null,"script_path":null,"argv":[]}
+"#,
+        )
+        .unwrap();
+        let err = EventTape::load(&path).unwrap_err();
+        assert!(err.contains("version 99"), "{err}");
+    }
+
+    #[test]
+    fn recorder_assigns_monotonic_seq() {
+        let recorder = Arc::new(TapeRecorder::new());
+        recorder.record(TapeRecordKind::ClockSleep { duration_ms: 1 });
+        recorder.record(TapeRecordKind::ClockSleep { duration_ms: 2 });
+        let snapshot = recorder.snapshot(TapeHeader::current(None, None, Vec::new()));
+        assert_eq!(snapshot.records[0].seq, 0);
+        assert_eq!(snapshot.records[1].seq, 1);
+    }
+}

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -137,6 +137,7 @@
 - [Windows test coverage](./dev/windows-test-coverage.md)
 - [Deterministic test patterns](./dev/testing.md)
 - [Testbench mode](./dev/testbench.md)
+- [Tape format](./dev/tape-format.md)
 - [VM and stdlib perf notes](./dev/vm-stdlib-perf-notes.md)
 
 # Tutorials and Guides

--- a/docs/src/dev/tape-format.md
+++ b/docs/src/dev/tape-format.md
@@ -1,0 +1,198 @@
+# Event tape format
+
+The event tape is the canonical artifact behind `harn test-bench
+--emit-tape`. Every non-deterministic input a script consumed during a
+run — clock reads, sleeps, LLM responses, FS reads/writes, subprocess
+spawns — lands as a typed [`TapeRecord`][record] with a logical
+sequence number and a virtual-time stamp. Tapes are diffable, content
+addressed, and versioned so they survive runtime upgrades.
+
+[record]: https://docs.rs/harn-vm/latest/harn_vm/testbench/tape/struct.TapeRecord.html
+
+This document is the source of truth for the on-disk schema. Bumping
+[`TAPE_FORMAT_VERSION`][version] requires an entry here.
+
+[version]: https://docs.rs/harn-vm/latest/harn_vm/testbench/tape/constant.TAPE_FORMAT_VERSION.html
+
+## File layout
+
+```text
+run.tape           # NDJSON: one header line + one record line per event
+run.tape.cas/      # content-addressed sidecar (BLAKE3 hex names)
+```
+
+`run.tape` is line-delimited JSON. Each line is one of two shapes:
+
+- **Header** (always the first line):
+
+  ```json
+  {
+    "type": "header",
+    "version": 1,
+    "harn_version": "0.8.4",
+    "started_at_unix_ms": 1700000000000,
+    "script_path": "examples/cron-rollup.harn",
+    "argv": ["--mode=daily"]
+  }
+  ```
+
+- **Record** (zero or more, after the header):
+
+  ```json
+  {
+    "type": "record",
+    "seq": 0,
+    "virtual_time_ms": 1700000000000,
+    "monotonic_ms": 0,
+    "kind": "clock_sleep",
+    "duration_ms": 250
+  }
+  ```
+
+`run.tape.cas/` holds payload bytes that are too large to inline (see
+[CAS thresholds](#content-addressed-storage)). The directory is
+optional — tapes that never spilled a payload have no sidecar.
+
+## Record kinds
+
+The current schema (`version = 1`) emits the kinds below. Unknown
+record kinds in newer tapes deserialize as `unknown` so older
+fidelity checkers still produce a structured report.
+
+| Kind | Payload fields | Source |
+|---|---|---|
+| `clock_read` | `source` (`"wall"` or `"monotonic"`), `value_ms` | `now_ms()` / `monotonic_ms()` builtins |
+| `clock_sleep` | `duration_ms` | `sleep(...)` / `advance_time(...)` |
+| `llm_call` | `request_digest`, `response` (inline or CAS) | LLM provider interception |
+| `file_read` | `path`, `content_hash`, `len_bytes` | `read_file(...)` builtins |
+| `file_write` | `path`, `content_hash`, `len_bytes` | `write_file(...)`, `append_file(...)` |
+| `file_delete` | `path` | `remove_file(...)` |
+| `process_spawn` | `program`, `args`, `cwd`, `exit_code`, `duration_ms`, `stdout_payload`, `stderr_payload` | Sandboxed subprocess invocation |
+
+Every record carries the wrapping fields:
+
+- `seq` — monotonic logical sequence number (assigned at record time).
+- `virtual_time_ms` — UNIX-epoch ms observed via the unified mock clock.
+- `monotonic_ms` — ms since the testbench session activated.
+
+Two tapes that differ only in real-time stamps (e.g. CI machines with
+different NTP skew) diff cleanly on the logical structure.
+
+## Content-addressed storage
+
+Records whose serialized payload exceeds **4 KiB** (the
+[`MAX_INLINE_BYTES`][threshold] threshold) spill to the sidecar. The
+inline JSON carries:
+
+```json
+{ "content_hash": "<blake3-hex>", "len_bytes": 12345 }
+```
+
+…and the bytes themselves live at `run.tape.cas/<blake3-hex>`. Reusing
+the same payload across records — e.g. an idempotent LLM response
+served to two callers — stores it once.
+
+Smaller payloads stay inline:
+
+```json
+{ "content_hash": "<blake3-hex>", "text": "...stdout..." }
+```
+
+`content_hash` is a hex BLAKE3 digest of the raw bytes. The fidelity
+oracle compares hashes only; it never re-hashes payloads at compare
+time.
+
+[threshold]: https://docs.rs/harn-vm/latest/harn_vm/testbench/tape/constant.MAX_INLINE_BYTES.html
+
+## Versioning contract
+
+The header's `version` integer gates compatibility:
+
+- Loaders accept tapes with `version <= TAPE_FORMAT_VERSION` and refuse
+  newer tapes with a structured error so a downgrade doesn't silently
+  drop records.
+- Adding a record kind is non-breaking: older fidelity checkers see
+  the unknown kind as `TapeRecordKind::Unknown` and emit a divergence
+  with category `unknown_kind`.
+- Renaming or repurposing an existing field is breaking and requires a
+  version bump.
+
+When you bump the version, add a "Changes from v\<previous\>" section
+below.
+
+## Fidelity oracle
+
+`harn test-bench fidelity` compares two tapes under one of three modes:
+
+- **`byte-identical`** (default, strictest). Every record matches by
+  position, kind, content hash, and timing. The mode CI uses to gate
+  "this PR did not regress replay determinism."
+- **`semantic`**. Ignores diffs that are non-meaningful by construction:
+  monotonic-only sequence stamps, pure virtual-time drift, and recorded
+  `monotonic_ms` deltas. Content hashes still gate every payload.
+- **`outcome`** (loosest). Compares only the script's externally
+  observable result: the final FS write set, the exit status of the
+  last subprocess, and the count of LLM calls. Useful for stochastic
+  LLM runs where intermediate token streams legitimately diverge.
+
+The CLI emits a structured JSON report (a [`FidelityReport`][report])
+listing every diverging record with a stable category tag. CI pipelines
+gate on `divergences == []`; the public leaderboard ([harn-cloud#19])
+ingests the score directly.
+
+[report]: https://docs.rs/harn-vm/latest/harn_vm/testbench/fidelity/struct.FidelityReport.html
+[harn-cloud#19]: https://github.com/burin-labs/harn-cloud/issues/19
+
+### Example
+
+Diff two recorded tapes:
+
+```sh
+harn test-bench fidelity recorded.tape replay.tape --mode byte-identical
+```
+
+Re-run a script under testbench replay and compare against the
+recorded tape:
+
+```sh
+harn test-bench fidelity script.harn --against recorded.tape \
+    --mode semantic --report fidelity.json
+```
+
+Both forms exit non-zero (status `2`) when the report has any
+divergences. CI gates can therefore rely on the exit code without
+parsing JSON.
+
+## Producing a tape
+
+```sh
+harn test-bench run script.harn \
+    --clock paused --start-at 1767225600000 \
+    --emit-tape run.tape
+```
+
+The tape is a byproduct of a normal testbench run; the script executes
+unmodified, and the recorder pushes a record at every host-capability
+boundary it crosses. When the run finishes, the tape (and its CAS
+sidecar) lands at the requested path.
+
+## Out of scope (v1)
+
+The first version intentionally ships a small but principled set of
+record kinds. The following are tracked separately:
+
+- HTTP request/response capture (independent of LLM calls). The
+  necessary capture point is the egress allowlist hook, but plumbing
+  through every connector is its own ticket.
+- Tape compaction / GC. The current encoding stores every record;
+  pruning can come once tapes get large in practice.
+- Cross-runtime tape exchange (Inngest/Temporal interop). Lives in the
+  harn-cloud#19 harness, not this crate.
+
+## See also
+
+- [Testbench mode](testbench.md) — the composition primitive that
+  installs the tape recorder.
+- [Testing](testing.md) — approved deterministic test patterns.
+- [Issue #1441](https://github.com/burin-labs/harn/issues/1441) —
+  design rationale for the unified tape and fidelity oracle.

--- a/docs/src/dev/testbench.md
+++ b/docs/src/dev/testbench.md
@@ -172,8 +172,12 @@ development calls for it.
 
 See also:
 
+- `docs/src/dev/tape-format.md` for the unified event tape schema and
+  the fidelity oracle that compares two tapes.
 - `docs/src/dev/testing.md` for approved test-pattern guidance.
 - `crates/harn-vm/src/testbench/` for the Rust source of every
   composable axis.
 - Issue [#1440](https://github.com/burin-labs/harn/issues/1440) for the
   composition primitive's design rationale.
+- Issue [#1441](https://github.com/burin-labs/harn/issues/1441) for the
+  recording/replay tape format and fidelity oracle.


### PR DESCRIPTION
## Summary

Closes [#1441](https://github.com/burin-labs/harn/issues/1441) — composes the existing per-axis testbench primitives (clock, LLM, FS overlay, process tape) behind a single opt-in unified-tape recorder, plus a structured fidelity oracle for comparing two recorded runs.

- New `harn test-bench run --emit-tape PATH` captures every non-deterministic input the script consumed (clock reads/sleeps, LLM calls, FS reads/writes/deletes, subprocess spawns) into one NDJSON stream with a content-addressed `.cas/` sidecar.
- New `harn test-bench fidelity` subcommand: diff two on-disk tapes (`fidelity TAPE-A TAPE-B`) or re-run a script under replay against a recorded tape (`fidelity SCRIPT --against TAPE`). Three modes — `byte-identical`, `semantic`, `outcome` — produce a structured `FidelityReport` listing every diverging record with a stable category tag.
- Format is versioned (`TAPE_FORMAT_VERSION = 1`), loaders refuse newer tapes with a structured error, and unknown record kinds deserialize as `Unknown` so older fidelity checkers still emit a divergence rather than failing to load.

## Acceptance criteria (from #1441)

- ✅ A run captured with `--emit-tape` re-runs deterministically with byte-identical fidelity — covered by [`unified_tape_byte_identical_round_trip`](crates/harn-cli/tests/test_bench_cli.rs).
- ✅ `harn test-bench fidelity TAPE-A TAPE-B` emits a structured JSON report listing every diverging record; exits status 2 on any divergence so CI can gate without parsing JSON.
- ✅ Tape format documented in [`docs/src/dev/tape-format.md`](docs/src/dev/tape-format.md) with a stable versioning story.
- ✅ Replay-fidelity metric (byte-for-byte vs. semantic) computable from a Harn-recorded tape — feeds [harn-cloud#19](https://github.com/burin-labs/harn-cloud/issues/19).
- ✅ Divergence test: deliberately introducing a wall-clock drift between two runs is captured as `ClockRead` records and flagged by the oracle as a `clock_read_value` divergence — covered by [`unified_tape_flags_unpinned_clock_divergence`](crates/harn-cli/tests/test_bench_cli.rs).

## Architecture

The recorder is a thread-local sink (`tape::TapeRecorder`) that the existing per-axis record paths push events into when active. No production overhead — every hook short-circuits with a single thread-local check when no recorder is installed. Payloads over 4 KiB spill to `<tape>.cas/<blake3>` so the main NDJSON stream stays diffable; reusing the same payload across records (e.g. an idempotent LLM response) stores it once.

## Out of scope (v1, deferred per #1441)

- HTTP request/response capture independent of LLM calls.
- Tape compaction / GC.
- Cross-runtime tape exchange (Inngest/Temporal interop) — lives in the harn-cloud#19 harness.

## Test plan

- [x] `make all` — clippy, tests (3562/3562), conformance, protocol conformance, replay oracle, all docs/spec/lint gates green.
- [x] New unit tests in `crates/harn-vm/src/testbench/{tape,fidelity}.rs` cover content-addressing thresholds, version refusal, comparison-mode semantics, and outcome-mode facets.
- [x] New integration tests in `crates/harn-cli/tests/test_bench_cli.rs` exercise the byte-identical round-trip and the wall-clock-divergence acceptance test end-to-end through `execute_run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)