### PR TITLE
persona supervision tail: deflake follow test + extract drive_tail

### DIFF
--- a/crates/harn-cli/src/commands/persona_supervision.rs
+++ b/crates/harn-cli/src/commands/persona_supervision.rs
@@ -1,4 +1,3 @@
-use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
@@ -74,15 +73,30 @@ pub(crate) async fn run_tail(
     args: &PersonaSupervisionTailArgs,
 ) -> Result<(), String> {
     let options = PersonaSupervisionTailOptions::from(args);
-    validate_tail_options(&options)?;
+    let stdout = std::io::stdout();
+    let mut stdout = stdout.lock();
+    drive_tail(manifest, state_dir, &options, &mut stdout, None).await
+}
+
+/// Drive the supervision tail loop against `writer`, optionally signalling
+/// `ready_tx` once the watcher is armed and the initial frames have been
+/// flushed. The CLI entrypoint passes a stdout lock and `None`; tests can
+/// inject an in-memory writer plus a oneshot to avoid subprocess timing
+/// races.
+pub async fn drive_tail<W: std::io::Write>(
+    manifest: Option<&Path>,
+    state_dir: &Path,
+    options: &PersonaSupervisionTailOptions,
+    writer: &mut W,
+    mut ready_tx: Option<tokio::sync::oneshot::Sender<()>>,
+) -> Result<(), String> {
+    validate_tail_options(options)?;
     let catalog = load_catalog_for_tail(manifest)?;
     let log = open_persona_log(state_dir)?;
     let topic = persona_runtime_topic()?;
     let mut cursor = options.since_event_id;
     let mut remaining = options.limit;
     let mut waiter = EventLogChangeWaiter::new(log.describe().location);
-    let stdout = std::io::stdout();
-    let mut stdout = stdout.lock();
 
     loop {
         let frames = read_supervision_frames(
@@ -97,15 +111,18 @@ pub(crate) async fn run_tail(
         for frame in frames {
             let line = serde_json::to_string(&frame)
                 .map_err(|error| format!("failed to serialize supervision frame: {error}"))?;
-            writeln!(stdout, "{line}")
+            writeln!(writer, "{line}")
                 .map_err(|error| format!("failed to write supervision frame: {error}"))?;
         }
-        stdout
+        writer
             .flush()
             .map_err(|error| format!("failed to flush supervision stream: {error}"))?;
 
         if remaining == Some(0) || !options.follow {
             return Ok(());
+        }
+        if let Some(tx) = ready_tx.take() {
+            let _ = tx.send(());
         }
         waiter.wait().await;
     }

--- a/crates/harn-cli/tests/persona_cli.rs
+++ b/crates/harn-cli/tests/persona_cli.rs
@@ -10,13 +10,12 @@
 use std::collections::BTreeSet;
 use std::fs;
 use std::path::Path;
-use std::process::Stdio;
+use std::sync::Arc;
 use std::time::Duration;
 
 use harn_cli::commands::{persona, persona_doctor, persona_scaffold, persona_supervision};
 use harn_vm::event_log::EventLog as _;
 use tempfile::TempDir;
-use tokio::io::{AsyncBufReadExt, BufReader};
 
 fn write_manifest(body: &str) -> TempDir {
     let temp = TempDir::new().unwrap();
@@ -748,26 +747,42 @@ async fn persona_supervision_tail_follow_streams_new_events() {
     let manifest = manifest_path(&temp);
     let state_dir = temp.path().join(".harn-personas-test");
 
-    let mut child = tokio::process::Command::new(env!("CARGO_BIN_EXE_harn"))
-        .arg("persona")
-        .arg("--manifest")
-        .arg(&manifest)
-        .arg("--state-dir")
-        .arg(&state_dir)
-        .arg("supervision")
-        .arg("tail")
-        .arg("--persona")
-        .arg("merge_captain")
-        .arg("--follow")
-        .arg("--limit")
-        .arg("1")
-        .arg("--json")
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("spawn harn persona supervision tail");
-    let stdout = child.stdout.take().expect("tail stdout");
-    let mut lines = BufReader::new(stdout).lines();
+    // Drive `drive_tail` in-process so the test can deterministically
+    // wait for the tail to arm its filesystem watcher (via `ready_tx`)
+    // before writing the next event. The previous subprocess+stdout race
+    // was inherently flaky because there is no observable signal for
+    // "subprocess has reached the wait loop" without a sentinel line.
+    let writer = Arc::new(std::sync::Mutex::new(Vec::<u8>::new()));
+    let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+    let options = persona_supervision::PersonaSupervisionTailOptions {
+        persona: Some("merge_captain".to_string()),
+        follow: true,
+        limit: Some(1),
+        ..Default::default()
+    };
+
+    let manifest_clone = manifest.clone();
+    let state_dir_clone = state_dir.clone();
+    let writer_clone = Arc::clone(&writer);
+    let task = tokio::spawn(async move {
+        let mut guard = SharedWriter(writer_clone);
+        persona_supervision::drive_tail(
+            Some(&manifest_clone),
+            &state_dir_clone,
+            &options,
+            &mut guard,
+            Some(ready_tx),
+        )
+        .await
+    });
+
+    // `ready_rx` fires only after the tail has flushed its initial read
+    // (empty, here) and is about to wait for changes — so any event we
+    // append now must traverse the follow path.
+    tokio::time::timeout(Duration::from_secs(5), ready_rx)
+        .await
+        .expect("tail signalled ready")
+        .expect("ready oneshot delivered");
 
     let _ = persona::tick_payload(
         Some(&manifest),
@@ -780,21 +795,35 @@ async fn persona_supervision_tail_follow_streams_new_events() {
     .await
     .expect("append followed event");
 
-    let line = tokio::time::timeout(Duration::from_secs(5), lines.next_line())
+    let result = tokio::time::timeout(Duration::from_secs(5), task)
         .await
-        .expect("tail produced a line before timeout")
-        .expect("read tail line")
-        .expect("tail line");
-    let frame: serde_json::Value = serde_json::from_str(&line).expect("tail line JSON");
+        .expect("tail finished")
+        .expect("tail task did not panic");
+    result.expect("tail completed without error");
+
+    let bytes = writer.lock().unwrap().clone();
+    let line = std::str::from_utf8(&bytes)
+        .expect("utf8 tail output")
+        .trim()
+        .to_string();
+    let frame: serde_json::Value = serde_json::from_str(&line).expect("follow JSON");
     assert_eq!(frame["persona_id"], "merge_captain");
     assert_eq!(frame["update_kind"], "receipt");
     assert_eq!(frame["payload"]["status"], "completed");
+    assert_eq!(frame["occurred_at"], "2026-05-10T15:00:00Z");
+}
 
-    let status = tokio::time::timeout(Duration::from_secs(5), child.wait())
-        .await
-        .expect("tail exited after limit")
-        .expect("wait for tail");
-    assert!(status.success(), "tail exited with {status}");
+struct SharedWriter(Arc<std::sync::Mutex<Vec<u8>>>);
+
+impl std::io::Write for SharedWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/crates/harn-modules/src/personas.rs
+++ b/crates/harn-modules/src/personas.rs
@@ -1092,7 +1092,14 @@ pub fn validate_persona_stages(
                 );
             }
         }
-        validate_persona_nested_extra(manifest_path, &field, "stages", &stage.extra, errors);
+        for key in stage.extra.keys() {
+            persona_error(
+                manifest_path,
+                format!("{field}.{key}"),
+                "unknown stage field",
+                errors,
+            );
+        }
         if let Some(tools) = stage.allowed_tools.as_ref() {
             for tool in tools {
                 if tool.trim().is_empty() {

--- a/docs/src/personas/stages.md
+++ b/docs/src/personas/stages.md
@@ -29,7 +29,7 @@ stages = [
 
 or directly on the `@persona` attribute in a Harn workflow:
 
-```harn,ignore
+```harn
 @persona(
   name: "scoped_persona",
   tools: [github, ci],
@@ -42,6 +42,9 @@ fn scoped_persona(ctx) {
   research(ctx)
   act(ctx)
 }
+
+@step(name: "research") fn research(ctx) { return ctx }
+@step(name: "act") fn act(ctx) { return ctx }
 ```
 
 Each stage's `name` must match a `@step(name: "...")` declaration in the


### PR DESCRIPTION
## Summary

Follow-up cleanup spotted while shipping #1728 — the `persona_supervision_tail_follow_streams_new_events` integration test was flaking locally (~1-in-3 runs). Reproducing without my branch confirmed it was pre-existing.

The test spawned `harn persona supervision tail --follow` as a subprocess and waited up to 5s on a stdout line. There is no observable signal that the subprocess has reached the follow wait loop, so on a busy machine the writer occasionally raced the subprocess startup and the 5s window expired.

## What changed

- Extract the tail loop into [`drive_tail(manifest, state_dir, options, writer, ready_tx)`](crates/harn-cli/src/commands/persona_supervision.rs:71). `run_tail` keeps wiring it to stdout for the CLI path. Tests inject an in-memory writer plus a oneshot, so we can deterministically wait for the watcher to be armed before appending the event under test. Runs in ~60ms and is stable across 8/8 local re-runs.
- Self-contain the [`stages.md`](docs/src/personas/stages.md) `@persona(stages: …)` snippet so it type-checks under `make check-docs-snippets` instead of being tagged `harn,ignore`.
- Fix the field-path label in [`validate_persona_stages`](crates/harn-modules/src/personas.rs:1062) — it was passing `"stages"` as the nested-field label to `validate_persona_nested_extra`, producing `[[personas]][0].stages[0].stages.foo` paths for unknown stage fields. Emit the error inline so the path is `stages[0].foo`.

## Test plan

- [x] `cargo test -p harn-cli --test persona_cli` (14/14 pass, ~120ms)
- [x] 8 consecutive runs of `persona_supervision_tail_follow_streams_new_events` (8/8 pass)
- [x] `cargo test -p harn-modules --lib personas::` (6/6 pass incl. validation)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `make check-docs-snippets`

🤖 Generated with [Claude Code](https://claude.com/claude-code)