### PR TITLE
Surface profiling for ACP and bench

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ condensed series summaries instead of full per-patch history.
 
 ### Added
 
+- **Profiling for ACP and benchmark workflows (#1559).** `harn serve acp` now
+  supports `--profile`, `--profile-json`, and `--trace`, with
+  `HARN_PROFILE`, `HARN_PROFILE_JSON`, and `HARN_TRACE` aliases. ACP profile
+  JSON is appended as one NDJSON object per prompt turn. `harn bench` now shares
+  the profile flags, reports p50/p95/stddev wall-time stats, and can write a
+  JSON benchmark report with per-iteration profile rollups.
 - **`std/tui::select_from` picker (#1544).** Added
   `select_from(items, opts?)` to `std/tui` so harness scripts stop
   hand-rolling fzf detection plus numbered-menu fallbacks. The picker

--- a/README.md
+++ b/README.md
@@ -502,6 +502,7 @@ Run Harn as an ACP backend:
 ```bash
 harn serve acp agent.harn
 harn serve acp --api-key "$HARN_ACP_KEY" agent.harn
+HARN_PROFILE_JSON=/tmp/acp.ndjson harn serve acp agent.harn
 ```
 
 Inspect persisted run records:

--- a/crates/harn-cli/src/acp/mod.rs
+++ b/crates/harn-cli/src/acp/mod.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use harn_serve::{AcpRuntimeConfigurator, AcpServerConfig, AuthPolicy};
+use harn_serve::{AcpProfileConfig, AcpRuntimeConfigurator, AcpServerConfig, AuthPolicy};
 use tokio::sync::mpsc;
 
 struct CliAcpRuntimeConfigurator;
@@ -67,9 +67,23 @@ fn ensure_acp_event_log(pipeline: Option<&str>) {
     }
 }
 
-pub(crate) async fn run_acp_server(pipeline: Option<&str>, auth_policy: AuthPolicy) {
+pub(crate) async fn run_acp_server(
+    pipeline: Option<&str>,
+    auth_policy: AuthPolicy,
+    trace: bool,
+    profile: AcpProfileConfig,
+) {
     ensure_acp_event_log(pipeline);
-    harn_serve::run_acp_server(server_config(pipeline.map(str::to_string), auth_policy)).await;
+    if trace {
+        harn_vm::llm::enable_tracing();
+    }
+    harn_serve::run_acp_server(
+        server_config(pipeline.map(str::to_string), auth_policy).with_profile(profile),
+    )
+    .await;
+    if trace {
+        eprint!("{}", crate::commands::run::render_trace_summary());
+    }
 }
 
 pub(crate) async fn run_acp_channel_server(

--- a/crates/harn-cli/src/cli/bench.rs
+++ b/crates/harn-cli/src/cli/bench.rs
@@ -1,5 +1,7 @@
 use clap::Args;
 
+use super::ProfileArgs;
+
 #[derive(Debug, Args)]
 pub(crate) struct BenchArgs {
     /// Path to the .harn file to benchmark.
@@ -7,4 +9,6 @@ pub(crate) struct BenchArgs {
     /// Number of benchmark iterations to run.
     #[arg(short = 'n', long, default_value_t = 10)]
     pub iterations: usize,
+    #[command(flatten)]
+    pub profile: ProfileArgs,
 }

--- a/crates/harn-cli/src/cli/mod.rs
+++ b/crates/harn-cli/src/cli/mod.rs
@@ -31,6 +31,7 @@ mod package;
 mod persona;
 mod playground;
 mod portal;
+mod profile;
 mod provider;
 mod quickstart;
 mod run;
@@ -116,6 +117,7 @@ pub(crate) use persona::{
 };
 pub(crate) use playground::PlaygroundArgs;
 pub(crate) use portal::PortalArgs;
+pub(crate) use profile::ProfileArgs;
 pub(crate) use provider::{ModelInfoArgs, ProviderCatalogArgs, ProviderReadyArgs};
 pub(crate) use quickstart::QuickstartArgs;
 pub(crate) use run::RunArgs;

--- a/crates/harn-cli/src/cli/profile.rs
+++ b/crates/harn-cli/src/cli/profile.rs
@@ -1,0 +1,18 @@
+use std::path::PathBuf;
+
+use clap::Args;
+
+#[derive(Clone, Debug, Default, Args)]
+pub(crate) struct ProfileArgs {
+    /// Print a categorical timing breakdown (LLM vs tools vs steps vs VM/residual).
+    #[arg(
+        long = "profile",
+        env = "HARN_PROFILE",
+        action = clap::ArgAction::SetTrue,
+        value_parser = clap::builder::BoolishValueParser::new()
+    )]
+    pub text: bool,
+    /// Write the profile rollup as JSON to the given path. Implies `--profile`.
+    #[arg(long = "profile-json", env = "HARN_PROFILE_JSON", value_name = "PATH")]
+    pub json_path: Option<PathBuf>,
+}

--- a/crates/harn-cli/src/cli/run.rs
+++ b/crates/harn-cli/src/cli/run.rs
@@ -1,21 +1,22 @@
 use clap::Args;
 
+use super::ProfileArgs;
+
 #[derive(Debug, Args)]
 pub(crate) struct RunArgs {
     /// Print the LLM trace summary after execution.
-    #[arg(long)]
+    #[arg(
+        long,
+        env = "HARN_TRACE",
+        action = clap::ArgAction::SetTrue,
+        value_parser = clap::builder::BoolishValueParser::new()
+    )]
     pub trace: bool,
-    /// Print a categorical timing breakdown after execution (LLM vs tools
-    /// vs steps vs VM/residual). Implies tracing instrumentation; OK to
-    /// combine with `--trace`.
-    #[arg(long)]
-    pub profile: bool,
+    #[command(flatten)]
+    pub profile: ProfileArgs,
     /// Print static LLM token/cost estimates and do not execute the script.
     #[arg(long = "explain-cost")]
     pub explain_cost: bool,
-    /// Write the profile rollup as JSON to the given path. Implies `--profile`.
-    #[arg(long = "profile-json", value_name = "PATH")]
-    pub profile_json: Option<String>,
     /// Deny specific builtins as a comma-separated list.
     #[arg(long, conflicts_with = "allow")]
     pub deny: Option<String>,

--- a/crates/harn-cli/src/cli/serve.rs
+++ b/crates/harn-cli/src/cli/serve.rs
@@ -3,6 +3,8 @@ use std::path::PathBuf;
 
 use clap::{Args, Subcommand, ValueEnum};
 
+use super::ProfileArgs;
+
 #[derive(Debug, Args)]
 pub(crate) struct ServeArgs {
     #[command(subcommand)]
@@ -30,6 +32,16 @@ pub(crate) struct ServeAcpArgs {
     /// Shared secret for HMAC authentication through the ACP authenticate method.
     #[arg(long = "hmac-secret", env = "HARN_SERVE_HMAC_SECRET")]
     pub hmac_secret: Option<String>,
+    /// Enable LLM trace summaries on shutdown.
+    #[arg(
+        long = "trace",
+        env = "HARN_TRACE",
+        action = clap::ArgAction::SetTrue,
+        value_parser = clap::builder::BoolishValueParser::new()
+    )]
+    pub trace: bool,
+    #[command(flatten)]
+    pub profile: ProfileArgs,
     /// Path to the .harn file to serve.
     pub file: String,
 }

