### PR TITLE
stdlib: migrate core builtins to metadata DSL

### DIFF
--- a/crates/harn-parser/src/builtin_signatures/signatures/stdlib.rs
+++ b/crates/harn-parser/src/builtin_signatures/signatures/stdlib.rs
@@ -172,6 +172,16 @@ pub(crate) const SIGNATURES: &[BuiltinSignature] = &[
         ],
         TY_STRING,
     ),
+    BuiltinSignature::simple("__select_list", &[Param::new("channels", TY_LIST)], TY_DICT),
+    BuiltinSignature::simple(
+        "__select_timeout",
+        &[
+            Param::new("channels", TY_LIST),
+            Param::new("timeout", TY_DURATION_OR_INT),
+        ],
+        TY_DICT,
+    ),
+    BuiltinSignature::simple("__select_try", &[Param::new("channels", TY_LIST)], TY_DICT),
     BuiltinSignature::simple("__signal_interrupted", &[], TY_BOOL),
     BuiltinSignature::simple(
         "__signal_off_interrupt",

--- a/crates/harn-vm/src/stdlib/concurrency.rs
+++ b/crates/harn-vm/src/stdlib/concurrency.rs
@@ -6,8 +6,11 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crate::shared_state::ScopedKey;
+use crate::stdlib::registration::{
+    async_builtin, register_builtin_group, AsyncBuiltin, BuiltinGroup, SyncBuiltin,
+};
 use crate::value::{VmAtomicHandle, VmChannelHandle, VmError, VmValue};
-use crate::vm::Vm;
+use crate::vm::{Vm, VmBuiltinArity};
 
 struct CircuitState {
     failures: usize,
@@ -19,6 +22,221 @@ struct CircuitState {
 thread_local! {
     static CIRCUITS: RefCell<HashMap<String, CircuitState>> = RefCell::new(HashMap::new());
 }
+
+const CONCURRENCY_SYNC_PRIMITIVES: &[SyncBuiltin] = &[
+    SyncBuiltin::new("sync_release", sync_release_builtin)
+        .signature("sync_release(permit)")
+        .arity(VmBuiltinArity::Exact(1))
+        .doc("Release a synchronization permit."),
+    SyncBuiltin::new("channel", channel_builtin)
+        .signature("channel(name?, capacity?)")
+        .arity(VmBuiltinArity::Range { min: 0, max: 2 })
+        .doc("Create an in-memory channel."),
+    SyncBuiltin::new("close_channel", close_channel_builtin)
+        .signature("close_channel(channel)")
+        .arity(VmBuiltinArity::Exact(1))
+        .doc("Mark a channel closed."),
+    SyncBuiltin::new("try_receive", try_receive_builtin)
+        .signature("try_receive(channel)")
+        .arity(VmBuiltinArity::Exact(1))
+        .doc("Try to receive one channel value without blocking."),
+    SyncBuiltin::new("atomic", atomic_builtin)
+        .signature("atomic(initial?)")
+        .arity(VmBuiltinArity::Range { min: 0, max: 1 })
+        .doc("Create an atomic integer handle."),
+    SyncBuiltin::new("atomic_get", atomic_get_builtin)
+        .signature("atomic_get(handle)")
+        .arity(VmBuiltinArity::Exact(1))
+        .doc("Read an atomic integer value."),
+    SyncBuiltin::new("atomic_set", atomic_set_builtin)
+        .signature("atomic_set(handle, value)")
+        .arity(VmBuiltinArity::Exact(2))
+        .doc("Set an atomic integer and return the previous value."),
+    SyncBuiltin::new("atomic_add", atomic_add_builtin)
+        .signature("atomic_add(handle, delta)")
+        .arity(VmBuiltinArity::Exact(2))
+        .doc("Add to an atomic integer and return the previous value."),
+    SyncBuiltin::new("atomic_cas", atomic_cas_builtin)
+        .signature("atomic_cas(handle, expected, value)")
+        .arity(VmBuiltinArity::Exact(3))
+        .doc("Compare and swap an atomic integer."),
+    SyncBuiltin::new("timer_start", timer_start_builtin)
+        .signature("timer_start(name?)")
+        .arity(VmBuiltinArity::Range { min: 0, max: 1 })
+        .doc("Start a named timer and return its handle."),
+    SyncBuiltin::new("circuit_breaker", circuit_breaker_builtin)
+        .signature("circuit_breaker(name, threshold?, reset_ms?)")
+        .arity(VmBuiltinArity::Range { min: 1, max: 3 })
+        .doc("Create or reset a named circuit breaker."),
+    SyncBuiltin::new("circuit_check", circuit_check_builtin)
+        .signature("circuit_check(name)")
+        .arity(VmBuiltinArity::Exact(1))
+        .doc("Return the state of a named circuit breaker."),
+    SyncBuiltin::new("circuit_record_success", circuit_record_success_builtin)
+        .signature("circuit_record_success(name)")
+        .arity(VmBuiltinArity::Exact(1))
+        .doc("Record a successful call for a named circuit breaker."),
+    SyncBuiltin::new("circuit_record_failure", circuit_record_failure_builtin)
+        .signature("circuit_record_failure(name)")
+        .arity(VmBuiltinArity::Exact(1))
+        .doc("Record a failed call and return whether the circuit opened."),
+    SyncBuiltin::new("circuit_reset", circuit_reset_builtin)
+        .signature("circuit_reset(name)")
+        .arity(VmBuiltinArity::Exact(1))
+        .doc("Reset a named circuit breaker to closed."),
+    SyncBuiltin::new("timer_end", timer_end_builtin)
+        .signature("timer_end(timer)")
+        .arity(VmBuiltinArity::Exact(1))
+        .doc("End a timer, print elapsed milliseconds, and return the elapsed time."),
+];
+
+const CONCURRENCY_ASYNC_PRIMITIVES: &[AsyncBuiltin] = &[
+    async_builtin!("sync_mutex_acquire", sync_mutex_acquire_builtin)
+        .signature("sync_mutex_acquire(key?, timeout_ms?)")
+        .arity(VmBuiltinArity::Range { min: 0, max: 2 })
+        .doc("Acquire a named mutex permit."),
+    async_builtin!("sync_semaphore_acquire", sync_semaphore_acquire_builtin)
+        .signature("sync_semaphore_acquire(key?, capacity?, permits?, timeout_ms?)")
+        .arity(VmBuiltinArity::Range { min: 0, max: 4 })
+        .doc("Acquire permits from a named semaphore."),
+    async_builtin!("sync_gate_acquire", sync_gate_acquire_builtin)
+        .signature("sync_gate_acquire(key?, limit?, timeout_ms?)")
+        .arity(VmBuiltinArity::Range { min: 0, max: 3 })
+        .doc("Acquire one permit from a named gate."),
+    async_builtin!("sync_rwlock_acquire", sync_rwlock_acquire_builtin)
+        .signature("sync_rwlock_acquire(key?, mode?, timeout_ms?)")
+        .arity(VmBuiltinArity::Range { min: 0, max: 3 })
+        .doc("Acquire a read or write permit from a named read-write lock."),
+    async_builtin!("sync_metrics", sync_metrics_builtin)
+        .signature("sync_metrics(kind?, key?)")
+        .arity(VmBuiltinArity::Range { min: 0, max: 2 })
+        .doc("Return synchronization runtime metrics."),
+    async_builtin!("shared_scope_id", shared_scope_id_builtin)
+        .signature("shared_scope_id(scope?, options?)")
+        .arity(VmBuiltinArity::Range { min: 0, max: 2 })
+        .doc("Resolve a shared-state scope identifier."),
+    async_builtin!("shared_cell", shared_cell_builtin)
+        .signature("shared_cell(options_or_key?, initial?)")
+        .arity(VmBuiltinArity::Range { min: 0, max: 2 })
+        .doc("Open or create a scoped shared cell."),
+    async_builtin!("shared_get", shared_get_builtin)
+        .signature("shared_get(handle)")
+        .arity(VmBuiltinArity::Exact(1))
+        .doc("Read a shared cell value."),
+    async_builtin!("shared_snapshot", shared_snapshot_builtin)
+        .signature("shared_snapshot(handle)")
+        .arity(VmBuiltinArity::Exact(1))
+        .doc("Return a shared cell snapshot."),
+    async_builtin!("shared_set", shared_set_builtin)
+        .signature("shared_set(handle, value)")
+        .arity(VmBuiltinArity::Exact(2))
+        .doc("Set a shared cell value."),
+    async_builtin!("shared_cas", shared_cas_builtin)
+        .signature("shared_cas(handle, expected, value)")
+        .arity(VmBuiltinArity::Exact(3))
+        .doc("Compare and swap a shared cell value."),
+    async_builtin!("shared_map", shared_map_builtin)
+        .signature("shared_map(options_or_key?, initial?)")
+        .arity(VmBuiltinArity::Range { min: 0, max: 2 })
+        .doc("Open or create a scoped shared map."),
+    async_builtin!("shared_map_get", shared_map_get_builtin)
+        .signature("shared_map_get(handle, key, default?)")
+        .arity(VmBuiltinArity::Range { min: 2, max: 3 })
+        .doc("Read a shared map entry."),
+    async_builtin!("shared_map_snapshot", shared_map_snapshot_builtin)
+        .signature("shared_map_snapshot(handle, key)")
+        .arity(VmBuiltinArity::Exact(2))
+        .doc("Return a shared map entry snapshot."),
+    async_builtin!("shared_map_entries", shared_map_entries_builtin)
+        .signature("shared_map_entries(handle)")
+        .arity(VmBuiltinArity::Exact(1))
+        .doc("Return all shared map entries."),
+    async_builtin!("shared_map_set", shared_map_set_builtin)
+        .signature("shared_map_set(handle, key, value)")
+        .arity(VmBuiltinArity::Exact(3))
+        .doc("Set a shared map entry."),
+    async_builtin!("shared_map_delete", shared_map_delete_builtin)
+        .signature("shared_map_delete(handle, key)")
+        .arity(VmBuiltinArity::Exact(2))
+        .doc("Delete a shared map entry."),
+    async_builtin!("shared_map_cas", shared_map_cas_builtin)
+        .signature("shared_map_cas(handle, key, expected, value)")
+        .arity(VmBuiltinArity::Exact(4))
+        .doc("Compare and swap a shared map entry."),
+    async_builtin!("shared_metrics", shared_metrics_builtin)
+        .signature("shared_metrics(handle?)")
+        .arity(VmBuiltinArity::Range { min: 0, max: 1 })
+        .doc("Return shared-state runtime metrics."),
+    async_builtin!("mailbox_open", mailbox_open_builtin)
+        .signature("mailbox_open(options_or_name?, capacity?)")
+        .arity(VmBuiltinArity::Range { min: 0, max: 2 })
+        .doc("Open or create a scoped mailbox."),
+    async_builtin!("mailbox_lookup", mailbox_lookup_builtin)
+        .signature("mailbox_lookup(target)")
+        .arity(VmBuiltinArity::Exact(1))
+        .doc("Look up a scoped mailbox handle."),
+    async_builtin!("mailbox_send", mailbox_send_builtin)
+        .signature("mailbox_send(target, value)")
+        .arity(VmBuiltinArity::Exact(2))
+        .doc("Send a value to a mailbox."),
+    async_builtin!("mailbox_try_receive", mailbox_try_receive_builtin)
+        .signature("mailbox_try_receive(target)")
+        .arity(VmBuiltinArity::Exact(1))
+        .doc("Try to receive one mailbox value without blocking."),
+    async_builtin!("mailbox_receive", mailbox_receive_builtin)
+        .signature("mailbox_receive(target)")
+        .arity(VmBuiltinArity::Exact(1))
+        .doc("Receive one mailbox value."),
+    async_builtin!("mailbox_close", mailbox_close_builtin)
+        .signature("mailbox_close(target)")
+        .arity(VmBuiltinArity::Exact(1))
+        .doc("Close a scoped mailbox."),
+    async_builtin!("mailbox_metrics", mailbox_metrics_builtin)
+        .signature("mailbox_metrics(target)")
+        .arity(VmBuiltinArity::Exact(1))
+        .doc("Return metrics for a scoped mailbox."),
+    async_builtin!("sleep", sleep_builtin)
+        .signature("sleep(ms)")
+        .arity(VmBuiltinArity::Range { min: 0, max: 1 })
+        .doc("Suspend execution for a duration in milliseconds."),
+    async_builtin!("yield_now", yield_now_builtin)
+        .signature("yield_now()")
+        .arity(VmBuiltinArity::Exact(0))
+        .doc("Yield cooperatively to other scheduled tasks."),
+    async_builtin!("send", send_builtin)
+        .signature("send(channel, value)")
+        .arity(VmBuiltinArity::Exact(2))
+        .doc("Send a value to a channel."),
+    async_builtin!("receive", receive_builtin)
+        .signature("receive(channel)")
+        .arity(VmBuiltinArity::Exact(1))
+        .doc("Receive one value from a channel."),
+    async_builtin!("select", select_builtin)
+        .signature("select(channels...)")
+        .arity(VmBuiltinArity::Min(1))
+        .doc("Wait until one of the provided channels yields a value."),
+    async_builtin!("__select_timeout", select_timeout_builtin)
+        .signature("__select_timeout(channels, timeout)")
+        .arity(VmBuiltinArity::Exact(2))
+        .doc("Select from a channel list with a timeout."),
+    async_builtin!("__select_try", select_try_builtin)
+        .signature("__select_try(channels)")
+        .arity(VmBuiltinArity::Exact(1))
+        .doc("Select from a channel list without blocking."),
+    async_builtin!("__select_list", select_list_builtin)
+        .signature("__select_list(channels)")
+        .arity(VmBuiltinArity::Exact(1))
+        .doc("Wait until one channel in a list yields a value."),
+    async_builtin!("channel_select", channel_select_builtin)
+        .signature("channel_select(channels, timeout_ms?)")
+        .arity(VmBuiltinArity::Range { min: 1, max: 2 })
+        .doc("Select over a list of channels with an optional timeout."),
+];
+
+const CONCURRENCY_PRIMITIVES: BuiltinGroup<'static> = BuiltinGroup::new()
+    .category("concurrency")
+    .sync(CONCURRENCY_SYNC_PRIMITIVES)
+    .async_(CONCURRENCY_ASYNC_PRIMITIVES);
 
 /// Build a select result dict with the given index, value, and channel name.
 fn select_result(index: usize, value: VmValue, channel_name: &str) -> VmValue {
@@ -247,970 +465,880 @@ fn scoped_from_handle_or_name(
 fn current_async_vm(builtin: &str) -> Result<Vm, VmError> {
     crate::vm::clone_async_builtin_child_vm().ok_or_else(|| {
         VmError::Runtime(format!(
-            "{builtin}: shared state builtin requires VM execution context"
+            "{builtin}: async builtin requires VM execution context"
         ))
     })
 }
 
 pub(crate) fn register_concurrency_builtins(vm: &mut Vm) {
-    let sync_runtime = vm.sync_runtime.clone();
-    vm.register_async_builtin("sync_mutex_acquire", move |args| {
-        let sync_runtime = sync_runtime.clone();
-        async move {
-            let key = args
-                .first()
-                .map(|a| a.display())
-                .unwrap_or_else(|| "__default__".to_string());
-            let timeout_ms = optional_timeout_ms(args.get(1));
-            let cancel_token =
-                crate::vm::clone_async_builtin_child_vm().and_then(|vm| vm.cancel_token.clone());
-            Ok(sync_runtime
-                .acquire("mutex", &key, 1, 1, timeout_ms, cancel_token)
-                .await?
-                .map(VmValue::SyncPermit)
-                .unwrap_or(VmValue::Nil))
-        }
-    });
+    register_builtin_group(vm, CONCURRENCY_PRIMITIVES);
+}
 
-    let sync_runtime = vm.sync_runtime.clone();
-    vm.register_async_builtin("sync_semaphore_acquire", move |args| {
-        let sync_runtime = sync_runtime.clone();
-        async move {
-            let key = args
-                .first()
-                .map(|a| a.display())
-                .unwrap_or_else(|| "default".to_string());
-            let capacity = positive_u32_arg(&args, 1, 1, "sync_semaphore_acquire")?;
-            let permits = positive_u32_arg(&args, 2, 1, "sync_semaphore_acquire")?;
-            let timeout_ms = optional_timeout_ms(args.get(3));
-            let cancel_token =
-                crate::vm::clone_async_builtin_child_vm().and_then(|vm| vm.cancel_token.clone());
-            Ok(sync_runtime
-                .acquire(
-                    "semaphore",
-                    &key,
-                    capacity,
-                    permits,
-                    timeout_ms,
-                    cancel_token,
-                )
-                .await?
-                .map(VmValue::SyncPermit)
-                .unwrap_or(VmValue::Nil))
-        }
-    });
+async fn sync_mutex_acquire_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+    let vm = current_async_vm("sync_mutex_acquire")?;
+    let key = args
+        .first()
+        .map(|a| a.display())
+        .unwrap_or_else(|| "__default__".to_string());
+    let timeout_ms = optional_timeout_ms(args.get(1));
+    Ok(vm
+        .sync_runtime
+        .acquire("mutex", &key, 1, 1, timeout_ms, vm.cancel_token.clone())
+        .await?
+        .map(VmValue::SyncPermit)
+        .unwrap_or(VmValue::Nil))
+}
 
-    let sync_runtime = vm.sync_runtime.clone();
-    vm.register_async_builtin("sync_gate_acquire", move |args| {
-        let sync_runtime = sync_runtime.clone();
-        async move {
-            let key = args
-                .first()
-                .map(|a| a.display())
-                .unwrap_or_else(|| "default".to_string());
-            let limit = positive_u32_arg(&args, 1, 1, "sync_gate_acquire")?;
-            let timeout_ms = optional_timeout_ms(args.get(2));
-            let cancel_token =
-                crate::vm::clone_async_builtin_child_vm().and_then(|vm| vm.cancel_token.clone());
-            Ok(sync_runtime
-                .acquire("gate", &key, limit, 1, timeout_ms, cancel_token)
-                .await?
-                .map(VmValue::SyncPermit)
-                .unwrap_or(VmValue::Nil))
-        }
-    });
+async fn sync_semaphore_acquire_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+    let vm = current_async_vm("sync_semaphore_acquire")?;
+    let key = args
+        .first()
+        .map(|a| a.display())
+        .unwrap_or_else(|| "default".to_string());
+    let capacity = positive_u32_arg(&args, 1, 1, "sync_semaphore_acquire")?;
+    let permits = positive_u32_arg(&args, 2, 1, "sync_semaphore_acquire")?;
+    let timeout_ms = optional_timeout_ms(args.get(3));
+    Ok(vm
+        .sync_runtime
+        .acquire(
+            "semaphore",
+            &key,
+            capacity,
+            permits,
+            timeout_ms,
+            vm.cancel_token.clone(),
+        )
+        .await?
+        .map(VmValue::SyncPermit)
+        .unwrap_or(VmValue::Nil))
+}
 
-    let sync_runtime = vm.sync_runtime.clone();
-    vm.register_async_builtin("sync_rwlock_acquire", move |args| {
-        let sync_runtime = sync_runtime.clone();
-        async move {
-            const RWLOCK_CAPACITY: u32 = 1024;
-            let key = args
-                .first()
-                .map(|a| a.display())
-                .unwrap_or_else(|| "default".to_string());
-            let mode = args
-                .get(1)
-                .map(|a| a.display())
-                .unwrap_or_else(|| "read".to_string());
-            let permits = match mode.as_str() {
-                "read" => 1,
-                "write" => RWLOCK_CAPACITY,
-                _ => {
-                    return Err(VmError::Runtime(
-                        "sync_rwlock_acquire: mode must be read or write".to_string(),
-                    ));
-                }
-            };
-            let timeout_ms = optional_timeout_ms(args.get(2));
-            let cancel_token =
-                crate::vm::clone_async_builtin_child_vm().and_then(|vm| vm.cancel_token.clone());
-            Ok(sync_runtime
-                .acquire(
-                    "rwlock",
-                    &key,
-                    RWLOCK_CAPACITY,
-                    permits,
-                    timeout_ms,
-                    cancel_token,
-                )
-                .await?
-                .map(VmValue::SyncPermit)
-                .unwrap_or(VmValue::Nil))
-        }
-    });
+async fn sync_gate_acquire_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+    let vm = current_async_vm("sync_gate_acquire")?;
+    let key = args
+        .first()
+        .map(|a| a.display())
+        .unwrap_or_else(|| "default".to_string());
+    let limit = positive_u32_arg(&args, 1, 1, "sync_gate_acquire")?;
+    let timeout_ms = optional_timeout_ms(args.get(2));
+    Ok(vm
+        .sync_runtime
+        .acquire("gate", &key, limit, 1, timeout_ms, vm.cancel_token.clone())
+        .await?
+        .map(VmValue::SyncPermit)
+        .unwrap_or(VmValue::Nil))
+}
 
-    vm.register_builtin("sync_release", |args, _out| {
-        let Some(VmValue::SyncPermit(permit)) = args.first() else {
+async fn sync_rwlock_acquire_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+    const RWLOCK_CAPACITY: u32 = 1024;
+    let vm = current_async_vm("sync_rwlock_acquire")?;
+    let key = args
+        .first()
+        .map(|a| a.display())
+        .unwrap_or_else(|| "default".to_string());
+    let mode = args
+        .get(1)
+        .map(|a| a.display())
+        .unwrap_or_else(|| "read".to_string());
+    let permits = match mode.as_str() {
+        "read" => 1,
+        "write" => RWLOCK_CAPACITY,
+        _ => {
             return Err(VmError::Runtime(
-                "sync_release: first argument must be a sync permit".to_string(),
+                "sync_rwlock_acquire: mode must be read or write".to_string(),
             ));
-        };
-        Ok(VmValue::Bool(permit.release()))
-    });
-
-    let sync_runtime = vm.sync_runtime.clone();
-    vm.register_builtin("sync_metrics", move |args, _out| {
-        let kind = args.first().map(|v| v.display());
-        let key = args.get(1).map(|v| v.display());
-        Ok(sync_runtime.metrics(kind.as_deref(), key.as_deref()))
-    });
-
-    vm.register_async_builtin("shared_scope_id", |args| async move {
-        let vm = current_async_vm("shared_scope_id")?;
-        let options = args.get(1).and_then(VmValue::as_dict);
-        let raw_scope = args.first().map(VmValue::display);
-        Ok(VmValue::String(Rc::from(resolve_shared_scope(
-            &vm,
-            raw_scope.as_deref(),
-            options,
-            "shared_scope_id",
-        )?)))
-    });
-
-    let shared_runtime = vm.shared_state_runtime.clone();
-    vm.register_async_builtin("shared_cell", move |args| {
-        let shared_runtime = shared_runtime.clone();
-        async move {
-            let vm = current_async_vm("shared_cell")?;
-            let (scoped, options) = scoped_from_open_args(&vm, &args, "shared_cell", "key")?;
-            let initial = options
-                .as_ref()
-                .and_then(|opts| opts.get("initial").cloned())
-                .or_else(|| args.get(1).cloned())
-                .unwrap_or(VmValue::Nil);
-            Ok(shared_runtime.open_cell(scoped, initial))
         }
-    });
+    };
+    let timeout_ms = optional_timeout_ms(args.get(2));
+    Ok(vm
+        .sync_runtime
+        .acquire(
+            "rwlock",
+            &key,
+            RWLOCK_CAPACITY,
+            permits,
+            timeout_ms,
+            vm.cancel_token.clone(),
+        )
+        .await?
+        .map(VmValue::SyncPermit)
+        .unwrap_or(VmValue::Nil))
+}
 
+fn sync_release_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    let Some(VmValue::SyncPermit(permit)) = args.first() else {
+        return Err(VmError::Runtime(
+            "sync_release: first argument must be a sync permit".to_string(),
+        ));
+    };
+    Ok(VmValue::Bool(permit.release()))
+}
+
+async fn sync_metrics_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+    let vm = current_async_vm("sync_metrics")?;
+    let kind = args.first().map(|v| v.display());
+    let key = args.get(1).map(|v| v.display());
+    Ok(vm.sync_runtime.metrics(kind.as_deref(), key.as_deref()))
+}
+
+async fn shared_scope_id_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+    let vm = current_async_vm("shared_scope_id")?;
+    let options = args.get(1).and_then(VmValue::as_dict);
+    let raw_scope = args.first().map(VmValue::display);
+    Ok(VmValue::String(Rc::from(resolve_shared_scope(
+        &vm,
+        raw_scope.as_deref(),
+        options,
+        "shared_scope_id",
+    )?)))
+}
+
+async fn shared_cell_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+    let vm = current_async_vm("shared_cell")?;
     let shared_runtime = vm.shared_state_runtime.clone();
