### PR TITLE
test: lift websocket_server_builtins handshake timeout to 10s

### DIFF
--- a/conformance/tests/stdlib/websocket_server_builtins.harn
+++ b/conformance/tests/stdlib/websocket_server_builtins.harn
@@ -1,7 +1,10 @@
 pipeline test(task) {
   transport_mock_clear()
   let server = websocket_server("127.0.0.1:0", {})
-  let ws_timeout_ms = 2000
+  // 10s instead of 2s gives the WebSocket handshake enough headroom when the
+  // conformance suite runs alongside release-harn's other cargo audit lanes;
+  // local solo runs still complete in milliseconds.
+  let ws_timeout_ms = 10000
   assert(websocket_route(server, "/acp", {idle_timeout_ms: 1000}))
   assert(websocket_route(server, "/secure", {auth: {bearer: "secret"}}))
   assert(websocket_route(server, "/limited", {max_message_bytes: 3}))


### PR DESCRIPTION
## Summary

Release-harn audit retry flaked on `websocket_server_builtins.harn` with `websocket_connect: failed: WebSocket protocol error: Handshake not finished`. Same pathology as #1684 — the 2 s `ws_timeout_ms` is plenty solo but the audit's concurrent rust/harn/grammar/smoke lanes can scheduling-starve the WebSocket handshake past that window.

Raise the timeout to 10 s. Solo runs still complete in milliseconds; the ceiling only matters under load.

## Test plan

- [x] Solo: `cargo run --bin harn -- test conformance --filter websocket_server_builtins` PASS.
- [ ] Release-harn audit retry to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)