### PR TITLE
[codex] Add rule-based approval policy DSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,11 @@ defaults, safe, prompts, catalog).
 - Per-agent capability policies with argument-level constraints: `agent_loop`
   accepts a `policy` dict to scope tool permissions, including `tool_arg_constraints`
   for pattern-matching on tool arguments.
+- Rule-based approval policies: `approval_policy.rules` expresses allow/ask/deny
+  over tool names/kinds, side-effect levels, declared paths, command identity,
+  URLs/domains/methods, MCP identity, agent/persona/mode, and repeat counts,
+  with deny-by-default sensitive path guards and replayable policy-decision
+  receipts in permission events and host approval prompts.
 - Dynamic per-agent permissions: `agent_loop`, `sub_agent_run`, and
   `spawn_agent` accept `permissions` with `allow` / `deny` tool rules, VM
   predicates over the tool args, and `on_escalation` callbacks that can grant a

--- a/conformance/tests/integration/approval_policy_rules.expected
+++ b/conformance/tests/integration/approval_policy_rules.expected
@@ -1,0 +1,12 @@
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true

--- a/conformance/tests/integration/approval_policy_rules.harn
+++ b/conformance/tests/integration/approval_policy_rules.harn
@@ -1,0 +1,137 @@
+fn policy_tools() {
+  var tools = tool_registry()
+  tools = tool_define(
+    tools,
+    "read_secret",
+    "Read a file",
+    {
+      handler: { args -> "read " + args.path },
+      parameters: {path: {type: "string"}},
+      returns: {type: "string"},
+    },
+  )
+  tools = tool_define(
+    tools,
+    "fetch_url",
+    "Fetch a URL",
+    {
+      handler: { args -> "fetched " + args.url },
+      parameters: {url: {type: "string"}, method: {type: "string"}},
+      returns: {type: "string"},
+    },
+  )
+  tools = tool_define(
+    tools,
+    "run_command",
+    "Run a command",
+    {
+      handler: { args -> "ran " + args.argv[0] },
+      parameters: {argv: {type: "array"}},
+      returns: {type: "string"},
+    },
+  )
+  tools = tool_define(
+    tools,
+    "github__create_issue",
+    "Create a GitHub issue",
+    {
+      handler: { args -> "created " + args.title },
+      parameters: {title: {type: "string"}},
+      returns: {type: "string"},
+    },
+  )
+  return tools
+}
+
+fn capability_policy() {
+  return {
+    tools: ["read_secret", "fetch_url", "run_command", "github__create_issue"],
+    tool_annotations: {
+      read_secret: {kind: "read", side_effect_level: "read_only", arg_schema: {path_params: ["path"]}},
+      fetch_url: {kind: "fetch", side_effect_level: "network"},
+      run_command: {kind: "execute", side_effect_level: "process_exec"},
+      github__create_issue: {kind: "edit", side_effect_level: "network"},
+    },
+  }
+}
+
+fn one_call(name, args, approval_policy) {
+  llm_mock({tool_calls: [{id: "call_1", name: name, arguments: args}]})
+  return agent_loop(
+    "Use the requested tool.",
+    "Use tools.",
+    {
+      provider: "mock",
+      tools: policy_tools(),
+      tool_format: "native",
+      max_iterations: 1,
+      policy: capability_policy(),
+      approval_policy: approval_policy,
+    },
+  )
+}
+
+pipeline main() {
+  let secret = one_call("read_secret", {path: "config/.env"}, {rules: [{allow: "*"}]})
+  let secret_events = json_stringify(transcript_events_by_kind(secret?.transcript, "PermissionDeny"))
+  println(secret?.tools?.rejected[0] == "read_secret")
+  println(secret_events.contains("sensitive_path"))
+  println(secret_events.contains("harn.permission_policy_decision.v1"))
+  let ask = one_call(
+    "fetch_url",
+    {url: "https://api.example.com/v1/issues", method: "post"},
+    {
+      rules: [
+        {
+          ask: {tool: "fetch_url", domain: "*.example.com", method: "POST"},
+          reason: "managed network approval",
+        },
+      ],
+    },
+  )
+  let ask_events = json_stringify(transcript_events_by_kind(ask?.transcript, "PermissionDeny"))
+  println(ask?.tools?.rejected[0] == "fetch_url")
+  println(ask_events.contains("managed network approval"))
+  println(ask_events.contains("\"action\":\"ask\""))
+  let allowed = one_call(
+    "run_command",
+    {argv: ["npm", "test"]},
+    {allow_sensitive_paths: true, rules: [{allow: {tool: "run_command", command_identity: "npm"}}]},
+  )
+  let grant_events = json_stringify(transcript_events_by_kind(allowed?.transcript, "PermissionGrant"))
+  println(len(allowed?.tools?.rejected) == 0)
+  println(grant_events.contains("command_rule"))
+  let mcp = one_call(
+    "github__create_issue",
+    {title: "blocked"},
+    {
+      rules: [{deny: {mcp_server: "github", mcp_tool: "create_issue"}, reason: "MCP issue creation blocked"}],
+    },
+  )
+  let mcp_events = json_stringify(transcript_events_by_kind(mcp?.transcript, "PermissionDeny"))
+  println(mcp?.tools?.rejected[0] == "github__create_issue")
+  println(mcp_events.contains("mcp_rule"))
+  llm_mock(
+    {
+      tool_calls: [
+        {id: "repeat_1", name: "run_command", arguments: {argv: ["echo", "ok"]}},
+        {id: "repeat_2", name: "run_command", arguments: {argv: ["echo", "ok"]}},
+      ],
+    },
+  )
+  let repeated = agent_loop(
+    "Run twice.",
+    "Use tools.",
+    {
+      provider: "mock",
+      tools: policy_tools(),
+      tool_format: "native",
+      max_iterations: 1,
+      policy: capability_policy(),
+      approval_policy: {allow_sensitive_paths: true, repeat_limit: 1, repeat_action: "deny"},
+    },
+  )
+  let repeat_events = json_stringify(transcript_events_by_kind(repeated?.transcript, "PermissionDeny"))
+  println(repeated?.tools?.rejected[0] == "run_command")
+  println(repeat_events.contains("repeated_call"))
+}

--- a/crates/harn-vm/src/llm/agent_session_host.rs
+++ b/crates/harn-vm/src/llm/agent_session_host.rs
@@ -390,6 +390,7 @@ async fn host_agent_session_finalize(args: Vec<VmValue>) -> Result<VmValue, VmEr
             ))
         })?;
     permissions::clear_session_grants(&session_id);
+    crate::orchestration::clear_approval_policy_repeat_counts(&session_id);
     if session.pushed_transcript_dir {
         super::agent_observe::pop_llm_transcript_dir();
     }

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -518,6 +518,7 @@ pub fn reset_llm_state() {
     autonomy_budget::reset_autonomy_budget_state();
     agent_session_host::reset_agent_session_host_state();
     permissions::clear_dynamic_permission_state();
+    crate::orchestration::clear_all_approval_policy_repeat_counts();
     trigger_predicate::reset_trigger_predicate_state();
     capabilities::clear_user_overrides();
     // Per-`@step` registry, active stack, and completed-step log are
@@ -1120,11 +1121,35 @@ fn emit_permission_event(
     reason: &str,
     escalated: bool,
 ) {
+    emit_permission_event_with_policy(
+        session_id, kind, tool_name, tool_args, reason, escalated, None,
+    );
+}
+
+fn emit_permission_event_with_policy(
+    session_id: &str,
+    kind: &str,
+    tool_name: &str,
+    tool_args: &serde_json::Value,
+    reason: &str,
+    escalated: bool,
+    policy_decision: Option<serde_json::Value>,
+) {
     if !crate::agent_sessions::exists(session_id) {
         return;
     }
-    let event =
-        permissions::permission_transcript_event(kind, tool_name, tool_args, reason, escalated);
+    let event = if let Some(policy_decision) = policy_decision {
+        permissions::permission_transcript_event_with_policy(
+            kind,
+            tool_name,
+            tool_args,
+            reason,
+            escalated,
+            Some(policy_decision),
+        )
+    } else {
+        permissions::permission_transcript_event(kind, tool_name, tool_args, reason, escalated)
+    };
     let _ = crate::agent_sessions::append_event(session_id, event);
 }
 
@@ -1395,38 +1420,57 @@ async fn host_agent_dispatch_tool_call(
         }
     }
 
