### PR TITLE
llm: drop vestigial prefer_prefill_done model field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,16 @@ condensed series summaries instead of full per-patch history.
   the NL-binder substrate work tracked under #1696/#1698 — empirical
   warm-state p50 of ~150ms from a residential network, p99 ~230ms.
 
+### Removed
+
+- **`prefer_prefill_done` model field.** Dropped the vestigial flag from
+  `ModelDef`, the `model_info(...)` builtin dict, the generated provider
+  catalog (Rust struct + JSON schema + JSON / TS / Swift artifacts), and
+  the two `providers.toml` rows (`gemma-4-e2b-it`, `gemma-4-e4b-it`)
+  that set it. The flag's only consumer in burin-code now gates on the
+  per-model `supports_assistant_prefill` capability added in #1665
+  (burin-labs/burin-code#787), so the field carried no behavior.
+
 ## v0.8.21
 
 ### Added

--- a/crates/harn-vm/src/llm/api/ollama.rs
+++ b/crates/harn-vm/src/llm/api/ollama.rs
@@ -843,7 +843,6 @@ mod tests {
                 deprecated: false,
                 deprecation_note: None,
                 quality_tags: Vec::new(),
-                prefer_prefill_done: None,
             },
         );
         crate::llm_config::set_user_overrides(Some(overlay));
@@ -936,7 +935,6 @@ mod tests {
                 deprecated: false,
                 deprecation_note: None,
                 quality_tags: Vec::new(),
-                prefer_prefill_done: None,
             },
         );
         crate::llm_config::set_user_overrides(Some(overlay));
@@ -1180,7 +1178,6 @@ mod tests {
                 deprecated: false,
                 deprecation_note: None,
                 quality_tags: Vec::new(),
-                prefer_prefill_done: None,
             },
         );
         crate::llm_config::set_user_overrides(Some(overlay));

--- a/crates/harn-vm/src/llm/config_builtins.rs
+++ b/crates/harn-vm/src/llm/config_builtins.rs
@@ -913,13 +913,6 @@ fn model_def_to_vm_value(id: &str, model: &llm_config::ModelDef) -> VmValue {
         "quality_tags".to_string(),
         string_list_to_vm_value(model.quality_tags.clone()),
     );
-    dict.insert(
-        "prefer_prefill_done".to_string(),
-        model
-            .prefer_prefill_done
-            .map(VmValue::Bool)
-            .unwrap_or(VmValue::Nil),
-    );
     VmValue::Dict(Rc::new(dict))
 }
 

--- a/crates/harn-vm/src/llm/cost.rs
+++ b/crates/harn-vm/src/llm/cost.rs
@@ -984,7 +984,6 @@ mod tests {
                 deprecated: false,
                 deprecation_note: None,
                 quality_tags: Vec::new(),
-                prefer_prefill_done: None,
             },
         );
         crate::llm_config::set_user_overrides(Some(overlay));

--- a/crates/harn-vm/src/llm/providers.toml
+++ b/crates/harn-vm/src/llm/providers.toml
@@ -994,9 +994,7 @@ context_window = 262144
 stream_timeout = 900.0
 capabilities = ["tools", "vision", "streaming", "thinking"]
 
-# Local OpenAI-compatible servers (vLLM / bring-your-own). The
-# `prefer_prefill_done` opts a small model into the issue #41 brevity
-# nudge — keep it on for the Gemma 4 E2B / E4B sizes that benefit most.
+# Local OpenAI-compatible servers (vLLM / bring-your-own).
 
 [models."gemma-4-e2b-it"]
 name = "Gemma 4 E2B (local)"
@@ -1004,7 +1002,6 @@ provider = "local"
 context_window = 131072
 stream_timeout = 300.0
 capabilities = ["streaming", "thinking"]
-prefer_prefill_done = true
 
 [models."gemma-4-e4b-it"]
 name = "Gemma 4 E4B (local)"
@@ -1012,7 +1009,6 @@ provider = "local"
 context_window = 131072
 stream_timeout = 300.0
 capabilities = ["streaming", "thinking"]
-prefer_prefill_done = true
 
 [models."gemma-4-26b-a4b-it"]
 name = "Gemma 4 26B MoE (local)"

