### PR TITLE
Refactor worker replay and sub-agent requests

### DIFF
--- a/crates/harn-vm/src/stdlib/agents.rs
+++ b/crates/harn-vm/src/stdlib/agents.rs
@@ -27,6 +27,7 @@ use self::agents_workers::{
     WORKER_REGISTRY,
 };
 use self::sub_agent::{execute_sub_agent, parse_sub_agent_request};
+use crate::orchestration::ArtifactRecord;
 use crate::stdlib::registration::{
     async_builtin, register_builtin_group, AsyncBuiltin, BuiltinGroup, SyncBuiltin,
 };
@@ -99,11 +100,42 @@ pub(super) struct SubAgentExecutionResult {
     pub(super) transcript: VmValue,
 }
 
+struct WorkerReplayCarry {
+    artifacts: Vec<ArtifactRecord>,
+    transcript: Option<VmValue>,
+    parent_worker_id: String,
+    worker_id: String,
+    resume_workflow: bool,
+    child_run_path: Option<String>,
+    reset_sub_agent_session: bool,
+}
+
 fn restart_worker_run(
     worker: &mut WorkerState,
     next_task: &str,
     clear_latest_payload: bool,
 ) -> Result<(), VmError> {
+    reset_worker_for_replay(worker, next_task, clear_latest_payload)
+}
+
+fn reset_worker_for_replay(
+    worker: &mut WorkerState,
+    next_task: &str,
+    clear_latest_payload: bool,
+) -> Result<(), VmError> {
+    reset_worker_runtime_state(worker, next_task, clear_latest_payload);
+    let carry = worker_replay_carry(worker)?;
+    worker.transcript = carry.transcript.clone();
+    ensure_worker_config_session_ids(&mut worker.config, &carry.worker_id);
+    apply_worker_replay_config(&mut worker.config, next_task, carry);
+    Ok(())
+}
+
+fn reset_worker_runtime_state(
+    worker: &mut WorkerState,
+    next_task: &str,
+    clear_latest_payload: bool,
+) {
     worker.cancel_token = Arc::new(AtomicBool::new(false));
     worker.task = next_task.to_string();
     worker.history.push(next_task.to_string());
@@ -116,66 +148,105 @@ fn restart_worker_run(
     if clear_latest_payload {
         worker.latest_payload = None;
     }
-    let next_artifacts = apply_worker_artifact_policy(&worker.artifacts, &worker.carry_policy);
-    let next_transcript =
-        apply_worker_transcript_policy(worker.transcript.clone(), &worker.carry_policy)?;
-    worker.transcript = next_transcript.clone();
-    let worker_parent = worker.id.clone();
-    let worker_id = worker.id.clone();
-    let resume_workflow = worker.carry_policy.resume_workflow;
-    let child_run_path = worker.child_run_path.clone();
-    ensure_worker_config_session_ids(&mut worker.config, &worker_id);
-    match &mut worker.config {
+}
+
+fn worker_replay_carry(worker: &WorkerState) -> Result<WorkerReplayCarry, VmError> {
+    Ok(WorkerReplayCarry {
+        artifacts: apply_worker_artifact_policy(&worker.artifacts, &worker.carry_policy),
+        transcript: apply_worker_transcript_policy(
+            worker.transcript.clone(),
+            &worker.carry_policy,
+        )?,
+        parent_worker_id: worker.id.clone(),
+        worker_id: worker.id.clone(),
+        resume_workflow: worker.carry_policy.resume_workflow,
+        child_run_path: worker.child_run_path.clone(),
+        reset_sub_agent_session: matches!(
+            worker.carry_policy.transcript_mode.as_str(),
+            "fork" | "reset"
+        ),
+    })
+}
+
+fn apply_worker_replay_config(
+    config: &mut WorkerConfig,
+    next_task: &str,
+    carry: WorkerReplayCarry,
+) {
+    match config {
         WorkerConfig::Workflow {
             artifacts, options, ..
-        } => {
-            if !next_artifacts.is_empty() {
-                *artifacts = next_artifacts.clone();
-            }
-            options.insert(
-                "parent_worker_id".to_string(),
-                VmValue::String(Rc::from(worker_parent)),
-            );
-            if let Some(transcript) = next_transcript.clone() {
-                options.insert("transcript".to_string(), transcript);
-            } else {
-                options.remove("transcript");
-            }
-            if resume_workflow {
-                if let Some(child_run_path) = child_run_path {
-                    options.insert(
-                        "resume_path".to_string(),
-                        VmValue::String(Rc::from(child_run_path)),
-                    );
-                }
-            } else {
-                options.remove("resume_path");
-            }
-        }
+        } => apply_workflow_replay_config(artifacts, options, carry),
         WorkerConfig::Stage {
             artifacts,
             transcript,
             ..
-        } => {
-            if !next_artifacts.is_empty() {
-                *artifacts = next_artifacts;
-            }
-            *transcript = next_transcript;
-        }
+        } => apply_stage_replay_config(artifacts, transcript, carry),
         WorkerConfig::SubAgent { spec } => {
-            spec.task = next_task.to_string();
-            if matches!(
-                worker.carry_policy.transcript_mode.as_str(),
-                "fork" | "reset"
-            ) {
-                spec.session_id = format!("sub_agent_session_{}", uuid::Uuid::now_v7());
-                spec.options.insert(
-                    "session_id".to_string(),
-                    VmValue::String(Rc::from(spec.session_id.clone())),
-                );
-            }
+            apply_sub_agent_replay_config(spec, next_task, carry.reset_sub_agent_session);
         }
     }
+}
+
+fn apply_workflow_replay_config(
+    artifacts: &mut Vec<ArtifactRecord>,
+    options: &mut BTreeMap<String, VmValue>,
+    carry: WorkerReplayCarry,
+) {
+    if !carry.artifacts.is_empty() {
+        *artifacts = carry.artifacts;
+    }
+    options.insert(
+        "parent_worker_id".to_string(),
+        VmValue::String(Rc::from(carry.parent_worker_id)),
+    );
+    if let Some(transcript) = carry.transcript {
+        options.insert("transcript".to_string(), transcript);
+    } else {
+        options.remove("transcript");
+    }
+    if carry.resume_workflow {
+        if let Some(child_run_path) = carry.child_run_path {
+            options.insert(
+                "resume_path".to_string(),
+                VmValue::String(Rc::from(child_run_path)),
+            );
+        }
+    } else {
+        options.remove("resume_path");
+    }
+}
+
+fn apply_stage_replay_config(
+    artifacts: &mut Vec<ArtifactRecord>,
+    transcript: &mut Option<VmValue>,
+    carry: WorkerReplayCarry,
+) {
+    if !carry.artifacts.is_empty() {
+        *artifacts = carry.artifacts;
+    }
+    *transcript = carry.transcript;
+}
+
+fn apply_sub_agent_replay_config(spec: &mut SubAgentRunSpec, next_task: &str, reset_session: bool) {
+    spec.task = next_task.to_string();
+    if reset_session {
+        spec.session_id = format!("sub_agent_session_{}", uuid::Uuid::now_v7());
+        spec.options.insert(
+            "session_id".to_string(),
+            VmValue::String(Rc::from(spec.session_id.clone())),
+        );
+    }
+}
+
+fn respawn_worker_task(state: Rc<RefCell<WorkerState>>) -> Result<(), VmError> {
+    {
+        let worker = state.borrow();
+        if worker.carry_policy.persist_state {
+            persist_worker_state_snapshot(&worker)?;
+        }
+    }
+    spawn_worker_task(state);
     Ok(())
 }
 
