### PR TITLE
stdlib: add cooperative signal handlers

### DIFF
--- a/conformance/tests/stdlib/signal_basic.expected
+++ b/conformance/tests/stdlib/signal_basic.expected
@@ -1,0 +1,6 @@
+b
+a
+a
+true
+interrupted
+kind:interrupted:handler_timeout

--- a/conformance/tests/stdlib/signal_basic.harn
+++ b/conformance/tests/stdlib/signal_basic.harn
@@ -1,0 +1,34 @@
+import "std/signal"
+
+pipeline default() {
+  let first = on_interrupt({ -> println("a") }, {once: false})
+  let second = on_interrupt({ -> println("b") }, {once: false})
+  __signal_raise("SIGINT")
+  off_interrupt(second)
+  __signal_raise("SIGINT")
+  println(interrupted())
+  off_interrupt(first)
+  let raised = try {
+    __signal_raise("SIGINT")
+    "not interrupted"
+  } catch (e) {
+    "interrupted"
+  }
+  println(raised)
+  on_interrupt(
+    { ->
+      var spin = 0
+      while true {
+        spin = spin + 1
+      }
+    },
+    {graceful_timeout_ms: 0},
+  )
+  let timed_out = try {
+    __signal_raise("SIGINT")
+    "missed timeout"
+  } catch (e) {
+    e
+  }
+  println(timed_out)
+}

--- a/conformance/tests/stdlib/signal_process_sigterm.expected
+++ b/conformance/tests/stdlib/signal_process_sigterm.expected
@@ -1,0 +1,3 @@
+true
+true
+true

--- a/conformance/tests/stdlib/signal_process_sigterm.harn
+++ b/conformance/tests/stdlib/signal_process_sigterm.harn
@@ -1,0 +1,27 @@
+import "../_common"
+
+pipeline default() {
+  let root = path_join(temp_dir(), "harn-signal-" + uuid())
+  mkdir(root)
+  let script_path = path_join(root, "sigterm.harn")
+  let log_path = path_join(root, "sigterm.log")
+  write_file(
+    script_path,
+    "import \"std/signal\"\n\npipeline default() {\n  on_interrupt({ -> println(\"term\") }, {signals: [\"SIGTERM\"], once: false})\n  println(\"ready\")\n  try {\n    sleep(duration_seconds(30))\n  } catch (e) {\n    println(\"caught\")\n  }\n  println(interrupted())\n}\n",
+  )
+  let repo_root = exec("git", "rev-parse", "--show-toplevel").stdout.trim()
+  let harn_bin = env_or("HARN_CONFORMANCE_HARN_BIN", resolve_harn_bin(repo_root))
+  let start = shell("\"" + harn_bin + "\" run \"" + script_path + "\" >\"" + log_path + "\" 2>&1 & echo $!")
+  let pid = start.stdout.trim()
+  require start.success, "failed to start harn run child"
+  require pid != "", "missing child pid"
+  require wait_for_log_contains(log_path, "ready"), "child did not become ready"
+  let _ = shell("kill -TERM " + pid)
+  let exited = wait_for_exit(pid)
+  let _ = shell("kill -TERM " + pid + " >/dev/null 2>&1 || true")
+  require exited, "child did not exit after SIGTERM"
+  let log = read_file(log_path)
+  println(contains(log, "\nterm\n"))
+  println(contains(log, "\ncaught\n"))
+  println(contains(log, "\ntrue\n"))
+}

--- a/crates/harn-cli/src/commands/run.rs
+++ b/crates/harn-cli/src/commands/run.rs
@@ -4,7 +4,7 @@ use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::process;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use harn_parser::DiagnosticSeverity;
 use harn_vm::event_log::EventLog;
@@ -241,6 +241,24 @@ impl RunProfileOptions {
     }
 }
 
+#[derive(Clone)]
+pub struct RunInterruptTokens {
+    pub cancel_token: Arc<AtomicBool>,
+    pub signal_token: Arc<Mutex<Option<String>>>,
+}
+
+struct ExecuteRunInputs<'a> {
+    path: &'a str,
+    trace: bool,
+    denied_builtins: HashSet<String>,
+    script_argv: Vec<String>,
+    skill_dirs_raw: Vec<String>,
+    llm_mock_mode: CliLlmMockMode,
+    attestation: Option<RunAttestationOptions>,
+    profile: RunProfileOptions,
+    interrupt_tokens: Option<RunInterruptTokens>,
+}
+
 /// Captured outcome of an in-process `execute_run` invocation. Tests use this
 /// instead of spawning the `harn` binary; the binary entry point translates
 /// it into real stdout/stderr writes + `process::exit`.