--- a/crates/harn-cli/src/cli/tests.rs
+++ b/crates/harn-cli/src/cli/tests.rs
@@ -364,6 +364,10 @@ fn test_parses_serve_acp() {
         "alpha,beta",
         "--hmac-secret",
         "shared",
+        "--trace",
+        "--profile",
+        "--profile-json",
+        "profiles/acp.ndjson",
         "agent.harn",
     ]);
 
@@ -375,6 +379,12 @@ fn test_parses_serve_acp() {
     };
     assert_eq!(serve.api_key, vec!["alpha".to_string(), "beta".to_string()]);
     assert_eq!(serve.hmac_secret.as_deref(), Some("shared"));
+    assert!(serve.trace);
+    assert!(serve.profile.text);
+    assert_eq!(
+        serve.profile.json_path.as_deref(),
+        Some(std::path::Path::new("profiles/acp.ndjson"))
+    );
     assert_eq!(serve.file, "agent.harn");
 }
 
@@ -1735,13 +1745,90 @@ fn test_parses_viz_args() {
 
 #[test]
 fn test_parses_bench_args() {
-    let cli = Cli::parse_from(["harn", "bench", "main.harn", "--iterations", "25"]);
+    let cli = Cli::parse_from([
+        "harn",
+        "bench",
+        "main.harn",
+        "--iterations",
+        "25",
+        "--profile",
+        "--profile-json",
+        "bench.json",
+    ]);
 
     let Command::Bench(args) = cli.command.unwrap() else {
         panic!("expected bench command");
     };
     assert_eq!(args.file, "main.harn");
     assert_eq!(args.iterations, 25);
+    assert!(args.profile.text);
+    assert_eq!(
+        args.profile.json_path.as_deref(),
+        Some(std::path::Path::new("bench.json"))
+    );
+}
+
+#[test]
+fn test_profile_env_aliases_apply_to_supported_commands() {
+    let _env = crate::tests::common::env_lock::lock_env().blocking_lock();
+    struct EnvRestore {
+        saved: [(&'static str, Option<String>); 3],
+    }
+    impl Drop for EnvRestore {
+        fn drop(&mut self) {
+            for (name, value) in self.saved.iter() {
+                match value {
+                    Some(value) => std::env::set_var(name, value),
+                    None => std::env::remove_var(name),
+                }
+            }
+        }
+    }
+    let _restore = EnvRestore {
+        saved: [
+            ("HARN_PROFILE", std::env::var("HARN_PROFILE").ok()),
+            ("HARN_PROFILE_JSON", std::env::var("HARN_PROFILE_JSON").ok()),
+            ("HARN_TRACE", std::env::var("HARN_TRACE").ok()),
+        ],
+    };
+    std::env::set_var("HARN_PROFILE", "1");
+    std::env::set_var("HARN_PROFILE_JSON", "env-profile.json");
+    std::env::set_var("HARN_TRACE", "1");
+
+    let run = Cli::parse_from(["harn", "run", "main.harn"]);
+    let Command::Run(run_args) = run.command.unwrap() else {
+        panic!("expected run command");
+    };
+    assert!(run_args.trace);
+    assert!(run_args.profile.text);
+    assert_eq!(
+        run_args.profile.json_path.as_deref(),
+        Some(std::path::Path::new("env-profile.json"))
+    );
+
+    let bench = Cli::parse_from(["harn", "bench", "main.harn"]);
+    let Command::Bench(bench_args) = bench.command.unwrap() else {
+        panic!("expected bench command");
+    };
+    assert!(bench_args.profile.text);
+    assert_eq!(
+        bench_args.profile.json_path.as_deref(),
+        Some(std::path::Path::new("env-profile.json"))
+    );
+
+    let serve = Cli::parse_from(["harn", "serve", "acp", "agent.harn"]);
+    let Command::Serve(serve_args) = serve.command.unwrap() else {
+        panic!("expected serve command");
+    };
+    let crate::cli::ServeCommand::Acp(acp_args) = serve_args.command else {
+        panic!("expected serve acp");
+    };
+    assert!(acp_args.trace);
+    assert!(acp_args.profile.text);
+    assert_eq!(
+        acp_args.profile.json_path.as_deref(),
+        Some(std::path::Path::new("env-profile.json"))
+    );
 }
 
 #[test]

--- a/crates/harn-cli/src/commands/bench.rs
+++ b/crates/harn-cli/src/commands/bench.rs
@@ -1,24 +1,41 @@
+use std::fs;
 use std::path::Path;
 use std::process;
 use std::time::Instant;
 
 use harn_parser::DiagnosticSeverity;
+use serde::Serialize;
 
-use crate::commands::run::connect_mcp_servers;
+use crate::commands::run::{connect_mcp_servers, RunProfileOptions};
 use crate::package;
 use crate::parse_source_file;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Serialize)]
 struct BenchRun {
+    iteration: usize,
     wall_time_ms: f64,
     llm_time_ms: i64,
     input_tokens: i64,
     output_tokens: i64,
     call_count: i64,
     total_cost_usd: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    profile: Option<harn_vm::profile::RunProfile>,
 }
 
-pub(crate) async fn run_bench(path: &str, iterations: usize) {
+#[derive(Debug, Clone, Copy, Serialize)]
+struct BenchStats {
+    iterations: usize,
+    min_ms: f64,
+    mean_ms: f64,
+    p50_ms: f64,
+    p95_ms: f64,
+    max_ms: f64,
+    stddev_ms: f64,
+    total_ms: f64,
+}
+
+pub(crate) async fn run_bench(path: &str, iterations: usize, profile: RunProfileOptions) {
     if iterations == 0 {
         eprintln!("error: `harn bench` requires at least one iteration");
         process::exit(1);
@@ -76,9 +93,13 @@ pub(crate) async fn run_bench(path: &str, iterations: usize) {
     package::install_runtime_extensions(&extensions);
 
     let mut runs = Vec::with_capacity(iterations);
+    let mut profile_span_groups = Vec::new();
     for iteration in 0..iterations {
         harn_vm::reset_thread_local_state();
         harn_vm::llm::enable_tracing();
+        if profile.is_enabled() {
+            harn_vm::tracing::set_tracing_enabled(true);
+        }
 
         let mut vm = harn_vm::Vm::new();
         harn_vm::register_vm_stdlib(&mut vm);
@@ -117,13 +138,23 @@ pub(crate) async fn run_bench(path: &str, iterations: usize) {
             Ok(_) => {
                 let (input_tokens, output_tokens, llm_time_ms, call_count) =
                     harn_vm::llm::peek_trace_summary();
+                let run_profile = if profile.is_enabled() {
+                    let spans = harn_vm::tracing::take_spans();
+                    let rollup = harn_vm::profile::build(&spans);
+                    profile_span_groups.push(spans);
+                    Some(rollup)
+                } else {
+                    None
+                };
                 runs.push(BenchRun {
+                    iteration: iteration + 1,
                     wall_time_ms,
                     llm_time_ms,
                     input_tokens,
                     output_tokens,
                     call_count,
                     total_cost_usd: harn_vm::llm::peek_total_cost(),
+                    profile: run_profile,
                 });
             }
             Err(error) => {
@@ -134,42 +165,57 @@ pub(crate) async fn run_bench(path: &str, iterations: usize) {
         }
     }
 
-    print!("{}", render_bench_report(path, &runs));
+    let aggregate_profile = if profile.is_enabled() {
+        Some(harn_vm::profile::build_aggregate(&profile_span_groups))
+    } else {
+        None
+    };
+    print!(
+        "{}",
+        render_bench_report(path, &runs, profile.text, aggregate_profile.as_ref())
+    );
+    if let Some(json_path) = profile.json_path.as_ref() {
+        if let Err(error) =
+            write_bench_profile_json(json_path, path, &runs, aggregate_profile.as_ref())
+        {
+            eprintln!("warning: failed to write benchmark profile: {error}");
+        }
+    }
 }
 
-fn render_bench_report(path: &str, runs: &[BenchRun]) -> String {
-    let iterations = runs.len() as f64;
-    let total_wall = runs.iter().map(|run| run.wall_time_ms).sum::<f64>();
+fn render_bench_report(
+    path: &str,
+    runs: &[BenchRun],
+    include_profile: bool,
+    aggregate_profile: Option<&harn_vm::profile::RunProfile>,
+) -> String {
+    let stats = bench_stats(runs);
     let total_llm = runs.iter().map(|run| run.llm_time_ms).sum::<i64>();
     let total_input = runs.iter().map(|run| run.input_tokens).sum::<i64>();
     let total_output = runs.iter().map(|run| run.output_tokens).sum::<i64>();
     let total_calls = runs.iter().map(|run| run.call_count).sum::<i64>();
     let total_cost = runs.iter().map(|run| run.total_cost_usd).sum::<f64>();
-    let min_wall = runs
-        .iter()
-        .map(|run| run.wall_time_ms)
-        .fold(f64::INFINITY, f64::min);
-    let max_wall = runs
-        .iter()
-        .map(|run| run.wall_time_ms)
-        .fold(f64::NEG_INFINITY, f64::max);
+    let iterations = stats.iterations as f64;
 
-    format!(
+    let mut report = format!(
         "\
 Benchmark: {path}
 Iterations: {}
-Wall time: min {:.2} ms | avg {:.2} ms | max {:.2} ms | total {:.2} ms
+Wall time: min {:.2} ms | mean {:.2} ms | p50 {:.2} ms | p95 {:.2} ms | max {:.2} ms | stddev {:.2} ms | total {:.2} ms
 LLM time: total {} ms | avg {:.2} ms/run
 LLM calls: total {} | avg {:.2}/run
 Input tokens: total {} | avg {:.2}/run
 Output tokens: total {} | avg {:.2}/run
 Cost: total ${:.4} | avg ${:.4}/run
 ",
-        runs.len(),
-        min_wall,
-        total_wall / iterations,
-        max_wall,
-        total_wall,
+        stats.iterations,
+        stats.min_ms,
+        stats.mean_ms,
+        stats.p50_ms,
+        stats.p95_ms,
+        stats.max_ms,
+        stats.stddev_ms,
+        stats.total_ms,
         total_llm,
         total_llm as f64 / iterations,
         total_calls,
@@ -180,12 +226,119 @@ Cost: total ${:.4} | avg ${:.4}/run
         total_output as f64 / iterations,
         total_cost,
         total_cost / iterations,
-    )
+    );
+    if include_profile {
+        if let Some(profile) = aggregate_profile {
+            report.push_str(&harn_vm::profile::render(profile));
+        }
+    }
+    report
+}
+
+fn bench_stats(runs: &[BenchRun]) -> BenchStats {
+    let mut sorted = runs.iter().map(|run| run.wall_time_ms).collect::<Vec<_>>();
+    sorted.sort_by(f64::total_cmp);
+    let total_ms = sorted.iter().sum::<f64>();
+    let iterations = sorted.len();
+    let mean_ms = total_ms / iterations as f64;
+    let variance = sorted
+        .iter()
+        .map(|ms| {
+            let delta = ms - mean_ms;
+            delta * delta
+        })
+        .sum::<f64>()
+        / iterations as f64;
+    BenchStats {
+        iterations,
+        min_ms: sorted[0],
+        mean_ms,
+        p50_ms: percentile_sorted(&sorted, 0.50),
+        p95_ms: percentile_sorted(&sorted, 0.95),
+        max_ms: sorted[iterations - 1],
+        stddev_ms: variance.sqrt(),
+        total_ms,
+    }
+}
+
+fn percentile_sorted(sorted: &[f64], percentile: f64) -> f64 {
+    if sorted.len() == 1 {
+        return sorted[0];
+    }
+    let rank = percentile.clamp(0.0, 1.0) * (sorted.len() - 1) as f64;
+    let lower = rank.floor() as usize;
+    let upper = rank.ceil() as usize;
+    if lower == upper {
+        sorted[lower]
+    } else {
+        let weight = rank - lower as f64;
+        sorted[lower] * (1.0 - weight) + sorted[upper] * weight
+    }
+}
+
+#[derive(Serialize)]
+struct BenchJsonReport<'a> {
+    path: &'a str,
+    iterations: &'a [BenchRun],
+    min_ms: f64,
+    mean_ms: f64,
+    p50_ms: f64,
+    p95_ms: f64,
+    max_ms: f64,
+    stddev_ms: f64,
+    total_ms: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    rollup: Option<&'a harn_vm::profile::RunProfile>,
+}
+
+fn write_bench_profile_json(
+    json_path: &Path,
+    bench_path: &str,
+    runs: &[BenchRun],
+    aggregate_profile: Option<&harn_vm::profile::RunProfile>,
+) -> Result<(), String> {
+    if let Some(parent) = json_path.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent)
+                .map_err(|error| format!("create {}: {error}", parent.display()))?;
+        }
+    }
+    let stats = bench_stats(runs);
+    let report = BenchJsonReport {
+        path: bench_path,
+        iterations: runs,
+        min_ms: stats.min_ms,
+        mean_ms: stats.mean_ms,
+        p50_ms: stats.p50_ms,
+        p95_ms: stats.p95_ms,
+        max_ms: stats.max_ms,
+        stddev_ms: stats.stddev_ms,
+        total_ms: stats.total_ms,
+        rollup: aggregate_profile,
+    };
+    let json = serde_json::to_string_pretty(&report)
+        .map_err(|error| format!("serialize benchmark profile: {error}"))?;
+    fs::write(json_path, json).map_err(|error| format!("write {}: {error}", json_path.display()))
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{render_bench_report, BenchRun};
+    use super::{
+        bench_stats, percentile_sorted, render_bench_report, write_bench_profile_json, BenchRun,
+    };
+
+    fn bench_run(iteration: usize, wall_time_ms: f64) -> BenchRun {
+        BenchRun {
+            iteration,
+            wall_time_ms,
+            llm_time_ms: 0,
+            input_tokens: 0,
+            output_tokens: 0,
+            call_count: 0,
+            total_cost_usd: 0.0,
+            profile: None,
+        }
+    }
 
     #[test]
     fn bench_report_summarizes_runs() {
@@ -193,28 +346,73 @@ mod tests {
             "examples/demo.harn",
             &[
                 BenchRun {
-                    wall_time_ms: 10.0,
                     llm_time_ms: 4,
                     input_tokens: 100,
                     output_tokens: 40,
                     call_count: 1,
                     total_cost_usd: 0.002,
+                    ..bench_run(1, 10.0)
                 },
                 BenchRun {
-                    wall_time_ms: 14.0,
                     llm_time_ms: 6,
                     input_tokens: 120,
                     output_tokens: 50,
                     call_count: 2,
                     total_cost_usd: 0.003,
+                    ..bench_run(2, 14.0)
                 },
             ],
+            false,
+            None,
         );
 
         assert!(report.contains("Benchmark: examples/demo.harn"));
         assert!(report.contains("Iterations: 2"));
-        assert!(report.contains("Wall time: min 10.00 ms | avg 12.00 ms | max 14.00 ms"));
+        assert!(report.contains("mean 12.00 ms"));
+        assert!(report.contains("p50 12.00 ms"));
+        assert!(report.contains("p95 13.80 ms"));
+        assert!(report.contains("stddev 2.00 ms"));
         assert!(report.contains("LLM calls: total 3 | avg 1.50/run"));
         assert!(report.contains("Cost: total $0.0050 | avg $0.0025/run"));
+    }
+
+    #[test]
+    fn bench_stats_reports_percentiles_and_stddev() {
+        let runs = [10.0, 20.0, 30.0, 40.0, 50.0]
+            .into_iter()
+            .enumerate()
+            .map(|(index, wall_time_ms)| bench_run(index + 1, wall_time_ms))
+            .collect::<Vec<_>>();
+
+        let stats = bench_stats(&runs);
+
+        assert_eq!(stats.mean_ms, 30.0);
+        assert_eq!(stats.p50_ms, 30.0);
+        assert_eq!(stats.p95_ms, 48.0);
+        assert_eq!(percentile_sorted(&[10.0, 20.0], 0.50), 15.0);
+        assert!((stats.stddev_ms - 14.1421356237).abs() < 0.0001);
+    }
+
+    #[test]
+    fn bench_profile_json_includes_iterations_stats_and_rollup() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("bench.json");
+        let runs = vec![bench_run(1, 10.0), bench_run(2, 14.0)];
+        let rollup = harn_vm::profile::build(&[]);
+
+        write_bench_profile_json(&path, "examples/demo.harn", &runs, Some(&rollup))
+            .expect("write benchmark profile json");
+
+        let value: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(path).expect("read benchmark json"))
+                .expect("benchmark json");
+        assert_eq!(value["path"], "examples/demo.harn");
+        assert_eq!(value["iterations"].as_array().unwrap().len(), 2);
+        assert_eq!(value["iterations"][0]["iteration"], 1);
+        assert_eq!(value["mean_ms"], 12.0);
+        assert_eq!(value["p50_ms"], 12.0);
+        assert_eq!(value["p95_ms"], 13.8);
+        assert_eq!(value["stddev_ms"], 2.0);
+        assert!(value["rollup"]["by_kind"].is_array());
     }
 }

--- a/crates/harn-cli/src/commands/run.rs
+++ b/crates/harn-cli/src/commands/run.rs
@@ -1020,7 +1020,7 @@ pub(crate) async fn connect_mcp_servers(
     }
 }
 
