### PR TITLE
Wire stall warnings to done judge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,13 @@ condensed series summaries instead of full per-patch history.
   candidate. Accepted judge calls still use transcript projection
   isolation: judge prompts and structured responses emit events but do
   not mutate the worker session transcript.
+- **Stall-gated done judge (#1632).** `agent_loop` now runs a configured
+  `done_judge.cadence.when: "stalled"` judge when stall diagnostics emit
+  `agent_loop_stall_warning`. A `done` verdict stops the loop with
+  `stalled_done_judge` before repeating the stalled tool call; a
+  `continue` verdict falls back to the existing stall feedback path.
+  Judge events now include an optional `trigger`, set to `"stalled"` for
+  stall-fired calls.
 
 ## v0.8.17
 

--- a/conformance/protocols/fixtures/acp/agent_event_ext_notifications.valid.json
+++ b/conformance/protocols/fixtures/acp/agent_event_ext_notifications.valid.json
@@ -242,6 +242,7 @@
         "nextStep": "run the verifier",
         "reasoning": "needs one more concrete action",
         "sessionId": "session-1",
+        "trigger": "stalled",
         "verdict": "continue"
       }
     },

--- a/conformance/tests/agents/agent_loop_stall_judge_continue.expected
+++ b/conformance/tests/agents/agent_loop_stall_judge_continue.expected
@@ -1,0 +1,12 @@
+budget_exhausted
+1
+1
+stalled
+continue
+3
+true
+5
+budget_exhausted
+1
+0
+2

--- a/conformance/tests/agents/agent_loop_stall_judge_continue.harn
+++ b/conformance/tests/agents/agent_loop_stall_judge_continue.harn
@@ -1,0 +1,107 @@
+import { agent_capture_events } from "std/agent/events"
+import { agent_session_messages } from "std/agent/state"
+
+fn events_of(events, kind) {
+  return events.filter({ event -> event.type == kind })
+}
+
+fn tool_message_count(session_id) {
+  var count = 0
+  for message in agent_session_messages(session_id) {
+    if message?.role == "tool" && message?.name == "noop" {
+      count = count + 1
+    }
+  }
+  return count
+}
+
+pipeline default() {
+  var tools = tool_registry()
+  tools = tool_define(
+    tools,
+    "noop",
+    "Return the same harmless result",
+    {
+      handler: { _args -> return "noop" },
+      parameters: {},
+      returns: {type: "string"},
+      annotations: {kind: "read"},
+    },
+  )
+  llm_mock_clear()
+  llm_mock({text: "", tool_calls: [{id: "noop1", name: "noop", arguments: {}}]})
+  llm_mock({text: "", tool_calls: [{id: "noop2", name: "noop", arguments: {}}]})
+  llm_mock({text: "", tool_calls: [{id: "noop3", name: "noop", arguments: {}}]})
+  llm_mock(
+    {
+      text: "{\"verdict\":\"continue\",\"reasoning\":\"needs one more turn\",\"next_step\":\"change approach\"}",
+    },
+  )
+  llm_mock({text: "still working"})
+  let session = "stall-judge-continue-" + uuid()
+  let captured = agent_capture_events(
+    session,
+    fn() { return agent_loop(
+      "Continue when the stall judge vetoes.",
+      nil,
+      {
+        provider: "mock",
+        tools: tools,
+        tool_format: "native",
+        loop_until_done: true,
+        max_iterations: 4,
+        session_id: session,
+        stall_diagnostics: {threshold: 3, inject_feedback: true, max_feedback: 1},
+        done_judge: {cadence: {when: "stalled"}},
+      },
+    ) },
+  )
+  let stalls = events_of(captured.events, "agent_loop_stall_warning")
+  let judges = events_of(captured.events, "judge_decision")
+  let messages = json_stringify(agent_session_messages(session))
+  println(captured.result.status)
+  println(len(stalls))
+  println(len(judges))
+  println(judges[0].trigger)
+  println(judges[0].verdict)
+  println(tool_message_count(session))
+  println(contains(messages, "Stall diagnostic"))
+  println(len(llm_mock_calls()))
+  var other_tools = tool_registry()
+  other_tools = tool_define(
+    other_tools,
+    "noop",
+    "Return the same harmless result",
+    {
+      handler: { _args -> return "noop" },
+      parameters: {},
+      returns: {type: "string"},
+      annotations: {kind: "read"},
+    },
+  )
+  llm_mock_clear()
+  llm_mock({text: "", tool_calls: [{id: "noopA", name: "noop", arguments: {}}]})
+  llm_mock({text: "", tool_calls: [{id: "noopB", name: "noop", arguments: {}}]})
+  let other_session = "stall-judge-other-" + uuid()
+  let other = agent_capture_events(
+    other_session,
+    fn() { return agent_loop(
+      "Do not run a stall judge for non-stalled cadence.",
+      nil,
+      {
+        provider: "mock",
+        tools: other_tools,
+        tool_format: "native",
+        loop_until_done: true,
+        max_iterations: 2,
+        session_id: other_session,
+        stall_diagnostics: {threshold: 2, inject_feedback: true, max_feedback: 1},
+        done_judge: {cadence: {when: "always"}},
+      },
+    ) },
+  )
+  println(other.result.status)
+  println(len(events_of(other.events, "agent_loop_stall_warning")))
+  println(len(events_of(other.events, "judge_decision")))
+  println(tool_message_count(other_session))
+}

