### PR TITLE
Add package tool authoring workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,8 +221,11 @@ defaults, safe, prompts, catalog).
   (`blocks`, `lines`, `tokens`), and event-log-backed OCR audit records for
   replayable agent/tool flows.
 - Manifest-backed extension ABI: packages can publish stable module entry
-  points via `[exports]` and ship provider/alias adapters declaratively via
-  `[llm]` in `harn.toml`, without editing core runtime registration code.
+  points via `[exports]`, declare custom tool and skill surfaces via
+  `[[package.tools]]` and `[[package.skills]]`, and ship provider/alias
+  adapters declaratively via `[llm]` in `harn.toml`, without editing core
+  runtime registration code. `harn tool new <name>` scaffolds a Harn-native
+  tool package with manifest metadata, tests, docs, and CI.
   Local sibling packages can be added with `harn add ../harn-openapi`;
   Harn derives the alias from the dependency's `harn.toml` and live-links
   directory path dependencies into `.harn/packages/` for fast multi-repo
@@ -230,6 +233,9 @@ defaults, safe, prompts, catalog).
   `harn package search`, `harn package info`, and
   `harn add @burin/<name>@<version>`, which resolve through the package
   index and then use the same git-backed install path as direct GitHub refs.
+  `harn package list` and `harn package doctor` expose locked exports,
+  permissions, host requirements, and materialized-package integrity for host
+  UI and CI policy checks.
 - Design-by-contract and project/runtime helpers: `require ...`,
   metadata/scanner runtime builtins, `import "std/project"` for
   freshness-aware metadata and scan state, and `import "std/runtime"` for

--- a/crates/harn-cli/src/cli/mod.rs
+++ b/crates/harn-cli/src/cli/mod.rs
@@ -43,6 +43,7 @@ mod skills;
 mod supervisor;
 mod test;
 mod test_bench;
+mod tool;
 mod trace;
 mod trigger;
 mod trust;
@@ -151,6 +152,7 @@ pub(crate) use test_bench::{
     TestBenchArgs, TestBenchCommand, TestBenchExportAnnotationsArgs, TestBenchFidelityArgs,
     TestBenchReplayArgs, TestBenchRunArgs, TestBenchValidateAnnotationsArgs,
 };
+pub(crate) use tool::{ToolArgs, ToolCommand, ToolNewArgs};
 pub(crate) use trace::{TraceArgs, TraceCommand, TraceImportArgs};
 pub(crate) use trigger::{TriggerArgs, TriggerCancelArgs, TriggerCommand, TriggerReplayArgs};
 pub(crate) use try_cmd::TryArgs;
@@ -336,6 +338,8 @@ SCRIPTING
     Skills(SkillsArgs),
     /// Manage skill provenance: keys, signatures, verification, and trust policy.
     Skill(SkillArgs),
+    /// Scaffold and inspect Harn-native custom tools.
+    Tool(ToolArgs),
     /// Print the decorated version banner.
     Version,
     /// Regenerate docs/theme/harn-keywords.js from the live lexer + stdlib sets.