-    vm.register_async_builtin("shared_get", move |args| {
-        let shared_runtime = shared_runtime.clone();
-        async move {
-            let vm = current_async_vm("shared_get")?;
-            let handle = args
-                .first()
-                .ok_or_else(|| VmError::Runtime("shared_get: handle is required".to_string()))?;
-            let scoped = scoped_from_handle_or_name(&vm, handle, "shared_cell", "shared_get")?;
-            Ok(shared_runtime.cell_get(&scoped))
+    let (scoped, options) = scoped_from_open_args(&vm, &args, "shared_cell", "key")?;
+    let initial = options
+        .as_ref()
+        .and_then(|opts| opts.get("initial").cloned())
+        .or_else(|| args.get(1).cloned())
+        .unwrap_or(VmValue::Nil);
+    Ok(shared_runtime.open_cell(scoped, initial))
+}
+
+async fn shared_get_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+    let vm = current_async_vm("shared_get")?;
+    let shared_runtime = vm.shared_state_runtime.clone();
+    let handle = args
+        .first()
+        .ok_or_else(|| VmError::Runtime("shared_get: handle is required".to_string()))?;
+    let scoped = scoped_from_handle_or_name(&vm, handle, "shared_cell", "shared_get")?;
+    Ok(shared_runtime.cell_get(&scoped))
+}
+
+async fn shared_snapshot_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+    let vm = current_async_vm("shared_snapshot")?;
+    let shared_runtime = vm.shared_state_runtime.clone();
+    let handle = args
+        .first()
+        .ok_or_else(|| VmError::Runtime("shared_snapshot: handle is required".to_string()))?;
+    let scoped = scoped_from_handle_or_name(&vm, handle, "shared_cell", "shared_snapshot")?;
+    Ok(shared_runtime.cell_snapshot(&scoped))
+}
+
+async fn shared_set_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+    let vm = current_async_vm("shared_set")?;
+    let shared_runtime = vm.shared_state_runtime.clone();
+    let handle = args
+        .first()
+        .ok_or_else(|| VmError::Runtime("shared_set: handle is required".to_string()))?;
+    let scoped = scoped_from_handle_or_name(&vm, handle, "shared_cell", "shared_set")?;
+    let value = args.get(1).cloned().unwrap_or(VmValue::Nil);
+    Ok(shared_runtime.cell_set(&scoped, value))
+}
+
+async fn shared_cas_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+    if args.len() < 3 {
+        return Err(VmError::Runtime(
+            "shared_cas: requires handle, expected, and new value".to_string(),
+        ));
+    }
+    let vm = current_async_vm("shared_cas")?;
+    let shared_runtime = vm.shared_state_runtime.clone();
+    let scoped = scoped_from_handle_or_name(&vm, &args[0], "shared_cell", "shared_cas")?;
+    Ok(VmValue::Bool(shared_runtime.cell_cas(
+        &scoped,
+        &args[1],
+        args[2].clone(),
+    )))
+}
+
+async fn shared_map_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+    let vm = current_async_vm("shared_map")?;
+    let shared_runtime = vm.shared_state_runtime.clone();
+    let (scoped, options) = scoped_from_open_args(&vm, &args, "shared_map", "key")?;
+    let initial = options
+        .as_ref()
+        .and_then(|opts| opts.get("initial"))
+        .or_else(|| args.get(1))
+        .and_then(VmValue::as_dict)
+        .cloned();
+    Ok(shared_runtime.open_map(scoped, initial))
+}
+
+async fn shared_map_get_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+    if args.len() < 2 {
+        return Err(VmError::Runtime(
+            "shared_map_get: requires handle and key".to_string(),
+        ));
+    }
+    let vm = current_async_vm("shared_map_get")?;
+    let shared_runtime = vm.shared_state_runtime.clone();
+    let scoped = scoped_from_handle_or_name(&vm, &args[0], "shared_map", "shared_map_get")?;
+    let default = args.get(2).cloned().unwrap_or(VmValue::Nil);
+    Ok(shared_runtime.map_get(&scoped, &args[1].display(), default))
+}
+
+async fn shared_map_snapshot_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+    if args.len() < 2 {
+        return Err(VmError::Runtime(
+            "shared_map_snapshot: requires handle and key".to_string(),
+        ));
+    }
+    let vm = current_async_vm("shared_map_snapshot")?;
+    let shared_runtime = vm.shared_state_runtime.clone();
+    let scoped = scoped_from_handle_or_name(&vm, &args[0], "shared_map", "shared_map_snapshot")?;
+    Ok(shared_runtime.map_snapshot(&scoped, &args[1].display()))
+}
+
+async fn shared_map_entries_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+    let vm = current_async_vm("shared_map_entries")?;
+    let shared_runtime = vm.shared_state_runtime.clone();
+    let handle = args
+        .first()
+        .ok_or_else(|| VmError::Runtime("shared_map_entries: handle is required".to_string()))?;
+    let scoped = scoped_from_handle_or_name(&vm, handle, "shared_map", "shared_map_entries")?;
+    Ok(shared_runtime.map_entries(&scoped))
+}
+
+async fn shared_map_set_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+    if args.len() < 3 {
+        return Err(VmError::Runtime(
+            "shared_map_set: requires handle, key, and value".to_string(),
+        ));
+    }
+    let vm = current_async_vm("shared_map_set")?;
+    let shared_runtime = vm.shared_state_runtime.clone();
+    let scoped = scoped_from_handle_or_name(&vm, &args[0], "shared_map", "shared_map_set")?;
+    Ok(shared_runtime.map_set(&scoped, args[1].display(), args[2].clone()))
+}
+
+async fn shared_map_delete_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+    if args.len() < 2 {
+        return Err(VmError::Runtime(
+            "shared_map_delete: requires handle and key".to_string(),
+        ));
+    }
+    let vm = current_async_vm("shared_map_delete")?;
+    let shared_runtime = vm.shared_state_runtime.clone();
+    let scoped = scoped_from_handle_or_name(&vm, &args[0], "shared_map", "shared_map_delete")?;
+    Ok(shared_runtime.map_delete(&scoped, &args[1].display()))
+}
+
+async fn shared_map_cas_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+    if args.len() < 4 {
+        return Err(VmError::Runtime(
+            "shared_map_cas: requires handle, key, expected, and new value".to_string(),
+        ));
+    }
+    let vm = current_async_vm("shared_map_cas")?;
+    let shared_runtime = vm.shared_state_runtime.clone();
+    let scoped = scoped_from_handle_or_name(&vm, &args[0], "shared_map", "shared_map_cas")?;
+    Ok(VmValue::Bool(shared_runtime.map_cas(
+        &scoped,
+        args[1].display(),
+        &args[2],
+        args[3].clone(),
+    )))
+}
+
+async fn shared_metrics_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+    let vm = current_async_vm("shared_metrics")?;
+    let shared_runtime = vm.shared_state_runtime.clone();
+    let Some(handle) = args.first() else {
+        return Ok(shared_runtime.metrics(None, None));
+    };
+    let Some(dict) = handle.as_dict() else {
+        return Ok(shared_runtime.metrics(None, None));
+    };
+    let kind = dict_string(dict, "_type")
+        .ok_or_else(|| VmError::Runtime("shared_metrics: handle missing _type".to_string()))?;
+    let scoped = scoped_from_handle_or_name(&vm, handle, &kind, "shared_metrics")?;
+    Ok(shared_runtime.metrics(Some(&kind), Some(&scoped)))
+}
+
+async fn mailbox_open_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+    let vm = current_async_vm("mailbox_open")?;
+    let shared_runtime = vm.shared_state_runtime.clone();
+    let (scoped, options) = scoped_from_open_args(&vm, &args, "mailbox_open", "name")?;
+    let capacity = options
+        .as_ref()
+        .and_then(|opts| opts.get("capacity").and_then(VmValue::as_int))
+        .or_else(|| args.get(1).and_then(VmValue::as_int))
+        .unwrap_or(256)
+        .max(1) as usize;
+    Ok(shared_runtime.open_mailbox(scoped, capacity))
+}
+
+async fn mailbox_lookup_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+    let vm = current_async_vm("mailbox_lookup")?;
+    let shared_runtime = vm.shared_state_runtime.clone();
+    let target = args.first().ok_or_else(|| {
+        VmError::Runtime("mailbox_lookup: name or handle is required".to_string())
+    })?;
+    let scoped = scoped_from_handle_or_name(&vm, target, "mailbox", "mailbox_lookup")?;
+    Ok(shared_runtime.mailbox(&scoped).unwrap_or(VmValue::Nil))
+}
+
+async fn mailbox_send_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+    if args.len() < 2 {
+        return Err(VmError::Runtime(
+            "mailbox_send: requires target and value".to_string(),
+        ));
+    }
+    let vm = current_async_vm("mailbox_send")?;
+    let shared_runtime = vm.shared_state_runtime.clone();
+    let scoped = scoped_from_handle_or_name(&vm, &args[0], "mailbox", "mailbox_send")?;
+    let Some(channel) = shared_runtime.mailbox_channel(&scoped) else {
+        return Ok(VmValue::Bool(false));
+    };
+    if channel.closed.load(Ordering::SeqCst) {
+        shared_runtime.note_mailbox_send(&scoped, false);
+        return Ok(VmValue::Bool(false));
+    }
+    let ok = channel.sender.send(args[1].clone()).await.is_ok();
+    shared_runtime.note_mailbox_send(&scoped, ok);
+    Ok(VmValue::Bool(ok))
+}
+
+async fn mailbox_try_receive_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+    let vm = current_async_vm("mailbox_try_receive")?;
+    let shared_runtime = vm.shared_state_runtime.clone();
+    let target = args
+        .first()
+        .ok_or_else(|| VmError::Runtime("mailbox_try_receive: target is required".to_string()))?;
+    let scoped = scoped_from_handle_or_name(&vm, target, "mailbox", "mailbox_try_receive")?;
+    let Some(channel) = shared_runtime.mailbox_channel(&scoped) else {
+        return Ok(VmValue::Nil);
+    };
+    let Ok(mut rx) = channel.receiver.try_lock() else {
+        return Ok(VmValue::Nil);
+    };
+    match rx.try_recv() {
+        Ok(value) => {
+            shared_runtime.note_mailbox_receive(&scoped);
+            Ok(value)
         }
-    });
+        Err(_) => Ok(VmValue::Nil),
+    }
+}
 
+async fn mailbox_receive_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+    let vm = current_async_vm("mailbox_receive")?;
     let shared_runtime = vm.shared_state_runtime.clone();
