### PR TITLE
Add with_scoped_executor tool-caller middleware (#1702)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ condensed series summaries instead of full per-patch history.
 
 ## Unreleased
 
+### Added
+
+- **`with_scoped_executor` tool-caller middleware (#1702).** Narrows the
+  active `CapabilityPolicy` for the duration of one tool dispatch:
+  `compose_tool_callers([..., with_scoped_executor({stage, allowed_tools,
+  side_effect_level?, capabilities?}), ...])`. The middleware pushes the
+  scoped policy via `with_execution_policy(...)` (now intersected with
+  the ambient policy so it can only tighten the surface, never widen
+  it), preemptively rejects out-of-allowlist tool names with the new
+  `status: "scope_violation"`, and decorates results with
+  `audit.scope = {stage, allowed_tools, ...}`. Pairs with
+  `PersonaRuntimeBinding.stages` for per-stage tool scoping outside a
+  persona manifest. Opt-in `on_violation: "raise"` throws instead of
+  short-circuiting so `try { agent_loop(...) }` can route on the
+  exception.
+
 ## v0.8.24
 
 ### Fixed

--- a/conformance/tests/integration/tool_middleware_with_scoped_executor.expected
+++ b/conformance/tests/integration/tool_middleware_with_scoped_executor.expected
@@ -1,0 +1,17 @@
+true
+research
+search_files,read_file
+ok
+false
+scope_violation
+scope_violation
+tool 'write_file' not in stage 'research' allowlist
+rejected
+caught
+scope_violation: tool 'edit_file' not in stage 'plan' allowlist
+true
+edit
+false
+caught-ctor
+false
+permission_denied

--- a/conformance/tests/integration/tool_middleware_with_scoped_executor.harn
+++ b/conformance/tests/integration/tool_middleware_with_scoped_executor.harn
@@ -1,0 +1,111 @@
+/**
+ * with_scoped_executor — preemptively rejects tool names outside the
+ * stage allowlist, decorates approved calls with `audit.scope`, and
+ * pushes a CapabilityPolicy that downstream dispatch sees as the top of
+ * the policy stack.
+ */
+import { with_scoped_executor } from "std/llm/tool_middleware"
+
+fn synthetic_next() {
+  return { call -> return {
+    ok: true,
+    status: "ok",
+    tool_name: call.tool_name,
+    tool_call_id: call.call_id,
+    arguments: call.tool_args,
+    result: "ran " + call.tool_name,
+    rendered_result: "ran " + call.tool_name,
+    observation: "",
+    error: nil,
+    error_category: nil,
+    executor: "harn",
+  } }
+}
+
+fn envelope(name) {
+  return {
+    tool_name: name,
+    tool_args: {},
+    call_id: "call-" + name,
+    declared_executor: "harn",
+    schema: nil,
+    description: "",
+    turn: {iteration: 0, session_id: "scope-test"},
+  }
+}
+
+pipeline default() {
+  let next = synthetic_next()
+  // Allowed tool passes; audit.scope records the stage + allowlist.
+  let research_mw = with_scoped_executor({stage: "research", allowed_tools: ["search_files", "read_file"]})
+  let ok = research_mw(envelope("search_files"), next)
+  println(ok.ok)
+  println(ok.audit.scope.stage)
+  println(join(ok.audit.scope.allowed_tools, ","))
+  println(ok.audit.layers[0].status)
+  // Disallowed tool short-circuits with `scope_violation`.
+  let reject = research_mw(envelope("write_file"), next)
+  println(reject.ok)
+  println(reject.status)
+  println(reject.error_category)
+  println(reject.error)
+  println(reject.audit.layers[0].status)
+  // `on_violation: "raise"` throws instead of short-circuiting.
+  let raising_mw = with_scoped_executor({stage: "plan", allowed_tools: ["sketch_plan"], on_violation: "raise"})
+  try {
+    raising_mw(envelope("edit_file"), next)
+    println("no-throw")
+  } catch (e) {
+    println("caught")
+    println(e)
+  }
+  // Missing `allowed_tools` skips the preemptive check; the middleware
+  // still pushes a side_effect_level for the duration of `next`.
+  let ceiling_mw = with_scoped_executor({stage: "edit", side_effect_level: "workspace_write"})
+  let r3 = ceiling_mw(envelope("anything"), next)
+  println(r3.ok)
+  println(r3.audit.scope.stage)
+  println(contains(r3.audit.scope.keys(), "allowed_tools"))
+  // Invalid on_violation rejects at middleware-construction time.
+  try {
+    with_scoped_executor({stage: "x", allowed_tools: ["y"], on_violation: "log"})
+    println("no-throw-ctor")
+  } catch (e) {
+    println("caught-ctor")
+  }
+  // Defense-in-depth: the pushed CapabilityPolicy is visible to the
+  // runtime's `enforce_current_policy_for_tool`, so even if a caller
+  // bypasses the preemptive check (e.g. by dispatching a different tool
+  // from inside `next`), the runtime still rejects it.
+  var tools = tool_registry()
+  tools = tool_define(
+    tools,
+    "read_note",
+    "Read a note",
+    {
+      handler: { args -> "read " + args.path },
+      parameters: {path: {type: "string"}},
+      returns: {type: "string"},
+    },
+  )
+  tools = tool_define(
+    tools,
+    "write_note",
+    "Write a note",
+    {
+      handler: { args -> "wrote " + args.path },
+      parameters: {path: {type: "string"}},
+      returns: {type: "string"},
+    },
+  )
+  let dispatch_next = { call -> return agent_dispatch_tool_call(
+    {name: "write_note", id: call.call_id, arguments: {path: "notes.txt"}},
+    tools,
+  ) }
+  let dispatch_mw = with_scoped_executor({stage: "audit", allowed_tools: ["read_note"]})
+  // Envelope advertises an allowed name; `next` rewrites to the denied
+  // name to simulate a misbehaving inner layer.
+  let runtime_deny = dispatch_mw(envelope("read_note"), dispatch_next)
+  println(runtime_deny.ok)
+  println(runtime_deny.error_category)
+}

--- a/crates/harn-stdlib/src/stdlib/llm/tool_middleware.harn
+++ b/crates/harn-stdlib/src/stdlib/llm/tool_middleware.harn
@@ -42,6 +42,9 @@
 //   hints?:       dict     // {read_only?, destructive?, idempotent?,
 //                          // open_world?} — verbatim from MCP tool annotations.
 //   consent?:     dict     // {decision, decided_by, decided_at} — coined.
+//   scope?:       dict     // {stage, allowed_tools?, side_effect_level?} —
+//                          // the scoped capability surface a stage middleware
+//                          // narrowed this call to.
 //   layers?:      list     // [{name, status, started_at, ended_at, error?}]
 //                          // per-layer audit trail.
 //   metadata?:    dict     // free-form extension slot — A2A/LangChain idiom.
@@ -50,8 +53,8 @@
 // composition stays predictable):
 //
 //   "ok", "tool_not_found", "schema_violation", "consent_denied",
-//   "policy_blocked", "executor_error", "redacted", "dry_run",
-//   "rate_limited", "exception", "tool_middleware_exception".
+//   "policy_blocked", "scope_violation", "executor_error", "redacted",
+//   "dry_run", "rate_limited", "exception", "tool_middleware_exception".
 //
 // Composition uses `compose_tool_callers([outer, ..., inner])` — leftmost is
 // the outermost wrapper. Exactly mirrors std/llm/handlers `compose`.
@@ -705,6 +708,101 @@ pub fn with_consent(prompt_fn) {
         },
         layers: [{name: "with_consent", status: verdict}],
       },
+    )
+  }
+}
+
+/**
+ * with_scoped_executor(opts) -> caller
+ *
+ * Narrows the active CapabilityPolicy for the duration of one tool
+ * dispatch. Wraps the downstream caller in `with_execution_policy(...)`
+ * so the runtime's existing `enforce_current_policy_for_tool` machinery
+ * (capability ceilings, side-effect ceiling, tool-arg constraints) sees
+ * the scoped policy as the top of the stack. A preemptive tool-name
+ * check short-circuits with `status: "scope_violation"` so the audit
+ * chain captures the stage label even when the wrapped dispatch never
+ * runs.
+ *
+ * Compose this OUTSIDE binder/consent layers so it can reject before
+ * either does expensive work:
+ *
+ *     compose_tool_callers([
+ *       with_audit_log({...}),
+ *       with_scoped_executor({stage: "research", allowed_tools: [...]}),
+ *       with_consent(...),
+ *       default_tool_caller(),
+ *     ])
+ *
+ * Options:
+ *   stage:              string       (default "scoped"; surfaced on audit.scope)
+ *   allowed_tools:      list<string> (empty/missing = no tool-name restriction)
+ *   side_effect_level:  string?      ("none"/"read_only"/"workspace_write"/
+ *                                     "process_exec"/"network" — tightens the
+ *                                     ambient ceiling for this call)
+ *   capabilities:       dict?        (capability.operation allowlist; same
+ *                                     shape as `CapabilityPolicy.capabilities`)
+ *   on_violation:       string       ("reject" (default) → short-circuit with
+ *                                     scope_violation status; "raise" → throw)
+ *
+ * The pushed policy is popped on success or throw (`with_execution_policy`
+ * owns the RAII guard). Subsequent middleware layers see the scope record
+ * on `audit.scope` and a layer entry under `audit.layers`.
+ */
+pub fn with_scoped_executor(opts) {
+  let cfg = __tool_mw_dict(opts)
+  let stage = to_string(cfg?.stage ?? "scoped")
+  let allowed = __tool_mw_string_list(cfg?.allowed_tools)
+  let restrict_tools = cfg?.allowed_tools != nil
+  let side_effect_level = __tool_mw_optional_text(cfg?.side_effect_level)
+  let capabilities_value = if type_of(cfg?.capabilities) == "dict" {
+    cfg.capabilities
+  } else {
+    nil
+  }
+  let on_violation = to_string(cfg?.on_violation ?? "reject")
+  if on_violation != "reject" && on_violation != "raise" {
+    throw "with_scoped_executor: on_violation must be `reject` or `raise`; got " + on_violation
+  }
+  let scope_descriptor = if restrict_tools {
+    {stage: stage, allowed_tools: allowed}
+  } else {
+    {stage: stage}
+  }
+  return { call, next ->
+    if restrict_tools && !contains(allowed, call.tool_name) {
+      let reason = "tool '" + call.tool_name + "' not in stage '" + stage + "' allowlist"
+      if on_violation == "raise" {
+        throw "scope_violation: " + reason
+      }
+      return __tool_mw_short_circuit(
+        call,
+        "scope_violation",
+        {
+          status: "scope_violation",
+          error: reason,
+          error_category: "scope_violation",
+          audit: {
+            scope: scope_descriptor,
+            layers: [{name: "with_scoped_executor", status: "rejected", stage: stage, reason: reason}],
+          },
+        },
+      )
+    }
+    var policy = {}
+    if restrict_tools {
+      policy = policy + {tools: allowed}
+    }
+    if side_effect_level != nil {
+      policy = policy + {side_effect_level: side_effect_level}
+    }
+    if capabilities_value != nil {
+      policy = policy + {capabilities: capabilities_value}
+    }
+    let result = with_execution_policy(policy, fn() { return next(call) })
+    return __tool_mw_attach_audit(
+      result,
+      {scope: scope_descriptor, layers: [{name: "with_scoped_executor", status: "ok", stage: stage}]},
     )
   }
 }

