### PR TITLE
vm: extend bytecode cache to imported modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,19 @@ condensed series summaries instead of full per-patch history.
   `session/fs_mode` and `session/fs_commit_staged`, and receive
   `session/update` progress notifications tagged
   `_meta.harn.kind = "staged_writes_pending"`.
+- **Imported-module bytecode cache + correctness fixes (#1710 follow-up).**
+  Extends the v0.8.22 entry cache to imported modules — both stdlib and
+  user files now persist a `.harnmod` artifact alongside the entry
+  `.harnbc`, eliminating per-process re-parse and re-compile of every
+  imported function pool. `harn precompile` emits both artifact families
+  per source so shipped libraries hit the cache whether the user runs
+  them as an entry or imports them. Cache key now folds in active
+  `CompilerOptions` (so flipping `HARN_DISABLE_OPTIMIZATIONS` between
+  runs no longer reuses a chunk compiled under the opposite setting),
+  and the on-disk format gains a kind discriminant so the two artifact
+  families coexist in one cache dir without filename collisions. Header
+  schema bumped to `2`; older v0.8.22-written cache files are rejected
+  fail-closed and recompiled.
 
 ## v0.8.22
 

--- a/crates/harn-cli/src/commands/precompile.rs
+++ b/crates/harn-cli/src/commands/precompile.rs
@@ -9,6 +9,7 @@
 use std::path::{Path, PathBuf};
 
 use harn_parser::DiagnosticSeverity;
+use harn_vm::module_artifact::ModuleArtifact;
 
 use crate::cli::PrecompileArgs;
 use crate::command_error;
@@ -20,6 +21,14 @@ use crate::parse_source_file;
 struct Stats {
     compiled: usize,
     failed: usize,
+}
+
+/// One file can be both an executable entry pipeline AND an imported
+/// module. Precompile emits both so the runtime loader hits whichever
+/// path the user takes.
+struct PrecompileArtifacts {
+    entry_chunk: harn_vm::Chunk,
+    module_artifact: Option<ModuleArtifact>,
 }
 
 pub fn run(args: PrecompileArgs) {
@@ -101,29 +110,73 @@ fn precompile_one(
         eprint!("{messages}");
     }
 
-    let chunk = harn_vm::Compiler::new()
-        .compile(&program)
-        .map_err(|e| format!("compile error: {e}"))?;
+    let artifacts = compile_artifacts(source_path, &program)?;
     let key = harn_vm::bytecode_cache::CacheKey::from_source(source_path, &source);
 
-    let dest = output_path(source_path, source_root, out_root)?;
-    harn_vm::bytecode_cache::store_at(&dest, &key, &chunk)
-        .map_err(|e| format!("write {}: {e}", dest.display()))?;
+    let entry_dest = output_path(
+        source_path,
+        source_root,
+        out_root,
+        harn_vm::bytecode_cache::CACHE_EXTENSION,
+    )?;
+    harn_vm::bytecode_cache::store_at(&entry_dest, &key, &artifacts.entry_chunk)
+        .map_err(|e| format!("write {}: {e}", entry_dest.display()))?;
 
-    Ok(dest)
+    if let Some(module_artifact) = &artifacts.module_artifact {
+        let module_dest = output_path(
+            source_path,
+            source_root,
+            out_root,
+            harn_vm::bytecode_cache::MODULE_CACHE_EXTENSION,
+        )?;
+        harn_vm::bytecode_cache::store_module_at(&module_dest, &key, module_artifact)
+            .map_err(|e| format!("write {}: {e}", module_dest.display()))?;
+    }
+
+    Ok(entry_dest)
+}
+
+/// Compile both the entry-chunk view and the module-artifact view of the
+/// same source. A `.harn` file with a `pipeline default { ... }` block is
+/// callable as both an entry and an importable module; one without is
+/// importable but produces an entry chunk that just returns `nil`. We
+/// emit both artifacts unconditionally so the runtime loader hits the
+/// cache regardless of how the user invokes the file.
+fn compile_artifacts(
+    source_path: &Path,
+    program: &[harn_parser::SNode],
+) -> Result<PrecompileArtifacts, String> {
+    let entry_chunk = harn_vm::Compiler::new()
+        .compile(program)
+        .map_err(|e| format!("compile error: {e}"))?;
+    let module_artifact = harn_vm::module_artifact::compile_module_artifact(
+        program,
+        Some(source_path.display().to_string()),
+    )
+    .map_err(|e| format!("module compile error: {e}"))
+    .ok();
+    Ok(PrecompileArtifacts {
+        entry_chunk,
+        module_artifact,
+    })
 }
 
 /// Map a source path under (optional) `source_root` to its destination
-/// under (optional) `out_root`. When no `out_root` is given the artifact
-/// lands adjacent to the source.
+/// under (optional) `out_root` with the given file extension. When no
+/// `out_root` is given the artifact lands adjacent to the source.
 fn output_path(
     source_path: &Path,
     source_root: Option<&Path>,
     out_root: Option<&Path>,
+    extension: &str,
 ) -> Result<PathBuf, String> {
-    let adjacent = harn_vm::bytecode_cache::adjacent_cache_path(source_path)
+    let stem = source_path
+        .file_stem()
         .ok_or_else(|| format!("source has no file stem: {}", source_path.display()))?;
     let Some(out_root) = out_root else {
+        let parent = source_path.parent().unwrap_or_else(|| Path::new(""));
+        let mut adjacent = parent.join(stem);
+        adjacent.set_extension(extension);
         return Ok(adjacent);
     };
     let relative = match source_root {
@@ -145,6 +198,6 @@ fn output_path(
         ),
     };
     let mut dest = out_root.join(&relative);
-    dest.set_extension(harn_vm::bytecode_cache::CACHE_EXTENSION);
+    dest.set_extension(extension);
     Ok(dest)
 }

--- a/crates/harn-cli/tests/bytecode_cache.rs
+++ b/crates/harn-cli/tests/bytecode_cache.rs
@@ -68,11 +68,20 @@ fn run_harn(cache_dir: &Path, script: &Path) -> RunOutcome {
 }
 
 fn cache_entries(dir: &Path) -> Vec<PathBuf> {
+    cache_entries_with_extension(dir, "harnbc")
+}
+
+fn module_cache_entries(dir: &Path) -> Vec<PathBuf> {
+    cache_entries_with_extension(dir, "harnmod")
+}
+
+fn cache_entries_with_extension(dir: &Path, ext: &str) -> Vec<PathBuf> {
+    let ext = ext.to_string();
     let mut entries: Vec<PathBuf> = fs::read_dir(dir)
         .map(|read| {
             read.filter_map(|entry| entry.ok())
                 .map(|entry| entry.path())
-                .filter(|path| path.extension().is_some_and(|ext| ext == "harnbc"))
+                .filter(|path| path.extension().is_some_and(|e| e == ext.as_str()))
                 .collect()
         })
         .unwrap_or_default();
@@ -110,6 +119,39 @@ fn source_edit_invalidates_cache() {
     assert!(
         entries.len() >= 2,
         "expected ≥2 cache entries, got {entries:?}"
+    );
+}
+
+#[test]
+fn imported_module_is_cached_to_disk() {
+    let workdir = TempDir::new().unwrap();
+    let cache = TempDir::new().unwrap();
+    let lib = workdir.path().join("lib.harn");
+    fs::write(&lib, "pub fn answer() -> int { return 42 }\n").unwrap();
+    let script = workdir.path().join("entry.harn");
+    fs::write(
+        &script,
+        "import { answer } from \"./lib\"\nprintln(answer())\n",
+    )
+    .unwrap();
+
+    let first = run_harn(cache.path(), &script);
+    assert_eq!(first.exit_code, 0, "first run failed: {}", first.stderr);
+    assert!(first.stdout.contains("42"), "stdout: {:?}", first.stdout);
+    let module_entries = module_cache_entries(cache.path());
+    assert_eq!(
+        module_entries.len(),
+        1,
+        "imported lib should have produced one cached module artifact, got {module_entries:?}"
+    );
+
+    let second = run_harn(cache.path(), &script);
+    assert_eq!(second.exit_code, 0, "second run failed: {}", second.stderr);
+    assert!(second.stdout.contains("42"));
+    assert_eq!(
+        module_cache_entries(cache.path()).len(),
+        1,
+        "second run should reuse the cached module without writing a new artifact"
     );
 }
 
@@ -173,6 +215,16 @@ fn precompile_then_run_skips_compile() {
     );
     let metadata = fs::metadata(&adjacent).expect("read adjacent metadata");
     assert!(metadata.len() > 0, "precompiled artifact is empty");
+    let module_adjacent = workdir.path().join("entry.harnmod");
+    assert!(
+        module_adjacent.exists(),
+        "expected precompile to also produce module artifact {module_adjacent:?} so files imported \
+         elsewhere hit the cache without recompile"
+    );
+    assert!(
+        fs::metadata(&module_adjacent).unwrap().len() > 0,
+        "precompiled module artifact is empty"
+    );
 
     let run_result = run_harn(cache.path(), &script);
     assert_eq!(run_result.exit_code, 0, "run failed: {}", run_result.stderr);
@@ -188,6 +240,48 @@ fn precompile_then_run_skips_compile() {
         shared.is_empty(),
         "expected adjacent artifact to satisfy the loader without populating \
          the shared cache dir; got {shared:?}"
+    );
+}
+
+#[test]
+fn precompiled_imported_module_uses_adjacent_artifact() {
+    let workdir = TempDir::new().unwrap();
+    let cache = TempDir::new().unwrap();
+    let lib = workdir.path().join("lib.harn");
+    fs::write(&lib, "pub fn answer() -> int { return 42 }\n").unwrap();
+    let script = workdir.path().join("entry.harn");
+    fs::write(
+        &script,
+        "import { answer } from \"./lib\"\nprintln(answer())\n",
+    )
+    .unwrap();
+
+    run_in_harn_runtime({
+        let target = lib.clone();
+        move || async move {
+            let _env_guard = env_lock::lock_env().lock().await;
+            harn_vm::reset_thread_local_state();
+            precompile::run(PrecompileArgs {
+                target,
+                out: None,
+                keep_going: false,
+                quiet: true,
+            });
+        }
+    });
+
+    let module_adjacent = workdir.path().join("lib.harnmod");
+    assert!(
+        module_adjacent.exists(),
+        "expected precompile to produce imported module artifact {module_adjacent:?}"
+    );
+
+    let run_result = run_harn(cache.path(), &script);
+    assert_eq!(run_result.exit_code, 0, "run failed: {}", run_result.stderr);
+    assert!(run_result.stdout.contains("42"));
+    assert!(
+        module_cache_entries(cache.path()).is_empty(),
+        "expected adjacent .harnmod to satisfy the import without writing a shared module cache"
     );
 }
 

--- a/crates/harn-vm/src/bytecode_cache.rs
+++ b/crates/harn-vm/src/bytecode_cache.rs
@@ -19,9 +19,11 @@
 //! schema_ver   : u32       = SCHEMA_VERSION
 //! version_len  : u32
 //! harn_version : [u8; version_len]
+//! compiler_tag : u8        bitmask of active CompilerOptions
+//! kind         : u8        1 = entry chunk, 2 = module artifact
 //! source_hash  : [u8; 32]
 //! import_hash  : [u8; 32]
-//! payload      : bincode-serialized CachedChunk
+//! payload      : bincode-serialized payload for `kind`
 //! ```
 //!
 //! The header lets a stale binary detect a future-version artifact
@@ -41,23 +43,33 @@ use std::path::{Path, PathBuf};
 use sha2::{Digest, Sha256};
 
 use crate::chunk::{CachedChunk, Chunk};
+use crate::compiler::CompilerOptions;
+use crate::module_artifact::ModuleArtifact;
 
-/// Header magic. The trailing NULs reserve room for a one-byte type
-/// discriminator should we later store IR alongside bytecode in the
-/// same file.
+/// Header magic for all bytecode-cache artifact families.
 pub const MAGIC: &[u8; 8] = b"HARNBC\0\0";
 
 /// On-disk format version. Bump when [`CachedChunk`] or the header
 /// layout changes in a backwards-incompatible way.
-pub const SCHEMA_VERSION: u32 = 1;
+pub const SCHEMA_VERSION: u32 = 2;
 
 /// Compile-time Harn release. Cache files written by a different release
 /// are rejected on load.
 pub const HARN_VERSION: &str = env!("CARGO_PKG_VERSION");
 
-/// Conventional extension for cache files. Used both for entries in the
-/// shared cache dir and for adjacent precompiled artifacts.
+/// Conventional extension for entry-chunk cache files.
 pub const CACHE_EXTENSION: &str = "harnbc";
+
+/// Conventional extension for module-artifact cache files. Distinct from
+/// [`CACHE_EXTENSION`] so the same `.harn` source can have both shipped
+/// adjacent if needed (e.g. when a file is both an executable entry and
+/// imported by other files).
+pub const MODULE_CACHE_EXTENSION: &str = "harnmod";
+
+/// On-disk discriminant for a [`Chunk`] payload.
+const KIND_ENTRY_CHUNK: u8 = 1;
+/// On-disk discriminant for a [`ModuleArtifact`] payload.
+const KIND_MODULE_ARTIFACT: u8 = 2;
 
 /// Environment override for the cache directory. When set, takes
 /// precedence over the XDG and home-directory fallbacks.
@@ -76,12 +88,16 @@ pub struct LookupOutcome {
 }
 
 /// Cache key components for a single pipeline source. Equality of all
-/// three fields is necessary and sufficient for cache reuse.
+/// fields is necessary and sufficient for cache reuse.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CacheKey {
     pub source_hash: [u8; 32],
     pub import_graph_hash: [u8; 32],
     pub harn_version: &'static str,
+    /// Compact tag for active [`CompilerOptions`]. Flipping
+    /// `HARN_DISABLE_OPTIMIZATIONS` between runs would otherwise reuse a
+    /// chunk compiled under the wrong setting.
+    pub compiler_tag: u8,
 }
 
 impl CacheKey {
@@ -95,15 +111,21 @@ impl CacheKey {
             source_hash,
             import_graph_hash,
             harn_version: HARN_VERSION,
+            compiler_tag: compiler_options_tag(CompilerOptions::from_env()),
         }
     }
 
