### PR TITLE
acp: mid-session model swap via session/set_config_option (#1721)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,17 @@ condensed series summaries instead of full per-patch history.
   under `crates/harn-hostlib/schemas/secret_store/` keep `harn check`
   preflight covering the new builtins. Docs at
   `docs/src/hostlib/secret_store.md`.
+- **ACP `session/set_config_option(configId="model")` (#1721).**
+  Generalized the config-option dispatch table from a hardcoded
+  `mode`-only branch to a registry covering `mode` and `model`.
+  Pinning a model writes a per-session selector that the LLM resolver
+  (`vm_resolve_model` / `vm_resolve_provider`) honours for subsequent
+  prompts without touching the transcript, tool-call audit log, or
+  memory context. Per-call `model:` options still win, and clearing
+  the pin (`value: "@inherit"`) reverts to the ambient default. Closes
+  the editor `/model` workaround that hinted "takes effect after
+  `/clear`" — the new wire path matches the mid-session model swap
+  Crush / OpenCode / Codex already ship.
 - **Cerebras provider (#1705).** Added a first-class `cerebras` provider
   routed through the OpenAI-compatible stack with a `provider_family =
   "openai"` capability inheritance row. Catalog ships canonical

--- a/crates/harn-cli/tests/acp_server_cli.rs
+++ b/crates/harn-cli/tests/acp_server_cli.rs
@@ -333,6 +333,146 @@ fn acp_session_fork_branches_runtime_state_and_dispatches_independently() {
     assert!(status.success(), "status={status}");
 }
 
+/// Round-trip the v1 mid-session model swap: pin a model via
+/// `session/set_config_option(configId="model")`, observe the
+/// `config_option_update` notification, and verify the next
+/// `session/prompt` sees the pin reflected in `agent_session_snapshot`.
+/// Locks the wire contract from #1721 against future regressions.
+#[ignore = "binary surface — moves to slow E2E/smoke job (issue #1069)"]
+#[test]
+fn acp_session_set_config_option_model_pins_for_next_prompt() {
+    let _guard = lock_acp_cli_tests();
+    let temp = TempDir::new().unwrap();
+    write_file(
+        temp.path(),
+        "pin_fixture.harn",
+        r#"
+pub pipeline main() {
+  let sid = agent_session_current_id()
+  guard sid != nil else { throw "ACP prompt installs the current session id" }
+  let snap = agent_session_snapshot(sid)
+  println(
+    json_stringify({
+      session_id: sid,
+      pinned_model: snap["pinned_model"],
+    }),
+  )
+}
+"#,
+    );
+
+    let mut child = harn_e2e_command()
+        .current_dir(temp.path())
+        .arg("serve")
+        .arg("acp")
+        .arg("pin_fixture.harn")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+
+    let mut stdin = child.stdin.take().unwrap();
+    let mut stdout = BufReader::new(child.stdout.take().unwrap());
+
+    let (_, _init) = send_request(
+        &mut stdin,
+        &mut stdout,
+        json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {},
+        }),
+    );
+
+    let (_, created) = send_request(
+        &mut stdin,
+        &mut stdout,
+        json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "session/new",
+            "params": {"cwd": temp.path()},
+        }),
+    );
+    let session_id = created["result"]["sessionId"].as_str().unwrap().to_string();
+    // Freshly created sessions have no model pinned — the `model`
+    // config option must advertise the inherit sentinel.
+    let model_option = created["result"]["configOptions"]
+        .as_array()
+        .expect("configOptions array")
+        .iter()
+        .find(|entry| entry["id"] == "model")
+        .expect("model config option in session/new response");
+    assert_eq!(model_option["currentValue"], "@inherit");
+
+    let (_pin_notifications, pin_ack) = send_request(
+        &mut stdin,
+        &mut stdout,
+        json!({
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "session/set_config_option",
+            "params": {
+                "sessionId": session_id,
+                "configId": "model",
+                "value": "claude-sonnet-4-6",
+            },
+        }),
+    );
+    let ack_model = pin_ack["result"]["configOptions"]
+        .as_array()
+        .expect("configOptions array")
+        .iter()
+        .find(|entry| entry["id"] == "model")
+        .expect("model config option in ack");
+    assert_eq!(ack_model["currentValue"], "claude-sonnet-4-6");
+
+    // The `config_option_update` notification is emitted *after* the
+    // ack (matching the `session/set_mode` convention), so it lands in
+    // the notification buffer of the *next* request rather than the
+    // one that triggered it.
+    let (prompt_notifications, prompt_response) = send_request(
+        &mut stdin,
+        &mut stdout,
+        json!({
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "session/prompt",
+            "params": {
+                "sessionId": session_id,
+                "prompt": [{"type": "text", "text": "irrelevant"}],
+            },
+        }),
+    );
+    assert_eq!(prompt_response["result"]["stopReason"], "end_turn");
+    let summary = latest_prompt_summary(&prompt_notifications, &session_id);
+    assert_eq!(summary["pinned_model"], "claude-sonnet-4-6");
+
+    let saw_update = prompt_notifications.iter().any(|message| {
+        message["method"] == "session/update"
+            && message["params"]["sessionId"] == session_id
+            && message["params"]["update"]["sessionUpdate"] == "config_option_update"
+            && message["params"]["update"]["configOptions"]
+                .as_array()
+                .map(|entries| {
+                    entries.iter().any(|entry| {
+                        entry["id"] == "model" && entry["currentValue"] == "claude-sonnet-4-6"
+                    })
+                })
+                .unwrap_or(false)
+    });
+    assert!(
+        saw_update,
+        "set_config_option(model) must emit config_option_update reflecting the pin"
+    );
+
+    drop(stdin);
+    let status = child.wait().unwrap();
+    assert!(status.success(), "status={status}");
+}
+
 #[ignore = "binary surface — moves to slow E2E/smoke job (issue #1069)"]
 #[test]
 fn acp_session_truncate_mutates_runtime_state_in_place() {

--- a/crates/harn-serve/src/adapters/acp/mod.rs
+++ b/crates/harn-serve/src/adapters/acp/mod.rs
@@ -650,7 +650,10 @@ impl AcpServer {
             serde_json::json!({
                 "sessionId": session_id,
                 "modes": modes::session_mode_state(modes::DEFAULT_MODE_ID),
-                "configOptions": modes::config_options_state(modes::DEFAULT_MODE_ID),
+                "configOptions": modes::config_options_state(
+                    modes::DEFAULT_MODE_ID,
+                    self.pinned_model(&session_id).as_deref(),
+                ),
             }),
         );
 
@@ -857,7 +860,10 @@ impl AcpServer {
                 "parent_id": src_id,
                 "branched_at": branched_at,
                 "modes": modes::session_mode_state(&parent_mode_id),
-                "configOptions": modes::config_options_state(&parent_mode_id),
+                "configOptions": modes::config_options_state(
+                    &parent_mode_id,
+                    self.pinned_model(&new_session_id).as_deref(),
+                ),
             }),
         );
     }
