### PR TITLE
Bound Windows release-smoke watch cleanup

### DIFF
--- a/scripts/release_smoke.sh
+++ b/scripts/release_smoke.sh
@@ -60,11 +60,28 @@ terminate_pid_tree() {
   local pid="$1"
   if [[ "$PLATFORM" == "windows" ]]; then
     taskkill //F //T //PID "$pid" >/dev/null 2>&1 || true
+    kill "$pid" 2>/dev/null || true
+    sleep 1
+    kill -0 "$pid" 2>/dev/null && kill -9 "$pid" 2>/dev/null || true
   else
     kill "$pid" 2>/dev/null || true
     sleep 2
     kill -0 "$pid" 2>/dev/null && kill -9 "$pid" 2>/dev/null || true
   fi
+}
+
+wait_for_pid_exit() {
+  local pid="$1"
+  local timeout_seconds="$2"
+  local elapsed=0
+  while kill -0 "$pid" 2>/dev/null; do
+    if [[ "$elapsed" -ge "$timeout_seconds" ]]; then
+      return 1
+    fi
+    sleep 1
+    elapsed=$((elapsed + 1))
+  done
+  return 0
 }
 
 run_with_timeout() {
@@ -77,7 +94,11 @@ run_with_timeout() {
     if [[ "$elapsed" -ge "$timeout_seconds" ]]; then
       echo "release-smoke ($PLATFORM): command exceeded ${timeout_seconds}s; terminating"
       terminate_pid_tree "$cmd_pid"
-      wait "$cmd_pid" 2>/dev/null || true
+      if wait_for_pid_exit "$cmd_pid" 5; then
+        wait "$cmd_pid" 2>/dev/null || true
+      else
+        echo "release-smoke ($PLATFORM): command did not exit after termination request"
+      fi
       return 124
     fi
     sleep 1
@@ -151,14 +172,13 @@ smoke_watch_boot() {
     fi
     sleep 0.5
   done
-  if [[ "$PLATFORM" == "windows" ]]; then
-    # Git Bash translates `kill` to a Cygwin signal that harn.exe does
-    # not catch; taskkill is the portable forceful shutdown.
-    taskkill //F //PID "$watch_pid" >/dev/null 2>&1 || true
+  terminate_pid_tree "$watch_pid"
+  if wait_for_pid_exit "$watch_pid" 5; then
+    wait "$watch_pid" 2>/dev/null || true
   else
-    kill "$watch_pid" 2>/dev/null || true
+    echo "harn watch did not exit after termination request on $PLATFORM"
+    return 1
   fi
-  wait "$watch_pid" 2>/dev/null || true
   if [[ "$ready" -ne 1 ]]; then
     echo "harn watch did not reach the ready state on $PLATFORM"
     echo "--- watch log ---"


### PR DESCRIPTION
## Summary
- make release-smoke termination try both native Windows taskkill and Bash signal cleanup
- bound post-termination waits so a stuck `harn watch boot` reports a capability failure instead of consuming the full GitHub step timeout
- reuse the shared cleanup path for the watch boot probe

Follow-up from watching #1511 while closing #1509.

## Verification
- bash -n scripts/release_smoke.sh
- HARN_BINARY=/tmp/harn-release-smoke-fix-target/debug/harn HARN_RELEASE_SMOKE_STEP_TIMEOUT_SECONDS=30 ./scripts/release_smoke.sh
- pre-commit hook
- pre-push hook