### PR TITLE
Derive agent_preset tool_format from model capability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ condensed series summaries instead of full per-patch history.
   tools" should prefer `caps.tools` — gating on `caps.native_tools` alone
   was rejecting tool-capable local routes like
   `ollama/qwen3.6:35b-a3b-coding-nvfp4` that use Harn's text wire format.
+- **`agent_preset` derives `tool_format` from the model capability matrix.**
+  Tool-using preset kinds (`audit`, `repair`, `merge_captain`,
+  `review_captain`, …) used to hardcode `tool_format: "native"`, which the
+  VM rejected with "option `tools` is not supported by ..." for tool-capable
+  text-format routes (e.g. `ollama/qwen3.6:35b-a3b-coding-nvfp4`) before
+  `native_tool_fallback` could engage. The preset now calls
+  `llm_resolve_model` to resolve `tool_format` from the capability matrix,
+  picking `"native"` for native-capable routes and `"text"` for text-only
+  routes. Callers that explicitly set `tool_format` still win.
 
 ## v0.8.18
 

--- a/conformance/tests/agents/agent_preset_audit_summary.harn
+++ b/conformance/tests/agents/agent_preset_audit_summary.harn
@@ -22,7 +22,7 @@ pipeline default() {
   llm_mock_clear()
   llm_mock({tool_calls: [{id: "i1", name: "inspect", arguments: {what: "release"}}]})
   llm_mock({text: "<user_response>Audit complete.</user_response>"})
-  let audit = audit_agent("Audit the release", {provider: "mock", tools: audit_tools()})
+  let audit = audit_agent("Audit the release", {provider: "mock", tools: audit_tools(), tool_format: "native"})
   println(audit.status)
   println(audit.text)
   println(audit.adaptive_budget.mode)
@@ -50,7 +50,10 @@ pipeline default() {
   llm_mock_clear()
   llm_mock({tool_calls: [{id: "r1", name: "inspect", arguments: {what: "fix"}}]})
   llm_mock({text: "<user_response>Fixed.</user_response>"})
-  let repair = repair_agent("Repair the regression", {provider: "mock", tools: audit_tools()})
+  let repair = repair_agent(
+    "Repair the regression",
+    {provider: "mock", tools: audit_tools(), tool_format: "native"},
+  )
   println(repair.status)
   println(repair.adaptive_budget.mode)
   println(repair.adaptive_budget.max >= repair.adaptive_budget.initial)

--- a/conformance/tests/agents/agent_preset_tool_format.expected
+++ b/conformance/tests/agents/agent_preset_tool_format.expected
@@ -1,0 +1,5 @@
+true
+native
+text
+text
+true

--- a/conformance/tests/agents/agent_preset_tool_format.harn
+++ b/conformance/tests/agents/agent_preset_tool_format.harn
@@ -1,0 +1,25 @@
+import { agent_preset } from "std/agent/presets"
+
+pipeline default() {
+  // No model supplied — `tool_format` should be absent so the VM can derive
+  // it at the llm_call boundary.
+  let bare = agent_preset("audit")
+  println(bare?.tool_format == nil)
+  // Native-capable model — preset derives `tool_format: "native"` from the
+  // capability matrix via `llm_resolve_model`.
+  let native_audit = agent_preset("audit", {model: "claude-sonnet-4-5"})
+  println(native_audit.tool_format)
+  // Text-only local route — preset derives `tool_format: "text"` so the VM
+  // capability gate accepts the request instead of rejecting with
+  // "option `tools` is not supported by ...".
+  let text_audit = agent_preset("audit", {provider: "ollama", model: "qwen3.6:35b-a3b-coding-nvfp4"})
+  println(text_audit.tool_format)
+  // Caller explicit `tool_format` wins over the derived default — even if the
+  // capability matrix disagrees.
+  let forced_text = agent_preset("audit", {model: "claude-sonnet-4-5", tool_format: "text"})
+  println(forced_text.tool_format)
+  // Summary preset does not opt into tool semantics, so the derivation is
+  // skipped and `tool_format` stays absent regardless of model.
+  let summary = agent_preset("summary", {model: "claude-sonnet-4-5"})
+  println(summary?.tool_format == nil)
+}

--- a/crates/harn-stdlib/src/stdlib/agent/presets.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/presets.harn
@@ -228,7 +228,6 @@ fn __tool_using_defaults(kind) {
   }
   return {
     profile: profile,
-    tool_format: "native",
     loop_until_done: true,
     done_sentinel: nil,
     done_judge: nil,
@@ -236,6 +235,59 @@ fn __tool_using_defaults(kind) {
     max_nudges: max_nudges,
     stall_diagnostics: {enabled: true, threshold: 3, inject_feedback: true, max_feedback: 1},
   }
+}
+
+/**
+ * Resolves the right `tool_format` for the configured model so it lands in
+ * the preset dict before downstream stdlib helpers (postturn / turn / options
+ * inspectors) read it. Previously this was hardcoded to `"native"`, which the
+ * VM's capability gate rejects for tool-capable text-format routes (e.g.
+ * `ollama/qwen3.6:35b-a3b-coding-nvfp4`) with "option `tools` is not supported
+ * by ..." before `native_tool_fallback` could engage. Now it defers to
+ * `llm_resolve_model`, which consults the capability matrix.
+ */
+fn __preset_default_tool_format(opts) {
+  if opts?.tool_format != nil {
+    return opts.tool_format
+  }
+  let model = opts?.model
+  if model == nil || model == "" {
+    return nil
+  }
+  // When the caller explicitly named a provider, consult the capability
+  // matrix directly. `llm_resolve_model` infers provider from the model id
+  // and would misclassify provider-specific identifiers like
+  // `qwen3.6:35b-a3b-coding-nvfp4` (Ollama) by defaulting them to the
+  // global default provider.
+  if opts?.provider != nil && opts.provider != "auto" && opts.provider != "" {
+    let caps = provider_capabilities(opts.provider, model)
+    if caps?.native_tools ?? false {
+      return "native"
+    }
+    return "text"
+  }
+  let resolved = try {
+    llm_resolve_model(model)
+  }
+  if is_err(resolved) {
+    return nil
+  }
+  let info = unwrap(resolved)
+  if info?.tool_format != nil {
+    return info.tool_format
+  }
+  return nil
+}
+
+fn __apply_tool_format(opts, kind) {
+  if kind == "summary" || kind == "verify" {
+    return opts
+  }
+  let resolved = __preset_default_tool_format(opts)
+  if resolved == nil {
+    return opts
+  }
+  return opts + {tool_format: resolved}
 }
 
 fn __kind_defaults(kind, opts) {
@@ -468,6 +520,7 @@ pub fn agent_preset(kind, options = nil) {
   opts = __apply_thinking(opts, resolved_kind)
   opts = __apply_captain_tool_caller(opts, resolved_kind)
   opts = __apply_captain_llm_caller(opts, resolved_kind)
+  opts = __apply_tool_format(opts, resolved_kind)
   return opts + {_preset_kind: resolved_kind}
 }
 


### PR DESCRIPTION
## Summary

- `agent_preset` hardcoded `tool_format: \"native\"` for tool-using kinds. The VM's capability gate at `parse_chat_options` rejected this for tool-capable text-format routes (e.g. `ollama/qwen3.6:35b-a3b-coding-nvfp4`) with \"option \`tools\` is not supported by ...\" before `native_tool_fallback` could engage — making `--agent` flows that pick text-only local models unusable.
- The preset now derives `tool_format` from the model's capability matrix via `llm_resolve_model` (or `provider_capabilities` when the caller explicitly named a provider, since `llm_resolve_model` infers provider from the model id and would misclassify provider-specific identifiers like Ollama's qwen3 family). Caller-supplied `tool_format` still wins.
- `agent_preset_audit_summary` conformance test updated to declare `tool_format: \"native\"` explicitly for its mock-provider cases. New `agent_preset_tool_format` test covers the derivation matrix.

This pairs with burin-labs/harn-bump-fleet#63 (fleet-side workaround for users on older harn binaries).

## Test plan

- [x] `cargo build --release -p harn-cli` — clean
- [x] `HARN_LLM_CALLS_DISABLED=1 ./target/release/harn test conformance` — 1005 passed, 16 pre-existing env failures (missing `claude`/`mcp` helpers, missing debug binary; none related to agent_preset)
- [x] New `agent_preset_tool_format` test confirms native↔text derivation for Claude / qwen3.6 routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)