### PR TITLE
ACP: cache reusable VM baselines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ condensed series summaries instead of full per-patch history.
 
 ### Added
 
+- **Reusable ACP VM baselines (#1563).** File-backed `session/prompt` turns now
+  cache a prepared VM baseline separately from the compiled bytecode cache, so
+  repeated turns reuse stable stdlib/project/source setup while instantiating a
+  clean execution VM for prompt globals, output, bridge state, tasks,
+  cancellation, sync primitives, and shared state. ACP profile rollups now
+  include a `vm_setup` bucket for prompt-turn setup diagnostics.
 - **Profiling for ACP and benchmark workflows (#1559).** `harn serve acp` now
   supports `--profile`, `--profile-json`, and `--trace`, with
   `HARN_PROFILE`, `HARN_PROFILE_JSON`, and `HARN_TRACE` aliases. ACP profile

--- a/crates/harn-serve/src/adapters/acp/execute.rs
+++ b/crates/harn-serve/src/adapters/acp/execute.rs
@@ -2,6 +2,7 @@
 //! ACP bridge, and loads MCP clients from host capabilities.
 
 use std::collections::BTreeMap;
+use std::path::Path;
 use std::rc::Rc;
 use std::sync::Arc;
 use std::time::Instant;
@@ -14,42 +15,48 @@ pub(super) struct PromptGlobals<'a> {
     pub messages: &'a [serde_json::Value],
 }
 
-/// Execute a compiled chunk with ACP bridge builtins.
-pub(super) async fn execute_chunk(
-    chunk: harn_vm::Chunk,
-    bridge: Rc<AcpBridge>,
-    host_bridge: Rc<harn_vm::bridge::HostBridge>,
-    prompt: PromptGlobals<'_>,
-    source_path: Option<&std::path::Path>,
-    cwd: &std::path::Path,
+pub(super) struct VmSetup<'a> {
+    pub source: &'a str,
+    pub baseline: Option<&'a harn_vm::VmBaseline>,
+    pub baseline_cache_hit: Option<bool>,
+    pub baseline_prepare_ms: u64,
+    pub source_path: Option<&'a Path>,
+    pub cwd: &'a Path,
+    pub runtime_configurator: Arc<dyn AcpRuntimeConfigurator>,
+}
+
+fn pipeline_name_for(source_path: Option<&Path>) -> String {
+    source_path
+        .and_then(|p| p.file_stem())
+        .and_then(|s| s.to_str())
+        .unwrap_or("acp")
+        .to_string()
+}
+
+async fn configure_stable_vm(
+    vm: &mut harn_vm::Vm,
+    source: &str,
+    source_path: Option<&Path>,
+    cwd: &Path,
     runtime_configurator: Arc<dyn AcpRuntimeConfigurator>,
 ) -> Result<String, String> {
-    let vm_setup_started = Instant::now();
-    let mut vm = harn_vm::Vm::new();
-    harn_vm::register_vm_stdlib(&mut vm);
+    harn_vm::register_vm_stdlib(vm);
     // Metadata/store rooted at harn.toml when present; cwd otherwise.
     let source_parent = source_path.and_then(|p| p.parent()).unwrap_or(cwd);
     let project_root = harn_vm::stdlib::process::find_project_root(source_parent)
         .or_else(|| harn_vm::stdlib::process::find_project_root(cwd));
     let store_base = project_root.as_deref().unwrap_or(cwd);
-    harn_vm::register_store_builtins(&mut vm, store_base);
-    harn_vm::register_metadata_builtins(&mut vm, store_base);
-    let pipeline_name = source_path
-        .and_then(|p| p.file_stem())
-        .and_then(|s| s.to_str())
-        .unwrap_or("acp");
-    harn_vm::register_checkpoint_builtins(&mut vm, store_base, pipeline_name);
-    bridge.set_script_name(pipeline_name);
+    harn_vm::register_store_builtins(vm, store_base);
+    harn_vm::register_metadata_builtins(vm, store_base);
+    let pipeline_name = pipeline_name_for(source_path);
+    harn_vm::register_checkpoint_builtins(vm, store_base, &pipeline_name);
     if let Some(ref root) = project_root {
         vm.set_project_root(root);
     }
 
     if let Some(path) = source_path {
         let path_str = path.to_string_lossy();
-        let source = std::fs::read_to_string(path).map_err(|error| {
-            format!("failed to read pipeline source '{path_str}' for diagnostic context: {error}")
-        })?;
-        vm.set_source_info(&path_str, &source);
+        vm.set_source_info(&path_str, source);
         if let Some(parent) = path.parent() {
             if !parent.as_os_str().is_empty() {
                 vm.set_source_dir(parent);
@@ -59,7 +66,56 @@ pub(super) async fn execute_chunk(
         vm.set_source_dir(cwd);
     }
 
-    runtime_configurator.configure(&mut vm, source_path).await?;
+    runtime_configurator.configure(vm, source_path).await?;
+    Ok(pipeline_name)
+}
+
+pub(super) async fn prepare_vm_baseline(
+    source: &str,
+    source_path: &Path,
+    cwd: &Path,
+    runtime_configurator: Arc<dyn AcpRuntimeConfigurator>,
+) -> Result<harn_vm::VmBaseline, String> {
+    let mut vm = harn_vm::Vm::new();
+    configure_stable_vm(
+        &mut vm,
+        source,
+        Some(source_path),
+        cwd,
+        runtime_configurator,
+    )
+    .await?;
+    Ok(vm.baseline())
+}
+
+/// Execute a compiled chunk with ACP bridge builtins.
+pub(super) async fn execute_chunk(
+    chunk: harn_vm::Chunk,
+    bridge: Rc<AcpBridge>,
+    host_bridge: Rc<harn_vm::bridge::HostBridge>,
+    prompt: PromptGlobals<'_>,
+    setup: VmSetup<'_>,
+) -> Result<String, String> {
+    let vm_setup_started = Instant::now();
+    let vm_setup_span =
+        harn_vm::tracing::span_start(harn_vm::tracing::SpanKind::VmSetup, "acp_vm_setup".into());
+    let pipeline_name = pipeline_name_for(setup.source_path);
+    bridge.set_script_name(&pipeline_name);
+
+    let mut vm = if let Some(baseline) = setup.baseline {
+        baseline.instantiate()
+    } else {
+        let mut vm = harn_vm::Vm::new();
+        configure_stable_vm(
+            &mut vm,
+            setup.source,
+            setup.source_path,
+            setup.cwd,
+            setup.runtime_configurator,
+        )
+        .await?;
+        vm
+    };
 
     vm.set_global("prompt", harn_vm::VmValue::String(Rc::from(prompt.text)));
     vm.set_global(
@@ -72,7 +128,7 @@ pub(super) async fn execute_chunk(
     );
     vm.set_global(
         "cwd",
-        harn_vm::VmValue::String(Rc::from(cwd.to_string_lossy().as_ref())),
+        harn_vm::VmValue::String(Rc::from(setup.cwd.to_string_lossy().as_ref())),
     );
 
     let mcp_globals = load_host_mcp_clients(host_bridge.clone()).await;
@@ -85,7 +141,7 @@ pub(super) async fn execute_chunk(
     // Forward unknown builtins to the ACP client as `builtin_call` JSON-RPC
     // until host-local pseudo-builtins are migrated to typed host
     // capabilities and explicit Harn stdlib wrappers.
-    host_bridge.set_script_name(pipeline_name);
+    host_bridge.set_script_name(&pipeline_name);
     vm.set_bridge(host_bridge.clone());
 
     // Replace the text-only agent_loop with a tool-aware variant that
@@ -99,19 +155,46 @@ pub(super) async fn execute_chunk(
     // call_start/call_end notifications through the bridge.
     harn_vm::llm::register_llm_call_structured_with_bridge(&mut vm, host_bridge);
 
-    let vm_setup_ms = vm_setup_started.elapsed().as_millis() as u64;
+    let dynamic_setup_ms = vm_setup_started.elapsed().as_millis() as u64;
+    let vm_setup_ms = setup.baseline_prepare_ms.saturating_add(dynamic_setup_ms);
+    harn_vm::tracing::span_set_metadata(
+        vm_setup_span,
+        "baseline_cache",
+        serde_json::Value::String(
+            match setup.baseline_cache_hit {
+                Some(true) => "hit",
+                Some(false) => "miss",
+                None => "none",
+            }
+            .to_string(),
+        ),
+    );
+    harn_vm::tracing::span_set_metadata(
+        vm_setup_span,
+        "vm_setup_ms",
+        serde_json::json!(vm_setup_ms),
+    );
+    harn_vm::tracing::span_end(vm_setup_span);
     bridge.send_log(
         "info",
         &format!("ACP_BOOT: vm_setup_ms={vm_setup_ms} pipeline={pipeline_name}"),
         Some(serde_json::json!({
-            "pipeline": pipeline_name,
+            "pipeline": pipeline_name.as_str(),
             "vm_setup_ms": vm_setup_ms,
+            "vm_setup_dynamic_ms": dynamic_setup_ms,
+            "vm_baseline_prepare_ms": setup.baseline_prepare_ms,
+            "vm_baseline_cache": match setup.baseline_cache_hit {
+                Some(true) => "hit",
+                Some(false) => "miss",
+                None => "none",
+            },
         })),
     );
 
     let execution = harn_vm::orchestration::RunExecutionRecord {
-        cwd: Some(cwd.to_string_lossy().into_owned()),
-        source_dir: source_path
+        cwd: Some(setup.cwd.to_string_lossy().into_owned()),
+        source_dir: setup
+            .source_path
             .and_then(|p| p.parent())
             .map(|p| p.to_string_lossy().into_owned()),
         ..Default::default()
@@ -130,7 +213,7 @@ pub(super) async fn execute_chunk(
         "info",
         &format!("ACP_BOOT: execute_ms={execute_ms} pipeline={pipeline_name}"),
         Some(serde_json::json!({
-            "pipeline": pipeline_name,
+            "pipeline": pipeline_name.as_str(),
             "execute_ms": execute_ms,
         })),
     );

--- a/crates/harn-serve/src/adapters/acp/mod.rs
+++ b/crates/harn-serve/src/adapters/acp/mod.rs
@@ -195,6 +195,21 @@ struct CompileCacheEntry {
     chunk: harn_vm::Chunk,
 }
 
+/// Cached VM baseline for a file-backed ACP pipeline. This is intentionally
+/// separate from bytecode caching: source can compile from cache while VM
+/// setup is invalidated by cwd, project-root discovery, target pipeline, or
+/// ACP mode changes.
+struct VmBaselineCacheEntry {
+    path: PathBuf,
+    mtime: SystemTime,
+    target_pipeline: Option<String>,
+    source: String,
+    cwd: PathBuf,
+    project_root: Option<PathBuf>,
+    mode_id: String,
+    baseline: harn_vm::VmBaseline,
+}
+
 /// ACP server that reads JSON-RPC requests from a transport and writes
 /// responses / notifications back to that same transport.
 pub struct AcpServer {
@@ -221,6 +236,8 @@ pub struct AcpServer {
     /// Compiled-pipeline cache. One slot — the ACP server runs a single
     /// pipeline file for its lifetime, so we only ever cache one chunk.
     compile_cache: Option<CompileCacheEntry>,
+    /// Prepared VM baseline cache for the same file-backed pipeline.
+    vm_baseline_cache: Option<VmBaselineCacheEntry>,
     /// Per-turn profile emission settings.
     profile: AcpProfileConfig,
 }
@@ -251,6 +268,7 @@ impl AcpServer {
             session_cancellations: Arc::new(std::sync::Mutex::new(HashMap::new())),
             output,
             compile_cache: None,
+            vm_baseline_cache: None,
             profile: config.profile,
         }
     }
@@ -304,6 +322,76 @@ impl AcpServer {
             });
         }
         Ok((chunk, false))
+    }
+
+    async fn prepare_vm_baseline_cached(
+        &mut self,
+        source: &str,
+        source_path: Option<&Path>,
+        target_pipeline: Option<&str>,
+        cwd: &Path,
+        mode_id: &str,
+    ) -> Result<(Option<harn_vm::VmBaseline>, Option<bool>, u64), String> {
+        let Some(source_path) = source_path else {
+            return Ok((None, None, 0));
+        };
+
+        let prepare_started = Instant::now();
+        let target_owned = target_pipeline.map(str::to_string);
+        let cache_key = std::fs::metadata(source_path)
+            .and_then(|m| m.modified())
+            .ok()
+            .map(|mtime| (source_path.to_path_buf(), mtime));
+        let source_parent = source_path.parent().unwrap_or(cwd);
+        let project_root = harn_vm::stdlib::process::find_project_root(source_parent)
+            .or_else(|| harn_vm::stdlib::process::find_project_root(cwd));
+
+        if let Some((ref path, mtime)) = cache_key {
+            if let Some(entry) = self.vm_baseline_cache.as_ref() {
+                if entry.path == *path
+                    && entry.mtime == mtime
+                    && entry.target_pipeline == target_owned
+                    && entry.source == source
+                    && entry.cwd == cwd
+                    && entry.project_root == project_root
+                    && entry.mode_id == mode_id
+                {
+                    return Ok((
+                        Some(entry.baseline.clone()),
+                        Some(true),
+                        prepare_started.elapsed().as_millis() as u64,
+                    ));
+                }
+            }
+        }
+
+        let baseline = execute::prepare_vm_baseline(
+            source,
+            source_path,
+            cwd,
+            self.runtime_configurator.clone(),
+        )
+        .await?;
+        if let Some((path, mtime)) = cache_key {
+            self.vm_baseline_cache = Some(VmBaselineCacheEntry {
+                path,
+                mtime,
+                target_pipeline: target_owned,
+                source: source.to_string(),
+                cwd: cwd.to_path_buf(),
+                project_root,
+                mode_id: mode_id.to_string(),
+                baseline: baseline.clone(),
+            });
+        } else {
+            self.vm_baseline_cache = None;
+        }
+
+        Ok((
+            Some(baseline),
+            Some(false),
+            prepare_started.elapsed().as_millis() as u64,
+        ))
     }
 
     /// Write a complete JSON-RPC message to the current transport.
@@ -931,14 +1019,31 @@ impl AcpServer {
                     .unwrap_or_else(|| "<inline>".to_string()),
             })),
         );
+        let profile_turn = self.begin_profile_turn(&session_id);
+        let _mode_guard = modes::ModePolicyGuard::enter(&current_mode_id);
+        let (vm_baseline, vm_baseline_cache_hit, vm_baseline_prepare_ms) = match self
+            .prepare_vm_baseline_cached(
+                &source,
+                source_path.as_deref(),
+                target_pipeline.as_deref(),
+                &cwd,
+                &current_mode_id,
+            )
+            .await
+        {
+            Ok(value) => value,
+            Err(message) => {
+                self.finish_profile_turn(&session_id, profile_turn);
+                self.send_prompt_error(&session_id, id, &message);
+                return;
+            }
+        };
         if let Some(session) = self.sessions.get_mut(&session_id) {
             session.host_bridge = Some(host_bridge.clone());
         }
 
-        let profile_turn = self.begin_profile_turn(&session_id);
         let id_owned = id.clone();
         let send_output = self.output.clone();
-        let _mode_guard = modes::ModePolicyGuard::enter(&current_mode_id);
         let host_bridge_for_response = host_bridge.clone();
         let result = execute::execute_chunk(
             chunk,
@@ -949,9 +1054,15 @@ impl AcpServer {
                 content: &prompt.content,
                 messages: &prompt.messages,
             },
-            source_path.as_deref(),
-            &cwd,
-            self.runtime_configurator.clone(),
+            execute::VmSetup {
+                source: &source,
+                baseline: vm_baseline.as_ref(),
+                baseline_cache_hit: vm_baseline_cache_hit,
+                baseline_prepare_ms: vm_baseline_prepare_ms,
+                source_path: source_path.as_deref(),
+                cwd: &cwd,
+                runtime_configurator: self.runtime_configurator.clone(),
+            },
         )
         .await;
         self.finish_profile_turn(&session_id, profile_turn);

--- a/crates/harn-serve/src/adapters/acp/tests.rs
+++ b/crates/harn-serve/src/adapters/acp/tests.rs
@@ -374,6 +374,81 @@ fn compile_pipeline_cached_does_not_cache_inline_prompts() {
     );
 }
 
+#[tokio::test(flavor = "current_thread")]
+async fn vm_baseline_cached_serves_file_backed_context_until_key_changes() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let pipeline_path = dir.path().join("baseline.harn");
+    let source = "pipeline main() { println(\"baseline\") }\n";
+    std::fs::write(&pipeline_path, source).expect("write pipeline");
+
+    let mut server = AcpServer::new(AcpServerConfig::new(Some(
+        pipeline_path.to_string_lossy().to_string(),
+    )));
+    let (_baseline, hit1, _ms1) = server
+        .prepare_vm_baseline_cached(
+            source,
+            Some(pipeline_path.as_path()),
+            None,
+            dir.path(),
+            "code",
+        )
+        .await
+        .expect("first prepare");
+    assert_eq!(hit1, Some(false), "first prepare must fill the cache");
+
+    let (_baseline, hit2, _ms2) = server
+        .prepare_vm_baseline_cached(
+            source,
+            Some(pipeline_path.as_path()),
+            None,
+            dir.path(),
+            "code",
+        )
+        .await
+        .expect("second prepare");
+    assert_eq!(hit2, Some(true), "unchanged file-backed context must hit");
+
+    let (_baseline, hit3, _ms3) = server
+        .prepare_vm_baseline_cached(
+            source,
+            Some(pipeline_path.as_path()),
+            Some("review"),
+            dir.path(),
+            "code",
+        )
+        .await
+        .expect("target prepare");
+    assert_eq!(
+        hit3,
+        Some(false),
+        "target pipeline is part of baseline invalidation"
+    );
+
+    let (_baseline, hit4, _ms4) = server
+        .prepare_vm_baseline_cached(
+            source,
+            Some(pipeline_path.as_path()),
+            Some("review"),
+            dir.path(),
+            "plan",
+        )
+        .await
+        .expect("mode prepare");
+    assert_eq!(
+        hit4,
+        Some(false),
+        "ACP mode is part of baseline invalidation"
+    );
+
+    let (baseline, hit5, ms5) = server
+        .prepare_vm_baseline_cached(source, None, None, dir.path(), "code")
+        .await
+        .expect("inline prepare");
+    assert!(baseline.is_none());
+    assert_eq!(hit5, None);
+    assert_eq!(ms5, 0);
+}
+
 mod commands;
 mod modes;
 mod sessions;

--- a/crates/harn-serve/src/adapters/acp/tests/sessions.rs
+++ b/crates/harn-serve/src/adapters/acp/tests/sessions.rs
@@ -1,4 +1,70 @@
 use super::*;
+
+async fn run_prompt_with_project_capability(
+    request_tx: &mpsc::UnboundedSender<serde_json::Value>,
+    response_rx: &mut mpsc::UnboundedReceiver<String>,
+    session_id: &str,
+    id: i64,
+    prompt_text: &str,
+    project_read_capability: bool,
+) -> String {
+    request_tx
+        .send(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": "session/prompt",
+            "params": {
+                "sessionId": session_id,
+                "prompt": [{"type": "text", "text": prompt_text}],
+            },
+        }))
+        .expect("send session/prompt");
+
+    let host_capabilities = if project_read_capability {
+        serde_json::json!({"project": ["read_file"]})
+    } else {
+        serde_json::json!({})
+    };
+    let mut output = String::new();
+    let mut saw_completed = false;
+    for _ in 0..64 {
+        let message = recv_json(response_rx).await;
+        match message.get("method").and_then(|value| value.as_str()) {
+            Some("host/capabilities") => {
+                request_tx
+                    .send(serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": message["id"].clone(),
+                        "result": host_capabilities.clone(),
+                    }))
+                    .expect("send host/capabilities response");
+            }
+            Some("session/update")
+                if message["params"]["update"]["sessionUpdate"] == "agent_message_chunk" =>
+            {
+                let content = &message["params"]["update"]["content"];
+                let text = content["text"].as_str().expect("chunk text");
+                let visible_delta = content["_meta"]["harn"]["visible_delta"]
+                    .as_str()
+                    .expect("visible_delta");
+                assert!(
+                    !visible_delta.contains(if prompt_text == "one" { "two" } else { "one" }),
+                    "each prompt turn gets a fresh bridge visible-text state"
+                );
+                output.push_str(text);
+            }
+            _ if message["id"] == id => {
+                assert_eq!(message["result"]["stopReason"], "end_turn");
+                saw_completed = true;
+                break;
+            }
+            _ => {}
+        }
+    }
+    assert!(saw_completed, "prompt {id} should complete successfully");
+    output
+}
+
 #[tokio::test(flavor = "current_thread")]
 async fn acp_server_handles_session_flow_and_prompt_updates() {
     let local = tokio::task::LocalSet::new();
@@ -224,6 +290,90 @@ async fn acp_profile_json_appends_one_line_per_prompt_turn() {
             assert_eq!(entries[0]["turn"], 1);
             assert_eq!(entries[1]["turn"], 2);
             assert!(entries[0]["rollup"]["by_kind"].is_array());
+
+            drop(request_tx);
+            server.await.expect("ACP channel server task");
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn acp_file_backed_vm_baseline_keeps_prompt_turns_isolated() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let pipeline_path = dir.path().join("isolation.harn");
+            let profile_path = dir.path().join("profile.ndjson");
+            std::fs::write(
+                &pipeline_path,
+                r#"
+pipeline default(task) {
+  let cell = shared_cell({scope: "task_group", key: "turn", initial: prompt})
+  println(prompt)
+  println(shared_get(cell))
+  shared_set(cell, "dirty")
+  let held = sync_gate_acquire("runner", 1)
+  let blocked = sync_gate_acquire("runner", 1, 0)
+  println(blocked == nil)
+  sync_release(held)
+  let metrics = sync_metrics("gate", "runner")
+  println(metrics.acquisition_count)
+  println(host_has("project", "read_file"))
+}"#,
+            )
+            .expect("write pipeline");
+            let config =
+                AcpServerConfig::for_pipeline(pipeline_path.to_string_lossy().to_string())
+                    .with_profile(AcpProfileConfig {
+                        text: false,
+                        json_path: Some(profile_path.clone()),
+                    });
+            let (request_tx, mut response_rx, server, session_id) =
+                start_acp_code_session_with_config(config, serde_json::json!(dir.path())).await;
+
+            let first = run_prompt_with_project_capability(
+                &request_tx,
+                &mut response_rx,
+                &session_id,
+                3,
+                "one",
+                true,
+            )
+            .await;
+            assert_eq!(first, "one\none\ntrue\n1\ntrue\n");
+
+            let second = run_prompt_with_project_capability(
+                &request_tx,
+                &mut response_rx,
+                &session_id,
+                4,
+                "two",
+                false,
+            )
+            .await;
+            assert_eq!(
+                second, "two\ntwo\ntrue\n1\nfalse\n",
+                "prompt globals, shared runtime state, sync metrics, and host capability cache must reset per turn"
+            );
+
+            let lines = std::fs::read_to_string(&profile_path).expect("read profile ndjson");
+            let entries = lines
+                .lines()
+                .map(|line| serde_json::from_str::<serde_json::Value>(line).expect("json line"))
+                .collect::<Vec<_>>();
+            assert_eq!(entries.len(), 2, "profile output:\n{lines}");
+            for entry in &entries {
+                let buckets = entry["rollup"]["by_kind"]
+                    .as_array()
+                    .expect("profile kind buckets");
+                assert!(
+                    buckets
+                        .iter()
+                        .any(|bucket| bucket["kind"] == "vm_setup" && bucket["count"] == 1),
+                    "ACP profile must expose vm_setup bucket: {entry}"
+                );
+            }
 
             drop(request_tx);
             server.await.expect("ACP channel server task");

--- a/crates/harn-vm/src/profile.rs
+++ b/crates/harn-vm/src/profile.rs
@@ -69,9 +69,9 @@ pub fn build(spans: &[Span]) -> RunProfile {
         return RunProfile::default();
     }
 
-    // The pipeline root is conventionally the only top-level span. If a
-    // run somehow produced multiple, we sum them — accurate for total
-    // wall time, just unusual.
+    // The pipeline root is conventionally the only top-level VM span. Host
+    // adapters may add sibling setup spans, so top-level non-pipeline spans
+    // contribute to wall time and their own buckets.
     let total_wall_ms: u64 = spans
         .iter()
         .filter(|s| s.parent_id.is_none())
@@ -82,14 +82,16 @@ pub fn build(spans: &[Span]) -> RunProfile {
 
     // Residual = wall - sum of "real work" categories at the top level.
     // Imports/parallel/spawn count as work too; the category buckets cover
-    // them so we just subtract everything that was already accounted for
-    // at depth 1.
-    let depth1_total: u64 = spans
+    // them so we subtract depth-1 work plus any host setup sibling spans.
+    let accounted_total: u64 = spans
         .iter()
-        .filter(|s| matches!(s.parent_id, Some(pid) if is_pipeline_root(spans, pid)))
+        .filter(|s| {
+            (s.parent_id.is_none() && !is_profile_root_span(s))
+                || matches!(s.parent_id, Some(pid) if is_pipeline_root(spans, pid))
+        })
         .map(|s| s.duration_ms)
         .sum();
-    let residual_ms = total_wall_ms.saturating_sub(depth1_total);
+    let residual_ms = total_wall_ms.saturating_sub(accounted_total);
 
     let top_llm_calls = top_n_by_duration(spans, "llm_call");
     let top_tool_calls = top_n_by_duration(spans, "tool_call");
@@ -130,8 +132,12 @@ fn is_pipeline_root(spans: &[Span], id: u64) -> bool {
     spans
         .iter()
         .find(|s| s.span_id == id)
-        .map(|s| s.parent_id.is_none())
+        .map(is_profile_root_span)
         .unwrap_or(false)
+}
+
+fn is_profile_root_span(span: &Span) -> bool {
+    span.parent_id.is_none() && span.kind == crate::tracing::SpanKind::Pipeline
 }
 
 fn bucket_by_kind(spans: &[Span], total_wall_ms: u64) -> Vec<KindBucket> {
@@ -141,7 +147,7 @@ fn bucket_by_kind(spans: &[Span], total_wall_ms: u64) -> Vec<KindBucket> {
     // leaves.
     let mut totals: BTreeMap<String, (u64, u64)> = BTreeMap::new();
     for span in spans {
-        if span.parent_id.is_none() {
+        if is_profile_root_span(span) {
             // Skip the synthetic pipeline span; it's the wall-time
             // denominator, not a category bucket.
             continue;
@@ -399,6 +405,22 @@ mod tests {
         assert_eq!(profile.by_kind[1].count, 2);
         // 1000 wall - (600 + 300) depth-1 = 100 ms residual
         assert_eq!(profile.residual_ms, 100);
+    }
+
+    #[test]
+    fn top_level_vm_setup_span_gets_its_own_bucket() {
+        let spans = vec![
+            span(1, None, SpanKind::VmSetup, "acp_vm_setup", 20),
+            span(2, None, SpanKind::Pipeline, "main", 80),
+            span(3, Some(2), SpanKind::LlmCall, "llm_call", 50),
+        ];
+        let profile = build(&spans);
+        assert_eq!(profile.total_wall_ms, 100);
+        assert_eq!(profile.residual_ms, 30);
+        assert!(profile
+            .by_kind
+            .iter()
+            .any(|bucket| bucket.kind == "vm_setup" && bucket.total_ms == 20));
     }
 
     #[test]

--- a/crates/harn-vm/src/stdlib.rs
+++ b/crates/harn-vm/src/stdlib.rs
@@ -172,6 +172,10 @@ pub fn register_vm_stdlib(vm: &mut Vm) {
     register_agent_stdlib(vm);
 }
 
+pub(crate) fn rebind_execution_state_builtins(vm: &mut Vm) {
+    concurrency::register_concurrency_builtins(vm);
+}
+
 fn stdlib_probe_vm() -> Vm {
     let mut vm = Vm::new();
     register_vm_stdlib(&mut vm);

--- a/crates/harn-vm/src/tracing.rs
+++ b/crates/harn-vm/src/tracing.rs
@@ -26,6 +26,8 @@ pub enum SpanKind {
     Spawn,
     /// A `@step`-annotated function while its frame is on the call stack.
     Step,
+    /// Host-side VM setup before user bytecode starts executing.
+    VmSetup,
 }
 
 impl SpanKind {
@@ -39,6 +41,7 @@ impl SpanKind {
             Self::Parallel => "parallel",
             Self::Spawn => "spawn",
             Self::Step => "step",
+            Self::VmSetup => "vm_setup",
         }
     }
 }

--- a/crates/harn-vm/src/vm/mod.rs
+++ b/crates/harn-vm/src/vm/mod.rs
@@ -25,7 +25,7 @@ pub use async_builtin::{
 pub use builtin::{VmBuiltinArity, VmBuiltinKind, VmBuiltinMetadata};
 pub use debug::{DebugAction, DebugState};
 pub use modules::resolve_module_import_path;
-pub use state::Vm;
+pub use state::{Vm, VmBaseline};
 
 pub(crate) use state::{
     CallFrame, ExceptionHandler, InterruptHandler, IterState, LocalSlot, ScopeSpan,

--- a/crates/harn-vm/src/vm/state.rs
+++ b/crates/harn-vm/src/vm/state.rs
@@ -245,6 +245,110 @@ pub struct Vm {
     pub(crate) debug_hook: Option<Box<DebugHook>>,
 }
 
+/// Reusable VM baseline for hosts that need many clean executions with the
+/// same stable builtin/source setup.
+///
+/// The baseline intentionally does not snapshot execution state. Each
+/// instantiation gets fresh stacks, frames, tasks, cancellation fields, sync
+/// primitives, shared cells/maps/mailboxes, and debug state. Builtin tables are
+/// shared through `Rc` until a per-execution rebind needs copy-on-write.
+#[derive(Clone)]
+pub struct VmBaseline {
+    builtins: Rc<BTreeMap<String, VmBuiltinFn>>,
+    async_builtins: Rc<BTreeMap<String, VmAsyncBuiltinFn>>,
+    builtin_metadata: Rc<BTreeMap<String, VmBuiltinMetadata>>,
+    builtins_by_id: Rc<BTreeMap<BuiltinId, VmBuiltinEntry>>,
+    builtin_id_collisions: Rc<HashSet<BuiltinId>>,
+    source_dir: Option<std::path::PathBuf>,
+    source_file: Option<String>,
+    source_text: Option<String>,
+    project_root: Option<std::path::PathBuf>,
+    globals: Rc<BTreeMap<String, VmValue>>,
+    denied_builtins: Rc<HashSet<String>>,
+}
+
+impl VmBaseline {
+    pub fn from_vm(vm: &Vm) -> Self {
+        Self {
+            builtins: Rc::clone(&vm.builtins),
+            async_builtins: Rc::clone(&vm.async_builtins),
+            builtin_metadata: Rc::clone(&vm.builtin_metadata),
+            builtins_by_id: Rc::clone(&vm.builtins_by_id),
+            builtin_id_collisions: Rc::clone(&vm.builtin_id_collisions),
+            source_dir: vm.source_dir.clone(),
+            source_file: vm.source_file.clone(),
+            source_text: vm.source_text.clone(),
+            project_root: vm.project_root.clone(),
+            globals: Rc::clone(&vm.globals),
+            denied_builtins: Rc::clone(&vm.denied_builtins),
+        }
+    }
+
+    pub fn instantiate(&self) -> Vm {
+        let mut source_cache = BTreeMap::new();
+        if let (Some(file), Some(text)) = (&self.source_file, &self.source_text) {
+            source_cache.insert(std::path::PathBuf::from(file), text.clone());
+        }
+        if let Some(dir) = &self.source_dir {
+            crate::stdlib::set_thread_source_dir(dir);
+        }
+
+        let mut vm = Vm {
+            stack: Vec::with_capacity(256),
+            env: VmEnv::new(),
+            output: String::new(),
+            builtins: Rc::clone(&self.builtins),
+            async_builtins: Rc::clone(&self.async_builtins),
+            builtin_metadata: Rc::clone(&self.builtin_metadata),
+            builtins_by_id: Rc::clone(&self.builtins_by_id),
+            builtin_id_collisions: Rc::clone(&self.builtin_id_collisions),
+            iterators: Vec::new(),
+            frames: Vec::new(),
+            exception_handlers: Vec::new(),
+            spawned_tasks: BTreeMap::new(),
+            sync_runtime: Arc::new(crate::synchronization::VmSyncRuntime::new()),
+            shared_state_runtime: Rc::new(crate::shared_state::VmSharedStateRuntime::new()),
+            held_sync_guards: Vec::new(),
+            task_counter: 0,
+            runtime_context_counter: 0,
+            runtime_context: crate::runtime_context::RuntimeContext::root(),
+            deadlines: Vec::new(),
+            breakpoints: BTreeMap::new(),
+            function_breakpoints: std::collections::BTreeSet::new(),
+            pending_function_bp: None,
+            step_mode: false,
+            step_frame_depth: 0,
+            stopped: false,
+            last_line: 0,
+            source_dir: self.source_dir.clone(),
+            imported_paths: Vec::new(),
+            module_cache: Rc::new(BTreeMap::new()),
+            source_cache: Rc::new(source_cache),
+            source_file: self.source_file.clone(),
+            source_text: self.source_text.clone(),
+            bridge: None,
+            denied_builtins: Rc::clone(&self.denied_builtins),
+            cancel_token: None,
+            interrupt_signal_token: None,
+            cancel_grace_instructions_remaining: None,
+            interrupt_handlers: Vec::new(),
+            next_interrupt_handle: 1,
+            pending_interrupt_signal: None,
+            interrupted: false,
+            dispatching_interrupt: false,
+            interrupt_handler_deadline: None,
+            error_stack_trace: Vec::new(),
+            yield_sender: None,
+            project_root: self.project_root.clone(),
+            globals: Rc::clone(&self.globals),
+            debug_hook: None,
+        };
+
+        crate::stdlib::rebind_execution_state_builtins(&mut vm);
+        vm
+    }
+}
+
 impl Vm {
     pub(crate) fn fresh_local_slots(chunk: &Chunk) -> Vec<LocalSlot> {
         chunk
@@ -449,6 +553,10 @@ impl Vm {
             globals: Rc::new(BTreeMap::new()),
             debug_hook: None,
         }
+    }
+
+    pub fn baseline(&self) -> VmBaseline {
+        VmBaseline::from_vm(self)
     }
 
     /// Set the bridge for delegating unknown builtins in bridge mode.
@@ -686,5 +794,82 @@ impl Drop for Vm {
 impl Default for Vm {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::rc::Rc;
+
+    use super::*;
+
+    fn baseline_with_stdlib(source: &str) -> VmBaseline {
+        let mut vm = Vm::new();
+        crate::register_vm_stdlib(&mut vm);
+        vm.set_source_info("baseline_test.harn", source);
+        vm.set_global("stable_global", VmValue::String(Rc::from("baseline")));
+        vm.baseline()
+    }
+
+    #[test]
+    fn vm_baseline_instantiates_clean_mutable_execution_state() {
+        let baseline = baseline_with_stdlib("pipeline main() { println(stable_global) }");
+
+        let mut dirty = baseline.instantiate();
+        dirty.stack.push(VmValue::Int(42));
+        dirty.output.push_str("dirty");
+        dirty.task_counter = 9;
+        dirty.runtime_context_counter = 7;
+        dirty
+            .error_stack_trace
+            .push(("main".to_string(), 1, 1, None));
+
+        let clean = baseline.instantiate();
+        assert!(clean.stack.is_empty());
+        assert!(clean.output.is_empty());
+        assert!(clean.frames.is_empty());
+        assert!(clean.exception_handlers.is_empty());
+        assert!(clean.spawned_tasks.is_empty());
+        assert!(clean.held_sync_guards.is_empty());
+        assert_eq!(clean.task_counter, 0);
+        assert_eq!(clean.runtime_context_counter, 0);
+        assert!(clean.deadlines.is_empty());
+        assert!(clean.cancel_token.is_none());
+        assert!(clean.interrupt_handlers.is_empty());
+        assert!(clean.error_stack_trace.is_empty());
+        assert!(clean.bridge.is_none());
+        assert!(clean
+            .globals
+            .get("stable_global")
+            .is_some_and(|value| value.display() == "baseline"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn vm_baseline_rebinds_shared_state_builtins_per_instance() {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let source = r#"
+pipeline main() {
+  let cell = shared_cell({scope: "task_group", key: "turn", initial: 0})
+  println(shared_get(cell))
+  shared_set(cell, shared_get(cell) + 1)
+}"#;
+                let chunk = crate::compile_source(source).expect("compile");
+                let baseline = baseline_with_stdlib(source);
+
+                let mut first = baseline.instantiate();
+                first.execute(&chunk).await.expect("first execute");
+                assert_eq!(first.output(), "0\n");
+
+                let mut second = baseline.instantiate();
+                second.execute(&chunk).await.expect("second execute");
+                assert_eq!(
+                    second.output(),
+                    "0\n",
+                    "shared state created by the first VM must not leak into the next baseline instance"
+                );
+            })
+            .await;
     }
 }

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -1294,8 +1294,10 @@ notifications, and forwards permission prompts through
 Use `--profile` / `HARN_PROFILE=1` to print one categorical timing rollup per
 executed `session/prompt`; use `--profile-json <path>` /
 `HARN_PROFILE_JSON=<path>` to append per-turn NDJSON records with
-`turn`, `session_id`, and `rollup`. `--trace` / `HARN_TRACE=1` enables the LLM
-trace summary printed when the stdio server shuts down.
+`turn`, `session_id`, and `rollup`. File-backed ACP prompts report `vm_setup`
+as a profile bucket and reuse a prepared VM baseline while preserving clean
+per-turn execution state. `--trace` / `HARN_TRACE=1` enables the LLM trace
+summary printed when the stdio server shuts down.
 
 See [MCP and ACP Integration](./mcp-and-acp.md) and
 [Outbound workflow server](./harn-serve.md) for protocol details.

--- a/docs/src/mcp-and-acp.md
+++ b/docs/src/mcp-and-acp.md
@@ -658,9 +658,13 @@ Runtime behavior:
   Hosts can render these as background task notifications instead of scraping
   stdout.
 - Bridge-mode logs also stream boot timing records (`ACP_BOOT` with
-  `compile_ms`, `vm_setup_ms`, and `execute_ms`) and live `span_end` duration
-  events while a prompt is still running, so hosts do not need to wait for the
-  final stdout flush to surface basic timing telemetry.
+  `compile_ms`, `vm_setup_ms`, `vm_baseline_cache`, and `execute_ms`) and live
+  `span_end` duration events while a prompt is still running, so hosts do not
+  need to wait for the final stdout flush to surface basic timing telemetry.
+  File-backed prompts keep the compile cache and VM baseline cache separate:
+  repeated turns reuse stable stdlib/project/source setup, then instantiate a
+  clean execution VM for prompt globals, output, bridge handles, tasks,
+  cancellation, sync primitives, shared state, and tracing.
 - `finish_step`: inject after the current tool/operation completes
 - `wait_for_completion`: defer until the current agent interaction yields
 


### PR DESCRIPTION
## Summary
- add `VmBaseline` support in harn-vm so hosts can snapshot stable builtin/source setup and instantiate clean per-turn VMs
- cache ACP VM baselines separately from compile cache for file-backed prompts, with mode/cwd/project/source invalidation and setup telemetry
- add ACP and VM tests for baseline cache hits, prompt/global/output/bridge/runtime isolation, and `vm_setup` profile buckets
- document ACP baseline reuse and update the changelog

Closes #1563

## Verification
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-1563 cargo check -p harn-cli -p harn-serve -p harn-vm`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-1563 cargo clippy -p harn-cli -p harn-serve -p harn-vm --all-targets -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-1563 cargo test -p harn-serve acp -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-1563 cargo test -p harn-vm vm_baseline -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-1563 cargo test -p harn-vm top_level_vm_setup_span_gets_its_own_bucket -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-1563 cargo test -p harn-cli profile -- --nocapture`
- `make lint-test-patterns`
- pre-commit hook: workspace clippy, highlight sync, markdown
- pre-push hook: targeted checks, markdown, generated highlight check, changelog check