### PR TITLE
Add staged filesystem hostlib mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ Pre-0.6 highlights live in [CHANGELOG-pre-0.6.md](CHANGELOG-pre-0.6.md).
 Harn had no external users before 0.6.0, so that archive intentionally keeps
 condensed series summaries instead of full per-patch history.
 
+## Unreleased
+
+### Added
+
+- **Staged filesystem hostlib mode (#1722).** Adds the `fs/` hostlib
+  capability with `hostlib_fs_set_mode`, `hostlib_fs_staged_status`,
+  `hostlib_fs_commit_staged`, and `hostlib_fs_discard_staged`.
+  Sessions can switch to deferred writes stored under
+  `.harn/state/staged/<session_id>/`; hostlib file reads, directory
+  listings, outlines, AST parse-file calls, and code-index file reads
+  see pending changes before disk, while commit/discard controls apply
+  or drop the accumulated diff. ACP hosts can drive the same mode with
+  `session/fs_mode` and `session/fs_commit_staged`, and receive
+  `session/update` progress notifications tagged
+  `_meta.harn.kind = "staged_writes_pending"`.
+
 ## v0.8.22
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2300,6 +2300,7 @@ dependencies = [
  "base64",
  "filetime",
  "futures",
+ "harn-hostlib",
  "harn-parser",
  "harn-vm",
  "hex",

--- a/crates/harn-cli/Cargo.toml
+++ b/crates/harn-cli/Cargo.toml
@@ -92,7 +92,7 @@ default = ["hostlib"]
 # server. Default-on so `harn run`-driven scripts that name a hostlib
 # builtin work without extra flags. Disable with `--no-default-features` if
 # you want a slimmer build that doesn't pull tree-sitter/notify/etc.
-hostlib = ["dep:harn-hostlib"]
+hostlib = ["dep:harn-hostlib", "harn-serve/hostlib"]
 
 [dev-dependencies]
 hmac = "0.13"

--- a/crates/harn-hostlib/README.md
+++ b/crates/harn-hostlib/README.md
@@ -9,6 +9,8 @@ Opt-in host builtins for the Harn VM that provide:
    file I/O, directory listing, file outline, git inspection (`gix`), file
    watching (`notify`), and process lifecycle (`run_command`, `run_test`,
    `run_build_command`, `inspect_test_results`, `manage_packages`).
+3. **Session filesystem staging** — per-session deferred writes, deletes,
+   read-through overlays, status reporting, commit, and discard.
 
 ## Status
 
@@ -30,6 +32,10 @@ host builtins (`query`, `rebuild`, `stats`, `imports_for`,
 [#569](https://github.com/burin-labs/harn/issues/569) lights up the
 `fs_watch` surface: cross-platform `notify` subscriptions with
 debounced AgentEvent batches.
+[#1722](https://github.com/burin-labs/harn/issues/1722) lights up the
+`fs` surface: deferred filesystem writes stored under
+`.harn/state/staged/<session_id>/` with read-through overlays and ACP
+commit controls.
 
 ### `ast/` languages
 
@@ -89,6 +95,7 @@ and commit the updated goldens.
 | #567  | `tools/` (read & search) | `search`, `read_file`, `list_directory`, `get_file_outline`, `git`                 | ✅ shipped |
 | #567  | `tools/` (mutating)      | `write_file`, `delete_file`                                                        | ✅ shipped |
 | #568  | `tools/` (process)       | `run_command`, `run_test`, `run_build_command`, `inspect_test_results`, `manage_packages` | ✅ shipped |
+| #1722 | `fs/`                    | `set_mode`, `staged_status`, `commit_staged`, `discard_staged`                    | ✅ shipped |
 
 ### Process tools
 
@@ -193,6 +200,31 @@ Embedders that want to enable the surface from Rust without going through
 the builtin can use [`tools::permissions::enable_for_test`] (test-only)
 or call `tools::permissions::enable("tools:deterministic")` directly.
 
+## Staged filesystem mode
+
+`fs/` adds a session-scoped deferred-write layer for hosts that want an
+agent to build a cumulative diff before touching the working tree.
+
+- `hostlib_fs_set_mode({ session_id, mode: "immediate" | "staged",
+  root? })` switches the session and returns `{ previous_mode }`.
+- `hostlib_fs_staged_status({ session_id })` returns pending writes,
+  deletes, byte counts, and the age of the oldest pending change.
+- `hostlib_fs_commit_staged({ session_id, paths? })` applies all pending
+  changes, or only the selected paths, and reports per-path failures.
+- `hostlib_fs_discard_staged({ session_id, paths? })` drops pending
+  changes without mutating the working tree.
+
+While a session is in `staged` mode, `tools/write_file` and
+`tools/delete_file` write to `.harn/state/staged/<session_id>/` instead
+of the target path. `tools/read_file`, `tools/list_directory`,
+`get_file_outline`, the AST parse-file helper, and code-index file reads
+consult the same overlay first, so the agent sees its pending changes
+until they are committed or discarded. The ACP server also exposes
+`session/fs_mode` and `session/fs_commit_staged`, and emits
+`session/update` progress notifications with
+`_meta.harn.kind = "staged_writes_pending"` whenever the pending count
+or staged byte total changes.
+
 ## How embedders consume it
 
 The `harn-cli` ACP server wires hostlib in by default:
@@ -250,6 +282,7 @@ crates/harn-hostlib/
 │   ├── ast/
 │   ├── code_index/
 │   ├── scanner/
+│   ├── fs/
 │   ├── fs_watch/
 │   └── tools/
 ├── src/
@@ -260,6 +293,7 @@ crates/harn-hostlib/
 │   ├── ast/
 │   ├── code_index/            # trigram + word index, dep graph (#565)
 │   ├── scanner/
+│   ├── fs.rs                  # deferred per-session filesystem overlay
 │   ├── fs_watch/
 │   └── tools/
 └── tests/

--- a/crates/harn-hostlib/schemas/fs/commit_staged.request.json
+++ b/crates/harn-hostlib/schemas/fs/commit_staged.request.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/fs/commit_staged.request.json",
+  "title": "fs.commit_staged request",
+  "type": "object",
+  "properties": {
+    "session_id": { "type": "string", "minLength": 1 },
+    "paths": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Optional exact staged paths to commit. Missing or empty commits every pending path."
+    }
+  },
+  "required": ["session_id"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/fs/commit_staged.response.json
+++ b/crates/harn-hostlib/schemas/fs/commit_staged.response.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/fs/commit_staged.response.json",
+  "title": "fs.commit_staged response",
+  "type": "object",
+  "properties": {
+    "committed_paths": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "failed_paths_with_reasons": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "path": { "type": "string" },
+          "reason": { "type": "string" }
+        },
+        "required": ["path", "reason"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["committed_paths", "failed_paths_with_reasons"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/fs/discard_staged.request.json
+++ b/crates/harn-hostlib/schemas/fs/discard_staged.request.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/fs/discard_staged.request.json",
+  "title": "fs.discard_staged request",
+  "type": "object",
+  "properties": {
+    "session_id": { "type": "string", "minLength": 1 },
+    "paths": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Optional exact staged paths to discard. Missing or empty discards every pending path."
+    }
+  },
+  "required": ["session_id"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/fs/discard_staged.response.json
+++ b/crates/harn-hostlib/schemas/fs/discard_staged.response.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/fs/discard_staged.response.json",
+  "title": "fs.discard_staged response",
+  "type": "object",
+  "properties": {
+    "discarded_paths": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  },
+  "required": ["discarded_paths"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/fs/set_mode.request.json
+++ b/crates/harn-hostlib/schemas/fs/set_mode.request.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/fs/set_mode.request.json",
+  "title": "fs.set_mode request",
+  "type": "object",
+  "properties": {
+    "session_id": { "type": "string", "minLength": 1 },
+    "mode": { "type": "string", "enum": ["immediate", "staged"] },
+    "root": {
+      "type": "string",
+      "description": "Optional workspace root for .harn/state/staged storage. Defaults to the session root when an embedder provides one, otherwise the process cwd."
+    }
+  },
+  "required": ["session_id", "mode"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/fs/set_mode.response.json
+++ b/crates/harn-hostlib/schemas/fs/set_mode.response.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/fs/set_mode.response.json",
+  "title": "fs.set_mode response",
+  "type": "object",
+  "properties": {
+    "previous_mode": { "type": "string", "enum": ["immediate", "staged"] }
+  },
+  "required": ["previous_mode"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/fs/staged_status.request.json
+++ b/crates/harn-hostlib/schemas/fs/staged_status.request.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/fs/staged_status.request.json",
+  "title": "fs.staged_status request",
+  "type": "object",
+  "properties": {
+    "session_id": { "type": "string", "minLength": 1 }
+  },
+  "required": ["session_id"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/fs/staged_status.response.json
+++ b/crates/harn-hostlib/schemas/fs/staged_status.response.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/fs/staged_status.response.json",
+  "title": "fs.staged_status response",
+  "type": "object",
+  "properties": {
+    "pending_writes": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/pending_write" }
+    },
+    "total_bytes_pending": { "type": "integer", "minimum": 0 },
+    "oldest_pending_age_ms": { "type": "integer", "minimum": 0 }
+  },
+  "required": ["pending_writes", "total_bytes_pending", "oldest_pending_age_ms"],
+  "additionalProperties": false,
+  "$defs": {
+    "pending_write": {
+      "type": "object",
+      "properties": {
+        "path": { "type": "string" },
+        "kind": { "type": "string", "enum": ["write", "delete", "move"] },
+        "bytes_added": { "type": "integer", "minimum": 0 },
+        "bytes_removed": { "type": "integer", "minimum": 0 }
+      },
+      "required": ["path", "kind", "bytes_added", "bytes_removed"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/crates/harn-hostlib/schemas/tools/delete_file.request.json
+++ b/crates/harn-hostlib/schemas/tools/delete_file.request.json
@@ -5,7 +5,11 @@
   "type": "object",
   "properties": {
     "path": { "type": "string" },
-    "recursive": { "type": "boolean", "default": false }
+    "recursive": { "type": "boolean", "default": false },
+    "session_id": {
+      "type": "string",
+      "description": "Optional hostlib session whose staged filesystem mode should intercept this delete."
+    }
   },
   "required": ["path"],
   "additionalProperties": false

--- a/crates/harn-hostlib/schemas/tools/get_file_outline.request.json
+++ b/crates/harn-hostlib/schemas/tools/get_file_outline.request.json
@@ -6,7 +6,11 @@
   "type": "object",
   "properties": {
     "path": { "type": "string" },
-    "max_depth": { "type": "integer", "minimum": 0 }
+    "max_depth": { "type": "integer", "minimum": 0 },
+    "session_id": {
+      "type": "string",
+      "description": "Optional hostlib session whose staged filesystem overlay should be consulted before disk."
+    }
   },
   "required": ["path"],
   "additionalProperties": false

--- a/crates/harn-hostlib/schemas/tools/list_directory.request.json
+++ b/crates/harn-hostlib/schemas/tools/list_directory.request.json
@@ -6,7 +6,11 @@
   "properties": {
     "path": { "type": "string" },
     "include_hidden": { "type": "boolean", "default": false },
-    "max_entries": { "type": "integer", "minimum": 0, "default": 0 }
+    "max_entries": { "type": "integer", "minimum": 0, "default": 0 },
+    "session_id": {
+      "type": "string",
+      "description": "Optional hostlib session whose staged filesystem overlay should be reflected in the listing."
+    }
   },
   "required": ["path"],
   "additionalProperties": false

--- a/crates/harn-hostlib/schemas/tools/read_file.request.json
+++ b/crates/harn-hostlib/schemas/tools/read_file.request.json
@@ -11,6 +11,10 @@
       "type": "string",
       "enum": ["utf-8", "binary"],
       "default": "utf-8"
+    },
+    "session_id": {
+      "type": "string",
+      "description": "Optional hostlib session whose staged filesystem overlay should be consulted before disk."
     }
   },
   "required": ["path"],

--- a/crates/harn-hostlib/schemas/tools/write_file.request.json
+++ b/crates/harn-hostlib/schemas/tools/write_file.request.json
@@ -13,7 +13,11 @@
       "default": "utf-8"
     },
     "create_parents": { "type": "boolean", "default": true },
-    "overwrite": { "type": "boolean", "default": true }
+    "overwrite": { "type": "boolean", "default": true },
+    "session_id": {
+      "type": "string",
+      "description": "Optional hostlib session whose staged filesystem mode should intercept this write."
+    }
   },
   "required": ["path", "content"],
   "additionalProperties": false

--- a/crates/harn-hostlib/src/ast/parse.rs
+++ b/crates/harn-hostlib/src/ast/parse.rs
@@ -67,7 +67,12 @@ pub(super) fn run(args: &[VmValue]) -> Result<VmValue, HostlibError> {
 /// Read the file, optionally truncating to the first `max_bytes` bytes.
 /// `max_bytes == 0` means unlimited (per the request schema).
 pub(super) fn read_source(path: &str, max_bytes: usize) -> Result<String, HostlibError> {
-    let bytes = std::fs::read(path).map_err(|err| HostlibError::Backend {
+    let path_buf = PathBuf::from(path);
+    let bytes = match crate::fs::read(&path_buf, None) {
+        Some(result) => result,
+        None => std::fs::read(path),
+    }
+    .map_err(|err| HostlibError::Backend {
         builtin: BUILTIN,
         message: format!("read `{path}`: {err}"),
     })?;

--- a/crates/harn-hostlib/src/code_index/builtins.rs
+++ b/crates/harn-hostlib/src/code_index/builtins.rs
@@ -384,7 +384,11 @@ pub(super) fn run_file_hash(
     let Some(abs) = state.absolute_path(&path) else {
         return Ok(VmValue::Nil);
     };
-    match std::fs::read(&abs) {
+    let bytes = match crate::fs::read(&abs, None) {
+        Some(result) => result,
+        None => std::fs::read(&abs),
+    };
+    match bytes {
         Ok(bytes) => Ok(str_value(fnv1a64(&bytes).to_string())),
         Err(_) => Ok(VmValue::Nil),
     }
@@ -436,7 +440,11 @@ pub(super) fn run_read_range(
     };
     drop(guard);
 
-    let content = match std::fs::read_to_string(&abs) {
+    let content_result = match crate::fs::read_to_string(&abs, None) {
+        Some(result) => result,
+        None => std::fs::read_to_string(&abs),
+    };
+    let content = match content_result {
         Ok(s) => s,
         Err(_) => {
             return Err(HostlibError::Backend {
@@ -940,7 +948,11 @@ fn candidates_for(state: &IndexState, needle: &str) -> Vec<FileId> {
 }
 
 fn read_file_text(root: &std::path::Path, relative: &str) -> Option<String> {
-    std::fs::read_to_string(root.join(relative)).ok()
+    let path = root.join(relative);
+    match crate::fs::read_to_string(&path, None) {
+        Some(result) => result.ok(),
+        None => std::fs::read_to_string(path).ok(),
+    }
 }
 
 fn count_matches(haystack: &str, needle: &str, case_sensitive: bool) -> u64 {

--- a/crates/harn-hostlib/src/fs.rs
+++ b/crates/harn-hostlib/src/fs.rs
@@ -1,0 +1,1141 @@
+//! Session-scoped staged filesystem mode.
+//!
+//! `hostlib_fs_set_mode({session_id, mode: "staged"})` makes hostlib file
+//! mutations land in a durable per-session overlay under
+//! `.harn/state/staged/<session_id>/`. Reads made by the same session consult
+//! that overlay first, so agent loops see their own pending writes without
+//! touching the working tree until `hostlib_fs_commit_staged`.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs as stdfs;
+use std::io::Write;
+use std::path::{Component, Path, PathBuf};
+use std::rc::Rc;
+use std::sync::{Mutex, OnceLock};
+
+use harn_vm::agent_events::AgentEvent;
+use harn_vm::VmValue;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::error::HostlibError;
+use crate::registry::{BuiltinRegistry, HostlibCapability, RegisteredBuiltin, SyncHandler};
+use crate::tools::args::{
+    build_dict, dict_arg, optional_string, optional_string_list, require_string, str_value,
+};
+
+const SET_MODE_BUILTIN: &str = "hostlib_fs_set_mode";
+const STATUS_BUILTIN: &str = "hostlib_fs_staged_status";
+const COMMIT_BUILTIN: &str = "hostlib_fs_commit_staged";
+const DISCARD_BUILTIN: &str = "hostlib_fs_discard_staged";
+
+const MANIFEST_VERSION: u32 = 1;
+const STATE_REL: &[&str] = &[".harn", "state", "staged"];
+
+/// Hostlib filesystem capability handle.
+#[derive(Default)]
+pub struct FsCapability;
+
+impl HostlibCapability for FsCapability {
+    fn module_name(&self) -> &'static str {
+        "fs"
+    }
+
+    fn register_builtins(&self, registry: &mut BuiltinRegistry) {
+        register(registry, SET_MODE_BUILTIN, "set_mode", set_mode_builtin);
+        register(
+            registry,
+            STATUS_BUILTIN,
+            "staged_status",
+            staged_status_builtin,
+        );
+        register(
+            registry,
+            COMMIT_BUILTIN,
+            "commit_staged",
+            commit_staged_builtin,
+        );
+        register(
+            registry,
+            DISCARD_BUILTIN,
+            "discard_staged",
+            discard_staged_builtin,
+        );
+    }
+}
+
+fn register(
+    registry: &mut BuiltinRegistry,
+    name: &'static str,
+    method: &'static str,
+    runner: fn(&[VmValue]) -> Result<VmValue, HostlibError>,
+) {
+    let handler: SyncHandler = std::sync::Arc::new(runner);
+    registry.register(RegisteredBuiltin {
+        name,
+        module: "fs",
+        method,
+        handler,
+    });
+}
+
+/// Filesystem mode for one hostlib session.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FsMode {
+    /// Mutations apply to the working tree immediately.
+    Immediate,
+    /// Mutations are recorded in the staging layer until committed.
+    Staged,
+}
+
+impl FsMode {
+    fn parse(builtin: &'static str, raw: &str) -> Result<Self, HostlibError> {
+        match raw {
+            "immediate" => Ok(Self::Immediate),
+            "staged" => Ok(Self::Staged),
+            other => Err(HostlibError::InvalidParameter {
+                builtin,
+                param: "mode",
+                message: format!("expected \"immediate\" or \"staged\", got `{other}`"),
+            }),
+        }
+    }
+
+    /// Wire string used by hostlib schemas.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Immediate => "immediate",
+            Self::Staged => "staged",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct Manifest {
+    version: u32,
+    session_id: String,
+    mode: FsMode,
+    root: String,
+    entries: BTreeMap<String, StagedEntry>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum StagedEntry {
+    Write {
+        body_hash: String,
+        len: u64,
+        created_at_ms: i64,
+    },
+    Delete {
+        recursive: bool,
+        created_at_ms: i64,
+    },
+}
+
+impl StagedEntry {
+    fn created_at_ms(&self) -> i64 {
+        match self {
+            Self::Write { created_at_ms, .. } | Self::Delete { created_at_ms, .. } => {
+                *created_at_ms
+            }
+        }
+    }
+
+    fn body_len(&self) -> u64 {
+        match self {
+            Self::Write { len, .. } => *len,
+            Self::Delete { .. } => 0,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct SessionState {
+    session_id: String,
+    mode: FsMode,
+    root: PathBuf,
+    entries: BTreeMap<PathBuf, StagedEntry>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct WriteOutcome {
+    pub(crate) created: bool,
+    pub(crate) bytes_written: usize,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct OverlayDirEntry {
+    pub(crate) name: String,
+    pub(crate) is_dir: bool,
+    pub(crate) is_symlink: bool,
+    pub(crate) size: u64,
+}
+
+/// Summary of staged filesystem changes for one session.
+#[derive(Clone, Debug)]
+pub struct StagedStatus {
+    /// Pending path changes, sorted by path.
+    pub pending_writes: Vec<PendingWrite>,
+    /// Bytes stored in staged write bodies.
+    pub total_bytes_pending: u64,
+    /// Age in milliseconds of the oldest pending change, or 0 when empty.
+    pub oldest_pending_age_ms: i64,
+}
+
+#[derive(Clone, Debug)]
+/// One pending staged filesystem change.
+pub struct PendingWrite {
+    /// Absolute path affected by this staged change.
+    pub path: String,
+    /// Change kind (`write`, `delete`, or reserved future `move`).
+    pub kind: &'static str,
+    /// Bytes the final staged view adds at this path.
+    pub bytes_added: u64,
+    /// Bytes the final staged view removes at this path.
+    pub bytes_removed: u64,
+}
+
+/// Result returned after changing a session's filesystem mode.
+#[derive(Clone, Debug)]
+pub struct SetModeResult {
+    /// Mode active before the change.
+    pub previous_mode: FsMode,
+}
+
+/// Result returned after applying staged changes to disk.
+#[derive(Clone, Debug)]
+pub struct CommitResult {
+    /// Paths successfully applied to disk.
+    pub committed_paths: Vec<String>,
+    /// Paths that failed to apply, with human-readable reasons.
+    pub failed_paths_with_reasons: Vec<(String, String)>,
+}
+
+/// Result returned after dropping staged changes.
+#[derive(Clone, Debug)]
+pub struct DiscardResult {
+    /// Paths whose staged entries were removed.
+    pub discarded_paths: Vec<String>,
+}
+
+static SESSIONS: OnceLock<Mutex<BTreeMap<String, SessionState>>> = OnceLock::new();
+
+fn sessions() -> &'static Mutex<BTreeMap<String, SessionState>> {
+    SESSIONS.get_or_init(|| Mutex::new(BTreeMap::new()))
+}
+
+/// Remember the workspace root associated with a live session.
+///
+/// ACP calls this when a prompt starts so Harn code can call
+/// `hostlib_fs_set_mode({session_id, mode})` without also passing a root.
+pub fn configure_session_root(session_id: &str, root: &Path) {
+    if session_id.trim().is_empty() {
+        return;
+    }
+    let root = normalize_logical(root);
+    let mut guard = sessions()
+        .lock()
+        .expect("hostlib fs session mutex poisoned");
+    match guard.get_mut(session_id) {
+        Some(state) if state.entries.is_empty() => {
+            state.root = root;
+        }
+        Some(_) => {}
+        None => {
+            let state = load_state(session_id, Some(root.clone())).unwrap_or(SessionState {
+                session_id: session_id.to_string(),
+                mode: FsMode::Immediate,
+                root,
+                entries: BTreeMap::new(),
+            });
+            guard.insert(session_id.to_string(), state);
+        }
+    }
+}
+
+/// Set a session's filesystem mode.
+pub fn set_mode(
+    session_id: &str,
+    mode: FsMode,
+    root: Option<&Path>,
+) -> Result<SetModeResult, HostlibError> {
+    validate_session_id(SET_MODE_BUILTIN, session_id)?;
+    let mut guard = sessions()
+        .lock()
+        .expect("hostlib fs session mutex poisoned");
+    let mut state = state_for_locked(&mut guard, session_id, root.map(normalize_logical))?;
+    let previous_mode = state.mode;
+    state.mode = mode;
+    persist_state(&state, "set_mode", None).map_err(|err| HostlibError::Backend {
+        builtin: SET_MODE_BUILTIN,
+        message: err,
+    })?;
+    guard.insert(session_id.to_string(), state);
+    Ok(SetModeResult { previous_mode })
+}
+
+/// Return the staged status for a session.
+pub fn staged_status(session_id: &str) -> Result<StagedStatus, HostlibError> {
+    validate_session_id(STATUS_BUILTIN, session_id)?;
+    let mut guard = sessions()
+        .lock()
+        .expect("hostlib fs session mutex poisoned");
+    let state = state_for_locked(&mut guard, session_id, None)?;
+    let status = status_from_state(&state);
+    guard.insert(session_id.to_string(), state);
+    Ok(status)
+}
+
+/// Commit staged changes for all paths or for a filtered path list.
+pub fn commit_staged(session_id: &str, paths: &[String]) -> Result<CommitResult, HostlibError> {
+    validate_session_id(COMMIT_BUILTIN, session_id)?;
+    let mut guard = sessions()
+        .lock()
+        .expect("hostlib fs session mutex poisoned");
+    let mut state = state_for_locked(&mut guard, session_id, None)?;
+    let selected = selected_paths(&state, paths);
+    let mut committed_paths = Vec::new();
+    let mut failed_paths_with_reasons = Vec::new();
+
+    for path in selected {
+        let Some(entry) = state.entries.get(&path).cloned() else {
+            continue;
+        };
+        let path_label = path.to_string_lossy().into_owned();
+        match commit_entry(&state, &path, &entry) {
+            Ok(()) => {
+                state.entries.remove(&path);
+                committed_paths.push(path_label);
+            }
+            Err(reason) => failed_paths_with_reasons.push((path_label, reason)),
+        }
+    }
+
+    persist_state(&state, "commit_staged", None).map_err(|err| HostlibError::Backend {
+        builtin: COMMIT_BUILTIN,
+        message: err,
+    })?;
+    emit_staged_update(&state);
+    guard.insert(session_id.to_string(), state);
+    Ok(CommitResult {
+        committed_paths,
+        failed_paths_with_reasons,
+    })
+}
+
+/// Discard staged changes for all paths or for a filtered path list.
+pub fn discard_staged(session_id: &str, paths: &[String]) -> Result<DiscardResult, HostlibError> {
+    validate_session_id(DISCARD_BUILTIN, session_id)?;
+    let mut guard = sessions()
+        .lock()
+        .expect("hostlib fs session mutex poisoned");
+    let mut state = state_for_locked(&mut guard, session_id, None)?;
+    let selected = selected_paths(&state, paths);
+    let mut discarded_paths = Vec::new();
+    for path in selected {
+        if state.entries.remove(&path).is_some() {
+            discarded_paths.push(path.to_string_lossy().into_owned());
+        }
+    }
+    persist_state(&state, "discard_staged", None).map_err(|err| HostlibError::Backend {
+        builtin: DISCARD_BUILTIN,
+        message: err,
+    })?;
+    emit_staged_update(&state);
+    guard.insert(session_id.to_string(), state);
+    Ok(DiscardResult { discarded_paths })
+}
+
+pub(crate) fn read(
+    path: &Path,
+    explicit_session_id: Option<&str>,
+) -> Option<std::io::Result<Vec<u8>>> {
+    let session_id = active_session_id(explicit_session_id)?;
+    let mut guard = sessions()
+        .lock()
+        .expect("hostlib fs session mutex poisoned");
+    let state = state_for_locked(&mut guard, &session_id, None).ok()?;
+    let result = if state.mode == FsMode::Staged {
+        overlay_read(&state, path)
+    } else {
+        None
+    };
+    guard.insert(session_id, state);
+    result
+}
+
+pub(crate) fn read_to_string(
+    path: &Path,
+    explicit_session_id: Option<&str>,
+) -> Option<std::io::Result<String>> {
+    read(path, explicit_session_id).map(|result| {
+        result.and_then(|bytes| {
+            String::from_utf8(bytes).map_err(|err| {
+                std::io::Error::new(std::io::ErrorKind::InvalidData, err.to_string())
+            })
+        })
+    })
+}
+
+pub(crate) fn read_dir(
+    path: &Path,
+    explicit_session_id: Option<&str>,
+) -> Option<std::io::Result<Vec<OverlayDirEntry>>> {
+    let session_id = active_session_id(explicit_session_id)?;
+    let mut guard = sessions()
+        .lock()
+        .expect("hostlib fs session mutex poisoned");
+    let state = state_for_locked(&mut guard, &session_id, None).ok()?;
+    let result = if state.mode == FsMode::Staged {
+        Some(overlay_read_dir(&state, path))
+    } else {
+        None
+    };
+    guard.insert(session_id, state);
+    result
+}
+
+pub(crate) fn stage_write_or_none(
+    builtin: &'static str,
+    path: &Path,
+    bytes: &[u8],
+    create_parents: bool,
+    overwrite: bool,
+    explicit_session_id: Option<&str>,
+) -> Result<Option<WriteOutcome>, HostlibError> {
+    let Some(session_id) = active_session_id(explicit_session_id) else {
+        return Ok(None);
+    };
+    let mut guard = sessions()
+        .lock()
+        .expect("hostlib fs session mutex poisoned");
+    let mut state = state_for_locked(&mut guard, &session_id, None)?;
+    if state.mode != FsMode::Staged {
+        guard.insert(session_id, state);
+        return Ok(None);
+    }
+
+    let key = normalize_logical(path);
+    let existed = overlay_exists(&state, &key);
+    if existed && !overwrite {
+        guard.insert(session_id, state);
+        return Err(HostlibError::Backend {
+            builtin,
+            message: format!("`{}` exists and overwrite=false", key.display()),
+        });
+    }
+    if !create_parents && !parent_exists(&state, &key) {
+        guard.insert(session_id, state);
+        return Err(HostlibError::Backend {
+            builtin,
+            message: format!("parent directory for `{}` does not exist", key.display()),
+        });
+    }
+
+    let hash = write_body(&state, bytes).map_err(|err| HostlibError::Backend {
+        builtin,
+        message: err,
+    })?;
+    state.entries.insert(
+        key.clone(),
+        StagedEntry::Write {
+            body_hash: hash,
+            len: bytes.len() as u64,
+            created_at_ms: now_ms(),
+        },
+    );
+    persist_state(&state, "write", Some(&key)).map_err(|err| HostlibError::Backend {
+        builtin,
+        message: err,
+    })?;
+    emit_staged_update(&state);
+    guard.insert(session_id, state);
+    Ok(Some(WriteOutcome {
+        created: !existed,
+        bytes_written: bytes.len(),
+    }))
+}
+
+pub(crate) fn stage_delete_or_none(
+    builtin: &'static str,
+    path: &Path,
+    recursive: bool,
+    explicit_session_id: Option<&str>,
+) -> Result<Option<bool>, HostlibError> {
+    let Some(session_id) = active_session_id(explicit_session_id) else {
+        return Ok(None);
+    };
+    let mut guard = sessions()
+        .lock()
+        .expect("hostlib fs session mutex poisoned");
+    let mut state = state_for_locked(&mut guard, &session_id, None)?;
+    if state.mode != FsMode::Staged {
+        guard.insert(session_id, state);
+        return Ok(None);
+    }
+
+    let key = normalize_logical(path);
+    let staged_targets = staged_paths_under(&state, &key);
+    let disk_exists = key.exists();
+    if !disk_exists && staged_targets.is_empty() {
+        guard.insert(session_id, state);
+        return Ok(Some(false));
+    }
+
+    if !disk_exists {
+        for staged in staged_targets {
+            state.entries.remove(&staged);
+        }
+    } else {
+        validate_delete_shape(builtin, &key, recursive)?;
+        for staged in staged_targets {
+            state.entries.remove(&staged);
+        }
+        state.entries.insert(
+            key.clone(),
+            StagedEntry::Delete {
+                recursive,
+                created_at_ms: now_ms(),
+            },
+        );
+    }
+    persist_state(&state, "delete", Some(&key)).map_err(|err| HostlibError::Backend {
+        builtin,
+        message: err,
+    })?;
+    emit_staged_update(&state);
+    guard.insert(session_id, state);
+    Ok(Some(true))
+}
+
+fn set_mode_builtin(args: &[VmValue]) -> Result<VmValue, HostlibError> {
+    let raw = dict_arg(SET_MODE_BUILTIN, args)?;
+    let dict = raw.as_ref();
+    let session_id = require_string(SET_MODE_BUILTIN, dict, "session_id")?;
+    let mode = FsMode::parse(
+        SET_MODE_BUILTIN,
+        &require_string(SET_MODE_BUILTIN, dict, "mode")?,
+    )?;
+    let root = optional_string(SET_MODE_BUILTIN, dict, "root")?.map(PathBuf::from);
+    let result = set_mode(&session_id, mode, root.as_deref())?;
+    Ok(build_dict([(
+        "previous_mode",
+        str_value(result.previous_mode.as_str()),
+    )]))
+}
+
+fn staged_status_builtin(args: &[VmValue]) -> Result<VmValue, HostlibError> {
+    let raw = dict_arg(STATUS_BUILTIN, args)?;
+    let session_id = require_string(STATUS_BUILTIN, raw.as_ref(), "session_id")?;
+    Ok(status_to_value(staged_status(&session_id)?))
+}
+
+fn commit_staged_builtin(args: &[VmValue]) -> Result<VmValue, HostlibError> {
+    let raw = dict_arg(COMMIT_BUILTIN, args)?;
+    let dict = raw.as_ref();
+    let session_id = require_string(COMMIT_BUILTIN, dict, "session_id")?;
+    let paths = optional_string_list(COMMIT_BUILTIN, dict, "paths")?;
+    Ok(commit_result_to_value(commit_staged(&session_id, &paths)?))
+}
+
+fn discard_staged_builtin(args: &[VmValue]) -> Result<VmValue, HostlibError> {
+    let raw = dict_arg(DISCARD_BUILTIN, args)?;
+    let dict = raw.as_ref();
+    let session_id = require_string(DISCARD_BUILTIN, dict, "session_id")?;
+    let paths = optional_string_list(DISCARD_BUILTIN, dict, "paths")?;
+    Ok(discard_result_to_value(discard_staged(
+        &session_id,
+        &paths,
+    )?))
+}
+
+fn state_for_locked(
+    guard: &mut BTreeMap<String, SessionState>,
+    session_id: &str,
+    root: Option<PathBuf>,
+) -> Result<SessionState, HostlibError> {
+    if let Some(existing) = guard.get(session_id) {
+        let mut state = existing.clone();
+        if let Some(root) = root {
+            if state.entries.is_empty() {
+                state.root = root;
+            }
+        }
+        return Ok(state);
+    }
+    let state = load_state(session_id, root).map_err(|err| HostlibError::Backend {
+        builtin: SET_MODE_BUILTIN,
+        message: err,
+    })?;
+    Ok(state)
+}
+
+fn load_state(session_id: &str, root: Option<PathBuf>) -> Result<SessionState, String> {
+    let root = root.unwrap_or_else(default_root);
+    let manifest_path = manifest_path(&root, session_id);
+    if manifest_path.exists() {
+        let text = stdfs::read_to_string(&manifest_path)
+            .map_err(|err| format!("read {}: {err}", manifest_path.display()))?;
+        let manifest: Manifest = serde_json::from_str(&text)
+            .map_err(|err| format!("parse {}: {err}", manifest_path.display()))?;
+        if manifest.version != MANIFEST_VERSION {
+            return Err(format!(
+                "unsupported staged fs manifest version {} in {}",
+                manifest.version,
+                manifest_path.display()
+            ));
+        }
+        if manifest.session_id != session_id {
+            return Err(format!(
+                "staged fs manifest session id mismatch in {}",
+                manifest_path.display()
+            ));
+        }
+        return Ok(SessionState {
+            session_id: manifest.session_id,
+            mode: manifest.mode,
+            root: normalize_logical(Path::new(&manifest.root)),
+            entries: manifest
+                .entries
+                .into_iter()
+                .map(|(path, entry)| (normalize_logical(Path::new(&path)), entry))
+                .collect(),
+        });
+    }
+    Ok(SessionState {
+        session_id: session_id.to_string(),
+        mode: FsMode::Immediate,
+        root,
+        entries: BTreeMap::new(),
+    })
+}
+
+fn persist_state(state: &SessionState, op: &str, path: Option<&Path>) -> Result<(), String> {
+    let dir = session_dir(&state.root, &state.session_id);
+    stdfs::create_dir_all(dir.join("bodies"))
+        .map_err(|err| format!("mkdir {}: {err}", dir.display()))?;
+    let manifest = Manifest {
+        version: MANIFEST_VERSION,
+        session_id: state.session_id.clone(),
+        mode: state.mode,
+        root: state.root.to_string_lossy().into_owned(),
+        entries: state
+            .entries
+            .iter()
+            .map(|(path, entry)| (path.to_string_lossy().into_owned(), entry.clone()))
+            .collect(),
+    };
+    let bytes = serde_json::to_vec_pretty(&manifest)
+        .map_err(|err| format!("serialize staged manifest: {err}"))?;
+    atomic_write(&manifest_path(&state.root, &state.session_id), &bytes)?;
+    append_journal(state, op, path)?;
+    prune_unreferenced_bodies(state);
+    Ok(())
+}
+
+fn append_journal(state: &SessionState, op: &str, path: Option<&Path>) -> Result<(), String> {
+    let dir = session_dir(&state.root, &state.session_id);
+    stdfs::create_dir_all(&dir).map_err(|err| format!("mkdir {}: {err}", dir.display()))?;
+    let line = serde_json::to_string(&serde_json::json!({
+        "ts_ms": now_ms(),
+        "op": op,
+        "path": path.map(|path| path.to_string_lossy().into_owned()),
+        "pending_count": state.entries.len(),
+    }))
+    .map_err(|err| format!("serialize staged journal: {err}"))?;
+    let mut file = stdfs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(dir.join("journal.jsonl"))
+        .map_err(|err| format!("open staged journal: {err}"))?;
+    writeln!(file, "{line}").map_err(|err| format!("write staged journal: {err}"))
+}
+
+fn write_body(state: &SessionState, bytes: &[u8]) -> Result<String, String> {
+    let hash = hex::encode(Sha256::digest(bytes));
+    let path = session_dir(&state.root, &state.session_id)
+        .join("bodies")
+        .join(&hash);
+    if !path.exists() {
+        atomic_write(&path, bytes)?;
+    }
+    Ok(hash)
+}
+
+fn read_body(state: &SessionState, hash: &str) -> std::io::Result<Vec<u8>> {
+    stdfs::read(
+        session_dir(&state.root, &state.session_id)
+            .join("bodies")
+            .join(hash),
+    )
+}
+
+fn prune_unreferenced_bodies(state: &SessionState) {
+    let live: BTreeSet<String> = state
+        .entries
+        .values()
+        .filter_map(|entry| match entry {
+            StagedEntry::Write { body_hash, .. } => Some(body_hash.clone()),
+            StagedEntry::Delete { .. } => None,
+        })
+        .collect();
+    let body_dir = session_dir(&state.root, &state.session_id).join("bodies");
+    let Ok(entries) = stdfs::read_dir(&body_dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if !live.contains(&name) {
+            let _ = stdfs::remove_file(entry.path());
+        }
+    }
+}
+
+fn atomic_write(path: &Path, bytes: &[u8]) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        stdfs::create_dir_all(parent)
+            .map_err(|err| format!("mkdir {}: {err}", parent.display()))?;
+    }
+    let tmp = path.with_extension(format!("tmp-{}-{}", std::process::id(), now_ms()));
+    stdfs::write(&tmp, bytes).map_err(|err| format!("write {}: {err}", tmp.display()))?;
+    match stdfs::rename(&tmp, path) {
+        Ok(()) => Ok(()),
+        Err(err) => {
+            let _ = stdfs::remove_file(path);
+            stdfs::rename(&tmp, path).map_err(|retry| {
+                format!(
+                    "rename {} to {}: {err}; retry: {retry}",
+                    tmp.display(),
+                    path.display()
+                )
+            })
+        }
+    }
+}
+
+fn commit_entry(state: &SessionState, path: &Path, entry: &StagedEntry) -> Result<(), String> {
+    match entry {
+        StagedEntry::Write { body_hash, .. } => {
+            let bytes = read_body(state, body_hash)
+                .map_err(|err| format!("read staged body for {}: {err}", path.display()))?;
+            atomic_write(path, &bytes)
+        }
+        StagedEntry::Delete { recursive, .. } => match stdfs::symlink_metadata(path) {
+            Ok(metadata) if metadata.is_dir() => {
+                if *recursive {
+                    stdfs::remove_dir_all(path)
+                        .map_err(|err| format!("remove_dir_all {}: {err}", path.display()))
+                } else {
+                    stdfs::remove_dir(path)
+                        .map_err(|err| format!("remove_dir {}: {err}", path.display()))
+                }
+            }
+            Ok(_) => stdfs::remove_file(path)
+                .map_err(|err| format!("remove_file {}: {err}", path.display())),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(err) => Err(format!("stat {}: {err}", path.display())),
+        },
+    }
+}
+
+fn overlay_read(state: &SessionState, path: &Path) -> Option<std::io::Result<Vec<u8>>> {
+    let key = normalize_logical(path);
+    if let Some(entry) = state.entries.get(&key) {
+        return Some(match entry {
+            StagedEntry::Write { body_hash, .. } => read_body(state, body_hash),
+            StagedEntry::Delete { .. } => Err(not_found(&key)),
+        });
+    }
+    if deleted_ancestor(state, &key) {
+        return Some(Err(not_found(&key)));
+    }
+    None
+}
+
+fn overlay_read_dir(state: &SessionState, path: &Path) -> std::io::Result<Vec<OverlayDirEntry>> {
+    let dir_key = normalize_logical(path);
+    if matches!(state.entries.get(&dir_key), Some(StagedEntry::Write { .. }))
+        || deleted_ancestor(state, &dir_key)
+        || matches!(
+            state.entries.get(&dir_key),
+            Some(StagedEntry::Delete { .. })
+        )
+    {
+        return Err(not_found(&dir_key));
+    }
+    if !path.exists() && !has_staged_descendant(state, &dir_key) {
+        return Err(not_found(&dir_key));
+    }
+
+    let mut entries: BTreeMap<String, OverlayDirEntry> = BTreeMap::new();
+    if path.exists() {
+        for entry in stdfs::read_dir(path)? {
+            let entry = entry?;
+            let name = entry.file_name().to_string_lossy().into_owned();
+            let file_type = entry.file_type().ok();
+            let metadata = entry.metadata().ok();
+            entries.insert(
+                name.clone(),
+                OverlayDirEntry {
+                    name,
+                    is_dir: file_type.is_some_and(|ty| ty.is_dir()),
+                    is_symlink: file_type.is_some_and(|ty| ty.is_symlink()),
+                    size: metadata.map(|m| m.len()).unwrap_or(0),
+                },
+            );
+        }
+    }
+
+    for (path, entry) in &state.entries {
+        let Some(name) = overlay_child_name(path, &dir_key) else {
+            continue;
+        };
+        match entry {
+            StagedEntry::Write { len, .. } => {
+                let is_dir = path.parent() != Some(dir_key.as_path());
+                entries.insert(
+                    name.clone(),
+                    OverlayDirEntry {
+                        name,
+                        is_dir,
+                        is_symlink: false,
+                        size: if is_dir { 0 } else { *len },
+                    },
+                );
+            }
+            StagedEntry::Delete { .. } => {
+                if path.parent() == Some(dir_key.as_path()) {
+                    entries.remove(&name);
+                }
+            }
+        }
+    }
+
+    Ok(entries.into_values().collect())
+}
+
+fn overlay_child_name(path: &Path, dir: &Path) -> Option<String> {
+    let suffix = path.strip_prefix(dir).ok()?;
+    let mut components = suffix.components();
+    let first = components.next()?;
+    match first {
+        Component::Normal(name) => Some(name.to_string_lossy().into_owned()),
+        _ => None,
+    }
+}
+
+fn overlay_exists(state: &SessionState, path: &Path) -> bool {
+    if let Some(entry) = state.entries.get(path) {
+        return matches!(entry, StagedEntry::Write { .. });
+    }
+    if deleted_ancestor(state, path) {
+        return false;
+    }
+    if has_staged_descendant(state, path) {
+        return true;
+    }
+    path.exists()
+}
+
+fn parent_exists(state: &SessionState, path: &Path) -> bool {
+    let Some(parent) = path.parent() else {
+        return true;
+    };
+    if parent.as_os_str().is_empty() {
+        return true;
+    }
+    if let Some(entry) = state.entries.get(parent) {
+        return !matches!(entry, StagedEntry::Delete { .. });
+    }
+    if deleted_ancestor(state, parent) {
+        return false;
+    }
+    if has_staged_descendant(state, parent) {
+        return true;
+    }
+    parent.is_dir()
+}
+
+fn deleted_ancestor(state: &SessionState, path: &Path) -> bool {
+    state.entries.iter().any(|(candidate, entry)| {
+        matches!(entry, StagedEntry::Delete { .. })
+            && path != candidate.as_path()
+            && path.starts_with(candidate)
+    })
+}
+
+fn has_staged_descendant(state: &SessionState, path: &Path) -> bool {
+    state.entries.iter().any(|(candidate, entry)| {
+        matches!(entry, StagedEntry::Write { .. })
+            && candidate != path
+            && candidate.starts_with(path)
+    })
+}
+
+fn staged_paths_under(state: &SessionState, path: &Path) -> Vec<PathBuf> {
+    state
+        .entries
+        .keys()
+        .filter(|candidate| *candidate == path || candidate.starts_with(path))
+        .cloned()
+        .collect()
+}
+
+fn validate_delete_shape(
+    builtin: &'static str,
+    path: &Path,
+    recursive: bool,
+) -> Result<(), HostlibError> {
+    let Ok(metadata) = stdfs::symlink_metadata(path) else {
+        return Ok(());
+    };
+    if metadata.is_dir() && !recursive {
+        let mut entries = stdfs::read_dir(path).map_err(|err| HostlibError::Backend {
+            builtin,
+            message: format!("read_dir `{}`: {err}", path.display()),
+        })?;
+        if entries.next().is_some() {
+            return Err(HostlibError::Backend {
+                builtin,
+                message: format!(
+                    "remove_dir `{}` (pass recursive=true to delete non-empty dirs): directory not empty",
+                    path.display()
+                ),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn status_from_state(state: &SessionState) -> StagedStatus {
+    let now = now_ms();
+    let mut pending_writes = Vec::new();
+    let mut total_bytes_pending = 0u64;
+    let mut oldest = None;
+    for (path, entry) in &state.entries {
+        total_bytes_pending = total_bytes_pending.saturating_add(entry.body_len());
+        oldest = Some(oldest.map_or(entry.created_at_ms(), |old: i64| {
+            old.min(entry.created_at_ms())
+        }));
+        let (kind, bytes_added, bytes_removed) = match entry {
+            StagedEntry::Write { len, .. } => ("write", *len, disk_size(path).unwrap_or(0)),
+            StagedEntry::Delete { .. } => ("delete", 0, disk_size(path).unwrap_or(0)),
+        };
+        pending_writes.push(PendingWrite {
+            path: path.to_string_lossy().into_owned(),
+            kind,
+            bytes_added,
+            bytes_removed,
+        });
+    }
+    StagedStatus {
+        pending_writes,
+        total_bytes_pending,
+        oldest_pending_age_ms: oldest.map(|old| now.saturating_sub(old)).unwrap_or(0),
+    }
+}
+
+fn disk_size(path: &Path) -> Option<u64> {
+    let metadata = stdfs::symlink_metadata(path).ok()?;
+    if metadata.is_file() {
+        return Some(metadata.len());
+    }
+    if metadata.is_dir() {
+        let mut total = 0u64;
+        for entry in walkdir::WalkDir::new(path)
+            .into_iter()
+            .filter_map(Result::ok)
+        {
+            if let Ok(metadata) = entry.metadata() {
+                if metadata.is_file() {
+                    total = total.saturating_add(metadata.len());
+                }
+            }
+        }
+        return Some(total);
+    }
+    Some(metadata.len())
+}
+
+fn selected_paths(state: &SessionState, paths: &[String]) -> Vec<PathBuf> {
+    if paths.is_empty() {
+        return state.entries.keys().cloned().collect();
+    }
+    let selected: BTreeSet<PathBuf> = paths
+        .iter()
+        .map(|path| normalize_logical(Path::new(path)))
+        .collect();
+    state
+        .entries
+        .keys()
+        .filter(|path| selected.contains(*path))
+        .cloned()
+        .collect()
+}
+
+fn active_session_id(explicit: Option<&str>) -> Option<String> {
+    explicit
+        .map(str::to_string)
+        .or_else(harn_vm::agent_sessions::current_session_id)
+        .filter(|id| !id.trim().is_empty())
+}
+
+fn validate_session_id(builtin: &'static str, session_id: &str) -> Result<(), HostlibError> {
+    if session_id.trim().is_empty() {
+        return Err(HostlibError::InvalidParameter {
+            builtin,
+            param: "session_id",
+            message: "must not be empty".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn default_root() -> PathBuf {
+    std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
+}
+
+fn session_dir(root: &Path, session_id: &str) -> PathBuf {
+    let mut dir = root.to_path_buf();
+    for component in STATE_REL {
+        dir.push(component);
+    }
+    dir.push(sanitize_component(session_id));
+    dir
+}
+
+fn manifest_path(root: &Path, session_id: &str) -> PathBuf {
+    session_dir(root, session_id).join("manifest.json")
+}
+
+fn sanitize_component(input: &str) -> String {
+    let sanitized: String = input
+        .chars()
+        .map(|ch| match ch {
+            'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_' | '.' => ch,
+            _ => '_',
+        })
+        .collect();
+    if sanitized == input {
+        sanitized
+    } else {
+        let hash = hex::encode(Sha256::digest(input.as_bytes()));
+        format!("{sanitized}-{}", &hash[..12])
+    }
+}
+
+fn normalize_logical(path: &Path) -> PathBuf {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        default_root().join(path)
+    };
+    let mut out = PathBuf::new();
+    for component in absolute.components() {
+        match component {
+            Component::ParentDir => {
+                out.pop();
+            }
+            Component::CurDir => {}
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+fn not_found(path: &Path) -> std::io::Error {
+    std::io::Error::new(
+        std::io::ErrorKind::NotFound,
+        format!("staged fs: {} is deleted or absent", path.display()),
+    )
+}
+
+fn now_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+fn emit_staged_update(state: &SessionState) {
+    let status = status_from_state(state);
+    harn_vm::agent_events::emit_event(&AgentEvent::StagedWritesPending {
+        session_id: state.session_id.clone(),
+        pending_count: status.pending_writes.len(),
+        total_bytes: status.total_bytes_pending,
+    });
+}
+
+fn pending_write_to_value(write: PendingWrite) -> VmValue {
+    build_dict([
+        ("path", str_value(&write.path)),
+        ("kind", str_value(write.kind)),
+        ("bytes_added", VmValue::Int(write.bytes_added as i64)),
+        ("bytes_removed", VmValue::Int(write.bytes_removed as i64)),
+    ])
+}
+
+fn status_to_value(status: StagedStatus) -> VmValue {
+    build_dict([
+        (
+            "pending_writes",
+            VmValue::List(Rc::new(
+                status
+                    .pending_writes
+                    .into_iter()
+                    .map(pending_write_to_value)
+                    .collect(),
+            )),
+        ),
+        (
+            "total_bytes_pending",
+            VmValue::Int(status.total_bytes_pending as i64),
+        ),
+        (
+            "oldest_pending_age_ms",
+            VmValue::Int(status.oldest_pending_age_ms),
+        ),
+    ])
+}
+
+fn commit_result_to_value(result: CommitResult) -> VmValue {
+    build_dict([
+        (
+            "committed_paths",
+            VmValue::List(Rc::new(
+                result
+                    .committed_paths
+                    .into_iter()
+                    .map(|path| VmValue::String(Rc::from(path)))
+                    .collect(),
+            )),
+        ),
+        (
+            "failed_paths_with_reasons",
+            VmValue::List(Rc::new(
+                result
+                    .failed_paths_with_reasons
+                    .into_iter()
+                    .map(|(path, reason)| {
+                        build_dict([("path", str_value(&path)), ("reason", str_value(&reason))])
+                    })
+                    .collect(),
+            )),
+        ),
+    ])
+}
+
+fn discard_result_to_value(result: DiscardResult) -> VmValue {
+    build_dict([(
+        "discarded_paths",
+        VmValue::List(Rc::new(
+            result
+                .discarded_paths
+                .into_iter()
+                .map(|path| VmValue::String(Rc::from(path)))
+                .collect(),
+        )),
+    )])
+}

--- a/crates/harn-hostlib/src/lib.rs
+++ b/crates/harn-hostlib/src/lib.rs
@@ -30,6 +30,7 @@
 pub mod ast;
 pub mod code_index;
 pub mod error;
+pub mod fs;
 pub mod fs_watch;
 pub mod process;
 pub mod scanner;
@@ -54,6 +55,7 @@ pub fn install_default(vm: &mut harn_vm::Vm) -> HostlibRegistry {
         .with(ast::AstCapability)
         .with(code_index::CodeIndexCapability::new())
         .with(scanner::ScannerCapability)
+        .with(fs::FsCapability)
         .with(fs_watch::FsWatchCapability)
         .with(tools::ToolsCapability)
         .with(secret_store::SecretStoreCapability);

--- a/crates/harn-hostlib/src/schemas.rs
+++ b/crates/harn-hostlib/src/schemas.rs
@@ -523,6 +523,55 @@ pub const SCHEMAS: &[(&str, &str, SchemaKind, &str)] = &[
         SchemaKind::Response,
         include_str!("../schemas/scanner/scan_incremental.response.json"),
     ),
+    // fs/
+    (
+        "fs",
+        "set_mode",
+        SchemaKind::Request,
+        include_str!("../schemas/fs/set_mode.request.json"),
+    ),
+    (
+        "fs",
+        "set_mode",
+        SchemaKind::Response,
+        include_str!("../schemas/fs/set_mode.response.json"),
+    ),
+    (
+        "fs",
+        "staged_status",
+        SchemaKind::Request,
+        include_str!("../schemas/fs/staged_status.request.json"),
+    ),
+    (
+        "fs",
+        "staged_status",
+        SchemaKind::Response,
+        include_str!("../schemas/fs/staged_status.response.json"),
+    ),
+    (
+        "fs",
+        "commit_staged",
+        SchemaKind::Request,
+        include_str!("../schemas/fs/commit_staged.request.json"),
+    ),
+    (
+        "fs",
+        "commit_staged",
+        SchemaKind::Response,
+        include_str!("../schemas/fs/commit_staged.response.json"),
+    ),
+    (
+        "fs",
+        "discard_staged",
+        SchemaKind::Request,
+        include_str!("../schemas/fs/discard_staged.request.json"),
+    ),
+    (
+        "fs",
+        "discard_staged",
+        SchemaKind::Response,
+        include_str!("../schemas/fs/discard_staged.response.json"),
+    ),
     // fs_watch/
     (
         "fs_watch",

--- a/crates/harn-hostlib/src/tools/file_io.rs
+++ b/crates/harn-hostlib/src/tools/file_io.rs
@@ -3,8 +3,8 @@
 //!
 //! Shapes are locked by `schemas/tools/{read_file,write_file,delete_file,list_directory}.{request,response}.json`.
 
-use std::fs;
-use std::io::Read;
+use std::fs as stdfs;
+use std::io::{Read, Seek};
 use std::path::PathBuf;
 use std::rc::Rc;
 
@@ -51,6 +51,7 @@ pub(super) fn read_file(args: &[VmValue]) -> Result<VmValue, HostlibError> {
     let limit_bytes = optional_int(READ_FILE_BUILTIN, dict, "limit_bytes", 0)?;
     let encoding_raw = optional_string(READ_FILE_BUILTIN, dict, "encoding")?;
     let encoding = Encoding::parse(READ_FILE_BUILTIN, encoding_raw.as_deref())?;
+    let session_id = optional_string(READ_FILE_BUILTIN, dict, "session_id")?;
 
     if offset < 0 {
         return Err(HostlibError::InvalidParameter {
@@ -68,54 +69,14 @@ pub(super) fn read_file(args: &[VmValue]) -> Result<VmValue, HostlibError> {
     }
 
     let path = PathBuf::from(&path_str);
-
-    let metadata = fs::metadata(&path).map_err(|err| HostlibError::Backend {
-        builtin: READ_FILE_BUILTIN,
-        message: format!("stat `{path_str}`: {err}"),
-    })?;
-    if !metadata.is_file() {
-        return Err(HostlibError::Backend {
-            builtin: READ_FILE_BUILTIN,
-            message: format!("`{path_str}` is not a regular file"),
-        });
-    }
-
-    let total_size = metadata.len();
     let offset_u64 = offset as u64;
-    if offset_u64 > total_size {
-        return Err(HostlibError::InvalidParameter {
-            builtin: READ_FILE_BUILTIN,
-            param: "offset",
-            message: format!("offset {offset_u64} exceeds file length {total_size}"),
-        });
-    }
-
-    let mut file = fs::File::open(&path).map_err(|err| HostlibError::Backend {
-        builtin: READ_FILE_BUILTIN,
-        message: format!("open `{path_str}`: {err}"),
-    })?;
-    if offset_u64 > 0 {
-        use std::io::Seek;
-        file.seek(std::io::SeekFrom::Start(offset_u64))
-            .map_err(|err| HostlibError::Backend {
-                builtin: READ_FILE_BUILTIN,
-                message: format!("seek `{path_str}`: {err}"),
-            })?;
-    }
-
-    let to_read_planned: u64 = if limit_bytes == 0 {
-        total_size - offset_u64
-    } else {
-        std::cmp::min(limit_bytes as u64, total_size - offset_u64)
-    };
-
-    let mut buf = Vec::with_capacity(to_read_planned as usize);
-    file.take(to_read_planned)
-        .read_to_end(&mut buf)
-        .map_err(|err| HostlibError::Backend {
-            builtin: READ_FILE_BUILTIN,
-            message: format!("read `{path_str}`: {err}"),
-        })?;
+    let (buf, total_size) = read_bytes(
+        &path,
+        &path_str,
+        session_id.as_deref(),
+        offset_u64,
+        limit_bytes as u64,
+    )?;
 
     let truncated = (offset_u64 + buf.len() as u64) < total_size;
 
@@ -155,6 +116,7 @@ pub(super) fn write_file(args: &[VmValue]) -> Result<VmValue, HostlibError> {
     let encoding_raw = optional_string(WRITE_FILE_BUILTIN, dict, "encoding")?;
     let create_parents = optional_bool(WRITE_FILE_BUILTIN, dict, "create_parents", true)?;
     let overwrite = optional_bool(WRITE_FILE_BUILTIN, dict, "overwrite", true)?;
+    let session_id = optional_string(WRITE_FILE_BUILTIN, dict, "session_id")?;
 
     let path = PathBuf::from(&path_str);
 
@@ -176,6 +138,21 @@ pub(super) fn write_file(args: &[VmValue]) -> Result<VmValue, HostlibError> {
         }
     };
 
+    if let Some(outcome) = crate::fs::stage_write_or_none(
+        WRITE_FILE_BUILTIN,
+        &path,
+        &bytes,
+        create_parents,
+        overwrite,
+        session_id.as_deref(),
+    )? {
+        return Ok(build_dict([
+            ("path", str_value(&path_str)),
+            ("bytes_written", VmValue::Int(outcome.bytes_written as i64)),
+            ("created", VmValue::Bool(outcome.created)),
+        ]));
+    }
+
     let preexisted = path.exists();
     if preexisted && !overwrite {
         return Err(HostlibError::Backend {
@@ -187,7 +164,7 @@ pub(super) fn write_file(args: &[VmValue]) -> Result<VmValue, HostlibError> {
     if create_parents {
         if let Some(parent) = path.parent() {
             if !parent.as_os_str().is_empty() {
-                fs::create_dir_all(parent).map_err(|err| HostlibError::Backend {
+                stdfs::create_dir_all(parent).map_err(|err| HostlibError::Backend {
                     builtin: WRITE_FILE_BUILTIN,
                     message: format!("mkdir `{}`: {err}", parent.display()),
                 })?;
@@ -195,7 +172,7 @@ pub(super) fn write_file(args: &[VmValue]) -> Result<VmValue, HostlibError> {
         }
     }
 
-    fs::write(&path, &bytes).map_err(|err| HostlibError::Backend {
+    stdfs::write(&path, &bytes).map_err(|err| HostlibError::Backend {
         builtin: WRITE_FILE_BUILTIN,
         message: format!("write `{path_str}`: {err}"),
     })?;
@@ -213,10 +190,22 @@ pub(super) fn delete_file(args: &[VmValue]) -> Result<VmValue, HostlibError> {
 
     let path_str = require_string(DELETE_FILE_BUILTIN, dict, "path")?;
     let recursive = optional_bool(DELETE_FILE_BUILTIN, dict, "recursive", false)?;
+    let session_id = optional_string(DELETE_FILE_BUILTIN, dict, "session_id")?;
 
     let path = PathBuf::from(&path_str);
+    if let Some(removed) = crate::fs::stage_delete_or_none(
+        DELETE_FILE_BUILTIN,
+        &path,
+        recursive,
+        session_id.as_deref(),
+    )? {
+        return Ok(build_dict([
+            ("path", str_value(&path_str)),
+            ("removed", VmValue::Bool(removed)),
+        ]));
+    }
 
-    let metadata = match fs::symlink_metadata(&path) {
+    let metadata = match stdfs::symlink_metadata(&path) {
         Ok(m) => m,
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
             return Ok(build_dict([
@@ -234,13 +223,13 @@ pub(super) fn delete_file(args: &[VmValue]) -> Result<VmValue, HostlibError> {
 
     let removed = if metadata.is_dir() {
         if recursive {
-            fs::remove_dir_all(&path).map_err(|err| HostlibError::Backend {
+            stdfs::remove_dir_all(&path).map_err(|err| HostlibError::Backend {
                 builtin: DELETE_FILE_BUILTIN,
                 message: format!("remove_dir_all `{path_str}`: {err}"),
             })?;
             true
         } else {
-            fs::remove_dir(&path).map_err(|err| HostlibError::Backend {
+            stdfs::remove_dir(&path).map_err(|err| HostlibError::Backend {
                 builtin: DELETE_FILE_BUILTIN,
                 message: format!(
                     "remove_dir `{path_str}` (pass recursive=true to delete non-empty dirs): {err}"
@@ -249,7 +238,7 @@ pub(super) fn delete_file(args: &[VmValue]) -> Result<VmValue, HostlibError> {
             true
         }
     } else {
-        fs::remove_file(&path).map_err(|err| HostlibError::Backend {
+        stdfs::remove_file(&path).map_err(|err| HostlibError::Backend {
             builtin: DELETE_FILE_BUILTIN,
             message: format!("remove_file `{path_str}`: {err}"),
         })?;
@@ -269,6 +258,7 @@ pub(super) fn list_directory(args: &[VmValue]) -> Result<VmValue, HostlibError> 
     let path_str = require_string(LIST_DIRECTORY_BUILTIN, dict, "path")?;
     let include_hidden = optional_bool(LIST_DIRECTORY_BUILTIN, dict, "include_hidden", false)?;
     let max_entries = optional_int(LIST_DIRECTORY_BUILTIN, dict, "max_entries", 0)?;
+    let session_id = optional_string(LIST_DIRECTORY_BUILTIN, dict, "session_id")?;
 
     if max_entries < 0 {
         return Err(HostlibError::InvalidParameter {
@@ -284,41 +274,54 @@ pub(super) fn list_directory(args: &[VmValue]) -> Result<VmValue, HostlibError> 
     };
 
     let path = PathBuf::from(&path_str);
-    let read = fs::read_dir(&path).map_err(|err| HostlibError::Backend {
-        builtin: LIST_DIRECTORY_BUILTIN,
-        message: format!("read_dir `{path_str}`: {err}"),
-    })?;
-
     let mut entries: Vec<(String, VmValue)> = Vec::new();
     let mut truncated = false;
-    let mut all_names: Vec<(String, fs::DirEntry, fs::Metadata)> = Vec::new();
+    let mut all_names: Vec<(String, bool, bool, u64)> = Vec::new();
 
-    for entry in read {
-        let entry = match entry {
-            Ok(e) => e,
-            Err(_) => continue,
-        };
-        let name = entry.file_name().to_string_lossy().into_owned();
-        if !include_hidden && name.starts_with('.') {
-            continue;
+    if let Some(read) = crate::fs::read_dir(&path, session_id.as_deref()) {
+        for entry in read.map_err(|err| HostlibError::Backend {
+            builtin: LIST_DIRECTORY_BUILTIN,
+            message: format!("read_dir `{path_str}`: {err}"),
+        })? {
+            if !include_hidden && entry.name.starts_with('.') {
+                continue;
+            }
+            all_names.push((entry.name, entry.is_dir, entry.is_symlink, entry.size));
         }
-        let metadata = match entry.metadata() {
-            Ok(m) => m,
-            Err(_) => continue,
-        };
-        all_names.push((name, entry, metadata));
+    } else {
+        let read = stdfs::read_dir(&path).map_err(|err| HostlibError::Backend {
+            builtin: LIST_DIRECTORY_BUILTIN,
+            message: format!("read_dir `{path_str}`: {err}"),
+        })?;
+        for entry in read {
+            let entry = match entry {
+                Ok(e) => e,
+                Err(_) => continue,
+            };
+            let name = entry.file_name().to_string_lossy().into_owned();
+            if !include_hidden && name.starts_with('.') {
+                continue;
+            }
+            let metadata = match entry.metadata() {
+                Ok(m) => m,
+                Err(_) => continue,
+            };
+            let file_type = entry.file_type().ok();
+            all_names.push((
+                name,
+                file_type.map(|t| t.is_dir()).unwrap_or(false),
+                file_type.map(|t| t.is_symlink()).unwrap_or(false),
+                file_size(&metadata),
+            ));
+        }
     }
     all_names.sort_by(|a, b| a.0.cmp(&b.0));
 
-    for (name, entry, metadata) in all_names {
+    for (name, is_dir, is_symlink, size) in all_names {
         if entries.len() >= cap {
             truncated = true;
             break;
         }
-        let file_type = entry.file_type().ok();
-        let is_dir = file_type.map(|t| t.is_dir()).unwrap_or(false);
-        let is_symlink = file_type.map(|t| t.is_symlink()).unwrap_or(false);
-        let size = file_size(&metadata);
         let entry_value = build_dict([
             ("name", str_value(&name)),
             ("is_dir", VmValue::Bool(is_dir)),
@@ -336,6 +339,88 @@ pub(super) fn list_directory(args: &[VmValue]) -> Result<VmValue, HostlibError> 
     ]))
 }
 
-fn file_size(metadata: &fs::Metadata) -> u64 {
+fn file_size(metadata: &stdfs::Metadata) -> u64 {
     metadata.len()
+}
+
+fn read_bytes(
+    path: &PathBuf,
+    path_str: &str,
+    session_id: Option<&str>,
+    offset: u64,
+    limit_bytes: u64,
+) -> Result<(Vec<u8>, u64), HostlibError> {
+    if let Some(result) = crate::fs::read(path, session_id) {
+        let bytes = result.map_err(|err| HostlibError::Backend {
+            builtin: READ_FILE_BUILTIN,
+            message: format!("read `{path_str}`: {err}"),
+        })?;
+        return slice_bytes(bytes, offset, limit_bytes);
+    }
+
+    let metadata = stdfs::metadata(path).map_err(|err| HostlibError::Backend {
+        builtin: READ_FILE_BUILTIN,
+        message: format!("stat `{path_str}`: {err}"),
+    })?;
+    if !metadata.is_file() {
+        return Err(HostlibError::Backend {
+            builtin: READ_FILE_BUILTIN,
+            message: format!("`{path_str}` is not a regular file"),
+        });
+    }
+    let total_size = metadata.len();
+    validate_read_offset(offset, total_size)?;
+    let to_read = planned_read_len(offset, limit_bytes, total_size);
+
+    let mut file = stdfs::File::open(path).map_err(|err| HostlibError::Backend {
+        builtin: READ_FILE_BUILTIN,
+        message: format!("open `{path_str}`: {err}"),
+    })?;
+    if offset > 0 {
+        file.seek(std::io::SeekFrom::Start(offset))
+            .map_err(|err| HostlibError::Backend {
+                builtin: READ_FILE_BUILTIN,
+                message: format!("seek `{path_str}`: {err}"),
+            })?;
+    }
+    let mut buf = Vec::with_capacity(to_read as usize);
+    file.take(to_read)
+        .read_to_end(&mut buf)
+        .map_err(|err| HostlibError::Backend {
+            builtin: READ_FILE_BUILTIN,
+            message: format!("read `{path_str}`: {err}"),
+        })?;
+    Ok((buf, total_size))
+}
+
+fn slice_bytes(
+    bytes: Vec<u8>,
+    offset: u64,
+    limit_bytes: u64,
+) -> Result<(Vec<u8>, u64), HostlibError> {
+    let total_size = bytes.len() as u64;
+    validate_read_offset(offset, total_size)?;
+    let to_read = planned_read_len(offset, limit_bytes, total_size);
+    let start = offset as usize;
+    let end = start + to_read as usize;
+    Ok((bytes[start..end].to_vec(), total_size))
+}
+
+fn validate_read_offset(offset: u64, total_size: u64) -> Result<(), HostlibError> {
+    if offset > total_size {
+        return Err(HostlibError::InvalidParameter {
+            builtin: READ_FILE_BUILTIN,
+            param: "offset",
+            message: format!("offset {offset} exceeds file length {total_size}"),
+        });
+    }
+    Ok(())
+}
+
+fn planned_read_len(offset: u64, limit_bytes: u64, total_size: u64) -> u64 {
+    if limit_bytes == 0 {
+        total_size - offset
+    } else {
+        std::cmp::min(limit_bytes, total_size - offset)
+    }
 }

--- a/crates/harn-hostlib/src/tools/outline.rs
+++ b/crates/harn-hostlib/src/tools/outline.rs
@@ -7,7 +7,6 @@
 //! `ast.outline`'s response schema, so the extractor can be replaced by a
 //! tree-sitter implementation without disturbing callers.
 
-use std::fs;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
@@ -24,6 +23,7 @@ pub(super) fn run(args: &[VmValue]) -> Result<VmValue, HostlibError> {
 
     let path_str = require_string(BUILTIN, dict, "path")?;
     let max_depth = optional_int(BUILTIN, dict, "max_depth", 0)?;
+    let session_id = crate::tools::args::optional_string(BUILTIN, dict, "session_id")?;
     if max_depth < 0 {
         return Err(HostlibError::InvalidParameter {
             builtin: BUILTIN,
@@ -36,7 +36,11 @@ pub(super) fn run(args: &[VmValue]) -> Result<VmValue, HostlibError> {
     let path = PathBuf::from(&path_str);
     let language = detect_language(&path);
 
-    let content = fs::read_to_string(&path).map_err(|err| HostlibError::Backend {
+    let content = match crate::fs::read_to_string(&path, session_id.as_deref()) {
+        Some(result) => result,
+        None => std::fs::read_to_string(&path),
+    }
+    .map_err(|err| HostlibError::Backend {
         builtin: BUILTIN,
         message: format!("read `{path_str}`: {err}"),
     })?;

--- a/crates/harn-hostlib/tests/fs_staging.rs
+++ b/crates/harn-hostlib/tests/fs_staging.rs
@@ -1,0 +1,352 @@
+//! Integration tests for session-scoped staged filesystem mode.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+use std::rc::Rc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use harn_hostlib::tools::permissions;
+use harn_hostlib::{fs::FsCapability, tools::ToolsCapability, BuiltinRegistry, HostlibCapability};
+use harn_vm::VmValue;
+use tempfile::TempDir;
+
+fn registry() -> BuiltinRegistry {
+    permissions::reset();
+    permissions::enable_for_test();
+    let mut registry = BuiltinRegistry::new();
+    FsCapability.register_builtins(&mut registry);
+    ToolsCapability.register_builtins(&mut registry);
+    registry
+}
+
+fn dict_arg(entries: &[(&str, VmValue)]) -> Vec<VmValue> {
+    let mut map: BTreeMap<String, VmValue> = BTreeMap::new();
+    for (k, v) in entries {
+        map.insert(k.to_string(), v.clone());
+    }
+    vec![VmValue::Dict(Rc::new(map))]
+}
+
+fn vm_string(s: &str) -> VmValue {
+    VmValue::String(Rc::from(s))
+}
+
+fn dict_get<'a>(value: &'a VmValue, key: &str) -> &'a VmValue {
+    match value {
+        VmValue::Dict(d) => d.get(key).expect("key present"),
+        other => panic!("not a dict: {other:?}"),
+    }
+}
+
+fn path_str(path: &Path) -> String {
+    path.to_string_lossy().into_owned()
+}
+
+fn unique_session(name: &str) -> String {
+    static NEXT_SESSION: AtomicUsize = AtomicUsize::new(1);
+    format!("{name}-{}", NEXT_SESSION.fetch_add(1, Ordering::Relaxed))
+}
+
+#[test]
+fn staged_write_is_read_through_until_commit() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("note.txt");
+    let session = unique_session("staged-write");
+    let reg = registry();
+
+    (reg.find("hostlib_fs_set_mode").unwrap().handler)(&dict_arg(&[
+        ("session_id", vm_string(&session)),
+        ("mode", vm_string("staged")),
+        ("root", vm_string(&path_str(dir.path()))),
+    ]))
+    .unwrap();
+
+    let write = reg.find("hostlib_tools_write_file").unwrap();
+    (write.handler)(&dict_arg(&[
+        ("session_id", vm_string(&session)),
+        ("path", vm_string(&path_str(&file))),
+        ("content", vm_string("draft")),
+    ]))
+    .unwrap();
+
+    assert!(
+        !file.exists(),
+        "staged writes must not touch the working tree"
+    );
+
+    let read = reg.find("hostlib_tools_read_file").unwrap();
+    let result = (read.handler)(&dict_arg(&[
+        ("session_id", vm_string(&session)),
+        ("path", vm_string(&path_str(&file))),
+    ]))
+    .unwrap();
+    assert!(matches!(dict_get(&result, "content"), VmValue::String(s) if s.as_ref() == "draft"));
+
+    let status = (reg.find("hostlib_fs_staged_status").unwrap().handler)(&dict_arg(&[(
+        "session_id",
+        vm_string(&session),
+    )]))
+    .unwrap();
+    assert!(matches!(
+        dict_get(&status, "total_bytes_pending"),
+        VmValue::Int(5)
+    ));
+
+    let commit = (reg.find("hostlib_fs_commit_staged").unwrap().handler)(&dict_arg(&[(
+        "session_id",
+        vm_string(&session),
+    )]))
+    .unwrap();
+    let committed = match dict_get(&commit, "committed_paths") {
+        VmValue::List(paths) => paths,
+        other => panic!("expected committed path list, got {other:?}"),
+    };
+    assert_eq!(committed.len(), 1);
+    assert_eq!(fs::read_to_string(&file).unwrap(), "draft");
+}
+
+#[test]
+fn staged_delete_masks_disk_and_discard_restores_view() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("keep.txt");
+    fs::write(&file, "disk").unwrap();
+    let session = unique_session("staged-delete");
+    let reg = registry();
+
+    (reg.find("hostlib_fs_set_mode").unwrap().handler)(&dict_arg(&[
+        ("session_id", vm_string(&session)),
+        ("mode", vm_string("staged")),
+        ("root", vm_string(&path_str(dir.path()))),
+    ]))
+    .unwrap();
+
+    let delete = reg.find("hostlib_tools_delete_file").unwrap();
+    let deleted = (delete.handler)(&dict_arg(&[
+        ("session_id", vm_string(&session)),
+        ("path", vm_string(&path_str(&file))),
+    ]))
+    .unwrap();
+    assert!(matches!(dict_get(&deleted, "removed"), VmValue::Bool(true)));
+    assert!(
+        file.exists(),
+        "staged deletes must leave the working tree untouched"
+    );
+
+    let read = reg.find("hostlib_tools_read_file").unwrap();
+    assert!(
+        (read.handler)(&dict_arg(&[
+            ("session_id", vm_string(&session)),
+            ("path", vm_string(&path_str(&file))),
+        ]))
+        .is_err(),
+        "read-through overlay should mask a staged delete"
+    );
+
+    let discard = (reg.find("hostlib_fs_discard_staged").unwrap().handler)(&dict_arg(&[(
+        "session_id",
+        vm_string(&session),
+    )]))
+    .unwrap();
+    let discarded = match dict_get(&discard, "discarded_paths") {
+        VmValue::List(paths) => paths,
+        other => panic!("expected discarded path list, got {other:?}"),
+    };
+    assert_eq!(discarded.len(), 1);
+
+    let result = (read.handler)(&dict_arg(&[
+        ("session_id", vm_string(&session)),
+        ("path", vm_string(&path_str(&file))),
+    ]))
+    .unwrap();
+    assert!(matches!(dict_get(&result, "content"), VmValue::String(s) if s.as_ref() == "disk"));
+}
+
+#[test]
+fn staged_overlay_uses_current_agent_session_when_args_omit_session_id() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("implicit.txt");
+    let session = unique_session("implicit-session");
+    let reg = registry();
+
+    (reg.find("hostlib_fs_set_mode").unwrap().handler)(&dict_arg(&[
+        ("session_id", vm_string(&session)),
+        ("mode", vm_string("staged")),
+        ("root", vm_string(&path_str(dir.path()))),
+    ]))
+    .unwrap();
+
+    let _session_guard = harn_vm::agent_sessions::enter_current_session(session.clone());
+    (reg.find("hostlib_tools_write_file").unwrap().handler)(&dict_arg(&[
+        ("path", vm_string(&path_str(&file))),
+        ("content", vm_string("implicit")),
+    ]))
+    .unwrap();
+
+    assert!(!file.exists());
+    let result = (reg.find("hostlib_tools_read_file").unwrap().handler)(&dict_arg(&[(
+        "path",
+        vm_string(&path_str(&file)),
+    )]))
+    .unwrap();
+    assert!(matches!(dict_get(&result, "content"), VmValue::String(s) if s.as_ref() == "implicit"));
+}
+
+#[test]
+fn staged_write_with_new_parent_is_visible_in_directory_overlay() {
+    let dir = TempDir::new().unwrap();
+    let nested = dir.path().join("new-parent").join("file.txt");
+    let session = unique_session("staged-implicit-parent");
+    let reg = registry();
+
+    (reg.find("hostlib_fs_set_mode").unwrap().handler)(&dict_arg(&[
+        ("session_id", vm_string(&session)),
+        ("mode", vm_string("staged")),
+        ("root", vm_string(&path_str(dir.path()))),
+    ]))
+    .unwrap();
+
+    (reg.find("hostlib_tools_write_file").unwrap().handler)(&dict_arg(&[
+        ("session_id", vm_string(&session)),
+        ("path", vm_string(&path_str(&nested))),
+        ("content", vm_string("nested")),
+        ("create_parents", VmValue::Bool(true)),
+    ]))
+    .unwrap();
+
+    let list_root = (reg.find("hostlib_tools_list_directory").unwrap().handler)(&dict_arg(&[
+        ("session_id", vm_string(&session)),
+        ("path", vm_string(&path_str(dir.path()))),
+    ]))
+    .unwrap();
+    let entries = match dict_get(&list_root, "entries") {
+        VmValue::List(entries) => entries,
+        other => panic!("expected directory entries, got {other:?}"),
+    };
+    let parent = entries.iter().find(|entry| {
+        matches!(dict_get(entry, "name"), VmValue::String(name) if name.as_ref() == "new-parent")
+    });
+    assert!(matches!(
+        parent.map(|entry| dict_get(entry, "is_dir")),
+        Some(VmValue::Bool(true))
+    ));
+
+    let list_nested = (reg.find("hostlib_tools_list_directory").unwrap().handler)(&dict_arg(&[
+        ("session_id", vm_string(&session)),
+        ("path", vm_string(&path_str(nested.parent().unwrap()))),
+    ]))
+    .unwrap();
+    let entries = match dict_get(&list_nested, "entries") {
+        VmValue::List(entries) => entries,
+        other => panic!("expected nested directory entries, got {other:?}"),
+    };
+    assert!(entries.iter().any(|entry| {
+        matches!(dict_get(entry, "name"), VmValue::String(name) if name.as_ref() == "file.txt")
+    }));
+    assert!(!nested.exists());
+}
+
+#[test]
+fn staged_delete_of_overlay_parent_drops_child_writes() {
+    let dir = TempDir::new().unwrap();
+    let nested = dir.path().join("new-parent").join("file.txt");
+    let session = unique_session("staged-delete-parent");
+    let reg = registry();
+
+    (reg.find("hostlib_fs_set_mode").unwrap().handler)(&dict_arg(&[
+        ("session_id", vm_string(&session)),
+        ("mode", vm_string("staged")),
+        ("root", vm_string(&path_str(dir.path()))),
+    ]))
+    .unwrap();
+
+    (reg.find("hostlib_tools_write_file").unwrap().handler)(&dict_arg(&[
+        ("session_id", vm_string(&session)),
+        ("path", vm_string(&path_str(&nested))),
+        ("content", vm_string("nested")),
+        ("create_parents", VmValue::Bool(true)),
+    ]))
+    .unwrap();
+
+    let deleted = (reg.find("hostlib_tools_delete_file").unwrap().handler)(&dict_arg(&[
+        ("session_id", vm_string(&session)),
+        ("path", vm_string(&path_str(&dir.path().join("new-parent")))),
+        ("recursive", VmValue::Bool(true)),
+    ]))
+    .unwrap();
+    assert!(matches!(dict_get(&deleted, "removed"), VmValue::Bool(true)));
+
+    let status = (reg.find("hostlib_fs_staged_status").unwrap().handler)(&dict_arg(&[(
+        "session_id",
+        vm_string(&session),
+    )]))
+    .unwrap();
+    let pending = match dict_get(&status, "pending_writes") {
+        VmValue::List(pending) => pending,
+        other => panic!("expected pending list, got {other:?}"),
+    };
+    assert!(pending.is_empty());
+    assert!(!nested.exists());
+}
+
+#[test]
+fn staged_discard_prunes_unreferenced_body_blobs() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("secret.txt");
+    let session = unique_session("staged-prune");
+    let reg = registry();
+
+    (reg.find("hostlib_fs_set_mode").unwrap().handler)(&dict_arg(&[
+        ("session_id", vm_string(&session)),
+        ("mode", vm_string("staged")),
+        ("root", vm_string(&path_str(dir.path()))),
+    ]))
+    .unwrap();
+
+    (reg.find("hostlib_tools_write_file").unwrap().handler)(&dict_arg(&[
+        ("session_id", vm_string(&session)),
+        ("path", vm_string(&path_str(&file))),
+        ("content", vm_string("secret")),
+    ]))
+    .unwrap();
+
+    let body_dir = dir
+        .path()
+        .join(".harn")
+        .join("state")
+        .join("staged")
+        .join(&session)
+        .join("bodies");
+    assert_eq!(fs::read_dir(&body_dir).unwrap().count(), 1);
+
+    (reg.find("hostlib_fs_discard_staged").unwrap().handler)(&dict_arg(&[(
+        "session_id",
+        vm_string(&session),
+    )]))
+    .unwrap();
+
+    assert_eq!(fs::read_dir(&body_dir).unwrap().count(), 0);
+}
+
+#[test]
+fn staged_directory_overlay_preserves_missing_directory_errors() {
+    let dir = TempDir::new().unwrap();
+    let session = unique_session("staged-missing-dir");
+    let reg = registry();
+
+    (reg.find("hostlib_fs_set_mode").unwrap().handler)(&dict_arg(&[
+        ("session_id", vm_string(&session)),
+        ("mode", vm_string("staged")),
+        ("root", vm_string(&path_str(dir.path()))),
+    ]))
+    .unwrap();
+
+    let result = (reg.find("hostlib_tools_list_directory").unwrap().handler)(&dict_arg(&[
+        ("session_id", vm_string(&session)),
+        ("path", vm_string(&path_str(&dir.path().join("missing")))),
+    ]));
+    assert!(
+        result.is_err(),
+        "missing staged directories should not list as empty"
+    );
+}

--- a/crates/harn-hostlib/tests/registration.rs
+++ b/crates/harn-hostlib/tests/registration.rs
@@ -8,9 +8,10 @@
 //! removed builtin.
 
 use harn_hostlib::{
-    ast::AstCapability, code_index::CodeIndexCapability, fs_watch::FsWatchCapability,
-    scanner::ScannerCapability, schemas, secret_store::SecretStoreCapability,
-    tools::ToolsCapability, BuiltinRegistry, HostlibCapability, HostlibError, HostlibRegistry,
+    ast::AstCapability, code_index::CodeIndexCapability, fs::FsCapability,
+    fs_watch::FsWatchCapability, scanner::ScannerCapability, schemas,
+    secret_store::SecretStoreCapability, tools::ToolsCapability, BuiltinRegistry,
+    HostlibCapability, HostlibError, HostlibRegistry,
 };
 
 fn collect_into_registry<C: HostlibCapability>(cap: C) -> BuiltinRegistry {
@@ -156,6 +157,38 @@ fn scanner_capability_registers_documented_methods() {
 }
 
 #[test]
+fn fs_capability_registers_documented_methods() {
+    let registry = collect_into_registry(FsCapability);
+    let names: Vec<_> = registry.iter().map(|b| b.name).collect();
+    assert_eq!(
+        names,
+        vec![
+            "hostlib_fs_set_mode",
+            "hostlib_fs_staged_status",
+            "hostlib_fs_commit_staged",
+            "hostlib_fs_discard_staged",
+        ]
+    );
+    let expected_missing: &[(&str, &str)] = &[
+        ("hostlib_fs_set_mode", "session_id"),
+        ("hostlib_fs_staged_status", "session_id"),
+        ("hostlib_fs_commit_staged", "session_id"),
+        ("hostlib_fs_discard_staged", "session_id"),
+    ];
+    for (name, expected_param) in expected_missing {
+        let entry = registry.find(name).expect("registered");
+        let err = (entry.handler)(&[]).expect_err("must reject empty args");
+        match err {
+            HostlibError::MissingParameter { builtin, param } => {
+                assert_eq!(builtin, *name);
+                assert_eq!(param, *expected_param);
+            }
+            other => panic!("expected MissingParameter for {name}, got {other:?}"),
+        }
+    }
+}
+
+#[test]
 fn fs_watch_capability_registers_documented_methods() {
     let registry = collect_into_registry(FsWatchCapability);
     let names: Vec<_> = registry.iter().map(|b| b.name).collect();
@@ -285,14 +318,15 @@ fn install_default_wires_every_module_into_a_vm() {
             "ast",
             "code_index",
             "scanner",
+            "fs",
             "fs_watch",
             "tools",
             "secret_store"
         ]
     );
-    // Builtin count: 12 ast + 27 code_index + 2 scanner + 2 fs_watch + 13
-    // tools + 1 hostlib_enable + 4 secret_store = 61.
-    assert!(registry.builtins().len() >= 61);
+    // Builtin count: 12 ast + 27 code_index + 2 scanner + 4 fs + 2
+    // fs_watch + 13 tools + 1 hostlib_enable + 4 secret_store = 65.
+    assert!(registry.builtins().len() >= 65);
 }
 
 #[test]
@@ -301,6 +335,7 @@ fn every_registered_builtin_has_request_and_response_schemas() {
         .with(AstCapability)
         .with(CodeIndexCapability::new())
         .with(ScannerCapability)
+        .with(FsCapability)
         .with(FsWatchCapability)
         .with(ToolsCapability)
         .with(SecretStoreCapability);

--- a/crates/harn-serve/Cargo.toml
+++ b/crates/harn-serve/Cargo.toml
@@ -15,6 +15,7 @@ base64 = "0.22"
 futures = "0.3"
 harn-parser = { path = "../harn-parser", version = "0.8" }
 harn-vm = { path = "../harn-vm", version = "0.8" }
+harn-hostlib = { path = "../harn-hostlib", version = "0.8", optional = true }
 hmac = "0.13"
 rcgen = "0.14"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
@@ -30,6 +31,10 @@ toml = "1.1"
 tracing = "0.1"
 url = "2"
 uuid = { version = "1", features = ["v4", "v7"] }
+
+[features]
+default = []
+hostlib = ["dep:harn-hostlib"]
 
 [dev-dependencies]
 filetime = "0.2"

--- a/crates/harn-serve/src/adapters/acp/events.rs
+++ b/crates/harn-serve/src/adapters/acp/events.rs
@@ -611,6 +611,37 @@ impl AgentEventSink for AcpAgentEventSink {
                     "update": update,
                 }));
             }
+            AgentEvent::StagedWritesPending {
+                session_id,
+                pending_count,
+                total_bytes,
+            } => {
+                let mut update = super::bridge::progress_update(
+                    "fs_staging",
+                    "staged writes pending",
+                    Some(*pending_count as i64),
+                    None,
+                    None,
+                );
+                let mut harn_meta = serde_json::Map::new();
+                harn_meta.insert(
+                    "kind".to_string(),
+                    serde_json::Value::String("staged_writes_pending".to_string()),
+                );
+                harn_meta.insert(
+                    "pendingCount".to_string(),
+                    serde_json::Value::from(*pending_count as u64),
+                );
+                harn_meta.insert(
+                    "totalBytes".to_string(),
+                    serde_json::Value::from(*total_bytes),
+                );
+                merge_harn_meta(&mut update, harn_meta);
+                self.write_notification(serde_json::json!({
+                    "sessionId": session_id,
+                    "update": update,
+                }));
+            }
             AgentEvent::WorkerUpdate {
                 session_id,
                 worker_id,

--- a/crates/harn-serve/src/adapters/acp/mod.rs
+++ b/crates/harn-serve/src/adapters/acp/mod.rs
@@ -632,7 +632,11 @@ impl AcpServer {
                 profile_turn: 0,
             },
         );
-        harn_vm::agent_sessions::open_or_create(Some(session_id));
+        harn_vm::agent_sessions::open_or_create(Some(session_id.clone()));
+        #[cfg(feature = "hostlib")]
+        if let Some(session) = self.sessions.get(&session_id) {
+            harn_hostlib::fs::configure_session_root(&session_id, &session.cwd);
+        }
     }
 
     fn handle_session_new(&mut self, id: &serde_json::Value, params: &serde_json::Value) {
@@ -963,6 +967,8 @@ impl AcpServer {
         };
         harn_vm::agent_sessions::open_or_create(Some(session_id.clone()));
         let _session_guard = harn_vm::agent_sessions::enter_current_session(session_id.clone());
+        #[cfg(feature = "hostlib")]
+        harn_hostlib::fs::configure_session_root(&session_id, &cwd);
 
         let (source, source_path) = if let Some(ref pipeline_path) = self.pipeline {
             let full_path = if Path::new(pipeline_path).is_absolute() {
@@ -1516,6 +1522,159 @@ impl AcpServer {
         );
     }
 
+    #[cfg(feature = "hostlib")]
+    fn emit_staged_writes_update(&self, session_id: &str) {
+        let Ok(status) = harn_hostlib::fs::staged_status(session_id) else {
+            return;
+        };
+        let mut update = bridge::progress_update(
+            "fs_staging",
+            "staged writes pending",
+            Some(status.pending_writes.len() as i64),
+            None,
+            None,
+        );
+        let mut harn_meta = serde_json::Map::new();
+        harn_meta.insert(
+            "kind".to_string(),
+            serde_json::Value::String("staged_writes_pending".to_string()),
+        );
+        harn_meta.insert(
+            "pendingCount".to_string(),
+            serde_json::Value::from(status.pending_writes.len() as u64),
+        );
+        harn_meta.insert(
+            "totalBytes".to_string(),
+            serde_json::Value::from(status.total_bytes_pending),
+        );
+        events::merge_harn_meta(&mut update, harn_meta);
+        self.send_notification(
+            "session/update",
+            serde_json::json!({
+                "sessionId": session_id,
+                "update": update,
+            }),
+        );
+    }
+
+    #[cfg(feature = "hostlib")]
+    fn handle_session_fs_mode(&mut self, id: &serde_json::Value, params: &serde_json::Value) {
+        let Some(session_id) = params
+            .get("sessionId")
+            .or_else(|| params.get("session_id"))
+            .and_then(serde_json::Value::as_str)
+        else {
+            self.send_error(id, -32602, "session/fs_mode requires sessionId");
+            return;
+        };
+        let Some(mode_raw) = params.get("mode").and_then(serde_json::Value::as_str) else {
+            self.send_error(id, -32602, "session/fs_mode requires mode");
+            return;
+        };
+        let mode = match mode_raw {
+            "immediate" => harn_hostlib::fs::FsMode::Immediate,
+            "staged" => harn_hostlib::fs::FsMode::Staged,
+            other => {
+                self.send_error(
+                    id,
+                    -32602,
+                    &format!("session/fs_mode mode must be immediate or staged, got {other}"),
+                );
+                return;
+            }
+        };
+        let Some(cwd) = self
+            .sessions
+            .get(session_id)
+            .map(|session| session.cwd.clone())
+        else {
+            self.send_error(id, -32602, &format!("Unknown session: {session_id}"));
+            return;
+        };
+        match harn_hostlib::fs::set_mode(session_id, mode, Some(&cwd)) {
+            Ok(result) => {
+                self.send_response(
+                    id,
+                    serde_json::json!({
+                        "previousMode": result.previous_mode.as_str(),
+                        "mode": mode.as_str(),
+                    }),
+                );
+                self.emit_staged_writes_update(session_id);
+            }
+            Err(error) => self.send_error(id, -32000, &error.to_string()),
+        }
+    }
+
+    #[cfg(not(feature = "hostlib"))]
+    fn handle_session_fs_mode(&mut self, id: &serde_json::Value, _params: &serde_json::Value) {
+        self.send_error(id, -32601, "session/fs_mode requires the hostlib feature");
+    }
+
+    #[cfg(feature = "hostlib")]
+    fn handle_session_fs_commit_staged(
+        &mut self,
+        id: &serde_json::Value,
+        params: &serde_json::Value,
+    ) {
+        let Some(session_id) = params
+            .get("sessionId")
+            .or_else(|| params.get("session_id"))
+            .and_then(serde_json::Value::as_str)
+        else {
+            self.send_error(id, -32602, "session/fs_commit_staged requires sessionId");
+            return;
+        };
+        if !self.sessions.contains_key(session_id) {
+            self.send_error(id, -32602, &format!("Unknown session: {session_id}"));
+            return;
+        }
+        let paths = params
+            .get("paths")
+            .and_then(serde_json::Value::as_array)
+            .map(|values| {
+                values
+                    .iter()
+                    .filter_map(serde_json::Value::as_str)
+                    .map(str::to_string)
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        match harn_hostlib::fs::commit_staged(session_id, &paths) {
+            Ok(result) => {
+                self.send_response(
+                    id,
+                    serde_json::json!({
+                        "committedPaths": result.committed_paths,
+                        "failedPathsWithReasons": result
+                            .failed_paths_with_reasons
+                            .into_iter()
+                            .map(|(path, reason)| serde_json::json!({
+                                "path": path,
+                                "reason": reason,
+                            }))
+                            .collect::<Vec<_>>(),
+                    }),
+                );
+                self.emit_staged_writes_update(session_id);
+            }
+            Err(error) => self.send_error(id, -32000, &error.to_string()),
+        }
+    }
+
+    #[cfg(not(feature = "hostlib"))]
+    fn handle_session_fs_commit_staged(
+        &mut self,
+        id: &serde_json::Value,
+        _params: &serde_json::Value,
+    ) {
+        self.send_error(
+            id,
+            -32601,
+            "session/fs_commit_staged requires the hostlib feature",
+        );
+    }
+
     fn handle_session_set_mode(&mut self, id: &serde_json::Value, params: &serde_json::Value) {
         let Some(session_id) = params
             .get("sessionId")
@@ -1649,6 +1808,18 @@ impl AcpServer {
                     return;
                 }
                 self.handle_session_set_config_option(&id, &params);
+            }
+            "session/fs_mode" => {
+                if self.reject_unauthenticated(&id) {
+                    return;
+                }
+                self.handle_session_fs_mode(&id, &params);
+            }
+            "session/fs_commit_staged" => {
+                if self.reject_unauthenticated(&id) {
+                    return;
+                }
+                self.handle_session_fs_commit_staged(&id, &params);
             }
             "session/prompt" => {
                 if self.reject_unauthenticated(&id) {

--- a/crates/harn-serve/src/adapters/acp/tests.rs
+++ b/crates/harn-serve/src/adapters/acp/tests.rs
@@ -121,6 +121,105 @@ async fn start_acp_code_session_with_config(
     (request_tx, response_rx, server, session_id)
 }
 
+#[cfg(feature = "hostlib")]
+#[tokio::test(flavor = "current_thread")]
+async fn acp_fs_mode_and_commit_staged_apply_deferred_hostlib_writes() {
+    use harn_hostlib::{
+        tools::{permissions, ToolsCapability},
+        BuiltinRegistry, HostlibCapability,
+    };
+
+    permissions::reset();
+    permissions::enable_for_test();
+
+    let dir = tempfile::TempDir::new().unwrap();
+    let file = dir.path().join("draft.txt");
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let mut server = AcpServer::new_with_output(AcpServerConfig::new(None), AcpOutput::Channel(tx));
+
+    server
+        .handle_incoming_message(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "session/new",
+            "params": {"cwd": dir.path().to_string_lossy()},
+        }))
+        .await;
+    let created = recv_json(&mut rx).await;
+    let session_id = created["result"]["sessionId"]
+        .as_str()
+        .expect("session id")
+        .to_string();
+
+    server
+        .handle_incoming_message(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "session/fs_mode",
+            "params": {"sessionId": session_id.clone(), "mode": "staged"},
+        }))
+        .await;
+    let mode_response = recv_json(&mut rx).await;
+    assert_eq!(mode_response["result"]["previousMode"], "immediate");
+    assert_eq!(mode_response["result"]["mode"], "staged");
+    let mode_update = recv_json(&mut rx).await;
+    assert_eq!(
+        mode_update["params"]["update"]["_meta"]["harn"]["kind"],
+        "staged_writes_pending"
+    );
+    assert_eq!(
+        mode_update["params"]["update"]["_meta"]["harn"]["pendingCount"],
+        0
+    );
+
+    let mut registry = BuiltinRegistry::new();
+    ToolsCapability.register_builtins(&mut registry);
+    let mut args = BTreeMap::new();
+    args.insert(
+        "session_id".to_string(),
+        VmValue::String(Rc::from(session_id.as_str())),
+    );
+    args.insert(
+        "path".to_string(),
+        VmValue::String(Rc::from(file.to_string_lossy().as_ref())),
+    );
+    args.insert("content".to_string(), VmValue::String(Rc::from("draft")));
+    (registry
+        .find("hostlib_tools_write_file")
+        .expect("write_file builtin")
+        .handler)(&[VmValue::Dict(Rc::new(args))])
+    .expect("stage write");
+    assert!(!file.exists(), "ACP staged mode should defer disk writes");
+
+    server
+        .handle_incoming_message(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "session/fs_commit_staged",
+            "params": {"sessionId": session_id.clone()},
+        }))
+        .await;
+    let commit_response = recv_json(&mut rx).await;
+    assert_eq!(
+        commit_response["result"]["committedPaths"]
+            .as_array()
+            .unwrap()
+            .len(),
+        1
+    );
+    assert_eq!(std::fs::read_to_string(&file).unwrap(), "draft");
+
+    let commit_update = recv_json(&mut rx).await;
+    assert_eq!(
+        commit_update["params"]["update"]["_meta"]["harn"]["kind"],
+        "staged_writes_pending"
+    );
+    assert_eq!(
+        commit_update["params"]["update"]["_meta"]["harn"]["pendingCount"],
+        0
+    );
+}
+
 #[test]
 fn normalize_host_capabilities_wraps_array_entries_in_ops_dicts() {
     let mut root = BTreeMap::new();

--- a/crates/harn-vm/src/agent_events.rs
+++ b/crates/harn-vm/src/agent_events.rs
@@ -525,6 +525,15 @@ pub enum AgentEvent {
         subscription_id: String,
         events: Vec<FsWatchEvent>,
     },
+    /// Emitted when hostlib staged filesystem state changes for a session.
+    /// The ACP adapter maps this to the existing `progress` extension so
+    /// clients can update rollup-diff badges without waiting for a prompt
+    /// turn boundary.
+    StagedWritesPending {
+        session_id: String,
+        pending_count: usize,
+        total_bytes: u64,
+    },
     /// Lifecycle update for a delegated/background worker. Carries the
     /// canonical typed `event` variant alongside the worker's current
     /// `status` string and the structured `metadata` payload that
@@ -704,6 +713,7 @@ impl AgentEvent {
             | Self::TranscriptCompacted { session_id, .. }
             | Self::Handoff { session_id, .. }
             | Self::FsWatch { session_id, .. }
+            | Self::StagedWritesPending { session_id, .. }
             | Self::WorkerUpdate { session_id, .. }
             | Self::HitlRequested { session_id, .. }
             | Self::HitlResolved { session_id, .. }

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -181,6 +181,7 @@
 - [Editor integration](./editor-integration.md)
 - [Testing](./testing.md)
 - [Secret store (hostlib)](./hostlib/secret_store.md)
+- [Staged filesystem (hostlib)](./hostlib/staged-fs.md)
 
 # Migrations
 

--- a/docs/src/hostlib/staged-fs.md
+++ b/docs/src/hostlib/staged-fs.md
@@ -1,0 +1,48 @@
+# Staged filesystem (hostlib)
+
+`harn-hostlib` includes a session-scoped filesystem staging layer for
+hosts that want agents to accumulate a diff before applying it to the
+working tree.
+
+The capability is registered by `harn_hostlib::install_default` as the
+`fs` module:
+
+| Method | Result |
+|--------|--------|
+| `hostlib_fs_set_mode` | Switches a session between `immediate` and `staged`, returning the previous mode. |
+| `hostlib_fs_staged_status` | Lists pending writes/deletes with byte counts and oldest pending age. |
+| `hostlib_fs_commit_staged` | Applies all pending changes, or only selected paths, to disk. |
+| `hostlib_fs_discard_staged` | Drops all pending changes, or only selected paths. |
+
+Staged data is stored below:
+
+```text
+<workspace>/.harn/state/staged/<session_id>/
+```
+
+The manifest records the active mode, root, and pending entries. File
+bodies are stored by SHA-256 content hash under `bodies/`, and
+`journal.jsonl` records each staging operation for audit/debugging.
+
+When a session is in `staged` mode, hostlib mutating tools write into
+the overlay:
+
+- `hostlib_tools_write_file` records a staged write.
+- `hostlib_tools_delete_file` records a staged delete.
+
+Read helpers use the same overlay before falling back to disk:
+
+- `hostlib_tools_read_file`
+- `hostlib_tools_list_directory`
+- `hostlib_tools_get_file_outline`
+- `hostlib_ast_parse_file`
+- code-index file read/hash helpers
+
+The ACP adapter exposes host controls for the same state:
+
+- `session/fs_mode` with `{ sessionId, mode }`
+- `session/fs_commit_staged` with `{ sessionId, paths? }`
+
+Every staging mutation emits a `session/update` progress extension with
+`_meta.harn.kind = "staged_writes_pending"`, `_meta.harn.pendingCount`,
+and `_meta.harn.totalBytes`.


### PR DESCRIPTION
## Summary
- add the `fs/` hostlib capability for per-session staged filesystem mode, status, commit, and discard
- route hostlib reads/listing/outline/AST/code-index paths through the staged overlay while writes/deletes defer to `.harn/state/staged/<session_id>/`
- expose ACP `session/fs_mode` and `session/fs_commit_staged` controls with staged-writes-pending session updates
- document the new staged filesystem surface and add regression coverage

Closes #1722.

## Verification
- pre-commit hook (`cargo fmt`, workspace clippy, markdown lint)
- pre-push hook targeted checks
- `CARGO_TARGET_DIR=/tmp/harn-target-1722 CARGO_INCREMENTAL=0 cargo test -p harn-hostlib --test fs_staging --test tools_file_io --test registration`
- `CARGO_TARGET_DIR=/tmp/harn-target-1722 CARGO_INCREMENTAL=0 cargo test -p harn-serve --features hostlib acp_fs_mode_and_commit_staged_apply_deferred_hostlib_writes`
- `CARGO_TARGET_DIR=/tmp/harn-target-1722 CARGO_INCREMENTAL=0 cargo check -p harn-cli --features hostlib`
- `CARGO_TARGET_DIR=/tmp/harn-target-1722 CARGO_INCREMENTAL=0 cargo test -p harn-serve --features hostlib`
- `make lint-test-patterns`
- `make lint-md`