@@ -1467,7 +1473,10 @@ impl AcpServer {
             serde_json::json!({
                 "session": session_value,
                 "modes": modes::session_mode_state(&session.current_mode_id),
-                "configOptions": modes::config_options_state(&session.current_mode_id),
+                "configOptions": modes::config_options_state(
+                    &session.current_mode_id,
+                    harn_vm::agent_sessions::pinned_model(session_id).as_deref(),
+                ),
                 "replayed": replayed,
             }),
         );
@@ -1490,6 +1499,34 @@ impl AcpServer {
         Ok(true)
     }
 
+    /// Pin (or clear, with `None`) the LLM model selector for `session_id`.
+    /// Returns `Ok(true)` when the value changed so callers can decide
+    /// whether to broadcast a `config_option_update` notification.
+    ///
+    /// The harn-vm session is auto-created if it doesn't exist yet (e.g.
+    /// when a client pins a model before its first prompt), keeping
+    /// the wire surface order-independent.
+    fn set_session_model(
+        &mut self,
+        session_id: &str,
+        model: Option<String>,
+    ) -> Result<bool, String> {
+        if !self.sessions.contains_key(session_id) {
+            return Err(format!("Unknown session: {session_id}"));
+        }
+        if !harn_vm::agent_sessions::exists(session_id) {
+            harn_vm::agent_sessions::open_or_create(Some(session_id.to_string()));
+        }
+        harn_vm::agent_sessions::set_pinned_model(session_id, model)
+    }
+
+    /// Read the currently pinned model for `session_id`, if any. Returns
+    /// `None` for unknown sessions or sessions running on the ambient
+    /// default — both are indistinguishable on the wire.
+    fn pinned_model(&self, session_id: &str) -> Option<String> {
+        harn_vm::agent_sessions::pinned_model(session_id)
+    }
+
     fn emit_current_mode_update(&self, session_id: &str, mode_id: &str) {
         self.send_notification(
             "session/update",
@@ -1510,7 +1547,10 @@ impl AcpServer {
                 "sessionId": session_id,
                 "update": {
                     "sessionUpdate": "config_option_update",
-                    "configOptions": modes::config_options_state(mode_id),
+                    "configOptions": modes::config_options_state(
+                        mode_id,
+                        self.pinned_model(session_id).as_deref(),
+                    ),
                 },
             }),
         );
@@ -1559,30 +1599,80 @@ impl AcpServer {
             self.send_error(id, -32602, "session/set_config_option requires configId");
             return;
         };
-        if config_id != "mode" {
-            self.send_error(
-                id,
-                -32602,
-                &format!("Unknown config option '{config_id}'. Available: mode"),
-            );
-            return;
-        }
-        let Some(mode_id) = params.get("value").and_then(serde_json::Value::as_str) else {
+        let Some(value) = params.get("value").and_then(serde_json::Value::as_str) else {
             self.send_error(id, -32602, "session/set_config_option requires value");
             return;
         };
 
+        let session_id = session_id.to_string();
+        match config_id {
+            "mode" => self.apply_set_mode_config_option(id, &session_id, value),
+            "model" => self.apply_set_model_config_option(id, &session_id, value),
+            other => self.send_error(
+                id,
+                -32602,
+                &format!("Unknown config option '{other}'. Available: mode, model"),
+            ),
+        }
+    }
+
+    fn apply_set_mode_config_option(
+        &mut self,
+        id: &serde_json::Value,
+        session_id: &str,
+        mode_id: &str,
+    ) {
         match self.set_session_mode(session_id, mode_id) {
             Ok(changed) => {
                 self.send_response(
                     id,
                     serde_json::json!({
-                        "configOptions": modes::config_options_state(mode_id),
+                        "configOptions": modes::config_options_state(
+                            mode_id,
+                            self.pinned_model(session_id).as_deref(),
+                        ),
                     }),
                 );
                 if changed {
                     self.emit_current_mode_update(session_id, mode_id);
                     self.emit_config_option_update(session_id, mode_id);
+                }
+            }
+            Err(message) => self.send_error(id, -32602, &message),
+        }
+    }
+
+    fn apply_set_model_config_option(
+        &mut self,
+        id: &serde_json::Value,
+        session_id: &str,
+        raw_value: &str,
+    ) {
+        let normalized = match modes::validate_model_selector(raw_value) {
+            Ok(value) => value,
+            Err(message) => {
+                self.send_error(id, -32602, &message);
+                return;
+            }
+        };
+        match self.set_session_model(session_id, normalized.clone()) {
+            Ok(changed) => {
+                let current_mode_id = self
+                    .sessions
+                    .get(session_id)
+                    .map(|session| session.current_mode_id.clone())
+                    .unwrap_or_else(|| modes::DEFAULT_MODE_ID.to_string());
+                self.send_response(
+                    id,
+                    serde_json::json!({
+                        "configOptions": modes::config_options_state(
+                            &current_mode_id,
+                            normalized.as_deref(),
+                        ),
+                    }),
+                );
+                if changed {
+                    self.emit_config_option_update(session_id, &current_mode_id);
                 }
             }
             Err(message) => self.send_error(id, -32602, &message),

--- a/crates/harn-serve/src/adapters/acp/modes.rs
+++ b/crates/harn-serve/src/adapters/acp/modes.rs
@@ -69,10 +69,20 @@ pub(super) fn session_mode_state(current_mode_id: &str) -> serde_json::Value {
     })
 }
 
