### PR TITLE
personas: per-stage tool-surface scoping (closes #1701)

### DIFF
--- a/conformance/tests/personas/persona_per_stage_scope.expected
+++ b/conformance/tests/personas/persona_per_stage_scope.expected
@@ -1,0 +1,10 @@
+true
+read-ok
+false
+permission_denied
+true
+edit-ok
+false
+permission_denied
+true
+edit-ok

--- a/conformance/tests/personas/persona_per_stage_scope.harn
+++ b/conformance/tests/personas/persona_per_stage_scope.harn
@@ -1,0 +1,76 @@
+/**
+ * Per-stage policy scoping (harn#1701):
+ * `@persona(stages: [...])` declares per-stage tool allowlists. While the
+ * matching `@step` runs the runtime pushes a CapabilityPolicy whose tool
+ * surface equals the stage's `allowed_tools`. Tool calls outside that
+ * surface come back as `permission_denied` receipts; in-stage calls
+ * dispatch normally. The execution policy stack is empty once every step
+ * frame unwinds.
+ */
+fn stage_tools() {
+  var tools = tool_registry()
+  tools = tool_define(
+    tools,
+    "read",
+    "Read",
+    {
+      handler: { _args -> "read-ok" },
+      parameters: {},
+      returns: {type: "string"},
+      annotations: {kind: "read"},
+    },
+  )
+  tools = tool_define(
+    tools,
+    "edit",
+    "Edit",
+    {
+      handler: { _args -> "edit-ok" },
+      parameters: {},
+      returns: {type: "string"},
+      annotations: {kind: "edit"},
+    },
+  )
+  return tools
+}
+
+@persona(name: "scoped_persona", stages: [{name: "research", allowed_tools: ["read"]}, {name: "edit_phase", allowed_tools: ["edit"]}])
+fn scoped_persona(ctx) {
+  let r = research_step(ctx)
+  let e = edit_phase_step(ctx)
+  return {research: r, edit: e}
+}
+
+@step(name: "research")
+fn research_step(ctx) {
+  let tools = ctx.tools
+  let in_scope = agent_dispatch_tool_call({name: "read", arguments: {}}, tools)
+  let out_of_scope = agent_dispatch_tool_call({name: "edit", arguments: {}}, tools)
+  return {in_scope: in_scope, out_of_scope: out_of_scope}
+}
+
+@step(name: "edit_phase")
+fn edit_phase_step(ctx) {
+  let tools = ctx.tools
+  let in_scope = agent_dispatch_tool_call({name: "edit", arguments: {}}, tools)
+  let out_of_scope = agent_dispatch_tool_call({name: "read", arguments: {}}, tools)
+  return {in_scope: in_scope, out_of_scope: out_of_scope}
+}
+
+pipeline main() {
+  let tools = stage_tools()
+  let outcome = scoped_persona({tools: tools})
+  println(outcome.research.in_scope.ok)
+  println(outcome.research.in_scope.rendered_result)
+  println(outcome.research.out_of_scope.ok)
+  println(outcome.research.out_of_scope.error_category)
+  println(outcome.edit.in_scope.ok)
+  println(outcome.edit.in_scope.rendered_result)
+  println(outcome.edit.out_of_scope.ok)
+  println(outcome.edit.out_of_scope.error_category)
+  // After every stage unwinds the per-stage policy is gone, so an ambient
+  // dispatch should pass.
+  let ambient = agent_dispatch_tool_call({name: "edit", arguments: {}}, tools)
+  println(ambient.ok)
+  println(ambient.rendered_result)
+}

--- a/crates/harn-cli/src/commands/persona.rs
+++ b/crates/harn-cli/src/commands/persona.rs
@@ -223,6 +223,24 @@ pub(crate) fn run_inspect(manifest: Option<&Path>, args: &PersonaInspectArgs) {
             println!("{detail}");
         }
     }
+    if !persona.stages.is_empty() {
+        println!("stages:");
+        for stage in &persona.stages {
+            let tools = stage
+                .allowed_tools
+                .as_deref()
+                .map(comma_or_dash)
+                .unwrap_or_else(|| "inherit".to_string());
+            let mut detail = format!("  - {} tools={tools}", stage.name);
+            if let Some(level) = stage.side_effect_level.as_deref() {
+                detail.push_str(&format!(" side_effect={level}"));
+            }
+            if let Some(max) = stage.max_iterations {
+                detail.push_str(&format!(" max_iterations={max}"));
+            }
+            println!("{detail}");
+        }
+    }
     if let Some(owner) = &persona.owner {
         println!("owner:          {owner}");
     }
@@ -541,36 +559,10 @@ fn runtime_binding_or_err(
                 catalog.manifest_path.display()
             )
         })?;