-    /// Cache filename for this key. We hash by source content alone so
-    /// that two invocations of the same source from different paths
+    /// Entry-chunk filename for this key. We hash by source content
+    /// alone so two invocations of the same source from different paths
     /// share a cache entry; the header's import-graph hash still gates
     /// reuse on a per-load basis.
     pub fn filename(&self) -> String {
         format!("{}.{}", hex(&self.source_hash), CACHE_EXTENSION)
+    }
+
+    /// Module-artifact filename for this key.
+    pub fn module_filename(&self) -> String {
+        format!("{}.{}", hex(&self.source_hash), MODULE_CACHE_EXTENSION)
     }
 }
 
@@ -181,50 +203,132 @@ pub fn store(key: &CacheKey, chunk: &Chunk) -> io::Result<()> {
     }
     let dir = cache_dir();
     fs::create_dir_all(&dir)?;
-    write_atomic(&dir.join(key.filename()), key, chunk)
+    write_atomic_chunk(&dir.join(key.filename()), key, chunk)
 }
 
-/// Write a precompiled artifact to an explicit path, for use by the
-/// `harn precompile` subcommand. The header still records the key, so
-/// adjacent artifacts shipped with source are validated like any other
-/// cache hit.
+/// Write a precompiled entry-chunk artifact to an explicit path, for
+/// use by the `harn precompile` subcommand. The header still records
+/// the key, so adjacent artifacts shipped with source are validated
+/// like any other cache hit.
 pub fn store_at(path: &Path, key: &CacheKey, chunk: &Chunk) -> io::Result<()> {
-    if let Some(parent) = path.parent() {
-        if !parent.as_os_str().is_empty() {
-            fs::create_dir_all(parent)?;
+    ensure_parent_dir(path)?;
+    write_atomic_chunk(path, key, chunk)
+}
+
+/// Look up the [`ModuleArtifact`] for `source_path` (whose contents are
+/// `source`). Mirrors [`load`] but for the `.harnmod` family.
+pub fn load_module(source_path: &Path, source: &str) -> ModuleLookupOutcome {
+    let key = CacheKey::from_source(source_path, source);
+    if !cache_enabled() {
+        return ModuleLookupOutcome {
+            key,
+            artifact: None,
+        };
+    }
+    let mut candidates: Vec<PathBuf> = Vec::with_capacity(2);
+    if let Some(adjacent) = adjacent_module_cache_path(source_path) {
+        candidates.push(adjacent);
+    }
+    candidates.push(cache_dir().join(key.module_filename()));
+    for path in candidates {
+        match read_module_if_matches(&path, &key) {
+            Ok(Some(artifact)) => {
+                return ModuleLookupOutcome {
+                    key,
+                    artifact: Some(artifact),
+                }
+            }
+            Ok(None) => continue,
+            Err(_) => continue,
         }
     }
-    write_atomic(path, key, chunk)
+    ModuleLookupOutcome {
+        key,
+        artifact: None,
+    }
 }
 
-/// Path to the adjacent precompiled artifact for `source_path`, if any.
-/// `foo.harn` → `foo.harnbc`; files without a stem or extension return
-/// `None`.
+/// Persist `artifact` to the shared cache under `key`. Atomic;
+/// concurrent invocations race safely.
+pub fn store_module(key: &CacheKey, artifact: &ModuleArtifact) -> io::Result<()> {
+    if !cache_enabled() {
+        return Ok(());
+    }
+    let dir = cache_dir();
+    fs::create_dir_all(&dir)?;
+    write_atomic_module(&dir.join(key.module_filename()), key, artifact)
+}
+
+/// Write a module artifact to an explicit path.
+pub fn store_module_at(path: &Path, key: &CacheKey, artifact: &ModuleArtifact) -> io::Result<()> {
+    ensure_parent_dir(path)?;
+    write_atomic_module(path, key, artifact)
+}
+
+/// Result of a [`load_module`] lookup. Carries the precomputed key so
+/// the caller can write it back on a miss without rehashing.
+pub struct ModuleLookupOutcome {
+    pub key: CacheKey,
+    pub artifact: Option<ModuleArtifact>,
+}
+
+/// Path to the adjacent precompiled entry-chunk artifact for
+/// `source_path`. `foo.harn` → `foo.harnbc`.
 pub fn adjacent_cache_path(source_path: &Path) -> Option<PathBuf> {
+    adjacent_path_with_extension(source_path, CACHE_EXTENSION)
+}
+
+/// Path to the adjacent precompiled module-artifact for `source_path`.
+/// `foo.harn` → `foo.harnmod`.
+pub fn adjacent_module_cache_path(source_path: &Path) -> Option<PathBuf> {
+    adjacent_path_with_extension(source_path, MODULE_CACHE_EXTENSION)
+}
+
+fn adjacent_path_with_extension(source_path: &Path, ext: &str) -> Option<PathBuf> {
     let stem = source_path.file_stem()?;
     if stem.is_empty() {
         return None;
     }
     let parent = source_path.parent().unwrap_or_else(|| Path::new(""));
     let mut out = parent.join(stem);
-    out.set_extension(CACHE_EXTENSION);
+    out.set_extension(ext);
     Some(out)
 }
 
-fn write_atomic(target: &Path, key: &CacheKey, chunk: &Chunk) -> io::Result<()> {
+fn ensure_parent_dir(path: &Path) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent)?;
+        }
+    }
+    Ok(())
+}
+
+fn write_atomic_chunk(target: &Path, key: &CacheKey, chunk: &Chunk) -> io::Result<()> {
     let cached = chunk.freeze_for_cache();
     let payload = bincode::serialize(&cached)
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+    write_atomic(target, key, KIND_ENTRY_CHUNK, &payload)
+}
 
