### PR TITLE
Add replay benchmark harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ condensed series summaries instead of full per-patch history.
   schemas, and remote `rejected` task states distinctly, with a new
   `examples/triggers/local-a2a-dispatch` reference flow and replay-oracle
   fixture proving local and A2A handlers can preserve logical output.
+- **Replay determinism benchmark harness (#1585).** Added
+  `harn bench replay`, a canonical replay benchmark suite, OpenCode-inspired
+  JSONL trace adapter, Harn Cloud ingest-shaped JSON report, replay benchmark
+  schema, and CI workflow template. The report includes replay-fidelity,
+  permission-preservation, tool-call drift, transcript drift, observed-cost,
+  and first-divergence triage metrics.
 
 ## v0.8.13
 

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
-.PHONY: setup install-hooks configure-merge-drivers build build-release sign-local check fmt fmt-harn fmt-harn-fix lint lint-md lint-actions lint-harn spec-lint test test-e2e test-cargo test-fast test-harn-scripts conformance protocol-conformance replay-oracle bench-vm bench-vm-clone bench-llm bench-orchestration all release-gate release-smoke smoke-audit portal portal-check portal-demo gen-highlight check-highlight gen-protocol-artifacts check-protocol-artifacts check-bindings gen-session-bundle-schema check-session-bundle-schema gen-trigger-quickref check-trigger-quickref gen-provider-matrix check-provider-matrix gen-connector-matrix check-connector-matrix check-trigger-examples check-docs-snippets check-docs-workflow-quickstart sync-language-spec check-language-spec lint-test-patterns check-receipt-structs lint-no-rust-prompt-prose lint-no-xfail-regression check-provider-catalog-drift
+.PHONY: setup install-hooks configure-merge-drivers build build-release sign-local check fmt fmt-harn fmt-harn-fix lint lint-md lint-actions lint-harn spec-lint test test-e2e test-cargo test-fast test-harn-scripts conformance protocol-conformance replay-oracle replay-bench bench-vm bench-vm-clone bench-llm bench-orchestration all release-gate release-smoke smoke-audit portal portal-check portal-demo gen-highlight check-highlight gen-protocol-artifacts check-protocol-artifacts check-bindings gen-session-bundle-schema check-session-bundle-schema gen-trigger-quickref check-trigger-quickref gen-provider-matrix check-provider-matrix gen-connector-matrix check-connector-matrix check-trigger-examples check-docs-snippets check-docs-workflow-quickstart sync-language-spec check-language-spec lint-test-patterns check-receipt-structs lint-no-rust-prompt-prose lint-no-xfail-regression check-provider-catalog-drift
 
 # Full quality check: format first, then lint/test in parallel.
 # Usage: make all -j       (parallel checks after formatting)
 #        make all           (sequential, also works)
 all: fmt
-	$(MAKE) lint lint-md lint-actions lint-harn spec-lint fmt-harn test test-harn-scripts conformance protocol-conformance replay-oracle check-highlight check-protocol-artifacts check-bindings check-session-bundle-schema check-language-spec check-trigger-quickref check-provider-matrix check-connector-matrix check-trigger-examples check-docs-snippets check-docs-workflow-quickstart lint-test-patterns check-receipt-structs check-provider-catalog-drift portal-check
+	$(MAKE) lint lint-md lint-actions lint-harn spec-lint fmt-harn test test-harn-scripts conformance protocol-conformance replay-oracle replay-bench check-highlight check-protocol-artifacts check-bindings check-session-bundle-schema check-language-spec check-trigger-quickref check-provider-matrix check-connector-matrix check-trigger-examples check-docs-snippets check-docs-workflow-quickstart lint-test-patterns check-receipt-structs check-provider-catalog-drift portal-check
 
 check: all
 
@@ -82,6 +82,9 @@ protocol-conformance:
 
 replay-oracle:
 	HARN_LLM_CALLS_DISABLED=1 cargo run --bin harn -- orchestrator replay-oracle
+
+replay-bench:
+	HARN_LLM_CALLS_DISABLED=1 cargo run --bin harn -- bench replay --json >/dev/null
 
 bench-vm:
 	./scripts/bench_vm.sh

--- a/benchmarks/replay/README.md
+++ b/benchmarks/replay/README.md
@@ -1,0 +1,29 @@
+# Replay benchmark suite
+
+`harn bench replay` reads `suite.json` by default and emits a stable JSON
+artifact for Harn Cloud replay-determinism leaderboard ingestion.
+
+The suite references canonical replay-oracle traces instead of duplicating
+them. That keeps pass/fail replay semantics and benchmark scoring on the same
+trace contract:
+
+- `simple_tool_run`: deterministic read-only tool call.
+- `permission_gated_edit`: HITL permission decision and file-effect receipt.
+- `event_triggered_multi_step_workflow`: event-triggered worker handoff with
+  protocol, transcript, and artifact material.
+
+Run locally:
+
+```sh
+cargo run --bin harn -- bench replay --json --output replay-benchmark.json
+```
+
+External adapter fixtures live under `adapters/`. They document the
+OpenCode-inspired JSONL shape accepted by:
+
+```sh
+harn bench replay \
+  --adapter opencode-jsonl \
+  --external-first benchmarks/replay/adapters/opencode/first.jsonl \
+  --external-second benchmarks/replay/adapters/opencode/second.jsonl
+```

--- a/benchmarks/replay/adapters/opencode/first.jsonl
+++ b/benchmarks/replay/adapters/opencode/first.jsonl
@@ -1,0 +1,5 @@
+{"type":"message","id":"m1","role":"assistant","content":"I will inspect the file before editing."}
+{"type":"tool_call","id":"t1","tool":"read_file","arguments":{"path":"README.md"},"result":{"ok":true,"bytes":128}}
+{"type":"permission","id":"p1","action":"write_file","capability":"fs.write","decision":"approved","reviewer":"operator"}
+{"type":"tool_call","id":"t2","tool":"write_file","arguments":{"path":"notes/summary.md"},"result":{"ok":true}}
+{"type":"llm","id":"l1","provider":"local","model":"qwen","usage":{"input_tokens":42,"output_tokens":11}}

--- a/benchmarks/replay/adapters/opencode/second.jsonl
+++ b/benchmarks/replay/adapters/opencode/second.jsonl
@@ -1,0 +1,5 @@
+{"type":"message","id":"m1","role":"assistant","content":"I will inspect the file before editing."}
+{"type":"tool_call","id":"t1","tool":"read_file","arguments":{"path":"README.md"},"result":{"ok":true,"bytes":128}}
+{"type":"permission","id":"p1","action":"write_file","capability":"fs.write","decision":"approved","reviewer":"operator"}
+{"type":"tool_call","id":"t2","tool":"write_file","arguments":{"path":"notes/summary.md"},"result":{"ok":true}}
+{"type":"llm","id":"l1","provider":"local","model":"qwen","usage":{"input_tokens":42,"output_tokens":11}}

--- a/benchmarks/replay/fixtures/simple_tool_run.valid.json
+++ b/benchmarks/replay/fixtures/simple_tool_run.valid.json
@@ -1,0 +1,78 @@
+{
+  "schema_version": "harn.orchestration.replay_trace.v1",
+  "name": "simple_tool_run",
+  "description": "A deterministic read-only tool call with matching protocol interaction, effect receipt, and policy decision.",
+  "expect": "match",
+  "allowlist": [
+    {
+      "path": "/run_id",
+      "reason": "run ids are allocated per execution"
+    }
+  ],
+  "first_run": {
+    "run_id": "run_live_simple_tool",
+    "protocol_interactions": [
+      {
+        "protocol": "mcp",
+        "boundary": "tools/call",
+        "request": {
+          "method": "tools/call",
+          "tool": "read_file",
+          "arguments_sha256": "sha256:8a1187230cc9589c8b559ca1ebf957c87b812f90d3a89bc37ad8e854dd54b9f4"
+        },
+        "response": {
+          "content_sha256": "sha256:5b6d2f2df85f9ce07666c51fdb2f4a974a8f5ae5f2fae9f26f4590dd4b383f19",
+          "status": "ok"
+        }
+      }
+    ],
+    "effect_receipts": [
+      {
+        "kind": "tool_call",
+        "tool": "read_file",
+        "status": "ok",
+        "result_sha256": "sha256:5b6d2f2df85f9ce07666c51fdb2f4a974a8f5ae5f2fae9f26f4590dd4b383f19"
+      }
+    ],
+    "policy_decisions": [
+      {
+        "capability": "fs.read",
+        "decision": "allow",
+        "reason": "read-only tool"
+      }
+    ]
+  },
+  "second_run": {
+    "run_id": "run_replay_simple_tool",
+    "protocol_interactions": [
+      {
+        "protocol": "mcp",
+        "boundary": "tools/call",
+        "request": {
+          "method": "tools/call",
+          "tool": "read_file",
+          "arguments_sha256": "sha256:8a1187230cc9589c8b559ca1ebf957c87b812f90d3a89bc37ad8e854dd54b9f4"
+        },
+        "response": {
+          "content_sha256": "sha256:5b6d2f2df85f9ce07666c51fdb2f4a974a8f5ae5f2fae9f26f4590dd4b383f19",
+          "status": "ok"
+        }
+      }
+    ],
+    "effect_receipts": [
+      {
+        "kind": "tool_call",
+        "tool": "read_file",
+        "status": "ok",
+        "result_sha256": "sha256:5b6d2f2df85f9ce07666c51fdb2f4a974a8f5ae5f2fae9f26f4590dd4b383f19"
+      }
+    ],
+    "policy_decisions": [
+      {
+        "capability": "fs.read",
+        "decision": "allow",
+        "reason": "read-only tool"
+      }
+    ]
+  }
+}

--- a/benchmarks/replay/suite.json
+++ b/benchmarks/replay/suite.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": "harn.replay_benchmark.suite.v1",
+  "name": "harn-canonical-replay-determinism",
+  "description": "Canonical replay benchmark suite for Harn Cloud leaderboard ingestion.",
+  "fixtures": [
+    {
+      "id": "simple_tool_run",
+      "path": "benchmarks/replay/fixtures/simple_tool_run.valid.json",
+      "category": "simple_tool_run"
+    },
+    {
+      "id": "permission_gated_edit",
+      "path": "conformance/replay-oracle/fixtures/approval_tool_call.valid.json",
+      "category": "permission_decision_preservation"
+    },
+    {
+      "id": "event_triggered_multi_step_workflow",
+      "path": "conformance/replay-oracle/fixtures/worker_a2a_path.valid.json",
+      "category": "event_triggered_workflow"
+    }
+  ]
+}

--- a/crates/harn-cli/src/cli/bench.rs
+++ b/crates/harn-cli/src/cli/bench.rs
@@ -1,14 +1,59 @@
-use clap::Args;
+use std::path::PathBuf;
+
+use clap::{Args, Subcommand};
 
 use super::ProfileArgs;
 
 #[derive(Debug, Args)]