-    vm.register_async_builtin("shared_snapshot", move |args| {
-        let shared_runtime = shared_runtime.clone();
-        async move {
-            let vm = current_async_vm("shared_snapshot")?;
-            let handle = args.first().ok_or_else(|| {
-                VmError::Runtime("shared_snapshot: handle is required".to_string())
-            })?;
-            let scoped = scoped_from_handle_or_name(&vm, handle, "shared_cell", "shared_snapshot")?;
-            Ok(shared_runtime.cell_snapshot(&scoped))
+    let cancel_token = vm.cancel_token.clone();
+    let target = args
+        .first()
+        .ok_or_else(|| VmError::Runtime("mailbox_receive: target is required".to_string()))?;
+    let scoped = scoped_from_handle_or_name(&vm, target, "mailbox", "mailbox_receive")?;
+    let Some(channel) = shared_runtime.mailbox_channel(&scoped) else {
+        return Ok(VmValue::Nil);
+    };
+    loop {
+        if cancel_token
+            .as_ref()
+            .is_some_and(|token| token.load(Ordering::SeqCst))
+        {
+            return Err(cancelled_vm_error());
         }
-    });
-
-    let shared_runtime = vm.shared_state_runtime.clone();
-    vm.register_async_builtin("shared_set", move |args| {
-        let shared_runtime = shared_runtime.clone();
-        async move {
-            let vm = current_async_vm("shared_set")?;
-            let handle = args
-                .first()
-                .ok_or_else(|| VmError::Runtime("shared_set: handle is required".to_string()))?;
-            let scoped = scoped_from_handle_or_name(&vm, handle, "shared_cell", "shared_set")?;
-            let value = args.get(1).cloned().unwrap_or(VmValue::Nil);
-            Ok(shared_runtime.cell_set(&scoped, value))
-        }
-    });
-
-    let shared_runtime = vm.shared_state_runtime.clone();
-    vm.register_async_builtin("shared_cas", move |args| {
-        let shared_runtime = shared_runtime.clone();
-        async move {
-            if args.len() < 3 {
-                return Err(VmError::Runtime(
-                    "shared_cas: requires handle, expected, and new value".to_string(),
-                ));
-            }
-            let vm = current_async_vm("shared_cas")?;
-            let scoped = scoped_from_handle_or_name(&vm, &args[0], "shared_cell", "shared_cas")?;
-            Ok(VmValue::Bool(shared_runtime.cell_cas(
-                &scoped,
-                &args[1],
-                args[2].clone(),
-            )))
-        }
-    });
-
-    let shared_runtime = vm.shared_state_runtime.clone();
-    vm.register_async_builtin("shared_map", move |args| {
-        let shared_runtime = shared_runtime.clone();
-        async move {
-            let vm = current_async_vm("shared_map")?;
-            let (scoped, options) = scoped_from_open_args(&vm, &args, "shared_map", "key")?;
-            let initial = options
-                .as_ref()
-                .and_then(|opts| opts.get("initial"))
-                .or_else(|| args.get(1))
-                .and_then(VmValue::as_dict)
-                .cloned();
-            Ok(shared_runtime.open_map(scoped, initial))
-        }
-    });
-
-    let shared_runtime = vm.shared_state_runtime.clone();
-    vm.register_async_builtin("shared_map_get", move |args| {
-        let shared_runtime = shared_runtime.clone();
-        async move {
-            if args.len() < 2 {
-                return Err(VmError::Runtime(
-                    "shared_map_get: requires handle and key".to_string(),
-                ));
-            }
-            let vm = current_async_vm("shared_map_get")?;
-            let scoped = scoped_from_handle_or_name(&vm, &args[0], "shared_map", "shared_map_get")?;
-            let default = args.get(2).cloned().unwrap_or(VmValue::Nil);
-            Ok(shared_runtime.map_get(&scoped, &args[1].display(), default))
-        }
-    });
-
-    let shared_runtime = vm.shared_state_runtime.clone();
-    vm.register_async_builtin("shared_map_snapshot", move |args| {
-        let shared_runtime = shared_runtime.clone();
-        async move {
-            if args.len() < 2 {
-                return Err(VmError::Runtime(
-                    "shared_map_snapshot: requires handle and key".to_string(),
-                ));
-            }
-            let vm = current_async_vm("shared_map_snapshot")?;
-            let scoped =
-                scoped_from_handle_or_name(&vm, &args[0], "shared_map", "shared_map_snapshot")?;
-            Ok(shared_runtime.map_snapshot(&scoped, &args[1].display()))
-        }
-    });
-
-    let shared_runtime = vm.shared_state_runtime.clone();
-    vm.register_async_builtin("shared_map_entries", move |args| {
-        let shared_runtime = shared_runtime.clone();
-        async move {
-            let vm = current_async_vm("shared_map_entries")?;
-            let handle = args.first().ok_or_else(|| {
-                VmError::Runtime("shared_map_entries: handle is required".to_string())
-            })?;
-            let scoped =
-                scoped_from_handle_or_name(&vm, handle, "shared_map", "shared_map_entries")?;
-            Ok(shared_runtime.map_entries(&scoped))
-        }
-    });
-
-    let shared_runtime = vm.shared_state_runtime.clone();
-    vm.register_async_builtin("shared_map_set", move |args| {
-        let shared_runtime = shared_runtime.clone();
-        async move {
-            if args.len() < 3 {
-                return Err(VmError::Runtime(
-                    "shared_map_set: requires handle, key, and value".to_string(),
-                ));
-            }
-            let vm = current_async_vm("shared_map_set")?;
-            let scoped = scoped_from_handle_or_name(&vm, &args[0], "shared_map", "shared_map_set")?;
-            Ok(shared_runtime.map_set(&scoped, args[1].display(), args[2].clone()))
-        }
-    });
-
-    let shared_runtime = vm.shared_state_runtime.clone();
-    vm.register_async_builtin("shared_map_delete", move |args| {
-        let shared_runtime = shared_runtime.clone();
-        async move {
-            if args.len() < 2 {
-                return Err(VmError::Runtime(
-                    "shared_map_delete: requires handle and key".to_string(),
-                ));
-            }
-            let vm = current_async_vm("shared_map_delete")?;
-            let scoped =
-                scoped_from_handle_or_name(&vm, &args[0], "shared_map", "shared_map_delete")?;
-            Ok(shared_runtime.map_delete(&scoped, &args[1].display()))
-        }
-    });
-
-    let shared_runtime = vm.shared_state_runtime.clone();
-    vm.register_async_builtin("shared_map_cas", move |args| {
-        let shared_runtime = shared_runtime.clone();
-        async move {
-            if args.len() < 4 {
-                return Err(VmError::Runtime(
-                    "shared_map_cas: requires handle, key, expected, and new value".to_string(),
-                ));
-            }
-            let vm = current_async_vm("shared_map_cas")?;
-            let scoped = scoped_from_handle_or_name(&vm, &args[0], "shared_map", "shared_map_cas")?;
-            Ok(VmValue::Bool(shared_runtime.map_cas(
-                &scoped,
-                args[1].display(),
-                &args[2],
-                args[3].clone(),
-            )))
-        }
-    });
-
-    let shared_runtime = vm.shared_state_runtime.clone();
-    vm.register_async_builtin("shared_metrics", move |args| {
-        let shared_runtime = shared_runtime.clone();
-        async move {
-            let vm = current_async_vm("shared_metrics")?;
-            let Some(handle) = args.first() else {
-                return Ok(shared_runtime.metrics(None, None));
-            };
-            let Some(dict) = handle.as_dict() else {
-                return Ok(shared_runtime.metrics(None, None));
-            };
-            let kind = dict_string(dict, "_type").ok_or_else(|| {
-                VmError::Runtime("shared_metrics: handle missing _type".to_string())
-            })?;
-            let scoped = scoped_from_handle_or_name(&vm, handle, &kind, "shared_metrics")?;
-            Ok(shared_runtime.metrics(Some(&kind), Some(&scoped)))
-        }
-    });
-
-    let shared_runtime = vm.shared_state_runtime.clone();
-    vm.register_async_builtin("mailbox_open", move |args| {
-        let shared_runtime = shared_runtime.clone();
-        async move {
-            let vm = current_async_vm("mailbox_open")?;
-            let (scoped, options) = scoped_from_open_args(&vm, &args, "mailbox_open", "name")?;
-            let capacity = options
-                .as_ref()
-                .and_then(|opts| opts.get("capacity").and_then(VmValue::as_int))
-                .or_else(|| args.get(1).and_then(VmValue::as_int))
-                .unwrap_or(256)
-                .max(1) as usize;
-            Ok(shared_runtime.open_mailbox(scoped, capacity))
-        }
-    });
-
-    let shared_runtime = vm.shared_state_runtime.clone();
-    vm.register_async_builtin("mailbox_lookup", move |args| {
-        let shared_runtime = shared_runtime.clone();
-        async move {
-            let vm = current_async_vm("mailbox_lookup")?;
-            let target = args.first().ok_or_else(|| {
-                VmError::Runtime("mailbox_lookup: name or handle is required".to_string())
-            })?;
-            let scoped = scoped_from_handle_or_name(&vm, target, "mailbox", "mailbox_lookup")?;
-            Ok(shared_runtime.mailbox(&scoped).unwrap_or(VmValue::Nil))
-        }
-    });
-
-    let shared_runtime = vm.shared_state_runtime.clone();
-    vm.register_async_builtin("mailbox_send", move |args| {
-        let shared_runtime = shared_runtime.clone();
-        async move {
-            if args.len() < 2 {
-                return Err(VmError::Runtime(
-                    "mailbox_send: requires target and value".to_string(),
-                ));
-            }
-            let vm = current_async_vm("mailbox_send")?;
-            let scoped = scoped_from_handle_or_name(&vm, &args[0], "mailbox", "mailbox_send")?;
-            let Some(channel) = shared_runtime.mailbox_channel(&scoped) else {
-                return Ok(VmValue::Bool(false));
-            };
-            if channel.closed.load(Ordering::SeqCst) {
-                shared_runtime.note_mailbox_send(&scoped, false);
-                return Ok(VmValue::Bool(false));
-            }
-            let ok = channel.sender.send(args[1].clone()).await.is_ok();
-            shared_runtime.note_mailbox_send(&scoped, ok);
-            Ok(VmValue::Bool(ok))
-        }
-    });
-
-    let shared_runtime = vm.shared_state_runtime.clone();
-    vm.register_async_builtin("mailbox_try_receive", move |args| {
-        let shared_runtime = shared_runtime.clone();
-        async move {
-            let vm = current_async_vm("mailbox_try_receive")?;
-            let target = args.first().ok_or_else(|| {
-                VmError::Runtime("mailbox_try_receive: target is required".to_string())
-            })?;
-            let scoped = scoped_from_handle_or_name(&vm, target, "mailbox", "mailbox_try_receive")?;
-            let Some(channel) = shared_runtime.mailbox_channel(&scoped) else {
-                return Ok(VmValue::Nil);
-            };
-            let Ok(mut rx) = channel.receiver.try_lock() else {
-                return Ok(VmValue::Nil);
-            };
-            match rx.try_recv() {
+        if channel.closed.load(Ordering::SeqCst) {
+            let mut rx = channel.receiver.lock().await;
+            return match rx.try_recv() {
                 Ok(value) => {
                     shared_runtime.note_mailbox_receive(&scoped);
                     Ok(value)
                 }
                 Err(_) => Ok(VmValue::Nil),
-            }
-        }
-    });
-
-    let shared_runtime = vm.shared_state_runtime.clone();
-    vm.register_async_builtin("mailbox_receive", move |args| {
-        let shared_runtime = shared_runtime.clone();
-        async move {
-            let vm = current_async_vm("mailbox_receive")?;
-            let cancel_token = vm.cancel_token.clone();
-            let target = args.first().ok_or_else(|| {
-                VmError::Runtime("mailbox_receive: target is required".to_string())
-            })?;
-            let scoped = scoped_from_handle_or_name(&vm, target, "mailbox", "mailbox_receive")?;
-            let Some(channel) = shared_runtime.mailbox_channel(&scoped) else {
-                return Ok(VmValue::Nil);
             };
-            loop {
-                if cancel_token
-                    .as_ref()
-                    .is_some_and(|token| token.load(Ordering::SeqCst))
-                {
-                    return Err(cancelled_vm_error());
-                }
-                if channel.closed.load(Ordering::SeqCst) {
-                    let mut rx = channel.receiver.lock().await;
-                    return match rx.try_recv() {
-                        Ok(value) => {
-                            shared_runtime.note_mailbox_receive(&scoped);
-                            Ok(value)
-                        }
-                        Err(_) => Ok(VmValue::Nil),
-                    };
-                }
-                let mut rx = channel.receiver.lock().await;
-                let poll = tokio::time::sleep(tokio::time::Duration::from_millis(10));
-                tokio::pin!(poll);
-                tokio::select! {
-                    value = rx.recv() => {
-                        return match value {
-                            Some(value) => {
-                                shared_runtime.note_mailbox_receive(&scoped);
-                                Ok(value)
-                            }
-                            None => Ok(VmValue::Nil),
-                        };
+        }
+        let mut rx = channel.receiver.lock().await;
+        let poll = tokio::time::sleep(tokio::time::Duration::from_millis(10));
+        tokio::pin!(poll);
+        tokio::select! {
+            value = rx.recv() => {
+                return match value {
+                    Some(value) => {
+                        shared_runtime.note_mailbox_receive(&scoped);
+                        Ok(value)
                     }
-                    _ = &mut poll => {}
-                }
-            }
-        }
-    });
-
-    let shared_runtime = vm.shared_state_runtime.clone();
-    vm.register_async_builtin("mailbox_close", move |args| {
-        let shared_runtime = shared_runtime.clone();
-        async move {
-            let vm = current_async_vm("mailbox_close")?;
-            let target = args
-                .first()
-                .ok_or_else(|| VmError::Runtime("mailbox_close: target is required".to_string()))?;
-            let scoped = scoped_from_handle_or_name(&vm, target, "mailbox", "mailbox_close")?;
-            Ok(VmValue::Bool(shared_runtime.close_mailbox(&scoped)))
-        }
-    });
-
-    let shared_runtime = vm.shared_state_runtime.clone();
-    vm.register_async_builtin("mailbox_metrics", move |args| {
-        let shared_runtime = shared_runtime.clone();
-        async move {
-            let vm = current_async_vm("mailbox_metrics")?;
-            let target = args.first().ok_or_else(|| {
-                VmError::Runtime("mailbox_metrics: target is required".to_string())
-            })?;
-            let scoped = scoped_from_handle_or_name(&vm, target, "mailbox", "mailbox_metrics")?;
-            Ok(shared_runtime.metrics(Some("mailbox"), Some(&scoped)))
-        }
-    });
-
-    vm.register_builtin("channel", |args, _out| {
-        let name = args
-            .first()
-            .map(|a| a.display())
-            .unwrap_or_else(|| "default".to_string());
-        let capacity = args.get(1).and_then(|a| a.as_int()).unwrap_or(256) as usize;
-        let capacity = capacity.max(1);
-        let (tx, rx) = tokio::sync::mpsc::channel(capacity);
-        // Arc is deliberate: refcount ownership within a single-threaded tokio
-        // LocalSet (VmValue is !Send because it holds Rc). The Arc never crosses
-        // threads — see the thread-local invariant on crate::llm::agent_runtime::emit_agent_event.
-        #[allow(clippy::arc_with_non_send_sync)]
-        Ok(VmValue::Channel(VmChannelHandle {
-            name: Rc::from(name),
-            sender: Arc::new(tx),
-            receiver: Arc::new(tokio::sync::Mutex::new(rx)),
-            closed: Arc::new(AtomicBool::new(false)),
-        }))
-    });
-
-    vm.register_builtin("close_channel", |args, _out| {
-        if args.is_empty() {
-            return Err(VmError::Thrown(VmValue::String(Rc::from(
-                "close_channel: requires a channel",
-            ))));
-        }
-        if let VmValue::Channel(ch) = &args[0] {
-            ch.closed.store(true, Ordering::SeqCst);
-            Ok(VmValue::Nil)
-        } else {
-            Err(VmError::Thrown(VmValue::String(Rc::from(
-                "close_channel: first argument must be a channel",
-            ))))
-        }
-    });
-
-    vm.register_builtin("try_receive", |args, _out| {
-        if args.is_empty() {
-            return Err(VmError::Thrown(VmValue::String(Rc::from(
-                "try_receive: requires a channel",
-            ))));
-        }
-        if let VmValue::Channel(ch) = &args[0] {
-            match ch.receiver.try_lock() {
-                Ok(mut rx) => match rx.try_recv() {
-                    Ok(val) => Ok(val),
-                    Err(_) => Ok(VmValue::Nil),
-                },
-                Err(_) => Ok(VmValue::Nil),
-            }
-        } else {
-            Err(VmError::Thrown(VmValue::String(Rc::from(
-                "try_receive: first argument must be a channel",
-            ))))
-        }
-    });
-
-    vm.register_builtin("atomic", |args, _out| {
-        let initial = match args.first() {
-            Some(VmValue::Int(n)) => *n,
-            Some(VmValue::Float(f)) => *f as i64,
-            Some(VmValue::Bool(b)) => i64::from(*b),
-            _ => 0,
-        };
-        Ok(VmValue::Atomic(VmAtomicHandle {
-            value: Arc::new(AtomicI64::new(initial)),
-        }))
-    });
-
-    vm.register_builtin("atomic_get", |args, _out| {
-        if let Some(VmValue::Atomic(a)) = args.first() {
-            Ok(VmValue::Int(a.value.load(Ordering::SeqCst)))
-        } else {
-            Ok(VmValue::Nil)
-        }
-    });
-
-    vm.register_builtin("atomic_set", |args, _out| {
-        if args.len() >= 2 {
-            if let (VmValue::Atomic(a), Some(val)) = (&args[0], args[1].as_int()) {
-                let old = a.value.swap(val, Ordering::SeqCst);
-                return Ok(VmValue::Int(old));
-            }
-        }
-        Ok(VmValue::Nil)
-    });
-
-    vm.register_builtin("atomic_add", |args, _out| {
-        if args.len() >= 2 {
-            if let (VmValue::Atomic(a), Some(delta)) = (&args[0], args[1].as_int()) {
-                let prev = a.value.fetch_add(delta, Ordering::SeqCst);
-                return Ok(VmValue::Int(prev));
-            }
-        }
-        Ok(VmValue::Nil)
-    });
-
-    vm.register_builtin("atomic_cas", |args, _out| {
-        if args.len() >= 3 {
-            if let (VmValue::Atomic(a), Some(expected), Some(new_val)) =
-                (&args[0], args[1].as_int(), args[2].as_int())
-            {
-                let result =
-                    a.value
-                        .compare_exchange(expected, new_val, Ordering::SeqCst, Ordering::SeqCst);
-                return Ok(VmValue::Bool(result.is_ok()));
-            }
-        }
-        Ok(VmValue::Bool(false))
-    });
-
-    vm.register_async_builtin("sleep", |args| async move {
-        let ms = match args.first() {
-            Some(VmValue::Duration(ms)) => (*ms).max(0) as u64,
-            Some(VmValue::Int(n)) => (*n).max(0) as u64,
-            _ => 0,
-        };
-        if ms == 0 {
-            return Ok(VmValue::Nil);
-        }
-        // Honor the unified test clock mock: when a script (or surrounding
-        // Rust test) has installed `mock_time(...)`, `sleep(...)` advances
-        // the mock instead of suspending the runtime. This converges with
-        // `sleep_ms` and lets conformance tests that exercise concurrency
-        // primitives drive deterministic timing without wall-clock flake.
-        if crate::stdlib::clock::is_mocked() {
-            crate::stdlib::clock::advance(ms as i64);
-            return Ok(VmValue::Nil);
-        }
-        let sleep = tokio::time::sleep(tokio::time::Duration::from_millis(ms));
-        tokio::pin!(sleep);
-        if let Some(vm) = crate::vm::clone_async_builtin_child_vm() {
-            let mut poll = tokio::time::interval(Duration::from_millis(10));
-            loop {
-                tokio::select! {
-                    _ = &mut sleep => break,
-                    _ = poll.tick() => {
-                        if vm.is_cancel_requested() {
-                            return Err(cancelled_vm_error());
-                        }
-                    }
-                }
-            }
-        } else {
-            sleep.await;
-        }
-        Ok(VmValue::Nil)
-    });
-
-    vm.register_async_builtin("yield_now", |_args| async move {
-        // Cooperative scheduling primitive — gives other tasks a chance to
-        // make progress without inserting a wall-clock sleep. Pairs with
-        // `mock_time(...)` for deterministic concurrency tests where the
-        // surrounding `parallel each` / channel orchestration just needs
-        // one more poll, not actual time advancement.
-        tokio::task::yield_now().await;
-        Ok(VmValue::Nil)
-    });
-
-    vm.register_async_builtin("send", |args| async move {
-        if args.len() < 2 {
-            return Err(VmError::Thrown(VmValue::String(Rc::from(
-                "send: requires channel and value",
-            ))));
-        }
-        if let VmValue::Channel(ch) = &args[0] {
-            if ch.closed.load(Ordering::SeqCst) {
-                return Ok(VmValue::Bool(false));
-            }
-            let val = args[1].clone();
-            match ch.sender.send(val).await {
-                Ok(()) => Ok(VmValue::Bool(true)),
-                Err(_) => Ok(VmValue::Bool(false)),
-            }
-        } else {
-            Err(VmError::Thrown(VmValue::String(Rc::from(
-                "send: first argument must be a channel",
-            ))))
-        }
-    });
-
-    vm.register_async_builtin("receive", |args| async move {
-        if args.is_empty() {
-            return Err(VmError::Thrown(VmValue::String(Rc::from(
-                "receive: requires a channel",
-            ))));
-        }
-        if let VmValue::Channel(ch) = &args[0] {
-            if ch.closed.load(Ordering::SeqCst) {
-                let mut rx = ch.receiver.lock().await;
-                return match rx.try_recv() {
-                    Ok(val) => Ok(val),
-                    Err(_) => Ok(VmValue::Nil),
+                    None => Ok(VmValue::Nil),
                 };
             }
-            let mut rx = ch.receiver.lock().await;
-            match rx.recv().await {
-                Some(val) => Ok(val),
-                None => Ok(VmValue::Nil),
-            }
-        } else {
-            Err(VmError::Thrown(VmValue::String(Rc::from(
-                "receive: first argument must be a channel",
-            ))))
+            _ = &mut poll => {}
         }
-    });
+    }
+}
 
-    vm.register_async_builtin("select", |args| async move {
-        if args.is_empty() {
-            return Err(VmError::Thrown(VmValue::String(Rc::from(
-                "select: requires at least one channel",
-            ))));
+async fn mailbox_close_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+    let vm = current_async_vm("mailbox_close")?;
+    let shared_runtime = vm.shared_state_runtime.clone();
+    let target = args
+        .first()
+        .ok_or_else(|| VmError::Runtime("mailbox_close: target is required".to_string()))?;
+    let scoped = scoped_from_handle_or_name(&vm, target, "mailbox", "mailbox_close")?;
+    Ok(VmValue::Bool(shared_runtime.close_mailbox(&scoped)))
+}
+
+async fn mailbox_metrics_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+    let vm = current_async_vm("mailbox_metrics")?;
+    let shared_runtime = vm.shared_state_runtime.clone();
+    let target = args
+        .first()
+        .ok_or_else(|| VmError::Runtime("mailbox_metrics: target is required".to_string()))?;
+    let scoped = scoped_from_handle_or_name(&vm, target, "mailbox", "mailbox_metrics")?;
+    Ok(shared_runtime.metrics(Some("mailbox"), Some(&scoped)))
+}
+
+fn channel_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    let name = args
+        .first()
+        .map(|a| a.display())
+        .unwrap_or_else(|| "default".to_string());
+    let capacity = args.get(1).and_then(|a| a.as_int()).unwrap_or(256) as usize;
+    let capacity = capacity.max(1);
+    let (tx, rx) = tokio::sync::mpsc::channel(capacity);
+    // The handle stays on the single-threaded VM LocalSet; VmValue itself is !Send.
+    #[allow(clippy::arc_with_non_send_sync)]
+    Ok(VmValue::Channel(VmChannelHandle {
+        name: Rc::from(name),
+        sender: Arc::new(tx),
+        receiver: Arc::new(tokio::sync::Mutex::new(rx)),
+        closed: Arc::new(AtomicBool::new(false)),
+    }))
+}
+
+fn close_channel_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    if args.is_empty() {
+        return Err(VmError::Thrown(VmValue::String(Rc::from(
+            "close_channel: requires a channel",
+        ))));
+    }
+    if let VmValue::Channel(ch) = &args[0] {
+        ch.closed.store(true, Ordering::SeqCst);
+        Ok(VmValue::Nil)
+    } else {
+        Err(VmError::Thrown(VmValue::String(Rc::from(
+            "close_channel: first argument must be a channel",
+        ))))
+    }
+}
+
+fn try_receive_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    if args.is_empty() {
+        return Err(VmError::Thrown(VmValue::String(Rc::from(
+            "try_receive: requires a channel",
+        ))));
+    }
+    if let VmValue::Channel(ch) = &args[0] {
+        match ch.receiver.try_lock() {
+            Ok(mut rx) => match rx.try_recv() {
+                Ok(val) => Ok(val),
+                Err(_) => Ok(VmValue::Nil),
+            },
+            Err(_) => Ok(VmValue::Nil),
         }
-        for arg in &args {
-            if !matches!(arg, VmValue::Channel(_)) {
-                return Err(VmError::Thrown(VmValue::String(Rc::from(
-                    "select: all arguments must be channels",
-                ))));
-            }
+    } else {
+        Err(VmError::Thrown(VmValue::String(Rc::from(
+            "try_receive: first argument must be a channel",
+        ))))
+    }
+}
+
+fn atomic_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    let initial = match args.first() {
+        Some(VmValue::Int(n)) => *n,
+        Some(VmValue::Float(f)) => *f as i64,
+        Some(VmValue::Bool(b)) => i64::from(*b),
+        _ => 0,
+    };
+    Ok(VmValue::Atomic(VmAtomicHandle {
+        value: Arc::new(AtomicI64::new(initial)),
+    }))
+}
+
+fn atomic_get_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    if let Some(VmValue::Atomic(a)) = args.first() {
+        Ok(VmValue::Int(a.value.load(Ordering::SeqCst)))
+    } else {
+        Ok(VmValue::Nil)
+    }
+}
+
+fn atomic_set_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    if args.len() >= 2 {
+        if let (VmValue::Atomic(a), Some(val)) = (&args[0], args[1].as_int()) {
+            let old = a.value.swap(val, Ordering::SeqCst);
+            return Ok(VmValue::Int(old));
         }
+    }
+    Ok(VmValue::Nil)
+}
+
+fn atomic_add_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    if args.len() >= 2 {
+        if let (VmValue::Atomic(a), Some(delta)) = (&args[0], args[1].as_int()) {
+            let prev = a.value.fetch_add(delta, Ordering::SeqCst);
+            return Ok(VmValue::Int(prev));
+        }
+    }
+    Ok(VmValue::Nil)
+}
+
+fn atomic_cas_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    if args.len() >= 3 {
+        if let (VmValue::Atomic(a), Some(expected), Some(new_val)) =
+            (&args[0], args[1].as_int(), args[2].as_int())
+        {
+            let result =
+                a.value
+                    .compare_exchange(expected, new_val, Ordering::SeqCst, Ordering::SeqCst);
+            return Ok(VmValue::Bool(result.is_ok()));
+        }
+    }
+    Ok(VmValue::Bool(false))
+}
+
+async fn sleep_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+    let ms = match args.first() {
+        Some(VmValue::Duration(ms)) => (*ms).max(0) as u64,
+        Some(VmValue::Int(n)) => (*n).max(0) as u64,
+        _ => 0,
+    };
+    if ms == 0 {
+        return Ok(VmValue::Nil);
+    }
+    if crate::stdlib::clock::is_mocked() {
+        crate::stdlib::clock::advance(ms as i64);
+        return Ok(VmValue::Nil);
+    }
+    let sleep = tokio::time::sleep(tokio::time::Duration::from_millis(ms));
+    tokio::pin!(sleep);
+    if let Some(vm) = crate::vm::clone_async_builtin_child_vm() {
+        let mut poll = tokio::time::interval(Duration::from_millis(10));
         loop {
-            let (found, all_closed) = try_poll_channels(&args);
-            if let Some((i, val, name)) = found {
-                return Ok(select_result(i, val, &name));
-            }
-            if all_closed {
-                return Ok(select_none());
-            }
-            tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
-        }
-    });
-
-    vm.register_async_builtin("__select_timeout", |args| async move {
-        if args.len() < 2 {
-            return Err(VmError::Thrown(VmValue::String(Rc::from(
-                "__select_timeout: requires channel list and timeout",
-            ))));
-        }
-        let channels = match &args[0] {
-            VmValue::List(items) => (**items).clone(),
-            _ => {
-                return Err(VmError::Thrown(VmValue::String(Rc::from(
-                    "__select_timeout: first argument must be a list of channels",
-                ))));
-            }
-        };
-        let timeout_ms = match &args[1] {
-            VmValue::Int(n) => (*n).max(0) as u64,
-            VmValue::Duration(ms) => (*ms).max(0) as u64,
-            _ => 5000,
-        };
-        let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_millis(timeout_ms);
-        loop {
-            let (found, all_closed) = try_poll_channels(&channels);
-            if let Some((i, val, name)) = found {
-                return Ok(select_result(i, val, &name));
-            }
-            if all_closed || tokio::time::Instant::now() >= deadline {
-                return Ok(select_none());
-            }
-            tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
-        }
-    });
-
-    vm.register_async_builtin("__select_try", |args| async move {
-        if args.is_empty() {
-            return Err(VmError::Thrown(VmValue::String(Rc::from(
-                "__select_try: requires channel list",
-            ))));
-        }
-        let channels = match &args[0] {
-            VmValue::List(items) => (**items).clone(),
-            _ => {
-                return Err(VmError::Thrown(VmValue::String(Rc::from(
-                    "__select_try: first argument must be a list of channels",
-                ))));
-            }
-        };
-        let (found, _) = try_poll_channels(&channels);
-        if let Some((i, val, name)) = found {
-            Ok(select_result(i, val, &name))
-        } else {
-            Ok(select_none())
-        }
-    });
-
-    vm.register_async_builtin("__select_list", |args| async move {
-        if args.is_empty() {
-            return Err(VmError::Thrown(VmValue::String(Rc::from(
-                "__select_list: requires channel list",
-            ))));
-        }
-        let channels = match &args[0] {
-            VmValue::List(items) => (**items).clone(),
-            _ => {
-                return Err(VmError::Thrown(VmValue::String(Rc::from(
-                    "__select_list: first argument must be a list of channels",
-                ))));
-            }
-        };
-        loop {
-            let (found, all_closed) = try_poll_channels(&channels);
-            if let Some((i, val, name)) = found {
-                return Ok(select_result(i, val, &name));
-            }
-            if all_closed {
-                return Ok(select_none());
-            }
-            tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
-        }
-    });
-
-    vm.register_async_builtin("channel_select", |args| async move {
-        let channels = require_channel_list(&args, "channel_select")?;
-        let timeout_ms = optional_timeout_ms(args.get(1));
-        let deadline = timeout_ms
-            .map(|ms| tokio::time::Instant::now() + tokio::time::Duration::from_millis(ms));
-        loop {
-            let (found, all_closed) = try_poll_channels(&channels);
-            if let Some((i, val, name)) = found {
-                return Ok(select_result(i, val, &name));
-            }
-            if all_closed {
-                return Ok(VmValue::Nil);
-            }
-            if deadline.is_some_and(|deadline| tokio::time::Instant::now() >= deadline) {
-                return Ok(VmValue::Nil);
-            }
-            tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
-        }
-    });
-
-    vm.register_builtin("timer_start", |args, _out| {
-        let name = args
-            .first()
-            .map(|a| a.display())
-            .unwrap_or_else(|| "default".to_string());
-        let now_ms = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis() as i64;
-        let mut timer = BTreeMap::new();
-        timer.insert("name".to_string(), VmValue::String(Rc::from(name)));
-        timer.insert("start_ms".to_string(), VmValue::Int(now_ms));
-        Ok(VmValue::Dict(Rc::new(timer)))
-    });
-
-    vm.register_builtin("circuit_breaker", |args, _out| {
-        let name = args
-            .first()
-            .map(|a| a.display())
-            .unwrap_or_else(|| "default".to_string());
-        let threshold = args.get(1).and_then(|a| a.as_int()).unwrap_or(5) as usize;
-        let reset_ms = args.get(2).and_then(|a| a.as_int()).unwrap_or(30000) as u64;
-        CIRCUITS.with(|circuits| {
-            circuits.borrow_mut().insert(
-                name.clone(),
-                CircuitState {
-                    failures: 0,
-                    threshold,
-                    reset_ms,
-                    opened_at: None,
-                },
-            );
-        });
-        Ok(VmValue::String(Rc::from(name)))
-    });
-
-    vm.register_builtin("circuit_check", |args, _out| {
-        let name = args
-            .first()
-            .map(|a| a.display())
-            .unwrap_or_else(|| "default".to_string());
-        let state = CIRCUITS.with(|circuits| {
-            let circuits = circuits.borrow();
-            let Some(cs) = circuits.get(&name) else {
-                return "closed".to_string();
-            };
-            match cs.opened_at {
-                None => "closed".to_string(),
-                Some(opened) => {
-                    let elapsed = opened.elapsed().as_millis() as u64;
-                    if elapsed >= cs.reset_ms {
-                        "half_open".to_string()
-                    } else {
-                        "open".to_string()
+            tokio::select! {
+                _ = &mut sleep => break,
+                _ = poll.tick() => {
+                    if vm.is_cancel_requested() {
+                        return Err(cancelled_vm_error());
                     }
                 }
             }
-        });
-        Ok(VmValue::String(Rc::from(state)))
-    });
+        }
+    } else {
+        sleep.await;
+    }
+    Ok(VmValue::Nil)
+}
 