-    Ok(harn_vm::PersonaRuntimeBinding {
-        name: persona.name.clone().unwrap_or_default(),
-        template_ref: persona_template_ref(persona),
-        entry_workflow: persona.entry_workflow.clone().unwrap_or_default(),
-        schedules: persona.schedules.clone(),
-        triggers: persona.triggers.clone(),
-        budget: harn_vm::PersonaBudgetPolicy {
-            daily_usd: persona.budget.daily_usd,
-            hourly_usd: persona.budget.hourly_usd,
-            run_usd: persona.budget.run_usd,
-            max_tokens: persona.budget.max_tokens,
-        },
-    })
-}
-
-fn persona_template_ref(persona: &PersonaManifestEntry) -> Option<String> {
-    persona
-        .package_source
-        .package
-        .as_ref()
-        .zip(persona.version.as_ref())
-        .map(|(package, version)| format!("{package}@{version}"))
-        .or_else(|| persona.package_source.package.clone())
-        .or_else(|| {
-            persona
-                .name
-                .as_ref()
-                .zip(persona.version.as_ref())
-                .map(|(name, version)| format!("{name}@{version}"))
-        })
+    Ok(crate::package::persona_runtime_binding(
+        persona.name.as_deref().unwrap_or_default(),
+        persona,
+    ))
 }
 
 pub(super) fn open_persona_log(state_dir: &Path) -> Result<Arc<AnyEventLog>, String> {
@@ -767,6 +759,7 @@ fn persona_to_json(
         "context_packs": &persona.context_packs,
         "evals": &persona.evals,
         "steps": &persona.steps,
+        "stages": &persona.stages,
         "owner": persona.owner.as_deref(),
         "package_source": {
             "package": persona.package_source.package.as_deref(),

--- a/crates/harn-cli/src/package/extensions.rs
+++ b/crates/harn-cli/src/package/extensions.rs
@@ -434,7 +434,17 @@ fn persona_runtime_binding_for_handler(
             format!("handler persona://{name} does not match a declared persona"),
         ));
     };
-    Ok(harn_vm::PersonaRuntimeBinding {
+    Ok(persona_runtime_binding(name, persona))
+}
+
+/// Lower a manifest persona entry into the runtime binding. Centralised so
+/// every call site (`harn persona` CLI, trigger registration, etc.) carries
+/// the same shape — stages included.
+pub(crate) fn persona_runtime_binding(
+    name: &str,
+    persona: &PersonaManifestEntry,
+) -> harn_vm::PersonaRuntimeBinding {
+    harn_vm::PersonaRuntimeBinding {
         name: name.to_string(),
         template_ref: persona_template_ref(persona),
         entry_workflow: persona.entry_workflow.clone().unwrap_or_default(),
@@ -446,7 +456,26 @@ fn persona_runtime_binding_for_handler(
             run_usd: persona.budget.run_usd,
             max_tokens: persona.budget.max_tokens,
         },
-    })
+        stages: persona
+            .stages
+            .iter()
+            .map(persona_stage_decl_to_runtime)
+            .collect(),
+    }
+}
+
+fn persona_stage_decl_to_runtime(stage: &PersonaStageDecl) -> harn_vm::StageDecl {
+    harn_vm::StageDecl {
+        name: stage.name.clone(),
+        allowed_tools: stage.allowed_tools.clone(),
+        side_effect_level: stage.side_effect_level.clone(),
+        max_iterations: stage.max_iterations,
+        on_exit: stage.on_exit.as_ref().map(|exit| harn_vm::StageExit {
+            on_complete: exit.on_complete.clone(),
+            on_failure: exit.on_failure.clone(),
+            policy_override: None,
+        }),
+    }
 }
 
 pub(crate) async fn compile_optional_trigger_expression(
@@ -773,19 +802,7 @@ fn persona_trigger_binding_spec(
     kind: &str,
     persona: &PersonaManifestEntry,
 ) -> harn_vm::TriggerBindingSpec {
-    let runtime_binding = harn_vm::PersonaRuntimeBinding {
-        name: name.to_string(),
-        template_ref: persona_template_ref(persona),
-        entry_workflow: persona.entry_workflow.clone().unwrap_or_default(),
-        schedules: persona.schedules.clone(),
-        triggers: persona.triggers.clone(),
-        budget: harn_vm::PersonaBudgetPolicy {
-            daily_usd: persona.budget.daily_usd,
-            hourly_usd: persona.budget.hourly_usd,
-            run_usd: persona.budget.run_usd,
-            max_tokens: persona.budget.max_tokens,
-        },
-    };
+    let runtime_binding = persona_runtime_binding(name, persona);
     let id = format!("persona.{name}.{provider}.{kind}");
     let handler = harn_vm::TriggerHandlerSpec::Persona {
         binding: runtime_binding.clone(),

--- a/crates/harn-cli/src/package/manifest.rs
+++ b/crates/harn-cli/src/package/manifest.rs
@@ -1,7 +1,8 @@
 use super::errors::PackageError;
 use super::*;
 pub use harn_modules::personas::{
-    PersonaAutonomyTier, PersonaManifestEntry, PersonaValidationError, ResolvedPersonaManifest,
+    PersonaAutonomyTier, PersonaManifestEntry, PersonaStageDecl, PersonaStageExit,
+    PersonaValidationError, ResolvedPersonaManifest,
 };
 
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/harn-cli/tests/persona_cli.rs
+++ b/crates/harn-cli/tests/persona_cli.rs
@@ -615,6 +615,7 @@ async fn persona_supervision_tail_projects_multiplexed_ndjson_contract() {
         schedules: Vec::new(),
         triggers: Vec::new(),
         budget: harn_vm::PersonaBudgetPolicy::default(),
+        stages: Vec::new(),
     };
     let _ = harn_vm::report_repair_worker_status(
         &log,

--- a/crates/harn-modules/src/personas.rs
+++ b/crates/harn-modules/src/personas.rs
@@ -52,6 +52,42 @@ pub struct PersonaManifestEntry {
     pub rollout_policy: PersonaRolloutPolicy,
     #[serde(default)]
     pub steps: Vec<PersonaStepMetadata>,
+    /// Per-stage tool-surface narrowing. Each stage names a `@step` and
+    /// declares the tools / side-effect ceiling enforced while that step
+    /// runs.
+    #[serde(default)]
+    pub stages: Vec<PersonaStageDecl>,
+    #[serde(flatten, default)]
+    pub extra: BTreeMap<String, toml::Value>,
+}
+
+/// Stage declaration carried on a `PersonaManifestEntry`.
+///
+/// Mirrors the runtime `harn_vm::StageDecl` shape so loaders can map
+/// directly. `allowed_tools = None` means "inherit the persona-level
+/// tool list"; `Some(vec![])` means "deny every tool while this stage is
+/// active".
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct PersonaStageDecl {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allowed_tools: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub side_effect_level: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_iterations: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_exit: Option<PersonaStageExit>,
+    #[serde(flatten, default)]
+    pub extra: BTreeMap<String, toml::Value>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct PersonaStageExit {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_complete: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_failure: Option<String>,
     #[serde(flatten, default)]
     pub extra: BTreeMap<String, toml::Value>,
 }
@@ -343,6 +379,7 @@ pub fn extract_personas_from_program(program: &[SNode]) -> PersonaManifestDocume
                 .and_then(|value| PersonaReceiptPolicy::from_str(value).ok())
                 .or(Some(PersonaReceiptPolicy::Optional)),
             steps,
+            stages: attr_stage_list(persona_attr),
             ..PersonaManifestEntry::default()
         });
     }
@@ -404,6 +441,55 @@ fn node_string(node: &SNode) -> Option<String> {
         }
         _ => None,
     }
+}
+
+fn attr_stage_list(attr: &Attribute) -> Vec<PersonaStageDecl> {
+    let Some(value) = attr.named_arg("stages") else {
+        return Vec::new();
+    };
+    let Node::ListLiteral(entries) = &value.node else {
+        return Vec::new();
+    };
+    let mut out = Vec::with_capacity(entries.len());
+    for entry in entries {
+        let Node::DictLiteral(fields) = &entry.node else {
+            continue;
+        };
+        let mut stage = PersonaStageDecl::default();
+        for dict_entry in fields {
+            let Some(key) = entry_key(&dict_entry.key) else {
+                continue;
+            };
+            match key {
+                "name" => {
+                    if let Some(name) = node_string(&dict_entry.value) {
+                        stage.name = name;
+                    }
+                }
+                "allowed_tools" => {
+                    if let Node::ListLiteral(items) = &dict_entry.value.node {
+                        let tools: Vec<String> = items.iter().filter_map(node_string).collect();
+                        stage.allowed_tools = Some(tools);
+                    }
+                }
+                "side_effect_level" => {
+                    stage.side_effect_level = node_string(&dict_entry.value);
+                }
+                "max_iterations" => {
+                    if let Node::IntLiteral(n) = dict_entry.value.node {
+                        if n >= 0 {
+                            stage.max_iterations = Some(n as u32);
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        if !stage.name.is_empty() {
+            out.push(stage);
+        }
+    }
+    out
 }
 
 fn attr_retry(attr: &Attribute) -> Option<PersonaStepRetry> {
@@ -837,6 +923,7 @@ pub fn validate_persona(
         }
     }
     validate_persona_budget(manifest_path, &root, &persona.budget, errors);
+    validate_persona_stages(manifest_path, &root, persona, context, errors);
     validate_persona_nested_extra(
         manifest_path,
         &root,
@@ -969,6 +1056,101 @@ pub fn validate_persona_nested_extra(
             format!("unknown {field} field"),
             errors,
         );
+    }
+}
+
+pub fn validate_persona_stages(
+    manifest_path: &Path,
+    root: &str,
+    persona: &PersonaManifestEntry,
+    context: &PersonaValidationContext,
+    errors: &mut Vec<PersonaValidationError>,
+) {
+    let stage_names: BTreeSet<&str> = persona
+        .stages
+        .iter()
+        .map(|stage| stage.name.as_str())
+        .collect();
+    let mut seen = BTreeSet::new();
+    for (index, stage) in persona.stages.iter().enumerate() {
+        let field = format!("{root}.stages[{index}]");
+        if stage.name.trim().is_empty() {
+            persona_error(
+                manifest_path,
+                format!("{field}.name"),
+                "stage name must not be empty",
+                errors,
+            );
+        } else {
+            validate_tokenish(manifest_path, &field, "name", &stage.name, errors);
+            if !seen.insert(stage.name.as_str()) {
+                persona_error(
+                    manifest_path,
+                    format!("{field}.name"),
+                    format!("duplicate stage name '{}'", stage.name),
+                    errors,
+                );
+            }
+        }
+        validate_persona_nested_extra(manifest_path, &field, "stages", &stage.extra, errors);
+        if let Some(tools) = stage.allowed_tools.as_ref() {
+            for tool in tools {
+                if tool.trim().is_empty() {
+                    persona_error(
+                        manifest_path,
+                        format!("{field}.allowed_tools"),
+                        "allowed_tools entries must not be empty",
+                        errors,
+                    );
+                    continue;
+                }
+                if !context.known_tools.is_empty() && !context.known_tools.contains(tool) {
+                    persona_error(
+                        manifest_path,
+                        format!("{field}.allowed_tools"),
+                        format!("unknown tool '{tool}'"),
+                        errors,
+                    );
+                } else if !persona.tools.is_empty() && !persona.tools.contains(tool) {
+                    persona_error(
+                        manifest_path,
+                        format!("{field}.allowed_tools"),
+                        format!("tool '{tool}' is not part of the persona-level tools allowlist"),
+                        errors,
+                    );
+                }
+            }
+        }
+        if let Some(level) = stage.side_effect_level.as_deref() {
+            match level {
+                "none" | "read_only" | "workspace_write" | "process_exec" | "network" => {}
+                _ => persona_error(
+                    manifest_path,
+                    format!("{field}.side_effect_level"),
+                    format!(
+                        "unknown side_effect_level '{level}' (expected none, read_only, workspace_write, process_exec, or network)"
+                    ),
+                    errors,
+                ),
+            }
+        }
+        if let Some(exit) = stage.on_exit.as_ref() {
+            validate_persona_nested_extra(manifest_path, &field, "on_exit", &exit.extra, errors);
+            for (key, target) in [
+                ("on_complete", exit.on_complete.as_deref()),
+                ("on_failure", exit.on_failure.as_deref()),
+            ] {
+                let Some(target) = target else { continue };
+                if !stage_names.contains(target) {
+                    persona_error(
+                        manifest_path,
+                        format!("{field}.on_exit.{key}"),
+                        format!("unknown stage '{target}'"),
+                        errors,
+                    );
+                }
+            }
+        }
     }
 }
 
@@ -1154,6 +1336,137 @@ surprise = true
         assert!(fields.contains("[[personas]][0].budget.daily_usd"));
         assert!(fields.contains("[[personas]][0].budget.surprise"));
         assert!(fields.contains("[[personas]][0].surprise"));
+    }
+
+    #[test]
+    fn manifest_stages_round_trip_through_serde() {
+        let parsed = parse_persona_manifest_str(
+            r#"
+[[personas]]
+name = "scoped"
+description = "Per-stage scoping demo."
+entry_workflow = "workflows/scoped.harn#run"
+tools = ["github", "ci"]
+autonomy = "act_with_approval"
+receipts = "required"
+
+[[personas.stages]]
+name = "research"
+allowed_tools = ["github"]
+side_effect_level = "read_only"
+
+[[personas.stages]]
+name = "act"
+allowed_tools = ["github", "ci"]
+side_effect_level = "process_exec"
+max_iterations = 4
+on_exit = { on_complete = "research" }
+"#,
+        )
+        .expect("manifest parses");
+
+        validate_persona_manifests(
+            Path::new("harn.toml"),
+            &parsed.personas,
+            &context(&["scoped"]),
+        )
+        .expect("stage-scoped manifest validates");
+        let persona = &parsed.personas[0];
+        assert_eq!(persona.stages.len(), 2);
+        assert_eq!(persona.stages[0].name, "research");
+        assert_eq!(
+            persona.stages[0].allowed_tools.as_deref(),
+            Some(["github".to_string()].as_slice())
+        );
+        assert_eq!(
+            persona.stages[1]
+                .on_exit
+                .as_ref()
+                .unwrap()
+                .on_complete
+                .as_deref(),
+            Some("research")
+        );
+
+        // Round-trip via the TOML serializer to ensure the shape is stable.
+        let serialised = toml::to_string(&PersonaManifestDocument {
+            personas: parsed.personas.clone(),
+        })
+        .expect("serialize");
+        let reparsed = parse_persona_manifest_str(&serialised).expect("reparse");
+        assert_eq!(reparsed.personas, parsed.personas);
+    }
+
+    #[test]
+    fn stage_validation_flags_unknown_targets_and_levels() {
+        let parsed = parse_persona_manifest_str(
+            r#"
+[[personas]]
+name = "scoped"
+description = "Bad stages."
+entry_workflow = "workflows/scoped.harn#run"
+tools = ["github"]
+autonomy = "suggest"
+receipts = "optional"
+
+[[personas.stages]]
+name = "research"
+allowed_tools = ["ci"]
+side_effect_level = "do_anything"
+on_exit = { on_complete = "missing" }
+
+[[personas.stages]]
+name = "research"
+"#,
+        )
+        .expect("manifest parses");
+
+        let errors = validate_persona_manifests(
+            Path::new("harn.toml"),
+            &parsed.personas,
+            &context(&["scoped"]),
+        )
+        .expect_err("rejects bad stage config");
+        let fields: BTreeSet<_> = errors
+            .iter()
+            .map(|error| error.field_path.as_str())
+            .collect();
+        assert!(fields.contains("[[personas]][0].stages[0].allowed_tools"));
+        assert!(fields.contains("[[personas]][0].stages[0].side_effect_level"));
+        assert!(fields.contains("[[personas]][0].stages[0].on_exit.on_complete"));
+        assert!(fields.contains("[[personas]][0].stages[1].name"));
+    }
+
+    #[test]
+    fn source_persona_picks_up_stage_attributes() {
+        let parsed = parse_persona_source_str(
+            r#"
+@persona(name: "scoped", tools: [github, ci], stages: [
+  {name: "research", allowed_tools: [github]},
+  {name: "act", allowed_tools: [github, ci], side_effect_level: "process_exec"},
+])
+fn scoped(ctx) {
+  research(ctx)
+  act(ctx)
+}
+
+@step(name: "research") fn research(ctx) { return ctx }
+@step(name: "act") fn act(ctx) { return ctx }
+"#,
+        )
+        .expect("source persona parses");
+
+        let persona = &parsed.personas[0];
+        assert_eq!(persona.stages.len(), 2);
+        assert_eq!(persona.stages[0].name, "research");
+        assert_eq!(
+            persona.stages[0].allowed_tools.as_deref(),
+            Some(["github".to_string()].as_slice()),
+        );
+        assert_eq!(
+            persona.stages[1].side_effect_level.as_deref(),
+            Some("process_exec"),
+        );
     }
 
     #[test]

--- a/crates/harn-parser/src/typechecker/inference/statements.rs
+++ b/crates/harn-parser/src/typechecker/inference/statements.rs
@@ -2061,6 +2061,7 @@ impl TypeChecker {
             "receipts",
             "model",
             "owner",
+            "stages",
         ];
         for arg in &attr.args {
             let Some(name) = self.require_named_arg("@persona", arg) else {
@@ -2081,6 +2082,7 @@ impl TypeChecker {
                     self.expect_list_of_symbols("@persona", name, &arg.value, arg.span)
                 }
                 "budget" => self.expect_budget_dict("@persona", name, &arg.value, arg.span),
+                "stages" => self.expect_persona_stages("@persona", &arg.value, arg.span),
                 "receipts" => {
                     if !is_symbol_like(&arg.value.node)
                         && !matches!(arg.value.node, Node::BoolLiteral(_))
@@ -2092,6 +2094,81 @@ impl TypeChecker {
                     }
                 }
                 _ => self.expect_symbol_like("@persona", name, &arg.value, arg.span),
+            }
+        }
+    }
+
+    fn expect_persona_stages(&mut self, owner: &str, value: &SNode, span: Span) {
+        let Node::ListLiteral(entries) = &value.node else {
+            self.warning_at(
+                format!("`{owner}(stages: ...)` must be a list of stage dicts"),
+                span,
+            );
+            return;
+        };
+        const KNOWN_STAGE_KEYS: &[&str] = &[
+            "name",
+            "allowed_tools",
+            "side_effect_level",
+            "max_iterations",
+        ];
+        for entry in entries {
+            let Node::DictLiteral(fields) = &entry.node else {
+                self.warning_at(
+                    format!("`{owner}(stages: ...)` entries must be dict literals"),
+                    entry.span,
+                );
+                continue;
+            };
+            let mut saw_name = false;
+            for dict_entry in fields {
+                let Some(key) = dict_entry_key_str(&dict_entry.key) else {
+                    self.warning_at(
+                        format!("`{owner}(stages: ...)` stage keys must be identifiers"),
+                        dict_entry.key.span,
+                    );
+                    continue;
+                };
+                if !KNOWN_STAGE_KEYS.contains(&key.as_str()) {
+                    self.warning_at(
+                        format!("unknown stage key `{key}`; expected one of {KNOWN_STAGE_KEYS:?}"),
+                        dict_entry.key.span,
+                    );
+                    continue;
+                }
+                match key.as_str() {
+                    "name" | "side_effect_level" => {
+                        if !is_symbol_like(&dict_entry.value.node) {
+                            self.warning_at(
+                                format!("stage `{key}` must be a string"),
+                                dict_entry.value.span,
+                            );
+                        }
+                        if key == "name" {
+                            saw_name = true;
+                        }
+                    }
+                    "allowed_tools" => self.expect_list_of_symbols(
+                        owner,
+                        "allowed_tools",
+                        &dict_entry.value,
+                        dict_entry.value.span,
+                    ),
+                    "max_iterations" if !matches!(dict_entry.value.node, Node::IntLiteral(n) if n >= 0) =>
+                    {
+                        self.warning_at(
+                            "stage `max_iterations` must be a non-negative integer".to_string(),
+                            dict_entry.value.span,
+                        );
+                    }
+                    _ => {}
+                }
+            }
+            if !saw_name {
+                self.warning_at(
+                    format!("`{owner}(stages: ...)` entry missing required `name`"),
+                    entry.span,
+                );
             }
         }
     }
@@ -2452,6 +2529,10 @@ fn symbol_like_value(node: &Node) -> Option<&str> {
         }
         _ => None,
     }
+}
+
+fn dict_entry_key_str(key: &SNode) -> Option<String> {
+    symbol_like_value(&key.node).map(str::to_string)
 }
 
 fn is_trigger_spec(node: &Node) -> bool {

--- a/crates/harn-vm/src/compiler/decls.rs
+++ b/crates/harn-vm/src/compiler/decls.rs
@@ -267,6 +267,14 @@ impl Compiler {
             self.compile_attribute_value(name)?;
             entries += 1;
         }
+        if let Some(stages) = attr.named_arg("stages") {
+            if matches!(stages.node, Node::ListLiteral(_)) {
+                let key_idx = self.chunk.add_constant(Constant::String("stages".into()));
+                self.chunk.emit_u16(Op::Constant, key_idx, self.line);
+                self.compile_attribute_value(stages)?;
+                entries += 1;
+            }
+        }
         self.chunk.emit_u16(Op::BuildDict, entries, self.line);
         self.chunk.emit_u8(Op::Call, 2, self.line);
         self.chunk.emit(Op::Pop, self.line);

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -181,7 +181,7 @@ pub use personas::{
     PersonaRunReceipt, PersonaRuntimeBinding, PersonaStatus, PersonaSupervisionEvent,
     PersonaSupervisionSink, PersonaSupervisionSinkRegistration, PersonaTriggerEnvelope,
     PersonaValueEvent, PersonaValueEventKind, PersonaValueReceipt, PersonaValueSink,
-    PersonaValueSinkRegistration, PERSONA_RUNTIME_TOPIC,
+    PersonaValueSinkRegistration, StageDecl, StageExit, PERSONA_RUNTIME_TOPIC,
 };
 pub use provenance::{
     build_signed_receipt, load_or_generate_agent_signing_key, verify_receipt, ProvenanceReceipt,

--- a/crates/harn-vm/src/personas.rs
+++ b/crates/harn-vm/src/personas.rs
@@ -65,6 +65,51 @@ pub struct PersonaRuntimeBinding {
     pub triggers: Vec<String>,
     #[serde(default)]
     pub budget: PersonaBudgetPolicy,
+    /// Ordered stage declarations. Each stage names a `@step` and narrows the
+    /// runtime capability surface for the duration of that step (see
+    /// `crates/harn-vm/src/step_runtime.rs`). Empty means the persona keeps
+    /// the ambient `CapabilityPolicy`.
+    #[serde(default)]
+    pub stages: Vec<StageDecl>,
+}
+
+/// Per-stage narrowing of the runtime tool surface.
+///
+/// `name` matches a `@step` declaration on the persona. When that step's
+/// frame is entered the runtime pushes a `CapabilityPolicy` whose `tools`
+/// allowlist is `allowed_tools` (when set) and whose side-effect ceiling is
+/// `side_effect_level` (when set). Both narrow the ambient policy — the
+/// existing ceiling still applies, this just adds a tighter scope.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct StageDecl {
+    pub name: String,
+    /// Tool allowlist for the stage. `None` (omitted) inherits the
+    /// persona-level allowlist; `Some(vec![])` denies every tool.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allowed_tools: Option<Vec<String>>,
+    /// Optional side-effect ceiling override (`none` / `read_only` /
+    /// `workspace_write` / `process_exec` / `network`). Tightens, never
+    /// loosens, the ambient ceiling.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub side_effect_level: Option<String>,
+    /// Optional agent-loop iteration cap for the stage. Surfaced for
+    /// downstream consumers; `agent_loop` reads it via the persona binding.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_iterations: Option<u32>,
+    /// Exit transitions that name the next stage on success/failure plus an
+    /// optional explicit policy override.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_exit: Option<StageExit>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct StageExit {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_complete: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_failure: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub policy_override: Option<crate::orchestration::CapabilityPolicy>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -1982,6 +2027,7 @@ mod tests {
                 run_usd: Some(0.02),
                 max_tokens: Some(100),
             },
+            stages: Vec::new(),
         }
     }
 

