### PR TITLE
Implement ACP session/resume

### DIFF
--- a/crates/harn-cli/src/commands/dump_protocol_artifacts.rs
+++ b/crates/harn-cli/src/commands/dump_protocol_artifacts.rs
@@ -28,6 +28,8 @@ use serde_json::json;
 const ACP_AGENT_METHODS: &[&str] = &[
     "initialize",
     "session/new",
+    "session/load",
+    "session/resume",
     "session/prompt",
     "session/truncate",
     "session/stop",

--- a/crates/harn-cli/src/commands/orchestrator/listener/tests.rs
+++ b/crates/harn-cli/src/commands/orchestrator/listener/tests.rs
@@ -460,6 +460,7 @@ async fn acp_websocket_requires_configured_bearer_auth() {
         response["result"]["agentCapabilities"]["sessionCapabilities"],
         json!({
             "list": {},
+            "resume": {},
         })
     );
     assert!(

--- a/crates/harn-cli/tests/acp_server_cli.rs
+++ b/crates/harn-cli/tests/acp_server_cli.rs
@@ -163,6 +163,7 @@ fn acp_session_fork_branches_runtime_state_and_dispatches_independently() {
         init["result"]["agentCapabilities"]["sessionCapabilities"],
         json!({
             "list": {},
+            "resume": {},
         })
     );
     assert!(init["result"]["agentCapabilities"]["sessionCapabilities"]

--- a/crates/harn-serve/src/adapters/acp/mod.rs
+++ b/crates/harn-serve/src/adapters/acp/mod.rs
@@ -1413,21 +1413,8 @@ impl AcpServer {
         }
     }
 
-    async fn handle_session_load(&mut self, id: &serde_json::Value, params: &serde_json::Value) {
-        let Some(session_id) = params
-            .get("sessionId")
-            .or_else(|| params.get("session_id"))
-            .and_then(serde_json::Value::as_str)
-        else {
-            self.send_error(id, -32602, "session/load requires sessionId");
-            return;
-        };
-
-        let Some(session) = self.sessions.get(session_id) else {
-            self.send_error(id, -32004, &format!("Session not found: {session_id}"));
-            return;
-        };
-
+    fn session_restore_result(&self, session_id: &str) -> Option<serde_json::Value> {
+        let session = self.sessions.get(session_id)?;
         let mut session_value = serde_json::json!({
             "sessionId": session_id,
             "cwd": session.cwd.display().to_string(),
@@ -1438,6 +1425,45 @@ impl AcpServer {
         if !session.info.meta.is_empty() {
             session_value["_meta"] = serde_json::Value::Object(session.info.meta.clone());
         }
+
+        Some(serde_json::json!({
+            "session": session_value,
+            "modes": modes::session_mode_state(&session.current_mode_id),
+            "configOptions": modes::config_options_state(
+                &session.current_mode_id,
+                self.pinned_model(session_id).as_deref(),
+            ),
+        }))
+    }
+
+    fn restored_session_id<'a>(
+        &self,
+        id: &serde_json::Value,
+        params: &'a serde_json::Value,
+        method: &str,
+    ) -> Option<&'a str> {
+        let Some(session_id) = params
+            .get("sessionId")
+            .or_else(|| params.get("session_id"))
+            .and_then(serde_json::Value::as_str)
+        else {
+            self.send_error(id, -32602, &format!("{method} requires sessionId"));
+            return None;
+        };
+
+        if !self.sessions.contains_key(session_id) {
+            self.send_error(id, -32602, &format!("unknown session: {session_id}"));
+            return None;
+        };
+
+        harn_vm::agent_sessions::open_or_create(Some(session_id.to_string()));
+        Some(session_id)
+    }
+
+    async fn handle_session_load(&mut self, id: &serde_json::Value, params: &serde_json::Value) {
+        let Some(session_id) = self.restored_session_id(id, params, "session/load") else {
+            return;
+        };
 
         let replay_events =
             match harn_vm::orchestration::load_agent_session_replay_events(session_id).await {
@@ -1468,18 +1494,21 @@ impl AcpServer {
             })
             .collect();
 
-        self.send_response(
-            id,
-            serde_json::json!({
-                "session": session_value,
-                "modes": modes::session_mode_state(&session.current_mode_id),
-                "configOptions": modes::config_options_state(
-                    &session.current_mode_id,
-                    harn_vm::agent_sessions::pinned_model(session_id).as_deref(),
-                ),
-                "replayed": replayed,
-            }),
-        );
+        let mut result = self
+            .session_restore_result(session_id)
+            .expect("validated session should still exist");
+        result["replayed"] = serde_json::json!(replayed);
+        self.send_response(id, result);
+    }
+
+    fn handle_session_resume(&self, id: &serde_json::Value, params: &serde_json::Value) {
+        let Some(session_id) = self.restored_session_id(id, params, "session/resume") else {
+            return;
+        };
+        let result = self
+            .session_restore_result(session_id)
+            .expect("validated session should still exist");
+        self.send_response(id, result);
     }
 
     fn set_session_mode(&mut self, session_id: &str, mode_id: &str) -> Result<bool, String> {
@@ -1715,6 +1744,12 @@ impl AcpServer {
                     return;
                 }
                 self.handle_session_load(&id, &params).await;
+            }
+            "session/resume" => {
+                if self.reject_unauthenticated(&id) {
+                    return;
+                }
+                self.handle_session_resume(&id, &params);
             }
             "session/fork" => {
                 if self.reject_unauthenticated(&id) {

--- a/crates/harn-serve/src/adapters/acp/schema.rs
+++ b/crates/harn-serve/src/adapters/acp/schema.rs
@@ -177,6 +177,7 @@ pub(super) fn acp_agent_capabilities() -> serde_json::Value {
         },
         "sessionCapabilities": {
             "list": {},
+            "resume": {},
         },
     })
 }

--- a/crates/harn-serve/src/adapters/acp/tests.rs
+++ b/crates/harn-serve/src/adapters/acp/tests.rs
@@ -267,6 +267,7 @@ fn acp_agent_capabilities_use_canonical_initialize_shape() {
         capabilities["sessionCapabilities"],
         serde_json::json!({
             "list": {},
+            "resume": {},
         })
     );
     assert!(

--- a/crates/harn-serve/src/adapters/acp/tests/modes.rs
+++ b/crates/harn-serve/src/adapters/acp/tests/modes.rs
@@ -245,6 +245,104 @@ async fn acp_session_load_includes_current_mode_state() {
         .any(|m| m["id"] == "architect"));
 }
 
+/// `session/resume` restores the same session mode/config state as
+/// `session/load`, but it must not replay persisted `session/update`
+/// notifications before responding.
+#[tokio::test(flavor = "current_thread")]
+async fn acp_session_resume_includes_current_mode_state_without_replay() {
+    harn_vm::event_log::reset_active_event_log();
+    let _log = harn_vm::event_log::install_memory_for_current_thread(64);
+
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let mut server = AcpServer::new_with_output(AcpServerConfig::new(None), AcpOutput::Channel(tx));
+
+    server
+        .handle_incoming_message(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "session/new",
+            "params": {"cwd": "."},
+        }))
+        .await;
+    let created = recv_json(&mut rx).await;
+    let session_id = created["result"]["sessionId"]
+        .as_str()
+        .expect("session id")
+        .to_string();
+
+    server
+        .handle_incoming_message(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "session/set_mode",
+            "params": {"sessionId": session_id, "modeId": "architect"},
+        }))
+        .await;
+    let _ack = recv_json(&mut rx).await;
+    let _mode_notification = recv_json(&mut rx).await;
+    let _config_notification = recv_json(&mut rx).await;
+
+    harn_vm::agent_events::emit_event(&harn_vm::agent_events::AgentEvent::AgentMessageChunk {
+        session_id: session_id.clone(),
+        content: "do not replay me".to_string(),
+    });
+    tokio::task::yield_now().await;
+
+    server
+        .handle_incoming_message(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "session/resume",
+            "params": {"sessionId": session_id},
+        }))
+        .await;
+    let resumed = recv_json(&mut rx).await;
+    assert_eq!(resumed["id"], 3);
+    assert!(resumed.get("method").is_none(), "resume must respond first");
+    assert_eq!(resumed["result"]["modes"]["currentModeId"], "architect");
+    assert_eq!(
+        resumed["result"]["configOptions"][0]["currentValue"],
+        "architect"
+    );
+    assert!(
+        resumed["result"].get("replayed").is_none(),
+        "session/resume must not include replay metadata"
+    );
+    assert!(
+        rx.try_recv().is_err(),
+        "session/resume must not emit replay notifications"
+    );
+
+    harn_vm::agent_events::clear_session_sinks(created["result"]["sessionId"].as_str().unwrap());
+    harn_vm::event_log::reset_active_event_log();
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn acp_session_restore_methods_reject_unknown_sessions() {
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let mut server = AcpServer::new_with_output(AcpServerConfig::new(None), AcpOutput::Channel(tx));
+
+    for (id, method) in [(1, "session/load"), (2, "session/resume")] {
+        server
+            .handle_incoming_message(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "method": method,
+                "params": {"sessionId": "missing-session"},
+            }))
+            .await;
+        let response = recv_json(&mut rx).await;
+        assert_eq!(response["id"], id);
+        assert_eq!(response["error"]["code"], -32602);
+        assert!(
+            response["error"]["message"]
+                .as_str()
+                .is_some_and(|message| message.contains("unknown session")),
+            "unexpected error for {method}: {response}"
+        );
+    }
+}
+
 #[tokio::test(flavor = "current_thread")]
 async fn acp_session_load_replays_persisted_agent_events() {
     harn_vm::event_log::reset_active_event_log();

--- a/crates/harn-serve/src/adapters/acp/tests/sessions.rs
+++ b/crates/harn-serve/src/adapters/acp/tests/sessions.rs
@@ -146,6 +146,7 @@ async fn acp_server_handles_session_flow_and_prompt_updates() {
                 initialize["result"]["agentCapabilities"]["sessionCapabilities"],
                 serde_json::json!({
                     "list": {},
+                    "resume": {},
                 })
             );
             assert!(

--- a/spec/protocol-artifacts/HarnProtocol.swift
+++ b/spec/protocol-artifacts/HarnProtocol.swift
@@ -74,6 +74,8 @@ public enum HarnProtocolConstants {
 public enum HarnACPAgentMethod: String, Codable, Sendable, CaseIterable {
     case initialize = "initialize"
     case sessionNew = "session/new"
+    case sessionLoad = "session/load"
+    case sessionResume = "session/resume"
     case sessionPrompt = "session/prompt"
     case sessionTruncate = "session/truncate"
     case sessionStop = "session/stop"

--- a/spec/protocol-artifacts/go/harnprotocol/harnprotocol.go
+++ b/spec/protocol-artifacts/go/harnprotocol/harnprotocol.go
@@ -31,6 +31,8 @@ type ACPAgentMethod = string
 var ACPAgentMethods = []ACPAgentMethod{
 	"initialize",
 	"session/new",
+	"session/load",
+	"session/resume",
 	"session/prompt",
 	"session/truncate",
 	"session/stop",

--- a/spec/protocol-artifacts/harn-protocol.ts
+++ b/spec/protocol-artifacts/harn-protocol.ts
@@ -6,6 +6,8 @@ export const HARN_PROTOCOL_ARTIFACT_VERSION = "0.8.22"
 export const ACP_AGENT_METHODS = [
   "initialize",
   "session/new",
+  "session/load",
+  "session/resume",
   "session/prompt",
   "session/truncate",
   "session/stop",

--- a/spec/protocol-artifacts/manifest.json
+++ b/spec/protocol-artifacts/manifest.json
@@ -34,6 +34,8 @@
     "agentMethods": [
       "initialize",
       "session/new",
+      "session/load",
+      "session/resume",
       "session/prompt",
       "session/truncate",
       "session/stop"

--- a/spec/protocol-artifacts/python/harn_protocol.py
+++ b/spec/protocol-artifacts/python/harn_protocol.py
@@ -97,6 +97,8 @@ MCP_PROTOCOL_VERSION: str = "2025-11-25"
 ACP_AGENT_METHODS: tuple = (
     "initialize",
     "session/new",
+    "session/load",
+    "session/resume",
     "session/prompt",
     "session/truncate",
     "session/stop",
@@ -312,6 +314,8 @@ MCP_LOGGING_LEVELS: tuple = (
 class ACPAgentMethod(str, Enum):
     INITIALIZE = "initialize"
     SESSION_NEW = "session/new"
+    SESSION_LOAD = "session/load"
+    SESSION_RESUME = "session/resume"
     SESSION_PROMPT = "session/prompt"
     SESSION_TRUNCATE = "session/truncate"
     SESSION_STOP = "session/stop"


### PR DESCRIPTION
## Summary
- Add ACP `session/resume` as a silent restore path that shares `session/load` state restoration without replaying persisted `session/update` notifications.
- Advertise `sessionCapabilities.resume` and align unknown restore-session errors on `-32602`.
- Regenerate protocol artifacts so downstream bindings include `session/load` and `session/resume` alongside current ACP methods.

Closes #1726

## Verification
- `CARGO_TARGET_DIR=/tmp/harn-target-6f36-1726 cargo test -p harn-serve adapters::acp::tests -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-6f36-1726 cargo test -p harn-cli --lib commands::orchestrator::listener::tests::acp_websocket_requires_configured_bearer_auth -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-6f36-1726 cargo test -p harn-cli --test acp_server_cli -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-6f36-1726 make check-protocol-artifacts`
- `make check-bindings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/lint_test_patterns.sh`
- `CARGO_TARGET_DIR=/tmp/harn-target-6f36-1726 cargo clippy -p harn-serve --lib --tests -- -D warnings`
- pre-commit hook: full workspace clippy and repo checks
- pre-push hook: targeted local checks