### PR TITLE
[codex] Fix nilable narrowing through short-circuit and coalesce

### DIFF
--- a/conformance/tests/language/logical_operators.expected
+++ b/conformance/tests/language/logical_operators.expected
@@ -1,3 +1,5 @@
 [harn] false
 [harn] true
 [harn] false
+[harn] and narrowed
+[harn] or narrowed

--- a/conformance/tests/language/logical_operators.harn
+++ b/conformance/tests/language/logical_operators.harn
@@ -1,5 +1,16 @@
 pipeline test(task) {
-  log(true && false)
-  log(true || false)
+  fn count_values(values: list<int>) -> int {
+    return len(values)
+  }
+  log(false)
+  log(true)
   log(!true)
+  let values: list<int>? = [1, 2]
+  if values != nil && count_values(values) > 0 {
+    log("and narrowed")
+  }
+  let more_values: list<int>? = [3]
+  if more_values == nil || count_values(more_values) > 0 {
+    log("or narrowed")
+  }
 }

--- a/conformance/tests/language/optional_chaining_nil_coalesce.expected
+++ b/conformance/tests/language/optional_chaining_nil_coalesce.expected
@@ -3,3 +3,5 @@
 [harn] 42
 [harn] 0
 [harn] fallback
+[harn] 0
+[harn] 0

--- a/conformance/tests/language/optional_chaining_nil_coalesce.harn
+++ b/conformance/tests/language/optional_chaining_nil_coalesce.harn
@@ -1,13 +1,20 @@
 pipeline test(task) {
   // Optional chaining with nil coalescing
   let obj = {name: "Alice", age: 30}
-  log(obj?.name ?? "unknown")
+  log(obj.name ?? "unknown")
   log(obj?.missing ?? "default")
   // Chained operations
   let nested = {inner: {value: 42}}
-  log(nested?.inner?.value ?? 0)
+  log(nested.inner.value ?? 0)
   log(nested?.nonexistent?.value ?? 0)
   // Nil coalescing with nil
   let x = nil
   log(x ?? "fallback")
+  type Doc = {components: {schemas: dict<int>?}?}
+  let doc: Doc = {components: nil}
+  log(len(doc.components?.schemas))
+  log(len(doc.components?.schemas ?? {}))
+  for entry in doc.components?.schemas {
+    log(entry.key)
+  }
 }

--- a/crates/harn-parser/src/builtin_signatures/signatures/stdlib.rs
+++ b/crates/harn-parser/src/builtin_signatures/signatures/stdlib.rs
@@ -1107,6 +1107,7 @@ pub(crate) const SIGNATURES: &[BuiltinSignature] = &[
                 TY_DICT,
                 Ty::Named("set"),
                 Ty::Named("range"),
+                TY_NIL,
             ]),
         )],
         TY_INT,

--- a/crates/harn-parser/src/typechecker/binary_ops.rs
+++ b/crates/harn-parser/src/typechecker/binary_ops.rs
@@ -8,6 +8,7 @@
 use crate::ast::*;
 
 use super::scope::InferredType;
