### PR TITLE
Add canonical session bundle import/export

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
-.PHONY: setup install-hooks configure-merge-drivers build build-release sign-local check fmt fmt-harn fmt-harn-fix lint lint-md lint-actions lint-harn spec-lint test test-e2e test-cargo test-fast test-harn-scripts conformance protocol-conformance replay-oracle bench-vm bench-vm-clone bench-llm bench-orchestration all release-gate release-smoke smoke-audit portal portal-check portal-demo gen-highlight check-highlight gen-protocol-artifacts check-protocol-artifacts check-bindings gen-trigger-quickref check-trigger-quickref gen-provider-matrix check-provider-matrix gen-connector-matrix check-connector-matrix check-trigger-examples check-docs-snippets check-docs-workflow-quickstart sync-language-spec check-language-spec lint-test-patterns check-receipt-structs lint-no-rust-prompt-prose lint-no-xfail-regression check-provider-catalog-drift
+.PHONY: setup install-hooks configure-merge-drivers build build-release sign-local check fmt fmt-harn fmt-harn-fix lint lint-md lint-actions lint-harn spec-lint test test-e2e test-cargo test-fast test-harn-scripts conformance protocol-conformance replay-oracle bench-vm bench-vm-clone bench-llm bench-orchestration all release-gate release-smoke smoke-audit portal portal-check portal-demo gen-highlight check-highlight gen-protocol-artifacts check-protocol-artifacts check-bindings gen-session-bundle-schema check-session-bundle-schema gen-trigger-quickref check-trigger-quickref gen-provider-matrix check-provider-matrix gen-connector-matrix check-connector-matrix check-trigger-examples check-docs-snippets check-docs-workflow-quickstart sync-language-spec check-language-spec lint-test-patterns check-receipt-structs lint-no-rust-prompt-prose lint-no-xfail-regression check-provider-catalog-drift
 
 # Full quality check: format first, then lint/test in parallel.
 # Usage: make all -j       (parallel checks after formatting)
 #        make all           (sequential, also works)
 all: fmt
-	$(MAKE) lint lint-md lint-actions lint-harn spec-lint fmt-harn test test-harn-scripts conformance protocol-conformance replay-oracle check-highlight check-protocol-artifacts check-bindings check-language-spec check-trigger-quickref check-provider-matrix check-connector-matrix check-trigger-examples check-docs-snippets check-docs-workflow-quickstart lint-test-patterns check-receipt-structs check-provider-catalog-drift portal-check
+	$(MAKE) lint lint-md lint-actions lint-harn spec-lint fmt-harn test test-harn-scripts conformance protocol-conformance replay-oracle check-highlight check-protocol-artifacts check-bindings check-session-bundle-schema check-language-spec check-trigger-quickref check-provider-matrix check-connector-matrix check-trigger-examples check-docs-snippets check-docs-workflow-quickstart lint-test-patterns check-receipt-structs check-provider-catalog-drift portal-check
 
 check: all
 
@@ -254,6 +254,14 @@ check-bindings:
 		echo "    skipping go round-trip (go not installed)"; \
 	fi
 	@echo "    Harn protocol bindings OK."
+
+gen-session-bundle-schema:
+	cargo run --quiet -p harn-cli -- session schema --out spec/schemas/session-bundle.v1.schema.json
+
+check-session-bundle-schema:
+	@echo "=== Checking session bundle schema is up to date ==="
+	@cargo run --quiet -p harn-cli -- session schema --check
+	@echo "    Session bundle schema OK."
 
 # Regenerate docs/src/language-spec.md from spec/HARN_SPEC.md (the
 # canonical authoring source). Mirrors what release_gate.sh audit's

--- a/crates/harn-cli/src/cli/mod.rs
+++ b/crates/harn-cli/src/cli/mod.rs
@@ -37,6 +37,7 @@ mod quickstart;
 mod run;
 mod runs;
 mod serve;
+mod session;
 mod skill;
 mod skills;
 mod supervisor;
