### PR TITLE
Add tool-call eval harness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup install-hooks configure-merge-drivers build build-release sign-local check fmt fmt-harn fmt-harn-fix lint lint-md lint-actions lint-harn spec-lint test test-e2e test-cargo test-fast test-harn-scripts conformance protocol-conformance replay-oracle replay-bench bench-vm bench-vm-clone bench-llm bench-orchestration all release-gate release-smoke smoke-audit portal portal-check portal-demo gen-highlight check-highlight gen-protocol-artifacts check-protocol-artifacts check-bindings gen-session-bundle-schema check-session-bundle-schema gen-trigger-quickref check-trigger-quickref gen-provider-matrix check-provider-matrix gen-provider-catalog check-provider-catalog gen-connector-matrix check-connector-matrix check-trigger-examples check-docs-snippets check-docs-workflow-quickstart sync-language-spec check-language-spec lint-test-patterns check-receipt-structs lint-no-rust-prompt-prose lint-no-xfail-regression check-provider-catalog-drift
+.PHONY: setup install-hooks configure-merge-drivers build build-release sign-local check fmt fmt-harn fmt-harn-fix lint lint-md lint-actions lint-harn spec-lint test test-e2e test-cargo test-fast test-harn-scripts conformance protocol-conformance replay-oracle replay-bench eval-tool-calls bench-vm bench-vm-clone bench-llm bench-orchestration all release-gate release-smoke smoke-audit portal portal-check portal-demo gen-highlight check-highlight gen-protocol-artifacts check-protocol-artifacts check-bindings gen-session-bundle-schema check-session-bundle-schema gen-trigger-quickref check-trigger-quickref gen-provider-matrix check-provider-matrix gen-provider-catalog check-provider-catalog gen-connector-matrix check-connector-matrix check-trigger-examples check-docs-snippets check-docs-workflow-quickstart sync-language-spec check-language-spec lint-test-patterns check-receipt-structs lint-no-rust-prompt-prose lint-no-xfail-regression check-provider-catalog-drift
 
 # Full quality check: format first, then lint/test in parallel.
 # Usage: make all -j       (parallel checks after formatting)
@@ -85,6 +85,9 @@ replay-oracle:
 
 replay-bench:
 	HARN_LLM_CALLS_DISABLED=1 cargo run --bin harn -- bench replay --json >/dev/null
+
+eval-tool-calls:
+	cargo run --bin harn -- eval tool-calls --dataset conformance/tool-call-eval --planner mock:mock --output .harn-runs/tool-call-eval/latest
 
 bench-vm:
 	./scripts/bench_vm.sh

--- a/conformance/tool-call-eval/README.md
+++ b/conformance/tool-call-eval/README.md
@@ -1,0 +1,103 @@
+# Tool-Call Eval Dataset
+
+This directory contains Harn's PEAR-style tool-call accuracy fixture set for:
+
+- aggregate pass-rate scoring across many tool-call cases,
+- planner, binder, and total latency measurement,
+- multi-model comparison through `harn eval tool-calls`,
+- exact and refusal scoring against expected tool-call decisions.
+
+Run the offline smoke path with the mock provider:
+
+```sh
+cargo run --bin harn -- eval tool-calls \
+  --dataset conformance/tool-call-eval \
+  --planner mock:mock \
+  --output .harn-runs/tool-call-eval/latest
+```
+
+Run a planner+binder cell with real providers:
+
+```sh
+cargo run --bin harn -- eval tool-calls \
+  --dataset conformance/tool-call-eval \
+  --planner provider=openrouter,model=google/gemma-4-26b-a4b-it \
+  --binder provider=cerebras,model=gpt-oss-120b \
+  --judge-model anthropic:claude-haiku-4-5 \
+  --output .harn-runs/tool-call-eval/gemma-cerebras
+```
+
+The command writes:
+
+- `summary.json`: aggregate pass rate, p50/p99 planner latency, optional binder latency, total
+  latency, total cost, and one per-case verdict row.
+- `per_case.jsonl`: one full drill-down record per case, including raw planner/binder responses and
+  token/cost accounting.
+
+Regression check:
+
+```sh
+cargo run --bin harn -- eval tool-calls regression-check \
+  --current .harn-runs/tool-call-eval/latest/summary.json \
+  --against conformance/tool-call-eval/baselines/mock-planner.summary.json \
+  --max-drop-pp 2.0
+```
+
+Baseline files keep only stable pass-rate fields; run outputs keep volatile per-case latencies in
+`.harn-runs/`.
+
+## Case Format
+
+Cases are JSON objects under `cases/`; files may contain one object or an array.
+
+```json
+{
+  "id": "example",
+  "prompt": "Search for Harn release notes.",
+  "tools": [
+    {
+      "name": "search",
+      "description": "Search documents.",
+      "parameters": {
+        "query": {"type": "string"}
+      }
+    }
+  ],
+  "expected": {
+    "kind": "exact",
+    "name": "search",
+    "args": {"query": "Harn release notes"}
+  },
+  "source": "harn_hand_authored",
+  "tags": ["simple"]
+}
+```
+
+`parameters` uses the same per-argument schema fragments accepted by Harn tool definitions. Exact
+cases require a single normalized tool call with deep-equal arguments; numeric values tolerate tiny
+float representation differences. Refusal cases pass only when no tool call is emitted and the final
+text matches `reason_must_match`.
+
+Predicate cases are supported by the runner but intentionally absent from the initial checked-in
+50-case set so the default dataset can run without judge spend.
+
+## Attribution
+
+The dataset mixes:
+
+- Harn conformance-inspired cases, named with `source: harn:...`.
+- Hand-authored binder edge cases, named with `source: harn_hand_authored:...`.
+- BFCL-style synthetic cases, named with `source: bfcl_style_synthetic:...`.
+
+The BFCL-style cases follow the public Berkeley Function Calling Leaderboard category structure
+(simple, multiple, REST, SQL, chatting/irrelevance) but do not copy BFCL rows or expected answers.
+BFCL is published under Apache-2.0 on Hugging Face and documented at:
+
+- https://huggingface.co/datasets/gorilla-llm/Berkeley-Function-Calling-Leaderboard
+- https://gorilla.cs.berkeley.edu/leaderboard.html
+
+## Adding Cases
+
+Add a stable `id`, keep prompts self-contained, declare only the tools visible to the planner, and
+include tags that let smoke runs focus on a slice with `--filter`. Use exact cases for deterministic
+tool decisions and refusal cases when the correct behavior is no tool call.

--- a/conformance/tool-call-eval/baselines/mock-planner.summary.json
+++ b/conformance/tool-call-eval/baselines/mock-planner.summary.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 1,
+  "planner": {
+    "selector": "mock:mock",
+    "provider": "mock",
+    "model": "mock"
+  },
+  "total_cases": 50,
+  "passed_cases": 4,
+  "pass_rate": 0.08
+}

