### PR TITLE
hostlib: add per-OS secret_store primitive (#1714)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ condensed series summaries instead of full per-patch history.
 
 ### Added
 
+- **`secret_store` hostlib capability (#1714).** Adds
+  `hostlib_secret_store_{get,set,delete,list}` to `harn-hostlib`, a
+  generic per-application credential primitive any Harn-hosted
+  application can compose. Picks an Apple Keychain backend on
+  macOS/iOS, a Credential Manager backend on Windows, and a
+  `0o600`-permissioned JSON file at
+  `$XDG_CONFIG_HOME/<account>/credentials.json` everywhere else.
+  `HARN_SECRET_STORE_BACKEND=file` forces the file backend on every OS
+  for sandboxed CI and eval harnesses. The file-backend path layout is
+  byte-compatible with burin-code's existing credentials file so
+  existing deployments migrate without data movement, and JSON schemas
+  under `crates/harn-hostlib/schemas/secret_store/` keep `harn check`
+  preflight covering the new builtins. Docs at
+  `docs/src/hostlib/secret_store.md`.
 - **Cerebras provider (#1705).** Added a first-class `cerebras` provider
   routed through the OpenAI-compatible stack with a `provider_family =
   "openai"` capability inheritance row. Catalog ships canonical

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2169,6 +2169,7 @@ dependencies = [
  "notify",
  "once_cell",
  "regex",
+ "security-framework 3.7.0",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -2198,6 +2199,7 @@ dependencies = [
  "tree-sitter-typescript",
  "tree-sitter-zig",
  "walkdir",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/harn-hostlib/Cargo.toml
+++ b/crates/harn-hostlib/Cargo.toml
@@ -75,6 +75,19 @@ tree-sitter-lua = "0.5"
 tree-sitter-haskell = "0.23"
 tree-sitter-r = "1.2"
 
+# Per-OS secret-store backends. The file backend is always compiled in
+# (and is the universal fallback when `HARN_SECRET_STORE_BACKEND=file` is
+# set); the OS-native backends are gated behind target_os so headless
+# Linux CI doesn't pull in macOS or Windows toolchains.
+[target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
+security-framework = "3.7"
+
+[target.'cfg(target_os = "windows")'.dependencies]
+windows-sys = { version = "0.61.2", features = [
+    "Win32_Foundation",
+    "Win32_Security_Credentials",
+] }
+
 [dev-dependencies]
 tempfile = "3"
 serde_json = "1"

--- a/crates/harn-hostlib/schemas/secret_store/delete.request.json
+++ b/crates/harn-hostlib/schemas/secret_store/delete.request.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/secret_store/delete.request.json",
+  "title": "secret_store.delete request",
+  "type": "object",
+  "properties": {
+    "account": { "type": "string", "minLength": 1 },
+    "key": { "type": "string", "minLength": 1 }
+  },
+  "required": ["account", "key"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/secret_store/delete.response.json
+++ b/crates/harn-hostlib/schemas/secret_store/delete.response.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/secret_store/delete.response.json",
+  "title": "secret_store.delete response",
+  "type": "object",
+  "properties": {
+    "account": { "type": "string" },
+    "key": { "type": "string" },
+    "deleted": { "type": "boolean" },
+    "backend": { "type": "string", "enum": ["keychain", "wincred", "file"] }
+  },
+  "required": ["account", "key", "deleted", "backend"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/secret_store/get.request.json
+++ b/crates/harn-hostlib/schemas/secret_store/get.request.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/secret_store/get.request.json",
+  "title": "secret_store.get request",
+  "type": "object",
+  "properties": {
+    "account": { "type": "string", "minLength": 1 },
+    "key": { "type": "string", "minLength": 1 }
+  },
+  "required": ["account", "key"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/secret_store/get.response.json
+++ b/crates/harn-hostlib/schemas/secret_store/get.response.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/secret_store/get.response.json",
+  "title": "secret_store.get response",
+  "type": "object",
+  "properties": {
+    "account": { "type": "string" },
+    "key": { "type": "string" },
+    "value": { "type": ["string", "null"] },
+    "backend": { "type": "string", "enum": ["keychain", "wincred", "file"] }
+  },
+  "required": ["account", "key", "value", "backend"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/secret_store/list.request.json
+++ b/crates/harn-hostlib/schemas/secret_store/list.request.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/secret_store/list.request.json",
+  "title": "secret_store.list request",
+  "type": "object",
+  "properties": {
+    "account": { "type": "string", "minLength": 1 }
+  },
+  "required": ["account"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/secret_store/list.response.json
+++ b/crates/harn-hostlib/schemas/secret_store/list.response.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/secret_store/list.response.json",
+  "title": "secret_store.list response",
+  "type": "object",
+  "properties": {
+    "account": { "type": "string" },
+    "keys": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "backend": { "type": "string", "enum": ["keychain", "wincred", "file"] }
+  },
+  "required": ["account", "keys", "backend"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/secret_store/set.request.json
+++ b/crates/harn-hostlib/schemas/secret_store/set.request.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/secret_store/set.request.json",
+  "title": "secret_store.set request",
+  "type": "object",
+  "properties": {
+    "account": { "type": "string", "minLength": 1 },
+    "key": { "type": "string", "minLength": 1 },
+    "value": { "type": "string" }
+  },
+  "required": ["account", "key", "value"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/secret_store/set.response.json
+++ b/crates/harn-hostlib/schemas/secret_store/set.response.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/secret_store/set.response.json",
+  "title": "secret_store.set response",
+  "type": "object",
+  "properties": {
+    "account": { "type": "string" },
+    "key": { "type": "string" },
+    "backend": { "type": "string", "enum": ["keychain", "wincred", "file"] }
+  },
+  "required": ["account", "key", "backend"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/src/lib.rs
+++ b/crates/harn-hostlib/src/lib.rs
@@ -34,6 +34,7 @@ pub mod fs_watch;
 pub mod process;
 pub mod scanner;
 pub mod schemas;
+pub mod secret_store;
 pub mod tools;
 
 mod registry;
@@ -54,7 +55,8 @@ pub fn install_default(vm: &mut harn_vm::Vm) -> HostlibRegistry {
         .with(code_index::CodeIndexCapability::new())
         .with(scanner::ScannerCapability)
         .with(fs_watch::FsWatchCapability)
-        .with(tools::ToolsCapability);
+        .with(tools::ToolsCapability)
+        .with(secret_store::SecretStoreCapability);
     registry.register_into_vm(vm);
     registry
 }

--- a/crates/harn-hostlib/src/schemas.rs
+++ b/crates/harn-hostlib/src/schemas.rs
@@ -729,6 +729,55 @@ pub const SCHEMAS: &[(&str, &str, SchemaKind, &str)] = &[
         SchemaKind::Response,
         include_str!("../schemas/tools/enable.response.json"),
     ),
+    // secret_store/
+    (
+        "secret_store",
+        "get",
+        SchemaKind::Request,
+        include_str!("../schemas/secret_store/get.request.json"),
+    ),
+    (
+        "secret_store",
+        "get",
+        SchemaKind::Response,
+        include_str!("../schemas/secret_store/get.response.json"),
+    ),
+    (
+        "secret_store",
+        "set",
+        SchemaKind::Request,
+        include_str!("../schemas/secret_store/set.request.json"),
+    ),
+    (
+        "secret_store",
+        "set",
+        SchemaKind::Response,
+        include_str!("../schemas/secret_store/set.response.json"),
+    ),
+    (
+        "secret_store",
+        "delete",
+        SchemaKind::Request,
+        include_str!("../schemas/secret_store/delete.request.json"),
+    ),
+    (
+        "secret_store",
+        "delete",
+        SchemaKind::Response,
+        include_str!("../schemas/secret_store/delete.response.json"),
+    ),
+    (
+        "secret_store",
+        "list",
+        SchemaKind::Request,
+        include_str!("../schemas/secret_store/list.request.json"),
+    ),
+    (
+        "secret_store",
+        "list",
+        SchemaKind::Response,
+        include_str!("../schemas/secret_store/list.response.json"),
+    ),
 ];
 
 /// Look up a single schema as raw JSON text.

--- a/crates/harn-hostlib/src/secret_store/file.rs
+++ b/crates/harn-hostlib/src/secret_store/file.rs
@@ -1,0 +1,169 @@
+//! File-backed secret store.
+//!
+//! Stores per-account `{key: value}` maps as a flat JSON dictionary. The
+//! root directory cascade is:
+//!
+//! 1. `$HARN_SECRET_STORE_FILE_ROOT` (test/eval hook).
+//! 2. `%APPDATA%` on Windows.
+//! 3. `$XDG_CONFIG_HOME` on every other OS.
+//! 4. `~/.config` if `$HOME` is set.
+//! 5. `./.harn-secret-store` as a last resort.
+//!
+//! `<account>/credentials.json` is appended underneath whichever root
+//! resolves first. On Unix the file is chmod-ed to `0o600` and the
+//! account subdirectory to `0o700`. On Windows the file sits inside
+//! `%APPDATA%`, which is already user-scoped, so no explicit chmod is
+//! issued.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use crate::secret_store::Backend;
+
+/// File-backed secret store. Stateless: every operation reloads from disk
+/// so concurrent processes see each other's writes immediately.
+pub(super) struct FileStore;
+
+impl FileStore {
+    pub(super) fn new() -> Self {
+        FileStore
+    }
+
+    fn credentials_path(account: &str) -> PathBuf {
+        config_dir().join(account).join("credentials.json")
+    }
+
+    fn read_map(account: &str) -> io::Result<BTreeMap<String, String>> {
+        let path = Self::credentials_path(account);
+        match fs::read(&path) {
+            Ok(bytes) => serde_json::from_slice(&bytes).map_err(|err| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "credentials file at {} is not a JSON object: {err}",
+                        path.display()
+                    ),
+                )
+            }),
+            Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(BTreeMap::new()),
+            Err(err) => Err(err),
+        }
+    }
+
+    fn write_map(account: &str, map: &BTreeMap<String, String>) -> io::Result<()> {
+        let path = Self::credentials_path(account);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+            apply_dir_permissions(parent)?;
+        }
+        let bytes = serde_json::to_vec_pretty(map)
+            .map_err(|err| io::Error::other(format!("serialize credentials map: {err}")))?;
+        atomic_write(&path, &bytes)?;
+        apply_file_permissions(&path)?;
+        Ok(())
+    }
+}
+
+impl Backend for FileStore {
+    fn name(&self) -> &'static str {
+        "file"
+    }
+
+    fn get(&self, account: &str, key: &str) -> io::Result<Option<String>> {
+        Ok(Self::read_map(account)?.get(key).cloned())
+    }
+
+    fn set(&self, account: &str, key: &str, value: &str) -> io::Result<()> {
+        let mut map = Self::read_map(account)?;
+        map.insert(key.to_string(), value.to_string());
+        Self::write_map(account, &map)
+    }
+
+    fn delete(&self, account: &str, key: &str) -> io::Result<bool> {
+        let mut map = Self::read_map(account)?;
+        let removed = map.remove(key).is_some();
+        if removed {
+            Self::write_map(account, &map)?;
+        }
+        Ok(removed)
+    }
+
+    fn list(&self, account: &str) -> io::Result<Vec<String>> {
+        Ok(Self::read_map(account)?.into_keys().collect())
+    }
+}
+
+/// Root config directory. The `<account>` segment is appended by the
+/// caller so each application's credentials land in its own subdirectory
+/// (matches Burin's existing `$XDG_CONFIG_HOME/burin/credentials.json`).
+fn config_dir() -> PathBuf {
+    if let Some(override_root) = env_nonempty("HARN_SECRET_STORE_FILE_ROOT") {
+        return PathBuf::from(override_root);
+    }
+    #[cfg(target_os = "windows")]
+    {
+        if let Some(appdata) = env_nonempty("APPDATA") {
+            return PathBuf::from(appdata);
+        }
+    }
+    if let Some(xdg) = env_nonempty("XDG_CONFIG_HOME") {
+        return PathBuf::from(xdg);
+    }
+    if let Some(home) = home_dir() {
+        return home.join(".config");
+    }
+    // Last-resort: current directory. Rare in practice (no $HOME, no
+    // XDG_CONFIG_HOME, no APPDATA — typically only in broken containers).
+    PathBuf::from(".harn-secret-store")
+}
+
+fn env_nonempty(key: &str) -> Option<String> {
+    std::env::var(key).ok().filter(|v| !v.is_empty())
+}
+
+fn home_dir() -> Option<PathBuf> {
+    #[cfg(target_os = "windows")]
+    {
+        if let Some(userprofile) = env_nonempty("USERPROFILE") {
+            return Some(PathBuf::from(userprofile));
+        }
+    }
+    env_nonempty("HOME").map(PathBuf::from)
+}
+
+fn atomic_write(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    let dir = path.parent().unwrap_or_else(|| Path::new("."));
+    let file_name = path
+        .file_name()
+        .map(|n| n.to_owned())
+        .unwrap_or_else(|| std::ffi::OsString::from("credentials.json"));
+    let mut tmp = dir.to_path_buf();
+    tmp.push(format!(".{}.tmp", file_name.to_string_lossy()));
+    fs::write(&tmp, bytes)?;
+    fs::rename(&tmp, path)?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn apply_dir_permissions(dir: &Path) -> io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    fs::set_permissions(dir, fs::Permissions::from_mode(0o700))
+}
+
+#[cfg(not(unix))]
+fn apply_dir_permissions(_dir: &Path) -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn apply_file_permissions(file: &Path) -> io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    fs::set_permissions(file, fs::Permissions::from_mode(0o600))
+}
+
+#[cfg(not(unix))]
+fn apply_file_permissions(_file: &Path) -> io::Result<()> {
+    Ok(())
+}

--- a/crates/harn-hostlib/src/secret_store/keychain.rs
+++ b/crates/harn-hostlib/src/secret_store/keychain.rs
@@ -1,0 +1,85 @@
+//! Apple Keychain-backed secret store. The `account` namespace maps to
+//! `kSecAttrService`, the `key` argument to `kSecAttrAccount`, matching the
+//! Swift `KeychainCredentialStore` layout from burin-code so existing
+//! credentials are reachable without migration.
+
+#![cfg(any(target_os = "macos", target_os = "ios"))]
+
+use std::io;
+
+use security_framework::item::{ItemClass, ItemSearchOptions, Limit, SearchResult};
+use security_framework::passwords::{
+    delete_generic_password, get_generic_password, set_generic_password,
+};
+
+use crate::secret_store::Backend;
+
+/// `errSecItemNotFound`. Returned when a Keychain query has no match.
+const ERR_SEC_ITEM_NOT_FOUND: i32 = -25300;
+
+pub(super) struct KeychainStore;
+
+impl KeychainStore {
+    pub(super) fn new() -> Self {
+        KeychainStore
+    }
+}
+
+impl Backend for KeychainStore {
+    fn name(&self) -> &'static str {
+        "keychain"
+    }
+
+    fn get(&self, account: &str, key: &str) -> io::Result<Option<String>> {
+        match get_generic_password(account, key) {
+            Ok(bytes) => {
+                let value = String::from_utf8(bytes)
+                    .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+                Ok(Some(value))
+            }
+            Err(err) if err.code() == ERR_SEC_ITEM_NOT_FOUND => Ok(None),
+            Err(err) => Err(io::Error::other(format!("keychain get: {err}"))),
+        }
+    }
+
+    fn set(&self, account: &str, key: &str, value: &str) -> io::Result<()> {
+        set_generic_password(account, key, value.as_bytes())
+            .map_err(|err| io::Error::other(format!("keychain set: {err}")))
+    }
+
+    fn delete(&self, account: &str, key: &str) -> io::Result<bool> {
+        match delete_generic_password(account, key) {
+            Ok(()) => Ok(true),
+            Err(err) if err.code() == ERR_SEC_ITEM_NOT_FOUND => Ok(false),
+            Err(err) => Err(io::Error::other(format!("keychain delete: {err}"))),
+        }
+    }
+
+    fn list(&self, account: &str) -> io::Result<Vec<String>> {
+        let mut search = ItemSearchOptions::new();
+        search
+            .class(ItemClass::generic_password())
+            .service(account)
+            .limit(Limit::All)
+            .load_attributes(true);
+
+        let results = match search.search() {
+            Ok(results) => results,
+            Err(err) if err.code() == ERR_SEC_ITEM_NOT_FOUND => return Ok(Vec::new()),
+            Err(err) => return Err(io::Error::other(format!("keychain list: {err}"))),
+        };
+
+        let mut keys = Vec::with_capacity(results.len());
+        for entry in results {
+            if let SearchResult::Dict(_) = &entry {
+                if let Some(attrs) = entry.simplify_dict() {
+                    if let Some(name) = attrs.get("acct") {
+                        keys.push(name.clone());
+                    }
+                }
+            }
+        }
+        keys.sort();
+        Ok(keys)
+    }
+}

--- a/crates/harn-hostlib/src/secret_store/mod.rs
+++ b/crates/harn-hostlib/src/secret_store/mod.rs
@@ -1,0 +1,205 @@
+//! Per-OS secret-store host primitive.
+//!
+//! Stores credentials in a per-application namespace (`account`) keyed by
+//! a free-form `key`. The active backend is picked at call time:
+//!
+//! | OS               | Default backend                                              |
+//! |------------------|--------------------------------------------------------------|
+//! | macOS / iOS      | Apple Keychain (`security-framework`, generic password item) |
+//! | Windows          | Credential Manager (`CredRead`/`CredWrite`, generic type)    |
+//! | Linux / other    | File backend at `$XDG_CONFIG_HOME/<account>/credentials.json`|
+//!
+//! Setting `HARN_SECRET_STORE_BACKEND=file` forces the file backend on every
+//! OS — useful for sandboxed CI, eval harnesses, and anything that must not
+//! touch the user's keychain. Tests also set `HARN_SECRET_STORE_FILE_ROOT`
+//! to redirect the file backend's root config directory.
+//!
+//! The four registered builtins are intentionally minimal — they own
+//! "where the bytes live" and nothing else. Audit logging, schema
+//! validation beyond builtin signatures, env-vs-stored precedence, and
+//! migration logic belong in the `.harn` orchestration layer.
+
+use std::io;
+use std::rc::Rc;
+use std::sync::Arc;
+
+use harn_vm::VmValue;
+
+use crate::error::HostlibError;
+use crate::registry::{BuiltinRegistry, HostlibCapability, RegisteredBuiltin, SyncHandler};
+use crate::tools::args::{build_dict, dict_arg, require_string, str_value};
+
+mod file;
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+mod keychain;
+#[cfg(target_os = "windows")]
+mod wincred;
+
+const GET_BUILTIN: &str = "hostlib_secret_store_get";
+const SET_BUILTIN: &str = "hostlib_secret_store_set";
+const DELETE_BUILTIN: &str = "hostlib_secret_store_delete";
+const LIST_BUILTIN: &str = "hostlib_secret_store_list";
+
+/// Backend-selection override. When set to `"file"` the file backend is
+/// used unconditionally. Other values fall through to the OS default.
+const BACKEND_ENV: &str = "HARN_SECRET_STORE_BACKEND";
+
+/// Minimal backend contract every implementation honors.
+trait Backend {
+    fn name(&self) -> &'static str;
+    fn get(&self, account: &str, key: &str) -> io::Result<Option<String>>;
+    fn set(&self, account: &str, key: &str, value: &str) -> io::Result<()>;
+    fn delete(&self, account: &str, key: &str) -> io::Result<bool>;
+    fn list(&self, account: &str) -> io::Result<Vec<String>>;
+}
+
+/// Secret-store capability. Stateless: backend selection is resolved on
+/// every call so environment-variable overrides (`HARN_SECRET_STORE_BACKEND`)
+/// take effect without requiring process restart.
+#[derive(Default)]
+pub struct SecretStoreCapability;
+
+impl HostlibCapability for SecretStoreCapability {
+    fn module_name(&self) -> &'static str {
+        "secret_store"
+    }
+
+    fn register_builtins(&self, registry: &mut BuiltinRegistry) {
+        register(registry, GET_BUILTIN, "get", handle_get);
+        register(registry, SET_BUILTIN, "set", handle_set);
+        register(registry, DELETE_BUILTIN, "delete", handle_delete);
+        register(registry, LIST_BUILTIN, "list", handle_list);
+    }
+}
+
+fn register(
+    registry: &mut BuiltinRegistry,
+    name: &'static str,
+    method: &'static str,
+    runner: fn(&[VmValue]) -> Result<VmValue, HostlibError>,
+) {
+    let handler: SyncHandler = Arc::new(runner);
+    registry.register(RegisteredBuiltin {
+        name,
+        module: "secret_store",
+        method,
+        handler,
+    });
+}
+
+fn handle_get(args: &[VmValue]) -> Result<VmValue, HostlibError> {
+    let dict = dict_arg(GET_BUILTIN, args)?;
+    let account = require_nonempty_string(GET_BUILTIN, &dict, "account")?;
+    let key = require_nonempty_string(GET_BUILTIN, &dict, "key")?;
+
+    let backend = select_backend();
+    let value = backend
+        .get(&account, &key)
+        .map_err(|err| backend_err(GET_BUILTIN, err))?;
+
+    Ok(build_dict([
+        ("account".to_string(), str_value(&account)),
+        ("key".to_string(), str_value(&key)),
+        (
+            "value".to_string(),
+            value.as_deref().map(str_value).unwrap_or(VmValue::Nil),
+        ),
+        ("backend".to_string(), str_value(backend.name())),
+    ]))
+}
+
+fn handle_set(args: &[VmValue]) -> Result<VmValue, HostlibError> {
+    let dict = dict_arg(SET_BUILTIN, args)?;
+    let account = require_nonempty_string(SET_BUILTIN, &dict, "account")?;
+    let key = require_nonempty_string(SET_BUILTIN, &dict, "key")?;
+    let value = require_string(SET_BUILTIN, &dict, "value")?;
+
+    let backend = select_backend();
+    backend
+        .set(&account, &key, &value)
+        .map_err(|err| backend_err(SET_BUILTIN, err))?;
+
+    Ok(build_dict([
+        ("account".to_string(), str_value(&account)),
+        ("key".to_string(), str_value(&key)),
+        ("backend".to_string(), str_value(backend.name())),
+    ]))
+}
+
+fn handle_delete(args: &[VmValue]) -> Result<VmValue, HostlibError> {
+    let dict = dict_arg(DELETE_BUILTIN, args)?;
+    let account = require_nonempty_string(DELETE_BUILTIN, &dict, "account")?;
+    let key = require_nonempty_string(DELETE_BUILTIN, &dict, "key")?;
+
+    let backend = select_backend();
+    let deleted = backend
+        .delete(&account, &key)
+        .map_err(|err| backend_err(DELETE_BUILTIN, err))?;
+
+    Ok(build_dict([
+        ("account".to_string(), str_value(&account)),
+        ("key".to_string(), str_value(&key)),
+        ("deleted".to_string(), VmValue::Bool(deleted)),
+        ("backend".to_string(), str_value(backend.name())),
+    ]))
+}
+
+fn handle_list(args: &[VmValue]) -> Result<VmValue, HostlibError> {
+    let dict = dict_arg(LIST_BUILTIN, args)?;
+    let account = require_nonempty_string(LIST_BUILTIN, &dict, "account")?;
+
+    let backend = select_backend();
+    let keys = backend
+        .list(&account)
+        .map_err(|err| backend_err(LIST_BUILTIN, err))?;
+
+    let items: Vec<VmValue> = keys.into_iter().map(|k| str_value(&k)).collect();
+    Ok(build_dict([
+        ("account".to_string(), str_value(&account)),
+        ("keys".to_string(), VmValue::List(Rc::new(items))),
+        ("backend".to_string(), str_value(backend.name())),
+    ]))
+}
+
+fn require_nonempty_string(
+    builtin: &'static str,
+    dict: &std::collections::BTreeMap<String, VmValue>,
+    key: &'static str,
+) -> Result<String, HostlibError> {
+    let value = require_string(builtin, dict, key)?;
+    if value.is_empty() {
+        Err(HostlibError::InvalidParameter {
+            builtin,
+            param: key,
+            message: "must be a non-empty string".to_string(),
+        })
+    } else {
+        Ok(value)
+    }
+}
+
+fn backend_err(builtin: &'static str, err: io::Error) -> HostlibError {
+    HostlibError::Backend {
+        builtin,
+        message: err.to_string(),
+    }
+}
+
+fn select_backend() -> Box<dyn Backend> {
+    if matches!(std::env::var(BACKEND_ENV).as_deref(), Ok("file")) {
+        return Box::new(file::FileStore::new());
+    }
+
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    {
+        Box::new(keychain::KeychainStore::new())
+    }
+    #[cfg(target_os = "windows")]
+    {
+        Box::new(wincred::WinCredStore::new())
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "windows")))]
+    {
+        Box::new(file::FileStore::new())
+    }
+}

--- a/crates/harn-hostlib/src/secret_store/wincred.rs
+++ b/crates/harn-hostlib/src/secret_store/wincred.rs
@@ -1,0 +1,154 @@
+//! Windows Credential Manager backend.
+//!
+//! Maps `(account, key)` onto a generic-type credential with target name
+//! `"<account>/<key>"`. We use the wide-string (`*W`) variants so non-ASCII
+//! account names and values round-trip cleanly.
+
+#![cfg(target_os = "windows")]
+
+use std::io;
+use std::os::windows::ffi::OsStrExt;
+use std::slice;
+
+use windows_sys::Win32::Foundation::{GetLastError, ERROR_NOT_FOUND};
+use windows_sys::Win32::Security::Credentials::{
+    CredDeleteW, CredEnumerateW, CredFree, CredReadW, CredWriteW, CREDENTIALW,
+    CRED_PERSIST_LOCAL_MACHINE, CRED_TYPE_GENERIC,
+};
+
+use crate::secret_store::Backend;
+
+pub(super) struct WinCredStore;
+
+impl WinCredStore {
+    pub(super) fn new() -> Self {
+        WinCredStore
+    }
+}
+
+impl Backend for WinCredStore {
+    fn name(&self) -> &'static str {
+        "wincred"
+    }
+
+    fn get(&self, account: &str, key: &str) -> io::Result<Option<String>> {
+        let target = target_name(account, key);
+        let target_w = to_utf16_z(&target);
+        let mut out: *mut CREDENTIALW = std::ptr::null_mut();
+        let ok = unsafe { CredReadW(target_w.as_ptr(), CRED_TYPE_GENERIC, 0, &mut out) };
+        if ok == 0 {
+            let err = unsafe { GetLastError() };
+            if err == ERROR_NOT_FOUND {
+                return Ok(None);
+            }
+            return Err(io::Error::other(format!("CredReadW failed: code {err}")));
+        }
+        let value = unsafe {
+            let cred = &*out;
+            let len = cred.CredentialBlobSize as usize;
+            let bytes = if cred.CredentialBlob.is_null() || len == 0 {
+                Vec::new()
+            } else {
+                slice::from_raw_parts(cred.CredentialBlob, len).to_vec()
+            };
+            CredFree(out as *const core::ffi::c_void);
+            bytes
+        };
+        let value = String::from_utf8(value)
+            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+        Ok(Some(value))
+    }
+
+    fn set(&self, account: &str, key: &str, value: &str) -> io::Result<()> {
+        let target = target_name(account, key);
+        let mut target_w = to_utf16_z(&target);
+        let mut username_w = to_utf16_z(key);
+        let blob = value.as_bytes();
+
+        let mut cred: CREDENTIALW = unsafe { core::mem::zeroed() };
+        cred.Type = CRED_TYPE_GENERIC;
+        cred.Persist = CRED_PERSIST_LOCAL_MACHINE;
+        cred.TargetName = target_w.as_mut_ptr();
+        cred.UserName = username_w.as_mut_ptr();
+        cred.CredentialBlobSize = blob.len() as u32;
+        cred.CredentialBlob = blob.as_ptr() as *mut u8;
+
+        let ok = unsafe { CredWriteW(&cred, 0) };
+        if ok == 0 {
+            let err = unsafe { GetLastError() };
+            return Err(io::Error::other(format!("CredWriteW failed: code {err}")));
+        }
+        Ok(())
+    }
+
+    fn delete(&self, account: &str, key: &str) -> io::Result<bool> {
+        let target = target_name(account, key);
+        let target_w = to_utf16_z(&target);
+        let ok = unsafe { CredDeleteW(target_w.as_ptr(), CRED_TYPE_GENERIC, 0) };
+        if ok != 0 {
+            return Ok(true);
+        }
+        let err = unsafe { GetLastError() };
+        if err == ERROR_NOT_FOUND {
+            Ok(false)
+        } else {
+            Err(io::Error::other(format!("CredDeleteW failed: code {err}")))
+        }
+    }
+
+    fn list(&self, account: &str) -> io::Result<Vec<String>> {
+        let prefix = format!("{account}/");
+        let filter = to_utf16_z(&format!("{prefix}*"));
+        let mut count: u32 = 0;
+        let mut creds: *mut *mut CREDENTIALW = std::ptr::null_mut();
+        let ok = unsafe { CredEnumerateW(filter.as_ptr(), 0, &mut count, &mut creds) };
+        if ok == 0 {
+            let err = unsafe { GetLastError() };
+            if err == ERROR_NOT_FOUND {
+                return Ok(Vec::new());
+            }
+            return Err(io::Error::other(format!(
+                "CredEnumerateW failed: code {err}"
+            )));
+        }
+        let mut keys = Vec::with_capacity(count as usize);
+        unsafe {
+            let entries = slice::from_raw_parts(creds, count as usize);
+            for entry in entries {
+                let cred = &**entry;
+                if !cred.TargetName.is_null() {
+                    let name = utf16_z_to_string(cred.TargetName);
+                    if let Some(rest) = name.strip_prefix(&prefix) {
+                        keys.push(rest.to_string());
+                    }
+                }
+            }
+            CredFree(creds as *const core::ffi::c_void);
+        }
+        keys.sort();
+        Ok(keys)
+    }
+}
+
+fn target_name(account: &str, key: &str) -> String {
+    format!("{account}/{key}")
+}
+
+fn to_utf16_z(s: &str) -> Vec<u16> {
+    std::ffi::OsString::from(s)
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect()
+}
+
+/// Read a NUL-terminated UTF-16 wide string from a Windows credentials
+/// pointer. Safe so long as the pointer originates from the Credentials
+/// API (always NUL-terminated when non-null).
+unsafe fn utf16_z_to_string(ptr: *const u16) -> String {
+    let mut len = 0;
+    while unsafe { *ptr.add(len) } != 0 {
+        len += 1;
+    }
+    let slice = unsafe { slice::from_raw_parts(ptr, len) };
+    String::from_utf16_lossy(slice)
+}

--- a/crates/harn-hostlib/tests/registration.rs
+++ b/crates/harn-hostlib/tests/registration.rs
@@ -9,8 +9,8 @@
 
 use harn_hostlib::{
     ast::AstCapability, code_index::CodeIndexCapability, fs_watch::FsWatchCapability,
-    scanner::ScannerCapability, schemas, tools::ToolsCapability, BuiltinRegistry,
-    HostlibCapability, HostlibError, HostlibRegistry,
+    scanner::ScannerCapability, schemas, secret_store::SecretStoreCapability,
+    tools::ToolsCapability, BuiltinRegistry, HostlibCapability, HostlibError, HostlibRegistry,
 };
 
 fn collect_into_registry<C: HostlibCapability>(cap: C) -> BuiltinRegistry {
@@ -241,17 +241,58 @@ fn tools_capability_registers_documented_methods() {
 }
 
 #[test]
+fn secret_store_capability_registers_documented_methods() {
+    let registry = collect_into_registry(SecretStoreCapability);
+    let names: Vec<_> = registry.iter().map(|b| b.name).collect();
+    assert_eq!(
+        names,
+        vec![
+            "hostlib_secret_store_get",
+            "hostlib_secret_store_set",
+            "hostlib_secret_store_delete",
+            "hostlib_secret_store_list",
+        ]
+    );
+    // Each entry must refuse an empty payload with a structured
+    // `MissingParameter` rather than panicking.
+    let expected_missing: &[(&str, &str)] = &[
+        ("hostlib_secret_store_get", "account"),
+        ("hostlib_secret_store_set", "account"),
+        ("hostlib_secret_store_delete", "account"),
+        ("hostlib_secret_store_list", "account"),
+    ];
+    for (name, expected_param) in expected_missing {
+        let entry = registry.find(name).expect("registered");
+        let err = (entry.handler)(&[]).expect_err("must reject empty args");
+        match err {
+            HostlibError::MissingParameter { builtin, param } => {
+                assert_eq!(builtin, *name);
+                assert_eq!(param, *expected_param);
+            }
+            other => panic!("expected MissingParameter for {name}, got {other:?}"),
+        }
+    }
+}
+
+#[test]
 fn install_default_wires_every_module_into_a_vm() {
     let mut vm = harn_vm::Vm::new();
     let registry = harn_hostlib::install_default(&mut vm);
 
     assert_eq!(
         registry.modules(),
-        &["ast", "code_index", "scanner", "fs_watch", "tools"]
+        &[
+            "ast",
+            "code_index",
+            "scanner",
+            "fs_watch",
+            "tools",
+            "secret_store"
+        ]
     );
     // Builtin count: 12 ast + 27 code_index + 2 scanner + 2 fs_watch + 13
-    // tools + 1 hostlib_enable = 57.
-    assert!(registry.builtins().len() >= 57);
+    // tools + 1 hostlib_enable + 4 secret_store = 61.
+    assert!(registry.builtins().len() >= 61);
 }
 
 #[test]
@@ -261,7 +302,8 @@ fn every_registered_builtin_has_request_and_response_schemas() {
         .with(CodeIndexCapability::new())
         .with(ScannerCapability)
         .with(FsWatchCapability)
-        .with(ToolsCapability);
+        .with(ToolsCapability)
+        .with(SecretStoreCapability);
 
     for entry in registry.builtins().iter() {
         assert!(

--- a/crates/harn-hostlib/tests/secret_store.rs
+++ b/crates/harn-hostlib/tests/secret_store.rs
@@ -1,0 +1,313 @@
+//! Integration tests for the secret-store hostlib capability.
+//!
+//! These tests run with `HARN_SECRET_STORE_BACKEND=file` and
+//! `HARN_SECRET_STORE_FILE_ROOT` redirected to a per-test `TempDir`, so
+//! they pass on every CI runner regardless of whether a real Keychain or
+//! Credential Manager is reachable. The OS-native backends are exercised
+//! by `os_native.rs` on the matching target.
+
+use std::collections::BTreeMap;
+use std::rc::Rc;
+use std::sync::Mutex;
+
+use harn_hostlib::{
+    secret_store::SecretStoreCapability, BuiltinRegistry, HostlibCapability, HostlibError,
+};
+use harn_vm::VmValue;
+use tempfile::TempDir;
+
+/// Process-wide lock guarding `HARN_SECRET_STORE_BACKEND` mutation. Cargo
+/// runs tests in parallel by default, and the env var is read on every
+/// builtin call, so we need to serialize writers.
+fn env_lock() -> &'static Mutex<()> {
+    static LOCK: Mutex<()> = Mutex::new(());
+    &LOCK
+}
+
+struct EnvGuard {
+    keys: Vec<&'static str>,
+    prior: Vec<Option<String>>,
+    _lock: std::sync::MutexGuard<'static, ()>,
+}
+
+impl EnvGuard {
+    fn new(vars: &[(&'static str, &str)]) -> Self {
+        let lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        let mut keys = Vec::with_capacity(vars.len());
+        let mut prior = Vec::with_capacity(vars.len());
+        for (key, value) in vars {
+            keys.push(*key);
+            prior.push(std::env::var(key).ok());
+            unsafe {
+                std::env::set_var(key, value);
+            }
+        }
+        Self {
+            keys,
+            prior,
+            _lock: lock,
+        }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for (key, prior) in self.keys.iter().zip(self.prior.iter()) {
+            unsafe {
+                match prior {
+                    Some(v) => std::env::set_var(key, v),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+    }
+}
+
+fn registry() -> BuiltinRegistry {
+    let mut registry = BuiltinRegistry::new();
+    SecretStoreCapability.register_builtins(&mut registry);
+    registry
+}
+
+fn dict_arg(entries: &[(&str, VmValue)]) -> Vec<VmValue> {
+    let mut map: BTreeMap<String, VmValue> = BTreeMap::new();
+    for (k, v) in entries {
+        map.insert(k.to_string(), v.clone());
+    }
+    vec![VmValue::Dict(Rc::new(map))]
+}
+
+fn vm_string(s: &str) -> VmValue {
+    VmValue::String(Rc::from(s))
+}
+
+fn dict_get<'a>(value: &'a VmValue, key: &str) -> &'a VmValue {
+    match value {
+        VmValue::Dict(d) => d.get(key).expect("key present"),
+        other => panic!("not a dict: {other:?}"),
+    }
+}
+
+fn as_string(value: &VmValue) -> &str {
+    match value {
+        VmValue::String(s) => s.as_ref(),
+        other => panic!("not a string: {other:?}"),
+    }
+}
+
+#[test]
+fn round_trip_set_get_delete_via_file_backend() {
+    let root = TempDir::new().unwrap();
+    let _env = EnvGuard::new(&[
+        ("HARN_SECRET_STORE_BACKEND", "file"),
+        ("HARN_SECRET_STORE_FILE_ROOT", root.path().to_str().unwrap()),
+    ]);
+    let reg = registry();
+
+    let set = reg.find("hostlib_secret_store_set").unwrap();
+    let get = reg.find("hostlib_secret_store_get").unwrap();
+    let delete = reg.find("hostlib_secret_store_delete").unwrap();
+
+    let set_args = dict_arg(&[
+        ("account", vm_string("burin")),
+        ("key", vm_string("OPENAI_API_KEY")),
+        ("value", vm_string("sk-test")),
+    ]);
+    let resp = (set.handler)(&set_args).unwrap();
+    assert_eq!(as_string(dict_get(&resp, "backend")), "file");
+
+    let get_args = dict_arg(&[
+        ("account", vm_string("burin")),
+        ("key", vm_string("OPENAI_API_KEY")),
+    ]);
+    let resp = (get.handler)(&get_args).unwrap();
+    assert_eq!(as_string(dict_get(&resp, "value")), "sk-test");
+
+    let delete_resp = (delete.handler)(&get_args).unwrap();
+    assert!(matches!(
+        dict_get(&delete_resp, "deleted"),
+        VmValue::Bool(true)
+    ));
+
+    let resp = (get.handler)(&get_args).unwrap();
+    assert!(matches!(dict_get(&resp, "value"), VmValue::Nil));
+}
+
+#[test]
+fn missing_value_returns_nil_with_backend_metadata() {
+    let root = TempDir::new().unwrap();
+    let _env = EnvGuard::new(&[
+        ("HARN_SECRET_STORE_BACKEND", "file"),
+        ("HARN_SECRET_STORE_FILE_ROOT", root.path().to_str().unwrap()),
+    ]);
+    let reg = registry();
+    let get = reg.find("hostlib_secret_store_get").unwrap();
+    let resp = (get.handler)(&dict_arg(&[
+        ("account", vm_string("never-existed")),
+        ("key", vm_string("nope")),
+    ]))
+    .unwrap();
+    assert!(matches!(dict_get(&resp, "value"), VmValue::Nil));
+    assert_eq!(as_string(dict_get(&resp, "backend")), "file");
+}
+
+#[test]
+fn delete_returns_false_when_key_absent() {
+    let root = TempDir::new().unwrap();
+    let _env = EnvGuard::new(&[
+        ("HARN_SECRET_STORE_BACKEND", "file"),
+        ("HARN_SECRET_STORE_FILE_ROOT", root.path().to_str().unwrap()),
+    ]);
+    let reg = registry();
+    let delete = reg.find("hostlib_secret_store_delete").unwrap();
+    let resp = (delete.handler)(&dict_arg(&[
+        ("account", vm_string("ghost")),
+        ("key", vm_string("none")),
+    ]))
+    .unwrap();
+    assert!(matches!(dict_get(&resp, "deleted"), VmValue::Bool(false)));
+}
+
+#[test]
+fn list_returns_sorted_keys_for_account() {
+    let root = TempDir::new().unwrap();
+    let _env = EnvGuard::new(&[
+        ("HARN_SECRET_STORE_BACKEND", "file"),
+        ("HARN_SECRET_STORE_FILE_ROOT", root.path().to_str().unwrap()),
+    ]);
+    let reg = registry();
+    let set = reg.find("hostlib_secret_store_set").unwrap();
+    let list = reg.find("hostlib_secret_store_list").unwrap();
+
+    for key in ["GAMMA", "ALPHA", "BETA"] {
+        let _ = (set.handler)(&dict_arg(&[
+            ("account", vm_string("app")),
+            ("key", vm_string(key)),
+            ("value", vm_string("v")),
+        ]))
+        .unwrap();
+    }
+
+    let resp = (list.handler)(&dict_arg(&[("account", vm_string("app"))])).unwrap();
+    let keys = match dict_get(&resp, "keys") {
+        VmValue::List(items) => items
+            .iter()
+            .map(|v| as_string(v).to_string())
+            .collect::<Vec<_>>(),
+        other => panic!("expected list, got {other:?}"),
+    };
+    assert_eq!(keys, vec!["ALPHA", "BETA", "GAMMA"]);
+}
+
+#[test]
+fn accounts_are_namespaced_so_keys_do_not_collide() {
+    let root = TempDir::new().unwrap();
+    let _env = EnvGuard::new(&[
+        ("HARN_SECRET_STORE_BACKEND", "file"),
+        ("HARN_SECRET_STORE_FILE_ROOT", root.path().to_str().unwrap()),
+    ]);
+    let reg = registry();
+    let set = reg.find("hostlib_secret_store_set").unwrap();
+    let get = reg.find("hostlib_secret_store_get").unwrap();
+
+    (set.handler)(&dict_arg(&[
+        ("account", vm_string("alpha")),
+        ("key", vm_string("TOKEN")),
+        ("value", vm_string("alpha-token")),
+    ]))
+    .unwrap();
+    (set.handler)(&dict_arg(&[
+        ("account", vm_string("beta")),
+        ("key", vm_string("TOKEN")),
+        ("value", vm_string("beta-token")),
+    ]))
+    .unwrap();
+
+    let alpha = (get.handler)(&dict_arg(&[
+        ("account", vm_string("alpha")),
+        ("key", vm_string("TOKEN")),
+    ]))
+    .unwrap();
+    let beta = (get.handler)(&dict_arg(&[
+        ("account", vm_string("beta")),
+        ("key", vm_string("TOKEN")),
+    ]))
+    .unwrap();
+    assert_eq!(as_string(dict_get(&alpha, "value")), "alpha-token");
+    assert_eq!(as_string(dict_get(&beta, "value")), "beta-token");
+}
+
+#[test]
+fn file_backend_writes_credentials_file_under_account_directory() {
+    let root = TempDir::new().unwrap();
+    let _env = EnvGuard::new(&[
+        ("HARN_SECRET_STORE_BACKEND", "file"),
+        ("HARN_SECRET_STORE_FILE_ROOT", root.path().to_str().unwrap()),
+    ]);
+    let reg = registry();
+    let set = reg.find("hostlib_secret_store_set").unwrap();
+    (set.handler)(&dict_arg(&[
+        ("account", vm_string("burin")),
+        ("key", vm_string("OPENAI_API_KEY")),
+        ("value", vm_string("sk-test")),
+    ]))
+    .unwrap();
+
+    let credentials = root.path().join("burin").join("credentials.json");
+    assert!(credentials.exists(), "credentials file should exist");
+    let body = std::fs::read_to_string(&credentials).unwrap();
+    let parsed: BTreeMap<String, String> = serde_json::from_str(&body).unwrap();
+    assert_eq!(
+        parsed.get("OPENAI_API_KEY").map(String::as_str),
+        Some("sk-test")
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn file_backend_writes_credentials_with_owner_only_permissions() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let root = TempDir::new().unwrap();
+    let _env = EnvGuard::new(&[
+        ("HARN_SECRET_STORE_BACKEND", "file"),
+        ("HARN_SECRET_STORE_FILE_ROOT", root.path().to_str().unwrap()),
+    ]);
+    let reg = registry();
+    let set = reg.find("hostlib_secret_store_set").unwrap();
+    (set.handler)(&dict_arg(&[
+        ("account", vm_string("burin")),
+        ("key", vm_string("OPENAI_API_KEY")),
+        ("value", vm_string("sk-test")),
+    ]))
+    .unwrap();
+
+    let credentials = root.path().join("burin").join("credentials.json");
+    let mode = std::fs::metadata(&credentials)
+        .unwrap()
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_eq!(
+        mode, 0o600,
+        "credentials file must be owner-read/write only"
+    );
+}
+
+#[test]
+fn empty_account_is_rejected_with_invalid_parameter() {
+    let _env = EnvGuard::new(&[("HARN_SECRET_STORE_BACKEND", "file")]);
+    let reg = registry();
+    let get = reg.find("hostlib_secret_store_get").unwrap();
+    let err = (get.handler)(&dict_arg(&[
+        ("account", vm_string("")),
+        ("key", vm_string("k")),
+    ]))
+    .unwrap_err();
+    match err {
+        HostlibError::InvalidParameter { param, .. } => {
+            assert_eq!(param, "account");
+        }
+        other => panic!("expected InvalidParameter, got {other:?}"),
+    }
+}

--- a/crates/harn-hostlib/tests/secret_store_os_native.rs
+++ b/crates/harn-hostlib/tests/secret_store_os_native.rs
@@ -1,0 +1,224 @@
+//! OS-native secret-store smoke tests.
+//!
+//! Exercises the live Keychain (macOS/iOS) and Credential Manager (Windows)
+//! backends end-to-end. These tests:
+//!
+//! * Are skipped when `HARN_SECRET_STORE_BACKEND=file` is set in the
+//!   environment — CI matrices that explicitly opt into the file backend
+//!   should not trigger keychain prompts.
+//! * Use a unique account name per run so concurrent CI invocations and
+//!   leftover entries from prior failed runs cannot cause cross-contamination.
+//! * Always clean up after themselves, even on assertion failure.
+//!
+//! On Linux there is no OS-native backend yet (secret-service is tracked
+//! as a follow-on; see `docs/src/hostlib/secret_store.md`), so this file
+//! compiles down to nothing on Linux targets.
+
+#![cfg(any(target_os = "macos", target_os = "windows"))]
+
+use std::collections::BTreeMap;
+use std::rc::Rc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use harn_hostlib::{secret_store::SecretStoreCapability, BuiltinRegistry, HostlibCapability};
+use harn_vm::VmValue;
+
+fn registry() -> BuiltinRegistry {
+    let mut registry = BuiltinRegistry::new();
+    SecretStoreCapability.register_builtins(&mut registry);
+    registry
+}
+
+fn dict_arg(entries: &[(&str, VmValue)]) -> Vec<VmValue> {
+    let mut map: BTreeMap<String, VmValue> = BTreeMap::new();
+    for (k, v) in entries {
+        map.insert(k.to_string(), v.clone());
+    }
+    vec![VmValue::Dict(Rc::new(map))]
+}
+
+fn vm_string(s: &str) -> VmValue {
+    VmValue::String(Rc::from(s))
+}
+
+fn dict_get<'a>(value: &'a VmValue, key: &str) -> &'a VmValue {
+    match value {
+        VmValue::Dict(d) => d.get(key).expect("key present"),
+        other => panic!("not a dict: {other:?}"),
+    }
+}
+
+fn as_string(value: &VmValue) -> &str {
+    match value {
+        VmValue::String(s) => s.as_ref(),
+        other => panic!("not a string: {other:?}"),
+    }
+}
+
+/// Process-unique account name so parallel test invocations cannot
+/// collide. The pid plus an atomic counter is sufficient: PIDs differ
+/// across concurrent processes, the counter differs across calls within
+/// a process, and every test cleans up after itself via `scopeguard_delete`
+/// (or the inline `Cleanup` RAII helper).
+fn unique_account(prefix: &str) -> String {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let pid = std::process::id();
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("harn-hostlib-tests-{prefix}-{pid}-{n}")
+}
+
+fn skip_if_file_backend_forced() -> bool {
+    matches!(
+        std::env::var("HARN_SECRET_STORE_BACKEND").as_deref(),
+        Ok("file")
+    )
+}
+
+#[test]
+fn os_native_round_trip_get_set_delete_list() {
+    if skip_if_file_backend_forced() {
+        eprintln!("skipping: HARN_SECRET_STORE_BACKEND=file is set");
+        return;
+    }
+    let reg = registry();
+    let account = unique_account("round-trip");
+    let key1 = "primary";
+    let key2 = "secondary";
+    let set = reg.find("hostlib_secret_store_set").unwrap();
+    let get = reg.find("hostlib_secret_store_get").unwrap();
+    let list = reg.find("hostlib_secret_store_list").unwrap();
+    let delete = reg.find("hostlib_secret_store_delete").unwrap();
+
+    // Always clean up, even if an assertion below fires.
+    struct Cleanup<'a> {
+        delete: &'a harn_hostlib::RegisteredBuiltin,
+        account: String,
+        keys: Vec<&'static str>,
+    }
+    impl Drop for Cleanup<'_> {
+        fn drop(&mut self) {
+            for key in &self.keys {
+                let _ = (self.delete.handler)(&dict_arg(&[
+                    ("account", vm_string(&self.account)),
+                    ("key", vm_string(key)),
+                ]));
+            }
+        }
+    }
+    let _cleanup = Cleanup {
+        delete,
+        account: account.clone(),
+        keys: vec![key1, key2],
+    };
+
+    (set.handler)(&dict_arg(&[
+        ("account", vm_string(&account)),
+        ("key", vm_string(key1)),
+        ("value", vm_string("value-1")),
+    ]))
+    .unwrap();
+    (set.handler)(&dict_arg(&[
+        ("account", vm_string(&account)),
+        ("key", vm_string(key2)),
+        ("value", vm_string("value-2")),
+    ]))
+    .unwrap();
+
+    let g1 = (get.handler)(&dict_arg(&[
+        ("account", vm_string(&account)),
+        ("key", vm_string(key1)),
+    ]))
+    .unwrap();
+    assert_eq!(as_string(dict_get(&g1, "value")), "value-1");
+    let backend = as_string(dict_get(&g1, "backend"));
+    assert!(
+        backend == "keychain" || backend == "wincred",
+        "expected OS-native backend, got {backend}"
+    );
+
+    let listed = (list.handler)(&dict_arg(&[("account", vm_string(&account))])).unwrap();
+    let keys = match dict_get(&listed, "keys") {
+        VmValue::List(items) => items
+            .iter()
+            .map(|v| as_string(v).to_string())
+            .collect::<Vec<_>>(),
+        other => panic!("expected list, got {other:?}"),
+    };
+    assert!(keys.contains(&key1.to_string()) && keys.contains(&key2.to_string()));
+
+    let del = (delete.handler)(&dict_arg(&[
+        ("account", vm_string(&account)),
+        ("key", vm_string(key1)),
+    ]))
+    .unwrap();
+    assert!(matches!(dict_get(&del, "deleted"), VmValue::Bool(true)));
+
+    let g_gone = (get.handler)(&dict_arg(&[
+        ("account", vm_string(&account)),
+        ("key", vm_string(key1)),
+    ]))
+    .unwrap();
+    assert!(matches!(dict_get(&g_gone, "value"), VmValue::Nil));
+}
+
+#[test]
+fn os_native_overwrite_replaces_existing_value() {
+    if skip_if_file_backend_forced() {
+        eprintln!("skipping: HARN_SECRET_STORE_BACKEND=file is set");
+        return;
+    }
+    let reg = registry();
+    let account = unique_account("overwrite");
+    let key = "only";
+    let set = reg.find("hostlib_secret_store_set").unwrap();
+    let get = reg.find("hostlib_secret_store_get").unwrap();
+    let delete = reg.find("hostlib_secret_store_delete").unwrap();
+
+    let _cleanup = scopeguard_delete(delete, account.clone(), key);
+
+    (set.handler)(&dict_arg(&[
+        ("account", vm_string(&account)),
+        ("key", vm_string(key)),
+        ("value", vm_string("first")),
+    ]))
+    .unwrap();
+    (set.handler)(&dict_arg(&[
+        ("account", vm_string(&account)),
+        ("key", vm_string(key)),
+        ("value", vm_string("second")),
+    ]))
+    .unwrap();
+
+    let g = (get.handler)(&dict_arg(&[
+        ("account", vm_string(&account)),
+        ("key", vm_string(key)),
+    ]))
+    .unwrap();
+    assert_eq!(as_string(dict_get(&g, "value")), "second");
+}
+
+/// Lightweight RAII helper: deletes the named key on drop.
+fn scopeguard_delete<'a>(
+    delete: &'a harn_hostlib::RegisteredBuiltin,
+    account: String,
+    key: &'static str,
+) -> impl Drop + 'a {
+    struct Guard<'a> {
+        delete: &'a harn_hostlib::RegisteredBuiltin,
+        account: String,
+        key: &'static str,
+    }
+    impl Drop for Guard<'_> {
+        fn drop(&mut self) {
+            let _ = (self.delete.handler)(&dict_arg(&[
+                ("account", vm_string(&self.account)),
+                ("key", vm_string(self.key)),
+            ]));
+        }
+    }
+    Guard {
+        delete,
+        account,
+        key,
+    }
+}

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -176,6 +176,7 @@
 - [Prompt templating](./prompt-templating.md)
 - [Editor integration](./editor-integration.md)
 - [Testing](./testing.md)
