### PR TITLE
Add typed tool call receipts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ docs/dist/
 tree-sitter-harn/*.dylib
 tree-sitter-harn/*.so
 tree-sitter-harn/*.dll
+.harn/receipts/
 .harn/
 # Conformance skill fixtures deliberately ship a .harn/ subdir so the
 # project-layer loader (issue #73) has something to discover. The

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,8 +91,8 @@ This repository implements Harn, a programming language and runtime for orchestr
   Go in `spec/protocol-artifacts/go/harnprotocol/`. The Go test file
   `harnprotocol_test.go` is hand-written and round-trips the published
   fixture.
-- `docs/dist/`, `.harn-runs/`, `.harn/`, `.claude/`, `.burin/`, `target/`, and `node_modules/` are
-  generated or local-only paths.
+- `docs/dist/`, `.harn-runs/`, `.harn/`, `.harn/receipts/`, `.claude/`, `.burin/`, `target/`,
+  and `node_modules/` are generated or local-only paths.
 
 ## Change Alignment Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,8 +121,8 @@ at `.claude/skills/harn-scripting/SKILL.md`.
   Go in `spec/protocol-artifacts/go/harnprotocol/`. The Go test file
   `harnprotocol_test.go` is hand-written and round-trips the published
   fixture.
-- `docs/dist/`, `.harn-runs/`, `.harn/`, `.claude/`, `.burin/`, `target/`, and `node_modules/` are
-  generated or local-only paths.
+- `docs/dist/`, `.harn-runs/`, `.harn/`, `.harn/receipts/`, `.claude/`, `.burin/`, `target/`,
+  and `node_modules/` are generated or local-only paths.
 
 ## Change Alignment Rules
 

--- a/conformance/protocols/fixtures/acp/agent_event_ext_notifications.valid.json
+++ b/conformance/protocols/fixtures/acp/agent_event_ext_notifications.valid.json
@@ -321,6 +321,30 @@
           "summary": "Read project context"
         },
         "kind": "tool_call_audit",
+        "receipt": {
+          "schema_version": 1,
+          "session_id": "session-1",
+          "run_id": "run-1",
+          "tool_call_id": "tool-1",
+          "tool_name": "read_file",
+          "iteration": 6,
+          "turn_index": 5,
+          "reason": "Read project context",
+          "kind": "read",
+          "executor": "harn",
+          "status": "ok",
+          "error_category": null,
+          "duration_ms": 7,
+          "args_hash": "0000000000000000000000000000000000000000000000000000000000000000",
+          "result_hash": "1111111111111111111111111111111111111111111111111111111111111111",
+          "audit": {
+            "consent": "not_required",
+            "summary": "Read project context"
+          },
+          "emitted_at": "2026-05-16T00:00:00Z",
+          "model": "mock",
+          "provider": "mock"
+        },
         "sessionId": "session-1",
         "toolCallId": "tool-1",
         "toolName": "read_file"

--- a/conformance/tests/integration/tool_call_receipts_local_sink.expected
+++ b/conformance/tests/integration/tool_call_receipts_local_sink.expected
@@ -1,0 +1,10 @@
+local_status=done
+local_records=1
+schema_version=1
+reason=Need a receipt
+receipt_status=ok
+secret_redacted=true
+args_hash_redacted=true
+result_hash_present=true
+cloud_receipts=1
+cloud_reason=Need a receipt

--- a/conformance/tests/integration/tool_call_receipts_local_sink.harn
+++ b/conformance/tests/integration/tool_call_receipts_local_sink.harn
@@ -1,0 +1,83 @@
+import { agent_capture_events } from "std/agent/events"
+import { read_jsonl } from "std/jsonl"
+import {
+  compose_tool_callers,
+  tools_use_middleware,
+  with_audit_log,
+  with_required_reason,
+} from "std/llm/tool_middleware"
+
+fn receipt_tools() {
+  let registry = tool_registry()
+  return tool_define(
+    registry,
+    "echo_receipt",
+    "Echo a message",
+    {
+      handler: { args -> return {echoed: to_string(args?.message ?? "")} },
+      parameters: {message: {type: "string"}, secret: {type: "string"}},
+    },
+  )
+}
+
+fn run_receipt_agent(session, audit_options) {
+  llm_mock_clear()
+  llm_mock(
+    {
+      tool_calls: [
+        {
+          id: "receipt-1",
+          name: "echo_receipt",
+          arguments: {message: "hello", secret: "hide-me", reason: "Need a receipt"},
+        },
+      ],
+    },
+  )
+  llm_mock({text: "Done. ##DONE##"})
+  let reason = with_required_reason({schema_required: false})
+  let tools = tools_use_middleware(receipt_tools(), reason.schema_transform)
+  let caller = compose_tool_callers([with_audit_log(audit_options), reason.caller])
+  return agent_loop(
+    "emit a tool receipt",
+    nil,
+    {
+      provider: "mock",
+      model: "mock",
+      session_id: session,
+      tools: tools,
+      tool_format: "native",
+      loop_until_done: true,
+      max_iterations: 3,
+      tool_caller: caller,
+    },
+  )
+}
+
+pipeline default() {
+  let local_session = "receipt-local-" + uuid()
+  let local_path = path_join(".harn", "receipts", local_session + ".jsonl")
+  if file_exists(local_path) {
+    delete_file(local_path)
+  }
+  let local_result = run_receipt_agent(local_session, {sink: "local", redact: ["secret"]})
+  let records = read_jsonl(local_path, {strict: true})
+  let receipt = records[0]
+  let receipt_json = json_stringify(receipt)
+  let expected_args_hash = sha256("{\"message\":\"hello\",\"reason\":\"Need a receipt\"}")
+  println("local_status=" + local_result.status)
+  println("local_records=" + to_string(len(records)))
+  println("schema_version=" + to_string(receipt.schema_version))
+  println("reason=" + receipt.reason)
+  println("receipt_status=" + receipt.status)
+  println("secret_redacted=" + to_string(!contains(receipt_json, "hide-me")))
+  println("args_hash_redacted=" + to_string(receipt.args_hash == expected_args_hash))
+  println("result_hash_present=" + to_string(len(to_string(receipt.result_hash ?? "")) == 64))
+  let cloud_session = "receipt-cloud-" + uuid()
+  let captured = agent_capture_events(
+    cloud_session,
+    fn() { return run_receipt_agent(cloud_session, {sink: "cloud", redact: ["secret"]}) },
+  )
+  let receipt_events = captured.events.filter({ event -> event.type == "tool_call_audit" && event?.receipt != nil })
+  println("cloud_receipts=" + to_string(len(receipt_events)))
+  println("cloud_reason=" + receipt_events[0].receipt.reason)
+}

--- a/crates/harn-cli/src/commands/dump_protocol_artifacts.rs
+++ b/crates/harn-cli/src/commands/dump_protocol_artifacts.rs
@@ -17,6 +17,10 @@ use harn_serve::adapters::acp::{
 };
 use harn_serve::{A2A_PROTOCOL_VERSION, MCP_PROTOCOL_VERSION};
 use harn_vm::agent_events::{ToolCallErrorCategory, ToolCallStatus, WorkerEvent};
+use harn_vm::llm::receipts::{
+    tool_call_receipt_schema, TOOL_CALL_RECEIPT_EXECUTORS, TOOL_CALL_RECEIPT_SCHEMA_ARTIFACT,
+    TOOL_CALL_RECEIPT_SCHEMA_VERSION, TOOL_CALL_RECEIPT_STATUSES,
+};
 use harn_vm::tool_annotations::{SideEffectLevel, ToolKind};
 use serde::Serialize;
 use serde_json::json;
@@ -187,6 +191,10 @@ fn generate_artifacts() -> Result<Vec<Artifact>, String> {
         Artifact::new("go/harnprotocol/harnprotocol.go", generate_go()),
         Artifact::new("go/harnprotocol/go.mod", generate_go_mod()),
         Artifact::new("fixtures/round_trip.json", generate_round_trip_fixture()?),
+        Artifact::new(
+            TOOL_CALL_RECEIPT_SCHEMA_ARTIFACT,
+            generate_tool_call_receipt_schema()?,
+        ),
     ];
 
     for schema in SCHEMA_COPIES {
@@ -197,6 +205,11 @@ fn generate_artifacts() -> Result<Vec<Artifact>, String> {
     }
     artifacts.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
     Ok(artifacts)
+}
+
+fn generate_tool_call_receipt_schema() -> Result<String, String> {
+    serde_json::to_string_pretty(&tool_call_receipt_schema())
+        .map_err(|error| format!("failed to serialize tool-call receipt schema: {error}"))
 }
 
 const PYTHON_INIT_STUB: &str = "from .harn_protocol import *  # noqa: F401,F403\n";
@@ -211,7 +224,7 @@ pub(crate) fn manifest_json() -> Result<String, String> {
 }
 
 fn generate_manifest() -> Result<String, String> {
-    let schemas = SCHEMA_COPIES
+    let mut schemas = SCHEMA_COPIES
         .iter()
         .map(|schema| {
             Ok(json!({
@@ -222,6 +235,16 @@ fn generate_manifest() -> Result<String, String> {
             }))
         })
         .collect::<Result<Vec<_>, String>>()?;
+    let receipt_schema = tool_call_receipt_schema();
+    schemas.push(json!({
+        "protocol": "harn",
+        "source": "crates/harn-vm/src/llm/receipts.rs",
+        "artifact": TOOL_CALL_RECEIPT_SCHEMA_ARTIFACT,
+        "provenance": receipt_schema
+            .get("x-harn-provenance")
+            .cloned()
+            .unwrap_or(serde_json::Value::Null),
+    }));
 
     serde_json::to_string_pretty(&json!({
         "schemaVersion": 1,
@@ -278,6 +301,12 @@ fn generate_manifest() -> Result<String, String> {
             "methods": MCP_METHODS,
             "loggingLevels": MCP_LOGGING_LEVELS,
         },
+        "receipts": {
+            "toolCallReceiptSchemaVersion": TOOL_CALL_RECEIPT_SCHEMA_VERSION,
+            "toolCallReceiptSchema": TOOL_CALL_RECEIPT_SCHEMA_ARTIFACT,
+            "toolCallReceiptStatuses": TOOL_CALL_RECEIPT_STATUSES,
+            "toolCallReceiptExecutors": TOOL_CALL_RECEIPT_EXECUTORS,
+        },
     }))
     .map_err(|error| format!("failed to serialize manifest: {error}"))
 }
@@ -306,6 +335,8 @@ fn generate_readme() -> String {
            profile (`{acp}`).\n\
          - `schemas/a2a-0.3.0.schema.json`: Harn's A2A schema profile (`{a2a}`).\n\
          - `schemas/mcp-2025-11-25.schema.json`: Harn's MCP schema profile (`{mcp}`).\n\
+         - `schemas/tool-call-receipt.schema.json`: Harn's typed, privacy-preserving\n\
+           `ToolCallReceipt` schema for audited tool calls.\n\
          - `harn-protocol.ts`: TypeScript definitions for ACP session updates,\n\
            tool lifecycle metadata, A2A task events, and MCP metadata.\n\
          - `HarnProtocol.swift`: Swift definitions for the same host-facing surface.\n\
@@ -394,6 +425,16 @@ fn generate_typescript() -> String {
         "HarnWorkerStatus",
     ));
     out.push_str(&ts_array(
+        "HARN_TOOL_CALL_RECEIPT_STATUSES",
+        TOOL_CALL_RECEIPT_STATUSES,
+        "HarnToolCallReceiptStatus",
+    ));
+    out.push_str(&ts_array(
+        "HARN_TOOL_CALL_RECEIPT_EXECUTORS",
+        TOOL_CALL_RECEIPT_EXECUTORS,
+        "HarnToolCallReceiptExecutor",
+    ));
+    out.push_str(&ts_array(
         "A2A_TASK_STATES",
         A2A_TASK_STATES,
         "A2ATaskState",
@@ -469,6 +510,28 @@ export interface HarnToolLifecycleMeta {
   executor?: ACPToolExecutor
   parsing?: boolean
   rawInputPartial?: string
+}
+
+export interface ToolCallReceipt {
+  schema_version: number
+  session_id: string
+  run_id: string | null
+  tool_call_id: string
+  tool_name: string
+  iteration: number
+  turn_index: number | null
+  reason: string | null
+  kind: string | null
+  executor: HarnToolCallReceiptExecutor | null
+  status: HarnToolCallReceiptStatus
+  error_category: string | null
+  duration_ms: number
+  args_hash: string
+  result_hash: string | null
+  audit: ACPValue
+  emitted_at: string
+  model: string | null
+  provider: string | null
 }
 
 export interface ACPToolCall {
@@ -706,6 +769,14 @@ fn generate_swift() -> String {
         "contentExtensionFields",
         HARN_CONTENT_EXTENSION_FIELDS,
     ));
+    out.push_str(&swift_string_array(
+        "toolCallReceiptStatuses",
+        TOOL_CALL_RECEIPT_STATUSES,
+    ));
+    out.push_str(&swift_string_array(
+        "toolCallReceiptExecutors",
+        TOOL_CALL_RECEIPT_EXECUTORS,
+    ));
     out.push_str("}\n\n");
 
     out.push_str(&swift_enum(
@@ -742,6 +813,14 @@ fn generate_swift() -> String {
         &side_effect_level_values(),
     ));
     out.push_str(&swift_enum("HarnWorkerStatus", &worker_status_values()));
+    out.push_str(&swift_enum(
+        "HarnToolCallReceiptStatus",
+        &strs_to_strings(TOOL_CALL_RECEIPT_STATUSES),
+    ));
+    out.push_str(&swift_enum(
+        "HarnToolCallReceiptExecutor",
+        &strs_to_strings(TOOL_CALL_RECEIPT_EXECUTORS),
+    ));
     out.push_str(&swift_enum(
         "HarnA2ATaskState",
         &strs_to_strings(A2A_TASK_STATES),
@@ -1171,6 +1250,50 @@ public struct HarnToolLifecycleMeta: Codable, Sendable, Equatable {
     public var rawInputPartial: String?
 }
 
+public struct HarnToolCallReceipt: Codable, Sendable, Equatable {
+    public var schemaVersion: Int
+    public var sessionId: String
+    public var runId: String?
+    public var toolCallId: String
+    public var toolName: String
+    public var iteration: Int
+    public var turnIndex: Int?
+    public var reason: String?
+    public var kind: String?
+    public var executor: HarnToolCallReceiptExecutor?
+    public var status: HarnToolCallReceiptStatus
+    public var errorCategory: String?
+    public var durationMs: Int
+    public var argsHash: String
+    public var resultHash: String?
+    public var audit: HarnACPValue
+    public var emittedAt: String
+    public var model: String?
+    public var provider: String?
+
+    enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case sessionId = "session_id"
+        case runId = "run_id"
+        case toolCallId = "tool_call_id"
+        case toolName = "tool_name"
+        case iteration
+        case turnIndex = "turn_index"
+        case reason
+        case kind
+        case executor
+        case status
+        case errorCategory = "error_category"
+        case durationMs = "duration_ms"
+        case argsHash = "args_hash"
+        case resultHash = "result_hash"
+        case audit
+        case emittedAt = "emitted_at"
+        case model
+        case provider
+    }
+}
+
 public struct HarnACPToolCall: Codable, Sendable, Equatable {
     public var sessionUpdate: HarnACPSessionUpdate
     public var toolCallId: String
@@ -1422,6 +1545,14 @@ fn generate_python() -> String {
         &worker_status_values(),
     ));
     out.push_str(&py_const_tuple(
+        "HARN_TOOL_CALL_RECEIPT_STATUSES",
+        TOOL_CALL_RECEIPT_STATUSES,
+    ));
+    out.push_str(&py_const_tuple(
+        "HARN_TOOL_CALL_RECEIPT_EXECUTORS",
+        TOOL_CALL_RECEIPT_EXECUTORS,
+    ));
+    out.push_str(&py_const_tuple(
         "HARN_TOOL_LIFECYCLE_EXTENSION_FIELDS",
         HARN_TOOL_LIFECYCLE_EXTENSION_FIELDS,
     ));
@@ -1461,6 +1592,14 @@ fn generate_python() -> String {
     out.push_str(&py_str_enum_owned(
         "HarnWorkerStatus",
         &worker_status_values(),
+    ));
+    out.push_str(&py_str_enum(
+        "ToolCallReceiptStatus",
+        TOOL_CALL_RECEIPT_STATUSES,
+    ));
+    out.push_str(&py_str_enum(
+        "ToolCallReceiptExecutor",
+        TOOL_CALL_RECEIPT_EXECUTORS,
     ));
     out.push_str(&py_str_enum("A2ATaskState", A2A_TASK_STATES));
     out.push_str(&py_str_enum("A2ATaskEventType", A2A_TASK_EVENT_TYPES));
@@ -1581,6 +1720,32 @@ class HarnToolLifecycleMeta(_HarnDataclass):
     executor: Optional[JsonValue] = None
     parsing: Optional[bool] = None
     rawInputPartial: Optional[str] = None
+
+
+@dataclass
+class ToolCallReceipt(_HarnDataclass):
+    schema_version: int
+    session_id: str
+    tool_call_id: str
+    tool_name: str
+    iteration: int
+    status: str
+    duration_ms: int
+    args_hash: str
+    audit: JsonValue
+    emitted_at: str
+    run_id: Optional[str] = None
+    turn_index: Optional[int] = None
+    reason: Optional[str] = None
+    kind: Optional[str] = None
+    executor: Optional[str] = None
+    error_category: Optional[str] = None
+    result_hash: Optional[str] = None
+    model: Optional[str] = None
+    provider: Optional[str] = None
+
+    def to_wire(self) -> JsonObject:
+        return asdict(self)
 
 
 @dataclass
@@ -1742,6 +1907,8 @@ fn python_public_names() -> Vec<String> {
         "HARN_TOOL_CALL_ERROR_CATEGORIES",
         "HARN_SIDE_EFFECT_LEVELS",
         "HARN_WORKER_STATUSES",
+        "HARN_TOOL_CALL_RECEIPT_STATUSES",
+        "HARN_TOOL_CALL_RECEIPT_EXECUTORS",
         "HARN_TOOL_LIFECYCLE_EXTENSION_FIELDS",
         "HARN_CONTENT_EXTENSION_FIELDS",
         "A2A_METHODS",
@@ -1758,6 +1925,8 @@ fn python_public_names() -> Vec<String> {
         "HarnToolCallErrorCategory",
         "HarnSideEffectLevel",
         "HarnWorkerStatus",
+        "ToolCallReceiptStatus",
+        "ToolCallReceiptExecutor",
         "A2ATaskState",
         "A2ATaskEventType",
         "MCPLoggingLevel",
@@ -1769,6 +1938,7 @@ fn python_public_names() -> Vec<String> {
         "HarnExtensionMeta",
         "ACPContentBlock",
         "HarnToolLifecycleMeta",
+        "ToolCallReceipt",
         "ACPToolCall",
         "ACPToolCallUpdate",
         "ACPSessionUpdateEnvelope",
@@ -1974,6 +2144,16 @@ fn generate_go() -> String {
         &worker_status_values(),
     ));
     out.push_str(&go_typed_array(
+        "ToolCallReceiptStatus",
+        "ToolCallReceiptStatuses",
+        TOOL_CALL_RECEIPT_STATUSES,
+    ));
+    out.push_str(&go_typed_array(
+        "ToolCallReceiptExecutor",
+        "ToolCallReceiptExecutors",
+        TOOL_CALL_RECEIPT_EXECUTORS,
+    ));
+    out.push_str(&go_typed_array(
         "A2ATaskState",
         "A2ATaskStates",
         A2A_TASK_STATES,
@@ -2110,6 +2290,30 @@ type HarnToolLifecycleMeta struct {
 	Executor            json.RawMessage `json:"executor,omitempty"`
 	Parsing             *bool           `json:"parsing,omitempty"`
 	RawInputPartial     *string         `json:"rawInputPartial,omitempty"`
+}
+
+// ToolCallReceipt is the typed, privacy-preserving receipt emitted for an
+// audited tool call.
+type ToolCallReceipt struct {
+	SchemaVersion int                      `json:"schema_version"`
+	SessionID     string                   `json:"session_id"`
+	RunID         *string                  `json:"run_id"`
+	ToolCallID    string                   `json:"tool_call_id"`
+	ToolName      string                   `json:"tool_name"`
+	Iteration     uint64                   `json:"iteration"`
+	TurnIndex     *uint64                  `json:"turn_index"`
+	Reason        *string                  `json:"reason"`
+	Kind          *string                  `json:"kind"`
+	Executor      *ToolCallReceiptExecutor `json:"executor"`
+	Status        ToolCallReceiptStatus    `json:"status"`
+	ErrorCategory *string                  `json:"error_category"`
+	DurationMs    uint64                   `json:"duration_ms"`
+	ArgsHash      string                   `json:"args_hash"`
+	ResultHash    *string                  `json:"result_hash"`
+	Audit         json.RawMessage          `json:"audit"`
+	EmittedAt     string                   `json:"emitted_at"`
+	Model         *string                  `json:"model"`
+	Provider      *string                  `json:"provider"`
 }
 
 // ACPToolCall is the `tool_call` session update.
@@ -2366,6 +2570,30 @@ fn generate_round_trip_fixture() -> Result<String, String> {
             },
         }
     });
+    let tool_call_receipt = json!({
+        "schema_version": TOOL_CALL_RECEIPT_SCHEMA_VERSION,
+        "session_id": "sess-42",
+        "run_id": "run-42",
+        "tool_call_id": "call-001",
+        "tool_name": "read_file",
+        "iteration": 1,
+        "turn_index": 0,
+        "reason": "Read README.md for context",
+        "kind": "read",
+        "executor": "harn",
+        "status": "ok",
+        "error_category": null,
+        "duration_ms": 12,
+        "args_hash": "0".repeat(64),
+        "result_hash": "1".repeat(64),
+        "audit": {
+            "summary": "Read README.md for context",
+            "layers": [{"name": "with_required_reason", "status": "ok"}],
+        },
+        "emitted_at": "2026-05-16T00:00:00Z",
+        "model": "mock",
+        "provider": "mock",
+    });
     let request = json!({
         "jsonrpc": "2.0",
         "id": 17,
@@ -2409,6 +2637,7 @@ fn generate_round_trip_fixture() -> Result<String, String> {
         },
         "a2aTask": a2a_task,
         "mcpTool": mcp_tool,
+        "toolCallReceipt": tool_call_receipt,
     });
 
     serde_json::to_string_pretty(&fixture)
@@ -2621,17 +2850,25 @@ mod tests {
         assert!(swift.contains("public var id: HarnJsonRpcId"));
         assert!(swift.contains("public init?(jsonObject: Any)"));
         assert!(swift.contains("public static func success(id: HarnJsonRpcId"));
+        assert!(swift.contains("public struct HarnToolCallReceipt"));
         for value in tool_kind_values()
             .into_iter()
             .chain(tool_call_status_values())
             .chain(tool_call_error_category_values())
             .chain(worker_status_values())
+            .chain(
+                TOOL_CALL_RECEIPT_STATUSES
+                    .iter()
+                    .map(|value| (*value).to_string()),
+            )
         {
             assert!(swift.contains(&value), "Swift artifact missing {value}");
         }
         assert!(swift.contains("public enum HarnWorkerStatus"));
         assert!(ts.contains("export type HarnWorkerStatus"));
         assert!(ts.contains("HARN_WORKER_STATUSES"));
+        assert!(ts.contains("export interface ToolCallReceipt"));
+        assert!(ts.contains("HARN_TOOL_CALL_RECEIPT_STATUSES"));
     }
 
     #[test]
@@ -2640,6 +2877,8 @@ mod tests {
         assert!(py.contains("class ACPSessionUpdate(str, Enum):"));
         assert!(py.contains("class HarnToolCallErrorCategory(str, Enum):"));
         assert!(py.contains("class HarnWorkerStatus(str, Enum):"));
+        assert!(py.contains("class ToolCallReceipt(_HarnDataclass):"));
+        assert!(py.contains("class ToolCallReceiptStatus(str, Enum):"));
         assert!(py.contains("class _HarnDataclass:"));
         assert!(py.contains("def is_request("));
         for value in HARN_SESSION_UPDATE_EXTENSIONS
@@ -2663,6 +2902,8 @@ mod tests {
         assert!(go.contains("func IsRequest(envelope map[string]json.RawMessage)"));
         assert!(go.contains("type HarnWorkerStatus = string"));
         assert!(go.contains("var HarnWorkerStatuses = []HarnWorkerStatus"));
+        assert!(go.contains("type ToolCallReceipt struct"));
+        assert!(go.contains("var ToolCallReceiptStatuses = []ToolCallReceiptStatus"));
         for value in HARN_SESSION_UPDATE_EXTENSIONS
             .iter()
             .chain(HARN_AGENT_EVENT_KINDS.iter())
@@ -2697,6 +2938,7 @@ mod tests {
             json!("composition_child_call")
         );
         assert_eq!(fixture["a2aTask"]["status"]["state"], json!("working"));
+        assert_eq!(fixture["toolCallReceipt"]["schema_version"], json!(1));
     }
 
     #[test]
@@ -2712,6 +2954,10 @@ mod tests {
         );
         assert_eq!(manifest["bindings"]["python"]["stability"], json!("stable"));
         assert_eq!(manifest["bindings"]["go"]["stability"], json!("stable"));
+        assert_eq!(
+            manifest["receipts"]["toolCallReceiptSchemaVersion"],
+            json!(TOOL_CALL_RECEIPT_SCHEMA_VERSION)
+        );
     }
 
     #[test]
@@ -2729,6 +2975,14 @@ mod tests {
                 schema.artifact
             );
         }
+        assert!(
+            manifest["schemas"]
+                .as_array()
+                .expect("schema array")
+                .iter()
+                .any(|entry| entry["artifact"] == TOOL_CALL_RECEIPT_SCHEMA_ARTIFACT),
+            "manifest missing {TOOL_CALL_RECEIPT_SCHEMA_ARTIFACT}"
+        );
     }
 
     #[test]

--- a/crates/harn-serve/src/adapters/acp/events.rs
+++ b/crates/harn-serve/src/adapters/acp/events.rs
@@ -906,16 +906,23 @@ impl AgentEventSink for AcpAgentEventSink {
                 tool_call_id,
                 tool_name,
                 audit,
+                receipt,
             } => {
-                self.emit_agent_event_ext(
-                    "tool_call_audit",
-                    session_id,
-                    serde_json::json!({
-                        "toolCallId": tool_call_id,
-                        "toolName": tool_name,
-                        "audit": audit,
-                    }),
-                );
+                let mut payload = serde_json::json!({
+                    "toolCallId": tool_call_id,
+                    "toolName": tool_name,
+                    "audit": audit,
+                });
+                if let Some(receipt) = receipt {
+                    payload
+                        .as_object_mut()
+                        .expect("tool_call_audit payload is an object")
+                        .insert(
+                            "receipt".to_string(),
+                            serde_json::to_value(receipt).expect("receipt serializes"),
+                        );
+                }
+                self.emit_agent_event_ext("tool_call_audit", session_id, payload);
             }
             AgentEvent::CacheHit {
                 session_id,

--- a/crates/harn-serve/src/adapters/acp/events/tests.rs
+++ b/crates/harn-serve/src/adapters/acp/events/tests.rs
@@ -5,6 +5,7 @@ use harn_vm::composition::{
     composition_snippet_hash, CompositionChildCall, CompositionChildResult,
     CompositionFailureCategory, CompositionRunEnvelope,
 };
+use harn_vm::llm::receipts::ToolCallReceipt;
 use harn_vm::orchestration::{
     HandoffArtifact, HandoffTargetRecord, MutationSessionRecord, ToolApprovalPolicy,
 };
@@ -55,6 +56,33 @@ fn fixture_handoff() -> HandoffArtifact {
         ..Default::default()
     }
     .normalize()
+}
+
+fn fixture_tool_call_receipt() -> ToolCallReceipt {
+    ToolCallReceipt {
+        schema_version: 1,
+        session_id: "session-1".to_string(),
+        run_id: Some("run-1".to_string()),
+        tool_call_id: "tool-1".to_string(),
+        tool_name: "read_file".to_string(),
+        iteration: 6,
+        turn_index: Some(5),
+        reason: Some("Read project context".to_string()),
+        kind: Some("read".to_string()),
+        executor: Some("harn".to_string()),
+        status: "ok".to_string(),
+        error_category: None,
+        duration_ms: 7,
+        args_hash: "0".repeat(64),
+        result_hash: Some("1".repeat(64)),
+        audit: serde_json::json!({
+            "summary": "Read project context",
+            "consent": "not_required"
+        }),
+        emitted_at: "2026-05-16T00:00:00Z".to_string(),
+        model: Some("mock".to_string()),
+        provider: Some("mock".to_string()),
+    }
 }
 
 fn standard_fixture_events() -> Vec<AgentEvent> {
@@ -408,6 +436,7 @@ fn agent_event_ext_fixture_events() -> Vec<AgentEvent> {
                 "summary": "Read project context",
                 "consent": "not_required"
             }),
+            receipt: Some(fixture_tool_call_receipt()),
         },
     ]
 }

--- a/crates/harn-serve/tests/fixtures/acp/agent_event_ext_notifications.json
+++ b/crates/harn-serve/tests/fixtures/acp/agent_event_ext_notifications.json
@@ -316,6 +316,30 @@
         "summary": "Read project context"
       },
       "kind": "tool_call_audit",
+      "receipt": {
+        "schema_version": 1,
+        "session_id": "session-1",
+        "run_id": "run-1",
+        "tool_call_id": "tool-1",
+        "tool_name": "read_file",
+        "iteration": 6,
+        "turn_index": 5,
+        "reason": "Read project context",
+        "kind": "read",
+        "executor": "harn",
+        "status": "ok",
+        "error_category": null,
+        "duration_ms": 7,
+        "args_hash": "0000000000000000000000000000000000000000000000000000000000000000",
+        "result_hash": "1111111111111111111111111111111111111111111111111111111111111111",
+        "audit": {
+          "consent": "not_required",
+          "summary": "Read project context"
+        },
+        "emitted_at": "2026-05-16T00:00:00Z",
+        "model": "mock",
+        "provider": "mock"
+      },
       "sessionId": "session-1",
       "toolCallId": "tool-1",
       "toolName": "read_file"

--- a/crates/harn-stdlib/src/stdlib/agent/loop.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/loop.harn
@@ -239,7 +239,13 @@ fn __tool_envelope(call, tools, options) {
     schema: schema,
     annotations: annotations,
     description: description,
-    turn: {iteration: options?._turn_iteration ?? 0, session_id: to_string(options?.session_id ?? "")},
+    turn: {
+      iteration: options?._turn_iteration ?? 0,
+      session_id: to_string(options?.session_id ?? ""),
+      run_id: options?.run_id ?? options?._run_id,
+      model: options?.model,
+      provider: options?.provider,
+    },
   }
 }
 
@@ -313,23 +319,29 @@ fn __invoke_tool(call, tools, options) {
   }
   let r = unwrap(outcome)
   __validate_tool_caller_result(r)
-  __maybe_emit_tool_audit(envelope.turn.session_id, envelope, r?.audit)
+  __maybe_emit_tool_audit(envelope.turn.session_id, envelope, r?.audit, r?.receipt)
   return r
 }
 
-fn __maybe_emit_tool_audit(session_id, envelope, audit) {
-  if audit == nil {
+fn __maybe_emit_tool_audit(session_id, envelope, audit, receipt = nil) {
+  if audit == nil && receipt == nil {
     return
   }
   if session_id == "" {
     return
   }
+  let payload = if receipt == nil {
+    {tool_call_id: envelope.call_id, tool_name: envelope.tool_name, audit: audit}
+  } else {
+    {
+      tool_call_id: envelope.call_id,
+      tool_name: envelope.tool_name,
+      audit: audit ?? {},
+      receipt: receipt,
+    }
+  }
   let _ = try {
-    agent_emit_event(
-      session_id,
-      "tool_call_audit",
-      {tool_call_id: envelope.call_id, tool_name: envelope.tool_name, audit: audit},
-    )
+    agent_emit_event(session_id, "tool_call_audit", payload)
   }
 }
 

--- a/crates/harn-stdlib/src/stdlib/llm/tool_middleware.harn
+++ b/crates/harn-stdlib/src/stdlib/llm/tool_middleware.harn
@@ -80,6 +80,79 @@ fn __tool_mw_list(value) -> list {
   return []
 }
 
+fn __tool_mw_string_list(value) -> list {
+  var out = []
+  for item in __tool_mw_list(value) {
+    if item != nil {
+      out = out.push(to_string(item))
+    }
+  }
+  return out
+}
+
+fn __tool_mw_optional_text(value) {
+  if value == nil {
+    return nil
+  }
+  let text = to_string(value)
+  if text == "" {
+    return nil
+  }
+  return text
+}
+
+fn __tool_mw_nonnegative_int(value) -> int {
+  let parsed = to_int(value) ?? 0
+  if parsed < 0 {
+    return 0
+  }
+  return parsed
+}
+
+fn __tool_mw_drop_keys(value, keys) {
+  if type_of(value) == "dict" {
+    var out = {}
+    for key in value.keys() {
+      if contains(keys, key) {
+        continue
+      }
+      out = out + {[key]: __tool_mw_drop_keys(value[key], keys)}
+    }
+    return out
+  }
+  if type_of(value) == "list" {
+    var out = []
+    for item in value {
+      out = out.push(__tool_mw_drop_keys(item, keys))
+    }
+    return out
+  }
+  return value
+}
+
+fn __tool_mw_canonical_json(value) -> string {
+  if type_of(value) == "dict" {
+    let keys = value.keys().sort()
+    var parts = []
+    for key in keys {
+      parts = parts.push(json_stringify(to_string(key)) + ":" + __tool_mw_canonical_json(value[key]))
+    }
+    return "{" + join(parts, ",") + "}"
+  }
+  if type_of(value) == "list" {
+    var parts = []
+    for item in value {
+      parts = parts.push(__tool_mw_canonical_json(item))
+    }
+    return "[" + join(parts, ",") + "]"
+  }
+  return json_stringify(value)
+}
+
+fn __tool_mw_sha256_value(value) -> string {
+  return sha256(__tool_mw_canonical_json(value))
+}
+
 fn __tool_mw_short_circuit(envelope, status, fields) {
   let base = {
     ok: false,
@@ -399,44 +472,170 @@ pub fn with_required_reason(opts = nil) {
 }
 
 /**
- * with_audit_log(sink) -> caller
+ * local_receipt_sink(session_id) -> sink_fn
  *
- * Pushes one record per tool call into `sink(record)` after the call
- * completes. `record` shape:
- *
- *   {
- *     tool_name, tool_call_id, ok, status, executor,
- *     duration_ms, args, result, error,
- *     audit,                           // middleware-attached metadata
- *     turn: {iteration, session_id},
- *   }
- *
- * The sink runs after `next` returns; exceptions inside the sink are
- * swallowed so audit failures don't break the agent loop.
+ * Returns a receipt sink that appends JSONL to `.harn/receipts/<session>.jsonl`.
+ * The sink writes one record per invocation and does not buffer.
  */