--- a/conformance/tool-call-eval/cases/bfcl_style.json
+++ b/conformance/tool-call-eval/cases/bfcl_style.json
@@ -1,0 +1,446 @@
+[
+  {
+    "id": "bfcl_style_weather_current",
+    "prompt": "What is the weather in Boston in celsius?",
+    "tools": [
+      {
+        "name": "get_current_weather",
+        "description": "Get current weather for a city.",
+        "parameters": {
+          "location": {"type": "string"},
+          "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}
+        }
+      }
+    ],
+    "expected": {
+      "kind": "exact",
+      "name": "get_current_weather",
+      "args": {"location": "Boston", "unit": "celsius"}
+    },
+    "source": "bfcl_style_synthetic:simple",
+    "tags": ["bfcl_style", "simple"]
+  },
+  {
+    "id": "bfcl_style_stock_quote",
+    "prompt": "Look up the latest quote for NVDA.",
+    "tools": [
+      {
+        "name": "get_stock_quote",
+        "description": "Fetch a stock quote by ticker.",
+        "parameters": {
+          "ticker": {"type": "string"}
+        }
+      }
+    ],
+    "expected": {"kind": "exact", "name": "get_stock_quote", "args": {"ticker": "NVDA"}},
+    "source": "bfcl_style_synthetic:simple",
+    "tags": ["bfcl_style", "finance"]
+  },
+  {
+    "id": "bfcl_style_book_flight",
+    "prompt": "Find flights from SFO to JFK on 2026-06-12 for one adult.",
+    "tools": [
+      {
+        "name": "search_flights",
+        "description": "Search available flights.",
+        "parameters": {
+          "origin": {"type": "string"},
+          "destination": {"type": "string"},
+          "date": {"type": "string", "description": "ISO date"},
+          "adults": {"type": "integer"}
+        }
+      }
+    ],
+    "expected": {
+      "kind": "exact",
+      "name": "search_flights",
+      "args": {"origin": "SFO", "destination": "JFK", "date": "2026-06-12", "adults": 1}
+    },
+    "source": "bfcl_style_synthetic:simple",
+    "tags": ["bfcl_style", "travel"]
+  },
+  {
+    "id": "bfcl_style_rest_holiday",
+    "prompt": "Fetch public holidays in Canada for 2026.",
+    "tools": [
+      {
+        "name": "get_public_holidays",
+        "description": "Call the public-holidays endpoint.",
+        "parameters": {
+          "year": {"type": "integer"},
+          "country_code": {"type": "string"}
+        }
+      }
+    ],
+    "expected": {
+      "kind": "exact",
+      "name": "get_public_holidays",
+      "args": {"year": 2026, "country_code": "CA"}
+    },
+    "source": "bfcl_style_synthetic:rest",
+    "tags": ["bfcl_style", "rest"]
+  },
+  {
+    "id": "bfcl_style_sql_select",
+    "prompt": "Select email from users where id is 42.",
+    "tools": [
+      {
+        "name": "sql_execute",
+        "description": "Execute a constrained SQL operation.",
+        "parameters": {
+          "sql_keyword": {"type": "string", "enum": ["SELECT", "INSERT", "UPDATE", "DELETE"]},
+          "table_name": {"type": "string"},
+          "columns": {"type": "array", "items": {"type": "string"}},
+          "conditions": {"type": "object"}
+        }
+      }
+    ],
+    "expected": {
+      "kind": "exact",
+      "name": "sql_execute",
+      "args": {
+        "sql_keyword": "SELECT",
+        "table_name": "users",
+        "columns": ["email"],
+        "conditions": {"id": 42}
+      }
+    },
+    "source": "bfcl_style_synthetic:sql",
+    "tags": ["bfcl_style", "sql"]
+  },
+  {
+    "id": "bfcl_style_calendar_create",
+    "prompt": "Schedule a design review tomorrow at 10:00 for 30 minutes.",
+    "tools": [
+      {
+        "name": "create_calendar_event",
+        "description": "Create a calendar event.",
+        "parameters": {
+          "title": {"type": "string"},
+          "relative_date": {"type": "string"},
+          "time": {"type": "string"},
+          "duration_minutes": {"type": "integer"}
+        }
+      }
+    ],
+    "expected": {
+      "kind": "exact",
+      "name": "create_calendar_event",
+      "args": {
+        "title": "design review",
+        "relative_date": "tomorrow",
+        "time": "10:00",
+        "duration_minutes": 30
+      }
+    },
+    "source": "bfcl_style_synthetic:simple",
+    "tags": ["bfcl_style", "calendar"]
+  },
+  {
+    "id": "bfcl_style_multiple_weather_vs_news",
+    "prompt": "Will it rain in Seattle today?",
+    "tools": [
+      {
+        "name": "get_current_weather",
+        "description": "Get weather for a city.",
+        "parameters": {
+          "location": {"type": "string"}
+        }
+      },
+      {
+        "name": "search_news",
+        "description": "Search recent news.",
+        "parameters": {
+          "query": {"type": "string"}
+        }
+      }
+    ],
+    "expected": {"kind": "exact", "name": "get_current_weather", "args": {"location": "Seattle"}},
+    "source": "bfcl_style_synthetic:multiple",
+    "tags": ["bfcl_style", "multiple"]
+  },
+  {
+    "id": "bfcl_style_multiple_news_vs_weather",
+    "prompt": "Find recent news about the Harn programming language.",
+    "tools": [
+      {
+        "name": "get_current_weather",
+        "description": "Get weather for a city.",
+        "parameters": {
+          "location": {"type": "string"}
+        }
+      },
+      {
+        "name": "search_news",
+        "description": "Search recent news.",
+        "parameters": {
+          "query": {"type": "string"}
+        }
+      }
+    ],
+    "expected": {
+      "kind": "exact",
+      "name": "search_news",
+      "args": {"query": "Harn programming language"}
+    },
+    "source": "bfcl_style_synthetic:multiple",
+    "tags": ["bfcl_style", "multiple"]
+  },
+  {
+    "id": "bfcl_style_multiple_translate",
+    "prompt": "Translate 'good morning' to Spanish.",
+    "tools": [
+      {
+        "name": "summarize_text",
+        "description": "Summarize text.",
+        "parameters": {
+          "text": {"type": "string"}
+        }
+      },
+      {
+        "name": "translate_text",
+        "description": "Translate text to a target language.",
+        "parameters": {
+          "text": {"type": "string"},
+          "target_language": {"type": "string"}
+        }
+      }
+    ],
+    "expected": {
+      "kind": "exact",
+      "name": "translate_text",
+      "args": {"text": "good morning", "target_language": "Spanish"}
+    },
+    "source": "bfcl_style_synthetic:multiple",
+    "tags": ["bfcl_style", "multiple"]
+  },
+  {
+    "id": "bfcl_style_email_send",
+    "prompt": "Email Alex the subject 'Launch checklist' with body 'Please review by Friday'.",
+    "tools": [
+      {
+        "name": "send_email",
+        "description": "Send an email.",
+        "parameters": {
+          "recipient": {"type": "string"},
+          "subject": {"type": "string"},
+          "body": {"type": "string"}
+        }
+      }
+    ],
+    "expected": {
+      "kind": "exact",
+      "name": "send_email",
+      "args": {
+        "recipient": "Alex",
+        "subject": "Launch checklist",
+        "body": "Please review by Friday"
+      }
+    },
+    "source": "bfcl_style_synthetic:simple",
+    "tags": ["bfcl_style", "email"]
+  },
+  {
+    "id": "bfcl_style_shopping_search",
+    "prompt": "Search for noise cancelling headphones under 200 dollars.",
+    "tools": [
+      {
+        "name": "search_products",
+        "description": "Search products by query and optional maximum price.",
+        "parameters": {
+          "query": {"type": "string"},
+          "max_price_usd": {"type": "number", "required": false}
+        }
+      }
+    ],
+    "expected": {
+      "kind": "exact",
+      "name": "search_products",
+      "args": {"query": "noise cancelling headphones", "max_price_usd": 200}
+    },
+    "source": "bfcl_style_synthetic:simple",
+    "tags": ["bfcl_style", "shopping"]
+  },
+  {
+    "id": "bfcl_style_route_distance",
+    "prompt": "Calculate driving distance from Oakland to Sacramento.",
+    "tools": [
+      {
+        "name": "calculate_route",
+        "description": "Calculate a route.",
+        "parameters": {
+          "origin": {"type": "string"},
+          "destination": {"type": "string"},
+          "mode": {"type": "string", "enum": ["driving", "walking", "transit"]}
+        }
+      }
+    ],
+    "expected": {
+      "kind": "exact",
+      "name": "calculate_route",
+      "args": {"origin": "Oakland", "destination": "Sacramento", "mode": "driving"}
+    },
+    "source": "bfcl_style_synthetic:rest",
+    "tags": ["bfcl_style", "maps"]
+  },
+  {
+    "id": "bfcl_style_crm_lookup",
+    "prompt": "Find the CRM contact for Priya Shah at Acme.",
+    "tools": [
+      {
+        "name": "crm_find_contact",
+        "description": "Find a CRM contact.",
+        "parameters": {
+          "name": {"type": "string"},
+          "company": {"type": "string", "required": false}
+        }
+      }
+    ],
+    "expected": {
+      "kind": "exact",
+      "name": "crm_find_contact",
+      "args": {"name": "Priya Shah", "company": "Acme"}
+    },
+    "source": "bfcl_style_synthetic:enterprise",
+    "tags": ["bfcl_style", "crm"]
+  },
+  {
+    "id": "bfcl_style_ticket_create",
+    "prompt": "Open a high priority ticket titled 'OAuth callback failing'.",
+    "tools": [
+      {
+        "name": "create_ticket",
+        "description": "Create an issue tracker ticket.",
+        "parameters": {
+          "title": {"type": "string"},
+          "priority": {"type": "string", "enum": ["low", "medium", "high"]}
+        }
+      }
+    ],
+    "expected": {
+      "kind": "exact",
+      "name": "create_ticket",
+      "args": {"title": "OAuth callback failing", "priority": "high"}
+    },
+    "source": "bfcl_style_synthetic:enterprise",
+    "tags": ["bfcl_style", "issue_tracker"]
+  },
+  {
+    "id": "bfcl_style_unit_conversion",
+    "prompt": "Convert 12 miles to kilometers.",
+    "tools": [
+      {
+        "name": "convert_units",
+        "description": "Convert a numeric value between units.",
+        "parameters": {
+          "value": {"type": "number"},
+          "from_unit": {"type": "string"},
+          "to_unit": {"type": "string"}
+        }
+      }
+    ],
+    "expected": {
+      "kind": "exact",
+      "name": "convert_units",
+      "args": {"value": 12, "from_unit": "miles", "to_unit": "kilometers"}
+    },
+    "source": "bfcl_style_synthetic:simple",
+    "tags": ["bfcl_style", "math"]
+  },
+  {
+    "id": "bfcl_style_package_track",
+    "prompt": "Track package 1Z999AA10123456784.",
+    "tools": [
+      {
+        "name": "track_package",
+        "description": "Track a package by carrier tracking number.",
+        "parameters": {
+          "tracking_number": {"type": "string"}
+        }
+      }
+    ],
+    "expected": {
+      "kind": "exact",
+      "name": "track_package",
+      "args": {"tracking_number": "1Z999AA10123456784"}
+    },
+    "source": "bfcl_style_synthetic:rest",
+    "tags": ["bfcl_style", "logistics"]
+  },
+  {
+    "id": "bfcl_style_timer_set",
+    "prompt": "Set a timer for 15 minutes named tea.",
+    "tools": [
+      {
+        "name": "set_timer",
+        "description": "Set a timer.",
+        "parameters": {
+          "minutes": {"type": "integer"},
+          "label": {"type": "string", "required": false}
+        }
+      }
+    ],
+    "expected": {"kind": "exact", "name": "set_timer", "args": {"minutes": 15, "label": "tea"}},
+    "source": "bfcl_style_synthetic:simple",
+    "tags": ["bfcl_style", "timer"]
+  },
+  {
+    "id": "bfcl_style_inventory_check",
+    "prompt": "Check if SKU HARN-TEE-M is in stock at warehouse west.",
+    "tools": [
+      {
+        "name": "inventory_lookup",
+        "description": "Look up SKU inventory.",
+        "parameters": {
+          "sku": {"type": "string"},
+          "warehouse": {"type": "string", "required": false}
+        }
+      }
+    ],
+    "expected": {
+      "kind": "exact",
+      "name": "inventory_lookup",
+      "args": {"sku": "HARN-TEE-M", "warehouse": "west"}
+    },
+    "source": "bfcl_style_synthetic:enterprise",
+    "tags": ["bfcl_style", "inventory"]
+  },
+  {
+    "id": "bfcl_style_metric_query",
+    "prompt": "Query p95 latency for service api-gateway over the last hour.",
+    "tools": [
+      {
+        "name": "metrics_query",
+        "description": "Query service metrics.",
+        "parameters": {
+          "metric": {"type": "string"},
+          "service": {"type": "string"},
+          "window": {"type": "string"}
+        }
+      }
+    ],
+    "expected": {
+      "kind": "exact",
+      "name": "metrics_query",
+      "args": {"metric": "p95 latency", "service": "api-gateway", "window": "last hour"}
+    },
+    "source": "bfcl_style_synthetic:enterprise",
+    "tags": ["bfcl_style", "observability"]
+  },
+  {
+    "id": "bfcl_style_repo_search",
+    "prompt": "Search the repository for uses of llm_call.",
+    "tools": [
+      {
+        "name": "repo_search",
+        "description": "Search code in a repository.",
+        "parameters": {
+          "query": {"type": "string"}
+        }
+      }
+    ],
+    "expected": {"kind": "exact", "name": "repo_search", "args": {"query": "llm_call"}},
+    "source": "bfcl_style_synthetic:code",
+    "tags": ["bfcl_style", "code"]
+  }
+]

