### PR TITLE
Add ACP session/close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,12 @@ condensed series summaries instead of full per-patch history.
   checks `pending_count` against it: any push that completed before
   the snapshot is visible via the entry count, and any push that
   completes after the snapshot triggers the `Notified`.
+- **ACP now exposes upstream `session/close` (#1725).** The stdio and
+  WebSocket ACP adapters advertise `sessionCapabilities.close`, route
+  `session/close` through session cleanup and active-prompt cancellation,
+  and keep `session/stop` as a one-release deprecated alias with a warning.
+  Generated TypeScript and Swift protocol bindings expose `session/close`
+  as the canonical method and mark `session/stop` deprecated.
 
 ## v0.8.22
 

--- a/crates/harn-cli/src/commands/dump_protocol_artifacts.rs
+++ b/crates/harn-cli/src/commands/dump_protocol_artifacts.rs
@@ -32,8 +32,13 @@ const ACP_AGENT_METHODS: &[&str] = &[
     "session/resume",
     "session/prompt",
     "session/truncate",
+    "session/close",
     "session/stop",
 ];
+const ACP_DEPRECATED_AGENT_METHODS: &[DeprecatedWireValue] = &[DeprecatedWireValue {
+    value: "session/stop",
+    replacement: "session/close",
+}];
 const ACP_CLIENT_METHODS: &[&str] = &[
     "fs/read_text_file",
     "fs/write_text_file",
@@ -120,6 +125,11 @@ struct SchemaCopy {
     protocol: &'static str,
     source: &'static str,
     artifact: &'static str,
+}
+
+struct DeprecatedWireValue {
+    value: &'static str,
+    replacement: &'static str,
 }
 
 #[derive(Debug)]
@@ -278,6 +288,7 @@ fn generate_manifest() -> Result<String, String> {
         "acp": {
             "schemaCompatibility": ACP_SCHEMA_COMPATIBILITY,
             "agentMethods": ACP_AGENT_METHODS,
+            "deprecatedAgentMethods": deprecated_wire_values(ACP_DEPRECATED_AGENT_METHODS),
             "clientMethods": ACP_CLIENT_METHODS,
             "agentNotifications": ACP_AGENT_NOTIFICATIONS,
             "sessionUpdateVariants": all_acp_session_updates(),
@@ -312,6 +323,20 @@ fn generate_manifest() -> Result<String, String> {
         },
     }))
     .map_err(|error| format!("failed to serialize manifest: {error}"))
+}
+
+fn deprecated_wire_values(values: &[DeprecatedWireValue]) -> serde_json::Value {
+    let mut map = serde_json::Map::new();
+    for value in values {
+        map.insert(
+            value.value.to_string(),
+            json!({
+                "replacement": value.replacement,
+                "removal": "after one release",
+            }),
+        );
+    }
+    serde_json::Value::Object(map)
 }
 
 fn generate_readme() -> String {
@@ -367,6 +392,11 @@ fn generate_typescript() -> String {
         "ACP_AGENT_METHODS",
         ACP_AGENT_METHODS,
         "ACPAgentMethod",
+    ));
+    out.push_str(&ts_wire_value_object(
+        "ACP_AGENT_METHOD",
+        ACP_AGENT_METHODS,
+        ACP_DEPRECATED_AGENT_METHODS,
     ));
     out.push_str(&ts_array(
         "ACP_CLIENT_METHODS",
@@ -791,9 +821,10 @@ fn generate_swift() -> String {
     ));
     out.push_str("}\n\n");
 
-    out.push_str(&swift_enum(
+    out.push_str(&swift_enum_with_deprecations(
         "HarnACPAgentMethod",
         &strs_to_strings(ACP_AGENT_METHODS),
+        ACP_DEPRECATED_AGENT_METHODS,
     ));
     out.push_str(&swift_enum(
         "HarnACPClientMethod",
@@ -2704,9 +2735,44 @@ fn ts_array_owned(name: &str, values: &[String], type_name: &str) -> String {
     out
 }
 
+fn ts_wire_value_object(
+    name: &str,
+    values: &[&str],
+    deprecated_values: &[DeprecatedWireValue],
+) -> String {
+    let mut out = format!("export const {name} = {{\n");
+    for value in values {
+        if let Some(deprecated) = deprecated_wire_value(deprecated_values, value) {
+            out.push_str("  /** @deprecated ");
+            out.push_str(&deprecation_message(deprecated));
+            out.push_str(" */\n");
+        }
+        out.push_str("  ");
+        out.push_str(&wire_value_property_name(value));
+        out.push_str(": ");
+        out.push_str(&json_string_literal(value));
+        out.push_str(",\n");
+    }
+    out.push_str("} as const\n\n");
+    out
+}
+
 fn swift_enum(name: &str, values: &[String]) -> String {
+    swift_enum_with_deprecations(name, values, &[])
+}
+
+fn swift_enum_with_deprecations(
+    name: &str,
+    values: &[String],
+    deprecated_values: &[DeprecatedWireValue],
+) -> String {
     let mut out = format!("public enum {name}: String, Codable, Sendable, CaseIterable {{\n");
     for value in values {
+        if let Some(deprecated) = deprecated_wire_value(deprecated_values, value) {
+            out.push_str("    @available(*, deprecated, message: ");
+            out.push_str(&json_string_literal(&deprecation_message(deprecated)));
+            out.push_str(")\n");
+        }
         out.push_str("    case ");
         out.push_str(&swift_case_name(value));
         out.push_str(" = ");
@@ -2715,6 +2781,26 @@ fn swift_enum(name: &str, values: &[String]) -> String {
     }
     out.push_str("}\n\n");
     out
+}
+
+fn deprecated_wire_value<'a>(
+    deprecated_values: &'a [DeprecatedWireValue],
+    value: &str,
+) -> Option<&'a DeprecatedWireValue> {
+    deprecated_values
+        .iter()
+        .find(|deprecated| deprecated.value == value)
+}
+
+fn deprecation_message(value: &DeprecatedWireValue) -> String {
+    format!(
+        "Use {}; {} will be removed after one release.",
+        value.replacement, value.value
+    )
+}
+
+fn wire_value_property_name(value: &str) -> String {
+    swift_case_name(value)
 }
 
 fn swift_string_array(name: &str, values: &[&str]) -> String {
@@ -2863,6 +2949,8 @@ mod tests {
     fn generated_types_include_harn_wire_vocabularies() {
         let ts = generate_typescript();
         assert!(ts.contains("export type JsonRpcId = number | string | null"));
+        assert!(ts.contains("sessionClose: \"session/close\""));
+        assert!(ts.contains("@deprecated Use session/close; session/stop will be removed"));
         for value in HARN_SESSION_UPDATE_EXTENSIONS
             .iter()
             .chain(HARN_AGENT_EVENT_KINDS.iter())
@@ -2872,6 +2960,8 @@ mod tests {
         }
         let swift = generate_swift();
         assert!(swift.contains("public enum HarnACPAgentMethod"));
+        assert!(swift.contains("case sessionClose = \"session/close\""));
+        assert!(swift.contains("@available(*, deprecated"));
         assert!(swift.contains("public enum HarnACPClientMethod"));
         assert!(swift.contains("public enum HarnACPAgentNotification"));
         assert!(swift.contains("public enum HarnJsonRpcId"));
@@ -2985,6 +3075,10 @@ mod tests {
         assert_eq!(
             manifest["receipts"]["toolCallReceiptSchemaVersion"],
             json!(TOOL_CALL_RECEIPT_SCHEMA_VERSION)
+        );
+        assert_eq!(
+            manifest["acp"]["deprecatedAgentMethods"]["session/stop"]["replacement"],
+            json!("session/close")
         );
     }
 

--- a/crates/harn-cli/src/commands/orchestrator/listener/tests.rs
+++ b/crates/harn-cli/src/commands/orchestrator/listener/tests.rs
@@ -459,6 +459,7 @@ async fn acp_websocket_requires_configured_bearer_auth() {
     assert_eq!(
         response["result"]["agentCapabilities"]["sessionCapabilities"],
         json!({
+            "close": {},
             "list": {},
             "resume": {},
         })

--- a/crates/harn-cli/tests/acp_server_cli.rs
+++ b/crates/harn-cli/tests/acp_server_cli.rs
@@ -162,6 +162,7 @@ fn acp_session_fork_branches_runtime_state_and_dispatches_independently() {
     assert_eq!(
         init["result"]["agentCapabilities"]["sessionCapabilities"],
         json!({
+            "close": {},
             "list": {},
             "resume": {},
         })
@@ -677,6 +678,78 @@ default_provider = "openai"
     assert_eq!(response["result"]["stopReason"], "end_turn");
     let summary = latest_prompt_summary(&notifications, &session_id);
     assert_eq!(summary["messages"][0]["content"], "packaged");
+
+    drop(stdin);
+    let status = child.wait().unwrap();
+    assert!(status.success(), "status={status}");
+}
+
+#[ignore = "binary surface — moves to slow E2E/smoke job (issue #1069)"]
+#[test]
+fn serve_acp_stdio_closes_sessions_with_close_and_stop_spellings() {
+    let _guard = lock_acp_cli_tests();
+    let temp = TempDir::new().unwrap();
+    write_fixture(&temp);
+
+    let mut child = harn_e2e_command()
+        .current_dir(temp.path())
+        .arg("serve")
+        .arg("acp")
+        .arg("acp_fixture.harn")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+
+    let mut stdin = child.stdin.take().unwrap();
+    let mut stdout = BufReader::new(child.stdout.take().unwrap());
+
+    for (index, method) in ["session/close", "session/stop"].into_iter().enumerate() {
+        let request_base = 10 + (index as i64 * 10);
+        let (_, created) = send_request(
+            &mut stdin,
+            &mut stdout,
+            json!({
+                "jsonrpc": "2.0",
+                "id": request_base,
+                "method": "session/new",
+                "params": {
+                    "cwd": temp.path(),
+                }
+            }),
+        );
+        let session_id = created["result"]["sessionId"].as_str().unwrap().to_string();
+
+        let (_, closed) = send_request(
+            &mut stdin,
+            &mut stdout,
+            json!({
+                "jsonrpc": "2.0",
+                "id": request_base + 1,
+                "method": method,
+                "params": {
+                    "sessionId": session_id.clone(),
+                }
+            }),
+        );
+        assert_eq!(closed["result"], json!({}));
+
+        let (_, listed) = send_request(
+            &mut stdin,
+            &mut stdout,
+            json!({
+                "jsonrpc": "2.0",
+                "id": request_base + 2,
+                "method": "session/list",
+                "params": {}
+            }),
+        );
+        let sessions = listed["result"]["sessions"].as_array().unwrap();
+        assert!(sessions
+            .iter()
+            .all(|entry| entry["sessionId"].as_str() != Some(session_id.as_str())));
+    }
 
     drop(stdin);
     let status = child.wait().unwrap();

--- a/crates/harn-serve/src/adapters/acp/mod.rs
+++ b/crates/harn-serve/src/adapters/acp/mod.rs
@@ -35,7 +35,7 @@ pub use schema::{
     HARN_TOOL_LIFECYCLE_EXTENSION_FIELDS,
 };
 use sessions::{
-    mark_cancelled_session, preempt_session_cancel_or_truncate, prepare_session_prompt, Session,
+    mark_cancelled_session, preempt_session_interruption, prepare_session_prompt, Session,
     SessionCancellation, SessionInfo,
 };
 pub use transport::{run_acp_channel_server, run_acp_server};
@@ -1073,15 +1073,18 @@ impl AcpServer {
             assistant_state: std::sync::Mutex::new(VisibleTextState::default()),
         });
         let bridge_output = output.clone();
-        let host_bridge = Rc::new(harn_vm::bridge::HostBridge::from_parts_with_writer(
-            bridge.pending.clone(),
-            Arc::new(AtomicBool::new(false)),
-            Arc::new(move |line| {
-                bridge_output.write_line(line);
-                Ok(())
-            }),
-            bridge.next_id_counter.fetch_add(10_000, Ordering::SeqCst),
-        ));
+        let host_bridge = Rc::new(
+            harn_vm::bridge::HostBridge::from_parts_with_writer_and_cancel_notify(
+                bridge.pending.clone(),
+                cancellation.cancelled.clone(),
+                cancellation.notify.clone(),
+                Arc::new(move |line| {
+                    bridge_output.write_line(line);
+                    Ok(())
+                }),
+                bridge.next_id_counter.fetch_add(10_000, Ordering::SeqCst),
+            ),
+        );
         host_bridge.set_session_id(&bridge.session_id);
 
         let compile_started = Instant::now();
@@ -1208,6 +1211,41 @@ impl AcpServer {
 
     fn handle_session_cancel(&mut self, params: &serde_json::Value) {
         mark_cancelled_session(&self.session_cancellations, params);
+    }
+
+    fn handle_session_close(
+        &mut self,
+        id: &serde_json::Value,
+        params: &serde_json::Value,
+        method: &str,
+    ) {
+        let Some(session_id) = params.get("sessionId").and_then(|value| value.as_str()) else {
+            self.send_error(id, -32602, &format!("{method} requires sessionId"));
+            return;
+        };
+
+        let Some(session) = self.sessions.remove(session_id) else {
+            self.send_error(id, -32004, &format!("Session not found: {session_id}"));
+            return;
+        };
+
+        session.cancellation.cancel();
+        self.session_cancellations
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .remove(session_id);
+        clear_session_sinks(session_id);
+        harn_vm::agent_sessions::close_with_status(
+            session_id,
+            "client_request",
+            "closed",
+            serde_json::json!({
+                "protocol": "acp",
+                "method": method,
+            }),
+        );
+
+        self.send_response(id, serde_json::json!({}));
     }
 
     async fn handle_session_input(&self, params: &serde_json::Value) {
@@ -1954,6 +1992,22 @@ impl AcpServer {
             }
             "session/cancel" => {
                 self.handle_session_cancel(&params);
+            }
+            "session/close" => {
+                if self.reject_unauthenticated(&id) {
+                    return;
+                }
+                self.handle_session_close(&id, &params, "session/close");
+            }
+            "session/stop" => {
+                if self.reject_unauthenticated(&id) {
+                    return;
+                }
+                tracing::warn!("ACP method session/stop is deprecated; use session/close instead");
+                eprintln!(
+                    "warning: ACP method session/stop is deprecated; use session/close instead"
+                );
+                self.handle_session_close(&id, &params, "session/stop");
             }
             "session/input" | "user_message" | "agent/user_message" => {
                 if self.reject_unauthenticated(&id) {

--- a/crates/harn-serve/src/adapters/acp/schema.rs
+++ b/crates/harn-serve/src/adapters/acp/schema.rs
@@ -176,6 +176,7 @@ pub(super) fn acp_agent_capabilities() -> serde_json::Value {
             "sse": true,
         },
         "sessionCapabilities": {
+            "close": {},
             "list": {},
             "resume": {},
         },

--- a/crates/harn-serve/src/adapters/acp/sessions.rs
+++ b/crates/harn-serve/src/adapters/acp/sessions.rs
@@ -96,7 +96,7 @@ pub(super) fn lookup_session_cancellation(
         .cloned()
 }
 
-pub(super) fn preempt_session_cancel_or_truncate(
+pub(super) fn preempt_session_interruption(
     cancellations: &Arc<std::sync::Mutex<HashMap<String, SessionCancellation>>>,
     msg: &serde_json::Value,
 ) -> bool {
@@ -107,7 +107,7 @@ pub(super) fn preempt_session_cancel_or_truncate(
             mark_cancelled_session(cancellations, params);
             msg.get("id").is_none()
         }
-        Some("session/truncate") => {
+        Some("session/truncate" | "session/close" | "session/stop") => {
             mark_cancelled_session(cancellations, params);
             false
         }

--- a/crates/harn-serve/src/adapters/acp/tests.rs
+++ b/crates/harn-serve/src/adapters/acp/tests.rs
@@ -365,6 +365,7 @@ fn acp_agent_capabilities_use_canonical_initialize_shape() {
     assert_eq!(
         capabilities["sessionCapabilities"],
         serde_json::json!({
+            "close": {},
             "list": {},
             "resume": {},
         })

--- a/crates/harn-serve/src/adapters/acp/tests/modes.rs
+++ b/crates/harn-serve/src/adapters/acp/tests/modes.rs
@@ -1,4 +1,46 @@
 use super::*;
+use harn_vm::event_log::EventLog as _;
+
+async fn wait_for_agent_event_log_entries(
+    log: &std::sync::Arc<harn_vm::event_log::AnyEventLog>,
+    session_id: &str,
+    expected: usize,
+) {
+    let topic = harn_vm::event_log::Topic::new(format!(
+        "observability.agent_events.{}",
+        harn_vm::event_log::sanitize_topic_component(session_id)
+    ))
+    .expect("session event topic");
+    for _ in 0..20 {
+        let entries = log
+            .read_range(&topic, None, expected)
+            .await
+            .expect("read event log");
+        if entries.len() >= expected {
+            return;
+        }
+        tokio::task::yield_now().await;
+    }
+    let entries = log
+        .read_range(&topic, None, expected)
+        .await
+        .expect("read event log after wait");
+    panic!(
+        "expected {expected} persisted event-log entries for {session_id}, saw {}",
+        entries.len()
+    );
+}
+
+fn install_test_agent_event_log_sink(
+    log: &std::sync::Arc<harn_vm::event_log::AnyEventLog>,
+    session_id: &str,
+) {
+    harn_vm::agent_events::clear_session_sinks(session_id);
+    harn_vm::agent_events::register_sink(
+        session_id.to_string(),
+        harn_vm::agent_events::EventLogSink::new(log.clone(), session_id),
+    );
+}
 #[tokio::test(flavor = "current_thread")]
 async fn acp_authenticate_uses_shared_auth_policy() {
     let local = tokio::task::LocalSet::new();
@@ -251,7 +293,7 @@ async fn acp_session_load_includes_current_mode_state() {
 #[tokio::test(flavor = "current_thread")]
 async fn acp_session_resume_includes_current_mode_state_without_replay() {
     harn_vm::event_log::reset_active_event_log();
-    let _log = harn_vm::event_log::install_memory_for_current_thread(64);
+    let log = harn_vm::event_log::install_memory_for_current_thread(64);
 
     let (tx, mut rx) = mpsc::unbounded_channel();
     let mut server = AcpServer::new_with_output(AcpServerConfig::new(None), AcpOutput::Channel(tx));
@@ -269,6 +311,7 @@ async fn acp_session_resume_includes_current_mode_state_without_replay() {
         .as_str()
         .expect("session id")
         .to_string();
+    install_test_agent_event_log_sink(&log, &session_id);
 
     server
         .handle_incoming_message(serde_json::json!({
@@ -286,7 +329,7 @@ async fn acp_session_resume_includes_current_mode_state_without_replay() {
         session_id: session_id.clone(),
         content: "do not replay me".to_string(),
     });
-    tokio::task::yield_now().await;
+    wait_for_agent_event_log_entries(&log, &session_id, 1).await;
 
     server
         .handle_incoming_message(serde_json::json!({
@@ -346,7 +389,7 @@ async fn acp_session_restore_methods_reject_unknown_sessions() {
 #[tokio::test(flavor = "current_thread")]
 async fn acp_session_load_replays_persisted_agent_events() {
     harn_vm::event_log::reset_active_event_log();
-    let _log = harn_vm::event_log::install_memory_for_current_thread(64);
+    let log = harn_vm::event_log::install_memory_for_current_thread(64);
 
     let (tx, mut rx) = mpsc::unbounded_channel();
     let mut server = AcpServer::new_with_output(AcpServerConfig::new(None), AcpOutput::Channel(tx));
@@ -364,6 +407,7 @@ async fn acp_session_load_replays_persisted_agent_events() {
         .as_str()
         .expect("session id")
         .to_string();
+    install_test_agent_event_log_sink(&log, &session_id);
 
     harn_vm::agent_events::emit_event(&harn_vm::agent_events::AgentEvent::AgentMessageChunk {
         session_id: session_id.clone(),
@@ -373,7 +417,7 @@ async fn acp_session_load_replays_persisted_agent_events() {
         session_id: session_id.clone(),
         plan: serde_json::json!([{"content": "do the thing", "status": "pending"}]),
     });
-    tokio::task::yield_now().await;
+    wait_for_agent_event_log_entries(&log, &session_id, 2).await;
 
     server
         .handle_incoming_message(serde_json::json!({

--- a/crates/harn-serve/src/adapters/acp/tests/sessions.rs
+++ b/crates/harn-serve/src/adapters/acp/tests/sessions.rs
@@ -145,6 +145,7 @@ async fn acp_server_handles_session_flow_and_prompt_updates() {
             assert_eq!(
                 initialize["result"]["agentCapabilities"]["sessionCapabilities"],
                 serde_json::json!({
+                    "close": {},
                     "list": {},
                     "resume": {},
                 })
@@ -487,6 +488,149 @@ async fn acp_profile_json_appends_one_line_per_prompt_turn() {
             assert_eq!(entries[0]["turn"], 1);
             assert_eq!(entries[1]["turn"], 2);
             assert!(entries[0]["rollup"]["by_kind"].is_array());
+
+            drop(request_tx);
+            server.await.expect("ACP channel server task");
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn acp_session_close_and_stop_alias_free_active_session() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let (request_tx, request_rx) = mpsc::unbounded_channel();
+            let (response_tx, mut response_rx) = mpsc::unbounded_channel();
+            let server = tokio::task::spawn_local(super::run_acp_channel_server(
+                AcpServerConfig::new(None),
+                request_rx,
+                response_tx,
+            ));
+
+            for (index, method) in ["session/close", "session/stop"].into_iter().enumerate() {
+                let request_base = 10 + (index as i64 * 10);
+                request_tx
+                    .send(serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": request_base,
+                        "method": "session/new",
+                        "params": {"cwd": "."},
+                    }))
+                    .expect("send session/new");
+                let created = recv_json(&mut response_rx).await;
+                let session_id = created["result"]["sessionId"]
+                    .as_str()
+                    .expect("session id")
+                    .to_string();
+                assert!(harn_vm::agent_sessions::exists(&session_id));
+
+                request_tx
+                    .send(serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": request_base + 1,
+                        "method": method,
+                        "params": {"sessionId": session_id},
+                    }))
+                    .expect("send session close request");
+                let closed = recv_json(&mut response_rx).await;
+                assert_eq!(closed["id"], request_base + 1);
+                assert_eq!(closed["result"], serde_json::json!({}));
+                assert!(
+                    !harn_vm::agent_sessions::exists(&session_id),
+                    "{method} should free VM session state"
+                );
+
+                request_tx
+                    .send(serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": request_base + 2,
+                        "method": "session/list",
+                        "params": {},
+                    }))
+                    .expect("send session/list");
+                let listed = recv_json(&mut response_rx).await;
+                let sessions = listed["result"]["sessions"].as_array().unwrap();
+                assert!(
+                    sessions
+                        .iter()
+                        .all(|entry| entry["sessionId"].as_str() != Some(session_id.as_str())),
+                    "{method} should remove the active ACP session"
+                );
+
+                request_tx
+                    .send(serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": request_base + 3,
+                        "method": "session/prompt",
+                        "params": {
+                            "sessionId": session_id,
+                            "prompt": [{"type": "text", "text": "println(\"closed\")"}],
+                        },
+                    }))
+                    .expect("send session/prompt");
+                let rejected = recv_json(&mut response_rx).await;
+                assert_eq!(rejected["id"], request_base + 3);
+                assert_eq!(rejected["error"]["code"], -32602);
+            }
+
+            drop(request_tx);
+            server.await.expect("ACP channel server task");
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn acp_session_close_cancels_pending_host_bridge_call() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let (request_tx, mut response_rx, server, session_id) =
+                start_acp_channel_session().await;
+
+            request_tx
+                .send(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 2,
+                    "method": "session/prompt",
+                    "params": {
+                        "sessionId": session_id.clone(),
+                        "prompt": [{"type": "text", "text": "println(\"after host capabilities\")"}],
+                    },
+                }))
+                .expect("send session/prompt");
+
+            let host_capabilities = recv_json(&mut response_rx).await;
+            assert_eq!(host_capabilities["method"], "host/capabilities");
+            request_tx
+                .send(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 3,
+                    "method": "session/close",
+                    "params": {"sessionId": session_id.clone()},
+                }))
+                .expect("send session/close");
+
+            let mut saw_cancelled_response = false;
+            let mut saw_close_response = false;
+            for _ in 0..8 {
+                let message = recv_json(&mut response_rx).await;
+                if message["id"] == 2 {
+                    assert_eq!(message["result"]["stopReason"], "cancelled");
+                    saw_cancelled_response = true;
+                } else if message["id"] == 3 {
+                    assert_eq!(message["result"], serde_json::json!({}));
+                    assert!(!harn_vm::agent_sessions::exists(&session_id));
+                    saw_close_response = true;
+                    break;
+                }
+            }
+
+            assert!(
+                saw_cancelled_response,
+                "prompt should observe close as cancellation"
+            );
+            assert!(saw_close_response, "session/close should free the session");
 
             drop(request_tx);
             server.await.expect("ACP channel server task");
@@ -928,6 +1072,122 @@ async fn acp_session_cancel_kills_active_terminal() {
             assert!(
                 saw_cancelled_response,
                 "prompt should finish with stopReason=cancelled"
+            );
+
+            drop(request_tx);
+            server.await.expect("ACP channel server task");
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn acp_session_close_cancels_active_terminal_before_freeing_session() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let (request_tx, mut response_rx, server, session_id) =
+                start_acp_channel_session().await;
+
+            request_tx
+                .send(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 2,
+                    "method": "session/prompt",
+                    "params": {
+                        "sessionId": session_id.clone(),
+                        "prompt": [{"type": "text", "text": "run_command(\"sleep 999\")"}],
+                    },
+                }))
+                .expect("send session/prompt");
+
+            let terminal_id = "term-close-demo";
+            let mut saw_wait = false;
+            let mut saw_kill = false;
+            let mut saw_release = false;
+            let mut saw_cancelled_response = false;
+            let mut saw_close_response = false;
+            for _ in 0..32 {
+                let message = recv_json(&mut response_rx).await;
+                match message.get("method").and_then(|value| value.as_str()) {
+                    Some("host/capabilities") => {
+                        request_tx
+                            .send(serde_json::json!({
+                                "jsonrpc": "2.0",
+                                "id": message["id"].clone(),
+                                "result": {},
+                            }))
+                            .expect("send host capabilities response");
+                    }
+                    Some("terminal/create") => {
+                        request_tx
+                            .send(serde_json::json!({
+                                "jsonrpc": "2.0",
+                                "id": message["id"].clone(),
+                                "result": {"terminalId": terminal_id},
+                            }))
+                            .expect("send terminal/create response");
+                    }
+                    Some("terminal/wait_for_exit") => {
+                        assert_eq!(message["params"]["terminalId"], terminal_id);
+                        saw_wait = true;
+                        request_tx
+                            .send(serde_json::json!({
+                                "jsonrpc": "2.0",
+                                "id": 3,
+                                "method": "session/close",
+                                "params": {"sessionId": session_id.clone()},
+                            }))
+                            .expect("send session/close");
+                    }
+                    Some("terminal/kill") => {
+                        assert_eq!(message["params"]["terminalId"], terminal_id);
+                        saw_kill = true;
+                        request_tx
+                            .send(serde_json::json!({
+                                "jsonrpc": "2.0",
+                                "id": message["id"].clone(),
+                                "result": {},
+                            }))
+                            .expect("send terminal/kill response");
+                    }
+                    Some("terminal/release") => {
+                        assert_eq!(message["params"]["terminalId"], terminal_id);
+                        saw_release = true;
+                        request_tx
+                            .send(serde_json::json!({
+                                "jsonrpc": "2.0",
+                                "id": message["id"].clone(),
+                                "result": {},
+                            }))
+                            .expect("send terminal/release response");
+                    }
+                    _ if message["id"] == 2 => {
+                        assert_eq!(message["result"]["stopReason"], "cancelled");
+                        saw_cancelled_response = true;
+                    }
+                    _ if message["id"] == 3 => {
+                        assert_eq!(message["result"], serde_json::json!({}));
+                        assert!(!harn_vm::agent_sessions::exists(&session_id));
+                        saw_close_response = true;
+                        break;
+                    }
+                    _ => {}
+                }
+            }
+
+            assert!(saw_wait, "prompt should block on terminal/wait_for_exit");
+            assert!(saw_kill, "session/close should issue terminal/kill");
+            assert!(
+                saw_release,
+                "closed terminal execution should still release the terminal"
+            );
+            assert!(
+                saw_cancelled_response,
+                "prompt should finish with stopReason=cancelled"
+            );
+            assert!(
+                saw_close_response,
+                "session/close should respond after cleanup"
             );
 
             drop(request_tx);

--- a/crates/harn-serve/src/adapters/acp/transport.rs
+++ b/crates/harn-serve/src/adapters/acp/transport.rs
@@ -29,7 +29,7 @@ pub async fn run_acp_channel_server(
                     }
 
                     prepare_session_prompt(&cancellations, &msg);
-                    if preempt_session_cancel_or_truncate(&cancellations, &msg) {
+                    if preempt_session_interruption(&cancellations, &msg) {
                         continue;
                     }
 
@@ -95,7 +95,7 @@ pub async fn run_acp_server(config: AcpServerConfig) {
                     }
 
                     prepare_session_prompt(&cancellations, &msg);
-                    if preempt_session_cancel_or_truncate(&cancellations, &msg) {
+                    if preempt_session_interruption(&cancellations, &msg) {
                         continue;
                     }
 

--- a/crates/harn-vm/src/bridge.rs
+++ b/crates/harn-vm/src/bridge.rs
@@ -374,11 +374,27 @@ impl HostBridge {
         writer: HostBridgeWriter,
         start_id: u64,
     ) -> Self {
+        Self::from_parts_with_writer_and_cancel_notify(
+            pending,
+            cancelled,
+            Arc::new(Notify::new()),
+            writer,
+            start_id,
+        )
+    }
+
+    pub fn from_parts_with_writer_and_cancel_notify(
+        pending: Arc<Mutex<HashMap<u64, oneshot::Sender<serde_json::Value>>>>,
+        cancelled: Arc<AtomicBool>,
+        cancel_notify: Arc<Notify>,
+        writer: HostBridgeWriter,
+        start_id: u64,
+    ) -> Self {
         Self {
             next_id: AtomicU64::new(start_id),
             pending,
             cancelled,
-            cancel_notify: Arc::new(Notify::new()),
+            cancel_notify,
             writer,
             session_id: std::sync::Mutex::new(String::new()),
             script_name: std::sync::Mutex::new(String::new()),

--- a/docs/src/acp/websocket.md
+++ b/docs/src/acp/websocket.md
@@ -95,6 +95,8 @@ surface as stdio ACP:
 - `session/list`
 - `session/prompt`
 - `session/cancel`
+- `session/truncate`
+- `session/close`
 - `session/input`
 - `session/fork`
 - `session/set_mode`

--- a/docs/src/mcp-and-acp.md
+++ b/docs/src/mcp-and-acp.md
@@ -489,6 +489,9 @@ The ACP server supports these JSON-RPC methods:
 | `session/list` | List active sessions known to the ACP adapter |
 | `session/prompt` | Send a prompt to the agent for execution |
 | `session/cancel` | Cancel the currently running prompt |
+| `session/truncate` | Truncate the session transcript to a requested prefix |
+| `session/close` | Close a session and cancel any active prompt |
+| `session/stop` | Deprecated alias for `session/close` |
 | `session/set_mode` | Switch the active session mode |
 | `session/set_config_option` | Switch a preferred ACP session config option (`mode` or `model`) |
 | `workflow/signal` | Enqueue a workflow signal message in the current session workspace |
@@ -506,9 +509,10 @@ use.
 
 During `initialize`, Harn keeps the public `agentCapabilities` object aligned
 with upstream ACP: `loadSession`, `promptCapabilities`, `mcpCapabilities`, and
-the canonical `sessionCapabilities.list` flag are advertised in their upstream
-locations. Harn-only methods such as `session/fork` remain documented
-extensions instead of being inserted into upstream `sessionCapabilities`.
+the canonical `sessionCapabilities.close` and `sessionCapabilities.list` flags
+are advertised in their upstream locations. Harn-only methods such as
+`session/fork` remain documented extensions instead of being inserted into
+upstream `sessionCapabilities`.
 
 ### Session Forking
 

--- a/spec/protocol-artifacts/HarnProtocol.swift
+++ b/spec/protocol-artifacts/HarnProtocol.swift
@@ -78,6 +78,8 @@ public enum HarnACPAgentMethod: String, Codable, Sendable, CaseIterable {
     case sessionResume = "session/resume"
     case sessionPrompt = "session/prompt"
     case sessionTruncate = "session/truncate"
+    case sessionClose = "session/close"
+    @available(*, deprecated, message: "Use session/close; session/stop will be removed after one release.")
     case sessionStop = "session/stop"
 }
 

--- a/spec/protocol-artifacts/go/harnprotocol/harnprotocol.go
+++ b/spec/protocol-artifacts/go/harnprotocol/harnprotocol.go
@@ -35,6 +35,7 @@ var ACPAgentMethods = []ACPAgentMethod{
 	"session/resume",
 	"session/prompt",
 	"session/truncate",
+	"session/close",
 	"session/stop",
 }
 

--- a/spec/protocol-artifacts/harn-protocol.ts
+++ b/spec/protocol-artifacts/harn-protocol.ts
@@ -10,9 +10,22 @@ export const ACP_AGENT_METHODS = [
   "session/resume",
   "session/prompt",
   "session/truncate",
+  "session/close",
   "session/stop",
 ] as const
 export type ACPAgentMethod = (typeof ACP_AGENT_METHODS)[number]
+
+export const ACP_AGENT_METHOD = {
+  initialize: "initialize",
+  sessionNew: "session/new",
+  sessionLoad: "session/load",
+  sessionResume: "session/resume",
+  sessionPrompt: "session/prompt",
+  sessionTruncate: "session/truncate",
+  sessionClose: "session/close",
+  /** @deprecated Use session/close; session/stop will be removed after one release. */
+  sessionStop: "session/stop",
+} as const
 
 export const ACP_CLIENT_METHODS = [
   "fs/read_text_file",

--- a/spec/protocol-artifacts/manifest.json
+++ b/spec/protocol-artifacts/manifest.json
@@ -38,6 +38,7 @@
       "session/resume",
       "session/prompt",
       "session/truncate",
+      "session/close",
       "session/stop"
     ],
     "agentNotifications": [
@@ -63,6 +64,12 @@
       "visible_delta",
       "visible_text"
     ],
+    "deprecatedAgentMethods": {
+      "session/stop": {
+        "removal": "after one release",
+        "replacement": "session/close"
+      }
+    },
     "harnAgentEventKinds": [
       "budget_exhausted",
       "composition_child_call",

--- a/spec/protocol-artifacts/python/harn_protocol.py
+++ b/spec/protocol-artifacts/python/harn_protocol.py
@@ -101,6 +101,7 @@ ACP_AGENT_METHODS: tuple = (
     "session/resume",
     "session/prompt",
     "session/truncate",
+    "session/close",
     "session/stop",
 )
 ACP_CLIENT_METHODS: tuple = (
@@ -318,6 +319,7 @@ class ACPAgentMethod(str, Enum):
     SESSION_RESUME = "session/resume"
     SESSION_PROMPT = "session/prompt"
     SESSION_TRUNCATE = "session/truncate"
+    SESSION_CLOSE = "session/close"
     SESSION_STOP = "session/stop"
 
 


### PR DESCRIPTION
## Summary
- Add canonical ACP `session/close` handling and advertise `sessionCapabilities.close`.
- Keep `session/stop` as a one-release deprecated alias with warning output and generated TypeScript/Swift deprecation metadata.
- Wire ACP host bridge cancellation through the shared session cancellation token so close/cancel wakes pending host calls, and add coverage for close, stop alias, pending host calls, active terminals, protocol artifacts, and docs.

Closes #1725.

## Verification
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-1725 cargo test -p harn-serve acp_session_ -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-1725 make check-protocol-artifacts`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-1725 make check-bindings`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-1725 cargo test -p harn-cli acp_websocket_requires_configured_bearer_auth -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-1725 make check-docs-snippets`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-1725 cargo clippy -p harn-serve -p harn-cli -p harn-vm --tests -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-1725 cargo fmt --check`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-1725 make test`
- `python3 scripts/check_changelog_no_retroactive_edits.py`
- pre-commit hook
- pre-push hook