### PR TITLE
[codex] Add layered runtime config

### DIFF
--- a/crates/harn-cli/src/cli/config_cmd.rs
+++ b/crates/harn-cli/src/cli/config_cmd.rs
@@ -1,0 +1,55 @@
+use std::path::PathBuf;
+
+use clap::{Args, Subcommand};
+
+#[derive(Debug, Args)]
+pub(crate) struct ConfigArgs {
+    #[command(subcommand)]
+    pub command: ConfigCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum ConfigCommand {
+    /// Print the merged runtime config.
+    Inspect(ConfigInspectArgs),
+    /// Validate local, project, or managed config overlays.
+    Validate(ConfigValidateArgs),
+    /// Print the editor JSON Schema for Harn config files.
+    Schema(ConfigSchemaArgs),
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct ConfigInspectArgs {
+    /// Include per-field provenance, shadowed candidates, and lock status.
+    #[arg(long)]
+    pub explain: bool,
+    /// Do not discover OS/user/project config files; only built-ins, explicit inputs, and env.
+    #[arg(long)]
+    pub no_discovery: bool,
+    /// Additional local/project config overlay to merge at project precedence.
+    #[arg(long = "config", value_name = "PATH")]
+    pub config_files: Vec<PathBuf>,
+    /// Managed policy overlay to merge before environment overrides.
+    #[arg(long = "managed", value_name = "PATH")]
+    pub managed_files: Vec<PathBuf>,
+    /// Remote default config URL. Requires HARN_CONFIG_TRUST_REMOTE=1.
+    #[arg(long = "remote-defaults-url", value_name = "URL")]
+    pub remote_defaults_url: Option<String>,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct ConfigValidateArgs {
+    /// Config files to validate. Defaults to discovered files.
+    #[arg(value_name = "PATH")]
+    pub files: Vec<PathBuf>,
+    /// Treat input files as managed policy overlays when reporting them.
+    #[arg(long)]
+    pub managed: bool,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct ConfigSchemaArgs {
+    /// Write the schema JSON to this path instead of stdout.
+    #[arg(long, value_name = "PATH")]
+    pub output: Option<PathBuf>,
+}

--- a/crates/harn-cli/src/cli/mod.rs
+++ b/crates/harn-cli/src/cli/mod.rs
@@ -13,6 +13,7 @@
 mod bench;
 mod check;
 mod completions;
+mod config_cmd;
 mod connect;
 mod connector;
 mod contracts;
@@ -55,6 +56,7 @@ mod workflow;
 pub(crate) use bench::BenchArgs;
 pub(crate) use check::{CheckArgs, CheckOutputFormat};
 pub(crate) use completions::{CompletionShell, CompletionsArgs};
+pub(crate) use config_cmd::{ConfigArgs, ConfigCommand, ConfigInspectArgs, ConfigValidateArgs};
 pub(crate) use connect::{
     ConnectApiKeyArgs, ConnectArgs, ConnectCommand, ConnectGenericArgs, ConnectGithubArgs,
     ConnectLinearArgs, ConnectOAuthArgs, ConnectSetupPlanArgs, ConnectStatusArgs,
@@ -214,6 +216,8 @@ SCRIPTING
     Run(RunArgs),
     /// Type-check .harn files or directories without executing them.
     Check(CheckArgs),
+    /// Inspect, validate, and emit schemas for layered Harn runtime config.
+    Config(ConfigArgs),
     /// Explain the control-flow path that violates a Harn invariant
     /// (e.g. `fs.writes`, `approval.reachability`) for a specific
     /// function or trigger handler.

--- a/crates/harn-cli/src/cli/tests.rs
+++ b/crates/harn-cli/src/cli/tests.rs
@@ -2,9 +2,9 @@ use std::path::PathBuf;
 use std::time::Duration as StdDuration;
 
 use super::{
-    CheckOutputFormat, Cli, Command, CompletionShell, ConnectCommand, ConnectorCommand,
-    CrystallizeCommand, FlowArchivistCommand, FlowCommand, McpCommand, ModelsCommand,
-    OrchestratorCommand, OrchestratorDeployProvider, OrchestratorLogFormat,
+    CheckOutputFormat, Cli, Command, CompletionShell, ConfigCommand, ConnectCommand,
+    ConnectorCommand, CrystallizeCommand, FlowArchivistCommand, FlowCommand, McpCommand,
+    ModelsCommand, OrchestratorCommand, OrchestratorDeployProvider, OrchestratorLogFormat,
     OrchestratorQueueCommand, OrchestratorTenantCommand, PackageArtifactsCommand,
     PackageCacheCommand, PackageCommand, PersonaCommand, ProjectTemplate, RunsCommand,
     SkillCommand, SkillKeyCommand, SkillTrustCommand, SkillsCommand, TraceCommand, TriggerCommand,
@@ -33,6 +33,52 @@ fn test_parses_conformance_target_selection() {
     );
     assert!(args.verbose);
     assert!(args.differential_optimizations);
+}
+
+#[test]
+fn test_parses_config_inspect_explain() {
+    let cli = Cli::parse_from([
+        "harn",
+        "config",
+        "inspect",
+        "--explain",
+        "--config",
+        "local.toml",
+        "--managed",
+        "managed.toml",
+    ]);
+
+    let Command::Config(args) = cli.command.unwrap() else {
+        panic!("expected config command");
+    };
+    let ConfigCommand::Inspect(inspect) = args.command else {
+        panic!("expected inspect command");
+    };
+    assert!(inspect.explain);
+    assert_eq!(inspect.config_files, vec![PathBuf::from("local.toml")]);
+    assert_eq!(inspect.managed_files, vec![PathBuf::from("managed.toml")]);
+}
+
+#[test]
+fn test_parses_config_validate_and_schema() {
+    let cli = Cli::parse_from(["harn", "config", "validate", "--managed", "policy.toml"]);
+    let Command::Config(args) = cli.command.unwrap() else {
+        panic!("expected config command");
+    };
+    let ConfigCommand::Validate(validate) = args.command else {
+        panic!("expected validate command");
+    };
+    assert!(validate.managed);
+    assert_eq!(validate.files, vec![PathBuf::from("policy.toml")]);
+
+    let cli = Cli::parse_from(["harn", "config", "schema", "--output", "schema.json"]);
+    let Command::Config(args) = cli.command.unwrap() else {
+        panic!("expected config command");
+    };
+    let ConfigCommand::Schema(schema) = args.command else {
+        panic!("expected schema command");
+    };
+    assert_eq!(schema.output, Some(PathBuf::from("schema.json")));
 }
 
 #[test]

--- a/crates/harn-cli/src/commands/config_cmd.rs
+++ b/crates/harn-cli/src/commands/config_cmd.rs
@@ -1,0 +1,535 @@
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use crate::cli::{ConfigArgs, ConfigCommand, ConfigInspectArgs, ConfigValidateArgs};
+
+const PROJECT_CONFIG: &str = "harn.config.toml";
+const MANIFEST: &str = "harn.toml";
+const MAX_PARENT_DIRS: usize = 16;
+
+pub(crate) async fn run(args: ConfigArgs) -> Result<(), String> {
+    match args.command {
+        ConfigCommand::Inspect(args) => run_inspect(args).await,
+        ConfigCommand::Validate(args) => run_validate(args),
+        ConfigCommand::Schema(args) => {
+            let text = serde_json::to_string_pretty(&harn_vm::config::schema_json())
+                .map_err(|error| error.to_string())?;
+            if let Some(path) = args.output {
+                harn_vm::atomic_io::atomic_write(&path, text.as_bytes())
+                    .map_err(|error| format!("failed to write {}: {error}", path.display()))?;
+            } else {
+                println!("{text}");
+            }
+            Ok(())
+        }
+    }
+}
+
+async fn run_inspect(args: ConfigInspectArgs) -> Result<(), String> {
+    let layers = build_layers(&args).await?;
+    let resolved = harn_vm::config::merge_layers(layers).map_err(|error| error.to_string())?;
+    let output = if args.explain {
+        serde_json::json!({
+            "config": resolved.redacted_config,
+            "layers": resolved.layers,
+            "explain": resolved.explain,
+        })
+    } else {
+        resolved.redacted_config
+    };
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&output).map_err(|error| error.to_string())?
+    );
+    Ok(())
+}
+
+fn run_validate(args: ConfigValidateArgs) -> Result<(), String> {
+    let files = if args.files.is_empty() {
+        discovered_validation_files()
+    } else {
+        args.files
+    };
+    if files.is_empty() {
+        println!("No Harn config files found.");
+        return Ok(());
+    }
+    for path in files {
+        let source = path.display().to_string();
+        let content = fs::read_to_string(&path)
+            .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
+        if path.file_name().is_some_and(|name| name == MANIFEST) {
+            if let Some(value) = harn_vm::config::parse_manifest_config_table(&content, &source)
+                .map_err(|error| error.to_string())?
+            {
+                if args.managed {
+                    harn_vm::config::validate_policy_paths(&value)
+                        .map_err(|error| error.to_string())?;
+                }
+            }
+        } else {
+            let value = harn_vm::config::parse_config_toml(&content, &source)
+                .map_err(|error| error.to_string())?;
+            if args.managed {
+                harn_vm::config::validate_policy_paths(&value)
+                    .map_err(|error| error.to_string())?;
+            }
+        }
+        let kind = if args.managed {
+            "managed policy"
+        } else {
+            "config"
+        };
+        println!("ok: {kind} {}", path.display());
+    }
+    Ok(())
+}
+
+async fn build_layers(
+    args: &ConfigInspectArgs,
+) -> Result<Vec<harn_vm::config::ConfigLayer>, String> {
+    let mut layers = vec![harn_vm::config::built_in_defaults_layer()];
+
+    if !args.no_discovery {
+        if let Some(layer) = legacy_provider_layer()? {
+            layers.push(layer);
+        }
+        for path in install_config_paths() {
+            push_file_layer(
+                &mut layers,
+                harn_vm::config::ConfigLayerKind::RuntimeInstallDefaults,
+                "runtime install defaults",
+                &path,
+            )?;
+        }
+        if let Some(url) = remote_defaults_url(args, true) {
+            layers.push(fetch_remote_defaults(&url).await?);
+        }
+        for path in user_config_paths() {
+            push_file_layer(
+                &mut layers,
+                harn_vm::config::ConfigLayerKind::UserConfig,
+                "user config",
+                &path,
+            )?;
+        }
+        if let Some(path) =
+            find_nearest_named(&env::current_dir().unwrap_or_default(), PROJECT_CONFIG)
+        {
+            push_file_layer(
+                &mut layers,
+                harn_vm::config::ConfigLayerKind::ProjectConfig,
+                "project config",
+                &path,
+            )?;
+        }
+        if let Some(path) = find_nearest_named(&env::current_dir().unwrap_or_default(), MANIFEST) {
+            push_manifest_config_layer(&mut layers, &path)?;
+        }
+    }
+
+    if args.no_discovery {
+        if let Some(url) = remote_defaults_url(args, false) {
+            layers.push(fetch_remote_defaults(&url).await?);
+        }
+    }
+
+    for path in &args.config_files {
+        push_explicit_file_layer(
+            &mut layers,
+            harn_vm::config::ConfigLayerKind::ProjectConfig,
+            "explicit config",
+            path,
+        )?;
+    }
+    if !args.no_discovery {
+        for path in managed_config_paths() {
+            push_file_layer(
+                &mut layers,
+                harn_vm::config::ConfigLayerKind::ManagedPolicy,
+                "managed policy",
+                &path,
+            )?;
+        }
+    }
+    for path in &args.managed_files {
+        push_explicit_file_layer(
+            &mut layers,
+            harn_vm::config::ConfigLayerKind::ManagedPolicy,
+            "explicit managed policy",
+            path,
+        )?;
+    }
+    if let Some(layer) =
+        harn_vm::config::environment_layer(env::vars()).map_err(|error| error.to_string())?
+    {
+        layers.push(layer);
+    }
+
+    Ok(layers)
+}
+
+fn legacy_provider_layer() -> Result<Option<harn_vm::config::ConfigLayer>, String> {
+    let path = if let Ok(path) = env::var("HARN_PROVIDERS_CONFIG") {
+        PathBuf::from(path)
+    } else {
+        let Some(path) = harn_vm::config::user_config_path_for_os(
+            env::consts::OS,
+            env::var("HOME").ok().as_deref(),
+            env::var("XDG_CONFIG_HOME").ok().as_deref(),
+            env::var("APPDATA").ok().as_deref(),
+        ) else {
+            return Ok(None);
+        };
+        path.with_file_name("providers.toml")
+    };
+    if !path.is_file() {
+        return Ok(None);
+    }
+    let source = path.display().to_string();
+    let content = fs::read_to_string(&path)
+        .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
+    let providers =
+        toml::from_str::<harn_vm::llm_config::ProvidersConfig>(&content).map_err(|error| {
+            format!(
+                "failed to parse legacy providers config {source}: {}",
+                sanitized_error_message(error)
+            )
+        })?;
+    Ok(Some(harn_vm::config::layer_from_providers_config(
+        harn_vm::config::ConfigLayerKind::UserConfig,
+        "legacy providers config",
+        source,
+        &providers,
+    )))
+}
+
+fn sanitized_error_message(error: impl ToString) -> String {
+    error
+        .to_string()
+        .lines()
+        .next()
+        .unwrap_or("parse error")
+        .to_string()
+}
+
+fn push_file_layer(
+    layers: &mut Vec<harn_vm::config::ConfigLayer>,
+    kind: harn_vm::config::ConfigLayerKind,
+    name: &str,
+    path: &Path,
+) -> Result<(), String> {
+    push_file_layer_with_required(layers, kind, name, path, false)
+}
+
+fn push_explicit_file_layer(
+    layers: &mut Vec<harn_vm::config::ConfigLayer>,
+    kind: harn_vm::config::ConfigLayerKind,
+    name: &str,
+    path: &Path,
+) -> Result<(), String> {
+    push_file_layer_with_required(layers, kind, name, path, true)
+}
+
+fn push_file_layer_with_required(
+    layers: &mut Vec<harn_vm::config::ConfigLayer>,
+    kind: harn_vm::config::ConfigLayerKind,
+    name: &str,
+    path: &Path,
+    required: bool,
+) -> Result<(), String> {
+    if !path.is_file() {
+        if required {
+            return Err(format!("config file {} does not exist", path.display()));
+        }
+        return Ok(());
+    }
+    let source = path.display().to_string();
+    let content = fs::read_to_string(path)
+        .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
+    let value =
+        harn_vm::config::parse_config_toml(&content, &source).map_err(|error| error.to_string())?;
+    layers.push(harn_vm::config::ConfigLayer::new(kind, name, source, value));
+    Ok(())
+}
+
+fn push_manifest_config_layer(
+    layers: &mut Vec<harn_vm::config::ConfigLayer>,
+    path: &Path,
+) -> Result<(), String> {
+    if !path.is_file() {
+        return Ok(());
+    }
+    let source = path.display().to_string();
+    let content = fs::read_to_string(path)
+        .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
+    let Some(value) = harn_vm::config::parse_manifest_config_table(&content, &source)
+        .map_err(|error| error.to_string())?
+    else {
+        return Ok(());
+    };
+    layers.push(harn_vm::config::ConfigLayer::new(
+        harn_vm::config::ConfigLayerKind::RepoConfig,
+        "repo manifest config",
+        source,
+        value,
+    ));
+    Ok(())
+}
+
+fn install_config_paths() -> Vec<PathBuf> {
+    if let Some(paths) = split_env_paths("HARN_CONFIG_INSTALL_DEFAULTS") {
+        return paths;
+    }
+    vec![harn_vm::config::install_config_path_for_os(
+        env::consts::OS,
+        env::var("PROGRAMDATA").ok().as_deref(),
+    )]
+}
+
+fn user_config_paths() -> Vec<PathBuf> {
+    if let Some(paths) = split_env_paths("HARN_CONFIG_USER") {
+        return paths;
+    }
+    harn_vm::config::user_config_path_for_os(
+        env::consts::OS,
+        env::var("HOME").ok().as_deref(),
+        env::var("XDG_CONFIG_HOME").ok().as_deref(),
+        env::var("APPDATA").ok().as_deref(),
+    )
+    .into_iter()
+    .collect()
+}
+
+fn managed_config_paths() -> Vec<PathBuf> {
+    split_env_paths("HARN_CONFIG_MANAGED").unwrap_or_default()
+}
+
+fn split_env_paths(key: &str) -> Option<Vec<PathBuf>> {
+    let value = env::var_os(key)?;
+    let paths: Vec<PathBuf> = env::split_paths(&value).collect();
+    if paths.is_empty() {
+        None
+    } else {
+        Some(paths)
+    }
+}
+
+fn remote_defaults_url(args: &ConfigInspectArgs, include_env: bool) -> Option<String> {
+    args.remote_defaults_url
+        .clone()
+        .or_else(|| {
+            include_env
+                .then(|| env::var("HARN_CONFIG_REMOTE_DEFAULTS_URL").ok())
+                .flatten()
+        })
+        .filter(|value| !value.trim().is_empty())
+}
+
+async fn fetch_remote_defaults(url: &str) -> Result<harn_vm::config::ConfigLayer, String> {
+    ensure_remote_trusted(url)?;
+    let display_url = redacted_url(url);
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(15))
+        .build()
+        .map_err(|error| format!("failed to create config HTTP client: {error}"))?;
+    let response = client
+        .get(url)
+        .send()
+        .await
+        .map_err(|error| format!("failed to fetch remote defaults {display_url}: {error}"))?
+        .error_for_status()
+        .map_err(|error| format!("failed to fetch remote defaults {display_url}: {error}"))?;
+    let text = response
+        .text()
+        .await
+        .map_err(|error| format!("failed to read remote defaults {display_url}: {error}"))?;
+    let value = if text.trim_start().starts_with('{') {
+        harn_vm::config::parse_config_json(&text, url).map_err(|error| error.to_string())?
+    } else {
+        harn_vm::config::parse_config_toml(&text, url).map_err(|error| error.to_string())?
+    };
+    Ok(harn_vm::config::ConfigLayer::new(
+        harn_vm::config::ConfigLayerKind::RemoteDefaults,
+        "remote defaults",
+        url,
+        value,
+    ))
+}
+
+fn ensure_remote_trusted(raw_url: &str) -> Result<(), String> {
+    let trusted = matches!(
+        env::var("HARN_CONFIG_TRUST_REMOTE").ok().as_deref(),
+        Some("1" | "true" | "TRUE" | "yes" | "YES")
+    );
+    remote_url_trust_error(raw_url, trusted).map_err(|reason| match reason {
+        RemoteTrustError::Untrusted => {
+            "remote defaults require HARN_CONFIG_TRUST_REMOTE=1 and an https or localhost URL"
+                .to_string()
+        }
+        RemoteTrustError::Invalid(error) => {
+            format!("invalid remote defaults URL: {error}")
+        }
+        RemoteTrustError::UnsupportedScheme => format!(
+            "remote defaults URL {} is not trusted; use https or http localhost",
+            redacted_url(raw_url)
+        ),
+    })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum RemoteTrustError {
+    Untrusted,
+    Invalid(String),
+    UnsupportedScheme,
+}
+
+fn remote_url_trust_error(raw_url: &str, trusted: bool) -> Result<(), RemoteTrustError> {
+    if !trusted {
+        return Err(RemoteTrustError::Untrusted);
+    }
+    let url =
+        url::Url::parse(raw_url).map_err(|error| RemoteTrustError::Invalid(error.to_string()))?;
+    let host = url.host_str().unwrap_or_default();
+    let local = matches!(host, "localhost" | "127.0.0.1" | "::1");
+    if url.scheme() == "https" || (local && url.scheme() == "http") {
+        Ok(())
+    } else {
+        Err(RemoteTrustError::UnsupportedScheme)
+    }
+}
+
+fn discovered_validation_files() -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    for path in install_config_paths()
+        .into_iter()
+        .chain(user_config_paths())
+        .chain(managed_config_paths())
+    {
+        if path.is_file() {
+            files.push(path);
+        }
+    }
+    let cwd = env::current_dir().unwrap_or_default();
+    if let Some(path) = find_nearest_named(&cwd, PROJECT_CONFIG) {
+        files.push(path);
+    }
+    if let Some(path) = find_nearest_named(&cwd, MANIFEST) {
+        files.push(path);
+    }
+    files.sort();
+    files.dedup();
+    files
+}
+
+fn find_nearest_named(start: &Path, name: &str) -> Option<PathBuf> {
+    let base = if start.is_absolute() {
+        start.to_path_buf()
+    } else {
+        env::current_dir().ok()?.join(start)
+    };
+    let mut cursor = if base.is_dir() {
+        Some(base)
+    } else {
+        base.parent().map(Path::to_path_buf)
+    };
+    let mut steps = 0usize;
+    while let Some(dir) = cursor {
+        if steps >= MAX_PARENT_DIRS {
+            break;
+        }
+        steps += 1;
+        let candidate = dir.join(name);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        if dir.join(".git").exists() {
+            break;
+        }
+        cursor = dir.parent().map(Path::to_path_buf);
+    }
+    None
+}
+
+fn redacted_url(value: &str) -> String {
+    if url::Url::parse(value).is_err() {
+        return "[redacted]".to_string();
+    }
+    harn_vm::redact::current_policy().redact_url(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_untrusted_remote_defaults() {
+        let error = ensure_remote_trusted("http://example.com/.well-known/harn").unwrap_err();
+        assert!(error.contains("HARN_CONFIG_TRUST_REMOTE") || error.contains("not trusted"));
+    }
+
+    #[test]
+    fn remote_defaults_trust_allows_only_https_or_http_localhost() {
+        assert!(remote_url_trust_error("https://example.com/.well-known/harn", true).is_ok());
+        assert!(remote_url_trust_error("http://localhost:8787/.well-known/harn", true).is_ok());
+        assert_eq!(
+            remote_url_trust_error("ftp://localhost/.well-known/harn", true),
+            Err(RemoteTrustError::UnsupportedScheme)
+        );
+        assert_eq!(
+            remote_url_trust_error("http://example.com/.well-known/harn", true),
+            Err(RemoteTrustError::UnsupportedScheme)
+        );
+    }
+
+    #[test]
+    fn explicit_config_files_must_exist() {
+        let mut layers = Vec::new();
+        let missing = PathBuf::from("__missing_harn_config.toml");
+        let error = push_explicit_file_layer(
+            &mut layers,
+            harn_vm::config::ConfigLayerKind::ProjectConfig,
+            "explicit config",
+            &missing,
+        )
+        .unwrap_err();
+
+        assert!(error.contains("does not exist"));
+    }
+
+    #[test]
+    fn managed_validation_rejects_invalid_policy_paths() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("policy.toml");
+        fs::write(&path, "[policy]\nlocked_fields = [\"limits..network\"]\n").unwrap();
+
+        let error = run_validate(ConfigValidateArgs {
+            files: vec![path],
+            managed: true,
+        })
+        .unwrap_err();
+
+        assert!(error.contains("invalid config field path"));
+    }
+
+    #[test]
+    fn managed_validation_rejects_invalid_manifest_policy_paths() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("harn.toml");
+        fs::write(
+            &path,
+            "[package]\nname = \"demo\"\n\n[config.policy]\ndenied_fields = [\"endpoints..mcp\"]\n",
+        )
+        .unwrap();
+
+        let error = run_validate(ConfigValidateArgs {
+            files: vec![path],
+            managed: true,
+        })
+        .unwrap_err();
+
+        assert!(error.contains("invalid config field path"));
+    }
+}

--- a/crates/harn-cli/src/commands/mod.rs
+++ b/crates/harn-cli/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod agents_conformance;
 pub(crate) mod bench;
 pub(crate) mod check;
+pub(crate) mod config_cmd;
 pub(crate) mod connect;
 pub(crate) mod connector;
 pub(crate) mod contracts;

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -289,6 +289,11 @@ async fn async_main() {
                 process::exit(1);
             }
         }
