### PR TITLE
Make review_captain persona actually review PRs

### DIFF
--- a/personas/review_captain/README.md
+++ b/personas/review_captain/README.md
@@ -1,14 +1,69 @@
 # Review Captain Persona
 
-This is the canonical Harn package for `review_captain`. Hosts such as
-Burin Code should discover it through `harn persona list --json` and
-`harn persona inspect review_captain --json`, then treat the resulting
-manifest as Harn-owned metadata.
+Canonical Harn package for `review_captain`. Hosts (Burin Code,
+harn-cloud, the CLI) discover it through `harn persona list --json` and
+treat the resulting manifest as Harn-owned metadata.
 
-## Local Checks
+The persona reviews one PR per invocation. It runs deterministic
+secret-scanning and risky-path classification first, then optionally
+calls `self_review` for one or more LLM rounds, and emits a single JSON
+`review_receipt` envelope. The schema is versioned (`schema_version`)
+and additive — embedders pin to the persona version they ship with.
+
+## Pipeline input
+
+The pipeline reads its input from stdin as a JSON object. When stdin is
+empty the runtime input is consulted; when both are absent the bundled
+fixture is used so smoke runs stay deterministic.
+
+```json
+{
+  "repo": "burin-labs/burin-code",
+  "pr_number": 235,
+  "head_sha": "...",
+  "base_sha": "...",
+  "diff": "...",
+  "changed_files": ["..."],
+  "max_rounds": 1,
+  "dry_run": true,
+  "rubric_preset": "code",
+  "policy_path": "personas/review_captain/policies/burin-code.json"
+}
+```
+
+`dry_run = true` skips the LLM hop. The deterministic stages still
+emit findings, so `secret_scan` hits and risky-path matches still
+surface.
+
+## Local checks
 
 ```bash
-cargo run --quiet --bin harn -- persona --manifest personas/review_captain/harn.toml inspect review_captain --json
-cargo run --quiet --bin harn -- run personas/review_captain/manifest.harn
-cargo run --quiet --bin harn -- eval personas/review_captain/evals/review_captain_smoke.json
+harn persona --manifest personas/review_captain/harn.toml inspect review_captain --json
+harn run personas/review_captain/manifest.harn < personas/review_captain/fixtures/pull_request.json
+harn test personas/review_captain/tests/
+harn persona --manifest personas/review_captain/harn.toml doctor review_captain
+```
+
+## Output schema
+
+```json
+{
+  "persona": "review_captain",
+  "kind": "review_receipt",
+  "schema_version": 1,
+  "repo": "...",
+  "pr_number": 0,
+  "head_sha": "...",
+  "base_sha": "...",
+  "verdict": "approve" | "needs_follow_up" | "blocking",
+  "blocking": false,
+  "summary": "...",
+  "findings": [{ "id": "...", "severity": "blocking|warning|info", ... }],
+  "secret_scan_findings": [...],
+  "risky_paths": ["..."],
+  "missing_tests": ["..."],
+  "rounds": 0,
+  "self_review_skipped_reason": null,
+  "handoff": "merge_captain" | null
+}
 ```

--- a/personas/review_captain/fixtures/pull_request.json
+++ b/personas/review_captain/fixtures/pull_request.json
@@ -1,0 +1,14 @@
+{
+  "repo": "burin-labs/burin-code",
+  "pr_number": 235,
+  "head_sha": "0123456789abcdef",
+  "base_sha": "fedcba9876543210",
+  "diff": "diff --git a/Sources/BurinCore/Personas/ReviewCaptainHost.swift b/Sources/BurinCore/Personas/ReviewCaptainHost.swift\nnew file mode 100644\n--- /dev/null\n+++ b/Sources/BurinCore/Personas/ReviewCaptainHost.swift\n@@\n+import Foundation\n+\n+public struct ReviewCaptainRequest: Codable {\n+    public let repo: String\n+    public let prNumber: Int\n+    public let diff: String\n+}\n",
+  "changed_files": [
+    "Sources/BurinCore/Personas/ReviewCaptainHost.swift",
+    "Tests/BurinCoreTests/Personas/ReviewCaptainHostTests.swift"
+  ],
+  "max_rounds": 1,
+  "dry_run": true,
+  "rubric_preset": "code"
+}

--- a/personas/review_captain/harn.toml
+++ b/personas/review_captain/harn.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 
 [[personas]]
 name = "review_captain"
