### PR TITLE
Add local A2A dispatch replay proof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ Pre-0.6 highlights live in [CHANGELOG-pre-0.6.md](CHANGELOG-pre-0.6.md).
 Harn had no external users before 0.6.0, so that archive intentionally keeps
 condensed series summaries instead of full per-patch history.
 
+## Unreleased
+
+### Added
+
+- **Local/A2A dispatch replay proof (#1586).** Trigger dispatch now records
+  trust-boundary and remote identity metadata on action-graph nodes, outbox
+  success records, and TrustGraph terminal records. A2A dispatch also
+  classifies cleartext/authority denials, timeouts, incompatible response
+  schemas, and remote `rejected` task states distinctly, with a new
+  `examples/triggers/local-a2a-dispatch` reference flow and replay-oracle
+  fixture proving local and A2A handlers can preserve logical output.
+
 ## v0.8.13
 
 ### Changed (breaking)

--- a/conformance/replay-oracle/fixtures/local_a2a_dispatch_equivalence.valid.json
+++ b/conformance/replay-oracle/fixtures/local_a2a_dispatch_equivalence.valid.json
@@ -1,0 +1,116 @@
+{
+  "schema_version": "harn.orchestration.replay_trace.v1",
+  "name": "local_a2a_dispatch_equivalence",
+  "description": "The same trigger handler result remains replay-comparable when the dispatch boundary moves from local process to A2A.",
+  "expect": "match",
+  "allowlist": [
+    {"path": "/run_id", "reason": "run ids are allocated per execution"},
+    {"path": "/event_log_entries/*/event_id", "reason": "EventLog offsets are backend-local"},
+    {"path": "/event_log_entries/*/occurred_at_ms", "reason": "append timestamps are wall-clock observations"},
+    {"path": "/event_log_entries/*/payload/event_id", "reason": "TriggerEvent ids are generated per intake"},
+    {"path": "/event_log_entries/*/payload/handler_kind", "reason": "this fixture intentionally compares local and A2A location metadata"},
+    {"path": "/event_log_entries/*/payload/target_uri", "reason": "this fixture intentionally compares local and A2A location metadata"},
+    {"path": "/event_log_entries/*/payload/dispatch_metadata/trust_boundary", "reason": "the trust boundary is the intentional difference under test"},
+    {"path": "/event_log_entries/*/payload/dispatch_metadata/execution_location", "reason": "the execution location is the intentional difference under test"},
+    {"path": "/event_log_entries/*/payload/dispatch_metadata/remote_identity", "reason": "remote identity only changes when the boundary moves to A2A"},
+    {"path": "/event_log_entries/*/payload/dispatch_metadata/remote_agent_id", "reason": "remote identity only changes when the boundary moves to A2A"},
+    {"path": "/event_log_entries/*/payload/dispatch_metadata/card_url", "reason": "A2A discovery metadata is location-specific"},
+    {"path": "/event_log_entries/*/payload/dispatch_metadata/rpc_url", "reason": "A2A discovery metadata is location-specific"},
+    {"path": "/event_log_entries/*/payload/dispatch_metadata/task_id", "reason": "A2A task ids are remote receipts"},
+    {"path": "/event_log_entries/*/payload/dispatch_metadata/state", "reason": "A2A task state is remote receipt metadata"},
+    {"path": "/trigger_firings/*/event_id", "reason": "TriggerEvent ids are generated per intake"},
+    {"path": "/trigger_firings/*/trace_id", "reason": "trace ids are generated per execution"},
+    {"path": "/trigger_firings/*/handler_kind", "reason": "this fixture intentionally compares local and A2A dispatch modes"},
+    {"path": "/trigger_firings/*/target_uri", "reason": "this fixture intentionally compares local and A2A dispatch modes"},
+    {"path": "/trigger_firings/*/trust_boundary", "reason": "the trust boundary is the intentional difference under test"},
+    {"path": "/trigger_firings/*/remote_identity", "reason": "remote identity only changes when the boundary moves to A2A"}
+  ],
+  "first_run": {
+    "run_id": "run_local_dispatch",
+    "event_log_entries": [
+      {
+        "event_id": 101,
+        "topic": "trigger.outbox",
+        "kind": "dispatch_succeeded",
+        "occurred_at_ms": 1770000000100,
+        "payload": {
+          "event_id": "trigger_evt_local",
+          "binding_id": "issue-triage",
+          "handler_kind": "local",
+          "target_uri": "handlers::triage_issue",
+          "dispatch_metadata": {
+            "trust_boundary": "local_process",
+            "execution_location": "in_process",
+            "remote_identity": null,
+            "remote_agent_id": null,
+            "card_url": null,
+            "rpc_url": null,
+            "task_id": null,
+            "state": null
+          },
+          "result": {
+            "status": "triaged",
+            "labels": ["needs-owner"],
+            "title": "Trust boundary dispatch demo"
+          }
+        }
+      }
+    ],
+    "trigger_firings": [
+      {
+        "binding_id": "issue-triage",
+        "event_id": "trigger_evt_local",
+        "trace_id": "trace_local",
+        "handler_kind": "local",
+        "target_uri": "handlers::triage_issue",
+        "trust_boundary": "local_process",
+        "remote_identity": null,
+        "decision": "dispatched"
+      }
+    ]
+  },
+  "second_run": {
+    "run_id": "run_a2a_dispatch",
+    "event_log_entries": [
+      {
+        "event_id": 201,
+        "topic": "trigger.outbox",
+        "kind": "dispatch_succeeded",
+        "occurred_at_ms": 1770001000100,
+        "payload": {
+          "event_id": "trigger_evt_a2a",
+          "binding_id": "issue-triage",
+          "handler_kind": "a2a",
+          "target_uri": "a2a://reviewer.example/triage",
+          "dispatch_metadata": {
+            "trust_boundary": "federated_a2a",
+            "execution_location": "remote",
+            "remote_identity": "triage",
+            "remote_agent_id": "reviewer.example",
+            "card_url": "https://reviewer.example/.well-known/agent-card.json",
+            "rpc_url": "https://reviewer.example/a2a",
+            "task_id": "task-deterministic",
+            "state": "completed"
+          },
+          "result": {
+            "status": "triaged",
+            "labels": ["needs-owner"],
+            "title": "Trust boundary dispatch demo"
+          }
+        }
+      }
+    ],
+    "trigger_firings": [
+      {
+        "binding_id": "issue-triage",
+        "event_id": "trigger_evt_a2a",
+        "trace_id": "trace_a2a",
+        "handler_kind": "a2a",
+        "target_uri": "a2a://reviewer.example/triage",
+        "trust_boundary": "federated_a2a",
+        "remote_identity": "triage",
+        "decision": "dispatched"
+      }
+    ]
+  }
+}

--- a/crates/harn-vm/src/a2a/mod.rs
+++ b/crates/harn-vm/src/a2a/mod.rs
@@ -44,6 +44,8 @@ pub enum A2aClientError {
     InvalidTarget(String),
     Discovery(String),
     Protocol(String),
+    Denied(String),
+    Timeout(String),
     Cancelled(String),
 }
 
@@ -53,6 +55,8 @@ impl std::fmt::Display for A2aClientError {
             Self::InvalidTarget(message)
             | Self::Discovery(message)
             | Self::Protocol(message)
+            | Self::Denied(message)
+            | Self::Timeout(message)
             | Self::Cancelled(message) => f.write_str(message),
         }
     }