-    vm.register_builtin("circuit_record_success", |args, _out| {
-        let name = args
-            .first()
-            .map(|a| a.display())
-            .unwrap_or_else(|| "default".to_string());
-        CIRCUITS.with(|circuits| {
-            let mut circuits = circuits.borrow_mut();
-            if let Some(cs) = circuits.get_mut(&name) {
-                cs.failures = 0;
-                cs.opened_at = None;
-            }
-        });
-        Ok(VmValue::Nil)
-    });
+async fn yield_now_builtin(_args: Vec<VmValue>) -> Result<VmValue, VmError> {
+    tokio::task::yield_now().await;
+    Ok(VmValue::Nil)
+}
 
-    vm.register_builtin("circuit_record_failure", |args, _out| {
-        let name = args
-            .first()
-            .map(|a| a.display())
-            .unwrap_or_else(|| "default".to_string());
-        let is_open = CIRCUITS.with(|circuits| {
-            let mut circuits = circuits.borrow_mut();
-            if let Some(cs) = circuits.get_mut(&name) {
-                cs.failures += 1;
-                if cs.failures >= cs.threshold && cs.opened_at.is_none() {
-                    cs.opened_at = Some(std::time::Instant::now());
-                    return true;
+async fn send_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+    if args.len() < 2 {
+        return Err(VmError::Thrown(VmValue::String(Rc::from(
+            "send: requires channel and value",
+        ))));
+    }
+    if let VmValue::Channel(ch) = &args[0] {
+        if ch.closed.load(Ordering::SeqCst) {
+            return Ok(VmValue::Bool(false));
+        }
+        let val = args[1].clone();
+        match ch.sender.send(val).await {
+            Ok(()) => Ok(VmValue::Bool(true)),
+            Err(_) => Ok(VmValue::Bool(false)),
+        }
+    } else {
+        Err(VmError::Thrown(VmValue::String(Rc::from(
+            "send: first argument must be a channel",
+        ))))
+    }
+}
+
+async fn receive_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+    if args.is_empty() {
+        return Err(VmError::Thrown(VmValue::String(Rc::from(
+            "receive: requires a channel",
+        ))));
+    }
+    if let VmValue::Channel(ch) = &args[0] {
+        if ch.closed.load(Ordering::SeqCst) {
+            let mut rx = ch.receiver.lock().await;
+            return match rx.try_recv() {
+                Ok(val) => Ok(val),
+                Err(_) => Ok(VmValue::Nil),
+            };
+        }
+        let mut rx = ch.receiver.lock().await;
+        match rx.recv().await {
+            Some(val) => Ok(val),
+            None => Ok(VmValue::Nil),
+        }
+    } else {
+        Err(VmError::Thrown(VmValue::String(Rc::from(
+            "receive: first argument must be a channel",
+        ))))
+    }
+}
+
+async fn select_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+    if args.is_empty() {
+        return Err(VmError::Thrown(VmValue::String(Rc::from(
+            "select: requires at least one channel",
+        ))));
+    }
+    for arg in &args {
+        if !matches!(arg, VmValue::Channel(_)) {
+            return Err(VmError::Thrown(VmValue::String(Rc::from(
+                "select: all arguments must be channels",
+            ))));
+        }
+    }
+    loop {
+        let (found, all_closed) = try_poll_channels(&args);
+        if let Some((i, val, name)) = found {
+            return Ok(select_result(i, val, &name));
+        }
+        if all_closed {
+            return Ok(select_none());
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
+    }
+}
+
+async fn select_timeout_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+    if args.len() < 2 {
+        return Err(VmError::Thrown(VmValue::String(Rc::from(
+            "__select_timeout: requires channel list and timeout",
+        ))));
+    }
+    let channels = match &args[0] {
+        VmValue::List(items) => (**items).clone(),
+        _ => {
+            return Err(VmError::Thrown(VmValue::String(Rc::from(
+                "__select_timeout: first argument must be a list of channels",
+            ))));
+        }
+    };
+    let timeout_ms = match &args[1] {
+        VmValue::Int(n) => (*n).max(0) as u64,
+        VmValue::Duration(ms) => (*ms).max(0) as u64,
+        _ => 5000,
+    };
+    let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_millis(timeout_ms);
+    loop {
+        let (found, all_closed) = try_poll_channels(&channels);
+        if let Some((i, val, name)) = found {
+            return Ok(select_result(i, val, &name));
+        }
+        if all_closed || tokio::time::Instant::now() >= deadline {
+            return Ok(select_none());
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
+    }
+}
+
+async fn select_try_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+    if args.is_empty() {
+        return Err(VmError::Thrown(VmValue::String(Rc::from(
+            "__select_try: requires channel list",
+        ))));
+    }
+    let channels = match &args[0] {
+        VmValue::List(items) => (**items).clone(),
+        _ => {
+            return Err(VmError::Thrown(VmValue::String(Rc::from(
+                "__select_try: first argument must be a list of channels",
+            ))));
+        }
+    };
+    let (found, _) = try_poll_channels(&channels);
+    if let Some((i, val, name)) = found {
+        Ok(select_result(i, val, &name))
+    } else {
+        Ok(select_none())
+    }
+}
+
+async fn select_list_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+    if args.is_empty() {
+        return Err(VmError::Thrown(VmValue::String(Rc::from(
+            "__select_list: requires channel list",
+        ))));
+    }
+    let channels = match &args[0] {
+        VmValue::List(items) => (**items).clone(),
+        _ => {
+            return Err(VmError::Thrown(VmValue::String(Rc::from(
+                "__select_list: first argument must be a list of channels",
+            ))));
+        }
+    };
+    loop {
+        let (found, all_closed) = try_poll_channels(&channels);
+        if let Some((i, val, name)) = found {
+            return Ok(select_result(i, val, &name));
+        }
+        if all_closed {
+            return Ok(select_none());
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
+    }
+}
+
+async fn channel_select_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+    let channels = require_channel_list(&args, "channel_select")?;
+    let timeout_ms = optional_timeout_ms(args.get(1));
+    let deadline =
+        timeout_ms.map(|ms| tokio::time::Instant::now() + tokio::time::Duration::from_millis(ms));
+    loop {
+        let (found, all_closed) = try_poll_channels(&channels);
+        if let Some((i, val, name)) = found {
+            return Ok(select_result(i, val, &name));
+        }
+        if all_closed {
+            return Ok(VmValue::Nil);
+        }
+        if deadline.is_some_and(|deadline| tokio::time::Instant::now() >= deadline) {
+            return Ok(VmValue::Nil);
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
+    }
+}
+
+fn timer_start_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    let name = args
+        .first()
+        .map(|a| a.display())
+        .unwrap_or_else(|| "default".to_string());
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64;
+    let mut timer = BTreeMap::new();
+    timer.insert("name".to_string(), VmValue::String(Rc::from(name)));
+    timer.insert("start_ms".to_string(), VmValue::Int(now_ms));
+    Ok(VmValue::Dict(Rc::new(timer)))
+}
+
+fn circuit_breaker_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    let name = args
+        .first()
+        .map(|a| a.display())
+        .unwrap_or_else(|| "default".to_string());
+    let threshold = args.get(1).and_then(|a| a.as_int()).unwrap_or(5) as usize;
+    let reset_ms = args.get(2).and_then(|a| a.as_int()).unwrap_or(30000) as u64;
+    CIRCUITS.with(|circuits| {
+        circuits.borrow_mut().insert(
+            name.clone(),
+            CircuitState {
+                failures: 0,
+                threshold,
+                reset_ms,
+                opened_at: None,
+            },
+        );
+    });
+    Ok(VmValue::String(Rc::from(name)))
+}
+
+fn circuit_check_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    let name = args
+        .first()
+        .map(|a| a.display())
+        .unwrap_or_else(|| "default".to_string());
+    let state = CIRCUITS.with(|circuits| {
+        let circuits = circuits.borrow();
+        let Some(cs) = circuits.get(&name) else {
+            return "closed".to_string();
+        };
+        match cs.opened_at {
+            None => "closed".to_string(),
+            Some(opened) => {
+                let elapsed = opened.elapsed().as_millis() as u64;
+                if elapsed >= cs.reset_ms {
+                    "half_open".to_string()
+                } else {
+                    "open".to_string()
                 }
             }
-            false
-        });
-        Ok(VmValue::Bool(is_open))
+        }
     });
+    Ok(VmValue::String(Rc::from(state)))
+}
 
