### PR TITLE
vm: content-addressed bytecode cache + harn precompile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,18 @@ condensed series summaries instead of full per-patch history.
 
 ### Added
 
+- **Bytecode cache + `harn precompile` (#1710).** `harn run` now persists
+  compiled bytecode under `$HARN_CACHE_DIR` (defaulting to
+  `~/.cache/harn/bytecode`) and reloads it whenever the entry source and
+  every transitively-imported user file are unchanged. Header-stable
+  format records magic, schema version, harn version, source hash, and
+  import-graph hash; mismatches transparently fall back to recompile.
+  `harn precompile <path>` precomputes artifacts for shipping
+  pre-compiled `.harnbc` files adjacent to source — the loader picks
+  those up before consulting the shared cache. Cold-start cost on small
+  pipelines collapses from full parse+typecheck+compile to a single
+  `fopen` + `bincode::deserialize`. Gates the burin-code thin-rust
+  cutover at burin-code#814. See `docs/perf/bytecode-cache.md`.
 - **`secret_store` hostlib capability (#1714).** Adds
   `hostlib_secret_store_{get,set,delete,list}` to `harn-hostlib`, a
   generic per-application credential primitive any Harn-hosted

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,6 +383,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2277,6 +2286,7 @@ name = "harn-parser"
 version = "0.8.21"
 dependencies = [
  "harn-lexer",
+ "serde",
  "yansi",
 ]
 
@@ -2323,6 +2333,7 @@ version = "0.8.21"
 dependencies = [
  "async-trait",
  "base64",
+ "bincode",
  "blake3",
  "brotli",
  "bytes",

--- a/crates/harn-cli/src/cli/mod.rs
+++ b/crates/harn-cli/src/cli/mod.rs
@@ -35,6 +35,7 @@ mod package;
 mod persona;
 mod playground;
 mod portal;
+mod precompile;
 mod profile;
 mod provider;
 mod providers;
@@ -135,6 +136,7 @@ pub(crate) use persona::{
 };
 pub(crate) use playground::PlaygroundArgs;
 pub(crate) use portal::PortalArgs;
+pub use precompile::PrecompileArgs;
 pub(crate) use profile::ProfileArgs;
 pub(crate) use provider::{
     ModelInfoArgs, ProviderCatalogArgs, ProviderProbeArgs, ProviderReadyArgs,
@@ -326,6 +328,16 @@ SCRIPTING
     Repl,
     /// Benchmark a .harn pipeline over repeated runs.
     Bench(BenchArgs),
+    /// Pre-compile `.harn` sources into the content-addressed bytecode
+    /// cache so cold-start `harn run` for the same source skips parse
+    /// and compile and goes straight to bytecode load.
+    ///
+    /// `harn precompile path/` walks the directory and compiles every
+    /// `.harn` file; `harn precompile script.harn` compiles a single
+    /// file. Artifacts are written adjacent to each source as
+    /// `<name>.harnbc` by default; pass `--out DIR` to redirect them
+    /// into a sibling tree.
+    Precompile(PrecompileArgs),
     /// Render a .harn file as a Mermaid workflow graph.
     Viz(VizArgs),
     /// Install dependencies declared in harn.toml.

--- a/crates/harn-cli/src/cli/precompile.rs
+++ b/crates/harn-cli/src/cli/precompile.rs
@@ -1,0 +1,24 @@
+use std::path::PathBuf;
+
+use clap::Args;
+
+#[derive(Debug, Args)]
+#[command(arg_required_else_help = true)]
+pub struct PrecompileArgs {
+    /// File or directory to precompile. Directories are walked recursively
+    /// for `.harn` files.
+    pub target: PathBuf,
+    /// Output directory for compiled `.harnbc` artifacts. When omitted,
+    /// each artifact is written next to its source. The directory tree
+    /// under `target` is mirrored under `--out` so per-source pathing is
+    /// preserved.
+    #[arg(long, value_name = "DIR")]
+    pub out: Option<PathBuf>,
+    /// Continue processing the remaining sources even if one fails to
+    /// compile. The exit code still reflects the failure.
+    #[arg(long)]
+    pub keep_going: bool,
+    /// Suppress per-file progress output.
+    #[arg(short = 'q', long)]
+    pub quiet: bool,
+}

--- a/crates/harn-cli/src/commands/mod.rs
+++ b/crates/harn-cli/src/commands/mod.rs
@@ -30,6 +30,7 @@ pub mod persona_scaffold;
 pub mod persona_supervision;
 pub mod playground;
 pub(crate) mod portal;
+pub mod precompile;
 pub(crate) mod protocol_conformance;
 pub(crate) mod provider;
 pub(crate) mod providers;

--- a/crates/harn-cli/src/commands/precompile.rs
+++ b/crates/harn-cli/src/commands/precompile.rs
@@ -1,0 +1,150 @@
+//! Implementation of the `harn precompile` subcommand.
+//!
+//! Walks a file or directory tree, compiles every `.harn` file into a
+//! `.harnbc` artifact, and either writes it adjacent to the source or
+//! mirrors the directory layout under `--out`. The on-disk artifact is
+//! the same format the runtime cache writes, so a shipped `.harnbc`
+//! beside its source elides parse+compile in the runtime loader.
+
+use std::path::{Path, PathBuf};
+
+use harn_parser::DiagnosticSeverity;
+
+use crate::cli::PrecompileArgs;
+use crate::command_error;
+use crate::commands::collect_harn_files;
+use crate::parse_source_file;
+
+/// Outcome aggregated across all sources walked in one invocation.
+#[derive(Default)]
+struct Stats {
+    compiled: usize,
+    failed: usize,
+}
+
+pub fn run(args: PrecompileArgs) {
+    let target = args.target.clone();
+    if !target.exists() {
+        command_error(&format!("target does not exist: {}", target.display()));
+    }
+
+    let (sources, source_root) = if target.is_dir() {
+        let mut files = Vec::new();
+        collect_harn_files(&target, &mut files);
+        files.sort();
+        files.dedup();
+        let root = target.canonicalize().unwrap_or_else(|_| target.clone());
+        (files, Some(root))
+    } else {
+        (vec![target.clone()], None)
+    };
+
+    if sources.is_empty() {
+        command_error(&format!("no .harn files found under {}", target.display()));
+    }
+
+    let mut stats = Stats::default();
+    for source in &sources {
+        let result = precompile_one(source, source_root.as_deref(), args.out.as_deref());
+        match result {
+            Ok(out_path) => {
+                stats.compiled += 1;
+                if !args.quiet {
+                    println!("{} -> {}", source.display(), out_path.display());
+                }
+            }
+            Err(err) => {
+                stats.failed += 1;
+                eprintln!("{}: {err}", source.display());
+                if !args.keep_going {
+                    break;
+                }
+            }
+        }
+    }
+
+    if !args.quiet {
+        eprintln!(
+            "precompile: {} succeeded, {} failed",
+            stats.compiled, stats.failed
+        );
+    }
+    if stats.failed > 0 {
+        std::process::exit(1);
+    }
+}
+
+fn precompile_one(
+    source_path: &Path,
+    source_root: Option<&Path>,
+    out_root: Option<&Path>,
+) -> Result<PathBuf, String> {
+    let source = std::fs::read_to_string(source_path).map_err(|e| format!("read: {e}"))?;
+    let path_str = source_path.to_string_lossy();
+
+    let (parsed_source, program) = parse_source_file(&path_str);
+    debug_assert_eq!(parsed_source, source);
+
+    let mut had_type_error = false;
+    let mut messages = String::new();
+    for diag in harn_parser::TypeChecker::new().check_with_source(&program, &source) {
+        let rendered = harn_parser::diagnostic::render_type_diagnostic(&source, &path_str, &diag);
+        if matches!(diag.severity, DiagnosticSeverity::Error) {
+            had_type_error = true;
+        }
+        messages.push_str(&rendered);
+    }
+    if had_type_error {
+        return Err(format!("type errors:\n{messages}"));
+    }
+    if !messages.is_empty() {
+        eprint!("{messages}");
+    }
+
+    let chunk = harn_vm::Compiler::new()
+        .compile(&program)
+        .map_err(|e| format!("compile error: {e}"))?;
+    let key = harn_vm::bytecode_cache::CacheKey::from_source(source_path, &source);
+
+    let dest = output_path(source_path, source_root, out_root)?;
+    harn_vm::bytecode_cache::store_at(&dest, &key, &chunk)
+        .map_err(|e| format!("write {}: {e}", dest.display()))?;
+
+    Ok(dest)
+}
+
+/// Map a source path under (optional) `source_root` to its destination
+/// under (optional) `out_root`. When no `out_root` is given the artifact
+/// lands adjacent to the source.
+fn output_path(
+    source_path: &Path,
+    source_root: Option<&Path>,
+    out_root: Option<&Path>,
+) -> Result<PathBuf, String> {
+    let adjacent = harn_vm::bytecode_cache::adjacent_cache_path(source_path)
+        .ok_or_else(|| format!("source has no file stem: {}", source_path.display()))?;
+    let Some(out_root) = out_root else {
+        return Ok(adjacent);
+    };
+    let relative = match source_root {
+        Some(root) => {
+            let canonical = source_path
+                .canonicalize()
+                .unwrap_or_else(|_| source_path.to_path_buf());
+            canonical
+                .strip_prefix(root)
+                .map(Path::to_path_buf)
+                .unwrap_or_else(|_| {
+                    PathBuf::from(source_path.file_name().unwrap_or(source_path.as_os_str()))
+                })
+        }
+        None => PathBuf::from(
+            source_path
+                .file_name()
+                .ok_or_else(|| format!("source has no file name: {}", source_path.display()))?,
+        ),
+    };
+    let mut dest = out_root.join(&relative);
+    dest.set_extension(harn_vm::bytecode_cache::CACHE_EXTENSION);
+    Ok(dest)
+}

--- a/crates/harn-cli/src/commands/run.rs
+++ b/crates/harn-cli/src/commands/run.rs
@@ -88,6 +88,78 @@ pub(crate) fn build_denied_builtins(
     }
 }
 
+/// Result of [`compile_or_load_chunk_for_run`]. Failures propagate as
+/// diagnostic text on the run path so callers map them straight to a
+/// non-zero exit code without bespoke error types.
+pub(crate) struct LoadedChunk {
+    pub(crate) source: String,
+    pub(crate) chunk: harn_vm::Chunk,
+}
+
+/// Load the entry pipeline as a runnable [`harn_vm::Chunk`], using the
+/// content-addressed bytecode cache when its key matches. On a cache miss
+/// we read, parse, type-check, and compile, then persist the chunk.
+/// On a hit we skip parse/typecheck/compile entirely — the cache invariant
+/// is that a stored chunk passed those phases on the writer's harn build,
+/// and the key includes every transitively-imported user file so any
+/// change re-runs the full path.
+///
+/// `stderr` receives any diagnostic output. Returns `None` when a fatal
+/// type or compile error blocks execution; the caller maps that to
+/// exit-code 1.
+pub(crate) fn compile_or_load_chunk_for_run(
+    path: &str,
+    stderr: &mut String,
+) -> Option<LoadedChunk> {
+    let source = match fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(e) => {
+            stderr.push_str(&format!("Error reading {path}: {e}\n"));
+            return None;
+        }
+    };
+    let lookup = harn_vm::bytecode_cache::load(Path::new(path), &source);
+    if let Some(chunk) = lookup.chunk {
+        return Some(LoadedChunk { source, chunk });
+    }
+
+    let (parsed_source, program) = parse_source_file(path);
+    debug_assert_eq!(parsed_source, source, "parse_source_file re-read drifted");
+
+    let mut had_type_error = false;
+    let type_diagnostics = typecheck_with_imports(&program, Path::new(path), &source);
+    for diag in &type_diagnostics {
+        let rendered = harn_parser::diagnostic::render_type_diagnostic(&source, path, diag);
+        if matches!(diag.severity, DiagnosticSeverity::Error) {
+            had_type_error = true;
+        }
+        stderr.push_str(&rendered);
+    }
+    if had_type_error {
+        return None;
+    }
+
+    let chunk = match harn_vm::Compiler::new().compile(&program) {
+        Ok(c) => c,
+        Err(e) => {
+            stderr.push_str(&format!("error: compile error: {e}\n"));
+            return None;
+        }
+    };
+
+    // Cache misses are best-effort — read-only homedirs, full disks, and
+    // sandboxes are common in CI environments. Surface the failure as a
+    // single-line warning when explicitly requested via the audit hook;
+    // otherwise stay quiet to avoid bloating happy-path output.
+    if let Err(err) = harn_vm::bytecode_cache::store(&lookup.key, &chunk) {
+        if std::env::var_os("HARN_BYTECODE_CACHE_DEBUG").is_some() {
+            eprintln!("[harn] bytecode cache write skipped: {err}");
+        }
+    }
+
+    Some(LoadedChunk { source, chunk })
+}
+
 /// Run the static type checker against `program` with cross-module
 /// import-aware call resolution when the file's imports all resolve. Used
 /// by `run_file` and the MCP server entry so `harn run` catches undefined
@@ -556,35 +628,13 @@ async fn execute_run_inner(inputs: ExecuteRunInputs<'_>) -> RunOutcome {
     let mut stderr = String::new();
     let mut stdout = String::new();
 
-    let (source, program) = parse_source_file(path);
-
-    let mut had_type_error = false;
-    let type_diagnostics = typecheck_with_imports(&program, Path::new(path), &source);
-    for diag in &type_diagnostics {
-        let rendered = harn_parser::diagnostic::render_type_diagnostic(&source, path, diag);
-        if matches!(diag.severity, DiagnosticSeverity::Error) {
-            had_type_error = true;
-        }
-        stderr.push_str(&rendered);
-    }
-    if had_type_error {
+    let Some(LoadedChunk { source, chunk }) = compile_or_load_chunk_for_run(path, &mut stderr)
+    else {
         return RunOutcome {
             stdout,
             stderr,
             exit_code: 1,
         };
-    }
-
-    let chunk = match harn_vm::Compiler::new().compile(&program) {
-        Ok(c) => c,
-        Err(e) => {
-            stderr.push_str(&format!("error: compile error: {e}\n"));
-            return RunOutcome {
-                stdout,
-                stderr,
-                exit_code: 1,
-            };
-        }
     };
 
     if trace {
@@ -1094,30 +1144,15 @@ pub(crate) async fn run_file_mcp_serve(
     card_source: Option<&str>,
     mode: RunFileMcpServeMode,
 ) {
-    let (source, program) = crate::parse_source_file(path);
-
-    let type_diagnostics = typecheck_with_imports(&program, Path::new(path), &source);
-    for diag in &type_diagnostics {
-        match diag.severity {
-            DiagnosticSeverity::Error => {
-                let rendered = harn_parser::diagnostic::render_type_diagnostic(&source, path, diag);
-                eprint!("{rendered}");
-                process::exit(1);
-            }
-            DiagnosticSeverity::Warning => {
-                let rendered = harn_parser::diagnostic::render_type_diagnostic(&source, path, diag);
-                eprint!("{rendered}");
-            }
-        }
-    }
-
-    let chunk = match harn_vm::Compiler::new().compile(&program) {
-        Ok(c) => c,
-        Err(e) => {
-            eprintln!("error: compile error: {e}");
-            process::exit(1);
-        }
+    let mut diagnostics = String::new();
+    let Some(LoadedChunk { source, chunk }) = compile_or_load_chunk_for_run(path, &mut diagnostics)
+    else {
+        eprint!("{diagnostics}");
+        process::exit(1);
     };
+    if !diagnostics.is_empty() {
+        eprint!("{diagnostics}");
+    }
 
     let mut vm = harn_vm::Vm::new();
     harn_vm::register_vm_stdlib(&mut vm);

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -850,6 +850,7 @@ async fn async_main() {
         },
         Command::Repl => commands::repl::run_repl().await,
         Command::Bench(args) => commands::bench::run(args).await,
+        Command::Precompile(args) => commands::precompile::run(args),
         Command::TestBench(args) => commands::test_bench::run(args.command).await,
         Command::Viz(args) => commands::viz::run_viz(&args.file, args.output.as_deref()),
         Command::Install(args) => package::install_packages(

--- a/crates/harn-cli/tests/bytecode_cache.rs
+++ b/crates/harn-cli/tests/bytecode_cache.rs
@@ -1,0 +1,239 @@
+#![recursion_limit = "256"]
+
+//! Integration coverage for the on-disk bytecode cache wired into
+//! `harn run`. Verifies the three invariants the cache must preserve:
+//!
+//! 1. Edits to the entry pipeline source bust the cache.
+//! 2. Edits to any transitively-imported user file bust the cache.
+//! 3. `harn precompile` produces artifacts that `harn run` recognizes,
+//!    skipping recompile on subsequent runs.
+
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::thread;
+
+use harn_cli::cli::PrecompileArgs;
+use harn_cli::commands::precompile;
+use harn_cli::commands::run::{execute_run, CliLlmMockMode, RunOutcome, RunProfileOptions};
+use harn_cli::tests::common::{cwd_lock, env_lock};
+use tempfile::TempDir;
+
+fn run_in_harn_runtime<F, Fut, R>(future_factory: F) -> R
+where
+    F: FnOnce() -> Fut + Send + 'static,
+    Fut: std::future::Future<Output = R>,
+    R: Send + 'static,
+{
+    let handle = thread::Builder::new()
+        .name("harn-cli-bytecache-test".to_string())
+        .stack_size(harn_cli::CLI_RUNTIME_STACK_SIZE)
+        .spawn(move || {
+            let runtime = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()
+                .expect("build runtime");
+            runtime.block_on(future_factory())
+        })
+        .expect("spawn runtime thread");
+    handle.join().expect("runtime thread completed")
+}
+
+fn run_harn(cache_dir: &Path, script: &Path) -> RunOutcome {
+    let cache_dir = cache_dir.to_path_buf();
+    let script = script.to_path_buf();
+    run_in_harn_runtime(move || async move {
+        let _env_guard = env_lock::lock_env().lock().await;
+        let _cwd_guard = cwd_lock::lock_cwd_async().await;
+        harn_vm::reset_thread_local_state();
+        let prev_cache = std::env::var("HARN_CACHE_DIR").ok();
+        std::env::set_var("HARN_CACHE_DIR", &cache_dir);
+        let outcome = execute_run(
+            &script.to_string_lossy(),
+            false,
+            HashSet::new(),
+            Vec::new(),
+            Vec::new(),
+            CliLlmMockMode::Off,
+            None,
+            RunProfileOptions::default(),
+        )
+        .await;
+        match prev_cache {
+            Some(value) => std::env::set_var("HARN_CACHE_DIR", value),
+            None => std::env::remove_var("HARN_CACHE_DIR"),
+        }
+        outcome
+    })
+}
+
+fn cache_entries(dir: &Path) -> Vec<PathBuf> {
+    let mut entries: Vec<PathBuf> = fs::read_dir(dir)
+        .map(|read| {
+            read.filter_map(|entry| entry.ok())
+                .map(|entry| entry.path())
+                .filter(|path| path.extension().is_some_and(|ext| ext == "harnbc"))
+                .collect()
+        })
+        .unwrap_or_default();
+    entries.sort();
+    entries
+}
+
+#[test]
+fn source_edit_invalidates_cache() {
+    let workdir = TempDir::new().unwrap();
+    let cache = TempDir::new().unwrap();
+    let script = workdir.path().join("entry.harn");
+    fs::write(&script, "println(\"alpha\")\n").unwrap();
+
+    let first = run_harn(cache.path(), &script);
+    assert_eq!(first.exit_code, 0, "first run failed: {}", first.stderr);
+    assert!(first.stdout.contains("alpha"), "stdout: {:?}", first.stdout);
+    assert_eq!(
+        cache_entries(cache.path()).len(),
+        1,
+        "expected one cache entry"
+    );
+
+    fs::write(&script, "println(\"bravo\")\n").unwrap();
+    let second = run_harn(cache.path(), &script);
+    assert_eq!(second.exit_code, 0, "second run failed: {}", second.stderr);
+    assert!(
+        second.stdout.contains("bravo"),
+        "stdout: {:?}",
+        second.stdout
+    );
+    // Old + new entry coexist because the cache filename is keyed by
+    // source hash. We just need to confirm the new content shows up.
+    let entries = cache_entries(cache.path());
+    assert!(
+        entries.len() >= 2,
+        "expected ≥2 cache entries, got {entries:?}"
+    );
+}
+
+#[test]
+fn imported_file_edit_invalidates_cache() {
+    let workdir = TempDir::new().unwrap();
+    let cache = TempDir::new().unwrap();
+    let lib = workdir.path().join("lib.harn");
+    fs::write(&lib, "pub fn greet() -> string { return \"lib v1\" }\n").unwrap();
+    let script = workdir.path().join("entry.harn");
+    fs::write(
+        &script,
+        "import { greet } from \"./lib\"\nprintln(greet())\n",
+    )
+    .unwrap();
+
+    let first = run_harn(cache.path(), &script);
+    assert_eq!(first.exit_code, 0, "first run failed: {}", first.stderr);
+    assert!(
+        first.stdout.contains("lib v1"),
+        "stdout: {:?}",
+        first.stdout
+    );
+
+    fs::write(&lib, "pub fn greet() -> string { return \"lib v2\" }\n").unwrap();
+    let second = run_harn(cache.path(), &script);
+    assert_eq!(second.exit_code, 0, "second run failed: {}", second.stderr);
+    assert!(
+        second.stdout.contains("lib v2"),
+        "expected the cached entry to be invalidated after the import \
+         changed; got stdout: {:?}",
+        second.stdout
+    );
+}
+
+#[test]
+fn precompile_then_run_skips_compile() {
+    let workdir = TempDir::new().unwrap();
+    let cache = TempDir::new().unwrap();
+    let script = workdir.path().join("entry.harn");
+    fs::write(&script, "println(\"precompiled\")\n").unwrap();
+
+    run_in_harn_runtime({
+        let target = script.clone();
+        move || async move {
+            let _env_guard = env_lock::lock_env().lock().await;
+            harn_vm::reset_thread_local_state();
+            precompile::run(PrecompileArgs {
+                target,
+                out: None,
+                keep_going: false,
+                quiet: true,
+            });
+        }
+    });
+
+    let adjacent = workdir.path().join("entry.harnbc");
+    assert!(
+        adjacent.exists(),
+        "expected precompile to produce {adjacent:?}"
+    );
+    let metadata = fs::metadata(&adjacent).expect("read adjacent metadata");
+    assert!(metadata.len() > 0, "precompiled artifact is empty");
+
+    let run_result = run_harn(cache.path(), &script);
+    assert_eq!(run_result.exit_code, 0, "run failed: {}", run_result.stderr);
+    assert!(
+        run_result.stdout.contains("precompiled"),
+        "stdout: {:?}",
+        run_result.stdout
+    );
+    // Adjacent artifact was the cache source, so the shared cache dir
+    // stays empty.
+    let shared = cache_entries(cache.path());
+    assert!(
+        shared.is_empty(),
+        "expected adjacent artifact to satisfy the loader without populating \
+         the shared cache dir; got {shared:?}"
+    );
+}
+
+#[test]
+fn disabled_cache_does_not_write_files() {
+    let workdir = TempDir::new().unwrap();
+    let cache = TempDir::new().unwrap();
+    let script = workdir.path().join("entry.harn");
+    fs::write(&script, "println(\"no cache\")\n").unwrap();
+
+    let script = script.clone();
+    let cache_dir = cache.path().to_path_buf();
+    let outcome = run_in_harn_runtime(move || async move {
+        let _env_guard = env_lock::lock_env().lock().await;
+        let _cwd_guard = cwd_lock::lock_cwd_async().await;
+        harn_vm::reset_thread_local_state();
+        let prev_cache = std::env::var("HARN_CACHE_DIR").ok();
+        let prev_toggle = std::env::var("HARN_BYTECODE_CACHE").ok();
+        std::env::set_var("HARN_CACHE_DIR", &cache_dir);
+        std::env::set_var("HARN_BYTECODE_CACHE", "0");
+        let outcome = execute_run(
+            &script.to_string_lossy(),
+            false,
+            HashSet::new(),
+            Vec::new(),
+            Vec::new(),
+            CliLlmMockMode::Off,
+            None,
+            RunProfileOptions::default(),
+        )
+        .await;
+        match prev_cache {
+            Some(value) => std::env::set_var("HARN_CACHE_DIR", value),
+            None => std::env::remove_var("HARN_CACHE_DIR"),
+        }
+        match prev_toggle {
+            Some(value) => std::env::set_var("HARN_BYTECODE_CACHE", value),
+            None => std::env::remove_var("HARN_BYTECODE_CACHE"),
+        }
+        outcome
+    });
+
+    assert_eq!(outcome.exit_code, 0, "stderr: {}", outcome.stderr);
+    assert!(outcome.stdout.contains("no cache"));
+    assert!(
+        cache_entries(cache.path()).is_empty(),
+        "cache disabled should leave the dir untouched"
+    );
+}

--- a/crates/harn-parser/Cargo.toml
+++ b/crates/harn-parser/Cargo.toml
@@ -9,4 +9,5 @@ description = "Parser, AST, and type checker for the Harn programming language"
 
 [dependencies]
 harn-lexer = { path = "../harn-lexer", version = "0.8" }
+serde = { version = "1", features = ["derive"] }
 yansi = "1"

--- a/crates/harn-parser/src/ast.rs
+++ b/crates/harn-parser/src/ast.rs
@@ -553,7 +553,7 @@ pub struct InterfaceMethod {
 }
 
 /// A type annotation (optional, for runtime checking).
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum TypeExpr {
     /// A named type: int, string, float, bool, nil, list, dict, closure,
     /// or a user-defined type name.
@@ -596,7 +596,7 @@ pub enum TypeExpr {
 }
 
 /// A field in a dict shape type.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct ShapeField {
     pub name: String,
     pub type_expr: TypeExpr,

--- a/crates/harn-vm/Cargo.toml
+++ b/crates/harn-vm/Cargo.toml
@@ -29,6 +29,7 @@ harn-modules = { path = "../harn-modules", version = "0.8" }
 harn-parser = { path = "../harn-parser", version = "0.8" }
 harn-stdlib = { path = "../harn-stdlib", version = "0.8" }
 async-trait = "0.1"
+bincode = "1.3"
 chrono = "0.4"
 chrono-tz = "0.10.4"
 croner = "3.0.1"

--- a/crates/harn-vm/src/bytecode_cache.rs
+++ b/crates/harn-vm/src/bytecode_cache.rs
@@ -1,0 +1,670 @@
+//! Content-addressed on-disk cache for compiled `.harn` pipelines.
+//!
+//! Cold-start `harn run` re-parses, type-checks, and compiles the entry
+//! pipeline before the VM gets a single instruction to execute. For short
+//! Harn subcommands that wrap a few `llm_call`s in a small pipeline, that
+//! compile cost dominates wall-clock time.
+//!
+//! This module persists [`Chunk`] bytecode under
+//! `$HARN_CACHE_DIR/<source-hash>.harnbc` (XDG-aware). The cache key is
+//! derived from the entry source plus the content hash of every
+//! transitively-imported user file; stdlib imports are covered by the
+//! embedded `harn_version` field in the header. Any change to any input
+//! flips the key and the next run recompiles.
+//!
+//! File layout — little-endian throughout:
+//!
+//! ```text
+//! magic        : [u8; 8]   = "HARNBC\0\0"
+//! schema_ver   : u32       = SCHEMA_VERSION
+//! version_len  : u32
+//! harn_version : [u8; version_len]
+//! source_hash  : [u8; 32]
+//! import_hash  : [u8; 32]
+//! payload      : bincode-serialized CachedChunk
+//! ```
+//!
+//! The header lets a stale binary detect a future-version artifact
+//! without crashing: a magic mismatch, schema mismatch, or version
+//! mismatch is returned as `Ok(None)` so the caller transparently
+//! recompiles. Real I/O errors propagate.
+//!
+//! Concurrency: writes are atomic (write-tmp-then-rename), and parallel
+//! invocations on a cache miss race safely — the last writer wins, but
+//! every reader observes a consistent file because the rename is atomic
+//! on every supported filesystem.
+
+use std::fs;
+use std::io::{self, Read as _, Write as _};
+use std::path::{Path, PathBuf};
+
+use sha2::{Digest, Sha256};
+
+use crate::chunk::{CachedChunk, Chunk};
+
+/// Header magic. The trailing NULs reserve room for a one-byte type
+/// discriminator should we later store IR alongside bytecode in the
+/// same file.
+pub const MAGIC: &[u8; 8] = b"HARNBC\0\0";
+
+/// On-disk format version. Bump when [`CachedChunk`] or the header
+/// layout changes in a backwards-incompatible way.
+pub const SCHEMA_VERSION: u32 = 1;
+
+/// Compile-time Harn release. Cache files written by a different release
+/// are rejected on load.
+pub const HARN_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Conventional extension for cache files. Used both for entries in the
+/// shared cache dir and for adjacent precompiled artifacts.
+pub const CACHE_EXTENSION: &str = "harnbc";
+
+/// Environment override for the cache directory. When set, takes
+/// precedence over the XDG and home-directory fallbacks.
+pub const CACHE_DIR_ENV: &str = "HARN_CACHE_DIR";
+
+/// Environment override that turns the cache off entirely. Setting this
+/// to `0`, `false`, `no`, or `off` skips both reads and writes; useful
+/// when debugging compiler changes.
+pub const CACHE_ENABLED_ENV: &str = "HARN_BYTECODE_CACHE";
+
+/// Result of a cache lookup. Carries the precomputed key so the caller
+/// can write it back on a miss without rehashing.
+pub struct LookupOutcome {
+    pub key: CacheKey,
+    pub chunk: Option<Chunk>,
+}
+
+/// Cache key components for a single pipeline source. Equality of all
+/// three fields is necessary and sufficient for cache reuse.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CacheKey {
+    pub source_hash: [u8; 32],
+    pub import_graph_hash: [u8; 32],
+    pub harn_version: &'static str,
+}
+
+impl CacheKey {
+    /// Compute the cache key for a `.harn` source file plus its transitive
+    /// user imports. `read_source` is the entry-file contents; the import
+    /// graph is walked from disk relative to `source_path`.
+    pub fn from_source(source_path: &Path, source: &str) -> Self {
+        let source_hash = sha256(source.as_bytes());
+        let import_graph_hash = hash_transitive_user_imports(source_path, source);
+        Self {
+            source_hash,
+            import_graph_hash,
+            harn_version: HARN_VERSION,
+        }
+    }
+
+    /// Cache filename for this key. We hash by source content alone so
+    /// that two invocations of the same source from different paths
+    /// share a cache entry; the header's import-graph hash still gates
+    /// reuse on a per-load basis.
+    pub fn filename(&self) -> String {
+        format!("{}.{}", hex(&self.source_hash), CACHE_EXTENSION)
+    }
+}
+
+/// Returns the directory the shared cache lives in. Honors
+/// `$HARN_CACHE_DIR`, then `$XDG_CACHE_HOME/harn/bytecode`, then
+/// `$HOME/.cache/harn/bytecode`. The directory is *not* created here —
+/// [`store`] creates it lazily on write so read-only environments don't
+/// pay an mkdir cost.
+pub fn cache_dir() -> PathBuf {
+    if let Some(custom) = std::env::var_os(CACHE_DIR_ENV) {
+        return PathBuf::from(custom);
+    }
+    if let Some(xdg) = std::env::var_os("XDG_CACHE_HOME") {
+        let xdg = PathBuf::from(xdg);
+        if !xdg.as_os_str().is_empty() {
+            return xdg.join("harn").join("bytecode");
+        }
+    }
+    if let Some(home) = std::env::var_os("HOME") {
+        return PathBuf::from(home)
+            .join(".cache")
+            .join("harn")
+            .join("bytecode");
+    }
+    // Final fallback: a directory beside the binary's working dir. Mostly
+    // hit in tests that scrub HOME from the environment.
+    PathBuf::from(".harn-cache").join("bytecode")
+}
+
+/// True when the cache is enabled by the current environment.
+pub fn cache_enabled() -> bool {
+    match std::env::var(CACHE_ENABLED_ENV).ok().as_deref() {
+        Some(value) => !matches!(
+            value.to_ascii_lowercase().as_str(),
+            "0" | "false" | "no" | "off"
+        ),
+        None => true,
+    }
+}
+
+/// Try to load a cached chunk for `source_path` whose contents are
+/// `source`. Returns the key alongside the (optional) chunk so callers
+/// avoid recomputing the key on miss.
+pub fn load(source_path: &Path, source: &str) -> LookupOutcome {
+    let key = CacheKey::from_source(source_path, source);
+    if !cache_enabled() {
+        return LookupOutcome { key, chunk: None };
+    }
+    let mut candidates: Vec<PathBuf> = Vec::with_capacity(2);
+    if let Some(adjacent) = adjacent_cache_path(source_path) {
+        candidates.push(adjacent);
+    }
+    candidates.push(cache_dir().join(key.filename()));
+    for path in candidates {
+        match read_chunk_if_matches(&path, &key) {
+            Ok(Some(chunk)) => {
+                return LookupOutcome {
+                    key,
+                    chunk: Some(chunk),
+                }
+            }
+            Ok(None) => continue,
+            Err(_) => continue,
+        }
+    }
+    LookupOutcome { key, chunk: None }
+}
+
+/// Persist `chunk` to the shared cache directory under `key`. Atomic: a
+/// temp file is written then renamed into place. Concurrent invocations
+/// on the same key race safely.
+pub fn store(key: &CacheKey, chunk: &Chunk) -> io::Result<()> {
+    if !cache_enabled() {
+        return Ok(());
+    }
+    let dir = cache_dir();
+    fs::create_dir_all(&dir)?;
+    write_atomic(&dir.join(key.filename()), key, chunk)
+}
+
+/// Write a precompiled artifact to an explicit path, for use by the
+/// `harn precompile` subcommand. The header still records the key, so
+/// adjacent artifacts shipped with source are validated like any other
+/// cache hit.
+pub fn store_at(path: &Path, key: &CacheKey, chunk: &Chunk) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent)?;
+        }
+    }
+    write_atomic(path, key, chunk)
+}
+
+/// Path to the adjacent precompiled artifact for `source_path`, if any.
+/// `foo.harn` → `foo.harnbc`; files without a stem or extension return
+/// `None`.
+pub fn adjacent_cache_path(source_path: &Path) -> Option<PathBuf> {
+    let stem = source_path.file_stem()?;
+    if stem.is_empty() {
+        return None;
+    }
+    let parent = source_path.parent().unwrap_or_else(|| Path::new(""));
+    let mut out = parent.join(stem);
+    out.set_extension(CACHE_EXTENSION);
+    Some(out)
+}
+
+fn write_atomic(target: &Path, key: &CacheKey, chunk: &Chunk) -> io::Result<()> {
+    let cached = chunk.freeze_for_cache();
+    let payload = bincode::serialize(&cached)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+
+    let mut buf: Vec<u8> = Vec::with_capacity(payload.len() + 128);
+    buf.extend_from_slice(MAGIC);
+    buf.extend_from_slice(&SCHEMA_VERSION.to_le_bytes());
+    let version_bytes = HARN_VERSION.as_bytes();
+    buf.extend_from_slice(&(version_bytes.len() as u32).to_le_bytes());
+    buf.extend_from_slice(version_bytes);
+    buf.extend_from_slice(&key.source_hash);
+    buf.extend_from_slice(&key.import_graph_hash);
+    buf.extend_from_slice(&payload);
+
+    let tmp_name = match target.file_name() {
+        Some(name) => format!(".{}.{}.tmp", name.to_string_lossy(), std::process::id(),),
+        None => format!(".harn-cache.{}.tmp", std::process::id()),
+    };
+    let tmp_path = target.with_file_name(tmp_name);
+    let mut tmp_file = fs::File::create(&tmp_path)?;
+    tmp_file.write_all(&buf)?;
+    tmp_file.sync_all()?;
+    drop(tmp_file);
+    match fs::rename(&tmp_path, target) {
+        Ok(()) => Ok(()),
+        Err(err) => {
+            let _ = fs::remove_file(&tmp_path);
+            Err(err)
+        }
+    }
+}
+
+fn read_chunk_if_matches(path: &Path, key: &CacheKey) -> io::Result<Option<Chunk>> {
+    let mut file = match fs::File::open(path) {
+        Ok(f) => f,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(err),
+    };
+    let mut header = [0u8; 8 + 4 + 4];
+    if file.read_exact(&mut header).is_err() {
+        return Ok(None);
+    }
+    if &header[..8] != MAGIC {
+        return Ok(None);
+    }
+    let schema = u32::from_le_bytes(header[8..12].try_into().unwrap());
+    if schema != SCHEMA_VERSION {
+        return Ok(None);
+    }
+    let version_len = u32::from_le_bytes(header[12..16].try_into().unwrap()) as usize;
+    // Sanity-check the version string length to keep a corrupted file
+    // from forcing an unbounded allocation.
+    if version_len > 256 {
+        return Ok(None);
+    }
+    let mut version_buf = vec![0u8; version_len];
+    if file.read_exact(&mut version_buf).is_err() {
+        return Ok(None);
+    }
+    if version_buf != key.harn_version.as_bytes() {
+        return Ok(None);
+    }
+    let mut hashes = [0u8; 64];
+    if file.read_exact(&mut hashes).is_err() {
+        return Ok(None);
+    }
+    if hashes[..32] != key.source_hash || hashes[32..] != key.import_graph_hash {
+        return Ok(None);
+    }
+    let mut payload = Vec::new();
+    if file.read_to_end(&mut payload).is_err() {
+        return Ok(None);
+    }
+    let cached: CachedChunk = match bincode::deserialize(&payload) {
+        Ok(c) => c,
+        Err(_) => return Ok(None),
+    };
+    Ok(Some(Chunk::from_cached(&cached)))
+}
+
+fn sha256(bytes: &[u8]) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hasher.finalize().into()
+}
+
+fn hex(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        out.push_str(&format!("{byte:02x}"));
+    }
+    out
+}
+
+/// Lightweight regex-free scan that surfaces user imports without paying
+/// a full lex+parse. False positives only increase cache churn, never
+/// correctness; comments and string literals are skipped so neither a
+/// commented-out import nor a `"import …"` value appearing inside an
+/// unrelated string gates the hash.
+fn collect_user_imports(source: &str) -> Vec<String> {
+    let scrubbed = strip_comments(source);
+    let mut out: Vec<String> = Vec::new();
+    let bytes = scrubbed.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'"' {
+            // Skip past any string literal so identifiers inside string
+            // values cannot trigger the keyword match below.
+            match read_string_literal(bytes, i) {
+                Some((_, end)) => {
+                    i = end;
+                    continue;
+                }
+                None => {
+                    i += 1;
+                    continue;
+                }
+            }
+        }
+        if !matches_keyword(bytes, i, b"import") {
+            i += 1;
+            continue;
+        }
+        // Skip past `import` and any selective `{ ... } from` clause; we
+        // only need the source-position of the path string literal.
+        let mut j = i + b"import".len();
+        let mut depth = 0i32;
+        while j < bytes.len() {
+            match bytes[j] {
+                b'"' => {
+                    if let Some((path, end)) = read_string_literal(bytes, j) {
+                        if !path.starts_with("std/") {
+                            out.push(path);
+                        }
+                        i = end;
+                        break;
+                    }
+                    j += 1;
+                }
+                b'{' => {
+                    depth += 1;
+                    j += 1;
+                }
+                b'}' => {
+                    depth -= 1;
+                    j += 1;
+                }
+                b'\n' if depth == 0 => {
+                    // No string literal on this logical line; bail and
+                    // continue scanning after the keyword to avoid an
+                    // infinite loop.
+                    i = j;
+                    break;
+                }
+                _ => j += 1,
+            }
+        }
+        if j >= bytes.len() {
+            break;
+        }
+        if i < j {
+            // Defensive: ensure forward progress when the inner loop
+            // exited without setting `i`.
+            i = j;
+        }
+    }
+    out
+}
+
+fn matches_keyword(bytes: &[u8], at: usize, keyword: &[u8]) -> bool {
+    let end = at + keyword.len();
+    if end > bytes.len() {
+        return false;
+    }
+    if &bytes[at..end] != keyword {
+        return false;
+    }
+    if at > 0 && is_ident_char(bytes[at - 1]) {
+        return false;
+    }
+    if end < bytes.len() && is_ident_char(bytes[end]) {
+        return false;
+    }
+    true
+}
+
+fn is_ident_char(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_'
+}
+
+fn read_string_literal(bytes: &[u8], at: usize) -> Option<(String, usize)> {
+    debug_assert_eq!(bytes[at], b'"');
+    let mut out = String::new();
+    let mut i = at + 1;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'"' => return Some((out, i + 1)),
+            b'\\' => {
+                if i + 1 >= bytes.len() {
+                    return None;
+                }
+                match bytes[i + 1] {
+                    b'"' => out.push('"'),
+                    b'\\' => out.push('\\'),
+                    b'n' => out.push('\n'),
+                    b'r' => out.push('\r'),
+                    b't' => out.push('\t'),
+                    other => out.push(other as char),
+                }
+                i += 2;
+            }
+            b'\n' => return None,
+            byte => {
+                out.push(byte as char);
+                i += 1;
+            }
+        }
+    }
+    None
+}
+
+fn strip_comments(source: &str) -> String {
+    let bytes = source.as_bytes();
+    let mut out = String::with_capacity(source.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if i + 1 < bytes.len() && bytes[i] == b'/' && bytes[i + 1] == b'/' {
+            while i < bytes.len() && bytes[i] != b'\n' {
+                i += 1;
+            }
+            continue;
+        }
+        if i + 1 < bytes.len() && bytes[i] == b'/' && bytes[i + 1] == b'*' {
+            i += 2;
+            while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                i += 1;
+            }
+            i = (i + 2).min(bytes.len());
+            continue;
+        }
+        if bytes[i] == b'"' {
+            if let Some((_, end)) = read_string_literal(bytes, i) {
+                out.push_str(&source[i..end]);
+                i = end;
+                continue;
+            }
+        }
+        out.push(bytes[i] as char);
+        i += 1;
+    }
+    out
+}
+
+/// Walk the user-import graph rooted at `source_path` and produce a
+/// stable hash of every transitively-reachable file. The hash is
+/// order-independent: each visited file is keyed by canonical path and
+/// emitted in sorted order, so reordering imports inside a file does
+/// not invalidate the cache while changing any file's content does.
+fn hash_transitive_user_imports(source_path: &Path, source: &str) -> [u8; 32] {
+    let mut visited: std::collections::BTreeMap<PathBuf, ImportNode> =
+        std::collections::BTreeMap::new();
+    let mut frontier: Vec<(PathBuf, String)> = collect_user_imports(source)
+        .into_iter()
+        .map(|import| (source_path.to_path_buf(), import))
+        .collect();
+
+    while let Some((anchor, import)) = frontier.pop() {
+        let Some(resolved) = harn_modules::resolve_import_path(&anchor, &import) else {
+            // Unresolved imports get a sentinel keyed by their resolution
+            // anchor so that dropping a real file under that anchor later
+            // produces a different key.
+            let sentinel = anchor.join(format!("__unresolved__/{import}"));
+            visited
+                .entry(sentinel)
+                .or_insert(ImportNode::Unresolved { import });
+            continue;
+        };
+        let canonical = resolved.canonicalize().unwrap_or_else(|_| resolved.clone());
+        if visited.contains_key(&canonical) {
+            continue;
+        }
+        match fs::read_to_string(&resolved) {
+            Ok(content) => {
+                let nested = collect_user_imports(&content);
+                visited.insert(
+                    canonical.clone(),
+                    ImportNode::Resolved {
+                        content: content.clone(),
+                    },
+                );
+                for nested_import in nested {
+                    frontier.push((resolved.clone(), nested_import));
+                }
+            }
+            Err(err) => {
+                visited.insert(
+                    canonical,
+                    ImportNode::IoError {
+                        kind: err.kind().to_string(),
+                    },
+                );
+            }
+        }
+    }
+
+    let mut hasher = Sha256::new();
+    for (path, node) in &visited {
+        hasher.update(path.to_string_lossy().as_bytes());
+        hasher.update(b"\0");
+        match node {
+            ImportNode::Resolved { content } => {
+                hasher.update(b"resolved\0");
+                hasher.update(content.as_bytes());
+            }
+            ImportNode::Unresolved { import } => {
+                hasher.update(b"unresolved\0");
+                hasher.update(import.as_bytes());
+            }
+            ImportNode::IoError { kind } => {
+                hasher.update(b"ioerror\0");
+                hasher.update(kind.as_bytes());
+            }
+        }
+        hasher.update(b"\0");
+    }
+    hasher.finalize().into()
+}
+
+enum ImportNode {
+    Resolved { content: String },
+    Unresolved { import: String },
+    IoError { kind: String },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::compile_source;
+
+    #[test]
+    fn header_round_trips_chunk() {
+        let chunk = compile_source("println(\"hello\")").expect("compile");
+        let key = CacheKey::from_source(Path::new("/tmp/example.harn"), "println(\"hello\")");
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("entry.harnbc");
+        store_at(&path, &key, &chunk).expect("write");
+        let loaded = read_chunk_if_matches(&path, &key).unwrap();
+        assert!(loaded.is_some(), "expected cached chunk to load");
+    }
+
+    #[test]
+    fn header_mismatch_returns_none() {
+        let chunk = compile_source("1 + 1").expect("compile");
+        let key = CacheKey::from_source(Path::new("/tmp/a.harn"), "1 + 1");
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("a.harnbc");
+        store_at(&path, &key, &chunk).expect("write");
+        let other = CacheKey {
+            source_hash: [0xAB; 32],
+            import_graph_hash: key.import_graph_hash,
+            harn_version: HARN_VERSION,
+        };
+        assert!(read_chunk_if_matches(&path, &other).unwrap().is_none());
+    }
+
+    #[test]
+    fn collect_user_imports_ignores_stdlib_and_comments() {
+        let source = r#"
+            // import "comment/should/be/ignored"
+            import "std/agents"
+            import { foo } from "pkg/bar"
+            import "./relative/path"
+        "#;
+        let imports = collect_user_imports(source);
+        assert_eq!(
+            imports,
+            vec!["pkg/bar".to_string(), "./relative/path".to_string()]
+        );
+    }
+
+    #[test]
+    fn cache_enabled_respects_env() {
+        std::env::set_var(CACHE_ENABLED_ENV, "0");
+        assert!(!cache_enabled());
+        std::env::set_var(CACHE_ENABLED_ENV, "1");
+        assert!(cache_enabled());
+        std::env::remove_var(CACHE_ENABLED_ENV);
+        assert!(cache_enabled());
+    }
+
+    #[test]
+    fn import_path_inside_string_literal_is_ignored() {
+        let source = r#"
+            let payload = "import { foo } from \"./other\""
+            import "./real"
+        "#;
+        let imports = collect_user_imports(source);
+        assert_eq!(imports, vec!["./real".to_string()]);
+    }
+
+    #[test]
+    fn import_hash_is_stable_across_import_order() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("a.harn"),
+            "pub fn a() -> int { return 1 }\n",
+        )
+        .unwrap();
+        std::fs::write(
+            tmp.path().join("b.harn"),
+            "pub fn b() -> int { return 2 }\n",
+        )
+        .unwrap();
+        let ab = tmp.path().join("entry_ab.harn");
+        std::fs::write(&ab, "import \"./a\"\nimport \"./b\"\nprintln(\"hi\")\n").unwrap();
+        let ba = tmp.path().join("entry_ba.harn");
+        std::fs::write(&ba, "import \"./b\"\nimport \"./a\"\nprintln(\"hi\")\n").unwrap();
+        let hash_ab = hash_transitive_user_imports(&ab, &std::fs::read_to_string(&ab).unwrap());
+        let hash_ba = hash_transitive_user_imports(&ba, &std::fs::read_to_string(&ba).unwrap());
+        assert_eq!(
+            hash_ab, hash_ba,
+            "import-graph hash must be order-independent so reordering imports \
+             does not bust the cache"
+        );
+    }
+
+    #[test]
+    fn import_hash_picks_up_nested_imports() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("leaf.harn"),
+            "pub fn x() -> int { return 1 }\n",
+        )
+        .unwrap();
+        std::fs::write(
+            tmp.path().join("mid.harn"),
+            "import \"./leaf\"\npub fn y() -> int { return 2 }\n",
+        )
+        .unwrap();
+        let entry = tmp.path().join("entry.harn");
+        std::fs::write(&entry, "import \"./mid\"\nprintln(\"hi\")\n").unwrap();
+
+        let before =
+            hash_transitive_user_imports(&entry, &std::fs::read_to_string(&entry).unwrap());
+        std::fs::write(
+            tmp.path().join("leaf.harn"),
+            "pub fn x() -> int { return 999 }\n",
+        )
+        .unwrap();
+        let after = hash_transitive_user_imports(&entry, &std::fs::read_to_string(&entry).unwrap());
+        assert_ne!(
+            before, after,
+            "editing a transitively-imported file must change the import-graph hash"
+        );
+    }
+}

