### PR TITLE
harn-vm: dedupe builtin registration, model version parsing, and percent-encoding

### DIFF
--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -68,6 +68,7 @@ pub mod tool_surface;
 pub mod tracing;
 pub mod triggers;
 pub mod trust_graph;
+pub(crate) mod url_encoding;
 
 /// Crate-wide deterministic clock mock used by stdlib time builtins, the
 /// trigger dispatcher, the cron scheduler, and Rust-side tests. Re-exports

--- a/crates/harn-vm/src/llm/providers/anthropic.rs
+++ b/crates/harn-vm/src/llm/providers/anthropic.rs
@@ -5,6 +5,7 @@ use std::collections::HashSet;
 
 use crate::llm::api::{DeltaSender, LlmRequestPayload, LlmResult, ThinkingConfig};
 use crate::llm::provider::{LlmProvider, LlmProviderChat};
+use crate::llm::providers::common::parse_major_minor_tail;
 use crate::value::VmError;
 
 pub(crate) const ANTHROPIC_INTERLEAVED_THINKING_BETA: &str = "interleaved-thinking-2025-05-14";
@@ -29,36 +30,10 @@ pub(crate) fn claude_generation(model: &str) -> Option<(u32, u32)> {
     if !lower.starts_with("claude-") && !lower.contains("/claude-") {
         return None;
     }
-    // Try dotted form first: "…claude-opus-4.7…", "…claude-opus-4.6-fast…".
     for family in ["opus", "sonnet", "haiku"] {
         let needle = format!("{family}-");
         if let Some(idx) = lower.find(&needle) {
-            let tail = &lower[idx + needle.len()..];
-            // Dotted: "4.7" / "4.6"
-            if let Some((major, rest)) = tail.split_once('.') {
-                if let Ok(major) = major.parse::<u32>() {
-                    let minor_str: String =
-                        rest.chars().take_while(|c| c.is_ascii_digit()).collect();
-                    if let Ok(minor) = minor_str.parse::<u32>() {
-                        return Some((major, minor));
-                    }
-                }
-            }
-            // Dashed: "4-7", "4-6", "4-20250514" (minor=0 when the second
-            // chunk is clearly a date, not a small version number).
-            let mut parts = tail.split('-');
-            if let Some(major_str) = parts.next() {
-                if let Ok(major) = major_str.parse::<u32>() {
-                    if let Some(minor_str) = parts.next() {
-                        if let Ok(minor) = minor_str.parse::<u32>() {
-                            // Dates ≥ 1000 aren't minor versions.
-                            let minor = if minor >= 1000 { 0 } else { minor };
-                            return Some((major, minor));
-                        }
-                    }
-                    return Some((major, 0));
-                }
-            }
+            return parse_major_minor_tail(&lower[idx + needle.len()..]);
         }
     }
     None

--- a/crates/harn-vm/src/llm/providers/azure_openai.rs
+++ b/crates/harn-vm/src/llm/providers/azure_openai.rs
@@ -6,9 +6,8 @@
 
 use crate::llm::api::{DeltaSender, LlmRequestPayload, LlmResult};
 use crate::llm::provider::{LlmProvider, LlmProviderChat};
-use crate::llm::providers::common::{
-    apply_provider_overrides, maybe_emit_delta, percent_encode_path_segment, vm_err,
-};
+use crate::llm::providers::common::{apply_provider_overrides, maybe_emit_delta, vm_err};
+use crate::url_encoding::percent_encode_component;
 use crate::value::VmError;
 
 use super::openai_compat::OpenAiCompatibleProvider;
@@ -60,7 +59,7 @@ impl AzureOpenAiProvider {
             .unwrap_or_else(|| DEFAULT_API_VERSION.to_string());
         Ok(format!(
             "{base_url}/openai/deployments/{}/chat/completions?api-version={api_version}",
-            percent_encode_path_segment(deployment.trim())
+            percent_encode_component(deployment.trim())
         ))
     }
 

--- a/crates/harn-vm/src/llm/providers/bedrock.rs
+++ b/crates/harn-vm/src/llm/providers/bedrock.rs
@@ -12,9 +12,9 @@ use sha2::{Digest, Sha256};
 use crate::llm::api::{DeltaSender, LlmRequestPayload, LlmResult};
 use crate::llm::provider::{LlmProvider, LlmProviderChat};
 use crate::llm::providers::common::{
-    apply_provider_overrides, maybe_emit_delta, percent_encode_path_segment, request_text_content,
-    vm_err,
+    apply_provider_overrides, maybe_emit_delta, request_text_content, vm_err,
 };
+use crate::url_encoding::percent_encode_component;
 use crate::value::VmError;
 
 pub(crate) struct BedrockProvider;
@@ -114,7 +114,7 @@ impl BedrockProvider {
             .map_err(|error| vm_err(format!("bedrock request serialization failed: {error}")))?;
         let path = format!(
             "/model/{}/converse",
-            percent_encode_path_segment(&request.model)
+            percent_encode_component(&request.model)
         );
         let base_url = bedrock_base_url(&region);
         let url = format!("{}{}", base_url.trim_end_matches('/'), path);

--- a/crates/harn-vm/src/llm/providers/common.rs
+++ b/crates/harn-vm/src/llm/providers/common.rs
@@ -36,19 +36,6 @@ pub(super) fn request_text_content(message: &serde_json::Value) -> String {
     text
 }
 
-pub(super) fn percent_encode_path_segment(input: &str) -> String {
-    let mut out = String::with_capacity(input.len());
-    for byte in input.bytes() {
-        match byte {
-            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
-                out.push(byte as char)
-            }
-            _ => out.push_str(&format!("%{byte:02X}")),
-        }
-    }
-    out
-}
-
 pub(super) fn empty_result(provider: &str, model: &str) -> LlmResult {
     LlmResult {
         text: String::new(),
@@ -77,5 +64,64 @@ pub(super) fn apply_provider_overrides(
     };
     for (key, value) in obj {
         body[key] = value.clone();
+    }
+}
+
+/// Parse a `(major, minor)` generation pair from the tail of a model ID after
+/// the family needle. Accepts both dotted forms (`4.7`, `5.4-preview`) and
+/// dashed forms (`4-7`, `5-4-preview`, `4-20251001`).
+///
+/// Trailing chunks that look like date stamps (≥ 1000) are not treated as a
+/// minor version — `claude-haiku-4-5-20251001` parses as `(4, 5)`,
+/// `claude-opus-4-20251001` parses as `(4, 0)`. If no integer major can be
+/// parsed at the start of `tail`, returns `None`.
+pub(super) fn parse_major_minor_tail(tail: &str) -> Option<(u32, u32)> {
+    if let Some((major, rest)) = tail.split_once('.') {
+        if let Ok(major) = major.parse::<u32>() {
+            let minor_str: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+            if let Ok(minor) = minor_str.parse::<u32>() {
+                return Some((major, minor));
+            }
+        }
+    }
+    let mut parts = tail.split('-');
+    let major = parts.next()?.parse::<u32>().ok()?;
+    let Some(minor_chunk) = parts.next() else {
+        return Some((major, 0));
+    };
+    let Ok(minor) = minor_chunk.parse::<u32>() else {
+        return Some((major, 0));
+    };
+    Some((major, if minor >= 1000 { 0 } else { minor }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_major_minor_tail_dotted() {
+        assert_eq!(parse_major_minor_tail("4.7"), Some((4, 7)));
+        assert_eq!(parse_major_minor_tail("5.4-preview"), Some((5, 4)));
+        assert_eq!(parse_major_minor_tail("5.4.1-turbo"), Some((5, 4)));
+    }
+
+    #[test]
+    fn parse_major_minor_tail_dashed() {
+        assert_eq!(parse_major_minor_tail("4-7"), Some((4, 7)));
+        assert_eq!(parse_major_minor_tail("5-4-preview"), Some((5, 4)));
+        assert_eq!(parse_major_minor_tail("5"), Some((5, 0)));
+    }
+
+    #[test]
+    fn parse_major_minor_tail_date_chunk_is_zero_minor() {
+        assert_eq!(parse_major_minor_tail("4-20251001"), Some((4, 0)));
+        assert_eq!(parse_major_minor_tail("5-20260115"), Some((5, 0)));
+    }
+
+    #[test]
+    fn parse_major_minor_tail_rejects_non_numeric_major() {
+        assert!(parse_major_minor_tail("preview").is_none());
+        assert!(parse_major_minor_tail("").is_none());
     }
 }

--- a/crates/harn-vm/src/llm/providers/openai_compat.rs
+++ b/crates/harn-vm/src/llm/providers/openai_compat.rs
@@ -4,6 +4,7 @@
 
 use crate::llm::api::{DeltaSender, LlmRequestPayload, LlmResult, ThinkingConfig};
 use crate::llm::provider::{LlmProvider, LlmProviderChat};
+use crate::llm::providers::common::parse_major_minor_tail;
 use crate::value::VmError;
 
 /// Parse the (major, minor) version out of a GPT model ID. Handles dotted
@@ -15,38 +16,12 @@ use crate::value::VmError;
 /// Returns `None` for non-GPT shapes (`claude-opus-4-7`, `llama-3.1`, …).
 pub(crate) fn gpt_generation(model: &str) -> Option<(u32, u32)> {
     let lower = model.to_lowercase();
-    // Strip any `namespace/` prefix (OpenRouter, Azure, vertex).
     let stripped = match lower.rsplit_once('/') {
         Some((_, tail)) => tail,
         None => lower.as_str(),
     };
-    let needle = "gpt-";
-    let idx = stripped.find(needle)?;
-    let tail = &stripped[idx + needle.len()..];
-    // Dotted: "5.4" / "5.4-preview" / "5.4-turbo".
-    if let Some((major, rest)) = tail.split_once('.') {
-        if let Ok(major) = major.parse::<u32>() {
-            let minor_str: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
-            if let Ok(minor) = minor_str.parse::<u32>() {
-                return Some((major, minor));
-            }
-        }
-    }
-    // Dashed: "5-4" / "5-4-preview" / "5" (minor=0).
-    let mut parts = tail.split('-');
-    if let Some(major_str) = parts.next() {
-        if let Ok(major) = major_str.parse::<u32>() {
-            if let Some(minor_str) = parts.next() {
-                if let Ok(minor) = minor_str.parse::<u32>() {
-                    // Dates ≥ 1000 are stamps, not minor versions.
-                    let minor = if minor >= 1000 { 0 } else { minor };
-                    return Some((major, minor));
-                }
-            }
-            return Some((major, 0));
-        }
-    }
-    None
+    let idx = stripped.find("gpt-")?;
+    parse_major_minor_tail(&stripped[idx + "gpt-".len()..])
 }
 
 /// True for GPT models that expose OpenAI's Responses-API `tool_search` meta-tool

--- a/crates/harn-vm/src/llm/providers/vertex.rs
+++ b/crates/harn-vm/src/llm/providers/vertex.rs
@@ -8,9 +8,9 @@
 use crate::llm::api::{DeltaSender, LlmRequestPayload, LlmResult};
 use crate::llm::provider::{LlmProvider, LlmProviderChat};
 use crate::llm::providers::common::{
-    apply_provider_overrides, maybe_emit_delta, percent_encode_path_segment, request_text_content,
-    vm_err,
+    apply_provider_overrides, maybe_emit_delta, request_text_content, vm_err,
 };
+use crate::url_encoding::percent_encode_component;
 use crate::value::VmError;
 
 pub(crate) struct VertexProvider;
@@ -131,9 +131,9 @@ impl VertexProvider {
         } else {
             format!(
                 "projects/{}/locations/{}/publishers/google/models/{}",
-                percent_encode_path_segment(&project),
-                percent_encode_path_segment(&location),
-                percent_encode_path_segment(&request.model)
+                percent_encode_component(&project),
+                percent_encode_component(&location),
+                percent_encode_component(&request.model)
             )
         };
         Ok(format!("{base_url}/{model}:generateContent"))

--- a/crates/harn-vm/src/stdlib/crypto.rs
+++ b/crates/harn-vm/src/stdlib/crypto.rs
@@ -5,6 +5,7 @@ use jsonwebtoken::{Algorithm, EncodingKey, Header};
 use url::Url;
 use zeroize::Zeroizing;
 
+use crate::url_encoding::percent_encode_component;
 use crate::value::{VmError, VmValue};
 use crate::vm::Vm;
 
@@ -255,19 +256,6 @@ fn parse_query_pairs(raw: &str) -> Vec<(String, String)> {
     url::form_urlencoded::parse(raw.as_bytes())
         .map(|(key, value)| (key.into_owned(), value.into_owned()))
         .collect()
-}
-
-fn percent_encode_component(input: &str) -> String {
-    let mut out = String::new();
-    for byte in input.as_bytes() {
-        match *byte {
-            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
-                out.push(*byte as char);
-            }
-            _ => out.push_str(&format!("%{byte:02X}")),
-        }
-    }
-    out
 }
 
 fn percent_encode_path(input: &str) -> String {

--- a/crates/harn-vm/src/stdlib/options.rs
+++ b/crates/harn-vm/src/stdlib/options.rs
@@ -1,27 +1,22 @@
 //! Shared option-bag and argument-extraction helpers for stdlib builtins.
 //!
-//! Before this module landed, every option-bag-accepting builtin had its own
-//! hand-rolled chain of `dict.get().map().and_then().ok_or_else()` plus its
-//! own near-duplicate `optional_string` / `required_string_arg` /
-//! `opts_dict_arg` helpers. Several modules duplicated the same logic under
-//! different names with subtly different error shapes (some emitted
-//! [`VmError::Runtime`], some [`VmError::Thrown`]). This module is the single
-//! canonical home for that logic; builtins pick an [`ErrorKind`] based on
-//! whether their failures should bubble out or be catchable from Harn.
+//! Builtins choose an [`ErrorKind`] per call: [`ErrorKind::Runtime`] for
+//! failures that should bubble out as runtime errors, [`ErrorKind::Thrown`]
+//! for failures that user code can `try` / `recover`.
 //!
 //! Conventions:
 //! - Function-name strings are `&'static str` so error messages can be
 //!   formatted without allocations on the success path.
 //! - Optional fields treat both `Nil` and "missing" as None.
-//! - String getters trim whitespace and treat trimmed-empty strings as None
-//!   (matching the pre-existing helpers).
-//! - [`OptionsParser`] tracks consumed keys so callsites with a closed schema
-//!   can call [`OptionsParser::finish_strict`] to reject unknown options.
+//! - String getters trim whitespace and treat trimmed-empty strings as None.
+//! - [`OptionsParser`] tracks consumed keys; call
+//!   [`OptionsParser::finish_strict`] on closed-schema option bags to reject
+//!   unknown options.
 //!
-//! Some helpers below are unused by today's callsites and intentionally kept
-//! for adoption by future stdlib additions (option-bag parsing is the most
-//! common new-builtin shape). `#![allow(dead_code)]` keeps the API surface
-//! intact without per-item attributes.
+//! Several helpers below have no callers today but are kept available for
+//! future stdlib additions — option-bag parsing is the most common
+//! new-builtin shape. `#![allow(dead_code)]` keeps the API surface intact
+//! without per-item attributes.
 #![allow(dead_code)]
 
 use std::collections::{BTreeMap, BTreeSet};

--- a/crates/harn-vm/src/stdlib/registration.rs
+++ b/crates/harn-vm/src/stdlib/registration.rs
@@ -10,111 +10,71 @@ pub(crate) type AsyncBuiltinFuture = Pin<Box<dyn Future<Output = Result<VmValue,
 pub(crate) type SyncBuiltinHandler = fn(&[VmValue], &mut String) -> Result<VmValue, VmError>;
 pub(crate) type AsyncBuiltinHandler = fn(Vec<VmValue>) -> AsyncBuiltinFuture;
 
-#[derive(Clone)]
-pub(crate) struct SyncBuiltin {
-    name: &'static str,
-    signature: Option<&'static str>,
-    arity: Option<VmBuiltinArity>,
-    doc: Option<&'static str>,
-    handler: SyncBuiltinHandler,
+/// Generate a builder struct for a builtin kind (sync or async).
+///
+/// Both kinds share the same builder surface — name, optional signature,
+/// arity, and doc — and the same metadata-application logic. The only
+/// thing that differs is the handler type and which `VmBuiltinMetadata`
+/// constructor stamps the kind (`sync_static` vs `async_static`).
+macro_rules! builtin_kind {
+    ($struct_name:ident, $handler_ty:ident, $meta_ctor:ident) => {
+        #[derive(Clone)]
+        pub(crate) struct $struct_name {
+            name: &'static str,
+            signature: Option<&'static str>,
+            arity: Option<VmBuiltinArity>,
+            doc: Option<&'static str>,
+            handler: $handler_ty,
+        }
+
+        impl $struct_name {
+            pub(crate) const fn new(name: &'static str, handler: $handler_ty) -> Self {
+                Self {
+                    name,
+                    signature: None,
+                    arity: None,
+                    doc: None,
+                    handler,
+                }
+            }
+
+            pub(crate) const fn signature(mut self, signature: &'static str) -> Self {
+                self.signature = Some(signature);
+                self
+            }
+
+            pub(crate) const fn arity(mut self, arity: VmBuiltinArity) -> Self {
+                self.arity = Some(arity);
+                self
+            }
+
+            pub(crate) const fn doc(mut self, doc: &'static str) -> Self {
+                self.doc = Some(doc);
+                self
+            }
+
+            fn metadata(&self, default_category: Option<&'static str>) -> VmBuiltinMetadata {
+                let mut metadata = VmBuiltinMetadata::$meta_ctor(self.name);
+                if let Some(signature) = self.signature {
+                    metadata = metadata.signature_static(signature);
+                }
+                if let Some(arity) = self.arity {
+                    metadata = metadata.arity(arity);
+                }
+                if let Some(category) = default_category {
+                    metadata = metadata.category_static(category);
+                }
+                if let Some(doc) = self.doc {
+                    metadata = metadata.doc_static(doc);
+                }
+                metadata
+            }
+        }
+    };
 }
 
-impl SyncBuiltin {
-    pub(crate) const fn new(name: &'static str, handler: SyncBuiltinHandler) -> Self {
-        Self {
-            name,
-            signature: None,
-            arity: None,
-            doc: None,
-            handler,
-        }
-    }
-
-    pub(crate) const fn signature(mut self, signature: &'static str) -> Self {
-        self.signature = Some(signature);
-        self
-    }
-
-    pub(crate) const fn arity(mut self, arity: VmBuiltinArity) -> Self {
-        self.arity = Some(arity);
-        self
-    }
-
-    pub(crate) const fn doc(mut self, doc: &'static str) -> Self {
-        self.doc = Some(doc);
-        self
-    }
-
-    fn metadata(&self, default_category: Option<&'static str>) -> VmBuiltinMetadata {
-        let mut metadata = VmBuiltinMetadata::sync_static(self.name);
-        if let Some(signature) = self.signature {
-            metadata = metadata.signature_static(signature);
-        }
-        if let Some(arity) = self.arity {
-            metadata = metadata.arity(arity);
-        }
-        if let Some(category) = default_category {
-            metadata = metadata.category_static(category);
-        }
-        if let Some(doc) = self.doc {
-            metadata = metadata.doc_static(doc);
-        }
-        metadata
-    }
-}
-
-#[derive(Clone)]
-pub(crate) struct AsyncBuiltin {
-    name: &'static str,
-    signature: Option<&'static str>,
-    arity: Option<VmBuiltinArity>,
-    doc: Option<&'static str>,
-    handler: AsyncBuiltinHandler,
-}
-
-impl AsyncBuiltin {
-    pub(crate) const fn new(name: &'static str, handler: AsyncBuiltinHandler) -> Self {
-        Self {
-            name,
-            signature: None,
-            arity: None,
-            doc: None,
-            handler,
-        }
-    }
-
-    pub(crate) const fn signature(mut self, signature: &'static str) -> Self {
-        self.signature = Some(signature);
-        self
-    }
-
-    pub(crate) const fn arity(mut self, arity: VmBuiltinArity) -> Self {
-        self.arity = Some(arity);
-        self
-    }
-
-    pub(crate) const fn doc(mut self, doc: &'static str) -> Self {
-        self.doc = Some(doc);
-        self
-    }
-
-    fn metadata(&self, default_category: Option<&'static str>) -> VmBuiltinMetadata {
-        let mut metadata = VmBuiltinMetadata::async_static(self.name);
-        if let Some(signature) = self.signature {
-            metadata = metadata.signature_static(signature);
-        }
-        if let Some(arity) = self.arity {
-            metadata = metadata.arity(arity);
-        }
-        if let Some(category) = default_category {
-            metadata = metadata.category_static(category);
-        }
-        if let Some(doc) = self.doc {
-            metadata = metadata.doc_static(doc);
-        }
-        metadata
-    }
-}
+builtin_kind!(SyncBuiltin, SyncBuiltinHandler, sync_static);
+builtin_kind!(AsyncBuiltin, AsyncBuiltinHandler, async_static);
 
 pub(crate) fn boxed_async_builtin<Fut>(future: Fut) -> AsyncBuiltinFuture
 where

--- a/crates/harn-vm/src/url_encoding.rs
+++ b/crates/harn-vm/src/url_encoding.rs
@@ -1,0 +1,41 @@
+//! RFC 3986 percent-encoding helpers shared across the crate.
+//!
+//! `url::form_urlencoded` encodes for `application/x-www-form-urlencoded`
+//! (spaces become `+`, etc.), which is the wrong shape for URL path
+//! segments and signed-URL canonical query strings. These helpers preserve
+//! the unreserved characters (`ALPHA / DIGIT / "-" / "." / "_" / "~"`) and
+//! escape everything else as `%HH`.
+
+/// Percent-encode `input` as an RFC 3986 component: every byte outside the
+/// unreserved set is escaped, including `/` and `?`.
+pub(crate) fn percent_encode_component(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for &byte in input.as_bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(byte as char);
+            }
+            _ => out.push_str(&format!("%{byte:02X}")),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unreserved_pass_through() {
+        assert_eq!(
+            percent_encode_component("Hello-World_1.0~"),
+            "Hello-World_1.0~"
+        );
+    }
+
+    #[test]
+    fn reserved_and_unicode_escaped() {
+        assert_eq!(percent_encode_component("a b/c?d"), "a%20b%2Fc%3Fd");
+        assert_eq!(percent_encode_component("é"), "%C3%A9");
+    }
+}


### PR DESCRIPTION
## Summary

A garden-tending pass that consolidates three DRY violations inside `harn-vm`:

- **`stdlib::registration`** — collapse the duplicated `SyncBuiltin` / `AsyncBuiltin` builder structs into a single macro-generated definition. Both kinds share the same `name` / `signature` / `arity` / `doc` surface and identical metadata-application logic; the macro emits both from one body. Public API and `const` builder chains are unchanged.
- **`llm::providers`** — extract the dotted/dashed major-minor parser shared by `claude_generation` and `gpt_generation` into `common::parse_major_minor_tail`. Removes ~60 lines and gives the date-stamp-as-minor rule one home. New unit tests cover the dotted, dashed, and date-stamp paths.
- **`url_encoding`** — new tiny crate-internal module hosting `percent_encode_component`, used by the LLM providers (Vertex/Bedrock/Azure URL construction) and `stdlib::crypto` (signed-URL canonical query encoding). The previous `percent_encode_path_segment` alias was misleading — it encoded `/` too, so it was a generic RFC 3986 component encoder.

Also: rewrites the `stdlib::options` module preamble to drop the historical "before this module landed" narrative in favor of stating the current conventions directly.

## Test plan

- [x] `cargo build -p harn-vm`
- [x] `cargo clippy -p harn-vm --all-targets`
- [x] `cargo test -p harn-vm --lib` (2070 passed, 0 failed)
- [x] Existing `gpt_generation_*` and `tool_search_*` tests still pass against the new shared parser
- [x] Pre-commit and pre-push hooks (fmt, clippy, lint ratchets, highlight-keywords sync) all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)