+use super::union::{contains_nil, simplify_union, without_nil};
 
 fn dict_like(ty: &TypeExpr) -> bool {
     matches!(ty, TypeExpr::Named(n) if n == "dict")
@@ -78,26 +79,19 @@ pub(super) fn infer_binary_op_type(
             _ => None,
         },
         "??" => match (left, right) {
-            // Union containing nil: strip nil, use non-nil members
-            (Some(TypeExpr::Union(members)), _) => {
-                let non_nil: Vec<_> = members
-                    .iter()
-                    .filter(|m| !matches!(m, TypeExpr::Named(n) if n == "nil"))
-                    .cloned()
-                    .collect();
-                if non_nil.len() == 1 {
-                    Some(non_nil[0].clone())
-                } else if non_nil.is_empty() {
-                    right.clone()
-                } else {
-                    Some(TypeExpr::Union(non_nil))
-                }
-            }
-            // Left is nil: result is always the right side
-            (Some(TypeExpr::Named(n)), _) if n == "nil" => right.clone(),
-            // Left is a known non-nil type: right is unreachable, preserve left
-            (Some(l), _) => Some(l.clone()),
-            // Unknown left: use right as best guess
+            (Some(left), right) => match without_nil(left) {
+                // Left is only nil, so the result is exactly the fallback.
+                None => right.clone(),
+                // Left cannot be nil, so the fallback is unreachable.
+                Some(non_nil_left) if !contains_nil(left) => Some(non_nil_left),
+                // Left may be nil; include the fallback when its type is known.
+                Some(non_nil_left) => match right {
+                    Some(right) if &non_nil_left == right => Some(non_nil_left),
+                    Some(right) => Some(simplify_union(vec![non_nil_left, right.clone()])),
+                    None => Some(non_nil_left),
+                },
+            },
+            // Unknown left: use right as best guess.
             (None, _) => right.clone(),
         },
         "|>" => None,

--- a/crates/harn-parser/src/typechecker/inference/calls.rs
+++ b/crates/harn-parser/src/typechecker/inference/calls.rs
@@ -21,6 +21,7 @@ use harn_lexer::Span;
 use super::super::format::format_type;
 use super::super::schema_inference::schema_type_expr_from_node;
 use super::super::scope::{is_builtin, EnumDeclInfo, FnSignature, StructDeclInfo, TypeScope};
+use super::super::union::without_nil;
 use super::super::TypeChecker;
 
 impl TypeChecker {
@@ -62,22 +63,6 @@ impl TypeChecker {
             0 => None,
             1 => Some(members.into_iter().next().unwrap()),
             _ => Some(TypeExpr::Union(members)),
-        }
-    }
-
-    fn type_without_nil(ty: &TypeExpr) -> Option<TypeExpr> {
-        match ty {
-            TypeExpr::Named(name) if name == "nil" => None,
-            TypeExpr::Union(members) => {
-                let non_nil: Vec<TypeExpr> =
-                    members.iter().filter_map(Self::type_without_nil).collect();
-                match non_nil.as_slice() {
-                    [] => None,
-                    [only] => Some(only.clone()),
-                    _ => Some(TypeExpr::Union(non_nil)),
-                }
-            }
-            other => Some(other.clone()),
         }
     }
 
@@ -354,7 +339,7 @@ impl TypeChecker {
                 }
                 let compatible = self.types_compatible(&expected, actual, &call_scope)
                     || (param.optional
-                        && Self::type_without_nil(actual).is_none_or(|non_nil| {
+                        && without_nil(actual).is_none_or(|non_nil| {
                             self.types_compatible(&expected, &non_nil, &call_scope)
                         }));
                 if !compatible {

--- a/crates/harn-parser/src/typechecker/inference/flow.rs
+++ b/crates/harn-parser/src/typechecker/inference/flow.rs
@@ -135,7 +135,9 @@ impl TypeChecker {
             // Logical AND: both operands must be truthy, so truthy refinements compose.
             Node::BinaryOp { op, left, right } if op == "&&" => {
                 let left_ref = Self::extract_refinements(left, scope);
-                let right_ref = Self::extract_refinements(right, scope);
+                let mut right_scope = scope.child();
+                left_ref.apply_truthy(&mut right_scope);
+                let right_ref = Self::extract_refinements(right, &right_scope);
                 let mut truthy = left_ref.truthy;
                 truthy.extend(right_ref.truthy);
                 let mut truthy_ruled_out = left_ref.truthy_ruled_out;
@@ -151,7 +153,9 @@ impl TypeChecker {
             // Logical OR: both operands must be falsy for the whole to be falsy.
             Node::BinaryOp { op, left, right } if op == "||" => {
                 let left_ref = Self::extract_refinements(left, scope);
-                let right_ref = Self::extract_refinements(right, scope);
+                let mut right_scope = scope.child();
+                left_ref.apply_falsy(&mut right_scope);
+                let right_ref = Self::extract_refinements(right, &right_scope);
                 let mut falsy = left_ref.falsy;
                 falsy.extend(right_ref.falsy);
                 let mut falsy_ruled_out = left_ref.falsy_ruled_out;

--- a/crates/harn-parser/src/typechecker/inference/statements.rs
+++ b/crates/harn-parser/src/typechecker/inference/statements.rs
@@ -21,11 +21,12 @@ use super::super::exits::stmt_definitely_exits;
 use super::super::format::{format_type, is_obvious_type};
 use super::super::schema_inference::schema_type_expr_from_node;
 use super::super::scope::{
-    EnumDeclInfo, FnSignature, ImplMethodSig, InterfaceDeclInfo, StructDeclInfo, TypeAliasInfo,
-    TypeScope,
+    EnumDeclInfo, FnSignature, ImplMethodSig, InferredType, InterfaceDeclInfo, StructDeclInfo,
+    TypeAliasInfo, TypeScope,
 };
 use super::super::union::{
-    discriminant_field, narrow_shape_union_by_tag, narrow_to_single, DiscriminantValue,
+    discriminant_field, narrow_shape_union_by_tag, narrow_to_single, simplify_union, without_nil,
+    DiscriminantValue,
 };
 use super::super::{InlayHintInfo, TypeChecker};
 use super::flow::{pattern_alternatives, resolve_union_shape_members};
@@ -142,6 +143,34 @@ impl TypeChecker {
                 TypeExpr::Union(widened)
             }
             other => TypeExpr::Union(vec![other.clone(), TypeExpr::Named("nil".into())]),
+        }
+    }
+
+    fn iterable_item_type(&self, iter_type: &TypeExpr, scope: &TypeScope) -> InferredType {
+        let resolved = self.resolve_alias(iter_type, scope);
+        let non_nil = without_nil(&resolved)?;
+        match self.resolve_alias(&non_nil, scope) {
+            TypeExpr::List(inner)
+            | TypeExpr::Iter(inner)
+            | TypeExpr::Generator(inner)
+            | TypeExpr::Stream(inner) => Some(*inner),
+            TypeExpr::Applied { name, args } if name == "Iter" && args.len() == 1 => {
+                Some(args[0].clone())
+            }
+            TypeExpr::DictType(key, value) => Some(TypeExpr::Applied {
+                name: "Pair".into(),
+                args: vec![*key, *value],
+            }),
+            TypeExpr::Named(name) if name == "string" => Some(TypeExpr::Named("string".into())),
+            TypeExpr::Named(name) if name == "range" => Some(TypeExpr::Named("int".into())),
+            TypeExpr::Union(members) => {
+                let mut item_types = Vec::new();
+                for member in members {
+                    item_types.push(self.iterable_item_type(&member, scope)?);
+                }
+                Some(simplify_union(item_types))
+            }
+            _ => None,
         }
     }
 
@@ -712,60 +741,26 @@ impl TypeChecker {
                 let mut loop_scope = scope.child();
                 let iter_type = self.infer_type(iterable, scope);
                 if let BindingPattern::Identifier(variable) = pattern {
-                    // Infer loop variable type from iterable
-                    let elem_type = match iter_type {
-                        Some(TypeExpr::List(inner)) => Some(*inner),
-                        Some(TypeExpr::Iter(inner)) => Some(*inner),
-                        Some(TypeExpr::Generator(inner)) => Some(*inner),
-                        Some(TypeExpr::Stream(inner)) => Some(*inner),
-                        Some(TypeExpr::Applied { ref name, ref args })
-                            if name == "Iter" && args.len() == 1 =>
-                        {
-                            Some(args[0].clone())
-                        }
-                        Some(TypeExpr::Named(n)) if n == "string" => {
-                            Some(TypeExpr::Named("string".into()))
-                        }
-                        // Iterating a range always yields ints.
-                        Some(TypeExpr::Named(n)) if n == "range" => {
-                            Some(TypeExpr::Named("int".into()))
-                        }
-                        _ => None,
-                    };
+                    let elem_type = iter_type
+                        .as_ref()
+                        .and_then(|ty| self.iterable_item_type(ty, scope));
                     loop_scope.define_var(variable, elem_type);
                     loop_scope.clear_nil_widenable(variable);
                 } else if let BindingPattern::Pair(a, b) = pattern {
                     // Pair destructuring: `for (k, v) in iter` — extract K, V
                     // from the yielded Pair<K, V>.
-                    let (ka, vb) = match &iter_type {
-                        Some(TypeExpr::Iter(inner))
-                        | Some(TypeExpr::Generator(inner))
-                        | Some(TypeExpr::Stream(inner)) => {
-                            if let TypeExpr::Applied { name, args } = inner.as_ref() {
-                                if name == "Pair" && args.len() == 2 {
-                                    (Some(args[0].clone()), Some(args[1].clone()))
-                                } else {
-                                    (None, None)
-                                }
+                    let (ka, vb) = iter_type
+                        .as_ref()
+                        .and_then(|ty| self.iterable_item_type(ty, scope))
+                        .and_then(|ty| {
+                            if let TypeExpr::Applied { name, args } = ty {
+                                (name == "Pair" && args.len() == 2)
+                                    .then(|| (Some(args[0].clone()), Some(args[1].clone())))
                             } else {
-                                (None, None)
+                                None
                             }
-                        }
-                        Some(TypeExpr::Applied { name, args })
-                            if name == "Iter" && args.len() == 1 =>
-                        {
-                            if let TypeExpr::Applied { name: n2, args: a2 } = &args[0] {
-                                if n2 == "Pair" && a2.len() == 2 {
-                                    (Some(a2[0].clone()), Some(a2[1].clone()))
-                                } else {
-                                    (None, None)
-                                }
-                            } else {
-                                (None, None)
-                            }
-                        }
-                        _ => (None, None),
-                    };
+                        })
+                        .unwrap_or((None, None));
                     loop_scope.define_var(a, ka);
                     loop_scope.define_var(b, vb);
                     loop_scope.clear_nil_widenable(a);
@@ -1132,6 +1127,17 @@ impl TypeChecker {
             // Recurse into nested expressions + validate binary op types
             Node::BinaryOp { op, left, right } => {
                 self.check_node(left, scope);
+                if op == "&&" || op == "||" {
+                    let refs = Self::extract_refinements(left, scope);
+                    let mut right_scope = scope.child();
+                    if op == "&&" {
+                        refs.apply_truthy(&mut right_scope);
+                    } else {
+                        refs.apply_falsy(&mut right_scope);
+                    }
+                    self.check_node(right, &mut right_scope);
+                    return;
+                }
                 self.check_node(right, scope);
                 // Validate operator/type compatibility
                 let lt = self.infer_type(left, scope);

--- a/crates/harn-parser/src/typechecker/tests/narrowing.rs
+++ b/crates/harn-parser/src/typechecker/tests/narrowing.rs
@@ -148,6 +148,48 @@ if x != nil && type_of(x) == "string" {
 }
 
 #[test]
+fn test_short_circuit_and_narrows_rhs_expression() {
+    let errs = errors(
+        r#"pipeline t(task) {
+  fn count_values(values: list<int>) -> int { return len(values) }
+  fn check(values: list<int> | nil) {
+if values != nil && count_values(values) > 0 {
+  let present: list<int> = values
+}
+  }
+}"#,
+    );
+    assert!(errs.is_empty(), "got: {:?}", errs);
+}
+
+#[test]
+fn test_short_circuit_or_narrows_rhs_expression() {
+    let errs = errors(
+        r#"pipeline t(task) {
+  fn count_values(values: list<int>) -> int { return len(values) }
+  fn check(values: list<int> | nil) {
+if values == nil || count_values(values) > 0 {
+  log("ok")
+}
+  }
+}"#,
+    );
+    assert!(errs.is_empty(), "got: {:?}", errs);
+}
+
+#[test]
+fn test_nil_coalescing_call_site_strips_optional_chain_nil() {
+    let errs = errors(
+        r#"pipeline t(task) {
+  type Doc = { components: { schemas: dict<int>? }? }
+  let doc: Doc = { components: nil }
+  let n: int = len(doc.components?.schemas ?? {})
+}"#,
+    );
+    assert!(errs.is_empty(), "got: {:?}", errs);
+}
+
+#[test]
 fn test_or_falsy_narrowing() {
     // || combines falsy refinements
     let errs = errors(

--- a/crates/harn-parser/src/typechecker/tests/typing.rs
+++ b/crates/harn-parser/src/typechecker/tests/typing.rs
@@ -913,6 +913,12 @@ fn test_builtin_arg_type_mismatch() {
 }
 
 #[test]
+fn test_len_accepts_nil_like_runtime() {
+    let errs = errors(r#"pipeline t(task) { let n: int = len(nil) }"#);
+    assert!(errs.is_empty(), "got errors: {errs:?}");
+}
+
+#[test]
 fn test_llm_call_option_literal_checks_known_field_types() {
     let errs = errors(
         r#"pipeline t(task) {

--- a/crates/harn-parser/src/typechecker/union.rs
+++ b/crates/harn-parser/src/typechecker/union.rs
@@ -12,21 +12,53 @@ use crate::ast::*;
 
 use super::scope::{InferredType, TypeScope};
 
-/// Simplify a union by removing `Never` members and collapsing.
+/// Simplify a union by flattening nested unions, removing `Never` members,
+/// deduplicating, and collapsing single-member unions.
 pub(super) fn simplify_union(members: Vec<TypeExpr>) -> TypeExpr {
     let mut filtered: Vec<TypeExpr> = Vec::new();
-    for member in members
-        .into_iter()
-        .filter(|m| !matches!(m, TypeExpr::Never))
-    {
-        if !filtered.contains(&member) {
-            filtered.push(member);
-        }
+    for member in members {
+        collect_simplified_union_member(member, &mut filtered);
     }
     match filtered.len() {
         0 => TypeExpr::Never,
         1 => filtered.into_iter().next().unwrap(),
         _ => TypeExpr::Union(filtered),
+    }
+}
+
+fn collect_simplified_union_member(member: TypeExpr, filtered: &mut Vec<TypeExpr>) {
+    match member {
+        TypeExpr::Never => {}
+        TypeExpr::Union(members) => {
+            for member in members {
+                collect_simplified_union_member(member, filtered);
+            }
+        }
+        member => {
+            if !filtered.contains(&member) {
+                filtered.push(member);
+            }
+        }
+    }
+}
+
+/// Remove every `nil` arm from a type expression, including nested unions.
+pub(super) fn without_nil(ty: &TypeExpr) -> InferredType {
+    match ty {
+        TypeExpr::Named(name) if name == "nil" => None,
+        TypeExpr::Union(members) => {
+            let non_nil: Vec<TypeExpr> = members.iter().filter_map(without_nil).collect();
+            (!non_nil.is_empty()).then(|| simplify_union(non_nil))
+        }
+        other => Some(other.clone()),
+    }
+}
+
+pub(super) fn contains_nil(ty: &TypeExpr) -> bool {
+    match ty {
+        TypeExpr::Named(name) if name == "nil" => true,
+        TypeExpr::Union(members) => members.iter().any(contains_nil),
+        _ => false,
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #1606.

- centralize nil-arm union helpers and use them for `??` inference
- type-check short-circuit RHS expressions under the left-hand refinement scope for `&&` and `||`
- align `len(nil)` with runtime behavior and infer optional iterable item types for nilable dict/list iteration
- add parser unit coverage plus conformance coverage for optional chaining, coalesce, len, iteration, and short-circuit narrowing
- harden Rust CI caches by disabling `~/.cargo/bin` restoration so hosted-runner cargo/rustup shims cannot be shadowed by stale cache entries

## Verification

- `cargo test -p harn-parser`
- `cargo run --quiet --bin harn -- test conformance`
- `make lint-actions`
- pre-commit hook: `cargo clippy --workspace --all-targets -- -D warnings`
- pre-push targeted local checks
