### PR TITLE
Add std/tui::select_from picker (#1544)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ condensed series summaries instead of full per-patch history.
 
 ### Added
 
+- **`std/tui::select_from` picker (#1544).** Added
+  `select_from(items, opts?)` to `std/tui` so harness scripts stop
+  hand-rolling fzf detection plus numbered-menu fallbacks. The picker
+  auto-detects `fzf` then `gum choose` at runtime, falls back to a
+  numbered `read_line` menu (which `mock_stdin` can drive in tests),
+  and always returns a stable `{ok, value, status}` envelope. Supports
+  `multi: true`, `default_index`, `cancel_value`, per-item `display`
+  and `preview` callbacks, and
+  `prefer_external: "auto" | "fzf" | "gum" | "none"` for forcing a
+  backend.
 - **JSONL-seeded agent sessions (#1546).** Added
   `agent_session_seed_from_jsonl(path, opts?)` to create a new
   first-class session from replayable `llm_transcript.jsonl` sidecars.
@@ -30,6 +40,17 @@ condensed series summaries instead of full per-patch history.
   `page` prints directly when stdout is not interactive, `no_pager` is set, or
   `$PAGER=cat`; otherwise it uses `$PAGER` with `less -R -F -X` defaults and
   falls back to print output when the pager binary is unavailable.
+
+### Fixed
+
+- **Tail-call inside `for` loops leaked iterator state across the
+  caller.** `return f(...)` from inside a `for x in xs { ... }` body
+  is tail-call-optimized, but the new frame was capturing the current
+  iterator depth instead of the popped frame's depth. The caller's
+  outer iterator then iterated against the inner loop's leaked state,
+  producing extra phantom items. The tail-called frame now inherits
+  the popped frame's `saved_iterator_depth` and the iterator stack is
+  truncated to match.
 
 ## v0.8.11
 

--- a/conformance/tests/functions/tail_call_inside_for.expected
+++ b/conformance/tests/functions/tail_call_inside_for.expected
@@ -1,0 +1,4 @@
+3
+one
+two
+three

--- a/conformance/tests/functions/tail_call_inside_for.harn
+++ b/conformance/tests/functions/tail_call_inside_for.harn
@@ -1,0 +1,29 @@
+/**
+ * Regression: `return f(...)` inside a `for x in [...]` loop is
+ * tail-call-optimized. The compiler must hand the tail-called frame
+ * the iterator depth from the *popped* frame, not the live depth, or
+ * iterators pushed by the caller's for-loop leak into the caller's
+ * caller — making the outer loop iterate too many times.
+ */
+fn first_value(item) -> any {
+  if type_of(item) == "dict" {
+    for key in ["a", "b", "c"] {
+      if item[key] != nil {
+        return to_string(item[key])
+      }
+    }
+  }
+  return to_string(item)
+}
+
+pipeline default() {
+  let items = [{a: "one"}, {b: "two"}, {c: "three"}]
+  var picked = []
+  for item in items {
+    picked = picked + [first_value(item)]
+  }
+  println(len(picked))
+  for value in picked {
+    println(value)
+  }
+}

--- a/conformance/tests/stdlib/tui_select_from.expected
+++ b/conformance/tests/stdlib/tui_select_from.expected
@@ -1,0 +1,30 @@
+1)  Alpha — recent
+2)  Beta
+3)  gamma
+Pick (1-3; q to exit)> ok=true status=selected value=beta
+1) *Alpha — recent
+2)  Beta
+3)  gamma
+Select (1-3; q to exit)> ok=true status=selected value=alpha
+1)  Alpha — recent
+2)  Beta
+3)  gamma
+Select (1-3; q to exit)> ok=false status=cancelled value=ABORTED
+1)  Alpha — recent
+2)  Beta
+3)  gamma
+Select (1-3; q to exit)> ok=false status=eof value=nil
+1)  Alpha — recent
+2)  Beta
+3)  gamma
+Select (1-3; q to exit)> ok=false status=error value=nil
+1)  Alpha — recent
+2)  Beta
+3)  gamma
+Select (comma-separated; blank=cancel; q to exit)> ok=true status=selected value=[alpha,gamma]
+1)  <alpha>
+2)  <beta>
+3)  <gamma>
+Select (1-3; q to exit)> ok=true status=selected value=alpha
+ok=false status=error value=nil
+ok=false status=error value=nil