+#[command(arg_required_else_help = true)]
 pub(crate) struct BenchArgs {
+    #[command(subcommand)]
+    pub command: Option<BenchCommand>,
     /// Path to the .harn file to benchmark.
-    pub file: String,
+    pub file: Option<String>,
     /// Number of benchmark iterations to run.
     #[arg(short = 'n', long, default_value_t = 10)]
     pub iterations: usize,
     #[command(flatten)]
     pub profile: ProfileArgs,
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum BenchCommand {
+    /// Score deterministic replay fixtures and emit a leaderboard-ready report.
+    Replay(BenchReplayArgs),
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct BenchReplayArgs {
+    /// Replay benchmark suite manifest, fixture file, or fixture directory.
+    /// Defaults to benchmarks/replay/suite.json.
+    pub selection: Option<PathBuf>,
+    /// Emit the machine-readable report to stdout.
+    #[arg(long)]
+    pub json: bool,
+    /// Write the machine-readable report to this path.
+    #[arg(long, value_name = "PATH")]
+    pub output: Option<PathBuf>,
+    /// Run only fixtures whose path or trace name contains this string.
+    #[arg(long, value_name = "TEXT")]
+    pub filter: Option<String>,
+    /// Suite name to place in the benchmark report.
+    #[arg(
+        long = "suite-name",
+        default_value = "harn-canonical-replay-determinism"
+    )]
+    pub suite_name: String,
+    /// External trace adapter to use for --external-first/--external-second.
+    #[arg(long, value_name = "ADAPTER", requires_all = ["external_first", "external_second"])]
+    pub adapter: Option<String>,
+    /// First external trace file for adapter-based comparison.
+    #[arg(long = "external-first", value_name = "PATH", requires = "adapter")]
+    pub external_first: Option<PathBuf>,
+    /// Second external trace file for adapter-based comparison.
+    #[arg(long = "external-second", value_name = "PATH", requires = "adapter")]
+    pub external_second: Option<PathBuf>,
+    /// Name for the adapted external trace pair.
+    #[arg(long = "external-name", default_value = "external-adapted-replay")]
+    pub external_name: String,
 }

--- a/crates/harn-cli/src/cli/mod.rs
+++ b/crates/harn-cli/src/cli/mod.rs
@@ -53,7 +53,7 @@ mod viz;
 mod watch;
 mod workflow;
 
