### PR TITLE
Wire composition dispatcher closure for real tool execution

### DIFF
--- a/conformance/tests/integration/composition_dispatcher.expected
+++ b/conformance/tests/integration/composition_dispatcher.expected
@@ -1,0 +1,7 @@
+true
+2
+read_file
+search
+<README.md>
+<README.md>
+2

--- a/conformance/tests/integration/composition_dispatcher.harn
+++ b/conformance/tests/integration/composition_dispatcher.harn
@@ -1,0 +1,36 @@
+pipeline main() {
+  let tools = [
+    {
+      name: "read_file",
+      parameters: {type: "object", required: ["path"]},
+      annotations: {kind: "read", side_effect_level: "read_only"},
+    },
+    {
+      name: "search",
+      parameters: {type: "object", required: ["query"]},
+      annotations: {kind: "search", side_effect_level: "read_only"},
+    },
+  ]
+  let manifest = composition_binding_manifest(tools)
+  let dispatch = { name, input -> return if name == "read_file" {
+    {kind: "text", path: input.path, content: "<" + input.path + ">"}
+  } else {
+    if name == "search" {
+      {kind: "matches", query: input.query, count: 2}
+    } else {
+      {error: "unknown binding " + name}
+    }
+  } }
+  let report = composition_execute(
+    "let readme = read_file({path: \"README.md\"})\nlet hits = search({query: readme.content})\nreturn {readme_content: readme.content, hits_query: hits.query, hits_count: hits.count}",
+    manifest,
+    {run_id: "conformance-dispatcher", dispatcher: dispatch},
+  )
+  println(report.ok)
+  println(report.child_calls.count)
+  println(report.child_calls[0].tool_name)
+  println(report.child_calls[1].tool_name)
+  println(report.run.result.readme_content)
+  println(report.run.result.hits_query)
+  println(report.run.result.hits_count)
+}

--- a/crates/harn-vm/src/composition.rs
+++ b/crates/harn-vm/src/composition.rs
@@ -1360,6 +1360,45 @@ impl CompositionToolHost for StaticCompositionToolHost {
     }
 }
 
