### PR TITLE
Add std/web source ingest helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -649,7 +649,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
 dependencies = [
  "chrono",
- "phf",
+ "phf 0.12.1",
 ]
 
 [[package]]
@@ -1145,6 +1145,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "cssparser"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dae61cf9c0abb83bd659dab65b7e4e38d8236824c85f0f804f173567bda257d2"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "phf 0.13.1",
+ "smallvec",
+]
+
+[[package]]
+name = "cssparser-macros"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "csv"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1430,6 +1453,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "dtoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
+
+[[package]]
+name = "dtoa-short"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
+dependencies = [
+ "dtoa",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1459,6 +1497,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "ego-tree"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b04dc5a38e4f151a79d9f2451ae6037fb6eaf5cba34771f44781f80e508498e3"
 
 [[package]]
 name = "either"
@@ -1845,6 +1889,15 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -2275,6 +2328,7 @@ dependencies = [
  "reqwest-eventsource",
  "rusqlite",
  "rustls",
+ "scraper",
  "serde",
  "serde_json",
  "serde_path_to_error",
@@ -2424,6 +2478,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
+dependencies = [
+ "log",
+ "markup5ever",
 ]
 
 [[package]]
@@ -3119,6 +3183,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "markup5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
+dependencies = [
+ "log",
+ "tendril",
+ "web_atoms",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3238,6 +3313,12 @@ name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nom"
@@ -3609,7 +3690,51 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.12.1",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros",
+ "phf_shared 0.13.1",
+ "serde",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
+dependencies = [
+ "phf_generator",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator",
+ "phf_shared 0.13.1",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3617,6 +3742,15 @@ name = "phf_shared"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher",
 ]
@@ -3732,6 +3866,12 @@ checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "prettyplease"
@@ -4431,6 +4571,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scraper"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f5297102b8b62b4454ee8561601b2d551b4913148feb4241ca9d1a04bf4526"
+dependencies = [
+ "cssparser",
+ "ego-tree",
+ "getopts",
+ "html5ever",
+ "precomputed-hash",
+ "selectors",
+ "tendril",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4464,6 +4619,25 @@ checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "selectors"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5d9c0c92a92d33f08817311cf3f2c29a3538a8240e94a6a3c622ce652d7e00c"
+dependencies = [
+ "bitflags 2.11.0",
+ "cssparser",
+ "derive_more",
+ "log",
+ "new_debug_unreachable",
+ "phf 0.13.1",
+ "phf_codegen",
+ "precomputed-hash",
+ "rustc-hash 2.1.2",
+ "servo_arc",
+ "smallvec",
 ]
 
 [[package]]
@@ -4574,6 +4748,15 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "servo_arc"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
+dependencies = [
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -4880,6 +5063,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
+name = "string_cache"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared 0.13.1",
+ "precomputed-hash",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
+dependencies = [
+ "phf_generator",
+ "phf_shared 0.13.1",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5006,6 +5213,16 @@ dependencies = [
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tendril"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
+dependencies = [
+ "new_debug_unreachable",
+ "utf-8",
 ]
 
 [[package]]
@@ -5835,6 +6052,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6407,6 +6630,18 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web_atoms"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7cff6eef815df1834fd250e3a2ff436044d82a9f1bc1980ca1dbdf07effc538"
+dependencies = [
+ "phf 0.13.1",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
 ]
 
 [[package]]

--- a/conformance/tests/stdlib/web_conditional_cache.expected
+++ b/conformance/tests/stdlib/web_conditional_cache.expected
@@ -1,0 +1,1 @@
+web_conditional_cache_ok

--- a/conformance/tests/stdlib/web_conditional_cache.harn
+++ b/conformance/tests/stdlib/web_conditional_cache.harn
@@ -1,0 +1,78 @@
+import { mem_cache } from "std/cache"
+import { web_fetch } from "std/web"
+
+pipeline test(task) {
+  http_mock_clear()
+  http_mock(
+    "GET",
+    "https://example.com/catalog",
+    {
+      responses: [
+        {
+          status: 200,
+          headers: {etag: "\"catalog-v1\"", "last-modified": "Mon, 11 May 2026 00:00:00 GMT"},
+          body: "fresh",
+        },
+        {status: 304, headers: {etag: "\"catalog-v1\""}, body: ""},
+      ],
+    },
+  )
+  http_mock(
+    "GET",
+    "https://example.com/item?id=1",
+    {
+      responses: [
+        {status: 200, headers: {etag: "\"item-1\""}, body: "one"},
+        {status: 304, headers: {etag: "\"item-1\""}, body: ""},
+      ],
+    },
+  )
+  http_mock(
+    "GET",
+    "https://example.com/item?id=2",
+    {status: 200, headers: {etag: "\"item-2\""}, body: "two"},
+  )
+  let store = mem_cache({namespace: "web-conditional-cache"})
+  let first = web_fetch(
+    "https://example.com/catalog",
+    {
+      store: store,
+      http_options: {headers: {Accept: "text/html"}},
+      headers: {"X-Source": "fixture"},
+      fetched_at: "t1",
+    },
+  )
+  let second = web_fetch(
+    "https://example.com/catalog",
+    {
+      store: store,
+      http_options: {headers: {Accept: "text/html"}},
+      headers: {"X-Source": "fixture"},
+      fetched_at: "t2",
+    },
+  )
+  assert_eq(first.cache_status, "miss")
+  assert_eq(second.cache_status, "not_modified")
+  assert_eq(second.status, 304)
+  assert_eq(second.ok, true)
+  assert_eq(second.body, "fresh")
+  assert_eq(second.etag, "\"catalog-v1\"")
+  assert_eq(second.fetched_at, "t2")
+  let calls = http_mock_calls({redact_sensitive: false})
+  assert_eq(calls[1].headers.accept, "text/html")
+  assert_eq(calls[1].headers["x-source"], "fixture")
+  assert_eq(calls[1].headers["if-none-match"], "\"catalog-v1\"")
+  assert_eq(calls[1].headers["if-modified-since"], "Mon, 11 May 2026 00:00:00 GMT")
+  let item_one = web_fetch("https://example.com/item", {store: store, query: {id: 1}})
+  let item_two = web_fetch("https://example.com/item", {store: store, query: {id: 2}})
+  let item_one_again = web_fetch("https://example.com/item", {store: store, query: {id: 1}})
+  assert_eq(item_one.body, "one")
+  assert_eq(item_two.cache_status, "miss")
+  assert_eq(item_two.body, "two")
+  assert_eq(item_one_again.cache_status, "not_modified")
+  assert_eq(item_one_again.body, "one")
+  let query_calls = http_mock_calls({redact_sensitive: false})
+  assert_eq(query_calls[3].url, "https://example.com/item?id=2")
+  assert_eq(query_calls[3].headers["if-none-match"], nil)
+  println("web_conditional_cache_ok")
+}

--- a/conformance/tests/stdlib/web_fetch_parse.expected
+++ b/conformance/tests/stdlib/web_fetch_parse.expected
@@ -1,0 +1,1 @@
+web_fetch_parse_ok

--- a/conformance/tests/stdlib/web_fetch_parse.harn
+++ b/conformance/tests/stdlib/web_fetch_parse.harn
@@ -1,0 +1,62 @@
+import { mem_cache } from "std/cache"
+import { web_fetch, web_parse_html } from "std/web"
+
+pipeline test(task) {
+  http_mock_clear()
+  http_mock(
+    "GET",
+    "https://example.com/article",
+    {
+      status: 200,
+      headers: {
+        "content-type": "text/html; charset=utf-8",
+        etag: "\"v1\"",
+        "last-modified": "Mon, 11 May 2026 00:00:00 GMT",
+      },
+      body: """
+        <html>
+          <head>
+            <title>Example &amp; Research</title>
+            <meta name="description" content="Deterministic source ingest">
+            <meta property="og:type" content="article">
+            <link rel="canonical" href="/article">
+            <script type="application/ld+json">{"@type":"Article","headline":"Example"}</script>
+          </head>
+          <body>
+            <nav><a href="/docs" rel="help">Docs</a></nav>
+            <main>
+              <p>Hello <strong>world</strong>.</p>
+              <table>
+                <caption>Prices</caption>
+                <tr><th>Plan</th><th>USD</th></tr>
+                <tr><td>Pro</td><td>20</td></tr>
+              </table>
+            </main>
+          </body>
+        </html>
+        """,
+    },
+  )
+  let store = mem_cache({namespace: "web-fetch-parse"})
+  let fetched = web_fetch("https://example.com/article", {store: store, fetched_at: "fixture-time"})
+  assert_eq(fetched.status, 200)
+  assert_eq(fetched.cache_status, "miss")
+  assert_eq(fetched.final_url, "https://example.com/article")
+  assert_eq(fetched.content_type, "text/html; charset=utf-8")
+  assert_eq(fetched.etag, "\"v1\"")
+  assert_eq(fetched.last_modified, "Mon, 11 May 2026 00:00:00 GMT")
+  assert_eq(fetched.fetched_at, "fixture-time")
+  let parsed = web_parse_html(fetched.body, fetched.final_url)
+  assert_eq(parsed.title, "Example & Research")
+  assert_eq(parsed.meta.description, "Deterministic source ingest")
+  assert_eq(parsed.meta["og:type"], "article")
+  assert_eq(parsed.canonical_url, "https://example.com/article")
+  assert_eq(parsed.links[0].url, "https://example.com/docs")
+  assert_eq(parsed.links[0].text, "Docs")
+  assert_eq(parsed.tables[0].caption, "Prices")
+  assert_eq(parsed.tables[0].headers, ["Plan", "USD"])
+  assert_eq(parsed.tables[0].rows[0], ["Pro", "20"])
+  assert_eq(parsed.json_ld[0].headline, "Example")
+  assert(contains(parsed.text, "Hello world"))
+  println("web_fetch_parse_ok")
+}

--- a/conformance/tests/stdlib/web_robots_sitemap.expected
+++ b/conformance/tests/stdlib/web_robots_sitemap.expected
@@ -1,0 +1,1 @@
+web_robots_sitemap_ok

--- a/conformance/tests/stdlib/web_robots_sitemap.harn
+++ b/conformance/tests/stdlib/web_robots_sitemap.harn
@@ -1,0 +1,74 @@
+import { robots_allowed, sitemap_urls, web_origin_url } from "std/web"
+
+pipeline test(task) {
+  http_mock_clear()
+  http_mock(
+    "GET",
+    "https://example.com/robots.txt",
+    {
+      status: 200,
+      body: """
+        User-agent: *
+        Disallow: /private
+        Allow: /private/public
+        Sitemap: https://example.com/sitemap.xml
+      """,
+    },
+  )
+  http_mock(
+    "GET",
+    "https://example.com/specific-robots.txt",
+    {
+      status: 200,
+      body: """
+        User-agent: *
+        Allow: /private
+
+        User-agent: AuditBot
+        Disallow: /private
+        Allow: /private/public
+      """,
+    },
+  )
+  http_mock(
+    "GET",
+    "https://example.com/sitemap.xml",
+    {
+      status: 200,
+      body: """
+        <urlset>
+          <url><loc>https://example.com/</loc></url>
+          <url><loc>https://example.com/docs</loc></url>
+        </urlset>
+      """,
+    },
+  )
+  assert_eq(robots_allowed("https://example.com/docs"), true)
+  assert_eq(robots_allowed("https://example.com/private/secret"), false)
+  assert_eq(robots_allowed("https://example.com/private/public/page"), true)
+  assert_eq(
+    robots_allowed(
+      "https://example.com/private/secret",
+      "AuditBot",
+      {robots_url: "https://example.com/specific-robots.txt"},
+    ),
+    false,
+  )
+  assert_eq(
+    robots_allowed(
+      "https://example.com/private/secret",
+      "OtherBot",
+      {robots_url: "https://example.com/specific-robots.txt"},
+    ),
+    true,
+  )
+  assert_eq(
+    web_origin_url("https://example.com/path?q=1#frag", "robots.txt"),
+    "https://example.com/robots.txt",
+  )
+  assert_eq(
+    sitemap_urls("https://example.com/docs"),
+    ["https://example.com/", "https://example.com/docs"],
+  )
+  println("web_robots_sitemap_ok")
+}

--- a/crates/harn-parser/src/builtin_signatures/signatures/stdlib.rs
+++ b/crates/harn-parser/src/builtin_signatures/signatures/stdlib.rs
@@ -121,6 +121,30 @@ pub(crate) const SIGNATURES: &[BuiltinSignature] = &[
         ],
         Ty::Union(&[TY_DICT, TY_LIST]),
     ),
+    BuiltinSignature::simple(
+        "__web_extract_html",
+        &[
+            Param::new("html", TY_STRING),
+            Param::optional("source_url", TY_STRING_OR_NIL),
+        ],
+        TY_DICT,
+    ),
+    BuiltinSignature::simple(
+        "__web_origin_url",
+        &[
+            Param::new("url", TY_STRING),
+            Param::optional("path", TY_STRING),
+        ],
+        TY_STRING,
+    ),
+    BuiltinSignature::simple(
+        "__web_resolve_url",
+        &[
+            Param::new("base_url", TY_STRING),
+            Param::new("href", TY_STRING),
+        ],
+        TY_STRING_OR_NIL,
+    ),
     BuiltinSignature::simple("abs", &[Param::new("value", TY_NUMBER)], TY_NUMBER),
     BuiltinSignature::simple("acos", &[Param::new("value", TY_NUMBER)], TY_FLOAT),
     BuiltinSignature::simple("addr_of", &[Param::new("value", TY_ANY)], TY_STRING),

--- a/crates/harn-stdlib/src/lib.rs
+++ b/crates/harn-stdlib/src/lib.rs
@@ -62,6 +62,10 @@ pub const STDLIB_SOURCES: &[StdlibSource] = &[
         source: include_str!("stdlib/stdlib_tools.harn"),
     },
     StdlibSource {
+        module: "web",
+        source: include_str!("stdlib/stdlib_web.harn"),
+    },
+    StdlibSource {
         module: "graphql",
         source: include_str!("stdlib/stdlib_graphql.harn"),
     },

--- a/crates/harn-stdlib/src/stdlib/stdlib_web.harn
+++ b/crates/harn-stdlib/src/stdlib/stdlib_web.harn
@@ -1,0 +1,409 @@
+// std/web — deterministic HTTP-backed source ingest and extraction helpers.
+import { cache_get, cache_put } from "std/cache"
+
+fn __web_header(headers, name) {
+  let wanted = lowercase(name)
+  for entry in headers ?? {} {
+    if lowercase(entry.key) == wanted {
+      return entry.value
+    }
+  }
+  return nil
+}
+
+fn __web_store_options(opts) {
+  if opts?.store == nil {
+    return nil
+  }
+  return {store: opts.store}
+}
+
+fn __web_cache_key(method, url, opts) {
+  return opts?.cache_key ?? ("std/web:web_fetch:" + uppercase(method) + ":" + url)
+}
+
+fn __web_effective_url(url, http_opts) {
+  let query = http_opts?.query
+  if query == nil {
+    return url
+  }
+  let parsed = url_parse(url)
+  var pairs = query_parse(parsed?.query ?? "")
+  for entry in query {
+    if entry.value != nil {
+      pairs = pairs + [{key: entry.key, value: to_string(entry.value)}]
+    }
+  }
+  return url_build(
+    {
+      scheme: parsed.scheme,
+      host: parsed.host,
+      port: parsed.port,
+      path: parsed.path ?? "/",
+      query: query_stringify(pairs),
+      fragment: parsed.fragment,
+      username: parsed.username,
+      password: parsed.password,
+    },
+  )
+}
+
+fn __web_base_headers(opts) {
+  let http_headers = opts?.http_options?.headers ?? {}
+  let headers = opts?.headers
+  if headers == nil {
+    return http_headers
+  }
+  return http_headers + headers
+}
+
+fn __web_conditional_headers(headers, previous, enabled) {
+  if !enabled || previous == nil {
+    return headers
+  }
+  var next = headers
+  if __web_header(next, "if-none-match") == nil && previous?.etag != nil {
+    next = next + {"If-None-Match": previous.etag}
+  }
+  if __web_header(next, "if-modified-since") == nil && previous?.last_modified != nil {
+    next = next + {"If-Modified-Since": previous.last_modified}
+  }
+  return next
+}
+
+fn __web_fetch_envelope(source_url, response, fetched_at, cache_status) {
+  let headers = response?.headers ?? {}
+  return {
+    ok: response?.ok ?? false,
+    status: response?.status,
+    body: response?.body ?? "",
+    headers: headers,
+    content_type: __web_header(headers, "content-type"),
+    etag: __web_header(headers, "etag"),
+    last_modified: __web_header(headers, "last-modified"),
+    fetched_at: fetched_at,
+    cache_status: cache_status,
+    source_url: source_url,
+    final_url: response?.final_url ?? source_url,
+    not_modified: false,
+  }
+}
+
+fn __web_not_modified(source_url, response, previous, fetched_at) {
+  let headers = response?.headers ?? {}
+  var next = previous
+  next = next
+    + {
+    ok: true,
+    status: 304,
+    headers: headers,
+    fetched_at: fetched_at,
+    cache_status: "not_modified",
+    source_url: source_url,
+    final_url: response?.final_url ?? previous?.final_url ?? source_url,
+    not_modified: true,
+  }
+  let etag = __web_header(headers, "etag")
+  if etag != nil {
+    next = next + {etag: etag}
+  }
+  let last_modified = __web_header(headers, "last-modified")
+  if last_modified != nil {
+    next = next + {last_modified: last_modified}
+  }
+  let content_type = __web_header(headers, "content-type")
+  if content_type != nil {
+    next = next + {content_type: content_type}
+  }
+  return next
+}
+
+/**
+ * Fetch a web source through Harn's HTTP stack and normalize provenance.
+ *
+ * Options:
+ *   - method, headers, query, body, timeout, retry, session, proxy, tls:
+ *     forwarded to `http_request`.
+ *   - http_options: explicit HTTP option dict when callers want web-specific
+ *     options kept separate.
+ *   - previous: previous `web_fetch` envelope used for conditional headers.
+ *   - store: `std/cache` store. When present, cached ETag / Last-Modified
+ *     values are used for conditional re-fetches and 304 responses reuse the
+ *     cached body.
+ *   - cache_key: override for the cache key.
+ *   - conditional: set false to skip If-None-Match / If-Modified-Since.
+ *   - fetched_at: deterministic timestamp override for fixtures.
+ */
+pub fn web_fetch(url: string, options = nil) -> dict {
+  let opts = options ?? {}
+  let method = uppercase(opts?.method ?? opts?.http_options?.method ?? "GET")
+  var http_opts = opts?.http_options ?? opts
+  let source_url = __web_effective_url(url, http_opts)
+  let store_opts = __web_store_options(opts)
+  let cache_key = __web_cache_key(method, source_url, opts)
+  var previous = opts?.previous
+  var cache_status = if store_opts == nil {
+    "bypass"
+  } else {
+    "miss"
+  }
+  if previous == nil && store_opts != nil {
+    let cached = cache_get(cache_key, store_opts)
+    if cached.hit {
+      previous = cached.value
+      cache_status = "refresh"
+    }
+  }
+  let headers = __web_conditional_headers(__web_base_headers(opts), previous, opts?.conditional ?? true)
+  http_opts = http_opts + {headers: headers}
+  let response = http_request(method, url, http_opts)
+  let fetched_at = opts?.fetched_at ?? timestamp()
+  if response.status == 304 && previous != nil {
+    let not_modified = __web_not_modified(source_url, response, previous, fetched_at)
+    if store_opts != nil {
+      cache_put(cache_key, not_modified, store_opts)
+    }
+    return not_modified
+  }
+  let envelope = __web_fetch_envelope(source_url, response, fetched_at, cache_status)
+  if store_opts != nil && envelope.ok {
+    cache_put(cache_key, envelope, store_opts)
+  }
+  return envelope
+}
+
+/** Resolve a URL reference against a fetched source URL. */
+pub fn web_resolve_url(base_url: string, href: string) {
+  return __web_resolve_url(base_url, href)
+}
+
+/** Return the origin URL with `path`, dropping query and fragment. */
+pub fn web_origin_url(url: string, path: string = "/") -> string {
+  return __web_origin_url(url, path)
+}
+
+/** Parse title, meta, canonical URL, links, tables, JSON-LD, and plain text. */
+pub fn web_parse_html(html: string, source_url = nil) -> dict {
+  return __web_extract_html(html, source_url)
+}
+
+/** Extract the HTML title. */
+pub fn html_title(html: string) {
+  return web_parse_html(html).title
+}
+
+/** Extract normalized HTML meta tags keyed by lower-case name/property. */
+pub fn html_meta(html: string) {
+  return web_parse_html(html).meta
+}
+
+/** Extract resolved links from anchors. */
+pub fn html_links(html: string, source_url = nil) {
+  return web_parse_html(html, source_url).links
+}
+
+/** Extract table captions, headers, and rows. */
+pub fn html_tables(html: string) {
+  return web_parse_html(html).tables
+}
+
+/** Extract parsed JSON-LD script blocks. */
+pub fn html_json_ld(html: string) {
+  return web_parse_html(html).json_ld
+}
+
+/** Extract normalized visible text without script/style/noscript bodies. */
+pub fn html_text(html: string) {
+  return web_parse_html(html).text
+}
+
+fn __web_robots_url(url) {
+  return web_origin_url(url, "/robots.txt")
+}
+
+fn __web_line_value(line) {
+  let parts = split(line, ":")
+  if len(parts) < 2 {
+    return nil
+  }
+  return {field: lowercase(trim(parts[0])), value: trim(join(parts[1:], ":"))}
+}
+
+fn __web_robots_rows(body) {
+  var rows = []
+  for line in split(body ?? "", "\n") {
+    let clean = trim(split(line, "#")[0])
+    if clean != "" {
+      let row = __web_line_value(clean)
+      if row != nil {
+        rows = rows + [row]
+      }
+    }
+  }
+  return rows
+}
+
+fn __web_robots_group_score(agents, target) {
+  var score = 0
+  for agent in agents {
+    let normalized = lowercase(trim(agent))
+    if normalized == target {
+      score = 2
+    } else if normalized == "*" && score < 1 {
+      score = 1
+    }
+  }
+  return score
+}
+
+fn __web_robots_push_group(groups, agents, rules, target) {
+  if len(agents) == 0 || len(rules) == 0 {
+    return groups
+  }
+  let score = __web_robots_group_score(agents, target)
+  if score <= 0 {
+    return groups
+  }
+  return groups + [{score: score, rules: rules}]
+}
+
+fn __web_robots_rules(body, user_agent) {
+  let target = lowercase(trim(user_agent ?? "*"))
+  var groups = []
+  var agents = []
+  var group_rules = []
+  for row in __web_robots_rows(body) {
+    if row.field == "user-agent" {
+      if len(group_rules) > 0 {
+        groups = __web_robots_push_group(groups, agents, group_rules, target)
+        agents = []
+        group_rules = []
+      }
+      agents = agents + [row.value]
+    } else if row.field == "allow" || row.field == "disallow" {
+      group_rules = group_rules + [{kind: row.field, path: row.value}]
+    }
+  }
+  groups = __web_robots_push_group(groups, agents, group_rules, target)
+  var best_score = 0
+  for group in groups {
+    if group.score > best_score {
+      best_score = group.score
+    }
+  }
+  var rules = []
+  for group in groups {
+    if group.score == best_score {
+      rules = rules + group.rules
+    }
+  }
+  return rules
+}
+
+fn __web_path_for_robots(url) {
+  let parsed = url_parse(url)
+  let query = parsed?.query
+  if query == nil || query == "" {
+    return parsed.path ?? "/"
+  }
+  let path = parsed.path ?? "/"
+  return path + "?" + query
+}
+
+/**
+ * Return whether robots.txt permits `user_agent` to fetch `url`.
+ *
+ * Missing or non-2xx robots files allow by default. Matching uses the
+ * deterministic subset recurring CI workflows need: exact or `*` user-agent
+ * groups, Allow/Disallow path prefixes, and longest-prefix precedence.
+ */
+pub fn robots_allowed(url: string, user_agent: string = "*", options = nil) -> bool {
+  let opts = options ?? {}
+  let robots_url = opts?.robots_url ?? __web_robots_url(url)
+  let response = web_fetch(robots_url, opts?.fetch_options ?? {})
+  if !(response.ok ?? false) {
+    return true
+  }
+  let path = __web_path_for_robots(url)
+  var best_len = -1
+  var allowed = true
+  for rule in __web_robots_rules(response.body, user_agent) {
+    if rule.path == "" {
+      continue
+    }
+    if starts_with(path, rule.path) {
+      let score = len(rule.path)
+      if score > best_len || (score == best_len && rule.kind == "allow") {
+        best_len = score
+        allowed = rule.kind == "allow"
+      }
+    }
+  }
+  return allowed
+}
+
+fn __web_xml_unescape(text) {
+  var out = regex_replace("&amp;", "&", text)
+  out = regex_replace("&lt;", "<", out)
+  out = regex_replace("&gt;", ">", out)
+  out = regex_replace("&quot;", "\"", out)
+  out = regex_replace("&apos;", "'", out)
+  return out
+}
+
+fn __web_sitemap_locs(xml) {
+  var urls = []
+  for capture in regex_captures("(?is)<loc\\b[^>]*>(.*?)</loc>", xml ?? "") {
+    let loc = trim(__web_xml_unescape(capture.groups[0] ?? ""))
+    if loc != "" && !urls.contains(loc) {
+      urls = urls + [loc]
+    }
+  }
+  return urls
+}
+
+fn __web_sitemap_candidates(base_url, opts) {
+  if opts?.sitemap_urls != nil {
+    return opts.sitemap_urls
+  }
+  var urls = []
+  let robots = web_fetch(opts?.robots_url ?? web_origin_url(base_url, "/robots.txt"), opts?.fetch_options ?? {})
+  if robots.ok {
+    for row in __web_robots_rows(robots.body) {
+      if row.field == "sitemap" && row.value != "" && !urls.contains(row.value) {
+        urls = urls + [row.value]
+      }
+    }
+  }
+  if len(urls) == 0 {
+    urls = [web_origin_url(base_url, "/sitemap.xml")]
+  }
+  return urls
+}
+
+/**
+ * Discover URLs from robots-advertised sitemaps or `/sitemap.xml`.
+ *
+ * Options: sitemap_urls, robots_url, fetch_options, max_sitemaps.
+ */
+pub fn sitemap_urls(base_url: string, options = nil) -> list<string> {
+  let opts = options ?? {}
+  let max_sitemaps = opts?.max_sitemaps ?? 10
+  var found = []
+  var count = 0
+  for sitemap_url in __web_sitemap_candidates(base_url, opts) {
+    if count >= max_sitemaps {
+      return found
+    }
+    count = count + 1
+    let response = web_fetch(sitemap_url, opts?.fetch_options ?? {})
+    if response.ok {
+      for loc in __web_sitemap_locs(response.body) {
+        if !found.contains(loc) {
+          found = found + [loc]
+        }
+      }
+    }
+  }
+  return found
+}

--- a/crates/harn-vm/Cargo.toml
+++ b/crates/harn-vm/Cargo.toml
@@ -33,6 +33,7 @@ chrono = "0.4"
 chrono-tz = "0.10.4"
 croner = "3.0.1"
 regex = "1"
+scraper = "0.26"
 serde_json = "1"
 rand = "0.10"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "time", "test-util", "process", "io-util", "io-std", "macros"] }

--- a/crates/harn-vm/src/http/client.rs
+++ b/crates/harn-vm/src/http/client.rs
@@ -115,11 +115,20 @@ pub(super) fn clear_http_streams() {
     HTTP_STREAMS.with(|streams| streams.borrow_mut().clear());
 }
 
-fn build_http_response(status: i64, headers: BTreeMap<String, VmValue>, body: String) -> VmValue {
+fn build_http_response(
+    status: i64,
+    headers: BTreeMap<String, VmValue>,
+    body: String,
+    final_url: &str,
+) -> VmValue {
     let mut result = BTreeMap::new();
     result.insert("status".to_string(), VmValue::Int(status));
     result.insert("headers".to_string(), VmValue::Dict(Rc::new(headers)));
     result.insert("body".to_string(), VmValue::String(Rc::from(body)));
+    result.insert(
+        "final_url".to_string(),
+        VmValue::String(Rc::from(final_url)),
+    );
     result.insert(
         "ok".to_string(),
         VmValue::Bool((200..300).contains(&(status as u16))),
@@ -1008,6 +1017,7 @@ async fn vm_execute_http_request_with_client(
                 mock_response.status,
                 mock_response.headers,
                 mock_response.body,
+                &final_url,
             ));
         }
 
@@ -1042,11 +1052,17 @@ async fn vm_execute_http_request_with_client(
 
                 let resp_headers = response_headers(response.headers());
 
+                let response_url = response.url().to_string();
                 let body_text = response
                     .text()
                     .await
                     .map_err(|e| vm_error(format!("http: failed to read response body: {e}")))?;
-                return Ok(build_http_response(status as i64, resp_headers, body_text));
+                return Ok(build_http_response(
+                    status as i64,
+                    resp_headers,
+                    body_text,
+                    &response_url,
+                ));
             }
             Err(e) => {
                 if should_retry_transport(config, &parts.method, &e, attempt) {

--- a/crates/harn-vm/src/stdlib.rs
+++ b/crates/harn-vm/src/stdlib.rs
@@ -66,6 +66,7 @@ mod url_parse;
 mod vision;
 pub(crate) mod waitpoint;
 mod waitpoints;
+mod web;
 pub mod workflow_messages;
 
 use crate::http::register_http_builtins;
@@ -97,6 +98,7 @@ pub fn register_core_stdlib(vm: &mut Vm) {
     junit::register_junit_builtins(vm);
     multipart::register_multipart_builtins(vm);
     url_parse::register_url_builtins(vm);
+    web::register_web_builtins(vm);
     cookies::register_cookie_builtins(vm);
     path::register_path_helper_builtins(vm);
     sets::register_set_builtins(vm);

--- a/crates/harn-vm/src/stdlib/web.rs
+++ b/crates/harn-vm/src/stdlib/web.rs
@@ -1,0 +1,345 @@
+//! Pure web-source helpers backing `std/web`.
+
+use std::collections::BTreeMap;
+use std::rc::Rc;
+
+use regex::Regex;
+use scraper::{ElementRef, Html, Selector};
+use url::Url;
+
+use crate::stdlib::json_to_vm_value;
+use crate::value::{VmError, VmValue};
+use crate::vm::Vm;
+
+fn vm_str(value: impl AsRef<str>) -> VmValue {
+    VmValue::String(Rc::from(value.as_ref()))
+}
+
+fn vm_list(values: Vec<VmValue>) -> VmValue {
+    VmValue::List(Rc::new(values))
+}
+
+fn vm_dict(values: BTreeMap<String, VmValue>) -> VmValue {
+    VmValue::Dict(Rc::new(values))
+}
+
+fn selector(pattern: &str) -> Selector {
+    Selector::parse(pattern).expect("static selector should parse")
+}
+
+fn normalized_text<'a>(parts: impl Iterator<Item = &'a str>) -> String {
+    parts
+        .collect::<Vec<_>>()
+        .join(" ")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn element_text(element: ElementRef<'_>) -> String {
+    normalized_text(element.text())
+}
+
+fn lower_attr(element: ElementRef<'_>, name: &str) -> Option<String> {
+    element
+        .value()
+        .attr(name)
+        .map(|value| value.trim().to_ascii_lowercase())
+}
+
+fn rel_contains(element: ElementRef<'_>, token: &str) -> bool {
+    lower_attr(element, "rel")
+        .map(|rel| rel.split_ascii_whitespace().any(|part| part == token))
+        .unwrap_or(false)
+}
+
+fn resolve_url(base: Option<&Url>, href: &str) -> String {
+    let trimmed = href.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+    Url::parse(trimmed)
+        .or_else(|_| {
+            base.map(|base| base.join(trimmed))
+                .unwrap_or_else(|| Url::parse(trimmed))
+        })
+        .map(|url| url.to_string())
+        .unwrap_or_else(|_| trimmed.to_string())
+}
+
+fn html_text_without_scripts(html: &str) -> String {
+    let stripped = Regex::new(
+        r"(?is)<script\b[^>]*>.*?</script>|<style\b[^>]*>.*?</style>|<noscript\b[^>]*>.*?</noscript>",
+    )
+    .expect("static regex should parse")
+    .replace_all(html, " ");
+    let document = Html::parse_document(&stripped);
+    let body_selector = selector("body");
+    if let Some(body) = document.select(&body_selector).next() {
+        return element_text(body);
+    }
+    normalized_text(document.root_element().text())
+}
+
+fn extract_meta(document: &Html) -> VmValue {
+    let meta_selector = selector("meta");
+    let mut meta = BTreeMap::new();
+    for element in document.select(&meta_selector) {
+        let value = element
+            .value()
+            .attr("content")
+            .or_else(|| element.value().attr("charset"))
+            .map(str::trim)
+            .unwrap_or("");
+        if value.is_empty() {
+            continue;
+        }
+        let key = element
+            .value()
+            .attr("name")
+            .or_else(|| element.value().attr("property"))
+            .or_else(|| element.value().attr("http-equiv"))
+            .or_else(|| element.value().attr("charset"))
+            .map(|key| key.trim().to_ascii_lowercase());
+        if let Some(key) = key.filter(|key| !key.is_empty()) {
+            meta.insert(key, vm_str(value));
+        }
+    }
+    vm_dict(meta)
+}
+
+fn extract_canonical(document: &Html, base: Option<&Url>) -> VmValue {
+    let link_selector = selector("link[href]");
+    for element in document.select(&link_selector) {
+        if rel_contains(element, "canonical") {
+            if let Some(href) = element.value().attr("href") {
+                return vm_str(resolve_url(base, href));
+            }
+        }
+    }
+    VmValue::Nil
+}
+
+fn extract_links(document: &Html, base: Option<&Url>) -> VmValue {
+    let link_selector = selector("a[href]");
+    let mut links = Vec::new();
+    for element in document.select(&link_selector) {
+        let Some(href) = element
+            .value()
+            .attr("href")
+            .map(str::trim)
+            .filter(|href| !href.is_empty())
+        else {
+            continue;
+        };
+        let mut row = BTreeMap::new();
+        row.insert("href".to_string(), vm_str(href));
+        row.insert("url".to_string(), vm_str(resolve_url(base, href)));
+        row.insert("text".to_string(), vm_str(element_text(element)));
+        if let Some(title) = element
+            .value()
+            .attr("title")
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            row.insert("title".to_string(), vm_str(title));
+        }
+        if let Some(rel) = element
+            .value()
+            .attr("rel")
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            row.insert("rel".to_string(), vm_str(rel));
+        }
+        links.push(vm_dict(row));
+    }
+    vm_list(links)
+}
+
+fn extract_json_ld(document: &Html) -> VmValue {
+    let script_selector = selector("script[type]");
+    let mut blocks = Vec::new();
+    for element in document.select(&script_selector) {
+        let script_type = lower_attr(element, "type").unwrap_or_default();
+        if script_type.split(';').next().map(str::trim) != Some("application/ld+json") {
+            continue;
+        }
+        let raw = element
+            .text()
+            .collect::<Vec<_>>()
+            .join("")
+            .trim()
+            .to_string();
+        if raw.is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<serde_json::Value>(&raw) {
+            Ok(parsed) => blocks.push(json_to_vm_value(&parsed)),
+            Err(_) => blocks.push(vm_str(raw)),
+        }
+    }
+    vm_list(blocks)
+}
+
+fn extract_tables(document: &Html) -> VmValue {
+    let table_selector = selector("table");
+    let caption_selector = selector("caption");
+    let row_selector = selector("tr");
+    let th_selector = selector("th");
+    let cell_selector = selector("th, td");
+    let td_selector = selector("td");
+    let mut tables = Vec::new();
+
+    for table in document.select(&table_selector) {
+        let mut rendered = BTreeMap::new();
+        let caption = table
+            .select(&caption_selector)
+            .next()
+            .map(element_text)
+            .unwrap_or_default();
+        rendered.insert("caption".to_string(), vm_str(caption));
+
+        let mut headers: Vec<VmValue> = Vec::new();
+        let mut rows: Vec<VmValue> = Vec::new();
+        for row in table.select(&row_selector) {
+            let th_cells = row
+                .select(&th_selector)
+                .map(element_text)
+                .filter(|text| !text.is_empty())
+                .collect::<Vec<_>>();
+            let td_cells = row
+                .select(&td_selector)
+                .map(element_text)
+                .filter(|text| !text.is_empty())
+                .collect::<Vec<_>>();
+            if headers.is_empty() && !th_cells.is_empty() {
+                headers = th_cells.iter().map(vm_str).collect();
+            }
+            if !td_cells.is_empty() {
+                let cells = row
+                    .select(&cell_selector)
+                    .map(element_text)
+                    .filter(|text| !text.is_empty())
+                    .map(vm_str)
+                    .collect::<Vec<_>>();
+                rows.push(vm_list(cells));
+            }
+        }
+        rendered.insert("headers".to_string(), vm_list(headers));
+        rendered.insert("rows".to_string(), vm_list(rows));
+        tables.push(vm_dict(rendered));
+    }
+    vm_list(tables)
+}
+
+fn extract_html(html: &str, source_url: Option<&str>) -> VmValue {
+    let document = Html::parse_document(html);
+    let base = source_url.and_then(|url| Url::parse(url).ok());
+    let title_selector = selector("title");
+    let title = document
+        .select(&title_selector)
+        .next()
+        .map(element_text)
+        .filter(|text| !text.is_empty())
+        .map(vm_str)
+        .unwrap_or(VmValue::Nil);
+
+    let mut out = BTreeMap::new();
+    out.insert("title".to_string(), title);
+    out.insert("meta".to_string(), extract_meta(&document));
+    out.insert(
+        "canonical_url".to_string(),
+        extract_canonical(&document, base.as_ref()),
+    );
+    out.insert("links".to_string(), extract_links(&document, base.as_ref()));
+    out.insert("tables".to_string(), extract_tables(&document));
+    out.insert("json_ld".to_string(), extract_json_ld(&document));
+    out.insert("text".to_string(), vm_str(html_text_without_scripts(html)));
+    vm_dict(out)
+}
+
+fn web_error(name: &str, message: impl std::fmt::Display) -> VmError {
+    VmError::Thrown(vm_str(format!("{name}: {message}")))
+}
+
+pub(crate) fn register_web_builtins(vm: &mut Vm) {
+    vm.register_builtin("__web_extract_html", |args, _out| {
+        let html = args
+            .first()
+            .map(|value| value.display())
+            .unwrap_or_default();
+        let source_url = args.get(1).and_then(|value| match value {
+            VmValue::Nil => None,
+            other => Some(other.display()),
+        });
+        Ok(extract_html(&html, source_url.as_deref()))
+    });
+
+    vm.register_builtin("__web_resolve_url", |args, _out| {
+        let base = args
+            .first()
+            .map(|value| value.display())
+            .unwrap_or_default();
+        let href = args.get(1).map(|value| value.display()).unwrap_or_default();
+        if href.trim().is_empty() {
+            return Ok(VmValue::Nil);
+        }
+        let parsed_base =
+            Url::parse(&base).map_err(|error| web_error("__web_resolve_url", error))?;
+        Ok(vm_str(resolve_url(Some(&parsed_base), &href)))
+    });
+
+    vm.register_builtin("__web_origin_url", |args, _out| {
+        let raw = args
+            .first()
+            .map(|value| value.display())
+            .unwrap_or_default();
+        let path = args
+            .get(1)
+            .map(|value| value.display())
+            .unwrap_or_else(|| "/".to_string());
+        let mut parsed = Url::parse(&raw).map_err(|error| web_error("__web_origin_url", error))?;
+        let normalized_path = if path.is_empty() {
+            "/".to_string()
+        } else if path.starts_with('/') {
+            path
+        } else {
+            format!("/{path}")
+        };
+        parsed.set_path(&normalized_path);
+        parsed.set_query(None);
+        parsed.set_fragment(None);
+        Ok(vm_str(parsed.as_str()))
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::extract_html;
+
+    #[test]
+    fn extracts_core_html_metadata() {
+        let value = extract_html(
+            r#"
+            <html><head>
+              <title>Example &amp; Test</title>
+              <meta name="description" content="A short description">
+              <link rel="canonical" href="/canonical">
+              <script type="application/ld+json">{"name":"Example"}</script>
+            </head><body>
+              <a href="/docs">Docs</a>
+              <table><tr><th>Name</th><th>Price</th></tr><tr><td>Pro</td><td>$20</td></tr></table>
+            </body></html>
+            "#,
+            Some("https://example.com/base/page"),
+        );
+        let dict = value.as_dict().expect("extract_html returns a dict");
+        assert_eq!(dict.get("title").unwrap().display(), "Example & Test");
+        assert_eq!(
+            dict.get("canonical_url").unwrap().display(),
+            "https://example.com/canonical"
+        );
+        assert!(dict.get("text").unwrap().display().contains("Docs"));
+    }
+}

--- a/docs/src/builtins.md
+++ b/docs/src/builtins.md
@@ -946,7 +946,7 @@ pipeline summarize() {
 | `websocket_server_close(server)` | server: string or dict | bool | Stop a WebSocket server handle |
 
 `http_get/post/put/patch/delete/request/session_request` return
-`{status: int, headers: dict, body: string, ok: bool}`.
+`{status: int, headers: dict, body: string, ok: bool, final_url: string}`.
 `http_download` returns `{bytes_written, status, headers, ok}`.
 Options: `timeout_ms` (alias `timeout`, both in ms), `total_timeout_ms`,
 `connect_timeout_ms`, `read_timeout_ms`, `retry: {max, backoff_ms}`,
@@ -1002,6 +1002,54 @@ returned handle can be inspected with `http_stream_info`, drained with
 repeated `http_stream_read(stream, max_bytes)`, and closed explicitly with
 `http_stream_close`. Reads return `bytes`; once the stream is exhausted they
 return `nil`.
+
+### std/web
+
+Import deterministic web-source helpers with `import { ... } from "std/web"`.
+They reuse the normal Harn HTTP stack, so egress policy, proxies, TLS options,
+sessions, retries, and `http_mock` apply exactly as they do for
+`http_request`. Sensitive request headers and query params remain governed by
+the HTTP mock redaction rules; `std/web` adds source provenance but does not
+log response bodies by itself.
+
+| Function | Args | Returns | Description |
+|---|---|---|---|
+| `web_fetch(url, options?)` | url: string, options: dict | dict | Fetch a source and return `{ok, status, body, headers, content_type, etag, last_modified, fetched_at, cache_status, source_url, final_url, not_modified}` |
+| `web_parse_html(html, source_url?)` | html: string, source_url: string or nil | dict | Extract `{title, meta, canonical_url, links, tables, json_ld, text}` from deterministic HTTP-fetched HTML |
+| `web_resolve_url(base_url, href)` | base_url: string, href: string | string or nil | Resolve a relative URL reference against a source URL |
+| `web_origin_url(url, path?)` | url: string, path: string | string | Return the URL origin with a replacement path and no query or fragment. Relative paths are rooted at `/` |
+| `robots_allowed(url, user_agent?, options?)` | url: string, user_agent: string, options: dict | bool | Check robots.txt using mocked or real HTTP. Missing/non-2xx robots files allow by default |
+| `sitemap_urls(base_url, options?)` | base_url: string, options: dict | list of strings | Discover URLs from robots-advertised sitemaps or `/sitemap.xml` |
+| `html_title/html_meta/html_links/html_tables/html_json_ld/html_text` | html: string, source_url?: string | value | Convenience projections over `web_parse_html` |
+
+`web_fetch` accepts normal `http_request` options directly, or an explicit
+`http_options` dict. Passing `store` from `std/cache` enables recurring
+conditional fetches: cached `ETag` and `Last-Modified` values become
+`If-None-Match` and `If-Modified-Since` request headers, and a 304 response
+returns the cached body with `cache_status: "not_modified"`. Pass `previous`
+to use a prior envelope without a cache store, `cache_key` to override the
+cache key, `conditional: false` to suppress conditional headers, and
+`fetched_at` to pin deterministic fixture timestamps. The default cache key is
+method plus the effective request URL after `query` options are applied, so
+distinct query variants do not share a cached envelope.
+
+`robots_allowed` implements a deterministic robots subset for source-ingest
+workflows: exact user-agent groups take precedence over wildcard groups,
+multiple matching groups at the same specificity are combined, and
+Allow/Disallow decisions use longest-prefix matching with Allow winning ties.
+
+```harn
+import { mem_cache } from "std/cache"
+import { web_fetch, web_parse_html, robots_allowed, sitemap_urls } from "std/web"
+
+let store = mem_cache({namespace: "weekly-doc-monitor"})
+let page = web_fetch("https://docs.example.com/models", {store: store})
+if page.cache_status != "not_modified" && robots_allowed(page.final_url) {
+  let parsed = web_parse_html(page.body, page.final_url)
+  println(parsed.title)
+  println(sitemap_urls(page.final_url))
+}
+```
 
 HTTP server TLS helper builtins only describe listener/security policy. Runtime
 hosts such as `harn serve` consume the same modes: `plain` for deliberate


### PR DESCRIPTION
## Summary
- add `std/web` with deterministic `web_fetch`, conditional cache refresh, robots/sitemap helpers, URL helpers, and HTML extraction projections
- add Rust VM helpers for HTML title/meta/canonical/link/table/JSON-LD/text extraction and expose HTTP `final_url` for real and mocked requests
- document egress/redaction/cache-key/robots behavior and add conformance fixtures for the issue acceptance criteria

Closes #1494

## Verification
- `CARGO_TARGET_DIR=/tmp/harn-target-1494 cargo run --quiet --bin harn -- test conformance --filter web_`
- `CARGO_TARGET_DIR=/tmp/harn-target-1494 make check-docs-snippets`
- `CARGO_TARGET_DIR=/tmp/harn-target-1494 make fmt-harn`
- `CARGO_TARGET_DIR=/tmp/harn-target-1494 make lint-harn`
- `CARGO_TARGET_DIR=/tmp/harn-target-1494 make conformance`
- `CARGO_TARGET_DIR=/tmp/harn-target-1494 make test`
- `CARGO_TARGET_DIR=/tmp/harn-target-1494 cargo clippy -p harn-vm --lib -- -D warnings`
- pre-commit hook: workspace clippy, markdownlint, highlight keyword sync
- pre-push hook: targeted Rust/Harn/docs/generated-file checks