### PR TITLE
template: auto-inject `llm.{provider,model,family,capabilities}` (#1664)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,20 @@ condensed series summaries instead of full per-patch history.
 
 ### Added
 
+- **Capability-aware prompt templates: auto-injected `llm` scope (#1664).**
+  When `render()` / `render_prompt()` / `render_string()` is invoked
+  from inside an LLM-aware frame (`llm_call`, `default_llm_caller`,
+  `agent_loop`), the engine now auto-injects a reserved
+  `llm = {provider, model, family, capabilities: {...}}` binding so a
+  single logical `.harn.prompt` can branch on
+  `llm.capabilities.native_tools` and friends without manual option
+  threading. Bare `render()` calls outside any LLM frame leave
+  `llm = nil`; templates guard with `{{ if llm }}` for the CI / doc-gen
+  path. User bindings that already supply an `llm` key win for
+  back-compat and trigger a one-shot `template.llm_scope` lint warning.
+  This is the load-bearing primitive for the capability-adaptive prompt-
+  rendering epic (#1663) — sibling tickets layer logical sections,
+  format-preference capabilities, and cross-model eval on top.
 - **One-line installer + signed binaries.** `install.sh` (served from
   `harnlang.com/install.sh`) now detects the host OS/CPU, resolves the
   latest GitHub release tag, downloads the matching pre-built archive,

--- a/conformance/tests/templates/template_llm_scope_absent.expected
+++ b/conformance/tests/templates/template_llm_scope_absent.expected
@@ -1,0 +1,2 @@
+bare-render
+fallback=/

--- a/conformance/tests/templates/template_llm_scope_absent.harn
+++ b/conformance/tests/templates/template_llm_scope_absent.harn
@@ -1,0 +1,6 @@
+pipeline default() {
+  let tmpl = "{{ if llm }}has-context{{ else }}bare-render{{ end }}"
+  println(render_string(tmpl, {}))
+  let tmpl2 = "fallback={{ llm.provider }}/{{ llm.capabilities.native_tools }}"
+  println(render_string(tmpl2, {}))
+}

--- a/conformance/tests/templates/template_llm_scope_inject.expected
+++ b/conformance/tests/templates/template_llm_scope_inject.expected
@@ -1,0 +1,2 @@
+provider=anthropic family=claude native_tools=true
+native

--- a/conformance/tests/templates/template_llm_scope_inject.harn
+++ b/conformance/tests/templates/template_llm_scope_inject.harn
@@ -1,0 +1,10 @@
+pipeline default() {
+  __push_llm_render_context("anthropic", "claude-3-5-sonnet")
+  defer {
+    __pop_llm_render_context()
+  }
+  let tmpl = "provider={{ llm.provider }} family={{ llm.family }} native_tools={{ llm.capabilities.native_tools }}"
+  println(render_string(tmpl, {}))
+  let tmpl2 = "{{ if llm.capabilities.native_tools }}native{{ else }}text{{ end }}"
+  println(render_string(tmpl2, {}))
+}

--- a/conformance/tests/templates/template_llm_scope_user_override.expected
+++ b/conformance/tests/templates/template_llm_scope_user_override.expected
@@ -1,0 +1,1 @@
+user=user-payload provider=user-provider

--- a/conformance/tests/templates/template_llm_scope_user_override.harn
+++ b/conformance/tests/templates/template_llm_scope_user_override.harn
@@ -1,0 +1,12 @@
+pipeline default() {
+  __push_llm_render_context("anthropic", "claude-3-5-sonnet")
+  defer {
+    __pop_llm_render_context()
+  }
+  // User-supplied `llm` binding wins over the auto-injected context,
+  // preserving back-compat for any pre-existing template that happens
+  // to use the `llm` key for unrelated data. A one-shot lint warning
+  // is emitted in the host log (not captured in this transcript).
+  let tmpl = "user={{ llm.tag }} provider={{ llm.provider }}"
+  println(render_string(tmpl, {llm: {tag: "user-payload", provider: "user-provider"}}))
+}

--- a/crates/harn-parser/src/builtin_signatures/signatures/stdlib.rs
+++ b/crates/harn-parser/src/builtin_signatures/signatures/stdlib.rs
@@ -172,6 +172,15 @@ pub(crate) const SIGNATURES: &[BuiltinSignature] = &[
         ],
         TY_STRING,
     ),
+    BuiltinSignature::simple("__pop_llm_render_context", &[], TY_NIL),
+    BuiltinSignature::simple(
+        "__push_llm_render_context",
+        &[
+            Param::new("provider", TY_STRING),
+            Param::optional("model", TY_STRING),
+        ],
+        TY_BOOL,
+    ),
     BuiltinSignature::simple("__select_list", &[Param::new("channels", TY_LIST)], TY_DICT),
     BuiltinSignature::simple(
         "__select_timeout",

--- a/crates/harn-stdlib/src/stdlib/agent/loop.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/loop.harn
@@ -1190,6 +1190,19 @@ fn __agent_loop_run(message, session, initial_opts) {
   var opts = initial_opts
   var iteration = 0
   var session_finalized = false
+  // Publish the resolved provider/model so any `.harn.prompt` rendered
+  // during turn-system construction (loop contract, tool contract,
+  // skills, …) can branch on `llm.capabilities.*` without manual
+  // option threading. Skipped when provider is empty — the render
+  // sees `llm = nil` and the existing branch falls through.
+  let __llm_ctx_provider = to_string(initial_opts?.provider ?? "")
+  let __llm_ctx_model = to_string(initial_opts?.model ?? "")
+  let __llm_ctx_pushed = __push_llm_render_context(__llm_ctx_provider, __llm_ctx_model)
+  defer {
+    if __llm_ctx_pushed {
+      __pop_llm_render_context()
+    }
+  }
   let run = try {
     opts = agent_mcp_bootstrap_if_needed(session, opts)
     var stop_reason = nil

--- a/crates/harn-stdlib/src/stdlib/llm/handlers.harn
+++ b/crates/harn-stdlib/src/stdlib/llm/handlers.harn
@@ -27,6 +27,14 @@ import { with_case_insensitive_keys } from "std/llm/safe"
  */
 pub fn default_llm_caller() {
   return { call ->
+    let provider = __default_caller_render_context_provider(call)
+    let model = __default_caller_render_context_model(call)
+    let pushed = __push_llm_render_context(provider, model)
+    defer {
+      if pushed {
+        __pop_llm_render_context()
+      }
+    }
     let result = try {
       llm_call(call.prompt, call.system, llm_call_options(call.opts))
     }
@@ -44,6 +52,21 @@ pub fn default_llm_caller() {
     }
     return {ok: false, status: "exception", error: err}
   }
+}
+
+/**
+ * Provider/model accessors for the ambient LLM render-context frame
+ * published around `default_llm_caller`. Named helpers keep the
+ * closure body readable and make the option-shape contract easy to
+ * extend (e.g. dispatch on `model_tier` if a future caller wants to
+ * publish the context before resolution).
+ */
+fn __default_caller_render_context_provider(call) -> string {
+  return to_string(call?.opts?.provider ?? "")
+}
+
+fn __default_caller_render_context_model(call) -> string {
+  return to_string(call?.opts?.model ?? "")
 }
 
 // -------------------------------------------------------------------------------------------------

--- a/crates/harn-vm/src/llm/config_builtins.rs
+++ b/crates/harn-vm/src/llm/config_builtins.rs
@@ -663,7 +663,7 @@ fn model_info_to_vm_value(resolved: &llm_config::ResolvedModel) -> VmValue {
     VmValue::Dict(Rc::new(dict))
 }
 
-fn capabilities_to_vm_value(
+pub(crate) fn capabilities_to_vm_value(
     provider: &str,
     model: &str,
     caps: &super::capabilities::Capabilities,

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -20,7 +20,7 @@ pub mod api;
 pub(crate) mod autonomy_budget;
 pub(crate) mod cache;
 pub mod capabilities;
-mod config_builtins;
+pub(crate) mod config_builtins;
 pub(crate) mod content;
 mod conversation;
 pub(crate) mod cost;
@@ -543,6 +543,13 @@ async fn llm_call_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     let opts = extract_llm_options(&args)?;
     let provider = opts.provider.clone();
     let model = opts.model.clone();
+    // Publish the resolved provider/model/capabilities to templates
+    // rendered while this `llm_call` frame is on the stack — e.g.
+    // schema-retry prompts or middleware that re-renders a partial
+    // for a corrective second pass.
+    let _llm_render_guard = crate::stdlib::template::LlmRenderContextGuard::enter(
+        crate::stdlib::template::LlmRenderContext::resolve(&provider, &model),
+    );
     match execute_llm_call(opts, options, None).await {
         Ok(v) => Ok(v),
         Err(err) => Err(VmError::Thrown(build_llm_error_dict(

--- a/crates/harn-vm/src/stdlib/strings.rs
+++ b/crates/harn-vm/src/stdlib/strings.rs
@@ -560,4 +560,31 @@ pub(crate) fn register_string_builtins(vm: &mut Vm) {
         crate::stdlib::template::record_prompt_render_index(prompt_id, event_index);
         Ok(VmValue::Int(event_index as i64))
     });
+
+    // Internal LLM render-context plumbing — paired push/pop hooks used
+    // by the agent_loop / handler-stack stdlib so user-authored
+    // `.harn.prompt` partials can branch on `llm.provider`,
+    // `llm.capabilities.native_tools`, etc. while rendering inside an
+    // LLM-aware frame. Userspace never calls these directly; the stdlib
+    // wraps every push in a matching `defer { __pop_llm_render_context() }`.
+    vm.register_builtin("__push_llm_render_context", |args, _out| {
+        let provider = args.first().map(|a| a.display()).unwrap_or_default();
+        let model = args.get(1).map(|a| a.display()).unwrap_or_default();
+        // Skip the push when the caller hasn't resolved a concrete
+        // provider yet (empty or `"auto"`). Templates rendered while
+        // the unresolved options are in scope simply see `llm = nil`
+        // instead of an empty-capabilities frame that would silently
+        // mis-flag every capability check as false.
+        if provider.is_empty() || provider.eq_ignore_ascii_case("auto") {
+            return Ok(VmValue::Bool(false));
+        }
+        crate::stdlib::template::push_llm_render_context(
+            crate::stdlib::template::LlmRenderContext::resolve(&provider, &model),
+        );
+        Ok(VmValue::Bool(true))
+    });
+    vm.register_builtin("__pop_llm_render_context", |_args, _out| {
+        crate::stdlib::template::pop_llm_render_context();
+        Ok(VmValue::Nil)
+    });
 }

--- a/crates/harn-vm/src/stdlib/template/llm_context.rs
+++ b/crates/harn-vm/src/stdlib/template/llm_context.rs
@@ -1,0 +1,247 @@
+//! Ambient render-time LLM context exposed to `.harn.prompt` templates.
+//!
+//! When `render()` / `render_prompt()` / `render_string()` is invoked from
+//! within an LLM-aware frame (`llm_call`, the default handler stack, or
+//! `agent_loop`), the active provider/model/family/capabilities are
+//! published as the reserved `llm` scope key so authors can write
+//! capability-aware partials without manual plumbing:
+//!
+//! ```text
+//! {{ if llm.capabilities.native_tools }}
+//!   Call `finish_task` when done.
+//! {{ else }}
+//!   When done, output: `<<DONE>>`
+//! {{ end }}
+//! ```
+//!
+//! Bare `render()` calls outside any LLM frame leave `llm = nil`, so
+//! templates branch on `{{ if llm }}` for the doc-gen / CI paths.
+//!
+//! The context lives in a thread-local stack so concurrent agent_loop
+//! iterations on different threads stay isolated; nested
+//! push/pop pairs (e.g. an inner `llm_call` from a middleware handler)
+//! shadow the outer frame for the duration of the inner render.
+
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::rc::Rc;
+
+use crate::value::VmValue;
+
+/// Resolved provider/model identity plus the corresponding capability
+/// snapshot, materialized at LLM-frame entry and injected as the `llm`
+/// binding during any `render()` call inside that frame.
+#[derive(Debug, Clone)]
+pub struct LlmRenderContext {
+    pub provider: String,
+    pub model: String,
+    pub family: String,
+    /// Snapshot of `provider_capabilities(provider, model)` — a
+    /// `VmValue::Dict` shaped exactly like the builtin's return value.
+    pub capabilities: VmValue,
+}
+
+impl LlmRenderContext {
+    /// Build a context from resolved provider/model strings, looking up
+    /// the capability snapshot and deriving the canonical model family.
+    pub fn resolve(provider: &str, model: &str) -> Self {
+        let caps = crate::llm::capabilities::lookup(provider, model);
+        let capabilities =
+            crate::llm::config_builtins::capabilities_to_vm_value(provider, model, &caps);
+        Self {
+            provider: provider.to_string(),
+            model: model.to_string(),
+            family: derive_family(provider, model),
+            capabilities,
+        }
+    }
+
+    /// Materialize the context as the `llm` scope value:
+    /// `{provider, model, family, capabilities: <provider_capabilities dict>}`.
+    pub fn to_vm_value(&self) -> VmValue {
+        let mut dict = BTreeMap::new();
+        dict.insert(
+            "provider".to_string(),
+            VmValue::String(Rc::from(self.provider.as_str())),
+        );
+        dict.insert(
+            "model".to_string(),
+            VmValue::String(Rc::from(self.model.as_str())),
+        );
+        dict.insert(
+            "family".to_string(),
+            VmValue::String(Rc::from(self.family.as_str())),
+        );
+        dict.insert("capabilities".to_string(), self.capabilities.clone());
+        VmValue::Dict(Rc::new(dict))
+    }
+}
+
+thread_local! {
+    static LLM_RENDER_STACK: RefCell<Vec<LlmRenderContext>> = const { RefCell::new(Vec::new()) };
+}
+
+/// Push a frame onto the ambient render-context stack. Pair with
+/// `pop_llm_render_context` (or use `LlmRenderContextGuard`) so the
+/// stack stays balanced even on the unwind path.
+pub fn push_llm_render_context(ctx: LlmRenderContext) {
+    LLM_RENDER_STACK.with(|stack| stack.borrow_mut().push(ctx));
+}
+
+/// Pop the most recently pushed frame. Returns `None` (rather than
+/// panicking) if the stack was empty, since the host may legitimately
+/// unwind through a balanced push/pop sequence.
+pub fn pop_llm_render_context() -> Option<LlmRenderContext> {
+    LLM_RENDER_STACK.with(|stack| stack.borrow_mut().pop())
+}
+
+/// Return a clone of the active frame, or `None` if no LLM context is
+/// in scope. Render entry-points use this to decide whether to inject
+/// the `llm` binding.
+pub fn current_llm_render_context() -> Option<LlmRenderContext> {
+    LLM_RENDER_STACK.with(|stack| stack.borrow().last().cloned())
+}
+
+/// Reset the stack — wired into `reset_thread_local_state` so tests
+/// and serialized adapter sessions start clean.
+pub(crate) fn reset_llm_render_stack() {
+    LLM_RENDER_STACK.with(|stack| stack.borrow_mut().clear());
+}
+
+/// RAII guard that pushes a context on construction and pops on drop.
+/// Use this in Rust hosts (e.g. `llm_call_impl`) so the stack stays
+/// balanced across `?`-shortcircuits and panics.
+pub struct LlmRenderContextGuard {
+    /// Tagged so a misuse (drop-order inversion across nested guards)
+    /// surfaces as a `debug_assert` instead of silently popping the
+    /// wrong frame. Carries no runtime cost in release builds.
+    expected_depth: usize,
+}
+
+impl LlmRenderContextGuard {
+    pub fn enter(ctx: LlmRenderContext) -> Self {
+        push_llm_render_context(ctx);
+        let depth = LLM_RENDER_STACK.with(|stack| stack.borrow().len());
+        Self {
+            expected_depth: depth,
+        }
+    }
+}
+
+impl Drop for LlmRenderContextGuard {
+    fn drop(&mut self) {
+        let depth = LLM_RENDER_STACK.with(|stack| stack.borrow().len());
+        debug_assert_eq!(
+            depth, self.expected_depth,
+            "LlmRenderContextGuard nested-drop order violated",
+        );
+        pop_llm_render_context();
+    }
+}
+
+/// Map a `(provider, model)` pair to a canonical model-family token
+/// (`claude` / `gpt` / `gemini` / `qwen` / `llama` / `mistral` / ...).
+/// This is distinct from `provider_family` in the capability matrix —
+/// that walks sibling-provider lineage (e.g. `openrouter → openai`);
+/// this walks model-id heuristics so authors can branch on the
+/// underlying LLM family regardless of the routing provider. Falls
+/// back to the normalized provider name when nothing matches.
+fn derive_family(provider: &str, model: &str) -> String {
+    let model_lc = model.to_ascii_lowercase();
+    // Order matters: longer/more-specific markers first so e.g.
+    // "claude" wins over a generic "ai" substring.
+    const MARKERS: &[(&str, &[&str])] = &[
+        ("claude", &["claude"]),
+        ("gpt", &["gpt-", "gpt_", "o1-", "o3-", "o4-"]),
+        ("gemini", &["gemini"]),
+        ("qwen", &["qwen"]),
+        ("llama", &["llama"]),
+        ("mistral", &["mistral", "mixtral"]),
+        ("deepseek", &["deepseek"]),
+        ("phi", &["phi-", "phi_"]),
+        ("grok", &["grok"]),
+        ("command", &["command-", "command_"]),
+    ];
+    for (family, needles) in MARKERS {
+        if needles.iter().any(|needle| model_lc.contains(needle)) {
+            return (*family).to_string();
+        }
+    }
+    // Model id gave us nothing — fall back to the routing provider
+    // mapped through known aliases so the family token stays stable
+    // when the same model is reached via different providers.
+    match provider {
+        "anthropic" | "bedrock" | "vertex-anthropic" => "claude".to_string(),
+        "openai" | "azure" => "gpt".to_string(),
+        "gemini" | "vertex" | "google" => "gemini".to_string(),
+        other if !other.is_empty() => other.to_string(),
+        _ => "unknown".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn family_from_model_id_takes_precedence() {
+        assert_eq!(
+            derive_family("openrouter", "anthropic/claude-3-5-sonnet"),
+            "claude"
+        );
+        assert_eq!(derive_family("openrouter", "openai/gpt-4o"), "gpt");
+        assert_eq!(
+            derive_family("openrouter", "google/gemini-1.5-pro"),
+            "gemini"
+        );
+        assert_eq!(
+            derive_family("ollama", "qwen3.6:35b-a3b-coding-nvfp4"),
+            "qwen"
+        );
+    }
+
+    #[test]
+    fn family_falls_back_to_provider_alias() {
+        assert_eq!(derive_family("anthropic", "unknown-future-model"), "claude");
+        assert_eq!(derive_family("azure", "deployment-xyz"), "gpt");
+        assert_eq!(derive_family("vertex", "model-xyz"), "gemini");
+        assert_eq!(derive_family("local", "anonymous-snapshot"), "local");
+        assert_eq!(derive_family("", ""), "unknown");
+    }
+
+    #[test]
+    fn push_pop_stack_round_trip() {
+        reset_llm_render_stack();
+        assert!(current_llm_render_context().is_none());
+        push_llm_render_context(LlmRenderContext::resolve("anthropic", "claude-3-5-sonnet"));
+        assert_eq!(
+            current_llm_render_context().map(|c| c.family),
+            Some("claude".to_string()),
+        );
+        push_llm_render_context(LlmRenderContext::resolve("openai", "gpt-4o"));
+        assert_eq!(
+            current_llm_render_context().map(|c| c.family),
+            Some("gpt".to_string()),
+        );
+        pop_llm_render_context();
+        assert_eq!(
+            current_llm_render_context().map(|c| c.family),
+            Some("claude".to_string()),
+        );
+        pop_llm_render_context();
+        assert!(current_llm_render_context().is_none());
+    }
+
+    #[test]
+    fn guard_pops_on_drop() {
+        reset_llm_render_stack();
+        {
+            let _guard = LlmRenderContextGuard::enter(LlmRenderContext::resolve(
+                "anthropic",
+                "claude-3-5-sonnet",
+            ));
+            assert!(current_llm_render_context().is_some());
+        }
+        assert!(current_llm_render_context().is_none());
+    }
+}

--- a/crates/harn-vm/src/stdlib/template/mod.rs
+++ b/crates/harn-vm/src/stdlib/template/mod.rs
@@ -22,8 +22,9 @@
 //! All new constructs raise `TemplateError` on parse or evaluation failure.
 
 use std::cell::RefCell;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::path::Path;
+use std::sync::{Mutex, OnceLock};
 
 use crate::value::{VmError, VmValue};
 
@@ -33,6 +34,7 @@ mod error;
 mod expr_parser;
 mod filters;
 mod lexer;
+mod llm_context;
 mod parser;
 mod render;
 
@@ -42,6 +44,10 @@ mod tests;
 use assets::parse_cached;
 pub(crate) use assets::TemplateAsset;
 use error::TemplateError;
+pub use llm_context::{
+    current_llm_render_context, pop_llm_render_context, push_llm_render_context, LlmRenderContext,
+    LlmRenderContextGuard,
+};
 use render::{render_nodes, RenderCtx, Scope};
 
 // Thread-local registry of recent prompt renders keyed by `prompt_id`.
@@ -216,6 +222,63 @@ pub(crate) fn reset_prompt_registry() {
     PROMPT_SERIAL.with(|s| *s.borrow_mut() = 0);
     PROMPT_RENDER_INDICES.with(|map| map.borrow_mut().clear());
     PROMPT_RENDER_ORDINAL.with(|c| *c.borrow_mut() = 0);
+    llm_context::reset_llm_render_stack();
+    if let Some(cache) = LLM_SHADOW_WARN_CACHE.get() {
+        if let Ok(mut g) = cache.lock() {
+            g.clear();
+        }
+    }
+}
+
+/// One-shot dedup for the user-supplied-`llm`-binding shadow warning.
+/// Keyed by template URI so a recurring render in a loop only emits
+/// the warning once per template per process.
+static LLM_SHADOW_WARN_CACHE: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+
+/// Build the merged bindings map that includes the ambient `llm` key
+/// when an LLM render context is in scope. Returns `None` to mean
+/// "no change required — pass the caller's bindings through unchanged":
+/// either there is no active context, or the user already supplied an
+/// `llm` binding (in which case we emit a lint warning and let their
+/// value win for back-compat).
+fn augment_bindings_with_llm(
+    asset: &TemplateAsset,
+    bindings: Option<&BTreeMap<String, VmValue>>,
+) -> Option<BTreeMap<String, VmValue>> {
+    let ctx = current_llm_render_context()?;
+    if bindings.is_some_and(|m| m.contains_key("llm")) {
+        warn_user_llm_shadowed(asset);
+        return None;
+    }
+    let mut merged = bindings.cloned().unwrap_or_default();
+    merged.insert("llm".to_string(), ctx.to_vm_value());
+    Some(merged)
+}
+
+fn warn_user_llm_shadowed(asset: &TemplateAsset) {
+    let cache = LLM_SHADOW_WARN_CACHE.get_or_init(|| Mutex::new(HashSet::new()));
+    let key = asset.uri.clone();
+    {
+        let mut guard = match cache.lock() {
+            Ok(g) => g,
+            Err(_) => return,
+        };
+        if !guard.insert(key.clone()) {
+            return;
+        }
+    }
+    crate::events::log_warn_meta(
+        "template.llm_scope",
+        "user-supplied `llm` binding shadows auto-injected LLM render context; \
+         rename your key to avoid relying on this back-compat path",
+        BTreeMap::from([
+            ("template_uri".to_string(), serde_json::Value::String(key)),
+            (
+                "reason".to_string(),
+                serde_json::Value::String("user_binding_shadowed".to_string()),
+            ),
+        ]),
+    );
 }
 
 /// Parse-only validation for lint/preflight. Returns a human-readable error
@@ -348,7 +411,14 @@ pub(crate) fn render_asset_with_provenance_result(
 ) -> Result<(String, Vec<PromptSourceSpan>), TemplateError> {
     let nodes = parse_cached(asset)?;
     let mut out = String::with_capacity(asset.source.len());
-    let mut scope = Scope::new(bindings);
+    // Materialize the ambient `llm` binding when the caller is inside
+    // an LLM frame (`llm_call` / `agent_loop` / handler-stack). User
+    // bindings that already supply `llm` win — emit a one-shot lint
+    // warning to flag the shadowed auto-injection so the author can
+    // rename their key.
+    let augmented = augment_bindings_with_llm(asset, bindings);
+    let scope_bindings = augmented.as_ref().or(bindings);
+    let mut scope = Scope::new(scope_bindings);
     let mut rc = RenderCtx {
         current_asset: asset.clone(),
         include_stack: Vec::new(),

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -2631,6 +2631,15 @@ and LSP go-to-definition follow `@`-paths to the target file.
   `{{- trim whitespace + one newline -}}`.
 - Missing *bare* `{{ident}}` passes through the literal source (back-compat).
   New constructs raise `template at L:C: ...` errors.
+- **`llm` scope**: inside an LLM-aware frame (`llm_call`, the default
+  handler stack, `agent_loop`) the engine auto-injects
+  `llm = {provider, model, family, capabilities: {...}}` so a single
+  logical prompt can adapt by capability. Branch on `{{ if llm }}` for
+  the bare-render fallback; branch on `{{ if llm.capabilities.native_tools }}`
+  to pick wire envelope. `family` is one of `claude` / `gpt` / `gemini` /
+  `qwen` / `llama` / `mistral` / `deepseek` / `phi` / `grok` / `command`.
+  User bindings that already provide an `llm` key win for back-compat
+  and trigger a one-shot warning under `template.llm_scope`.
 - Full reference: `docs/src/prompt-templating.md`.
 
 ## Discovery

--- a/docs/src/prompt-templating.md
+++ b/docs/src/prompt-templating.md
@@ -290,6 +290,69 @@ Typical cases:
 - `circular include detected: a.prompt → b.prompt → a.prompt`.
 - `include path must be a string` — `{{ include }}` target wasn't a string.
 
+## The `llm` scope
+
+When `render()` / `render_prompt()` / `render_string()` is invoked from
+inside an LLM-aware frame (`llm_call`, the default handler stack, or
+`agent_loop`), the engine auto-injects a reserved `llm` binding so a
+single logical template can adapt its wire envelope per provider
+without manual option threading:
+
+```harn-prompt
+{{ if llm.capabilities.native_tools }}
+  Call `finish_task` when done.
+{{ else }}
+  When done, output: `<<DONE>>`
+{{ end }}
+```
+
+The injected value is shaped:
+
+```text
+llm = {
+  provider: "anthropic",          // resolved provider name
+  model:    "claude-3-5-sonnet",  // resolved model id
+  family:   "claude",             // canonical model-family token
+  capabilities: { ... },          // result of provider_capabilities()
+}
+```
+
+`family` is one of `claude` / `gpt` / `gemini` / `qwen` / `llama` /
+`mistral` / `deepseek` / `phi` / `grok` / `command`, derived from the
+model id with a provider-alias fallback. Branch on `family` for
+human-readable identity checks; branch on `capabilities.*` for wire-
+format adaptation (native vs text-format tools, prompt caching,
+structured output, etc.).
+
+Bare `render()` calls outside any LLM frame leave `llm = nil`, so the
+same template works in CI / doc-gen contexts as long as it guards with
+`{{ if llm }}`:
+
+```harn-prompt
+{{ if llm }}
+  Targeting {{ llm.provider }}/{{ llm.model }} — using
+  {{ if llm.capabilities.native_tools }}native{{ else }}text{{ end }} tools.
+{{ else }}
+  Generic prompt — no model selected.
+{{ end }}
+```
+
+The frame is published by:
+
+- the native `llm_call` builtin for its full call duration (covers
+  middleware-driven re-renders during schema retry),
+- `default_llm_caller` for the entire handler-stack closure (so
+  user-authored middleware that renders sees the same context), and
+- `agent_loop` for the whole loop, so every per-turn system-prompt
+  partial (loop contract, native-tool contract, skill catalog, …)
+  renders against the active provider/model.
+
+User bindings that already supply an `llm` key are left untouched —
+the engine emits a one-shot lint warning under the
+`template.llm_scope` category and the user's value wins for
+back-compat. Rename your key (e.g. `local_model`, `current_llm`) to
+clear the warning.
+
 ## Preflight checks
 
 `harn check` parses every template referenced by a literal `render(...)` /


### PR DESCRIPTION
Closes #1664. Load-bearing primitive for the capability-adaptive prompt-rendering epic ([#1663](https://github.com/burin-labs/harn/issues/1663)).

## Summary

- When `render()` / `render_prompt()` / `render_string()` runs inside an LLM-aware frame (`llm_call`, the default handler stack, or `agent_loop`), the engine now publishes a reserved `llm = {provider, model, family, capabilities: {...}}` binding so a single logical `.harn.prompt` can branch on `llm.capabilities.native_tools` and friends without manual option threading.
- Bare `render()` calls outside any LLM frame leave `llm = nil`; templates guard with `{{ if llm }}` for CI / doc-gen paths.
- User bindings that already supply an `llm` key win for back-compat and trigger a one-shot `template.llm_scope` lint warning.

```harn-prompt
{{ if llm.capabilities.native_tools }}
  Call `finish_task` when done.
{{ else }}
  When done, output: `<<DONE>>`
{{ end }}
```

## Wiring

- New thread-local stack in `crates/harn-vm/src/stdlib/template/llm_context.rs` with `LlmRenderContextGuard` RAII helper for Rust hosts.
- New `__push_llm_render_context` / `__pop_llm_render_context` internal builtins (parser signatures added).
- Pushed at `llm_call_impl` (Rust, RAII guard), `__agent_loop_run` (Harn, `defer`), and the `default_llm_caller` closure (Harn, `defer`).
- Bindings merge happens once at the top of `render_asset_with_provenance_result`, so all three render builtins + the provenance-collecting path get identical treatment.
- `family` derivation walks a model-id heuristic first (`claude` / `gpt` / `gemini` / `qwen` / `llama` / `mistral` / `deepseek` / `phi` / `grok` / `command`), then falls back to a provider-alias map — distinct from the existing `provider_family` chain (which is for capability inheritance, not author-facing identity).

## Test plan

- [x] 3 new conformance tests: `template_llm_scope_{absent,inject,user_override}.harn`
- [x] 4 new Rust unit tests covering the stack push/pop, RAII guard, and family-derivation precedence
- [x] `make test` (3880 tests, 0 failures, 2 skipped)
- [x] `make conformance` (1029 tests)
- [x] `make check-docs-snippets` (525 snippets parse clean)
- [x] `make lint-test-patterns`
- [x] `make check-highlight`
- [x] `make fmt-harn` / `make lint-harn`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)