@@ -125,6 +126,10 @@ pub(crate) use runs::{EvalArgs, ReplayArgs, RunsArgs, RunsCommand};
 pub(crate) use serve::{
     A2aServeArgs, McpServeTransport, ServeAcpArgs, ServeArgs, ServeCommand, ServeMcpArgs,
     ServeTlsMode,
+};
+pub(crate) use session::{
+    SessionArgs, SessionCommand, SessionExportArgs, SessionImportArgs, SessionSchemaArgs,
+    SessionValidateArgs,
 };
 pub(crate) use skill::{
     SkillArgs, SkillCommand, SkillEndorseArgs, SkillKeyCommand, SkillKeyGenerateArgs,
@@ -280,6 +285,8 @@ SCRIPTING
     Playground(PlaygroundArgs),
     /// Inspect persisted workflow run records.
     Runs(RunsArgs),
+    /// Export, import, and validate portable Harn session bundles.
+    Session(SessionArgs),
     /// Replay a persisted workflow run record.
     Replay(ReplayArgs),
     /// Evaluate a run record, run directory, or eval manifest.

--- a/crates/harn-cli/src/cli/session.rs
+++ b/crates/harn-cli/src/cli/session.rs
@@ -1,0 +1,71 @@
+use clap::{Args, Subcommand};
+
+#[derive(Debug, Args)]
+pub(crate) struct SessionArgs {
+    #[command(subcommand)]
+    pub command: SessionCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum SessionCommand {
+    /// Export a persisted run record as a portable Harn session bundle.
+    Export(SessionExportArgs),
+    /// Import a Harn session bundle back into a local run record.
+    Import(SessionImportArgs),
+    /// Validate a Harn session bundle without importing it.
+    Validate(SessionValidateArgs),
+    /// Print or check the generated session-bundle JSON Schema.
+    Schema(SessionSchemaArgs),
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct SessionExportArgs {
+    /// Path to the run record JSON file to export.
+    pub run_record: String,
+    /// Write the bundle to this path. Prints JSON to stdout when omitted.
+    #[arg(long, value_name = "PATH")]
+    pub out: Option<String>,
+    /// Preserve local-only content instead of applying the default redaction policy.
+    #[arg(long, conflicts_with = "replay_only")]
+    pub local: bool,
+    /// Export replay metadata with prompt/tool payloads withheld.
+    #[arg(long, conflicts_with = "local")]
+    pub replay_only: bool,
+    /// Include artifact payloads in the bundle. Omitted by default for share safety.
+    #[arg(long)]
+    pub include_attachments: bool,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct SessionImportArgs {
+    /// Path to a Harn session bundle JSON file.
+    pub bundle: String,
+    /// Write the imported run record to this path.
+    #[arg(long, value_name = "PATH")]
+    pub out: Option<String>,
+    /// Allow bundles that still contain high-confidence secret markers.
+    #[arg(long)]
+    pub allow_unsafe_secret_markers: bool,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct SessionValidateArgs {
+    /// Path to a Harn session bundle JSON file.
+    pub bundle: String,
+    /// Allow bundles that still contain high-confidence secret markers.
+    #[arg(long)]
+    pub allow_unsafe_secret_markers: bool,
+    /// Print a compact JSON summary on success.
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct SessionSchemaArgs {
+    /// Check that the checked-in schema file is up to date.
+    #[arg(long)]
+    pub check: bool,
+    /// Schema path used by --check, or write destination when --check is absent.
+    #[arg(long, value_name = "PATH")]
+    pub out: Option<String>,
+}

--- a/crates/harn-cli/src/cli/tests.rs
+++ b/crates/harn-cli/src/cli/tests.rs
@@ -7,8 +7,8 @@ use super::{
     OrchestratorCommand, OrchestratorDeployProvider, OrchestratorLogFormat,
     OrchestratorQueueCommand, OrchestratorTenantCommand, PackageArtifactsCommand,
     PackageCacheCommand, PackageCommand, PersonaCommand, ProjectTemplate, RunsCommand,
-    SkillCommand, SkillKeyCommand, SkillTrustCommand, SkillsCommand, TraceCommand, TriggerCommand,
-    TrustCommand, TrustOutcomeArg, TrustTierArg,
+    SessionCommand, SkillCommand, SkillKeyCommand, SkillTrustCommand, SkillsCommand, TraceCommand,
+    TriggerCommand, TrustCommand, TrustOutcomeArg, TrustTierArg,
 };
 use clap::{CommandFactory, Parser};
 
@@ -405,6 +405,68 @@ fn test_parses_runs_inspect_compare() {
     let RunsCommand::Inspect(inspect) = args.command;
     assert_eq!(inspect.path, "run.json");
     assert_eq!(inspect.compare.as_deref(), Some("baseline.json"));
+}
+
+#[test]
+fn test_parses_session_bundle_commands() {
+    let cli = Cli::parse_from([
+        "harn",
+        "session",
+        "export",
+        "run.json",
+        "--out",
+        "bundle.json",
+        "--include-attachments",
+    ]);
+
+    let Command::Session(args) = cli.command.unwrap() else {
+        panic!("expected session command");
+    };
+    let SessionCommand::Export(export) = args.command else {
+        panic!("expected session export");
+    };
+    assert_eq!(export.run_record, "run.json");
+    assert_eq!(export.out.as_deref(), Some("bundle.json"));
+    assert!(export.include_attachments);
+
+    let cli = Cli::parse_from([
+        "harn",
+        "session",
+        "import",
+        "bundle.json",
+        "--out",
+        "imported.json",
+        "--allow-unsafe-secret-markers",
+    ]);
+
+    let Command::Session(args) = cli.command.unwrap() else {
+        panic!("expected session command");
+    };
+    let SessionCommand::Import(import) = args.command else {
+        panic!("expected session import");
+    };
+    assert_eq!(import.bundle, "bundle.json");
+    assert_eq!(import.out.as_deref(), Some("imported.json"));
+    assert!(import.allow_unsafe_secret_markers);
+
+    let cli = Cli::parse_from(["harn", "session", "validate", "bundle.json", "--json"]);
+    let Command::Session(args) = cli.command.unwrap() else {
+        panic!("expected session command");
+    };
+    let SessionCommand::Validate(validate) = args.command else {
+        panic!("expected session validate");
+    };
+    assert_eq!(validate.bundle, "bundle.json");
+    assert!(validate.json);
+
+    let cli = Cli::parse_from(["harn", "session", "schema", "--check"]);
+    let Command::Session(args) = cli.command.unwrap() else {
+        panic!("expected session command");
+    };
+    let SessionCommand::Schema(schema) = args.command else {
+        panic!("expected session schema");
+    };
+    assert!(schema.check);
 }
 
 #[test]

--- a/crates/harn-cli/src/commands/mod.rs
+++ b/crates/harn-cli/src/commands/mod.rs
@@ -29,6 +29,7 @@ pub(crate) mod quickstart;
 pub(crate) mod repl;
 pub mod run;
 pub(crate) mod serve;
+pub(crate) mod session;
 pub(crate) mod skill;
 pub(crate) mod skills;
 pub(crate) mod supervisor;

--- a/crates/harn-cli/src/commands/session.rs
+++ b/crates/harn-cli/src/commands/session.rs
@@ -1,0 +1,215 @@
+use std::fs;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::process;
+
+use crate::cli::{
+    SessionArgs, SessionCommand, SessionExportArgs, SessionImportArgs, SessionSchemaArgs,
+    SessionValidateArgs,
+};
+
+const DEFAULT_SCHEMA_PATH: &str = "spec/schemas/session-bundle.v1.schema.json";
+
+pub(crate) fn run(args: SessionArgs) {
+    match args.command {
+        SessionCommand::Export(export) => run_export(export),
+        SessionCommand::Import(import) => run_import(import),
+        SessionCommand::Validate(validate) => run_validate(validate),
+        SessionCommand::Schema(schema) => run_schema(schema),
+    }
+}
+
+fn run_export(args: SessionExportArgs) {
+    let run = match harn_vm::orchestration::load_run_record(Path::new(&args.run_record)) {
+        Ok(run) => run,
+        Err(error) => {
+            eprintln!(
+                "error: failed to load run record {}: {error}",
+                args.run_record
+            );
+            process::exit(1);
+        }
+    };
+    let mode = if args.local {
+        harn_vm::session_bundle::SessionBundleExportMode::Local
+    } else if args.replay_only {
+        harn_vm::session_bundle::SessionBundleExportMode::ReplayOnly
+    } else {
+        harn_vm::session_bundle::SessionBundleExportMode::Sanitized
+    };
+    let options = harn_vm::session_bundle::SessionBundleExportOptions {
+        mode,
+        include_attachments: args.include_attachments,
+        ..Default::default()
+    };
+    let bundle = match harn_vm::session_bundle::export_run_record_bundle(&run, &options) {
+        Ok(bundle) => bundle,
+        Err(error) => {
+            eprintln!("error: failed to export session bundle: {error}");
+            process::exit(1);
+        }
+    };
+    let rendered = match serde_json::to_string_pretty(&bundle) {
+        Ok(json) => format!("{json}\n"),
+        Err(error) => {
+            eprintln!("error: failed to render session bundle: {error}");
+            process::exit(1);
+        }
+    };
+    if let Some(out) = args.out {
+        write_text(Path::new(&out), &rendered);
+        println!("{out}");
+    } else {
+        write_stdout(&rendered);
+    }
+}
+
+fn run_import(args: SessionImportArgs) {
+    let bundle = read_validated_bundle(
+        &args.bundle,
+        args.allow_unsafe_secret_markers,
+        "invalid session bundle",
+    );
+    let run_record = match harn_vm::session_bundle::import_run_record_value(&bundle) {
+        Ok(run_record) => run_record,
+        Err(error) => {
+            eprintln!("error: failed to import session bundle: {error}");
+            process::exit(1);
+        }
+    };
+    let rendered = match serde_json::to_string_pretty(&run_record) {
+        Ok(json) => format!("{json}\n"),
+        Err(error) => {
+            eprintln!("error: failed to render imported run record: {error}");
+            process::exit(1);
+        }
+    };
+    let out = args.out.map(PathBuf::from).unwrap_or_else(|| {
+        harn_vm::runtime_paths::run_root(Path::new("."))
+            .join("imported")
+            .join(format!("{}.json", bundle.source.run_record_id))
+    });
+    write_text(&out, &rendered);
+    println!("{}", out.display());
+}
+
+fn run_validate(args: SessionValidateArgs) {
+    let bundle = read_validated_bundle(
+        &args.bundle,
+        args.allow_unsafe_secret_markers,
+        "invalid session bundle",
+    );
+    if args.json {
+        let summary = serde_json::json!({
+            "ok": true,
+            "bundle_id": bundle.bundle_id,
+            "schema_version": bundle.schema_version,
+            "mode": bundle.redaction.mode,
+            "run_record_id": bundle.source.run_record_id,
+        });
+        match serde_json::to_string_pretty(&summary) {
+            Ok(json) => println!("{json}"),
+            Err(error) => {
+                eprintln!("error: failed to render validation summary: {error}");
+                process::exit(1);
+            }
+        }
+    } else {
+        println!(
+            "OK {} schema_version={} mode={}",
+            bundle.bundle_id, bundle.schema_version, bundle.redaction.mode
+        );
+    }
+}
+
+fn run_schema(args: SessionSchemaArgs) {
+    let rendered = match harn_vm::session_bundle::session_bundle_schema_pretty() {
+        Ok(schema) => schema,
+        Err(error) => {
+            eprintln!("error: failed to render session bundle schema: {error}");
+            process::exit(1);
+        }
+    };
+    let write_to_file = args.out.is_some();
+    let path = args
+        .out
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(DEFAULT_SCHEMA_PATH));
+    if args.check {
+        match fs::read_to_string(&path) {
+            Ok(existing)
+                if normalize_line_endings(&existing) == normalize_line_endings(&rendered) =>
+            {
+                return;
+            }
+            Ok(_) => {
+                eprintln!(
+                    "error: {} is stale. Run `make gen-session-bundle-schema` to regenerate.",
+                    path.display()
+                );
+                process::exit(1);
+            }
+            Err(error) => {
+                eprintln!("error: failed to read {}: {error}", path.display());
+                process::exit(1);
+            }
+        }
+    }
+    if write_to_file {
+        write_text(&path, &rendered);
+        println!("{}", path.display());
+    } else {
+        write_stdout(&rendered);
+    }
+}
+
+fn read_validated_bundle(
+    path: &str,
+    allow_unsafe_secret_markers: bool,
+    context: &str,
+) -> harn_vm::session_bundle::SessionBundle {
+    let content = match fs::read_to_string(path) {
+        Ok(content) => content,
+        Err(error) => {
+            eprintln!("error: failed to read session bundle {path}: {error}");
+            process::exit(1);
+        }
+    };
+    let options = harn_vm::session_bundle::SessionBundleValidationOptions {
+        allow_unsafe_secret_markers,
+        ..Default::default()
+    };
+    match harn_vm::session_bundle::validate_session_bundle_str(&content, &options) {
+        Ok(bundle) => bundle,
+        Err(error) => {
+            eprintln!("error: {context}: {error}");
+            process::exit(1);
+        }
+    }
+}
+
+fn write_text(path: &Path, content: &str) {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            if let Err(error) = fs::create_dir_all(parent) {
+                eprintln!("error: failed to create {}: {error}", parent.display());
+                process::exit(1);
+            }
+        }
+    }
+    if let Err(error) = fs::write(path, content) {
+        eprintln!("error: failed to write {}: {error}", path.display());
+        process::exit(1);
+    }
+}
+
+fn write_stdout(content: &str) {
+    if let Err(error) = io::stdout().write_all(content.as_bytes()) {
+        eprintln!("error: failed to write stdout: {error}");
+        process::exit(1);
+    }
+}
+
+fn normalize_line_endings(input: &str) -> String {
+    input.replace("\r\n", "\n")
+}

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -729,6 +729,7 @@ async fn async_main() {
                 inspect_run_record(&inspect.path, inspect.compare.as_deref())
             }
         },
+        Command::Session(args) => commands::session::run(args),
         Command::Replay(args) => replay_run_record(&args.path),
         Command::Eval(args) => {
             let llm_mock_mode = if let Some(path) = args.llm_mock.as_ref() {

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -48,6 +48,7 @@ pub mod runtime_context;
 pub mod runtime_paths;
 pub mod schema;
 pub mod secrets;
+pub mod session_bundle;
 pub mod sessions;
 pub(crate) mod shared_state;
 pub mod shells;

--- a/crates/harn-vm/src/session_bundle.rs
+++ b/crates/harn-vm/src/session_bundle.rs
@@ -1,0 +1,1137 @@
+//! Canonical session bundle export/import support.
+//!
+//! A session bundle is the portable JSON envelope that downstream hosts use
+//! for local exports, sanitized shares, and replay-only handoffs. The bundle
+//! is intentionally built from existing Harn run-record surfaces so replay,
+//! transcripts, tool calls, HITL questions, and observability do not fork into
+//! a second persistence model.
+
+use std::borrow::Cow;
+use std::collections::BTreeMap;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value as JsonValue};
+
+use crate::orchestration::{
+    new_id, now_rfc3339, ReplayFixture, RunCheckpointRecord, RunHitlQuestionRecord, RunRecord,
+    RunTraceSpanRecord, RunTransitionRecord, ToolCallRecord,
+};
+use crate::redact::{RedactionPolicy, REDACTED_PLACEHOLDER};
+
+mod schema;
+pub use schema::{session_bundle_schema, session_bundle_schema_pretty};
+
+#[cfg(test)]
+mod tests;
+
+pub const SESSION_BUNDLE_TYPE: &str = "harn_session_bundle";
+pub const SESSION_BUNDLE_SCHEMA_VERSION: u32 = 1;
+pub const SESSION_BUNDLE_SCHEMA_ID: &str = "https://harnlang.com/schemas/session-bundle.v1.json";
+pub const REPLAY_ONLY_PLACEHOLDER: &str = "[withheld]";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SessionBundleExportMode {
+    Local,
+    Sanitized,
+    ReplayOnly,
+}
+
+impl SessionBundleExportMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Local => "local",
+            Self::Sanitized => "sanitized",
+            Self::ReplayOnly => "replay_only",
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct SessionBundleExportOptions {
+    pub mode: SessionBundleExportMode,
+    pub include_attachments: bool,
+    pub redaction_policy: RedactionPolicy,
+}
+
+impl Default for SessionBundleExportOptions {
+    fn default() -> Self {
+        Self {
+            mode: SessionBundleExportMode::Sanitized,
+            include_attachments: false,
+            redaction_policy: RedactionPolicy::default(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct SessionBundleValidationOptions {
+    pub allow_unsafe_secret_markers: bool,
+    pub redaction_policy: RedactionPolicy,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct SessionBundle {
+    #[serde(rename = "_type")]
+    pub type_name: String,
+    pub schema_version: u32,
+    pub bundle_id: String,
+    pub created_at: String,
+    pub producer: BundleProducer,
+    pub source: BundleSource,
+    pub runtime: BundleRuntime,
+    pub workspace: Option<BundleWorkspace>,
+    pub transcript: BundleTranscript,
+    pub tools: BundleTools,
+    pub permissions: Vec<BundlePermission>,
+    pub replay: BundleReplay,
+    pub redaction: RedactionManifest,
+    pub attachments: Vec<BundleAttachment>,
+    pub metadata: BTreeMap<String, JsonValue>,
+}
+
+impl Default for SessionBundle {
+    fn default() -> Self {
+        Self {
+            type_name: SESSION_BUNDLE_TYPE.to_string(),
+            schema_version: SESSION_BUNDLE_SCHEMA_VERSION,
+            bundle_id: String::new(),
+            created_at: String::new(),
+            producer: BundleProducer::default(),
+            source: BundleSource::default(),
+            runtime: BundleRuntime::default(),
+            workspace: None,
+            transcript: BundleTranscript::default(),
+            tools: BundleTools::default(),
+            permissions: Vec::new(),
+            replay: BundleReplay::default(),
+            redaction: RedactionManifest::default(),
+            attachments: Vec::new(),
+            metadata: BTreeMap::new(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct BundleProducer {
+    pub name: String,
+    pub version: String,
+    pub schema_id: String,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct BundleSource {
+    pub kind: String,
+    pub run_record_id: String,
+    pub workflow_id: String,
+    pub workflow_name: Option<String>,
+    pub task: String,
+    pub status: String,
+    pub started_at: String,
+    pub finished_at: Option<String>,
+    pub persisted_path: Option<String>,
+    pub root_run_id: Option<String>,
+    pub parent_run_id: Option<String>,
+    pub child_run_count: usize,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct BundleRuntime {
+    pub harn_version: String,
+    pub provider_models: Vec<String>,
+    pub usage: Option<BundleUsage>,
+    pub metadata: BTreeMap<String, JsonValue>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct BundleUsage {
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub call_count: i64,
+    pub total_duration_ms: i64,
+    pub total_cost: f64,
+    pub models: Vec<String>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct BundleWorkspace {
+    pub identity: Option<String>,
+    pub source_root: Option<String>,
+    pub policy: String,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct BundleTranscript {
+    pub sections: Vec<BundleTranscriptSection>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct BundleTranscriptSection {
+    pub id: String,
+    pub label: String,
+    pub scope: String,
+    pub location: String,
+    pub summary: Option<String>,
+    pub messages: Vec<JsonValue>,
+    pub events: Vec<JsonValue>,
+    pub assets: Vec<JsonValue>,
+    pub metadata: BTreeMap<String, JsonValue>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct BundleTools {
+    pub schemas: Vec<BundleJsonEntry>,
+    pub calls: Vec<BundleToolCall>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct BundleJsonEntry {
+    pub source: String,
+    pub index: usize,
+    pub value: JsonValue,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct BundleToolCall {
+    pub tool_name: String,
+    pub tool_use_id: String,
+    pub args_hash: String,
+    pub result: String,
+    pub is_rejected: bool,
+    pub duration_ms: u64,
+    pub iteration: usize,
+    pub timestamp: String,
+}
+
+impl From<&ToolCallRecord> for BundleToolCall {
+    fn from(record: &ToolCallRecord) -> Self {
+        Self {
+            tool_name: record.tool_name.clone(),
+            tool_use_id: record.tool_use_id.clone(),
+            args_hash: record.args_hash.clone(),
+            result: record.result.clone(),
+            is_rejected: record.is_rejected,
+            duration_ms: record.duration_ms,
+            iteration: record.iteration,
+            timestamp: record.timestamp.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct BundlePermission {
+    pub kind: String,
+    pub source: String,
+    pub request_id: Option<String>,
+    pub agent: Option<String>,
+    pub payload: JsonValue,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct BundleReplay {
+    pub replay_fixture: Option<ReplayFixture>,
+    pub run_record: Option<JsonValue>,
+    pub event_log_pointers: Vec<BundleEventLogPointer>,
+    pub transitions: Vec<RunTransitionRecord>,
+    pub checkpoints: Vec<RunCheckpointRecord>,
+    pub trace_spans: Vec<RunTraceSpanRecord>,
+    pub deterministic_events: Vec<BundleJsonEntry>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct BundleEventLogPointer {
+    pub kind: String,
+    pub topic: Option<String>,
+    pub path: Option<String>,
+    pub location: String,
+    pub available: bool,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct RedactionManifest {
+    pub mode: String,
+    pub policy: String,
+    pub placeholder: String,
+    pub entries: Vec<RedactionEntry>,
+    pub unsafe_secret_markers_rejected: bool,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct RedactionEntry {
+    pub path: String,
+    pub class: String,
+    pub action: String,
+    pub replacement: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct BundleAttachment {
+    pub id: String,
+    pub kind: String,
+    pub title: Option<String>,
+    pub stage: Option<String>,
+    pub text: Option<String>,
+    pub data: Option<JsonValue>,
+    pub metadata: BTreeMap<String, JsonValue>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SessionBundleError {
+    Decode(String),
+    Encode(String),
+    MissingRequired(String),
+    UnsupportedSchemaVersion { found: u64, supported: u32 },
+    InvalidType { path: String, expected: String },
+    UnsafeSecretMarker { path: String, excerpt: String },
+    MissingRunRecord,
+}
+
+impl fmt::Display for SessionBundleError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Decode(error) => write!(f, "failed to decode session bundle: {error}"),
+            Self::Encode(error) => write!(f, "failed to encode session bundle: {error}"),
+            Self::MissingRequired(path) => {
+                write!(f, "session bundle is missing required field {path}")
+            }
+            Self::UnsupportedSchemaVersion { found, supported } => write!(
+                f,
+                "unsupported session bundle schema_version {found}; this build supports <= {supported}"
+            ),
+            Self::InvalidType { path, expected } => {
+                write!(f, "session bundle field {path} must be {expected}")
+            }
+            Self::UnsafeSecretMarker { path, excerpt } => write!(
+                f,
+                "session bundle contains an unsafe unredacted secret marker at {path}: {excerpt}"
+            ),
+            Self::MissingRunRecord => write!(f, "session bundle does not include an importable run record"),
+        }
+    }
+}
+
+impl std::error::Error for SessionBundleError {}
+
+pub fn export_run_record_bundle(
+    run: &RunRecord,
+    options: &SessionBundleExportOptions,
+) -> Result<SessionBundle, SessionBundleError> {
+    let run_record_value =
+        serde_json::to_value(run).map_err(|error| SessionBundleError::Encode(error.to_string()))?;
+    let mut bundle = raw_bundle_from_run(run, run_record_value, options.include_attachments)?;
+    let mut bundle_value = serde_json::to_value(&bundle)
+        .map_err(|error| SessionBundleError::Encode(error.to_string()))?;
+
+    let mut manifest = RedactionManifest {
+        mode: options.mode.as_str().to_string(),
+        policy: if matches!(options.mode, SessionBundleExportMode::Local) {
+            "none".to_string()
+        } else {
+            "harn_vm::redact::RedactionPolicy::default+session_bundle_local_paths".to_string()
+        },
+        placeholder: REDACTED_PLACEHOLDER.to_string(),
+        entries: Vec::new(),
+        unsafe_secret_markers_rejected: !matches!(options.mode, SessionBundleExportMode::Local),
+    };
+
+    if !matches!(options.mode, SessionBundleExportMode::Local) {
+        let redaction_policy = bundle_redaction_policy(&options.redaction_policy);
+        redact_json_with_manifest(
+            &mut bundle_value,
+            "$",
+            &redaction_policy,
+            &mut manifest.entries,
+        );
+        redact_bundle_pointer_paths_json(&mut bundle_value, "$", &mut manifest.entries);
+    }
+    if matches!(options.mode, SessionBundleExportMode::ReplayOnly) {
+        withhold_replay_only_json(&mut bundle_value, "$", &mut manifest.entries);
+    }
+    set_json_path(
+        &mut bundle_value,
+        &["redaction"],
+        serde_json::to_value(&manifest)
+            .map_err(|error| SessionBundleError::Encode(error.to_string()))?,
+    );
+    bundle = serde_json::from_value(bundle_value)
+        .map_err(|error| SessionBundleError::Decode(error.to_string()))?;
+    Ok(bundle)
+}
+
+pub fn validate_session_bundle_value(
+    value: &JsonValue,
+    options: &SessionBundleValidationOptions,
+) -> Result<SessionBundle, SessionBundleError> {
+    require_field(value, "_type")?;
+    require_field(value, "schema_version")?;
+    require_field(value, "bundle_id")?;
+    require_field(value, "created_at")?;
+    require_field(value, "producer")?;
+    require_field(value, "source")?;
+    require_field(value, "runtime")?;
+    require_field(value, "transcript")?;
+    require_field(value, "tools")?;
+    require_field(value, "permissions")?;
+    require_field(value, "replay")?;
+    require_field(value, "redaction")?;
+    require_field(value, "attachments")?;
+    require_nested_field(value, &["producer", "name"])?;
+    require_nested_field(value, &["producer", "version"])?;
+    require_nested_field(value, &["producer", "schema_id"])?;
+    require_nested_field(value, &["source", "kind"])?;
+    require_nested_field(value, &["source", "run_record_id"])?;
+    require_nested_field(value, &["source", "workflow_id"])?;
+    require_nested_field(value, &["source", "task"])?;
+    require_nested_field(value, &["source", "status"])?;
+    require_nested_field(value, &["runtime", "harn_version"])?;
+    require_nested_field(value, &["runtime", "provider_models"])?;
+    require_nested_field(value, &["transcript", "sections"])?;
+    require_nested_field(value, &["tools", "schemas"])?;
+    require_nested_field(value, &["tools", "calls"])?;
+    require_nested_field(value, &["replay", "event_log_pointers"])?;
+    require_nested_field(value, &["replay", "transitions"])?;
+    require_nested_field(value, &["replay", "checkpoints"])?;
+    require_nested_field(value, &["replay", "trace_spans"])?;
+    require_nested_field(value, &["replay", "deterministic_events"])?;
+    require_nested_field(value, &["redaction", "mode"])?;
+    require_nested_field(value, &["redaction", "policy"])?;
+    require_nested_field(value, &["redaction", "placeholder"])?;
+    require_nested_field(value, &["redaction", "entries"])?;
+    require_nested_field(value, &["redaction", "unsafe_secret_markers_rejected"])?;
+
+    let type_name = value
+        .get("_type")
+        .and_then(JsonValue::as_str)
+        .ok_or_else(|| SessionBundleError::InvalidType {
+            path: "$._type".to_string(),
+            expected: "string".to_string(),
+        })?;
+    if type_name != SESSION_BUNDLE_TYPE {
+        return Err(SessionBundleError::InvalidType {
+            path: "$._type".to_string(),
+            expected: format!("\"{SESSION_BUNDLE_TYPE}\""),
+        });
+    }
+
+    let version = value
+        .get("schema_version")
+        .and_then(JsonValue::as_u64)
+        .ok_or_else(|| SessionBundleError::InvalidType {
+            path: "$.schema_version".to_string(),
+            expected: "positive integer".to_string(),
+        })?;
+    if version == 0 || version > u64::from(SESSION_BUNDLE_SCHEMA_VERSION) {
+        return Err(SessionBundleError::UnsupportedSchemaVersion {
+            found: version,
+            supported: SESSION_BUNDLE_SCHEMA_VERSION,
+        });
+    }
+
+    if !options.allow_unsafe_secret_markers {
+        reject_unredacted_secret_markers(value, "$", &options.redaction_policy)?;
+    }
+
+    serde_json::from_value::<SessionBundle>(value.clone())
+        .map_err(|error| SessionBundleError::Decode(error.to_string()))
+}
+
+pub fn validate_session_bundle_str(
+    content: &str,
+    options: &SessionBundleValidationOptions,
+) -> Result<SessionBundle, SessionBundleError> {
+    let value: JsonValue = serde_json::from_str(content)
+        .map_err(|error| SessionBundleError::Decode(error.to_string()))?;
+    validate_session_bundle_value(&value, options)
+}
+
+pub fn import_run_record_value(bundle: &SessionBundle) -> Result<JsonValue, SessionBundleError> {
+    if let Some(run_record) = bundle.replay.run_record.clone() {
+        return Ok(run_record);
+    }
+    if let Some(fixture) = &bundle.replay.replay_fixture {
+        let transcript = bundle.transcript.sections.first().map(|section| {
+            json!({
+                "_type": "transcript",
+                "messages": section.messages.clone(),
+                "events": section.events.clone(),
+                "assets": section.assets.clone(),
+                "summary": section.summary.clone(),
+                "metadata": section.metadata.clone(),
+            })
+        });
+        let hitl_questions = bundle
+            .permissions
+            .iter()
+            .filter(|permission| permission.kind == "hitl_question")
+            .map(|permission| permission.payload.clone())
+            .collect::<Vec<_>>();
+        return Ok(json!({
+            "_type": "run_record",
+            "id": bundle.source.run_record_id.clone(),
+            "workflow_id": bundle.source.workflow_id.clone(),
+            "workflow_name": bundle.source.workflow_name.clone(),
+            "task": bundle.source.task.clone(),
+            "status": bundle.source.status.clone(),
+            "started_at": bundle.source.started_at.clone(),
+            "finished_at": bundle.source.finished_at.clone(),
+            "stages": [],
+            "transitions": bundle.replay.transitions.clone(),
+            "checkpoints": bundle.replay.checkpoints.clone(),
+            "pending_nodes": [],
+            "completed_nodes": [],
+            "child_runs": [],
+            "artifacts": [],
+            "handoffs": [],
+            "policy": {},
+            "transcript": transcript,
+            "usage": bundle.runtime.usage.clone(),
+            "replay_fixture": fixture,
+            "trace_spans": bundle.replay.trace_spans.clone(),
+            "tool_recordings": bundle.tools.calls.clone(),
+            "hitl_questions": hitl_questions,
+            "persona_runtime": [],
+            "metadata": {
+                "imported_from_session_bundle": bundle.bundle_id.clone(),
+                "session_bundle_schema_version": bundle.schema_version,
+            }
+        }));
+    }
+    Err(SessionBundleError::MissingRunRecord)
+}
+
+fn raw_bundle_from_run(
+    run: &RunRecord,
+    run_record_value: JsonValue,
+    include_attachments: bool,
+) -> Result<SessionBundle, SessionBundleError> {
+    let mut bundle = SessionBundle {
+        bundle_id: new_id("bundle"),
+        created_at: now_rfc3339(),
+        producer: BundleProducer {
+            name: "harn".to_string(),
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            schema_id: SESSION_BUNDLE_SCHEMA_ID.to_string(),
+        },
+        source: BundleSource {
+            kind: "run_record".to_string(),
+            run_record_id: run.id.clone(),
+            workflow_id: run.workflow_id.clone(),
+            workflow_name: run.workflow_name.clone(),
+            task: run.task.clone(),
+            status: run.status.clone(),
+            started_at: run.started_at.clone(),
+            finished_at: run.finished_at.clone(),
+            persisted_path: run.persisted_path.clone(),
+            root_run_id: run.root_run_id.clone(),
+            parent_run_id: run.parent_run_id.clone(),
+            child_run_count: run.child_runs.len(),
+        },
+        runtime: BundleRuntime {
+            harn_version: env!("CARGO_PKG_VERSION").to_string(),
+            provider_models: run
+                .usage
+                .as_ref()
+                .map(|usage| usage.models.clone())
+                .unwrap_or_default(),
+            usage: run.usage.as_ref().map(|usage| BundleUsage {
+                input_tokens: usage.input_tokens,
+                output_tokens: usage.output_tokens,
+                call_count: usage.call_count,
+                total_duration_ms: usage.total_duration_ms,
+                total_cost: usage.total_cost,
+                models: usage.models.clone(),
+            }),
+            metadata: BTreeMap::new(),
+        },
+        workspace: workspace_from_run(run),
+        transcript: transcript_from_run(run),
+        tools: BundleTools {
+            schemas: tool_schema_entries(run),
+            calls: run
+                .tool_recordings
+                .iter()
+                .map(BundleToolCall::from)
+                .collect(),
+        },
+        permissions: permissions_from_run(run),
+        replay: BundleReplay {
+            replay_fixture: run.replay_fixture.clone(),
+            run_record: Some(run_record_value),
+            event_log_pointers: event_log_pointers_from_run(run),
+            transitions: run.transitions.clone(),
+            checkpoints: run.checkpoints.clone(),
+            trace_spans: run.trace_spans.clone(),
+            deterministic_events: deterministic_events_from_run(run)?,
+        },
+        redaction: RedactionManifest {
+            mode: "sanitized".to_string(),
+            policy: "harn_vm::redact::RedactionPolicy::default+session_bundle_local_paths"
+                .to_string(),
+            placeholder: REDACTED_PLACEHOLDER.to_string(),
+            entries: Vec::new(),
+            unsafe_secret_markers_rejected: true,
+        },
+        attachments: if include_attachments {
+            attachments_from_run(run)
+        } else {
+            Vec::new()
+        },
+        ..SessionBundle::default()
+    };
+    bundle.metadata.insert(
+        "format_note".to_string(),
+        json!("Session bundles are portable JSON envelopes; hosted share links should reference sanitized bundles rather than raw run records."),
+    );
+    Ok(bundle)
+}
+
+fn bundle_redaction_policy(base: &RedactionPolicy) -> RedactionPolicy {
+    base.clone()
+        .with_extra_field("persisted_path")
+        .with_extra_field("project_root")
+        .with_extra_field("run_path")
+        .with_extra_field("snapshot_path")
+        .with_extra_field("source_root")
+        .with_extra_field("workspace_root")
+}
+
+fn workspace_from_run(run: &RunRecord) -> Option<BundleWorkspace> {
+    let source_root = run
+        .metadata
+        .get("project_root")
+        .and_then(JsonValue::as_str)
+        .or_else(|| {
+            run.metadata
+                .get("workspace_root")
+                .and_then(JsonValue::as_str)
+        })
+        .map(str::to_string);
+    let identity = run
+        .metadata
+        .get("workspace_id")
+        .and_then(JsonValue::as_str)
+        .map(str::to_string);
+    if source_root.is_none() && identity.is_none() {
+        return None;
+    }
+    Some(BundleWorkspace {
+        identity,
+        source_root,
+        policy: "safe_identity_only".to_string(),
+    })
+}
+
+fn transcript_from_run(run: &RunRecord) -> BundleTranscript {
+    let mut sections = Vec::new();
+    if let Some(transcript) = &run.transcript {
+        sections.push(transcript_section(
+            "run",
+            "Run transcript",
+            "run",
+            "$.transcript",
+            transcript,
+        ));
+    }
+    for (index, stage) in run.stages.iter().enumerate() {
+        if let Some(transcript) = &stage.transcript {
+            sections.push(transcript_section(
+                &stage.id,
+                &format!("Stage {}", stage.node_id),
+                "stage",
+                &format!("$.stages[{index}].transcript"),
+                transcript,
+            ));
+        }
+    }
+    BundleTranscript { sections }
+}
+
+fn transcript_section(
+    id: &str,
+    label: &str,
+    scope: &str,
+    location: &str,
+    transcript: &JsonValue,
+) -> BundleTranscriptSection {
+    BundleTranscriptSection {
+        id: id.to_string(),
+        label: label.to_string(),
+        scope: scope.to_string(),
+        location: location.to_string(),
+        summary: transcript
+            .get("summary")
+            .and_then(JsonValue::as_str)
+            .map(str::to_string),
+        messages: json_array(transcript.get("messages")),
+        events: json_array(transcript.get("events")),
+        assets: json_array(transcript.get("assets")),
+        metadata: transcript
+            .get("metadata")
+            .and_then(JsonValue::as_object)
+            .map(|map| {
+                map.iter()
+                    .map(|(key, value)| (key.clone(), value.clone()))
+                    .collect()
+            })
+            .unwrap_or_default(),
+    }
+}
+
+fn json_array(value: Option<&JsonValue>) -> Vec<JsonValue> {
+    value
+        .and_then(JsonValue::as_array)
+        .cloned()
+        .unwrap_or_default()
+}
+
+fn tool_schema_entries(run: &RunRecord) -> Vec<BundleJsonEntry> {
+    let mut entries = Vec::new();
+    collect_tool_schema_entries_from_transcript(&mut entries, "run.transcript", &run.transcript);
+    for stage in &run.stages {
+        collect_tool_schema_entries_from_transcript(
+            &mut entries,
+            &format!("stage.{}.transcript", stage.node_id),
+            &stage.transcript,
+        );
+        if let Some(tools) = stage
+            .metadata
+            .get("tool_schemas")
+            .or_else(|| stage.metadata.get("tools"))
+        {
+            entries.push(BundleJsonEntry {
+                source: format!("stage.{}.metadata", stage.node_id),
+                index: entries.len(),
+                value: tools.clone(),
+            });
+        }
+    }
+    entries
+}
+
+fn collect_tool_schema_entries_from_transcript(
+    entries: &mut Vec<BundleJsonEntry>,
+    source: &str,
+    transcript: &Option<JsonValue>,
+) {
+    let Some(transcript) = transcript else {
+        return;
+    };
+    for event in transcript
+        .get("events")
+        .and_then(JsonValue::as_array)
+        .into_iter()
+        .flatten()
+    {
+        let kind = event
+            .get("type")
+            .or_else(|| event.get("kind"))
+            .and_then(JsonValue::as_str)
+            .unwrap_or_default();
+        if kind == "tool_schemas" || kind == "tool_schema" {
+            entries.push(BundleJsonEntry {
+                source: source.to_string(),
+                index: entries.len(),
+                value: event.clone(),
+            });
+        }
+    }
+}
+
+fn permissions_from_run(run: &RunRecord) -> Vec<BundlePermission> {
+    let mut permissions = run
+        .hitl_questions
+        .iter()
+        .map(permission_from_hitl_question)
+        .collect::<Vec<_>>();
+    collect_permission_events(&mut permissions, "run.transcript", &run.transcript);
+    for stage in &run.stages {
+        collect_permission_events(
+            &mut permissions,
+            &format!("stage.{}.transcript", stage.node_id),
+            &stage.transcript,
+        );
+        if let Some(worker) = stage.metadata.get("worker") {
+            if let Some(policy) = worker
+                .get("audit")
+                .and_then(|audit| audit.get("approval_policy"))
+            {
+                permissions.push(BundlePermission {
+                    kind: "approval_policy".to_string(),
+                    source: format!("stage.{}.worker.audit", stage.node_id),
+                    request_id: None,
+                    agent: worker
+                        .get("name")
+                        .and_then(JsonValue::as_str)
+                        .map(str::to_string),
+                    payload: policy.clone(),
+                });
+            }
+        }
+    }
+    permissions
+}
+
+fn permission_from_hitl_question(question: &RunHitlQuestionRecord) -> BundlePermission {
+    BundlePermission {
+        kind: "hitl_question".to_string(),
+        source: "run.hitl_questions".to_string(),
+        request_id: Some(question.request_id.clone()),
+        agent: if question.agent.is_empty() {
+            None
+        } else {
+            Some(question.agent.clone())
+        },
+        payload: serde_json::to_value(question).unwrap_or(JsonValue::Null),
+    }
+}
+
+fn collect_permission_events(
+    permissions: &mut Vec<BundlePermission>,
+    source: &str,
+    transcript: &Option<JsonValue>,
+) {
+    let Some(transcript) = transcript else {
+        return;
+    };
+    for event in transcript
+        .get("events")
+        .and_then(JsonValue::as_array)
+        .into_iter()
+        .flatten()
+    {
+        let kind = event
+            .get("type")
+            .or_else(|| event.get("kind"))
+            .and_then(JsonValue::as_str)
+            .unwrap_or_default();
+        if kind.contains("permission") || kind.contains("approval") || kind.starts_with("hitl_") {
+            permissions.push(BundlePermission {
+                kind: kind.to_string(),
+                source: source.to_string(),
+                request_id: event
+                    .get("request_id")
+                    .or_else(|| event.get("id"))
+                    .and_then(JsonValue::as_str)
+                    .map(str::to_string),
+                agent: event
+                    .get("agent")
+                    .and_then(JsonValue::as_str)
+                    .map(str::to_string),
+                payload: event.clone(),
+            });
+        }
+    }
+}
+
+fn event_log_pointers_from_run(run: &RunRecord) -> Vec<BundleEventLogPointer> {
+    let mut pointers = Vec::new();
+    if let Some(observability) = &run.observability {
+        for pointer in &observability.transcript_pointers {
+            pointers.push(BundleEventLogPointer {
+                kind: pointer.kind.clone(),
+                topic: None,
+                path: pointer.path.clone(),
+                location: pointer.location.clone(),
+                available: pointer.available,
+            });
+        }
+        for worker in &observability.worker_lineage {
+            if let Some(session_id) = &worker.session_id {
+                pointers.push(BundleEventLogPointer {
+                    kind: "agent_events".to_string(),
+                    topic: Some(format!("observability.agent_events.{session_id}")),
+                    path: worker.snapshot_path.clone(),
+                    location: format!("worker.{}.session", worker.worker_id),
+                    available: worker.snapshot_path.is_some(),
+                });
+            }
+        }
+    }
+    pointers
+}
+
+fn deterministic_events_from_run(
+    run: &RunRecord,
+) -> Result<Vec<BundleJsonEntry>, SessionBundleError> {
+    let mut events = Vec::new();
+    for (index, transition) in run.transitions.iter().enumerate() {
+        events.push(BundleJsonEntry {
+            source: "run.transitions".to_string(),
+            index,
+            value: serde_json::to_value(transition)
+                .map_err(|error| SessionBundleError::Encode(error.to_string()))?,
+        });
+    }
+    for (index, checkpoint) in run.checkpoints.iter().enumerate() {
+        events.push(BundleJsonEntry {
+            source: "run.checkpoints".to_string(),
+            index,
+            value: serde_json::to_value(checkpoint)
+                .map_err(|error| SessionBundleError::Encode(error.to_string()))?,
+        });
+    }
+    Ok(events)
+}
+
+fn attachments_from_run(run: &RunRecord) -> Vec<BundleAttachment> {
+    run.artifacts
+        .iter()
+        .map(|artifact| BundleAttachment {
+            id: artifact.id.clone(),
+            kind: artifact.kind.clone(),
+            title: artifact.title.clone(),
+            stage: artifact.stage.clone(),
+            text: artifact.text.clone(),
+            data: artifact.data.clone(),
+            metadata: artifact.metadata.clone(),
+        })
+        .collect()
+}
+
+fn redact_json_with_manifest(
+    value: &mut JsonValue,
+    path: &str,
+    policy: &RedactionPolicy,
+    entries: &mut Vec<RedactionEntry>,
+) {
+    match value {
+        JsonValue::Object(map) => {
+            let keys = map.keys().cloned().collect::<Vec<_>>();
+            for key in keys {
+                let child_path = json_path_child(path, &key);
+                if policy.field_is_sensitive(&key) {
+                    map.insert(key, JsonValue::String(REDACTED_PLACEHOLDER.to_string()));
+                    entries.push(RedactionEntry {
+                        path: child_path,
+                        class: "sensitive_field".to_string(),
+                        action: "replaced".to_string(),
+                        replacement: Some(REDACTED_PLACEHOLDER.to_string()),
+                    });
+                } else if let Some(child) = map.get_mut(&key) {
+                    redact_json_with_manifest(child, &child_path, policy, entries);
+                }
+            }
+        }
+        JsonValue::Array(items) => {
+            for (index, item) in items.iter_mut().enumerate() {
+                redact_json_with_manifest(item, &format!("{path}[{index}]"), policy, entries);
+            }
+        }
+        JsonValue::String(text) => {
+            let redacted = policy.redact_string(text);
+            if let Cow::Owned(replacement) = redacted {
+                *text = replacement;
+                entries.push(RedactionEntry {
+                    path: path.to_string(),
+                    class: "secret_pattern_or_url".to_string(),
+                    action: "replaced".to_string(),
+                    replacement: Some(REDACTED_PLACEHOLDER.to_string()),
+                });
+            }
+        }
+        _ => {}
+    }
+}
+
+fn redact_bundle_pointer_paths_json(
+    value: &mut JsonValue,
+    path: &str,
+    entries: &mut Vec<RedactionEntry>,
+) {
+    match value {
+        JsonValue::Object(map) => {
+            let keys = map.keys().cloned().collect::<Vec<_>>();
+            for key in keys {
+                let child_path = json_path_child(path, &key);
+                if key == "path" && bundle_pointer_path_should_redact(&child_path) {
+                    if !map.get(&key).is_some_and(JsonValue::is_null) {
+                        map.insert(key, JsonValue::String(REDACTED_PLACEHOLDER.to_string()));
+                        entries.push(RedactionEntry {
+                            path: child_path,
+                            class: "local_pointer_path".to_string(),
+                            action: "replaced".to_string(),
+                            replacement: Some(REDACTED_PLACEHOLDER.to_string()),
+                        });
+                    }
+                } else if let Some(child) = map.get_mut(&key) {
+                    redact_bundle_pointer_paths_json(child, &child_path, entries);
+                }
+            }
+        }
+        JsonValue::Array(items) => {
+            for (index, item) in items.iter_mut().enumerate() {
+                redact_bundle_pointer_paths_json(item, &format!("{path}[{index}]"), entries);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn bundle_pointer_path_should_redact(path: &str) -> bool {
+    path.contains(".event_log_pointers[") || path.contains(".transcript_pointers[")
+}
+
+fn withhold_replay_only_json(value: &mut JsonValue, path: &str, entries: &mut Vec<RedactionEntry>) {
+    match value {
+        JsonValue::Object(map) => {
+            let keys = map.keys().cloned().collect::<Vec<_>>();
+            for key in keys {
+                let child_path = json_path_child(path, &key);
+                if replay_only_field_is_prompt_payload(&key) {
+                    if !map.get(&key).is_some_and(JsonValue::is_null) {
+                        map.insert(key, JsonValue::String(REPLAY_ONLY_PLACEHOLDER.to_string()));
+                        entries.push(RedactionEntry {
+                            path: child_path,
+                            class: "prompt_or_tool_payload".to_string(),
+                            action: "withheld".to_string(),
+                            replacement: Some(REPLAY_ONLY_PLACEHOLDER.to_string()),
+                        });
+                    }
+                } else if let Some(child) = map.get_mut(&key) {
+                    withhold_replay_only_json(child, &child_path, entries);
+                }
+            }
+        }
+        JsonValue::Array(items) => {
+            for (index, item) in items.iter_mut().enumerate() {
+                withhold_replay_only_json(item, &format!("{path}[{index}]"), entries);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn replay_only_field_is_prompt_payload(key: &str) -> bool {
+    matches!(
+        key,
+        "args"
+            | "arguments"
+            | "blocks"
+            | "content"
+            | "data"
+            | "private_reasoning"
+            | "prompt"
+            | "raw_input"
+            | "raw_output"
+            | "result"
+            | "response_text"
+            | "summary"
+            | "system"
+            | "system_prompt"
+            | "task"
+            | "text"
+            | "thinking"
+            | "visible_text"
+    )
+}
+
+fn set_json_path(value: &mut JsonValue, path: &[&str], replacement: JsonValue) {
+    let Some((head, tail)) = path.split_first() else {
+        *value = replacement;
+        return;
+    };
+    if tail.is_empty() {
+        if let JsonValue::Object(map) = value {
+            map.insert((*head).to_string(), replacement);
+        }
+        return;
+    }
+    if let JsonValue::Object(map) = value {
+        if let Some(child) = map.get_mut(*head) {
+            set_json_path(child, tail, replacement);
+        }
+    }
+}
+
+fn require_field(value: &JsonValue, field: &str) -> Result<(), SessionBundleError> {
+    if value.get(field).is_some() {
+        Ok(())
+    } else {
+        Err(SessionBundleError::MissingRequired(format!("$.{field}")))
+    }
+}
+
+fn require_nested_field(value: &JsonValue, path: &[&str]) -> Result<(), SessionBundleError> {
+    let mut current = value;
+    for segment in path {
+        current = current
+            .get(*segment)
+            .ok_or_else(|| SessionBundleError::MissingRequired(json_path_from_segments(path)))?;
+    }
+    Ok(())
+}
+
+fn json_path_from_segments(path: &[&str]) -> String {
+    path.iter().fold("$".to_string(), |parent, segment| {
+        json_path_child(&parent, segment)
+    })
+}
+
+fn reject_unredacted_secret_markers(
+    value: &JsonValue,
+    path: &str,
+    policy: &RedactionPolicy,
+) -> Result<(), SessionBundleError> {
+    match value {
+        JsonValue::Object(map) => {
+            for (key, child) in map {
+                reject_unredacted_secret_markers(child, &json_path_child(path, key), policy)?;
+            }
+        }
+        JsonValue::Array(items) => {
+            for (index, item) in items.iter().enumerate() {
+                reject_unredacted_secret_markers(item, &format!("{path}[{index}]"), policy)?;
+            }
+        }
+        JsonValue::String(text) => {
+            if matches!(policy.redact_string(text), Cow::Owned(_)) {
+                return Err(SessionBundleError::UnsafeSecretMarker {
+                    path: path.to_string(),
+                    excerpt: secret_excerpt(text),
+                });
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn secret_excerpt(text: &str) -> String {
+    let excerpt = text.chars().take(80).collect::<String>();
+    if text.chars().count() > 80 {
+        format!("{excerpt}...")
+    } else {
+        excerpt
+    }
+}
+
+fn json_path_child(parent: &str, key: &str) -> String {
+    if key
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
+    {
+        format!("{parent}.{key}")
+    } else {
+        format!(
+            "{parent}[{}]",
+            serde_json::to_string(key).unwrap_or_default()
+        )
+    }
+}

--- a/crates/harn-vm/src/session_bundle/schema.rs
+++ b/crates/harn-vm/src/session_bundle/schema.rs
@@ -1,0 +1,161 @@
+use serde_json::{json, Value as JsonValue};
+
+use super::{
+    SessionBundleError, SESSION_BUNDLE_SCHEMA_ID, SESSION_BUNDLE_SCHEMA_VERSION,
+    SESSION_BUNDLE_TYPE,
+};
+
+pub fn session_bundle_schema() -> JsonValue {
+    json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": SESSION_BUNDLE_SCHEMA_ID,
+        "title": "Harn Session Bundle v1",
+        "type": "object",
+        "additionalProperties": true,
+        "required": [
+            "_type",
+            "schema_version",
+            "bundle_id",
+            "created_at",
+            "producer",
+            "source",
+            "runtime",
+            "transcript",
+            "tools",
+            "permissions",
+            "replay",
+            "redaction",
+            "attachments"
+        ],
+        "properties": {
+            "_type": {"const": SESSION_BUNDLE_TYPE},
+            "schema_version": {"type": "integer", "minimum": 1, "maximum": SESSION_BUNDLE_SCHEMA_VERSION},
+            "bundle_id": {"type": "string", "minLength": 1},
+            "created_at": {"type": "string", "minLength": 1},
+            "producer": {
+                "type": "object",
+                "required": ["name", "version", "schema_id"],
+                "additionalProperties": true,
+                "properties": {
+                    "name": {"type": "string"},
+                    "version": {"type": "string"},
+                    "schema_id": {"type": "string"}
+                }
+            },
+            "source": {
+                "type": "object",
+                "required": ["kind", "run_record_id", "workflow_id", "task", "status"],
+                "additionalProperties": true,
+                "properties": {
+                    "kind": {"type": "string"},
+                    "run_record_id": {"type": "string"},
+                    "workflow_id": {"type": "string"},
+                    "workflow_name": {"type": ["string", "null"]},
+                    "task": {"type": "string"},
+                    "status": {"type": "string"},
+                    "started_at": {"type": "string"},
+                    "finished_at": {"type": ["string", "null"]},
+                    "persisted_path": {"type": ["string", "null"]},
+                    "root_run_id": {"type": ["string", "null"]},
+                    "parent_run_id": {"type": ["string", "null"]},
+                    "child_run_count": {"type": "integer", "minimum": 0}
+                }
+            },
+            "runtime": {
+                "type": "object",
+                "required": ["harn_version", "provider_models"],
+                "additionalProperties": true,
+                "properties": {
+                    "harn_version": {"type": "string"},
+                    "provider_models": {"type": "array", "items": {"type": "string"}},
+                    "usage": {"type": ["object", "null"]},
+                    "metadata": {"type": "object"}
+                }
+            },
+            "workspace": {"type": ["object", "null"]},
+            "transcript": {
+                "type": "object",
+                "required": ["sections"],
+                "additionalProperties": true,
+                "properties": {
+                    "sections": {
+                        "type": "array",
+                        "items": {"$ref": "#/$defs/transcript_section"}
+                    }
+                }
+            },
+            "tools": {
+                "type": "object",
+                "required": ["schemas", "calls"],
+                "additionalProperties": true,
+                "properties": {
+                    "schemas": {"type": "array", "items": {"$ref": "#/$defs/json_entry"}},
+                    "calls": {"type": "array", "items": {"type": "object"}}
+                }
+            },
+            "permissions": {"type": "array", "items": {"type": "object"}},
+            "replay": {
+                "type": "object",
+                "required": ["event_log_pointers", "transitions", "checkpoints", "trace_spans", "deterministic_events"],
+                "additionalProperties": true,
+                "properties": {
+                    "replay_fixture": {"type": ["object", "null"]},
+                    "run_record": {"type": ["object", "null"]},
+                    "event_log_pointers": {"type": "array", "items": {"type": "object"}},
+                    "transitions": {"type": "array", "items": {"type": "object"}},
+                    "checkpoints": {"type": "array", "items": {"type": "object"}},
+                    "trace_spans": {"type": "array", "items": {"type": "object"}},
+                    "deterministic_events": {"type": "array", "items": {"$ref": "#/$defs/json_entry"}}
+                }
+            },
+            "redaction": {
+                "type": "object",
+                "required": ["mode", "policy", "placeholder", "entries", "unsafe_secret_markers_rejected"],
+                "additionalProperties": true,
+                "properties": {
+                    "mode": {"enum": ["local", "sanitized", "replay_only"]},
+                    "policy": {"type": "string"},
+                    "placeholder": {"type": "string"},
+                    "entries": {"type": "array", "items": {"type": "object"}},
+                    "unsafe_secret_markers_rejected": {"type": "boolean"}
+                }
+            },
+            "attachments": {"type": "array", "items": {"type": "object"}},
+            "metadata": {"type": "object"}
+        },
+        "$defs": {
+            "json_entry": {
+                "type": "object",
+                "required": ["source", "index", "value"],
+                "additionalProperties": true,
+                "properties": {
+                    "source": {"type": "string"},
+                    "index": {"type": "integer", "minimum": 0},
+                    "value": true
+                }
+            },
+            "transcript_section": {
+                "type": "object",
+                "required": ["id", "label", "scope", "location", "messages", "events", "assets", "metadata"],
+                "additionalProperties": true,
+                "properties": {
+                    "id": {"type": "string"},
+                    "label": {"type": "string"},
+                    "scope": {"type": "string"},
+                    "location": {"type": "string"},
+                    "summary": {"type": ["string", "null"]},
+                    "messages": {"type": "array", "items": true},
+                    "events": {"type": "array", "items": true},
+                    "assets": {"type": "array", "items": true},
+                    "metadata": {"type": "object"}
+                }
+            }
+        }
+    })
+}
+
+pub fn session_bundle_schema_pretty() -> Result<String, SessionBundleError> {
+    serde_json::to_string_pretty(&session_bundle_schema())
+        .map(|schema| format!("{schema}\n"))
+        .map_err(|error| SessionBundleError::Encode(error.to_string()))
+}

--- a/crates/harn-vm/src/session_bundle/tests.rs
+++ b/crates/harn-vm/src/session_bundle/tests.rs
@@ -1,0 +1,217 @@
+use std::fs;
+
+use serde_json::json;
+
+use super::*;
+use crate::orchestration::{LlmUsageRecord, RunStageRecord};
+
+fn repo_fixture_path(name: &str) -> String {
+    format!(
+        "{}/../../spec/session-bundles/fixtures/{name}",
+        env!("CARGO_MANIFEST_DIR")
+    )
+}
+
+fn fixture_run() -> RunRecord {
+    let synthetic_api_key = format!("{}{}", "sk-test_", "1234567890abcdefghijklmnop");
+    let synthetic_bearer = format!("{} {}", "Bearer", "abcDEFghi12345");
+    RunRecord {
+        type_name: "run_record".to_string(),
+        id: "run_123".to_string(),
+        workflow_id: "wf_123".to_string(),
+        workflow_name: Some("Review".to_string()),
+        task: "Review the failing deployment".to_string(),
+        status: "completed".to_string(),
+        started_at: "2026-05-01T00:00:00Z".to_string(),
+        finished_at: Some("2026-05-01T00:01:00Z".to_string()),
+        transcript: Some(json!({
+            "_type": "transcript",
+            "messages": [
+                {"role": "user", "content": format!("token {synthetic_api_key}")}
+            ],
+            "events": [
+                {"kind": "permission_denied", "reason": "policy", "arguments": {"api_key": "abc"}},
+                {"type": "tool_schemas", "schemas": [{"name": "read_file"}]}
+            ],
+            "assets": [],
+            "summary": "done",
+            "metadata": {"system_prompt": "be careful"}
+        })),
+        usage: Some(LlmUsageRecord {
+            input_tokens: 10,
+            output_tokens: 4,
+            call_count: 1,
+            total_duration_ms: 100,
+            total_cost: 0.01,
+            models: vec!["mock/model".to_string()],
+        }),
+        stages: vec![RunStageRecord {
+            id: "stage_1".to_string(),
+            node_id: "answer".to_string(),
+            transcript: Some(json!({
+                "messages": [{"role": "assistant", "content": "done"}],
+                "events": [],
+                "assets": []
+            })),
+            ..RunStageRecord::default()
+        }],
+        tool_recordings: vec![ToolCallRecord {
+            tool_name: "read_file".to_string(),
+            tool_use_id: "toolu_1".to_string(),
+            args_hash: "abc123".to_string(),
+            result: synthetic_bearer,
+            is_rejected: false,
+            duration_ms: 7,
+            iteration: 1,
+            timestamp: "2026-05-01T00:00:30Z".to_string(),
+        }],
+        hitl_questions: vec![RunHitlQuestionRecord {
+            request_id: "hitl_1".to_string(),
+            prompt: "Approve?".to_string(),
+            agent: "agent".to_string(),
+            trace_id: None,
+            asked_at: "2026-05-01T00:00:10Z".to_string(),
+        }],
+        ..RunRecord::default()
+    }
+}
+
+#[test]
+fn sanitized_export_redacts_secrets_and_records_manifest() {
+    let bundle =
+        export_run_record_bundle(&fixture_run(), &SessionBundleExportOptions::default()).unwrap();
+    let rendered = serde_json::to_string(&bundle).unwrap();
+    assert!(!rendered.contains("1234567890abcdefghijklmnop"));
+    assert!(!rendered.contains("abcDEFghi12345"));
+    assert!(rendered.contains(REDACTED_PLACEHOLDER));
+    assert!(bundle
+        .redaction
+        .entries
+        .iter()
+        .any(|entry| entry.class == "secret_pattern_or_url"));
+    assert_eq!(bundle.transcript.sections.len(), 2);
+    assert_eq!(bundle.tools.schemas.len(), 1);
+    assert_eq!(bundle.permissions.len(), 2);
+}
+
+#[test]
+fn replay_only_export_withholds_prompt_and_tool_payloads() {
+    let options = SessionBundleExportOptions {
+        mode: SessionBundleExportMode::ReplayOnly,
+        ..SessionBundleExportOptions::default()
+    };
+    let bundle = export_run_record_bundle(&fixture_run(), &options).unwrap();
+    let rendered = serde_json::to_string(&bundle).unwrap();
+    assert!(!rendered.contains("Review the failing deployment"));
+    assert!(!rendered.contains("done"));
+    assert!(rendered.contains(REPLAY_ONLY_PLACEHOLDER));
+    assert!(bundle
+        .redaction
+        .entries
+        .iter()
+        .any(|entry| entry.action == "withheld"));
+}
+
+#[test]
+fn validation_rejects_missing_required_fields() {
+    let err = validate_session_bundle_value(&json!({}), &SessionBundleValidationOptions::default())
+        .unwrap_err();
+    assert_eq!(
+        err,
+        SessionBundleError::MissingRequired("$._type".to_string())
+    );
+
+    let bundle =
+        export_run_record_bundle(&fixture_run(), &SessionBundleExportOptions::default()).unwrap();
+    let mut value = serde_json::to_value(bundle).unwrap();
+    value.as_object_mut().unwrap().remove("producer");
+    let err = validate_session_bundle_value(&value, &SessionBundleValidationOptions::default())
+        .unwrap_err();
+    assert_eq!(
+        err,
+        SessionBundleError::MissingRequired("$.producer".to_string())
+    );
+
+    let bundle =
+        export_run_record_bundle(&fixture_run(), &SessionBundleExportOptions::default()).unwrap();
+    let mut value = serde_json::to_value(bundle).unwrap();
+    value["source"]
+        .as_object_mut()
+        .unwrap()
+        .remove("run_record_id");
+    let err = validate_session_bundle_value(&value, &SessionBundleValidationOptions::default())
+        .unwrap_err();
+    assert_eq!(
+        err,
+        SessionBundleError::MissingRequired("$.source.run_record_id".to_string())
+    );
+}
+
+#[test]
+fn validation_rejects_future_versions() {
+    let bundle =
+        export_run_record_bundle(&fixture_run(), &SessionBundleExportOptions::default()).unwrap();
+    let mut value = serde_json::to_value(bundle).unwrap();
+    value["schema_version"] = json!(999);
+    let err = validate_session_bundle_value(&value, &SessionBundleValidationOptions::default())
+        .unwrap_err();
+    assert_eq!(
+        err,
+        SessionBundleError::UnsupportedSchemaVersion {
+            found: 999,
+            supported: SESSION_BUNDLE_SCHEMA_VERSION,
+        }
+    );
+}
+
+#[test]
+fn validation_rejects_unredacted_secret_markers() {
+    let options = SessionBundleExportOptions {
+        mode: SessionBundleExportMode::Local,
+        ..SessionBundleExportOptions::default()
+    };
+    let bundle = export_run_record_bundle(&fixture_run(), &options).unwrap();
+    let value = serde_json::to_value(bundle).unwrap();
+    let err = validate_session_bundle_value(&value, &SessionBundleValidationOptions::default())
+        .unwrap_err();
+    assert!(matches!(err, SessionBundleError::UnsafeSecretMarker { .. }));
+}
+
+#[test]
+fn imported_run_record_prefers_embedded_run_record() {
+    let bundle =
+        export_run_record_bundle(&fixture_run(), &SessionBundleExportOptions::default()).unwrap();
+    let run_record = import_run_record_value(&bundle).unwrap();
+    assert_eq!(run_record["_type"], "run_record");
+    assert_eq!(run_record["id"], "run_123");
+}
+
+#[test]
+fn schema_is_self_describing() {
+    let schema = session_bundle_schema();
+    assert_eq!(schema["properties"]["_type"]["const"], SESSION_BUNDLE_TYPE);
+    assert_eq!(
+        schema["properties"]["schema_version"]["maximum"],
+        SESSION_BUNDLE_SCHEMA_VERSION
+    );
+}
+
+#[test]
+fn checked_session_bundle_fixtures_validate_and_import() {
+    for fixture in [
+        "sample-local.bundle.json",
+        "sample-sanitized.bundle.json",
+        "sample-replay-only.bundle.json",
+    ] {
+        let path = repo_fixture_path(fixture);
+        let content = fs::read_to_string(&path).unwrap();
+        let bundle =
+            validate_session_bundle_str(&content, &SessionBundleValidationOptions::default())
+                .unwrap();
+        assert_eq!(bundle.source.run_record_id, "run_fixture_session_bundle");
+
+        let imported = import_run_record_value(&bundle).unwrap();
+        assert_eq!(imported["_type"], "run_record");
+        assert_eq!(imported["id"], "run_fixture_session_bundle");
+    }
+}

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -62,6 +62,7 @@
   - [Merge Captain](./personas/merge-captain.md)
 - [Skill provenance](./skill-provenance.md)
 - [Sessions](./sessions.md)
+- [Session bundles](./session-bundles.md)
 - [Agent state](./agent-state.md)
 - [Memory](./memory.md)
 - [Transcript architecture](./transcript-architecture.md)

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -83,6 +83,31 @@ Verification recomputes the EventLog record chain, the receipt event root, the
 receipt hash, and the Ed25519 signature. It exits non-zero if any receipt event
 or signature material has been changed.
 
+## harn session
+
+Export, validate, import, and check canonical session bundles.
+
+```bash
+harn session export .harn-runs/<run>/run.json --out run.bundle.json
+harn session export .harn-runs/<run>/run.json --local --out run.local.bundle.json
+harn session export .harn-runs/<run>/run.json --replay-only --out run.replay.bundle.json
+harn session validate run.bundle.json --json
+harn session import run.bundle.json --out imported-run.json
+harn session schema --check
+```
+
+| Subcommand | Description |
+|---|---|
+| `export <run-record>` | Writes a `harn_session_bundle` envelope. Default output is sanitized; `--local` preserves local-only content; `--replay-only` withholds prompt/tool payload fields. |
+| `validate <bundle>` | Validates required fields, schema version, bundle type, and high-confidence secret markers without writing a run record. |
+| `import <bundle>` | Validates the bundle and materializes a local run record from `replay.run_record` or replay metadata. |
+| `schema` | Prints, writes, or checks `spec/schemas/session-bundle.v1.schema.json`. |
+
+`export --include-attachments` copies artifact payloads into the top-level
+`attachments` array. By default attachment payloads are omitted for share
+safety. `import` and `validate` accept
+`--allow-unsafe-secret-markers` only for trusted local bundles.
+
 ## harn completions
 
 Print shell completion scripts.

--- a/docs/src/redaction.md
+++ b/docs/src/redaction.md
@@ -61,6 +61,7 @@ grepping logs trivial to write.
 | `LogEvent` payloads | [`LogEvent::redact_in_place`](../../crates/harn-vm/src/event_log/mod.rs) | Headers are scrubbed in-place; the JSON payload is walked recursively. Backends are intentionally unaware of redaction so emitters that need it call this before appending. |
 | Portal transcript projection | [`portal::transcript`](../../crates/harn-cli/src/commands/portal/transcript.rs) | Defense in depth: even transcripts written before the unified policy landed are redacted at portal read time. |
 | Workflow artifacts | [`ArtifactRecord::redact_in_place`](../../crates/harn-vm/src/orchestration/artifacts.rs) | `text` is run through the secret-pattern scanner; `data` and `metadata` go through the JSON walk. |
+| Session bundles | [`harn_vm::session_bundle`](../../crates/harn-vm/src/session_bundle.rs) | Sanitized exports walk the whole bundle and emit a redaction manifest; replay-only exports additionally withhold prompt and tool payload fields. Import and validation reject high-confidence secret markers unless explicitly allowed. |
 | Connector inbound headers | [`HeaderRedactionPolicy` (alias for `RedactionPolicy`)](../../crates/harn-vm/src/triggers/event.rs) | Each connector strips inbound HTTP headers before they reach the durable inbox. |
 | HTTP egress diagnostics | [`crate::egress`](../../crates/harn-vm/src/egress.rs) | URLs reported in `EgressBlocked` errors and `http_mock` calls are redacted via the same policy. |
 

--- a/docs/src/session-bundles.md
+++ b/docs/src/session-bundles.md
@@ -1,0 +1,104 @@
+# Session bundles
+
+A **session bundle** is the portable JSON envelope for moving a
+persisted Harn run between local debugging, support handoff, sharing,
+and replay workflows. It is built from the existing run record instead
+of introducing a second persistence model, so transcripts, tool call
+recordings, HITL questions, event-log pointers, replay fixtures, trace
+spans, and workflow checkpoints keep one canonical shape.
+
+The current bundle type is `harn_session_bundle` with
+`schema_version: 1`. The checked schema lives at
+`spec/schemas/session-bundle.v1.schema.json`; regenerate it with:
+
+```bash
+make gen-session-bundle-schema
+make check-session-bundle-schema
+```
+
+## Export modes
+
+`harn session export` reads a persisted run-record JSON file and writes a
+bundle:
+
+```bash
+harn session export .harn-runs/<run>/run.json --out run.bundle.json
+harn session export .harn-runs/<run>/run.json --local --out run.local.bundle.json
+harn session export .harn-runs/<run>/run.json --replay-only --out run.replay.bundle.json
+```
+
+The default mode is **sanitized**. It walks the whole bundle with the
+runtime redaction policy and records every replacement in
+`redaction.entries`. Bundle export also treats local path fields such
+as `persisted_path`, `project_root`, `source_root`, and `run_path` as
+share-sensitive. This is the right mode for support tickets, PR
+attachments, issue reproductions, and any hosted share link.
+
+`--local` preserves the raw run record content. It is useful for
+workstation-to-workstation debugging inside the same trust boundary.
+Import and validate still reject high-confidence secret patterns unless
+`--allow-unsafe-secret-markers` is passed.
+
+`--replay-only` applies redaction and then withholds prompt/tool payload
+fields such as `content`, `prompt`, `system_prompt`, `arguments`,
+`result`, and `private_reasoning`. It keeps deterministic replay
+metadata, tool-call hashes, stage transitions, checkpoints, trace spans,
+and replay fixtures, so another host can inspect or rerun structure
+without receiving prompt text.
+
+Artifacts are omitted unless `--include-attachments` is passed. The
+bundle always includes attachment metadata that already exists inside the
+embedded run record; the top-level `attachments` array is reserved for
+payloads that callers intentionally include.
+
+## Import and validation
+
+Use `harn session validate` to check the envelope without writing
+anything:
+
+```bash
+harn session validate run.bundle.json
+harn session validate run.bundle.json --json
+```
+
+Validation rejects:
+
+- missing required schema fields,
+- `_type` values other than `harn_session_bundle`,
+- unsupported future `schema_version` values,
+- unredacted high-confidence secret markers unless explicitly allowed.
+
+Use `harn session import` to materialize a local run record:
+
+```bash
+harn session import run.bundle.json --out imported-run.json
+```
+
+Import prefers the embedded `replay.run_record` because that preserves
+the complete run record. If a bundle has no embedded run record but does
+carry a replay fixture and transcript sections, import reconstructs a
+minimal replayable run record from those canonical sections.
+
+## Fixtures
+
+Contract fixtures live under `spec/session-bundles/fixtures/`:
+
+- `sample-run-record.json` is the source run record.
+- `sample-local.bundle.json` preserves local-only fields.
+- `sample-sanitized.bundle.json` demonstrates the redaction manifest.
+- `sample-replay-only.bundle.json` demonstrates prompt/tool payload
+  withholding.
+
+The runtime unit tests validate and import these checked fixtures, while
+the negative tests cover missing required fields, future schema versions,
+and unsafe secret markers.
+
+## Migration
+
+Before session bundles, the closest export story was "attach the raw
+run record plus whatever sidecars seemed useful." That leaked trust
+boundary decisions into every caller and made replay handoffs brittle.
+New callers should export a session bundle instead of sharing raw
+`.harn-runs/*` directories. Existing run records remain the source of
+truth; migration is a direct cutover at the boundary where a run leaves
+the local machine.

--- a/docs/src/sessions.md
+++ b/docs/src/sessions.md
@@ -134,6 +134,18 @@ tool_format?, error?}`. `source_format` is `message_events`,
 with `validate: false` and is assistant-response best effort, not prefix-cache
 equivalent replay.
 
+## Portable session bundles
+
+VM-local session builtins own live transcript state. Persisted run
+records can leave the workstation through the canonical
+[`harn session export`](./session-bundles.md) bundle format. Bundles
+carry transcript sections, tool-call records, permission/HITL evidence,
+replay fixtures, trace spans, and a redaction manifest in one envelope.
+
+Use sanitized bundles for support and sharing, local bundles inside one
+trust boundary, and replay-only bundles when another host needs replay
+evidence without prompt or tool payload text.
+
 ## Storage model
 
 Sessions live in a per-thread `HashMap<String, SessionState>` in

--- a/spec/schemas/session-bundle.v1.schema.json
+++ b/spec/schemas/session-bundle.v1.schema.json
@@ -1,0 +1,371 @@
+{
+  "$defs": {
+    "json_entry": {
+      "additionalProperties": true,
+      "properties": {
+        "index": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "source": {
+          "type": "string"
+        },
+        "value": true
+      },
+      "required": [
+        "source",
+        "index",
+        "value"
+      ],
+      "type": "object"
+    },
+    "transcript_section": {
+      "additionalProperties": true,
+      "properties": {
+        "assets": {
+          "items": true,
+          "type": "array"
+        },
+        "events": {
+          "items": true,
+          "type": "array"
+        },
+        "id": {
+          "type": "string"
+        },
+        "label": {
+          "type": "string"
+        },
+        "location": {
+          "type": "string"
+        },
+        "messages": {
+          "items": true,
+          "type": "array"
+        },
+        "metadata": {
+          "type": "object"
+        },
+        "scope": {
+          "type": "string"
+        },
+        "summary": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "id",
+        "label",
+        "scope",
+        "location",
+        "messages",
+        "events",
+        "assets",
+        "metadata"
+      ],
+      "type": "object"
+    }
+  },
+  "$id": "https://harnlang.com/schemas/session-bundle.v1.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": true,
+  "properties": {
+    "_type": {
+      "const": "harn_session_bundle"
+    },
+    "attachments": {
+      "items": {
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "bundle_id": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "created_at": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "permissions": {
+      "items": {
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "producer": {
+      "additionalProperties": true,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "schema_id": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "version",
+        "schema_id"
+      ],
+      "type": "object"
+    },
+    "redaction": {
+      "additionalProperties": true,
+      "properties": {
+        "entries": {
+          "items": {
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "mode": {
+          "enum": [
+            "local",
+            "sanitized",
+            "replay_only"
+          ]
+        },
+        "placeholder": {
+          "type": "string"
+        },
+        "policy": {
+          "type": "string"
+        },
+        "unsafe_secret_markers_rejected": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "mode",
+        "policy",
+        "placeholder",
+        "entries",
+        "unsafe_secret_markers_rejected"
+      ],
+      "type": "object"
+    },
+    "replay": {
+      "additionalProperties": true,
+      "properties": {
+        "checkpoints": {
+          "items": {
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "deterministic_events": {
+          "items": {
+            "$ref": "#/$defs/json_entry"
+          },
+          "type": "array"
+        },
+        "event_log_pointers": {
+          "items": {
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "replay_fixture": {
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "run_record": {
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "trace_spans": {
+          "items": {
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "transitions": {
+          "items": {
+            "type": "object"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "event_log_pointers",
+        "transitions",
+        "checkpoints",
+        "trace_spans",
+        "deterministic_events"
+      ],
+      "type": "object"
+    },
+    "runtime": {
+      "additionalProperties": true,
+      "properties": {
+        "harn_version": {
+          "type": "string"
+        },
+        "metadata": {
+          "type": "object"
+        },
+        "provider_models": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "usage": {
+          "type": [
+            "object",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "harn_version",
+        "provider_models"
+      ],
+      "type": "object"
+    },
+    "schema_version": {
+      "maximum": 1,
+      "minimum": 1,
+      "type": "integer"
+    },
+    "source": {
+      "additionalProperties": true,
+      "properties": {
+        "child_run_count": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "finished_at": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "kind": {
+          "type": "string"
+        },
+        "parent_run_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "persisted_path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "root_run_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "run_record_id": {
+          "type": "string"
+        },
+        "started_at": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        },
+        "task": {
+          "type": "string"
+        },
+        "workflow_id": {
+          "type": "string"
+        },
+        "workflow_name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "kind",
+        "run_record_id",
+        "workflow_id",
+        "task",
+        "status"
+      ],
+      "type": "object"
+    },
+    "tools": {
+      "additionalProperties": true,
+      "properties": {
+        "calls": {
+          "items": {
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "schemas": {
+          "items": {
+            "$ref": "#/$defs/json_entry"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "schemas",
+        "calls"
+      ],
+      "type": "object"
+    },
+    "transcript": {
+      "additionalProperties": true,
+      "properties": {
+        "sections": {
+          "items": {
+            "$ref": "#/$defs/transcript_section"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "sections"
+      ],
+      "type": "object"
+    },
+    "workspace": {
+      "type": [
+        "object",
+        "null"
+      ]
+    }
+  },
+  "required": [
+    "_type",
+    "schema_version",
+    "bundle_id",
+    "created_at",
+    "producer",
+    "source",
+    "runtime",
+    "transcript",
+    "tools",
+    "permissions",
+    "replay",
+    "redaction",
+    "attachments"
+  ],
+  "title": "Harn Session Bundle v1",
+  "type": "object"
+}

--- a/spec/session-bundles/fixtures/sample-local.bundle.json
+++ b/spec/session-bundles/fixtures/sample-local.bundle.json
@@ -1,0 +1,616 @@
+{
+  "_type": "harn_session_bundle",
+  "schema_version": 1,
+  "bundle_id": "bundle_019e21e9-d44d-75e0-b482-a73a9048a73f",
+  "created_at": "1778685432",
+  "producer": {
+    "name": "harn",
+    "version": "0.8.12",
+    "schema_id": "https://harnlang.com/schemas/session-bundle.v1.json"
+  },
+  "source": {
+    "kind": "run_record",
+    "run_record_id": "run_fixture_session_bundle",
+    "workflow_id": "wf_fixture_session_bundle",
+    "workflow_name": "Session bundle fixture",
+    "task": "Summarize a deploy investigation and preserve replay evidence.",
+    "status": "completed",
+    "started_at": "2026-05-01T00:00:00Z",
+    "finished_at": "2026-05-01T00:00:30Z",
+    "persisted_path": "spec/session-bundles/fixtures/sample-run-record.json",
+    "root_run_id": null,
+    "parent_run_id": null,
+    "child_run_count": 0
+  },
+  "runtime": {
+    "harn_version": "0.8.12",
+    "provider_models": [
+      "mock/deploy-investigator"
+    ],
+    "usage": {
+      "input_tokens": 42,
+      "output_tokens": 17,
+      "call_count": 1,
+      "total_duration_ms": 1200,
+      "total_cost": 0.002,
+      "models": [
+        "mock/deploy-investigator"
+      ]
+    },
+    "metadata": {}
+  },
+  "workspace": {
+    "identity": "workspace_fixture",
+    "source_root": "/workspace/example",
+    "policy": "safe_identity_only"
+  },
+  "transcript": {
+    "sections": [
+      {
+        "id": "run",
+        "label": "Run transcript",
+        "scope": "run",
+        "location": "$.transcript",
+        "summary": "Canary health check used stale config.",
+        "messages": [
+          {
+            "content": "Why did the canary deploy fail?",
+            "role": "user"
+          },
+          {
+            "content": "The canary health check used stale config.",
+            "role": "assistant"
+          }
+        ],
+        "events": [
+          {
+            "schemas": [
+              {
+                "name": "read_file"
+              }
+            ],
+            "type": "tool_schemas"
+          },
+          {
+            "agent": "deploy-investigator",
+            "arguments": {
+              "api_key": "fixture-local-key"
+            },
+            "kind": "permission_requested",
+            "request_id": "perm_fixture_1"
+          }
+        ],
+        "assets": [],
+        "metadata": {
+          "system_prompt": "Use local logs and explain the deployment failure."
+        }
+      },
+      {
+        "id": "stage_fixture_answer",
+        "label": "Stage answer",
+        "scope": "stage",
+        "location": "$.stages[0].transcript",
+        "summary": null,
+        "messages": [
+          {
+            "content": "The deploy failed because the canary health check used stale config.",
+            "role": "assistant"
+          }
+        ],
+        "events": [],
+        "assets": [],
+        "metadata": {
+          "tool_schemas": [
+            {
+              "input_schema": {
+                "properties": {
+                  "path": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "name": "read_file"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "tools": {
+    "schemas": [
+      {
+        "source": "run.transcript",
+        "index": 0,
+        "value": {
+          "schemas": [
+            {
+              "name": "read_file"
+            }
+          ],
+          "type": "tool_schemas"
+        }
+      }
+    ],
+    "calls": [
+      {
+        "tool_name": "read_file",
+        "tool_use_id": "tool_fixture_1",
+        "args_hash": "fixture_args_hash",
+        "result": "Read deploy.log: stale config detected.",
+        "is_rejected": false,
+        "duration_ms": 8,
+        "iteration": 1,
+        "timestamp": "2026-05-01T00:00:10Z"
+      }
+    ]
+  },
+  "permissions": [
+    {
+      "kind": "hitl_question",
+      "source": "run.hitl_questions",
+      "request_id": "hitl_fixture_1",
+      "agent": "deploy-investigator",
+      "payload": {
+        "agent": "deploy-investigator",
+        "asked_at": "2026-05-01T00:00:05Z",
+        "prompt": "Approve reading deploy.log?",
+        "request_id": "hitl_fixture_1",
+        "trace_id": null
+      }
+    },
+    {
+      "kind": "permission_requested",
+      "source": "run.transcript",
+      "request_id": "perm_fixture_1",
+      "agent": "deploy-investigator",
+      "payload": {
+        "agent": "deploy-investigator",
+        "arguments": {
+          "api_key": "fixture-local-key"
+        },
+        "kind": "permission_requested",
+        "request_id": "perm_fixture_1"
+      }
+    }
+  ],
+  "replay": {
+    "replay_fixture": {
+      "_type": "replay_fixture",
+      "id": "replay_fixture_session_bundle",
+      "source_run_id": "run_fixture_session_bundle",
+      "workflow_id": "wf_fixture_session_bundle",
+      "workflow_name": "Session bundle fixture",
+      "created_at": "2026-05-01T00:00:31Z",
+      "eval_kind": null,
+      "clarifying_question": null,
+      "expected_status": "completed",
+      "stage_assertions": [
+        {
+          "node_id": "answer",
+          "expected_status": "completed",
+          "expected_outcome": "ok",
+          "expected_branch": null,
+          "required_artifact_kinds": [
+            "summary"
+          ],
+          "visible_text_contains": "stale config"
+        }
+      ]
+    },
+    "run_record": {
+      "_type": "run_record",
+      "artifacts": [
+        {
+          "_type": "",
+          "created_at": "",
+          "data": null,
+          "estimated_tokens": null,
+          "freshness": null,
+          "id": "artifact_fixture_summary",
+          "kind": "summary",
+          "lineage": [],
+          "metadata": {
+            "classification": "shareable"
+          },
+          "priority": null,
+          "relevance": null,
+          "source": null,
+          "stage": "stage_fixture_answer",
+          "text": "Canary health checks used stale config.",
+          "title": "Deploy investigation summary"
+        }
+      ],
+      "checkpoints": [
+        {
+          "completed_nodes": [
+            "answer"
+          ],
+          "id": "checkpoint_fixture_done",
+          "last_stage_id": "stage_fixture_answer",
+          "persisted_at": "2026-05-01T00:00:30Z",
+          "ready_nodes": [],
+          "reason": "completed"
+        }
+      ],
+      "child_runs": [],
+      "completed_nodes": [
+        "answer"
+      ],
+      "execution": null,
+      "finished_at": "2026-05-01T00:00:30Z",
+      "handoffs": [],
+      "hitl_questions": [
+        {
+          "agent": "deploy-investigator",
+          "asked_at": "2026-05-01T00:00:05Z",
+          "prompt": "Approve reading deploy.log?",
+          "request_id": "hitl_fixture_1",
+          "trace_id": null
+        }
+      ],
+      "id": "run_fixture_session_bundle",
+      "metadata": {
+        "project_root": "/workspace/example",
+        "workspace_id": "workspace_fixture"
+      },
+      "observability": {
+        "action_graph_edges": [
+          {
+            "from_id": "run:run_fixture_session_bundle",
+            "kind": "transition",
+            "label": null,
+            "to_id": "stage:stage_fixture_answer"
+          }
+        ],
+        "action_graph_nodes": [
+          {
+            "id": "run:run_fixture_session_bundle",
+            "kind": "run",
+            "label": "Session bundle fixture",
+            "metadata": {
+              "workflow_id": "wf_fixture_session_bundle"
+            },
+            "node_id": null,
+            "outcome": "completed",
+            "run_id": "run_fixture_session_bundle",
+            "run_path": "spec/session-bundles/fixtures/sample-run-record.json",
+            "stage_id": null,
+            "status": "completed",
+            "trace_id": null,
+            "worker_id": null
+          },
+          {
+            "id": "stage:stage_fixture_answer",
+            "kind": "stage",
+            "label": "answer",
+            "metadata": {
+              "stage_kind": "agent"
+            },
+            "node_id": "answer",
+            "outcome": "ok",
+            "run_id": null,
+            "run_path": null,
+            "stage_id": "stage_fixture_answer",
+            "status": "completed",
+            "trace_id": null,
+            "worker_id": null
+          }
+        ],
+        "compaction_events": [],
+        "daemon_events": [],
+        "planner_rounds": [],
+        "research_fact_count": 0,
+        "schema_version": 4,
+        "transcript_pointers": [
+          {
+            "available": true,
+            "id": "stage:stage_fixture_answer:transcript",
+            "kind": "embedded_transcript",
+            "label": "Stage answer transcript",
+            "location": "run.stages[answer].transcript",
+            "path": "spec/session-bundles/fixtures/sample-run-record.json"
+          },
+          {
+            "available": true,
+            "id": "run:transcript",
+            "kind": "embedded_transcript",
+            "label": "Run transcript",
+            "location": "run.transcript",
+            "path": "spec/session-bundles/fixtures/sample-run-record.json"
+          },
+          {
+            "available": false,
+            "id": "run:llm_transcript",
+            "kind": "llm_jsonl",
+            "label": "LLM transcript sidecar",
+            "location": "run sidecar",
+            "path": "spec/session-bundles/fixtures/sample-run-record-llm/llm_transcript.jsonl"
+          }
+        ],
+        "verification_outcomes": [],
+        "worker_lineage": []
+      },
+      "parent_run_id": null,
+      "pending_nodes": [],
+      "persisted_path": "spec/session-bundles/fixtures/sample-run-record.json",
+      "persona_runtime": [],
+      "policy": {
+        "capabilities": {},
+        "recursion_limit": null,
+        "side_effect_level": null,
+        "tool_annotations": {},
+        "tool_arg_constraints": [],
+        "tools": [],
+        "workspace_roots": []
+      },
+      "replay_fixture": {
+        "_type": "replay_fixture",
+        "clarifying_question": null,
+        "created_at": "2026-05-01T00:00:31Z",
+        "eval_kind": null,
+        "expected_status": "completed",
+        "id": "replay_fixture_session_bundle",
+        "source_run_id": "run_fixture_session_bundle",
+        "stage_assertions": [
+          {
+            "expected_branch": null,
+            "expected_outcome": "ok",
+            "expected_status": "completed",
+            "node_id": "answer",
+            "required_artifact_kinds": [
+              "summary"
+            ],
+            "visible_text_contains": "stale config"
+          }
+        ],
+        "workflow_id": "wf_fixture_session_bundle",
+        "workflow_name": "Session bundle fixture"
+      },
+      "root_run_id": null,
+      "stages": [
+        {
+          "artifacts": [],
+          "attempts": [],
+          "branch": null,
+          "consumed_artifact_ids": [],
+          "finished_at": "2026-05-01T00:00:20Z",
+          "id": "stage_fixture_answer",
+          "kind": "agent",
+          "metadata": {},
+          "node_id": "answer",
+          "outcome": "ok",
+          "private_reasoning": "The local-only notes should not appear in replay-only shares.",
+          "produced_artifact_ids": [],
+          "started_at": "2026-05-01T00:00:01Z",
+          "status": "completed",
+          "transcript": {
+            "assets": [],
+            "events": [],
+            "messages": [
+              {
+                "content": "The deploy failed because the canary health check used stale config.",
+                "role": "assistant"
+              }
+            ],
+            "metadata": {
+              "tool_schemas": [
+                {
+                  "input_schema": {
+                    "properties": {
+                      "path": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "name": "read_file"
+                }
+              ]
+            }
+          },
+          "usage": null,
+          "verification": null,
+          "visible_text": "The deploy failed because the canary health check used stale config."
+        }
+      ],
+      "started_at": "2026-05-01T00:00:00Z",
+      "status": "completed",
+      "task": "Summarize a deploy investigation and preserve replay evidence.",
+      "tool_recordings": [
+        {
+          "args_hash": "fixture_args_hash",
+          "duration_ms": 8,
+          "is_rejected": false,
+          "iteration": 1,
+          "result": "Read deploy.log: stale config detected.",
+          "timestamp": "2026-05-01T00:00:10Z",
+          "tool_name": "read_file",
+          "tool_use_id": "tool_fixture_1"
+        }
+      ],
+      "trace_spans": [
+        {
+          "duration_ms": 1200,
+          "kind": "stage",
+          "metadata": {},
+          "name": "answer",
+          "parent_id": null,
+          "span_id": 1,
+          "start_ms": 0
+        }
+      ],
+      "transcript": {
+        "_type": "transcript",
+        "assets": [],
+        "events": [
+          {
+            "schemas": [
+              {
+                "name": "read_file"
+              }
+            ],
+            "type": "tool_schemas"
+          },
+          {
+            "agent": "deploy-investigator",
+            "arguments": {
+              "api_key": "fixture-local-key"
+            },
+            "kind": "permission_requested",
+            "request_id": "perm_fixture_1"
+          }
+        ],
+        "messages": [
+          {
+            "content": "Why did the canary deploy fail?",
+            "role": "user"
+          },
+          {
+            "content": "The canary health check used stale config.",
+            "role": "assistant"
+          }
+        ],
+        "metadata": {
+          "system_prompt": "Use local logs and explain the deployment failure."
+        },
+        "summary": "Canary health check used stale config."
+      },
+      "transitions": [
+        {
+          "branch": null,
+          "consumed_artifact_ids": [],
+          "from_node_id": null,
+          "from_stage_id": null,
+          "id": "transition_fixture_start",
+          "produced_artifact_ids": [],
+          "timestamp": "2026-05-01T00:00:01Z",
+          "to_node_id": "answer"
+        }
+      ],
+      "usage": {
+        "call_count": 1,
+        "input_tokens": 42,
+        "models": [
+          "mock/deploy-investigator"
+        ],
+        "output_tokens": 17,
+        "total_cost": 0.002,
+        "total_duration_ms": 1200
+      },
+      "workflow_id": "wf_fixture_session_bundle",
+      "workflow_name": "Session bundle fixture"
+    },
+    "event_log_pointers": [
+      {
+        "kind": "embedded_transcript",
+        "topic": null,
+        "path": "spec/session-bundles/fixtures/sample-run-record.json",
+        "location": "run.stages[answer].transcript",
+        "available": true
+      },
+      {
+        "kind": "embedded_transcript",
+        "topic": null,
+        "path": "spec/session-bundles/fixtures/sample-run-record.json",
+        "location": "run.transcript",
+        "available": true
+      },
+      {
+        "kind": "llm_jsonl",
+        "topic": null,
+        "path": "spec/session-bundles/fixtures/sample-run-record-llm/llm_transcript.jsonl",
+        "location": "run sidecar",
+        "available": false
+      }
+    ],
+    "transitions": [
+      {
+        "id": "transition_fixture_start",
+        "from_stage_id": null,
+        "from_node_id": null,
+        "to_node_id": "answer",
+        "branch": null,
+        "timestamp": "2026-05-01T00:00:01Z",
+        "consumed_artifact_ids": [],
+        "produced_artifact_ids": []
+      }
+    ],
+    "checkpoints": [
+      {
+        "id": "checkpoint_fixture_done",
+        "ready_nodes": [],
+        "completed_nodes": [
+          "answer"
+        ],
+        "last_stage_id": "stage_fixture_answer",
+        "persisted_at": "2026-05-01T00:00:30Z",
+        "reason": "completed"
+      }
+    ],
+    "trace_spans": [
+      {
+        "span_id": 1,
+        "parent_id": null,
+        "kind": "stage",
+        "name": "answer",
+        "start_ms": 0,
+        "duration_ms": 1200,
+        "metadata": {}
+      }
+    ],
+    "deterministic_events": [
+      {
+        "source": "run.transitions",
+        "index": 0,
+        "value": {
+          "branch": null,
+          "consumed_artifact_ids": [],
+          "from_node_id": null,
+          "from_stage_id": null,
+          "id": "transition_fixture_start",
+          "produced_artifact_ids": [],
+          "timestamp": "2026-05-01T00:00:01Z",
+          "to_node_id": "answer"
+        }
+      },
+      {
+        "source": "run.checkpoints",
+        "index": 0,
+        "value": {
+          "completed_nodes": [
+            "answer"
+          ],
+          "id": "checkpoint_fixture_done",
+          "last_stage_id": "stage_fixture_answer",
+          "persisted_at": "2026-05-01T00:00:30Z",
+          "ready_nodes": [],
+          "reason": "completed"
+        }
+      }
+    ]
+  },
+  "redaction": {
+    "mode": "local",
+    "policy": "none",
+    "placeholder": "[redacted]",
+    "entries": [],
+    "unsafe_secret_markers_rejected": false
+  },
+  "attachments": [
+    {
+      "id": "artifact_fixture_summary",
+      "kind": "summary",
+      "title": "Deploy investigation summary",
+      "stage": "stage_fixture_answer",
+      "text": "Canary health checks used stale config.",
+      "data": null,
+      "metadata": {
+        "classification": "shareable"
+      }
+    }
+  ],
+  "metadata": {
+    "format_note": "Session bundles are portable JSON envelopes; hosted share links should reference sanitized bundles rather than raw run records."
+  }
+}

--- a/spec/session-bundles/fixtures/sample-replay-only.bundle.json
+++ b/spec/session-bundles/fixtures/sample-replay-only.bundle.json
@@ -1,0 +1,821 @@
+{
+  "_type": "harn_session_bundle",
+  "schema_version": 1,
+  "bundle_id": "bundle_019e21f3-2b71-7c51-91c5-abd31902541f",
+  "created_at": "1778686045",
+  "producer": {
+    "name": "harn",
+    "version": "0.8.12",
+    "schema_id": "https://harnlang.com/schemas/session-bundle.v1.json"
+  },
+  "source": {
+    "kind": "run_record",
+    "run_record_id": "run_fixture_session_bundle",
+    "workflow_id": "wf_fixture_session_bundle",
+    "workflow_name": "Session bundle fixture",
+    "task": "[withheld]",
+    "status": "completed",
+    "started_at": "2026-05-01T00:00:00Z",
+    "finished_at": "2026-05-01T00:00:30Z",
+    "persisted_path": "[redacted]",
+    "root_run_id": null,
+    "parent_run_id": null,
+    "child_run_count": 0
+  },
+  "runtime": {
+    "harn_version": "0.8.12",
+    "provider_models": [
+      "mock/deploy-investigator"
+    ],
+    "usage": {
+      "input_tokens": 42,
+      "output_tokens": 17,
+      "call_count": 1,
+      "total_duration_ms": 1200,
+      "total_cost": 0.002,
+      "models": [
+        "mock/deploy-investigator"
+      ]
+    },
+    "metadata": {}
+  },
+  "workspace": {
+    "identity": "workspace_fixture",
+    "source_root": "[redacted]",
+    "policy": "safe_identity_only"
+  },
+  "transcript": {
+    "sections": [
+      {
+        "id": "run",
+        "label": "Run transcript",
+        "scope": "run",
+        "location": "$.transcript",
+        "summary": "[withheld]",
+        "messages": [
+          {
+            "content": "[withheld]",
+            "role": "user"
+          },
+          {
+            "content": "[withheld]",
+            "role": "assistant"
+          }
+        ],
+        "events": [
+          {
+            "schemas": [
+              {
+                "name": "read_file"
+              }
+            ],
+            "type": "tool_schemas"
+          },
+          {
+            "agent": "deploy-investigator",
+            "arguments": "[withheld]",
+            "kind": "permission_requested",
+            "request_id": "perm_fixture_1"
+          }
+        ],
+        "assets": [],
+        "metadata": {
+          "system_prompt": "[withheld]"
+        }
+      },
+      {
+        "id": "stage_fixture_answer",
+        "label": "Stage answer",
+        "scope": "stage",
+        "location": "$.stages[0].transcript",
+        "summary": null,
+        "messages": [
+          {
+            "content": "[withheld]",
+            "role": "assistant"
+          }
+        ],
+        "events": [],
+        "assets": [],
+        "metadata": {
+          "tool_schemas": [
+            {
+              "input_schema": {
+                "properties": {
+                  "path": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "name": "read_file"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "tools": {
+    "schemas": [
+      {
+        "source": "run.transcript",
+        "index": 0,
+        "value": {
+          "schemas": [
+            {
+              "name": "read_file"
+            }
+          ],
+          "type": "tool_schemas"
+        }
+      }
+    ],
+    "calls": [
+      {
+        "tool_name": "read_file",
+        "tool_use_id": "tool_fixture_1",
+        "args_hash": "fixture_args_hash",
+        "result": "[withheld]",
+        "is_rejected": false,
+        "duration_ms": 8,
+        "iteration": 1,
+        "timestamp": "2026-05-01T00:00:10Z"
+      }
+    ]
+  },
+  "permissions": [
+    {
+      "kind": "hitl_question",
+      "source": "run.hitl_questions",
+      "request_id": "hitl_fixture_1",
+      "agent": "deploy-investigator",
+      "payload": {
+        "agent": "deploy-investigator",
+        "asked_at": "2026-05-01T00:00:05Z",
+        "prompt": "[withheld]",
+        "request_id": "hitl_fixture_1",
+        "trace_id": null
+      }
+    },
+    {
+      "kind": "permission_requested",
+      "source": "run.transcript",
+      "request_id": "perm_fixture_1",
+      "agent": "deploy-investigator",
+      "payload": {
+        "agent": "deploy-investigator",
+        "arguments": "[withheld]",
+        "kind": "permission_requested",
+        "request_id": "perm_fixture_1"
+      }
+    }
+  ],
+  "replay": {
+    "replay_fixture": {
+      "_type": "replay_fixture",
+      "id": "replay_fixture_session_bundle",
+      "source_run_id": "run_fixture_session_bundle",
+      "workflow_id": "wf_fixture_session_bundle",
+      "workflow_name": "Session bundle fixture",
+      "created_at": "2026-05-01T00:00:31Z",
+      "eval_kind": null,
+      "clarifying_question": null,
+      "expected_status": "completed",
+      "stage_assertions": [
+        {
+          "node_id": "answer",
+          "expected_status": "completed",
+          "expected_outcome": "ok",
+          "expected_branch": null,
+          "required_artifact_kinds": [
+            "summary"
+          ],
+          "visible_text_contains": "stale config"
+        }
+      ]
+    },
+    "run_record": {
+      "_type": "run_record",
+      "artifacts": [
+        {
+          "_type": "",
+          "created_at": "",
+          "data": null,
+          "estimated_tokens": null,
+          "freshness": null,
+          "id": "artifact_fixture_summary",
+          "kind": "summary",
+          "lineage": [],
+          "metadata": {
+            "classification": "shareable"
+          },
+          "priority": null,
+          "relevance": null,
+          "source": null,
+          "stage": "stage_fixture_answer",
+          "text": "[withheld]",
+          "title": "Deploy investigation summary"
+        }
+      ],
+      "checkpoints": [
+        {
+          "completed_nodes": [
+            "answer"
+          ],
+          "id": "checkpoint_fixture_done",
+          "last_stage_id": "stage_fixture_answer",
+          "persisted_at": "2026-05-01T00:00:30Z",
+          "ready_nodes": [],
+          "reason": "completed"
+        }
+      ],
+      "child_runs": [],
+      "completed_nodes": [
+        "answer"
+      ],
+      "execution": null,
+      "finished_at": "2026-05-01T00:00:30Z",
+      "handoffs": [],
+      "hitl_questions": [
+        {
+          "agent": "deploy-investigator",
+          "asked_at": "2026-05-01T00:00:05Z",
+          "prompt": "[withheld]",
+          "request_id": "hitl_fixture_1",
+          "trace_id": null
+        }
+      ],
+      "id": "run_fixture_session_bundle",
+      "metadata": {
+        "project_root": "[redacted]",
+        "workspace_id": "workspace_fixture"
+      },
+      "observability": {
+        "action_graph_edges": [
+          {
+            "from_id": "run:run_fixture_session_bundle",
+            "kind": "transition",
+            "label": null,
+            "to_id": "stage:stage_fixture_answer"
+          }
+        ],
+        "action_graph_nodes": [
+          {
+            "id": "run:run_fixture_session_bundle",
+            "kind": "run",
+            "label": "Session bundle fixture",
+            "metadata": {
+              "workflow_id": "wf_fixture_session_bundle"
+            },
+            "node_id": null,
+            "outcome": "completed",
+            "run_id": "run_fixture_session_bundle",
+            "run_path": "[redacted]",
+            "stage_id": null,
+            "status": "completed",
+            "trace_id": null,
+            "worker_id": null
+          },
+          {
+            "id": "stage:stage_fixture_answer",
+            "kind": "stage",
+            "label": "answer",
+            "metadata": {
+              "stage_kind": "agent"
+            },
+            "node_id": "answer",
+            "outcome": "ok",
+            "run_id": null,
+            "run_path": "[redacted]",
+            "stage_id": "stage_fixture_answer",
+            "status": "completed",
+            "trace_id": null,
+            "worker_id": null
+          }
+        ],
+        "compaction_events": [],
+        "daemon_events": [],
+        "planner_rounds": [],
+        "research_fact_count": 0,
+        "schema_version": 4,
+        "transcript_pointers": [
+          {
+            "available": true,
+            "id": "stage:stage_fixture_answer:transcript",
+            "kind": "embedded_transcript",
+            "label": "Stage answer transcript",
+            "location": "run.stages[answer].transcript",
+            "path": "[redacted]"
+          },
+          {
+            "available": true,
+            "id": "run:transcript",
+            "kind": "embedded_transcript",
+            "label": "Run transcript",
+            "location": "run.transcript",
+            "path": "[redacted]"
+          },
+          {
+            "available": false,
+            "id": "run:llm_transcript",
+            "kind": "llm_jsonl",
+            "label": "LLM transcript sidecar",
+            "location": "run sidecar",
+            "path": "[redacted]"
+          }
+        ],
+        "verification_outcomes": [],
+        "worker_lineage": []
+      },
+      "parent_run_id": null,
+      "pending_nodes": [],
+      "persisted_path": "[redacted]",
+      "persona_runtime": [],
+      "policy": {
+        "capabilities": {},
+        "recursion_limit": null,
+        "side_effect_level": null,
+        "tool_annotations": {},
+        "tool_arg_constraints": [],
+        "tools": [],
+        "workspace_roots": []
+      },
+      "replay_fixture": {
+        "_type": "replay_fixture",
+        "clarifying_question": null,
+        "created_at": "2026-05-01T00:00:31Z",
+        "eval_kind": null,
+        "expected_status": "completed",
+        "id": "replay_fixture_session_bundle",
+        "source_run_id": "run_fixture_session_bundle",
+        "stage_assertions": [
+          {
+            "expected_branch": null,
+            "expected_outcome": "ok",
+            "expected_status": "completed",
+            "node_id": "answer",
+            "required_artifact_kinds": [
+              "summary"
+            ],
+            "visible_text_contains": "stale config"
+          }
+        ],
+        "workflow_id": "wf_fixture_session_bundle",
+        "workflow_name": "Session bundle fixture"
+      },
+      "root_run_id": null,
+      "stages": [
+        {
+          "artifacts": [],
+          "attempts": [],
+          "branch": null,
+          "consumed_artifact_ids": [],
+          "finished_at": "2026-05-01T00:00:20Z",
+          "id": "stage_fixture_answer",
+          "kind": "agent",
+          "metadata": {},
+          "node_id": "answer",
+          "outcome": "ok",
+          "private_reasoning": "[withheld]",
+          "produced_artifact_ids": [],
+          "started_at": "2026-05-01T00:00:01Z",
+          "status": "completed",
+          "transcript": {
+            "assets": [],
+            "events": [],
+            "messages": [
+              {
+                "content": "[withheld]",
+                "role": "assistant"
+              }
+            ],
+            "metadata": {
+              "tool_schemas": [
+                {
+                  "input_schema": {
+                    "properties": {
+                      "path": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "name": "read_file"
+                }
+              ]
+            }
+          },
+          "usage": null,
+          "verification": null,
+          "visible_text": "[withheld]"
+        }
+      ],
+      "started_at": "2026-05-01T00:00:00Z",
+      "status": "completed",
+      "task": "[withheld]",
+      "tool_recordings": [
+        {
+          "args_hash": "fixture_args_hash",
+          "duration_ms": 8,
+          "is_rejected": false,
+          "iteration": 1,
+          "result": "[withheld]",
+          "timestamp": "2026-05-01T00:00:10Z",
+          "tool_name": "read_file",
+          "tool_use_id": "tool_fixture_1"
+        }
+      ],
+      "trace_spans": [
+        {
+          "duration_ms": 1200,
+          "kind": "stage",
+          "metadata": {},
+          "name": "answer",
+          "parent_id": null,
+          "span_id": 1,
+          "start_ms": 0
+        }
+      ],
+      "transcript": {
+        "_type": "transcript",
+        "assets": [],
+        "events": [
+          {
+            "schemas": [
+              {
+                "name": "read_file"
+              }
+            ],
+            "type": "tool_schemas"
+          },
+          {
+            "agent": "deploy-investigator",
+            "arguments": "[withheld]",
+            "kind": "permission_requested",
+            "request_id": "perm_fixture_1"
+          }
+        ],
+        "messages": [
+          {
+            "content": "[withheld]",
+            "role": "user"
+          },
+          {
+            "content": "[withheld]",
+            "role": "assistant"
+          }
+        ],
+        "metadata": {
+          "system_prompt": "[withheld]"
+        },
+        "summary": "[withheld]"
+      },
+      "transitions": [
+        {
+          "branch": null,
+          "consumed_artifact_ids": [],
+          "from_node_id": null,
+          "from_stage_id": null,
+          "id": "transition_fixture_start",
+          "produced_artifact_ids": [],
+          "timestamp": "2026-05-01T00:00:01Z",
+          "to_node_id": "answer"
+        }
+      ],
+      "usage": {
+        "call_count": 1,
+        "input_tokens": 42,
+        "models": [
+          "mock/deploy-investigator"
+        ],
+        "output_tokens": 17,
+        "total_cost": 0.002,
+        "total_duration_ms": 1200
+      },
+      "workflow_id": "wf_fixture_session_bundle",
+      "workflow_name": "Session bundle fixture"
+    },
+    "event_log_pointers": [
+      {
+        "kind": "embedded_transcript",
+        "topic": null,
+        "path": "[redacted]",
+        "location": "run.stages[answer].transcript",
+        "available": true
+      },
+      {
+        "kind": "embedded_transcript",
+        "topic": null,
+        "path": "[redacted]",
+        "location": "run.transcript",
+        "available": true
+      },
+      {
+        "kind": "llm_jsonl",
+        "topic": null,
+        "path": "[redacted]",
+        "location": "run sidecar",
+        "available": false
+      }
+    ],
+    "transitions": [
+      {
+        "id": "transition_fixture_start",
+        "from_stage_id": null,
+        "from_node_id": null,
+        "to_node_id": "answer",
+        "branch": null,
+        "timestamp": "2026-05-01T00:00:01Z",
+        "consumed_artifact_ids": [],
+        "produced_artifact_ids": []
+      }
+    ],
+    "checkpoints": [
+      {
+        "id": "checkpoint_fixture_done",
+        "ready_nodes": [],
+        "completed_nodes": [
+          "answer"
+        ],
+        "last_stage_id": "stage_fixture_answer",
+        "persisted_at": "2026-05-01T00:00:30Z",
+        "reason": "completed"
+      }
+    ],
+    "trace_spans": [
+      {
+        "span_id": 1,
+        "parent_id": null,
+        "kind": "stage",
+        "name": "answer",
+        "start_ms": 0,
+        "duration_ms": 1200,
+        "metadata": {}
+      }
+    ],
+    "deterministic_events": [
+      {
+        "source": "run.transitions",
+        "index": 0,
+        "value": {
+          "branch": null,
+          "consumed_artifact_ids": [],
+          "from_node_id": null,
+          "from_stage_id": null,
+          "id": "transition_fixture_start",
+          "produced_artifact_ids": [],
+          "timestamp": "2026-05-01T00:00:01Z",
+          "to_node_id": "answer"
+        }
+      },
+      {
+        "source": "run.checkpoints",
+        "index": 0,
+        "value": {
+          "completed_nodes": [
+            "answer"
+          ],
+          "id": "checkpoint_fixture_done",
+          "last_stage_id": "stage_fixture_answer",
+          "persisted_at": "2026-05-01T00:00:30Z",
+          "ready_nodes": [],
+          "reason": "completed"
+        }
+      }
+    ]
+  },
+  "redaction": {
+    "mode": "replay_only",
+    "policy": "harn_vm::redact::RedactionPolicy::default+session_bundle_local_paths",
+    "placeholder": "[redacted]",
+    "entries": [
+      {
+        "path": "$.permissions[1].payload.arguments.api_key",
+        "class": "sensitive_field",
+        "action": "replaced",
+        "replacement": "[redacted]"
+      },
+      {
+        "path": "$.replay.run_record.metadata.project_root",
+        "class": "sensitive_field",
+        "action": "replaced",
+        "replacement": "[redacted]"
+      },
+      {
+        "path": "$.replay.run_record.observability.action_graph_nodes[0].run_path",
+        "class": "sensitive_field",
+        "action": "replaced",
+        "replacement": "[redacted]"
+      },
+      {
+        "path": "$.replay.run_record.observability.action_graph_nodes[1].run_path",
+        "class": "sensitive_field",
+        "action": "replaced",
+        "replacement": "[redacted]"
+      },
+      {
+        "path": "$.replay.run_record.persisted_path",
+        "class": "sensitive_field",
+        "action": "replaced",
+        "replacement": "[redacted]"
+      },
+      {
+        "path": "$.replay.run_record.transcript.events[1].arguments.api_key",
+        "class": "sensitive_field",
+        "action": "replaced",
+        "replacement": "[redacted]"
+      },
+      {
+        "path": "$.source.persisted_path",
+        "class": "sensitive_field",
+        "action": "replaced",
+        "replacement": "[redacted]"
+      },
+      {
+        "path": "$.transcript.sections[0].events[1].arguments.api_key",
+        "class": "sensitive_field",
+        "action": "replaced",
+        "replacement": "[redacted]"
+      },
+      {
+        "path": "$.workspace.source_root",
+        "class": "sensitive_field",
+        "action": "replaced",
+        "replacement": "[redacted]"
+      },
+      {
+        "path": "$.replay.event_log_pointers[0].path",
+        "class": "local_pointer_path",
+        "action": "replaced",
+        "replacement": "[redacted]"
+      },
+      {
+        "path": "$.replay.event_log_pointers[1].path",
+        "class": "local_pointer_path",
+        "action": "replaced",
+        "replacement": "[redacted]"
+      },
+      {
+        "path": "$.replay.event_log_pointers[2].path",
+        "class": "local_pointer_path",
+        "action": "replaced",
+        "replacement": "[redacted]"
+      },
+      {
+        "path": "$.replay.run_record.observability.transcript_pointers[0].path",
+        "class": "local_pointer_path",
+        "action": "replaced",
+        "replacement": "[redacted]"
+      },
+      {
+        "path": "$.replay.run_record.observability.transcript_pointers[1].path",
+        "class": "local_pointer_path",
+        "action": "replaced",
+        "replacement": "[redacted]"
+      },
+      {
+        "path": "$.replay.run_record.observability.transcript_pointers[2].path",
+        "class": "local_pointer_path",
+        "action": "replaced",
+        "replacement": "[redacted]"
+      },
+      {
+        "path": "$.permissions[0].payload.prompt",
+        "class": "prompt_or_tool_payload",
+        "action": "withheld",
+        "replacement": "[withheld]"
+      },
+      {
+        "path": "$.permissions[1].payload.arguments",
+        "class": "prompt_or_tool_payload",
+        "action": "withheld",
+        "replacement": "[withheld]"
+      },
+      {
+        "path": "$.replay.run_record.artifacts[0].text",
+        "class": "prompt_or_tool_payload",
+        "action": "withheld",
+        "replacement": "[withheld]"
+      },
+      {
+        "path": "$.replay.run_record.hitl_questions[0].prompt",
+        "class": "prompt_or_tool_payload",
+        "action": "withheld",
+        "replacement": "[withheld]"
+      },
+      {
+        "path": "$.replay.run_record.stages[0].private_reasoning",
+        "class": "prompt_or_tool_payload",
+        "action": "withheld",
+        "replacement": "[withheld]"
+      },
+      {
+        "path": "$.replay.run_record.stages[0].transcript.messages[0].content",
+        "class": "prompt_or_tool_payload",
+        "action": "withheld",
+        "replacement": "[withheld]"
+      },
+      {
+        "path": "$.replay.run_record.stages[0].visible_text",
+        "class": "prompt_or_tool_payload",
+        "action": "withheld",
+        "replacement": "[withheld]"
+      },
+      {
+        "path": "$.replay.run_record.task",
+        "class": "prompt_or_tool_payload",
+        "action": "withheld",
+        "replacement": "[withheld]"
+      },
+      {
+        "path": "$.replay.run_record.tool_recordings[0].result",
+        "class": "prompt_or_tool_payload",
+        "action": "withheld",
+        "replacement": "[withheld]"
+      },
+      {
+        "path": "$.replay.run_record.transcript.events[1].arguments",
+        "class": "prompt_or_tool_payload",
+        "action": "withheld",
+        "replacement": "[withheld]"
+      },
+      {
+        "path": "$.replay.run_record.transcript.messages[0].content",
+        "class": "prompt_or_tool_payload",
+        "action": "withheld",
+        "replacement": "[withheld]"
+      },
+      {
+        "path": "$.replay.run_record.transcript.messages[1].content",
+        "class": "prompt_or_tool_payload",
+        "action": "withheld",
+        "replacement": "[withheld]"
+      },
+      {
+        "path": "$.replay.run_record.transcript.metadata.system_prompt",
+        "class": "prompt_or_tool_payload",
+        "action": "withheld",
+        "replacement": "[withheld]"
+      },
+      {
+        "path": "$.replay.run_record.transcript.summary",
+        "class": "prompt_or_tool_payload",
+        "action": "withheld",
+        "replacement": "[withheld]"
+      },
+      {
+        "path": "$.source.task",
+        "class": "prompt_or_tool_payload",
+        "action": "withheld",
+        "replacement": "[withheld]"
+      },
+      {
+        "path": "$.tools.calls[0].result",
+        "class": "prompt_or_tool_payload",
+        "action": "withheld",
+        "replacement": "[withheld]"
+      },
+      {
+        "path": "$.transcript.sections[0].events[1].arguments",
+        "class": "prompt_or_tool_payload",
+        "action": "withheld",
+        "replacement": "[withheld]"
+      },
+      {
+        "path": "$.transcript.sections[0].messages[0].content",
+        "class": "prompt_or_tool_payload",
+        "action": "withheld",
+        "replacement": "[withheld]"
+      },
+      {
+        "path": "$.transcript.sections[0].messages[1].content",
+        "class": "prompt_or_tool_payload",
+        "action": "withheld",
+        "replacement": "[withheld]"
+      },
+      {
+        "path": "$.transcript.sections[0].metadata.system_prompt",
+        "class": "prompt_or_tool_payload",
+        "action": "withheld",
+        "replacement": "[withheld]"
+      },
+      {
+        "path": "$.transcript.sections[0].summary",
+        "class": "prompt_or_tool_payload",
+        "action": "withheld",
+        "replacement": "[withheld]"
+      },
+      {
+        "path": "$.transcript.sections[1].messages[0].content",
+        "class": "prompt_or_tool_payload",
+        "action": "withheld",
+        "replacement": "[withheld]"
+      }
+    ],
+    "unsafe_secret_markers_rejected": true
+  },
+  "attachments": [],
+  "metadata": {
+    "format_note": "Session bundles are portable JSON envelopes; hosted share links should reference sanitized bundles rather than raw run records."
+  }
+}

--- a/spec/session-bundles/fixtures/sample-run-record.json
+++ b/spec/session-bundles/fixtures/sample-run-record.json
@@ -1,0 +1,182 @@
+{
+  "_type": "run_record",
+  "id": "run_fixture_session_bundle",
+  "workflow_id": "wf_fixture_session_bundle",
+  "workflow_name": "Session bundle fixture",
+  "task": "Summarize a deploy investigation and preserve replay evidence.",
+  "status": "completed",
+  "started_at": "2026-05-01T00:00:00Z",
+  "finished_at": "2026-05-01T00:00:30Z",
+  "stages": [
+    {
+      "id": "stage_fixture_answer",
+      "node_id": "answer",
+      "kind": "agent",
+      "status": "completed",
+      "outcome": "ok",
+      "started_at": "2026-05-01T00:00:01Z",
+      "finished_at": "2026-05-01T00:00:20Z",
+      "visible_text": "The deploy failed because the canary health check used stale config.",
+      "private_reasoning": "The local-only notes should not appear in replay-only shares.",
+      "transcript": {
+        "messages": [
+          {
+            "role": "assistant",
+            "content": "The deploy failed because the canary health check used stale config."
+          }
+        ],
+        "events": [],
+        "assets": [],
+        "metadata": {
+          "tool_schemas": [
+            {
+              "name": "read_file",
+              "input_schema": {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "transitions": [
+    {
+      "id": "transition_fixture_start",
+      "to_node_id": "answer",
+      "timestamp": "2026-05-01T00:00:01Z"
+    }
+  ],
+  "checkpoints": [
+    {
+      "id": "checkpoint_fixture_done",
+      "ready_nodes": [],
+      "completed_nodes": [
+        "answer"
+      ],
+      "last_stage_id": "stage_fixture_answer",
+      "persisted_at": "2026-05-01T00:00:30Z",
+      "reason": "completed"
+    }
+  ],
+  "completed_nodes": [
+    "answer"
+  ],
+  "artifacts": [
+    {
+      "id": "artifact_fixture_summary",
+      "kind": "summary",
+      "title": "Deploy investigation summary",
+      "stage": "stage_fixture_answer",
+      "text": "Canary health checks used stale config.",
+      "metadata": {
+        "classification": "shareable"
+      }
+    }
+  ],
+  "transcript": {
+    "_type": "transcript",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Why did the canary deploy fail?"
+      },
+      {
+        "role": "assistant",
+        "content": "The canary health check used stale config."
+      }
+    ],
+    "events": [
+      {
+        "type": "tool_schemas",
+        "schemas": [
+          {
+            "name": "read_file"
+          }
+        ]
+      },
+      {
+        "kind": "permission_requested",
+        "request_id": "perm_fixture_1",
+        "agent": "deploy-investigator",
+        "arguments": {
+          "api_key": "fixture-local-key"
+        }
+      }
+    ],
+    "assets": [],
+    "summary": "Canary health check used stale config.",
+    "metadata": {
+      "system_prompt": "Use local logs and explain the deployment failure."
+    }
+  },
+  "usage": {
+    "input_tokens": 42,
+    "output_tokens": 17,
+    "total_duration_ms": 1200,
+    "call_count": 1,
+    "total_cost": 0.002,
+    "models": [
+      "mock/deploy-investigator"
+    ]
+  },
+  "replay_fixture": {
+    "_type": "replay_fixture",
+    "id": "replay_fixture_session_bundle",
+    "source_run_id": "run_fixture_session_bundle",
+    "workflow_id": "wf_fixture_session_bundle",
+    "workflow_name": "Session bundle fixture",
+    "created_at": "2026-05-01T00:00:31Z",
+    "expected_status": "completed",
+    "stage_assertions": [
+      {
+        "node_id": "answer",
+        "expected_status": "completed",
+        "expected_outcome": "ok",
+        "required_artifact_kinds": [
+          "summary"
+        ],
+        "visible_text_contains": "stale config"
+      }
+    ]
+  },
+  "trace_spans": [
+    {
+      "span_id": 1,
+      "kind": "stage",
+      "name": "answer",
+      "start_ms": 0,
+      "duration_ms": 1200
+    }
+  ],
+  "tool_recordings": [
+    {
+      "tool_name": "read_file",
+      "tool_use_id": "tool_fixture_1",
+      "args_hash": "fixture_args_hash",
+      "result": "Read deploy.log: stale config detected.",
+      "is_rejected": false,
+      "duration_ms": 8,
+      "iteration": 1,
+      "timestamp": "2026-05-01T00:00:10Z"
+    }
+  ],
+  "hitl_questions": [
+    {
+      "request_id": "hitl_fixture_1",
+      "prompt": "Approve reading deploy.log?",
+      "agent": "deploy-investigator",
+      "asked_at": "2026-05-01T00:00:05Z"
+    }
+  ],
+  "metadata": {
+    "workspace_id": "workspace_fixture",
+    "project_root": "/workspace/example"
+  },
+  "persisted_path": "spec/session-bundles/fixtures/sample-run-record.json"
+}

--- a/spec/session-bundles/fixtures/sample-sanitized.bundle.json
+++ b/spec/session-bundles/fixtures/sample-sanitized.bundle.json
@@ -1,0 +1,695 @@
+{
+  "_type": "harn_session_bundle",
+  "schema_version": 1,
+  "bundle_id": "bundle_019e21eb-38d6-76e0-8e5c-150f6233942b",
+  "created_at": "1778685524",
+  "producer": {
+    "name": "harn",
+    "version": "0.8.12",
+    "schema_id": "https://harnlang.com/schemas/session-bundle.v1.json"
+  },
+  "source": {
+    "kind": "run_record",
+    "run_record_id": "run_fixture_session_bundle",
+    "workflow_id": "wf_fixture_session_bundle",
+    "workflow_name": "Session bundle fixture",
+    "task": "Summarize a deploy investigation and preserve replay evidence.",
+    "status": "completed",
+    "started_at": "2026-05-01T00:00:00Z",
+    "finished_at": "2026-05-01T00:00:30Z",
+    "persisted_path": "[redacted]",
+    "root_run_id": null,
+    "parent_run_id": null,
+    "child_run_count": 0
+  },
+  "runtime": {
+    "harn_version": "0.8.12",
+    "provider_models": [
+      "mock/deploy-investigator"
+    ],
+    "usage": {
+      "input_tokens": 42,
+      "output_tokens": 17,
+      "call_count": 1,
+      "total_duration_ms": 1200,
+      "total_cost": 0.002,
+      "models": [
+        "mock/deploy-investigator"
+      ]
+    },
+    "metadata": {}
+  },
+  "workspace": {
+    "identity": "workspace_fixture",
+    "source_root": "[redacted]",
+    "policy": "safe_identity_only"
+  },
+  "transcript": {
+    "sections": [
+      {
+        "id": "run",
+        "label": "Run transcript",
+        "scope": "run",
+        "location": "$.transcript",
+        "summary": "Canary health check used stale config.",
+        "messages": [
+          {
+            "content": "Why did the canary deploy fail?",
+            "role": "user"
+          },
+          {
+            "content": "The canary health check used stale config.",
+            "role": "assistant"
+          }
+        ],
+        "events": [
+          {
+            "schemas": [
+              {
+                "name": "read_file"
+              }
+            ],
+            "type": "tool_schemas"
+          },
+          {
+            "agent": "deploy-investigator",
+            "arguments": {
+              "api_key": "[redacted]"
+            },
+            "kind": "permission_requested",
+            "request_id": "perm_fixture_1"
+          }
+        ],
+        "assets": [],
+        "metadata": {
+          "system_prompt": "Use local logs and explain the deployment failure."
+        }
+      },
+      {
+        "id": "stage_fixture_answer",
+        "label": "Stage answer",
+        "scope": "stage",
+        "location": "$.stages[0].transcript",
+        "summary": null,
+        "messages": [
+          {
+            "content": "The deploy failed because the canary health check used stale config.",
+            "role": "assistant"
+          }
+        ],
+        "events": [],
+        "assets": [],
+        "metadata": {
+          "tool_schemas": [
+            {
+              "input_schema": {
+                "properties": {
+                  "path": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "name": "read_file"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "tools": {
+    "schemas": [
+      {
+        "source": "run.transcript",
+        "index": 0,
+        "value": {
+          "schemas": [
+            {
+              "name": "read_file"
+            }
+          ],
+          "type": "tool_schemas"
+        }
+      }
+    ],
+    "calls": [
+      {
+        "tool_name": "read_file",
+        "tool_use_id": "tool_fixture_1",
+        "args_hash": "fixture_args_hash",
+        "result": "Read deploy.log: stale config detected.",
+        "is_rejected": false,
+        "duration_ms": 8,
+        "iteration": 1,
+        "timestamp": "2026-05-01T00:00:10Z"
+      }
+    ]
+  },
+  "permissions": [
+    {
+      "kind": "hitl_question",
+      "source": "run.hitl_questions",
+      "request_id": "hitl_fixture_1",
+      "agent": "deploy-investigator",
+      "payload": {
+        "agent": "deploy-investigator",
+        "asked_at": "2026-05-01T00:00:05Z",
+        "prompt": "Approve reading deploy.log?",
+        "request_id": "hitl_fixture_1",
+        "trace_id": null
+      }
+    },
+    {
+      "kind": "permission_requested",
+      "source": "run.transcript",
+      "request_id": "perm_fixture_1",
+      "agent": "deploy-investigator",
+      "payload": {
+        "agent": "deploy-investigator",
+        "arguments": {
+          "api_key": "[redacted]"
+        },
+        "kind": "permission_requested",
+        "request_id": "perm_fixture_1"
+      }
+    }
+  ],
+  "replay": {
+    "replay_fixture": {
+      "_type": "replay_fixture",
+      "id": "replay_fixture_session_bundle",
+      "source_run_id": "run_fixture_session_bundle",
+      "workflow_id": "wf_fixture_session_bundle",
+      "workflow_name": "Session bundle fixture",
+      "created_at": "2026-05-01T00:00:31Z",
+      "eval_kind": null,
+      "clarifying_question": null,
+      "expected_status": "completed",
+      "stage_assertions": [
+        {
+          "node_id": "answer",
+          "expected_status": "completed",
+          "expected_outcome": "ok",
+          "expected_branch": null,
+          "required_artifact_kinds": [
+            "summary"
+          ],
+          "visible_text_contains": "stale config"
+        }
+      ]
+    },
+    "run_record": {
+      "_type": "run_record",
+      "artifacts": [
+        {
+          "_type": "",
+          "created_at": "",
+          "data": null,
+          "estimated_tokens": null,
+          "freshness": null,
+          "id": "artifact_fixture_summary",
+          "kind": "summary",
+          "lineage": [],
+          "metadata": {
+            "classification": "shareable"
+          },
+          "priority": null,
+          "relevance": null,
+          "source": null,
+          "stage": "stage_fixture_answer",
+          "text": "Canary health checks used stale config.",
+          "title": "Deploy investigation summary"
+        }
+      ],
+      "checkpoints": [
+        {
+          "completed_nodes": [
+            "answer"
+          ],
+          "id": "checkpoint_fixture_done",
+          "last_stage_id": "stage_fixture_answer",
+          "persisted_at": "2026-05-01T00:00:30Z",
+          "ready_nodes": [],
+          "reason": "completed"
+        }
+      ],
+      "child_runs": [],
+      "completed_nodes": [
+        "answer"
+      ],
+      "execution": null,
+      "finished_at": "2026-05-01T00:00:30Z",
+      "handoffs": [],
+      "hitl_questions": [
+        {
+          "agent": "deploy-investigator",
+          "asked_at": "2026-05-01T00:00:05Z",
+          "prompt": "Approve reading deploy.log?",
+          "request_id": "hitl_fixture_1",
+          "trace_id": null
+        }
+      ],
+      "id": "run_fixture_session_bundle",
+      "metadata": {
+        "project_root": "[redacted]",
+        "workspace_id": "workspace_fixture"
+      },
+      "observability": {
+        "action_graph_edges": [
+          {
+            "from_id": "run:run_fixture_session_bundle",
+            "kind": "transition",
+            "label": null,
+            "to_id": "stage:stage_fixture_answer"
+          }
+        ],
+        "action_graph_nodes": [
+          {
+            "id": "run:run_fixture_session_bundle",
+            "kind": "run",
+            "label": "Session bundle fixture",
+            "metadata": {
+              "workflow_id": "wf_fixture_session_bundle"
+            },
+            "node_id": null,
+            "outcome": "completed",
+            "run_id": "run_fixture_session_bundle",
+            "run_path": "[redacted]",
+            "stage_id": null,
+            "status": "completed",
+            "trace_id": null,
+            "worker_id": null
+          },
+          {
+            "id": "stage:stage_fixture_answer",
+            "kind": "stage",
+            "label": "answer",
+            "metadata": {
+              "stage_kind": "agent"
+            },
+            "node_id": "answer",
+            "outcome": "ok",
+            "run_id": null,
+            "run_path": "[redacted]",
+            "stage_id": "stage_fixture_answer",
+            "status": "completed",
+            "trace_id": null,
+            "worker_id": null
+          }
+        ],
+        "compaction_events": [],
+        "daemon_events": [],
+        "planner_rounds": [],
+        "research_fact_count": 0,
+        "schema_version": 4,
+        "transcript_pointers": [
+          {
+            "available": true,
+            "id": "stage:stage_fixture_answer:transcript",
+            "kind": "embedded_transcript",
+            "label": "Stage answer transcript",
+            "location": "run.stages[answer].transcript",
+            "path": "[redacted]"
+          },
+          {
+            "available": true,
+            "id": "run:transcript",
+            "kind": "embedded_transcript",
+            "label": "Run transcript",
+            "location": "run.transcript",
+            "path": "[redacted]"
+          },
+          {
+            "available": false,
+            "id": "run:llm_transcript",
+            "kind": "llm_jsonl",
+            "label": "LLM transcript sidecar",
+            "location": "run sidecar",
+            "path": "[redacted]"
+          }
+        ],
+        "verification_outcomes": [],
+        "worker_lineage": []
+      },
+      "parent_run_id": null,
+      "pending_nodes": [],
+      "persisted_path": "[redacted]",
+      "persona_runtime": [],
+      "policy": {
+        "capabilities": {},
+        "recursion_limit": null,
+        "side_effect_level": null,
+        "tool_annotations": {},
+        "tool_arg_constraints": [],
+        "tools": [],
+        "workspace_roots": []
+      },
+      "replay_fixture": {
+        "_type": "replay_fixture",
+        "clarifying_question": null,
+        "created_at": "2026-05-01T00:00:31Z",
+        "eval_kind": null,
+        "expected_status": "completed",
+        "id": "replay_fixture_session_bundle",
+        "source_run_id": "run_fixture_session_bundle",
+        "stage_assertions": [
+          {
+            "expected_branch": null,
+            "expected_outcome": "ok",
+            "expected_status": "completed",
+            "node_id": "answer",
+            "required_artifact_kinds": [
+              "summary"
+            ],
+            "visible_text_contains": "stale config"
+          }
+        ],
+        "workflow_id": "wf_fixture_session_bundle",
+        "workflow_name": "Session bundle fixture"
+      },
+      "root_run_id": null,
+      "stages": [
+        {
+          "artifacts": [],
+          "attempts": [],
+          "branch": null,
+          "consumed_artifact_ids": [],
+          "finished_at": "2026-05-01T00:00:20Z",
+          "id": "stage_fixture_answer",
+          "kind": "agent",
+          "metadata": {},
+          "node_id": "answer",
+          "outcome": "ok",
+          "private_reasoning": "The local-only notes should not appear in replay-only shares.",
+          "produced_artifact_ids": [],
+          "started_at": "2026-05-01T00:00:01Z",
+          "status": "completed",
+          "transcript": {
+            "assets": [],
+            "events": [],
+            "messages": [
+              {
+                "content": "The deploy failed because the canary health check used stale config.",
+                "role": "assistant"
+              }
+            ],
+            "metadata": {
+              "tool_schemas": [
+                {
+                  "input_schema": {
+                    "properties": {
+                      "path": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "name": "read_file"
+                }
+              ]
+            }
+          },
+          "usage": null,
+          "verification": null,
+          "visible_text": "The deploy failed because the canary health check used stale config."
+        }
+      ],
+      "started_at": "2026-05-01T00:00:00Z",
+      "status": "completed",
+      "task": "Summarize a deploy investigation and preserve replay evidence.",
+      "tool_recordings": [
+        {
+          "args_hash": "fixture_args_hash",
+          "duration_ms": 8,
+          "is_rejected": false,
+          "iteration": 1,
+          "result": "Read deploy.log: stale config detected.",
+          "timestamp": "2026-05-01T00:00:10Z",
+          "tool_name": "read_file",
+          "tool_use_id": "tool_fixture_1"
+        }
+      ],
+      "trace_spans": [
+        {
+          "duration_ms": 1200,
+          "kind": "stage",
+          "metadata": {},
+          "name": "answer",
+          "parent_id": null,
+          "span_id": 1,
+          "start_ms": 0
+        }
+      ],
+      "transcript": {
+        "_type": "transcript",
+        "assets": [],
+        "events": [
+          {
+            "schemas": [
+              {
+                "name": "read_file"
+              }
+            ],
+            "type": "tool_schemas"
+          },
+          {
+            "agent": "deploy-investigator",
+            "arguments": {
+              "api_key": "[redacted]"
+            },
+            "kind": "permission_requested",
+            "request_id": "perm_fixture_1"
+          }
+        ],
+        "messages": [
+          {
+            "content": "Why did the canary deploy fail?",
+            "role": "user"
+          },
+          {
+            "content": "The canary health check used stale config.",
+            "role": "assistant"
+          }
+        ],
+        "metadata": {
+          "system_prompt": "Use local logs and explain the deployment failure."
+        },
+        "summary": "Canary health check used stale config."
+      },
+      "transitions": [
+        {
+          "branch": null,
+          "consumed_artifact_ids": [],
+          "from_node_id": null,
+          "from_stage_id": null,
+          "id": "transition_fixture_start",
+          "produced_artifact_ids": [],
+          "timestamp": "2026-05-01T00:00:01Z",
+          "to_node_id": "answer"
+        }
+      ],
+      "usage": {
+        "call_count": 1,
+        "input_tokens": 42,
+        "models": [
+          "mock/deploy-investigator"
+        ],
+        "output_tokens": 17,
+        "total_cost": 0.002,
+        "total_duration_ms": 1200
+      },
+      "workflow_id": "wf_fixture_session_bundle",
+      "workflow_name": "Session bundle fixture"
+    },
+    "event_log_pointers": [
+      {
+        "kind": "embedded_transcript",
+        "topic": null,
+        "path": "[redacted]",
+        "location": "run.stages[answer].transcript",
+        "available": true
+      },
+      {
+        "kind": "embedded_transcript",
+        "topic": null,
+        "path": "[redacted]",
+        "location": "run.transcript",
+        "available": true
+      },
+      {
+        "kind": "llm_jsonl",
+        "topic": null,
+        "path": "[redacted]",
+        "location": "run sidecar",
+        "available": false
+      }
+    ],
+    "transitions": [
+      {
+        "id": "transition_fixture_start",
+        "from_stage_id": null,
+        "from_node_id": null,
+        "to_node_id": "answer",
+        "branch": null,
+        "timestamp": "2026-05-01T00:00:01Z",
+        "consumed_artifact_ids": [],
+        "produced_artifact_ids": []
+      }
+    ],
+    "checkpoints": [
+      {
+        "id": "checkpoint_fixture_done",
+        "ready_nodes": [],
+        "completed_nodes": [
+          "answer"
+        ],
+        "last_stage_id": "stage_fixture_answer",
+        "persisted_at": "2026-05-01T00:00:30Z",
+        "reason": "completed"
+      }
+    ],
+    "trace_spans": [
+      {
+        "span_id": 1,
+        "parent_id": null,
+        "kind": "stage",
+        "name": "answer",
+        "start_ms": 0,
+        "duration_ms": 1200,
+        "metadata": {}
+      }
+    ],
+    "deterministic_events": [
+      {
+        "source": "run.transitions",
+        "index": 0,
+        "value": {
+          "branch": null,
+          "consumed_artifact_ids": [],
+          "from_node_id": null,
+          "from_stage_id": null,
+          "id": "transition_fixture_start",
+          "produced_artifact_ids": [],
+          "timestamp": "2026-05-01T00:00:01Z",
+          "to_node_id": "answer"
+        }
+      },
+      {
+        "source": "run.checkpoints",
+        "index": 0,
+        "value": {
+          "completed_nodes": [
+            "answer"
+          ],
+          "id": "checkpoint_fixture_done",
+          "last_stage_id": "stage_fixture_answer",
+          "persisted_at": "2026-05-01T00:00:30Z",
+          "ready_nodes": [],
+          "reason": "completed"
+        }
+      }
+    ]
+  },
+  "redaction": {
+    "mode": "sanitized",
+    "policy": "harn_vm::redact::RedactionPolicy::default+session_bundle_local_paths",
+    "placeholder": "[redacted]",
+    "entries": [
+      {
+        "path": "$.permissions[1].payload.arguments.api_key",
+        "class": "sensitive_field",
+        "action": "replaced",
+        "replacement": "[redacted]"
+      },
+      {
+        "path": "$.replay.run_record.metadata.project_root",
+        "class": "sensitive_field",
+        "action": "replaced",
+        "replacement": "[redacted]"
+      },
+      {
+        "path": "$.replay.run_record.observability.action_graph_nodes[0].run_path",
+        "class": "sensitive_field",
+        "action": "replaced",
+        "replacement": "[redacted]"
+      },
+      {
+        "path": "$.replay.run_record.observability.action_graph_nodes[1].run_path",
+        "class": "sensitive_field",
+        "action": "replaced",
+        "replacement": "[redacted]"
+      },
+      {
+        "path": "$.replay.run_record.persisted_path",
+        "class": "sensitive_field",
+        "action": "replaced",
+        "replacement": "[redacted]"
+      },
+      {
+        "path": "$.replay.run_record.transcript.events[1].arguments.api_key",
+        "class": "sensitive_field",
+        "action": "replaced",
+        "replacement": "[redacted]"
+      },
+      {
+        "path": "$.source.persisted_path",
+        "class": "sensitive_field",
+        "action": "replaced",
+        "replacement": "[redacted]"
+      },
+      {
+        "path": "$.transcript.sections[0].events[1].arguments.api_key",
+        "class": "sensitive_field",
+        "action": "replaced",
+        "replacement": "[redacted]"
+      },
+      {
+        "path": "$.workspace.source_root",
+        "class": "sensitive_field",
+        "action": "replaced",
+        "replacement": "[redacted]"
+      },
+      {
+        "path": "$.replay.event_log_pointers[0].path",
+        "class": "local_pointer_path",
+        "action": "replaced",
+        "replacement": "[redacted]"
+      },
+      {
+        "path": "$.replay.event_log_pointers[1].path",
+        "class": "local_pointer_path",
+        "action": "replaced",
+        "replacement": "[redacted]"
+      },
+      {
+        "path": "$.replay.event_log_pointers[2].path",
+        "class": "local_pointer_path",
+        "action": "replaced",
+        "replacement": "[redacted]"
+      },
+      {
+        "path": "$.replay.run_record.observability.transcript_pointers[0].path",
+        "class": "local_pointer_path",
+        "action": "replaced",
+        "replacement": "[redacted]"
+      },
+      {
+        "path": "$.replay.run_record.observability.transcript_pointers[1].path",
+        "class": "local_pointer_path",
+        "action": "replaced",
+        "replacement": "[redacted]"
+      },
+      {
+        "path": "$.replay.run_record.observability.transcript_pointers[2].path",
+        "class": "local_pointer_path",
+        "action": "replaced",
+        "replacement": "[redacted]"
+      }
+    ],
+    "unsafe_secret_markers_rejected": true
+  },
+  "attachments": [],
+  "metadata": {
+    "format_note": "Session bundles are portable JSON envelopes; hosted share links should reference sanitized bundles rather than raw run records."
+  }
+}


### PR DESCRIPTION
## Summary
- add versioned `harn_session_bundle` export/import/validate/schema support backed by `harn_vm::session_bundle`
- add local, sanitized, and replay-only bundle modes with deterministic redaction manifests, local path scrubbing, checked schema generation, and fixtures
- document bundle modes, validation/import usage, migration semantics, and redaction behavior

Closes #1587

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p harn-vm session_bundle`
- `cargo test -p harn-cli test_parses_session_bundle_commands`
- `cargo clippy -p harn-vm -p harn-cli --all-targets -- -D warnings`
- `make check-session-bundle-schema`
- `cargo run --quiet -p harn-cli -- session validate spec/session-bundles/fixtures/sample-sanitized.bundle.json --json`
- `cargo run --quiet -p harn-cli -- session import spec/session-bundles/fixtures/sample-sanitized.bundle.json --out "$tmpdir/imported-run.json" && test -s "$tmpdir/imported-run.json"`
- pre-commit hook: full workspace clippy, markdownlint, actionlint, highlight drift
- pre-push hook: targeted cargo checks, markdownlint, highlight drift
