### PR TITLE
[codex] Define composition event contract

### DIFF
--- a/conformance/protocols/fixtures/acp/agent_event_ext_notifications.valid.json
+++ b/conformance/protocols/fixtures/acp/agent_event_ext_notifications.valid.json
@@ -30,6 +30,199 @@
       "jsonrpc": "2.0",
       "method": "_harn/agentEvent",
       "params": {
+        "artifacts": [],
+        "bindingManifestHash": "sha256:manifest-readonly",
+        "durationMs": null,
+        "error": null,
+        "failureCategory": null,
+        "kind": "composition_start",
+        "language": "harn",
+        "metadata": {},
+        "requestedSideEffectCeiling": "read_only",
+        "result": null,
+        "runId": "cmp-1",
+        "sessionId": "session-1",
+        "snippetHash": "sha256:2ef48d9c1687d751a5d53acf87171cfa53db1e0bfb28f4e86ea57e8054d9e775",
+        "stderr": null,
+        "stdout": null
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "method": "_harn/agentEvent",
+      "params": {
+        "annotations": {
+          "arg_schema": {
+            "arg_aliases": {},
+            "path_params": [],
+            "required": []
+          },
+          "capabilities": {},
+          "emits_artifacts": false,
+          "inline_result": false,
+          "kind": "search",
+          "result_readers": [],
+          "side_effect_level": "read_only"
+        },
+        "kind": "composition_child_call",
+        "operationIndex": 0,
+        "policyContext": {
+          "approval": "not_required",
+          "ceiling": "read_only"
+        },
+        "rawInput": {
+          "query": "agent_events"
+        },
+        "requestedSideEffectLevel": "read_only",
+        "runId": "cmp-1",
+        "sessionId": "session-1",
+        "toolCallId": "tool-cmp-1",
+        "toolName": "tool.search"
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "method": "_harn/agentEvent",
+      "params": {
+        "durationMs": 11,
+        "error": null,
+        "errorCategory": null,
+        "executionDurationMs": 9,
+        "executor": "harn_builtin",
+        "kind": "composition_child_result",
+        "operationIndex": 0,
+        "rawOutput": {
+          "count": 1
+        },
+        "runId": "cmp-1",
+        "sessionId": "session-1",
+        "status": "completed",
+        "toolCallId": "tool-cmp-1",
+        "toolName": "tool.search"
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "method": "_harn/agentEvent",
+      "params": {
+        "artifacts": [],
+        "bindingManifestHash": "sha256:manifest-readonly",
+        "durationMs": 18,
+        "error": null,
+        "failureCategory": null,
+        "kind": "composition_finish",
+        "language": "harn",
+        "metadata": {},
+        "requestedSideEffectCeiling": "read_only",
+        "result": {
+          "matches": ["crates/harn-vm/src/lib.rs"]
+        },
+        "runId": "cmp-1",
+        "sessionId": "session-1",
+        "snippetHash": "sha256:2ef48d9c1687d751a5d53acf87171cfa53db1e0bfb28f4e86ea57e8054d9e775",
+        "stderr": null,
+        "stdout": "2 files scanned"
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "method": "_harn/agentEvent",
+      "params": {
+        "artifacts": [],
+        "bindingManifestHash": "sha256:manifest-write",
+        "durationMs": null,
+        "error": null,
+        "failureCategory": null,
+        "kind": "composition_start",
+        "language": "harn",
+        "metadata": {},
+        "requestedSideEffectCeiling": "workspace_write",
+        "result": null,
+        "runId": "cmp-2",
+        "sessionId": "session-1",
+        "snippetHash": "sha256:67d844681154387a2adfd1e6e797b73dc6d0b688a9d0ef83edd7fafdd70954fb",
+        "stderr": null,
+        "stdout": null
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "method": "_harn/agentEvent",
+      "params": {
+        "annotations": {
+          "arg_schema": {
+            "arg_aliases": {},
+            "path_params": [],
+            "required": []
+          },
+          "capabilities": {},
+          "emits_artifacts": false,
+          "inline_result": false,
+          "kind": "edit",
+          "result_readers": [],
+          "side_effect_level": "workspace_write"
+        },
+        "kind": "composition_child_call",
+        "operationIndex": 0,
+        "policyContext": {
+          "approval": "denied",
+          "ceiling": "workspace_write"
+        },
+        "rawInput": {
+          "content": "...",
+          "path": "src/lib.rs"
+        },
+        "requestedSideEffectLevel": "workspace_write",
+        "runId": "cmp-2",
+        "sessionId": "session-1",
+        "toolCallId": "tool-cmp-2",
+        "toolName": "tool.write_file"
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "method": "_harn/agentEvent",
+      "params": {
+        "durationMs": 3,
+        "error": "workspace writes require approval",
+        "errorCategory": "permission_denied",
+        "executionDurationMs": 0,
+        "executor": null,
+        "kind": "composition_child_result",
+        "operationIndex": 0,
+        "rawOutput": null,
+        "runId": "cmp-2",
+        "sessionId": "session-1",
+        "status": "failed",
+        "toolCallId": "tool-cmp-2",
+        "toolName": "tool.write_file"
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "method": "_harn/agentEvent",
+      "params": {
+        "artifacts": [],
+        "bindingManifestHash": "sha256:manifest-write",
+        "durationMs": 3,
+        "error": "workspace writes require approval",
+        "failureCategory": "policy_denied",
+        "kind": "composition_error",
+        "language": "harn",
+        "metadata": {},
+        "requestedSideEffectCeiling": "workspace_write",
+        "result": null,
+        "runId": "cmp-2",
+        "sessionId": "session-1",
+        "snippetHash": "sha256:67d844681154387a2adfd1e6e797b73dc6d0b688a9d0ef83edd7fafdd70954fb",
+        "stderr": null,
+        "stdout": null
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "method": "_harn/agentEvent",
+      "params": {
         "kind": "session_closed",
         "metadata": {
           "idle_ms": 5000

--- a/conformance/protocols/schemas/acp-session-update.schema.json
+++ b/conformance/protocols/schemas/acp-session-update.schema.json
@@ -79,6 +79,11 @@
             "kind": {
               "enum": [
                 "budget_exhausted",
+                "composition_child_call",
+                "composition_child_result",
+                "composition_error",
+                "composition_finish",
+                "composition_start",
                 "daemon_watchdog_tripped",
                 "feedback_injected",
                 "judge_decision",

--- a/crates/harn-cli/src/commands/dump_protocol_artifacts.rs
+++ b/crates/harn-cli/src/commands/dump_protocol_artifacts.rs
@@ -2346,8 +2346,24 @@ fn generate_round_trip_fixture() -> Result<String, String> {
         "method": HARN_AGENT_EVENT_METHOD,
         "params": {
             "sessionId": "sess-42",
-            "kind": "turn_end",
-            "turnId": "turn-9",
+            "kind": "composition_child_call",
+            "runId": "cmp-42",
+            "toolCallId": "tool-cmp-42",
+            "toolName": "tool.write_file",
+            "operationIndex": 0,
+            "requestedSideEffectLevel": "workspace_write",
+            "annotations": {
+                "kind": "edit",
+                "side_effect_level": "workspace_write",
+            },
+            "policyContext": {
+                "ceiling": "workspace_write",
+                "approval": "denied",
+            },
+            "rawInput": {
+                "path": "src/lib.rs",
+                "content": "...",
+            },
         }
     });
     let request = json!({
@@ -2675,6 +2691,10 @@ mod tests {
         assert_eq!(
             fixture["envelopes"]["agentEventNotification"]["method"],
             json!(HARN_AGENT_EVENT_METHOD)
+        );
+        assert_eq!(
+            fixture["envelopes"]["agentEventNotification"]["params"]["kind"],
+            json!("composition_child_call")
         );
         assert_eq!(fixture["a2aTask"]["status"]["state"], json!("working"));
     }

--- a/crates/harn-serve/src/adapters/acp/events.rs
+++ b/crates/harn-serve/src/adapters/acp/events.rs
@@ -2,6 +2,7 @@
 //! `session/update` notifications. Registered per-session at prompt start.
 
 use harn_vm::agent_events::{AgentEvent, AgentEventSink, ToolExecutor};
+use harn_vm::composition::{CompositionChildCall, CompositionChildResult, CompositionRunEnvelope};
 use harn_vm::visible_text::sanitize_visible_assistant_text;
 
 use super::AcpOutput;
@@ -110,6 +111,53 @@ impl AcpAgentEventSink {
         harn_meta: serde_json::Map<String, serde_json::Value>,
     ) {
         merge_harn_meta(update, harn_meta);
+    }
+
+    fn composition_run_to_json(run: &CompositionRunEnvelope) -> serde_json::Value {
+        serde_json::json!({
+            "runId": &run.run_id,
+            "language": &run.language,
+            "snippetHash": &run.snippet_hash,
+            "bindingManifestHash": &run.binding_manifest_hash,
+            "requestedSideEffectCeiling": run.requested_side_effect_ceiling.as_str(),
+            "stdout": &run.stdout,
+            "stderr": &run.stderr,
+            "artifacts": &run.artifacts,
+            "result": &run.result,
+            "failureCategory": run.failure_category.map(|category| category.as_str()),
+            "error": &run.error,
+            "durationMs": run.duration_ms,
+            "metadata": &run.metadata,
+        })
+    }
+
+    fn composition_child_call_to_json(call: &CompositionChildCall) -> serde_json::Value {
+        serde_json::json!({
+            "runId": &call.run_id,
+            "toolCallId": &call.tool_call_id,
+            "toolName": &call.tool_name,
+            "operationIndex": call.operation_index,
+            "annotations": &call.annotations,
+            "requestedSideEffectLevel": call.requested_side_effect_level.as_str(),
+            "policyContext": &call.policy_context,
+            "rawInput": &call.raw_input,
+        })
+    }
+
+    fn composition_child_result_to_json(result: &CompositionChildResult) -> serde_json::Value {
+        serde_json::json!({
+            "runId": &result.run_id,
+            "toolCallId": &result.tool_call_id,
+            "toolName": &result.tool_name,
+            "operationIndex": result.operation_index,
+            "status": Self::status_str(result.status),
+            "rawOutput": &result.raw_output,
+            "error": &result.error,
+            "errorCategory": result.error_category.map(|category| category.as_str()),
+            "executor": result.executor.as_ref().map(Self::executor_to_json),
+            "durationMs": result.duration_ms,
+            "executionDurationMs": result.execution_duration_ms,
+        })
     }
 }
 
@@ -837,6 +885,41 @@ impl AgentEventSink for AcpAgentEventSink {
                 ..
             } => {
                 self.emit_agent_event_ext("cache_miss", session_id, payload.clone());
+            }
+            AgentEvent::CompositionStart { session_id, run } => {
+                self.emit_agent_event_ext(
+                    "composition_start",
+                    session_id,
+                    Self::composition_run_to_json(run),
+                );
+            }
+            AgentEvent::CompositionChildCall { session_id, call } => {
+                self.emit_agent_event_ext(
+                    "composition_child_call",
+                    session_id,
+                    Self::composition_child_call_to_json(call),
+                );
+            }
+            AgentEvent::CompositionChildResult { session_id, result } => {
+                self.emit_agent_event_ext(
+                    "composition_child_result",
+                    session_id,
+                    Self::composition_child_result_to_json(result),
+                );
+            }
+            AgentEvent::CompositionFinish { session_id, run } => {
+                self.emit_agent_event_ext(
+                    "composition_finish",
+                    session_id,
+                    Self::composition_run_to_json(run),
+                );
+            }
+            AgentEvent::CompositionError { session_id, run } => {
+                self.emit_agent_event_ext(
+                    "composition_error",
+                    session_id,
+                    Self::composition_run_to_json(run),
+                );
             }
         }
     }

--- a/crates/harn-serve/src/adapters/acp/events/tests.rs
+++ b/crates/harn-serve/src/adapters/acp/events/tests.rs
@@ -1,10 +1,14 @@
 use harn_vm::agent_events::{
     AgentEvent, AgentEventSink, FsWatchEvent, ToolCallErrorCategory, ToolCallStatus, ToolExecutor,
 };
+use harn_vm::composition::{
+    composition_snippet_hash, CompositionChildCall, CompositionChildResult,
+    CompositionFailureCategory, CompositionRunEnvelope,
+};
 use harn_vm::orchestration::{
     HandoffArtifact, HandoffTargetRecord, MutationSessionRecord, ToolApprovalPolicy,
 };
-use harn_vm::tool_annotations::ToolKind;
+use harn_vm::tool_annotations::{SideEffectLevel, ToolAnnotations, ToolKind};
 use tokio::sync::mpsc;
 
 use super::super::schema::{
@@ -219,6 +223,30 @@ async fn protocol_conformance_standard_session_update_fixture_is_adapter_generat
 }
 
 fn agent_event_ext_fixture_events() -> Vec<AgentEvent> {
+    let read_only_start = CompositionRunEnvelope::read_only(
+        "cmp-1",
+        "harn",
+        composition_snippet_hash("harn", "tool.search(\"agent_events\")"),
+        "sha256:manifest-readonly",
+    );
+    let read_only_finish = CompositionRunEnvelope {
+        stdout: Some("2 files scanned".to_string()),
+        result: Some(serde_json::json!({"matches": ["crates/harn-vm/src/lib.rs"]})),
+        duration_ms: Some(18),
+        ..read_only_start.clone()
+    };
+    let mut failed_start = CompositionRunEnvelope::read_only(
+        "cmp-2",
+        "harn",
+        composition_snippet_hash("harn", "write_file(\"src/lib.rs\", \"...\")"),
+        "sha256:manifest-write",
+    );
+    failed_start.requested_side_effect_ceiling = SideEffectLevel::WorkspaceWrite;
+    let mut failed_error = failed_start.clone();
+    failed_error.failure_category = Some(CompositionFailureCategory::PolicyDenied);
+    failed_error.error = Some("workspace writes require approval".to_string());
+    failed_error.duration_ms = Some(3);
+
     vec![
         AgentEvent::TurnStart {
             session_id: "session-1".to_string(),
@@ -231,6 +259,95 @@ fn agent_event_ext_fixture_events() -> Vec<AgentEvent> {
                 "tool_calls": 2,
                 "tool_names": ["read_file", "grep"]
             }),
+        },
+        AgentEvent::CompositionStart {
+            session_id: "session-1".to_string(),
+            run: read_only_start,
+        },
+        AgentEvent::CompositionChildCall {
+            session_id: "session-1".to_string(),
+            call: CompositionChildCall {
+                run_id: "cmp-1".to_string(),
+                tool_call_id: "tool-cmp-1".to_string(),
+                tool_name: "tool.search".to_string(),
+                operation_index: 0,
+                requested_side_effect_level: SideEffectLevel::ReadOnly,
+                annotations: Some(ToolAnnotations {
+                    kind: ToolKind::Search,
+                    side_effect_level: SideEffectLevel::ReadOnly,
+                    ..ToolAnnotations::default()
+                }),
+                policy_context: serde_json::json!({
+                    "ceiling": "read_only",
+                    "approval": "not_required"
+                }),
+                raw_input: serde_json::json!({"query": "agent_events"}),
+            },
+        },
+        AgentEvent::CompositionChildResult {
+            session_id: "session-1".to_string(),
+            result: CompositionChildResult {
+                run_id: "cmp-1".to_string(),
+                tool_call_id: "tool-cmp-1".to_string(),
+                tool_name: "tool.search".to_string(),
+                operation_index: 0,
+                status: ToolCallStatus::Completed,
+                raw_output: Some(serde_json::json!({"count": 1})),
+                executor: Some(ToolExecutor::HarnBuiltin),
+                duration_ms: Some(11),
+                execution_duration_ms: Some(9),
+                ..CompositionChildResult::default()
+            },
+        },
+        AgentEvent::CompositionFinish {
+            session_id: "session-1".to_string(),
+            run: read_only_finish,
+        },
+        AgentEvent::CompositionStart {
+            session_id: "session-1".to_string(),
+            run: failed_start,
+        },
+        AgentEvent::CompositionChildCall {
+            session_id: "session-1".to_string(),
+            call: CompositionChildCall {
+                run_id: "cmp-2".to_string(),
+                tool_call_id: "tool-cmp-2".to_string(),
+                tool_name: "tool.write_file".to_string(),
+                operation_index: 0,
+                requested_side_effect_level: SideEffectLevel::WorkspaceWrite,
+                annotations: Some(ToolAnnotations {
+                    kind: ToolKind::Edit,
+                    side_effect_level: SideEffectLevel::WorkspaceWrite,
+                    ..ToolAnnotations::default()
+                }),
+                policy_context: serde_json::json!({
+                    "ceiling": "workspace_write",
+                    "approval": "denied"
+                }),
+                raw_input: serde_json::json!({
+                    "path": "src/lib.rs",
+                    "content": "..."
+                }),
+            },
+        },
+        AgentEvent::CompositionChildResult {
+            session_id: "session-1".to_string(),
+            result: CompositionChildResult {
+                run_id: "cmp-2".to_string(),
+                tool_call_id: "tool-cmp-2".to_string(),
+                tool_name: "tool.write_file".to_string(),
+                operation_index: 0,
+                status: ToolCallStatus::Failed,
+                error: Some("workspace writes require approval".to_string()),
+                error_category: Some(ToolCallErrorCategory::PermissionDenied),
+                duration_ms: Some(3),
+                execution_duration_ms: Some(0),
+                ..CompositionChildResult::default()
+            },
+        },
+        AgentEvent::CompositionError {
+            session_id: "session-1".to_string(),
+            run: failed_error,
         },
         AgentEvent::SessionClosed {
             session_id: "session-1".to_string(),

--- a/crates/harn-serve/src/adapters/acp/schema.rs
+++ b/crates/harn-serve/src/adapters/acp/schema.rs
@@ -48,6 +48,11 @@ pub const HARN_AGENT_EVENT_METHOD: &str = "_harn/agentEvent";
 /// keep it in lockstep with the match arm in `events.rs`.
 pub const HARN_AGENT_EVENT_KINDS: &[&str] = &[
     "budget_exhausted",
+    "composition_child_call",
+    "composition_child_result",
+    "composition_error",
+    "composition_finish",
+    "composition_start",
     "daemon_watchdog_tripped",
     "feedback_injected",
     "judge_decision",

--- a/crates/harn-serve/tests/fixtures/acp/agent_event_ext_notifications.json
+++ b/crates/harn-serve/tests/fixtures/acp/agent_event_ext_notifications.json
@@ -25,6 +25,199 @@
     "jsonrpc": "2.0",
     "method": "_harn/agentEvent",
     "params": {
+      "artifacts": [],
+      "bindingManifestHash": "sha256:manifest-readonly",
+      "durationMs": null,
+      "error": null,
+      "failureCategory": null,
+      "kind": "composition_start",
+      "language": "harn",
+      "metadata": {},
+      "requestedSideEffectCeiling": "read_only",
+      "result": null,
+      "runId": "cmp-1",
+      "sessionId": "session-1",
+      "snippetHash": "sha256:2ef48d9c1687d751a5d53acf87171cfa53db1e0bfb28f4e86ea57e8054d9e775",
+      "stderr": null,
+      "stdout": null
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "_harn/agentEvent",
+    "params": {
+      "annotations": {
+        "arg_schema": {
+          "arg_aliases": {},
+          "path_params": [],
+          "required": []
+        },
+        "capabilities": {},
+        "emits_artifacts": false,
+        "inline_result": false,
+        "kind": "search",
+        "result_readers": [],
+        "side_effect_level": "read_only"
+      },
+      "kind": "composition_child_call",
+      "operationIndex": 0,
+      "policyContext": {
+        "approval": "not_required",
+        "ceiling": "read_only"
+      },
+      "rawInput": {
+        "query": "agent_events"
+      },
+      "requestedSideEffectLevel": "read_only",
+      "runId": "cmp-1",
+      "sessionId": "session-1",
+      "toolCallId": "tool-cmp-1",
+      "toolName": "tool.search"
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "_harn/agentEvent",
+    "params": {
+      "durationMs": 11,
+      "error": null,
+      "errorCategory": null,
+      "executionDurationMs": 9,
+      "executor": "harn_builtin",
+      "kind": "composition_child_result",
+      "operationIndex": 0,
+      "rawOutput": {
+        "count": 1
+      },
+      "runId": "cmp-1",
+      "sessionId": "session-1",
+      "status": "completed",
+      "toolCallId": "tool-cmp-1",
+      "toolName": "tool.search"
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "_harn/agentEvent",
+    "params": {
+      "artifacts": [],
+      "bindingManifestHash": "sha256:manifest-readonly",
+      "durationMs": 18,
+      "error": null,
+      "failureCategory": null,
+      "kind": "composition_finish",
+      "language": "harn",
+      "metadata": {},
+      "requestedSideEffectCeiling": "read_only",
+      "result": {
+        "matches": ["crates/harn-vm/src/lib.rs"]
+      },
+      "runId": "cmp-1",
+      "sessionId": "session-1",
+      "snippetHash": "sha256:2ef48d9c1687d751a5d53acf87171cfa53db1e0bfb28f4e86ea57e8054d9e775",
+      "stderr": null,
+      "stdout": "2 files scanned"
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "_harn/agentEvent",
+    "params": {
+      "artifacts": [],
+      "bindingManifestHash": "sha256:manifest-write",
+      "durationMs": null,
+      "error": null,
+      "failureCategory": null,
+      "kind": "composition_start",
+      "language": "harn",
+      "metadata": {},
+      "requestedSideEffectCeiling": "workspace_write",
+      "result": null,
+      "runId": "cmp-2",
+      "sessionId": "session-1",
+      "snippetHash": "sha256:67d844681154387a2adfd1e6e797b73dc6d0b688a9d0ef83edd7fafdd70954fb",
+      "stderr": null,
+      "stdout": null
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "_harn/agentEvent",
+    "params": {
+      "annotations": {
+        "arg_schema": {
+          "arg_aliases": {},
+          "path_params": [],
+          "required": []
+        },
+        "capabilities": {},
+        "emits_artifacts": false,
+        "inline_result": false,
+        "kind": "edit",
+        "result_readers": [],
+        "side_effect_level": "workspace_write"
+      },
+      "kind": "composition_child_call",
+      "operationIndex": 0,
+      "policyContext": {
+        "approval": "denied",
+        "ceiling": "workspace_write"
+      },
+      "rawInput": {
+        "content": "...",
+        "path": "src/lib.rs"
+      },
+      "requestedSideEffectLevel": "workspace_write",
+      "runId": "cmp-2",
+      "sessionId": "session-1",
+      "toolCallId": "tool-cmp-2",
+      "toolName": "tool.write_file"
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "_harn/agentEvent",
+    "params": {
+      "durationMs": 3,
+      "error": "workspace writes require approval",
+      "errorCategory": "permission_denied",
+      "executionDurationMs": 0,
+      "executor": null,
+      "kind": "composition_child_result",
+      "operationIndex": 0,
+      "rawOutput": null,
+      "runId": "cmp-2",
+      "sessionId": "session-1",
+      "status": "failed",
+      "toolCallId": "tool-cmp-2",
+      "toolName": "tool.write_file"
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "_harn/agentEvent",
+    "params": {
+      "artifacts": [],
+      "bindingManifestHash": "sha256:manifest-write",
+      "durationMs": 3,
+      "error": "workspace writes require approval",
+      "failureCategory": "policy_denied",
+      "kind": "composition_error",
+      "language": "harn",
+      "metadata": {},
+      "requestedSideEffectCeiling": "workspace_write",
+      "result": null,
+      "runId": "cmp-2",
+      "sessionId": "session-1",
+      "snippetHash": "sha256:67d844681154387a2adfd1e6e797b73dc6d0b688a9d0ef83edd7fafdd70954fb",
+      "stderr": null,
+      "stdout": null
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "_harn/agentEvent",
+    "params": {
       "kind": "session_closed",
       "metadata": {
         "idle_ms": 5000

--- a/crates/harn-vm/src/agent_events.rs
+++ b/crates/harn-vm/src/agent_events.rs
@@ -23,6 +23,7 @@ use std::sync::{Arc, Mutex, OnceLock, RwLock};
 
 use serde::{Deserialize, Serialize};
 
+use crate::composition::{CompositionChildCall, CompositionChildResult, CompositionRunEnvelope};
 use crate::event_log::{AnyEventLog, EventLog, LogEvent as EventLogRecord, Topic};
 use crate::orchestration::{HandoffArtifact, MutationSessionRecord};
 use crate::tool_annotations::ToolKind;
@@ -631,6 +632,37 @@ pub enum AgentEvent {
         namespace: String,
         payload: serde_json::Value,
     },
+    /// A language-neutral tool-composition snippet has started. The envelope
+    /// identifies the snippet and binding manifest hashes plus the side-effect
+    /// ceiling requested for the whole parent run.
+    CompositionStart {
+        session_id: String,
+        run: CompositionRunEnvelope,
+    },
+    /// A composition snippet is dispatching a child binding call. The child
+    /// remains visible as its own operation with annotations and policy context
+    /// instead of being hidden inside the parent composition blob.
+    CompositionChildCall {
+        session_id: String,
+        call: CompositionChildCall,
+    },
+    /// A child binding operation emitted a status/result update.
+    CompositionChildResult {
+        session_id: String,
+        result: CompositionChildResult,
+    },
+    /// A composition run finished successfully and carries stdout/stderr,
+    /// artifacts, and the structured result in the terminal envelope.
+    CompositionFinish {
+        session_id: String,
+        run: CompositionRunEnvelope,
+    },
+    /// A composition run failed before producing a successful terminal result.
+    /// The terminal envelope carries the failure category and optional error.
+    CompositionError {
+        session_id: String,
+        run: CompositionRunEnvelope,
+    },
 }
 
 impl AgentEvent {
@@ -665,7 +697,12 @@ impl AgentEvent {
             | Self::AgentLoopStallWarning { session_id, .. }
             | Self::ToolCallAudit { session_id, .. }
             | Self::CacheHit { session_id, .. }
-            | Self::CacheMiss { session_id, .. } => session_id,
+            | Self::CacheMiss { session_id, .. }
+            | Self::CompositionStart { session_id, .. }
+            | Self::CompositionChildCall { session_id, .. }
+            | Self::CompositionChildResult { session_id, .. }
+            | Self::CompositionFinish { session_id, .. }
+            | Self::CompositionError { session_id, .. } => session_id,
         }
     }
 }

--- a/crates/harn-vm/src/composition.rs
+++ b/crates/harn-vm/src/composition.rs
@@ -1,0 +1,275 @@
+//! Language-neutral executable tool-composition contract.
+//!
+//! A composition run is a tiny program over already-typed tool bindings. The
+//! runtime must expose it as a parent run with child tool operations, not as an
+//! opaque "execute code" blob, so policy, transcript, replay, and host approval
+//! surfaces can keep reasoning about each child call normally.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+use crate::agent_events::{ToolCallErrorCategory, ToolCallStatus, ToolExecutor};
+use crate::tool_annotations::{SideEffectLevel, ToolAnnotations};
+
+/// Stable failure taxonomy for a composition run. Tool-level failures stay on
+/// [`CompositionChildResult`]; this classifies why the parent composition
+/// itself failed or stopped.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CompositionFailureCategory {
+    /// The snippet language is unknown or not enabled by the current host.
+    UnsupportedLanguage,
+    /// The snippet or manifest did not validate before execution.
+    SchemaValidation,
+    /// Capability policy rejected the requested side-effect ceiling or a child
+    /// operation.
+    PolicyDenied,
+    /// A child binding returned an error.
+    ChildToolError,
+    /// The executor failed before it could attribute the error to a child call.
+    ExecutionError,
+    /// The run exceeded its time or step budget.
+    Timeout,
+    /// The host or caller cancelled the run.
+    Cancelled,
+    /// Fallback when a producer cannot classify the failure.
+    Unknown,
+}
+
+impl CompositionFailureCategory {
+    pub const ALL: [Self; 8] = [
+        Self::UnsupportedLanguage,
+        Self::SchemaValidation,
+        Self::PolicyDenied,
+        Self::ChildToolError,
+        Self::ExecutionError,
+        Self::Timeout,
+        Self::Cancelled,
+        Self::Unknown,
+    ];
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::UnsupportedLanguage => "unsupported_language",
+            Self::SchemaValidation => "schema_validation",
+            Self::PolicyDenied => "policy_denied",
+            Self::ChildToolError => "child_tool_error",
+            Self::ExecutionError => "execution_error",
+            Self::Timeout => "timeout",
+            Self::Cancelled => "cancelled",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+/// Identity and policy envelope for one composition run.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct CompositionRunEnvelope {
+    /// Runtime-unique id used to correlate child calls and terminal events.
+    pub run_id: String,
+    /// Snippet frontend (`harn`, `typescript`, `javascript`, ...).
+    pub language: String,
+    /// `sha256:<hex>` digest over the language and snippet bytes.
+    pub snippet_hash: String,
+    /// `sha256:<hex>` digest over the binding manifest shown to the model.
+    pub binding_manifest_hash: String,
+    /// Highest side-effect level requested by the parent run.
+    pub requested_side_effect_ceiling: SideEffectLevel,
+    /// Captured stdout-like text emitted by the composition executor.
+    pub stdout: Option<String>,
+    /// Captured stderr-like text emitted by the composition executor.
+    pub stderr: Option<String>,
+    /// Artifact descriptors/handles emitted by the composition executor.
+    pub artifacts: Vec<Value>,
+    /// Structured result returned by the snippet.
+    pub result: Option<Value>,
+    /// Parent-run failure class, absent for successful finishes.
+    pub failure_category: Option<CompositionFailureCategory>,
+    /// Human-readable parent-run error, absent for successful finishes.
+    pub error: Option<String>,
+    /// Runtime wall-clock duration when a producer has measured it.
+    pub duration_ms: Option<u64>,
+    /// Forward-compatible producer metadata. Consumers must ignore unknown keys.
+    pub metadata: Value,
+}
+
+impl Default for CompositionRunEnvelope {
+    fn default() -> Self {
+        Self {
+            run_id: String::new(),
+            language: String::new(),
+            snippet_hash: String::new(),
+            binding_manifest_hash: String::new(),
+            requested_side_effect_ceiling: SideEffectLevel::ReadOnly,
+            stdout: None,
+            stderr: None,
+            artifacts: Vec::new(),
+            result: None,
+            failure_category: None,
+            error: None,
+            duration_ms: None,
+            metadata: Value::Object(serde_json::Map::new()),
+        }
+    }
+}
+
+impl CompositionRunEnvelope {
+    pub fn read_only(
+        run_id: impl Into<String>,
+        language: impl Into<String>,
+        snippet_hash: impl Into<String>,
+        binding_manifest_hash: impl Into<String>,
+    ) -> Self {
+        Self {
+            run_id: run_id.into(),
+            language: language.into(),
+            snippet_hash: snippet_hash.into(),
+            binding_manifest_hash: binding_manifest_hash.into(),
+            requested_side_effect_ceiling: SideEffectLevel::ReadOnly,
+            ..Self::default()
+        }
+    }
+}
+
+/// Child tool call made by a composition snippet. This is intentionally close
+/// to `AgentEvent::ToolCall`, but includes parent-run correlation and the
+/// policy/annotation context the composition executor used when deciding
+/// whether the call was allowed.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct CompositionChildCall {
+    pub run_id: String,
+    pub tool_call_id: String,
+    pub tool_name: String,
+    pub operation_index: u64,
+    pub annotations: Option<ToolAnnotations>,
+    pub requested_side_effect_level: SideEffectLevel,
+    pub policy_context: Value,
+    pub raw_input: Value,
+}
+
+impl Default for CompositionChildCall {
+    fn default() -> Self {
+        Self {
+            run_id: String::new(),
+            tool_call_id: String::new(),
+            tool_name: String::new(),
+            operation_index: 0,
+            annotations: None,
+            requested_side_effect_level: SideEffectLevel::None,
+            policy_context: Value::Object(serde_json::Map::new()),
+            raw_input: Value::Null,
+        }
+    }
+}
+
+/// Terminal or intermediate result for a child binding operation. Consumers
+/// should pair this with the corresponding [`CompositionChildCall`] to recover
+/// the policy annotations and requested side-effect level for the operation.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct CompositionChildResult {
+    pub run_id: String,
+    pub tool_call_id: String,
+    pub tool_name: String,
+    pub operation_index: u64,
+    pub status: ToolCallStatus,
+    pub raw_output: Option<Value>,
+    pub error: Option<String>,
+    pub error_category: Option<ToolCallErrorCategory>,
+    pub executor: Option<ToolExecutor>,
+    pub duration_ms: Option<u64>,
+    pub execution_duration_ms: Option<u64>,
+}
+
+impl Default for CompositionChildResult {
+    fn default() -> Self {
+        Self {
+            run_id: String::new(),
+            tool_call_id: String::new(),
+            tool_name: String::new(),
+            operation_index: 0,
+            status: ToolCallStatus::Pending,
+            raw_output: None,
+            error: None,
+            error_category: None,
+            executor: None,
+            duration_ms: None,
+            execution_duration_ms: None,
+        }
+    }
+}
+
+/// Stable digest for the prompt-visible snippet body.
+pub fn composition_snippet_hash(language: &str, snippet: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"harn.composition.snippet.v1\0");
+    hasher.update(language.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(snippet.as_bytes());
+    format!("sha256:{}", hex::encode(hasher.finalize()))
+}
+
+/// Stable digest for a binding manifest value. Producers should build
+/// manifests with deterministic object key order before hashing.
+pub fn binding_manifest_hash(manifest: &Value) -> Result<String, serde_json::Error> {
+    let canonical = serde_json::to_vec(manifest)?;
+    let mut hasher = Sha256::new();
+    hasher.update(b"harn.composition.binding_manifest.v1\0");
+    hasher.update(&canonical);
+    Ok(format!("sha256:{}", hex::encode(hasher.finalize())))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snippet_hash_includes_language() {
+        let harn = composition_snippet_hash("harn", "read_file(\"AGENTS.md\")");
+        let ts = composition_snippet_hash("typescript", "read_file(\"AGENTS.md\")");
+        assert_ne!(harn, ts);
+        assert!(harn.starts_with("sha256:"));
+    }
+
+    #[test]
+    fn binding_manifest_hash_is_stable_for_identical_values() {
+        let manifest = serde_json::json!({
+            "bindings": [
+                {
+                    "name": "read_file",
+                    "annotations": {"side_effect_level": "read_only"}
+                }
+            ]
+        });
+        assert_eq!(
+            binding_manifest_hash(&manifest).unwrap(),
+            binding_manifest_hash(&manifest).unwrap()
+        );
+    }
+
+    #[test]
+    fn child_call_preserves_mutation_annotations() {
+        let call = CompositionChildCall {
+            run_id: "run-1".into(),
+            tool_call_id: "tool-1".into(),
+            tool_name: "write_file".into(),
+            operation_index: 0,
+            requested_side_effect_level: SideEffectLevel::WorkspaceWrite,
+            annotations: Some(ToolAnnotations {
+                side_effect_level: SideEffectLevel::WorkspaceWrite,
+                ..ToolAnnotations::default()
+            }),
+            raw_input: serde_json::json!({"path": "src/lib.rs"}),
+            ..CompositionChildCall::default()
+        };
+        let encoded = serde_json::to_value(&call).unwrap();
+        assert_eq!(encoded["requested_side_effect_level"], "workspace_write");
+        assert_eq!(
+            encoded["annotations"]["side_effect_level"],
+            "workspace_write"
+        );
+    }
+}

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -16,6 +16,7 @@ mod builtin_id;
 pub mod checkpoint;
 mod chunk;
 mod compiler;
+pub mod composition;
 pub mod config;
 pub mod connectors;
 pub mod corrections;

--- a/docs/src/bridge-protocol.md
+++ b/docs/src/bridge-protocol.md
@@ -141,6 +141,32 @@ canonical ACP content block, not the session-update envelope. Example:
 }
 ```
 
+### Composition Event Migration Note
+
+Governed Code Mode composition runs are represented on the Harn
+`_harn/agentEvent` extension channel, not as one opaque tool call and
+not as new ACP `session/update` variants. Consumers that do not render
+composition events can ignore unknown `_harn/agentEvent.kind` values and
+continue reading ordinary `tool_call` / `tool_call_update` events.
+
+Consumers that do render them should group by `runId`:
+
+- `composition_start` identifies the snippet language, snippet hash,
+  binding-manifest hash, and requested side-effect ceiling.
+- `composition_child_call` records each child binding operation with
+  `rawInput`, `policyContext`, `requestedSideEffectLevel`, and the
+  `ToolAnnotations` used for policy decisions.
+- `composition_child_result` records the child status, executor,
+  output/error, and timing.
+- `composition_finish` and `composition_error` are terminal parent
+  events carrying stdout, stderr, artifacts, structured result, duration,
+  and failure category.
+
+Portal and transcript indexers should treat composition events as a
+parent/child grouping overlay. A mutating child remains a mutating child
+operation because its own annotations and side-effect level are present;
+do not infer the whole run is read-only from the parent event alone.
+
 ### `audit` tag
 
 Both `tool_call` and `tool_call_update` carry an optional `_meta.harn.audit`

--- a/spec/protocol-artifacts/HarnProtocol.swift
+++ b/spec/protocol-artifacts/HarnProtocol.swift
@@ -25,6 +25,11 @@ public enum HarnProtocolConstants {
     ]
     public static let harnAgentEventKinds: [String] = [
         "budget_exhausted",
+        "composition_child_call",
+        "composition_child_result",
+        "composition_error",
+        "composition_finish",
+        "composition_start",
         "daemon_watchdog_tripped",
         "feedback_injected",
         "judge_decision",

--- a/spec/protocol-artifacts/fixtures/round_trip.json
+++ b/spec/protocol-artifacts/fixtures/round_trip.json
@@ -22,9 +22,25 @@
       "jsonrpc": "2.0",
       "method": "_harn/agentEvent",
       "params": {
-        "kind": "turn_end",
+        "annotations": {
+          "kind": "edit",
+          "side_effect_level": "workspace_write"
+        },
+        "kind": "composition_child_call",
+        "operationIndex": 0,
+        "policyContext": {
+          "approval": "denied",
+          "ceiling": "workspace_write"
+        },
+        "rawInput": {
+          "content": "...",
+          "path": "src/lib.rs"
+        },
+        "requestedSideEffectLevel": "workspace_write",
+        "runId": "cmp-42",
         "sessionId": "sess-42",
-        "turnId": "turn-9"
+        "toolCallId": "tool-cmp-42",
+        "toolName": "tool.write_file"
       }
     },
     "errorResponse": {

--- a/spec/protocol-artifacts/go/harnprotocol/harnprotocol.go
+++ b/spec/protocol-artifacts/go/harnprotocol/harnprotocol.go
@@ -114,6 +114,11 @@ type HarnAgentEventKind = string
 // HarnAgentEventKinds enumerates every wire value Harn currently emits for HarnAgentEventKind.
 var HarnAgentEventKinds = []HarnAgentEventKind{
 	"budget_exhausted",
+	"composition_child_call",
+	"composition_child_result",
+	"composition_error",
+	"composition_finish",
+	"composition_start",
 	"daemon_watchdog_tripped",
 	"feedback_injected",
 	"judge_decision",

--- a/spec/protocol-artifacts/harn-protocol.ts
+++ b/spec/protocol-artifacts/harn-protocol.ts
@@ -75,6 +75,11 @@ export type HarnACPSessionUpdateExtension = (typeof HARN_ACP_SESSION_UPDATE_EXTE
 export const HARN_AGENT_EVENT_METHOD = "_harn/agentEvent"
 export const HARN_AGENT_EVENT_KINDS = [
   "budget_exhausted",
+  "composition_child_call",
+  "composition_child_result",
+  "composition_error",
+  "composition_finish",
+  "composition_start",
   "daemon_watchdog_tripped",
   "feedback_injected",
   "judge_decision",

--- a/spec/protocol-artifacts/manifest.json
+++ b/spec/protocol-artifacts/manifest.json
@@ -62,6 +62,11 @@
     ],
     "harnAgentEventKinds": [
       "budget_exhausted",
+      "composition_child_call",
+      "composition_child_result",
+      "composition_error",
+      "composition_finish",
+      "composition_start",
       "daemon_watchdog_tripped",
       "feedback_injected",
       "judge_decision",

--- a/spec/protocol-artifacts/python/harn_protocol.py
+++ b/spec/protocol-artifacts/python/harn_protocol.py
@@ -150,6 +150,11 @@ HARN_ACP_SESSION_UPDATE_EXTENSIONS: tuple = (
 )
 HARN_AGENT_EVENT_KINDS: tuple = (
     "budget_exhausted",
+    "composition_child_call",
+    "composition_child_result",
+    "composition_error",
+    "composition_finish",
+    "composition_start",
     "daemon_watchdog_tripped",
     "feedback_injected",
     "judge_decision",

--- a/spec/protocol-artifacts/schemas/acp-session-update.schema.json
+++ b/spec/protocol-artifacts/schemas/acp-session-update.schema.json
@@ -79,6 +79,11 @@
             "kind": {
               "enum": [
                 "budget_exhausted",
+                "composition_child_call",
+                "composition_child_result",
+                "composition_error",
+                "composition_finish",
+                "composition_start",
                 "daemon_watchdog_tripped",
                 "feedback_injected",
                 "judge_decision",


### PR DESCRIPTION
## Summary
- define the language-neutral composition run envelope plus child call/result payloads in `harn-vm`
- emit `composition_start`, `composition_child_call`, `composition_child_result`, `composition_finish`, and `composition_error` over ACP `_harn/agentEvent`
- pin read-only and mutating child-operation fixtures, update generated protocol artifacts/binding round-trip coverage, and document the transcript/portal migration path

Closes #1617

## Verification
- `CARGO_TARGET_DIR=/private/tmp/harn-issue1617-target cargo test -p harn-vm composition --lib`
- `CARGO_TARGET_DIR=/private/tmp/harn-issue1617-target cargo test -p harn-serve adapters::acp::events::tests --lib`
- `CARGO_TARGET_DIR=/private/tmp/harn-issue1617-target cargo test -p harn-cli round_trip_fixture_matches_python_and_go_field_set --lib`
- `make gen-protocol-artifacts`
- `make check-protocol-artifacts`
- `make check-bindings`
- `cargo fmt --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/private/tmp/harn-issue1617-target make conformance` (1008 passed)
- pre-commit hook: Rust format, clippy, markdown
- pre-push hook: targeted local checks, markdown, generated highlight drift
