### PR TITLE
Land cache_hit/cache_miss as canonical AgentEvent variants (#1473)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,14 +26,15 @@ condensed series summaries instead of full per-patch history.
   from the unified clock (`mock_time` / `advance_time` honored), so
   testbench fixtures can reproduce expiry windows without wall-clock
   flakiness. When `options.session_id` is set, `with_cache` emits
-  `cache.hit` / `cache.miss` events on the agent event tape with
-  cost-moat receipts (`model_calls_avoided`, `tokens_saved` from
-  `usage.input_tokens` + `usage.output_tokens`, `latency_saved_ms`
-  from `latency_ms`) for the persona value ledger
-  (harn-cloud#58) and crystallization receipts. The
-  `with_cache(next, opts?)` middleware form in `std/llm/handlers`
-  now actually caches — previously it was a passthrough — and shares
-  one cache key with the direct-call form. Docs at
+  `cache_hit` / `cache_miss` events on the agent event tape (now
+  registered as first-class `AgentEvent` variants so ACP and closure
+  subscribers see them) with cost-moat receipts
+  (`model_calls_avoided`, `tokens_saved` from `usage.input_tokens` +
+  `usage.output_tokens`, `latency_saved_ms` from `latency_ms`) for the
+  persona value ledger (harn-cloud#58) and crystallization receipts.
+  Both the `with_cache(next, opts?)` middleware form and the direct
+  `with_cache(prompt, system, opts)` form in `std/llm/handlers` cache
+  and emit receipts; they share one cache key. Docs at
   [`docs/src/stdlib/cache.md`](docs/src/stdlib/cache.md).
 
 ## v0.8.6

--- a/conformance/tests/integration/cache_event_receipts.expected
+++ b/conformance/tests/integration/cache_event_receipts.expected
@@ -1,0 +1,8 @@
+direct_emit_ok=true
+first.text=answer
+byte_identical=true
+mock_calls=1
+hits=2
+misses=1
+hit.tokens_saved=18
+hit.model_calls_avoided=1

--- a/conformance/tests/integration/cache_event_receipts.harn
+++ b/conformance/tests/integration/cache_event_receipts.harn
@@ -1,0 +1,72 @@
+/**
+ * Cache cost-moat receipts on the agent event tape.
+ *
+ * Verifies the ledger story end-to-end:
+ *  - `agent_emit_event(session_id, "cache_hit"|"cache_miss", payload)`
+ *    is accepted by the host. Pre-fix the event names weren't
+ *    registered as `AgentEvent` variants and the wrapper's `try`
+ *    around `agent_emit_event` silently swallowed the rejection.
+ *  - The direct-call `with_cache(prompt, system, opts)` form emits
+ *    the same `cache_hit` / `cache_miss` receipts as the caller-
+ *    wrapper form when `opts.session_id` is set.
+ *  - Receipts carry `model_calls_avoided` and `tokens_saved`
+ *    derived from the cached LLM envelope's `usage`. (latency_saved_ms
+ *    is only populated when the cached envelope includes a `latency_ms`
+ *    field; llm_call does not currently surface one.)
+ */
+import { agent_emit_event } from "std/agent/state"
+import { cache_clear, mem_cache } from "std/cache"
+import { with_cache } from "std/llm/handlers"
+
+pipeline default() {
+  let session_id = "cache-event-receipts-" + uuid()
+  let hits = atomic(0)
+  let misses = atomic(0)
+  let last_hit_tokens = atomic(0)
+  let last_hit_calls_avoided = atomic(0)
+  agent_subscribe(
+    session_id,
+    { ev ->
+      if ev?.type == "cache_hit" {
+        let _ = atomic_add(hits, 1)
+        let _ = atomic_set(last_hit_tokens, to_int(ev?.payload?.metrics?.tokens_saved ?? 0))
+        let _ = atomic_set(last_hit_calls_avoided, to_int(ev?.payload?.metrics?.model_calls_avoided ?? 0))
+      }
+      if ev?.type == "cache_miss" {
+        let _ = atomic_add(misses, 1)
+      }
+    },
+  )
+  // Direct host emit: pre-fix this returned an "unsupported event type"
+  // error that the wrapper silently swallowed. With cache_hit / cache_miss
+  // registered as canonical AgentEvent variants, the call succeeds.
+  let direct = try {
+    agent_emit_event(
+      session_id,
+      "cache_hit",
+      {key: "direct", backend: "mem", namespace: "ns", metrics: {model_calls_avoided: 1}},
+    )
+  }
+  println("direct_emit_ok=" + to_string(!is_err(direct)))
+  // Direct-call form: a miss + hit pair should land on the tape with
+  // the cost-moat receipts derived from the cached LLM envelope. The
+  // mock surfaces `input_tokens` + `output_tokens` at the top level
+  // (the LLM result then exposes them through `usage` for the metric
+  // reader).
+  llm_mock_clear()
+  llm_mock({text: "answer", input_tokens: 11, output_tokens: 7, model: "m", provider: "p"})
+  llm_mock({text: "would-recompute", model: "m", provider: "p"})
+  let store = mem_cache({namespace: "cache-event-receipts-direct-" + uuid()})
+  cache_clear({store: store})
+  let opts = {provider: "p", model: "m", stream: false, store: store, session_id: session_id}
+  let first = with_cache("hello", "sys", opts)
+  let second = with_cache("hello", "sys", opts)
+  println("first.text=" + first.text)
+  println("byte_identical=" + to_string(json_stringify(first) == json_stringify(second)))
+  println("mock_calls=" + to_string(len(llm_mock_calls())))
+  // hits counter started at 1 from the direct emit above, so we expect 2.
+  println("hits=" + to_string(atomic_get(hits)))
+  println("misses=" + to_string(atomic_get(misses)))
+  println("hit.tokens_saved=" + to_string(atomic_get(last_hit_tokens)))
+  println("hit.model_calls_avoided=" + to_string(atomic_get(last_hit_calls_avoided)))
+}

--- a/conformance/tests/integration/with_cache_caller_replay.expected
+++ b/conformance/tests/integration/with_cache_caller_replay.expected
@@ -3,3 +3,6 @@ second.ok=true
 byte_identical=true
 mock_calls=1
 after_tool_call_mock_calls=2
+misses=1
+hits=1
+hit.tokens_saved=18

--- a/conformance/tests/integration/with_cache_caller_replay.harn
+++ b/conformance/tests/integration/with_cache_caller_replay.harn
@@ -7,7 +7,7 @@
  *
  *  - first call hits the underlying mock; second call hits the cache
  *  - replayed value is byte-identical to the recorded value (json eq)
- *  - cache.hit / cache.miss events appear on the agent event tape
+ *  - cache_hit / cache_miss events appear on the agent event tape
  *    in deterministic order with the right metric receipts
  *  - tools-bearing calls bypass the cache (skip_when default)
  */
@@ -18,10 +18,28 @@ pipeline default() {
   let store = mem_cache({namespace: "with-cache-caller-" + uuid()})
   cache_clear({store: store})
   let caller = with_cache(default_llm_caller(), {store: store, ttl: "1h"})
+  let session_id = "with-cache-caller-session-" + uuid()
+  let hits = atomic(0)
+  let misses = atomic(0)
+  let last_hit_tokens = atomic(0)
+  agent_subscribe(
+    session_id,
+    { ev ->
+      if ev?.type == "cache_hit" {
+        let _ = atomic_add(hits, 1)
+        let _ = atomic_set(last_hit_tokens, to_int(ev?.payload?.metrics?.tokens_saved ?? 0))
+      }
+      if ev?.type == "cache_miss" {
+        let _ = atomic_add(misses, 1)
+      }
+    },
+  )
   llm_mock_clear()
-  llm_mock({text: "answer", usage: {input_tokens: 11, output_tokens: 7}, model: "m", provider: "p"})
+  // The mock surfaces input_tokens/output_tokens at the top level; the
+  // LLM result wraps them into `usage` so the cache receipt reader sees
+  // the right `tokens_saved` figure on hits.
+  llm_mock({text: "answer", input_tokens: 11, output_tokens: 7, model: "m", provider: "p"})
   llm_mock({text: "fresh-if-uncached", model: "m", provider: "p"})
-  let session_id = "with-cache-caller-session"
   let opts = {provider: "p", model: "m", stream: false}
   let call_one = {
     prompt: "hello",
@@ -39,4 +57,7 @@ pipeline default() {
   let tool_call = call_one + {opts: opts + {tools: []}}
   let _ = caller(tool_call)
   println("after_tool_call_mock_calls=" + to_string(len(llm_mock_calls())))
+  println("misses=" + to_string(atomic_get(misses)))
+  println("hits=" + to_string(atomic_get(hits)))
+  println("hit.tokens_saved=" + to_string(atomic_get(last_hit_tokens)))
 }

--- a/crates/harn-serve/src/adapters/acp/events.rs
+++ b/crates/harn-serve/src/adapters/acp/events.rs
@@ -808,6 +808,20 @@ impl AgentEventSink for AcpAgentEventSink {
                     }),
                 );
             }
+            AgentEvent::CacheHit {
+                session_id,
+                payload,
+                ..
+            } => {
+                self.emit_agent_event_ext("cache_hit", session_id, payload.clone());
+            }
+            AgentEvent::CacheMiss {
+                session_id,
+                payload,
+                ..
+            } => {
+                self.emit_agent_event_ext("cache_miss", session_id, payload.clone());
+            }
         }
     }
 }

