### PR TITLE
Preserve local runtime telemetry per LLM call (#1614)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ Pre-0.6 highlights live in [CHANGELOG-pre-0.6.md](CHANGELOG-pre-0.6.md).
 Harn had no external users before 0.6.0, so that archive intentionally keeps
 condensed series summaries instead of full per-patch history.
 
+## Unreleased
+
+### Added
+
+- **Provider telemetry envelope (#1614).** `llm_call` results now carry a
+  normalized `provider_telemetry` block that preserves server-side timings
+  local runtimes already report and represents missing fields explicitly.
+  Ollama's `/api/chat` NDJSON and `/api/generate` raw stream lift
+  `total_duration`, `load_duration`, `prompt_eval_duration`, and
+  `eval_duration` (rounded to milliseconds) plus the prompt-eval / eval
+  token counts and the daemon-resolved model id. OpenAI-compatible
+  responses expose `prompt_tokens` / `completion_tokens` even when no
+  durations are reported, and llama.cpp's `usage.timings` extension is
+  promoted to `llamacpp_timings` with the prefill / decode breakdown.
+  Anthropic Messages responses preserve the response id alongside usage
+  counts. Every call also records `client_wall_ms` so end-to-end latency
+  can be decomposed from the network and streaming overhead the
+  server-side counters omit. The same envelope flows through the
+  structured-output wrapper so eval aggregators get the data without
+  provider-specific decoders. The `OllamaPsModel` parser is shared with
+  `harn local list` / `status`, picking up `context_length` from the
+  `/api/ps` payload where the daemon reports it.
+- **`harn provider probe <provider>` command (#1614).** Machine-readable
+  one-shot snapshot of provider readiness plus the loaded-model state
+  Ollama surfaces via `/api/ps` (size, VRAM, expiry, context window).
+  JSON output by default for eval pipelines; pair with `harn local
+  status --json` to inspect lifecycle state across every local runtime.
+
 ## v0.8.17
 
 ### Added

--- a/crates/harn-cli/src/cli/mod.rs
+++ b/crates/harn-cli/src/cli/mod.rs
@@ -127,7 +127,9 @@ pub(crate) use persona::{
 pub(crate) use playground::PlaygroundArgs;
 pub(crate) use portal::PortalArgs;
 pub(crate) use profile::ProfileArgs;
-pub(crate) use provider::{ModelInfoArgs, ProviderCatalogArgs, ProviderReadyArgs};
+pub(crate) use provider::{
+    ModelInfoArgs, ProviderCatalogArgs, ProviderProbeArgs, ProviderReadyArgs,
+};
 pub(crate) use providers::{
     ProvidersArgs, ProvidersCommand, ProvidersExportArgs, ProvidersRefreshArgs,
     ProvidersValidateArgs,
@@ -348,6 +350,10 @@ SCRIPTING
     ProviderCatalog(ProviderCatalogArgs),
     /// Probe a provider's /models endpoint and optionally verify a served model.
     ProviderReady(ProviderReadyArgs),
+    /// Snapshot a provider: readiness, served models, loaded models with
+    /// memory/context details. Designed for eval pipelines that need a
+    /// stable telemetry envelope per provider.
+    ProviderProbe(ProviderProbeArgs),
     /// One-shot agent_loop with a prompt. Routes through the configured
     /// provider (or `HARN_LLM_PROVIDER=mock` for offline use).
     #[command(name = "try")]

--- a/crates/harn-cli/src/cli/provider.rs
+++ b/crates/harn-cli/src/cli/provider.rs
@@ -50,3 +50,34 @@ pub(crate) struct ProviderReadyArgs {
     #[arg(long, default_value_t = false, action = ArgAction::SetTrue)]
     pub json: bool,
 }
+
+/// Surface for `harn provider probe`: combined `/v1/models` readiness +
+/// loaded-model state (`/api/ps` for Ollama) under one machine-readable
+/// command. Evals consume the JSON to record cold load time / VRAM /
+/// context length alongside per-call telemetry.
+#[derive(Debug, Args)]
+pub(crate) struct ProviderProbeArgs {
+    /// Provider id from Harn provider config (`ollama`, `llamacpp`, `mlx`,
+    /// `openai`, ...). Required because the probe is provider-scoped.
+    #[arg(
+        value_parser = llm_provider_completion_parser(),
+        hide_possible_values = true
+    )]
+    pub provider: String,
+    /// Optional model alias or provider-native id. When set the probe
+    /// also confirms the model is currently served.
+    #[arg(
+        long,
+        value_parser = llm_model_completion_parser(),
+        hide_possible_values = true
+    )]
+    pub model: Option<String>,
+    /// Override the configured provider base URL.
+    #[arg(long = "base-url")]
+    pub base_url: Option<String>,
+    /// Emit JSON. Defaults to true since this command is meant for
+    /// machine consumption (eval aggregators); pass `--json=false` to
+    /// drop back to the human summary the readiness probe prints.
+    #[arg(long, default_value_t = true, action = ArgAction::Set)]
+    pub json: bool,
+}

--- a/crates/harn-cli/src/cli/tests.rs
+++ b/crates/harn-cli/src/cli/tests.rs
@@ -2467,6 +2467,29 @@ fn test_parses_completions_args() {
 }
 
 #[test]
+fn test_parses_provider_probe_args() {
+    let cli = Cli::parse_from([
+        "harn",
+        "provider-probe",
+        "ollama",
+        "--model",
+        "qwen3.6-coding",
+        "--base-url",
+        "http://127.0.0.1:11434",
+    ]);
+
+    let Command::ProviderProbe(args) = cli.command.unwrap() else {
+        panic!("expected provider-probe command");
+    };
+    assert_eq!(args.provider, "ollama");
+    assert_eq!(args.model.as_deref(), Some("qwen3.6-coding"));
+    assert_eq!(args.base_url.as_deref(), Some("http://127.0.0.1:11434"));
+    // The probe is meant for eval pipelines; JSON output is the default
+    // surface so an aggregator doesn't have to opt in.
+    assert!(args.json);
+}
+
+#[test]
 fn test_provider_model_completion_candidates_stay_permissive() {
     let cli = Cli::parse_from([
         "harn",

--- a/crates/harn-cli/src/commands/local/runtime.rs
+++ b/crates/harn-cli/src/commands/local/runtime.rs
@@ -5,6 +5,7 @@
 use std::path::Path;
 use std::time::Duration;
 
+use harn_vm::llm::api::OllamaPsModel;
 use harn_vm::llm::readiness::{probe_provider_readiness, ProviderReadiness, ReadinessStatus};
 use harn_vm::llm_config::{self, ProviderDef};
 use serde::Serialize;
@@ -44,6 +45,10 @@ pub(crate) struct LoadedModel {
     pub size_vram_bytes: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expires_at: Option<String>,
+    /// Context window the model was loaded with. Surfaced where Ollama
+    /// includes it in `/api/ps` (newer daemons; older builds return None).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context_length: Option<u64>,
 }
 
 pub(crate) fn local_provider_ids(filter: Option<&str>) -> Vec<String> {
@@ -212,7 +217,7 @@ fn port_from_base_url(base_url: &str) -> Option<u16> {
 /// models are loaded right now plus their memory footprint. We swallow
 /// errors so list/status keep working when the daemon is older or the
 /// endpoint is unavailable.
-async fn fetch_ollama_ps(base_url: &str) -> Result<Vec<LoadedModel>, String> {
+pub(crate) async fn fetch_ollama_ps(base_url: &str) -> Result<Vec<LoadedModel>, String> {
     let url = ollama_endpoint(base_url, "/api/ps")?;
     let client = local_http_client()?;
     let response = client
@@ -230,22 +235,20 @@ async fn fetch_ollama_ps(base_url: &str) -> Result<Vec<LoadedModel>, String> {
     let Some(models) = models else {
         return Ok(Vec::new());
     };
+    // The harn-vm `OllamaPsModel` parser is the canonical shape, so per-call
+    // telemetry and per-snapshot loaded-model listings can't drift: any new
+    // upstream field (e.g. context window changes) lands in one place.
     Ok(models
         .iter()
         .filter_map(|entry| {
-            let name = entry
-                .get("name")
-                .and_then(serde_json::Value::as_str)
-                .or_else(|| entry.get("model").and_then(serde_json::Value::as_str))?
-                .to_string();
+            let ps = OllamaPsModel::from_ps_entry(entry)?;
+            let name = ps.name?;
             Some(LoadedModel {
                 name,
-                size_bytes: entry.get("size").and_then(serde_json::Value::as_u64),
-                size_vram_bytes: entry.get("size_vram").and_then(serde_json::Value::as_u64),
-                expires_at: entry
-                    .get("expires_at")
-                    .and_then(serde_json::Value::as_str)
-                    .map(str::to_string),
+                size_bytes: ps.size_bytes,
+                size_vram_bytes: ps.size_vram_bytes,
+                expires_at: ps.expires_at,
+                context_length: ps.context_length,
             })
         })
         .collect())

--- a/crates/harn-cli/src/commands/mod.rs
+++ b/crates/harn-cli/src/commands/mod.rs
@@ -27,6 +27,7 @@ pub mod persona_supervision;
 pub mod playground;
 pub(crate) mod portal;
 pub(crate) mod protocol_conformance;
+pub(crate) mod provider;
 pub(crate) mod providers;
 pub(crate) mod quickstart;
 pub(crate) mod repl;

--- a/crates/harn-cli/src/commands/provider.rs
+++ b/crates/harn-cli/src/commands/provider.rs
@@ -1,0 +1,106 @@
+//! `harn provider probe` — one-shot machine-readable provider snapshot.
+//!
+//! Combines provider readiness (`/v1/models` or equivalent) with the
+//! runtime-state details that local engines surface separately (Ollama's
+//! `/api/ps` shows VRAM, size, expiry, and on newer builds the context
+//! window the model was loaded with). Output is a structured envelope so
+//! eval pipelines decode it with the same shape they use for per-call
+//! `provider_telemetry`.
+
+use std::process;
+
+use harn_vm::llm::readiness::{probe_provider_readiness, ProviderReadiness};
+use harn_vm::llm_config;
+use serde::Serialize;
+
+use crate::cli::ProviderProbeArgs;
+use crate::commands::local::runtime::{fetch_ollama_ps, LoadedModel};
+
+#[derive(Debug, Serialize)]
+struct ProviderProbe {
+    provider: String,
+    base_url: Option<String>,
+    readiness: ProviderReadiness,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    loaded_models: Vec<LoadedModel>,
+}
+
+pub(crate) async fn run_provider_probe(args: ProviderProbeArgs) {
+    let readiness = probe_provider_readiness(
+        &args.provider,
+        args.model.as_deref(),
+        args.base_url.as_deref(),
+    )
+    .await;
+
+    let base_url = readiness.base_url.clone().or_else(|| {
+        llm_config::provider_config(&args.provider).map(|def| llm_config::resolve_base_url(&def))
+    });
+
+    let loaded_models = if args.provider == "ollama" {
+        let base = base_url
+            .clone()
+            .unwrap_or_else(|| "http://localhost:11434".to_string());
+        match fetch_ollama_ps(&base).await {
+            Ok(entries) => entries,
+            Err(error) => {
+                // `/api/ps` is best-effort: a daemon that doesn't expose it
+                // shouldn't block the readiness signal. Warn so eval logs
+                // surface the gap without failing the probe.
+                eprintln!("warning: /api/ps unavailable: {error}");
+                Vec::new()
+            }
+        }
+    } else {
+        Vec::new()
+    };
+
+    let exit_code = if readiness.ok { 0 } else { 1 };
+
+    let probe = ProviderProbe {
+        provider: args.provider.clone(),
+        base_url,
+        readiness,
+        loaded_models,
+    };
+
+    if args.json {
+        match serde_json::to_string_pretty(&probe) {
+            Ok(payload) => println!("{payload}"),
+            Err(error) => eprintln!("error: {error}"),
+        }
+    } else if probe.readiness.ok {
+        println!("{}", probe.readiness.message);
+        if !probe.loaded_models.is_empty() {
+            println!("loaded:");
+            for model in &probe.loaded_models {
+                println!(
+                    "  - {} (size={} vram={} ctx={} expires={})",
+                    model.name,
+                    fmt_bytes(model.size_bytes),
+                    fmt_bytes(model.size_vram_bytes),
+                    fmt_u64(model.context_length),
+                    model.expires_at.as_deref().unwrap_or("-"),
+                );
+            }
+        }
+    } else {
+        eprintln!("{}", probe.readiness.message);
+    }
+
+    if exit_code != 0 {
+        process::exit(exit_code);
+    }
+}
+
+fn fmt_bytes(value: Option<u64>) -> String {
+    value
+        .map(|n| format!("{n}B"))
+        .unwrap_or_else(|| "-".to_string())
+}
+
+fn fmt_u64(value: Option<u64>) -> String {
+    value
+        .map(|n| n.to_string())
+        .unwrap_or_else(|| "-".to_string())
+}

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -1045,6 +1045,7 @@ async fn async_main() {
             )
             .await
         }
+        Command::ProviderProbe(args) => commands::provider::run_provider_probe(args).await,
         Command::Skills(args) => match args.command {
             SkillsCommand::List(list) => commands::skills::run_list(&list),
             SkillsCommand::Inspect(inspect) => commands::skills::run_inspect(&inspect),

--- a/crates/harn-vm/src/llm/agent_config.rs
+++ b/crates/harn-vm/src/llm/agent_config.rs
@@ -496,6 +496,7 @@ mod tests {
             stop_reason: None,
             logprobs: Vec::new(),
             blocks: Vec::new(),
+            telemetry: crate::llm::api::ProviderTelemetry::default(),
         };
 
         let candidates = structured_output_candidates(&result, None);

--- a/crates/harn-vm/src/llm/agent_observe.rs
+++ b/crates/harn-vm/src/llm/agent_observe.rs
@@ -485,6 +485,7 @@ pub(super) fn dump_llm_response(
         .transpose()
         .unwrap_or(None)
         .unwrap_or(serde_json::Value::Null);
+    let telemetry = serde_json::to_value(&result.telemetry).unwrap_or(serde_json::Value::Null);
     append_llm_transcript_entry(&serde_json::json!({
         "type": "provider_call_response",
         "iteration": iteration,
@@ -522,6 +523,9 @@ pub(super) fn dump_llm_response(
         "thinking": result.thinking,
         "thinking_summary": result.thinking_summary,
         "response_ms": response_ms,
+        // Server-side runtime telemetry (Ollama timings, llama.cpp prefill /
+        // decode breakdown, etc.). Empty for providers that report nothing.
+        "provider_telemetry": telemetry,
         "structural_experiment": structural_experiment,
     }));
 }

--- a/crates/harn-vm/src/llm/api.rs
+++ b/crates/harn-vm/src/llm/api.rs
@@ -15,6 +15,7 @@ mod partial_tool_args;
 mod readiness;
 mod response;
 mod result;
+mod telemetry;
 mod thinking;
 mod transport;
 
@@ -55,6 +56,7 @@ pub use readiness::{
 };
 pub(crate) use response::parse_llm_response as parse_llm_response_for_provider;
 pub(crate) use result::{vm_build_llm_result, LlmResult};
+pub use telemetry::{source as telemetry_source, OllamaPsModel, ProviderTelemetry};
 pub(crate) use thinking::{split_openai_thinking_blocks, ThinkingStreamSplitter};
 pub(crate) use transport::vm_call_llm_api_with_body;
 

--- a/crates/harn-vm/src/llm/api.rs
+++ b/crates/harn-vm/src/llm/api.rs
@@ -56,6 +56,7 @@ pub use readiness::{
 };
 pub(crate) use response::parse_llm_response as parse_llm_response_for_provider;
 pub(crate) use result::{vm_build_llm_result, LlmResult};
+pub(crate) use telemetry::elapsed_ms;
 pub use telemetry::{source as telemetry_source, OllamaPsModel, ProviderTelemetry};
 pub(crate) use thinking::{split_openai_thinking_blocks, ThinkingStreamSplitter};
 pub(crate) use transport::vm_call_llm_api_with_body;

--- a/crates/harn-vm/src/llm/api/completion.rs
+++ b/crates/harn-vm/src/llm/api/completion.rs
@@ -14,6 +14,7 @@ use super::response::{
     extract_cache_read_tokens, extract_cache_write_tokens, extract_openai_choice_logprobs,
 };
 use super::result::{mock_completion_response, LlmResult};
+use super::telemetry::{source as telemetry_source, ProviderTelemetry};
 
 async fn completion_json_response(
     provider: &str,
@@ -134,6 +135,8 @@ async fn vm_call_completion_openai_style(
         )))));
     }
 
+    let request_id = json["id"].as_str().filter(|value| !value.is_empty());
+    let telemetry = ProviderTelemetry::from_openai_usage(&json["usage"], request_id);
     Ok(LlmResult {
         text: json["choices"][0]["text"]
             .as_str()
@@ -157,6 +160,7 @@ async fn vm_call_completion_openai_style(
             "visibility": "public",
         })],
         logprobs: extract_openai_choice_logprobs(&json["choices"][0]),
+        telemetry,
     })
 }
 
@@ -234,6 +238,7 @@ async fn vm_call_completion_ollama(
         )))));
     }
 