-/// Render the preferred ACP `configOptions` representation for the same mode
-/// catalog. ACP clients that understand this field should prefer it over
-/// `modes`; Harn keeps both in sync while the protocol transitions.
-pub(super) fn config_options_state(current_mode_id: &str) -> serde_json::Value {
+/// Render the preferred ACP `configOptions` representation for the
+/// per-session knobs Harn exposes today: session mode plus pinned LLM
+/// model. Both entries follow the `select` shape (the only `type` the
+/// current spec defines, per
+/// <https://agentclientprotocol.com/protocol/session-config-options>).
+///
+/// New knobs (temperature, permissions, …) plug in here by appending
+/// another entry rather than introducing a new wire surface; ACP keeps
+/// `configId` open-ended so clients can ignore unknown ids without
+/// breaking.
+pub(super) fn config_options_state(
+    current_mode_id: &str,
+    pinned_model: Option<&str>,
+) -> serde_json::Value {
     serde_json::json!([
         {
             "id": "mode",
@@ -82,7 +92,8 @@ pub(super) fn config_options_state(current_mode_id: &str) -> serde_json::Value {
             "type": "select",
             "currentValue": current_mode_id,
             "options": mode_entries("value"),
-        }
+        },
+        model_config_option(pinned_model),
     ])
 }
 
@@ -100,6 +111,128 @@ fn mode_entries(id_key: &str) -> Vec<serde_json::Value> {
             serde_json::Value::Object(entry)
         })
         .collect()
+}
+
+/// Sentinel option value rendered on the model selector when no
+/// session-level pin is active. Picking it through
+/// `session/set_config_option` clears any prior pin and reverts the
+/// session to the ambient default (env / providers.toml).
+///
+/// Spec note: the ACP `ConfigOption.currentValue` field has
+/// `minLength: 1`, so an empty string can't represent "unpinned".
+/// `@inherit` is a stable sentinel that satisfies the schema and
+/// clearly signals "fall through to the ambient default" instead of
+/// being mistaken for a real model id.
+pub(super) const MODEL_INHERIT_VALUE: &str = "@inherit";
+
+fn model_config_option(pinned_model: Option<&str>) -> serde_json::Value {
+    serde_json::json!({
+        "id": "model",
+        "name": "LLM Model",
+        "description": "Pinned model for subsequent prompts. llm_call invocations without an \
+                        explicit `model:` option resolve to this selector. Aliases and \
+                        `provider:model` selectors are both accepted; pick `@inherit` to clear \
+                        the pin and revert to the ambient default.",
+        "category": "model",
+        "type": "select",
+        "currentValue": pinned_model.unwrap_or(MODEL_INHERIT_VALUE),
+        "options": model_select_options(pinned_model),
+    })
+}
+
+/// Curated list of model values the spec-mandated `select` renders.
+/// Anything that resolves through `harn_vm::llm_config::resolve_model_info`
+/// to a registered provider is accepted by the handler — the dropdown is
+/// a UI hint, not the enforcement boundary.
+fn model_select_options(pinned_model: Option<&str>) -> Vec<serde_json::Value> {
+    let mut entries: Vec<serde_json::Value> = Vec::new();
+    entries.push(serde_json::json!({
+        "value": MODEL_INHERIT_VALUE,
+        "name": "Inherit ambient default",
+        "description": "Clear any session-level pin and use HARN_LLM_MODEL / providers.toml.",
+    }));
+    let mut seen: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    for alias in harn_vm::llm_config::known_model_names() {
+        let resolved = harn_vm::llm_config::resolve_model_info(&alias);
+        let label = format!("{alias} ({}/{})", resolved.provider, resolved.id);
+        if seen.insert(alias.clone()) {
+            let description = if resolved.tier.is_empty() {
+                resolved.provider.clone()
+            } else {
+                format!("tier: {}", resolved.tier)
+            };
+            entries.push(serde_json::json!({
+                "value": alias,
+                "name": label,
+                "description": description,
+            }));
+        }
+    }
+    // The currently pinned selector may be a free-form id outside the
+    // alias catalog. Surface it so the dropdown reflects the real
+    // state instead of showing a stale "(none)" entry.
+    if let Some(pinned) = pinned_model.filter(|value| !value.is_empty()) {
+        if seen.insert(pinned.to_string()) {
+            entries.push(serde_json::json!({
+                "value": pinned,
+                "name": pinned,
+                "description": "Currently pinned (not in alias catalog).",
+            }));
+        }
+    }
+    entries
+}
+
+/// Validate a model selector for `session/set_config_option(configId="model")`.
+/// Returns the normalized selector (trimmed; aliases are kept verbatim so
+/// the session pin tracks the user's chosen handle) or a descriptive
+/// error suitable for surfacing as `invalid_model`.
+///
+/// The wire surface is intentionally curated: scripts that need ad-hoc
+/// selectors should pass `model:` directly to `llm_call`. Accepted forms:
+///
+/// - empty / whitespace → `Ok(None)` (clear pin sentinel)
+/// - `provider:model` / `provider/model` where provider is in `providers.toml`
+/// - an alias from `known_model_names()`
+/// - a model id present in `model_catalog_entries()`
+pub(super) fn validate_model_selector(raw: &str) -> Result<Option<String>, String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() || trimmed == MODEL_INHERIT_VALUE {
+        return Ok(None);
+    }
+    if let Some((provider, _model)) = split_provider_prefix(trimmed)
+        .filter(|(provider, model)| !provider.trim().is_empty() && !model.trim().is_empty())
+    {
+        if provider == "mock" || harn_vm::llm_config::provider_config(provider).is_some() {
+            return Ok(Some(trimmed.to_string()));
+        }
+        return Err(format!(
+            "invalid_model: provider '{provider}' is not registered. Available: {}",
+            harn_vm::llm_config::provider_names().join(", ")
+        ));
+    }
+    if harn_vm::llm_config::known_model_names()
+        .iter()
+        .any(|name| name == trimmed)
+    {
+        return Ok(Some(trimmed.to_string()));
+    }
+    if harn_vm::llm_config::model_catalog_entry(trimmed).is_some() {
+        return Ok(Some(trimmed.to_string()));
+    }
+    Err(format!(
+        "invalid_model: '{trimmed}' is not a known alias, catalog model id, or 'provider:model' form."
+    ))
+}
+
+/// Split a selector on the first provider-form separator. Both `:` and
+/// `/` are recognized because the two appear in the wild — Anthropic /
+/// OpenAI route paths use `/` (e.g. `anthropic/claude-opus-4-7`), while
+/// Ollama tag selectors use `:` (e.g. `ollama:llama3.2:latest`).
+fn split_provider_prefix(value: &str) -> Option<(&str, &str)> {
+    let position = value.find([':', '/'])?;
+    let (provider, rest) = value.split_at(position);
+    Some((provider, &rest[1..]))
 }
 
 /// Capability ceiling enforced while a prompt runs in this mode. Harn's
