### PR TITLE
Accept tool_choice on text-format tool routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ condensed series summaries instead of full per-patch history.
   tools" should prefer `caps.tools` — gating on `caps.native_tools` alone
   was rejecting tool-capable local routes like
   `ollama/qwen3.6:35b-a3b-coding-nvfp4` that use Harn's text wire format.
+- **`tool_choice` accepted on text-format tool routes.** The VM's
+  capability gate rejected `tool_choice` whenever `caps.native_tools`
+  was false, even for routes whose text-format tool wire is fully
+  supported. Agent scripts that pass `tool_choice: "none"` to suppress
+  further tool calls (e.g. release_harn's finalization turn) hit
+  "option `tool_choice` is not supported by ..." mid-loop. The gate
+  now permits tool_choice whenever either `native_tools` or
+  `text_tool_wire_format_supported` is true, mirroring the relaxed
+  `tools` gate.
 - **`agent_preset` derives `tool_format` from the model capability matrix.**
   Tool-using preset kinds (`audit`, `repair`, `merge_captain`,
   `review_captain`, …) used to hardcode `tool_format: "native"`, which the

--- a/crates/harn-vm/src/llm/helpers/options.rs
+++ b/crates/harn-vm/src/llm/helpers/options.rs
@@ -1250,7 +1250,18 @@ pub(crate) fn extract_llm_options(
         .and_then(|o| o.get("tool_choice"))
         .filter(|value| !matches!(value, VmValue::Nil))
         .map(vm_value_to_json);
-    if enforce_capability_gates && tool_choice.is_some() && !caps.native_tools {
+    // tool_choice is accepted for any route that can call tools at all —
+    // native or text-format. Text-format routes don't have a protocol-level
+    // tool_choice field, but the value is still meaningful (e.g. `"none"`
+    // signals "skip tool calls this turn") and providers like Ollama
+    // forward it through. Gating only on `native_tools` blocked scripts
+    // that legitimately request tool_choice on text-tool routes such as
+    // `ollama/qwen3.6:35b-a3b-coding-nvfp4`.
+    if enforce_capability_gates
+        && tool_choice.is_some()
+        && !caps.native_tools
+        && !caps.text_tool_wire_format_supported
+    {
         return Err(unsupported_option_error("tool_choice", &provider, &model));
     }
 
@@ -2305,13 +2316,6 @@ mod routing_tests {
                 ("tools", one_tool_list()),
             ],
         );
-        assert_unsupported_local_option(
-            "tool_choice",
-            vec![(
-                "tool_choice",
-                VmValue::String(Rc::from("required".to_string())),
-            )],
-        );
         assert_unsupported_local_option("cache", vec![("cache", VmValue::Bool(true))]);
         assert_unsupported_local_option("vision", vec![("vision", VmValue::Bool(true))]);
         assert_unsupported_local_option("audio", vec![("audio", VmValue::Bool(true))]);
@@ -2327,6 +2331,38 @@ mod routing_tests {
             "interleaved_thinking",
             vec![("interleaved_thinking", VmValue::Bool(true))],
         );
+    }
+
+    #[test]
+    fn tool_choice_accepted_on_text_tool_routes() {
+        // qwen3.6 on Ollama is native_tools=false but
+        // text_tool_wire_format_supported=true. tool_choice should not
+        // be rejected on text-format routes (e.g. agent scripts that
+        // pass tool_choice="none" to suppress further tool calls).
+        crate::llm::capabilities::clear_user_overrides();
+        crate::llm_config::clear_user_overrides();
+        super::super::reset_provider_key_cache();
+
+        let options = BTreeMap::from([
+            (
+                "provider".to_string(),
+                VmValue::String(Rc::from("ollama".to_string())),
+            ),
+            (
+                "model".to_string(),
+                VmValue::String(Rc::from("qwen3.6:35b-a3b-coding-nvfp4".to_string())),
+            ),
+            (
+                "tool_choice".to_string(),
+                VmValue::String(Rc::from("none".to_string())),
+            ),
+        ]);
+        extract_llm_options(&[
+            VmValue::String(Rc::from("hello".to_string())),
+            VmValue::Nil,
+            VmValue::Dict(Rc::new(options)),
+        ])
+        .expect("tool_choice accepted on text-format routes");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- The VM's capability gate at `parse_chat_options` rejected `tool_choice` whenever `caps.native_tools` was false, even on routes whose text-format tool wire is fully supported. Agent scripts that pass `tool_choice: \"none\"` to suppress further tool calls (e.g. release_harn's finalization post-turn callback) hit \"option \`tool_choice\` is not supported by ...\" mid-loop on `ollama/qwen3.6:35b-a3b-coding-nvfp4`, even though the prior turn's text-format tool calls had worked.
- Relax the gate to accept `tool_choice` whenever either `native_tools` or `text_tool_wire_format_supported` is true, mirroring the relaxed `tools` gate.

## Test plan

- [x] `cargo test -p harn-vm --lib -- llm::helpers::options` — 22 / 22 pass
- [x] Updated `unsupported_capability_options_error_with_provider_matrix_hint` (tool_choice no longer fires on text-format-default `local` routes)
- [x] New `tool_choice_accepted_on_text_tool_routes` test covers the qwen3.6/ollama case

🤖 Generated with [Claude Code](https://claude.com/claude-code)