+    let telemetry = ProviderTelemetry::from_ollama_done(&json, telemetry_source::OLLAMA_GENERATE);
     Ok(LlmResult {
         text: json["response"].as_str().unwrap_or("").to_string(),
         tool_calls: Vec::new(),
@@ -252,6 +257,7 @@ async fn vm_call_completion_ollama(
             "visibility": "public",
         })],
         logprobs: Vec::new(),
+        telemetry,
     })
 }
 

--- a/crates/harn-vm/src/llm/api/response.rs
+++ b/crates/harn-vm/src/llm/api/response.rs
@@ -8,6 +8,7 @@ use crate::value::{VmError, VmValue};
 
 use super::openai_normalize::{append_paragraph, normalize_openai_message_text};
 use super::result::LlmResult;
+use super::telemetry::ProviderTelemetry;
 
 fn render_reasoning_summary_value(value: &serde_json::Value) -> String {
     match value {
@@ -281,6 +282,8 @@ pub(crate) fn parse_llm_response(
         let cache_read_tokens = extract_cache_read_tokens(&json["usage"]);
         let cache_write_tokens = extract_cache_write_tokens(&json["usage"]);
         let stop_reason = json["stop_reason"].as_str().map(|s| s.to_string());
+        let request_id = json["id"].as_str().filter(|value| !value.is_empty());
+        let telemetry = ProviderTelemetry::from_anthropic_usage(&json["usage"], request_id);
 
         Ok(LlmResult {
             text,
@@ -300,6 +303,7 @@ pub(crate) fn parse_llm_response(
             stop_reason,
             blocks,
             logprobs: Vec::new(),
+            telemetry,
         })
     } else {
         if let Some(err) = json["error"]["message"].as_str() {
@@ -417,6 +421,8 @@ pub(crate) fn parse_llm_response(
         let stop_reason = json["choices"][0]["finish_reason"]
             .as_str()
             .map(|s| s.to_string());
+        let request_id = json["id"].as_str().filter(|value| !value.is_empty());
+        let telemetry = ProviderTelemetry::from_openai_usage(&json["usage"], request_id);
 
         // OpenAI Responses-API `tool_search_call` / `tool_search_output`
         // blocks (harn#71) are server-executed and get stripped from
@@ -465,6 +471,7 @@ pub(crate) fn parse_llm_response(
             stop_reason,
             blocks,
             logprobs: extract_openai_choice_logprobs(&json["choices"][0]),
+            telemetry,
         })
     }
 }
@@ -825,5 +832,92 @@ mod tests {
             Some("get_weather"),
             "reference name preserved"
         );
+    }
+
+    #[test]
+    fn openai_parser_preserves_partial_usage_in_telemetry() {
+        // OpenAI-compatible local servers (vLLM, MLX) often report only
+        // `prompt_tokens` and `completion_tokens`. The parser must still
+        // surface those values in the telemetry envelope rather than
+        // dropping them on the floor — otherwise eval dashboards see
+        // empty per-call accounting and have to fall back to
+        // wall-clock heuristics.
+        let resolved = crate::llm::helpers::ResolvedProvider::resolve("vllm");
+        let response = serde_json::json!({
+            "id": "chatcmpl-abc",
+            "choices": [{
+                "message": {"content": "done"},
+                "finish_reason": "stop"
+            }],
+            "usage": {"prompt_tokens": 314, "completion_tokens": 27}
+        });
+
+        let result =
+            parse_llm_response(&response, "vllm", "qwen3.6", &resolved).expect("parser succeeds");
+
+        assert_eq!(
+            result.telemetry.source,
+            crate::llm::api::telemetry_source::OPENAI_USAGE
+        );
+        assert_eq!(result.telemetry.server_prompt_tokens, Some(314));
+        assert_eq!(result.telemetry.server_output_tokens, Some(27));
+        assert_eq!(result.telemetry.server_prompt_eval_ms, None);
+        assert_eq!(result.telemetry.request_id.as_deref(), Some("chatcmpl-abc"));
+    }
+
+    #[test]
+    fn openai_parser_lifts_llamacpp_timings_into_telemetry() {
+        // llama.cpp's OpenAI-compatible server extends `usage` with a
+        // `timings` block. Preserve the millisecond fields verbatim and
+        // promote the source to `llamacpp_timings` so eval scripts can
+        // route on them.
+        let resolved = crate::llm::helpers::ResolvedProvider::resolve("llamacpp");
+        let response = serde_json::json!({
+            "choices": [{
+                "message": {"content": "answer"},
+                "finish_reason": "stop"
+            }],
+            "usage": {
+                "prompt_tokens": 200,
+                "completion_tokens": 17,
+                "timings": {
+                    "prompt_n": 200,
+                    "prompt_ms": 145.4,
+                    "predicted_n": 17,
+                    "predicted_ms": 89.1
+                }
+            }
+        });
+
+        let result = parse_llm_response(&response, "llamacpp", "qwen-7b", &resolved)
+            .expect("parser succeeds");
+
+        assert_eq!(
+            result.telemetry.source,
+            crate::llm::api::telemetry_source::LLAMACPP_TIMINGS
+        );
+        assert_eq!(result.telemetry.server_prompt_eval_ms, Some(145));
+        assert_eq!(result.telemetry.server_generation_ms, Some(89));
+        assert_eq!(result.telemetry.server_total_ms, Some(234));
+    }
+
+    #[test]
+    fn anthropic_parser_captures_request_id_in_telemetry() {
+        let resolved = anthropic_resolved();
+        let response = serde_json::json!({
+            "id": "msg_01ABC",
+            "content": [{"type": "text", "text": "ok"}],
+            "usage": {"input_tokens": 5, "output_tokens": 2},
+            "stop_reason": "end_turn"
+        });
+        let result = parse_llm_response(&response, "anthropic", "claude-opus-4-7", &resolved)
+            .expect("parser succeeds");
+        assert_eq!(
+            result.telemetry.source,
+            crate::llm::api::telemetry_source::ANTHROPIC_USAGE
+        );
+        assert_eq!(result.telemetry.request_id.as_deref(), Some("msg_01ABC"));
+        assert_eq!(result.telemetry.server_prompt_tokens, Some(5));
+        assert_eq!(result.telemetry.server_output_tokens, Some(2));
     }
 }

--- a/crates/harn-vm/src/llm/api/result.rs
+++ b/crates/harn-vm/src/llm/api/result.rs
@@ -4,6 +4,7 @@
 use std::collections::BTreeMap;
 use std::rc::Rc;
 
+use super::telemetry::ProviderTelemetry;
 use crate::value::VmValue;
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq)]
@@ -29,6 +30,10 @@ pub(crate) struct LlmResult {
     pub stop_reason: Option<String>,
     pub blocks: Vec<serde_json::Value>,
     pub logprobs: Vec<serde_json::Value>,
+    /// Server-side timings and runtime accounting captured from this
+    /// response. Empty for mocks and providers that report nothing usable.
+    #[serde(default, skip_serializing_if = "ProviderTelemetry::is_empty")]
+    pub telemetry: ProviderTelemetry,
 }
 
 fn build_usage_dict(result: &LlmResult) -> BTreeMap<String, VmValue> {
@@ -125,7 +130,19 @@ pub(crate) fn vm_build_llm_result(
     if let Some(value) = usage.get("cache_savings_usd") {
         dict.insert("cache_savings_usd".to_string(), value.clone());
     }
+    // Surface provider-side timings (Ollama load_duration, prompt_eval_duration,
+    // eval_duration; OpenAI usage; llama.cpp `timings`). Evals key off
+    // `provider_telemetry` for cold-vs-steady-state and prefill-vs-generation
+    // breakdowns; absent fields stay absent rather than collapsing to zero.
+    let telemetry_dict = result.telemetry.as_vm_dict();
+    let mut usage = usage;
+    if let Some(ref telemetry_dict) = telemetry_dict {
+        usage.insert("provider_telemetry".to_string(), telemetry_dict.clone());
+    }
     dict.insert("usage".to_string(), VmValue::Dict(Rc::new(usage)));
+    if let Some(telemetry_dict) = telemetry_dict {
+        dict.insert("provider_telemetry".to_string(), telemetry_dict);
+    }
 
     if let Some(json_val) = parsed_json {
         dict.insert("data".to_string(), json_val);
@@ -318,5 +335,6 @@ pub(super) fn mock_completion_response(prefix: &str, suffix: Option<&str>) -> Ll
             "visibility": "public",
         })],
         logprobs: Vec::new(),
