### PR TITLE
Surface Ollama context drift via /api/ps observation (#1600)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ Pre-0.6 highlights live in [CHANGELOG-pre-0.6.md](CHANGELOG-pre-0.6.md).
 Harn had no external users before 0.6.0, so that archive intentionally keeps
 condensed series summaries instead of full per-patch history.
 
+## Unreleased
+
+### Fixed
+
+- **Ollama warmup now applies `num_ctx` (#1600).** The `ollama_readiness`
+  warmup path previously sent `/api/generate` with only `keep_alive` set,
+  which caused Ollama to load the runner at the model's declared maximum
+  context (e.g. `262144` for `qwen3.6:35b-a3b-coding-nvfp4`) regardless of
+  `HARN_OLLAMA_NUM_CTX` or the catalog's `runtime_context_window`. The
+  warmup body now derives from `OllamaRuntimeSettings::warmup_body`, so
+  the runner is loaded at the same `num_ctx` chat/completion paths
+  request.
+
+### Added
+
+- **`/api/ps` observability in model-info (#1600).** `harn model-info
+  <alias> --verify` (and `--warm`) now hits `/api/ps`, surfaces the
+  loaded runner's `context_length`, and reports the `num_ctx` Harn would
+  request as `expected.num_ctx`. When the two diverge, `context_drift`
+  explains the load-time semantics and points at `ollama stop <model>`
+  for recovery. Also documented in `docs/src/llm/providers.md`.
+
 ## v0.8.14
 
 ### Added

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -1170,6 +1170,7 @@ async fn print_model_info(args: &ModelInfoArgs) -> bool {
         if resolved.provider == "ollama" {
             let mut readiness = harn_vm::llm::OllamaReadinessOptions::new(resolved.id.clone());
             readiness.warm = args.warm;
+            readiness.observe_loaded = true;
             readiness.keep_alive = args
                 .keep_alive
                 .as_deref()

--- a/crates/harn-vm/src/llm/api/ollama.rs
+++ b/crates/harn-vm/src/llm/api/ollama.rs
@@ -34,6 +34,46 @@ pub struct OllamaReadinessResult {
     pub keep_alive: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub warmup: Option<OllamaWarmupResult>,
+    /// Runtime settings Harn would inject into a request body for this
+    /// model, computed from env, provider overrides, and the catalog.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expected: Option<OllamaExpectedRequest>,
+    /// The matched runner reported by `/api/ps`, if the model is currently
+    /// loaded. The `context_length` field is the effective context the
+    /// loaded runner was started with — this is what `ollama ps` prints.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub loaded_runner: Option<OllamaLoadedRunner>,
+    /// Set when the loaded runner's `context_length` differs from the
+    /// `expected.num_ctx` Harn would request. Explains how to reload.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context_drift: Option<String>,
+}
+
+/// The runtime knobs Harn would attach to chat/completion/warmup
+/// requests for a given model. Surfaced by readiness so callers can
+/// compare it against what `/api/ps` says is actually loaded.
+#[derive(Debug, Clone, Serialize)]
+pub struct OllamaExpectedRequest {
+    pub num_ctx: u64,
+    pub keep_alive: Value,
+}
+
+/// One entry from `GET /api/ps` — a model the Ollama daemon currently
+/// has loaded into memory. `context_length` is the effective context
+/// the runner was started with and is fixed for the lifetime of the
+/// loaded process; reloading is required to change it.
+#[derive(Debug, Clone, Serialize)]
+pub struct OllamaLoadedRunner {
+    pub name: String,
+    pub model: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context_length: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub size_vram: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub size: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -44,6 +84,9 @@ pub struct OllamaReadinessOptions {
     pub keep_alive: Option<serde_json::Value>,
     pub tags_timeout: Duration,
     pub warmup_timeout: Duration,
+    /// Hit `/api/ps` and report any drift between the loaded runner's
+    /// `context_length` and the `num_ctx` Harn would request.
+    pub observe_loaded: bool,
 }
 
 impl OllamaReadinessOptions {
@@ -55,6 +98,7 @@ impl OllamaReadinessOptions {
             keep_alive: None,
             tags_timeout: Duration::from_secs(15),
             warmup_timeout: Duration::from_secs(135),
+            observe_loaded: false,
         }
     }
 }
@@ -64,12 +108,6 @@ impl OllamaReadinessOptions {
 /// to environment overrides.
 pub fn normalize_ollama_keep_alive(raw: &str) -> Option<serde_json::Value> {
     parse_keep_alive_str(raw)
-}
-
-/// Resolve the keep-alive override from `HARN_OLLAMA_KEEP_ALIVE` /
-/// `OLLAMA_KEEP_ALIVE`, normalized through [`normalize_ollama_keep_alive`].
-pub fn ollama_keep_alive_override() -> Option<serde_json::Value> {
-    keep_alive_from_env()
 }
 
 pub const OLLAMA_DEFAULT_NUM_CTX: u64 = 32_768;
@@ -334,24 +372,13 @@ fn apply_non_runtime_ollama_overrides(body: &mut Value, overrides: Option<&Value
 
 pub async fn ollama_readiness(options: OllamaReadinessOptions) -> OllamaReadinessResult {
     let base_url = options.base_url.unwrap_or_else(default_ollama_base_url);
+    let mut result = OllamaReadinessResult::probing(base_url.clone(), options.model.clone());
+
     let tags_url = match ollama_endpoint_url(&base_url, "/api/tags") {
         Ok(url) => url,
-        Err(message) => {
-            return OllamaReadinessResult {
-                valid: false,
-                status: "invalid_url".to_string(),
-                message,
-                base_url,
-                tags_url: String::new(),
-                model: options.model,
-                matched_model: None,
-                available_models: Vec::new(),
-                http_status: None,
-                keep_alive: None,
-                warmup: None,
-            };
-        }
+        Err(message) => return result.fail("invalid_url", message),
     };
+    result.tags_url = tags_url.clone();
 
     let client = crate::llm::shared_utility_client();
     let response = match client
@@ -362,143 +389,139 @@ pub async fn ollama_readiness(options: OllamaReadinessOptions) -> OllamaReadines
     {
         Ok(response) => response,
         Err(error) => {
-            return OllamaReadinessResult {
-                valid: false,
-                status: "daemon_down".to_string(),
-                message: format!("Ollama not reachable at {tags_url}: {error}"),
-                base_url,
-                tags_url,
-                model: options.model,
-                matched_model: None,
-                available_models: Vec::new(),
-                http_status: None,
-                keep_alive: None,
-                warmup: None,
-            };
+            return result.fail(
+                "daemon_down",
+                format!("Ollama not reachable at {tags_url}: {error}"),
+            );
         }
     };
 
     let status = response.status();
+    result.http_status = Some(status.as_u16());
     if !status.is_success() {
         let body = response.text().await.unwrap_or_default();
-        return OllamaReadinessResult {
-            valid: false,
-            status: "bad_status".to_string(),
-            message: format!(
-                "Ollama returned HTTP {} from /api/tags: {}",
-                status.as_u16(),
-                body
+        return result.fail(
+            "bad_status",
+            format!(
+                "Ollama returned HTTP {} from /api/tags: {body}",
+                status.as_u16()
             ),
-            base_url,
-            tags_url,
-            model: options.model,
-            matched_model: None,
-            available_models: Vec::new(),
-            http_status: Some(status.as_u16()),
-            keep_alive: None,
-            warmup: None,
-        };
+        );
     }
 
-    let body: serde_json::Value = match response.json().await {
+    let body: Value = match response.json().await {
         Ok(value) => value,
         Err(error) => {
-            return OllamaReadinessResult {
-                valid: false,
-                status: "invalid_response".to_string(),
-                message: format!("Could not parse Ollama model list: {error}"),
-                base_url,
-                tags_url,
-                model: options.model,
-                matched_model: None,
-                available_models: Vec::new(),
-                http_status: Some(status.as_u16()),
-                keep_alive: None,
-                warmup: None,
-            };
+            return result.fail(
+                "invalid_response",
+                format!("Could not parse Ollama model list: {error}"),
+            );
         }
     };
 
     let Some(models) = parse_ollama_model_names(&body) else {
-        return OllamaReadinessResult {
-            valid: false,
-            status: "invalid_response".to_string(),
-            message: "Could not parse Ollama model list: missing models[].name".to_string(),
-            base_url,
-            tags_url,
-            model: options.model,
-            matched_model: None,
-            available_models: Vec::new(),
-            http_status: Some(status.as_u16()),
-            keep_alive: None,
-            warmup: None,
-        };
+        return result.fail(
+            "invalid_response",
+            "Could not parse Ollama model list: missing models[].name".to_string(),
+        );
     };
+    result.available_models = models.clone();
 
-    let matched_model = find_ollama_model_match(&models, &options.model);
-    let Some(matched) = matched_model.clone() else {
+    let Some(matched) = find_ollama_model_match(&models, &options.model) else {
         let available = if models.is_empty() {
             "(none)".to_string()
         } else {
             models.join(", ")
         };
-        return OllamaReadinessResult {
-            valid: false,
-            status: "model_missing".to_string(),
-            message: format!(
+        return result.fail(
+            "model_missing",
+            format!(
                 "Ollama model '{}' not found. Available: {available}",
                 options.model
             ),
-            base_url,
-            tags_url,
-            model: options.model,
-            matched_model: None,
-            available_models: models,
-            http_status: Some(status.as_u16()),
-            keep_alive: None,
-            warmup: None,
-        };
+        );
     };
+    result.matched_model = Some(matched.clone());
 
+    let settings = OllamaRuntimeSettings::from_env_overrides_and_model(None, Some(&matched));
+    result.expected = Some(OllamaExpectedRequest {
+        num_ctx: settings.num_ctx,
+        keep_alive: settings.keep_alive.clone(),
+    });
     let keep_alive = options
         .keep_alive
-        .or_else(ollama_keep_alive_override)
-        .or_else(|| Some(serde_json::json!("30m")));
-    let mut warmup = None;
-    let mut valid = true;
-    let mut readiness_status = "ok".to_string();
-    let mut message = format!("Ollama is reachable and model '{matched}' is available");
+        .clone()
+        .unwrap_or_else(|| settings.keep_alive.clone());
+    result.keep_alive = Some(keep_alive.clone());
 
+    result.message = format!("Ollama is reachable and model '{matched}' is available");
     if options.warm {
         let warm = ollama_warmup(
             &base_url,
             &matched,
-            keep_alive.clone(),
+            Some(keep_alive),
             options.warmup_timeout,
         )
         .await;
         if !warm.valid {
-            valid = false;
-            readiness_status = "warmup_failed".to_string();
-            message = warm.message.clone();
+            result.valid = false;
+            result.status = "warmup_failed".to_string();
+            result.message = warm.message.clone();
         } else {
-            message = format!("{message}; {}", warm.message);
+            result.message = format!("{}; {}", result.message, warm.message);
         }
-        warmup = Some(warm);
+        result.warmup = Some(warm);
     }
 
-    OllamaReadinessResult {
-        valid,
-        status: readiness_status,
-        message,
-        base_url,
-        tags_url,
-        model: options.model,
-        matched_model: Some(matched),
-        available_models: models,
-        http_status: Some(status.as_u16()),
-        keep_alive,
-        warmup,
+    if options.observe_loaded {
+        match fetch_ollama_loaded_runners(&base_url, options.tags_timeout).await {
+            Ok(runners) => {
+                if let Some(runner) = match_loaded_runner(runners, &matched) {
+                    if let Some(actual) = runner.context_length {
+                        if actual != settings.num_ctx {
+                            result.context_drift =
+                                Some(describe_context_drift(settings.num_ctx, actual));
+                        }
+                    }
+                    result.loaded_runner = Some(runner);
+                }
+            }
+            Err(error) => {
+                // /api/ps is best-effort; surface the failure in the
+                // message but don't fail the overall readiness check.
+                result.message = format!("{}; /api/ps probe skipped: {error}", result.message);
+            }
+        }
+    }
+
+    result
+}
+
+impl OllamaReadinessResult {
+    fn probing(base_url: String, model: String) -> Self {
+        Self {
+            valid: true,
+            status: "ok".to_string(),
+            message: String::new(),
+            base_url,
+            tags_url: String::new(),
+            model,
+            matched_model: None,
+            available_models: Vec::new(),
+            http_status: None,
+            keep_alive: None,
+            warmup: None,
+            expected: None,
+            loaded_runner: None,
+            context_drift: None,
+        }
+    }
+
+    fn fail(mut self, status: &str, message: String) -> Self {
+        self.valid = false;
+        self.status = status.to_string();
+        self.message = message;
+        self
     }
 }
 
@@ -552,6 +575,87 @@ fn find_ollama_model_match(models: &[String], selected: &str) -> Option<String> 
         .cloned()
 }
 
+/// Fetch the list of currently-loaded runners from Ollama's `/api/ps`
+/// endpoint. Returns an empty list when no models are loaded; returns an
+/// error when the daemon is unreachable or the response is malformed.
+pub async fn fetch_ollama_loaded_runners(
+    base_url: &str,
+    timeout: Duration,
+) -> Result<Vec<OllamaLoadedRunner>, String> {
+    let url = ollama_endpoint_url(base_url, "/api/ps")?;
+    let response = crate::llm::shared_utility_client()
+        .get(&url)
+        .timeout(timeout)
+        .send()
+        .await
+        .map_err(|error| format!("Ollama /api/ps not reachable at {url}: {error}"))?;
+    if !response.status().is_success() {
+        return Err(format!(
+            "Ollama returned HTTP {} from /api/ps",
+            response.status().as_u16()
+        ));
+    }
+    let body: Value = response
+        .json()
+        .await
+        .map_err(|error| format!("Could not parse Ollama /api/ps response: {error}"))?;
+    Ok(parse_ollama_loaded_runners(&body))
+}
+
+fn parse_ollama_loaded_runners(value: &Value) -> Vec<OllamaLoadedRunner> {
+    let Some(models) = value.get("models").and_then(Value::as_array) else {
+        return Vec::new();
+    };
+    models
+        .iter()
+        .filter_map(|entry| {
+            let name = entry.get("name").and_then(Value::as_str)?.to_string();
+            let model = entry
+                .get("model")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+                .unwrap_or_else(|| name.clone());
+            Some(OllamaLoadedRunner {
+                name,
+                model,
+                context_length: entry.get("context_length").and_then(Value::as_u64),
+                size_vram: entry.get("size_vram").and_then(Value::as_u64),
+                size: entry.get("size").and_then(Value::as_u64),
+                expires_at: entry
+                    .get("expires_at")
+                    .and_then(Value::as_str)
+                    .map(str::to_string),
+            })
+        })
+        .collect()
+}
+
+fn match_loaded_runner(
+    runners: Vec<OllamaLoadedRunner>,
+    model: &str,
+) -> Option<OllamaLoadedRunner> {
+    runners
+        .into_iter()
+        .find(|runner| runner.name == model || runner.model == model)
+}
+
+fn describe_context_drift(expected: u64, actual: u64) -> String {
+    if actual > expected {
+        format!(
+            "Loaded runner context_length={actual} exceeds expected num_ctx={expected}. \
+             Ollama keeps a runner at the context it was loaded with; run \
+             `ollama stop <model>` (or wait for keep_alive to expire) and let Harn \
+             re-warm it to apply the smaller context."
+        )
+    } else {
+        format!(
+            "Loaded runner context_length={actual} is smaller than expected \
+             num_ctx={expected}. The runner was loaded at a smaller context — \
+             unload with `ollama stop <model>` and let Harn re-warm to expand."
+        )
+    }
+}
+
 async fn ollama_warmup(
     base_url: &str,
     model: &str,
@@ -572,11 +676,14 @@ async fn ollama_warmup(
         }
     };
 
-    let mut body = serde_json::json!({
-        "model": model,
-        "prompt": "",
-        "stream": false,
-    });
+    // Derive the warmup body from runtime settings so num_ctx is loaded
+    // into the runner the same way chat/completion requests would. Without
+    // it, Ollama loads the model at its Modelfile-declared maximum
+    // context, and a subsequent chat request asking for a smaller
+    // num_ctx cannot shrink an already-loaded runner — see the
+    // "Effective vs. loaded context" section of docs/src/llm/providers.md.
+    let settings = OllamaRuntimeSettings::from_env_overrides_and_model(None, Some(model));
+    let mut body = settings.warmup_body(model);
     if let Some(value) = keep_alive {
         body["keep_alive"] = value;
     }
@@ -866,8 +973,28 @@ mod tests {
         assert_eq!(normalize_ollama_keep_alive("   "), None);
     }
 
+    fn readiness_options(model: &str, base_url: String) -> OllamaReadinessOptions {
+        OllamaReadinessOptions {
+            model: model.to_string(),
+            base_url: Some(base_url),
+            warm: false,
+            keep_alive: None,
+            tags_timeout: Duration::from_secs(2),
+            warmup_timeout: Duration::from_secs(2),
+            observe_loaded: false,
+        }
+    }
+
     #[test]
     fn ollama_readiness_verifies_model_and_warms_matched_tag() {
+        let _guard = env_lock().lock().expect("env lock");
+        let _env = [
+            ScopedEnvVar::set("HARN_OLLAMA_NUM_CTX", "65536"),
+            ScopedEnvVar::remove("OLLAMA_CONTEXT_LENGTH"),
+            ScopedEnvVar::remove("OLLAMA_NUM_CTX"),
+            ScopedEnvVar::remove("HARN_OLLAMA_KEEP_ALIVE"),
+            ScopedEnvVar::remove("OLLAMA_KEEP_ALIVE"),
+        ];
         let captured = Arc::new(Mutex::new(Vec::new()));
         let (addr, server) = spawn_stub(
             vec![
@@ -883,12 +1010,9 @@ mod tests {
         let result = tokio::runtime::Runtime::new()
             .expect("runtime")
             .block_on(ollama_readiness(OllamaReadinessOptions {
-                model: "qwen3".to_string(),
-                base_url: Some(format!("http://{addr}")),
                 warm: true,
                 keep_alive: Some(serde_json::json!(-1)),
-                tags_timeout: Duration::from_secs(2),
-                warmup_timeout: Duration::from_secs(2),
+                ..readiness_options("qwen3", format!("http://{addr}"))
             }));
 
         server.join().expect("stub server");
@@ -896,6 +1020,8 @@ mod tests {
         assert_eq!(result.status, "ok");
         assert_eq!(result.matched_model.as_deref(), Some("qwen3:latest"));
         assert!(result.warmup.as_ref().is_some_and(|warm| warm.valid));
+        let expected = result.expected.as_ref().expect("expected request");
+        assert_eq!(expected.num_ctx, 65_536);
 
         let requests = captured.lock().expect("captured requests");
         assert!(requests[0].starts_with("GET /api/tags "));
@@ -906,6 +1032,10 @@ mod tests {
         assert_eq!(json["prompt"], "");
         assert_eq!(json["stream"], false);
         assert_eq!(json["keep_alive"], -1);
+        assert_eq!(
+            json["options"]["num_ctx"], 65_536,
+            "warmup must inject num_ctx so Ollama loads the runner at the requested context — see issue #1600"
+        );
     }
 
     #[test]
@@ -918,20 +1048,207 @@ mod tests {
 
         let result = tokio::runtime::Runtime::new()
             .expect("runtime")
-            .block_on(ollama_readiness(OllamaReadinessOptions {
-                model: "qwen3".to_string(),
-                base_url: Some(format!("http://{addr}")),
-                warm: false,
-                keep_alive: None,
-                tags_timeout: Duration::from_secs(2),
-                warmup_timeout: Duration::from_secs(2),
-            }));
+            .block_on(ollama_readiness(readiness_options(
+                "qwen3",
+                format!("http://{addr}"),
+            )));
 
         server.join().expect("stub server");
         assert!(!result.valid);
         assert_eq!(result.status, "model_missing");
         assert_eq!(result.available_models, vec!["llama3.2:latest"]);
         assert!(result.message.contains("qwen3"));
+    }
+
+    #[test]
+    fn ollama_readiness_observes_loaded_runner_and_reports_no_drift() {
+        let _guard = env_lock().lock().expect("env lock");
+        let _env = [
+            ScopedEnvVar::set("HARN_OLLAMA_NUM_CTX", "32768"),
+            ScopedEnvVar::remove("OLLAMA_CONTEXT_LENGTH"),
+            ScopedEnvVar::remove("OLLAMA_NUM_CTX"),
+            ScopedEnvVar::remove("HARN_OLLAMA_KEEP_ALIVE"),
+            ScopedEnvVar::remove("OLLAMA_KEEP_ALIVE"),
+        ];
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let (addr, server) = spawn_stub(
+            vec![
+                (200, r#"{"models":[{"name":"qwen3:latest"}]}"#),
+                (
+                    200,
+                    r#"{"models":[{"name":"qwen3:latest","model":"qwen3:latest","context_length":32768,"size_vram":1234,"size":4321,"expires_at":"2026-05-13T12:00:00Z"}]}"#,
+                ),
+            ],
+            captured.clone(),
+        );
+
+        let result = tokio::runtime::Runtime::new()
+            .expect("runtime")
+            .block_on(ollama_readiness(OllamaReadinessOptions {
+                observe_loaded: true,
+                ..readiness_options("qwen3", format!("http://{addr}"))
+            }));
+
+        server.join().expect("stub server");
+        assert!(result.valid, "result was: {result:?}");
+        let runner = result.loaded_runner.expect("loaded runner present");
+        assert_eq!(runner.context_length, Some(32_768));
+        assert_eq!(runner.size_vram, Some(1234));
+        assert!(
+            result.context_drift.is_none(),
+            "no drift expected; got {:?}",
+            result.context_drift
+        );
+
+        let requests = captured.lock().expect("captured requests");
+        assert!(requests[0].starts_with("GET /api/tags "));
+        assert!(requests[1].starts_with("GET /api/ps "));
+    }
+
+    #[test]
+    fn ollama_readiness_flags_context_drift_when_loaded_exceeds_expected() {
+        let _guard = env_lock().lock().expect("env lock");
+        let _env = [
+            ScopedEnvVar::set("HARN_OLLAMA_NUM_CTX", "32768"),
+            ScopedEnvVar::remove("OLLAMA_CONTEXT_LENGTH"),
+            ScopedEnvVar::remove("OLLAMA_NUM_CTX"),
+            ScopedEnvVar::remove("HARN_OLLAMA_KEEP_ALIVE"),
+            ScopedEnvVar::remove("OLLAMA_KEEP_ALIVE"),
+        ];
+        let (addr, server) = spawn_stub(
+            vec![
+                (
+                    200,
+                    r#"{"models":[{"name":"qwen3.6:35b-a3b-coding-nvfp4"}]}"#,
+                ),
+                (
+                    200,
+                    r#"{"models":[{"name":"qwen3.6:35b-a3b-coding-nvfp4","model":"qwen3.6:35b-a3b-coding-nvfp4","context_length":262144}]}"#,
+                ),
+            ],
+            Arc::new(Mutex::new(Vec::new())),
+        );
+
+        let result = tokio::runtime::Runtime::new()
+            .expect("runtime")
+            .block_on(ollama_readiness(OllamaReadinessOptions {
+                observe_loaded: true,
+                ..readiness_options("qwen3.6:35b-a3b-coding-nvfp4", format!("http://{addr}"))
+            }));
+
+        server.join().expect("stub server");
+        assert!(result.valid, "result was: {result:?}");
+        let drift = result.context_drift.expect("drift expected");
+        assert!(drift.contains("262144"), "drift message: {drift}");
+        assert!(drift.contains("32768"), "drift message: {drift}");
+        assert!(
+            drift.contains("ollama stop"),
+            "drift message must teach the user how to recover: {drift}"
+        );
+    }
+
+    #[test]
+    fn ollama_readiness_uses_alias_resolved_runtime_settings() {
+        let _guard = env_lock().lock().expect("env lock");
+        let _env = [
+            ScopedEnvVar::remove("HARN_OLLAMA_NUM_CTX"),
+            ScopedEnvVar::remove("OLLAMA_CONTEXT_LENGTH"),
+            ScopedEnvVar::remove("OLLAMA_NUM_CTX"),
+            ScopedEnvVar::remove("HARN_OLLAMA_KEEP_ALIVE"),
+            ScopedEnvVar::remove("OLLAMA_KEEP_ALIVE"),
+        ];
+        crate::llm_config::clear_user_overrides();
+        let mut overlay = crate::llm_config::ProvidersConfig::default();
+        overlay.aliases.insert(
+            "qwen3.6-coding".to_string(),
+            crate::llm_config::AliasDef {
+                id: "qwen3.6:35b-a3b-coding-nvfp4".to_string(),
+                provider: "ollama".to_string(),
+                tool_format: None,
+            },
+        );
+        overlay.models.insert(
+            "qwen3.6:35b-a3b-coding-nvfp4".to_string(),
+            crate::llm_config::ModelDef {
+                name: "Qwen 3.6 Coding".to_string(),
+                provider: "ollama".to_string(),
+                context_window: 262_144,
+                runtime_context_window: Some(98_304),
+                stream_timeout: None,
+                capabilities: vec![],
+                pricing: None,
+                deprecated: false,
+                deprecation_note: None,
+                quality_tags: Vec::new(),
+                prefer_prefill_done: None,
+            },
+        );
+        crate::llm_config::set_user_overrides(Some(overlay));
+
+        let (resolved, _) = crate::llm_config::resolve_model("qwen3.6-coding");
+        assert_eq!(resolved, "qwen3.6:35b-a3b-coding-nvfp4");
+
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let (addr, server) = spawn_stub(
+            vec![
+                (
+                    200,
+                    r#"{"models":[{"name":"qwen3.6:35b-a3b-coding-nvfp4"}]}"#,
+                ),
+                (200, r#"{"response":"","done":true}"#),
+            ],
+            captured.clone(),
+        );
+
+        let result = tokio::runtime::Runtime::new()
+            .expect("runtime")
+            .block_on(ollama_readiness(OllamaReadinessOptions {
+                warm: true,
+                ..readiness_options(&resolved, format!("http://{addr}"))
+            }));
+
+        server.join().expect("stub server");
+        crate::llm_config::clear_user_overrides();
+
+        assert!(result.valid, "result was: {result:?}");
+        let expected = result.expected.expect("expected request populated");
+        assert_eq!(
+            expected.num_ctx, 98_304,
+            "alias-resolved model must pull runtime_context_window from the catalog"
+        );
+
+        let requests = captured.lock().expect("captured requests");
+        let warmup_body = requests[1].split("\r\n\r\n").nth(1).unwrap_or("");
+        let json: serde_json::Value = serde_json::from_str(warmup_body).expect("warmup body");
+        assert_eq!(json["options"]["num_ctx"], 98_304);
+    }
+
+    #[test]
+    fn fetch_ollama_loaded_runners_parses_optional_fields() {
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let (addr, server) = spawn_stub(
+            vec![(
+                200,
+                r#"{"models":[{"name":"a:latest","model":"a:latest"},{"name":"b:latest","model":"b:latest","context_length":8192,"size_vram":42,"expires_at":"now"}]}"#,
+            )],
+            captured,
+        );
+
+        let runners = tokio::runtime::Runtime::new()
+            .expect("runtime")
+            .block_on(fetch_ollama_loaded_runners(
+                &format!("http://{addr}"),
+                Duration::from_secs(2),
+            ))
+            .expect("ps response parses");
+        server.join().expect("stub server");
+
+        assert_eq!(runners.len(), 2);
+        assert_eq!(runners[0].name, "a:latest");
+        assert!(runners[0].context_length.is_none());
+        assert_eq!(runners[1].context_length, Some(8192));
+        assert_eq!(runners[1].size_vram, Some(42));
+        assert_eq!(runners[1].expires_at.as_deref(), Some("now"));
     }
 
     fn spawn_stub(

--- a/crates/harn-vm/src/llm/config_builtins.rs
+++ b/crates/harn-vm/src/llm/config_builtins.rs
@@ -426,6 +426,9 @@ async fn llm_healthcheck_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError>
             let (resolved_model, _) = llm_config::resolve_model(&model);
             let mut readiness = super::api::OllamaReadinessOptions::new(resolved_model);
             readiness.warm = warm;
+            readiness.observe_loaded = options
+                .and_then(|opts| opts.get("observe_loaded"))
+                .is_some_and(|value| matches!(value, VmValue::Bool(true)));
             readiness.base_url = options
                 .and_then(|opts| opts.get("base_url").or_else(|| opts.get("url")))
                 .map(|value| value.display())

--- a/docs/src/llm/providers.md
+++ b/docs/src/llm/providers.md
@@ -256,6 +256,50 @@ adapters and model aliases without editing Rust-side registration code.
   than this after the request starts, Harn emits one progress notification that
   the model is warming up.
 
+#### Effective vs. loaded context (`num_ctx` semantics)
+
+Ollama sets `num_ctx` once, when a model is **loaded** into memory. After
+that, the runner keeps the same context window for its lifetime — a chat
+request with a different `num_ctx` does *not* shrink an already-loaded
+runner; Ollama unloads and reloads only when the requested value changes
+substantially across requests.
+
+`ollama ps` (and `GET /api/ps`) report `context_length` for each loaded
+runner. That number is the **effective** context the runner will use, not
+the model's declared maximum.
+
+Common gotcha: a model whose Modelfile defaults to a large context (e.g.
+`qwen3.6:35b-a3b-coding-nvfp4` defaults to `262144`) will be loaded at
+that maximum if the first request to load it does not pass an explicit
+`num_ctx`. Subsequent Harn calls with `HARN_OLLAMA_NUM_CTX=32768` then
+appear to be ignored — they are not, but Ollama is reusing the larger
+runner.
+
+Inspect what is actually loaded vs. what Harn would request:
+
+```bash
+harn model-info qwen3.6-coding --verify --warm
+```
+
+The JSON output includes:
+
+- `expected.num_ctx` / `expected.keep_alive` — what Harn injects into
+  request bodies for this model.
+- `loaded_runner.context_length` — what `/api/ps` reports for the
+  matched runner, when present.
+- `context_drift` — a remediation message when the two diverge.
+
+If `context_drift` is set, force a reload with:
+
+```bash
+ollama stop qwen3.6:35b-a3b-coding-nvfp4
+harn model-info qwen3.6-coding --verify --warm
+```
+
+The new warmup correctly passes `options.num_ctx`, so the next load
+respects `HARN_OLLAMA_NUM_CTX` (or the catalog's
+`runtime_context_window`, in that priority order).
+
 ### Local OpenAI-compatible server
 
 - Endpoint: `<LOCAL_LLM_BASE_URL>/v1/chat/completions`


### PR DESCRIPTION
## Summary

- Fix `ollama_warmup` to inject `num_ctx` so warmup loads the runner at the same context chat/completion paths request — root cause of #1600 (Ollama loaded `qwen3.6:35b-a3b-coding-nvfp4` at its declared max `262144` instead of `HARN_OLLAMA_NUM_CTX=32768`).
- Add `/api/ps` observation to `OllamaReadinessResult` (gated by `observe_loaded`): `expected.{num_ctx,keep_alive}` shows what Harn would request, `loaded_runner.context_length` shows what `/api/ps` reports, `context_drift` explains how to recover with `ollama stop` when they diverge.
- `harn model-info <alias> --verify` enables the probe by default; script-callable `llm_healthcheck({observe_loaded: true, ...})` opts in explicitly.
- Document the load-time semantics (effective vs. loaded context, `ollama ps` reporting) in `docs/src/llm/providers.md`.

## Test plan

- [x] `cargo test -p harn-vm --lib llm::api::ollama::` (13/13 pass; new tests cover warmup body containing `num_ctx`, `/api/ps` observation success, drift detection on `qwen3.6:35b-a3b-coding-nvfp4`, alias-resolved `runtime_context_window` propagation, `/api/ps` parsing).
- [x] `cargo test -p harn-vm --lib llm::` (481/481 pass).
- [x] `cargo test -p harn-cli --lib` (505/505 pass).
- [x] `cargo test --workspace --lib` (1963/1963 pass).
- [x] `cargo clippy -p harn-vm -p harn-cli --all-targets -- -D warnings` clean.
- [x] `make lint-md` clean.
- [x] `make lint-test-patterns` clean.
- [x] `cargo run --bin harn -- test conformance --filter ollama` passes.

Closes #1600.

🤖 Generated with [Claude Code](https://claude.com/claude-code)