### PR TITLE
portal: surface tool-call rationale + audit layers in RunDetail (#1695)

### DIFF
--- a/crates/harn-cli/portal/src/components/RunDetail.test.tsx
+++ b/crates/harn-cli/portal/src/components/RunDetail.test.tsx
@@ -1,0 +1,162 @@
+import { render, screen, within } from "@testing-library/react"
+import { IntlProvider } from "react-intl"
+import { describe, expect, it } from "vitest"
+
+import type { PortalActivity, PortalRunDetail, RunSummary } from "../types"
+import { RunDetail } from "./RunDetail"
+
+const baseSummary: RunSummary = {
+  path: "run.json",
+  id: "run-1",
+  workflow_name: "demo",
+  status: "completed",
+  last_stage_node_id: "finalize",
+  failure_summary: null,
+  started_at: "2026-05-16T10:00:00Z",
+  finished_at: "2026-05-16T10:00:05Z",
+  duration_ms: 5000,
+  stage_count: 1,
+  child_run_count: 0,
+  call_count: 2,
+  input_tokens: 10,
+  output_tokens: 5,
+  models: ["gpt-5"],
+  updated_at_ms: 1,
+  skills: [],
+}
+
+const auditedActivity: PortalActivity = {
+  label: "search_files",
+  kind: "tool_call",
+  started_offset_ms: 0,
+  duration_ms: 12,
+  stage_node_id: "plan",
+  call_id: "call-with-audit",
+  summary: "tool call summary",
+  audit: {
+    reason: "Look up rate limiter",
+    kind: "search",
+    status: "ok",
+    layers: [
+      { name: "with_required_reason", status: "ok" },
+      { name: "with_consent", status: "approved" },
+      { name: "with_audit_log", status: "ok" },
+    ],
+    receipt_uri: "file:///tmp/.harn/receipts/session.jsonl",
+  },
+}
+
+const plainActivity: PortalActivity = {
+  label: "read_file",
+  kind: "tool_call",
+  started_offset_ms: 50,
+  duration_ms: 5,
+  stage_node_id: "plan",
+  call_id: "call-no-audit",
+  summary: "tool call summary",
+}
+
+function buildDetail(activities: PortalActivity[]): PortalRunDetail {
+  return {
+    summary: baseSummary,
+    task: "Demo audit chip rendering",
+    workflow_id: "wf",
+    parent_run_id: null,
+    root_run_id: null,
+    policy_summary: {
+      tools: [],
+      capabilities: [],
+      workspace_roots: [],
+      side_effect_level: null,
+      recursion_limit: null,
+      tool_arg_constraints: [],
+      validation_valid: true,
+      validation_errors: [],
+      validation_warnings: [],
+      reachable_nodes: [],
+    },
+    replay_summary: null,
+    execution: null,
+    insights: [],
+    stages: [],
+    spans: [],
+    activities,
+    transitions: [],
+    checkpoints: [],
+    artifacts: [],
+    execution_summary: null,
+    transcript_steps: [],
+    template_renders: [],
+    story: [],
+    child_runs: [],
+    observability: {
+      schema_version: 4,
+      planner_rounds: [],
+      research_fact_count: 0,
+      action_graph_nodes: [],
+      action_graph_edges: [],
+      worker_lineage: [],
+      verification_outcomes: [],
+      transcript_pointers: [],
+      daemon_events: [],
+    },
+    skill_timeline: [],
+    skill_match_events: [],
+    tool_load_events: [],
+    active_skills: [],
+  }
+}
+
+function renderRunDetail(detail: PortalRunDetail) {
+  return render(
+    <IntlProvider locale="en">
+      <RunDetail detail={detail} runs={[baseSummary]} onSelectRun={() => {}} />
+    </IntlProvider>,
+  )
+}
+
+function findActivityRow(label: string) {
+  return screen
+    .getAllByText(label)
+    .map((node) => node.closest(".activity-item"))
+    .find((node): node is HTMLElement => node instanceof HTMLElement)
+}
+
+describe("RunDetail audit chip", () => {
+  it("renders the rationale chip, layer tooltip, and receipt link when audit is present", () => {
+    renderRunDetail(buildDetail([auditedActivity]))
+
+    const row = findActivityRow("search_files")
+    expect(row).toBeTruthy()
+    const scoped = within(row!)
+
+    expect(scoped.getByText("Look up rate limiter")).toBeInTheDocument()
+    expect(scoped.getByText(/3 layers/)).toBeInTheDocument()
+    expect(
+      scoped.getByText(
+        "with_required_reason → with_consent → with_audit_log",
+      ),
+    ).toBeInTheDocument()
+
+    const tooltip = scoped.getByRole("tooltip")
+    expect(tooltip).toBeInTheDocument()
+    expect(tooltip).toHaveTextContent(
+      "with_required_reason → with_consent → with_audit_log",
+    )
+
+    const link = scoped.getByRole("link", { name: /view receipt/i })
+    expect(link).toHaveAttribute(
+      "href",
+      "file:///tmp/.harn/receipts/session.jsonl",
+    )
+  })
+
+  it("renders no audit container when audit is absent", () => {
+    const { container } = renderRunDetail(buildDetail([plainActivity]))
+
+    const row = findActivityRow("read_file")
+    expect(row).toBeTruthy()
+    expect(row!.querySelector(".activity-audit")).toBeNull()
+    expect(container.querySelectorAll(".activity-audit")).toHaveLength(0)
+  })
+})

--- a/crates/harn-cli/portal/src/components/RunDetail.tsx
+++ b/crates/harn-cli/portal/src/components/RunDetail.tsx
@@ -178,6 +178,14 @@ const messages = defineMessages({
     id: "portal.detail.noActivity",
     defaultMessage: "No span activity captured for this run.",
   },
+  auditLayersTooltip: {
+    id: "portal.detail.auditLayersTooltip",
+    defaultMessage: "Middleware layers (outer → inner)",
+  },
+  auditReceiptLink: {
+    id: "portal.detail.auditReceiptLink",
+    defaultMessage: "View receipt",
+  },
   noArtifacts: {
     id: "portal.detail.noArtifacts",
     defaultMessage: "This run did not persist any artifacts.",
@@ -1293,19 +1301,75 @@ export function RunDetail({ detail, runs, onSelectRun }: RunDetailProps) {
           </div>
           <div className="activity-list">
             {detail.activities.length ? (
-              detail.activities.slice(0, 40).map((item) => (
-                <div className="activity-item" key={`${item.label}-${item.started_offset_ms}`}>
-                  <div className="row">
-                    <strong>{item.label}</strong>
-                    <span>{formatDuration(item.duration_ms)}</span>
+              detail.activities.slice(0, 40).map((item) => {
+                const audit = item.audit
+                const layerChain = audit?.layers.length
+                  ? audit.layers.map((layer) => layer.name).join(" → ")
+                  : null
+                const tooltipId = audit
+                  ? `activity-audit-${item.call_id ?? item.label}-${item.started_offset_ms}`
+                  : undefined
+                return (
+                  <div
+                    className="activity-item"
+                    key={`${item.label}-${item.started_offset_ms}`}
+                  >
+                    <div className="row">
+                      <strong>{item.label}</strong>
+                      <span>{formatDuration(item.duration_ms)}</span>
+                    </div>
+                    {audit ? (
+                      <div className="activity-audit">
+                        {audit.reason ? (
+                          <span
+                            className="turn-chip activity-audit-reason"
+                            title={audit.reason}
+                          >
+                            {audit.reason}
+                          </span>
+                        ) : null}
+                        {layerChain ? (
+                          <span
+                            className="turn-chip activity-audit-layers"
+                            aria-describedby={tooltipId}
+                            title={layerChain}
+                          >
+                            {audit.layers.length} layer
+                            {audit.layers.length === 1 ? "" : "s"}
+                            <span
+                              id={tooltipId}
+                              role="tooltip"
+                              className="activity-audit-tooltip"
+                            >
+                              <span className="activity-audit-tooltip-title">
+                                {intl.formatMessage(messages.auditLayersTooltip)}
+                              </span>
+                              <span className="activity-audit-tooltip-chain">
+                                {layerChain}
+                              </span>
+                            </span>
+                          </span>
+                        ) : null}
+                        {audit.receipt_uri ? (
+                          <a
+                            className="turn-chip activity-audit-receipt"
+                            href={audit.receipt_uri}
+                            target="_blank"
+                            rel="noreferrer"
+                          >
+                            {intl.formatMessage(messages.auditReceiptLink)}
+                          </a>
+                        ) : null}
+                      </div>
+                    ) : null}
+                    <div className="meta">
+                      {item.kind} • +{formatDuration(item.started_offset_ms)}
+                      {item.stage_node_id ? ` • ${item.stage_node_id}` : ""}
+                    </div>
+                    <div className="meta">{item.summary}</div>
                   </div>
-                  <div className="meta">
-                    {item.kind} • +{formatDuration(item.started_offset_ms)}
-                    {item.stage_node_id ? ` • ${item.stage_node_id}` : ""}
-                  </div>
-                  <div className="meta">{item.summary}</div>
-                </div>
-              ))
+                )
+              })
             ) : (
               <div className="muted">{intl.formatMessage(messages.noActivity)}</div>
             )}

--- a/crates/harn-cli/portal/src/styles.css
+++ b/crates/harn-cli/portal/src/styles.css
@@ -753,6 +753,72 @@ textarea {
   margin-bottom: 0;
 }
 
+.activity-audit {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 6px;
+}
+
+.activity-audit-reason {
+  background: rgba(110, 168, 254, 0.14);
+  border-color: rgba(110, 168, 254, 0.32);
+  max-width: 100%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.activity-audit-layers {
+  position: relative;
+  cursor: help;
+}
+
+.activity-audit-receipt {
+  text-decoration: none;
+}
+
+.activity-audit-receipt:hover {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.activity-audit-tooltip {
+  position: absolute;
+  bottom: calc(100% + 4px);
+  left: 0;
+  display: none;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 220px;
+  padding: 8px 10px;
+  background: var(--panel-3);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
+  font-size: 11px;
+  color: var(--text);
+  z-index: 5;
+  pointer-events: none;
+  white-space: normal;
+}
+
+.activity-audit-layers:hover .activity-audit-tooltip,
+.activity-audit-layers:focus-within .activity-audit-tooltip {
+  display: flex;
+}
+
+.activity-audit-tooltip-title {
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: 10px;
+}
+
+.activity-audit-tooltip-chain {
+  color: var(--text);
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
+}
+
 .run-card-link {
   margin-top: 10px;
   cursor: pointer;

--- a/crates/harn-cli/portal/src/types.ts
+++ b/crates/harn-cli/portal/src/types.ts
@@ -322,6 +322,20 @@ export type PortalSpan = {
   metadata: Record<string, unknown>
 }
 
+export type PortalActivityAuditLayer = {
+  name: string
+  status: string
+  metadata?: Record<string, unknown>
+}
+
+export type PortalActivityAudit = {
+  reason?: string
+  kind?: string
+  status: string
+  layers: PortalActivityAuditLayer[]
+  receipt_uri?: string
+}
+
 export type PortalActivity = {
   label: string
   kind: string
@@ -330,6 +344,7 @@ export type PortalActivity = {
   stage_node_id: string | null
   call_id: string | null
   summary: string
+  audit?: PortalActivityAudit
 }
 
 export type PortalTransition = {

--- a/crates/harn-cli/src/commands/portal/dto.rs
+++ b/crates/harn-cli/src/commands/portal/dto.rs
@@ -150,6 +150,44 @@ pub(super) struct PortalActivity {
     pub(super) stage_node_id: Option<String>,
     pub(super) call_id: Option<String>,
     pub(super) summary: String,
+    /// Captured `tool_call_audit` payload joined by `call_id`, when the
+    /// underlying middleware stack attached one. `None` keeps the
+    /// activity row visually clean for spans that never went through
+    /// `with_required_reason` / `with_audit_log` / etc.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) audit: Option<PortalActivityAudit>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct PortalActivityAudit {
+    /// User-facing one-liner pulled from `audit.summary`
+    /// (ACP `title` / OpenAI `summary_text` convention). Renders as a
+    /// chip below the tool name.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) reason: Option<String>,
+    /// Optional ACP-style classification (`read`, `search`, etc.) from
+    /// `audit.kind` or the typed receipt.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) kind: Option<String>,
+    /// Receipt status (`ok` / `error` / `consent_denied` / etc.) when a
+    /// `ToolCallReceipt` was attached.
+    pub(super) status: String,
+    /// Dispatch-order layer chain (outer-to-inner) extracted from
+    /// `audit.layers`. Powers the tooltip on hover.
+    pub(super) layers: Vec<PortalActivityAuditLayer>,
+    /// Pointer to a persisted receipt (`file://` for local sinks or a
+    /// pre-signed cloud URL). Passed through unchanged — the portal
+    /// never rewrites it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) receipt_uri: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct PortalActivityAuditLayer {
+    pub(super) name: String,
+    pub(super) status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) metadata: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/crates/harn-cli/src/commands/portal/run_analysis.rs
+++ b/crates/harn-cli/src/commands/portal/run_analysis.rs
@@ -7,11 +7,12 @@ use axum::http::StatusCode;
 use axum::Json;
 
 use super::dto::{
-    PortalActivity, PortalArtifact, PortalCheckpoint, PortalChildRun, PortalCostReport,
-    PortalCostSummary, PortalCostTrendPoint, PortalExecutionSummary, PortalInsight,
-    PortalPolicySummary, PortalProviderCostBreakdown, PortalReplayAssertion, PortalReplaySummary,
-    PortalRunDetail, PortalRunSummary, PortalSpan, PortalStage, PortalStageDebug, PortalStats,
-    PortalStorySection, PortalTranscriptStep, PortalTransition,
+    PortalActivity, PortalActivityAudit, PortalActivityAuditLayer, PortalArtifact,
+    PortalCheckpoint, PortalChildRun, PortalCostReport, PortalCostSummary, PortalCostTrendPoint,
+    PortalExecutionSummary, PortalInsight, PortalPolicySummary, PortalProviderCostBreakdown,
+    PortalReplayAssertion, PortalReplaySummary, PortalRunDetail, PortalRunSummary, PortalSpan,
+    PortalStage, PortalStageDebug, PortalStats, PortalStorySection, PortalTranscriptStep,
+    PortalTransition,
 };
 use super::errors::{bad_request_error, internal_error};
 use super::query::{ErrorResponse, ListRunsQuery};
@@ -438,7 +439,8 @@ pub(super) fn build_run_detail(
     let summary = build_run_summary(relative_path, 0, run);
     let spans = build_spans(run);
     let stages = build_stages(run);
-    let activities = build_activities(&spans, &stages);
+    let audit_index = build_tool_call_audit_index(run);
+    let activities = build_activities(&spans, &stages, &audit_index);
     let transitions = build_transitions(run);
     let checkpoints = build_checkpoints(run);
     let artifacts = build_artifacts(run);
@@ -658,24 +660,183 @@ fn build_spans(run: &harn_vm::orchestration::RunRecord) -> Vec<PortalSpan> {
         .collect()
 }
 
-fn build_activities(spans: &[PortalSpan], stages: &[PortalStage]) -> Vec<PortalActivity> {
+fn build_activities(
+    spans: &[PortalSpan],
+    stages: &[PortalStage],
+    audit_index: &HashMap<String, PortalActivityAudit>,
+) -> Vec<PortalActivity> {
     spans
         .iter()
         .filter(|span| span.kind != "pipeline")
-        .map(|span| PortalActivity {
-            label: span.label.clone(),
-            kind: span.kind.clone(),
-            started_offset_ms: span.start_ms,
-            duration_ms: span.duration_ms,
-            stage_node_id: owning_stage(span, stages).map(|stage| stage.node_id.clone()),
-            call_id: span
+        .map(|span| {
+            let call_id = span
                 .metadata
                 .get("call_id")
                 .and_then(|value| value.as_str())
-                .map(str::to_string),
-            summary: compact_metadata(&span.metadata),
+                .map(str::to_string);
+            let audit = call_id
+                .as_deref()
+                .and_then(|id| audit_index.get(id).cloned());
+            PortalActivity {
+                label: span.label.clone(),
+                kind: span.kind.clone(),
+                started_offset_ms: span.start_ms,
+                duration_ms: span.duration_ms,
+                stage_node_id: owning_stage(span, stages).map(|stage| stage.node_id.clone()),
+                call_id,
+                summary: compact_metadata(&span.metadata),
+                audit,
+            }
         })
         .collect()
+}
+
+/// Build a lookup table from `tool_call_id` to the joined audit/receipt
+/// payload by scanning every transcript on the run (run-level plus
+/// per-stage). One pass per run, O(1) lookup per activity span — keeps
+/// `build_activities` linear in the span count even when the audit
+/// stream is large.
+fn build_tool_call_audit_index(
+    run: &harn_vm::orchestration::RunRecord,
+) -> HashMap<String, PortalActivityAudit> {
+    let mut index: HashMap<String, PortalActivityAudit> = HashMap::new();
+    if let Some(transcript) = &run.transcript {
+        collect_tool_call_audit_events(transcript, &mut index);
+    }
+    for stage in &run.stages {
+        if let Some(transcript) = &stage.transcript {
+            collect_tool_call_audit_events(transcript, &mut index);
+        }
+    }
+    index
+}
+
+fn collect_tool_call_audit_events(
+    transcript: &serde_json::Value,
+    index: &mut HashMap<String, PortalActivityAudit>,
+) {
+    let Some(events) = transcript.get("events").and_then(|value| value.as_array()) else {
+        return;
+    };
+    for event in events {
+        let kind = event
+            .get("kind")
+            .and_then(|value| value.as_str())
+            .unwrap_or_default();
+        if kind != "tool_call_audit" {
+            continue;
+        }
+        let metadata = event.get("metadata");
+        let Some(call_id) = metadata
+            .and_then(|m| m.get("tool_call_id"))
+            .and_then(|value| value.as_str())
+            .filter(|value| !value.is_empty())
+        else {
+            continue;
+        };
+        let entry = portal_audit_from_event_metadata(metadata.unwrap_or(&serde_json::Value::Null));
+        // Latest audit for a given `tool_call_id` wins — middleware can
+        // emit multiple events in sequence (e.g. consent prompt update
+        // followed by the final outcome) and the most recent payload
+        // carries the terminal status + receipt.
+        index.insert(call_id.to_string(), entry);
+    }
+}
+
+fn portal_audit_from_event_metadata(metadata: &serde_json::Value) -> PortalActivityAudit {
+    let receipt = metadata.get("receipt");
+    let audit = metadata
+        .get("audit")
+        .cloned()
+        .unwrap_or(serde_json::Value::Null);
+    let reason = audit
+        .get("summary")
+        .and_then(|value| value.as_str())
+        .map(str::to_string)
+        .or_else(|| {
+            receipt
+                .and_then(|r| r.get("reason"))
+                .and_then(|value| value.as_str())
+                .map(str::to_string)
+        })
+        .filter(|value| !value.is_empty());
+    let kind = audit
+        .get("kind")
+        .and_then(|value| value.as_str())
+        .map(str::to_string)
+        .or_else(|| {
+            receipt
+                .and_then(|r| r.get("kind"))
+                .and_then(|value| value.as_str())
+                .map(str::to_string)
+        })
+        .filter(|value| !value.is_empty());
+    let status = receipt
+        .and_then(|r| r.get("status"))
+        .and_then(|value| value.as_str())
+        .map(str::to_string)
+        .unwrap_or_else(|| "unknown".to_string());
+    let layers = audit
+        .get("layers")
+        .and_then(|value| value.as_array())
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(portal_audit_layer_from_value)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let receipt_uri = audit
+        .get("receipt_uri")
+        .and_then(|value| value.as_str())
+        .or_else(|| {
+            receipt
+                .and_then(|r| r.get("audit"))
+                .and_then(|value| value.get("receipt_uri"))
+                .and_then(|value| value.as_str())
+        })
+        .map(str::to_string)
+        .filter(|value| !value.is_empty());
+
+    PortalActivityAudit {
+        reason,
+        kind,
+        status,
+        layers,
+        receipt_uri,
+    }
+}
+
+fn portal_audit_layer_from_value(value: &serde_json::Value) -> Option<PortalActivityAuditLayer> {
+    let name = value
+        .get("name")
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .filter(|v| !v.is_empty())?;
+    let status = value
+        .get("status")
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .unwrap_or_else(|| "unknown".to_string());
+    let metadata = value
+        .as_object()
+        .map(|obj| {
+            let mut clone = serde_json::Map::new();
+            for (key, val) in obj {
+                if key == "name" || key == "status" {
+                    continue;
+                }
+                clone.insert(key.clone(), val.clone());
+            }
+            clone
+        })
+        .filter(|map| !map.is_empty())
+        .map(serde_json::Value::Object);
+    Some(PortalActivityAuditLayer {
+        name,
+        status,
+        metadata,
+    })
 }
 
 fn build_transitions(run: &harn_vm::orchestration::RunRecord) -> Vec<PortalTransition> {

--- a/crates/harn-cli/src/commands/portal/tests.rs
+++ b/crates/harn-cli/src/commands/portal/tests.rs
@@ -246,6 +246,119 @@ fn build_run_detail_exposes_observability_summary() {
 }
 
 #[test]
+fn build_run_detail_joins_tool_call_audit_onto_matching_activity() {
+    let temp = tempfile::tempdir().unwrap();
+    let run_path = temp.path().join("audit-run.json");
+    fs::write(&run_path, "{}").unwrap();
+
+    // Two trace spans, only one of which has a matching audit event.
+    let trace_spans = vec![
+        harn_vm::orchestration::RunTraceSpanRecord {
+            span_id: 1,
+            parent_id: None,
+            kind: "tool_call".to_string(),
+            name: "search_files".to_string(),
+            start_ms: 0,
+            duration_ms: 12,
+            metadata: BTreeMap::from([(
+                "call_id".to_string(),
+                serde_json::json!("call-with-audit"),
+            )]),
+        },
+        harn_vm::orchestration::RunTraceSpanRecord {
+            span_id: 2,
+            parent_id: None,
+            kind: "tool_call".to_string(),
+            name: "read_file".to_string(),
+            start_ms: 20,
+            duration_ms: 5,
+            metadata: BTreeMap::from([(
+                "call_id".to_string(),
+                serde_json::json!("call-without-audit"),
+            )]),
+        },
+    ];
+
+    let transcript = serde_json::json!({
+        "events": [
+            {
+                "kind": "tool_call_audit",
+                "role": "tool",
+                "metadata": {
+                    "session_id": "s",
+                    "tool_call_id": "call-with-audit",
+                    "tool_name": "search_files",
+                    "audit": {
+                        "summary": "Look up rate limiter",
+                        "kind": "search",
+                        "layers": [
+                            {"name": "with_required_reason", "status": "ok"},
+                            {"name": "with_consent", "status": "approved", "decided_by": "auto"},
+                            {"name": "with_audit_log", "status": "ok"},
+                        ],
+                        "receipt_uri": "file:///tmp/.harn/receipts/s.jsonl",
+                    },
+                    "receipt": {
+                        "schema_version": 1,
+                        "session_id": "s",
+                        "tool_call_id": "call-with-audit",
+                        "tool_name": "search_files",
+                        "iteration": 1,
+                        "status": "ok",
+                    }
+                }
+            }
+        ]
+    });
+
+    let run = harn_vm::orchestration::RunRecord {
+        id: "run-audit".to_string(),
+        workflow_id: "wf".to_string(),
+        workflow_name: Some("audit-demo".to_string()),
+        task: "task".to_string(),
+        status: "succeeded".to_string(),
+        persisted_path: Some(run_path.to_string_lossy().into_owned()),
+        trace_spans,
+        transcript: Some(transcript),
+        ..Default::default()
+    };
+
+    let detail = build_run_detail(temp.path(), "audit-run.json", &run);
+    let with_audit = detail
+        .activities
+        .iter()
+        .find(|activity| activity.call_id.as_deref() == Some("call-with-audit"))
+        .expect("activity for call-with-audit");
+    let audit = with_audit
+        .audit
+        .as_ref()
+        .expect("matching activity carries audit");
+    assert_eq!(audit.reason.as_deref(), Some("Look up rate limiter"));
+    assert_eq!(audit.kind.as_deref(), Some("search"));
+    assert_eq!(audit.status, "ok");
+    let layer_names: Vec<&str> = audit
+        .layers
+        .iter()
+        .map(|layer| layer.name.as_str())
+        .collect();
+    assert_eq!(
+        layer_names,
+        vec!["with_required_reason", "with_consent", "with_audit_log"]
+    );
+    assert_eq!(
+        audit.receipt_uri.as_deref(),
+        Some("file:///tmp/.harn/receipts/s.jsonl")
+    );
+
+    let without_audit = detail
+        .activities
+        .iter()
+        .find(|activity| activity.call_id.as_deref() == Some("call-without-audit"))
+        .expect("activity for call-without-audit");
+    assert!(without_audit.audit.is_none(), "no audit event => no chip");
+}
+
+#[test]
 fn scan_launch_targets_finds_harn_files() {
     let temp = tempfile::tempdir().unwrap();
     fs::create_dir_all(temp.path().join("examples")).unwrap();

--- a/crates/harn-vm/src/llm/agent_session_host.rs
+++ b/crates/harn-vm/src/llm/agent_session_host.rs
@@ -1221,8 +1221,12 @@ async fn host_agent_emit_event(args: Vec<VmValue>) -> Result<VmValue, VmError> {
             | "tool_search_result"
             | "typed_checkpoint"
             | "agent_loop_stall_warning"
+            | "tool_call_audit"
     ) {
-        let role = if event_type == "tool_search_result" {
+        let role = if matches!(
+            event_type.as_str(),
+            "tool_search_result" | "tool_call_audit"
+        ) {
             "tool"
         } else {
             "assistant"


### PR DESCRIPTION
## Summary
- Surface `tool_call_audit` events on the RunDetail timeline: reason chip, layer-count badge with hover tooltip listing each middleware layer's name/decision/rationale, and a "View receipt" deep-link when a receipt id is present.
- Map `tool_call_audit` to the `tool` chat role in `agent_session_host` so the portal renders it alongside tool calls instead of treating it as an unknown event.
- Adds `PortalActivityAudit` + `PortalActivityAuditLayer` to the portal types and wires them through `RunDetail.tsx` with `defineMessages` for i18n consistency. ARIA: `aria-describedby` + `role="tooltip"` on the hover badge.

Closes #1695. Epic #1693 (audit-receipts) becomes closable once this lands.

## Test plan
- [ ] Portal frontend CI (lint + unit + build) green
- [ ] Manual: load a run with a tool-call audit entry; confirm reason chip + layer tooltip + receipt link render
- [ ] Manual: load a run with no audit entries; confirm no chrome regression