### PR TITLE
template: variant-resolution transcripts + drift-prevention lints (#1668, #1669)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,34 @@ condensed series summaries instead of full per-patch history.
 
 ### Added
 
+- **`template.render` transcript events for variant resolution (#1668).**
+  Every `render()` / `render_prompt()` call performed under an
+  LLM-aware frame now emits a `template.render` event into the run's
+  `llm_transcript.jsonl`. The event captures the resolved `llm` snapshot
+  (`provider`, `model`, `family`, `capabilities`), a per-`{{ if }}`
+  /`{{ elif }}` /`{{ section }}` branch trace with line + column
+  anchors, the template URI + content hash, and the rendered byte count.
+  The portal surfaces a new "Variant resolution" panel showing which
+  capability branches fired for the active model, so an on-call engineer
+  can answer "which prompt did this model actually see?" without
+  re-running the script. Renders outside any LLM frame (doc-gen, CI)
+  emit no event. The branch trace is deterministic across repeated
+  renders of the same template + bindings, which is what makes replay
+  reproducible.
+- **`template-provider-identity-branch` lint rule (#1669).** `harn lint`
+  now also walks `.harn.prompt` (and bare `.prompt`) files and warns
+  when a template branches on `llm.provider`, `llm.model`, or
+  `llm.family` directly. Vendor-identity strings are the trap every
+  prompt-variant framework before #1663 fell into — the diagnostic
+  carries a per-comparison capability-flag replacement suggestion
+  (e.g. `provider == "anthropic"` →
+  `llm.capabilities.prefers_xml_scaffolding`).
+- **`template-variant-explosion` lint rule (#1669).** Companion rule
+  that warns when a single `.harn.prompt` carries more than `N`
+  capability-aware conditionals — combinatorial explosion + drift
+  between materializations is the #1 failure mode for prompt-variant
+  systems per the literature. Default threshold is 3, configurable via
+  `[lint] template_variant_branch_threshold = N` in `harn.toml`.
 - **`harn eval prompt <file> --fleet <models>` (#1670).** New CLI
   subcommand that renders a single `.harn.prompt` template against a
   fleet of models so authors can validate that capability-adapted

--- a/crates/harn-cli/portal/src/App.test.tsx
+++ b/crates/harn-cli/portal/src/App.test.tsx
@@ -100,6 +100,7 @@ const detailPayload = {
   artifacts: [],
   execution_summary: null,
   transcript_steps: [],
+  template_renders: [],
   story: [],
   child_runs: [],
   observability: {

--- a/crates/harn-cli/portal/src/components/RunDetail.tsx
+++ b/crates/harn-cli/portal/src/components/RunDetail.tsx
@@ -83,6 +83,28 @@ const messages = defineMessages({
     defaultMessage:
       "Saved request/response turns from llm_transcript.jsonl when a transcript sidecar exists.",
   },
+  variantResolution: {
+    id: "portal.detail.variantResolution",
+    defaultMessage: "Variant resolution",
+  },
+  variantResolutionCopy: {
+    id: "portal.detail.variantResolutionCopy",
+    defaultMessage:
+      "Which capability-adaptive branches fired in each prompt template, alongside the resolved LLM identity and capability snapshot.",
+  },
+  noTemplateRenders: {
+    id: "portal.detail.noTemplateRenders",
+    defaultMessage:
+      "No template.render events were captured for this run. (Variant resolution is only recorded when render() runs inside an LLM-aware frame.)",
+  },
+  variantBranchesNone: {
+    id: "portal.detail.variantBranchesNone",
+    defaultMessage: "No capability branches recorded.",
+  },
+  variantCapabilitiesNone: {
+    id: "portal.detail.variantCapabilitiesNone",
+    defaultMessage: "No capability snapshot recorded.",
+  },
   transcriptStory: { id: "portal.detail.transcriptStory", defaultMessage: "Transcript story" },
   transcriptStoryCopy: {
     id: "portal.detail.transcriptStoryCopy",
@@ -1322,6 +1344,70 @@ export function RunDetail({ detail, runs, onSelectRun }: RunDetailProps) {
             ))
           ) : (
             <div className="muted">{intl.formatMessage(messages.noArtifacts)}</div>
+          )}
+        </div>
+      </section>
+
+      <section className="panel">
+        <div className="panel-header">
+          <div>
+            <h3>{intl.formatMessage(messages.variantResolution)}</h3>
+            <p>{intl.formatMessage(messages.variantResolutionCopy)}</p>
+          </div>
+        </div>
+        <div className="turn-list">
+          {detail.template_renders.length ? (
+            detail.template_renders.map((render, index) => {
+              const capabilityKeys = Object.keys(render.capabilities)
+              return (
+                <div className="turn-item" key={`${render.template_uri}-${index}`}>
+                  <div className="row">
+                    <strong>{render.template_uri || "(inline template)"}</strong>
+                    <span className="pill running">{render.family || "unknown"}</span>
+                  </div>
+                  <div className="meta">
+                    {render.provider}
+                    {render.model ? ` • ${render.model}` : ""}
+                    {render.rendered_bytes ? ` • ${formatNumber(render.rendered_bytes)} bytes` : ""}
+                  </div>
+                  <div className="turn-chip-row">
+                    {render.branches.length ? (
+                      render.branches.map((branch, branchIndex) => (
+                        <span
+                          className="turn-chip"
+                          key={`${branch.template_uri}:${branch.line}:${branch.col}:${branchIndex}`}
+                          title={branch.branch_label ?? undefined}
+                        >
+                          {branch.kind}:{branch.branch_id}
+                          {branch.branch_label ? ` — ${branch.branch_label}` : ""}
+                        </span>
+                      ))
+                    ) : (
+                      <span className="muted">
+                        {intl.formatMessage(messages.variantBranchesNone)}
+                      </span>
+                    )}
+                  </div>
+                  <details>
+                    <summary>Capability snapshot</summary>
+                    {capabilityKeys.length ? (
+                      <pre>
+                        {capabilityKeys
+                          .sort()
+                          .map((key) => `${key}: ${JSON.stringify(render.capabilities[key])}`)
+                          .join("\n")}
+                      </pre>
+                    ) : (
+                      <div className="muted">
+                        {intl.formatMessage(messages.variantCapabilitiesNone)}
+                      </div>
+                    )}
+                  </details>
+                </div>
+              )
+            })
+          ) : (
+            <div className="muted">{intl.formatMessage(messages.noTemplateRenders)}</div>
           )}
         </div>
       </section>

--- a/crates/harn-cli/portal/src/types.ts
+++ b/crates/harn-cli/portal/src/types.ts
@@ -413,6 +413,28 @@ export type PortalTranscriptStep = {
   summary: string
 }
 
+export type PortalTemplateBranch = {
+  kind: string
+  template_uri: string
+  line: number
+  col: number
+  branch_id: string
+  branch_label: string | null
+}
+
+export type PortalTemplateRender = {
+  template_uri: string
+  template_revision_hash: string
+  rendered_bytes: number
+  provider: string
+  model: string
+  family: string
+  capabilities: Record<string, unknown>
+  branches: PortalTemplateBranch[]
+  span_id: number | null
+  timestamp: string | null
+}
+
 export type PortalStorySection = {
   title: string
   scope: string
@@ -602,6 +624,7 @@ export type PortalRunDetail = {
   artifacts: PortalArtifact[]
   execution_summary: PortalExecutionSummary | null
   transcript_steps: PortalTranscriptStep[]
+  template_renders: PortalTemplateRender[]
   story: PortalStorySection[]
   child_runs: PortalChildRun[]
   observability: RunObservability

--- a/crates/harn-cli/src/commands/check/config.rs
+++ b/crates/harn-cli/src/commands/check/config.rs
@@ -59,19 +59,57 @@ pub(crate) fn harn_lint_persona_step_allowlist(path: &Path) -> Vec<String> {
     }
 }
 
+/// Read `[lint] template_variant_branch_threshold` from the nearest
+/// harn.toml. Returns `None` when unset; the
+/// `template-variant-explosion` rule falls back to
+/// [`harn_lint::DEFAULT_TEMPLATE_VARIANT_BRANCH_THRESHOLD`].
+pub(crate) fn harn_lint_template_variant_branch_threshold(path: &Path) -> Option<usize> {
+    match harn_config::load_for_path(path) {
+        Ok(cfg) => cfg.lint.template_variant_branch_threshold,
+        Err(e) => {
+            eprintln!("warning: {e}");
+            None
+        }
+    }
+}
+
+/// Read `[lint] disabled` from the nearest harn.toml.
+pub(crate) fn harn_lint_disabled_rules(path: &Path) -> Vec<String> {
+    match harn_config::load_for_path(path) {
+        Ok(cfg) => cfg.lint.disabled.unwrap_or_default(),
+        Err(e) => {
+            eprintln!("warning: {e}");
+            Vec::new()
+        }
+    }
+}
+
 pub(crate) fn collect_harn_targets(targets: &[&str]) -> Vec<PathBuf> {
     let mut files = Vec::new();
     for target in targets {
         let path = Path::new(target);
         if path.is_dir() {
             super::super::collect_harn_files(path, &mut files);
-        } else {
+        } else if is_harn_program_file(path) {
             files.push(path.to_path_buf());
         }
     }
     files.sort();
     files.dedup();
     files
+}
+
+/// Recognize `.harn` program files while excluding `.harn.prompt`
+/// (which `harn lint` routes through the prompt-template lint pass
+/// instead — see `commands::check::template_lint`).
+fn is_harn_program_file(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+        return false;
+    };
+    if name.ends_with(".harn.prompt") || name.ends_with(".prompt") {
+        return false;
+    }
+    path.extension().is_some_and(|ext| ext == "harn")
 }
 
 /// Collect every function name that appears in a selective import across

--- a/crates/harn-cli/src/commands/check/mod.rs
+++ b/crates/harn-cli/src/commands/check/mod.rs
@@ -11,6 +11,7 @@ mod outcome;
 mod preflight;
 pub(crate) mod provider_matrix;
 mod source;
+mod template_lint;
 
 #[cfg(test)]
 mod tests;
@@ -19,9 +20,10 @@ pub(crate) use bundle::build_bundle_manifest;
 pub(crate) use check_cmd::check_file_inner;
 pub(crate) use config::{
     apply_harn_lint_config, build_module_graph, collect_cross_file_imports, collect_harn_targets,
-    harn_lint_complexity_threshold, harn_lint_persona_step_allowlist,
-    harn_lint_require_file_header,
+    harn_lint_complexity_threshold, harn_lint_disabled_rules, harn_lint_persona_step_allowlist,
+    harn_lint_require_file_header, harn_lint_template_variant_branch_threshold,
 };
 pub(crate) use fmt::{fmt_targets, FmtMode};
 pub(crate) use host_capabilities::load_host_capabilities;
 pub(crate) use lint::{lint_file_inner, lint_fix_file};
+pub(crate) use template_lint::{collect_prompt_targets, lint_prompt_file_inner};

--- a/crates/harn-cli/src/commands/check/template_lint.rs
+++ b/crates/harn-cli/src/commands/check/template_lint.rs
@@ -1,0 +1,93 @@
+//! Glue between `harn lint` and the prompt-template lint rules.
+//!
+//! `.harn.prompt` files don't go through the regular Harn parser, so
+//! they need their own discovery + invocation path. This module
+//! provides:
+//!
+//! - [`collect_prompt_targets`] — recursive walker that picks up
+//!   `*.harn.prompt` / `*.prompt` files under the targets passed to
+//!   `harn lint`.
+//! - [`lint_prompt_file_inner`] — read the source, dispatch to
+//!   `harn_lint::lint_prompt_template`, and print diagnostics in the
+//!   same format as `harn lint` uses for `.harn` files.
+
+use std::path::{Path, PathBuf};
+
+use harn_lint::LintSeverity;
+
+use super::outcome::{print_lint_diagnostics, CommandOutcome};
+
+/// Recursively gather `.harn.prompt` / `.prompt` files under `targets`.
+/// Targets that are files themselves are returned as-is when they
+/// match one of those extensions.
+pub(crate) fn collect_prompt_targets(targets: &[&str]) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    for target in targets {
+        let path = Path::new(target);
+        if path.is_dir() {
+            collect_prompt_files(path, &mut files);
+        } else if is_prompt_file(path) {
+            files.push(path.to_path_buf());
+        }
+    }
+    files.sort();
+    files.dedup();
+    files
+}
+
+fn collect_prompt_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    let mut entries: Vec<_> = entries.filter_map(|e| e.ok()).collect();
+    entries.sort_by_key(|e| e.path());
+    for entry in entries {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_prompt_files(&path, out);
+        } else if is_prompt_file(&path) {
+            out.push(path);
+        }
+    }
+}
+
+fn is_prompt_file(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+        return false;
+    };
+    name.ends_with(".harn.prompt") || name.ends_with(".prompt")
+}
+
+/// Lint a single `.harn.prompt` template. Prints diagnostics through
+/// the shared CLI formatter so output is consistent with `.harn` lint
+/// runs.
+pub(crate) fn lint_prompt_file_inner(
+    path: &Path,
+    branch_threshold: Option<usize>,
+    disabled_rules: &[String],
+) -> CommandOutcome {
+    let path_str = path.to_string_lossy().into_owned();
+    let source = match std::fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(error) => {
+            eprintln!("error: failed to read {path_str}: {error}");
+            return CommandOutcome {
+                has_error: true,
+                has_warning: false,
+            };
+        }
+    };
+    let diagnostics = harn_lint::lint_prompt_template(&source, branch_threshold, disabled_rules);
+    if diagnostics.is_empty() {
+        println!("{path_str}: no issues found");
+        return CommandOutcome::default();
+    }
+    let has_warning = diagnostics
+        .iter()
+        .any(|d| d.severity == LintSeverity::Warning);
+    let has_error = print_lint_diagnostics(&path_str, &source, &diagnostics);
+    CommandOutcome {
+        has_error,
+        has_warning,
+    }
+}

--- a/crates/harn-cli/src/commands/check/tests.rs
+++ b/crates/harn-cli/src/commands/check/tests.rs
@@ -1373,6 +1373,82 @@ pub fn exposed() -> string {
 }
 
 #[test]
+fn lint_prompt_file_flags_provider_identity_branch() {
+    use super::template_lint::lint_prompt_file_inner;
+    let dir = unique_temp_dir("harn-lint-prompt-identity");
+    std::fs::create_dir_all(&dir).unwrap();
+    let file = dir.join("sample.harn.prompt");
+    std::fs::write(
+        &file,
+        "{{ if llm.provider == \"anthropic\" }}x{{ else }}y{{ end }}\n",
+    )
+    .unwrap();
+    let outcome = lint_prompt_file_inner(&file, None, &[]);
+    assert!(outcome.has_warning);
+    assert!(!outcome.has_error);
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn lint_prompt_file_flags_variant_explosion_above_threshold() {
+    use super::template_lint::lint_prompt_file_inner;
+    let dir = unique_temp_dir("harn-lint-prompt-explosion");
+    std::fs::create_dir_all(&dir).unwrap();
+    let file = dir.join("sample.harn.prompt");
+    let body: String = (0..4)
+        .map(|i| {
+            let flag = match i {
+                0 => "native_tools",
+                1 => "prefers_xml_scaffolding",
+                2 => "supports_assistant_prefill",
+                _ => "prefers_markdown_scaffolding",
+            };
+            format!("{{{{ if llm.capabilities.{flag} }}}}x{{{{ end }}}}\n")
+        })
+        .collect();
+    std::fs::write(&file, body).unwrap();
+    // Default threshold (3): 4 branches trips the rule.
+    let outcome = lint_prompt_file_inner(&file, None, &[]);
+    assert!(outcome.has_warning);
+    // Explicit threshold of 5 silences the rule.
+    let outcome_lifted = lint_prompt_file_inner(&file, Some(5), &[]);
+    assert!(!outcome_lifted.has_warning);
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn lint_prompt_file_respects_disabled_rules() {
+    use super::template_lint::lint_prompt_file_inner;
+    let dir = unique_temp_dir("harn-lint-prompt-disabled");
+    std::fs::create_dir_all(&dir).unwrap();
+    let file = dir.join("sample.harn.prompt");
+    std::fs::write(&file, "{{ if llm.provider == \"anthropic\" }}x{{ end }}\n").unwrap();
+    let outcome = lint_prompt_file_inner(
+        &file,
+        None,
+        &["template-provider-identity-branch".to_string()],
+    );
+    assert!(!outcome.has_warning);
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn lint_collects_prompt_targets_from_directories() {
+    use super::template_lint::collect_prompt_targets;
+    let dir = unique_temp_dir("harn-lint-prompt-collect");
+    std::fs::create_dir_all(dir.join("nested")).unwrap();
+    std::fs::write(dir.join("a.harn.prompt"), "x").unwrap();
+    std::fs::write(dir.join("nested").join("b.harn.prompt"), "y").unwrap();
+    std::fs::write(dir.join("c.txt"), "ignore").unwrap();
+    let target = dir.display().to_string();
+    let files = collect_prompt_targets(&[target.as_str()]);
+    assert_eq!(files.len(), 2);
+    assert!(files.contains(&dir.join("a.harn.prompt")));
+    assert!(files.contains(&dir.join("nested").join("b.harn.prompt")));
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn lint_file_inner_reports_type_aware_lint_rules() {
     let dir = unique_temp_dir("harn-lint-type-aware");
     std::fs::create_dir_all(&dir).unwrap();

--- a/crates/harn-cli/src/commands/portal/dto.rs
+++ b/crates/harn-cli/src/commands/portal/dto.rs
@@ -250,6 +250,36 @@ pub(super) struct PortalTranscriptStep {
     pub(super) summary: String,
 }
 
+/// Variant-resolution snapshot recovered from a `template.render`
+/// transcript event. One entry per top-level `render()` /
+/// `render_prompt()` call that executed inside an LLM-aware frame.
+/// Powers the portal's "Variant resolution" panel (#1668) so on-call
+/// engineers can answer "which capability branch fired for this
+/// model?" without re-running the template.
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct PortalTemplateRender {
+    pub(super) template_uri: String,
+    pub(super) template_revision_hash: String,
+    pub(super) rendered_bytes: usize,
+    pub(super) provider: String,
+    pub(super) model: String,
+    pub(super) family: String,
+    pub(super) capabilities: BTreeMap<String, serde_json::Value>,
+    pub(super) branches: Vec<PortalTemplateBranch>,
+    pub(super) span_id: Option<u64>,
+    pub(super) timestamp: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct PortalTemplateBranch {
+    pub(super) kind: String,
+    pub(super) template_uri: String,
+    pub(super) line: usize,
+    pub(super) col: usize,
+    pub(super) branch_id: String,
+    pub(super) branch_label: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub(super) struct PortalStorySection {
     pub(super) title: String,
@@ -342,6 +372,7 @@ pub(super) struct PortalRunDetail {
     pub(super) artifacts: Vec<PortalArtifact>,
     pub(super) execution_summary: Option<PortalExecutionSummary>,
     pub(super) transcript_steps: Vec<PortalTranscriptStep>,
+    pub(super) template_renders: Vec<PortalTemplateRender>,
     pub(super) story: Vec<PortalStorySection>,
     pub(super) child_runs: Vec<PortalChildRun>,
     pub(super) observability: harn_vm::orchestration::RunObservabilityRecord,

--- a/crates/harn-cli/src/commands/portal/run_analysis.rs
+++ b/crates/harn-cli/src/commands/portal/run_analysis.rs
@@ -16,7 +16,7 @@ use super::dto::{
 use super::errors::{bad_request_error, internal_error};
 use super::query::{ErrorResponse, ListRunsQuery};
 use super::skill_events::{extract as extract_skill_events, ExtractedEvents};
-use super::transcript::{build_story, discover_transcript_steps};
+use super::transcript::{build_story, discover_template_renders, discover_transcript_steps};
 use super::util::{
     compact_json, compact_metadata, date_ms, format_duration, humanize_kind, is_completed_status,
     is_failed_status, metadata_pretty_json, metadata_string, owning_stage, preview_text,
@@ -443,6 +443,7 @@ pub(super) fn build_run_detail(
     let checkpoints = build_checkpoints(run);
     let artifacts = build_artifacts(run);
     let transcript_steps = discover_transcript_steps(run_dir, relative_path).unwrap_or_default();
+    let template_renders = discover_template_renders(run_dir, relative_path).unwrap_or_default();
     let story = build_story(run);
     let child_runs = run
         .child_runs
@@ -489,6 +490,7 @@ pub(super) fn build_run_detail(
         artifacts,
         execution_summary: build_execution_summary(run.execution.as_ref()),
         transcript_steps,
+        template_renders,
         story,
         child_runs,
         observability: run.observability.clone().unwrap_or_else(|| {

--- a/crates/harn-cli/src/commands/portal/transcript.rs
+++ b/crates/harn-cli/src/commands/portal/transcript.rs
@@ -1,22 +1,35 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::path::Path;
 
-use super::dto::{PortalStorySection, PortalTranscriptMessage, PortalTranscriptStep};
+use super::dto::{
+    PortalStorySection, PortalTemplateBranch, PortalTemplateRender, PortalTranscriptMessage,
+    PortalTranscriptStep,
+};
 use super::util::preview_text;
 
 pub(super) fn discover_transcript_steps(
     run_dir: &Path,
     relative_path: &str,
 ) -> Option<Vec<PortalTranscriptStep>> {
+    let path = locate_llm_transcript(run_dir, relative_path)?;
+    parse_transcript_steps(&path).ok()
+}
+
+pub(super) fn discover_template_renders(
+    run_dir: &Path,
+    relative_path: &str,
+) -> Option<Vec<PortalTemplateRender>> {
+    let path = locate_llm_transcript(run_dir, relative_path)?;
+    parse_template_renders(&path).ok()
+}
+
+fn locate_llm_transcript(run_dir: &Path, relative_path: &str) -> Option<std::path::PathBuf> {
     let run_path = run_dir.join(relative_path);
     let stem = run_path.file_stem()?.to_str()?;
     let parent = run_path.parent()?;
     let transcript_path = parent.join(format!("{stem}-llm/llm_transcript.jsonl"));
-    if !transcript_path.exists() {
-        return None;
-    }
-    parse_transcript_steps(&transcript_path).ok()
+    transcript_path.exists().then_some(transcript_path)
 }
 
 fn parse_transcript_steps(path: &Path) -> Result<Vec<PortalTranscriptStep>, String> {
@@ -182,6 +195,120 @@ fn parse_transcript_steps(path: &Path) -> Result<Vec<PortalTranscriptStep>, Stri
     }
 
     Ok(steps)
+}
+
+fn parse_template_renders(path: &Path) -> Result<Vec<PortalTemplateRender>, String> {
+    let content = fs::read_to_string(path)
+        .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
+    let mut out = Vec::new();
+    let policy = harn_vm::redact::current_policy();
+    for line in content.lines().filter(|line| !line.trim().is_empty()) {
+        let mut raw: serde_json::Value = match serde_json::from_str(line) {
+            Ok(value) => value,
+            Err(_) => continue,
+        };
+        policy.redact_json_in_place(&mut raw);
+        if raw.get("type").and_then(|v| v.as_str()) != Some("template.render") {
+            continue;
+        }
+        let Some(record) = extract_template_render(&raw) else {
+            continue;
+        };
+        out.push(record);
+    }
+    Ok(out)
+}
+
+fn extract_template_render(raw: &serde_json::Value) -> Option<PortalTemplateRender> {
+    let template_uri = raw
+        .get("template_uri")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let template_revision_hash = raw
+        .get("template_revision_hash")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let rendered_bytes = raw
+        .get("rendered_bytes")
+        .and_then(|v| v.as_u64())
+        .unwrap_or_default() as usize;
+    let llm = raw.get("llm")?;
+    let provider = llm
+        .get("provider")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let model = llm
+        .get("model")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let family = llm
+        .get("family")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let capabilities = llm
+        .get("capabilities")
+        .and_then(|v| v.as_object())
+        .map(|map| {
+            map.iter()
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect::<BTreeMap<_, _>>()
+        })
+        .unwrap_or_default();
+    let branches = raw
+        .get("branches")
+        .and_then(|v| v.as_array())
+        .map(|items| items.iter().filter_map(extract_template_branch).collect())
+        .unwrap_or_default();
+    let span_id = raw.get("span_id").and_then(|v| v.as_u64());
+    let timestamp = raw
+        .get("timestamp")
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+    Some(PortalTemplateRender {
+        template_uri,
+        template_revision_hash,
+        rendered_bytes,
+        provider,
+        model,
+        family,
+        capabilities,
+        branches,
+        span_id,
+        timestamp,
+    })
+}
+
+fn extract_template_branch(raw: &serde_json::Value) -> Option<PortalTemplateBranch> {
+    let kind = raw.get("kind").and_then(|v| v.as_str())?.to_string();
+    let template_uri = raw
+        .get("template_uri")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let line = raw.get("line").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
+    let col = raw.get("col").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
+    let branch_id = raw
+        .get("branch_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let branch_label = raw
+        .get("branch_label")
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+    Some(PortalTemplateBranch {
+        kind,
+        template_uri,
+        line,
+        col,
+        branch_id,
+        branch_label,
+    })
 }
 
 fn summarize_transcript_step(step: &PortalTranscriptStep) -> String {

--- a/crates/harn-cli/src/config.rs
+++ b/crates/harn-cli/src/config.rs
@@ -21,6 +21,7 @@
 //! require_file_header = false
 //! complexity_threshold = 25
 //! persona_step_allowlist = ["legacy_helper"]
+//! template_variant_branch_threshold = 3
 //!
 //! # Reusable fleets consumed by `harn eval prompt --fleet-name <name>`.
 //! [eval.fleets.frontier]
@@ -84,6 +85,10 @@ pub struct LintConfig {
     /// bodies without being declared as `@step`.
     #[serde(default, alias = "persona-step-allowlist")]
     pub persona_step_allowlist: Vec<String>,
+    /// Threshold for the `template-variant-explosion` rule. Defaults
+    /// to [`harn_lint::DEFAULT_TEMPLATE_VARIANT_BRANCH_THRESHOLD`].
+    #[serde(default, alias = "template-variant-branch-threshold")]
+    pub template_variant_branch_threshold: Option<usize>,
 }
 
 /// `[eval]` section of `harn.toml`. Reserves a `[eval.fleets.<name>]`

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -316,8 +316,9 @@ async fn async_main() {
         Command::Lint(args) => {
             let targets: Vec<&str> = args.targets.iter().map(String::as_str).collect();
             let files = commands::check::collect_harn_targets(&targets);
-            if files.is_empty() {
-                command_error("no .harn files found under the given target(s)");
+            let prompt_files = commands::check::collect_prompt_targets(&targets);
+            if files.is_empty() && prompt_files.is_empty() {
+                command_error("no .harn or .harn.prompt files found under the given target(s)");
             }
             let module_graph = commands::check::build_module_graph(&files);
             let cross_file_imports = commands::check::collect_cross_file_imports(&module_graph);
@@ -341,6 +342,16 @@ async fn async_main() {
                         &persona_step_allowlist,
                     );
                 }
+                for file in &prompt_files {
+                    let threshold =
+                        commands::check::harn_lint_template_variant_branch_threshold(file);
+                    let disabled = commands::check::harn_lint_disabled_rules(file);
+                    // The template lint rules don't carry autofix
+                    // edits yet (intentionally — see
+                    // `template_provider_identity::make_diagnostic`),
+                    // so `--fix` is equivalent to a regular run.
+                    commands::check::lint_prompt_file_inner(file, threshold, &disabled);
+                }
             } else {
                 let mut should_fail = false;
                 for file in &files {
@@ -361,6 +372,15 @@ async fn async_main() {
                         complexity_threshold,
                         &persona_step_allowlist,
                     );
+                    should_fail |= outcome.should_fail(config.strict);
+                }
+                for file in &prompt_files {
+                    let threshold =
+                        commands::check::harn_lint_template_variant_branch_threshold(file);
+                    let disabled = commands::check::harn_lint_disabled_rules(file);
+                    let config = package::load_check_config(Some(file));
+                    let outcome =
+                        commands::check::lint_prompt_file_inner(file, threshold, &disabled);
                     should_fail |= outcome.should_fail(config.strict);
                 }
                 if should_fail {

--- a/crates/harn-lint/src/lib.rs
+++ b/crates/harn-lint/src/lib.rs
@@ -25,6 +25,59 @@ mod tests;
 pub use diagnostic::{LintDiagnostic, LintOptions, LintSeverity, DEFAULT_COMPLEXITY_THRESHOLD};
 pub use naming::simplify_bool_comparison;
 pub use rules::file_header::derive_file_header_title;
+pub use rules::template_variant_explosion::DEFAULT_BRANCH_THRESHOLD as DEFAULT_TEMPLATE_VARIANT_BRANCH_THRESHOLD;
+
+/// Lint a single `.harn.prompt` template source. Returns the
+/// diagnostics produced by the template-specific lint rules
+/// (`template-provider-identity-branch`, `template-variant-explosion`).
+///
+/// `branch_threshold` overrides the default for the variant-
+/// explosion rule (see [`DEFAULT_TEMPLATE_VARIANT_BRANCH_THRESHOLD`]);
+/// `disabled_rules` is the same comma-separated list `harn lint`
+/// accepts everywhere else.
+///
+/// Returns a single `LintDiagnostic` with rule `"template-parse"`
+/// when the template doesn't parse — surface that to the user before
+/// continuing, mirroring how `harn lint` reports parse failures for
+/// `.harn` programs.
+pub fn lint_prompt_template(
+    source: &str,
+    branch_threshold: Option<usize>,
+    disabled_rules: &[String],
+) -> Vec<LintDiagnostic> {
+    let constructs = match harn_vm::stdlib::template::lint::parse(source) {
+        Ok(constructs) => constructs,
+        Err(message) => {
+            return vec![LintDiagnostic {
+                rule: "template-parse",
+                message: format!("template did not parse: {message}"),
+                span: harn_lexer::Span::dummy(),
+                severity: LintSeverity::Error,
+                suggestion: None,
+                fix: None,
+            }];
+        }
+    };
+    let threshold = branch_threshold.unwrap_or(DEFAULT_TEMPLATE_VARIANT_BRANCH_THRESHOLD);
+    let mut diagnostics = Vec::new();
+    diagnostics.extend(rules::template_provider_identity::check(
+        &constructs,
+        source,
+    ));
+    diagnostics.extend(rules::template_variant_explosion::check(
+        &constructs,
+        threshold,
+        source,
+    ));
+    if disabled_rules.is_empty() {
+        diagnostics
+    } else {
+        diagnostics
+            .into_iter()
+            .filter(|d| !rule_disabled(d.rule, disabled_rules))
+            .collect()
+    }
+}
 
 use linter::Linter;
 use rules::file_header::check_require_file_header;

--- a/crates/harn-lint/src/rules/mod.rs
+++ b/crates/harn-lint/src/rules/mod.rs
@@ -10,5 +10,7 @@ pub(crate) mod deprecated_llm_options;
 pub(crate) mod file_header;
 pub(crate) mod import_order;
 pub(crate) mod optional_shorthand;
+pub(crate) mod template_provider_identity;
+pub(crate) mod template_variant_explosion;
 pub(crate) mod trailing_comma;
 pub(crate) mod unnecessary_parentheses;

--- a/crates/harn-lint/src/rules/template_provider_identity.rs
+++ b/crates/harn-lint/src/rules/template_provider_identity.rs
@@ -1,0 +1,201 @@
+//! `template-provider-identity-branch` lint rule.
+//!
+//! Warn when a `.harn.prompt` template branches on `llm.provider`,
+//! `llm.model`, or `llm.family` directly. Identity-string branches
+//! are the vendor-lock trap every framework before #1663 fell into —
+//! the rule nudges authors toward capability-flag dispatch instead.
+//!
+//! The diagnostic surfaces a recommended capability-flag replacement
+//! in its body (e.g. `llm.provider == "anthropic"` →
+//! `llm.capabilities.prefers_xml_scaffolding`), but no autofix is
+//! attached — the mapping from identity-string to capability isn't
+//! 1-to-1 enough to apply blindly; the author has to pick the flag
+//! that matches the branch's intent.
+
+use harn_lexer::Span;
+use harn_vm::stdlib::template::lint::{ConditionShape, IdentityField, LintConstruct};
+
+use crate::diagnostic::{LintDiagnostic, LintSeverity};
+
+pub(crate) const RULE_NAME: &str = "template-provider-identity-branch";
+
+/// Walk parsed template constructs and emit one diagnostic per
+/// identity-string branch.
+pub(crate) fn check(constructs: &[LintConstruct], source: &str) -> Vec<LintDiagnostic> {
+    let mut diagnostics = Vec::new();
+    for construct in constructs {
+        let LintConstruct::IfChain { branches } = construct else {
+            continue;
+        };
+        for branch in branches {
+            let ConditionShape::ProviderIdentity(field) = &branch.condition else {
+                continue;
+            };
+            diagnostics.push(make_diagnostic(*field, branch.line, branch.col, source));
+        }
+    }
+    diagnostics
+}
+
+fn make_diagnostic(field: IdentityField, line: usize, col: usize, source: &str) -> LintDiagnostic {
+    let span = match locate_directive(source, line) {
+        Some((start, end, line, column)) => Span {
+            start,
+            end,
+            line,
+            column,
+            end_line: line,
+        },
+        None => Span {
+            start: 0,
+            end: 0,
+            line: line.max(1),
+            column: col.max(1),
+            end_line: line.max(1),
+        },
+    };
+    let suggestion_text = suggestion(field);
+    let message = format!(
+        "branching on `llm.{}` couples the template to vendor identity strings — \
+         dispatch on a capability flag instead so the prompt stays correct as \
+         models and routing layers change (see harn#1663). {}",
+        field.as_str(),
+        suggestion_text,
+    );
+    LintDiagnostic {
+        rule: RULE_NAME,
+        message,
+        span,
+        severity: LintSeverity::Warning,
+        suggestion: Some(suggestion_text),
+        // Identity-string comparisons span an open question: which
+        // capability flag captures the intent? We expose the
+        // recommended replacement in the diagnostic body, but the
+        // mapping isn't 1-to-1 enough to make an autofix safe — author
+        // must pick the flag that matches the branch's actual purpose.
+        fix: None,
+    }
+}
+
+fn suggestion(field: IdentityField) -> String {
+    match field {
+        IdentityField::Provider => {
+            "For provider==\"anthropic\" replace with `llm.capabilities.prefers_xml_scaffolding`. \
+             For provider==\"openai\" replace with `llm.capabilities.prefers_markdown_scaffolding` \
+             or `llm.capabilities.prefers_role_developer`. For local/qwen routes use \
+             `llm.capabilities.text_tool_wire_format_supported` or \
+             `llm.capabilities.native_tools`."
+                .to_string()
+        }
+        IdentityField::Model => {
+            "Model-string branches don't survive routing/aliasing. If the branch tracks a \
+             real capability difference, use the corresponding `llm.capabilities.<flag>`; \
+             otherwise lift the decision out of the template (`agent_preset` / `llm_call` \
+             options handle it once)."
+                .to_string()
+        }
+        IdentityField::Family => {
+            "Family branches are still vendor-lock: `gpt-5.4` and `gpt-4o` share a family \
+             but have different capability profiles. Dispatch on the specific \
+             `llm.capabilities.<flag>` you care about instead."
+                .to_string()
+        }
+    }
+}
+
+/// Find the byte offsets of the `{{ if ... }}` (or `{{ elif ... }}`)
+/// directive on the given line, plus its line/column for the diagnostic
+/// underline. Falls back to the line as a whole when the directive can't
+/// be located (e.g. multi-line wrapping). Returning `None` causes the
+/// caller to emit a span without a byte range.
+fn locate_directive(source: &str, line: usize) -> Option<(usize, usize, usize, usize)> {
+    if line == 0 {
+        return None;
+    }
+    let mut offset = 0usize;
+    for (current_line, src_line) in source.split_inclusive('\n').enumerate() {
+        let line_no = current_line + 1;
+        if line_no == line {
+            for needle in ["{{ if ", "{{if ", "{{ elif ", "{{elif "] {
+                if let Some(rel) = src_line.find(needle) {
+                    let start = offset + rel;
+                    let end_rel = src_line[rel..]
+                        .find("}}")
+                        .map(|idx| rel + idx + 2)
+                        .unwrap_or(src_line.len());
+                    let end = offset + end_rel;
+                    let column = utf8_column_for_byte_offset(src_line, rel).unwrap_or(rel + 1);
+                    return Some((start, end, line_no, column));
+                }
+            }
+            return None;
+        }
+        offset += src_line.len();
+    }
+    None
+}
+
+fn utf8_column_for_byte_offset(line: &str, byte_offset: usize) -> Option<usize> {
+    let prefix = line.get(..byte_offset)?;
+    Some(prefix.chars().count() + 1)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::lint_prompt_template;
+
+    fn diags(src: &str) -> Vec<crate::LintDiagnostic> {
+        lint_prompt_template(src, None, &[])
+    }
+
+    fn rule_count(d: &[crate::LintDiagnostic], rule: &str) -> usize {
+        d.iter().filter(|x| x.rule == rule).count()
+    }
+
+    #[test]
+    fn provider_equality_triggers_one_diag() {
+        let d = diags("{{ if llm.provider == \"anthropic\" }}x{{ end }}");
+        assert_eq!(rule_count(&d, super::RULE_NAME), 1);
+        assert!(d[0].message.contains("prefers_xml_scaffolding"));
+    }
+
+    #[test]
+    fn model_inequality_triggers_diag() {
+        let d = diags("{{ if llm.model != \"gpt-5\" }}x{{ end }}");
+        assert_eq!(rule_count(&d, super::RULE_NAME), 1);
+        assert!(d[0].message.contains("`llm.model`"));
+    }
+
+    #[test]
+    fn family_branch_triggers_diag() {
+        let d = diags("{{ if llm.family == \"claude\" }}x{{ end }}");
+        assert_eq!(rule_count(&d, super::RULE_NAME), 1);
+        assert!(d[0].message.contains("`llm.family`"));
+    }
+
+    #[test]
+    fn capability_branch_is_not_flagged() {
+        let d = diags("{{ if llm.capabilities.native_tools }}x{{ end }}");
+        assert_eq!(rule_count(&d, super::RULE_NAME), 0);
+    }
+
+    #[test]
+    fn elif_chain_flags_each_identity_branch() {
+        let d = diags(
+            "{{ if llm.provider == \"openai\" }}o\
+             {{ elif llm.model == \"gpt-5\" }}g\
+             {{ else }}x{{ end }}",
+        );
+        assert_eq!(rule_count(&d, super::RULE_NAME), 2);
+    }
+
+    #[test]
+    fn rule_can_be_disabled() {
+        let d = lint_prompt_template(
+            "{{ if llm.provider == \"anthropic\" }}x{{ end }}",
+            None,
+            &[super::RULE_NAME.to_string()],
+        );
+        assert_eq!(rule_count(&d, super::RULE_NAME), 0);
+    }
+}

--- a/crates/harn-lint/src/rules/template_variant_explosion.rs
+++ b/crates/harn-lint/src/rules/template_variant_explosion.rs
@@ -1,0 +1,170 @@
+//! `template-variant-explosion` lint rule.
+//!
+//! Warn when a single `.harn.prompt` template has more than `N`
+//! capability-aware conditionals. The literature's #1 failure mode
+//! for prompt-variant systems is combinatorial explosion + silent
+//! drift between materializations — keeping branch count low keeps
+//! the rendered prompts comparable.
+//!
+//! Threshold defaults to `3` and is configurable via
+//! `[lint] template_variant_branch_threshold` in `harn.toml`.
+
+use harn_lexer::Span;
+use harn_vm::stdlib::template::lint::{ConditionShape, LintConstruct};
+
+use crate::diagnostic::{LintDiagnostic, LintSeverity};
+
+pub(crate) const RULE_NAME: &str = "template-variant-explosion";
+
+/// Default threshold; see [`template_variant_branch_threshold`] in
+/// `harn_cli::config::LintConfig`. Picked to match the issue's stated
+/// default (#1669).
+pub const DEFAULT_BRANCH_THRESHOLD: usize = 3;
+
+/// Emit a single diagnostic per template when the count of
+/// capability-aware conditional branches exceeds `threshold`. The
+/// diagnostic anchors to the first capability branch so the author
+/// sees a location to click into.
+pub(crate) fn check(
+    constructs: &[LintConstruct],
+    threshold: usize,
+    source: &str,
+) -> Vec<LintDiagnostic> {
+    let mut capability_branches: Vec<(usize, usize)> = Vec::new();
+    for construct in constructs {
+        if let LintConstruct::IfChain { branches } = construct {
+            for branch in branches {
+                if matches!(branch.condition, ConditionShape::CapabilityFlag { .. }) {
+                    capability_branches.push((branch.line, branch.col));
+                }
+            }
+        }
+    }
+    if capability_branches.len() <= threshold {
+        return Vec::new();
+    }
+    let (line, col) = capability_branches.first().copied().unwrap_or((1, 1));
+    let span = anchor_span(source, line, col);
+    let count = capability_branches.len();
+    let message = format!(
+        "this template has {count} capability-aware branches but the configured \
+         threshold is {threshold}. Combinatorial explosion + drift between \
+         materializations is the #1 failure mode for prompt-variant systems — \
+         consider splitting into logical sections (`{{{{ section \"task\" }}}}`, \
+         `{{{{ section \"tools\" }}}}`, …) so the capability dispatch lives in \
+         one shared place instead of being scattered across the prompt.",
+    );
+    vec![LintDiagnostic {
+        rule: RULE_NAME,
+        message,
+        span,
+        severity: LintSeverity::Warning,
+        suggestion: Some(
+            "Lift each capability branch into a logical section (see \
+             docs/src/prompt-templating.md#logical-sections) or raise \
+             `[lint] template_variant_branch_threshold` in harn.toml if the \
+             count is intentional."
+                .to_string(),
+        ),
+        fix: None,
+    }]
+}
+
+fn anchor_span(source: &str, line: usize, col: usize) -> Span {
+    if line == 0 {
+        return Span::dummy();
+    }
+    let mut offset = 0usize;
+    for (current_line, src_line) in source.split_inclusive('\n').enumerate() {
+        if current_line + 1 == line {
+            let start = offset;
+            let end = offset + src_line.trim_end_matches('\n').len();
+            return Span {
+                start,
+                end,
+                line,
+                column: col.max(1),
+                end_line: line,
+            };
+        }
+        offset += src_line.len();
+    }
+    Span::dummy()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::lint_prompt_template;
+
+    fn rule_count(d: &[crate::LintDiagnostic], rule: &str) -> usize {
+        d.iter().filter(|x| x.rule == rule).count()
+    }
+
+    fn many_branches(n: usize) -> String {
+        (0..n)
+            .map(|i| {
+                let flag = match i % 4 {
+                    0 => "native_tools",
+                    1 => "prefers_xml_scaffolding",
+                    2 => "supports_assistant_prefill",
+                    _ => "prefers_markdown_scaffolding",
+                };
+                format!("{{{{ if llm.capabilities.{flag} }}}}x{{{{ end }}}}")
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn under_threshold_no_diag() {
+        let d = lint_prompt_template(&many_branches(3), None, &[]);
+        assert_eq!(rule_count(&d, super::RULE_NAME), 0);
+    }
+
+    #[test]
+    fn over_threshold_emits_one_diag() {
+        let d = lint_prompt_template(&many_branches(5), None, &[]);
+        assert_eq!(rule_count(&d, super::RULE_NAME), 1);
+        let diag = d.iter().find(|x| x.rule == super::RULE_NAME).unwrap();
+        assert!(diag.message.contains("5 capability-aware branches"));
+        assert!(diag.message.contains("threshold is 3"));
+    }
+
+    #[test]
+    fn configurable_threshold_lifts_signal() {
+        // With default threshold 3, 4 branches would fire. With an
+        // explicit threshold of 5 the rule should not fire.
+        let d = lint_prompt_template(&many_branches(4), Some(5), &[]);
+        assert_eq!(rule_count(&d, super::RULE_NAME), 0);
+    }
+
+    #[test]
+    fn provider_identity_branches_do_not_count_toward_explosion() {
+        let identity_branches = (0..5)
+            .map(|i| {
+                let provider = match i % 3 {
+                    0 => "anthropic",
+                    1 => "openai",
+                    _ => "google",
+                };
+                format!("{{{{ if llm.provider == \"{provider}\" }}}}x{{{{ end }}}}")
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        let d = lint_prompt_template(&identity_branches, None, &[]);
+        // template-variant-explosion is about capability flags
+        // specifically — identity branches get caught by the sibling
+        // rule, not double-counted here.
+        assert_eq!(rule_count(&d, super::RULE_NAME), 0);
+        assert_eq!(
+            rule_count(&d, super::super::template_provider_identity::RULE_NAME),
+            5,
+        );
+    }
+
+    #[test]
+    fn rule_can_be_disabled() {
+        let d = lint_prompt_template(&many_branches(6), None, &[super::RULE_NAME.to_string()]);
+        assert_eq!(rule_count(&d, super::RULE_NAME), 0);
+    }
+}

--- a/crates/harn-vm/src/llm/agent_observe.rs
+++ b/crates/harn-vm/src/llm/agent_observe.rs
@@ -323,6 +323,90 @@ fn append_llm_transcript_event_log(entry: &serde_json::Value) {
     }
 }
 
+/// Record a `template.render` transcript event for a `render()` /
+/// `render_prompt()` call that resolved under an LLM-aware frame.
+/// Captures the active LLM identity + capability snapshot plus the
+/// branch trace produced during rendering. Replay determinism is
+/// guaranteed by the renderer itself; this function is purely a
+/// serializer.
+pub fn record_template_render(
+    template_uri: &str,
+    template_revision_hash: &str,
+    ctx: &crate::stdlib::template::LlmRenderContext,
+    trace: &[crate::stdlib::template::BranchDecision],
+    rendered_bytes: usize,
+) {
+    let branches = trace
+        .iter()
+        .map(|decision| {
+            let mut entry = serde_json::Map::new();
+            entry.insert(
+                "kind".to_string(),
+                serde_json::Value::String(decision.kind.as_str().to_string()),
+            );
+            entry.insert(
+                "template_uri".to_string(),
+                serde_json::Value::String(decision.template_uri.clone()),
+            );
+            entry.insert("line".to_string(), serde_json::json!(decision.line));
+            entry.insert("col".to_string(), serde_json::json!(decision.col));
+            entry.insert(
+                "branch_id".to_string(),
+                serde_json::Value::String(decision.branch_id.clone()),
+            );
+            if let Some(label) = decision.branch_label.as_ref() {
+                entry.insert(
+                    "branch_label".to_string(),
+                    serde_json::Value::String(label.clone()),
+                );
+            }
+            serde_json::Value::Object(entry)
+        })
+        .collect::<Vec<_>>();
+    let llm = serde_json::json!({
+        "provider": ctx.provider,
+        "model": ctx.model,
+        "family": ctx.family,
+        "capabilities": vm_value_to_json(&ctx.capabilities),
+    });
+    let mut fields = serde_json::Map::new();
+    fields.insert(
+        "template_uri".to_string(),
+        serde_json::Value::String(template_uri.to_string()),
+    );
+    fields.insert(
+        "template_revision_hash".to_string(),
+        serde_json::Value::String(template_revision_hash.to_string()),
+    );
+    fields.insert("llm".to_string(), llm);
+    fields.insert("branches".to_string(), serde_json::Value::Array(branches));
+    fields.insert(
+        "rendered_bytes".to_string(),
+        serde_json::json!(rendered_bytes),
+    );
+    append_llm_observability_entry("template.render", fields);
+}
+
+fn vm_value_to_json(value: &crate::value::VmValue) -> serde_json::Value {
+    use crate::value::VmValue;
+    match value {
+        VmValue::Nil => serde_json::Value::Null,
+        VmValue::Bool(b) => serde_json::Value::Bool(*b),
+        VmValue::Int(n) => serde_json::json!(*n),
+        VmValue::Float(f) => serde_json::json!(*f),
+        VmValue::String(s) => serde_json::Value::String(s.to_string()),
+        VmValue::List(items) => {
+            serde_json::Value::Array(items.iter().map(vm_value_to_json).collect())
+        }
+        VmValue::Dict(d) => serde_json::Value::Object(
+            d.iter()
+                .map(|(k, v)| (k.clone(), vm_value_to_json(v)))
+                .collect(),
+        ),
+        other => serde_json::Value::String(other.display()),
+    }
+}
+
 pub(crate) fn append_llm_observability_entry(
     event_type: &str,
     mut fields: serde_json::Map<String, serde_json::Value>,
@@ -995,6 +1079,55 @@ mod retry_tests {
             message: msg.to_string(),
             category,
         }
+    }
+
+    #[test]
+    fn template_render_event_round_trips_through_jsonl() {
+        use crate::stdlib::template::{
+            render_template_to_string, LlmRenderContext, LlmRenderContextGuard,
+        };
+        let dir = tempfile::tempdir().expect("tempdir");
+        push_llm_transcript_dir(dir.path().to_str().expect("utf8"));
+        {
+            let _ctx = LlmRenderContextGuard::enter(LlmRenderContext::resolve(
+                "anthropic",
+                "claude-opus-4-7",
+            ));
+            let rendered = render_template_to_string(
+                "{{ if llm.capabilities.native_tools }}native{{ else }}text{{ end }}\
+                 {{ section \"task\" }}b{{ endsection }}",
+                None,
+                None,
+                None,
+            )
+            .expect("render");
+            assert!(rendered.contains("native"));
+            assert!(rendered.contains("<task>"));
+        }
+        pop_llm_transcript_dir();
+        let transcript = std::fs::read_to_string(dir.path().join("llm_transcript.jsonl"))
+            .expect("read transcript");
+        let line = transcript
+            .lines()
+            .find(|line| line.contains("\"template.render\""))
+            .expect("template.render event present");
+        let event: serde_json::Value = serde_json::from_str(line).expect("parse event");
+        assert_eq!(event["type"], "template.render");
+        assert_eq!(event["llm"]["provider"], "anthropic");
+        assert_eq!(event["llm"]["family"], "claude");
+        assert_eq!(event["llm"]["capabilities"]["native_tools"], true);
+        let branches = event["branches"].as_array().expect("branches array");
+        let if_branch = branches
+            .iter()
+            .find(|b| b["kind"] == "if")
+            .expect("if branch present");
+        assert_eq!(if_branch["branch_id"], "if");
+        let section_branch = branches
+            .iter()
+            .find(|b| b["kind"] == "section")
+            .expect("section branch present");
+        assert_eq!(section_branch["branch_id"], "xml");
+        assert_eq!(section_branch["branch_label"], "task");
     }
 
     #[test]

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -12,7 +12,7 @@
 //! - `config_builtins`: Provider configuration query builtins
 
 mod agent_config;
-mod agent_observe;
+pub(crate) mod agent_observe;
 mod agent_runtime;
 mod agent_session_host;
 mod agent_tools;

--- a/crates/harn-vm/src/stdlib/template/assets.rs
+++ b/crates/harn-vm/src/stdlib/template/assets.rs
@@ -137,6 +137,14 @@ impl TemplateAsset {
         }
     }
 
+    /// Stable content hash for the template source, used as the
+    /// `template_revision_hash` field on `template.render` transcript
+    /// events so replay can detect "the rendered text matches but the
+    /// source drifted underneath" drift (#1668).
+    pub(crate) fn template_revision_hash(&self) -> String {
+        blake3::hash(self.source.as_bytes()).to_hex().to_string()
+    }
+
     pub(crate) fn error_path(&self) -> Option<PathBuf> {
         match &self.location {
             TemplateLocation::Inline { source_path, .. } => source_path.clone(),

--- a/crates/harn-vm/src/stdlib/template/ast.rs
+++ b/crates/harn-vm/src/stdlib/template/ast.rs
@@ -7,7 +7,7 @@ pub(super) enum Node {
         col: usize,
     },
     If {
-        branches: Vec<(Expr, Vec<Node>)>,
+        branches: Vec<IfBranch>,
         else_branch: Option<Vec<Node>>,
         line: usize,
         col: usize,
@@ -39,6 +39,18 @@ pub(super) enum Node {
     LegacyBareInterp {
         ident: String,
     },
+}
+
+/// One `{{ if expr }}` or `{{ elif expr }}` branch inside an
+/// [`Node::If`] chain. Tracks per-branch source position so lint
+/// rules and the branch-trace recorder can point at the specific
+/// `{{ if }} / {{ elif }}` directive that fired (or didn't).
+#[derive(Debug, Clone)]
+pub(super) struct IfBranch {
+    pub(super) cond: Expr,
+    pub(super) line: usize,
+    pub(super) col: usize,
+    pub(super) body: Vec<Node>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/harn-vm/src/stdlib/template/lint.rs
+++ b/crates/harn-vm/src/stdlib/template/lint.rs
@@ -1,0 +1,337 @@
+//! AST surface that `harn-lint` consumes to enforce `.harn.prompt`
+//! drift-prevention rules (#1669).
+//!
+//! The template parser and AST are otherwise internal — exposing a
+//! shallow read-only view through this module keeps the lint crate
+//! free of template-engine internals while still giving rules enough
+//! structure to walk conditionals, sections, and includes.
+
+use super::ast::{BinOp, Expr, Node, PathSeg};
+use super::parser::parse as parse_template;
+
+/// Parse a template source string into a flat list of lintable
+/// constructs (conditionals + sections). Returns `Err` when the
+/// template doesn't parse — callers should surface the underlying
+/// `validate_template_syntax` error to the user before linting.
+pub fn parse(src: &str) -> Result<Vec<LintConstruct>, String> {
+    let nodes = parse_template(src).map_err(|error| error.message())?;
+    let mut out = Vec::new();
+    walk_nodes(&nodes, &mut out);
+    Ok(out)
+}
+
+/// One lintable construct, materialized in source order so rules can
+/// reason about counts (e.g. branch-explosion) and individual call
+/// sites (e.g. provider-identity comparisons).
+#[derive(Debug, Clone)]
+pub enum LintConstruct {
+    /// An `{{ if .. }}` / `{{ elif }}` chain. One entry per condition
+    /// in the chain (the trailing `{{ else }}` is implicit and not
+    /// listed). Conditions are flattened across `elif` to make
+    /// branch-count rules straightforward.
+    IfChain { branches: Vec<IfBranch> },
+    /// A `{{ section "..." }}` block. Sections are themselves
+    /// capability-adaptive but never look identity-driven; rules use
+    /// this to count capability-aware partials.
+    Section {
+        name: String,
+        line: usize,
+        col: usize,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub struct IfBranch {
+    pub line: usize,
+    pub col: usize,
+    pub condition: ConditionShape,
+}
+
+/// Coarse classification of an `{{ if expr }}` condition. The lint
+/// rules don't need to evaluate or fully reconstruct expressions —
+/// just enough structure to detect the two failure patterns called
+/// out in #1669:
+///
+/// - Identity comparisons (`llm.provider == "..."`).
+/// - Capability-flag branches (`llm.capabilities.<flag>`), which the
+///   variant-explosion rule counts.
+///
+/// Conditions outside these shapes resolve to `Other` and don't
+/// participate in either rule.
+#[derive(Debug, Clone)]
+pub enum ConditionShape {
+    /// `llm.provider == "..."` / `llm.model == "..."` /
+    /// `llm.family == "..."` (or `!=`).
+    ProviderIdentity(IdentityField),
+    /// Any path-based condition mentioning `llm.capabilities.<flag>`
+    /// (including negation and use as a comparison operand). The
+    /// variant-explosion rule counts every branch with this shape.
+    /// Source position lives on the surrounding [`IfBranch`].
+    CapabilityFlag {
+        flag: String,
+    },
+    Other,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IdentityField {
+    Provider,
+    Model,
+    Family,
+}
+
+impl IdentityField {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            IdentityField::Provider => "provider",
+            IdentityField::Model => "model",
+            IdentityField::Family => "family",
+        }
+    }
+}
+
+fn walk_nodes(nodes: &[Node], out: &mut Vec<LintConstruct>) {
+    for node in nodes {
+        walk_node(node, out);
+    }
+}
+
+fn walk_node(node: &Node, out: &mut Vec<LintConstruct>) {
+    match node {
+        Node::Text(_) | Node::Expr { .. } | Node::LegacyBareInterp { .. } => {}
+        Node::If {
+            branches,
+            else_branch,
+            line: _,
+            col: _,
+        } => {
+            let mut summary = Vec::with_capacity(branches.len());
+            for branch in branches {
+                summary.push(IfBranch {
+                    line: branch.line,
+                    col: branch.col,
+                    condition: classify_condition(&branch.cond),
+                });
+                walk_nodes(&branch.body, out);
+            }
+            out.push(LintConstruct::IfChain { branches: summary });
+            if let Some(else_body) = else_branch {
+                walk_nodes(else_body, out);
+            }
+        }
+        Node::For { body, empty, .. } => {
+            walk_nodes(body, out);
+            if let Some(empty) = empty {
+                walk_nodes(empty, out);
+            }
+        }
+        Node::Include { .. } => {
+            // Include resolution happens at render time. Linting only
+            // walks the calling template; the included partial gets
+            // linted independently when the linter encounters it.
+        }
+        Node::Section {
+            name,
+            body,
+            line,
+            col,
+            ..
+        } => {
+            out.push(LintConstruct::Section {
+                name: name.clone(),
+                line: *line,
+                col: *col,
+            });
+            walk_nodes(body, out);
+        }
+    }
+}
+
+/// Classify the top-level shape of an `{{ if expr }}` condition.
+fn classify_condition(expr: &Expr) -> ConditionShape {
+    if let Some(identity) = match_identity_compare(expr) {
+        return ConditionShape::ProviderIdentity(identity);
+    }
+    if let Some(capability) = match_capability_path(expr) {
+        return capability;
+    }
+    ConditionShape::Other
+}
+
+/// Match `llm.<provider|model|family> == "..."` or `!= "..."`,
+/// returning the LHS identity field that was compared.
+fn match_identity_compare(expr: &Expr) -> Option<IdentityField> {
+    let Expr::Binary(op, lhs, rhs) = expr else {
+        return None;
+    };
+    if !matches!(op, BinOp::Eq | BinOp::Neq) {
+        return None;
+    }
+    let path = match (lhs.as_ref(), rhs.as_ref()) {
+        (Expr::Path(p), Expr::Str(_)) | (Expr::Str(_), Expr::Path(p)) => p,
+        _ => return None,
+    };
+    if !path_starts_with_llm(path) {
+        return None;
+    }
+    match path.get(1) {
+        Some(PathSeg::Field(name) | PathSeg::Key(name)) if name == "provider" => {
+            Some(IdentityField::Provider)
+        }
+        Some(PathSeg::Field(name) | PathSeg::Key(name)) if name == "model" => {
+            Some(IdentityField::Model)
+        }
+        Some(PathSeg::Field(name) | PathSeg::Key(name)) if name == "family" => {
+            Some(IdentityField::Family)
+        }
+        _ => None,
+    }
+}
+
+/// Match `llm.capabilities.<flag>` (possibly negated by `!`) or
+/// `llm.capabilities.<flag> == <literal>`, returning the flag name.
+fn match_capability_path(expr: &Expr) -> Option<ConditionShape> {
+    fn find_capability_path(expr: &Expr) -> Option<String> {
+        match expr {
+            Expr::Path(path) => capability_flag_from_path(path),
+            Expr::Unary(_, inner) => find_capability_path(inner),
+            Expr::Binary(_, lhs, rhs) => {
+                find_capability_path(lhs).or_else(|| find_capability_path(rhs))
+            }
+            Expr::Filter(inner, _, _) => find_capability_path(inner),
+            _ => None,
+        }
+    }
+    let flag = find_capability_path(expr)?;
+    Some(ConditionShape::CapabilityFlag { flag })
+}
+
+fn capability_flag_from_path(path: &[PathSeg]) -> Option<String> {
+    if !path_starts_with_llm(path) {
+        return None;
+    }
+    let Some(PathSeg::Field(name) | PathSeg::Key(name)) = path.get(1) else {
+        return None;
+    };
+    if name != "capabilities" {
+        return None;
+    }
+    let Some(PathSeg::Field(flag) | PathSeg::Key(flag)) = path.get(2) else {
+        return None;
+    };
+    Some(flag.clone())
+}
+
+fn path_starts_with_llm(path: &[PathSeg]) -> bool {
+    matches!(
+        path.first(),
+        Some(PathSeg::Field(name)) if name == "llm",
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_ok(src: &str) -> Vec<LintConstruct> {
+        parse(src).expect("template should parse")
+    }
+
+    fn first_if(constructs: &[LintConstruct]) -> &[IfBranch] {
+        match constructs
+            .iter()
+            .find(|c| matches!(c, LintConstruct::IfChain { .. }))
+            .expect("if chain present")
+        {
+            LintConstruct::IfChain { branches } => branches.as_slice(),
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn provider_identity_eq_detected() {
+        let constructs = parse_ok("{{ if llm.provider == \"anthropic\" }}x{{ else }}y{{ end }}");
+        let branches = first_if(&constructs);
+        assert_eq!(branches.len(), 1);
+        assert!(matches!(
+            branches[0].condition,
+            ConditionShape::ProviderIdentity(IdentityField::Provider)
+        ));
+    }
+
+    #[test]
+    fn model_identity_neq_detected() {
+        let constructs = parse_ok("{{ if llm.model != \"gpt-5\" }}x{{ end }}");
+        let branches = first_if(&constructs);
+        assert!(matches!(
+            branches[0].condition,
+            ConditionShape::ProviderIdentity(IdentityField::Model)
+        ));
+    }
+
+    #[test]
+    fn capability_flag_detected_in_negation_and_filter() {
+        let constructs = parse_ok(
+            "{{ if !llm.capabilities.native_tools }}x{{ end }}\
+             {{ if llm.capabilities.prefers_xml_scaffolding | default: false }}y{{ end }}",
+        );
+        let if_chains: Vec<_> = constructs
+            .iter()
+            .filter_map(|c| match c {
+                LintConstruct::IfChain { branches } => Some(branches.clone()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(if_chains.len(), 2);
+        assert!(matches!(
+            if_chains[0][0].condition,
+            ConditionShape::CapabilityFlag { ref flag, .. } if flag == "native_tools"
+        ));
+        assert!(matches!(
+            if_chains[1][0].condition,
+            ConditionShape::CapabilityFlag { ref flag, .. } if flag == "prefers_xml_scaffolding"
+        ));
+    }
+
+    #[test]
+    fn elif_chain_lifts_per_branch_condition() {
+        let constructs = parse_ok(
+            "{{ if llm.provider == \"openai\" }}a\
+             {{ elif llm.capabilities.native_tools }}b\
+             {{ else }}c{{ end }}",
+        );
+        let branches = first_if(&constructs);
+        assert_eq!(branches.len(), 2);
+        assert!(matches!(
+            branches[0].condition,
+            ConditionShape::ProviderIdentity(IdentityField::Provider)
+        ));
+        assert!(matches!(
+            branches[1].condition,
+            ConditionShape::CapabilityFlag { ref flag, .. } if flag == "native_tools"
+        ));
+    }
+
+    #[test]
+    fn unrelated_condition_falls_through_to_other() {
+        let constructs = parse_ok("{{ if score > 0.5 }}a{{ end }}");
+        let branches = first_if(&constructs);
+        assert!(matches!(branches[0].condition, ConditionShape::Other));
+    }
+
+    #[test]
+    fn sections_listed_in_source_order() {
+        let constructs = parse_ok(
+            "{{ section \"task\" }}t{{ endsection }}\
+             {{ section \"output_format\" }}o{{ endsection }}",
+        );
+        let names: Vec<_> = constructs
+            .iter()
+            .filter_map(|c| match c {
+                LintConstruct::Section { name, .. } => Some(name.clone()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(names, vec!["task", "output_format"]);
+    }
+}

--- a/crates/harn-vm/src/stdlib/template/mod.rs
+++ b/crates/harn-vm/src/stdlib/template/mod.rs
@@ -35,6 +35,7 @@ mod error;
 mod expr_parser;
 mod filters;
 mod lexer;
+pub mod lint;
 mod llm_context;
 mod parser;
 mod render;
@@ -351,6 +352,45 @@ pub struct PromptSourceSpan {
     pub template_uri: String,
 }
 
+/// One conditional or section decision recorded during a template
+/// render. Powers the "variant resolution" trace surfaced in the
+/// portal so on-call engineers can answer "which capability branch
+/// fired for this model?" without re-running the template. Recorded
+/// deterministically — same `llm` snapshot + bindings always produce
+/// the same trace, which is what makes replay reproducible (#1668).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BranchDecision {
+    pub kind: BranchKind,
+    pub template_uri: String,
+    pub line: usize,
+    pub col: usize,
+    /// Short identifier for the taken branch. For `{{ if }}`/`elif`:
+    /// `"if"`, `"elif:<idx>"`, `"else"`, or `"none"` when nothing
+    /// matched and no `{{ else }}` was provided. For `{{ section }}`:
+    /// the materialized envelope (e.g. `"xml"`, `"markdown"`,
+    /// `"native_tools"`, `"react"`).
+    pub branch_id: String,
+    /// Human-readable label. For conditionals: the source-derived
+    /// condition expression (e.g. `llm.capabilities.native_tools`).
+    /// For sections: the section name (e.g. `tools`).
+    pub branch_label: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BranchKind {
+    If,
+    Section,
+}
+
+impl BranchKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            BranchKind::If => "if",
+            BranchKind::Section => "section",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PromptSpanKind {
     /// Literal template text between directives.
@@ -409,6 +449,32 @@ pub(crate) fn render_stdlib_prompt_asset(
     render_asset_result(&asset, bindings).map_err(VmError::from)
 }
 
+/// Test-only helper: render an inline template under the active LLM
+/// render context and return the rendered text plus the branch trace
+/// that drove `template.render` event emission. The same trace is
+/// emitted to the transcript JSONL when a transcript dir is wired in;
+/// exposing it here lets unit tests assert determinism without
+/// scraping the JSONL.
+#[cfg(test)]
+pub(crate) fn render_template_collect_branch_trace(
+    template: &str,
+) -> Result<(String, Vec<BranchDecision>), TemplateError> {
+    let asset = TemplateAsset::inline(template, None, None);
+    let nodes = parse_cached(&asset)?;
+    let mut out = String::with_capacity(asset.source.len());
+    let augmented = augment_bindings_with_llm(&asset, None);
+    let scope_bindings = augmented.as_ref();
+    let mut scope = Scope::new(scope_bindings);
+    let mut rc = RenderCtx {
+        current_asset: asset.clone(),
+        include_stack: Vec::new(),
+        current_include_parent: None,
+        branch_trace: Some(Vec::new()),
+    };
+    render_nodes(&nodes, &mut scope, &mut rc, &mut out, None)?;
+    Ok((out, rc.branch_trace.unwrap_or_default()))
+}
+
 pub(crate) fn render_asset_with_provenance_result(
     asset: &TemplateAsset,
     bindings: Option<&BTreeMap<String, VmValue>>,
@@ -424,10 +490,16 @@ pub(crate) fn render_asset_with_provenance_result(
     let augmented = augment_bindings_with_llm(asset, bindings);
     let scope_bindings = augmented.as_ref().or(bindings);
     let mut scope = Scope::new(scope_bindings);
+    // Only collect a branch trace when an LLM frame is in scope —
+    // that's the only context where the trace adds debugging value
+    // (capability-adaptive rendering), and the empty-trace events
+    // would otherwise spam every doc-gen / CI render.
+    let llm_ctx = current_llm_render_context();
     let mut rc = RenderCtx {
         current_asset: asset.clone(),
         include_stack: Vec::new(),
         current_include_parent: None,
+        branch_trace: llm_ctx.as_ref().map(|_| Vec::new()),
     };
     let mut spans = if collect_provenance {
         Some(Vec::new())
@@ -443,5 +515,27 @@ pub(crate) fn render_asset_with_provenance_result(
         }
         e
     })?;
+    if let (Some(ctx), Some(trace)) = (llm_ctx, rc.branch_trace.take()) {
+        emit_template_render_event(asset, &ctx, &trace, out.len());
+    }
     Ok((out, spans.unwrap_or_default()))
+}
+
+/// Emit a `template.render` transcript event capturing the resolved
+/// LLM identity + capability snapshot and the branch trace produced
+/// during rendering. Implementation in
+/// [`crate::llm::agent_observe::record_template_render`].
+fn emit_template_render_event(
+    asset: &TemplateAsset,
+    ctx: &LlmRenderContext,
+    trace: &[BranchDecision],
+    rendered_bytes: usize,
+) {
+    crate::llm::agent_observe::record_template_render(
+        &asset.uri,
+        asset.template_revision_hash().as_str(),
+        ctx,
+        trace,
+        rendered_bytes,
+    );
 }

--- a/crates/harn-vm/src/stdlib/template/parser.rs
+++ b/crates/harn-vm/src/stdlib/template/parser.rs
@@ -1,4 +1,4 @@
-use super::ast::{Expr, Node};
+use super::ast::{Expr, IfBranch, Node};
 use super::error::TemplateError;
 use super::expr_parser::parse_expr;
 use super::lexer::{tokenize, Token};
@@ -115,9 +115,16 @@ impl<'a> Parser<'a> {
         let mut branches = Vec::new();
         let mut else_branch = None;
         let mut cur_cond = first_cond;
+        let mut cur_line = line;
+        let mut cur_col = col;
         loop {
             let body = self.parse_block(&["end", "else", "elif"])?;
-            branches.push((cur_cond, body));
+            branches.push(IfBranch {
+                cond: cur_cond,
+                line: cur_line,
+                col: cur_col,
+                body,
+            });
             let tok = self.peek().cloned();
             match tok {
                 Some(Token::Directive {
@@ -149,6 +156,8 @@ impl<'a> Parser<'a> {
                         "elif" => {
                             let cond = parse_expr(tbody[4..].trim(), tline, tcol)?;
                             cur_cond = cond;
+                            cur_line = tline;
+                            cur_col = tcol;
                             continue;
                         }
                         _ => unreachable!(),

--- a/crates/harn-vm/src/stdlib/template/render.rs
+++ b/crates/harn-vm/src/stdlib/template/render.rs
@@ -3,10 +3,10 @@ use std::rc::Rc;
 
 use crate::value::{values_equal, VmValue};
 
-use super::ast::{BinOp, Expr, Node, PathSeg, UnOp};
+use super::ast::{BinOp, Expr, IfBranch, Node, PathSeg, UnOp};
 use super::error::TemplateError;
 use super::filters::apply_filter;
-use super::{PromptSourceSpan, PromptSpanKind, TemplateAsset};
+use super::{BranchDecision, BranchKind, PromptSourceSpan, PromptSpanKind, TemplateAsset};
 
 #[derive(Default, Debug, Clone)]
 pub(super) struct Scope<'a> {
@@ -68,6 +68,11 @@ pub(super) struct RenderCtx {
     /// IDE can walk a breadcrumb back through nested includes
     /// (#96). `None` at the top level.
     pub(super) current_include_parent: Option<Box<PromptSourceSpan>>,
+    /// When set, every conditional / section node appends a
+    /// [`BranchDecision`] here so callers can reconstruct which
+    /// capability-adaptive branches fired. Only populated when the
+    /// top-level render entry-point opts in.
+    pub(super) branch_trace: Option<Vec<BranchDecision>>,
 }
 
 /// Template URI reported alongside every span. Filesystem templates use
@@ -159,20 +164,21 @@ fn render_node(
             line,
             col,
         } => {
-            let mut matched = false;
-            for (cond, body) in branches {
-                let v = eval_expr(cond, scope, *line, *col)?;
+            let mut matched: Option<usize> = None;
+            for (idx, branch) in branches.iter().enumerate() {
+                let v = eval_expr(&branch.cond, scope, branch.line, branch.col)?;
                 if truthy(&v) {
-                    render_nodes(body, scope, rc, out, spans.as_deref_mut())?;
-                    matched = true;
+                    render_nodes(&branch.body, scope, rc, out, spans.as_deref_mut())?;
+                    matched = Some(idx);
                     break;
                 }
             }
-            if !matched {
+            if matched.is_none() {
                 if let Some(eb) = else_branch {
                     render_nodes(eb, scope, rc, out, spans.as_deref_mut())?;
                 }
             }
+            record_branch_if(rc, *line, *col, branches, else_branch.is_some(), matched);
             if let Some(spans) = spans.as_deref_mut() {
                 spans.push(PromptSourceSpan {
                     template_line: *line,
@@ -346,6 +352,17 @@ fn render_node(
                 *line,
                 *col,
             )?;
+            let template_uri = current_template_uri(rc);
+            if let Some(trace) = rc.branch_trace.as_mut() {
+                trace.push(BranchDecision {
+                    kind: BranchKind::Section,
+                    template_uri,
+                    line: *line,
+                    col: *col,
+                    branch_id: section.envelope.to_string(),
+                    branch_label: Some(name.clone()),
+                });
+            }
             out.push_str(&section.text);
             if let Some(spans) = spans {
                 if let (Some(child_spans), Some(body_output_start)) =
@@ -379,6 +396,112 @@ fn render_node(
         }
     }
     Ok(())
+}
+
+/// Record a branch decision for an `{{ if }}` chain.
+///
+/// `matched` is the 0-based index of the conditional whose body fired;
+/// `None` means none of the conditions were truthy. `had_else` is true
+/// when the source carried an `{{ else }}` branch, which is the
+/// label used in the trace when no condition matched but an else
+/// rendered.
+fn record_branch_if(
+    rc: &mut RenderCtx,
+    line: usize,
+    col: usize,
+    branches: &[IfBranch],
+    had_else: bool,
+    matched: Option<usize>,
+) {
+    if rc.branch_trace.is_none() {
+        return;
+    }
+    let template_uri = current_template_uri(rc);
+    let (branch_id, branch_label, anchor_line, anchor_col) = match matched {
+        Some(0) => (
+            "if".to_string(),
+            describe_condition(&branches[0].cond),
+            branches[0].line,
+            branches[0].col,
+        ),
+        Some(idx) => (
+            format!("elif:{idx}"),
+            describe_condition(&branches[idx].cond),
+            branches[idx].line,
+            branches[idx].col,
+        ),
+        None if had_else => ("else".to_string(), None, line, col),
+        None => ("none".to_string(), None, line, col),
+    };
+    if let Some(trace) = rc.branch_trace.as_mut() {
+        trace.push(BranchDecision {
+            kind: BranchKind::If,
+            template_uri,
+            line: anchor_line,
+            col: anchor_col,
+            branch_id,
+            branch_label,
+        });
+    }
+}
+
+/// Describe an `{{ if expr }}` condition compactly so the trace shows
+/// *what* gated the branch (e.g. `llm.capabilities.native_tools`). The
+/// renderer doesn't depend on perfect source reconstruction here — the
+/// trace already carries line/col for jump-to-source — but a readable
+/// label helps in the portal's variant-resolution panel.
+fn describe_condition(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::Path(segs) => Some(format_path(segs)),
+        Expr::Unary(UnOp::Not, inner) => describe_condition(inner).map(|s| format!("!{s}")),
+        Expr::Binary(op, a, b) => {
+            let lhs = describe_value(a);
+            let rhs = describe_value(b);
+            let op_str = match op {
+                BinOp::Eq => "==",
+                BinOp::Neq => "!=",
+                BinOp::Lt => "<",
+                BinOp::Le => "<=",
+                BinOp::Gt => ">",
+                BinOp::Ge => ">=",
+                BinOp::And => "&&",
+                BinOp::Or => "||",
+            };
+            Some(format!("{lhs} {op_str} {rhs}"))
+        }
+        Expr::Filter(inner, name, _) => describe_condition(inner).map(|s| format!("{s} | {name}")),
+        _ => Some(describe_value(expr)),
+    }
+}
+
+fn describe_value(expr: &Expr) -> String {
+    match expr {
+        Expr::Nil => "nil".to_string(),
+        Expr::Bool(b) => b.to_string(),
+        Expr::Int(n) => n.to_string(),
+        Expr::Float(f) => f.to_string(),
+        Expr::Str(s) => format!("\"{s}\""),
+        Expr::Path(segs) => format_path(segs),
+        _ => "<expr>".to_string(),
+    }
+}
+
+fn format_path(segs: &[PathSeg]) -> String {
+    let mut out = String::new();
+    for (idx, seg) in segs.iter().enumerate() {
+        match seg {
+            PathSeg::Field(name) | PathSeg::Key(name) => {
+                if idx > 0 {
+                    out.push('.');
+                }
+                out.push_str(name);
+            }
+            PathSeg::Index(i) => {
+                out.push_str(&format!("[{i}]"));
+            }
+        }
+    }
+    out
 }
 
 /// Cap a rendered value's preview at 80 chars so span records don't

--- a/crates/harn-vm/src/stdlib/template/sections.rs
+++ b/crates/harn-vm/src/stdlib/template/sections.rs
@@ -19,6 +19,11 @@ pub(super) struct SectionRender {
     pub(super) body_output_start: Option<usize>,
     pub(super) body_source_start: usize,
     pub(super) body_source_end: usize,
+    /// Capability-driven envelope label recorded in the branch trace
+    /// (e.g. `xml`, `markdown`, `thinking_blocks`, `react`). Distinct
+    /// from the section *name* (which is what the author wrote) so the
+    /// trace shows which materialization fired for the active model.
+    pub(super) envelope: &'static str,
 }
 
 #[derive(Debug, Default)]
@@ -109,16 +114,32 @@ enum Scaffold {
     Plain,
 }
 
+impl Scaffold {
+    fn label(self) -> &'static str {
+        match self {
+            Scaffold::Xml => "xml",
+            Scaffold::Markdown => "markdown",
+            Scaffold::Plain => "plain",
+        }
+    }
+}
+
 fn render_scaffolded(
     xml_tag: &str,
     title: &str,
     body: &str,
     profile: &SectionProfile,
 ) -> SectionRender {
-    match profile.scaffold() {
-        Scaffold::Xml => wrap_body(body, &format!("<{xml_tag}>\n"), &format!("\n</{xml_tag}>")),
-        Scaffold::Markdown => wrap_body(body, &format!("## {title}\n"), ""),
-        Scaffold::Plain => wrap_body(body, &format!("{title}:\n"), ""),
+    let scaffold = profile.scaffold();
+    match scaffold {
+        Scaffold::Xml => wrap_body(
+            body,
+            &format!("<{xml_tag}>\n"),
+            &format!("\n</{xml_tag}>"),
+            scaffold.label(),
+        ),
+        Scaffold::Markdown => wrap_body(body, &format!("## {title}\n"), "", scaffold.label()),
+        Scaffold::Plain => wrap_body(body, &format!("{title}:\n"), "", scaffold.label()),
     }
 }
 
@@ -128,15 +149,30 @@ fn render_system_framing(body: &str, profile: &SectionProfile) -> SectionRender 
     } else {
         "system"
     };
-    match profile.scaffold() {
-        Scaffold::Xml => wrap_body(body, &format!("<{role}>\n"), &format!("\n</{role}>")),
+    let scaffold = profile.scaffold();
+    let envelope = if profile.prefers_role_developer {
+        match scaffold {
+            Scaffold::Xml => "xml_developer",
+            Scaffold::Markdown => "markdown_developer",
+            Scaffold::Plain => "plain_developer",
+        }
+    } else {
+        scaffold.label()
+    };
+    match scaffold {
+        Scaffold::Xml => wrap_body(
+            body,
+            &format!("<{role}>\n"),
+            &format!("\n</{role}>"),
+            envelope,
+        ),
         Scaffold::Markdown => {
             let title = if profile.prefers_role_developer {
                 "Developer Instructions"
             } else {
                 "System Instructions"
             };
-            wrap_body(body, &format!("## {title}\n"), "")
+            wrap_body(body, &format!("## {title}\n"), "", envelope)
         }
         Scaffold::Plain => {
             let title = if profile.prefers_role_developer {
@@ -144,7 +180,7 @@ fn render_system_framing(body: &str, profile: &SectionProfile) -> SectionRender 
             } else {
                 "System Instructions"
             };
-            wrap_body(body, &format!("{title}:\n"), "")
+            wrap_body(body, &format!("{title}:\n"), "", envelope)
         }
     }
 }
@@ -157,7 +193,7 @@ fn render_output_format(
     col: usize,
 ) -> Result<SectionRender, TemplateError> {
     if profile.structured_output_mode == "native_json" {
-        return Ok(empty_render(body));
+        return Ok(empty_render(body, "native_json"));
     }
     let (body_content, body_source_start, body_source_end) = normalized_body(body);
     let schema = args
@@ -186,13 +222,13 @@ fn render_output_format(
         content.push_str("Return output matching this JSON Schema:\n");
         content.push_str(&schema);
     }
-    let (prefix, suffix) = match profile.structured_output_mode.as_str() {
-        "xml_tagged" => ("<output_format>\n", "\n</output_format>"),
-        "delimited" => ("[[ ## output_format ## ]]\n", ""),
+    let (prefix, suffix, envelope) = match profile.structured_output_mode.as_str() {
+        "xml_tagged" => ("<output_format>\n", "\n</output_format>", "xml_tagged"),
+        "delimited" => ("[[ ## output_format ## ]]\n", "", "delimited"),
         _ => match profile.scaffold() {
-            Scaffold::Xml => ("<output_format>\n", "\n</output_format>"),
-            Scaffold::Markdown => ("## Output Format\n", ""),
-            Scaffold::Plain => ("Output Format:\n", ""),
+            Scaffold::Xml => ("<output_format>\n", "\n</output_format>", "xml"),
+            Scaffold::Markdown => ("## Output Format\n", "", "markdown"),
+            Scaffold::Plain => ("Output Format:\n", "", "plain"),
         },
     };
     Ok(wrap_content_with_mapping(
@@ -202,6 +238,7 @@ fn render_output_format(
         body_offset,
         body_source_start,
         body_source_end,
+        envelope,
     ))
 }
 
@@ -240,6 +277,7 @@ fn render_tools(
             body_offset,
             body_source_start,
             body_source_end,
+            "xml_tools",
         )
     } else if profile.native_tools {
         wrap_content_with_mapping(
@@ -249,6 +287,7 @@ fn render_tools(
             body_offset,
             body_source_start,
             body_source_end,
+            "native_tools",
         )
     } else if profile.text_tool_wire_format_supported {
         let mut react = String::from(
@@ -273,6 +312,7 @@ fn render_tools(
             body_output_start: react_body_output_start,
             body_source_start,
             body_source_end,
+            envelope: "react",
         }
     } else {
         wrap_content_with_mapping(
@@ -282,6 +322,7 @@ fn render_tools(
             body_offset,
             body_source_start,
             body_source_end,
+            "plain",
         )
     };
     Ok(render)
@@ -294,28 +335,41 @@ fn render_thinking_scaffold(body: &str, profile: &SectionProfile) -> SectionRend
             "Think through the task before answering.",
             "<thinking>\n",
             "\n</thinking>",
+            "thinking_blocks",
         ),
         "reasoning_summary" => render_body_or_default(
             body,
             "Use internal reasoning and provide a concise answer.",
             "## Reasoning\n",
             "",
+            "reasoning_summary",
         ),
-        "inline" => render_body_or_default(body, "Reason privately before answering.", "", ""),
-        _ => empty_render(body),
+        "inline" => {
+            render_body_or_default(body, "Reason privately before answering.", "", "", "inline")
+        }
+        _ => empty_render(body, "none"),
     }
 }
 
 fn render_chain_of_thought(body: &str, profile: &SectionProfile) -> SectionRender {
     let default = "Reason privately step by step before answering.";
-    match profile.scaffold() {
-        Scaffold::Xml => render_body_or_default(body, default, "<reasoning>\n", "\n</reasoning>"),
-        Scaffold::Markdown => render_body_or_default(body, default, "## Reasoning\n", ""),
-        Scaffold::Plain => render_body_or_default(body, default, "", ""),
+    let scaffold = profile.scaffold();
+    match scaffold {
+        Scaffold::Xml => render_body_or_default(
+            body,
+            default,
+            "<reasoning>\n",
+            "\n</reasoning>",
+            scaffold.label(),
+        ),
+        Scaffold::Markdown => {
+            render_body_or_default(body, default, "## Reasoning\n", "", scaffold.label())
+        }
+        Scaffold::Plain => render_body_or_default(body, default, "", "", scaffold.label()),
     }
 }
 
-fn wrap_body(body: &str, prefix: &str, suffix: &str) -> SectionRender {
+fn wrap_body(body: &str, prefix: &str, suffix: &str, envelope: &'static str) -> SectionRender {
     let (content, source_start, source_end) = normalized_body(body);
     let body_output_start = (!content.is_empty()).then_some(prefix.len());
     let mut text = String::with_capacity(prefix.len() + content.len() + suffix.len());
@@ -327,15 +381,38 @@ fn wrap_body(body: &str, prefix: &str, suffix: &str) -> SectionRender {
         body_output_start,
         body_source_start: source_start,
         body_source_end: source_end,
+        envelope,
     }
 }
 
-fn render_body_or_default(body: &str, default: &str, prefix: &str, suffix: &str) -> SectionRender {
+fn render_body_or_default(
+    body: &str,
+    default: &str,
+    prefix: &str,
+    suffix: &str,
+    envelope: &'static str,
+) -> SectionRender {
     let (content, source_start, source_end) = normalized_body(body);
     if content.is_empty() {
-        return wrap_content_with_mapping(default, prefix, suffix, None, source_start, source_end);
+        return wrap_content_with_mapping(
+            default,
+            prefix,
+            suffix,
+            None,
+            source_start,
+            source_end,
+            envelope,
+        );
     }
-    wrap_content_with_mapping(content, prefix, suffix, Some(0), source_start, source_end)
+    wrap_content_with_mapping(
+        content,
+        prefix,
+        suffix,
+        Some(0),
+        source_start,
+        source_end,
+        envelope,
+    )
 }
 
 fn wrap_content_with_mapping(
@@ -345,6 +422,7 @@ fn wrap_content_with_mapping(
     body_offset: Option<usize>,
     body_source_start: usize,
     body_source_end: usize,
+    envelope: &'static str,
 ) -> SectionRender {
     let body_output_start = body_offset.map(|offset| prefix.len() + offset);
     let mut text = String::with_capacity(prefix.len() + content.len() + suffix.len());
@@ -356,15 +434,17 @@ fn wrap_content_with_mapping(
         body_output_start,
         body_source_start,
         body_source_end,
+        envelope,
     }
 }
 
-fn empty_render(body: &str) -> SectionRender {
+fn empty_render(body: &str, envelope: &'static str) -> SectionRender {
     SectionRender {
         text: String::new(),
         body_output_start: None,
         body_source_start: 0,
         body_source_end: body.len(),
+        envelope,
     }
 }
 

--- a/crates/harn-vm/src/stdlib/template/tests.rs
+++ b/crates/harn-vm/src/stdlib/template/tests.rs
@@ -639,3 +639,76 @@ fn include_cannot_escape_template_root() {
 fn tempdir() -> tempfile::TempDir {
     tempfile::tempdir().unwrap()
 }
+
+// Branch-trace coverage for #1668. The transcript event built on this
+// trace is what powers the portal's variant-resolution panel; here we
+// assert determinism (same llm snapshot → same trace) plus the
+// labels the trace consumer expects.
+
+#[test]
+fn branch_trace_records_if_taken_branch() {
+    let _guard =
+        LlmRenderContextGuard::enter(LlmRenderContext::resolve("anthropic", "claude-opus-4-7"));
+    let tpl = "{{ if llm.capabilities.native_tools }}native{{ else }}text{{ end }}";
+    let (rendered, trace) = render_template_collect_branch_trace(tpl).unwrap();
+    assert_eq!(rendered, "native");
+    assert_eq!(trace.len(), 1);
+    let decision = &trace[0];
+    assert_eq!(decision.kind, BranchKind::If);
+    assert_eq!(decision.branch_id, "if");
+    assert_eq!(
+        decision.branch_label.as_deref(),
+        Some("llm.capabilities.native_tools"),
+    );
+}
+
+#[test]
+fn branch_trace_records_else_when_no_branch_matches() {
+    let _guard =
+        LlmRenderContextGuard::enter(LlmRenderContext::resolve("anthropic", "claude-opus-4-7"));
+    let tpl =
+        "{{ if llm.provider == \"openai\" }}openai{{ elif llm.provider == \"google\" }}google{{ else }}other{{ end }}";
+    let (rendered, trace) = render_template_collect_branch_trace(tpl).unwrap();
+    assert_eq!(rendered, "other");
+    assert_eq!(trace.len(), 1);
+    assert_eq!(trace[0].branch_id, "else");
+}
+
+#[test]
+fn branch_trace_records_section_envelope() {
+    let _guard =
+        LlmRenderContextGuard::enter(LlmRenderContext::resolve("anthropic", "claude-opus-4-7"));
+    let tpl = "{{ section \"task\" }}Build a tree CLI.{{ endsection }}";
+    let (_rendered, trace) = render_template_collect_branch_trace(tpl).unwrap();
+    let section = trace
+        .iter()
+        .find(|d| d.kind == BranchKind::Section)
+        .expect("section trace entry");
+    assert_eq!(section.branch_id, "xml");
+    assert_eq!(section.branch_label.as_deref(), Some("task"));
+}
+
+#[test]
+fn branch_trace_is_deterministic_across_repeated_renders() {
+    let _guard =
+        LlmRenderContextGuard::enter(LlmRenderContext::resolve("anthropic", "claude-opus-4-7"));
+    let tpl = "\
+{{ if llm.capabilities.native_tools }}n{{ end }}\
+{{ section \"task\" }}b{{ endsection }}";
+    let (_, trace_a) = render_template_collect_branch_trace(tpl).unwrap();
+    let (_, trace_b) = render_template_collect_branch_trace(tpl).unwrap();
+    assert_eq!(trace_a, trace_b);
+}
+
+#[test]
+fn branch_trace_label_summarizes_provider_identity_comparison() {
+    let _guard = LlmRenderContextGuard::enter(LlmRenderContext::resolve("openai", "gpt-5.4"));
+    let tpl = "{{ if llm.provider == \"openai\" }}o{{ else }}x{{ end }}";
+    let (_rendered, trace) = render_template_collect_branch_trace(tpl).unwrap();
+    assert_eq!(trace.len(), 1);
+    assert_eq!(trace[0].branch_id, "if");
+    assert_eq!(
+        trace[0].branch_label.as_deref(),
+        Some("llm.provider == \"openai\""),
+    );
+}

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -2688,6 +2688,16 @@ and LSP go-to-definition follow `@`-paths to the target file.
   `qwen` / `llama` / `mistral` / `deepseek` / `phi` / `grok` / `command`.
   User bindings that already provide an `llm` key win for back-compat
   and trigger a one-shot warning under `template.llm_scope`.
+- **Variant resolution transcripts**: a `template.render` event lands in
+  `llm_transcript.jsonl` for every render under an LLM frame, carrying
+  the resolved `llm` snapshot and a per-branch / per-section trace.
+  Surface in the portal under "Variant resolution".
+- **Drift-prevention lints**: `harn lint` walks `.harn.prompt` files and
+  warns when a template branches on `llm.provider` / `llm.model` /
+  `llm.family` directly (`template-provider-identity-branch`) or when
+  more than three capability-aware conditionals appear in the same file
+  (`template-variant-explosion`). Configure the threshold via
+  `[lint] template_variant_branch_threshold = N`.
 - Full reference: `docs/src/prompt-templating.md`.
 
 ## Discovery

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -399,9 +399,15 @@ variables, unused functions, dead code after terminating statements,
 pointless comparisons, redundant clones, empty blocks, missing `/** */`
 HarnDoc on public functions, etc.).
 
+`harn lint` also walks `.harn.prompt` (and bare `.prompt`) files in the
+same pass and applies template-specific drift-prevention rules
+(`template-provider-identity-branch`,
+`template-variant-explosion` — see `docs/src/prompt-templating.md`).
+
 ```bash
 harn lint main.harn
 harn lint src/ tests/
+harn lint prompts/system.harn.prompt
 ```
 
 Pass `--fix` to automatically apply safe fixes (e.g., `var` → `let` for

--- a/docs/src/prompt-templating.md
+++ b/docs/src/prompt-templating.md
@@ -411,6 +411,45 @@ Capability dispatch is feature-based, not provider-string-based:
 | `thinking_block_style` | Controls `thinking_scaffold` (`none`, `thinking_blocks`, `reasoning_summary`, `inline`). |
 | `prefers_role_developer` | `system_framing` targets developer instructions instead of system instructions. |
 
+## Variant resolution in transcripts
+
+Every `render()` / `render_prompt()` call made under an LLM-aware frame
+(`llm_call`, `default_llm_caller`, `agent_loop`) emits a
+`template.render` event into the run's `llm_transcript.jsonl`. The event
+captures:
+
+- The resolved `llm` snapshot — `provider`, `model`, `family`, and the
+  full `capabilities` map at render time.
+- A branch trace listing every `{{ if }}` / `{{ elif }}` / `{{ else }}`
+  decision and every `{{ section }}` envelope that fired, anchored to
+  source line + column.
+- The template URI and a stable content hash (`template_revision_hash`)
+  so replay can detect "the rendered text matches but the source drifted
+  underneath" drift.
+
+The portal renders this as a "Variant resolution" panel in the run
+detail view. Renders outside any LLM frame (doc-gen, CI) emit no event.
+The trace is deterministic — the same `llm` snapshot and the same
+bindings always produce the same trace, which is what makes replay
+reproducible.
+
+## Drift-prevention lints
+
+`harn lint` walks `.harn.prompt` (and bare `.prompt`) files alongside
+`.harn` programs and enforces two rules that keep the
+capability-adaptive primitive honest:
+
+| Rule | What it catches |
+| :--- | :--- |
+| `template-provider-identity-branch` | Branching directly on `llm.provider`, `llm.model`, or `llm.family`. The diagnostic suggests the corresponding capability flag (e.g. `provider == "anthropic"` → `llm.capabilities.prefers_xml_scaffolding`). |
+| `template-variant-explosion` | More than `N` capability-aware conditionals in a single template. Default `N=3`, configurable via `[lint] template_variant_branch_threshold` in `harn.toml`. |
+
+Both rules can be disabled per-file via the standard `[lint] disabled`
+list. Lifting capability branches into [logical sections](#logical-sections)
+is the recommended way to silence variant-explosion without raising the
+threshold — the section's envelope dispatch lives in one shared place
+instead of being scattered across the prompt.
+
 ## Preflight checks
 
 `harn check` parses every template referenced by a literal `render(...)` /


### PR DESCRIPTION
## Summary

- **#1668 — `template.render` transcript events for variant resolution.**
  Every `render()` / `render_prompt()` call performed under an LLM-aware
  frame emits a `template.render` event into the run's
  `llm_transcript.jsonl`. The event captures the resolved `llm` snapshot
  (`provider`, `model`, `family`, `capabilities`), a per-`{{ if }}` /
  `{{ elif }}` / `{{ section }}` branch trace with line + column anchors,
  the template URI + a stable `template_revision_hash`, and the rendered
  byte count. The portal surfaces a new "Variant resolution" panel
  showing which capability branches fired for the active model. Renders
  outside any LLM frame (doc-gen, CI) emit no event. Trace is
  deterministic across repeated renders — same `llm` snapshot + bindings
  always produce the same trace, which is what makes replay reproducible.

- **#1669 — `template-provider-identity-branch` lint rule.** `harn lint`
  now also walks `.harn.prompt` (and bare `.prompt`) files and warns when
  a template branches on `llm.provider`, `llm.model`, or `llm.family`
  directly. Diagnostic suggests the corresponding capability flag (e.g.
  `provider == "anthropic"` → `llm.capabilities.prefers_xml_scaffolding`).
  No autofix (the mapping from identity → capability isn't 1-to-1 enough
  to apply blindly; the author has to pick the flag matching the
  branch's intent).

- **#1669 — `template-variant-explosion` lint rule.** Companion rule
  that warns when a single `.harn.prompt` carries more than `N`
  capability-aware conditionals. Default `N=3`, configurable via
  `[lint] template_variant_branch_threshold` in `harn.toml`. Suggests
  lifting capability branches into [logical sections](https://harnlang.com/docs/prompt-templating.html#logical-sections)
  so the dispatch lives in one shared place.

## Implementation notes

- AST/parser carry per-branch line+col on `IfBranch` so both the lint
  rules and the branch-trace recorder anchor diagnostics on the exact
  `{{ if }}` / `{{ elif }}` directive (not just the chain head).
- Section renderer threads a capability-driven `envelope` label
  (`xml`, `markdown`, `native_tools`, `react`, …) through to the
  trace so the panel shows which materialization fired.
- Lint surface lives in `harn-vm::stdlib::template::lint` (a shallow,
  read-only view over the otherwise-internal template AST) so the
  `harn-lint` crate stays free of template-engine internals.
- Branch trace is only collected when an LLM frame is in scope —
  empty-trace events would otherwise spam every doc-gen / CI render.
- Identity branches are caught by the sibling rule and explicitly do
  not count toward variant-explosion, to avoid double-warning.

## Test plan

- [x] `cargo build --workspace` clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [x] `cargo nextest run -p harn-vm -E 'test(template)'` — 68 passed.
- [x] `cargo nextest run -p harn-lint` — 216 passed (includes 12 new template-lint tests).
- [x] `cargo nextest run -p harn-cli -E 'test(prompt)'` — 21 passed (includes 4 new prompt-lint CLI tests).
- [x] `cargo run --bin harn -- test conformance` — 1051 passed.
- [x] `make lint-md` — 0 errors.
- [x] `make check-docs-snippets` — 529 checked, 0 failed.
- [x] `make fmt-harn` / `make lint-harn` clean (no false positives on personas/_templates or scripts).
- [x] Portal: `npm run lint`, `npm test`, `npm run build` all green; new "Variant resolution" panel renders against fixture.
- [x] Round-trip integration test: `render_template_to_string` under `LlmRenderContextGuard` emits a JSONL `template.render` event that parses back into the portal DTO.

Closes #1668. Closes #1669.

🤖 Generated with [Claude Code](https://claude.com/claude-code)