-    vm.register_builtin("circuit_reset", |args, _out| {
-        let name = args
-            .first()
-            .map(|a| a.display())
-            .unwrap_or_else(|| "default".to_string());
-        CIRCUITS.with(|circuits| {
-            let mut circuits = circuits.borrow_mut();
-            if let Some(cs) = circuits.get_mut(&name) {
-                cs.failures = 0;
-                cs.opened_at = None;
-            }
-        });
-        Ok(VmValue::Nil)
+fn circuit_record_success_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    let name = args
+        .first()
+        .map(|a| a.display())
+        .unwrap_or_else(|| "default".to_string());
+    CIRCUITS.with(|circuits| {
+        let mut circuits = circuits.borrow_mut();
+        if let Some(cs) = circuits.get_mut(&name) {
+            cs.failures = 0;
+            cs.opened_at = None;
+        }
     });
+    Ok(VmValue::Nil)
+}
 
-    vm.register_builtin("timer_end", |args, out| {
-        let timer = match args.first() {
-            Some(VmValue::Dict(d)) => d,
-            _ => {
-                return Err(VmError::Thrown(VmValue::String(Rc::from(
-                    "timer_end: argument must be a timer dict from timer_start",
-                ))));
+fn circuit_record_failure_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    let name = args
+        .first()
+        .map(|a| a.display())
+        .unwrap_or_else(|| "default".to_string());
+    let is_open = CIRCUITS.with(|circuits| {
+        let mut circuits = circuits.borrow_mut();
+        if let Some(cs) = circuits.get_mut(&name) {
+            cs.failures += 1;
+            if cs.failures >= cs.threshold && cs.opened_at.is_none() {
+                cs.opened_at = Some(std::time::Instant::now());
+                return true;
             }
-        };
-        let now_ms = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis() as i64;
-        let start_ms = timer
-            .get("start_ms")
-            .and_then(|v| v.as_int())
-            .unwrap_or(now_ms);
-        let elapsed = now_ms - start_ms;
-        let name = timer.get("name").map(|v| v.display()).unwrap_or_default();
-        out.push_str(&format!("[timer] {name}: {elapsed}ms\n"));
-        Ok(VmValue::Int(elapsed))
+        }
+        false
     });
+    Ok(VmValue::Bool(is_open))
+}
+
+fn circuit_reset_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    let name = args
+        .first()
+        .map(|a| a.display())
+        .unwrap_or_else(|| "default".to_string());
+    CIRCUITS.with(|circuits| {
+        let mut circuits = circuits.borrow_mut();
+        if let Some(cs) = circuits.get_mut(&name) {
+            cs.failures = 0;
+            cs.opened_at = None;
+        }
+    });
+    Ok(VmValue::Nil)
+}
+
+fn timer_end_builtin(args: &[VmValue], out: &mut String) -> Result<VmValue, VmError> {
+    let timer = match args.first() {
+        Some(VmValue::Dict(d)) => d,
+        _ => {
+            return Err(VmError::Thrown(VmValue::String(Rc::from(
+                "timer_end: argument must be a timer dict from timer_start",
+            ))));
+        }
+    };
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64;
+    let start_ms = timer
+        .get("start_ms")
+        .and_then(|v| v.as_int())
+        .unwrap_or(now_ms);
+    let elapsed = now_ms - start_ms;
+    let name = timer.get("name").map(|v| v.display()).unwrap_or_default();
+    out.push_str(&format!("[timer] {name}: {elapsed}ms\n"));
+    Ok(VmValue::Int(elapsed))
 }
 
 #[cfg(test)]

--- a/crates/harn-vm/src/stdlib/fs.rs
+++ b/crates/harn-vm/src/stdlib/fs.rs
@@ -5,15 +5,94 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::SystemTime;
 use std::{cell::RefCell, thread_local};
 
+use crate::stdlib::registration::{register_builtin_group, BuiltinGroup, SyncBuiltin};
 use crate::testbench::overlay_fs::helpers as overlay;
 use crate::value::{VmError, VmValue};
-use crate::vm::Vm;
+use crate::vm::{Vm, VmBuiltinArity};
 
 thread_local! {
     static FILE_TEXT_CACHE: RefCell<BTreeMap<PathBuf, FileTextCacheEntry>> = const { RefCell::new(BTreeMap::new()) };
 }
 
 const FILE_TEXT_CACHE_MAX_ENTRIES: usize = 256;
+
+const FS_SYNC_PRIMITIVES: &[SyncBuiltin] = &[
+    SyncBuiltin::new("read_file", read_file_builtin)
+        .signature("read_file(path)")
+        .arity(VmBuiltinArity::Exact(1))
+        .doc("Read an entire UTF-8 file or embedded stdlib prompt asset."),
+    SyncBuiltin::new("read_file_result", read_file_result_builtin)
+        .signature("read_file_result(path)")
+        .arity(VmBuiltinArity::Exact(1))
+        .doc("Read a UTF-8 file and return Result.Ok or Result.Err."),
+    SyncBuiltin::new("read_file_bytes", read_file_bytes_builtin)
+        .signature("read_file_bytes(path)")
+        .arity(VmBuiltinArity::Exact(1))
+        .doc("Read an entire file as bytes."),
+    SyncBuiltin::new("write_file", write_file_builtin)
+        .signature("write_file(path, content)")
+        .arity(VmBuiltinArity::Exact(2))
+        .doc("Write UTF-8 text to a file."),
+    SyncBuiltin::new("write_file_bytes", write_file_bytes_builtin)
+        .signature("write_file_bytes(path, content)")
+        .arity(VmBuiltinArity::Exact(2))
+        .doc("Write bytes to a file."),
+    SyncBuiltin::new("file_exists", file_exists_builtin)
+        .signature("file_exists(path)")
+        .arity(VmBuiltinArity::Exact(1))
+        .doc("Return whether a file-system path exists."),
+    SyncBuiltin::new("delete_file", delete_file_builtin)
+        .signature("delete_file(path)")
+        .arity(VmBuiltinArity::Exact(1))
+        .doc("Delete a file or directory."),
+    SyncBuiltin::new("append_file", append_file_builtin)
+        .signature("append_file(path, content)")
+        .arity(VmBuiltinArity::Exact(2))
+        .doc("Append UTF-8 text to a file."),
+    SyncBuiltin::new("list_dir", list_dir_builtin)
+        .signature("list_dir(path?)")
+        .arity(VmBuiltinArity::Range { min: 0, max: 1 })
+        .doc("Return sorted directory entry names."),
+    SyncBuiltin::new("mkdir", mkdir_builtin)
+        .signature("mkdir(path)")
+        .arity(VmBuiltinArity::Exact(1))
+        .doc("Create a directory and any missing parents."),
+    SyncBuiltin::new("path_join", path_join_builtin)
+        .signature("path_join(args...)")
+        .arity(VmBuiltinArity::Variadic)
+        .doc("Join path segments with the platform path separator."),
+    SyncBuiltin::new("copy_file", copy_file_builtin)
+        .signature("copy_file(src, dst)")
+        .arity(VmBuiltinArity::Exact(2))
+        .doc("Copy a file to a destination path."),
+    SyncBuiltin::new("temp_dir", temp_dir_builtin)
+        .signature("temp_dir()")
+        .arity(VmBuiltinArity::Exact(0))
+        .doc("Return the host temporary directory path."),
+    SyncBuiltin::new("stat", stat_builtin)
+        .signature("stat(path)")
+        .arity(VmBuiltinArity::Exact(1))
+        .doc("Return metadata for a file-system path."),
+    SyncBuiltin::new("move_file", move_file_builtin)
+        .signature("move_file(src, dst)")
+        .arity(VmBuiltinArity::Exact(2))
+        .doc("Move a file to a destination path."),
+    SyncBuiltin::new("read_lines", read_lines_builtin)
+        .signature("read_lines(path)")
+        .arity(VmBuiltinArity::Exact(1))
+        .doc("Read a UTF-8 file as a list of lines."),
+    SyncBuiltin::new("walk_dir", walk_dir_builtin)
+        .signature("walk_dir(path, options?)")
+        .arity(VmBuiltinArity::Range { min: 1, max: 2 })
+        .doc("Recursively list files and directories."),
+    SyncBuiltin::new("glob", glob_builtin)
+        .signature("glob(pattern, base_or_options?, options?)")
+        .arity(VmBuiltinArity::Range { min: 1, max: 3 })
+        .doc("Match files under a base directory using a glob pattern."),
+];
+
+const FS_PRIMITIVES: BuiltinGroup<'static> =
+    BuiltinGroup::new().category("fs").sync(FS_SYNC_PRIMITIVES);
 
 #[derive(Clone)]
 struct FileTextCacheEntry {
@@ -249,486 +328,474 @@ fn write_cached_text(path: PathBuf, content: Rc<str>) {
 }
 
 pub(crate) fn register_fs_builtins(vm: &mut Vm) {
-    vm.register_builtin("read_file", |args, _out| {
-        let path = args.first().map(|a| a.display()).unwrap_or_default();
-        if let Some(source) = crate::stdlib_modules::get_stdlib_prompt_asset(&path) {
-            return Ok(VmValue::String(Rc::from(source)));
+    register_builtin_group(vm, FS_PRIMITIVES);
+}
+
+fn read_file_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    let path = args.first().map(|a| a.display()).unwrap_or_default();
+    if let Some(source) = crate::stdlib_modules::get_stdlib_prompt_asset(&path) {
+        return Ok(VmValue::String(Rc::from(source)));
+    }
+    if crate::stdlib::asset_paths::stdlib_prompt_asset_path(&path).is_some() {
+        return Err(VmError::Thrown(VmValue::String(Rc::from(format!(
+            "Unknown stdlib prompt asset {path}"
+        )))));
+    }
+    let resolved = resolve_fs_path(&path);
+    crate::stdlib::sandbox::enforce_fs_path(
+        "read_file",
+        &resolved,
+        crate::stdlib::sandbox::FsAccess::Read,
+    )?;
+    if let Some(cached) = read_cached_text(&resolved) {
+        return Ok(VmValue::String(cached));
+    }
+    match overlay::read_to_string(&resolved) {
+        Ok(content) => {
+            let shared: Rc<str> = Rc::from(content);
+            write_cached_text(resolved.clone(), shared.clone());
+            Ok(VmValue::String(shared))
         }
-        if crate::stdlib::asset_paths::stdlib_prompt_asset_path(&path).is_some() {
-            return Err(VmError::Thrown(VmValue::String(Rc::from(format!(
-                "Unknown stdlib prompt asset {path}"
-            )))));
+        Err(e) => Err(VmError::Thrown(VmValue::String(Rc::from(format!(
+            "Failed to read file {}: {e}",
+            resolved.display()
+        ))))),
+    }
+}
+
+fn read_file_result_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    let path = args.first().map(|a| a.display()).unwrap_or_default();
+    if let Some(source) = crate::stdlib_modules::get_stdlib_prompt_asset(&path) {
+        return Ok(result_ok(VmValue::String(Rc::from(source))));
+    }
+    if crate::stdlib::asset_paths::stdlib_prompt_asset_path(&path).is_some() {
+        return Ok(result_err(VmValue::String(Rc::from(format!(
+            "Unknown stdlib prompt asset {path}"
+        )))));
+    }
+    let resolved = resolve_fs_path(&path);
+    if let Err(error) = crate::stdlib::sandbox::enforce_fs_path(
+        "read_file_result",
+        &resolved,
+        crate::stdlib::sandbox::FsAccess::Read,
+    ) {
+        return Ok(result_err(VmValue::String(Rc::from(error.to_string()))));
+    }
+    if let Some(cached) = read_cached_text(&resolved) {
+        return Ok(result_ok(VmValue::String(cached)));
+    }
+    match overlay::read_to_string(&resolved) {
+        Ok(content) => {
+            let shared: Rc<str> = Rc::from(content);
+            write_cached_text(resolved.clone(), shared.clone());
+            Ok(result_ok(VmValue::String(shared)))
         }
+        Err(e) => Ok(result_err(VmValue::String(Rc::from(format!(
+            "Failed to read file {}: {e}",
+            resolved.display()
+        ))))),
+    }
+}
+
+fn read_file_bytes_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    let path = args.first().map(|a| a.display()).unwrap_or_default();
+    let resolved = resolve_fs_path(&path);
+    crate::stdlib::sandbox::enforce_fs_path(
+        "read_file_bytes",
+        &resolved,
+        crate::stdlib::sandbox::FsAccess::Read,
+    )?;
+    match overlay::read(&resolved) {
+        Ok(content) => Ok(VmValue::Bytes(Rc::new(content))),
+        Err(e) => Err(VmError::Thrown(VmValue::String(Rc::from(format!(
+            "Failed to read file {}: {e}",
+            resolved.display()
+        ))))),
+    }
+}
+
+fn write_file_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    if args.len() >= 2 {
+        let path = args[0].display();
+        let content = args[1].display();
         let resolved = resolve_fs_path(&path);
         crate::stdlib::sandbox::enforce_fs_path(
-            "read_file",
+            "write_file",
             &resolved,
-            crate::stdlib::sandbox::FsAccess::Read,
+            crate::stdlib::sandbox::FsAccess::Write,
         )?;
-        if let Some(cached) = read_cached_text(&resolved) {
-            return Ok(VmValue::String(cached));
-        }
-        match overlay::read_to_string(&resolved) {
-            Ok(content) => {
-                let shared: Rc<str> = Rc::from(content);
-                write_cached_text(resolved.clone(), shared.clone());
-                Ok(VmValue::String(shared))
+        overlay::write(&resolved, content.as_bytes()).map_err(|e| {
+            VmError::Thrown(VmValue::String(Rc::from(format!(
+                "Failed to write file {}: {e}",
+                resolved.display()
+            ))))
+        })?;
+        write_cached_text(resolved, Rc::from(content));
+    }
+    Ok(VmValue::Nil)
+}
+
+fn write_file_bytes_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    if args.len() >= 2 {
+        let path = args[0].display();
+        let resolved = resolve_fs_path(&path);
+        let content = match &args[1] {
+            VmValue::Bytes(bytes) => bytes.as_slice(),
+            other => {
+                return Err(VmError::Thrown(VmValue::String(Rc::from(format!(
+                    "write_file_bytes expects bytes content, got {}",
+                    other.type_name()
+                )))));
             }
-            Err(e) => Err(VmError::Thrown(VmValue::String(Rc::from(format!(
-                "Failed to read file {}: {e}",
-                resolved.display()
-            ))))),
-        }
-    });
-
-    vm.register_builtin("read_file_result", |args, _out| {
-        let path = args.first().map(|a| a.display()).unwrap_or_default();
-        if let Some(source) = crate::stdlib_modules::get_stdlib_prompt_asset(&path) {
-            return Ok(result_ok(VmValue::String(Rc::from(source))));
-        }
-        if crate::stdlib::asset_paths::stdlib_prompt_asset_path(&path).is_some() {
-            return Ok(result_err(VmValue::String(Rc::from(format!(
-                "Unknown stdlib prompt asset {path}"
-            )))));
-        }
-        let resolved = resolve_fs_path(&path);
-        if let Err(error) = crate::stdlib::sandbox::enforce_fs_path(
-            "read_file_result",
-            &resolved,
-            crate::stdlib::sandbox::FsAccess::Read,
-        ) {
-            return Ok(result_err(VmValue::String(Rc::from(error.to_string()))));
-        }
-        if let Some(cached) = read_cached_text(&resolved) {
-            return Ok(result_ok(VmValue::String(cached)));
-        }
-        match overlay::read_to_string(&resolved) {
-            Ok(content) => {
-                let shared: Rc<str> = Rc::from(content);
-                write_cached_text(resolved.clone(), shared.clone());
-                Ok(result_ok(VmValue::String(shared)))
-            }
-            Err(e) => Ok(result_err(VmValue::String(Rc::from(format!(
-                "Failed to read file {}: {e}",
-                resolved.display()
-            ))))),
-        }
-    });
-
-    vm.register_builtin("read_file_bytes", |args, _out| {
-        let path = args.first().map(|a| a.display()).unwrap_or_default();
-        let resolved = resolve_fs_path(&path);
+        };
         crate::stdlib::sandbox::enforce_fs_path(
-            "read_file_bytes",
+            "write_file_bytes",
             &resolved,
-            crate::stdlib::sandbox::FsAccess::Read,
+            crate::stdlib::sandbox::FsAccess::Write,
         )?;
-        match overlay::read(&resolved) {
-            Ok(content) => Ok(VmValue::Bytes(Rc::new(content))),
-            Err(e) => Err(VmError::Thrown(VmValue::String(Rc::from(format!(
-                "Failed to read file {}: {e}",
+        overlay::write(&resolved, content).map_err(|e| {
+            VmError::Thrown(VmValue::String(Rc::from(format!(
+                "Failed to write file {}: {e}",
                 resolved.display()
-            ))))),
-        }
-    });
-
-    vm.register_builtin("write_file", |args, _out| {
-        if args.len() >= 2 {
-            let path = args[0].display();
-            let content = args[1].display();
-            let resolved = resolve_fs_path(&path);
-            crate::stdlib::sandbox::enforce_fs_path(
-                "write_file",
-                &resolved,
-                crate::stdlib::sandbox::FsAccess::Write,
-            )?;
-            overlay::write(&resolved, content.as_bytes()).map_err(|e| {
-                VmError::Thrown(VmValue::String(Rc::from(format!(
-                    "Failed to write file {}: {e}",
-                    resolved.display()
-                ))))
-            })?;
-            write_cached_text(resolved, Rc::from(content));
-        }
-        Ok(VmValue::Nil)
-    });
-
-    vm.register_builtin("write_file_bytes", |args, _out| {
-        if args.len() >= 2 {
-            let path = args[0].display();
-            let resolved = resolve_fs_path(&path);
-            let content = match &args[1] {
-                VmValue::Bytes(bytes) => bytes.as_slice(),
-                other => {
-                    return Err(VmError::Thrown(VmValue::String(Rc::from(format!(
-                        "write_file_bytes expects bytes content, got {}",
-                        other.type_name()
-                    )))));
-                }
-            };
-            crate::stdlib::sandbox::enforce_fs_path(
-                "write_file_bytes",
-                &resolved,
-                crate::stdlib::sandbox::FsAccess::Write,
-            )?;
-            overlay::write(&resolved, content).map_err(|e| {
-                VmError::Thrown(VmValue::String(Rc::from(format!(
-                    "Failed to write file {}: {e}",
-                    resolved.display()
-                ))))
-            })?;
-            FILE_TEXT_CACHE.with(|cache| {
-                cache.borrow_mut().remove(&resolved);
-            });
-        }
-        Ok(VmValue::Nil)
-    });
-
-    vm.register_builtin("file_exists", |args, _out| {
-        let path = args.first().map(|a| a.display()).unwrap_or_default();
-        let resolved = resolve_fs_path(&path);
-        crate::stdlib::sandbox::enforce_fs_path(
-            "file_exists",
-            &resolved,
-            crate::stdlib::sandbox::FsAccess::Read,
-        )?;
-        Ok(VmValue::Bool(overlay::exists(&resolved)))
-    });
-
-    vm.register_builtin("delete_file", |args, _out| {
-        let path = args.first().map(|a| a.display()).unwrap_or_default();
-        let resolved = resolve_fs_path(&path);
-        crate::stdlib::sandbox::enforce_fs_path(
-            "delete_file",
-            &resolved,
-            crate::stdlib::sandbox::FsAccess::Delete,
-        )?;
-        // Overlay treats files and directories alike — both become an
-        // overlay "deleted" marker. When no overlay is active we fall
-        // back to the historical std::fs path that distinguishes the
-        // two so directory deletion still recurses on the real tree.
-        if crate::testbench::overlay_fs::active_overlay().is_some() {
-            overlay::remove_file(&resolved).map_err(|e| {
-                VmError::Thrown(VmValue::String(Rc::from(format!(
-                    "Failed to delete {}: {e}",
-                    resolved.display()
-                ))))
-            })?;
-        } else if resolved.is_dir() {
-            std::fs::remove_dir_all(&resolved).map_err(|e| {
-                VmError::Thrown(VmValue::String(Rc::from(format!(
-                    "Failed to delete directory {}: {e}",
-                    resolved.display()
-                ))))
-            })?;
-        } else {
-            std::fs::remove_file(&resolved).map_err(|e| {
-                VmError::Thrown(VmValue::String(Rc::from(format!(
-                    "Failed to delete file {}: {e}",
-                    resolved.display()
-                ))))
-            })?;
-        }
+            ))))
+        })?;
         FILE_TEXT_CACHE.with(|cache| {
             cache.borrow_mut().remove(&resolved);
         });
-        Ok(VmValue::Nil)
-    });
+    }
+    Ok(VmValue::Nil)
+}
 
-    vm.register_builtin("append_file", |args, _out| {
-        if args.len() >= 2 {
-            let path = args[0].display();
-            let content = args[1].display();
-            let resolved = resolve_fs_path(&path);
-            crate::stdlib::sandbox::enforce_fs_path(
-                "append_file",
-                &resolved,
-                crate::stdlib::sandbox::FsAccess::Write,
-            )?;
-            overlay::append(&resolved, content.as_bytes()).map_err(|e| {
-                VmError::Thrown(VmValue::String(Rc::from(format!(
-                    "Failed to append to file {}: {e}",
-                    resolved.display()
-                ))))
-            })?;
-            FILE_TEXT_CACHE.with(|cache| {
-                cache.borrow_mut().remove(&resolved);
-            });
-        }
-        Ok(VmValue::Nil)
-    });
+fn file_exists_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    let path = args.first().map(|a| a.display()).unwrap_or_default();
+    let resolved = resolve_fs_path(&path);
+    crate::stdlib::sandbox::enforce_fs_path(
+        "file_exists",
+        &resolved,
+        crate::stdlib::sandbox::FsAccess::Read,
+    )?;
+    Ok(VmValue::Bool(overlay::exists(&resolved)))
+}
 
