### PR TITLE
[personas] Transparent profile bulletin schema and tool contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,19 @@ condensed series summaries instead of full per-patch history.
   pure-logic helpers and every adapter shape (HTML, JSON, skipped
   key-required, key-required-with-key, conflicting observation,
   context-window-only change, fetch error).
+- **Transparent profile bulletin schema and tool contract (#1506).** Added
+  `std/personas/bulletins` with the `harn.profile_bulletin.v1` envelope for
+  durable persona/user/project/team facts. Proposals carry stable id, scope,
+  scope key, subject, persona, context key, assertion, status, confidence,
+  structured evidence, source provenance, privacy/sync flags, and optional
+  TTL/review timestamps. `bulletin_emit` always writes status `proposed` to
+  `personas.bulletins.proposed`; hosts emit `harn.profile_bulletin_decision.v1`
+  envelopes (`accept`, `reject`, `expire`, `supersede`) on
+  `personas.bulletins.decisions` so review history is replayable.
+  `bulletin_apply_decisions`, `bulletin_partition`, and `bulletin_active` keep
+  prompt context derived from accepted, non-expired bulletins; the
+  `bulletin_render_for_prompt` renderer visibly separates accepted facts from
+  pending proposals so models cannot confuse them.
 
 ## v0.8.10
 

--- a/README.md
+++ b/README.md
@@ -178,6 +178,15 @@ defaults, safe, prompts, catalog).
   verifier-then-actor gates, bounded loops, cheap-classifier escalation,
   circuit-broken parallel sweeps, audit receipt wrappers, and approval gates
   give durable personas reusable control flow without host-specific glue.
+- Transparent profile bulletin proposals via
+  `import "std/personas/bulletins"`: `bulletin_propose` builds typed
+  `harn.profile_bulletin.v1` envelopes with stable id, scope, evidence,
+  source, privacy, and TTL fields; `bulletin_emit` always writes proposals
+  to `personas.bulletins.proposed`, and `bulletin_accept` / `bulletin_reject`
+  / `bulletin_expire` / `bulletin_supersede` emit
+  `harn.profile_bulletin_decision.v1` audit records so hosts (Burin local,
+  Harn Cloud) can review persona context instead of accepting silent prompt
+  mutation.
 - Delegated worker lifecycle builtins via `spawn_agent(...)`, `send_input(...)`,
   `resume_agent(...)`, `wait_agent(...)`, `close_agent(...)`, and `list_agents()`,
   with child run lineage, persisted worker snapshots, and host-visible worker

--- a/conformance/tests/stdlib/profile_bulletins.expected
+++ b/conformance/tests/stdlib/profile_bulletins.expected
@@ -1,0 +1,42 @@
+harn.profile_bulletin.v1
+proposed
+user
+0.92
+local_only
+2
+true
+true
+harn.profile_bulletin_emit_receipt.v1
+profile_bulletin_proposed
+proposed
+profile_bulletin_proposed
+harn.profile_bulletin.v1
+user
+accept
+accepted
+user
+profile_bulletin_decision
+accept
+accepted
+1
+0
+0
+Accepted facts:
+- kenneth: prefers concise responses without trailing summaries [conf 92%]
+
+Proposed (pending review — do not treat as fact):
+- kenneth: uses gh to look up repo URLs rather than guessing [conf 80%]
+Accepted facts:
+- kenneth: prefers concise responses without trailing summaries [conf 92%]
+2
+supersede
+true
+true
+rejected
+expired
+true
+true
+true
+true
+true
+true

