### PR TITLE
hooks: wire `session_idle` lifecycle event from daemon agent loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ condensed series summaries instead of full per-patch history.
 
 ### Fixed
 
+- **`session_idle` lifecycle hook now fires.** `register_session_hook("session_idle", …)`
+  was registrable but had no firing path, so handlers never ran. The
+  daemon-mode agent loop now fires it once per `wake_interval_ms` wait
+  with `{session, iteration, wake_interval_ms, consolidate_on_idle}`,
+  matching the placement documented in `docs/src/extensibility/hooks.md`.
+  Conformance coverage at `conformance/tests/hooks_session/session_idle.harn`.
 - **Trailing comments on body statements are preserved.** `harn fmt`
   previously dropped same-line comments that followed a statement inside
   any block body (`fn`/`pipeline`/`if`/`else`/`while`/`for`/`try`/`catch`/

--- a/conformance/tests/hooks_session/session_idle.expected
+++ b/conformance/tests/hooks_session/session_idle.expected
@@ -1,0 +1,2 @@
+budget_exhausted
+true

--- a/conformance/tests/hooks_session/session_idle.harn
+++ b/conformance/tests/hooks_session/session_idle.harn
@@ -1,0 +1,31 @@
+/**
+ * `session_idle` hooks fire whenever the daemon-mode loop enters an
+ * idle wait. Advisory only: the hook can observe iteration count and
+ * `wake_interval_ms` but cannot block the wait.
+ */
+let idle_seen = atomic(0)
+
+pipeline default() {
+  clear_session_hooks()
+  register_session_hook(
+    "session_idle",
+    { event ->
+      if type_of(event?.session?.id) == "string"
+        && type_of(event?.wake_interval_ms) == "int" {
+        atomic_add(idle_seen, 1)
+      }
+      return nil
+    },
+  )
+  llm_mock_clear()
+  llm_mock({text: "tick"})
+  llm_mock({text: "tock"})
+  let result = agent_loop(
+    "poll background",
+    nil,
+    {provider: "mock", daemon: true, max_iterations: 2, wake_interval_ms: 1},
+  )
+  println(result.status)
+  println(atomic_get(idle_seen) >= 1)
+  clear_session_hooks()
+}

--- a/crates/harn-stdlib/src/stdlib/agent/daemon.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/daemon.harn
@@ -59,6 +59,15 @@ pub fn agent_daemon_snapshot(session, opts, daemon_state = "idle", iteration = 0
 pub fn agent_daemon_step(session, opts, iteration) {
   let snapshot = agent_daemon_snapshot(session, opts, "idle", iteration)
   let timeout = opts?.wake_interval_ms ?? 0
+  __host_fire_session_hook(
+    "session_idle",
+    {
+      session: {id: session.session_id},
+      iteration: iteration,
+      wake_interval_ms: timeout,
+      consolidate_on_idle: opts?.consolidate_on_idle ?? false,
+    },
+  )
   var wake = __host_agent_daemon_wait(session.session_id, timeout)
   while wake?.reason == nil && timeout > 0 {
     wake = __host_agent_daemon_wait(session.session_id, timeout)

--- a/crates/harn-stdlib/src/stdlib/agent/loop.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/loop.harn
@@ -1508,11 +1508,6 @@ fn __agent_loop_run(message, session, initial_opts) {
       enforced
     }
   }
-  // Drain queued FileEdited notifications so hooks fire at a
-  // deterministic turn boundary; replay observes the same firing
-  // order regardless of when the underlying writes happened.
-  // Drain any FileEdited notifications recorded during the last
-  // turn so terminal hooks observe them before SessionEnd fires.
   if is_err(run) {
     if !session_finalized {
       __agent_loop_finalize_failed(session, iteration)

--- a/docs/src/extensibility/hooks.md
+++ b/docs/src/extensibility/hooks.md
@@ -47,7 +47,7 @@ tool call.
 | `permission_replied` | After the dynamic permission policy decides | Advisory |
 | `file_edited` | After `write_file` / `append_file` / `write_file_bytes` / `notify_file_edited` queues an edit. Drained at each agent-loop turn boundary | Advisory |
 | `session_error` | Before `session_end` when the loop ended with an error status or terminal error | Advisory |
-| `session_idle` | (Defined for forward compatibility; no firing path yet) | Advisory |
+| `session_idle` | Each time the daemon-mode agent loop enters its `wake_interval_ms` wait between turns | Advisory |
 
 ### Return-value protocol
 


### PR DESCRIPTION
## Summary

Closes #1648.

The session-level lifecycle hooks surface from #1648 landed in #1662, but the `session_idle` event was registrable via `register_session_hook("session_idle", …)` with no firing path — handlers never ran. Daemon-mode loops now fire it once per `wake_interval_ms` wait between turns with `{session, iteration, wake_interval_ms, consolidate_on_idle}`, matching the placement documented in `docs/src/extensibility/hooks.md`.

Drive-by: drop two near-duplicate orphan comments stranded above `if is_err(run)` in `agent_loop.harn` — the lines they describe (`__host_drain_file_edits` invocations) live earlier in the same function and the function names already carry the intent.

## Files

- `crates/harn-stdlib/src/stdlib/agent/daemon.harn` — fire `session_idle` from `agent_daemon_step` before the wait.
- `crates/harn-stdlib/src/stdlib/agent/loop.harn` — remove orphan comments above `if is_err(run)`.
- `docs/src/extensibility/hooks.md` — update the `session_idle` row to describe the firing path.
- `conformance/tests/hooks_session/session_idle.{harn,expected}` — new coverage: daemon-mode loop with `wake_interval_ms: 1` observes ≥1 idle event.
- `CHANGELOG.md` — Unreleased `Fixed` entry referencing the wiring.

## Test plan

- [x] `cargo run --bin harn -- test conformance --filter hooks_session` — 8/8 pass (existing 7 + new `session_idle.harn`)
- [x] `cargo run --bin harn -- test conformance --filter daemon` — 2/2 pass (no regression)
- [x] `make all` — full repo gate clean (rust fmt, clippy, workspace tests, conformance, markdown lint, Harn lint/format, highlight drift, docs snippet check, portal build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)