-fn render_trace_summary() -> String {
+pub(crate) fn render_trace_summary() -> String {
     use std::fmt::Write;
     let entries = harn_vm::llm::take_trace();
     if entries.is_empty() {

--- a/crates/harn-cli/src/commands/serve.rs
+++ b/crates/harn-cli/src/commands/serve.rs
@@ -30,6 +30,11 @@ pub(crate) async fn run_acp_server(args: &ServeAcpArgs) -> Result<(), String> {
     crate::acp::run_acp_server(
         Some(&args.file),
         build_auth_policy(&args.api_key, args.hmac_secret.as_ref()),
+        args.trace,
+        harn_serve::AcpProfileConfig {
+            text: args.profile.text,
+            json_path: args.profile.json_path.clone(),
+        },
     )
     .await;
     Ok(())

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -151,10 +151,7 @@ async fn async_main() {
                 receipt_out: args.receipt_out.as_ref().map(PathBuf::from),
                 agent_id: args.attest_agent.clone(),
             });
-            let profile_options = commands::run::RunProfileOptions {
-                text: args.profile,
-                json_path: args.profile_json.as_ref().map(PathBuf::from),
-            };
+            let profile_options = run_profile_options(&args.profile);
 
             match (args.eval.as_deref(), args.file.as_deref()) {
                 (Some(code), None) => {
@@ -754,7 +751,14 @@ async fn async_main() {
             )
         }
         Command::Repl => commands::repl::run_repl().await,
-        Command::Bench(args) => commands::bench::run_bench(&args.file, args.iterations).await,
+        Command::Bench(args) => {
+            commands::bench::run_bench(
+                &args.file,
+                args.iterations,
+                run_profile_options(&args.profile),
+            )
+            .await
+        }
         Command::TestBench(args) => commands::test_bench::run(args.command).await,
         Command::Viz(args) => commands::viz::run_viz(&args.file, args.output.as_deref()),
         Command::Install(args) => package::install_packages(
@@ -1034,6 +1038,13 @@ async fn async_main() {
         Command::DumpProtocolArtifacts(args) => {
             commands::dump_protocol_artifacts::run(&args.output_dir, args.check);
         }
+    }
+}
+
+fn run_profile_options(args: &cli::ProfileArgs) -> commands::run::RunProfileOptions {
+    commands::run::RunProfileOptions {
+        text: args.text,
+        json_path: args.json_path.clone(),
     }
 }
 

--- a/crates/harn-serve/src/adapters/acp/mod.rs
+++ b/crates/harn-serve/src/adapters/acp/mod.rs
@@ -41,6 +41,7 @@ use sessions::{
 pub use transport::{run_acp_channel_server, run_acp_server};
 
 use std::collections::{BTreeMap, HashMap};
+use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
@@ -66,6 +67,37 @@ use io::send_json_response;
 
 const ACP_AUTH_REQUIRED_CODE: i64 = -32000;
 
+fn append_profile_json_line(
+    path: &std::path::Path,
+    session_id: &str,
+    turn: u64,
+    rollup: &harn_vm::profile::RunProfile,
+) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent).map_err(|error| {
+                format!(
+                    "failed to create profile directory {}: {error}",
+                    parent.display()
+                )
+            })?;
+        }
+    }
+    let line = serde_json::to_string(&serde_json::json!({
+        "turn": turn,
+        "session_id": session_id,
+        "rollup": rollup,
+    }))
+    .map_err(|error| format!("failed to serialize profile: {error}"))?;
+    let mut file = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .map_err(|error| format!("failed to open {}: {error}", path.display()))?;
+    writeln!(file, "{line}")
+        .map_err(|error| format!("failed to append {}: {error}", path.display()))
+}
+
 #[async_trait(?Send)]
 pub trait AcpRuntimeConfigurator: Send + Sync {
     async fn configure(
@@ -83,6 +115,18 @@ pub struct NoopAcpRuntimeConfigurator;
 #[async_trait(?Send)]
 impl AcpRuntimeConfigurator for NoopAcpRuntimeConfigurator {}
 
+#[derive(Clone, Default)]
+pub struct AcpProfileConfig {
+    pub text: bool,
+    pub json_path: Option<PathBuf>,
+}
+
+impl AcpProfileConfig {
+    pub fn is_enabled(&self) -> bool {
+        self.text || self.json_path.is_some()
+    }
+}
+
 #[derive(Clone)]
 pub struct AcpServerConfig {
     pub pipeline: Option<String>,
@@ -90,6 +134,7 @@ pub struct AcpServerConfig {
     pub runtime_configurator: Arc<dyn AcpRuntimeConfigurator>,
     pub llm_config_overrides: Option<harn_vm::llm_config::ProvidersConfig>,
     pub llm_capability_overrides: Option<harn_vm::llm::capabilities::CapabilitiesFile>,
+    pub profile: AcpProfileConfig,
 }
 
 impl AcpServerConfig {
@@ -100,6 +145,7 @@ impl AcpServerConfig {
             runtime_configurator: Arc::new(NoopAcpRuntimeConfigurator),
             llm_config_overrides: None,
             llm_capability_overrides: None,
+            profile: AcpProfileConfig::default(),
         }
     }
 
@@ -127,6 +173,11 @@ impl AcpServerConfig {
     ) -> Self {
         self.llm_config_overrides = llm_config;
         self.llm_capability_overrides = llm_capabilities;
+        self
+    }
+
+    pub fn with_profile(mut self, profile: AcpProfileConfig) -> Self {
+        self.profile = profile;
         self
     }
 }
@@ -170,6 +221,8 @@ pub struct AcpServer {
     /// Compiled-pipeline cache. One slot — the ACP server runs a single
     /// pipeline file for its lifetime, so we only ever cache one chunk.
     compile_cache: Option<CompileCacheEntry>,
+    /// Per-turn profile emission settings.
+    profile: AcpProfileConfig,
 }
 
 impl AcpServer {
@@ -198,6 +251,7 @@ impl AcpServer {
             session_cancellations: Arc::new(std::sync::Mutex::new(HashMap::new())),
             output,
             compile_cache: None,
+            profile: config.profile,
         }
     }
 
@@ -462,6 +516,7 @@ impl AcpServer {
                 info,
                 advertised_commands: Vec::new(),
                 current_mode_id: modes::DEFAULT_MODE_ID.to_string(),
+                profile_turn: 0,
             },
         );
         harn_vm::agent_sessions::open_or_create(Some(session_id));
@@ -555,6 +610,35 @@ impl AcpServer {
                 "update": update,
             }),
         );
