### PR TITLE
Document agent progress and stalled completion judges

### DIFF
--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -892,7 +892,7 @@ println(response.logprobs)       // present when requested and returned
 | `llm_backoff_ms` | int | 250 | (deprecated; see `with_retry`) Base exponential backoff in milliseconds. |
 | `llm_caller` | closure | nil | (`agent_loop` only) Custom caller wrapping the per-turn `llm_call`. See "Composable LLM callers" below. |
 | `tool_caller` | closure | nil | (`agent_loop` only) Custom caller wrapping every tool dispatch. Signature `fn(call, next) -> result_dict`. See "Composable tool middleware" below. |
-| `progress_tool` | bool \| dict | false | (`agent_loop` only) Expose an opt-in progress-reporting tool. `true` installs `agent_progress`; dict form may set `name`, `description`, and `system_prompt_nudge`. ACP clients receive entries as canonical `plan` updates and message-only reports as Harn `progress` narration. |
+| `progress_tool` | bool \| dict | false | (`agent_loop` only) Expose an opt-in progress-reporting tool. `true` installs `agent_progress`; dict form may set `name`, `description`, and `system_prompt_nudge`. ACP clients receive entries as canonical `plan` updates; A2A clients receive non-terminal `working` status updates; message-only reports surface as Harn progress narration. |
 | `stream` | bool | true | SSE streaming transport. |
 
 Provider auto-resolution precedence:
@@ -1479,6 +1479,33 @@ tool calls in the same iteration still run; only subsequent
 iterations are skipped. The loop exits with `status = "done"` and
 the tool name appears in `tools.successful`.
 
+### Progress narration
+
+Use `agent_progress({message?, entries?, replace?, metadata?})` from inside an
+agent session when a meaningful sub-step completes or the visible plan changes.
+The payload must include a non-empty `message` or `entries`; `replace` defaults
+to `true`.
+
+```harn
+agent_progress({
+  message: "Finished API inventory; checking auth paths next.",
+  entries: [
+    {content: "Inventory public API routes", status: "completed", priority: "high"},
+    {content: "Trace auth middleware", status: "in_progress"},
+  ],
+})
+```
+
+`entries` are task-list items with `content`, `status`, and optional
+`priority`. ACP clients receive entries as canonical `session/update`
+`plan` payloads. A2A clients receive non-terminal `TaskStatusUpdateEvent`
+updates with `status.state = "working"`. Message-only reports surface as Harn
+progress narration for clients that do not render plans.
+
+For model-facing loops, set `progress_tool: true` or pass a dict to customize
+the tool name, description, or system-prompt nudge. Call it after observable
+progress, not on a timer.
+
 Pass `done_judge: true` or `done_judge: {...}` to run a structured
 completion judge after a native-tool loop naturally completes or after
 the model emits `##DONE##` in a sentinel loop.
@@ -1516,6 +1543,12 @@ Omitting `cadence` preserves the default behavior: every completion
 candidate is judged. `when: "stalled"` is quiet during healthy turns and
 is reserved for stall diagnostics; pair it with stall-aware loop policy
 instead of fixed "are you done?" prompting.
