### PR TITLE
Migrate stdlib option parsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ condensed series summaries instead of full per-patch history.
   Migration: rename the keys in your `daemon_spawn({...})` calls. No
   in-repo callers used the deprecated aliases; this only affects external
   scripts.
+- **Strict option-bag parsing for remaining stdlib agent/IO configs (#1568).**
+  `spawn_agent`, `sub_agent_run`'s normalized host request, worker carry
+  policy bags, worker snapshots, and `std/io.read_line` now reject unknown
+  closed-schema option keys instead of silently ignoring typos.
 
 ### Added
 

--- a/crates/harn-vm/src/stdlib/agents_sub_agent.rs
+++ b/crates/harn-vm/src/stdlib/agents_sub_agent.rs
@@ -4,7 +4,10 @@ use std::rc::Rc;
 use super::agents_workers;
 use super::{SubAgentExecutionResult, SubAgentRunSpec};
 use crate::orchestration::CapabilityPolicy;
+use crate::stdlib::options::{ErrorKind, OptionsParser};
 use crate::value::{VmError, VmValue};
+
+const SUB_AGENT_RUN_FN: &str = "sub_agent_run";
 
 pub(super) struct ParsedSubAgentRequest {
     pub(super) spec: SubAgentRunSpec,
@@ -53,7 +56,7 @@ fn sub_agent_requested_policy(
         .filter(|value| !matches!(value, VmValue::Nil))
         .map(|value| serde_json::from_value(crate::llm::vm_value_to_json(value)))
         .transpose()
-        .map_err(|e| VmError::Runtime(format!("sub_agent_run: policy parse error: {e}")))?;
+        .map_err(|e| VmError::Runtime(format!("{SUB_AGENT_RUN_FN}: policy parse error: {e}")))?;
     let tool_policy = if allowed_tools.is_empty() {
         None
     } else {
@@ -73,51 +76,40 @@ fn sub_agent_requested_policy(
     }
 }
 
-fn request_string_field(
-    request: &BTreeMap<String, VmValue>,
-    key: &str,
-    fallback: Option<&str>,
-) -> Option<String> {
-    request.get(key).and_then(|value| match value {
-        VmValue::String(text) if !text.trim().is_empty() => Some(text.to_string()),
-        _ => fallback.map(str::to_string),
-    })
-}
-
-fn request_options(
-    request: &BTreeMap<String, VmValue>,
-) -> Result<BTreeMap<String, VmValue>, VmError> {
-    match request.get("options") {
-        Some(VmValue::Dict(options)) => Ok(options.as_ref().clone()),
-        Some(VmValue::Nil) | None => Ok(BTreeMap::new()),
-        Some(_) => Err(VmError::Runtime(
-            "sub_agent_run: request.options must be a dict".to_string(),
-        )),
-    }
+fn non_empty_raw_string(value: Option<String>) -> Option<String> {
+    value.filter(|text| !text.trim().is_empty())
 }
 
 pub(super) fn parse_sub_agent_request(args: &[VmValue]) -> Result<ParsedSubAgentRequest, VmError> {
     let request = validate_sub_agent_request_envelope(args)?;
-    let task = request_string_field(&request, "task", None)
-        .ok_or_else(|| VmError::Runtime("sub_agent_run: task is required".to_string()))?;
-    let policies = resolve_sub_agent_policies(&request)?;
-    let session_id = request_string_field(&request, "session_id", None)
+    let mut parser = OptionsParser::new(SUB_AGENT_RUN_FN, request, ErrorKind::Runtime);
+    if parser.optional_string_raw("_type")?.as_deref() != Some("sub_agent_request") {
+        return Err(invalid_sub_agent_request());
+    }
+    let task = parser.required_string("task")?;
+    let background = parser.bool_or("background", false)?;
+    let policies = resolve_sub_agent_policies(request, &mut parser)?;
+    let returns_schema = sub_agent_returns_schema(&mut parser)?;
+    let system = non_empty_raw_string(parser.optional_string_raw("system")?);
+    let session_id = non_empty_raw_string(parser.optional_string_raw("session_id")?)
         .unwrap_or_else(|| format!("sub_agent_session_{}", uuid::Uuid::now_v7()));
     let options =
-        prepare_sub_agent_options(&request, &session_id, policies.requested_policy.as_ref())?;
+        prepare_sub_agent_options(&mut parser, &session_id, policies.requested_policy.as_ref())?;
+    let name = non_empty_raw_string(parser.optional_string_raw("name")?)
+        .unwrap_or_else(|| "sub-agent".to_string());
+    parser.finish_strict(&[])?;
 
     Ok(ParsedSubAgentRequest {
         spec: SubAgentRunSpec {
-            name: request_string_field(&request, "name", Some("sub-agent"))
-                .unwrap_or_else(|| "sub-agent".to_string()),
+            name,
             task,
-            system: request_string_field(&request, "system", None),
+            system,
             options,
-            returns_schema: sub_agent_returns_schema(&request),
+            returns_schema,
             session_id,
             parent_session_id: crate::llm::current_agent_session_id(),
         },
-        background: matches!(request.get("background"), Some(VmValue::Bool(true))),
+        background,
         carry_policy: policies.carry_policy,
         execution: policies.execution,
         worker_policy: policies.worker_policy,
@@ -126,33 +118,30 @@ pub(super) fn parse_sub_agent_request(args: &[VmValue]) -> Result<ParsedSubAgent
 
 fn validate_sub_agent_request_envelope(
     args: &[VmValue],
-) -> Result<BTreeMap<String, VmValue>, VmError> {
-    let request = match args.first() {
-        Some(VmValue::Dict(map)) => map.as_ref().clone(),
-        _ => return Err(invalid_sub_agent_request()),
-    };
-    if matches!(
-        request.get("_type"),
-        Some(VmValue::String(kind)) if kind.as_ref() == "sub_agent_request"
-    ) {
-        return Ok(request);
+) -> Result<&BTreeMap<String, VmValue>, VmError> {
+    match args.first() {
+        Some(VmValue::Dict(map)) => Ok(map.as_ref()),
+        _ => Err(invalid_sub_agent_request()),
     }
-    Err(invalid_sub_agent_request())
 }
 
 fn invalid_sub_agent_request() -> VmError {
-    VmError::Runtime("sub_agent_run: expected a normalized sub_agent_request dict".to_string())
+    VmError::Runtime(format!(
+        "{SUB_AGENT_RUN_FN}: expected a normalized sub_agent_request dict"
+    ))
 }
 
 fn resolve_sub_agent_policies(
     request: &BTreeMap<String, VmValue>,
+    parser: &mut OptionsParser<'_>,
 ) -> Result<SubAgentPolicyResolution, VmError> {
     let allowed_tools =
-        parse_string_list(request.get("allowed_tools"), "sub_agent_run.allowed_tools")?;
-    let requested_policy = sub_agent_requested_policy(request.get("policy"), &allowed_tools)?;
+        parse_string_list(parser.raw("allowed_tools"), "sub_agent_run.allowed_tools")?;
+    let requested_policy = sub_agent_requested_policy(parser.raw("policy"), &allowed_tools)?;
     let worker_policy = agents_workers::resolve_inherited_worker_policy(requested_policy.clone())?;
+    parser.allow("carry");
     let carry_policy = agents_workers::parse_worker_carry_policy(request)?;
-    let execution = agents_workers::parse_worker_execution_profile(request.get("execution"))?;
+    let execution = agents_workers::parse_worker_execution_profile(parser.raw("execution"))?;
     Ok(SubAgentPolicyResolution {
         requested_policy,
         worker_policy,
@@ -161,26 +150,24 @@ fn resolve_sub_agent_policies(
     })
 }
 
-fn sub_agent_returns_schema(request: &BTreeMap<String, VmValue>) -> Option<VmValue> {
-    request
-        .get("returns_schema")
+fn sub_agent_returns_schema(parser: &mut OptionsParser<'_>) -> Result<Option<VmValue>, VmError> {
+    let returns_schema_value = parser
+        .raw("returns_schema")
         .filter(|value| !matches!(value, VmValue::Nil))
-        .cloned()
-        .or_else(|| {
-            request
-                .get("returns")
-                .and_then(|value| value.as_dict())
-                .and_then(|dict| dict.get("schema"))
-                .cloned()
-        })
+        .cloned();
+    let returns = parser.optional_dict("returns")?;
+    Ok(returns_schema_value.or_else(|| returns.and_then(|dict| dict.get("schema")).cloned()))
 }
 
 fn prepare_sub_agent_options(
-    request: &BTreeMap<String, VmValue>,
+    parser: &mut OptionsParser<'_>,
     session_id: &str,
     requested_policy: Option<&CapabilityPolicy>,
 ) -> Result<BTreeMap<String, VmValue>, VmError> {
-    let mut options = request_options(request)?;
+    let mut options = parser
+        .optional_dict("options")?
+        .cloned()
+        .unwrap_or_default();
     inject_sub_agent_skill_context(&mut options);
     options.insert(
         "session_id".to_string(),
@@ -825,6 +812,47 @@ mod tests {
             ("role".to_string(), VmValue::String(Rc::from("assistant"))),
             ("content".to_string(), VmValue::String(Rc::from(text))),
         ])))
+    }
+
+    fn normalized_request(extra: Vec<(&str, VmValue)>) -> VmValue {
+        let mut request = BTreeMap::from([
+            (
+                "_type".to_string(),
+                VmValue::String(Rc::from("sub_agent_request")),
+            ),
+            ("task".to_string(), VmValue::String(Rc::from("summarize"))),
+        ]);
+        for (key, value) in extra {
+            request.insert(key.to_string(), value);
+        }
+        VmValue::Dict(Rc::new(request))
+    }
+
+    #[test]
+    fn parse_sub_agent_request_rejects_unknown_top_level_options() {
+        let request = normalized_request(vec![("backgrund", VmValue::Bool(true))]);
+
+        let err = match parse_sub_agent_request(&[request]) {
+            Ok(_) => panic!("expected unknown option failure"),
+            Err(err) => err,
+        };
+
+        match err {
+            VmError::Runtime(message) => assert!(message.contains("backgrund"), "got: {message}"),
+            other => panic!("expected Runtime error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_sub_agent_request_preserves_session_id_whitespace() {
+        let request = normalized_request(vec![(
+            "session_id",
+            VmValue::String(Rc::from("  child-session  ")),
+        )]);
+
+        let parsed = parse_sub_agent_request(&[request]).unwrap();
+
+        assert_eq!(parsed.spec.session_id, "  child-session  ");
     }
 
     #[test]

--- a/crates/harn-vm/src/stdlib/agents_workers/config.rs
+++ b/crates/harn-vm/src/stdlib/agents_workers/config.rs
@@ -16,7 +16,11 @@ use super::{
     WorkerState,
 };
 use crate::orchestration::{ArtifactRecord, MutationSessionRecord, WorkflowGraph};
+use crate::stdlib::options::{ErrorKind, OptionsParser};
 use crate::value::{VmError, VmValue};
+
+const SPAWN_AGENT_FN: &str = "spawn_agent";
+const WORKER_SNAPSHOT_CONFIG: &str = "worker snapshot config";
 
 fn worker_config_to_json(config: &WorkerConfig) -> serde_json::Value {
     match config {
@@ -112,12 +116,21 @@ fn sub_agent_spec_from_json(value: &serde_json::Value) -> Result<SubAgentRunSpec
 }
 
 fn worker_config_from_json(value: &serde_json::Value) -> Result<WorkerConfig, VmError> {
-    let mode = value
-        .get("mode")
-        .and_then(|mode| mode.as_str())
+    let parser_dict = value
+        .as_object()
+        .map(|object| {
+            object
+                .iter()
+                .map(|(key, value)| (key.clone(), crate::stdlib::json_to_vm_value(value)))
+                .collect::<BTreeMap<_, _>>()
+        })
         .unwrap_or_default();
-    match mode {
+    let mut parser = OptionsParser::new(WORKER_SNAPSHOT_CONFIG, &parser_dict, ErrorKind::Runtime);
+    let mode = parser.optional_string_raw("mode")?.unwrap_or_default();
+    match mode.as_str() {
         "workflow" => {
+            parser.allow("graph");
+            parser.allow("artifacts");
             let graph: WorkflowGraph = serde_json::from_value(
                 value.get("graph").cloned().unwrap_or_default(),
             )
@@ -127,16 +140,11 @@ fn worker_config_from_json(value: &serde_json::Value) -> Result<WorkerConfig, Vm
                     .map_err(|e| {
                         VmError::Runtime(format!("worker snapshot artifacts parse error: {e}"))
                     })?;
-            let options = value
-                .get("options")
-                .and_then(|options| options.as_object())
-                .map(|options| {
-                    options
-                        .iter()
-                        .map(|(key, value)| (key.clone(), crate::stdlib::json_to_vm_value(value)))
-                        .collect::<BTreeMap<_, _>>()
-                })
+            let options = parser
+                .optional_dict("options")?
+                .cloned()
                 .unwrap_or_default();
+            parser.finish_strict(&[])?;
             Ok(WorkerConfig::Workflow {
                 graph: Box::new(graph),
                 artifacts,
@@ -144,6 +152,9 @@ fn worker_config_from_json(value: &serde_json::Value) -> Result<WorkerConfig, Vm
             })
         }
         "stage" => {
+            parser.allow("node");
+            parser.allow("artifacts");
+            parser.allow("transcript");
             let node = crate::orchestration::parse_workflow_node_json(
                 value.get("node").cloned().unwrap_or_default(),
                 "worker snapshot node",
@@ -154,6 +165,7 @@ fn worker_config_from_json(value: &serde_json::Value) -> Result<WorkerConfig, Vm
                         VmError::Runtime(format!("worker snapshot artifacts parse error: {e}"))
                     })?;
             let transcript = value.get("transcript").map(crate::stdlib::json_to_vm_value);
+            parser.finish_strict(&[])?;
             Ok(WorkerConfig::Stage {
                 node: Box::new(node),
                 artifacts,
@@ -161,11 +173,13 @@ fn worker_config_from_json(value: &serde_json::Value) -> Result<WorkerConfig, Vm
             })
         }
         "sub_agent" => {
+            parser.allow("spec");
             let spec =
                 sub_agent_spec_from_json(value.get("spec").unwrap_or(&serde_json::Value::Null))
                     .map_err(|e| {
                         VmError::Runtime(format!("worker snapshot sub-agent parse error: {e}"))
                     })?;
+            parser.finish_strict(&[])?;
             Ok(WorkerConfig::SubAgent {
                 spec: Box::new(spec),
             })
@@ -398,70 +412,70 @@ pub(super) fn parse_execution_profile_json(
 pub(in super::super) fn parse_worker_config(value: &VmValue) -> Result<WorkerInit, VmError> {
     let dict = value
         .as_dict()
-        .ok_or_else(|| VmError::Runtime("spawn_agent: config must be a dict".to_string()))?;
-    let task = dict
-        .get("task")
-        .map(|value| value.display())
-        .filter(|value| !value.is_empty())
-        .ok_or_else(|| VmError::Runtime("spawn_agent: config.task is required".to_string()))?;
-    let name = dict
-        .get("name")
-        .map(|value| value.display())
+        .ok_or_else(|| VmError::Runtime(format!("{SPAWN_AGENT_FN}: config must be a dict")))?;
+    let mut parser = OptionsParser::new(SPAWN_AGENT_FN, dict, ErrorKind::Runtime);
+    let task = parser.required_string("task")?;
+    let name = parser
+        .optional_string_raw("name")?
         .filter(|value| !value.is_empty())
         .unwrap_or_else(|| "worker".to_string());
-    let wait = matches!(dict.get("wait"), Some(VmValue::Bool(true)));
+    let wait = parser.bool_or("wait", false)?;
+    parser.allow("carry");
+    parser.allow("policy");
+    parser.allow("tools");
+    parser.allow("audit");
     let mut carry_policy = parse_worker_carry_policy(dict)?;
     carry_policy.policy = resolve_worker_policy(dict)?;
-    let execution = parse_worker_execution_profile(dict.get("execution"))?;
+    let execution = parse_worker_execution_profile(parser.raw("execution"))?;
     let audit = parse_worker_audit(dict)?;
+    let graph_value = parser.raw("graph");
+    let node_value = parser.raw("node");
+    let artifacts_value = parser.raw("artifacts");
+    let permissions = parser.raw("permissions").cloned();
+    let transcript = parser.raw("transcript").cloned();
+    let options = parser
+        .optional_dict("options")?
+        .cloned()
+        .unwrap_or_default();
 
-    if let Some(graph_value) = dict.get("graph") {
+    let config = if let Some(graph_value) = graph_value {
         let graph = crate::orchestration::normalize_workflow_value(graph_value)?;
-        let artifacts = parse_artifact_list(dict.get("artifacts"))?;
-        let options = dict
-            .get("options")
-            .and_then(|value| value.as_dict())
-            .cloned()
-            .unwrap_or_default();
-        return Ok(WorkerInit {
-            name,
-            task,
-            config: WorkerConfig::Workflow {
-                graph: Box::new(graph),
-                artifacts,
-                options,
-            },
-            wait,
-            carry_policy,
-            execution,
-            audit,
-        });
-    }
-
-    let node_value = dict.get("node").ok_or_else(|| {
-        VmError::Runtime("spawn_agent: config requires either graph or node".to_string())
-    })?;
-    let mut node = crate::orchestration::parse_workflow_node_value(node_value, "spawn_agent node")?;
-    if let Some(permissions) = dict.get("permissions").cloned() {
-        let mut raw_model_policy = node
-            .raw_model_policy
-            .as_ref()
-            .and_then(|value| value.as_dict())
-            .cloned()
-            .unwrap_or_default();
-        raw_model_policy.insert("permissions".to_string(), permissions);
-        node.raw_model_policy = Some(VmValue::Dict(Rc::new(raw_model_policy)));
-    }
-    let artifacts = parse_artifact_list(dict.get("artifacts"))?;
-    let transcript = dict.get("transcript").cloned();
-    Ok(WorkerInit {
-        name,
-        task,
-        config: WorkerConfig::Stage {
+        let artifacts = parse_artifact_list(artifacts_value)?;
+        WorkerConfig::Workflow {
+            graph: Box::new(graph),
+            artifacts,
+            options,
+        }
+    } else {
+        let node_value = node_value.ok_or_else(|| {
+            VmError::Runtime(format!(
+                "{SPAWN_AGENT_FN}: config requires either graph or node"
+            ))
+        })?;
+        let mut node =
+            crate::orchestration::parse_workflow_node_value(node_value, "spawn_agent node")?;
+        if let Some(permissions) = permissions {
+            let mut raw_model_policy = node
+                .raw_model_policy
+                .as_ref()
+                .and_then(|value| value.as_dict())
+                .cloned()
+                .unwrap_or_default();
+            raw_model_policy.insert("permissions".to_string(), permissions);
+            node.raw_model_policy = Some(VmValue::Dict(Rc::new(raw_model_policy)));
+        }
+        let artifacts = parse_artifact_list(artifacts_value)?;
+        WorkerConfig::Stage {
             node: Box::new(node),
             artifacts,
             transcript,
-        },
+        }
+    };
+    parser.finish_strict(&[])?;
+    Ok(WorkerInit {
+        name,
+        task,
+        config,
         wait,
         carry_policy,
         execution,

--- a/crates/harn-vm/src/stdlib/agents_workers/policy.rs
+++ b/crates/harn-vm/src/stdlib/agents_workers/policy.rs
@@ -3,41 +3,72 @@ use std::collections::BTreeMap;
 use super::super::parse_context_policy;
 use super::WorkerCarryPolicy;
 use crate::orchestration::{select_artifacts, ArtifactRecord, CapabilityPolicy, ContextPolicy};
+use crate::stdlib::options::{ErrorKind, OptionsParser};
 use crate::value::{VmError, VmValue};
+
+const SPAWN_AGENT_FN: &str = "spawn_agent";
+
+fn default_worker_carry_policy() -> WorkerCarryPolicy {
+    WorkerCarryPolicy {
+        artifact_mode: "inherit".to_string(),
+        transcript_mode: "inherit".to_string(),
+        context_policy: ContextPolicy::default(),
+        resume_workflow: true,
+        persist_state: true,
+        retriggerable: false,
+        policy: None,
+    }
+}
+
+fn display_non_empty(value: Option<&VmValue>) -> Option<String> {
+    match value {
+        None | Some(VmValue::Nil) => None,
+        Some(value) => {
+            let rendered = value.display();
+            if rendered.is_empty() {
+                None
+            } else {
+                Some(rendered)
+            }
+        }
+    }
+}
 
 pub(in crate::stdlib::agents) fn parse_worker_carry_policy(
     dict: &BTreeMap<String, VmValue>,
 ) -> Result<WorkerCarryPolicy, VmError> {
-    let carry = dict
-        .get("carry")
-        .and_then(|value| value.as_dict())
-        .cloned()
-        .unwrap_or_default();
-    let artifact_mode = carry
-        .get("artifact_mode")
-        .or_else(|| carry.get("artifacts"))
-        .map(|value| value.display())
-        .filter(|value| !value.is_empty())
+    let mut parent = OptionsParser::new(SPAWN_AGENT_FN, dict, ErrorKind::Runtime);
+    let Some(carry) = parent.optional_dict("carry")? else {
+        return Ok(default_worker_carry_policy());
+    };
+
+    let mut parser = OptionsParser::new(SPAWN_AGENT_FN, carry, ErrorKind::Runtime);
+    let artifacts_alias = parser.raw("artifacts");
+    let transcript_alias = parser.raw("transcript");
+    let context_policy_value = parser.raw("context_policy");
+    let artifact_mode = display_non_empty(parser.raw("artifact_mode").or(artifacts_alias))
         .unwrap_or_else(|| "inherit".to_string());
-    let transcript_mode = carry
-        .get("transcript_mode")
-        .or_else(|| carry.get("transcript"))
+    let transcript_mode = parser
+        .raw("transcript_mode")
+        .or(transcript_alias)
         .map(parse_transcript_mode)
         .transpose()?
         .unwrap_or_else(|| "inherit".to_string());
-    let context_policy = parse_context_policy(carry.get("context_policy").or_else(|| {
-        carry
-            .get("artifacts")
-            .filter(|value| value.as_dict().is_some())
-    }))?;
+    let context_policy = parse_context_policy(
+        context_policy_value.or_else(|| artifacts_alias.filter(|value| value.as_dict().is_some())),
+    )?;
+    let resume_workflow = parser.bool_or("resume_workflow", true)?;
+    let persist_state = parser.bool_or("persist_state", true)?;
+    let retriggerable = parser.bool_or("retriggerable", false)?;
+    parser.finish_strict(&["policy", "tools"])?;
 
     Ok(WorkerCarryPolicy {
         artifact_mode,
         transcript_mode,
         context_policy,
-        resume_workflow: !matches!(carry.get("resume_workflow"), Some(VmValue::Bool(false))),
-        persist_state: !matches!(carry.get("persist_state"), Some(VmValue::Bool(false))),
-        retriggerable: matches!(carry.get("retriggerable"), Some(VmValue::Bool(true))),
+        resume_workflow,
+        persist_state,
+        retriggerable,
         policy: None,
     })
 }
@@ -56,7 +87,7 @@ pub(super) fn parse_transcript_mode(value: &VmValue) -> Result<String, VmError> 
     match mode.as_str() {
         "inherit" | "fork" | "reset" | "compact" => Ok(mode),
         _ => Err(VmError::Runtime(format!(
-            "spawn_agent: carry.transcript_mode must be one of inherit, fork, reset, compact; got `{mode}`"
+            "{SPAWN_AGENT_FN}: carry.transcript_mode must be one of inherit, fork, reset, compact; got `{mode}`"
         ))),
     }
 }
@@ -64,7 +95,7 @@ pub(super) fn parse_transcript_mode(value: &VmValue) -> Result<String, VmError> 
 pub(super) fn parse_worker_policy_value(value: &VmValue) -> Result<CapabilityPolicy, VmError> {
     let json = crate::llm::helpers::vm_value_to_json(value);
     serde_json::from_value(json)
-        .map_err(|e| VmError::Runtime(format!("spawn_agent: policy parse error: {e}")))
+        .map_err(|e| VmError::Runtime(format!("{SPAWN_AGENT_FN}: policy parse error: {e}")))
 }
 
 pub(super) fn worker_policy_value(value: Option<&VmValue>) -> Option<&VmValue> {
@@ -78,9 +109,9 @@ fn parse_worker_tools_policy(value: Option<&VmValue>) -> Result<Option<Capabilit
     let tools = match value {
         VmValue::List(list) => list,
         _ => {
-            return Err(VmError::Runtime(
-                "spawn_agent: tools shorthand must be a list of strings".to_string(),
-            ))
+            return Err(VmError::Runtime(format!(
+                "{SPAWN_AGENT_FN}: tools shorthand must be a list of strings"
+            )))
         }
     };
     let mut allowed = Vec::new();
@@ -88,9 +119,9 @@ fn parse_worker_tools_policy(value: Option<&VmValue>) -> Result<Option<Capabilit
         let name = match tool {
             VmValue::String(text) => text.trim().to_string(),
             _ => {
-                return Err(VmError::Runtime(
-                    "spawn_agent: tools shorthand must be a list of strings".to_string(),
-                ))
+                return Err(VmError::Runtime(format!(
+                    "{SPAWN_AGENT_FN}: tools shorthand must be a list of strings"
+                )))
             }
         };
         if !name.is_empty() && !allowed.contains(&name) {
@@ -98,9 +129,9 @@ fn parse_worker_tools_policy(value: Option<&VmValue>) -> Result<Option<Capabilit
         }
     }
     if allowed.is_empty() {
-        return Err(VmError::Runtime(
-            "spawn_agent: tools shorthand must include at least one tool name".to_string(),
-        ));
+        return Err(VmError::Runtime(format!(
+            "{SPAWN_AGENT_FN}: tools shorthand must include at least one tool name"
+        )));
     }
     Ok(Some(CapabilityPolicy {
         tools: allowed,
@@ -127,7 +158,7 @@ pub(super) fn resolve_worker_policy(
         (Some(policy), Some(tool_policy)) => Some(
             policy
                 .intersect(&tool_policy)
-                .map_err(|e| VmError::Runtime(format!("spawn_agent: {e}")))?,
+                .map_err(|e| VmError::Runtime(format!("{SPAWN_AGENT_FN}: {e}")))?,
         ),
         (Some(policy), None) => Some(policy),
         (None, Some(tool_policy)) => Some(tool_policy),
@@ -143,7 +174,7 @@ pub(in super::super) fn resolve_inherited_worker_policy(
     match (parent, requested) {
         (Some(parent), Some(requested)) => {
             Ok(Some(parent.intersect(&requested).map_err(|e| {
-                VmError::Runtime(format!("spawn_agent: {e}"))
+                VmError::Runtime(format!("{SPAWN_AGENT_FN}: {e}"))
             })?))
         }
         (Some(parent), None) => Ok(Some(parent)),

--- a/crates/harn-vm/src/stdlib/agents_workers/tests.rs
+++ b/crates/harn-vm/src/stdlib/agents_workers/tests.rs
@@ -9,6 +9,19 @@ use crate::orchestration::{
 
 use super::*;
 
+fn vm_string(value: &str) -> VmValue {
+    VmValue::String(Rc::from(value))
+}
+
+fn vm_dict(pairs: Vec<(&str, VmValue)>) -> VmValue {
+    VmValue::Dict(Rc::new(
+        pairs
+            .into_iter()
+            .map(|(key, value)| (key.to_string(), value))
+            .collect(),
+    ))
+}
+
 #[test]
 fn worker_snapshot_round_trip_preserves_resume_fields() {
     let dir = std::env::temp_dir().join(format!("harn-worker-test-{}", uuid::Uuid::now_v7()));
@@ -150,6 +163,44 @@ fn worker_snapshot_round_trip_preserves_resume_fields() {
 
     let _ = std::fs::remove_dir_all(&dir);
     unsafe { std::env::remove_var("HARN_WORKER_STATE_DIR") };
+}
+
+#[test]
+fn parse_worker_config_rejects_unknown_top_level_options() {
+    let config = vm_dict(vec![
+        ("task", vm_string("do work")),
+        ("node", vm_dict(vec![("kind", vm_string("stage"))])),
+        ("typo", VmValue::Bool(true)),
+    ]);
+
+    let err = match super::config::parse_worker_config(&config) {
+        Ok(_) => panic!("expected unknown option failure"),
+        Err(err) => err,
+    };
+
+    match err {
+        VmError::Runtime(message) => assert!(message.contains("typo"), "got: {message}"),
+        other => panic!("expected Runtime error, got {other:?}"),
+    }
+}
+
+#[test]
+fn parse_worker_config_rejects_unknown_carry_options() {
+    let config = vm_dict(vec![
+        ("task", vm_string("do work")),
+        ("node", vm_dict(vec![("kind", vm_string("stage"))])),
+        ("carry", vm_dict(vec![("transcritp", vm_string("fork"))])),
+    ]);
+
+    let err = match super::config::parse_worker_config(&config) {
+        Ok(_) => panic!("expected unknown carry option failure"),
+        Err(err) => err,
+    };
+
+    match err {
+        VmError::Runtime(message) => assert!(message.contains("transcritp"), "got: {message}"),
+        other => panic!("expected Runtime error, got {other:?}"),
+    }
 }
 
 #[test]

--- a/crates/harn-vm/src/stdlib/io.rs
+++ b/crates/harn-vm/src/stdlib/io.rs
@@ -8,6 +8,7 @@ use std::sync::Mutex;
 #[cfg(unix)]
 use std::time::Instant;
 
+use crate::stdlib::options::{self, ErrorKind, OptionsParser};
 use crate::stdlib::registration::{register_builtin_group, BuiltinGroup, SyncBuiltin};
 use crate::value::{VmError, VmValue};
 use crate::vm::{Vm, VmBuiltinArity};
@@ -386,70 +387,47 @@ fn read_line_result(outcome: ReadLineOutcome) -> VmValue {
     VmValue::Dict(Rc::new(out))
 }
 
-fn read_line_field_bool(
-    dict: &BTreeMap<String, VmValue>,
-    field: &str,
-    default: bool,
-) -> Result<bool, VmError> {
-    match dict.get(field) {
-        None | Some(VmValue::Nil) => Ok(default),
-        Some(VmValue::Bool(value)) => Ok(*value),
-        Some(_) => Err(VmError::Runtime(format!(
-            "std/io.read_line: `{field}` must be a bool"
-        ))),
-    }
-}
+const READ_LINE_FN: &str = "std/io.read_line";
 
-fn read_line_field_timeout_ms(dict: &BTreeMap<String, VmValue>) -> Result<Option<u64>, VmError> {
-    match dict.get("timeout_ms") {
+fn parse_read_line_timeout_ms(value: Option<&VmValue>) -> Result<Option<u64>, VmError> {
+    match value {
         None | Some(VmValue::Nil) => Ok(None),
         Some(VmValue::Int(value)) | Some(VmValue::Duration(value)) => {
             if *value < 0 {
-                return Err(VmError::Runtime(
-                    "std/io.read_line: `timeout_ms` must be non-negative".to_string(),
-                ));
+                return Err(VmError::Runtime(format!(
+                    "{READ_LINE_FN}: `timeout_ms` must be non-negative"
+                )));
             }
             Ok(Some(*value as u64))
         }
-        Some(_) => Err(VmError::Runtime(
-            "std/io.read_line: `timeout_ms` must be an int, duration, or nil".to_string(),
-        )),
+        Some(value) => Err(VmError::Runtime(format!(
+            "{READ_LINE_FN}: `timeout_ms` must be an int, duration, or nil (got {})",
+            value.type_name()
+        ))),
     }
 }
 
 fn parse_read_line_options(args: &[VmValue]) -> Result<ReadLineOptions, VmError> {
     if args.len() > 1 {
-        return Err(VmError::Runtime(
-            "std/io.read_line: expected at most one options dict".to_string(),
-        ));
+        return Err(VmError::Runtime(format!(
+            "{READ_LINE_FN}: expected at most one options dict"
+        )));
     }
-    let Some(value) = args.first() else {
+    let Some(dict) =
+        options::optional_dict_arg(args, 0, READ_LINE_FN, "options", ErrorKind::Runtime)?
+    else {
         return Ok(ReadLineOptions::default());
     };
-    if matches!(value, VmValue::Nil) {
-        return Ok(ReadLineOptions::default());
-    }
-    let VmValue::Dict(dict) = value else {
-        return Err(VmError::Runtime(
-            "std/io.read_line: options must be a dict or nil".to_string(),
-        ));
+    let mut parser = OptionsParser::new(READ_LINE_FN, dict, ErrorKind::Runtime);
+    let options = ReadLineOptions {
+        prompt: parser.optional_string_raw("prompt")?.unwrap_or_default(),
+        timeout_ms: parse_read_line_timeout_ms(parser.raw("timeout_ms"))?,
+        trim: parser.bool_or("trim", true)?,
+        echo: parser.bool_or("echo", true)?,
+        raw: parser.bool_or("raw", false)?,
     };
-    let prompt = match dict.get("prompt") {
-        None | Some(VmValue::Nil) => String::new(),
-        Some(VmValue::String(value)) => value.to_string(),
-        Some(_) => {
-            return Err(VmError::Runtime(
-                "std/io.read_line: `prompt` must be a string".to_string(),
-            ));
-        }
-    };
-    Ok(ReadLineOptions {
-        prompt,
-        timeout_ms: read_line_field_timeout_ms(dict)?,
-        trim: read_line_field_bool(dict, "trim", true)?,
-        echo: read_line_field_bool(dict, "echo", true)?,
-        raw: read_line_field_bool(dict, "raw", false)?,
-    })
+    parser.finish_strict(&[])?;
+    Ok(options)
 }
 
 fn read_line_from_mock_or_real(options: &ReadLineOptions) -> ReadLineOutcome {
@@ -1120,6 +1098,31 @@ mod tests {
     #[test]
     fn progress_bar_falls_back_to_empty_bar_for_zero_total() {
         assert_eq!(render_progress_bar(2, 0, 5), "[-----]");
+    }
+
+    #[test]
+    fn read_line_options_preserve_prompt_whitespace() {
+        let mut options = BTreeMap::new();
+        options.insert("prompt".to_string(), VmValue::String(Rc::from("  > ")));
+        options.insert("trim".to_string(), VmValue::Bool(false));
+
+        let parsed = super::parse_read_line_options(&[VmValue::Dict(Rc::new(options))]).unwrap();
+
+        assert_eq!(parsed.prompt, "  > ");
+        assert!(!parsed.trim);
+    }
+
+    #[test]
+    fn read_line_options_reject_unknown_keys() {
+        let mut options = BTreeMap::new();
+        options.insert("promtp".to_string(), VmValue::String(Rc::from("> ")));
+
+        let err = super::parse_read_line_options(&[VmValue::Dict(Rc::new(options))]).unwrap_err();
+
+        match err {
+            crate::value::VmError::Runtime(message) => assert!(message.contains("promtp")),
+            other => panic!("expected Runtime error, got {other:?}"),
+        }
     }
 
     #[cfg(unix)]

--- a/crates/harn-vm/src/stdlib/options.rs
+++ b/crates/harn-vm/src/stdlib/options.rs
@@ -247,6 +247,23 @@ impl<'a> OptionsParser<'a> {
         }
     }
 
+    /// Optional string field that preserves the value exactly. Use this for
+    /// fields where leading/trailing whitespace is part of the public contract.
+    pub(crate) fn optional_string_raw(
+        &mut self,
+        key: &'static str,
+    ) -> Result<Option<String>, VmError> {
+        self.mark(key);
+        match self.dict.get(key) {
+            None | Some(VmValue::Nil) => Ok(None),
+            Some(VmValue::String(s)) => Ok(Some(s.to_string())),
+            Some(value) => Err(self.err(format_args!(
+                "`{key}` must be a string or nil (got {})",
+                value.type_name()
+            ))),
+        }
+    }
+
     pub(crate) fn optional_bool(&mut self, key: &'static str) -> Result<Option<bool>, VmError> {
         self.mark(key);
         match self.dict.get(key) {
@@ -384,6 +401,26 @@ mod tests {
         let d = dict(&[("name", VmValue::String(Rc::from("  joe  ")))]);
         let mut p = OptionsParser::new("agent", &d, ErrorKind::Runtime);
         assert_eq!(p.optional_string("name").unwrap().as_deref(), Some("joe"));
+    }
+
+    #[test]
+    fn parser_optional_string_raw_preserves_whitespace() {
+        let d = dict(&[("prompt", VmValue::String(Rc::from("  >  ")))]);
+        let mut p = OptionsParser::new("std/io.read_line", &d, ErrorKind::Runtime);
+        assert_eq!(
+            p.optional_string_raw("prompt").unwrap().as_deref(),
+            Some("  >  ")
+        );
+    }
+
+    #[test]
+    fn parser_optional_string_raw_accepts_empty_string() {
+        let d = dict(&[("prompt", VmValue::String(Rc::from("")))]);
+        let mut p = OptionsParser::new("std/io.read_line", &d, ErrorKind::Runtime);
+        assert_eq!(
+            p.optional_string_raw("prompt").unwrap().as_deref(),
+            Some("")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Migrate the remaining stdlib worker/read-line/sub-agent option bags from hand-rolled dict parsing to OptionsParser.
- Add raw string option parsing for public fields that must preserve whitespace.
- Add targeted regression tests for strict unknown-key handling and whitespace preservation.

Closes #1568

## Verification
- cargo test -p harn-vm --lib stdlib::options
- cargo test -p harn-vm --lib read_line_options
- cargo test -p harn-vm --lib parse_worker_config
- cargo test -p harn-vm --lib parse_sub_agent_request
- cargo test -p harn-vm --lib stdlib::agents::agents_workers
- cargo test -p harn-vm --lib stdlib::agents::sub_agent
- cargo run --bin harn -- test conformance (1006 passed)
- npx markdownlint-cli2 CHANGELOG.md
- cargo test -p harn-vm --lib
- make lint-test-patterns
- cargo clippy -p harn-vm --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check
- pre-commit hook
- pre-push hook