@@ -341,10 +359,10 @@ pub(crate) async fn run_file_with_skill_dirs(
     profile: RunProfileOptions,
 ) {
     // Graceful shutdown: flush run records before exit on SIGINT/SIGTERM.
-    let cancelled = install_signal_shutdown_handler();
+    let interrupt_tokens = install_signal_shutdown_handler();
 
     let _stdout_passthrough = StdoutPassthroughGuard::enable();
-    let outcome = execute_run(
+    let outcome = execute_run_inner(ExecuteRunInputs {
         path,
         trace,
         denied_builtins,
@@ -353,7 +371,8 @@ pub(crate) async fn run_file_with_skill_dirs(
         llm_mock_mode,
         attestation,
         profile,
-    )
+        interrupt_tokens: Some(interrupt_tokens.clone()),
+    })
     .await;
 
     // `harn run` streams normal program stdout during execution. Any stdout
@@ -366,7 +385,7 @@ pub(crate) async fn run_file_with_skill_dirs(
     }
 
     let mut exit_code = outcome.exit_code;
-    if exit_code != 0 && cancelled.load(Ordering::SeqCst) {
+    if exit_code != 0 && interrupt_tokens.cancel_token.load(Ordering::SeqCst) {
         exit_code = 124;
     }
     if exit_code != 0 {
@@ -424,33 +443,58 @@ impl Drop for StdoutPassthroughGuard {
     }
 }
 
-fn install_signal_shutdown_handler() -> Arc<AtomicBool> {
-    let cancelled = Arc::new(AtomicBool::new(false));
-    let cancelled_clone = cancelled.clone();
+fn install_signal_shutdown_handler() -> RunInterruptTokens {
+    let tokens = RunInterruptTokens {
+        cancel_token: Arc::new(AtomicBool::new(false)),
+        signal_token: Arc::new(Mutex::new(None)),
+    };
+    let tokens_clone = tokens.clone();
     tokio::spawn(async move {
         #[cfg(unix)]
         {
             use tokio::signal::unix::{signal, SignalKind};
             let mut sigterm = signal(SignalKind::terminate()).expect("SIGTERM handler");
             let mut sigint = signal(SignalKind::interrupt()).expect("SIGINT handler");
-            tokio::select! {
-                _ = sigterm.recv() => {},
-                _ = sigint.recv() => {},
+            let mut sighup = signal(SignalKind::hangup()).expect("SIGHUP handler");
+            let mut seen_signal = false;
+            loop {
+                let signal_name = tokio::select! {
+                    _ = sigterm.recv() => "SIGTERM",
+                    _ = sigint.recv() => "SIGINT",
+                    _ = sighup.recv() => "SIGHUP",
+                };
+                if seen_signal {
+                    eprintln!("[harn] second signal received, terminating");
+                    process::exit(124);
+                }
+                seen_signal = true;
+                request_vm_interrupt(&tokens_clone, signal_name);
+                eprintln!("[harn] signal received, interrupting VM...");
             }
-            cancelled_clone.store(true, Ordering::SeqCst);
-            eprintln!("[harn] signal received, flushing state...");
-            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-            process::exit(124);
         }
         #[cfg(not(unix))]
         {
-            let _ = tokio::signal::ctrl_c().await;
-            cancelled_clone.store(true, Ordering::SeqCst);
-            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-            process::exit(124);
+            let mut seen_signal = false;
+            loop {
+                let _ = tokio::signal::ctrl_c().await;
+                if seen_signal {
+                    eprintln!("[harn] second signal received, terminating");
+                    process::exit(124);
+                }
+                seen_signal = true;
+                request_vm_interrupt(&tokens_clone, "SIGINT");
+                eprintln!("[harn] signal received, interrupting VM...");
+            }
         }
     });
-    cancelled
+    tokens
+}
+
+fn request_vm_interrupt(tokens: &RunInterruptTokens, signal_name: &str) {
+    if let Ok(mut signal) = tokens.signal_token.lock() {
+        *signal = Some(signal_name.to_string());
+    }
+    tokens.cancel_token.store(true, Ordering::SeqCst);
 }
 
 /// In-process equivalent of `run_file_with_skill_dirs`. Returns the captured
@@ -468,6 +512,33 @@ pub async fn execute_run(
     attestation: Option<RunAttestationOptions>,
     profile: RunProfileOptions,
 ) -> RunOutcome {
+    execute_run_inner(ExecuteRunInputs {
+        path,
+        trace,
+        denied_builtins,
+        script_argv,
+        skill_dirs_raw,
+        llm_mock_mode,
+        attestation,
+        profile,
+        interrupt_tokens: None,
+    })
+    .await
+}
+
+async fn execute_run_inner(inputs: ExecuteRunInputs<'_>) -> RunOutcome {
+    let ExecuteRunInputs {
+        path,
+        trace,
+        denied_builtins,
+        script_argv,
+        skill_dirs_raw,
+        llm_mock_mode,
+        attestation,
+        profile,
+        interrupt_tokens,
+    } = inputs;
+
     let mut stderr = String::new();
     let mut stdout = String::new();
 
@@ -518,6 +589,10 @@ pub async fn execute_run(
     }
 
     let mut vm = harn_vm::Vm::new();
+    if let Some(interrupt_tokens) = interrupt_tokens {
+        vm.install_interrupt_signal_token(interrupt_tokens.signal_token);
+        vm.install_cancel_token(interrupt_tokens.cancel_token);
+    }
     harn_vm::register_vm_stdlib(&mut vm);
     crate::install_default_hostlib(&mut vm);
     let source_parent = std::path::Path::new(path)

--- a/crates/harn-parser/src/builtin_signatures/signatures/stdlib.rs
+++ b/crates/harn-parser/src/builtin_signatures/signatures/stdlib.rs
@@ -160,6 +160,25 @@ pub(crate) const SIGNATURES: &[BuiltinSignature] = &[
         ],
         TY_STRING,
     ),
+    BuiltinSignature::simple("__signal_interrupted", &[], TY_BOOL),
+    BuiltinSignature::simple(
+        "__signal_off_interrupt",
+        &[Param::new("handle", TY_ANY)],
+        TY_NIL,
+    ),
+    BuiltinSignature::simple(
+        "__signal_on_interrupt",
+        &[
+            Param::new("handler", TY_CLOSURE),
+            Param::optional("options", TY_DICT_OR_NIL),
+        ],
+        TY_DICT,
+    ),
+    BuiltinSignature::simple(
+        "__signal_raise",
+        &[Param::optional("signal", TY_STRING)],
+        TY_NIL,
+    ),
     BuiltinSignature::simple(
         "__waitpoint_cancel",
         &[

--- a/crates/harn-stdlib/src/lib.rs
+++ b/crates/harn-stdlib/src/lib.rs
@@ -106,6 +106,10 @@ pub const STDLIB_SOURCES: &[StdlibSource] = &[
         source: include_str!("stdlib/stdlib_command.harn"),
     },
     StdlibSource {
+        module: "signal",
+        source: include_str!("stdlib/stdlib_signal.harn"),
+    },
+    StdlibSource {
         module: "review",
         source: include_str!("stdlib/stdlib_review.harn"),
     },
@@ -936,6 +940,22 @@ mod tests {
             !exports.contains("retry_with_backoff"),
             "std/async should not retain the old retry_with_backoff export"
         );
+    }
+
+    #[test]
+    fn signal_stdlib_module_exports_interrupt_helpers() {
+        let exports = public_functions_for_module("signal")
+            .into_iter()
+            .map(|function| function.name)
+            .collect::<BTreeSet<_>>();
+        for name in [
+            "on_interrupt",
+            "off_interrupt",
+            "interrupted",
+            "with_interrupt",
+        ] {
+            assert!(exports.contains(name), "std/signal should export {name}");
+        }
     }
 
     #[test]

--- a/crates/harn-stdlib/src/stdlib/stdlib_signal.harn
+++ b/crates/harn-stdlib/src/stdlib/stdlib_signal.harn
@@ -1,0 +1,28 @@
+// std/signal — cooperative process interruption helpers.
+/** Register a process interrupt handler. */
+pub fn on_interrupt(handler, options = nil) {
+  return __signal_on_interrupt(handler, options)
+}
+
+/** Remove an interrupt handler returned by `on_interrupt`. */
+pub fn off_interrupt(handle) {
+  return __signal_off_interrupt(handle)
+}
+
+/** Return true after the current VM observes an interrupt. */
+pub fn interrupted() -> bool {
+  return __signal_interrupted()
+}
+
+/** Run `body` with an interrupt handler that is always unregistered afterward. */
+pub fn with_interrupt(handler, body, options = nil) {
+  let registration = on_interrupt(handler, options)
+  try {
+    let result = body()
+    off_interrupt(registration)
+    return result
+  } catch (e) {
+    off_interrupt(registration)
+    throw e
+  }
+}

--- a/crates/harn-vm/src/stdlib.rs
+++ b/crates/harn-vm/src/stdlib.rs
@@ -195,6 +195,10 @@ pub fn stdlib_builtin_names() -> Vec<String> {
         "await",
         "cancel",
         "cancel_graceful",
+        "__signal_interrupted",
+        "__signal_off_interrupt",
+        "__signal_on_interrupt",
+        "__signal_raise",
         "is_cancelled",
     ] {
         names.push(extra.to_string());

--- a/crates/harn-vm/src/vm/debug.rs
+++ b/crates/harn-vm/src/vm/debug.rs
@@ -233,6 +233,16 @@ impl Vm {
         self.cancel_grace_instructions_remaining = None;
     }
 
+    /// Install a host signal token paired with the cancellation token. Hosts set
+    /// it to `SIGINT`, `SIGTERM`, or `SIGHUP` before flipping cancellation so
+    /// `std/signal` handlers can match the actual process signal.
+    pub fn install_interrupt_signal_token(
+        &mut self,
+        token: std::sync::Arc<std::sync::Mutex<Option<String>>>,
+    ) {
+        self.interrupt_signal_token = Some(token);
+    }
+
     /// Signal cooperative cancellation on this VM — the step loop
     /// unwinds on its next instruction check. Lazily allocates a
     /// fresh token when none is installed so hosts don't need to
@@ -349,14 +359,14 @@ impl Vm {
     /// cleanup ops emitted at line 0 after branch/loop exits — keeps
     /// the debugger aligned with what's actually going to run.
     pub async fn step_execute(&mut self) -> Result<Option<(VmValue, bool)>, VmError> {
-        // Cooperative cancellation (#108): the DAP adapter flips the
-        // shared flag when the IDE presses the Stop pill. Check here
-        // before any instruction work so the loop unwinds promptly
-        // on the next tick.
+        // Cooperative cancellation and std/signal interrupts are both
+        // observed before instruction work so debug stepping exits promptly.
+        if let Some(err) = self.pending_scope_interrupt().await {
+            return Err(err);
+        }
         if self.is_cancel_requested() {
-            return Err(VmError::Thrown(VmValue::String(Rc::from(
-                "kind:cancelled:VM cancelled by host",
-            ))));
+            self.cancel_spawned_tasks();
+            return Err(Self::cancelled_error());
         }
         let current_line = self.upcoming_line();
         let line_changed = current_line != self.last_line && current_line > 0;

--- a/crates/harn-vm/src/vm/execution.rs
+++ b/crates/harn-vm/src/vm/execution.rs
@@ -6,8 +6,13 @@ use crate::value::{ModuleFunctionRegistry, VmError, VmValue};
 
 use super::{CallFrame, LocalSlot, Vm};
 
-const CANCEL_GRACE_INSTRUCTIONS: usize = 1024;
 const CANCEL_GRACE_ASYNC_OP: Duration = Duration::from_millis(250);
+
+#[derive(Clone, Copy)]
+enum DeadlineKind {
+    Scope,
+    InterruptHandler,
+}
 
 impl Vm {
     /// Execute a compiled chunk.
@@ -131,7 +136,7 @@ impl Vm {
         });
 
         loop {
-            if let Some(err) = self.pending_scope_interrupt() {
+            if let Some(err) = self.pending_scope_interrupt().await {
                 match self.handle_error(err) {
                     Ok(None) => continue,
                     Ok(Some(val)) => return Ok(val),
@@ -306,6 +311,20 @@ impl Vm {
     }
 }
 
+fn next_deadline(
+    scope_deadline: Option<Instant>,
+    interrupt_handler_deadline: Option<Instant>,
+) -> (Option<Instant>, Option<DeadlineKind>) {
+    match (scope_deadline, interrupt_handler_deadline) {
+        (Some(scope), Some(interrupt)) if interrupt < scope => {
+            (Some(interrupt), Some(DeadlineKind::InterruptHandler))
+        }
+        (Some(scope), _) => (Some(scope), Some(DeadlineKind::Scope)),
+        (None, Some(interrupt)) => (Some(interrupt), Some(DeadlineKind::InterruptHandler)),
+        (None, None) => (None, None),
+    }
+}
+
 fn step_runtime_error_message(error: &VmError) -> String {
     match error {
         VmError::Thrown(VmValue::Dict(dict)) => dict
@@ -323,7 +342,7 @@ pub(crate) enum StepBoundaryOutcome {
 
 impl crate::vm::Vm {
     pub(crate) async fn execute_one_cycle(&mut self) -> Result<Option<(VmValue, bool)>, VmError> {
-        if let Some(err) = self.pending_scope_interrupt() {
+        if let Some(err) = self.pending_scope_interrupt().await {
             match self.handle_error(err) {
                 Ok(None) => return Ok(None),
                 Ok(Some(val)) => return Ok(Some((val, false))),
@@ -397,39 +416,20 @@ impl crate::vm::Vm {
         }
     }
 
-    fn pending_scope_interrupt(&mut self) -> Option<VmError> {
-        if self.is_cancel_requested() {
-            match self.cancel_grace_instructions_remaining.as_mut() {
-                Some(0) => {
-                    self.cancel_spawned_tasks();
-                    return Some(Self::cancelled_error());
-                }
-                Some(remaining) => *remaining -= 1,
-                None => self.cancel_grace_instructions_remaining = Some(CANCEL_GRACE_INSTRUCTIONS),
-            }
-        } else {
-            self.cancel_grace_instructions_remaining = None;
-        }
-        if let Some(&(deadline, _)) = self.deadlines.last() {
-            if Instant::now() >= deadline {
-                self.deadlines.pop();
-                return Some(Self::deadline_exceeded_error());
-            }
-        }
-        None
-    }
-
     async fn execute_op_with_scope_interrupts(
         &mut self,
         op: u8,
     ) -> Result<Option<VmValue>, VmError> {
         enum ScopeInterruptResult {
             Op(Result<Option<VmValue>, VmError>),
-            Deadline,
+            Deadline(DeadlineKind),
             CancelTimedOut,
         }
 
-        let deadline = self.deadlines.last().map(|(deadline, _)| *deadline);
+        let (deadline, deadline_kind) = next_deadline(
+            self.deadlines.last().map(|(deadline, _)| *deadline),
+            self.interrupt_handler_deadline,
+        );
         let cancel_token = self.cancel_token.clone();
 
         if deadline.is_none() && cancel_token.is_none() {
@@ -463,7 +463,9 @@ impl crate::vm::Vm {
             tokio::pin!(op_future);
             tokio::select! {
                 result = &mut op_future => ScopeInterruptResult::Op(result),
-                _ = deadline_sleep, if has_deadline => ScopeInterruptResult::Deadline,
+                _ = deadline_sleep, if has_deadline => {
+                    ScopeInterruptResult::Deadline(deadline_kind.unwrap_or(DeadlineKind::Scope))
+                },
                 _ = cancel_sleep, if has_cancel => {
                     let grace = tokio::time::sleep(CANCEL_GRACE_ASYNC_OP);
                     tokio::pin!(grace);
@@ -477,13 +479,22 @@ impl crate::vm::Vm {
 
         match result {
             ScopeInterruptResult::Op(result) => result,
-            ScopeInterruptResult::Deadline => {
+            ScopeInterruptResult::Deadline(DeadlineKind::Scope) => {
                 self.deadlines.pop();
                 self.cancel_spawned_tasks();
                 Err(Self::deadline_exceeded_error())
             }
+            ScopeInterruptResult::Deadline(DeadlineKind::InterruptHandler) => {
+                Err(Self::interrupt_handler_timeout_error())
+            }
             ScopeInterruptResult::CancelTimedOut => {
                 self.cancel_spawned_tasks();
+                let signal = self
+                    .take_host_interrupt_signal()
+                    .unwrap_or_else(|| "SIGINT".to_string());
+                if self.has_interrupt_handler_for(&signal) {
+                    self.dispatch_interrupt_handlers(&signal).await?;
+                }
                 Err(Self::cancelled_error())
             }
         }

--- a/crates/harn-vm/src/vm/interrupts.rs
+++ b/crates/harn-vm/src/vm/interrupts.rs
@@ -1,0 +1,318 @@
+use std::collections::BTreeMap;
+use std::rc::Rc;
+use std::time::{Duration, Instant};
+
+use crate::value::{VmError, VmValue};
+
+use super::Vm;
+
+const CANCEL_GRACE_INSTRUCTIONS: usize = 1024;
+
+impl Vm {
+    pub(crate) fn register_interrupt_handler(
+        &mut self,
+        handler: VmValue,
+        opts: Option<&VmValue>,
+    ) -> Result<VmValue, VmError> {
+        if !Self::is_callable_value(&handler) {
+            return Err(VmError::TypeError(format!(
+                "on_interrupt: handler must be callable, got {}",
+                handler.type_name()
+            )));
+        }
+
+        let signals = parse_signal_list(opts)?;
+        let once = parse_bool_option(opts, "once")?.unwrap_or(true);
+        let graceful_timeout_ms =
+            parse_non_negative_int_option(opts, "graceful_timeout_ms")?.map(|ms| ms as u64);
+
+        let handle = self.next_interrupt_handle;
+        self.next_interrupt_handle += 1;
+        self.interrupt_handlers.push(super::InterruptHandler {
+            handle,
+            signals: signals.clone(),
+            once,
+            graceful_timeout_ms,
+            handler,
+        });
+
+        Ok(VmValue::Dict(Rc::new(BTreeMap::from([
+            ("handle".to_string(), VmValue::Int(handle)),
+            (
+                "signals".to_string(),
+                VmValue::List(Rc::new(
+                    signals
+                        .into_iter()
+                        .map(|signal| VmValue::String(Rc::from(signal)))
+                        .collect(),
+                )),
+            ),
+            ("once".to_string(), VmValue::Bool(once)),
+        ]))))
+    }
+
+    pub(crate) fn unregister_interrupt_handler(&mut self, handle: &VmValue) -> Result<(), VmError> {
+        let handle = parse_handle(handle)?;
+        self.interrupt_handlers
+            .retain(|entry| entry.handle != handle);
+        Ok(())
+    }
+
+    pub(crate) fn interrupted(&self) -> bool {
+        self.interrupted
+            || self.pending_interrupt_signal.is_some()
+            || self
+                .interrupt_signal_token
+                .as_ref()
+                .is_some_and(|token| token.lock().ok().is_some_and(|guard| guard.is_some()))
+            || self.is_cancel_requested()
+    }
+
+    pub(crate) fn signal_interrupt(&mut self, signal: &str) -> Result<(), VmError> {
+        let signal = normalize_signal(signal)?;
+        self.pending_interrupt_signal = Some(signal);
+        Ok(())
+    }
+
+    pub(crate) fn has_interrupt_handler_for(&self, signal: &str) -> bool {
+        self.interrupt_handlers
+            .iter()
+            .any(|entry| entry.signals.iter().any(|candidate| candidate == signal))
+    }
+
+    pub(crate) async fn dispatch_interrupt_handlers(
+        &mut self,
+        signal: &str,
+    ) -> Result<bool, VmError> {
+        let signal = normalize_signal(signal)?;
+        self.interrupted = true;
+
+        if self.dispatching_interrupt {
+            return Err(Self::cancelled_error());
+        }
+
+        let matching: Vec<(i64, bool, Option<u64>, VmValue)> = self
+            .interrupt_handlers
+            .iter()
+            .rev()
+            .filter(|entry| entry.signals.iter().any(|candidate| candidate == &signal))
+            .map(|entry| {
+                (
+                    entry.handle,
+                    entry.once,
+                    entry.graceful_timeout_ms,
+                    entry.handler.clone(),
+                )
+            })
+            .collect();
+        if matching.is_empty() {
+            return Ok(false);
+        }
+
+        self.clear_cancel_request();
+        self.dispatching_interrupt = true;
+        let mut once_handles = Vec::new();
+        let mut result = Ok(());
+        for (handle, once, graceful_timeout_ms, handler) in matching {
+            if once {
+                once_handles.push(handle);
+            }
+            let saved_interrupt_deadline = self.interrupt_handler_deadline;
+            self.interrupt_handler_deadline = graceful_timeout_ms
+                .and_then(|ms| Instant::now().checked_add(Duration::from_millis(ms)));
+            let handler_result = self.call_callable_value(&handler, &[]).await;
+            self.interrupt_handler_deadline = saved_interrupt_deadline;
+            if let Err(error) = handler_result {
+                result = Err(error);
+                break;
+            }
+        }
+        self.dispatching_interrupt = false;
+
+        if !once_handles.is_empty() {
+            self.interrupt_handlers
+                .retain(|entry| !once_handles.contains(&entry.handle));
+        }
+
+        result.map(|()| true)
+    }
+
+    pub(crate) async fn pending_scope_interrupt(&mut self) -> Option<VmError> {
+        let mut pending_from_host = false;
+        if self.pending_interrupt_signal.is_none() {
+            self.pending_interrupt_signal = self.take_host_interrupt_signal();
+            pending_from_host = self.pending_interrupt_signal.is_some();
+        }
+        if let Some(signal) = self.pending_interrupt_signal.take() {
+            match self.dispatch_interrupt_handlers(&signal).await {
+                Ok(true) => return None,
+                Ok(false) if !pending_from_host => return Some(Self::interrupted_error(&signal)),
+                Ok(false) => {}
+                Err(error) => return Some(error),
+            }
+        }
+
+        if self
+            .interrupt_handler_deadline
+            .is_some_and(|deadline| Instant::now() >= deadline)
+        {
+            return Some(Self::interrupt_handler_timeout_error());
+        }
+
+        if self.is_cancel_requested() {
+            let signal = self
+                .take_host_interrupt_signal()
+                .unwrap_or_else(|| "SIGINT".to_string());
+            if self.has_interrupt_handler_for(&signal) {
+                match self.dispatch_interrupt_handlers(&signal).await {
+                    Ok(true) => return None,
+                    Ok(false) => {}
+                    Err(error) => return Some(error),
+                }
+            }
+
+            match self.cancel_grace_instructions_remaining.as_mut() {
+                Some(0) => {
+                    self.cancel_spawned_tasks();
+                    return Some(Self::cancelled_error());
+                }
+                Some(remaining) => *remaining -= 1,
+                None => self.cancel_grace_instructions_remaining = Some(CANCEL_GRACE_INSTRUCTIONS),
+            }
+        } else {
+            self.cancel_grace_instructions_remaining = None;
+        }
+
+        if let Some(&(deadline, _)) = self.deadlines.last() {
+            if Instant::now() >= deadline {
+                self.deadlines.pop();
+                return Some(Self::deadline_exceeded_error());
+            }
+        }
+
+        None
+    }
+
+    fn clear_cancel_request(&mut self) {
+        if let Some(token) = &self.cancel_token {
+            token.store(false, std::sync::atomic::Ordering::SeqCst);
+        }
+        self.cancel_grace_instructions_remaining = None;
+    }
+
+    pub(crate) fn take_host_interrupt_signal(&mut self) -> Option<String> {
+        self.interrupt_signal_token
+            .as_ref()
+            .and_then(|token| token.lock().ok().and_then(|mut guard| guard.take()))
+    }
+
+    pub(crate) fn interrupted_error(signal: &str) -> VmError {
+        VmError::Thrown(VmValue::String(Rc::from(format!(
+            "kind:interrupted:{signal}"
+        ))))
+    }
+
+    pub(crate) fn interrupt_handler_timeout_error() -> VmError {
+        VmError::Thrown(VmValue::String(Rc::from(
+            "kind:interrupted:handler_timeout",
+        )))
+    }
+}
+
+fn parse_signal_list(opts: Option<&VmValue>) -> Result<Vec<String>, VmError> {
+    let Some(VmValue::Dict(opts)) = opts else {
+        return Ok(vec!["SIGINT".to_string()]);
+    };
+    let Some(value) = opts.get("signals") else {
+        return Ok(vec!["SIGINT".to_string()]);
+    };
+    match value {
+        VmValue::Nil => Ok(vec!["SIGINT".to_string()]),
+        VmValue::String(signal) => Ok(vec![normalize_signal(signal.as_ref())?]),
+        VmValue::List(items) => {
+            if items.is_empty() {
+                return Err(VmError::Runtime(
+                    "on_interrupt: signals must not be empty".to_string(),
+                ));
+            }
+            let mut out = Vec::with_capacity(items.len());
+            for item in items.iter() {
+                let VmValue::String(signal) = item else {
+                    return Err(VmError::TypeError(format!(
+                        "on_interrupt: signals entries must be strings, got {}",
+                        item.type_name()
+                    )));
+                };
+                out.push(normalize_signal(signal.as_ref())?);
+            }
+            out.sort();
+            out.dedup();
+            Ok(out)
+        }
+        other => Err(VmError::TypeError(format!(
+            "on_interrupt: signals must be a string or list<string>, got {}",
+            other.type_name()
+        ))),
+    }
+}
+
+fn parse_bool_option(opts: Option<&VmValue>, key: &str) -> Result<Option<bool>, VmError> {
+    let Some(VmValue::Dict(opts)) = opts else {
+        return Ok(None);
+    };
+    match opts.get(key) {
+        Some(VmValue::Bool(value)) => Ok(Some(*value)),
+        Some(VmValue::Nil) | None => Ok(None),
+        Some(other) => Err(VmError::TypeError(format!(
+            "on_interrupt: {key} must be bool, got {}",
+            other.type_name()
+        ))),
+    }
+}
+
+fn parse_non_negative_int_option(
+    opts: Option<&VmValue>,
+    key: &str,
+) -> Result<Option<i64>, VmError> {
+    let Some(VmValue::Dict(opts)) = opts else {
+        return Ok(None);
+    };
+    match opts.get(key) {
+        Some(VmValue::Int(value)) if *value >= 0 => Ok(Some(*value)),
+        Some(VmValue::Duration(value)) if *value >= 0 => Ok(Some(*value)),
+        Some(VmValue::Nil) | None => Ok(None),
+        Some(other) => Err(VmError::TypeError(format!(
+            "on_interrupt: {key} must be a non-negative int or duration, got {}",
+            other.type_name()
+        ))),
+    }
+}
+
+fn parse_handle(value: &VmValue) -> Result<i64, VmError> {
+    match value {
+        VmValue::Int(handle) => Ok(*handle),
+        VmValue::Dict(map) => match map.get("handle") {
+            Some(VmValue::Int(handle)) => Ok(*handle),
+            Some(other) => Err(VmError::TypeError(format!(
+                "off_interrupt: handle field must be int, got {}",
+                other.type_name()
+            ))),
+            None => Err(VmError::Runtime(
+                "off_interrupt: handle dict is missing `handle`".to_string(),
+            )),
+        },
+        other => Err(VmError::TypeError(format!(
+            "off_interrupt: expected handle int or dict, got {}",
+            other.type_name()
+        ))),
+    }
+}
+
+fn normalize_signal(signal: &str) -> Result<String, VmError> {
+    match signal {
+        "SIGINT" | "SIGTERM" | "SIGHUP" => Ok(signal.to_string()),
+        other => Err(VmError::Runtime(format!(
+            "on_interrupt: unsupported signal '{other}'"
+        ))),
+    }
+}

--- a/crates/harn-vm/src/vm/mod.rs
+++ b/crates/harn-vm/src/vm/mod.rs
@@ -4,6 +4,7 @@ mod debug;
 mod dispatch;
 mod execution;
 mod format;
+mod interrupts;
 pub mod iter;
 mod methods;
 mod modules;
@@ -27,5 +28,6 @@ pub use modules::resolve_module_import_path;
 pub use state::Vm;
 
 pub(crate) use state::{
-    CallFrame, ExceptionHandler, IterState, LocalSlot, ScopeSpan, VmBuiltinDispatch, VmBuiltinEntry,
+    CallFrame, ExceptionHandler, InterruptHandler, IterState, LocalSlot, ScopeSpan,
+    VmBuiltinDispatch, VmBuiltinEntry,
 };

--- a/crates/harn-vm/src/vm/ops/call.rs
+++ b/crates/harn-vm/src/vm/ops/call.rs
@@ -488,6 +488,49 @@ impl super::super::Vm {
             return Ok(true);
         }
 
+        if name == "__signal_on_interrupt" {
+            crate::typecheck::validate_builtin_call(name, args, None)?;
+            let handler = args.first().cloned().ok_or_else(|| {
+                VmError::Runtime("__signal_on_interrupt: handler is required".to_string())
+            })?;
+            let result = self.register_interrupt_handler(handler, args.get(1))?;
+            self.stack.push(result);
+            return Ok(true);
+        }
+
+        if name == "__signal_off_interrupt" {
+            crate::typecheck::validate_builtin_call(name, args, None)?;
+            let handle = args.first().ok_or_else(|| {
+                VmError::Runtime("__signal_off_interrupt: handle is required".to_string())
+            })?;
+            self.unregister_interrupt_handler(handle)?;
+            self.stack.push(VmValue::Nil);
+            return Ok(true);
+        }
+
+        if name == "__signal_interrupted" {
+            crate::typecheck::validate_builtin_call(name, args, None)?;
+            self.stack.push(VmValue::Bool(self.interrupted()));
+            return Ok(true);
+        }
+
+        if name == "__signal_raise" {
+            crate::typecheck::validate_builtin_call(name, args, None)?;
+            let signal = match args.first() {
+                Some(VmValue::String(signal)) => signal.to_string(),
+                Some(other) => {
+                    return Err(VmError::TypeError(format!(
+                        "__signal_raise: signal must be string, got {}",
+                        other.type_name()
+                    )))
+                }
+                None => "SIGINT".to_string(),
+            };
+            self.signal_interrupt(&signal)?;
+            self.stack.push(VmValue::Nil);
+            return Ok(true);
+        }
+
         Ok(false)
     }
 
@@ -694,8 +737,7 @@ impl super::super::Vm {
         } else {
             match callee {
                 VmValue::String(name) => {
-                    let result = self.call_named_builtin(&name, args).await?;
-                    self.stack.push(result);
+                    self.call_named_value(&name, args, None).await?;
                 }
                 _ => {
                     return Err(VmError::TypeError(format!(

--- a/crates/harn-vm/src/vm/state.rs
+++ b/crates/harn-vm/src/vm/state.rs
@@ -35,6 +35,15 @@ pub(crate) struct LocalSlot {
     pub(crate) synced: bool,
 }
 
+#[derive(Clone)]
+pub(crate) struct InterruptHandler {
+    pub(crate) handle: i64,
+    pub(crate) signals: Vec<String>,
+    pub(crate) once: bool,
+    pub(crate) graceful_timeout_ms: Option<u64>,
+    pub(crate) handler: VmValue,
+}
+
 /// Call frame for function execution.
 pub(crate) struct CallFrame {
     pub(crate) chunk: ChunkRef,
@@ -208,11 +217,19 @@ pub struct Vm {
     pub(crate) denied_builtins: Rc<HashSet<String>>,
     /// Cancellation token for cooperative graceful shutdown (set by parent).
     pub(crate) cancel_token: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
+    pub(crate) interrupt_signal_token: Option<std::sync::Arc<std::sync::Mutex<Option<String>>>>,
     /// Remaining instruction-boundary checks before a requested host
     /// cancellation is forcefully raised. This gives `is_cancelled()` loops a
     /// deterministic chance to return cleanly without letting non-cooperative
     /// CPU-bound code run forever.
     pub(crate) cancel_grace_instructions_remaining: Option<usize>,
+    /// User-visible interrupt handlers registered through `std/signal`.
+    pub(crate) interrupt_handlers: Vec<InterruptHandler>,
+    pub(crate) next_interrupt_handle: i64,
+    pub(crate) pending_interrupt_signal: Option<String>,
+    pub(crate) interrupted: bool,
+    pub(crate) dispatching_interrupt: bool,
+    pub(crate) interrupt_handler_deadline: Option<Instant>,
     /// Captured stack trace from the most recent error (fn_name, line, col).
     pub(crate) error_stack_trace: Vec<(String, usize, usize, Option<String>)>,
     /// Yield channel sender for generator execution. When set, `Op::Yield`
@@ -418,7 +435,14 @@ impl Vm {
             bridge: None,
             denied_builtins: Rc::new(HashSet::new()),
             cancel_token: None,
+            interrupt_signal_token: None,
             cancel_grace_instructions_remaining: None,
+            interrupt_handlers: Vec::new(),
+            next_interrupt_handle: 1,
+            pending_interrupt_signal: None,
+            interrupted: false,
+            dispatching_interrupt: false,
+            interrupt_handler_deadline: None,
             error_stack_trace: Vec::new(),
             yield_sender: None,
             project_root: None,
@@ -511,7 +535,14 @@ impl Vm {
             bridge: self.bridge.clone(),
             denied_builtins: Rc::clone(&self.denied_builtins),
             cancel_token: self.cancel_token.clone(),
+            interrupt_signal_token: self.interrupt_signal_token.clone(),
             cancel_grace_instructions_remaining: None,
+            interrupt_handlers: Vec::new(),
+            next_interrupt_handle: 1,
+            pending_interrupt_signal: None,
+            interrupted: self.interrupted,
+            dispatching_interrupt: false,
+            interrupt_handler_deadline: None,
             error_stack_trace: Vec::new(),
             yield_sender: None,
             project_root: self.project_root.clone(),

--- a/crates/harn-vm/src/vm/tests_runtime.rs
+++ b/crates/harn-vm/src/vm/tests_runtime.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use std::path::Path;
 use std::rc::Rc;
 use std::time::Duration;
@@ -1336,6 +1336,119 @@ log(contains(unwrap_err(result), "cancelled"))
 }"#,
     );
     assert_eq!(out, "[harn] true\n[harn] true");
+}
+
+#[test]
+fn test_std_signal_handlers_are_lifo_and_removable() {
+    let out = run_output(
+        r#"
+import "std/signal"
+
+pipeline t() {
+  let first = on_interrupt({ -> log("a") }, {once: false})
+  let second = on_interrupt({ -> log("b") }, {once: false})
+  __signal_raise("SIGINT")
+  off_interrupt(second)
+  __signal_raise("SIGINT")
+  log(interrupted())
+  off_interrupt(first.handle)
+}
+"#,
+    );
+    assert_eq!(out, "[harn] b\n[harn] a\n[harn] a\n[harn] true");
+}
+
+#[test]
+fn test_with_interrupt_unregisters_after_throw() {
+    let out = run_output(
+        r#"
+import "std/signal"
+
+pipeline t() {
+  try {
+    with_interrupt({ -> log("leaked") }, { -> throw "boom" }, {once: false})
+  } catch (e) {
+  }
+  let raised = try {
+    __signal_raise("SIGINT")
+    "not interrupted"
+  } catch (e) {
+    "interrupted"
+  }
+  log(raised)
+}
+"#,
+    );
+    assert_eq!(out, "[harn] interrupted");
+}
+
+#[test]
+fn test_interrupt_handler_graceful_timeout_is_enforced() {
+    let out = run_output(
+        r#"
+import "std/signal"
+
+pipeline t() {
+  on_interrupt({ ->
+    var spin = 0
+    while true { spin = spin + 1 }
+  }, {graceful_timeout_ms: 0})
+  let result = try {
+    __signal_raise("SIGINT")
+    "missed timeout"
+  } catch (e) {
+    e
+  }
+  log(result)
+}
+"#,
+    );
+    assert_eq!(out, "[harn] kind:interrupted:handler_timeout");
+}
+
+#[test]
+fn test_host_signal_token_dispatches_matching_signal() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(async {
+        let mut vm = Vm::new();
+        vm.register_builtin("term_marker", |_, out| {
+            out.push_str("[harn] term\n");
+            Ok(VmValue::Nil)
+        });
+        vm.register_builtin("int_marker", |_, out| {
+            out.push_str("[harn] int\n");
+            Ok(VmValue::Nil)
+        });
+        let term_options = VmValue::Dict(Rc::new(BTreeMap::from([(
+            "signals".to_string(),
+            VmValue::List(Rc::new(vec![VmValue::String(Rc::from("SIGTERM"))])),
+        )])));
+        let int_options = VmValue::Dict(Rc::new(BTreeMap::from([(
+            "signals".to_string(),
+            VmValue::List(Rc::new(vec![VmValue::String(Rc::from("SIGINT"))])),
+        )])));
+        vm.register_interrupt_handler(
+            VmValue::BuiltinRef(Rc::from("term_marker")),
+            Some(&term_options),
+        )
+        .unwrap();
+        vm.register_interrupt_handler(
+            VmValue::BuiltinRef(Rc::from("int_marker")),
+            Some(&int_options),
+        )
+        .unwrap();
+
+        let cancel_token = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true));
+        let signal_token = std::sync::Arc::new(std::sync::Mutex::new(Some("SIGTERM".to_string())));
+        vm.install_interrupt_signal_token(signal_token);
+        vm.install_cancel_token(cancel_token);
+
+        assert!(vm.pending_scope_interrupt().await.is_none());
+        assert_eq!(vm.output().trim_end(), "[harn] term");
+    });
 }
 
 #[test]

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -372,6 +372,8 @@ Imports starting with `std/` load embedded stdlib modules:
   store_refresh)
 - `import "std/async"` — polling and retry helpers (wait_for, retry_until,
   retry_predicate_with_backoff, circuit_call)
+- `import "std/signal"` — cooperative process interruption helpers
+  (on_interrupt, off_interrupt, interrupted, with_interrupt)
 - `import "std/vision"` — deterministic OCR helpers (`ocr(image, options?)`)
 - `import "std/prompt_library"` — reusable prompt fragments, cache metadata,
   tenant-scoped k-means hotspot proposals, and review-queue records
@@ -1381,6 +1383,34 @@ parent's runtime context snapshot and cancellation token. The VM checks
 cancellation between bytecode instructions and while awaiting interruptible
 async operations, so CPU-bound Harn loops and blocked async calls both unwind.
 When a VM exits, any un-awaited spawned tasks it owns are cancelled and aborted.
+
+### std/signal
+
+```harn
+import "std/signal"
+
+let registration = on_interrupt({ ->
+  agent_session_close(session, {status: "interrupted"})
+}, {signals: ["SIGINT", "SIGTERM"], once: true})
+
+defer { off_interrupt(registration) }
+```
+
+`std/signal` exposes cooperative process interruption for scripts run by
+`harn run`. `on_interrupt(handler, options?)` registers a callable for
+`SIGINT`, `SIGTERM`, or `SIGHUP`; matching handlers run in LIFO order at the
+next VM interrupt checkpoint. The default is `{signals: ["SIGINT"], once:
+true}`. `graceful_timeout_ms` bounds handler execution at VM interrupt
+checkpoints; an expired handler throws `kind:interrupted:handler_timeout`.
+`off_interrupt(handle)` removes a handler, and `interrupted()` remains true
+after the VM has observed an interrupt so tight loops can poll and return
+through normal `defer` cleanup. `with_interrupt(handler, body, options?)`
+registers a handler for the dynamic extent of `body` and always unregisters it
+before returning or rethrowing.
+
+If no matching handler is registered, process interruption falls back to normal
+VM cancellation. A second process signal terminates `harn run` immediately so a
+wedged handler cannot trap the operator.
 
 ### deadline
 

--- a/scripts/lint_test_patterns.sh
+++ b/scripts/lint_test_patterns.sh
@@ -459,6 +459,9 @@ NON_TEST_WALL_CLOCK_ALLOWLIST=(
   "crates/harn-vm/src/triggers/worker_queue.rs"
   "crates/harn-vm/src/trust_graph.rs"
   "crates/harn-vm/src/vm/execution.rs"
+  # std/signal interrupt handler deadlines share the VM's existing monotonic
+  # deadline mechanism until the broader Clock-injection cleanup reaches vm/.
+  "crates/harn-vm/src/vm/interrupts.rs"
   "crates/harn-vm/src/vm/iter.rs"
   "crates/harn-vm/src/vm/ops/parallel.rs"
   "crates/harn-vm/src/waitpoints.rs"

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -370,6 +370,8 @@ Imports starting with `std/` load embedded stdlib modules:
   store_refresh)
 - `import "std/async"` — polling and retry helpers (wait_for, retry_until,
   retry_predicate_with_backoff, circuit_call)
+- `import "std/signal"` — cooperative process interruption helpers
+  (on_interrupt, off_interrupt, interrupted, with_interrupt)
 - `import "std/vision"` — deterministic OCR helpers (`ocr(image, options?)`)
 - `import "std/prompt_library"` — reusable prompt fragments, cache metadata,
   tenant-scoped k-means hotspot proposals, and review-queue records
@@ -1379,6 +1381,34 @@ parent's runtime context snapshot and cancellation token. The VM checks
 cancellation between bytecode instructions and while awaiting interruptible
 async operations, so CPU-bound Harn loops and blocked async calls both unwind.
 When a VM exits, any un-awaited spawned tasks it owns are cancelled and aborted.
+
+### std/signal
+
+```harn
+import "std/signal"
+
+let registration = on_interrupt({ ->
+  agent_session_close(session, {status: "interrupted"})
+}, {signals: ["SIGINT", "SIGTERM"], once: true})
+
+defer { off_interrupt(registration) }
+```
+
+`std/signal` exposes cooperative process interruption for scripts run by
+`harn run`. `on_interrupt(handler, options?)` registers a callable for
+`SIGINT`, `SIGTERM`, or `SIGHUP`; matching handlers run in LIFO order at the
+next VM interrupt checkpoint. The default is `{signals: ["SIGINT"], once:
+true}`. `graceful_timeout_ms` bounds handler execution at VM interrupt
+checkpoints; an expired handler throws `kind:interrupted:handler_timeout`.
+`off_interrupt(handle)` removes a handler, and `interrupted()` remains true
+after the VM has observed an interrupt so tight loops can poll and return
+through normal `defer` cleanup. `with_interrupt(handler, body, options?)`
+registers a handler for the dynamic extent of `body` and always unregisters it
+before returning or rethrowing.
+
+If no matching handler is registered, process interruption falls back to normal
+VM cancellation. A second process signal terminates `harn run` immediately so a
+wedged handler cannot trap the operator.
 
 ### deadline
 


### PR DESCRIPTION
## Summary
- add std/signal with on_interrupt, off_interrupt, interrupted, and with_interrupt
- route harn run SIGINT/SIGTERM/SIGHUP into VM interrupt dispatch with second-signal hard exit
- add handler LIFO/removal, graceful timeout, host signal, and process SIGTERM conformance coverage

## Verification
- cargo test -p harn-vm signal --lib
- cargo test -p harn-vm interrupt --lib
- cargo test -p harn-cli execute_run --lib
- cargo test -p harn-vm --test builtin_registry_alignment
- cargo test -p harn-stdlib signal_stdlib_module_exports_interrupt_helpers
- cargo run --quiet --bin harn -- test conformance --filter signal
- cargo clippy -p harn-vm --lib --tests -- -D warnings
- cargo clippy -p harn-cli --lib --tests -- -D warnings
- make lint-test-patterns
- make fmt-harn
- make check-language-spec
- make check-highlight

Closes #1547