@@ -172,9 +305,9 @@ mod tests {
 
     #[test]
     fn config_options_state_contains_mode_selector() {
-        let state = config_options_state("code");
+        let state = config_options_state("code", None);
         let options = state.as_array().expect("config options array");
-        assert_eq!(options.len(), 1);
+        assert_eq!(options.len(), 2);
         assert_eq!(options[0]["id"], "mode");
         assert_eq!(options[0]["currentValue"], "code");
         assert!(options[0]["options"]
@@ -182,6 +315,78 @@ mod tests {
             .expect("mode options")
             .iter()
             .any(|m| m["value"] == "ask"));
+    }
+
+    #[test]
+    fn config_options_state_includes_model_selector_with_pin_clear_sentinel() {
+        let state = config_options_state("code", None);
+        let options = state.as_array().expect("config options array");
+        let model_option = options
+            .iter()
+            .find(|entry| entry["id"] == "model")
+            .expect("model config option");
+        assert_eq!(model_option["category"], "model");
+        assert_eq!(model_option["type"], "select");
+        assert_eq!(model_option["currentValue"], MODEL_INHERIT_VALUE);
+        let values: Vec<&str> = model_option["options"]
+            .as_array()
+            .expect("model options")
+            .iter()
+            .map(|entry| entry["value"].as_str().expect("value string"))
+            .collect();
+        assert!(
+            values.contains(&MODEL_INHERIT_VALUE),
+            "options must include the inherit sentinel: {values:?}"
+        );
+    }
+
+    #[test]
+    fn config_options_state_surfaces_free_form_pinned_model() {
+        let state = config_options_state("code", Some("custom-model-not-in-catalog"));
+        let model_option = state
+            .as_array()
+            .expect("config options array")
+            .iter()
+            .find(|entry| entry["id"] == "model")
+            .cloned()
+            .expect("model config option");
+        assert_eq!(model_option["currentValue"], "custom-model-not-in-catalog");
+        let has_entry = model_option["options"]
+            .as_array()
+            .expect("model options")
+            .iter()
+            .any(|entry| entry["value"] == "custom-model-not-in-catalog");
+        assert!(
+            has_entry,
+            "free-form pinned model must appear in select options"
+        );
+    }
+
+    #[test]
+    fn validate_model_selector_accepts_empty_as_clear_pin() {
+        assert!(validate_model_selector("").unwrap().is_none());
+        assert!(validate_model_selector("   ").unwrap().is_none());
+        assert!(validate_model_selector("@inherit").unwrap().is_none());
+    }
+
+    #[test]
+    fn validate_model_selector_accepts_known_alias() {
+        // `claude-sonnet-4-6` is the catalog default; any registered
+        // alias works for this check.
+        let resolved = validate_model_selector("claude-sonnet-4-6")
+            .expect("known alias should validate")
+            .expect("known alias should produce a Some(...) selector");
+        assert_eq!(resolved, "claude-sonnet-4-6");
+    }
+
+    #[test]
+    fn validate_model_selector_rejects_unknown_provider_form() {
+        let error = validate_model_selector("nosuchprovider:nosuchmodel")
+            .expect_err("unknown provider must error");
+        assert!(
+            error.contains("invalid_model"),
+            "error should be tagged invalid_model: {error}"
+        );
     }
 
     #[test]

--- a/crates/harn-serve/src/adapters/acp/tests/modes.rs
+++ b/crates/harn-serve/src/adapters/acp/tests/modes.rs
@@ -162,18 +162,31 @@ async fn acp_session_new_advertises_session_mode_state_and_config_options() {
     let config_options = created["result"]["configOptions"]
         .as_array()
         .expect("configOptions array");
-    assert_eq!(config_options.len(), 1);
-    assert_eq!(config_options[0]["id"], "mode");
-    assert_eq!(config_options[0]["category"], "mode");
-    assert_eq!(config_options[0]["type"], "select");
-    assert_eq!(config_options[0]["currentValue"], "ask");
-    let option_ids: Vec<&str> = config_options[0]["options"]
+    let mode_option = config_options
+        .iter()
+        .find(|entry| entry["id"] == "mode")
+        .expect("mode config option");
+    assert_eq!(mode_option["category"], "mode");
+    assert_eq!(mode_option["type"], "select");
+    assert_eq!(mode_option["currentValue"], "ask");
+    let option_ids: Vec<&str> = mode_option["options"]
         .as_array()
         .expect("mode options")
         .iter()
         .map(|mode| mode["value"].as_str().expect("mode value"))
         .collect();
     assert_eq!(option_ids, vec!["ask", "architect", "code", "shadow"]);
+
+    let model_option = config_options
+        .iter()
+        .find(|entry| entry["id"] == "model")
+        .expect("model config option");
+    assert_eq!(model_option["category"], "model");
+    assert_eq!(model_option["type"], "select");
+    // No model is pinned for a freshly created session — the dropdown
+    // should advertise the "inherit ambient default" sentinel as the
+    // current value so clients render an "unpinned" state.
+    assert_eq!(model_option["currentValue"], "@inherit");
 }
 
 /// `session/load` echoes the active mode state back to a
@@ -795,5 +808,210 @@ async fn acp_session_fork_inherits_parent_current_mode() {
     assert_eq!(
         fork_response["result"]["modes"]["currentModeId"],
         "architect"
+    );
+}
+
+/// Pinning a model via `session/set_config_option(configId="model")`
+/// updates the harn-vm session pin, surfaces the new value back in the
+/// response, and emits a `config_option_update` notification so other
+/// connected clients (e.g. additional editor panes) re-render the
+/// selector. Validates the v1 model-swap contract from #1721.
+#[tokio::test(flavor = "current_thread")]
+async fn acp_set_config_option_pins_model_and_emits_update() {
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let mut server = AcpServer::new_with_output(AcpServerConfig::new(None), AcpOutput::Channel(tx));
+
+    server
+        .handle_incoming_message(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "session/new",
+            "params": {"cwd": "."},
+        }))
+        .await;
+    let created = recv_json(&mut rx).await;
+    let session_id = created["result"]["sessionId"]
+        .as_str()
+        .expect("session id")
+        .to_string();
+
+    server
+        .handle_incoming_message(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "session/set_config_option",
+            "params": {
+                "sessionId": session_id,
+                "configId": "model",
+                "value": "claude-sonnet-4-6",
+            },
+        }))
+        .await;
+    let ack = recv_json(&mut rx).await;
+    assert_eq!(ack["id"], 2);
+    let pinned_value = ack["result"]["configOptions"]
+        .as_array()
+        .expect("configOptions array")
+        .iter()
+        .find(|entry| entry["id"] == "model")
+        .expect("model config option")
+        .get("currentValue")
+        .and_then(|v| v.as_str())
+        .expect("currentValue string");
+    assert_eq!(pinned_value, "claude-sonnet-4-6");
+
+    let notification = recv_json(&mut rx).await;
+    assert_eq!(notification["method"], "session/update");
+    assert_eq!(
+        notification["params"]["update"]["sessionUpdate"],
+        "config_option_update"
+    );
+    let pin_in_notification = notification["params"]["update"]["configOptions"]
+        .as_array()
+        .expect("configOptions in notification")
+        .iter()
+        .find(|entry| entry["id"] == "model")
+        .expect("model entry in notification")
+        .get("currentValue")
+        .and_then(|v| v.as_str())
+        .expect("currentValue string");
+    assert_eq!(pin_in_notification, "claude-sonnet-4-6");
+
+    assert_eq!(
+        harn_vm::agent_sessions::pinned_model(&session_id).as_deref(),
+        Some("claude-sonnet-4-6"),
+        "vm session state must reflect the pin"
+    );
+
+    // Clear the pin by sending the `@inherit` sentinel — empty strings
+    // would violate the spec's `currentValue` minLength constraint, so
+    // the wire surface uses a stable string instead.
+    server
+        .handle_incoming_message(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "session/set_config_option",
+            "params": {
+                "sessionId": session_id,
+                "configId": "model",
+                "value": "@inherit",
+            },
+        }))
+        .await;
+    let clear_ack = recv_json(&mut rx).await;
+    assert_eq!(clear_ack["id"], 3);
+    let cleared_value = clear_ack["result"]["configOptions"]
+        .as_array()
+        .expect("configOptions array")
+        .iter()
+        .find(|entry| entry["id"] == "model")
+        .expect("model config option")
+        .get("currentValue")
+        .and_then(|v| v.as_str())
+        .expect("currentValue string");
+    assert_eq!(cleared_value, "@inherit");
+    let _clear_notification = recv_json(&mut rx).await;
+    assert!(
+        harn_vm::agent_sessions::pinned_model(&session_id).is_none(),
+        "clearing the pin should remove the vm-side selector"
+    );
+}
+
+/// `session/set_config_option(configId="model")` rejects selectors that
+/// don't resolve to a registered provider — the wire surface stays
+/// distinct from the more permissive `provider/model` form a Harn
+/// script can pass to `llm_call`.
+#[tokio::test(flavor = "current_thread")]
+async fn acp_set_config_option_rejects_unknown_model_provider() {
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let mut server = AcpServer::new_with_output(AcpServerConfig::new(None), AcpOutput::Channel(tx));
+
+    server
+        .handle_incoming_message(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "session/new",
+            "params": {"cwd": "."},
+        }))
+        .await;
+    let created = recv_json(&mut rx).await;
+    let session_id = created["result"]["sessionId"]
+        .as_str()
+        .expect("session id")
+        .to_string();
+
+    server
+        .handle_incoming_message(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "session/set_config_option",
+            "params": {
+                "sessionId": session_id,
+                "configId": "model",
+                "value": "nosuchprovider:nosuchmodel",
+            },
+        }))
+        .await;
+    let response = recv_json(&mut rx).await;
+    assert_eq!(response["id"], 2);
+    assert_eq!(response["error"]["code"], -32602);
+    let message = response["error"]["message"]
+        .as_str()
+        .unwrap_or_default()
+        .to_string();
+    assert!(
+        message.contains("invalid_model"),
+        "error message should be tagged invalid_model: {message}"
+    );
+    assert!(
+        harn_vm::agent_sessions::pinned_model(&session_id).is_none(),
+        "rejected pin must not mutate vm session state"
+    );
+}
+
+/// Unknown `configId` values surface a structured error listing the
+/// supported ids, so clients can distinguish "spec drift" from
+/// "validation failure" without parsing the message.
+#[tokio::test(flavor = "current_thread")]
+async fn acp_set_config_option_rejects_unknown_config_id() {
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let mut server = AcpServer::new_with_output(AcpServerConfig::new(None), AcpOutput::Channel(tx));
+
+    server
+        .handle_incoming_message(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "session/new",
+            "params": {"cwd": "."},
+        }))
+        .await;
+    let created = recv_json(&mut rx).await;
+    let session_id = created["result"]["sessionId"]
+        .as_str()
+        .expect("session id")
+        .to_string();
+
+    server
+        .handle_incoming_message(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "session/set_config_option",
+            "params": {
+                "sessionId": session_id,
+                "configId": "temperature",
+                "value": "0.4",
+            },
+        }))
+        .await;
+    let response = recv_json(&mut rx).await;
+    assert_eq!(response["id"], 2);
+    assert_eq!(response["error"]["code"], -32602);
+    let message = response["error"]["message"]
+        .as_str()
+        .unwrap_or_default()
+        .to_string();
+    assert!(
+        message.contains("Unknown config option") && message.contains("model"),
+        "error message should advertise the registry's supported ids: {message}"
     );
 }