@@ -362,11 +433,8 @@ async fn send_input_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
             )));
         }
         restart_worker_run(&mut worker, &next_task, true)?;
-        if worker.carry_policy.persist_state {
-            persist_worker_state_snapshot(&worker)?;
-        }
         drop(worker);
-        spawn_worker_task(state.clone());
+        respawn_worker_task(state.clone())?;
         let summary = worker_summary(&state.borrow())?;
         Ok(summary)
     })
@@ -411,12 +479,9 @@ async fn worker_trigger_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> 
             )));
         }
         restart_worker_run(&mut worker, &next_task, false)?;
-        if worker.carry_policy.persist_state {
-            persist_worker_state_snapshot(&worker)?;
-        }
         let snapshot = worker_event_snapshot(&worker);
         drop(worker);
-        spawn_worker_task(state.clone());
+        respawn_worker_task(state.clone())?;
         Ok(snapshot)
     })?;
     // Emit the progressed lifecycle *after* the new cycle has been

--- a/crates/harn-vm/src/stdlib/agents_sub_agent.rs
+++ b/crates/harn-vm/src/stdlib/agents_sub_agent.rs
@@ -14,6 +14,13 @@ pub(super) struct ParsedSubAgentRequest {
     pub(super) worker_policy: Option<CapabilityPolicy>,
 }
 
