### PR TITLE
Harden release binary artifact publishing

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -233,13 +233,45 @@ jobs:
           done
 
           (cd "target/${TARGET}/release" && zip -j "$NOTARY_ZIP" harn harn-dap harn-lsp)
-          echo "Submitting to Apple notary (this typically takes 1-5 minutes)..."
-          xcrun notarytool submit "$NOTARY_ZIP" \
-            --key "$KEY_FILE" \
-            --key-id "$APPLE_API_KEY_ID" \
-            --issuer "$APPLE_API_ISSUER_ID" \
-            --wait \
-            --timeout 30m
+          notary_submit_with_retry() {
+            local attempt=1
+            local max_attempts=4
+            local delay=20
+
+            while [ "$attempt" -le "$max_attempts" ]; do
+              local log_file="$RUNNER_TEMP/notary-submit-${attempt}.log"
+              echo "Submitting to Apple notary (attempt ${attempt}/${max_attempts}; this typically takes 1-5 minutes)..."
+              set +e
+              xcrun notarytool submit "$NOTARY_ZIP" \
+                --key "$KEY_FILE" \
+                --key-id "$APPLE_API_KEY_ID" \
+                --issuer "$APPLE_API_ISSUER_ID" \
+                --wait \
+                --timeout 30m 2>&1 | tee "$log_file"
+              local status="${PIPESTATUS[0]}"
+              set -e
+
+              if [ "$status" -eq 0 ]; then
+                return 0
+              fi
+
+              if [ "$attempt" -eq "$max_attempts" ]; then
+                return "$status"
+              fi
+
+              if grep -Eiq 'NSURLErrorDomain|offline|timed out|connection|network|gateway|service unavailable|Current status: In Progress' "$log_file"; then
+                echo "Apple notary returned a transient polling/upload error; retrying in ${delay}s..."
+                sleep "$delay"
+                attempt=$((attempt + 1))
+                delay=$((delay * 2))
+                continue
+              fi
+
+              return "$status"
+            done
+          }
+
+          notary_submit_with_retry
           rm -f "$KEY_FILE" "$NOTARY_ZIP"
 
       - name: Tear down macOS keychain
@@ -366,12 +398,25 @@ jobs:
         working-directory: artifacts
         run: |
           set -euo pipefail