--- a/conformance/tests/stdlib/profile_bulletins.harn
+++ b/conformance/tests/stdlib/profile_bulletins.harn
@@ -1,0 +1,176 @@
+import {
+  bulletin_accept,
+  bulletin_active,
+  bulletin_apply_decisions,
+  bulletin_decide,
+  bulletin_dedupe,
+  bulletin_emit,
+  bulletin_emit_decision,
+  bulletin_expire,
+  bulletin_id,
+  bulletin_partition,
+  bulletin_propose,
+  bulletin_reject,
+  bulletin_render_for_prompt,
+  bulletin_supersede,
+  bulletin_validate,
+} from "std/personas/bulletins"
+
+pipeline default() {
+  let proposed = bulletin_propose(
+    {
+      scope: "user",
+      scope_key: "kenneth@example.com",
+      subject: "kenneth",
+      persona: "burin_home",
+      context_key: "preferences",
+      assertion: "prefers concise responses without trailing summaries",
+      confidence: 0.92,
+      source: {agent: "burin_home_curator", workflow: "memory_review", run_id: "run-1"},
+      evidence: [
+        {kind: "user_msg", ref: "msg-42", excerpt: "stop summarizing"},
+        {kind: "transcript", ref: "transcript-7"},
+      ],
+      privacy: {sync: "local_only", redacted: false, contains_sensitive: false, redaction_hints: []},
+      proposed_at: "2026-05-11T16:00:00.000Z",
+      review_after: "2026-08-11T00:00:00.000Z",
+    },
+  )
+  println(proposed.schema)
+  println(proposed.status)
+  println(proposed.scope)
+  println(proposed.confidence)
+  println(proposed.privacy.sync)
+  println(len(proposed.evidence))
+  let stable_id = bulletin_id(
+    "user",
+    "kenneth@example.com",
+    "kenneth",
+    "prefers concise responses without trailing summaries",
+    "burin_home",
+  )
+  println(proposed.id == stable_id)
+  let validated = bulletin_validate(proposed)
+  println(validated.id == proposed.id)
+  let proposal_receipt = bulletin_emit(proposed, {topic: "personas.bulletins.test.proposed"})
+  println(proposal_receipt.schema)
+  println(proposal_receipt.kind)
+  println(proposal_receipt.bulletin.status)
+  let proposal_stream = event_log
+    .subscribe(
+    {topic: "personas.bulletins.test.proposed", from_cursor: proposal_receipt.event_log_id - 1},
+  )
+  let proposal_event = proposal_stream.next().value
+  println(proposal_event.kind)
+  println(proposal_event.headers.schema)
+  println(proposal_event.payload.scope)
+  let accept_receipt = bulletin_accept(
+    proposed,
+    {
+      topic: "personas.bulletins.test.decisions",
+      decided_by: "user",
+      decided_at: "2026-05-11T16:05:00.000Z",
+      rationale: "Matches stated preference",
+    },
+  )
+  println(accept_receipt.decision.action)
+  println(accept_receipt.decision.status)
+  println(accept_receipt.decision.decided_by)
+  let decision_stream = event_log
+    .subscribe(
+    {topic: "personas.bulletins.test.decisions", from_cursor: accept_receipt.event_log_id - 1},
+  )
+  let decision_event = decision_stream.next().value
+  println(decision_event.kind)
+  println(decision_event.headers.action)
+  let updated = bulletin_apply_decisions([proposed], [accept_receipt.decision])
+  println(updated[0].status)
+  let partitioned = bulletin_partition(updated)
+  println(len(partitioned.accepted))
+  println(len(partitioned.proposed))
+  let expired_proposed = proposed + {expires_at: "2020-01-01T00:00:00.000Z"}
+  let expired_after_accept = bulletin_apply_decisions([expired_proposed], [accept_receipt.decision])
+  let active = bulletin_active(expired_after_accept, "2026-05-11T16:10:00.000Z")
+  println(len(active))
+  let second = bulletin_propose(
+    {
+      scope: "user",
+      scope_key: "kenneth@example.com",
+      subject: "kenneth",
+      assertion: "uses gh to look up repo URLs rather than guessing",
+      confidence: 0.8,
+      source: {agent: "merge_captain"},
+      evidence: [{kind: "user_msg", ref: "msg-43"}],
+    },
+  )
+  let rendered = bulletin_render_for_prompt(updated + [second])
+  println(rendered)
+  let rendered_accepted_only = bulletin_render_for_prompt(updated + [second], {include_proposed: false})
+  println(rendered_accepted_only)
+  let dedup = bulletin_dedupe([proposed, proposed, second])
+  println(len(dedup))
+  let supersede_receipt = bulletin_supersede(
+    second,
+    [proposed.id],
+    {
+      decided_by: "user",
+      decided_at: "2026-05-11T17:00:00.000Z",
+      topic: "personas.bulletins.test.decisions",
+    },
+  )
+  println(supersede_receipt.decision.action)
+  println(supersede_receipt.decision.supersedes[0] == proposed.id)
+  println(supersede_receipt.topic == "personas.bulletins.test.decisions")
+  let reject_receipt = bulletin_reject(
+    proposed,
+    {
+      decided_by: "user",
+      decided_at: "2026-05-11T16:30:00.000Z",
+      rationale: "duplicate",
+      topic: "personas.bulletins.test.decisions",
+    },
+  )
+  println(reject_receipt.decision.status)
+  let expire_receipt = bulletin_expire(
+    proposed,
+    {
+      decided_by: "policy",
+      decided_at: "2026-05-11T16:45:00.000Z",
+      topic: "personas.bulletins.test.decisions",
+    },
+  )
+  println(expire_receipt.decision.status)
+  let bad_scope = try {
+    bulletin_propose({scope: "weird", scope_key: "x", subject: "x", assertion: "x", confidence: 0.5})
+  }
+  println(is_err(bad_scope))
+  let bad_confidence = try {
+    bulletin_propose({scope: "user", scope_key: "x", subject: "x", assertion: "x", confidence: 1.5})
+  }
+  println(is_err(bad_confidence))
+  let missing_assertion = try {
+    bulletin_propose({scope: "user", scope_key: "x", subject: "x", confidence: 0.5})
+  }
+  println(is_err(missing_assertion))
+  let supersede_missing = try {
+    bulletin_decide(second, "supersede", {})
+  }
+  println(is_err(supersede_missing))
+  let bad_decision_schema = try {
+    bulletin_emit_decision({schema: "not.real.v1", bulletin_id: "x"})
+  }
+  println(is_err(bad_decision_schema))
+  let bad_sync = try {
+    bulletin_propose(
+      {
+        scope: "user",
+        scope_key: "x",
+        subject: "x",
+        assertion: "x",
+        confidence: 0.5,
+        privacy: {sync: "outerspace"},
+      },
+    )
+  }
+  println(is_err(bad_sync))
+}

--- a/crates/harn-stdlib/src/lib.rs
+++ b/crates/harn-stdlib/src/lib.rs
@@ -378,6 +378,10 @@ pub const STDLIB_SOURCES: &[StdlibSource] = &[
         source: include_str!("stdlib/stdlib_personas_prelude.harn"),
     },
     StdlibSource {
+        module: "personas/bulletins",
+        source: include_str!("stdlib/stdlib_personas_bulletins.harn"),
+    },
+    StdlibSource {
         module: "connectors/shared",
         source: include_str!("stdlib/stdlib_connectors_shared.harn"),
     },