--- a/conformance/tests/agents/agent_loop_stall_triggers_judge.expected
+++ b/conformance/tests/agents/agent_loop_stall_triggers_judge.expected
@@ -1,0 +1,7 @@
+done
+stalled_done_judge
+stalled
+done
+true
+2
+4

--- a/conformance/tests/agents/agent_loop_stall_triggers_judge.harn
+++ b/conformance/tests/agents/agent_loop_stall_triggers_judge.harn
@@ -1,0 +1,65 @@
+import { agent_capture_events } from "std/agent/events"
+import { agent_session_messages } from "std/agent/state"
+
+fn events_of(events, kind) {
+  return events.filter({ event -> event.type == kind })
+}
+
+fn tool_message_count(session_id) {
+  var count = 0
+  for message in agent_session_messages(session_id) {
+    if message?.role == "tool" && message?.name == "noop" {
+      count = count + 1
+    }
+  }
+  return count
+}
+
+pipeline default() {
+  var tools = tool_registry()
+  tools = tool_define(
+    tools,
+    "noop",
+    "Return the same harmless result",
+    {
+      handler: { _args -> return "noop" },
+      parameters: {},
+      returns: {type: "string"},
+      annotations: {kind: "read"},
+    },
+  )
+  llm_mock_clear()
+  llm_mock({text: "", tool_calls: [{id: "noop1", name: "noop", arguments: {}}]})
+  llm_mock({text: "", tool_calls: [{id: "noop2", name: "noop", arguments: {}}]})
+  llm_mock({text: "", tool_calls: [{id: "noop3", name: "noop", arguments: {}}]})
+  llm_mock({text: "{\"verdict\":\"done\",\"reasoning\":\"the repeated call is enough\"}"})
+  let session = "stall-judge-done-" + uuid()
+  let captured = agent_capture_events(
+    session,
+    fn() { return agent_loop(
+      "Stop when the stall judge accepts.",
+      nil,
+      {
+        provider: "mock",
+        tools: tools,
+        tool_format: "native",
+        loop_until_done: true,
+        max_iterations: 5,
+        session_id: session,
+        stall_diagnostics: {threshold: 3, inject_feedback: true, max_feedback: 1},
+        done_judge: {cadence: {when: "stalled"}},
+      },
+    ) },
+  )
+  let stalls = events_of(captured.events, "agent_loop_stall_warning")
+  let judges = events_of(captured.events, "judge_decision")
+  require len(stalls) == 1, "stall warning should fire once"
+  require len(judges) == 1, "stalled done_judge should fire once"
+  println(captured.result.status)
+  println(captured.result.stop_reason)
+  println(judges[0].trigger)
+  println(judges[0].verdict)
+  println(judges[0].iteration == stalls[0].warning.iteration)
+  println(tool_message_count(session))
+  println(len(llm_mock_calls()))
+}

--- a/crates/harn-serve/src/adapters/acp/events.rs
+++ b/crates/harn-serve/src/adapters/acp/events.rs
@@ -757,6 +757,7 @@ impl AgentEventSink for AcpAgentEventSink {
                 reasoning,
                 next_step,
                 judge_duration_ms,
+                trigger,
             } => {
                 self.emit_agent_event_ext(
                     "judge_decision",
@@ -767,6 +768,7 @@ impl AgentEventSink for AcpAgentEventSink {
                         "reasoning": reasoning,
                         "nextStep": next_step,
                         "judgeDurationMs": judge_duration_ms,
+                        "trigger": trigger,
                     }),
                 );
             }