--- a/crates/harn-vm/src/chunk.rs
+++ b/crates/harn-vm/src/chunk.rs
@@ -4,6 +4,7 @@ use std::fmt;
 use std::rc::Rc;
 
 use harn_parser::TypeExpr;
+use serde::{Deserialize, Serialize};
 
 /// Bytecode opcodes for the Harn VM.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -369,7 +370,7 @@ impl Op {
 }
 
 /// A constant value in the constant pool.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum Constant {
     Int(i64),
     Float(f64),
@@ -434,7 +435,7 @@ pub(crate) enum MethodCacheTarget {
 }
 
 /// Debug metadata for a slot-indexed local in a compiled chunk.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LocalSlotInfo {
     pub name: String,
     pub mutable: bool,
@@ -488,30 +489,34 @@ pub struct Chunk {
 pub type ChunkRef = Rc<Chunk>;
 pub type CompiledFunctionRef = Rc<CompiledFunction>;
 
-#[derive(Debug, Clone)]
-pub(crate) struct CachedChunk {
-    code: Vec<u8>,
-    constants: Vec<Constant>,
-    lines: Vec<u32>,
-    columns: Vec<u32>,
-    source_file: Option<String>,
-    current_col: u32,
-    functions: Vec<CachedCompiledFunction>,
-    inline_cache_slots: BTreeMap<usize, usize>,
-    local_slots: Vec<LocalSlotInfo>,
+/// Serializable snapshot of a [`Chunk`] suitable for the on-disk bytecode
+/// cache and for in-memory stdlib artifact caches. Inline-cache state is
+/// dropped at freeze time because it warms at runtime per-process; the
+/// rest of the chunk round-trips byte-identically.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CachedChunk {
+    pub(crate) code: Vec<u8>,
+    pub(crate) constants: Vec<Constant>,
+    pub(crate) lines: Vec<u32>,
+    pub(crate) columns: Vec<u32>,
+    pub(crate) source_file: Option<String>,
+    pub(crate) current_col: u32,
+    pub(crate) functions: Vec<CachedCompiledFunction>,
+    pub(crate) inline_cache_slots: BTreeMap<usize, usize>,
+    pub(crate) local_slots: Vec<LocalSlotInfo>,
 }
 
-#[derive(Debug, Clone)]
-pub(crate) struct CachedCompiledFunction {
-    name: String,
-    type_params: Vec<String>,
-    nominal_type_names: Vec<String>,
-    params: Vec<ParamSlot>,
-    default_start: Option<usize>,
-    chunk: CachedChunk,
-    is_generator: bool,
-    is_stream: bool,
-    has_rest_param: bool,
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CachedCompiledFunction {
+    pub(crate) name: String,
+    pub(crate) type_params: Vec<String>,
+    pub(crate) nominal_type_names: Vec<String>,
+    pub(crate) params: Vec<ParamSlot>,
+    pub(crate) default_start: Option<usize>,
+    pub(crate) chunk: CachedChunk,
+    pub(crate) is_generator: bool,
+    pub(crate) is_stream: bool,
+    pub(crate) has_rest_param: bool,
 }
 
 /// One parameter slot of a compiled user-defined function. Carries the
@@ -519,7 +524,7 @@ pub(crate) struct CachedCompiledFunction {
 /// for whether a default value was provided. The runtime consults the
 /// type expression in `bind_param_slots` to enforce declared types
 /// against the values supplied at the call site.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ParamSlot {
     pub name: String,
     /// Declared parameter type. `None` for untyped parameters (gradual
@@ -826,7 +831,7 @@ impl Chunk {
         }
     }
 
-    pub(crate) fn freeze_for_cache(&self) -> CachedChunk {
+    pub fn freeze_for_cache(&self) -> CachedChunk {
         CachedChunk {
             code: self.code.clone(),
             constants: self.constants.clone(),
@@ -844,7 +849,7 @@ impl Chunk {
         }
     }
 
-    pub(crate) fn from_cached(cached: &CachedChunk) -> Self {
+    pub fn from_cached(cached: &CachedChunk) -> Self {
         let inline_cache_count = cached.inline_cache_slots.len();
         Self {
             code: cached.code.clone(),

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -13,6 +13,7 @@ pub mod atomic_io;
 pub mod autonomy;
 pub mod bridge;
 mod builtin_id;
+pub mod bytecode_cache;
 pub mod checkpoint;
 mod chunk;
 mod compiler;

--- a/docs/perf/bytecode-cache.md
+++ b/docs/perf/bytecode-cache.md
@@ -1,0 +1,137 @@
+# Bytecode cache (`.harnbc`)
+
+Short-lived `harn` invocations spend the bulk of their wall time before
+the VM executes a single instruction: read the source, lex it, parse it,
+run the type checker, compile the AST to a bytecode chunk. Cold-start
+for the kind of subcommand burin-code is porting into `.harn`
+(`burin keys list`, `burin status`, `burin diagnose`) is dominated by
+that pipeline — the LLM/HTTP/IO work the script eventually performs
+goes through the same builtins on every run.
+
+The bytecode cache eliminates that fixed cost when nothing in the input
+graph has changed. The runtime hashes the entry source + every
+transitively-imported user file, looks for a `.harnbc` artifact whose
+header matches, and on a hit goes straight from "load bytecode" to
+"start VM."
+
+## File format
+
+Little-endian throughout. Every cache file starts with this header:
+
+```text
+magic        : [u8; 8]   = "HARNBC\0\0"
+schema_ver   : u32       = 1
+version_len  : u32
+harn_version : [u8; version_len]
+source_hash  : [u8; 32]   sha256(entry source)
+import_hash  : [u8; 32]   sha256(sorted import graph contents)
+payload      : bincode-serialized CachedChunk
+```
+
+Mismatch on any of magic / schema / harn_version / source_hash /
+import_hash triggers a silent recompile and rewrite. A future Harn
+release that bumps the schema can simply increment `SCHEMA_VERSION`
+in `crates/harn-vm/src/bytecode_cache.rs`; older binaries reject the
+file as a header mismatch instead of panicking inside `bincode`.
+
+## Cache directory
+
+Resolution order:
+
+1. `$HARN_CACHE_DIR` (explicit override; used by tests + CI).
+2. `$XDG_CACHE_HOME/harn/bytecode`.
+3. `$HOME/.cache/harn/bytecode`.
+4. `./.harn-cache/bytecode` (fallback for hermetic environments with no
+   `$HOME`).
+
+The directory is created lazily on the first cache write. The cache is
+process-local; there is no IPC, no shared lock file, and no need for
+one — atomic rename gives the runtime concurrent-safe writes without a
+mutex.
+
+Concurrent invocations of the same script race on the rename: the last
+writer wins, but every reader sees a consistent file because rename is
+atomic on every supported filesystem.
+
+## Cache key
+
+The on-disk filename is `<hex(source_hash)>.harnbc`. We key by the
+content of the entry file alone so two invocations from different
+`PATH`-relative locations share one cache entry; the in-file
+`import_hash` then guards against stale reuse when an imported file
+changes but the entry stays identical.
+
+`source_hash` is sha256 of the entry file's bytes.
+`import_hash` is sha256 of the canonical path + content of every user
+file transitively reachable through `import` declarations. `std/…`
+imports are excluded because the embedded `harn_version` covers them.
+Unresolved imports still contribute a fixed sentinel so dropping a
+matching file into place later invalidates the cache.
+
+The import scan is a lightweight string walk, not a full lex/parse:
+it strips comments and looks for `import "path"` and
+`import { … } from "path"` patterns. False positives (e.g. an unrelated
+string starting with `import` inside a heredoc) only churn the cache;
+they never produce an incorrect bytecode load.
+
+## Loader / writer flow
+
+`harn run script.harn` resolves the cache like this:
+
+1. Read the source from disk (always — needed for runtime error
+   reporting via `vm.set_source_info`).
+2. Compute the cache key.
+3. Look for an adjacent `script.harnbc` (shipped artifacts win over the
+   shared cache so release builds avoid touching `$HOME`).
+4. Look for `$HARN_CACHE_DIR/<source_hash>.harnbc`.
+5. On a hit, deserialize the payload and execute. Parse, type-check,
+   and compile are all skipped: the writer ran them.
+6. On a miss, parse + type-check + compile, then atomically write
+   the artifact back into the shared cache. Write failures are
+   best-effort and silent unless `HARN_BYTECODE_CACHE_DEBUG=1`.
+
+`harn precompile <path>` runs the same compile path and writes the
+artifact directly to disk. Pass a directory to walk it; otherwise it
+compiles a single file. `--out DIR` mirrors the input layout under
+`DIR`; without `--out`, artifacts land adjacent to each source. Burin
+Code's release pipeline runs `harn precompile` against its bundled
+`Sources/BurinCore/Resources/pipelines/` so the shipped DMG already
+contains a `.harnbc` for every script the user might run.
+
+## Toggles and environment
+
+- `HARN_CACHE_DIR=<path>` — relocate the cache directory.
+- `HARN_BYTECODE_CACHE=0` — disable both reads and writes (compiler
+  debugging, deterministic eval reruns).
+- `HARN_BYTECODE_CACHE_DEBUG=1` — surface cache write failures.
+
+## Type-check warnings on cache hit
+
+Cache hits skip parse + type-check, which means non-fatal type-check
+warnings (e.g. deprecated-builtin notices) are not re-emitted from a
+cached invocation. The warning was emitted once when the cache wrote
+the artifact, and it re-emits whenever the cache busts. `harn check`
+remains the canonical surface for the complete diagnostic list — use
+it if you need every warning every time, or set
+`HARN_BYTECODE_CACHE=0` to force a fresh compile.
+
+## Out of scope
+
+- JIT (LLVM/Cranelift). Interpreted bytecode plus the cache is enough
+  for the cold-start gate that gates the burin-code thin-rust epic.
+- Cross-process shared cache / IPC.
+- Standalone artifact loading without source. The current loader
+  recomputes the key from the on-disk source, so the source has to
+  exist. Shipping bytecode without source would require dropping the
+  rehash and trusting the embedded hash — a follow-on if the
+  burin-code release pipeline grows that constraint.
+- Caching of imported modules. The cache short-circuits parse +
+  type-check + compile of the **entry** pipeline only; runtime
+  `Op::Import` still re-parses and re-compiles every imported user
+  file and stdlib module on each process invocation. For burin-code's
+  short subcommands the entry pipeline is the dominant per-invocation
+  cost, but for pipelines that depend on a large stdlib surface the
+  remaining import cost is the next target. The `CachedChunk` /
+  `CachedCompiledFunction` serde shape already supports the same
+  on-disk format, so the follow-on plug-point is `execute_import` in
+  `crates/harn-vm/src/vm/modules.rs`.

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -159,6 +159,7 @@
 - [Annotation tape format](./dev/annotation-tape-format.md)
 - [DES runtime mode](./dev/des-mode.md)
 - [VM and stdlib perf notes](./dev/vm-stdlib-perf-notes.md)
+- [Bytecode cache](./perf/bytecode-cache.md)
 
 # Tutorials and Guides
 

--- a/docs/src/perf/bytecode-cache.md
+++ b/docs/src/perf/bytecode-cache.md
@@ -1,0 +1,3 @@
+# Bytecode cache
+
+{{#include ../../perf/bytecode-cache.md:3:}}

--- a/scripts/bench_vm.sh
+++ b/scripts/bench_vm.sh
@@ -7,23 +7,40 @@ iterations="${HARN_BENCH_ITERATIONS:-20}"
 baseline_file=""
 build_release=1
 harn_bin="${HARN_BIN:-}"
+mode="loop"
+startup_runs="${HARN_BENCH_STARTUP_RUNS:-5}"
 
 usage() {
   cat <<'EOF'
 Usage: scripts/bench_vm.sh [--iterations N] [--baseline FILE] [--no-build]
+                           [--cold-start | --warm-start] [--startup-runs N]
 
 Runs the deterministic VM microbenchmark fixture set with the release harn
 binary and prints one row per benchmark.
 
+Modes:
+  (default)        Use `harn bench` to time the inner pipeline loop,
+                   excluding parse/compile cost. Best for VM-only signal.
+  --cold-start     Time end-to-end `harn run` with the bytecode cache
+                   wiped between runs. Captures parse + typecheck +
+                   compile + VM cost — the latency the user sees on a
+                   fresh checkout or after a cache eviction.
+  --warm-start     Time `harn run` with the cache pre-warmed. Captures
+                   parse-skip + bytecode-load + VM cost — the latency a
+                   developer feels on every subsequent invocation.
+
 Options:
-  -n, --iterations N  Number of harn bench iterations per fixture (default: 20)
-  --baseline FILE     Markdown baseline table to compare average wall time
-  --no-build          Skip cargo build --release --bin harn
-  -h, --help          Show this help
+  -n, --iterations N    `harn bench` iterations per fixture (default: 20)
+  --startup-runs N      cold/warm-start measurement runs per fixture
+                        (default: 5)
+  --baseline FILE       Markdown baseline table to compare average wall time
+  --no-build            Skip cargo build --release --bin harn
+  -h, --help            Show this help
 
 Environment:
   HARN_BIN                  Override the harn binary path
-  HARN_BENCH_ITERATIONS     Default iteration count
+  HARN_BENCH_ITERATIONS     Default iteration count for loop mode
+  HARN_BENCH_STARTUP_RUNS   Default per-fixture runs for cold/warm modes
   HARN_BENCH_FIXTURES_DIR   Override fixture directory
   CARGO_TARGET_DIR          Cargo target directory for release builds
 EOF
@@ -51,6 +68,22 @@ while [[ $# -gt 0 ]]; do
       build_release=0
       shift
       ;;
+    --cold-start)
+      mode="cold-start"
+      shift
+      ;;
+    --warm-start)
+      mode="warm-start"
+      shift
+      ;;
+    --startup-runs)
+      if [[ $# -lt 2 ]]; then
+        echo "error: --startup-runs requires a value" >&2
+        exit 2
+      fi
+      startup_runs="${2:-}"
+      shift 2
+      ;;
     -h|--help)
       usage
       exit 0
@@ -65,6 +98,11 @@ done
 
 if ! [[ "$iterations" =~ ^[1-9][0-9]*$ ]]; then
   echo "error: --iterations must be a positive integer" >&2
+  exit 2
+fi
+
+if ! [[ "$startup_runs" =~ ^[1-9][0-9]*$ ]]; then
+  echo "error: --startup-runs must be a positive integer" >&2
   exit 2
 fi
 
@@ -121,40 +159,160 @@ extract_metric() {
   sed -nE "s/.*${key} ([0-9]+([.][0-9]+)?) ms.*/\\1/p" <<<"$line"
 }
 
-printf "%-28s %10s %10s %10s %10s" "benchmark" "iterations" "min_ms" "avg_ms" "max_ms"
-if [[ -n "$baseline_file" ]]; then
-  printf " %14s %10s" "baseline_avg" "delta"
-fi
-printf "\n"
+# Time a single end-to-end `harn run` invocation and print elapsed
+# milliseconds to stdout. Falls through to `python3 -c` because
+# `/usr/bin/time -p` does not exist on every host the bench runs on and
+# `date +%N` is missing on macOS. `python3` is a soft dep of the dev
+# workflow.
+time_run_ms() {
+  local fixture="$1"
+  python3 - "$harn_bin" "$fixture" <<'PY'
+import os, subprocess, sys, time
+binary, fixture = sys.argv[1], sys.argv[2]
+start = time.perf_counter()
+result = subprocess.run(
+    [binary, "run", fixture],
+    stdout=subprocess.DEVNULL,
+    stderr=subprocess.PIPE,
+    env={**os.environ},
+)
+elapsed_ms = (time.perf_counter() - start) * 1000.0
+if result.returncode != 0:
+    sys.stderr.write(result.stderr.decode("utf-8", errors="replace"))
+    sys.exit(result.returncode)
+print(f"{elapsed_ms:.3f}")
+PY
+}
 
-status=0
-for fixture in "${fixtures[@]}"; do
-  benchmark="$(basename "$fixture" .harn)"
-  output="$("$harn_bin" bench "$fixture" --iterations "$iterations")" || status=$?
-  if [[ "$status" -ne 0 ]]; then
-    printf "%s\n" "$output" >&2
-    exit "$status"
+# Aggregate `time_run_ms` across $startup_runs invocations and print
+# `min avg max` triple in milliseconds.
+aggregate_runs() {
+  local fixture="$1"
+  python3 - "$harn_bin" "$fixture" "$startup_runs" <<'PY'
+import os, subprocess, sys, time
+binary, fixture, runs = sys.argv[1], sys.argv[2], int(sys.argv[3])
+samples = []
+for _ in range(runs):
+    start = time.perf_counter()
+    result = subprocess.run(
+        [binary, "run", fixture],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        env={**os.environ},
+    )
+    elapsed_ms = (time.perf_counter() - start) * 1000.0
+    if result.returncode != 0:
+        sys.stderr.write(result.stderr.decode("utf-8", errors="replace"))
+        sys.exit(result.returncode)
+    samples.append(elapsed_ms)
+mn, mx = min(samples), max(samples)
+avg = sum(samples) / len(samples)
+print(f"{mn:.3f} {avg:.3f} {mx:.3f}")
+PY
+}
+
+clear_cache_dir() {
+  if [[ -n "${HARN_CACHE_DIR:-}" && -d "$HARN_CACHE_DIR" ]]; then
+    rm -rf "$HARN_CACHE_DIR"
   fi
+}
 
-  wall_line="$(awk '/^Wall time:/ { print; exit }' <<<"$output")"
-  min_ms="$(extract_metric "$wall_line" "min")"
-  avg_ms="$(extract_metric "$wall_line" "avg")"
-  max_ms="$(extract_metric "$wall_line" "max")"
-  if [[ ! "$min_ms" =~ ^[0-9]+([.][0-9]+)?$ || ! "$avg_ms" =~ ^[0-9]+([.][0-9]+)?$ || ! "$max_ms" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
-    echo "error: failed to parse wall-time metrics from harn bench output for $fixture" >&2
-    printf "%s\n" "$output" >&2
-    exit 1
-  fi
-
-  printf "%-28s %10s %10s %10s %10s" "$benchmark" "$iterations" "$min_ms" "$avg_ms" "$max_ms"
+if [[ "$mode" == "loop" ]]; then
+  printf "%-28s %10s %10s %10s %10s" "benchmark" "iterations" "min_ms" "avg_ms" "max_ms"
   if [[ -n "$baseline_file" ]]; then
-    baseline_avg="$(baseline_avg_for "$benchmark" "$baseline_file")"
-    if [[ "$baseline_avg" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
-      delta="$(awk -v current="$avg_ms" -v baseline="$baseline_avg" 'BEGIN { printf "%+.1f%%", ((current - baseline) / baseline) * 100.0 }')"
-      printf " %14s %10s" "$baseline_avg" "$delta"
-    else
-      printf " %14s %10s" "-" "-"
-    fi
+    printf " %14s %10s" "baseline_avg" "delta"
   fi
   printf "\n"
+
+  status=0
+  for fixture in "${fixtures[@]}"; do
+    benchmark="$(basename "$fixture" .harn)"
+    output="$("$harn_bin" bench "$fixture" --iterations "$iterations")" || status=$?
+    if [[ "$status" -ne 0 ]]; then
+      printf "%s\n" "$output" >&2
+      exit "$status"
+    fi
+
+    wall_line="$(awk '/^Wall time:/ { print; exit }' <<<"$output")"
+    min_ms="$(extract_metric "$wall_line" "min")"
+    avg_ms="$(extract_metric "$wall_line" "avg")"
+    max_ms="$(extract_metric "$wall_line" "max")"
+    if [[ ! "$min_ms" =~ ^[0-9]+([.][0-9]+)?$ || ! "$avg_ms" =~ ^[0-9]+([.][0-9]+)?$ || ! "$max_ms" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+      echo "error: failed to parse wall-time metrics from harn bench output for $fixture" >&2
+      printf "%s\n" "$output" >&2
+      exit 1
+    fi
+
+    printf "%-28s %10s %10s %10s %10s" "$benchmark" "$iterations" "$min_ms" "$avg_ms" "$max_ms"
+    if [[ -n "$baseline_file" ]]; then
+      baseline_avg="$(baseline_avg_for "$benchmark" "$baseline_file")"
+      if [[ "$baseline_avg" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+        delta="$(awk -v current="$avg_ms" -v baseline="$baseline_avg" 'BEGIN { printf "%+.1f%%", ((current - baseline) / baseline) * 100.0 }')"
+        printf " %14s %10s" "$baseline_avg" "$delta"
+      else
+        printf " %14s %10s" "-" "-"
+      fi
+    fi
+    printf "\n"
+  done
+  exit 0
+fi
+
+# Cold/warm-start mode. Drives `harn run` end-to-end and times the full
+# CLI invocation, capturing parse + typecheck + compile + bytecode-load +
+# VM startup. We rely on a process-local cache directory so that the
+# benchmark can wipe the cache between runs without touching the user's
+# real ~/.cache.
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "error: cold/warm-start modes require python3 in PATH" >&2
+  exit 2
+fi
+
+bench_cache_dir="${HARN_BENCH_CACHE_DIR:-$repo_root/target/harn-bench-cache}"
+export HARN_CACHE_DIR="$bench_cache_dir"
+mkdir -p "$bench_cache_dir"
+
+printf "%-28s %10s %10s %10s %10s\n" \
+  "benchmark[$mode]" "runs" "min_ms" "avg_ms" "max_ms"
+
+for fixture in "${fixtures[@]}"; do
+  benchmark="$(basename "$fixture" .harn)"
+  case "$mode" in
+    cold-start)
+      # Wipe the cache between every measurement so each run pays the
+      # full parse+compile cost.
+      samples_min="" samples_avg="" samples_max=""
+      mn="" avg="" mx=""
+      total_min="" total_max="" total_sum="0"
+      for ((i = 0; i < startup_runs; i++)); do
+        clear_cache_dir
+        mkdir -p "$bench_cache_dir"
+        elapsed_ms="$(time_run_ms "$fixture")"
+        if [[ -z "${total_min}" ]] || awk "BEGIN{exit !($elapsed_ms < $total_min)}"; then
+          total_min="$elapsed_ms"
+        fi
+        if [[ -z "${total_max}" ]] || awk "BEGIN{exit !($elapsed_ms > $total_max)}"; then
+          total_max="$elapsed_ms"
+        fi
+        total_sum="$(awk -v s="$total_sum" -v v="$elapsed_ms" 'BEGIN{printf "%.6f", s+v}')"
+      done
+      avg="$(awk -v s="$total_sum" -v n="$startup_runs" 'BEGIN{printf "%.3f", s/n}')"
+      mn="$total_min"
+      mx="$total_max"
+      ;;
+    warm-start)
+      # Warm the cache once, then time `startup_runs` invocations.
+      clear_cache_dir
+      mkdir -p "$bench_cache_dir"
+      "$harn_bin" run "$fixture" >/dev/null
+      read -r mn avg mx < <(aggregate_runs "$fixture")
+      ;;
+  esac
+
+  if [[ ! "$mn" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+    echo "error: failed to measure $fixture" >&2
+    exit 1
+  fi
+  printf "%-28s %10s %10s %10s %10s\n" \
+    "$benchmark" "$startup_runs" "$mn" "$avg" "$mx"
 done


### PR DESCRIPTION
## Summary

Closes #1710 (gates [burin-code#814](https://github.com/burin-labs/burin-code/issues/814)).

- New `crates/harn-vm/src/bytecode_cache.rs` persists compiled pipeline IR under `$HARN_CACHE_DIR/<sha256-of-source>.harnbc` (XDG-aware, `HARN_CACHE_DIR` override). Header records magic + `SCHEMA_VERSION` + `harn_version` + source hash + transitive-import-graph hash; any mismatch falls back to a transparent recompile (no panic on a future-version artifact). Atomic writes via write-tmp-then-rename, race-safe for concurrent invocations.
- `harn run` now loads from the cache before parsing: adjacent `<source>.harnbc` first, shared cache dir second. Cache hit skips parse + typecheck + compile entirely. Cache miss compiles normally and writes the artifact best-effort.
- New `harn precompile <path>` subcommand walks a file or directory and produces `.harnbc` artifacts adjacent to source (or under `--out`). Used by burin-code's release pipeline to ship pre-compiled artifacts so end-user cold-start is one `fopen` + `bincode::deserialize` instead of full parse + compile.
- `scripts/bench_vm.sh` gains `--cold-start` / `--warm-start` modes that drive `harn run` end-to-end against the existing fixture corpus, wiping/pre-warming the cache between runs.
- Docs at `docs/perf/bytecode-cache.md` (mirrored into mdbook via `docs/src/perf/bytecode-cache.md`).

## Test plan

- [x] `cargo test -p harn-vm --lib bytecode_cache` — 7 unit tests (header round-trip, header mismatch, comment / string-literal scan, env toggle, order-independent import hash, nested-import invalidation).
- [x] `cargo test -p harn-cli --test bytecode_cache` — 4 integration tests covering source-edit invalidation, transitively-imported file invalidation, `harn precompile` → `harn run` round-trip, and `HARN_BYTECODE_CACHE=0` disables writes.
- [x] `cargo test -p harn-vm --lib` — 2062 existing tests pass after serde derives on `Constant` / `CachedChunk` / `ParamSlot` / `TypeExpr`.
- [x] `cargo clippy --workspace --tests -- -D warnings`.
- [x] `npx markdownlint-cli2 "**/*.md"`.
- [x] Manual cold/warm bench end-to-end: cache file is created, source edits and transitive-import edits both invalidate, adjacent precompiled `.harnbc` satisfies the loader without populating the shared dir.

## Follow-ups (not in this PR)

- Caching of stdlib + user-imported modules. The cache short-circuits parse + typecheck + compile for the **entry** pipeline only; `Op::Import` at runtime still re-parses and re-compiles every imported module on each invocation. The `CachedChunk` / `CachedCompiledFunction` serde shape already supports the same on-disk format, so the natural plug-point is `execute_import` in `crates/harn-vm/src/vm/modules.rs`. Documented at the bottom of `docs/perf/bytecode-cache.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)