### PR TITLE
Apply typed agent option shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,11 +44,13 @@ condensed series summaries instead of full per-patch history.
   (`AGENT_SESSION_SEED_OPTS`), `agent_session_compact`
   (`AGENT_SESSION_COMPACT_OPTS`), `agent_session_ancestry`
   (`SESSION_ANCESTRY` return), and `spawn_agent` (`WORKER_SUMMARY`
-  return). Shapes for `AGENT_SPAWN_CONFIG`, `SUB_AGENT_OPTIONS`, and
-  `LLM_CALL_OPTIONS` are defined in
-  `crates/harn-parser/src/builtin_signatures/signatures/shapes.rs` and
-  documented; full enforcement on those slots is deferred until internal
-  callers (`agent_loop`, `agent_turn`) converge on the documented shape.
+  return), `spawn_agent` config (`AGENT_SPAWN_CONFIG`), and
+  `sub_agent_run` / `sub_agent_request` options (`SUB_AGENT_OPTIONS`).
+  Literal worker/sub-agent option bags now reject unknown keys at `harn check`
+  time, so misspelled worker/sub-agent options fail before runtime.
+  `LLM_CALL_OPTIONS` remains defined and documented, with full
+  enforcement deferred until internal callers (`agent_loop`, `agent_turn`)
+  converge on the documented shape.
 
 ### Changed
 

