### PR TITLE
Add done judge cadence policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,13 @@ condensed series summaries instead of full per-patch history.
   Ollama surfaces via `/api/ps` (size, VRAM, expiry, context window).
   JSON output by default for eval pipelines; pair with `harn local
   status --json` to inspect lifecycle state across every local runtime.
+- **Done-judge cadence policy (#1631).** `agent_loop` now accepts
+  `done_judge.cadence` with `every`, `when`, `max_invocations`, and
+  `min_iterations_before_first` gates so completion checks can run on
+  explicit cadence or stall signals instead of every completion
+  candidate. Accepted judge calls still use transcript projection
+  isolation: judge prompts and structured responses emit events but do
+  not mutate the worker session transcript.
 
 ## v0.8.17
 

--- a/conformance/tests/agents/agent_loop_done_judge_cadence.expected
+++ b/conformance/tests/agents/agent_loop_done_judge_cadence.expected
@@ -1,0 +1,5 @@
+done
+candidate four
+4
+6
+2

--- a/conformance/tests/agents/agent_loop_done_judge_cadence.harn
+++ b/conformance/tests/agents/agent_loop_done_judge_cadence.harn
@@ -1,0 +1,42 @@
+import { agent_capture_events } from "std/agent/events"
+
+fn judge_events(events) {
+  return events.filter({ event -> event.type == "judge_decision" })
+}
+
+pipeline default() {
+  llm_mock_clear()
+  llm_mock({text: "<user_response>candidate one</user_response>\n<done>##DONE##</done>"})
+  llm_mock({text: "<user_response>candidate two</user_response>\n<done>##DONE##</done>"})
+  llm_mock(
+    {
+      text: "{\"verdict\":\"continue\",\"reasoning\":\"wait for another candidate\",\"next_step\":\"try again\"}",
+    },
+  )
+  llm_mock({text: "<user_response>candidate three</user_response>\n<done>##DONE##</done>"})
+  llm_mock({text: "<user_response>candidate four</user_response>\n<done>##DONE##</done>"})
+  llm_mock({text: "{\"verdict\":\"done\",\"reasoning\":\"fourth candidate is complete\"}"})
+  let session = "done-judge-cadence-" + uuid()
+  let captured = agent_capture_events(
+    session,
+    fn() { return agent_loop(
+      "Finish on cadence.",
+      nil,
+      {
+        provider: "mock",
+        loop_until_done: true,
+        max_iterations: 5,
+        max_nudges: 10,
+        session_id: session,
+        done_judge: {cadence: {every: 2}},
+      },
+    ) },
+  )
+  let judges = judge_events(captured.events)
+  require len(judges) == 2, "done_judge cadence should fire on every second completion candidate"
+  println(captured.result.status)
+  println(captured.result.visible_text)
+  println(captured.result.llm.iterations)
+  println(len(llm_mock_calls()))
+  println(len(judges))
+}

--- a/conformance/tests/agents/agent_loop_done_judge_cadence_limits.expected
+++ b/conformance/tests/agents/agent_loop_done_judge_cadence_limits.expected
@@ -1,0 +1,12 @@
+budget_exhausted
+3
+0
+3
+budget_exhausted
+4
+1
+5
+done
+2
+1
+3

--- a/conformance/tests/agents/agent_loop_done_judge_cadence_limits.harn
+++ b/conformance/tests/agents/agent_loop_done_judge_cadence_limits.harn
@@ -1,0 +1,86 @@
+import { agent_capture_events } from "std/agent/events"
+
+fn judge_events(events) {
+  return events.filter({ event -> event.type == "judge_decision" })
+}
+
+pipeline default() {
+  llm_mock_clear()
+  llm_mock({text: "<user_response>healthy one</user_response>\n<done>##DONE##</done>"})
+  llm_mock({text: "<user_response>healthy two</user_response>\n<done>##DONE##</done>"})
+  llm_mock({text: "<user_response>healthy three</user_response>\n<done>##DONE##</done>"})
+  let stalled_session = "done-judge-stalled-" + uuid()
+  let stalled = agent_capture_events(
+    stalled_session,
+    fn() { return agent_loop(
+      "Do not judge unless stalled.",
+      nil,
+      {
+        provider: "mock",
+        loop_until_done: true,
+        max_iterations: 3,
+        max_nudges: 10,
+        session_id: stalled_session,
+        done_judge: {cadence: {when: "stalled"}},
+      },
+    ) },
+  )
+  println(stalled.result.status)
+  println(stalled.result.llm.iterations)
+  println(len(judge_events(stalled.events)))
+  println(len(llm_mock_calls()))
+  llm_mock_clear()
+  llm_mock({text: "<user_response>capped one</user_response>\n<done>##DONE##</done>"})
+  llm_mock(
+    {
+      text: "{\"verdict\":\"continue\",\"reasoning\":\"first and only judge fire\",\"next_step\":\"keep going\"}",
+    },
+  )
+  llm_mock({text: "<user_response>capped two</user_response>\n<done>##DONE##</done>"})
+  llm_mock({text: "<user_response>capped three</user_response>\n<done>##DONE##</done>"})
+  llm_mock({text: "<user_response>capped four</user_response>\n<done>##DONE##</done>"})
+  let capped_session = "done-judge-cap-" + uuid()
+  let capped = agent_capture_events(
+    capped_session,
+    fn() { return agent_loop(
+      "Judge once at most.",
+      nil,
+      {
+        provider: "mock",
+        loop_until_done: true,
+        max_iterations: 4,
+        max_nudges: 10,
+        session_id: capped_session,
+        done_judge: {cadence: {every: 1, max_invocations: 1}},
+      },
+    ) },
+  )
+  println(capped.result.status)
+  println(capped.result.llm.iterations)
+  println(len(judge_events(capped.events)))
+  println(len(llm_mock_calls()))
+  llm_mock_clear()
+  llm_mock({text: "<user_response>closure one</user_response>\n<done>##DONE##</done>"})
+  llm_mock({text: "<user_response>closure two</user_response>\n<done>##DONE##</done>"})
+  llm_mock({text: "{\"verdict\":\"done\",\"reasoning\":\"closure accepted on turn two\"}"})
+  let closure_session = "done-judge-closure-" + uuid()
+  let closure = agent_capture_events(
+    closure_session,
+    fn() { return agent_loop(
+      "Judge when the loop-state predicate says so.",
+      nil,
+      {
+        provider: "mock",
+        loop_until_done: true,
+        max_iterations: 3,
+        max_nudges: 10,
+        session_id: closure_session,
+        done_judge: {cadence: {when: { state -> state.iteration == 2 }}},
+      },
+    ) },
+  )
+  println(closure.result.status)
+  println(closure.result.llm.iterations)
+  println(len(judge_events(closure.events)))
+  println(len(llm_mock_calls()))
+}

--- a/conformance/tests/agents/agent_loop_done_judge_transcript_isolation.expected
+++ b/conformance/tests/agents/agent_loop_done_judge_transcript_isolation.expected
@@ -1,0 +1,6 @@
+done
+2
+true
+true
+true
+2

--- a/conformance/tests/agents/agent_loop_done_judge_transcript_isolation.harn
+++ b/conformance/tests/agents/agent_loop_done_judge_transcript_isolation.harn
@@ -1,0 +1,39 @@
+import { agent_capture_events } from "std/agent/events"
+import { agent_session_messages } from "std/agent/state"
+
+fn judge_events(events) {
+  return events.filter({ event -> event.type == "judge_decision" })
+}
+
+pipeline default() {
+  llm_mock_clear()
+  llm_mock({text: "<user_response>isolated final answer</user_response>"})
+  llm_mock({text: "{\"verdict\":\"done\",\"reasoning\":\"complete\"}"})
+  let session = "done-judge-isolation-" + uuid()
+  let captured = agent_capture_events(
+    session,
+    fn() { return agent_loop(
+      "Finish once.",
+      nil,
+      {
+        provider: "mock",
+        tools: tool_registry(),
+        tool_format: "native",
+        loop_until_done: true,
+        max_iterations: 2,
+        session_id: session,
+        done_judge: true,
+      },
+    ) },
+  )
+  let messages = agent_session_messages(session)
+  let encoded = json_stringify(messages)
+  let judges = judge_events(captured.events)
+  require len(judges) == 1, "done_judge should emit one decision"
+  println(captured.result.status)
+  println(len(messages))
+  println(contains(encoded, "isolated final answer"))
+  println(!contains(encoded, "\"verdict\""))
+  println(!contains(encoded, "complete"))
+  println(len(llm_mock_calls()))
+}

--- a/crates/harn-stdlib/src/stdlib/agent/judge.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/judge.harn
@@ -164,9 +164,12 @@ pub fn agent_verify_or_continue(session, opts, stop_reason, text, iteration = 0)
     verdict = __judge_invoke_structured(opts.verify_completion_judge, opts, payload)
     __emit_judge_decision(session.session_id, iteration, verdict)
   }
