### PR TITLE
llm: dispatch behavior on capability flags, not provider strings (#1667)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,13 @@ condensed series summaries instead of full per-patch history.
   with `{session, iteration, wake_interval_ms, consolidate_on_idle}`,
   matching the placement documented in `docs/src/extensibility/hooks.md`.
   Conformance coverage at `conformance/tests/hooks_session/session_idle.harn`.
+- **LLM provider behavior dispatch now uses capabilities.** Rust call
+  sites that previously branched on provider strings for Anthropic-style
+  messages, native tool schemas, image URL support, reasoning request
+  shapes, and file-upload transports now read `provider_capabilities`.
+  Bedrock-hosted Claude and custom proxy routes can opt into the same
+  behavior through the capability matrix instead of pretending to be the
+  canonical provider name.
 - **Trailing comments on body statements are preserved.** `harn fmt`
   previously dropped same-line comments that followed a statement inside
   any block body (`fn`/`pipeline`/`if`/`else`/`while`/`for`/`try`/`catch`/

--- a/crates/harn-vm/src/llm/agent_config.rs
+++ b/crates/harn-vm/src/llm/agent_config.rs
@@ -83,6 +83,7 @@ pub(crate) fn agent_loop_result_from_llm(
         &result.tool_calls,
         result.thinking.as_deref(),
         &opts.provider,
+        &opts.model,
     ));
     let transcript_metadata = system_prompt_transcript_metadata(opts.system.as_ref());
     let prefix_events = system_prompt_transcript_events(opts.system.as_ref());
@@ -178,6 +179,7 @@ pub(crate) fn build_llm_call_result(
         &result.tool_calls,
         result.thinking.as_deref(),
         &opts.provider,
+        &opts.model,
     ));
     let transcript_metadata = system_prompt_transcript_metadata(opts.system.as_ref());
     let prefix_events = system_prompt_transcript_events(opts.system.as_ref());

--- a/crates/harn-vm/src/llm/agent_session_host.rs
+++ b/crates/harn-vm/src/llm/agent_session_host.rs
@@ -20,7 +20,6 @@ use crate::value::{VmError, VmValue};
 use crate::vm::{Vm, VmBuiltinArity, VmBuiltinMetadata};
 
 use super::cost::calculate_cost_for_provider;
-use super::helpers::ResolvedProvider;
 use super::permissions;
 use super::tools::build_assistant_response_message;
 