--- a/crates/harn-cli/src/cli/package.rs
+++ b/crates/harn-cli/src/cli/package.rs
@@ -74,6 +74,10 @@ pub(crate) struct PackageArgs {
 
 #[derive(Debug, Subcommand)]
 pub(crate) enum PackageCommand {
+    /// List locked and materialized packages plus exported surfaces.
+    List(PackageListArgs),
+    /// Diagnose harn.toml, harn.lock, installed packages, and host requirements.
+    Doctor(PackageDoctorArgs),
     /// Search the package registry index.
     Search(PackageSearchArgs),
     /// Show package registry metadata for one package.
@@ -92,6 +96,20 @@ pub(crate) enum PackageCommand {
     Audit(PackageAuditArgs),
     /// Inspect or verify the published Harn protocol-artifact contract.
     Artifacts(PackageArtifactsArgs),
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct PackageListArgs {
+    /// Emit JSON instead of a human-readable report.
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct PackageDoctorArgs {
+    /// Emit JSON instead of a human-readable report.
+    #[arg(long)]
+    pub json: bool,
 }
 
 #[derive(Debug, Args)]

--- a/crates/harn-cli/src/cli/skill.rs
+++ b/crates/harn-cli/src/cli/skill.rs
@@ -1,5 +1,7 @@
 use clap::{Args, Subcommand};
 
+use super::skills::SkillsNewArgs;
+
 #[derive(Debug, Args)]
 pub(crate) struct SkillArgs {
     #[command(subcommand)]
@@ -8,6 +10,8 @@ pub(crate) struct SkillArgs {
 
 #[derive(Debug, Subcommand)]
 pub(crate) enum SkillCommand {
+    /// Scaffold a new SKILL.md bundle under `.harn/skills/<name>/`.
+    New(SkillsNewArgs),
     /// Manage Ed25519 signing keys for skill provenance.
     Key(SkillKeyArgs),
     /// Sign a skill manifest and emit `<path>.sig`.

--- a/crates/harn-cli/src/cli/tests.rs
+++ b/crates/harn-cli/src/cli/tests.rs
@@ -7,8 +7,8 @@ use super::{
     OrchestratorCommand, OrchestratorDeployProvider, OrchestratorLogFormat,
     OrchestratorQueueCommand, OrchestratorTenantCommand, PackageArtifactsCommand,
     PackageCacheCommand, PackageCommand, PersonaCommand, ProjectTemplate, RunsCommand,
-    SessionCommand, SkillCommand, SkillKeyCommand, SkillTrustCommand, SkillsCommand, TraceCommand,
-    TriggerCommand, TrustCommand, TrustOutcomeArg, TrustTierArg,
+    SessionCommand, SkillCommand, SkillKeyCommand, SkillTrustCommand, SkillsCommand, ToolCommand,
+    TraceCommand, TriggerCommand, TrustCommand, TrustOutcomeArg, TrustTierArg,
 };
 use clap::{CommandFactory, Parser};
 
@@ -1571,6 +1571,24 @@ fn test_parses_add_registry_override() {
 
 #[test]
 fn test_parses_package_cache_subcommands() {
+    let cli = Cli::parse_from(["harn", "package", "list", "--json"]);
+    let Command::Package(args) = cli.command.unwrap() else {
+        panic!("expected package command");
+    };
+    let PackageCommand::List(list) = args.command else {
+        panic!("expected package list");
+    };
+    assert!(list.json);
+
+    let cli = Cli::parse_from(["harn", "package", "doctor", "--json"]);
+    let Command::Package(args) = cli.command.unwrap() else {
+        panic!("expected package command");
+    };
+    let PackageCommand::Doctor(doctor) = args.command else {
+        panic!("expected package doctor");
+    };
+    assert!(doctor.json);
+
     let cli = Cli::parse_from([
         "harn",
         "package",
@@ -1669,6 +1687,39 @@ fn test_parses_package_cache_subcommands() {
         panic!("expected package cache verify");
     };
     assert!(verify.materialized);
+}
+
+#[test]
+fn test_parses_tool_new_and_skill_new_alias() {
+    let cli = Cli::parse_from([
+        "harn",
+        "tool",
+        "new",
+        "acme-tool",
+        "--description",
+        "Echo text",
+        "--dir",
+        "packages/acme-tool",
+        "--force",
+    ]);
+    let Command::Tool(args) = cli.command.unwrap() else {
+        panic!("expected tool command");
+    };
+    let ToolCommand::New(new) = args.command;
+    assert_eq!(new.name, "acme-tool");
+    assert_eq!(new.description.as_deref(), Some("Echo text"));
+    assert_eq!(new.dir.as_deref(), Some("packages/acme-tool"));
+    assert!(new.force);
+
+    let cli = Cli::parse_from(["harn", "skill", "new", "deploy", "--description", "Deploy"]);
+    let Command::Skill(args) = cli.command.unwrap() else {
+        panic!("expected skill command");
+    };
+    let SkillCommand::New(new) = args.command else {
+        panic!("expected skill new alias");
+    };
+    assert_eq!(new.name, "deploy");
+    assert_eq!(new.description.as_deref(), Some("Deploy"));
 }
 
 #[test]

--- a/crates/harn-cli/src/cli/tool.rs
+++ b/crates/harn-cli/src/cli/tool.rs
@@ -1,0 +1,28 @@
+use clap::{Args, Subcommand};
+
+#[derive(Debug, Args)]
+pub(crate) struct ToolArgs {
+    #[command(subcommand)]
+    pub command: ToolCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum ToolCommand {
+    /// Scaffold a Harn package that exports one custom tool.
+    New(ToolNewArgs),
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct ToolNewArgs {
+    /// Tool/package name. May use dashes; generated Harn identifiers use underscores.
+    pub name: String,
+    /// One-line tool description.
+    #[arg(long)]
+    pub description: Option<String>,
+    /// Destination directory. Defaults to `<name>/`.
+    #[arg(long = "dir", value_name = "PATH")]
+    pub dir: Option<String>,
+    /// Overwrite an existing generated directory.
+    #[arg(long)]
+    pub force: bool,
+}

--- a/crates/harn-cli/src/commands/mod.rs
+++ b/crates/harn-cli/src/commands/mod.rs
@@ -35,6 +35,7 @@ pub(crate) mod skills;
 pub(crate) mod supervisor;
 pub(crate) mod test;
 pub mod test_bench;
+pub(crate) mod tool;
 pub(crate) mod trace;
 pub mod trigger;
 pub(crate) mod trust;

--- a/crates/harn-cli/src/commands/tool.rs
+++ b/crates/harn-cli/src/commands/tool.rs
@@ -1,0 +1,350 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::cli::ToolNewArgs;
+use crate::package::{
+    current_harn_range_example, generate_package_docs_impl, toml_string_literal,
+    validate_package_alias, PackageError,
+};
+
+pub(crate) fn run_new(args: &ToolNewArgs) -> Result<(), PackageError> {
+    validate_package_alias(&args.name)?;
+    let dest = args
+        .dir
+        .as_deref()
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(&args.name));
+    if dest.exists() {
+        if !args.force {
+            return Err(format!(
+                "{} already exists. Pass --force to overwrite.",
+                dest.display()
+            )
+            .into());
+        }
+        if !dest.is_dir() {
+            return Err(format!("{} exists and is not a directory.", dest.display()).into());
+        }
+    } else {
+        fs::create_dir_all(&dest)
+            .map_err(|error| format!("failed to create {}: {error}", dest.display()))?;
+    }
+
+    let description = args
+        .description
+        .clone()
+        .unwrap_or_else(|| format!("Custom Harn tool package for {}.", args.name));
+    let ident = harn_identifier(&args.name)?;
+    let handler = format!("handle_{ident}");
+
+    for (relative_path, content) in tool_template_files(&args.name, &ident, &handler, &description)?
+    {
+        write_file(&dest, relative_path, &content)?;
+    }
+    generate_package_docs_impl(Some(&dest), None, false)?;
+
+    println!(
+        "Scaffolded tool package '{}' at {}",
+        args.name,
+        dest.display()
+    );
+    println!("  harn test tests/");
+    println!("  harn package check");
+    println!("  harn package docs --check");
+    println!("  harn package pack --dry-run");
+    Ok(())
+}
+
+fn tool_template_files(
+    package_name: &str,
+    ident: &str,
+    handler: &str,
+    description: &str,
+) -> Result<Vec<(&'static str, String)>, PackageError> {
+    let harn_range = current_harn_range_example();
+    let package_name_toml = toml_string_literal(package_name)?;
+    let description_toml = toml_string_literal(description)?;
+    let repository = toml_string_literal(&format!("https://github.com/OWNER/{package_name}"))?;
+    let provenance = toml_string_literal(&format!(
+        "https://github.com/OWNER/{package_name}/releases/tag/v0.1.0"
+    ))?;
+    let tool_name_harn = harn_string_literal(package_name);
+    let description_harn = harn_string_literal(description);
+    let handler_doc = description.trim_end_matches('.');
+
+    Ok(vec![
+        (
+            "harn.toml",
+            format!(
+                r#"[package]
+name = {package_name_toml}
+version = "0.1.0"
+description = {description_toml}
+license = "MIT OR Apache-2.0"
+repository = {repository}
+provenance = {provenance}
+harn = "{harn_range}"
+docs_url = "docs/api.md"
+permissions = ["tool:read_only"]
+
+[exports]
+tools = "lib/tools.harn"
+
+[[package.tools]]
+name = {package_name_toml}
+module = "lib/tools.harn"
+symbol = "tools"
+description = {description_toml}
+permissions = ["tool:read_only"]
+
+[package.tools.input_schema]
+type = "object"
+required = ["text"]
+
+[package.tools.input_schema.properties.text]
+type = "string"
+description = "Text to echo."
+
+[package.tools.output_schema]
+type = "string"
+
+[package.tools.annotations]
+kind = "read"
+side_effect_level = "read_only"
+
+[package.tools.annotations.arg_schema]
+required = ["text"]
+
+[dependencies]
+"#
+            ),
+        ),
+        (
+            "lib/tools.harn",
+            format!(
+                r#"/** {handler_doc}. */
+pub fn {handler}(args) {{
+  let input = schema_expect(args, {{
+    type: "object",
+    properties: {{
+      text: {{type: "string"}}
+    }},
+    required: ["text"]
+  }})
+  return input.text
+}}
+
+/** Return a tool registry containing `{package_name}`. */
+pub fn tools(registry = nil) {{
+  var reg = registry ?? tool_registry()
+  reg = tool_define(reg, {tool_name_harn}, {description_harn}, {{
+    parameters: {{
+      text: {{
+        type: "string",
+        description: "Text to echo."
+      }}
+    }},
+    returns: {{type: "string"}},
+    annotations: {{
+      kind: "read",
+      side_effect_level: "read_only",
+      arg_schema: {{required: ["text"]}}
+    }},
+    handler: {handler}
+  }})
+  return reg
+}}
+"#
+            ),
+        ),
+        (
+            "main.harn",
+            format!(
+                r#"import {{ agent_dispatch_tool_call }} from "std/agent/primitives"
+import {{ tools }} from "lib/tools"
+
+pipeline default() {{
+  let registry = tools()
+  var text = "hello"
+  if len(argv) > 0 {{
+    text = argv[0]
+  }}
+  let result = agent_dispatch_tool_call({{
+    name: {tool_name_harn},
+    arguments: {{text: text}}
+  }}, registry)
+  if !result.ok {{
+    throw (result.error?.message ?? "tool call failed")
+  }}
+  println(result.rendered_result)
+}}
+"#
+            ),
+        ),
+        (
+            "tests/test_tool.harn",
+            format!(
+                r#"import {{ agent_dispatch_tool_call }} from "std/agent/primitives"
+import {{ tools }} from "../lib/tools"
+
+pipeline test_{ident}_tool(task) {{
+  let registry = tools()
+  let ok = agent_dispatch_tool_call({{
+    name: {tool_name_harn},
+    arguments: {{text: "hello"}}
+  }}, registry)
+  assert(ok.ok, ok.error?.message ?? "tool call should pass")
+  assert_eq(ok.rendered_result, "hello")
+
+  let bad = agent_dispatch_tool_call({{
+    name: {tool_name_harn},
+    arguments: {{}}
+  }}, registry)
+  assert(!bad.ok, "schema validation should reject missing text")
+}}
+"#
+            ),
+        ),
+        (
+            "README.md",
+            format!(
+                r#"# {package_name}
+
+{description}
+
+## Develop
+
+```bash
+harn test tests/
+harn package check
+harn package docs --check
+harn package pack --dry-run
+```
+
+## Install into another project
+
+```bash
+harn add ../{package_name}
+harn install
+```
+
+Consumers import the stable registry builder with:
+
+```harn
+import {{ tools }} from "{package_name}/tools"
+```
+"#
+            ),
+        ),
+        ("LICENSE", "MIT OR Apache-2.0\n".to_string()),
+        (
+            ".github/workflows/harn-package.yml",
+            r#"name: Harn tool package
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@cargo-binstall
+      - run: cargo binstall harn-cli --no-confirm
+      - run: harn install --locked --offline || harn install
+      - run: harn test tests/
+      - run: harn package check
+      - run: harn package docs --check
+      - run: harn package pack --dry-run
+"#
+            .to_string(),
+        ),
+    ])
+}
+
+fn write_file(root: &Path, relative_path: &str, content: &str) -> Result<(), PackageError> {
+    let path = root.join(relative_path);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|error| format!("failed to create {}: {error}", parent.display()))?;
+    }
+    harn_vm::atomic_io::atomic_write(&path, content.as_bytes())
+        .map_err(|error| format!("failed to write {}: {error}", path.display()))?;
+    Ok(())
+}
+
+fn harn_identifier(name: &str) -> Result<String, PackageError> {
+    let mut out = String::new();
+    for ch in name.chars() {
+        if ch == '_' || ch.is_ascii_alphanumeric() {
+            out.push(ch);
+        } else {
+            out.push('_');
+        }
+    }
+    while out.contains("__") {
+        out = out.replace("__", "_");
+    }
+    let out = out.trim_matches('_').to_string();
+    if out.is_empty() {
+        return Err(format!("tool name {name:?} does not contain an identifier").into());
+    }
+    if out
+        .chars()
+        .next()
+        .is_some_and(|ch| ch.is_ascii_alphabetic() || ch == '_')
+    {
+        Ok(out)
+    } else {
+        Ok(format!("tool_{out}"))
+    }
+}
+
+fn harn_string_literal(value: &str) -> String {
+    let mut out = String::with_capacity(value.len() + 2);
+    out.push('"');
+    for ch in value.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            other => out.push(other),
+        }
+    }
+    out.push('"');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn harn_identifier_normalizes_package_names() {
+        assert_eq!(harn_identifier("acme-tool").unwrap(), "acme_tool");
+        assert_eq!(harn_identifier("123-tool").unwrap(), "tool_123_tool");
+    }
+
+    #[test]
+    fn force_overwrites_templates_without_deleting_extra_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dest = tmp.path().join("acme-tool");
+        fs::create_dir_all(&dest).unwrap();
+        fs::write(dest.join("keep.txt"), "keep").unwrap();
+
+        run_new(&ToolNewArgs {
+            name: "acme-tool".to_string(),
+            description: None,
+            dir: Some(dest.display().to_string()),
+            force: true,
+        })
+        .unwrap();
+
+        assert_eq!(fs::read_to_string(dest.join("keep.txt")).unwrap(), "keep");
+        assert!(dest.join("harn.toml").exists());
+    }
+}

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -23,7 +23,7 @@ use cli::{
     Cli, Command, CompletionShell, MergeCaptainCommand, MergeCaptainMockCommand, ModelInfoArgs,
     PackageArtifactsCommand, PackageCacheCommand, PackageCommand, PersonaCommand,
     PersonaSupervisionCommand, RunsCommand, ServeCommand, SkillCommand, SkillKeyCommand,
-    SkillTrustCommand, SkillsCommand,
+    SkillTrustCommand, SkillsCommand, ToolCommand,
 };
 use harn_lexer::Lexer;
 use harn_parser::{DiagnosticSeverity, Parser, TypeChecker};
@@ -111,6 +111,7 @@ async fn async_main() {
                 SkillTrustCommand::Add(add) => commands::skill::run_trust_add(&add),
                 SkillTrustCommand::List(list) => commands::skill::run_trust_list(&list),
             },
+            SkillCommand::New(new_args) => commands::skills::run_new(&new_args),
         },
         Command::Run(args) => {
             if !args.explain_cost {
@@ -784,6 +785,8 @@ async fn async_main() {
         Command::Remove(args) => package::remove_package(&args.alias),
         Command::Lock => package::lock_packages(),
         Command::Package(args) => match args.command {
+            PackageCommand::List(list) => package::list_packages(list.json),
+            PackageCommand::Doctor(doctor) => package::doctor_packages(doctor.json),
             PackageCommand::Search(search) => package::search_package_registry(
                 search.query.as_deref(),
                 search.registry.as_deref(),
@@ -1026,6 +1029,14 @@ async fn async_main() {
             SkillsCommand::Match(matcher) => commands::skills::run_match(&matcher),
             SkillsCommand::Install(install) => commands::skills::run_install(&install),
             SkillsCommand::New(new_args) => commands::skills::run_new(&new_args),
+        },
+        Command::Tool(args) => match args.command {
+            ToolCommand::New(new_args) => {
+                if let Err(error) = commands::tool::run_new(&new_args) {
+                    eprintln!("error: {error}");
+                    process::exit(1);
+                }
+            }
         },
         Command::DumpHighlightKeywords(args) => {
             commands::dump_highlight_keywords::run(&args.output, args.check);

--- a/crates/harn-cli/src/package/lockfile.rs
+++ b/crates/harn-cli/src/package/lockfile.rs
@@ -57,6 +57,9 @@ pub(crate) struct LockEntry {
     /// current Harn line.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) harn_compat: Option<String>,
+    /// Package-authored provenance URL or identifier from `[package]`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) provenance: Option<String>,
     /// SHA-256 digest (`sha256:<hex>`) of the resolved package's
     /// `harn.toml`, separate from the full-contents `content_hash`. Lets
     /// audit detect manifest tampering without re-hashing the entire tree.
@@ -68,6 +71,12 @@ pub(crate) struct LockEntry {
     /// version.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) registry: Option<RegistryProvenance>,
+    #[serde(default, skip_serializing_if = "PackageLockExports::is_empty")]
+    pub(crate) exports: PackageLockExports,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) permissions: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) host_requirements: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -77,6 +86,36 @@ pub(crate) struct RegistryProvenance {
     pub(crate) version: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) provenance_url: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PackageLockExports {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub modules: Vec<PackageLockExport>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tools: Vec<PackageLockExport>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub skills: Vec<PackageLockExport>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub personas: Vec<String>,
+}
+
+impl PackageLockExports {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.modules.is_empty()
+            && self.tools.is_empty()
+            && self.skills.is_empty()
+            && self.personas.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PackageLockExport {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub symbol: Option<String>,
 }
 
 impl LockFile {
@@ -101,10 +140,10 @@ impl LockFile {
                 lock.sort_entries();
                 Ok(Some(lock))
             }
-            Some(1) => {
-                // v1 bump migration: load with the same struct (the new
-                // fields default), then stamp the version so the next save
-                // rewrites in v2 with provenance fully populated.
+            Some(1 | 2) => {
+                // Older lockfile versions load through the current struct
+                // because added fields are optional. Saving stamps the current
+                // version and enriches provenance on the next install.
                 let mut lock: Self = toml::from_str(&content)
                     .map_err(|error| format!("failed to parse {}: {error}", path.display()))?;
                 lock.version = LOCK_FILE_VERSION;
@@ -140,8 +179,12 @@ impl LockFile {
                             content_hash: None,
                             package_version: None,
                             harn_compat: None,
+                            provenance: None,
                             manifest_digest: None,
                             registry: None,
+                            exports: PackageLockExports::default(),
+                            permissions: Vec::new(),
+                            host_requirements: Vec::new(),
                         })
                         .collect(),
                 };
@@ -287,7 +330,11 @@ pub(crate) fn read_package_manifest_from_dir(dir: &Path) -> Result<Option<Manife
 pub(crate) struct LockEntryProvenance {
     pub(crate) package_version: Option<String>,
     pub(crate) harn_compat: Option<String>,
+    pub(crate) provenance: Option<String>,
     pub(crate) manifest_digest: Option<String>,
+    pub(crate) exports: PackageLockExports,
+    pub(crate) permissions: Vec<String>,
+    pub(crate) host_requirements: Vec<String>,
 }
 
 pub(crate) fn read_lock_entry_provenance(
@@ -301,22 +348,106 @@ pub(crate) fn read_lock_entry_provenance(
         .map_err(|error| format!("failed to read {}: {error}", manifest_path.display()))?;
     let digest = format!("sha256:{}", sha256_hex(&bytes));
     let manifest = read_manifest_from_path(&manifest_path)?;
-    let (package_version, harn_compat) = manifest
+    let (package_version, harn_compat, provenance, permissions, host_requirements) = manifest
         .package
         .as_ref()
-        .map(|info| (info.version.clone(), info.harn.clone()))
-        .unwrap_or((None, None));
+        .map(|info| {
+            (
+                info.version.clone(),
+                info.harn.clone(),
+                info.provenance.clone(),
+                info.permissions.clone(),
+                info.host_requirements.clone(),
+            )
+        })
+        .unwrap_or((None, None, None, Vec::new(), Vec::new()));
     Ok(LockEntryProvenance {
         package_version,
         harn_compat,
+        provenance,
         manifest_digest: Some(digest),
+        exports: package_lock_exports_from_manifest(&manifest),
+        permissions: normalized_requirements(&permissions),
+        host_requirements: normalized_requirements(&host_requirements),
     })
 }
 
 fn fill_provenance(entry: &mut LockEntry, provenance: LockEntryProvenance) {
     entry.package_version = provenance.package_version;
     entry.harn_compat = provenance.harn_compat;
+    entry.provenance = provenance.provenance;
     entry.manifest_digest = provenance.manifest_digest;
+    entry.exports = provenance.exports;
+    entry.permissions = provenance.permissions;
+    entry.host_requirements = provenance.host_requirements;
+}
+
+pub(crate) fn package_lock_exports_from_manifest(manifest: &Manifest) -> PackageLockExports {
+    let mut modules: Vec<PackageLockExport> = manifest
+        .exports
+        .iter()
+        .map(|(name, path)| PackageLockExport {
+            name: name.clone(),
+            path: Some(path.clone()),
+            symbol: None,
+        })
+        .collect();
+    modules.sort_by(|left, right| left.name.cmp(&right.name));
+
+    let (mut tools, mut skills) = manifest
+        .package
+        .as_ref()
+        .map(|package| {
+            let tools = package
+                .tools
+                .iter()
+                .map(|tool| PackageLockExport {
+                    name: tool.name.clone(),
+                    path: Some(tool.module.clone()),
+                    symbol: Some(tool.symbol.clone()),
+                })
+                .collect::<Vec<_>>();
+            let skills = package
+                .skills
+                .iter()
+                .map(|skill| PackageLockExport {
+                    name: skill.name.clone(),
+                    path: Some(skill.path.clone()),
+                    symbol: None,
+                })
+                .collect::<Vec<_>>();
+            (tools, skills)
+        })
+        .unwrap_or_default();
+    tools.sort_by(|left, right| left.name.cmp(&right.name));
+    skills.sort_by(|left, right| left.name.cmp(&right.name));
+
+    let mut personas: Vec<String> = manifest
+        .personas
+        .iter()
+        .filter_map(|persona| persona.name.clone())
+        .collect();
+    personas.sort();
+    personas.dedup();
+
+    PackageLockExports {
+        modules,
+        tools,
+        skills,
+        personas,
+    }
+}
+
+pub(crate) fn normalized_requirements(values: &[String]) -> Vec<String> {
+    let mut out: Vec<String> = values
+        .iter()
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .collect();
+    out.sort();
+    out.dedup();
+    out
 }
 
 pub(crate) fn dependency_conflict_message(
@@ -455,7 +586,10 @@ pub(crate) fn build_lockfile(
                         offline,
                     )?;
                     let cache_dir = git_cache_dir_in(workspace, &entry.source, commit)?;
-                    if entry.manifest_digest.is_none() || entry.package_version.is_none() {
+                    if entry.manifest_digest.is_none()
+                        || entry.package_version.is_none()
+                        || entry.provenance.is_none()
+                    {
                         fill_provenance(&mut entry, read_lock_entry_provenance(&cache_dir)?);
                     }
                     if entry.registry.is_none() {
@@ -476,7 +610,10 @@ pub(crate) fn build_lockfile(
                 } else if entry.source.starts_with("path+") {
                     let source = path_from_source_uri(&entry.source)?;
                     let manifest_dir = dependency_manifest_dir(&source);
-                    if entry.manifest_digest.is_none() || entry.package_version.is_none() {
+                    if entry.manifest_digest.is_none()
+                        || entry.package_version.is_none()
+                        || entry.provenance.is_none()
+                    {
                         if let Some(dir) = manifest_dir.as_deref() {
                             fill_provenance(&mut entry, read_lock_entry_provenance(dir)?);
                         }
@@ -523,8 +660,12 @@ pub(crate) fn build_lockfile(
                 content_hash: None,
                 package_version: None,
                 harn_compat: None,
+                provenance: None,
                 manifest_digest: None,
                 registry: None,
+                exports: PackageLockExports::default(),
+                permissions: Vec::new(),
+                host_requirements: Vec::new(),
             };
             fill_provenance(&mut entry, provenance);
             let inserted = replace_lock_entry(&mut lock, entry)?;
@@ -569,8 +710,12 @@ pub(crate) fn build_lockfile(
                 content_hash: Some(content_hash),
                 package_version: None,
                 harn_compat: None,
+                provenance: None,
                 manifest_digest: None,
                 registry: dependency.registry_provenance(),
+                exports: PackageLockExports::default(),
+                permissions: Vec::new(),
+                host_requirements: Vec::new(),
             };
             fill_provenance(&mut entry, provenance);
             let inserted = replace_lock_entry(&mut lock, entry)?;
@@ -1285,8 +1430,27 @@ mod tests {
                 content_hash: Some("sha256:deadbeef".to_string()),
                 package_version: Some("1.0.0".to_string()),
                 harn_compat: Some(">=0.8,<0.9".to_string()),
+                provenance: Some(
+                    "https://github.com/acme/acme-lib/releases/tag/v1.0.0".to_string(),
+                ),
                 manifest_digest: Some("sha256:cafebabe".to_string()),
                 registry: None,
+                exports: PackageLockExports {
+                    modules: vec![PackageLockExport {
+                        name: "lib".to_string(),
+                        path: Some("lib/main.harn".to_string()),
+                        symbol: None,
+                    }],
+                    tools: vec![PackageLockExport {
+                        name: "echo".to_string(),
+                        path: Some("lib/tools.harn".to_string()),
+                        symbol: Some("tools".to_string()),
+                    }],
+                    skills: Vec::new(),
+                    personas: Vec::new(),
+                },
+                permissions: vec!["tool:read_only".to_string()],
+                host_requirements: vec!["workspace.read_text".to_string()],
             }],
         };
         lock.save(&path).unwrap();

--- a/crates/harn-cli/src/package/manifest.rs
+++ b/crates/harn-cli/src/package/manifest.rs
@@ -686,6 +686,52 @@ pub struct PackageInfo {
     pub harn: Option<String>,
     #[serde(default)]
     pub docs_url: Option<String>,
+    #[serde(default)]
+    pub provenance: Option<String>,
+    #[serde(default)]
+    pub permissions: Vec<String>,
+    #[serde(default, alias = "host-requirements")]
+    pub host_requirements: Vec<String>,
+    #[serde(default)]
+    pub tools: Vec<PackageToolExport>,
+    #[serde(default)]
+    pub skills: Vec<PackageSkillExport>,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct PackageToolExport {
+    pub name: String,
+    pub module: String,
+    #[serde(default = "default_package_tool_symbol")]
+    pub symbol: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub permissions: Vec<String>,
+    #[serde(default, alias = "host-requirements")]
+    pub host_requirements: Vec<String>,
+    #[serde(default, alias = "input-schema")]
+    pub input_schema: Option<toml::Value>,
+    #[serde(default, alias = "output-schema")]
+    pub output_schema: Option<toml::Value>,
+    #[serde(default)]
+    pub annotations: BTreeMap<String, toml::Value>,
+}
+
+pub(crate) fn default_package_tool_symbol() -> String {
+    "tools".to_string()
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct PackageSkillExport {
+    pub name: String,
+    pub path: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub permissions: Vec<String>,
+    #[serde(default, alias = "host-requirements")]
+    pub host_requirements: Vec<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/harn-cli/src/package/mod.rs
+++ b/crates/harn-cli/src/package/mod.rs
@@ -21,7 +21,7 @@ const HARN_CACHE_DIR_ENV: &str = "HARN_CACHE_DIR";
 const HARN_PACKAGE_REGISTRY_ENV: &str = "HARN_PACKAGE_REGISTRY";
 const DEFAULT_PACKAGE_REGISTRY_URL: &str = "https://packages.harnlang.com/index.toml";
 const CACHE_METADATA_VERSION: u32 = 1;
-const LOCK_FILE_VERSION: u32 = 2;
+const LOCK_FILE_VERSION: u32 = 3;
 const REGISTRY_INDEX_VERSION: u32 = 1;
 const PKG_DIR: &str = ".harn/packages";
 const MANIFEST: &str = "harn.toml";
@@ -47,7 +47,7 @@ pub use lockfile::add_package;
 pub(crate) use lockfile::*;
 pub use lockfile::{
     add_package_with_registry, ensure_dependencies_materialized, install_packages, lock_packages,
-    remove_package, update_packages,
+    remove_package, update_packages, PackageLockExport, PackageLockExports,
 };
 pub use manifest::*;
 pub use maturity::{

--- a/crates/harn-cli/src/package/package_ops.rs
+++ b/crates/harn-cli/src/package/package_ops.rs
@@ -10,6 +10,8 @@ pub struct PackageCheckReport {
     pub errors: Vec<PackageCheckDiagnostic>,
     pub warnings: Vec<PackageCheckDiagnostic>,
     pub exports: Vec<PackageExportReport>,
+    pub tools: Vec<PackageToolExportReport>,
+    pub skills: Vec<PackageSkillExportReport>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -23,6 +25,23 @@ pub struct PackageExportReport {
     pub name: String,
     pub path: String,
     pub symbols: Vec<PackageApiSymbol>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PackageToolExportReport {
+    pub name: String,
+    pub module: String,
+    pub symbol: String,
+    pub permissions: Vec<String>,
+    pub host_requirements: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PackageSkillExportReport {
+    pub name: String,
+    pub path: String,
+    pub permissions: Vec<String>,
+    pub host_requirements: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -49,6 +68,47 @@ pub struct PackagePublishReport {
     pub artifact_dir: String,
     pub files: Vec<String>,
     pub check: PackageCheckReport,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PackageListReport {
+    pub manifest_path: String,
+    pub lock_path: String,
+    pub lock_present: bool,
+    pub dependency_count: usize,
+    pub packages: Vec<PackageListEntry>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PackageListEntry {
+    pub name: String,
+    pub source: String,
+    pub package_version: Option<String>,
+    pub harn_compat: Option<String>,
+    pub provenance: Option<String>,
+    pub materialized: bool,
+    pub integrity: String,
+    pub exports: PackageLockExports,
+    pub permissions: Vec<String>,
+    pub host_requirements: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PackageDoctorReport {
+    pub ok: bool,
+    pub manifest_path: String,
+    pub lock_path: String,
+    pub diagnostics: Vec<PackageDoctorDiagnostic>,
+    pub packages: Vec<PackageListEntry>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PackageDoctorDiagnostic {
+    pub severity: String,
+    pub code: String,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub help: Option<String>,
 }
 
 pub fn check_package(anchor: Option<&Path>, json: bool) {
@@ -125,6 +185,48 @@ pub fn publish_package(anchor: Option<&Path>, dry_run: bool, registry: Option<&s
                 println!("Dry-run publish to {} succeeded.", report.registry);
                 println!("artifact: {}", report.artifact_dir);
                 println!("files: {}", report.files.len());
+            }
+        }
+        Err(error) => {
+            eprintln!("error: {error}");
+            process::exit(1);
+        }
+    }
+}
+
+pub fn list_packages(json: bool) {
+    match list_packages_impl() {
+        Ok(report) if json => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&report)
+                    .unwrap_or_else(|error| format!(r#"{{"error":"{error}"}}"#))
+            );
+        }
+        Ok(report) => print_package_list_report(&report),
+        Err(error) => {
+            eprintln!("error: {error}");
+            process::exit(1);
+        }
+    }
+}
+
+pub fn doctor_packages(json: bool) {
+    match doctor_packages_impl() {
+        Ok(report) if json => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&report)
+                    .unwrap_or_else(|error| format!(r#"{{"error":"{error}"}}"#))
+            );
+            if !report.ok {
+                process::exit(1);
+            }
+        }
+        Ok(report) => {
+            print_package_doctor_report(&report);
+            if !report.ok {
+                process::exit(1);
             }
         }
         Err(error) => {
@@ -218,6 +320,7 @@ pub(crate) fn check_package_impl(
         push_error(&mut errors, "handoff_routes", error.to_string());
     }
     let exports = validate_exports_for_publish(&ctx, &mut errors, &mut warnings);
+    let (tools, skills) = validate_package_interface_exports(&ctx, &mut errors, &mut warnings);
 
     Ok(PackageCheckReport {
         package_dir: ctx.dir.display().to_string(),
@@ -227,7 +330,287 @@ pub(crate) fn check_package_impl(
         errors,
         warnings,
         exports,
+        tools,
+        skills,
     })
+}
+
+pub(crate) fn list_packages_impl() -> Result<PackageListReport, PackageError> {
+    let workspace = PackageWorkspace::from_current_dir()?;
+    list_packages_in(&workspace)
+}
+
+fn list_packages_in(workspace: &PackageWorkspace) -> Result<PackageListReport, PackageError> {
+    let ctx = workspace.load_manifest_context()?;
+    let lock_path = ctx.lock_path();
+    let lock = LockFile::load(&lock_path)?;
+    let packages = lock
+        .as_ref()
+        .map(|lock| package_list_entries(&ctx, lock))
+        .unwrap_or_default();
+    Ok(PackageListReport {
+        manifest_path: ctx.manifest_path().display().to_string(),
+        lock_path: lock_path.display().to_string(),
+        lock_present: lock.is_some(),
+        dependency_count: ctx.manifest.dependencies.len(),
+        packages,
+    })
+}
+
+pub(crate) fn doctor_packages_impl() -> Result<PackageDoctorReport, PackageError> {
+    let workspace = PackageWorkspace::from_current_dir()?;
+    doctor_packages_in(&workspace)
+}
+
+fn doctor_packages_in(workspace: &PackageWorkspace) -> Result<PackageDoctorReport, PackageError> {
+    let ctx = workspace.load_manifest_context()?;
+    let lock_path = ctx.lock_path();
+    let mut diagnostics = Vec::new();
+
+    let mut root_errors = Vec::new();
+    let mut root_warnings = Vec::new();
+    if let Some(package) = ctx.manifest.package.as_ref() {
+        if let Some(name) = package.name.as_ref() {
+            if let Err(message) = validate_package_alias(name) {
+                push_error(&mut root_errors, "[package].name", message);
+            }
+        }
+    }
+    validate_package_interface_exports(&ctx, &mut root_errors, &mut root_warnings);
+    for diagnostic in root_errors {
+        diagnostics.push(package_doctor_diagnostic(
+            "error",
+            "root-package-contract",
+            format!("{}: {}", diagnostic.field, diagnostic.message),
+            Some("fix install-facing package metadata in harn.toml"),
+        ));
+    }
+    for diagnostic in root_warnings {
+        diagnostics.push(package_doctor_diagnostic(
+            "warning",
+            "root-package-contract",
+            format!("{}: {}", diagnostic.field, diagnostic.message),
+            None::<String>,
+        ));
+    }
+
+    let lock = LockFile::load(&lock_path)?;
+    if ctx.manifest.dependencies.is_empty() {
+        diagnostics.push(package_doctor_diagnostic(
+            "info",
+            "no-dependencies",
+            "manifest has no package dependencies",
+            None::<String>,
+        ));
+    } else if lock.is_none() {
+        diagnostics.push(package_doctor_diagnostic(
+            "error",
+            "missing-lockfile",
+            format!("{} is missing", lock_path.display()),
+            Some("run `harn install` to resolve dependencies and write harn.lock"),
+        ));
+    }
+
+    if let Some(lock) = lock.as_ref() {
+        if let Err(error) = validate_lock_matches_manifest(&ctx, lock) {
+            diagnostics.push(package_doctor_diagnostic(
+                "error",
+                "stale-lockfile",
+                error.to_string(),
+                Some("run `harn install` to refresh harn.lock"),
+            ));
+        }
+        for entry in &lock.packages {
+            validate_installed_package_entry(&ctx, entry, &mut diagnostics);
+        }
+    }
+
+    let packages = lock
+        .as_ref()
+        .map(|lock| package_list_entries(&ctx, lock))
+        .unwrap_or_default();
+    let ok = diagnostics
+        .iter()
+        .all(|diagnostic| diagnostic.severity != "error");
+    Ok(PackageDoctorReport {
+        ok,
+        manifest_path: ctx.manifest_path().display().to_string(),
+        lock_path: lock_path.display().to_string(),
+        diagnostics,
+        packages,
+    })
+}
+
+fn package_list_entries(ctx: &ManifestContext, lock: &LockFile) -> Vec<PackageListEntry> {
+    lock.packages
+        .iter()
+        .map(|entry| {
+            let materialized = materialized_package_exists(ctx, entry);
+            PackageListEntry {
+                name: entry.name.clone(),
+                source: entry.source.clone(),
+                package_version: entry.package_version.clone(),
+                harn_compat: entry.harn_compat.clone(),
+                provenance: entry.provenance.clone(),
+                materialized,
+                integrity: package_integrity_status(ctx, entry),
+                exports: entry.exports.clone(),
+                permissions: entry.permissions.clone(),
+                host_requirements: entry.host_requirements.clone(),
+            }
+        })
+        .collect()
+}
+
+fn materialized_package_path(ctx: &ManifestContext, entry: &LockEntry) -> PathBuf {
+    let packages_dir = ctx.packages_dir();
+    let dir = packages_dir.join(&entry.name);
+    if dir.exists() {
+        return dir;
+    }
+    packages_dir.join(format!("{}.harn", entry.name))
+}
+
+fn materialized_package_exists(ctx: &ManifestContext, entry: &LockEntry) -> bool {
+    materialized_package_path(ctx, entry).exists()
+}
+
+fn package_integrity_status(ctx: &ManifestContext, entry: &LockEntry) -> String {
+    if !materialized_package_exists(ctx, entry) {
+        return "missing".to_string();
+    }
+    let Some(expected) = entry.content_hash.as_deref() else {
+        return "not_checked".to_string();
+    };
+    let path = materialized_package_path(ctx, entry);
+    if path.is_dir() && materialized_hash_matches(&path, expected) {
+        "ok".to_string()
+    } else {
+        "mismatch".to_string()
+    }
+}
+
+fn validate_installed_package_entry(
+    ctx: &ManifestContext,
+    entry: &LockEntry,
+    diagnostics: &mut Vec<PackageDoctorDiagnostic>,
+) {
+    let materialized_path = materialized_package_path(ctx, entry);
+    if !materialized_path.exists() {
+        diagnostics.push(package_doctor_diagnostic(
+            "error",
+            "package-not-materialized",
+            format!(
+                "package {} is locked but missing from {}",
+                entry.name,
+                ctx.packages_dir().display()
+            ),
+            Some("run `harn install` to materialize locked packages"),
+        ));
+        return;
+    }
+
+    if package_integrity_status(ctx, entry) == "mismatch" {
+        diagnostics.push(package_doctor_diagnostic(
+            "error",
+            "content-hash-mismatch",
+            format!(
+                "package {} does not match its locked content hash",
+                entry.name
+            ),
+            Some(
+                "run `harn install --refetch {alias}` or inspect local tampering"
+                    .replace("{alias}", &entry.name),
+            ),
+        ));
+    }
+
+    for requirement in &entry.host_requirements {
+        if !host_requirement_satisfied(&ctx.manifest.check, requirement) {
+            diagnostics.push(package_doctor_diagnostic(
+                "error",
+                "missing-host-capability",
+                format!(
+                    "package {} requires host capability {requirement}, but harn.toml does not declare it",
+                    entry.name
+                ),
+                Some("add the capability under [check.host_capabilities] or preflight_allow after the host implements it"),
+            ));
+        }
+    }
+
+    if materialized_path.is_dir() {
+        match read_package_manifest_from_dir(&materialized_path) {
+            Ok(Some(manifest)) => {
+                let installed_ctx = ManifestContext {
+                    manifest,
+                    dir: materialized_path,
+                };
+                let mut errors = Vec::new();
+                let mut warnings = Vec::new();
+                validate_package_interface_exports(&installed_ctx, &mut errors, &mut warnings);
+                for diagnostic in errors {
+                    diagnostics.push(package_doctor_diagnostic(
+                        "error",
+                        "installed-package-export",
+                        format!("{}: {}", diagnostic.field, diagnostic.message),
+                        Some(format!("fix package {} and reinstall it", entry.name)),
+                    ));
+                }
+                for diagnostic in warnings {
+                    diagnostics.push(package_doctor_diagnostic(
+                        "warning",
+                        "installed-package-export-warning",
+                        format!("{}: {}", diagnostic.field, diagnostic.message),
+                        None::<String>,
+                    ));
+                }
+            }
+            Ok(None) => {}
+            Err(error) => diagnostics.push(package_doctor_diagnostic(
+                "error",
+                "installed-manifest-unreadable",
+                format!("failed to read package {} manifest: {error}", entry.name),
+                Some("repair the package source and run `harn install`"),
+            )),
+        }
+    }
+}
+
+fn host_requirement_satisfied(check: &CheckConfig, requirement: &str) -> bool {
+    if check.preflight_allow.iter().any(|allow| {
+        allow == "*"
+            || allow == requirement
+            || requirement
+                .strip_prefix(allow.trim_end_matches(".*"))
+                .is_some_and(|rest| allow.ends_with(".*") && rest.starts_with('.'))
+            || requirement
+                .split_once('.')
+                .is_some_and(|(capability, _)| allow == capability)
+    }) {
+        return true;
+    }
+    let Some((capability, operation)) = requirement.split_once('.') else {
+        return false;
+    };
+    check
+        .host_capabilities
+        .get(capability)
+        .is_some_and(|ops| ops.iter().any(|op| op == "*" || op == operation))
+}
+
+fn package_doctor_diagnostic(
+    severity: impl Into<String>,
+    code: impl Into<String>,
+    message: impl Into<String>,
+    help: Option<impl Into<String>>,
+) -> PackageDoctorDiagnostic {
+    PackageDoctorDiagnostic {
+        severity: severity.into(),
+        code: code.into(),
+        message: message.into(),
+        help: help.map(Into::into),
+    }
 }
 
 pub(crate) fn pack_package_impl(
@@ -553,6 +936,354 @@ pub(crate) fn validate_exports_for_publish(
     exports
 }
 
+pub(crate) fn validate_package_interface_exports(
+    ctx: &ManifestContext,
+    errors: &mut Vec<PackageCheckDiagnostic>,
+    warnings: &mut Vec<PackageCheckDiagnostic>,
+) -> (Vec<PackageToolExportReport>, Vec<PackageSkillExportReport>) {
+    let Some(package) = ctx.manifest.package.as_ref() else {
+        return (Vec::new(), Vec::new());
+    };
+
+    validate_permission_tokens(
+        &package.permissions,
+        "[package].permissions",
+        errors,
+        warnings,
+    );
+    validate_host_requirements(
+        &package.host_requirements,
+        "[package].host_requirements",
+        errors,
+    );
+
+    let mut tools = Vec::new();
+    for (index, tool) in package.tools.iter().enumerate() {
+        let field = format!("[[package.tools]] #{}", index + 1);
+        if let Err(message) = validate_package_alias(&tool.name) {
+            push_error(errors, format!("{field}.name"), message.to_string());
+        }
+        validate_required_manifest_string(&tool.module, &format!("{field}.module"), errors);
+        validate_required_manifest_string(&tool.symbol, &format!("{field}.symbol"), errors);
+        validate_package_module_path(ctx, &tool.module, &format!("{field}.module"), errors);
+        validate_permission_tokens(
+            &tool.permissions,
+            &format!("{field}.permissions"),
+            errors,
+            warnings,
+        );
+        validate_host_requirements(
+            &tool.host_requirements,
+            &format!("{field}.host_requirements"),
+            errors,
+        );
+        validate_schema_value(
+            tool.input_schema.as_ref(),
+            &format!("{field}.input_schema"),
+            errors,
+        );
+        validate_schema_value(
+            tool.output_schema.as_ref(),
+            &format!("{field}.output_schema"),
+            errors,
+        );
+        validate_tool_annotations(&tool.annotations, &format!("{field}.annotations"), errors);
+        if tool.annotations.is_empty() {
+            push_warning(
+                warnings,
+                format!("{field}.annotations"),
+                "tool export has no annotations; policy evaluation will treat it conservatively",
+            );
+        }
+        tools.push(PackageToolExportReport {
+            name: tool.name.clone(),
+            module: tool.module.clone(),
+            symbol: tool.symbol.clone(),
+            permissions: merge_package_requirements(&package.permissions, &tool.permissions),
+            host_requirements: merge_package_requirements(
+                &package.host_requirements,
+                &tool.host_requirements,
+            ),
+        });
+    }
+    tools.sort_by(|left, right| left.name.cmp(&right.name));
+
+    let mut skills = Vec::new();
+    for (index, skill) in package.skills.iter().enumerate() {
+        let field = format!("[[package.skills]] #{}", index + 1);
+        if let Err(message) = validate_package_alias(&skill.name) {
+            push_error(errors, format!("{field}.name"), message.to_string());
+        }
+        validate_required_manifest_string(&skill.path, &format!("{field}.path"), errors);
+        validate_package_skill_path(ctx, &skill.path, &format!("{field}.path"), errors);
+        validate_permission_tokens(
+            &skill.permissions,
+            &format!("{field}.permissions"),
+            errors,
+            warnings,
+        );
+        validate_host_requirements(
+            &skill.host_requirements,
+            &format!("{field}.host_requirements"),
+            errors,
+        );
+        skills.push(PackageSkillExportReport {
+            name: skill.name.clone(),
+            path: skill.path.clone(),
+            permissions: merge_package_requirements(&package.permissions, &skill.permissions),
+            host_requirements: merge_package_requirements(
+                &package.host_requirements,
+                &skill.host_requirements,
+            ),
+        });
+    }
+    skills.sort_by(|left, right| left.name.cmp(&right.name));
+
+    (tools, skills)
+}
+
+pub(crate) fn merge_package_requirements(base: &[String], item: &[String]) -> Vec<String> {
+    let mut merged = BTreeSet::new();
+    merged.extend(
+        base.iter()
+            .filter_map(|value| normalized_requirement(value)),
+    );
+    merged.extend(
+        item.iter()
+            .filter_map(|value| normalized_requirement(value)),
+    );
+    merged.into_iter().collect()
+}
+
+fn normalized_requirement(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
+}
+
+fn validate_required_manifest_string(
+    value: &str,
+    field: &str,
+    errors: &mut Vec<PackageCheckDiagnostic>,
+) {
+    if value.trim().is_empty() {
+        push_error(errors, field, format!("missing required {field}"));
+    }
+}
+
+fn validate_permission_tokens(
+    permissions: &[String],
+    field: &str,
+    errors: &mut Vec<PackageCheckDiagnostic>,
+    warnings: &mut Vec<PackageCheckDiagnostic>,
+) {
+    let mut seen = BTreeSet::new();
+    for permission in permissions {
+        let trimmed = permission.trim();
+        if trimmed.is_empty() {
+            push_error(errors, field, "permission entries cannot be empty");
+            continue;
+        }
+        if trimmed.chars().any(char::is_whitespace) {
+            push_error(
+                errors,
+                field,
+                format!("permission {permission:?} cannot contain whitespace"),
+            );
+        }
+        if !trimmed.contains(':') && !trimmed.contains('.') {
+            push_warning(
+                warnings,
+                field,
+                format!("permission {permission:?} should use a namespaced token"),
+            );
+        }
+        if !seen.insert(trimmed.to_string()) {
+            push_warning(
+                warnings,
+                field,
+                format!("duplicate permission {permission:?}"),
+            );
+        }
+    }
+}
+
+pub(crate) fn validate_host_requirements(
+    requirements: &[String],
+    field: &str,
+    errors: &mut Vec<PackageCheckDiagnostic>,
+) {
+    let mut seen = BTreeSet::new();
+    for requirement in requirements {
+        let trimmed = requirement.trim();
+        if trimmed.is_empty() {
+            push_error(errors, field, "host requirement entries cannot be empty");
+            continue;
+        }
+        let Some((capability, operation)) = trimmed.split_once('.') else {
+            push_error(
+                errors,
+                field,
+                format!("host requirement {requirement:?} must use capability.operation"),
+            );
+            continue;
+        };
+        if !valid_identifier(capability)
+            || !(valid_identifier(operation) || operation == "*")
+            || trimmed.matches('.').count() != 1
+        {
+            push_error(
+                errors,
+                field,
+                format!("host requirement {requirement:?} must use valid capability.operation identifiers"),
+            );
+        }
+        if !seen.insert(trimmed.to_string()) {
+            push_error(
+                errors,
+                field,
+                format!("duplicate host requirement {requirement:?}"),
+            );
+        }
+    }
+}
+
+fn validate_package_module_path(
+    ctx: &ManifestContext,
+    rel_path: &str,
+    field: &str,
+    errors: &mut Vec<PackageCheckDiagnostic>,
+) {
+    let Ok(path) = safe_package_relative_path(&ctx.dir, rel_path) else {
+        push_error(errors, field, "module path must stay inside the package");
+        return;
+    };
+    if path.extension() != Some(OsStr::new("harn")) {
+        push_error(errors, field, "module path must point at a .harn file");
+        return;
+    }
+    match fs::read_to_string(&path) {
+        Ok(content) => {
+            if let Err(error) = parse_harn_source(&content) {
+                push_error(errors, field, format!("failed to parse module: {error}"));
+            }
+        }
+        Err(error) => push_error(
+            errors,
+            field,
+            format!("failed to read module {}: {error}", path.display()),
+        ),
+    }
+}
+
+fn validate_package_skill_path(
+    ctx: &ManifestContext,
+    rel_path: &str,
+    field: &str,
+    errors: &mut Vec<PackageCheckDiagnostic>,
+) {
+    let Ok(path) = safe_package_relative_path(&ctx.dir, rel_path) else {
+        push_error(errors, field, "skill path must stay inside the package");
+        return;
+    };
+    let skill_file = if path.is_dir() {
+        path.join("SKILL.md")
+    } else {
+        path.clone()
+    };
+    if skill_file.file_name() != Some(OsStr::new("SKILL.md")) {
+        push_error(
+            errors,
+            field,
+            "skill path must be a SKILL.md file or skill directory",
+        );
+        return;
+    }
+    match fs::read_to_string(&skill_file) {
+        Ok(content) => {
+            let (frontmatter, _) = harn_vm::skills::split_frontmatter(&content);
+            if let Err(error) = harn_vm::skills::parse_frontmatter(frontmatter) {
+                push_error(
+                    errors,
+                    field,
+                    format!("invalid SKILL.md frontmatter: {error}"),
+                );
+            }
+        }
+        Err(error) => push_error(
+            errors,
+            field,
+            format!("failed to read skill {}: {error}", skill_file.display()),
+        ),
+    }
+}
+
+fn validate_schema_value(
+    value: Option<&toml::Value>,
+    field: &str,
+    errors: &mut Vec<PackageCheckDiagnostic>,
+) {
+    let Some(value) = value else {
+        return;
+    };
+    let json = match toml_value_to_json(value) {
+        Ok(json) => json,
+        Err(error) => {
+            push_error(errors, field, error);
+            return;
+        }
+    };
+    let Some(object) = json.as_object() else {
+        push_error(errors, field, "schema must be a table/object");
+        return;
+    };
+    if let Some(schema_type) = object.get("type") {
+        if !schema_type.is_string() {
+            push_error(errors, field, "schema `type` must be a string when present");
+        }
+    }
+    if let Some(required) = object.get("required") {
+        let valid = required
+            .as_array()
+            .is_some_and(|items| items.iter().all(|item| item.as_str().is_some()));
+        if !valid {
+            push_error(errors, field, "schema `required` must be a list of strings");
+        }
+    }
+}
+
+fn validate_tool_annotations(
+    annotations: &BTreeMap<String, toml::Value>,
+    field: &str,
+    errors: &mut Vec<PackageCheckDiagnostic>,
+) {
+    if annotations.is_empty() {
+        return;
+    }
+    let json = match toml_value_to_json(&toml::Value::Table(
+        annotations
+            .clone()
+            .into_iter()
+            .collect::<toml::map::Map<String, toml::Value>>(),
+    )) {
+        Ok(json) => json,
+        Err(error) => {
+            push_error(errors, field, error);
+            return;
+        }
+    };
+    if let Err(error) = serde_json::from_value::<harn_vm::tool_annotations::ToolAnnotations>(json) {
+        push_error(
+            errors,
+            field,
+            format!("annotations do not match ToolAnnotations: {error}"),
+        );
+    }
+}
+
+fn toml_value_to_json(value: &toml::Value) -> Result<serde_json::Value, String> {
+    serde_json::to_value(value).map_err(|error| format!("failed to normalize TOML value: {error}"))
+}
+
 pub(crate) fn parse_harn_source(source: &str) -> Result<(), PackageError> {
     let mut lexer = harn_lexer::Lexer::new(source);
     let tokens = lexer.tokenize().map_err(|error| error.to_string())?;
@@ -838,6 +1569,33 @@ pub(crate) fn render_package_api_docs(report: &PackageCheckReport) -> String {
             out.push_str("\n```\n");
         }
     }
+    if !report.tools.is_empty() {
+        out.push_str("\n## Tool Exports\n");
+        for tool in &report.tools {
+            out.push_str(&format!(
+                "\n### `{}`\n\n- module: `{}`\n- symbol: `{}`\n",
+                tool.name, tool.module, tool.symbol
+            ));
+            if !tool.permissions.is_empty() {
+                out.push_str(&format!(
+                    "- permissions: `{}`\n",
+                    tool.permissions.join("`, `")
+                ));
+            }
+            if !tool.host_requirements.is_empty() {
+                out.push_str(&format!(
+                    "- host requirements: `{}`\n",
+                    tool.host_requirements.join("`, `")
+                ));
+            }
+        }
+    }
+    if !report.skills.is_empty() {
+        out.push_str("\n## Skill Exports\n");
+        for skill in &report.skills {
+            out.push_str(&format!("\n### `{}`\n\n`{}`\n", skill.name, skill.path));
+        }
+    }
     out
 }
 
@@ -859,6 +1617,12 @@ pub(crate) fn print_package_check_report(report: &PackageCheckReport) {
             export.path,
             export.symbols.len()
         );
+    }
+    for tool in &report.tools {
+        println!("tool {} -> {}::{}", tool.name, tool.module, tool.symbol);
+    }
+    for skill in &report.skills {
+        println!("skill {} -> {}", skill.name, skill.path);
     }
     if !report.warnings.is_empty() {
         println!("\nwarnings:");
@@ -886,6 +1650,93 @@ pub(crate) fn print_package_pack_report(report: &PackagePackReport) {
     println!("files:");
     for file in &report.files {
         println!("- {file}");
+    }
+}
+
+pub(crate) fn print_package_list_report(report: &PackageListReport) {
+    println!("manifest: {}", report.manifest_path);
+    println!("lock: {}", report.lock_path);
+    if !report.lock_present {
+        println!("lock status: missing");
+        if report.dependency_count > 0 {
+            println!(
+                "run `harn install` to resolve {} dependency(s)",
+                report.dependency_count
+            );
+        }
+        return;
+    }
+    if report.packages.is_empty() {
+        println!("No packages installed.");
+        return;
+    }
+    println!("Packages ({}):", report.packages.len());
+    for entry in &report.packages {
+        let version = entry.package_version.as_deref().unwrap_or("unversioned");
+        let status = if entry.materialized {
+            "installed"
+        } else {
+            "missing"
+        };
+        println!(
+            "  {}  {}  {}  integrity={}",
+            entry.name, version, status, entry.integrity
+        );
+        if !entry.exports.modules.is_empty() {
+            let modules: Vec<&str> = entry
+                .exports
+                .modules
+                .iter()
+                .map(|export| export.name.as_str())
+                .collect();
+            println!("    modules: {}", modules.join(", "));
+        }
+        if !entry.exports.tools.is_empty() {
+            let tools: Vec<&str> = entry
+                .exports
+                .tools
+                .iter()
+                .map(|export| export.name.as_str())
+                .collect();
+            println!("    tools: {}", tools.join(", "));
+        }
+        if !entry.exports.skills.is_empty() {
+            let skills: Vec<&str> = entry
+                .exports
+                .skills
+                .iter()
+                .map(|export| export.name.as_str())
+                .collect();
+            println!("    skills: {}", skills.join(", "));
+        }
+        if !entry.permissions.is_empty() {
+            println!("    permissions: {}", entry.permissions.join(", "));
+        }
+        if !entry.host_requirements.is_empty() {
+            println!(
+                "    host requirements: {}",
+                entry.host_requirements.join(", ")
+            );
+        }
+    }
+}
+
+pub(crate) fn print_package_doctor_report(report: &PackageDoctorReport) {
+    println!("Package doctor");
+    println!("manifest: {}", report.manifest_path);
+    println!("lock: {}", report.lock_path);
+    if report.diagnostics.is_empty() {
+        println!("ok: no package issues found");
+        return;
+    }
+    for diagnostic in &report.diagnostics {
+        println!(
+            "{} [{}] {}",
+            diagnostic.severity, diagnostic.code, diagnostic.message
+        );
+        if let Some(help) = diagnostic.help.as_deref() {
+            println!("  help: {help}");
+        }
     }
 }
 
@@ -982,5 +1833,218 @@ mod tests {
         let pack = pack_package_impl(Some(tmp.path()), None, true).unwrap();
         assert!(pack.files.contains(&"harn.toml".to_string()));
         assert!(pack.files.contains(&"lib/main.harn".to_string()));
+    }
+
+    #[test]
+    fn package_check_validates_tool_and_skill_exports() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_publishable_package(tmp.path());
+        fs::create_dir_all(tmp.path().join("skills/review")).unwrap();
+        fs::write(
+            tmp.path().join("harn.toml"),
+            format!(
+                r#"[package]
+name = "acme-lib"
+version = "0.1.0"
+description = "Acme helpers"
+license = "MIT"
+repository = "https://github.com/acme/acme-lib"
+harn = "{}"
+docs_url = "docs/api.md"
+permissions = ["tool:read_only"]
+host_requirements = ["workspace.read_text"]
+
+[exports]
+lib = "lib/main.harn"
+
+[[package.tools]]
+name = "read-note"
+module = "lib/main.harn"
+symbol = "tools"
+permissions = ["tool:read_only"]
+
+[package.tools.input_schema]
+type = "object"
+required = ["path"]
+
+[package.tools.annotations]
+kind = "read"
+side_effect_level = "read_only"
+
+[package.tools.annotations.arg_schema]
+required = ["path"]
+
+[[package.skills]]
+name = "review"
+path = "skills/review"
+permissions = ["skill:prompt"]
+
+[dependencies]
+"#,
+                current_harn_range_example()
+            ),
+        )
+        .unwrap();
+        fs::write(
+            tmp.path().join("skills/review/SKILL.md"),
+            "---\nname: review\nshort: Review changes\n---\n# Review\n",
+        )
+        .unwrap();
+
+        let report = check_package_impl(Some(tmp.path())).unwrap();
+
+        assert!(report.errors.is_empty(), "{:?}", report.errors);
+        assert_eq!(report.tools[0].name, "read-note");
+        assert_eq!(
+            report.tools[0].host_requirements,
+            vec!["workspace.read_text"]
+        );
+        assert_eq!(report.skills[0].name, "review");
+    }
+
+    #[test]
+    fn package_check_rejects_invalid_tool_schema_and_host_requirement() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_publishable_package(tmp.path());
+        fs::write(
+            tmp.path().join(MANIFEST),
+            format!(
+                r#"[package]
+name = "acme-lib"
+version = "0.1.0"
+description = "Acme helpers"
+license = "MIT"
+repository = "https://github.com/acme/acme-lib"
+harn = "{}"
+docs_url = "docs/api.md"
+
+[exports]
+lib = "lib/main.harn"
+
+[[package.tools]]
+name = "broken"
+module = "lib/main.harn"
+symbol = "tools"
+host_requirements = ["workspace"]
+
+[package.tools.input_schema]
+required = [1]
+
+[dependencies]
+"#,
+                current_harn_range_example()
+            ),
+        )
+        .unwrap();
+
+        let report = check_package_impl(Some(tmp.path())).unwrap();
+        let messages = report
+            .errors
+            .iter()
+            .map(|diagnostic| diagnostic.message.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(messages.contains("capability.operation"));
+        assert!(messages.contains("schema `required` must be a list of strings"));
+    }
+
+    #[test]
+    fn package_doctor_accepts_application_manifests_with_tool_exports() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(
+            tmp.path().join(MANIFEST),
+            r#"[package]
+name = "acme-app"
+
+[[package.tools]]
+name = "echo"
+module = "tools.harn"
+symbol = "tools"
+
+[package.tools.input_schema]
+type = "object"
+
+[package.tools.annotations]
+kind = "read"
+side_effect_level = "read_only"
+"#,
+        )
+        .unwrap();
+        fs::write(tmp.path().join("tools.harn"), "pub fn tools() {}\n").unwrap();
+        let workspace = TestWorkspace::new(tmp.path());
+
+        let report = doctor_packages_in(workspace.env()).unwrap();
+
+        assert!(report.ok, "{:?}", report.diagnostics);
+        assert!(
+            report
+                .diagnostics
+                .iter()
+                .all(|diagnostic| diagnostic.code != "root-package-check"),
+            "{:?}",
+            report.diagnostics
+        );
+    }
+
+    #[test]
+    fn package_list_reports_locked_tool_and_skill_exports() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(
+            tmp.path().join(MANIFEST),
+            r#"[package]
+name = "consumer"
+"#,
+        )
+        .unwrap();
+        let lock = LockFile {
+            packages: vec![LockEntry {
+                name: "acme-tools".to_string(),
+                source: "path+../acme-tools".to_string(),
+                package_version: Some("0.1.0".to_string()),
+                provenance: Some(
+                    "https://github.com/acme/acme-tools/releases/tag/v0.1.0".to_string(),
+                ),
+                exports: PackageLockExports {
+                    modules: vec![PackageLockExport {
+                        name: "tools".to_string(),
+                        path: Some("lib/tools.harn".to_string()),
+                        symbol: None,
+                    }],
+                    tools: vec![PackageLockExport {
+                        name: "echo".to_string(),
+                        path: Some("lib/tools.harn".to_string()),
+                        symbol: Some("tools".to_string()),
+                    }],
+                    skills: vec![PackageLockExport {
+                        name: "review".to_string(),
+                        path: Some("skills/review".to_string()),
+                        symbol: None,
+                    }],
+                    personas: Vec::new(),
+                },
+                permissions: vec!["tool:read_only".to_string()],
+                host_requirements: vec!["workspace.read_text".to_string()],
+                ..LockEntry::default()
+            }],
+            ..LockFile::default()
+        };
+        let lock_body = toml::to_string_pretty(&lock).unwrap();
+        fs::write(tmp.path().join(LOCK_FILE), lock_body).unwrap();
+        let workspace = TestWorkspace::new(tmp.path());
+
+        let report = list_packages_in(workspace.env()).unwrap();
+
+        assert_eq!(report.packages.len(), 1);
+        let package = &report.packages[0];
+        assert_eq!(package.name, "acme-tools");
+        assert_eq!(
+            package.provenance.as_deref(),
+            Some("https://github.com/acme/acme-tools/releases/tag/v0.1.0")
+        );
+        assert_eq!(package.exports.tools[0].name, "echo");
+        assert_eq!(package.exports.skills[0].name, "review");
+        assert_eq!(package.permissions, vec!["tool:read_only"]);
+        assert_eq!(package.host_requirements, vec!["workspace.read_text"]);
     }
 }

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -577,6 +577,30 @@ harn new package my-lib
 the default quick-start flow and `new` when you want the template choice to be
 explicit.
 
+## harn tool
+
+Scaffold Harn-native custom tool packages.
+
+```bash
+harn tool new acme-echo
+harn tool new acme-echo --dir packages/acme-echo
+harn tool new acme-echo --description "Echo text for tests."
+```
+
+The generated package includes `[[package.tools]]` metadata, a stable
+`tools` export, package-local dispatch tests, API docs, and CI commands for
+`harn test`, `harn package check`, `harn package docs --check`, and
+`harn package pack --dry-run`.
+
+## harn skill
+
+Scaffold or inspect one custom skill. `harn skill new` is the singular alias
+for `harn skills new`.
+
+```bash
+harn skill new review-helper
+```
+
 ## harn quickstart
 
 Inspect local provider readiness and write starter LLM configuration.
@@ -1439,6 +1463,34 @@ Remove one dependency from `harn.toml`, `harn.lock`, and
 ```bash
 harn remove my-lib
 ```
+
+## harn package list
+
+List packages from the current `harn.lock`.
+
+```bash
+harn package list
+harn package list --json
+```
+
+The report includes each locked package's source, materialization status,
+integrity status, package version, Harn compatibility range, exported
+modules/tools/skills, permissions, and host requirements.
+
+## harn package doctor
+
+Diagnose package install and contract issues.
+
+```bash
+harn package doctor
+harn package doctor --json
+```
+
+Doctor checks for missing or stale lockfiles, missing materialized packages,
+content-hash mismatches, declared host capability gaps, and invalid installed
+package tool/skill metadata. Publish-readiness checks remain under
+`harn package check`, so applications can use doctor without adding package
+metadata that only published libraries need.
 
 ## harn package search
 

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -4777,6 +4777,13 @@ stem. Use `harn add <alias> --path ../repo` for the legacy explicit
 alias form, or `harn add <alias> --git ../repo` when a local git checkout
 should be pinned by commit instead of live-linked.
 
+`harn tool new <name>` scaffolds a Harn-native tool package with
+`[[package.tools]]` metadata, a stable `tools` export, package-local dispatch
+tests, API docs, and CI. `harn skill new <name>` is the singular alias for
+`harn skills new <name>`. Tool and skill packages still install through the
+same `[dependencies]`, `.harn/packages/`, and `harn.lock` mechanism as ordinary
+module packages.
+
 ### Eval packs
 
 Packages can ship portable eval packs in `harn.eval.toml` or in paths listed
@@ -4975,17 +4982,29 @@ community packages by capability and stable name. Use direct GitHub refs
 for local dogfood, private repositories, unreleased commits, or temporary
 pins that are not ready for the shared index.
 
-`harn.lock` is a typed TOML file with `version = 1` and one `[[package]]`
+`harn.lock` is a typed TOML file with `version = 3` and one `[[package]]`
 entry per dependency. Each git entry records:
 
 - `source`
 - `rev_request`
 - `commit`
 - `content_hash`
+- `package_version`
+- `harn_compat`
+- `provenance`
+- `manifest_digest`
+- `exports`
+- `permissions`
+- `host_requirements`
 
 `content_hash` is a SHA-256 over the cached package tree. Harn verifies
 that hash whenever it reuses a cached package or re-materializes
-`.harn/packages/<alias>/`.
+`.harn/packages/<alias>/`. `manifest_digest` separately hashes the resolved
+package manifest so audit and host policy can detect package-surface drift
+without re-hashing the full tree. `provenance`, `exports`, `permissions`, and
+`host_requirements` mirror the resolved package's declared source,
+module/tool/skill surface, and policy requirements for host UI, CI, and
+locked-install review.
 
 For CI and production hosts, `harn install --locked --offline` uses only
 the committed `harn.lock` plus the local shared cache; it fails when the
@@ -4994,6 +5013,13 @@ already cached. `harn package cache list`, `clean`, and `verify`
 inspect, garbage-collect, and recompute content hashes for cached git
 packages. `harn package cache verify --materialized` also verifies
 installed `.harn/packages/` contents against the lockfile hashes.
+`harn package list` summarizes locked packages, their exported surfaces,
+permissions, host requirements, materialization status, and integrity state.
+`harn package doctor` diagnoses missing/stale lockfiles, missing materialized
+packages, content-hash mismatches, host capability gaps, and invalid installed
+tool or skill metadata. Publish-readiness checks stay under
+`harn package check`; applications can run doctor without becoming
+publishable packages.
 
 ### `[exports]` — stable package module entry points
 
@@ -5010,6 +5036,50 @@ directory layout.
 
 Exports are resolved after the direct `.harn/packages/<path>` lookup, so
 packages can still expose raw file trees when they want that behavior.
+
+### `[[package.tools]]` and `[[package.skills]]`
+
+Custom tool and skill packages declare their host-facing surface in the
+`[package]` table so installs can be reviewed from the manifest and lockfile:
+
+```toml
+[package]
+name = "acme-tools"
+version = "0.1.0"
+provenance = "https://github.com/acme/acme-tools/releases/tag/v0.1.0"
+permissions = ["tool:read_only"]
+host_requirements = ["workspace.read_text"]
+
+[exports]
+tools = "lib/tools.harn"
+
+[[package.tools]]
+name = "read-note"
+module = "lib/tools.harn"
+symbol = "tools"
+description = "Read a note through the package tool registry."
+permissions = ["tool:read_only"]
+
+[package.tools.input_schema]
+type = "object"
+required = ["path"]
+
+[package.tools.annotations]
+kind = "read"
+side_effect_level = "read_only"
+
+[[package.skills]]
+name = "review"
+path = "skills/review"
+```
+
+Each tool `module` is a package-root-relative Harn module and `symbol` names
+the exported registry builder. `input_schema`, `output_schema`, and
+`annotations` are TOML tables that must round-trip to the runtime JSON schema
+and tool annotation shapes. Each skill `path` is a package-root-relative
+directory containing `SKILL.md` with valid front matter. Package-level
+permissions and host requirements are merged with per-tool or per-skill values
+when Harn writes the lockfile.
 
 ### `[asset_roots]` — package-root prompt asset aliases
 

--- a/docs/src/package-authoring.md
+++ b/docs/src/package-authoring.md
@@ -29,10 +29,43 @@ Consumers can add a local package while developing:
 ```bash
 harn add ../acme-tools
 harn install
+harn package list
+harn package doctor
 ```
 
 Before publishing, replace local path dependencies with registry or git
 dependencies pinned to a version or rev.
+
+## Create a tool package
+
+```bash
+harn tool new acme-echo
+cd acme-echo
+harn test tests/
+harn package check
+harn package docs --check
+harn package pack --dry-run
+```
+
+The tool template creates a package with a Harn-native registry builder,
+`[[package.tools]]` metadata, a local smoke test that dispatches the tool,
+and CI that exercises the same publish-readiness checks. The generated package
+is intentionally ordinary Harn source; consumers install it with `harn add`,
+import the stable export, and merge it into their own tool registry:
+
+```harn,ignore
+import { tools } from "acme-echo/tools"
+```
+
+## Create a skill package
+
+```bash
+harn skill new review-helper
+```
+
+`harn skill new` is the singular alias for `harn skills new`. Package authors
+can publish skills by adding `[[package.skills]]` entries that point at
+package-root-relative skill directories containing `SKILL.md`.
 
 ## Create a connector package
 
@@ -72,20 +105,47 @@ version = "0.1.0"
 description = "Reusable Harn helpers."
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/acme/acme-tools"
+provenance = "https://github.com/acme/acme-tools/releases/tag/v0.1.0"
 harn = ">=0.8,<0.9"
 docs_url = "docs/api.md"
+permissions = ["tool:read_only"]
+host_requirements = ["workspace.read_text"]
 
 [exports]
 lib = "lib/main.harn"
+
+[[package.tools]]
+name = "read-note"
+module = "lib/main.harn"
+symbol = "tools"
+description = "Read a note through the package tool registry."
+permissions = ["tool:read_only"]
+
+[package.tools.input_schema]
+type = "object"
+required = ["path"]
+
+[package.tools.annotations]
+kind = "read"
+side_effect_level = "read_only"
+
+[[package.skills]]
+name = "review"
+path = "skills/review"
 
 [dependencies]
 json-helpers = { git = "https://github.com/acme/json-helpers", rev = "v0.1.0" }
 ```
 
 `harn package check` validates required metadata, dependency declarations,
-stable exports, README/license presence, docs links, and Harn compatibility.
-Publish readiness rejects path-only dependencies and unsupported Harn version
-ranges because they cannot be reproduced from a registry index.
+stable exports, tool and skill declarations, README/license presence, docs
+links, and Harn compatibility. Tool declarations must point at a parseable
+Harn module, provide valid JSON-schema-shaped `input_schema` and
+`output_schema` tables when present, and use policy annotations that match the
+runtime tool annotation schema. Skill declarations must stay inside the package
+root and point at a directory with valid `SKILL.md` front matter. Publish
+readiness rejects path-only dependencies and unsupported Harn version ranges
+because they cannot be reproduced from a registry index.
 
 ## API docs
 
@@ -134,8 +194,11 @@ write captures:
   top level so downstream automation can detect when the lock was produced
   by an older Harn line.
 - Per-entry `source`, `commit`, and `content_hash` for git/registry deps,
-  plus `package_version`, `harn_compat`, and a separate `manifest_digest`
-  taken from the resolved package's `harn.toml`.
+  plus `package_version`, `harn_compat`, package `provenance`, and a separate
+  `manifest_digest` taken from the resolved package's `harn.toml`.
+- Exported modules, custom tools, skills, package permissions, and host
+  requirements declared by the resolved package. Hosts and CI can inspect this
+  metadata without reading arbitrary package source.
 - A `[package.registry]` table for entries originally added via
   `harn add @scope/name@version`, preserving the registry source, package
   name, and requested version so `harn package outdated` can compare
@@ -147,9 +210,16 @@ resolved `path+file://` URI plus the same `package_version` and
 
 ## Maturing the package surface
 
-Once a manifest and lockfile are in place, three commands cover the
+Once a manifest and lockfile are in place, these commands cover the
 day-to-day automation surface:
 
+- `harn package list` — summarize locked packages, materialization status,
+  exported modules/tools/skills, and declared permission or host requirements.
+  Use `--json` when the output feeds host UI or CI policy.
+- `harn package doctor` — diagnose missing or stale lockfiles, missing
+  materialized packages, content-hash mismatches, declared host capability
+  gaps, and invalid installed package tool/skill metadata. It is safe for
+  applications: publish-only checks remain under `harn package check`.
 - `harn package outdated` — surface registry version bumps and (with
   `--remote`) git branch HEAD drift. JSON output matches the report
   struct documented in
@@ -173,22 +243,26 @@ consistent way to land the bump. The recommended sequence:
 1. **Refresh the running Harn binary** in the downstream repo
    (`fetch-harn`, `make setup`, or whatever the local script is).
 2. **Re-resolve dependencies** with `harn install` so `harn.lock`
-   rewrites in v2 with the current `generator_version` and
-   `protocol_artifact_version`.
-3. **Audit** with `harn package audit --json`. If any package declares a
+   rewrites with the current `generator_version`,
+   `protocol_artifact_version`, exported package surface, and host
+   requirements.
+3. **Inspect** with `harn package list --json` and `harn package doctor --json`
+   so host requirements and materialized package state are visible before
+   tests start.
+4. **Audit** with `harn package audit --json`. If any package declares a
    `harn` range that excludes the new line, contact the package owner or
    pin to a previous tag.
-4. **Check vendored protocol bindings** with
+5. **Check vendored protocol bindings** with
    `harn package artifacts check path/to/vendored/manifest.json`. If it
    reports drift, regenerate the bindings (`make gen-protocol-artifacts`
    inside the downstream repo, or `harn package artifacts manifest
    --output …` to refresh the vendored copy).
-5. **Surface registry updates** with `harn package outdated --json` and
+6. **Surface registry updates** with `harn package outdated --json` and
    bump dependency versions intentionally; `harn update <alias>` keeps
    each upgrade in its own commit.
 
-Steps 2–4 are a single CI job for hosts that vendor Harn artifacts:
-`harn install --frozen --json`, then `harn package audit --json`, then
-`harn package artifacts check`. The `--json` output is stable across
-Harn lines, so the same automation script runs against multiple Harn
-versions during a staged rollout.
+Steps 2–5 are a single CI job for hosts that vendor Harn artifacts:
+`harn install --frozen --json`, then `harn package doctor --json`, then
+`harn package audit --json`, then `harn package artifacts check`. The `--json`
+output is stable across Harn lines, so the same automation script runs against
+multiple Harn versions during a staged rollout.

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -4775,6 +4775,13 @@ stem. Use `harn add <alias> --path ../repo` for the legacy explicit
 alias form, or `harn add <alias> --git ../repo` when a local git checkout
 should be pinned by commit instead of live-linked.
 
+`harn tool new <name>` scaffolds a Harn-native tool package with
+`[[package.tools]]` metadata, a stable `tools` export, package-local dispatch
+tests, API docs, and CI. `harn skill new <name>` is the singular alias for
+`harn skills new <name>`. Tool and skill packages still install through the
+same `[dependencies]`, `.harn/packages/`, and `harn.lock` mechanism as ordinary
+module packages.
+
 ### Eval packs
 
 Packages can ship portable eval packs in `harn.eval.toml` or in paths listed
@@ -4973,17 +4980,29 @@ community packages by capability and stable name. Use direct GitHub refs
 for local dogfood, private repositories, unreleased commits, or temporary
 pins that are not ready for the shared index.
 
-`harn.lock` is a typed TOML file with `version = 1` and one `[[package]]`
+`harn.lock` is a typed TOML file with `version = 3` and one `[[package]]`
 entry per dependency. Each git entry records:
 
 - `source`
 - `rev_request`
 - `commit`
 - `content_hash`
+- `package_version`
+- `harn_compat`
+- `provenance`
+- `manifest_digest`
+- `exports`
+- `permissions`
+- `host_requirements`
 
 `content_hash` is a SHA-256 over the cached package tree. Harn verifies
 that hash whenever it reuses a cached package or re-materializes
-`.harn/packages/<alias>/`.
+`.harn/packages/<alias>/`. `manifest_digest` separately hashes the resolved
+package manifest so audit and host policy can detect package-surface drift
+without re-hashing the full tree. `provenance`, `exports`, `permissions`, and
+`host_requirements` mirror the resolved package's declared source,
+module/tool/skill surface, and policy requirements for host UI, CI, and
+locked-install review.
 
 For CI and production hosts, `harn install --locked --offline` uses only
 the committed `harn.lock` plus the local shared cache; it fails when the
@@ -4992,6 +5011,13 @@ already cached. `harn package cache list`, `clean`, and `verify`
 inspect, garbage-collect, and recompute content hashes for cached git
 packages. `harn package cache verify --materialized` also verifies
 installed `.harn/packages/` contents against the lockfile hashes.
+`harn package list` summarizes locked packages, their exported surfaces,
+permissions, host requirements, materialization status, and integrity state.
+`harn package doctor` diagnoses missing/stale lockfiles, missing materialized
+packages, content-hash mismatches, host capability gaps, and invalid installed
+tool or skill metadata. Publish-readiness checks stay under
+`harn package check`; applications can run doctor without becoming
+publishable packages.
 
 ### `[exports]` — stable package module entry points
 
@@ -5008,6 +5034,50 @@ directory layout.
 
 Exports are resolved after the direct `.harn/packages/<path>` lookup, so
 packages can still expose raw file trees when they want that behavior.
+
+### `[[package.tools]]` and `[[package.skills]]`
+
+Custom tool and skill packages declare their host-facing surface in the
+`[package]` table so installs can be reviewed from the manifest and lockfile:
+
+```toml
+[package]
+name = "acme-tools"
+version = "0.1.0"
+provenance = "https://github.com/acme/acme-tools/releases/tag/v0.1.0"
+permissions = ["tool:read_only"]
+host_requirements = ["workspace.read_text"]
+
+[exports]
+tools = "lib/tools.harn"
+
+[[package.tools]]
+name = "read-note"
+module = "lib/tools.harn"
+symbol = "tools"
+description = "Read a note through the package tool registry."
+permissions = ["tool:read_only"]
+
+[package.tools.input_schema]
+type = "object"
+required = ["path"]
+
+[package.tools.annotations]
+kind = "read"
+side_effect_level = "read_only"
+
+[[package.skills]]
+name = "review"
+path = "skills/review"
+```
+
+Each tool `module` is a package-root-relative Harn module and `symbol` names
+the exported registry builder. `input_schema`, `output_schema`, and
+`annotations` are TOML tables that must round-trip to the runtime JSON schema
+and tool annotation shapes. Each skill `path` is a package-root-relative
+directory containing `SKILL.md` with valid front matter. Package-level
+permissions and host requirements are merged with per-tool or per-skill values
+when Harn writes the lockfile.
 
 ### `[asset_roots]` — package-root prompt asset aliases
 


### PR DESCRIPTION
Closes #1583.

## Summary
- Add `harn tool new` for Harn-native custom tool package scaffolding, plus a singular `harn skill new` alias.
- Extend package manifests and lockfiles with tool/skill exports, provenance, permissions, host requirements, and locked export metadata.
- Add `harn package list` and `harn package doctor` so installed packages expose and validate their locked custom tool/skill contract.
- Update the package docs, CLI reference, language spec mirror, and README for the new authoring and install workflows.

## Verification
- `CARGO_TARGET_DIR=/tmp/harn-target-issue1583 cargo test -p harn-cli package --lib`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue1583 cargo test -p harn-cli tool --lib`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue1583 cargo clippy -p harn-cli --lib -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue1583 make check-language-spec`
- `npx markdownlint-cli2 README.md docs/src/package-authoring.md docs/src/cli-reference.md spec/HARN_SPEC.md`
- `git diff --check`
- Pre-commit hook: Rust fmt, workspace clippy, generated language spec sync, markdown lint.
- Pre-push hook: targeted Rust checks, markdown lint, generated language spec mirror check.
- End-to-end smoke: scaffolded `acme-echo` with `harn tool new`, ran its generated tests, package check/docs/pack dry-run, installed it into a consumer package, imported its exported tools module, dispatched the tool, and verified `package list --json` plus `package doctor --json` expose the locked exports/provenance/requirements.