--- a/crates/harn-vm/src/agent_sessions.rs
+++ b/crates/harn-vm/src/agent_sessions.rs
@@ -52,6 +52,12 @@ pub struct SessionState {
     /// metadata, not a replay message: providers receive it through
     /// their system/developer instruction channel on each call.
     pub system_prompt: Option<String>,
+    /// Session-pinned model selector. When set, `llm_call` invocations
+    /// that do not pass an explicit `model:` option resolve to this
+    /// selector instead of `HARN_LLM_MODEL` / provider defaults. Mid-
+    /// session swap is exposed over ACP via `session/set_config_option`
+    /// (configId="model").
+    pub pinned_model: Option<String>,
 }
 
 impl SessionState {
@@ -70,6 +76,7 @@ impl SessionState {
             active_skills: Vec::new(),
             tool_format: None,
             system_prompt: None,
+            pinned_model: None,
         }
     }
 }
@@ -374,19 +381,21 @@ pub fn reset_transcript(id: &str) -> bool {
 /// operation itself can't make `src` look stale and kick it out of
 /// the LRU just to make room for the new fork.
 pub fn fork(src_id: &str, dst_id: Option<String>) -> Option<String> {
-    let (src_transcript, src_tool_format, src_system_prompt, dst) = SESSIONS.with(|s| {
-        let mut map = s.borrow_mut();
-        let src = map.get_mut(src_id)?;
-        src.last_accessed = Instant::now();
-        let dst = dst_id.unwrap_or_else(|| uuid::Uuid::now_v7().to_string());
-        let forked_transcript = clone_transcript_with_id(&src.transcript, &dst);
-        Some((
-            forked_transcript,
-            src.tool_format.clone(),
-            src.system_prompt.clone(),
-            dst,
-        ))
-    })?;
+    let (src_transcript, src_tool_format, src_system_prompt, src_pinned_model, dst) = SESSIONS
+        .with(|s| {
+            let mut map = s.borrow_mut();
+            let src = map.get_mut(src_id)?;
+            src.last_accessed = Instant::now();
+            let dst = dst_id.unwrap_or_else(|| uuid::Uuid::now_v7().to_string());
+            let forked_transcript = clone_transcript_with_id(&src.transcript, &dst);
+            Some((
+                forked_transcript,
+                src.tool_format.clone(),
+                src.system_prompt.clone(),
+                src.pinned_model.clone(),
+                dst,
+            ))
+        })?;
     // Ensure cap is respected when inserting the fork.
     open_or_create(Some(dst.clone()));
     SESSIONS.with(|s| {
@@ -395,6 +404,7 @@ pub fn fork(src_id: &str, dst_id: Option<String>) -> Option<String> {
             state.transcript = src_transcript;
             state.tool_format = src_tool_format;
             state.system_prompt = src_system_prompt;
+            state.pinned_model = src_pinned_model;
             state.last_accessed = Instant::now();
         }
         update_lineage(&mut map, src_id, &dst, None);
@@ -973,6 +983,37 @@ pub fn system_prompt(id: &str) -> Option<String> {
     })
 }
 
+/// Pin (or clear, with `None`) a model selector on a session. Returns
+/// `Ok(true)` when the value actually changed so callers can decide
+/// whether to broadcast a notification. The selector is stored verbatim
+/// — alias / catalog resolution is the call-site's job.
+pub fn set_pinned_model(id: &str, model: Option<String>) -> Result<bool, String> {
+    let normalized = model
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+    SESSIONS.with(|s| {
+        let mut map = s.borrow_mut();
+        let Some(state) = map.get_mut(id) else {
+            return Err(format!("agent session '{id}' does not exist"));
+        };
+        let changed = state.pinned_model != normalized;
+        state.pinned_model = normalized;
+        state.last_accessed = Instant::now();
+        Ok(changed)
+    })
+}
+
+/// Read the session's pinned model selector, if any. Consumed by
+/// `vm_resolve_model` as the per-session default when a script-level
+/// `llm_call` does not pass `model:` explicitly.
+pub fn pinned_model(id: &str) -> Option<String> {
+    SESSIONS.with(|s| {
+        s.borrow()
+            .get(id)
+            .and_then(|state| state.pinned_model.clone())
+    })
+}
+
 fn empty_transcript(id: &str) -> VmValue {
     use crate::llm::helpers::new_transcript_with;
     new_transcript_with(Some(id.to_string()), Vec::new(), None, None)
@@ -1115,6 +1156,14 @@ fn session_snapshot(state: &SessionState) -> VmValue {
             .tool_format
             .as_ref()
             .map(|format| VmValue::String(Rc::from(format.clone())))
+            .unwrap_or(VmValue::Nil),
+    );
+    next.insert(
+        "pinned_model".to_string(),
+        state
+            .pinned_model
+            .as_ref()
+            .map(|model| VmValue::String(Rc::from(model.clone())))
             .unwrap_or(VmValue::Nil),
     );
     VmValue::Dict(Rc::new(next))
@@ -1319,6 +1368,70 @@ mod tests {
             .is_some());
         assert_eq!(message_count(&id), 1);
         assert_eq!(event_count_by_kind(&id, "system_prompt"), 1);
+    }
+
+    #[test]
+    fn pinned_model_round_trips_through_session_state_and_snapshot() {
+        reset_session_store();
+        let id = open_or_create(Some("pinned-model-session".into()));
+
+        // Default: no pin.
+        assert!(pinned_model(&id).is_none());
+        let initial_snapshot = snapshot(&id).expect("session snapshot");
+        assert!(matches!(
+            initial_snapshot
+                .as_dict()
+                .and_then(|d| d.get("pinned_model")),
+            Some(VmValue::Nil)
+        ));
+
+        // First set returns changed=true; snapshot reflects the pin.
+        assert!(set_pinned_model(&id, Some("custom-model".into())).unwrap());
+        assert_eq!(pinned_model(&id).as_deref(), Some("custom-model"));
+        let pinned_snapshot = snapshot(&id).expect("session snapshot");
+        let pinned_value = pinned_snapshot
+            .as_dict()
+            .and_then(|d| d.get("pinned_model"))
+            .map(|v| v.display())
+            .unwrap_or_default();
+        assert_eq!(pinned_value, "custom-model");
+
+        // Re-setting to the same selector returns changed=false; no churn.
+        assert!(!set_pinned_model(&id, Some("custom-model".into())).unwrap());
+
+        // Whitespace-only input is normalized to None (clears the pin).
+        assert!(set_pinned_model(&id, Some("   ".into())).unwrap());
+        assert!(pinned_model(&id).is_none());
+
+        // Setting on an unknown session surfaces a descriptive error.
+        let error = set_pinned_model("ghost-session", Some("x".into())).unwrap_err();
+        assert!(
+            error.contains("ghost-session"),
+            "unknown-session error must name the session: {error}"
+        );
+    }
+
+    #[test]
+    fn fork_inherits_parent_pinned_model_so_branch_starts_on_same_route() {
+        reset_session_store();
+        let parent_id = open_or_create(Some("fork-pin-parent".into()));
+        set_pinned_model(&parent_id, Some("claude-sonnet-4-6".into())).unwrap();
+        let child_id = fork(&parent_id, Some("fork-pin-child".into())).expect("fork");
+
+        assert_eq!(
+            pinned_model(&child_id).as_deref(),
+            Some("claude-sonnet-4-6"),
+            "fork should mirror tool_format/system_prompt by carrying the parent's model pin",
+        );
+
+        // Independent state: re-pinning on the child must not affect
+        // the parent.
+        set_pinned_model(&child_id, Some("gpt-4o-mini".into())).unwrap();
+        assert_eq!(
+            pinned_model(&parent_id).as_deref(),
+            Some("claude-sonnet-4-6")
+        );
+        assert_eq!(pinned_model(&child_id).as_deref(), Some("gpt-4o-mini"));
     }
 
     #[test]

--- a/crates/harn-vm/src/llm/helpers/mod.rs
+++ b/crates/harn-vm/src/llm/helpers/mod.rs
@@ -444,4 +444,101 @@ mod tests {
 
         assert_eq!(resolved, "anthropic/claude-sonnet-4.6");
     }
+
+    #[test]
+    fn session_pinned_model_overrides_env_default_resolution() {
+        // ACP `session/set_config_option(configId="model")` writes a
+        // per-session pin via `agent_sessions::set_pinned_model`. The
+        // resolvers must surface that pin in place of the env-driven
+        // default so the next `llm_call` honours it without each
+        // builtin threading the session id manually.
+        let _guard = crate::llm::env_lock().lock().expect("env lock");
+        let prev_harn_model = std::env::var("HARN_LLM_MODEL").ok();
+        let prev_harn_provider = std::env::var("HARN_LLM_PROVIDER").ok();
+        unsafe {
+            std::env::set_var("HARN_LLM_MODEL", "gpt-4o-mini");
+            std::env::set_var("HARN_LLM_PROVIDER", "openai");
+        }
+        reset_provider_key_cache();
+
+        crate::agent_sessions::reset_session_store();
+        let id = crate::agent_sessions::open_or_create(Some("pinned-resolver-session".to_string()));
+        crate::agent_sessions::set_pinned_model(&id, Some("claude-sonnet-4-6".to_string()))
+            .expect("set pinned model");
+        let _session_guard = crate::agent_sessions::enter_current_session(id.clone());
+
+        let provider = vm_resolve_provider(&None);
+        let model = vm_resolve_model(&None, &provider);
+
+        // Drop the guard before mutating shared env to keep cleanup
+        // local even if the assertion below fails.
+        drop(_session_guard);
+        crate::agent_sessions::reset_session_store();
+        unsafe {
+            match prev_harn_model {
+                Some(value) => std::env::set_var("HARN_LLM_MODEL", value),
+                None => std::env::remove_var("HARN_LLM_MODEL"),
+            }
+            match prev_harn_provider {
+                Some(value) => std::env::set_var("HARN_LLM_PROVIDER", value),
+                None => std::env::remove_var("HARN_LLM_PROVIDER"),
+            }
+        }
+        reset_provider_key_cache();
+
+        assert_eq!(provider, "anthropic", "session pin should reroute provider");
+        assert_eq!(
+            model, "claude-sonnet-4-6",
+            "session pin should reroute model"
+        );
+    }
+
+    #[test]
+    fn explicit_call_site_model_wins_over_session_pin() {
+        let _guard = crate::llm::env_lock().lock().expect("env lock");
+        let prev_harn_model = std::env::var("HARN_LLM_MODEL").ok();
+        let prev_harn_provider = std::env::var("HARN_LLM_PROVIDER").ok();
+        unsafe {
+            std::env::remove_var("HARN_LLM_MODEL");
+            std::env::remove_var("HARN_LLM_PROVIDER");
+        }
+        reset_provider_key_cache();
+
+        crate::agent_sessions::reset_session_store();
+        let id =
+            crate::agent_sessions::open_or_create(Some("explicit-override-session".to_string()));
+        crate::agent_sessions::set_pinned_model(&id, Some("claude-sonnet-4-6".to_string()))
+            .expect("set pinned model");
+        let _session_guard = crate::agent_sessions::enter_current_session(id.clone());
+
+        // Call-site `model:` option must win — scripts opting into a
+        // specific model should not be silently overridden by an ACP
+        // pin meant only for "no-option" calls.
+        let mut explicit_opts: BTreeMap<String, VmValue> = BTreeMap::new();
+        explicit_opts.insert(
+            "model".to_string(),
+            VmValue::String(Rc::from("gpt-4o-mini")),
+        );
+        explicit_opts.insert("provider".to_string(), VmValue::String(Rc::from("openai")));
+        let opts = Some(explicit_opts);
+        let provider = vm_resolve_provider(&opts);
+        let model = vm_resolve_model(&opts, &provider);
+
+        drop(_session_guard);
+        crate::agent_sessions::reset_session_store();
+        unsafe {
+            match prev_harn_model {
+                Some(value) => std::env::set_var("HARN_LLM_MODEL", value),
+                None => std::env::remove_var("HARN_LLM_MODEL"),
+            }
+            match prev_harn_provider {
+                Some(value) => std::env::set_var("HARN_LLM_PROVIDER", value),
+                None => std::env::remove_var("HARN_LLM_PROVIDER"),
+            }
+        }
+        reset_provider_key_cache();
+
+        assert_eq!(provider, "openai");
+        assert_eq!(model, "gpt-4o-mini");
+    }
 }

--- a/crates/harn-vm/src/llm/helpers/provider.rs
+++ b/crates/harn-vm/src/llm/helpers/provider.rs
@@ -113,6 +113,16 @@ fn infer_provider_from_model_selector(raw_model: &str, warn_on_default: bool) ->
     inference.provider
 }
 
