### PR TITLE
[codex] Allow optional required-reason schema fields

### DIFF
--- a/conformance/tests/integration/tool_middleware_with_required_reason.expected
+++ b/conformance/tests/integration/tool_middleware_with_required_reason.expected
@@ -6,7 +6,14 @@ false
 /tmp/x
 true
 true
+true
 Brief one-line reason for invoking this tool
 true
 ship the fix
 false
+true
+false
+false
+true
+(no reason given)
+/tmp/y

--- a/conformance/tests/integration/tool_middleware_with_required_reason.harn
+++ b/conformance/tests/integration/tool_middleware_with_required_reason.harn
@@ -4,7 +4,8 @@
  * 1. Calls without `reason` are short-circuited with status `schema_violation`.
  * 2. Calls with `reason` strip it from the args passed to `next` and surface
  *    it on `audit.summary`.
- * 3. The paired schema_transform makes `reason` a required parameter.
+ * 3. The paired schema_transform makes `reason` a required parameter by default.
+ * 4. Schema-required mode can be relaxed for forgiving native-provider surfaces.
  */
 import { with_required_reason } from "std/llm/tool_middleware"
 
@@ -64,6 +65,7 @@ pipeline default() {
   let entry = mw.schema_transform(tools.tools[0])
   println(contains(entry.parameters.properties.keys(), "reason"))
   println(contains(entry.parameters.required, "reason"))
+  println(entry.parameters.properties.reason.required)
   println(entry.parameters.properties.reason.description)
   // (4) custom field name + audit_key.
   let mw2 = with_required_reason({field: "intent", audit_key: "rationale"})
@@ -71,4 +73,16 @@ pipeline default() {
   println(r3.ok)
   println(r3.audit.rationale)
   println(contains(r3.arguments.keys(), "intent"))
+  // (5) tolerant native-provider surfaces can advertise `reason` without
+  // marking it required. Missing reasons still flow through the audit layer,
+  // but original args are preserved when `strip: false`.
+  let mw3 = with_required_reason({on_missing: "fill_blank", strip: false, schema_required: false})
+  let entry3 = mw3.schema_transform(tools.tools[0])
+  println(contains(entry3.parameters.properties.keys(), "reason"))
+  println(contains(entry3.parameters.required, "reason"))
+  println(entry3.parameters.properties.reason.required)
+  let r4 = mw3.caller(envelope("read", {path: "/tmp/y"}), next)
+  println(r4.ok)
+  println(r4.audit.summary)
+  println(r4.arguments.path)
 }

--- a/crates/harn-stdlib/src/stdlib/llm/tool_middleware.harn
+++ b/crates/harn-stdlib/src/stdlib/llm/tool_middleware.harn
@@ -321,6 +321,7 @@ pub fn compose_tool_callers(wrappers) {
  *   audit_key:     string   // where to store on `audit` (default "summary")
  *   min_length:    int      // reject calls shorter than this (default 1)
  *   on_missing:    string   // "reject" | "fill_blank" (default "reject")
+ *   schema_required: bool   // mark the reason field required in the tool schema (default true)
  *
  * Apply with:
  *
@@ -336,8 +337,9 @@ pub fn with_required_reason(opts = nil) {
   let audit_key = to_string(cfg?.audit_key ?? "summary")
   let min_length = cfg?.min_length ?? 1
   let on_missing = to_string(cfg?.on_missing ?? "reject")
-  let schema_fragment = {type: "string", description: description}
-  let schema_transform = { entry -> return tool_inject_param(entry, field, schema_fragment, {required: true}) }
+  let schema_required = cfg?.schema_required ?? true
+  let schema_fragment = {type: "string", description: description, required: schema_required}
+  let schema_transform = { entry -> return tool_inject_param(entry, field, schema_fragment, {required: schema_required}) }
   let caller = { call, next ->
     let raw = call.tool_args?[field]
     let value = if type_of(raw) == "string" {
@@ -929,7 +931,7 @@ pub fn with_timeout(opts) {
   let per_tool = __tool_mw_dict(cfg?.per_tool)
   let message = to_string(cfg?.message ?? "tool call exceeded time budget")
   return { call, next ->
-    let limit = if per_tool?[call.tool_name] != nil {
+    let limit = if per_tool[call.tool_name] != nil {
       per_tool[call.tool_name]
     } else {
       default_ms

--- a/docs/src/stdlib/tool-middleware.md
+++ b/docs/src/stdlib/tool-middleware.md
@@ -114,13 +114,20 @@ their own right.
 ### `with_required_reason(opts?) -> {schema_transform, caller}`
 
 The originating use case. Returns a paired schema decorator + execution
-caller. Forces every tool call to provide a non-empty `reason` (or a
-custom-named field), strips it before delegating to `next`, and surfaces
-it on `audit.summary`.
+caller. By default it forces every tool call to provide a non-empty
+`reason` (or a custom-named field), strips it before delegating to
+`next`, and surfaces it on `audit.summary`.
 
 Options: `field` (default `"reason"`), `description`, `strip` (bool,
 default true), `audit_key` (default `"summary"`), `min_length` (default
-1), `on_missing` (`"reject"` (default) or `"fill_blank"`).
+1), `on_missing` (`"reject"` (default) or `"fill_blank"`), and
+`schema_required` (bool, default true).
+
+Set `schema_required: false` with `on_missing: "fill_blank"` when a host
+wants the audit field advertised but cannot trust provider-native tool
+schema enforcement. This keeps the real tool arguments intact even when
+the model omits the synthetic `reason` field, while still recording
+`"(no reason given)"` in the audit summary.
 
 ```harn,ignore
 let mw = with_required_reason()


### PR DESCRIPTION
## Summary

- Add `schema_required` to `std/llm/tool_middleware.with_required_reason` so hosts can advertise a synthetic `reason` field without marking it required in provider-native schemas.
- Preserve the existing strict default while enabling tolerant `fill_blank` mode for providers that omit synthetic reasoning fields.
- Document the option and add conformance coverage for both default-required and tolerant-schema behavior.

## Validation

- `cargo run --quiet --bin harn -- test conformance --filter tool_middleware_with_required_reason`
- `cargo run --quiet --bin harn -- test conformance --filter agent_loop_reasoning_policy`
- pre-commit and pre-push hooks passed, including affected Harn format/lint, markdown lint, and highlight keyword drift check.