-    vm.register_builtin("list_dir", |args, _out| {
-        let path = args
-            .first()
-            .map(|a| a.display())
-            .unwrap_or_else(|| ".".to_string());
+fn delete_file_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    let path = args.first().map(|a| a.display()).unwrap_or_default();
+    let resolved = resolve_fs_path(&path);
+    crate::stdlib::sandbox::enforce_fs_path(
+        "delete_file",
+        &resolved,
+        crate::stdlib::sandbox::FsAccess::Delete,
+    )?;
+    // Overlay treats files and directories alike by recording an overlay deletion marker.
+    if crate::testbench::overlay_fs::active_overlay().is_some() {
+        overlay::remove_file(&resolved).map_err(|e| {
+            VmError::Thrown(VmValue::String(Rc::from(format!(
+                "Failed to delete {}: {e}",
+                resolved.display()
+            ))))
+        })?;
+    } else if resolved.is_dir() {
+        std::fs::remove_dir_all(&resolved).map_err(|e| {
+            VmError::Thrown(VmValue::String(Rc::from(format!(
+                "Failed to delete directory {}: {e}",
+                resolved.display()
+            ))))
+        })?;
+    } else {
+        std::fs::remove_file(&resolved).map_err(|e| {
+            VmError::Thrown(VmValue::String(Rc::from(format!(
+                "Failed to delete file {}: {e}",
+                resolved.display()
+            ))))
+        })?;
+    }
+    FILE_TEXT_CACHE.with(|cache| {
+        cache.borrow_mut().remove(&resolved);
+    });
+    Ok(VmValue::Nil)
+}
+
+fn append_file_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    if args.len() >= 2 {
+        let path = args[0].display();
+        let content = args[1].display();
         let resolved = resolve_fs_path(&path);
         crate::stdlib::sandbox::enforce_fs_path(
-            "list_dir",
+            "append_file",
             &resolved,
+            crate::stdlib::sandbox::FsAccess::Write,
+        )?;
+        overlay::append(&resolved, content.as_bytes()).map_err(|e| {
+            VmError::Thrown(VmValue::String(Rc::from(format!(
+                "Failed to append to file {}: {e}",
+                resolved.display()
+            ))))
+        })?;
+        FILE_TEXT_CACHE.with(|cache| {
+            cache.borrow_mut().remove(&resolved);
+        });
+    }
+    Ok(VmValue::Nil)
+}
+
+fn list_dir_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    let path = args
+        .first()
+        .map(|a| a.display())
+        .unwrap_or_else(|| ".".to_string());
+    let resolved = resolve_fs_path(&path);
+    crate::stdlib::sandbox::enforce_fs_path(
+        "list_dir",
+        &resolved,
+        crate::stdlib::sandbox::FsAccess::Read,
+    )?;
+    let entries = std::fs::read_dir(&resolved).map_err(|e| {
+        VmError::Thrown(VmValue::String(Rc::from(format!(
+            "Failed to list directory {}: {e}",
+            resolved.display()
+        ))))
+    })?;
+    let mut result = Vec::new();
+    for entry in entries {
+        let entry = entry.map_err(|e| VmError::Thrown(VmValue::String(Rc::from(e.to_string()))))?;
+        let name = entry.file_name().to_string_lossy().into_owned();
+        result.push(VmValue::String(Rc::from(name)));
+    }
+    result.sort_by_key(|a| a.display());
+    Ok(VmValue::List(Rc::new(result)))
+}
+
+fn mkdir_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    let path = args.first().map(|a| a.display()).unwrap_or_default();
+    let resolved = resolve_fs_path(&path);
+    crate::stdlib::sandbox::enforce_fs_path(
+        "mkdir",
+        &resolved,
+        crate::stdlib::sandbox::FsAccess::Write,
+    )?;
+    overlay::create_dir_all(&resolved).map_err(|e| {
+        VmError::Thrown(VmValue::String(Rc::from(format!(
+            "Failed to create directory {}: {e}",
+            resolved.display()
+        ))))
+    })?;
+    Ok(VmValue::Nil)
+}
+
+fn path_join_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    let mut path = std::path::PathBuf::new();
+    for arg in args {
+        path.push(arg.display());
+    }
+    Ok(VmValue::String(Rc::from(
+        path.to_string_lossy().into_owned().as_str(),
+    )))
+}
+
+fn copy_file_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    if args.len() >= 2 {
+        let src = args[0].display();
+        let dst = args[1].display();
+        let resolved_src = resolve_fs_path(&src);
+        let resolved_dst = resolve_fs_path(&dst);
+        crate::stdlib::sandbox::enforce_fs_path(
+            "copy_file",
+            &resolved_src,
             crate::stdlib::sandbox::FsAccess::Read,
         )?;
-        let entries = std::fs::read_dir(&resolved).map_err(|e| {
-            VmError::Thrown(VmValue::String(Rc::from(format!(
-                "Failed to list directory {}: {e}",
-                resolved.display()
-            ))))
-        })?;
-        let mut result = Vec::new();
-        for entry in entries {
-            let entry =
-                entry.map_err(|e| VmError::Thrown(VmValue::String(Rc::from(e.to_string()))))?;
-            let name = entry.file_name().to_string_lossy().into_owned();
-            result.push(VmValue::String(Rc::from(name)));
-        }
-        result.sort_by_key(|a| a.display());
-        Ok(VmValue::List(Rc::new(result)))
-    });
-
-    vm.register_builtin("mkdir", |args, _out| {
-        let path = args.first().map(|a| a.display()).unwrap_or_default();
-        let resolved = resolve_fs_path(&path);
         crate::stdlib::sandbox::enforce_fs_path(
-            "mkdir",
-            &resolved,
+            "copy_file",
+            &resolved_dst,
             crate::stdlib::sandbox::FsAccess::Write,
         )?;
-        overlay::create_dir_all(&resolved).map_err(|e| {
+        std::fs::copy(&resolved_src, &resolved_dst).map_err(|e| {
             VmError::Thrown(VmValue::String(Rc::from(format!(
-                "Failed to create directory {}: {e}",
-                resolved.display()
+                "Failed to copy {} to {}: {e}",
+                resolved_src.display(),
+                resolved_dst.display()
             ))))
         })?;
-        Ok(VmValue::Nil)
-    });
+        FILE_TEXT_CACHE.with(|cache| {
+            cache.borrow_mut().remove(&resolved_dst);
+        });
+    }
+    Ok(VmValue::Nil)
+}
 
-    vm.register_builtin("path_join", |args, _out| {
-        let mut path = std::path::PathBuf::new();
-        for arg in args {
-            path.push(arg.display());
+fn temp_dir_builtin(_args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    Ok(VmValue::String(Rc::from(
+        std::env::temp_dir().to_string_lossy().into_owned().as_str(),
+    )))
+}
+
+fn stat_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    let path = args.first().map(|a| a.display()).unwrap_or_default();
+    let resolved = resolve_fs_path(&path);
+    crate::stdlib::sandbox::enforce_fs_path(
+        "stat",
+        &resolved,
+        crate::stdlib::sandbox::FsAccess::Read,
+    )?;
+    let metadata = std::fs::metadata(&resolved).map_err(|e| {
+        VmError::Thrown(VmValue::String(Rc::from(format!(
+            "Failed to stat {}: {e}",
+            resolved.display()
+        ))))
+    })?;
+    let mut info = BTreeMap::new();
+    info.insert("size".to_string(), VmValue::Int(metadata.len() as i64));
+    info.insert("is_file".to_string(), VmValue::Bool(metadata.is_file()));
+    info.insert("is_dir".to_string(), VmValue::Bool(metadata.is_dir()));
+    info.insert(
+        "readonly".to_string(),
+        VmValue::Bool(metadata.permissions().readonly()),
+    );
+    if let Ok(modified) = metadata.modified() {
+        if let Ok(dur) = modified.duration_since(std::time::UNIX_EPOCH) {
+            info.insert("modified".to_string(), VmValue::Float(dur.as_secs_f64()));
         }
-        Ok(VmValue::String(Rc::from(
-            path.to_string_lossy().into_owned().as_str(),
-        )))
-    });
+    }
+    Ok(VmValue::Dict(Rc::new(info)))
+}
 
-    vm.register_builtin("copy_file", |args, _out| {
-        if args.len() >= 2 {
-            let src = args[0].display();
-            let dst = args[1].display();
-            let resolved_src = resolve_fs_path(&src);
-            let resolved_dst = resolve_fs_path(&dst);
-            crate::stdlib::sandbox::enforce_fs_path(
-                "copy_file",
-                &resolved_src,
-                crate::stdlib::sandbox::FsAccess::Read,
-            )?;
-            crate::stdlib::sandbox::enforce_fs_path(
-                "copy_file",
-                &resolved_dst,
-                crate::stdlib::sandbox::FsAccess::Write,
-            )?;
-            std::fs::copy(&resolved_src, &resolved_dst).map_err(|e| {
-                VmError::Thrown(VmValue::String(Rc::from(format!(
-                    "Failed to copy {} to {}: {e}",
-                    resolved_src.display(),
-                    resolved_dst.display()
-                ))))
-            })?;
-            FILE_TEXT_CACHE.with(|cache| {
-                cache.borrow_mut().remove(&resolved_dst);
-            });
-        }
-        Ok(VmValue::Nil)
-    });
-
-    vm.register_builtin("temp_dir", |_args, _out| {
-        Ok(VmValue::String(Rc::from(
-            std::env::temp_dir().to_string_lossy().into_owned().as_str(),
-        )))
-    });
-
-    vm.register_builtin("stat", |args, _out| {
-        let path = args.first().map(|a| a.display()).unwrap_or_default();
-        let resolved = resolve_fs_path(&path);
-        crate::stdlib::sandbox::enforce_fs_path(
-            "stat",
-            &resolved,
-            crate::stdlib::sandbox::FsAccess::Read,
-        )?;
-        let metadata = std::fs::metadata(&resolved).map_err(|e| {
-            VmError::Thrown(VmValue::String(Rc::from(format!(
-                "Failed to stat {}: {e}",
-                resolved.display()
-            ))))
-        })?;
-        let mut info = BTreeMap::new();
-        info.insert("size".to_string(), VmValue::Int(metadata.len() as i64));
-        info.insert("is_file".to_string(), VmValue::Bool(metadata.is_file()));
-        info.insert("is_dir".to_string(), VmValue::Bool(metadata.is_dir()));
-        info.insert(
-            "readonly".to_string(),
-            VmValue::Bool(metadata.permissions().readonly()),
-        );
-        if let Ok(modified) = metadata.modified() {
-            if let Ok(dur) = modified.duration_since(std::time::UNIX_EPOCH) {
-                info.insert("modified".to_string(), VmValue::Float(dur.as_secs_f64()));
-            }
-        }
-        Ok(VmValue::Dict(Rc::new(info)))
-    });
-
-    // --- scripting-polish additions ----------------------------------
-
-    vm.register_builtin("move_file", |args, _out| {
-        if args.len() < 2 {
-            return Err(VmError::Thrown(VmValue::String(Rc::from(
-                "move_file: src and dst are required",
-            ))));
-        }
-        let src = resolve_fs_path(&args[0].display());
-        let dst = resolve_fs_path(&args[1].display());
-        crate::stdlib::sandbox::enforce_fs_path(
-            "move_file",
-            &src,
-            crate::stdlib::sandbox::FsAccess::Write,
-        )?;
-        crate::stdlib::sandbox::enforce_fs_path(
-            "move_file",
-            &dst,
-            crate::stdlib::sandbox::FsAccess::Write,
-        )?;
-        // Try rename first (fast, atomic on the same filesystem). Fall
-        // back to copy+delete which crosses filesystems.
-        if std::fs::rename(&src, &dst).is_ok() {
-            FILE_TEXT_CACHE.with(|c| {
-                let mut c = c.borrow_mut();
-                c.remove(&src);
-                c.remove(&dst);
-            });
-            return Ok(VmValue::Nil);
-        }
-        std::fs::copy(&src, &dst).map_err(|e| {
-            VmError::Thrown(VmValue::String(Rc::from(format!(
-                "move_file: copy failed: {e}"
-            ))))
-        })?;
-        std::fs::remove_file(&src).map_err(|e| {
-            VmError::Thrown(VmValue::String(Rc::from(format!(
-                "move_file: remove src failed: {e}"
-            ))))
-        })?;
+fn move_file_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    if args.len() < 2 {
+        return Err(VmError::Thrown(VmValue::String(Rc::from(
+            "move_file: src and dst are required",
+        ))));
+    }
+    let src = resolve_fs_path(&args[0].display());
+    let dst = resolve_fs_path(&args[1].display());
+    crate::stdlib::sandbox::enforce_fs_path(
+        "move_file",
+        &src,
+        crate::stdlib::sandbox::FsAccess::Write,
+    )?;
+    crate::stdlib::sandbox::enforce_fs_path(
+        "move_file",
+        &dst,
+        crate::stdlib::sandbox::FsAccess::Write,
+    )?;
+    if std::fs::rename(&src, &dst).is_ok() {
         FILE_TEXT_CACHE.with(|c| {
             let mut c = c.borrow_mut();
             c.remove(&src);
             c.remove(&dst);
         });
-        Ok(VmValue::Nil)
+        return Ok(VmValue::Nil);
+    }
+    std::fs::copy(&src, &dst).map_err(|e| {
+        VmError::Thrown(VmValue::String(Rc::from(format!(
+            "move_file: copy failed: {e}"
+        ))))
+    })?;
+    std::fs::remove_file(&src).map_err(|e| {
+        VmError::Thrown(VmValue::String(Rc::from(format!(
+            "move_file: remove src failed: {e}"
+        ))))
+    })?;
+    FILE_TEXT_CACHE.with(|c| {
+        let mut c = c.borrow_mut();
+        c.remove(&src);
+        c.remove(&dst);
     });
+    Ok(VmValue::Nil)
+}
 
-    vm.register_builtin("read_lines", |args, _out| {
-        let path = args.first().map(|a| a.display()).unwrap_or_default();
-        let resolved = resolve_fs_path(&path);
-        crate::stdlib::sandbox::enforce_fs_path(
-            "read_lines",
-            &resolved,
-            crate::stdlib::sandbox::FsAccess::Read,
-        )?;
-        let content = std::fs::read_to_string(&resolved).map_err(|e| {
-            VmError::Thrown(VmValue::String(Rc::from(format!(
-                "read_lines: {}: {e}",
-                resolved.display()
-            ))))
-        })?;
-        // split_terminator drops the trailing empty element from a final
-        // newline; lines() handles \r\n correctly.
-        let lines: Vec<VmValue> = content
-            .lines()
-            .map(|l| VmValue::String(Rc::from(l)))
-            .collect();
-        Ok(VmValue::List(Rc::new(lines)))
-    });
+fn read_lines_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    let path = args.first().map(|a| a.display()).unwrap_or_default();
+    let resolved = resolve_fs_path(&path);
+    crate::stdlib::sandbox::enforce_fs_path(
+        "read_lines",
+        &resolved,
+        crate::stdlib::sandbox::FsAccess::Read,
+    )?;
+    let content = std::fs::read_to_string(&resolved).map_err(|e| {
+        VmError::Thrown(VmValue::String(Rc::from(format!(
+            "read_lines: {}: {e}",
+            resolved.display()
+        ))))
+    })?;
+    let lines: Vec<VmValue> = content
+        .lines()
+        .map(|l| VmValue::String(Rc::from(l)))
+        .collect();
+    Ok(VmValue::List(Rc::new(lines)))
+}
 
-    vm.register_builtin("walk_dir", |args, _out| {
-        let root = args.first().map(|a| a.display()).unwrap_or_default();
-        if root.is_empty() {
-            return Err(VmError::Thrown(VmValue::String(Rc::from(
-                "walk_dir: root path is required",
-            ))));
-        }
-        let resolved = resolve_fs_path(&root);
-        crate::stdlib::sandbox::enforce_fs_path(
+fn walk_dir_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    let root = args.first().map(|a| a.display()).unwrap_or_default();
+    if root.is_empty() {
+        return Err(VmError::Thrown(VmValue::String(Rc::from(
+            "walk_dir: root path is required",
+        ))));
+    }
+    let resolved = resolve_fs_path(&root);
+    crate::stdlib::sandbox::enforce_fs_path(
+        "walk_dir",
+        &resolved,
+        crate::stdlib::sandbox::FsAccess::Read,
+    )?;
+    let options = parse_walk_dir_options(args);
+    if options.long_running {
+        let session_id = crate::llm::current_agent_session_id().unwrap_or_default();
+        let descriptor = format!("walk_dir {}", resolved.display());
+        let handle = crate::stdlib::long_running::spawn_json_operation(
             "walk_dir",
-            &resolved,
-            crate::stdlib::sandbox::FsAccess::Read,
-        )?;
-        let options = parse_walk_dir_options(args);
-        if options.long_running {
-            let session_id = crate::llm::current_agent_session_id().unwrap_or_default();
-            let descriptor = format!("walk_dir {}", resolved.display());
-            let handle = crate::stdlib::long_running::spawn_json_operation(
-                "walk_dir",
-                descriptor,
-                session_id,
-                move |cancel| {
-                    Ok(walk_entries_to_json(walk_dir_entries(
-                        &resolved,
-                        options,
-                        Some(&cancel),
-                    )))
-                },
-            )
-            .map_err(VmError::Runtime)?;
-            return Ok(handle.into_vm_value());
-        }
-        let entries = walk_dir_entries(&resolved, options, None)
-            .into_iter()
-            .map(walk_entry_to_vm)
-            .collect::<Vec<_>>();
-        Ok(VmValue::List(Rc::new(entries)))
-    });
+            descriptor,
+            session_id,
+            move |cancel| {
+                Ok(walk_entries_to_json(walk_dir_entries(
+                    &resolved,
+                    options,
+                    Some(&cancel),
+                )))
+            },
+        )
+        .map_err(VmError::Runtime)?;
+        return Ok(handle.into_vm_value());
+    }
+    let entries = walk_dir_entries(&resolved, options, None)
+        .into_iter()
+        .map(walk_entry_to_vm)
+        .collect::<Vec<_>>();
+    Ok(VmValue::List(Rc::new(entries)))
+}
 