+/// Read the pinned model selector for the session currently on the
+/// VM's session stack, if any. Used by `vm_resolve_provider` /
+/// `vm_resolve_model` to honour ACP `session/set_config_option`
+/// (configId="model") swaps without each builtin needing to thread the
+/// session id manually.
+fn current_session_pinned_model() -> Option<String> {
+    let id = crate::agent_sessions::current_session_id()?;
+    crate::agent_sessions::pinned_model(&id)
+}
+
 fn env_selected_model_for_tier() -> Option<(String, String)> {
     use crate::llm_config;
 
@@ -257,6 +267,9 @@ pub(crate) fn vm_resolve_provider(options: &Option<BTreeMap<String, VmValue>>) -
             return infer_provider_from_model_selector(&m, true);
         }
     }
+    if let Some(pinned) = current_session_pinned_model() {
+        return infer_provider_from_model_selector(&pinned, true);
+    }
     if let Ok(p) = std::env::var("HARN_LLM_PROVIDER") {
         return p;
     }
@@ -323,6 +336,14 @@ pub(crate) fn vm_resolve_model(
         .map(|v| v.display())
     {
         if let Some((resolved, _)) = resolve_available_tier_model(&tier, Some(provider)) {
+            return resolved;
+        }
+    }
+    if let Some(pinned) = current_session_pinned_model() {
+        let (resolved, resolved_provider) = llm_config::resolve_model(&pinned);
+        let inferred_provider =
+            resolved_provider.unwrap_or_else(|| infer_provider_from_model_selector(&pinned, false));
+        if inferred_provider == provider {
             return resolved;
         }
     }

--- a/docs/src/mcp-and-acp.md
+++ b/docs/src/mcp-and-acp.md
@@ -490,7 +490,7 @@ The ACP server supports these JSON-RPC methods:
 | `session/prompt` | Send a prompt to the agent for execution |
 | `session/cancel` | Cancel the currently running prompt |
 | `session/set_mode` | Switch the active session mode |
-| `session/set_config_option` | Switch a preferred ACP session config option such as `mode` |
+| `session/set_config_option` | Switch a preferred ACP session config option (`mode` or `model`) |
 | `workflow/signal` | Enqueue a workflow signal message in the current session workspace |
 | `workflow/query` | Read a named workflow query value from the current session workspace |
 | `workflow/update` | Send a workflow update request and wait for a response |
@@ -574,6 +574,17 @@ it; Harn keeps `modes` available for clients still on `session/set_mode`.
         { "value": "code",      "name": "Code",      "description": "..." },
         { "value": "shadow",    "name": "Shadow",    "description": "..." }
       ]