--- a/crates/harn-vm/src/stdlib/runtime_scope.rs
+++ b/crates/harn-vm/src/stdlib/runtime_scope.rs
@@ -57,14 +57,18 @@ pub(crate) fn register_runtime_scope_builtins(vm: &mut Vm) {
         let policy_value = args
             .first()
             .ok_or_else(|| VmError::Runtime("with_execution_policy: policy is required".into()))?;
-        let policy = serde_json::from_value::<crate::orchestration::CapabilityPolicy>(
+        let requested = serde_json::from_value::<crate::orchestration::CapabilityPolicy>(
             crate::llm::helpers::vm_value_to_json(policy_value),
         )
         .map_err(|error| {
             VmError::Runtime(format!("with_execution_policy: invalid policy: {error}"))
         })?;
         let closure = closure_arg(&args, 1, "with_execution_policy")?;
-        crate::orchestration::push_execution_policy(policy);
+        let effective = match crate::orchestration::current_execution_policy() {
+            Some(outer) => outer.intersect(&requested).map_err(VmError::Runtime)?,
+            None => requested,
+        };
+        crate::orchestration::push_execution_policy(effective);
         let _guard = ScopeGuard::new(crate::orchestration::pop_execution_policy);
         call_scoped_closure(closure, "with_execution_policy").await
     });

