### PR TITLE
Add HarnWorkerStatus to protocol artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ Pre-0.6 highlights live in [CHANGELOG-pre-0.6.md](CHANGELOG-pre-0.6.md).
 Harn had no external users before 0.6.0, so that archive intentionally keeps
 condensed series summaries instead of full per-patch history.
 
+## Unreleased
+
+### Added
+
+- **`HarnWorkerStatus` protocol artifact.** `dump-protocol-artifacts` now
+  emits the canonical worker-status wire vocabulary
+  (`running`, `progressed`, `awaiting_input`, `completed`, `failed`,
+  `cancelled`) as a typed enum in every binding (TypeScript, Swift,
+  Python, Go) and a `harnWorkerStatuses` field on the manifest. Hosts
+  consuming `worker_lineage[].status` or `worker_update` payloads can now
+  vendor this enum instead of maintaining hand-rolled synonym buckets
+  for statuses Harn never emits (e.g. `succeeded`, `error`, `timed_out`).
+  `WorkerEvent::ALL` exposes the same set programmatically.
+
 ## v0.8.15
 
 ### Added

--- a/crates/harn-cli/src/commands/dump_protocol_artifacts.rs
+++ b/crates/harn-cli/src/commands/dump_protocol_artifacts.rs
@@ -16,7 +16,7 @@ use harn_serve::adapters::acp::{
     HARN_TOOL_LIFECYCLE_EXTENSION_FIELDS,
 };
 use harn_serve::{A2A_PROTOCOL_VERSION, MCP_PROTOCOL_VERSION};
-use harn_vm::agent_events::{ToolCallErrorCategory, ToolCallStatus};
+use harn_vm::agent_events::{ToolCallErrorCategory, ToolCallStatus, WorkerEvent};
 use harn_vm::tool_annotations::{SideEffectLevel, ToolKind};
 use serde::Serialize;
 use serde_json::json;
