### PR TITLE
test: stabilize orchestrator_recover_stranded_envelopes under load

### DIFF
--- a/conformance/tests/_common.harn
+++ b/conformance/tests/_common.harn
@@ -73,10 +73,20 @@ pub fn wait_for_a2a_server_url(log_path) {
   return wait_for_log_match(log_path, "Harn A2A server listening on (\\S+)")
 }
 
-/** Wait for a subprocess to exit after the test has requested shutdown. */
+/**
+ * Wait for a subprocess to exit after the test has requested shutdown.
+ *
+ * Polls every 50ms for up to 30s. The upper bound is generous so the
+ * helper stays reliable when the conformance suite runs alongside other
+ * cargo audit lanes (e.g. release-harn's parallel rust-audit / harn-audit
+ * / grammar-audit / smoke-audit lanes), where the async runtime
+ * scheduling the doomed subprocess can be starved long past the
+ * single-suite baseline. Returns false on timeout; callers that need the
+ * process gone for subsequent steps should pair this with `kill -KILL`.
+ */
 pub fn wait_for_exit(pid) {
   var attempts = 0
-  while attempts < 200 {
+  while attempts < 600 {
     if !process_alive(pid) {
       return true
     }

--- a/conformance/tests/integration/orchestrator_recover_stranded_envelopes.harn
+++ b/conformance/tests/integration/orchestrator_recover_stranded_envelopes.harn
@@ -51,7 +51,17 @@ pipeline test(task) {
       headers: {"Content-Type": "application/json", Authorization: "Bearer test-key"},
     },
   )
-  println(response.status == 200 && wait_for_exit(crash_pid))
+  let crash_exited = wait_for_exit(crash_pid)
+  if !crash_exited && process_alive(crash_pid) {
+    // Under heavy CI load the dispatcher can be scheduling-starved past
+    // the wait_for_exit timeout. Force-kill so the restart orchestrator
+    // doesn't race the still-alive crash process for the state dir; the
+    // assertion below still reflects whether the crash happened
+    // naturally under HARN_TEST_DISPATCHER_FAIL_BEFORE_OUTBOX.
+    let _ = shell("kill -KILL " + crash_pid)
+    wait_for_exit(crash_pid)
+  }
+  println(response.status == 200 && crash_exited)
   let restart = shell_at(
     root,
     "nohup env HARN_SECRET_PROVIDERS=env HARN_EVENT_LOG_BACKEND=file HARN_ORCHESTRATOR_API_KEYS=test-key HARN_ORCHESTRATOR_HMAC_SECRET=shared-secret "


### PR DESCRIPTION
## Summary

The release-harn audit (which runs four cargo lanes — `rust-audit` clippy+nextest, `harn-audit` conformance, `grammar-audit`, and `smoke-audit` — in parallel) flaked on `orchestrator_recover_stranded_envelopes.harn` during the v0.8.20 release attempt, with the canonical "3 falses" failure mode:

```
- true
+ false
- true
+ false
- true
+ false
```

## Root cause

Under heavy parallel load the dispatcher in the crash orchestrator is scheduling-starved past the existing 10-second `wait_for_exit` window. When the helper times out, the test starts the restart orchestrator while the crash process is still alive and writing to the shared state dir — state-dir contention then makes all three `println` assertions fail.

The test runs solo reliably (5/5 passing). It only fails under release-audit-level concurrency.

## Two-layer fix

1. Raise the shared `wait_for_exit` ceiling from 10 s → 30 s in `conformance/tests/_common.harn`. Solo runs still exit in well under a second; the headroom only matters under contention.
2. Force-kill safety net in `orchestrator_recover_stranded_envelopes.harn`: if the dispatcher still hasn't crashed after the 30 s wait, send SIGKILL so the restart orchestrator never races a live crash process for the state dir. The first `println` stays `false` in that pathological case, so a real regression in the crash-on-dispatch path is still caught.

## Test plan

- [x] Solo: `cargo run --bin harn -- test conformance --filter orchestrator_recover_stranded_envelopes` (5/5 PASS).
- [x] Under concurrent `cargo test --workspace` load (3/3 PASS).
- [ ] Release-harn audit re-run to confirm the canonical failure path is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)