+struct SubAgentPolicyResolution {
+    requested_policy: Option<CapabilityPolicy>,
+    worker_policy: Option<CapabilityPolicy>,
+    carry_policy: agents_workers::WorkerCarryPolicy,
+    execution: agents_workers::WorkerExecutionProfile,
+}
+
 fn parse_string_list(value: Option<&VmValue>, label: &str) -> Result<Vec<String>, VmError> {
     let Some(value) = value else {
         return Ok(Vec::new());
@@ -90,32 +97,72 @@ fn request_options(
 }
 
 pub(super) fn parse_sub_agent_request(args: &[VmValue]) -> Result<ParsedSubAgentRequest, VmError> {
+    let request = validate_sub_agent_request_envelope(args)?;
+    let task = request_string_field(&request, "task", None)
+        .ok_or_else(|| VmError::Runtime("sub_agent_run: task is required".to_string()))?;
+    let policies = resolve_sub_agent_policies(&request)?;
+    let session_id = request_string_field(&request, "session_id", None)
+        .unwrap_or_else(|| format!("sub_agent_session_{}", uuid::Uuid::now_v7()));
+    let options =
+        prepare_sub_agent_options(&request, &session_id, policies.requested_policy.as_ref())?;
+
+    Ok(ParsedSubAgentRequest {
+        spec: SubAgentRunSpec {
+            name: request_string_field(&request, "name", Some("sub-agent"))
+                .unwrap_or_else(|| "sub-agent".to_string()),
+            task,
+            system: request_string_field(&request, "system", None),
+            options,
+            returns_schema: sub_agent_returns_schema(&request),
+            session_id,
+            parent_session_id: crate::llm::current_agent_session_id(),
+        },
+        background: matches!(request.get("background"), Some(VmValue::Bool(true))),
+        carry_policy: policies.carry_policy,
+        execution: policies.execution,
+        worker_policy: policies.worker_policy,
+    })
+}
+
+fn validate_sub_agent_request_envelope(
+    args: &[VmValue],
+) -> Result<BTreeMap<String, VmValue>, VmError> {
     let request = match args.first() {
         Some(VmValue::Dict(map)) => map.as_ref().clone(),
-        _ => {
-            return Err(VmError::Runtime(
-                "sub_agent_run: expected a normalized sub_agent_request dict".to_string(),
-            ))
-        }
+        _ => return Err(invalid_sub_agent_request()),
     };
-    if !matches!(
+    if matches!(
         request.get("_type"),
         Some(VmValue::String(kind)) if kind.as_ref() == "sub_agent_request"
     ) {
-        return Err(VmError::Runtime(
-            "sub_agent_run: expected a normalized sub_agent_request dict".to_string(),
-        ));
+        return Ok(request);
     }
-    let task = request_string_field(&request, "task", None)
-        .ok_or_else(|| VmError::Runtime("sub_agent_run: task is required".to_string()))?;
-    let background = matches!(request.get("background"), Some(VmValue::Bool(true)));
+    Err(invalid_sub_agent_request())
+}
+
+fn invalid_sub_agent_request() -> VmError {
+    VmError::Runtime("sub_agent_run: expected a normalized sub_agent_request dict".to_string())
+}
+
+fn resolve_sub_agent_policies(
+    request: &BTreeMap<String, VmValue>,
+) -> Result<SubAgentPolicyResolution, VmError> {
     let allowed_tools =
         parse_string_list(request.get("allowed_tools"), "sub_agent_run.allowed_tools")?;
     let requested_policy = sub_agent_requested_policy(request.get("policy"), &allowed_tools)?;
     let worker_policy = agents_workers::resolve_inherited_worker_policy(requested_policy.clone())?;
-    let carry_policy = agents_workers::parse_worker_carry_policy(&request)?;
+    let carry_policy = agents_workers::parse_worker_carry_policy(request)?;
     let execution = agents_workers::parse_worker_execution_profile(request.get("execution"))?;
-    let returns_schema = request
+    Ok(SubAgentPolicyResolution {
+        requested_policy,
+        worker_policy,
+        carry_policy,
+        execution,
+    })
+}
+
+fn sub_agent_returns_schema(request: &BTreeMap<String, VmValue>) -> Option<VmValue> {
+    request
         .get("returns_schema")
         .filter(|value| !matches!(value, VmValue::Nil))
         .cloned()
@@ -125,53 +172,45 @@ pub(super) fn parse_sub_agent_request(args: &[VmValue]) -> Result<ParsedSubAgent
                 .and_then(|value| value.as_dict())
                 .and_then(|dict| dict.get("schema"))
                 .cloned()
-        });
-    let system = request_string_field(&request, "system", None);
-    let session_id = request_string_field(&request, "session_id", None)
-        .unwrap_or_else(|| format!("sub_agent_session_{}", uuid::Uuid::now_v7()));
+        })
+}
 