+  let done_judge_due = opts?._done_judge_due ?? true
   let done_judge_applies = opts?.done_judge != nil && (stop_reason == "sentinel" || stop_reason == "natural")
+    && done_judge_due
   if !verdict.vetoed && done_judge_applies {
     verdict = __judge_invoke_structured(opts.done_judge, opts, payload)
+    verdict = verdict + {done_judge_invoked: true}
     __emit_judge_decision(session.session_id, iteration, verdict)
   }
   if verdict.vetoed && verdict?.feedback != nil && verdict.feedback != "" {

--- a/crates/harn-stdlib/src/stdlib/agent/loop.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/loop.harn
@@ -1134,6 +1134,7 @@ fn __agent_loop_run(message, session, initial_opts) {
     var final_status = ""
     var terminal_error = nil
     var verify_attempts = 0
+    var done_judge_invocations = 0
     var consecutive_text_only = 0
     var fallback_index = 0
     var successful_tools_seen = []
@@ -1246,8 +1247,32 @@ fn __agent_loop_run(message, session, initial_opts) {
         stop_reason = "max_nudges"
         break
       }
+      let missing_required_for_loop = __required_tools_missing_list(opts, successful_tools_seen)
+      let cadence_loop_state = __snapshot_loop_state(
+        {
+          iteration: iteration,
+          current_limit: current_max,
+          budget_max: budget.max,
+          extensions_used: extensions_used,
+          tool_count: tool_count,
+          turn_successful: turn_successful,
+          turn_rejected: turn_rejected,
+          visible_text: visible_text,
+          turn_native_fallback_used: fallback_outcome.triggered && fallback_outcome.accepted,
+          session_successful: successful_tools_seen,
+          session_rejected: rejected_tools_seen,
+          missing_required_tools: missing_required_for_loop,
+          completion_proposed: false,
+          verdict: nil,
+        },
+      )
       let post_turn_opts = turn_opts
-        + {_session_successful_tools: successful_tools_seen, _session_rejected_tools: rejected_tools_seen}
+        + {
+        _session_successful_tools: successful_tools_seen,
+        _session_rejected_tools: rejected_tools_seen,
+        _done_judge_invocations: done_judge_invocations,
+        _done_judge_loop_state: cadence_loop_state,
+      }
       let outcome = agent_compute_post_turn(
         session,
         normalized + {raw_text: raw_text, parsed_done_marker: parsed?.done_marker ?? ""},
@@ -1269,8 +1294,12 @@ fn __agent_loop_run(message, session, initial_opts) {
             stop_reason = outcome.stop_reason
             break
           }
-          let verdict = agent_verify_or_continue(session, turn_opts, outcome.stop_reason, llm_result.text, turn_index)
+          let verify_opts = turn_opts + {_done_judge_due: outcome?.done_judge_due ?? true}
+          let verdict = agent_verify_or_continue(session, verify_opts, outcome.stop_reason, llm_result.text, turn_index)
           verdict_record = verdict
+          if verdict?.done_judge_invoked ?? false {
+            done_judge_invocations = done_judge_invocations + 1
+          }
           if verdict.vetoed {
             verify_attempts = verify_attempts + 1
             should_continue = true
@@ -1290,7 +1319,6 @@ fn __agent_loop_run(message, session, initial_opts) {
           break
         }
       }
-      let missing_required_for_loop = __required_tools_missing_list(opts, successful_tools_seen)
       let loop_state = __snapshot_loop_state(
         {
           iteration: iteration,

--- a/crates/harn-stdlib/src/stdlib/agent/options.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/options.harn
@@ -142,6 +142,67 @@ fn __validate_judge_dict_or_bool(label, value) {
   }
 }
 
+fn __validate_optional_positive_int(label, field, value) {
+  if value == nil {
+    return
+  }
+  if type_of(value) != "int" {
+    throw "agent_loop: `" + label + "." + field + "` must be an integer or nil; got "
+      + type_of(value)
+  }
+  if value < 1 {
+    throw "agent_loop: `" + label + "." + field + "` must be >= 1"
+  }
+}
+
+fn __validate_optional_nonnegative_int(label, field, value) {
+  if value == nil {
+    return
+  }
+  if type_of(value) != "int" {
+    throw "agent_loop: `" + label + "." + field + "` must be an integer or nil; got "
+      + type_of(value)
+  }
+  if value < 0 {
+    throw "agent_loop: `" + label + "." + field + "` must be >= 0"
+  }
+}
+
+fn __validate_judge_cadence(label, value) {
+  if value == nil {
+    return
+  }
+  if type_of(value) != "dict" {
+    throw "agent_loop: `" + label + "` must be a dict or nil; got " + type_of(value)
+  }
+  __validate_optional_positive_int(label, "every", value?.every)
+  __validate_optional_nonnegative_int(label, "max_invocations", value?.max_invocations)
+  __validate_optional_nonnegative_int(
+    label,
+    "min_iterations_before_first",
+    value?.min_iterations_before_first,
+  )
+  let when = value?.when
+  if when == nil {
+    return
+  }
+  let kind = type_of(when)
+  if kind == "closure" {
+    return
+  }
+  if kind == "string" && (when == "always" || when == "stalled") {
+    return
+  }
+  throw "agent_loop: `" + label + ".when` must be \"always\", \"stalled\", a closure, or nil; got "
+    + to_string(when)
+}
+
+fn __validate_done_judge_cadence(value) {
+  if type_of(value) == "dict" {
+    __validate_judge_cadence("done_judge.cadence", value?.cadence)
+  }
+}
+
 fn __positive_int_default(value, fallback) {
   if value == nil {
     return fallback
@@ -200,6 +261,7 @@ fn __validate_agent_loop_completion_options(opts) {
   }
   if __has_key(opts, "done_judge") {
     __validate_judge_dict_or_bool("done_judge", opts.done_judge)
+    __validate_done_judge_cadence(opts.done_judge)
   }
 }
 

--- a/crates/harn-stdlib/src/stdlib/agent/postturn.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/postturn.harn
@@ -136,6 +136,110 @@ fn __native_tool_text_completion(opts, has_tool_calls, text) {
   return trim(text) != ""
 }
 
+fn __done_judge_config(opts) {
+  let judge = opts?.done_judge
+  if judge == nil {
+    return nil
+  }
+  if type_of(judge) == "bool" {
+    return if judge {
+      {}
+    } else {
+      nil
+    }
+  }
+  if type_of(judge) == "dict" {
+    return judge
+  }
+  return nil
+}
+
+fn __done_judge_cadence(opts) {
+  let judge = __done_judge_config(opts)
+  if judge == nil {
+    return nil
+  }
+  let cadence = judge?.cadence
+  if type_of(cadence) == "dict" {
+    return cadence
+  }
+  return {}
+}
+
+fn __done_judge_loop_state(opts, completion_proposed) {
+  let state = opts?._done_judge_loop_state ?? {}
+  let base_completion = state?.completion ?? {}
+  let completion = base_completion + {proposed: completion_proposed}
+  return state + {completion: completion}
+}
+
+fn __done_judge_when_due(opts, cadence, state) {
+  let when = cadence?.when ?? "always"
+  if type_of(when) == "closure" {
+    return when(state) ? true : false
+  }
+  if when == "always" {
+    return true
+  }
+  if when == "stalled" {
+    let trigger = opts?._done_judge_trigger ?? ""
+    let stalled = state?.stall?.triggered ?? false
+    return trigger == "stalled" || stalled
+  }
+  return false
+}
+
+fn __done_judge_every_due(cadence, turn_number) {
+  let every = cadence?.every
+  if every == nil {
+    return true
+  }
+  return turn_number % every == 0
+}
+
+fn __done_judge_past_warmup(cadence, turn_number) {
+  let min_iterations = cadence?.min_iterations_before_first
+  if min_iterations == nil {
+    return true
+  }
+  return turn_number > min_iterations
+}
+
+fn __done_judge_under_cap(opts, cadence) {
+  let max_invocations = cadence?.max_invocations
+  if max_invocations == nil {
+    return true
+  }
+  let invocations = opts?._done_judge_invocations ?? 0
+  return invocations < max_invocations
+}
+
+fn __done_judge_due(opts, payload, completion_proposed) {
+  let cadence = __done_judge_cadence(opts)
+  if cadence == nil {
+    return false
+  }
+  let raw_iteration = payload?.iteration ?? 0
+  let turn_number = raw_iteration + 1
+  let state = __done_judge_loop_state(opts, completion_proposed)
+  return __done_judge_under_cap(opts, cadence)
+    && __done_judge_past_warmup(cadence, turn_number)
+    && __done_judge_every_due(cadence, turn_number)
+    && __done_judge_when_due(opts, cadence, state)
+}
+
+fn __completion_result(opts, payload, stop_reason) {
+  let verify_due = opts?.verify_completion != nil || opts?.verify_completion_judge != nil
+  let done_due = __done_judge_due(opts, payload, true)
+  if verify_due || done_due {
+    return {kind: "break", stop_reason: stop_reason, needs_verify: true, done_judge_due: done_due}
+  }
+  if __done_judge_config(opts) != nil {
+    return {kind: "continue", done_judge_due: false}
+  }
+  return {kind: "break", stop_reason: stop_reason, needs_verify: false, done_judge_due: false}
+}
+
 fn __post_turn_verdict_result(session, opts, verdict) {
   if verdict.kind == "stop" {
     return {kind: "break", stop_reason: "post_turn_stop", needs_verify: opts?.verify_completion != nil}
@@ -192,17 +296,6 @@ pub fn agent_compute_post_turn(session, llm_result, dispatch, opts, iteration) {
   let successful_tool_names = __successful_tool_names(dispatch)
   let rejected_tool_names = __rejected_tool_names(dispatch)
   let has_tool_calls = len(llm_result?.tool_calls ?? []) > 0 || len(dispatch_results) > 0
-  if __sentinel_hit(sentinel_text, sentinel, parsed_done_marker) {
-    return {
-      kind: "break",
-      stop_reason: "sentinel",
-      needs_verify: opts?.done_judge != nil || opts?.verify_completion != nil
-        || opts?.verify_completion_judge != nil,
-    }
-  }
-  if __stop_after_successful_tools(opts, dispatch) {
-    return {kind: "break", stop_reason: "natural", needs_verify: false}
-  }
   let payload = {
     session_id: session.session_id,
     iteration: iteration,
@@ -217,30 +310,27 @@ pub fn agent_compute_post_turn(session, llm_result, dispatch, opts, iteration) {
     text: text,
     visible_text: text,
   }
+  if __sentinel_hit(sentinel_text, sentinel, parsed_done_marker) {
+    return __completion_result(opts, payload, "sentinel")
+  }
+  if __stop_after_successful_tools(opts, dispatch) {
+    return {kind: "break", stop_reason: "natural", needs_verify: false, done_judge_due: false}
+  }
   let verdict = __post_turn_callback_verdict(opts, payload)
   let verdict_result = __post_turn_verdict_result(session, opts, verdict)
   if verdict_result != nil {
     return verdict_result
   }
   if !has_tool_calls && trim(text) != "" && opts?.done_judge != nil {
-    return {kind: "break", stop_reason: "natural", needs_verify: true}
+    return __completion_result(opts, payload, "natural")
   }
   if __native_tool_text_completion(opts, has_tool_calls, text) {
-    return {
-      kind: "break",
-      stop_reason: "natural",
-      needs_verify: opts?.done_judge != nil || opts?.verify_completion != nil
-        || opts?.verify_completion_judge != nil,
-    }
+    return __completion_result(opts, payload, "natural")
   }
   let loop_until_done = opts?.loop_until_done ?? false
   let daemon = opts?.daemon ?? false
   if !has_tool_calls && !loop_until_done && !daemon {
-    return {
-      kind: "break",
-      stop_reason: "natural",
-      needs_verify: opts?.done_judge != nil || opts?.verify_completion != nil,
-    }
+    return __completion_result(opts, payload, "natural")
   }
-  return {kind: "continue"}
+  return {kind: "continue", done_judge_due: false}
 }

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -1489,6 +1489,28 @@ Each judge call emits a `JudgeDecision` agent event. Use
 `verify_completion_judge` instead when every natural stop should be
 judged.
 
+Use `done_judge.cadence` when completion checks should be signal-gated
+instead of firing on every completion candidate:
+
+```harn
+agent_loop(task, system, {
+  loop_until_done: true,
+  done_judge: {
+    cadence: {
+      every: 5,                         // judge turns 5, 10, 15, ...
+      when: "always",                   // or "stalled" / { state -> bool }
+      max_invocations: 3,
+      min_iterations_before_first: 2,
+    },
+  },
+})
+```
+
+Omitting `cadence` preserves the default behavior: every completion
+candidate is judged. `when: "stalled"` is quiet during healthy turns and
+is reserved for stall diagnostics; pair it with stall-aware loop policy
+instead of fixed "are you done?" prompting.
+
 Pass `permissions` to scope one agent below the ambient `policy` ceiling:
 
 ```harn

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -146,6 +146,7 @@
 - [Maintainer release workflow](./maintainer-release.md)
 - [Platform compatibility](./dev/platform-compatibility.md)
 - [Windows test coverage](./dev/windows-test-coverage.md)
+- [Agent loop runtime notes](./dev/agent-loops.md)
 - [Deterministic test patterns](./dev/testing.md)
 - [Testbench mode](./dev/testbench.md)
 - [Tape format](./dev/tape-format.md)

--- a/docs/src/dev/agent-loops.md
+++ b/docs/src/dev/agent-loops.md
@@ -1,0 +1,15 @@
+# Agent Loop Runtime Notes
+
+## Completion Judge Isolation
+
+`done_judge` and `verify_completion_judge` run on a transcript projection. The
+judge prompt includes the worker transcript, but the judge's own LLM request and
+structured response are not appended to `agent_session_messages(session_id)`.
+Only legitimate worker turns and explicit runtime feedback injections mutate the
+worker session transcript.
+
+This keeps replay and follow-up turns deterministic: a judge veto may inject a
+feedback message because that message is intended to steer the worker, while an
+accepted judge decision only emits `judge_decision` and `typed_checkpoint`
+events. Tests should assert transcript equality around accepted judge calls
+instead of inferring isolation from event counts.

--- a/docs/src/llm/agent_loop.md
+++ b/docs/src/llm/agent_loop.md
@@ -249,7 +249,7 @@ Same as `llm_call`, plus additional options:
 | `post_turn_callback` | closure | nil | Hook called after each turn. Receives turn metadata and may inject a message, request an immediate stage stop, or merge next-turn options such as `llm_options: {tool_choice: "none"}` |
 | `verify_completion` | closure | nil | Hook called when the loop is about to stop naturally. Return `nil`/`true` to accept the stop or feedback text to veto and continue |
 | `verify_completion_judge` | bool/dict | nil | Built-in structured judge for any natural stop. `true` uses defaults; a dict may set `provider`, `model`, `system`, and `feedback_fallback` |
-| `done_judge` | bool/dict | nil | Completion structured judge. It runs when the model naturally completes a native-tool loop or emits the done sentinel, and may veto by returning `verdict: "continue"` plus `next_step` or `reasoning` |
+| `done_judge` | bool/dict | nil | Completion structured judge. It runs when the model naturally completes a native-tool loop or emits the done sentinel, and may veto by returning `verdict: "continue"` plus `next_step` or `reasoning`. Dict configs may include `cadence: {every?, when?, max_invocations?, min_iterations_before_first?}` |
 | `llm_transcript_dir` | string | nil | Per-loop directory for Harn's existing `llm_transcript.jsonl` sidecar. This is equivalent to scoping `HARN_LLM_TRANSCRIPT_DIR` to one agent loop and is preferred when a script needs run-specific auditable model-turn JSONL |
 | `turn_policy` | dict | nil | Turn-shape policy for action stages. Supports `require_action_or_yield: bool`, `allow_done_sentinel: bool` (default `true`; set to `false` in workflow-owned action stages so nudges stop advertising the done sentinel), and `max_prose_chars: int` |
 | `native_tool_fallback` | string | `"allow"` | Native-tool-stage policy when the provider emits text-mode `<tool_call>` content instead of native tool calls. `"allow"` preserves the current recovery path, `"allow_once"` accepts the first fallback turn then rejects later repeats with corrective feedback, and `"reject"` fails closed on the first text fallback |
@@ -616,10 +616,29 @@ When `loop_until_done: true`, the system prompt is automatically extended with:
 `done_judge` adds a second gate after completion is detected. The loop renders
 the transcript for a structured judge call and expects
 `verdict: "done" | "continue"` plus optional `reasoning` and `next_step`.
-A veto injects runtime feedback and the loop
-continues until the judge accepts or `max_verify_attempts` is exhausted. Every
-judge call emits `JudgeDecision` with `session_id`, `iteration`, `verdict`,
-`reasoning`, `next_step`, and `judge_duration_ms`.
+A veto injects runtime feedback and the loop continues until the judge accepts
+or `max_verify_attempts` is exhausted. Every judge call emits `JudgeDecision`
+with `session_id`, `iteration`, `verdict`, `reasoning`, `next_step`, and
+`judge_duration_ms`.
+
+Use `done_judge.cadence` to gate the judge. Omit it to preserve the default:
+every completion candidate is judged. `every: N` judges turns `N`, `2N`, and so
+on; `max_invocations` caps total done-judge calls; `min_iterations_before_first`
+skips the first K turns; `when` accepts `"always"`, `"stalled"`, or a closure
+that receives the same loop-state shape as `loop_control`.
+
+```harn
+agent_loop(task, system, {
+  loop_until_done: true,
+  done_judge: {
+    cadence: {every: 5, when: "always", max_invocations: 3},
+  },
+})
+```
+
+`when: "stalled"` does not fire on ordinary completion candidates. It is the
+policy hook used by stall diagnostics so completion checks happen on a signal
+rather than a fixed "are you done?" prompt.
 
 ## Daemon stdlib wrappers
 


### PR DESCRIPTION
## Summary
- add `done_judge.cadence` validation and post-turn gating for `every`, `when`, `max_invocations`, and `min_iterations_before_first`
- track done-judge invocations in `agent_loop` and count only actual structured judge calls
- add conformance coverage for cadence, stalled gating, invocation caps, closure predicates, and judge transcript isolation; document the option and runtime invariant

Closes #1631.

## Verification
- `CARGO_TARGET_DIR=/private/tmp/harn-issue1631-target make fmt-harn`
- `CARGO_TARGET_DIR=/private/tmp/harn-issue1631-target make lint-harn`
- `CARGO_TARGET_DIR=/private/tmp/harn-issue1631-target make conformance`
- `CARGO_TARGET_DIR=/private/tmp/harn-issue1631-target make test`
- `CARGO_TARGET_DIR=/private/tmp/harn-issue1631-target make check-docs-snippets`
- `make lint-md`
- `cargo fmt --check`
- `git diff --check`
- pre-commit hook
- pre-push hook