### PR TITLE
Route ACP agent progress plans canonically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ condensed series summaries instead of full per-patch history.
   model-facing tool off by default; opt in with `progress_tool: true` or
   customize `{name, description, system_prompt_nudge}`. ACP extension
   notifications and protocol artifacts now include the new event kind.
+- **ACP progress plan routing (#1627).** ACP renders `agent_progress`
+  entries as canonical `sessionUpdate: "plan"` updates so clients replace
+  their structured task list directly, while message-only progress reports
+  continue to use Harn's vendor `progress` extension with `phase:
+  "narration"`.
 - **Provider telemetry envelope (#1614).** `llm_call` results now carry a
   normalized `provider_telemetry` block that preserves server-side timings
   local runtimes already report and represents missing fields explicitly.

--- a/conformance/protocols/fixtures/acp/agent_event_ext_notifications.valid.json
+++ b/conformance/protocols/fixtures/acp/agent_event_ext_notifications.valid.json
@@ -262,30 +262,6 @@
       "jsonrpc": "2.0",
       "method": "_harn/agentEvent",
       "params": {
-        "entries": [
-          {
-            "content": "Implement progress helper.",
-            "priority": "high",
-            "status": "completed"
-          },
-          {
-            "content": "Run conformance.",
-            "status": "pending"
-          }
-        ],
-        "kind": "progress_reported",
-        "message": "Patched stdlib API.",
-        "metadata": {
-          "source": "agent_progress"
-        },
-        "replace": true,
-        "sessionId": "session-1"
-      }
-    },
-    {
-      "jsonrpc": "2.0",
-      "method": "_harn/agentEvent",
-      "params": {
         "content": "missed required tool call; reissuing",
         "feedbackKind": "protocol_violation",
         "kind": "feedback_injected",

--- a/crates/harn-serve/src/adapters/acp/bridge.rs
+++ b/crates/harn-serve/src/adapters/acp/bridge.rs
@@ -143,28 +143,21 @@ impl AcpBridge {
         total: Option<i64>,
         data: Option<serde_json::Value>,
     ) {
-        let mut update = serde_json::json!({
-            "sessionUpdate": "progress",
-        });
-        let mut harn_meta = serde_json::Map::new();
-        harn_meta.insert(
-            "phase".to_string(),
-            serde_json::Value::String(phase.to_string()),
+        let update = progress_update(phase, message, progress, total, data);
+        self.send_notification(
+            "session/update",
+            serde_json::json!({
+                "sessionId": self.session_id,
+                "update": update,
+            }),
         );
-        harn_meta.insert(
-            "message".to_string(),
-            serde_json::Value::String(message.to_string()),
-        );
-        if let Some(p) = progress {
-            harn_meta.insert("progress".to_string(), serde_json::Value::from(p));
-        }
-        if let Some(t) = total {
-            harn_meta.insert("total".to_string(), serde_json::Value::from(t));
-        }
-        if let Some(d) = data {
-            harn_meta.insert("data".to_string(), d);
-        }
-        events::merge_harn_meta(&mut update, harn_meta);
+    }
+
+    /// Send a canonical ACP `plan` update. Per ACP, each plan update is
+    /// a full replacement for the client's current plan state.
+    #[allow(dead_code)]
+    pub(super) fn send_plan(&self, entries: serde_json::Value) {
+        let update = plan_update(entries);
         self.send_notification(
             "session/update",
             serde_json::json!({
@@ -306,4 +299,43 @@ impl AcpBridge {
             }
         }
     }
+}
+
+pub(super) fn plan_update(entries: serde_json::Value) -> serde_json::Value {
+    serde_json::json!({
+        "sessionUpdate": "plan",
+        "entries": entries,
+    })
+}
+
+pub(super) fn progress_update(
+    phase: &str,
+    message: &str,
+    progress: Option<i64>,
+    total: Option<i64>,
+    data: Option<serde_json::Value>,
+) -> serde_json::Value {
+    let mut update = serde_json::json!({
+        "sessionUpdate": "progress",
+    });
+    let mut harn_meta = serde_json::Map::new();
+    harn_meta.insert(
+        "phase".to_string(),
+        serde_json::Value::String(phase.to_string()),
+    );
+    harn_meta.insert(
+        "message".to_string(),
+        serde_json::Value::String(message.to_string()),
+    );
+    if let Some(p) = progress {
+        harn_meta.insert("progress".to_string(), serde_json::Value::from(p));
+    }
+    if let Some(t) = total {
+        harn_meta.insert("total".to_string(), serde_json::Value::from(t));
+    }
+    if let Some(d) = data {
+        harn_meta.insert("data".to_string(), d);
+    }
+    events::merge_harn_meta(&mut update, harn_meta);
+    update
 }

--- a/crates/harn-serve/src/adapters/acp/events.rs
+++ b/crates/harn-serve/src/adapters/acp/events.rs
@@ -177,6 +177,13 @@ fn mark_replayed_params(method: &str, params: &mut serde_json::Value) {
     }
 }
 
+fn has_progress_entries(entries: &serde_json::Value) -> bool {
+    entries
+        .as_array()
+        .map(|entries| !entries.is_empty())
+        .unwrap_or(false)
+}
+
 /// Merge `harn_meta` keys into `value._meta.harn`, creating intermediate
 /// objects as needed. Existing `_meta.harn` keys are preserved (unless
 /// overwritten by `harn_meta`). No-op when `harn_meta` is empty or
@@ -789,16 +796,34 @@ impl AgentEventSink for AcpAgentEventSink {
                 replace,
                 metadata,
             } => {
-                self.emit_agent_event_ext(
-                    "progress_reported",
-                    session_id,
-                    serde_json::json!({
-                        "message": message,
-                        "entries": entries,
-                        "replace": replace,
-                        "metadata": metadata,
-                    }),
-                );
+                if has_progress_entries(entries) {
+                    self.write_notification(serde_json::json!({
+                        "sessionId": session_id,
+                        "update": super::bridge::plan_update(entries.clone()),
+                    }));
+                } else if let Some(message) = message {
+                    self.write_notification(serde_json::json!({
+                        "sessionId": session_id,
+                        "update": super::bridge::progress_update(
+                            "narration",
+                            message,
+                            None,
+                            None,
+                            None,
+                        ),
+                    }));
+                } else {
+                    self.emit_agent_event_ext(
+                        "progress_reported",
+                        session_id,
+                        serde_json::json!({
+                            "message": message,
+                            "entries": entries,
+                            "replace": replace,
+                            "metadata": metadata,
+                        }),
+                    );
+                }
             }
             AgentEvent::FeedbackInjected {
                 session_id,

--- a/crates/harn-serve/src/adapters/acp/events/tests.rs
+++ b/crates/harn-serve/src/adapters/acp/events/tests.rs
@@ -371,16 +371,6 @@ fn agent_event_ext_fixture_events() -> Vec<AgentEvent> {
                 "stage": "verify"
             }),
         },
-        AgentEvent::ProgressReported {
-            session_id: "session-1".to_string(),
-            message: Some("Patched stdlib API.".to_string()),
-            entries: serde_json::json!([
-                {"content": "Implement progress helper.", "status": "completed", "priority": "high"},
-                {"content": "Run conformance.", "status": "pending"}
-            ]),
-            replace: true,
-            metadata: serde_json::json!({"source": "agent_progress"}),
-        },
         AgentEvent::FeedbackInjected {
             session_id: "session-1".to_string(),
             kind: "protocol_violation".to_string(),
@@ -1406,6 +1396,26 @@ async fn bridge_progress_and_log_session_updates_namespace_vendor_fields() {
             assert!(harn_meta.get("total").is_none());
             assert!(harn_meta.get("data").is_none());
             assert!(update.get("progress").is_none());
+
+            bridge.send_plan(serde_json::json!([
+                {"content": "Implement progress helper.", "status": "completed", "priority": "high"},
+                {"content": "Run conformance.", "status": "pending"}
+            ]));
+            let line = rx.recv().await.expect("plan notification");
+            let payload: serde_json::Value = serde_json::from_str(&line).expect("json");
+            let update = &payload["params"]["update"];
+            assert_eq!(update["sessionUpdate"], "plan");
+            assert_eq!(
+                update["entries"],
+                serde_json::json!([
+                    {"content": "Implement progress helper.", "status": "completed", "priority": "high"},
+                    {"content": "Run conformance.", "status": "pending"}
+                ])
+            );
+            assert!(
+                update.get("_meta").is_none(),
+                "canonical plan updates must not carry Harn extension metadata: {update}"
+            );
         })
         .await;
 }
@@ -1463,13 +1473,6 @@ fn internal_agent_events_never_emit_session_updates() {
         kind: "user".to_string(),
         content: "continue".to_string(),
     });
-    sink.handle_event(&AgentEvent::ProgressReported {
-        session_id: "session-1".to_string(),
-        message: Some("working".to_string()),
-        entries: serde_json::json!([]),
-        replace: true,
-        metadata: serde_json::json!({}),
-    });
     sink.handle_event(&AgentEvent::LoopStuck {
         session_id: "session-1".to_string(),
         max_nudges: 2,
@@ -1499,7 +1502,77 @@ fn internal_agent_events_never_emit_session_updates() {
         );
     }
     assert_eq!(
-        count, 7,
+        count, 6,
         "expected one ExtNotification per fed AgentEvent, got {count}"
+    );
+}
+
+#[test]
+fn progress_reported_entries_emit_canonical_acp_plan_update() {
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let sink = AcpAgentEventSink::new(AcpOutput::Channel(tx));
+    let entries = serde_json::json!([
+        {"content": "Implement progress helper.", "status": "completed", "priority": "high"},
+        {"content": "Run conformance.", "status": "pending"}
+    ]);
+
+    sink.handle_event(&AgentEvent::ProgressReported {
+        session_id: "session-1".to_string(),
+        message: Some("Patched stdlib API.".to_string()),
+        entries: entries.clone(),
+        replace: true,
+        metadata: serde_json::json!({"source": "agent_progress"}),
+    });
+
+    let line = rx.try_recv().expect("ACP plan notification");
+    let payload: serde_json::Value = serde_json::from_str(&line).expect("notification json");
+    assert_eq!(payload["method"], "session/update");
+    assert_eq!(payload["params"]["sessionId"], "session-1");
+    let update = &payload["params"]["update"];
+    assert_eq!(update["sessionUpdate"], "plan");
+    assert_eq!(update["entries"], entries);
+    for forbidden in ["_meta", "message", "metadata", "replace"] {
+        assert!(
+            update.get(forbidden).is_none(),
+            "agent_progress entries must emit canonical ACP plan only; got {update}"
+        );
+    }
+    assert!(
+        rx.try_recv().is_err(),
+        "agent_progress entries must emit exactly one ACP notification"
+    );
+}
+
+#[test]
+fn progress_reported_message_only_uses_harn_progress_extension() {
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let sink = AcpAgentEventSink::new(AcpOutput::Channel(tx));
+
+    sink.handle_event(&AgentEvent::ProgressReported {
+        session_id: "session-1".to_string(),
+        message: Some("Working through verification.".to_string()),
+        entries: serde_json::json!([]),
+        replace: false,
+        metadata: serde_json::json!({"source": "agent_progress"}),
+    });
+
+    let line = rx.try_recv().expect("ACP progress notification");
+    let payload: serde_json::Value = serde_json::from_str(&line).expect("notification json");
+    assert_eq!(payload["method"], "session/update");
+    assert_eq!(payload["params"]["sessionId"], "session-1");
+    let update = &payload["params"]["update"];
+    assert_eq!(update["sessionUpdate"], "progress");
+    let harn_meta = &update["_meta"]["harn"];
+    assert_eq!(harn_meta["phase"], "narration");
+    assert_eq!(harn_meta["message"], "Working through verification.");
+    for forbidden in ["phase", "message", "progress", "total", "data"] {
+        assert!(
+            update.get(forbidden).is_none(),
+            "progress extension fields must stay under _meta.harn; got {update}"
+        );
+    }
+    assert!(
+        rx.try_recv().is_err(),
+        "message-only agent_progress must emit exactly one ACP notification"
     );
 }

--- a/crates/harn-serve/tests/fixtures/acp/agent_event_ext_notifications.json
+++ b/crates/harn-serve/tests/fixtures/acp/agent_event_ext_notifications.json
@@ -257,30 +257,6 @@
     "jsonrpc": "2.0",
     "method": "_harn/agentEvent",
     "params": {
-      "entries": [
-        {
-          "content": "Implement progress helper.",
-          "priority": "high",
-          "status": "completed"
-        },
-        {
-          "content": "Run conformance.",
-          "status": "pending"
-        }
-      ],
-      "kind": "progress_reported",
-      "message": "Patched stdlib API.",
-      "metadata": {
-        "source": "agent_progress"
-      },
-      "replace": true,
-      "sessionId": "session-1"
-    }
-  },
-  {
-    "jsonrpc": "2.0",
-    "method": "_harn/agentEvent",
-    "params": {
       "content": "missed required tool call; reissuing",
       "feedbackKind": "protocol_violation",
       "kind": "feedback_injected",

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -892,7 +892,7 @@ println(response.logprobs)       // present when requested and returned
 | `llm_backoff_ms` | int | 250 | (deprecated; see `with_retry`) Base exponential backoff in milliseconds. |
 | `llm_caller` | closure | nil | (`agent_loop` only) Custom caller wrapping the per-turn `llm_call`. See "Composable LLM callers" below. |
 | `tool_caller` | closure | nil | (`agent_loop` only) Custom caller wrapping every tool dispatch. Signature `fn(call, next) -> result_dict`. See "Composable tool middleware" below. |
-| `progress_tool` | bool \| dict | false | (`agent_loop` only) Expose an opt-in progress-reporting tool. `true` installs `agent_progress`; dict form may set `name`, `description`, and `system_prompt_nudge`. |
+| `progress_tool` | bool \| dict | false | (`agent_loop` only) Expose an opt-in progress-reporting tool. `true` installs `agent_progress`; dict form may set `name`, `description`, and `system_prompt_nudge`. ACP clients receive entries as canonical `plan` updates and message-only reports as Harn `progress` narration. |
 | `stream` | bool | true | SSE streaming transport. |
 
 Provider auto-resolution precedence:

--- a/docs/src/llm/agent_loop.md
+++ b/docs/src/llm/agent_loop.md
@@ -228,7 +228,7 @@ Same as `llm_call`, plus additional options:
 | `reasoning_task` | string | inferred | Task hint for `reasoning_policy: "auto"`: `chat`, `agent`, `code`, `verify`, or `summarize` |
 | `tool_retries` | int | `0` | Number of retry attempts for failed tool calls |
 | `tool_backoff_ms` | int | `1000` | Base backoff delay in ms for tool retries (doubles each attempt) |
-| `progress_tool` | bool/dict | `false` | Opt in to a model-facing progress tool that emits `progress_reported` agent events. `true` exposes `agent_progress`; a dict may set `name`, `description`, and `system_prompt_nudge` |
+| `progress_tool` | bool/dict | `false` | Opt in to a model-facing progress tool that emits `progress_reported` agent events. `true` exposes `agent_progress`; a dict may set `name`, `description`, and `system_prompt_nudge`. ACP clients receive task-list entries as canonical `plan` updates and message-only reports as Harn `progress` narration |
 | `policy` | dict | nil | Capability ceiling applied to this agent loop |
 | `daemon` | bool | `false` | Idle instead of terminating after text-only turns |
 | `persist_path` | string | nil | Persist daemon snapshots to this path on idle/finalize |

--- a/docs/src/spec/harn-extensions/v1.md
+++ b/docs/src/spec/harn-extensions/v1.md
@@ -117,6 +117,11 @@ Harn extension session updates keep the `sessionUpdate` discriminator at
 The `audit` field on `worker_update` is the same mutation-session record shape
 used by tool lifecycle `audit`.
 
+`agent_progress` task-list entries are not encoded as the Harn `progress`
+extension. ACP adapters emit them as canonical `sessionUpdate: "plan"` updates
+with full-replacement `entries`; message-only `agent_progress` reports use the
+Harn `progress` extension with `phase: "narration"`.
+
 Standard ACP updates such as `agent_message_chunk`, `tool_call`,
 `tool_call_update`, and `plan` keep their standard payload fields at the root
 of `params.update`.


### PR DESCRIPTION
## Summary
- Route `agent_progress` events with entries to canonical ACP `session/update` plan updates.
- Keep message-only progress on the existing Harn vendor progress extension with `phase = narration`.
- Leave bridge progress/log callers intact and update ACP protocol fixtures/docs.

Closes #1627.

## Verification
- `CARGO_TARGET_DIR=/private/tmp/harn-issue1627-target cargo test -p harn-serve adapters::acp::events::tests`
- `CARGO_TARGET_DIR=/private/tmp/harn-issue1627-target make protocol-conformance`
- `cargo fmt --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/private/tmp/harn-issue1627-target make test`
- pre-push hook