--- a/crates/harn-vm/src/step_runtime.rs
+++ b/crates/harn-vm/src/step_runtime.rs
@@ -21,7 +21,11 @@ use std::rc::Rc;
 use serde::Serialize;
 use serde_json::Value as JsonValue;
 
-use crate::orchestration::HookEvent;
+use crate::orchestration::{
+    current_execution_policy, pop_execution_policy, push_execution_policy, CapabilityPolicy,
+    HookEvent,
+};
+use crate::personas::StageDecl;
 use crate::value::{VmClosure, VmError, VmValue};
 
 fn vm_str(value: &VmValue) -> Option<&str> {
@@ -52,6 +56,11 @@ pub struct StepDefinition {
 #[derive(Debug, Default, Clone)]
 pub struct PersonaDefinition {
     pub name: String,
+    /// Per-stage tool/side-effect scoping. Keyed lookups by stage name happen
+    /// every step entry; the list is small (a handful of stages per persona)
+    /// so a `Vec` keeps insertion order and matches the manifest's authored
+    /// ordering.
+    pub stages: Vec<StageDecl>,
 }
 
 impl StepDefinition {
@@ -89,6 +98,11 @@ pub struct ActiveStep {
     /// completion. 0 when tracing was disabled at push time, in which
     /// case `span_end` is a no-op anyway.
     pub span_id: u64,
+    /// True when this step pushed a per-stage `CapabilityPolicy` onto the
+    /// execution policy stack. The runtime pops it when the step's frame
+    /// unwinds, mirroring the RAII guard pattern in
+    /// `crates/harn-serve/src/adapters/acp/modes.rs`.
+    pub stage_policy_pushed: bool,
 }
 
 impl ActiveStep {
@@ -98,6 +112,7 @@ impl ActiveStep {
         persona: Option<String>,
         args: Vec<VmValue>,
         span_id: u64,
+        stage_policy_pushed: bool,
     ) -> Self {
         Self {
             frame_depth,
@@ -110,6 +125,7 @@ impl ActiveStep {
             llm_calls: 0,
             last_model: None,
             span_id,
+            stage_policy_pushed,
         }
     }
 
@@ -207,9 +223,76 @@ pub fn register_persona_from_dict(args: Vec<VmValue>) -> Result<VmValue, VmError
             .and_then(vm_str)
             .map(str::to_string)
             .unwrap_or_else(|| function.clone()),
+        stages: parse_stage_decls(meta.get("stages"))?,
     };
     register_persona(&function, definition);
     Ok(VmValue::Nil)
+}
+
+fn parse_stage_decls(value: Option<&VmValue>) -> Result<Vec<StageDecl>, VmError> {
+    let Some(value) = value else {
+        return Ok(Vec::new());
+    };
+    let entries = match value {
+        VmValue::Nil => return Ok(Vec::new()),
+        VmValue::List(list) => list.as_ref(),
+        _ => {
+            return Err(VmError::Thrown(VmValue::String(Rc::from(
+                "__register_persona: stages argument must be a list of dicts",
+            ))));
+        }
+    };
+    let mut out = Vec::with_capacity(entries.len());
+    for entry in entries {
+        let dict = entry.as_dict().ok_or_else(|| {
+            VmError::Thrown(VmValue::String(Rc::from(
+                "__register_persona: each stage entry must be a dict",
+            )))
+        })?;
+        let Some(name) = dict.get("name").and_then(vm_str) else {
+            return Err(VmError::Thrown(VmValue::String(Rc::from(
+                "__register_persona: stage dict missing required 'name'",
+            ))));
+        };
+        let allowed_tools = match dict.get("allowed_tools") {
+            None | Some(VmValue::Nil) => None,
+            Some(VmValue::List(items)) => Some(
+                items
+                    .iter()
+                    .map(|item| {
+                        vm_str(item).map(str::to_string).ok_or_else(|| {
+                            VmError::Thrown(VmValue::String(Rc::from(
+                                "__register_persona: stage allowed_tools entries must be strings",
+                            )))
+                        })
+                    })
+                    .collect::<Result<Vec<_>, _>>()?,
+            ),
+            _ => {
+                return Err(VmError::Thrown(VmValue::String(Rc::from(
+                    "__register_persona: stage allowed_tools must be a list of strings",
+                ))));
+            }
+        };
+        let side_effect_level = dict
+            .get("side_effect_level")
+            .and_then(vm_str)
+            .map(str::to_string)
+            .filter(|s| !s.is_empty());
+        let max_iterations = match dict.get("max_iterations") {
+            Some(VmValue::Int(n)) if *n >= 0 => Some(*n as u32),
+            Some(VmValue::Float(f)) if f.is_finite() && *f >= 0.0 => Some(*f as u32),
+            _ => None,
+        };
+        out.push(StageDecl {
+            name: name.to_string(),
+            allowed_tools,
+            side_effect_level,
+            max_iterations,
+            on_exit: None,
+        });
+    }
+    Ok(out)
 }
 
 /// Builtin entry point invoked by compiler-emitted bytecode after every
@@ -371,6 +454,53 @@ pub fn current_persona_name() -> Option<String> {
     PERSONA_STACK.with(|stack| stack.borrow().last().map(|p| p.definition.name.clone()))
 }
 
+/// Resolve the per-stage policy for `step_name` against the currently
+/// active persona's stage declarations. Returns `None` when no persona is
+/// active or no stage matches the step name. Caller pushes the result onto
+/// `EXECUTION_POLICY_STACK`.
+///
+/// When an ambient policy is already active, the stage policy is
+/// intersected with it so a stage can only ever tighten the tool surface
+/// and side-effect ceiling — never widen them.
+fn stage_policy_for_active_step(step_name: &str) -> Option<CapabilityPolicy> {
+    let stage_policy = PERSONA_STACK.with(|stack| {
+        let stack = stack.borrow();
+        let persona = stack.last()?;
+        let stage = persona
+            .definition
+            .stages
+            .iter()
+            .find(|stage| stage.name == step_name)?;
+        Some(stage_decl_to_policy(stage))
+    })?;
+    let Some(parent) = current_execution_policy() else {
+        return Some(stage_policy);
+    };
+    // `intersect` is conservative: failure means the stage referenced a tool
+    // the ambient policy already denied. Fall back to a narrowed copy that
+    // drops those entries so the stage can never widen the ceiling.
+    Some(parent.intersect(&stage_policy).unwrap_or_else(|_| {
+        let intersected_tools: Vec<String> = stage_policy
+            .tools
+            .iter()
+            .filter(|tool| parent.tools.is_empty() || parent.tools.contains(*tool))
+            .cloned()
+            .collect();
+        CapabilityPolicy {
+            tools: intersected_tools,
+            ..stage_policy
+        }
+    }))
+}
+
+fn stage_decl_to_policy(stage: &StageDecl) -> CapabilityPolicy {
+    CapabilityPolicy {
+        tools: stage.allowed_tools.clone().unwrap_or_default(),
+        side_effect_level: stage.side_effect_level.clone(),
+        ..CapabilityPolicy::default()
+    }
+}
+
 fn persona_matches(pattern: &str, persona: &str) -> bool {
     crate::orchestration::glob_match(pattern, persona)
 }
@@ -447,6 +577,7 @@ pub fn maybe_push_active_step(function_name: &str, frame_depth: usize, args: &[V
             serde_json::Value::String(model.to_string()),
         );
     }
+    let step_name = definition.name.clone();
     STEP_STACK.with(|stack| {
         stack.borrow_mut().push(ActiveStep::new(
             frame_depth,
@@ -454,8 +585,17 @@ pub fn maybe_push_active_step(function_name: &str, frame_depth: usize, args: &[V
             persona,
             args.to_vec(),
             span_id,
+            false,
         ));
     });
+    if let Some(policy) = stage_policy_for_active_step(&step_name) {
+        push_execution_policy(policy);
+        STEP_STACK.with(|stack| {
+            if let Some(top) = stack.borrow_mut().last_mut() {
+                top.stage_policy_pushed = true;
+            }
+        });
+    }
     true
 }
 
@@ -532,6 +672,9 @@ pub fn pop_and_record(current_frame_depth: usize, status: &str, error: Option<St
 }
 
 fn finish_step(step: ActiveStep, status: &str, error: Option<String>) {
+    if step.stage_policy_pushed {
+        pop_execution_policy();
+    }
     crate::tracing::span_set_metadata(
         step.span_id,
         "status",
@@ -862,5 +1005,93 @@ mod tests {
         fresh_state();
         assert!(!maybe_push_active_step("not_a_step", 1, &[]));
         assert!(active_step_frame_depth().is_none());
+    }
+
+    #[test]
+    fn stage_policy_narrows_but_does_not_widen_parent_policy() {
+        fresh_state();
+        let mut meta: BTreeMap<String, VmValue> = BTreeMap::new();
+        meta.insert("name".to_string(), VmValue::String(Rc::from("research")));
+        register_step_from_dict(vec![
+            VmValue::String(Rc::from("research_step")),
+            VmValue::Dict(Rc::new(meta)),
+        ])
+        .expect("step registration");
+
+        let mut stage_dict: BTreeMap<String, VmValue> = BTreeMap::new();
+        stage_dict.insert("name".to_string(), VmValue::String(Rc::from("research")));
+        // Stage tries to add `edit` on top of a parent that only allowed `read`.
+        stage_dict.insert(
+            "allowed_tools".to_string(),
+            VmValue::List(Rc::new(vec![
+                VmValue::String(Rc::from("read")),
+                VmValue::String(Rc::from("edit")),
+            ])),
+        );
+        let mut persona_meta: BTreeMap<String, VmValue> = BTreeMap::new();
+        persona_meta.insert("name".to_string(), VmValue::String(Rc::from("scoped")));
+        persona_meta.insert(
+            "stages".to_string(),
+            VmValue::List(Rc::new(vec![VmValue::Dict(Rc::new(stage_dict))])),
+        );
+        register_persona_from_dict(vec![
+            VmValue::String(Rc::from("scoped_persona")),
+            VmValue::Dict(Rc::new(persona_meta)),
+        ])
+        .expect("persona registration");
+
+        push_execution_policy(CapabilityPolicy {
+            tools: vec!["read".to_string()],
+            ..CapabilityPolicy::default()
+        });
+        assert!(maybe_push_active_persona("scoped_persona", 1));
+        assert!(maybe_push_active_step("research_step", 2, &[]));
+        let policy = current_execution_policy().expect("stage policy active");
+        // `edit` is filtered out because the parent already denied it.
+        assert_eq!(policy.tools, vec!["read".to_string()]);
+
+        prune_below_frame(0);
+        pop_execution_policy();
+        assert!(current_execution_policy().is_none());
+    }
+
+    #[test]
+    fn stage_policy_is_pushed_and_popped_around_step() {
+        fresh_state();
+        let mut meta: BTreeMap<String, VmValue> = BTreeMap::new();
+        meta.insert("name".to_string(), VmValue::String(Rc::from("research")));
+        register_step_from_dict(vec![
+            VmValue::String(Rc::from("research_step")),
+            VmValue::Dict(Rc::new(meta)),
+        ])
+        .expect("step registration succeeds");
+
+        let mut stage_dict: BTreeMap<String, VmValue> = BTreeMap::new();
+        stage_dict.insert("name".to_string(), VmValue::String(Rc::from("research")));
+        stage_dict.insert(
+            "allowed_tools".to_string(),
+            VmValue::List(Rc::new(vec![VmValue::String(Rc::from("read"))])),
+        );
+        let mut persona_meta: BTreeMap<String, VmValue> = BTreeMap::new();
+        persona_meta.insert("name".to_string(), VmValue::String(Rc::from("scoped")));
+        persona_meta.insert(
+            "stages".to_string(),
+            VmValue::List(Rc::new(vec![VmValue::Dict(Rc::new(stage_dict))])),
+        );
+        register_persona_from_dict(vec![
+            VmValue::String(Rc::from("scoped_persona")),
+            VmValue::Dict(Rc::new(persona_meta)),
+        ])
+        .expect("persona registration succeeds");
+
+        assert!(maybe_push_active_persona("scoped_persona", 1));
+        assert!(crate::orchestration::current_execution_policy().is_none());
+        assert!(maybe_push_active_step("research_step", 2, &[]));
+        let policy = crate::orchestration::current_execution_policy()
+            .expect("stage policy is active inside step");
+        assert_eq!(policy.tools, vec!["read".to_string()]);
+
+        prune_below_frame(0);
+        assert!(crate::orchestration::current_execution_policy().is_none());
     }
 }

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -61,6 +61,7 @@
 - [Skills](./skills.md)
 - [Personas](./personas.md)
   - [Persona Prelude](./personas/prelude.md)
+  - [Per-stage tool scoping](./personas/stages.md)
   - [Profile bulletins](./personas/profile-bulletins.md)
   - [Merge Captain](./personas/merge-captain.md)
 - [Skill provenance](./skill-provenance.md)

--- a/docs/src/personas/stages.md
+++ b/docs/src/personas/stages.md
@@ -1,0 +1,87 @@
+# Per-stage tool scoping
+
+A persona that walks through `research → plan → edit → verify` usually
+runs the entire run under one ambient `CapabilityPolicy`. The model is
+trusted by prompt convention to only call read-only tools during
+`research`. That trust is one prompt injection away from breaking.
+
+Persona stage declarations close the gap: each stage names a `@step` and
+the tool / side-effect surface enforced for the duration of that step.
+The runtime pushes a `CapabilityPolicy` on entry and pops it on exit, so
+a tool call that escapes the declared surface comes back as a
+`permission_denied` receipt without ever reaching the handler.
+
+## Declaring stages
+
+Stages are part of the persona manifest. They can live in `harn.toml`:
+
+```toml
+[[personas]]
+name = "merge_captain"
+tools = ["github", "ci", "linear", "notion", "slack", "mcp"]
+# ...
+stages = [
+  { name = "classify", allowed_tools = ["github", "ci"], side_effect_level = "read_only" },
+  { name = "plan_repair", allowed_tools = ["github", "ci", "linear", "notion"], side_effect_level = "read_only" },
+  { name = "apply_repair", allowed_tools = ["github", "ci"], side_effect_level = "process_exec", on_exit = { on_complete = "classify", on_failure = "plan_repair" } },
+]
+```
+
+or directly on the `@persona` attribute in a Harn workflow:
+
+```harn,ignore
+@persona(
+  name: "scoped_persona",
+  tools: [github, ci],
+  stages: [
+    {name: "research", allowed_tools: ["github"], side_effect_level: "read_only"},
+    {name: "act", allowed_tools: ["github", "ci"], side_effect_level: "process_exec"},
+  ],
+)
+fn scoped_persona(ctx) {
+  research(ctx)
+  act(ctx)
+}
+```
+
+Each stage's `name` must match a `@step(name: "...")` declaration in the
+same persona. The matched step's frame is what activates and deactivates
+the stage policy.
+
+## Fields
+
+| Field               | Type                | Meaning                                                                                                    |
+| ------------------- | ------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `name`              | string              | Matches a `@step` declaration. Required.                                                                   |
+| `allowed_tools`     | `string[]?`         | Tool allowlist for the stage. Omit to inherit the persona's `tools`. `[]` denies every tool.               |
+| `side_effect_level` | string?             | One of `none` / `read_only` / `workspace_write` / `process_exec` / `network`. Tightens the ambient ceiling. |
+| `max_iterations`    | u32?                | Optional agent-loop iteration cap surfaced to downstream consumers.                                        |
+| `on_exit`           | `{on_complete?, on_failure?}` | Transition hints recorded with the stage receipt. The runtime does not auto-route — the workflow does. |
+
+## Validation
+
+Persona load (`harn persona list`, `harn check`) rejects manifests where:
+
+- A stage's `allowed_tools` references a tool that isn't in the persona's
+  top-level `tools` list, or isn't known to the host tool catalog.
+- `side_effect_level` is not one of the canonical names above.
+- `on_exit.on_complete` / `on_exit.on_failure` references a stage that
+  the persona doesn't declare.
+- Two stages share a `name`.
+
+## Runtime semantics
+
+Stage policies are pushed onto the same `EXECUTION_POLICY_STACK` that
+`with_execution_policy(...)` uses. They intersect with whatever ambient
+policy was already active — a stage can tighten the surface but never
+loosen it. When a step frame unwinds (success, error, or escape via
+`on_exit`), the runtime pops the stage policy, mirroring the existing
+RAII guard pattern used by ACP modes.
+
+A stage with `allowed_tools = [...]` and no `side_effect_level` leaves
+the ambient side-effect ceiling intact; combine both fields to scope a
+read-only research stage against a workspace-mutating persona.
+
+If `stages` is empty (or omitted), behavior is identical to a persona
+without stage declarations — the ambient policy alone governs every
+tool call.

--- a/examples/personas/harn.toml
+++ b/examples/personas/harn.toml
@@ -33,6 +33,11 @@ budget = { daily_usd = 10.0, frontier_escalations = 1, max_tokens = 60000, max_r
 model_policy = { default_model = "gpt-5.4-mini", escalation_model = "gpt-5.4", fallback_models = ["gpt-5.2"], reasoning_effort = "medium" }
 rollout_policy = { mode = "approval_only", percentage = 100, cohorts = ["template-pack"] }
 package_source = { package = "harn-persona-template-pack", path = "examples/personas" }
+stages = [
+  { name = "classify", allowed_tools = ["github", "ci"], side_effect_level = "read_only" },
+  { name = "plan_repair", allowed_tools = ["github", "ci", "linear", "notion"], side_effect_level = "read_only" },
+  { name = "apply_repair", allowed_tools = ["github", "ci"], side_effect_level = "process_exec", on_exit = { on_complete = "classify", on_failure = "plan_repair" } },
+]
 
 [[personas]]
 name = "review_captain"


### PR DESCRIPTION
## Summary

Closes #1701 (child of epic #1700).

- Persona manifests can now declare `[[personas.stages]]` (or the `@persona(stages: [...])` attribute form). Each stage names a `@step` and narrows the runtime tool / side-effect surface for the duration of that step's frame.
- The step runtime pushes a `CapabilityPolicy` intersected with the ambient policy on stage entry and pops it on exit — a stage can tighten the ceiling but never widen it.
- Out-of-stage tool calls come back as `permission_denied` receipts without ever reaching the handler, regardless of whether the planner emitted them.

## What changed

- `harn-vm`: `StageDecl` / `StageExit` types; `PersonaRuntimeBinding.stages`; `PersonaDefinition.stages` parsed from the `__register_persona` dict; stage-policy push/pop wired into `maybe_push_active_step` / `finish_step`.
- `harn-parser`: `@persona(stages: [...])` accepted with structural validation; compiler forwards the attribute into the registration dict.
- `harn-modules`: `PersonaStageDecl` / `PersonaStageExit` on the manifest shape; validation flags unknown tools, bad side-effect levels, duplicate names, and dangling `on_exit` targets; serde round-trip covered.
- `harn-cli`: single `persona_runtime_binding` helper threaded through trigger and CLI paths; `harn persona inspect` surfaces stages in text and JSON.
- `examples/personas/harn.toml`: `merge_captain` declares classify / plan_repair / apply_repair stages with explicit `on_exit` transitions.
- Conformance: [`personas/persona_per_stage_scope.harn`](conformance/tests/personas/persona_per_stage_scope.harn) exercises in-stage allowed dispatch, out-of-stage `permission_denied`, stage swap on transition, and post-unwind ambient dispatch.
- Docs: new [`docs/src/personas/stages.md`](docs/src/personas/stages.md), linked from SUMMARY.

## Test plan

- [x] `cargo test -p harn-vm --lib step_runtime::` (4 passed, incl. new stage push/pop + parent-intersection tests)
- [x] `cargo test -p harn-modules --lib personas::` (6 passed, incl. round-trip and validation)
- [x] `make test` (3995 passed, 2 skipped)
- [x] `make conformance` (1060 passed)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `make check-docs-snippets`
- [x] `make lint-test-patterns`
- [x] `make fmt-harn` / `make lint-harn`
- [x] `harn persona inspect merge_captain --manifest examples/personas/harn.toml [--json]` shows stages in both modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)