### PR TITLE
Mark v0.8.24 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ condensed series summaries instead of full per-patch history.
 
 ## Unreleased
 
+## v0.8.24
+
 ### Fixed
 
 - **Swift protocol artifact CaseIterable synthesis.** Generated Swift


### PR DESCRIPTION
## Summary
- move the Swift protocol artifact fix notes under a concrete v0.8.24 heading so the release bump detector sees the pending patch release

## Verification
- python3 scripts/verify_release_metadata.py
- npx markdownlint-cli2 CHANGELOG.md
- git diff --check
- pre-commit hook
- pre-push hook