+fn write_atomic_module(target: &Path, key: &CacheKey, artifact: &ModuleArtifact) -> io::Result<()> {
+    let payload = bincode::serialize(artifact)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+    write_atomic(target, key, KIND_MODULE_ARTIFACT, &payload)
+}
+
+fn write_atomic(target: &Path, key: &CacheKey, kind: u8, payload: &[u8]) -> io::Result<()> {
     let mut buf: Vec<u8> = Vec::with_capacity(payload.len() + 128);
     buf.extend_from_slice(MAGIC);
     buf.extend_from_slice(&SCHEMA_VERSION.to_le_bytes());
     let version_bytes = HARN_VERSION.as_bytes();
     buf.extend_from_slice(&(version_bytes.len() as u32).to_le_bytes());
     buf.extend_from_slice(version_bytes);
+    buf.push(key.compiler_tag);
+    buf.push(kind);
     buf.extend_from_slice(&key.source_hash);
     buf.extend_from_slice(&key.import_graph_hash);
-    buf.extend_from_slice(&payload);
+    buf.extend_from_slice(payload);
 
     let tmp_name = match target.file_name() {
         Some(name) => format!(".{}.{}.tmp", name.to_string_lossy(), std::process::id(),),
@@ -244,7 +348,14 @@ fn write_atomic(target: &Path, key: &CacheKey, chunk: &Chunk) -> io::Result<()> 
     }
 }
 
