### PR TITLE
Disable CARGO_INCREMENTAL during prepare; reassure operators on Ctrl-C

### DIFF
--- a/crates/harn-cli/src/commands/run.rs
+++ b/crates/harn-cli/src/commands/run.rs
@@ -446,6 +446,17 @@ impl Drop for StdoutPassthroughGuard {
     }
 }
 
+// User-facing copy on Ctrl-C. We want the operator to know that a brief
+// pause after the first signal is expected (the VM rewinds the active
+// instruction, drops in-flight async ops like a hanging Ollama request,
+// and unwinds frames before the runtime exits) so they don't reflexively
+// reach for a second Ctrl-C and force-kill the process. The "Ctrl-C
+// again to force-exit" hint is load-bearing — earlier runs of harn
+// released to the fleet showed operators routinely double-tapping the
+// shortcut and losing the chance to inspect the error trace.
+const FIRST_SIGNAL_MESSAGE: &str =
+    "[harn] signal received, interrupting VM (give it a moment to unwind in-flight async ops; Ctrl-C again to force-exit)...";
+
 fn install_signal_shutdown_handler() -> RunInterruptTokens {
     let tokens = RunInterruptTokens {
         cancel_token: Arc::new(AtomicBool::new(false)),
@@ -472,7 +483,7 @@ fn install_signal_shutdown_handler() -> RunInterruptTokens {
                 }
                 seen_signal = true;
                 request_vm_interrupt(&tokens_clone, signal_name);
-                eprintln!("[harn] signal received, interrupting VM...");
+                eprintln!("{FIRST_SIGNAL_MESSAGE}");
             }
         }
         #[cfg(not(unix))]
@@ -486,7 +497,7 @@ fn install_signal_shutdown_handler() -> RunInterruptTokens {
                 }
                 seen_signal = true;
                 request_vm_interrupt(&tokens_clone, "SIGINT");
-                eprintln!("[harn] signal received, interrupting VM...");
+                eprintln!("{FIRST_SIGNAL_MESSAGE}");
             }
         }
     });

--- a/scripts/release_gate.sh
+++ b/scripts/release_gate.sh
@@ -314,6 +314,17 @@ cmd_prepare() {
   next="$(next_version "$bump")"
   bump_version "$next"
   python3 scripts/sync_protocol_fixture_runtime_versions.py --from "$current" --to "$next"
+  # The audit lanes that ran before prepare populate `target/debug/incremental/`
+  # with object-file references keyed to the *old* version's crate hashes.
+  # Once `bump_version` rewrites Cargo.toml the workspace crates rebuild with
+  # fresh hashes, and the stale incremental directory has dangling .o refs —
+  # cargo aborts with "failed to open object file ... No such file or
+  # directory" and "extern location for harn_modules does not exist". Forcing
+  # `CARGO_INCREMENTAL=0` for the prepare-time cargo calls skips the
+  # incremental fast path entirely (these are one-shot builds anyway). Export
+  # so child make/cargo invocations downstream of release_ship.sh's
+  # `regenerate_derived_files` step inherit it too.
+  export CARGO_INCREMENTAL=0
   make gen-protocol-artifacts
   cargo check --workspace --all-targets >/dev/null
   echo "Version updated: $current -> $next"

--- a/scripts/release_ship.sh
+++ b/scripts/release_ship.sh
@@ -499,6 +499,12 @@ prepare_here() {
     exit 1
   fi
 
+  # `release_gate.sh prepare` already exported CARGO_INCREMENTAL=0 to
+  # work around incremental-cache corruption after parallel audit builds
+  # + a Cargo.toml version bump. That export does not survive the
+  # subprocess boundary, so re-apply it for the cargo invocations
+  # `regenerate_derived_files` runs in this shell.
+  export CARGO_INCREMENTAL=0
   regenerate_derived_files
 
   log_step "Stage release content"


### PR DESCRIPTION
## Summary

Two release-flow polish fixes surfaced by a v0.8.21 attempt where `release_harn.harn` ran `release_ship.sh --prepare`, sat through 6 minutes of audit, then crashed in `make gen-protocol-artifacts` with cargo incremental-cache corruption.

### 1. `CARGO_INCREMENTAL=0` for the prepare phase

The audit lanes (`rust-audit`, `harn-audit`, `docs-audit`, …) populate `target/debug/incremental/` keyed to the **previous** version's crate hashes. Once `bump_version` rewrites `Cargo.toml`, the workspace crates rebuild with **fresh** hashes and the stale incremental directory has dangling `.o` references — cargo aborts mid-build with:

```
warning: error copying object file `target/debug/deps/harn_modules-88b45c3b...rcgu.o` to incremental directory ...: No such file or directory (os error 2)
error: failed to build archive at `target/debug/deps/libharn_modules-88b45c3b...rlib`: failed to open object file: No such file or directory (os error 2)
error: extern location for harn_modules does not exist
```

Fix: export `CARGO_INCREMENTAL=0` in `release_gate.sh cmd_prepare` (covering `make gen-protocol-artifacts` and `cargo check`) **and** in `release_ship.sh prepare_here` after `release_gate.sh prepare` returns (covering `regenerate_derived_files`'s `make sync-language-spec` / `make gen-highlight`, which run in a fresh shell that doesn't inherit the inner script's export). The prepare cargo invocations are one-shot — there's no benefit to incremental anyway.

### 2. Reassure operators during the Ctrl-C unwind window

The first-signal `eprintln` was terse enough that operators routinely reach for a second Ctrl-C before the VM finishes draining in-flight async ops (the cancel-grace window is short, but a hanging Ollama request can still be ~250ms+ to drop). Expand the copy to:

```
[harn] signal received, interrupting VM (give it a moment to unwind in-flight async ops; Ctrl-C again to force-exit)...
```

so the operator knows the brief gap is expected.

## Test plan
- [ ] `cargo check -p harn-cli` passes
- [ ] `cargo clippy -p harn-cli -- -D warnings` passes (run during dev)
- [ ] Manual: run `release_harn.harn` against a real release; confirm `make gen-protocol-artifacts` no longer fails after the audit + version bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)