@@ -105,6 +109,8 @@ enum AgentCardFetchError {
     Cancelled(String),
     Discovery(String),
     ConnectRefused(String),
+    Denied(String),
+    Timeout(String),
 }
 
 pub async fn dispatch_trigger_event(
@@ -227,6 +233,14 @@ pub async fn dispatch_trigger_event(
                 result: inline,
             },
         ));
+    }
+
+    if state == "rejected" {
+        record_a2a_metric(raw_target, "failed", started.elapsed());
+        return Err(A2aClientError::Denied(format!(
+            "A2A task rejected by remote agent: {}",
+            task_status_message(&result).unwrap_or("permission rejected")
+        )));
     }
 
     if let Some(config) = push_config {
@@ -379,6 +393,12 @@ async fn resolve_endpoint(
                 Err(AgentCardFetchError::Cancelled(message)) => {
                     return Err(A2aClientError::Cancelled(message));
                 }
+                Err(AgentCardFetchError::Timeout(message)) => {
+                    return Err(A2aClientError::Timeout(message));
+                }
+                Err(AgentCardFetchError::Denied(message)) => {
+                    return Err(A2aClientError::Denied(message));
+                }
                 Err(error) => {
                     last_error = Some(agent_card_fetch_error_message(&error));
                     last_scheme_error = Some(error);
@@ -407,6 +427,9 @@ async fn fetch_agent_card(
         response = crate::llm::shared_utility_client().get(card_url).send() => {
             match response {
                 Ok(response) => Ok(response),
+                Err(error) if error.is_timeout() => Err(AgentCardFetchError::Timeout(
+                    format!("A2A HTTP request timed out: {error}")
+                )),
                 Err(error) if is_connect_refused(&error) => Err(AgentCardFetchError::ConnectRefused(
                     format!("A2A HTTP request failed: {error}")
                 )),
@@ -419,6 +442,15 @@ async fn fetch_agent_card(
             "A2A agent-card fetch cancelled".to_string()
         )),
     }?;
+    if matches!(
+        response.status(),
+        reqwest::StatusCode::UNAUTHORIZED | reqwest::StatusCode::FORBIDDEN
+    ) {
+        return Err(AgentCardFetchError::Denied(format!(
+            "GET {card_url} returned HTTP {}",
+            response.status()
+        )));
+    }
     if !response.status().is_success() {
         return Err(AgentCardFetchError::Discovery(format!(
             "GET {card_url} returned HTTP {}",
@@ -605,7 +637,7 @@ fn resolve_declared_url(
     ensure_cleartext_allowed(&url, allow_cleartext, label)?;
     let declared_authority = url_authority(&url)?;
     if !authorities_equivalent(&declared_authority, requested_authority) {
-        return Err(A2aClientError::Discovery(format!(
+        return Err(A2aClientError::Denied(format!(
             "A2A {label} authority mismatch: requested '{requested_authority}', card returned '{declared_authority}'"
         )));
     }
@@ -642,7 +674,9 @@ fn should_try_cleartext_fallback(
         return false;
     }
     match error {
-        AgentCardFetchError::Cancelled(_) => false,
+        AgentCardFetchError::Cancelled(_)
+        | AgentCardFetchError::Denied(_)
+        | AgentCardFetchError::Timeout(_) => false,
         AgentCardFetchError::ConnectRefused(_) => true,
         AgentCardFetchError::Discovery(_) => is_loopback_authority(authority),
     }
@@ -656,7 +690,7 @@ fn ensure_cleartext_allowed(
     if allow_cleartext || url.scheme() != "http" {
         return Ok(());
     }
-    Err(A2aClientError::Discovery(format!(
+    Err(A2aClientError::Denied(format!(
         "cleartext A2A {label} '{url}' requires `allow_cleartext = true` on the trigger binding"
     )))
 }
@@ -721,7 +755,9 @@ fn agent_card_fetch_error_message(error: &AgentCardFetchError) -> String {
     match error {
         AgentCardFetchError::Cancelled(message)
         | AgentCardFetchError::Discovery(message)
-        | AgentCardFetchError::ConnectRefused(message) => message.clone(),
+        | AgentCardFetchError::ConnectRefused(message)
+        | AgentCardFetchError::Denied(message)
+        | AgentCardFetchError::Timeout(message) => message.clone(),
     }
 }
 
@@ -769,6 +805,15 @@ async fn send_jsonrpc(
         "A2A task dispatch cancelled",
     )
     .await?;
+    if matches!(
+        response.status(),
+        reqwest::StatusCode::UNAUTHORIZED | reqwest::StatusCode::FORBIDDEN
+    ) {
+        return Err(A2aClientError::Denied(format!(
+            "A2A task dispatch returned HTTP {}",
+            response.status()
+        )));
+    }
     if !response.status().is_success() {
         return Err(A2aClientError::Protocol(format!(
             "A2A task dispatch returned HTTP {}",
@@ -787,8 +832,13 @@ async fn send_http(
     cancelled_message: &'static str,
 ) -> Result<reqwest::Response, A2aClientError> {
     tokio::select! {
-        response = request.send() => response
-            .map_err(|error| A2aClientError::Protocol(format!("A2A HTTP request failed: {error}"))),
+        response = request.send() => response.map_err(|error| {
+            if error.is_timeout() {
+                A2aClientError::Timeout(format!("A2A HTTP request timed out: {error}"))
+            } else {
+                A2aClientError::Protocol(format!("A2A HTTP request failed: {error}"))
+            }
+        }),
         _ = recv_cancel(cancel_rx) => Err(A2aClientError::Cancelled(cancelled_message.to_string())),
     }
 }
@@ -800,6 +850,21 @@ fn task_state(task: &Value) -> Result<&str, A2aClientError> {
         .ok_or_else(|| {
             A2aClientError::Protocol("A2A task response missing result.status.state".to_string())
         })
+}
+
+fn task_status_message(task: &Value) -> Option<&str> {
+    task.pointer("/status/message/parts")
+        .and_then(Value::as_array)
+        .and_then(|parts| {
+            parts.iter().find_map(|part| {
+                if part.get("type").and_then(Value::as_str) == Some("text") {
+                    part.get("text").and_then(Value::as_str).map(str::trim)
+                } else {
+                    None
+                }
+            })
+        })
+        .filter(|message| !message.is_empty())
 }
 
 fn extract_inline_result(task: &Value) -> Value {

--- a/crates/harn-vm/src/triggers/dispatcher/action_graph.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/action_graph.rs
@@ -207,6 +207,7 @@ pub(super) fn dispatch_node_metadata(
         "target_uri".to_string(),
         serde_json::json!(route.target_uri()),
     );
+    metadata.extend(route.dispatch_boundary_metadata());
     metadata.insert("attempt".to_string(), serde_json::json!(attempt));
     metadata.insert(
         "trigger_id".to_string(),

--- a/crates/harn-vm/src/triggers/dispatcher/audit.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/audit.rs
@@ -61,6 +61,7 @@ impl Dispatcher {
             "target_uri".to_string(),
             serde_json::json!(route.target_uri()),
         );
+        record.metadata.extend(route.dispatch_boundary_metadata());
         record.metadata.insert(
             "terminal_status".to_string(),
             serde_json::json!(terminal_status),

--- a/crates/harn-vm/src/triggers/dispatcher/mod.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/mod.rs
@@ -83,8 +83,8 @@ use action_graph::{
 use state::install_test_inbox_dequeued_signal;
 use state::{notify_test_inbox_dequeued, ACTIVE_DISPATCHER_STATE, ACTIVE_DISPATCH_IS_REPLAY};
 use types::{
-    AcquiredFlowControl, ConcurrencyLease, DispatchSkipStage, DispatcherRuntimeState,
-    FlowControlOutcome, SingletonLease, DEFAULT_AUTONOMY_BUDGET_REVIEWER,
+    AcquiredFlowControl, ConcurrencyLease, DispatchCallResult, DispatchSkipStage,
+    DispatcherRuntimeState, FlowControlOutcome, SingletonLease, DEFAULT_AUTONOMY_BUDGET_REVIEWER,
 };
 use util::{
     accepted_at_ms, binding_key_from_parts, build_batched_event, cancelled_dispatch_outcome,
@@ -1218,7 +1218,9 @@ impl Dispatcher {
             let completed_at = now_rfc3339();
 
             match result {
-                Ok(result) => {
+                Ok(dispatch_result) => {
+                    let result = dispatch_result.output;
+                    let dispatch_metadata = dispatch_result.metadata;
                     let attempt_record = DispatchAttemptRecord {
                         trigger_id: binding.id.as_str().to_string(),
                         binding_key: binding.binding_key(),
@@ -1247,6 +1249,7 @@ impl Dispatcher {
                             "attempt": attempt,
                             "handler_kind": route.kind(),
                             "target_uri": route.target_uri(),
+                            "dispatch_metadata": dispatch_metadata,
                             "result": result,
                             "replay_of_event_id": replay_of_event_id,
                         }),
@@ -1266,12 +1269,16 @@ impl Dispatcher {
                             "binding_key": binding.binding_key(),
                             "handler_kind": route.kind(),
                             "target_uri": route.target_uri(),
+                            "dispatch_metadata": dispatch_metadata,
                             "result": result,
                             "replay_of_event_id": replay_of_event_id,
                         }),
                         replay_of_event_id.as_ref(),
                     )
                     .await?;
+                    let mut node_metadata =
+                        dispatch_success_metadata(&route, binding, &event, attempt, &result);
+                    node_metadata.extend(dispatch_metadata.clone());
                     self.emit_action_graph(
                         &event,
                         vec![RunActionGraphNodeRecord {
@@ -1286,9 +1293,7 @@ impl Dispatcher {
                             worker_id: None,
                             run_id: None,
                             run_path: None,
-                            metadata: dispatch_success_metadata(
-                                &route, binding, &event, attempt, &result,
-                            ),
+                            metadata: node_metadata,
                         }],
                         Vec::new(),
                         serde_json::json!({
@@ -1299,6 +1304,7 @@ impl Dispatcher {
                             "attempt": attempt,
                             "handler_kind": route.kind(),
                             "target_uri": route.target_uri(),
+                            "dispatch_metadata": dispatch_metadata,
                             "result": result,
                             "replay_of_event_id": replay_of_event_id,
                         }),
@@ -1984,7 +1990,7 @@ impl Dispatcher {
         autonomy_tier: AutonomyTier,
         wait_lease: Option<DispatchWaitLease>,
         cancel_rx: &mut broadcast::Receiver<()>,
-    ) -> Result<serde_json::Value, DispatchError> {
+    ) -> Result<DispatchCallResult, DispatchError> {
         match route {
             DispatchUri::Local { .. } => {
                 let TriggerHandlerSpec::Local { closure, .. } = &binding.handler else {
@@ -2006,7 +2012,10 @@ impl Dispatcher {
                         cancel_rx,
                     )
                     .await?;
-                Ok(vm_value_to_json(&value))
+                Ok(DispatchCallResult {
+                    output: vm_value_to_json(&value),
+                    metadata: route.dispatch_boundary_metadata(),
+                })
             }
             DispatchUri::A2a {
                 target,
@@ -2017,7 +2026,7 @@ impl Dispatcher {
                         "dispatcher shutdown cancelled A2A dispatch".to_string(),
                     ));
                 }
-                let (_endpoint, ack) = self
+                let (endpoint, ack) = self
                     .a2a_client
                     .dispatch(
                         target,
@@ -2032,11 +2041,45 @@ impl Dispatcher {
                         crate::a2a::A2aClientError::Cancelled(message) => {
                             DispatchError::Cancelled(message)
                         }
+                        crate::a2a::A2aClientError::Denied(message) => {
+                            DispatchError::Denied(message)
+                        }
+                        crate::a2a::A2aClientError::Timeout(message) => {
+                            DispatchError::Timeout(message)
+                        }
                         other => DispatchError::A2a(other.to_string()),
                     })?;
+                let mut metadata = route.dispatch_boundary_metadata();
+                metadata.insert(
+                    "target_agent".to_string(),
+                    serde_json::json!(endpoint.target_agent),
+                );
+                metadata.insert("card_url".to_string(), serde_json::json!(endpoint.card_url));
+                metadata.insert("rpc_url".to_string(), serde_json::json!(endpoint.rpc_url));
+                if let Some(agent_id) = endpoint.agent_id {
+                    metadata.insert("remote_agent_id".to_string(), serde_json::json!(agent_id));
+                }
                 match ack {
-                    crate::a2a::DispatchAck::InlineResult { result, .. } => Ok(result),
-                    crate::a2a::DispatchAck::PendingTask { handle, .. } => Ok(handle),
+                    crate::a2a::DispatchAck::InlineResult { task_id, result } => {
+                        metadata.insert("task_id".to_string(), serde_json::json!(task_id));
+                        metadata.insert("state".to_string(), serde_json::json!("completed"));
+                        Ok(DispatchCallResult {
+                            output: result,
+                            metadata,
+                        })
+                    }
+                    crate::a2a::DispatchAck::PendingTask {
+                        task_id,
+                        state,
+                        handle,
+                    } => {
+                        metadata.insert("task_id".to_string(), serde_json::json!(task_id));
+                        metadata.insert("state".to_string(), serde_json::json!(state));
+                        Ok(DispatchCallResult {
+                            output: handle,
+                            metadata,
+                        })
+                    }
                 }
             }
             DispatchUri::Worker { queue } => {
@@ -2053,8 +2096,13 @@ impl Dispatcher {
                     })
                     .await
                     .map_err(DispatchError::from)?;
-                Ok(serde_json::to_value(receipt)
-                    .map_err(|error| DispatchError::Serde(error.to_string()))?)
+                let mut metadata = route.dispatch_boundary_metadata();
+                metadata.insert("queue_name".to_string(), serde_json::json!(queue));
+                Ok(DispatchCallResult {
+                    output: serde_json::to_value(receipt)
+                        .map_err(|error| DispatchError::Serde(error.to_string()))?,
+                    metadata,
+                })
             }
             DispatchUri::Persona { .. } => {
                 let TriggerHandlerSpec::Persona {
@@ -2077,8 +2125,11 @@ impl Dispatcher {
                 )
                 .await
                 .map_err(DispatchError::Local)?;
-                Ok(serde_json::to_value(receipt)
-                    .map_err(|error| DispatchError::Serde(error.to_string()))?)
+                Ok(DispatchCallResult {
+                    output: serde_json::to_value(receipt)
+                        .map_err(|error| DispatchError::Serde(error.to_string()))?,
+                    metadata: route.dispatch_boundary_metadata(),
+                })
             }
         }
     }

--- a/crates/harn-vm/src/triggers/dispatcher/tests/dispatch.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/tests/dispatch.rs
@@ -160,6 +160,140 @@ async fn a2a_handler_returns_inline_result_and_emits_a2a_action_graph() {
                 logged.headers.get("trace_id").map(String::as_str) == Some("trace_inline")
                     && logged.payload["context"]["target_agent"] == serde_json::json!("triage")
             }));
+            assert!(graph.iter().any(|(_, logged)| {
+                logged.payload["observability"]["action_graph_nodes"]
+                    .as_array()
+                    .is_some_and(|nodes| {
+                        nodes.iter().any(|node| {
+                            node["kind"] == serde_json::json!("a2a_hop")
+                                && node["metadata"]["trust_boundary"]
+                                    == serde_json::json!("federated_a2a")
+                                && node["metadata"]["execution_location"]
+                                    == serde_json::json!("remote")
+                                && node["metadata"]["remote_identity"]
+                                    == serde_json::json!("triage")
+                                && node["metadata"]["remote_agent_id"]
+                                    == serde_json::json!("agent:mock-a2a/triage")
+                        })
+                    })
+            }));
+
+            let trust_records = crate::query_trust_records(
+                &log,
+                &crate::TrustQueryFilters {
+                    agent: Some("github-a2a-review".to_string()),
+                    action: Some("github.issues.opened".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("query trust records");
+            assert!(trust_records.iter().any(|logged| {
+                logged.metadata["trust_boundary"] == serde_json::json!("federated_a2a")
+                    && logged.metadata["remote_identity"] == serde_json::json!("triage")
+            }));
+        })
+        .await;
+}
+
+#[tokio::test(start_paused = true, flavor = "current_thread")]
+async fn local_and_a2a_handlers_preserve_logical_output_and_replay_shape() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let expected = serde_json::json!({
+                "status": "triaged",
+                "labels": ["needs-owner"],
+            });
+            let (_local_dir, local_log, local_dispatcher) = dispatcher_fixture(
+                r#"
+import "std/triggers"
+
+pub fn local_fn(_event: TriggerEvent) -> dict {
+  return {status: "triaged", labels: ["needs-owner"]}
+}
+"#,
+                "local_fn",
+                None,
+                TriggerRetryConfig::default(),
+            )
+            .await;
+            let mut local_event = trigger_event("issues.opened", "delivery-local-equivalent");
+            local_event.trace_id = TraceId("trace-equivalent".to_string());
+            let local_outcome = local_dispatcher
+                .dispatch_event(local_event)
+                .await
+                .expect("local dispatch succeeds")
+                .pop()
+                .expect("local outcome");
+            let local_outbox = read_topic(local_log.clone(), "trigger.outbox").await;
+            let local_attempts = read_topic(local_log.clone(), "trigger.attempts").await;
+
+            let mock_client = InProcessMockA2aClient::new(MockA2aResponse::Inline {
+                task_id: "task-equivalent".to_string(),
+                result: expected.clone(),
+            });
+            let (_a2a_dir, a2a_log, a2a_dispatcher) = a2a_dispatcher_fixture(
+                "mock-a2a/triage".to_string(),
+                TriggerRetryConfig::default(),
+                false,
+                mock_client,
+            )
+            .await;
+            let mut a2a_event = trigger_event("issues.opened", "delivery-a2a-equivalent");
+            a2a_event.trace_id = TraceId("trace-equivalent".to_string());
+            let a2a_outcome = a2a_dispatcher
+                .dispatch_event(a2a_event)
+                .await
+                .expect("A2A dispatch succeeds")
+                .pop()
+                .expect("A2A outcome");
+            let a2a_outbox = read_topic(a2a_log.clone(), "trigger.outbox").await;
+            let a2a_attempts = read_topic(a2a_log.clone(), "trigger.attempts").await;
+
+            assert_eq!(local_outcome.result, Some(expected.clone()));
+            assert_eq!(a2a_outcome.result, Some(expected));
+            assert_eq!(
+                local_outbox
+                    .iter()
+                    .map(|(_, event)| event.kind.as_str())
+                    .collect::<Vec<_>>(),
+                a2a_outbox
+                    .iter()
+                    .map(|(_, event)| event.kind.as_str())
+                    .collect::<Vec<_>>(),
+            );
+            assert_eq!(
+                local_attempts
+                    .iter()
+                    .map(|(_, event)| event.kind.as_str())
+                    .collect::<Vec<_>>(),
+                a2a_attempts
+                    .iter()
+                    .map(|(_, event)| event.kind.as_str())
+                    .collect::<Vec<_>>(),
+            );
+
+            let local_success = local_outbox
+                .iter()
+                .find(|(_, event)| event.kind == "dispatch_succeeded")
+                .expect("local dispatch_succeeded");
+            let a2a_success = a2a_outbox
+                .iter()
+                .find(|(_, event)| event.kind == "dispatch_succeeded")
+                .expect("A2A dispatch_succeeded");
+            assert_eq!(
+                local_success.1.payload["dispatch_metadata"]["trust_boundary"],
+                serde_json::json!("local_process")
+            );
+            assert_eq!(
+                a2a_success.1.payload["dispatch_metadata"]["trust_boundary"],
+                serde_json::json!("federated_a2a")
+            );
+            assert_eq!(
+                a2a_success.1.payload["dispatch_metadata"]["remote_identity"],
+                serde_json::json!("triage")
+            );
         })
         .await;
 }
@@ -308,7 +442,7 @@ async fn a2a_handler_rejects_cleartext_by_default() {
     let local = tokio::task::LocalSet::new();
     local
         .run_until(async {
-            let mock_client = InProcessMockA2aClient::new(MockA2aResponse::Protocol(
+            let mock_client = InProcessMockA2aClient::new(MockA2aResponse::Denied(
                 "A2A endpoint uses cleartext HTTP; set allow_cleartext = true to opt in"
                     .to_string(),
             ));
@@ -325,11 +459,125 @@ async fn a2a_handler_rejects_cleartext_by_default() {
                 .await
                 .expect("cleartext denial returns terminal outcome");
             assert_eq!(outcomes.len(), 1);
-            assert_eq!(outcomes[0].status, DispatchStatus::Dlq);
+            assert_eq!(outcomes[0].status, DispatchStatus::Failed);
             assert!(outcomes[0]
                 .error
                 .as_deref()
                 .is_some_and(|message| message.contains("allow_cleartext = true")));
+        })
+        .await;
+}
+
+#[tokio::test(start_paused = true, flavor = "current_thread")]
+async fn a2a_timeout_retries_then_dlqs() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let mock_client = InProcessMockA2aClient::new(MockA2aResponse::Timeout(
+                "A2A HTTP request timed out".to_string(),
+            ));
+            let (_dir, log, dispatcher) = a2a_dispatcher_fixture(
+                "mock-a2a/triage".to_string(),
+                TriggerRetryConfig::new(1, RetryPolicy::Linear { delay_ms: 0 }),
+                false,
+                mock_client,
+            )
+            .await;
+
+            let outcomes = dispatcher
+                .dispatch_event(trigger_event("issues.opened", "delivery-a2a-timeout"))
+                .await
+                .expect("timeout returns terminal outcome");
+            assert_eq!(outcomes.len(), 1);
+            assert_eq!(outcomes[0].status, DispatchStatus::Dlq);
+            assert!(outcomes[0]
+                .error
+                .as_deref()
+                .is_some_and(|message| message.contains("timed out")));
+
+            let attempts = read_topic(log.clone(), "trigger.attempts").await;
+            assert!(attempts.iter().any(|(_, event)| {
+                event.kind == "attempt_recorded"
+                    && event.payload["outcome"] == serde_json::json!("timeout")
+            }));
+        })
+        .await;
+}
+
+#[tokio::test(start_paused = true, flavor = "current_thread")]
+async fn a2a_incompatible_schema_dlqs() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let mock_client = InProcessMockA2aClient::new(MockA2aResponse::Protocol(
+                "A2A task response missing result.status.state".to_string(),
+            ));
+            let (_dir, _log, dispatcher) = a2a_dispatcher_fixture(
+                "mock-a2a/triage".to_string(),
+                TriggerRetryConfig::new(1, RetryPolicy::Linear { delay_ms: 0 }),
+                false,
+                mock_client,
+            )
+            .await;
+
+            let outcomes = dispatcher
+                .dispatch_event(trigger_event("issues.opened", "delivery-a2a-schema"))
+                .await
+                .expect("schema mismatch returns terminal outcome");
+            assert_eq!(outcomes.len(), 1);
+            assert_eq!(outcomes[0].status, DispatchStatus::Dlq);
+            assert!(outcomes[0]
+                .error
+                .as_deref()
+                .is_some_and(|message| message.contains("result.status.state")));
+        })
+        .await;
+}
+
+#[tokio::test(start_paused = true, flavor = "current_thread")]
+async fn a2a_permission_rejection_fails_closed_without_retry() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let mock_client = InProcessMockA2aClient::new(MockA2aResponse::Denied(
+                "A2A task rejected by remote agent: permission denied".to_string(),
+            ));
+            let (_dir, log, dispatcher) = a2a_dispatcher_fixture(
+                "mock-a2a/triage".to_string(),
+                TriggerRetryConfig::new(3, RetryPolicy::Linear { delay_ms: 0 }),
+                false,
+                mock_client.clone(),
+            )
+            .await;
+
+            let outcomes = dispatcher
+                .dispatch_event(trigger_event("issues.opened", "delivery-a2a-denied"))
+                .await
+                .expect("permission rejection returns terminal outcome");
+            assert_eq!(outcomes.len(), 1);
+            assert_eq!(outcomes[0].status, DispatchStatus::Failed);
+            assert_eq!(outcomes[0].attempt_count, 1);
+            assert!(outcomes[0]
+                .error
+                .as_deref()
+                .is_some_and(|message| message.contains("permission denied")));
+            assert_eq!(mock_client.take_calls().await.len(), 1);
+
+            let trust_records = crate::query_trust_records(
+                &log,
+                &crate::TrustQueryFilters {
+                    agent: Some("github-a2a-review".to_string()),
+                    action: Some("github.issues.opened".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("query trust records");
+            assert!(trust_records.iter().any(|event| {
+                event.outcome == crate::TrustOutcome::Denied
+                    && event.metadata["terminal_status"] == serde_json::json!("failed")
+                    && event.metadata["trust_boundary"] == serde_json::json!("federated_a2a")
+            }));
         })
         .await;
 }

--- a/crates/harn-vm/src/triggers/dispatcher/tests/fixtures.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/tests/fixtures.rs
@@ -386,6 +386,8 @@ pub(super) enum MockA2aResponse {
         state: String,
         handle: serde_json::Value,
     },
+    Timeout(String),
+    Denied(String),
     /// Return a protocol error carrying `message`.
     Protocol(String),
     /// Block until the cancel broadcast fires, then return `Cancelled`.
@@ -434,7 +436,7 @@ impl crate::a2a::A2aClient for InProcessMockA2aClient {
         let endpoint = crate::a2a::ResolvedA2aEndpoint {
             card_url: format!("https://{}/.well-known/agent-card.json", target),
             rpc_url: format!("https://{}/rpc", target),
-            agent_id: None,
+            agent_id: Some(format!("agent:{target}")),
             target_agent: crate::a2a::target_agent_label(target),
         };
 
@@ -458,6 +460,12 @@ impl crate::a2a::A2aClient for InProcessMockA2aClient {
                     handle: handle.clone(),
                 },
             )),
+            MockA2aResponse::Timeout(message) => {
+                Err(crate::a2a::A2aClientError::Timeout(message.clone()))
+            }
+            MockA2aResponse::Denied(message) => {
+                Err(crate::a2a::A2aClientError::Denied(message.clone()))
+            }
             MockA2aResponse::Protocol(message) => {
                 Err(crate::a2a::A2aClientError::Protocol(message.clone()))
             }

--- a/crates/harn-vm/src/triggers/dispatcher/types.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/types.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
@@ -332,6 +333,12 @@ pub(super) enum FlowControlOutcome {
     Skip {
         reason: String,
     },
+}
+
+#[derive(Debug)]
+pub(super) struct DispatchCallResult {
+    pub(super) output: serde_json::Value,
+    pub(super) metadata: BTreeMap<String, serde_json::Value>,
 }
 
 #[derive(Clone, Debug)]

--- a/crates/harn-vm/src/triggers/dispatcher/uri.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/uri.rs
@@ -100,6 +100,52 @@ impl DispatchUri {
             Self::Persona { name } => format!("persona://{name}"),
         }
     }
+
+    pub fn trust_boundary(&self) -> &'static str {
+        match self {
+            Self::Local { .. } => "local_process",
+            Self::A2a { .. } => "federated_a2a",
+            Self::Worker { .. } => "event_log_worker_queue",
+            Self::Persona { .. } => "persona_runtime",
+        }
+    }
+
+    pub fn execution_location(&self) -> &'static str {
+        match self {
+            Self::Local { .. } => "in_process",
+            Self::A2a { .. } => "remote",
+            Self::Worker { .. } => "queued",
+            Self::Persona { .. } => "managed_persona",
+        }
+    }
+
+    pub fn remote_identity(&self) -> Option<String> {
+        match self {
+            Self::A2a { target, .. } => Some(crate::a2a::target_agent_label(target)),
+            _ => None,
+        }
+    }
+
+    pub fn dispatch_boundary_metadata(
+        &self,
+    ) -> std::collections::BTreeMap<String, serde_json::Value> {
+        let mut metadata = std::collections::BTreeMap::new();
+        metadata.insert(
+            "trust_boundary".to_string(),
+            serde_json::json!(self.trust_boundary()),
+        );
+        metadata.insert(
+            "execution_location".to_string(),
+            serde_json::json!(self.execution_location()),
+        );
+        if let Some(remote_identity) = self.remote_identity() {
+            metadata.insert(
+                "remote_identity".to_string(),
+                serde_json::json!(remote_identity),
+            );
+        }
+        metadata
+    }
 }
 
 impl From<&TriggerHandlerSpec> for DispatchUri {

--- a/crates/harn-vm/src/triggers/dispatcher/util.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/util.rs
@@ -257,9 +257,7 @@ pub(super) fn duration_between_ms(later_ms: i64, earlier_ms: i64) -> Duration {
     Duration::from_millis(later_ms.saturating_sub(earlier_ms).max(0) as u64)
 }
 
-pub(super) fn dispatch_result_status(
-    result: &Result<serde_json::Value, DispatchError>,
-) -> &'static str {
+pub(super) fn dispatch_result_status<T>(result: &Result<T, DispatchError>) -> &'static str {
     match result {
         Ok(_) => "succeeded",
         Err(DispatchError::Waiting(_)) => "waiting",

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -103,6 +103,7 @@
 - [Dashboard job envelopes](./orchestrator/dashboard-jobs.md)
 - [Orchestrator backpressure](./orchestrator/backpressure.md)
 - [Worker dispatch](./orchestrator/worker-dispatch.md)
+- [Local and A2A dispatch](./orchestrator/local-a2a-dispatch.md)
 - [Orchestrator secrets](./orchestrator/secrets.md)
 - [Multi-tenant orchestrator](./orchestrator/multi-tenant.md)
 - [Connector OAuth](./orchestrator/oauth.md)

--- a/docs/src/orchestrator/local-a2a-dispatch.md
+++ b/docs/src/orchestrator/local-a2a-dispatch.md
@@ -1,0 +1,85 @@
+# Local And A2A Dispatch
+
+Harn trigger handlers can move between in-process execution and A2A dispatch
+without changing the handler's input contract. Keep the trigger `id`, provider
+match, retry policy, and handler source stable; change only the handler target
+when the boundary changes:
+
+```toml
+# local
+handler = "handlers::triage_issue"
+
+# federated
+handler = "a2a://reviewer.example/triage"
+```
+
+The dispatcher still records the same core lifecycle shape:
+
+- `dispatch_started`
+- `attempt_recorded`
+- `dispatch_succeeded`, `dispatch_failed`, `dispatch_waiting`, or `dlq_moved`
+- a trust record for the terminal dispatch decision
+- action-graph nodes and edges for replay comparison
+
+## Choosing A Mode
+
+Use a local handler when the workflow should run inside the current Harn process:
+
+- development and deterministic test fixtures
+- low-latency handlers with no cross-tenant boundary
+- handlers that need direct access to local host capabilities already granted to
+  the current orchestrator
+
+Use A2A dispatch when execution crosses an agent or trust boundary:
+
+- a managed Harn Cloud worker owns the handler
+- a federated agent has separate credentials, quotas, or receipts
+- an operator needs to see that the work ran remotely
+- retries and DLQ movement should treat the remote endpoint as a destination
+
+## Trust And Replay
+
+Local and A2A dispatch share typed `TriggerEvent` input and JSON output
+semantics. A2A wraps the event in a `harn.trigger.dispatch` envelope, sends it
+with `message/send`, and unwraps the completed task's final text part as the
+logical handler result.
+
+The difference is recorded as metadata, not as a handler-source requirement.
+Action-graph nodes and trust records include:
+
+- `trust_boundary`: `local_process`, `federated_a2a`,
+  `event_log_worker_queue`, or `persona_runtime`
+- `execution_location`: `in_process`, `remote`, `queued`, or
+  `managed_persona`
+- `remote_identity`: the A2A target agent label for remote dispatch
+- A2A task metadata such as `task_id`, `state`, `card_url`, `rpc_url`, and
+  `remote_agent_id` when the remote card exposes it
+
+Replay comparisons should assert the logical output and event shape while
+allowlisting location-specific metadata such as `trust_boundary`,
+`remote_identity`, remote URLs, and generated task ids.
+
+## Failure Modes
+
+A2A dispatch fails closed for trust-boundary denials:
+
+- cleartext HTTP endpoints require `allow_cleartext = true`
+- agent-card authority mismatches are denied
+- HTTP `401` / `403` dispatch responses are denied
+- A2A `rejected` task state becomes a permission-denied dispatch failure
+
+Remote timeouts are classified as timeout failures and remain retryable under
+the trigger's retry policy. Incompatible A2A response schemas are protocol
+failures and move to DLQ when retries are exhausted.
+
+## Demo
+
+The reference flow is in `examples/triggers/local-a2a-dispatch/`.
+
+```sh
+scripts/demo_local_a2a_dispatch.sh
+```
+
+The script starts a local `harn serve` A2A receiver on a random port, fires the
+same deterministic issue event through a local handler and through A2A, and
+prints whether the logical outputs match.

--- a/docs/src/triggers/manifest.md
+++ b/docs/src/triggers/manifest.md
@@ -61,6 +61,13 @@ Harn currently accepts three handler forms:
 
 Unsupported URI schemes fail fast at load time.
 
+Switching a handler between local and A2A dispatch is intentionally a manifest
+change, not a handler-source change. Keep the same trigger id and event match,
+then change `handler = "handlers::on_event"` to an `a2a://...` target when the
+trust boundary moves out of process. See
+[Local and A2A dispatch](../orchestrator/local-a2a-dispatch.md) for the replay
+and observability contract.
+
 `a2a://...` handlers accept one extra opt-in field:
 
 - `allow_cleartext = true` permits HTTP A2A card discovery / JSON-RPC dispatch

--- a/examples/triggers/README.md
+++ b/examples/triggers/README.md
@@ -1,11 +1,12 @@
 # Trigger manifest examples
 
 These examples show ready-to-customize `[[triggers]]` shapes. Each directory
-contains `harn.toml`, `lib.harn`, `README.md`, and `SKILL.md`:
+contains `harn.toml`, `lib.harn`, `README.md`, and `SKILL.md` unless noted:
 
 - `cron-daily-digest/`: cron schedule + local handler
 - `github-new-issue/`: webhook trigger + local predicate + local handler
 - `a2a-reviewer-fanout/`: a2a-push trigger + remote A2A handler
+- `local-a2a-dispatch/`: one handler with local and A2A trigger manifests
 - `stream-fan-in/`: multi-source handler combining cron and Kafka stream bindings
 - `github-stale-pr-nudger/`: scheduled stale pull-request follow-up
 - `github-release-notes-generator/`: release note generation from GitHub events

--- a/examples/triggers/local-a2a-dispatch/README.md
+++ b/examples/triggers/local-a2a-dispatch/README.md
@@ -1,0 +1,17 @@
+# Local / A2A Dispatch Demo
+
+This example keeps the handler logic stable while moving dispatch across the
+trust boundary.
+
+- `harn.local.toml` runs `handlers::triage_issue` in process.
+- `harn.remote.toml` changes only the trigger handler target to
+  `a2a://127.0.0.1:8787/triage`.
+- `remote-handler.harn` is the receiving A2A wrapper used by the demo script;
+  it imports the same triage helper from `lib.harn`.
+
+## Verify
+
+```sh
+harn check lib.harn
+scripts/demo_local_a2a_dispatch.sh
+```

--- a/examples/triggers/local-a2a-dispatch/demo.harn
+++ b/examples/triggers/local-a2a-dispatch/demo.harn
@@ -1,0 +1,68 @@
+import "std/triggers"
+import { triage_issue_payload } from "lib"
+
+fn local_triage(event: TriggerEvent) -> dict {
+  let raw = event.provider_payload.raw ?? {}
+  let context = handler_context()
+  return triage_issue_payload(raw, context?.trace_id ?? event.trace_id, context?.replay_of_event_id)
+}
+
+fn register_local() {
+  return trigger_register(
+    {
+      id: "issue-triage-local-demo",
+      kind: "webhook",
+      provider: "github",
+      match: {events: ["issues.opened"]},
+      handler: local_triage,
+      retry: {max: 1, backoff: "immediate"},
+    },
+  )
+}
+
+fn register_remote(port) {
+  return trigger_register(
+    {
+      id: "issue-triage-a2a-demo",
+      kind: "webhook",
+      provider: "github",
+      match: {events: ["issues.opened"]},
+      handler: "a2a://127.0.0.1:" + port + "/triage",
+      allow_cleartext: true,
+      retry: {max: 1, backoff: "immediate"},
+    },
+  )
+}
+
+fn fire(handle, suffix) {
+  return trigger_fire(
+    handle,
+    {
+      id: "evt-demo-" + suffix,
+      provider: "github",
+      kind: "issues.opened",
+      trace_id: "trace-demo-" + suffix,
+      dedupe_key: "demo:" + suffix,
+      issue: {title: "Trust boundary dispatch demo"},
+    },
+  )
+}
+
+pipeline default() {
+  let port = env_or("HARN_DEMO_REMOTE_PORT", "8787")
+  let local = fire(register_local(), "local")
+  let remote = fire(register_remote(port), "a2a")
+  println(
+    json_stringify(
+      {
+        local_status: local.status,
+        remote_status: remote.status,
+        same_logical_output: local.result.status == remote.result.status
+          && local.result.title == remote.result.title
+          && local.result.labels[0] == remote.result.labels[0],
+        local_result: local.result,
+        remote_result: remote.result,
+      },
+    ),
+  )
+}

--- a/examples/triggers/local-a2a-dispatch/harn.local.toml
+++ b/examples/triggers/local-a2a-dispatch/harn.local.toml
@@ -1,0 +1,14 @@
+[package]
+name = "local-a2a-dispatch-demo"
+
+[exports]
+handlers = "lib.harn"
+
+[[triggers]]
+id = "issue-triage"
+kind = "webhook"
+provider = "github"
+match = { events = ["issues.opened"] }
+handler = "handlers::triage_issue"
+dedupe_key = "event.dedupe_key"
+retry = { max = 1, backoff = "immediate" }

--- a/examples/triggers/local-a2a-dispatch/harn.remote.toml
+++ b/examples/triggers/local-a2a-dispatch/harn.remote.toml
@@ -1,0 +1,15 @@
+[package]
+name = "local-a2a-dispatch-demo"
+
+[exports]
+handlers = "lib.harn"
+
+[[triggers]]
+id = "issue-triage"
+kind = "webhook"
+provider = "github"
+match = { events = ["issues.opened"] }
+handler = "a2a://127.0.0.1:8787/triage"
+allow_cleartext = true
+dedupe_key = "event.dedupe_key"
+retry = { max = 1, backoff = "immediate" }

--- a/examples/triggers/local-a2a-dispatch/lib.harn
+++ b/examples/triggers/local-a2a-dispatch/lib.harn
@@ -1,0 +1,21 @@
+import "std/triggers"
+
+/** Return deterministic issue triage output from normalized issue input. */
+pub fn triage_issue_payload(raw, trace_id, replay_of_event_id) -> dict {
+  let issue = raw.issue ?? raw
+  let title = issue.title ?? "untitled issue"
+  return {
+    status: "triaged",
+    labels: ["needs-owner"],
+    title: title,
+    trace_id: trace_id,
+    replay_of_event_id: replay_of_event_id,
+  }
+}
+
+/** Return deterministic issue triage output for local and A2A dispatch demos. */
+pub fn triage_issue(event: TriggerEvent) -> dict {
+  let raw = event.provider_payload.raw ?? {}
+  let context = handler_context()
+  return triage_issue_payload(raw, context?.trace_id ?? event.trace_id, context?.replay_of_event_id)
+}

--- a/examples/triggers/local-a2a-dispatch/remote-handler.harn
+++ b/examples/triggers/local-a2a-dispatch/remote-handler.harn
@@ -1,0 +1,11 @@
+import { triage_issue_payload } from "lib"
+
+pipeline default(task) {
+  let envelope = json_parse(task)
+  let raw = envelope.event.provider_payload?.raw ?? {}
+  println(
+    json_stringify(
+      triage_issue_payload(raw, envelope.event.trace_id, envelope.event.replay_of_event_id),
+    ),
+  )
+}

--- a/scripts/demo_local_a2a_dispatch.sh
+++ b/scripts/demo_local_a2a_dispatch.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+if [[ -z "${HARN_BIN:-}" ]]; then
+  TARGET_DIR="$(
+    cargo metadata --no-deps --format-version 1 |
+      python3 -c 'import json, sys; print(json.load(sys.stdin)["target_directory"])'
+  )"
+  HARN_BIN="$TARGET_DIR/debug/harn"
+fi
+
+if [[ ! -x "$HARN_BIN" ]]; then
+  cargo build --quiet --bin harn
+fi
+if [[ ! -x "$HARN_BIN" ]]; then
+  echo "Built harn binary was not found at $HARN_BIN" >&2
+  exit 1
+fi
+
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/harn-local-a2a-demo.XXXXXX")"
+LOG="$TMP_DIR/receiver.log"
+PID=""
+
+cleanup() {
+  if [[ -n "$PID" ]]; then
+    kill -TERM "$PID" >/dev/null 2>&1 || true
+    wait "$PID" >/dev/null 2>&1 || true
+  fi
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+"$HARN_BIN" serve --port 0 "$ROOT/examples/triggers/local-a2a-dispatch/remote-handler.harn" \
+  >"$LOG" 2>&1 &
+PID="$!"
+
+for _ in {1..400}; do
+  if ! kill -0 "$PID" >/dev/null 2>&1; then
+    echo "A2A receiver exited before it became ready" >&2
+    cat "$LOG" >&2
+    exit 1
+  fi
+  if grep -E 'Harn A2A server listening on ' "$LOG" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.05
+done
+
+URL="$(sed -nE 's/.*Harn A2A server listening on ([^[:space:]]+).*/\1/p' "$LOG" | tail -n 1)"
+if [[ -z "$URL" ]]; then
+  echo "A2A receiver did not start" >&2
+  cat "$LOG" >&2
+  exit 1
+fi
+PORT="${URL##*:}"
+
+HARN_DEMO_REMOTE_PORT="$PORT" \
+  "$HARN_BIN" run "$ROOT/examples/triggers/local-a2a-dispatch/demo.harn"


### PR DESCRIPTION
## Summary
- records trust boundary, execution location, and remote identity metadata for trigger dispatch across action graph, outbox, and trust records
- classifies A2A denied/timeout/rejected failure modes distinctly and adds focused failure tests
- adds the local/A2A dispatch example, demo script, docs, and replay-oracle fixture proving equivalent logical outputs

## Verification
- cargo check -p harn-vm --tests
- cargo test -p harn-vm a2a -- --nocapture
- cargo run --quiet --bin harn -- orchestrator replay-oracle conformance/replay-oracle/fixtures/local_a2a_dispatch_equivalence.valid.json
- scripts/demo_local_a2a_dispatch.sh
- cargo run --quiet --bin harn -- test conformance --filter orchestrator_a2a_dispatch_sync
- make check-docs-snippets
- pre-commit hooks: clippy workspace, markdown lint
- pre-push hooks: targeted local checks, affected Harn fmt/lint, markdown lint

Closes #1586