--- a/docs/src/personas/stages.md
+++ b/docs/src/personas/stages.md
@@ -88,3 +88,15 @@ read-only research stage against a workspace-mutating persona.
 If `stages` is empty (or omitted), behavior is identical to a persona
 without stage declarations — the ambient policy alone governs every
 tool call.
+
+## Per-dispatch scoping outside a persona
+
+For callers that don't run under a persona — ad-hoc agents, one-off
+`agent_loop` invocations, or test harnesses — the same scoping is
+available as a tool-caller middleware:
+[`with_scoped_executor(...)`](../stdlib/tool-middleware.md). It pushes
+a `CapabilityPolicy` for the duration of a single dispatch (intersected
+with whatever ambient policy is active) and decorates the result with
+`audit.scope = {stage, allowed_tools, ...}`. Out-of-scope tool names
+short-circuit with `status: "scope_violation"` so callers can route on
+the typed receipt.

--- a/docs/src/stdlib/tool-middleware.md
+++ b/docs/src/stdlib/tool-middleware.md
@@ -89,6 +89,7 @@ the field names align with prevailing specs where they exist:
 | `kind?` | ACP ToolCall.kind | One of `read`/`edit`/`delete`/`move`/`search`/`execute`/`think`/`fetch`/`other` |
 | `hints?` | MCP tool annotations | `{read_only?, destructive?, idempotent?, open_world?}` |
 | `consent?` | (coined; ACP/MCP keep this off the call object) | `{decision, decided_by, decided_at}` |
