### PR TITLE
Emit A2A progress as status updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ condensed series summaries instead of full per-patch history.
   their structured task list directly, while message-only progress reports
   continue to use Harn's vendor `progress` extension with `phase:
   "narration"`.
+- **A2A progress status updates (#1629).** A2A task streams now translate
+  `progress_reported` events into non-terminal `working` status updates
+  with agent message text. Entry lists render as deterministic markdown
+  checklists, while terminal completion status emission remains unchanged.
 - **Provider telemetry envelope (#1614).** `llm_call` results now carry a
   normalized `provider_telemetry` block that preserves server-side timings
   local runtimes already report and represents missing fields explicitly.

--- a/crates/harn-serve/src/adapters/a2a/events.rs
+++ b/crates/harn-serve/src/adapters/a2a/events.rs
@@ -59,6 +59,12 @@ impl harn_vm::agent_events::AgentEventSink for A2aWorkerSink {
                     "plan": plan,
                 })
             }
+            harn_vm::agent_events::AgentEvent::ProgressReported {
+                message, entries, ..
+            } => {
+                self.emit_progress_status(message.as_deref(), entries);
+                return;
+            }
             harn_vm::agent_events::AgentEvent::HitlRequested {
                 request_id,
                 kind,
@@ -132,6 +138,44 @@ impl A2aWorkerSink {
         publish_locked(task, event);
     }
 
+    fn emit_progress_status(&self, message: Option<&str>, entries: &JsonValue) {
+        let Some(text) = render_progress_message(message, entries) else {
+            return;
+        };
+        let mut tasks = self.tasks.lock().expect("tasks poisoned");
+        let Some(task) = tasks.get_mut(&self.task_id) else {
+            return;
+        };
+        if task.status.is_terminal() {
+            return;
+        }
+        task.status = TaskStatus::Working;
+        let mut event = json!({
+            "kind": "status-update",
+            "type": "status",
+            "taskId": self.task_id,
+            "status": {
+                "state": TaskStatus::Working.as_str(),
+                "message": {
+                    "id": Uuid::now_v7().to_string(),
+                    "role": "agent",
+                    "parts": [
+                        {
+                            "kind": "text",
+                            "type": "text",
+                            "text": text,
+                        }
+                    ],
+                },
+            },
+            "final": false,
+        });
+        if let Some(context_id) = task.context_id.as_ref() {
+            event["contextId"] = JsonValue::String(context_id.clone());
+        }
+        publish_locked(task, event);
+    }
+
     /// Flip the task into `input-required` while a HITL primitive is
     /// blocked waiting for a response. The script remains suspended on
     /// a waitpoint; subscribers see two events — a structured `hitl`
@@ -192,5 +236,58 @@ impl A2aWorkerSink {
             task.status = TaskStatus::Working;
             publish_locked(task, status_event(&self.task_id, TaskStatus::Working));
         }
+    }
+}
+
+fn render_progress_message(message: Option<&str>, entries: &JsonValue) -> Option<String> {
+    let mut sections = Vec::new();
+    if let Some(message) = message.map(str::trim).filter(|message| !message.is_empty()) {
+        sections.push(message.to_string());
+    }
+
+    if let Some(entries) = entries.as_array().filter(|entries| !entries.is_empty()) {
+        let mut lines = vec!["Plan:".to_string()];
+        for entry in entries {
+            let Some(content) = entry
+                .get("content")
+                .and_then(JsonValue::as_str)
+                .map(str::trim)
+                .filter(|content| !content.is_empty())
+            else {
+                continue;
+            };
+            let status = entry
+                .get("status")
+                .and_then(JsonValue::as_str)
+                .unwrap_or("pending");
+            let marker = if status == "completed" { "[x]" } else { "[ ]" };
+            let mut line = format!("- {marker} {content}");
+            let mut qualifiers = Vec::new();
+            if !matches!(status, "pending" | "completed") {
+                qualifiers.push(status.replace('_', " "));
+            }
+            if let Some(priority) = entry
+                .get("priority")
+                .and_then(JsonValue::as_str)
+                .filter(|priority| !priority.is_empty())
+            {
+                qualifiers.push(format!("priority: {priority}"));
+            }
+            if !qualifiers.is_empty() {
+                line.push_str(" (");
+                line.push_str(&qualifiers.join(", "));
+                line.push(')');
+            }
+            lines.push(line);
+        }
+        if lines.len() > 1 {
+            sections.push(lines.join("\n"));
+        }
+    }
+
+    if sections.is_empty() {
+        None
+    } else {
+        Some(sections.join("\n\n"))
     }
 }

--- a/crates/harn-serve/src/adapters/a2a/tests/tasks.rs
+++ b/crates/harn-serve/src/adapters/a2a/tests/tasks.rs
@@ -305,6 +305,98 @@ pub fn triage(task: string) -> string {
     }));
 }
 
+#[tokio::test]
+async fn streaming_agent_progress_emits_status_update_before_completion() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let script = dir.path().join("server.harn");
+    std::fs::write(
+        &script,
+        r#"
+import { agent_progress } from "std/agent/progress"
+
+pub fn triage(task: string) -> string {
+  agent_progress({
+    message: "Agent is checking progress.",
+    entries: [
+      {content: "Inspect code.", status: "completed", priority: "high"},
+      {content: "Run A2A stream.", status: "in_progress"},
+    ],
+  })
+  return task
+}
+"#,
+    )
+    .expect("write script");
+    let core = DispatchCore::new(DispatchCoreConfig::for_script(&script)).expect("core");
+    let server = Arc::new(A2aServer::new(A2aServerConfig::new(core)));
+    let request = harn_vm::jsonrpc::request(
+        "stream-progress-1",
+        "message/stream",
+        json!({
+            "function": "triage",
+            "message": {
+                "parts": [{"type": "text", "text": "stream progress"}]
+            }
+        }),
+    );
+
+    let processed = server.process_rpc(request, AuthRequest::default()).await;
+    let RpcOutcome::Sse(mut rx) = processed.outcome else {
+        panic!("expected sse response");
+    };
+    let mut events = Vec::new();
+    while let Some(event) = tokio::time::timeout(std::time::Duration::from_secs(2), rx.next())
+        .await
+        .expect("stream event")
+    {
+        let done = event
+            .pointer("/result/status/state")
+            .and_then(JsonValue::as_str)
+            == Some("completed");
+        events.push(event);
+        if done {
+            break;
+        }
+    }
+
+    let progress = events
+        .iter()
+        .find(|event| {
+            event.pointer("/result/kind").and_then(JsonValue::as_str) == Some("status-update")
+        })
+        .expect("progress status update");
+    assert_eq!(
+        progress.pointer("/result/type").and_then(JsonValue::as_str),
+        Some("status")
+    );
+    assert_eq!(
+        progress
+            .pointer("/result/status/state")
+            .and_then(JsonValue::as_str),
+        Some("working")
+    );
+    assert_eq!(
+        progress
+            .pointer("/result/final")
+            .and_then(JsonValue::as_bool),
+        Some(false)
+    );
+    assert_eq!(
+        progress
+            .pointer("/result/status/message/parts/0/text")
+            .and_then(JsonValue::as_str),
+        Some(
+            "Agent is checking progress.\n\nPlan:\n- [x] Inspect code. (priority: high)\n- [ ] Run A2A stream. (in progress)"
+        )
+    );
+    assert!(events.iter().any(|event| {
+        event
+            .pointer("/result/status/state")
+            .and_then(JsonValue::as_str)
+            == Some("completed")
+    }));
+}
+
 #[test]
 fn signed_card_adds_signature_envelope() {
     let mut card = json!({"id": "agent", "skills": []});
@@ -418,6 +510,143 @@ fn a2a_worker_sink_publishes_plan_extension_to_task_stream() {
     assert_eq!(event["taskId"], task_id);
     assert_eq!(event["entries"][0]["content"], "Inspect files.");
     assert_eq!(event["plan"]["schema_version"], "harn.plan.v1");
+}
+
+#[test]
+fn a2a_worker_sink_publishes_progress_as_status_update() {
+    let task_id = "task-progress".to_string();
+    let task = TaskState {
+        id: task_id.clone(),
+        context_id: Some("ctx-progress".to_string()),
+        status: TaskStatus::Working,
+        history: Vec::new(),
+        artifacts: Vec::new(),
+        metadata: BTreeMap::new(),
+        events: Vec::new(),
+        subscribers: Vec::new(),
+        cancel_token: None,
+    };
+    let tasks: TaskStore = Arc::new(Mutex::new(HashMap::from([(task_id.clone(), task)])));
+    let sink = super::A2aWorkerSink {
+        task_id: task_id.clone(),
+        tasks: tasks.clone(),
+    };
+
+    sink.handle_event(&harn_vm::agent_events::AgentEvent::ProgressReported {
+        session_id: super::a2a_worker_session_id(&task_id),
+        message: Some("Patched stdlib API.".to_string()),
+        entries: serde_json::json!([
+            {"content": "Implement progress helper.", "status": "completed", "priority": "high"},
+            {"content": "Run conformance.", "status": "in_progress"}
+        ]),
+        replace: true,
+        metadata: serde_json::json!({"source": "agent_progress"}),
+    });
+
+    let tasks = tasks.lock().expect("tasks");
+    let task = tasks.get(&task_id).expect("task");
+    assert_eq!(task.status, TaskStatus::Working);
+    let event = task
+        .events
+        .iter()
+        .find(|event| event.get("kind").and_then(JsonValue::as_str) == Some("status-update"))
+        .expect("status-update event");
+    assert_eq!(event["type"], "status");
+    assert_eq!(event["taskId"], task_id);
+    assert_eq!(event["contextId"], "ctx-progress");
+    assert_eq!(event["final"], false);
+    assert_eq!(event["status"]["state"], "working");
+    assert!(event["status"]["message"]["id"].is_string());
+    assert_eq!(event["status"]["message"]["role"], "agent");
+    assert_eq!(event["status"]["message"]["parts"][0]["kind"], "text");
+    assert_eq!(event["status"]["message"]["parts"][0]["type"], "text");
+    assert_eq!(
+        event["status"]["message"]["parts"][0]["text"],
+        "Patched stdlib API.\n\nPlan:\n- [x] Implement progress helper. (priority: high)\n- [ ] Run conformance. (in progress)"
+    );
+}
+
+#[test]
+fn a2a_worker_sink_publishes_message_only_progress_status() {
+    let task_id = "task-progress-message".to_string();
+    let task = TaskState {
+        id: task_id.clone(),
+        context_id: None,
+        status: TaskStatus::Working,
+        history: Vec::new(),
+        artifacts: Vec::new(),
+        metadata: BTreeMap::new(),
+        events: Vec::new(),
+        subscribers: Vec::new(),
+        cancel_token: None,
+    };
+    let tasks: TaskStore = Arc::new(Mutex::new(HashMap::from([(task_id.clone(), task)])));
+    let sink = super::A2aWorkerSink {
+        task_id: task_id.clone(),
+        tasks: tasks.clone(),
+    };
+
+    sink.handle_event(&harn_vm::agent_events::AgentEvent::ProgressReported {
+        session_id: super::a2a_worker_session_id(&task_id),
+        message: Some("Working through verification.".to_string()),
+        entries: serde_json::json!([]),
+        replace: true,
+        metadata: serde_json::json!({}),
+    });
+
+    let tasks = tasks.lock().expect("tasks");
+    let task = tasks.get(&task_id).expect("task");
+    let event = task
+        .events
+        .iter()
+        .find(|event| event.get("kind").and_then(JsonValue::as_str) == Some("status-update"))
+        .expect("status-update event");
+    assert_eq!(event["status"]["state"], "working");
+    assert_eq!(
+        event["status"]["message"]["parts"][0]["text"],
+        "Working through verification."
+    );
+    assert!(event.get("contextId").is_none());
+}
+
+#[test]
+fn a2a_worker_sink_does_not_override_terminal_task_with_progress() {
+    let task_id = "task-progress-terminal".to_string();
+    let task = TaskState {
+        id: task_id.clone(),
+        context_id: None,
+        status: TaskStatus::Completed,
+        history: Vec::new(),
+        artifacts: Vec::new(),
+        metadata: BTreeMap::new(),
+        events: Vec::new(),
+        subscribers: Vec::new(),
+        cancel_token: None,
+    };
+    let tasks: TaskStore = Arc::new(Mutex::new(HashMap::from([(task_id.clone(), task)])));
+    let sink = super::A2aWorkerSink {
+        task_id: task_id.clone(),
+        tasks: tasks.clone(),
+    };
+
+    sink.handle_event(&harn_vm::agent_events::AgentEvent::ProgressReported {
+        session_id: super::a2a_worker_session_id(&task_id),
+        message: Some("This should not revive the task.".to_string()),
+        entries: serde_json::json!([
+            {"content": "Ignored progress.", "status": "in_progress"}
+        ]),
+        replace: true,
+        metadata: serde_json::json!({}),
+    });
+
+    let tasks = tasks.lock().expect("tasks");
+    let task = tasks.get(&task_id).expect("task");
+    assert_eq!(task.status, TaskStatus::Completed);
+    assert!(
+        task.events.is_empty(),
+        "terminal task should not publish progress events: {:?}",
+        task.events
+    );
 }
 
 #[tokio::test]

--- a/docs/src/bridge-protocol.md
+++ b/docs/src/bridge-protocol.md
@@ -434,6 +434,14 @@ Structured Harn plan emissions use the same task stream. When an agent calls
 standard ACP-compatible `entries` plus the normalized `harn.plan.v1` artifact
 under `plan`.
 
+Agent progress reports use protocol-native A2A status updates. When
+`agent_progress` emits narration or entries, task-stream subscribers receive a
+non-terminal `status-update` event with `type: "status"`,
+`status.state: "working"`, a populated `status.message`, and `final: false`.
+Entry lists render as a deterministic markdown checklist inside the message
+text. Final task completion still emits the terminal `completed` status
+separately.
+
 ## Daemon idle/resume notifications
 
 Daemon agents stay alive after text-only turns and wait for host activity with adaptive

--- a/docs/src/harn-serve.md
+++ b/docs/src/harn-serve.md
@@ -168,6 +168,9 @@ Behavior today:
 - REST-style POST paths at `/message/send`, `/message/stream`,
   `/tasks/resubscribe`, and `/tasks/cancel`, plus deprecated `/tasks/send` and
   `/tasks/send_and_wait` aliases
+- `agent_progress` events stream as non-terminal `working` status updates with
+  agent message text; entry lists render as markdown checklists and final task
+  completion is still emitted separately
 - cooperative cancel propagation into the shared VM cancel token
 - push notification callbacks from caller-provided task configuration
 - HTTP auth hooks built on the shared `AuthPolicy` surface:


### PR DESCRIPTION
## Summary
- Translate `progress_reported` / `agent_progress` events into non-terminal A2A `status-update` task stream events.
- Render progress entries as a deterministic markdown checklist in `status.message` and keep message-only progress working.
- Preserve terminal task status by dropping late progress after completion/cancel/failure.
- Document the A2A stream behavior in bridge and serve docs.

Closes #1629.

## Verification
- `CARGO_TARGET_DIR=/private/tmp/harn-issue1629-target cargo test -p harn-serve a2a_worker_sink`
- `CARGO_TARGET_DIR=/private/tmp/harn-issue1629-target cargo test -p harn-serve streaming_agent_progress_emits_status_update_before_completion`
- `CARGO_TARGET_DIR=/private/tmp/harn-issue1629-target cargo test -p harn-serve adapters::a2a::tests::tasks`
- `cargo fmt --check`
- `git diff --check`
- `make lint-md`
- `CARGO_TARGET_DIR=/private/tmp/harn-issue1629-target make protocol-conformance`
- `CARGO_TARGET_DIR=/private/tmp/harn-issue1629-target make test`
- pre-commit hook
- pre-push hook

## Note
- #1638 is already queued ahead of this PR. If it lands first, this branch may need a simple changelog rebase before merge.