-pub fn with_audit_log(sink) {
-  if !__tool_mw_is_callable(sink) {
-    throw "with_audit_log: sink must be callable; got " + type_of(sink)
+pub fn local_receipt_sink(session_id) {
+  let fallback = __tool_mw_optional_text(session_id) ?? "session"
+  return { receipt ->
+    let raw_session = __tool_mw_optional_text(receipt?.session_id) ?? fallback
+    let filename = raw_session.replace("/", "_").replace("\\", "_")
+    let dir = path_join(".harn", "receipts")
+    mkdir(dir)
+    let path = path_join(dir, filename + ".jsonl")
+    append_file(path, json_stringify(receipt) + "\n")
+    return path
   }
+}
+
+fn __tool_mw_receipt_status(result) -> string {
+  let status = to_string(result?.status ?? "")
+  let category = to_string(result?.error_category ?? "")
+  if result?.ok ?? result?.success ?? false {
+    return "ok"
+  }
+  if status == "ok" || status == "success" || status == "completed" {
+    return "ok"
+  }
+  if status == "schema_violation" || category == "schema_violation" || category == "schema_validation" {
+    return "schema_violation"
+  }
+  if status == "consent_denied" || category == "consent_denied" {
+    return "consent_denied"
+  }
+  if status == "timeout" || category == "timeout" {
+    return "timeout"
+  }
+  return "error"
+}
+
+fn __tool_mw_receipt_executor(value) {
+  let raw = __tool_mw_optional_text(value)
+  if raw == nil {
+    return nil
+  }
+  if raw == "harn" || raw == "harn_builtin" {
+    return "harn"
+  }
+  if raw == "host_bridge" || raw == "mcp_server" || raw == "provider_native" {
+    return raw
+  }
+  if raw.starts_with("mcp") {
+    return "mcp_server"
+  }
+  return nil
+}
+
+fn __tool_mw_receipt_kind(call, audit) {
+  let audit_kind = __tool_mw_optional_text(audit?.kind)
+  if audit_kind != nil {
+    return audit_kind
+  }
+  return __tool_mw_optional_text(call?.annotations?.kind)
+}
+
+fn __tool_mw_receipt_result_hash(result) {
+  if result?.result == nil {
+    return nil
+  }
+  return __tool_mw_sha256_value(result.result)
+}
+
+fn __tool_mw_tool_call_receipt(call, result, duration_ms, redact_keys) {
+  let turn = __tool_mw_dict(call?.turn)
+  let audit = __tool_mw_dict(result?.audit)
+  let iteration = __tool_mw_nonnegative_int(turn?.iteration)
+  let turn_index = if iteration > 0 {
+    iteration - 1
+  } else {
+    nil
+  }
+  let args_for_hash = __tool_mw_drop_keys(call?.tool_args ?? {}, redact_keys)
+  return {
+    schema_version: 1,
+    session_id: to_string(turn?.session_id ?? ""),
+    run_id: __tool_mw_optional_text(turn?.run_id),
+    tool_call_id: to_string(call?.call_id ?? ""),
+    tool_name: to_string(call?.tool_name ?? ""),
+    iteration: iteration,
+    turn_index: turn_index,
+    reason: __tool_mw_optional_text(audit?.summary),
+    kind: __tool_mw_receipt_kind(call, audit),
+    executor: __tool_mw_receipt_executor(result?.executor ?? call?.declared_executor),
+    status: __tool_mw_receipt_status(result),
+    error_category: __tool_mw_optional_text(result?.error_category),
+    duration_ms: __tool_mw_nonnegative_int(duration_ms),
+    args_hash: __tool_mw_sha256_value(args_for_hash),
+    result_hash: __tool_mw_receipt_result_hash(result),
+    audit: audit,
+    emitted_at: __tool_mw_now_iso(),
+    model: __tool_mw_optional_text(turn?.model),
+    provider: __tool_mw_optional_text(turn?.provider),
+  }
+}
+
+fn __tool_mw_audit_log_config(sink) {
+  let raw_cfg = if type_of(sink) == "dict" {
+    sink
+  } else {
+    {sink: sink}
+  }
+  let redact_keys = __tool_mw_string_list(raw_cfg?.redact)
+  let raw_sink = raw_cfg?.sink
+  if __tool_mw_is_callable(raw_sink) {
+    return {mode: "closure", sink_fn: raw_sink, redact_keys: redact_keys}
+  }
+  if type_of(raw_sink) != "string" {
+    throw "with_audit_log: sink must be callable or one of local/cloud/both; got " + type_of(raw_sink)
+  }
+  let mode = to_string(raw_sink)
+  if mode != "local" && mode != "cloud" && mode != "both" {
+    throw "with_audit_log: sink must be callable or one of local/cloud/both; got " + mode
+  }
+  return {mode: mode, sink_fn: nil, redact_keys: redact_keys}
+}
+
+fn __tool_mw_audit_log_emit_local(receipt) {
+  let sink = local_receipt_sink(receipt?.session_id)
+  let _ = try {
+    sink(receipt)
+  }
+}
+
+/**
+ * with_audit_log(sink_or_options) -> caller
+ *
+ * Builds one typed ToolCallReceipt per tool call after the call completes.
+ * `sink_or_options` accepts:
+ *
+ *   - callable: sink(receipt)
+ *   - "local": append JSONL under `.harn/receipts/<session_id>.jsonl`
+ *   - "cloud": mirror the receipt through the host event bridge
+ *   - "both": local append first, then host event bridge
+ *   - {sink, redact}: same modes, dropping matching argument keys from args_hash
+ *
+ * Receipts carry hashes instead of raw args/results, so local and cloud
+ * sinks can be queryable without leaking tool payloads.
+ */
+pub fn with_audit_log(sink_or_options) {
+  let cfg = __tool_mw_audit_log_config(sink_or_options)
   return { call, next ->
     let started = now_ms()
     let result = next(call)
     let duration = now_ms() - started
-    let record = {
-      tool_name: call.tool_name,
-      tool_call_id: call.call_id,
-      ok: result?.ok ?? false,
-      status: to_string(result?.status ?? ""),
-      executor: result?.executor,
-      duration_ms: duration,
-      args: call.tool_args,
-      result: result?.result,
-      error: result?.error,
-      audit: result?.audit,
-      turn: call.turn,
+    let receipt = __tool_mw_tool_call_receipt(call, result, duration, cfg.redact_keys)
+    if cfg.mode == "local" || cfg.mode == "both" {
+      __tool_mw_audit_log_emit_local(receipt)
     }
-    let _ = try {
-      sink(record)
+    if cfg.sink_fn != nil {
+      let _ = try {
+        cfg.sink_fn(receipt)
+      }
+    }
+    if cfg.mode == "cloud" || cfg.mode == "both" {
+      return result + {receipt: receipt}
     }
     return result
   }

--- a/crates/harn-vm/src/agent_events.rs
+++ b/crates/harn-vm/src/agent_events.rs
@@ -25,6 +25,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::composition::{CompositionChildCall, CompositionChildResult, CompositionRunEnvelope};
 use crate::event_log::{AnyEventLog, EventLog, LogEvent as EventLogRecord, Topic};
+use crate::llm::receipts::ToolCallReceipt;
 use crate::orchestration::{HandoffArtifact, MutationSessionRecord};
 use crate::tool_annotations::ToolKind;
 
@@ -608,12 +609,15 @@ pub enum AgentEvent {
     /// existing `ToolCall` / `ToolCallUpdate` stream. The `audit` payload
     /// is intentionally free-form JSON so middleware can carry whatever
     /// shape the harness author chooses without needing protocol-level
-    /// changes per new middleware.
+    /// changes per new middleware. When present, `receipt` carries the
+    /// stable typed, privacy-preserving record hosts can persist or mirror.
     ToolCallAudit {
         session_id: String,
         tool_call_id: String,
         tool_name: String,
         audit: serde_json::Value,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        receipt: Option<ToolCallReceipt>,
     },
     /// Emitted by `std/cache::with_cache` (both the generic and LLM
     /// forms) when a cached lookup returns a hit. Carries the
@@ -1870,6 +1874,7 @@ mod tests {
             tool_call_id: "tc-1".into(),
             tool_name: "search_files".into(),
             audit: audit.clone(),
+            receipt: None,
         };
         let json = serde_json::to_value(&event).unwrap();
         assert_eq!(json["type"], "tool_call_audit");
@@ -1886,7 +1891,43 @@ mod tests {
             tool_call_id: "tc".into(),
             tool_name: "read".into(),
             audit: serde_json::Value::Null,
+            receipt: None,
         };
         assert_eq!(event.session_id(), "abc");
+    }
+
+    #[test]
+    fn tool_call_audit_serializes_typed_receipt_when_present() {
+        let receipt = ToolCallReceipt {
+            schema_version: 1,
+            session_id: "s".into(),
+            run_id: None,
+            tool_call_id: "tc-1".into(),
+            tool_name: "search_files".into(),
+            iteration: 3,
+            turn_index: Some(2),
+            reason: Some("Search for middleware".into()),
+            kind: Some("search".into()),
+            executor: Some("harn".into()),
+            status: "ok".into(),
+            error_category: None,
+            duration_ms: 9,
+            args_hash: "0".repeat(64),
+            result_hash: Some("1".repeat(64)),
+            audit: serde_json::json!({"summary": "Search for middleware"}),
+            emitted_at: "2026-05-16T00:00:00Z".into(),
+            model: Some("mock".into()),
+            provider: Some("mock".into()),
+        };
+        let event = AgentEvent::ToolCallAudit {
+            session_id: "s".into(),
+            tool_call_id: "tc-1".into(),
+            tool_name: "search_files".into(),
+            audit: receipt.audit.clone(),
+            receipt: Some(receipt.clone()),
+        };
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["receipt"], serde_json::to_value(receipt).unwrap());
+        assert_eq!(json["receipt"]["args_hash"], "0".repeat(64));
     }
 }

--- a/crates/harn-vm/src/llm/agent_session_host.rs
+++ b/crates/harn-vm/src/llm/agent_session_host.rs
@@ -1241,6 +1241,7 @@ fn build_agent_event(
     payload: &serde_json::Value,
 ) -> Result<crate::agent_events::AgentEvent, VmError> {
     use crate::agent_events::AgentEvent;
+    use crate::llm::receipts::ToolCallReceipt;
     let payload_obj = payload.as_object();
     let get_usize = |key: &str| -> usize {
         payload_obj
@@ -1353,15 +1354,28 @@ fn build_agent_event(
             session_id: session_id.to_string(),
             warning: payload.clone(),
         }),
-        "tool_call_audit" => Ok(AgentEvent::ToolCallAudit {
-            session_id: session_id.to_string(),
-            tool_call_id: get_string("tool_call_id"),
-            tool_name: get_string("tool_name"),
-            audit: payload_obj
-                .and_then(|m| m.get("audit"))
+        "tool_call_audit" => {
+            let receipt = payload_obj
+                .and_then(|m| m.get("receipt"))
                 .cloned()
-                .unwrap_or(serde_json::Value::Null),
-        }),
+                .map(serde_json::from_value::<ToolCallReceipt>)
+                .transpose()
+                .map_err(|error| {
+                    VmError::Runtime(format!(
+                        "{HOST_AGENT_EMIT_EVENT}: invalid tool_call_audit.receipt: {error}"
+                    ))
+                })?;
+            Ok(AgentEvent::ToolCallAudit {
+                session_id: session_id.to_string(),
+                tool_call_id: get_string("tool_call_id"),
+                tool_name: get_string("tool_name"),
+                audit: payload_obj
+                    .and_then(|m| m.get("audit"))
+                    .cloned()
+                    .unwrap_or(serde_json::Value::Null),
+                receipt,
+            })
+        }
         "cache_hit" => Ok(AgentEvent::CacheHit {
             session_id: session_id.to_string(),
             key: get_string("key"),

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -122,6 +122,7 @@ mod healthcheck;
 pub(crate) mod provider;
 pub(crate) mod providers;
 pub(crate) mod rate_limit;
+pub mod receipts;
 mod stream;
 pub(crate) mod tools;
 mod trace;

--- a/crates/harn-vm/src/llm/receipts.rs
+++ b/crates/harn-vm/src/llm/receipts.rs
@@ -1,0 +1,201 @@
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value as JsonValue};
+
+pub const TOOL_CALL_RECEIPT_SCHEMA_VERSION: u32 = 1;
+pub const TOOL_CALL_RECEIPT_SCHEMA_ID: &str =
+    "https://harnlang.com/schemas/tool-call-receipt.v1.json";
+pub const TOOL_CALL_RECEIPT_SCHEMA_ARTIFACT: &str = "schemas/tool-call-receipt.schema.json";
+pub const TOOL_CALL_RECEIPT_STATUSES: &[&str] = &[
+    "ok",
+    "schema_violation",
+    "consent_denied",
+    "timeout",
+    "error",
+];
+pub const TOOL_CALL_RECEIPT_EXECUTORS: &[&str] =
+    &["harn", "host_bridge", "mcp_server", "provider_native"];
+
+/// Typed receipt emitted for each audited tool call.
+///
+/// Receipts intentionally avoid raw arguments and raw results. Callers get
+/// stable hashes for correlation, plus free-form audit metadata for
+/// user-visible rationale and middleware decisions.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ToolCallReceipt {
+    pub schema_version: u32,
+    pub session_id: String,
+    pub run_id: Option<String>,
+    pub tool_call_id: String,
+    pub tool_name: String,
+    pub iteration: u64,
+    pub turn_index: Option<u64>,
+    pub reason: Option<String>,
+    pub kind: Option<String>,
+    pub executor: Option<String>,
+    pub status: String,
+    pub error_category: Option<String>,
+    pub duration_ms: u64,
+    pub args_hash: String,
+    pub result_hash: Option<String>,
+    pub audit: JsonValue,
+    pub emitted_at: String,
+    pub model: Option<String>,
+    pub provider: Option<String>,
+}
+
+pub fn tool_call_receipt_schema() -> JsonValue {
+    json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": TOOL_CALL_RECEIPT_SCHEMA_ID,
+        "title": "ToolCallReceipt",
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+            "schema_version",
+            "session_id",
+            "run_id",
+            "tool_call_id",
+            "tool_name",
+            "iteration",
+            "turn_index",
+            "reason",
+            "kind",
+            "executor",
+            "status",
+            "error_category",
+            "duration_ms",
+            "args_hash",
+            "result_hash",
+            "audit",
+            "emitted_at",
+            "model",
+            "provider"
+        ],
+        "properties": {
+            "schema_version": {
+                "type": "integer",
+                "const": TOOL_CALL_RECEIPT_SCHEMA_VERSION,
+                "description": "Receipt schema version. Starts at 1."
+            },
+            "session_id": {"type": "string", "minLength": 1},
+            "run_id": nullable_string(),
+            "tool_call_id": {"type": "string", "minLength": 1},
+            "tool_name": {"type": "string", "minLength": 1},
+            "iteration": {"type": "integer", "minimum": 0},
+            "turn_index": {"type": ["integer", "null"], "minimum": 0},
+            "reason": nullable_string(),
+            "kind": nullable_string(),
+            "executor": {
+                "type": ["string", "null"],
+                "enum": executor_schema_enum(),
+            },
+            "status": {
+                "type": "string",
+                "enum": TOOL_CALL_RECEIPT_STATUSES,
+            },
+            "error_category": nullable_string(),
+            "duration_ms": {"type": "integer", "minimum": 0},
+            "args_hash": digest_schema(),
+            "result_hash": {
+                "anyOf": [
+                    digest_schema(),
+                    {"type": "null"}
+                ],
+            },
+            "audit": true,
+            "emitted_at": {
+                "type": "string",
+                "format": "date-time",
+            },
+            "model": nullable_string(),
+            "provider": nullable_string(),
+        },
+        "x-harn-provenance": {
+            "source": "crates/harn-vm/src/llm/receipts.rs",
+            "schemaVersion": TOOL_CALL_RECEIPT_SCHEMA_VERSION
+        }
+    })
+}
+
+fn nullable_string() -> JsonValue {
+    json!({"type": ["string", "null"]})
+}
+
+fn digest_schema() -> JsonValue {
+    json!({
+        "type": "string",
+        "pattern": "^[a-f0-9]{64}$",
+    })
+}
+
+fn executor_schema_enum() -> JsonValue {
+    let mut values: Vec<JsonValue> = TOOL_CALL_RECEIPT_EXECUTORS
+        .iter()
+        .map(|value| JsonValue::String((*value).to_string()))
+        .collect();
+    values.push(JsonValue::Null);
+    JsonValue::Array(values)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture_receipt() -> ToolCallReceipt {
+        ToolCallReceipt {
+            schema_version: TOOL_CALL_RECEIPT_SCHEMA_VERSION,
+            session_id: "session-1".to_string(),
+            run_id: Some("run-1".to_string()),
+            tool_call_id: "tool-1".to_string(),
+            tool_name: "read_file".to_string(),
+            iteration: 2,
+            turn_index: Some(1),
+            reason: Some("Read project context".to_string()),
+            kind: Some("read".to_string()),
+            executor: Some("harn".to_string()),
+            status: "ok".to_string(),
+            error_category: None,
+            duration_ms: 7,
+            args_hash: "0".repeat(64),
+            result_hash: Some("1".repeat(64)),
+            audit: json!({"summary": "Read project context"}),
+            emitted_at: "2026-05-16T00:00:00Z".to_string(),
+            model: Some("mock".to_string()),
+            provider: Some("mock".to_string()),
+        }
+    }
+
+    #[test]
+    fn tool_call_receipt_serializes_nullable_optional_fields() {
+        let mut receipt = fixture_receipt();
+        receipt.run_id = None;
+        receipt.turn_index = None;
+        receipt.result_hash = None;
+        let value = serde_json::to_value(&receipt).expect("receipt serializes");
+        assert_eq!(value["schema_version"], json!(1));
+        assert_eq!(value["run_id"], JsonValue::Null);
+        assert_eq!(value["turn_index"], JsonValue::Null);
+        assert_eq!(value["result_hash"], JsonValue::Null);
+
+        let round_trip: ToolCallReceipt =
+            serde_json::from_value(value).expect("receipt deserializes");
+        assert_eq!(round_trip, receipt);
+    }
+
+    #[test]
+    fn schema_pins_statuses_and_privacy_hash_fields() {
+        let schema = tool_call_receipt_schema();
+        assert_eq!(
+            schema["properties"]["status"]["enum"],
+            json!(TOOL_CALL_RECEIPT_STATUSES)
+        );
+        assert_eq!(
+            schema["properties"]["args_hash"]["pattern"],
+            json!("^[a-f0-9]{64}$")
+        );
+        assert_eq!(
+            schema["x-harn-provenance"]["source"],
+            json!("crates/harn-vm/src/llm/receipts.rs")
+        );
+    }
+}

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -2509,17 +2509,23 @@ import {
   compose_tool_callers, tools_use_middleware,
 } from "std/llm/tool_middleware"
 
-let mw = with_required_reason()
+let mw = with_required_reason({schema_required: false})
 let registry = tools_use_middleware(my_registry, mw.schema_transform)
 
 let caller = compose_tool_callers([
-  with_audit_log({ record -> persist_audit(record) }),
+  with_audit_log({sink: "both", redact: ["token", "content"]}),
   with_consent({ call -> ask_human(call) }),
   mw.caller,
 ])
 
 agent_loop(task, system, {tools: registry, tool_caller: caller})
 ```
+
+`with_audit_log` emits typed `ToolCallReceipt` records with rationale,
+status, timing, model/provider, and hashes instead of raw args/results.
+Use `sink: "local"` for `.harn/receipts/<session_id>.jsonl`,
+`sink: "cloud"` for host bridge mirroring, or `sink: "both"` for both
+paths.
 
 The caller signature is `fn(call, next) -> result_dict` where
 `call = {tool_name, tool_args, call_id, declared_executor, schema, description, turn}`

--- a/docs/src/stdlib/tool-middleware.md
+++ b/docs/src/stdlib/tool-middleware.md
@@ -130,16 +130,38 @@ the model omits the synthetic `reason` field, while still recording
 `"(no reason given)"` in the audit summary.
 
 ```harn,ignore
-let mw = with_required_reason()
+let mw = with_required_reason({schema_required: false})
 let registry = tools_use_middleware(my_registry, mw.schema_transform)
 agent_loop(task, system, {tools: registry, tool_caller: mw.caller})
 ```
 
-### `with_audit_log(sink) -> caller`
+`schema_required: false` keeps runtime validation aligned with the
+default `strip: true`; the middleware still rejects calls that omit the
+reason before the tool handler runs.
 
-Pushes one record per tool call into `sink(record)` after the call
-completes. Useful for shipping audit data to a database, file, or
-observability sink. Sink exceptions are swallowed.
+### `with_audit_log(sink_or_options) -> caller`
+
+Builds one typed `ToolCallReceipt` per tool call after the call
+completes. Receipts include the required-reason summary, status,
+executor, timing, model/provider, audit metadata, and SHA-256 hashes of
+canonicalized args/results instead of raw payloads.
+
+`sink_or_options` accepts a callable sink, `"local"`, `"cloud"`,
+`"both"`, or `{sink, redact}`. Local receipts append to
+`.harn/receipts/<session_id>.jsonl`; cloud receipts mirror through the
+host event bridge; `both` writes local first and mirrors the same
+receipt. `redact` is a list of argument keys removed before `args_hash`
+is computed.
+
+```harn,ignore
+let caller = compose_tool_callers([
+  with_audit_log({sink: "both", redact: ["token", "content"]}),
+  with_required_reason({schema_required: false}).caller,
+])
+```
+
+For explicit file routing, `local_receipt_sink(session_id)` returns the
+same append-only JSONL sink used by `sink: "local"`.
 
 ### `with_consent(prompt_fn) -> caller`
 
@@ -225,10 +247,10 @@ outermost. This mirrors `compose` in `std/llm/handlers`.
 
 ```harn,ignore
 let caller = compose_tool_callers([
-  with_audit_log(sink),
+  with_audit_log({sink: "both", redact: ["token", "content"]}),
   with_consent(prompt),
   with_redaction(redactor),
-  with_required_reason().caller,
+  with_required_reason({schema_required: false}).caller,
 ])
 ```
 
@@ -255,10 +277,10 @@ import {
   with_telemetry,
 } from "std/llm/tool_middleware"
 
-let reason_mw = with_required_reason()
+let reason_mw = with_required_reason({schema_required: false})
 
 let captain_tool_caller = compose_tool_callers([
-  with_audit_log(receipts_sink),               // every dispatch → audit ledger
+  with_audit_log({sink: "both", redact: ["token", "content"]}), // typed tool receipts
   with_telemetry(otel_sink),                   // gen_ai.tool.* spans
   with_summary({ call, _r -> describe(call) }), // user-facing one-liner
   with_consent(persona.autonomy_policy),       // act_with_approval gate

--- a/scripts/check_protocol_bindings.py
+++ b/scripts/check_protocol_bindings.py
@@ -71,6 +71,7 @@ def main() -> int:
         ),
         ("A2ATask", fixture["a2aTask"], hp.A2ATask),
         ("MCPTool", fixture["mcpTool"], hp.MCPTool),
+        ("ToolCallReceipt", fixture["toolCallReceipt"], hp.ToolCallReceipt),
     ]
     for label, payload, cls in cases:
         instance = cls.from_wire(payload)

--- a/scripts/smoke_tool_receipts.harn
+++ b/scripts/smoke_tool_receipts.harn
@@ -1,0 +1,63 @@
+import { read_jsonl } from "std/jsonl"
+import {
+  compose_tool_callers,
+  tools_use_middleware,
+  with_audit_log,
+  with_required_reason,
+} from "std/llm/tool_middleware"
+
+fn smoke_tools() {
+  let registry = tool_registry()
+  return tool_define(
+    registry,
+    "receipt_echo",
+    "Echo receipt smoke input",
+    {
+      handler: { args -> return {echoed: to_string(args?.message ?? "")} },
+      parameters: {message: {type: "string"}, token: {type: "string"}},
+    },
+  )
+}
+
+pipeline default() {
+  let session = "smoke-tool-receipts-" + uuid()
+  let receipt_path = path_join(".harn", "receipts", session + ".jsonl")
+  if file_exists(receipt_path) {
+    delete_file(receipt_path)
+  }
+  llm_mock_clear()
+  llm_mock(
+    {
+      tool_calls: [
+        {
+          id: "smoke-receipt-1",
+          name: "receipt_echo",
+          arguments: {message: "hello", token: "redacted", reason: "Verify receipt smoke path"},
+        },
+      ],
+    },
+  )
+  llm_mock({text: "Done. ##DONE##"})
+  let reason = with_required_reason({schema_required: false})
+  let tools = tools_use_middleware(smoke_tools(), reason.schema_transform)
+  let caller = compose_tool_callers([with_audit_log({sink: "local", redact: ["token"]}), reason.caller])
+  let result = agent_loop(
+    "smoke tool receipts",
+    nil,
+    {
+      provider: "mock",
+      model: "mock",
+      session_id: session,
+      tools: tools,
+      tool_format: "native",
+      loop_until_done: true,
+      max_iterations: 3,
+      tool_caller: caller,
+    },
+  )
+  let records = read_jsonl(receipt_path, {strict: true})
+  println("status=" + result.status)
+  println("receipt_path=" + receipt_path)
+  println("records=" + to_string(len(records)))
+  println("reason=" + records[0].reason)
+}

--- a/spec/protocol-artifacts/HarnProtocol.swift
+++ b/spec/protocol-artifacts/HarnProtocol.swift
@@ -56,6 +56,19 @@ public enum HarnProtocolConstants {
         "visible_delta",
         "visible_text",
     ]
+    public static let toolCallReceiptStatuses: [String] = [
+        "ok",
+        "schema_violation",
+        "consent_denied",
+        "timeout",
+        "error",
+    ]
+    public static let toolCallReceiptExecutors: [String] = [
+        "harn",
+        "host_bridge",
+        "mcp_server",
+        "provider_native",
+    ]
 }
 
 public enum HarnACPAgentMethod: String, Codable, Sendable, CaseIterable {
@@ -161,6 +174,21 @@ public enum HarnWorkerStatus: String, Codable, Sendable, CaseIterable {
     case completed = "completed"
     case failed = "failed"
     case cancelled = "cancelled"
+}
+
+public enum HarnToolCallReceiptStatus: String, Codable, Sendable, CaseIterable {
+    case ok = "ok"
+    case schemaViolation = "schema_violation"
+    case consentDenied = "consent_denied"
+    case timeout = "timeout"
+    case error = "error"
+}
+
+public enum HarnToolCallReceiptExecutor: String, Codable, Sendable, CaseIterable {
+    case harn = "harn"
+    case hostBridge = "host_bridge"
+    case mcpServer = "mcp_server"
+    case providerNative = "provider_native"
 }
 
 public enum HarnA2ATaskState: String, Codable, Sendable, CaseIterable {
@@ -621,6 +649,50 @@ public struct HarnToolLifecycleMeta: Codable, Sendable, Equatable {
     public var executor: HarnACPToolExecutor?
     public var parsing: Bool?
     public var rawInputPartial: String?
+}
+
+public struct HarnToolCallReceipt: Codable, Sendable, Equatable {
+    public var schemaVersion: Int
+    public var sessionId: String
+    public var runId: String?
+    public var toolCallId: String
+    public var toolName: String
+    public var iteration: Int
+    public var turnIndex: Int?
+    public var reason: String?
+    public var kind: String?
+    public var executor: HarnToolCallReceiptExecutor?
+    public var status: HarnToolCallReceiptStatus
+    public var errorCategory: String?
+    public var durationMs: Int
+    public var argsHash: String
+    public var resultHash: String?
+    public var audit: HarnACPValue
+    public var emittedAt: String
+    public var model: String?
+    public var provider: String?
+
+    enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case sessionId = "session_id"
+        case runId = "run_id"
+        case toolCallId = "tool_call_id"
+        case toolName = "tool_name"
+        case iteration
+        case turnIndex = "turn_index"
+        case reason
+        case kind
+        case executor
+        case status
+        case errorCategory = "error_category"
+        case durationMs = "duration_ms"
+        case argsHash = "args_hash"
+        case resultHash = "result_hash"
+        case audit
+        case emittedAt = "emitted_at"
+        case model
+        case provider
+    }
 }
 
 public struct HarnACPToolCall: Codable, Sendable, Equatable {

--- a/spec/protocol-artifacts/README.md
+++ b/spec/protocol-artifacts/README.md
@@ -28,6 +28,8 @@ extension fields, and generated binding vocabulary.
 profile (`agentclientprotocol/agent-client-protocol schema v0.12.2`).
 - `schemas/a2a-0.3.0.schema.json`: Harn's A2A schema profile (`0.3.0`).
 - `schemas/mcp-2025-11-25.schema.json`: Harn's MCP schema profile (`2025-11-25`).
+- `schemas/tool-call-receipt.schema.json`: Harn's typed, privacy-preserving
+`ToolCallReceipt` schema for audited tool calls.
 - `harn-protocol.ts`: TypeScript definitions for ACP session updates,
 tool lifecycle metadata, A2A task events, and MCP metadata.
 - `HarnProtocol.swift`: Swift definitions for the same host-facing surface.

--- a/spec/protocol-artifacts/fixtures/round_trip.json
+++ b/spec/protocol-artifacts/fixtures/round_trip.json
@@ -111,5 +111,34 @@
     },
     "name": "echo",
     "title": "Echo"
+  },
+  "toolCallReceipt": {
+    "args_hash": "0000000000000000000000000000000000000000000000000000000000000000",
+    "audit": {
+      "layers": [
+        {
+          "name": "with_required_reason",
+          "status": "ok"
+        }
+      ],
+      "summary": "Read README.md for context"
+    },
+    "duration_ms": 12,
+    "emitted_at": "2026-05-16T00:00:00Z",
+    "error_category": null,
+    "executor": "harn",
+    "iteration": 1,
+    "kind": "read",
+    "model": "mock",
+    "provider": "mock",
+    "reason": "Read README.md for context",
+    "result_hash": "1111111111111111111111111111111111111111111111111111111111111111",
+    "run_id": "run-42",
+    "schema_version": 1,
+    "session_id": "sess-42",
+    "status": "ok",
+    "tool_call_id": "call-001",
+    "tool_name": "read_file",
+    "turn_index": 0
   }
 }

--- a/spec/protocol-artifacts/go/harnprotocol/harnprotocol.go
+++ b/spec/protocol-artifacts/go/harnprotocol/harnprotocol.go
@@ -214,6 +214,29 @@ var HarnWorkerStatuses = []HarnWorkerStatus{
 	"cancelled",
 }
 
+// ToolCallReceiptStatus is the typed alias for the ToolCallReceiptStatuses wire vocabulary.
+type ToolCallReceiptStatus = string
+
+// ToolCallReceiptStatuses enumerates every wire value Harn currently emits for ToolCallReceiptStatus.
+var ToolCallReceiptStatuses = []ToolCallReceiptStatus{
+	"ok",
+	"schema_violation",
+	"consent_denied",
+	"timeout",
+	"error",
+}
+
+// ToolCallReceiptExecutor is the typed alias for the ToolCallReceiptExecutors wire vocabulary.
+type ToolCallReceiptExecutor = string
+
+// ToolCallReceiptExecutors enumerates every wire value Harn currently emits for ToolCallReceiptExecutor.
+var ToolCallReceiptExecutors = []ToolCallReceiptExecutor{
+	"harn",
+	"host_bridge",
+	"mcp_server",
+	"provider_native",
+}
+
 // A2ATaskState is the typed alias for the A2ATaskStates wire vocabulary.
 type A2ATaskState = string
 
@@ -415,6 +438,30 @@ type HarnToolLifecycleMeta struct {
 	Executor            json.RawMessage `json:"executor,omitempty"`
 	Parsing             *bool           `json:"parsing,omitempty"`
 	RawInputPartial     *string         `json:"rawInputPartial,omitempty"`
+}
+
+// ToolCallReceipt is the typed, privacy-preserving receipt emitted for an
+// audited tool call.
+type ToolCallReceipt struct {
+	SchemaVersion int                      `json:"schema_version"`
+	SessionID     string                   `json:"session_id"`
+	RunID         *string                  `json:"run_id"`
+	ToolCallID    string                   `json:"tool_call_id"`
+	ToolName      string                   `json:"tool_name"`
+	Iteration     uint64                   `json:"iteration"`
+	TurnIndex     *uint64                  `json:"turn_index"`
+	Reason        *string                  `json:"reason"`
+	Kind          *string                  `json:"kind"`
+	Executor      *ToolCallReceiptExecutor `json:"executor"`
+	Status        ToolCallReceiptStatus    `json:"status"`
+	ErrorCategory *string                  `json:"error_category"`
+	DurationMs    uint64                   `json:"duration_ms"`
+	ArgsHash      string                   `json:"args_hash"`
+	ResultHash    *string                  `json:"result_hash"`
+	Audit         json.RawMessage          `json:"audit"`
+	EmittedAt     string                   `json:"emitted_at"`
+	Model         *string                  `json:"model"`
+	Provider      *string                  `json:"provider"`
 }
 
 // ACPToolCall is the `tool_call` session update.

--- a/spec/protocol-artifacts/go/harnprotocol/harnprotocol_test.go
+++ b/spec/protocol-artifacts/go/harnprotocol/harnprotocol_test.go
@@ -235,6 +235,25 @@ func TestRoundTripFixture(t *testing.T) {
 		}
 		assertRoundTrip(t, "MCPTool", raw, out)
 	})
+
+	t.Run("ToolCallReceipt", func(t *testing.T) {
+		raw, ok := fixture["toolCallReceipt"]
+		if !ok {
+			t.Fatal("fixture missing toolCallReceipt")
+		}
+		var receipt ToolCallReceipt
+		if err := json.Unmarshal(raw, &receipt); err != nil {
+			t.Fatalf("decode tool call receipt: %v", err)
+		}
+		if receipt.SchemaVersion != 1 {
+			t.Fatalf("expected schema_version=1, got %d", receipt.SchemaVersion)
+		}
+		out, err := json.Marshal(receipt)
+		if err != nil {
+			t.Fatalf("encode tool call receipt: %v", err)
+		}
+		assertRoundTrip(t, "ToolCallReceipt", raw, out)
+	})
 }
 
 func mustString(t *testing.T, fixture map[string]json.RawMessage, key string) string {
@@ -330,6 +349,8 @@ func TestVocabulariesArePopulated(t *testing.T) {
 		{"ACPToolCallStatuses", ACPToolCallStatuses},
 		{"HarnToolCallErrorCategories", HarnToolCallErrorCategories},
 		{"HarnSideEffectLevels", HarnSideEffectLevels},
+		{"ToolCallReceiptStatuses", ToolCallReceiptStatuses},
+		{"ToolCallReceiptExecutors", ToolCallReceiptExecutors},
 		{"A2ATaskStates", A2ATaskStates},
 		{"A2ATaskEventTypes", A2ATaskEventTypes},
 		{"MCPMethods", MCPMethods},

--- a/spec/protocol-artifacts/harn-protocol.ts
+++ b/spec/protocol-artifacts/harn-protocol.ts
@@ -158,6 +158,23 @@ export const HARN_WORKER_STATUSES = [
 ] as const
 export type HarnWorkerStatus = (typeof HARN_WORKER_STATUSES)[number]
 
+export const HARN_TOOL_CALL_RECEIPT_STATUSES = [
+  "ok",
+  "schema_violation",
+  "consent_denied",
+  "timeout",
+  "error",
+] as const
+export type HarnToolCallReceiptStatus = (typeof HARN_TOOL_CALL_RECEIPT_STATUSES)[number]
+
+export const HARN_TOOL_CALL_RECEIPT_EXECUTORS = [
+  "harn",
+  "host_bridge",
+  "mcp_server",
+  "provider_native",
+] as const
+export type HarnToolCallReceiptExecutor = (typeof HARN_TOOL_CALL_RECEIPT_EXECUTORS)[number]
+
 export const A2A_TASK_STATES = [
   "submitted",
   "working",
@@ -266,6 +283,28 @@ export interface HarnToolLifecycleMeta {
   executor?: ACPToolExecutor
   parsing?: boolean
   rawInputPartial?: string
+}
+
+export interface ToolCallReceipt {
+  schema_version: number
+  session_id: string
+  run_id: string | null
+  tool_call_id: string
+  tool_name: string
+  iteration: number
+  turn_index: number | null
+  reason: string | null
+  kind: string | null
+  executor: HarnToolCallReceiptExecutor | null
+  status: HarnToolCallReceiptStatus
+  error_category: string | null
+  duration_ms: number
+  args_hash: string
+  result_hash: string | null
+  audit: ACPValue
+  emitted_at: string
+  model: string | null
+  provider: string | null
 }
 
 export interface ACPToolCall {

--- a/spec/protocol-artifacts/manifest.json
+++ b/spec/protocol-artifacts/manifest.json
@@ -228,6 +228,23 @@
     ],
     "protocolVersion": "2025-11-25"
   },
+  "receipts": {
+    "toolCallReceiptExecutors": [
+      "harn",
+      "host_bridge",
+      "mcp_server",
+      "provider_native"
+    ],
+    "toolCallReceiptSchema": "schemas/tool-call-receipt.schema.json",
+    "toolCallReceiptSchemaVersion": 1,
+    "toolCallReceiptStatuses": [
+      "ok",
+      "schema_violation",
+      "consent_denied",
+      "timeout",
+      "error"
+    ]
+  },
   "schemaVersion": 1,
   "schemas": [
     {
@@ -271,6 +288,15 @@
         "upstream_version": "2025-11-25"
       },
       "source": "conformance/protocols/schemas/mcp-2025-11-25.schema.json"
+    },
+    {
+      "artifact": "schemas/tool-call-receipt.schema.json",
+      "protocol": "harn",
+      "provenance": {
+        "schemaVersion": 1,
+        "source": "crates/harn-vm/src/llm/receipts.rs"
+      },
+      "source": "crates/harn-vm/src/llm/receipts.rs"
     }
   ]
 }

--- a/spec/protocol-artifacts/python/harn_protocol.py
+++ b/spec/protocol-artifacts/python/harn_protocol.py
@@ -33,6 +33,8 @@ __all__ = [
     "HARN_TOOL_CALL_ERROR_CATEGORIES",
     "HARN_SIDE_EFFECT_LEVELS",
     "HARN_WORKER_STATUSES",
+    "HARN_TOOL_CALL_RECEIPT_STATUSES",
+    "HARN_TOOL_CALL_RECEIPT_EXECUTORS",
     "HARN_TOOL_LIFECYCLE_EXTENSION_FIELDS",
     "HARN_CONTENT_EXTENSION_FIELDS",
     "A2A_METHODS",
@@ -49,6 +51,8 @@ __all__ = [
     "HarnToolCallErrorCategory",
     "HarnSideEffectLevel",
     "HarnWorkerStatus",
+    "ToolCallReceiptStatus",
+    "ToolCallReceiptExecutor",
     "A2ATaskState",
     "A2ATaskEventType",
     "MCPLoggingLevel",
@@ -60,6 +64,7 @@ __all__ = [
     "HarnExtensionMeta",
     "ACPContentBlock",
     "HarnToolLifecycleMeta",
+    "ToolCallReceipt",
     "ACPToolCall",
     "ACPToolCallUpdate",
     "ACPSessionUpdateEnvelope",
@@ -218,6 +223,19 @@ HARN_WORKER_STATUSES: tuple = (
     "completed",
     "failed",
     "cancelled",
+)
+HARN_TOOL_CALL_RECEIPT_STATUSES: tuple = (
+    "ok",
+    "schema_violation",
+    "consent_denied",
+    "timeout",
+    "error",
+)
+HARN_TOOL_CALL_RECEIPT_EXECUTORS: tuple = (
+    "harn",
+    "host_bridge",
+    "mcp_server",
+    "provider_native",
 )
 HARN_TOOL_LIFECYCLE_EXTENSION_FIELDS: tuple = (
     "audit",
@@ -386,6 +404,21 @@ class HarnWorkerStatus(str, Enum):
     CANCELLED = "cancelled"
 
 
+class ToolCallReceiptStatus(str, Enum):
+    OK = "ok"
+    SCHEMA_VIOLATION = "schema_violation"
+    CONSENT_DENIED = "consent_denied"
+    TIMEOUT = "timeout"
+    ERROR = "error"
+
+
+class ToolCallReceiptExecutor(str, Enum):
+    HARN = "harn"
+    HOST_BRIDGE = "host_bridge"
+    MCP_SERVER = "mcp_server"
+    PROVIDER_NATIVE = "provider_native"
+
+
 class A2ATaskState(str, Enum):
     SUBMITTED = "submitted"
     WORKING = "working"
@@ -524,6 +557,32 @@ class HarnToolLifecycleMeta(_HarnDataclass):
     executor: Optional[JsonValue] = None
     parsing: Optional[bool] = None
     rawInputPartial: Optional[str] = None
+
+
+@dataclass
+class ToolCallReceipt(_HarnDataclass):
+    schema_version: int
+    session_id: str
+    tool_call_id: str
+    tool_name: str
+    iteration: int
+    status: str
+    duration_ms: int
+    args_hash: str
+    audit: JsonValue
+    emitted_at: str
+    run_id: Optional[str] = None
+    turn_index: Optional[int] = None
+    reason: Optional[str] = None
+    kind: Optional[str] = None
+    executor: Optional[str] = None
+    error_category: Optional[str] = None
+    result_hash: Optional[str] = None
+    model: Optional[str] = None
+    provider: Optional[str] = None
+
+    def to_wire(self) -> JsonObject:
+        return asdict(self)
 
 
 @dataclass

--- a/spec/protocol-artifacts/schemas/tool-call-receipt.schema.json
+++ b/spec/protocol-artifacts/schemas/tool-call-receipt.schema.json
@@ -1,0 +1,145 @@
+{
+  "$id": "https://harnlang.com/schemas/tool-call-receipt.v1.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "args_hash": {
+      "pattern": "^[a-f0-9]{64}$",
+      "type": "string"
+    },
+    "audit": true,
+    "duration_ms": {
+      "minimum": 0,
+      "type": "integer"
+    },
+    "emitted_at": {
+      "format": "date-time",
+      "type": "string"
+    },
+    "error_category": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "executor": {
+      "enum": [
+        "harn",
+        "host_bridge",
+        "mcp_server",
+        "provider_native",
+        null
+      ],
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "iteration": {
+      "minimum": 0,
+      "type": "integer"
+    },
+    "kind": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "model": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "provider": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "reason": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "result_hash": {
+      "anyOf": [
+        {
+          "pattern": "^[a-f0-9]{64}$",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "run_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "schema_version": {
+      "const": 1,
+      "description": "Receipt schema version. Starts at 1.",
+      "type": "integer"
+    },
+    "session_id": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "status": {
+      "enum": [
+        "ok",
+        "schema_violation",
+        "consent_denied",
+        "timeout",
+        "error"
+      ],
+      "type": "string"
+    },
+    "tool_call_id": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "tool_name": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "turn_index": {
+      "minimum": 0,
+      "type": [
+        "integer",
+        "null"
+      ]
+    }
+  },
+  "required": [
+    "schema_version",
+    "session_id",
+    "run_id",
+    "tool_call_id",
+    "tool_name",
+    "iteration",
+    "turn_index",
+    "reason",
+    "kind",
+    "executor",
+    "status",
+    "error_category",
+    "duration_ms",
+    "args_hash",
+    "result_hash",
+    "audit",
+    "emitted_at",
+    "model",
+    "provider"
+  ],
+  "title": "ToolCallReceipt",
+  "type": "object",
+  "x-harn-provenance": {
+    "schemaVersion": 1,
+    "source": "crates/harn-vm/src/llm/receipts.rs"
+  }
+}


### PR DESCRIPTION
## Summary
- add a typed `ToolCallReceipt` schema/serde type and wire it through `tool_call_audit` agent events plus ACP event mirroring
- extend `with_audit_log` with `local`/`cloud`/`both` sinks, `local_receipt_sink`, argument-key redaction, and privacy-preserving hashes
- publish generated schema/bindings and add conformance, smoke, and docs coverage

Closes #1694

## Verification
- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-1694 cargo test -p harn-vm tool_call --lib`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-1694 cargo test -p harn-cli dump_protocol_artifacts --lib`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-1694 cargo test -p harn-serve agent_event --lib`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-1694 make check-protocol-artifacts`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-1694 make check-bindings`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-1694 cargo run --quiet --bin harn -- test conformance --filter tool_call_receipts_local_sink`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-1694 cargo run --quiet --bin harn -- test conformance --filter tool_middleware`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-1694 cargo run --quiet --bin harn -- run scripts/smoke_tool_receipts.harn`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-1694 make fmt-harn`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-1694 make check-docs-snippets`
- `make lint-test-patterns`
- `git diff --check`
- pre-commit hook: Rust/Harn formatting, staged Harn lint, clippy, CI ratchets, highlight sync, markdown lint
- pre-push hook: targeted local checks, affected Harn format/lint, markdown lint, highlight drift check
