### PR TITLE
Add ACP session truncate

### DIFF
--- a/conformance/protocols/fixtures/acp/session_update_extensions.valid.json
+++ b/conformance/protocols/fixtures/acp/session_update_extensions.valid.json
@@ -23,6 +23,20 @@
       "params": {
         "sessionId": "session-1",
         "update": {
+          "sessionUpdate": "session_truncated",
+          "keptTurnCount": 1,
+          "removedTurnCount": 2,
+          "newTipTurnId": "turn-1",
+          "reason": "user_edit"
+        }
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "method": "session/update",
+      "params": {
+        "sessionId": "session-1",
+        "update": {
           "sessionUpdate": "tool_search_query",
           "toolUseId": "search-1",
           "name": "tool_search",

--- a/conformance/protocols/schemas/acp-session-update.schema.json
+++ b/conformance/protocols/schemas/acp-session-update.schema.json
@@ -150,6 +150,7 @@
         { "$ref": "#/$defs/CurrentModeUpdate" },
         { "$ref": "#/$defs/ConfigOptionUpdate" },
         { "$ref": "#/$defs/SessionInfoUpdate" },
+        { "$ref": "#/$defs/SessionTruncated" },
         { "$ref": "#/$defs/SkillActivated" },
         { "$ref": "#/$defs/SkillDeactivated" },
         { "$ref": "#/$defs/SkillScopeTools" },
@@ -336,6 +337,18 @@
       "additionalProperties": true,
       "properties": {
         "sessionUpdate": { "const": "session_info_update" }
+      }
+    },
+    "SessionTruncated": {
+      "type": "object",
+      "required": ["sessionUpdate", "keptTurnCount", "removedTurnCount"],
+      "additionalProperties": true,
+      "properties": {
+        "sessionUpdate": { "const": "session_truncated" },
+        "keptTurnCount": { "type": "integer", "minimum": 0 },
+        "removedTurnCount": { "type": "integer", "minimum": 0 },
+        "newTipTurnId": { "type": ["string", "null"] },
+        "reason": { "type": "string" }
       }
     },
     "SkillActivated": {

--- a/crates/harn-cli/src/commands/dump_protocol_artifacts.rs
+++ b/crates/harn-cli/src/commands/dump_protocol_artifacts.rs
@@ -29,6 +29,7 @@ const ACP_AGENT_METHODS: &[&str] = &[
     "initialize",
     "session/new",
     "session/prompt",
+    "session/truncate",
     "session/stop",
 ];
 const ACP_CLIENT_METHODS: &[&str] = &[
@@ -571,6 +572,14 @@ export interface ACPPlanUpdate {
   harnPlan?: ACPValue
 }
 
+export interface ACPSessionTruncatedUpdate {
+  sessionUpdate: "session_truncated"
+  keptTurnCount: number
+  removedTurnCount: number
+  newTipTurnId?: string | null
+  reason?: string
+}
+
 export interface ACPHarnExtensionUpdate {
   sessionUpdate: HarnACPSessionUpdateExtension
   _meta?: ACPExtensionMeta<ACPObject>
@@ -581,6 +590,7 @@ export type ACPSessionUpdateEnvelope =
   | ACPToolCall
   | ACPToolCallUpdate
   | ACPPlanUpdate
+  | ACPSessionTruncatedUpdate
   | ACPHarnExtensionUpdate
 
 export interface ACPSessionUpdateParams {
@@ -1324,6 +1334,10 @@ public struct HarnACPSessionUpdateEnvelope: Codable, Sendable, Equatable {
     public var sessionUpdate: HarnACPSessionUpdate
     public var content: HarnACPContentBlock?
     public var entries: [HarnACPValue]?
+    public var keptTurnCount: Int?
+    public var removedTurnCount: Int?
+    public var newTipTurnId: String?
+    public var reason: String?
     public var toolCallId: String?
     public var title: String?
     public var kind: HarnACPToolKind?
@@ -1336,6 +1350,10 @@ public struct HarnACPSessionUpdateEnvelope: Codable, Sendable, Equatable {
         case sessionUpdate
         case content
         case entries
+        case keptTurnCount
+        case removedTurnCount
+        case newTipTurnId
+        case reason
         case toolCallId
         case title
         case kind
@@ -1781,6 +1799,10 @@ class ACPSessionUpdateEnvelope(_HarnDataclass):
     sessionUpdate: str
     content: Optional[ACPContentBlock] = None
     entries: Optional[List[JsonValue]] = None
+    keptTurnCount: Optional[int] = None
+    removedTurnCount: Optional[int] = None
+    newTipTurnId: Optional[str] = None
+    reason: Optional[str] = None
     toolCallId: Optional[str] = None
     title: Optional[str] = None
     kind: Optional[str] = None
@@ -2349,16 +2371,20 @@ type ACPToolCallUpdate struct {
 // `sessionUpdate` discriminator will be populated; the rest stay zero-value
 // and are stripped via `omitempty` on serialization.
 type ACPSessionUpdateEnvelope struct {
-	SessionUpdate string             `json:"sessionUpdate"`
-	Content       *ACPContentBlock   `json:"content,omitempty"`
-	Entries       []json.RawMessage  `json:"entries,omitempty"`
-	ToolCallID    *string            `json:"toolCallId,omitempty"`
-	Title         *string            `json:"title,omitempty"`
-	Kind          *string            `json:"kind,omitempty"`
-	Status        *string            `json:"status,omitempty"`
-	RawInput      json.RawMessage    `json:"rawInput,omitempty"`
-	RawOutput     json.RawMessage    `json:"rawOutput,omitempty"`
-	Meta          *HarnExtensionMeta `json:"_meta,omitempty"`
+	SessionUpdate    string             `json:"sessionUpdate"`
+	Content          *ACPContentBlock   `json:"content,omitempty"`
+	Entries          []json.RawMessage  `json:"entries,omitempty"`
+	KeptTurnCount    *int               `json:"keptTurnCount,omitempty"`
+	RemovedTurnCount *int               `json:"removedTurnCount,omitempty"`
+	NewTipTurnID     *string            `json:"newTipTurnId,omitempty"`
+	Reason           *string            `json:"reason,omitempty"`
+	ToolCallID       *string            `json:"toolCallId,omitempty"`
+	Title            *string            `json:"title,omitempty"`
+	Kind             *string            `json:"kind,omitempty"`
+	Status           *string            `json:"status,omitempty"`
+	RawInput         json.RawMessage    `json:"rawInput,omitempty"`
+	RawOutput        json.RawMessage    `json:"rawOutput,omitempty"`
+	Meta             *HarnExtensionMeta `json:"_meta,omitempty"`
 }
 
 // ACPSessionUpdateParams is the params payload of `session/update`.

--- a/crates/harn-cli/tests/acp_server_cli.rs
+++ b/crates/harn-cli/tests/acp_server_cli.rs
@@ -335,6 +335,130 @@ fn acp_session_fork_branches_runtime_state_and_dispatches_independently() {
 
 #[ignore = "binary surface — moves to slow E2E/smoke job (issue #1069)"]
 #[test]
+fn acp_session_truncate_mutates_runtime_state_in_place() {
+    let _guard = lock_acp_cli_tests();
+    let temp = TempDir::new().unwrap();
+    write_fixture(&temp);
+
+    let mut child = harn_e2e_command()
+        .current_dir(temp.path())
+        .arg("serve")
+        .arg("acp")
+        .arg("acp_fixture.harn")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+
+    let mut stdin = child.stdin.take().unwrap();
+    let mut stdout = BufReader::new(child.stdout.take().unwrap());
+
+    let (_, created) = send_request(
+        &mut stdin,
+        &mut stdout,
+        json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "session/new",
+            "params": {
+                "cwd": temp.path(),
+            }
+        }),
+    );
+    let session_id = created["result"]["sessionId"].as_str().unwrap().to_string();
+
+    let (alpha_notifications, alpha_response) = send_request(
+        &mut stdin,
+        &mut stdout,
+        json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "session/prompt",
+            "params": {
+                "sessionId": session_id,
+                "prompt": [{ "type": "text", "text": "alpha" }]
+            }
+        }),
+    );
+    assert_eq!(alpha_response["result"]["stopReason"], "end_turn");
+    assert_eq!(
+        latest_prompt_summary(&alpha_notifications, &session_id)["len"],
+        1
+    );
+
+    let (beta_notifications, beta_response) = send_request(
+        &mut stdin,
+        &mut stdout,
+        json!({
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "session/prompt",
+            "params": {
+                "sessionId": session_id,
+                "prompt": [{ "type": "text", "text": "beta" }]
+            }
+        }),
+    );
+    assert_eq!(beta_response["result"]["stopReason"], "end_turn");
+    assert_eq!(
+        latest_prompt_summary(&beta_notifications, &session_id)["len"],
+        2
+    );
+
+    let (truncate_notifications, truncate_response) = send_request(
+        &mut stdin,
+        &mut stdout,
+        json!({
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "session/truncate",
+            "params": {
+                "sessionId": session_id,
+                "keepFirst": 1,
+                "reason": "user_edit"
+            }
+        }),
+    );
+    assert_eq!(truncate_response["result"]["sessionId"], session_id);
+    assert_eq!(truncate_response["result"]["keptTurnCount"], 1);
+    assert_eq!(truncate_response["result"]["removedTurnCount"], 1);
+    assert!(truncate_response["result"]["newTipTurnId"].is_string());
+    let truncate_update = truncate_notifications
+        .iter()
+        .find(|message| {
+            message["method"] == "session/update"
+                && message["params"]["sessionId"] == session_id
+                && message["params"]["update"]["sessionUpdate"] == "session_truncated"
+        })
+        .unwrap_or_else(|| panic!("missing session_truncated update"));
+    assert_eq!(truncate_update["params"]["update"]["reason"], "user_edit");
+
+    let (snapshot_notifications, snapshot_response) = send_request(
+        &mut stdin,
+        &mut stdout,
+        json!({
+            "jsonrpc": "2.0",
+            "id": 5,
+            "method": "session/prompt",
+            "params": {
+                "sessionId": session_id,
+                "prompt": [{ "type": "text", "text": "snapshot" }]
+            }
+        }),
+    );
+    assert_eq!(snapshot_response["result"]["stopReason"], "end_turn");
+    let snapshot = latest_prompt_summary(&snapshot_notifications, &session_id);
+    assert_eq!(snapshot["len"], 1);
+    assert_eq!(snapshot["messages"][0]["content"], "alpha");
+
+    drop(stdin);
+    let status = child.wait().unwrap();
+    assert!(status.success(), "status={status}");
+}
+
+#[ignore = "binary surface — moves to slow E2E/smoke job (issue #1069)"]
+#[test]
 fn serve_acp_stdio_runs_packaged_adapter() {
     let _guard = lock_acp_cli_tests();
     let temp = TempDir::new().unwrap();

--- a/crates/harn-serve/openapi.yaml
+++ b/crates/harn-serve/openapi.yaml
@@ -534,6 +534,31 @@ paths:
         default:
           $ref: "#/components/responses/Error"
 
+  /v1/sessions/{session_id}/truncate:
+    post:
+      tags: [Sessions]
+      operationId: truncateSession
+      summary: Truncate a Session transcript in place.
+      parameters:
+        - $ref: "#/components/parameters/ProtocolVersion"
+        - $ref: "#/components/parameters/SessionId"
+        - $ref: "#/components/parameters/IdempotencyKey"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TruncateSessionRequest"
+      responses:
+        "200":
+          description: Truncated Session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TruncateSessionResponse"
+        default:
+          $ref: "#/components/responses/Error"
+
   /v1/sessions/{session_id}/messages:
     get:
       tags: [Messages]
@@ -2172,6 +2197,42 @@ components:
           type: [string, "null"]
         metadata:
           $ref: "#/components/schemas/Metadata"
+    TruncateSessionRequest:
+      type: object
+      required: [keep_first]
+      properties:
+        keep_first:
+          type: integer
+          minimum: 0
+          description: Number of leading turns to keep in the current Session transcript.
+        reason:
+          type: string
+          description: Optional client-visible reason for the truncation notification.
+    TruncateSessionResponse:
+      type: object
+      required:
+        - object
+        - session_id
+        - kept_turn_count
+        - removed_turn_count
+        - new_tip_turn_id
+        - session
+      properties:
+        object:
+          type: string
+          enum: [session.truncate_result]
+        session_id:
+          type: string
+        kept_turn_count:
+          type: integer
+          minimum: 0
+        removed_turn_count:
+          type: integer
+          minimum: 0
+        new_tip_turn_id:
+          type: [string, "null"]
+        session:
+          $ref: "#/components/schemas/Session"
 
     Task:
       allOf:

--- a/crates/harn-serve/src/adapters/acp/mod.rs
+++ b/crates/harn-serve/src/adapters/acp/mod.rs
@@ -35,7 +35,7 @@ pub use schema::{
     HARN_TOOL_LIFECYCLE_EXTENSION_FIELDS,
 };
 use sessions::{
-    mark_cancelled_session, preempt_session_cancel, prepare_session_prompt, Session,
+    mark_cancelled_session, preempt_session_cancel_or_truncate, prepare_session_prompt, Session,
     SessionCancellation, SessionInfo,
 };
 pub use transport::{run_acp_channel_server, run_acp_server};
@@ -66,6 +66,31 @@ use events::AcpAgentEventSink;
 use io::send_json_response;
 
 const ACP_AUTH_REQUIRED_CODE: i64 = -32000;
+
+fn session_id_param(params: &serde_json::Value) -> Option<String> {
+    params
+        .get("sessionId")
+        .or_else(|| params.get("session_id"))
+        .and_then(|value| value.as_str())
+        .map(str::to_string)
+}
+
+fn nonnegative_usize_param(
+    params: &serde_json::Value,
+    names: &[&str],
+    label: &str,
+) -> Result<Option<usize>, String> {
+    for name in names {
+        let Some(value) = params.get(*name) else {
+            continue;
+        };
+        return match value.as_i64() {
+            Some(value) if value >= 0 => Ok(Some(value as usize)),
+            _ => Err(format!("Invalid {label}: must be >= 0")),
+        };
+    }
+    Ok(None)
+}
 
 fn append_profile_json_line(
     path: &std::path::Path,
@@ -730,11 +755,7 @@ impl AcpServer {
     }
 
     fn handle_session_fork(&mut self, id: &serde_json::Value, params: &serde_json::Value) {
-        let src_id = params
-            .get("session_id")
-            .or_else(|| params.get("sessionId"))
-            .and_then(|value| value.as_str())
-            .map(str::to_string);
+        let src_id = session_id_param(params);
         let Some(src_id) = src_id else {
             self.send_error(id, -32602, "Missing session_id");
             return;
@@ -752,14 +773,14 @@ impl AcpServer {
             harn_vm::agent_sessions::open_or_create(Some(src_id.clone()));
         }
 
-        let keep_first = match params.get("keep_first").and_then(|value| value.as_i64()) {
-            Some(value) if value < 0 => {
-                self.send_error(id, -32602, "Invalid keep_first: must be >= 0");
-                return;
-            }
-            Some(value) => Some(value as usize),
-            None => None,
-        };
+        let keep_first =
+            match nonnegative_usize_param(params, &["keep_first", "keepFirst"], "keep_first") {
+                Ok(value) => value,
+                Err(message) => {
+                    self.send_error(id, -32602, &message);
+                    return;
+                }
+            };
         let dst_id = params
             .get("id")
             .and_then(|value| value.as_str())
@@ -837,6 +858,72 @@ impl AcpServer {
                 "branched_at": branched_at,
                 "modes": modes::session_mode_state(&parent_mode_id),
                 "configOptions": modes::config_options_state(&parent_mode_id),
+            }),
+        );
+    }
+
+    fn handle_session_truncate(&mut self, id: &serde_json::Value, params: &serde_json::Value) {
+        let Some(session_id) = session_id_param(params) else {
+            self.send_error(id, -32602, "Missing sessionId");
+            return;
+        };
+        let keep_first =
+            match nonnegative_usize_param(params, &["keepFirst", "keep_first"], "keepFirst") {
+                Ok(Some(value)) => value,
+                Ok(None) => {
+                    self.send_error(id, -32602, "Missing keepFirst");
+                    return;
+                }
+                Err(message) => {
+                    self.send_error(id, -32602, &message);
+                    return;
+                }
+            };
+        let Some(cancellation) = self
+            .sessions
+            .get(&session_id)
+            .map(|session| session.cancellation.clone())
+        else {
+            self.send_error(id, -32602, &format!("Unknown session: {session_id}"));
+            return;
+        };
+
+        cancellation.cancel();
+        if !harn_vm::agent_sessions::exists(&session_id) {
+            harn_vm::agent_sessions::open_or_create(Some(session_id.clone()));
+        }
+        let Some(result) = harn_vm::agent_sessions::truncate(&session_id, keep_first) else {
+            self.send_error(
+                id,
+                -32000,
+                &format!("Failed to truncate session: {session_id}"),
+            );
+            return;
+        };
+
+        let mut update = serde_json::json!({
+            "sessionUpdate": "session_truncated",
+            "keptTurnCount": result.kept_turn_count,
+            "removedTurnCount": result.removed_turn_count,
+            "newTipTurnId": result.new_tip_turn_id.clone(),
+        });
+        if let Some(reason) = params.get("reason").and_then(|value| value.as_str()) {
+            update["reason"] = serde_json::json!(reason);
+        }
+        self.send_notification(
+            "session/update",
+            serde_json::json!({
+                "sessionId": session_id,
+                "update": update,
+            }),
+        );
+        self.send_response(
+            id,
+            serde_json::json!({
+                "sessionId": session_id,
+                "keptTurnCount": result.kept_turn_count,
+                "removedTurnCount": result.removed_turn_count,
+                "newTipTurnId": result.new_tip_turn_id,
             }),
         );
     }
@@ -1544,6 +1631,12 @@ impl AcpServer {
                     return;
                 }
                 self.handle_session_fork(&id, &params);
+            }
+            "session/truncate" => {
+                if self.reject_unauthenticated(&id) {
+                    return;
+                }
+                self.handle_session_truncate(&id, &params);
             }
             "session/set_mode" => {
                 if self.reject_unauthenticated(&id) {

--- a/crates/harn-serve/src/adapters/acp/schema.rs
+++ b/crates/harn-serve/src/adapters/acp/schema.rs
@@ -13,6 +13,7 @@ pub const ACP_SESSION_UPDATE_VARIANTS: &[&str] = &[
     "current_mode_update",
     "config_option_update",
     "session_info_update",
+    "session_truncated",
 ];
 
 pub const HARN_SESSION_UPDATE_EXTENSIONS: &[&str] = &[

--- a/crates/harn-serve/src/adapters/acp/sessions.rs
+++ b/crates/harn-serve/src/adapters/acp/sessions.rs
@@ -71,7 +71,11 @@ pub(super) fn mark_cancelled_session(
     cancellations: &Arc<std::sync::Mutex<HashMap<String, SessionCancellation>>>,
     params: &serde_json::Value,
 ) -> bool {
-    let Some(session_id) = params.get("sessionId").and_then(|value| value.as_str()) else {
+    let Some(session_id) = params
+        .get("sessionId")
+        .or_else(|| params.get("session_id"))
+        .and_then(|value| value.as_str())
+    else {
         return false;
     };
     let Some(cancellation) = lookup_session_cancellation(cancellations, session_id) else {
@@ -92,16 +96,23 @@ pub(super) fn lookup_session_cancellation(
         .cloned()
 }
 
-pub(super) fn preempt_session_cancel(
+pub(super) fn preempt_session_cancel_or_truncate(
     cancellations: &Arc<std::sync::Mutex<HashMap<String, SessionCancellation>>>,
     msg: &serde_json::Value,
 ) -> bool {
-    if msg.get("method").and_then(|value| value.as_str()) != Some("session/cancel") {
-        return false;
-    }
+    let method = msg.get("method").and_then(|value| value.as_str());
     let params = msg.get("params").unwrap_or(&serde_json::Value::Null);
-    mark_cancelled_session(cancellations, params);
-    msg.get("id").is_none()
+    match method {
+        Some("session/cancel") => {
+            mark_cancelled_session(cancellations, params);
+            msg.get("id").is_none()
+        }
+        Some("session/truncate") => {
+            mark_cancelled_session(cancellations, params);
+            false
+        }
+        _ => false,
+    }
 }
 
 pub(super) fn prepare_session_prompt(

--- a/crates/harn-serve/src/adapters/acp/tests/sessions.rs
+++ b/crates/harn-serve/src/adapters/acp/tests/sessions.rs
@@ -65,6 +65,55 @@ async fn run_prompt_with_project_capability(
     output
 }
 
+async fn run_json_prompt(
+    request_tx: &mpsc::UnboundedSender<serde_json::Value>,
+    response_rx: &mut mpsc::UnboundedReceiver<String>,
+    session_id: &str,
+    id: i64,
+    prompt_text: &str,
+) -> serde_json::Value {
+    request_tx
+        .send(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": "session/prompt",
+            "params": {
+                "sessionId": session_id,
+                "prompt": [{"type": "text", "text": prompt_text}],
+            },
+        }))
+        .expect("send session/prompt");
+
+    let mut output = String::new();
+    for _ in 0..64 {
+        let message = recv_json(response_rx).await;
+        match message.get("method").and_then(|value| value.as_str()) {
+            Some("host/capabilities") => {
+                request_tx
+                    .send(serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": message["id"].clone(),
+                        "result": {},
+                    }))
+                    .expect("send host/capabilities response");
+            }
+            Some("session/update")
+                if message["params"]["update"]["sessionUpdate"] == "agent_message_chunk" =>
+            {
+                if let Some(text) = message["params"]["update"]["content"]["text"].as_str() {
+                    output.push_str(text);
+                }
+            }
+            _ if message["id"] == id => {
+                assert_eq!(message["result"]["stopReason"], "end_turn");
+                return serde_json::from_str(output.trim()).expect("prompt JSON output");
+            }
+            _ => {}
+        }
+    }
+    panic!("prompt {id} did not complete")
+}
+
 #[tokio::test(flavor = "current_thread")]
 async fn acp_server_handles_session_flow_and_prompt_updates() {
     let local = tokio::task::LocalSet::new();
@@ -225,6 +274,153 @@ async fn acp_server_handles_session_flow_and_prompt_updates() {
             }
             assert!(saw_update, "prompt should emit session/update text");
             assert!(saw_completed, "prompt should finish successfully");
+
+            drop(request_tx);
+            server.await.expect("ACP channel server task");
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn acp_session_truncate_mutates_current_session_and_notifies_client() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            harn_vm::reset_thread_local_state();
+            let (request_tx, mut response_rx, server, session_id) =
+                start_acp_channel_session().await;
+
+            let first = run_json_prompt(
+                &request_tx,
+                &mut response_rx,
+                &session_id,
+                2,
+                r#"
+let sid = agent_session_current_id()
+guard sid != nil else { throw "missing session id" }
+agent_session_inject(sid, {role: "user", content: "alpha"})
+let snap = agent_session_snapshot(sid)
+println(json_stringify({len: len(snap["messages"]), messages: snap["messages"]}))
+"#,
+            )
+            .await;
+            assert_eq!(first["len"], 1);
+            let second = run_json_prompt(
+                &request_tx,
+                &mut response_rx,
+                &session_id,
+                3,
+                r#"
+let sid = agent_session_current_id()
+guard sid != nil else { throw "missing session id" }
+agent_session_inject(sid, {role: "user", content: "beta"})
+let snap = agent_session_snapshot(sid)
+println(json_stringify({len: len(snap["messages"]), messages: snap["messages"]}))
+"#,
+            )
+            .await;
+            assert_eq!(second["len"], 2);
+
+            request_tx
+                .send(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 4,
+                    "method": "session/truncate",
+                    "params": {
+                        "sessionId": session_id.clone(),
+                        "keepFirst": 1,
+                        "reason": "user_edit",
+                    },
+                }))
+                .expect("send session/truncate");
+
+            let mut response = None;
+            let mut notification = None;
+            for _ in 0..4 {
+                let message = recv_json(&mut response_rx).await;
+                if message["id"] == 4 {
+                    response = Some(message);
+                } else if message["method"] == "session/update"
+                    && message["params"]["update"]["sessionUpdate"] == "session_truncated"
+                {
+                    notification = Some(message);
+                }
+                if response.is_some() && notification.is_some() {
+                    break;
+                }
+            }
+            let response = response.expect("truncate response");
+            assert_eq!(response["result"]["sessionId"], session_id);
+            assert_eq!(response["result"]["keptTurnCount"], 1);
+            assert_eq!(response["result"]["removedTurnCount"], 1);
+            assert!(response["result"]["newTipTurnId"].is_string());
+
+            let notification = notification.expect("session_truncated notification");
+            assert_eq!(notification["params"]["sessionId"], session_id);
+            assert_eq!(notification["params"]["update"]["keptTurnCount"], 1);
+            assert_eq!(notification["params"]["update"]["removedTurnCount"], 1);
+            assert_eq!(notification["params"]["update"]["reason"], "user_edit");
+
+            let snapshot = run_json_prompt(
+                &request_tx,
+                &mut response_rx,
+                &session_id,
+                5,
+                r#"
+let sid = agent_session_current_id()
+guard sid != nil else { throw "missing session id" }
+let snap = agent_session_snapshot(sid)
+println(json_stringify({len: len(snap["messages"]), messages: snap["messages"]}))
+"#,
+            )
+            .await;
+            assert_eq!(snapshot["len"], 1);
+            assert_eq!(snapshot["messages"][0]["content"], "alpha");
+
+            drop(request_tx);
+            server.await.expect("ACP channel server task");
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn acp_session_truncate_validates_inputs() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let (request_tx, mut response_rx, server, session_id) =
+                start_acp_channel_session().await;
+
+            for (id, params, expected) in [
+                (
+                    2,
+                    serde_json::json!({"sessionId": session_id.clone()}),
+                    "Missing keepFirst",
+                ),
+                (
+                    3,
+                    serde_json::json!({"sessionId": session_id.clone(), "keepFirst": -1}),
+                    "Invalid keepFirst: must be >= 0",
+                ),
+                (
+                    4,
+                    serde_json::json!({"sessionId": "missing-session", "keepFirst": 0}),
+                    "Unknown session: missing-session",
+                ),
+            ] {
+                request_tx
+                    .send(serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": id,
+                        "method": "session/truncate",
+                        "params": params,
+                    }))
+                    .expect("send session/truncate");
+                let response = recv_json(&mut response_rx).await;
+                assert_eq!(response["id"], id);
+                assert_eq!(response["error"]["code"], -32602);
+                assert_eq!(response["error"]["message"], expected);
+            }
 
             drop(request_tx);
             server.await.expect("ACP channel server task");

--- a/crates/harn-serve/src/adapters/acp/transport.rs
+++ b/crates/harn-serve/src/adapters/acp/transport.rs
@@ -29,7 +29,7 @@ pub async fn run_acp_channel_server(
                     }
 
                     prepare_session_prompt(&cancellations, &msg);
-                    if preempt_session_cancel(&cancellations, &msg) {
+                    if preempt_session_cancel_or_truncate(&cancellations, &msg) {
                         continue;
                     }
 
@@ -95,7 +95,7 @@ pub async fn run_acp_server(config: AcpServerConfig) {
                     }
 
                     prepare_session_prompt(&cancellations, &msg);
-                    if preempt_session_cancel(&cancellations, &msg) {
+                    if preempt_session_cancel_or_truncate(&cancellations, &msg) {
                         continue;
                     }
 

--- a/crates/harn-serve/src/adapters/api.rs
+++ b/crates/harn-serve/src/adapters/api.rs
@@ -597,6 +597,7 @@ fn api_router(state: ApiState) -> Router {
         )
         .route("/v1/sessions/{session_id}/close", post(close_session))
         .route("/v1/sessions/{session_id}/fork", post(fork_session))
+        .route("/v1/sessions/{session_id}/truncate", post(truncate_session))
         .route(
             "/v1/sessions/{session_id}/messages",
             get(list_session_messages).post(append_session_message),
@@ -1196,6 +1197,114 @@ async fn fork_session(
     }
     state.append_event(Some(new_id), None, "session.forked", session.clone());
     (StatusCode::CREATED, Json(session)).into_response()
+}
+
+async fn truncate_session(
+    State(state): State<ApiState>,
+    AxumPath(session_id): AxumPath<String>,
+    OriginalUri(uri): OriginalUri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    if let Err(response) = authorize(&state, Method::POST, &uri, &headers, body.clone()).await {
+        return response;
+    }
+    let Ok(input) = parse_json_body(&body) else {
+        return api_error(
+            StatusCode::BAD_REQUEST,
+            "invalid_json",
+            "request body must be JSON",
+        );
+    };
+    let keep_first = match input
+        .get("keep_first")
+        .or_else(|| input.get("keepFirst"))
+        .and_then(Value::as_i64)
+    {
+        Some(value) if value >= 0 => value as usize,
+        _ => {
+            return api_error(
+                StatusCode::BAD_REQUEST,
+                "invalid_request",
+                "keep_first must be a non-negative integer",
+            )
+        }
+    };
+    {
+        let inner = state.inner.lock().expect("api state poisoned");
+        if !inner.sessions.contains_key(&session_id) {
+            return api_error(StatusCode::NOT_FOUND, "not_found", "session not found");
+        }
+    }
+
+    let mut acp_params = json!({
+        "sessionId": session_id.clone(),
+        "keepFirst": keep_first,
+    });
+    if let Some(reason) = input.get("reason").and_then(Value::as_str) {
+        acp_params["reason"] = json!(reason);
+    }
+    let result = match state.acp.call("session/truncate", acp_params).await {
+        Ok(result) => result,
+        Err(error) => return api_error(StatusCode::BAD_GATEWAY, "acp_error", &error),
+    };
+    let kept_turn_count = result
+        .get("keptTurnCount")
+        .and_then(Value::as_u64)
+        .unwrap_or(0) as usize;
+    let removed_turn_count = result
+        .get("removedTurnCount")
+        .and_then(Value::as_u64)
+        .unwrap_or(0) as usize;
+    let new_tip_turn_id = result.get("newTipTurnId").cloned().unwrap_or(Value::Null);
+
+    let (session, canceled_task) = {
+        let mut inner = state.inner.lock().expect("api state poisoned");
+        if let Some(messages) = inner.messages.get_mut(&session_id) {
+            messages.truncate(keep_first);
+        }
+        let canceled_task_id = inner.active_task_by_session.remove(&session_id);
+        let canceled_task = canceled_task_id.and_then(|task_id| {
+            let task = inner.tasks.get_mut(&task_id)?;
+            if task.get("status").and_then(Value::as_str) != Some("CANCELED") {
+                task["status"] = json!("CANCELED");
+                task["updated_at"] = json!(now_rfc3339());
+                task["canceled_at"] = json!(now_rfc3339());
+            }
+            Some((task_id, task.clone()))
+        });
+        let Some(session) = inner.sessions.get_mut(&session_id) else {
+            return api_error(StatusCode::NOT_FOUND, "not_found", "session not found");
+        };
+        if session.get("state").and_then(Value::as_str) != Some("CLOSED") {
+            session["state"] = json!("IDLE");
+        }
+        session["updated_at"] = json!(now_rfc3339());
+        (session.clone(), canceled_task)
+    };
+    if let Some((task_id, task)) = canceled_task {
+        state.append_event(
+            Some(session_id.clone()),
+            Some(task_id),
+            "task.canceled",
+            task,
+        );
+    }
+    let response = json!({
+        "object": "session.truncate_result",
+        "session_id": session_id,
+        "kept_turn_count": kept_turn_count,
+        "removed_turn_count": removed_turn_count,
+        "new_tip_turn_id": new_tip_turn_id,
+        "session": session,
+    });
+    state.append_event(
+        Some(session_id),
+        None,
+        "session.truncated",
+        response.clone(),
+    );
+    Json(response).into_response()
 }
 
 async fn list_session_messages(
@@ -2068,7 +2177,7 @@ fn prompt_text(input: &Value) -> Option<String> {
 
 fn capability_values() -> Vec<Value> {
     vec![
-        json!({"id": "sessions", "description": "Create, inspect, fork, update, and close ACP-backed Harn sessions."}),
+        json!({"id": "sessions", "description": "Create, inspect, fork, truncate, update, and close ACP-backed Harn sessions."}),
         json!({"id": "tasks", "description": "Submit prompts asynchronously, track task status, and abort active tasks."}),
         json!({"id": "events", "description": "Read snapshots and stream live session, task, tool, permission, and runtime events over SSE."}),
         json!({"id": "permissions", "description": "Approve or deny host permission and HITL requests through the same ACP runtime path."}),
@@ -2093,6 +2202,14 @@ fn tool_values() -> Vec<Value> {
             "name": "session.cancel",
             "description": "Cancel the active prompt for a Harn session.",
             "input_schema": {"type": "object", "required": ["session_id"]},
+            "output_schema": {"type": "object"}
+        }),
+        json!({
+            "id": "harn.session.truncate",
+            "object": "tool",
+            "name": "session.truncate",
+            "description": "Drop a Harn session transcript after the first N turns.",
+            "input_schema": {"type": "object", "required": ["session_id", "keep_first"]},
             "output_schema": {"type": "object"}
         }),
         json!({
@@ -2205,6 +2322,91 @@ mod tests {
         assert_eq!(task["object"], "task");
         assert_eq!(task["status"], "WORKING");
         assert_eq!(task["session_id"], session_id);
+    }
+
+    #[tokio::test]
+    async fn local_api_truncates_session_messages() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let script = dir.path().join("agent.harn");
+        std::fs::write(&script, "pipeline main() { println(prompt) }\n").expect("write script");
+        let server = ApiServer::new(ApiServerConfig::for_pipeline(
+            script.to_string_lossy().to_string(),
+        ));
+        let app = api_router(server.state);
+
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/sessions")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"workspace_id":"local"}"#))
+                    .expect("request"),
+            )
+            .await
+            .expect("session response");
+        assert_eq!(response.status(), StatusCode::CREATED);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body");
+        let session: Value = serde_json::from_slice(&body).expect("session");
+        let session_id = session["id"].as_str().expect("session id");
+
+        for text in ["alpha", "beta"] {
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .method("POST")
+                        .uri(format!("/v1/sessions/{session_id}/messages"))
+                        .header("content-type", "application/json")
+                        .body(Body::from(format!(
+                            r#"{{"role":"user","parts":[{{"type":"text","text":"{text}","visibility":"public"}}]}}"#
+                        )))
+                        .expect("request"),
+                )
+                .await
+                .expect("message response");
+            assert_eq!(response.status(), StatusCode::CREATED);
+        }
+
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/v1/sessions/{session_id}/truncate"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"keep_first":1,"reason":"user_edit"}"#))
+                    .expect("request"),
+            )
+            .await
+            .expect("truncate response");
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body");
+        let result: Value = serde_json::from_slice(&body).expect("truncate json");
+        assert_eq!(result["object"], "session.truncate_result");
+        assert_eq!(result["session_id"], session_id);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/v1/sessions/{session_id}/messages"))
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("messages response");
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body");
+        let messages: Value = serde_json::from_slice(&body).expect("messages json");
+        assert_eq!(messages["data"].as_array().expect("messages").len(), 1);
+        assert_eq!(messages["data"][0]["parts"][0]["text"], "alpha");
     }
 
     #[tokio::test]

--- a/crates/harn-vm/src/agent_sessions.rs
+++ b/crates/harn-vm/src/agent_sessions.rs
@@ -81,6 +81,13 @@ pub struct SessionAncestry {
     pub root_id: String,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SessionTruncateResult {
+    pub kept_turn_count: usize,
+    pub removed_turn_count: usize,
+    pub new_tip_turn_id: Option<String>,
+}
+
 thread_local! {
     static SESSIONS: RefCell<HashMap<String, SessionState>> = RefCell::new(HashMap::new());
     static SESSION_CAP: Cell<usize> = const { Cell::new(DEFAULT_SESSION_CAP) };
@@ -420,39 +427,70 @@ pub fn fork_at(src_id: &str, keep_first: usize, dst_id: Option<String>) -> Optio
     })?;
     let new_id = fork(src_id, dst_id)?;
     link_child_session_with_branch(src_id, &new_id, Some(branched_at_event_index));
-    retain_first(&new_id, keep_first);
+    let _ = truncate(&new_id, keep_first);
     Some(new_id)
 }
 
 /// Truncate the session transcript to the first `keep_first`
-/// messages (opposite of `trim`, which keeps the last N). Used by
-/// `fork_at` to cut a branch at a scrubber position.
-fn retain_first(id: &str, keep_first: usize) {
+/// messages (opposite of `trim`, which keeps the last N). Returns
+/// counts and the retained tip event id when the session exists.
+pub fn truncate(id: &str, keep_first: usize) -> Option<SessionTruncateResult> {
     SESSIONS.with(|s| {
         let mut map = s.borrow_mut();
-        let Some(state) = map.get_mut(id) else {
-            return;
+        let state = map.get_mut(id)?;
+        Some(truncate_state(state, keep_first))
+    })
+}
+
+fn truncate_state(state: &mut SessionState, keep_first: usize) -> SessionTruncateResult {
+    let dict = state
+        .transcript
+        .as_dict()
+        .cloned()
+        .unwrap_or_else(BTreeMap::new);
+    let messages: Vec<VmValue> = match dict.get("messages") {
+        Some(VmValue::List(list)) => list.iter().cloned().collect(),
+        _ => Vec::new(),
+    };
+    let existing_events = match dict.get("events") {
+        Some(VmValue::List(list)) => Some(list.iter().cloned().collect::<Vec<_>>()),
+        _ => None,
+    };
+    let kept_turn_count = keep_first.min(messages.len());
+    let removed_turn_count = messages.len().saturating_sub(kept_turn_count);
+    let mut new_tip_turn_id = existing_events
+        .as_ref()
+        .map(|events| turn_event_id_for_count(events, kept_turn_count))
+        .unwrap_or_else(|| {
+            let events = crate::llm::helpers::transcript_events_from_messages(&messages);
+            turn_event_id_for_count(&events, kept_turn_count)
+        });
+
+    if removed_turn_count > 0 {
+        let retained: Vec<VmValue> = messages.into_iter().take(kept_turn_count).collect();
+        let retained_events = match existing_events {
+            Some(events) => {
+                let keep_event_count = event_prefix_len_for_messages(&events, kept_turn_count);
+                events.into_iter().take(keep_event_count).collect()
+            }
+            None => crate::llm::helpers::transcript_events_from_messages(&retained),
         };
-        let Some(dict) = state.transcript.as_dict() else {
-            return;
-        };
-        let dict = dict.clone();
-        let messages: Vec<VmValue> = match dict.get("messages") {
-            Some(VmValue::List(list)) => list.iter().cloned().collect(),
-            _ => Vec::new(),
-        };
-        let retained: Vec<VmValue> = messages.into_iter().take(keep_first).collect();
+        new_tip_turn_id = turn_event_id_for_count(&retained_events, kept_turn_count);
         let mut next = dict;
         next.insert(
             "events".to_string(),
-            VmValue::List(Rc::new(
-                crate::llm::helpers::transcript_events_from_messages(&retained),
-            )),
+            VmValue::List(Rc::new(retained_events)),
         );
         next.insert("messages".to_string(), VmValue::List(Rc::new(retained)));
+        next.remove("summary");
         state.transcript = VmValue::Dict(Rc::new(next));
-        state.last_accessed = Instant::now();
-    });
+    }
+    state.last_accessed = Instant::now();
+    SessionTruncateResult {
+        kept_turn_count,
+        removed_turn_count,
+        new_tip_turn_id,
+    }
 }
 
 /// Retain only the last `keep_last` messages in the session transcript.
@@ -1119,13 +1157,37 @@ fn branch_event_index(transcript: &VmValue, keep_first: usize) -> usize {
     let Some(VmValue::List(events)) = dict.get("events") else {
         return keep_first;
     };
+    event_prefix_len_for_messages(events, keep_first)
+}
+
+fn event_kind(event: &VmValue) -> Option<String> {
+    event
+        .as_dict()
+        .and_then(|dict| dict.get("kind"))
+        .map(VmValue::display)
+}
+
+fn event_id(event: &VmValue) -> Option<String> {
+    event
+        .as_dict()
+        .and_then(|dict| dict.get("id"))
+        .map(VmValue::display)
+}
+
+fn is_turn_event(event: &VmValue) -> bool {
+    matches!(
+        event_kind(event).as_deref(),
+        Some("message" | "tool_result")
+    )
+}
+
+fn event_prefix_len_for_messages(events: &[VmValue], keep_first: usize) -> usize {
+    if keep_first == 0 {
+        return 0;
+    }
     let mut retained_messages = 0usize;
     for (index, event) in events.iter().enumerate() {
-        let kind = event
-            .as_dict()
-            .and_then(|dict| dict.get("kind"))
-            .map(VmValue::display);
-        if matches!(kind.as_deref(), Some("message" | "tool_result")) {
+        if is_turn_event(event) {
             retained_messages += 1;
             if retained_messages == keep_first {
                 return index + 1;
@@ -1133,6 +1195,22 @@ fn branch_event_index(transcript: &VmValue, keep_first: usize) -> usize {
         }
     }
     events.len()
+}
+
+fn turn_event_id_for_count(events: &[VmValue], keep_first: usize) -> Option<String> {
+    if keep_first == 0 {
+        return None;
+    }
+    let mut retained_messages = 0usize;
+    for event in events {
+        if is_turn_event(event) {
+            retained_messages += 1;
+            if retained_messages == keep_first {
+                return event_id(event);
+            }
+        }
+    }
+    None
 }
 
 #[cfg(test)]
@@ -1306,6 +1384,76 @@ mod tests {
         // Subscribers not carried — forks start with a clean fanout list.
         assert_eq!(subscriber_count(&dst), 0);
         reset_session_store();
+    }
+
+    #[test]
+    fn truncate_retains_prefix_and_reports_removed_turns() {
+        reset_session_store();
+        let id = open_or_create(Some("truncate-prefix".into()));
+        inject_message(&id, make_msg("user", "a")).unwrap();
+        inject_message(&id, make_msg("assistant", "b")).unwrap();
+        inject_message(&id, make_msg("user", "c")).unwrap();
+        append_event(
+            &id,
+            crate::llm::helpers::transcript_event(
+                "tool_call_audit",
+                "tool",
+                "internal",
+                "audit for dropped turn",
+                None,
+            ),
+        )
+        .unwrap();
+
+        let result = truncate(&id, 2).expect("truncate result");
+        assert_eq!(result.kept_turn_count, 2);
+        assert_eq!(result.removed_turn_count, 1);
+        assert!(
+            result.new_tip_turn_id.is_some(),
+            "retained tip event id should be surfaced"
+        );
+        assert_eq!(message_count(&id), 2);
+        assert_eq!(event_count_by_kind(&id, "message"), 2);
+        assert_eq!(event_count_by_kind(&id, "tool_call_audit"), 0);
+
+        let messages = messages_json(&id);
+        assert_eq!(messages[0]["content"], "a");
+        assert_eq!(messages[1]["content"], "b");
+        reset_session_store();
+    }
+
+    #[test]
+    fn truncate_to_zero_clears_messages_events_and_stale_summary() {
+        reset_session_store();
+        let id = open_or_create(Some("truncate-zero".into()));
+        replace_messages_with_summary(
+            &id,
+            &[
+                serde_json::json!({"role": "user", "content": "before"}),
+                serde_json::json!({"role": "assistant", "content": "after"}),
+            ],
+            Some("summary that mentions removed turns"),
+        );
+
+        let result = truncate(&id, 0).expect("truncate result");
+        assert_eq!(result.kept_turn_count, 0);
+        assert_eq!(result.removed_turn_count, 2);
+        assert_eq!(result.new_tip_turn_id, None);
+        assert_eq!(message_count(&id), 0);
+        assert_eq!(event_count_by_kind(&id, "message"), 0);
+        let snapshot = snapshot(&id).expect("session snapshot");
+        let dict = snapshot.as_dict().expect("snapshot dict");
+        assert!(
+            !dict.contains_key("summary"),
+            "truncating away summarized turns must not leave stale prompt summary"
+        );
+        reset_session_store();
+    }
+
+    #[test]
+    fn truncate_unknown_session_returns_none() {
+        reset_session_store();
+        assert!(truncate("does-not-exist", 1).is_none());
     }
 
     #[test]

--- a/spec/AGENTS_PROTOCOL.md
+++ b/spec/AGENTS_PROTOCOL.md
@@ -172,6 +172,11 @@ Servers MUST preserve message ordering inside a Session. Servers MAY compact
 older transcript content, but compaction MUST preserve enough event and
 artifact references for audit and replay.
 
+Servers that support transcript walk-back MUST expose a truncate operation that
+keeps the first N turns of the current Session and drops all later turns in
+place. Truncation mutates the current trunk; clients that need a recoverable
+side branch SHOULD fork the Session before truncating it.
+
 ### Task
 
 A Task is a unit of agent work submitted by a user, connector, automation, or
@@ -466,7 +471,7 @@ paths and schemas. This narrative spec requires the REST surface to cover:
 - discovery and HarnAgentCard retrieval
 - Persona, Workspace, Session, Task, Branch, Message, Artifact, Event,
   Receipt, Memory, Connector, Skill, Outcome, and Quota reads
-- Session creation, close, fork, and message append
+- Session creation, close, fork, truncate, and message append
 - Task submit, get, cancel, and list
 - artifact upload or registration
 - event range reads
@@ -501,6 +506,7 @@ The WebSocket profile MUST support:
 
 - client-to-server user messages
 - client-to-server task cancellation
+- client-to-server session truncation
 - server-to-client Event frames
 - server-to-client input or authorization requests
 - optional host-mediated tool or approval requests
@@ -665,6 +671,7 @@ describe decisions without revealing private reasoning.
 - `session.closed`
 - `session.message_appended`
 - `session.compacted`
+- `session.truncated`
 - `session.thread_forked`
 - `session.thread_merged`
 - `session.replayed`

--- a/spec/openapi.snapshot
+++ b/spec/openapi.snapshot
@@ -26,6 +26,7 @@ GET /v1/sessions/{session_id}
 PATCH /v1/sessions/{session_id}
 POST /v1/sessions/{session_id}/close
 POST /v1/sessions/{session_id}/fork
+POST /v1/sessions/{session_id}/truncate
 GET /v1/sessions/{session_id}/messages
 POST /v1/sessions/{session_id}/messages
 GET /v1/sessions/{session_id}/tasks
@@ -106,6 +107,8 @@ SessionList
 CreateSessionRequest
 UpdateSessionRequest
 ForkSessionRequest
+TruncateSessionRequest
+TruncateSessionResponse
 Task
 TaskStatus
 TaskList

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -534,6 +534,31 @@ paths:
         default:
           $ref: "#/components/responses/Error"
 
+  /v1/sessions/{session_id}/truncate:
+    post:
+      tags: [Sessions]
+      operationId: truncateSession
+      summary: Truncate a Session transcript in place.
+      parameters:
+        - $ref: "#/components/parameters/ProtocolVersion"
+        - $ref: "#/components/parameters/SessionId"
+        - $ref: "#/components/parameters/IdempotencyKey"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TruncateSessionRequest"
+      responses:
+        "200":
+          description: Truncated Session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TruncateSessionResponse"
+        default:
+          $ref: "#/components/responses/Error"
+
   /v1/sessions/{session_id}/messages:
     get:
       tags: [Messages]
@@ -2172,6 +2197,42 @@ components:
           type: [string, "null"]
         metadata:
           $ref: "#/components/schemas/Metadata"
+    TruncateSessionRequest:
+      type: object
+      required: [keep_first]
+      properties:
+        keep_first:
+          type: integer
+          minimum: 0
+          description: Number of leading turns to keep in the current Session transcript.
+        reason:
+          type: string
+          description: Optional client-visible reason for the truncation notification.
+    TruncateSessionResponse:
+      type: object
+      required:
+        - object
+        - session_id
+        - kept_turn_count
+        - removed_turn_count
+        - new_tip_turn_id
+        - session
+      properties:
+        object:
+          type: string
+          enum: [session.truncate_result]
+        session_id:
+          type: string
+        kept_turn_count:
+          type: integer
+          minimum: 0
+        removed_turn_count:
+          type: integer
+          minimum: 0
+        new_tip_turn_id:
+          type: [string, "null"]
+        session:
+          $ref: "#/components/schemas/Session"
 
     Task:
       allOf:

--- a/spec/protocol-artifacts/HarnProtocol.swift
+++ b/spec/protocol-artifacts/HarnProtocol.swift
@@ -75,6 +75,7 @@ public enum HarnACPAgentMethod: String, Codable, Sendable, CaseIterable {
     case initialize = "initialize"
     case sessionNew = "session/new"
     case sessionPrompt = "session/prompt"
+    case sessionTruncate = "session/truncate"
     case sessionStop = "session/stop"
 }
 
@@ -103,6 +104,7 @@ public enum HarnACPSessionUpdate: String, Codable, Sendable, CaseIterable {
     case currentModeUpdate = "current_mode_update"
     case configOptionUpdate = "config_option_update"
     case sessionInfoUpdate = "session_info_update"
+    case sessionTruncated = "session_truncated"
     case fsWatch = "fs_watch"
     case handoff = "handoff"
     case hitlRequest = "hitl_request"
@@ -725,6 +727,10 @@ public struct HarnACPSessionUpdateEnvelope: Codable, Sendable, Equatable {
     public var sessionUpdate: HarnACPSessionUpdate
     public var content: HarnACPContentBlock?
     public var entries: [HarnACPValue]?
+    public var keptTurnCount: Int?
+    public var removedTurnCount: Int?
+    public var newTipTurnId: String?
+    public var reason: String?
     public var toolCallId: String?
     public var title: String?
     public var kind: HarnACPToolKind?
@@ -737,6 +743,10 @@ public struct HarnACPSessionUpdateEnvelope: Codable, Sendable, Equatable {
         case sessionUpdate
         case content
         case entries
+        case keptTurnCount
+        case removedTurnCount
+        case newTipTurnId
+        case reason
         case toolCallId
         case title
         case kind

--- a/spec/protocol-artifacts/go/harnprotocol/harnprotocol.go
+++ b/spec/protocol-artifacts/go/harnprotocol/harnprotocol.go
@@ -32,6 +32,7 @@ var ACPAgentMethods = []ACPAgentMethod{
 	"initialize",
 	"session/new",
 	"session/prompt",
+	"session/truncate",
 	"session/stop",
 }
 
@@ -72,6 +73,7 @@ var ACPSessionUpdates = []ACPSessionUpdate{
 	"current_mode_update",
 	"config_option_update",
 	"session_info_update",
+	"session_truncated",
 	"fs_watch",
 	"handoff",
 	"hitl_request",
@@ -497,16 +499,20 @@ type ACPToolCallUpdate struct {
 // `sessionUpdate` discriminator will be populated; the rest stay zero-value
 // and are stripped via `omitempty` on serialization.
 type ACPSessionUpdateEnvelope struct {
-	SessionUpdate string             `json:"sessionUpdate"`
-	Content       *ACPContentBlock   `json:"content,omitempty"`
-	Entries       []json.RawMessage  `json:"entries,omitempty"`
-	ToolCallID    *string            `json:"toolCallId,omitempty"`
-	Title         *string            `json:"title,omitempty"`
-	Kind          *string            `json:"kind,omitempty"`
-	Status        *string            `json:"status,omitempty"`
-	RawInput      json.RawMessage    `json:"rawInput,omitempty"`
-	RawOutput     json.RawMessage    `json:"rawOutput,omitempty"`
-	Meta          *HarnExtensionMeta `json:"_meta,omitempty"`
+	SessionUpdate    string             `json:"sessionUpdate"`
+	Content          *ACPContentBlock   `json:"content,omitempty"`
+	Entries          []json.RawMessage  `json:"entries,omitempty"`
+	KeptTurnCount    *int               `json:"keptTurnCount,omitempty"`
+	RemovedTurnCount *int               `json:"removedTurnCount,omitempty"`
+	NewTipTurnID     *string            `json:"newTipTurnId,omitempty"`
+	Reason           *string            `json:"reason,omitempty"`
+	ToolCallID       *string            `json:"toolCallId,omitempty"`
+	Title            *string            `json:"title,omitempty"`
+	Kind             *string            `json:"kind,omitempty"`
+	Status           *string            `json:"status,omitempty"`
+	RawInput         json.RawMessage    `json:"rawInput,omitempty"`
+	RawOutput        json.RawMessage    `json:"rawOutput,omitempty"`
+	Meta             *HarnExtensionMeta `json:"_meta,omitempty"`
 }
 
 // ACPSessionUpdateParams is the params payload of `session/update`.

--- a/spec/protocol-artifacts/harn-protocol.ts
+++ b/spec/protocol-artifacts/harn-protocol.ts
@@ -7,6 +7,7 @@ export const ACP_AGENT_METHODS = [
   "initialize",
   "session/new",
   "session/prompt",
+  "session/truncate",
   "session/stop",
 ] as const
 export type ACPAgentMethod = (typeof ACP_AGENT_METHODS)[number]
@@ -38,6 +39,7 @@ export const ACP_SESSION_UPDATES = [
   "current_mode_update",
   "config_option_update",
   "session_info_update",
+  "session_truncated",
   "fs_watch",
   "handoff",
   "hitl_request",
@@ -344,6 +346,14 @@ export interface ACPPlanUpdate {
   harnPlan?: ACPValue
 }
 
+export interface ACPSessionTruncatedUpdate {
+  sessionUpdate: "session_truncated"
+  keptTurnCount: number
+  removedTurnCount: number
+  newTipTurnId?: string | null
+  reason?: string
+}
+
 export interface ACPHarnExtensionUpdate {
   sessionUpdate: HarnACPSessionUpdateExtension
   _meta?: ACPExtensionMeta<ACPObject>
@@ -354,6 +364,7 @@ export type ACPSessionUpdateEnvelope =
   | ACPToolCall
   | ACPToolCallUpdate
   | ACPPlanUpdate
+  | ACPSessionTruncatedUpdate
   | ACPHarnExtensionUpdate
 
 export interface ACPSessionUpdateParams {

--- a/spec/protocol-artifacts/manifest.json
+++ b/spec/protocol-artifacts/manifest.json
@@ -35,6 +35,7 @@
       "initialize",
       "session/new",
       "session/prompt",
+      "session/truncate",
       "session/stop"
     ],
     "agentNotifications": [
@@ -108,6 +109,7 @@
       "current_mode_update",
       "config_option_update",
       "session_info_update",
+      "session_truncated",
       "fs_watch",
       "handoff",
       "hitl_request",

--- a/spec/protocol-artifacts/python/harn_protocol.py
+++ b/spec/protocol-artifacts/python/harn_protocol.py
@@ -98,6 +98,7 @@ ACP_AGENT_METHODS: tuple = (
     "initialize",
     "session/new",
     "session/prompt",
+    "session/truncate",
     "session/stop",
 )
 ACP_CLIENT_METHODS: tuple = (
@@ -123,6 +124,7 @@ ACP_SESSION_UPDATES: tuple = (
     "current_mode_update",
     "config_option_update",
     "session_info_update",
+    "session_truncated",
     "fs_watch",
     "handoff",
     "hitl_request",
@@ -311,6 +313,7 @@ class ACPAgentMethod(str, Enum):
     INITIALIZE = "initialize"
     SESSION_NEW = "session/new"
     SESSION_PROMPT = "session/prompt"
+    SESSION_TRUNCATE = "session/truncate"
     SESSION_STOP = "session/stop"
 
 
@@ -339,6 +342,7 @@ class ACPSessionUpdate(str, Enum):
     CURRENT_MODE_UPDATE = "current_mode_update"
     CONFIG_OPTION_UPDATE = "config_option_update"
     SESSION_INFO_UPDATE = "session_info_update"
+    SESSION_TRUNCATED = "session_truncated"
     FS_WATCH = "fs_watch"
     HANDOFF = "handoff"
     HITL_REQUEST = "hitl_request"
@@ -618,6 +622,10 @@ class ACPSessionUpdateEnvelope(_HarnDataclass):
     sessionUpdate: str
     content: Optional[ACPContentBlock] = None
     entries: Optional[List[JsonValue]] = None
+    keptTurnCount: Optional[int] = None
+    removedTurnCount: Optional[int] = None
+    newTipTurnId: Optional[str] = None
+    reason: Optional[str] = None
     toolCallId: Optional[str] = None
     title: Optional[str] = None
     kind: Optional[str] = None

--- a/spec/protocol-artifacts/schemas/acp-session-update.schema.json
+++ b/spec/protocol-artifacts/schemas/acp-session-update.schema.json
@@ -150,6 +150,7 @@
         { "$ref": "#/$defs/CurrentModeUpdate" },
         { "$ref": "#/$defs/ConfigOptionUpdate" },
         { "$ref": "#/$defs/SessionInfoUpdate" },
+        { "$ref": "#/$defs/SessionTruncated" },
         { "$ref": "#/$defs/SkillActivated" },
         { "$ref": "#/$defs/SkillDeactivated" },
         { "$ref": "#/$defs/SkillScopeTools" },
@@ -336,6 +337,18 @@
       "additionalProperties": true,
       "properties": {
         "sessionUpdate": { "const": "session_info_update" }
+      }
+    },
+    "SessionTruncated": {
+      "type": "object",
+      "required": ["sessionUpdate", "keptTurnCount", "removedTurnCount"],
+      "additionalProperties": true,
+      "properties": {
+        "sessionUpdate": { "const": "session_truncated" },
+        "keptTurnCount": { "type": "integer", "minimum": 0 },
+        "removedTurnCount": { "type": "integer", "minimum": 0 },
+        "newTipTurnId": { "type": ["string", "null"] },
+        "reason": { "type": "string" }
       }
     },
     "SkillActivated": {


### PR DESCRIPTION
Closes #1719.

## Summary
- add VM-backed ACP `session/truncate` handling with in-flight prompt cancellation, session update notification, and audit/event walk-back semantics
- expose HTTP `POST /v1/sessions/{session_id}/truncate` and local API event emission
- update protocol schemas/artifacts, OpenAPI specs, docs, and focused coverage for VM, ACP, CLI, and API paths

## Verification
- `CARGO_TARGET_DIR=/tmp/harn-target-b710 cargo test -p harn-vm truncate_`
- `CARGO_TARGET_DIR=/tmp/harn-target-b710 cargo test -p harn-serve truncate`
- `CARGO_TARGET_DIR=/tmp/harn-target-b710 cargo test -p harn-cli --test acp_server_cli acp_session_truncate_mutates_runtime_state_in_place -- --ignored --exact`
- `CARGO_TARGET_DIR=/tmp/harn-target-b710 make check-protocol-artifacts`
- `make check-bindings`
- `CARGO_TARGET_DIR=/tmp/harn-target-b710 HARN_LLM_CALLS_DISABLED=1 cargo run --bin harn -- test protocols --filter acp.session_update.harn_extensions`
- `CARGO_TARGET_DIR=/tmp/harn-target-b710 cargo run --quiet --bin harn -- run scripts/check_openapi_snapshot.harn`
- `make lint-test-patterns`
- `cargo fmt --check && git diff --check`
- pre-commit hook
- pre-push hook