### PR TITLE
[codex] Fix crate boundary and runtime bugs

### DIFF
--- a/conformance/tests/stdlib/stdlib_path_module.expected
+++ b/conformance/tests/stdlib/stdlib_path_module.expected
@@ -1,0 +1,7 @@
+[harn] rs
+[harn] archive.tar
+[harn] .gitignore
+[harn] true
+[harn] true
+[harn] false
+[harn] false

--- a/conformance/tests/stdlib/stdlib_path_module.harn
+++ b/conformance/tests/stdlib/stdlib_path_module.harn
@@ -1,0 +1,11 @@
+import "std/path"
+
+pipeline test(task) {
+  log(ext("lib/main.rs"))
+  log(stem("archive.tar.gz"))
+  log(stem(".gitignore"))
+  log(is_absolute("/tmp/x"))
+  log(is_absolute("C:/tmp/x"))
+  log(is_absolute("C:tmp/x"))
+  log(is_absolute("relative/path"))
+}

--- a/crates/harn-cli/src/package/package_ops.rs
+++ b/crates/harn-cli/src/package/package_ops.rs
@@ -1497,13 +1497,21 @@ pub(crate) fn collect_package_files_inner(
         let entry =
             entry.map_err(|error| format!("failed to read {} entry: {error}", dir.display()))?;
         let path = entry.path();
-        let name = entry.file_name();
-        if path.is_dir() {
-            if should_skip_package_dir(&name) {
+        let file_type = entry
+            .file_type()
+            .map_err(|error| format!("failed to inspect {}: {error}", path.display()))?;
+        if file_type.is_symlink() {
+            continue;
+        }
+        if file_type.is_dir() {
+            let rel = path
+                .strip_prefix(root)
+                .map_err(|error| format!("failed to relativize {}: {error}", path.display()))?;
+            if should_skip_package_dir(rel) {
                 continue;
             }
             collect_package_files_inner(root, &path, out)?;
-        } else if path.is_file() {
+        } else if file_type.is_file() {
             let rel = path
                 .strip_prefix(root)
                 .map_err(|error| format!("failed to relativize {}: {error}", path.display()))?
@@ -1515,11 +1523,16 @@ pub(crate) fn collect_package_files_inner(
     Ok(())
 }
 
-pub(crate) fn should_skip_package_dir(name: &OsStr) -> bool {
-    matches!(
-        name.to_str(),
-        Some(".git" | ".harn" | "target" | "node_modules" | "docs/dist")
-    )
+pub(crate) fn should_skip_package_dir(rel: &Path) -> bool {
+    if rel == Path::new("docs").join("dist") {
+        return true;
+    }
+    rel.components().any(|component| {
+        matches!(
+            component.as_os_str().to_str(),
+            Some(".git" | ".harn" | "target" | "node_modules")
+        )
+    })
 }
 
 pub(crate) fn default_artifact_dir(ctx: &ManifestContext, report: &PackageCheckReport) -> PathBuf {
@@ -1833,6 +1846,40 @@ mod tests {
         let pack = pack_package_impl(Some(tmp.path()), None, true).unwrap();
         assert!(pack.files.contains(&"harn.toml".to_string()));
         assert!(pack.files.contains(&"lib/main.harn".to_string()));
+    }
+
+    #[test]
+    fn package_pack_skips_generated_docs_dist() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_publishable_package(tmp.path());
+        fs::create_dir_all(tmp.path().join("docs/dist")).unwrap();
+        fs::write(tmp.path().join("docs/dist/index.html"), "<html></html>\n").unwrap();
+
+        let pack = pack_package_impl(Some(tmp.path()), None, true).unwrap();
+
+        assert!(
+            !pack.files.iter().any(|path| path.starts_with("docs/dist/")),
+            "{:?}",
+            pack.files
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn package_pack_does_not_follow_symlinked_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_publishable_package(tmp.path());
+        let outside = tempfile::NamedTempFile::new().unwrap();
+        fs::write(outside.path(), "secret\n").unwrap();
+        std::os::unix::fs::symlink(outside.path(), tmp.path().join("secret.txt")).unwrap();
+
+        let pack = pack_package_impl(Some(tmp.path()), None, true).unwrap();
+
+        assert!(
+            !pack.files.contains(&"secret.txt".to_string()),
+            "{:?}",
+            pack.files
+        );
     }
 
     #[test]

--- a/crates/harn-dap/src/debugger/breakpoints.rs
+++ b/crates/harn-dap/src/debugger/breakpoints.rs
@@ -75,7 +75,9 @@ impl Debugger {
         // Breakpoints replaced for this file — hit counts from the prior
         // set would be attached to now-stale ids, so drop them. Hit
         // counts on breakpoints in other files survive.
-        self.bp_hit_counts.clear();
+        let live_ids: Vec<i64> = self.breakpoints.iter().map(|bp| bp.id).collect();
+        self.bp_hit_counts.retain(|id, _| live_ids.contains(id));
+        self.armed_breakpoints.retain(|id, _| live_ids.contains(id));
 
         if let Some(vm) = &mut self.vm {
             // Push per-file breakpoint sets so the VM can match
@@ -90,9 +92,14 @@ impl Debugger {
                     .unwrap_or_default();
                 by_file.entry(key).or_default().push(bp.line as usize);
             }
-            // Clear stale files first by setting empty for every file we
-            // know about -- covers the case where the user removed all
-            // breakpoints from a file that previously had some.
+            // If this request cleared the source's final breakpoint,
+            // mirror the empty set to the VM. `by_file` only contains
+            // files that still have active breakpoints.
+            if let Some(path) = request_path.as_deref() {
+                if !by_file.contains_key(path) {
+                    vm.set_breakpoints_for_file(path, Vec::new());
+                }
+            }
             let known_keys: Vec<String> = by_file.keys().cloned().collect();
             for key in known_keys.iter() {
                 vm.set_breakpoints_for_file(key, by_file[key].clone());

--- a/crates/harn-dap/src/debugger/sources.rs
+++ b/crates/harn-dap/src/debugger/sources.rs
@@ -97,8 +97,56 @@ impl Debugger {
             return Some(source.to_string());
         }
 
-        let fs_path = path.strip_prefix("file://").unwrap_or(path);
+        let fs_path = file_uri_to_path(path).unwrap_or_else(|| std::path::PathBuf::from(path));
         std::fs::read_to_string(fs_path).ok()
+    }
+}
+
+fn file_uri_to_path(uri: &str) -> Option<std::path::PathBuf> {
+    let rest = uri.strip_prefix("file://")?;
+    let local = if rest == "localhost" {
+        ""
+    } else if rest.starts_with("localhost/") {
+        &rest["localhost".len()..]
+    } else {
+        rest
+    };
+    let decoded = percent_decode(local)?;
+    #[cfg(windows)]
+    {
+        let path = decoded.strip_prefix('/').unwrap_or(&decoded);
+        Some(std::path::PathBuf::from(path))
+    }
+    #[cfg(not(windows))]
+    {
+        Some(std::path::PathBuf::from(decoded))
+    }
+}
+
+fn percent_decode(input: &str) -> Option<String> {
+    let bytes = input.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' {
+            let hi = *bytes.get(i + 1)?;
+            let lo = *bytes.get(i + 2)?;
+            out.push((hex_value(hi)? << 4) | hex_value(lo)?);
+            i += 3;
+        } else {
+            out.push(bytes[i]);
+            i += 1;
+        }
+    }
+    String::from_utf8(out).ok()
+}
+
+fn hex_value(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
     }
 }
 

--- a/crates/harn-dap/src/debugger/tests.rs
+++ b/crates/harn-dap/src/debugger/tests.rs
@@ -354,6 +354,31 @@ fn test_source_reads_prompt_template_from_disk() {
 }
 
 #[test]
+fn test_source_decodes_file_uri_paths() {
+    let (dir, file) = write_temp_program("space name.harn", "pipeline test(task) {}\n");
+    let encoded = file.to_string_lossy().replace(' ', "%20");
+
+    for (seq, uri) in [
+        format!("file://{encoded}"),
+        format!("file://localhost{encoded}"),
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let responses = Debugger::new().handle_message(make_request(
+            seq as i64 + 1,
+            "source",
+            Some(json!({"source": {"path": uri}})),
+        ));
+        assert_eq!(responses.len(), 1);
+        assert_eq!(responses[0].success, Some(true), "{responses:?}");
+        let body = responses[0].body.as_ref().unwrap();
+        assert_eq!(body["content"], "pipeline test(task) {}\n");
+    }
+    drop(dir);
+}
+
+#[test]
 fn test_source_reads_stdlib_synthetic_source() {
     let responses = Debugger::new().handle_message(make_request(
         1,
@@ -536,6 +561,59 @@ fn test_breakpoint_stop() {
     assert!(
         stopped_on_breakpoint,
         "expected a stopped event with reason=breakpoint for the entry script"
+    );
+    drop(dbg);
+}
+
+#[test]
+fn test_clearing_breakpoints_updates_live_vm() {
+    let mut dbg = Debugger::new();
+
+    let (_dir, file) = write_temp_program(
+        "clear_breakpoints.harn",
+        "pipeline test(task) {\n  let x = 1\n  let y = 2\n  log(x + y)\n}\n",
+    );
+    let path = file.to_string_lossy().to_string();
+
+    dbg.handle_message(make_request(1, "initialize", None));
+    dbg.handle_message(make_request(
+        2,
+        "setBreakpoints",
+        Some(json!({
+            "source": {"path": path},
+            "breakpoints": [{"line": 3}]
+        })),
+    ));
+    dbg.handle_message(make_request(
+        3,
+        "launch",
+        Some(json!({"program": file.to_string_lossy()})),
+    ));
+    dbg.handle_message(make_request(
+        4,
+        "setBreakpoints",
+        Some(json!({
+            "source": {"path": file.to_string_lossy()},
+            "breakpoints": []
+        })),
+    ));
+
+    let mut responses = dbg.handle_message(make_request(5, "configurationDone", None));
+    while dbg.is_running() {
+        responses.extend(dbg.step_running_vm());
+    }
+
+    assert!(
+        responses
+            .iter()
+            .all(|r| r.event.as_deref() != Some("stopped")),
+        "cleared breakpoint should not stop the VM: {responses:?}"
+    );
+    assert!(
+        responses
+            .iter()
+            .any(|r| r.event.as_deref() == Some("terminated")),
+        "program should run through after breakpoint clear"
     );
     drop(dbg);
 }

--- a/crates/harn-hostlib/src/code_index/builtins.rs
+++ b/crates/harn-hostlib/src/code_index/builtins.rs
@@ -381,7 +381,9 @@ pub(super) fn run_file_hash(
     let Some(state) = guard.as_ref() else {
         return Ok(VmValue::Nil);
     };
-    let abs = state.absolute_path(&path);
+    let Some(abs) = state.absolute_path(&path) else {
+        return Ok(VmValue::Nil);
+    };
     match std::fs::read(&abs) {
         Ok(bytes) => Ok(str_value(fnv1a64(&bytes).to_string())),
         Err(_) => Ok(VmValue::Nil),
@@ -421,7 +423,15 @@ pub(super) fn run_read_range(
     };
     let guard = index.lock().expect("code_index mutex poisoned");
     let abs = match guard.as_ref() {
-        Some(state) => state.absolute_path(&path),
+        Some(state) => {
+            state
+                .absolute_path(&path)
+                .ok_or_else(|| HostlibError::InvalidParameter {
+                    builtin: BUILTIN_READ_RANGE,
+                    param: "path",
+                    message: "path must stay within the indexed workspace root".to_string(),
+                })?
+        }
         None => PathBuf::from(&path),
     };
     drop(guard);
@@ -471,7 +481,13 @@ pub(super) fn run_reindex_file(
             ("file_id", VmValue::Nil),
         ]));
     };
-    let abs = state.absolute_path(&path);
+    let Some(abs) = state.absolute_path(&path) else {
+        return Err(HostlibError::InvalidParameter {
+            builtin: BUILTIN_REINDEX_FILE,
+            param: "path",
+            message: "path must stay within the indexed workspace root".to_string(),
+        });
+    };
     let id = state.reindex_file(&abs);
     Ok(build_dict([
         ("indexed", VmValue::Bool(id.is_some())),

--- a/crates/harn-hostlib/src/code_index/state.rs
+++ b/crates/harn-hostlib/src/code_index/state.rs
@@ -249,12 +249,18 @@ impl IndexState {
     /// Resolve a workspace-relative path against the canonical root.
     /// Used by host builtins that take a `path` argument and need to
     /// open the underlying file (e.g. `read_range`, `file_hash`).
-    pub fn absolute_path(&self, rel_or_abs: &str) -> PathBuf {
+    pub fn absolute_path(&self, rel_or_abs: &str) -> Option<PathBuf> {
         let p = Path::new(rel_or_abs);
-        if p.is_absolute() {
+        let candidate = if p.is_absolute() {
             p.to_path_buf()
         } else {
             self.root.join(p)
+        };
+        let canonical = canonicalize_existing(&candidate);
+        if canonical.strip_prefix(&self.root).is_ok() {
+            Some(canonical)
+        } else {
+            None
         }
     }
 

--- a/crates/harn-hostlib/src/fs_watch/mod.rs
+++ b/crates/harn-hostlib/src/fs_watch/mod.rs
@@ -262,11 +262,19 @@ impl SubscribeRequest {
             } else {
                 path
             };
-            watch_paths.push(normalize_existing_path_buf(
-                SUBSCRIBE_BUILTIN,
-                "paths",
-                &resolved,
-            )?);
+            let normalized = normalize_existing_path_buf(SUBSCRIBE_BUILTIN, "paths", &resolved)?;
+            if normalized.strip_prefix(&root).is_err() {
+                return Err(HostlibError::InvalidParameter {
+                    builtin: SUBSCRIBE_BUILTIN,
+                    param: "paths",
+                    message: format!(
+                        "watch path `{}` is outside root `{}`",
+                        normalized.display(),
+                        root.display()
+                    ),
+                });
+            }
+            watch_paths.push(normalized);
         }
 
         let recursive = optional_bool(SUBSCRIBE_BUILTIN, dict, "recursive", true)?;

--- a/crates/harn-hostlib/tests/code_index_live_state.rs
+++ b/crates/harn-hostlib/tests/code_index_live_state.rs
@@ -232,6 +232,26 @@ fn file_hash_reads_the_file_off_disk() {
     assert_eq!(s, expected.to_string());
 }
 
+#[test]
+fn file_hash_rejects_absolute_paths_outside_workspace() {
+    let dir = workspace();
+    let outside = tempfile::NamedTempFile::new().unwrap();
+    fs::write(outside.path(), "outside workspace\n").unwrap();
+    let (registry, _) = build();
+    rebuild_in(dir.path(), &registry);
+
+    let value = call(
+        &registry,
+        "hostlib_code_index_file_hash",
+        dict(&[(
+            "path",
+            VmValue::String(Rc::from(outside.path().to_string_lossy().to_string())),
+        )]),
+    );
+
+    assert!(matches!(value, VmValue::Nil));
+}
+
 // === Cached reads ===
 
 #[test]
@@ -279,6 +299,27 @@ fn read_range_errors_when_file_missing() {
     .expect_err("missing file should error");
     let msg = format!("{err}");
     assert!(msg.contains("file not found"));
+}
+
+#[test]
+fn read_range_rejects_paths_outside_workspace() {
+    let dir = workspace();
+    let outside = tempfile::NamedTempFile::new().unwrap();
+    fs::write(outside.path(), "outside workspace\n").unwrap();
+    let (registry, _) = build();
+    rebuild_in(dir.path(), &registry);
+
+    let err = try_call(
+        &registry,
+        "hostlib_code_index_read_range",
+        dict(&[(
+            "path",
+            VmValue::String(Rc::from(outside.path().to_string_lossy().to_string())),
+        )]),
+    )
+    .expect_err("outside workspace path should error");
+    let msg = format!("{err}");
+    assert!(msg.contains("indexed workspace root"));
 }
 
 #[test]

--- a/crates/harn-hostlib/tests/fs_watch.rs
+++ b/crates/harn-hostlib/tests/fs_watch.rs
@@ -94,3 +94,24 @@ fn unsubscribe_reports_unknown_handles() {
         Some(false)
     );
 }
+
+#[test]
+fn subscribe_rejects_paths_outside_root() {
+    let root = tempfile::tempdir().expect("root tempdir");
+    let outside = tempfile::tempdir().expect("outside tempdir");
+    let registry = registry();
+    let subscribe = registry
+        .find("hostlib_fs_watch_subscribe")
+        .expect("subscribe registered");
+    let outside_path = outside.path().to_string_lossy().to_string();
+
+    let err = (subscribe.handler)(&[dict([
+        ("session_id", str_value("fs-watch-boundary")),
+        ("root", str_value(root.path().to_string_lossy())),
+        ("paths", list(&[outside_path.as_str()])),
+    ])])
+    .expect_err("outside path should be rejected");
+
+    let msg = format!("{err}");
+    assert!(msg.contains("outside root"), "{msg}");
+}

--- a/crates/harn-stdlib/src/stdlib/stdlib_path.harn
+++ b/crates/harn-stdlib/src/stdlib/stdlib_path.harn
@@ -5,7 +5,7 @@
 fn ext(path) {
   let e = extname(path)
   if len(e) > 0 {
-    return e.substring(1, len(e) - 1)
+    return e.substring(1)
   }
   return ""
 }
@@ -13,8 +13,8 @@ fn ext(path) {
 /** Get the filename without extension. */
 fn stem(path) {
   let base = basename(path)
-  let dot = base.index_of(".")
-  if dot < 0 {
+  let dot = base.last_index_of(".")
+  if dot <= 0 {
     return base
   }
   return base.substring(0, dot)
@@ -27,7 +27,9 @@ fn normalize(path) {
 
 /** Check if a path is absolute. */
 fn is_absolute(path) {
-  return path.starts_with("/") || (len(path) >= 3 && path.substring(1, 1) == ":")
+  let normalized = normalize(path)
+  let windows_drive_root = len(normalized) >= 3 && normalized.substring(1, 2) == ":" && normalized.substring(2, 3) == "/"
+  return normalized.starts_with("/") || windows_drive_root
 }
 
 /** Classify a path at the workspace boundary. */

--- a/crates/harn-vm/src/orchestration/compaction.rs
+++ b/crates/harn-vm/src/orchestration/compaction.rs
@@ -110,16 +110,31 @@ impl Default for AutoCompactConfig {
 
 /// Estimate token count from a list of JSON messages (chars / 4 heuristic).
 pub fn estimate_message_tokens(messages: &[serde_json::Value]) -> usize {
-    messages
-        .iter()
-        .map(|m| {
-            m.get("content")
-                .and_then(|c| c.as_str())
-                .map(|s| s.len())
-                .unwrap_or(0)
-        })
-        .sum::<usize>()
-        / 4
+    messages.iter().map(estimate_message_chars).sum::<usize>() / 4
+}
+
+fn estimate_message_chars(message: &serde_json::Value) -> usize {
+    let mut total = message
+        .get("content")
+        .map(estimate_content_chars)
+        .unwrap_or_default();
+    if let Some(reasoning) = message.get("reasoning") {
+        total += estimate_content_chars(reasoning);
+    }
+    if let Some(tool_calls) = message.get("tool_calls") {
+        total += estimate_content_chars(tool_calls);
+    }
+    total
+}
+
+fn estimate_content_chars(value: &serde_json::Value) -> usize {
+    match value {
+        serde_json::Value::String(text) => text.len(),
+        serde_json::Value::Array(items) => items.iter().map(estimate_content_chars).sum(),
+        serde_json::Value::Object(map) => map.values().map(estimate_content_chars).sum(),
+        serde_json::Value::Null => 0,
+        other => other.to_string().len(),
+    }
 }
 
 fn is_reasoning_or_tool_turn_message(message: &serde_json::Value) -> bool {
@@ -715,6 +730,29 @@ mod tests {
         assert!(
             result.contains("[diagnostic lines preserved]"),
             "has diagnostic marker"
+        );
+    }
+
+    #[test]
+    fn token_estimate_counts_structured_message_content() {
+        let text = "x".repeat(400);
+        let messages = vec![serde_json::json!({
+            "role": "user",
+            "content": [
+                {"type": "text", "text": text},
+                {"type": "input_text", "text": "tail"},
+            ],
+            "reasoning": {"text": "scratch"},
+            "tool_calls": [{
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "read", "arguments": "{\"path\":\"src/main.rs\"}"}
+            }],
+        })];
+
+        assert!(
+            estimate_message_tokens(&messages) >= 100,
+            "structured content must not count as zero"
         );
     }
 

--- a/crates/harn-vm/src/stdlib/fs.rs
+++ b/crates/harn-vm/src/stdlib/fs.rs
@@ -548,7 +548,7 @@ fn list_dir_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmEr
         &resolved,
         crate::stdlib::sandbox::FsAccess::Read,
     )?;
-    let entries = std::fs::read_dir(&resolved).map_err(|e| {
+    let entries = overlay::read_dir(&resolved).map_err(|e| {
         VmError::Thrown(VmValue::String(Rc::from(format!(
             "Failed to list directory {}: {e}",
             resolved.display()
@@ -556,8 +556,10 @@ fn list_dir_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmEr
     })?;
     let mut result = Vec::new();
     for entry in entries {
-        let entry = entry.map_err(|e| VmError::Thrown(VmValue::String(Rc::from(e.to_string()))))?;
-        let name = entry.file_name().to_string_lossy().into_owned();
+        let Some(name) = entry.path.file_name() else {
+            continue;
+        };
+        let name = name.to_string_lossy().into_owned();
         result.push(VmValue::String(Rc::from(name)));
     }
     result.sort_by_key(|a| a.display());
@@ -709,7 +711,7 @@ fn read_lines_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, Vm
         &resolved,
         crate::stdlib::sandbox::FsAccess::Read,
     )?;
-    let content = std::fs::read_to_string(&resolved).map_err(|e| {
+    let content = overlay::read_to_string(&resolved).map_err(|e| {
         VmError::Thrown(VmValue::String(Rc::from(format!(
             "read_lines: {}: {e}",
             resolved.display()
@@ -919,6 +921,66 @@ mod tests {
                 .unwrap()
                 .display(),
             "two updated"
+        );
+    }
+
+    #[test]
+    fn list_dir_observes_active_overlay_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        let overlay = std::sync::Arc::new(crate::testbench::overlay_fs::OverlayFs::rooted_at(
+            dir.path(),
+        ));
+        let _guard = crate::testbench::overlay_fs::install_overlay(overlay);
+        let mut vm = vm();
+        let subdir = dir.path().join("overlay-dir");
+        let file = subdir.join("created.txt");
+
+        call(&mut vm, "mkdir", vec![s(&subdir.to_string_lossy())]).unwrap();
+        call(
+            &mut vm,
+            "write_file",
+            vec![s(&file.to_string_lossy()), s("overlay only")],
+        )
+        .unwrap();
+
+        let listed = call(&mut vm, "list_dir", vec![s(&subdir.to_string_lossy())]).unwrap();
+        let VmValue::List(items) = listed else {
+            panic!("list_dir returns list");
+        };
+        let names = items.iter().map(VmValue::display).collect::<Vec<_>>();
+        assert_eq!(names, vec!["created.txt".to_string()]);
+        assert!(
+            !file.exists(),
+            "overlay write should not materialize on the underlying fs"
+        );
+    }
+
+    #[test]
+    fn read_lines_observes_active_overlay_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let overlay = std::sync::Arc::new(crate::testbench::overlay_fs::OverlayFs::rooted_at(
+            dir.path(),
+        ));
+        let _guard = crate::testbench::overlay_fs::install_overlay(overlay);
+        let mut vm = vm();
+        let path = dir.path().join("lines.txt");
+
+        call(
+            &mut vm,
+            "write_file",
+            vec![s(&path.to_string_lossy()), s("one\ntwo\n")],
+        )
+        .unwrap();
+
+        let lines = call(&mut vm, "read_lines", vec![s(&path.to_string_lossy())]).unwrap();
+        let VmValue::List(items) = lines else {
+            panic!("read_lines returns list");
+        };
+        let lines = items.iter().map(VmValue::display).collect::<Vec<_>>();
+        assert_eq!(lines, vec!["one".to_string(), "two".to_string()]);
+        assert!(
+            !path.exists(),
+            "overlay write should not materialize on the underlying fs"
         );
     }
 

--- a/crates/harn-vm/src/testbench/overlay_fs.rs
+++ b/crates/harn-vm/src/testbench/overlay_fs.rs
@@ -553,6 +553,25 @@ pub mod helpers {
             None => std::fs::create_dir_all(path),
         }
     }
+
+    pub fn read_dir(path: &Path) -> std::io::Result<Vec<OverlayDirEntry>> {
+        match active_overlay() {
+            Some(overlay) => overlay.read_dir(path),
+            None => {
+                let mut entries = Vec::new();
+                for entry in std::fs::read_dir(path)? {
+                    let entry = entry?;
+                    let file_type = entry.file_type()?;
+                    entries.push(OverlayDirEntry {
+                        path: entry.path(),
+                        is_dir: file_type.is_dir(),
+                        is_file: file_type.is_file(),
+                    });
+                }
+                Ok(entries)
+            }
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Fixes a set of concrete correctness, security, compatibility, and runtime bugs across crates:

- Corrects `std/path` extension, stem, hidden-file, and Windows absolute-path handling with conformance coverage.
- Routes VM `list_dir` and `read_lines` through the active testbench overlay instead of leaking to the host filesystem.
- Counts structured message content, reasoning, and tool calls in orchestration compaction token estimates.
- Tightens hostlib code-index and fs-watch path handling so absolute paths, traversal, and symlink escapes cannot leave the workspace root.
- Fixes DAP source loading for percent-encoded `file://` URIs and clearing live VM breakpoints after a setBreakpoints empty update.
- Prevents package packing from following symlinks or including generated `docs/dist` content.

## Validation

- `cargo fmt --check --all`
- `git diff --check`
- `make lint-test-patterns`
- `CARGO_TARGET_DIR=/tmp/harn-467c-target make lint-harn fmt-harn`
- `CARGO_TARGET_DIR=/tmp/harn-467c-target cargo check --workspace` after rebasing on latest `origin/main`
- `CARGO_TARGET_DIR=/tmp/harn-467c-target cargo run --quiet --bin harn -- test conformance --filter stdlib_path_module`
- `CARGO_TARGET_DIR=/tmp/harn-467c-target cargo test -p harn-vm --lib stdlib::fs::tests::`
- `CARGO_TARGET_DIR=/tmp/harn-467c-target cargo test -p harn-vm --lib orchestration::compaction::tests::token_estimate_counts_structured_message_content`
- `CARGO_TARGET_DIR=/tmp/harn-467c-target cargo test -p harn-hostlib --test fs_watch`
- `CARGO_TARGET_DIR=/tmp/harn-467c-target cargo test -p harn-hostlib --test code_index_live_state -- --test-threads=1`
- `CARGO_TARGET_DIR=/tmp/harn-467c-target cargo test -p harn-dap`
- `CARGO_TARGET_DIR=/tmp/harn-467c-target cargo test -p harn-cli package_pack`
- `CARGO_TARGET_DIR=/tmp/harn-467c-target make test` (3900 passed, 2 skipped)
- Pre-commit hook passed, including `cargo clippy --workspace --all-targets -- -D warnings`
- Pre-push hook passed