### PR TITLE
Type stdlib return-contract shapes

### DIFF
--- a/crates/harn-parser/src/builtin_signatures/signatures/agents.rs
+++ b/crates/harn-parser/src/builtin_signatures/signatures/agents.rs
@@ -2,25 +2,29 @@
 
 use super::shapes::{
     AGENT_SESSION_COMPACT_OPTS, AGENT_SESSION_SEED_OPTS, AGENT_SPAWN_CONFIG, LLM_CALL_OPTIONS,
-    SESSION_ANCESTRY, SUB_AGENT_OPTIONS, WORKER_SUMMARY,
+    LLM_CALL_RESULT, LLM_CALL_SAFE_RESULT, SESSION_ANCESTRY, SESSION_SNAPSHOT, SUB_AGENT_OPTIONS,
+    SUB_AGENT_RESULT, TRANSCRIPT, WORKER_SUMMARY,
 };
 use super::{
     BuiltinSignature, Param, Ty, TY_ANY, TY_BOOL, TY_CLOSURE, TY_DICT, TY_DICT_OR_NIL, TY_FLOAT,
     TY_INT, TY_LIST, TY_NIL, TY_STRING, TY_STRING_OR_NIL,
 };
 
-/// `list | dict` — used for transcripts/message-lists arguments where
-/// either a raw `messages` list or a `transcript` dict is accepted, and
-/// for return values that mirror the input shape.
-const TY_LIST_OR_DICT: Ty = Ty::Union(&[TY_LIST, TY_DICT]);
+/// `list | dict | Transcript | SessionSnapshot` — used for
+/// transcripts/message-list arguments where either a raw `messages` list, a
+/// dynamic transcript dict, or one of the typed transcript shapes is accepted.
+const TY_MESSAGES_OR_TRANSCRIPT: Ty = Ty::Union(&[TY_LIST, TY_DICT, TRANSCRIPT, SESSION_SNAPSHOT]);
 
 /// `string | dict` — low-level LLM helpers accept raw text or an
 /// `llm_call` result dictionary.
 const TY_STRING_OR_DICT: Ty = Ty::Union(&[TY_STRING, TY_DICT]);
 
-/// `list | dict | nil` — transcript stats/event helpers intentionally
-/// tolerate nil/non-transcript inputs and produce empty results.
-const TY_LIST_OR_DICT_OR_NIL: Ty = Ty::Union(&[TY_LIST, TY_DICT, TY_NIL]);
+/// `list | dict | Transcript | SessionSnapshot | nil` — read-only transcript
+/// helpers are often fed values through optional chaining. Runtime validation
+/// still rejects nil for the core transcript readers; this keeps the static
+/// checker aligned with established call sites that know the value is present.
+const TY_MESSAGES_OR_TRANSCRIPT_OR_NIL: Ty =
+    Ty::Union(&[TY_LIST, TY_DICT, TRANSCRIPT, SESSION_SNAPSHOT, TY_NIL]);
 
 /// `dict | Schema<any>` — schema aliases type-check as `Schema<T>` but
 /// compile down to JSON-Schema dictionaries at runtime.
