### PR TITLE
Add std/tui pager helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ condensed series summaries instead of full per-patch history.
   `ok`/`eof`/`timeout`/`interrupt`/`error` statuses, writes prompts to stderr
   with ANSI preserved, supports sub-second Unix timeouts without shelling out
   to `bash`, and disables terminal echo for password-style prompts.
+- **Terminal pager helpers (#1543).** Added `std/tui` with `page(...)` for
+  long text/markdown artifacts, `terminal_width()`, `rule()`, and `clear()`.
+  `page` prints directly when stdout is not interactive, `no_pager` is set, or
+  `$PAGER=cat`; otherwise it uses `$PAGER` with `less -R -F -X` defaults and
+  falls back to print output when the pager binary is unavailable.
 
 ## v0.8.11
 

--- a/conformance/tests/stdlib/tui_helpers.expected
+++ b/conformance/tests/stdlib/tui_helpers.expected
@@ -1,0 +1,11 @@
+=====
+aaa
+true
+Report
+──────
+
+alpha
+beta
+--- end of Report ---
+paged=false
+ok=true

--- a/conformance/tests/stdlib/tui_helpers.harn
+++ b/conformance/tests/stdlib/tui_helpers.harn
@@ -1,0 +1,12 @@
+import { page, rule, terminal_width } from "std/tui"
+
+pipeline test(task) {
+  println(rule("=", 5))
+  println(rule("ab", 3))
+  println(terminal_width(1) > 0)
+  mock_tty("stdout", false)
+  let result = page({title: "Report", body: "alpha\nbeta", format: "markdown"})
+  println("paged=" + to_string(result.paged))
+  println("ok=" + to_string(result.ok))
+  unmock_tty()
+}

--- a/crates/harn-parser/src/builtin_signatures/signatures/stdlib.rs
+++ b/crates/harn-parser/src/builtin_signatures/signatures/stdlib.rs
@@ -184,6 +184,13 @@ pub(crate) const SIGNATURES: &[BuiltinSignature] = &[
         &[Param::optional("signal", TY_STRING)],
         TY_NIL,
     ),
+    BuiltinSignature::simple("__tui_clear", &[], TY_NIL),
+    BuiltinSignature::simple("__tui_page", &[Param::new("options", TY_DICT)], TY_DICT),
+    BuiltinSignature::simple(
+        "__tui_terminal_width",
+        &[Param::optional("default_width", TY_INT)],
+        TY_INT,
+    ),
     BuiltinSignature::simple(
         "__waitpoint_cancel",
         &[

--- a/crates/harn-stdlib/src/lib.rs
+++ b/crates/harn-stdlib/src/lib.rs
@@ -150,6 +150,10 @@ pub const STDLIB_SOURCES: &[StdlibSource] = &[
         source: include_str!("stdlib/stdlib_cli.harn"),
     },
     StdlibSource {
+        module: "tui",
+        source: include_str!("stdlib/stdlib_tui.harn"),
+    },
+    StdlibSource {
         module: "jsonl",
         source: include_str!("stdlib/stdlib_jsonl.harn"),
     },
@@ -981,6 +985,17 @@ mod tests {
             "git_toolbox_tools",
         ] {
             assert!(exports.contains(name), "std/git should export {name}");
+        }
+    }
+
+    #[test]
+    fn tui_stdlib_module_exports_terminal_helpers() {
+        let exports = public_functions_for_module("tui")
+            .into_iter()
+            .map(|function| function.name)
+            .collect::<BTreeSet<_>>();
+        for name in ["page", "terminal_width", "rule", "clear"] {
+            assert!(exports.contains(name), "std/tui should export {name}");
         }
     }
 

--- a/crates/harn-stdlib/src/stdlib/stdlib_tui.harn
+++ b/crates/harn-stdlib/src/stdlib/stdlib_tui.harn
@@ -1,0 +1,41 @@
+/** std/tui - terminal presentation helpers for interactive scripts. */
+type PageFormat = "text" | "markdown"
+
+type PageOptions = {
+  title?: string,
+  body: string,
+  format?: PageFormat,
+  no_pager?: bool,
+  footer?: string,
+}
+
+type PageResult = {ok: bool, paged: bool, error?: string}
+
+/** page shows a text or markdown artifact through a pager when stdout is interactive. */
+pub fn page(opts: PageOptions) -> PageResult {
+  return __tui_page(opts)
+}
+
+/** terminal_width returns the current terminal width, or default_width when unknown. */
+pub fn terminal_width(default_width = 80) -> int {
+  return __tui_terminal_width(default_width)
+}
+
+/** rule returns a repeated character line sized to width or the terminal width. */
+pub fn rule(char = "─", width = nil) -> string {
+  let mark = if type_of(char) == "string" && len(char) > 0 {
+    substring(char, 0, 1)
+  } else {
+    "─"
+  }
+  let resolved_width = width ?? terminal_width()
+  if resolved_width <= 0 {
+    return ""
+  }
+  return mark.repeat(resolved_width)
+}
+
+/** clear writes the ANSI clear-screen sequence to stdout. */
+pub fn clear() {
+  __tui_clear()
+}

--- a/crates/harn-vm/src/stdlib.rs
+++ b/crates/harn-vm/src/stdlib.rs
@@ -62,6 +62,7 @@ pub(crate) mod tools;
 pub mod tracing;
 mod transcript_compact;
 mod triggers_stdlib;
+mod tui;
 mod types;
 mod url_parse;
 mod vision;
@@ -130,6 +131,7 @@ pub fn register_io_stdlib(vm: &mut Vm) {
     testbench::register_testbench_builtins(vm);
     project::register_project_builtins(vm);
     tracing::register_tracing_builtins(vm);
+    tui::register_tui_builtins(vm);
 }
 
 /// Register agent builtins (requires network access and async runtime).

--- a/crates/harn-vm/src/stdlib/io.rs
+++ b/crates/harn-vm/src/stdlib/io.rs
@@ -120,7 +120,7 @@ fn write_stderr(line: &str) {
     }
 }
 
-fn write_stdout(out: &mut String, text: &str) {
+pub(crate) fn write_stdout(out: &mut String, text: &str) {
     if stdout_passthrough_enabled() {
         let mut stdout = std::io::stdout().lock();
         let _ = stdout.write_all(text.as_bytes());
@@ -477,7 +477,7 @@ fn read_stdin_line_real_with_options(options: &ReadLineOptions) -> ReadLineOutco
     }
 }
 
-fn is_tty_for(stream: &str) -> bool {
+pub(crate) fn is_tty_for(stream: &str) -> bool {
     let mocked = TTY_MOCK.with(|t| {
         let mock = *t.borrow();
         match stream {

--- a/crates/harn-vm/src/stdlib/tui.rs
+++ b/crates/harn-vm/src/stdlib/tui.rs
@@ -1,0 +1,382 @@
+//! Terminal UI builtins backing the Harn `std/tui` module.
+
+use std::collections::BTreeMap;
+use std::io::{ErrorKind, Write};
+use std::process::{Command, Stdio};
+use std::rc::Rc;
+
+use crate::value::{VmError, VmValue};
+use crate::vm::Vm;
+
+const CLEAR_SEQUENCE: &str = "\x1b[2J\x1b[H";
+const DEFAULT_TERMINAL_WIDTH: usize = 80;
+const DEFAULT_RULE_CHAR: &str = "─";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PageOptions {
+    title: Option<String>,
+    body: String,
+    footer: Option<String>,
+    format: PageFormat,
+    no_pager: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PageFormat {
+    Text,
+    Markdown,
+}
+
+pub(crate) fn register_tui_builtins(vm: &mut Vm) {
+    vm.register_builtin("__tui_page", tui_page_builtin);
+    vm.register_builtin("__tui_clear", |_args, out| {
+        super::io::write_stdout(out, CLEAR_SEQUENCE);
+        Ok(VmValue::Nil)
+    });
+    vm.register_builtin("__tui_terminal_width", |args, _out| {
+        let default = args
+            .first()
+            .and_then(VmValue::as_int)
+            .and_then(|n| usize::try_from(n).ok())
+            .filter(|n| *n > 0)
+            .unwrap_or(DEFAULT_TERMINAL_WIDTH);
+        Ok(VmValue::Int(terminal_width(default) as i64))
+    });
+}
+
+fn tui_page_builtin(args: &[VmValue], out: &mut String) -> Result<VmValue, VmError> {
+    let options = parse_page_options(args)?;
+    let content = render_page_content(&options);
+
+    if should_print_without_pager(&options) {
+        super::io::write_stdout(out, &content);
+        return Ok(page_result(true, false, None));
+    }
+
+    match run_pager(&content) {
+        Ok(()) => Ok(page_result(true, true, None)),
+        Err(PagerError::Unavailable(_)) => {
+            super::io::write_stdout(out, &content);
+            Ok(page_result(true, false, None))
+        }
+        Err(error) => Ok(page_result(false, true, Some(error.to_string()))),
+    }
+}
+
+fn parse_page_options(args: &[VmValue]) -> Result<PageOptions, VmError> {
+    let Some(VmValue::Dict(opts)) = args.first() else {
+        return Err(VmError::Runtime(
+            "page: options must be a dict with a body string".to_string(),
+        ));
+    };
+    let body = required_string(opts, "body", "page")?;
+    let title = optional_string(opts, "title", "page")?;
+    let footer = optional_string(opts, "footer", "page")?;
+    let no_pager = optional_bool(opts, "no_pager", "page")?.unwrap_or(false);
+    let format = match optional_string(opts, "format", "page")?.as_deref() {
+        None | Some("text") => PageFormat::Text,
+        Some("markdown") => PageFormat::Markdown,
+        Some(other) => {
+            return Err(VmError::Runtime(format!(
+                "page: format must be 'text' or 'markdown', got '{other}'"
+            )));
+        }
+    };
+    Ok(PageOptions {
+        title,
+        body,
+        footer,
+        format,
+        no_pager,
+    })
+}
+
+fn required_string(
+    opts: &BTreeMap<String, VmValue>,
+    key: &str,
+    builtin: &str,
+) -> Result<String, VmError> {
+    match opts.get(key) {
+        Some(VmValue::String(value)) => Ok(value.as_ref().to_string()),
+        Some(VmValue::Nil) | None => Err(VmError::Runtime(format!(
+            "{builtin}: missing string field '{key}'"
+        ))),
+        Some(other) => Err(VmError::Runtime(format!(
+            "{builtin}: field '{key}' must be a string, got {}",
+            other.type_name()
+        ))),
+    }
+}
+
+fn optional_string(
+    opts: &BTreeMap<String, VmValue>,
+    key: &str,
+    builtin: &str,
+) -> Result<Option<String>, VmError> {
+    match opts.get(key) {
+        Some(VmValue::String(value)) => Ok(Some(value.as_ref().to_string())),
+        Some(VmValue::Nil) | None => Ok(None),
+        Some(other) => Err(VmError::Runtime(format!(
+            "{builtin}: field '{key}' must be a string, got {}",
+            other.type_name()
+        ))),
+    }
+}
+
+fn optional_bool(
+    opts: &BTreeMap<String, VmValue>,
+    key: &str,
+    builtin: &str,
+) -> Result<Option<bool>, VmError> {
+    match opts.get(key) {
+        Some(VmValue::Bool(value)) => Ok(Some(*value)),
+        Some(VmValue::Nil) | None => Ok(None),
+        Some(other) => Err(VmError::Runtime(format!(
+            "{builtin}: field '{key}' must be a bool, got {}",
+            other.type_name()
+        ))),
+    }
+}
+
+fn render_page_content(options: &PageOptions) -> String {
+    let mut rendered = String::new();
+    if let Some(title) = options
+        .title
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        rendered.push_str(title);
+        rendered.push('\n');
+        rendered.push_str(&DEFAULT_RULE_CHAR.repeat(title.chars().count().max(3)));
+        rendered.push_str("\n\n");
+    }
+
+    let body = match options.format {
+        PageFormat::Text | PageFormat::Markdown => options.body.as_str(),
+    };
+    rendered.push_str(body);
+
+    if !rendered.ends_with('\n') {
+        rendered.push('\n');
+    }
+    let footer = options
+        .footer
+        .clone()
+        .unwrap_or_else(|| match options.title.as_deref() {
+            Some(title) if !title.trim().is_empty() => format!("--- end of {} ---", title.trim()),
+            _ => "--- end ---".to_string(),
+        });
+    if !footer.is_empty() {
+        rendered.push_str(&footer);
+        rendered.push('\n');
+    }
+    rendered
+}
+
+fn should_print_without_pager(options: &PageOptions) -> bool {
+    options.no_pager || !super::io::is_tty_for("stdout") || pager_command_is_cat()
+}
+
+fn pager_command_is_cat() -> bool {
+    pager_command()
+        .first()
+        .and_then(|program| program.rsplit('/').next())
+        .is_some_and(|program| program == "cat")
+}
+
+fn pager_command() -> Vec<String> {
+    let mut command = std::env::var("PAGER")
+        .ok()
+        .map(|pager| {
+            pager
+                .split_whitespace()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+        })
+        .filter(|parts| !parts.is_empty())
+        .unwrap_or_else(|| vec!["less".to_string()]);
+    add_default_less_flags(&mut command);
+    command
+}
+
+fn add_default_less_flags(command: &mut Vec<String>) {
+    let Some(program) = command.first() else {
+        return;
+    };
+    if program.rsplit('/').next() != Some("less") {
+        return;
+    }
+    for flag in ["-R", "-F", "-X"] {
+        if !command.iter().any(|arg| arg == flag) {
+            command.push(flag.to_string());
+        }
+    }
+}
+
+#[derive(Debug)]
+enum PagerError {
+    Unavailable(String),
+    Io(String),
+    Failed(String),
+}
+
+impl std::fmt::Display for PagerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PagerError::Unavailable(message)
+            | PagerError::Io(message)
+            | PagerError::Failed(message) => f.write_str(message),
+        }
+    }
+}
+
+fn run_pager(content: &str) -> Result<(), PagerError> {
+    let command = pager_command();
+    let Some((program, args)) = command.split_first() else {
+        return Err(PagerError::Unavailable(
+            "pager command is empty".to_string(),
+        ));
+    };
+    let mut child = Command::new(program)
+        .args(args)
+        .stdin(Stdio::piped())
+        .spawn()
+        .map_err(|error| {
+            if error.kind() == ErrorKind::NotFound {
+                PagerError::Unavailable(format!("pager not found: {program}"))
+            } else {
+                PagerError::Io(format!("failed to spawn pager {program}: {error}"))
+            }
+        })?;
+
+    let write_result = child.stdin.take().map(|mut stdin| {
+        let result = stdin.write_all(content.as_bytes());
+        drop(stdin);
+        result
+    });
+
+    let status = child
+        .wait()
+        .map_err(|error| PagerError::Io(format!("failed to wait for pager: {error}")))?;
+    if let Some(Err(error)) = write_result {
+        if error.kind() != ErrorKind::BrokenPipe || !status.success() {
+            return Err(PagerError::Io(format!(
+                "failed to write pager input: {error}"
+            )));
+        }
+    }
+    if status.success() {
+        Ok(())
+    } else {
+        Err(PagerError::Failed(format!(
+            "pager exited with status {}",
+            status
+                .code()
+                .map(|code| code.to_string())
+                .unwrap_or_else(|| "signal".to_string())
+        )))
+    }
+}
+
+fn page_result(ok: bool, paged: bool, error: Option<String>) -> VmValue {
+    let mut result = BTreeMap::from([
+        ("ok".to_string(), VmValue::Bool(ok)),
+        ("paged".to_string(), VmValue::Bool(paged)),
+    ]);
+    if let Some(error) = error {
+        result.insert("error".to_string(), VmValue::String(Rc::from(error)));
+    }
+    VmValue::Dict(Rc::new(result))
+}
+
+fn terminal_width(default_width: usize) -> usize {
+    terminal_width_from_columns(std::env::var("COLUMNS").ok().as_deref())
+        .or_else(platform_terminal_width)
+        .unwrap_or(default_width)
+}
+
+fn terminal_width_from_columns(raw: Option<&str>) -> Option<usize> {
+    raw.and_then(|value| value.trim().parse::<usize>().ok())
+        .filter(|width| *width > 0)
+}
+
+#[cfg(unix)]
+fn platform_terminal_width() -> Option<usize> {
+    let mut winsize = std::mem::MaybeUninit::<libc::winsize>::zeroed();
+    let rc = unsafe { libc::ioctl(libc::STDOUT_FILENO, libc::TIOCGWINSZ, winsize.as_mut_ptr()) };
+    if rc != 0 {
+        return None;
+    }
+    let winsize = unsafe { winsize.assume_init() };
+    (winsize.ws_col > 0).then_some(winsize.ws_col as usize)
+}
+
+#[cfg(not(unix))]
+fn platform_terminal_width() -> Option<usize> {
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::rc::Rc;
+
+    use crate::value::VmValue;
+
+    use super::{
+        add_default_less_flags, parse_page_options, render_page_content,
+        terminal_width_from_columns, PageFormat,
+    };
+
+    fn dict(entries: &[(&str, VmValue)]) -> Vec<VmValue> {
+        let map = entries
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), value.clone()))
+            .collect::<BTreeMap<_, _>>();
+        vec![VmValue::Dict(Rc::new(map))]
+    }
+
+    #[test]
+    fn page_content_adds_title_rule_and_default_footer() {
+        let opts = parse_page_options(&dict(&[
+            ("title", VmValue::String(Rc::from("Audit"))),
+            ("body", VmValue::String(Rc::from("line one\nline two"))),
+        ]))
+        .unwrap();
+
+        assert_eq!(
+            render_page_content(&opts),
+            "Audit\n─────\n\nline one\nline two\n--- end of Audit ---\n"
+        );
+    }
+
+    #[test]
+    fn page_options_accept_markdown_passthrough() {
+        let opts = parse_page_options(&dict(&[
+            ("body", VmValue::String(Rc::from("# Heading"))),
+            ("format", VmValue::String(Rc::from("markdown"))),
+            ("no_pager", VmValue::Bool(true)),
+        ]))
+        .unwrap();
+
+        assert_eq!(opts.format, PageFormat::Markdown);
+        assert!(opts.no_pager);
+    }
+
+    #[test]
+    fn terminal_width_ignores_invalid_columns() {
+        assert_eq!(terminal_width_from_columns(Some("132")), Some(132));
+        assert_eq!(terminal_width_from_columns(Some("0")), None);
+        assert_eq!(terminal_width_from_columns(Some("wide")), None);
+        assert_eq!(terminal_width_from_columns(None), None);
+    }
+
+    #[test]
+    fn less_pager_receives_harn_defaults() {
+        let mut command = vec!["less".to_string(), "-S".to_string()];
+        add_default_less_flags(&mut command);
+
+        assert_eq!(command, ["less", "-S", "-R", "-F", "-X"]);
+    }
+}

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -228,6 +228,18 @@ In tests: `mock_stdin(text)` / `unmock_stdin()`,
 `mock_tty(stream, bool)` / `unmock_tty()`,
 `capture_stderr_start()` / `capture_stderr_take()`.
 
+For long terminal artifacts, import `std/tui`:
+
+```harn
+import { page, rule, terminal_width, clear } from "std/tui"
+
+let result = page({title: "Audit", body: markdown, format: "markdown"})
+```
+
+`page(...)` uses `$PAGER` when stdout is a TTY, adds `-R -F -X` for `less`,
+falls back to full print output when stdout is not interactive or the pager is
+missing, and returns `{ok, paged, error?}`.
+
 ## Time, sleep, monotonic clock
 
 - `now_ms()` — wall-clock millis since UNIX_EPOCH (`int`).

--- a/docs/src/builtins.md
+++ b/docs/src/builtins.md
@@ -586,6 +586,10 @@ does **not** drain the iterator.
 | `runtime_paths()` | none | dict | Resolved runtime path model: `{execution_root, asset_root, state_root, run_root, worktree_root}` |
 | `date_iso()` | none | string | Current UTC time in ISO 8601 format (e.g., `"2026-03-29T14:30:00.123Z"`) |
 
+For interactive terminal presentation, import `std/tui`. It provides
+`page({title?, body, format?, no_pager?, footer?})`, `terminal_width()`,
+`rule()`, and `clear()` on top of the TTY-aware stdout primitives.
+
 ## Regular expressions
 
 | Function | Parameters | Returns | Description |

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -369,6 +369,8 @@ Imports starting with `std/` load embedded stdlib modules:
   ui_tool_result_validate, ui_host_capabilities, ui_host_supports_apps,
   ui_select_for_host, ui_tool_call_envelope, ui_context_update_envelope,
   ui_resource_csp_header, ui_resource_sandbox_attr)