-    let mut options = request_options(&request)?;
-    if let Some(context) = crate::orchestration::current_workflow_skill_context() {
-        if !options.contains_key("skills") {
-            if let Some(registry) = context.registry {
-                options.insert("skills".to_string(), registry);
-            }
-        }
-        if !options.contains_key("skill_match") {
-            if let Some(match_config) = context.match_config {
-                options.insert("skill_match".to_string(), match_config);
-            }
-        }
-    }
+fn prepare_sub_agent_options(
+    request: &BTreeMap<String, VmValue>,
+    session_id: &str,
+    requested_policy: Option<&CapabilityPolicy>,
+) -> Result<BTreeMap<String, VmValue>, VmError> {
+    let mut options = request_options(request)?;
+    inject_sub_agent_skill_context(&mut options);
     options.insert(
         "session_id".to_string(),
-        VmValue::String(Rc::from(session_id.clone())),
+        VmValue::String(Rc::from(session_id.to_string())),
     );
     match requested_policy {
         Some(policy) => {
-            options.insert("policy".to_string(), super::to_vm(&policy)?);
+            options.insert("policy".to_string(), super::to_vm(policy)?);
         }
         None => {
             options.remove("policy");
         }
     }
+    Ok(options)
+}
 
-    Ok(ParsedSubAgentRequest {
-        spec: SubAgentRunSpec {
-            name: request_string_field(&request, "name", Some("sub-agent"))
-                .unwrap_or_else(|| "sub-agent".to_string()),
-            task,
-            system,
-            options,
-            returns_schema,
-            session_id,
-            parent_session_id: crate::llm::current_agent_session_id(),
-        },
-        background,
-        carry_policy,
-        execution,
-        worker_policy,
-    })
+fn inject_sub_agent_skill_context(options: &mut BTreeMap<String, VmValue>) {
+    let Some(context) = crate::orchestration::current_workflow_skill_context() else {
+        return;
+    };
+    if !options.contains_key("skills") {
+        if let Some(registry) = context.registry {
+            options.insert("skills".to_string(), registry);
+        }
+    }
+    if !options.contains_key("skill_match") {
+        if let Some(match_config) = context.match_config {
+            options.insert("skill_match".to_string(), match_config);
+        }
+    }
 }
 
 fn sub_agent_error_dict(


### PR DESCRIPTION
## Summary
- Split worker replay reset/carry propagation/spawn responsibilities into small helpers.
- Split sub-agent request parsing into envelope validation, policy resolution, options preparation, and final assembly.
- Kept worker/sub-agent replay behavior unchanged while making the two issue-targeted functions short and focused.

Closes #1571

## Verification
- `CARGO_TARGET_DIR=/tmp/harn-target-7477-1571 cargo check -p harn-vm`
- `CARGO_TARGET_DIR=/tmp/harn-target-7477-1571 cargo run --quiet --bin harn -- test conformance --filter 'sub_agent|worker'`
- `CARGO_TARGET_DIR=/tmp/harn-target-7477-1571 make test`
- pre-commit hook: `cargo fmt`, clippy, generated highlight check
- pre-push hook: targeted local checks, generated highlight check