+
+Fixed-cadence completion prompts are not recommended: Huang et al.'s
+[AutoGPT/agent benchmark study](https://arxiv.org/abs/2310.01798) found that
+periodic "are you done?" checks can distort behavior. Prefer explicit progress
+signals and `done_judge.cadence.when: "stalled"` when the loop is actually
+showing stall symptoms.
 
 Pass `permissions` to scope one agent below the ambient `policy` ceiling:
 

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -390,6 +390,8 @@ Imports starting with `std/` load embedded stdlib modules:
   (agent_state_init, agent_state_resume, agent_state_write,
   agent_state_read, agent_state_list, agent_state_delete,
   agent_state_handoff)
+- `import "std/agent/progress"` — agent progress narration and task-list
+  helpers (agent_progress, agent_progress_tool)
 - `import "std/memory"` — append-only durable memory helpers
   (memory_store, memory_recall, memory_summarize, memory_forget)
 - `import "std/trust"` — TrustGraph query and policy helpers
@@ -2097,6 +2099,27 @@ judge_duration_ms, trigger?}`. The optional `trigger` is `"stalled"` when a
 `agent_loop_stall_warning`; a `done` verdict stops the loop with
 `stalled_done_judge` before the repeated tool call dispatches, and a
 `continue` verdict leaves the stall feedback path in place.
+
+#### Agent progress events
+
+`std/agent/progress` exposes `agent_progress(input)` and
+`agent_progress_tool(registry?, options?)` for live agent status. The
+`agent_progress` input must contain a non-empty `message` or `entries`.
+`entries` is a list of task-list dicts with `content`, `status`, and optional
+`priority`; `replace` defaults to `true`, and `metadata` defaults to `{}`.
+
+At runtime `agent_progress` emits the `progress_reported` agent event for the
+current agent session. ACP bridges encode task-list entries as canonical
+`session/update` payloads with `sessionUpdate: "plan"` and full-replacement
+`entries`; message-only reports use Harn progress narration. A2A bridges encode
+progress reports as non-terminal `TaskStatusUpdateEvent` messages with
+`status.state = "working"` and no push-delivery side effect.
+
+`agent_progress_tool` installs a model-facing tool that calls
+`agent_progress`. `agent_loop(..., {progress_tool: true})` installs the default
+tool; dict form may override `name`, `description`, and
+`system_prompt_nudge`. Progress reports are intended for meaningful sub-step
+completion or plan changes, not fixed timer ticks.
 
 `agent_turn(prompt, options?)` is the high-level wrapper for a single complete
 agent request. It uses `agent_loop`, folds `options.system` into the system

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -388,6 +388,8 @@ Imports starting with `std/` load embedded stdlib modules:
   (agent_state_init, agent_state_resume, agent_state_write,
   agent_state_read, agent_state_list, agent_state_delete,
   agent_state_handoff)
+- `import "std/agent/progress"` — agent progress narration and task-list
+  helpers (agent_progress, agent_progress_tool)
 - `import "std/memory"` — append-only durable memory helpers
   (memory_store, memory_recall, memory_summarize, memory_forget)
 - `import "std/trust"` — TrustGraph query and policy helpers
@@ -2095,6 +2097,27 @@ judge_duration_ms, trigger?}`. The optional `trigger` is `"stalled"` when a
 `agent_loop_stall_warning`; a `done` verdict stops the loop with
 `stalled_done_judge` before the repeated tool call dispatches, and a
 `continue` verdict leaves the stall feedback path in place.
+
+#### Agent progress events
+
+`std/agent/progress` exposes `agent_progress(input)` and
+`agent_progress_tool(registry?, options?)` for live agent status. The
+`agent_progress` input must contain a non-empty `message` or `entries`.
+`entries` is a list of task-list dicts with `content`, `status`, and optional
+`priority`; `replace` defaults to `true`, and `metadata` defaults to `{}`.
+
+At runtime `agent_progress` emits the `progress_reported` agent event for the
+current agent session. ACP bridges encode task-list entries as canonical
+`session/update` payloads with `sessionUpdate: "plan"` and full-replacement
+`entries`; message-only reports use Harn progress narration. A2A bridges encode
+progress reports as non-terminal `TaskStatusUpdateEvent` messages with
+`status.state = "working"` and no push-delivery side effect.
+
+`agent_progress_tool` installs a model-facing tool that calls
+`agent_progress`. `agent_loop(..., {progress_tool: true})` installs the default
+tool; dict form may override `name`, `description`, and
+`system_prompt_nudge`. Progress reports are intended for meaningful sub-step
+completion or plan changes, not fixed timer ticks.
 
 `agent_turn(prompt, options?)` is the high-level wrapper for a single complete
 agent request. It uses `agent_loop`, folds `options.system` into the system


### PR DESCRIPTION
Closes #1633.

## Summary
- add quickref progress narration guidance for `agent_progress`, ACP plan updates, and A2A working status updates
- document the fixed-cadence completion prompt caveat and prefer `done_judge.cadence.when: "stalled"`
- add `std/agent/progress` and `progress_reported` wire semantics to the language spec, then sync generated docs

## Verification
- `CARGO_TARGET_DIR=/private/tmp/harn-issue1633-target make check-language-spec`
- `CARGO_TARGET_DIR=/private/tmp/harn-issue1633-target make check-docs-snippets`
- `make lint-md`
- `git diff --check`