--- a/conformance/tests/stdlib/tui_select_from.harn
+++ b/conformance/tests/stdlib/tui_select_from.harn
@@ -1,0 +1,70 @@
+// Exercises the numbered fallback in std/tui::select_from end-to-end.
+// External backends (fzf/gum) take over the controlling tty and can't
+// be driven from a captured-stdout test runner; we pin them off with
+// `prefer_external: "none"` and validate the parsing + cancel paths
+// under `mock_stdin`.
+import { select_from } from "std/tui"
+
+fn show(result) {
+  let value_kind = type_of(result?.value)
+  let value_repr = if value_kind == "dict" {
+    result.value?.id ?? to_string(result.value)
+  } else {
+    if value_kind == "list" {
+      var parts = []
+      for entry in result.value {
+        let part = if type_of(entry) == "dict" {
+          entry?.id ?? to_string(entry)
+        } else {
+          to_string(entry)
+        }
+        parts = parts + [part]
+      }
+      "[" + join(parts, ",") + "]"
+    } else {
+      to_string(result.value)
+    }
+  }
+  println("ok=" + to_string(result.ok) + " status=" + result.status + " value=" + value_repr)
+}
+
+pipeline default() {
+  let items = [{id: "alpha", label: "Alpha — recent"}, {id: "beta", title: "Beta"}, "gamma"]
+  // 1) Pick the second item by typing "2".
+  mock_stdin("2\n")
+  show(select_from(items, {prefer_external: "none", prompt: "Pick"}))
+  unmock_stdin()
+  // 2) Empty input + default_index falls through to the default.
+  mock_stdin("\n")
+  show(select_from(items, {prefer_external: "none", default_index: 0}))
+  unmock_stdin()
+  // 3) "/exit" cancels and returns the supplied cancel_value.
+  mock_stdin("/exit\n")
+  show(select_from(items, {prefer_external: "none", cancel_value: "ABORTED"}))
+  unmock_stdin()
+  // 4) EOF (no input at all) maps to status "eof".
+  mock_stdin("")
+  show(select_from(items, {prefer_external: "none"}))
+  unmock_stdin()
+  // 5) Out-of-range token surfaces an error, not a panic.
+  mock_stdin("99\n")
+  show(select_from(items, {prefer_external: "none"}))
+  unmock_stdin()
+  // 6) Multi-select parses comma-separated 1-based indices.
+  mock_stdin("1,3\n")
+  show(select_from(items, {prefer_external: "none", multi: true}))
+  unmock_stdin()
+  // 7) Custom display function overrides the dict-key heuristic.
+  mock_stdin("1\n")
+  show(
+    select_from(
+      items,
+      {prefer_external: "none", display: { item -> "<" + item?.id ?? to_string(item) + ">" }},
+    ),
+  )
+  unmock_stdin()
+  // 8) Empty items list is an error, not a hang.
+  show(select_from([], {prefer_external: "none"}))
+  // 9) Invalid prefer_external is rejected up front.
+  show(select_from(items, {prefer_external: "rofi"}))
+}