-    vm.register_builtin("glob", |args, _out| {
-        let pattern = args.first().map(|a| a.display()).unwrap_or_default();
-        if pattern.is_empty() {
-            return Err(VmError::Thrown(VmValue::String(Rc::from(
-                "glob: pattern is required",
-            ))));
-        }
-        let options = parse_glob_options(args);
-        let base = resolve_fs_path(&options.base);
-        crate::stdlib::sandbox::enforce_fs_path(
+fn glob_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    let pattern = args.first().map(|a| a.display()).unwrap_or_default();
+    if pattern.is_empty() {
+        return Err(VmError::Thrown(VmValue::String(Rc::from(
+            "glob: pattern is required",
+        ))));
+    }
+    let options = parse_glob_options(args);
+    let base = resolve_fs_path(&options.base);
+    crate::stdlib::sandbox::enforce_fs_path("glob", &base, crate::stdlib::sandbox::FsAccess::Read)?;
+    if options.long_running {
+        let session_id = crate::llm::current_agent_session_id().unwrap_or_default();
+        let descriptor = format!("glob {} in {}", pattern, base.display());
+        let handle = crate::stdlib::long_running::spawn_json_operation(
             "glob",
-            &base,
-            crate::stdlib::sandbox::FsAccess::Read,
-        )?;
-        if options.long_running {
-            let session_id = crate::llm::current_agent_session_id().unwrap_or_default();
-            let descriptor = format!("glob {} in {}", pattern, base.display());
-            let handle = crate::stdlib::long_running::spawn_json_operation(
-                "glob",
-                descriptor,
-                session_id,
-                move |cancel| {
-                    glob_matches(&pattern, &base, Some(&cancel))
-                        .map(|items| {
-                            serde_json::Value::Array(
-                                items.into_iter().map(serde_json::Value::String).collect(),
-                            )
-                        })
-                        .map_err(|error| error.to_string())
-                },
-            )
-            .map_err(VmError::Runtime)?;
-            return Ok(handle.into_vm_value());
-        }
-        let matches = glob_matches(&pattern, &base, None)?
-            .into_iter()
-            .map(|path| VmValue::String(Rc::from(path)))
-            .collect::<Vec<_>>();
-        Ok(VmValue::List(Rc::new(matches)))
-    });
+            descriptor,
+            session_id,
+            move |cancel| {
+                glob_matches(&pattern, &base, Some(&cancel))
+                    .map(|items| {
+                        serde_json::Value::Array(
+                            items.into_iter().map(serde_json::Value::String).collect(),
+                        )
+                    })
+                    .map_err(|error| error.to_string())
+            },
+        )
+        .map_err(VmError::Runtime)?;
+        return Ok(handle.into_vm_value());
+    }
+    let matches = glob_matches(&pattern, &base, None)?
+        .into_iter()
+        .map(|path| VmValue::String(Rc::from(path)))
+        .collect::<Vec<_>>();
+    Ok(VmValue::List(Rc::new(matches)))
 }
 
 #[cfg(test)]

--- a/crates/harn-vm/src/stdlib/io.rs
+++ b/crates/harn-vm/src/stdlib/io.rs
@@ -8,8 +8,9 @@ use std::sync::Mutex;
 #[cfg(unix)]
 use std::time::Instant;
 
+use crate::stdlib::registration::{register_builtin_group, BuiltinGroup, SyncBuiltin};
 use crate::value::{VmError, VmValue};
-use crate::vm::Vm;
+use crate::vm::{Vm, VmBuiltinArity};
 
 use super::logging::{vm_build_log_line, vm_escape_json_str_quoted, VM_MIN_LOG_LEVEL};
 
@@ -77,6 +78,148 @@ thread_local! {
 }
 
 static STDIN_READ_LOCK: Mutex<()> = Mutex::new(());
+
+const IO_SYNC_PRIMITIVES: &[SyncBuiltin] = &[
+    SyncBuiltin::new("log", log_builtin)
+        .signature("log(message)")
+        .arity(VmBuiltinArity::Exact(1))
+        .doc("Write a Harn-prefixed message to stdout."),
+    SyncBuiltin::new("print", print_builtin)
+        .signature("print(args...)")
+        .arity(VmBuiltinArity::Variadic)
+        .doc("Write text to stdout without appending a newline."),
+    SyncBuiltin::new("println", println_builtin)
+        .signature("println(args...)")
+        .arity(VmBuiltinArity::Variadic)
+        .doc("Write text to stdout and append a newline."),
+    SyncBuiltin::new("color", color_builtin)
+        .signature("color(text, color)")
+        .arity(VmBuiltinArity::Exact(2))
+        .doc("Apply an ANSI foreground color when color output is enabled."),
+    SyncBuiltin::new("bold", bold_builtin)
+        .signature("bold(text)")
+        .arity(VmBuiltinArity::Exact(1))
+        .doc("Apply ANSI bold styling when color output is enabled."),
+    SyncBuiltin::new("dim", dim_builtin)
+        .signature("dim(text)")
+        .arity(VmBuiltinArity::Exact(1))
+        .doc("Apply ANSI dim styling when color output is enabled."),
+    SyncBuiltin::new("set_color_mode", set_color_mode_builtin)
+        .signature("set_color_mode(mode)")
+        .arity(VmBuiltinArity::Exact(1))
+        .doc("Set ANSI color handling to auto, always, or never."),
+    SyncBuiltin::new("eprint", eprint_builtin)
+        .signature("eprint(message)")
+        .arity(VmBuiltinArity::Exact(1))
+        .doc("Write text to stderr without appending a newline."),
+    SyncBuiltin::new("eprintln", eprintln_builtin)
+        .signature("eprintln(message)")
+        .arity(VmBuiltinArity::Exact(1))
+        .doc("Write text to stderr and append a newline."),
+    SyncBuiltin::new("read_stdin", read_stdin_builtin)
+        .signature("read_stdin()")
+        .arity(VmBuiltinArity::Exact(0))
+        .doc("Read all remaining stdin as a string."),
+    SyncBuiltin::new("read_line", read_line_builtin)
+        .signature("read_line()")
+        .arity(VmBuiltinArity::Exact(0))
+        .doc("Read one line from stdin or return nil at EOF."),
+    SyncBuiltin::new("__io_read_line", io_read_line_builtin)
+        .signature("__io_read_line(options?)")
+        .arity(VmBuiltinArity::Range { min: 0, max: 1 })
+        .doc("Read one line from stdin with structured status metadata."),
+    SyncBuiltin::new("is_stdin_tty", is_stdin_tty_builtin)
+        .signature("is_stdin_tty()")
+        .arity(VmBuiltinArity::Exact(0))
+        .doc("Return whether stdin is attached to a terminal."),
+    SyncBuiltin::new("is_stdout_tty", is_stdout_tty_builtin)
+        .signature("is_stdout_tty()")
+        .arity(VmBuiltinArity::Exact(0))
+        .doc("Return whether stdout is attached to a terminal."),
+    SyncBuiltin::new("is_stderr_tty", is_stderr_tty_builtin)
+        .signature("is_stderr_tty()")
+        .arity(VmBuiltinArity::Exact(0))
+        .doc("Return whether stderr is attached to a terminal."),
+    SyncBuiltin::new("mock_stdin", mock_stdin_builtin)
+        .signature("mock_stdin(text)")
+        .arity(VmBuiltinArity::Exact(1))
+        .doc("Install mocked stdin text for tests."),
+    SyncBuiltin::new("unmock_stdin", unmock_stdin_builtin)
+        .signature("unmock_stdin()")
+        .arity(VmBuiltinArity::Exact(0))
+        .doc("Clear mocked stdin text and line state."),
+    SyncBuiltin::new("mock_tty", mock_tty_builtin)
+        .signature("mock_tty(stream, is_tty)")
+        .arity(VmBuiltinArity::Exact(2))
+        .doc("Override terminal detection for stdin, stdout, or stderr."),
+    SyncBuiltin::new("unmock_tty", unmock_tty_builtin)
+        .signature("unmock_tty()")
+        .arity(VmBuiltinArity::Exact(0))
+        .doc("Clear terminal detection overrides."),
+    SyncBuiltin::new("capture_stderr_start", capture_stderr_start_builtin)
+        .signature("capture_stderr_start()")
+        .arity(VmBuiltinArity::Exact(0))
+        .doc("Start capturing stderr into an in-memory buffer."),
+    SyncBuiltin::new("capture_stderr_take", capture_stderr_take_builtin)
+        .signature("capture_stderr_take()")
+        .arity(VmBuiltinArity::Exact(0))
+        .doc("Stop stderr capture and return the buffered text."),
+    SyncBuiltin::new("uuid", uuid_builtin)
+        .signature("uuid()")
+        .arity(VmBuiltinArity::Exact(0))
+        .doc("Generate a random version 4 UUID."),
+    SyncBuiltin::new("uuid_parse", uuid_parse_builtin)
+        .signature("uuid_parse(value)")
+        .arity(VmBuiltinArity::Exact(1))
+        .doc("Parse and normalize a UUID string, or return nil."),
+    SyncBuiltin::new("uuid_v7", uuid_v7_builtin)
+        .signature("uuid_v7()")
+        .arity(VmBuiltinArity::Exact(0))
+        .doc("Generate a time-ordered version 7 UUID."),
+    SyncBuiltin::new("uuid_v5", uuid_v5_builtin)
+        .signature("uuid_v5(namespace, name)")
+        .arity(VmBuiltinArity::Exact(2))
+        .doc("Generate a deterministic version 5 UUID."),
+    SyncBuiltin::new("uuid_nil", uuid_nil_builtin)
+        .signature("uuid_nil()")
+        .arity(VmBuiltinArity::Exact(0))
+        .doc("Return the nil UUID."),
+    SyncBuiltin::new("prompt_user", prompt_user_builtin)
+        .signature("prompt_user(message?)")
+        .arity(VmBuiltinArity::Range { min: 0, max: 1 })
+        .doc("Prompt on stdout and read one line from stdin."),
+    SyncBuiltin::new("log_debug", log_debug_builtin)
+        .signature("log_debug(message, fields?)")
+        .arity(VmBuiltinArity::Range { min: 1, max: 2 })
+        .doc("Write a structured debug log line."),
+    SyncBuiltin::new("log_info", log_info_builtin)
+        .signature("log_info(message, fields?)")
+        .arity(VmBuiltinArity::Range { min: 1, max: 2 })
+        .doc("Write a structured info log line."),
+    SyncBuiltin::new("log_warn", log_warn_builtin)
+        .signature("log_warn(message, fields?)")
+        .arity(VmBuiltinArity::Range { min: 1, max: 2 })
+        .doc("Write a structured warning log line."),
+    SyncBuiltin::new("log_error", log_error_builtin)
+        .signature("log_error(message, fields?)")
+        .arity(VmBuiltinArity::Range { min: 1, max: 2 })
+        .doc("Write a structured error log line."),
+    SyncBuiltin::new("log_set_level", log_set_level_builtin)
+        .signature("log_set_level(level)")
+        .arity(VmBuiltinArity::Exact(1))
+        .doc("Set the minimum structured log level."),
+    SyncBuiltin::new("progress", progress_builtin)
+        .signature("progress(phase, message, progress_or_options?, total?)")
+        .arity(VmBuiltinArity::Range { min: 2, max: 4 })
+        .doc("Write a human-readable progress log line."),
+    SyncBuiltin::new("log_json", log_json_builtin)
+        .signature("log_json(key, value?)")
+        .arity(VmBuiltinArity::Range { min: 1, max: 2 })
+        .doc("Write a structured JSON log line."),
+];
+
+const IO_PRIMITIVES: BuiltinGroup<'static> =
+    BuiltinGroup::new().category("io").sync(IO_SYNC_PRIMITIVES);
 
 /// Reset all io thread-local state for test isolation.
 pub(crate) fn reset_io_state() {
@@ -516,277 +659,279 @@ fn ansi_enabled_for_stream(stream: &str) -> bool {
 }
 
 pub(crate) fn register_io_builtins(vm: &mut Vm) {
-    vm.register_builtin("log", |args, out| {
-        let msg = args.first().map(|a| a.display()).unwrap_or_default();
-        write_stdout(out, &format!("[harn] {msg}\n"));
-        Ok(VmValue::Nil)
-    });
-    vm.register_builtin("print", |args, out| {
-        let msg = args.first().map(|a| a.display()).unwrap_or_default();
-        write_stdout(out, &msg);
-        Ok(VmValue::Nil)
-    });
-    vm.register_builtin("println", |args, out| {
-        let msg = args.first().map(|a| a.display()).unwrap_or_default();
-        write_stdout(out, &format!("{msg}\n"));
-        Ok(VmValue::Nil)
-    });
+    register_builtin_group(vm, IO_PRIMITIVES);
+}
 
-    vm.register_builtin("color", |args, _out| {
-        let text = args.first().map(|a| a.display()).unwrap_or_default();
-        let name = args.get(1).map(|a| a.display()).unwrap_or_default();
-        if !ansi_enabled_for_stream("stdout") {
-            return Ok(VmValue::String(Rc::from(text)));
+fn log_builtin(args: &[VmValue], out: &mut String) -> Result<VmValue, VmError> {
+    let msg = args.first().map(|a| a.display()).unwrap_or_default();
+    write_stdout(out, &format!("[harn] {msg}\n"));
+    Ok(VmValue::Nil)
+}
+
+fn print_builtin(args: &[VmValue], out: &mut String) -> Result<VmValue, VmError> {
+    let msg = args.first().map(|a| a.display()).unwrap_or_default();
+    write_stdout(out, &msg);
+    Ok(VmValue::Nil)
+}
+
+fn println_builtin(args: &[VmValue], out: &mut String) -> Result<VmValue, VmError> {
+    let msg = args.first().map(|a| a.display()).unwrap_or_default();
+    write_stdout(out, &format!("{msg}\n"));
+    Ok(VmValue::Nil)
+}
+
+fn color_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    let text = args.first().map(|a| a.display()).unwrap_or_default();
+    let name = args.get(1).map(|a| a.display()).unwrap_or_default();
+    if !ansi_enabled_for_stream("stdout") {
+        return Ok(VmValue::String(Rc::from(text)));
+    }
+    Ok(VmValue::String(Rc::from(ansi_colorize(&text, &name))))
+}
+
+fn bold_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    let text = args.first().map(|a| a.display()).unwrap_or_default();
+    if !ansi_enabled_for_stream("stdout") {
+        return Ok(VmValue::String(Rc::from(text)));
+    }
+    Ok(VmValue::String(Rc::from(format!(
+        "\u{1b}[1m{text}\u{1b}[0m"
+    ))))
+}
+
+fn dim_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    let text = args.first().map(|a| a.display()).unwrap_or_default();
+    if !ansi_enabled_for_stream("stdout") {
+        return Ok(VmValue::String(Rc::from(text)));
+    }
+    Ok(VmValue::String(Rc::from(format!(
+        "\u{1b}[2m{text}\u{1b}[0m"
+    ))))
+}
+
+fn set_color_mode_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    let mode = args.first().map(|a| a.display()).unwrap_or_default();
+    let parsed = match mode.as_str() {
+        "auto" => ColorMode::Auto,
+        "always" => ColorMode::Always,
+        "never" => ColorMode::Never,
+        other => {
+            return Err(VmError::Thrown(VmValue::String(Rc::from(format!(
+                "set_color_mode: invalid mode '{other}'. Expected 'auto', 'always', or 'never'."
+            )))));
         }
-        Ok(VmValue::String(Rc::from(ansi_colorize(&text, &name))))
-    });
+    };
+    COLOR_MODE.with(|m| *m.borrow_mut() = parsed);
+    Ok(VmValue::Nil)
+}
 
-    vm.register_builtin("bold", |args, _out| {
-        let text = args.first().map(|a| a.display()).unwrap_or_default();
-        if !ansi_enabled_for_stream("stdout") {
-            return Ok(VmValue::String(Rc::from(text)));
-        }
-        Ok(VmValue::String(Rc::from(format!(
-            "\u{1b}[1m{text}\u{1b}[0m"
-        ))))
-    });
+fn eprint_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    let msg = args.first().map(|a| a.display()).unwrap_or_default();
+    write_stderr(&msg);
+    Ok(VmValue::Nil)
+}
 
-    vm.register_builtin("dim", |args, _out| {
-        let text = args.first().map(|a| a.display()).unwrap_or_default();
-        if !ansi_enabled_for_stream("stdout") {
-            return Ok(VmValue::String(Rc::from(text)));
-        }
-        Ok(VmValue::String(Rc::from(format!(
-            "\u{1b}[2m{text}\u{1b}[0m"
-        ))))
-    });
+fn eprintln_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    let msg = args.first().map(|a| a.display()).unwrap_or_default();
+    write_stderr(&format!("{msg}\n"));
+    Ok(VmValue::Nil)
+}
 
-    vm.register_builtin("set_color_mode", |args, _out| {
-        let mode = args.first().map(|a| a.display()).unwrap_or_default();
-        let parsed = match mode.as_str() {
-            "auto" => ColorMode::Auto,
-            "always" => ColorMode::Always,
-            "never" => ColorMode::Never,
+fn read_stdin_builtin(_args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    // Drain any remaining mocked stdin first.
+    let mocked = STDIN_MOCK.with(|s| s.borrow_mut().take());
+    if let Some(buf) = mocked {
+        // After read_stdin, future read_line calls return nil because stdin is consumed.
+        STDIN_LINES.with(|lines| *lines.borrow_mut() = Some(VecDeque::new()));
+        return Ok(VmValue::String(Rc::from(buf)));
+    }
+    match read_stdin_all_real() {
+        Some(s) => Ok(VmValue::String(Rc::from(s))),
+        None => Ok(VmValue::Nil),
+    }
+}
+
+fn read_line_builtin(_args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    let options = ReadLineOptions {
+        trim: false,
+        ..ReadLineOptions::default()
+    };
+    match read_line_from_mock_or_real(&options) {
+        ReadLineOutcome::Ok(line) => Ok(VmValue::String(Rc::from(line))),
+        ReadLineOutcome::Eof => Ok(VmValue::Nil),
+        #[cfg(unix)]
+        ReadLineOutcome::Timeout => Ok(VmValue::Nil),
+        #[cfg(unix)]
+        ReadLineOutcome::Interrupt => Ok(VmValue::Nil),
+        ReadLineOutcome::Error(_) => Ok(VmValue::Nil),
+    }
+}
+
+fn io_read_line_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    let options = parse_read_line_options(args)?;
+    Ok(read_line_result(read_line_from_mock_or_real(&options)))
+}
+
+fn is_stdin_tty_builtin(_args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    Ok(VmValue::Bool(is_tty_for("stdin")))
+}
+
+fn is_stdout_tty_builtin(_args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    Ok(VmValue::Bool(is_tty_for("stdout")))
+}
+
+fn is_stderr_tty_builtin(_args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    Ok(VmValue::Bool(is_tty_for("stderr")))
+}
+
+fn mock_stdin_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    let text = args.first().map(|a| a.display()).unwrap_or_default();
+    STDIN_MOCK.with(|s| *s.borrow_mut() = Some(text));
+    STDIN_LINES.with(|s| *s.borrow_mut() = None);
+    Ok(VmValue::Nil)
+}
+
+fn unmock_stdin_builtin(_args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    STDIN_MOCK.with(|s| *s.borrow_mut() = None);
+    STDIN_LINES.with(|s| *s.borrow_mut() = None);
+    Ok(VmValue::Nil)
+}
+
+fn mock_tty_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    let stream = args.first().map(|a| a.display()).unwrap_or_default();
+    let is_tty = matches!(args.get(1), Some(VmValue::Bool(true)));
+    TTY_MOCK.with(|t| {
+        let mut mock = t.borrow_mut();
+        match stream.as_str() {
+            "stdin" => mock.stdin = Some(is_tty),
+            "stdout" => mock.stdout = Some(is_tty),
+            "stderr" => mock.stderr = Some(is_tty),
             other => {
                 return Err(VmError::Thrown(VmValue::String(Rc::from(format!(
-                    "set_color_mode: invalid mode '{other}'. Expected 'auto', 'always', or 'never'."
+                    "mock_tty: invalid stream '{other}'. Expected 'stdin', 'stdout', or 'stderr'."
                 )))));
             }
-        };
-        COLOR_MODE.with(|m| *m.borrow_mut() = parsed);
-        Ok(VmValue::Nil)
-    });
-
-    vm.register_builtin("eprint", |args, _out| {
-        let msg = args.first().map(|a| a.display()).unwrap_or_default();
-        write_stderr(&msg);
-        Ok(VmValue::Nil)
-    });
-
-    vm.register_builtin("eprintln", |args, _out| {
-        let msg = args.first().map(|a| a.display()).unwrap_or_default();
-        write_stderr(&format!("{msg}\n"));
-        Ok(VmValue::Nil)
-    });
-
-    vm.register_builtin("read_stdin", |_args, _out| {
-        // Drain any remaining mocked stdin first.
-        let mocked = STDIN_MOCK.with(|s| s.borrow_mut().take());
-        if let Some(buf) = mocked {
-            // After read_stdin, future read_line calls return nil — stdin is consumed.
-            STDIN_LINES.with(|lines| *lines.borrow_mut() = Some(VecDeque::new()));
-            return Ok(VmValue::String(Rc::from(buf)));
         }
-        match read_stdin_all_real() {
-            Some(s) => Ok(VmValue::String(Rc::from(s))),
-            None => Ok(VmValue::Nil),
-        }
-    });
-
-    vm.register_builtin("read_line", |_args, _out| {
-        let options = ReadLineOptions {
-            trim: false,
-            ..ReadLineOptions::default()
-        };
-        match read_line_from_mock_or_real(&options) {
-            ReadLineOutcome::Ok(line) => Ok(VmValue::String(Rc::from(line))),
-            ReadLineOutcome::Eof => Ok(VmValue::Nil),
-            #[cfg(unix)]
-            ReadLineOutcome::Timeout => Ok(VmValue::Nil),
-            #[cfg(unix)]
-            ReadLineOutcome::Interrupt => Ok(VmValue::Nil),
-            ReadLineOutcome::Error(_) => Ok(VmValue::Nil),
-        }
-    });
-
-    vm.register_builtin("__io_read_line", |args, _out| {
-        let options = parse_read_line_options(args)?;
-        Ok(read_line_result(read_line_from_mock_or_real(&options)))
-    });
-
-    vm.register_builtin("is_stdin_tty", |_args, _out| {
-        Ok(VmValue::Bool(is_tty_for("stdin")))
-    });
-    vm.register_builtin("is_stdout_tty", |_args, _out| {
-        Ok(VmValue::Bool(is_tty_for("stdout")))
-    });
-    vm.register_builtin("is_stderr_tty", |_args, _out| {
-        Ok(VmValue::Bool(is_tty_for("stderr")))
-    });
-
-    vm.register_builtin("mock_stdin", |args, _out| {
-        let text = args.first().map(|a| a.display()).unwrap_or_default();
-        STDIN_MOCK.with(|s| *s.borrow_mut() = Some(text));
-        STDIN_LINES.with(|s| *s.borrow_mut() = None);
         Ok(VmValue::Nil)
-    });
+    })
+}
 
