### PR TITLE
acp: cache compiled pipeline bytecode across turns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2283,6 +2283,7 @@ dependencies = [
  "axum",
  "axum-server",
  "base64",
+ "filetime",
  "futures",
  "harn-parser",
  "harn-vm",

--- a/crates/harn-serve/Cargo.toml
+++ b/crates/harn-serve/Cargo.toml
@@ -31,6 +31,7 @@ url = "2"
 uuid = { version = "1", features = ["v4", "v7"] }
 
 [dev-dependencies]
+filetime = "0.2"
 hex = "0.4"
 jsonwebtoken = { version = "9", default-features = false, features = ["use_pem"] }
 tempfile = "3"

--- a/crates/harn-serve/src/adapters/acp/mod.rs
+++ b/crates/harn-serve/src/adapters/acp/mod.rs
@@ -42,11 +42,11 @@ pub use transport::{run_acp_channel_server, run_acp_server};
 
 use std::collections::{BTreeMap, HashMap};
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Instant, SystemTime};
 
 use async_trait::async_trait;
 use harn_vm::agent_events::{clear_session_sinks, register_sink, AgentEventSink};
@@ -131,6 +131,19 @@ impl AcpServerConfig {
     }
 }
 
+/// Cached compiled pipeline. The ACP server re-uses the same pipeline file
+/// across every `session/prompt`; recompiling on each turn was the dominant
+/// per-turn overhead inside the VM (~80ms on auto.harn) before this cache.
+/// Keyed by (path, mtime, target_pipeline_name) — when the file's mtime moves
+/// forward we discard the cache and re-read/re-compile.
+struct CompileCacheEntry {
+    path: PathBuf,
+    mtime: SystemTime,
+    target_pipeline: Option<String>,
+    source: String,
+    chunk: harn_vm::Chunk,
+}
+
 /// ACP server that reads JSON-RPC requests from a transport and writes
 /// responses / notifications back to that same transport.
 pub struct AcpServer {
@@ -154,6 +167,9 @@ pub struct AcpServer {
     session_cancellations: Arc<std::sync::Mutex<HashMap<String, SessionCancellation>>>,
     /// Transport output sink.
     output: AcpOutput,
+    /// Compiled-pipeline cache. One slot — the ACP server runs a single
+    /// pipeline file for its lifetime, so we only ever cache one chunk.
+    compile_cache: Option<CompileCacheEntry>,
 }
 
 impl AcpServer {
@@ -181,7 +197,59 @@ impl AcpServer {
             pending: Arc::new(Mutex::new(HashMap::new())),
             session_cancellations: Arc::new(std::sync::Mutex::new(HashMap::new())),
             output,
+            compile_cache: None,
         }
+    }
+
+    /// Compile `source` for `target_pipeline` (or the default entry point
+    /// when `target_pipeline` is None), reusing the cached chunk when the
+    /// file at `source_path` has the same mtime as the last cache fill and
+    /// the target hasn't changed.
+    ///
+    /// Returns `(chunk, hit)` so the caller can keep its existing compile-
+    /// time telemetry meaningful (hits report ~0 ms).
+    ///
+    /// Inline-mode prompts pass `source_path: None` and never hit cache —
+    /// the source is freshly generated per turn so there's nothing to reuse.
+    fn compile_pipeline_cached(
+        &mut self,
+        source: &str,
+        source_path: Option<&Path>,
+        target_pipeline: Option<&str>,
+    ) -> Result<(harn_vm::Chunk, bool), String> {
+        let target_owned = target_pipeline.map(|s| s.to_string());
+        let cache_key = source_path.and_then(|path| {
+            std::fs::metadata(path)
+                .and_then(|m| m.modified())
+                .ok()
+                .map(|mtime| (path.to_path_buf(), mtime))
+        });
+        if let Some((ref path, mtime)) = cache_key {
+            if let Some(entry) = self.compile_cache.as_ref() {
+                if entry.path == *path
+                    && entry.mtime == mtime
+                    && entry.target_pipeline == target_owned
+                    && entry.source == source
+                {
+                    return Ok((entry.chunk.clone(), true));
+                }
+            }
+        }
+        let chunk = match target_pipeline {
+            Some(name) => harn_vm::compile_source_named(source, name),
+            None => harn_vm::compile_source(source),
+        }
+        .map_err(|e| format!("Compilation error: {e}"))?;
+        if let Some((path, mtime)) = cache_key {
+            self.compile_cache = Some(CompileCacheEntry {
+                path,
+                mtime,
+                target_pipeline: target_owned,
+                source: source.to_string(),
+                chunk: chunk.clone(),
+            });
+        }
+        Ok((chunk, false))
     }
 
     /// Write a complete JSON-RPC message to the current transport.
@@ -637,7 +705,7 @@ impl AcpServer {
         let _session_guard = harn_vm::agent_sessions::enter_current_session(session_id.clone());
 
         let (source, source_path) = if let Some(ref pipeline_path) = self.pipeline {
-            let full_path = if std::path::Path::new(pipeline_path).is_absolute() {
+            let full_path = if Path::new(pipeline_path).is_absolute() {
                 PathBuf::from(pipeline_path)
             } else {
                 cwd.join(pipeline_path)
@@ -745,23 +813,33 @@ impl AcpServer {
         host_bridge.set_session_id(&bridge.session_id);
 
         let compile_started = Instant::now();
-        let chunk = match target_pipeline.as_deref() {
-            Some(name) => harn_vm::compile_source_named(&source, name),
-            None => harn_vm::compile_source(&source),
-        };
-        let chunk = match chunk {
-            Ok(c) => c,
-            Err(e) => {
-                self.send_prompt_error(&session_id, id, &format!("Compilation error: {e}"));
+        let (chunk, cache_hit) = match self.compile_pipeline_cached(
+            &source,
+            source_path.as_deref(),
+            target_pipeline.as_deref(),
+        ) {
+            Ok(value) => value,
+            Err(message) => {
+                // Drop the error's "Compilation error: " prefix added inside
+                // the helper — the caller used to format it identically.
+                let formatted = message
+                    .strip_prefix("Compilation error: ")
+                    .map(|rest| format!("Compilation error: {rest}"))
+                    .unwrap_or(message);
+                self.send_prompt_error(&session_id, id, &formatted);
                 return;
             }
         };
         let compile_ms = compile_started.elapsed().as_millis() as u64;
         bridge.send_log(
             "info",
-            &format!("ACP_BOOT: compile_ms={compile_ms}"),
+            &format!(
+                "ACP_BOOT: compile_ms={compile_ms} cache={}",
+                if cache_hit { "hit" } else { "miss" }
+            ),
             Some(serde_json::json!({
                 "compile_ms": compile_ms,
+                "compile_cache": if cache_hit { "hit" } else { "miss" },
                 "pipeline": source_path
                     .as_ref()
                     .map(|p| p.display().to_string())

--- a/crates/harn-serve/src/adapters/acp/tests.rs
+++ b/crates/harn-serve/src/adapters/acp/tests.rs
@@ -302,6 +302,78 @@ fn acp_prompt_capabilities_follow_configured_model_aliases() {
     );
 }
 
+/// Compile cache: re-issuing a `session/prompt` on the same pipeline file
+/// must serve the bytecode from cache. Touching the file (advancing mtime)
+/// or switching the target pipeline name must invalidate the slot. This
+/// drives the helper directly rather than spinning a full ACP server so the
+/// assertion stays focused on the cache mechanics — the end-to-end path is
+/// exercised by the existing hot-reload test in the `commands` submodule.
+#[test]
+fn compile_pipeline_cached_serves_cached_chunk_until_mtime_advances() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let pipeline_path = dir.path().join("p.harn");
+    let initial = "pipeline main() { println(\"first\") }\n";
+    std::fs::write(&pipeline_path, initial).expect("write initial");
+
+    let mut server = AcpServer::new(AcpServerConfig::new(Some(
+        pipeline_path.to_string_lossy().to_string(),
+    )));
+
+    let (_chunk, hit1) = server
+        .compile_pipeline_cached(initial, Some(pipeline_path.as_path()), None)
+        .expect("first compile");
+    assert!(!hit1, "first compile must miss the cache");
+
+    let (_chunk, hit2) = server
+        .compile_pipeline_cached(initial, Some(pipeline_path.as_path()), None)
+        .expect("second compile");
+    assert!(hit2, "second compile of unchanged source must hit");
+
+    // Switching `target_pipeline` invalidates the slot — a named compile
+    // produces a different chunk than the default-entry compile.
+    let named_source = "@command(name: \"alpha\") pipeline alpha() { println(\"alpha\") }\n\
+                       pipeline main() { println(\"main\") }\n";
+    std::fs::write(&pipeline_path, named_source).expect("write named");
+    // Force mtime advance with a deterministic far-future literal so the
+    // test doesn't read the wall clock (banned by `make lint-test-patterns`).
+    // 2_000_000_000 = 2033-05-18, comfortably after any plausible CI clock
+    // and well past the whole-second rounding some filesystems apply to
+    // fresh writes.
+    let bumped = filetime::FileTime::from_unix_time(2_000_000_000, 0);
+    filetime::set_file_mtime(&pipeline_path, bumped).expect("bump mtime");
+    let (_chunk, hit3) = server
+        .compile_pipeline_cached(named_source, Some(pipeline_path.as_path()), Some("alpha"))
+        .expect("named compile");
+    assert!(
+        !hit3,
+        "different mtime + target_pipeline must miss the previous slot"
+    );
+
+    let (_chunk, hit4) = server
+        .compile_pipeline_cached(named_source, Some(pipeline_path.as_path()), Some("alpha"))
+        .expect("named compile second");
+    assert!(hit4, "repeated named compile must hit");
+}
+
+/// Inline-mode prompts (no `source_path`) are not cached — they're one-off
+/// by construction and caching them would just bloat memory.
+#[test]
+fn compile_pipeline_cached_does_not_cache_inline_prompts() {
+    let mut server = AcpServer::new(AcpServerConfig::new(None));
+    let source = "pipeline main() { println(\"inline\") }\n";
+    let (_chunk, hit1) = server
+        .compile_pipeline_cached(source, None, None)
+        .expect("first inline compile");
+    assert!(!hit1);
+    let (_chunk, hit2) = server
+        .compile_pipeline_cached(source, None, None)
+        .expect("second inline compile");
+    assert!(
+        !hit2,
+        "inline-mode compiles must not be cached (per-turn source is dynamic)"
+    );
+}
+
 mod commands;
 mod modes;
 mod sessions;


### PR DESCRIPTION
## Summary

- `AcpServer::handle_session_prompt` re-reads and re-compiles the configured pipeline on every turn. On the auto.harn surface used by Burin that compile costs ~80 ms (parse + type-check + bytecode for the full import tree) — over an interactive session of N turns we pay N × 80 ms for no behavioural reason.
- Cache the compiled `Chunk` on the `AcpServer`, keyed by (`path`, `mtime`, `target_pipeline_name`). Invalidate when the file's mtime advances or the slash router picks a different named pipeline. Inline-mode prompts (no `source_path`) are deliberately not cached.
- The compile-time log line gains a `cache=hit|miss` field so observers can see hit ratios without a separate event.

## Test plan

- [x] `cargo test -p harn-serve` — 153 tests pass, including the existing `acp_reemits_available_commands_on_pipeline_hot_reload` hot-reload test that drives the mtime-bump invalidation end-to-end.
- [x] Two new focused unit tests pin the helper's invariants directly: `compile_pipeline_cached_serves_cached_chunk_until_mtime_advances` and `compile_pipeline_cached_does_not_cache_inline_prompts`.
- [x] `cargo clippy -p harn-serve --lib` clean.
- [x] Release build + a real TUI smoke (`burin --print --new ...` against `auto.harn` × multi-turn) — the first session/prompt logs `cache=miss`, subsequent prompts in the same session log `cache=hit` with `compile_ms=0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)