### PR TITLE
release: cover .githooks for CARGO_INCREMENTAL bug; auto-rename Unreleased

### DIFF
--- a/.githooks/lib.sh
+++ b/.githooks/lib.sh
@@ -55,17 +55,63 @@ hook_write_staged_files() {
   git diff --cached --name-only --diff-filter=ACMR > "$1"
 }
 
-hook_write_push_files() {
-  output=$1
+hook_push_base() {
   upstream=$(git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || true)
   if [ -n "$upstream" ]; then
-    base=$(git merge-base HEAD "$upstream")
+    git merge-base HEAD "$upstream"
   elif git rev-parse --verify origin/main >/dev/null 2>&1; then
-    base=$(git merge-base HEAD origin/main)
+    git merge-base HEAD origin/main
   else
-    base=$(git rev-list --max-parents=0 HEAD | tail -n 1)
+    git rev-list --max-parents=0 HEAD | tail -n 1
   fi
+}
+
+hook_write_push_files() {
+  output=$1
+  base=$(hook_push_base)
   git diff --name-only --diff-filter=ACMR "$base"...HEAD > "$output"
+}
+
+# Cover the same incremental-cache corruption that scripts/release_gate.sh
+# `cmd_prepare` and scripts/release_ship.sh `prepare_here` work around for
+# their own cargo invocations: once `bump_version` rewrites Cargo.toml the
+# workspace crates rebuild with fresh hashes, and any
+# `target/debug/incremental/` populated against the previous version
+# leaves dangling .o references that abort cargo with "failed to open
+# object file ... No such file or directory" / "extern location for
+# harn_modules does not exist". Those scripts export CARGO_INCREMENTAL=0
+# in their own process, but git hooks run cargo from fresh subprocesses
+# the export does not reach. Mirror the fix here for the hook context.
+#
+# Day-to-day commits keep incremental cache enabled — we only disable it
+# when the staged or push diff is actually bumping the workspace
+# version line.
+#
+# Args:
+#   $1 = "staged"        # pre-commit context (uses --cached)
+#      | "push <base>"   # pre-push context (uses <base>...HEAD)
+hook_disable_cargo_incremental_if_release_bump() {
+  case "$1" in
+    staged)
+      diff_args="--cached"
+      ;;
+    "push "*)
+      base=${1#push }
+      diff_args="$base...HEAD"
+      ;;
+    *)
+      return 0
+      ;;
+  esac
+  # `version =` matches both the root workspace key and per-crate
+  # manifests; either one moving is a workspace bump signal.
+  # shellcheck disable=SC2086
+  if git diff $diff_args -- Cargo.toml 'crates/*/Cargo.toml' 2>/dev/null \
+      | grep -Eq '^[-+]version = '; then
+    echo "=== Hook: workspace version bump detected; disabling cargo incremental cache ==="
+    export CARGO_INCREMENTAL=0
+    rm -rf target/debug/incremental
+  fi
 }
 
 hook_harn_format_supported() {

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -9,6 +9,7 @@ harn_format_files=$(mktemp)
 harn_lint_files=$(mktemp)
 trap 'rm -f "$changed" "$harn_format_files" "$harn_lint_files"' EXIT
 hook_write_staged_files "$changed"
+hook_disable_cargo_incremental_if_release_bump staged
 
 if hook_paths_match "$changed" "$HOOK_RUST_PATTERN"; then
   echo "=== Pre-commit: formatting Rust ==="

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -10,6 +10,7 @@ harn_lint_files=$(mktemp)
 changed_packages=$(mktemp)
 trap 'rm -f "$changed" "$harn_format_files" "$harn_lint_files" "$changed_packages"' EXIT
 hook_write_push_files "$changed"
+hook_disable_cargo_incremental_if_release_bump "push $(hook_push_base)"
 
 # Merge-queue guard. GitHub does not reject pushes to a PR that's already
 # in the merge queue — it just keeps using the snapshot it took when the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ condensed series summaries instead of full per-patch history.
 
 ## Unreleased
 
+### Fixed
+
+- **`.githooks/` cover the same incremental-cache corruption #1707
+  fixed in the release scripts.** `release_gate.sh` and
+  `release_ship.sh` export `CARGO_INCREMENTAL=0` for the prepare
+  phase, but `.githooks/pre-commit` and `.githooks/pre-push` run
+  cargo from fresh subprocesses the export does not reach — committing
+  the "Release vX.Y.Z" change still hit `cached cgu ... should have an
+  object file, but doesn't` against the stale incremental dir from the
+  audit. A new helper in `lib.sh`
+  (`hook_disable_cargo_incremental_if_release_bump`) inspects the
+  staged/push diff for a `^version =` change in `Cargo.toml` or
+  `crates/*/Cargo.toml`; on a real workspace bump it exports
+  `CARGO_INCREMENTAL=0` and purges `target/debug/incremental` for the
+  hook run only. Day-to-day commits keep incremental cache enabled.
+- **`release_ship.sh --prepare` auto-renames `## Unreleased` →
+  `## vX.Y.Z` instead of erroring after the audit.** The accumulator
+  convention between releases is to drop new bullets under
+  `## Unreleased`; the strict heading check in
+  `require_changelog_top_matches` rejected that exact shape and only
+  surfaced after burning ~7 min of audit wall time. The check now
+  promotes a top `## Unreleased` heading to `## v$expected` in place
+  (subsequent `git add -u` in the staging step picks the rename up).
+  Mismatched `## vX.Y.Z` headings still error with the same hint.
+
 ### Added
 
 - **Cerebras provider (#1705).** Added a first-class `cerebras` provider

--- a/scripts/release_ship.sh
+++ b/scripts/release_ship.sh
@@ -326,29 +326,57 @@ require_release_branch() {
 
 # Verify the top CHANGELOG.md heading matches the expected next version.
 # The human is expected to have authored "## vX.Y.Z" before running prepare.
+#
+# Convenience: if the first H2 is `## Unreleased` (the convention for
+# accumulating bullets between releases), promote it to `## v$expected`
+# in-place rather than failing after the audit has already burned ~7
+# minutes of wall time. The `git add -u` in the staging step picks the
+# rename up; if --prepare is later cancelled the rename is harmless.
 require_changelog_top_matches() {
   local expected="$1"
-  local top
-  top="$(python3 - <<'PY'
-from pathlib import Path
+  python3 - "$expected" <<'PY'
 import re
-text = Path("CHANGELOG.md").read_text()
-for line in text.splitlines():
-    m = re.match(r"^## v(\d+\.\d+\.\d+)\s*$", line)
-    if m:
-        print(m.group(1))
+import sys
+from pathlib import Path
+
+expected = sys.argv[1]
+path = Path("CHANGELOG.md")
+text = path.read_text()
+lines = text.splitlines(keepends=True)
+top_index = None
+for i, line in enumerate(lines):
+    if re.match(r"^## ", line):
+        top_index = i
         break
+
+if top_index is None:
+    sys.stderr.write("error: CHANGELOG.md has no '## vX.Y.Z' heading\n")
+    sys.exit(1)
+
+top = lines[top_index].rstrip("\n").rstrip("\r")
+m = re.match(r"^## v(\d+\.\d+\.\d+)\s*$", top)
+if m:
+    if m.group(1) == expected:
+        sys.exit(0)
+    sys.stderr.write(
+        f"error: CHANGELOG.md top heading is v{m.group(1)} but --bump implies v{expected}\n"
+        f"hint: edit CHANGELOG.md to add '## v{expected}' as the new top entry, then re-run\n"
+    )
+    sys.exit(1)
+
+if re.match(r"^## Unreleased\s*$", top):
+    lines[top_index] = f"## v{expected}\n"
+    path.write_text("".join(lines))
+    print(f"note: renamed CHANGELOG.md top heading '## Unreleased' -> '## v{expected}'")
+    sys.exit(0)
+
+sys.stderr.write(
+    f"error: CHANGELOG.md top heading '{top}' is neither '## Unreleased' "
+    f"nor '## v$expected'\n"
+    f"hint: edit CHANGELOG.md to add '## v{expected}' as the new top entry, then re-run\n"
+)
+sys.exit(1)
 PY
-)"
-  if [[ -z "$top" ]]; then
-    echo "error: CHANGELOG.md has no '## vX.Y.Z' heading"
-    exit 1
-  fi
-  if [[ "$top" != "$expected" ]]; then
-    echo "error: CHANGELOG.md top heading is v$top but --bump implies v$expected"
-    echo "hint: edit CHANGELOG.md to add '## v$expected' as the new top entry, then re-run"
-    exit 1
-  fi
 }
 
 run_common_gates() {


### PR DESCRIPTION
## Summary

Two release-flow polish fixes, in the same shape #1707 took. Surfaced
by the v0.8.21 release PR (#1708):

1. **`.githooks/` cover the same incremental-cache failure mode that
   #1707 fixed in `scripts/release_*.sh`.** The release scripts export
   `CARGO_INCREMENTAL=0` to work around stale `target/debug/incremental`
   after the audit + `bump_version` rewrite, but `.githooks/pre-commit`
   and `.githooks/pre-push` run cargo from fresh subprocesses the export
   does not reach. The `Release v0.8.21` commit still hit
   `cached cgu ... should have an object file, but doesn't` inside the
   pre-commit clippy step.

   New helper `hook_disable_cargo_incremental_if_release_bump` in
   `.githooks/lib.sh` inspects the staged (pre-commit) or push-range
   (pre-push) diff for a `^version =` line change in `Cargo.toml` or
   `crates/*/Cargo.toml`. On a real workspace bump it exports
   `CARGO_INCREMENTAL=0` and purges `target/debug/incremental` for the
   hook process only. Day-to-day commits keep incremental cache
   enabled. `hook_push_base` is factored out of `hook_write_push_files`
   so the pre-push call site can pass the same base to the helper.

2. **`release_ship.sh --prepare` auto-renames `## Unreleased` →
   `## vX.Y.Z` instead of erroring after the audit.** The accumulator
   convention between releases is to add bullets under `## Unreleased`,
   but the strict heading check in `require_changelog_top_matches`
   rejected that exact shape only after the audit had already burned
   ~7 min of wall time. The check now promotes `## Unreleased` to
   `## v$expected` in place (subsequent `git add -u` in the staging
   step picks the rename up). Mismatched `## vX.Y.Z` headings still
   error with the same hint as before.

## Test plan

- [x] Hook helper smoke test:
      - empty diff → no fire (`CARGO_INCREMENTAL` stays unset)
      - synthetic `version = "0.1.0"` → `version = "0.1.1"` staged
        diff → fires (`CARGO_INCREMENTAL=0` exported, incremental dir
        purged)
      - non-version Cargo.toml diff → no fire
- [x] `require_changelog_top_matches` matrix:
      - top is `## Unreleased` → renamed in place to `## v0.8.22`, exit 0
      - top is `## v0.8.22` (matches) → no-op, exit 0
      - top is `## v0.8.21` (mismatch) → error with original hint
      - no `## ` heading at all → error
- [x] `bash -n` on all four modified scripts
- [x] `shellcheck -s sh .githooks/{lib.sh,pre-commit,pre-push}`
      reports only pre-existing SC2034 warnings on `HOOK_*_PATTERN`
      exports
- [x] Pre-commit hook on this branch's own commit ran clean (markdown
      lint + actions lint fired because `.githooks/` and `CHANGELOG.md`
      were touched; helper correctly stayed quiet since this commit
      isn't itself a version bump)
- [x] Pre-push hook on this branch's push ran clean
- [ ] Merge-queue CI gate
- [ ] Verified on next release: `Release v0.8.22` commit no longer
      requires `rm -rf target/debug/incremental && CARGO_INCREMENTAL=0`
      workaround

🤖 Generated with [Claude Code](https://claude.com/claude-code)