--- a/crates/harn-stdlib/src/lib.rs
+++ b/crates/harn-stdlib/src/lib.rs
@@ -994,7 +994,7 @@ mod tests {
             .into_iter()
             .map(|function| function.name)
             .collect::<BTreeSet<_>>();
-        for name in ["page", "terminal_width", "rule", "clear"] {
+        for name in ["page", "terminal_width", "rule", "clear", "select_from"] {
             assert!(exports.contains(name), "std/tui should export {name}");
         }
     }

--- a/crates/harn-stdlib/src/stdlib/stdlib_tui.harn
+++ b/crates/harn-stdlib/src/stdlib/stdlib_tui.harn
@@ -1,4 +1,17 @@
-/** std/tui - terminal presentation helpers for interactive scripts. */
+// std/tui — terminal presentation helpers for interactive scripts.
+//
+// Two complementary surfaces:
+//   * `page` / `terminal_width` / `rule` / `clear` for rendering long
+//     artifacts and chrome.
+//   * `select_from(items, opts?)` for harness-style pickers. Auto-
+//     detects `fzf` and `gum choose` at runtime and falls back to a
+//     numbered `read_line` menu when neither is available, so callers
+//     stop branching on which binary happens to be installed. The
+//     fallback is testable end-to-end with `mock_stdin` / `mock_tty`;
+//     external backends require the controlling terminal so tests
+//     should pass `prefer_external: "none"` to skip the probes.
+import { command_run } from "std/command"
+
 type PageFormat = "text" | "markdown"
 
 type PageOptions = {
@@ -10,6 +23,18 @@ type PageOptions = {
 }
 
 type PageResult = {ok: bool, paged: bool, error?: string}
+
+/** Optional dict passed to `select_from`. */
+type SelectFromOptions = {
+  prompt?: string,
+  display?: any,
+  preview?: any,
+  multi?: bool,
+  default_index?: int,
+  cancel_value?: any,
+  prefer_external?: string,
+  header?: string,
+}
 
 /** page shows a text or markdown artifact through a pager when stdout is interactive. */
 pub fn page(opts: PageOptions) -> PageResult {
@@ -38,4 +63,418 @@ pub fn rule(char = "─", width = nil) -> string {
 /** clear writes the ANSI clear-screen sequence to stdout. */
 pub fn clear() {
   __tui_clear()
+}
+
+let __TUI_CANCEL_TOKENS = ["q", "quit", "/quit", "exit", "/exit", "/cancel"]
+
+let __TUI_LINE_SEP = "\t"
+
+fn __tui_is_callable(value) -> bool {
+  let kind = type_of(value)
+  return kind == "function" || kind == "closure" || kind == "fn"
+}
+
+fn __tui_to_string(value) -> string {
+  if type_of(value) == "string" {
+    return value
+  }
+  return to_string(value)
+}
+
+fn __tui_default_display(item) -> string {
+  if type_of(item) == "dict" {
+    for key in ["label", "title", "name", "headline"] {
+      if item[key] != nil {
+        return __tui_to_string(item[key])
+      }
+    }
+  }
+  return __tui_to_string(item)
+}
+
+fn __tui_sanitize(text: string) -> string {
+  // Backends are line-and-tab-delimited; collapse embedded \r/\n/\t so
+  // each item maps to exactly one row with no field-separator surprises.
+  let no_cr = replace(text, "\r", " ")
+  let no_lf = replace(no_cr, "\n", " ")
+  return replace(no_lf, __TUI_LINE_SEP, " ")
+}
+
+fn __tui_render_label(item, display_fn) -> string {
+  let raw = if display_fn != nil && __tui_is_callable(display_fn) {
+    display_fn(item)
+  } else {
+    __tui_default_display(item)
+  }
+  return __tui_sanitize(__tui_to_string(raw))
+}
+
+fn __tui_render_preview(item, preview_fn) -> string {
+  if preview_fn == nil || !__tui_is_callable(preview_fn) {
+    return ""
+  }
+  let raw = preview_fn(item)
+  if raw == nil {
+    return ""
+  }
+  return __tui_to_string(raw)
+}
+
+fn __tui_result(ok, value, status) -> dict {
+  return {ok: ok, value: value, status: status}
+}
+
+fn __tui_cancelled(opts) -> dict {
+  return __tui_result(false, opts?.cancel_value, "cancelled")
+}
+
+fn __tui_eof(opts) -> dict {
+  return __tui_result(false, opts?.cancel_value, "eof")
+}
+
+fn __tui_error(opts, message: string) -> dict {
+  return {ok: false, value: opts?.cancel_value, status: "error", error: message}
+}
+
+fn __tui_probe(binary: string) -> bool {
+  let probed = try {
+    command_run({argv: [binary, "--version"]}, {capture: {max_inline_bytes: 256}})
+  }
+  if !is_ok(probed) {
+    return false
+  }
+  let result = unwrap(probed)
+  return result?.exit_code == 0
+}
+
+fn __tui_pick_backend(prefer: string) -> string {
+  if prefer == "fzf" || prefer == "gum" || prefer == "none" {
+    return prefer
+  }
+  // "auto": only consider external pickers when stdout is a real
+  // terminal — they draw their UI over /dev/tty and can't render into
+  // captured pipes. Tests can force a backend via `prefer_external`.
+  if !is_stdout_tty() {
+    return "numbered"
+  }
+  if __tui_probe("fzf") {
+    return "fzf"
+  }
+  if __tui_probe("gum") {
+    return "gum"
+  }
+  return "numbered"
+}
+
+fn __tui_parse_index(token: string, len_items: int) -> any {
+  let trimmed = trim(token)
+  if trimmed == "" {
+    return nil
+  }
+  let parsed = to_int(trimmed)
+  if parsed == nil {
+    return nil
+  }
+  // Numbered display is 1-based to humans; map back to a 0-based index.
+  let zero_based = parsed - 1
+  if zero_based < 0 || zero_based >= len_items {
+    return nil
+  }
+  return zero_based
+}
+
+fn __tui_parse_multi(line: string, len_items: int) -> any {
+  var selected = []
+  var seen = {}
+  for piece in split(line, ",") {
+    let idx = __tui_parse_index(piece, len_items)
+    if idx == nil {
+      return nil
+    }
+    if seen[to_string(idx)] == nil {
+      seen = seen + {[to_string(idx)]: true}
+      selected = selected + [idx]
+    }
+  }
+  if len(selected) == 0 {
+    return nil
+  }
+  return selected
+}
+
+fn __tui_print_menu(items, labels: list<string>, opts) {
+  let prompt = opts?.prompt ?? "Select"
+  let header = opts?.header
+  if header != nil && trim(__tui_to_string(header)) != "" {
+    println(__tui_to_string(header))
+  }
+  var idx = 0
+  for label in labels {
+    let human = idx + 1
+    let marker = if opts?.default_index == idx {
+      " *"
+    } else {
+      "  "
+    }
+    println(to_string(human) + ")" + marker + label)
+    idx = idx + 1
+  }
+  let multi = opts?.multi ?? false
+  let hint = if multi {
+    " (comma-separated; blank=cancel; q to exit)"
+  } else {
+    " (1-" + to_string(len(items)) + "; q to exit)"
+  }
+  print(__tui_to_string(prompt) + hint + "> ")
+}
+
+fn __tui_numbered_pick(items, labels, opts) -> dict {
+  __tui_print_menu(items, labels, opts)
+  let line_raw = read_line()
+  if line_raw == nil {
+    return __tui_eof(opts)
+  }
+  let line = trim(line_raw)
+  if contains(__TUI_CANCEL_TOKENS, lowercase(line)) {
+    return __tui_cancelled(opts)
+  }
+  let multi = opts?.multi ?? false
+  if line == "" {
+    if opts?.default_index != nil && opts.default_index >= 0 && opts.default_index < len(items) {
+      let chosen = items[opts.default_index]
+      let value = if multi {
+        [chosen]
+      } else {
+        chosen
+      }
+      return __tui_result(true, value, "selected")
+    }
+    return __tui_cancelled(opts)
+  }
+  if multi {
+    let indices = __tui_parse_multi(line, len(items))
+    if indices == nil {
+      return __tui_error(opts, "invalid selection: " + line_raw)
+    }
+    var picked = []
+    for i in indices {
+      picked = picked + [items[i]]
+    }
+    return __tui_result(true, picked, "selected")
+  }
+  let idx = __tui_parse_index(line, len(items))
+  if idx == nil {
+    return __tui_error(opts, "invalid selection: " + line_raw)
+  }
+  return __tui_result(true, items[idx], "selected")
+}
+
+fn __tui_join_stdin(labels: list<string>) -> string {
+  var lines = []
+  var idx = 0
+  for label in labels {
+    // Encode rows as "<idx>\t<label>" so we can recover the original
+    // item after fzf prints the chosen line back. fzf treats this as a
+    // single column when `--with-nth=2..` is set.
+    lines = lines + [to_string(idx) + __TUI_LINE_SEP + label]
+    idx = idx + 1
+  }
+  return join(lines, "\n") + "\n"
+}
+
+fn __tui_preview_setup(items, preview_fn) -> dict {
+  if preview_fn == nil || !__tui_is_callable(preview_fn) {
+    return {dir: nil, args: []}
+  }
+  let dir = temp_dir() + "/harn-tui-" + uuid_v7()
+  mkdir(dir)
+  var idx = 0
+  for item in items {
+    write_file(dir + "/" + to_string(idx) + ".txt", __tui_render_preview(item, preview_fn))
+    idx = idx + 1
+  }
+  // fzf evaluates `--preview` through the host shell — `cmd.exe` on
+  // Windows, `sh` elsewhere — so the read command has to match.
+  let reader = if platform() == "windows" {
+    "type"
+  } else {
+    "cat"
+  }
+  return {dir: dir, args: ["--preview", reader + " " + dir + "/{1}.txt"]}
+}
+
+fn __tui_preview_cleanup(dir) {
+  if dir == nil {
+    return
+  }
+  let _ = try {
+    delete_file(dir)
+  }
+}
+
+fn __tui_lookup_by_index(items, label_line: string) -> any {
+  let parts = split(label_line, __TUI_LINE_SEP)
+  if len(parts) < 1 {
+    return nil
+  }
+  let idx = to_int(trim(parts[0]))
+  if idx == nil || idx < 0 || idx >= len(items) {
+    return nil
+  }
+  return items[idx]
+}
+
+fn __tui_fzf_decode(items, body: string, multi: bool, opts) -> dict {
+  let lines = split(body, "\n")
+  if multi {
+    var picked = []
+    for raw in lines {
+      let item = __tui_lookup_by_index(items, raw)
+      if item != nil {
+        picked = picked + [item]
+      }
+    }
+    if len(picked) == 0 {
+      return __tui_cancelled(opts)
+    }
+    return __tui_result(true, picked, "selected")
+  }
+  let chosen = __tui_lookup_by_index(items, lines[0])
+  if chosen == nil {
+    return __tui_error(opts, "fzf returned unparseable selection: " + lines[0])
+  }
+  return __tui_result(true, chosen, "selected")
+}
+
+fn __tui_fzf_pick(items, labels, opts) -> dict {
+  let stdin = __tui_join_stdin(labels)
+  let prompt = __tui_to_string(opts?.prompt ?? "Select> ")
+  let header = opts?.header
+  let multi = opts?.multi ?? false
+  var argv = [
+    "fzf",
+    "--ansi",
+    "--no-sort",
+    "--delimiter=" + __TUI_LINE_SEP,
+    "--with-nth=2..",
+    "--prompt=" + prompt,
+  ]
+  if header != nil && trim(__tui_to_string(header)) != "" {
+    argv = argv + ["--header=" + __tui_to_string(header)]
+  }
+  if multi {
+    argv = argv + ["-m"]
+  }
+  let preview = __tui_preview_setup(items, opts?.preview)
+  argv = argv + preview.args
+  let result = command_run({argv: argv}, {stdin: stdin, capture: {max_inline_bytes: 1048576}})
+  __tui_preview_cleanup(preview.dir)
+  if result.exit_code == 130 {
+    return __tui_cancelled(opts)
+  }
+  if !result.success {
+    return __tui_error(opts, "fzf exited with code " + to_string(result.exit_code))
+  }
+  let body = trim(result.stdout ?? "")
+  if body == "" {
+    return __tui_cancelled(opts)
+  }
+  return __tui_fzf_decode(items, body, multi, opts)
+}
+
+fn __tui_gum_pick(items, labels, opts) -> dict {
+  let stdin = join(labels, "\n") + "\n"
+  let header = __tui_to_string(opts?.header ?? opts?.prompt ?? "Select")
+  var argv = ["gum", "choose", "--header", header]
+  if opts?.multi ?? false {
+    argv = argv + ["--no-limit"]
+  }
+  let result = command_run({argv: argv}, {stdin: stdin, capture: {max_inline_bytes: 1048576}})
+  if !result.success {
+    return __tui_cancelled(opts)
+  }
+  let body = trim(result.stdout ?? "")
+  if body == "" {
+    return __tui_cancelled(opts)
+  }
+  let chosen_labels = split(body, "\n")
+  // gum echoes the label back unchanged; map labels → items by position
+  // so duplicate labels still resolve deterministically (first match).
+  var label_index = {}
+  var i = 0
+  for label in labels {
+    if label_index[label] == nil {
+      label_index = label_index + {[label]: i}
+    }
+    i = i + 1
+  }
+  if opts?.multi ?? false {
+    var picked = []
+    for raw in chosen_labels {
+      let idx = label_index[raw]
+      if idx != nil {
+        picked = picked + [items[idx]]
+      }
+    }
+    if len(picked) == 0 {
+      return __tui_cancelled(opts)
+    }
+    return __tui_result(true, picked, "selected")
+  }
+  let idx = label_index[chosen_labels[0]]
+  if idx == nil {
+    return __tui_error(opts, "gum returned unknown label: " + chosen_labels[0])
+  }
+  return __tui_result(true, items[idx], "selected")
+}
+
+/**
+ * Present `items` as a picker and return `{ok, value, status}`.
+ *
+ * `value` is the chosen item (or list of items when `multi: true`).
+ * `status` is `"selected"`, `"cancelled"`, `"eof"`, or `"error"`. On a
+ * non-selected outcome, `value` is `opts.cancel_value` (defaults to
+ * `nil`); on `"error"`, an `error` string field is also present.
+ *
+ * `display` and `preview` are optional `fn(item) -> string` callbacks.
+ * The default `display` walks `label` / `title` / `name` / `headline`
+ * on dicts and falls back to `to_string(item)`.
+ *
+ * `prefer_external` accepts `"auto"` (default), `"fzf"`, `"gum"`, or
+ * `"none"`. `"auto"` probes fzf then gum then falls back to the
+ * numbered menu (and short-circuits to numbered when stdout is not a
+ * TTY, so harness tests with `mock_stdin` keep working).
+ */
+pub fn select_from(items: list, opts: SelectFromOptions = {}) -> dict {
+  let options = opts ?? {}
+  if type_of(items) != "list" || len(items) == 0 {
+    return __tui_error(options, "select_from: items must be a non-empty list")
+  }
+  let prefer = __tui_to_string(options?.prefer_external ?? "auto")
+  if prefer != "auto" && prefer != "fzf" && prefer != "gum" && prefer != "none" {
+    return __tui_error(options, "select_from: prefer_external must be auto/fzf/gum/none (got " + prefer + ")")
+  }
+  let display_fn = options.display
+  if display_fn != nil && !__tui_is_callable(display_fn) {
+    return __tui_error(options, "select_from: display must be a function")
+  }
+  if options.preview != nil && !__tui_is_callable(options.preview) {
+    return __tui_error(options, "select_from: preview must be a function")
+  }
+  var labels = []
+  for item in items {
+    labels = labels + [__tui_render_label(item, display_fn)]
+  }
+  let backend = if prefer == "none" {
+    "numbered"
+  } else {
+    __tui_pick_backend(prefer)
+  }
+  if backend == "fzf" {
+    return __tui_fzf_pick(items, labels, options)
+  }
+  if backend == "gum" {
+    return __tui_gum_pick(items, labels, options)
+  }
+  return __tui_numbered_pick(items, labels, options)
 }

--- a/crates/harn-vm/src/vm/ops/call.rs
+++ b/crates/harn-vm/src/vm/ops/call.rs
@@ -716,6 +716,13 @@ impl super::super::Vm {
             Self::bind_param_slots(&mut local_slots, &closure.func, &args, false);
             let initial_local_slots = local_slots.clone();
 
+            // Inherit the popped frame's iterator depth so iterators
+            // pushed by for-loops inside the caller (`return f(...)` from
+            // inside `for x in xs { ... }`) get torn down when the
+            // tail-called callee eventually returns, instead of leaking
+            // into the caller's caller.
+            let saved_iterator_depth = popped.saved_iterator_depth;
+            self.iterators.truncate(saved_iterator_depth);
             let argc = args.len();
             self.frames.push(CallFrame {
                 chunk: Rc::clone(&closure.func.chunk),
@@ -724,7 +731,7 @@ impl super::super::Vm {
                 saved_env: parent_env,
                 initial_env: Some(initial_env),
                 initial_local_slots: Some(initial_local_slots),
-                saved_iterator_depth: self.iterators.len(),
+                saved_iterator_depth,
                 fn_name: closure.func.name.clone(),
                 argc,
                 saved_source_dir,

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -240,6 +240,12 @@ let result = page({title: "Audit", body: markdown, format: "markdown"})
 falls back to full print output when stdout is not interactive or the pager is
 missing, and returns `{ok, paged, error?}`.
 
+For interactive pickers, the same module exports
+`select_from(items, opts?)` so harness scripts stop hand-rolling
+`fzf` / `gum choose` detection. It returns `{ok, value, status}`,
+auto-detects fzf then gum then falls back to a numbered `read_line`
+menu, and honors `mock_stdin` under `prefer_external: "none"`.
+
 ## Time, sleep, monotonic clock
 
 - `now_ms()` — wall-clock millis since UNIX_EPOCH (`int`).

--- a/docs/src/modules.md
+++ b/docs/src/modules.md
@@ -664,11 +664,12 @@ let step = command_step("verify package", ["cargo", "test", "-p", "harn-vm"], {
 
 ### std/tui
 
-Terminal presentation helpers for interactive scripts:
+Terminal presentation and picker helpers for interactive scripts:
 
 | Function | Description |
 |---|---|
 | `page(opts)` | Show a text or markdown artifact through `$PAGER` when stdout is a TTY; otherwise print the full artifact and footer. Returns `{ok, paged, error?}` |
+| `select_from(items, opts?)` | Show a picker over `items` and return `{ok, value, status}`. Auto-detects `fzf` then `gum choose` and falls back to a numbered `read_line` menu when neither is available or stdout is not a TTY |
 | `terminal_width(default_width?)` | Return the current terminal width, falling back to `default_width` or 80 |
 | `rule(char?, width?)` | Return `char` repeated to `width`, or to the terminal width when width is omitted |
 | `clear()` | Write the ANSI clear-screen sequence to stdout |
@@ -689,6 +690,45 @@ let result = page({
 })
 if !result.ok {
   eprintln(result.error ?? "pager failed")
+}
+```
+
+`select_from` accepts:
+
+- `prompt` — header shown above the menu / passed to fzf's `--prompt`.
+- `display` — `fn(item) -> string` rendering each row. Default reads
+  `label` / `title` / `name` / `headline` on dicts and falls through
+  to `to_string`.
+- `preview` — `fn(item) -> string` rendered into fzf's preview pane.
+  The numbered fallback ignores it.
+- `multi` — `true` returns a list of items; `false` (default) returns
+  one. Numbered fallback accepts comma-separated 1-based indices.
+- `default_index` — 0-based index to use when the operator hits Enter
+  on an empty line. The numbered menu marks it with a leading `*`.
+- `cancel_value` — value returned in `value` when the operator
+  cancels (Ctrl+C, Esc, `q`, `/exit`). Defaults to `nil`.
+- `prefer_external` — `"auto"` (default), `"fzf"`, `"gum"`, or
+  `"none"`. Use `"none"` in scripted tests to force the numbered
+  fallback so `mock_stdin` drives the run.
+- `header` — extra banner shown above the menu / passed via
+  `--header`.
+
+Return shape: `{ok: bool, value: any | list<any>, status: string,
+error?: string}`. `status` is `"selected"`, `"cancelled"`, `"eof"`,
+or `"error"`. On errors the `error` field carries a one-line message
+describing what went wrong; the value is `opts.cancel_value` (or
+`nil`).
+
+```harn,ignore
+import { select_from } from "std/tui"
+
+let runs = [
+  {id: "r-001", label: "r-001 — 2 PRs queued"},
+  {id: "r-002", label: "r-002 — verification flake"},
+]
+let pick = select_from(runs, {prompt: "Pick a run", default_index: 0})
+if pick.ok {
+  println("operator chose " + pick.value.id)
 }
 ```
 


### PR DESCRIPTION
## Summary

- Adds `select_from(items, opts?)` to `std/tui` so harness scripts stop hand-rolling fzf detection and numbered-menu fallbacks. Closes [#1544](https://github.com/burin-labs/harn/issues/1544).
- The picker auto-detects `fzf` then `gum choose` at runtime, falls back to a numbered `read_line` menu, and always returns a stable `{ok, value, status}` envelope. Supports `multi`, `default_index`, `cancel_value`, per-item `display` / `preview` callbacks, and `prefer_external: "auto" | "fzf" | "gum" | "none"` for forcing a backend.
- Fixes a VM tail-call bug surfaced while building the conformance test: `return f(...)` from inside a `for x in xs { ... }` body is tail-call-optimized, but the new frame was capturing the current iterator depth instead of the popped frame's depth, so the caller's outer iterator then iterated against the inner loop's leaked state. The tail-called frame now inherits the popped frame's `saved_iterator_depth` and the iterator stack is truncated to match.

## Design notes

- Pure-Harn implementation in `crates/harn-stdlib/src/stdlib/stdlib_tui.harn` next to the existing `page` / `terminal_width` / `rule` / `clear` helpers from [#1554](https://github.com/burin-labs/harn/pull/1554).
- Fzf preview pane is wired by writing per-item preview text to a temp dir and pointing `--preview` at `cat <dir>/{1}.txt` (`type` on Windows). The temp dir is cleaned up after fzf exits.
- `prefer_external: "auto"` short-circuits to the numbered fallback when stdout is not a TTY so harness tests can mock stdin without skipping the probes manually.
- Numbered fallback maps `q` / `/exit` / `/quit` / `exit` / `quit` / `/cancel` to a `"cancelled"` outcome with `opts.cancel_value`.

## Test plan

- [x] `cargo run --quiet --bin harn -- test conformance --filter tui` — `tui_helpers` + new `tui_select_from`.
- [x] `cargo run --quiet --bin harn -- test conformance --filter tail_call` — new `tail_call_inside_for` regression.
- [x] `cargo run --quiet --bin harn -- test conformance` — 1001 + 2 new pass; no regressions.
- [x] `cargo nextest run -p harn-vm` — 1897 passed, 2 skipped.
- [x] `cargo nextest run -p harn-stdlib` — 13 passed (includes updated `tui_stdlib_module_exports_terminal_helpers` for `select_from`).
- [x] `make all` — full repo gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)