+        telemetry: ProviderTelemetry::default(),
     }
 }

--- a/crates/harn-vm/src/llm/api/telemetry.rs
+++ b/crates/harn-vm/src/llm/api/telemetry.rs
@@ -44,6 +44,10 @@ pub mod source {
     pub const UNKNOWN: &str = "unknown";
 }
 
+pub(crate) fn elapsed_ms(started: std::time::Instant) -> u64 {
+    started.elapsed().as_millis().min(u128::from(u64::MAX)) as u64
+}
+
 /// Provider-side timing and runtime accounting captured per LLM call.
 ///
 /// All fields default to `None` / empty. Producers fill in what they can

--- a/crates/harn-vm/src/llm/api/telemetry.rs
+++ b/crates/harn-vm/src/llm/api/telemetry.rs
@@ -1,0 +1,564 @@
+//! Per-call provider telemetry envelope.
+//!
+//! Local runtimes (Ollama in particular) report enough server-side timing
+//! information to diagnose slow runs without scraping daemon logs: cold load
+//! vs steady state, prefill vs generation, and tokens-per-second ratios. The
+//! Anthropic and OpenAI hosted APIs don't expose comparable metrics, but the
+//! local runtimes Harn cares most about (Ollama, llama.cpp, MLX, vLLM) all
+//! ship at least a partial subset. This module normalizes whatever the
+//! provider reports into one stable envelope and represents missing fields
+//! as `None` so downstream evals can distinguish "not reported" from "zero".
+//!
+//! Conventions:
+//! - Durations are milliseconds (Ollama reports nanoseconds; we convert).
+//! - Token counts are signed `i64` to match the rest of `LlmResult`.
+//! - `source` identifies which wire format the values were lifted from so
+//!   eval scripts can route on it without re-deriving provider names.
+
+use std::collections::BTreeMap;
+use std::rc::Rc;
+
+use crate::value::VmValue;
+
+/// Wire-format identifiers for `ProviderTelemetry::source`. Keep these in
+/// sync with the matching strings in `docs/src/observability/*` and the
+/// Burin eval aggregator.
+pub mod source {
+    /// Ollama `/api/chat` NDJSON stream — full timing breakdown.
+    pub const OLLAMA_CHAT: &str = "ollama_chat";
+    /// Ollama `/api/generate` (raw) — full timing breakdown.
+    pub const OLLAMA_GENERATE: &str = "ollama_generate";
+    /// OpenAI-style `usage` block (prompt/completion tokens, optional cache
+    /// details). No server-side timings unless the runtime extends the
+    /// schema.
+    pub const OPENAI_USAGE: &str = "openai_usage";
+    /// llama.cpp `usage.timings` extension (`prompt_ms`, `predicted_ms`,
+    /// `predicted_n`, `prompt_n`, ...). Preserved verbatim from the
+    /// non-OpenAI subset.
+    pub const LLAMACPP_TIMINGS: &str = "llamacpp_timings";
+    /// Anthropic Messages API — usage counts only; no timings.
+    pub const ANTHROPIC_USAGE: &str = "anthropic_usage";
+    /// Provider responded but we did not capture anything beyond what
+    /// already lives on `LlmResult` (e.g. mock / fake providers, or a
+    /// stream that finished without a usage frame).
+    pub const UNKNOWN: &str = "unknown";
+}
+
+/// Provider-side timing and runtime accounting captured per LLM call.
+///
+/// All fields default to `None` / empty. Producers fill in what they can
+/// extract and leave the rest absent; consumers must treat missing fields as
+/// "not reported by this provider", not "zero".
+#[derive(Clone, Debug, Default, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct ProviderTelemetry {
+    /// Wire format the values came from (`ollama_chat`, `openai_usage`, ...).
+    /// See [`source`] for the canonical strings. Empty when no telemetry was
+    /// captured.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub source: String,
+    /// Total server-side wall clock (Ollama `total_duration`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub server_total_ms: Option<u64>,
+    /// Time the server spent loading/warming the model (Ollama
+    /// `load_duration`). Useful for detecting cold-start latency.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub server_load_ms: Option<u64>,
+    /// Prompt-prefill time (Ollama `prompt_eval_duration`). Anything else
+    /// would be marketing — this is the field evals key on for prefill
+    /// regression detection.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub server_prompt_eval_ms: Option<u64>,
+    /// Generation/decode time (Ollama `eval_duration`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub server_generation_ms: Option<u64>,
+    /// Tokens the server reports it prefilled (Ollama `prompt_eval_count`).
+    /// Distinct from `LlmResult::input_tokens` because hosted providers
+    /// frequently bill different token boundaries than the on-device
+    /// tokenizer reports.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub server_prompt_tokens: Option<i64>,
+    /// Tokens the server reports it generated (Ollama `eval_count`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub server_output_tokens: Option<i64>,
+    /// Client-side wall clock around the HTTP request. Includes network and
+    /// streaming latency the server-side counters omit. Recorded for every
+    /// call regardless of provider.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_wall_ms: Option<u64>,
+    /// Context window the model was loaded with (where the runtime
+    /// reports it; `/api/ps` for Ollama).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime_context_length: Option<u64>,
+    /// Exact model id the server resolved. May differ from
+    /// `LlmResult::model` when an alias / digest is rewritten upstream.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime_loaded_model: Option<String>,
+    /// Total resident bytes for the loaded model (Ollama `/api/ps.size`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime_memory_bytes: Option<u64>,
+    /// VRAM bytes for the loaded model (Ollama `/api/ps.size_vram`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime_memory_vram_bytes: Option<u64>,
+    /// When the server will unload the model (Ollama `/api/ps.expires_at`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime_keep_alive_until: Option<String>,
+    /// Provider-supplied request id (`x-request-id` / `request_id`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
+}
+
+impl ProviderTelemetry {
+    pub fn new(source: &str) -> Self {
+        Self {
+            source: source.to_string(),
+            ..Self::default()
+        }
+    }
+
+    /// Returns `true` when no meaningful telemetry was captured. A bare
+    /// `client_wall_ms` is still "meaningful" — it lets evals reason about
+    /// per-call latency even for providers that report nothing else.
+    pub fn is_empty(&self) -> bool {
+        let Self {
+            source,
+            server_total_ms,
+            server_load_ms,
+            server_prompt_eval_ms,
+            server_generation_ms,
+            server_prompt_tokens,
+            server_output_tokens,
+            client_wall_ms,
+            runtime_context_length,
+            runtime_loaded_model,
+            runtime_memory_bytes,
+            runtime_memory_vram_bytes,
+            runtime_keep_alive_until,
+            request_id,
+        } = self;
+        source.is_empty()
+            && server_total_ms.is_none()
+            && server_load_ms.is_none()
+            && server_prompt_eval_ms.is_none()
+            && server_generation_ms.is_none()
+            && server_prompt_tokens.is_none()
+            && server_output_tokens.is_none()
+            && client_wall_ms.is_none()
+            && runtime_context_length.is_none()
+            && runtime_loaded_model.is_none()
+            && runtime_memory_bytes.is_none()
+            && runtime_memory_vram_bytes.is_none()
+            && runtime_keep_alive_until.is_none()
+            && request_id.is_none()
+    }
+
+    /// Convert nanoseconds (Ollama's reporting unit) to milliseconds with
+    /// integer rounding. Centralized so every Ollama timing field uses the
+    /// same conversion and zero-vs-None semantics line up.
+    pub fn ns_to_ms(ns: u64) -> u64 {
+        // Use floor division (the conversion is approximate by design); when
+        // the upstream reports 0 ns we want a 0 ms entry rather than None,
+        // so callers should pass through `Some(ns_to_ms(0))` consciously.
+        ns / 1_000_000
+    }
+
+    /// Extract Ollama-shape telemetry from a `done=true` chat or generate
+    /// frame. Returns a populated [`ProviderTelemetry`] whose `source` is
+    /// the caller-provided wire identifier.
+    pub fn from_ollama_done(frame: &serde_json::Value, source: &str) -> Self {
+        let mut telemetry = Self::new(source);
+        telemetry.server_total_ms = ns_field(frame, "total_duration");
+        telemetry.server_load_ms = ns_field(frame, "load_duration");
+        telemetry.server_prompt_eval_ms = ns_field(frame, "prompt_eval_duration");
+        telemetry.server_generation_ms = ns_field(frame, "eval_duration");
+        telemetry.server_prompt_tokens = frame
+            .get("prompt_eval_count")
+            .and_then(serde_json::Value::as_i64);
+        telemetry.server_output_tokens =
+            frame.get("eval_count").and_then(serde_json::Value::as_i64);
+        if let Some(model) = frame.get("model").and_then(serde_json::Value::as_str) {
+            telemetry.runtime_loaded_model = Some(model.to_string());
+        }
+        telemetry
+    }
+
+    /// Extract OpenAI-shape `usage` telemetry. Most OpenAI-compatible local
+    /// runtimes only report counts; llama.cpp's `usage.timings` extension is
+    /// folded in here as well so a single envelope captures both shapes.
+    pub fn from_openai_usage(usage: &serde_json::Value, request_id: Option<&str>) -> Self {
+        let mut telemetry = Self::new(source::OPENAI_USAGE);
+        telemetry.server_prompt_tokens = usage
+            .get("prompt_tokens")
+            .and_then(serde_json::Value::as_i64);
+        telemetry.server_output_tokens = usage
+            .get("completion_tokens")
+            .and_then(serde_json::Value::as_i64);
+        if let Some(timings) = usage.get("timings").filter(|value| value.is_object()) {
+            telemetry.source = source::LLAMACPP_TIMINGS.to_string();
+            telemetry.server_prompt_eval_ms = ms_or_round(timings.get("prompt_ms"));
+            telemetry.server_generation_ms = ms_or_round(timings.get("predicted_ms"));
+            // llama.cpp also reports `prompt_n` / `predicted_n` here when
+            // its usage breakdown is enabled; prefer them over the
+            // legacy top-level counts so prefill cache hits surface
+            // correctly.
+            if let Some(prefill) = timings.get("prompt_n").and_then(serde_json::Value::as_i64) {
+                telemetry.server_prompt_tokens = Some(prefill);
+            }
+            if let Some(predicted) = timings
+                .get("predicted_n")
+                .and_then(serde_json::Value::as_i64)
+            {
+                telemetry.server_output_tokens = Some(predicted);
+            }
+            let total = telemetry
+                .server_prompt_eval_ms
+                .unwrap_or(0)
+                .saturating_add(telemetry.server_generation_ms.unwrap_or(0));
+            if total > 0 {
+                telemetry.server_total_ms = Some(total);
+            }
+        }
+        if let Some(request_id) = request_id.filter(|value| !value.is_empty()) {
+            telemetry.request_id = Some(request_id.to_string());
+        }
+        telemetry
+    }
+
+    /// Extract Anthropic-shape `usage` telemetry. Anthropic only reports
+    /// input/output (and cache) counts — preserving the request id is the
+    /// most useful incremental signal beyond what `LlmResult` already
+    /// carries.
+    pub fn from_anthropic_usage(usage: &serde_json::Value, request_id: Option<&str>) -> Self {
+        let mut telemetry = Self::new(source::ANTHROPIC_USAGE);
+        telemetry.server_prompt_tokens = usage
+            .get("input_tokens")
+            .and_then(serde_json::Value::as_i64);
+        telemetry.server_output_tokens = usage
+            .get("output_tokens")
+            .and_then(serde_json::Value::as_i64);
+        if let Some(request_id) = request_id.filter(|value| !value.is_empty()) {
+            telemetry.request_id = Some(request_id.to_string());
+        }
+        telemetry
+    }
+
+    /// Merge a `/api/ps` snapshot of a loaded Ollama model into this
+    /// telemetry envelope. Only fills in fields that were not already
+    /// populated so a per-call extraction keeps precedence.
+    pub fn merge_ollama_ps(&mut self, ps: &OllamaPsModel) {
+        if self.runtime_loaded_model.is_none() {
+            self.runtime_loaded_model = ps.name.clone();
+        }
+        if self.runtime_context_length.is_none() {
+            self.runtime_context_length = ps.context_length;
+        }
+        if self.runtime_memory_bytes.is_none() {
+            self.runtime_memory_bytes = ps.size_bytes;
+        }
+        if self.runtime_memory_vram_bytes.is_none() {
+            self.runtime_memory_vram_bytes = ps.size_vram_bytes;
+        }
+        if self.runtime_keep_alive_until.is_none() {
+            self.runtime_keep_alive_until = ps.expires_at.clone();
+        }
+    }
+
+    /// Render this envelope into the dictionary shape `llm_call` returns.
+    /// Returns `None` if the envelope is empty so callers can omit the key
+    /// entirely.
+    pub fn as_vm_dict(&self) -> Option<VmValue> {
+        if self.is_empty() {
+            return None;
+        }
+        let mut dict: BTreeMap<String, VmValue> = BTreeMap::new();
+        if !self.source.is_empty() {
+            dict.insert(
+                "source".to_string(),
+                VmValue::String(Rc::from(self.source.as_str())),
+            );
+        }
+        insert_opt_u64(&mut dict, "server_total_ms", self.server_total_ms);
+        insert_opt_u64(&mut dict, "server_load_ms", self.server_load_ms);
+        insert_opt_u64(
+            &mut dict,
+            "server_prompt_eval_ms",
+            self.server_prompt_eval_ms,
+        );
+        insert_opt_u64(&mut dict, "server_generation_ms", self.server_generation_ms);
+        insert_opt_i64(&mut dict, "server_prompt_tokens", self.server_prompt_tokens);
+        insert_opt_i64(&mut dict, "server_output_tokens", self.server_output_tokens);
+        insert_opt_u64(&mut dict, "client_wall_ms", self.client_wall_ms);
+        insert_opt_u64(
+            &mut dict,
+            "runtime_context_length",
+            self.runtime_context_length,
+        );
+        if let Some(ref model) = self.runtime_loaded_model {
+            dict.insert(
+                "runtime_loaded_model".to_string(),
+                VmValue::String(Rc::from(model.as_str())),
+            );
+        }
+        insert_opt_u64(&mut dict, "runtime_memory_bytes", self.runtime_memory_bytes);
+        insert_opt_u64(
+            &mut dict,
+            "runtime_memory_vram_bytes",
+            self.runtime_memory_vram_bytes,
+        );
+        if let Some(ref expires) = self.runtime_keep_alive_until {
+            dict.insert(
+                "runtime_keep_alive_until".to_string(),
+                VmValue::String(Rc::from(expires.as_str())),
+            );
+        }
+        if let Some(ref request_id) = self.request_id {
+            dict.insert(
+                "request_id".to_string(),
+                VmValue::String(Rc::from(request_id.as_str())),
+            );
+        }
+        Some(VmValue::Dict(Rc::new(dict)))
+    }
+}
+
+/// Loaded-model snapshot from Ollama's `/api/ps`. Shared with the CLI's
+/// `harn local` family so we don't duplicate the response shape.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct OllamaPsModel {
+    pub name: Option<String>,
+    pub size_bytes: Option<u64>,
+    pub size_vram_bytes: Option<u64>,
+    pub expires_at: Option<String>,
+    pub context_length: Option<u64>,
+}
+
+impl OllamaPsModel {
+    /// Decode one `/api/ps` `models[]` entry. Returns `None` when the entry
+    /// has no usable identifier (an old daemon may emit completely empty
+    /// rows under load).
+    pub fn from_ps_entry(entry: &serde_json::Value) -> Option<Self> {
+        let name = entry
+            .get("name")
+            .and_then(serde_json::Value::as_str)
+            .or_else(|| entry.get("model").and_then(serde_json::Value::as_str))
+            .map(str::to_string);
+        let context_length = entry
+            .get("context_length")
+            .and_then(serde_json::Value::as_u64)
+            .or_else(|| {
+                entry
+                    .get("details")
+                    .and_then(|details| details.get("context_length"))
+                    .and_then(serde_json::Value::as_u64)
+            });
+        Some(Self {
+            name,
+            size_bytes: entry.get("size").and_then(serde_json::Value::as_u64),
+            size_vram_bytes: entry.get("size_vram").and_then(serde_json::Value::as_u64),
+            expires_at: entry
+                .get("expires_at")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string),
+            context_length,
+        })
+    }
+}
+
+fn ns_field(frame: &serde_json::Value, key: &str) -> Option<u64> {
+    frame
+        .get(key)
+        .and_then(serde_json::Value::as_u64)
+        .map(ProviderTelemetry::ns_to_ms)
+}
+
+fn ms_or_round(value: Option<&serde_json::Value>) -> Option<u64> {
+    let value = value?;
+    if let Some(n) = value.as_u64() {
+        return Some(n);
+    }
+    value.as_f64().map(|n| n.round().max(0.0) as u64)
+}
+
+fn insert_opt_u64(dict: &mut BTreeMap<String, VmValue>, key: &str, value: Option<u64>) {
+    if let Some(value) = value {
+        dict.insert(key.to_string(), VmValue::Int(value as i64));
+    }
+}
+
+fn insert_opt_i64(dict: &mut BTreeMap<String, VmValue>, key: &str, value: Option<i64>) {
+    if let Some(value) = value {
+        dict.insert(key.to_string(), VmValue::Int(value));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ollama_done_frame_extracts_full_breakdown() {
+        let frame = serde_json::json!({
+            "model": "qwen3.6:35b-a3b-coding-nvfp4",
+            "total_duration": 7_400_000_000u64,
+            "load_duration": 400_000_000u64,
+            "prompt_eval_duration": 1_200_000_000u64,
+            "eval_duration": 5_800_000_000u64,
+            "prompt_eval_count": 1024,
+            "eval_count": 64
+        });
+
+        let telemetry = ProviderTelemetry::from_ollama_done(&frame, source::OLLAMA_CHAT);
+
+        assert_eq!(telemetry.source, source::OLLAMA_CHAT);
+        assert_eq!(telemetry.server_total_ms, Some(7400));
+        assert_eq!(telemetry.server_load_ms, Some(400));
+        assert_eq!(telemetry.server_prompt_eval_ms, Some(1200));
+        assert_eq!(telemetry.server_generation_ms, Some(5800));
+        assert_eq!(telemetry.server_prompt_tokens, Some(1024));
+        assert_eq!(telemetry.server_output_tokens, Some(64));
+        assert_eq!(
+            telemetry.runtime_loaded_model.as_deref(),
+            Some("qwen3.6:35b-a3b-coding-nvfp4")
+        );
+        assert!(!telemetry.is_empty());
+    }
+
+    #[test]
+    fn ollama_done_frame_leaves_missing_fields_as_none() {
+        let frame = serde_json::json!({
+            "model": "qwen3.6:35b-a3b-coding-nvfp4",
+            // Older Ollama builds omit duration fields on early frames.
+        });
+
+        let telemetry = ProviderTelemetry::from_ollama_done(&frame, source::OLLAMA_CHAT);
+
+        assert_eq!(telemetry.server_total_ms, None);
+        assert_eq!(telemetry.server_load_ms, None);
+        assert_eq!(telemetry.server_prompt_eval_ms, None);
+        assert_eq!(telemetry.server_generation_ms, None);
+        assert_eq!(telemetry.server_prompt_tokens, None);
+        assert_eq!(telemetry.server_output_tokens, None);
+    }
+
+    #[test]
+    fn openai_usage_partial_extracts_counts_only() {
+        let usage = serde_json::json!({
+            "prompt_tokens": 200,
+            "completion_tokens": 50
+        });
+
+        let telemetry = ProviderTelemetry::from_openai_usage(&usage, Some("req-abc"));
+
+        assert_eq!(telemetry.source, source::OPENAI_USAGE);
+        assert_eq!(telemetry.server_prompt_tokens, Some(200));
+        assert_eq!(telemetry.server_output_tokens, Some(50));
+        assert_eq!(telemetry.server_prompt_eval_ms, None);
+        assert_eq!(telemetry.request_id.as_deref(), Some("req-abc"));
+    }
+
+    #[test]
+    fn llamacpp_timings_promotes_source_and_fills_durations() {
+        let usage = serde_json::json!({
+            "prompt_tokens": 220,
+            "completion_tokens": 17,
+            "timings": {
+                "prompt_n": 200,
+                "prompt_ms": 145.4,
+                "predicted_n": 17,
+                "predicted_ms": 89.1,
+            }
+        });
+
+        let telemetry = ProviderTelemetry::from_openai_usage(&usage, None);
+
+        assert_eq!(telemetry.source, source::LLAMACPP_TIMINGS);
+        assert_eq!(telemetry.server_prompt_eval_ms, Some(145));
+        assert_eq!(telemetry.server_generation_ms, Some(89));
+        assert_eq!(telemetry.server_total_ms, Some(234));
+        assert_eq!(telemetry.server_prompt_tokens, Some(200));
+        assert_eq!(telemetry.server_output_tokens, Some(17));
+        assert!(!telemetry.is_empty());
+    }
+
+    #[test]
+    fn ps_entry_pulls_context_length_from_top_level_or_details() {
+        let entry = serde_json::json!({
+            "name": "qwen3.6:35b-a3b-coding-nvfp4",
+            "size": 4_700_000_000u64,
+            "size_vram": 4_500_000_000u64,
+            "expires_at": "2026-05-14T10:30:00Z",
+            "context_length": 32768
+        });
+        let model = OllamaPsModel::from_ps_entry(&entry).expect("ps entry parses");
+        assert_eq!(model.context_length, Some(32768));
+
+        let entry_nested = serde_json::json!({
+            "name": "qwen3.6:35b-a3b-coding-nvfp4",
+            "details": {"context_length": 16384}
+        });
+        let nested = OllamaPsModel::from_ps_entry(&entry_nested).expect("ps entry parses");
+        assert_eq!(nested.context_length, Some(16384));
+    }
+
+    #[test]
+    fn merge_ollama_ps_preserves_call_level_values() {
+        let mut telemetry = ProviderTelemetry::new(source::OLLAMA_CHAT);
+        telemetry.runtime_loaded_model = Some("real-model".to_string());
+        let ps = OllamaPsModel {
+            name: Some("alias-model".to_string()),
+            size_bytes: Some(1),
+            size_vram_bytes: Some(2),
+            expires_at: Some("forever".to_string()),
+            context_length: Some(8192),
+        };
+        telemetry.merge_ollama_ps(&ps);
+        assert_eq!(
+            telemetry.runtime_loaded_model.as_deref(),
+            Some("real-model")
+        );
+        assert_eq!(telemetry.runtime_memory_bytes, Some(1));
+        assert_eq!(telemetry.runtime_memory_vram_bytes, Some(2));
+        assert_eq!(
+            telemetry.runtime_keep_alive_until.as_deref(),
+            Some("forever")
+        );
+        assert_eq!(telemetry.runtime_context_length, Some(8192));
+    }
+
+    #[test]
+    fn as_vm_dict_returns_none_when_empty() {
+        let telemetry = ProviderTelemetry::default();
+        assert!(telemetry.is_empty());
+        assert!(telemetry.as_vm_dict().is_none());
+    }
+
+    #[test]
+    fn as_vm_dict_serializes_all_present_fields() {
+        let telemetry = ProviderTelemetry {
+            source: source::OLLAMA_CHAT.to_string(),
+            server_total_ms: Some(100),
+            client_wall_ms: Some(120),
+            runtime_loaded_model: Some("qwen".to_string()),
+            ..Default::default()
+        };
+        let value = telemetry.as_vm_dict().expect("dict present");
+        let dict = value.as_dict().expect("dict body");
+        assert_eq!(
+            dict.get("source").map(VmValue::display).as_deref(),
+            Some(source::OLLAMA_CHAT)
+        );
+        assert_eq!(
+            dict.get("server_total_ms").and_then(|v| match v {
+                VmValue::Int(n) => Some(*n),
+                _ => None,
+            }),
+            Some(100)
+        );
+        assert_eq!(
+            dict.get("client_wall_ms").and_then(|v| match v {
+                VmValue::Int(n) => Some(*n),
+                _ => None,
+            }),
+            Some(120)
+        );
+    }
+}

--- a/crates/harn-vm/src/llm/api/transport.rs
+++ b/crates/harn-vm/src/llm/api/transport.rs
@@ -16,6 +16,7 @@ use super::options::{DeltaSender, LlmRequestPayload};
 use super::partial_tool_args::{project_partial, DeltaCoalescer, PartialToolArgs};
 use super::response::{extract_cache_read_tokens, extract_cache_write_tokens, parse_llm_response};
 use super::result::LlmResult;
+use super::telemetry::{source as telemetry_source, ProviderTelemetry};
 use super::thinking::ThinkingStreamSplitter;
 
 fn parse_ollama_tool_arguments(arguments: &serde_json::Value) -> serde_json::Value {
@@ -243,6 +244,34 @@ async fn dispatch_to_registered_provider(
 /// Provider implementations call this after building their provider-specific
 /// request body via `build_request_body()`.
 pub(crate) async fn vm_call_llm_api_with_body(
+    opts: &LlmRequestPayload,
+    delta_tx: Option<DeltaSender>,
+    body: serde_json::Value,
+    is_anthropic_style: bool,
+    is_ollama: bool,
+) -> Result<LlmResult, VmError> {
+    let started = Instant::now();
+    let mut result =
+        vm_call_llm_api_with_body_inner(opts, delta_tx, body, is_anthropic_style, is_ollama)
+            .await?;
+    // Preserve a per-call wall clock regardless of provider. Server-side
+    // timings (when available) cover only the model's view; client_wall_ms
+    // captures network + streaming overhead the server cannot see, so eval
+    // dashboards can decompose total latency end-to-end.
+    if result.telemetry.client_wall_ms.is_none() {
+        result.telemetry.client_wall_ms = Some(elapsed_ms(started));
+    }
+    if result.telemetry.source.is_empty() {
+        result.telemetry.source = telemetry_source::UNKNOWN.to_string();
+    }
+    Ok(result)
+}
+
+pub(crate) fn elapsed_ms(started: Instant) -> u64 {
+    started.elapsed().as_millis().min(u128::from(u64::MAX)) as u64
+}
+
+async fn vm_call_llm_api_with_body_inner(
     opts: &LlmRequestPayload,
     delta_tx: Option<DeltaSender>,
     mut body: serde_json::Value,
@@ -590,6 +619,8 @@ pub(super) async fn consume_sse_lines<R: tokio::io::AsyncBufRead + Unpin>(
     let mut output_tokens: i64 = 0;
     let mut tool_calls: Vec<serde_json::Value> = Vec::new();
     let mut blocks: Vec<serde_json::Value> = Vec::new();
+    let mut telemetry = ProviderTelemetry::default();
+    let mut anth_request_id: Option<String> = None;
 
     struct ToolBlock {
         id: String,
@@ -676,6 +707,11 @@ pub(super) async fn consume_sse_lines<R: tokio::io::AsyncBufRead + Unpin>(
                     let cw = extract_cache_write_tokens(usage);
                     if cw > 0 {
                         cache_write_tokens = cw;
+                    }
+                    if let Some(rid) = json["message"]["id"].as_str() {
+                        if !rid.is_empty() {
+                            anth_request_id = Some(rid.to_string());
+                        }
                     }
                 }
                 Some("content_block_start") => {
@@ -997,6 +1033,11 @@ pub(super) async fn consume_sse_lines<R: tokio::io::AsyncBufRead + Unpin>(
                 if cw > 0 {
                     cache_write_tokens = cw;
                 }
+                let request_id = json
+                    .get("id")
+                    .and_then(serde_json::Value::as_str)
+                    .filter(|value| !value.is_empty());
+                telemetry = ProviderTelemetry::from_openai_usage(usage, request_id);
             }
         }
     }
@@ -1064,6 +1105,13 @@ pub(super) async fn consume_sse_lines<R: tokio::io::AsyncBufRead + Unpin>(
     } else {
         provider.to_string()
     };
+    if telemetry.is_empty() && is_anthropic_style && (input_tokens > 0 || output_tokens > 0) {
+        let usage = serde_json::json!({
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+        });
+        telemetry = ProviderTelemetry::from_anthropic_usage(&usage, anth_request_id.as_deref());
+    }
     Ok(LlmResult {
         text,
         tool_calls,
@@ -1082,6 +1130,7 @@ pub(super) async fn consume_sse_lines<R: tokio::io::AsyncBufRead + Unpin>(
         stop_reason,
         blocks,
         logprobs: Vec::new(),
+        telemetry,
     })
 }
 
@@ -1135,6 +1184,7 @@ where
     let mut blocks = Vec::new();
     let mut saw_done = false;
     let mut saw_chunk = false;
+    let mut telemetry = ProviderTelemetry::default();
 
     loop {
         let line = next_ollama_ndjson_line(&mut lines, model, unload_grace, warmup_gate)
@@ -1194,6 +1244,7 @@ where
             if let Some(n) = json["eval_count"].as_i64() {
                 output_tokens = n;
             }
+            telemetry = ProviderTelemetry::from_ollama_done(&json, telemetry_source::OLLAMA_CHAT);
             saw_done = true;
             break;
         }
@@ -1250,6 +1301,7 @@ where
         stop_reason: None,
         blocks,
         logprobs: Vec::new(),
+        telemetry,
     })
 }
 
@@ -1308,7 +1360,7 @@ fn is_ollama_empty_content_parser_bug(err: &VmError) -> bool {
 mod tests {
     use super::{
         append_ollama_tool_calls, consume_ollama_ndjson_lines, parse_ollama_tool_arguments,
-        should_request_stream_usage,
+        should_request_stream_usage, telemetry_source,
     };
     use std::time::Duration;
 
@@ -1404,6 +1456,39 @@ mod tests {
         .await
         .expect_err("truncated Ollama stream should fail");
         assert!(err.to_string().contains("unexpected EOF before done=true"));
+    }
+
+    #[tokio::test]
+    async fn ollama_ndjson_captures_server_telemetry_from_done_frame() {
+        let body = b"{\"message\":{\"role\":\"assistant\",\"content\":\"ok\"},\"done\":false}\n\
+            {\"message\":{\"role\":\"assistant\",\"content\":\"\"},\"done\":true,\
+            \"model\":\"qwen3.6:35b-a3b-coding-nvfp4\",\
+            \"total_duration\":4500000000,\"load_duration\":300000000,\
+            \"prompt_eval_count\":42,\"prompt_eval_duration\":1100000000,\
+            \"eval_count\":7,\"eval_duration\":3000000000}\n";
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut warmup_gate = false;
+        let result = consume_ollama_ndjson_lines(
+            &body[..],
+            "ollama",
+            "qwen3.6:35b-a3b-coding-nvfp4",
+            tx,
+            Duration::ZERO,
+            &mut warmup_gate,
+        )
+        .await
+        .expect("ollama stream parses");
+        assert_eq!(result.telemetry.source, telemetry_source::OLLAMA_CHAT);
+        assert_eq!(result.telemetry.server_total_ms, Some(4500));
+        assert_eq!(result.telemetry.server_load_ms, Some(300));
+        assert_eq!(result.telemetry.server_prompt_eval_ms, Some(1100));
+        assert_eq!(result.telemetry.server_generation_ms, Some(3000));
+        assert_eq!(result.telemetry.server_prompt_tokens, Some(42));
+        assert_eq!(result.telemetry.server_output_tokens, Some(7));
+        assert_eq!(
+            result.telemetry.runtime_loaded_model.as_deref(),
+            Some("qwen3.6:35b-a3b-coding-nvfp4")
+        );
     }
 }
 

--- a/crates/harn-vm/src/llm/api/transport.rs
+++ b/crates/harn-vm/src/llm/api/transport.rs
@@ -16,7 +16,7 @@ use super::options::{DeltaSender, LlmRequestPayload};
 use super::partial_tool_args::{project_partial, DeltaCoalescer, PartialToolArgs};
 use super::response::{extract_cache_read_tokens, extract_cache_write_tokens, parse_llm_response};
 use super::result::LlmResult;
-use super::telemetry::{source as telemetry_source, ProviderTelemetry};
+use super::telemetry::{elapsed_ms, source as telemetry_source, ProviderTelemetry};
 use super::thinking::ThinkingStreamSplitter;
 
 fn parse_ollama_tool_arguments(arguments: &serde_json::Value) -> serde_json::Value {
@@ -265,10 +265,6 @@ pub(crate) async fn vm_call_llm_api_with_body(
         result.telemetry.source = telemetry_source::UNKNOWN.to_string();
     }
     Ok(result)
-}
-
-pub(crate) fn elapsed_ms(started: Instant) -> u64 {
-    started.elapsed().as_millis().min(u128::from(u64::MAX)) as u64
 }
 
 async fn vm_call_llm_api_with_body_inner(

--- a/crates/harn-vm/src/llm/fake.rs
+++ b/crates/harn-vm/src/llm/fake.rs
@@ -48,7 +48,7 @@
 use std::cell::RefCell;
 use std::time::Duration;
 
-use crate::llm::api::{DeltaSender, LlmRequestPayload, LlmResult};
+use crate::llm::api::{DeltaSender, LlmRequestPayload, LlmResult, ProviderTelemetry};
 use crate::llm::provider::{LlmProvider, LlmProviderChat};
 use crate::value::{ErrorCategory, VmError};
 
@@ -455,6 +455,7 @@ async fn play_stream(
         stop_reason: Some(stop_reason.as_str().to_string()),
         blocks,
         logprobs: Vec::new(),
+        telemetry: ProviderTelemetry::default(),
     })
 }
 

--- a/crates/harn-vm/src/llm/mock.rs
+++ b/crates/harn-vm/src/llm/mock.rs
@@ -1,7 +1,7 @@
 use std::cell::RefCell;
 use std::collections::BTreeSet;
 
-use super::api::LlmResult;
+use super::api::{LlmResult, ProviderTelemetry};
 use crate::orchestration::ToolCallRecord;
 use crate::value::{ErrorCategory, VmError};
 
@@ -236,6 +236,7 @@ fn build_mock_result(mock: &LlmMock, last_msg_len: usize) -> LlmResult {
         stop_reason: mock.stop_reason.clone(),
         blocks,
         logprobs: mock.logprobs.clone(),
+        telemetry: ProviderTelemetry::default(),
     }
 }
 
@@ -583,6 +584,7 @@ pub(crate) fn load_fixture(hash: &str) -> Option<LlmResult> {
         stop_reason: json["stop_reason"].as_str().map(|s| s.to_string()),
         blocks: json["blocks"].as_array().cloned().unwrap_or_default(),
         logprobs: json["logprobs"].as_array().cloned().unwrap_or_default(),
+        telemetry: serde_json::from_value(json["telemetry"].clone()).unwrap_or_default(),
     })
 }
 