+| `scope?` | (coined; mirrors `PersonaRuntimeBinding.stages`) | `{stage, allowed_tools?, side_effect_level?}` — the scoped capability surface this call ran under |
 | `layers?` | (coined) | `[{name, status, started_at, ended_at, error?}]` per-layer audit log |
 | `metadata?` | A2A `metadata`, LangChain | Free-form extension slot |
 
@@ -102,8 +103,9 @@ When a layer short-circuits, prefer one of these `status` values so
 composition stays predictable:
 
 `"ok"`, `"tool_not_found"`, `"schema_violation"`, `"consent_denied"`,
-`"policy_blocked"`, `"executor_error"`, `"redacted"`, `"dry_run"`,
-`"rate_limited"`, `"exception"`, `"tool_middleware_exception"`.
+`"policy_blocked"`, `"scope_violation"`, `"executor_error"`,
+`"redacted"`, `"dry_run"`, `"rate_limited"`, `"exception"`,
+`"tool_middleware_exception"`.
 
 ## Bundled middleware
 
@@ -169,6 +171,49 @@ same append-only JSONL sink used by `sink: "local"`.
 Denied calls short-circuit with `consent_denied`; approved calls
 proceed and record the decision in `audit.consent`. Pair with the host
 UX (e.g. burin-code's approval modal) for destructive tools.
+
+### `with_scoped_executor(opts) -> caller`
+
+Narrows the active `CapabilityPolicy` for the duration of one tool
+dispatch. Wraps the downstream chain in `with_execution_policy(...)`
+so the runtime's existing `enforce_current_policy_for_tool` machinery
+(capability ceilings, side-effect ceiling, tool-arg constraints) sees
+the scoped policy as the top of the stack — the scoped policy is
+intersected with the ambient policy, so a stage can only tighten the
+surface, never widen it. A preemptive tool-name check short-circuits
+with `status: "scope_violation"` so the audit chain captures the stage
+label even when the wrapped dispatch never runs.
+
+Compose this **outside** binder / consent layers so it can reject
+before either does expensive work:
+
+```harn,ignore
+let caller = compose_tool_callers([
+  with_audit_log({...}),
+  with_scoped_executor({stage: "research", allowed_tools: ["search_files", "read_file"]}),
+  with_consent(prompt),
+  default_tool_caller(),
+])
+```
+
+Options:
+
+- `stage` (default `"scoped"`) — surfaced on `audit.scope.stage` and in
+  layer/error messages.
+- `allowed_tools` (list of tool names; empty / missing skips the
+  preemptive check and any tool-surface restriction).
+- `side_effect_level` (`"none"` / `"read_only"` / `"workspace_write"` /
+  `"process_exec"` / `"network"`; tightens the ambient ceiling).
+- `capabilities` (capability → operation allowlist; same shape as
+  `CapabilityPolicy.capabilities`).
+- `on_violation` (`"reject"` (default) → short-circuit with
+  `scope_violation` and a typed receipt; `"raise"` → throw so the agent
+  loop's `try { ... }` can react).
+
+Companion to per-stage persona declarations (`PersonaRuntimeBinding.stages`):
+the persona runtime auto-installs stage policies at step boundaries,
+while this middleware lets standalone tool callers narrow the surface
+without declaring a full persona manifest.
 
 ### `with_dry_run(opts?) -> caller`
 


### PR DESCRIPTION
## Summary

- Adds `with_scoped_executor({stage, allowed_tools, side_effect_level?, capabilities?, on_violation?})` to `std/llm/tool_middleware`. Narrows the active `CapabilityPolicy` for the duration of one tool dispatch by wrapping `next(call)` in `with_execution_policy(...)` so dispatch-time enforcement (`enforce_current_policy_for_tool`) sees the scoped policy on top of the stack. A preemptive tool-name check short-circuits with `status: "scope_violation"` and decorates `audit.scope = {stage, allowed_tools, ...}` so the audit chain captures stage context even when the wrapped dispatch never runs.
- Sharpens `with_execution_policy` to intersect the requested policy with the ambient policy before pushing (matches `agent_loop({policy: ...})` and the persona-stage runtime — a scope can only tighten the surface, never widen it). No existing in-tree Harn callers, so no migration surface.
- New conformance test covers: allowed call decoration, scope-violation short-circuit, `on_violation: "raise"` throw path, side-effect-only configuration, ctor-time validation, and defense-in-depth where the inner layer bypasses the preemptive check and the runtime's own policy enforcement denies the call.
- Docs: new section in `docs/src/stdlib/tool-middleware.md`, cross-link from `docs/src/personas/stages.md`, expanded `audit.scope` row + reserved `scope_violation` status, CHANGELOG entry.

Closes #1702. Pairs with #1701 (per-stage persona policies) for the dispatch-time complement outside a persona manifest.

## Test plan

- [x] `cargo run --bin harn -- test conformance` — 1063 tests pass
- [x] `make test` — 4068 workspace tests pass
- [x] `make lint-harn` / `make fmt-harn` — clean
- [x] `make check-docs-snippets` — 537 snippets parse
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] New conformance test `conformance/tests/integration/tool_middleware_with_scoped_executor.harn` exercises the full surface, including a defense-in-depth path that re-dispatches a disallowed tool through `agent_dispatch_tool_call` and confirms the runtime denies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)