+    }
+
+    fn begin_profile_turn(&mut self, session_id: &str) -> u64 {
+        if !self.profile.is_enabled() {
+            return 0;
+        }
+        let Some(session) = self.sessions.get_mut(session_id) else {
+            return 0;
+        };
+        session.profile_turn += 1;
+        harn_vm::tracing::set_tracing_enabled(true);
+        session.profile_turn
+    }
+
+    fn finish_profile_turn(&self, session_id: &str, turn: u64) {
+        if turn == 0 || !self.profile.is_enabled() {
+            return;
+        }
+        let spans = harn_vm::tracing::take_spans();
+        let rollup = harn_vm::profile::build(&spans);
+        if self.profile.text {
+            eprintln!("[harn] ACP profile session={session_id} turn={turn}");
+            eprint!("{}", harn_vm::profile::render(&rollup));
+        }
+        if let Some(path) = self.profile.json_path.as_ref() {
+            if let Err(error) = append_profile_json_line(path, session_id, turn, &rollup) {
+                eprintln!("warning: failed to write ACP profile: {error}");
+            }
+        }
     }
 
     fn handle_session_fork(&mut self, id: &serde_json::Value, params: &serde_json::Value) {
@@ -651,6 +735,7 @@ impl AcpServer {
                 info: info.clone(),
                 advertised_commands: Vec::new(),
                 current_mode_id: parent_mode_id.clone(),
+                profile_turn: 0,
             },
         );
         self.emit_session_info_update(&new_session_id, &info);