--- a/crates/harn-serve/src/adapters/acp/events/tests.rs
+++ b/crates/harn-serve/src/adapters/acp/events/tests.rs
@@ -362,6 +362,7 @@ fn agent_event_ext_fixture_events() -> Vec<AgentEvent> {
             reasoning: "needs one more concrete action".to_string(),
             next_step: Some("run the verifier".to_string()),
             judge_duration_ms: 42,
+            trigger: Some("stalled".to_string()),
         },
         AgentEvent::TypedCheckpoint {
             session_id: "session-1".to_string(),

--- a/crates/harn-serve/tests/fixtures/acp/agent_event_ext_notifications.json
+++ b/crates/harn-serve/tests/fixtures/acp/agent_event_ext_notifications.json
@@ -237,6 +237,7 @@
       "nextStep": "run the verifier",
       "reasoning": "needs one more concrete action",
       "sessionId": "session-1",
+      "trigger": "stalled",
       "verdict": "continue"
     }
   },

--- a/crates/harn-stdlib/src/stdlib/agent/judge.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/judge.harn
@@ -149,6 +149,7 @@ fn __emit_judge_decision(session_id, iteration, verdict) {
       reasoning: verdict?.reasoning ?? "",
       next_step: verdict?.next_step ?? "",
       judge_duration_ms: verdict?.judge_duration_ms ?? 0,
+      trigger: verdict?.trigger ?? nil,
     },
   )
 }
@@ -165,11 +166,12 @@ pub fn agent_verify_or_continue(session, opts, stop_reason, text, iteration = 0)
     __emit_judge_decision(session.session_id, iteration, verdict)
   }
   let done_judge_due = opts?._done_judge_due ?? true