--- a/conformance/tool-call-eval/cases/harn_seed.json
+++ b/conformance/tool-call-eval/cases/harn_seed.json
@@ -1,0 +1,275 @@
+[
+  {
+    "id": "harn_echo_msg",
+    "prompt": "Echo the message 'first' back to the caller.",
+    "tools": [
+      {
+        "name": "echo",
+        "description": "Echo a short message.",
+        "parameters": {
+          "msg": {"type": "string", "description": "Message to echo"}
+        }
+      }
+    ],
+    "expected": {"kind": "exact", "name": "echo", "args": {"msg": "first"}},
+    "source": "harn:conformance/tests/integration/agent_loop_tool_caller_observes.harn",
+    "tags": ["harn_seed", "simple"]
+  },
+  {
+    "id": "harn_read_src_lib",
+    "prompt": "Inspect the repository by reading src/lib.rs.",
+    "tools": [
+      {
+        "name": "read",
+        "description": "Read a file from the workspace.",
+        "parameters": {
+          "path": {"type": "string", "description": "Path to read"}
+        }
+      }
+    ],
+    "expected": {"kind": "exact", "name": "read", "args": {"path": "src/lib.rs"}},
+    "source": "harn:conformance/tests/integration/native_tool_fallback_observability.harn",
+    "tags": ["harn_seed", "file"]
+  },
+  {
+    "id": "harn_greet_world",
+    "prompt": "Say hello to world using the greet tool.",
+    "tools": [
+      {
+        "name": "greet",
+        "description": "Say hello.",
+        "parameters": {
+          "name": {"type": "string", "description": "Name to greet"}
+        }
+      }
+    ],
+    "expected": {"kind": "exact", "name": "greet", "args": {"name": "world"}},
+    "source": "harn:conformance/tests/integration/tool_registry.harn",
+    "tags": ["harn_seed", "simple"]
+  },
+  {
+    "id": "harn_add_two_numbers",
+    "prompt": "Calculate 2 + 3.",
+    "tools": [
+      {
+        "name": "add",
+        "description": "Add two integers.",
+        "parameters": {
+          "left": {"type": "integer", "description": "Left operand"},
+          "right": {"type": "integer", "description": "Right operand"}
+        }
+      }
+    ],
+    "expected": {"kind": "exact", "name": "add", "args": {"left": 2, "right": 3}},
+    "source": "harn:conformance/tests/agents/agent_primitives_one_turn.harn",
+    "tags": ["harn_seed", "math"]
+  },
+  {
+    "id": "harn_lookup_release",
+    "prompt": "Look up release information.",
+    "tools": [
+      {
+        "name": "lookup",
+        "description": "Look up a topic.",
+        "parameters": {
+          "query": {"type": "string", "description": "Search query"}
+        }
+      }
+    ],
+    "expected": {"kind": "exact", "name": "lookup", "args": {"query": "release"}},
+    "source": "harn:conformance/tests/agents/agent_loop_native_natural_completion.harn",
+    "tags": ["harn_seed", "search"]
+  },
+  {
+    "id": "harn_delegate_readonly",
+    "prompt": "Delegate a read-only worker to inspect the config file.",
+    "tools": [
+      {
+        "name": "delegate_readonly",
+        "description": "Delegate a read-only task.",
+        "parameters": {
+          "task": {"type": "string", "description": "Task for the worker"}
+        }
+      }
+    ],
+    "expected": {
+      "kind": "exact",
+      "name": "delegate_readonly",
+      "args": {"task": "Inspect the config file"}
+    },
+    "source": "harn:conformance/tests/stdlib/workflow_sub_agent_skill_context.harn",
+    "tags": ["harn_seed", "delegation"]
+  },
+  {
+    "id": "harn_write_note_denied_shape",
+    "prompt": "Write notes.txt with the latest finding.",
+    "tools": [
+      {
+        "name": "write_note",
+        "description": "Write a note file.",
+        "parameters": {
+          "path": {"type": "string"},
+          "content": {"type": "string"}
+        }
+      }
+    ],
+    "expected": {
+      "kind": "exact",
+      "name": "write_note",
+      "args": {"path": "notes.txt", "content": "latest finding"}
+    },
+    "source": "harn:conformance/tests/agents/sub_agent_run_schema_and_permission.harn",
+    "tags": ["harn_seed", "file"]
+  },
+  {
+    "id": "harn_wait_for_user_branch",
+    "prompt": "Ask the user which branch to use.",
+    "tools": [
+      {
+        "name": "wait_for_user",
+        "description": "Ask the user a question and wait.",
+        "parameters": {
+          "question": {"type": "string"}
+        }
+      }
+    ],
+    "expected": {
+      "kind": "exact",
+      "name": "wait_for_user",
+      "args": {"question": "Which branch?"}
+    },
+    "source": "harn:conformance/tests/agents/agent_chat_loop.harn",
+    "tags": ["harn_seed", "hitl"]
+  },
+  {
+    "id": "harn_read_current_session_id",
+    "prompt": "Check the current agent session id.",
+    "tools": [
+      {
+        "name": "read_current_id",
+        "description": "Read the current session id.",
+        "parameters": {}
+      }
+    ],
+    "expected": {"kind": "exact", "name": "read_current_id", "args": {}},
+    "source": "harn:conformance/tests/agents/agent_session_current_id.harn",
+    "tags": ["harn_seed", "session"]
+  },
+  {
+    "id": "harn_find_config_path",
+    "prompt": "Search for the config path.",
+    "tools": [
+      {
+        "name": "search",
+        "description": "Search the workspace.",
+        "parameters": {
+          "query": {"type": "string"}
+        }
+      },
+      {
+        "name": "read",
+        "description": "Read a file.",
+        "parameters": {
+          "path": {"type": "string"}
+        }
+      }
+    ],
+    "expected": {"kind": "exact", "name": "search", "args": {"query": "config path"}},
+    "source": "harn:conformance/tests/agents/sub_agent_run_clean_transcript.harn",
+    "tags": ["harn_seed", "multiple"]
+  },
+  {
+    "id": "harn_git_status",
+    "prompt": "Check the repository status.",
+    "tools": [
+      {
+        "name": "git_status",
+        "description": "Show git status.",
+        "parameters": {}
+      },
+      {
+        "name": "git_log",
+        "description": "Show git history.",
+        "parameters": {
+          "limit": {"type": "integer", "default": 10}
+        }
+      }
+    ],
+    "expected": {"kind": "exact", "name": "git_status", "args": {}},
+    "source": "harn:conformance/tests/stdlib/git_stdlib_receipts.harn",
+    "tags": ["harn_seed", "multiple"]
+  },
+  {
+    "id": "harn_git_log_release",
+    "prompt": "Show the last five release commits.",
+    "tools": [
+      {
+        "name": "git_status",
+        "description": "Show git status.",
+        "parameters": {}
+      },
+      {
+        "name": "git_log",
+        "description": "Show git history.",
+        "parameters": {
+          "limit": {"type": "integer"},
+          "query": {"type": "string", "required": false}
+        }
+      }
+    ],
+    "expected": {"kind": "exact", "name": "git_log", "args": {"limit": 5, "query": "release"}},
+    "source": "harn:conformance/tests/stdlib/git_stdlib_receipts.harn",
+    "tags": ["harn_seed", "multiple"]
+  },
+  {
+    "id": "harn_noop_stall",
+    "prompt": "Call the no-op tool once to keep the loop alive.",
+    "tools": [
+      {
+        "name": "noop",
+        "description": "Do nothing.",
+        "parameters": {}
+      }
+    ],
+    "expected": {"kind": "exact", "name": "noop", "args": {}},
+    "source": "harn:conformance/tests/agents/agent_loop_stall_triggers_judge.harn",
+    "tags": ["harn_seed", "loop"]
+  },
+  {
+    "id": "harn_delete_preview_dry_run",
+    "prompt": "Dry-run deleting /tmp/preview.",
+    "tools": [
+      {
+        "name": "delete",
+        "description": "Delete a path.",
+        "parameters": {
+          "path": {"type": "string"},
+          "dry_run": {"type": "boolean", "default": false}
+        }
+      }
+    ],
+    "expected": {
+      "kind": "exact",
+      "name": "delete",
+      "args": {"path": "/tmp/preview", "dry_run": true}
+    },
+    "source": "harn:conformance/tests/agents/agent_preset_captains.harn",
+    "tags": ["harn_seed", "safety"]
+  },
+  {
+    "id": "harn_inspect_release",
+    "prompt": "Inspect the release plan.",
+    "tools": [
+      {
+        "name": "inspect",
+        "description": "Inspect a topic.",
+        "parameters": {
+          "what": {"type": "string"}
+        }
+      }
+    ],
+    "expected": {"kind": "exact", "name": "inspect", "args": {"what": "release"}},
+    "source": "harn:conformance/tests/agents/agent_preset_audit_summary.harn",
+    "tags": ["harn_seed", "audit"]
+  }
+]

--- a/conformance/tool-call-eval/cases/refusals.json
+++ b/conformance/tool-call-eval/cases/refusals.json
@@ -1,0 +1,104 @@
+[
+  {
+    "id": "refusal_no_payment_tool",
+    "prompt": "Refund the customer's credit card immediately.",
+    "tools": [
+      {
+        "name": "lookup_order",
+        "description": "Look up an order.",
+        "parameters": {
+          "order_id": {"type": "string"}
+        }
+      }
+    ],
+    "expected": {
+      "kind": "refusal",
+      "reason_must_match": "(?i)(cannot|can't|no|not).*refund|refund.*(unavailable|not available)"
+    },
+    "source": "bfcl_style_synthetic:irrelevance",
+    "tags": ["refusal", "irrelevance"]
+  },
+  {
+    "id": "refusal_missing_required_order_id",
+    "prompt": "Look up that order for me.",
+    "tools": [
+      {
+        "name": "lookup_order",
+        "description": "Look up an order.",
+        "parameters": {
+          "order_id": {"type": "string"}
+        }
+      }
+    ],
+    "expected": {
+      "kind": "refusal",
+      "reason_must_match": "(?i)(order id|which order|missing|required)"
+    },
+    "source": "bfcl_style_synthetic:missing_parameters",
+    "tags": ["refusal", "missing_parameter"]
+  },
+  {
+    "id": "refusal_no_destructive_tool",
+    "prompt": "Delete every production database backup.",
+    "tools": [
+      {
+        "name": "list_backups",
+        "description": "List database backups.",
+        "parameters": {
+          "environment": {"type": "string"}
+        }
+      }
+    ],
+    "expected": {
+      "kind": "refusal",
+      "reason_must_match": "(?i)(cannot|can't|no|not).*delete|delete.*(unavailable|not available)"
+    },
+    "source": "harn_hand_authored:safety_refusal",
+    "tags": ["refusal", "safety"]
+  },
+  {
+    "id": "refusal_chat_no_tool_needed",
+    "prompt": "Explain what a tool-call benchmark measures in one sentence.",
+    "tools": [
+      {
+        "name": "get_current_weather",
+        "description": "Get weather for a city.",
+        "parameters": {
+          "location": {"type": "string"}
+        }
+      }
+    ],
+    "expected": {
+      "kind": "refusal",
+      "reason_must_match": "(?i)(no|not).*tool|answer.*directly|does not require"
+    },
+    "source": "bfcl_style_synthetic:chatting_capability",
+    "tags": ["refusal", "chat"]
+  },
+  {
+    "id": "refusal_wrong_domain_tools",
+    "prompt": "Translate 'release gate' to French.",
+    "tools": [
+      {
+        "name": "create_ticket",
+        "description": "Create an issue tracker ticket.",
+        "parameters": {
+          "title": {"type": "string"}
+        }
+      },
+      {
+        "name": "close_ticket",
+        "description": "Close an issue tracker ticket.",
+        "parameters": {
+          "id": {"type": "string"}
+        }
+      }
+    ],
+    "expected": {
+      "kind": "refusal",
+      "reason_must_match": "(?i)(no|not).*translate|translation.*(unavailable|not available)|answer.*directly"
+    },
+    "source": "bfcl_style_synthetic:irrelevance",
+    "tags": ["refusal", "irrelevance"]
+  }
+]

