### PR TITLE
evals: add prompt context quality gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ Pre-0.6 highlights live in [CHANGELOG-pre-0.6.md](CHANGELOG-pre-0.6.md).
 Harn had no external users before 0.6.0, so that archive intentionally keeps
 condensed series summaries instead of full per-patch history.
 
+## Unreleased
+
+### Added
+
+- **Prompt context-quality gates for `harn eval prompt` (#1682).**
+  `harn eval prompt` now accepts repeatable `--context-fixture <json>`
+  inputs. Each fixture case supplies candidate repository artifacts plus
+  `assemble_context` options and expectations for selected artifact ids,
+  stale/noisy rejection, token budget adherence, and logical-section
+  envelopes across the fleet. JSON/HTML/terminal output includes a
+  `context_eval` report with per-case scores and per-model section
+  shapes, giving Burin CI/eval dashboards a deterministic gate for
+  context-engineering changes before live prompt runs.
+
 ## v0.8.20
 
 ### Fixed

--- a/crates/harn-cli/src/cli/eval.rs
+++ b/crates/harn-cli/src/cli/eval.rs
@@ -72,6 +72,10 @@ pub struct EvalPromptArgs {
     /// JSON file with bindings injected into the template scope.
     #[arg(long)]
     pub bindings: Option<PathBuf>,
+    /// Prompt context-quality fixture(s) that score artifact selection,
+    /// stale/noisy rejection, budget adherence, and logical-section shape.
+    #[arg(long = "context-fixture")]
+    pub context_fixture: Vec<PathBuf>,
     /// Evaluation mode.
     #[arg(long, value_enum, default_value_t = EvalPromptMode::Render)]
     pub mode: EvalPromptMode,

--- a/crates/harn-cli/src/commands/eval_prompt.rs
+++ b/crates/harn-cli/src/commands/eval_prompt.rs
@@ -16,13 +16,16 @@ use std::path::{Path, PathBuf};
 
 use harn_vm::llm_config;
 use harn_vm::stdlib::template::{
-    render_template_to_string, LlmRenderContext, LlmRenderContextGuard,
+    render_template_to_string_with_branch_trace, BranchDecision, LlmRenderContext,
+    LlmRenderContextGuard,
 };
 use harn_vm::value::VmValue;
 use serde_json::Value as JsonValue;
 
 use crate::cli::{EvalPromptArgs, EvalPromptMode, EvalPromptOutput};
 use crate::config;
+
+use super::eval_prompt_context::{evaluate_context_fixtures, PromptContextEvalReport};
 
 /// Resolved per-model envelope produced by `--mode render`.
 #[derive(Debug, Clone, serde::Serialize)]
@@ -36,6 +39,8 @@ struct ModelRender {
     /// `Some` on success; `None` if template rendering failed.
     rendered: Option<String>,
     error: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    branches: Vec<TemplateBranch>,
     /// `true` when the model's provider has no usable credentials. In
     /// render mode this is informational; in run/judge mode it controls
     /// whether the call is skipped.
@@ -60,6 +65,8 @@ struct PromptReport {
     runs: BTreeMap<String, ModelRunResult>,
     #[serde(skip_serializing_if = "Option::is_none")]
     judge: Option<JudgeReport>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    context_eval: Option<PromptContextEvalReport>,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -69,6 +76,30 @@ struct JudgeReport {
     /// short JSON or prose verdict; we surface it verbatim so the user
     /// can inspect.
     verdict: String,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+struct TemplateBranch {
+    kind: String,
+    template_uri: String,
+    line: usize,
+    col: usize,
+    branch_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    branch_label: Option<String>,
+}
+
+impl From<&BranchDecision> for TemplateBranch {
+    fn from(decision: &BranchDecision) -> Self {
+        Self {
+            kind: decision.kind.as_str().to_string(),
+            template_uri: decision.template_uri.clone(),
+            line: decision.line,
+            col: decision.col,
+            branch_id: decision.branch_id.clone(),
+            branch_label: decision.branch_label.clone(),
+        }
+    }
 }
 
 pub async fn run(args: EvalPromptArgs) -> i32 {
@@ -119,7 +150,24 @@ pub async fn run(args: EvalPromptArgs) -> i32 {
         renders,
         runs: BTreeMap::new(),
         judge: None,
+        context_eval: None,
     };
+
+    if !args.context_fixture.is_empty() {
+        match evaluate_context_fixtures(
+            &args.context_fixture,
+            &fleet,
+            &template_source,
+            &template_path,
+            bindings.as_ref(),
+        ) {
+            Ok(context_eval) => report.context_eval = Some(context_eval),
+            Err(error) => {
+                eprintln!("error: {error}");
+                return 1;
+            }
+        }
+    }
 
     if matches!(mode, EvalPromptMode::Run | EvalPromptMode::Judge) {
         let bindings_text = args
@@ -175,10 +223,18 @@ pub async fn run(args: EvalPromptArgs) -> i32 {
         }
     }
 
-    if report.renders.iter().any(|r| r.error.is_some()) {
+    let context_eval_active = report.context_eval.is_some();
+    if !context_eval_active && report.renders.iter().any(|r| r.error.is_some()) {
         return 1;
     }
     if report.runs.values().any(|r| r.error.is_some()) {
+        return 1;
+    }
+    if report
+        .context_eval
+        .as_ref()
+        .is_some_and(|context_eval| !context_eval.pass)
+    {
         return 1;
     }
     0
@@ -236,10 +292,10 @@ fn resolve_fleet(args: &EvalPromptArgs, template_path: &Path) -> Result<Vec<Flee
 }
 
 #[derive(Debug, Clone)]
-struct FleetEntry {
-    selector: String,
-    provider: String,
-    model: String,
+pub(crate) struct FleetEntry {
+    pub(crate) selector: String,
+    pub(crate) provider: String,
+    pub(crate) model: String,
 }
 
 fn load_bindings(path: Option<&Path>) -> Result<Option<VmValue>, String> {
@@ -284,7 +340,7 @@ fn render_fleet(
 
             let result = {
                 let _guard = LlmRenderContextGuard::enter(ctx);
-                render_template_to_string(
+                render_template_to_string_with_branch_trace(
                     template_source,
                     bindings_dict.as_ref(),
                     base,
@@ -292,9 +348,13 @@ fn render_fleet(
                 )
             };
 
-            let (rendered, error) = match result {
-                Ok(text) => (Some(text), None),
-                Err(message) => (None, Some(message)),
+            let (rendered, branches, error) = match result {
+                Ok((text, trace)) => (
+                    Some(text),
+                    trace.iter().map(TemplateBranch::from).collect(),
+                    None,
+                ),
+                Err(message) => (None, Vec::new(), Some(message)),
             };
 
             ModelRender {
@@ -305,6 +365,7 @@ fn render_fleet(
                 capabilities,
                 rendered,
                 error,
+                branches,
                 auth_available,
             }
         })
@@ -684,6 +745,35 @@ fn render_terminal(report: &PromptReport) -> String {
         out.push('\n');
     }
 
+    if let Some(context_eval) = report.context_eval.as_ref() {
+        out.push_str(&format!(
+            "\n# Context fixture gates: {} passed / {} total\n",
+            context_eval.passed, context_eval.total,
+        ));
+        for fixture in &context_eval.fixtures {
+            out.push_str(&format!(
+                "\n## {} ({} passed / {} total)\n",
+                fixture.path.display(),
+                fixture.passed,
+                fixture.total,
+            ));
+            for case in &fixture.cases {
+                out.push_str(&format!(
+                    "- {}: {} score={:.3} selected=[{}] tokens={}/{}\n",
+                    case.id,
+                    if case.pass { "pass" } else { "fail" },
+                    case.score.overall,
+                    case.selected_artifact_ids.join(", "),
+                    case.budget.total_tokens,
+                    case.budget.budget_tokens,
+                ));
+                for failure in &case.failures {
+                    out.push_str(&format!("    failure: {failure}\n"));
+                }
+            }
+        }
+    }
+
     if !report.runs.is_empty() {
         out.push_str("\n# Model responses\n");
         for render in &report.renders {
@@ -817,6 +907,30 @@ fn render_html(report: &PromptReport) -> String {
         out.push_str("</div>");
     }
     out.push_str("</div>");
+    if let Some(context_eval) = report.context_eval.as_ref() {
+        out.push_str(&format!(
+            "<h2>Context fixture gates</h2><p>{} passed / {} total</p>",
+            context_eval.passed, context_eval.total,
+        ));
+        for fixture in &context_eval.fixtures {
+            out.push_str(&format!(
+                "<h3>{}</h3><ul>",
+                html_escape(&fixture.path.to_string_lossy()),
+            ));
+            for case in &fixture.cases {
+                out.push_str(&format!(
+                    "<li><strong>{}</strong>: {} · score {:.3} · selected [{}] · tokens {}/{}</li>",
+                    html_escape(&case.id),
+                    if case.pass { "pass" } else { "fail" },
+                    case.score.overall,
+                    html_escape(&case.selected_artifact_ids.join(", ")),
+                    case.budget.total_tokens,
+                    case.budget.budget_tokens,
+                ));
+            }
+            out.push_str("</ul>");
+        }
+    }
     if let Some(judge) = report.judge.as_ref() {
         out.push_str(&format!(
             "<h2>Judge ({})</h2><pre>{}</pre>",
@@ -858,6 +972,7 @@ mod tests {
             ],
             fleet_name: None,
             bindings: None,
+            context_fixture: Vec::new(),
             mode: EvalPromptMode::Render,
             output: EvalPromptOutput::Terminal,
             out_file: None,

--- a/crates/harn-cli/src/commands/eval_prompt_context.rs
+++ b/crates/harn-cli/src/commands/eval_prompt_context.rs
@@ -1,0 +1,719 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use harn_vm::orchestration::{
+    assemble_context, render_assembled_chunks, ArtifactRecord, AssembleDedup, AssembleOptions,
+    AssembleStrategy, AssembledContext,
+};
+use harn_vm::stdlib::template::{
+    render_template_to_string_with_branch_trace, BranchDecision, LlmRenderContext,
+    LlmRenderContextGuard,
+};
+use harn_vm::value::VmValue;
+use serde_json::{json, Value as JsonValue};
+
+use super::eval_prompt::FleetEntry;
+
+#[derive(Debug, Clone, serde::Deserialize, Default)]
+#[serde(default)]
+struct PromptContextFixture {
+    #[serde(rename = "_type")]
+    type_name: Option<String>,
+    version: Option<u32>,
+    id: Option<String>,
+    name: Option<String>,
+    cases: Vec<PromptContextCase>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize, Default)]
+#[serde(default)]
+struct PromptContextCase {
+    id: Option<String>,
+    name: Option<String>,
+    description: Option<String>,
+    bindings: Option<JsonValue>,
+    artifacts: Vec<ArtifactRecord>,
+    assembler: ContextAssemblerSpec,
+    expect: ContextExpectation,
+}
+
+#[derive(Debug, Clone, serde::Deserialize, Default)]
+#[serde(default)]
+struct ContextAssemblerSpec {
+    #[serde(alias = "budget-tokens")]
+    budget_tokens: Option<usize>,
+    dedup: Option<String>,
+    strategy: Option<String>,
+    query: Option<String>,
+    #[serde(alias = "microcompact-threshold")]
+    microcompact_threshold: Option<usize>,
+    #[serde(alias = "semantic-overlap")]
+    semantic_overlap: Option<f64>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize, Default)]
+#[serde(default)]
+struct ContextExpectation {
+    #[serde(alias = "selected-artifact-ids")]
+    selected_artifact_ids: Vec<String>,
+    #[serde(alias = "rejected-artifact-ids")]
+    rejected_artifact_ids: Vec<String>,
+    #[serde(alias = "stale-artifact-ids")]
+    stale_artifact_ids: Vec<String>,
+    #[serde(alias = "max-total-tokens")]
+    max_total_tokens: Option<usize>,
+    #[serde(alias = "required-section-names")]
+    required_section_names: Vec<String>,
+    #[serde(alias = "section-envelopes-by-family")]
+    section_envelopes_by_family: BTreeMap<String, BTreeMap<String, String>>,
+    #[serde(alias = "section-envelopes-by-selector")]
+    section_envelopes_by_selector: BTreeMap<String, BTreeMap<String, String>>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub(crate) struct PromptContextEvalReport {
+    pub(crate) pass: bool,
+    pub(crate) total: usize,
+    pub(crate) passed: usize,
+    pub(crate) failed: usize,
+    pub(crate) fixtures: Vec<PromptContextFixtureReport>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub(crate) struct PromptContextFixtureReport {
+    pub(crate) path: PathBuf,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) name: Option<String>,
+    pub(crate) pass: bool,
+    pub(crate) total: usize,
+    pub(crate) passed: usize,
+    pub(crate) failed: usize,
+    pub(crate) cases: Vec<PromptContextCaseReport>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub(crate) struct PromptContextCaseReport {
+    pub(crate) id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) description: Option<String>,
+    pub(crate) pass: bool,
+    pub(crate) score: ContextScoreBreakdown,
+    pub(crate) selected_artifact_ids: Vec<String>,
+    pub(crate) dropped_artifact_ids: Vec<String>,
+    pub(crate) stale_artifact_ids: Vec<String>,
+    pub(crate) budget: ContextBudgetReport,
+    pub(crate) variants: Vec<ContextVariantReport>,
+    pub(crate) failures: Vec<String>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub(crate) struct ContextScoreBreakdown {
+    pub(crate) overall: f64,
+    pub(crate) selected_artifacts: f64,
+    pub(crate) rejected_artifacts: f64,
+    pub(crate) stale_rejection: f64,
+    pub(crate) token_budget: f64,
+    pub(crate) rendered_sections: f64,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub(crate) struct ContextBudgetReport {
+    pub(crate) total_tokens: usize,
+    pub(crate) budget_tokens: usize,
+    pub(crate) max_total_tokens: usize,
+    pub(crate) pass: bool,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub(crate) struct ContextVariantReport {
+    pub(crate) selector: String,
+    pub(crate) provider: String,
+    pub(crate) model: String,
+    pub(crate) family: String,
+    pub(crate) rendered_bytes: usize,
+    pub(crate) pass: bool,
+    pub(crate) sections: Vec<ContextSectionShape>,
+    pub(crate) failures: Vec<String>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub(crate) struct ContextSectionShape {
+    pub(crate) name: String,
+    pub(crate) envelope: String,
+    pub(crate) line: usize,
+    pub(crate) col: usize,
+}
+
+pub(crate) fn evaluate_context_fixtures(
+    paths: &[PathBuf],
+    fleet: &[FleetEntry],
+    template_source: &str,
+    template_path: &Path,
+    base_bindings: Option<&VmValue>,
+) -> Result<PromptContextEvalReport, String> {
+    let mut fixtures = Vec::new();
+    for path in paths {
+        let fixture = load_context_fixture(path)?;
+        let mut cases = Vec::new();
+        for (index, case) in fixture.cases.iter().enumerate() {
+            cases.push(evaluate_context_case(
+                case,
+                index,
+                fleet,
+                template_source,
+                template_path,
+                base_bindings,
+            )?);
+        }
+        let total = cases.len();
+        let passed = cases.iter().filter(|case| case.pass).count();
+        let failed = total.saturating_sub(passed);
+        fixtures.push(PromptContextFixtureReport {
+            path: path.clone(),
+            id: fixture.id,
+            name: fixture.name,
+            pass: failed == 0,
+            total,
+            passed,
+            failed,
+            cases,
+        });
+    }
+
+    let total = fixtures.iter().map(|fixture| fixture.total).sum();
+    let passed = fixtures.iter().map(|fixture| fixture.passed).sum();
+    let failed = fixtures.iter().map(|fixture| fixture.failed).sum();
+    Ok(PromptContextEvalReport {
+        pass: failed == 0,
+        total,
+        passed,
+        failed,
+        fixtures,
+    })
+}
+
+fn load_context_fixture(path: &Path) -> Result<PromptContextFixture, String> {
+    let raw = fs::read_to_string(path)
+        .map_err(|error| format!("failed to read context fixture {}: {error}", path.display()))?;
+    let fixture: PromptContextFixture = serde_json::from_str(&raw).map_err(|error| {
+        format!(
+            "failed to parse context fixture {}: {error}",
+            path.display()
+        )
+    })?;
+    if let Some(kind) = fixture.type_name.as_deref() {
+        if kind != "prompt_context_eval_fixture" {
+            return Err(format!(
+                "context fixture {} has unsupported _type `{kind}`",
+                path.display(),
+            ));
+        }
+    }
+    if let Some(version) = fixture.version {
+        if version != 1 {
+            return Err(format!(
+                "context fixture {} has unsupported version {version}",
+                path.display(),
+            ));
+        }
+    }
+    if fixture.cases.is_empty() {
+        return Err(format!(
+            "context fixture {} must declare at least one case",
+            path.display()
+        ));
+    }
+    for (index, case) in fixture.cases.iter().enumerate() {
+        if !case.has_context_assertion() {
+            let case_label = case
+                .id
+                .as_deref()
+                .filter(|id| !id.trim().is_empty())
+                .map(str::to_string)
+                .unwrap_or_else(|| format!("case_{}", index + 1));
+            return Err(format!(
+                "context fixture {} case `{case_label}` must declare at least one expectation",
+                path.display(),
+            ));
+        }
+    }
+    Ok(fixture)
+}
+
+impl PromptContextCase {
+    fn has_context_assertion(&self) -> bool {
+        !self.expect.selected_artifact_ids.is_empty()
+            || !self.expect.rejected_artifact_ids.is_empty()
+            || !self.expect.stale_artifact_ids.is_empty()
+            || self.expect.max_total_tokens.is_some()
+            || !self.expect.required_section_names.is_empty()
+            || !self.expect.section_envelopes_by_family.is_empty()
+            || !self.expect.section_envelopes_by_selector.is_empty()
+    }
+}
+
+fn evaluate_context_case(
+    case: &PromptContextCase,
+    index: usize,
+    fleet: &[FleetEntry],
+    template_source: &str,
+    template_path: &Path,
+    base_bindings: Option<&VmValue>,
+) -> Result<PromptContextCaseReport, String> {
+    let id = case
+        .id
+        .clone()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| format!("case_{}", index + 1));
+    let artifacts: Vec<ArtifactRecord> = case
+        .artifacts
+        .clone()
+        .into_iter()
+        .map(ArtifactRecord::normalize)
+        .collect();
+    let options = context_assemble_options(&case.assembler)?;
+    let assembled = assemble_context(&artifacts, &options, None);
+    let selected_artifact_ids = selected_artifact_ids(&assembled);
+    let dropped_artifact_ids = dropped_artifact_ids(&assembled);
+    let stale_artifact_ids = expected_stale_artifact_ids(case, &artifacts);
+
+    let mut failures = Vec::new();
+    if artifacts.is_empty() {
+        failures.push("case has no candidate artifacts".to_string());
+    }
+
+    let selected_score = score_expected_present(
+        "selected artifact",
+        &case.expect.selected_artifact_ids,
+        &selected_artifact_ids,
+        &mut failures,
+    );
+    let rejected_score = score_expected_absent(
+        "rejected artifact",
+        &case.expect.rejected_artifact_ids,
+        &selected_artifact_ids,
+        &mut failures,
+    );
+    let stale_score = score_expected_absent(
+        "stale artifact",
+        &stale_artifact_ids,
+        &selected_artifact_ids,
+        &mut failures,
+    );
+
+    let max_total_tokens = case
+        .expect
+        .max_total_tokens
+        .unwrap_or(options.budget_tokens);
+    let budget_pass = assembled.total_tokens <= options.budget_tokens
+        && assembled.total_tokens <= max_total_tokens;
+    if !budget_pass {
+        failures.push(format!(
+            "assembled context used {} tokens; expected <= {} and budget <= {}",
+            assembled.total_tokens, max_total_tokens, options.budget_tokens,
+        ));
+    }
+    let budget = ContextBudgetReport {
+        total_tokens: assembled.total_tokens,
+        budget_tokens: options.budget_tokens,
+        max_total_tokens,
+        pass: budget_pass,
+    };
+
+    let bindings = context_case_bindings(
+        base_bindings,
+        case.bindings.as_ref(),
+        &artifacts,
+        &assembled,
+        &selected_artifact_ids,
+        &dropped_artifact_ids,
+    )?;
+    let variants = render_context_variants(
+        fleet,
+        template_source,
+        template_path,
+        &bindings,
+        &case.expect,
+    );
+    for variant in &variants {
+        failures.extend(
+            variant
+                .failures
+                .iter()
+                .map(|failure| format!("{}: {failure}", variant.selector)),
+        );
+    }
+    let rendered_sections_score = if variants.is_empty() {
+        failures.push("fleet is empty for context fixture case".to_string());
+        0.0
+    } else {
+        variants.iter().filter(|variant| variant.pass).count() as f64 / variants.len() as f64
+    };
+
+    let token_budget_score = if budget.pass { 1.0 } else { 0.0 };
+    let overall = average_scores(&[
+        selected_score,
+        rejected_score,
+        stale_score,
+        token_budget_score,
+        rendered_sections_score,
+    ]);
+    let score = ContextScoreBreakdown {
+        overall,
+        selected_artifacts: selected_score,
+        rejected_artifacts: rejected_score,
+        stale_rejection: stale_score,
+        token_budget: token_budget_score,
+        rendered_sections: rendered_sections_score,
+    };
+
+    Ok(PromptContextCaseReport {
+        id,
+        name: case.name.clone(),
+        description: case.description.clone(),
+        pass: failures.is_empty(),
+        score,
+        selected_artifact_ids,
+        dropped_artifact_ids,
+        stale_artifact_ids,
+        budget,
+        variants,
+        failures,
+    })
+}
+
+fn context_assemble_options(spec: &ContextAssemblerSpec) -> Result<AssembleOptions, String> {
+    let mut options = AssembleOptions::default();
+    if let Some(value) = spec.budget_tokens {
+        options.budget_tokens = value;
+    }
+    if let Some(value) = spec.microcompact_threshold {
+        options.microcompact_threshold = value;
+    }
+    if let Some(value) = spec.semantic_overlap {
+        if !(0.0..=1.0).contains(&value) {
+            return Err("context fixture semantic_overlap must be in [0.0, 1.0]".to_string());
+        }
+        options.semantic_overlap = value;
+    }
+    if let Some(value) = spec.dedup.as_deref() {
+        options.dedup = AssembleDedup::parse(value)?;
+    }
+    if let Some(value) = spec.strategy.as_deref() {
+        options.strategy = AssembleStrategy::parse(value)?;
+    }
+    if let Some(query) = spec.query.as_ref().filter(|query| !query.trim().is_empty()) {
+        options.query = Some(query.clone());
+    }
+    Ok(options)
+}
+
+fn selected_artifact_ids(assembled: &AssembledContext) -> Vec<String> {
+    unique_preserve_order(
+        assembled
+            .chunks
+            .iter()
+            .map(|chunk| chunk.artifact_id.clone()),
+    )
+}
+
+fn dropped_artifact_ids(assembled: &AssembledContext) -> Vec<String> {
+    unique_preserve_order(
+        assembled
+            .dropped
+            .iter()
+            .map(|entry| entry.artifact_id.clone()),
+    )
+}
+
+fn expected_stale_artifact_ids(
+    case: &PromptContextCase,
+    artifacts: &[ArtifactRecord],
+) -> Vec<String> {
+    unique_preserve_order(
+        case.expect.stale_artifact_ids.iter().cloned().chain(
+            artifacts
+                .iter()
+                .filter(|artifact| artifact.freshness.as_deref() == Some("stale"))
+                .map(|artifact| artifact.id.clone()),
+        ),
+    )
+}
+
+fn unique_preserve_order(values: impl IntoIterator<Item = String>) -> Vec<String> {
+    let mut seen = BTreeSet::new();
+    let mut out = Vec::new();
+    for value in values {
+        if seen.insert(value.clone()) {
+            out.push(value);
+        }
+    }
+    out
+}
+
+fn score_expected_present(
+    label: &str,
+    expected: &[String],
+    actual: &[String],
+    failures: &mut Vec<String>,
+) -> f64 {
+    if expected.is_empty() {
+        return 1.0;
+    }
+    let actual: BTreeSet<&str> = actual.iter().map(String::as_str).collect();
+    let mut matched = 0usize;
+    for id in expected {
+        if actual.contains(id.as_str()) {
+            matched += 1;
+        } else {
+            failures.push(format!("missing expected {label} `{id}`"));
+        }
+    }
+    matched as f64 / expected.len() as f64
+}
+
+fn score_expected_absent(
+    label: &str,
+    expected_absent: &[String],
+    actual: &[String],
+    failures: &mut Vec<String>,
+) -> f64 {
+    if expected_absent.is_empty() {
+        return 1.0;
+    }
+    let actual: BTreeSet<&str> = actual.iter().map(String::as_str).collect();
+    let mut absent = 0usize;
+    for id in expected_absent {
+        if actual.contains(id.as_str()) {
+            failures.push(format!("selected forbidden {label} `{id}`"));
+        } else {
+            absent += 1;
+        }
+    }
+    absent as f64 / expected_absent.len() as f64
+}
+
+fn average_scores(scores: &[f64]) -> f64 {
+    if scores.is_empty() {
+        return 1.0;
+    }
+    let raw = scores.iter().sum::<f64>() / scores.len() as f64;
+    (raw * 1000.0).round() / 1000.0
+}
+
+fn context_case_bindings(
+    base_bindings: Option<&VmValue>,
+    case_bindings: Option<&JsonValue>,
+    artifacts: &[ArtifactRecord],
+    assembled: &AssembledContext,
+    selected_artifact_ids: &[String],
+    dropped_artifact_ids: &[String],
+) -> Result<BTreeMap<String, VmValue>, String> {
+    let mut bindings = match base_bindings {
+        Some(VmValue::Dict(dict)) => dict.as_ref().clone(),
+        Some(other) => {
+            return Err(format!(
+                "context fixture base bindings must be a dict, got {}",
+                other.type_name()
+            ));
+        }
+        None => BTreeMap::new(),
+    };
+    if let Some(case_bindings) = case_bindings {
+        let object = case_bindings
+            .as_object()
+            .ok_or_else(|| "context fixture case bindings must be a JSON object".to_string())?;
+        for (key, value) in object {
+            bindings.insert(key.clone(), harn_vm::json_to_vm_value(value));
+        }
+    }
+
+    let context_text = render_assembled_chunks(assembled);
+    bindings.insert(
+        "candidate_artifacts".to_string(),
+        harn_vm::json_to_vm_value(
+            &serde_json::to_value(artifacts)
+                .map_err(|error| format!("failed to serialize candidate artifacts: {error}"))?,
+        ),
+    );
+    bindings.insert(
+        "assembled_context".to_string(),
+        harn_vm::json_to_vm_value(&assembled_context_to_json(assembled)),
+    );
+    bindings.insert(
+        "context".to_string(),
+        harn_vm::json_to_vm_value(&JsonValue::String(context_text)),
+    );
+    bindings.insert(
+        "selected_artifact_ids".to_string(),
+        harn_vm::json_to_vm_value(&json!(selected_artifact_ids)),
+    );
+    bindings.insert(
+        "dropped_artifact_ids".to_string(),
+        harn_vm::json_to_vm_value(&json!(dropped_artifact_ids)),
+    );
+    Ok(bindings)
+}
+
+fn assembled_context_to_json(assembled: &AssembledContext) -> JsonValue {
+    json!({
+        "chunks": assembled.chunks.iter().map(|chunk| {
+            json!({
+                "id": &chunk.id,
+                "artifact_id": &chunk.artifact_id,
+                "artifact_kind": &chunk.artifact_kind,
+                "title": &chunk.title,
+                "source": &chunk.source,
+                "text": &chunk.text,
+                "estimated_tokens": chunk.estimated_tokens,
+                "chunk_index": chunk.chunk_index,
+                "chunk_count": chunk.chunk_count,
+                "score": chunk.score,
+            })
+        }).collect::<Vec<_>>(),
+        "included": assembled.included.iter().map(|summary| {
+            json!({
+                "artifact_id": &summary.artifact_id,
+                "artifact_kind": &summary.artifact_kind,
+                "chunks_included": summary.chunks_included,
+                "chunks_total": summary.chunks_total,
+                "tokens_included": summary.tokens_included,
+            })
+        }).collect::<Vec<_>>(),
+        "dropped": assembled.dropped.iter().map(|entry| {
+            json!({
+                "artifact_id": &entry.artifact_id,
+                "chunk_id": &entry.chunk_id,
+                "reason": entry.reason,
+                "detail": &entry.detail,
+            })
+        }).collect::<Vec<_>>(),
+        "reasons": assembled.reasons.iter().map(|reason| {
+            json!({
+                "chunk_id": &reason.chunk_id,
+                "artifact_id": &reason.artifact_id,
+                "strategy": reason.strategy,
+                "score": reason.score,
+                "included": reason.included,
+                "reason": reason.reason,
+            })
+        }).collect::<Vec<_>>(),
+        "total_tokens": assembled.total_tokens,
+        "budget_tokens": assembled.budget_tokens,
+        "strategy": assembled.strategy.as_str(),
+        "dedup": assembled.dedup.as_str(),
+    })
+}
+
+fn render_context_variants(
+    fleet: &[FleetEntry],
+    template_source: &str,
+    template_path: &Path,
+    bindings: &BTreeMap<String, VmValue>,
+    expect: &ContextExpectation,
+) -> Vec<ContextVariantReport> {
+    let base = template_path.parent();
+    fleet
+        .iter()
+        .map(|entry| {
+            let ctx = LlmRenderContext::resolve(&entry.provider, &entry.model);
+            let family = ctx.family.clone();
+            let result = {
+                let _guard = LlmRenderContextGuard::enter(ctx);
+                render_template_to_string_with_branch_trace(
+                    template_source,
+                    Some(bindings),
+                    base,
+                    Some(template_path),
+                )
+            };
+            match result {
+                Ok((rendered, trace)) => {
+                    let sections = section_shapes(&trace);
+                    let failures = evaluate_section_shape(entry, &family, &sections, expect);
+                    ContextVariantReport {
+                        selector: entry.selector.clone(),
+                        provider: entry.provider.clone(),
+                        model: entry.model.clone(),
+                        family,
+                        rendered_bytes: rendered.len(),
+                        pass: failures.is_empty(),
+                        sections,
+                        failures,
+                    }
+                }
+                Err(error) => ContextVariantReport {
+                    selector: entry.selector.clone(),
+                    provider: entry.provider.clone(),
+                    model: entry.model.clone(),
+                    family,
+                    rendered_bytes: 0,
+                    pass: false,
+                    sections: Vec::new(),
+                    failures: vec![format!("template render failed: {error}")],
+                },
+            }
+        })
+        .collect()
+}
+
+fn section_shapes(trace: &[BranchDecision]) -> Vec<ContextSectionShape> {
+    trace
+        .iter()
+        .filter_map(|decision| {
+            if decision.kind.as_str() != "section" {
+                return None;
+            }
+            Some(ContextSectionShape {
+                name: decision.branch_label.clone().unwrap_or_default(),
+                envelope: decision.branch_id.clone(),
+                line: decision.line,
+                col: decision.col,
+            })
+        })
+        .collect()
+}
+
+fn evaluate_section_shape(
+    entry: &FleetEntry,
+    family: &str,
+    sections: &[ContextSectionShape],
+    expect: &ContextExpectation,
+) -> Vec<String> {
+    let mut failures = Vec::new();
+    let sections_by_name: BTreeMap<&str, &ContextSectionShape> = sections
+        .iter()
+        .map(|section| (section.name.as_str(), section))
+        .collect();
+
+    for required in &expect.required_section_names {
+        if !sections_by_name.contains_key(required.as_str()) {
+            failures.push(format!("missing logical section `{required}`"));
+        }
+    }
+
+    let expected_envelopes = expect
+        .section_envelopes_by_selector
+        .get(&entry.selector)
+        .or_else(|| expect.section_envelopes_by_family.get(family));
+    if let Some(expected_envelopes) = expected_envelopes {
+        for (section_name, expected_envelope) in expected_envelopes {
+            match sections_by_name.get(section_name.as_str()) {
+                Some(section) if &section.envelope == expected_envelope => {}
+                Some(section) => failures.push(format!(
+                    "section `{section_name}` envelope `{}` != expected `{expected_envelope}`",
+                    section.envelope,
+                )),
+                None => failures.push(format!(
+                    "missing logical section `{section_name}` for envelope check"
+                )),
+            }
+        }
+    }
+    failures
+}

--- a/crates/harn-cli/src/commands/mod.rs
+++ b/crates/harn-cli/src/commands/mod.rs
@@ -12,6 +12,7 @@ pub(crate) mod dump_highlight_keywords;
 pub(crate) mod dump_protocol_artifacts;
 pub(crate) mod dump_trigger_quickref;
 pub mod eval_prompt;
+pub(crate) mod eval_prompt_context;
 pub(crate) mod explain;
 pub mod flow;
 pub(crate) mod hardware;

--- a/crates/harn-cli/tests/eval_prompt_cli.rs
+++ b/crates/harn-cli/tests/eval_prompt_cli.rs
@@ -68,6 +68,7 @@ provider={{ llm.provider }} family={{ llm.family }}\n",
         ],
         fleet_name: None,
         bindings: None,
+        context_fixture: Vec::new(),
         mode: EvalPromptMode::Render,
         output: EvalPromptOutput::Json,
         out_file: Some(out_file.clone()),
@@ -143,6 +144,7 @@ models = ["claude-3-5-sonnet", "gpt-4o"]
         fleet: Vec::new(),
         fleet_name: Some("smoke".to_string()),
         bindings: None,
+        context_fixture: Vec::new(),
         mode: EvalPromptMode::Render,
         output: EvalPromptOutput::Json,
         out_file: Some(out_file.clone()),
@@ -191,6 +193,7 @@ models = ["claude-3-5-sonnet"]
         fleet: Vec::new(),
         fleet_name: Some("nope".to_string()),
         bindings: None,
+        context_fixture: Vec::new(),
         mode: EvalPromptMode::Render,
         output: EvalPromptOutput::Terminal,
         out_file: None,
@@ -220,6 +223,7 @@ fn bindings_file_drives_template_scope() {
         fleet: vec!["claude-3-5-sonnet".to_string()],
         fleet_name: None,
         bindings: Some(bindings),
+        context_fixture: Vec::new(),
         mode: EvalPromptMode::Render,
         output: EvalPromptOutput::Json,
         out_file: Some(out_file.clone()),
@@ -241,4 +245,143 @@ fn bindings_file_drives_template_scope() {
         .expect("rendered")
         .to_string();
     assert_eq!(rendered, "task=Hello from bindings\n", "bindings injected");
+}
+
+#[test]
+fn context_fixture_scores_artifact_selection_and_section_shape() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let template = tmp.path().join("repo-context.harn.prompt");
+    fs::write(
+        &template,
+        "{{ section \"system_framing\" }}Use only selected repository context.{{ endsection }}\n\
+{{ section \"task\" }}{{ task }}{{ endsection }}\n\
+{{ section \"examples\" }}{{ context }}{{ endsection }}\n",
+    )
+    .expect("write template");
+
+    let fixture = tmp.path().join("context-fixture.json");
+    fs::write(
+        &fixture,
+        r#"{
+  "_type": "prompt_context_eval_fixture",
+  "version": 1,
+  "id": "repo_context_quality",
+  "cases": [
+    {
+      "id": "rust_parser_regression",
+      "bindings": {
+        "task": "Fix the Rust parser token span regression."
+      },
+      "assembler": {
+        "budget_tokens": 18,
+        "dedup": "none",
+        "strategy": "relevance",
+        "query": "Rust parser token span regression",
+        "microcompact_threshold": 2000
+      },
+      "artifacts": [
+        {
+          "id": "rust-parser-current",
+          "kind": "workspace_file",
+          "title": "Rust parser current",
+          "source": "crates/harn-parser/src/parser.rs",
+          "created_at": "2026-05-16T00:00:00Z",
+          "freshness": "fresh",
+          "text": "Rust parser token span regression fix in harn-parser."
+        },
+        {
+          "id": "rust-parser-stale",
+          "kind": "workspace_file",
+          "title": "Stale parser note",
+          "source": "notes/parser.md",
+          "created_at": "2025-01-01T00:00:00Z",
+          "freshness": "stale",
+          "text": "Old parser note before the diagnostic rewrite. Do not use for the current Rust regression."
+        },
+        {
+          "id": "swift-wrong-language",
+          "kind": "workspace_file",
+          "title": "Swift scanner notes",
+          "source": "Sources/BurinCore/Scanner.swift",
+          "created_at": "2026-05-16T00:00:00Z",
+          "freshness": "fresh",
+          "text": "Swift scanner token span advice for a different host implementation."
+        },
+        {
+          "id": "ci-noisy",
+          "kind": "command_result",
+          "title": "Tempting CI noise",
+          "source": "ci.log",
+          "created_at": "2026-05-16T00:00:00Z",
+          "freshness": "fresh",
+          "text": "Rust parser troubleshooting log: unrelated macOS sandbox output, retry chatter, and dependency download noise."
+        }
+      ],
+      "expect": {
+        "selected_artifact_ids": ["rust-parser-current"],
+        "rejected_artifact_ids": ["rust-parser-stale", "swift-wrong-language", "ci-noisy"],
+        "stale_artifact_ids": ["rust-parser-stale"],
+        "max_total_tokens": 18,
+        "required_section_names": ["system_framing", "task", "examples"],
+        "section_envelopes_by_family": {
+          "claude": {"system_framing": "xml", "task": "xml", "examples": "xml"},
+          "gpt": {"system_framing": "markdown", "task": "markdown", "examples": "markdown"},
+          "qwen": {"system_framing": "markdown", "task": "markdown", "examples": "markdown"}
+        }
+      }
+    }
+  ]
+}"#,
+    )
+    .expect("write fixture");
+
+    let out_file = tmp.path().join("report.json");
+    let args = EvalPromptArgs {
+        file: template,
+        fleet: vec![
+            "claude-3-5-sonnet".to_string(),
+            "gpt-4o".to_string(),
+            "ollama:qwen3.5".to_string(),
+        ],
+        fleet_name: None,
+        bindings: None,
+        context_fixture: vec![fixture],
+        mode: EvalPromptMode::Render,
+        output: EvalPromptOutput::Json,
+        out_file: Some(out_file.clone()),
+        max_concurrent: 1,
+        judge_template: None,
+        judge_model: "claude-opus-4-7".to_string(),
+        max_tokens: 256,
+        fail_on_unauthorized: false,
+    };
+
+    let exit =
+        run_in_harn_runtime(|| async move { harn_cli::commands::eval_prompt::run(args).await });
+    assert_eq!(exit, 0, "context fixture eval should pass");
+
+    let report: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&out_file).expect("report")).expect("parsed JSON");
+    let context_eval = &report["context_eval"];
+    assert_eq!(context_eval["pass"], true);
+    let case = &context_eval["fixtures"][0]["cases"][0];
+    assert_eq!(case["selected_artifact_ids"][0], "rust-parser-current");
+    assert_eq!(case["score"]["overall"], 1.0);
+    assert_eq!(case["score"]["selected_artifacts"], 1.0);
+    assert_eq!(case["score"]["rejected_artifacts"], 1.0);
+    assert_eq!(case["score"]["stale_rejection"], 1.0);
+    assert_eq!(case["score"]["token_budget"], 1.0);
+    assert_eq!(case["score"]["rendered_sections"], 1.0);
+    assert_eq!(case["budget"]["pass"], true);
+    let variants = case["variants"].as_array().expect("variants");
+    assert_eq!(variants.len(), 3);
+    for variant in variants {
+        assert_eq!(
+            variant["pass"], true,
+            "variant should satisfy section shape: {variant:?}",
+        );
+    }
+    assert_eq!(variants[0]["sections"][0]["envelope"], "xml");
+    assert_eq!(variants[1]["sections"][0]["envelope"], "markdown");
+    assert_eq!(variants[2]["sections"][0]["envelope"], "markdown");
 }

--- a/crates/harn-vm/src/stdlib/template/mod.rs
+++ b/crates/harn-vm/src/stdlib/template/mod.rs
@@ -358,7 +358,7 @@ pub struct PromptSourceSpan {
 /// fired for this model?" without re-running the template. Recorded
 /// deterministically — same `llm` snapshot + bindings always produce
 /// the same trace, which is what makes replay reproducible (#1668).
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub struct BranchDecision {
     pub kind: BranchKind,
     pub template_uri: String,
@@ -376,7 +376,8 @@ pub struct BranchDecision {
     pub branch_label: Option<String>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum BranchKind {
     If,
     Section,
@@ -460,19 +461,8 @@ pub(crate) fn render_template_collect_branch_trace(
     template: &str,
 ) -> Result<(String, Vec<BranchDecision>), TemplateError> {
     let asset = TemplateAsset::inline(template, None, None);
-    let nodes = parse_cached(&asset)?;
-    let mut out = String::with_capacity(asset.source.len());
-    let augmented = augment_bindings_with_llm(&asset, None);
-    let scope_bindings = augmented.as_ref();
-    let mut scope = Scope::new(scope_bindings);
-    let mut rc = RenderCtx {
-        current_asset: asset.clone(),
-        include_stack: Vec::new(),
-        current_include_parent: None,
-        branch_trace: Some(Vec::new()),
-    };
-    render_nodes(&nodes, &mut scope, &mut rc, &mut out, None)?;
-    Ok((out, rc.branch_trace.unwrap_or_default()))
+    render_asset_with_provenance_and_trace_result(&asset, None, false, true)
+        .map(|(rendered, _spans, trace)| (rendered, trace))
 }
 
 pub(crate) fn render_asset_with_provenance_result(
@@ -480,6 +470,17 @@ pub(crate) fn render_asset_with_provenance_result(
     bindings: Option<&BTreeMap<String, VmValue>>,
     collect_provenance: bool,
 ) -> Result<(String, Vec<PromptSourceSpan>), TemplateError> {
+    let (rendered, spans, _trace) =
+        render_asset_with_provenance_and_trace_result(asset, bindings, collect_provenance, false)?;
+    Ok((rendered, spans))
+}
+
+fn render_asset_with_provenance_and_trace_result(
+    asset: &TemplateAsset,
+    bindings: Option<&BTreeMap<String, VmValue>>,
+    collect_provenance: bool,
+    force_branch_trace: bool,
+) -> Result<(String, Vec<PromptSourceSpan>, Vec<BranchDecision>), TemplateError> {
     let nodes = parse_cached(asset)?;
     let mut out = String::with_capacity(asset.source.len());
     // Materialize the ambient `llm` binding when the caller is inside
@@ -499,7 +500,7 @@ pub(crate) fn render_asset_with_provenance_result(
         current_asset: asset.clone(),
         include_stack: Vec::new(),
         current_include_parent: None,
-        branch_trace: llm_ctx.as_ref().map(|_| Vec::new()),
+        branch_trace: (force_branch_trace || llm_ctx.is_some()).then(Vec::new),
     };
     let mut spans = if collect_provenance {
         Some(Vec::new())
@@ -515,10 +516,27 @@ pub(crate) fn render_asset_with_provenance_result(
         }
         e
     })?;
-    if let (Some(ctx), Some(trace)) = (llm_ctx, rc.branch_trace.take()) {
+    let trace = rc.branch_trace.take().unwrap_or_default();
+    if let Some(ctx) = llm_ctx {
         emit_template_render_event(asset, &ctx, &trace, out.len());
     }
-    Ok((out, spans.unwrap_or_default()))
+    Ok((out, spans.unwrap_or_default(), trace))
+}
+
+/// Render a template and return the capability branch trace that drove
+/// logical-section materialization. This is the deterministic counterpart
+/// to the `template.render` transcript event and is used by prompt evals
+/// that need to score section shape without scraping JSONL artifacts.
+pub fn render_template_to_string_with_branch_trace(
+    template: &str,
+    bindings: Option<&BTreeMap<String, VmValue>>,
+    base: Option<&Path>,
+    source_path: Option<&Path>,
+) -> Result<(String, Vec<BranchDecision>), String> {
+    let asset = TemplateAsset::inline(template, base, source_path);
+    render_asset_with_provenance_and_trace_result(&asset, bindings, false, true)
+        .map(|(rendered, _spans, trace)| (rendered, trace))
+        .map_err(|error| error.message())
 }
 
 /// Emit a `template.render` transcript event capturing the resolved

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -1096,6 +1096,12 @@ harn eval prompt examples/coding-agent-system.harn.prompt \
 
 # Use a named fleet from `[eval.fleets.<name>]` in harn.toml.
 harn eval prompt prompts/agent.harn.prompt --fleet-name frontier --output html -o report.html
+
+# Score repo-context artifact selection and rendered section shape.
+harn eval prompt examples/evals/repo-context-quality.harn.prompt \
+    --fleet claude-3-5-sonnet,gpt-4o,ollama:qwen3.5 \
+    --context-fixture examples/evals/context-retrieval-fixture.json \
+    --output json -o context-quality.json
 ```
 
 | Flag | Description |
@@ -1103,6 +1109,7 @@ harn eval prompt prompts/agent.harn.prompt --fleet-name frontier --output html -
 | `--fleet <list>` | Comma-separated model selectors (alias or `provider:model`). Repeatable. |
 | `--fleet-name <name>` | Named fleet from `[eval.fleets.<name>]` in `harn.toml`. |
 | `--bindings <path>` | JSON file injected into the template scope. Top-level value must be an object. |
+| `--context-fixture <path>` | JSON fixture(s) for context-quality gates. Each case supplies candidate artifacts, assembler options, and expectations for selected/rejected/stale artifact ids, token budget, and logical-section envelopes. Repeatable. |
 | `--mode <render\|run\|judge>` | Default `render`. |
 | `--output <terminal\|json\|html>` | Default `terminal`. |
 | `-o, --out-file <path>` | Write `--output` payload to a file instead of stdout. |
@@ -1130,6 +1137,16 @@ routes through the existing `llm_call` infrastructure, so credentials,
 provider catalog, and `HARN_LLM_PROVIDER=mock` work exactly as in
 `harn run`. Judge mode is run mode plus a final LLM-as-judge call that
 asks for a one-line JSON verdict on cross-model equivalence.
+
+`--context-fixture` adds deterministic repo-context quality gates to
+the same fleet render. The CLI first packs each case's candidate
+artifacts with `assemble_context`, injects `context`,
+`assembled_context`, `candidate_artifacts`, `selected_artifact_ids`,
+and `dropped_artifact_ids` into the template bindings, then renders the
+case across every fleet member. JSON/HTML/terminal output includes a
+`context_eval` report with selected artifact ids, stale/noisy rejection,
+budget adherence, per-model logical-section envelopes, and an overall
+score suitable for CI or dashboard ingestion.
 
 ## harn merge-captain
 

--- a/examples/evals/context-retrieval-fixture.json
+++ b/examples/evals/context-retrieval-fixture.json
@@ -1,0 +1,85 @@
+{
+  "_type": "prompt_context_eval_fixture",
+  "version": 1,
+  "id": "repo_context_quality",
+  "name": "Repository context artifact-selection golden",
+  "cases": [
+    {
+      "id": "rust_parser_regression",
+      "name": "Rust parser regression selects current Harn artifact",
+      "description": "The fixture includes a correct Rust artifact, stale Rust note, wrong-language Swift note, and tempting CI noise.",
+      "bindings": {
+        "task": "Fix the Rust parser token span regression."
+      },
+      "assembler": {
+        "budget_tokens": 18,
+        "dedup": "none",
+        "strategy": "relevance",
+        "query": "Rust parser token span regression",
+        "microcompact_threshold": 2000
+      },
+      "artifacts": [
+        {
+          "id": "rust-parser-current",
+          "kind": "workspace_file",
+          "title": "Rust parser current",
+          "source": "crates/harn-parser/src/parser.rs",
+          "created_at": "2026-05-16T00:00:00Z",
+          "freshness": "fresh",
+          "text": "Rust parser token span regression fix in harn-parser."
+        },
+        {
+          "id": "rust-parser-stale",
+          "kind": "workspace_file",
+          "title": "Stale parser note",
+          "source": "notes/parser.md",
+          "created_at": "2025-01-01T00:00:00Z",
+          "freshness": "stale",
+          "text": "Old parser note before the diagnostic rewrite. Do not use for the current Rust regression."
+        },
+        {
+          "id": "swift-wrong-language",
+          "kind": "workspace_file",
+          "title": "Swift scanner notes",
+          "source": "Sources/BurinCore/Scanner.swift",
+          "created_at": "2026-05-16T00:00:00Z",
+          "freshness": "fresh",
+          "text": "Swift scanner token span advice for a different host implementation."
+        },
+        {
+          "id": "ci-noisy",
+          "kind": "command_result",
+          "title": "Tempting CI noise",
+          "source": "ci.log",
+          "created_at": "2026-05-16T00:00:00Z",
+          "freshness": "fresh",
+          "text": "Rust parser troubleshooting log: unrelated macOS sandbox output, retry chatter, and dependency download noise."
+        }
+      ],
+      "expect": {
+        "selected_artifact_ids": ["rust-parser-current"],
+        "rejected_artifact_ids": ["rust-parser-stale", "swift-wrong-language", "ci-noisy"],
+        "stale_artifact_ids": ["rust-parser-stale"],
+        "max_total_tokens": 18,
+        "required_section_names": ["system_framing", "task", "examples"],
+        "section_envelopes_by_family": {
+          "claude": {
+            "system_framing": "xml",
+            "task": "xml",
+            "examples": "xml"
+          },
+          "gpt": {
+            "system_framing": "markdown",
+            "task": "markdown",
+            "examples": "markdown"
+          },
+          "qwen": {
+            "system_framing": "markdown",
+            "task": "markdown",
+            "examples": "markdown"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/examples/evals/repo-context-quality.harn.prompt
+++ b/examples/evals/repo-context-quality.harn.prompt
@@ -1,0 +1,11 @@
+{{ section "system_framing" }}
+Use only the selected repository context. Ignore stale, wrong-language, or log-noise artifacts even when they share keywords with the task.
+{{ endsection }}
+
+{{ section "task" }}
+{{ task }}
+{{ endsection }}
+
+{{ section "examples" }}
+{{ context }}
+{{ endsection }}


### PR DESCRIPTION
## Summary

Closes #1682.

- Adds repeatable `harn eval prompt --context-fixture <json>` gates that assemble candidate repo-context artifacts, score selected/rejected/stale artifact ids, enforce token budgets, and verify provider-family logical-section envelopes across the fleet.
- Exposes a structured `context_eval` report in JSON/HTML/terminal output, including per-case score components and per-model section shapes for CI/dashboard ingestion.
- Adds a repository-context example fixture and prompt covering current/stale/wrong-language/noisy artifacts, plus docs and changelog coverage.

## Verification

- `cargo check -p harn-cli --tests`
- `cargo test -p harn-cli --test eval_prompt_cli`
- `cargo test -p harn-vm branch_trace`
- `cargo test -p harn-vm template_render_event_round_trips_through_jsonl`
- `cargo clippy -p harn-vm -p harn-cli --tests -- -D warnings`
- `cargo run --quiet --bin harn -- eval prompt examples/evals/repo-context-quality.harn.prompt --fleet claude-3-5-sonnet,gpt-4o,ollama:qwen3.5 --context-fixture examples/evals/context-retrieval-fixture.json --output json --out-file /tmp/harn-context-quality.json`
- Pre-commit hook: Rust fmt, workspace clippy, highlight sync, markdown lint
- Pre-push hook: targeted local checks, markdown lint, generated highlight check, changelog retroactive-edit check