-version = "0.1.0"
-description = "Harn-native review captain. Produces deterministic review receipts, missing-test checks, and approval-ready follow-up handoff summaries."
+version = "0.2.0"
+description = "Harn-native review captain. Runs deterministic secret/risk checks plus optional self_review LLM rounds and emits a structured review receipt."
 entry_workflow = "manifest.harn#run"
 tools = ["github", "mcp"]
 capabilities = [
@@ -17,7 +17,7 @@ capabilities = [
 ]
 autonomy_tier = "suggest"
 receipt_policy = "required"
-triggers = ["github.review_requested", "github.pull_request_synchronized"]
+triggers = ["github.review_requested", "github.pull_request_synchronized", "github.pull_request_opened"]
 schedules = ["0 */2 * * *"]
 handoffs = []
 context_packs = ["repo_policy", "review_policy"]

--- a/personas/review_captain/lib/policy.harn
+++ b/personas/review_captain/lib/policy.harn
@@ -1,0 +1,66 @@
+// Per-repo policy loading for review_captain.
+//
+// Each repo can declare a JSON policy file that lists risky path
+// patterns and test-file globs. The policy is intentionally tiny —
+// anything more elaborate belongs in the LLM rubric, not in
+// deterministic Harn code.
+/** load_policy_json(raw) -> {ok, policy?, error?}. */
+pub fn load_policy_json(raw) {
+  let text = raw ?? ""
+  if text == "" {
+    return _default_policy_result()
+  }
+  let parsed = json_parse(text)
+  if parsed == nil {
+    return {ok: false, error: "policy JSON failed to parse"}
+  }
+  let risky_paths = parsed.risky_paths ?? []
+  let test_globs = parsed.test_globs ?? _default_test_globs()
+  return {ok: true, policy: {repo: parsed.repo ?? "", risky_paths: risky_paths, test_globs: test_globs}}
+}
+
+/**
+ * default_policy() returns a baseline policy used when no per-repo
+ * policy file is present. The patterns favour false positives over
+ * false negatives — review_captain would rather over-warn than miss a
+ * risky touch.
+ */
+pub fn default_policy() {
+  return {repo: "", risky_paths: _default_risky_paths(), test_globs: _default_test_globs()}
+}
+
+fn _default_policy_result() {
+  return {ok: true, policy: default_policy()}
+}
+
+fn _default_risky_paths() {
+  return [
+    ".github/workflows",
+    "scripts/release",
+    "scripts/build-release",
+    "scripts/fetch-harn",
+    "Package.swift",
+    "harn.toml",
+    "providers.toml",
+    ".env",
+    ".burin/",
+    "migrations/",
+    "schema.sql",
+  ]
+}
+
+fn _default_test_globs() {
+  return [
+    "tests/",
+    "Tests/",
+    "test/",
+    "__tests__",
+    "_test.swift",
+    "_test.go",
+    "_test.ts",
+    "_test.tsx",
+    "Test.swift",
+    ".test.ts",
+    ".spec.ts",
+  ]
+}

--- a/personas/review_captain/lib/receipt.harn
+++ b/personas/review_captain/lib/receipt.harn
@@ -1,0 +1,145 @@
+// Receipt envelope for review_captain runs.
+//
+// The envelope is the contract between the persona and Burin's
+// host-side `ReviewCaptainHost`. Burin reads the JSON Wire format off
+// stdout, decodes it into a strongly-typed `ReviewCaptainResult`, and
+// uses it to render PR diff comments / append to PR bodies / gate
+// auto-merge. Keep the schema additive: only ever extend, never rename
+// or remove fields without bumping the persona version.
+/** build_review_receipt assembles the durable receipt for one PR. */
+pub fn build_review_receipt(args) {
+  let request = args.request ?? {}
+  let secret_findings = args.secret_findings ?? []
+  let llm_findings = args.llm_findings ?? []
+  let llm_summary = args.llm_summary ?? ""
+  let llm_rounds = args.llm_rounds ?? 0
+  let risky_hits = args.risky_hits ?? []
+  let missing_tests = args.missing_tests ?? []
+  let llm_skipped_reason = args.llm_skipped_reason
+  let secret_review_findings = _findings_from_secrets(secret_findings)
+  let combined_findings = _dedupe(secret_review_findings + llm_findings)
+  let blocking = _has_blocking(combined_findings)
+  let verdict = if blocking {
+    "blocking"
+  } else {
+    if len(combined_findings) > 0 || len(missing_tests) > 0 || len(risky_hits) > 0 {
+      "needs_follow_up"
+    } else {
+      "approve"
+    }
+  }
+  let summary = _summary(combined_findings, llm_summary, blocking, missing_tests, risky_hits)
+  return {
+    persona: "review_captain",
+    kind: "review_receipt",
+    schema_version: 1,
+    repo: request.repo ?? "",
+    pr_number: request.pr_number ?? 0,
+    head_sha: request.head_sha ?? "",
+    base_sha: request.base_sha ?? "",
+    verdict: verdict,
+    blocking: blocking,
+    summary: summary,
+    findings: combined_findings,
+    secret_scan_findings: secret_findings,
+    risky_paths: risky_hits,
+    missing_tests: missing_tests,
+    rounds: llm_rounds,
+    self_review_skipped_reason: llm_skipped_reason,
+    handoff: if blocking {
+      "merge_captain"
+    } else {
+      nil
+    },
+  }
+}
+
+/**
+ * envelope_for_dry_run(request) returns the canned receipt used when
+ * dry_run=true skips the LLM stage but other deterministic stages
+ * still ran. The request payload still flows through so consumers see
+ * repo / PR identity.
+ */
+pub fn envelope_for_dry_run(request, secret_findings, missing_tests, risky_hits) {
+  return build_review_receipt(
+    {
+      request: request,
+      secret_findings: secret_findings,
+      llm_findings: [],
+      llm_summary: "",
+      llm_rounds: 0,
+      risky_hits: risky_hits,
+      missing_tests: missing_tests,
+      llm_skipped_reason: "dry_run",
+    },
+  )
+}
+
+fn _findings_from_secrets(secret_findings) {
+  var findings = []
+  for finding in secret_findings {
+    findings = findings
+      + [
+      {
+        id: "secret:${finding.detector ?? finding.title ?? "unknown"}:${finding.fingerprint ?? to_string(finding.line ?? 0)}",
+        severity: "blocking",
+        category: "secret",
+        title: finding.title ?? "Secret detected",
+        detail: "Secret-like value detected in diff (${finding.detector ?? "scanner"}).",
+        suggestion: "Rotate the credential and replace the literal with an environment variable or vaulted secret.",
+        file: nil,
+        line_start: finding.line,
+        line_end: finding.line,
+        source: "secret_scan",
+      },
+    ]
+  }
+  return findings
+}
+
+fn _dedupe(findings) {
+  var seen_ids = []
+  var deduped = []
+  for finding in findings {
+    let id = finding.id ?? ""
+    if id != "" && !_contains_string(seen_ids, id) {
+      seen_ids = seen_ids + [id]
+      deduped = deduped + [finding]
+    } else if id == "" {
+      deduped = deduped + [finding]
+    }
+  }
+  return deduped
+}
+
+fn _contains_string(haystack, needle) {
+  for entry in haystack {
+    if entry == needle {
+      return true
+    }
+  }
+  return false
+}
+
+fn _has_blocking(findings) {
+  for finding in findings {
+    if finding.severity ?? "" == "blocking" {
+      return true
+    }
+  }
+  return false
+}
+
+fn _summary(findings, llm_summary, blocking, missing_tests, risky_hits) {
+  if blocking {
+    return "review_captain blocked the PR: ${to_string(len(findings))} blocking finding(s)."
+  }
+  if len(findings) == 0 && len(missing_tests) == 0 && len(risky_hits) == 0 {
+    if llm_summary != "" {
+      return llm_summary
+    }
+    return "review_captain found no blocking issues."
+  }
+  let warn_count = len(findings)
+  return "review_captain flagged ${to_string(warn_count)} finding(s); ${to_string(len(risky_hits))} risky path(s); ${to_string(len(missing_tests))} file(s) without companion tests."
+}

--- a/personas/review_captain/lib/review.harn
+++ b/personas/review_captain/lib/review.harn
@@ -1,0 +1,80 @@
+import { build_review_receipt, envelope_for_dry_run } from "receipt"
+// Single-PR review orchestration.
+//
+// The persona wires this entry point from `manifest.harn#run`. It owns
+// the order of operations: secret_scan → risk classification → optional
+// `self_review` LLM rounds → receipt construction. Pulled out so the
+// tests in `tests/review_test.harn` can drive each stage without
+// shelling out to LLMs.
+import { classify_risky_paths, infer_missing_tests } from "risk"
+
+/**
+ * review_pr(request, policy, opts) is the deterministic entry point
+ * the persona dispatches to. `opts` lets callers (and tests) override
+ * the LLM hook so smoke runs and unit tests stay hermetic.
+ */
+pub fn review_pr(request, policy, opts) {
+  let normalized = _normalize_request(request)
+  let active_policy = _active_policy(policy)
+  let resolved_opts = opts ?? {}
+  let llm_hook = resolved_opts.llm_hook
+  let secret_findings = _scan_secrets(normalized.diff)
+  let risky = classify_risky_paths(normalized.changed_files, active_policy.risky_paths)
+  let missing_tests = infer_missing_tests(normalized.changed_files, active_policy.test_globs)
+  if normalized.dry_run || normalized.diff == "" {
+    return envelope_for_dry_run(normalized, secret_findings, missing_tests, risky.hits)
+  }
+  let llm_result = _run_llm(llm_hook, normalized)
+  return build_review_receipt(
+    {
+      request: normalized,
+      secret_findings: secret_findings,
+      llm_findings: llm_result.findings,
+      llm_summary: llm_result.summary,
+      llm_rounds: llm_result.rounds,
+      risky_hits: risky.hits,
+      missing_tests: missing_tests,
+      llm_skipped_reason: llm_result.skipped_reason,
+    },
+  )
+}
+
+fn _normalize_request(raw) {
+  let request = raw ?? {}
+  return {
+    repo: request.repo ?? "",
+    pr_number: request.pr_number ?? 0,
+    head_sha: request.head_sha ?? "",
+    base_sha: request.base_sha ?? "",
+    diff: request.diff ?? "",
+    changed_files: request.changed_files ?? [],
+    max_rounds: request.max_rounds ?? 1,
+    dry_run: request.dry_run ?? false,
+    rubric_preset: request.rubric_preset ?? "code",
+  }
+}
+
+fn _active_policy(policy) {
+  let policy_or_default = policy ?? {}
+  return {risky_paths: policy_or_default.risky_paths ?? [], test_globs: policy_or_default.test_globs ?? []}
+}
+
+fn _scan_secrets(diff) {
+  if diff == "" {
+    return []
+  }
+  return secret_scan(diff)
+}
+
+fn _run_llm(hook, request) {
+  if hook != nil {
+    return hook(request)
+  }
+  let llm = self_review(request.diff, request.rubric_preset, request.max_rounds)
+  return {
+    findings: llm.findings ?? [],
+    summary: llm.summary ?? "",
+    rounds: len(llm.rounds ?? []),
+    skipped_reason: nil,
+  }
+}

--- a/personas/review_captain/lib/risk.harn
+++ b/personas/review_captain/lib/risk.harn
@@ -1,0 +1,78 @@
+// Deterministic risk classification for changed files.
+//
+// Categorises a list of changed files against a list of glob-style risky
+// path prefixes. Patterns are intentionally simple — substring with `*`
+// suffix wildcard or `*.ext` extension match — because the LLM stage of
+// review is the source of truth; this layer only surfaces obvious
+// hotspots without requiring an LLM hop.
+/** classify_risky_paths(changed_files, patterns) -> {hits, misses}. */
+pub fn classify_risky_paths(changed_files, patterns) {
+  let pats = patterns ?? []
+  let files = changed_files ?? []
+  var hits = []
+  var misses = []
+  for file in files {
+    if _matches_any(file, pats) {
+      hits = hits + [file]
+    } else {
+      misses = misses + [file]
+    }
+  }
+  return {hits: hits, misses: misses}
+}
+
+/**
+ * infer_missing_tests(changed_files, test_globs) returns the source
+ * files that look risky but have no companion test in the same diff.
+ * The heuristic is intentionally narrow: a file qualifies as a test if
+ * its lowered path matches one of the supplied test globs (for example
+ * `tests/`, `__tests__`, `_test.swift`).
+ */
+pub fn infer_missing_tests(changed_files, test_globs) {
+  let files = changed_files ?? []
+  let globs = test_globs ?? []
+  var test_files = []
+  var source_files = []
+  for file in files {
+    if _looks_like_test(file, globs) {
+      test_files = test_files + [file]
+    } else {
+      source_files = source_files + [file]
+    }
+  }
+  if len(test_files) > 0 {
+    return []
+  }
+  return source_files
+}
+
+fn _matches_any(file, patterns) {
+  for pattern in patterns {
+    if _matches(file, pattern) {
+      return true
+    }
+  }
+  return false
+}
+
+fn _matches(file, pattern) {
+  if ends_with(pattern, "*") {
+    let prefix = substring(pattern, 0, len(pattern) - 1)
+    return starts_with(file, prefix)
+  }
+  if starts_with(pattern, "*.") {
+    let suffix = substring(pattern, 1, len(pattern))
+    return ends_with(file, suffix)
+  }
+  return contains(file, pattern)
+}
+
+fn _looks_like_test(file, globs) {
+  let lowered = lowercase(file)
+  for glob in globs {
+    if _matches(lowered, lowercase(glob)) {
+      return true
+    }
+  }
+  return false
+}

--- a/personas/review_captain/manifest.harn
+++ b/personas/review_captain/manifest.harn
@@ -1,17 +1,30 @@
 // Review Captain entry pipeline.
 //
-// This package is the canonical Harn home for the review persona Burin
-// surfaces in its persona manager. The workflow remains deterministic by
-// default so local smoke runs do not require live GitHub credentials.
+// One invocation reviews one PR. The pipeline accepts an `input` JSON
+// object on stdin so any embedder (Burin Code, harn-cloud, the CLI)
+// drives the persona by piping a `ReviewCaptainRequest` payload in;
+// when stdin is empty it falls back to the bundled smoke fixture so
+// `harn run personas/review_captain/manifest.harn` still produces a
+// deterministic receipt.
 import { runtime_pipeline_input } from "std/runtime"
+import { default_policy, load_policy_json } from "lib/policy"
+import { review_pr } from "lib/review"
 
-@persona(name: "review_captain", description: "Harn-native review quality captain.", tools: [github], autonomy: suggest, receipts: required, triggers: [github.review_requested, github.pull_request_synchronized])
+@persona(name: "review_captain", description: "Harn-native review captain. Runs deterministic secret/risk checks plus optional self_review LLM rounds and emits a structured review receipt.", tools: [github, mcp], autonomy: suggest, receipts: required, triggers: [github.review_requested, github.pull_request_synchronized, github.pull_request_opened])
 /** Static persona graph used by `harn persona inspect` to expose Review Captain's durable steps. */
 pub fn review_captain_persona(ctx) {
   let input = resolve_review_input_step(ctx)
-  let diff = collect_review_context_step(input)
-  let verdict = classify_review_risk_step(diff)
-  let receipt = emit_review_receipt_step({input: input, verdict: verdict})
+  let secret_scan_findings = scan_secrets_step(input)
+  let risky_paths = classify_risky_paths_step({input: input, secret_scan_findings: secret_scan_findings})
+  let llm_findings = run_self_review_step({input: input, risky_paths: risky_paths})
+  let receipt = build_review_receipt_step(
+    {
+      input: input,
+      llm_findings: llm_findings,
+      secret_scan_findings: secret_scan_findings,
+      risky_paths: risky_paths,
+    },
+  )
   return summarize_review_step(receipt)
 }
 
@@ -20,18 +33,23 @@ fn resolve_review_input_step(ctx) {
   return ctx
 }
 
-@step(name: "collect_review_context", receipt: audit, error_boundary: fail)
-fn collect_review_context_step(ctx) {
+@step(name: "scan_secrets", receipt: audit, error_boundary: fail)
+fn scan_secrets_step(ctx) {
   return ctx
 }
 
-@step(name: "classify_review_risk", model: "gpt-5.4-mini", receipt: audit, error_boundary: escalate)
-fn classify_review_risk_step(ctx) {
+@step(name: "classify_risky_paths", receipt: audit, error_boundary: fail)
+fn classify_risky_paths_step(ctx) {
   return ctx
 }
 
-@step(name: "emit_review_receipt", receipt: audit, error_boundary: fail)
-fn emit_review_receipt_step(ctx) {
+@step(name: "run_self_review", model: "gpt-5.4-mini", receipt: audit, error_boundary: continue, retry: {max_attempts: 2})
+fn run_self_review_step(ctx) {
+  return ctx
+}
+
+@step(name: "build_review_receipt", receipt: audit, error_boundary: fail)
+fn build_review_receipt_step(ctx) {
   return ctx
 }
 
@@ -40,67 +58,84 @@ fn summarize_review_step(ctx) {
   return ctx
 }
 
-fn _default_review() {
+fn _default_request() {
   return {
-    repo: "burin-labs/harn",
-    pr_number: 463,
-    changed_files: ["personas/review_captain/harn.toml", "personas/review_captain/manifest.harn"],
-    missing_tests: ["persona smoke run"],
-    risky_paths: ["personas/review_captain/harn.toml"],
+    repo: "burin-labs/burin-code",
+    pr_number: 235,
+    head_sha: "0000000000000000000000000000000000000000",
+    base_sha: "0000000000000000000000000000000000000000",
+    diff: "",
+    changed_files: [],
+    max_rounds: 1,
+    dry_run: true,
+    rubric_preset: "code",
+    policy_path: nil,
   }
 }
 
-fn _resolve_review() {
+fn _resolve_request() {
+  let from_stdin = _try_stdin()
+  if from_stdin != nil {
+    return _merge_with_defaults(from_stdin)
+  }
+  let from_runtime = _try_runtime_input()
+  if from_runtime != nil {
+    return _merge_with_defaults(from_runtime)
+  }
+  return _default_request()
+}
+
+fn _try_stdin() {
+  let raw = trim(read_stdin() ?? "")
+  if raw == "" {
+    return nil
+  }
+  return json_parse(raw)
+}
+
+fn _try_runtime_input() {
   let attempt = try {
     runtime_pipeline_input()
   }
-  let provided = if is_ok(attempt) {
-    unwrap(attempt) ?? {}
-  } else {
-    {}
+  if !is_ok(attempt) {
+    return nil
   }
-  let review = provided.review_captain ?? provided
-  let defaults = _default_review()
+  return unwrap(attempt)
+}
+
+fn _merge_with_defaults(provided) {
+  let defaults = _default_request()
   return {
-    repo: review.repo ?? defaults.repo,
-    pr_number: review.pr_number ?? defaults.pr_number,
-    changed_files: review.changed_files ?? defaults.changed_files,
-    missing_tests: review.missing_tests ?? defaults.missing_tests,
-    risky_paths: review.risky_paths ?? defaults.risky_paths,
+    repo: provided.repo ?? defaults.repo,
+    pr_number: provided.pr_number ?? defaults.pr_number,
+    head_sha: provided.head_sha ?? defaults.head_sha,
+    base_sha: provided.base_sha ?? defaults.base_sha,
+    diff: provided.diff ?? defaults.diff,
+    changed_files: provided.changed_files ?? defaults.changed_files,
+    max_rounds: provided.max_rounds ?? defaults.max_rounds,
+    dry_run: provided.dry_run ?? defaults.dry_run,
+    rubric_preset: provided.rubric_preset ?? defaults.rubric_preset,
+    policy_path: provided.policy_path ?? defaults.policy_path,
   }
 }
 
-fn _review_verdict(review) {
-  if len(review.missing_tests) > 0 || len(review.risky_paths) > 0 {
-    return "needs_follow_up"
+fn _resolve_policy(request) {
+  let path = request.policy_path
+  if path == nil || path == "" {
+    return default_policy()
   }
-  return "low_risk"
+  let raw = read_file(path)
+  let result = load_policy_json(raw)
+  if result.ok {
+    return result.policy
+  }
+  return default_policy()
 }
 
 pipeline run(task) {
-  let review = _resolve_review()
-  let verdict = _review_verdict(review)
-  let result = {
-    persona: "review_captain",
-    execution_mode: "dry_run",
-    approval_required: false,
-    repo: review.repo,
-    pr_number: review.pr_number,
-    summary: "structured review receipt for PR #${review.pr_number}",
-    focus: ["regressions", "missing tests", "risky diffs"],
-    receipt: {
-      kind: "review_receipt",
-      verdict: verdict,
-      missing_tests: review.missing_tests,
-      risky_paths: review.risky_paths,
-      changed_files: review.changed_files,
-    },
-    handoff: if verdict == "needs_follow_up" {
-      "merge_captain"
-    } else {
-      nil
-    },
-  }
-  println(json_stringify(result))
-  return result
+  let request = _resolve_request()
+  let policy = _resolve_policy(request)
+  let receipt = review_pr(request, policy, nil)
+  println(json_stringify(receipt))
+  return receipt
 }

--- a/personas/review_captain/tests/policy_test.harn
+++ b/personas/review_captain/tests/policy_test.harn
@@ -1,0 +1,32 @@
+// Run: harn test personas/review_captain/tests/policy_test.harn
+import { default_policy, load_policy_json } from "../lib/policy"
+
+pipeline test_default_policy_has_baseline_patterns(task) {
+  let policy = default_policy()
+  assert(len(policy.risky_paths) > 0)
+  assert(len(policy.test_globs) > 0)
+}
+
+pipeline test_load_policy_json_returns_default_when_empty(task) {
+  let result = load_policy_json("")
+  assert_eq(result.ok, true)
+  assert(len(result.policy.risky_paths) > 0)
+}
+
+pipeline test_load_policy_json_round_trips(task) {
+  let raw = "{\"repo\":\"burin-labs/burin-code\",\"risky_paths\":[\"Package.swift\"],\"test_globs\":[\"Tests/\"]}"
+  let result = load_policy_json(raw)
+  assert_eq(result.ok, true)
+  assert_eq(result.policy.repo, "burin-labs/burin-code")
+  assert_eq(len(result.policy.risky_paths), 1)
+  assert_eq(result.policy.risky_paths[0], "Package.swift")
+  assert_eq(len(result.policy.test_globs), 1)
+  assert_eq(result.policy.test_globs[0], "Tests/")
+}
+
+pipeline test_load_policy_json_falls_back_to_default_test_globs(task) {
+  let raw = "{\"repo\":\"x/y\",\"risky_paths\":[\"a\"]}"
+  let result = load_policy_json(raw)
+  assert_eq(result.ok, true)
+  assert(len(result.policy.test_globs) > 0)
+}

--- a/personas/review_captain/tests/receipt_test.harn
+++ b/personas/review_captain/tests/receipt_test.harn
@@ -1,0 +1,107 @@
+// Run: harn test personas/review_captain/tests/receipt_test.harn
+import { build_review_receipt, envelope_for_dry_run } from "../lib/receipt"
+
+fn _request() {
+  return {repo: "burin-labs/burin-code", pr_number: 42, head_sha: "abc", base_sha: "def"}
+}
+
+pipeline test_clean_receipt_returns_approve(task) {
+  let receipt = build_review_receipt(
+    {
+      request: _request(),
+      secret_findings: [],
+      llm_findings: [],
+      llm_summary: "",
+      llm_rounds: 1,
+      risky_hits: [],
+      missing_tests: [],
+    },
+  )
+  assert_eq(receipt.verdict, "approve")
+  assert_eq(receipt.blocking, false)
+  assert_eq(len(receipt.findings), 0)
+  assert_eq(receipt.handoff, nil)
+  assert_eq(receipt.persona, "review_captain")
+  assert_eq(receipt.kind, "review_receipt")
+  assert_eq(receipt.repo, "burin-labs/burin-code")
+}
+
+pipeline test_secret_findings_set_blocking(task) {
+  let receipt = build_review_receipt(
+    {
+      request: _request(),
+      secret_findings: [{detector: "aws-access-key-id", title: "AWS access key id", line: 4, fingerprint: "abc123"}],
+      llm_findings: [],
+      llm_summary: "",
+      llm_rounds: 0,
+      risky_hits: [],
+      missing_tests: [],
+    },
+  )
+  assert_eq(receipt.verdict, "blocking")
+  assert_eq(receipt.blocking, true)
+  assert_eq(len(receipt.findings), 1)
+  assert_eq(receipt.findings[0].source, "secret_scan")
+  assert_eq(receipt.findings[0].severity, "blocking")
+  assert_eq(receipt.handoff, "merge_captain")
+}
+
+pipeline test_warning_findings_set_needs_follow_up(task) {
+  let receipt = build_review_receipt(
+    {
+      request: _request(),
+      secret_findings: [],
+      llm_findings: [
+        {
+          id: "warn1",
+          severity: "warning",
+          category: "tests",
+          title: "missing test",
+          detail: "x",
+          source: "self_review",
+        },
+      ],
+      llm_summary: "1 warning",
+      llm_rounds: 1,
+      risky_hits: [],
+      missing_tests: [],
+    },
+  )
+  assert_eq(receipt.verdict, "needs_follow_up")
+  assert_eq(receipt.blocking, false)
+  assert_eq(len(receipt.findings), 1)
+}
+
+pipeline test_dedupe_drops_duplicate_ids(task) {
+  let receipt = build_review_receipt(
+    {
+      request: _request(),
+      secret_findings: [],
+      llm_findings: [
+        {id: "warn1", severity: "warning", category: "x", title: "t", detail: "d", source: "self_review"},
+        {
+          id: "warn1",
+          severity: "warning",
+          category: "x",
+          title: "t-dup",
+          detail: "d",
+          source: "self_review",
+        },
+      ],
+      llm_summary: "",
+      llm_rounds: 1,
+      risky_hits: [],
+      missing_tests: [],
+    },
+  )
+  assert_eq(len(receipt.findings), 1)
+}
+
+pipeline test_dry_run_envelope_skips_llm(task) {
+  let receipt = envelope_for_dry_run(_request(), [], ["sources/foo.swift"], ["scripts/release.sh"])
+  assert_eq(receipt.self_review_skipped_reason, "dry_run")
+  assert_eq(receipt.rounds, 0)
+  assert_eq(receipt.verdict, "needs_follow_up")
+  assert_eq(len(receipt.risky_paths), 1)
+  assert_eq(len(receipt.missing_tests), 1)
+}

--- a/personas/review_captain/tests/review_captain_smoke.harn
+++ b/personas/review_captain/tests/review_captain_smoke.harn
@@ -1,0 +1,24 @@
+// Run: harn test personas/review_captain/tests/review_captain_smoke.harn
+//
+// Smoke covers the persona's full pipeline against the bundled fixture
+// in dry_run mode so the LLM step is skipped. Confirms shape stability
+// of the JSON receipt embedders depend on.
+import { default_policy } from "../lib/policy"
+import { review_pr } from "../lib/review"
+
+fn _fixture_request() {
+  let raw = read_file("../fixtures/pull_request.json")
+  return json_parse(raw)
+}
+
+pipeline test_smoke_dry_run_emits_receipt(task) {
+  let request = _fixture_request()
+  let receipt = review_pr(request, default_policy(), nil)
+  assert_eq(receipt.persona, "review_captain")
+  assert_eq(receipt.kind, "review_receipt")
+  assert_eq(receipt.schema_version, 1)
+  assert_eq(receipt.repo, "burin-labs/burin-code")
+  assert_eq(receipt.pr_number, 235)
+  assert_eq(receipt.self_review_skipped_reason, "dry_run")
+  assert_eq(receipt.blocking, false)
+}

--- a/personas/review_captain/tests/review_test.harn
+++ b/personas/review_captain/tests/review_test.harn
@@ -1,0 +1,90 @@
+// Run: harn test personas/review_captain/tests/review_test.harn
+import { default_policy } from "../lib/policy"
+import { review_pr } from "../lib/review"
+
+fn _request(diff, files, dry_run) {
+  return {
+    repo: "burin-labs/burin-code",
+    pr_number: 1234,
+    head_sha: "abc",
+    base_sha: "def",
+    diff: diff,
+    changed_files: files,
+    max_rounds: 1,
+    dry_run: dry_run,
+  }
+}
+
+fn _llm_no_findings(_request) {
+  return {findings: [], summary: "all clear", rounds: 1, skipped_reason: nil}
+}
+
+fn _llm_blocking(_request) {
+  return {
+    findings: [
+      {
+        id: "llm:1",
+        severity: "blocking",
+        category: "correctness",
+        title: "off-by-one",
+        detail: "loop bound is wrong",
+        source: "self_review",
+      },
+    ],
+    summary: "found 1 blocking finding",
+    rounds: 1,
+    skipped_reason: nil,
+  }
+}
+
+pipeline test_dry_run_skips_llm(task) {
+  let receipt = review_pr(_request("", [], true), default_policy(), nil)
+  assert_eq(receipt.self_review_skipped_reason, "dry_run")
+  assert_eq(receipt.rounds, 0)
+}
+
+pipeline test_secret_in_diff_returns_blocking(task) {
+  let diff = "+let key = \"AKIAIOSFODNN7EXAMPLE\""
+  let receipt = review_pr(_request(diff, ["src/secret.swift"], true), default_policy(), nil)
+  assert_eq(receipt.blocking, true)
+  assert_eq(receipt.verdict, "blocking")
+  assert(len(receipt.secret_scan_findings) > 0)
+  assert(len(receipt.findings) > 0)
+}
+
+pipeline test_clean_diff_returns_approve(task) {
+  let diff = "+let answer = 42"
+  let receipt = review_pr(
+    _request(diff, ["Tests/AnswerTests.swift"], false),
+    default_policy(),
+    {llm_hook: _llm_no_findings},
+  )
+  assert_eq(receipt.verdict, "approve")
+  assert_eq(receipt.blocking, false)
+  assert_eq(receipt.rounds, 1)
+  assert_eq(receipt.summary, "all clear")
+}
+
+pipeline test_llm_blocking_finding_is_propagated(task) {
+  let diff = "+let answer = 42"
+  let receipt = review_pr(
+    _request(diff, ["Tests/AnswerTests.swift"], false),
+    default_policy(),
+    {llm_hook: _llm_blocking},
+  )
+  assert_eq(receipt.blocking, true)
+  assert_eq(receipt.verdict, "blocking")
+  assert_eq(receipt.handoff, "merge_captain")
+  assert_eq(len(receipt.findings), 1)
+}
+
+pipeline test_risky_paths_surface_in_receipt(task) {
+  let diff = "+# changed workflow"
+  let receipt = review_pr(
+    _request(diff, [".github/workflows/deploy.yml"], false),
+    default_policy(),
+    {llm_hook: _llm_no_findings},
+  )
+  assert(len(receipt.risky_paths) > 0)
+  assert_eq(receipt.verdict, "needs_follow_up")
+}

--- a/personas/review_captain/tests/risk_test.harn
+++ b/personas/review_captain/tests/risk_test.harn
@@ -1,0 +1,36 @@
+// Run: harn test personas/review_captain/tests/risk_test.harn
+import { classify_risky_paths, infer_missing_tests } from "../lib/risk"
+
+pipeline test_classify_with_suffix_wildcard(task) {
+  let result = classify_risky_paths(
+    ["scripts/release.sh", "Package.swift", "Sources/foo.swift"],
+    ["scripts/release*", "Package.swift"],
+  )
+  assert_eq(len(result.hits), 2)
+  assert_eq(result.hits[0], "scripts/release.sh")
+  assert_eq(result.hits[1], "Package.swift")
+  assert_eq(len(result.misses), 1)
+  assert_eq(result.misses[0], "Sources/foo.swift")
+}
+
+pipeline test_classify_with_extension_wildcard(task) {
+  let result = classify_risky_paths(["a.toml", "b.swift", "c.toml"], ["*.toml"])
+  assert_eq(len(result.hits), 2)
+  assert_eq(len(result.misses), 1)
+}
+
+pipeline test_classify_nil_inputs(task) {
+  let result = classify_risky_paths(nil, nil)
+  assert_eq(len(result.hits), 0)
+  assert_eq(len(result.misses), 0)
+}
+
+pipeline test_missing_tests_when_no_tests(task) {
+  let missing = infer_missing_tests(["Sources/Foo.swift", "Sources/Bar.swift"], ["Tests/", "_test.swift"])
+  assert_eq(len(missing), 2)
+}
+
+pipeline test_missing_tests_when_tests_present(task) {
+  let missing = infer_missing_tests(["Sources/Foo.swift", "Tests/FooTests.swift"], ["Tests/", "_test.swift"])
+  assert_eq(len(missing), 0)
+}


### PR DESCRIPTION
## Summary

Upgrades the `review_captain` persona package from a deterministic stub to a real PR reviewer that's wireable by Burin Code's self-review-before-open loop and PR-bot hook (closes the Harn-side scope of [burin-code#235](https://github.com/burin-labs/burin-code/issues/235)).

The persona now reads a `ReviewCaptainRequest` JSON object from stdin (with `runtime_pipeline_input` and a bundled fixture as fallbacks), runs `secret_scan` over the diff, classifies changed files against per-repo risky-path patterns, optionally calls `self_review` for one or more LLM rounds, and emits a single versioned `review_receipt` envelope.

The lib modules (`risk`, `receipt`, `policy`, `review`) split deterministic logic from the LLM hook so embedders can dry-run hermetically and the test suite covers each stage without spinning up a model. Policy is loaded from JSON when `policy_path` is provided and falls back to a sensible baseline (workflows, release scripts, manifests, env files).

Schema is intentionally additive: bump `schema_version` before renaming or removing fields. Hosts decode the receipt off stdout to attach findings to PR descriptions, gate auto-merge, and drive the self-review-before-open loop.

## Test plan

- [x] `harn fmt personas/review_captain/`
- [x] `harn test personas/review_captain/tests/` — 20 tests pass
- [x] `harn persona --manifest personas/review_captain/harn.toml doctor review_captain` — all green except the optional `prompt-assets` and per-step `cost-budget` tier
- [x] End-to-end smoke: `cat fixtures/pull_request.json | harn run personas/review_captain/manifest.harn` returns a deterministic dry-run receipt
- [x] Secret-bearing diff: piped stdin with an AWS key triggers `verdict: blocking` and a `secret_scan_findings` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)