+- [Secret store (hostlib)](./hostlib/secret_store.md)
 
 # Migrations
 

--- a/docs/src/hostlib/secret_store.md
+++ b/docs/src/hostlib/secret_store.md
@@ -1,0 +1,92 @@
+# Secret store (hostlib)
+
+The `secret_store` capability is a small, sync host primitive for storing
+per-application credentials in the operating system's native secret store,
+with a portable JSON file fallback for headless environments. It is
+registered automatically by `harn_hostlib::install_default` and exposes
+four builtins:
+
+| Builtin                            | Returns                                    |
+|------------------------------------|--------------------------------------------|
+| `hostlib_secret_store_get`         | `{account, key, value, backend}`           |
+| `hostlib_secret_store_set`         | `{account, key, backend}`                  |
+| `hostlib_secret_store_delete`      | `{account, key, deleted, backend}`         |
+| `hostlib_secret_store_list`        | `{account, keys, backend}`                 |
+
+`value` is `nil` when the key is absent. `backend` is one of
+`"keychain"`, `"wincred"`, or `"file"` so callers can surface backend
+status in diagnostics without re-deriving it.
+
+## Backend selection
+
+The active backend is resolved on every call (selection is essentially
+free) so an env-var override takes effect without a process restart.
+
+| OS               | Default backend                                              |
+|------------------|--------------------------------------------------------------|
+| macOS / iOS      | Apple Keychain (`security-framework`, generic password item) |
+| Windows          | Credential Manager (`CredRead`/`CredWrite`, generic type)    |
+| Linux and other  | File backend at `$XDG_CONFIG_HOME/<account>/credentials.json`|
+
+### Forcing the file backend
+
+Set `HARN_SECRET_STORE_BACKEND=file` to use the file backend regardless of
+OS. This is the right knob for sandboxed CI, eval harnesses, container
+images that must not touch the user's keychain, and anything else that
+needs deterministic, file-based storage.
+
+### Account namespacing
+
+The `account` argument scopes every key to the calling application
+(`burin`, `harn-cloud-admin`, etc.) so two applications can use the same
+key name without collision:
+
+* **Keychain** — `account` maps to `kSecAttrService`; `key` maps to
+  `kSecAttrAccount`. Matches the layout used by the legacy Swift
+  `KeychainCredentialStore` in burin-code so existing entries are
+  reachable without migration.
+* **Credential Manager** — `account/key` becomes the credential's target
+  name (e.g. `burin/OPENAI_API_KEY`).
+* **File backend** — credentials land at
+  `$XDG_CONFIG_HOME/<account>/credentials.json`
+  (or `%APPDATA%\<account>\credentials.json` on Windows). The file is
+  written with `0o600` on Unix; the containing directory with `0o700`.
+
+The path layout for the file backend is byte-compatible with burin-code's
+existing `$XDG_CONFIG_HOME/burin/credentials.json`, so existing
+deployments migrate without any data movement.
+
+## Scope and non-goals
+
+The capability owns *where the bytes live* and nothing else. Audit logging,
+env-vs-stored precedence, schema validation beyond builtin signatures, and
+migration logic belong in the `.harn` orchestration layer that composes
+this primitive. Concretely:
+
+* No "convenience" helpers like `effectiveValue(envKey, fallback)` — the
+  caller decides whether to read `env`, the secret store, or both.
+* No rotation, versioning, or zeroizing buffers. Those live in
+  `harn-vm::secrets` (the async `SecretProvider` chain used by the LLM
+  caller), which solves a different problem.
+* No hardware-backed key stores. Deferred to a follow-up if any consumer
+  asks.
+
+## Verifying a setup
+
+```text
+HARN_SECRET_STORE_BACKEND=file cargo test -p harn-hostlib --test secret_store
+```
+
+`secret_store.rs` (file backend) runs on every CI runner.
+`secret_store_os_native.rs` exercises the Keychain (macOS) and Credential
+Manager (Windows) backends end-to-end; on Linux it compiles down to nothing
+because there is no OS-native backend yet.
+
+## Open follow-up
+
+* **Linux libsecret / secret-service backend.** Implemented as a wrapper
+  around the `keyring` crate's `linux-native` feature when a consumer
+  needs it — `harn-vm::secrets::KeyringSecretProvider` already pulls the
+  same crate, so the dependency is free. Headless Linux CI keeps using
+  the file backend (the same fallback `HARN_SECRET_STORE_BACKEND=file`
+  selects) so behavior is identical to today.


