### PR TITLE
Fix escaped interpolation in multiline strings

### DIFF
--- a/conformance/tests/strings/multiline_string_escaped_interpolation.expected
+++ b/conformance/tests/strings/multiline_string_escaped_interpolation.expected
@@ -1,0 +1,4 @@
+[harn] single=${VAR}
+[harn] shell ${VAR:-default}
+harn world
+[harn] only ${VAR}

--- a/conformance/tests/strings/multiline_string_escaped_interpolation.harn
+++ b/conformance/tests/strings/multiline_string_escaped_interpolation.harn
@@ -1,0 +1,14 @@
+pipeline test(task) {
+  let name = "world"
+  let single = "\${VAR}"
+  log("single=${single}")
+  let multi = """
+    shell \${VAR:-default}
+    harn ${name}
+    """
+  log(multi)
+  let escaped_only = """
+    only \${VAR}
+    """
+  log(escaped_only)
+}

--- a/crates/harn-fmt/src/helpers.rs
+++ b/crates/harn-fmt/src/helpers.rs
@@ -246,6 +246,7 @@ pub(crate) fn escape_string(s: &str) -> String {
         .replace('\r', "\\r")
         .replace('\t', "\\t")
         .replace('\0', "\\0")
+        .replace("${", "\\${")
 }
 
 /// Format the `(error_var: Type)` portion of a catch clause.

--- a/crates/harn-fmt/src/tests.rs
+++ b/crates/harn-fmt/src/tests.rs
@@ -1546,6 +1546,18 @@ fn test_multiline_interpolated_string_preserves_verbatim_body() {
 }
 
 #[test]
+fn test_string_literal_escapes_interpolation_start() {
+    let source = "pipeline test(task) {\n  let s = \"\\${VAR}\"\n  log(s)\n}\n";
+    let out = format_source(source).unwrap();
+    assert_eq!(
+        out, source,
+        "formatter should preserve escaped interpolation starts"
+    );
+    let out2 = format_source(&out).unwrap();
+    assert_eq!(out, out2, "formatter should be idempotent");
+}
+
+#[test]
 fn test_multi_nil_coalescing_chain_wraps_each_operand() {
     // A chain of ≥3 `??` operators must wrap with each operator at
     // line start and a +2-space continuation indent relative to the

--- a/crates/harn-lexer/src/lexer.rs
+++ b/crates/harn-lexer/src/lexer.rs
@@ -426,7 +426,7 @@ impl Lexer {
                         .collect();
                     let indent = common_indent(&full_text);
                     let segments = if indent > 0 {
-                        segments
+                        let stripped_segments = segments
                             .into_iter()
                             .map(|seg| match seg {
                                 StringSegment::Literal(s) => {
@@ -434,7 +434,8 @@ impl Lexer {
                                 }
                                 other => other,
                             })
-                            .collect()
+                            .collect();
+                        strip_trailing_newline_segments(stripped_segments)
                     } else {
                         strip_trailing_newline_segments(segments)
                     };
@@ -487,6 +488,21 @@ impl Lexer {
                 self.advance();
                 segments.push(StringSegment::Expression(expr, expr_line, expr_col));
                 continue;
+            }
+
+            if self.source[self.pos] == '\\'
+                && self.peek() == Some('$')
+                && self.source.get(self.pos + 2) == Some(&'{')
+            {
+                // Only an unpaired backslash escapes `${`; pairs remain literal text.
+                let preceding_backslashes =
+                    value.chars().rev().take_while(|ch| *ch == '\\').count();
+                if preceding_backslashes % 2 == 0 {
+                    self.advance();
+                    value.push('$');
+                    self.advance();
+                    continue;
+                }
             }
 
             if self.source[self.pos] == '\n' {
@@ -975,6 +991,36 @@ mod tests {
         } else {
             panic!("Expected interpolated string");
         }
+    }
+
+    #[test]
+    fn test_multiline_string_escaped_dollar_before_interpolation() {
+        let mut lexer = Lexer::new("\"\"\"\n  hi \\${VAR}\n  hello ${name}\n\"\"\"");
+        let tokens = lexer.tokenize().unwrap();
+        if let TokenKind::InterpolatedString(segs) = &tokens[0].kind {
+            assert_eq!(segs.len(), 2);
+            assert_eq!(segs[0], StringSegment::Literal("hi ${VAR}\nhello ".into()));
+            assert!(matches!(&segs[1], StringSegment::Expression(e, _, _) if e == "name"));
+        } else {
+            panic!("Expected interpolated string");
+        }
+    }
+
+    #[test]
+    fn test_multiline_string_escaped_dollar_without_interpolation() {
+        let mut lexer = Lexer::new("\"\"\"\n  hi \\${VAR}\n\"\"\"");
+        let tokens = lexer.tokenize().unwrap();
+        assert_eq!(tokens[0].kind, TokenKind::StringLiteral("hi ${VAR}".into()));
+    }
+
+    #[test]
+    fn test_multiline_string_preserves_non_interpolation_dollar_escape() {
+        let mut lexer = Lexer::new("\"\"\"\n  echo \\$PATH\n\"\"\"");
+        let tokens = lexer.tokenize().unwrap();
+        assert_eq!(
+            tokens[0].kind,
+            TokenKind::StringLiteral("echo \\$PATH".into())
+        );
     }
 
     #[test]

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -208,6 +208,7 @@ A trailing newline before the closing `"""` is removed.
 Multi-line strings support `${expression}` interpolation with automatic indent
 stripping. If at least one `${...}` interpolation is present, the result is an
 `interpolatedString` token; otherwise it is a plain `stringLiteral` token.
+Use `\${` for a literal `${` sequence inside a multi-line string.
 
 ```harn
 let name = "world"

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -206,6 +206,7 @@ A trailing newline before the closing `"""` is removed.
 Multi-line strings support `${expression}` interpolation with automatic indent
 stripping. If at least one `${...}` interpolation is present, the result is an
 `interpolatedString` token; otherwise it is a plain `stringLiteral` token.
+Use `\${` for a literal `${` sequence inside a multi-line string.
 
 ```harn
 let name = "world"


### PR DESCRIPTION
## Summary

- Treat `\${...}` in triple-quoted strings as literal `${...}` instead of starting interpolation.
- Preserve non-interpolation shell escapes like `\$PATH` in multi-line strings.
- Add lexer and conformance coverage, and sync the generated language spec docs.

Fixes #1548

## Verification

- `cargo test -p harn-lexer multiline_string`
- `cargo run --quiet --bin harn -- test conformance --filter multiline_string_escaped_interpolation`
- `cargo test -p harn-lexer`
- `make check-language-spec`
- `cargo run --quiet --bin harn -- test conformance --filter multiline_string`
- `make conformance`
- `make test`
- pre-commit hook
- pre-push hook