@@ -51,44 +55,44 @@ pub(crate) const SIGNATURES: &[BuiltinSignature] = &[
     BuiltinSignature::simple(
         "add_assistant",
         &[
-            Param::new("messages_or_transcript", TY_LIST_OR_DICT),
+            Param::new("messages_or_transcript", TY_MESSAGES_OR_TRANSCRIPT),
             Param::new("content", TY_ANY),
         ],
-        TY_LIST_OR_DICT,
+        TY_MESSAGES_OR_TRANSCRIPT,
     ),
     BuiltinSignature::simple(
         "add_message",
         &[
-            Param::new("messages_or_transcript", TY_LIST_OR_DICT),
+            Param::new("messages_or_transcript", TY_MESSAGES_OR_TRANSCRIPT),
             Param::new("role", TY_STRING),
             Param::new("content", TY_ANY),
         ],
-        TY_LIST_OR_DICT,
+        TY_MESSAGES_OR_TRANSCRIPT,
     ),
     BuiltinSignature::simple(
         "add_system",
         &[
-            Param::new("messages_or_transcript", TY_LIST_OR_DICT),
+            Param::new("messages_or_transcript", TY_MESSAGES_OR_TRANSCRIPT),
             Param::new("content", TY_ANY),
         ],
-        TY_LIST_OR_DICT,
+        TY_MESSAGES_OR_TRANSCRIPT,
     ),
     BuiltinSignature::simple(
         "add_tool_result",
         &[
-            Param::new("messages_or_transcript", TY_LIST_OR_DICT),
+            Param::new("messages_or_transcript", TY_MESSAGES_OR_TRANSCRIPT),
             Param::new("tool_use_id", TY_STRING),
             Param::new("content", TY_ANY),
         ],
-        TY_LIST_OR_DICT,
+        TY_MESSAGES_OR_TRANSCRIPT,
     ),
     BuiltinSignature::simple(
         "add_user",
         &[
-            Param::new("messages_or_transcript", TY_LIST_OR_DICT),
+            Param::new("messages_or_transcript", TY_MESSAGES_OR_TRANSCRIPT),
             Param::new("content", TY_ANY),
         ],
-        TY_LIST_OR_DICT,
+        TY_MESSAGES_OR_TRANSCRIPT,
     ),
     BuiltinSignature::simple(
         "agent",
@@ -175,7 +179,7 @@ pub(crate) const SIGNATURES: &[BuiltinSignature] = &[
             Param::optional("system", TY_STRING_OR_NIL),
             Param::optional("options", TY_DICT),
         ],
-        TY_DICT,
+        LLM_CALL_RESULT,
     ),
     BuiltinSignature::simple(
         "agent_loop",
@@ -370,7 +374,7 @@ pub(crate) const SIGNATURES: &[BuiltinSignature] = &[
     BuiltinSignature::simple(
         "agent_session_snapshot",
         &[Param::new("id", TY_STRING)],
-        TY_DICT_OR_NIL,
+        SESSION_SNAPSHOT,
     ),
     BuiltinSignature::simple(
         "agent_session_system_prompt",
@@ -456,7 +460,7 @@ pub(crate) const SIGNATURES: &[BuiltinSignature] = &[
             Param::optional("system", TY_STRING),
             Param::optional("options", LLM_CALL_OPTIONS),
         ],
-        TY_DICT,
+        LLM_CALL_RESULT,
     ),
     BuiltinSignature::simple(
         "llm_call_safe",
@@ -465,7 +469,7 @@ pub(crate) const SIGNATURES: &[BuiltinSignature] = &[
             Param::optional("system", TY_STRING),
             Param::optional("options", LLM_CALL_OPTIONS),
         ],
-        TY_DICT,
+        LLM_CALL_SAFE_RESULT,
     ),
     BuiltinSignature::simple(
         "llm_stream_call",
@@ -511,7 +515,7 @@ pub(crate) const SIGNATURES: &[BuiltinSignature] = &[
             Param::optional("system", TY_STRING),
             Param::optional("options", LLM_CALL_OPTIONS),
         ],
-        TY_DICT,
+        LLM_CALL_RESULT,
     ),
     BuiltinSignature::simple(
         "llm_config",
@@ -685,7 +689,7 @@ pub(crate) const SIGNATURES: &[BuiltinSignature] = &[
             Param::new("task", TY_STRING),
             Param::optional("options", SUB_AGENT_OPTIONS),
         ],
-        TY_DICT,
+        Ty::Union(&[SUB_AGENT_RESULT, WORKER_SUMMARY]),
     ),
     BuiltinSignature::simple(
         "sub_agent_request",
@@ -698,29 +702,29 @@ pub(crate) const SIGNATURES: &[BuiltinSignature] = &[
     BuiltinSignature::simple(
         "transcript",
         &[Param::optional("metadata", TY_DICT)],
-        TY_DICT,
+        TRANSCRIPT,
     ),
     BuiltinSignature::simple(
         "transcript_abandon",
-        &[Param::new("transcript", TY_LIST_OR_DICT)],
-        TY_DICT,
+        &[Param::new("transcript", TY_MESSAGES_OR_TRANSCRIPT)],
+        TRANSCRIPT,
     ),
     BuiltinSignature::simple(
         "transcript_add_asset",
         &[
-            Param::new("transcript", TY_LIST_OR_DICT),
+            Param::new("transcript", TY_MESSAGES_OR_TRANSCRIPT),
             Param::new("asset", TY_DICT),
         ],
-        TY_DICT,
+        TRANSCRIPT,
     ),
     BuiltinSignature::simple(
         "transcript_archive",
-        &[Param::new("transcript", TY_LIST_OR_DICT)],
-        TY_DICT,
+        &[Param::new("transcript", TY_MESSAGES_OR_TRANSCRIPT)],
+        TRANSCRIPT,
     ),
     BuiltinSignature::simple(
         "transcript_assets",
-        &[Param::new("transcript", TY_LIST_OR_DICT)],
+        &[Param::new("transcript", TY_MESSAGES_OR_TRANSCRIPT_OR_NIL)],
         TY_LIST,
     ),
     BuiltinSignature::simple(
@@ -734,45 +738,48 @@ pub(crate) const SIGNATURES: &[BuiltinSignature] = &[
     BuiltinSignature::simple(
         "transcript_compact",
         &[
-            Param::new("transcript", TY_LIST_OR_DICT),
+            Param::new("transcript", TY_MESSAGES_OR_TRANSCRIPT),
             Param::optional("options", TY_DICT),
         ],
-        TY_DICT,
+        TRANSCRIPT,
     ),
     BuiltinSignature::simple(
         "transcript_events",
-        &[Param::new("transcript", TY_LIST_OR_DICT)],
+        &[Param::new("transcript", TY_MESSAGES_OR_TRANSCRIPT_OR_NIL)],
         TY_LIST,
     ),
     BuiltinSignature::simple(
         "transcript_events_by_kind",
         &[
-            Param::new("transcript", TY_LIST_OR_DICT_OR_NIL),
+            Param::new("transcript", TY_MESSAGES_OR_TRANSCRIPT_OR_NIL),
             Param::new("kind", TY_STRING),
         ],
         TY_LIST,
     ),
     BuiltinSignature::simple(
         "transcript_export",
-        &[Param::new("transcript", TY_LIST_OR_DICT)],
+        &[Param::new("transcript", TY_MESSAGES_OR_TRANSCRIPT)],
         TY_STRING,
     ),
     BuiltinSignature::simple(
         "transcript_fork",
         &[
-            Param::new("transcript", TY_LIST_OR_DICT),
+            Param::new("transcript", TY_MESSAGES_OR_TRANSCRIPT),
             Param::optional("options", TY_DICT),
         ],
-        TY_DICT,
+        TRANSCRIPT,
     ),
     BuiltinSignature::simple(
         "transcript_from_messages",
-        &[Param::new("messages_or_transcript", TY_LIST_OR_DICT)],
-        TY_DICT,
+        &[Param::new(
+            "messages_or_transcript",
+            TY_MESSAGES_OR_TRANSCRIPT,
+        )],
+        TRANSCRIPT,
     ),
     BuiltinSignature::simple(
         "transcript_id",
-        &[Param::new("transcript", TY_LIST_OR_DICT)],
+        &[Param::new("transcript", TY_MESSAGES_OR_TRANSCRIPT_OR_NIL)],
         TY_STRING,
     ),
     BuiltinSignature::simple(
@@ -782,45 +789,45 @@ pub(crate) const SIGNATURES: &[BuiltinSignature] = &[
     ),
     BuiltinSignature::simple(
         "transcript_messages",
-        &[Param::new("transcript", TY_LIST_OR_DICT)],
+        &[Param::new("transcript", TY_MESSAGES_OR_TRANSCRIPT_OR_NIL)],
         TY_LIST,
     ),
     BuiltinSignature::simple(
         "transcript_render_full",
-        &[Param::new("transcript", TY_LIST_OR_DICT)],
+        &[Param::new("transcript", TY_MESSAGES_OR_TRANSCRIPT_OR_NIL)],
         TY_STRING,
     ),
     BuiltinSignature::simple(
         "transcript_render_visible",
-        &[Param::new("transcript", TY_LIST_OR_DICT)],
+        &[Param::new("transcript", TY_MESSAGES_OR_TRANSCRIPT_OR_NIL)],
         TY_STRING,
     ),
     BuiltinSignature::simple(
         "transcript_reset",
         &[Param::optional("opts", TY_DICT)],
-        TY_DICT,
+        TRANSCRIPT,
     ),
     BuiltinSignature::simple(
         "transcript_resume",
-        &[Param::new("transcript", TY_LIST_OR_DICT)],
-        TY_DICT,
+        &[Param::new("transcript", TY_MESSAGES_OR_TRANSCRIPT)],
+        TRANSCRIPT,
     ),
     BuiltinSignature::simple(
         "transcript_stats",
-        &[Param::new("transcript", TY_LIST_OR_DICT_OR_NIL)],
+        &[Param::new("transcript", TY_MESSAGES_OR_TRANSCRIPT_OR_NIL)],
         TY_DICT,
     ),
     BuiltinSignature::simple(
         "transcript_summarize",
         &[
-            Param::new("transcript", TY_LIST_OR_DICT),
+            Param::new("transcript", TY_MESSAGES_OR_TRANSCRIPT),
             Param::optional("options", TY_DICT),
         ],
-        TY_DICT,
+        TRANSCRIPT,
     ),
     BuiltinSignature::simple(
         "transcript_summary",
-        &[Param::new("transcript", TY_LIST_OR_DICT)],
+        &[Param::new("transcript", TY_MESSAGES_OR_TRANSCRIPT_OR_NIL)],
         TY_STRING_OR_NIL,
     ),
     BuiltinSignature::simple(

--- a/crates/harn-parser/src/builtin_signatures/signatures/integrations.rs
+++ b/crates/harn-parser/src/builtin_signatures/signatures/integrations.rs
@@ -1,5 +1,6 @@
 //! Connector, host, tool, and shell-facing builtin signatures.
 
+use super::shapes::TOOL_REGISTRY;
 use super::{
     BuiltinSignature, Param, Ty, TY_ANY, TY_BOOL, TY_BYTES_OR_NIL, TY_CLOSURE, TY_DICT,
     TY_DICT_OR_NIL, TY_INT, TY_LIST, TY_NIL, TY_NUMBER, TY_STRING, TY_STRING_OR_NIL,
@@ -695,7 +696,11 @@ pub(crate) const SIGNATURES: &[BuiltinSignature] = &[
         &[Param::optional("registry", TY_TOOL_REGISTRY)],
         TY_DICT_OR_NIL,
     ),
-    BuiltinSignature::simple("__host_current_tool_registry", &[], TY_DICT_OR_NIL),
+    BuiltinSignature::simple(
+        "__host_current_tool_registry",
+        &[],
+        Ty::Union(&[TOOL_REGISTRY, TY_NIL]),
+    ),
     BuiltinSignature::simple(
         "tool_count",
         &[Param::new("registry", TY_TOOL_REGISTRY)],
@@ -742,7 +747,7 @@ pub(crate) const SIGNATURES: &[BuiltinSignature] = &[
         TY_STRING,
     ),
     BuiltinSignature::simple("tool_ref", &[Param::new("name", TY_STRING)], TY_STRING),
-    BuiltinSignature::simple("tool_registry", &[], TY_DICT),
+    BuiltinSignature::simple("tool_registry", &[], TOOL_REGISTRY),
     BuiltinSignature::simple(
         "tool_remove",
         &[

--- a/crates/harn-parser/src/builtin_signatures/signatures/shapes.rs
+++ b/crates/harn-parser/src/builtin_signatures/signatures/shapes.rs
@@ -414,7 +414,7 @@ pub(crate) const SIGNAL_HANDLER_OPTIONS: Ty = Ty::Shape(&[
 /// and `sub_agent_run` background mode. Mirrors `clone_worker_state` in
 /// `crates/harn-vm/src/stdlib/agents_workers/mod.rs`.
 pub(crate) const WORKER_SUMMARY: Ty = Ty::Shape(&[
-    ShapeFieldDescriptor::new("_type", TY_STRING),
+    ShapeFieldDescriptor::new("_type", Ty::LitString("agent_handle")),
     ShapeFieldDescriptor::new("id", TY_STRING),
     ShapeFieldDescriptor::new("name", TY_STRING),
     ShapeFieldDescriptor::new("task", TY_STRING),
@@ -440,6 +440,21 @@ pub(crate) const WORKER_SUMMARY: Ty = Ty::Shape(&[
     ShapeFieldDescriptor::new("audit", TY_DICT),
 ]);
 
+/// User-facing result returned by foreground `sub_agent_run`. Background mode
+/// returns [`WORKER_SUMMARY`] instead.
+pub(crate) const SUB_AGENT_RESULT: Ty = Ty::Shape(&[
+    ShapeFieldDescriptor::new("ok", TY_BOOL),
+    ShapeFieldDescriptor::new("summary", TY_STRING),
+    ShapeFieldDescriptor::new("artifacts", TY_LIST),
+    ShapeFieldDescriptor::new("evidence_added", TY_INT),
+    ShapeFieldDescriptor::new("tokens_used", TY_INT),
+    ShapeFieldDescriptor::new("budget_exceeded", TY_BOOL),
+    ShapeFieldDescriptor::new("data", TY_ANY),
+    ShapeFieldDescriptor::new("error", TY_ANY),
+    ShapeFieldDescriptor::new("session_id", TY_STRING),
+    ShapeFieldDescriptor::new("transcript", TRANSCRIPT),
+]);
+
 /// Return type of `daemon_spawn`, `daemon_snapshot`, `daemon_resume`,
 /// `daemon_stop`, `daemon_trigger`. Mirrors `daemon_summary` in
 /// `crates/harn-vm/src/stdlib/agents_daemon.rs`.
@@ -462,8 +477,111 @@ pub(crate) const DAEMON_SUMMARY: Ty = Ty::Shape(&[
 
 /// Result returned by `agent_session_ancestry`.
 pub(crate) const SESSION_ANCESTRY: Ty = Ty::Shape(&[
-    ShapeFieldDescriptor::optional("parent_id", TY_STRING_OR_NIL),
+    ShapeFieldDescriptor::new("parent_id", TY_STRING_OR_NIL),
     ShapeFieldDescriptor::new("child_ids", TY_LIST),
+    ShapeFieldDescriptor::new("root_id", TY_STRING),
+]);
+
+/// Canonical transcript dict returned by the transcript lifecycle builtins.
+pub(crate) const TRANSCRIPT: Ty = Ty::Shape(&[
+    ShapeFieldDescriptor::new("_type", Ty::LitString("transcript")),
+    ShapeFieldDescriptor::new("version", TY_INT),
+    ShapeFieldDescriptor::new("id", TY_STRING),
+    ShapeFieldDescriptor::new("messages", TY_LIST),
+    ShapeFieldDescriptor::new("events", TY_LIST),
+    ShapeFieldDescriptor::new("assets", TY_LIST),
+    ShapeFieldDescriptor::optional("summary", TY_STRING),
+    ShapeFieldDescriptor::optional("metadata", TY_DICT),
+    ShapeFieldDescriptor::optional("state", TY_STRING),
+    ShapeFieldDescriptor::optional("archived_messages", TY_INT),
+]);
+
+/// `agent_session_snapshot(id)` returns the transcript plus session lineage
+/// and prompt/tool metadata.
+pub(crate) const SESSION_SNAPSHOT: Ty = Ty::Shape(&[
+    ShapeFieldDescriptor::new("_type", Ty::LitString("transcript")),
+    ShapeFieldDescriptor::new("version", TY_INT),
+    ShapeFieldDescriptor::new("id", TY_STRING),
+    ShapeFieldDescriptor::new("length", TY_INT),
+    ShapeFieldDescriptor::new("messages", TY_LIST),
+    ShapeFieldDescriptor::new("events", TY_LIST),
+    ShapeFieldDescriptor::new("assets", TY_LIST),
+    ShapeFieldDescriptor::new("created_at", TY_STRING),
+    ShapeFieldDescriptor::new("parent_id", TY_STRING_OR_NIL),
+    ShapeFieldDescriptor::new("child_ids", TY_LIST),
+    ShapeFieldDescriptor::new("branched_at_event_index", Ty::Union(&[TY_INT, TY_NIL])),
+    ShapeFieldDescriptor::new("system_prompt", TY_STRING_OR_NIL),
+    ShapeFieldDescriptor::new("tool_format", TY_STRING_OR_NIL),
+    ShapeFieldDescriptor::optional("summary", TY_STRING),
+    ShapeFieldDescriptor::optional("metadata", TY_DICT),
+    ShapeFieldDescriptor::optional("state", TY_STRING),
+]);
+
+/// `tool_registry()` and related host-current registry lookups.
+pub(crate) const TOOL_REGISTRY: Ty = Ty::Shape(&[
+    ShapeFieldDescriptor::new("_type", Ty::LitString("tool_registry")),
+    ShapeFieldDescriptor::new("tools", TY_LIST),
+]);
+
+/// Token and provider-cache accounting embedded in `llm_call` results.
+pub(crate) const LLM_USAGE: Ty = Ty::Shape(&[
+    ShapeFieldDescriptor::new("input_tokens", TY_INT),
+    ShapeFieldDescriptor::new("output_tokens", TY_INT),
+    ShapeFieldDescriptor::new("cache_read_tokens", TY_INT),
+    ShapeFieldDescriptor::new("cache_write_tokens", TY_INT),
+    ShapeFieldDescriptor::new("cache_creation_input_tokens", TY_INT),
+    ShapeFieldDescriptor::new("cache_hit_ratio", TY_FLOAT),
+    ShapeFieldDescriptor::new("cache_savings_usd", TY_FLOAT),
+]);
+
+/// Harn-facing response dict assembled by `vm_build_llm_result` for
+/// `llm_call` and `llm_completion`.
+pub(crate) const LLM_CALL_RESULT: Ty = Ty::Shape(&[
+    ShapeFieldDescriptor::new("text", TY_STRING),
+    ShapeFieldDescriptor::new("model", TY_STRING),
+    ShapeFieldDescriptor::new("provider", TY_STRING),
+    ShapeFieldDescriptor::new("input_tokens", TY_INT),
+    ShapeFieldDescriptor::new("output_tokens", TY_INT),
+    ShapeFieldDescriptor::new("cache_read_tokens", TY_INT),
+    ShapeFieldDescriptor::new("cache_write_tokens", TY_INT),
+    ShapeFieldDescriptor::new("cache_creation_input_tokens", TY_INT),
+    ShapeFieldDescriptor::new("cache_hit_ratio", TY_FLOAT),
+    ShapeFieldDescriptor::new("cache_savings_usd", TY_FLOAT),
+    ShapeFieldDescriptor::new("usage", LLM_USAGE),
+    ShapeFieldDescriptor::new("native_tool_calls", TY_LIST),
+    ShapeFieldDescriptor::new("prose", TY_STRING),
+    ShapeFieldDescriptor::new("visible_text", TY_STRING),
+    ShapeFieldDescriptor::new("blocks", TY_LIST),
+    ShapeFieldDescriptor::optional("data", TY_ANY),
+    ShapeFieldDescriptor::new("tool_calls", TY_LIST),
+    ShapeFieldDescriptor::optional("protocol_violations", TY_LIST),
+    ShapeFieldDescriptor::optional("tool_parse_errors", TY_LIST),
+    ShapeFieldDescriptor::optional("done_marker", TY_STRING),
+    ShapeFieldDescriptor::optional("canonical_text", TY_STRING),
+    ShapeFieldDescriptor::optional("thinking", TY_STRING),
+    ShapeFieldDescriptor::optional("private_reasoning", TY_STRING),
+    ShapeFieldDescriptor::optional("thinking_summary", TY_STRING),
+    ShapeFieldDescriptor::optional("stop_reason", TY_STRING),
+    ShapeFieldDescriptor::new("transcript", TRANSCRIPT),
+    ShapeFieldDescriptor::optional("logprobs", TY_LIST),
+]);
+
+/// Error dict surfaced by `llm_call` throws and `llm_call_safe`.
+pub(crate) const LLM_CALL_ERROR: Ty = Ty::Shape(&[
+    ShapeFieldDescriptor::new("category", TY_STRING),
+    ShapeFieldDescriptor::new("kind", TY_STRING),
+    ShapeFieldDescriptor::new("reason", TY_STRING),
+    ShapeFieldDescriptor::new("message", TY_STRING),
+    ShapeFieldDescriptor::optional("retry_after_ms", TY_INT),
+    ShapeFieldDescriptor::optional("provider", TY_STRING),
+    ShapeFieldDescriptor::optional("model", TY_STRING),
+]);
+
+/// Non-throwing envelope returned by `llm_call_safe`.
+pub(crate) const LLM_CALL_SAFE_RESULT: Ty = Ty::Shape(&[
+    ShapeFieldDescriptor::new("ok", TY_BOOL),
+    ShapeFieldDescriptor::new("response", LLM_CALL_RESULT),
+    ShapeFieldDescriptor::new("error", LLM_CALL_ERROR),
 ]);
 
 /// Standard `{ ok, status, ...payload }` result envelope returned by I/O

--- a/crates/harn-parser/src/typechecker/tests/typing.rs
+++ b/crates/harn-parser/src/typechecker/tests/typing.rs
@@ -970,6 +970,76 @@ fn test_workflow_and_transcript_builtins_are_known() {
 }
 
 #[test]
+fn test_structured_stdlib_return_shapes_allow_documented_field_access() {
+    let errs = errors(
+        r#"pipeline t(task) {
+  let call = llm_call("prompt", "system")
+  let text: string = call.text
+  let tool_calls: list = call.tool_calls
+  let input_tokens: int = call.usage.input_tokens
+
+  let safe = llm_call_safe("prompt", "system")
+  let ok: bool = safe.ok
+  let safe_text: string | nil = safe.response?.text
+  let safe_error: string | nil = safe.error?.message
+
+  let completion = llm_completion("prefix", "suffix", "system")
+  let stop: string | nil = completion.stop_reason
+
+  let snap = agent_session_snapshot("session")
+  let length: int = snap.length
+  let messages: list = snap.messages
+  let created: string = snap.created_at
+
+  let child = sub_agent_run("summarize this")
+  let summary: string | nil = child?.summary
+  let worker_id: string | nil = child?.id
+
+  let transcript = transcript_reset({metadata: {source: "test"}})
+  let transcript_id: string = transcript.id
+  let archived_state: string | nil = transcript_archive(transcript).state
+
+  let tools = tool_registry()
+  let tool_type: string = tools._type
+  let tool_entries: list = tools.tools
+
+  println(text)
+  println(tool_calls)
+  println(input_tokens)
+  println(ok)
+  println(safe_text)
+  println(safe_error)
+  println(stop)
+  println(length)
+  println(messages)
+  println(created)
+  println(summary)
+  println(worker_id)
+  println(transcript_id)
+  println(archived_state)
+  println(tool_type)
+  println(tool_entries)
+}"#,
+    );
+    assert!(errs.is_empty(), "unexpected type errors: {errs:?}");
+}
+
+#[test]
+fn test_structured_stdlib_return_shapes_type_known_fields() {
+    let errs = errors(
+        r#"pipeline t(task) {
+  let call = llm_call("prompt", "system")
+  let bad: int = call.text
+}"#,
+    );
+    assert_eq!(errs.len(), 1, "expected one type error: {errs:?}");
+    assert!(
+        errs[0].contains("expected int") && errs[0].contains("found string"),
+        "unexpected error: {errs:?}"
+    );
+}
+
+#[test]
 fn test_binary_op_type_inference() {
     let errs = errors("pipeline t(task) { let x: string = 1 + 2 }");
     assert_eq!(errs.len(), 1);

--- a/crates/harn-vm/src/agent_sessions.rs
+++ b/crates/harn-vm/src/agent_sessions.rs
@@ -33,7 +33,7 @@ pub struct SessionState {
     pub id: String,
     pub transcript: VmValue,
     pub subscribers: Vec<VmValue>,
-    pub created_at: Instant,
+    pub created_at: String,
     pub last_accessed: Instant,
     pub parent_id: Option<String>,
     pub child_ids: Vec<String>,
@@ -62,7 +62,7 @@ impl SessionState {
             id,
             transcript,
             subscribers: Vec::new(),
-            created_at: now,
+            created_at: crate::orchestration::now_rfc3339(),
             last_accessed: now,
             parent_id: None,
             child_ids: Vec::new(),
@@ -163,6 +163,16 @@ pub fn length(id: &str) -> Option<usize> {
 
 pub fn snapshot(id: &str) -> Option<VmValue> {
     SESSIONS.with(|s| s.borrow().get(id).map(session_snapshot))
+}
+
+/// Return the canonical transcript surface for APIs whose result field is
+/// named `transcript`. Session-only fields stay on `agent_session_snapshot`.
+pub fn transcript(id: &str) -> Option<VmValue> {
+    SESSIONS.with(|s| {
+        s.borrow()
+            .get(id)
+            .map(|state| transcript_with_session_metadata(state.transcript.clone(), state))
+    })
 }
 
 /// Open a session, or create it if missing. Returns the resolved id.
@@ -1015,6 +1025,18 @@ fn session_snapshot(state: &SessionState) -> VmValue {
         return state.transcript.clone();
     };
     let mut next = dict.clone();
+    let length = next
+        .get("messages")
+        .and_then(|value| match value {
+            VmValue::List(list) => Some(list.len() as i64),
+            _ => None,
+        })
+        .unwrap_or(0);
+    next.insert("length".to_string(), VmValue::Int(length));
+    next.insert(
+        "created_at".to_string(),
+        VmValue::String(Rc::from(state.created_at.clone())),
+    );
     next.insert(
         "parent_id".to_string(),
         state
@@ -1039,6 +1061,22 @@ fn session_snapshot(state: &SessionState) -> VmValue {
         state
             .branched_at_event_index
             .map(|index| VmValue::Int(index as i64))
+            .unwrap_or(VmValue::Nil),
+    );
+    next.insert(
+        "system_prompt".to_string(),
+        state
+            .system_prompt
+            .as_ref()
+            .map(|prompt| VmValue::String(Rc::from(prompt.clone())))
+            .unwrap_or(VmValue::Nil),
+    );
+    next.insert(
+        "tool_format".to_string(),
+        state
+            .tool_format
+            .as_ref()
+            .map(|format| VmValue::String(Rc::from(format.clone())))
             .unwrap_or(VmValue::Nil),
     );
     VmValue::Dict(Rc::new(next))
@@ -1172,9 +1210,9 @@ mod tests {
         inject_message(&id, make_msg("user", "hello")).unwrap();
 
         let snapshot = snapshot(&id).expect("session snapshot");
-        let metadata = snapshot
-            .as_dict()
-            .and_then(|dict| dict.get("metadata"))
+        let snapshot_dict = snapshot.as_dict().expect("session snapshot dict");
+        let metadata = snapshot_dict
+            .get("metadata")
             .and_then(VmValue::as_dict)
             .expect("metadata");
         let system_prompt = metadata
@@ -1188,6 +1226,19 @@ mod tests {
                 .as_deref(),
             Some("Follow the workflow.")
         );
+        assert!(
+            matches!(snapshot_dict.get("system_prompt"), Some(VmValue::String(value)) if value.as_ref() == "Follow the workflow.")
+        );
+        assert!(matches!(snapshot_dict.get("length"), Some(VmValue::Int(1))));
+
+        let transcript = transcript(&id).expect("canonical transcript");
+        let transcript_dict = transcript.as_dict().expect("canonical transcript dict");
+        assert!(!transcript_dict.contains_key("system_prompt"));
+        assert!(transcript_dict
+            .get("metadata")
+            .and_then(VmValue::as_dict)
+            .and_then(|metadata| metadata.get("system_prompt"))
+            .is_some());
         assert_eq!(message_count(&id), 1);
         assert_eq!(event_count_by_kind(&id, "system_prompt"), 1);
     }
@@ -1291,6 +1342,15 @@ mod tests {
         assert!(
             matches!(transcript.get("child_ids"), Some(VmValue::List(children)) if children.is_empty())
         );
+        assert!(matches!(transcript.get("length"), Some(VmValue::Int(0))));
+        assert!(
+            matches!(transcript.get("created_at"), Some(VmValue::String(value)) if !value.is_empty())
+        );
+        assert!(matches!(
+            transcript.get("system_prompt"),
+            Some(VmValue::Nil)
+        ));
+        assert!(matches!(transcript.get("tool_format"), Some(VmValue::Nil)));
         assert!(matches!(
             transcript.get("branched_at_event_index"),
             Some(VmValue::Nil)

--- a/crates/harn-vm/src/llm/agent_session_host.rs
+++ b/crates/harn-vm/src/llm/agent_session_host.rs
@@ -430,7 +430,7 @@ async fn host_agent_session_finalize(args: Vec<VmValue>) -> Result<VmValue, VmEr
         );
         let _ = crate::agent_sessions::append_event(&session_id, transcript_event);
     }
-    let snapshot = crate::agent_sessions::snapshot(&session_id);
+    let snapshot = crate::agent_sessions::transcript(&session_id);
     let transcript_json = snapshot
         .as_ref()
         .map(vm_to_json)
@@ -536,7 +536,7 @@ fn host_agent_session_messages_builtin(
     _out: &mut String,
 ) -> Result<VmValue, VmError> {
     let session_id = args.first().map(|v| v.display()).unwrap_or_default();
-    let snapshot = crate::agent_sessions::snapshot(&session_id);
+    let snapshot = crate::agent_sessions::transcript(&session_id);
     let messages = snapshot
         .as_ref()
         .and_then(|v| dict_get(v, "messages"))
@@ -1354,7 +1354,7 @@ fn host_agent_daemon_snapshot_builtin(
     let daemon_state = opt_str(&opts_map, "daemon_state").unwrap_or_else(|| "idle".to_string());
     let total_iterations = opt_int(&opts_map, "total_iterations").unwrap_or(0).max(0) as usize;
     let transcript_summary_override = opt_str(&opts_map, "transcript_summary");
-    let transcript = crate::agent_sessions::snapshot(&session_id).unwrap_or(VmValue::Nil);
+    let transcript = crate::agent_sessions::transcript(&session_id).unwrap_or(VmValue::Nil);
     let transcript_json = vm_to_json(&transcript);
     let visible_messages = transcript_json
         .get("messages")

--- a/crates/harn-vm/src/stdlib/agents_sub_agent.rs
+++ b/crates/harn-vm/src/stdlib/agents_sub_agent.rs
@@ -652,7 +652,7 @@ pub(super) async fn execute_sub_agent(
                     None,
                 ),
             };
-            let transcript = crate::agent_sessions::snapshot(&spec.session_id)
+            let transcript = crate::agent_sessions::transcript(&spec.session_id)
                 .unwrap_or_else(|| crate::stdlib::json_to_vm_value(&serde_json::json!({})));
             let tokens_used = transcript_tokens_used(&transcript);
             let envelope = wrap_sub_agent_error(

--- a/docs/src/builtins.md
+++ b/docs/src/builtins.md
@@ -1533,11 +1533,11 @@ See [LLM calls and agent loops](llm-and-agents.md) for full documentation.
 
 | Function | Parameters | Returns | Description |
 |---|---|---|---|
-| `llm_call(prompt, system?, options?)` | prompt: string, system: string, options: dict | dict | Single LLM request. Returns `{text, model, input_tokens, output_tokens}`. Supports `budget: {max_cost_usd?, max_input_tokens?, max_output_tokens?, total_budget_usd?}` pre-flight checks and throws on transport / rate-limit / budget / schema-validation failures |
-| `llm_call_safe(prompt, system?, options?)` | prompt: string, system: string, options: dict | dict | Non-throwing envelope around `llm_call`. Returns `{ok: bool, response: dict or nil, error: {category, message} or nil}`. `error.category` is one of `ErrorCategory`'s canonical strings (`"rate_limit"`, `"timeout"`, `"overloaded"`, `"server_error"`, `"transient_network"`, `"schema_validation"`, `"auth"`, `"not_found"`, `"circuit_open"`, `"budget_exceeded"`, `"tool_error"`, `"tool_rejected"`, `"egress_blocked"`, `"cancelled"`, `"generic"`) |
+| `llm_call(prompt, system?, options?)` | prompt: string, system: string, options: dict | dict | Single LLM request. Returns `{text, model, provider, input_tokens, output_tokens, usage, prose, visible_text, blocks, transcript?, tool_calls?, stop_reason?, data?}`. Supports `budget: {max_cost_usd?, max_input_tokens?, max_output_tokens?, total_budget_usd?}` pre-flight checks and throws on transport / rate-limit / budget / schema-validation failures |
+| `llm_call_safe(prompt, system?, options?)` | prompt: string, system: string, options: dict | dict | Non-throwing envelope around `llm_call`. Returns `{ok: bool, response: llm_call result or nil, error: {category, kind, reason, message, provider?, model?, retry_after_ms?} or nil}`. `error.category` is one of `ErrorCategory`'s canonical strings (`"rate_limit"`, `"timeout"`, `"overloaded"`, `"server_error"`, `"transient_network"`, `"schema_validation"`, `"auth"`, `"not_found"`, `"circuit_open"`, `"budget_exceeded"`, `"tool_error"`, `"tool_rejected"`, `"egress_blocked"`, `"cancelled"`, `"generic"`) |
 | `llm_stream_call(prompt, system?, options?)` | prompt: string, system: string, options: dict | stream | Streaming LLM request. Returns `Stream<{delta, visible_delta, partial, role, finish_reason}>`; dropping the stream cancels the background request. Uses the same options as `llm_call`; the `stream` option remains the transport toggle |
 | `with_rate_limit(provider, fn, options?)` | provider: string, fn: closure, options: dict | whatever `fn` returns | Acquire a permit from the provider's sliding-window rate limiter, invoke `fn`, and retry with exponential backoff on retryable errors (`rate_limit`, `overloaded`, `transient_network`, `timeout`). Options: `max_retries` (default 5), `backoff_ms` (default 1000, capped at 30s after doubling) |
-| `llm_completion(prefix, suffix?, system?, options?)` | prefix: string, suffix: string, system: string, options: dict | dict | Text completion / fill-in-the-middle request. Returns `{text, model, input_tokens, output_tokens}` |
+| `llm_completion(prefix, suffix?, system?, options?)` | prefix: string, suffix: string, system: string, options: dict | dict | Text completion / fill-in-the-middle request. Returns the same result shape as `llm_call` |
 | `agent_loop(prompt, system?, options?)` | prompt: string, system: string, options: dict | dict | Multi-turn agent loop with natural completion for native-tool loops, sentinel completion for text/no-tool loops (`<done>##DONE##</done>` in tagged text-tool stages), daemon/idling support, optional per-turn context filtering, opt-in repeated-tool-call stall diagnostics, and structured provider/tool-protocol failure capture. Returns `{status, error?, text, visible_text, llm: {iterations, duration_ms, input_tokens, output_tokens}, tools: {calls, successful, rejected, mode}, transcript, task_ledger, trace, …}` |
 | `agent_turn(prompt, options?)` | prompt: string, options: dict | dict | High-level agent turn wrapper around `agent_loop`. It installs generic user-visible progress guidance, requires the completion judge (`done_judge`), defaults to loop-until-done completion (natural for native-tool turns, sentinel-based for text/no-tool turns), and returns the normal loop result plus `iterations` and `judge_decisions` summaries |
 | `agent_llm_turn(prompt, system?, options?)` | prompt: string, system: string, options: dict | dict | Low-level one-turn LLM request used by stdlib orchestration; equivalent to `llm_call` but intentionally lives under the agent primitive surface |
@@ -1646,16 +1646,16 @@ llm_mock_clear()
 
 | Function | Parameters | Returns | Description |
 |---|---|---|---|
-| `transcript(metadata?)` | metadata: dict | dict | Create a new transcript |
-| `transcript_from_messages(messages_or_transcript)` | list or dict | dict | Normalize a message list into a transcript |
+| `transcript(metadata?)` | metadata: dict | transcript | Create a new transcript |
+| `transcript_from_messages(messages_or_transcript)` | list or dict | transcript | Normalize a message list into a transcript |
 | `transcript_messages(transcript)` | transcript: dict | list | Get transcript messages |
 | `transcript_summary(transcript)` | transcript: dict | string or nil | Get transcript summary |
 | `transcript_id(transcript)` | transcript: dict | string | Get transcript id |
 | `transcript_export(transcript)` | transcript: dict | string | Export transcript as JSON |
 | `transcript_import(json_text)` | json_text: string | dict | Import transcript JSON |
-| `transcript_fork(transcript, options?)` | transcript: dict, options: dict | dict | Fork transcript, optionally dropping messages or summary |
-| `transcript_summarize(transcript, options?)` | transcript: dict, options: dict | dict | Summarize and compact a transcript via `llm_call` |
-| `transcript_compact(transcript, options?)` | transcript: dict, options: dict | dict | Compact a transcript with the runtime compaction engine, preserving durable artifacts and compaction events. `strategy: "custom"` requires `custom_compactor`, a closure that returns the replacement transcript state |
+| `transcript_fork(transcript, options?)` | transcript: dict, options: dict | transcript | Fork transcript, optionally dropping messages or summary |
+| `transcript_summarize(transcript, options?)` | transcript: dict, options: dict | transcript | Summarize and compact a transcript via `llm_call` |
+| `transcript_compact(transcript, options?)` | transcript: dict, options: dict | transcript | Compact a transcript with the runtime compaction engine, preserving durable artifacts and compaction events. `strategy: "custom"` requires `custom_compactor`, a closure that returns the replacement transcript state |
 | `transcript_auto_compact(messages, options?)` | messages: list, options: dict | list | Apply the agent-loop compaction pipeline to a message list using `llm`, `truncate`, or `custom` strategy |
 
 ### Provider configuration
@@ -2077,7 +2077,7 @@ tool registry dict.
 
 | Function | Parameters | Returns | Description |
 |---|---|---|---|
-| `tool_registry()` | — | dict | Create an empty tool registry |
+| `tool_registry()` | — | tool registry | Create an empty `{_type: "tool_registry", tools: []}` registry |
 | `tool_define(registry, name, desc, config)` | registry, name, desc: string, config: dict | dict | Add a tool (config: `{parameters, handler, returns?, annotations?, ...}`) |
 | `tool_define_many(registry, specs)` | registry: dict, specs: list | dict | Stdlib helper from `std/tools`; add many declarative tool specs to a registry |
 | `tool_registry_from(specs)` | specs: list | dict | Stdlib helper from `std/tools`; create a registry from declarative tool specs |
@@ -2424,7 +2424,7 @@ artifact list and bake the packed chunks into the system prompt.
 |---|---|---|---|
 | `spawn_agent(config)` | config: dict | dict | Start a worker from a workflow graph or delegated stage config |
 | `sub_agent_request(task, options?)` | task: string, options: dict | dict | Build the normalized child-agent request that `sub_agent_run` sends to the host execution primitive |
-| `sub_agent_run(task, options?)` | task: string, options: dict | dict | Run an isolated child agent loop and return a clean envelope `{summary, artifacts, evidence_added, tokens_used, budget_exceeded, ...}` without leaking the child transcript into the parent |
+| `sub_agent_run(task, options?)` | task: string, options: dict | dict | Run an isolated child agent loop and return a clean envelope `{ok, summary, artifacts, evidence_added, tokens_used, budget_exceeded, data, error, session_id, transcript}`; with `background: true`, returns an agent-handle summary |
 | `send_input(handle, task)` | handle, task | dict | Re-run a completed worker with a new task, carrying forward worker state where applicable |
 | `resume_agent(id_or_snapshot_path)` | id or path | dict | Restore a persisted worker snapshot into the current runtime |
 | `wait_agent(handle_or_list)` | handle or list | dict or list | Wait for one worker or a list of workers to finish |
@@ -2527,7 +2527,7 @@ See the [Sessions](./sessions.md) chapter for the full model.
 | `agent_session_exists(id)` | id | bool | Safe on unknown ids |
 | `agent_session_current_id()` | none | string or nil | Returns the innermost active session id, or `nil` outside any active session |
 | `agent_session_length(id)` | id | int | Message count; errors on unknown id |
-| `agent_session_snapshot(id)` | id | dict or nil | Read-only transcript snapshot plus `parent_id`, `child_ids`, `branched_at_event_index` |
+| `agent_session_snapshot(id)` | id | dict or nil | Read-only transcript snapshot plus `length`, `created_at`, `system_prompt`, `tool_format`, `parent_id`, `child_ids`, and `branched_at_event_index` |
 | `agent_session_ancestry(id)` | id | dict or nil | Returns `{parent_id, child_ids, root_id}` for the current in-VM lineage |
 | `agent_session_reset(id)` | id | nil | Wipes history; preserves id and subscribers |
 | `agent_session_fork(src, dst?)` | src, dst | string | Copies transcript, sets `dst.parent_id`, and appends `dst` to `src.child_ids` |

--- a/docs/src/sessions.md
+++ b/docs/src/sessions.md
@@ -64,7 +64,7 @@ the "one-shot" call shape.
 | `agent_session_exists(id)` | `bool` | Safe on unknown ids. |
 | `agent_session_current_id()` | `string` or `nil` | Returns the innermost active session id for the current thread, or `nil` outside any active session. |
 | `agent_session_length(id)` | `int` | Message count. Errors if `id` doesn't exist. |
-| `agent_session_snapshot(id)` | `dict` or `nil` | Read-only transcript snapshot plus `parent_id`, `child_ids`, and `branched_at_event_index`. |
+| `agent_session_snapshot(id)` | `dict` or `nil` | Read-only transcript snapshot plus `length`, `created_at`, `system_prompt`, `tool_format`, `parent_id`, `child_ids`, and `branched_at_event_index`. |
 | `agent_session_ancestry(id)` | `dict` or `nil` | Returns `{parent_id, child_ids, root_id}` for the in-VM session graph. |
 | `agent_session_reset(id)` | `nil` | Wipes history; preserves id and subscribers. |
 | `agent_session_fork(src, dst?)` | `string` | Copies transcript, sets parent/child lineage, and does NOT copy subscribers. |


### PR DESCRIPTION
## Summary
- add typed Shape return aliases for session snapshots, sub-agent foreground results, LLM call results, transcripts, and tool registries
- apply those shapes to builtin signatures while preserving canonical transcript surfaces for agent-loop/sub-agent result payloads
- expose session snapshot metadata fields (`length`, `created_at`, `system_prompt`, `tool_format`) and document the typed return surfaces

## Verification
- `cargo fmt`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-1570 cargo test -p harn-parser`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-1570 cargo test -p harn-vm agent_sessions::tests`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-1570 HARN_LLM_CALLS_DISABLED=1 cargo run --bin harn -- test conformance` (1006 passed)
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-1570 cargo check --workspace`
- repo pre-commit and pre-push hooks passed

Closes #1570