@@ -850,6 +935,7 @@ impl AcpServer {
             session.host_bridge = Some(host_bridge.clone());
         }
 
+        let profile_turn = self.begin_profile_turn(&session_id);
         let id_owned = id.clone();
         let send_output = self.output.clone();
         let _mode_guard = modes::ModePolicyGuard::enter(&current_mode_id);
@@ -868,6 +954,7 @@ impl AcpServer {
             self.runtime_configurator.clone(),
         )
         .await;
+        self.finish_profile_turn(&session_id, profile_turn);
         drop(_mode_guard);
         if let Some(session) = self.sessions.get_mut(&session_id) {
             session.host_bridge = None;

--- a/crates/harn-serve/src/adapters/acp/sessions.rs
+++ b/crates/harn-serve/src/adapters/acp/sessions.rs
@@ -63,6 +63,8 @@ pub(super) struct Session {
     /// Active session mode id (one of [`modes::MODE_CATALOG`]). Drives
     /// the capability ceiling pushed for the next `session/prompt`.
     pub(super) current_mode_id: String,
+    /// Prompt executions emitted to profile output for this ACP session.
+    pub(super) profile_turn: u64,
 }
 
 pub(super) fn mark_cancelled_session(

--- a/crates/harn-serve/src/adapters/acp/tests/sessions.rs
+++ b/crates/harn-serve/src/adapters/acp/tests/sessions.rs
@@ -167,6 +167,71 @@ async fn acp_server_handles_session_flow_and_prompt_updates() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn acp_profile_json_appends_one_line_per_prompt_turn() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let profile_path = dir.path().join("profile.ndjson");
+            let config = AcpServerConfig::new(None).with_profile(AcpProfileConfig {
+                text: false,
+                json_path: Some(profile_path.clone()),
+            });
+            let (request_tx, mut response_rx, server, session_id) =
+                start_acp_channel_session_with_config(config, serde_json::json!(dir.path())).await;
+
+            for id in 2..=3 {
+                request_tx
+                    .send(serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": id,
+                        "method": "session/prompt",
+                        "params": {
+                            "sessionId": session_id.clone(),
+                            "prompt": [{"type": "text", "text": "println(\"profiled\")"}],
+                        },
+                    }))
+                    .expect("send session/prompt");
+
+                let mut saw_completed = false;
+                for _ in 0..16 {
+                    let message = recv_json(&mut response_rx).await;
+                    if message["method"] == "host/capabilities" {
+                        request_tx
+                            .send(serde_json::json!({
+                                "jsonrpc": "2.0",
+                                "id": message["id"].clone(),
+                                "result": {},
+                            }))
+                            .expect("send host capabilities response");
+                    }
+                    if message["id"] == id {
+                        assert_eq!(message["result"]["stopReason"], "end_turn");
+                        saw_completed = true;
+                        break;
+                    }
+                }
+                assert!(saw_completed, "prompt should finish successfully");
+            }
+
+            let lines = std::fs::read_to_string(&profile_path).expect("read profile ndjson");
+            let entries = lines
+                .lines()
+                .map(|line| serde_json::from_str::<serde_json::Value>(line).expect("json line"))
+                .collect::<Vec<_>>();
+            assert_eq!(entries.len(), 2, "profile output:\n{lines}");
+            assert_eq!(entries[0]["session_id"], session_id);
+            assert_eq!(entries[0]["turn"], 1);
+            assert_eq!(entries[1]["turn"], 2);
+            assert!(entries[0]["rollup"]["by_kind"].is_array());
+
+            drop(request_tx);
+            server.await.expect("ACP channel server task");
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn acp_session_prompt_exposes_multimodal_prompt_messages() {
     let local = tokio::task::LocalSet::new();
     local

--- a/crates/harn-serve/src/adapters/acp/transport.rs
+++ b/crates/harn-serve/src/adapters/acp/transport.rs
@@ -6,6 +6,7 @@ pub async fn run_acp_channel_server(
     mut request_rx: mpsc::UnboundedReceiver<serde_json::Value>,
     response_tx: mpsc::UnboundedSender<String>,
 ) {
+    let profile_enabled = config.profile.is_enabled();
     let local = tokio::task::LocalSet::new();
     local
         .run_until(async move {
@@ -44,10 +45,14 @@ pub async fn run_acp_channel_server(
             }
         })
         .await;
+    if profile_enabled {
+        harn_vm::tracing::set_tracing_enabled(false);
+    }
 }
 
 /// Start the ACP server. Reads JSON-RPC from stdin, writes to stdout.
 pub async fn run_acp_server(config: AcpServerConfig) {
+    let profile_enabled = config.profile.is_enabled();
     let local = tokio::task::LocalSet::new();
 
     local
@@ -107,4 +112,7 @@ pub async fn run_acp_server(config: AcpServerConfig) {
             }
         })
         .await;