@@ -265,6 +265,7 @@ fn generate_manifest() -> Result<String, String> {
             "toolCallStatuses": tool_call_status_values(),
             "toolCallErrorCategories": tool_call_error_category_values(),
             "toolExecutorSimpleValues": ACP_TOOL_EXECUTOR_SIMPLE_VALUES,
+            "workerStatuses": worker_status_values(),
         },
         "a2a": {
             "protocolVersion": A2A_PROTOCOL_VERSION,
@@ -386,6 +387,11 @@ fn generate_typescript() -> String {
         "HARN_SIDE_EFFECT_LEVELS",
         &side_effect_level_values(),
         "HarnSideEffectLevel",
+    ));
+    out.push_str(&ts_array_owned(
+        "HARN_WORKER_STATUSES",
+        &worker_status_values(),
+        "HarnWorkerStatus",
     ));
     out.push_str(&ts_array(
         "A2A_TASK_STATES",
@@ -735,6 +741,7 @@ fn generate_swift() -> String {
         "HarnSideEffectLevel",
         &side_effect_level_values(),
     ));
+    out.push_str(&swift_enum("HarnWorkerStatus", &worker_status_values()));
     out.push_str(&swift_enum(
         "HarnA2ATaskState",
         &strs_to_strings(A2A_TASK_STATES),
@@ -1410,6 +1417,10 @@ fn generate_python() -> String {
         "HARN_SIDE_EFFECT_LEVELS",
         &side_effect_level_values(),
     ));
+    out.push_str(&py_const_tuple_owned(
+        "HARN_WORKER_STATUSES",
+        &worker_status_values(),
+    ));
     out.push_str(&py_const_tuple(
         "HARN_TOOL_LIFECYCLE_EXTENSION_FIELDS",
         HARN_TOOL_LIFECYCLE_EXTENSION_FIELDS,
@@ -1446,6 +1457,10 @@ fn generate_python() -> String {
     out.push_str(&py_str_enum_owned(
         "HarnSideEffectLevel",
         &side_effect_level_values(),
+    ));
+    out.push_str(&py_str_enum_owned(
+        "HarnWorkerStatus",
+        &worker_status_values(),
     ));
     out.push_str(&py_str_enum("A2ATaskState", A2A_TASK_STATES));
     out.push_str(&py_str_enum("A2ATaskEventType", A2A_TASK_EVENT_TYPES));
@@ -1726,6 +1741,7 @@ fn python_public_names() -> Vec<String> {
         "ACP_TOOL_CALL_STATUSES",
         "HARN_TOOL_CALL_ERROR_CATEGORIES",
         "HARN_SIDE_EFFECT_LEVELS",
+        "HARN_WORKER_STATUSES",
         "HARN_TOOL_LIFECYCLE_EXTENSION_FIELDS",
         "HARN_CONTENT_EXTENSION_FIELDS",
         "A2A_METHODS",
@@ -1741,6 +1757,7 @@ fn python_public_names() -> Vec<String> {
         "ACPToolCallStatus",
         "HarnToolCallErrorCategory",
         "HarnSideEffectLevel",
+        "HarnWorkerStatus",
         "A2ATaskState",
         "A2ATaskEventType",
         "MCPLoggingLevel",
@@ -1950,6 +1967,11 @@ fn generate_go() -> String {
         "HarnSideEffectLevel",
         "HarnSideEffectLevels",
         &side_effect_level_values(),
+    ));
+    out.push_str(&go_typed_array_owned(
+        "HarnWorkerStatus",
+        "HarnWorkerStatuses",
+        &worker_status_values(),
     ));
     out.push_str(&go_typed_array(
         "A2ATaskState",
@@ -2486,6 +2508,13 @@ fn tool_call_error_category_values() -> Vec<String> {
         .collect()
 }
 
+fn worker_status_values() -> Vec<String> {
+    WorkerEvent::ALL
+        .iter()
+        .map(|event| event.as_status().to_string())
+        .collect()
+}
+
 fn side_effect_level_values() -> Vec<String> {
     SideEffectLevel::ALL
         .iter()
@@ -2580,9 +2609,13 @@ mod tests {
             .into_iter()
             .chain(tool_call_status_values())
             .chain(tool_call_error_category_values())
+            .chain(worker_status_values())
         {
             assert!(swift.contains(&value), "Swift artifact missing {value}");
         }
+        assert!(swift.contains("public enum HarnWorkerStatus"));
+        assert!(ts.contains("export type HarnWorkerStatus"));
+        assert!(ts.contains("HARN_WORKER_STATUSES"));
     }
 
     #[test]
@@ -2590,6 +2623,7 @@ mod tests {
         let py = generate_python();
         assert!(py.contains("class ACPSessionUpdate(str, Enum):"));
         assert!(py.contains("class HarnToolCallErrorCategory(str, Enum):"));
+        assert!(py.contains("class HarnWorkerStatus(str, Enum):"));
         assert!(py.contains("class _HarnDataclass:"));
         assert!(py.contains("def is_request("));
         for value in HARN_SESSION_UPDATE_EXTENSIONS
@@ -2598,6 +2632,9 @@ mod tests {
             .chain(ACP_AGENT_METHODS.iter())
         {
             assert!(py.contains(value), "Python artifact missing {value}");
+        }
+        for value in worker_status_values() {
+            assert!(py.contains(&value), "Python artifact missing {value}");
         }
     }
 
@@ -2608,12 +2645,17 @@ mod tests {
         assert!(go.contains("type JSONRPCID struct"));
         assert!(go.contains("type ACPSessionUpdateNotification struct"));
         assert!(go.contains("func IsRequest(envelope map[string]json.RawMessage)"));
+        assert!(go.contains("type HarnWorkerStatus = string"));
+        assert!(go.contains("var HarnWorkerStatuses = []HarnWorkerStatus"));
         for value in HARN_SESSION_UPDATE_EXTENSIONS
             .iter()
             .chain(HARN_AGENT_EVENT_KINDS.iter())
             .chain(ACP_AGENT_METHODS.iter())
         {
             assert!(go.contains(value), "Go artifact missing {value}");
+        }
+        for value in worker_status_values() {
+            assert!(go.contains(&value), "Go artifact missing {value}");
         }
     }
 

--- a/crates/harn-vm/src/agent_events.rs
+++ b/crates/harn-vm/src/agent_events.rs
@@ -60,6 +60,19 @@ pub enum WorkerEvent {
 }
 
 impl WorkerEvent {
+    /// The full set of `WorkerEvent` variants in canonical order. Mirrors
+    /// the pattern used by `ToolCallStatus::ALL` so the protocol-artifact
+    /// dumper can enumerate worker status wire values without
+    /// special-casing each lifecycle event.
+    pub const ALL: [Self; 6] = [
+        Self::WorkerSpawned,
+        Self::WorkerProgressed,
+        Self::WorkerWaitingForInput,
+        Self::WorkerCompleted,
+        Self::WorkerFailed,
+        Self::WorkerCancelled,
+    ];
+
     /// Wire-level status string used by bridge `worker_update` payloads
     /// and ACP `worker_update` session updates. The four canonical
     /// states are mirrored from harn's internal worker `status` field
@@ -1567,6 +1580,25 @@ mod tests {
                 "{non_terminal:?} should not be terminal"
             );
         }
+
+        // `ALL` is the iteration order downstream protocol-artifact
+        // dumpers walk; keep it in lockstep with the variant list so a
+        // new event doesn't slip in without a wire-status decision.
+        let collected: Vec<&'static str> = WorkerEvent::ALL
+            .iter()
+            .map(|event| event.as_status())
+            .collect();
+        assert_eq!(
+            collected,
+            vec![
+                "running",
+                "progressed",
+                "awaiting_input",
+                "completed",
+                "failed",
+                "cancelled",
+            ]
+        );
     }
 
     #[test]

--- a/spec/protocol-artifacts/HarnProtocol.swift
+++ b/spec/protocol-artifacts/HarnProtocol.swift
@@ -148,6 +148,15 @@ public enum HarnSideEffectLevel: String, Codable, Sendable, CaseIterable {
     case network = "network"
 }
 
+public enum HarnWorkerStatus: String, Codable, Sendable, CaseIterable {
+    case running = "running"
+    case progressed = "progressed"
+    case awaitingInput = "awaiting_input"
+    case completed = "completed"
+    case failed = "failed"
+    case cancelled = "cancelled"
+}
+
 public enum HarnA2ATaskState: String, Codable, Sendable, CaseIterable {
     case submitted = "submitted"
     case working = "working"

--- a/spec/protocol-artifacts/go/harnprotocol/harnprotocol.go
+++ b/spec/protocol-artifacts/go/harnprotocol/harnprotocol.go
@@ -195,6 +195,19 @@ var HarnSideEffectLevels = []HarnSideEffectLevel{
 	"network",
 }
 
+// HarnWorkerStatus is the typed alias for the HarnWorkerStatuses wire vocabulary.
+type HarnWorkerStatus = string
+
+// HarnWorkerStatuses enumerates every wire value Harn currently emits for HarnWorkerStatus.
+var HarnWorkerStatuses = []HarnWorkerStatus{
+	"running",
+	"progressed",
+	"awaiting_input",
+	"completed",
+	"failed",
+	"cancelled",
+}
+
 // A2ATaskState is the typed alias for the A2ATaskStates wire vocabulary.
 type A2ATaskState = string
 

--- a/spec/protocol-artifacts/harn-protocol.ts
+++ b/spec/protocol-artifacts/harn-protocol.ts
@@ -142,6 +142,16 @@ export const HARN_SIDE_EFFECT_LEVELS = [
 ] as const
 export type HarnSideEffectLevel = (typeof HARN_SIDE_EFFECT_LEVELS)[number]
 
+export const HARN_WORKER_STATUSES = [
+  "running",
+  "progressed",
+  "awaiting_input",
+  "completed",
+  "failed",
+  "cancelled",
+] as const
+export type HarnWorkerStatus = (typeof HARN_WORKER_STATUSES)[number]
+
 export const A2A_TASK_STATES = [
   "submitted",
   "working",

--- a/spec/protocol-artifacts/manifest.json
+++ b/spec/protocol-artifacts/manifest.json
@@ -160,6 +160,14 @@
       "executor",
       "parsing",
       "rawInputPartial"
+    ],
+    "workerStatuses": [
+      "running",
+      "progressed",
+      "awaiting_input",
+      "completed",
+      "failed",
+      "cancelled"
     ]
   },
   "artifactVersion": "0.8.15",

--- a/spec/protocol-artifacts/python/harn_protocol.py
+++ b/spec/protocol-artifacts/python/harn_protocol.py
@@ -32,6 +32,7 @@ __all__ = [
     "ACP_TOOL_CALL_STATUSES",
     "HARN_TOOL_CALL_ERROR_CATEGORIES",
     "HARN_SIDE_EFFECT_LEVELS",
+    "HARN_WORKER_STATUSES",
     "HARN_TOOL_LIFECYCLE_EXTENSION_FIELDS",
     "HARN_CONTENT_EXTENSION_FIELDS",
     "A2A_METHODS",
@@ -47,6 +48,7 @@ __all__ = [
     "ACPToolCallStatus",
     "HarnToolCallErrorCategory",
     "HarnSideEffectLevel",
+    "HarnWorkerStatus",
     "A2ATaskState",
     "A2ATaskEventType",
     "MCPLoggingLevel",
@@ -202,6 +204,14 @@ HARN_SIDE_EFFECT_LEVELS: tuple = (
     "workspace_write",
     "process_exec",
     "network",
+)
+HARN_WORKER_STATUSES: tuple = (
+    "running",
+    "progressed",
+    "awaiting_input",
+    "completed",
+    "failed",
+    "cancelled",
 )
 HARN_TOOL_LIFECYCLE_EXTENSION_FIELDS: tuple = (
     "audit",
@@ -359,6 +369,15 @@ class HarnSideEffectLevel(str, Enum):
     WORKSPACE_WRITE = "workspace_write"
     PROCESS_EXEC = "process_exec"
     NETWORK = "network"
+
+
+class HarnWorkerStatus(str, Enum):
+    RUNNING = "running"
+    PROGRESSED = "progressed"
+    AWAITING_INPUT = "awaiting_input"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
 
 
 class A2ATaskState(str, Enum):


### PR DESCRIPTION
## Summary

- Add `HarnWorkerStatus` to `dump-protocol-artifacts` so downstream hosts (Burin Code, Harn Cloud, future SDKs) can vendor the canonical worker-status wire vocabulary instead of hand-rolling synonym buckets for statuses Harn never emits (e.g. `succeeded`, `error`, `timed_out`, `done`).
- Expose `WorkerEvent::ALL` so the protocol-artifact dumper can enumerate worker statuses without re-listing variants.
- Bundles the Ollama warmup + `/api/ps` observability fixes (#1600, #1601, #1602) already on `main` into the v0.8.15 release.

The new enum mirrors `WorkerEvent::as_status()`:

```
running, progressed, awaiting_input, completed, failed, cancelled
```

Generated artifacts gain:
- Swift: `public enum HarnWorkerStatus`
- TypeScript: `HARN_WORKER_STATUSES` const + `HarnWorkerStatus` type
- Python: `HarnWorkerStatus(str, Enum)` + `HARN_WORKER_STATUSES` tuple
- Go: `HarnWorkerStatus` typed alias + `HarnWorkerStatuses` slice
- Manifest: `acp.workerStatuses` field

Motivated by [burin-labs/burin-code#703](https://github.com/burin-labs/burin-code/issues/703) — the IDE sidebar and TUI inbox both hand-roll synonym buckets for `worker_lineage[].status`, and they disagree about which synonyms exist. Vendoring this enum lets both surfaces collapse to the canonical set.

## Test plan

- [x] `cargo test -p harn-vm worker_event` — `worker_event_status_strings_cover_all_variants` covers `WorkerEvent::ALL` + every wire string.
- [x] `cargo test -p harn-cli commands::dump_protocol_artifacts` — `generated_types_include_harn_wire_vocabularies`, `generated_python_includes_harn_wire_vocabularies`, `generated_go_includes_harn_wire_vocabularies`, and `committed_protocol_artifacts_match_generator` all exercise the new enum across the four bindings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)