--- a/crates/harn-parser/src/builtin_signatures/signatures/agents.rs
+++ b/crates/harn-parser/src/builtin_signatures/signatures/agents.rs
@@ -1,7 +1,8 @@
 //! Agent / orchestration / sub-agent builtin signatures.
 
 use super::shapes::{
-    AGENT_SESSION_COMPACT_OPTS, AGENT_SESSION_SEED_OPTS, SESSION_ANCESTRY, WORKER_SUMMARY,
+    AGENT_SESSION_COMPACT_OPTS, AGENT_SESSION_SEED_OPTS, AGENT_SPAWN_CONFIG, SESSION_ANCESTRY,
+    SUB_AGENT_OPTIONS, WORKER_SUMMARY,
 };
 use super::{
     BuiltinSignature, Param, Ty, TY_ANY, TY_BOOL, TY_CLOSURE, TY_DICT, TY_DICT_OR_NIL, TY_FLOAT,
@@ -680,24 +681,16 @@ pub(crate) const SIGNATURES: &[BuiltinSignature] = &[
         &[Param::new("answerer", TY_ANY)],
         TY_DICT,
     ),
-    // NOTE: AGENT_SPAWN_CONFIG / SUB_AGENT_OPTIONS shapes exist in
-    // `super::shapes` and are accurate for *user-facing* literal-call sites,
-    // but the runtime checker applies the same type contract to internal
-    // calls that pass dicts with broader runtime types (e.g. `tools` as a
-    // tool_registry dict). Use `TY_DICT` at the parser layer until either:
-    //   1. The runtime check loosens for these slots, or
-    //   2. The internal callers are updated to match the documented shape.
-    // The constants remain authoritative documentation in `shapes.rs`.
     BuiltinSignature::simple(
         "spawn_agent",
-        &[Param::new("config", TY_DICT)],
+        &[Param::new("config", AGENT_SPAWN_CONFIG)],
         WORKER_SUMMARY,
     ),
     BuiltinSignature::simple(
         "sub_agent_run",
         &[
             Param::new("task", TY_STRING),
-            Param::optional("options", TY_DICT),
+            Param::optional("options", SUB_AGENT_OPTIONS),
         ],
         TY_DICT,
     ),
@@ -705,7 +698,7 @@ pub(crate) const SIGNATURES: &[BuiltinSignature] = &[
         "sub_agent_request",
         &[
             Param::new("task", TY_STRING),
-            Param::optional("options", TY_DICT),
+            Param::optional("options", SUB_AGENT_OPTIONS),
         ],
         TY_DICT,
     ),

--- a/crates/harn-parser/src/builtin_signatures/signatures/shapes.rs
+++ b/crates/harn-parser/src/builtin_signatures/signatures/shapes.rs
@@ -27,6 +27,16 @@ use super::{
     TY_NIL, TY_STRING, TY_STRING_OR_NIL,
 };
 
+const TY_BOOL_OR_DICT: Ty = Ty::Union(&[TY_BOOL, TY_DICT]);
+const TY_BOOL_OR_DICT_OR_NIL: Ty = Ty::Union(&[TY_BOOL, TY_DICT, TY_NIL]);
+const TY_INT_OR_FLOAT_OR_DICT: Ty = Ty::Union(&[TY_INT, TY_FLOAT, TY_DICT]);
+const TY_LIST_OR_STRING: Ty = Ty::Union(&[TY_LIST, TY_STRING]);
+const TY_STRING_OR_DICT: Ty = Ty::Union(&[TY_STRING, TY_DICT]);
+const TY_STRING_OR_DICT_OR_BOOL: Ty = Ty::Union(&[TY_STRING, TY_DICT, TY_BOOL]);
+const TY_STRING_OR_DICT_OR_NIL: Ty = Ty::Union(&[TY_STRING, TY_DICT, TY_NIL]);
+const TY_STRING_OR_LIST: Ty = Ty::Union(&[TY_STRING, TY_LIST]);
+const TY_TOOL_REGISTRY_OR_LIST: Ty = Ty::Union(&[TY_LIST, TY_DICT]);
+
 // ---------------------------------------------------------------------------
 // Agent option bags
 // ---------------------------------------------------------------------------
@@ -38,11 +48,6 @@ use super::{
 /// that constraint (would require a sum-of-shapes), but the runtime returns a
 /// clear error.
 ///
-/// **Not yet applied** to the parser signature: the runtime call-site type
-/// check rejects internally-passed dicts whose `tools` field is a
-/// tool_registry-dict (vs the documented `list`). Tracked for adoption once
-/// `agent_loop` / `agent_turn` / `sub_agent_run` converge on this shape.
-#[allow(dead_code)]
 pub(crate) const AGENT_SPAWN_CONFIG: Ty = Ty::Shape(&[
     ShapeFieldDescriptor::new("task", TY_STRING),
     ShapeFieldDescriptor::optional("name", TY_STRING),
@@ -55,43 +60,157 @@ pub(crate) const AGENT_SPAWN_CONFIG: Ty = Ty::Shape(&[
     ShapeFieldDescriptor::optional("options", TY_DICT),
     ShapeFieldDescriptor::optional("execution", TY_DICT),
     ShapeFieldDescriptor::optional("audit", TY_DICT),
-    ShapeFieldDescriptor::optional("artifact_mode", TY_STRING),
-    ShapeFieldDescriptor::optional("transcript_mode", TY_ANY),
-    ShapeFieldDescriptor::optional("context_policy", TY_ANY),
-    ShapeFieldDescriptor::optional("resume_workflow", TY_BOOL),
-    ShapeFieldDescriptor::optional("persist_state", TY_BOOL),
-    ShapeFieldDescriptor::optional("retriggerable", TY_BOOL),
+    ShapeFieldDescriptor::optional("carry", TY_DICT),
     ShapeFieldDescriptor::optional("policy", TY_ANY),
+    ShapeFieldDescriptor::optional("tools", TY_LIST),
 ]);
 
 /// Options dict accepted by `sub_agent_run` / `sub_agent_request` as their
 /// second positional argument. `task` is provided separately as the first
 /// positional arg, so this shape has *all* fields optional.
 ///
-/// Field set mirrors `parse_sub_agent_request` in
-/// `crates/harn-vm/src/stdlib/agents_sub_agent.rs`.
+/// Field set includes the sub-agent controls consumed by
+/// `std/agent/workers.harn` plus the documented `agent_loop` / `llm_call`
+/// options forwarded to the child loop.
 ///
-/// **Not yet applied** to the parser signature for the same reason as
-/// [`AGENT_SPAWN_CONFIG`].
-#[allow(dead_code)]
 pub(crate) const SUB_AGENT_OPTIONS: Ty = Ty::Shape(&[
+    // Request envelope / worker controls.
     ShapeFieldDescriptor::optional("_type", TY_STRING),
     ShapeFieldDescriptor::optional("name", TY_STRING),
     ShapeFieldDescriptor::optional("system", TY_STRING),
     ShapeFieldDescriptor::optional("session_id", TY_STRING),
     ShapeFieldDescriptor::optional("background", TY_BOOL),
+    ShapeFieldDescriptor::optional("carry", TY_DICT),
     ShapeFieldDescriptor::optional("allowed_tools", TY_LIST),
     ShapeFieldDescriptor::optional("policy", TY_ANY),
     ShapeFieldDescriptor::optional("returns_schema", TY_ANY),
     ShapeFieldDescriptor::optional("returns", TY_DICT),
     ShapeFieldDescriptor::optional("execution", TY_DICT),
+    ShapeFieldDescriptor::optional("request", TY_ANY),
+    ShapeFieldDescriptor::optional("research_questions", TY_LIST),
+    ShapeFieldDescriptor::optional("questions", TY_LIST),
+    ShapeFieldDescriptor::optional("action_items", TY_LIST),
+    ShapeFieldDescriptor::optional("actions", TY_LIST),
+    ShapeFieldDescriptor::optional("workflow_stages", TY_LIST),
+    ShapeFieldDescriptor::optional("stages", TY_LIST),
+    ShapeFieldDescriptor::optional("verification_steps", TY_LIST),
+    ShapeFieldDescriptor::optional("verification", TY_LIST),
+    // Provider / LLM-call controls forwarded through agent_loop.
     ShapeFieldDescriptor::optional("model", TY_STRING),
     ShapeFieldDescriptor::optional("provider", TY_STRING),
     ShapeFieldDescriptor::optional("max_tokens", TY_INT),
     ShapeFieldDescriptor::optional("temperature", TY_FLOAT),
-    ShapeFieldDescriptor::optional("tools", TY_LIST),
-    ShapeFieldDescriptor::optional("artifact_mode", TY_STRING),
-    ShapeFieldDescriptor::optional("transcript_mode", TY_ANY),
+    ShapeFieldDescriptor::optional("top_p", TY_FLOAT),
+    ShapeFieldDescriptor::optional("top_k", TY_INT),
+    ShapeFieldDescriptor::optional("stop", TY_STRING_OR_LIST),
+    ShapeFieldDescriptor::optional("seed", TY_INT),
+    ShapeFieldDescriptor::optional("frequency_penalty", TY_FLOAT),
+    ShapeFieldDescriptor::optional("presence_penalty", TY_FLOAT),
+    ShapeFieldDescriptor::optional("response_format", TY_STRING_OR_DICT),
+    ShapeFieldDescriptor::optional("schema", TY_ANY),
+    ShapeFieldDescriptor::optional("schema_retries", TY_INT),
+    ShapeFieldDescriptor::optional("schema_recover", TY_BOOL),
+    ShapeFieldDescriptor::optional("cache", TY_BOOL_OR_DICT),
+    ShapeFieldDescriptor::optional("transcript", TY_ANY),
+    ShapeFieldDescriptor::optional("budget", TY_INT_OR_FLOAT_OR_DICT),
+    ShapeFieldDescriptor::optional("budget_usd", Ty::Union(&[TY_INT, TY_FLOAT])),
+    ShapeFieldDescriptor::optional("mock", TY_ANY),
+    ShapeFieldDescriptor::optional("messages", TY_LIST),
+    ShapeFieldDescriptor::optional("metadata", TY_DICT),
+    ShapeFieldDescriptor::optional("tool_choice", TY_STRING_OR_DICT),
+    ShapeFieldDescriptor::optional("thinking", TY_ANY),
+    ShapeFieldDescriptor::optional("reasoning_effort", TY_STRING),
+    ShapeFieldDescriptor::optional("interleaved_thinking", TY_BOOL),
+    ShapeFieldDescriptor::optional("anthropic_beta_features", TY_LIST),
+    // Agent-loop controls.
+    ShapeFieldDescriptor::optional("profile", TY_STRING),
+    ShapeFieldDescriptor::optional("loop_until_done", TY_BOOL),
+    ShapeFieldDescriptor::optional("done_sentinel", TY_STRING_OR_NIL),
+    ShapeFieldDescriptor::optional("max_iterations", TY_INT),
+    ShapeFieldDescriptor::optional("iteration_budget", TY_STRING_OR_DICT_OR_NIL),
+    ShapeFieldDescriptor::optional("loop_control", TY_ANY),
+    ShapeFieldDescriptor::optional("max_nudges", TY_INT),
+    ShapeFieldDescriptor::optional("nudge", TY_STRING),
+    ShapeFieldDescriptor::optional("llm_caller", TY_ANY),
+    ShapeFieldDescriptor::optional("tool_caller", TY_ANY),
+    ShapeFieldDescriptor::optional("llm_retries", TY_INT),
+    ShapeFieldDescriptor::optional("llm_backoff_ms", TY_INT),
+    ShapeFieldDescriptor::optional("reasoning_policy", TY_ANY),
+    ShapeFieldDescriptor::optional("thinking_policy", TY_ANY),
+    ShapeFieldDescriptor::optional("reasoning_scale", TY_STRING),
+    ShapeFieldDescriptor::optional("problem_scale", TY_STRING),
+    ShapeFieldDescriptor::optional("reasoning_task", TY_STRING),
+    ShapeFieldDescriptor::optional("task_kind", TY_STRING),
+    ShapeFieldDescriptor::optional("tools", TY_TOOL_REGISTRY_OR_LIST),
+    ShapeFieldDescriptor::optional("tool_format", TY_STRING),
+    ShapeFieldDescriptor::optional("native_tool_fallback", TY_STRING),
+    ShapeFieldDescriptor::optional("tool_search", TY_DICT),
+    ShapeFieldDescriptor::optional("tool_retries", TY_INT),
+    ShapeFieldDescriptor::optional("tool_backoff_ms", TY_INT),
+    ShapeFieldDescriptor::optional("stop_after_successful_tools", TY_LIST),
+    ShapeFieldDescriptor::optional("require_successful_tools", TY_LIST),
+    ShapeFieldDescriptor::optional("turn_policy", TY_DICT),
+    ShapeFieldDescriptor::optional("require_action_or_yield", TY_BOOL),
+    ShapeFieldDescriptor::optional("tool_examples", TY_STRING),
+    ShapeFieldDescriptor::optional("shared_types", TY_STRING),
+    ShapeFieldDescriptor::optional("stall_diagnostics", TY_BOOL_OR_DICT_OR_NIL),
+    ShapeFieldDescriptor::optional("permissions", TY_ANY),
+    ShapeFieldDescriptor::optional("approval_policy", TY_ANY),
+    ShapeFieldDescriptor::optional("command_policy", TY_ANY),
+    ShapeFieldDescriptor::optional("autonomy_budget", TY_ANY),
+    ShapeFieldDescriptor::optional("token_budget", TY_INT),
+    ShapeFieldDescriptor::optional("output_format", TY_ANY),
+    ShapeFieldDescriptor::optional("json_schema", TY_ANY),
+    ShapeFieldDescriptor::optional("output_schema", TY_ANY),
+    ShapeFieldDescriptor::optional("root_task", TY_STRING),
+    ShapeFieldDescriptor::optional("deliverables", TY_LIST),
+    ShapeFieldDescriptor::optional("task_ledger", TY_DICT),
+    ShapeFieldDescriptor::optional("persona", TY_STRING),
+    // Daemon / compaction / prompt-context controls.
+    ShapeFieldDescriptor::optional("daemon", TY_BOOL),
+    ShapeFieldDescriptor::optional("persist_path", TY_STRING),
+    ShapeFieldDescriptor::optional("resume_path", TY_STRING),
+    ShapeFieldDescriptor::optional("wake_interval_ms", TY_INT),
+    ShapeFieldDescriptor::optional("watch_paths", TY_LIST_OR_STRING),
+    ShapeFieldDescriptor::optional("consolidate_on_idle", TY_BOOL),
+    ShapeFieldDescriptor::optional("compaction", TY_STRING_OR_DICT_OR_BOOL),
+    ShapeFieldDescriptor::optional("auto_compact", TY_BOOL_OR_DICT),
+    ShapeFieldDescriptor::optional("compact_threshold", TY_INT),
+    ShapeFieldDescriptor::optional("compact_keep_first", TY_INT),
+    ShapeFieldDescriptor::optional("compact_keep_last", TY_INT),
+    ShapeFieldDescriptor::optional("compact_strategy", TY_STRING),
+    ShapeFieldDescriptor::optional("compact_callback", TY_ANY),
+    ShapeFieldDescriptor::optional("idle_watchdog_attempts", TY_INT),
+    ShapeFieldDescriptor::optional("context_callback", TY_ANY),
+    ShapeFieldDescriptor::optional("context_filter", TY_ANY),
+    ShapeFieldDescriptor::optional("timestamp_messages", TY_BOOL),
+    ShapeFieldDescriptor::optional("message_timestamps", TY_BOOL),
+    ShapeFieldDescriptor::optional("message_decorator", TY_ANY),
+    ShapeFieldDescriptor::optional("decorate_message", TY_ANY),
+    ShapeFieldDescriptor::optional("prompts", TY_DICT),
+    ShapeFieldDescriptor::optional("prompt_overrides", TY_DICT),
+    ShapeFieldDescriptor::optional("post_turn_callback", TY_ANY),
+    ShapeFieldDescriptor::optional("verify_completion", TY_ANY),
+    ShapeFieldDescriptor::optional("verify_completion_judge", TY_BOOL_OR_DICT),
+    ShapeFieldDescriptor::optional("done_judge", TY_BOOL_OR_DICT),
+    ShapeFieldDescriptor::optional("max_verify_attempts", TY_INT),
+    ShapeFieldDescriptor::optional("llm_transcript_dir", TY_STRING),
+    ShapeFieldDescriptor::optional("skills", TY_ANY),
+    ShapeFieldDescriptor::optional("skill_registry", TY_ANY),
+    ShapeFieldDescriptor::optional("skill_match", TY_DICT),
+    ShapeFieldDescriptor::optional("skill_catalog_limit", TY_INT),
+    ShapeFieldDescriptor::optional("skill_catalog_budget", TY_INT),
+    ShapeFieldDescriptor::optional("skill_catalog_always", TY_BOOL),
+    ShapeFieldDescriptor::optional("working_files", TY_LIST_OR_STRING),
+    ShapeFieldDescriptor::optional("mcp_servers", TY_LIST),
+    ShapeFieldDescriptor::optional("mcp_initialize_advisory", TY_BOOL),
+    ShapeFieldDescriptor::optional("mcp_context", TY_DICT),
+    ShapeFieldDescriptor::optional("system_preamble", TY_ANY),
+    ShapeFieldDescriptor::optional("system_prefix", TY_ANY),
+    ShapeFieldDescriptor::optional("system_context", TY_ANY),
+    ShapeFieldDescriptor::optional("system_prompt_parts", TY_ANY),
+    ShapeFieldDescriptor::optional("system_appendix", TY_ANY),
+    ShapeFieldDescriptor::optional("system_suffix", TY_ANY),
 ]);
 
 /// Configuration accepted by `daemon_spawn`.
@@ -108,17 +227,23 @@ pub(crate) const DAEMON_CONFIG: Ty = Ty::Shape(&[
     ShapeFieldDescriptor::optional("event_queue_capacity", TY_INT),
     ShapeFieldDescriptor::optional("model", TY_STRING),
     ShapeFieldDescriptor::optional("provider", TY_STRING),
-    ShapeFieldDescriptor::optional("tools", TY_LIST),
+    ShapeFieldDescriptor::optional("max_iterations", TY_INT),
+    ShapeFieldDescriptor::optional("tools", TY_TOOL_REGISTRY_OR_LIST),
+    ShapeFieldDescriptor::optional("wake_interval_ms", TY_INT),
+    ShapeFieldDescriptor::optional("watch_paths", TY_LIST_OR_STRING),
+    ShapeFieldDescriptor::optional("consolidate_on_idle", TY_BOOL),
+    ShapeFieldDescriptor::optional("idle_watchdog_attempts", TY_INT),
     ShapeFieldDescriptor::optional("options", TY_DICT),
 ]);
 
 /// `agent_session_seed_from_jsonl` `opts?` argument.
 pub(crate) const AGENT_SESSION_SEED_OPTS: Ty = Ty::Shape(&[
-    ShapeFieldDescriptor::optional("id", TY_STRING),
-    ShapeFieldDescriptor::optional("model", TY_STRING),
+    ShapeFieldDescriptor::optional("truncate_to_last", TY_INT),
+    ShapeFieldDescriptor::optional("drop_tool_calls", TY_BOOL),
+    ShapeFieldDescriptor::optional("rename_session", TY_STRING),
+    ShapeFieldDescriptor::optional("validate", TY_BOOL),
     ShapeFieldDescriptor::optional("provider", TY_STRING),
-    ShapeFieldDescriptor::optional("system", TY_STRING),
-    ShapeFieldDescriptor::optional("tool_format", TY_STRING),
+    ShapeFieldDescriptor::optional("model", TY_STRING),
 ]);
 
 /// `agent_session_compact` `opts?` argument.

--- a/crates/harn-parser/src/typechecker/inference/calls.rs
+++ b/crates/harn-parser/src/typechecker/inference/calls.rs
@@ -47,6 +47,79 @@ impl TypeChecker {
         Some((entry.0.as_str(), entry.1.as_ref()))
     }
 
+    fn single_shape_fields(ty: &TypeExpr) -> Option<&[ShapeField]> {
+        match ty {
+            TypeExpr::Shape(fields) => Some(fields),
+            TypeExpr::Union(members) => {
+                let mut shape = None;
+                for member in members {
+                    match member {
+                        TypeExpr::Named(name) if name == "nil" => {}
+                        TypeExpr::Shape(fields) if shape.is_none() => {
+                            shape = Some(fields.as_slice())
+                        }
+                        TypeExpr::Shape(_) => return None,
+                        _ => return None,
+                    }
+                }
+                shape
+            }
+            _ => None,
+        }
+    }
+
+    fn check_builtin_literal_shape_keys(
+        &mut self,
+        builtin_name: &str,
+        param_name: &str,
+        expected: &TypeExpr,
+        arg: &SNode,
+    ) {
+        // Structural shapes remain width-subtyped elsewhere. These option bags
+        // are closed user-facing surfaces where a misspelled literal key is
+        // almost certainly a bug.
+        if !matches!(
+            (builtin_name, param_name),
+            ("spawn_agent", "config")
+                | ("sub_agent_run", "options")
+                | ("sub_agent_request", "options")
+        ) {
+            return;
+        }
+        let Some(expected_fields) = Self::single_shape_fields(expected) else {
+            return;
+        };
+        let Node::DictLiteral(entries) = &arg.node else {
+            return;
+        };
+        let known_fields = expected_fields
+            .iter()
+            .map(|field| field.name.as_str())
+            .collect::<Vec<_>>();
+        for entry in entries {
+            let key = match &entry.key.node {
+                Node::StringLiteral(key) | Node::RawStringLiteral(key) | Node::Identifier(key) => {
+                    key
+                }
+                _ => continue,
+            };
+            if known_fields.iter().any(|field| field == key) {
+                continue;
+            }
+            let max_dist = if key.len() <= 4 { 1 } else { 2 };
+            let suggestion =
+                crate::diagnostic::find_closest_match(key, known_fields.iter().copied(), max_dist);
+            let mut message = format!(
+                "argument `{param_name}` for builtin `{builtin_name}` has unknown option key `{key}`"
+            );
+            if let Some(close) = suggestion {
+                message.push_str(&format!(" — did you mean `{close}`?"));
+            }
+            let help = format!("available option keys: {}", known_fields.join(", "));
+            self.error_at_with_help(message, entry.key.span, help);
+        }
+    }
+
     /// Collapse the field types of a shape into a single value type. Used when
     /// binding `dict<string, V>` against a heterogeneous shape literal — V is
     /// the union of every field type, simplified so a homogeneous shape stays
@@ -206,6 +279,7 @@ impl TypeChecker {
                         &call_scope,
                     );
                 }
+                self.check_builtin_literal_shape_keys(name, param.name, &expected, arg);
             }
         }
 

--- a/crates/harn-parser/src/typechecker/tests/strict_types.rs
+++ b/crates/harn-parser/src/typechecker/tests/strict_types.rs
@@ -279,6 +279,53 @@ fn test_renamed_stdlib_call_suggests_replacement() {
 }
 
 #[test]
+fn test_spawn_agent_literal_config_rejects_unknown_option_key() {
+    let errs = errors(
+        r#"pipeline t(task) {
+  spawn_agent({
+    task: "do it",
+    node: {kind: "stage"},
+    persmissions: {}
+  })
+}"#,
+    );
+    assert!(
+        errs.iter()
+            .any(|m| m.contains("unknown option key `persmissions`")
+                && m.contains("did you mean `permissions`")),
+        "expected spawn_agent option-key typo error, got: {errs:?}"
+    );
+}
+
+#[test]
+fn test_sub_agent_run_literal_options_rejects_unknown_option_key() {
+    let errs = errors(
+        r#"pipeline t(task) {
+  sub_agent_run("do it", {provider: "mock", backgroun: true})
+}"#,
+    );
+    assert!(
+        errs.iter()
+            .any(|m| m.contains("unknown option key `backgroun`")
+                && m.contains("did you mean `background`")),
+        "expected sub_agent_run option-key typo error, got: {errs:?}"
+    );
+}
+
+#[test]
+fn test_sub_agent_request_accepts_registry_tools_shape() {
+    let errs = errors(
+        r#"pipeline t(task) {
+  sub_agent_request("do it", {provider: "mock", tools: tool_registry()})
+}"#,
+    );
+    assert!(
+        errs.is_empty(),
+        "sub_agent_request should accept a tool registry dict in options.tools, got: {errs:?}"
+    );
+}
+
+#[test]
 fn test_cross_module_local_fn_not_flagged() {
     let diags = check_source_with_imports(
         r#"fn local_fn() { 42 }

--- a/docs/src/cookbook.md
+++ b/docs/src/cookbook.md
@@ -610,11 +610,21 @@ parallel.
 
 ```harn
 // Spawn workers and collect results
-let agents = ["research", "analyze", "summarize"]
-let results = parallel each agents { role ->
-  let agent = spawn_agent({name: role, system: "You are a ${role} agent."})
-  send_input(agent, task)
-  wait_agent(agent)
+pipeline default(task) {
+  let roles = ["research", "analyze", "summarize"]
+  let _results = parallel each roles { role ->
+    let agent = spawn_agent({
+      name: role,
+      task: "Handle ${role}: ${task}",
+      node: {
+        kind: "subagent",
+        mode: "llm",
+        model_policy: {provider: "mock"},
+        output_contract: {output_kinds: ["summary"]},
+      },
+    })
+    wait_agent(agent)
+  }
 }
 ```
 


### PR DESCRIPTION
## Summary
- Wire `AGENT_SPAWN_CONFIG` into `spawn_agent` and `SUB_AGENT_OPTIONS` into `sub_agent_run` / `sub_agent_request`.
- Add literal option-key checking for those closed worker/sub-agent option bags, including did-you-mean help for typos.
- Widen/polish the agent option shapes for runtime-forwarded options, tool registry dicts, daemon options, and session JSONL seed options.
- Update the cookbook multi-agent snippet to use the real typed `spawn_agent` contract.

Fixes #1566

## Verification
- `cargo test -p harn-parser typechecker::tests::strict_types -- --nocapture`
- `cargo test -p harn-parser`
- `cargo run --quiet --bin harn -- test conformance` (1006 passed, 0 failed, 0 skipped)
- `make lint-test-patterns`
- `make check-docs-snippets`
- `make lint-md`
- pre-commit hook: `cargo fmt`, workspace clippy `-D warnings`, markdown lint
- pre-push hook: targeted parser checks, markdown lint, changelog check