-          shopt -s nullglob
-          files=(*.tar.gz *.zip)
-          if (( ${#files[@]} == 0 )); then
-            echo "::error::No release artifacts found to checksum"
+          expected=(
+            harn-aarch64-apple-darwin.tar.gz
+            harn-aarch64-unknown-linux-gnu.tar.gz
+            harn-x86_64-apple-darwin.tar.gz
+            harn-x86_64-pc-windows-msvc.zip
+            harn-x86_64-unknown-linux-gnu.tar.gz
+          )
+          missing=()
+          for file in "${expected[@]}"; do
+            if [ ! -f "$file" ]; then
+              missing+=("$file")
+            fi
+          done
+          if (( ${#missing[@]} > 0 )); then
+            printf '::error::Missing release artifacts: %s\n' "${missing[*]}"
+            find . -maxdepth 1 -type f -print | sort
             exit 1
           fi
+          files=("${expected[@]}")
           sha256sum "${files[@]}" | LC_ALL=C sort -k 2 > SHA256SUMS
           cat SHA256SUMS
 

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -5,7 +5,8 @@ name: Publish release
 #   1. push to a `vX.Y.Z` tag — the canonical "tag is truth" path. The
 #      bump-fleet `release_harn.harn` harness pushes the tag at the
 #      pinned release commit BEFORE the Release PR merges; this trigger
-#      ships crates.io and the GitHub release from that exact commit,
+#      ships crates.io from that exact commit while the binary workflow
+#      creates the GitHub release with artifacts from the same tag,
 #      independent of whatever lands on main between PR-open and merge.
 #      The tag push (under the harn-release-bot App identity) also
 #      cascades to build-release-binaries.yml for tarballs + container.
@@ -26,8 +27,10 @@ name: Publish release
 #      crates so manual re-fire is idempotent.
 #
 # Runs ./scripts/release_ship.sh --finalize, which dry-run publishes,
-# tags (no-op if already at HEAD), publishes to crates.io, and
-# creates/updates the GitHub release.
+# tags (no-op if already at HEAD), and publishes to crates.io. The
+# build-release-binaries.yml cascade creates/updates the GitHub release
+# only after the binary assets are ready, so a failed binary build cannot
+# leave a visible release page with zero artifacts.
 #
 # Audit is skipped by default (RELEASE_FINALIZE_REAUDIT=0): the
 # merge-queue CI of the just-landed Release PR ran the same gates a
@@ -275,7 +278,7 @@ jobs:
           # local recovery runs.
           RELEASE_FINALIZE_REAUDIT: ${{ inputs.reaudit && '1' || '0' }}
         run: |
-          args=(--finalize)
+          args=(--finalize --skip-github-release)
           if [[ "${{ inputs.skip_dry_run }}" == "true" ]]; then
             args+=(--skip-dry-run)
           fi

--- a/scripts/release_ship.sh
+++ b/scripts/release_ship.sh
@@ -61,7 +61,7 @@ usage() {
 Usage:
   ./scripts/release_ship.sh --prepare --bump patch|minor|major [--skip-audit] [--skip-dry-run]
   ./scripts/release_ship.sh --bump patch|minor|major [--skip-dry-run] [--base main]   # recovery
-  ./scripts/release_ship.sh --finalize [--skip-dry-run] [--reaudit] [--notes-output path] [--base main]
+  ./scripts/release_ship.sh --finalize [--skip-dry-run] [--reaudit] [--notes-output path] [--skip-github-release] [--base main]
 
 Merge-queue-safe release sequence for a prepared Harn release.
 
@@ -92,12 +92,12 @@ DEFAULT FLOW (one human PR, then bot finalizes)
        gh pr create
 
   5. publish-release.yml fires on the tag push, checks out the tagged
-     commit (detached), and finalizes — crates.io publish, GitHub
-     release, build-release-binaries cascade — all from the pinned
-     commit. The Release PR remains as paperwork; auto-merge can land
-     it whenever, even if main has moved on. The post-merge push to
-     main no-ops (no drift, since Cargo.toml on main now matches the
-     tag).
+     commit (detached), and finalizes crates.io. The
+     build-release-binaries cascade creates the GitHub release with
+     binary artifacts from the same pinned commit. The Release PR
+     remains as paperwork; auto-merge can land it whenever, even if
+     main has moved on. The post-merge push to main no-ops (no drift,
+     since Cargo.toml on main now matches the tag).
 
 ==============================================================================
 PREPARE MODE
@@ -156,7 +156,9 @@ FINALIZE MODE
   4. Pushes the tag (no-op if origin already has it).
   5. Runs cargo publish to upload crates to crates.io.
   6. Renders changelog-backed release notes.
-  7. Creates/updates a GitHub release with the rendered notes.
+  7. Creates/updates a GitHub release with the rendered notes, unless
+     --skip-github-release is passed because another workflow owns the
+     release page and binary artifacts.
 
   Set RELEASE_FINALIZE_REAUDIT=1 (or pass --reaudit) to opt back into
   the full release-gate audit before finalizing — useful when running
@@ -552,6 +554,7 @@ SKIP_AUDIT=0
 MODE="bump-pr"
 BASE_BRANCH="main"
 NOTES_OUTPUT=""
+SKIP_GITHUB_RELEASE=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -589,6 +592,10 @@ while [[ $# -gt 0 ]]; do
     --notes-output)
       NOTES_OUTPUT="${2:-}"
       shift 2
+      ;;
+    --skip-github-release)
+      SKIP_GITHUB_RELEASE=1
+      shift
       ;;
     --no-push)
       echo "error: --no-push was removed from release_ship.sh"
@@ -695,12 +702,15 @@ log_step "Release notes"
 ./scripts/release_gate.sh notes --version "$TAG" --output "$NOTES_OUTPUT"
 cat "$NOTES_OUTPUT"
 
-# Create or update GitHub release with rendered notes as the LAST step, so
-# the release body reflects the final crates.io + git state. If crates.io
-# was slow, the upstream tag is already live — downstream CI will have
-# kicked off minutes ago.
 GH_RELEASE_URL=""
-if command -v gh &>/dev/null; then
+if [[ "$SKIP_GITHUB_RELEASE" -eq 1 ]]; then
+  log_step "GitHub release skipped"
+  echo "Skipping GitHub release creation/update; binary release workflow owns release assets and notes."
+elif command -v gh &>/dev/null; then
+  # Create or update GitHub release with rendered notes as the LAST step, so
+  # the release body reflects the final crates.io + git state. If crates.io
+  # was slow, the upstream tag is already live — downstream CI will have
+  # kicked off minutes ago.
   log_step "GitHub release"
   if gh release view "$TAG" &>/dev/null; then
     GH_RELEASE_URL="$(gh release edit "$TAG" --notes-file "$NOTES_OUTPUT" 2>&1)"


### PR DESCRIPTION
## Summary
- retry transient Apple notary polling/upload failures in the macOS release binary job
- validate the complete expected release asset set before checksumming/uploading
- stop publish-release from creating a visible GitHub release before binary assets are ready; build-release-binaries owns release notes + assets

## Verification
- actionlint .github/workflows/build-release-binaries.yml .github/workflows/publish-release.yml
- bash -n scripts/release_ship.sh
- ./scripts/release_ship.sh --help
- git diff --check