### PR DESCRIPTION
## Summary

Closes #1714. Adds `secret_store` capability to `harn-hostlib`, exposing
`hostlib_secret_store_{get,set,delete,list}` as a generic per-application
credential primitive any Harn-hosted application can compose.

- **Per-OS backends**, picked at call time (so `HARN_SECRET_STORE_BACKEND=file` takes effect without process restart):
  - **macOS / iOS** → Apple Keychain via `security-framework` (generic password item, `kSecAttrService=<account>`, `kSecAttrAccount=<key>`)
  - **Windows** → Credential Manager via `windows-sys` (CredRead/CredWrite/CredDelete/CredEnumerate, target name `<account>/<key>`)
  - **Linux / other** → file backend at `$XDG_CONFIG_HOME/<account>/credentials.json` with `0o600` permissions
- **`HARN_SECRET_STORE_BACKEND=file`** forces the file backend on every OS — for sandboxed CI, eval harnesses, and anything that must not touch the user's keychain.
- **`account` namespacing** — every key is scoped to the calling application (e.g. `burin`, `harn-cloud-admin`), preventing cross-app collisions.
- **Path layout matches burin-code's existing `$XDG_CONFIG_HOME/burin/credentials.json`** byte-for-byte, so existing deployments migrate without any data movement. Directly unblocks the [burin-code thin-rust epic](https://github.com/burin-labs/burin-code/issues/814) — the P1 keys subcommand can compose this primitive instead of either re-implementing storage in Rust or falling back to Swift.
- **JSON schemas** under `crates/harn-hostlib/schemas/secret_store/` registered in `schemas::SCHEMAS` so `harn check` preflight covers the new builtins.
- **Docs** at [`docs/src/hostlib/secret_store.md`](docs/src/hostlib/secret_store.md) describe backend selection, namespacing, env-var overrides, and the deliberately-small scope vs `harn-vm::secrets`.