@@ -845,6 +849,7 @@ mod tests {
             "llm/ensemble",
             "llm/rerank",
             "personas/prelude",
+            "personas/bulletins",
             "agent/host_tools",
             "agent/user",
             "llm/optimize",

--- a/crates/harn-stdlib/src/stdlib/stdlib_personas_bulletins.harn
+++ b/crates/harn-stdlib/src/stdlib/stdlib_personas_bulletins.harn
@@ -1,0 +1,651 @@
+import { filter_nil } from "std/collections"
+
+/**
+ * std/personas/bulletins — transparent profile bulletin proposals.
+ *
+ * Persona-shaped agents propose durable facts about a user, project, team, or
+ * task as typed `harn.profile_bulletin.v1` records. Proposals never silently
+ * enter prompt context as durable fact; hosts own the review/persistence
+ * decision and record a separate `harn.profile_bulletin_decision.v1` envelope
+ * for each accept, reject, expire, or supersede outcome.
+ *
+ * The same envelope is consumable by Burin local review surfaces and Harn
+ * Cloud sync without per-host translation. Receipts retain the proposal and
+ * decision history so replay tooling can audit how persona context evolved.
+ */
+type BulletinScope = "user" | "project" | "workspace" | "task" | "team" | "session" | "global" | string
+
+type BulletinStatus = "proposed" | "accepted" | "rejected" | "expired" | "superseded" | string
+
+type BulletinSync = "local_only" | "host_default" | "tenant" | "shared" | string
+
+type BulletinDecisionAction = "accept" | "reject" | "expire" | "supersede" | string
+
+type BulletinEvidence = {kind: string, ref: string, label?: string, excerpt?: string}
+
+type BulletinSource = {
+  agent?: string,
+  workflow?: string,
+  persona?: string,
+  run_id?: string,
+  task?: string,
+}
+
+type BulletinPrivacy = {
+  sync: BulletinSync,
+  redacted: bool,
+  contains_sensitive: bool,
+  redaction_hints: list<string>,
+  flags: list<string>,
+}
+
+type ProfileBulletin = {
+  schema: "harn.profile_bulletin.v1",
+  id: string,
+  scope: BulletinScope,
+  scope_key: string,
+  subject: string,
+  persona?: string,
+  context_key?: string,
+  assertion: string,
+  status: BulletinStatus,
+  confidence: float,
+  evidence: list<BulletinEvidence>,
+  source: BulletinSource,
+  privacy: BulletinPrivacy,
+  proposed_at: string,
+  expires_at?: string,
+  review_after?: string,
+  supersedes: list<string>,
+}
+
+type ProfileBulletinDecision = {
+  schema: "harn.profile_bulletin_decision.v1",
+  bulletin_id: string,
+  action: BulletinDecisionAction,
+  status: BulletinStatus,
+  decided_at: string,
+  decided_by: string,
+  rationale?: string,
+  supersedes: list<string>,
+}
+
+type BulletinProposeReceipt = {
+  schema: "harn.profile_bulletin_emit_receipt.v1",
+  topic: string,
+  kind: "profile_bulletin_proposed",
+  event_log_id: int,
+  bulletin: ProfileBulletin,
+}
+
+type BulletinDecisionReceipt = {
+  schema: "harn.profile_bulletin_decision_receipt.v1",
+  topic: string,
+  kind: "profile_bulletin_decision",
+  event_log_id: int,
+  decision: ProfileBulletinDecision,
+}
+
+type BulletinPartition = {
+  proposed: list<ProfileBulletin>,
+  accepted: list<ProfileBulletin>,
+  rejected: list<ProfileBulletin>,
+  expired: list<ProfileBulletin>,
+  superseded: list<ProfileBulletin>,
+}
+
+let BULLETIN_SCHEMA = "harn.profile_bulletin.v1"
+
+let BULLETIN_DECISION_SCHEMA = "harn.profile_bulletin_decision.v1"
+
+let BULLETIN_PROPOSED_KIND = "profile_bulletin_proposed"
+
+let BULLETIN_DECISION_KIND = "profile_bulletin_decision"
+
+let BULLETIN_PROPOSAL_TOPIC = "personas.bulletins.proposed"
+
+let BULLETIN_DECISION_TOPIC = "personas.bulletins.decisions"
+
+let BULLETIN_VALID_SCOPES = ["user", "project", "workspace", "task", "team", "session", "global"]
+
+let BULLETIN_VALID_STATUSES = ["proposed", "accepted", "rejected", "expired", "superseded"]
+
+let BULLETIN_VALID_ACTIONS = ["accept", "reject", "expire", "supersede"]
+
+let BULLETIN_VALID_SYNC = ["local_only", "host_default", "tenant", "shared"]
+
+fn __bulletin_text(value) {
+  if value == nil {
+    return ""
+  }
+  return trim(to_string(value))
+}
+
+fn __bulletin_first(values) {
+  for value in values {
+    let text = __bulletin_text(value)
+    if text != "" {
+      return text
+    }
+  }
+  return nil
+}
+
+fn __bulletin_confidence(value) -> float {
+  if value == nil {
+    return 0.5
+  }
+  let kind = type_of(value)
+  if kind != "int" && kind != "float" {
+    throw "std/personas/bulletins: confidence must be a number"
+  }
+  return value + 0.0
+}
+
+fn __bulletin_list(value) {
+  if value == nil {
+    return []
+  }
+  if type_of(value) != "list" {
+    throw "std/personas/bulletins: expected a list value"
+  }
+  return value
+}
+
+fn __bulletin_in(needle, allowed) -> bool {
+  for candidate in allowed {
+    if candidate == needle {
+      return true
+    }
+  }
+  return false
+}
+
+fn __bulletin_string_list(value) -> list<string> {
+  let raw = __bulletin_list(value)
+  var out = []
+  for entry in raw {
+    let text = __bulletin_text(entry)
+    if text != "" {
+      out = out.push(text)
+    }
+  }
+  return out
+}
+
+fn __bulletin_evidence_entry(entry) -> BulletinEvidence {
+  if entry == nil {
+    throw "std/personas/bulletins: evidence entries must not be nil"
+  }
+  if type_of(entry) != "dict" {
+    throw "std/personas/bulletins: evidence entries must be dicts"
+  }
+  let kind = __bulletin_text(entry?.kind)
+  let ref = __bulletin_text(entry?.ref)
+  if kind == "" {
+    throw "std/personas/bulletins: evidence.kind is required"
+  }
+  if ref == "" {
+    throw "std/personas/bulletins: evidence.ref is required"
+  }
+  let label = __bulletin_first([entry?.label])
+  let excerpt = __bulletin_first([entry?.excerpt])
+  return filter_nil({kind: kind, ref: ref, label: label, excerpt: excerpt})
+}
+
+fn __bulletin_evidence(value) -> list<BulletinEvidence> {
+  let raw = __bulletin_list(value)
+  var out = []
+  for entry in raw {
+    out = out.push(__bulletin_evidence_entry(entry))
+  }
+  return out
+}
+
+fn __bulletin_source(value) -> BulletinSource {
+  if value == nil {
+    return {}
+  }
+  if type_of(value) != "dict" {
+    throw "std/personas/bulletins: source must be a dict"
+  }
+  return filter_nil(
+    {
+      agent: __bulletin_first([value?.agent]),
+      workflow: __bulletin_first([value?.workflow]),
+      persona: __bulletin_first([value?.persona]),
+      run_id: __bulletin_first([value?.run_id, value?.run]),
+      task: __bulletin_first([value?.task]),
+    },
+  )
+}
+
+fn __bulletin_privacy(value) -> BulletinPrivacy {
+  let raw = value ?? {}
+  if type_of(raw) != "dict" {
+    throw "std/personas/bulletins: privacy must be a dict"
+  }
+  let sync = __bulletin_text(raw?.sync)
+  let resolved_sync = if sync == "" {
+    "host_default"
+  } else {
+    if !__bulletin_in(sync, BULLETIN_VALID_SYNC) {
+      throw "std/personas/bulletins: unknown privacy.sync `" + sync + "`"
+    }
+    sync
+  }
+  return {
+    sync: resolved_sync,
+    redacted: raw?.redacted ?? false,
+    contains_sensitive: raw?.contains_sensitive ?? false,
+    redaction_hints: __bulletin_string_list(raw?.redaction_hints),
+    flags: __bulletin_string_list(raw?.flags),
+  }
+}
+
+/** Build the stable bulletin id from scope, scope_key, subject, persona, and assertion. */
+pub fn bulletin_id(scope, scope_key, subject, assertion, persona = nil) -> string {
+  let seed = lowercase(__bulletin_text(scope))
+    + "\n"
+    + __bulletin_text(scope_key)
+    + "\n"
+    + __bulletin_text(subject)
+    + "\n"
+    + __bulletin_text(persona)
+    + "\n"
+    + __bulletin_text(assertion)
+  return "bulletin_" + substring(sha256(seed), 0, 32)
+}
+
+fn __bulletin_resolve_scope(value) -> string {
+  let scope = lowercase(__bulletin_text(value))
+  if scope == "" {
+    throw "std/personas/bulletins: scope is required"
+  }
+  if !__bulletin_in(scope, BULLETIN_VALID_SCOPES) {
+    throw "std/personas/bulletins: unknown scope `" + scope + "`"
+  }
+  return scope
+}
+
+fn __bulletin_resolve_status(value) -> string {
+  let status = lowercase(__bulletin_text(value))
+  if status == "" {
+    return "proposed"
+  }
+  if !__bulletin_in(status, BULLETIN_VALID_STATUSES) {
+    throw "std/personas/bulletins: unknown status `" + status + "`"
+  }
+  return status
+}
+
+fn __bulletin_resolve_action(value) -> string {
+  let action = lowercase(__bulletin_text(value))
+  if action == "" {
+    throw "std/personas/bulletins: decision action is required"
+  }
+  if !__bulletin_in(action, BULLETIN_VALID_ACTIONS) {
+    throw "std/personas/bulletins: unknown decision action `" + action + "`"
+  }
+  return action
+}
+
+fn __bulletin_status_for_action(action) -> string {
+  if action == "accept" {
+    return "accepted"
+  }
+  if action == "reject" {
+    return "rejected"
+  }
+  if action == "expire" {
+    return "expired"
+  }
+  return "superseded"
+}
+
+/** Validate that a bulletin envelope has the required fields and shapes. */
+pub fn bulletin_validate(bulletin: ProfileBulletin) -> ProfileBulletin {
+  if bulletin.schema != BULLETIN_SCHEMA {
+    throw "std/personas/bulletins: unsupported schema " + __bulletin_text(bulletin.schema)
+  }
+  for key in ["id", "scope", "scope_key", "subject", "assertion", "status", "proposed_at"] {
+    if __bulletin_text(bulletin[key]) == "" {
+      throw "std/personas/bulletins: " + key + " is required"
+    }
+  }
+  let _ = __bulletin_resolve_scope(bulletin.scope)
+  let _ = __bulletin_resolve_status(bulletin.status)
+  let confidence = bulletin.confidence
+  if confidence == nil {
+    throw "std/personas/bulletins: confidence is required"
+  }
+  let kind = type_of(confidence)
+  if kind != "int" && kind != "float" {
+    throw "std/personas/bulletins: confidence must be a number"
+  }
+  if confidence < 0.0 || confidence > 1.0 {
+    throw "std/personas/bulletins: confidence must be in [0, 1]"
+  }
+  return bulletin
+}
+
+/**
+ * Build a `harn.profile_bulletin.v1` proposal. Proposals default to
+ * `status = "proposed"` so they never silently enter durable context.
+ */
+pub fn bulletin_propose(input, options = nil) -> ProfileBulletin {
+  if input == nil || type_of(input) != "dict" {
+    throw "std/personas/bulletins: bulletin_propose requires a dict input"
+  }
+  let opts = options ?? {}
+  let scope = __bulletin_resolve_scope(opts?.scope ?? input?.scope)
+  let scope_key = __bulletin_text(opts?.scope_key ?? input?.scope_key)
+  if scope_key == "" {
+    throw "std/personas/bulletins: scope_key is required"
+  }
+  let subject = __bulletin_text(opts?.subject ?? input?.subject)
+  if subject == "" {
+    throw "std/personas/bulletins: subject is required"
+  }
+  let assertion = __bulletin_text(opts?.assertion ?? input?.assertion)
+  if assertion == "" {
+    throw "std/personas/bulletins: assertion is required"
+  }
+  let persona = __bulletin_first([opts?.persona, input?.persona])
+  let context_key = __bulletin_first([opts?.context_key, input?.context_key])
+  let status = __bulletin_resolve_status(opts?.status ?? input?.status ?? "proposed")
+  let confidence = __bulletin_confidence(opts?.confidence ?? input?.confidence ?? 0.5)
+  let evidence = __bulletin_evidence(opts?.evidence ?? input?.evidence)
+  let source = __bulletin_source(opts?.source ?? input?.source)
+  let privacy = __bulletin_privacy(opts?.privacy ?? input?.privacy)
+  let proposed_at = __bulletin_first([opts?.proposed_at, input?.proposed_at]) ?? date_now_iso()
+  let expires_at = __bulletin_first([opts?.expires_at, input?.expires_at])
+  let review_after = __bulletin_first([opts?.review_after, input?.review_after])
+  let supersedes = __bulletin_string_list(opts?.supersedes ?? input?.supersedes)
+  let id = __bulletin_first([opts?.id, input?.id])
+    ?? bulletin_id(scope, scope_key, subject, assertion, persona)
+  let bulletin = {
+    schema: BULLETIN_SCHEMA,
+    id: id,
+    scope: scope,
+    scope_key: scope_key,
+    subject: subject,
+    persona: persona,
+    context_key: context_key,
+    assertion: assertion,
+    status: status,
+    confidence: confidence,
+    evidence: evidence,
+    source: source,
+    privacy: privacy,
+    proposed_at: proposed_at,
+    expires_at: expires_at,
+    review_after: review_after,
+    supersedes: supersedes,
+  }
+  return bulletin_validate(filter_nil(bulletin))
+}
+
+/** Drop duplicate proposals by stable bulletin id, preserving first-seen order. */
+pub fn bulletin_dedupe(bulletins: list) -> list<ProfileBulletin> {
+  var seen = {}
+  var out = []
+  for entry in bulletins {
+    let bulletin = entry?.schema == BULLETIN_SCHEMA ? entry : bulletin_propose(entry)
+    if seen[bulletin.id] == nil {
+      seen[bulletin.id] = true
+      out = out.push(bulletin)
+    }
+  }
+  return out
+}
+
+/**
+ * Emit a bulletin proposal to the EventLog and return an audit receipt.
+ *
+ * Hosts read the proposal topic to surface bulletins for review. The emit is
+ * always status `proposed`: callers that want to record an already-accepted
+ * decision should use `bulletin_emit_decision`.
+ */
+pub fn bulletin_emit(input, options = nil) -> BulletinProposeReceipt {
+  let opts = options ?? {}
+  let raw = input?.schema == BULLETIN_SCHEMA ? bulletin_validate(input) : bulletin_propose(input, opts)
+  let bulletin = raw + {status: "proposed"}
+  let topic = opts?.topic ?? BULLETIN_PROPOSAL_TOPIC
+  let event_log_id = event_log
+    .emit(
+    topic,
+    BULLETIN_PROPOSED_KIND,
+    bulletin,
+    {
+      schema: BULLETIN_SCHEMA,
+      bulletin_id: bulletin.id,
+      scope: bulletin.scope,
+      scope_key: bulletin.scope_key,
+    },
+  )
+  return {
+    schema: "harn.profile_bulletin_emit_receipt.v1",
+    topic: topic,
+    kind: BULLETIN_PROPOSED_KIND,
+    event_log_id: event_log_id,
+    bulletin: bulletin,
+  }
+}
+
+/** Build a typed decision envelope without writing to the EventLog. */
+pub fn bulletin_decide(bulletin: ProfileBulletin, action, options = nil) -> ProfileBulletinDecision {
+  let opts = options ?? {}
+  let resolved_action = __bulletin_resolve_action(action)
+  let status = __bulletin_status_for_action(resolved_action)
+  let decided_at = __bulletin_first([opts?.decided_at]) ?? date_now_iso()
+  let decided_by = __bulletin_text(opts?.decided_by)
+  let resolved_by = decided_by == "" ? "host" : decided_by
+  let rationale = __bulletin_first([opts?.rationale])
+  let supersedes_input = if resolved_action == "supersede" {
+    __bulletin_string_list(opts?.supersedes ?? bulletin?.supersedes)
+  } else {
+    []
+  }
+  if resolved_action == "supersede" && len(supersedes_input) == 0 {
+    throw "std/personas/bulletins: supersede decisions must list at least one prior bulletin id"
+  }
+  let decision = {
+    schema: BULLETIN_DECISION_SCHEMA,
+    bulletin_id: __bulletin_text(bulletin?.id),
+    action: resolved_action,
+    status: status,
+    decided_at: decided_at,
+    decided_by: resolved_by,
+    rationale: rationale,
+    supersedes: supersedes_input,
+  }
+  if decision.bulletin_id == "" {
+    throw "std/personas/bulletins: decision requires a bulletin_id"
+  }
+  return filter_nil(decision)
+}
+
+/** Emit a decision envelope to the EventLog and return an audit receipt. */
+pub fn bulletin_emit_decision(decision: ProfileBulletinDecision, options = nil) -> BulletinDecisionReceipt {
+  let opts = options ?? {}
+  if decision.schema != BULLETIN_DECISION_SCHEMA {
+    throw "std/personas/bulletins: unsupported decision schema " + __bulletin_text(decision.schema)
+  }
+  if __bulletin_text(decision.bulletin_id) == "" {
+    throw "std/personas/bulletins: decision bulletin_id is required"
+  }
+  let topic = opts?.topic ?? BULLETIN_DECISION_TOPIC
+  let event_log_id = event_log
+    .emit(
+    topic,
+    BULLETIN_DECISION_KIND,
+    decision,
+    {schema: BULLETIN_DECISION_SCHEMA, bulletin_id: decision.bulletin_id, action: decision.action},
+  )
+  return {
+    schema: "harn.profile_bulletin_decision_receipt.v1",
+    topic: topic,
+    kind: BULLETIN_DECISION_KIND,
+    event_log_id: event_log_id,
+    decision: decision,
+  }
+}
+
+/** Shorthand: build and emit an accept decision for a bulletin. */
+pub fn bulletin_accept(bulletin: ProfileBulletin, options = nil) -> BulletinDecisionReceipt {
+  return bulletin_emit_decision(bulletin_decide(bulletin, "accept", options), options)
+}
+
+/** Shorthand: build and emit a reject decision. Rationale should be supplied. */
+pub fn bulletin_reject(bulletin: ProfileBulletin, options = nil) -> BulletinDecisionReceipt {
+  return bulletin_emit_decision(bulletin_decide(bulletin, "reject", options), options)
+}
+
+/** Shorthand: build and emit an expire decision (TTL elapsed or out of date). */
+pub fn bulletin_expire(bulletin: ProfileBulletin, options = nil) -> BulletinDecisionReceipt {
+  return bulletin_emit_decision(bulletin_decide(bulletin, "expire", options), options)
+}
+
+/** Shorthand: supersede prior bulletin ids with this proposal. */
+pub fn bulletin_supersede(bulletin: ProfileBulletin, supersedes: list<string>, options = nil) -> BulletinDecisionReceipt {
+  let merged = options ?? {} + {supersedes: supersedes}
+  return bulletin_emit_decision(bulletin_decide(bulletin, "supersede", merged), merged)
+}
+
+fn __bulletin_decision_index(decisions) {
+  var index = {}
+  for raw in __bulletin_list(decisions) {
+    if raw?.schema != BULLETIN_DECISION_SCHEMA {
+      continue
+    }
+    let id = __bulletin_text(raw?.bulletin_id)
+    if id == "" {
+      continue
+    }
+    let existing = index[id]
+    if existing == nil || __bulletin_text(raw?.decided_at) >= __bulletin_text(existing?.decided_at) {
+      index = index + {[id]: raw}
+    }
+  }
+  return index
+}
+
+/**
+ * Apply the latest decision per bulletin id and return bulletins with their
+ * effective `status` field updated. Bulletins without a recorded decision keep
+ * their original status (typically `proposed`).
+ */
+pub fn bulletin_apply_decisions(bulletins: list, decisions: list) -> list<ProfileBulletin> {
+  let index = __bulletin_decision_index(decisions)
+  var out = []
+  for bulletin in __bulletin_list(bulletins) {
+    let decision = index[bulletin?.id]
+    if decision == nil {
+      out = out.push(bulletin)
+    } else {
+      out = out.push(bulletin + {status: decision.status})
+    }
+  }
+  return out
+}
+
+/** Partition bulletins by their effective status. */
+pub fn bulletin_partition(bulletins: list) -> BulletinPartition {
+  var proposed = []
+  var accepted = []
+  var rejected = []
+  var expired = []
+  var superseded = []
+  for bulletin in __bulletin_list(bulletins) {
+    let status = __bulletin_resolve_status(bulletin?.status)
+    if status == "accepted" {
+      accepted = accepted.push(bulletin)
+    } else if status == "rejected" {
+      rejected = rejected.push(bulletin)
+    } else if status == "expired" {
+      expired = expired.push(bulletin)
+    } else if status == "superseded" {
+      superseded = superseded.push(bulletin)
+    } else {
+      proposed = proposed.push(bulletin)
+    }
+  }
+  return {
+    proposed: proposed,
+    accepted: accepted,
+    rejected: rejected,
+    expired: expired,
+    superseded: superseded,
+  }
+}
+
+fn __bulletin_expired_now(bulletin, now_iso) -> bool {
+  let expires = __bulletin_text(bulletin?.expires_at)
+  if expires == "" {
+    return false
+  }
+  return expires <= now_iso
+}
+
+/**
+ * Return only bulletins that are still active for prompt context — accepted
+ * status and not past `expires_at`. Proposals are excluded so they never
+ * become durable fact without an accept decision.
+ */
+pub fn bulletin_active(bulletins: list, now = nil) -> list<ProfileBulletin> {
+  let now_iso = __bulletin_text(now) == "" ? date_now_iso() : __bulletin_text(now)
+  var out = []
+  for bulletin in __bulletin_list(bulletins) {
+    let status = __bulletin_resolve_status(bulletin?.status)
+    if status == "accepted" && !__bulletin_expired_now(bulletin, now_iso) {
+      out = out.push(bulletin)
+    }
+  }
+  return out
+}
+
+fn __bulletin_render_line(bulletin) -> string {
+  let confidence_pct = round(bulletin.confidence * 100.0)
+  let subject = __bulletin_text(bulletin?.subject)
+  let prefix = subject == "" ? "" : subject + ": "
+  return "- " + prefix + __bulletin_text(bulletin.assertion)
+    + " [conf "
+    + to_string(confidence_pct)
+    + "%]"
+}
+
+/**
+ * Render bulletins as a prompt-ready block that visibly distinguishes accepted
+ * facts from proposed ones. Proposals are listed under a "Proposed (pending
+ * review)" heading so models cannot confuse them with durable, host-reviewed
+ * fact. Pass `{include_proposed: false}` to drop proposals entirely.
+ */
+pub fn bulletin_render_for_prompt(bulletins: list, options = nil) -> string {
+  let opts = options ?? {}
+  let now = __bulletin_text(opts?.now)
+  let active_only = opts?.active_only ?? true
+  let include_proposed = opts?.include_proposed ?? true
+  let parts = bulletin_partition(bulletins)
+  let accepted_pool = if active_only {
+    bulletin_active(parts.accepted, now == "" ? nil : now)
+  } else {
+    parts.accepted
+  }
+  var sections = []
+  if len(accepted_pool) > 0 {
+    var lines = ["Accepted facts:"]
+    for bulletin in accepted_pool {
+      lines = lines.push(__bulletin_render_line(bulletin))
+    }
+    sections = sections.push(join(lines, "\n"))
+  }
+  if include_proposed && len(parts.proposed) > 0 {
+    var lines = ["Proposed (pending review — do not treat as fact):"]
+    for bulletin in parts.proposed {
+      lines = lines.push(__bulletin_render_line(bulletin))
+    }
+    sections = sections.push(join(lines, "\n"))
+  }
+  return join(sections, "\n\n")
+}

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -2001,6 +2001,50 @@ let rendered = ui_select_for_host(result, host_capabilities)
 Examples: `examples/ui_resource/dashboard-widget.harn`,
 `examples/ui_resource/review-form.harn`.
 
+### Profile bulletins stdlib
+
+Use `std/personas/bulletins` when an agent learns a durable fact about a
+person, project, team, or task. Bulletins are proposals — they never silently
+enter durable context, and hosts emit separate decision events so the review
+trail is replayable:
+
+```harn
+import { bulletin_propose, bulletin_emit, bulletin_accept, bulletin_render_for_prompt } from "std/personas/bulletins"
+
+let bulletin = bulletin_propose(
+  {
+    scope: "user",
+    scope_key: "kenneth@example.com",
+    subject: "kenneth",
+    persona: "burin_home",
+    assertion: "prefers concise responses without trailing summaries",
+    confidence: 0.92,
+    source: {agent: "burin_home_curator"},
+    evidence: [{kind: "user_msg", ref: "msg-42"}],
+    privacy: {sync: "local_only"},
+  },
+)
+let _proposal = bulletin_emit(bulletin)
+let _accepted = bulletin_accept(bulletin, {decided_by: "user"})
+```
+
+- `bulletin_propose(input, options?)` returns `harn.profile_bulletin.v1` with
+  `id`, `scope`, `scope_key`, `subject`, `assertion`, `status` (always
+  `proposed` by default), `confidence` in `[0, 1]`, structured `evidence`,
+  `source`, `privacy`, `proposed_at`, optional `expires_at` and `review_after`,
+  and optional `supersedes` list.
+- `bulletin_emit(input, options?)` always writes status `proposed` to
+  `personas.bulletins.proposed`, even when the input has a different status.
+- `bulletin_accept` / `bulletin_reject` / `bulletin_expire` /
+  `bulletin_supersede` build and emit a typed
+  `harn.profile_bulletin_decision.v1` envelope on
+  `personas.bulletins.decisions`. `bulletin_supersede` requires at least one
+  prior bulletin id.
+- `bulletin_active(bulletins, now?)` returns only `accepted` bulletins still
+  within their TTL; `bulletin_render_for_prompt(bulletins, options?)` renders
+  prompt-ready text that visibly separates accepted facts from proposals
+  pending review. Pass `{include_proposed: false}` to drop proposals.
+
 Workflow stages pick up a session id from `model_policy.session_id`;
 two stages sharing an id share their conversation automatically. The
 pre-0.7 `transcript_policy` dict (with `mode: "reset" | "fork"`) was

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -58,6 +58,7 @@
 - [Skills](./skills.md)
 - [Personas](./personas.md)
   - [Persona Prelude](./personas/prelude.md)
+  - [Profile bulletins](./personas/profile-bulletins.md)
   - [Merge Captain](./personas/merge-captain.md)
 - [Skill provenance](./skill-provenance.md)
 - [Sessions](./sessions.md)

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -397,6 +397,11 @@ Imports starting with `std/` load embedded stdlib modules:
   (verify_then_act, bounded_loop, cheap_classify_then_escalate,
   parallel_sweep_with_circuit_breaker, with_audit_receipt,
   with_approval_gate)
+- `import "std/personas/bulletins"` — transparent profile bulletin proposals
+  and host-owned decisions (bulletin_propose, bulletin_emit, bulletin_accept,
+  bulletin_reject, bulletin_expire, bulletin_supersede, bulletin_decide,
+  bulletin_apply_decisions, bulletin_partition, bulletin_active,
+  bulletin_render_for_prompt, bulletin_dedupe)
 
 These modules are compiled into the interpreter binary and require no
 filesystem access.

--- a/docs/src/modules.md
+++ b/docs/src/modules.md
@@ -86,6 +86,7 @@ described below (`std/text`, `std/json`, `std/math`, `std/collections`,
 `std/experiments`,
 `std/project`, `std/memory`, `std/prompt_library`, `std/monitors`,
 `std/triage`, `std/worktree`, `std/checkpoint`, `std/personas/prelude`,
+`std/personas/bulletins`,
 `std/connectors/shared`, and provider-specific `std/connectors/...` modules).
 These add layered
 utilities on top of the core builtins; the core builtins themselves are
@@ -116,6 +117,7 @@ import "std/llm/prompts"
 import "std/math"
 import "std/monitors"
 import "std/path"
+import "std/personas/bulletins"
 import "std/personas/prelude"
 import "std/prompt_library"
 import "std/review"
@@ -845,6 +847,27 @@ Helpers for isolated git worktree execution built on `exec_at(...)` and
 | `worktree_status(path)` | Run `git status --short --branch` in the worktree |
 | `worktree_diff(path, base_ref?)` | Render diff output for the worktree |
 | `worktree_shell(path, script)` | Run an arbitrary shell command inside the worktree |
+
+### std/personas/bulletins
+
+Transparent profile bulletin envelopes for durable persona facts. See
+[Profile bulletins](./personas/profile-bulletins.md) for the full envelope and
+review semantics.
+
+| Function | Description |
+|---|---|
+| `bulletin_propose(input, options?)` | Build a `harn.profile_bulletin.v1` proposal with stable id, evidence, source, and privacy fields |
+| `bulletin_id(scope, scope_key, subject, assertion, persona?)` | Compute the stable bulletin id for matching/dedupe |
+| `bulletin_validate(bulletin)` | Throw if the envelope is missing required fields or has out-of-range confidence |
+| `bulletin_emit(input, options?)` | Append a `proposed` bulletin to `personas.bulletins.proposed` and return an emit receipt |
+| `bulletin_decide(bulletin, action, options?)` | Build a typed `harn.profile_bulletin_decision.v1` envelope without emitting |
+| `bulletin_emit_decision(decision, options?)` | Append a decision envelope to `personas.bulletins.decisions` |
+| `bulletin_accept` / `bulletin_reject` / `bulletin_expire` / `bulletin_supersede` | Decide-and-emit shorthands |
+| `bulletin_apply_decisions(bulletins, decisions)` | Project the latest decision per id onto bulletins |
+| `bulletin_partition(bulletins)` | Group bulletins by status |
+| `bulletin_active(bulletins, now?)` | Return `accepted` bulletins still within their TTL |
+| `bulletin_render_for_prompt(bulletins, options?)` | Render an audit-friendly prompt block distinguishing accepted facts from proposals |
+| `bulletin_dedupe(bulletins)` | Drop duplicate bulletins by stable id |
 
 ### std/personas/prelude
 

--- a/docs/src/personas/profile-bulletins.md
+++ b/docs/src/personas/profile-bulletins.md
@@ -1,0 +1,119 @@
+# Profile bulletins
+
+`std/personas/bulletins` is Harn's typed envelope for proposing durable
+persona/user/project/team facts. Bulletins make persona context auditable and
+reviewable rather than hidden prompt mutation: an agent emits a
+`harn.profile_bulletin.v1` proposal, the host decides whether to accept it, and
+both events stay in the EventLog for replay.
+
+```harn
+import {
+  bulletin_propose,
+  bulletin_emit,
+  bulletin_accept,
+  bulletin_render_for_prompt,
+} from "std/personas/bulletins"
+
+let bulletin = bulletin_propose(
+  {
+    scope: "user",
+    scope_key: "kenneth@example.com",
+    subject: "kenneth",
+    persona: "burin_home",
+    context_key: "preferences",
+    assertion: "prefers concise responses without trailing summaries",
+    confidence: 0.92,
+    source: {agent: "burin_home_curator", workflow: "memory_review"},
+    evidence: [
+      {kind: "user_msg", ref: "msg-42", excerpt: "stop summarizing"},
+    ],
+    privacy: {sync: "local_only"},
+  },
+)
+let proposal = bulletin_emit(bulletin)
+let decision = bulletin_accept(bulletin, {decided_by: "user"})
+```
+
+## Envelope
+
+`bulletin_propose(input, options?)` returns `harn.profile_bulletin.v1`:
+
+| Field | Purpose |
+|---|---|
+| `id` | Stable hash derived from `(scope, scope_key, subject, persona, assertion)` |
+| `scope` | `user`, `project`, `workspace`, `task`, `team`, `session`, or `global` |
+| `scope_key` | Stable target identifier (e.g. email, repo slug, task id) |
+| `subject` | Display label for the fact (e.g. `"kenneth"`, `"harn"`) |
+| `persona` | Optional persona name this bulletin is bound to |
+| `context_key` | Optional context tag such as `"preferences"` or `"constraints"` |
+| `assertion` | The durable fact text |
+| `status` | `proposed` (default), `accepted`, `rejected`, `expired`, or `superseded` |
+| `confidence` | Number in `[0, 1]`; out-of-range or non-numeric values throw |
+| `evidence` | List of `{kind, ref, label?, excerpt?}` provenance pointers |
+| `source` | `{agent?, workflow?, persona?, run_id?, task?}` proposing context |
+| `privacy` | `{sync, redacted, contains_sensitive, redaction_hints, flags}` |
+| `proposed_at` | ISO timestamp (defaults to `date_now_iso()`) |
+| `expires_at`, `review_after` | Optional ISO timestamps for host TTL/review prompts |
+| `supersedes` | Optional list of prior bulletin ids this proposal would replace |
+
+`scope`, `scope_key`, `subject`, `assertion`, `confidence`, and `proposed_at`
+are required. `privacy.sync` defaults to `host_default` and must be one of
+`local_only`, `host_default`, `tenant`, or `shared`.
+
+## Decisions
+
+Hosts review proposals and emit decisions on the
+`personas.bulletins.decisions` topic. Each decision is itself an auditable
+record (`harn.profile_bulletin_decision.v1`) so the proposal/decision history
+is replayable.
+
+| Helper | Action |
+|---|---|
+| `bulletin_accept(bulletin, options?)` | Decision `accept`; status becomes `accepted` |
+| `bulletin_reject(bulletin, options?)` | Decision `reject`; status becomes `rejected` |
+| `bulletin_expire(bulletin, options?)` | Decision `expire` for TTL or staleness |
+| `bulletin_supersede(bulletin, supersedes, options?)` | Replaces prior bulletin ids |
+| `bulletin_decide(bulletin, action, options?)` | Build a typed decision envelope without emitting |
+| `bulletin_emit_decision(decision, options?)` | Emit a prebuilt decision |
+
+`bulletin_supersede` requires at least one prior bulletin id; the helpers
+accept `decided_by` (`"host"`, `"user"`, `"policy"`, …), `decided_at`,
+`rationale`, and a custom `topic`.
+
+## Prompt context
+
+Bulletins must never silently enter context as durable fact:
+
+- `bulletin_emit` always writes status `proposed`, regardless of any
+  caller-provided override.
+- `bulletin_active(bulletins, now?)` returns only `accepted` bulletins that
+  have not passed `expires_at` — proposals are excluded.
+- `bulletin_render_for_prompt(bulletins, options?)` renders accepted facts and
+  proposals under separate headings. The proposed section is labeled
+  `"Proposed (pending review — do not treat as fact)"` so models can see the
+  boundary. Pass `{include_proposed: false}` to drop proposals entirely.
+
+```harn,ignore
+let prompt_text = bulletin_render_for_prompt(known_bulletins)
+```
+
+## Replay and dedupe
+
+- `bulletin_dedupe(bulletins)` drops duplicate proposals by stable `id`,
+  preserving first-seen order.
+- `bulletin_apply_decisions(bulletins, decisions)` projects the latest
+  decision per `id` onto a list of bulletins, returning copies with their
+  effective `status` updated. The original bulletin records are not mutated.
+- `bulletin_partition(bulletins)` returns
+  `{proposed, accepted, rejected, expired, superseded}` lists.
+
+## Action boundary
+
+`bulletin_emit` returns a `harn.profile_bulletin_emit_receipt.v1` envelope
+with the EventLog id and the `proposed` bulletin payload.
+`bulletin_emit_decision` returns
+`harn.profile_bulletin_decision_receipt.v1`. Hosts subscribe to
+`personas.bulletins.proposed` and `personas.bulletins.decisions` for review
+surfaces and to fan out cloud sync once a decision is durable. Harn never
+performs the persistence; the host decides what (if anything) to store and
+which sync tier (`local_only`, `host_default`, `tenant`, `shared`) applies.

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -395,6 +395,11 @@ Imports starting with `std/` load embedded stdlib modules:
   (verify_then_act, bounded_loop, cheap_classify_then_escalate,
   parallel_sweep_with_circuit_breaker, with_audit_receipt,
   with_approval_gate)
+- `import "std/personas/bulletins"` — transparent profile bulletin proposals
+  and host-owned decisions (bulletin_propose, bulletin_emit, bulletin_accept,
+  bulletin_reject, bulletin_expire, bulletin_supersede, bulletin_decide,
+  bulletin_apply_decisions, bulletin_partition, bulletin_active,
+  bulletin_render_for_prompt, bulletin_dedupe)
 
 These modules are compiled into the interpreter binary and require no
 filesystem access.


### PR DESCRIPTION
## Summary

- Adds `std/personas/bulletins` with the `harn.profile_bulletin.v1` envelope
  for transparent, auditable persona/user/project/team facts (closes #1506).
- Proposals carry stable id, scope, scope key, subject, persona, context
  key, assertion, status, confidence, structured evidence, source
  provenance, privacy/sync flags, and optional TTL/review timestamps.
- `bulletin_emit` always writes status `proposed` to
  `personas.bulletins.proposed`; hosts emit
  `harn.profile_bulletin_decision.v1` envelopes (`accept`, `reject`,
  `expire`, `supersede`) on `personas.bulletins.decisions` so review
  history is replayable from the EventLog.
- `bulletin_apply_decisions`, `bulletin_partition`, `bulletin_active`, and
  `bulletin_render_for_prompt` keep prompt context derived from accepted,
  non-expired bulletins and visibly separate accepted facts from pending
  proposals so models cannot treat proposals as fact.
- Updates module docs, the LLM quickref, language spec, CHANGELOG, README,
  and the docs `SUMMARY.md` table of contents.

## Test plan

- [x] `CARGO_TARGET_DIR=/tmp/harn-target-1506 cargo run --bin harn -- test conformance --filter profile_bulletins`
- [x] `CARGO_TARGET_DIR=/tmp/harn-target-1506 cargo run --bin harn -- test conformance` (994 passed)
- [x] `CARGO_TARGET_DIR=/tmp/harn-target-1506 HARN_LLM_CALLS_DISABLED=1 make test` (3620 passed)
- [x] `CARGO_TARGET_DIR=/tmp/harn-target-1506 cargo test -p harn-stdlib`
- [x] `CARGO_TARGET_DIR=/tmp/harn-target-1506 make check-docs-snippets`
- [x] `CARGO_TARGET_DIR=/tmp/harn-target-1506 make lint-test-patterns`
- [x] `CARGO_TARGET_DIR=/tmp/harn-target-1506 make lint-md`
- [x] `CARGO_TARGET_DIR=/tmp/harn-target-1506 make lint-harn` / `make fmt-harn`
- [x] `CARGO_TARGET_DIR=/tmp/harn-target-1506 make check-language-spec` / `check-highlight` / `check-trigger-quickref` / `check-protocol-artifacts`
- [x] `CARGO_TARGET_DIR=/tmp/harn-target-1506 cargo clippy --workspace --all-targets -- -D warnings`
- [x] Pre-commit + pre-push hooks (Rust fmt + clippy, staged Harn fmt/lint, ratchets, highlight keyword drift, markdown lint, CHANGELOG drift check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)