### PR TITLE
llm: move provider/model catalog defaults to embedded providers.toml

### DIFF
--- a/crates/harn-serve/src/adapters/acp/tests.rs
+++ b/crates/harn-serve/src/adapters/acp/tests.rs
@@ -238,9 +238,14 @@ fn acp_agent_capabilities_use_canonical_initialize_shape() {
 
     let capabilities = acp_agent_capabilities();
 
-    assert_eq!(
-        configured_llm_route_for_capabilities(),
-        ("openai".into(), "gpt-4o".into())
+    // Pin only the provider routing invariant + that the resolved
+    // model is a registered catalog entry. The specific OpenAI default
+    // moves as the catalog tracks model deprecations.
+    let (provider, model) = configured_llm_route_for_capabilities();
+    assert_eq!(provider, "openai");
+    assert!(
+        harn_vm::llm_config::model_catalog_entry(&model).is_some(),
+        "openai fallback must point at a registered catalog model (got {model})"
     );
     assert_eq!(capabilities["loadSession"], true);
     assert_eq!(
@@ -288,9 +293,17 @@ fn acp_prompt_capabilities_follow_configured_model_aliases() {
 
     let capabilities = acp_agent_capabilities();
 
-    assert_eq!(
-        configured_llm_route_for_capabilities(),
-        ("anthropic".into(), "claude-sonnet-4-20250514".into())
+    // The `frontier` alias resolves to whatever the embedded
+    // providers.toml currently designates as the flagship Anthropic
+    // model; pinning a specific id here would force a test churn every
+    // time the catalog tracks an Anthropic refresh. Pin only the
+    // routing invariant (provider) plus the model's catalog presence.
+    let (provider, model) = configured_llm_route_for_capabilities();
+    assert_eq!(provider, "anthropic");
+    assert!(
+        harn_vm::llm_config::model_catalog_entry(&model)
+            .is_some_and(|entry| entry.provider == "anthropic" && !entry.deprecated),
+        "frontier route must point at a registered, non-deprecated anthropic model (got {model})"
     );
     assert_eq!(
         capabilities["promptCapabilities"],

--- a/crates/harn-vm/src/llm/providers.toml
+++ b/crates/harn-vm/src/llm/providers.toml
@@ -1,0 +1,967 @@
+# providers.toml — Harn's built-in LLM provider/model catalog defaults.
+#
+# This file is the single source of truth for Harn's bundled defaults:
+# providers, model aliases, inference + tier routing rules, canonical
+# model metadata + pricing, qc defaults, and per-pattern hyperparameter
+# overrides. It deserializes into `ProvidersConfig` via the same Serde
+# pipeline that loads HARN_PROVIDERS_CONFIG / ~/.config/harn/providers.toml
+# / harn.toml [providers] / package-manifest [llm] sections at runtime.
+#
+# Resolution order at startup (later overlays win on per-key basis):
+#   1. This file (embedded into the VM via include_str!)
+#   2. ~/.config/harn/providers.toml (user-global override)
+#   3. HARN_PROVIDERS_CONFIG env var (explicit per-process override)
+#   4. Per-run programmatic overlays installed by hosts via
+#      llm_config::set_user_overrides()
+#
+# Edit this file directly to change defaults. Do not re-add the equivalent
+# data as Rust literals in llm_config.rs — that creates the parallel
+# system this file exists to eliminate.
+
+default_provider = "anthropic"
+
+# ── Providers ────────────────────────────────────────────────────────────────
+# Each [providers.X] block defines an LLM endpoint Harn can dial. The
+# `auth_env` field can be a single string or an array (tried in order).
+# `cost_per_1k_in/out` are coarse provider-level fallbacks used when a
+# specific [models.X] entry has no `pricing` table.
+
+[providers.anthropic]
+base_url = "https://api.anthropic.com/v1"
+auth_style = "header"
+auth_header = "x-api-key"
+auth_env = "ANTHROPIC_API_KEY"
+chat_endpoint = "/messages"
+features = ["prompt_caching", "thinking"]
+cost_per_1k_in = 0.003
+cost_per_1k_out = 0.015
+latency_p50_ms = 2500
+extra_headers = { "anthropic-version" = "2023-06-01" }
+
+[providers.anthropic.healthcheck]
+method = "POST"
+path = "/messages/count_tokens"
+body = '{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":"x"}]}'
+
+[providers.openai]
+base_url = "https://api.openai.com/v1"
+auth_style = "bearer"
+auth_env = "OPENAI_API_KEY"
+chat_endpoint = "/chat/completions"
+completion_endpoint = "/completions"
+cost_per_1k_in = 0.0025
+cost_per_1k_out = 0.010
+latency_p50_ms = 1800
+
+[providers.openai.healthcheck]
+method = "GET"
+path = "/models"
+
+[providers.openrouter]
+base_url = "https://openrouter.ai/api/v1"
+auth_style = "bearer"
+auth_env = "OPENROUTER_API_KEY"
+chat_endpoint = "/chat/completions"
+completion_endpoint = "/completions"
+cost_per_1k_in = 0.003
+cost_per_1k_out = 0.015
+latency_p50_ms = 2200
+
+[providers.openrouter.healthcheck]
+method = "GET"
+path = "/auth/key"
+
+[providers.huggingface]
+base_url = "https://router.huggingface.co/v1"
+auth_style = "bearer"
+auth_env = ["HF_TOKEN", "HUGGINGFACE_API_KEY"]
+chat_endpoint = "/chat/completions"
+completion_endpoint = "/completions"
+cost_per_1k_in = 0.0002
+cost_per_1k_out = 0.0006
+latency_p50_ms = 2400
+
+[providers.huggingface.healthcheck]
+method = "GET"
+url = "https://huggingface.co/api/whoami-v2"
+
+# Ollama defaults to /api/chat (native NDJSON) so the test stubs keep
+# working; hosts can flip to /v1/chat/completions via a providers.toml
+# overlay to bypass Ollama's per-model tool-call post-processors
+# (qwen3coder.go, qwen35.go) that raise HTTP 500s on text-mode responses
+# for the Qwen3.5 family.
+[providers.ollama]
+base_url = "http://localhost:11434"
+base_url_env = "OLLAMA_HOST"
+auth_style = "none"
+chat_endpoint = "/api/chat"
+completion_endpoint = "/api/generate"
+cost_per_1k_in = 0.0
+cost_per_1k_out = 0.0
+latency_p50_ms = 1200
+
+[providers.ollama.healthcheck]
+method = "GET"
+path = "/api/tags"
+
+[providers.gemini]
+base_url = "https://generativelanguage.googleapis.com"
+base_url_env = "GEMINI_BASE_URL"
+auth_style = "header"
+auth_header = "x-goog-api-key"
+auth_env = ["GEMINI_API_KEY", "GOOGLE_API_KEY"]
+chat_endpoint = "/v1beta/models"
+cost_per_1k_in = 0.00125
+cost_per_1k_out = 0.005
+latency_p50_ms = 1800
+
+[providers.gemini.healthcheck]
+method = "GET"
+path = "/v1beta/models"
+
+[providers.together]
+base_url = "https://api.together.xyz/v1"
+base_url_env = "TOGETHER_AI_BASE_URL"
+auth_style = "bearer"
+auth_env = "TOGETHER_AI_API_KEY"
+chat_endpoint = "/chat/completions"
+completion_endpoint = "/completions"
+cost_per_1k_in = 0.0002
+cost_per_1k_out = 0.0006
+latency_p50_ms = 1600
+
+[providers.together.healthcheck]
+method = "GET"
+path = "/models"
+
+# Groq — OpenAI-compatible LPU-hosted fast inference. Headline ~840 tok/s
+# on Llama 3.1 8B, ~594 tok/s on Llama 4 Scout. Useful executor target
+# when sub-100ms TTFT matters more than raw quality.
+[providers.groq]
+base_url = "https://api.groq.com/openai/v1"
+base_url_env = "GROQ_BASE_URL"
+auth_style = "bearer"
+auth_env = "GROQ_API_KEY"
+chat_endpoint = "/chat/completions"
+completion_endpoint = "/completions"
+cost_per_1k_in = 0.0001
+cost_per_1k_out = 0.0003
+latency_p50_ms = 450
+
+[providers.groq.healthcheck]
+method = "GET"
+path = "/models"
+
+[providers.deepseek]
+base_url = "https://api.deepseek.com/v1"
+base_url_env = "DEEPSEEK_BASE_URL"
+auth_style = "bearer"
+auth_env = "DEEPSEEK_API_KEY"
+chat_endpoint = "/chat/completions"
+completion_endpoint = "/completions"
+cost_per_1k_in = 0.00014
+cost_per_1k_out = 0.00028
+latency_p50_ms = 1800
+
+[providers.deepseek.healthcheck]
+method = "GET"
+path = "/models"
+
+[providers.fireworks]
+base_url = "https://api.fireworks.ai/inference/v1"
+base_url_env = "FIREWORKS_BASE_URL"
+auth_style = "bearer"
+auth_env = "FIREWORKS_API_KEY"
+chat_endpoint = "/chat/completions"
+completion_endpoint = "/completions"
+cost_per_1k_in = 0.0002
+cost_per_1k_out = 0.0006
+latency_p50_ms = 1400
+
+[providers.fireworks.healthcheck]
+method = "GET"
+path = "/models"
+
+[providers.dashscope]
+base_url = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+base_url_env = "DASHSCOPE_BASE_URL"
+auth_style = "bearer"
+auth_env = "DASHSCOPE_API_KEY"
+chat_endpoint = "/chat/completions"
+completion_endpoint = "/completions"
+cost_per_1k_in = 0.0003
+cost_per_1k_out = 0.0012
+latency_p50_ms = 1600
+
+[providers.dashscope.healthcheck]
+method = "GET"
+path = "/models"
+
+# AWS Bedrock — resolves credentials through env, profile, container, or
+# EC2 instance roles, then signs Converse API calls with SigV4.
+[providers.bedrock]
+base_url = ""
+base_url_env = "BEDROCK_BASE_URL"
+auth_style = "aws_sigv4"
+chat_endpoint = "/model/{model}/converse"
+features = ["native_tools"]
+latency_p50_ms = 2600
+
+# Azure OpenAI — deployment name is routed in the URL; callers can
+# either pass the deployment as the Harn model field or set
+# AZURE_OPENAI_DEPLOYMENT.
+[providers.azure_openai]
+base_url = "https://{resource}.openai.azure.com"
+base_url_env = "AZURE_OPENAI_ENDPOINT"
+auth_style = "azure_openai"
+auth_env = ["AZURE_OPENAI_API_KEY", "AZURE_OPENAI_AD_TOKEN", "AZURE_OPENAI_BEARER_TOKEN"]
+chat_endpoint = "/openai/deployments/{deployment}/chat/completions?api-version={api_version}"
+features = ["native_tools"]
+cost_per_1k_in = 0.0025
+cost_per_1k_out = 0.010
+latency_p50_ms = 1900
+
+[providers.vertex]
+base_url = "https://aiplatform.googleapis.com/v1"
+base_url_env = "VERTEX_AI_BASE_URL"
+auth_style = "bearer"
+auth_env = ["VERTEX_AI_ACCESS_TOKEN", "GOOGLE_OAUTH_ACCESS_TOKEN", "GOOGLE_APPLICATION_CREDENTIALS"]
+chat_endpoint = "/projects/{project}/locations/{location}/publishers/google/models/{model}:generateContent"
+features = ["native_tools"]
+cost_per_1k_in = 0.00125
+cost_per_1k_out = 0.005
+latency_p50_ms = 2100
+
+[providers.local]
+base_url = "http://localhost:8000"
+base_url_env = "LOCAL_LLM_BASE_URL"
+auth_style = "none"
+chat_endpoint = "/v1/chat/completions"
+completion_endpoint = "/v1/completions"
+cost_per_1k_in = 0.0
+cost_per_1k_out = 0.0
+latency_p50_ms = 900
+
+[providers.local.healthcheck]
+method = "GET"
+path = "/v1/models"
+
+# llama.cpp — separate from `local` so capability rules can isolate Qwen
+# chat-template thinking quirks from other local OpenAI-compatible hosts.
+[providers.llamacpp]
+base_url = "http://127.0.0.1:8001"
+base_url_env = "LLAMACPP_BASE_URL"
+auth_style = "none"
+chat_endpoint = "/v1/chat/completions"
+completion_endpoint = "/v1/completions"
+cost_per_1k_in = 0.0
+cost_per_1k_out = 0.0
+latency_p50_ms = 900
+
+[providers.llamacpp.healthcheck]
+method = "GET"
+path = "/v1/models"
+
+# Apple Silicon MLX. Harn owns readiness probing; hosts that want
+# script-based auto-start should launch the process first, then call
+# Harn again to verify readiness.
+[providers.mlx]
+base_url = "http://127.0.0.1:8002"
+base_url_env = "MLX_BASE_URL"
+auth_style = "none"
+chat_endpoint = "/v1/chat/completions"
+completion_endpoint = "/v1/completions"
+cost_per_1k_in = 0.0
+cost_per_1k_out = 0.0
+latency_p50_ms = 900
+
+[providers.mlx.healthcheck]
+method = "GET"
+path = "/v1/models"
+
+[providers.vllm]
+base_url = "http://localhost:8000"
+base_url_env = "VLLM_BASE_URL"
+auth_style = "none"
+chat_endpoint = "/v1/chat/completions"
+completion_endpoint = "/v1/completions"
+cost_per_1k_in = 0.0
+cost_per_1k_out = 0.0
+latency_p50_ms = 800
+
+[providers.vllm.healthcheck]
+method = "GET"
+path = "/v1/models"
+
+[providers.tgi]
+base_url = "http://localhost:8080"
+base_url_env = "TGI_BASE_URL"
+auth_style = "none"
+chat_endpoint = "/v1/chat/completions"
+completion_endpoint = "/v1/completions"
+cost_per_1k_in = 0.0
+cost_per_1k_out = 0.0
+latency_p50_ms = 950
+
+[providers.tgi.healthcheck]
+method = "GET"
+path = "/health"
+
+# ── Inference rules ──────────────────────────────────────────────────────────
+# Map a model ID shape to a default provider when the caller doesn't
+# specify one. First match wins. User overlays prepend, so they can
+# preempt these defaults without removing them.
+
+[[inference_rules]]
+pattern = "claude-*"
+provider = "anthropic"
+
+[[inference_rules]]
+pattern = "gpt-*"
+provider = "openai"
+
+[[inference_rules]]
+pattern = "o1*"
+provider = "openai"
+
+[[inference_rules]]
+pattern = "o3*"
+provider = "openai"
+
+[[inference_rules]]
+pattern = "o4*"
+provider = "openai"
+
+[[inference_rules]]
+pattern = "anthropic.claude-*"
+provider = "bedrock"
+
+[[inference_rules]]
+pattern = "meta.llama*"
+provider = "bedrock"
+
+[[inference_rules]]
+pattern = "amazon.*"
+provider = "bedrock"
+
+[[inference_rules]]
+pattern = "mistral.*"
+provider = "bedrock"
+
+[[inference_rules]]
+pattern = "cohere.*"
+provider = "bedrock"
+
+[[inference_rules]]
+pattern = "gemini-*"
+provider = "gemini"
+
+# ── Tier rules ───────────────────────────────────────────────────────────────
+# Classify a model into small / mid / frontier for default routing and
+# evaluation budgets. First match wins.
+
+[[tier_rules]]
+contains = "9b"
+tier = "small"
+
+[[tier_rules]]
+contains = "a3b"
+tier = "small"
+
+[[tier_rules]]
+contains = "gemma-4-e2b"
+tier = "small"
+
+[[tier_rules]]
+contains = "gemma-4-e4b"
+tier = "small"
+
+[[tier_rules]]
+contains = "gemma-4-26b"
+tier = "mid"
+
+[[tier_rules]]
+contains = "gemma-4-31b"
+tier = "frontier"
+
+[[tier_rules]]
+contains = "gemma4:26b"
+tier = "mid"
+
+[[tier_rules]]
+contains = "gemma4:31b"
+tier = "frontier"
+
+[[tier_rules]]
+pattern = "claude-*"
+tier = "frontier"
+
+[[tier_rules]]
+exact = "gpt-4o"
+tier = "frontier"
+
+[tier_defaults]
+default = "mid"
+
+# ── Aliases ──────────────────────────────────────────────────────────────────
+# Short symbolic names → (model id, provider, optional tool_format). The
+# tier-resolution path (`resolve_tier_model("frontier", None)`) reads
+# `frontier`, `mid`, `small`; provider-scoped tiers like `tier/mid` let
+# callers force a specific resolution per provider.
+
+# Short flagship aliases — these track whatever the current
+# generation is. Bump these when a successor lands.
+[aliases.sonnet]
+id = "claude-sonnet-4-6"
+provider = "anthropic"
+
+[aliases.opus]
+id = "claude-opus-4-7"
+provider = "anthropic"
+
+[aliases.haiku]
+id = "claude-haiku-4-5-20251001"
+provider = "anthropic"
+
+[aliases.frontier]
+id = "claude-sonnet-4-6"
+provider = "anthropic"
+
+[aliases."tier/frontier"]
+id = "claude-sonnet-4-6"
+provider = "anthropic"
+
+[aliases.mid]
+id = "gpt-4o-mini"
+provider = "openai"
+
+[aliases."tier/mid"]
+id = "gpt-4o-mini"
+provider = "openai"
+
+[aliases.small]
+id = "Qwen/Qwen3.5-9B"
+provider = "openrouter"
+
+[aliases."tier/small"]
+id = "Qwen/Qwen3.5-9B"
+provider = "openrouter"
+
+# Local Gemma 4 variants (vLLM / OpenAI-compat backend at `providers.local`).
+[aliases.local-gemma4]
+id = "gemma-4-26b-a4b-it"
+provider = "local"
+
+[aliases.local-gemma4-26b]
+id = "gemma-4-26b-a4b-it"
+provider = "local"
+
+[aliases.local-gemma4-31b]
+id = "gemma-4-31b-it"
+provider = "local"
+
+[aliases.local-gemma4-e4b]
+id = "gemma-4-e4b-it"
+provider = "local"
+
+[aliases.local-gemma4-e2b]
+id = "gemma-4-e2b-it"
+provider = "local"
+
+[aliases.ollama-gemma4]
+id = "gemma4:26b"
+provider = "ollama"
+tool_format = "text"
+
+[aliases.ollama-gemma4-26b]
+id = "gemma4:26b"
+provider = "ollama"
+tool_format = "text"
+
+# Qwen3.6 — Ollama (text tool calling is the safe default; the `-native`
+# variant opts into the experimental native path).
+[aliases."qwen3.6-coding"]
+id = "qwen3.6:35b-a3b-coding-nvfp4"
+provider = "ollama"
+tool_format = "text"
+
+[aliases."qwen3.6-35b-coding"]
+id = "qwen3.6:35b-a3b-coding-nvfp4"
+provider = "ollama"
+tool_format = "text"
+
+[aliases."qwen3.6-coding-nvfp4"]
+id = "qwen3.6:35b-a3b-coding-nvfp4"
+provider = "ollama"
+tool_format = "text"
+
+[aliases."qwen3.6-coding-native"]
+id = "qwen3.6:35b-a3b-coding-nvfp4"
+provider = "ollama"
+tool_format = "native"
+
+# llama.cpp — Unsloth Dynamic 2.0 GGUF served by llama-server.
+[aliases."llamacpp-qwen3.6"]
+id = "qwen3.6-35b-a3b"
+provider = "llamacpp"
+tool_format = "text"
+
+[aliases."llamacpp-qwen3.6-q4"]
+id = "qwen3.6-35b-a3b-ud-q4-k-xl"
+provider = "llamacpp"
+tool_format = "text"
+
+[aliases."local-qwen3.6"]
+id = "qwen3.6-35b-a3b-ud-q4-k-xl"
+provider = "llamacpp"
+tool_format = "text"
+
+[aliases."local-qwen3.6-gguf"]
+id = "qwen3.6-35b-a3b-ud-q4-k-xl"
+provider = "llamacpp"
+tool_format = "text"
+
+# MLX (Apple Silicon).
+[aliases.mlx-qwen36-27b]
+id = "unsloth/Qwen3.6-27B-UD-MLX-4bit"
+provider = "mlx"
+
+[aliases."mlx-qwen3.6-27b"]
+id = "unsloth/Qwen3.6-27B-UD-MLX-4bit"
+provider = "mlx"
+tool_format = "native"
+
+[aliases."mlx-qwen3.6-27b-q4"]
+id = "unsloth/Qwen3.6-27B-UD-MLX-4bit"
+provider = "mlx"
+tool_format = "native"
+
+[aliases."local-qwen3.6-27b"]
+id = "unsloth/Qwen3.6-27B-UD-MLX-4bit"
+provider = "mlx"
+tool_format = "native"
+
+# Devstral (Mistral's agentic-coding tune).
+[aliases.devstral-small-2]
+id = "devstral-small-2:24b"
+provider = "ollama"
+tool_format = "text"
+
+[aliases.ollama-devstral-small-2]
+id = "devstral-small-2:24b"
+provider = "ollama"
+tool_format = "text"
+
+[aliases.ollama-devstral-small-2-native]
+id = "devstral-small-2:24b"
+provider = "ollama"
+tool_format = "native"
+
+# ── Alias tool-calling probe state ───────────────────────────────────────────
+# Per-alias overrides recording the last-observed native vs. text vs.
+# streaming tool-call probe outcome and the desired fallback. Hosts may
+# update these via providers.toml overlays as they re-probe a model.
+
+[alias_tool_calling."qwen3.6-coding"]
+native = "unknown"
+text = "unknown"
+streaming_native = "unknown"
+fallback_mode = "text"
+
+[alias_tool_calling."qwen3.6-coding-native"]
+native = "unknown"
+text = "unknown"
+streaming_native = "unknown"
+fallback_mode = "native"
+
+[alias_tool_calling.ollama-gemma4]
+native = "unknown"
+text = "unknown"
+streaming_native = "unknown"
+fallback_mode = "disabled"
+failure_reason = "requires_tool_probe"
+
+[alias_tool_calling."llamacpp-qwen3.6-q4"]
+native = "unknown"
+text = "unknown"
+streaming_native = "unknown"
+fallback_mode = "text"
+failure_reason = "requires_tool_probe_and_cache_probe"
+
+[alias_tool_calling."mlx-qwen3.6-27b"]
+native = "unknown"
+text = "unknown"
+streaming_native = "unknown"
+fallback_mode = "native"
+failure_reason = "requires_served_identity_and_tool_probe"
+
+# ── QC defaults ──────────────────────────────────────────────────────────────
+# Default low-cost model per provider for cheap quality-check / repair
+# passes. Scripts read these via `qc_default_model(provider)`.
+
+[qc_defaults]
+anthropic = "claude-haiku-4-5-20251001"
+openai = "gpt-4o-mini"
+openrouter = "google/gemini-2.5-flash"
+ollama = "llama3.2"
+local = "gpt-4o"
+
+# ── Models ───────────────────────────────────────────────────────────────────
+# Canonical model metadata: display name, provider, context window,
+# capabilities, pricing (USD per 1M tokens), and deprecation status.
+# Pricing reflects public provider pages snapshotted at the comment
+# beside each section; edit the literal here and the change shows up in
+# `git blame`.
+
+# Anthropic ─ pricing pages: https://www.anthropic.com/pricing &
+# https://platform.claude.com/docs/en/about-claude/model-deprecations.
+# Sonnet 4.5 retired 2026-05-15; Sonnet 4 and Opus 4 retire 2026-06-15.
+
+[models."claude-3-5-haiku-20241022"]
+name = "Claude Haiku 3.5"
+provider = "anthropic"
+context_window = 200000
+capabilities = ["tools", "streaming", "prompt_caching", "thinking"]
+pricing = { input_per_mtok = 0.80, output_per_mtok = 4.00, cache_read_per_mtok = 0.08, cache_write_per_mtok = 1.00 }
+
+[models."claude-haiku-4-5-20251001"]
+name = "Claude Haiku 4.5"
+provider = "anthropic"
+context_window = 200000
+capabilities = ["tools", "streaming", "prompt_caching", "thinking"]
+pricing = { input_per_mtok = 1.00, output_per_mtok = 5.00, cache_read_per_mtok = 0.10, cache_write_per_mtok = 1.25 }
+
+[models."claude-3-5-sonnet-20240620"]
+name = "Claude Sonnet 3.5 (2024-06-20)"
+provider = "anthropic"
+context_window = 200000
+capabilities = ["tools", "streaming", "prompt_caching", "thinking"]
+pricing = { input_per_mtok = 3.00, output_per_mtok = 15.00, cache_read_per_mtok = 0.30, cache_write_per_mtok = 3.75 }
+
+[models."claude-3-5-sonnet-20241022"]
+name = "Claude Sonnet 3.5 (2024-10-22)"
+provider = "anthropic"
+context_window = 200000
+capabilities = ["tools", "streaming", "prompt_caching", "thinking"]
+pricing = { input_per_mtok = 3.00, output_per_mtok = 15.00, cache_read_per_mtok = 0.30, cache_write_per_mtok = 3.75 }
+
+[models."claude-sonnet-4-20250514"]
+name = "Claude Sonnet 4"
+provider = "anthropic"
+context_window = 200000
+capabilities = ["tools", "streaming", "prompt_caching", "thinking"]
+pricing = { input_per_mtok = 3.00, output_per_mtok = 15.00, cache_read_per_mtok = 0.30, cache_write_per_mtok = 3.75 }
+deprecated = true
+deprecation_note = "Sunset 2026-06-15 per Anthropic deprecations page. Replaced by claude-sonnet-4-6."
+
+[models."claude-sonnet-4-5"]
+name = "Claude Sonnet 4.5"
+provider = "anthropic"
+context_window = 200000
+capabilities = ["tools", "streaming", "prompt_caching", "thinking"]
+pricing = { input_per_mtok = 3.00, output_per_mtok = 15.00, cache_read_per_mtok = 0.30, cache_write_per_mtok = 3.75 }
+deprecated = true
+deprecation_note = "Sunset 2026-05-15 per Anthropic deprecations page. Replaced by claude-sonnet-4-6."
+
+[models."claude-sonnet-4-6"]
+name = "Claude Sonnet 4.6"
+provider = "anthropic"
+context_window = 200000
+capabilities = ["tools", "streaming", "prompt_caching", "thinking"]
+pricing = { input_per_mtok = 3.00, output_per_mtok = 15.00, cache_read_per_mtok = 0.30, cache_write_per_mtok = 3.75 }
+
+[models."claude-sonnet-4-7"]
+name = "Claude Sonnet 4.7"
+provider = "anthropic"
+context_window = 200000
+capabilities = ["tools", "streaming", "prompt_caching", "thinking"]
+pricing = { input_per_mtok = 3.00, output_per_mtok = 15.00, cache_read_per_mtok = 0.30, cache_write_per_mtok = 3.75 }
+
+[models."claude-3-opus-20240229"]
+name = "Claude Opus 3"
+provider = "anthropic"
+context_window = 200000
+capabilities = ["tools", "streaming", "prompt_caching", "thinking"]
+pricing = { input_per_mtok = 15.00, output_per_mtok = 75.00, cache_read_per_mtok = 1.50, cache_write_per_mtok = 18.75 }
+
+[models."claude-opus-4-20250514"]
+name = "Claude Opus 4"
+provider = "anthropic"
+context_window = 200000
+capabilities = ["tools", "streaming", "prompt_caching", "thinking"]
+pricing = { input_per_mtok = 15.00, output_per_mtok = 75.00, cache_read_per_mtok = 1.50, cache_write_per_mtok = 18.75 }
+deprecated = true
+deprecation_note = "Sunset 2026-06-15 per Anthropic deprecations page. Replaced by claude-opus-4-7."
+
+[models."claude-opus-4-1-20250805"]
+name = "Claude Opus 4.1"
+provider = "anthropic"
+context_window = 200000
+capabilities = ["tools", "streaming", "prompt_caching", "thinking"]
+pricing = { input_per_mtok = 15.00, output_per_mtok = 75.00, cache_read_per_mtok = 1.50, cache_write_per_mtok = 18.75 }
+deprecated = true
+deprecation_note = "Superseded by claude-opus-4-7. No formal sunset yet; switch when convenient."
+
+[models."claude-opus-4-6"]
+name = "Claude Opus 4.6"
+provider = "anthropic"
+context_window = 200000
+capabilities = ["tools", "streaming", "prompt_caching", "thinking"]
+pricing = { input_per_mtok = 15.00, output_per_mtok = 75.00, cache_read_per_mtok = 1.50, cache_write_per_mtok = 18.75 }
+
+[models."claude-opus-4-7"]
+name = "Claude Opus 4.7"
+provider = "anthropic"
+context_window = 200000
+capabilities = ["tools", "streaming", "prompt_caching", "thinking"]
+pricing = { input_per_mtok = 15.00, output_per_mtok = 75.00, cache_read_per_mtok = 1.50, cache_write_per_mtok = 18.75 }
+
+# OpenAI ─ pricing pages: https://platform.openai.com/docs/pricing.
+# GPT-4o retired from ChatGPT 2026-02-13; chatgpt-4o-latest removed
+# from API 2026-02-17 (Enterprise/Edu grace until 2026-04-03).
+
+[models."gpt-4o"]
+name = "GPT-4o"
+provider = "openai"
+context_window = 128000
+capabilities = ["tools", "streaming"]
+pricing = { input_per_mtok = 2.50, output_per_mtok = 10.00, cache_read_per_mtok = 1.25 }
+deprecated = true
+deprecation_note = "API sunset 2026-02-17 per OpenAI deprecations page. Switch to gpt-5-mini for cheap routing or gpt-5 for frontier."
+
+[models."gpt-4o-mini"]
+name = "GPT-4o Mini"
+provider = "openai"
+context_window = 128000
+capabilities = ["tools", "streaming"]
+pricing = { input_per_mtok = 0.15, output_per_mtok = 0.60 }
+# Not yet deprecated as of 2026-05 — OpenAI's deprecation page lists
+# gpt-4o (Feb 17 2026 API sunset) but gpt-4o-mini has no announced
+# sunset. Still the canonical `mid` tier default until gpt-5-mini ships
+# with confirmed pricing.
+
+[models."gpt-4-turbo"]
+name = "GPT-4 Turbo"
+provider = "openai"
+context_window = 128000
+capabilities = ["tools", "streaming"]
+pricing = { input_per_mtok = 10.00, output_per_mtok = 30.00 }
+deprecated = true
+deprecation_note = "Superseded by gpt-5 family. Listed for cost-attribution backfill only."
+
+[models.o1]
+name = "OpenAI o1"
+provider = "openai"
+context_window = 200000
+capabilities = ["tools", "streaming"]
+pricing = { input_per_mtok = 15.00, output_per_mtok = 60.00, cache_read_per_mtok = 7.50 }
+
+[models."o1-mini"]
+name = "OpenAI o1-mini"
+provider = "openai"
+context_window = 128000
+capabilities = ["tools", "streaming"]
+pricing = { input_per_mtok = 3.00, output_per_mtok = 12.00, cache_read_per_mtok = 1.50 }
+
+[models.o3]
+name = "OpenAI o3"
+provider = "openai"
+context_window = 200000
+capabilities = ["tools", "streaming"]
+pricing = { input_per_mtok = 15.00, output_per_mtok = 60.00, cache_read_per_mtok = 7.50 }
+
+[models."o3-mini"]
+name = "OpenAI o3-mini"
+provider = "openai"
+context_window = 200000
+capabilities = ["tools", "streaming"]
+pricing = { input_per_mtok = 1.10, output_per_mtok = 4.40, cache_read_per_mtok = 0.55 }
+
+# Google Gemini ─ pricing: https://ai.google.dev/pricing.
+# Gemini 1.0 / 1.5 already retired. Gemini 2.0 Flash + Flash-Lite shut
+# down 2026-06-01 per the deprecations page.
+
+[models."gemini-2.5-flash"]
+name = "Gemini 2.5 Flash"
+provider = "gemini"
+context_window = 1048576
+capabilities = ["tools", "streaming"]
+pricing = { input_per_mtok = 0.10, output_per_mtok = 0.40, cache_read_per_mtok = 0.025 }
+
+# OpenRouter-routed variant of the same model — kept as a distinct
+# catalog entry so the `qc_defaults.openrouter` lookup resolves to a
+# registered ID. Pricing matches the native Gemini API; OpenRouter adds
+# its own margin at request time.
+[models."google/gemini-2.5-flash"]
+name = "Gemini 2.5 Flash (via OpenRouter)"
+provider = "openrouter"
+context_window = 1048576
+capabilities = ["tools", "streaming"]
+pricing = { input_per_mtok = 0.10, output_per_mtok = 0.40, cache_read_per_mtok = 0.025 }
+
+[models."gemini-2.5-pro"]
+name = "Gemini 2.5 Pro"
+provider = "gemini"
+context_window = 2097152
+capabilities = ["tools", "streaming"]
+pricing = { input_per_mtok = 1.25, output_per_mtok = 5.00, cache_read_per_mtok = 0.3125 }
+
+# Mistral hosted via OpenRouter.
+
+[models."mistral-large-latest"]
+name = "Mistral Large"
+provider = "openrouter"
+context_window = 128000
+capabilities = ["tools", "streaming"]
+pricing = { input_per_mtok = 2.00, output_per_mtok = 6.00 }
+
+[models."mistral-small-latest"]
+name = "Mistral Small"
+provider = "openrouter"
+context_window = 128000
+capabilities = ["tools", "streaming"]
+pricing = { input_per_mtok = 0.20, output_per_mtok = 0.60 }
+
+# Open-weight executor candidates (<$2/Mtok with function calling). Use
+# these via OpenRouter or Fireworks for fast secondary-model dispatch.
+# Pricing snapshot 2026-05 from OpenRouter / Artificial Analysis.
+
+[models."qwen/qwen3-coder"]
+name = "Qwen3 Coder 480B A35B"
+provider = "openrouter"
+context_window = 262144
+capabilities = ["tools", "streaming"]
+pricing = { input_per_mtok = 0.22, output_per_mtok = 1.80 }
+
+[models."deepseek/deepseek-v3.2"]
+name = "DeepSeek V3.2"
+provider = "openrouter"
+context_window = 131072
+capabilities = ["tools", "streaming"]
+pricing = { input_per_mtok = 0.28, output_per_mtok = 0.42 }
+
+[models."moonshotai/kimi-k2.6"]
+name = "Kimi K2.6"
+provider = "openrouter"
+context_window = 200000
+capabilities = ["tools", "streaming"]
+pricing = { input_per_mtok = 0.55, output_per_mtok = 2.20 }
+
+[models."openai/gpt-oss-120b"]
+name = "GPT-OSS 120B"
+provider = "openrouter"
+context_window = 131072
+capabilities = ["tools", "streaming"]
+pricing = { input_per_mtok = 0.15, output_per_mtok = 0.60 }
+
+# Open-router Qwen3.5 9B (kept for the `small` tier alias).
+
+[models."Qwen/Qwen3.5-9B"]
+name = "Qwen3.5 9B"
+provider = "openrouter"
+context_window = 131072
+capabilities = ["tools", "streaming"]
+
+# Ollama / local models — no `pricing` (free); context_window reflects
+# model card ceiling. `runtime_context_window` caps what Harn will
+# actually feed the runtime (host memory budget).
+
+[models."llama3.2"]
+name = "Llama 3.2"
+provider = "ollama"
+context_window = 32000
+stream_timeout = 300.0
+capabilities = ["tools", "streaming"]
+
+[models."gemma4:26b"]
+name = "Gemma 4 26B MoE"
+provider = "ollama"
+context_window = 262144
+runtime_context_window = 32768
+stream_timeout = 300.0
+capabilities = ["tools", "vision", "streaming", "thinking"]
+
+[models."qwen3.6:35b-a3b-coding-nvfp4"]
+name = "Qwen3.6 35B A3B Coding (NVFP4)"
+provider = "ollama"
+context_window = 262144
+runtime_context_window = 32768
+stream_timeout = 900.0
+capabilities = ["tools", "streaming", "thinking"]
+
+[models."devstral-small-2:24b"]
+name = "Devstral Small 2 24B"
+provider = "ollama"
+context_window = 262144
+runtime_context_window = 32768
+stream_timeout = 600.0
+capabilities = ["tools", "streaming"]
+
+# llama.cpp — Unsloth Dynamic 2.0 GGUF served by llama-server.
+
+[models."qwen3.6-35b-a3b-ud-q4-k-xl"]
+name = "Qwen3.6 35B (Unsloth Q4_K_XL, llama.cpp)"
+provider = "llamacpp"
+context_window = 262144
+runtime_context_window = 65536
+stream_timeout = 900.0
+capabilities = ["tools", "streaming", "thinking"]
+
+[models."qwen3.6-35b-a3b-ud-q5-k-xl"]
+name = "Qwen3.6 35B (Unsloth Q5_K_XL, llama.cpp)"
+provider = "llamacpp"
+context_window = 262144
+runtime_context_window = 65536
+stream_timeout = 900.0
+capabilities = ["tools", "streaming", "thinking"]
+
+[models."qwen3.6-35b-a3b"]
+name = "Qwen3.6 35B (llama.cpp)"
+provider = "llamacpp"
+context_window = 262144
+runtime_context_window = 65536
+stream_timeout = 900.0
+capabilities = ["tools", "streaming", "thinking"]
+
+# Apple Silicon MLX.
+
+[models."unsloth/Qwen3.6-27B-UD-MLX-4bit"]
+name = "Qwen3.6 27B (MLX 4-bit)"
+provider = "mlx"
+context_window = 262144
+stream_timeout = 900.0
+capabilities = ["tools", "vision", "streaming", "thinking"]
+
+# Local OpenAI-compatible servers (vLLM / bring-your-own). The
+# `prefer_prefill_done` opts a small model into the issue #41 brevity
+# nudge — keep it on for the Gemma 4 E2B / E4B sizes that benefit most.
+
+[models."gemma-4-e2b-it"]
+name = "Gemma 4 E2B (local)"
+provider = "local"
+context_window = 131072
+stream_timeout = 300.0
+capabilities = ["streaming", "thinking"]
+prefer_prefill_done = true
+
+[models."gemma-4-e4b-it"]
+name = "Gemma 4 E4B (local)"
+provider = "local"
+context_window = 131072
+stream_timeout = 300.0
+capabilities = ["streaming", "thinking"]
+prefer_prefill_done = true
+
+[models."gemma-4-26b-a4b-it"]
+name = "Gemma 4 26B MoE (local)"
+provider = "local"
+context_window = 131072
+stream_timeout = 600.0
+capabilities = ["streaming", "thinking"]
+
+[models."gemma-4-31b-it"]
+name = "Gemma 4 31B (local)"
+provider = "local"
+context_window = 131072
+stream_timeout = 600.0
+capabilities = ["streaming", "thinking"]

--- a/crates/harn-vm/src/llm_config.rs
+++ b/crates/harn-vm/src/llm_config.rs
@@ -640,13 +640,13 @@ pub fn default_model_for_provider(provider: &str) -> String {
     match provider {
         "local" => std::env::var("LOCAL_LLM_MODEL")
             .or_else(|_| std::env::var("HARN_LLM_MODEL"))
-            .unwrap_or_else(|_| "gpt-4o".to_string()),
+            .unwrap_or_else(|_| "gemma-4-26b-a4b-it".to_string()),
         "mlx" => std::env::var("MLX_MODEL_ID")
             .unwrap_or_else(|_| "unsloth/Qwen3.6-27B-UD-MLX-4bit".to_string()),
-        "openai" => "gpt-4o".to_string(),
+        "openai" => "gpt-4o-mini".to_string(),
         "ollama" => "llama3.2".to_string(),
         "openrouter" => "anthropic/claude-sonnet-4.6".to_string(),
-        _ => "claude-sonnet-4-20250514".to_string(),
+        _ => "claude-sonnet-4-6".to_string(),
     }
 }
 
@@ -931,1360 +931,25 @@ pub fn resolve_base_url(pdef: &ProviderDef) -> String {
     pdef.base_url.clone()
 }
 
+/// Embedded copy of `llm/providers.toml`, the single source of truth for
+/// Harn's bundled provider/model catalog. Edit the TOML, not this string.
+const EMBEDDED_PROVIDERS_TOML: &str = include_str!("llm/providers.toml");
+
+/// Parse the embedded `providers.toml` into the runtime `ProvidersConfig`.
+///
+/// Hosts overlay this base via `HARN_PROVIDERS_CONFIG`,
+/// `~/.config/harn/providers.toml`, `harn.toml`, package-manifest
+/// `[llm]` sections, and per-run `set_user_overrides(...)`. The same
+/// Serde shape applies at every layer, so there is exactly one schema to
+/// keep coherent — no parallel Rust-literal catalog.
+///
+/// We `expect` on parse failure because the file is bundled into the
+/// binary at compile time; a malformed embedded catalog is a build-time
+/// invariant violation that should fail every test, not silently
+/// degrade in production.
 fn default_config() -> ProvidersConfig {
-    let mut config = ProvidersConfig {
-        default_provider: Some("anthropic".to_string()),
-        ..Default::default()
-    };
-
-    config.providers.insert(
-        "anthropic".to_string(),
-        ProviderDef {
-            base_url: "https://api.anthropic.com/v1".to_string(),
-            auth_style: "header".to_string(),
-            auth_header: Some("x-api-key".to_string()),
-            auth_env: AuthEnv::Single("ANTHROPIC_API_KEY".to_string()),
-            extra_headers: BTreeMap::from([(
-                "anthropic-version".to_string(),
-                "2023-06-01".to_string(),
-            )]),
-            chat_endpoint: "/messages".to_string(),
-            completion_endpoint: None,
-            healthcheck: Some(HealthcheckDef {
-                method: "POST".to_string(),
-                path: Some("/messages/count_tokens".to_string()),
-                url: None,
-                body: Some(
-                    r#"{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"x"}]}"#
-                        .to_string(),
-                ),
-            }),
-            features: vec!["prompt_caching".to_string(), "thinking".to_string()],
-            cost_per_1k_in: Some(0.003),
-            cost_per_1k_out: Some(0.015),
-            latency_p50_ms: Some(2500),
-            ..Default::default()
-        },
-    );
-
-    // OpenAI
-    config.providers.insert(
-        "openai".to_string(),
-        ProviderDef {
-            base_url: "https://api.openai.com/v1".to_string(),
-            auth_style: "bearer".to_string(),
-            auth_env: AuthEnv::Single("OPENAI_API_KEY".to_string()),
-            chat_endpoint: "/chat/completions".to_string(),
-            completion_endpoint: Some("/completions".to_string()),
-            healthcheck: Some(HealthcheckDef {
-                method: "GET".to_string(),
-                path: Some("/models".to_string()),
-                url: None,
-                body: None,
-            }),
-            cost_per_1k_in: Some(0.0025),
-            cost_per_1k_out: Some(0.010),
-            latency_p50_ms: Some(1800),
-            ..Default::default()
-        },
-    );
-
-    // OpenRouter
-    config.providers.insert(
-        "openrouter".to_string(),
-        ProviderDef {
-            base_url: "https://openrouter.ai/api/v1".to_string(),
-            auth_style: "bearer".to_string(),
-            auth_env: AuthEnv::Single("OPENROUTER_API_KEY".to_string()),
-            chat_endpoint: "/chat/completions".to_string(),
-            completion_endpoint: Some("/completions".to_string()),
-            healthcheck: Some(HealthcheckDef {
-                method: "GET".to_string(),
-                path: Some("/auth/key".to_string()),
-                url: None,
-                body: None,
-            }),
-            cost_per_1k_in: Some(0.003),
-            cost_per_1k_out: Some(0.015),
-            latency_p50_ms: Some(2200),
-            ..Default::default()
-        },
-    );
-
-    // HuggingFace
-    config.providers.insert(
-        "huggingface".to_string(),
-        ProviderDef {
-            base_url: "https://router.huggingface.co/v1".to_string(),
-            auth_style: "bearer".to_string(),
-            auth_env: AuthEnv::Multiple(vec![
-                "HF_TOKEN".to_string(),
-                "HUGGINGFACE_API_KEY".to_string(),
-            ]),
-            chat_endpoint: "/chat/completions".to_string(),
-            completion_endpoint: Some("/completions".to_string()),
-            healthcheck: Some(HealthcheckDef {
-                method: "GET".to_string(),
-                url: Some("https://huggingface.co/api/whoami-v2".to_string()),
-                path: None,
-                body: None,
-            }),
-            cost_per_1k_in: Some(0.0002),
-            cost_per_1k_out: Some(0.0006),
-            latency_p50_ms: Some(2400),
-            ..Default::default()
-        },
-    );
-
-    // Ollama default. Hosts can override this to `/v1/chat/completions`
-    // via a bundled `providers.toml` (loaded by setting
-    // `HARN_PROVIDERS_CONFIG` in the host process). The OpenAI-compat
-    // path bypasses Ollama's per-model tool-call post-processors
-    // (qwen3coder.go, qwen35.go) which raise HTTP 500s on text-mode
-    // responses for the Qwen3.5 family. The default here stays on
-    // `/api/chat` so the harn-vm test stub keeps working with Ollama's
-    // native NDJSON wire format.
-    config.providers.insert(
-        "ollama".to_string(),
-        ProviderDef {
-            base_url: "http://localhost:11434".to_string(),
-            base_url_env: Some("OLLAMA_HOST".to_string()),
-            auth_style: "none".to_string(),
-            chat_endpoint: "/api/chat".to_string(),
-            completion_endpoint: Some("/api/generate".to_string()),
-            healthcheck: Some(HealthcheckDef {
-                method: "GET".to_string(),
-                path: Some("/api/tags".to_string()),
-                url: None,
-                body: None,
-            }),
-            cost_per_1k_in: Some(0.0),
-            cost_per_1k_out: Some(0.0),
-            latency_p50_ms: Some(1200),
-            ..Default::default()
-        },
-    );
-
-    // Google Gemini native API.
-    config.providers.insert(
-        "gemini".to_string(),
-        ProviderDef {
-            base_url: "https://generativelanguage.googleapis.com".to_string(),
-            base_url_env: Some("GEMINI_BASE_URL".to_string()),
-            auth_style: "header".to_string(),
-            auth_header: Some("x-goog-api-key".to_string()),
-            auth_env: AuthEnv::Multiple(vec![
-                "GEMINI_API_KEY".to_string(),
-                "GOOGLE_API_KEY".to_string(),
-            ]),
-            chat_endpoint: "/v1beta/models".to_string(),
-            healthcheck: Some(HealthcheckDef {
-                method: "GET".to_string(),
-                path: Some("/v1beta/models".to_string()),
-                url: None,
-                body: None,
-            }),
-            cost_per_1k_in: Some(0.00125),
-            cost_per_1k_out: Some(0.005),
-            latency_p50_ms: Some(1800),
-            ..Default::default()
-        },
-    );
-
-    // Together AI (OpenAI-compatible)
-    config.providers.insert(
-        "together".to_string(),
-        ProviderDef {
-            base_url: "https://api.together.xyz/v1".to_string(),
-            base_url_env: Some("TOGETHER_AI_BASE_URL".to_string()),
-            auth_style: "bearer".to_string(),
-            auth_env: AuthEnv::Single("TOGETHER_AI_API_KEY".to_string()),
-            chat_endpoint: "/chat/completions".to_string(),
-            completion_endpoint: Some("/completions".to_string()),
-            healthcheck: Some(HealthcheckDef {
-                method: "GET".to_string(),
-                path: Some("/models".to_string()),
-                url: None,
-                body: None,
-            }),
-            cost_per_1k_in: Some(0.0002),
-            cost_per_1k_out: Some(0.0006),
-            latency_p50_ms: Some(1600),
-            ..Default::default()
-        },
-    );
-
-    // Groq (OpenAI-compatible)
-    config.providers.insert(
-        "groq".to_string(),
-        ProviderDef {
-            base_url: "https://api.groq.com/openai/v1".to_string(),
-            base_url_env: Some("GROQ_BASE_URL".to_string()),
-            auth_style: "bearer".to_string(),
-            auth_env: AuthEnv::Single("GROQ_API_KEY".to_string()),
-            chat_endpoint: "/chat/completions".to_string(),
-            completion_endpoint: Some("/completions".to_string()),
-            healthcheck: Some(HealthcheckDef {
-                method: "GET".to_string(),
-                path: Some("/models".to_string()),
-                url: None,
-                body: None,
-            }),
-            cost_per_1k_in: Some(0.0001),
-            cost_per_1k_out: Some(0.0003),
-            latency_p50_ms: Some(450),
-            ..Default::default()
-        },
-    );
-
-    // DeepSeek (OpenAI-compatible)
-    config.providers.insert(
-        "deepseek".to_string(),
-        ProviderDef {
-            base_url: "https://api.deepseek.com/v1".to_string(),
-            base_url_env: Some("DEEPSEEK_BASE_URL".to_string()),
-            auth_style: "bearer".to_string(),
-            auth_env: AuthEnv::Single("DEEPSEEK_API_KEY".to_string()),
-            chat_endpoint: "/chat/completions".to_string(),
-            completion_endpoint: Some("/completions".to_string()),
-            healthcheck: Some(HealthcheckDef {
-                method: "GET".to_string(),
-                path: Some("/models".to_string()),
-                url: None,
-                body: None,
-            }),
-            cost_per_1k_in: Some(0.00014),
-            cost_per_1k_out: Some(0.00028),
-            latency_p50_ms: Some(1800),
-            ..Default::default()
-        },
-    );
-
-    // Fireworks (OpenAI-compatible open-weight hosting)
-    config.providers.insert(
-        "fireworks".to_string(),
-        ProviderDef {
-            base_url: "https://api.fireworks.ai/inference/v1".to_string(),
-            base_url_env: Some("FIREWORKS_BASE_URL".to_string()),
-            auth_style: "bearer".to_string(),
-            auth_env: AuthEnv::Single("FIREWORKS_API_KEY".to_string()),
-            chat_endpoint: "/chat/completions".to_string(),
-            completion_endpoint: Some("/completions".to_string()),
-            healthcheck: Some(HealthcheckDef {
-                method: "GET".to_string(),
-                path: Some("/models".to_string()),
-                url: None,
-                body: None,
-            }),
-            cost_per_1k_in: Some(0.0002),
-            cost_per_1k_out: Some(0.0006),
-            latency_p50_ms: Some(1400),
-            ..Default::default()
-        },
-    );
-
-    // Alibaba DashScope (OpenAI-compatible Qwen host)
-    config.providers.insert(
-        "dashscope".to_string(),
-        ProviderDef {
-            base_url: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1".to_string(),
-            base_url_env: Some("DASHSCOPE_BASE_URL".to_string()),
-            auth_style: "bearer".to_string(),
-            auth_env: AuthEnv::Single("DASHSCOPE_API_KEY".to_string()),
-            chat_endpoint: "/chat/completions".to_string(),
-            completion_endpoint: Some("/completions".to_string()),
-            healthcheck: Some(HealthcheckDef {
-                method: "GET".to_string(),
-                path: Some("/models".to_string()),
-                url: None,
-                body: None,
-            }),
-            cost_per_1k_in: Some(0.0003),
-            cost_per_1k_out: Some(0.0012),
-            latency_p50_ms: Some(1600),
-            ..Default::default()
-        },
-    );
-
-    // AWS Bedrock Runtime. The provider shim resolves AWS credentials through
-    // env vars, the selected/default profile, container credentials, or EC2
-    // instance profile credentials, then signs Converse API calls with SigV4.
-    config.providers.insert(
-        "bedrock".to_string(),
-        ProviderDef {
-            base_url: String::new(),
-            base_url_env: Some("BEDROCK_BASE_URL".to_string()),
-            auth_style: "aws_sigv4".to_string(),
-            auth_env: AuthEnv::None,
-            chat_endpoint: "/model/{model}/converse".to_string(),
-            features: vec!["native_tools".to_string()],
-            latency_p50_ms: Some(2600),
-            ..Default::default()
-        },
-    );
-
-    // Azure OpenAI. The deployment name is routed in the URL; callers can
-    // use the Harn model field as the deployment name or set
-    // AZURE_OPENAI_DEPLOYMENT.
-    config.providers.insert(
-        "azure_openai".to_string(),
-        ProviderDef {
-            base_url: "https://{resource}.openai.azure.com".to_string(),
-            base_url_env: Some("AZURE_OPENAI_ENDPOINT".to_string()),
-            auth_style: "azure_openai".to_string(),
-            auth_env: AuthEnv::Multiple(vec![
-                "AZURE_OPENAI_API_KEY".to_string(),
-                "AZURE_OPENAI_AD_TOKEN".to_string(),
-                "AZURE_OPENAI_BEARER_TOKEN".to_string(),
-            ]),
-            chat_endpoint:
-                "/openai/deployments/{deployment}/chat/completions?api-version={api_version}"
-                    .to_string(),
-            features: vec!["native_tools".to_string()],
-            cost_per_1k_in: Some(0.0025),
-            cost_per_1k_out: Some(0.010),
-            latency_p50_ms: Some(1900),
-            ..Default::default()
-        },
-    );
-
-    // Google Vertex AI Gemini.
-    config.providers.insert(
-        "vertex".to_string(),
-        ProviderDef {
-            base_url: "https://aiplatform.googleapis.com/v1".to_string(),
-            base_url_env: Some("VERTEX_AI_BASE_URL".to_string()),
-            auth_style: "bearer".to_string(),
-            auth_env: AuthEnv::Multiple(vec![
-                "VERTEX_AI_ACCESS_TOKEN".to_string(),
-                "GOOGLE_OAUTH_ACCESS_TOKEN".to_string(),
-                "GOOGLE_APPLICATION_CREDENTIALS".to_string(),
-            ]),
-            chat_endpoint:
-                "/projects/{project}/locations/{location}/publishers/google/models/{model}:generateContent"
-                    .to_string(),
-            features: vec!["native_tools".to_string()],
-            cost_per_1k_in: Some(0.00125),
-            cost_per_1k_out: Some(0.005),
-            latency_p50_ms: Some(2100),
-            ..Default::default()
-        },
-    );
-
-    // Local OpenAI-compatible server
-    config.providers.insert(
-        "local".to_string(),
-        ProviderDef {
-            base_url: "http://localhost:8000".to_string(),
-            base_url_env: Some("LOCAL_LLM_BASE_URL".to_string()),
-            auth_style: "none".to_string(),
-            chat_endpoint: "/v1/chat/completions".to_string(),
-            completion_endpoint: Some("/v1/completions".to_string()),
-            healthcheck: Some(HealthcheckDef {
-                method: "GET".to_string(),
-                path: Some("/v1/models".to_string()),
-                url: None,
-                body: None,
-            }),
-            cost_per_1k_in: Some(0.0),
-            cost_per_1k_out: Some(0.0),
-            latency_p50_ms: Some(900),
-            ..Default::default()
-        },
-    );
-
-    // llama.cpp / llama-server OpenAI-compatible server. This is separate
-    // from `local` so capability rules can distinguish Qwen chat-template
-    // thinking quirks from other local OpenAI-compatible hosts.
-    config.providers.insert(
-        "llamacpp".to_string(),
-        ProviderDef {
-            base_url: "http://127.0.0.1:8001".to_string(),
-            base_url_env: Some("LLAMACPP_BASE_URL".to_string()),
-            auth_style: "none".to_string(),
-            chat_endpoint: "/v1/chat/completions".to_string(),
-            completion_endpoint: Some("/v1/completions".to_string()),
-            healthcheck: Some(HealthcheckDef {
-                method: "GET".to_string(),
-                path: Some("/v1/models".to_string()),
-                url: None,
-                body: None,
-            }),
-            cost_per_1k_in: Some(0.0),
-            cost_per_1k_out: Some(0.0),
-            latency_p50_ms: Some(900),
-            ..Default::default()
-        },
-    );
-
-    // Apple Silicon MLX OpenAI-compatible server. Harn owns readiness
-    // probing; hosts that want script-based auto-start should launch the
-    // process first, then call Harn again to verify readiness.
-    config.providers.insert(
-        "mlx".to_string(),
-        ProviderDef {
-            base_url: "http://127.0.0.1:8002".to_string(),
-            base_url_env: Some("MLX_BASE_URL".to_string()),
-            auth_style: "none".to_string(),
-            chat_endpoint: "/v1/chat/completions".to_string(),
-            completion_endpoint: Some("/v1/completions".to_string()),
-            healthcheck: Some(HealthcheckDef {
-                method: "GET".to_string(),
-                path: Some("/v1/models".to_string()),
-                url: None,
-                body: None,
-            }),
-            cost_per_1k_in: Some(0.0),
-            cost_per_1k_out: Some(0.0),
-            latency_p50_ms: Some(900),
-            ..Default::default()
-        },
-    );
-
-    // vLLM OpenAI-compatible server.
-    config.providers.insert(
-        "vllm".to_string(),
-        ProviderDef {
-            base_url: "http://localhost:8000".to_string(),
-            base_url_env: Some("VLLM_BASE_URL".to_string()),
-            auth_style: "none".to_string(),
-            chat_endpoint: "/v1/chat/completions".to_string(),
-            completion_endpoint: Some("/v1/completions".to_string()),
-            healthcheck: Some(HealthcheckDef {
-                method: "GET".to_string(),
-                path: Some("/v1/models".to_string()),
-                url: None,
-                body: None,
-            }),
-            cost_per_1k_in: Some(0.0),
-            cost_per_1k_out: Some(0.0),
-            latency_p50_ms: Some(800),
-            ..Default::default()
-        },
-    );
-
-    // HuggingFace Text Generation Inference OpenAI-compatible endpoint.
-    config.providers.insert(
-        "tgi".to_string(),
-        ProviderDef {
-            base_url: "http://localhost:8080".to_string(),
-            base_url_env: Some("TGI_BASE_URL".to_string()),
-            auth_style: "none".to_string(),
-            chat_endpoint: "/v1/chat/completions".to_string(),
-            completion_endpoint: Some("/v1/completions".to_string()),
-            healthcheck: Some(HealthcheckDef {
-                method: "GET".to_string(),
-                path: Some("/health".to_string()),
-                url: None,
-                body: None,
-            }),
-            cost_per_1k_in: Some(0.0),
-            cost_per_1k_out: Some(0.0),
-            latency_p50_ms: Some(950),
-            ..Default::default()
-        },
-    );
-
-    // Default inference rules
-    config.inference_rules = vec![
-        InferenceRule {
-            pattern: Some("claude-*".to_string()),
-            contains: None,
-            exact: None,
-            provider: "anthropic".to_string(),
-        },
-        InferenceRule {
-            pattern: Some("gpt-*".to_string()),
-            contains: None,
-            exact: None,
-            provider: "openai".to_string(),
-        },
-        InferenceRule {
-            pattern: Some("o1*".to_string()),
-            contains: None,
-            exact: None,
-            provider: "openai".to_string(),
-        },
-        InferenceRule {
-            pattern: Some("o3*".to_string()),
-            contains: None,
-            exact: None,
-            provider: "openai".to_string(),
-        },
-        InferenceRule {
-            pattern: Some("o4*".to_string()),
-            contains: None,
-            exact: None,
-            provider: "openai".to_string(),
-        },
-        InferenceRule {
-            pattern: Some("anthropic.claude-*".to_string()),
-            contains: None,
-            exact: None,
-            provider: "bedrock".to_string(),
-        },
-        InferenceRule {
-            pattern: Some("meta.llama*".to_string()),
-            contains: None,
-            exact: None,
-            provider: "bedrock".to_string(),
-        },
-        InferenceRule {
-            pattern: Some("amazon.*".to_string()),
-            contains: None,
-            exact: None,
-            provider: "bedrock".to_string(),
-        },
-        InferenceRule {
-            pattern: Some("mistral.*".to_string()),
-            contains: None,
-            exact: None,
-            provider: "bedrock".to_string(),
-        },
-        InferenceRule {
-            pattern: Some("cohere.*".to_string()),
-            contains: None,
-            exact: None,
-            provider: "bedrock".to_string(),
-        },
-        InferenceRule {
-            pattern: Some("gemini-*".to_string()),
-            contains: None,
-            exact: None,
-            provider: "gemini".to_string(),
-        },
-    ];
-
-    // Default tier rules
-    config.tier_rules = vec![
-        TierRule {
-            contains: Some("9b".to_string()),
-            pattern: None,
-            exact: None,
-            tier: "small".to_string(),
-        },
-        TierRule {
-            contains: Some("a3b".to_string()),
-            pattern: None,
-            exact: None,
-            tier: "small".to_string(),
-        },
-        TierRule {
-            contains: Some("gemma-4-e2b".to_string()),
-            pattern: None,
-            exact: None,
-            tier: "small".to_string(),
-        },
-        TierRule {
-            contains: Some("gemma-4-e4b".to_string()),
-            pattern: None,
-            exact: None,
-            tier: "small".to_string(),
-        },
-        TierRule {
-            contains: Some("gemma-4-26b".to_string()),
-            pattern: None,
-            exact: None,
-            tier: "mid".to_string(),
-        },
-        TierRule {
-            contains: Some("gemma-4-31b".to_string()),
-            pattern: None,
-            exact: None,
-            tier: "frontier".to_string(),
-        },
-        TierRule {
-            contains: Some("gemma4:26b".to_string()),
-            pattern: None,
-            exact: None,
-            tier: "mid".to_string(),
-        },
-        TierRule {
-            contains: Some("gemma4:31b".to_string()),
-            pattern: None,
-            exact: None,
-            tier: "frontier".to_string(),
-        },
-        TierRule {
-            pattern: Some("claude-*".to_string()),
-            contains: None,
-            exact: None,
-            tier: "frontier".to_string(),
-        },
-        TierRule {
-            exact: Some("gpt-4o".to_string()),
-            contains: None,
-            pattern: None,
-            tier: "frontier".to_string(),
-        },
-    ];
-
-    config.tier_defaults = TierDefaults {
-        default: "mid".to_string(),
-    };
-
-    config.aliases.insert(
-        "frontier".to_string(),
-        AliasDef {
-            id: "claude-sonnet-4-20250514".to_string(),
-            provider: "anthropic".to_string(),
-            tool_format: None,
-        },
-    );
-    config.aliases.insert(
-        "tier/frontier".to_string(),
-        AliasDef {
-            id: "claude-sonnet-4-20250514".to_string(),
-            provider: "anthropic".to_string(),
-            tool_format: None,
-        },
-    );
-    config.aliases.insert(
-        "mid".to_string(),
-        AliasDef {
-            id: "gpt-4o-mini".to_string(),
-            provider: "openai".to_string(),
-            tool_format: None,
-        },
-    );
-    config.aliases.insert(
-        "tier/mid".to_string(),
-        AliasDef {
-            id: "gpt-4o-mini".to_string(),
-            provider: "openai".to_string(),
-            tool_format: None,
-        },
-    );
-    config.aliases.insert(
-        "small".to_string(),
-        AliasDef {
-            id: "Qwen/Qwen3.5-9B".to_string(),
-            provider: "openrouter".to_string(),
-            tool_format: None,
-        },
-    );
-    config.aliases.insert(
-        "tier/small".to_string(),
-        AliasDef {
-            id: "Qwen/Qwen3.5-9B".to_string(),
-            provider: "openrouter".to_string(),
-            tool_format: None,
-        },
-    );
-    config.aliases.insert(
-        "local-gemma4".to_string(),
-        AliasDef {
-            id: "gemma-4-26b-a4b-it".to_string(),
-            provider: "local".to_string(),
-            tool_format: None,
-        },
-    );
-    config.aliases.insert(
-        "local-gemma4-26b".to_string(),
-        AliasDef {
-            id: "gemma-4-26b-a4b-it".to_string(),
-            provider: "local".to_string(),
-            tool_format: None,
-        },
-    );
-    config.aliases.insert(
-        "local-gemma4-31b".to_string(),
-        AliasDef {
-            id: "gemma-4-31b-it".to_string(),
-            provider: "local".to_string(),
-            tool_format: None,
-        },
-    );
-    config.aliases.insert(
-        "local-gemma4-e4b".to_string(),
-        AliasDef {
-            id: "gemma-4-e4b-it".to_string(),
-            provider: "local".to_string(),
-            tool_format: None,
-        },
-    );
-    config.aliases.insert(
-        "local-gemma4-e2b".to_string(),
-        AliasDef {
-            id: "gemma-4-e2b-it".to_string(),
-            provider: "local".to_string(),
-            tool_format: None,
-        },
-    );
-    config.aliases.insert(
-        "ollama-gemma4".to_string(),
-        AliasDef {
-            id: "gemma4:26b".to_string(),
-            provider: "ollama".to_string(),
-            tool_format: Some("text".to_string()),
-        },
-    );
-    config.aliases.insert(
-        "ollama-gemma4-26b".to_string(),
-        AliasDef {
-            id: "gemma4:26b".to_string(),
-            provider: "ollama".to_string(),
-            tool_format: Some("text".to_string()),
-        },
-    );
-    config.aliases.insert(
-        "qwen3.6-coding".to_string(),
-        AliasDef {
-            id: "qwen3.6:35b-a3b-coding-nvfp4".to_string(),
-            provider: "ollama".to_string(),
-            tool_format: Some("text".to_string()),
-        },
-    );
-    config.aliases.insert(
-        "qwen3.6-35b-coding".to_string(),
-        AliasDef {
-            id: "qwen3.6:35b-a3b-coding-nvfp4".to_string(),
-            provider: "ollama".to_string(),
-            tool_format: Some("text".to_string()),
-        },
-    );
-    config.aliases.insert(
-        "qwen3.6-coding-nvfp4".to_string(),
-        AliasDef {
-            id: "qwen3.6:35b-a3b-coding-nvfp4".to_string(),
-            provider: "ollama".to_string(),
-            tool_format: Some("text".to_string()),
-        },
-    );
-    config.aliases.insert(
-        "qwen3.6-coding-native".to_string(),
-        AliasDef {
-            id: "qwen3.6:35b-a3b-coding-nvfp4".to_string(),
-            provider: "ollama".to_string(),
-            tool_format: Some("native".to_string()),
-        },
-    );
-    config.aliases.insert(
-        "llamacpp-qwen3.6".to_string(),
-        AliasDef {
-            id: "qwen3.6-35b-a3b".to_string(),
-            provider: "llamacpp".to_string(),
-            tool_format: Some("text".to_string()),
-        },
-    );
-    config.aliases.insert(
-        "llamacpp-qwen3.6-q4".to_string(),
-        AliasDef {
-            id: "qwen3.6-35b-a3b-ud-q4-k-xl".to_string(),
-            provider: "llamacpp".to_string(),
-            tool_format: Some("text".to_string()),
-        },
-    );
-    config.aliases.insert(
-        "local-qwen3.6".to_string(),
-        AliasDef {
-            id: "qwen3.6-35b-a3b-ud-q4-k-xl".to_string(),
-            provider: "llamacpp".to_string(),
-            tool_format: Some("text".to_string()),
-        },
-    );
-    config.aliases.insert(
-        "local-qwen3.6-gguf".to_string(),
-        AliasDef {
-            id: "qwen3.6-35b-a3b-ud-q4-k-xl".to_string(),
-            provider: "llamacpp".to_string(),
-            tool_format: Some("text".to_string()),
-        },
-    );
-    config.aliases.insert(
-        "mlx-qwen36-27b".to_string(),
-        AliasDef {
-            id: "unsloth/Qwen3.6-27B-UD-MLX-4bit".to_string(),
-            provider: "mlx".to_string(),
-            tool_format: None,
-        },
-    );
-    config.aliases.insert(
-        "mlx-qwen3.6-27b".to_string(),
-        AliasDef {
-            id: "unsloth/Qwen3.6-27B-UD-MLX-4bit".to_string(),
-            provider: "mlx".to_string(),
-            tool_format: Some("native".to_string()),
-        },
-    );
-    config.aliases.insert(
-        "mlx-qwen3.6-27b-q4".to_string(),
-        AliasDef {
-            id: "unsloth/Qwen3.6-27B-UD-MLX-4bit".to_string(),
-            provider: "mlx".to_string(),
-            tool_format: Some("native".to_string()),
-        },
-    );
-    config.aliases.insert(
-        "local-qwen3.6-27b".to_string(),
-        AliasDef {
-            id: "unsloth/Qwen3.6-27B-UD-MLX-4bit".to_string(),
-            provider: "mlx".to_string(),
-            tool_format: Some("native".to_string()),
-        },
-    );
-    config.aliases.insert(
-        "devstral-small-2".to_string(),
-        AliasDef {
-            id: "devstral-small-2:24b".to_string(),
-            provider: "ollama".to_string(),
-            tool_format: Some("text".to_string()),
-        },
-    );
-    config.aliases.insert(
-        "ollama-devstral-small-2".to_string(),
-        AliasDef {
-            id: "devstral-small-2:24b".to_string(),
-            provider: "ollama".to_string(),
-            tool_format: Some("text".to_string()),
-        },
-    );
-    config.aliases.insert(
-        "ollama-devstral-small-2-native".to_string(),
-        AliasDef {
-            id: "devstral-small-2:24b".to_string(),
-            provider: "ollama".to_string(),
-            tool_format: Some("native".to_string()),
-        },
-    );
-
-    config.alias_tool_calling.extend(BTreeMap::from([
-        (
-            "qwen3.6-coding".to_string(),
-            AliasToolCallingDef {
-                native: Some("unknown".to_string()),
-                text: Some("unknown".to_string()),
-                streaming_native: Some("unknown".to_string()),
-                fallback_mode: Some("text".to_string()),
-                failure_reason: None,
-                last_probe_at: None,
-            },
-        ),
-        (
-            "qwen3.6-coding-native".to_string(),
-            AliasToolCallingDef {
-                native: Some("unknown".to_string()),
-                text: Some("unknown".to_string()),
-                streaming_native: Some("unknown".to_string()),
-                fallback_mode: Some("native".to_string()),
-                failure_reason: None,
-                last_probe_at: None,
-            },
-        ),
-        (
-            "ollama-gemma4".to_string(),
-            AliasToolCallingDef {
-                native: Some("unknown".to_string()),
-                text: Some("unknown".to_string()),
-                streaming_native: Some("unknown".to_string()),
-                fallback_mode: Some("disabled".to_string()),
-                failure_reason: Some("requires_tool_probe".to_string()),
-                last_probe_at: None,
-            },
-        ),
-        (
-            "llamacpp-qwen3.6-q4".to_string(),
-            AliasToolCallingDef {
-                native: Some("unknown".to_string()),
-                text: Some("unknown".to_string()),
-                streaming_native: Some("unknown".to_string()),
-                fallback_mode: Some("text".to_string()),
-                failure_reason: Some("requires_tool_probe_and_cache_probe".to_string()),
-                last_probe_at: None,
-            },
-        ),
-        (
-            "mlx-qwen3.6-27b".to_string(),
-            AliasToolCallingDef {
-                native: Some("unknown".to_string()),
-                text: Some("unknown".to_string()),
-                streaming_native: Some("unknown".to_string()),
-                fallback_mode: Some("native".to_string()),
-                failure_reason: Some("requires_served_identity_and_tool_probe".to_string()),
-                last_probe_at: None,
-            },
-        ),
-    ]));
-
-    config.qc_defaults.extend(BTreeMap::from([
-        (
-            "anthropic".to_string(),
-            "claude-3-5-haiku-20241022".to_string(),
-        ),
-        ("openai".to_string(), "gpt-4o-mini".to_string()),
-        (
-            "openrouter".to_string(),
-            "google/gemini-2.5-flash".to_string(),
-        ),
-        ("ollama".to_string(), "llama3.2".to_string()),
-        ("local".to_string(), "gpt-4o".to_string()),
-    ]));
-
-    config.models.extend(BTreeMap::from([
-        (
-            "qwen3.6:35b-a3b-coding-nvfp4".to_string(),
-            ModelDef {
-                name: "Qwen3.6 35B A3B Coding (NVFP4)".to_string(),
-                provider: "ollama".to_string(),
-                context_window: 262_144,
-                runtime_context_window: Some(32_768),
-                stream_timeout: Some(900.0),
-                capabilities: vec![
-                    "tools".to_string(),
-                    "streaming".to_string(),
-                    "thinking".to_string(),
-                ],
-                pricing: None,
-                deprecated: false,
-                deprecation_note: None,
-                quality_tags: Vec::new(),
-                prefer_prefill_done: None,
-            },
-        ),
-        (
-            "gemma4:26b".to_string(),
-            ModelDef {
-                name: "Gemma 4 26B MoE".to_string(),
-                provider: "ollama".to_string(),
-                context_window: 262_144,
-                runtime_context_window: Some(32_768),
-                stream_timeout: Some(300.0),
-                capabilities: vec![
-                    "tools".to_string(),
-                    "vision".to_string(),
-                    "streaming".to_string(),
-                    "thinking".to_string(),
-                ],
-                pricing: None,
-                deprecated: false,
-                deprecation_note: None,
-                quality_tags: Vec::new(),
-                prefer_prefill_done: None,
-            },
-        ),
-        (
-            "claude-sonnet-4-20250514".to_string(),
-            ModelDef {
-                name: "Claude Sonnet 4".to_string(),
-                provider: "anthropic".to_string(),
-                context_window: 200_000,
-                runtime_context_window: None,
-                stream_timeout: None,
-                capabilities: vec![
-                    "tools".to_string(),
-                    "streaming".to_string(),
-                    "prompt_caching".to_string(),
-                    "thinking".to_string(),
-                ],
-                pricing: Some(ModelPricing {
-                    input_per_mtok: 3.0,
-                    output_per_mtok: 15.0,
-                    cache_read_per_mtok: Some(0.3),
-                    cache_write_per_mtok: Some(3.75),
-                }),
-                deprecated: false,
-                deprecation_note: None,
-                quality_tags: Vec::new(),
-                prefer_prefill_done: None,
-            },
-        ),
-        (
-            "gpt-4o-mini".to_string(),
-            ModelDef {
-                name: "GPT-4o Mini".to_string(),
-                provider: "openai".to_string(),
-                context_window: 128_000,
-                runtime_context_window: None,
-                stream_timeout: None,
-                capabilities: vec!["tools".to_string(), "streaming".to_string()],
-                pricing: Some(ModelPricing {
-                    input_per_mtok: 0.15,
-                    output_per_mtok: 0.60,
-                    cache_read_per_mtok: None,
-                    cache_write_per_mtok: None,
-                }),
-                deprecated: false,
-                deprecation_note: None,
-                quality_tags: Vec::new(),
-                prefer_prefill_done: None,
-            },
-        ),
-        (
-            "Qwen/Qwen3.5-9B".to_string(),
-            ModelDef {
-                name: "Qwen3.5 9B".to_string(),
-                provider: "openrouter".to_string(),
-                context_window: 131_072,
-                runtime_context_window: None,
-                stream_timeout: None,
-                capabilities: vec!["tools".to_string(), "streaming".to_string()],
-                pricing: None,
-                deprecated: false,
-                deprecation_note: None,
-                quality_tags: Vec::new(),
-                prefer_prefill_done: None,
-            },
-        ),
-        (
-            "llama3.2".to_string(),
-            ModelDef {
-                name: "Llama 3.2".to_string(),
-                provider: "ollama".to_string(),
-                context_window: 32_000,
-                runtime_context_window: None,
-                stream_timeout: Some(300.0),
-                capabilities: vec!["tools".to_string(), "streaming".to_string()],
-                pricing: None,
-                deprecated: false,
-                deprecation_note: None,
-                quality_tags: Vec::new(),
-                prefer_prefill_done: None,
-            },
-        ),
-    ]));
-
-    let mut local_model =
-        |id: &str, name: &str, stream_timeout: f64, prefer_prefill_done: Option<bool>| {
-            config.models.insert(
-                id.to_string(),
-                ModelDef {
-                    name: name.to_string(),
-                    provider: "local".to_string(),
-                    context_window: 131_072,
-                    runtime_context_window: None,
-                    stream_timeout: Some(stream_timeout),
-                    capabilities: vec!["streaming".to_string(), "thinking".to_string()],
-                    pricing: None,
-                    deprecated: false,
-                    deprecation_note: None,
-                    quality_tags: Vec::new(),
-                    prefer_prefill_done,
-                },
-            );
-        };
-    local_model("gemma-4-e2b-it", "Gemma 4 E2B (local)", 300.0, Some(true));
-    local_model("gemma-4-e4b-it", "Gemma 4 E4B (local)", 300.0, Some(true));
-    local_model("gemma-4-26b-a4b-it", "Gemma 4 26B MoE (local)", 600.0, None);
-    local_model("gemma-4-31b-it", "Gemma 4 31B (local)", 600.0, None);
-
-    for (id, name) in [
-        (
-            "qwen3.6-35b-a3b-ud-q4-k-xl",
-            "Qwen3.6 35B (Unsloth Q4_K_XL, llama.cpp)",
-        ),
-        (
-            "qwen3.6-35b-a3b-ud-q5-k-xl",
-            "Qwen3.6 35B (Unsloth Q5_K_XL, llama.cpp)",
-        ),
-        ("qwen3.6-35b-a3b", "Qwen3.6 35B (llama.cpp)"),
-    ] {
-        config.models.insert(
-            id.to_string(),
-            ModelDef {
-                name: name.to_string(),
-                provider: "llamacpp".to_string(),
-                context_window: 262_144,
-                runtime_context_window: Some(65_536),
-                stream_timeout: Some(900.0),
-                capabilities: vec![
-                    "tools".to_string(),
-                    "streaming".to_string(),
-                    "thinking".to_string(),
-                ],
-                pricing: None,
-                deprecated: false,
-                deprecation_note: None,
-                quality_tags: Vec::new(),
-                prefer_prefill_done: None,
-            },
-        );
-    }
-
-    config.models.insert(
-        "unsloth/Qwen3.6-27B-UD-MLX-4bit".to_string(),
-        ModelDef {
-            name: "Qwen3.6 27B (MLX 4-bit)".to_string(),
-            provider: "mlx".to_string(),
-            context_window: 262_144,
-            runtime_context_window: None,
-            stream_timeout: Some(900.0),
-            capabilities: vec![
-                "tools".to_string(),
-                "vision".to_string(),
-                "streaming".to_string(),
-                "thinking".to_string(),
-            ],
-            pricing: None,
-            deprecated: false,
-            deprecation_note: None,
-            quality_tags: Vec::new(),
-            prefer_prefill_done: None,
-        },
-    );
-
-    config.models.insert(
-        "devstral-small-2:24b".to_string(),
-        ModelDef {
-            name: "Devstral Small 2 24B".to_string(),
-            provider: "ollama".to_string(),
-            context_window: 262_144,
-            runtime_context_window: Some(32_768),
-            stream_timeout: Some(600.0),
-            capabilities: vec!["tools".to_string(), "streaming".to_string()],
-            pricing: None,
-            deprecated: false,
-            deprecation_note: None,
-            quality_tags: Vec::new(),
-            prefer_prefill_done: None,
-        },
-    );
-
-    config.models.extend(canonical_priced_models());
-
-    config
-}
-
-/// Canonical hosted-model pricing entries (USD per 1M tokens). Provenance: the
-/// public Anthropic, OpenAI, Google Gemini, and Mistral pricing pages snapshot
-/// at 2026-01. These replace the previous `model_pricing_per_million` Rust
-/// fallback table that lived in `llm/cost.rs` and could silently drift; if a
-/// listed rate changes, edit the literal here so the change shows up in `git
-/// blame`. Users can override or extend the table per environment via
-/// `HARN_PROVIDERS_CONFIG` or `harn.toml`.
-fn canonical_priced_models() -> BTreeMap<String, ModelDef> {
-    let mut out = BTreeMap::new();
-    let anthropic_caps = vec![
-        "tools".to_string(),
-        "streaming".to_string(),
-        "prompt_caching".to_string(),
-        "thinking".to_string(),
-    ];
-    let openai_caps = vec!["tools".to_string(), "streaming".to_string()];
-    let gemini_caps = vec!["tools".to_string(), "streaming".to_string()];
-
-    let mut anthropic = |id: &str,
-                         name: &str,
-                         context_window: u64,
-                         input: f64,
-                         output: f64,
-                         cache_read: Option<f64>,
-                         cache_write: Option<f64>| {
-        out.insert(
-            id.to_string(),
-            ModelDef {
-                name: name.to_string(),
-                provider: "anthropic".to_string(),
-                context_window,
-                runtime_context_window: None,
-                stream_timeout: None,
-                capabilities: anthropic_caps.clone(),
-                pricing: Some(ModelPricing {
-                    input_per_mtok: input,
-                    output_per_mtok: output,
-                    cache_read_per_mtok: cache_read,
-                    cache_write_per_mtok: cache_write,
-                }),
-                deprecated: false,
-                deprecation_note: None,
-                quality_tags: Vec::new(),
-                prefer_prefill_done: None,
-            },
-        );
-    };
-    anthropic(
-        "claude-3-5-haiku-20241022",
-        "Claude Haiku 3.5",
-        200_000,
-        0.80,
-        4.00,
-        Some(0.08),
-        Some(1.00),
-    );
-    anthropic(
-        "claude-haiku-4-5-20251001",
-        "Claude Haiku 4.5",
-        200_000,
-        1.00,
-        5.00,
-        Some(0.10),
-        Some(1.25),
-    );
-    anthropic(
-        "claude-3-5-sonnet-20240620",
-        "Claude Sonnet 3.5 (2024-06-20)",
-        200_000,
-        3.00,
-        15.00,
-        Some(0.30),
-        Some(3.75),
-    );
-    anthropic(
-        "claude-3-5-sonnet-20241022",
-        "Claude Sonnet 3.5 (2024-10-22)",
-        200_000,
-        3.00,
-        15.00,
-        Some(0.30),
-        Some(3.75),
-    );
-    anthropic(
-        "claude-3-opus-20240229",
-        "Claude Opus 3",
-        200_000,
-        15.00,
-        75.00,
-        Some(1.50),
-        Some(18.75),
-    );
-    anthropic(
-        "claude-opus-4-20250514",
-        "Claude Opus 4",
-        200_000,
-        15.00,
-        75.00,
-        Some(1.50),
-        Some(18.75),
-    );
-    anthropic(
-        "claude-opus-4-1-20250805",
-        "Claude Opus 4.1",
-        200_000,
-        15.00,
-        75.00,
-        Some(1.50),
-        Some(18.75),
-    );
-
-    let mut openai = |id: &str,
-                      name: &str,
-                      context_window: u64,
-                      input: f64,
-                      output: f64,
-                      cache_read: Option<f64>| {
-        out.insert(
-            id.to_string(),
-            ModelDef {
-                name: name.to_string(),
-                provider: "openai".to_string(),
-                context_window,
-                runtime_context_window: None,
-                stream_timeout: None,
-                capabilities: openai_caps.clone(),
-                pricing: Some(ModelPricing {
-                    input_per_mtok: input,
-                    output_per_mtok: output,
-                    cache_read_per_mtok: cache_read,
-                    cache_write_per_mtok: None,
-                }),
-                deprecated: false,
-                deprecation_note: None,
-                quality_tags: Vec::new(),
-                prefer_prefill_done: None,
-            },
-        );
-    };
-    openai("gpt-4o", "GPT-4o", 128_000, 2.50, 10.00, Some(1.25));
-    openai("gpt-4-turbo", "GPT-4 Turbo", 128_000, 10.00, 30.00, None);
-    openai("o1", "OpenAI o1", 200_000, 15.00, 60.00, Some(7.50));
-    openai(
-        "o1-mini",
-        "OpenAI o1-mini",
-        128_000,
-        3.00,
-        12.00,
-        Some(1.50),
-    );
-    openai("o3", "OpenAI o3", 200_000, 15.00, 60.00, Some(7.50));
-    openai("o3-mini", "OpenAI o3-mini", 200_000, 1.10, 4.40, Some(0.55));
-
-    let mut gemini = |id: &str,
-                      name: &str,
-                      context_window: u64,
-                      input: f64,
-                      output: f64,
-                      cache_read: Option<f64>| {
-        out.insert(
-            id.to_string(),
-            ModelDef {
-                name: name.to_string(),
-                provider: "gemini".to_string(),
-                context_window,
-                runtime_context_window: None,
-                stream_timeout: None,
-                capabilities: gemini_caps.clone(),
-                pricing: Some(ModelPricing {
-                    input_per_mtok: input,
-                    output_per_mtok: output,
-                    cache_read_per_mtok: cache_read,
-                    cache_write_per_mtok: None,
-                }),
-                deprecated: false,
-                deprecation_note: None,
-                quality_tags: Vec::new(),
-                prefer_prefill_done: None,
-            },
-        );
-    };
-    gemini(
-        "gemini-2.5-flash",
-        "Gemini 2.5 Flash",
-        1_048_576,
-        0.10,
-        0.40,
-        Some(0.025),
-    );
-    gemini(
-        "gemini-2.5-pro",
-        "Gemini 2.5 Pro",
-        2_097_152,
-        1.25,
-        5.00,
-        Some(0.3125),
-    );
-
-    out.insert(
-        "mistral-large-latest".to_string(),
-        ModelDef {
-            name: "Mistral Large".to_string(),
-            provider: "openrouter".to_string(),
-            context_window: 128_000,
-            runtime_context_window: None,
-            stream_timeout: None,
-            capabilities: openai_caps.clone(),
-            pricing: Some(ModelPricing {
-                input_per_mtok: 2.00,
-                output_per_mtok: 6.00,
-                cache_read_per_mtok: None,
-                cache_write_per_mtok: None,
-            }),
-            deprecated: false,
-            deprecation_note: None,
-            quality_tags: Vec::new(),
-            prefer_prefill_done: None,
-        },
-    );
-    out.insert(
-        "mistral-small-latest".to_string(),
-        ModelDef {
-            name: "Mistral Small".to_string(),
-            provider: "openrouter".to_string(),
-            context_window: 128_000,
-            runtime_context_window: None,
-            stream_timeout: None,
-            capabilities: openai_caps,
-            pricing: Some(ModelPricing {
-                input_per_mtok: 0.20,
-                output_per_mtok: 0.60,
-                cache_read_per_mtok: None,
-                cache_write_per_mtok: None,
-            }),
-            deprecated: false,
-            deprecation_note: None,
-            quality_tags: Vec::new(),
-            prefer_prefill_done: None,
-        },
-    );
-    out
+    parse_config_toml(EMBEDDED_PROVIDERS_TOML)
+        .expect("embedded providers.toml must parse — invariant checked by harn-vm tests")
 }
 
 #[cfg(test)]
@@ -2451,20 +1116,47 @@ mod tests {
 
     #[test]
     fn test_resolve_tier_model_default_aliases() {
-        let (model, provider) = resolve_tier_model("frontier", None).unwrap();
-        assert_eq!(model, "claude-sonnet-4-20250514");
+        // Exercise the alias-resolution machinery, not the specific catalog
+        // value: the model under each tier alias evolves as the embedded
+        // providers.toml is updated. The invariants worth pinning are the
+        // provider routing + catalog-registration of the resolved model.
+        let (model, provider) = resolve_tier_model("frontier", None)
+            .expect("frontier alias must resolve from the embedded catalog");
         assert_eq!(provider, "anthropic");
+        assert!(
+            model_catalog_entry(&model)
+                .is_some_and(|entry| entry.provider == "anthropic" && !entry.deprecated),
+            "frontier alias must point at a registered, non-deprecated anthropic model (got {model})"
+        );
 
-        let (model, provider) = resolve_tier_model("small", None).unwrap();
-        assert_eq!(model, "Qwen/Qwen3.5-9B");
-        assert_eq!(provider, "openrouter");
+        let (model, provider) = resolve_tier_model("small", None)
+            .expect("small alias must resolve from the embedded catalog");
+        assert!(
+            [
+                "openrouter",
+                "huggingface",
+                "local",
+                "llamacpp",
+                "mlx",
+                "ollama"
+            ]
+            .contains(&provider.as_str()),
+            "small tier should resolve to an open-weight provider (got {provider} / {model})"
+        );
     }
 
     #[test]
     fn test_resolve_tier_model_prefers_provider_scoped_aliases() {
-        let (model, provider) = resolve_tier_model("mid", Some("openai")).unwrap();
-        assert_eq!(model, "gpt-4o-mini");
+        // tier/<provider> takes precedence over generic tier when the
+        // caller scopes by provider. Don't pin the specific model — the
+        // catalog evolves.
+        let (model, provider) = resolve_tier_model("mid", Some("openai"))
+            .expect("mid tier scoped to openai must resolve");
         assert_eq!(provider, "openai");
+        assert!(
+            model_catalog_entry(&model).is_some(),
+            "mid/openai alias must point at a registered model (got {model})"
+        );
     }
 
     #[test]
@@ -2722,5 +1414,145 @@ mod tests {
         assert_eq!(infer_provider("internal-foo"), "openai");
 
         reset_overrides();
+    }
+
+    // ── Embedded providers.toml invariants ───────────────────────────────────
+    // These tests pin properties of the *system* — TOML parses, every
+    // alias resolves, every deprecated model has a note — without
+    // pinning specific catalog values. They survive future catalog
+    // churn and surface real schema breakage.
+
+    #[test]
+    fn embedded_providers_toml_parses_and_is_not_trivially_empty() {
+        let config = default_config();
+        assert!(
+            config.providers.len() >= 10,
+            "expected >=10 providers in embedded catalog, got {}",
+            config.providers.len()
+        );
+        assert!(
+            config.models.len() >= 20,
+            "expected >=20 models in embedded catalog, got {}",
+            config.models.len()
+        );
+        assert!(
+            config.aliases.len() >= 15,
+            "expected >=15 aliases in embedded catalog, got {}",
+            config.aliases.len()
+        );
+        assert_eq!(config.default_provider.as_deref(), Some("anthropic"));
+    }
+
+    #[test]
+    fn embedded_catalog_every_deprecated_model_has_a_note() {
+        let config = default_config();
+        let offenders: Vec<&str> = config
+            .models
+            .iter()
+            .filter(|(_, model)| {
+                model.deprecated
+                    && model
+                        .deprecation_note
+                        .as_deref()
+                        .unwrap_or("")
+                        .trim()
+                        .is_empty()
+            })
+            .map(|(id, _)| id.as_str())
+            .collect();
+        assert!(
+            offenders.is_empty(),
+            "deprecated models missing a deprecation_note: {offenders:?}"
+        );
+    }
+
+    #[test]
+    fn embedded_catalog_every_model_targets_a_registered_provider() {
+        let config = default_config();
+        let known: std::collections::BTreeSet<&str> =
+            config.providers.keys().map(String::as_str).collect();
+        let orphans: Vec<(&str, &str)> = config
+            .models
+            .iter()
+            .filter(|(_, model)| !known.contains(model.provider.as_str()))
+            .map(|(id, model)| (id.as_str(), model.provider.as_str()))
+            .collect();
+        assert!(
+            orphans.is_empty(),
+            "models reference unknown providers: {orphans:?}"
+        );
+    }
+
+    #[test]
+    fn embedded_catalog_every_alias_targets_a_registered_provider() {
+        let config = default_config();
+        let known: std::collections::BTreeSet<&str> =
+            config.providers.keys().map(String::as_str).collect();
+        let orphans: Vec<(&str, &str)> = config
+            .aliases
+            .iter()
+            .filter(|(_, alias)| !known.contains(alias.provider.as_str()))
+            .map(|(name, alias)| (name.as_str(), alias.provider.as_str()))
+            .collect();
+        assert!(
+            orphans.is_empty(),
+            "aliases reference unknown providers: {orphans:?}"
+        );
+    }
+
+    #[test]
+    fn embedded_catalog_every_qc_default_targets_a_known_model() {
+        let config = default_config();
+        let orphans: Vec<(&str, &str)> = config
+            .qc_defaults
+            .iter()
+            .filter(|(_, model_id)| !config.models.contains_key(model_id.as_str()))
+            .map(|(provider, model_id)| (provider.as_str(), model_id.as_str()))
+            .collect();
+        assert!(
+            orphans.is_empty(),
+            "qc_defaults reference unknown models: {orphans:?}"
+        );
+    }
+
+    #[test]
+    fn embedded_catalog_pricing_rates_are_non_negative() {
+        let config = default_config();
+        for (id, model) in &config.models {
+            let Some(pricing) = &model.pricing else {
+                continue;
+            };
+            assert!(
+                pricing.input_per_mtok >= 0.0 && pricing.output_per_mtok >= 0.0,
+                "{id}: negative pricing — in={} out={}",
+                pricing.input_per_mtok,
+                pricing.output_per_mtok
+            );
+            if let Some(rate) = pricing.cache_read_per_mtok {
+                assert!(rate >= 0.0, "{id}: negative cache_read rate {rate}");
+            }
+            if let Some(rate) = pricing.cache_write_per_mtok {
+                assert!(rate >= 0.0, "{id}: negative cache_write rate {rate}");
+            }
+        }
+    }
+
+    #[test]
+    fn embedded_catalog_tier_aliases_resolve_to_active_models() {
+        // The three canonical tier aliases (frontier / mid / small) MUST
+        // resolve to non-deprecated catalog entries; a default that
+        // routes the loop into a sunsetted model is a release blocker.
+        for alias in ["frontier", "mid", "small"] {
+            let (model, _provider) = resolve_tier_model(alias, None)
+                .unwrap_or_else(|| panic!("tier alias `{alias}` must resolve"));
+            let entry = model_catalog_entry(&model).unwrap_or_else(|| {
+                panic!("tier alias `{alias}` -> `{model}` must be a registered catalog entry")
+            });
+            assert!(
+                !entry.deprecated,
+                "tier alias `{alias}` resolves to deprecated model `{model}` ({:?})",
+                entry.deprecation_note
+            );
+        }
     }
 }

--- a/spec/provider-catalog/HarnProviderCatalog.swift
+++ b/spec/provider-catalog/HarnProviderCatalog.swift
@@ -965,7 +965,9 @@ public let harnProviderCatalogJSON = #"""
       "id": "claude-haiku-4-5-20251001",
       "name": "Claude Haiku 4.5",
       "provider": "anthropic",
-      "aliases": [],
+      "aliases": [
+        "haiku"
+      ],
       "context_window": 200000,
       "modalities": {
         "input": [
@@ -1083,7 +1085,8 @@ public let harnProviderCatalogJSON = #"""
         "cache_write_per_mtok": 18.75
       },
       "deprecation": {
-        "status": "active"
+        "status": "deprecated",
+        "note": "Superseded by claude-opus-4-7. No formal sunset yet; switch when convenient."
       },
       "quality_tags": [],
       "capability_tags": [
@@ -1152,7 +1155,8 @@ public let harnProviderCatalogJSON = #"""
         "cache_write_per_mtok": 18.75
       },
       "deprecation": {
-        "status": "active"
+        "status": "deprecated",
+        "note": "Sunset 2026-06-15 per Anthropic deprecations page. Replaced by claude-opus-4-7."
       },
       "quality_tags": [],
       "capability_tags": [
@@ -1169,13 +1173,152 @@ public let harnProviderCatalogJSON = #"""
       ]
     },
     {
+      "id": "claude-opus-4-6",
+      "name": "Claude Opus 4.6",
+      "provider": "anthropic",
+      "aliases": [],
+      "context_window": 200000,
+      "modalities": {
+        "input": [
+          "text",
+          "image",
+          "audio",
+          "pdf"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "tool_search": [
+          "bm25",
+          "regex"
+        ],
+        "max_tools": 10000
+      },
+      "structured_output": "tool_use",
+      "format_preferences": {
+        "prefers_xml_scaffolding": true,
+        "prefers_markdown_scaffolding": false,
+        "structured_output_mode": "xml_tagged",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": true,
+        "thinking_block_style": "thinking_blocks"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": true,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 15.0,
+        "output_per_mtok": 75.0,
+        "cache_read_per_mtok": 1.5,
+        "cache_write_per_mtok": 18.75
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "tool_search",
+        "vision",
+        "audio",
+        "pdf",
+        "files",
+        "prompt_caching",
+        "thinking",
+        "extended_thinking",
+        "structured_output"
+      ]
+    },
+    {
+      "id": "claude-opus-4-7",
+      "name": "Claude Opus 4.7",
+      "provider": "anthropic",
+      "aliases": [
+        "opus"
+      ],
+      "context_window": 200000,
+      "modalities": {
+        "input": [
+          "text",
+          "image",
+          "audio",
+          "pdf"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "tool_search": [
+          "bm25",
+          "regex"
+        ],
+        "max_tools": 10000
+      },
+      "structured_output": "tool_use",
+      "format_preferences": {
+        "prefers_xml_scaffolding": true,
+        "prefers_markdown_scaffolding": false,
+        "structured_output_mode": "xml_tagged",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": true,
+        "thinking_block_style": "thinking_blocks"
+      },
+      "reasoning": {
+        "modes": [
+          "adaptive"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": true,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 15.0,
+        "output_per_mtok": 75.0,
+        "cache_read_per_mtok": 1.5,
+        "cache_write_per_mtok": 18.75
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "tool_search",
+        "vision",
+        "audio",
+        "pdf",
+        "files",
+        "prompt_caching",
+        "thinking",
+        "extended_thinking",
+        "structured_output"
+      ]
+    },
+    {
       "id": "claude-sonnet-4-20250514",
       "name": "Claude Sonnet 4",
       "provider": "anthropic",
-      "aliases": [
-        "frontier",
-        "tier/frontier"
-      ],
+      "aliases": [],
       "context_window": 200000,
       "modalities": {
         "input": [
@@ -1224,6 +1367,150 @@ public let harnProviderCatalogJSON = #"""
         "cache_write_per_mtok": 3.75
       },
       "deprecation": {
+        "status": "deprecated",
+        "note": "Sunset 2026-06-15 per Anthropic deprecations page. Replaced by claude-sonnet-4-6."
+      },
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "tool_search",
+        "vision",
+        "audio",
+        "pdf",
+        "files",
+        "prompt_caching",
+        "thinking",
+        "structured_output"
+      ]
+    },
+    {
+      "id": "claude-sonnet-4-5",
+      "name": "Claude Sonnet 4.5",
+      "provider": "anthropic",
+      "aliases": [],
+      "context_window": 200000,
+      "modalities": {
+        "input": [
+          "text",
+          "image",
+          "audio",
+          "pdf"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "tool_search": [
+          "bm25",
+          "regex"
+        ],
+        "max_tools": 10000
+      },
+      "structured_output": "tool_use",
+      "format_preferences": {
+        "prefers_xml_scaffolding": true,
+        "prefers_markdown_scaffolding": false,
+        "structured_output_mode": "xml_tagged",
+        "supports_assistant_prefill": true,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": true,
+        "thinking_block_style": "thinking_blocks"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 3.0,
+        "output_per_mtok": 15.0,
+        "cache_read_per_mtok": 0.3,
+        "cache_write_per_mtok": 3.75
+      },
+      "deprecation": {
+        "status": "deprecated",
+        "note": "Sunset 2026-05-15 per Anthropic deprecations page. Replaced by claude-sonnet-4-6."
+      },
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "tool_search",
+        "vision",
+        "audio",
+        "pdf",
+        "files",
+        "prompt_caching",
+        "thinking",
+        "structured_output"
+      ]
+    },
+    {
+      "id": "claude-sonnet-4-6",
+      "name": "Claude Sonnet 4.6",
+      "provider": "anthropic",
+      "aliases": [
+        "frontier",
+        "sonnet",
+        "tier/frontier"
+      ],
+      "context_window": 200000,
+      "modalities": {
+        "input": [
+          "text",
+          "image",
+          "audio",
+          "pdf"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "tool_search": [
+          "bm25",
+          "regex"
+        ],
+        "max_tools": 10000
+      },
+      "structured_output": "tool_use",
+      "format_preferences": {
+        "prefers_xml_scaffolding": true,
+        "prefers_markdown_scaffolding": false,
+        "structured_output_mode": "xml_tagged",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": true,
+        "thinking_block_style": "thinking_blocks"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 3.0,
+        "output_per_mtok": 15.0,
+        "cache_read_per_mtok": 0.3,
+        "cache_write_per_mtok": 3.75
+      },
+      "deprecation": {
         "status": "active"
       },
       "quality_tags": [
@@ -1239,6 +1526,76 @@ public let harnProviderCatalogJSON = #"""
         "files",
         "prompt_caching",
         "thinking",
+        "structured_output"
+      ]
+    },
+    {
+      "id": "claude-sonnet-4-7",
+      "name": "Claude Sonnet 4.7",
+      "provider": "anthropic",
+      "aliases": [],
+      "context_window": 200000,
+      "modalities": {
+        "input": [
+          "text",
+          "image",
+          "audio",
+          "pdf"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "tool_search": [
+          "bm25",
+          "regex"
+        ],
+        "max_tools": 10000
+      },
+      "structured_output": "tool_use",
+      "format_preferences": {
+        "prefers_xml_scaffolding": true,
+        "prefers_markdown_scaffolding": false,
+        "structured_output_mode": "xml_tagged",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": true,
+        "thinking_block_style": "thinking_blocks"
+      },
+      "reasoning": {
+        "modes": [
+          "adaptive"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 3.0,
+        "output_per_mtok": 15.0,
+        "cache_read_per_mtok": 0.3,
+        "cache_write_per_mtok": 3.75
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "tool_search",
+        "vision",
+        "audio",
+        "pdf",
+        "files",
+        "prompt_caching",
+        "thinking",
+        "extended_thinking",
         "structured_output"
       ]
     },
@@ -2081,7 +2438,8 @@ public let harnProviderCatalogJSON = #"""
         "cache_write_per_mtok": null
       },
       "deprecation": {
-        "status": "active"
+        "status": "deprecated",
+        "note": "Superseded by gpt-5 family. Listed for cost-attribution backfill only."
       },
       "quality_tags": [],
       "capability_tags": [
@@ -2136,7 +2494,8 @@ public let harnProviderCatalogJSON = #"""
         "cache_write_per_mtok": null
       },
       "deprecation": {
-        "status": "active"
+        "status": "deprecated",
+        "note": "API sunset 2026-02-17 per OpenAI deprecations page. Switch to gpt-5-mini for cheap routing or gpt-5 for frontier."
       },
       "quality_tags": [],
       "capability_tags": [
@@ -2495,6 +2854,130 @@ public let harnProviderCatalogJSON = #"""
       ]
     },
     {
+      "id": "deepseek/deepseek-v3.2",
+      "name": "DeepSeek V3.2",
+      "provider": "openrouter",
+      "aliases": [],
+      "context_window": 131072,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "reasoning_summary"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled",
+          "effort"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 0.28,
+        "output_per_mtok": 0.42,
+        "cache_read_per_mtok": null,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "prompt_caching",
+        "thinking",
+        "extended_thinking",
+        "structured_output"
+      ]
+    },
+    {
+      "id": "google/gemini-2.5-flash",
+      "name": "Gemini 2.5 Flash (via OpenRouter)",
+      "provider": "openrouter",
+      "aliases": [],
+      "context_window": 1048576,
+      "modalities": {
+        "input": [
+          "text",
+          "image",
+          "audio",
+          "pdf"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "reasoning_summary"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled",
+          "effort"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 0.1,
+        "output_per_mtok": 0.4,
+        "cache_read_per_mtok": 0.025,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "vision",
+        "audio",
+        "pdf",
+        "prompt_caching",
+        "thinking",
+        "extended_thinking",
+        "structured_output"
+      ]
+    },
+    {
       "id": "mistral-large-latest",
       "name": "Mistral Large",
       "provider": "openrouter",
@@ -2597,6 +3080,164 @@ public let harnProviderCatalogJSON = #"""
         "streaming",
         "tools"
       ]
+    },
+    {
+      "id": "moonshotai/kimi-k2.6",
+      "name": "Kimi K2.6",
+      "provider": "openrouter",
+      "aliases": [],
+      "context_window": 200000,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": false,
+        "text": true,
+        "tool_search": []
+      },
+      "structured_output": "none",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": false,
+        "structured_output_mode": "none",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "none"
+      },
+      "reasoning": {
+        "modes": [],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "pricing": {
+        "input_per_mtok": 0.55,
+        "output_per_mtok": 2.2,
+        "cache_read_per_mtok": null,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools"
+      ]
+    },
+    {
+      "id": "openai/gpt-oss-120b",
+      "name": "GPT-OSS 120B",
+      "provider": "openrouter",
+      "aliases": [],
+      "context_window": 131072,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "none"
+      },
+      "reasoning": {
+        "modes": [],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "pricing": {
+        "input_per_mtok": 0.15,
+        "output_per_mtok": 0.6,
+        "cache_read_per_mtok": null,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "structured_output"
+      ]
+    },
+    {
+      "id": "qwen/qwen3-coder",
+      "name": "Qwen3 Coder 480B A35B",
+      "provider": "openrouter",
+      "aliases": [],
+      "context_window": 262144,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "delimited",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "none"
+      },
+      "reasoning": {
+        "modes": [],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "pricing": {
+        "input_per_mtok": 0.22,
+        "output_per_mtok": 1.8,
+        "cache_read_per_mtok": null,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "structured_output"
+      ]
     }
   ],
   "aliases": [
@@ -2608,7 +3249,12 @@ public let harnProviderCatalogJSON = #"""
     },
     {
       "name": "frontier",
-      "model_id": "claude-sonnet-4-20250514",
+      "model_id": "claude-sonnet-4-6",
+      "provider": "anthropic"
+    },
+    {
+      "name": "haiku",
+      "model_id": "claude-haiku-4-5-20251001",
       "provider": "anthropic"
     },
     {
@@ -2734,6 +3380,11 @@ public let harnProviderCatalogJSON = #"""
       "tool_format": "text"
     },
     {
+      "name": "opus",
+      "model_id": "claude-opus-4-7",
+      "provider": "anthropic"
+    },
+    {
       "name": "qwen3.6-35b-coding",
       "model_id": "qwen3.6:35b-a3b-coding-nvfp4",
       "provider": "ollama",
@@ -2775,8 +3426,13 @@ public let harnProviderCatalogJSON = #"""
       "provider": "openrouter"
     },
     {
+      "name": "sonnet",
+      "model_id": "claude-sonnet-4-6",
+      "provider": "anthropic"
+    },
+    {
       "name": "tier/frontier",
-      "model_id": "claude-sonnet-4-20250514",
+      "model_id": "claude-sonnet-4-6",
       "provider": "anthropic"
     },
     {
@@ -2811,7 +3467,7 @@ public let harnProviderCatalogJSON = #"""
       "id": "high-reasoning",
       "label": "High reasoning",
       "description": "Frontier route for hard planning, repair, and review tasks.",
-      "model_id": "claude-sonnet-4-20250514",
+      "model_id": "claude-sonnet-4-6",
       "provider": "anthropic",
       "source": "alias:frontier"
     },
@@ -2849,7 +3505,7 @@ public let harnProviderCatalogJSON = #"""
     }
   ],
   "qc_defaults": {
-    "anthropic": "claude-3-5-haiku-20241022",
+    "anthropic": "claude-haiku-4-5-20251001",
     "local": "gpt-4o",
     "ollama": "llama3.2",
     "openai": "gpt-4o-mini",

--- a/spec/provider-catalog/harn-provider-catalog.ts
+++ b/spec/provider-catalog/harn-provider-catalog.ts
@@ -863,7 +863,9 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "id": "claude-haiku-4-5-20251001",
       "name": "Claude Haiku 4.5",
       "provider": "anthropic",
-      "aliases": [],
+      "aliases": [
+        "haiku"
+      ],
       "context_window": 200000,
       "modalities": {
         "input": [
@@ -981,7 +983,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
         "cache_write_per_mtok": 18.75
       },
       "deprecation": {
-        "status": "active"
+        "status": "deprecated",
+        "note": "Superseded by claude-opus-4-7. No formal sunset yet; switch when convenient."
       },
       "quality_tags": [],
       "capability_tags": [
@@ -1050,7 +1053,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
         "cache_write_per_mtok": 18.75
       },
       "deprecation": {
-        "status": "active"
+        "status": "deprecated",
+        "note": "Sunset 2026-06-15 per Anthropic deprecations page. Replaced by claude-opus-4-7."
       },
       "quality_tags": [],
       "capability_tags": [
@@ -1067,13 +1071,152 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       ]
     },
     {
+      "id": "claude-opus-4-6",
+      "name": "Claude Opus 4.6",
+      "provider": "anthropic",
+      "aliases": [],
+      "context_window": 200000,
+      "modalities": {
+        "input": [
+          "text",
+          "image",
+          "audio",
+          "pdf"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "tool_search": [
+          "bm25",
+          "regex"
+        ],
+        "max_tools": 10000
+      },
+      "structured_output": "tool_use",
+      "format_preferences": {
+        "prefers_xml_scaffolding": true,
+        "prefers_markdown_scaffolding": false,
+        "structured_output_mode": "xml_tagged",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": true,
+        "thinking_block_style": "thinking_blocks"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": true,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 15.0,
+        "output_per_mtok": 75.0,
+        "cache_read_per_mtok": 1.5,
+        "cache_write_per_mtok": 18.75
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "tool_search",
+        "vision",
+        "audio",
+        "pdf",
+        "files",
+        "prompt_caching",
+        "thinking",
+        "extended_thinking",
+        "structured_output"
+      ]
+    },
+    {
+      "id": "claude-opus-4-7",
+      "name": "Claude Opus 4.7",
+      "provider": "anthropic",
+      "aliases": [
+        "opus"
+      ],
+      "context_window": 200000,
+      "modalities": {
+        "input": [
+          "text",
+          "image",
+          "audio",
+          "pdf"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "tool_search": [
+          "bm25",
+          "regex"
+        ],
+        "max_tools": 10000
+      },
+      "structured_output": "tool_use",
+      "format_preferences": {
+        "prefers_xml_scaffolding": true,
+        "prefers_markdown_scaffolding": false,
+        "structured_output_mode": "xml_tagged",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": true,
+        "thinking_block_style": "thinking_blocks"
+      },
+      "reasoning": {
+        "modes": [
+          "adaptive"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": true,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 15.0,
+        "output_per_mtok": 75.0,
+        "cache_read_per_mtok": 1.5,
+        "cache_write_per_mtok": 18.75
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "tool_search",
+        "vision",
+        "audio",
+        "pdf",
+        "files",
+        "prompt_caching",
+        "thinking",
+        "extended_thinking",
+        "structured_output"
+      ]
+    },
+    {
       "id": "claude-sonnet-4-20250514",
       "name": "Claude Sonnet 4",
       "provider": "anthropic",
-      "aliases": [
-        "frontier",
-        "tier/frontier"
-      ],
+      "aliases": [],
       "context_window": 200000,
       "modalities": {
         "input": [
@@ -1122,6 +1265,150 @@ export const harnProviderCatalog: HarnProviderCatalog = {
         "cache_write_per_mtok": 3.75
       },
       "deprecation": {
+        "status": "deprecated",
+        "note": "Sunset 2026-06-15 per Anthropic deprecations page. Replaced by claude-sonnet-4-6."
+      },
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "tool_search",
+        "vision",
+        "audio",
+        "pdf",
+        "files",
+        "prompt_caching",
+        "thinking",
+        "structured_output"
+      ]
+    },
+    {
+      "id": "claude-sonnet-4-5",
+      "name": "Claude Sonnet 4.5",
+      "provider": "anthropic",
+      "aliases": [],
+      "context_window": 200000,
+      "modalities": {
+        "input": [
+          "text",
+          "image",
+          "audio",
+          "pdf"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "tool_search": [
+          "bm25",
+          "regex"
+        ],
+        "max_tools": 10000
+      },
+      "structured_output": "tool_use",
+      "format_preferences": {
+        "prefers_xml_scaffolding": true,
+        "prefers_markdown_scaffolding": false,
+        "structured_output_mode": "xml_tagged",
+        "supports_assistant_prefill": true,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": true,
+        "thinking_block_style": "thinking_blocks"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 3.0,
+        "output_per_mtok": 15.0,
+        "cache_read_per_mtok": 0.3,
+        "cache_write_per_mtok": 3.75
+      },
+      "deprecation": {
+        "status": "deprecated",
+        "note": "Sunset 2026-05-15 per Anthropic deprecations page. Replaced by claude-sonnet-4-6."
+      },
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "tool_search",
+        "vision",
+        "audio",
+        "pdf",
+        "files",
+        "prompt_caching",
+        "thinking",
+        "structured_output"
+      ]
+    },
+    {
+      "id": "claude-sonnet-4-6",
+      "name": "Claude Sonnet 4.6",
+      "provider": "anthropic",
+      "aliases": [
+        "frontier",
+        "sonnet",
+        "tier/frontier"
+      ],
+      "context_window": 200000,
+      "modalities": {
+        "input": [
+          "text",
+          "image",
+          "audio",
+          "pdf"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "tool_search": [
+          "bm25",
+          "regex"
+        ],
+        "max_tools": 10000
+      },
+      "structured_output": "tool_use",
+      "format_preferences": {
+        "prefers_xml_scaffolding": true,
+        "prefers_markdown_scaffolding": false,
+        "structured_output_mode": "xml_tagged",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": true,
+        "thinking_block_style": "thinking_blocks"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 3.0,
+        "output_per_mtok": 15.0,
+        "cache_read_per_mtok": 0.3,
+        "cache_write_per_mtok": 3.75
+      },
+      "deprecation": {
         "status": "active"
       },
       "quality_tags": [
@@ -1137,6 +1424,76 @@ export const harnProviderCatalog: HarnProviderCatalog = {
         "files",
         "prompt_caching",
         "thinking",
+        "structured_output"
+      ]
+    },
+    {
+      "id": "claude-sonnet-4-7",
+      "name": "Claude Sonnet 4.7",
+      "provider": "anthropic",
+      "aliases": [],
+      "context_window": 200000,
+      "modalities": {
+        "input": [
+          "text",
+          "image",
+          "audio",
+          "pdf"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "tool_search": [
+          "bm25",
+          "regex"
+        ],
+        "max_tools": 10000
+      },
+      "structured_output": "tool_use",
+      "format_preferences": {
+        "prefers_xml_scaffolding": true,
+        "prefers_markdown_scaffolding": false,
+        "structured_output_mode": "xml_tagged",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": true,
+        "thinking_block_style": "thinking_blocks"
+      },
+      "reasoning": {
+        "modes": [
+          "adaptive"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 3.0,
+        "output_per_mtok": 15.0,
+        "cache_read_per_mtok": 0.3,
+        "cache_write_per_mtok": 3.75
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "tool_search",
+        "vision",
+        "audio",
+        "pdf",
+        "files",
+        "prompt_caching",
+        "thinking",
+        "extended_thinking",
         "structured_output"
       ]
     },
@@ -1979,7 +2336,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
         "cache_write_per_mtok": null
       },
       "deprecation": {
-        "status": "active"
+        "status": "deprecated",
+        "note": "Superseded by gpt-5 family. Listed for cost-attribution backfill only."
       },
       "quality_tags": [],
       "capability_tags": [
@@ -2034,7 +2392,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
         "cache_write_per_mtok": null
       },
       "deprecation": {
-        "status": "active"
+        "status": "deprecated",
+        "note": "API sunset 2026-02-17 per OpenAI deprecations page. Switch to gpt-5-mini for cheap routing or gpt-5 for frontier."
       },
       "quality_tags": [],
       "capability_tags": [
@@ -2393,6 +2752,130 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       ]
     },
     {
+      "id": "deepseek/deepseek-v3.2",
+      "name": "DeepSeek V3.2",
+      "provider": "openrouter",
+      "aliases": [],
+      "context_window": 131072,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "reasoning_summary"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled",
+          "effort"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 0.28,
+        "output_per_mtok": 0.42,
+        "cache_read_per_mtok": null,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "prompt_caching",
+        "thinking",
+        "extended_thinking",
+        "structured_output"
+      ]
+    },
+    {
+      "id": "google/gemini-2.5-flash",
+      "name": "Gemini 2.5 Flash (via OpenRouter)",
+      "provider": "openrouter",
+      "aliases": [],
+      "context_window": 1048576,
+      "modalities": {
+        "input": [
+          "text",
+          "image",
+          "audio",
+          "pdf"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "reasoning_summary"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled",
+          "effort"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 0.1,
+        "output_per_mtok": 0.4,
+        "cache_read_per_mtok": 0.025,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "vision",
+        "audio",
+        "pdf",
+        "prompt_caching",
+        "thinking",
+        "extended_thinking",
+        "structured_output"
+      ]
+    },
+    {
       "id": "mistral-large-latest",
       "name": "Mistral Large",
       "provider": "openrouter",
@@ -2495,6 +2978,164 @@ export const harnProviderCatalog: HarnProviderCatalog = {
         "streaming",
         "tools"
       ]
+    },
+    {
+      "id": "moonshotai/kimi-k2.6",
+      "name": "Kimi K2.6",
+      "provider": "openrouter",
+      "aliases": [],
+      "context_window": 200000,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": false,
+        "text": true,
+        "tool_search": []
+      },
+      "structured_output": "none",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": false,
+        "structured_output_mode": "none",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "none"
+      },
+      "reasoning": {
+        "modes": [],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "pricing": {
+        "input_per_mtok": 0.55,
+        "output_per_mtok": 2.2,
+        "cache_read_per_mtok": null,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools"
+      ]
+    },
+    {
+      "id": "openai/gpt-oss-120b",
+      "name": "GPT-OSS 120B",
+      "provider": "openrouter",
+      "aliases": [],
+      "context_window": 131072,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "none"
+      },
+      "reasoning": {
+        "modes": [],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "pricing": {
+        "input_per_mtok": 0.15,
+        "output_per_mtok": 0.6,
+        "cache_read_per_mtok": null,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "structured_output"
+      ]
+    },
+    {
+      "id": "qwen/qwen3-coder",
+      "name": "Qwen3 Coder 480B A35B",
+      "provider": "openrouter",
+      "aliases": [],
+      "context_window": 262144,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "delimited",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "none"
+      },
+      "reasoning": {
+        "modes": [],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "pricing": {
+        "input_per_mtok": 0.22,
+        "output_per_mtok": 1.8,
+        "cache_read_per_mtok": null,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "structured_output"
+      ]
     }
   ],
   "aliases": [
@@ -2506,7 +3147,12 @@ export const harnProviderCatalog: HarnProviderCatalog = {
     },
     {
       "name": "frontier",
-      "model_id": "claude-sonnet-4-20250514",
+      "model_id": "claude-sonnet-4-6",
+      "provider": "anthropic"
+    },
+    {
+      "name": "haiku",
+      "model_id": "claude-haiku-4-5-20251001",
       "provider": "anthropic"
     },
     {
@@ -2632,6 +3278,11 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "tool_format": "text"
     },
     {
+      "name": "opus",
+      "model_id": "claude-opus-4-7",
+      "provider": "anthropic"
+    },
+    {
       "name": "qwen3.6-35b-coding",
       "model_id": "qwen3.6:35b-a3b-coding-nvfp4",
       "provider": "ollama",
@@ -2673,8 +3324,13 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "provider": "openrouter"
     },
     {
+      "name": "sonnet",
+      "model_id": "claude-sonnet-4-6",
+      "provider": "anthropic"
+    },
+    {
       "name": "tier/frontier",
-      "model_id": "claude-sonnet-4-20250514",
+      "model_id": "claude-sonnet-4-6",
       "provider": "anthropic"
     },
     {
@@ -2709,7 +3365,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "id": "high-reasoning",
       "label": "High reasoning",
       "description": "Frontier route for hard planning, repair, and review tasks.",
-      "model_id": "claude-sonnet-4-20250514",
+      "model_id": "claude-sonnet-4-6",
       "provider": "anthropic",
       "source": "alias:frontier"
     },
@@ -2747,7 +3403,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
     }
   ],
   "qc_defaults": {
-    "anthropic": "claude-3-5-haiku-20241022",
+    "anthropic": "claude-haiku-4-5-20251001",
     "local": "gpt-4o",
     "ollama": "llama3.2",
     "openai": "gpt-4o-mini",

--- a/spec/provider-catalog/provider-catalog.json
+++ b/spec/provider-catalog/provider-catalog.json
@@ -721,7 +721,9 @@
       "id": "claude-haiku-4-5-20251001",
       "name": "Claude Haiku 4.5",
       "provider": "anthropic",
-      "aliases": [],
+      "aliases": [
+        "haiku"
+      ],
       "context_window": 200000,
       "modalities": {
         "input": [
@@ -839,7 +841,8 @@
         "cache_write_per_mtok": 18.75
       },
       "deprecation": {
-        "status": "active"
+        "status": "deprecated",
+        "note": "Superseded by claude-opus-4-7. No formal sunset yet; switch when convenient."
       },
       "quality_tags": [],
       "capability_tags": [
@@ -908,7 +911,8 @@
         "cache_write_per_mtok": 18.75
       },
       "deprecation": {
-        "status": "active"
+        "status": "deprecated",
+        "note": "Sunset 2026-06-15 per Anthropic deprecations page. Replaced by claude-opus-4-7."
       },
       "quality_tags": [],
       "capability_tags": [
@@ -925,13 +929,152 @@
       ]
     },
     {
+      "id": "claude-opus-4-6",
+      "name": "Claude Opus 4.6",
+      "provider": "anthropic",
+      "aliases": [],
+      "context_window": 200000,
+      "modalities": {
+        "input": [
+          "text",
+          "image",
+          "audio",
+          "pdf"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "tool_search": [
+          "bm25",
+          "regex"
+        ],
+        "max_tools": 10000
+      },
+      "structured_output": "tool_use",
+      "format_preferences": {
+        "prefers_xml_scaffolding": true,
+        "prefers_markdown_scaffolding": false,
+        "structured_output_mode": "xml_tagged",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": true,
+        "thinking_block_style": "thinking_blocks"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": true,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 15.0,
+        "output_per_mtok": 75.0,
+        "cache_read_per_mtok": 1.5,
+        "cache_write_per_mtok": 18.75
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "tool_search",
+        "vision",
+        "audio",
+        "pdf",
+        "files",
+        "prompt_caching",
+        "thinking",
+        "extended_thinking",
+        "structured_output"
+      ]
+    },
+    {
+      "id": "claude-opus-4-7",
+      "name": "Claude Opus 4.7",
+      "provider": "anthropic",
+      "aliases": [
+        "opus"
+      ],
+      "context_window": 200000,
+      "modalities": {
+        "input": [
+          "text",
+          "image",
+          "audio",
+          "pdf"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "tool_search": [
+          "bm25",
+          "regex"
+        ],
+        "max_tools": 10000
+      },
+      "structured_output": "tool_use",
+      "format_preferences": {
+        "prefers_xml_scaffolding": true,
+        "prefers_markdown_scaffolding": false,
+        "structured_output_mode": "xml_tagged",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": true,
+        "thinking_block_style": "thinking_blocks"
+      },
+      "reasoning": {
+        "modes": [
+          "adaptive"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": true,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 15.0,
+        "output_per_mtok": 75.0,
+        "cache_read_per_mtok": 1.5,
+        "cache_write_per_mtok": 18.75
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "tool_search",
+        "vision",
+        "audio",
+        "pdf",
+        "files",
+        "prompt_caching",
+        "thinking",
+        "extended_thinking",
+        "structured_output"
+      ]
+    },
+    {
       "id": "claude-sonnet-4-20250514",
       "name": "Claude Sonnet 4",
       "provider": "anthropic",
-      "aliases": [
-        "frontier",
-        "tier/frontier"
-      ],
+      "aliases": [],
       "context_window": 200000,
       "modalities": {
         "input": [
@@ -980,6 +1123,150 @@
         "cache_write_per_mtok": 3.75
       },
       "deprecation": {
+        "status": "deprecated",
+        "note": "Sunset 2026-06-15 per Anthropic deprecations page. Replaced by claude-sonnet-4-6."
+      },
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "tool_search",
+        "vision",
+        "audio",
+        "pdf",
+        "files",
+        "prompt_caching",
+        "thinking",
+        "structured_output"
+      ]
+    },
+    {
+      "id": "claude-sonnet-4-5",
+      "name": "Claude Sonnet 4.5",
+      "provider": "anthropic",
+      "aliases": [],
+      "context_window": 200000,
+      "modalities": {
+        "input": [
+          "text",
+          "image",
+          "audio",
+          "pdf"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "tool_search": [
+          "bm25",
+          "regex"
+        ],
+        "max_tools": 10000
+      },
+      "structured_output": "tool_use",
+      "format_preferences": {
+        "prefers_xml_scaffolding": true,
+        "prefers_markdown_scaffolding": false,
+        "structured_output_mode": "xml_tagged",
+        "supports_assistant_prefill": true,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": true,
+        "thinking_block_style": "thinking_blocks"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 3.0,
+        "output_per_mtok": 15.0,
+        "cache_read_per_mtok": 0.3,
+        "cache_write_per_mtok": 3.75
+      },
+      "deprecation": {
+        "status": "deprecated",
+        "note": "Sunset 2026-05-15 per Anthropic deprecations page. Replaced by claude-sonnet-4-6."
+      },
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "tool_search",
+        "vision",
+        "audio",
+        "pdf",
+        "files",
+        "prompt_caching",
+        "thinking",
+        "structured_output"
+      ]
+    },
+    {
+      "id": "claude-sonnet-4-6",
+      "name": "Claude Sonnet 4.6",
+      "provider": "anthropic",
+      "aliases": [
+        "frontier",
+        "sonnet",
+        "tier/frontier"
+      ],
+      "context_window": 200000,
+      "modalities": {
+        "input": [
+          "text",
+          "image",
+          "audio",
+          "pdf"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "tool_search": [
+          "bm25",
+          "regex"
+        ],
+        "max_tools": 10000
+      },
+      "structured_output": "tool_use",
+      "format_preferences": {
+        "prefers_xml_scaffolding": true,
+        "prefers_markdown_scaffolding": false,
+        "structured_output_mode": "xml_tagged",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": true,
+        "thinking_block_style": "thinking_blocks"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 3.0,
+        "output_per_mtok": 15.0,
+        "cache_read_per_mtok": 0.3,
+        "cache_write_per_mtok": 3.75
+      },
+      "deprecation": {
         "status": "active"
       },
       "quality_tags": [
@@ -995,6 +1282,76 @@
         "files",
         "prompt_caching",
         "thinking",
+        "structured_output"
+      ]
+    },
+    {
+      "id": "claude-sonnet-4-7",
+      "name": "Claude Sonnet 4.7",
+      "provider": "anthropic",
+      "aliases": [],
+      "context_window": 200000,
+      "modalities": {
+        "input": [
+          "text",
+          "image",
+          "audio",
+          "pdf"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "tool_search": [
+          "bm25",
+          "regex"
+        ],
+        "max_tools": 10000
+      },
+      "structured_output": "tool_use",
+      "format_preferences": {
+        "prefers_xml_scaffolding": true,
+        "prefers_markdown_scaffolding": false,
+        "structured_output_mode": "xml_tagged",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": true,
+        "thinking_block_style": "thinking_blocks"
+      },
+      "reasoning": {
+        "modes": [
+          "adaptive"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 3.0,
+        "output_per_mtok": 15.0,
+        "cache_read_per_mtok": 0.3,
+        "cache_write_per_mtok": 3.75
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "tool_search",
+        "vision",
+        "audio",
+        "pdf",
+        "files",
+        "prompt_caching",
+        "thinking",
+        "extended_thinking",
         "structured_output"
       ]
     },
@@ -1837,7 +2194,8 @@
         "cache_write_per_mtok": null
       },
       "deprecation": {
-        "status": "active"
+        "status": "deprecated",
+        "note": "Superseded by gpt-5 family. Listed for cost-attribution backfill only."
       },
       "quality_tags": [],
       "capability_tags": [
@@ -1892,7 +2250,8 @@
         "cache_write_per_mtok": null
       },
       "deprecation": {
-        "status": "active"
+        "status": "deprecated",
+        "note": "API sunset 2026-02-17 per OpenAI deprecations page. Switch to gpt-5-mini for cheap routing or gpt-5 for frontier."
       },
       "quality_tags": [],
       "capability_tags": [
@@ -2251,6 +2610,130 @@
       ]
     },
     {
+      "id": "deepseek/deepseek-v3.2",
+      "name": "DeepSeek V3.2",
+      "provider": "openrouter",
+      "aliases": [],
+      "context_window": 131072,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "reasoning_summary"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled",
+          "effort"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 0.28,
+        "output_per_mtok": 0.42,
+        "cache_read_per_mtok": null,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "prompt_caching",
+        "thinking",
+        "extended_thinking",
+        "structured_output"
+      ]
+    },
+    {
+      "id": "google/gemini-2.5-flash",
+      "name": "Gemini 2.5 Flash (via OpenRouter)",
+      "provider": "openrouter",
+      "aliases": [],
+      "context_window": 1048576,
+      "modalities": {
+        "input": [
+          "text",
+          "image",
+          "audio",
+          "pdf"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "reasoning_summary"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled",
+          "effort"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 0.1,
+        "output_per_mtok": 0.4,
+        "cache_read_per_mtok": 0.025,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "vision",
+        "audio",
+        "pdf",
+        "prompt_caching",
+        "thinking",
+        "extended_thinking",
+        "structured_output"
+      ]
+    },
+    {
       "id": "mistral-large-latest",
       "name": "Mistral Large",
       "provider": "openrouter",
@@ -2353,6 +2836,164 @@
         "streaming",
         "tools"
       ]
+    },
+    {
+      "id": "moonshotai/kimi-k2.6",
+      "name": "Kimi K2.6",
+      "provider": "openrouter",
+      "aliases": [],
+      "context_window": 200000,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": false,
+        "text": true,
+        "tool_search": []
+      },
+      "structured_output": "none",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": false,
+        "structured_output_mode": "none",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "none"
+      },
+      "reasoning": {
+        "modes": [],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "pricing": {
+        "input_per_mtok": 0.55,
+        "output_per_mtok": 2.2,
+        "cache_read_per_mtok": null,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools"
+      ]
+    },
+    {
+      "id": "openai/gpt-oss-120b",
+      "name": "GPT-OSS 120B",
+      "provider": "openrouter",
+      "aliases": [],
+      "context_window": 131072,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "none"
+      },
+      "reasoning": {
+        "modes": [],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "pricing": {
+        "input_per_mtok": 0.15,
+        "output_per_mtok": 0.6,
+        "cache_read_per_mtok": null,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "structured_output"
+      ]
+    },
+    {
+      "id": "qwen/qwen3-coder",
+      "name": "Qwen3 Coder 480B A35B",
+      "provider": "openrouter",
+      "aliases": [],
+      "context_window": 262144,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "delimited",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "none"
+      },
+      "reasoning": {
+        "modes": [],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "pricing": {
+        "input_per_mtok": 0.22,
+        "output_per_mtok": 1.8,
+        "cache_read_per_mtok": null,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "structured_output"
+      ]
     }
   ],
   "aliases": [
@@ -2364,7 +3005,12 @@
     },
     {
       "name": "frontier",
-      "model_id": "claude-sonnet-4-20250514",
+      "model_id": "claude-sonnet-4-6",
+      "provider": "anthropic"
+    },
+    {
+      "name": "haiku",
+      "model_id": "claude-haiku-4-5-20251001",
       "provider": "anthropic"
     },
     {
@@ -2490,6 +3136,11 @@
       "tool_format": "text"
     },
     {
+      "name": "opus",
+      "model_id": "claude-opus-4-7",
+      "provider": "anthropic"
+    },
+    {
       "name": "qwen3.6-35b-coding",
       "model_id": "qwen3.6:35b-a3b-coding-nvfp4",
       "provider": "ollama",
@@ -2531,8 +3182,13 @@
       "provider": "openrouter"
     },
     {
+      "name": "sonnet",
+      "model_id": "claude-sonnet-4-6",
+      "provider": "anthropic"
+    },
+    {
       "name": "tier/frontier",
-      "model_id": "claude-sonnet-4-20250514",
+      "model_id": "claude-sonnet-4-6",
       "provider": "anthropic"
     },
     {
@@ -2567,7 +3223,7 @@
       "id": "high-reasoning",
       "label": "High reasoning",
       "description": "Frontier route for hard planning, repair, and review tasks.",
-      "model_id": "claude-sonnet-4-20250514",
+      "model_id": "claude-sonnet-4-6",
       "provider": "anthropic",
       "source": "alias:frontier"
     },
@@ -2605,7 +3261,7 @@
     }
   ],
   "qc_defaults": {
-    "anthropic": "claude-3-5-haiku-20241022",
+    "anthropic": "claude-haiku-4-5-20251001",
     "local": "gpt-4o",
     "ollama": "llama3.2",
     "openai": "gpt-4o-mini",


### PR DESCRIPTION
## Summary

- Collapses ~1100 lines of Rust literals in `default_config()` into a single embedded `crates/harn-vm/src/llm/providers.toml`. The new file deserializes through the same `ProvidersConfig` schema that `HARN_PROVIDERS_CONFIG` / `~/.config/harn/providers.toml` / `harn.toml [llm]` / package manifests already use — one source of truth, no parallel system. Adds and deprecates models in the same file (the brittle bit) rather than across a thousand lines of Rust closures.
- Catalog refresh: registers `claude-sonnet-4-5/4-6/4-7`, `claude-opus-4-6/4-7`, `qwen/qwen3-coder`, `deepseek/deepseek-v3.2`, `moonshotai/kimi-k2.6`, `openai/gpt-oss-120b`, and `google/gemini-2.5-flash` (the OpenRouter-routed variant). Marks `claude-sonnet-4-20250514` (sunset 2026-06-15), `claude-sonnet-4-5` (sunset 2026-05-15), `claude-opus-4` (2026-06-15), `claude-opus-4-1`, `gpt-4o` (2026-02-17 API sunset), and `gpt-4-turbo` as deprecated with replacement notes from Anthropic's and OpenAI's public deprecations pages. Bumps the `frontier` tier alias from `claude-sonnet-4-20250514` to `claude-sonnet-4-6`.
- Tests rewritten to exercise the system instead of pinning specific values, per the request to make tests less brittle as the catalog churns. New invariant tests under `llm_config::tests::embedded_*` verify the TOML parses, every deprecated model has a `deprecation_note`, every alias/model targets a known provider, every `qc_default` resolves, pricing rates are non-negative, and the three tier aliases (`frontier`/`mid`/`small`) resolve to active (non-deprecated) catalog entries. Two previously-brittle assertions (`test_resolve_tier_model_default_aliases`, `acp_agent_capabilities_use_canonical_initialize_shape`) loosened.

## Why

Asked for: bring the model catalog up to date (Sonnet 4.5 sunset 2026-05-15, Sonnet 4 + Opus 4 retire 2026-06-15, GPT-4o API sunset already past, plus open-weight executor candidates from current research). While in there, push the catalog out of Rust literals and into TOML so future refreshes don't need a 1000-line diff. Use the existing `ProvidersConfig` schema rather than inventing a parallel `catalog.toml` system.

## Test plan

- [x] `cargo check -p harn-vm` (embedded TOML parses)
- [x] `cargo test --workspace` — 2066 passed; 0 failed; 1 ignored
- [x] `cargo clippy --workspace --no-deps -- -D warnings`
- [x] `cargo fmt --check`
- [x] `make check-provider-catalog` (artifact validation)
- [x] `make check-provider-matrix` (capability matrix docs up to date)
- [x] `make check-provider-catalog-drift` (fixture-based drift workflow)
- [x] Regenerated `spec/provider-catalog/{provider-catalog.json, .schema.json, harn-provider-catalog.ts, HarnProviderCatalog.swift}` via `make gen-provider-catalog`
- [ ] CI

## Follow-up

- `burin-code` ships its own `Sources/BurinCore/Resources/providers.toml` (834 lines) that overlaps significantly with what now lives in harn defaults. Follow-up PR against burin-code can thin that file to only the entries it overrides beyond harn (Fireworks-hosted Qwen3.6 Plus aliases, lora-corpus-specific `model_defaults` blocks, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)