## Scope discipline

Kept the primitive minimal as the issue asks: no `effectiveValue(envKey, …)` convenience, no audit logging, no schema validation beyond the builtin signatures, no rotation/versioning. Those belong in the `.harn` orchestration layer that composes this primitive, or in `harn-vm::secrets` (the async provider chain used by the LLM caller, which solves a different problem and stays parallel).

Linux secret-service (libsecret) is deferred to a follow-up: headless Linux CI hits the file backend either way (matches Burin's Swift today), and adding it later is a pure feature add behind the existing `Backend` trait. The doc page calls this out so consumers know what to expect.

## Test plan

- [x] `cargo test -p harn-hostlib --test secret_store` — file-backend round-trip, namespace isolation, missing-key returns `nil`, delete returns `false` when absent, list returns sorted keys, 0600 file perms on Unix, empty `account` rejected with `InvalidParameter`
- [x] `cargo test -p harn-hostlib --test secret_store_os_native` — round-trip + overwrite on the live Apple Keychain (compiles only on macOS/iOS/Windows; cleans up after itself even on assertion failure; pid+counter-unique account names so concurrent runs don't collide)
- [x] `cargo test -p harn-hostlib --test registration` — every secret_store builtin has matching request+response schemas, `install_default` wires the module in
- [x] `cargo test -p harn-hostlib` — full hostlib suite, 344 tests green
- [x] `cargo clippy -p harn-hostlib --tests -- -D warnings` — clean
- [x] `cargo fmt --check`, `make lint-md`, `make check-docs-snippets`, `scripts/lint_test_patterns.sh` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)