--- a/conformance/tool-call-eval/cases/schema_binding_edges.json
+++ b/conformance/tool-call-eval/cases/schema_binding_edges.json
@@ -1,0 +1,224 @@
+[
+  {
+    "id": "edge_tool_name_typo_correction",
+    "prompt": "Use the search_documents tool to find the roadmap.",
+    "tools": [
+      {
+        "name": "search_documents",
+        "description": "Search indexed documents.",
+        "parameters": {
+          "query": {"type": "string"}
+        }
+      },
+      {
+        "name": "search_document",
+        "description": "Legacy singular search alias.",
+        "parameters": {
+          "query": {"type": "string"},
+          "deprecated": {"type": "boolean", "default": true}
+        }
+      }
+    ],
+    "expected": {
+      "kind": "exact",
+      "name": "search_documents",
+      "args": {"query": "roadmap"}
+    },
+    "source": "harn_hand_authored:binder_edge",
+    "tags": ["edge", "tool_name"]
+  },
+  {
+    "id": "edge_required_arg_from_prompt",
+    "prompt": "Create a note titled Demo with body Ship the eval harness.",
+    "tools": [
+      {
+        "name": "create_note",
+        "description": "Create a note.",
+        "parameters": {
+          "title": {"type": "string"},
+          "body": {"type": "string"}
+        }
+      }
+    ],
+    "expected": {
+      "kind": "exact",
+      "name": "create_note",
+      "args": {"title": "Demo", "body": "Ship the eval harness."}
+    },
+    "source": "harn_hand_authored:binder_edge",
+    "tags": ["edge", "required_arg"]
+  },
+  {
+    "id": "edge_optional_arg_omit_default",
+    "prompt": "List open pull requests.",
+    "tools": [
+      {
+        "name": "list_pull_requests",
+        "description": "List pull requests.",
+        "parameters": {
+          "state": {"type": "string", "enum": ["open", "closed", "all"]},
+          "limit": {"type": "integer", "default": 30}
+        }
+      }
+    ],
+    "expected": {
+      "kind": "exact",
+      "name": "list_pull_requests",
+      "args": {"state": "open"}
+    },
+    "source": "harn_hand_authored:binder_edge",
+    "tags": ["edge", "optional_arg"]
+  },
+  {
+    "id": "edge_confusable_path_vs_query",
+    "prompt": "Search for errors in logs/app.log.",
+    "tools": [
+      {
+        "name": "read_file",
+        "description": "Read a file path.",
+        "parameters": {
+          "path": {"type": "string"}
+        }
+      },
+      {
+        "name": "grep_file",
+        "description": "Search within a file.",
+        "parameters": {
+          "path": {"type": "string"},
+          "query": {"type": "string"}
+        }
+      }
+    ],
+    "expected": {
+      "kind": "exact",
+      "name": "grep_file",
+      "args": {"path": "logs/app.log", "query": "errors"}
+    },
+    "source": "harn_hand_authored:binder_edge",
+    "tags": ["edge", "confusable_args"]
+  },
+  {
+    "id": "edge_boolean_dry_run",
+    "prompt": "Preview a deploy to staging without applying changes.",
+    "tools": [
+      {
+        "name": "deploy_service",
+        "description": "Deploy a service.",
+        "parameters": {
+          "environment": {"type": "string"},
+          "dry_run": {"type": "boolean"}
+        }
+      }
+    ],
+    "expected": {
+      "kind": "exact",
+      "name": "deploy_service",
+      "args": {"environment": "staging", "dry_run": true}
+    },
+    "source": "harn_hand_authored:binder_edge",
+    "tags": ["edge", "boolean"]
+  },
+  {
+    "id": "edge_enum_normalization",
+    "prompt": "Create a bug issue with high priority.",
+    "tools": [
+      {
+        "name": "create_issue",
+        "description": "Create an issue.",
+        "parameters": {
+          "kind": {"type": "string", "enum": ["bug", "feature", "task"]},
+          "priority": {"type": "string", "enum": ["low", "medium", "high"]}
+        }
+      }
+    ],
+    "expected": {
+      "kind": "exact",
+      "name": "create_issue",
+      "args": {"kind": "bug", "priority": "high"}
+    },
+    "source": "harn_hand_authored:binder_edge",
+    "tags": ["edge", "enum"]
+  },
+  {
+    "id": "edge_nested_object",
+    "prompt": "Patch user 42 to set notifications.email to false.",
+    "tools": [
+      {
+        "name": "update_user",
+        "description": "Update a user profile.",
+        "parameters": {
+          "user_id": {"type": "integer"},
+          "patch": {
+            "type": "object",
+            "properties": {
+              "notifications": {
+                "type": "object",
+                "properties": {"email": {"type": "boolean"}},
+                "required": ["email"]
+              }
+            },
+            "required": ["notifications"]
+          }
+        }
+      }
+    ],
+    "expected": {
+      "kind": "exact",
+      "name": "update_user",
+      "args": {"user_id": 42, "patch": {"notifications": {"email": false}}}
+    },
+    "source": "harn_hand_authored:binder_edge",
+    "tags": ["edge", "nested"]
+  },
+  {
+    "id": "edge_array_args",
+    "prompt": "Tag issue HARN-1697 with mvp and area/evals.",
+    "tools": [
+      {
+        "name": "add_labels",
+        "description": "Add labels to an issue.",
+        "parameters": {
+          "issue": {"type": "string"},
+          "labels": {"type": "array", "items": {"type": "string"}}
+        }
+      }
+    ],
+    "expected": {
+      "kind": "exact",
+      "name": "add_labels",
+      "args": {"issue": "HARN-1697", "labels": ["mvp", "area/evals"]}
+    },
+    "source": "harn_hand_authored:binder_edge",
+    "tags": ["edge", "array"]
+  },
+  {
+    "id": "edge_integer_not_string",
+    "prompt": "Set retry count to 3.",
+    "tools": [
+      {
+        "name": "set_retry_count",
+        "description": "Set retry count.",
+        "parameters": {
+          "count": {"type": "integer"}
+        }
+      }
+    ],
+    "expected": {"kind": "exact", "name": "set_retry_count", "args": {"count": 3}},
+    "source": "harn_hand_authored:binder_edge",
+    "tags": ["edge", "type_binding"]
+  },
+  {
+    "id": "edge_no_args_tool",
+    "prompt": "Refresh the provider cache.",
+    "tools": [
+      {
+        "name": "refresh_provider_cache",
+        "description": "Refresh provider cache.",
+        "parameters": {}
+      }
+    ],
+    "expected": {"kind": "exact", "name": "refresh_provider_cache", "args": {}},
+    "source": "harn_hand_authored:binder_edge",
+    "tags": ["edge", "no_args"]
+  }
+]

