### PR TITLE
Bound Windows release smoke watch cleanup

### DIFF
--- a/scripts/release_smoke.sh
+++ b/scripts/release_smoke.sh
@@ -60,11 +60,28 @@ terminate_pid_tree() {
   local pid="$1"
   if [[ "$PLATFORM" == "windows" ]]; then
     taskkill //F //T //PID "$pid" >/dev/null 2>&1 || true
+    kill "$pid" 2>/dev/null || true
+    sleep 1
+    kill -0 "$pid" 2>/dev/null && kill -9 "$pid" 2>/dev/null || true
   else
     kill "$pid" 2>/dev/null || true
     sleep 2
     kill -0 "$pid" 2>/dev/null && kill -9 "$pid" 2>/dev/null || true
   fi
+}
+
+wait_for_pid_exit() {
+  local pid="$1"
+  local timeout_seconds="$2"
+  local elapsed=0
+  while kill -0 "$pid" 2>/dev/null; do
+    if [[ "$elapsed" -ge "$timeout_seconds" ]]; then
+      return 1
+    fi
+    sleep 1
+    elapsed=$((elapsed + 1))
+  done
+  return 0
 }
 
 run_with_timeout() {
@@ -77,7 +94,11 @@ run_with_timeout() {
     if [[ "$elapsed" -ge "$timeout_seconds" ]]; then
       echo "release-smoke ($PLATFORM): command exceeded ${timeout_seconds}s; terminating"
       terminate_pid_tree "$cmd_pid"
-      wait "$cmd_pid" 2>/dev/null || true
+      if wait_for_pid_exit "$cmd_pid" 5; then
+        wait "$cmd_pid" 2>/dev/null || true
+      else
+        echo "release-smoke ($PLATFORM): command did not exit after termination request"
+      fi
       return 124
     fi
     sleep 1
@@ -151,14 +172,13 @@ smoke_watch_boot() {
     fi
     sleep 0.5
   done
-  if [[ "$PLATFORM" == "windows" ]]; then
-    # Git Bash translates `kill` to a Cygwin signal that harn.exe does
-    # not catch; taskkill is the portable forceful shutdown.
-    taskkill //F //PID "$watch_pid" >/dev/null 2>&1 || true
+  terminate_pid_tree "$watch_pid"
+  if wait_for_pid_exit "$watch_pid" 5; then
+    wait "$watch_pid" 2>/dev/null || true
   else
-    kill "$watch_pid" 2>/dev/null || true
+    echo "harn watch did not exit after termination request on $PLATFORM"
+    return 1
   fi
-  wait "$watch_pid" 2>/dev/null || true
   if [[ "$ready" -ne 1 ]]; then
     echo "harn watch did not reach the ready state on $PLATFORM"
     echo "--- watch log ---"


### PR DESCRIPTION
## Summary
- Prevents `scripts/release_smoke.sh` from hanging indefinitely while cleaning up `harn watch` on Windows.
- Uses `taskkill /T` plus the existing Git Bash kill path, then bounds the post-termination wait so the outer step timeout cannot stall the whole action for another 10 minutes.
- Applies the same bounded wait to the generic timeout cleanup path.

This follows up the merged #1513 run, where Windows release smoke timed out in `harn watch boot` even though the earlier smoke commands passed.

## Verification
- `bash -n scripts/release_smoke.sh`
- `git diff --check origin/main...HEAD`
- `HARN_BINARY=/var/folders/1h/v3ltwjgn6h79_77xhvgxwgm80000gn/T//harn-target/7d38-harn/debug/harn ./scripts/release_smoke.sh`
- Pre-commit hook
- Pre-push hook