+    },
+    {
+      "id": "model",
+      "name": "LLM Model",
+      "category": "model",
+      "type": "select",
+      "currentValue": "@inherit",
+      "options": [
+        { "value": "@inherit",         "name": "Inherit ambient default", "description": "..." },
+        { "value": "claude-sonnet-4-6", "name": "claude-sonnet-4-6 (anthropic/claude-sonnet-4-6)", "description": "tier: frontier" }
+      ]
     }
   ],
   "modes": {
@@ -637,6 +648,57 @@ policy from the same `AutonomyTier` machinery used by trigger dispatch, so
 ACP sessions and runtime autonomy stay aligned. The conformance case
 `acp_architect_mode_blocks_destructive_writes_in_prompt` locks this behavior
 end-to-end.
+
+### Session Model Pin
+
+`session/set_config_option(configId="model")` pins an LLM model selector on
+the session so subsequent `llm_call` invocations without an explicit
+`model:` option resolve to the pinned value instead of the
+`HARN_LLM_MODEL` / providers.toml default. This is the wire surface
+behind editor `/model` commands (Crush, OpenCode `<leader>m`, Codex
+`/model`) and replaces the "the change takes effect after `/clear`"
+workaround.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 42,
+  "method": "session/set_config_option",
+  "params": {
+    "sessionId": "sess_abc",
+    "configId": "model",
+    "value": "claude-sonnet-4-6"
+  }
+}
+```
+
+Accepted selector forms:
+
+- a known alias from the llm.toml catalog (e.g. `claude-sonnet-4-6`)
+- an explicit `provider:model` or `provider/model` pair where the
+  provider is in `providers.toml`
+- a model id present in the catalog (`model_catalog_entry`)
+
+Setting the value to the sentinel `"@inherit"` (also accepted: empty
+string) clears the pin and reverts the session to the ambient default.
+The ACP wire surface is intentionally curated; scripts that need
+ad-hoc selectors still pass `model:` directly to `llm_call`.
+
+Per-call options always win over the pin — invoking
+`llm_call(..., {model: "..."})` ignores the session pin so prompts that
+deliberately route to a different model aren't silently rebound. The
+existing conversation buffer, transcript metadata, and memory context
+are untouched by a model swap; only the resolver for the next prompt's
+default model changes. Pinning rejects unregistered providers with a
+`-32602` error tagged `invalid_model`.
+
+Notification semantics match `mode`: a `session/update` with
+`sessionUpdate: "config_option_update"` is emitted whenever the pin
+actually changes (re-pinning to the same selector is a silent ack).
+`session/fork` carries the parent's pin over to the new branch
+(matching how `tool_format` and the session-level system prompt
+inherit), so a branch starts with the same effective model as the
+parent. Setting a different pin on the child stays local.
 
 ### Queued user messages during agent execution
 


### PR DESCRIPTION
## Summary

- Generalizes `session/set_config_option` from a hardcoded `mode`-only branch into a configId registry (`mode` + `model` for v1).
- Pinning a model via `configId="model"` writes a per-session selector that `vm_resolve_provider` / `vm_resolve_model` honour for subsequent prompts, leaving the conversation buffer, tool-call audit log, and memory context untouched.
- Per-call `model:` options always win; the wire surface is intentionally curated (aliases, catalog model ids, or `provider:model` forms with a registered provider) and rejects unknown providers with a `-32602` error tagged `invalid_model`.

Closes [#1721](https://github.com/burin-labs/harn/issues/1721).

## Implementation notes

- `harn_vm::agent_sessions::set_pinned_model` / `pinned_model` are the in-VM primitives. `fork()` carries the pin to branches alongside `tool_format` and `system_prompt`.
- `vm_resolve_provider` / `vm_resolve_model` consult the current session pin between explicit options and env defaults via a thin `current_session_pinned_model` shim, so per-call `model:` is unaffected.
- `modes::config_options_state` now renders the model selector alongside the mode selector. ACP `ConfigOption.currentValue` has `minLength: 1`, so the "unpinned" state uses the `@inherit` sentinel rather than an empty string.
- `validate_model_selector` enforces the curated wire surface; ad-hoc selectors still work through `llm_call(..., {model: "..."})`.
- New `apply_set_mode_config_option` / `apply_set_model_config_option` split keeps each handler focused and ready for the next registry entry (temperature, permissions, …).

## Test plan

- [x] `cargo test -p harn-vm -p harn-serve --lib` (2068+93 unit tests pass, includes 7 new tests covering pin round-trip, fork inheritance, resolver precedence, ACP dispatch, and validation)
- [x] `cargo test -p harn-cli --test acp_server_cli acp_session_set_config_option_model_pins_for_next_prompt -- --ignored` (full stdio round-trip from `set_config_option` through next prompt's session snapshot)
- [x] `cargo clippy -p harn-vm -p harn-serve --lib --tests` clean
- [x] `make all` Rust gate passes (portal-check fails only because this worktree lacks `npm install`; unrelated)
- [x] Docs updated (`docs/src/mcp-and-acp.md`) with the new wire shape and selector semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)