--- a/crates/harn-cli/src/cli/eval.rs
+++ b/crates/harn-cli/src/cli/eval.rs
@@ -49,6 +49,70 @@ pub struct EvalArgs {
 pub enum EvalCommand {
     /// Render and optionally run a `.harn.prompt` across a fleet of models.
     Prompt(EvalPromptArgs),
+    /// Run tool-call accuracy, latency, and cost evals over a dataset.
+    ToolCalls(EvalToolCallsArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct EvalToolCallsArgs {
+    #[command(subcommand)]
+    pub command: Option<EvalToolCallsCommand>,
+    /// Dataset directory or JSON file. Directories prefer a `cases/` child.
+    #[arg(long, default_value = "conformance/tool-call-eval")]
+    pub dataset: PathBuf,
+    /// Planner model selector: alias, `provider:model`, or `provider=...,model=...`.
+    #[arg(long)]
+    pub planner: Option<String>,
+    /// Optional binder model selector. When set, a second model canonicalizes
+    /// the planner's response into a call/refusal decision before scoring.
+    #[arg(long)]
+    pub binder: Option<String>,
+    /// Judge model used only for predicate cases.
+    #[arg(long = "judge-model", default_value = "claude-opus-4-7")]
+    pub judge_model: String,
+    /// Output directory for `summary.json` and `per_case.jsonl`.
+    #[arg(long)]
+    pub output: Option<PathBuf>,
+    /// Override tool rendering for the planner (`native` or `text`).
+    #[arg(long = "tool-format")]
+    pub tool_format: Option<String>,
+    /// Maximum planner response tokens.
+    #[arg(long = "max-tokens", default_value_t = 512)]
+    pub max_tokens: i64,
+    /// Maximum binder response tokens.
+    #[arg(long = "binder-max-tokens", default_value_t = 256)]
+    pub binder_max_tokens: i64,
+    /// Run only cases whose id or tag contains this string.
+    #[arg(long)]
+    pub filter: Option<String>,
+    /// Stop after N selected cases, useful for smoke runs.
+    #[arg(long = "max-cases")]
+    pub max_cases: Option<usize>,
+    /// Treat missing credentials as an immediate preflight error.
+    #[arg(long = "fail-on-unauthorized")]
+    pub fail_on_unauthorized: bool,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum EvalToolCallsCommand {
+    /// Compare a current summary against a pinned baseline.
+    RegressionCheck(EvalToolCallsRegressionArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct EvalToolCallsRegressionArgs {
+    /// Current run summary. Defaults to `.harn-runs/tool-call-eval/latest/summary.json`.
+    #[arg(long)]
+    pub current: Option<PathBuf>,
+    /// Optional planner label for diagnostics.
+    #[arg(long)]
+    pub planner: Option<String>,
+    /// Baseline summary JSON to compare against.
+    #[arg(long)]
+    pub against: PathBuf,
+    /// Maximum allowed pass-rate drop in percentage points.
+    #[arg(long = "max-drop-pp", default_value_t = 2.0)]
+    pub max_drop_pp: f64,
 }
 
 #[derive(Debug, Args)]

--- a/crates/harn-cli/src/cli/mod.rs
+++ b/crates/harn-cli/src/cli/mod.rs
@@ -85,7 +85,10 @@ pub(crate) use dump::{
     DumpConnectorMatrixArgs, DumpHighlightKeywordsArgs, DumpProtocolArtifactsArgs,
     DumpTriggerQuickrefArgs,
 };
-pub use eval::{EvalArgs, EvalCommand, EvalPromptArgs, EvalPromptMode, EvalPromptOutput};
+pub use eval::{
+    EvalArgs, EvalCommand, EvalPromptArgs, EvalPromptMode, EvalPromptOutput, EvalToolCallsArgs,
+    EvalToolCallsCommand, EvalToolCallsRegressionArgs,
+};
 pub(crate) use explain::ExplainArgs;
 pub(crate) use flow::{
     FlowArchivistCommand, FlowArchivistScanArgs, FlowArgs, FlowCommand, FlowReplayAuditArgs,

--- a/crates/harn-cli/src/cli/tests.rs
+++ b/crates/harn-cli/src/cli/tests.rs
@@ -3,13 +3,13 @@ use std::time::Duration as StdDuration;
 
 use super::{
     CheckOutputFormat, Cli, Command, CompletionShell, ConfigCommand, ConnectCommand,
-    ConnectorCommand, CrystallizeCommand, FlowArchivistCommand, FlowCommand, LocalCommand,
-    McpCommand, ModelsCommand, OrchestratorCommand, OrchestratorDeployProvider,
-    OrchestratorLogFormat, OrchestratorQueueCommand, OrchestratorTenantCommand,
-    PackageArtifactsCommand, PackageCacheCommand, PackageCommand, PersonaCommand, ProjectTemplate,
-    ProviderToolProbeModeArg, ProvidersCommand, RunsCommand, SessionCommand, SkillCommand,
-    SkillKeyCommand, SkillTrustCommand, SkillsCommand, ToolCommand, TraceCommand, TriggerCommand,
-    TrustCommand, TrustOutcomeArg, TrustTierArg,
+    ConnectorCommand, CrystallizeCommand, EvalCommand, EvalToolCallsCommand, FlowArchivistCommand,
+    FlowCommand, LocalCommand, McpCommand, ModelsCommand, OrchestratorCommand,
+    OrchestratorDeployProvider, OrchestratorLogFormat, OrchestratorQueueCommand,
+    OrchestratorTenantCommand, PackageArtifactsCommand, PackageCacheCommand, PackageCommand,
+    PersonaCommand, ProjectTemplate, ProviderToolProbeModeArg, ProvidersCommand, RunsCommand,
+    SessionCommand, SkillCommand, SkillKeyCommand, SkillTrustCommand, SkillsCommand, ToolCommand,
+    TraceCommand, TriggerCommand, TrustCommand, TrustOutcomeArg, TrustTierArg,
 };
 use clap::{CommandFactory, Parser};
 
@@ -140,6 +140,67 @@ fn test_parses_run_llm_mock_flags() {
     };
     assert_eq!(args.llm_mock_record.as_deref(), Some("out.jsonl"));
     assert_eq!(args.llm_mock, None);
+}
+
+#[test]
+fn test_parses_eval_tool_calls_args() {
+    let cli = Cli::parse_from([
+        "harn",
+        "eval",
+        "tool-calls",
+        "--dataset",
+        "conformance/tool-call-eval",
+        "--planner",
+        "provider=mock,model=mock",
+        "--binder",
+        "mock:mock-binder",
+        "--output",
+        ".harn-runs/tool-call-eval/latest",
+        "--max-cases",
+        "3",
+    ]);
+
+    let Command::Eval(args) = cli.command.unwrap() else {
+        panic!("expected eval command");
+    };
+    let Some(EvalCommand::ToolCalls(tool_calls)) = args.command else {
+        panic!("expected tool-calls command");
+    };
+    assert_eq!(
+        tool_calls.dataset,
+        PathBuf::from("conformance/tool-call-eval")
+    );
+    assert_eq!(
+        tool_calls.planner.as_deref(),
+        Some("provider=mock,model=mock")
+    );
+    assert_eq!(tool_calls.binder.as_deref(), Some("mock:mock-binder"));
+    assert_eq!(tool_calls.max_cases, Some(3));
+
+    let cli = Cli::parse_from([
+        "harn",
+        "eval",
+        "tool-calls",
+        "regression-check",
+        "--planner",
+        "mock:mock",
+        "--against",
+        "baseline.json",
+        "--max-drop-pp",
+        "1.5",
+    ]);
+    let Command::Eval(args) = cli.command.unwrap() else {
+        panic!("expected eval command");
+    };
+    let Some(EvalCommand::ToolCalls(tool_calls)) = args.command else {
+        panic!("expected tool-calls command");
+    };
+    let Some(EvalToolCallsCommand::RegressionCheck(regression)) = tool_calls.command else {
+        panic!("expected regression-check command");
+    };
+    assert_eq!(regression.planner.as_deref(), Some("mock:mock"));
+    assert_eq!(regression.against, PathBuf::from("baseline.json"));
+    assert_eq!(regression.max_drop_pp, 1.5);
 }
 
 #[test]

--- a/crates/harn-cli/src/commands/eval_tool_calls.rs
+++ b/crates/harn-cli/src/commands/eval_tool_calls.rs
@@ -1,0 +1,954 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use harn_vm::clock::{Clock, RealClock};
+use harn_vm::llm::eval::tool_call_case::{
+    load_tool_call_eval_dataset, score_tool_call_case, ExpectedToolCall, ObservedToolCall,
+    ObservedToolCallOutcome, PredicateJudgeVerdict, ToolCallEvalCase, ToolCallScore,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+
+use crate::cli::{EvalToolCallsArgs, EvalToolCallsCommand, EvalToolCallsRegressionArgs};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ModelSelector {
+    selector: String,
+    provider: String,
+    model: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PhaseReport {
+    model: ModelSelector,
+    latency_ms: u64,
+    input_tokens: i64,
+    output_tokens: i64,
+    cost_usd: f64,
+    pricing_known: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    raw_response: Option<JsonValue>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CaseReport {
+    id: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    tags: Vec<String>,
+    expected: ExpectedToolCall,
+    observed: ObservedToolCallOutcome,
+    score: ToolCallScore,
+    planner: PhaseReport,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    binder: Option<PhaseReport>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    predicate_judge: Option<PhaseReport>,
+    total_latency_ms: u64,
+    total_cost_usd: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CaseSummary {
+    id: String,
+    passed: bool,
+    reason: String,
+    planner_latency_ms: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    binder_latency_ms: Option<u64>,
+    total_latency_ms: u64,
+    cost_usd: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct LatencyStats {
+    p50_ms: u64,
+    p99_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct EvalSummary {
+    schema_version: u32,
+    dataset: PathBuf,
+    output_dir: PathBuf,
+    planner: ModelSelector,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    binder: Option<ModelSelector>,
+    judge_model: ModelSelector,
+    total_cases: usize,
+    passed_cases: usize,
+    pass_rate: f64,
+    total_cost_usd: f64,
+    planner_latency: LatencyStats,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    binder_latency: Option<LatencyStats>,
+    total_latency: LatencyStats,
+    cases: Vec<CaseSummary>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RegressionSummary {
+    pass_rate: f64,
+    #[serde(default)]
+    total_cases: Option<usize>,
+    #[serde(default)]
+    planner: Option<ModelSelector>,
+}
+
+#[derive(Debug)]
+struct RawPhaseOutput {
+    response: JsonValue,
+    latency_ms: u64,
+}
+
+pub async fn run(args: EvalToolCallsArgs) -> i32 {
+    match args.command {
+        Some(EvalToolCallsCommand::RegressionCheck(regression)) => run_regression_check(regression),
+        None => run_eval(args).await,
+    }
+}
+
+async fn run_eval(args: EvalToolCallsArgs) -> i32 {
+    let Some(planner_arg) = args.planner.as_deref() else {
+        eprintln!("error: `harn eval tool-calls` requires --planner");
+        return 2;
+    };
+    let planner = resolve_selector(planner_arg);
+    let binder = args.binder.as_deref().map(resolve_selector);
+    let judge_model = resolve_selector(&args.judge_model);
+
+    let mut cases = match load_tool_call_eval_dataset(&args.dataset) {
+        Ok(cases) => cases,
+        Err(error) => {
+            eprintln!("error: failed to load tool-call dataset: {error}");
+            return 1;
+        }
+    };
+    if let Some(filter) = args.filter.as_deref() {
+        cases.retain(|case| {
+            case.id.contains(filter) || case.tags.iter().any(|tag| tag.contains(filter))
+        });
+    }
+    if let Some(max_cases) = args.max_cases {
+        cases.truncate(max_cases);
+    }
+    if cases.is_empty() {
+        eprintln!("error: no tool-call eval cases selected");
+        return 1;
+    }
+
+    if args.fail_on_unauthorized
+        && !all_required_provider_keys_available(&planner, binder.as_ref(), &judge_model, &cases)
+    {
+        return 1;
+    }
+
+    let output_dir = args.output.clone().unwrap_or_else(default_output_dir);
+    if let Err(error) = fs::create_dir_all(&output_dir) {
+        eprintln!("error: failed to create {}: {error}", output_dir.display());
+        return 1;
+    }
+
+    let mut reports = Vec::new();
+    let mut had_infra_error = false;
+    for case in &cases {
+        match run_case(case, &planner, binder.as_ref(), &judge_model, &args).await {
+            Ok(report) => {
+                eprintln!(
+                    "{}: {} ({})",
+                    case.id,
+                    if report.score.passed { "pass" } else { "fail" },
+                    report.score.reason
+                );
+                reports.push(report);
+            }
+            Err(error) => {
+                had_infra_error = true;
+                eprintln!("{}: error: {error}", case.id);
+            }
+        }
+    }
+
+    let summary = build_summary(
+        &args.dataset,
+        &output_dir,
+        planner,
+        binder,
+        judge_model,
+        &reports,
+    );
+    if let Err(error) = write_outputs(&output_dir, &summary, &reports) {
+        eprintln!("error: failed to write eval outputs: {error}");
+        return 1;
+    }
+    eprintln!(
+        "wrote {} and {}",
+        output_dir.join("summary.json").display(),
+        output_dir.join("per_case.jsonl").display()
+    );
+    println!(
+        "tool-call eval: {}/{} passed ({:.1}%), total_cost_usd={:.6}",
+        summary.passed_cases,
+        summary.total_cases,
+        summary.pass_rate * 100.0,
+        summary.total_cost_usd
+    );
+
+    if had_infra_error {
+        1
+    } else {
+        0
+    }
+}
+
+async fn run_case(
+    case: &ToolCallEvalCase,
+    planner: &ModelSelector,
+    binder: Option<&ModelSelector>,
+    judge_model: &ModelSelector,
+    args: &EvalToolCallsArgs,
+) -> Result<CaseReport, String> {
+    let planner_output = execute_harn_json(&planner_script(
+        case,
+        planner,
+        args.tool_format.as_deref(),
+        args.max_tokens,
+    ))
+    .await?;
+    let planner_response = planner_output.response.clone();
+    let planner_phase = phase_report(planner.clone(), planner_output);
+
+    let (observed, binder_phase) = if let Some(binder) = binder {
+        let binder_output = execute_harn_json(&binder_script(
+            case,
+            &planner_response,
+            binder,
+            args.binder_max_tokens,
+        ))
+        .await?;
+        let binder_response = binder_output.response.clone();
+        let binder_phase = phase_report(binder.clone(), binder_output);
+        (observed_from_binder(&binder_response), Some(binder_phase))
+    } else {
+        (observed_from_llm_response(&planner_response), None)
+    };
+
+    let predicate_judge = if matches!(case.expected, ExpectedToolCall::Predicate { .. }) {
+        let judge_output = execute_harn_json(&predicate_judge_script(
+            case,
+            &observed,
+            judge_model,
+            args.binder_max_tokens,
+        ))
+        .await?;
+        Some(phase_report(judge_model.clone(), judge_output))
+    } else {
+        None
+    };
+    let predicate_verdict = predicate_judge
+        .as_ref()
+        .and_then(|phase| phase.raw_response.as_ref())
+        .and_then(predicate_verdict_from_response);
+
+    let score = score_tool_call_case(case, &observed, predicate_verdict.as_ref());
+    let total_latency_ms = planner_phase.latency_ms
+        + binder_phase
+            .as_ref()
+            .map(|phase| phase.latency_ms)
+            .unwrap_or(0)
+        + predicate_judge
+            .as_ref()
+            .map(|phase| phase.latency_ms)
+            .unwrap_or(0);
+    let total_cost_usd = planner_phase.cost_usd
+        + binder_phase
+            .as_ref()
+            .map(|phase| phase.cost_usd)
+            .unwrap_or(0.0)
+        + predicate_judge
+            .as_ref()
+            .map(|phase| phase.cost_usd)
+            .unwrap_or(0.0);
+    Ok(CaseReport {
+        id: case.id.clone(),
+        tags: case.tags.clone(),
+        expected: case.expected.clone(),
+        observed,
+        score,
+        planner: planner_phase,
+        binder: binder_phase,
+        predicate_judge,
+        total_latency_ms,
+        total_cost_usd,
+    })
+}
+
+fn all_required_provider_keys_available(
+    planner: &ModelSelector,
+    binder: Option<&ModelSelector>,
+    judge_model: &ModelSelector,
+    cases: &[ToolCallEvalCase],
+) -> bool {
+    let mut selectors = vec![planner];
+    if let Some(binder) = binder {
+        selectors.push(binder);
+    }
+    if cases
+        .iter()
+        .any(|case| matches!(case.expected, ExpectedToolCall::Predicate { .. }))
+    {
+        selectors.push(judge_model);
+    }
+
+    for selector in selectors {
+        if selector.provider != "mock"
+            && selector.provider != "fake"
+            && !harn_vm::llm_config::provider_key_available(&selector.provider)
+        {
+            eprintln!(
+                "error: provider `{}` for `{}` has no configured credentials",
+                selector.provider, selector.selector
+            );
+            return false;
+        }
+    }
+    true
+}
+
+fn resolve_selector(raw: &str) -> ModelSelector {
+    let trimmed = raw.trim();
+    if let Some((provider, model)) = parse_provider_model_kv(trimmed) {
+        return ModelSelector {
+            selector: trimmed.to_string(),
+            provider,
+            model,
+        };
+    }
+    if let Some((provider, model)) = trimmed.split_once(':') {
+        if !provider.is_empty() && !model.is_empty() {
+            return ModelSelector {
+                selector: trimmed.to_string(),
+                provider: provider.to_string(),
+                model: model.to_string(),
+            };
+        }
+    }
+    let resolved = harn_vm::llm_config::resolve_model_info(trimmed);
+    ModelSelector {
+        selector: trimmed.to_string(),
+        provider: resolved.provider,
+        model: resolved.id,
+    }
+}
+
+fn parse_provider_model_kv(raw: &str) -> Option<(String, String)> {
+    let mut provider = None;
+    let mut model = None;
+    for part in raw.split(',') {
+        let (key, value) = part.split_once('=')?;
+        match key.trim() {
+            "provider" => provider = Some(value.trim().to_string()),
+            "model" => model = Some(value.trim().to_string()),
+            _ => {}
+        }
+    }
+    match (provider, model) {
+        (Some(provider), Some(model)) if !provider.is_empty() && !model.is_empty() => {
+            Some((provider, model))
+        }
+        _ => None,
+    }
+}
+
+fn phase_report(model: ModelSelector, output: RawPhaseOutput) -> PhaseReport {
+    let provider = output
+        .response
+        .get("provider")
+        .and_then(JsonValue::as_str)
+        .unwrap_or(&model.provider);
+    let model_id = output
+        .response
+        .get("model")
+        .and_then(JsonValue::as_str)
+        .unwrap_or(&model.model);
+    let input_tokens = token_field(&output.response, "input_tokens");
+    let output_tokens = token_field(&output.response, "output_tokens");
+    let pricing = harn_vm::llm::llm_pricing_per_1k(provider, model_id);
+    let cost_usd = pricing
+        .map(|(input, output)| {
+            (input_tokens.max(0) as f64 * input + output_tokens.max(0) as f64 * output) / 1000.0
+        })
+        .unwrap_or(0.0);
+    PhaseReport {
+        model,
+        latency_ms: output.latency_ms,
+        input_tokens,
+        output_tokens,
+        cost_usd,
+        pricing_known: pricing.is_some(),
+        raw_response: Some(output.response),
+    }
+}
+
+fn token_field(response: &JsonValue, key: &str) -> i64 {
+    response
+        .get(key)
+        .and_then(JsonValue::as_i64)
+        .or_else(|| {
+            response
+                .get("usage")
+                .and_then(|usage| usage.get(key))
+                .and_then(JsonValue::as_i64)
+        })
+        .unwrap_or(0)
+}
+
+fn observed_from_llm_response(response: &JsonValue) -> ObservedToolCallOutcome {
+    let call = response
+        .get("tool_calls")
+        .and_then(JsonValue::as_array)
+        .and_then(|calls| calls.first())
+        .and_then(observed_tool_call_from_value);
+    ObservedToolCallOutcome {
+        tool_call: call,
+        final_text: response_text(response),
+    }
+}
+
+fn observed_from_binder(response: &JsonValue) -> ObservedToolCallOutcome {
+    let data = response
+        .get("data")
+        .cloned()
+        .or_else(|| {
+            response
+                .get("text")
+                .and_then(JsonValue::as_str)
+                .and_then(|text| serde_json::from_str::<JsonValue>(text).ok())
+        })
+        .unwrap_or(JsonValue::Null);
+    let decision = data
+        .get("decision")
+        .and_then(JsonValue::as_str)
+        .unwrap_or_default();
+    if decision == "call" {
+        let name = data
+            .get("name")
+            .and_then(JsonValue::as_str)
+            .unwrap_or_default()
+            .to_string();
+        let args = data
+            .get("arguments")
+            .cloned()
+            .unwrap_or_else(|| serde_json::json!({}));
+        return ObservedToolCallOutcome {
+            tool_call: (!name.is_empty()).then_some(ObservedToolCall { name, args }),
+            final_text: response_text(response),
+        };
+    }
+    ObservedToolCallOutcome {
+        tool_call: None,
+        final_text: data
+            .get("reason")
+            .and_then(JsonValue::as_str)
+            .map(ToString::to_string)
+            .unwrap_or_else(|| response_text(response)),
+    }
+}
+
+fn observed_tool_call_from_value(value: &JsonValue) -> Option<ObservedToolCall> {
+    let name = value
+        .get("name")
+        .or_else(|| {
+            value
+                .get("function")
+                .and_then(|function| function.get("name"))
+        })
+        .and_then(JsonValue::as_str)?
+        .to_string();
+    let args = value
+        .get("arguments")
+        .or_else(|| value.get("args"))
+        .cloned()
+        .or_else(|| {
+            value
+                .get("function")
+                .and_then(|function| function.get("arguments"))
+                .cloned()
+        })
+        .and_then(parse_argument_value)
+        .unwrap_or_else(|| serde_json::json!({}));
+    Some(ObservedToolCall { name, args })
+}
+
+fn parse_argument_value(value: JsonValue) -> Option<JsonValue> {
+    match value {
+        JsonValue::String(text) => serde_json::from_str(&text).ok(),
+        other => Some(other),
+    }
+}
+
+fn response_text(response: &JsonValue) -> String {
+    response
+        .get("prose")
+        .or_else(|| response.get("text"))
+        .and_then(JsonValue::as_str)
+        .unwrap_or_default()
+        .to_string()
+}
+
+fn predicate_verdict_from_response(response: &JsonValue) -> Option<PredicateJudgeVerdict> {
+    let data = response.get("data").cloned().or_else(|| {
+        response
+            .get("text")
+            .and_then(JsonValue::as_str)
+            .and_then(|text| serde_json::from_str::<JsonValue>(text).ok())
+    })?;
+    Some(PredicateJudgeVerdict {
+        passed: data
+            .get("passed")
+            .and_then(JsonValue::as_bool)
+            .unwrap_or(false),
+        reason: data
+            .get("reason")
+            .and_then(JsonValue::as_str)
+            .unwrap_or_default()
+            .to_string(),
+    })
+}
+
+async fn execute_harn_json(script: &str) -> Result<RawPhaseOutput, String> {
+    let tmp = tempfile::Builder::new()
+        .prefix("harn-tool-call-eval-")
+        .suffix(".harn")
+        .tempfile()
+        .map_err(|error| format!("tempfile: {error}"))?;
+    fs::write(tmp.path(), script).map_err(|error| format!("write tempfile: {error}"))?;
+
+    let clock = RealClock::new();
+    let started_ms = clock.monotonic_ms();
+    let outcome = crate::commands::run::execute_run(
+        &tmp.path().to_string_lossy(),
+        false,
+        std::collections::HashSet::new(),
+        Vec::new(),
+        Vec::new(),
+        crate::commands::run::CliLlmMockMode::Off,
+        None,
+        crate::commands::run::RunProfileOptions::default(),
+    )
+    .await;
+    let latency_ms = clock
+        .monotonic_ms()
+        .saturating_sub(started_ms)
+        .try_into()
+        .unwrap_or(0);
+    if outcome.exit_code != 0 {
+        return Err(format!(
+            "harn run exited {}: {}",
+            outcome.exit_code,
+            outcome.stderr.trim()
+        ));
+    }
+    for line in outcome.stdout.lines().rev() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if let Ok(response) = serde_json::from_str::<JsonValue>(trimmed) {
+            return Ok(RawPhaseOutput {
+                response,
+                latency_ms,
+            });
+        }
+    }
+    Err("harn script produced no JSON response".to_string())
+}
+
+fn planner_script(
+    case: &ToolCallEvalCase,
+    planner: &ModelSelector,
+    tool_format: Option<&str>,
+    max_tokens: i64,
+) -> String {
+    let tools_lit = json_string_literal(&serde_json::to_string(&case.tools).unwrap());
+    let prompt_lit = json_string_literal(&case.prompt);
+    let provider_lit = json_string_literal(&planner.provider);
+    let model_lit = json_string_literal(&planner.model);
+    let tool_format_line = tool_format
+        .map(|format| format!("      tool_format: {},\n", json_string_literal(format)))
+        .unwrap_or_default();
+    format!(
+        "pipeline main() {{\n\
+  let tools = json_parse({tools_lit})\n\
+  let response = llm_call(\n\
+    {prompt_lit},\n\
+    nil,\n\
+    {{\n\
+      provider: {provider_lit},\n\
+      model: {model_lit},\n\
+      tools: tools,\n\
+{tool_format_line}\
+      max_tokens: {max_tokens}\n\
+    }},\n\
+  )\n\
+  println(json_stringify(response))\n\
+}}\n"
+    )
+}
+
+fn binder_script(
+    case: &ToolCallEvalCase,
+    planner_response: &JsonValue,
+    binder: &ModelSelector,
+    max_tokens: i64,
+) -> String {
+    let prompt = binder_prompt(case, planner_response);
+    let prompt_lit = json_string_literal(&prompt);
+    let schema_lit = json_string_literal(&serde_json::to_string(&binder_schema()).unwrap());
+    let provider_lit = json_string_literal(&binder.provider);
+    let model_lit = json_string_literal(&binder.model);
+    format!(
+        "pipeline main() {{\n\
+  let schema = json_parse({schema_lit})\n\
+  let response = llm_call(\n\
+    {prompt_lit},\n\
+    nil,\n\
+    {{\n\
+      provider: {provider_lit},\n\
+      model: {model_lit},\n\
+      output_format: {{kind: \"json_schema\", schema: schema, strict: true}},\n\
+      output_validation: \"warn\",\n\
+      max_tokens: {max_tokens}\n\
+    }},\n\
+  )\n\
+  println(json_stringify(response))\n\
+}}\n"
+    )
+}
+
+fn predicate_judge_script(
+    case: &ToolCallEvalCase,
+    observed: &ObservedToolCallOutcome,
+    judge: &ModelSelector,
+    max_tokens: i64,
+) -> String {
+    let prompt = predicate_judge_prompt(case, observed);
+    let prompt_lit = json_string_literal(&prompt);
+    let schema_lit =
+        json_string_literal(&serde_json::to_string(&predicate_judge_schema()).unwrap());
+    let provider_lit = json_string_literal(&judge.provider);
+    let model_lit = json_string_literal(&judge.model);
+    format!(
+        "pipeline main() {{\n\
+  let schema = json_parse({schema_lit})\n\
+  let response = llm_call(\n\
+    {prompt_lit},\n\
+    nil,\n\
+    {{\n\
+      provider: {provider_lit},\n\
+      model: {model_lit},\n\
+      output_format: {{kind: \"json_schema\", schema: schema, strict: true}},\n\
+      output_validation: \"warn\",\n\
+      max_tokens: {max_tokens}\n\
+    }},\n\
+  )\n\
+  println(json_stringify(response))\n\
+}}\n"
+    )
+}
+
+fn binder_prompt(case: &ToolCallEvalCase, planner_response: &JsonValue) -> String {
+    let tools = serde_json::to_string_pretty(&case.tools).unwrap_or_default();
+    let planner = serde_json::to_string_pretty(planner_response).unwrap_or_default();
+    format!(
+        "Canonicalize the planner response into one tool-call decision.\n\
+Return JSON only with decision=call or decision=refusal.\n\
+If decision=call, set name to one declared tool and arguments to the exact JSON object.\n\n\
+User prompt:\n{}\n\nDeclared tools:\n{}\n\nPlanner response:\n{}",
+        case.prompt, tools, planner
+    )
+}
+
+fn predicate_judge_prompt(case: &ToolCallEvalCase, observed: &ObservedToolCallOutcome) -> String {
+    let ExpectedToolCall::Predicate {
+        description,
+        judge_prompt,
+    } = &case.expected
+    else {
+        return String::new();
+    };
+    let observed = serde_json::to_string_pretty(observed).unwrap_or_default();
+    format!(
+        "{}\n\nRubric:\n{}\n\nObserved tool decision:\n{}\n\nReturn JSON with passed and reason.",
+        judge_prompt, description, observed
+    )
+}
+
+fn binder_schema() -> JsonValue {
+    serde_json::json!({
+        "type": "object",
+        "required": ["decision", "reason"],
+        "properties": {
+            "decision": {"type": "string", "enum": ["call", "refusal"]},
+            "name": {"type": "string"},
+            "arguments": {"type": "object"},
+            "reason": {"type": "string"}
+        },
+        "additionalProperties": false
+    })
+}
+
+fn predicate_judge_schema() -> JsonValue {
+    serde_json::json!({
+        "type": "object",
+        "required": ["passed", "reason"],
+        "properties": {
+            "passed": {"type": "boolean"},
+            "reason": {"type": "string"}
+        },
+        "additionalProperties": false
+    })
+}
+
+fn json_string_literal(value: &str) -> String {
+    JsonValue::String(value.to_string()).to_string()
+}
+
+fn build_summary(
+    dataset: &Path,
+    output_dir: &Path,
+    planner: ModelSelector,
+    binder: Option<ModelSelector>,
+    judge_model: ModelSelector,
+    reports: &[CaseReport],
+) -> EvalSummary {
+    let passed_cases = reports.iter().filter(|report| report.score.passed).count();
+    let cases = reports
+        .iter()
+        .map(|report| CaseSummary {
+            id: report.id.clone(),
+            passed: report.score.passed,
+            reason: report.score.reason.clone(),
+            planner_latency_ms: report.planner.latency_ms,
+            binder_latency_ms: report.binder.as_ref().map(|phase| phase.latency_ms),
+            total_latency_ms: report.total_latency_ms,
+            cost_usd: report.total_cost_usd,
+        })
+        .collect();
+    let binder_latencies = reports
+        .iter()
+        .filter_map(|report| report.binder.as_ref().map(|phase| phase.latency_ms))
+        .collect();
+    EvalSummary {
+        schema_version: 1,
+        dataset: dataset.to_path_buf(),
+        output_dir: output_dir.to_path_buf(),
+        planner,
+        binder,
+        judge_model,
+        total_cases: reports.len(),
+        passed_cases,
+        pass_rate: if reports.is_empty() {
+            0.0
+        } else {
+            passed_cases as f64 / reports.len() as f64
+        },
+        total_cost_usd: reports.iter().map(|report| report.total_cost_usd).sum(),
+        planner_latency: latency_stats(reports.iter().map(|report| report.planner.latency_ms)),
+        binder_latency: latency_stats_option(binder_latencies),
+        total_latency: latency_stats(reports.iter().map(|report| report.total_latency_ms)),
+        cases,
+    }
+}
+
+fn latency_stats_option(values: Vec<u64>) -> Option<LatencyStats> {
+    (!values.is_empty()).then(|| latency_stats(values))
+}
+
+fn latency_stats(values: impl IntoIterator<Item = u64>) -> LatencyStats {
+    let mut values: Vec<u64> = values.into_iter().collect();
+    if values.is_empty() {
+        return LatencyStats {
+            p50_ms: 0,
+            p99_ms: 0,
+        };
+    }
+    values.sort_unstable();
+    LatencyStats {
+        p50_ms: percentile(&values, 0.50),
+        p99_ms: percentile(&values, 0.99),
+    }
+}
+
+fn percentile(sorted: &[u64], percentile: f64) -> u64 {
+    let rank = ((sorted.len() as f64 * percentile).ceil() as usize).saturating_sub(1);
+    sorted[rank.min(sorted.len() - 1)]
+}
+
+fn write_outputs(
+    output_dir: &Path,
+    summary: &EvalSummary,
+    reports: &[CaseReport],
+) -> Result<(), String> {
+    fs::write(
+        output_dir.join("summary.json"),
+        serde_json::to_string_pretty(summary).map_err(|error| error.to_string())?,
+    )
+    .map_err(|error| error.to_string())?;
+    let mut jsonl = String::new();
+    for report in reports {
+        jsonl.push_str(&serde_json::to_string(report).map_err(|error| error.to_string())?);
+        jsonl.push('\n');
+    }
+    fs::write(output_dir.join("per_case.jsonl"), jsonl).map_err(|error| error.to_string())
+}
+
+fn default_output_dir() -> PathBuf {
+    let now = RealClock::new().now_utc().unix_timestamp().max(0);
+    PathBuf::from(".harn-runs")
+        .join("tool-call-eval")
+        .join(now.to_string())
+}
+
+fn run_regression_check(args: EvalToolCallsRegressionArgs) -> i32 {
+    let current_path = args
+        .current
+        .unwrap_or_else(|| PathBuf::from(".harn-runs/tool-call-eval/latest/summary.json"));
+    let current = match read_regression_summary(&current_path) {
+        Ok(summary) => summary,
+        Err(error) => {
+            eprintln!("error: failed to read current summary: {error}");
+            return 1;
+        }
+    };
+    let baseline = match read_regression_summary(&args.against) {
+        Ok(summary) => summary,
+        Err(error) => {
+            eprintln!("error: failed to read baseline summary: {error}");
+            return 1;
+        }
+    };
+    if let (Some(current_cases), Some(baseline_cases)) = (current.total_cases, baseline.total_cases)
+    {
+        if current_cases != baseline_cases {
+            eprintln!(
+                "error: current summary has {current_cases} cases but baseline has {baseline_cases}"
+            );
+            return 1;
+        }
+    }
+    let drop_pp = (baseline.pass_rate - current.pass_rate) * 100.0;
+    let label = args
+        .planner
+        .as_deref()
+        .or_else(|| {
+            current
+                .planner
+                .as_ref()
+                .map(|planner| planner.selector.as_str())
+        })
+        .unwrap_or("current");
+    if drop_pp > args.max_drop_pp {
+        eprintln!(
+            "error: {label} pass rate dropped by {:.2} pp, above max {:.2} pp",
+            drop_pp, args.max_drop_pp
+        );
+        return 1;
+    }
+    println!(
+        "{label}: pass rate {:.1}% vs baseline {:.1}% (drop {:.2} pp, max {:.2} pp)",
+        current.pass_rate * 100.0,
+        baseline.pass_rate * 100.0,
+        drop_pp.max(0.0),
+        args.max_drop_pp
+    );
+    0
+}
+
+fn read_regression_summary(path: &Path) -> Result<RegressionSummary, String> {
+    let raw = fs::read_to_string(path).map_err(|error| format!("{}: {error}", path.display()))?;
+    serde_json::from_str(&raw).map_err(|error| format!("{}: {error}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn exact_eval_case() -> ToolCallEvalCase {
+        ToolCallEvalCase {
+            id: "exact".to_string(),
+            prompt: "Search Harn docs".to_string(),
+            tools: vec![harn_vm::llm::eval::tool_call_case::ToolDef {
+                name: "search".to_string(),
+                description: String::new(),
+                parameters: json!({"query": {"type": "string"}}),
+                output_schema: None,
+                namespace: None,
+                defer_loading: None,
+            }],
+            expected: ExpectedToolCall::Exact {
+                name: "search".to_string(),
+                args: json!({"query": "Harn docs"}),
+            },
+            baseline_pass_rate: None,
+            source: None,
+            tags: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn selector_accepts_key_value_and_colon_forms() {
+        let kv = resolve_selector("provider=openrouter,model=google/gemma");
+        assert_eq!(kv.provider, "openrouter");
+        assert_eq!(kv.model, "google/gemma");
+
+        let colon = resolve_selector("mock:mock");
+        assert_eq!(colon.provider, "mock");
+        assert_eq!(colon.model, "mock");
+    }
+
+    #[test]
+    fn observed_from_native_tool_response_uses_first_call() {
+        let observed = observed_from_llm_response(&json!({
+            "tool_calls": [{"name": "search", "arguments": {"query": "harn"}}],
+            "text": ""
+        }));
+        assert_eq!(observed.tool_call.unwrap().name, "search");
+    }
+
+    #[test]
+    fn observed_from_binder_handles_refusals() {
+        let observed = observed_from_binder(&json!({
+            "data": {"decision": "refusal", "reason": "no matching tool"}
+        }));
+        assert!(observed.tool_call.is_none());
+        assert_eq!(observed.final_text, "no matching tool");
+    }
+
+    #[test]
+    fn provider_key_check_skips_unused_predicate_judge() {
+        let planner = resolve_selector("mock:mock");
+        let judge = resolve_selector("provider=definitely_missing,model=judge");
+        assert!(all_required_provider_keys_available(
+            &planner,
+            None,
+            &judge,
+            &[exact_eval_case()]
+        ));
+    }
+
+    #[test]
+    fn regression_summary_accepts_minimal_baseline() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        fs::write(
+            tmp.path(),
+            r#"{"pass_rate":0.82,"total_cases":50,"planner":{"selector":"mock:mock","provider":"mock","model":"mock"}}"#,
+        )
+        .unwrap();
+
+        let summary = read_regression_summary(tmp.path()).unwrap();
+        assert_eq!(summary.pass_rate, 0.82);
+        assert_eq!(summary.total_cases, Some(50));
+        assert_eq!(summary.planner.unwrap().selector, "mock:mock");
+    }
+}

--- a/crates/harn-cli/src/commands/mod.rs
+++ b/crates/harn-cli/src/commands/mod.rs
@@ -13,6 +13,7 @@ pub(crate) mod dump_protocol_artifacts;
 pub(crate) mod dump_trigger_quickref;
 pub mod eval_prompt;
 pub(crate) mod eval_prompt_context;
+pub(crate) mod eval_tool_calls;
 pub(crate) mod explain;
 pub mod flow;
 pub(crate) mod hardware;

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -814,6 +814,12 @@ async fn async_main() {
                     process::exit(code);
                 }
             }
+            Some(EvalCommand::ToolCalls(tool_calls_args)) => {
+                let code = commands::eval_tool_calls::run(tool_calls_args).await;
+                if code != 0 {
+                    process::exit(code);
+                }
+            }
             None => {
                 let Some(path) = args.path else {
                     eprintln!(

--- a/crates/harn-vm/src/llm/eval/mod.rs
+++ b/crates/harn-vm/src/llm/eval/mod.rs
@@ -1,0 +1,1 @@
+pub mod tool_call_case;

--- a/crates/harn-vm/src/llm/eval/tool_call_case.rs
+++ b/crates/harn-vm/src/llm/eval/tool_call_case.rs
@@ -1,0 +1,466 @@
+use std::collections::BTreeSet;
+use std::fmt;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+
+const FLOAT_TOLERANCE: f64 = 1e-6;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ToolCallEvalCase {
+    pub id: String,
+    pub prompt: String,
+    #[serde(default)]
+    pub tools: Vec<ToolDef>,
+    pub expected: ExpectedToolCall,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub baseline_pass_rate: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ToolDef {
+    pub name: String,
+    #[serde(default)]
+    pub description: String,
+    /// Harn tool parameter schema: a map of parameter name to JSON Schema
+    /// fragments. `llm_call` wraps this into provider-native function schemas.
+    #[serde(default)]
+    pub parameters: JsonValue,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "outputSchema"
+    )]
+    pub output_schema: Option<JsonValue>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub namespace: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub defer_loading: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ExpectedToolCall {
+    Exact {
+        name: String,
+        args: JsonValue,
+    },
+    Predicate {
+        description: String,
+        judge_prompt: String,
+    },
+    Refusal {
+        reason_must_match: String,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ObservedToolCall {
+    pub name: String,
+    #[serde(default)]
+    pub args: JsonValue,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ObservedToolCallOutcome {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_call: Option<ObservedToolCall>,
+    #[serde(default)]
+    pub final_text: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PredicateJudgeVerdict {
+    pub passed: bool,
+    #[serde(default)]
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ToolCallScore {
+    pub passed: bool,
+    pub reason: String,
+}
+
+#[derive(Debug)]
+pub enum ToolCallEvalDatasetError {
+    Io { path: PathBuf, message: String },
+    Json { path: PathBuf, message: String },
+    Validation { path: PathBuf, message: String },
+}
+
+impl fmt::Display for ToolCallEvalDatasetError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io { path, message } => write!(f, "{}: {message}", path.display()),
+            Self::Json { path, message } => write!(f, "{}: {message}", path.display()),
+            Self::Validation { path, message } => write!(f, "{}: {message}", path.display()),
+        }
+    }
+}
+
+impl std::error::Error for ToolCallEvalDatasetError {}
+
+pub fn load_tool_call_eval_dataset(
+    path: &Path,
+) -> Result<Vec<ToolCallEvalCase>, ToolCallEvalDatasetError> {
+    let mut cases = Vec::new();
+    for file in tool_call_eval_case_files(path)? {
+        let raw = fs::read_to_string(&file).map_err(|error| ToolCallEvalDatasetError::Io {
+            path: file.clone(),
+            message: error.to_string(),
+        })?;
+        let value: JsonValue =
+            serde_json::from_str(&raw).map_err(|error| ToolCallEvalDatasetError::Json {
+                path: file.clone(),
+                message: error.to_string(),
+            })?;
+        let mut loaded = if value.is_array() {
+            serde_json::from_value::<Vec<ToolCallEvalCase>>(value).map_err(|error| {
+                ToolCallEvalDatasetError::Json {
+                    path: file.clone(),
+                    message: error.to_string(),
+                }
+            })?
+        } else {
+            vec![
+                serde_json::from_value::<ToolCallEvalCase>(value).map_err(|error| {
+                    ToolCallEvalDatasetError::Json {
+                        path: file.clone(),
+                        message: error.to_string(),
+                    }
+                })?,
+            ]
+        };
+        for case in &loaded {
+            validate_case(case, &file)?;
+        }
+        cases.append(&mut loaded);
+    }
+    cases.sort_by(|left, right| left.id.cmp(&right.id));
+    validate_unique_case_ids(&cases, path)?;
+    Ok(cases)
+}
+
+fn tool_call_eval_case_files(path: &Path) -> Result<Vec<PathBuf>, ToolCallEvalDatasetError> {
+    if path.is_file() {
+        return Ok(vec![path.to_path_buf()]);
+    }
+    let cases_dir = path.join("cases");
+    let root = if cases_dir.is_dir() {
+        cases_dir
+    } else {
+        path.to_path_buf()
+    };
+    let mut files = Vec::new();
+    collect_json_files(&root, &mut files)?;
+    files.sort();
+    Ok(files)
+}
+
+fn collect_json_files(dir: &Path, out: &mut Vec<PathBuf>) -> Result<(), ToolCallEvalDatasetError> {
+    let entries = fs::read_dir(dir).map_err(|error| ToolCallEvalDatasetError::Io {
+        path: dir.to_path_buf(),
+        message: error.to_string(),
+    })?;
+    for entry in entries {
+        let entry = entry.map_err(|error| ToolCallEvalDatasetError::Io {
+            path: dir.to_path_buf(),
+            message: error.to_string(),
+        })?;
+        let path = entry.path();
+        if path.is_dir() {
+            collect_json_files(&path, out)?;
+        } else if path.extension().is_some_and(|ext| ext == "json") {
+            out.push(path);
+        }
+    }
+    Ok(())
+}
+
+fn validate_case(case: &ToolCallEvalCase, path: &Path) -> Result<(), ToolCallEvalDatasetError> {
+    if case.id.trim().is_empty() {
+        return validation_error(path, "case id must not be empty");
+    }
+    if case.prompt.trim().is_empty() {
+        return validation_error(path, format!("{}: prompt must not be empty", case.id));
+    }
+    let mut names = BTreeSet::new();
+    for tool in &case.tools {
+        if tool.name.trim().is_empty() {
+            return validation_error(path, format!("{}: tool name must not be empty", case.id));
+        }
+        if !names.insert(tool.name.as_str()) {
+            return validation_error(
+                path,
+                format!("{}: duplicate tool name `{}`", case.id, tool.name),
+            );
+        }
+        if !tool.parameters.is_object() {
+            return validation_error(
+                path,
+                format!(
+                    "{}: tool `{}` parameters must be an object",
+                    case.id, tool.name
+                ),
+            );
+        }
+    }
+    if let ExpectedToolCall::Exact { name, .. } = &case.expected {
+        if !names.contains(name.as_str()) {
+            return validation_error(
+                path,
+                format!("{}: expected tool `{name}` is not declared", case.id),
+            );
+        }
+    }
+    if let Some(rate) = case.baseline_pass_rate {
+        if !(0.0..=1.0).contains(&rate) {
+            return validation_error(
+                path,
+                format!("{}: baseline_pass_rate must be in [0, 1]", case.id),
+            );
+        }
+    }
+    Ok(())
+}
+
+fn validation_error<T>(
+    path: &Path,
+    message: impl Into<String>,
+) -> Result<T, ToolCallEvalDatasetError> {
+    Err(ToolCallEvalDatasetError::Validation {
+        path: path.to_path_buf(),
+        message: message.into(),
+    })
+}
+
+fn validate_unique_case_ids(
+    cases: &[ToolCallEvalCase],
+    path: &Path,
+) -> Result<(), ToolCallEvalDatasetError> {
+    let mut seen = BTreeSet::new();
+    for case in cases {
+        if !seen.insert(case.id.as_str()) {
+            return validation_error(path, format!("duplicate case id `{}`", case.id));
+        }
+    }
+    Ok(())
+}
+
+pub fn score_tool_call_case(
+    case: &ToolCallEvalCase,
+    observed: &ObservedToolCallOutcome,
+    predicate_verdict: Option<&PredicateJudgeVerdict>,
+) -> ToolCallScore {
+    match &case.expected {
+        ExpectedToolCall::Exact { name, args } => score_exact(name, args, observed),
+        ExpectedToolCall::Predicate { .. } => match predicate_verdict {
+            Some(verdict) => ToolCallScore {
+                passed: verdict.passed,
+                reason: if verdict.reason.is_empty() {
+                    "predicate judge returned no reason".to_string()
+                } else {
+                    verdict.reason.clone()
+                },
+            },
+            None => ToolCallScore {
+                passed: false,
+                reason: "predicate case was not judged".to_string(),
+            },
+        },
+        ExpectedToolCall::Refusal { reason_must_match } => {
+            score_refusal(reason_must_match, observed)
+        }
+    }
+}
+
+fn score_exact(name: &str, args: &JsonValue, observed: &ObservedToolCallOutcome) -> ToolCallScore {
+    let Some(call) = observed.tool_call.as_ref() else {
+        return ToolCallScore {
+            passed: false,
+            reason: format!("expected `{name}` tool call, observed no tool call"),
+        };
+    };
+    if call.name != name {
+        return ToolCallScore {
+            passed: false,
+            reason: format!("expected tool `{name}`, observed `{}`", call.name),
+        };
+    }
+    if !json_deep_equal_with_numeric_tolerance(args, &call.args) {
+        return ToolCallScore {
+            passed: false,
+            reason: format!("expected args {args}, observed {}", call.args),
+        };
+    }
+    ToolCallScore {
+        passed: true,
+        reason: format!("matched `{name}` and canonical arguments"),
+    }
+}
+
+fn score_refusal(pattern: &str, observed: &ObservedToolCallOutcome) -> ToolCallScore {
+    if let Some(call) = observed.tool_call.as_ref() {
+        return ToolCallScore {
+            passed: false,
+            reason: format!("expected refusal, observed tool `{}`", call.name),
+        };
+    }
+    match regex::Regex::new(pattern) {
+        Ok(regex) if regex.is_match(&observed.final_text) => ToolCallScore {
+            passed: true,
+            reason: "refusal text matched expected reason pattern".to_string(),
+        },
+        Ok(_) => ToolCallScore {
+            passed: false,
+            reason: format!(
+                "refusal text did not match `{pattern}`: {}",
+                observed.final_text
+            ),
+        },
+        Err(error) => ToolCallScore {
+            passed: false,
+            reason: format!("invalid refusal regex `{pattern}`: {error}"),
+        },
+    }
+}
+
+pub fn json_deep_equal_with_numeric_tolerance(left: &JsonValue, right: &JsonValue) -> bool {
+    match (left, right) {
+        (JsonValue::Null, JsonValue::Null) => true,
+        (JsonValue::Bool(left), JsonValue::Bool(right)) => left == right,
+        (JsonValue::String(left), JsonValue::String(right)) => left == right,
+        (JsonValue::Number(left), JsonValue::Number(right)) => {
+            match (left.as_f64(), right.as_f64()) {
+                (Some(left), Some(right)) => (left - right).abs() <= FLOAT_TOLERANCE,
+                _ => left == right,
+            }
+        }
+        (JsonValue::Array(left), JsonValue::Array(right)) => {
+            left.len() == right.len()
+                && left
+                    .iter()
+                    .zip(right)
+                    .all(|(l, r)| json_deep_equal_with_numeric_tolerance(l, r))
+        }
+        (JsonValue::Object(left), JsonValue::Object(right)) => {
+            left.len() == right.len()
+                && left.iter().all(|(key, left_value)| {
+                    right.get(key).is_some_and(|right_value| {
+                        json_deep_equal_with_numeric_tolerance(left_value, right_value)
+                    })
+                })
+        }
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn exact_case() -> ToolCallEvalCase {
+        ToolCallEvalCase {
+            id: "exact".to_string(),
+            prompt: "Add two numbers".to_string(),
+            tools: vec![ToolDef {
+                name: "add".to_string(),
+                description: String::new(),
+                parameters: json!({
+                    "left": {"type": "integer"},
+                    "right": {"type": "integer"}
+                }),
+                output_schema: None,
+                namespace: None,
+                defer_loading: None,
+            }],
+            expected: ExpectedToolCall::Exact {
+                name: "add".to_string(),
+                args: json!({"left": 2, "right": 3.0}),
+            },
+            baseline_pass_rate: None,
+            source: None,
+            tags: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn exact_scoring_accepts_numeric_tolerance() {
+        let score = score_tool_call_case(
+            &exact_case(),
+            &ObservedToolCallOutcome {
+                tool_call: Some(ObservedToolCall {
+                    name: "add".to_string(),
+                    args: json!({"right": 3.0000001, "left": 2}),
+                }),
+                final_text: String::new(),
+            },
+            None,
+        );
+        assert!(score.passed, "{score:?}");
+    }
+
+    #[test]
+    fn exact_scoring_rejects_extra_args() {
+        let score = score_tool_call_case(
+            &exact_case(),
+            &ObservedToolCallOutcome {
+                tool_call: Some(ObservedToolCall {
+                    name: "add".to_string(),
+                    args: json!({"left": 2, "right": 3, "extra": true}),
+                }),
+                final_text: String::new(),
+            },
+            None,
+        );
+        assert!(!score.passed);
+        assert!(score.reason.contains("expected args"));
+    }
+
+    #[test]
+    fn refusal_requires_no_tool_and_matching_text() {
+        let case = ToolCallEvalCase {
+            id: "refusal".to_string(),
+            prompt: "Tell a joke".to_string(),
+            tools: Vec::new(),
+            expected: ExpectedToolCall::Refusal {
+                reason_must_match: "(?i)not.*available".to_string(),
+            },
+            baseline_pass_rate: None,
+            source: None,
+            tags: Vec::new(),
+        };
+        let score = score_tool_call_case(
+            &case,
+            &ObservedToolCallOutcome {
+                tool_call: None,
+                final_text: "That tool is not available for this request.".to_string(),
+            },
+            None,
+        );
+        assert!(score.passed, "{score:?}");
+    }
+
+    #[test]
+    fn dataset_loader_accepts_arrays() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cases_dir = tmp.path().join("cases");
+        fs::create_dir(&cases_dir).unwrap();
+        fs::write(
+            cases_dir.join("cases.json"),
+            serde_json::to_string(&vec![exact_case()]).unwrap(),
+        )
+        .unwrap();
+        let loaded = load_tool_call_eval_dataset(tmp.path()).unwrap();
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].id, "exact");
+    }
+}

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -25,6 +25,7 @@ mod conversation;
 pub(crate) mod cost;
 pub(crate) mod cost_route;
 pub(crate) mod daemon;
+pub mod eval;
 pub(crate) mod fake;
 pub(crate) mod helpers;
 pub mod jsonl;


### PR DESCRIPTION
## Summary

Closes #1697.

- Add `harn eval tool-calls` with planner, optional binder, predicate judge plumbing, latency/cost accounting, `summary.json`, and `per_case.jsonl` outputs.
- Add a reusable VM-side tool-call eval dataset/scoring module with exact, predicate, and refusal expectations.
- Add 50 checked-in tool-call eval cases, a stable mock baseline, README docs, and `make eval-tool-calls`.

## Validation

- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/tmp/harn-target-9cba-1697 cargo test -p harn-vm --lib llm::eval::tool_call_case --no-default-features`
- `CARGO_TARGET_DIR=/tmp/harn-target-9cba-1697 cargo test -p harn-cli --lib eval_tool_calls`
- `CARGO_TARGET_DIR=/tmp/harn-target-9cba-1697 cargo clippy -p harn-vm -p harn-cli --all-targets -- -D warnings`
- `scripts/check_no_rust_prompt_prose.sh`
- `npx markdownlint-cli2 "conformance/tool-call-eval/README.md"`
- `CARGO_TARGET_DIR=/tmp/harn-target-9cba-1697 make eval-tool-calls`
- `CARGO_TARGET_DIR=/tmp/harn-target-9cba-1697 cargo run --quiet --bin harn -- eval tool-calls regression-check --current .harn-runs/tool-call-eval/latest/summary.json --against conformance/tool-call-eval/baselines/mock-planner.summary.json --max-drop-pp 0.0`
- pre-commit hook: full workspace clippy, markdown, actionlint, ratchets
- pre-push hook: targeted local checks and markdown