-fn read_chunk_if_matches(path: &Path, key: &CacheKey) -> io::Result<Option<Chunk>> {
+/// Parsed cache header. Read by both the chunk and module loaders so the
+/// header-validation logic stays in one place.
+struct ParsedHeader {
+    kind: u8,
+    payload: Vec<u8>,
+}
+
+fn read_header_if_matches(path: &Path, key: &CacheKey) -> io::Result<Option<ParsedHeader>> {
     let mut file = match fs::File::open(path) {
         Ok(f) => f,
         Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(None),
@@ -262,9 +373,8 @@ fn read_chunk_if_matches(path: &Path, key: &CacheKey) -> io::Result<Option<Chunk
         return Ok(None);
     }
     let version_len = u32::from_le_bytes(header[12..16].try_into().unwrap()) as usize;
-    // Sanity-check the version string length to keep a corrupted file
-    // from forcing an unbounded allocation.
     if version_len > 256 {
+        // Bound the alloc so a corrupted file cannot force an unbounded read.
         return Ok(None);
     }
     let mut version_buf = vec![0u8; version_len];
@@ -274,6 +384,14 @@ fn read_chunk_if_matches(path: &Path, key: &CacheKey) -> io::Result<Option<Chunk
     if version_buf != key.harn_version.as_bytes() {
         return Ok(None);
     }
+    let mut compiler_and_kind = [0u8; 2];
+    if file.read_exact(&mut compiler_and_kind).is_err() {
+        return Ok(None);
+    }
+    if compiler_and_kind[0] != key.compiler_tag {
+        return Ok(None);
+    }
+    let kind = compiler_and_kind[1];
     let mut hashes = [0u8; 64];
     if file.read_exact(&mut hashes).is_err() {
         return Ok(None);
@@ -285,11 +403,48 @@ fn read_chunk_if_matches(path: &Path, key: &CacheKey) -> io::Result<Option<Chunk
     if file.read_to_end(&mut payload).is_err() {
         return Ok(None);
     }
-    let cached: CachedChunk = match bincode::deserialize(&payload) {
+    Ok(Some(ParsedHeader { kind, payload }))
+}
+
+fn read_chunk_if_matches(path: &Path, key: &CacheKey) -> io::Result<Option<Chunk>> {
+    let Some(header) = read_header_if_matches(path, key)? else {
+        return Ok(None);
+    };
+    if header.kind != KIND_ENTRY_CHUNK {
+        return Ok(None);
+    }
+    let cached: CachedChunk = match bincode::deserialize(&header.payload) {
         Ok(c) => c,
         Err(_) => return Ok(None),
     };
     Ok(Some(Chunk::from_cached(&cached)))
+}
+
+fn read_module_if_matches(path: &Path, key: &CacheKey) -> io::Result<Option<ModuleArtifact>> {
+    let Some(header) = read_header_if_matches(path, key)? else {
+        return Ok(None);
+    };
+    if header.kind != KIND_MODULE_ARTIFACT {
+        return Ok(None);
+    }
+    match bincode::deserialize::<ModuleArtifact>(&header.payload) {
+        Ok(artifact) => Ok(Some(artifact)),
+        Err(_) => Ok(None),
+    }
+}
+
+/// Compact representation of [`CompilerOptions`] for the cache header.
+/// Independent flags get distinct bits so adding a new flag never
+/// silently changes existing keys when an old binary reads a new
+/// artifact — the header check will fail-closed before we get there
+/// anyway, but mapping to bits also keeps the tag a stable function
+/// of the option set.
+fn compiler_options_tag(options: CompilerOptions) -> u8 {
+    let mut tag: u8 = 0;
+    if options.optimizations_enabled() {
+        tag |= 0b0000_0001;
+    }
+    tag
 }
 
 fn sha256(bytes: &[u8]) -> [u8; 32] {
@@ -573,8 +728,27 @@ mod tests {
             source_hash: [0xAB; 32],
             import_graph_hash: key.import_graph_hash,
             harn_version: HARN_VERSION,
+            compiler_tag: key.compiler_tag,
         };
         assert!(read_chunk_if_matches(&path, &other).unwrap().is_none());
+    }
+
+    #[test]
+    fn compiler_tag_mismatch_returns_none() {
+        let chunk = compile_source("1 + 1").expect("compile");
+        let key = CacheKey::from_source(Path::new("/tmp/b.harn"), "1 + 1");
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("b.harnbc");
+        store_at(&path, &key, &chunk).expect("write");
+        let other = CacheKey {
+            compiler_tag: key.compiler_tag ^ 0xFF,
+            ..key.clone()
+        };
+        assert!(
+            read_chunk_if_matches(&path, &other).unwrap().is_none(),
+            "flipped HARN_DISABLE_OPTIMIZATIONS must not reuse a chunk \
+             compiled under the opposite setting"
+        );
     }
 
     #[test]

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -38,6 +38,7 @@ pub mod mcp_registry;
 pub mod mcp_sampling;
 pub mod mcp_server;
 pub mod metadata;
+pub mod module_artifact;
 pub mod observability;
 pub mod orchestration;
 pub mod personas;

--- a/crates/harn-vm/src/module_artifact.rs
+++ b/crates/harn-vm/src/module_artifact.rs
@@ -1,0 +1,152 @@
+//! Serializable shape of a compiled `.harn` module — the unit the
+//! on-disk module cache stores.
+//!
+//! A module is anything `import` can name: a stdlib file (`std/foo`) or
+//! a user file on disk. The artifact captures **only** the result of
+//! the parse + compile pipeline; instantiation (running the `init`
+//! chunk, creating closures bound to a fresh module env, and applying
+//! re-exports) happens fresh per process and is not cached. This split
+//! lets the cache short-circuit the expensive parse+compile while still
+//! producing the per-process state the runtime needs.
+
+use std::collections::{BTreeMap, HashSet};
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use crate::chunk::{CachedChunk, CachedCompiledFunction};
+use crate::value::VmError;
+
+/// A single `import`-style declaration inside a module. Re-resolved at
+/// instantiation time so that the cached artifact does not bake in
+/// stale resolved paths.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ModuleImportSpec {
+    pub path: String,
+    pub selected_names: Option<Vec<String>>,
+    pub is_pub: bool,
+}
+
+/// Serializable compile artifact for one `.harn` module. The runtime
+/// turns this into a loaded module by replaying [`init_chunk`](Self::init_chunk)
+/// into a fresh env, minting closures for each entry in
+/// [`functions`](Self::functions), and re-issuing every nested
+/// [`imports`](Self::imports).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ModuleArtifact {
+    pub imports: Vec<ModuleImportSpec>,
+    pub init_chunk: Option<CachedChunk>,
+    pub functions: BTreeMap<String, CachedCompiledFunction>,
+    pub public_names: HashSet<String>,
+}
+
+/// Compile a parsed `.harn` module into the serializable artifact shape.
+/// Pure compilation — no I/O, no execution. Used by both the runtime
+/// import path (`crates/harn-vm/src/vm/modules.rs`) and the
+/// `harn precompile` CLI subcommand.
+pub fn compile_module_artifact(
+    program: &[harn_parser::SNode],
+    module_source_file: Option<String>,
+) -> Result<ModuleArtifact, VmError> {
+    let imports = program
+        .iter()
+        .filter_map(|node| match &node.node {
+            harn_parser::Node::ImportDecl { path, is_pub } => Some(ModuleImportSpec {
+                path: path.clone(),
+                selected_names: None,
+                is_pub: *is_pub,
+            }),
+            harn_parser::Node::SelectiveImport {
+                names,
+                path,
+                is_pub,
+            } => Some(ModuleImportSpec {
+                path: path.clone(),
+                selected_names: Some(names.clone()),
+                is_pub: *is_pub,
+            }),
+            _ => None,
+        })
+        .collect();
+
+    let init_nodes: Vec<harn_parser::SNode> = program
+        .iter()
+        .filter(|sn| {
+            matches!(
+                &sn.node,
+                harn_parser::Node::VarBinding { .. } | harn_parser::Node::LetBinding { .. }
+            )
+        })
+        .cloned()
+        .collect();
+    let init_chunk = if init_nodes.is_empty() {
+        None
+    } else {
+        Some(
+            crate::Compiler::new()
+                .compile(&init_nodes)
+                .map_err(|e| VmError::Runtime(format!("Import init compile error: {e}")))?
+                .freeze_for_cache(),
+        )
+    };
+
+    let mut functions = BTreeMap::new();
+    let mut public_names = HashSet::new();
+    for node in program {
+        let inner = match &node.node {
+            harn_parser::Node::AttributedDecl { inner, .. } => inner.as_ref(),
+            _ => node,
+        };
+        let harn_parser::Node::FnDecl {
+            name,
+            type_params,
+            params,
+            body,
+            is_pub,
+            ..
+        } = &inner.node
+        else {
+            continue;
+        };
+
+        let mut compiler = crate::Compiler::new();
+        let func_chunk = compiler
+            .compile_fn_body(type_params, params, body, module_source_file.clone())
+            .map_err(|e| VmError::Runtime(format!("Import compile error: {e}")))?;
+        functions.insert(name.clone(), func_chunk.freeze_for_cache());
+        if *is_pub {
+            public_names.insert(name.clone());
+        }
+    }
+
+    Ok(ModuleArtifact {
+        imports,
+        init_chunk,
+        functions,
+        public_names,
+    })
+}
+
+/// Lex + parse + [`compile_module_artifact`] in one call. Used when the
+/// caller already has the raw source bytes and wants the artifact in one
+/// step.
+pub fn compile_module_artifact_from_source(
+    source_path: &Path,
+    source: &str,
+) -> Result<ModuleArtifact, VmError> {
+    let mut lexer = harn_lexer::Lexer::new(source);
+    let tokens = lexer.tokenize().map_err(|e| {
+        VmError::Runtime(format!(
+            "Import lex error in {}: {e}",
+            source_path.display()
+        ))
+    })?;
+    let mut parser = harn_parser::Parser::new(tokens);
+    let program = parser.parse().map_err(|e| {
+        VmError::Runtime(format!(
+            "Import parse error in {}: {e}",
+            source_path.display()
+        ))
+    })?;
+    compile_module_artifact(&program, Some(source_path.display().to_string()))
+}

--- a/crates/harn-vm/src/vm/modules.rs
+++ b/crates/harn-vm/src/vm/modules.rs
@@ -7,30 +7,17 @@ use std::pin::Pin;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex, OnceLock};
 
