### PR TITLE
Add local persona supervision tail

### DIFF
--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -78,9 +78,16 @@ jobs:
           cache-on-failure: true
       - name: Build release harn binary
         shell: bash
+        env:
+          # Match build-release-binaries.yml. Fat LTO makes this smoke gate
+          # spend most of its wall time in a link step that is not meaningfully
+          # cacheable, while published release binaries already use thin LTO.
+          CARGO_PROFILE_RELEASE_LTO: thin
         run: cargo build --release -p harn-cli --bin harn
       - name: Run release smoke
         shell: bash
+        timeout-minutes: 10
         env:
           HARN_BINARY: ${{ matrix.harn_binary }}
+          HARN_RELEASE_SMOKE_STEP_TIMEOUT_SECONDS: "120"
         run: ./scripts/release_smoke.sh

--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,7 @@ release-gate:
 # you only get the host platform, but the driver still exercises every
 # user-visible capability and prints a per-step status summary.
 release-smoke:
-	cargo build --release -p harn-cli --bin harn
+	CARGO_PROFILE_RELEASE_LTO=thin cargo build --release -p harn-cli --bin harn
 	./scripts/release_smoke.sh
 
 # Faster `release-smoke` variant that reuses the debug `harn` binary.

--- a/crates/harn-cli/src/cli/mod.rs
+++ b/crates/harn-cli/src/cli/mod.rs
@@ -111,7 +111,8 @@ pub(crate) use package::{
 pub(crate) use persona::{
     PersonaArgs, PersonaCheckArgs, PersonaCommand, PersonaControlArgs, PersonaDoctorArgs,
     PersonaInspectArgs, PersonaListArgs, PersonaNewArgs, PersonaSpendArgs, PersonaStatusArgs,
-    PersonaTemplateKind, PersonaTickArgs, PersonaTriggerArgs,
+    PersonaSupervisionCommand, PersonaSupervisionTailArgs, PersonaTemplateKind, PersonaTickArgs,
+    PersonaTriggerArgs,
 };
 pub(crate) use playground::PlaygroundArgs;
 pub(crate) use portal::PortalArgs;

--- a/crates/harn-cli/src/cli/persona.rs
+++ b/crates/harn-cli/src/cli/persona.rs
@@ -47,6 +47,8 @@ pub(crate) enum PersonaCommand {
     Trigger(PersonaTriggerArgs),
     /// Record an expensive-work budget receipt for a persona.
     Spend(PersonaSpendArgs),
+    /// Stream the local universal persona supervision feed.
+    Supervision(PersonaSupervisionArgs),
 }
 
 #[derive(Debug, Args)]
@@ -212,4 +214,38 @@ pub(crate) struct PersonaSpendArgs {
     /// Emit stable JSON.
     #[arg(long)]
     pub json: bool,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct PersonaSupervisionArgs {
+    #[command(subcommand)]
+    pub command: PersonaSupervisionCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum PersonaSupervisionCommand {
+    /// Emit local persona/update frames as newline-delimited JSON.
+    Tail(PersonaSupervisionTailArgs),
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct PersonaSupervisionTailArgs {
+    /// Persona name to stream. When omitted, streams every persona in the local state directory.
+    #[arg(long)]
+    pub persona: Option<String>,
+    /// Replay events strictly after this event-log cursor.
+    #[arg(long, value_name = "N")]
+    pub since_event_id: Option<u64>,
+    /// RFC3339 timestamp accepted for deterministic harness parity.
+    #[arg(long, value_name = "RFC3339")]
+    pub at: Option<String>,
+    /// Keep waiting for new events after the current backlog drains.
+    #[arg(long)]
+    pub follow: bool,
+    /// Accepted for host symmetry; output is always newline-delimited JSON.
+    #[arg(long)]
+    pub json: bool,
+    /// Maximum number of emitted supervision frames.
+    #[arg(long, value_name = "N")]
+    pub limit: Option<usize>,
 }

--- a/crates/harn-cli/src/commands/mod.rs
+++ b/crates/harn-cli/src/commands/mod.rs
@@ -21,6 +21,7 @@ pub mod orchestrator;
 pub mod persona;
 pub mod persona_doctor;
 pub mod persona_scaffold;
+pub mod persona_supervision;
 pub mod playground;
 pub(crate) mod portal;
 pub(crate) mod protocol_conformance;

--- a/crates/harn-cli/src/commands/persona.rs
+++ b/crates/harn-cli/src/commands/persona.rs
@@ -495,13 +495,7 @@ fn load_catalog_or_exit(manifest: Option<&Path>) -> ResolvedPersonaManifest {
 }
 
 fn load_catalog_result(manifest: Option<&Path>) -> Result<ResolvedPersonaManifest, String> {
-    load_catalog_validation(manifest).map_err(|errors| {
-        errors
-            .iter()
-            .map(ToString::to_string)
-            .collect::<Vec<_>>()
-            .join("\n")
-    })
+    load_catalog_validation(manifest).map_err(|errors| validation_errors_to_string(&errors))
 }
 
 fn load_catalog_validation(
@@ -522,6 +516,14 @@ fn load_catalog_validation(
         }]),
         Err(errors) => Err(errors),
     }
+}
+
+fn validation_errors_to_string(errors: &[PersonaValidationError]) -> String {
+    errors
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 fn runtime_binding_or_err(
@@ -571,7 +573,7 @@ fn persona_template_ref(persona: &PersonaManifestEntry) -> Option<String> {
         })
 }
 
-fn open_persona_log(state_dir: &Path) -> Result<Arc<AnyEventLog>, String> {
+pub(super) fn open_persona_log(state_dir: &Path) -> Result<Arc<AnyEventLog>, String> {
     let state_dir = absolutize_from_cwd(state_dir)?;
     std::fs::create_dir_all(&state_dir).map_err(|error| {
         format!(
@@ -592,7 +594,7 @@ fn absolutize_from_cwd(path: &Path) -> Result<PathBuf, String> {
         .map_err(|error| format!("failed to read current directory: {error}"))
 }
 
-fn timestamp_arg(value: Option<&str>) -> Result<i64, String> {
+pub(super) fn timestamp_arg(value: Option<&str>) -> Result<i64, String> {
     match value {
         Some(value) => harn_vm::parse_persona_ms(value),
         None => Ok(harn_vm::persona_now_ms()),

--- a/crates/harn-cli/src/commands/persona_supervision.rs
+++ b/crates/harn-cli/src/commands/persona_supervision.rs
@@ -1,0 +1,435 @@
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use harn_vm::event_log::{AnyEventLog, EventId, EventLog, LogEvent, Topic};
+use serde::Serialize;
+
+use crate::cli::PersonaSupervisionTailArgs;
+use crate::package::{self, PersonaValidationError, ResolvedPersonaManifest};
+
+use super::persona::{open_persona_log, timestamp_arg};
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct PersonaSupervisionTailFrame {
+    pub event_id: EventId,
+    pub persona_id: String,
+    pub persona_kind: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub persona_version: Option<String>,
+    pub actor: String,
+    pub update_kind: String,
+    pub occurred_at: String,
+    pub payload: serde_json::Value,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct PersonaSupervisionTailOptions {
+    pub persona: Option<String>,
+    pub since_event_id: Option<EventId>,
+    pub at: Option<String>,
+    pub follow: bool,
+    pub limit: Option<usize>,
+}
+
+impl From<&PersonaSupervisionTailArgs> for PersonaSupervisionTailOptions {
+    fn from(args: &PersonaSupervisionTailArgs) -> Self {
+        Self {
+            persona: args.persona.clone(),
+            since_event_id: args.since_event_id,
+            at: args.at.clone(),
+            follow: args.follow,
+            limit: args.limit,
+        }
+    }
+}
+
+/// In-process variant of `harn persona supervision tail` for finite reads.
+pub async fn tail_payload(
+    manifest: Option<&Path>,
+    state_dir: &Path,
+    options: &PersonaSupervisionTailOptions,
+) -> Result<Vec<PersonaSupervisionTailFrame>, String> {
+    validate_tail_options(options)?;
+    let catalog = load_catalog_for_tail(manifest)?;
+    let log = open_persona_log(state_dir)?;
+    let topic = persona_runtime_topic()?;
+    let mut cursor = options.since_event_id;
+    let mut remaining = options.limit;
+    read_supervision_frames(
+        &log,
+        &topic,
+        &catalog,
+        options.persona.as_deref(),
+        &mut cursor,
+        &mut remaining,
+    )
+    .await
+}
+
+pub(crate) async fn run_tail(
+    manifest: Option<&Path>,
+    state_dir: &Path,
+    args: &PersonaSupervisionTailArgs,
+) -> Result<(), String> {
+    let options = PersonaSupervisionTailOptions::from(args);
+    validate_tail_options(&options)?;
+    let catalog = load_catalog_for_tail(manifest)?;
+    let log = open_persona_log(state_dir)?;
+    let topic = persona_runtime_topic()?;
+    let mut cursor = options.since_event_id;
+    let mut remaining = options.limit;
+    let mut waiter = EventLogChangeWaiter::new(log.describe().location);
+    let stdout = std::io::stdout();
+    let mut stdout = stdout.lock();
+
+    loop {
+        let frames = read_supervision_frames(
+            &log,
+            &topic,
+            &catalog,
+            options.persona.as_deref(),
+            &mut cursor,
+            &mut remaining,
+        )
+        .await?;
+        for frame in frames {
+            let line = serde_json::to_string(&frame)
+                .map_err(|error| format!("failed to serialize supervision frame: {error}"))?;
+            writeln!(stdout, "{line}")
+                .map_err(|error| format!("failed to write supervision frame: {error}"))?;
+        }
+        stdout
+            .flush()
+            .map_err(|error| format!("failed to flush supervision stream: {error}"))?;
+
+        if remaining == Some(0) || !options.follow {
+            return Ok(());
+        }
+        waiter.wait().await;
+    }
+}
+
+fn load_catalog_for_tail(
+    manifest: Option<&Path>,
+) -> Result<Option<ResolvedPersonaManifest>, String> {
+    if let Some(path) = manifest {
+        return package::load_personas_from_manifest_path(path)
+            .map(Some)
+            .map_err(|errors| validation_errors_to_string(&errors));
+    }
+    package::load_personas_config(None).map_err(|errors| validation_errors_to_string(&errors))
+}
+
+fn validation_errors_to_string(errors: &[PersonaValidationError]) -> String {
+    errors
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn validate_tail_options(options: &PersonaSupervisionTailOptions) -> Result<(), String> {
+    if let Some(at) = options.at.as_deref() {
+        let _ = timestamp_arg(Some(at))?;
+    }
+    Ok(())
+}
+
+async fn read_supervision_frames(
+    log: &Arc<AnyEventLog>,
+    topic: &Topic,
+    catalog: &Option<ResolvedPersonaManifest>,
+    persona_filter: Option<&str>,
+    cursor: &mut Option<EventId>,
+    remaining: &mut Option<usize>,
+) -> Result<Vec<PersonaSupervisionTailFrame>, String> {
+    if remaining.as_ref() == Some(&0) {
+        return Ok(Vec::new());
+    }
+
+    let raw_events = log
+        .read_range(topic, *cursor, usize::MAX)
+        .await
+        .map_err(|error| error.to_string())?;
+    let mut frames = Vec::new();
+    for (event_id, event) in raw_events {
+        *cursor = Some(event_id);
+        if let Some(frame) = supervision_frame_from_event(event_id, event, catalog, persona_filter)?
+        {
+            frames.push(frame);
+            if let Some(left) = remaining.as_mut() {
+                *left = left.saturating_sub(1);
+                if *left == 0 {
+                    break;
+                }
+            }
+        }
+    }
+    Ok(frames)
+}
+
+fn supervision_frame_from_event(
+    event_id: EventId,
+    event: LogEvent,
+    catalog: &Option<ResolvedPersonaManifest>,
+    persona_filter: Option<&str>,
+) -> Result<Option<PersonaSupervisionTailFrame>, String> {
+    let persona = event
+        .headers
+        .get("persona")
+        .cloned()
+        .or_else(|| {
+            event
+                .payload
+                .get("persona_id")
+                .and_then(serde_json::Value::as_str)
+                .map(ToString::to_string)
+        })
+        .or_else(|| {
+            event
+                .payload
+                .get("persona")
+                .and_then(serde_json::Value::as_str)
+                .map(ToString::to_string)
+        });
+    let Some(persona) = persona else {
+        return Ok(None);
+    };
+    if persona_filter.is_some_and(|filter| filter != persona) {
+        return Ok(None);
+    }
+
+    match event.kind.as_str() {
+        kind if kind.starts_with("persona.supervision.") => {
+            let update: harn_vm::PersonaSupervisionEvent = serde_json::from_value(event.payload)
+                .map_err(|error| {
+                    format!(
+                        "failed to decode persisted persona supervision event {event_id}: {error}"
+                    )
+                })?;
+            let persona_id = update.persona_id().to_string();
+            if persona_filter.is_some_and(|filter| filter != persona_id) {
+                return Ok(None);
+            }
+            let metadata = persona_metadata(catalog, &persona_id, update.template_ref());
+            let frame = PersonaSupervisionTailFrame {
+                event_id,
+                persona_id,
+                persona_kind: metadata.kind,
+                persona_version: metadata.version,
+                actor: "runtime".to_string(),
+                update_kind: update.update_kind().to_string(),
+                occurred_at: harn_vm::format_persona_ms(update.occurred_at_ms()),
+                payload: supervision_update_payload(update)?,
+            };
+            Ok(Some(frame))
+        }
+        "persona.control.paused" | "persona.control.resumed" | "persona.control.disabled" => {
+            let action = match event.kind.as_str() {
+                "persona.control.paused" => "pause",
+                "persona.control.resumed" => "resume",
+                "persona.control.disabled" => "disable",
+                _ => unreachable!("control event kind was matched above"),
+            };
+            let metadata = persona_metadata(catalog, &persona, None);
+            Ok(Some(PersonaSupervisionTailFrame {
+                event_id,
+                persona_id: persona,
+                persona_kind: metadata.kind,
+                persona_version: metadata.version,
+                actor: "runtime".to_string(),
+                update_kind: "control".to_string(),
+                occurred_at: harn_vm::format_persona_ms(event.occurred_at_ms),
+                payload: serde_json::json!({
+                    "action": action,
+                    "metadata": event.payload,
+                }),
+            }))
+        }
+        "persona.trigger.queued" => {
+            let Some(payload) = handoff_payload_from_queued_event(&event)? else {
+                return Ok(None);
+            };
+            let metadata = persona_metadata(catalog, &persona, None);
+            Ok(Some(PersonaSupervisionTailFrame {
+                event_id,
+                persona_id: persona,
+                persona_kind: metadata.kind,
+                persona_version: metadata.version,
+                actor: "runtime".to_string(),
+                update_kind: "handoff".to_string(),
+                occurred_at: harn_vm::format_persona_ms(event.occurred_at_ms),
+                payload,
+            }))
+        }
+        _ => Ok(None),
+    }
+}
+
+fn supervision_update_payload(
+    update: harn_vm::PersonaSupervisionEvent,
+) -> Result<serde_json::Value, String> {
+    match update {
+        harn_vm::PersonaSupervisionEvent::QueuePosition(update) => Ok(serde_json::json!({
+            "work_key": update.work_key,
+            "queue_depth": update.queue_depth,
+            "position": update.position,
+            "queued_at_ms": update.queued_at_ms,
+            "queued_at": harn_vm::format_persona_ms(update.queued_at_ms),
+        })),
+        harn_vm::PersonaSupervisionEvent::RepairWorkerStatus(update) => Ok(serde_json::json!({
+            "repair_worker_id": update.repair_worker_id,
+            "lifecycle": update.lifecycle.as_str(),
+            "work_key": update.work_key,
+            "lease_id": update.lease_id,
+            "scratchpad_url": update.scratchpad_url,
+            "last_heartbeat_ms": update.last_heartbeat_ms,
+            "last_heartbeat_at": harn_vm::format_persona_ms(update.last_heartbeat_ms),
+        })),
+        harn_vm::PersonaSupervisionEvent::Receipt(update) => {
+            serde_json::to_value(update.receipt).map_err(|error| error.to_string())
+        }
+        harn_vm::PersonaSupervisionEvent::Checkpoint(update) => Ok(serde_json::json!({
+            "action": update.action.as_str(),
+            "checkpoint_id": update.checkpoint_id,
+            "work_key": update.work_key,
+            "resumed_from": update.resumed_from,
+        })),
+    }
+}
+
+fn handoff_payload_from_queued_event(
+    event: &LogEvent,
+) -> Result<Option<serde_json::Value>, String> {
+    let Some(envelope) = event.payload.get("envelope") else {
+        return Ok(None);
+    };
+    let envelope: harn_vm::PersonaTriggerEnvelope =
+        serde_json::from_value(envelope.clone()).map_err(|error| error.to_string())?;
+    if envelope.provider != "handoff" && !envelope.metadata.contains_key("handoff_id") {
+        return Ok(None);
+    }
+    Ok(Some(serde_json::json!({
+        "status": "queued",
+        "work_key": envelope.subject_key,
+        "handoff_id": envelope.metadata.get("handoff_id"),
+        "handoff_kind": envelope
+            .metadata
+            .get("handoff_kind")
+            .or_else(|| envelope.metadata.get("kind")),
+        "source_persona": envelope.metadata.get("source_persona"),
+        "task": envelope.metadata.get("task"),
+        "reason": event
+            .payload
+            .get("reason")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("queued"),
+        "queued_at": harn_vm::format_persona_ms(event.occurred_at_ms),
+    })))
+}
+
+struct PersonaProjectionMetadata {
+    kind: String,
+    version: Option<String>,
+}
+
+fn persona_metadata(
+    catalog: &Option<ResolvedPersonaManifest>,
+    persona_id: &str,
+    template_ref: Option<&str>,
+) -> PersonaProjectionMetadata {
+    if let Some(persona) = catalog.as_ref().and_then(|catalog| {
+        catalog
+            .personas
+            .iter()
+            .find(|persona| persona.name.as_deref() == Some(persona_id))
+    }) {
+        return PersonaProjectionMetadata {
+            kind: persona
+                .name
+                .clone()
+                .unwrap_or_else(|| persona_id.to_string()),
+            version: persona.version.clone(),
+        };
+    }
+    PersonaProjectionMetadata {
+        kind: persona_id.to_string(),
+        version: template_ref.and_then(version_from_template_ref),
+    }
+}
+
+fn version_from_template_ref(template_ref: &str) -> Option<String> {
+    let (_, version) = template_ref.rsplit_once('@')?;
+    if version.trim().is_empty() {
+        None
+    } else {
+        Some(version.to_string())
+    }
+}
+
+fn persona_runtime_topic() -> Result<Topic, String> {
+    Topic::new(harn_vm::PERSONA_RUNTIME_TOPIC).map_err(|error| error.to_string())
+}
+
+struct EventLogChangeWaiter {
+    rx: Option<tokio::sync::mpsc::UnboundedReceiver<()>>,
+    _watcher: Option<notify::RecommendedWatcher>,
+}
+
+impl EventLogChangeWaiter {
+    fn new(location: Option<PathBuf>) -> Self {
+        let Some(location) = location else {
+            return Self::polling();
+        };
+        let watch_path = if location.is_dir() {
+            location
+        } else if let Some(parent) = location.parent() {
+            parent.to_path_buf()
+        } else {
+            location
+        };
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let watcher = notify::recommended_watcher(move |result: notify::Result<notify::Event>| {
+            if result.is_ok() {
+                let _ = tx.send(());
+            }
+        });
+        let Ok(mut watcher) = watcher else {
+            return Self::polling();
+        };
+        {
+            use notify::Watcher as _;
+            if watcher
+                .watch(&watch_path, notify::RecursiveMode::NonRecursive)
+                .is_err()
+            {
+                return Self::polling();
+            }
+        }
+        Self {
+            rx: Some(rx),
+            _watcher: Some(watcher),
+        }
+    }
+
+    fn polling() -> Self {
+        Self {
+            rx: None,
+            _watcher: None,
+        }
+    }
+
+    async fn wait(&mut self) {
+        let Some(rx) = self.rx.as_mut() else {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            return;
+        };
+        tokio::select! {
+            _ = rx.recv() => {}
+            _ = tokio::time::sleep(Duration::from_millis(250)) => {}
+        }
+        while rx.try_recv().is_ok() {}
+    }
+}

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -21,8 +21,9 @@ use std::{env, fs, process, thread};
 
 use cli::{
     Cli, Command, CompletionShell, MergeCaptainCommand, MergeCaptainMockCommand, ModelInfoArgs,
-    PackageArtifactsCommand, PackageCacheCommand, PackageCommand, PersonaCommand, RunsCommand,
-    ServeCommand, SkillCommand, SkillKeyCommand, SkillTrustCommand, SkillsCommand,
+    PackageArtifactsCommand, PackageCacheCommand, PackageCommand, PersonaCommand,
+    PersonaSupervisionCommand, RunsCommand, ServeCommand, SkillCommand, SkillKeyCommand,
+    SkillTrustCommand, SkillsCommand,
 };
 use harn_lexer::Lexer;
 use harn_parser::{DiagnosticSeverity, Parser, TypeChecker};
@@ -984,6 +985,20 @@ async fn async_main() {
                     process::exit(1);
                 }
             }
+            PersonaCommand::Supervision(supervision) => match supervision.command {
+                PersonaSupervisionCommand::Tail(tail) => {
+                    if let Err(error) = commands::persona_supervision::run_tail(
+                        args.manifest.as_deref(),
+                        &args.state_dir,
+                        &tail,
+                    )
+                    .await
+                    {
+                        eprintln!("error: {error}");
+                        process::exit(1);
+                    }
+                }
+            },
         },
         Command::ModelInfo(args) => {
             if !print_model_info(&args).await {

--- a/crates/harn-cli/tests/persona_cli.rs
+++ b/crates/harn-cli/tests/persona_cli.rs
@@ -7,11 +7,16 @@
 //! and asserts on the returned struct/JSON value rather than parsing
 //! subprocess stdout.
 
+use std::collections::BTreeSet;
 use std::fs;
 use std::path::Path;
+use std::process::Stdio;
+use std::time::Duration;
 
-use harn_cli::commands::{persona, persona_doctor, persona_scaffold};
+use harn_cli::commands::{persona, persona_doctor, persona_scaffold, persona_supervision};
+use harn_vm::event_log::EventLog as _;
 use tempfile::TempDir;
+use tokio::io::{AsyncBufReadExt, BufReader};
 
 fn write_manifest(body: &str) -> TempDir {
     let temp = TempDir::new().unwrap();
@@ -68,6 +73,25 @@ capabilities = ["interaction.ask"]
 autonomy_tier = "act_with_approval"
 receipt_policy = "required"
 "#
+}
+
+fn versioned_manifest() -> String {
+    valid_manifest()
+        .replacen(
+            "name = \"merge_captain\"",
+            "name = \"merge_captain\"\nversion = \"1.4.0\"",
+            1,
+        )
+        .replacen(
+            "name = \"review_captain\"",
+            "name = \"review_captain\"\nversion = \"1.1.0\"",
+            1,
+        )
+        .replacen(
+            "name = \"oncall_captain\"",
+            "name = \"oncall_captain\"\nversion = \"0.9.1\"",
+            1,
+        )
 }
 
 #[test]
@@ -512,6 +536,264 @@ async fn persona_pause_resume_disable_trigger_controls_are_durable() {
     .await
     .expect("trigger while disabled");
     assert_eq!(receipt.status, "dead_lettered");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn persona_supervision_tail_projects_multiplexed_ndjson_contract() {
+    let temp = write_manifest(&versioned_manifest());
+    let manifest = manifest_path(&temp);
+    let state_dir = temp.path().join(".harn-personas-test");
+
+    let _ = persona::pause_payload(
+        Some(&manifest),
+        &state_dir,
+        "merge_captain",
+        Some("2026-05-10T14:00:00Z"),
+    )
+    .await
+    .expect("pause merge captain");
+    let _ = persona::trigger_payload(
+        Some(&manifest),
+        &state_dir,
+        "merge_captain",
+        "github",
+        "pull_request",
+        &[
+            "repository=burin-labs/harn".to_string(),
+            "number=1490".to_string(),
+        ],
+        Some("2026-05-10T14:00:01Z"),
+        0.0,
+        0,
+    )
+    .await
+    .expect("queue github work");
+    let _ = persona::trigger_payload(
+        Some(&manifest),
+        &state_dir,
+        "merge_captain",
+        "handoff",
+        "review",
+        &[
+            "dedupe_key=handoff-1490".to_string(),
+            "handoff_id=handoff-1490".to_string(),
+            "handoff_kind=review_request".to_string(),
+            "source_persona=oncall_captain".to_string(),
+            "task=Review issue 1490 tail output".to_string(),
+        ],
+        Some("2026-05-10T14:00:02Z"),
+        0.0,
+        0,
+    )
+    .await
+    .expect("queue handoff");
+    let _ = persona::resume_payload(
+        Some(&manifest),
+        &state_dir,
+        "merge_captain",
+        Some("2026-05-10T14:00:03Z"),
+    )
+    .await
+    .expect("resume merge captain");
+    let _ = persona::tick_payload(
+        Some(&manifest),
+        &state_dir,
+        "oncall_captain",
+        Some("2026-05-10T14:00:04Z"),
+        0.0,
+        0,
+    )
+    .await
+    .expect("tick oncall captain");
+
+    let log = harn_vm::event_log::install_default_for_base_dir(&state_dir)
+        .expect("open persona event log");
+    let merge_binding = harn_vm::PersonaRuntimeBinding {
+        name: "merge_captain".to_string(),
+        template_ref: Some("merge_captain@1.4.0".to_string()),
+        entry_workflow: "workflows/merge.harn#run".to_string(),
+        schedules: Vec::new(),
+        triggers: Vec::new(),
+        budget: harn_vm::PersonaBudgetPolicy::default(),
+    };
+    let _ = harn_vm::report_repair_worker_status(
+        &log,
+        &merge_binding,
+        harn_vm::PersonaRepairWorkerStatusUpdate {
+            persona_id: String::new(),
+            template_ref: None,
+            repair_worker_id: "rw_1490".to_string(),
+            lifecycle: harn_vm::PersonaRepairWorkerLifecycle::Running,
+            work_key: Some("github:burin-labs/harn:pr:1490".to_string()),
+            lease_id: Some("persona_lease_1490".to_string()),
+            scratchpad_url: Some("file:///tmp/rw_1490".to_string()),
+            last_heartbeat_ms: 0,
+            occurred_at_ms: 0,
+        },
+        harn_vm::parse_persona_ms("2026-05-10T14:00:05Z").expect("timestamp"),
+    )
+    .await
+    .expect("repair worker status");
+    let _ = harn_vm::restore_persona_checkpoint(
+        &log,
+        &merge_binding,
+        harn_vm::PersonaCheckpointRestoreRequest {
+            checkpoint_id: "cp_1490".to_string(),
+            work_key: Some("github:burin-labs/harn:pr:1490".to_string()),
+            resumed_from: None,
+        },
+        harn_vm::parse_persona_ms("2026-05-10T14:00:06Z").expect("timestamp"),
+    )
+    .await
+    .expect("checkpoint restore ack");
+    log.flush().await.expect("flush supervision events");
+
+    let frames = persona_supervision::tail_payload(
+        Some(&manifest),
+        &state_dir,
+        &persona_supervision::PersonaSupervisionTailOptions::default(),
+    )
+    .await
+    .expect("tail supervision frames");
+    assert!(
+        frames
+            .windows(2)
+            .all(|pair| pair[0].event_id < pair[1].event_id),
+        "tail cursors must be strictly increasing: {frames:?}"
+    );
+
+    let kinds: BTreeSet<_> = frames
+        .iter()
+        .map(|frame| frame.update_kind.as_str())
+        .collect();
+    for expected in [
+        "control",
+        "queue_position",
+        "repair_worker_status",
+        "handoff",
+        "checkpoint",
+        "receipt",
+    ] {
+        assert!(
+            kinds.contains(expected),
+            "expected update_kind={expected}; saw {kinds:?}"
+        );
+    }
+    assert!(frames.iter().any(|frame| {
+        frame.persona_id == "merge_captain"
+            && frame.persona_kind == "merge_captain"
+            && frame.persona_version.as_deref() == Some("1.4.0")
+    }));
+    assert!(frames.iter().any(|frame| {
+        frame.persona_id == "oncall_captain"
+            && frame.persona_kind == "oncall_captain"
+            && frame.persona_version.as_deref() == Some("0.9.1")
+            && frame.update_kind == "receipt"
+    }));
+    assert!(frames.iter().any(|frame| {
+        frame.persona_id == "merge_captain"
+            && frame.update_kind == "repair_worker_status"
+            && frame.payload["lifecycle"] == "running"
+            && frame.payload["repair_worker_id"] == "rw_1490"
+    }));
+
+    let cursor = frames.last().expect("at least one frame").event_id;
+    let resumed = persona_supervision::tail_payload(
+        Some(&manifest),
+        &state_dir,
+        &persona_supervision::PersonaSupervisionTailOptions {
+            since_event_id: Some(cursor),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("tail after cursor");
+    assert!(
+        resumed.is_empty(),
+        "strict cursor replay yielded duplicates"
+    );
+
+    let limited = persona_supervision::tail_payload(
+        Some(&manifest),
+        &state_dir,
+        &persona_supervision::PersonaSupervisionTailOptions {
+            limit: Some(2),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("limited tail");
+    assert_eq!(limited.len(), 2);
+
+    let oncall = persona_supervision::tail_payload(
+        Some(&manifest),
+        &state_dir,
+        &persona_supervision::PersonaSupervisionTailOptions {
+            persona: Some("oncall_captain".to_string()),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("filtered tail");
+    assert!(!oncall.is_empty());
+    assert!(oncall
+        .iter()
+        .all(|frame| frame.persona_id == "oncall_captain"));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn persona_supervision_tail_follow_streams_new_events() {
+    let temp = write_manifest(valid_manifest());
+    let manifest = manifest_path(&temp);
+    let state_dir = temp.path().join(".harn-personas-test");
+
+    let mut child = tokio::process::Command::new(env!("CARGO_BIN_EXE_harn"))
+        .arg("persona")
+        .arg("--manifest")
+        .arg(&manifest)
+        .arg("--state-dir")
+        .arg(&state_dir)
+        .arg("supervision")
+        .arg("tail")
+        .arg("--persona")
+        .arg("merge_captain")
+        .arg("--follow")
+        .arg("--limit")
+        .arg("1")
+        .arg("--json")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn harn persona supervision tail");
+    let stdout = child.stdout.take().expect("tail stdout");
+    let mut lines = BufReader::new(stdout).lines();
+
+    let _ = persona::tick_payload(
+        Some(&manifest),
+        &state_dir,
+        "merge_captain",
+        Some("2026-05-10T15:00:00Z"),
+        0.0,
+        0,
+    )
+    .await
+    .expect("append followed event");
+
+    let line = tokio::time::timeout(Duration::from_secs(5), lines.next_line())
+        .await
+        .expect("tail produced a line before timeout")
+        .expect("read tail line")
+        .expect("tail line");
+    let frame: serde_json::Value = serde_json::from_str(&line).expect("tail line JSON");
+    assert_eq!(frame["persona_id"], "merge_captain");
+    assert_eq!(frame["update_kind"], "receipt");
+    assert_eq!(frame["payload"]["status"], "completed");
+
+    let status = tokio::time::timeout(Duration::from_secs(5), child.wait())
+        .await
+        .expect("tail exited after limit")
+        .expect("wait for tail");
+    assert!(status.success(), "tail exited with {status}");
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/crates/harn-vm/src/llm/cache.rs
+++ b/crates/harn-vm/src/llm/cache.rs
@@ -564,9 +564,10 @@ fn sqlite_get(
             return Ok(None);
         }
     };
+    let last_accessed_ms = next_access_ms_for(options, now_ms);
     tx.execute(
         "UPDATE cache_entries SET last_accessed_ms = ?3 WHERE namespace = ?1 AND cache_key = ?2",
-        params![&options.namespace, key, now_ms],
+        params![&options.namespace, key, last_accessed_ms],
     )
     .map_err(sqlite_error)?;
     tx.commit().map_err(sqlite_error)?;
@@ -581,7 +582,8 @@ fn sqlite_put(
 ) -> Result<(), VmError> {
     let mut conn = sqlite_connection(&options.path)?;
     let tx = conn.transaction().map_err(sqlite_error)?;
-    let record = CacheRecord::new(key, value, now_ms, options.ttl_seconds);
+    let mut record = CacheRecord::new(key, value, now_ms, options.ttl_seconds);
+    record.last_accessed_ms = next_access_ms_for(options, now_ms);
     let value_json = serde_json::to_string(&record.value).map_err(|error| {
         VmError::Runtime(format!("cache sqlite: failed to encode value: {error}"))
     })?;
@@ -688,7 +690,7 @@ fn fs_get(
         let _ = std::fs::remove_file(path);
         return Ok(None);
     }
-    record.last_accessed_ms = now_ms;
+    record.last_accessed_ms = next_access_ms_for(options, now_ms);
     write_fs_record(&path, &record)?;
     Ok(Some(record.value))
 }
@@ -700,7 +702,8 @@ fn fs_put(
     now_ms: i64,
 ) -> Result<(), VmError> {
     let path = fs_key_path(options, key);
-    let record = CacheRecord::new(key, value, now_ms, options.ttl_seconds);
+    let mut record = CacheRecord::new(key, value, now_ms, options.ttl_seconds);
+    record.last_accessed_ms = next_access_ms_for(options, now_ms);
     write_fs_record(&path, &record)?;
     fs_evict(options, now_ms)
 }
@@ -802,6 +805,31 @@ fn canonicalize_json_value(value: &serde_json::Value) -> serde_json::Value {
         }
         other => other.clone(),
     }
+}
+
+thread_local! {
+    static ACCESS_CLOCK: RefCell<BTreeMap<String, i64>> =
+        const { RefCell::new(BTreeMap::new()) };
+}
+
+fn access_clock_key(options: &CacheOptions) -> String {
+    format!(
+        "{}:{}:{}",
+        options.backend.name(),
+        options.namespace,
+        options.path.display()
+    )
+}
+
+fn next_access_ms_for(options: &CacheOptions, now_ms: i64) -> i64 {
+    let key = access_clock_key(options);
+    ACCESS_CLOCK.with(|clock| {
+        let mut clock = clock.borrow_mut();
+        let previous = clock.get(&key).copied().unwrap_or(i64::MIN);
+        let next = now_ms.max(previous.saturating_add(1));
+        clock.insert(key, next);
+        next
+    })
 }
 
 // -------------------------------------------------------------------------
@@ -938,6 +966,7 @@ fn reset_metrics_for(options: &CacheOptions) {
 pub fn reset_in_process_cache_state() {
     MEM_STORE.with(|store| store.borrow_mut().clear());
     METRICS.with(|metrics| metrics.borrow_mut().by_namespace.clear());
+    ACCESS_CLOCK.with(|clock| clock.borrow_mut().clear());
 }
 
 #[cfg(test)]

--- a/crates/harn-vm/src/llm/cache_tests.rs
+++ b/crates/harn-vm/src/llm/cache_tests.rs
@@ -73,6 +73,54 @@ fn fs_cache_hits_and_evicts_oldest() {
 }
 
 #[test]
+fn fs_cache_evicts_lru_when_operations_share_wall_millisecond() {
+    reset_in_process_cache_state();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let options = CacheOptions {
+        backend: CacheBackend::Fs,
+        namespace: "test".to_string(),
+        path: dir.path().join("fs-cache"),
+        ttl_seconds: 60,
+        max_entries: 2,
+    };
+
+    cache_put_at(&options, "a", serde_json::json!({"value": "a"}), 1_000).unwrap();
+    cache_put_at(&options, "b", serde_json::json!({"value": "b"}), 1_000).unwrap();
+    cache_put_at(&options, "c", serde_json::json!({"value": "c"}), 1_000).unwrap();
+
+    assert_eq!(cache_get_at(&options, "a", 1_000).unwrap(), None);
+    assert_eq!(
+        cache_get_at(&options, "b", 1_000).unwrap(),
+        Some(serde_json::json!({"value": "b"}))
+    );
+    assert_eq!(
+        cache_get_at(&options, "c", 1_000).unwrap(),
+        Some(serde_json::json!({"value": "c"}))
+    );
+}
+
+#[test]
+fn sqlite_cache_evicts_lru_when_operations_share_wall_millisecond() {
+    reset_in_process_cache_state();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let options = sqlite_options(dir.path().join("cache.sqlite"));
+
+    cache_put_at(&options, "a", serde_json::json!({"value": "a"}), 1_000).unwrap();
+    cache_put_at(&options, "b", serde_json::json!({"value": "b"}), 1_000).unwrap();
+    cache_put_at(&options, "c", serde_json::json!({"value": "c"}), 1_000).unwrap();
+
+    assert_eq!(cache_get_at(&options, "a", 1_000).unwrap(), None);
+    assert_eq!(
+        cache_get_at(&options, "b", 1_000).unwrap(),
+        Some(serde_json::json!({"value": "b"}))
+    );
+    assert_eq!(
+        cache_get_at(&options, "c", 1_000).unwrap(),
+        Some(serde_json::json!({"value": "c"}))
+    );
+}
+
+#[test]
 fn corrupt_cache_entries_are_misses() {
     let dir = tempfile::tempdir().expect("tempdir");
     let sqlite = sqlite_options(dir.path().join("cache.sqlite"));

--- a/crates/harn-vm/src/personas.rs
+++ b/crates/harn-vm/src/personas.rs
@@ -265,6 +265,44 @@ pub enum PersonaSupervisionEvent {
     Checkpoint(PersonaCheckpointUpdate),
 }
 
+impl PersonaSupervisionEvent {
+    pub fn update_kind(&self) -> &'static str {
+        match self {
+            Self::QueuePosition(_) => "queue_position",
+            Self::RepairWorkerStatus(_) => "repair_worker_status",
+            Self::Receipt(_) => "receipt",
+            Self::Checkpoint(_) => "checkpoint",
+        }
+    }
+
+    pub fn persona_id(&self) -> &str {
+        match self {
+            Self::QueuePosition(update) => &update.persona_id,
+            Self::RepairWorkerStatus(update) => &update.persona_id,
+            Self::Receipt(update) => &update.persona_id,
+            Self::Checkpoint(update) => &update.persona_id,
+        }
+    }
+
+    pub fn template_ref(&self) -> Option<&str> {
+        match self {
+            Self::QueuePosition(update) => update.template_ref.as_deref(),
+            Self::RepairWorkerStatus(update) => update.template_ref.as_deref(),
+            Self::Receipt(update) => update.template_ref.as_deref(),
+            Self::Checkpoint(update) => update.template_ref.as_deref(),
+        }
+    }
+
+    pub fn occurred_at_ms(&self) -> i64 {
+        match self {
+            Self::QueuePosition(update) => update.occurred_at_ms,
+            Self::RepairWorkerStatus(update) => update.occurred_at_ms,
+            Self::Receipt(update) => update.occurred_at_ms,
+            Self::Checkpoint(update) => update.occurred_at_ms,
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct PersonaQueuePositionUpdate {
     pub persona_id: String,
@@ -804,7 +842,12 @@ pub async fn report_repair_worker_status(
         status.occurred_at_ms,
     )
     .await?;
-    emit_persona_supervision_sink_event(&PersonaSupervisionEvent::RepairWorkerStatus(status));
+    record_persona_supervision_event(
+        log,
+        &binding.name,
+        PersonaSupervisionEvent::RepairWorkerStatus(status),
+    )
+    .await?;
     Ok(true)
 }
 
@@ -867,7 +910,12 @@ pub async fn restore_persona_checkpoint(
         now_ms,
     )
     .await?;
-    emit_persona_supervision_sink_event(&PersonaSupervisionEvent::Checkpoint(update.clone()));
+    record_persona_supervision_event(
+        log,
+        &binding.name,
+        PersonaSupervisionEvent::Checkpoint(update.clone()),
+    )
+    .await?;
     Ok(PersonaCheckpointRestoreOutcome {
         acked: true,
         update,
@@ -945,8 +993,8 @@ async fn run_for_envelope(
     let pre_queue = queue_snapshot(log, binding, now_ms).await?;
     let receipt = run_for_envelope_inner(log, binding, envelope, cost, now_ms).await?;
     let post_queue = queue_snapshot(log, binding, now_ms).await?;
-    emit_queue_position_supervision(binding, &pre_queue, &post_queue, now_ms);
-    emit_receipt_supervision(binding, &receipt, now_ms);
+    emit_queue_position_supervision(log, binding, &pre_queue, &post_queue, now_ms).await?;
+    emit_receipt_supervision(log, binding, &receipt, now_ms).await?;
     Ok(receipt)
 }
 
@@ -1645,6 +1693,25 @@ fn emit_persona_supervision_sink_event(event: &PersonaSupervisionEvent) {
     }
 }
 
+async fn record_persona_supervision_event(
+    log: &Arc<AnyEventLog>,
+    persona: &str,
+    event: PersonaSupervisionEvent,
+) -> Result<(), String> {
+    let update_kind = event.update_kind();
+    let occurred_at_ms = event.occurred_at_ms();
+    append_persona_event(
+        log,
+        persona,
+        &format!("persona.supervision.{update_kind}"),
+        serde_json::to_value(&event).map_err(|error| error.to_string())?,
+        occurred_at_ms,
+    )
+    .await?;
+    emit_persona_supervision_sink_event(&event);
+    Ok(())
+}
+
 #[derive(Clone, Debug)]
 struct QueueEntry {
     work_key: String,
@@ -1667,12 +1734,13 @@ async fn queue_snapshot(
         .collect())
 }
 
-fn emit_queue_position_supervision(
+async fn emit_queue_position_supervision(
+    log: &Arc<AnyEventLog>,
     binding: &PersonaRuntimeBinding,
     before: &[QueueEntry],
     after: &[QueueEntry],
     now_ms: i64,
-) {
+) -> Result<(), String> {
     use std::collections::HashSet;
     let before_keys: HashSet<&str> = before.iter().map(|e| e.work_key.as_str()).collect();
     let after_keys: HashSet<&str> = after.iter().map(|e| e.work_key.as_str()).collect();
@@ -1680,8 +1748,10 @@ fn emit_queue_position_supervision(
 
     for (index, entry) in after.iter().enumerate() {
         if !before_keys.contains(entry.work_key.as_str()) {
-            emit_persona_supervision_sink_event(&PersonaSupervisionEvent::QueuePosition(
-                PersonaQueuePositionUpdate {
+            record_persona_supervision_event(
+                log,
+                &binding.name,
+                PersonaSupervisionEvent::QueuePosition(PersonaQueuePositionUpdate {
                     persona_id: binding.name.clone(),
                     template_ref: binding.template_ref.clone(),
                     work_key: entry.work_key.clone(),
@@ -1689,14 +1759,17 @@ fn emit_queue_position_supervision(
                     position: (index + 1) as i64,
                     queued_at_ms: entry.queued_at_ms,
                     occurred_at_ms: now_ms,
-                },
-            ));
+                }),
+            )
+            .await?;
         }
     }
     for entry in before {
         if !after_keys.contains(entry.work_key.as_str()) {
-            emit_persona_supervision_sink_event(&PersonaSupervisionEvent::QueuePosition(
-                PersonaQueuePositionUpdate {
+            record_persona_supervision_event(
+                log,
+                &binding.name,
+                PersonaSupervisionEvent::QueuePosition(PersonaQueuePositionUpdate {
                     persona_id: binding.name.clone(),
                     template_ref: binding.template_ref.clone(),
                     work_key: entry.work_key.clone(),
@@ -1704,23 +1777,31 @@ fn emit_queue_position_supervision(
                     position: 0,
                     queued_at_ms: entry.queued_at_ms,
                     occurred_at_ms: now_ms,
-                },
-            ));
+                }),
+            )
+            .await?;
         }
     }
+    Ok(())
 }
 
-fn emit_receipt_supervision(
+async fn emit_receipt_supervision(
+    log: &Arc<AnyEventLog>,
     binding: &PersonaRuntimeBinding,
     receipt: &PersonaRunReceipt,
     now_ms: i64,
-) {
-    emit_persona_supervision_sink_event(&PersonaSupervisionEvent::Receipt(PersonaReceiptUpdate {
-        persona_id: binding.name.clone(),
-        template_ref: binding.template_ref.clone(),
-        receipt: receipt.clone(),
-        occurred_at_ms: now_ms,
-    }));
+) -> Result<(), String> {
+    record_persona_supervision_event(
+        log,
+        &binding.name,
+        PersonaSupervisionEvent::Receipt(PersonaReceiptUpdate {
+            persona_id: binding.name.clone(),
+            template_ref: binding.template_ref.clone(),
+            receipt: receipt.clone(),
+            occurred_at_ms: now_ms,
+        }),
+    )
+    .await
 }
 
 fn run_value_metadata(
@@ -2360,6 +2441,24 @@ mod tests {
             assert_eq!(event.persona_id, binding.name);
             assert_eq!(event.template_ref.as_deref(), Some("software_factory@v0"));
         }
+        let persisted_kinds: Vec<_> = read_persona_events(&log, &binding.name)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|(_, event)| event.kind)
+            .collect();
+        assert!(
+            persisted_kinds
+                .iter()
+                .any(|kind| kind == "persona.supervision.queue_position"),
+            "queue_position supervision events should be durable: {persisted_kinds:?}"
+        );
+        assert!(
+            persisted_kinds
+                .iter()
+                .any(|kind| kind == "persona.supervision.receipt"),
+            "receipt supervision events should be durable: {persisted_kinds:?}"
+        );
     }
 
     #[tokio::test]

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -245,13 +245,20 @@ harn persona --manifest examples/personas/harn.toml trigger merge_captain \
 harn persona --manifest examples/personas/harn.toml pause merge_captain
 harn persona --manifest examples/personas/harn.toml resume merge_captain
 harn persona --manifest examples/personas/harn.toml disable merge_captain
+harn persona --manifest examples/personas/harn.toml supervision tail --json
+harn persona --manifest examples/personas/harn.toml supervision tail \
+  --persona merge_captain --since-event-id 42 --follow --limit 200 --json
 ```
 
 | Flag | Description |
 |---|---|
 | `--manifest <path>` | Use an explicit `harn.toml` path or directory containing one |
 | `--state-dir <dir>` | Store persona runtime events under a durable EventLog base directory, default `.harn/personas` |
-| `--json` | Emit stable JSON for list, inspect, status, controls, trigger, tick, and budget receipts |
+| `--json` | Emit stable JSON for list, inspect, status, controls, trigger, tick, and budget receipts. `supervision tail` always emits NDJSON frames and accepts `--json` for host symmetry |
+| `--persona <name>` | Filter `supervision tail` to one persona; omitted streams every persona in the local state directory |
+| `--since-event-id <N>` | Replay `supervision tail` frames with `event_id > N` |
+| `--follow` | Keep `supervision tail` open and stream new appended frames |
+| `--limit <N>` | Cap emitted `supervision tail` frames |
 
 `harn persona` validates the manifest before printing. It rejects missing entry
 workflows, unknown capabilities, invalid budget fields, invalid schedules, and
@@ -262,6 +269,10 @@ Runtime commands append event-sourced lifecycle records to
 `resume` drains queued events once under a lease, and `disable` records later
 events as dead-lettered. `tick`, `trigger`, and `spend` enforce per-persona
 daily, hourly, run, and token budgets before recording expensive-work receipts.
+`supervision tail` projects those records into hosted-compatible
+`persona/update` NDJSON frames with `event_id`, `persona_id`, `persona_kind`,
+optional `persona_version`, `actor`, `update_kind`, `occurred_at`, and
+`payload`.
 
 ## harn fmt
 

--- a/docs/src/personas.md
+++ b/docs/src/personas.md
@@ -201,6 +201,14 @@ Budget checks run before schedule and trigger work records. Per-persona
 `daily_usd`, `hourly_usd`, `run_usd`, and `max_tokens` caps block expensive
 work and append a structured budget-exhaustion event with a receipt id.
 
+`harn persona supervision tail` projects `persona.runtime.events` into the
+hosted supervision feed shape as newline-delimited JSON. It accepts
+`--persona <name>` to narrow the multiplexed stream, `--since-event-id <N>` for
+strict greater-than cursor replay, `--limit <N>` for cheap poll loops, and
+`--follow` to wait for new appends. Each line carries `event_id`, `persona_id`,
+`persona_kind`, optional `persona_version`, `actor`, `update_kind`,
+`occurred_at`, and `payload`, matching the hosted `persona/update` frame body.
+
 External trigger metadata is normalized for common continuous-persona sources:
 GitHub PRs and check runs, Linear issues, Slack messages, and generic webhooks.
 For example, GitHub PR metadata with `repository=burin-labs/harn` and

--- a/scripts/release_smoke.sh
+++ b/scripts/release_smoke.sh
@@ -37,6 +37,12 @@ if [[ ! -x "$HARN" ]]; then
   exit 1
 fi
 
+STEP_TIMEOUT_SECONDS="${HARN_RELEASE_SMOKE_STEP_TIMEOUT_SECONDS:-120}"
+if [[ ! "$STEP_TIMEOUT_SECONDS" =~ ^[1-9][0-9]*$ ]]; then
+  echo "::error::release-smoke: HARN_RELEASE_SMOKE_STEP_TIMEOUT_SECONDS must be a positive integer, got '$STEP_TIMEOUT_SECONDS'"
+  exit 1
+fi
+
 # Disable real LLM dispatch even though every fixture uses
 # `provider: "mock"`. A misrouted call would otherwise pull on the
 # host-credential path and obscure the smoke failure mode.
@@ -50,6 +56,38 @@ trap 'rm -rf "$TMP_ROOT"' EXIT
 
 FAILED=0
 
+terminate_pid_tree() {
+  local pid="$1"
+  if [[ "$PLATFORM" == "windows" ]]; then
+    taskkill //F //T //PID "$pid" >/dev/null 2>&1 || true
+  else
+    kill "$pid" 2>/dev/null || true
+    sleep 2
+    kill -0 "$pid" 2>/dev/null && kill -9 "$pid" 2>/dev/null || true
+  fi
+}
+
+run_with_timeout() {
+  local timeout_seconds="$1"
+  shift
+  "$@" &
+  local cmd_pid=$!
+  local elapsed=0
+  while kill -0 "$cmd_pid" 2>/dev/null; do
+    if [[ "$elapsed" -ge "$timeout_seconds" ]]; then
+      echo "release-smoke ($PLATFORM): command exceeded ${timeout_seconds}s; terminating"
+      terminate_pid_tree "$cmd_pid"
+      wait "$cmd_pid" 2>/dev/null || true
+      return 124
+    fi
+    sleep 1
+    elapsed=$((elapsed + 1))
+  done
+  local rc=0
+  wait "$cmd_pid" || rc=$?
+  return "$rc"
+}
+
 # Run one labelled step. stdout streams to the log group; on failure
 # we emit a `::error::` annotation so the PR summary points at the
 # specific (platform, capability) regression instead of just "smoke
@@ -60,11 +98,18 @@ run_step() {
   local label="$1"
   shift
   echo "::group::[$PLATFORM] $label"
+  local start_seconds=$SECONDS
   local rc=0
-  "$@" || rc=$?
+  run_with_timeout "$STEP_TIMEOUT_SECONDS" "$@" || rc=$?
+  local elapsed_seconds=$((SECONDS - start_seconds))
+  echo "release-smoke ($PLATFORM): $label finished in ${elapsed_seconds}s"
   echo "::endgroup::"
   if [[ "$rc" -ne 0 ]]; then
-    echo "::error::release-smoke ($PLATFORM): $label failed (exit $rc)"
+    if [[ "$rc" -eq 124 ]]; then
+      echo "::error::release-smoke ($PLATFORM): $label timed out after ${STEP_TIMEOUT_SECONDS}s"
+    else
+      echo "::error::release-smoke ($PLATFORM): $label failed (exit $rc)"
+    fi
     FAILED=1
   fi
 }


### PR DESCRIPTION
## Summary

- add `harn persona supervision tail` with strict cursor replay, persona filtering, finite limits, and follow-mode streaming
- persist runtime supervision updates into `persona.runtime.events` so local tailing has durable queue, repair-worker, receipt, and checkpoint frames
- document the local NDJSON feed and cover the multiplexed contract in persona CLI tests

Closes #1490

## Verification

- `cargo fmt --check`
- `cargo test -p harn-cli --test persona_cli -- --nocapture`
- `cargo test -p harn-vm personas::tests::supervision_sink_emits_queue_position_and_receipt -- --nocapture`
- `cargo run --quiet --bin harn -- persona supervision tail --help`
- `cargo clippy -p harn-cli --test persona_cli -- -D warnings`
- `cargo clippy -p harn-vm --lib -- -D warnings`
- `make lint-md`
- pre-commit hook: workspace clippy + markdown lint
- pre-push hook: targeted local checks + markdown lint
