### PR TITLE
Expose text-tool capability in provider_capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ Pre-0.6 highlights live in [CHANGELOG-pre-0.6.md](CHANGELOG-pre-0.6.md).
 Harn had no external users before 0.6.0, so that archive intentionally keeps
 condensed series summaries instead of full per-patch history.
 
+## Unreleased
+
+### Changed
+
+- **`provider_capabilities` exposes text-tool capability.** The dict
+  returned by `provider_capabilities(...)` and `llm_model_info(...)` now
+  includes `text_tool_wire_format_supported` (mirrors the rule field) and a
+  derived `tools` boolean (`native_tools || text_tool_wire_format_supported`)
+  that matches the VM's own tool-capability gate at
+  `effective_model_capability_tags`. Scripts gating on "can this model do
+  tools" should prefer `caps.tools` — gating on `caps.native_tools` alone
+  was rejecting tool-capable local routes like
+  `ollama/qwen3.6:35b-a3b-coding-nvfp4` that use Harn's text wire format.
+
 ## v0.8.18
 
 ### Added

--- a/crates/harn-vm/src/llm/config_builtins.rs
+++ b/crates/harn-vm/src/llm/config_builtins.rs
@@ -679,6 +679,16 @@ fn capabilities_to_vm_value(
     );
     dict.insert("native_tools".to_string(), VmValue::Bool(caps.native_tools));
     dict.insert(
+        "text_tool_wire_format_supported".to_string(),
+        VmValue::Bool(caps.text_tool_wire_format_supported),
+    );
+    // Mirrors the VM's tool-capability gate at llm_config::effective_model_capability_tags:
+    // either native or text-format tool calling counts as tool-capable.
+    dict.insert(
+        "tools".to_string(),
+        VmValue::Bool(caps.native_tools || caps.text_tool_wire_format_supported),
+    );
+    dict.insert(
         "defer_loading".to_string(),
         VmValue::Bool(caps.defer_loading),
     );
@@ -1117,5 +1127,27 @@ mod tests {
                 None => std::env::remove_var("HARN_DEFAULT_PROVIDER"),
             }
         }
+    }
+
+    #[test]
+    fn test_provider_capabilities_exposes_tools_for_text_only_models() {
+        super::super::capabilities::clear_user_overrides();
+        let mut out = String::new();
+        let args = vec![
+            VmValue::String(Rc::from("ollama")),
+            VmValue::String(Rc::from("qwen3.6:35b-a3b-coding-nvfp4")),
+        ];
+        let result =
+            provider_capabilities_builtin(&args, &mut out).expect("builtin returned error");
+        let dict = result.as_dict().expect("expected dict");
+        // qwen3.6 on Ollama uses Harn's text tool-call wire format, not native API tools.
+        // Scripts gating on `tools` should still see it as tool-capable.
+        let expect_bool = |key: &str, want: bool| match dict.get(key) {
+            Some(VmValue::Bool(b)) => assert_eq!(*b, want, "{key}"),
+            other => panic!("expected Bool for {key}, got {other:?}"),
+        };
+        expect_bool("native_tools", false);
+        expect_bool("text_tool_wire_format_supported", true);
+        expect_bool("tools", true);
     }
 }

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -1099,7 +1099,8 @@ Query the effective matrix at runtime:
 let caps = provider_capabilities("anthropic", "claude-opus-4-7")
 // {
 //   provider: "anthropic", model: "claude-opus-4-7",
-//   native_tools: true, defer_loading: true,
+//   native_tools: true, text_tool_wire_format_supported: true,
+//   tools: true, defer_loading: true,
 //   tool_search: ["bm25", "regex"], max_tools: 10000,
 //   prompt_caching: true, thinking: true,
 //   thinking_modes: ["adaptive"],
@@ -1107,6 +1108,11 @@ let caps = provider_capabilities("anthropic", "claude-opus-4-7")
 //   reasoning_effort_supported: false,
 //   interleaved_thinking_supported: true,
 // }
+
+// `caps.tools` matches Harn's own tool gate: true when the route can call
+// tools via either the native API wire shape or Harn's text wire format.
+// Inspect `native_tools` or `text_tool_wire_format_supported` directly when
+// you need to distinguish.
 
 if "bm25" in caps.tool_search {
   // opt into progressive disclosure

--- a/docs/src/llm/providers.md
+++ b/docs/src/llm/providers.md
@@ -161,13 +161,17 @@ vendor-specific knowledge:
 ```harn
 let caps = provider_capabilities("anthropic", "claude-opus-4-7")
 // {
-//   native_tools: true, defer_loading: true,
+//   native_tools: true, text_tool_wire_format_supported: true,
+//   tools: true, defer_loading: true,
 //   tool_search: ["bm25", "regex"], max_tools: 10000,
 //   prompt_caching: true, thinking: true, vision_supported: true,
 //   interleaved_thinking_supported: true,
 // }
 
-if "bm25" in caps.tool_search {
+// Gate on `tools` for "can this route call tools at all" — true for either
+// native or text-format tool wire. Inspect `native_tools` or
+// `text_tool_wire_format_supported` directly when you need to distinguish.
+if caps.tools && "bm25" in caps.tool_search {
   llm_call(prompt, sys, {
     tools: registry,
     tool_search: "bm25",


### PR DESCRIPTION
## Summary

- `provider_capabilities(...)` and `llm_model_info(...)` only exposed `native_tools`, but the VM's tool gate (`effective_model_capability_tags`) is `native_tools || text_tool_wire_format_supported`. Scripts checking `caps.native_tools` rejected tool-capable local routes like `ollama/qwen3.6:35b-a3b-coding-nvfp4` that use Harn's text wire format for tool calls.
- Expose `text_tool_wire_format_supported` plus a derived `tools` boolean that matches the VM gate. Docs updated to recommend `caps.tools` as the gate. Added a focused test against the qwen3.6 case.

This was hit by `harn-bump-fleet`'s `release_harn.harn` pre-check throwing the now-infamous "model X does not support Harn tools; choose a tool-capable local model such as X" error.

## Test plan

- [x] `cargo test -p harn-vm --lib config_builtins` — new `test_provider_capabilities_exposes_tools_for_text_only_models` passes
- [x] `cargo test -p harn-vm --lib capabilities` — 37 existing capability tests still pass
- [x] Pre-commit clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)