+- `import "std/tui"` — terminal presentation helpers (page,
+  terminal_width, rule, clear)
 - `import "std/collections"` — collection utilities (filter_nil, store_stale,
   store_refresh)
 - `import "std/async"` — polling and retry helpers (wait_for, retry_until,

--- a/docs/src/modules.md
+++ b/docs/src/modules.md
@@ -82,7 +82,7 @@ described below (`std/text`, `std/json`, `std/math`, `std/collections`,
 `std/path`, `std/edit`, `std/artifact/web`, `std/ui_resource`, `std/cache`,
 `std/llm/handlers`, `std/llm/budget`, `std/llm/prompts`, `std/vision`,
 `std/context`, `std/agent_state`, `std/agents`, `std/agent/user`,
-`std/runtime`, `std/command`, `std/git`, `std/review`,
+`std/runtime`, `std/command`, `std/tui`, `std/git`, `std/review`,
 `std/experiments`,
 `std/project`, `std/memory`, `std/prompt_library`, `std/monitors`,
 `std/triage`, `std/worktree`, `std/checkpoint`, `std/personas/prelude`,
@@ -123,6 +123,7 @@ import "std/prompt_library"
 import "std/review"
 import "std/text"
 import "std/triage"
+import "std/tui"
 import "std/vision"
 ```
 
@@ -659,6 +660,36 @@ let step = command_step("verify package", ["cargo", "test", "-p", "harn-vm"], {
     return nil
   },
 })
+```
+
+### std/tui
+
+Terminal presentation helpers for interactive scripts:
+
+| Function | Description |
+|---|---|
+| `page(opts)` | Show a text or markdown artifact through `$PAGER` when stdout is a TTY; otherwise print the full artifact and footer. Returns `{ok, paged, error?}` |
+| `terminal_width(default_width?)` | Return the current terminal width, falling back to `default_width` or 80 |
+| `rule(char?, width?)` | Return `char` repeated to `width`, or to the terminal width when width is omitted |
+| `clear()` | Write the ANSI clear-screen sequence to stdout |
+
+`page` accepts `{title?, body, format?, no_pager?, footer?}`. `format` may be
+`"text"` or `"markdown"`; markdown currently passes through raw so callers can
+choose their own renderer before paging. In pager mode Harn respects `$PAGER`,
+adds `-R -F -X` for `less`, falls back to printing when the pager is missing,
+and treats `$PAGER=cat` as print-only.
+
+```harn
+import { page } from "std/tui"
+
+let result = page({
+  title: "Release audit",
+  body: audit_markdown,
+  format: "markdown",
+})
+if !result.ok {
+  eprintln(result.error ?? "pager failed")
+}
 ```
 
 ### std/git

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -367,6 +367,8 @@ Imports starting with `std/` load embedded stdlib modules:
   ui_tool_result_validate, ui_host_capabilities, ui_host_supports_apps,
   ui_select_for_host, ui_tool_call_envelope, ui_context_update_envelope,
   ui_resource_csp_header, ui_resource_sandbox_attr)
+- `import "std/tui"` — terminal presentation helpers (page,
+  terminal_width, rule, clear)
 - `import "std/collections"` — collection utilities (filter_nil, store_stale,
   store_refresh)
 - `import "std/async"` — polling and retry helpers (wait_for, retry_until,


### PR DESCRIPTION
## Summary
- add `std/tui` with `page`, `terminal_width`, `rule`, and `clear` helpers
- back `page` with native pager handling that respects `$PAGER`, defaults `less` to `-R -F -X`, falls back to print when non-interactive or pager is unavailable, and returns `{ok, paged, error?}`
- document the module, update the spec mirror, and add conformance coverage

Closes #1543.

## Verification
- `cargo test -p harn-vm stdlib::tui`
- `cargo test -p harn-stdlib tui_stdlib_module_exports_terminal_helpers`
- `cargo run --quiet --bin harn -- test conformance --filter tui_helpers`
- `cargo run --quiet --bin harn -- check crates/harn-stdlib/src/stdlib/stdlib_tui.harn`
- `cargo run --quiet --bin harn -- fmt --check crates/harn-stdlib/src/stdlib/stdlib_tui.harn conformance/tests/stdlib/tui_helpers.harn`
- `cargo clippy -p harn-vm --lib -- -D warnings`
- pre-commit hook
- pre-push hook