-use crate::chunk::{CachedChunk, CachedCompiledFunction, Chunk, CompiledFunction};
+use crate::bytecode_cache;
+use crate::chunk::{Chunk, CompiledFunction};
+use crate::module_artifact::{compile_module_artifact_from_source, ModuleArtifact};
 use crate::value::{ModuleFunctionRegistry, VmClosure, VmEnv, VmError, VmValue};
 
 use super::{ScopeSpan, Vm};
 
-#[derive(Clone)]
-struct ModuleImportSpec {
-    path: String,
-    selected_names: Option<Vec<String>>,
-    is_pub: bool,
-}
-
-#[derive(Clone)]
-struct CompiledStdlibModule {
-    imports: Vec<ModuleImportSpec>,
-    init_chunk: Option<CachedChunk>,
-    functions: BTreeMap<String, CachedCompiledFunction>,
-    public_names: HashSet<String>,
-}
-
-static STDLIB_MODULE_ARTIFACT_CACHE: OnceLock<Mutex<BTreeMap<String, Arc<CompiledStdlibModule>>>> =
+static STDLIB_MODULE_ARTIFACT_CACHE: OnceLock<Mutex<BTreeMap<String, Arc<ModuleArtifact>>>> =
     OnceLock::new();
 
-fn stdlib_module_artifact_cache() -> &'static Mutex<BTreeMap<String, Arc<CompiledStdlibModule>>> {
+fn stdlib_module_artifact_cache() -> &'static Mutex<BTreeMap<String, Arc<ModuleArtifact>>> {
     STDLIB_MODULE_ARTIFACT_CACHE.get_or_init(|| Mutex::new(BTreeMap::new()))
 }
 
