### PR TITLE
Fix shape literal inference for untyped return fields

### DIFF
--- a/conformance/tests/types/type_narrowing_early_exit.expected
+++ b/conformance/tests/types/type_narrowing_early_exit.expected
@@ -1,3 +1,5 @@
 [harn] got: hello
 [harn] was nil
 [harn] safe: world
+[harn] v1
+[harn] v2

--- a/conformance/tests/types/type_narrowing_early_exit.harn
+++ b/conformance/tests/types/type_narrowing_early_exit.harn
@@ -1,4 +1,6 @@
 /** Test post-branch narrowing when one branch exits early */
+type NarrowDoc = {version: string}
+
 pipeline test(task) {
   fn early_return(x: string?) -> string {
     if x == nil {
@@ -17,7 +19,22 @@ pipeline test(task) {
     // else branch threw, so truthy refinements apply: x is string
     return "safe: ${x}"
   }
+  fn early_throw_shape_return(version: string?) -> NarrowDoc {
+    if version == nil {
+      throw "missing version"
+    }
+    return {version: version}
+  }
+  fn early_throw_untyped_shape_return(raw: dict<string, unknown>) -> NarrowDoc {
+    let version = raw.get("version")
+    if version == nil {
+      throw "missing version"
+    }
+    return {version: version}
+  }
   log(early_return("hello"))
   log(early_return(nil))
   log(early_throw_else("world"))
+  log(early_throw_shape_return("v1").version)
+  log(early_throw_untyped_shape_return({version: "v2"}).version)
 }

--- a/crates/harn-parser/src/typechecker/inference/expressions.rs
+++ b/crates/harn-parser/src/typechecker/inference/expressions.rs
@@ -267,7 +267,7 @@ impl TypeChecker {
                     };
                     let val_type = self
                         .infer_type(&entry.value, scope)
-                        .unwrap_or(TypeExpr::Named("nil".into()));
+                        .unwrap_or_else(Self::wildcard_type);
                     fields.push(ShapeField {
                         name: key,
                         type_expr: val_type,


### PR DESCRIPTION
## Summary

- Keep untyped shape-literal field expressions gradual instead of inferring them as `nil`
- Add conformance coverage for throw-barrier narrowing into structural returns, including the `dict<string, unknown>.get(...)` repro from #1509

Fixes #1509

## Verification

- `cargo run --quiet --bin harn -- test conformance --filter type_narrowing_early_exit`
- `cargo test -p harn-parser`
- `cargo run --quiet --bin harn -- test conformance`
- `make test lint-harn fmt-harn lint-test-patterns`
- `make lint`
- pre-commit hook
- pre-push hook