@@ -66,6 +65,7 @@ struct AgentHostSession {
     rejected_tools: Vec<String>,
     tool_mode: String,
     last_provider: Option<String>,
+    last_model: Option<String>,
     pushed_transcript_dir: bool,
     started_at: String,
     /// Iteration cap from `agent_loop(options.max_iterations)`. Captured
@@ -302,6 +302,7 @@ async fn host_agent_session_init(args: Vec<VmValue>) -> Result<VmValue, VmError>
         rejected_tools: Vec::new(),
         tool_mode: tool_format,
         last_provider: None,
+        last_model: None,
         pushed_transcript_dir,
         started_at: now_id(),
         max_iterations,
@@ -681,6 +682,9 @@ fn assistant_message_from_llm_result(llm_result: &VmValue) -> VmValue {
     let provider = dict_get(llm_result, "provider")
         .map(|v| v.display())
         .unwrap_or_default();
+    let model = dict_get(llm_result, "model")
+        .map(|v| v.display())
+        .unwrap_or_default();
     // Only attach provider-native tool calls to the assistant envelope.
     // Text-mode calls remain inline in `text` and are parsed from there.
     let native_calls_value = dict_get(llm_result, "native_tool_calls")
@@ -704,6 +708,7 @@ fn assistant_message_from_llm_result(llm_result: &VmValue) -> VmValue {
         &native_calls_json,
         thinking.as_deref(),
         &provider,
+        &model,
     );
     json_to_vm(&msg)
 }
@@ -715,6 +720,9 @@ fn host_agent_session_record_assistant_builtin(
     let session_id = args.first().map(|v| v.display()).unwrap_or_default();
     let llm_result = args.get(1).cloned().unwrap_or(VmValue::Nil);
     let provider = dict_get(&llm_result, "provider")
+        .map(|v| v.display())
+        .unwrap_or_default();
+    let model = dict_get(&llm_result, "model")
         .map(|v| v.display())
         .unwrap_or_default();
     let raw_tool_calls = dict_get(&llm_result, "tool_calls")
@@ -729,6 +737,9 @@ fn host_agent_session_record_assistant_builtin(
         if !provider.is_empty() {
             session.last_provider = Some(provider);
         }
+        if !model.is_empty() {
+            session.last_model = Some(model);
+        }
         Ok(())
     });
     let _ = crate::agent_sessions::inject_message(
@@ -740,12 +751,13 @@ fn host_agent_session_record_assistant_builtin(
 
 fn tool_result_message_for_provider(
     provider: &str,
+    model: &str,
     name: &str,
     tool_call_id: &str,
     observation: &str,
 ) -> VmValue {
     let mut msg = BTreeMap::new();
-    if ResolvedProvider::resolve(provider).is_anthropic_style {
+    if crate::llm::provider::provider_uses_anthropic_messages(provider, model) {
         msg.insert("role".to_string(), VmValue::String(Rc::from("tool_result")));
         msg.insert(
             "tool_use_id".to_string(),
@@ -806,10 +818,14 @@ fn host_agent_session_record_tool_results_builtin(
 ) -> Result<VmValue, VmError> {
     let session_id = args.first().map(|v| v.display()).unwrap_or_default();
     let dispatch = args.get(1).cloned().unwrap_or(VmValue::Nil);
-    let provider = with_session(&session_id, HOST_SESSION_RECORD_TOOL_RESULTS, |session| {
-        Ok(session.last_provider.clone().unwrap_or_default())
-    })
-    .unwrap_or_default();
+    let (provider, model) =
+        with_session(&session_id, HOST_SESSION_RECORD_TOOL_RESULTS, |session| {
+            Ok((
+                session.last_provider.clone().unwrap_or_default(),
+                session.last_model.clone().unwrap_or_default(),
+            ))
+        })
+        .unwrap_or_default();
     // dispatch may be either a flat list of results (as returned by
     // agent_dispatch_tool_batch) or a dict with a `results` key (legacy
     // shape some callers still synthesize). Handle both.
@@ -870,7 +886,7 @@ fn host_agent_session_record_tool_results_builtin(
         }
         let _ = crate::agent_sessions::inject_message(
             &session_id,
-            tool_result_message_for_provider(&provider, &name, &tool_call_id, &observation),
+            tool_result_message_for_provider(&provider, &model, &name, &tool_call_id, &observation),
         );
     }
     let _ = with_session(&session_id, HOST_SESSION_RECORD_TOOL_RESULTS, |session| {
@@ -2028,6 +2044,7 @@ mod tests {
     fn tool_results_replay_with_provider_appropriate_ids() {
         let local = vm_to_json(&tool_result_message_for_provider(
             "local",
+            "Qwen/Qwen3.6-35B-A3B",
             "release_run",
             "call_001",
             "ok",
@@ -2038,12 +2055,23 @@ mod tests {
 
         let anthropic = vm_to_json(&tool_result_message_for_provider(
             "anthropic",
+            "claude-opus-4-7",
             "release_run",
             "call_002",
             "ok",
         ));
         assert_eq!(anthropic["role"], "tool_result");
         assert_eq!(anthropic["tool_use_id"], "call_002");
+
+        let bedrock_claude = vm_to_json(&tool_result_message_for_provider(
+            "bedrock",
+            "anthropic.claude-3-5-sonnet-20240620-v1:0",
+            "release_run",
+            "call_003",
+            "ok",
+        ));
+        assert_eq!(bedrock_claude["role"], "tool_result");
+        assert_eq!(bedrock_claude["tool_use_id"], "call_003");
     }
 
     #[test]

--- a/crates/harn-vm/src/llm/api/context_window.rs
+++ b/crates/harn-vm/src/llm/api/context_window.rs
@@ -187,24 +187,15 @@ async fn fetch_provider_max_context_uncached(
         return Some(n);
     }
 
-    if provider == "ollama" {
+    let caps = crate::llm::capabilities::lookup(provider, model);
+    if caps.message_wire_format == "ollama" {
         return fetch_ollama_context_window(model, base_url).await;
     }
 
-    let is_openai_compatible = matches!(
-        provider,
-        "local"
-            | "openai"
-            | "mlx"
-            | "llamacpp"
-            | "vllm"
-            | "groq"
-            | "together"
-            | "openrouter"
-            | "deepinfra"
-            | "fireworks"
-            | "huggingface"
-    );
+    let endpoint = crate::llm::helpers::ResolvedProvider::resolve(provider).endpoint;
+    let is_openai_compatible = endpoint.contains("/chat/completions")
+        || endpoint.contains("/responses")
+        || endpoint.contains("/v1/");
     if is_openai_compatible {
         return fetch_openai_compatible_context_window(provider, model, api_key, base_url).await;
     }

--- a/crates/harn-vm/src/llm/api/response.rs
+++ b/crates/harn-vm/src/llm/api/response.rs
@@ -191,9 +191,9 @@ pub(crate) fn parse_llm_response(
     json: &serde_json::Value,
     provider: &str,
     model: &str,
-    resolved: &crate::llm::helpers::ResolvedProvider,
+    is_anthropic_style: bool,
 ) -> Result<LlmResult, VmError> {
-    if resolved.is_anthropic_style {
+    if is_anthropic_style {
         let mut text = String::new();
         let mut thinking_text = String::new();
         let mut tool_calls = Vec::new();
@@ -554,13 +554,6 @@ mod tests {
         parse_llm_response,
     };
 
-    // Build a ResolvedProvider for the Anthropic path without going through
-    // the thread-local provider registry — these parser tests only need the
-    // is_anthropic_style flag set.
-    fn anthropic_resolved() -> crate::llm::helpers::ResolvedProvider {
-        crate::llm::helpers::ResolvedProvider::resolve("anthropic")
-    }
-
     #[test]
     fn cache_write_tokens_supports_openrouter_prompt_details_shape() {
         let usage = serde_json::json!({
@@ -649,7 +642,6 @@ mod tests {
 
     #[test]
     fn anthropic_parser_records_server_tool_use_as_tool_search_query() {
-        let resolved = anthropic_resolved();
         // Build a minimal Anthropic Messages API response containing a
         // server_tool_use block (the model calling the search tool).
         let response = serde_json::json!({
@@ -664,7 +656,7 @@ mod tests {
             ],
             "usage": {"input_tokens": 10, "output_tokens": 5}
         });
-        let result = parse_llm_response(&response, "anthropic", "claude-opus-4-7", &resolved)
+        let result = parse_llm_response(&response, "anthropic", "claude-opus-4-7", true)
             .expect("parser succeeds");
 
         // tool_calls is for *dispatchable* user tools — server-side tools
@@ -691,7 +683,6 @@ mod tests {
         // `tool_calls` vector — OpenAI runs the search on their side —
         // but must record a `tool_search_query` transcript block so
         // replay lines up with the Anthropic path.
-        let resolved = crate::llm::helpers::ResolvedProvider::resolve("openai");
         let response = serde_json::json!({
             "choices": [{
                 "message": {
@@ -708,7 +699,7 @@ mod tests {
             }],
             "usage": {"prompt_tokens": 10, "completion_tokens": 5}
         });
-        let result = parse_llm_response(&response, "openai", "gpt-5.4-preview", &resolved)
+        let result = parse_llm_response(&response, "openai", "gpt-5.4-preview", false)
             .expect("parser succeeds");
 
         assert!(
@@ -726,7 +717,6 @@ mod tests {
 
     #[test]
     fn openai_parser_records_tool_search_output_as_result_event() {
-        let resolved = crate::llm::helpers::ResolvedProvider::resolve("openai");
         let response = serde_json::json!({
             "choices": [{
                 "message": {
@@ -746,7 +736,7 @@ mod tests {
             }],
             "usage": {"prompt_tokens": 3, "completion_tokens": 1}
         });
-        let result = parse_llm_response(&response, "openai", "gpt-5.4-preview", &resolved)
+        let result = parse_llm_response(&response, "openai", "gpt-5.4-preview", false)
             .expect("parser succeeds");
 
         assert!(result.tool_calls.is_empty());
@@ -765,7 +755,6 @@ mod tests {
 
     #[test]
     fn openai_parser_surfaces_reasoning_summary_separate_from_text() {
-        let resolved = crate::llm::helpers::ResolvedProvider::resolve("openai");
         let response = serde_json::json!({
             "choices": [{
                 "message": {
@@ -780,8 +769,7 @@ mod tests {
             "usage": {"prompt_tokens": 5, "completion_tokens": 7}
         });
 
-        let result =
-            parse_llm_response(&response, "openai", "o3", &resolved).expect("parser succeeds");
+        let result = parse_llm_response(&response, "openai", "o3", false).expect("parser succeeds");
 
         assert_eq!(result.text, "Final answer.");
         assert_eq!(
@@ -798,7 +786,6 @@ mod tests {
 
     #[test]
     fn anthropic_parser_records_tool_search_tool_result_as_event() {
-        let resolved = anthropic_resolved();
         let response = serde_json::json!({
             "content": [
                 {
@@ -815,7 +802,7 @@ mod tests {
             ],
             "usage": {"input_tokens": 3, "output_tokens": 1}
         });
-        let result = parse_llm_response(&response, "anthropic", "claude-opus-4-7", &resolved)
+        let result = parse_llm_response(&response, "anthropic", "claude-opus-4-7", true)
             .expect("parser succeeds");
 
         let result_block = result
@@ -842,7 +829,6 @@ mod tests {
         // dropping them on the floor — otherwise eval dashboards see
         // empty per-call accounting and have to fall back to
         // wall-clock heuristics.
-        let resolved = crate::llm::helpers::ResolvedProvider::resolve("vllm");
         let response = serde_json::json!({
             "id": "chatcmpl-abc",
             "choices": [{
@@ -853,7 +839,7 @@ mod tests {
         });
 
         let result =
-            parse_llm_response(&response, "vllm", "qwen3.6", &resolved).expect("parser succeeds");
+            parse_llm_response(&response, "vllm", "qwen3.6", false).expect("parser succeeds");
 
         assert_eq!(
             result.telemetry.source,
@@ -871,7 +857,6 @@ mod tests {
         // `timings` block. Preserve the millisecond fields verbatim and
         // promote the source to `llamacpp_timings` so eval scripts can
         // route on them.
-        let resolved = crate::llm::helpers::ResolvedProvider::resolve("llamacpp");
         let response = serde_json::json!({
             "choices": [{
                 "message": {"content": "answer"},
@@ -889,8 +874,8 @@ mod tests {
             }
         });
 
-        let result = parse_llm_response(&response, "llamacpp", "qwen-7b", &resolved)
-            .expect("parser succeeds");
+        let result =
+            parse_llm_response(&response, "llamacpp", "qwen-7b", false).expect("parser succeeds");
 
         assert_eq!(
             result.telemetry.source,
@@ -903,14 +888,13 @@ mod tests {
 
     #[test]
     fn anthropic_parser_captures_request_id_in_telemetry() {
-        let resolved = anthropic_resolved();
         let response = serde_json::json!({
             "id": "msg_01ABC",
             "content": [{"type": "text", "text": "ok"}],
             "usage": {"input_tokens": 5, "output_tokens": 2},
             "stop_reason": "end_turn"
         });
-        let result = parse_llm_response(&response, "anthropic", "claude-opus-4-7", &resolved)
+        let result = parse_llm_response(&response, "anthropic", "claude-opus-4-7", true)
             .expect("parser succeeds");
         assert_eq!(
             result.telemetry.source,

--- a/crates/harn-vm/src/llm/api/transport.rs
+++ b/crates/harn-vm/src/llm/api/transport.rs
@@ -150,9 +150,9 @@ pub(super) async fn vm_call_llm_api(
     }
 
     // Fallback for unregistered providers: dispatch by API style.
-    let resolved = crate::llm::helpers::ResolvedProvider::resolve(provider);
-    let is_ollama = provider == "ollama" || resolved.endpoint.contains("/api/chat");
-    let is_anthropic = resolved.is_anthropic_style;
+    let is_ollama = crate::llm::provider::provider_uses_ollama_messages(provider, &opts.model);
+    let is_anthropic =
+        crate::llm::provider::provider_uses_anthropic_messages(provider, &opts.model);
 
     if is_ollama {
         return crate::llm::providers::OllamaProvider
@@ -183,7 +183,6 @@ async fn dispatch_to_registered_provider(
     // Providers are zero-cost unit structs constructed inline to avoid
     // RefCell-across-await conflicts on a shared registry.
     let provider = &opts.provider;
-    let resolved = crate::llm::helpers::ResolvedProvider::resolve(provider);
 
     let mock = crate::llm::providers::MockProvider;
     if mock.is_mock() && provider == mock.name() {
@@ -197,12 +196,15 @@ async fn dispatch_to_registered_provider(
     }
 
     let ollama = crate::llm::providers::OllamaProvider;
-    if (provider == ollama.name() || resolved.endpoint.contains("/api/chat")) && ollama.is_local() {
+    if (provider == ollama.name()
+        || crate::llm::provider::provider_uses_ollama_messages(provider, &opts.model))
+        && ollama.is_local()
+    {
         return ollama.chat_impl(opts, delta_tx).await;
     }
 
-    if provider == "gemini" {
-        let gemini = crate::llm::providers::GeminiProvider;
+    let gemini = crate::llm::providers::GeminiProvider;
+    if provider == gemini.name() {
         return gemini.chat_impl(opts, delta_tx).await;
     }
 
@@ -224,7 +226,7 @@ async fn dispatch_to_registered_provider(
             .await;
     }
 
-    if resolved.is_anthropic_style {
+    if crate::llm::provider::provider_uses_anthropic_messages(provider, &opts.model) {
         let anthropic = crate::llm::providers::AnthropicProvider;
         return anthropic.chat_impl(opts, delta_tx).await;
     }
@@ -391,7 +393,7 @@ async fn vm_call_llm_api_with_body_inner(
                     response,
                     provider,
                     model,
-                    &resolved,
+                    is_anthropic_style,
                     tx,
                     opts.session_id.as_deref(),
                 )
@@ -461,7 +463,9 @@ async fn vm_call_llm_api_with_body_inner(
         ))))
     })?;
 
-    parse_llm_response(&json, provider, model, &resolved)
+    let is_anthropic_style =
+        crate::llm::provider::provider_uses_anthropic_messages(provider, model);
+    parse_llm_response(&json, provider, model, is_anthropic_style)
 }
 
 /// Consume an SSE streaming response from an already-sent request.
@@ -472,7 +476,7 @@ async fn vm_call_llm_api_sse_from_response(
     response: reqwest::Response,
     provider: &str,
     model: &str,
-    resolved: &crate::llm::helpers::ResolvedProvider,
+    is_anthropic_style: bool,
     delta_tx: DeltaSender,
     session_id: Option<&str>,
 ) -> Result<LlmResult, VmError> {
@@ -486,7 +490,7 @@ async fn vm_call_llm_api_sse_from_response(
         reader,
         provider,
         model,
-        resolved.is_anthropic_style,
+        is_anthropic_style,
         delta_tx,
         session_id,
     )

--- a/crates/harn-vm/src/llm/capabilities.rs
+++ b/crates/harn-vm/src/llm/capabilities.rs
@@ -14,10 +14,9 @@
 //!   trait delegates to as the single source of truth.
 //!
 //! Before this module the Anthropic / OpenAI gates were spread across
-//! `providers/anthropic.rs` (`claude_generation`, `claude_model_supports_tool_search`)
-//! and `providers/openai_compat.rs` (`gpt_generation`, `gpt_model_supports_tool_search`).
-//! Those parsers are still used here — they supply the version extractor —
-//! but the boolean gates that used to live alongside them are now data.
+//! `providers/anthropic.rs` and `providers/openai_compat.rs`. Their
+//! generation parsers are still used here for `version_min`, but the
+//! boolean gates that used to live alongside them are now data.
 
 use std::cell::RefCell;
 use std::collections::BTreeMap;
@@ -38,10 +37,131 @@ pub struct CapabilitiesFile {
     /// Per-provider ordered rule lists. First matching rule wins.
     #[serde(default)]
     pub provider: BTreeMap<String, Vec<ProviderRule>>,
+    /// Per-provider defaults applied to every matching row and to
+    /// provider/model pairs that have no model-specific row. This keeps
+    /// transport-shape facts in data without repeating them on every
+    /// generation-specific capability row.
+    #[serde(default)]
+    pub provider_defaults: BTreeMap<String, ProviderDefaults>,
     /// Sibling → canonical family mapping. Providers with no rule of
     /// their own fall through to the named family (recursively).
     #[serde(default)]
     pub provider_family: BTreeMap<String, String>,
+}
+
+/// Provider-wide default fields merged into matching rules.
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct ProviderDefaults {
+    /// Message/request/response wire format used by shared helpers.
+    /// Known values are `openai`, `anthropic`, and `ollama`.
+    #[serde(default)]
+    pub message_wire_format: Option<String>,
+    /// Native tool definition wire shape. Known values are `openai`
+    /// and `anthropic`.
+    #[serde(default)]
+    pub native_tool_wire_format: Option<String>,
+    /// Whether image content blocks may reference remote URLs.
+    #[serde(default)]
+    pub image_url_input_supported: Option<bool>,
+    /// File-upload transport used by `std/files.upload`. Known values
+    /// are `anthropic` and `gemini`.
+    #[serde(default)]
+    pub file_upload_wire_format: Option<String>,
+    /// Provider-specific reasoning request shape for OpenAI-compatible
+    /// transports. Known values are `openrouter` and `enabled`.
+    #[serde(default)]
+    pub reasoning_wire_format: Option<String>,
+    #[serde(default)]
+    pub files_api_supported: Option<bool>,
+    #[serde(default)]
+    pub seed_supported: Option<bool>,
+    #[serde(default)]
+    pub top_k_supported: Option<bool>,
+    #[serde(default)]
+    pub frequency_penalty_supported: Option<bool>,
+    #[serde(default)]
+    pub presence_penalty_supported: Option<bool>,
+}
+
+impl ProviderDefaults {
+    fn overlay(&mut self, other: &ProviderDefaults) {
+        if other.message_wire_format.is_some() {
+            self.message_wire_format = other.message_wire_format.clone();
+        }
+        if other.native_tool_wire_format.is_some() {
+            self.native_tool_wire_format = other.native_tool_wire_format.clone();
+        }
+        if other.image_url_input_supported.is_some() {
+            self.image_url_input_supported = other.image_url_input_supported;
+        }
+        if other.file_upload_wire_format.is_some() {
+            self.file_upload_wire_format = other.file_upload_wire_format.clone();
+        }
+        if other.reasoning_wire_format.is_some() {
+            self.reasoning_wire_format = other.reasoning_wire_format.clone();
+        }
+        if other.files_api_supported.is_some() {
+            self.files_api_supported = other.files_api_supported;
+        }
+        if other.seed_supported.is_some() {
+            self.seed_supported = other.seed_supported;
+        }
+        if other.top_k_supported.is_some() {
+            self.top_k_supported = other.top_k_supported;
+        }
+        if other.frequency_penalty_supported.is_some() {
+            self.frequency_penalty_supported = other.frequency_penalty_supported;
+        }
+        if other.presence_penalty_supported.is_some() {
+            self.presence_penalty_supported = other.presence_penalty_supported;
+        }
+    }
+
+    fn fill_missing_from(&mut self, other: &ProviderDefaults) {
+        if self.message_wire_format.is_none() {
+            self.message_wire_format = other.message_wire_format.clone();
+        }
+        if self.native_tool_wire_format.is_none() {
+            self.native_tool_wire_format = other.native_tool_wire_format.clone();
+        }
+        if self.image_url_input_supported.is_none() {
+            self.image_url_input_supported = other.image_url_input_supported;
+        }
+        if self.file_upload_wire_format.is_none() {
+            self.file_upload_wire_format = other.file_upload_wire_format.clone();
+        }
+        if self.reasoning_wire_format.is_none() {
+            self.reasoning_wire_format = other.reasoning_wire_format.clone();
+        }
+        if self.files_api_supported.is_none() {
+            self.files_api_supported = other.files_api_supported;
+        }
+        if self.seed_supported.is_none() {
+            self.seed_supported = other.seed_supported;
+        }
+        if self.top_k_supported.is_none() {
+            self.top_k_supported = other.top_k_supported;
+        }
+        if self.frequency_penalty_supported.is_none() {
+            self.frequency_penalty_supported = other.frequency_penalty_supported;
+        }
+        if self.presence_penalty_supported.is_none() {
+            self.presence_penalty_supported = other.presence_penalty_supported;
+        }
+    }
+
+    fn has_any_field(&self) -> bool {
+        self.message_wire_format.is_some()
+            || self.native_tool_wire_format.is_some()
+            || self.image_url_input_supported.is_some()
+            || self.file_upload_wire_format.is_some()
+            || self.reasoning_wire_format.is_some()
+            || self.files_api_supported.is_some()
+            || self.seed_supported.is_some()
+            || self.top_k_supported.is_some()
+            || self.frequency_penalty_supported.is_some()
+            || self.presence_penalty_supported.is_some()
+    }
 }
 
 /// One row of the capability matrix.
@@ -58,6 +178,14 @@ pub struct ProviderRule {
     pub version_min: Option<Vec<u32>>,
     #[serde(default)]
     pub native_tools: Option<bool>,
+    /// Message/request/response wire format used by shared helpers.
+    /// Known values are `openai`, `anthropic`, and `ollama`.
+    #[serde(default)]
+    pub message_wire_format: Option<String>,
+    /// Native tool definition wire shape. Known values are `openai`
+    /// and `anthropic`.
+    #[serde(default)]
+    pub native_tool_wire_format: Option<String>,
     #[serde(default)]
     pub defer_loading: Option<bool>,
     #[serde(default)]
@@ -81,6 +209,10 @@ pub struct ProviderRule {
     /// Whether uploaded file references can be reused in message content.
     #[serde(default)]
     pub files_api_supported: Option<bool>,
+    /// File-upload transport used by `std/files.upload`. Known values
+    /// are `anthropic` and `gemini`.
+    #[serde(default)]
+    pub file_upload_wire_format: Option<String>,
     /// Structured-output transport strategy. Known values are:
     /// `native`, `tool_use`, `format_kw`, and `none`.
     #[serde(default)]
@@ -130,6 +262,9 @@ pub struct ProviderRule {
     /// Whether the model accepts image inputs in chat content.
     #[serde(default)]
     pub vision_supported: Option<bool>,
+    /// Whether image content blocks may reference remote URLs.
+    #[serde(default)]
+    pub image_url_input_supported: Option<bool>,
     /// Carry `<think>...</think>` blocks in assistant history across turns.
     /// Qwen3.6 exposes this as `chat_template_kwargs.preserve_thinking`;
     /// Alibaba recommends enabling it for long-horizon agent loops so the
@@ -159,6 +294,18 @@ pub struct ProviderRule {
     /// floor at `minimal`.
     #[serde(default)]
     pub reasoning_none_supported: Option<bool>,
+    /// Provider-specific reasoning request shape for OpenAI-compatible
+    /// transports. Known values are `openrouter` and `enabled`.
+    #[serde(default)]
+    pub reasoning_wire_format: Option<String>,
+    #[serde(default)]
+    pub seed_supported: Option<bool>,
+    #[serde(default)]
+    pub top_k_supported: Option<bool>,
+    #[serde(default)]
+    pub frequency_penalty_supported: Option<bool>,
+    #[serde(default)]
+    pub presence_penalty_supported: Option<bool>,
     /// Preferred endpoint family for this provider/model route. Values
     /// are descriptive labels consumed by providers, e.g.
     /// `/api/generate-raw` for Ollama raw prompt bypass.
@@ -184,6 +331,8 @@ pub struct ProviderRule {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Capabilities {
     pub native_tools: bool,
+    pub message_wire_format: String,
+    pub native_tool_wire_format: String,
     pub defer_loading: bool,
     pub tool_search: Vec<String>,
     pub max_tools: Option<u32>,
@@ -192,6 +341,7 @@ pub struct Capabilities {
     pub audio: bool,
     pub pdf: bool,
     pub files_api_supported: bool,
+    pub file_upload_wire_format: Option<String>,
     pub structured_output: Option<String>,
     pub prefers_xml_scaffolding: bool,
     pub prefers_markdown_scaffolding: bool,
@@ -206,12 +356,18 @@ pub struct Capabilities {
     pub interleaved_thinking_supported: bool,
     pub anthropic_beta_features: Vec<String>,
     pub vision_supported: bool,
+    pub image_url_input_supported: bool,
     pub preserve_thinking: bool,
     pub server_parser: String,
     pub honors_chat_template_kwargs: bool,
     pub requires_completion_tokens: bool,
     pub reasoning_effort_supported: bool,
     pub reasoning_none_supported: bool,
+    pub reasoning_wire_format: Option<String>,
+    pub seed_supported: bool,
+    pub top_k_supported: bool,
+    pub frequency_penalty_supported: bool,
+    pub presence_penalty_supported: bool,
     pub recommended_endpoint: Option<String>,
     pub text_tool_wire_format_supported: bool,
     pub thinking_disable_directive: Option<String>,
@@ -221,6 +377,8 @@ impl Default for Capabilities {
     fn default() -> Self {
         Self {
             native_tools: false,
+            message_wire_format: "openai".to_string(),
+            native_tool_wire_format: "openai".to_string(),
             defer_loading: false,
             tool_search: Vec::new(),
             max_tools: None,
@@ -229,6 +387,7 @@ impl Default for Capabilities {
             audio: false,
             pdf: false,
             files_api_supported: false,
+            file_upload_wire_format: None,
             structured_output: None,
             prefers_xml_scaffolding: false,
             prefers_markdown_scaffolding: false,
@@ -242,12 +401,18 @@ impl Default for Capabilities {
             interleaved_thinking_supported: false,
             anthropic_beta_features: Vec::new(),
             vision_supported: false,
+            image_url_input_supported: true,
             preserve_thinking: false,
             server_parser: "none".to_string(),
             honors_chat_template_kwargs: false,
             requires_completion_tokens: false,
             reasoning_effort_supported: false,
             reasoning_none_supported: false,
+            reasoning_wire_format: None,
+            seed_supported: true,
+            top_k_supported: true,
+            frequency_penalty_supported: true,
+            presence_penalty_supported: true,
             recommended_endpoint: None,
             text_tool_wire_format_supported: true,
             thinking_disable_directive: None,
@@ -424,12 +589,23 @@ fn lookup_with(
     // Special case: mock spoofs either shape. Try anthropic first
     // (Claude-shape model strings) so `mock` + `claude-opus-4-7`
     // resolves to the Anthropic capability row — the same behaviour
-    // the hardcoded dispatch gave before this refactor.
+    // the hardcoded dispatch gave before this refactor. The native
+    // tool-definition wire shape is pinned to OpenAI so existing
+    // mock-based tests keep observing `t.function.name` regardless of
+    // which family's capability row matched; per-message wire format
+    // still tracks the matched family so Anthropic-specific request
+    // plumbing (beta headers, file-id passthrough) is exercised when
+    // a Claude model is mocked.
     if provider == "mock" {
-        if let Some(caps) = try_match_layer(user, builtin, "anthropic", model, provider) {
+        let anthropic_defaults = merged_provider_defaults(user, builtin, "anthropic");
+        if let Some(mut caps) =
+            try_match_layer(user, builtin, "anthropic", model, &anthropic_defaults)
+        {
+            caps.native_tool_wire_format = "openai".to_string();
             return caps;
         }
-        if let Some(caps) = try_match_layer(user, builtin, "openai", model, provider) {
+        let openai_defaults = merged_provider_defaults(user, builtin, "openai");
+        if let Some(caps) = try_match_layer(user, builtin, "openai", model, &openai_defaults) {
             return caps;
         }
         return Capabilities::default();
@@ -438,9 +614,16 @@ fn lookup_with(
     // Normal chain: walk provider → family(provider) → ... with a
     // visited-guard to avoid cycles in malformed user overrides.
     let mut current = provider.to_string();
+    let mut effective_defaults = ProviderDefaults::default();
     let mut visited: std::collections::HashSet<String> = std::collections::HashSet::new();
     while visited.insert(current.clone()) {
-        if let Some(caps) = try_match_layer(user, builtin, &current, model, provider) {
+        let layer_defaults = merged_provider_defaults(user, builtin, &current);
+        if effective_defaults.has_any_field() {
+            effective_defaults.fill_missing_from(&layer_defaults);
+        } else {
+            effective_defaults.overlay(&layer_defaults);
+        }
+        if let Some(caps) = try_match_layer(user, builtin, &current, model, &effective_defaults) {
             return caps;
         }
         let next = user
@@ -451,6 +634,9 @@ fn lookup_with(
             Some(parent) => current = parent,
             None => break,
         }
+    }
+    if effective_defaults.has_any_field() {
+        return defaults_to_caps(&effective_defaults);
     }
     Capabilities::default()
 }
@@ -463,13 +649,13 @@ fn try_match_layer(
     builtin: &CapabilitiesFile,
     layer_provider: &str,
     model: &str,
-    _original_provider: &str,
+    defaults: &ProviderDefaults,
 ) -> Option<Capabilities> {
     if let Some(user) = user {
         if let Some(rules) = user.provider.get(layer_provider) {
             for rule in rules {
                 if rule_matches(rule, model) {
-                    return Some(rule_to_caps(rule));
+                    return Some(rule_to_caps(rule, defaults));
                 }
             }
         }
@@ -477,17 +663,92 @@ fn try_match_layer(
     if let Some(rules) = builtin.provider.get(layer_provider) {
         for rule in rules {
             if rule_matches(rule, model) {
-                return Some(rule_to_caps(rule));
+                return Some(rule_to_caps(rule, defaults));
             }
         }
     }
     None
 }
 
-fn rule_to_caps(rule: &ProviderRule) -> Capabilities {
+fn merged_provider_defaults(
+    user: Option<&CapabilitiesFile>,
+    builtin: &CapabilitiesFile,
+    provider: &str,
+) -> ProviderDefaults {
+    let mut defaults = builtin
+        .provider_defaults
+        .get(provider)
+        .cloned()
+        .unwrap_or_default();
+    if let Some(user_defaults) = user.and_then(|file| file.provider_defaults.get(provider)) {
+        defaults.overlay(user_defaults);
+    }
+    defaults
+}
+
+fn defaults_to_caps(defaults: &ProviderDefaults) -> Capabilities {
+    let empty = ProviderRule {
+        model_match: "*".to_string(),
+        version_min: None,
+        native_tools: None,
+        message_wire_format: None,
+        native_tool_wire_format: None,
+        defer_loading: None,
+        tool_search: None,
+        max_tools: None,
+        prompt_caching: None,
+        vision: None,
+        audio: None,
+        pdf: None,
+        files_api_supported: None,
+        file_upload_wire_format: None,
+        structured_output: None,
+        prefers_xml_scaffolding: None,
+        prefers_markdown_scaffolding: None,
+        structured_output_mode: None,
+        supports_assistant_prefill: None,
+        prefers_role_developer: None,
+        prefers_xml_tools: None,
+        thinking_block_style: None,
+        json_schema: None,
+        thinking_modes: None,
+        interleaved_thinking_supported: None,
+        anthropic_beta_features: None,
+        thinking: None,
+        vision_supported: None,
+        image_url_input_supported: None,
+        preserve_thinking: None,
+        server_parser: None,
+        honors_chat_template_kwargs: None,
+        requires_completion_tokens: None,
+        reasoning_effort_supported: None,
+        reasoning_none_supported: None,
+        reasoning_wire_format: None,
+        seed_supported: None,
+        top_k_supported: None,
+        frequency_penalty_supported: None,
+        presence_penalty_supported: None,
+        recommended_endpoint: None,
+        text_tool_wire_format_supported: None,
+        thinking_disable_directive: None,
+    };
+    rule_to_caps(&empty, defaults)
+}
+
+fn rule_to_caps(rule: &ProviderRule, defaults: &ProviderDefaults) -> Capabilities {
     let thinking_modes = rule_thinking_modes(rule);
     Capabilities {
         native_tools: rule.native_tools.unwrap_or(false),
+        message_wire_format: rule
+            .message_wire_format
+            .clone()
+            .or_else(|| defaults.message_wire_format.clone())
+            .unwrap_or_else(|| "openai".to_string()),
+        native_tool_wire_format: rule
+            .native_tool_wire_format
+            .clone()
+            .or_else(|| defaults.native_tool_wire_format.clone())
+            .unwrap_or_else(|| "openai".to_string()),
         defer_loading: rule.defer_loading.unwrap_or(false),
         tool_search: rule.tool_search.clone().unwrap_or_default(),
         max_tools: rule.max_tools,
@@ -495,7 +756,14 @@ fn rule_to_caps(rule: &ProviderRule) -> Capabilities {
         vision: rule_vision(rule),
         audio: rule.audio.unwrap_or(false),
         pdf: rule.pdf.unwrap_or(false),
-        files_api_supported: rule.files_api_supported.unwrap_or(false),
+        files_api_supported: rule
+            .files_api_supported
+            .or(defaults.files_api_supported)
+            .unwrap_or(false),
+        file_upload_wire_format: rule
+            .file_upload_wire_format
+            .clone()
+            .or_else(|| defaults.file_upload_wire_format.clone()),
         structured_output: rule_structured_output(rule),
         prefers_xml_scaffolding: rule.prefers_xml_scaffolding.unwrap_or(false),
         prefers_markdown_scaffolding: rule.prefers_markdown_scaffolding.unwrap_or(false),
@@ -511,6 +779,10 @@ fn rule_to_caps(rule: &ProviderRule) -> Capabilities {
         interleaved_thinking_supported: rule.interleaved_thinking_supported.unwrap_or(false),
         anthropic_beta_features: rule.anthropic_beta_features.clone().unwrap_or_default(),
         vision_supported: rule.vision_supported.unwrap_or(false),
+        image_url_input_supported: rule
+            .image_url_input_supported
+            .or(defaults.image_url_input_supported)
+            .unwrap_or(true),
         preserve_thinking: rule.preserve_thinking.unwrap_or(false),
         server_parser: rule
             .server_parser
@@ -520,6 +792,26 @@ fn rule_to_caps(rule: &ProviderRule) -> Capabilities {
         requires_completion_tokens: rule.requires_completion_tokens.unwrap_or(false),
         reasoning_effort_supported: rule.reasoning_effort_supported.unwrap_or(false),
         reasoning_none_supported: rule.reasoning_none_supported.unwrap_or(false),
+        reasoning_wire_format: rule
+            .reasoning_wire_format
+            .clone()
+            .or_else(|| defaults.reasoning_wire_format.clone()),
+        seed_supported: rule
+            .seed_supported
+            .or(defaults.seed_supported)
+            .unwrap_or(true),
+        top_k_supported: rule
+            .top_k_supported
+            .or(defaults.top_k_supported)
+            .unwrap_or(true),
+        frequency_penalty_supported: rule
+            .frequency_penalty_supported
+            .or(defaults.frequency_penalty_supported)
+            .unwrap_or(true),
+        presence_penalty_supported: rule
+            .presence_penalty_supported
+            .or(defaults.presence_penalty_supported)
+            .unwrap_or(true),
         recommended_endpoint: rule.recommended_endpoint.clone(),
         text_tool_wire_format_supported: rule.text_tool_wire_format_supported.unwrap_or(true),
         thinking_disable_directive: rule.thinking_disable_directive.clone(),
@@ -802,6 +1094,17 @@ anthropic_beta_features = ["fine-grained-tool-streaming-2025-05-14"]
         let caps = lookup("openrouter", "gpt-5.4");
         assert!(caps.defer_loading);
         assert_eq!(caps.tool_search, vec!["hosted", "client"]);
+        assert_eq!(caps.reasoning_wire_format.as_deref(), Some("openrouter"));
+        assert!(!caps.top_k_supported);
+    }
+
+    #[test]
+    fn bedrock_claude_uses_anthropic_wire_capabilities() {
+        reset();
+        let caps = lookup("bedrock", "anthropic.claude-3-5-sonnet-20240620-v1:0");
+        assert!(caps.native_tools);
+        assert_eq!(caps.message_wire_format, "anthropic");
+        assert_eq!(caps.native_tool_wire_format, "anthropic");
     }
 
     #[test]

--- a/crates/harn-vm/src/llm/capabilities.toml
+++ b/crates/harn-vm/src/llm/capabilities.toml
@@ -22,6 +22,10 @@
 #   model_match     : glob pattern matched against the lowercased model ID.
 #   version_min     : [major, minor] lower bound, provider-aware parse.
 #   native_tools    : whether the model accepts native tool-call wire shape.
+#   message_wire_format:
+#                     shared helper wire format: openai, anthropic, or ollama.
+#   native_tool_wire_format:
+#                     native tool definition shape: openai or anthropic.
 #   defer_loading   : whether `defer_loading: true` is honored on tool defs.
 #   tool_search     : list of native tool-search variants, preferred first.
 #                     Anthropic = ["bm25", "regex"];
@@ -34,6 +38,8 @@
 #   pdf_supported   : whether Harn can send PDF/document input blocks on this route.
 #   files_api_supported:
 #                     whether file_id references from std/files::upload are accepted.
+#   file_upload_wire_format:
+#                     file-upload API family for std/files.upload: anthropic or gemini.
 #   structured_output: structured-output transport: native, tool_use, format_kw, none.
 #   prefers_xml_scaffolding:
 #                     logical prompt sections render as XML tags.
@@ -58,12 +64,17 @@
 #                     unconditional Anthropic beta feature names to request
 #                     for this route.
 #   vision_supported: whether image content blocks are accepted.
+#   image_url_input_supported:
+#                     whether image content blocks may reference remote URLs.
 #   preserve_thinking: whether prior <think> blocks should be carried forward.
 #   server_parser   : server-side response parser that transforms model output.
 #   honors_chat_template_kwargs: whether chat_template_kwargs are honored.
 #   requires_completion_tokens: whether to send max_completion_tokens instead of max_tokens.
 #   reasoning_effort_supported: whether reasoning_effort is accepted.
 #   reasoning_none_supported: whether reasoning_effort="none" is accepted.
+#   reasoning_wire_format:
+#                     OpenAI-compatible non-standard reasoning transport:
+#                     openrouter or enabled.
 #   recommended_endpoint: preferred endpoint family for this route.
 #   text_tool_wire_format_supported: whether Harn text tool calls survive.
 #   thinking_disable_directive:
@@ -73,6 +84,41 @@
 #                     whenever the resolved `thinking` config is `Disabled`,
 #                     so script authors don't need to know provider-specific
 #                     prompt directives. Idempotent — never injected twice.
+
+[provider_defaults.anthropic]
+message_wire_format = "anthropic"
+native_tool_wire_format = "anthropic"
+file_upload_wire_format = "anthropic"
+files_api_supported = true
+seed_supported = false
+frequency_penalty_supported = false
+presence_penalty_supported = false
+
+[provider_defaults.openai]
+top_k_supported = false
+
+[provider_defaults.openrouter]
+reasoning_wire_format = "openrouter"
+top_k_supported = false
+
+[provider_defaults.huggingface]
+top_k_supported = false
+
+[provider_defaults.local]
+top_k_supported = false
+
+[provider_defaults.together]
+reasoning_wire_format = "enabled"
+
+[provider_defaults.ollama]
+message_wire_format = "ollama"
+image_url_input_supported = false
+frequency_penalty_supported = false
+presence_penalty_supported = false
+
+[provider_defaults.gemini]
+file_upload_wire_format = "gemini"
+files_api_supported = true
 
 # ---------- Anthropic (Claude) ------------------------------------------------
 
@@ -1137,6 +1183,14 @@ structured_output_mode = "native_json"
 # Amazon, Mistral, and other Bedrock-hosted model families. Tool-search and
 # prompt-cache semantics remain provider/model-specific, so don't advertise
 # those through the generic Bedrock route yet.
+[[provider.bedrock]]
+model_match = "anthropic.claude-*"
+native_tools = true
+message_wire_format = "anthropic"
+native_tool_wire_format = "anthropic"
+recommended_endpoint = "/model/{model}/converse"
+text_tool_wire_format_supported = true
+
 [[provider.bedrock]]
 model_match = "*"
 native_tools = true

--- a/crates/harn-vm/src/llm/config_builtins.rs
+++ b/crates/harn-vm/src/llm/config_builtins.rs
@@ -679,6 +679,14 @@ pub(crate) fn capabilities_to_vm_value(
     );
     dict.insert("native_tools".to_string(), VmValue::Bool(caps.native_tools));
     dict.insert(
+        "message_wire_format".to_string(),
+        VmValue::String(Rc::from(caps.message_wire_format.clone())),
+    );
+    dict.insert(
+        "native_tool_wire_format".to_string(),
+        VmValue::String(Rc::from(caps.native_tool_wire_format.clone())),
+    );
+    dict.insert(
         "text_tool_wire_format_supported".to_string(),
         VmValue::Bool(caps.text_tool_wire_format_supported),
     );
@@ -731,6 +739,13 @@ pub(crate) fn capabilities_to_vm_value(
     dict.insert(
         "files_api_supported".to_string(),
         VmValue::Bool(caps.files_api_supported),
+    );
+    dict.insert(
+        "file_upload_wire_format".to_string(),
+        caps.file_upload_wire_format
+            .as_ref()
+            .map(|value| VmValue::String(Rc::from(value.clone())))
+            .unwrap_or(VmValue::Nil),
     );
     dict.insert(
         "structured_output".to_string(),
@@ -789,6 +804,29 @@ pub(crate) fn capabilities_to_vm_value(
     dict.insert(
         "reasoning_none_supported".to_string(),
         VmValue::Bool(caps.reasoning_none_supported),
+    );
+    dict.insert(
+        "reasoning_wire_format".to_string(),
+        caps.reasoning_wire_format
+            .as_ref()
+            .map(|value| VmValue::String(Rc::from(value.clone())))
+            .unwrap_or(VmValue::Nil),
+    );
+    dict.insert(
+        "seed_supported".to_string(),
+        VmValue::Bool(caps.seed_supported),
+    );
+    dict.insert(
+        "top_k_supported".to_string(),
+        VmValue::Bool(caps.top_k_supported),
+    );
+    dict.insert(
+        "frequency_penalty_supported".to_string(),
+        VmValue::Bool(caps.frequency_penalty_supported),
+    );
+    dict.insert(
+        "presence_penalty_supported".to_string(),
+        VmValue::Bool(caps.presence_penalty_supported),
     );
     VmValue::Dict(Rc::new(dict))
 }

--- a/crates/harn-vm/src/llm/helpers/options.rs
+++ b/crates/harn-vm/src/llm/helpers/options.rs
@@ -399,24 +399,12 @@ fn provider_overrides_force_native(
 }
 
 /// Decide which wire shape this (provider, model) pair should emit for
-/// the native tool-search meta-tool. Anthropic + Claude → Anthropic
-/// shape; anything else → OpenAI shape. For `provider: "mock"` we
-/// inspect the model string so conformance tests can spoof either
-/// backend without HTTP.
+/// the native tool-search meta-tool.
 fn classify_native_shape(
     provider: &str,
     model: &str,
 ) -> crate::llm::provider::NativeToolSearchShape {
-    use crate::llm::provider::NativeToolSearchShape;
-    if provider == "anthropic" {
-        return NativeToolSearchShape::Anthropic;
-    }
-    if provider == "mock"
-        && crate::llm::providers::anthropic::claude_model_supports_tool_search(model)
-    {
-        return NativeToolSearchShape::Anthropic;
-    }
-    NativeToolSearchShape::OpenAi
+    crate::llm::provider::provider_native_tool_search_shape(provider, model)
 }
 
 fn parse_schema_value(
@@ -1068,10 +1056,7 @@ pub(crate) fn extract_llm_options(
     if enforce_capability_gates && uses_file_ids && !caps.files_api_supported {
         return Err(unsupported_option_error("files_api", &provider, &model));
     }
-    if uses_file_ids
-        && (provider == "anthropic"
-            || (provider == "mock" && model.to_lowercase().contains("claude")))
-    {
+    if uses_file_ids && caps.message_wire_format == "anthropic" {
         crate::llm::api::push_unique_anthropic_beta_feature(
             &mut anthropic_beta_features,
             crate::stdlib::files::ANTHROPIC_FILES_API_BETA,
@@ -1081,11 +1066,11 @@ pub(crate) fn extract_llm_options(
         return Err(unsupported_option_error("cache", &provider, &model));
     }
     if vision
-        && provider == "ollama"
+        && !crate::llm::provider::provider_supports_image_urls(&provider, &model)
         && crate::llm::content::messages_contain_url_images(&messages)?
     {
         return Err(VmError::Thrown(VmValue::String(std::rc::Rc::from(
-            "llm_call: provider \"ollama\" requires image base64; url image content is not supported",
+            "llm_call: this provider/model route requires image base64; url image content is not supported",
         ))));
     }
 
@@ -1104,7 +1089,7 @@ pub(crate) fn extract_llm_options(
         return Err(unsupported_option_error("tools", &provider, &model));
     }
     let mut native_tools = if let Some(tools) = &tools_val {
-        Some(vm_tools_to_native(tools, &provider)?)
+        Some(vm_tools_to_native(tools, &provider, &model)?)
     } else {
         None
     };
@@ -1785,54 +1770,31 @@ pub(crate) fn opt_str_list(
 
 /// Emit warnings for options not supported by the target provider.
 fn validate_options(opts: &crate::llm::api::LlmCallOptions) {
-    let p = opts.provider.as_str();
+    let caps = crate::llm::capabilities::lookup(&opts.provider, &opts.model);
     let warn = |param: &str| {
         crate::events::log_warn(
             "llm",
-            &format!("\"{param}\" is not supported by provider \"{p}\", ignoring"),
+            &format!(
+                "\"{param}\" is not supported by provider \"{}\" model \"{}\", ignoring",
+                opts.provider, opts.model
+            ),
         );
     };
 
-    match p {
-        "anthropic" => {
-            if opts.seed.is_some() {
-                warn("seed");
-            }
-            if opts.frequency_penalty.is_some() {
-                warn("frequency_penalty");
-            }
-            if opts.presence_penalty.is_some() {
-                warn("presence_penalty");
-            }
-        }
-        "openai" | "huggingface" | "local" => {
-            if opts.top_k.is_some() {
-                warn("top_k");
-            }
-            if opts.cache {
-                warn("cache");
-            }
-        }
-        "openrouter" => {
-            if opts.top_k.is_some() {
-                warn("top_k");
-            }
-            if opts.cache {
-                warn("cache");
-            }
-        }
-        "ollama" => {
-            if opts.frequency_penalty.is_some() {
-                warn("frequency_penalty");
-            }
-            if opts.presence_penalty.is_some() {
-                warn("presence_penalty");
-            }
-            if opts.cache {
-                warn("cache");
-            }
-        }
-        _ => {}
+    if opts.seed.is_some() && !caps.seed_supported {
+        warn("seed");
+    }
+    if opts.top_k.is_some() && !caps.top_k_supported {
+        warn("top_k");
+    }
+    if opts.frequency_penalty.is_some() && !caps.frequency_penalty_supported {
+        warn("frequency_penalty");
+    }
+    if opts.presence_penalty.is_some() && !caps.presence_penalty_supported {
+        warn("presence_penalty");
+    }
+    if opts.cache && !caps.prompt_caching {
+        warn("cache");
     }
 }
 

--- a/crates/harn-vm/src/llm/helpers/provider.rs
+++ b/crates/harn-vm/src/llm/helpers/provider.rs
@@ -444,7 +444,6 @@ pub fn resolve_api_key(provider: &str) -> Result<String, VmError> {
 
 pub(crate) struct ResolvedProvider {
     pub pdef: Option<crate::llm_config::ProviderDef>,
-    pub is_anthropic_style: bool,
     pub base_url: String,
     pub endpoint: String,
 }
@@ -455,7 +454,9 @@ impl ResolvedProvider {
         let is_anthropic_style = pdef
             .as_ref()
             .map(|p| p.chat_endpoint.contains("/messages"))
-            .unwrap_or(provider == "anthropic");
+            .unwrap_or_else(|| {
+                crate::llm::capabilities::lookup(provider, "").message_wire_format == "anthropic"
+            });
         let (default_base, default_endpoint) = if is_anthropic_style {
             ("https://api.anthropic.com/v1", "/messages")
         } else {
@@ -471,7 +472,6 @@ impl ResolvedProvider {
             .unwrap_or_else(|| default_endpoint.to_string());
         ResolvedProvider {
             pdef,
-            is_anthropic_style,
             base_url,
             endpoint,
         }

--- a/crates/harn-vm/src/llm/provider.rs
+++ b/crates/harn-vm/src/llm/provider.rs
@@ -245,6 +245,34 @@ pub(crate) fn provider_tool_search_variants(provider: &str, model: &str) -> Vec<
     super::capabilities::lookup(provider, model).tool_search
 }
 
+/// Shared helper message/request/response wire format. This is a model
+/// capability rather than a provider-name check so mock/proxy routes can
+/// exercise the same behavior as the hosted model family they emulate.
+pub(crate) fn provider_uses_anthropic_messages(provider: &str, model: &str) -> bool {
+    super::capabilities::lookup(provider, model).message_wire_format == "anthropic"
+}
+
+/// Whether shared helpers should use Ollama's chat message quirks.
+pub(crate) fn provider_uses_ollama_messages(provider: &str, model: &str) -> bool {
+    super::capabilities::lookup(provider, model).message_wire_format == "ollama"
+}
+
+/// Whether native tool definitions should use Anthropic's `input_schema`
+/// shape instead of OpenAI-compatible `function.parameters`.
+pub(crate) fn provider_uses_anthropic_native_tools(provider: &str, model: &str) -> bool {
+    super::capabilities::lookup(provider, model).native_tool_wire_format == "anthropic"
+}
+
+/// Whether image content blocks may contain remote URLs for this route.
+pub(crate) fn provider_supports_image_urls(provider: &str, model: &str) -> bool {
+    super::capabilities::lookup(provider, model).image_url_input_supported
+}
+
+/// File upload API family for `std/files.upload`, when supported.
+pub(crate) fn provider_file_upload_wire_format(provider: &str) -> Option<String> {
+    super::capabilities::lookup(provider, "").file_upload_wire_format
+}
+
 /// Module-level dispatch for `LlmProvider::supports_thinking`.
 #[allow(dead_code)]
 pub(crate) fn provider_thinking_modes(provider: &str, model: &str) -> Vec<String> {
@@ -262,4 +290,22 @@ pub(crate) enum NativeToolSearchShape {
     Anthropic,
     /// OpenAI Responses API's `{"type": "tool_search"}`.
     OpenAi,
+}
+
+/// Native tool-search meta-tool shape, derived from capability flags.
+pub(crate) fn provider_native_tool_search_shape(
+    provider: &str,
+    model: &str,
+) -> NativeToolSearchShape {
+    let caps = super::capabilities::lookup(provider, model);
+    if caps.native_tool_wire_format == "anthropic"
+        || caps
+            .tool_search
+            .iter()
+            .any(|variant| variant == "bm25" || variant == "regex")
+    {
+        NativeToolSearchShape::Anthropic
+    } else {
+        NativeToolSearchShape::OpenAi
+    }
 }

--- a/crates/harn-vm/src/llm/providers/anthropic.rs
+++ b/crates/harn-vm/src/llm/providers/anthropic.rs
@@ -100,6 +100,7 @@ fn model_supports_anthropic_prefill(model: &str) -> bool {
 /// server-side tools and the `defer_loading: true` flag on tool definitions.
 /// Per Anthropic's tool-search docs: Claude Mythos Preview, Sonnet 4.0+,
 /// Opus 4.0+, Haiku 4.5+.
+#[allow(dead_code)]
 pub(crate) fn claude_model_supports_tool_search(model: &str) -> bool {
     let lower = model.to_lowercase();
     match claude_generation(&lower) {

--- a/crates/harn-vm/src/llm/providers/azure_openai.rs
+++ b/crates/harn-vm/src/llm/providers/azure_openai.rs
@@ -119,12 +119,11 @@ impl AzureOpenAiProvider {
             .json()
             .await
             .map_err(|error| vm_err(format!("azure_openai response parse error: {error}")))?;
-        let resolved = crate::llm::helpers::ResolvedProvider::resolve("openai");
         let result = crate::llm::api::parse_llm_response_for_provider(
             &json,
             "azure_openai",
             &request.model,
-            &resolved,
+            false,
         )?;
         maybe_emit_delta(delta_tx, &result.text);
         Ok(result)

--- a/crates/harn-vm/src/llm/providers/openai_compat.rs
+++ b/crates/harn-vm/src/llm/providers/openai_compat.rs
@@ -96,13 +96,16 @@ impl LlmProvider for OpenAiCompatibleProvider {
         &self.provider_name
     }
 
-    /// Apply provider-specific request body transformations. For OpenRouter,
-    /// strip the `chat_template_kwargs` thinking field since OpenRouter does
-    /// not reliably support it.
+    /// Apply provider-specific request body transformations.
     fn transform_request(&self, body: &mut serde_json::Value) {
-        if self.provider_name.to_lowercase().contains("openrouter") {
-            if let Some(obj) = body.as_object_mut() {
-                obj.remove("chat_template_kwargs");
+        let model = body
+            .get("model")
+            .and_then(|value| value.as_str())
+            .unwrap_or("");
+        let caps = crate::llm::capabilities::lookup(&self.provider_name, model);
+        if !caps.honors_chat_template_kwargs {
+            if let Some(object) = body.as_object_mut() {
+                object.remove("chat_template_kwargs");
             }
         }
     }
@@ -190,22 +193,24 @@ impl OpenAiCompatibleProvider {
         if let Some(pp) = opts.presence_penalty {
             body["presence_penalty"] = serde_json::json!(pp);
         }
-        if opts.provider == "openrouter" {
-            if let Some(reasoning) = openrouter_reasoning_config(&opts.thinking) {
-                body["reasoning"] = reasoning;
-            }
-        } else {
-            if opts.provider == "together" && !caps.honors_chat_template_kwargs {
-                if let Some(reasoning) = together_reasoning_config(&opts.thinking, &caps) {
+        match caps.reasoning_wire_format.as_deref() {
+            Some("openrouter") => {
+                if let Some(reasoning) = openrouter_reasoning_config(&opts.thinking) {
                     body["reasoning"] = reasoning;
                 }
             }
-            if caps.reasoning_effort_supported {
-                if let ThinkingConfig::Effort { level } = &opts.thinking {
-                    if *level != crate::llm::api::ReasoningEffort::None || opts.provider == "openai"
-                    {
-                        body["reasoning_effort"] = serde_json::json!(level.as_str());
-                    }
+            Some("enabled") => {
+                if let Some(reasoning) = enabled_reasoning_config(&opts.thinking, &caps) {
+                    body["reasoning"] = reasoning;
+                }
+            }
+            _ => {}
+        }
+        if caps.reasoning_effort_supported {
+            if let ThinkingConfig::Effort { level } = &opts.thinking {
+                if *level != crate::llm::api::ReasoningEffort::None || caps.reasoning_none_supported
+                {
+                    body["reasoning_effort"] = serde_json::json!(level.as_str());
                 }
             }
         }
@@ -301,7 +306,7 @@ fn openrouter_reasoning_config(thinking: &ThinkingConfig) -> Option<serde_json::
     }
 }
 
-fn together_reasoning_config(
+fn enabled_reasoning_config(
     thinking: &ThinkingConfig,
     caps: &crate::llm::capabilities::Capabilities,
 ) -> Option<serde_json::Value> {
@@ -461,6 +466,45 @@ mod tests {
             "Qwen3.6 should request preserve_thinking so <think> blocks survive across agentic turns"
         );
         assert_eq!(body["chat_template_kwargs"]["enable_thinking"], true);
+    }
+
+    #[test]
+    fn transform_request_preserves_chat_template_kwargs_when_capability_allows() {
+        crate::llm::capabilities::set_user_overrides_toml(
+            r#"
+[[provider.openrouter]]
+model_match = "custom-qwen"
+honors_chat_template_kwargs = true
+thinking_modes = ["enabled"]
+"#,
+        )
+        .expect("capability override");
+        let provider = OpenAiCompatibleProvider::new("openrouter".to_string());
+        let mut payload = base_request_payload();
+        payload.model = "custom-qwen".to_string();
+        payload.thinking = ThinkingConfig::Enabled {
+            budget_tokens: None,
+        };
+        let mut body = OpenAiCompatibleProvider::build_request_body(&payload, false);
+        assert!(body.get("chat_template_kwargs").is_some());
+
+        provider.transform_request(&mut body);
+
+        assert!(body.get("chat_template_kwargs").is_some());
+        crate::llm::capabilities::clear_user_overrides();
+    }
+
+    #[test]
+    fn transform_request_strips_chat_template_kwargs_when_capability_denies() {
+        let provider = OpenAiCompatibleProvider::new("acme".to_string());
+        let mut body = json!({
+            "model": "custom-qwen",
+            "chat_template_kwargs": {"enable_thinking": true},
+        });
+
+        provider.transform_request(&mut body);
+
+        assert!(body.get("chat_template_kwargs").is_none());
     }
 
     #[test]

--- a/crates/harn-vm/src/llm/stream.rs
+++ b/crates/harn-vm/src/llm/stream.rs
@@ -17,8 +17,9 @@ pub(crate) async fn vm_stream_llm(
     let client = super::shared_streaming_client().clone();
 
     let resolved = ResolvedProvider::resolve(provider);
+    let is_anthropic = super::provider::provider_uses_anthropic_messages(provider, &opts.model);
 
-    let body = if resolved.is_anthropic_style {
+    let body = if is_anthropic {
         let mut body = serde_json::json!({
             "model": opts.model,
             "messages": opts.messages,
@@ -102,7 +103,7 @@ pub(crate) async fn vm_stream_llm(
                 if msg.data == "[DONE]" {
                     break;
                 }
-                let chunk_text = if resolved.is_anthropic_style {
+                let chunk_text = if is_anthropic {
                     parse_anthropic_sse_chunk(&msg.data)
                 } else {
                     parse_openai_sse_chunk(&msg.data)

--- a/crates/harn-vm/src/llm/tool_conformance.rs
+++ b/crates/harn-vm/src/llm/tool_conformance.rs
@@ -591,7 +591,7 @@ fn probe_request_body(provider: &str, model: &str, mode: ToolProbeMode, marker: 
         "stream": mode == ToolProbeMode::Streaming,
         "temperature": 0,
     });
-    if provider != "ollama" {
+    if !crate::llm::provider::provider_uses_ollama_messages(provider, model) {
         body["tool_choice"] = json!({
             "type": "function",
             "function": {"name": TOOL_PROBE_TOOL_NAME}

--- a/crates/harn-vm/src/llm/tools/messages.rs
+++ b/crates/harn-vm/src/llm/tools/messages.rs
@@ -6,10 +6,10 @@ pub(crate) fn build_assistant_tool_message(
     text: &str,
     tool_calls: &[serde_json::Value],
     provider: &str,
+    model: &str,
 ) -> serde_json::Value {
-    let resolved = super::super::helpers::ResolvedProvider::resolve(provider);
-    let is_anthropic = resolved.is_anthropic_style;
-    let is_ollama = provider == "ollama" || resolved.endpoint.contains("/api/chat");
+    let is_anthropic = super::super::provider::provider_uses_anthropic_messages(provider, model);
+    let is_ollama = super::super::provider::provider_uses_ollama_messages(provider, model);
     if is_anthropic {
         // Anthropic format: content blocks with text and tool_use
         let mut content = Vec::new();
@@ -83,9 +83,10 @@ pub(crate) fn build_assistant_response_message(
     tool_calls: &[serde_json::Value],
     reasoning: Option<&str>,
     provider: &str,
+    model: &str,
 ) -> serde_json::Value {
     let mut message = if !tool_calls.is_empty() {
-        build_assistant_tool_message(text, tool_calls, provider)
+        build_assistant_tool_message(text, tool_calls, provider, model)
     } else if !blocks.is_empty() {
         serde_json::json!({
             "role": "assistant",

--- a/crates/harn-vm/src/llm/tools/mod.rs
+++ b/crates/harn-vm/src/llm/tools/mod.rs
@@ -15,8 +15,6 @@ pub(crate) use handle_local::{handle_tool_locally, is_vm_stdlib_short_circuit};
 #[cfg(test)]
 pub(crate) use messages::build_assistant_tool_message;
 pub(crate) use messages::{build_assistant_response_message, normalize_tool_args};
-#[cfg(test)]
-pub(crate) use native::apply_tool_search_native_injection;
 pub(crate) use native::{
     apply_tool_search_native_injection_typed, extract_deferred_tool_names, vm_tools_to_native,
 };

--- a/crates/harn-vm/src/llm/tools/native.rs
+++ b/crates/harn-vm/src/llm/tools/native.rs
@@ -6,6 +6,7 @@ use crate::value::{VmError, VmValue};
 pub(crate) fn vm_tools_to_native(
     tools_val: &VmValue,
     provider: &str,
+    model: &str,
 ) -> Result<Vec<serde_json::Value>, VmError> {
     // Accept either a tool_registry dict or a list of tool dicts.
     let tools_list = match tools_val {
@@ -48,12 +49,7 @@ pub(crate) fn vm_tools_to_native(
 
                 let input_schema = vm_build_json_schema(params);
 
-                // API style (not provider name) determines schema shape:
-                // Anthropic = {name, description, input_schema};
-                // OpenAI-compat = {type: "function", function: {...}}.
-                let is_anthropic =
-                    super::super::helpers::ResolvedProvider::resolve(provider).is_anthropic_style;
-                if is_anthropic {
+                if super::super::provider::provider_uses_anthropic_native_tools(provider, model) {
                     let mut tool_json = serde_json::json!({
                         "name": name,
                         "description": description,
@@ -165,23 +161,6 @@ pub(crate) fn extract_deferred_tool_names(native_tools: &[serde_json::Value]) ->
 /// No-ops if `native_tools` is `None` (no tools passed = no search to
 /// do). The meta-tool itself never has `defer_loading` — that's a hard
 /// requirement of Anthropic's API and we match it here.
-#[cfg(test)]
-pub(crate) fn apply_tool_search_native_injection(
-    native_tools: &mut Option<Vec<serde_json::Value>>,
-    provider: &str,
-    variant: &str,
-) {
-    // Back-compat entry for existing unit tests: pick the shape by
-    // provider name alone. The canonical call site (options.rs) uses the
-    // model-aware helper below.
-    let shape = if provider == "anthropic" {
-        super::super::provider::NativeToolSearchShape::Anthropic
-    } else {
-        super::super::provider::NativeToolSearchShape::OpenAi
-    };
-    apply_tool_search_native_injection_typed(native_tools, shape, variant, "hosted");
-}
-
 /// Native tool-search injection with an explicit wire shape + OpenAI
 /// execution mode. `mode` is `"hosted"` or `"client"`; it only affects
 /// the OpenAI Responses-API shape (Anthropic's server always runs the

--- a/crates/harn-vm/src/llm/tools/tests/heredoc_and_messages.rs
+++ b/crates/harn-vm/src/llm/tools/tests/heredoc_and_messages.rs
@@ -635,6 +635,7 @@ fn assistant_tool_message_includes_empty_content_for_openai_style() {
             "arguments": {"path": "main.rs"},
         })],
         "together",
+        "moonshotai/Kimi-K2.5",
     );
 
     assert_eq!(message["role"], "assistant");
@@ -652,6 +653,7 @@ fn assistant_tool_message_stringifies_ollama_arguments() {
             "arguments": {"path": "main.rs"},
         })],
         "ollama",
+        "qwen3.6:35b-a3b-coding-nvfp4",
     );
 
     assert_eq!(message["role"], "assistant");
@@ -668,6 +670,25 @@ fn assistant_tool_message_stringifies_ollama_arguments() {
 }
 
 #[test]
+fn assistant_tool_message_uses_model_capability_shape_for_bedrock_claude() {
+    let message = build_assistant_tool_message(
+        "using a tool",
+        &[json!({
+            "id": "call_001",
+            "name": "read",
+            "arguments": {"path": "main.rs"},
+        })],
+        "bedrock",
+        "anthropic.claude-3-5-sonnet-20240620-v1:0",
+    );
+
+    assert_eq!(message["role"], "assistant");
+    assert_eq!(message["content"][0]["type"], "text");
+    assert_eq!(message["content"][1]["type"], "tool_use");
+    assert_eq!(message["content"][1]["name"], "read");
+}
+
+#[test]
 fn assistant_response_message_preserves_reasoning() {
     let message = build_assistant_response_message(
         "",
@@ -679,6 +700,7 @@ fn assistant_response_message_preserves_reasoning() {
         })],
         Some("inspect the file before editing"),
         "together",
+        "moonshotai/Kimi-K2.5",
     );
 
     assert_eq!(message["reasoning"], "inspect the file before editing");

--- a/crates/harn-vm/src/llm/tools/tests/mod.rs
+++ b/crates/harn-vm/src/llm/tools/tests/mod.rs
@@ -9,7 +9,7 @@
 //! module. Either way the flat `use super::{…}` below is accurate.
 
 pub(super) use super::{
-    apply_tool_search_native_injection, build_assistant_response_message,
+    apply_tool_search_native_injection_typed, build_assistant_response_message,
     build_assistant_tool_message, collect_tool_schemas, extract_deferred_tool_names,
     normalize_tool_args, parse_bare_calls_in_body, parse_native_json_tool_calls,
     parse_text_tool_calls_with_tools, validate_tool_args, vm_tools_to_native,

--- a/crates/harn-vm/src/llm/tools/tests/native_tools.rs
+++ b/crates/harn-vm/src/llm/tools/tests/native_tools.rs
@@ -1,14 +1,16 @@
 use super::{
-    apply_tool_search_native_injection, defer_loading_registry, extract_deferred_tool_names, json,
-    sample_tool_registry, vm_bool, vm_dict, vm_list, vm_str, vm_tools_to_native,
+    apply_tool_search_native_injection_typed, defer_loading_registry, extract_deferred_tool_names,
+    json, sample_tool_registry, vm_bool, vm_dict, vm_list, vm_str, vm_tools_to_native,
 };
+use crate::llm::provider::NativeToolSearchShape;
 use std::collections::BTreeMap;
 use std::rc::Rc;
 
 #[test]
 fn vm_tools_to_native_emits_defer_loading_for_anthropic() {
     let registry = defer_loading_registry();
-    let tools = vm_tools_to_native(&registry, "anthropic").expect("anthropic native tools");
+    let tools = vm_tools_to_native(&registry, "anthropic", "claude-opus-4-7")
+        .expect("anthropic native tools");
     // Eager `look` tool has no defer_loading key.
     let look = tools
         .iter()
@@ -29,6 +31,24 @@ fn vm_tools_to_native_emits_defer_loading_for_anthropic() {
 }
 
 #[test]
+fn vm_tools_to_native_uses_model_capability_shape_for_bedrock_claude() {
+    let registry = sample_tool_registry();
+    let tools = vm_tools_to_native(
+        &registry,
+        "bedrock",
+        "anthropic.claude-3-5-sonnet-20240620-v1:0",
+    )
+    .expect("bedrock claude native tools");
+
+    assert_eq!(tools[0]["name"].as_str(), Some("edit"));
+    assert!(tools[0].get("input_schema").is_some());
+    assert!(
+        tools[0].get("function").is_none(),
+        "Bedrock-hosted Claude should use Anthropic native tool shape"
+    );
+}
+
+#[test]
 fn vm_tools_to_native_emits_namespace_for_openai_compat() {
     // `namespace` on a tool entry (harn#71) flows through to the
     // OpenAI-shape wrapper alongside `defer_loading`. Anthropic
@@ -45,11 +65,12 @@ fn vm_tools_to_native_emits_namespace_for_openai_compat() {
     ]);
     let registry = vm_list(vec![deferred]);
 
-    let openai = vm_tools_to_native(&registry, "openai").expect("openai native tools");
+    let openai = vm_tools_to_native(&registry, "openai", "gpt-5.4").expect("openai native tools");
     assert_eq!(openai[0]["namespace"].as_str(), Some("ops"));
     assert_eq!(openai[0]["defer_loading"].as_bool(), Some(true));
 
-    let anthropic = vm_tools_to_native(&registry, "anthropic").expect("anthropic native tools");
+    let anthropic = vm_tools_to_native(&registry, "anthropic", "claude-opus-4-7")
+        .expect("anthropic native tools");
     assert_eq!(
         anthropic[0]["namespace"].as_str(),
         Some("ops"),
@@ -65,7 +86,7 @@ fn vm_tools_to_native_emits_defer_loading_for_openai_compat() {
     // the flag will never actually see it — the capability gate in
     // options.rs blocks them before the request leaves the VM.
     let registry = defer_loading_registry();
-    let tools = vm_tools_to_native(&registry, "openai").expect("openai native tools");
+    let tools = vm_tools_to_native(&registry, "openai", "gpt-5.4").expect("openai native tools");
     let deploy = tools
         .iter()
         .find(|tool| {
@@ -86,7 +107,7 @@ fn vm_tools_to_native_emits_defer_loading_for_openai_compat() {
 #[test]
 fn vm_tools_to_native_preserves_rich_parameter_schema_for_openai_compat() {
     let registry = sample_tool_registry();
-    let tools = vm_tools_to_native(&registry, "openai").expect("openai native tools");
+    let tools = vm_tools_to_native(&registry, "openai", "gpt-5.4").expect("openai native tools");
     let edit = tools
         .iter()
         .find(|tool| {
@@ -149,7 +170,7 @@ fn vm_tools_to_native_normalizes_nested_harn_type_aliases() {
     ]);
     let registry = vm_list(vec![tool]);
 
-    let tools = vm_tools_to_native(&registry, "openai").expect("openai native tools");
+    let tools = vm_tools_to_native(&registry, "openai", "gpt-5.4").expect("openai native tools");
     let filters = &tools[0]["function"]["parameters"]["properties"]["filters"];
     assert_eq!(filters["type"].as_str(), Some("object"));
     assert_eq!(
@@ -190,7 +211,7 @@ fn vm_tools_to_native_preserves_json_schema_required_arrays() {
     ]);
     let registry = vm_list(vec![tool]);
 
-    let tools = vm_tools_to_native(&registry, "openai").expect("openai native tools");
+    let tools = vm_tools_to_native(&registry, "openai", "gpt-5.4").expect("openai native tools");
     let payload = &tools[0]["function"]["parameters"]["properties"]["payload"];
     assert_eq!(payload["type"].as_str(), Some("object"));
     assert_eq!(payload["required"], json!(["id"]));
@@ -229,7 +250,12 @@ fn extract_deferred_tool_names_walks_both_wire_shapes() {
 fn apply_tool_search_native_injection_prepends_meta_tool() {
     let mut tools: Option<Vec<serde_json::Value>> =
         Some(vec![json!({"name": "look"}), json!({"name": "deploy"})]);
-    apply_tool_search_native_injection(&mut tools, "anthropic", "bm25");
+    apply_tool_search_native_injection_typed(
+        &mut tools,
+        NativeToolSearchShape::Anthropic,
+        "bm25",
+        "hosted",
+    );
     let tools = tools.expect("tools still set");
     assert_eq!(tools.len(), 3, "search tool prepended");
     assert_eq!(
@@ -243,7 +269,12 @@ fn apply_tool_search_native_injection_prepends_meta_tool() {
 #[test]
 fn apply_tool_search_native_injection_regex_variant() {
     let mut tools: Option<Vec<serde_json::Value>> = Some(vec![json!({"name": "look"})]);
-    apply_tool_search_native_injection(&mut tools, "anthropic", "regex");
+    apply_tool_search_native_injection_typed(
+        &mut tools,
+        NativeToolSearchShape::Anthropic,
+        "regex",
+        "hosted",
+    );
     let tools = tools.unwrap();
     assert_eq!(
         tools[0]["type"].as_str(),
@@ -258,7 +289,12 @@ fn apply_tool_search_native_injection_emits_openai_shape_for_non_anthropic() {
     // `{"type": "tool_search", "mode": "hosted"}` shape, distinct from
     // Anthropic's versioned `tool_search_tool_*_20251119` block.
     let mut tools: Option<Vec<serde_json::Value>> = Some(vec![json!({"name": "look"})]);
-    apply_tool_search_native_injection(&mut tools, "openai", "bm25");
+    apply_tool_search_native_injection_typed(
+        &mut tools,
+        NativeToolSearchShape::OpenAi,
+        "bm25",
+        "hosted",
+    );
     let tools = tools.unwrap();
     assert_eq!(tools.len(), 2, "OpenAI meta-tool prepended");
     assert_eq!(tools[0]["type"].as_str(), Some("tool_search"));
@@ -291,7 +327,12 @@ fn apply_tool_search_native_injection_openai_collects_namespaces() {
             "namespace": "crm",
         }),
     ]);
-    apply_tool_search_native_injection(&mut tools, "openai", "bm25");
+    apply_tool_search_native_injection_typed(
+        &mut tools,
+        NativeToolSearchShape::OpenAi,
+        "bm25",
+        "hosted",
+    );
     let tools = tools.unwrap();
     let namespaces = tools[0]["namespaces"]
         .as_array()
@@ -306,7 +347,12 @@ fn apply_tool_search_native_injection_openai_collects_namespaces() {
 #[test]
 fn apply_tool_search_native_injection_creates_list_when_empty() {
     let mut tools: Option<Vec<serde_json::Value>> = None;
-    apply_tool_search_native_injection(&mut tools, "anthropic", "bm25");
+    apply_tool_search_native_injection_typed(
+        &mut tools,
+        NativeToolSearchShape::Anthropic,
+        "bm25",
+        "hosted",
+    );
     let tools = tools.expect("tools populated");
     assert_eq!(tools.len(), 1);
     assert_eq!(

--- a/crates/harn-vm/src/llm/transcript_seed.rs
+++ b/crates/harn-vm/src/llm/transcript_seed.rs
@@ -428,6 +428,9 @@ fn assistant_message_from_response(record: &Value, state: &ImportState) -> Optio
     let provider = string_field(record, "provider")
         .or_else(|| state.provider.clone())
         .unwrap_or_default();
+    let model = string_field(record, "model")
+        .or_else(|| state.model.clone())
+        .unwrap_or_default();
     let reasoning = string_field(record, "thinking");
     let message = build_assistant_response_message(
         &text,
@@ -435,6 +438,7 @@ fn assistant_message_from_response(record: &Value, state: &ImportState) -> Optio
         &tool_calls,
         reasoning.as_deref(),
         &provider,
+        &model,
     );
     normalize_message(&message)
 }

--- a/crates/harn-vm/src/stdlib/files.rs
+++ b/crates/harn-vm/src/stdlib/files.rs
@@ -275,20 +275,23 @@ async fn upload_file(path: String, provider: String) -> Result<String, VmError> 
         return Ok(file_id);
     }
 
-    let file_id = match provider.as_str() {
-        "mock" => mock_file_id(&provider, &media_type, &bytes),
-        "anthropic" => {
-            let resolved = crate::llm::helpers::ResolvedProvider::resolve(&provider);
-            upload_anthropic(&resolved, &api_key, &resolved_path, &media_type, bytes).await?
-        }
-        "gemini" => {
-            let resolved = crate::llm::helpers::ResolvedProvider::resolve(&provider);
-            upload_gemini(&resolved, &api_key, &resolved_path, &media_type, bytes).await?
-        }
-        other => {
-            return Err(runtime_error(format!(
-                "files.upload: provider `{other}` does not support file uploads"
-            )));
+    let file_id = if provider == "mock" {
+        mock_file_id(&provider, &media_type, &bytes)
+    } else {
+        match crate::llm::provider::provider_file_upload_wire_format(&provider).as_deref() {
+            Some("anthropic") => {
+                let resolved = crate::llm::helpers::ResolvedProvider::resolve(&provider);
+                upload_anthropic(&resolved, &api_key, &resolved_path, &media_type, bytes).await?
+            }
+            Some("gemini") => {
+                let resolved = crate::llm::helpers::ResolvedProvider::resolve(&provider);
+                upload_gemini(&resolved, &api_key, &resolved_path, &media_type, bytes).await?
+            }
+            _ => {
+                return Err(runtime_error(format!(
+                    "files.upload: provider `{provider}` does not support file uploads"
+                )));
+            }
         }
     };
     cache_put(key, file_id.clone());

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -1107,6 +1107,8 @@ let caps = provider_capabilities("anthropic", "claude-opus-4-7")
 //   requires_completion_tokens: false,
 //   reasoning_effort_supported: false,
 //   interleaved_thinking_supported: true,
+//   message_wire_format: "anthropic",
+//   native_tool_wire_format: "anthropic",
 // }
 
 // `caps.tools` matches Harn's own tool gate: true when the route can call
@@ -1127,13 +1129,16 @@ Additional helpers:
   `harn.toml`.
 - `provider_capabilities_clear()` — revert to the shipped defaults.
 
-Rule schema (per `[[provider.<name>]]` entry):
+Rule schema (per `[[provider.<name>]]` entry). Shared defaults can also be
+set under `[provider_defaults.<name>]`:
 
 | Field | Type | Purpose |
 |---|---|---|
 | `model_match` | glob string | Required. Matched against lowercased model ID. |
 | `version_min` | `[major, minor]` | Optional lower bound; parsed via Claude / GPT version extractors. |
 | `native_tools` | bool | Native tool-call wire shape supported. |
+| `message_wire_format` | string | Shared request/response message format: `openai`, `anthropic`, or `ollama`. |
+| `native_tool_wire_format` | string | Native tool definition shape: `openai` or `anthropic`. |
 | `defer_loading` | bool | Provider honors `defer_loading: true` on tool defs. |
 | `tool_search` | `[string]` | Native variants (`["bm25", "regex"]` or `["hosted", "client"]`). Empty = no native support. |
 | `max_tools` | int | Cap on tool count (used by `harn lint`). |
@@ -1146,10 +1151,14 @@ Rule schema (per `[[provider.<name>]]` entry):
 | `prefers_xml_tools` | bool | Text-rendered tool sections prefer XML tags. |
 | `thinking_block_style` | string | Section-level thinking style: `none`, `thinking_blocks`, `reasoning_summary`, `inline`. |
 | `thinking_modes` | `[string]` | Supported script-facing modes: `enabled`, `adaptive`, `effort`. |
+| `reasoning_wire_format` | string | Non-standard OpenAI-compatible reasoning shape: `openrouter` or `enabled`. |
 | `requires_completion_tokens` | bool | Use OpenAI `max_completion_tokens` instead of `max_tokens`. |
 | `reasoning_effort_supported` | bool | Provider/model accepts OpenAI `reasoning_effort`. |
 | `interleaved_thinking_supported` | bool | `thinking: true` can request Anthropic's interleaved-thinking beta header. |
 | `anthropic_beta_features` | `[string]` | Anthropic beta feature names always requested for this route. |
+| `image_url_input_supported` | bool | Image content may use remote URLs. Set false for base64-only routes. |
+| `file_upload_wire_format` | string | Upload API family used by `files.upload`: `anthropic` or `gemini`. |
+| `seed_supported`, `top_k_supported`, `frequency_penalty_supported`, `presence_penalty_supported` | bool | Generation option support flags. |
 | `thinking_disable_directive` | string | In-prompt directive (e.g. `"/no_think"` for Qwen3) auto-prepended to system when `thinking: false`. Idempotent. |
 
 First match wins within a provider's rule list. `[provider_family]`

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -2254,6 +2254,7 @@ let caps = provider_capabilities("anthropic", "claude-opus-4-7")
 //   tool_search: [string], max_tools: int | nil,
 //   prompt_caching, thinking, thinking_modes: [string],
 //   reasoning_effort_supported, reasoning_none_supported,
+//   message_wire_format, native_tool_wire_format,
 // }
 ```
 

--- a/docs/src/llm/providers.md
+++ b/docs/src/llm/providers.md
@@ -166,6 +166,8 @@ let caps = provider_capabilities("anthropic", "claude-opus-4-7")
 //   tool_search: ["bm25", "regex"], max_tools: 10000,
 //   prompt_caching: true, thinking: true, vision_supported: true,
 //   interleaved_thinking_supported: true,
+//   message_wire_format: "anthropic",
+//   native_tool_wire_format: "anthropic",
 //   prefers_xml_scaffolding: true, prefers_xml_tools: true,
 //   structured_output_mode: "xml_tagged",
 //   thinking_block_style: "thinking_blocks",
@@ -219,13 +221,18 @@ prompt_caching = true
 thinking_modes = ["enabled"]
 ```
 
-Each `[[capabilities.provider.<name>]]` entry accepts these fields:
+Provider-wide defaults can be declared under
+`[capabilities.provider_defaults.<name>]`; rule entries override those
+defaults for matching models. Each `[[capabilities.provider.<name>]]`
+entry accepts these fields:
 
 | Field | Type | Purpose |
 |---|---|---|
 | `model_match` | glob string | Required. Matched against the lowercased model ID. Leading/trailing `*` or a single middle `*` supported. |
 | `version_min` | `[major, minor]` | Narrows the match to a parseable version (Anthropic / OpenAI extractors). Rules where `version_min` is set but the model ID won't parse are skipped. |
 | `native_tools` | bool | Whether the provider accepts a native tool-call wire shape. |
+| `message_wire_format` | string | Shared request/response message format: `openai`, `anthropic`, or `ollama`. |
+| `native_tool_wire_format` | string | Native tool definition shape: `openai` or `anthropic`. |
 | `defer_loading` | bool | Whether `defer_loading: true` on tool definitions is honored server-side. |
 | `tool_search` | list of strings | Native `tool_search` variants, preferred first. Anthropic: `["bm25", "regex"]`. OpenAI: `["hosted", "client"]`. Empty = no native support (client fallback only). |
 | `max_tools` | int | Cap on tool count. `harn lint` will warn if a registry exceeds the smallest cap any active provider advertises. |
@@ -238,11 +245,15 @@ Each `[[capabilities.provider.<name>]]` entry accepts these fields:
 | `prefers_xml_tools` | bool | Text-rendered tool sections prefer XML tags. |
 | `thinking_block_style` | string | Section-level thinking style: `none`, `thinking_blocks`, `reasoning_summary`, `inline`. |
 | `thinking_modes` | list of strings | Supported script-facing thinking modes. Values are `enabled`, `adaptive`, or `effort`. |
+| `reasoning_wire_format` | string | Non-standard OpenAI-compatible reasoning request shape: `openrouter` or `enabled`. |
 | `reasoning_effort_supported` | bool | Provider accepts a `reasoning_effort` request field for effort-capable models. |
 | `reasoning_none_supported` | bool | Provider accepts `reasoning_effort: "none"` as true reasoning-off instead of flooring at `minimal`. |
 | `interleaved_thinking_supported` | bool | `thinking: true` can request Anthropic's `interleaved-thinking-2025-05-14` beta header. |
 | `anthropic_beta_features` | list of strings | Anthropic beta feature names always requested for this provider/model route. |
 | `vision_supported` | bool | Image content accepted by the provider/model route. |
+| `image_url_input_supported` | bool | Image content may reference remote URLs. Set false for routes that require base64 images. |
+| `file_upload_wire_format` | string | Upload API family used by `files.upload`: `anthropic` or `gemini`. |
+| `seed_supported`, `top_k_supported`, `frequency_penalty_supported`, `presence_penalty_supported` | bool | Generation option support flags used for warnings and provider-neutral validation. |
 | `thinking_disable_directive` | string | In-prompt directive (e.g. `"/no_think"` for Qwen3 chat templates) auto-prepended to the system message when the resolved `thinking` is `Disabled`. Lets script authors write `thinking: false` uniformly across providers without learning per-template prompt directives. Idempotent — never injected twice. |
 
 First match wins. User rules for a given provider are consulted

--- a/docs/src/provider-matrix.md
+++ b/docs/src/provider-matrix.md
@@ -30,6 +30,7 @@ Regenerate with `make gen-provider-matrix` and verify with `make check-provider-
 | `azure_openai` | `o1*` | no | no | no | no | yes | no | no | `plain` | `none` | `none` | yes | no |
 | `azure_openai` | `o3*` | no | no | no | no | yes | no | no | `plain` | `none` | `none` | yes | no |
 | `azure_openai` | `o4*` | no | no | no | no | yes | no | no | `plain` | `none` | `none` | yes | no |
+| `bedrock` | `anthropic.claude-*` | no | no | no | no | yes | no | no | `plain` | `none` | `none` | yes | no |
 | `bedrock` | `*` | no | no | no | no | yes | no | no | `plain` | `none` | `none` | yes | no |
 | `dashscope` | `qwen3.6*` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `native_json` | `none` | yes | no |
 | `dashscope` | `qwen*` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `native_json` | `none` | yes | no |

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -2252,6 +2252,7 @@ let caps = provider_capabilities("anthropic", "claude-opus-4-7")
 //   tool_search: [string], max_tools: int | nil,
 //   prompt_caching, thinking, thinking_modes: [string],
 //   reasoning_effort_supported, reasoning_none_supported,
+//   message_wire_format, native_tool_wire_format,
 // }
 ```
 


### PR DESCRIPTION
## Summary

Closes #1667. Replaces `if provider == "anthropic" / "openai" / "ollama" / "openrouter" / "together"` switches in `crates/harn-vm/src/llm/**` with `provider_capabilities` queries. Bedrock-hosted Claude, OpenAI-compat self-hosted routes, and proxy setups now opt into the right behavior through the capability matrix instead of pretending to be the canonical provider name.

New capability flags carry the underlying behavioral facts:

- `message_wire_format` (`openai` | `anthropic` | `ollama`)
- `native_tool_wire_format` (`openai` | `anthropic`)
- `file_upload_wire_format` (`anthropic` | `gemini`)
- `reasoning_wire_format` (`openrouter` | `enabled`)
- `image_url_input_supported`, `seed_supported`, `top_k_supported`, `frequency_penalty_supported`, `presence_penalty_supported`

A new `[provider_defaults.*]` block in `capabilities.toml` lets each provider state its baseline transport once instead of repeating it on every generation-specific row. Defaults fall through the `provider_family` chain, so the new `bedrock` row matching `anthropic.claude-*` reuses the Anthropic wire-format facts.

Catalog/auth/endpoint resolution (`provider_config`, `auth_env`, `provider_key_available`, `matrix_rows` filtering) still keys on provider identity per the issue's "legitimately identity-driven" carve-out.

## Acceptance

- `rg 'provider\s*==\s*"(anthropic|openai|google|gemini|qwen|ollama)"' crates/harn-vm/` returns no behavior-switching hits — only a catalog test assertion and the auth-key fallback for Ollama.
- `cargo nextest run -p harn-vm` → 2063 passed.
- Workspace `cargo check --all-targets` + `cargo clippy --workspace --all-targets -- -D warnings` clean.
- New regression test: Bedrock-hosted Claude goes through the Anthropic-style `tool_result` / `native_tool_wire_format` / `message_wire_format` paths (`agent_session_host.rs`, `capabilities.rs`).

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo nextest run -p harn-vm` (2063 passed, 2 skipped)
- [ ] CI: workspace tests, conformance, markdown, docs snippets

🤖 Generated with [Claude Code](https://claude.com/claude-code)