+    if profile_enabled {
+        harn_vm::tracing::set_tracing_enabled(false);
+    }
 }

--- a/crates/harn-serve/src/lib.rs
+++ b/crates/harn-serve/src/lib.rs
@@ -16,8 +16,8 @@ pub mod tls;
 pub use adapter::{AdapterDescriptor, TransportAdapter};
 pub use adapters::a2a::{A2aHttpServeOptions, A2aServer, A2aServerConfig, A2A_PROTOCOL_VERSION};
 pub use adapters::acp::{
-    run_acp_channel_server, run_acp_server, AcpRuntimeConfigurator, AcpServer, AcpServerConfig,
-    NoopAcpRuntimeConfigurator,
+    run_acp_channel_server, run_acp_server, AcpProfileConfig, AcpRuntimeConfigurator, AcpServer,
+    AcpServerConfig, NoopAcpRuntimeConfigurator,
 };
 pub use adapters::mcp::{
     McpHttpServeOptions, McpServer, McpServerConfig, McpStdioServer, MCP_PROTOCOL_VERSION,

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -353,6 +353,8 @@ pub fn reset_thread_local_state() {
     triggers::clear_dispatcher_state();
     triggers::clear_trigger_registry();
     events::reset_event_sinks();
+    tracing::set_tracing_enabled(false);
+    tracing::reset_tracing();
     agent_events::reset_all_sinks();
     agent_sessions::reset_session_store();
     mcp_registry::reset();

--- a/crates/harn-vm/src/profile.rs
+++ b/crates/harn-vm/src/profile.rs
@@ -105,6 +105,27 @@ pub fn build(spans: &[Span]) -> RunProfile {
     }
 }
 
+/// Build one aggregate profile from independent span snapshots.
+///
+/// Each input snapshot can reuse span ids starting at 1. The helper remaps ids
+/// before folding so parent/child relationships do not collide across runs.
+pub fn build_aggregate(span_groups: &[Vec<Span>]) -> RunProfile {
+    let mut merged = Vec::new();
+    let mut next_offset = 0u64;
+    for group in span_groups {
+        let offset = next_offset;
+        let max_id = group.iter().map(|span| span.span_id).max().unwrap_or(0);
+        for span in group {
+            let mut remapped = span.clone();
+            remapped.span_id += offset;
+            remapped.parent_id = remapped.parent_id.map(|id| id + offset);
+            merged.push(remapped);
+        }
+        next_offset += max_id + 1;
+    }
+    build(&merged)
+}
+
 fn is_pipeline_root(spans: &[Span], id: u64) -> bool {
     spans
         .iter()
@@ -461,5 +482,28 @@ mod tests {
         let rendered = render(&RunProfile::default());
         assert!(rendered.contains("Run profile"));
         assert!(rendered.contains("vm/residual"));
+    }
+
+    #[test]
+    fn aggregate_remaps_duplicate_span_ids_across_runs() {
+        let first = vec![
+            span(1, None, SpanKind::Pipeline, "main", 100),
+            span(2, Some(1), SpanKind::LlmCall, "llm_call", 40),
+        ];
+        let second = vec![
+            span(1, None, SpanKind::Pipeline, "main", 200),
+            span(2, Some(1), SpanKind::ToolCall, "tool", 50),
+        ];
+
+        let profile = build_aggregate(&[first, second]);
+
+        assert_eq!(profile.total_wall_ms, 300);
+        assert_eq!(profile.by_kind.len(), 2);
+        assert!(profile.by_kind.iter().any(|bucket| {
+            bucket.kind == "llm_call" && bucket.total_ms == 40 && bucket.count == 1
+        }));
+        assert!(profile.by_kind.iter().any(|bucket| {
+            bucket.kind == "tool_call" && bucket.total_ms == 50 && bucket.count == 1
+        }));
     }
 }

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -9,6 +9,7 @@ Execute a `.harn` file.
 ```bash
 harn run <file.harn>
 harn run --trace <file.harn>
+harn run --profile --profile-json profile.json <file.harn>
 harn run -e 'println("hello")'
 harn run --deny shell,exec <file.harn>
 harn run --allow read_file,write_file <file.harn>
@@ -20,7 +21,9 @@ harn run --attest --receipt-out receipt.json <file.harn>
 
 | Flag | Description |
 |---|---|
-| `--trace` | Print LLM trace summary after execution |
+| `--trace` | Print LLM trace summary after execution. Can also be set with `HARN_TRACE=1` |
+| `--profile` | Print a categorical timing breakdown after execution. Can also be set with `HARN_PROFILE=1` |
+| `--profile-json <path>` | Write the categorical timing breakdown as JSON. Can also be set with `HARN_PROFILE_JSON=<path>` |
 | `--explain-cost` | Print static LLM token/cost estimates without executing the script |
 | `-e <code>` | Evaluate inline code instead of a file |
 | `--deny <builtins>` | Deny specific builtins (comma-separated) |
@@ -182,11 +185,16 @@ Benchmark a `.harn` file over repeated runs.
 ```bash
 harn bench main.harn
 harn bench main.harn --iterations 25
+harn bench main.harn --iterations 25 --profile-json bench.json
 ```
 
 `harn bench` parses and compiles the file once, executes it with a fresh VM for
 each iteration, and reports wall time plus aggregated LLM token, call, and cost
-metrics.
+metrics. The wall-time rollup includes min, mean, p50, p95, max, stddev, and
+total. `--profile` prints the aggregate categorical timing rollup; `--profile-json`
+writes a JSON report with `iterations[]`, `mean_ms`, `p50_ms`, `p95_ms`,
+`stddev_ms`, and `rollup`. `HARN_PROFILE=1` and `HARN_PROFILE_JSON=<path>` work
+as environment aliases.
 
 ## harn viz
 
@@ -1245,6 +1253,7 @@ harn serve a2a agent.harn                  # explicit A2A
 harn serve agent.harn                      # legacy A2A shorthand
 harn serve --port 3000 agent.harn          # legacy A2A shorthand with custom port
 harn serve acp agent.harn                  # ACP session server over stdio
+harn serve acp --profile-json /tmp/acp.ndjson agent.harn
 harn serve mcp server.harn                 # exported pub fn -> MCP tools over stdio
 harn serve mcp --transport http server.harn
 ```
@@ -1282,6 +1291,11 @@ notifications, and forwards permission prompts through
 `session/request_permission`. Use `--api-key <key>` / `HARN_SERVE_API_KEY` or
 `--hmac-secret <secret>` / `HARN_SERVE_HMAC_SECRET` to advertise ACP
 `authMethods` and require `authenticate` before protected session methods.
+Use `--profile` / `HARN_PROFILE=1` to print one categorical timing rollup per
+executed `session/prompt`; use `--profile-json <path>` /
+`HARN_PROFILE_JSON=<path>` to append per-turn NDJSON records with
+`turn`, `session_id`, and `rollup`. `--trace` / `HARN_TRACE=1` enables the LLM
+trace summary printed when the stdio server shuts down.
 
 See [MCP and ACP Integration](./mcp-and-acp.md) and
 [Outbound workflow server](./harn-serve.md) for protocol details.


### PR DESCRIPTION
## Summary

Closes #1559.

- Adds shared CLI profile flags (`--profile`, `--profile-json`) with `HARN_PROFILE` / `HARN_PROFILE_JSON` env aliases across `harn run`, `harn bench`, and `harn serve acp`; `HARN_TRACE=1` now works for `run` and ACP.
- Emits ACP per-prompt profile rollups as NDJSON and prints optional per-turn text summaries while preserving the compile-cache work now on `main`.
- Expands `harn bench` output with min/mean/p50/p95/max/stddev/total stats and writes JSON containing `iterations[]` plus an aggregate categorical rollup.
- Adds focused CLI, benchmark JSON/stat, ACP NDJSON, and VM aggregate-profile coverage, plus docs/changelog updates.

## Notes

This intentionally does not change ACP to reuse one mutable VM across prompt turns. The compile cache already landed on `main` and removes the bigger repeated compile cost without weakening turn isolation; this PR adds the profiling surface needed to measure the remaining VM setup and execution costs per turn.

## Verification

- `cargo test -p harn-cli commands::bench::tests`
- `cargo test -p harn-cli profile`
- `cargo test -p harn-cli test_parses_serve_acp`
- `cargo test -p harn-cli test_parses_bench_args`
- `cargo test -p harn-serve`
- `cargo test -p harn-vm profile::tests`
- `cargo check -p harn-cli -p harn-serve -p harn-vm`
- `cargo clippy -p harn-cli -p harn-serve -p harn-vm --all-targets -- -D warnings`
- `make lint-test-patterns`
- `cargo run --quiet --bin harn -- bench examples/hello.harn -n 2 --profile-json /tmp/harn-bench-1559.json`
- `HARN_PROFILE_JSON=/tmp/harn-run-1559.json HARN_PROFILE=1 cargo run --quiet --bin harn -- run examples/hello.harn`
- Pre-commit hook: workspace clippy, markdown lint, highlight drift check
- Pre-push hook: targeted local checks, markdown lint, highlight drift check, changelog retroactive-edit check