@@ -714,6 +716,7 @@ pub(crate) fn mock_llm_response(
                     "visibility": "internal",
                 })],
                 logprobs: Vec::new(),
+                telemetry: ProviderTelemetry::default(),
             };
             if cache {
                 apply_mock_prompt_cache(&mut result, &cache_key);
@@ -761,6 +764,7 @@ pub(crate) fn mock_llm_response(
             "visibility": "public",
         })],
         logprobs: Vec::new(),
+        telemetry: ProviderTelemetry::default(),
     };
     if cache {
         apply_mock_prompt_cache(&mut result, &cache_key);

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -16,7 +16,7 @@ mod agent_observe;
 mod agent_runtime;
 mod agent_session_host;
 mod agent_tools;
-pub(crate) mod api;
+pub mod api;
 pub(crate) mod autonomy_budget;
 pub(crate) mod cache;
 pub mod capabilities;

--- a/crates/harn-vm/src/llm/providers/common.rs
+++ b/crates/harn-vm/src/llm/providers/common.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 
-use crate::llm::api::{DeltaSender, LlmResult};
+use crate::llm::api::{DeltaSender, LlmResult, ProviderTelemetry};
 use crate::value::{VmError, VmValue};
 
 pub(super) fn vm_err(message: impl Into<String>) -> VmError {
@@ -64,6 +64,7 @@ pub(super) fn empty_result(provider: &str, model: &str) -> LlmResult {
         stop_reason: None,
         blocks: Vec::new(),
         logprobs: Vec::new(),
+        telemetry: ProviderTelemetry::default(),
     }
 }
 

--- a/crates/harn-vm/src/llm/providers/gemini.rs
+++ b/crates/harn-vm/src/llm/providers/gemini.rs
@@ -2,7 +2,9 @@
 
 use std::rc::Rc;
 
-use crate::llm::api::{DeltaSender, LlmRequestPayload, LlmResult, ReasoningEffort, ThinkingConfig};
+use crate::llm::api::{
+    DeltaSender, LlmRequestPayload, LlmResult, ProviderTelemetry, ReasoningEffort, ThinkingConfig,
+};
 use crate::llm::provider::{LlmProvider, LlmProviderChat};
 use crate::value::{VmError, VmValue};
 
@@ -219,6 +221,17 @@ fn parse_response(
     let stop_reason = json["candidates"][0]["finishReason"]
         .as_str()
         .map(str::to_string);
+    // Gemini's REST response carries only token counts (no server-side
+    // timings) so we synthesize an OpenAI-shaped usage block and route it
+    // through the same normalizer the rest of the providers use.
+    let usage = serde_json::json!({
+        "prompt_tokens": input_tokens,
+        "completion_tokens": output_tokens,
+    });
+    let request_id = json["responseId"]
+        .as_str()
+        .filter(|value| !value.is_empty());
+    let telemetry = ProviderTelemetry::from_openai_usage(&usage, request_id);
     Ok(LlmResult {
         text,
         tool_calls: Vec::new(),
@@ -233,6 +246,7 @@ fn parse_response(
         stop_reason,
         blocks,
         logprobs: Vec::new(),
+        telemetry,
     })
 }
 

--- a/crates/harn-vm/src/llm/providers/ollama.rs
+++ b/crates/harn-vm/src/llm/providers/ollama.rs
@@ -1,7 +1,7 @@
 //! Ollama provider — local Ollama server with NDJSON streaming.
 
 use crate::llm::api::{
-    telemetry_source, DeltaSender, LlmRequestPayload, LlmResult, ProviderTelemetry,
+    elapsed_ms, telemetry_source, DeltaSender, LlmRequestPayload, LlmResult, ProviderTelemetry,
 };
 use crate::llm::provider::{LlmProvider, LlmProviderChat};
 use crate::value::{VmError, VmValue};
@@ -255,10 +255,6 @@ impl OllamaProvider {
         result.telemetry.client_wall_ms = Some(elapsed_ms(started));
         Ok(result)
     }
-}
-
-fn elapsed_ms(started: Instant) -> u64 {
-    started.elapsed().as_millis().min(u128::from(u64::MAX)) as u64
 }
 
 fn render_qwen_chat_prompt(opts: &LlmRequestPayload) -> String {

--- a/crates/harn-vm/src/llm/providers/ollama.rs
+++ b/crates/harn-vm/src/llm/providers/ollama.rs
@@ -1,9 +1,12 @@
 //! Ollama provider — local Ollama server with NDJSON streaming.
 
-use crate::llm::api::{DeltaSender, LlmRequestPayload, LlmResult};
+use crate::llm::api::{
+    telemetry_source, DeltaSender, LlmRequestPayload, LlmResult, ProviderTelemetry,
+};
 use crate::llm::provider::{LlmProvider, LlmProviderChat};
 use crate::value::{VmError, VmValue};
 use std::rc::Rc;
+use std::time::Instant;
 
 /// Zero-cost unit struct for the Ollama provider.
 pub(crate) struct OllamaProvider;
@@ -223,6 +226,7 @@ impl OllamaProvider {
             .timeout(std::time::Duration::from_secs(request.resolve_timeout()))
             .json(&body);
         let req = crate::llm::api::apply_auth_headers(req, &request.api_key, pdef.as_ref());
+        let started = Instant::now();
         let response = req.send().await.map_err(|error| {
             VmError::Thrown(VmValue::String(Rc::from(format!(
                 "ollama raw generate API error: {error}"
@@ -239,16 +243,22 @@ impl OllamaProvider {
             let msg = Self::classify_http_error(status, retry_after.as_deref(), &body).message;
             return Err(VmError::Thrown(VmValue::String(Rc::from(msg))));
         }
-        if request.stream {
+        let mut result = if request.stream {
             let tx = delta_tx.unwrap_or_else(|| {
                 let (tx, _rx) = tokio::sync::mpsc::unbounded_channel::<String>();
                 tx
             });
-            parse_raw_generate_stream(response, &request.provider, &request.model, tx).await
+            parse_raw_generate_stream(response, &request.provider, &request.model, tx).await?
         } else {
-            parse_raw_generate_response(response, request).await
-        }
+            parse_raw_generate_response(response, request).await?
+        };
+        result.telemetry.client_wall_ms = Some(elapsed_ms(started));
+        Ok(result)
     }
+}
+
+fn elapsed_ms(started: Instant) -> u64 {
+    started.elapsed().as_millis().min(u128::from(u64::MAX)) as u64
 }
 
 fn render_qwen_chat_prompt(opts: &LlmRequestPayload) -> String {
@@ -389,6 +399,7 @@ async fn parse_raw_generate_response(
             request.model
         )))));
     }
+    let telemetry = ProviderTelemetry::from_ollama_done(&json, telemetry_source::OLLAMA_GENERATE);
     Ok(LlmResult {
         blocks: blocks_from_text_and_thinking(&text, &thinking),
         text,
@@ -410,6 +421,7 @@ async fn parse_raw_generate_response(
             .and_then(|value| value.as_str())
             .map(str::to_string),
         logprobs: Vec::new(),
+        telemetry,
     })
 }
 
@@ -433,6 +445,7 @@ async fn parse_raw_generate_stream(
     let mut input_tokens = 0;
     let mut output_tokens = 0;
     let mut stop_reason = None;
+    let mut telemetry = ProviderTelemetry::default();
 
     while let Ok(Some(line)) = lines.next_line().await {
         if line.is_empty() {
@@ -470,6 +483,8 @@ async fn parse_raw_generate_stream(
                 .get("done_reason")
                 .and_then(|value| value.as_str())
                 .map(str::to_string);
+            telemetry =
+                ProviderTelemetry::from_ollama_done(&json, telemetry_source::OLLAMA_GENERATE);
             break;
         }
     }
@@ -501,6 +516,7 @@ async fn parse_raw_generate_stream(
         thinking_summary: None,
         stop_reason,
         logprobs: Vec::new(),
+        telemetry,
     })
 }
 

--- a/scripts/lint_test_patterns.sh
+++ b/scripts/lint_test_patterns.sh
@@ -400,6 +400,9 @@ NON_TEST_WALL_CLOCK_ALLOWLIST=(
   "crates/harn-vm/src/llm/cache.rs"
   "crates/harn-vm/src/llm/mod.rs"
   "crates/harn-vm/src/llm/model_test.rs"
+  # Ollama raw `/api/generate` bypasses the shared transport wrapper, so it
+  # records actual host monotonic elapsed time for provider telemetry.
+  "crates/harn-vm/src/llm/providers/ollama.rs"
   "crates/harn-vm/src/llm/providers/vertex.rs"
   "crates/harn-vm/src/llm/rate_limit.rs"
   "crates/harn-vm/src/llm/stream.rs"


### PR DESCRIPTION
## Summary

Closes #1614. Adds a normalized `ProviderTelemetry` envelope so server-side timings the local runtimes already report flow through `llm_call`, transcripts, and the structured-output wrapper.

- **`ProviderTelemetry` on every `LlmResult`** — Ollama `/api/chat` NDJSON and `/api/generate` lift `total_duration`, `load_duration`, `prompt_eval_duration`, `eval_duration`, prompt-eval / eval token counts, and the daemon-resolved model id (`ns→ms` centralized). OpenAI-compatible responses preserve `prompt_tokens` / `completion_tokens` even without timings; llama.cpp's `usage.timings` extension promotes the source to `llamacpp_timings` with prefill/decode milliseconds. Anthropic Messages preserve the `id`. Missing fields stay `None` so eval pipelines can distinguish "not reported" from "zero".
- **`client_wall_ms` always recorded** in the wrapper around `vm_call_llm_api_with_body` (Ollama raw_generate sets its own first); decomposes network/streaming overhead the server counters miss.
- **Single envelope across surfaces**: `llm_call` result dict gets `provider_telemetry` at the top level and under `usage`; the structured-output wrapper picks it up via the existing `usage`-clone path; `dump_llm_response` writes it to transcripts so Burin evals decode one shape per provider.
- **`OllamaPsModel` shared between harn-vm and `harn local`** — `/api/ps` parsing now lives in one place; `LoadedModel` picks up `context_length` where the daemon reports it.
- **New `harn provider probe <provider>` command** — machine-readable readiness + loaded-model snapshot (size, VRAM, expiry, context length). Pairs with `harn local status --json` for full lifecycle insight.

Acceptance criteria from the issue are all covered:

- [x] Ollama captures and serializes the telemetry fields documented in the spec.
- [x] `harn local status --json` includes `/api/ps` model state (now also `context_length`).
- [x] OpenAI-compatible providers preserve any `usage` or timing metadata.
- [x] Missing telemetry is explicit (`None`), never silently zero.
- [x] Burin eval summaries can consume the Harn envelope without provider-specific parsing.
- [x] Regression tests for Ollama response parsing and partial-usage OpenAI-compatible fallback.

## Test plan

- [x] `cargo test --workspace` (3825 tests pass)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `make lint-md` clean
- [x] New tests:
  - `llm::api::telemetry::tests::*` — 8 cases covering Ollama done-frame extraction, partial OpenAI usage, llama.cpp timings promotion, `/api/ps` context_length, and dict serialization.
  - `llm::api::transport::tests::ollama_ndjson_captures_server_telemetry_from_done_frame` — end-to-end NDJSON capture.
  - `llm::api::response::tests::{openai_parser_preserves_partial_usage_in_telemetry, openai_parser_lifts_llamacpp_timings_into_telemetry, anthropic_parser_captures_request_id_in_telemetry}`.
  - `cli::tests::test_parses_provider_probe_args`.
- [ ] Manual smoke: `harn provider probe ollama --model qwen3.6-coding` against a real daemon (not exercised in CI; covered by mock-stub structure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)