--- a/crates/harn-stdlib/src/stdlib/llm/handlers.harn
+++ b/crates/harn-stdlib/src/stdlib/llm/handlers.harn
@@ -102,22 +102,29 @@ fn __llm_handler_should_skip_cache(prompt, system, opts) -> bool {
 }
 
 fn __llm_handler_cache_options(opts) -> dict {
-  var ttl = opts?.ttl
-  if ttl == nil && opts?.ttl_seconds == nil && opts?.max_age_seconds == nil {
-    ttl = "10m"
+  // LLM caches default to a 10-minute TTL when the caller has not supplied
+  // any TTL-equivalent. Deterministic builtins set their own.
+  var cache_opts = {store: opts?.store ?? "llm.with_cache"}
+  if opts?.ttl != nil {
+    cache_opts = cache_opts + {ttl: opts.ttl}
+  } else if opts?.ttl_seconds == nil && opts?.max_age_seconds == nil {
+    cache_opts = cache_opts + {ttl: "10m"}
   }
-  return {
-    store: opts?.store ?? "llm.with_cache",
-    backend: opts?.backend,
-    namespace: opts?.namespace,
-    name: opts?.name,
-    path: opts?.path,
-    cache_dir: opts?.cache_dir,
-    ttl: ttl,
-    ttl_seconds: opts?.ttl_seconds,
-    max_age_seconds: opts?.max_age_seconds,
-    max_entries: opts?.max_entries ?? 256,
+  for key in [
+    "backend",
+    "namespace",
+    "name",
+    "path",
+    "cache_dir",
+    "ttl_seconds",
+    "max_age_seconds",
+    "max_entries",
+  ] {
+    if opts?[key] != nil {
+      cache_opts = cache_opts + {[key]: opts[key]}
+    }
   }
+  return cache_opts
 }
 
 fn __safe_invoke(next, call) {
@@ -669,13 +676,15 @@ pub fn llm_cache_key(prompt, system = nil, options = nil) -> string {
  *   with_cache(next, opts?) -> caller     (composable middleware)
  *
  * Both forms share the same on-disk cache namespaced under
- * `llm.with_cache` by default. The caller-wrapper form keys on the
- * canonical LLM cache key derived from `call.prompt`, `call.system`, and
- * `call.opts`, and emits `cache.hit` / `cache.miss` events on the agent
- * event tape when the call carries a session_id. On hits, the wrapper
- * also records "model calls avoided" + "tokens saved" + "latency saved"
- * receipts pulled from the cached envelope so the persona value ledger
- * (harn-cloud#58) and crystallization receipts can read them back.
+ * `llm.with_cache` by default and key on the canonical
+ * `llm_cache_key(prompt, system, opts)` sha256. When a session_id is
+ * available — `call.turn.session_id` for the caller form,
+ * `options.session_id` for the direct form — both forms emit
+ * `cache_hit` / `cache_miss` events on the agent event tape. On hits,
+ * the wrapper records "model calls avoided" + "tokens saved" +
+ * "latency saved" receipts pulled from the cached envelope so the
+ * persona value ledger (harn-cloud#58) and crystallization receipts
+ * can read them back.
  */
 pub fn with_cache(first, second = nil, third = nil) {
   if __llm_handler_is_callable(first) {
@@ -687,55 +696,69 @@ pub fn with_cache(first, second = nil, third = nil) {
         return __safe_invoke(next, call)
       }
       let merged_opts = opts + cfg
-      let key = llm_cache_key(call?.prompt, call?.system, merged_opts)
-      let cache_options = __llm_handler_cache_options(merged_opts)
-      let session_id = to_string(call?.turn?.session_id ?? "")
-      let cached = cache_get(key, cache_options)
-      if cached.hit {
-        __with_cache_emit_hit(session_id, key, cached, merged_opts)
-        return cached.value
-      }
-      let started_ms = monotonic_ms()
-      let result = __safe_invoke(next, call)
-      let compute_ms = monotonic_ms() - started_ms
-      if __llm_handler_should_store_result(result) {
-        cache_put(key, result, cache_options)
-        __with_cache_emit_miss(session_id, key, cached, compute_ms)
-      }
-      return result
+      let session_id = to_string(call?.turn?.session_id ?? merged_opts?.session_id ?? "")
+      return __with_cache_run(
+        call?.prompt,
+        call?.system,
+        merged_opts,
+        session_id,
+        fn() { return __safe_invoke(next, call) },
+        __llm_handler_should_store_result,
+      )
     }
   }
   let prompt = first
   let system = second
   let opts = third ?? {}
+  let session_id = to_string(opts?.session_id ?? "")
+  return __with_cache_run(
+    prompt,
+    system,
+    opts,
+    session_id,
+    fn() { return llm_call(prompt, system, opts) },
+    fn(result) { return __llm_handler_should_store_direct_result(result) },
+  )
+}
+
+fn __with_cache_run(prompt, system, opts, session_id, compute, should_store) {
   if __llm_handler_should_skip_cache(prompt, system, opts) {
-    return llm_call(prompt, system, opts)
+    return compute()
   }
   let key = llm_cache_key(prompt, system, opts)
   let cache_options = __llm_handler_cache_options(opts)
   let cached = cache_get(key, cache_options)
   if cached.hit {
+    __with_cache_emit_hit(session_id, key, cached, opts)
     return cached.value
   }
-  let result = llm_call(prompt, system, opts)
-  cache_put(key, result, cache_options)
+  let started_ms = monotonic_ms()
+  let result = compute()
+  let compute_ms = monotonic_ms() - started_ms
+  if should_store(result) {
+    cache_put(key, result, cache_options)
+    __with_cache_emit_miss(session_id, key, cached, compute_ms)
+  }
   return result
 }
 
-fn __llm_handler_should_store_result(result) -> bool {
+fn __llm_handler_should_store_direct_result(result) -> bool {
+  // Direct-call form returns the raw llm_call envelope; cache anything
+  // that is not an error envelope (i.e. has no `status` field).
   if type_of(result) != "dict" {
     return false
   }
+  return !contains(result.keys(), "status")
+}
+
+fn __llm_handler_should_store_result(result) -> bool {
   // The caller seam returns `{ok: true, value}` on success and
   // `{ok: false, status: ...}` on failure. Only cache successes; failure
   // envelopes are transient retry state, not durable answers.
-  let keys = result.keys()
-  if contains(keys, "ok") {
-    return result?.ok ?? false
+  if type_of(result) != "dict" {
+    return false
   }
-  // Pre-existing direct-call shape: cache anything that is not an error
-  // envelope (i.e. has no `status` field).
-  return !contains(keys, "status")
+  return result?.ok ?? false
 }
 
 fn __with_cache_hit_metrics_from_envelope(cached_value) -> dict {
@@ -776,7 +799,7 @@ fn __with_cache_emit_hit(session_id, key, cached, opts) {
   }
   __emit_event(
     session_id,
-    "cache.hit",
+    "cache_hit",
     {
       key: key,
       backend: cached?.backend ?? "",
@@ -794,7 +817,7 @@ fn __with_cache_emit_miss(session_id, key, cached, compute_ms) {
   }
   __emit_event(
     session_id,
-    "cache.miss",
+    "cache_miss",
     {
       key: key,
       backend: cached?.backend ?? "",

--- a/crates/harn-stdlib/src/stdlib/stdlib_cache.harn
+++ b/crates/harn-stdlib/src/stdlib/stdlib_cache.harn
@@ -135,7 +135,7 @@ fn __cache_store_dict(backend, path, opts) -> dict {
  *                     site (most callers should set these on the store
  *                     constructor instead).
  *   - session_id    : optional string. When set, cache hits and misses emit
- *                     `cache.hit` / `cache.miss` events on the agent event
+ *                     `cache_hit` / `cache_miss` events on the agent event
  *                     tape (replay-deterministic; testbench can pin them).
  *   - estimate      : optional dict with cost-moat receipts shown on hit:
  *                     {model_calls_avoided?: int, tokens_saved?: int,
@@ -168,7 +168,7 @@ pub fn with_cache_envelope(key: string, compute, options = nil) -> dict {
     if session_id != "" {
       __with_cache_emit(
         session_id,
-        "cache.hit",
+        "cache_hit",
         {key: key, backend: cached?.backend ?? "", namespace: cached?.namespace ?? "", metrics: metrics},
       )
     }
@@ -181,7 +181,7 @@ pub fn with_cache_envelope(key: string, compute, options = nil) -> dict {
   if session_id != "" {
     __with_cache_emit(
       session_id,
-      "cache.miss",
+      "cache_miss",
       {
         key: key,
         backend: cached?.backend ?? "",

--- a/crates/harn-vm/src/agent_events.rs
+++ b/crates/harn-vm/src/agent_events.rs
@@ -582,6 +582,32 @@ pub enum AgentEvent {
         tool_name: String,
         audit: serde_json::Value,
     },
+    /// Emitted by `std/cache::with_cache` (both the generic and LLM
+    /// forms) when a cached lookup returns a hit. Carries the
+    /// content-addressed key, the backend that served the value, and a
+    /// `metrics` block with the cost-moat receipts the persona value
+    /// ledger (harn-cloud#58) and crystallization receipts read:
+    /// `model_calls_avoided`, plus `tokens_saved` / `latency_saved_ms`
+    /// when the cached envelope carried `usage` / `latency_ms`.
+    CacheHit {
+        session_id: String,
+        key: String,
+        backend: String,
+        namespace: String,
+        payload: serde_json::Value,
+    },
+    /// Paired with `CacheHit`. Emitted on the miss path when the
+    /// fresh result is stored. `payload.metrics.compute_ms` carries
+    /// the wall-clock cost of the underlying computation, which
+    /// callers can feed back as `estimate.latency_saved_ms` on the
+    /// next hit.
+    CacheMiss {
+        session_id: String,
+        key: String,
+        backend: String,
+        namespace: String,
+        payload: serde_json::Value,
+    },
 }
 
 impl AgentEvent {
@@ -613,7 +639,9 @@ impl AgentEvent {
             | Self::HitlResolved { session_id, .. }
             | Self::LoopControlDecision { session_id, .. }
             | Self::AgentLoopStallWarning { session_id, .. }
-            | Self::ToolCallAudit { session_id, .. } => session_id,
+            | Self::ToolCallAudit { session_id, .. }
+            | Self::CacheHit { session_id, .. }
+            | Self::CacheMiss { session_id, .. } => session_id,
         }
     }
 }

--- a/crates/harn-vm/src/llm/agent_session_host.rs
+++ b/crates/harn-vm/src/llm/agent_session_host.rs
@@ -1200,6 +1200,20 @@ fn build_agent_event(
                 .cloned()
                 .unwrap_or(serde_json::Value::Null),
         }),
+        "cache_hit" => Ok(AgentEvent::CacheHit {
+            session_id: session_id.to_string(),
+            key: get_string("key"),
+            backend: get_string("backend"),
+            namespace: get_string("namespace"),
+            payload: payload.clone(),
+        }),
+        "cache_miss" => Ok(AgentEvent::CacheMiss {
+            session_id: session_id.to_string(),
+            key: get_string("key"),
+            backend: get_string("backend"),
+            namespace: get_string("namespace"),
+            payload: payload.clone(),
+        }),
         other => Err(VmError::Runtime(format!(
             "{HOST_AGENT_EMIT_EVENT}: unsupported event type `{other}`"
         ))),

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -2216,10 +2216,10 @@ Common options: `namespace`, `ttl` (string like `"10m"`) or `ttl_seconds`,
 it into `compose([...])` to deduplicate identical `(prompt, system, opts)`
 LLM calls. Tool-bearing calls bypass the cache by default.
 
-On a cache hit with `options.session_id` set, the wrapper emits
-`cache.hit` + receipts (`model_calls_avoided`, `tokens_saved`,
-`latency_saved_ms`) on the agent event tape. The persona value ledger
-and crystallization receipts read these back.
+On a cache hit with `options.session_id` set, both the caller-wrapper
+and direct-call forms emit `cache_hit` + receipts (`model_calls_avoided`,
+`tokens_saved`, `latency_saved_ms`) on the agent event tape. The persona
+value ledger and crystallization receipts read these back.
 
 Full reference: [`docs/src/stdlib/cache.md`](https://harnlang.com/docs/stdlib/cache.html).
 

--- a/docs/src/stdlib/cache.md
+++ b/docs/src/stdlib/cache.md
@@ -63,8 +63,8 @@ receipts. The metrics dict carries `{compute_ms}` on misses and (by
 default) `{model_calls_avoided: 1}` on hits — pass `options.estimate`
 to enrich the hit receipts with `tokens_saved` and `latency_saved_ms`.
 
-When `options.session_id` is set, `with_cache` emits `cache.hit` and
-`cache.miss` events on the agent event tape. The tape is the
+When `options.session_id` is set, `with_cache` emits `cache_hit` and
+`cache_miss` events on the agent event tape. The tape is the
 record/replay surface for crystallization shadow runs and persona value
 ledgers — cached calls show up there as durable receipts instead of
 ghosting through unobserved.
@@ -143,7 +143,7 @@ let fixture = with_cache("trace:" + trace_id, fn() {
 ```
 
 Because the session_id is set, the shadow run's tape captures the
-`cache.hit` events for every replay — the crystallization receipts and
+`cache_hit` events for every replay — the crystallization receipts and
 persona value ledger read them back to show "model calls avoided" in
 the demo from the [Moat Addendum: Workflow Crystallization](https://www.notion.so/34a7d224c63281fcbc13cf390981b01b).
 
@@ -152,7 +152,7 @@ the demo from the [Moat Addendum: Workflow Crystallization](https://www.notion.s
 Cached calls are deterministic. The cache key is a sha256 of the
 canonical-JSON-sorted identity for the call, and the cached value is
 the verbatim envelope from the original miss. Replaying a recorded
-tape that contains `cache.hit` events does not touch the underlying
+tape that contains `cache_hit` events does not touch the underlying
 model or filesystem — the cached value is returned byte-identical.
 TTL expiry honors the unified clock (`mock_time` / `advance_time`), so
 testbench fixtures can reproduce expiry windows without wall-clock


### PR DESCRIPTION
## Summary

Polish follow-up to [#1483](https://github.com/burin-labs/harn/pull/1483). PR #1483 emitted `cache.hit` / `cache.miss` events through `agent_emit_event`, but the host's `build_agent_event` didn't recognize those names — it returned `unsupported event type`, which the wrapper's surrounding `try { ... }` silently swallowed. The cost-moat receipts ("model calls avoided", "tokens saved", "latency saved") that the persona value ledger and crystallization receipts are supposed to read off the tape never actually landed on the tape.

- **Promote `CacheHit` / `CacheMiss` to first-class `AgentEvent` variants.** `build_agent_event` accepts the wire names `cache_hit` / `cache_miss` (snake_case, matching every other event variant — the prior dot-separated form was an outlier), and the ACP adapter forwards them as `cache_hit` / `cache_miss` session-update extensions for hosts that care to render them.
- **Wire the direct-call `with_cache(prompt, system, opts)` form** to emit `cache_hit`/`cache_miss` when `opts.session_id` is set. Previously only the caller-wrapper form did, leaving one-shot callers silently ungoverned. Both forms now share `__with_cache_run`.
- **Tighten `__llm_handler_cache_options`** to omit nil keys instead of passing `{backend: nil, namespace: nil, ...}` through to the Rust parser on every call.
- **Drop the pre-existing `__llm_handler_should_store_result` fallback** that accepted both `{ok}` and `{status}` shapes (predates the unified caller contract); add a separate `__llm_handler_should_store_direct_result` for the raw `llm_call` envelope.
- **Add `conformance/tests/integration/cache_event_receipts.harn`** — uses `agent_subscribe` to capture `cache_hit` / `cache_miss` off the tape and assert `model_calls_avoided` + `tokens_saved` carry the right values. Extend `with_cache_caller_replay.harn` to actually verify what its docstring already claimed (events on the tape, not just byte-identical replay).

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo clippy -p harn-vm -p harn-serve --all-targets`
- [x] `cargo test -p harn-vm -p harn-serve`
- [x] `cargo run --bin harn -- test conformance --filter cache` (9 passed, including new test)
- [x] `cargo run --bin harn -- test conformance` (969 passed)
- [x] `make check-docs-snippets`
- [x] `make check-highlight`
- [x] `make lint-test-patterns`
- [x] `make lint-md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)