### PR TITLE
Harden rust-cache cargo bin restores

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -154,6 +154,7 @@ jobs:
         with:
           shared-key: release-${{ matrix.target }}
           cache-on-failure: true
+          cache-bin: false
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Add cross-compile target to pinned toolchain

--- a/.github/workflows/bump-release.yml
+++ b/.github/workflows/bump-release.yml
@@ -109,6 +109,7 @@ jobs:
         if: steps.bump.outputs.skip != 'true'
         with:
           shared-key: workspace
+          cache-bin: false
 
       - name: Install cargo-nextest
         if: steps.bump.outputs.skip != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
         continue-on-error: true
         with:
           shared-key: workspace
+          cache-bin: false
       - name: Install cargo-nextest
         uses: taiki-e/install-action@c070f87102a1c75b3183910f391c1cb887fe13c8 # v2.77.6
         continue-on-error: true
@@ -141,6 +142,7 @@ jobs:
         with:
           shared-key: workspace-windows
           cache-on-failure: true
+          cache-bin: false
       - name: Install cargo-nextest
         uses: taiki-e/install-action@c070f87102a1c75b3183910f391c1cb887fe13c8 # v2.77.6
         continue-on-error: true
@@ -212,6 +214,7 @@ jobs:
         continue-on-error: true
         with:
           shared-key: e2e
+          cache-bin: false
       - name: Install cargo-nextest
         uses: taiki-e/install-action@c070f87102a1c75b3183910f391c1cb887fe13c8 # v2.77.6
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -37,6 +37,7 @@ jobs:
         continue-on-error: true
         with:
           shared-key: e2e
+          cache-bin: false
       - name: Install cargo-nextest
         uses: taiki-e/install-action@c070f87102a1c75b3183910f391c1cb887fe13c8 # v2.77.6
         with:

--- a/.github/workflows/flake-detection.yml
+++ b/.github/workflows/flake-detection.yml
@@ -75,6 +75,7 @@ jobs:
         continue-on-error: true
         with:
           shared-key: workspace
+          cache-bin: false
 
       - name: Install cargo-nextest
         if: steps.touched.outputs.has_tests == 'true'

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -215,6 +215,7 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           shared-key: workspace
+          cache-bin: false
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@c070f87102a1c75b3183910f391c1cb887fe13c8 # v2.77.6

--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -76,6 +76,21 @@ jobs:
           # boots quickly when the unit slice already filled the cache.
           shared-key: release-smoke-${{ matrix.platform }}
           cache-on-failure: true
+          # Keep rustup's freshly-installed cargo shim authoritative.
+          # Stale cached binaries can shadow it on macOS tag runners.
+          cache-bin: false
+      - name: Verify macOS Rust toolchain
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          set -euo pipefail
+          rustup show active-toolchain || rustup show
+          echo "cargo path: $(command -v cargo)"
+          echo "rustup cargo: $(rustup which cargo)"
+          echo "rustc path: $(command -v rustc)"
+          echo "rustup rustc: $(rustup which rustc)"
+          cargo --version
+          rustc --version
       - name: Build release harn binary
         shell: bash
         env:

--- a/.github/workflows/thread-parity.yml
+++ b/.github/workflows/thread-parity.yml
@@ -36,6 +36,7 @@ jobs:
         continue-on-error: true
         with:
           shared-key: workspace
+          cache-bin: false
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@c070f87102a1c75b3183910f391c1cb887fe13c8 # v2.77.6

--- a/.github/workflows/windows-nightly.yml
+++ b/.github/workflows/windows-nightly.yml
@@ -49,6 +49,7 @@ jobs:
           # piggy-back on whatever artifacts already landed today.
           shared-key: workspace-windows
           cache-on-failure: true
+          cache-bin: false
       - name: Install cargo-nextest
         uses: taiki-e/install-action@c070f87102a1c75b3183910f391c1cb887fe13c8 # v2.77.6
         with:


### PR DESCRIPTION
## Summary
- Disable Swatinem/rust-cache caching of `${CARGO_HOME}/bin` in every workflow so restored caches cannot shadow rustup cargo shims.
- Add a macOS release-smoke toolchain verification step before the release build so any recurrence logs cargo/rustc paths and versions before failing.

Fixes #1607

## Verification
- `make lint-actions`
- `git diff --check`
- pre-commit GitHub Actions workflow lint
- pre-push targeted checks