-  let done_judge_applies = opts?.done_judge != nil && (stop_reason == "sentinel" || stop_reason == "natural")
+  let done_judge_applies = opts?.done_judge != nil
+    && (stop_reason == "sentinel" || stop_reason == "natural" || stop_reason == "stalled")
     && done_judge_due
   if !verdict.vetoed && done_judge_applies {
     verdict = __judge_invoke_structured(opts.done_judge, opts, payload)
-    verdict = verdict + {done_judge_invoked: true}
+    verdict = verdict + {done_judge_invoked: true, trigger: opts?._done_judge_trigger ?? nil}
     __emit_judge_decision(session.session_id, iteration, verdict)
   }
   if verdict.vetoed && verdict?.feedback != nil && verdict.feedback != "" {

--- a/crates/harn-stdlib/src/stdlib/agent/loop.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/loop.harn
@@ -445,8 +445,7 @@ fn __stall_warning_record(iteration, tool_name, args, signature, repeat_count, c
   return record
 }
 
-fn __stall_maybe_emit(session_id, warning, config, state) {
-  agent_emit_event(session_id, "agent_loop_stall_warning", warning)
+fn __stall_inject_feedback(session_id, warning, config, state) {
   let wants_feedback = config.inject_feedback ?? true
   let should_feedback = wants_feedback && state.feedback_count < config.max_feedback
   if should_feedback {
@@ -456,15 +455,35 @@ fn __stall_maybe_emit(session_id, warning, config, state) {
   return state
 }
 
-fn __stall_observe_tool_calls(session_id, tool_calls, iteration, raw_config, state) {
+fn __stall_maybe_emit(session_id, warning, config, state, defer_feedback) {
+  agent_emit_event(session_id, "agent_loop_stall_warning", warning)
+  if defer_feedback {
+    return {state: state, warning: warning, feedback_deferred: true}
+  }
+  return {
+    state: __stall_inject_feedback(session_id, warning, config, state),
+    warning: warning,
+    feedback_deferred: false,
+  }
+}
+
+fn __stall_observe_tool_calls(session_id, tool_calls, iteration, raw_config, state, defer_feedback) {
   let config = __stall_diagnostics_config(raw_config)
   if !config.enabled {
-    return {state: state, enabled: false}
+    return {state: state, enabled: false, warning: nil, feedback_deferred: false, config: config}
   }
   if len(tool_calls) == 0 {
-    return {state: __stall_reset_state(state), enabled: true}
+    return {
+      state: __stall_reset_state(state),
+      enabled: true,
+      warning: nil,
+      feedback_deferred: false,
+      config: config,
+    }
   }
   var next_state = state
+  var emitted_warning = nil
+  var feedback_deferred = false
   for call in tool_calls {
     let tool_name = __tool_call_name(call)
     if tool_name == "" || contains(config.exempt_tools, tool_name) {
@@ -486,11 +505,22 @@ fn __stall_observe_tool_calls(session_id, tool_calls, iteration, raw_config, sta
       + {last_signature: signature, streak: streak, repeated_tool_calls: repeated}
     if streak == config.threshold {
       let warning = __stall_warning_record(iteration, tool_name, __tool_call_args(call), signature, streak, config)
-      next_state = __stall_maybe_emit(session_id, warning, config, next_state)
+      let emitted = __stall_maybe_emit(session_id, warning, config, next_state, defer_feedback)
+      next_state = emitted.state
+      if emitted_warning == nil {
+        emitted_warning = warning
+      }
+      feedback_deferred = feedback_deferred || emitted?.feedback_deferred ?? false
       next_state = next_state + {warnings: next_state.warnings.push(warning)}
     }
   }
-  return {state: next_state, enabled: true}
+  return {
+    state: next_state,
+    enabled: true,
+    warning: emitted_warning,
+    feedback_deferred: feedback_deferred,
+    config: config,
+  }
 }
 
 fn __apply_stall_result(result, stall_enabled, stall_state) {
@@ -503,6 +533,38 @@ fn __apply_stall_result(result, stall_enabled, stall_state) {
     stall_warnings: stall_state.warnings,
     suspected_loop: len(stall_state.warnings) > 0,
   }
+}
+
+fn __done_judge_stall_cadence(opts) {
+  let judge = opts?.done_judge
+  if type_of(judge) != "dict" {
+    return nil
+  }
+  let cadence = judge?.cadence
+  if type_of(cadence) != "dict" || cadence?.when != "stalled" {
+    return nil
+  }
+  return cadence
+}
+
+fn __done_judge_stall_due(opts, invocations, turn_number) {
+  let cadence = __done_judge_stall_cadence(opts)
+  if cadence == nil {
+    return false
+  }
+  let max_invocations = cadence?.max_invocations
+  if max_invocations != nil && invocations >= max_invocations {
+    return false
+  }
+  let min_iterations = cadence?.min_iterations_before_first
+  if min_iterations != nil && turn_number <= min_iterations {
+    return false
+  }
+  let every = cadence?.every
+  if every != nil && turn_number % every != 0 {
+    return false
+  }
+  return true
 }
 
 fn __native_fallback_feedback(policy, fallback_index) {
@@ -1207,15 +1269,46 @@ fn __agent_loop_run(message, session, initial_opts) {
       } else {
         __resolve_tool_calls(llm_result, parsed)
       }
+      let stall_judge_due = __done_judge_stall_due(turn_opts, done_judge_invocations, turn_index + 1)
       let stall_observation = __stall_observe_tool_calls(
         session.session_id,
         tool_calls,
         turn_index + 1,
         turn_opts?.stall_diagnostics,
         stall_state,
+        stall_judge_due,
       )
       stall_state = stall_observation.state
       stall_enabled_seen = stall_enabled_seen || stall_observation.enabled
+      if stall_judge_due && stall_observation?.warning != nil {
+        let stall_verify_opts = turn_opts
+          + {_done_judge_due: true, _done_judge_trigger: "stalled"}
+        let stall_verdict = agent_verify_or_continue(session, stall_verify_opts, "stalled", visible_text, turn_index + 1)
+        if stall_verdict?.done_judge_invoked ?? false {
+          done_judge_invocations = done_judge_invocations + 1
+        }
+        if stall_verdict.vetoed {
+          if stall_observation?.feedback_deferred ?? false {
+            stall_state = __stall_inject_feedback(
+              session.session_id,
+              stall_observation.warning,
+              stall_observation.config,
+              stall_state,
+            )
+          }
+        } else {
+          agent_session_record_usage(session.session_id, llm_result)
+          let tool_count = len(tool_calls)
+          agent_emit_event(
+            session.session_id,
+            "turn_end",
+            {iteration: turn_index + 1, turn_info: {tool_count: tool_count, text: visible_text}},
+          )
+          final_status = "done"
+          stop_reason = "stalled_done_judge"
+          break
+        }
+      }
       let dispatched = __dispatch_tool_calls(
         session.session_id,
         tool_calls,

--- a/crates/harn-stdlib/src/stdlib/agent/turn.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/turn.harn
@@ -68,6 +68,7 @@ fn __agent_turn_judge_decisions(events) {
           reasoning: event.reasoning,
           next_step: event.next_step,
           judge_duration_ms: event.judge_duration_ms,
+          trigger: event?.trigger,
         },
       )
     }

--- a/crates/harn-vm/src/agent_events.rs
+++ b/crates/harn-vm/src/agent_events.rs
@@ -420,6 +420,8 @@ pub enum AgentEvent {
         reasoning: String,
         next_step: Option<String>,
         judge_duration_ms: u64,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        trigger: Option<String>,
     },
     TypedCheckpoint {
         session_id: String,
@@ -1276,6 +1278,7 @@ mod tests {
             reasoning: "needs a concrete next step".into(),
             next_step: Some("run the verifier".into()),
             judge_duration_ms: 17,
+            trigger: Some("stalled".into()),
         });
         sink.flush().unwrap();
 
@@ -1290,6 +1293,7 @@ mod tests {
                 reasoning,
                 next_step,
                 judge_duration_ms,
+                trigger,
             } => {
                 assert_eq!(session_id, "s");
                 assert_eq!(iteration, 2);
@@ -1297,6 +1301,7 @@ mod tests {
                 assert_eq!(reasoning, "needs a concrete next step");
                 assert_eq!(next_step.as_deref(), Some("run the verifier"));
                 assert_eq!(judge_duration_ms, 17);
+                assert_eq!(trigger.as_deref(), Some("stalled"));
             }
             other => panic!("expected JudgeDecision, got {other:?}"),
         }

--- a/crates/harn-vm/src/llm/agent_session_host.rs
+++ b/crates/harn-vm/src/llm/agent_session_host.rs
@@ -1144,6 +1144,7 @@ fn build_agent_event(
                 .and_then(|m| m.get("judge_duration_ms"))
                 .and_then(|v| v.as_u64())
                 .unwrap_or(0),
+            trigger: get_opt_string("trigger"),
         }),
         "typed_checkpoint" => Ok(AgentEvent::TypedCheckpoint {
             session_id: session_id.to_string(),

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -1409,7 +1409,7 @@ The result is the normal `agent_loop` dict plus:
 - `iterations` — compact per-turn summaries from live loop events.
 - `judge_decisions` — structured completion judge decisions with
   `iteration`, `verdict`, `reasoning`, `next_step`, and
-  `judge_duration_ms`.
+  `judge_duration_ms`, plus optional `trigger`.
 
 ```harn
 let result = agent_turn("Review this patch and fix obvious issues.", {
@@ -1485,7 +1485,8 @@ the model emits `##DONE##` in a sentinel loop.
 The judge returns `verdict: "done" | "continue"` plus optional
 `reasoning` and `next_step`. A veto injects feedback and the loop
 continues until the judge accepts or `max_verify_attempts` is exhausted.
-Each judge call emits a `JudgeDecision` agent event. Use
+Each judge call emits a `JudgeDecision` agent event with optional `trigger`.
+Use
 `verify_completion_judge` instead when every natural stop should be
 judged.
 
@@ -1505,6 +1506,11 @@ agent_loop(task, system, {
   },
 })
 ```
+
+With `when: "stalled"`, stall diagnostics run the judge when
+`agent_loop_stall_warning` fires. `done` stops the loop with
+`stalled_done_judge`; `continue` keeps the normal stall feedback fallback. The
+judge event includes `trigger: "stalled"`.
 
 Omitting `cadence` preserves the default behavior: every completion
 candidate is judged. `when: "stalled"` is quiet during healthy turns and

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -2092,7 +2092,11 @@ judge returns `verdict: "done" | "continue"` plus optional `reasoning` and
 `next_step`, and injects judge feedback before continuing when the verdict
 rejects completion. Each built-in judge call emits
 `JudgeDecision {session_id, iteration, verdict, reasoning, next_step,
-judge_duration_ms}`.
+judge_duration_ms, trigger?}`. The optional `trigger` is `"stalled"` when a
+`done_judge.cadence.when: "stalled"` judge fires from an
+`agent_loop_stall_warning`; a `done` verdict stops the loop with
+`stalled_done_judge` before the repeated tool call dispatches, and a
+`continue` verdict leaves the stall feedback path in place.
 
 `agent_turn(prompt, options?)` is the high-level wrapper for a single complete
 agent request. It uses `agent_loop`, folds `options.system` into the system

--- a/docs/src/llm/agent_loop.md
+++ b/docs/src/llm/agent_loop.md
@@ -12,7 +12,7 @@ judge; omit it to use the default judge.
 
 The return value is the normal `agent_loop` result with two extra summaries:
 `iterations` (`[{iteration, started, ended?, tool_count?, prose_chars?}]`) and `judge_decisions`
-(`[{iteration, verdict, reasoning, next_step, judge_duration_ms}]`).
+(`[{iteration, verdict, reasoning, next_step, judge_duration_ms, trigger?}]`).
 
 ```harn
 let result = agent_turn("Summarize the current project risks.", {
@@ -619,13 +619,18 @@ the transcript for a structured judge call and expects
 A veto injects runtime feedback and the loop continues until the judge accepts
 or `max_verify_attempts` is exhausted. Every judge call emits `JudgeDecision`
 with `session_id`, `iteration`, `verdict`, `reasoning`, `next_step`, and
-`judge_duration_ms`.
+`judge_duration_ms`, plus optional `trigger`.
 
 Use `done_judge.cadence` to gate the judge. Omit it to preserve the default:
 every completion candidate is judged. `every: N` judges turns `N`, `2N`, and so
 on; `max_invocations` caps total done-judge calls; `min_iterations_before_first`
 skips the first K turns; `when` accepts `"always"`, `"stalled"`, or a closure
 that receives the same loop-state shape as `loop_control`.
+When `when: "stalled"` is configured, a stall warning can fire the judge
+directly. A `done` verdict stops the loop with `stalled_done_judge` before the
+repeated tool call is dispatched; a `continue` verdict leaves the existing
+stall feedback injection path in place. The corresponding `JudgeDecision`
+event carries `trigger: "stalled"`.
 
 ```harn
 agent_loop(task, system, {

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -2090,7 +2090,11 @@ judge returns `verdict: "done" | "continue"` plus optional `reasoning` and
 `next_step`, and injects judge feedback before continuing when the verdict
 rejects completion. Each built-in judge call emits
 `JudgeDecision {session_id, iteration, verdict, reasoning, next_step,
-judge_duration_ms}`.
+judge_duration_ms, trigger?}`. The optional `trigger` is `"stalled"` when a
+`done_judge.cadence.when: "stalled"` judge fires from an
+`agent_loop_stall_warning`; a `done` verdict stops the loop with
+`stalled_done_judge` before the repeated tool call dispatches, and a
+`continue` verdict leaves the stall feedback path in place.
 
 `agent_turn(prompt, options?)` is the high-level wrapper for a single complete
 agent request. It uses `agent_loop`, folds `options.system` into the system


### PR DESCRIPTION
## Summary
- run `done_judge.cadence.when: "stalled"` when stall diagnostics emit `agent_loop_stall_warning`
- stop with `stalled_done_judge` before dispatching the repeated tool call when the stall judge returns `done`; otherwise fall back to the existing stall feedback path
- add optional `trigger` on `judge_decision` events and ACP extension payloads, plus conformance coverage for done/continue/non-stalled cadence cases

Closes #1632.

## Verification
- `CARGO_TARGET_DIR=/private/tmp/harn-issue1632-target cargo run --quiet --bin harn -- test conformance --filter agent_loop_stall`
- `CARGO_TARGET_DIR=/private/tmp/harn-issue1632-target cargo test -p harn-serve agent_event_ext`
- `CARGO_TARGET_DIR=/private/tmp/harn-issue1632-target cargo test -p harn-serve protocol_conformance_agent_event_fixture_is_adapter_generated`
- `CARGO_TARGET_DIR=/private/tmp/harn-issue1632-target cargo test -p harn-vm judge_decision_round_trips_through_jsonl_sink`
- `CARGO_TARGET_DIR=/private/tmp/harn-issue1632-target make fmt-harn`
- `CARGO_TARGET_DIR=/private/tmp/harn-issue1632-target make lint-harn`
- `CARGO_TARGET_DIR=/private/tmp/harn-issue1632-target make check-language-spec`
- `CARGO_TARGET_DIR=/private/tmp/harn-issue1632-target make conformance`
- `CARGO_TARGET_DIR=/private/tmp/harn-issue1632-target make protocol-conformance`
- `CARGO_TARGET_DIR=/private/tmp/harn-issue1632-target make check-docs-snippets`
- `CARGO_TARGET_DIR=/private/tmp/harn-issue1632-target make check-protocol-artifacts`
- `CARGO_TARGET_DIR=/private/tmp/harn-issue1632-target make test`
- `make lint-md`
- `cargo fmt --check`
- `git diff --check`
- pre-commit hook
- pre-push hook