+        Command::Config(args) => {
+            if let Err(error) = commands::config_cmd::run(args).await {
+                command_error(&error);
+            }
+        }
         Command::Explain(args) => {
             let code = commands::explain::run_explain(&args);
             if code != 0 {

--- a/crates/harn-vm/src/config.rs
+++ b/crates/harn-vm/src/config.rs
@@ -1,0 +1,1617 @@
+//! Canonical layered Harn runtime configuration.
+//!
+//! The VM owns the typed shape and deterministic merge engine so hosts can
+//! inspect, validate, and explain configuration without depending on the CLI's
+//! `harn.toml` package manifest model.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Map as JsonMap, Value as JsonValue};
+
+use crate::redact::current_policy;
+
+pub const CONFIG_SCHEMA_VERSION: u32 = 1;
+pub const CONFIG_SCHEMA_ID: &str = "https://harnlang.com/schemas/harn-config.schema.json";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(default, deny_unknown_fields)]
+pub struct HarnConfig {
+    pub schema_version: u32,
+    pub models: ModelPolicyConfig,
+    pub permissions: PermissionConfig,
+    pub endpoints: EndpointCatalogConfig,
+    pub packages: PackageSourcesConfig,
+    pub skills: SkillSourcesConfig,
+    pub plugins: PluginSourcesConfig,
+    pub logging: LoggingConfig,
+    pub retention: RetentionConfig,
+    pub redaction: RedactionConfig,
+    pub replay: ReplayConfig,
+    pub limits: RuntimeLimitsConfig,
+    pub policy: ManagedPolicyConfig,
+}
+
+impl Default for HarnConfig {
+    fn default() -> Self {
+        Self {
+            schema_version: CONFIG_SCHEMA_VERSION,
+            models: ModelPolicyConfig::default(),
+            permissions: PermissionConfig::default(),
+            endpoints: EndpointCatalogConfig::default(),
+            packages: PackageSourcesConfig::default(),
+            skills: SkillSourcesConfig::default(),
+            plugins: PluginSourcesConfig::default(),
+            logging: LoggingConfig::default(),
+            retention: RetentionConfig::default(),
+            redaction: RedactionConfig::default(),
+            replay: ReplayConfig::default(),
+            limits: RuntimeLimitsConfig::default(),
+            policy: ManagedPolicyConfig::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(default, deny_unknown_fields)]
+pub struct ModelPolicyConfig {
+    pub default_provider: Option<String>,
+    pub default_model: Option<String>,
+    pub capability_refs: Vec<String>,
+    pub providers: BTreeMap<String, ProviderPolicyConfig>,
+    pub aliases: BTreeMap<String, ModelAliasConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(default, deny_unknown_fields)]
+pub struct ProviderPolicyConfig {
+    pub base_url: Option<String>,
+    pub auth_env: Vec<String>,
+    pub capability_refs: Vec<String>,
+    pub models: Vec<String>,
+    pub metadata: BTreeMap<String, JsonValue>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(default, deny_unknown_fields)]
+pub struct ModelAliasConfig {
+    pub model: String,
+    pub provider: String,
+    pub capability_refs: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum PermissionMode {
+    Allow,
+    #[default]
+    Ask,
+    Deny,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(default, deny_unknown_fields)]
+pub struct PermissionConfig {
+    pub default: PermissionMode,
+    pub capabilities: BTreeMap<String, PermissionMode>,
+}
+
+impl Default for PermissionConfig {
+    fn default() -> Self {
+        Self {
+            default: PermissionMode::Ask,
+            capabilities: BTreeMap::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(default, deny_unknown_fields)]
+pub struct EndpointCatalogConfig {
+    pub mcp: BTreeMap<String, EndpointConfig>,
+    pub a2a: BTreeMap<String, EndpointConfig>,
+    pub acp: BTreeMap<String, EndpointConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(default, deny_unknown_fields)]
+pub struct EndpointConfig {
+    pub enabled: bool,
+    pub url: Option<String>,
+    pub command: Vec<String>,
+    pub transport: Option<String>,
+    pub headers: BTreeMap<String, String>,
+}
+
+impl Default for EndpointConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            url: None,
+            command: Vec::new(),
+            transport: None,
+            headers: BTreeMap::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(default, deny_unknown_fields)]
+pub struct PackageSourcesConfig {
+    pub sources: Vec<SourceConfig>,
+    pub lockfile: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(default, deny_unknown_fields)]
+pub struct SkillSourcesConfig {
+    pub paths: Vec<String>,
+    pub sources: Vec<SourceConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(default, deny_unknown_fields)]
+pub struct PluginSourcesConfig {
+    pub sources: Vec<SourceConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(default, deny_unknown_fields)]
+pub struct SourceConfig {
+    pub name: String,
+    pub kind: String,
+    pub url: Option<String>,
+    pub path: Option<String>,
+    pub trust: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum LogLevel {
+    Error,
+    Warn,
+    #[default]
+    Info,
+    Debug,
+    Trace,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(default, deny_unknown_fields)]
+pub struct LoggingConfig {
+    pub level: LogLevel,
+    pub format: String,
+    pub file: Option<String>,
+}
+
+impl Default for LoggingConfig {
+    fn default() -> Self {
+        Self {
+            level: LogLevel::Info,
+            format: "text".to_string(),
+            file: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(default, deny_unknown_fields)]
+pub struct RetentionConfig {
+    pub days: Option<u64>,
+    pub max_bytes: Option<u64>,
+}
+
+impl Default for RetentionConfig {
+    fn default() -> Self {
+        Self {
+            days: Some(30),
+            max_bytes: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum RedactionMode {
+    Off,
+    #[default]
+    Standard,
+    Strict,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(default, deny_unknown_fields)]
+pub struct RedactionConfig {
+    pub mode: RedactionMode,
+    pub extra_fields: Vec<String>,
+    pub extra_url_params: Vec<String>,
+}
+
+impl Default for RedactionConfig {
+    fn default() -> Self {
+        Self {
+            mode: RedactionMode::Standard,
+            extra_fields: Vec::new(),
+            extra_url_params: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(default, deny_unknown_fields)]
+pub struct ReplayConfig {
+    pub enabled: bool,
+    pub directory: Option<String>,
+}
+
+impl Default for ReplayConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            directory: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum NetworkMode {
+    Allow,
+    #[default]
+    Ask,
+    Deny,
+    Offline,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum FilesystemMode {
+    ReadWrite,
+    ReadOnly,
+    #[default]
+    Sandboxed,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum SandboxMode {
+    Host,
+    #[default]
+    Process,
+    Container,
+    Worktree,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(default, deny_unknown_fields)]
+pub struct RuntimeLimitsConfig {
+    pub budget_usd: Option<f64>,
+    pub tokens: Option<u64>,
+    pub concurrency: Option<u64>,
+    pub network: NetworkMode,
+    pub filesystem: FilesystemMode,
+    pub sandbox: SandboxMode,
+}
+
+impl Default for RuntimeLimitsConfig {
+    fn default() -> Self {
+        Self {
+            budget_usd: None,
+            tokens: None,
+            concurrency: None,
+            network: NetworkMode::Ask,
+            filesystem: FilesystemMode::Sandboxed,
+            sandbox: SandboxMode::Process,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(default, deny_unknown_fields)]
+pub struct ManagedPolicyConfig {
+    pub locked_fields: Vec<String>,
+    pub denied_fields: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "snake_case")]
+pub enum ConfigLayerKind {
+    BuiltInDefaults,
+    RuntimeInstallDefaults,
+    RemoteDefaults,
+    UserConfig,
+    ProjectConfig,
+    RepoConfig,
+    ManagedPolicy,
+    EnvironmentOverrides,
+}
+
+impl ConfigLayerKind {
+    pub fn label(self) -> &'static str {
+        match self {
+            ConfigLayerKind::BuiltInDefaults => "built-in defaults",
+            ConfigLayerKind::RuntimeInstallDefaults => "runtime install defaults",
+            ConfigLayerKind::RemoteDefaults => "remote defaults",
+            ConfigLayerKind::UserConfig => "user config",
+            ConfigLayerKind::ProjectConfig => "project config",
+            ConfigLayerKind::RepoConfig => "repo config",
+            ConfigLayerKind::ManagedPolicy => "managed policy",
+            ConfigLayerKind::EnvironmentOverrides => "environment overrides",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ConfigLayer {
+    pub kind: ConfigLayerKind,
+    pub name: String,
+    pub source: String,
+    pub value: JsonValue,
+}
+
+impl ConfigLayer {
+    pub fn new(
+        kind: ConfigLayerKind,
+        name: impl Into<String>,
+        source: impl Into<String>,
+        value: JsonValue,
+    ) -> Self {
+        Self {
+            kind,
+            name: name.into(),
+            source: source.into(),
+            value,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LayerSummary {
+    pub name: String,
+    pub kind: ConfigLayerKind,
+    pub source: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct FieldCandidate {
+    pub layer: String,
+    pub kind: ConfigLayerKind,
+    pub source: String,
+    pub status: CandidateStatus,
+    pub value: JsonValue,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub blocked_by: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CandidateStatus {
+    Applied,
+    Shadowed,
+    Locked,
+    Denied,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct FieldExplanation {
+    pub path: String,
+    pub value: JsonValue,
+    pub source: String,
+    pub layer: String,
+    pub kind: ConfigLayerKind,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub locked_by: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub denied_by: Option<String>,
+    pub candidates: Vec<FieldCandidate>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ResolvedConfig {
+    #[serde(skip_serializing)]
+    pub config: HarnConfig,
+    pub redacted_config: JsonValue,
+    pub layers: Vec<LayerSummary>,
+    pub explain: Vec<FieldExplanation>,
+}
+
+#[derive(Debug)]
+pub enum ConfigError {
+    ParseToml { source: String, message: String },
+    ParseJson { source: String, message: String },
+    InvalidConfig { source: String, message: String },
+    InvalidPath { path: String },
+}
+
+impl fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ConfigError::ParseToml { source, message } => {
+                write!(f, "failed to parse TOML config {source}: {message}")
+            }
+            ConfigError::ParseJson { source, message } => {
+                write!(f, "failed to parse JSON config {source}: {message}")
+            }
+            ConfigError::InvalidConfig { source, message } => {
+                write!(f, "invalid config {source}: {message}")
+            }
+            ConfigError::InvalidPath { path } => {
+                write!(f, "invalid config field path `{path}`")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ConfigError {}
+
+pub fn built_in_defaults_layer() -> ConfigLayer {
+    ConfigLayer::new(
+        ConfigLayerKind::BuiltInDefaults,
+        "built-in defaults",
+        "harn-vm",
+        serde_json::to_value(HarnConfig::default()).expect("default config serializes"),
+    )
+}
+
+pub fn layer_from_providers_config(
+    kind: ConfigLayerKind,
+    name: impl Into<String>,
+    source: impl Into<String>,
+    providers: &crate::llm_config::ProvidersConfig,
+) -> ConfigLayer {
+    let mut canonical_providers = JsonMap::new();
+    for (provider_name, provider) in &providers.providers {
+        canonical_providers.insert(
+            provider_name.clone(),
+            json!({
+                "base_url": provider.base_url,
+                "auth_env": crate::llm_config::auth_env_names(&provider.auth_env),
+                "capability_refs": provider.features,
+                "models": [],
+                "metadata": {
+                    "auth_style": provider.auth_style,
+                    "chat_endpoint": provider.chat_endpoint,
+                    "completion_endpoint": provider.completion_endpoint,
+                }
+            }),
+        );
+    }
+    for (model_id, model) in &providers.models {
+        let entry = canonical_providers
+            .entry(model.provider.clone())
+            .or_insert_with(|| {
+                json!({
+                    "base_url": null,
+                    "auth_env": [],
+                    "capability_refs": [],
+                    "models": [],
+                    "metadata": {}
+                })
+            });
+        if let Some(models) = entry.get_mut("models").and_then(JsonValue::as_array_mut) {
+            models.push(JsonValue::String(model_id.clone()));
+        }
+    }
+    let aliases = providers
+        .aliases
+        .iter()
+        .map(|(alias, entry)| {
+            (
+                alias.clone(),
+                json!({
+                    "model": entry.id,
+                    "provider": entry.provider,
+                    "capability_refs": [],
+                }),
+            )
+        })
+        .collect::<JsonMap<String, JsonValue>>();
+    ConfigLayer::new(
+        kind,
+        name,
+        source,
+        json!({
+            "models": {
+                "default_provider": providers.default_provider,
+                "providers": canonical_providers,
+                "aliases": aliases,
+            }
+        }),
+    )
+}
+
+pub fn parse_config_toml(
+    content: &str,
+    source: impl Into<String>,
+) -> Result<JsonValue, ConfigError> {
+    let source = source.into();
+    let value = toml::from_str::<toml::Value>(content).map_err(|error| ConfigError::ParseToml {
+        source: source.clone(),
+        message: sanitized_error_message(error),
+    })?;
+    let json = serde_json::to_value(value).map_err(|error| ConfigError::InvalidConfig {
+        source: source.clone(),
+        message: error.to_string(),
+    })?;
+    validate_layer_value(&json, &source)?;
+    Ok(json)
+}
+
+pub fn parse_config_json(
+    content: &str,
+    source: impl Into<String>,
+) -> Result<JsonValue, ConfigError> {
+    let source = source.into();
+    let json =
+        serde_json::from_str::<JsonValue>(content).map_err(|error| ConfigError::ParseJson {
+            source: source.clone(),
+            message: sanitized_error_message(error),
+        })?;
+    validate_layer_value(&json, &source)?;
+    Ok(json)
+}
+
+pub fn parse_manifest_config_table(
+    content: &str,
+    source: impl Into<String>,
+) -> Result<Option<JsonValue>, ConfigError> {
+    let source = source.into();
+    let value = toml::from_str::<toml::Value>(content).map_err(|error| ConfigError::ParseToml {
+        source: source.clone(),
+        message: sanitized_error_message(error),
+    })?;
+    let Some(table) = value.as_table() else {
+        return Ok(None);
+    };
+    let Some(config) = table.get("config") else {
+        return Ok(None);
+    };
+    let json = serde_json::to_value(config).map_err(|error| ConfigError::InvalidConfig {
+        source: source.clone(),
+        message: error.to_string(),
+    })?;
+    validate_layer_value(&json, &source)?;
+    Ok(Some(json))
+}
+
+pub fn environment_layer<I, K, V>(vars: I) -> Result<Option<ConfigLayer>, ConfigError>
+where
+    I: IntoIterator<Item = (K, V)>,
+    K: Into<String>,
+    V: Into<String>,
+{
+    let vars: BTreeMap<String, String> = vars
+        .into_iter()
+        .map(|(key, value)| (key.into(), value.into()))
+        .collect();
+    let mut value = match vars.get("HARN_CONFIG_JSON") {
+        Some(raw) if !raw.trim().is_empty() => parse_config_json(raw, "HARN_CONFIG_JSON")?,
+        _ => JsonValue::Object(JsonMap::new()),
+    };
+
+    set_env_string(
+        &mut value,
+        &vars,
+        "HARN_DEFAULT_PROVIDER",
+        "models.default_provider",
+    )?;
+    set_env_string(
+        &mut value,
+        &vars,
+        "HARN_DEFAULT_MODEL",
+        "models.default_model",
+    )?;
+    set_env_enum(&mut value, &vars, "HARN_LOG_LEVEL", "logging.level")?;
+    set_env_enum(&mut value, &vars, "HARN_REDACTION_MODE", "redaction.mode")?;
+    set_env_enum(&mut value, &vars, "HARN_NETWORK_MODE", "limits.network")?;
+    set_env_enum(
+        &mut value,
+        &vars,
+        "HARN_FILESYSTEM_MODE",
+        "limits.filesystem",
+    )?;
+    set_env_enum(&mut value, &vars, "HARN_SANDBOX_MODE", "limits.sandbox")?;
+    set_env_u64(&mut value, &vars, "HARN_RETENTION_DAYS", "retention.days")?;
+    set_env_u64(&mut value, &vars, "HARN_TOKEN_BUDGET", "limits.tokens")?;
+    set_env_u64(
+        &mut value,
+        &vars,
+        "HARN_MAX_CONCURRENCY",
+        "limits.concurrency",
+    )?;
+    set_env_f64(&mut value, &vars, "HARN_BUDGET_USD", "limits.budget_usd")?;
+    set_env_bool(&mut value, &vars, "HARN_REPLAY_ENABLED", "replay.enabled")?;
+
+    if value.as_object().is_some_and(JsonMap::is_empty) {
+        return Ok(None);
+    }
+    validate_layer_value(&value, "environment overrides")?;
+    Ok(Some(ConfigLayer::new(
+        ConfigLayerKind::EnvironmentOverrides,
+        "environment overrides",
+        "process environment",
+        value,
+    )))
+}
+
+pub fn merge_layers(layers: Vec<ConfigLayer>) -> Result<ResolvedConfig, ConfigError> {
+    let mut merged = JsonValue::Object(JsonMap::new());
+    let mut candidate_map: BTreeMap<String, Vec<FieldCandidate>> = BTreeMap::new();
+    let mut winner_map: BTreeMap<String, (String, String, ConfigLayerKind)> = BTreeMap::new();
+    let mut locked: BTreeMap<String, String> = BTreeMap::new();
+    let mut denied: BTreeMap<String, String> = BTreeMap::new();
+    let mut summaries = Vec::new();
+
+    for layer in layers {
+        validate_layer_value(&layer.value, &layer.source)?;
+        let display_source = redact_display(&layer.source);
+        summaries.push(LayerSummary {
+            name: layer.name.clone(),
+            kind: layer.kind,
+            source: display_source.clone(),
+        });
+
+        let leaves = leaf_values(&layer.value);
+        for (path, value) in leaves {
+            if path == "policy.locked_fields" || path == "policy.denied_fields" {
+                apply_candidate(
+                    &mut merged,
+                    &mut candidate_map,
+                    &mut winner_map,
+                    &layer,
+                    &path,
+                    value,
+                )?;
+                continue;
+            }
+            if let Some((policy_path, source)) = first_policy_match(&denied, &path) {
+                push_blocked_candidate(
+                    &mut candidate_map,
+                    &layer,
+                    &path,
+                    value,
+                    CandidateStatus::Denied,
+                    format!("{source} denied {policy_path}"),
+                );
+                continue;
+            }
+            if let Some((policy_path, source)) = first_policy_match(&locked, &path) {
+                push_blocked_candidate(
+                    &mut candidate_map,
+                    &layer,
+                    &path,
+                    value,
+                    CandidateStatus::Locked,
+                    format!("{source} locked {policy_path}"),
+                );
+                continue;
+            }
+            apply_candidate(
+                &mut merged,
+                &mut candidate_map,
+                &mut winner_map,
+                &layer,
+                &path,
+                value,
+            )?;
+        }
+
+        if layer.kind == ConfigLayerKind::ManagedPolicy {
+            for path in string_list_at(&layer.value, "policy.locked_fields") {
+                validate_field_path(&path)?;
+                locked.insert(path, display_source.clone());
+            }
+            for path in string_list_at(&layer.value, "policy.denied_fields") {
+                validate_field_path(&path)?;
+                denied.insert(path.clone(), display_source.clone());
+                apply_denied_policy(
+                    &mut merged,
+                    &mut candidate_map,
+                    &mut winner_map,
+                    &path,
+                    &display_source,
+                )?;
+            }
+        }
+    }
+
+    let config: HarnConfig =
+        serde_json::from_value(merged.clone()).map_err(|error| ConfigError::InvalidConfig {
+            source: "merged config".to_string(),
+            message: error.to_string(),
+        })?;
+    let redacted_config = current_policy().redact_json(&merged);
+    let mut explain = Vec::new();
+    for (path, value) in leaf_values(&merged) {
+        let Some((source, layer, kind)) = winner_map.get(&path).cloned() else {
+            continue;
+        };
+        let locked_by = first_policy_match(&locked, &path).map(|(_, source)| source);
+        let denied_by = first_policy_match(&denied, &path).map(|(_, source)| source);
+        let mut candidates = candidate_map.remove(&path).unwrap_or_default();
+        for candidate in &mut candidates {
+            candidate.value = redact_value_at_path(&path, candidate.value.clone());
+        }
+        explain.push(FieldExplanation {
+            path: path.clone(),
+            value: redact_value_at_path(&path, value),
+            source,
+            layer,
+            kind,
+            locked_by,
+            denied_by,
+            candidates,
+        });
+    }
+    for (path, mut candidates) in candidate_map {
+        if candidates.is_empty() {
+            continue;
+        }
+        for candidate in &mut candidates {
+            candidate.value = redact_value_at_path(&path, candidate.value.clone());
+        }
+        let locked_by = first_policy_match(&locked, &path).map(|(_, source)| source);
+        let denied_by = first_policy_match(&denied, &path).map(|(_, source)| source);
+        explain.push(FieldExplanation {
+            path: path.clone(),
+            value: JsonValue::Null,
+            source: "<blocked>".to_string(),
+            layer: "<blocked>".to_string(),
+            kind: candidates
+                .last()
+                .map(|candidate| candidate.kind)
+                .unwrap_or(ConfigLayerKind::BuiltInDefaults),
+            locked_by,
+            denied_by,
+            candidates,
+        });
+    }
+    explain.sort_by(|left, right| left.path.cmp(&right.path));
+    Ok(ResolvedConfig {
+        config,
+        redacted_config,
+        layers: summaries,
+        explain,
+    })
+}
+
+pub fn validate_policy_paths(value: &JsonValue) -> Result<(), ConfigError> {
+    for path in string_list_at(value, "policy.locked_fields")
+        .into_iter()
+        .chain(string_list_at(value, "policy.denied_fields"))
+    {
+        validate_field_path(&path)?;
+    }
+    Ok(())
+}
+
+pub fn schema_json() -> JsonValue {
+    json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": CONFIG_SCHEMA_ID,
+        "title": "Harn runtime config",
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "schema_version": {"type": "integer", "const": CONFIG_SCHEMA_VERSION},
+            "models": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "default_provider": {"type": ["string", "null"]},
+                    "default_model": {"type": ["string", "null"]},
+                    "capability_refs": {"type": "array", "items": {"type": "string"}},
+                    "providers": {"type": "object", "additionalProperties": {"$ref": "#/$defs/provider"}},
+                    "aliases": {"type": "object", "additionalProperties": {"$ref": "#/$defs/model_alias"}}
+                }
+            },
+            "permissions": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "default": {"$ref": "#/$defs/permission_mode"},
+                    "capabilities": {"type": "object", "additionalProperties": {"$ref": "#/$defs/permission_mode"}}
+                }
+            },
+            "endpoints": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "mcp": {"type": "object", "additionalProperties": {"$ref": "#/$defs/endpoint"}},
+                    "a2a": {"type": "object", "additionalProperties": {"$ref": "#/$defs/endpoint"}},
+                    "acp": {"type": "object", "additionalProperties": {"$ref": "#/$defs/endpoint"}}
+                }
+            },
+            "packages": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "sources": {"type": "array", "items": {"$ref": "#/$defs/source"}},
+                    "lockfile": {"type": ["string", "null"]}
+                }
+            },
+            "skills": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "paths": {"type": "array", "items": {"type": "string"}},
+                    "sources": {"type": "array", "items": {"$ref": "#/$defs/source"}}
+                }
+            },
+            "plugins": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "sources": {"type": "array", "items": {"$ref": "#/$defs/source"}}
+                }
+            },
+            "logging": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "level": {"enum": ["error", "warn", "info", "debug", "trace"]},
+                    "format": {"type": "string"},
+                    "file": {"type": ["string", "null"]}
+                }
+            },
+            "retention": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "days": {"type": ["integer", "null"], "minimum": 0},
+                    "max_bytes": {"type": ["integer", "null"], "minimum": 0}
+                }
+            },
+            "redaction": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "mode": {"enum": ["off", "standard", "strict"]},
+                    "extra_fields": {"type": "array", "items": {"type": "string"}},
+                    "extra_url_params": {"type": "array", "items": {"type": "string"}}
+                }
+            },
+            "replay": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "enabled": {"type": "boolean"},
+                    "directory": {"type": ["string", "null"]}
+                }
+            },
+            "limits": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "budget_usd": {"type": ["number", "null"], "minimum": 0},
+                    "tokens": {"type": ["integer", "null"], "minimum": 0},
+                    "concurrency": {"type": ["integer", "null"], "minimum": 0},
+                    "network": {"enum": ["allow", "ask", "deny", "offline"]},
+                    "filesystem": {"enum": ["read-write", "read-only", "sandboxed"]},
+                    "sandbox": {"enum": ["host", "process", "container", "worktree"]}
+                }
+            },
+            "policy": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "locked_fields": {"type": "array", "items": {"type": "string"}},
+                    "denied_fields": {"type": "array", "items": {"type": "string"}}
+                }
+            }
+        },
+        "$defs": {
+            "permission_mode": {"enum": ["allow", "ask", "deny"]},
+            "provider": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "base_url": {"type": ["string", "null"]},
+                    "auth_env": {"type": "array", "items": {"type": "string"}},
+                    "capability_refs": {"type": "array", "items": {"type": "string"}},
+                    "models": {"type": "array", "items": {"type": "string"}},
+                    "metadata": {"type": "object"}
+                }
+            },
+            "model_alias": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "model": {"type": "string"},
+                    "provider": {"type": "string"},
+                    "capability_refs": {"type": "array", "items": {"type": "string"}}
+                }
+            },
+            "endpoint": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "enabled": {"type": "boolean"},
+                    "url": {"type": ["string", "null"]},
+                    "command": {"type": "array", "items": {"type": "string"}},
+                    "transport": {"type": ["string", "null"]},
+                    "headers": {"type": "object", "additionalProperties": {"type": "string"}}
+                }
+            },
+            "source": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "name": {"type": "string"},
+                    "kind": {"type": "string"},
+                    "url": {"type": ["string", "null"]},
+                    "path": {"type": ["string", "null"]},
+                    "trust": {"type": ["string", "null"]}
+                }
+            }
+        }
+    })
+}
+
+pub fn install_config_path_for_os(os: &str, program_data: Option<&str>) -> PathBuf {
+    if os == "windows" {
+        PathBuf::from(program_data.unwrap_or(r"C:\ProgramData")).join(r"Harn\config.toml")
+    } else {
+        PathBuf::from("/etc/harn/config.toml")
+    }
+}
+
+pub fn user_config_path_for_os(
+    os: &str,
+    home: Option<&str>,
+    xdg_config_home: Option<&str>,
+    appdata: Option<&str>,
+) -> Option<PathBuf> {
+    if os == "windows" {
+        return appdata.map(|root| PathBuf::from(root).join(r"Harn\config.toml"));
+    }
+    if let Some(root) = xdg_config_home.filter(|value| !value.trim().is_empty()) {
+        return Some(PathBuf::from(root).join("harn").join("config.toml"));
+    }
+    home.map(|root| {
+        PathBuf::from(root)
+            .join(".config")
+            .join("harn")
+            .join("config.toml")
+    })
+}
+
+fn validate_layer_value(value: &JsonValue, source: &str) -> Result<(), ConfigError> {
+    serde_json::from_value::<HarnConfig>(value.clone()).map_err(|error| {
+        ConfigError::InvalidConfig {
+            source: source.to_string(),
+            message: error.to_string(),
+        }
+    })?;
+    Ok(())
+}
+
+fn sanitized_error_message(error: impl ToString) -> String {
+    let message = error
+        .to_string()
+        .lines()
+        .next()
+        .unwrap_or("parse error")
+        .to_string();
+    current_policy().redact_string(&message).into_owned()
+}
+
+fn set_env_string(
+    value: &mut JsonValue,
+    vars: &BTreeMap<String, String>,
+    env_key: &str,
+    path: &str,
+) -> Result<(), ConfigError> {
+    if let Some(raw) = vars
+        .get(env_key)
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+    {
+        set_path(value, path, JsonValue::String(raw.to_string()))?;
+    }
+    Ok(())
+}
+
+fn set_env_enum(
+    value: &mut JsonValue,
+    vars: &BTreeMap<String, String>,
+    env_key: &str,
+    path: &str,
+) -> Result<(), ConfigError> {
+    if let Some(raw) = vars
+        .get(env_key)
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+    {
+        let normalized = raw.to_ascii_lowercase().replace('_', "-");
+        set_path(value, path, JsonValue::String(normalized))?;
+    }
+    Ok(())
+}
+
+fn set_env_u64(
+    value: &mut JsonValue,
+    vars: &BTreeMap<String, String>,
+    env_key: &str,
+    path: &str,
+) -> Result<(), ConfigError> {
+    if let Some(raw) = vars
+        .get(env_key)
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+    {
+        let parsed = raw
+            .parse::<u64>()
+            .map_err(|error| ConfigError::InvalidConfig {
+                source: env_key.to_string(),
+                message: error.to_string(),
+            })?;
+        set_path(value, path, json!(parsed))?;
+    }
+    Ok(())
+}
+
+fn set_env_f64(
+    value: &mut JsonValue,
+    vars: &BTreeMap<String, String>,
+    env_key: &str,
+    path: &str,
+) -> Result<(), ConfigError> {
+    if let Some(raw) = vars
+        .get(env_key)
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+    {
+        let parsed = raw
+            .parse::<f64>()
+            .map_err(|error| ConfigError::InvalidConfig {
+                source: env_key.to_string(),
+                message: error.to_string(),
+            })?;
+        set_path(value, path, json!(parsed))?;
+    }
+    Ok(())
+}
+
+fn set_env_bool(
+    value: &mut JsonValue,
+    vars: &BTreeMap<String, String>,
+    env_key: &str,
+    path: &str,
+) -> Result<(), ConfigError> {
+    if let Some(raw) = vars
+        .get(env_key)
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+    {
+        let parsed = match raw.to_ascii_lowercase().as_str() {
+            "1" | "true" | "yes" | "on" => true,
+            "0" | "false" | "no" | "off" => false,
+            _ => {
+                return Err(ConfigError::InvalidConfig {
+                    source: env_key.to_string(),
+                    message: "expected one of true/false, yes/no, on/off, or 1/0".to_string(),
+                });
+            }
+        };
+        set_path(value, path, json!(parsed))?;
+    }
+    Ok(())
+}
+
+fn apply_candidate(
+    merged: &mut JsonValue,
+    candidate_map: &mut BTreeMap<String, Vec<FieldCandidate>>,
+    winner_map: &mut BTreeMap<String, (String, String, ConfigLayerKind)>,
+    layer: &ConfigLayer,
+    path: &str,
+    value: JsonValue,
+) -> Result<(), ConfigError> {
+    if let Some(candidates) = candidate_map.get_mut(path) {
+        if let Some(previous) = candidates
+            .iter_mut()
+            .rev()
+            .find(|candidate| candidate.status == CandidateStatus::Applied)
+        {
+            previous.status = CandidateStatus::Shadowed;
+        }
+    }
+    set_path(merged, path, value.clone())?;
+    candidate_map
+        .entry(path.to_string())
+        .or_default()
+        .push(FieldCandidate {
+            layer: layer.name.clone(),
+            kind: layer.kind,
+            source: redact_display(&layer.source),
+            status: CandidateStatus::Applied,
+            value,
+            blocked_by: None,
+        });
+    winner_map.insert(
+        path.to_string(),
+        (
+            redact_display(&layer.source),
+            layer.name.clone(),
+            layer.kind,
+        ),
+    );
+    Ok(())
+}
+
+fn push_blocked_candidate(
+    candidate_map: &mut BTreeMap<String, Vec<FieldCandidate>>,
+    layer: &ConfigLayer,
+    path: &str,
+    value: JsonValue,
+    status: CandidateStatus,
+    blocked_by: String,
+) {
+    candidate_map
+        .entry(path.to_string())
+        .or_default()
+        .push(FieldCandidate {
+            layer: layer.name.clone(),
+            kind: layer.kind,
+            source: redact_display(&layer.source),
+            status,
+            value,
+            blocked_by: Some(blocked_by),
+        });
+}
+
+fn apply_denied_policy(
+    merged: &mut JsonValue,
+    candidate_map: &mut BTreeMap<String, Vec<FieldCandidate>>,
+    winner_map: &mut BTreeMap<String, (String, String, ConfigLayerKind)>,
+    policy_path: &str,
+    policy_source: &str,
+) -> Result<(), ConfigError> {
+    remove_path(merged, policy_path)?;
+    let blocked_by = format!("{policy_source} denied {policy_path}");
+    let keys = candidate_map
+        .keys()
+        .filter(|candidate_path| policy_path_matches(policy_path, candidate_path))
+        .cloned()
+        .collect::<Vec<_>>();
+
+    for path in keys {
+        let mut fallback = None;
+        if let Some(candidates) = candidate_map.get_mut(&path) {
+            for candidate in candidates.iter_mut() {
+                if candidate.kind == ConfigLayerKind::BuiltInDefaults {
+                    candidate.status = CandidateStatus::Applied;
+                    candidate.blocked_by = None;
+                    fallback = Some((
+                        candidate.value.clone(),
+                        candidate.source.clone(),
+                        candidate.layer.clone(),
+                        candidate.kind,
+                    ));
+                } else {
+                    candidate.status = CandidateStatus::Denied;
+                    candidate.blocked_by = Some(blocked_by.clone());
+                }
+            }
+        }
+
+        if let Some((value, source, layer, kind)) = fallback {
+            set_path(merged, &path, value)?;
+            winner_map.insert(path, (source, layer, kind));
+        } else {
+            remove_path(merged, &path)?;
+            winner_map.remove(&path);
+        }
+    }
+    Ok(())
+}
+
+fn leaf_values(value: &JsonValue) -> Vec<(String, JsonValue)> {
+    let mut leaves = Vec::new();
+    collect_leaf_values(value, "", &mut leaves);
+    leaves
+}
+
+fn collect_leaf_values(value: &JsonValue, prefix: &str, leaves: &mut Vec<(String, JsonValue)>) {
+    match value {
+        JsonValue::Object(map) if !map.is_empty() => {
+            for (key, child) in map {
+                let next = if prefix.is_empty() {
+                    key.clone()
+                } else {
+                    format!("{prefix}.{key}")
+                };
+                collect_leaf_values(child, &next, leaves);
+            }
+        }
+        JsonValue::Object(_) if prefix.is_empty() => {}
+        _ if !prefix.is_empty() => leaves.push((prefix.to_string(), value.clone())),
+        _ => {}
+    }
+}
+
+fn set_path(root: &mut JsonValue, path: &str, value: JsonValue) -> Result<(), ConfigError> {
+    validate_field_path(path)?;
+    let parts: Vec<&str> = path.split('.').collect();
+    if !root.is_object() {
+        *root = JsonValue::Object(JsonMap::new());
+    }
+    let mut cursor = root;
+    for part in &parts[..parts.len() - 1] {
+        let object = cursor
+            .as_object_mut()
+            .ok_or_else(|| ConfigError::InvalidPath {
+                path: path.to_string(),
+            })?;
+        cursor = object
+            .entry((*part).to_string())
+            .or_insert_with(|| JsonValue::Object(JsonMap::new()));
+    }
+    let object = cursor
+        .as_object_mut()
+        .ok_or_else(|| ConfigError::InvalidPath {
+            path: path.to_string(),
+        })?;
+    object.insert(parts[parts.len() - 1].to_string(), value);
+    Ok(())
+}
+
+fn remove_path(root: &mut JsonValue, path: &str) -> Result<(), ConfigError> {
+    validate_field_path(path)?;
+    let parts = path.split('.').collect::<Vec<_>>();
+    remove_path_parts(root, &parts);
+    Ok(())
+}
+
+fn remove_path_parts(value: &mut JsonValue, parts: &[&str]) -> bool {
+    let Some((part, rest)) = parts.split_first() else {
+        return false;
+    };
+    let Some(object) = value.as_object_mut() else {
+        return false;
+    };
+    if rest.is_empty() {
+        object.remove(*part);
+    } else if let Some(child) = object.get_mut(*part) {
+        if remove_path_parts(child, rest) {
+            object.remove(*part);
+        }
+    }
+    object.is_empty()
+}
+
+fn validate_field_path(path: &str) -> Result<(), ConfigError> {
+    let valid = !path.trim().is_empty()
+        && path
+            .split('.')
+            .all(|part| !part.is_empty() && part.chars().all(valid_path_char));
+    if valid {
+        Ok(())
+    } else {
+        Err(ConfigError::InvalidPath {
+            path: path.to_string(),
+        })
+    }
+}
+
+fn valid_path_char(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-')
+}
+
+fn first_policy_match(policies: &BTreeMap<String, String>, path: &str) -> Option<(String, String)> {
+    policies
+        .iter()
+        .find(|(policy_path, _)| policy_path_matches(policy_path, path))
+        .map(|(policy_path, source)| (policy_path.clone(), source.clone()))
+}
+
+fn policy_path_matches(policy_path: &str, candidate_path: &str) -> bool {
+    candidate_path == policy_path
+        || candidate_path
+            .strip_prefix(policy_path)
+            .is_some_and(|suffix| suffix.starts_with('.'))
+        || policy_path
+            .strip_prefix(candidate_path)
+            .is_some_and(|suffix| suffix.starts_with('.'))
+}
+
+fn string_list_at(value: &JsonValue, path: &str) -> Vec<String> {
+    let mut cursor = value;
+    for part in path.split('.') {
+        let Some(next) = cursor.get(part) else {
+            return Vec::new();
+        };
+        cursor = next;
+    }
+    cursor
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(|item| item.as_str().map(str::to_string))
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn redact_value_at_path(path: &str, value: JsonValue) -> JsonValue {
+    let key = path.rsplit('.').next().unwrap_or(path);
+    let mut object = JsonMap::new();
+    object.insert(key.to_string(), value);
+    let redacted = current_policy().redact_json(&JsonValue::Object(object));
+    redacted
+        .get(key)
+        .cloned()
+        .unwrap_or(JsonValue::String("[redacted]".to_string()))
+}
+
+fn redact_display(value: &str) -> String {
+    let policy = current_policy();
+    if value.starts_with("http://") || value.starts_with("https://") {
+        if url::Url::parse(value).is_ok() {
+            return policy.redact_url(value);
+        }
+        return "[redacted]".to_string();
+    }
+    policy.redact_string(value).into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn layer(kind: ConfigLayerKind, name: &str, value: JsonValue) -> ConfigLayer {
+        ConfigLayer::new(kind, name, name, value)
+    }
+
+    #[test]
+    fn precedence_tracks_winner_and_shadowed_candidates() {
+        let resolved = merge_layers(vec![
+            built_in_defaults_layer(),
+            layer(
+                ConfigLayerKind::UserConfig,
+                "user",
+                json!({"logging": {"level": "warn"}}),
+            ),
+            layer(
+                ConfigLayerKind::ProjectConfig,
+                "project",
+                json!({"logging": {"level": "debug"}}),
+            ),
+        ])
+        .unwrap();
+
+        assert_eq!(resolved.config.logging.level, LogLevel::Debug);
+        let level = resolved
+            .explain
+            .iter()
+            .find(|field| field.path == "logging.level")
+            .expect("logging.level explanation");
+        assert_eq!(level.source, "project");
+        assert!(level
+            .candidates
+            .iter()
+            .any(|candidate| candidate.source == "user"
+                && candidate.status == CandidateStatus::Shadowed));
+    }
+
+    #[test]
+    fn managed_lock_blocks_later_environment_override() {
+        let resolved = merge_layers(vec![
+            built_in_defaults_layer(),
+            layer(
+                ConfigLayerKind::ManagedPolicy,
+                "managed",
+                json!({
+                    "limits": {"network": "offline"},
+                    "policy": {"locked_fields": ["limits.network"]}
+                }),
+            ),
+            layer(
+                ConfigLayerKind::EnvironmentOverrides,
+                "env",
+                json!({"limits": {"network": "allow"}}),
+            ),
+        ])
+        .unwrap();
+
+        assert_eq!(resolved.config.limits.network, NetworkMode::Offline);
+        let network = resolved
+            .explain
+            .iter()
+            .find(|field| field.path == "limits.network")
+            .expect("network explanation");
+        assert_eq!(network.locked_by.as_deref(), Some("managed"));
+        assert!(network
+            .candidates
+            .iter()
+            .any(|candidate| candidate.source == "env"
+                && candidate.status == CandidateStatus::Locked));
+    }
+
+    #[test]
+    fn managed_deny_blocks_later_field() {
+        let resolved = merge_layers(vec![
+            built_in_defaults_layer(),
+            layer(
+                ConfigLayerKind::ManagedPolicy,
+                "managed",
+                json!({"policy": {"denied_fields": ["endpoints.mcp.untrusted"]}}),
+            ),
+            layer(
+                ConfigLayerKind::ProjectConfig,
+                "project",
+                json!({"endpoints": {"mcp": {"untrusted": {"url": "https://example.com"}}}}),
+            ),
+        ])
+        .unwrap();
+
+        assert!(!resolved.config.endpoints.mcp.contains_key("untrusted"));
+        let candidates = resolved
+            .explain
+            .iter()
+            .flat_map(|field| field.candidates.iter())
+            .collect::<Vec<_>>();
+        assert!(candidates
+            .iter()
+            .any(|candidate| candidate.status == CandidateStatus::Denied));
+    }
+
+    #[test]
+    fn managed_deny_masks_lower_precedence_dynamic_fields() {
+        let resolved = merge_layers(vec![
+            built_in_defaults_layer(),
+            layer(
+                ConfigLayerKind::ProjectConfig,
+                "project",
+                json!({"endpoints": {"mcp": {"untrusted": {"url": "https://example.com"}}}}),
+            ),
+            layer(
+                ConfigLayerKind::ManagedPolicy,
+                "managed",
+                json!({"policy": {"denied_fields": ["endpoints.mcp.untrusted"]}}),
+            ),
+        ])
+        .unwrap();
+
+        assert!(!resolved.config.endpoints.mcp.contains_key("untrusted"));
+        let untrusted = resolved
+            .explain
+            .iter()
+            .find(|field| field.path == "endpoints.mcp.untrusted.url")
+            .expect("blocked endpoint explanation");
+        assert_eq!(untrusted.denied_by.as_deref(), Some("managed"));
+        assert!(untrusted
+            .candidates
+            .iter()
+            .any(|candidate| candidate.source == "project"
+                && candidate.status == CandidateStatus::Denied));
+    }
+
+    #[test]
+    fn secrets_are_redacted_in_config_and_explain() {
+        let resolved = merge_layers(vec![
+            built_in_defaults_layer(),
+            layer(
+                ConfigLayerKind::UserConfig,
+                "user",
+                json!({
+                    "endpoints": {
+                        "mcp": {
+                            "secret": {
+                                "headers": {"authorization": "Bearer sk_live_1234567890abcdef"}
+                            }
+                        }
+                    }
+                }),
+            ),
+        ])
+        .unwrap();
+
+        let rendered = serde_json::to_string(&resolved).unwrap();
+        assert!(!rendered.contains("sk_live_1234567890abcdef"));
+        assert!(rendered.contains("[redacted]"));
+    }
+
+    #[test]
+    fn sources_are_redacted_in_explain_output() {
+        let resolved = merge_layers(vec![
+            built_in_defaults_layer(),
+            ConfigLayer::new(
+                ConfigLayerKind::RemoteDefaults,
+                "remote",
+                "https://example.com/.well-known/harn?api_key=sk_live_1234567890abcdef",
+                json!({"logging": {"level": "debug"}}),
+            ),
+        ])
+        .unwrap();
+
+        let rendered = serde_json::to_string(&resolved).unwrap();
+        assert!(!rendered.contains("sk_live_1234567890abcdef"));
+        assert!(rendered.contains("api_key=%5Bredacted%5D"));
+    }
+
+    #[test]
+    fn parses_config_table_from_manifest() {
+        let value = parse_manifest_config_table(
+            r#"
+[package]
+name = "demo"
+
+[config.logging]
+level = "trace"
+"#,
+            "harn.toml",
+        )
+        .unwrap()
+        .expect("config table");
+        assert_eq!(value["logging"]["level"], "trace");
+    }
+
+    #[test]
+    fn environment_overrides_are_typed() {
+        let env = environment_layer([
+            ("HARN_LOG_LEVEL", "debug"),
+            ("HARN_TOKEN_BUDGET", "1200"),
+            ("HARN_REPLAY_ENABLED", "false"),
+        ])
+        .unwrap()
+        .expect("env layer");
+        let config: HarnConfig = serde_json::from_value(env.value).unwrap();
+        assert_eq!(config.logging.level, LogLevel::Debug);
+        assert_eq!(config.limits.tokens, Some(1200));
+        assert!(!config.replay.enabled);
+    }
+
+    #[test]
+    fn environment_bool_overrides_reject_unknown_values() {
+        let error = environment_layer([("HARN_REPLAY_ENABLED", "sometimes")]).unwrap_err();
+        assert!(error.to_string().contains("expected one of"));
+    }
+
+    #[test]
+    fn parse_errors_do_not_echo_source_lines() {
+        let error = parse_config_toml(
+            "secret = \"sk_live_1234567890abcdef\"\n[",
+            "bad-config.toml",
+        )
+        .unwrap_err();
+        let rendered = error.to_string();
+        assert!(!rendered.contains("sk_live_1234567890abcdef"));
+    }
+
+    #[test]
+    fn schema_is_valid_json_schema_document() {
+        let schema = schema_json();
+        assert_eq!(schema["$id"], CONFIG_SCHEMA_ID);
+        assert_eq!(
+            schema["properties"]["limits"]["properties"]["network"]["enum"][3],
+            "offline"
+        );
+    }
+
+    #[test]
+    fn config_locations_are_cross_platform() {
+        assert_eq!(
+            install_config_path_for_os("linux", None),
+            PathBuf::from("/etc/harn/config.toml")
+        );
+        assert_eq!(
+            user_config_path_for_os("linux", Some("/home/me"), None, None),
+            Some(PathBuf::from("/home/me/.config/harn/config.toml"))
+        );
+        assert_eq!(
+            user_config_path_for_os("linux", Some("/home/me"), Some("/xdg"), None),
+            Some(PathBuf::from("/xdg/harn/config.toml"))
+        );
+        assert_eq!(
+            install_config_path_for_os("windows", Some(r"D:\ProgramData")),
+            PathBuf::from(r"D:\ProgramData").join(r"Harn\config.toml")
+        );
+        assert_eq!(
+            user_config_path_for_os("windows", None, None, Some(r"C:\Users\me\AppData\Roaming")),
+            Some(PathBuf::from(r"C:\Users\me\AppData\Roaming").join(r"Harn\config.toml"))
+        );
+    }
+}

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -16,6 +16,7 @@ mod builtin_id;
 pub mod checkpoint;
 mod chunk;
 mod compiler;
+pub mod config;
 pub mod connectors;
 pub mod corrections;
 pub mod egress;

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -40,6 +40,7 @@
   - [LLM providers](./llm/providers.md)
   - [Provider capability matrix](./provider-matrix.md)
   - [Provider catalog refresh workflow](./llm/provider-catalog-refresh.md)
+- [Layered runtime configuration](./configuration.md)
 - [Long-running tools](./long-running-tools.md)
 - [Tool surface validation](./tool-surface-validation.md)
 - [Cache stdlib](./stdlib/cache.md)

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -96,6 +96,28 @@ harn completions fish
 Generated completions include subcommands plus static candidates for known
 provider and model values.
 
+## harn config
+
+Inspect, validate, and emit schemas for layered runtime configuration.
+
+```bash
+harn config inspect
+harn config inspect --explain
+harn config inspect --config ./harn.config.toml --managed ./org-policy.toml --explain
+harn config validate ./harn.config.toml
+harn config schema --output docs/src/schemas/harn-config.schema.json
+```
+
+| Command | Description |
+|---|---|
+| `inspect` | Print the redacted merged runtime config |
+| `inspect --explain` | Include per-field provenance, shadowed candidates, and managed policy lock status |
+| `validate` | Validate local, project, or managed overlays against the typed config shape |
+| `schema` | Print the editor JSON Schema for `harn.config.toml` |
+
+See [Layered runtime configuration](./configuration.md) for precedence, file
+locations, environment override names, and managed policy examples.
+
 ## harn playground
 
 Run a pipeline against a Harn-native host module for fast local iteration.

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -1,0 +1,181 @@
+# Layered Runtime Configuration
+
+Harn runtime configuration is a typed, layered document used by the CLI, VM
+hosts, and downstream products to explain model policy, permissions, protocol
+endpoints, package and skill sources, logging, replay, redaction, and runtime
+limits.
+
+The canonical file shape is `harn.config.toml`. Existing `harn.toml` manifests
+can also carry a `[config]` table for repo-checked package or agent defaults.
+
+## Commands
+
+```bash
+harn config inspect
+harn config inspect --explain
+harn config inspect --config ./harn.config.toml --managed ./org-policy.toml --explain
+harn config validate ./harn.config.toml ./org-policy.toml
+harn config schema --output docs/src/schemas/harn-config.schema.json
+```
+
+`inspect --explain` prints the redacted merged config, each loaded layer, and a
+per-field explanation containing the winning source plus shadowed, locked, or
+denied candidates. Secret-shaped fields and high-confidence secret strings are
+redacted with the same runtime redaction policy used for transcripts and event
+logs.
+
+`validate` parses local, project, and managed overlays with the same typed
+schema used by `inspect`. When no path is provided, it validates discovered
+files.
+
+`schema` emits the JSON Schema used by editor integrations. The checked-in
+schema is available at `docs/src/schemas/harn-config.schema.json`.
+
+## Precedence
+
+Layers are merged from lowest to highest precedence:
+
+1. Built-in defaults compiled into `harn-vm`.
+2. Legacy provider compatibility from `HARN_PROVIDERS_CONFIG` or
+   `~/.config/harn/providers.toml`.
+3. Runtime install defaults.
+4. Remote defaults from an explicitly trusted URL.
+5. User config.
+6. Project config from the nearest `harn.config.toml`.
+7. Repo manifest config from the nearest `harn.toml` `[config]` table.
+8. Explicit `--config` files.
+9. Managed policy files.
+10. Environment overrides.
+
+Managed policies are merged before environment overrides so organizations can
+choose which fields stay adjustable. A managed file can set:
+
+```toml
+[policy]
+locked_fields = ["limits.network", "permissions.default"]
+denied_fields = ["endpoints.mcp.untrusted"]
+```
+
+Locked fields keep the managed value even if a later environment override tries
+to replace it. Denied fields reject later candidates entirely.
+
+## File Locations
+
+Runtime install defaults:
+
+| OS | Default path | Override |
+|---|---|---|
+| macOS/Linux | `/etc/harn/config.toml` | `HARN_CONFIG_INSTALL_DEFAULTS` |
+| Windows | `%PROGRAMDATA%\Harn\config.toml` | `HARN_CONFIG_INSTALL_DEFAULTS` |
+
+User config:
+
+| OS | Default path | Override |
+|---|---|---|
+| macOS/Linux | `$XDG_CONFIG_HOME/harn/config.toml`, or `~/.config/harn/config.toml` | `HARN_CONFIG_USER` |
+| Windows | `%APPDATA%\Harn\config.toml` | `HARN_CONFIG_USER` |
+
+Managed policy:
+
+| OS | Default path | Override |
+|---|---|---|
+| All | none | `HARN_CONFIG_MANAGED` |
+
+`HARN_CONFIG_INSTALL_DEFAULTS`, `HARN_CONFIG_USER`, and `HARN_CONFIG_MANAGED`
+accept platform path lists, so multiple files can be supplied with `:` on
+macOS/Linux or `;` on Windows.
+
+Project discovery walks up from the current directory, stops at `.git`, and
+checks at most 16 parent directories. It looks for `harn.config.toml` and
+`harn.toml`.
+
+Remote defaults use `HARN_CONFIG_REMOTE_DEFAULTS_URL` or
+`--remote-defaults-url`. Harn fetches them only when
+`HARN_CONFIG_TRUST_REMOTE=1` is present, and only from `https://` or localhost
+URLs. This keeps enterprise bootstrap explicit while leaving cloud policy
+distribution decoupled from local OSS Harn.
+
+## Environment Overrides
+
+Environment overrides are intentionally small and explainable:
+
+| Variable | Field |
+|---|---|
+| `HARN_CONFIG_JSON` | Arbitrary JSON config overlay |
+| `HARN_DEFAULT_PROVIDER` | `models.default_provider` |
+| `HARN_DEFAULT_MODEL` | `models.default_model` |
+| `HARN_LOG_LEVEL` | `logging.level` |
+| `HARN_RETENTION_DAYS` | `retention.days` |
+| `HARN_REDACTION_MODE` | `redaction.mode` |
+| `HARN_TOKEN_BUDGET` | `limits.tokens` |
+| `HARN_BUDGET_USD` | `limits.budget_usd` |
+| `HARN_MAX_CONCURRENCY` | `limits.concurrency` |
+| `HARN_NETWORK_MODE` | `limits.network` |
+| `HARN_FILESYSTEM_MODE` | `limits.filesystem` |
+| `HARN_SANDBOX_MODE` | `limits.sandbox` |
+| `HARN_REPLAY_ENABLED` | `replay.enabled` |
+
+## Local OSS Example
+
+```toml
+schema_version = 1
+
+[models]
+default_provider = "ollama"
+default_model = "qwen3:14b"
+capability_refs = ["local-qwen"]
+
+[permissions]
+default = "ask"
+
+[limits]
+network = "ask"
+filesystem = "sandboxed"
+sandbox = "process"
+tokens = 200000
+concurrency = 4
+
+[logging]
+level = "info"
+
+[redaction]
+mode = "standard"
+extra_fields = ["internal_audit_token"]
+```
+
+## Org-Managed Example
+
+```toml
+[permissions]
+default = "deny"
+
+[limits]
+network = "offline"
+filesystem = "sandboxed"
+sandbox = "worktree"
+
+[retention]
+days = 14
+
+[policy]
+locked_fields = [
+  "permissions.default",
+  "limits.network",
+  "limits.filesystem",
+  "limits.sandbox",
+  "retention.days",
+]
+denied_fields = ["endpoints.mcp.experimental"]
+```
+
+## Compatibility
+
+Existing provider config keeps working. `HARN_PROVIDERS_CONFIG` and
+`~/.config/harn/providers.toml` are still consumed by the LLM runtime, and
+`harn config inspect --explain` projects that legacy provider surface into the
+canonical `models` section so teams can see where those values came from.
+
+Existing project manifests keep working as well. The richer package manifest
+schema still owns `[llm]`, `[capabilities]`, connectors, triggers, personas,
+and package metadata. New runtime policy belongs in `harn.config.toml` or in a
+`[config]` table inside `harn.toml` when it should be checked in with a package.

--- a/docs/src/schemas/harn-config.schema.json
+++ b/docs/src/schemas/harn-config.schema.json
@@ -1,0 +1,411 @@
+{
+  "$defs": {
+    "endpoint": {
+      "additionalProperties": false,
+      "properties": {
+        "command": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "headers": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "transport": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "url": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "model_alias": {
+      "additionalProperties": false,
+      "properties": {
+        "capability_refs": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "model": {
+          "type": "string"
+        },
+        "provider": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "permission_mode": {
+      "enum": [
+        "allow",
+        "ask",
+        "deny"
+      ]
+    },
+    "provider": {
+      "additionalProperties": false,
+      "properties": {
+        "auth_env": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "base_url": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "capability_refs": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "metadata": {
+          "type": "object"
+        },
+        "models": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "source": {
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "trust": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "url": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    }
+  },
+  "$id": "https://harnlang.com/schemas/harn-config.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "endpoints": {
+      "additionalProperties": false,
+      "properties": {
+        "a2a": {
+          "additionalProperties": {
+            "$ref": "#/$defs/endpoint"
+          },
+          "type": "object"
+        },
+        "acp": {
+          "additionalProperties": {
+            "$ref": "#/$defs/endpoint"
+          },
+          "type": "object"
+        },
+        "mcp": {
+          "additionalProperties": {
+            "$ref": "#/$defs/endpoint"
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "limits": {
+      "additionalProperties": false,
+      "properties": {
+        "budget_usd": {
+          "minimum": 0,
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "concurrency": {
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "filesystem": {
+          "enum": [
+            "read-write",
+            "read-only",
+            "sandboxed"
+          ]
+        },
+        "network": {
+          "enum": [
+            "allow",
+            "ask",
+            "deny",
+            "offline"
+          ]
+        },
+        "sandbox": {
+          "enum": [
+            "host",
+            "process",
+            "container",
+            "worktree"
+          ]
+        },
+        "tokens": {
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "logging": {
+      "additionalProperties": false,
+      "properties": {
+        "file": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "format": {
+          "type": "string"
+        },
+        "level": {
+          "enum": [
+            "error",
+            "warn",
+            "info",
+            "debug",
+            "trace"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "models": {
+      "additionalProperties": false,
+      "properties": {
+        "aliases": {
+          "additionalProperties": {
+            "$ref": "#/$defs/model_alias"
+          },
+          "type": "object"
+        },
+        "capability_refs": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "default_model": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "default_provider": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "providers": {
+          "additionalProperties": {
+            "$ref": "#/$defs/provider"
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "packages": {
+      "additionalProperties": false,
+      "properties": {
+        "lockfile": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "sources": {
+          "items": {
+            "$ref": "#/$defs/source"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "permissions": {
+      "additionalProperties": false,
+      "properties": {
+        "capabilities": {
+          "additionalProperties": {
+            "$ref": "#/$defs/permission_mode"
+          },
+          "type": "object"
+        },
+        "default": {
+          "$ref": "#/$defs/permission_mode"
+        }
+      },
+      "type": "object"
+    },
+    "plugins": {
+      "additionalProperties": false,
+      "properties": {
+        "sources": {
+          "items": {
+            "$ref": "#/$defs/source"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "policy": {
+      "additionalProperties": false,
+      "properties": {
+        "denied_fields": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "locked_fields": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "redaction": {
+      "additionalProperties": false,
+      "properties": {
+        "extra_fields": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "extra_url_params": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "mode": {
+          "enum": [
+            "off",
+            "standard",
+            "strict"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "replay": {
+      "additionalProperties": false,
+      "properties": {
+        "directory": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "retention": {
+      "additionalProperties": false,
+      "properties": {
+        "days": {
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "max_bytes": {
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "schema_version": {
+      "const": 1,
+      "type": "integer"
+    },
+    "skills": {
+      "additionalProperties": false,
+      "properties": {
+        "paths": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "sources": {
+          "items": {
+            "$ref": "#/$defs/source"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "title": "Harn runtime config",
+  "type": "object"
+}


### PR DESCRIPTION
## Summary

- Add a canonical typed Harn runtime config model and deterministic layered merge engine with per-field provenance, redacted explain output, managed locks, and managed denies.
- Add `harn config inspect`, `harn config validate`, and `harn config schema`, including discovery for install/user/project/manifest/managed/remote/env layers and legacy provider config projection.
- Add editor schema and documentation for precedence, OS paths, environment overrides, local OSS usage, org-managed usage, and compatibility notes.

Closes #1581

## Validation

- `cargo test -p harn-vm config::tests --no-default-features`
- `cargo test -p harn-cli config --no-default-features`
- `cargo run -p harn-cli --no-default-features -- config schema --output docs/src/schemas/harn-config.schema.json`
- live `harn config inspect --no-discovery --config ... --managed ... --explain` smoke with secret redaction, locked/denied candidates, JSON parsing, managed validation, and missing explicit file failure
- `make lint-test-patterns`
- `make check-docs-snippets`
- pre-commit hook: Rust format, clippy, generated highlight drift, markdown lint
- pre-push hook: targeted Cargo checks, markdown lint, generated highlight drift