-    vm.register_builtin("unmock_stdin", |_args, _out| {
-        STDIN_MOCK.with(|s| *s.borrow_mut() = None);
-        STDIN_LINES.with(|s| *s.borrow_mut() = None);
+fn unmock_tty_builtin(_args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    TTY_MOCK.with(|t| *t.borrow_mut() = TtyMock::default());
+    Ok(VmValue::Nil)
+}
+
+fn capture_stderr_start_builtin(_args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    STDERR_CAPTURING.with(|c| *c.borrow_mut() = true);
+    STDERR_BUFFER.with(|s| s.borrow_mut().clear());
+    Ok(VmValue::Nil)
+}
+
+fn capture_stderr_take_builtin(_args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    let buf = STDERR_BUFFER.with(|s| std::mem::take(&mut *s.borrow_mut()));
+    STDERR_CAPTURING.with(|c| *c.borrow_mut() = false);
+    Ok(VmValue::String(Rc::from(buf)))
+}
+
+fn uuid_builtin(_args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    Ok(VmValue::String(Rc::from(uuid::Uuid::new_v4().to_string())))
+}
+
+fn uuid_parse_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    let raw = args.first().map(|a| a.display()).unwrap_or_default();
+    match uuid::Uuid::parse_str(&raw) {
+        Ok(uuid) => Ok(VmValue::String(Rc::from(uuid.to_string()))),
+        Err(_) => Ok(VmValue::Nil),
+    }
+}
+
+fn uuid_v7_builtin(_args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    Ok(VmValue::String(Rc::from(uuid::Uuid::now_v7().to_string())))
+}
+
+fn uuid_v5_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    if args.len() < 2 {
+        return Err(VmError::Runtime(
+            "uuid_v5(namespace, name): requires namespace and name".to_string(),
+        ));
+    }
+    let namespace_raw = args[0].display();
+    let namespace = uuid_v5_namespace(&namespace_raw).ok_or_else(|| {
+        VmError::Runtime("uuid_v5: namespace must be a UUID or one of dns/url/oid/x500".to_string())
+    })?;
+    let name = args[1].display();
+    Ok(VmValue::String(Rc::from(
+        uuid::Uuid::new_v5(&namespace, name.as_bytes()).to_string(),
+    )))
+}
+
+fn uuid_nil_builtin(_args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    Ok(VmValue::String(Rc::from(uuid::Uuid::nil().to_string())))
+}
+
+fn prompt_user_builtin(args: &[VmValue], out: &mut String) -> Result<VmValue, VmError> {
+    let msg = args.first().map(|a| a.display()).unwrap_or_default();
+    write_stdout(out, &msg);
+    let mut input = String::new();
+    if std::io::stdin().lock().read_line(&mut input).is_ok() {
+        Ok(VmValue::String(Rc::from(input.trim_end())))
+    } else {
         Ok(VmValue::Nil)
-    });
+    }
+}
 
-    vm.register_builtin("mock_tty", |args, _out| {
-        let stream = args.first().map(|a| a.display()).unwrap_or_default();
-        let is_tty = matches!(args.get(1), Some(VmValue::Bool(true)));
-        TTY_MOCK.with(|t| {
-            let mut mock = t.borrow_mut();
-            match stream.as_str() {
-                "stdin" => mock.stdin = Some(is_tty),
-                "stdout" => mock.stdout = Some(is_tty),
-                "stderr" => mock.stderr = Some(is_tty),
-                other => {
-                    return Err(VmError::Thrown(VmValue::String(Rc::from(format!(
-                        "mock_tty: invalid stream '{other}'. Expected 'stdin', 'stdout', or 'stderr'."
-                    )))));
-                }
-            }
-            Ok(VmValue::Nil)
-        })
-    });
+fn log_debug_builtin(args: &[VmValue], out: &mut String) -> Result<VmValue, VmError> {
+    vm_write_log("debug", 0, args, out);
+    Ok(VmValue::Nil)
+}
 
-    vm.register_builtin("unmock_tty", |_args, _out| {
-        TTY_MOCK.with(|t| *t.borrow_mut() = TtyMock::default());
-        Ok(VmValue::Nil)
-    });
+fn log_info_builtin(args: &[VmValue], out: &mut String) -> Result<VmValue, VmError> {
+    vm_write_log("info", 1, args, out);
+    Ok(VmValue::Nil)
+}
 
-    vm.register_builtin("capture_stderr_start", |_args, _out| {
-        STDERR_CAPTURING.with(|c| *c.borrow_mut() = true);
-        STDERR_BUFFER.with(|s| s.borrow_mut().clear());
-        Ok(VmValue::Nil)
-    });
+fn log_warn_builtin(args: &[VmValue], out: &mut String) -> Result<VmValue, VmError> {
+    vm_write_log("warn", 2, args, out);
+    Ok(VmValue::Nil)
+}
 
-    vm.register_builtin("capture_stderr_take", |_args, _out| {
-        let buf = STDERR_BUFFER.with(|s| std::mem::take(&mut *s.borrow_mut()));
-        STDERR_CAPTURING.with(|c| *c.borrow_mut() = false);
-        Ok(VmValue::String(Rc::from(buf)))
-    });
+fn log_error_builtin(args: &[VmValue], out: &mut String) -> Result<VmValue, VmError> {
+    vm_write_log("error", 3, args, out);
+    Ok(VmValue::Nil)
+}
 
-    vm.register_builtin("uuid", |_args, _out| {
-        Ok(VmValue::String(Rc::from(uuid::Uuid::new_v4().to_string())))
-    });
-
-    vm.register_builtin("uuid_parse", |args, _out| {
-        let raw = args.first().map(|a| a.display()).unwrap_or_default();
-        match uuid::Uuid::parse_str(&raw) {
-            Ok(uuid) => Ok(VmValue::String(Rc::from(uuid.to_string()))),
-            Err(_) => Ok(VmValue::Nil),
-        }
-    });
-
-    vm.register_builtin("uuid_v7", |_args, _out| {
-        Ok(VmValue::String(Rc::from(uuid::Uuid::now_v7().to_string())))
-    });
-
-    vm.register_builtin("uuid_v5", |args, _out| {
-        if args.len() < 2 {
-            return Err(VmError::Runtime(
-                "uuid_v5(namespace, name): requires namespace and name".to_string(),
-            ));
-        }
-        let namespace_raw = args[0].display();
-        let namespace = uuid_v5_namespace(&namespace_raw).ok_or_else(|| {
-            VmError::Runtime(
-                "uuid_v5: namespace must be a UUID or one of dns/url/oid/x500".to_string(),
-            )
-        })?;
-        let name = args[1].display();
-        Ok(VmValue::String(Rc::from(
-            uuid::Uuid::new_v5(&namespace, name.as_bytes()).to_string(),
-        )))
-    });
-
-    vm.register_builtin("uuid_nil", |_args, _out| {
-        Ok(VmValue::String(Rc::from(uuid::Uuid::nil().to_string())))
-    });
-
-    vm.register_builtin("prompt_user", |args, out| {
-        let msg = args.first().map(|a| a.display()).unwrap_or_default();
-        write_stdout(out, &msg);
-        let mut input = String::new();
-        if std::io::stdin().lock().read_line(&mut input).is_ok() {
-            Ok(VmValue::String(Rc::from(input.trim_end())))
-        } else {
+fn log_set_level_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    let level_str = args.first().map(|a| a.display()).unwrap_or_default();
+    match super::logging::vm_level_to_u8(&level_str) {
+        Some(n) => {
+            VM_MIN_LOG_LEVEL.store(n, Ordering::Relaxed);
             Ok(VmValue::Nil)
         }
-    });
+        None => Err(VmError::Thrown(VmValue::String(Rc::from(format!(
+            "log_set_level: invalid level '{}'. Expected debug, info, warn, or error",
+            level_str
+        ))))),
+    }
+}
 
-    vm.register_builtin("log_debug", |args, out| {
-        vm_write_log("debug", 0, args, out);
-        Ok(VmValue::Nil)
-    });
+fn progress_builtin(args: &[VmValue], out: &mut String) -> Result<VmValue, VmError> {
+    write_stdout(out, &render_progress_line(args));
+    Ok(VmValue::Nil)
+}
 
-    vm.register_builtin("log_info", |args, out| {
-        vm_write_log("info", 1, args, out);
-        Ok(VmValue::Nil)
-    });
-
-    vm.register_builtin("log_warn", |args, out| {
-        vm_write_log("warn", 2, args, out);
-        Ok(VmValue::Nil)
-    });
-
-    vm.register_builtin("log_error", |args, out| {
-        vm_write_log("error", 3, args, out);
-        Ok(VmValue::Nil)
-    });
-
-    vm.register_builtin("log_set_level", |args, _out| {
-        let level_str = args.first().map(|a| a.display()).unwrap_or_default();
-        match super::logging::vm_level_to_u8(&level_str) {
-            Some(n) => {
-                VM_MIN_LOG_LEVEL.store(n, Ordering::Relaxed);
-                Ok(VmValue::Nil)
-            }
-            None => Err(VmError::Thrown(VmValue::String(Rc::from(format!(
-                "log_set_level: invalid level '{}'. Expected debug, info, warn, or error",
-                level_str
-            ))))),
-        }
-    });
-
-    // Standalone mode writes a structured log line; bridge/ACP mode overrides
-    // this to emit structured notifications.
-    vm.register_builtin("progress", |args, out| {
-        write_stdout(out, &render_progress_line(args));
-        Ok(VmValue::Nil)
-    });
-
-    vm.register_builtin("log_json", |args, out| {
-        let key = args.first().map(|a| a.display()).unwrap_or_default();
-        let value = args.get(1).cloned().unwrap_or(VmValue::Nil);
-        let json_val = super::logging::vm_value_to_json_fragment(&value);
-        let ts = super::logging::vm_format_timestamp_utc();
-        let line = format!(
-            "{{\"ts\":{},\"key\":{},\"value\":{}}}\n",
-            vm_escape_json_str_quoted(&ts),
-            vm_escape_json_str_quoted(&key),
-            json_val,
-        );
-        write_stdout(out, &line);
-        Ok(VmValue::Nil)
-    });
+fn log_json_builtin(args: &[VmValue], out: &mut String) -> Result<VmValue, VmError> {
+    let key = args.first().map(|a| a.display()).unwrap_or_default();
+    let value = args.get(1).cloned().unwrap_or(VmValue::Nil);
+    let json_val = super::logging::vm_value_to_json_fragment(&value);
+    let ts = super::logging::vm_format_timestamp_utc();
+    let line = format!(
+        "{{\"ts\":{},\"key\":{},\"value\":{}}}\n",
+        vm_escape_json_str_quoted(&ts),
+        vm_escape_json_str_quoted(&key),
+        json_val,
+    );
+    write_stdout(out, &line);
+    Ok(VmValue::Nil)
 }
 
 fn uuid_v5_namespace(raw: &str) -> Option<uuid::Uuid> {

--- a/crates/harn-vm/src/stdlib/tui.rs
+++ b/crates/harn-vm/src/stdlib/tui.rs
@@ -5,12 +5,32 @@ use std::io::{ErrorKind, Write};
 use std::process::{Command, Stdio};
 use std::rc::Rc;
 
+use crate::stdlib::registration::{register_builtin_group, BuiltinGroup, SyncBuiltin};
 use crate::value::{VmError, VmValue};
-use crate::vm::Vm;
+use crate::vm::{Vm, VmBuiltinArity};
 
 const CLEAR_SEQUENCE: &str = "\x1b[2J\x1b[H";
 const DEFAULT_TERMINAL_WIDTH: usize = 80;
 const DEFAULT_RULE_CHAR: &str = "─";
+
+const TUI_SYNC_PRIMITIVES: &[SyncBuiltin] = &[
+    SyncBuiltin::new("__tui_page", tui_page_builtin)
+        .signature("__tui_page(options)")
+        .arity(VmBuiltinArity::Exact(1))
+        .doc("Render a text or markdown page through a pager when appropriate."),
+    SyncBuiltin::new("__tui_clear", tui_clear_builtin)
+        .signature("__tui_clear()")
+        .arity(VmBuiltinArity::Exact(0))
+        .doc("Write the ANSI clear-screen sequence to stdout."),
+    SyncBuiltin::new("__tui_terminal_width", tui_terminal_width_builtin)
+        .signature("__tui_terminal_width(default_width?)")
+        .arity(VmBuiltinArity::Range { min: 0, max: 1 })
+        .doc("Return the current terminal width or the supplied default."),
+];
+
+const TUI_PRIMITIVES: BuiltinGroup<'static> = BuiltinGroup::new()
+    .category("tui")
+    .sync(TUI_SYNC_PRIMITIVES);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct PageOptions {
@@ -28,20 +48,7 @@ enum PageFormat {
 }
 
 pub(crate) fn register_tui_builtins(vm: &mut Vm) {
-    vm.register_builtin("__tui_page", tui_page_builtin);
-    vm.register_builtin("__tui_clear", |_args, out| {
-        super::io::write_stdout(out, CLEAR_SEQUENCE);
-        Ok(VmValue::Nil)
-    });
-    vm.register_builtin("__tui_terminal_width", |args, _out| {
-        let default = args
-            .first()
-            .and_then(VmValue::as_int)
-            .and_then(|n| usize::try_from(n).ok())
-            .filter(|n| *n > 0)
-            .unwrap_or(DEFAULT_TERMINAL_WIDTH);
-        Ok(VmValue::Int(terminal_width(default) as i64))
-    });
+    register_builtin_group(vm, TUI_PRIMITIVES);
 }
 
 fn tui_page_builtin(args: &[VmValue], out: &mut String) -> Result<VmValue, VmError> {
@@ -61,6 +68,21 @@ fn tui_page_builtin(args: &[VmValue], out: &mut String) -> Result<VmValue, VmErr
         }
         Err(error) => Ok(page_result(false, true, Some(error.to_string()))),
     }
+}
+
+fn tui_clear_builtin(_args: &[VmValue], out: &mut String) -> Result<VmValue, VmError> {
+    super::io::write_stdout(out, CLEAR_SEQUENCE);
+    Ok(VmValue::Nil)
+}
+
+fn tui_terminal_width_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    let default = args
+        .first()
+        .and_then(VmValue::as_int)
+        .and_then(|n| usize::try_from(n).ok())
+        .filter(|n| *n > 0)
+        .unwrap_or(DEFAULT_TERMINAL_WIDTH);
+    Ok(VmValue::Int(terminal_width(default) as i64))
 }
 
 fn parse_page_options(args: &[VmValue]) -> Result<PageOptions, VmError> {

--- a/crates/harn-vm/tests/builtin_registry_alignment.rs
+++ b/crates/harn-vm/tests/builtin_registry_alignment.rs
@@ -147,9 +147,6 @@ const RUNTIME_ONLY_EXCEPTIONS: &[&str] = &[
     "__range__",
     "__register_persona",
     "__register_step",
-    "__select_list",
-    "__select_timeout",
-    "__select_try",
     "__testing_call_body",
 ];
 
@@ -232,4 +229,60 @@ fn llm_config_builtins_publish_runtime_metadata() {
             .category(),
         Some("llm.rate_limit")
     );
+}
+
+#[test]
+fn migrated_stdlib_modules_publish_runtime_metadata() {
+    let metadata = harn_vm::stdlib::stdlib_builtin_metadata();
+    let migrated_categories = [
+        ("concurrency", 51usize),
+        ("fs", 18usize),
+        ("io", 34usize),
+        ("tui", 3usize),
+    ];
+
+    for (category, expected_count) in migrated_categories {
+        let entries = metadata
+            .iter()
+            .filter(|entry| entry.category() == Some(category))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            entries.len(),
+            expected_count,
+            "unexpected builtin count for `{category}` category"
+        );
+
+        for entry in entries {
+            assert!(
+                entry.signature().is_some(),
+                "{} should carry signature metadata",
+                entry.name()
+            );
+            assert!(
+                entry.arity_metadata().is_some(),
+                "{} should carry arity metadata",
+                entry.name()
+            );
+            assert!(
+                entry.doc().is_some(),
+                "{} should carry doc metadata",
+                entry.name()
+            );
+        }
+    }
+
+    let names = metadata
+        .iter()
+        .map(|entry| entry.name())
+        .collect::<std::collections::BTreeSet<_>>();
+    for name in ["__select_list", "__select_timeout", "__select_try"] {
+        assert!(
+            harn_parser::is_known_builtin(name),
+            "{name} should have a parser signature"
+        );
+        assert!(
+            names.contains(name),
+            "{name} should be registered at runtime"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Migrates `io`, `fs`, `concurrency`, and sibling `tui` stdlib builtin registration to `BuiltinGroup` / `SyncBuiltin` / `AsyncBuiltin` metadata tables.
- Adds parser signatures for the internal `__select_*` helpers now that they are registered runtime builtins.
- Extends registry alignment coverage so the migrated categories must publish signature, arity, doc, and category metadata.

Closes #1567

## Verification
- `cargo fmt --all`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-1567 cargo check -p harn-vm -p harn-parser`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-1567 cargo test -p harn-vm stdlib::concurrency::tests -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-1567 cargo test -p harn-vm stdlib::fs::tests -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-1567 cargo test -p harn-vm stdlib::io::tests -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-1567 cargo test -p harn-vm stdlib::tui::tests -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-1567 cargo test -p harn-vm --test builtin_registry_alignment -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-1567 make test`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-1567 cargo run --bin harn -- test conformance`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-1567 cargo run --quiet --bin harn -- help`
- pre-commit hook: `cargo clippy --workspace --all-targets -- -D warnings`
- pre-push hook: targeted local checks + generated highlight check