-pub(crate) use bench::BenchArgs;
+pub(crate) use bench::{BenchArgs, BenchCommand, BenchReplayArgs};
 pub(crate) use check::{CheckArgs, CheckOutputFormat};
 pub(crate) use completions::{CompletionShell, CompletionsArgs};
 pub(crate) use connect::{

--- a/crates/harn-cli/src/cli/tests.rs
+++ b/crates/harn-cli/src/cli/tests.rs
@@ -1821,13 +1821,63 @@ fn test_parses_bench_args() {
     let Command::Bench(args) = cli.command.unwrap() else {
         panic!("expected bench command");
     };
-    assert_eq!(args.file, "main.harn");
+    assert_eq!(args.file.as_deref(), Some("main.harn"));
     assert_eq!(args.iterations, 25);
     assert!(args.profile.text);
     assert_eq!(
         args.profile.json_path.as_deref(),
         Some(std::path::Path::new("bench.json"))
     );
+}
+
+#[test]
+fn test_parses_bench_replay_args() {
+    let cli = Cli::parse_from([
+        "harn",
+        "bench",
+        "replay",
+        "benchmarks/replay/suite.json",
+        "--json",
+        "--output",
+        "replay-benchmark.json",
+        "--filter",
+        "permission",
+        "--adapter",
+        "opencode-jsonl",
+        "--external-first",
+        "first.jsonl",
+        "--external-second",
+        "second.jsonl",
+        "--external-name",
+        "opencode-permission",
+    ]);
+
+    let Command::Bench(args) = cli.command.unwrap() else {
+        panic!("expected bench command");
+    };
+    let Some(crate::cli::BenchCommand::Replay(replay)) = args.command else {
+        panic!("expected bench replay command");
+    };
+    assert_eq!(
+        replay.selection.as_deref(),
+        Some(std::path::Path::new("benchmarks/replay/suite.json"))
+    );
+    assert!(replay.json);
+    assert_eq!(
+        replay.output.as_deref(),
+        Some(std::path::Path::new("replay-benchmark.json"))
+    );
+    assert_eq!(replay.filter.as_deref(), Some("permission"));
+    assert_eq!(replay.adapter.as_deref(), Some("opencode-jsonl"));
+    assert_eq!(
+        replay.external_first.as_deref(),
+        Some(std::path::Path::new("first.jsonl"))
+    );
+    assert_eq!(
+        replay.external_second.as_deref(),
+        Some(std::path::Path::new("second.jsonl"))
+    );
+    assert_eq!(replay.external_name, "opencode-permission");
 }
 
 #[test]

--- a/crates/harn-cli/src/commands/bench.rs
+++ b/crates/harn-cli/src/commands/bench.rs
@@ -1,11 +1,12 @@
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process;
 use std::time::Instant;
 
 use harn_parser::DiagnosticSeverity;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
+use crate::cli::{BenchArgs, BenchCommand, BenchReplayArgs};
 use crate::commands::run::{connect_mcp_servers, RunProfileOptions};
 use crate::package;
 use crate::parse_source_file;
@@ -33,6 +34,29 @@ struct BenchStats {
     max_ms: f64,
     stddev_ms: f64,
     total_ms: f64,
+}
+
+pub(crate) async fn run(args: BenchArgs) {
+    match args.command {
+        Some(BenchCommand::Replay(replay)) => {
+            if let Err(error) = run_replay_bench(replay) {
+                eprintln!("error: {error}");
+                process::exit(1);
+            }
+        }
+        None => {
+            let Some(path) = args.file.as_deref() else {
+                eprintln!("error: `harn bench` requires a .harn file or a subcommand");
+                process::exit(1);
+            };
+            run_bench(
+                path,
+                args.iterations,
+                crate::run_profile_options(&args.profile),
+            )
+            .await;
+        }
+    }
 }
 
 pub(crate) async fn run_bench(path: &str, iterations: usize, profile: RunProfileOptions) {
@@ -324,11 +348,331 @@ fn write_bench_profile_json(
     fs::write(json_path, json).map_err(|error| format!("write {}: {error}", json_path.display()))
 }
 
+const REPLAY_BENCHMARK_SUITE_SCHEMA_VERSION: &str = "harn.replay_benchmark.suite.v1";
+
+#[derive(Debug, Deserialize)]
+struct ReplayBenchmarkSuiteManifest {
+    #[serde(default)]
+    schema_version: String,
+    #[serde(default)]
+    name: Option<String>,
+    fixtures: Vec<ReplayBenchmarkFixtureRef>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReplayBenchmarkFixtureRef {
+    path: String,
+}
+
+fn run_replay_bench(args: BenchReplayArgs) -> Result<(), String> {
+    let repo_root = discover_repo_root().unwrap_or_else(|| PathBuf::from("."));
+    let selection = resolve_replay_selection(args.selection.as_ref(), &repo_root);
+    let (suite_name, fixture_paths) =
+        resolve_replay_benchmark_selection(&selection, &repo_root, &args.suite_name)?;
+    let mut reports = Vec::new();
+
+    for fixture_path in fixture_paths {
+        let display_path = display_path(&fixture_path);
+        let trace = read_replay_trace_fixture(&fixture_path)?;
+        if !matches_replay_benchmark_filter(args.filter.as_deref(), &display_path, &trace.name) {
+            continue;
+        }
+        validate_protocol_fixture_refs(&repo_root, &trace.protocol_fixture_refs)?;
+        reports.push(
+            harn_vm::benchmark_replay_trace(display_path, &trace)
+                .map_err(|error| error.to_string())?,
+        );
+    }
+
+    if let Some(adapter_id) = args.adapter.as_deref() {
+        let adapter = replay_trace_adapter(adapter_id)?;
+        let first_path = args
+            .external_first
+            .as_ref()
+            .ok_or_else(|| "--external-first is required with --adapter".to_string())?;
+        let second_path = args
+            .external_second
+            .as_ref()
+            .ok_or_else(|| "--external-second is required with --adapter".to_string())?;
+        let first = fs::read_to_string(first_path)
+            .map_err(|error| format!("read {}: {error}", first_path.display()))?;
+        let second = fs::read_to_string(second_path)
+            .map_err(|error| format!("read {}: {error}", second_path.display()))?;
+        if matches_replay_benchmark_filter(
+            args.filter.as_deref(),
+            &format!("adapter:{adapter_id}:{}", args.external_name),
+            &args.external_name,
+        ) {
+            reports.push(
+                harn_vm::benchmark_adapted_replay_pair(
+                    adapter.as_ref(),
+                    args.external_name.clone(),
+                    &first,
+                    &second,
+                )
+                .map_err(|error| error.to_string())?,
+            );
+        }
+    }
+
+    if reports.is_empty() {
+        return Err(format!(
+            "no replay benchmark fixtures matched {}",
+            selection.display()
+        ));
+    }
+
+    let source_paths = reports
+        .iter()
+        .map(|report| report.path.clone())
+        .collect::<Vec<_>>();
+    let report = harn_vm::build_replay_benchmark_report(suite_name, source_paths, reports);
+    let json = serde_json::to_string_pretty(&report)
+        .map_err(|error| format!("serialize replay benchmark report: {error}"))?;
+
+    if let Some(output_path) = args.output.as_ref() {
+        write_replay_benchmark_report(output_path, &json)?;
+    }
+    if args.json {
+        println!("{json}");
+    } else {
+        print!("{}", render_replay_benchmark_report(&report));
+        if let Some(output_path) = args.output.as_ref() {
+            println!("Report JSON: {}", output_path.display());
+        }
+    }
+
+    if report.summary.failed > 0 {
+        return Err(format!(
+            "replay benchmark failed: {} passed, {} failed",
+            report.summary.passed, report.summary.failed
+        ));
+    }
+    Ok(())
+}
+
+fn resolve_replay_selection(selection: Option<&PathBuf>, repo_root: &Path) -> PathBuf {
+    match selection {
+        Some(selection) if selection.is_absolute() || selection.exists() => selection.clone(),
+        Some(selection) => repo_root.join(selection),
+        None => repo_root.join("benchmarks/replay/suite.json"),
+    }
+}
+
+fn resolve_replay_benchmark_selection(
+    selection: &Path,
+    repo_root: &Path,
+    fallback_suite_name: &str,
+) -> Result<(String, Vec<PathBuf>), String> {
+    if !selection.exists() {
+        return Err(format!(
+            "replay benchmark target not found: {}",
+            selection.display()
+        ));
+    }
+    if selection.is_file() {
+        let text = fs::read_to_string(selection)
+            .map_err(|error| format!("read {}: {error}", selection.display()))?;
+        let value: serde_json::Value = serde_json::from_str(&text)
+            .map_err(|error| format!("invalid JSON in {}: {error}", selection.display()))?;
+        if value.get("fixtures").is_some() {
+            let manifest: ReplayBenchmarkSuiteManifest =
+                serde_json::from_value(value).map_err(|error| {
+                    format!(
+                        "invalid replay benchmark suite {}: {error}",
+                        selection.display()
+                    )
+                })?;
+            if manifest.schema_version != REPLAY_BENCHMARK_SUITE_SCHEMA_VERSION {
+                return Err(format!(
+                    "unsupported replay benchmark suite schema_version {:?}; expected {REPLAY_BENCHMARK_SUITE_SCHEMA_VERSION}",
+                    manifest.schema_version
+                ));
+            }
+            let base = selection.parent().unwrap_or_else(|| Path::new("."));
+            let mut fixtures = Vec::with_capacity(manifest.fixtures.len());
+            for fixture in manifest.fixtures {
+                fixtures.push(resolve_suite_fixture_path(repo_root, base, &fixture.path));
+            }
+            return Ok((
+                manifest
+                    .name
+                    .unwrap_or_else(|| fallback_suite_name.to_string()),
+                fixtures,
+            ));
+        }
+        return Ok((
+            fallback_suite_name.to_string(),
+            vec![selection.to_path_buf()],
+        ));
+    }
+
+    let mut fixtures = Vec::new();
+    collect_json_files(selection, &mut fixtures);
+    if fixtures.is_empty() {
+        return Err(format!(
+            "no replay benchmark JSON fixtures found under {}",
+            selection.display()
+        ));
+    }
+    Ok((fallback_suite_name.to_string(), fixtures))
+}
+
+fn resolve_suite_fixture_path(repo_root: &Path, base: &Path, raw: &str) -> PathBuf {
+    let path = Path::new(raw);
+    if path.is_absolute() {
+        return path.to_path_buf();
+    }
+    let repo_relative = repo_root.join(path);
+    if repo_relative.exists() {
+        repo_relative
+    } else {
+        base.join(path)
+    }
+}
+
+fn collect_json_files(path: &Path, out: &mut Vec<PathBuf>) {
+    if path.is_file() {
+        if path.extension().is_some_and(|ext| ext == "json") {
+            out.push(path.to_path_buf());
+        }
+        return;
+    }
+    let Ok(entries) = fs::read_dir(path) else {
+        return;
+    };
+    let mut entries = entries.filter_map(Result::ok).collect::<Vec<_>>();
+    entries.sort_by_key(|entry| entry.path());
+    for entry in entries {
+        collect_json_files(&entry.path(), out);
+    }
+}
+
+fn read_replay_trace_fixture(path: &Path) -> Result<harn_vm::ReplayOracleTrace, String> {
+    let text =
+        fs::read_to_string(path).map_err(|error| format!("read {}: {error}", path.display()))?;
+    serde_json::from_str(&text)
+        .map_err(|error| format!("invalid replay trace JSON in {}: {error}", path.display()))
+}
+
+fn validate_protocol_fixture_refs(repo_root: &Path, refs: &[String]) -> Result<(), String> {
+    for fixture_ref in refs {
+        if !fixture_ref.starts_with("conformance/protocols/fixtures/") {
+            return Err(format!(
+                "protocol fixture ref must point under conformance/protocols/fixtures: {fixture_ref}"
+            ));
+        }
+        let path = Path::new(fixture_ref);
+        if path.is_absolute() {
+            return Err(format!(
+                "protocol fixture ref must be repo-relative: {fixture_ref}"
+            ));
+        }
+        let candidate = repo_root.join(path);
+        if !candidate.is_file() {
+            return Err(format!(
+                "protocol fixture ref not found: {}",
+                candidate.display()
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn matches_replay_benchmark_filter(filter: Option<&str>, path: &str, name: &str) -> bool {
+    let Some(filter) = filter else {
+        return true;
+    };
+    path.contains(filter) || name.contains(filter)
+}
+
+fn replay_trace_adapter(adapter_id: &str) -> Result<Box<dyn harn_vm::ReplayTraceAdapter>, String> {
+    match adapter_id {
+        harn_vm::OPENCODE_JSONL_ADAPTER_ID | "opencode" => {
+            Ok(Box::new(harn_vm::OpenCodeJsonlAdapter))
+        }
+        other => Err(format!(
+            "unsupported replay trace adapter `{other}`; expected `{}`",
+            harn_vm::OPENCODE_JSONL_ADAPTER_ID
+        )),
+    }
+}
+
+fn write_replay_benchmark_report(path: &Path, json: &str) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent)
+                .map_err(|error| format!("create {}: {error}", parent.display()))?;
+        }
+    }
+    fs::write(path, json).map_err(|error| format!("write {}: {error}", path.display()))
+}
+
+fn render_replay_benchmark_report(report: &harn_vm::ReplayBenchmarkReport) -> String {
+    let mut out = format!(
+        "\
+Replay benchmark: {}
+Fixtures: {} passed, {} failed
+Mean replay fidelity: {:.3}
+Permission preservation: {:.3}
+Tool-call drift count: {}
+Transcript drift count: {}
+Observed interactions: {}
+",
+        report.suite.name,
+        report.summary.passed,
+        report.summary.failed,
+        report.summary.mean_replay_fidelity_score,
+        report.summary.mean_permission_decision_preservation_score,
+        report.summary.tool_call_drift_count,
+        report.summary.transcript_drift_count,
+        report.summary.observed_interactions,
+    );
+    for fixture in &report.fixtures {
+        let status = if fixture.passed { "PASS" } else { "FAIL" };
+        out.push_str(&format!(
+            "  {status} {} fidelity={:.3} determinism={:.3} tool_drift={} transcript_drift={}\n",
+            fixture.name,
+            fixture.metrics.replay_fidelity_score,
+            fixture.metrics.determinism_score,
+            fixture.metrics.tool_call_drift_count,
+            fixture.metrics.transcript_drift_count,
+        ));
+        if let Some(divergence) = &fixture.first_divergence {
+            out.push_str(&format!("    first divergence: {}\n", divergence.path));
+        }
+    }
+    out
+}
+
+fn discover_repo_root() -> Option<PathBuf> {
+    let cwd = std::env::current_dir().ok()?;
+    for ancestor in cwd.ancestors() {
+        if ancestor.join("Cargo.toml").is_file() && ancestor.join("conformance").is_dir() {
+            return Some(ancestor.to_path_buf());
+        }
+    }
+    None
+}
+
+fn display_path(path: &Path) -> String {
+    discover_repo_root()
+        .and_then(|root| path.strip_prefix(root).ok().map(Path::to_path_buf))
+        .unwrap_or_else(|| path.to_path_buf())
+        .components()
+        .map(|component| component.as_os_str().to_string_lossy())
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        bench_stats, percentile_sorted, render_bench_report, write_bench_profile_json, BenchRun,
+        bench_stats, percentile_sorted, read_replay_trace_fixture, render_bench_report,
+        render_replay_benchmark_report, resolve_replay_benchmark_selection,
+        validate_protocol_fixture_refs, write_bench_profile_json, BenchRun,
     };
+    use std::path::PathBuf;
 
     fn bench_run(iteration: usize, wall_time_ms: f64) -> BenchRun {
         BenchRun {
@@ -417,5 +761,50 @@ mod tests {
         assert_eq!(value["p95_ms"], 13.8);
         assert_eq!(value["stddev_ms"], 2.0);
         assert!(value["rollup"]["by_kind"].is_array());
+    }
+
+    #[test]
+    fn replay_benchmark_suite_manifest_runs_canonical_fixtures() {
+        let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(|path| path.parent())
+            .expect("repo root")
+            .to_path_buf();
+        let selection = repo_root.join("benchmarks/replay/suite.json");
+        let (suite_name, fixture_paths) =
+            resolve_replay_benchmark_selection(&selection, &repo_root, "fallback")
+                .expect("resolve replay benchmark suite");
+        assert_eq!(suite_name, "harn-canonical-replay-determinism");
+        assert_eq!(fixture_paths.len(), 3);
+
+        let reports = fixture_paths
+            .iter()
+            .map(|path| {
+                let trace = read_replay_trace_fixture(path).expect("read replay fixture");
+                validate_protocol_fixture_refs(&repo_root, &trace.protocol_fixture_refs)
+                    .expect("protocol refs valid");
+                harn_vm::benchmark_replay_trace(path.to_string_lossy(), &trace)
+                    .expect("benchmark replay trace")
+            })
+            .collect::<Vec<_>>();
+        let report = harn_vm::build_replay_benchmark_report(
+            suite_name,
+            reports.iter().map(|fixture| fixture.path.clone()).collect(),
+            reports,
+        );
+
+        assert_eq!(report.summary.passed, 3);
+        assert_eq!(report.summary.failed, 0);
+        assert_eq!(report.summary.deterministic_fixtures, 3);
+        assert_eq!(report.summary.tool_call_drift_count, 0);
+        assert_eq!(report.summary.transcript_drift_count, 0);
+        assert_eq!(report.summary.mean_replay_fidelity_score, 1.0);
+        assert_eq!(
+            report.summary.mean_permission_decision_preservation_score,
+            1.0
+        );
+        let text = render_replay_benchmark_report(&report);
+        assert!(text.contains("Replay benchmark: harn-canonical-replay-determinism"));
+        assert!(text.contains("PASS simple_tool_run"));
     }
 }

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -752,14 +752,7 @@ async fn async_main() {
             )
         }
         Command::Repl => commands::repl::run_repl().await,
-        Command::Bench(args) => {
-            commands::bench::run_bench(
-                &args.file,
-                args.iterations,
-                run_profile_options(&args.profile),
-            )
-            .await
-        }
+        Command::Bench(args) => commands::bench::run(args).await,
         Command::TestBench(args) => commands::test_bench::run(args.command).await,
         Command::Viz(args) => commands::viz::run_viz(&args.file, args.output.as_deref()),
         Command::Install(args) => package::install_packages(

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -148,6 +148,15 @@ pub use mcp_server::{
 };
 pub use metadata::{register_metadata_builtins, register_scan_builtins};
 pub use orchestration::{
+    benchmark_adapted_replay_pair, benchmark_replay_trace, build_replay_benchmark_report,
+    OpenCodeJsonlAdapter, ReplayBenchmarkCloudIngest, ReplayBenchmarkError,
+    ReplayBenchmarkFixtureReceipt, ReplayBenchmarkFixtureReport, ReplayBenchmarkMetrics,
+    ReplayBenchmarkReport, ReplayBenchmarkSuiteIdentity, ReplayBenchmarkSummary,
+    ReplayCategoryMetric, ReplayDebuggingProxyMetrics, ReplayRuntimeCostMetrics,
+    ReplayTraceAdapter, OPENCODE_JSONL_ADAPTER_ID, OPENCODE_JSONL_ADAPTER_SCHEMA_VERSION,
+    REPLAY_BENCHMARK_CLOUD_INGEST_KIND, REPLAY_BENCHMARK_REPORT_SCHEMA_VERSION,
+};
+pub use orchestration::{
     canonicalize_run, first_divergence, run_replay_oracle_trace, ReplayAllowlistRule,
     ReplayDivergence, ReplayExpectation, ReplayOracleError, ReplayOracleReport, ReplayOracleTrace,
     ReplayTraceRun, ReplayTraceRunCounts, REPLAY_TRACE_SCHEMA_VERSION,

--- a/crates/harn-vm/src/orchestration/mod.rs
+++ b/crates/harn-vm/src/orchestration/mod.rs
@@ -54,6 +54,9 @@ pub use release_fixture::*;
 mod replay_oracle;
 pub use replay_oracle::*;
 
+mod replay_bench;
+pub use replay_bench::*;
+
 mod policy;
 pub use policy::*;
 

--- a/crates/harn-vm/src/orchestration/replay_bench.rs
+++ b/crates/harn-vm/src/orchestration/replay_bench.rs
@@ -1,0 +1,1033 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value as JsonValue};
+use sha2::{Digest, Sha256};
+
+use super::{
+    canonicalize_run, run_replay_oracle_trace, ReplayAllowlistRule, ReplayDivergence,
+    ReplayExpectation, ReplayOracleError, ReplayOracleReport, ReplayOracleTrace, ReplayTraceRun,
+    ReplayTraceRunCounts, REPLAY_TRACE_SCHEMA_VERSION,
+};
+
+pub const REPLAY_BENCHMARK_REPORT_SCHEMA_VERSION: &str = "harn.replay_benchmark.report.v1";
+pub const REPLAY_BENCHMARK_CLOUD_INGEST_KIND: &str = "harn_cloud.replay_determinism.leaderboard.v1";
+pub const OPENCODE_JSONL_ADAPTER_ID: &str = "opencode-jsonl";
+pub const OPENCODE_JSONL_ADAPTER_SCHEMA_VERSION: &str =
+    "harn.replay_benchmark.adapter.opencode_jsonl.v1";
+
+const REPLAY_TRACE_SECTIONS: [&str; 10] = [
+    "event_log_entries",
+    "trigger_firings",
+    "llm_interactions",
+    "protocol_interactions",
+    "approval_interactions",
+    "effect_receipts",
+    "persona_runtime_states",
+    "agent_transcript_deltas",
+    "final_artifacts",
+    "policy_decisions",
+];
+
+const TOOL_DRIFT_SECTIONS: [&str; 3] = [
+    "llm_interactions",
+    "protocol_interactions",
+    "effect_receipts",
+];
+
+const PERMISSION_SECTIONS: [&str; 2] = ["approval_interactions", "policy_decisions"];
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct ReplayBenchmarkReport {
+    pub schema_version: String,
+    pub cloud_ingest: ReplayBenchmarkCloudIngest,
+    pub suite: ReplayBenchmarkSuiteIdentity,
+    pub summary: ReplayBenchmarkSummary,
+    pub fixtures: Vec<ReplayBenchmarkFixtureReport>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct ReplayBenchmarkCloudIngest {
+    pub kind: String,
+    pub leaderboard_key: String,
+    pub report_schema_version: String,
+    pub replay_trace_schema_version: String,
+    pub artifact_contract: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct ReplayBenchmarkSuiteIdentity {
+    pub name: String,
+    pub fixture_count: usize,
+    pub source_paths: Vec<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct ReplayBenchmarkSummary {
+    pub passed: usize,
+    pub failed: usize,
+    pub deterministic_fixtures: usize,
+    pub drifted_fixtures: usize,
+    pub mean_replay_fidelity_score: f64,
+    pub mean_permission_decision_preservation_score: f64,
+    pub tool_call_drift_count: usize,
+    pub transcript_drift_count: usize,
+    pub observed_interactions: usize,
+    pub llm_input_tokens: u64,
+    pub llm_output_tokens: u64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct ReplayBenchmarkFixtureReport {
+    pub path: String,
+    pub name: String,
+    pub description: Option<String>,
+    pub expectation: ReplayExpectation,
+    pub passed: bool,
+    pub deterministic: bool,
+    pub first_run_counts: ReplayTraceRunCounts,
+    pub second_run_counts: ReplayTraceRunCounts,
+    pub metrics: ReplayBenchmarkMetrics,
+    pub first_divergence: Option<ReplayDivergence>,
+    pub receipt: ReplayBenchmarkFixtureReceipt,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct ReplayBenchmarkMetrics {
+    pub determinism_score: f64,
+    pub replay_fidelity_score: f64,
+    pub permission_decision_preservation_score: f64,
+    pub tool_call_drift_count: usize,
+    pub transcript_drift_count: usize,
+    pub runtime_cost: ReplayRuntimeCostMetrics,
+    pub debugging_time_to_root_cause_proxy: ReplayDebuggingProxyMetrics,
+    pub category_scores: BTreeMap<String, ReplayCategoryMetric>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct ReplayCategoryMetric {
+    pub compared: bool,
+    pub matched: bool,
+    pub drift_count: usize,
+    pub first_run_count: usize,
+    pub second_run_count: usize,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+pub struct ReplayRuntimeCostMetrics {
+    pub observed_interactions: usize,
+    pub event_log_entries: usize,
+    pub trigger_firings: usize,
+    pub llm_interactions: usize,
+    pub protocol_interactions: usize,
+    pub approval_interactions: usize,
+    pub effect_receipts: usize,
+    pub persona_runtime_states: usize,
+    pub agent_transcript_deltas: usize,
+    pub final_artifacts: usize,
+    pub policy_decisions: usize,
+    pub llm_input_tokens: u64,
+    pub llm_output_tokens: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub observed_cost_usd: Option<f64>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct ReplayDebuggingProxyMetrics {
+    pub proxy_kind: String,
+    pub first_divergence_path: Option<String>,
+    pub first_divergence_depth: usize,
+    pub drift_surface_count: usize,
+    pub estimated_triage_steps: usize,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct ReplayBenchmarkFixtureReceipt {
+    pub ingest_kind: String,
+    pub report_schema_version: String,
+    pub replay_trace_schema_version: String,
+    pub canonical_first_sha256: String,
+    pub canonical_second_sha256: String,
+    pub benchmark_receipt_sha256: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReplayBenchmarkError {
+    Oracle(ReplayOracleError),
+    Adapter(String),
+    Serialization(String),
+}
+
+impl fmt::Display for ReplayBenchmarkError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Oracle(error) => error.fmt(f),
+            Self::Adapter(message) | Self::Serialization(message) => message.fmt(f),
+        }
+    }
+}
+
+impl std::error::Error for ReplayBenchmarkError {}
+
+impl From<ReplayOracleError> for ReplayBenchmarkError {
+    fn from(error: ReplayOracleError) -> Self {
+        Self::Oracle(error)
+    }
+}
+
+pub trait ReplayTraceAdapter {
+    fn adapter_id(&self) -> &'static str;
+    fn input_schema_version(&self) -> &'static str;
+    fn adapt_run(&self, input: &str, run_id: &str) -> Result<ReplayTraceRun, ReplayBenchmarkError>;
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct OpenCodeJsonlAdapter;
+
+impl ReplayTraceAdapter for OpenCodeJsonlAdapter {
+    fn adapter_id(&self) -> &'static str {
+        OPENCODE_JSONL_ADAPTER_ID
+    }
+
+    fn input_schema_version(&self) -> &'static str {
+        OPENCODE_JSONL_ADAPTER_SCHEMA_VERSION
+    }
+
+    fn adapt_run(&self, input: &str, run_id: &str) -> Result<ReplayTraceRun, ReplayBenchmarkError> {
+        adapt_opencode_jsonl(input, run_id)
+    }
+}
+
+pub fn benchmark_replay_trace(
+    path: impl Into<String>,
+    trace: &ReplayOracleTrace,
+) -> Result<ReplayBenchmarkFixtureReport, ReplayBenchmarkError> {
+    let path = path.into();
+    let oracle = run_replay_oracle_trace(trace)?;
+    benchmark_replay_trace_from_oracle(path, trace, oracle)
+}
+
+pub fn benchmark_adapted_replay_pair(
+    adapter: &dyn ReplayTraceAdapter,
+    name: impl Into<String>,
+    first_input: &str,
+    second_input: &str,
+) -> Result<ReplayBenchmarkFixtureReport, ReplayBenchmarkError> {
+    let name = name.into();
+    let trace = ReplayOracleTrace {
+        schema_version: REPLAY_TRACE_SCHEMA_VERSION.to_string(),
+        name: name.clone(),
+        description: Some(format!(
+            "External replay trace pair adapted with {} ({})",
+            adapter.adapter_id(),
+            adapter.input_schema_version()
+        )),
+        expect: ReplayExpectation::Match,
+        allowlist: vec![ReplayAllowlistRule {
+            path: "/run_id".to_string(),
+            reason: "external trace runs are imported as separate executions".to_string(),
+            replacement: None,
+        }],
+        first_run: adapter.adapt_run(first_input, "adapted_first_run")?,
+        second_run: adapter.adapt_run(second_input, "adapted_second_run")?,
+        protocol_fixture_refs: Vec::new(),
+    };
+    benchmark_replay_trace(format!("adapter:{}:{name}", adapter.adapter_id()), &trace)
+}
+
+pub fn build_replay_benchmark_report(
+    suite_name: impl Into<String>,
+    source_paths: Vec<String>,
+    fixtures: Vec<ReplayBenchmarkFixtureReport>,
+) -> ReplayBenchmarkReport {
+    let suite_name = suite_name.into();
+    let summary = summarize_replay_benchmark(&fixtures);
+    ReplayBenchmarkReport {
+        schema_version: REPLAY_BENCHMARK_REPORT_SCHEMA_VERSION.to_string(),
+        cloud_ingest: ReplayBenchmarkCloudIngest {
+            kind: REPLAY_BENCHMARK_CLOUD_INGEST_KIND.to_string(),
+            leaderboard_key: "replay-determinism".to_string(),
+            report_schema_version: REPLAY_BENCHMARK_REPORT_SCHEMA_VERSION.to_string(),
+            replay_trace_schema_version: REPLAY_TRACE_SCHEMA_VERSION.to_string(),
+            artifact_contract:
+                "fixtures[].receipt + fixtures[].metrics are stable Cloud leaderboard inputs"
+                    .to_string(),
+        },
+        suite: ReplayBenchmarkSuiteIdentity {
+            name: suite_name,
+            fixture_count: fixtures.len(),
+            source_paths,
+        },
+        summary,
+        fixtures,
+    }
+}
+
+fn benchmark_replay_trace_from_oracle(
+    path: String,
+    trace: &ReplayOracleTrace,
+    oracle: ReplayOracleReport,
+) -> Result<ReplayBenchmarkFixtureReport, ReplayBenchmarkError> {
+    let first = canonicalize_run(&trace.first_run, &trace.allowlist)?;
+    let second = canonicalize_run(&trace.second_run, &trace.allowlist)?;
+    let category_scores = category_scores(&first, &second, &oracle);
+    let metrics = replay_metrics(trace, &oracle, category_scores)?;
+    let canonical_first_sha256 = sha256_json(&first)?;
+    let canonical_second_sha256 = sha256_json(&second)?;
+    let receipt = fixture_receipt(
+        &trace.name,
+        &path,
+        &metrics,
+        &canonical_first_sha256,
+        &canonical_second_sha256,
+    )?;
+
+    Ok(ReplayBenchmarkFixtureReport {
+        path,
+        name: oracle.name,
+        description: trace.description.clone(),
+        expectation: oracle.expectation,
+        passed: oracle.passed,
+        deterministic: oracle.divergence.is_none(),
+        first_run_counts: oracle.first_run_counts,
+        second_run_counts: oracle.second_run_counts,
+        metrics,
+        first_divergence: oracle.divergence,
+        receipt,
+    })
+}
+
+fn summarize_replay_benchmark(fixtures: &[ReplayBenchmarkFixtureReport]) -> ReplayBenchmarkSummary {
+    let fixture_count = fixtures.len();
+    let passed = fixtures.iter().filter(|fixture| fixture.passed).count();
+    let deterministic_fixtures = fixtures
+        .iter()
+        .filter(|fixture| fixture.deterministic)
+        .count();
+    let runtime = fixtures
+        .iter()
+        .fold(ReplayRuntimeCostMetrics::default(), |mut acc, fixture| {
+            let runtime = &fixture.metrics.runtime_cost;
+            acc.observed_interactions += runtime.observed_interactions;
+            acc.event_log_entries += runtime.event_log_entries;
+            acc.trigger_firings += runtime.trigger_firings;
+            acc.llm_interactions += runtime.llm_interactions;
+            acc.protocol_interactions += runtime.protocol_interactions;
+            acc.approval_interactions += runtime.approval_interactions;
+            acc.effect_receipts += runtime.effect_receipts;
+            acc.persona_runtime_states += runtime.persona_runtime_states;
+            acc.agent_transcript_deltas += runtime.agent_transcript_deltas;
+            acc.final_artifacts += runtime.final_artifacts;
+            acc.policy_decisions += runtime.policy_decisions;
+            acc.llm_input_tokens += runtime.llm_input_tokens;
+            acc.llm_output_tokens += runtime.llm_output_tokens;
+            acc.observed_cost_usd =
+                sum_optional_cost(acc.observed_cost_usd, runtime.observed_cost_usd);
+            acc
+        });
+    ReplayBenchmarkSummary {
+        passed,
+        failed: fixture_count.saturating_sub(passed),
+        deterministic_fixtures,
+        drifted_fixtures: fixture_count.saturating_sub(deterministic_fixtures),
+        mean_replay_fidelity_score: average_metric(fixtures, |fixture| {
+            fixture.metrics.replay_fidelity_score
+        }),
+        mean_permission_decision_preservation_score: average_metric(fixtures, |fixture| {
+            fixture.metrics.permission_decision_preservation_score
+        }),
+        tool_call_drift_count: fixtures
+            .iter()
+            .map(|fixture| fixture.metrics.tool_call_drift_count)
+            .sum(),
+        transcript_drift_count: fixtures
+            .iter()
+            .map(|fixture| fixture.metrics.transcript_drift_count)
+            .sum(),
+        observed_interactions: runtime.observed_interactions,
+        llm_input_tokens: runtime.llm_input_tokens,
+        llm_output_tokens: runtime.llm_output_tokens,
+    }
+}
+
+fn replay_metrics(
+    trace: &ReplayOracleTrace,
+    oracle: &ReplayOracleReport,
+    category_scores: BTreeMap<String, ReplayCategoryMetric>,
+) -> Result<ReplayBenchmarkMetrics, ReplayBenchmarkError> {
+    let compared_categories = category_scores
+        .values()
+        .filter(|metric| metric.compared)
+        .count();
+    let matched_categories = category_scores
+        .values()
+        .filter(|metric| metric.compared && metric.matched)
+        .count();
+    let replay_fidelity_score = if compared_categories == 0 {
+        0.0
+    } else {
+        matched_categories as f64 / compared_categories as f64
+    };
+    let permission_decision_preservation_score =
+        section_score(&category_scores, &PERMISSION_SECTIONS);
+    let tool_call_drift_count = section_drift_count(&category_scores, &TOOL_DRIFT_SECTIONS);
+    let transcript_drift_count =
+        section_drift_count(&category_scores, &["agent_transcript_deltas"]);
+    let runtime_cost = runtime_cost_metrics(&trace.first_run, &trace.second_run);
+    let debugging_time_to_root_cause_proxy =
+        debugging_proxy_metrics(oracle.divergence.as_ref(), &category_scores);
+
+    Ok(ReplayBenchmarkMetrics {
+        determinism_score: if oracle.divergence.is_none() {
+            1.0
+        } else {
+            0.0
+        },
+        replay_fidelity_score,
+        permission_decision_preservation_score,
+        tool_call_drift_count,
+        transcript_drift_count,
+        runtime_cost,
+        debugging_time_to_root_cause_proxy,
+        category_scores,
+    })
+}
+
+fn category_scores(
+    first: &JsonValue,
+    second: &JsonValue,
+    oracle: &ReplayOracleReport,
+) -> BTreeMap<String, ReplayCategoryMetric> {
+    let first_counts = counts_by_section(&oracle.first_run_counts);
+    let second_counts = counts_by_section(&oracle.second_run_counts);
+    REPLAY_TRACE_SECTIONS
+        .iter()
+        .map(|section| {
+            let first_value = first.get(*section).unwrap_or(&JsonValue::Null);
+            let second_value = second.get(*section).unwrap_or(&JsonValue::Null);
+            let first_run_count = first_counts.get(*section).copied().unwrap_or_default();
+            let second_run_count = second_counts.get(*section).copied().unwrap_or_default();
+            let compared = first_run_count > 0 || second_run_count > 0;
+            let drift_count = if compared {
+                drift_count(first_value, second_value)
+            } else {
+                0
+            };
+            (
+                (*section).to_string(),
+                ReplayCategoryMetric {
+                    compared,
+                    matched: drift_count == 0,
+                    drift_count,
+                    first_run_count,
+                    second_run_count,
+                },
+            )
+        })
+        .collect()
+}
+
+fn counts_by_section(counts: &ReplayTraceRunCounts) -> BTreeMap<&'static str, usize> {
+    BTreeMap::from([
+        ("event_log_entries", counts.event_log_entries),
+        ("trigger_firings", counts.trigger_firings),
+        ("llm_interactions", counts.llm_interactions),
+        ("protocol_interactions", counts.protocol_interactions),
+        ("approval_interactions", counts.approval_interactions),
+        ("effect_receipts", counts.effect_receipts),
+        ("persona_runtime_states", counts.persona_runtime_states),
+        ("agent_transcript_deltas", counts.agent_transcript_deltas),
+        ("final_artifacts", counts.final_artifacts),
+        ("policy_decisions", counts.policy_decisions),
+    ])
+}
+
+fn drift_count(first: &JsonValue, second: &JsonValue) -> usize {
+    if first == second {
+        return 0;
+    }
+    match (first, second) {
+        (JsonValue::Array(first_items), JsonValue::Array(second_items)) => {
+            let shared = first_items.len().min(second_items.len());
+            let item_drifts = (0..shared)
+                .filter(|index| first_items[*index] != second_items[*index])
+                .count();
+            item_drifts + first_items.len().abs_diff(second_items.len())
+        }
+        (JsonValue::Object(first_map), JsonValue::Object(second_map)) => {
+            let keys = first_map
+                .keys()
+                .chain(second_map.keys())
+                .collect::<BTreeSet<_>>();
+            keys.into_iter()
+                .filter(|key| first_map.get(*key) != second_map.get(*key))
+                .count()
+        }
+        _ => 1,
+    }
+}
+
+fn section_score(
+    category_scores: &BTreeMap<String, ReplayCategoryMetric>,
+    sections: &[&str],
+) -> f64 {
+    let compared = sections
+        .iter()
+        .filter_map(|section| category_scores.get(*section))
+        .filter(|metric| metric.compared)
+        .collect::<Vec<_>>();
+    if compared.is_empty() {
+        return 1.0;
+    }
+    compared.iter().filter(|metric| metric.matched).count() as f64 / compared.len() as f64
+}
+
+fn section_drift_count(
+    category_scores: &BTreeMap<String, ReplayCategoryMetric>,
+    sections: &[&str],
+) -> usize {
+    sections
+        .iter()
+        .filter_map(|section| category_scores.get(*section))
+        .map(|metric| metric.drift_count)
+        .sum()
+}
+
+fn runtime_cost_metrics(
+    first_run: &ReplayTraceRun,
+    second_run: &ReplayTraceRun,
+) -> ReplayRuntimeCostMetrics {
+    let first = first_run.counts();
+    let second = second_run.counts();
+    let observed_cost_usd =
+        sum_optional_cost(cost_usd_for_run(first_run), cost_usd_for_run(second_run));
+    ReplayRuntimeCostMetrics {
+        observed_interactions: trace_material_count(&first) + trace_material_count(&second),
+        event_log_entries: first.event_log_entries + second.event_log_entries,
+        trigger_firings: first.trigger_firings + second.trigger_firings,
+        llm_interactions: first.llm_interactions + second.llm_interactions,
+        protocol_interactions: first.protocol_interactions + second.protocol_interactions,
+        approval_interactions: first.approval_interactions + second.approval_interactions,
+        effect_receipts: first.effect_receipts + second.effect_receipts,
+        persona_runtime_states: first.persona_runtime_states + second.persona_runtime_states,
+        agent_transcript_deltas: first.agent_transcript_deltas + second.agent_transcript_deltas,
+        final_artifacts: first.final_artifacts + second.final_artifacts,
+        policy_decisions: first.policy_decisions + second.policy_decisions,
+        llm_input_tokens: token_total(first_run, "input_tokens")
+            + token_total(second_run, "input_tokens"),
+        llm_output_tokens: token_total(first_run, "output_tokens")
+            + token_total(second_run, "output_tokens"),
+        observed_cost_usd,
+    }
+}
+
+fn trace_material_count(counts: &ReplayTraceRunCounts) -> usize {
+    counts.event_log_entries
+        + counts.trigger_firings
+        + counts.llm_interactions
+        + counts.protocol_interactions
+        + counts.approval_interactions
+        + counts.effect_receipts
+        + counts.persona_runtime_states
+        + counts.agent_transcript_deltas
+        + counts.final_artifacts
+        + counts.policy_decisions
+}
+
+fn token_total(run: &ReplayTraceRun, token_key: &str) -> u64 {
+    run.llm_interactions
+        .iter()
+        .filter_map(|interaction| {
+            interaction
+                .get(token_key)
+                .and_then(JsonValue::as_u64)
+                .or_else(|| {
+                    interaction
+                        .get("usage")
+                        .and_then(|usage| usage.get(token_key))
+                        .and_then(JsonValue::as_u64)
+                })
+        })
+        .sum()
+}
+
+fn cost_usd_for_run(run: &ReplayTraceRun) -> Option<f64> {
+    let mut seen = false;
+    let mut total = 0.0;
+    for interaction in &run.llm_interactions {
+        if let Some(cost) = interaction
+            .get("cost_usd")
+            .and_then(JsonValue::as_f64)
+            .or_else(|| {
+                interaction
+                    .get("usage")
+                    .and_then(|usage| usage.get("cost_usd"))
+                    .and_then(JsonValue::as_f64)
+            })
+        {
+            seen = true;
+            total += cost;
+        }
+    }
+    seen.then_some(total)
+}
+
+fn sum_optional_cost(left: Option<f64>, right: Option<f64>) -> Option<f64> {
+    match (left, right) {
+        (Some(left), Some(right)) => Some(left + right),
+        (Some(value), None) | (None, Some(value)) => Some(value),
+        (None, None) => None,
+    }
+}
+
+fn debugging_proxy_metrics(
+    divergence: Option<&ReplayDivergence>,
+    category_scores: &BTreeMap<String, ReplayCategoryMetric>,
+) -> ReplayDebuggingProxyMetrics {
+    let first_divergence_path = divergence.map(|divergence| divergence.path.clone());
+    let first_divergence_depth = first_divergence_path
+        .as_deref()
+        .map(json_path_depth)
+        .unwrap_or_default();
+    let drift_surface_count = category_scores
+        .values()
+        .filter(|metric| metric.compared && !metric.matched)
+        .count();
+    ReplayDebuggingProxyMetrics {
+        proxy_kind: "first_divergence_depth_plus_drift_surfaces".to_string(),
+        first_divergence_path,
+        first_divergence_depth,
+        drift_surface_count,
+        estimated_triage_steps: if drift_surface_count == 0 {
+            0
+        } else {
+            1 + first_divergence_depth + drift_surface_count
+        },
+    }
+}
+
+fn json_path_depth(path: &str) -> usize {
+    let path = path.trim();
+    if path == "$" {
+        return 0;
+    }
+    if let Some(pointer_path) = path.strip_prefix('/') {
+        return pointer_path
+            .split('/')
+            .filter(|segment| !segment.is_empty())
+            .count();
+    }
+    path.split('.')
+        .filter(|segment| !segment.is_empty() && *segment != "$")
+        .count()
+}
+
+fn fixture_receipt(
+    name: &str,
+    path: &str,
+    metrics: &ReplayBenchmarkMetrics,
+    canonical_first_sha256: &str,
+    canonical_second_sha256: &str,
+) -> Result<ReplayBenchmarkFixtureReceipt, ReplayBenchmarkError> {
+    let receipt_material = json!({
+        "ingest_kind": REPLAY_BENCHMARK_CLOUD_INGEST_KIND,
+        "report_schema_version": REPLAY_BENCHMARK_REPORT_SCHEMA_VERSION,
+        "replay_trace_schema_version": REPLAY_TRACE_SCHEMA_VERSION,
+        "name": name,
+        "path": path,
+        "canonical_first_sha256": canonical_first_sha256,
+        "canonical_second_sha256": canonical_second_sha256,
+        "metrics": metrics,
+    });
+    Ok(ReplayBenchmarkFixtureReceipt {
+        ingest_kind: REPLAY_BENCHMARK_CLOUD_INGEST_KIND.to_string(),
+        report_schema_version: REPLAY_BENCHMARK_REPORT_SCHEMA_VERSION.to_string(),
+        replay_trace_schema_version: REPLAY_TRACE_SCHEMA_VERSION.to_string(),
+        canonical_first_sha256: canonical_first_sha256.to_string(),
+        canonical_second_sha256: canonical_second_sha256.to_string(),
+        benchmark_receipt_sha256: sha256_json(&receipt_material)?,
+    })
+}
+
+fn sha256_json(value: &JsonValue) -> Result<String, ReplayBenchmarkError> {
+    let bytes = serde_json::to_vec(value)
+        .map_err(|error| ReplayBenchmarkError::Serialization(error.to_string()))?;
+    Ok(format!("sha256:{}", hex::encode(Sha256::digest(bytes))))
+}
+
+fn sha256_value(value: &JsonValue) -> Result<String, ReplayBenchmarkError> {
+    sha256_json(value)
+}
+
+fn sha256_text(text: &str) -> String {
+    format!("sha256:{}", hex::encode(Sha256::digest(text.as_bytes())))
+}
+
+fn average_metric(
+    fixtures: &[ReplayBenchmarkFixtureReport],
+    metric: impl Fn(&ReplayBenchmarkFixtureReport) -> f64,
+) -> f64 {
+    if fixtures.is_empty() {
+        0.0
+    } else {
+        fixtures.iter().map(metric).sum::<f64>() / fixtures.len() as f64
+    }
+}
+
+fn adapt_opencode_jsonl(input: &str, run_id: &str) -> Result<ReplayTraceRun, ReplayBenchmarkError> {
+    let mut run = ReplayTraceRun {
+        run_id: run_id.to_string(),
+        ..ReplayTraceRun::default()
+    };
+    for (index, raw_line) in input.lines().enumerate() {
+        let line_no = index + 1;
+        let line = raw_line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let value: JsonValue = serde_json::from_str(line).map_err(|error| {
+            ReplayBenchmarkError::Adapter(format!(
+                "invalid {} JSONL line {line_no}: {error}",
+                OPENCODE_JSONL_ADAPTER_ID
+            ))
+        })?;
+        let object = value.as_object().ok_or_else(|| {
+            ReplayBenchmarkError::Adapter(format!(
+                "{} JSONL line {line_no} must be an object",
+                OPENCODE_JSONL_ADAPTER_ID
+            ))
+        })?;
+        let event_type = object
+            .get("type")
+            .or_else(|| object.get("event"))
+            .and_then(JsonValue::as_str)
+            .unwrap_or("event");
+        match event_type {
+            "message" | "session.message" => {
+                run.agent_transcript_deltas
+                    .push(adapt_opencode_message(object, line_no));
+            }
+            "tool_call" | "tool" | "session.tool_call" => {
+                let (protocol, receipt) = adapt_opencode_tool_call(object, line_no)?;
+                run.protocol_interactions.push(protocol);
+                run.effect_receipts.push(receipt);
+            }
+            "permission" | "permission_decision" | "session.permission" => {
+                let (approval, policy) = adapt_opencode_permission(object, line_no);
+                run.approval_interactions.push(approval);
+                run.policy_decisions.push(policy);
+            }
+            "llm" | "model" | "session.llm" => {
+                run.llm_interactions
+                    .push(adapt_opencode_llm(object, line_no));
+            }
+            _ => run
+                .event_log_entries
+                .push(adapt_opencode_event(object, event_type, line_no)),
+        }
+    }
+    if trace_material_count(&run.counts()) == 0 {
+        return Err(ReplayBenchmarkError::Adapter(format!(
+            "{} input contained no adaptable events",
+            OPENCODE_JSONL_ADAPTER_ID
+        )));
+    }
+    Ok(run)
+}
+
+fn adapt_opencode_message(
+    object: &serde_json::Map<String, JsonValue>,
+    line_no: usize,
+) -> JsonValue {
+    let content = object.get("content").cloned().unwrap_or(JsonValue::Null);
+    json!({
+        "delta_id": object_string(object, "id").unwrap_or_else(|| format!("message-{line_no}")),
+        "agent": object_string(object, "agent").unwrap_or_else(|| "opencode".to_string()),
+        "role": object_string(object, "role").unwrap_or_else(|| "assistant".to_string()),
+        "content_sha256": sha256_text(&content.to_string()),
+    })
+}
+
+fn adapt_opencode_tool_call(
+    object: &serde_json::Map<String, JsonValue>,
+    line_no: usize,
+) -> Result<(JsonValue, JsonValue), ReplayBenchmarkError> {
+    let tool = object_string(object, "tool")
+        .or_else(|| object_string(object, "name"))
+        .unwrap_or_else(|| "unknown_tool".to_string());
+    let arguments = object
+        .get("arguments")
+        .or_else(|| object.get("args"))
+        .cloned()
+        .unwrap_or_else(|| json!({}));
+    let result = object
+        .get("result")
+        .or_else(|| object.get("output"))
+        .cloned()
+        .unwrap_or(JsonValue::Null);
+    let status = object_string(object, "status").unwrap_or_else(|| "completed".to_string());
+    let arguments_sha256 = sha256_value(&arguments)?;
+    let result_sha256 = sha256_value(&result)?;
+    Ok((
+        json!({
+            "protocol": "opencode",
+            "boundary": "tool_call",
+            "tool": tool,
+            "call_id": object_string(object, "id").unwrap_or_else(|| format!("tool-{line_no}")),
+            "arguments_sha256": arguments_sha256,
+            "status": status,
+            "result_sha256": result_sha256,
+        }),
+        json!({
+            "receipt_id": object_string(object, "receipt_id").unwrap_or_else(|| format!("tool-receipt-{line_no}")),
+            "kind": "tool_call",
+            "tool": tool,
+            "status": status,
+            "arguments_sha256": arguments_sha256,
+            "result_sha256": result_sha256,
+        }),
+    ))
+}
+
+fn adapt_opencode_permission(
+    object: &serde_json::Map<String, JsonValue>,
+    line_no: usize,
+) -> (JsonValue, JsonValue) {
+    let action = object_string(object, "action").unwrap_or_else(|| "unknown".to_string());
+    let decision = object_string(object, "decision")
+        .or_else(|| object_string(object, "response"))
+        .unwrap_or_else(|| "unknown".to_string());
+    (
+        json!({
+            "request_id": object_string(object, "id").unwrap_or_else(|| format!("permission-{line_no}")),
+            "principal": object_string(object, "principal").unwrap_or_else(|| "agent".to_string()),
+            "action": action,
+            "response": decision,
+            "reviewer": object.get("reviewer").cloned().unwrap_or(JsonValue::Null),
+        }),
+        json!({
+            "decision_id": object_string(object, "decision_id").unwrap_or_else(|| format!("policy-{line_no}")),
+            "capability": object_string(object, "capability").unwrap_or(action),
+            "decision": decision,
+            "approval_required": true,
+        }),
+    )
+}
+
+fn adapt_opencode_llm(object: &serde_json::Map<String, JsonValue>, line_no: usize) -> JsonValue {
+    let input_tokens = object
+        .get("input_tokens")
+        .and_then(JsonValue::as_u64)
+        .or_else(|| {
+            object
+                .get("usage")
+                .and_then(|usage| usage.get("input_tokens"))
+                .and_then(JsonValue::as_u64)
+        })
+        .unwrap_or_default();
+    let output_tokens = object
+        .get("output_tokens")
+        .and_then(JsonValue::as_u64)
+        .or_else(|| {
+            object
+                .get("usage")
+                .and_then(|usage| usage.get("output_tokens"))
+                .and_then(JsonValue::as_u64)
+        })
+        .unwrap_or_default();
+    let messages_sha256 = object
+        .get("messages")
+        .map(|value| sha256_text(&value.to_string()))
+        .unwrap_or_else(|| sha256_text(""));
+    let response_sha256 = object
+        .get("response")
+        .map(|value| sha256_text(&value.to_string()))
+        .unwrap_or_else(|| sha256_text(""));
+    json!({
+        "request_id": object_string(object, "id").unwrap_or_else(|| format!("llm-{line_no}")),
+        "provider": object_string(object, "provider").unwrap_or_else(|| "opencode".to_string()),
+        "model": object_string(object, "model").unwrap_or_else(|| "unknown".to_string()),
+        "messages_sha256": messages_sha256,
+        "response_sha256": response_sha256,
+        "usage": {
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+        },
+    })
+}
+
+fn adapt_opencode_event(
+    object: &serde_json::Map<String, JsonValue>,
+    event_type: &str,
+    line_no: usize,
+) -> JsonValue {
+    json!({
+        "event_id": line_no,
+        "topic": object_string(object, "topic").unwrap_or_else(|| "opencode.session".to_string()),
+        "kind": event_type,
+        "payload": object.get("payload").cloned().unwrap_or_else(|| JsonValue::Object(object.clone())),
+    })
+}
+
+fn object_string(object: &serde_json::Map<String, JsonValue>, key: &str) -> Option<String> {
+    object
+        .get(key)
+        .and_then(JsonValue::as_str)
+        .map(str::to_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn trace_pair(status: (&str, &str)) -> ReplayOracleTrace {
+        ReplayOracleTrace {
+            schema_version: REPLAY_TRACE_SCHEMA_VERSION.to_string(),
+            name: "simple_tool_run".to_string(),
+            description: Some("golden replay benchmark fixture".to_string()),
+            expect: ReplayExpectation::Match,
+            allowlist: vec![ReplayAllowlistRule {
+                path: "/run_id".to_string(),
+                reason: "run ids are allocated per execution".to_string(),
+                replacement: None,
+            }],
+            first_run: ReplayTraceRun {
+                run_id: "first".to_string(),
+                protocol_interactions: vec![json!({
+                    "protocol": "mcp",
+                    "boundary": "tools/call",
+                    "tool": "read_file",
+                    "status": status.0,
+                })],
+                policy_decisions: vec![json!({
+                    "capability": "fs.read",
+                    "decision": "allow",
+                })],
+                ..ReplayTraceRun::default()
+            },
+            second_run: ReplayTraceRun {
+                run_id: "second".to_string(),
+                protocol_interactions: vec![json!({
+                    "protocol": "mcp",
+                    "boundary": "tools/call",
+                    "tool": "read_file",
+                    "status": status.1,
+                })],
+                policy_decisions: vec![json!({
+                    "capability": "fs.read",
+                    "decision": "allow",
+                })],
+                ..ReplayTraceRun::default()
+            },
+            protocol_fixture_refs: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn replay_benchmark_reports_stable_golden_metrics_for_matching_trace() {
+        let fixture =
+            benchmark_replay_trace("benchmarks/replay/simple.json", &trace_pair(("ok", "ok")))
+                .expect("benchmark fixture");
+
+        assert!(fixture.passed);
+        assert!(fixture.deterministic);
+        assert_eq!(fixture.metrics.determinism_score, 1.0);
+        assert_eq!(fixture.metrics.replay_fidelity_score, 1.0);
+        assert_eq!(fixture.metrics.permission_decision_preservation_score, 1.0);
+        assert_eq!(fixture.metrics.tool_call_drift_count, 0);
+        assert!(fixture
+            .receipt
+            .benchmark_receipt_sha256
+            .starts_with("sha256:"));
+    }
+
+    #[test]
+    fn replay_benchmark_reports_reduced_fidelity_for_meaningful_drift() {
+        let fixture =
+            benchmark_replay_trace("benchmarks/replay/drift.json", &trace_pair(("ok", "error")))
+                .expect("benchmark fixture");
+
+        assert!(!fixture.passed);
+        assert!(!fixture.deterministic);
+        assert_eq!(fixture.metrics.determinism_score, 0.0);
+        assert_eq!(fixture.metrics.replay_fidelity_score, 0.5);
+        assert_eq!(fixture.metrics.tool_call_drift_count, 1);
+        assert_eq!(
+            fixture
+                .metrics
+                .debugging_time_to_root_cause_proxy
+                .first_divergence_path
+                .as_deref(),
+            Some("/protocol_interactions/0/status")
+        );
+        assert_eq!(
+            fixture
+                .metrics
+                .debugging_time_to_root_cause_proxy
+                .first_divergence_depth,
+            3
+        );
+        assert_eq!(
+            fixture
+                .metrics
+                .debugging_time_to_root_cause_proxy
+                .estimated_triage_steps,
+            5
+        );
+    }
+
+    #[test]
+    fn replay_benchmark_summary_is_stable_across_repeated_runs() {
+        let first = benchmark_replay_trace("fixture.json", &trace_pair(("ok", "ok")))
+            .expect("first benchmark");
+        let second = benchmark_replay_trace("fixture.json", &trace_pair(("ok", "ok")))
+            .expect("second benchmark");
+
+        let first_json = serde_json::to_string(&first).expect("serialize first");
+        let second_json = serde_json::to_string(&second).expect("serialize second");
+        assert_eq!(first_json, second_json);
+    }
+
+    #[test]
+    fn opencode_jsonl_adapter_maps_messages_tools_permissions_and_llm_usage() {
+        let input = concat!(
+            "{\"type\":\"message\",\"id\":\"m1\",\"role\":\"assistant\",\"content\":\"done\"}\n",
+            "{\"type\":\"tool_call\",\"id\":\"t1\",\"tool\":\"write_file\",\"arguments\":{\"path\":\"notes.md\"},\"result\":{\"ok\":true}}\n",
+            "{\"type\":\"permission\",\"id\":\"p1\",\"action\":\"write_file\",\"decision\":\"approved\"}\n",
+            "{\"type\":\"llm\",\"id\":\"l1\",\"model\":\"qwen\",\"usage\":{\"input_tokens\":7,\"output_tokens\":3}}\n"
+        );
+
+        let run = OpenCodeJsonlAdapter
+            .adapt_run(input, "opencode-run")
+            .expect("adapt opencode jsonl");
+
+        assert_eq!(run.run_id, "opencode-run");
+        assert_eq!(run.agent_transcript_deltas.len(), 1);
+        assert_eq!(run.protocol_interactions.len(), 1);
+        assert_eq!(run.effect_receipts.len(), 1);
+        assert_eq!(run.approval_interactions.len(), 1);
+        assert_eq!(run.policy_decisions.len(), 1);
+        assert_eq!(run.llm_interactions.len(), 1);
+        assert_eq!(token_total(&run, "input_tokens"), 7);
+        assert_eq!(token_total(&run, "output_tokens"), 3);
+    }
+
+    #[test]
+    fn adapted_trace_pair_can_be_benchmarked() {
+        let first = "{\"type\":\"tool_call\",\"tool\":\"read_file\",\"result\":{\"ok\":true}}\n";
+        let second = "{\"type\":\"tool_call\",\"tool\":\"read_file\",\"result\":{\"ok\":true}}\n";
+
+        let fixture = benchmark_adapted_replay_pair(
+            &OpenCodeJsonlAdapter,
+            "external-tool-run",
+            first,
+            second,
+        )
+        .expect("benchmark adapted pair");
+
+        assert!(fixture.passed);
+        assert_eq!(fixture.name, "external-tool-run");
+        assert_eq!(fixture.metrics.tool_call_drift_count, 0);
+    }
+}

--- a/docs/fixtures/github-actions/harn-replay-benchmark.yml
+++ b/docs/fixtures/github-actions/harn-replay-benchmark.yml
@@ -1,0 +1,26 @@
+name: Harn Replay Benchmark
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  replay-benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Harn
+        run: cargo install --git https://github.com/burin-labs/harn --locked harn-cli
+
+      - name: Run replay benchmark
+        run: harn bench replay --json --output replay-benchmark.json
+
+      - name: Upload benchmark artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: harn-replay-benchmark
+          path: replay-benchmark.json

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -133,6 +133,7 @@
 - [Debugging agent runs](./debugging.md)
 - [Trigger observability in the action graph](./observability/triggers-in-action-graph.md)
 - [Orchestrator observability](./orchestrator/observability.md)
+- [Replay benchmarks](./observability/replay-benchmarks.md)
 
 # Operations
 

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -205,12 +205,15 @@ control-flow blocks directly.
 
 ## harn bench
 
-Benchmark a `.harn` file over repeated runs.
+Benchmark a `.harn` file over repeated runs, or score deterministic replay
+fixtures.
 
 ```bash
 harn bench main.harn
 harn bench main.harn --iterations 25
 harn bench main.harn --iterations 25 --profile-json bench.json
+harn bench replay --json --output replay-benchmark.json
+harn bench replay conformance/replay-oracle/fixtures --filter approval --json
 ```
 
 `harn bench` parses and compiles the file once, executes it with a fresh VM for
@@ -220,6 +223,26 @@ total. `--profile` prints the aggregate categorical timing rollup; `--profile-js
 writes a JSON report with `iterations[]`, `mean_ms`, `p50_ms`, `p95_ms`,
 `stddev_ms`, and `rollup`. `HARN_PROFILE=1` and `HARN_PROFILE_JSON=<path>` work
 as environment aliases.
+
+`harn bench replay` reads `benchmarks/replay/suite.json` by default. It emits
+schema `harn.replay_benchmark.report.v1`, including Harn Cloud ingest metadata,
+fixture receipts, replay-fidelity scores, permission-preservation scores,
+tool-call drift counts, transcript drift counts, observed interaction totals,
+and first-divergence triage data. Use `--output <path>` to write the JSON report
+and `--json` to print it to stdout. The command exits non-zero when any fixture
+fails its expected replay result.
+
+External trace pairs can be adapted with the documented OpenCode-inspired JSONL
+adapter:
+
+```bash
+harn bench replay \
+  --adapter opencode-jsonl \
+  --external-first benchmarks/replay/adapters/opencode/first.jsonl \
+  --external-second benchmarks/replay/adapters/opencode/second.jsonl \
+  --external-name opencode-permission-run \
+  --json
+```
 
 ## harn viz
 

--- a/docs/src/observability/replay-benchmarks.md
+++ b/docs/src/observability/replay-benchmarks.md
@@ -1,0 +1,105 @@
+# Replay benchmarks
+
+`harn bench replay` scores replay determinism fixtures and emits a
+machine-readable artifact for CI and Harn Cloud leaderboard ingestion.
+It uses the same `harn.orchestration.replay_trace.v1` trace contract as
+`harn orchestrator replay-oracle`; the benchmark layer adds comparable
+metrics and stable receipt hashes.
+
+## Run the canonical suite
+
+```bash
+harn bench replay --json --output replay-benchmark.json
+```
+
+By default the command reads `benchmarks/replay/suite.json`. That suite
+references three canonical replay-oracle fixtures:
+
+- simple tool run
+- permission-gated edit
+- event-triggered multi-step workflow
+
+Run one file, directory, or suite manifest explicitly:
+
+```bash
+harn bench replay conformance/replay-oracle/fixtures/approval_tool_call.valid.json --json
+harn bench replay conformance/replay-oracle/fixtures --filter worker --json
+```
+
+The command exits non-zero when any fixture fails its replay expectation,
+so CI can gate on the process status while still uploading
+`replay-benchmark.json` for inspection.
+
+## Output contract
+
+Reports use schema `harn.replay_benchmark.report.v1`. The public JSON
+schema lives at `spec/schemas/replay-benchmark.v1.schema.json`.
+
+Top-level fields:
+
+- `cloud_ingest`: Harn Cloud routing metadata. `kind` is
+  `harn_cloud.replay_determinism.leaderboard.v1`.
+- `suite`: suite name, source paths, and fixture count.
+- `summary`: pass/fail counts, average fidelity, permission-preservation
+  score, drift counts, and observed interaction totals.
+- `fixtures`: one result per trace, including category metrics, first
+  divergence, and a stable receipt hash.
+
+The receipt hashes are derived from canonicalized replay trace material
+after fixture allowlists have been applied. Harn Cloud can ingest the
+benchmark report without re-reading raw EventLog, transcript, or tool
+payloads.
+
+## Metrics
+
+`determinism_score` is `1.0` when canonical replay output matches and
+`0.0` when a meaningful divergence remains.
+
+`replay_fidelity_score` is the fraction of populated trace sections that
+match after allowlists. The compared sections are EventLog entries,
+trigger firings, LLM interactions, protocol interactions, approvals,
+effect receipts, persona runtime state, transcript deltas, final
+artifacts, and policy decisions.
+
+`permission_decision_preservation_score` compares approval interactions
+and policy decisions. Fixtures with no permission surface score `1.0`
+because there was no permission boundary to preserve.
+
+`tool_call_drift_count` counts drift across LLM interactions, protocol
+interactions, and effect receipts. `transcript_drift_count` counts drift
+inside agent transcript deltas.
+
+`debugging_time_to_root_cause_proxy` is not a time measurement. It is a
+stable triage proxy based on the first divergent JSON path and the
+number of drifted trace sections.
+
+`runtime_cost` is an observed fixture-cost summary: interaction counts,
+LLM token totals, and optional `cost_usd` values when fixtures contain
+them. It does not benchmark wall-clock runtime.
+
+## External trace adapter
+
+The first adapter is `opencode-jsonl`, a documented OpenCode-inspired
+JSONL shape for session events. It accepts line-delimited objects with
+`type` values such as `message`, `tool_call`, `permission`, and `llm`,
+then maps them into Harn replay trace buckets.
+
+```bash
+harn bench replay \
+  --adapter opencode-jsonl \
+  --external-first benchmarks/replay/adapters/opencode/first.jsonl \
+  --external-second benchmarks/replay/adapters/opencode/second.jsonl \
+  --external-name opencode-permission-run \
+  --json
+```
+
+Adapter input is intentionally small and explicit. It is a bridge format
+for benchmarking public/simple external traces, not a claim that every
+OpenCode session log shape is natively supported.
+
+## CI template
+
+A copy-paste GitHub Actions template is checked in at
+`docs/fixtures/github-actions/harn-replay-benchmark.yml`. It installs
+the Harn CLI, runs `harn bench replay`, and uploads
+`replay-benchmark.json` as a build artifact.

--- a/docs/src/orchestrator.md
+++ b/docs/src/orchestrator.md
@@ -189,6 +189,11 @@ On meaningful drift the command exits non-zero and prints the first divergent
 canonical path with left/right values. `make replay-oracle` runs the default
 fixture set and is included in `make all`.
 
+Use `harn bench replay` when you need CI- and Cloud-ingestable replay
+benchmark artifacts rather than only oracle pass/fail output. The benchmark
+command reuses the same trace schema and adds replay-fidelity,
+permission-preservation, tool-drift, transcript-drift, and receipt metrics.
+
 ## HTTP Listener
 
 The orchestrator listener assembles routes from `[[triggers]]` entries

--- a/spec/schemas/replay-benchmark.v1.schema.json
+++ b/spec/schemas/replay-benchmark.v1.schema.json
@@ -1,0 +1,218 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/replay-benchmark.v1.schema.json",
+  "title": "Harn replay benchmark report",
+  "type": "object",
+  "required": ["schema_version", "cloud_ingest", "suite", "summary", "fixtures"],
+  "properties": {
+    "schema_version": {
+      "const": "harn.replay_benchmark.report.v1"
+    },
+    "cloud_ingest": {
+      "type": "object",
+      "required": [
+        "kind",
+        "leaderboard_key",
+        "report_schema_version",
+        "replay_trace_schema_version",
+        "artifact_contract"
+      ],
+      "properties": {
+        "kind": {
+          "const": "harn_cloud.replay_determinism.leaderboard.v1"
+        },
+        "leaderboard_key": { "type": "string" },
+        "report_schema_version": { "type": "string" },
+        "replay_trace_schema_version": { "type": "string" },
+        "artifact_contract": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "suite": {
+      "type": "object",
+      "required": ["name", "fixture_count", "source_paths"],
+      "properties": {
+        "name": { "type": "string" },
+        "fixture_count": { "type": "integer", "minimum": 0 },
+        "source_paths": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      },
+      "additionalProperties": false
+    },
+    "summary": {
+      "type": "object",
+      "required": [
+        "passed",
+        "failed",
+        "deterministic_fixtures",
+        "drifted_fixtures",
+        "mean_replay_fidelity_score",
+        "mean_permission_decision_preservation_score",
+        "tool_call_drift_count",
+        "transcript_drift_count",
+        "observed_interactions",
+        "llm_input_tokens",
+        "llm_output_tokens"
+      ],
+      "properties": {
+        "passed": { "type": "integer", "minimum": 0 },
+        "failed": { "type": "integer", "minimum": 0 },
+        "deterministic_fixtures": { "type": "integer", "minimum": 0 },
+        "drifted_fixtures": { "type": "integer", "minimum": 0 },
+        "mean_replay_fidelity_score": { "type": "number", "minimum": 0, "maximum": 1 },
+        "mean_permission_decision_preservation_score": { "type": "number", "minimum": 0, "maximum": 1 },
+        "tool_call_drift_count": { "type": "integer", "minimum": 0 },
+        "transcript_drift_count": { "type": "integer", "minimum": 0 },
+        "observed_interactions": { "type": "integer", "minimum": 0 },
+        "llm_input_tokens": { "type": "integer", "minimum": 0 },
+        "llm_output_tokens": { "type": "integer", "minimum": 0 }
+      },
+      "additionalProperties": false
+    },
+    "fixtures": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "path",
+          "name",
+          "expectation",
+          "passed",
+          "deterministic",
+          "metrics",
+          "receipt"
+        ],
+        "properties": {
+          "path": { "type": "string" },
+          "name": { "type": "string" },
+          "description": { "type": ["string", "null"] },
+          "expectation": { "enum": ["match", "drift"] },
+          "passed": { "type": "boolean" },
+          "deterministic": { "type": "boolean" },
+          "first_run_counts": { "type": "object" },
+          "second_run_counts": { "type": "object" },
+          "first_divergence": { "type": ["object", "null"] },
+          "metrics": {
+            "type": "object",
+            "required": [
+              "determinism_score",
+              "replay_fidelity_score",
+              "permission_decision_preservation_score",
+              "tool_call_drift_count",
+              "transcript_drift_count",
+              "runtime_cost",
+              "debugging_time_to_root_cause_proxy",
+              "category_scores"
+            ],
+            "properties": {
+              "determinism_score": { "type": "number", "minimum": 0, "maximum": 1 },
+              "replay_fidelity_score": { "type": "number", "minimum": 0, "maximum": 1 },
+              "permission_decision_preservation_score": { "type": "number", "minimum": 0, "maximum": 1 },
+              "tool_call_drift_count": { "type": "integer", "minimum": 0 },
+              "transcript_drift_count": { "type": "integer", "minimum": 0 },
+              "runtime_cost": {
+                "type": "object",
+                "required": [
+                  "observed_interactions",
+                  "event_log_entries",
+                  "trigger_firings",
+                  "llm_interactions",
+                  "protocol_interactions",
+                  "approval_interactions",
+                  "effect_receipts",
+                  "persona_runtime_states",
+                  "agent_transcript_deltas",
+                  "final_artifacts",
+                  "policy_decisions",
+                  "llm_input_tokens",
+                  "llm_output_tokens"
+                ],
+                "properties": {
+                  "observed_interactions": { "type": "integer", "minimum": 0 },
+                  "event_log_entries": { "type": "integer", "minimum": 0 },
+                  "trigger_firings": { "type": "integer", "minimum": 0 },
+                  "llm_interactions": { "type": "integer", "minimum": 0 },
+                  "protocol_interactions": { "type": "integer", "minimum": 0 },
+                  "approval_interactions": { "type": "integer", "minimum": 0 },
+                  "effect_receipts": { "type": "integer", "minimum": 0 },
+                  "persona_runtime_states": { "type": "integer", "minimum": 0 },
+                  "agent_transcript_deltas": { "type": "integer", "minimum": 0 },
+                  "final_artifacts": { "type": "integer", "minimum": 0 },
+                  "policy_decisions": { "type": "integer", "minimum": 0 },
+                  "llm_input_tokens": { "type": "integer", "minimum": 0 },
+                  "llm_output_tokens": { "type": "integer", "minimum": 0 },
+                  "observed_cost_usd": { "type": "number", "minimum": 0 }
+                },
+                "additionalProperties": false
+              },
+              "debugging_time_to_root_cause_proxy": {
+                "type": "object",
+                "required": [
+                  "proxy_kind",
+                  "first_divergence_path",
+                  "first_divergence_depth",
+                  "drift_surface_count",
+                  "estimated_triage_steps"
+                ],
+                "properties": {
+                  "proxy_kind": { "type": "string" },
+                  "first_divergence_path": { "type": ["string", "null"] },
+                  "first_divergence_depth": { "type": "integer", "minimum": 0 },
+                  "drift_surface_count": { "type": "integer", "minimum": 0 },
+                  "estimated_triage_steps": { "type": "integer", "minimum": 0 }
+                },
+                "additionalProperties": false
+              },
+              "category_scores": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object",
+                  "required": [
+                    "compared",
+                    "matched",
+                    "drift_count",
+                    "first_run_count",
+                    "second_run_count"
+                  ],
+                  "properties": {
+                    "compared": { "type": "boolean" },
+                    "matched": { "type": "boolean" },
+                    "drift_count": { "type": "integer", "minimum": 0 },
+                    "first_run_count": { "type": "integer", "minimum": 0 },
+                    "second_run_count": { "type": "integer", "minimum": 0 }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          "receipt": {
+            "type": "object",
+            "required": [
+              "ingest_kind",
+              "report_schema_version",
+              "replay_trace_schema_version",
+              "canonical_first_sha256",
+              "canonical_second_sha256",
+              "benchmark_receipt_sha256"
+            ],
+            "properties": {
+              "ingest_kind": { "const": "harn_cloud.replay_determinism.leaderboard.v1" },
+              "report_schema_version": { "type": "string" },
+              "replay_trace_schema_version": { "type": "string" },
+              "canonical_first_sha256": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+              "canonical_second_sha256": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+              "benchmark_receipt_sha256": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary
- add `harn bench replay` with canonical replay fixture scoring and stable Cloud-ingest report artifacts
- add replay benchmark metrics, receipts, schema, docs, canonical fixtures, and an OpenCode-inspired JSONL trace adapter
- add a CI workflow template and wire `make replay-bench` into the local quality gate

Closes #1585

## Verification
- `cargo test -p harn-vm replay_bench`
- `cargo test -p harn-cli test_parses_bench`
- `cargo test -p harn-cli replay_benchmark_suite_manifest_runs_canonical_fixtures`
- `cargo clippy -p harn-vm -p harn-cli --all-targets -- -D warnings`
- `make replay-oracle replay-bench`
- `actionlint docs/fixtures/github-actions/harn-replay-benchmark.yml`
- canonical `harn bench replay --json`, drift-negative fixture, and `opencode-jsonl` adapter smoke runs
- repo pre-commit and pre-push hooks