--- a/crates/harn-vm/src/llm_config.rs
+++ b/crates/harn-vm/src/llm_config.rs
@@ -252,8 +252,6 @@ pub struct ModelDef {
     pub deprecation_note: Option<String>,
     #[serde(default)]
     pub quality_tags: Vec<String>,
-    #[serde(default)]
-    pub prefer_prefill_done: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -1394,7 +1392,6 @@ mod tests {
                 deprecated: false,
                 deprecation_note: None,
                 quality_tags: Vec::new(),
-                prefer_prefill_done: None,
             },
         );
         overlay

--- a/crates/harn-vm/src/provider_catalog.rs
+++ b/crates/harn-vm/src/provider_catalog.rs
@@ -96,8 +96,6 @@ pub struct CatalogModel {
     pub runtime_context_window: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stream_timeout: Option<f64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub prefer_prefill_done: Option<bool>,
     pub modalities: ModelModalities,
     pub tool_support: ModelToolSupport,
     pub structured_output: String,
@@ -499,7 +497,6 @@ pub fn schema_value() -> Value {
                     "context_window": {"type": "integer", "minimum": 1},
                     "runtime_context_window": {"type": "integer", "minimum": 1},
                     "stream_timeout": {"type": "number", "exclusiveMinimum": 0},
-                    "prefer_prefill_done": {"type": "boolean"},
                     "modalities": {"$ref": "#/$defs/modalities"},
                     "tool_support": {"$ref": "#/$defs/tool_support"},
                     "structured_output": {"type": "string"},
@@ -703,7 +700,6 @@ fn catalog_model(
         context_window: model.context_window,
         runtime_context_window: model.runtime_context_window,
         stream_timeout: model.stream_timeout,
-        prefer_prefill_done: model.prefer_prefill_done,
     }
 }
 
@@ -1016,7 +1012,6 @@ export interface HarnCatalogModel {
   context_window: number
   runtime_context_window?: number
   stream_timeout?: number
-  prefer_prefill_done?: boolean
   modalities: { input: string[]; output: string[] }
   tool_support: {
     native: boolean
@@ -1078,7 +1073,6 @@ export interface CatalogEntry {
     cacheWritePerMTok?: number | null
   }
   streamTimeout?: number
-  preferPrefillDone?: boolean
 }
 
 export interface CatalogAlias {
@@ -1108,7 +1102,6 @@ export const MODEL_CATALOG: readonly CatalogEntry[] = harnProviderCatalog.models
       }
     : undefined,
   streamTimeout: model.stream_timeout,
-  preferPrefillDone: model.prefer_prefill_done,
 }))
 
 export const ALIASES: readonly CatalogAlias[] = harnProviderCatalog.aliases.map((alias) => ({
@@ -1251,7 +1244,6 @@ public struct HarnCatalogModel: Codable, Sendable, Equatable {
     public let contextWindow: Int
     public let runtimeContextWindow: Int?
     public let streamTimeout: Double?
-    public let preferPrefillDone: Bool?
     public let modalities: HarnModelModalities
     public let toolSupport: HarnModelToolSupport
     public let structuredOutput: String
@@ -1271,7 +1263,6 @@ public struct HarnCatalogModel: Codable, Sendable, Equatable {
         case contextWindow = "context_window"
         case runtimeContextWindow = "runtime_context_window"
         case streamTimeout = "stream_timeout"
-        case preferPrefillDone = "prefer_prefill_done"
         case modalities
         case toolSupport = "tool_support"
         case structuredOutput = "structured_output"

--- a/spec/provider-catalog/HarnProviderCatalog.swift
+++ b/spec/provider-catalog/HarnProviderCatalog.swift
@@ -115,7 +115,6 @@ public struct HarnCatalogModel: Codable, Sendable, Equatable {
     public let contextWindow: Int
     public let runtimeContextWindow: Int?
     public let streamTimeout: Double?
-    public let preferPrefillDone: Bool?
     public let modalities: HarnModelModalities
     public let toolSupport: HarnModelToolSupport
     public let structuredOutput: String
@@ -135,7 +134,6 @@ public struct HarnCatalogModel: Codable, Sendable, Equatable {
         case contextWindow = "context_window"
         case runtimeContextWindow = "runtime_context_window"
         case streamTimeout = "stream_timeout"
-        case preferPrefillDone = "prefer_prefill_done"
         case modalities
         case toolSupport = "tool_support"
         case structuredOutput = "structured_output"
@@ -2198,7 +2196,6 @@ public let harnProviderCatalogJSON = #"""
       ],
       "context_window": 131072,
       "stream_timeout": 300.0,
-      "prefer_prefill_done": true,
       "modalities": {
         "input": [
           "text"
@@ -2253,7 +2250,6 @@ public let harnProviderCatalogJSON = #"""
       ],
       "context_window": 131072,
       "stream_timeout": 300.0,
-      "prefer_prefill_done": true,
       "modalities": {
         "input": [
           "text"

--- a/spec/provider-catalog/harn-provider-catalog.ts
+++ b/spec/provider-catalog/harn-provider-catalog.ts
@@ -66,7 +66,6 @@ export interface HarnCatalogModel {
   context_window: number
   runtime_context_window?: number
   stream_timeout?: number
-  prefer_prefill_done?: boolean
   modalities: { input: string[]; output: string[] }
   tool_support: {
     native: boolean
@@ -128,7 +127,6 @@ export interface CatalogEntry {
     cacheWritePerMTok?: number | null
   }
   streamTimeout?: number
-  preferPrefillDone?: boolean
 }
 
 export interface CatalogAlias {
@@ -2096,7 +2094,6 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       ],
       "context_window": 131072,
       "stream_timeout": 300.0,
-      "prefer_prefill_done": true,
       "modalities": {
         "input": [
           "text"
@@ -2151,7 +2148,6 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       ],
       "context_window": 131072,
       "stream_timeout": 300.0,
-      "prefer_prefill_done": true,
       "modalities": {
         "input": [
           "text"
@@ -3610,7 +3606,6 @@ export const MODEL_CATALOG: readonly CatalogEntry[] = harnProviderCatalog.models
       }
     : undefined,
   streamTimeout: model.stream_timeout,
-  preferPrefillDone: model.prefer_prefill_done,
 }))
 
 export const ALIASES: readonly CatalogAlias[] = harnProviderCatalog.aliases.map((alias) => ({

--- a/spec/provider-catalog/provider-catalog.json
+++ b/spec/provider-catalog/provider-catalog.json
@@ -1954,7 +1954,6 @@
       ],
       "context_window": 131072,
       "stream_timeout": 300.0,
-      "prefer_prefill_done": true,
       "modalities": {
         "input": [
           "text"
@@ -2009,7 +2008,6 @@
       ],
       "context_window": 131072,
       "stream_timeout": 300.0,
-      "prefer_prefill_done": true,
       "modalities": {
         "input": [
           "text"

--- a/spec/provider-catalog/provider-catalog.schema.json
+++ b/spec/provider-catalog/provider-catalog.schema.json
@@ -223,9 +223,6 @@
           "minLength": 1,
           "type": "string"
         },
-        "prefer_prefill_done": {
-          "type": "boolean"
-        },
         "pricing": {
           "$ref": "#/$defs/pricing"
         },


### PR DESCRIPTION
## Summary

- Removes the `prefer_prefill_done` flag from `ModelDef`, the `model_info(...)` builtin dict, the generated provider catalog (Rust struct + JSON schema + JSON / TS / Swift artifacts), and the two `providers.toml` rows (`gemma-4-e2b-it`, `gemma-4-e4b-it`) that set it.
- The flag's only consumer in burin-code now gates on the per-model `supports_assistant_prefill` capability (added in #1665, wired up by [burin-labs/burin-code#787](https://github.com/burin-labs/burin-code/issues/787) / PR #839), so the field carried no behavior — pure deletion.
- Regenerated `spec/provider-catalog/*` via `make gen-provider-catalog`.

## Test plan

- [x] `cargo build -p harn-vm`
- [x] `cargo test -p harn-vm --lib provider_catalog` (10/10 pass)
- [x] `cargo test -p harn-vm --lib llm_config` (35/35 pass)
- [x] `cargo test -p harn-vm --lib llm::cost` (9/9 pass)
- [x] `cargo test -p harn-vm --lib llm::api::ollama` (13/13 pass)
- [x] `make check-provider-catalog` (artifact validation OK)
- [ ] After this lands and a Harn release cuts, burin-code re-runs `npm run codegen:models` to drop the field from its five copies of the catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)