+/// Dispatches every binding call to a caller-supplied Harn closure.
+///
+/// The closure is compiled in the calling VM and receives
+/// `(binding_name: string, input: dict)`. Returning a value yields a successful
+/// child result; raising an error fails the child call. Each invocation runs
+/// on a fresh clone of the outer VM so closure-side builtins (`host_call`,
+/// pipeline imports, etc.) resolve normally — the inner composition VM only
+/// sees the manifest bindings plus pure helpers.
+pub struct ClosureCompositionToolHost {
+    closure: crate::VmClosure,
+    outer_vm: Vm,
+}
+
+impl ClosureCompositionToolHost {
+    pub fn new(closure: crate::VmClosure, outer_vm: Vm) -> Self {
+        Self { closure, outer_vm }
+    }
+}
+
+#[async_trait::async_trait(?Send)]
+impl CompositionToolHost for ClosureCompositionToolHost {
+    async fn call(&self, binding: &BindingManifestEntry, input: Value) -> CompositionToolOutput {
+        let mut vm = self.outer_vm.child_vm();
+        let args = vec![
+            VmValue::String(Rc::from(binding.name.as_str())),
+            crate::json_to_vm_value(&input),
+        ];
+        match vm.call_closure_pub(&self.closure, &args).await {
+            Ok(value) => {
+                let json = crate::llm::vm_value_to_json(&value);
+                CompositionToolOutput::ok(json)
+            }
+            Err(error) => {
+                CompositionToolOutput::error(error.to_string(), ToolCallErrorCategory::ToolError)
+            }
+        }
+    }
+}
+
 pub fn composition_search_examples(query: &str, limit: usize) -> Value {
     let mut examples = vec![
         serde_json::json!({
@@ -1816,6 +1855,14 @@ pub fn register_composition_builtins(vm: &mut Vm) {
             .get(1)
             .map(crate::llm::vm_value_to_json)
             .ok_or_else(|| VmError::Runtime("composition_execute: manifest is required".into()))?;
+        let dispatcher = args.get(2).and_then(|value| match value {
+            VmValue::Closure(closure) => Some((**closure).clone()),
+            VmValue::Dict(dict) => match dict.get("dispatcher") {
+                Some(VmValue::Closure(closure)) => Some((**closure).clone()),
+                _ => None,
+            },
+            _ => None,
+        });
         let mut request = CompositionExecutionRequest {
             snippet,
             manifest: serde_json::from_value(manifest_value).map_err(|error| {
@@ -1841,11 +1888,19 @@ pub fn register_composition_builtins(vm: &mut Vm) {
                 request.limits.max_output_bytes = max_output_bytes;
             }
         }
-        let report = execute_harn_composition(
-            request,
-            Rc::new(StaticCompositionToolHost::new(BTreeMap::new())),
-        )
-        .await;
+        let host: Rc<dyn CompositionToolHost> = match dispatcher {
+            Some(closure) => {
+                let outer_vm = crate::vm::clone_async_builtin_child_vm().ok_or_else(|| {
+                    VmError::Runtime(
+                        "composition_execute: dispatcher requires an async builtin VM context"
+                            .into(),
+                    )
+                })?;
+                Rc::new(ClosureCompositionToolHost::new(closure, outer_vm))
+            }
+            None => Rc::new(StaticCompositionToolHost::new(BTreeMap::new())),
+        };
+        let report = execute_harn_composition(request, host).await;
         Ok(crate::json_to_vm_value(
             &serde_json::to_value(report).unwrap_or_else(|_| serde_json::json!({"ok": false})),
         ))
@@ -2186,6 +2241,64 @@ mod tests {
             Some(CompositionFailureCategory::Timeout)
         );
         assert_eq!(report.child_calls.len(), 1);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn harn_composition_dispatcher_closure_receives_real_inputs_and_returns_outputs() {
+        use std::cell::RefCell;
+        let tools = serde_json::json!([
+            {
+                "name": "read_file",
+                "parameters": {"type": "object", "required": ["path"]},
+                "annotations": {"kind": "read", "side_effect_level": "read_only"},
+            }
+        ]);
+        let manifest =
+            binding_manifest_from_tool_surface(&tools, BindingManifestOptions::default());
+
+        struct CapturingHost {
+            calls: RefCell<Vec<(String, Value)>>,
+        }
+        #[async_trait::async_trait(?Send)]
+        impl CompositionToolHost for CapturingHost {
+            async fn call(
+                &self,
+                binding: &BindingManifestEntry,
+                input: Value,
+            ) -> CompositionToolOutput {
+                self.calls
+                    .borrow_mut()
+                    .push((binding.name.clone(), input.clone()));
+                CompositionToolOutput::ok(serde_json::json!({
+                    "path": input.get("path").cloned().unwrap_or(Value::Null),
+                    "text": "real-file-bytes",
+                }))
+            }
+        }
+        let host = Rc::new(CapturingHost {
+            calls: RefCell::new(Vec::new()),
+        });
+        let report = execute_harn_composition(
+            CompositionExecutionRequest {
+                run_id: "run-dispatch".into(),
+                snippet: "let f = read_file({path: \"README.md\"})\nreturn f.text".into(),
+                manifest,
+                ..CompositionExecutionRequest::default()
+            },
+            host.clone(),
+        )
+        .await;
+        assert!(report.ok, "{}", report.summary);
+        assert_eq!(host.calls.borrow().len(), 1);
+        assert_eq!(host.calls.borrow()[0].0, "read_file");
+        assert_eq!(
+            host.calls.borrow()[0].1.get("path").and_then(Value::as_str),
+            Some("README.md")
+        );
+        assert_eq!(
+            report.run.result.as_ref().and_then(Value::as_str),
+            Some("real-file-bytes")
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/docs/src/code-mode.md
+++ b/docs/src/code-mode.md
@@ -115,6 +115,30 @@ the caller wants Harn to emit the corresponding `composition_start`,
 events to the live agent event sinks. Future frontends must route every binding
 call through the same child dispatch path.
 
+### Host Dispatcher
+
+By default, every binding call resolves through `metadata.mock_output` or a
+structured echo, which is the right behavior for replay fixtures and offline
+audits. Hosts that want real tool dispatch pass a `dispatcher` closure on the
+options dict:
+
+```harn
+let dispatch = { binding_name, input ->
+  if binding_name == "read_file" {
+    return host_call("workspace.read_text", input)
+  }
+  return {error: "unknown binding " + binding_name}
+}
+let report = composition_execute(snippet, manifest, {dispatcher: dispatch})
+```
+
+The dispatcher receives `(binding_name: string, input: dict)` for each child
+call and may return any value or raise a runtime error to fail the child. The
+closure executes on a fresh clone of the outer VM, so host bridge builtins
+(`host_call`, MCP, pipeline imports) resolve normally. The inner composition VM
+still only sees manifest bindings plus the curated pure-helper list, so the
+snippet itself cannot bypass policy by reaching for those builtins directly.
+
 ## MCP Profile
 
 For large connector packages, expose a compact Code Mode profile instead of


### PR DESCRIPTION
## Summary

Lets `composition_execute(snippet, manifest, options)` route every child binding call through a caller-supplied Harn closure instead of the mock-only `StaticCompositionToolHost`. Hosts pass `dispatcher: { name, input -> ... }` on the options dict and the closure runs on a fresh clone of the outer VM, so `host_call`, MCP, and pipeline imports resolve normally while the inner composition VM still sees only the manifest bindings plus the curated pure-helper list.

Unblocks Burin's `code_bundle` tool ([burin-code#743](https://github.com/burin-labs/burin-code/issues/743)) so Code Mode snippets can actually exercise the read-only `look`/`search`/`glob` surface instead of returning structured echoes.

## Test plan

- [x] `cargo test -p harn-vm --lib composition` — adds `harn_composition_dispatcher_closure_receives_real_inputs_and_returns_outputs`
- [x] `cargo run --bin harn -- test conformance --filter composition` — adds `composition_dispatcher.harn` covering the Harn-level options shape
- [x] Existing `composition_code_mode`, `composition_limits`, `composition_mcp_profile` still pass
- [x] `cargo clippy -p harn-vm --all-targets -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)