@@ -80,8 +67,8 @@ fn stdlib_artifact_cache_key(module: &str, source: &str) -> String {
 fn stdlib_module_artifact(
     module: &str,
     synthetic: &Path,
-    source: &str,
-) -> Result<Arc<CompiledStdlibModule>, VmError> {
+    source: &'static str,
+) -> Result<Arc<ModuleArtifact>, VmError> {
     let key = stdlib_artifact_cache_key(module, source);
     {
         let cache = stdlib_module_artifact_cache().lock().unwrap();
@@ -90,109 +77,30 @@ fn stdlib_module_artifact(
         }
     }
 
-    let compiled = Arc::new(compile_stdlib_module_artifact(synthetic, source)?);
+    // Stdlib modules are embedded in the binary so their content cannot
+    // legitimately change between processes; that means the disk cache
+    // for stdlib can use a synthetic source_path. The harn_version field
+    // of the cache key gates correctness across releases.
+    let lookup = bytecode_cache::load_module(synthetic, source);
+    let artifact = if let Some(artifact) = lookup.artifact {
+        artifact
+    } else {
+        let compiled = compile_module_artifact_from_source(synthetic, source)?;
+        if let Err(err) = bytecode_cache::store_module(&lookup.key, &compiled) {
+            if std::env::var_os("HARN_BYTECODE_CACHE_DEBUG").is_some() {
+                eprintln!("[harn] stdlib module cache write skipped for {module}: {err}");
+            }
+        }
+        compiled
+    };
+
+    let compiled = Arc::new(artifact);
     let mut cache = stdlib_module_artifact_cache().lock().unwrap();
     if let Some(cached) = cache.get(&key) {
         return Ok(Arc::clone(cached));
     }
     cache.insert(key, Arc::clone(&compiled));
     Ok(compiled)
-}
-
-fn compile_stdlib_module_artifact(
-    synthetic: &Path,
-    source: &str,
-) -> Result<CompiledStdlibModule, VmError> {
-    let mut lexer = harn_lexer::Lexer::new(source);
-    let tokens = lexer.tokenize().map_err(|e| {
-        VmError::Runtime(format!("Import lex error in {}: {e}", synthetic.display()))
-    })?;
-    let mut parser = harn_parser::Parser::new(tokens);
-    let program = parser.parse().map_err(|e| {
-        VmError::Runtime(format!(
-            "Import parse error in {}: {e}",
-            synthetic.display()
-        ))
-    })?;
-
-    let imports = program
-        .iter()
-        .filter_map(|node| match &node.node {
-            harn_parser::Node::ImportDecl { path, is_pub } => Some(ModuleImportSpec {
-                path: path.clone(),
-                selected_names: None,
-                is_pub: *is_pub,
-            }),
-            harn_parser::Node::SelectiveImport {
-                names,
-                path,
-                is_pub,
-            } => Some(ModuleImportSpec {
-                path: path.clone(),
-                selected_names: Some(names.clone()),
-                is_pub: *is_pub,
-            }),
-            _ => None,
-        })
-        .collect();
-
-    let init_nodes: Vec<harn_parser::SNode> = program
-        .iter()
-        .filter(|sn| {
-            matches!(
-                &sn.node,
-                harn_parser::Node::VarBinding { .. } | harn_parser::Node::LetBinding { .. }
-            )
-        })
-        .cloned()
-        .collect();
-    let init_chunk = if init_nodes.is_empty() {
-        None
-    } else {
-        Some(
-            crate::Compiler::new()
-                .compile(&init_nodes)
-                .map_err(|e| VmError::Runtime(format!("Import init compile error: {e}")))?
-                .freeze_for_cache(),
-        )
-    };
-
-    let mut functions = BTreeMap::new();
-    let mut public_names = HashSet::new();
-    let module_source_file = Some(synthetic.display().to_string());
-    for node in &program {
-        let inner = match &node.node {
-            harn_parser::Node::AttributedDecl { inner, .. } => inner.as_ref(),
-            _ => node,
-        };
-        let harn_parser::Node::FnDecl {
-            name,
-            type_params,
-            params,
-            body,
-            is_pub,
-            ..
-        } = &inner.node
-        else {
-            continue;
-        };
-
-        let mut compiler = crate::Compiler::new();
-        let func_chunk = compiler
-            .compile_fn_body(type_params, params, body, module_source_file.clone())
-            .map_err(|e| VmError::Runtime(format!("Import compile error: {e}")))?;
-        functions.insert(name.clone(), func_chunk.freeze_for_cache());
-        if *is_pub {
-            public_names.insert(name.clone());
-        }
-    }
-
-    Ok(CompiledStdlibModule {
-        imports,
-        init_chunk,
-        functions,
-        public_names,
-    })
 }
 
 impl Vm {
@@ -206,22 +114,10 @@ impl Vm {
         }
         Rc::make_mut(&mut self.source_cache).insert(synthetic.clone(), source.to_string());
 
-        let mut lexer = harn_lexer::Lexer::new(source);
-        let tokens = lexer.tokenize().map_err(|e| {
-            VmError::Runtime(format!("Import lex error in {}: {e}", synthetic.display()))
-        })?;
-        let mut parser = harn_parser::Parser::new(tokens);
-        let program = parser.parse().map_err(|e| {
-            VmError::Runtime(format!(
-                "Import parse error in {}: {e}",
-                synthetic.display()
-            ))
-        })?;
+        let artifact = compile_module_artifact_from_source(&synthetic, source)?;
 
         self.imported_paths.push(synthetic.clone());
-        let loaded = self
-            .import_declarations(&program, None, Some(&synthetic))
-            .await?;
+        let loaded = self.instantiate_module(None, &artifact).await?;
         self.imported_paths.pop();
         Rc::make_mut(&mut self.module_cache).insert(synthetic, loaded.clone());
         Ok(loaded)
@@ -240,9 +136,7 @@ impl Vm {
 
         let artifact = stdlib_module_artifact(module, &synthetic, source)?;
         self.imported_paths.push(synthetic.clone());
-        let loaded = self
-            .instantiate_stdlib_module(&synthetic, artifact.as_ref())
-            .await?;
+        let loaded = self.instantiate_stdlib_module(artifact.as_ref()).await?;
         self.imported_paths.pop();
         Rc::make_mut(&mut self.module_cache).insert(synthetic, loaded.clone());
         Ok(loaded)
@@ -250,13 +144,27 @@ impl Vm {
 
     async fn instantiate_stdlib_module(
         &mut self,
-        _synthetic: &Path,
-        artifact: &CompiledStdlibModule,
+        artifact: &ModuleArtifact,
+    ) -> Result<LoadedModule, VmError> {
+        self.instantiate_module(None, artifact).await
+    }
+
+    /// Instantiate a previously-compiled [`ModuleArtifact`] into a
+    /// [`LoadedModule`]. Re-runs nested imports, replays the init chunk
+    /// into a fresh module env, mints a [`VmClosure`] for each compiled
+    /// function (stamped with `module_source_dir` so imports from inside
+    /// those functions resolve against the originating file), and
+    /// applies the re-export pass. Used by both stdlib and user-import
+    /// code paths.
+    async fn instantiate_module(
+        &mut self,
+        module_source_dir: Option<PathBuf>,
+        artifact: &ModuleArtifact,
     ) -> Result<LoadedModule, VmError> {
         let caller_env = self.env.clone();
         let old_source_dir = self.source_dir.clone();
         self.env = VmEnv::new();
-        self.source_dir = None;
+        self.source_dir = module_source_dir.clone();
 
         for import in &artifact.imports {
             self.execute_import(&import.path, import.selected_names.as_deref())
@@ -292,7 +200,7 @@ impl Vm {
             let closure = Rc::new(VmClosure {
                 func: Rc::new(CompiledFunction::from_cached(compiled)),
                 env: module_env.clone(),
-                source_dir: None,
+                source_dir: module_source_dir.clone(),
                 module_functions: Some(Rc::clone(&registry)),
                 module_state: Some(Rc::clone(&module_state)),
             });
@@ -440,222 +348,33 @@ impl Vm {
             Rc::make_mut(&mut self.source_cache).insert(canonical.clone(), source.clone());
             Rc::make_mut(&mut self.source_cache).insert(file_path.clone(), source.clone());
 
-            let mut lexer = harn_lexer::Lexer::new(&source);
-            let tokens = lexer
-                .tokenize()
-                .map_err(|e| VmError::Runtime(format!("Import lex error: {e}")))?;
-            let mut parser = harn_parser::Parser::new(tokens);
-            let program = parser
-                .parse()
-                .map_err(|e| VmError::Runtime(format!("Import parse error: {e}")))?;
+            // Disk cache first: hits skip parse + compile for the imported
+            // module's whole function pool, not just the entry pipeline.
+            let lookup = bytecode_cache::load_module(&file_path, &source);
+            let artifact = if let Some(artifact) = lookup.artifact {
+                artifact
+            } else {
+                let compiled = compile_module_artifact_from_source(&file_path, &source)?;
+                if let Err(err) = bytecode_cache::store_module(&lookup.key, &compiled) {
+                    if std::env::var_os("HARN_BYTECODE_CACHE_DEBUG").is_some() {
+                        eprintln!(
+                            "[harn] module cache write skipped for {}: {err}",
+                            file_path.display()
+                        );
+                    }
+                }
+                compiled
+            };
 
+            let module_source_dir = file_path.parent().map(|p| p.to_path_buf());
             let loaded = self
-                .import_declarations(&program, Some(&file_path), Some(&file_path))
+                .instantiate_module(module_source_dir, &artifact)
                 .await?;
             self.imported_paths.pop();
             Rc::make_mut(&mut self.module_cache).insert(canonical.clone(), loaded.clone());
             self.export_loaded_module(&canonical, &loaded, selected_names)?;
 
             Ok(())
-        })
-    }
-
-    /// Process top-level declarations from an imported module.
-    fn import_declarations<'a>(
-        &'a mut self,
-        program: &'a [harn_parser::SNode],
-        file_path: Option<&'a Path>,
-        debug_source_file: Option<&'a Path>,
-    ) -> Pin<Box<dyn Future<Output = Result<LoadedModule, VmError>> + 'a>> {
-        Box::pin(async move {
-            let caller_env = self.env.clone();
-            let old_source_dir = self.source_dir.clone();
-            self.env = VmEnv::new();
-            if let Some(fp) = file_path {
-                if let Some(parent) = fp.parent() {
-                    self.source_dir = Some(parent.to_path_buf());
-                }
-            }
-
-            for node in program {
-                match &node.node {
-                    harn_parser::Node::ImportDecl { path: sub_path, .. } => {
-                        self.execute_import(sub_path, None).await?;
-                    }
-                    harn_parser::Node::SelectiveImport {
-                        names,
-                        path: sub_path,
-                        ..
-                    } => {
-                        self.execute_import(sub_path, Some(names)).await?;
-                    }
-                    _ => {}
-                }
-            }
-
-            // Route top-level `var`/`let` bindings into a shared
-            // `module_state` rather than `module_env`. If they appeared in
-            // `module_env` (captured by each closure's lexical snapshot),
-            // every call's per-invocation env clone would shadow them and
-            // writes would land in a per-call copy discarded on return.
-            let module_state: crate::value::ModuleState = {
-                let mut init_env = self.env.clone();
-                let init_nodes: Vec<harn_parser::SNode> = program
-                    .iter()
-                    .filter(|sn| {
-                        matches!(
-                            &sn.node,
-                            harn_parser::Node::VarBinding { .. }
-                                | harn_parser::Node::LetBinding { .. }
-                        )
-                    })
-                    .cloned()
-                    .collect();
-                if !init_nodes.is_empty() {
-                    let init_compiler = crate::Compiler::new();
-                    let init_chunk = init_compiler
-                        .compile(&init_nodes)
-                        .map_err(|e| VmError::Runtime(format!("Import init compile error: {e}")))?;
-                    // Save frame state so run_chunk_entry's top-level
-                    // frame-pop doesn't restore self.env.
-                    let saved_env = std::mem::replace(&mut self.env, init_env);
-                    let saved_frames = std::mem::take(&mut self.frames);
-                    let saved_handlers = std::mem::take(&mut self.exception_handlers);
-                    let saved_iterators = std::mem::take(&mut self.iterators);
-                    let saved_deadlines = std::mem::take(&mut self.deadlines);
-                    let init_result = self.run_chunk(&init_chunk).await;
-                    init_env = std::mem::replace(&mut self.env, saved_env);
-                    self.frames = saved_frames;
-                    self.exception_handlers = saved_handlers;
-                    self.iterators = saved_iterators;
-                    self.deadlines = saved_deadlines;
-                    init_result?;
-                }
-                Rc::new(RefCell::new(init_env))
-            };
-
-            let module_env = self.env.clone();
-            let registry: ModuleFunctionRegistry = Rc::new(RefCell::new(BTreeMap::new()));
-            let source_dir = file_path.and_then(|fp| fp.parent().map(|p| p.to_path_buf()));
-            let mut functions: BTreeMap<String, Rc<VmClosure>> = BTreeMap::new();
-            let mut public_names: HashSet<String> = HashSet::new();
-
-            for node in program {
-                // Imports may carry `@deprecated` / `@test` etc. on top-level
-                // fn decls; transparently peel the wrapper before pattern
-                // matching the FnDecl shape.
-                let inner = match &node.node {
-                    harn_parser::Node::AttributedDecl { inner, .. } => inner.as_ref(),
-                    _ => node,
-                };
-                let harn_parser::Node::FnDecl {
-                    name,
-                    type_params,
-                    params,
-                    body,
-                    is_pub,
-                    ..
-                } = &inner.node
-                else {
-                    continue;
-                };
-
-                let mut compiler = crate::Compiler::new();
-                let module_source_file = debug_source_file.map(|p| p.display().to_string());
-                let func_chunk = compiler
-                    .compile_fn_body(type_params, params, body, module_source_file)
-                    .map_err(|e| VmError::Runtime(format!("Import compile error: {e}")))?;
-                let closure = Rc::new(VmClosure {
-                    func: Rc::new(func_chunk),
-                    env: module_env.clone(),
-                    source_dir: source_dir.clone(),
-                    module_functions: Some(Rc::clone(&registry)),
-                    module_state: Some(Rc::clone(&module_state)),
-                });
-                registry
-                    .borrow_mut()
-                    .insert(name.clone(), Rc::clone(&closure));
-                self.env
-                    .define(name, VmValue::Closure(Rc::clone(&closure)), false)?;
-                // Publish into module_state so sibling fns can be read
-                // as VALUES (e.g. `{handler: other_fn}` or as callbacks).
-                // Closures captured module_env BEFORE fn decls were added,
-                // so their static env alone can't resolve sibling fns.
-                // Direct calls use the module_functions late-binding path;
-                // value reads rely on this module_state entry.
-                module_state.borrow_mut().define(
-                    name,
-                    VmValue::Closure(Rc::clone(&closure)),
-                    false,
-                )?;
-                functions.insert(name.clone(), Rc::clone(&closure));
-                if *is_pub {
-                    public_names.insert(name.clone());
-                }
-            }
-
-            // Re-export pass: for every `pub import ...` declaration in
-            // the module, surface the imported closures in this module's
-            // `functions`/`public_names` so callers that import this
-            // module see the re-exported names.
-            for node in program {
-                let (sub_path, selective_names, is_pub_import) = match &node.node {
-                    harn_parser::Node::ImportDecl {
-                        path: sub_path,
-                        is_pub,
-                    } => (sub_path.clone(), None, *is_pub),
-                    harn_parser::Node::SelectiveImport {
-                        names,
-                        path: sub_path,
-                        is_pub,
-                    } => (sub_path.clone(), Some(names.clone()), *is_pub),
-                    _ => continue,
-                };
-                if !is_pub_import {
-                    continue;
-                }
-                let cache_key = self.cache_key_for_import(&sub_path);
-                let Some(loaded) = self.module_cache.get(&cache_key).cloned() else {
-                    return Err(VmError::Runtime(format!(
-                        "Re-export error: imported module '{sub_path}' was not loaded"
-                    )));
-                };
-                let names_to_reexport: Vec<String> = match selective_names {
-                    Some(names) => names,
-                    None => {
-                        if loaded.public_names.is_empty() {
-                            loaded.functions.keys().cloned().collect()
-                        } else {
-                            loaded.public_names.iter().cloned().collect()
-                        }
-                    }
-                };
-                for name in names_to_reexport {
-                    let Some(closure) = loaded.functions.get(&name) else {
-                        return Err(VmError::Runtime(format!(
-                            "Re-export error: '{name}' is not exported by '{sub_path}'"
-                        )));
-                    };
-                    if let Some(existing) = functions.get(&name) {
-                        if !Rc::ptr_eq(existing, closure) {
-                            return Err(VmError::Runtime(format!(
-                                "Re-export collision: '{name}' is defined here and also \
-                                 re-exported from '{sub_path}'"
-                            )));
-                        }
-                    }
-                    functions.insert(name.clone(), Rc::clone(closure));
-                    public_names.insert(name);
-                }
-            }
-
-            self.env = caller_env;
-            self.source_dir = old_source_dir;
-
-            Ok(LoadedModule {
-                functions,
-                public_names,
-            })
         })
     }
 

--- a/docs/perf/bytecode-cache.md
+++ b/docs/perf/bytecode-cache.md
@@ -20,12 +20,14 @@ Little-endian throughout. Every cache file starts with this header:
 
 ```text
 magic        : [u8; 8]   = "HARNBC\0\0"
-schema_ver   : u32       = 1
+schema_ver   : u32       = SCHEMA_VERSION
 version_len  : u32
 harn_version : [u8; version_len]
+compiler_tag : u8        bitmask of active CompilerOptions
+kind         : u8        1 = entry chunk, 2 = module artifact
 source_hash  : [u8; 32]   sha256(entry source)
 import_hash  : [u8; 32]   sha256(sorted import graph contents)
-payload      : bincode-serialized CachedChunk
+payload      : bincode-serialized payload (Chunk or ModuleArtifact, per kind)
 ```
 
 Mismatch on any of magic / schema / harn_version / source_hash /
@@ -90,13 +92,23 @@ they never produce an incorrect bytecode load.
    the artifact back into the shared cache. Write failures are
    best-effort and silent unless `HARN_BYTECODE_CACHE_DEBUG=1`.
 
-`harn precompile <path>` runs the same compile path and writes the
-artifact directly to disk. Pass a directory to walk it; otherwise it
-compiles a single file. `--out DIR` mirrors the input layout under
+Each `import` the VM executes at runtime follows the same protocol
+for the `.harnmod` family: read source, look for an adjacent
+`<lib>.harnmod`, then `$HARN_CACHE_DIR/<source_hash>.harnmod`. A hit
+returns a [`ModuleArtifact`] (compiled init chunk + per-function
+chunks + import list); the loader then runs the init chunk and mints
+fresh closures bound to a per-process module env.
+
+`harn precompile <path>` runs the same compile path and writes both
+artifact families directly to disk: `<name>.harnbc` (entry chunk) and
+`<name>.harnmod` (module artifact). Shipping both means the same file
+hits the cache whether the user runs it (`harn run lib.harn`) or
+imports it from another script. Pass a directory to walk it; otherwise
+it compiles a single file. `--out DIR` mirrors the input layout under
 `DIR`; without `--out`, artifacts land adjacent to each source. Burin
 Code's release pipeline runs `harn precompile` against its bundled
 `Sources/BurinCore/Resources/pipelines/` so the shipped DMG already
-contains a `.harnbc` for every script the user might run.
+contains both artifact files for every script the user might run.
 
 ## Toggles and environment
 
@@ -115,6 +127,28 @@ remains the canonical surface for the complete diagnostic list — use
 it if you need every warning every time, or set
 `HARN_BYTECODE_CACHE=0` to force a fresh compile.
 
+## What gets cached
+
+Three artifact families share the same header but use distinct file
+extensions so they coexist in one directory:
+
+- **Entry chunks (`.harnbc`)** — the compiled [`Chunk`] for the script
+  passed to `harn run`. The shortcut: cache hit, skip parse + typecheck
+  and compile, go straight to VM.
+- **Module artifacts (`.harnmod`)** — the [`ModuleArtifact`] for each
+  imported user file or stdlib module. The shortcut: cache hit, skip
+  parse + per-function compile of the imported module; the loader still
+  has to run the module's `init` chunk and mint per-process closures.
+  Module caching is what closes the cold-start gap for pipelines whose
+  cost is dominated by `import`s rather than the entry source itself.
+- **Stdlib modules** — same artifact format as user modules; the
+  `STDLIB_MODULE_ARTIFACT_CACHE` in-memory layer remains the L1 cache
+  per process, with the on-disk artifact as L2 across processes.
+
+A single `.harn` source can therefore produce up to two cached files —
+a `.harnbc` if anyone runs it as an entry, and a `.harnmod` if anyone
+imports it.
+
 ## Out of scope
 
 - JIT (LLVM/Cranelift). Interpreted bytecode plus the cache is enough
@@ -125,13 +159,3 @@ it if you need every warning every time, or set
   exist. Shipping bytecode without source would require dropping the
   rehash and trusting the embedded hash — a follow-on if the
   burin-code release pipeline grows that constraint.
-- Caching of imported modules. The cache short-circuits parse +
-  type-check + compile of the **entry** pipeline only; runtime
-  `Op::Import` still re-parses and re-compiles every imported user
-  file and stdlib module on each process invocation. For burin-code's
-  short subcommands the entry pipeline is the dominant per-invocation
-  cost, but for pipelines that depend on a large stdlib surface the
-  remaining import cost is the next target. The `CachedChunk` /
-  `CachedCompiledFunction` serde shape already supports the same
-  on-disk format, so the follow-on plug-point is `execute_import` in
-  `crates/harn-vm/src/vm/modules.rs`.


### PR DESCRIPTION
## Summary

Follow-up to #1710 and #1733. The v0.8.22 bytecode cache covered entry chunks, but runtime imports still paid parse + compile for every imported module on each process start. This PR adds a `.harnmod` module-artifact cache so imported user modules and stdlib modules can reuse serialized compile artifacts across process invocations.

Changes:
- adds a versioned `ModuleArtifact` payload for importable modules
- extends the cache header with compiler-option and artifact-kind discriminants
- teaches runtime import loading to read/write `.harnmod` artifacts for user and stdlib modules
- teaches `harn precompile` to emit both `.harnbc` and `.harnmod`
- documents the two artifact families and adds regression coverage for adjacent `.harnmod` imports

## Validation

- `cargo fmt --check`
- `cargo test -p harn-cli --test bytecode_cache` (6 passed)
- `cargo test -p harn-vm bytecode_cache` (8 passed)
- `cargo clippy -p harn-vm -p harn-cli --all-targets -- -D warnings`
- pre-commit hook: workspace clippy passed
- pre-push hook: targeted checks, markdownlint, portal lint, highlight keyword check passed
- debug startup smoke on `conformance/tests/modules/pub_import_chained.harn`: cold avg 40.447 ms, warm avg 22.073 ms (warm/cold avg = 0.546x)

Note: the timing smoke used the debug binary to confirm the import-cache path, not a release perf gate.