-    let approval = crate::orchestration::current_approval_policy()
-        .map(|policy| policy.evaluate(&tool_name, &tool_args));
+    let approval = crate::orchestration::current_approval_policy().map(|policy| {
+        let repeat_count = crate::orchestration::next_approval_policy_repeat_count(
+            &session_id,
+            &tool_name,
+            &tool_args,
+        );
+        policy.evaluate_detailed_with_repeat(&tool_name, &tool_args, repeat_count)
+    });
     let mut approval_status = None;
     match approval {
-        None | Some(crate::orchestration::ToolApprovalDecision::AutoApproved) => {}
-        Some(crate::orchestration::ToolApprovalDecision::AutoDenied { reason }) => {
-            emit_permission_event(
+        None => {}
+        Some(decision) if decision.is_allow() && decision.has_audit_signal() => {
+            emit_permission_event_with_policy(
+                &session_id,
+                "PermissionGrant",
+                &tool_name,
+                &tool_args,
+                &decision.reason,
+                false,
+                Some(decision.receipt.clone()),
+            );
+        }
+        Some(decision) if decision.is_deny() => {
+            emit_permission_event_with_policy(
                 &session_id,
                 "PermissionDeny",
                 &tool_name,
                 &tool_args,
-                &reason,
+                &decision.reason,
                 false,
+                Some(decision.receipt.clone()),
             );
             return Ok(json_to_vm_value(&agent_primitive_denied_tool(
                 &tool_name,
                 &tool_id,
                 &tool_args,
-                reason,
+                decision.reason,
                 crate::agent_events::ToolCallErrorCategory::PermissionDenied,
             )));
         }
-        Some(crate::orchestration::ToolApprovalDecision::RequiresHostApproval) => {
+        Some(decision) if decision.is_ask() => {
             let Some(bridge) = bridge.as_ref() else {
                 let reason = "approval required but no host bridge is available";
-                emit_permission_event(
+                emit_permission_event_with_policy(
                     &session_id,
                     "PermissionDeny",
                     &tool_name,
                     &tool_args,
                     reason,
                     false,
+                    Some(decision.receipt.clone()),
                 );
                 return Ok(json_to_vm_value(&agent_primitive_denied_tool(
                     &tool_name,
@@ -1447,7 +1491,7 @@ async fn host_agent_dispatch_tool_call(
                 tool_args.clone(),
                 session_id.clone(),
                 Vec::new(),
-                serde_json::Value::Null,
+                serde_json::json!({"policy_decision": decision.receipt.clone()}),
                 vec![format!("tool.{tool_name}")],
             );
             let response = bridge
@@ -1456,6 +1500,7 @@ async fn host_agent_dispatch_tool_call(
                     serde_json::json!({
                         "sessionId": session_id,
                         "approvalRequest": approval_request,
+                        "policyDecision": decision.receipt.clone(),
                         "toolCall": {
                             "toolCallId": approval_id,
                             "toolName": tool_name,
@@ -1482,26 +1527,28 @@ async fn host_agent_dispatch_tool_call(
                             tool_args = new_args.clone();
                         }
                         approval_status = Some("host_granted");
-                        emit_permission_event(
+                        emit_permission_event_with_policy(
                             &session_id,
                             "PermissionGrant",
                             &tool_name,
                             &tool_args,
                             "host approved tool call",
                             true,
+                            Some(decision.receipt.clone()),
                         );
                     } else {
                         let reason = response
                             .get("reason")
                             .and_then(|value| value.as_str())
                             .unwrap_or("host did not grant approval");
-                        emit_permission_event(
+                        emit_permission_event_with_policy(
                             &session_id,
                             "PermissionDeny",
                             &tool_name,
                             &tool_args,
                             reason,
                             true,
+                            Some(decision.receipt.clone()),
                         );
                         return Ok(json_to_vm_value(&agent_primitive_denied_tool(
                             &tool_name,
@@ -1515,13 +1562,14 @@ async fn host_agent_dispatch_tool_call(
                 Err(_) => {
                     let reason =
                         "approval request failed or host does not implement session/request_permission";
-                    emit_permission_event(
+                    emit_permission_event_with_policy(
                         &session_id,
                         "PermissionDeny",
                         &tool_name,
                         &tool_args,
                         reason,
                         true,
+                        Some(decision.receipt.clone()),
                     );
                     return Ok(json_to_vm_value(&agent_primitive_denied_tool(
                         &tool_name,
@@ -1533,6 +1581,7 @@ async fn host_agent_dispatch_tool_call(
                 }
             }
         }
+        Some(_) => {}
     }
 
     match crate::orchestration::run_pre_tool_hooks(&tool_name, &tool_args).await? {

--- a/crates/harn-vm/src/llm/permissions.rs
+++ b/crates/harn-vm/src/llm/permissions.rs
@@ -46,18 +46,27 @@ pub(crate) fn permission_transcript_event(
     reason: &str,
     escalated: bool,
 ) -> VmValue {
-    crate::llm::helpers::transcript_event(
-        kind,
-        "tool",
-        "internal",
-        reason,
-        Some(serde_json::json!({
-            "tool_name": tool_name,
-            "arguments": args,
-            "reason": reason,
-            "escalated": escalated,
-        })),
-    )
+    permission_transcript_event_with_policy(kind, tool_name, args, reason, escalated, None)
+}
+
+pub(crate) fn permission_transcript_event_with_policy(
+    kind: &str,
+    tool_name: &str,
+    args: &serde_json::Value,
+    reason: &str,
+    escalated: bool,
+    policy_decision: Option<serde_json::Value>,
+) -> VmValue {
+    let mut metadata = serde_json::json!({
+        "tool_name": tool_name,
+        "arguments": args,
+        "reason": reason,
+        "escalated": escalated,
+    });
+    if let Some(policy_decision) = policy_decision {
+        metadata["policy_decision"] = policy_decision;
+    }
+    crate::llm::helpers::transcript_event(kind, "tool", "internal", reason, Some(metadata))
 }
 
 thread_local! {

--- a/crates/harn-vm/src/orchestration/hooks.rs
+++ b/crates/harn-vm/src/orchestration/hooks.rs
@@ -230,6 +230,13 @@ pub(crate) fn glob_match(pattern: &str, name: &str) -> bool {
     if pattern == "*" {
         return true;
     }
+    if pattern.contains('*') || pattern.contains('?') || pattern.contains('[') {
+        if let Ok(glob) = globset::Glob::new(pattern) {
+            if glob.compile_matcher().is_match(name) {
+                return true;
+            }
+        }
+    }
     if let Some(prefix) = pattern.strip_suffix('*') {
         return name.starts_with(prefix);
     }

--- a/crates/harn-vm/src/orchestration/policy/approval_rules.rs
+++ b/crates/harn-vm/src/orchestration/policy/approval_rules.rs
@@ -1,0 +1,1412 @@
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::thread_local;
+
+use serde::de::{Error as DeError, MapAccess, Visitor};
+use serde::{Deserialize, Deserializer, Serialize};
+use serde_json::Value as JsonValue;
+use sha2::{Digest, Sha256};
+
+use crate::workspace_path::{WorkspacePathInfo, WorkspacePathKind};
+
+use super::ToolApprovalPolicy;
+
+const POLICY_RECEIPT_TYPE: &str = "harn.permission_policy_decision.v1";
+
+thread_local! {
+    static APPROVAL_CALL_COUNTS: RefCell<BTreeMap<String, u64>> = const { RefCell::new(BTreeMap::new()) };
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PolicyAction {
+    Allow,
+    Ask,
+    Deny,
+}
+
+impl PolicyAction {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Allow => "allow",
+            Self::Ask => "ask",
+            Self::Deny => "deny",
+        }
+    }
+
+    fn rank(self) -> u8 {
+        match self {
+            Self::Allow => 0,
+            Self::Ask => 1,
+            Self::Deny => 2,
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for PolicyAction {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        parse_policy_action(&value).ok_or_else(|| {
+            D::Error::custom(format!(
+                "unsupported policy action {value:?}; expected allow, ask, require_approval, or deny"
+            ))
+        })
+    }
+}
+
+fn parse_policy_action(value: &str) -> Option<PolicyAction> {
+    match value {
+        "allow" | "approve" | "auto_approve" => Some(PolicyAction::Allow),
+        "ask" | "approval" | "require_approval" | "requires_approval" => Some(PolicyAction::Ask),
+        "deny" | "block" | "auto_deny" => Some(PolicyAction::Deny),
+        _ => None,
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ApprovalShape {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub risk: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub reviewers: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub grant_options: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<JsonValue>,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct PolicyRuleMatch {
+    #[serde(
+        alias = "tools",
+        deserialize_with = "deserialize_string_list",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub tool: Vec<String>,
+    #[serde(
+        alias = "tool_kinds",
+        deserialize_with = "deserialize_string_list",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub tool_kind: Vec<String>,
+    #[serde(
+        alias = "side_effect_level",
+        alias = "side_effect_levels",
+        deserialize_with = "deserialize_string_list",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub side_effect: Vec<String>,
+    #[serde(
+        alias = "paths",
+        deserialize_with = "deserialize_string_list",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub path: Vec<String>,
+    #[serde(
+        alias = "commands",
+        deserialize_with = "deserialize_string_list",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub command: Vec<String>,
+    #[serde(
+        alias = "command_identities",
+        deserialize_with = "deserialize_string_list",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub command_identity: Vec<String>,
+    #[serde(
+        alias = "urls",
+        deserialize_with = "deserialize_string_list",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub url: Vec<String>,
+    #[serde(
+        alias = "domains",
+        deserialize_with = "deserialize_string_list",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub domain: Vec<String>,
+    #[serde(
+        alias = "method",
+        alias = "methods",
+        alias = "http_methods",
+        deserialize_with = "deserialize_string_list",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub http_method: Vec<String>,
+    #[serde(
+        alias = "mcp_servers",
+        deserialize_with = "deserialize_string_list",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub mcp_server: Vec<String>,
+    #[serde(
+        alias = "mcp_tools",
+        deserialize_with = "deserialize_string_list",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub mcp_tool: Vec<String>,
+    #[serde(
+        alias = "agents",
+        deserialize_with = "deserialize_string_list",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub agent: Vec<String>,
+    #[serde(
+        alias = "personas",
+        deserialize_with = "deserialize_string_list",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub persona: Vec<String>,
+    #[serde(
+        alias = "modes",
+        deserialize_with = "deserialize_string_list",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub mode: Vec<String>,
+    #[serde(
+        alias = "capabilities",
+        deserialize_with = "deserialize_string_list",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub capability: Vec<String>,
+    #[serde(alias = "repeat_count_gte", alias = "repeat_at_least")]
+    pub repeat_count_at_least: Option<u64>,
+}
+
+impl PolicyRuleMatch {
+    fn from_shorthand(value: JsonValue) -> Result<Self, String> {
+        match value {
+            JsonValue::Null | JsonValue::Bool(true) => Ok(Self::default()),
+            JsonValue::String(pattern) => Ok(Self {
+                tool: vec![pattern],
+                ..Default::default()
+            }),
+            JsonValue::Array(items) => {
+                let mut tool = Vec::new();
+                for item in items {
+                    let Some(pattern) = item.as_str() else {
+                        return Err(format!(
+                            "policy rule shorthand list entries must be strings, got {item}"
+                        ));
+                    };
+                    tool.push(pattern.to_string());
+                }
+                Ok(Self {
+                    tool,
+                    ..Default::default()
+                })
+            }
+            JsonValue::Object(_) => {
+                serde_json::from_value(value).map_err(|error| error.to_string())
+            }
+            other => Err(format!(
+                "policy rule matcher must be a string, list, or dict, got {other}"
+            )),
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.tool.is_empty()
+            && self.tool_kind.is_empty()
+            && self.side_effect.is_empty()
+            && self.path.is_empty()
+            && self.command.is_empty()
+            && self.command_identity.is_empty()
+            && self.url.is_empty()
+            && self.domain.is_empty()
+            && self.http_method.is_empty()
+            && self.mcp_server.is_empty()
+            && self.mcp_tool.is_empty()
+            && self.agent.is_empty()
+            && self.persona.is_empty()
+            && self.mode.is_empty()
+            && self.capability.is_empty()
+            && self.repeat_count_at_least.is_none()
+    }
+
+    fn matches(&self, ctx: &EvaluationContext) -> bool {
+        (self.tool.is_empty() || any_glob_matches(&self.tool, &[ctx.tool_name.clone()]))
+            && (self.tool_kind.is_empty() || any_glob_matches(&self.tool_kind, &ctx.tool_kinds()))
+            && (self.side_effect.is_empty()
+                || any_glob_matches(&self.side_effect, &ctx.side_effects()))
+            && (self.path.is_empty() || any_glob_matches(&self.path, &ctx.path_candidates))
+            && (self.command.is_empty()
+                || any_fragment_matches(&self.command, &ctx.command_candidates))
+            && (self.command_identity.is_empty()
+                || any_glob_matches(&self.command_identity, &ctx.command_identities))
+            && (self.url.is_empty() || any_fragment_matches(&self.url, &ctx.urls))
+            && (self.domain.is_empty() || any_glob_matches(&self.domain, &ctx.domains))
+            && (self.http_method.is_empty()
+                || any_glob_matches(
+                    &normalize_patterns_upper(&self.http_method),
+                    &ctx.http_methods,
+                ))
+            && (self.mcp_server.is_empty() || any_glob_matches(&self.mcp_server, &ctx.mcp_servers))
+            && (self.mcp_tool.is_empty() || any_glob_matches(&self.mcp_tool, &ctx.mcp_tools))
+            && (self.agent.is_empty()
+                || ctx.agent.as_ref().is_some_and(|agent| {
+                    any_glob_matches(&self.agent, std::slice::from_ref(agent))
+                }))
+            && (self.persona.is_empty()
+                || ctx.persona.as_ref().is_some_and(|persona| {
+                    any_glob_matches(&self.persona, std::slice::from_ref(persona))
+                }))
+            && (self.mode.is_empty()
+                || ctx
+                    .mode
+                    .as_ref()
+                    .is_some_and(|mode| any_glob_matches(&self.mode, std::slice::from_ref(mode))))
+            && (self.capability.is_empty() || any_glob_matches(&self.capability, &ctx.capabilities))
+            && self
+                .repeat_count_at_least
+                .map(|threshold| ctx.repeat_count.unwrap_or(0) >= threshold)
+                .unwrap_or(true)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct PolicyRule {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    pub action: PolicyAction,
+    #[serde(rename = "match")]
+    pub matches: PolicyRuleMatch,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    #[serde(default, skip_serializing_if = "ApprovalShape::is_empty")]
+    pub approval: ApprovalShape,
+}
+
+impl ApprovalShape {
+    fn is_empty(&self) -> bool {
+        self.prompt.is_none()
+            && self.risk.is_none()
+            && self.reviewers.is_empty()
+            && self.grant_options.is_empty()
+            && self.metadata.is_none()
+    }
+}
+
+impl<'de> Deserialize<'de> for PolicyRule {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_map(PolicyRuleVisitor)
+    }
+}
+
+struct PolicyRuleVisitor;
+
+impl<'de> Visitor<'de> for PolicyRuleVisitor {
+    type Value = PolicyRule;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("a policy rule object")
+    }
+
+    fn visit_map<M>(self, mut map: M) -> Result<Self::Value, M::Error>
+    where
+        M: MapAccess<'de>,
+    {
+        let mut raw = serde_json::Map::new();
+        while let Some((key, value)) = map.next_entry::<String, JsonValue>()? {
+            raw.insert(key, value);
+        }
+
+        let id = raw
+            .remove("id")
+            .or_else(|| raw.remove("name"))
+            .and_then(|value| value.as_str().map(ToOwned::to_owned));
+        let reason = raw
+            .remove("reason")
+            .and_then(|value| value.as_str().map(ToOwned::to_owned));
+        let approval = raw
+            .remove("approval")
+            .map(serde_json::from_value)
+            .transpose()
+            .map_err(M::Error::custom)?
+            .unwrap_or_default();
+
+        let mut action = match raw.remove("action") {
+            Some(JsonValue::String(value)) => Some(parse_policy_action(&value).ok_or_else(|| {
+                M::Error::custom(format!(
+                    "unsupported policy action {value:?}; expected allow, ask, require_approval, or deny"
+                ))
+            })?),
+            Some(other) => {
+                return Err(M::Error::custom(format!(
+                    "policy rule action must be a string, got {other}"
+                )));
+            }
+            None => None,
+        };
+        let mut matcher_value = raw
+            .remove("match")
+            .or_else(|| raw.remove("matches"))
+            .or_else(|| raw.remove("when"));
+
+        for (key, candidate_action) in [
+            ("deny", PolicyAction::Deny),
+            ("ask", PolicyAction::Ask),
+            ("require_approval", PolicyAction::Ask),
+            ("allow", PolicyAction::Allow),
+        ] {
+            if let Some(value) = raw.remove(key) {
+                if action.is_some() {
+                    return Err(M::Error::custom(
+                        "policy rule must not mix action with allow/ask/deny shorthand",
+                    ));
+                }
+                action = Some(candidate_action);
+                matcher_value = Some(value);
+            }
+        }
+
+        if matcher_value.is_none() && !raw.is_empty() {
+            matcher_value = Some(JsonValue::Object(raw));
+        } else if matcher_value.is_some() && !raw.is_empty() {
+            let mut fields = raw.keys().cloned().collect::<Vec<_>>();
+            fields.sort();
+            return Err(M::Error::custom(format!(
+                "policy rule has matcher fields outside match/allow/ask/deny: {}",
+                fields.join(", ")
+            )));
+        }
+
+        let action = action.ok_or_else(|| {
+            M::Error::custom("policy rule must include action or allow/ask/deny shorthand")
+        })?;
+        let matches = PolicyRuleMatch::from_shorthand(matcher_value.unwrap_or(JsonValue::Null))
+            .map_err(M::Error::custom)?;
+        Ok(PolicyRule {
+            id,
+            action,
+            matches,
+            reason,
+            approval,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct PolicyMatchedRule {
+    pub source: String,
+    pub action: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub index: Option<usize>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct PolicyEvaluation {
+    pub action: String,
+    pub reason: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub matched_rule: Option<PolicyMatchedRule>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub required_approval: Option<ApprovalShape>,
+    #[serde(default)]
+    pub risk_labels: Vec<String>,
+    pub receipt: JsonValue,
+}
+
+impl PolicyEvaluation {
+    pub fn is_allow(&self) -> bool {
+        self.action == PolicyAction::Allow.as_str()
+    }
+
+    pub fn is_ask(&self) -> bool {
+        self.action == PolicyAction::Ask.as_str()
+    }
+
+    pub fn is_deny(&self) -> bool {
+        self.action == PolicyAction::Deny.as_str()
+    }
+
+    pub fn has_audit_signal(&self) -> bool {
+        self.matched_rule.is_some() || !self.risk_labels.is_empty()
+    }
+}
+
+#[derive(Clone, Debug)]
+struct EvaluationContext {
+    tool_name: String,
+    tool_kind: Option<String>,
+    side_effect: Option<String>,
+    capabilities: Vec<String>,
+    path_entries: Vec<WorkspacePathInfo>,
+    path_candidates: Vec<String>,
+    string_candidates: Vec<String>,
+    command_candidates: Vec<String>,
+    command_identities: Vec<String>,
+    urls: Vec<String>,
+    domains: Vec<String>,
+    http_methods: Vec<String>,
+    mcp_servers: Vec<String>,
+    mcp_tools: Vec<String>,
+    agent: Option<String>,
+    persona: Option<String>,
+    mode: Option<String>,
+    repeat_count: Option<u64>,
+}
+
+impl EvaluationContext {
+    fn new(tool_name: &str, args: &JsonValue, repeat_count: Option<u64>) -> Self {
+        let annotations = super::current_tool_annotations(tool_name);
+        let path_entries = super::current_tool_declared_path_entries(tool_name, args);
+        let mut path_candidates = Vec::new();
+        for entry in &path_entries {
+            path_candidates.extend(entry.policy_candidates());
+        }
+        dedup(&mut path_candidates);
+
+        let mut string_candidates = Vec::new();
+        collect_string_values(args, &mut string_candidates);
+        dedup(&mut string_candidates);
+
+        let (command_candidates, command_identities) = command_candidates(args);
+        let (urls, domains) = url_candidates(&string_candidates);
+        let http_methods = http_method_candidates(args);
+        let (mcp_servers, mcp_tools) = mcp_candidates(tool_name, args);
+        let dispatch = crate::triggers::dispatcher::current_dispatch_context();
+        let agent = string_field(args, "agent")
+            .or_else(|| string_field(args, "agent_id"))
+            .or_else(|| dispatch.as_ref().map(|context| context.agent_id.clone()));
+        let persona = string_field(args, "persona").or_else(|| string_field(args, "persona_id"));
+        let mode = string_field(args, "mode")
+            .or_else(|| string_field(args, "action"))
+            .or_else(|| dispatch.as_ref().map(|context| context.action.clone()));
+        let capabilities = annotations
+            .as_ref()
+            .map(|annotations| {
+                annotations
+                    .capabilities
+                    .iter()
+                    .flat_map(|(capability, ops)| {
+                        ops.iter()
+                            .map(|op| format!("{capability}.{op}"))
+                            .collect::<Vec<_>>()
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+
+        Self {
+            tool_name: tool_name.to_string(),
+            tool_kind: annotations
+                .as_ref()
+                .map(|annotations| tool_kind_string(annotations.kind).to_string()),
+            side_effect: annotations
+                .as_ref()
+                .map(|annotations| annotations.side_effect_level.as_str().to_string()),
+            capabilities,
+            path_entries,
+            path_candidates,
+            string_candidates,
+            command_candidates,
+            command_identities,
+            urls,
+            domains,
+            http_methods,
+            mcp_servers,
+            mcp_tools,
+            agent,
+            persona,
+            mode,
+            repeat_count,
+        }
+    }
+
+    fn tool_kinds(&self) -> Vec<String> {
+        self.tool_kind.iter().cloned().collect()
+    }
+
+    fn side_effects(&self) -> Vec<String> {
+        self.side_effect.iter().cloned().collect()
+    }
+
+    fn receipt_context(&self) -> JsonValue {
+        serde_json::json!({
+            "tool_name": self.tool_name,
+            "tool_kind": self.tool_kind,
+            "side_effect": self.side_effect,
+            "capabilities": self.capabilities,
+            "paths": self.path_entries.iter().map(path_entry_json).collect::<Vec<_>>(),
+            "command_identities": self.command_identities,
+            "urls": self.urls,
+            "domains": self.domains,
+            "http_methods": self.http_methods,
+            "mcp_servers": self.mcp_servers,
+            "mcp_tools": self.mcp_tools,
+            "agent": self.agent,
+            "persona": self.persona,
+            "mode": self.mode,
+            "repeat_count": self.repeat_count,
+        })
+    }
+}
+
+struct Candidate {
+    source: String,
+    index: Option<usize>,
+    id: Option<String>,
+    action: PolicyAction,
+    reason: String,
+    approval: ApprovalShape,
+    risk_labels: Vec<String>,
+}
+
+impl Candidate {
+    fn matched_rule(&self) -> PolicyMatchedRule {
+        PolicyMatchedRule {
+            source: self.source.clone(),
+            action: self.action.as_str().to_string(),
+            id: self.id.clone(),
+            index: self.index,
+        }
+    }
+}
+
+pub fn next_approval_policy_repeat_count(
+    session_id: &str,
+    tool_name: &str,
+    args: &JsonValue,
+) -> u64 {
+    let key = format!("{session_id}:{tool_name}:{}", stable_json_digest(args));
+    APPROVAL_CALL_COUNTS.with(|counts| {
+        let mut counts = counts.borrow_mut();
+        let count = counts.entry(key).or_insert(0);
+        *count += 1;
+        *count
+    })
+}
+
+pub fn clear_approval_policy_repeat_counts(session_id: &str) {
+    let prefix = format!("{session_id}:");
+    APPROVAL_CALL_COUNTS.with(|counts| {
+        counts
+            .borrow_mut()
+            .retain(|key, _| !key.starts_with(prefix.as_str()));
+    });
+}
+
+pub fn clear_all_approval_policy_repeat_counts() {
+    APPROVAL_CALL_COUNTS.with(|counts| counts.borrow_mut().clear());
+}
+
+pub fn evaluate_tool_approval_policy(
+    policy: &ToolApprovalPolicy,
+    tool_name: &str,
+    args: &JsonValue,
+    repeat_count: Option<u64>,
+) -> PolicyEvaluation {
+    let ctx = EvaluationContext::new(tool_name, args, repeat_count);
+    if let Some(default) = default_guard(policy, &ctx) {
+        return evaluation_from_candidate(default, &ctx);
+    }
+
+    let mut candidates = Vec::new();
+    candidates.extend(legacy_candidates(policy, &ctx));
+    candidates.extend(rule_candidates(policy, &ctx));
+    if let Some(repeat_limit) = policy.repeat_limit {
+        if ctx.repeat_count.is_some_and(|count| count > repeat_limit) {
+            let action = policy.repeat_action.unwrap_or(PolicyAction::Ask);
+            candidates.push(Candidate {
+                source: "repeat_limit".to_string(),
+                index: None,
+                id: Some("repeat_limit".to_string()),
+                action,
+                reason: format!(
+                    "tool '{}' repeated more than {repeat_limit} time(s) with the same arguments",
+                    ctx.tool_name
+                ),
+                approval: ApprovalShape::default(),
+                risk_labels: vec!["repeated_call".to_string()],
+            });
+        }
+    }
+
+    if let Some(candidate) = strongest_candidate(candidates) {
+        return evaluation_from_candidate(candidate, &ctx);
+    }
+
+    default_allow(&ctx)
+}
+
+fn default_guard(policy: &ToolApprovalPolicy, ctx: &EvaluationContext) -> Option<Candidate> {
+    if !policy.allow_sensitive_paths {
+        if let Some(path) = first_sensitive_candidate(policy, ctx) {
+            return Some(Candidate {
+                source: "default_sensitive_path".to_string(),
+                index: None,
+                id: Some("sensitive_path".to_string()),
+                action: PolicyAction::Deny,
+                reason: format!("path '{path}' is denied by the sensitive-path default"),
+                approval: ApprovalShape::default(),
+                risk_labels: vec!["sensitive_path".to_string()],
+            });
+        }
+    }
+
+    if !policy.allow_external_paths {
+        for entry in &ctx.path_entries {
+            if matches!(entry.kind, WorkspacePathKind::Invalid) {
+                return Some(Candidate {
+                    source: "default_path_guard".to_string(),
+                    index: None,
+                    id: Some("invalid_path".to_string()),
+                    action: PolicyAction::Deny,
+                    reason: entry
+                        .reason
+                        .clone()
+                        .unwrap_or_else(|| format!("path '{}' is invalid", entry.display_path())),
+                    approval: ApprovalShape::default(),
+                    risk_labels: vec!["invalid_path".to_string()],
+                });
+            }
+            if entry.workspace_path.is_none()
+                && entry
+                    .host_path
+                    .as_ref()
+                    .is_some_and(|path| !under_external_root(path, &policy.external_roots))
+            {
+                return Some(Candidate {
+                    source: "default_external_path".to_string(),
+                    index: None,
+                    id: Some("external_path".to_string()),
+                    action: PolicyAction::Deny,
+                    reason: format!(
+                        "path '{}' is outside the workspace and no external root allows it",
+                        entry.display_path()
+                    ),
+                    approval: ApprovalShape::default(),
+                    risk_labels: vec!["external_path".to_string()],
+                });
+            }
+        }
+    }
+
+    None
+}
+
+fn legacy_candidates(policy: &ToolApprovalPolicy, ctx: &EvaluationContext) -> Vec<Candidate> {
+    let mut candidates = Vec::new();
+    for (index, pattern) in policy.auto_deny.iter().enumerate() {
+        if super::super::glob_match(pattern, &ctx.tool_name) {
+            candidates.push(Candidate {
+                source: "auto_deny".to_string(),
+                index: Some(index),
+                id: Some(pattern.clone()),
+                action: PolicyAction::Deny,
+                reason: format!("tool '{}' matches deny pattern '{pattern}'", ctx.tool_name),
+                approval: ApprovalShape::default(),
+                risk_labels: vec!["matched_deny_rule".to_string()],
+            });
+        }
+    }
+
+    if !policy.write_path_allowlist.is_empty()
+        && super::tool_kind_participates_in_write_allowlist(&ctx.tool_name)
+    {
+        for path in &ctx.path_entries {
+            let allowed = policy.write_path_allowlist.iter().any(|pattern| {
+                path.policy_candidates()
+                    .iter()
+                    .any(|candidate| super::super::glob_match(pattern, candidate))
+            });
+            if !allowed {
+                candidates.push(Candidate {
+                    source: "write_path_allowlist".to_string(),
+                    index: None,
+                    id: None,
+                    action: PolicyAction::Deny,
+                    reason: format!(
+                        "tool '{}' targets '{}' which is not in the write-path allowlist",
+                        ctx.tool_name,
+                        path.display_path()
+                    ),
+                    approval: ApprovalShape::default(),
+                    risk_labels: vec!["write_path_not_allowed".to_string()],
+                });
+            }
+        }
+    }
+
+    for (index, pattern) in policy.require_approval.iter().enumerate() {
+        if super::super::glob_match(pattern, &ctx.tool_name) {
+            candidates.push(Candidate {
+                source: "require_approval".to_string(),
+                index: Some(index),
+                id: Some(pattern.clone()),
+                action: PolicyAction::Ask,
+                reason: format!(
+                    "tool '{}' matches approval pattern '{pattern}'",
+                    ctx.tool_name
+                ),
+                approval: ApprovalShape::default(),
+                risk_labels: vec!["approval_required".to_string()],
+            });
+        }
+    }
+
+    for (index, pattern) in policy.auto_approve.iter().enumerate() {
+        if super::super::glob_match(pattern, &ctx.tool_name) {
+            candidates.push(Candidate {
+                source: "auto_approve".to_string(),
+                index: Some(index),
+                id: Some(pattern.clone()),
+                action: PolicyAction::Allow,
+                reason: format!("tool '{}' matches allow pattern '{pattern}'", ctx.tool_name),
+                approval: ApprovalShape::default(),
+                risk_labels: Vec::new(),
+            });
+        }
+    }
+    candidates
+}
+
+fn rule_candidates(policy: &ToolApprovalPolicy, ctx: &EvaluationContext) -> Vec<Candidate> {
+    policy
+        .rules
+        .iter()
+        .enumerate()
+        .filter(|(_, rule)| rule.matches.is_empty() || rule.matches.matches(ctx))
+        .map(|(index, rule)| Candidate {
+            source: "rules".to_string(),
+            index: Some(index),
+            id: rule.id.clone(),
+            action: rule.action,
+            reason: rule
+                .reason
+                .clone()
+                .or_else(|| rule.approval.risk.clone())
+                .unwrap_or_else(|| format!("tool '{}' matched policy rule", ctx.tool_name)),
+            approval: rule.approval.clone(),
+            risk_labels: risk_labels_for_rule(rule),
+        })
+        .collect()
+}
+
+fn strongest_candidate(candidates: Vec<Candidate>) -> Option<Candidate> {
+    let mut best: Option<Candidate> = None;
+    for candidate in candidates {
+        if best
+            .as_ref()
+            .map(|best| candidate.action.rank() > best.action.rank())
+            .unwrap_or(true)
+        {
+            best = Some(candidate);
+        }
+    }
+    best
+}
+
+fn evaluation_from_candidate(candidate: Candidate, ctx: &EvaluationContext) -> PolicyEvaluation {
+    let matched_rule = Some(candidate.matched_rule());
+    let required_approval = (candidate.action == PolicyAction::Ask).then_some(candidate.approval);
+    let mut risk_labels = candidate.risk_labels;
+    risk_labels.sort();
+    risk_labels.dedup();
+    let receipt = receipt_json(
+        candidate.action,
+        &candidate.reason,
+        matched_rule.as_ref(),
+        required_approval.as_ref(),
+        &risk_labels,
+        ctx,
+    );
+    PolicyEvaluation {
+        action: candidate.action.as_str().to_string(),
+        reason: candidate.reason,
+        matched_rule,
+        required_approval,
+        risk_labels,
+        receipt,
+    }
+}
+
+fn default_allow(ctx: &EvaluationContext) -> PolicyEvaluation {
+    let action = PolicyAction::Allow;
+    let reason = format!("tool '{}' approved by default", ctx.tool_name);
+    let receipt = receipt_json(action, &reason, None, None, &[], ctx);
+    PolicyEvaluation {
+        action: action.as_str().to_string(),
+        reason,
+        matched_rule: None,
+        required_approval: None,
+        risk_labels: Vec::new(),
+        receipt,
+    }
+}
+
+fn receipt_json(
+    action: PolicyAction,
+    reason: &str,
+    matched_rule: Option<&PolicyMatchedRule>,
+    approval: Option<&ApprovalShape>,
+    risk_labels: &[String],
+    ctx: &EvaluationContext,
+) -> JsonValue {
+    serde_json::json!({
+        "type": POLICY_RECEIPT_TYPE,
+        "action": action.as_str(),
+        "reason": reason,
+        "matched_rule": matched_rule,
+        "required_approval": approval,
+        "risk_labels": risk_labels,
+        "context": ctx.receipt_context(),
+    })
+}
+
+fn risk_labels_for_rule(rule: &PolicyRule) -> Vec<String> {
+    let mut labels = Vec::new();
+    if rule.action == PolicyAction::Ask {
+        labels.push("approval_required".to_string());
+    }
+    if rule.action == PolicyAction::Deny {
+        labels.push("matched_deny_rule".to_string());
+    }
+    if !rule.matches.path.is_empty() {
+        labels.push("path_rule".to_string());
+    }
+    if !rule.matches.command.is_empty() || !rule.matches.command_identity.is_empty() {
+        labels.push("command_rule".to_string());
+    }
+    if !rule.matches.url.is_empty()
+        || !rule.matches.domain.is_empty()
+        || !rule.matches.http_method.is_empty()
+    {
+        labels.push("network_rule".to_string());
+    }
+    if !rule.matches.mcp_server.is_empty() || !rule.matches.mcp_tool.is_empty() {
+        labels.push("mcp_rule".to_string());
+    }
+    if rule.matches.repeat_count_at_least.is_some() {
+        labels.push("repeated_call".to_string());
+    }
+    labels
+}
+
+fn first_sensitive_candidate(
+    policy: &ToolApprovalPolicy,
+    ctx: &EvaluationContext,
+) -> Option<String> {
+    let patterns = if policy.sensitive_path_patterns.is_empty() {
+        default_sensitive_path_patterns()
+    } else {
+        policy.sensitive_path_patterns.clone()
+    };
+    ctx.path_candidates
+        .iter()
+        .chain(ctx.string_candidates.iter())
+        .find(|candidate| is_sensitive_path_candidate(candidate, &patterns))
+        .cloned()
+}
+
+fn is_sensitive_path_candidate(candidate: &str, patterns: &[String]) -> bool {
+    let normalized = candidate.replace('\\', "/").to_ascii_lowercase();
+    let basename = normalized.rsplit('/').next().unwrap_or(normalized.as_str());
+    patterns.iter().any(|pattern| {
+        let pattern = pattern.to_ascii_lowercase();
+        super::super::glob_match(&pattern, &normalized)
+            || super::super::glob_match(&pattern, basename)
+            || glob_or_contains(&pattern, &normalized)
+    })
+}
+
+fn default_sensitive_path_patterns() -> Vec<String> {
+    [
+        ".env",
+        ".env.*",
+        "**/.env",
+        "**/.env.*",
+        "id_rsa",
+        "id_ed25519",
+        "**/.aws/credentials",
+        "**/.npmrc",
+        "**/.netrc",
+        "*.pem",
+        "*.key",
+    ]
+    .iter()
+    .map(|value| value.to_string())
+    .collect()
+}
+
+fn under_external_root(path: &str, roots: &[String]) -> bool {
+    if roots.is_empty() {
+        return false;
+    }
+    let path = normalize_path(Path::new(path));
+    roots
+        .iter()
+        .map(|root| normalize_path(Path::new(root)))
+        .any(|root| path.starts_with(root))
+}
+
+fn path_entry_json(entry: &WorkspacePathInfo) -> JsonValue {
+    serde_json::json!({
+        "input": entry.input,
+        "kind": entry.kind,
+        "normalized": entry.normalized,
+        "workspace_path": entry.workspace_path,
+        "host_path": entry.host_path,
+        "recovered_root_drift": entry.recovered_root_drift,
+        "reason": entry.reason,
+    })
+}
+
+fn command_candidates(args: &JsonValue) -> (Vec<String>, Vec<String>) {
+    let mut commands = Vec::new();
+    let mut identities = Vec::new();
+    if let Some(command) = string_field(args, "command").or_else(|| string_field(args, "cmd")) {
+        commands.push(collapse_whitespace(&command));
+        if let Some(identity) = shell_command_identity(&command) {
+            identities.push(identity);
+        }
+    }
+    if let Some(argv) = args.get("argv").and_then(|value| value.as_array()) {
+        let parts = argv
+            .iter()
+            .filter_map(|value| value.as_str().map(ToOwned::to_owned))
+            .collect::<Vec<_>>();
+        if !parts.is_empty() {
+            commands.push(parts.join(" "));
+            identities.push(parts[0].clone());
+        }
+    }
+    dedup(&mut commands);
+    dedup(&mut identities);
+    (commands, identities)
+}
+
+fn shell_command_identity(command: &str) -> Option<String> {
+    command
+        .split_whitespace()
+        .next()
+        .map(|part| part.trim_matches(|c| matches!(c, '"' | '\'')))
+        .filter(|part| !part.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn url_candidates(strings: &[String]) -> (Vec<String>, Vec<String>) {
+    let mut urls = Vec::new();
+    let mut domains = Vec::new();
+    for candidate in strings {
+        if let Ok(url) = url::Url::parse(candidate) {
+            if matches!(url.scheme(), "http" | "https") {
+                urls.push(url.to_string());
+                if let Some(host) = url.host_str() {
+                    domains.push(host.to_ascii_lowercase());
+                }
+            }
+        }
+    }
+    dedup(&mut urls);
+    dedup(&mut domains);
+    (urls, domains)
+}
+
+fn http_method_candidates(args: &JsonValue) -> Vec<String> {
+    let mut methods = Vec::new();
+    for key in ["method", "http_method"] {
+        if let Some(method) = string_field(args, key) {
+            methods.push(method.to_ascii_uppercase());
+        }
+    }
+    dedup(&mut methods);
+    methods
+}
+
+fn mcp_candidates(tool_name: &str, args: &JsonValue) -> (Vec<String>, Vec<String>) {
+    let mut servers = Vec::new();
+    let mut tools = Vec::new();
+    if let Some((server, tool)) = tool_name.split_once("__") {
+        if !server.is_empty() && !tool.is_empty() {
+            servers.push(server.to_string());
+            tools.push(tool.to_string());
+        }
+    }
+    for key in ["mcp_server", "_mcp_server", "server"] {
+        if let Some(value) = string_field(args, key) {
+            servers.push(value);
+        }
+    }
+    for key in ["mcp_tool", "tool"] {
+        if let Some(value) = string_field(args, key) {
+            tools.push(value);
+        }
+    }
+    dedup(&mut servers);
+    dedup(&mut tools);
+    (servers, tools)
+}
+
+fn string_field(args: &JsonValue, key: &str) -> Option<String> {
+    args.get(key)
+        .and_then(|value| value.as_str())
+        .filter(|value| !value.trim().is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn collect_string_values(value: &JsonValue, out: &mut Vec<String>) {
+    match value {
+        JsonValue::String(text) => out.push(text.clone()),
+        JsonValue::Array(items) => {
+            for item in items {
+                collect_string_values(item, out);
+            }
+        }
+        JsonValue::Object(map) => {
+            for value in map.values() {
+                collect_string_values(value, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn any_glob_matches(patterns: &[String], candidates: &[String]) -> bool {
+    candidates.iter().any(|candidate| {
+        patterns
+            .iter()
+            .any(|pattern| super::super::glob_match(pattern, candidate))
+    })
+}
+
+fn any_fragment_matches(patterns: &[String], candidates: &[String]) -> bool {
+    candidates.iter().any(|candidate| {
+        patterns
+            .iter()
+            .any(|pattern| glob_or_contains(pattern, candidate))
+    })
+}
+
+fn glob_or_contains(pattern: &str, text: &str) -> bool {
+    if super::super::glob_match(pattern, text) {
+        return true;
+    }
+    if pattern.contains('*') {
+        let mut rest = text;
+        for part in pattern.split('*').filter(|part| !part.is_empty()) {
+            let Some(index) = rest.find(part) else {
+                return false;
+            };
+            rest = &rest[index + part.len()..];
+        }
+        true
+    } else {
+        text.contains(pattern)
+    }
+}
+
+fn normalize_patterns_upper(patterns: &[String]) -> Vec<String> {
+    patterns
+        .iter()
+        .map(|pattern| pattern.to_ascii_uppercase())
+        .collect()
+}
+
+fn collapse_whitespace(value: &str) -> String {
+    value.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn normalize_path(path: &Path) -> PathBuf {
+    let raw = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        crate::stdlib::process::execution_root_path().join(path)
+    };
+    let mut out = PathBuf::new();
+    for component in raw.components() {
+        match component {
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                out.pop();
+            }
+            std::path::Component::Prefix(prefix) => out.push(prefix.as_os_str()),
+            std::path::Component::RootDir => out.push(component.as_os_str()),
+            std::path::Component::Normal(part) => out.push(part),
+        }
+    }
+    out
+}
+
+fn tool_kind_string(kind: crate::tool_annotations::ToolKind) -> &'static str {
+    match kind {
+        crate::tool_annotations::ToolKind::Read => "read",
+        crate::tool_annotations::ToolKind::Edit => "edit",
+        crate::tool_annotations::ToolKind::Delete => "delete",
+        crate::tool_annotations::ToolKind::Move => "move",
+        crate::tool_annotations::ToolKind::Search => "search",
+        crate::tool_annotations::ToolKind::Execute => "execute",
+        crate::tool_annotations::ToolKind::Think => "think",
+        crate::tool_annotations::ToolKind::Fetch => "fetch",
+        crate::tool_annotations::ToolKind::Other => "other",
+    }
+}
+
+fn deserialize_string_list<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = Option::<JsonValue>::deserialize(deserializer)?.unwrap_or(JsonValue::Null);
+    match value {
+        JsonValue::Null => Ok(Vec::new()),
+        JsonValue::String(value) => Ok(vec![value]),
+        JsonValue::Array(items) => items
+            .into_iter()
+            .map(|item| match item {
+                JsonValue::String(value) => Ok(value),
+                other => Err(D::Error::custom(format!(
+                    "expected string list item, got {other}"
+                ))),
+            })
+            .collect(),
+        other => Err(D::Error::custom(format!(
+            "expected string or string list, got {other}"
+        ))),
+    }
+}
+
+fn dedup(values: &mut Vec<String>) {
+    values.sort();
+    values.dedup();
+}
+
+fn stable_json_digest(value: &JsonValue) -> String {
+    let canonical = serde_json::to_string(value).unwrap_or_default();
+    let digest = Sha256::digest(canonical.as_bytes());
+    hex::encode(digest)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::*;
+    use crate::orchestration::{pop_execution_policy, push_execution_policy, CapabilityPolicy};
+    use crate::tool_annotations::{SideEffectLevel, ToolAnnotations, ToolArgSchema, ToolKind};
+
+    fn policy_with_path_annotation(tool: &str, kind: ToolKind) {
+        let mut annotations = BTreeMap::new();
+        annotations.insert(
+            tool.to_string(),
+            ToolAnnotations {
+                kind,
+                side_effect_level: match kind {
+                    ToolKind::Fetch => SideEffectLevel::Network,
+                    ToolKind::Execute => SideEffectLevel::ProcessExec,
+                    ToolKind::Edit | ToolKind::Delete | ToolKind::Move => {
+                        SideEffectLevel::WorkspaceWrite
+                    }
+                    _ => SideEffectLevel::ReadOnly,
+                },
+                arg_schema: ToolArgSchema {
+                    path_params: vec!["path".to_string()],
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        );
+        push_execution_policy(CapabilityPolicy {
+            tool_annotations: annotations,
+            ..Default::default()
+        });
+    }
+
+    #[test]
+    fn compact_rule_shorthand_deserializes() {
+        let rule: PolicyRule = serde_json::from_value(serde_json::json!({
+            "deny": {"tool": "read_*", "path": "**/.env"},
+            "reason": "secret file"
+        }))
+        .expect("rule");
+        assert_eq!(rule.action, PolicyAction::Deny);
+        assert_eq!(rule.matches.tool, vec!["read_*"]);
+        assert_eq!(rule.matches.path, vec!["**/.env"]);
+        assert_eq!(rule.reason.as_deref(), Some("secret file"));
+    }
+
+    #[test]
+    fn ambiguous_or_invalid_rule_shapes_are_rejected() {
+        let invalid_action = serde_json::from_value::<PolicyRule>(serde_json::json!({
+            "action": "maybe",
+            "match": {"tool": "read_file"}
+        }));
+        assert!(invalid_action.is_err());
+
+        let mixed_matchers = serde_json::from_value::<PolicyRule>(serde_json::json!({
+            "action": "deny",
+            "match": {"tool": "read_file"},
+            "path": "**/.env"
+        }));
+        assert!(mixed_matchers.is_err());
+    }
+
+    #[test]
+    fn deny_beats_ask_and_allow_regardless_of_order() {
+        let policy: ToolApprovalPolicy = serde_json::from_value(serde_json::json!({
+            "rules": [
+                {"allow": {"tool": "write_file"}},
+                {"ask": {"tool": "write_*"}},
+                {"deny": {"tool": "write_file"}, "reason": "blocked"}
+            ]
+        }))
+        .expect("policy");
+        let decision =
+            evaluate_tool_approval_policy(&policy, "write_file", &serde_json::json!({}), None);
+        assert!(decision.is_deny());
+        assert_eq!(decision.reason, "blocked");
+        assert_eq!(
+            decision.matched_rule.as_ref().and_then(|rule| rule.index),
+            Some(2)
+        );
+    }
+
+    #[test]
+    fn sensitive_paths_are_denied_by_default() {
+        let policy = ToolApprovalPolicy::default();
+        let decision = evaluate_tool_approval_policy(
+            &policy,
+            "read_file",
+            &serde_json::json!({"path": "config/.env"}),
+            None,
+        );
+        assert!(decision.is_deny());
+        assert!(decision.risk_labels.contains(&"sensitive_path".to_string()));
+    }
+
+    #[test]
+    fn explicit_sensitive_opt_out_allows_regular_evaluation() {
+        let policy = ToolApprovalPolicy {
+            allow_sensitive_paths: true,
+            ..Default::default()
+        };
+        let decision = evaluate_tool_approval_policy(
+            &policy,
+            "read_file",
+            &serde_json::json!({"path": "config/.env"}),
+            None,
+        );
+        assert!(decision.is_allow());
+        assert!(!decision.has_audit_signal());
+    }
+
+    #[test]
+    fn external_declared_paths_are_denied_without_root() {
+        let temp = tempfile::tempdir().unwrap();
+        crate::stdlib::process::set_thread_execution_context(Some(
+            crate::orchestration::RunExecutionRecord {
+                cwd: Some(temp.path().to_string_lossy().into_owned()),
+                source_dir: Some(temp.path().to_string_lossy().into_owned()),
+                env: BTreeMap::new(),
+                adapter: None,
+                repo_path: None,
+                worktree_path: None,
+                branch: None,
+                base_ref: None,
+                cleanup: None,
+            },
+        ));
+        policy_with_path_annotation("read_file", ToolKind::Read);
+        let decision = evaluate_tool_approval_policy(
+            &ToolApprovalPolicy::default(),
+            "read_file",
+            &serde_json::json!({"path": "/tmp/outside.txt"}),
+            None,
+        );
+        assert!(decision.is_deny());
+        assert!(decision.risk_labels.contains(&"external_path".to_string()));
+        pop_execution_policy();
+        crate::stdlib::process::set_thread_execution_context(None);
+    }
+
+    #[test]
+    fn path_rule_uses_declared_path_params() {
+        policy_with_path_annotation("write_file", ToolKind::Edit);
+        let policy: ToolApprovalPolicy = serde_json::from_value(serde_json::json!({
+            "allow_sensitive_paths": true,
+            "rules": [{"ask": {"tool": "write_*", "path": "src/**"}, "reason": "source edit"}]
+        }))
+        .expect("policy");
+        let decision = evaluate_tool_approval_policy(
+            &policy,
+            "write_file",
+            &serde_json::json!({"path": "src/lib.rs"}),
+            None,
+        );
+        assert!(decision.is_ask());
+        assert_eq!(decision.reason, "source edit");
+        pop_execution_policy();
+    }
+
+    #[test]
+    fn command_url_mcp_identity_and_repeat_rules_match() {
+        let policy: ToolApprovalPolicy = serde_json::from_value(serde_json::json!({
+            "allow_sensitive_paths": true,
+            "rules": [
+                {"ask": {"tool": "run_command", "command_identity": "npm"}},
+                {"deny": {"tool": "fetch_url", "domain": "*.example.com", "method": "POST"}},
+                {"deny": {"mcp_server": "github", "mcp_tool": "create_issue"}},
+                {"deny": {"tool": "read_file", "repeat_count_gte": 3}}
+            ]
+        }))
+        .expect("policy");
+        assert!(evaluate_tool_approval_policy(
+            &policy,
+            "run_command",
+            &serde_json::json!({"argv": ["npm", "install"]}),
+            None,
+        )
+        .is_ask());
+        assert!(evaluate_tool_approval_policy(
+            &policy,
+            "fetch_url",
+            &serde_json::json!({"url": "https://api.example.com/v1", "method": "post"}),
+            None,
+        )
+        .is_deny());
+        assert!(evaluate_tool_approval_policy(
+            &policy,
+            "github__create_issue",
+            &serde_json::json!({}),
+            None,
+        )
+        .is_deny());
+        assert!(evaluate_tool_approval_policy(
+            &policy,
+            "read_file",
+            &serde_json::json!({"path": "README.md"}),
+            Some(3),
+        )
+        .is_deny());
+    }
+
+    #[test]
+    fn persona_agent_and_mode_rules_match_args() {
+        let policy: ToolApprovalPolicy = serde_json::from_value(serde_json::json!({
+            "allow_sensitive_paths": true,
+            "rules": [{"deny": {"agent": "release-*", "persona": "shipper", "mode": "act"}}]
+        }))
+        .expect("policy");
+        let decision = evaluate_tool_approval_policy(
+            &policy,
+            "publish",
+            &serde_json::json!({"agent": "release-1", "persona": "shipper", "mode": "act"}),
+            None,
+        );
+        assert!(decision.is_deny());
+    }
+}

--- a/crates/harn-vm/src/orchestration/policy/mod.rs
+++ b/crates/harn-vm/src/orchestration/policy/mod.rs
@@ -1,5 +1,6 @@
 //! Policy types and capability-ceiling enforcement.
 
+mod approval_rules;
 mod types;
 
 use std::cell::RefCell;
@@ -9,12 +10,16 @@ use std::thread_local;
 
 use serde::{Deserialize, Serialize};
 
-use super::glob_match;
 use crate::tool_annotations::{SideEffectLevel, ToolAnnotations};
 use crate::value::{VmError, VmValue};
 use crate::workspace_path::{classify_workspace_path, WorkspacePathInfo};
 
 pub use crate::tool_annotations::{ToolArgSchema, ToolKind};
+pub use approval_rules::{
+    clear_all_approval_policy_repeat_counts, clear_approval_policy_repeat_counts,
+    next_approval_policy_repeat_count, ApprovalShape, PolicyAction, PolicyEvaluation,
+    PolicyMatchedRule, PolicyRule, PolicyRuleMatch,
+};
 pub use types::{
     enforce_tool_arg_constraints, AutoCompactPolicy, BranchSemantics, CapabilityPolicy,
     ContextPolicy, EqIgnored, EscalationPolicy, JoinPolicy, MapPolicy, ModelPolicy,
@@ -66,7 +71,7 @@ pub fn current_tool_annotations(tool: &str) -> Option<ToolAnnotations> {
     current_execution_policy().and_then(|policy| policy.tool_annotations.get(tool).cloned())
 }
 
-fn tool_kind_participates_in_write_allowlist(tool_name: &str) -> bool {
+pub(super) fn tool_kind_participates_in_write_allowlist(tool_name: &str) -> bool {
     current_tool_annotations(tool_name)
         .map(|annotations| !annotations.kind.is_read_only())
         .unwrap_or(true)
@@ -501,6 +506,10 @@ pub fn builtin_ceiling() -> CapabilityPolicy {
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(default)]
 pub struct ToolApprovalPolicy {
+    /// Ordered allow/ask/deny rules over tool metadata, path, command,
+    /// URL, MCP, agent/persona/mode, and repeat-count dimensions.
+    #[serde(default)]
+    pub rules: Vec<PolicyRule>,
     /// Glob patterns for tools that should be auto-approved.
     #[serde(default)]
     pub auto_approve: Vec<String>,
@@ -513,6 +522,25 @@ pub struct ToolApprovalPolicy {
     /// Glob patterns for writable paths.
     #[serde(default)]
     pub write_path_allowlist: Vec<String>,
+    /// Explicit opt-out for the deny-by-default sensitive-path guard.
+    #[serde(default)]
+    pub allow_sensitive_paths: bool,
+    /// Additional or replacement sensitive path globs. Empty uses the
+    /// runtime defaults such as `.env`, private keys, and credential files.
+    #[serde(default)]
+    pub sensitive_path_patterns: Vec<String>,
+    /// Explicit opt-out for the external-path guard on declared path args.
+    #[serde(default)]
+    pub allow_external_paths: bool,
+    /// Host-absolute roots allowed when `allow_external_paths` is false.
+    #[serde(default)]
+    pub external_roots: Vec<String>,
+    /// Optional repeated-call threshold for the same `(session, tool, args)`.
+    #[serde(default, alias = "repeated_call_limit")]
+    pub repeat_limit: Option<u64>,
+    /// Action for `repeat_limit`; defaults to `ask`.
+    #[serde(default, alias = "repeated_call_action")]
+    pub repeat_action: Option<PolicyAction>,
 }
 
 /// Result of evaluating a tool call against a ToolApprovalPolicy.
@@ -528,51 +556,31 @@ pub enum ToolApprovalDecision {
 }
 
 impl ToolApprovalPolicy {
+    pub fn evaluate_detailed(&self, tool_name: &str, args: &serde_json::Value) -> PolicyEvaluation {
+        approval_rules::evaluate_tool_approval_policy(self, tool_name, args, None)
+    }
+
+    pub fn evaluate_detailed_with_repeat(
+        &self,
+        tool_name: &str,
+        args: &serde_json::Value,
+        repeat_count: u64,
+    ) -> PolicyEvaluation {
+        approval_rules::evaluate_tool_approval_policy(self, tool_name, args, Some(repeat_count))
+    }
+
     /// Evaluate whether a tool call should be approved, denied, or needs
     /// host confirmation.
     pub fn evaluate(&self, tool_name: &str, args: &serde_json::Value) -> ToolApprovalDecision {
-        // Auto-deny takes precedence over every other pattern list.
-        for pattern in &self.auto_deny {
-            if glob_match(pattern, tool_name) {
-                return ToolApprovalDecision::AutoDenied {
-                    reason: format!("tool '{tool_name}' matches deny pattern '{pattern}'"),
-                };
-            }
+        let decision = self.evaluate_detailed(tool_name, args);
+        if decision.is_deny() {
+            return ToolApprovalDecision::AutoDenied {
+                reason: decision.reason,
+            };
         }
-
-        if !self.write_path_allowlist.is_empty()
-            && tool_kind_participates_in_write_allowlist(tool_name)
-        {
-            let paths = super::current_tool_declared_path_entries(tool_name, args);
-            for path in &paths {
-                let allowed = self.write_path_allowlist.iter().any(|pattern| {
-                    path.policy_candidates()
-                        .iter()
-                        .any(|candidate| glob_match(pattern, candidate))
-                });
-                if !allowed {
-                    return ToolApprovalDecision::AutoDenied {
-                        reason: format!(
-                            "tool '{tool_name}' targets '{}' which is not in the write-path allowlist",
-                            path.display_path()
-                        ),
-                    };
-                }
-            }
+        if decision.is_ask() {
+            return ToolApprovalDecision::RequiresHostApproval;
         }
-
-        for pattern in &self.auto_approve {
-            if glob_match(pattern, tool_name) {
-                return ToolApprovalDecision::AutoApproved;
-            }
-        }
-
-        for pattern in &self.require_approval {
-            if glob_match(pattern, tool_name) {
-                return ToolApprovalDecision::RequiresHostApproval;
-            }
-        }
-
         ToolApprovalDecision::AutoApproved
     }
 
@@ -608,11 +616,50 @@ impl ToolApprovalPolicy {
                 .cloned()
                 .collect()
         };
+        let mut rules = self.rules.clone();
+        rules.extend(other.rules.iter().cloned());
+        let mut sensitive_path_patterns = self.sensitive_path_patterns.clone();
+        sensitive_path_patterns.extend(other.sensitive_path_patterns.iter().cloned());
+        sensitive_path_patterns.sort();
+        sensitive_path_patterns.dedup();
+        let external_roots = if self.external_roots.is_empty() {
+            other.external_roots.clone()
+        } else if other.external_roots.is_empty() {
+            self.external_roots.clone()
+        } else {
+            self.external_roots
+                .iter()
+                .filter(|root| other.external_roots.contains(root))
+                .cloned()
+                .collect()
+        };
         ToolApprovalPolicy {
+            rules,
             auto_approve,
             auto_deny,
             require_approval,
             write_path_allowlist,
+            allow_sensitive_paths: self.allow_sensitive_paths && other.allow_sensitive_paths,
+            sensitive_path_patterns,
+            allow_external_paths: self.allow_external_paths && other.allow_external_paths,
+            external_roots,
+            repeat_limit: match (self.repeat_limit, other.repeat_limit) {
+                (Some(left), Some(right)) => Some(left.min(right)),
+                (Some(left), None) => Some(left),
+                (None, Some(right)) => Some(right),
+                (None, None) => None,
+            },
+            repeat_action: match (self.repeat_action, other.repeat_action) {
+                (Some(PolicyAction::Deny), _) | (_, Some(PolicyAction::Deny)) => {
+                    Some(PolicyAction::Deny)
+                }
+                (Some(PolicyAction::Ask), _) | (_, Some(PolicyAction::Ask)) => {
+                    Some(PolicyAction::Ask)
+                }
+                (Some(PolicyAction::Allow), Some(PolicyAction::Allow)) => Some(PolicyAction::Allow),
+                (Some(action), None) | (None, Some(action)) => Some(action),
+                (None, None) => None,
+            },
         }
     }
 }

--- a/crates/harn-vm/src/stdlib/git.rs
+++ b/crates/harn-vm/src/stdlib/git.rs
@@ -552,27 +552,32 @@ async fn enforce_git_approval(command: &GitCommand) -> Result<Option<JsonValue>,
         "affected_paths": command.affected_paths,
     });
     if command.mutation == GitMutation::Risky {
-        let approval = request_permission(command.operation, &args).await?;
+        let approval = request_permission(command.operation, &args, None).await?;
         return Ok(Some(approval));
     }
     let Some(policy) = crate::orchestration::current_approval_policy() else {
         return Ok(None);
     };
-    match policy.evaluate(command.operation, &args) {
-        crate::orchestration::ToolApprovalDecision::AutoApproved => Ok(None),
-        crate::orchestration::ToolApprovalDecision::AutoDenied { reason } => {
-            Err(VmError::CategorizedError {
-                message: reason,
-                category: crate::value::ErrorCategory::ToolRejected,
-            })
-        }
-        crate::orchestration::ToolApprovalDecision::RequiresHostApproval => {
-            request_permission(command.operation, &args).await.map(Some)
-        }
+    let decision = policy.evaluate_detailed(command.operation, &args);
+    if decision.is_allow() {
+        Ok(None)
+    } else if decision.is_deny() {
+        Err(VmError::CategorizedError {
+            message: decision.reason,
+            category: crate::value::ErrorCategory::ToolRejected,
+        })
+    } else {
+        request_permission(command.operation, &args, Some(decision.receipt))
+            .await
+            .map(Some)
     }
 }
 
-async fn request_permission(operation: &str, args: &JsonValue) -> Result<JsonValue, VmError> {
+async fn request_permission(
+    operation: &str,
+    args: &JsonValue,
+    policy_decision: Option<JsonValue>,
+) -> Result<JsonValue, VmError> {
     let Some(bridge) = crate::vm::clone_async_builtin_child_vm().and_then(|vm| vm.bridge.clone())
     else {
         return Err(VmError::CategorizedError {
@@ -587,7 +592,10 @@ async fn request_permission(operation: &str, args: &JsonValue) -> Result<JsonVal
         args.clone(),
         crate::llm::current_agent_session_id().unwrap_or_else(|| "harn".to_string()),
         Vec::new(),
-        JsonValue::Null,
+        policy_decision
+            .as_ref()
+            .map(|decision| json!({"policy_decision": decision}))
+            .unwrap_or(JsonValue::Null),
         vec![format!("stdlib.{operation}")],
     );
     let response = bridge
@@ -595,6 +603,7 @@ async fn request_permission(operation: &str, args: &JsonValue) -> Result<JsonVal
             "session/request_permission",
             json!({
                 "approvalRequest": approval_request,
+                "policyDecision": policy_decision,
                 "toolCall": {
                     "toolCallId": approval_id,
                     "toolName": operation,

--- a/crates/harn-vm/src/tool_surface.rs
+++ b/crates/harn-vm/src/tool_surface.rs
@@ -789,22 +789,41 @@ fn validate_approval_patterns(
         ),
     ] {
         for pattern in patterns {
-            if pattern.contains('*') {
-                continue;
-            }
-            if !active_names
-                .iter()
-                .any(|name| crate::orchestration::glob_match(pattern, name))
-            {
-                diagnostics.push(
-                    ToolSurfaceDiagnostic::warning(
-                        "TOOL_SURFACE_APPROVAL_PATTERN_NO_MATCH",
-                        format!("{field} pattern '{pattern}' matches no active tool"),
-                    )
-                    .with_field(field),
-                );
-            }
+            validate_approval_tool_pattern(pattern, field, active_names, diagnostics);
         }
+    }
+    for (index, rule) in approval.rules.iter().enumerate() {
+        for pattern in &rule.matches.tool {
+            validate_approval_tool_pattern(
+                pattern,
+                &format!("approval_policy.rules[{index}].tool"),
+                active_names,
+                diagnostics,
+            );
+        }
+    }
+}
+
+fn validate_approval_tool_pattern(
+    pattern: &str,
+    field: &str,
+    active_names: &BTreeSet<String>,
+    diagnostics: &mut Vec<ToolSurfaceDiagnostic>,
+) {
+    if pattern.contains('*') {
+        return;
+    }
+    if !active_names
+        .iter()
+        .any(|name| crate::orchestration::glob_match(pattern, name))
+    {
+        diagnostics.push(
+            ToolSurfaceDiagnostic::warning(
+                "TOOL_SURFACE_APPROVAL_PATTERN_NO_MATCH",
+                format!("{field} pattern '{pattern}' matches no active tool"),
+            )
+            .with_field(field),
+        );
     }
 }
 
@@ -1368,6 +1387,34 @@ mod tests {
             .diagnostics
             .iter()
             .any(|d| d.code == "TOOL_SURFACE_PROMPT_TOOL_NOT_IN_POLICY"));
+    }
+
+    #[test]
+    fn approval_rule_tool_references_are_reported() {
+        let approval_policy: ToolApprovalPolicy = serde_json::from_value(serde_json::json!({
+            "rules": [
+                {"ask": {"tool": "missing_tool"}, "reason": "unknown"},
+                {"allow": {"tool": "read_*"}}
+            ]
+        }))
+        .unwrap();
+        let report = validate_tool_surface(&ToolSurfaceInput {
+            native_tools: Some(vec![serde_json::json!({
+                "name": "read_file",
+                "parameters": {"type": "object"},
+            })]),
+            approval_policy: Some(approval_policy),
+            ..ToolSurfaceInput::default()
+        });
+
+        assert!(report.diagnostics.iter().any(|d| {
+            d.code == "TOOL_SURFACE_APPROVAL_PATTERN_NO_MATCH"
+                && d.field.as_deref() == Some("approval_policy.rules[0].tool")
+        }));
+        assert!(!report.diagnostics.iter().any(|d| {
+            d.code == "TOOL_SURFACE_APPROVAL_PATTERN_NO_MATCH"
+                && d.field.as_deref() == Some("approval_policy.rules[1].tool")
+        }));
     }
 
     #[test]

--- a/docs/src/bridge-protocol.md
+++ b/docs/src/bridge-protocol.md
@@ -243,9 +243,29 @@ Request payload (harn-issued):
       "session_id": "session_123",
       "run_id": "run_123",
       "worker_id": null,
-      "mutation_scope": "apply_workspace"
+      "mutation_scope": "apply_workspace",
+      "policy_decision": {
+        "type": "harn.permission_policy_decision.v1",
+        "action": "ask",
+        "reason": "workspace edit",
+        "matched_rule": {"source": "rules", "action": "ask", "id": "edit-src", "index": 0},
+        "risk_labels": ["approval_required", "path_rule"]
+      }
     },
     "capabilities_requested": ["workspace.write_text"]
+  },
+  "policyDecision": {
+    "type": "harn.permission_policy_decision.v1",
+    "action": "ask",
+    "reason": "workspace edit",
+    "matched_rule": {"source": "rules", "action": "ask", "id": "edit-src", "index": 0},
+    "risk_labels": ["approval_required", "path_rule"],
+    "context": {
+      "tool_name": "edit_file",
+      "tool_kind": "edit",
+      "side_effect": "workspace_write",
+      "paths": [{"workspace_path": "src/main.rs"}]
+    }
   },
   "toolCall": {
     "toolCallId": "call_123",
@@ -264,9 +284,14 @@ Request payload (harn-issued):
 ```
 
 `approvalRequest` is the canonical Harn `ApprovalRequest` payload. Hosts should
-render approval UI from that object and treat the surrounding `toolCall`,
-`mutation`, and `declaredPaths` fields as compatibility/context fields. The same
-shape is used in stdlib HITL notifications at
+render approval UI from that object and use `policyDecision` as the policy
+rationale: it includes the matched rule, risk labels, normalized context, and
+the action (`ask` for host approval requests). The same receipt is copied into
+`approvalRequest.undo_metadata.policy_decision` and into
+`PermissionGrant`/`PermissionDeny` transcript-event metadata so approvals are
+auditable and replayable even when the host only persists the canonical request.
+Treat the surrounding `toolCall`, `mutation`, and `declaredPaths` fields as
+compatibility/context fields. The same shape is used in stdlib HITL notifications at
 `harn.hitl.requested.params.payload.approval_request`, so Burin Code,
 harn-cloud approval inboxes, and CLI-style hosts can share one renderer.
 

--- a/docs/src/builtins.md
+++ b/docs/src/builtins.md
@@ -2165,22 +2165,93 @@ execution time.
 ```harn
 agent_loop("task", "system", {
   approval_policy: {
+    rules: [
+      {deny: {path: "**/.env*"}, reason: "credential file"},
+      {ask: {tool: "edit_*", path: "src/**"}, reason: "workspace edit"},
+      {deny: {tool: "run_command", command: ["*curl*", "*wget*"]}}
+    ],
     auto_approve: ["read*", "list_*"],
     auto_deny: ["shell*"],
     require_approval: ["edit_*", "write_*"],
-    write_path_allowlist: ["/workspace/**"]
+    write_path_allowlist: ["/workspace/**"],
+    repeat_limit: 3
   }
 })
 ```
 
-Evaluation order: `auto_deny` → `write_path_allowlist` → `auto_approve` →
-`require_approval`. Tools that match no pattern default to `AutoApproved`.
-`require_approval` calls the host via the canonical ACP
-`session/request_permission` request and **fails closed** if the host
-does not implement it. Policies compose
+`rules` is the typed policy DSL. Each rule uses `allow`, `ask`, or `deny`
+shorthand, or `{action: "ask", match: {...}}`. Match fields are ANDed inside a
+rule and accept strings or string lists:
+
+| Field | Matches |
+|---|---|
+| `tool` | Tool-name glob |
+| `tool_kind` | Annotated ACP tool kind (`read`, `edit`, `execute`, `fetch`, ...) |
+| `side_effect` | Annotated side-effect level (`read_only`, `workspace_write`, `process_exec`, `network`) |
+| `path` | Declared path arguments from `ToolAnnotations.arg_schema.path_params` |
+| `command` / `command_identity` | Shell text or normalized argv/program identity |
+| `url` / `domain` / `method` | URL strings, normalized host domains, and HTTP methods found in tool args |
+| `mcp_server` / `mcp_tool` | MCP owner inferred from `<server>__<tool>` names or MCP arg metadata |
+| `agent` / `persona` / `mode` | Agent/persona/mode identity from args or trigger context |
+| `capability` | Annotated capability operation such as `workspace.read_text` |
+| `repeat_count_gte` | Same `(session, tool, args)` call count threshold |
+
+Deny beats ask, and ask beats allow regardless of rule order. Legacy
+`auto_deny`, `require_approval`, and `auto_approve` are evaluated through the
+same precedence model, so old policy bags remain valid while the richer DSL is
+available. Tools that match no pattern default to `AutoApproved`.
+
+When an `approval_policy` is active, Harn denies sensitive path strings such as
+`.env`, private keys, and credential files by default. Declared host-absolute
+paths outside the workspace are also denied unless `external_roots` explicitly
+allows the root or `allow_external_paths: true` is set. Set
+`allow_sensitive_paths: true` only when a host already mediates secret reads.
+
+`ask` and `require_approval` call the host via the canonical ACP
+`session/request_permission` request and **fail closed** if the host does not
+implement it. The prompt payload includes a `policyDecision` receipt with the
+matched rule, risk labels, normalized context, and rationale. Permission grant
+and denial transcript events carry the same receipt under
+`metadata.policy_decision` for replay and audit.
+
+Example profiles:
+
+```harn
+let local_dev_policy = {
+  rules: [
+    {allow: {tool_kind: ["read", "search"]}},
+    {ask: {tool_kind: ["edit", "move"], path: "src/**"}, reason: "workspace mutation"},
+    {deny: {command: ["*curl*", "*wget*"]}, reason: "downloaded shell is not allowed"}
+  ],
+  repeat_limit: 3
+}
+
+let ci_headless_policy = {
+  rules: [
+    {allow: {tool_kind: ["read", "search"]}},
+    {allow: {tool: "run_command", command_identity: ["cargo", "npm", "make"]}},
+    {deny: "*"}
+  ],
+  allow_sensitive_paths: false,
+  repeat_limit: 1,
+  repeat_action: "deny"
+}
+
+let managed_enterprise_policy = {
+  rules: [
+    {ask: {side_effect: ["workspace_write", "process_exec", "network"]}, reason: "managed approval"},
+    {deny: {domain: ["*.pastebin.com", "*.ngrok.io"]}},
+    {deny: {path: ["**/.env*", "**/.aws/credentials"]}}
+  ],
+  external_roots: ["/tmp/harn-approved"]
+}
+```
+
+Policies compose
 across nested scopes with most-restrictive intersection: auto-deny and
 require-approval take the union, while `auto_approve` and
-`write_path_allowlist` take the intersection.
+`write_path_allowlist` take the intersection. Rule lists concatenate and retain
+deny/ask/allow precedence; repeat limits keep the smaller threshold.
 
 Example (`agent.harn`):
 

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -1518,6 +1518,28 @@ decisions append `PermissionGrant`, `PermissionDeny`, and
 `suggest` trigger contexts append a `trust.promote` OpenTrustGraph record at
 `act_with_approval`.
 
+`approval_policy` is the declarative host-approval policy. It accepts legacy
+`auto_approve`, `auto_deny`, `require_approval`, and `write_path_allowlist`
+fields plus `rules`, a compact allow/ask/deny DSL. A rule may be written as
+`{allow: {...}}`, `{ask: {...}}`, `{deny: {...}}`, or
+`{action: "ask", match: {...}}`. Match dimensions include `tool`,
+`tool_kind`, `side_effect`, `path`, `command`, `command_identity`, `url`,
+`domain`, `method`, `mcp_server`, `mcp_tool`, `agent`, `persona`, `mode`,
+`capability`, and `repeat_count_gte`. Dimensions inside a rule are ANDed;
+string fields accept glob patterns. Deny beats ask, ask beats allow, and
+unmatched tools are approved.
+
+When an approval policy is active, sensitive path strings such as `.env`,
+private keys, and credential files are denied by default unless
+`allow_sensitive_paths: true` is set. Declared host-absolute paths outside the
+workspace are denied unless `external_roots` covers the path or
+`allow_external_paths: true` is set. `ask` decisions call the host via
+`session/request_permission` and fail closed when no host bridge is attached.
+Each approval decision produces a `harn.permission_policy_decision.v1` receipt
+containing the matched rule, risk labels, normalized context, and rationale;
+host approval payloads and permission transcript events carry that receipt for
+audit and replay.
+
 ```harn
 let budget = shared_cell({scope: "task_group", key: "tokens", initial: 0})
 

--- a/docs/src/llm/agent_loop.md
+++ b/docs/src/llm/agent_loop.md
@@ -1009,6 +1009,18 @@ lineage metadata.
 - `error: {category, message, tool?}` when the child fails or a narrowed tool
   policy rejects a call
 
+`agent_loop(...)`, `sub_agent_run(...)`, and `spawn_agent(...)` accept
+`approval_policy` for declarative allow/ask/deny gating before a tool runs.
+Use `approval_policy.rules` for typed matching over tool name/kind,
+side-effect level, declared paths, commands, URLs/domains/methods, MCP identity,
+agent/persona/mode, capability operation, and repeated-call counts. Deny wins
+over ask, ask wins over allow, and unmatched tools are approved. Active
+approval policies deny sensitive filenames such as `.env` and private keys by
+default, and declared host-absolute paths outside the workspace require an
+explicit `external_roots` allowance. Ask decisions call
+`session/request_permission`; the host request and the transcript event both
+carry a `policyDecision` receipt with matched rule and rationale.
+
 `agent_loop(...)`, `sub_agent_run(...)`, and `spawn_agent(...)` also accept a
 `permissions` dict for per-agent dynamic policy. `allow` and `deny` entries can
 be tool-name glob lists, argument pattern lists, or Harn predicates over the tool

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -1516,6 +1516,28 @@ decisions append `PermissionGrant`, `PermissionDeny`, and
 `suggest` trigger contexts append a `trust.promote` OpenTrustGraph record at
 `act_with_approval`.
 
+`approval_policy` is the declarative host-approval policy. It accepts legacy
+`auto_approve`, `auto_deny`, `require_approval`, and `write_path_allowlist`
+fields plus `rules`, a compact allow/ask/deny DSL. A rule may be written as
+`{allow: {...}}`, `{ask: {...}}`, `{deny: {...}}`, or
+`{action: "ask", match: {...}}`. Match dimensions include `tool`,
+`tool_kind`, `side_effect`, `path`, `command`, `command_identity`, `url`,
+`domain`, `method`, `mcp_server`, `mcp_tool`, `agent`, `persona`, `mode`,
+`capability`, and `repeat_count_gte`. Dimensions inside a rule are ANDed;
+string fields accept glob patterns. Deny beats ask, ask beats allow, and
+unmatched tools are approved.
+
+When an approval policy is active, sensitive path strings such as `.env`,
+private keys, and credential files are denied by default unless
+`allow_sensitive_paths: true` is set. Declared host-absolute paths outside the
+workspace are denied unless `external_roots` covers the path or
+`allow_external_paths: true` is set. `ask` decisions call the host via
+`session/request_permission` and fail closed when no host bridge is attached.
+Each approval decision produces a `harn.permission_policy_decision.v1` receipt
+containing the matched rule, risk labels, normalized context, and rationale;
+host approval payloads and permission transcript events carry that receipt for
+audit and replay.
+
 ```harn
 let budget = shared_cell({scope: "task_group", key: "tokens", initial: 0})
 


### PR DESCRIPTION
Closes #1582.

Summary:
- Add `approval_policy.rules` with allow/ask/deny matching over tool metadata, paths, commands, URLs/domains/methods, MCP identity, agent/persona/mode, capabilities, and repeat counts.
- Add deny-by-default sensitive path and external path guards, repeated-call enforcement, deterministic policy receipts, and host/transcript propagation via `policyDecision` / `metadata.policy_decision`.
- Update git/std-agent approval paths, tool-surface validation, docs/spec, and conformance coverage.

Verification:
- `CARGO_TARGET_DIR=/tmp/harn-target-1582 cargo test -p harn-vm approval_ --lib`
- `CARGO_TARGET_DIR=/tmp/harn-target-1582 cargo run --quiet --bin harn -- test conformance --filter approval_policy_rules`
- `CARGO_TARGET_DIR=/tmp/harn-target-1582 cargo clippy -p harn-vm -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/harn-target-1582 make check-language-spec`
- `CARGO_TARGET_DIR=/tmp/harn-target-1582 make check-docs-snippets`
- pre-commit hooks
- pre-push hooks