### PR TITLE
hostlib: per-tool-call FS snapshot + restore primitives (#1720)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,25 @@ condensed series summaries instead of full per-patch history.
   `audit.binder.status = "timeout"`. Surfaces a typed audit slot at
   `audit.binder = {provider, model, status, latency_ms, reason?, attempts}`
   alongside the existing `with_audit_log` receipt machinery.
+- **Per-tool-call FS snapshot + restore hostlib primitives (#1720).**
+  Adds `hostlib_fs_snapshot`, `hostlib_fs_restore`,
+  `hostlib_fs_list_snapshots`, and `hostlib_fs_drop_snapshot` builtins
+  under the existing `fs/` schema bucket. Snapshots are keyed by the
+  caller-supplied `scope_id` (canonically the ACP `toolCallId`) and
+  stored content-addressed under
+  `.harn/state/snapshots/<session>/<scope>/`. `tools/write_file` and
+  `tools/delete_file` lazy-capture pre-images into any open snapshot
+  bound to the current `harn_vm::agent_sessions::current_tool_call_id`,
+  so a single `hostlib_fs_snapshot({session_id, scope_id})`
+  registration is enough to roll the next mutation back. Session
+  bundles evict oldest-first past a configurable byte cap (default
+  1 GiB).
+- **ACP `session/restore_tool_call` method (#1720).** The ACP server now
+  advertises `{ sessionCapabilities: { restoreToolCall: {} } }` in the
+  initialize response and exposes a `session/restore_tool_call` method
+  that drives `harn_hostlib::fs_snapshot::restore`. Each restore emits
+  a canonical `session/update` with `sessionUpdate: "tool_call_update"`,
+  `status: "restored"`, and `_meta.harn.kind = "tool_call_restored"`.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2187,6 +2187,7 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
  "tokio",
+ "tracing",
  "tree-sitter",
  "tree-sitter-bash",
  "tree-sitter-c",

--- a/crates/harn-cli/src/commands/orchestrator/listener/tests.rs
+++ b/crates/harn-cli/src/commands/orchestrator/listener/tests.rs
@@ -462,6 +462,7 @@ async fn acp_websocket_requires_configured_bearer_auth() {
             "close": {},
             "list": {},
             "resume": {},
+            "restoreToolCall": {},
         })
     );
     assert!(

--- a/crates/harn-cli/tests/acp_server_cli.rs
+++ b/crates/harn-cli/tests/acp_server_cli.rs
@@ -165,6 +165,7 @@ fn acp_session_fork_branches_runtime_state_and_dispatches_independently() {
             "close": {},
             "list": {},
             "resume": {},
+            "restoreToolCall": {},
         })
     );
     assert!(init["result"]["agentCapabilities"]["sessionCapabilities"]

--- a/crates/harn-hostlib/Cargo.toml
+++ b/crates/harn-hostlib/Cargo.toml
@@ -27,6 +27,7 @@ tokio = { version = "1", features = ["rt", "macros", "sync", "fs", "process", "t
 anyhow = "1"
 thiserror = "2"
 once_cell = "1"
+tracing = "0.1"
 
 # Foundational dependencies for the upcoming module implementations
 # (B2/B3/B4/C1/C2/C3). They are wired in here so the workspace lockfile is

--- a/crates/harn-hostlib/README.md
+++ b/crates/harn-hostlib/README.md
@@ -96,6 +96,7 @@ and commit the updated goldens.
 | #567  | `tools/` (mutating)      | `write_file`, `delete_file`                                                        | ✅ shipped |
 | #568  | `tools/` (process)       | `run_command`, `run_test`, `run_build_command`, `inspect_test_results`, `manage_packages` | ✅ shipped |
 | #1722 | `fs/`                    | `set_mode`, `staged_status`, `commit_staged`, `discard_staged`                    | ✅ shipped |
+| #1720 | `fs/` (snapshots)        | `snapshot`, `restore`, `list_snapshots`, `drop_snapshot`                          | ✅ shipped |
 
 ### Process tools
 
@@ -224,6 +225,54 @@ until they are committed or discarded. The ACP server also exposes
 `session/update` progress notifications with
 `_meta.harn.kind = "staged_writes_pending"` whenever the pending count
 or staged byte total changes.
+
+## Per-tool-call FS snapshots
+
+`fs/` also ships a Gemini-style rollback primitive paralleling the staged
+overlay. Four builtins under the same `fs/` schema bucket:
+
+- `hostlib_fs_snapshot({ session_id, scope_id, paths?, root? })` registers
+  a snapshot keyed by `scope_id` (canonically the ACP `toolCallId`).
+  Passing `paths` captures their pre-images immediately; omitting them
+  leaves the snapshot "open" for lazy capture by the auto-on-write hook
+  inside `tools/write_file` and `tools/delete_file`. Auto-capture binds
+  to the active snapshot whose id matches
+  [`harn_vm::agent_sessions::current_tool_call_id`].
+- `hostlib_fs_restore({ session_id, snapshot_id, paths? })` writes
+  captured bytes back onto disk and surgically removes paths the
+  snapshot saw as absent. The ACP server exposes the same operation as
+  `session/restore_tool_call` and broadcasts the result as a
+  `session/update` tagged `_meta.harn.kind = "tool_call_restored"`.
+- `hostlib_fs_list_snapshots({ session_id })` returns one entry per
+  registered snapshot — `snapshot_id`, `scope_id`, `taken_at_ms`,
+  `captured_paths`, `byte_count` — sorted by capture time.
+- `hostlib_fs_drop_snapshot({ session_id, snapshot_id })` removes a
+  snapshot from both the in-memory store and
+  `.harn/state/snapshots/<session>/<scope>/`.
+
+Each snapshot is content-addressed under
+`.harn/state/snapshots/<session>/<scope>/bodies/<sha256>` with a
+`manifest.json` mapping logical paths to entries. When a session bundle
+exceeds the configurable byte cap (default 1 GiB; tune with
+[`fs_snapshot::set_session_byte_cap`]), the oldest snapshots are
+evicted in insertion order. Snapshots are ephemeral and live only as
+long as the in-memory store; consumers that need durable rollback bundle
+them into a session via `session/load`.
+
+To advertise `restoreToolCall` over ACP the agent emits
+`{ sessionCapabilities: { restoreToolCall: {} } }` in the initialize
+response. Clients can then call:
+
+```jsonc
+{
+  "method": "session/restore_tool_call",
+  "params": { "sessionId": "sess_abc", "toolCallId": "tc_42" }
+}
+```
+
+The Rust dispatch routes through `harn_hostlib::fs_snapshot::restore`
+and emits a `tool_call_update` with `status: "restored"` plus
+`restoredPaths` on the canonical SessionUpdate channel.
 
 ## How embedders consume it
 

--- a/crates/harn-hostlib/README.md
+++ b/crates/harn-hostlib/README.md
@@ -253,11 +253,13 @@ overlay. Four builtins under the same `fs/` schema bucket:
 Each snapshot is content-addressed under
 `.harn/state/snapshots/<session>/<scope>/bodies/<sha256>` with a
 `manifest.json` mapping logical paths to entries. When a session bundle
-exceeds the configurable byte cap (default 1 GiB; tune with
-[`fs_snapshot::set_session_byte_cap`]), the oldest snapshots are
-evicted in insertion order. Snapshots are ephemeral and live only as
-long as the in-memory store; consumers that need durable rollback bundle
-them into a session via `session/load`.
+exceeds the per-session byte cap (default
+[`fs_snapshot::DEFAULT_SESSION_BYTE_CAP`] = 1 GiB; override per session
+with [`fs_snapshot::configure_session_byte_cap`]), the oldest snapshots
+are evicted in insertion order. Snapshots are ephemeral and live only
+as long as the in-memory store; consumers that need durable rollback
+bundle them into a session via `session/load`, and the ACP server drops
+the bundle automatically on `session/close`.
 
 To advertise `restoreToolCall` over ACP the agent emits
 `{ sessionCapabilities: { restoreToolCall: {} } }` in the initialize

--- a/crates/harn-hostlib/schemas/fs/drop_snapshot.request.json
+++ b/crates/harn-hostlib/schemas/fs/drop_snapshot.request.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/fs/drop_snapshot.request.json",
+  "title": "fs.drop_snapshot request",
+  "type": "object",
+  "properties": {
+    "session_id": { "type": "string", "minLength": 1 },
+    "snapshot_id": { "type": "string", "minLength": 1 }
+  },
+  "required": ["session_id", "snapshot_id"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/fs/drop_snapshot.response.json
+++ b/crates/harn-hostlib/schemas/fs/drop_snapshot.response.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/fs/drop_snapshot.response.json",
+  "title": "fs.drop_snapshot response",
+  "type": "object",
+  "properties": {
+    "snapshot_id": { "type": "string", "minLength": 1 },
+    "dropped": {
+      "type": "boolean",
+      "description": "True when an existing snapshot was removed; false when no snapshot with that id was registered."
+    }
+  },
+  "required": ["snapshot_id", "dropped"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/fs/list_snapshots.request.json
+++ b/crates/harn-hostlib/schemas/fs/list_snapshots.request.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/fs/list_snapshots.request.json",
+  "title": "fs.list_snapshots request",
+  "type": "object",
+  "properties": {
+    "session_id": { "type": "string", "minLength": 1 }
+  },
+  "required": ["session_id"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/fs/list_snapshots.response.json
+++ b/crates/harn-hostlib/schemas/fs/list_snapshots.response.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/fs/list_snapshots.response.json",
+  "title": "fs.list_snapshots response",
+  "type": "object",
+  "properties": {
+    "snapshots": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "snapshot_id": { "type": "string", "minLength": 1 },
+          "scope_id": { "type": "string", "minLength": 1 },
+          "taken_at_ms": { "type": "integer", "minimum": 0 },
+          "captured_paths": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "byte_count": { "type": "integer", "minimum": 0 }
+        },
+        "required": [
+          "snapshot_id",
+          "scope_id",
+          "taken_at_ms",
+          "captured_paths",
+          "byte_count"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["snapshots"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/fs/restore.request.json
+++ b/crates/harn-hostlib/schemas/fs/restore.request.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/fs/restore.request.json",
+  "title": "fs.restore request",
+  "type": "object",
+  "properties": {
+    "session_id": { "type": "string", "minLength": 1 },
+    "snapshot_id": { "type": "string", "minLength": 1 },
+    "paths": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Optional subset of paths to restore. Omitted/empty restores every captured path."
+    }
+  },
+  "required": ["session_id", "snapshot_id"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/fs/restore.response.json
+++ b/crates/harn-hostlib/schemas/fs/restore.response.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/fs/restore.response.json",
+  "title": "fs.restore response",
+  "type": "object",
+  "properties": {
+    "snapshot_id": { "type": "string", "minLength": 1 },
+    "restored_paths": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "skipped_paths_with_reasons": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "path": { "type": "string" },
+          "reason": { "type": "string" }
+        },
+        "required": ["path", "reason"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["snapshot_id", "restored_paths", "skipped_paths_with_reasons"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/fs/snapshot.request.json
+++ b/crates/harn-hostlib/schemas/fs/snapshot.request.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/fs/snapshot.request.json",
+  "title": "fs.snapshot request",
+  "type": "object",
+  "properties": {
+    "session_id": { "type": "string", "minLength": 1 },
+    "scope_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Caller-chosen snapshot id; canonically the ACP toolCallId. Opaque to this primitive."
+    },
+    "paths": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Optional explicit paths to capture. Omitted/empty leaves the snapshot open for auto-on-write capture by subsequent mutating tools."
+    },
+    "root": {
+      "type": "string",
+      "description": "Optional workspace root used to anchor snapshot storage and relative paths. Defaults to the active session root."
+    }
+  },
+  "required": ["session_id", "scope_id"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/fs/snapshot.response.json
+++ b/crates/harn-hostlib/schemas/fs/snapshot.response.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/fs/snapshot.response.json",
+  "title": "fs.snapshot response",
+  "type": "object",
+  "properties": {
+    "snapshot_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Stable handle for restore/list/drop. Equal to scope_id from the request."
+    },
+    "captured_paths": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "byte_count": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Sum of bytes copied into the snapshot for captured_paths."
+    }
+  },
+  "required": ["snapshot_id", "captured_paths", "byte_count"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/src/fs_snapshot.rs
+++ b/crates/harn-hostlib/src/fs_snapshot.rs
@@ -1,0 +1,1060 @@
+//! Per-tool-call filesystem snapshots — Gemini-style `/restore` primitives.
+//!
+//! Captures the pre-image of paths touched by a mutating tool call so a
+//! client can roll the change back surgically without losing untracked
+//! work. Snapshot identity is the ACP `toolCallId`, so consumers index
+//! into the same id space the rest of the transcript already records.
+//!
+//! Two capture modes:
+//!
+//! 1. **Explicit** — the caller passes a `paths` list to
+//!    `hostlib_fs_snapshot`; bytes are copied immediately.
+//! 2. **Auto-on-write** — calling `hostlib_fs_snapshot` without `paths`
+//!    registers an open snapshot. The
+//!    [`auto_capture_for_write`] hook fires from inside
+//!    `tools/write_file` and `tools/delete_file` and lazy-copies each
+//!    pre-image into the active snapshot keyed by the current
+//!    [`harn_vm::agent_sessions::current_tool_call_id`].
+//!
+//! Storage layout (per session):
+//!
+//! ```text
+//! .harn/state/snapshots/<session_id>/
+//!   <snapshot_id>/
+//!     manifest.json    # path -> { kind, body_hash?, mode? }
+//!     bodies/<sha256>  # content-addressed; deduped across snapshots
+//! ```
+//!
+//! Snapshots are session-scoped and ephemeral. They are not persisted
+//! across machine reboots; consumers that need durable rollback bundle
+//! them into a session via `session/load`.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs as stdfs;
+use std::path::{Component, Path, PathBuf};
+use std::rc::Rc;
+use std::sync::{Mutex, OnceLock};
+
+use harn_vm::VmValue;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::error::HostlibError;
+use crate::registry::{BuiltinRegistry, HostlibCapability, RegisteredBuiltin, SyncHandler};
+use crate::tools::args::{
+    build_dict, dict_arg, optional_string, optional_string_list, require_string, str_value,
+};
+
+const SNAPSHOT_BUILTIN: &str = "hostlib_fs_snapshot";
+const RESTORE_BUILTIN: &str = "hostlib_fs_restore";
+const LIST_BUILTIN: &str = "hostlib_fs_list_snapshots";
+const DROP_BUILTIN: &str = "hostlib_fs_drop_snapshot";
+
+const MANIFEST_VERSION: u32 = 1;
+const STATE_REL: &[&str] = &[".harn", "state", "snapshots"];
+
+/// Default cap on the on-disk footprint of one session's snapshot bundle
+/// before the oldest snapshots are evicted. Matches the proposal in
+/// [#1720](https://github.com/burin-labs/harn/issues/1720): 1 GiB.
+pub const DEFAULT_SESSION_BYTE_CAP: u64 = 1024 * 1024 * 1024;
+
+/// Hostlib filesystem snapshot capability handle.
+#[derive(Default)]
+pub struct FsSnapshotCapability;
+
+impl HostlibCapability for FsSnapshotCapability {
+    fn module_name(&self) -> &'static str {
+        // Snapshots live under the existing `fs/` schema directory so the
+        // contract surface stays consolidated alongside the staging
+        // primitives.
+        "fs"
+    }
+
+    fn register_builtins(&self, registry: &mut BuiltinRegistry) {
+        register(registry, SNAPSHOT_BUILTIN, "snapshot", snapshot_builtin);
+        register(registry, RESTORE_BUILTIN, "restore", restore_builtin);
+        register(
+            registry,
+            LIST_BUILTIN,
+            "list_snapshots",
+            list_snapshots_builtin,
+        );
+        register(
+            registry,
+            DROP_BUILTIN,
+            "drop_snapshot",
+            drop_snapshot_builtin,
+        );
+    }
+}
+
+fn register(
+    registry: &mut BuiltinRegistry,
+    name: &'static str,
+    method: &'static str,
+    runner: fn(&[VmValue]) -> Result<VmValue, HostlibError>,
+) {
+    let handler: SyncHandler = std::sync::Arc::new(runner);
+    registry.register(RegisteredBuiltin {
+        name,
+        module: "fs",
+        method,
+        handler,
+    });
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum SnapshotEntry {
+    File {
+        body_hash: String,
+        len: u64,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        mode: Option<u32>,
+    },
+    Absent,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct Manifest {
+    version: u32,
+    snapshot_id: String,
+    scope_id: String,
+    session_id: String,
+    root: String,
+    taken_at_ms: i64,
+    entries: BTreeMap<String, SnapshotEntry>,
+}
+
+#[derive(Clone, Debug)]
+struct SnapshotState {
+    snapshot_id: String,
+    scope_id: String,
+    session_id: String,
+    root: PathBuf,
+    taken_at_ms: i64,
+    /// Logical absolute paths (workspace-relative when storage permits).
+    entries: BTreeMap<PathBuf, SnapshotEntry>,
+}
+
+/// Per-snapshot summary returned by `list_snapshots`.
+#[derive(Clone, Debug)]
+pub struct SnapshotSummary {
+    /// Stable identifier (canonically the ACP toolCallId).
+    pub snapshot_id: String,
+    /// Caller-chosen scope id passed when the snapshot was created.
+    pub scope_id: String,
+    /// Wall-clock capture time, milliseconds since the UNIX epoch.
+    pub taken_at_ms: i64,
+    /// Logical paths captured at snapshot time.
+    pub captured_paths: Vec<String>,
+    /// Total bytes captured for `captured_paths`.
+    pub byte_count: u64,
+}
+
+/// Result returned after capturing a new snapshot.
+#[derive(Clone, Debug)]
+pub struct SnapshotResult {
+    /// Stable identifier (equal to the requested `scope_id`).
+    pub snapshot_id: String,
+    /// Paths captured into this snapshot.
+    pub captured_paths: Vec<String>,
+    /// Total bytes captured for `captured_paths`.
+    pub byte_count: u64,
+}
+
+/// Result returned after restoring a snapshot.
+#[derive(Clone, Debug)]
+pub struct RestoreResult {
+    /// Echoed snapshot id.
+    pub snapshot_id: String,
+    /// Paths successfully restored.
+    pub restored_paths: Vec<String>,
+    /// Paths skipped, with human-readable reasons.
+    pub skipped_paths_with_reasons: Vec<(String, String)>,
+}
+
+/// Result returned after dropping a snapshot.
+#[derive(Clone, Debug)]
+pub struct DropResult {
+    /// Echoed snapshot id.
+    pub snapshot_id: String,
+    /// True when an existing snapshot was removed.
+    pub dropped: bool,
+}
+
+#[derive(Default, Debug)]
+struct SessionSnapshots {
+    /// Snapshots, in insertion order.
+    snapshots: Vec<SnapshotState>,
+    /// Bytes currently held in this session's snapshot bundle. We track
+    /// this rather than recomputing from `bodies/` so eviction stays
+    /// O(snapshots) instead of walking the filesystem on every write.
+    byte_count: u64,
+}
+
+static SESSIONS: OnceLock<Mutex<BTreeMap<String, SessionSnapshots>>> = OnceLock::new();
+static SESSION_BYTE_CAP: OnceLock<Mutex<u64>> = OnceLock::new();
+
+fn sessions() -> &'static Mutex<BTreeMap<String, SessionSnapshots>> {
+    SESSIONS.get_or_init(|| Mutex::new(BTreeMap::new()))
+}
+
+fn session_byte_cap() -> u64 {
+    *SESSION_BYTE_CAP
+        .get_or_init(|| Mutex::new(DEFAULT_SESSION_BYTE_CAP))
+        .lock()
+        .expect("fs_snapshot byte cap mutex poisoned")
+}
+
+/// Override the per-session byte cap. Returns the previous value.
+///
+/// Primarily for tests that want to force eviction without writing a
+/// gigabyte. Production embedders should leave the default in place
+/// unless they have evidence it is too large.
+pub fn set_session_byte_cap(bytes: u64) -> u64 {
+    let mutex = SESSION_BYTE_CAP.get_or_init(|| Mutex::new(DEFAULT_SESSION_BYTE_CAP));
+    let mut guard = mutex.lock().expect("fs_snapshot byte cap mutex poisoned");
+    let previous = *guard;
+    *guard = bytes.max(1);
+    previous
+}
+
+/// Test-only helper that clears the in-memory snapshot store. We deliberately
+/// leave on-disk state alone — tests that need a clean filesystem use a
+/// `TempDir` and reseat the workspace root.
+#[doc(hidden)]
+pub fn reset_for_test() {
+    let mut guard = sessions()
+        .lock()
+        .expect("fs_snapshot session mutex poisoned");
+    guard.clear();
+}
+
+/// Take a snapshot. When `paths` is empty the snapshot is "open" — bytes
+/// are captured lazily as `auto_capture_for_write` fires from inside
+/// the mutating tool builtins.
+pub fn snapshot(
+    session_id: &str,
+    scope_id: &str,
+    paths: &[String],
+    root: Option<&Path>,
+) -> Result<SnapshotResult, HostlibError> {
+    validate_session_id(SNAPSHOT_BUILTIN, session_id)?;
+    validate_scope_id(SNAPSHOT_BUILTIN, scope_id)?;
+    let root = resolve_root(root);
+    let mut guard = sessions()
+        .lock()
+        .expect("fs_snapshot session mutex poisoned");
+    let bundle = guard.entry(session_id.to_string()).or_default();
+    upsert_snapshot(bundle, session_id, scope_id, &root)?;
+    let mut captured_paths = Vec::new();
+    let mut byte_count = 0u64;
+    for raw in paths {
+        let path = normalize_logical(Path::new(raw));
+        let added =
+            capture_path(bundle, session_id, scope_id, &path, &root).map_err(|message| {
+                HostlibError::Backend {
+                    builtin: SNAPSHOT_BUILTIN,
+                    message,
+                }
+            })?;
+        if let Some(bytes) = added {
+            byte_count = byte_count.saturating_add(bytes);
+            captured_paths.push(path.to_string_lossy().into_owned());
+        }
+    }
+    enforce_byte_cap(bundle, session_id);
+    let state = bundle
+        .snapshots
+        .iter()
+        .find(|snap| snap.snapshot_id == scope_id)
+        .expect("snapshot just upserted");
+    persist_manifest(state).map_err(|err| HostlibError::Backend {
+        builtin: SNAPSHOT_BUILTIN,
+        message: err,
+    })?;
+    Ok(SnapshotResult {
+        snapshot_id: state.snapshot_id.clone(),
+        captured_paths,
+        byte_count,
+    })
+}
+
+/// Restore a previously-captured snapshot.
+pub fn restore(
+    session_id: &str,
+    snapshot_id: &str,
+    paths: &[String],
+) -> Result<RestoreResult, HostlibError> {
+    validate_session_id(RESTORE_BUILTIN, session_id)?;
+    validate_scope_id(RESTORE_BUILTIN, snapshot_id)?;
+    let mut guard = sessions()
+        .lock()
+        .expect("fs_snapshot session mutex poisoned");
+    let bundle = guard
+        .get_mut(session_id)
+        .ok_or_else(|| HostlibError::Backend {
+            builtin: RESTORE_BUILTIN,
+            message: format!("no snapshots registered for session `{session_id}`"),
+        })?;
+    let state = bundle
+        .snapshots
+        .iter()
+        .find(|snap| snap.snapshot_id == snapshot_id)
+        .cloned()
+        .ok_or_else(|| HostlibError::Backend {
+            builtin: RESTORE_BUILTIN,
+            message: format!("unknown snapshot `{snapshot_id}` for session `{session_id}`"),
+        })?;
+    let selected = select_paths(&state, paths);
+    let mut restored_paths = Vec::new();
+    let mut skipped_paths_with_reasons = Vec::new();
+    for path in selected {
+        let Some(entry) = state.entries.get(&path) else {
+            continue;
+        };
+        let label = path.to_string_lossy().into_owned();
+        match restore_entry(&state, &path, entry) {
+            Ok(()) => restored_paths.push(label),
+            Err(reason) => skipped_paths_with_reasons.push((label, reason)),
+        }
+    }
+    Ok(RestoreResult {
+        snapshot_id: snapshot_id.to_string(),
+        restored_paths,
+        skipped_paths_with_reasons,
+    })
+}
+
+/// List snapshots registered for a session, sorted by capture time.
+pub fn list_snapshots(session_id: &str) -> Result<Vec<SnapshotSummary>, HostlibError> {
+    validate_session_id(LIST_BUILTIN, session_id)?;
+    let guard = sessions()
+        .lock()
+        .expect("fs_snapshot session mutex poisoned");
+    let Some(bundle) = guard.get(session_id) else {
+        return Ok(Vec::new());
+    };
+    let mut summaries: Vec<SnapshotSummary> = bundle
+        .snapshots
+        .iter()
+        .map(|state| SnapshotSummary {
+            snapshot_id: state.snapshot_id.clone(),
+            scope_id: state.scope_id.clone(),
+            taken_at_ms: state.taken_at_ms,
+            captured_paths: state
+                .entries
+                .keys()
+                .map(|path| path.to_string_lossy().into_owned())
+                .collect(),
+            byte_count: entry_byte_count(state),
+        })
+        .collect();
+    summaries.sort_by_key(|summary| summary.taken_at_ms);
+    Ok(summaries)
+}
+
+/// Drop a snapshot's in-memory and on-disk state.
+pub fn drop_snapshot(session_id: &str, snapshot_id: &str) -> Result<DropResult, HostlibError> {
+    validate_session_id(DROP_BUILTIN, session_id)?;
+    validate_scope_id(DROP_BUILTIN, snapshot_id)?;
+    let mut guard = sessions()
+        .lock()
+        .expect("fs_snapshot session mutex poisoned");
+    let Some(bundle) = guard.get_mut(session_id) else {
+        return Ok(DropResult {
+            snapshot_id: snapshot_id.to_string(),
+            dropped: false,
+        });
+    };
+    let position = bundle
+        .snapshots
+        .iter()
+        .position(|snap| snap.snapshot_id == snapshot_id);
+    let dropped = match position {
+        Some(idx) => {
+            let removed = bundle.snapshots.remove(idx);
+            bundle.byte_count = bundle.byte_count.saturating_sub(entry_byte_count(&removed));
+            remove_snapshot_dir(&removed);
+            true
+        }
+        None => false,
+    };
+    Ok(DropResult {
+        snapshot_id: snapshot_id.to_string(),
+        dropped,
+    })
+}
+
+/// Auto-on-write hook called from the mutating tool builtins.
+///
+/// Captures `path`'s pre-image into the snapshot whose id matches the
+/// current [`harn_vm::agent_sessions::current_tool_call_id`]. Silently
+/// no-ops when no session is active, no tool-call id is set, or no
+/// snapshot is registered under that id — this is the zero-cost path
+/// for read-only tools and immediate-mode writes outside an active
+/// snapshot scope.
+pub(crate) fn auto_capture_for_write(builtin: &'static str, path: &Path) {
+    let Some(session_id) = active_session_id() else {
+        return;
+    };
+    let Some(snapshot_id) = harn_vm::agent_sessions::current_tool_call_id() else {
+        return;
+    };
+    let mut guard = sessions()
+        .lock()
+        .expect("fs_snapshot session mutex poisoned");
+    let Some(bundle) = guard.get_mut(&session_id) else {
+        return;
+    };
+    let Some(snapshot) = bundle
+        .snapshots
+        .iter()
+        .find(|snap| snap.snapshot_id == snapshot_id)
+    else {
+        return;
+    };
+    let scope_id = snapshot.scope_id.clone();
+    let root = snapshot.root.clone();
+    let key = normalize_logical(path);
+    match capture_path(bundle, &session_id, &snapshot_id, &key, &root) {
+        Ok(_added) => {
+            if let Some(state) = bundle
+                .snapshots
+                .iter()
+                .find(|snap| snap.snapshot_id == snapshot_id)
+            {
+                if let Err(err) = persist_manifest(state) {
+                    tracing::warn!(
+                        "fs_snapshot: failed to persist manifest for snapshot {snapshot_id} in session {session_id} (scope_id={scope_id}, builtin={builtin}): {err}"
+                    );
+                }
+            }
+        }
+        Err(err) => {
+            tracing::warn!(
+                "fs_snapshot: failed to auto-capture `{}` for snapshot {snapshot_id} in session {session_id} (scope_id={scope_id}, builtin={builtin}): {err}",
+                key.display()
+            );
+        }
+    }
+    enforce_byte_cap(bundle, &session_id);
+}
+
+fn snapshot_builtin(args: &[VmValue]) -> Result<VmValue, HostlibError> {
+    let raw = dict_arg(SNAPSHOT_BUILTIN, args)?;
+    let dict = raw.as_ref();
+    let session_id = require_string(SNAPSHOT_BUILTIN, dict, "session_id")?;
+    let scope_id = require_string(SNAPSHOT_BUILTIN, dict, "scope_id")?;
+    let paths = optional_string_list(SNAPSHOT_BUILTIN, dict, "paths")?;
+    let root = optional_string(SNAPSHOT_BUILTIN, dict, "root")?.map(PathBuf::from);
+    let result = snapshot(&session_id, &scope_id, &paths, root.as_deref())?;
+    Ok(build_dict([
+        ("snapshot_id", str_value(&result.snapshot_id)),
+        (
+            "captured_paths",
+            VmValue::List(Rc::new(
+                result
+                    .captured_paths
+                    .into_iter()
+                    .map(|path| VmValue::String(Rc::from(path)))
+                    .collect(),
+            )),
+        ),
+        ("byte_count", VmValue::Int(result.byte_count as i64)),
+    ]))
+}
+
+fn restore_builtin(args: &[VmValue]) -> Result<VmValue, HostlibError> {
+    let raw = dict_arg(RESTORE_BUILTIN, args)?;
+    let dict = raw.as_ref();
+    let session_id = require_string(RESTORE_BUILTIN, dict, "session_id")?;
+    let snapshot_id = require_string(RESTORE_BUILTIN, dict, "snapshot_id")?;
+    let paths = optional_string_list(RESTORE_BUILTIN, dict, "paths")?;
+    let result = restore(&session_id, &snapshot_id, &paths)?;
+    Ok(build_dict([
+        ("snapshot_id", str_value(&result.snapshot_id)),
+        (
+            "restored_paths",
+            VmValue::List(Rc::new(
+                result
+                    .restored_paths
+                    .into_iter()
+                    .map(|path| VmValue::String(Rc::from(path)))
+                    .collect(),
+            )),
+        ),
+        (
+            "skipped_paths_with_reasons",
+            VmValue::List(Rc::new(
+                result
+                    .skipped_paths_with_reasons
+                    .into_iter()
+                    .map(|(path, reason)| {
+                        build_dict([("path", str_value(&path)), ("reason", str_value(&reason))])
+                    })
+                    .collect(),
+            )),
+        ),
+    ]))
+}
+
+fn list_snapshots_builtin(args: &[VmValue]) -> Result<VmValue, HostlibError> {
+    let raw = dict_arg(LIST_BUILTIN, args)?;
+    let dict = raw.as_ref();
+    let session_id = require_string(LIST_BUILTIN, dict, "session_id")?;
+    let summaries = list_snapshots(&session_id)?;
+    Ok(build_dict([(
+        "snapshots",
+        VmValue::List(Rc::new(
+            summaries.into_iter().map(snapshot_summary_value).collect(),
+        )),
+    )]))
+}
+
+fn drop_snapshot_builtin(args: &[VmValue]) -> Result<VmValue, HostlibError> {
+    let raw = dict_arg(DROP_BUILTIN, args)?;
+    let dict = raw.as_ref();
+    let session_id = require_string(DROP_BUILTIN, dict, "session_id")?;
+    let snapshot_id = require_string(DROP_BUILTIN, dict, "snapshot_id")?;
+    let result = drop_snapshot(&session_id, &snapshot_id)?;
+    Ok(build_dict([
+        ("snapshot_id", str_value(&result.snapshot_id)),
+        ("dropped", VmValue::Bool(result.dropped)),
+    ]))
+}
+
+fn snapshot_summary_value(summary: SnapshotSummary) -> VmValue {
+    build_dict([
+        ("snapshot_id", str_value(&summary.snapshot_id)),
+        ("scope_id", str_value(&summary.scope_id)),
+        ("taken_at_ms", VmValue::Int(summary.taken_at_ms)),
+        (
+            "captured_paths",
+            VmValue::List(Rc::new(
+                summary
+                    .captured_paths
+                    .into_iter()
+                    .map(|path| VmValue::String(Rc::from(path)))
+                    .collect(),
+            )),
+        ),
+        ("byte_count", VmValue::Int(summary.byte_count as i64)),
+    ])
+}
+
+fn upsert_snapshot(
+    bundle: &mut SessionSnapshots,
+    session_id: &str,
+    scope_id: &str,
+    root: &Path,
+) -> Result<(), HostlibError> {
+    if bundle
+        .snapshots
+        .iter()
+        .any(|snap| snap.snapshot_id == scope_id)
+    {
+        return Ok(());
+    }
+    let state = SnapshotState {
+        snapshot_id: scope_id.to_string(),
+        scope_id: scope_id.to_string(),
+        session_id: session_id.to_string(),
+        root: root.to_path_buf(),
+        taken_at_ms: now_ms(),
+        entries: BTreeMap::new(),
+    };
+    let dir = snapshot_dir(&state.root, &state.session_id, &state.snapshot_id);
+    stdfs::create_dir_all(dir.join("bodies")).map_err(|err| HostlibError::Backend {
+        builtin: SNAPSHOT_BUILTIN,
+        message: format!("mkdir {}: {err}", dir.display()),
+    })?;
+    bundle.snapshots.push(state);
+    Ok(())
+}
+
+fn capture_path(
+    bundle: &mut SessionSnapshots,
+    session_id: &str,
+    snapshot_id: &str,
+    path: &Path,
+    root: &Path,
+) -> Result<Option<u64>, String> {
+    let snap_index = bundle
+        .snapshots
+        .iter()
+        .position(|snap| snap.snapshot_id == snapshot_id)
+        .ok_or_else(|| format!("snapshot `{snapshot_id}` is not registered"))?;
+    if bundle.snapshots[snap_index].entries.contains_key(path) {
+        return Ok(None);
+    }
+    let metadata = stdfs::symlink_metadata(path);
+    let (entry, byte_count) = match metadata {
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => (SnapshotEntry::Absent, 0u64),
+        Err(err) => {
+            return Err(format!("stat `{}`: {err}", path.display()));
+        }
+        Ok(metadata) if metadata.is_dir() => {
+            return Err(format!(
+                "snapshot of directory `{}` is not supported yet",
+                path.display()
+            ));
+        }
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            return Err(format!(
+                "snapshot of symlink `{}` is not supported yet",
+                path.display()
+            ));
+        }
+        Ok(metadata) => {
+            let bytes = stdfs::read(path)
+                .map_err(|err| format!("read `{}` for snapshot: {err}", path.display()))?;
+            let body_hash = hex::encode(Sha256::digest(&bytes));
+            let len = bytes.len() as u64;
+            store_body(root, session_id, snapshot_id, &body_hash, &bytes)?;
+            #[cfg(unix)]
+            let mode = {
+                use std::os::unix::fs::MetadataExt;
+                Some(metadata.mode())
+            };
+            #[cfg(not(unix))]
+            let mode = {
+                let _ = &metadata;
+                None
+            };
+            (
+                SnapshotEntry::File {
+                    body_hash,
+                    len,
+                    mode,
+                },
+                len,
+            )
+        }
+    };
+    let snap = &mut bundle.snapshots[snap_index];
+    snap.entries.insert(path.to_path_buf(), entry);
+    bundle.byte_count = bundle.byte_count.saturating_add(byte_count);
+    Ok(Some(byte_count))
+}
+
+fn store_body(
+    root: &Path,
+    session_id: &str,
+    snapshot_id: &str,
+    body_hash: &str,
+    bytes: &[u8],
+) -> Result<(), String> {
+    let bodies = snapshot_dir(root, session_id, snapshot_id).join("bodies");
+    stdfs::create_dir_all(&bodies).map_err(|err| format!("mkdir {}: {err}", bodies.display()))?;
+    let body_path = bodies.join(body_hash);
+    if !body_path.exists() {
+        atomic_write(&body_path, bytes)?;
+    }
+    Ok(())
+}
+
+fn restore_entry(state: &SnapshotState, path: &Path, entry: &SnapshotEntry) -> Result<(), String> {
+    match entry {
+        SnapshotEntry::Absent => match stdfs::symlink_metadata(path) {
+            Ok(metadata) if metadata.is_dir() => stdfs::remove_dir_all(path)
+                .map_err(|err| format!("remove_dir_all {}: {err}", path.display())),
+            Ok(_) => stdfs::remove_file(path)
+                .map_err(|err| format!("remove_file {}: {err}", path.display())),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(err) => Err(format!("stat {}: {err}", path.display())),
+        },
+        SnapshotEntry::File {
+            body_hash, mode, ..
+        } => {
+            let body_path = snapshot_dir(&state.root, &state.session_id, &state.snapshot_id)
+                .join("bodies")
+                .join(body_hash);
+            let bytes = stdfs::read(&body_path)
+                .map_err(|err| format!("read snapshot body `{}`: {err}", body_path.display()))?;
+            atomic_write(path, &bytes)?;
+            #[cfg(unix)]
+            if let Some(bits) = mode {
+                use std::os::unix::fs::PermissionsExt;
+                let permissions = stdfs::Permissions::from_mode(*bits);
+                stdfs::set_permissions(path, permissions)
+                    .map_err(|err| format!("set_permissions `{}`: {err}", path.display()))?;
+            }
+            #[cfg(not(unix))]
+            let _ = mode;
+            Ok(())
+        }
+    }
+}
+
+fn persist_manifest(state: &SnapshotState) -> Result<(), String> {
+    let dir = snapshot_dir(&state.root, &state.session_id, &state.snapshot_id);
+    stdfs::create_dir_all(&dir).map_err(|err| format!("mkdir {}: {err}", dir.display()))?;
+    let manifest = Manifest {
+        version: MANIFEST_VERSION,
+        snapshot_id: state.snapshot_id.clone(),
+        scope_id: state.scope_id.clone(),
+        session_id: state.session_id.clone(),
+        root: state.root.to_string_lossy().into_owned(),
+        taken_at_ms: state.taken_at_ms,
+        entries: state
+            .entries
+            .iter()
+            .map(|(path, entry)| (path.to_string_lossy().into_owned(), entry.clone()))
+            .collect(),
+    };
+    let bytes = serde_json::to_vec_pretty(&manifest)
+        .map_err(|err| format!("serialize snapshot manifest: {err}"))?;
+    atomic_write(&dir.join("manifest.json"), &bytes)
+}
+
+fn atomic_write(path: &Path, bytes: &[u8]) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        stdfs::create_dir_all(parent)
+            .map_err(|err| format!("mkdir {}: {err}", parent.display()))?;
+    }
+    let tmp = path.with_extension(format!("tmp-{}-{}", std::process::id(), now_ms()));
+    stdfs::write(&tmp, bytes).map_err(|err| format!("write {}: {err}", tmp.display()))?;
+    match stdfs::rename(&tmp, path) {
+        Ok(()) => Ok(()),
+        Err(rename_err) => {
+            let _ = stdfs::remove_file(path);
+            stdfs::rename(&tmp, path).map_err(|retry| {
+                format!(
+                    "rename {} to {}: {rename_err}; retry: {retry}",
+                    tmp.display(),
+                    path.display()
+                )
+            })
+        }
+    }
+}
+
+fn enforce_byte_cap(bundle: &mut SessionSnapshots, session_id: &str) {
+    let cap = session_byte_cap();
+    while bundle.byte_count > cap && !bundle.snapshots.is_empty() {
+        let evicted = bundle.snapshots.remove(0);
+        bundle.byte_count = bundle.byte_count.saturating_sub(entry_byte_count(&evicted));
+        tracing::info!(
+            "fs_snapshot: evicting snapshot `{}` from session `{session_id}` (over byte cap {cap})",
+            evicted.snapshot_id
+        );
+        remove_snapshot_dir(&evicted);
+    }
+}
+
+fn remove_snapshot_dir(state: &SnapshotState) {
+    let dir = snapshot_dir(&state.root, &state.session_id, &state.snapshot_id);
+    let _ = stdfs::remove_dir_all(&dir);
+}
+
+fn entry_byte_count(state: &SnapshotState) -> u64 {
+    state
+        .entries
+        .values()
+        .map(|entry| match entry {
+            SnapshotEntry::File { len, .. } => *len,
+            SnapshotEntry::Absent => 0,
+        })
+        .sum()
+}
+
+fn select_paths(state: &SnapshotState, paths: &[String]) -> Vec<PathBuf> {
+    if paths.is_empty() {
+        return state.entries.keys().cloned().collect();
+    }
+    let requested: BTreeSet<PathBuf> = paths
+        .iter()
+        .map(|path| normalize_logical(Path::new(path)))
+        .collect();
+    state
+        .entries
+        .keys()
+        .filter(|path| requested.contains(*path))
+        .cloned()
+        .collect()
+}
+
+fn validate_session_id(builtin: &'static str, session_id: &str) -> Result<(), HostlibError> {
+    if session_id.trim().is_empty() {
+        return Err(HostlibError::InvalidParameter {
+            builtin,
+            param: "session_id",
+            message: "must not be empty".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn validate_scope_id(builtin: &'static str, scope_id: &str) -> Result<(), HostlibError> {
+    if scope_id.trim().is_empty() {
+        let param = match builtin {
+            SNAPSHOT_BUILTIN => "scope_id",
+            _ => "snapshot_id",
+        };
+        return Err(HostlibError::InvalidParameter {
+            builtin,
+            param,
+            message: "must not be empty".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn active_session_id() -> Option<String> {
+    harn_vm::agent_sessions::current_session_id().filter(|id| !id.trim().is_empty())
+}
+
+fn resolve_root(root: Option<&Path>) -> PathBuf {
+    match root {
+        Some(path) => normalize_logical(path),
+        None => normalize_logical(&std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))),
+    }
+}
+
+fn snapshot_dir(root: &Path, session_id: &str, snapshot_id: &str) -> PathBuf {
+    let mut dir = root.to_path_buf();
+    for component in STATE_REL {
+        dir.push(component);
+    }
+    dir.push(sanitize_component(session_id));
+    dir.push(sanitize_component(snapshot_id));
+    dir
+}
+
+fn sanitize_component(input: &str) -> String {
+    let sanitized: String = input
+        .chars()
+        .map(|ch| match ch {
+            'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_' | '.' => ch,
+            _ => '_',
+        })
+        .collect();
+    if sanitized == input {
+        sanitized
+    } else {
+        let hash = hex::encode(Sha256::digest(input.as_bytes()));
+        format!("{sanitized}-{}", &hash[..12])
+    }
+}
+
+fn normalize_logical(path: &Path) -> PathBuf {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .unwrap_or_else(|_| PathBuf::from("."))
+            .join(path)
+    };
+    let mut out = PathBuf::new();
+    for component in absolute.components() {
+        match component {
+            Component::ParentDir => {
+                out.pop();
+            }
+            Component::CurDir => {}
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+fn now_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Mutex, MutexGuard, OnceLock};
+    use tempfile::TempDir;
+
+    /// Tests in this module mutate process-wide snapshot state and the
+    /// thread-local session/tool-call stacks. Serialize them so reset
+    /// calls from one test don't race with another's in-flight setup.
+    fn test_guard() -> MutexGuard<'static, ()> {
+        static GUARD: OnceLock<Mutex<()>> = OnceLock::new();
+        GUARD
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn enter_session(id: &'static str) -> harn_vm::agent_sessions::CurrentSessionGuard {
+        harn_vm::agent_sessions::reset_session_store();
+        harn_vm::agent_sessions::open_or_create(Some(id.to_string()));
+        harn_vm::agent_sessions::enter_current_session(id)
+    }
+
+    #[test]
+    fn explicit_snapshot_then_restore_round_trips_file_bytes() {
+        let _guard = test_guard();
+        reset_for_test();
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("note.txt");
+        stdfs::write(&file, b"v1").unwrap();
+        let _session = enter_session("snap-roundtrip");
+
+        let result = snapshot(
+            "snap-roundtrip",
+            "tc-1",
+            &[file.to_string_lossy().into_owned()],
+            Some(dir.path()),
+        )
+        .unwrap();
+        assert_eq!(result.snapshot_id, "tc-1");
+        assert_eq!(result.captured_paths.len(), 1);
+        assert_eq!(result.byte_count, 2);
+
+        stdfs::write(&file, b"clobbered").unwrap();
+        let restored = restore("snap-roundtrip", "tc-1", &[]).unwrap();
+        assert_eq!(restored.restored_paths.len(), 1);
+        assert!(restored.skipped_paths_with_reasons.is_empty());
+        assert_eq!(stdfs::read(&file).unwrap(), b"v1");
+    }
+
+    #[test]
+    fn restore_reinstates_deleted_file() {
+        let _guard = test_guard();
+        reset_for_test();
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("doomed.txt");
+        stdfs::write(&file, b"alive").unwrap();
+        let _session = enter_session("snap-reinstate");
+
+        snapshot(
+            "snap-reinstate",
+            "tc-2",
+            &[file.to_string_lossy().into_owned()],
+            Some(dir.path()),
+        )
+        .unwrap();
+        stdfs::remove_file(&file).unwrap();
+        assert!(!file.exists());
+        let restored = restore("snap-reinstate", "tc-2", &[]).unwrap();
+        assert_eq!(restored.restored_paths.len(), 1);
+        assert_eq!(stdfs::read(&file).unwrap(), b"alive");
+    }
+
+    #[test]
+    fn absent_snapshot_means_restore_deletes_paths_created_during_the_call() {
+        let _guard = test_guard();
+        reset_for_test();
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("new.txt");
+        assert!(!file.exists());
+        let _session = enter_session("snap-absent");
+
+        snapshot(
+            "snap-absent",
+            "tc-3",
+            &[file.to_string_lossy().into_owned()],
+            Some(dir.path()),
+        )
+        .unwrap();
+        stdfs::write(&file, b"created during call").unwrap();
+        let restored = restore("snap-absent", "tc-3", &[]).unwrap();
+        assert_eq!(restored.restored_paths.len(), 1);
+        assert!(
+            !file.exists(),
+            "restore must delete files that the snapshot saw as absent"
+        );
+    }
+
+    #[test]
+    fn list_and_drop_round_trip_through_metadata() {
+        let _guard = test_guard();
+        reset_for_test();
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("listed.txt");
+        stdfs::write(&file, b"abc").unwrap();
+        let _session = enter_session("snap-list");
+
+        snapshot(
+            "snap-list",
+            "tc-4",
+            &[file.to_string_lossy().into_owned()],
+            Some(dir.path()),
+        )
+        .unwrap();
+        let summaries = list_snapshots("snap-list").unwrap();
+        assert_eq!(summaries.len(), 1);
+        assert_eq!(summaries[0].snapshot_id, "tc-4");
+        assert_eq!(summaries[0].byte_count, 3);
+
+        let dropped = drop_snapshot("snap-list", "tc-4").unwrap();
+        assert!(dropped.dropped);
+        assert!(list_snapshots("snap-list").unwrap().is_empty());
+
+        let again = drop_snapshot("snap-list", "tc-4").unwrap();
+        assert!(!again.dropped, "second drop must be idempotent");
+    }
+
+    #[test]
+    fn auto_capture_records_pre_image_keyed_by_current_tool_call_id() {
+        let _guard = test_guard();
+        reset_for_test();
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("auto.txt");
+        stdfs::write(&file, b"pre").unwrap();
+        let _session = enter_session("snap-auto");
+        let _tool = harn_vm::agent_sessions::enter_current_tool_call("tc-auto");
+
+        snapshot("snap-auto", "tc-auto", &[], Some(dir.path())).unwrap();
+        // Pretend a mutating tool fired:
+        auto_capture_for_write("hostlib_tools_write_file", &file);
+        stdfs::write(&file, b"post").unwrap();
+
+        let restored = restore("snap-auto", "tc-auto", &[]).unwrap();
+        assert_eq!(restored.restored_paths.len(), 1);
+        assert_eq!(stdfs::read(&file).unwrap(), b"pre");
+    }
+
+    #[test]
+    fn byte_cap_evicts_oldest_snapshot_when_exceeded() {
+        let _guard = test_guard();
+        reset_for_test();
+        let prev_cap = set_session_byte_cap(8);
+        let dir = TempDir::new().unwrap();
+        let _session = enter_session("snap-evict");
+
+        let mk = |name: &str| {
+            let path = dir.path().join(name);
+            stdfs::write(&path, b"12345").unwrap();
+            path
+        };
+
+        let a = mk("a.txt");
+        snapshot(
+            "snap-evict",
+            "tc-a",
+            &[a.to_string_lossy().into_owned()],
+            Some(dir.path()),
+        )
+        .unwrap();
+        let b = mk("b.txt");
+        snapshot(
+            "snap-evict",
+            "tc-b",
+            &[b.to_string_lossy().into_owned()],
+            Some(dir.path()),
+        )
+        .unwrap();
+        let snapshots = list_snapshots("snap-evict").unwrap();
+        let ids: Vec<&str> = snapshots
+            .iter()
+            .map(|summary| summary.snapshot_id.as_str())
+            .collect();
+        assert_eq!(
+            ids,
+            vec!["tc-b"],
+            "older snapshot must be evicted when the per-session byte cap is exceeded"
+        );
+
+        set_session_byte_cap(prev_cap);
+    }
+}

--- a/crates/harn-hostlib/src/fs_snapshot.rs
+++ b/crates/harn-hostlib/src/fs_snapshot.rs
@@ -183,7 +183,7 @@ pub struct DropResult {
     pub dropped: bool,
 }
 
-#[derive(Default, Debug)]
+#[derive(Debug)]
 struct SessionSnapshots {
     /// Snapshots, in insertion order.
     snapshots: Vec<SnapshotState>,
@@ -191,44 +191,62 @@ struct SessionSnapshots {
     /// this rather than recomputing from `bodies/` so eviction stays
     /// O(snapshots) instead of walking the filesystem on every write.
     byte_count: u64,
+    /// Per-session byte cap. Defaults to [`DEFAULT_SESSION_BYTE_CAP`] and
+    /// can be overridden with [`configure_session_byte_cap`].
+    byte_cap: u64,
+}
+
+impl Default for SessionSnapshots {
+    fn default() -> Self {
+        Self {
+            snapshots: Vec::new(),
+            byte_count: 0,
+            byte_cap: DEFAULT_SESSION_BYTE_CAP,
+        }
+    }
 }
 
 static SESSIONS: OnceLock<Mutex<BTreeMap<String, SessionSnapshots>>> = OnceLock::new();
-static SESSION_BYTE_CAP: OnceLock<Mutex<u64>> = OnceLock::new();
 
 fn sessions() -> &'static Mutex<BTreeMap<String, SessionSnapshots>> {
     SESSIONS.get_or_init(|| Mutex::new(BTreeMap::new()))
 }
 
-fn session_byte_cap() -> u64 {
-    *SESSION_BYTE_CAP
-        .get_or_init(|| Mutex::new(DEFAULT_SESSION_BYTE_CAP))
-        .lock()
-        .expect("fs_snapshot byte cap mutex poisoned")
-}
-
-/// Override the per-session byte cap. Returns the previous value.
+/// Override the byte cap for a specific session and immediately enforce
+/// it. Returns the previous cap.
 ///
-/// Primarily for tests that want to force eviction without writing a
-/// gigabyte. Production embedders should leave the default in place
-/// unless they have evidence it is too large.
-pub fn set_session_byte_cap(bytes: u64) -> u64 {
-    let mutex = SESSION_BYTE_CAP.get_or_init(|| Mutex::new(DEFAULT_SESSION_BYTE_CAP));
-    let mut guard = mutex.lock().expect("fs_snapshot byte cap mutex poisoned");
-    let previous = *guard;
-    *guard = bytes.max(1);
-    previous
-}
-
-/// Test-only helper that clears the in-memory snapshot store. We deliberately
-/// leave on-disk state alone — tests that need a clean filesystem use a
-/// `TempDir` and reseat the workspace root.
-#[doc(hidden)]
-pub fn reset_for_test() {
+/// Primarily intended for tests that want to force eviction without
+/// writing a gigabyte. Production embedders generally leave the default
+/// in place; touching one session never affects another.
+pub fn configure_session_byte_cap(session_id: &str, bytes: u64) -> u64 {
     let mut guard = sessions()
         .lock()
         .expect("fs_snapshot session mutex poisoned");
-    guard.clear();
+    let bundle = guard.entry(session_id.to_string()).or_default();
+    let previous = bundle.byte_cap;
+    bundle.byte_cap = bytes.max(1);
+    enforce_byte_cap(bundle, session_id);
+    previous
+}
+
+/// Drop every snapshot registered for `session_id`, both in memory and
+/// on disk. Returns the number of snapshots removed.
+///
+/// ACP hosts should call this on session close so the snapshot bundle
+/// doesn't outlive the conversation. Tests can also call it on
+/// teardown when reusing a session id across cases.
+pub fn drop_session_snapshots(session_id: &str) -> usize {
+    let mut guard = sessions()
+        .lock()
+        .expect("fs_snapshot session mutex poisoned");
+    let Some(bundle) = guard.remove(session_id) else {
+        return 0;
+    };
+    let count = bundle.snapshots.len();
+    for snapshot in &bundle.snapshots {
+        remove_snapshot_dir(snapshot);
+    }
+    count
 }
 
 /// Take a snapshot. When `paths` is empty the snapshot is "open" — bytes
@@ -732,13 +750,13 @@ fn atomic_write(path: &Path, bytes: &[u8]) -> Result<(), String> {
 }
 
 fn enforce_byte_cap(bundle: &mut SessionSnapshots, session_id: &str) {
-    let cap = session_byte_cap();
-    while bundle.byte_count > cap && !bundle.snapshots.is_empty() {
+    while bundle.byte_count > bundle.byte_cap && !bundle.snapshots.is_empty() {
         let evicted = bundle.snapshots.remove(0);
         bundle.byte_count = bundle.byte_count.saturating_sub(entry_byte_count(&evicted));
         tracing::info!(
-            "fs_snapshot: evicting snapshot `{}` from session `{session_id}` (over byte cap {cap})",
-            evicted.snapshot_id
+            "fs_snapshot: evicting snapshot `{}` from session `{session_id}` (over byte cap {})",
+            evicted.snapshot_id,
+            bundle.byte_cap,
         );
         remove_snapshot_dir(&evicted);
     }
@@ -870,48 +888,50 @@ fn now_ms() -> i64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Mutex, MutexGuard, OnceLock};
+    use std::sync::atomic::{AtomicU64, Ordering};
     use tempfile::TempDir;
 
-    /// Tests in this module mutate process-wide snapshot state and the
-    /// thread-local session/tool-call stacks. Serialize them so reset
-    /// calls from one test don't race with another's in-flight setup.
-    fn test_guard() -> MutexGuard<'static, ()> {
-        static GUARD: OnceLock<Mutex<()>> = OnceLock::new();
-        GUARD
-            .get_or_init(|| Mutex::new(()))
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    /// Hand each test its own session id so the process-wide `SESSIONS`
+    /// map isolates them by key — no serialization or process-wide
+    /// reset required.
+    fn unique_session(prefix: &str) -> String {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        format!("{prefix}-{n}-{}", std::process::id())
     }
 
-    fn enter_session(id: &'static str) -> harn_vm::agent_sessions::CurrentSessionGuard {
-        harn_vm::agent_sessions::reset_session_store();
+    fn unique_scope() -> String {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        format!("tc-{}", COUNTER.fetch_add(1, Ordering::Relaxed))
+    }
+
+    fn enter_session(id: &str) -> harn_vm::agent_sessions::CurrentSessionGuard {
         harn_vm::agent_sessions::open_or_create(Some(id.to_string()));
-        harn_vm::agent_sessions::enter_current_session(id)
+        harn_vm::agent_sessions::enter_current_session(id.to_string())
     }
 
     #[test]
     fn explicit_snapshot_then_restore_round_trips_file_bytes() {
-        let _guard = test_guard();
-        reset_for_test();
         let dir = TempDir::new().unwrap();
         let file = dir.path().join("note.txt");
         stdfs::write(&file, b"v1").unwrap();
-        let _session = enter_session("snap-roundtrip");
+        let session = unique_session("snap-roundtrip");
+        let scope = unique_scope();
+        let _session_guard = enter_session(&session);
 
         let result = snapshot(
-            "snap-roundtrip",
-            "tc-1",
+            &session,
+            &scope,
             &[file.to_string_lossy().into_owned()],
             Some(dir.path()),
         )
         .unwrap();
-        assert_eq!(result.snapshot_id, "tc-1");
+        assert_eq!(result.snapshot_id, scope);
         assert_eq!(result.captured_paths.len(), 1);
         assert_eq!(result.byte_count, 2);
 
         stdfs::write(&file, b"clobbered").unwrap();
-        let restored = restore("snap-roundtrip", "tc-1", &[]).unwrap();
+        let restored = restore(&session, &scope, &[]).unwrap();
         assert_eq!(restored.restored_paths.len(), 1);
         assert!(restored.skipped_paths_with_reasons.is_empty());
         assert_eq!(stdfs::read(&file).unwrap(), b"v1");
@@ -919,45 +939,45 @@ mod tests {
 
     #[test]
     fn restore_reinstates_deleted_file() {
-        let _guard = test_guard();
-        reset_for_test();
         let dir = TempDir::new().unwrap();
         let file = dir.path().join("doomed.txt");
         stdfs::write(&file, b"alive").unwrap();
-        let _session = enter_session("snap-reinstate");
+        let session = unique_session("snap-reinstate");
+        let scope = unique_scope();
+        let _session_guard = enter_session(&session);
 
         snapshot(
-            "snap-reinstate",
-            "tc-2",
+            &session,
+            &scope,
             &[file.to_string_lossy().into_owned()],
             Some(dir.path()),
         )
         .unwrap();
         stdfs::remove_file(&file).unwrap();
         assert!(!file.exists());
-        let restored = restore("snap-reinstate", "tc-2", &[]).unwrap();
+        let restored = restore(&session, &scope, &[]).unwrap();
         assert_eq!(restored.restored_paths.len(), 1);
         assert_eq!(stdfs::read(&file).unwrap(), b"alive");
     }
 
     #[test]
     fn absent_snapshot_means_restore_deletes_paths_created_during_the_call() {
-        let _guard = test_guard();
-        reset_for_test();
         let dir = TempDir::new().unwrap();
         let file = dir.path().join("new.txt");
         assert!(!file.exists());
-        let _session = enter_session("snap-absent");
+        let session = unique_session("snap-absent");
+        let scope = unique_scope();
+        let _session_guard = enter_session(&session);
 
         snapshot(
-            "snap-absent",
-            "tc-3",
+            &session,
+            &scope,
             &[file.to_string_lossy().into_owned()],
             Some(dir.path()),
         )
         .unwrap();
         stdfs::write(&file, b"created during call").unwrap();
-        let restored = restore("snap-absent", "tc-3", &[]).unwrap();
+        let restored = restore(&session, &scope, &[]).unwrap();
         assert_eq!(restored.restored_paths.len(), 1);
         assert!(
             !file.exists(),
@@ -967,60 +987,61 @@ mod tests {
 
     #[test]
     fn list_and_drop_round_trip_through_metadata() {
-        let _guard = test_guard();
-        reset_for_test();
         let dir = TempDir::new().unwrap();
         let file = dir.path().join("listed.txt");
         stdfs::write(&file, b"abc").unwrap();
-        let _session = enter_session("snap-list");
+        let session = unique_session("snap-list");
+        let scope = unique_scope();
+        let _session_guard = enter_session(&session);
 
         snapshot(
-            "snap-list",
-            "tc-4",
+            &session,
+            &scope,
             &[file.to_string_lossy().into_owned()],
             Some(dir.path()),
         )
         .unwrap();
-        let summaries = list_snapshots("snap-list").unwrap();
+        let summaries = list_snapshots(&session).unwrap();
         assert_eq!(summaries.len(), 1);
-        assert_eq!(summaries[0].snapshot_id, "tc-4");
+        assert_eq!(summaries[0].snapshot_id, scope);
         assert_eq!(summaries[0].byte_count, 3);
 
-        let dropped = drop_snapshot("snap-list", "tc-4").unwrap();
+        let dropped = drop_snapshot(&session, &scope).unwrap();
         assert!(dropped.dropped);
-        assert!(list_snapshots("snap-list").unwrap().is_empty());
+        assert!(list_snapshots(&session).unwrap().is_empty());
 
-        let again = drop_snapshot("snap-list", "tc-4").unwrap();
+        let again = drop_snapshot(&session, &scope).unwrap();
         assert!(!again.dropped, "second drop must be idempotent");
     }
 
     #[test]
     fn auto_capture_records_pre_image_keyed_by_current_tool_call_id() {
-        let _guard = test_guard();
-        reset_for_test();
         let dir = TempDir::new().unwrap();
         let file = dir.path().join("auto.txt");
         stdfs::write(&file, b"pre").unwrap();
-        let _session = enter_session("snap-auto");
-        let _tool = harn_vm::agent_sessions::enter_current_tool_call("tc-auto");
+        let session = unique_session("snap-auto");
+        let scope = unique_scope();
+        let _session_guard = enter_session(&session);
+        let _tool_guard = harn_vm::agent_sessions::enter_current_tool_call(scope.clone());
 
-        snapshot("snap-auto", "tc-auto", &[], Some(dir.path())).unwrap();
-        // Pretend a mutating tool fired:
+        snapshot(&session, &scope, &[], Some(dir.path())).unwrap();
         auto_capture_for_write("hostlib_tools_write_file", &file);
         stdfs::write(&file, b"post").unwrap();
 
-        let restored = restore("snap-auto", "tc-auto", &[]).unwrap();
+        let restored = restore(&session, &scope, &[]).unwrap();
         assert_eq!(restored.restored_paths.len(), 1);
         assert_eq!(stdfs::read(&file).unwrap(), b"pre");
     }
 
     #[test]
     fn byte_cap_evicts_oldest_snapshot_when_exceeded() {
-        let _guard = test_guard();
-        reset_for_test();
-        let prev_cap = set_session_byte_cap(8);
         let dir = TempDir::new().unwrap();
-        let _session = enter_session("snap-evict");
+        let session = unique_session("snap-evict");
+        let _session_guard = enter_session(&session);
+
+        // Per-session cap: only affects this test's session, so other
+        // tests can run in parallel without seeing the squeeze.
+        configure_session_byte_cap(&session, 8);
 
         let mk = |name: &str| {
             let path = dir.path().join(name);
@@ -1028,33 +1049,65 @@ mod tests {
             path
         };
 
+        let scope_a = unique_scope();
+        let scope_b = unique_scope();
         let a = mk("a.txt");
         snapshot(
-            "snap-evict",
-            "tc-a",
+            &session,
+            &scope_a,
             &[a.to_string_lossy().into_owned()],
             Some(dir.path()),
         )
         .unwrap();
         let b = mk("b.txt");
         snapshot(
-            "snap-evict",
-            "tc-b",
+            &session,
+            &scope_b,
             &[b.to_string_lossy().into_owned()],
             Some(dir.path()),
         )
         .unwrap();
-        let snapshots = list_snapshots("snap-evict").unwrap();
-        let ids: Vec<&str> = snapshots
-            .iter()
-            .map(|summary| summary.snapshot_id.as_str())
+
+        let ids: Vec<String> = list_snapshots(&session)
+            .unwrap()
+            .into_iter()
+            .map(|summary| summary.snapshot_id)
             .collect();
         assert_eq!(
             ids,
-            vec!["tc-b"],
+            vec![scope_b],
             "older snapshot must be evicted when the per-session byte cap is exceeded"
         );
+    }
 
-        set_session_byte_cap(prev_cap);
+    #[test]
+    fn drop_session_snapshots_removes_every_snapshot_for_a_session() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("retained.txt");
+        stdfs::write(&file, b"x").unwrap();
+        let session = unique_session("snap-drop-session");
+        let scope_a = unique_scope();
+        let scope_b = unique_scope();
+        let _session_guard = enter_session(&session);
+
+        snapshot(
+            &session,
+            &scope_a,
+            &[file.to_string_lossy().into_owned()],
+            Some(dir.path()),
+        )
+        .unwrap();
+        snapshot(
+            &session,
+            &scope_b,
+            &[file.to_string_lossy().into_owned()],
+            Some(dir.path()),
+        )
+        .unwrap();
+        assert_eq!(list_snapshots(&session).unwrap().len(), 2);
+
+        assert_eq!(drop_session_snapshots(&session), 2);
+        assert!(list_snapshots(&session).unwrap().is_empty());
+        assert_eq!(drop_session_snapshots(&session), 0, "idempotent");
     }
 }

--- a/crates/harn-hostlib/src/lib.rs
+++ b/crates/harn-hostlib/src/lib.rs
@@ -31,6 +31,7 @@ pub mod ast;
 pub mod code_index;
 pub mod error;
 pub mod fs;
+pub mod fs_snapshot;
 pub mod fs_watch;
 pub mod process;
 pub mod scanner;
@@ -56,6 +57,7 @@ pub fn install_default(vm: &mut harn_vm::Vm) -> HostlibRegistry {
         .with(code_index::CodeIndexCapability::new())
         .with(scanner::ScannerCapability)
         .with(fs::FsCapability)
+        .with(fs_snapshot::FsSnapshotCapability)
         .with(fs_watch::FsWatchCapability)
         .with(tools::ToolsCapability)
         .with(secret_store::SecretStoreCapability);

--- a/crates/harn-hostlib/src/schemas.rs
+++ b/crates/harn-hostlib/src/schemas.rs
@@ -572,6 +572,54 @@ pub const SCHEMAS: &[(&str, &str, SchemaKind, &str)] = &[
         SchemaKind::Response,
         include_str!("../schemas/fs/discard_staged.response.json"),
     ),
+    (
+        "fs",
+        "snapshot",
+        SchemaKind::Request,
+        include_str!("../schemas/fs/snapshot.request.json"),
+    ),
+    (
+        "fs",
+        "snapshot",
+        SchemaKind::Response,
+        include_str!("../schemas/fs/snapshot.response.json"),
+    ),
+    (
+        "fs",
+        "restore",
+        SchemaKind::Request,
+        include_str!("../schemas/fs/restore.request.json"),
+    ),
+    (
+        "fs",
+        "restore",
+        SchemaKind::Response,
+        include_str!("../schemas/fs/restore.response.json"),
+    ),
+    (
+        "fs",
+        "list_snapshots",
+        SchemaKind::Request,
+        include_str!("../schemas/fs/list_snapshots.request.json"),
+    ),
+    (
+        "fs",
+        "list_snapshots",
+        SchemaKind::Response,
+        include_str!("../schemas/fs/list_snapshots.response.json"),
+    ),
+    (
+        "fs",
+        "drop_snapshot",
+        SchemaKind::Request,
+        include_str!("../schemas/fs/drop_snapshot.request.json"),
+    ),
+    (
+        "fs",
+        "drop_snapshot",
+        SchemaKind::Response,
+        include_str!("../schemas/fs/drop_snapshot.response.json"),
+    ),
     // fs_watch/
     (
         "fs_watch",

--- a/crates/harn-hostlib/src/tools/file_io.rs
+++ b/crates/harn-hostlib/src/tools/file_io.rs
@@ -161,6 +161,10 @@ pub(super) fn write_file(args: &[VmValue]) -> Result<VmValue, HostlibError> {
         });
     }
 
+    // Capture the pre-image into any open snapshots before mutating disk
+    // so a `session/restore_tool_call` can roll the write back surgically.
+    crate::fs_snapshot::auto_capture_for_write(WRITE_FILE_BUILTIN, &path);
+
     if create_parents {
         if let Some(parent) = path.parent() {
             if !parent.as_os_str().is_empty() {
@@ -220,6 +224,10 @@ pub(super) fn delete_file(args: &[VmValue]) -> Result<VmValue, HostlibError> {
             });
         }
     };
+
+    // Capture the pre-image into any open snapshots before mutating disk
+    // so a `session/restore_tool_call` can roll the delete back.
+    crate::fs_snapshot::auto_capture_for_write(DELETE_FILE_BUILTIN, &path);
 
     let removed = if metadata.is_dir() {
         if recursive {

--- a/crates/harn-hostlib/tests/fs_snapshot.rs
+++ b/crates/harn-hostlib/tests/fs_snapshot.rs
@@ -1,0 +1,270 @@
+//! Integration tests for the per-tool-call FS snapshot primitives.
+//!
+//! Exercises both the explicit `hostlib_fs_snapshot({paths: [...]})` form
+//! and the auto-on-write path that snaps pre-images out of
+//! `tools/write_file` / `tools/delete_file` when an open snapshot is
+//! registered for the current tool call.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+use std::rc::Rc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Mutex, OnceLock};
+
+use harn_hostlib::tools::permissions;
+use harn_hostlib::{
+    fs_snapshot::FsSnapshotCapability, tools::ToolsCapability, BuiltinRegistry, HostlibCapability,
+};
+use harn_vm::agent_sessions;
+use harn_vm::VmValue;
+use tempfile::TempDir;
+
+/// Serialize tests in this binary. Each test mutates process-wide
+/// snapshot state and thread-local session/tool-call stacks; parallel
+/// execution observed `reset_for_test` racing the auto-capture path.
+fn test_guard() -> std::sync::MutexGuard<'static, ()> {
+    static GUARD: OnceLock<Mutex<()>> = OnceLock::new();
+    GUARD
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+fn registry() -> BuiltinRegistry {
+    permissions::reset();
+    permissions::enable_for_test();
+    let mut registry = BuiltinRegistry::new();
+    FsSnapshotCapability.register_builtins(&mut registry);
+    ToolsCapability.register_builtins(&mut registry);
+    registry
+}
+
+fn dict_arg(entries: &[(&str, VmValue)]) -> Vec<VmValue> {
+    let mut map: BTreeMap<String, VmValue> = BTreeMap::new();
+    for (k, v) in entries {
+        map.insert(k.to_string(), v.clone());
+    }
+    vec![VmValue::Dict(Rc::new(map))]
+}
+
+fn vm_string(s: &str) -> VmValue {
+    VmValue::String(Rc::from(s))
+}
+
+fn dict_get<'a>(value: &'a VmValue, key: &str) -> &'a VmValue {
+    match value {
+        VmValue::Dict(d) => d.get(key).expect("key present"),
+        other => panic!("not a dict: {other:?}"),
+    }
+}
+
+fn path_str(path: &Path) -> String {
+    path.to_string_lossy().into_owned()
+}
+
+fn unique(prefix: &str) -> String {
+    static COUNTER: AtomicUsize = AtomicUsize::new(1);
+    format!("{prefix}-{}", COUNTER.fetch_add(1, Ordering::Relaxed))
+}
+
+#[test]
+fn explicit_snapshot_then_restore_through_builtins() {
+    let _guard = test_guard();
+    harn_hostlib::fs_snapshot::reset_for_test();
+    agent_sessions::reset_session_store();
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("explicit.txt");
+    fs::write(&file, b"original").unwrap();
+    let session = unique("snap-explicit");
+    agent_sessions::open_or_create(Some(session.clone()));
+    let _session_guard = agent_sessions::enter_current_session(session.clone());
+    let reg = registry();
+
+    let snapshot = (reg.find("hostlib_fs_snapshot").unwrap().handler)(&dict_arg(&[
+        ("session_id", vm_string(&session)),
+        ("scope_id", vm_string("tc-explicit")),
+        (
+            "paths",
+            VmValue::List(Rc::new(vec![vm_string(&path_str(&file))])),
+        ),
+        ("root", vm_string(&path_str(dir.path()))),
+    ]))
+    .unwrap();
+    assert!(
+        matches!(dict_get(&snapshot, "snapshot_id"), VmValue::String(id) if id.as_ref() == "tc-explicit")
+    );
+    assert!(matches!(dict_get(&snapshot, "byte_count"), VmValue::Int(8)));
+
+    fs::write(&file, b"corrupted").unwrap();
+
+    let restored = (reg.find("hostlib_fs_restore").unwrap().handler)(&dict_arg(&[
+        ("session_id", vm_string(&session)),
+        ("snapshot_id", vm_string("tc-explicit")),
+    ]))
+    .unwrap();
+    let restored_paths = match dict_get(&restored, "restored_paths") {
+        VmValue::List(items) => items.iter().count(),
+        other => panic!("restored_paths not a list: {other:?}"),
+    };
+    assert_eq!(restored_paths, 1);
+    assert_eq!(fs::read(&file).unwrap(), b"original");
+}
+
+#[test]
+fn auto_on_write_captures_pre_image_via_tools_write_file() {
+    let _guard = test_guard();
+    harn_hostlib::fs_snapshot::reset_for_test();
+    agent_sessions::reset_session_store();
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("auto.txt");
+    fs::write(&file, b"pre").unwrap();
+    let session = unique("snap-auto");
+    agent_sessions::open_or_create(Some(session.clone()));
+    let _session_guard = agent_sessions::enter_current_session(session.clone());
+    let _tool_guard = agent_sessions::enter_current_tool_call("tc-auto");
+    let reg = registry();
+
+    // Register an open snapshot. No paths provided so capture is lazy.
+    (reg.find("hostlib_fs_snapshot").unwrap().handler)(&dict_arg(&[
+        ("session_id", vm_string(&session)),
+        ("scope_id", vm_string("tc-auto")),
+        ("root", vm_string(&path_str(dir.path()))),
+    ]))
+    .unwrap();
+
+    // Mutate through the tool builtin. Pre-image must be captured first.
+    (reg.find("hostlib_tools_write_file").unwrap().handler)(&dict_arg(&[
+        ("path", vm_string(&path_str(&file))),
+        ("content", vm_string("post")),
+    ]))
+    .unwrap();
+    assert_eq!(fs::read(&file).unwrap(), b"post");
+
+    // Restore the snapshot and confirm the byte-for-byte pre-image is back.
+    (reg.find("hostlib_fs_restore").unwrap().handler)(&dict_arg(&[
+        ("session_id", vm_string(&session)),
+        ("snapshot_id", vm_string("tc-auto")),
+    ]))
+    .unwrap();
+    assert_eq!(fs::read(&file).unwrap(), b"pre");
+}
+
+#[test]
+fn auto_on_write_captures_delete_so_restore_reinstates_file() {
+    let _guard = test_guard();
+    harn_hostlib::fs_snapshot::reset_for_test();
+    agent_sessions::reset_session_store();
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("victim.txt");
+    fs::write(&file, b"important").unwrap();
+    let session = unique("snap-delete");
+    agent_sessions::open_or_create(Some(session.clone()));
+    let _session_guard = agent_sessions::enter_current_session(session.clone());
+    let _tool_guard = agent_sessions::enter_current_tool_call("tc-delete");
+    let reg = registry();
+
+    (reg.find("hostlib_fs_snapshot").unwrap().handler)(&dict_arg(&[
+        ("session_id", vm_string(&session)),
+        ("scope_id", vm_string("tc-delete")),
+        ("root", vm_string(&path_str(dir.path()))),
+    ]))
+    .unwrap();
+
+    (reg.find("hostlib_tools_delete_file").unwrap().handler)(&dict_arg(&[(
+        "path",
+        vm_string(&path_str(&file)),
+    )]))
+    .unwrap();
+    assert!(!file.exists());
+
+    (reg.find("hostlib_fs_restore").unwrap().handler)(&dict_arg(&[
+        ("session_id", vm_string(&session)),
+        ("snapshot_id", vm_string("tc-delete")),
+    ]))
+    .unwrap();
+    assert_eq!(fs::read(&file).unwrap(), b"important");
+}
+
+#[test]
+fn list_and_drop_remove_snapshot_state_through_builtins() {
+    let _guard = test_guard();
+    harn_hostlib::fs_snapshot::reset_for_test();
+    agent_sessions::reset_session_store();
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("listed.txt");
+    fs::write(&file, b"abcd").unwrap();
+    let session = unique("snap-list");
+    agent_sessions::open_or_create(Some(session.clone()));
+    let _session_guard = agent_sessions::enter_current_session(session.clone());
+    let reg = registry();
+
+    (reg.find("hostlib_fs_snapshot").unwrap().handler)(&dict_arg(&[
+        ("session_id", vm_string(&session)),
+        ("scope_id", vm_string("tc-list")),
+        (
+            "paths",
+            VmValue::List(Rc::new(vec![vm_string(&path_str(&file))])),
+        ),
+        ("root", vm_string(&path_str(dir.path()))),
+    ]))
+    .unwrap();
+
+    let listed = (reg.find("hostlib_fs_list_snapshots").unwrap().handler)(&dict_arg(&[(
+        "session_id",
+        vm_string(&session),
+    )]))
+    .unwrap();
+    let count = match dict_get(&listed, "snapshots") {
+        VmValue::List(items) => items.len(),
+        other => panic!("snapshots not a list: {other:?}"),
+    };
+    assert_eq!(count, 1);
+
+    let dropped = (reg.find("hostlib_fs_drop_snapshot").unwrap().handler)(&dict_arg(&[
+        ("session_id", vm_string(&session)),
+        ("snapshot_id", vm_string("tc-list")),
+    ]))
+    .unwrap();
+    assert!(matches!(dict_get(&dropped, "dropped"), VmValue::Bool(true)));
+    let listed_after = (reg.find("hostlib_fs_list_snapshots").unwrap().handler)(&dict_arg(&[(
+        "session_id",
+        vm_string(&session),
+    )]))
+    .unwrap();
+    assert!(matches!(
+        dict_get(&listed_after, "snapshots"),
+        VmValue::List(items) if items.is_empty()
+    ));
+}
+
+#[test]
+fn auto_on_write_no_ops_when_no_snapshot_is_registered() {
+    let _guard = test_guard();
+    harn_hostlib::fs_snapshot::reset_for_test();
+    agent_sessions::reset_session_store();
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("plain.txt");
+    let session = unique("snap-noop");
+    agent_sessions::open_or_create(Some(session.clone()));
+    let _session_guard = agent_sessions::enter_current_session(session.clone());
+    let reg = registry();
+
+    // No fs_snapshot call — write should be a plain mutation.
+    (reg.find("hostlib_tools_write_file").unwrap().handler)(&dict_arg(&[
+        ("path", vm_string(&path_str(&file))),
+        ("content", vm_string("hi")),
+    ]))
+    .unwrap();
+    assert_eq!(fs::read(&file).unwrap(), b"hi");
+
+    let listed = (reg.find("hostlib_fs_list_snapshots").unwrap().handler)(&dict_arg(&[(
+        "session_id",
+        vm_string(&session),
+    )]))
+    .unwrap();
+    assert!(matches!(
+        dict_get(&listed, "snapshots"),
+        VmValue::List(items) if items.is_empty()
+    ));
+}

--- a/crates/harn-hostlib/tests/fs_snapshot.rs
+++ b/crates/harn-hostlib/tests/fs_snapshot.rs
@@ -4,13 +4,16 @@
 //! and the auto-on-write path that snaps pre-images out of
 //! `tools/write_file` / `tools/delete_file` when an open snapshot is
 //! registered for the current tool call.
+//!
+//! Tests rely on session-id isolation, not serialization: every test
+//! mints a unique session id, so the process-wide snapshot store keys
+//! cleanly. No process-wide reset is required.
 
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
 use std::rc::Rc;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Mutex, OnceLock};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use harn_hostlib::tools::permissions;
 use harn_hostlib::{
@@ -20,19 +23,7 @@ use harn_vm::agent_sessions;
 use harn_vm::VmValue;
 use tempfile::TempDir;
 
-/// Serialize tests in this binary. Each test mutates process-wide
-/// snapshot state and thread-local session/tool-call stacks; parallel
-/// execution observed `reset_for_test` racing the auto-capture path.
-fn test_guard() -> std::sync::MutexGuard<'static, ()> {
-    static GUARD: OnceLock<Mutex<()>> = OnceLock::new();
-    GUARD
-        .get_or_init(|| Mutex::new(()))
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
-}
-
 fn registry() -> BuiltinRegistry {
-    permissions::reset();
     permissions::enable_for_test();
     let mut registry = BuiltinRegistry::new();
     FsSnapshotCapability.register_builtins(&mut registry);
@@ -63,27 +54,69 @@ fn path_str(path: &Path) -> String {
     path.to_string_lossy().into_owned()
 }
 
-fn unique(prefix: &str) -> String {
-    static COUNTER: AtomicUsize = AtomicUsize::new(1);
-    format!("{prefix}-{}", COUNTER.fetch_add(1, Ordering::Relaxed))
+fn unique_session(prefix: &str) -> String {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("{prefix}-{n}-{}", std::process::id())
+}
+
+fn unique_scope() -> String {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    format!("tc-{}", COUNTER.fetch_add(1, Ordering::Relaxed))
+}
+
+struct Fixture {
+    session: String,
+    scope: String,
+    _session_guard: agent_sessions::CurrentSessionGuard,
+    _tool_guard: Option<agent_sessions::CurrentToolCallGuard>,
+}
+
+impl Fixture {
+    /// Set up a session + scope id and enter both onto the thread-local
+    /// stacks. `enter_tool_call` toggles whether the auto-on-write path
+    /// can fire; tests that exercise the explicit-paths surface only
+    /// don't need it.
+    fn new(prefix: &str, enter_tool_call: bool) -> Self {
+        let session = unique_session(prefix);
+        let scope = unique_scope();
+        agent_sessions::open_or_create(Some(session.clone()));
+        let session_guard = agent_sessions::enter_current_session(session.clone());
+        let tool_guard = if enter_tool_call {
+            Some(agent_sessions::enter_current_tool_call(scope.clone()))
+        } else {
+            None
+        };
+        Self {
+            session,
+            scope,
+            _session_guard: session_guard,
+            _tool_guard: tool_guard,
+        }
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        // Best-effort cleanup so successive tests inside a single shared
+        // process don't leak `.harn/state/snapshots/<session>/` dirs
+        // under their TempDirs. Snapshot state is keyed by session id,
+        // so this only ever touches this test's data.
+        harn_hostlib::fs_snapshot::drop_session_snapshots(&self.session);
+    }
 }
 
 #[test]
 fn explicit_snapshot_then_restore_through_builtins() {
-    let _guard = test_guard();
-    harn_hostlib::fs_snapshot::reset_for_test();
-    agent_sessions::reset_session_store();
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("explicit.txt");
     fs::write(&file, b"original").unwrap();
-    let session = unique("snap-explicit");
-    agent_sessions::open_or_create(Some(session.clone()));
-    let _session_guard = agent_sessions::enter_current_session(session.clone());
+    let fixture = Fixture::new("snap-explicit", false);
     let reg = registry();
 
     let snapshot = (reg.find("hostlib_fs_snapshot").unwrap().handler)(&dict_arg(&[
-        ("session_id", vm_string(&session)),
-        ("scope_id", vm_string("tc-explicit")),
+        ("session_id", vm_string(&fixture.session)),
+        ("scope_id", vm_string(&fixture.scope)),
         (
             "paths",
             VmValue::List(Rc::new(vec![vm_string(&path_str(&file))])),
@@ -91,16 +124,17 @@ fn explicit_snapshot_then_restore_through_builtins() {
         ("root", vm_string(&path_str(dir.path()))),
     ]))
     .unwrap();
-    assert!(
-        matches!(dict_get(&snapshot, "snapshot_id"), VmValue::String(id) if id.as_ref() == "tc-explicit")
-    );
+    assert!(matches!(
+        dict_get(&snapshot, "snapshot_id"),
+        VmValue::String(id) if id.as_ref() == fixture.scope
+    ));
     assert!(matches!(dict_get(&snapshot, "byte_count"), VmValue::Int(8)));
 
     fs::write(&file, b"corrupted").unwrap();
 
     let restored = (reg.find("hostlib_fs_restore").unwrap().handler)(&dict_arg(&[
-        ("session_id", vm_string(&session)),
-        ("snapshot_id", vm_string("tc-explicit")),
+        ("session_id", vm_string(&fixture.session)),
+        ("snapshot_id", vm_string(&fixture.scope)),
     ]))
     .unwrap();
     let restored_paths = match dict_get(&restored, "restored_paths") {
@@ -113,22 +147,16 @@ fn explicit_snapshot_then_restore_through_builtins() {
 
 #[test]
 fn auto_on_write_captures_pre_image_via_tools_write_file() {
-    let _guard = test_guard();
-    harn_hostlib::fs_snapshot::reset_for_test();
-    agent_sessions::reset_session_store();
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("auto.txt");
     fs::write(&file, b"pre").unwrap();
-    let session = unique("snap-auto");
-    agent_sessions::open_or_create(Some(session.clone()));
-    let _session_guard = agent_sessions::enter_current_session(session.clone());
-    let _tool_guard = agent_sessions::enter_current_tool_call("tc-auto");
+    let fixture = Fixture::new("snap-auto", true);
     let reg = registry();
 
     // Register an open snapshot. No paths provided so capture is lazy.
     (reg.find("hostlib_fs_snapshot").unwrap().handler)(&dict_arg(&[
-        ("session_id", vm_string(&session)),
-        ("scope_id", vm_string("tc-auto")),
+        ("session_id", vm_string(&fixture.session)),
+        ("scope_id", vm_string(&fixture.scope)),
         ("root", vm_string(&path_str(dir.path()))),
     ]))
     .unwrap();
@@ -141,10 +169,10 @@ fn auto_on_write_captures_pre_image_via_tools_write_file() {
     .unwrap();
     assert_eq!(fs::read(&file).unwrap(), b"post");
 
-    // Restore the snapshot and confirm the byte-for-byte pre-image is back.
+    // Restore and confirm the byte-for-byte pre-image is back.
     (reg.find("hostlib_fs_restore").unwrap().handler)(&dict_arg(&[
-        ("session_id", vm_string(&session)),
-        ("snapshot_id", vm_string("tc-auto")),
+        ("session_id", vm_string(&fixture.session)),
+        ("snapshot_id", vm_string(&fixture.scope)),
     ]))
     .unwrap();
     assert_eq!(fs::read(&file).unwrap(), b"pre");
@@ -152,21 +180,15 @@ fn auto_on_write_captures_pre_image_via_tools_write_file() {
 
 #[test]
 fn auto_on_write_captures_delete_so_restore_reinstates_file() {
-    let _guard = test_guard();
-    harn_hostlib::fs_snapshot::reset_for_test();
-    agent_sessions::reset_session_store();
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("victim.txt");
     fs::write(&file, b"important").unwrap();
-    let session = unique("snap-delete");
-    agent_sessions::open_or_create(Some(session.clone()));
-    let _session_guard = agent_sessions::enter_current_session(session.clone());
-    let _tool_guard = agent_sessions::enter_current_tool_call("tc-delete");
+    let fixture = Fixture::new("snap-delete", true);
     let reg = registry();
 
     (reg.find("hostlib_fs_snapshot").unwrap().handler)(&dict_arg(&[
-        ("session_id", vm_string(&session)),
-        ("scope_id", vm_string("tc-delete")),
+        ("session_id", vm_string(&fixture.session)),
+        ("scope_id", vm_string(&fixture.scope)),
         ("root", vm_string(&path_str(dir.path()))),
     ]))
     .unwrap();
@@ -179,8 +201,8 @@ fn auto_on_write_captures_delete_so_restore_reinstates_file() {
     assert!(!file.exists());
 
     (reg.find("hostlib_fs_restore").unwrap().handler)(&dict_arg(&[
-        ("session_id", vm_string(&session)),
-        ("snapshot_id", vm_string("tc-delete")),
+        ("session_id", vm_string(&fixture.session)),
+        ("snapshot_id", vm_string(&fixture.scope)),
     ]))
     .unwrap();
     assert_eq!(fs::read(&file).unwrap(), b"important");
@@ -188,20 +210,15 @@ fn auto_on_write_captures_delete_so_restore_reinstates_file() {
 
 #[test]
 fn list_and_drop_remove_snapshot_state_through_builtins() {
-    let _guard = test_guard();
-    harn_hostlib::fs_snapshot::reset_for_test();
-    agent_sessions::reset_session_store();
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("listed.txt");
     fs::write(&file, b"abcd").unwrap();
-    let session = unique("snap-list");
-    agent_sessions::open_or_create(Some(session.clone()));
-    let _session_guard = agent_sessions::enter_current_session(session.clone());
+    let fixture = Fixture::new("snap-list", false);
     let reg = registry();
 
     (reg.find("hostlib_fs_snapshot").unwrap().handler)(&dict_arg(&[
-        ("session_id", vm_string(&session)),
-        ("scope_id", vm_string("tc-list")),
+        ("session_id", vm_string(&fixture.session)),
+        ("scope_id", vm_string(&fixture.scope)),
         (
             "paths",
             VmValue::List(Rc::new(vec![vm_string(&path_str(&file))])),
@@ -212,7 +229,7 @@ fn list_and_drop_remove_snapshot_state_through_builtins() {
 
     let listed = (reg.find("hostlib_fs_list_snapshots").unwrap().handler)(&dict_arg(&[(
         "session_id",
-        vm_string(&session),
+        vm_string(&fixture.session),
     )]))
     .unwrap();
     let count = match dict_get(&listed, "snapshots") {
@@ -222,14 +239,14 @@ fn list_and_drop_remove_snapshot_state_through_builtins() {
     assert_eq!(count, 1);
 
     let dropped = (reg.find("hostlib_fs_drop_snapshot").unwrap().handler)(&dict_arg(&[
-        ("session_id", vm_string(&session)),
-        ("snapshot_id", vm_string("tc-list")),
+        ("session_id", vm_string(&fixture.session)),
+        ("snapshot_id", vm_string(&fixture.scope)),
     ]))
     .unwrap();
     assert!(matches!(dict_get(&dropped, "dropped"), VmValue::Bool(true)));
     let listed_after = (reg.find("hostlib_fs_list_snapshots").unwrap().handler)(&dict_arg(&[(
         "session_id",
-        vm_string(&session),
+        vm_string(&fixture.session),
     )]))
     .unwrap();
     assert!(matches!(
@@ -240,14 +257,9 @@ fn list_and_drop_remove_snapshot_state_through_builtins() {
 
 #[test]
 fn auto_on_write_no_ops_when_no_snapshot_is_registered() {
-    let _guard = test_guard();
-    harn_hostlib::fs_snapshot::reset_for_test();
-    agent_sessions::reset_session_store();
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("plain.txt");
-    let session = unique("snap-noop");
-    agent_sessions::open_or_create(Some(session.clone()));
-    let _session_guard = agent_sessions::enter_current_session(session.clone());
+    let fixture = Fixture::new("snap-noop", true);
     let reg = registry();
 
     // No fs_snapshot call — write should be a plain mutation.
@@ -260,7 +272,7 @@ fn auto_on_write_no_ops_when_no_snapshot_is_registered() {
 
     let listed = (reg.find("hostlib_fs_list_snapshots").unwrap().handler)(&dict_arg(&[(
         "session_id",
-        vm_string(&session),
+        vm_string(&fixture.session),
     )]))
     .unwrap();
     assert!(matches!(

--- a/crates/harn-hostlib/tests/registration.rs
+++ b/crates/harn-hostlib/tests/registration.rs
@@ -9,8 +9,8 @@
 
 use harn_hostlib::{
     ast::AstCapability, code_index::CodeIndexCapability, fs::FsCapability,
-    fs_watch::FsWatchCapability, scanner::ScannerCapability, schemas,
-    secret_store::SecretStoreCapability, tools::ToolsCapability, BuiltinRegistry,
+    fs_snapshot::FsSnapshotCapability, fs_watch::FsWatchCapability, scanner::ScannerCapability,
+    schemas, secret_store::SecretStoreCapability, tools::ToolsCapability, BuiltinRegistry,
     HostlibCapability, HostlibError, HostlibRegistry,
 };
 
@@ -189,6 +189,38 @@ fn fs_capability_registers_documented_methods() {
 }
 
 #[test]
+fn fs_snapshot_capability_registers_documented_methods() {
+    let registry = collect_into_registry(FsSnapshotCapability);
+    let names: Vec<_> = registry.iter().map(|b| b.name).collect();
+    assert_eq!(
+        names,
+        vec![
+            "hostlib_fs_snapshot",
+            "hostlib_fs_restore",
+            "hostlib_fs_list_snapshots",
+            "hostlib_fs_drop_snapshot",
+        ]
+    );
+    let expected_missing: &[(&str, &str)] = &[
+        ("hostlib_fs_snapshot", "session_id"),
+        ("hostlib_fs_restore", "session_id"),
+        ("hostlib_fs_list_snapshots", "session_id"),
+        ("hostlib_fs_drop_snapshot", "session_id"),
+    ];
+    for (name, expected_param) in expected_missing {
+        let entry = registry.find(name).expect("registered");
+        let err = (entry.handler)(&[]).expect_err("must reject empty args");
+        match err {
+            HostlibError::MissingParameter { builtin, param } => {
+                assert_eq!(builtin, *name);
+                assert_eq!(param, *expected_param);
+            }
+            other => panic!("expected MissingParameter for {name}, got {other:?}"),
+        }
+    }
+}
+
+#[test]
 fn fs_watch_capability_registers_documented_methods() {
     let registry = collect_into_registry(FsWatchCapability);
     let names: Vec<_> = registry.iter().map(|b| b.name).collect();
@@ -319,14 +351,15 @@ fn install_default_wires_every_module_into_a_vm() {
             "code_index",
             "scanner",
             "fs",
+            "fs",
             "fs_watch",
             "tools",
             "secret_store"
         ]
     );
-    // Builtin count: 12 ast + 27 code_index + 2 scanner + 4 fs + 2
-    // fs_watch + 13 tools + 1 hostlib_enable + 4 secret_store = 65.
-    assert!(registry.builtins().len() >= 65);
+    // Builtin count: 12 ast + 27 code_index + 2 scanner + 4 fs + 4 fs_snapshot
+    // + 2 fs_watch + 13 tools + 1 hostlib_enable + 4 secret_store = 69.
+    assert!(registry.builtins().len() >= 69);
 }
 
 #[test]
@@ -336,6 +369,7 @@ fn every_registered_builtin_has_request_and_response_schemas() {
         .with(CodeIndexCapability::new())
         .with(ScannerCapability)
         .with(FsCapability)
+        .with(FsSnapshotCapability)
         .with(FsWatchCapability)
         .with(ToolsCapability)
         .with(SecretStoreCapability);

--- a/crates/harn-hostlib/tests/smoke_harn_script.rs
+++ b/crates/harn-hostlib/tests/smoke_harn_script.rs
@@ -226,17 +226,14 @@ return {{
 
 #[test]
 fn end_to_end_fs_snapshot_and_auto_restore_via_harn_script() {
-    use std::sync::{Mutex, OnceLock};
-    static GUARD: OnceLock<Mutex<()>> = OnceLock::new();
-    let _serialize = GUARD
-        .get_or_init(|| Mutex::new(()))
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let session = format!("smoke-snapshot-session-{}-{}", std::process::id(), n);
+    let scope = format!("smoke-tc-{n}");
     permissions::reset();
-    harn_hostlib::fs_snapshot::reset_for_test();
-    harn_vm::agent_sessions::reset_session_store();
-    let _session_guard = harn_vm::agent_sessions::enter_current_session("smoke-snapshot-session");
-    let _tool_guard = harn_vm::agent_sessions::enter_current_tool_call("smoke-tc");
+    let _session_guard = harn_vm::agent_sessions::enter_current_session(session.clone());
+    let _tool_guard = harn_vm::agent_sessions::enter_current_tool_call(scope.clone());
 
     let dir = TempDir::new().unwrap();
     let root = dir.path();
@@ -245,8 +242,6 @@ fn end_to_end_fs_snapshot_and_auto_restore_via_harn_script() {
 
     let root_str = root.to_string_lossy().replace('\\', "/");
     let target = format!("{}/target.txt", root_str);
-    let session = "smoke-snapshot-session";
-    let scope = "smoke-tc";
 
     // The script opens an auto-on-write snapshot keyed by the tool-call id,
     // performs a destructive `hostlib_tools_write_file`, then asks

--- a/crates/harn-hostlib/tests/smoke_harn_script.rs
+++ b/crates/harn-hostlib/tests/smoke_harn_script.rs
@@ -225,6 +225,85 @@ return {{
 }
 
 #[test]
+fn end_to_end_fs_snapshot_and_auto_restore_via_harn_script() {
+    use std::sync::{Mutex, OnceLock};
+    static GUARD: OnceLock<Mutex<()>> = OnceLock::new();
+    let _serialize = GUARD
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    permissions::reset();
+    harn_hostlib::fs_snapshot::reset_for_test();
+    harn_vm::agent_sessions::reset_session_store();
+    let _session_guard = harn_vm::agent_sessions::enter_current_session("smoke-snapshot-session");
+    let _tool_guard = harn_vm::agent_sessions::enter_current_tool_call("smoke-tc");
+
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    let original = "original-bytes";
+    fs::write(root.join("target.txt"), original).unwrap();
+
+    let root_str = root.to_string_lossy().replace('\\', "/");
+    let target = format!("{}/target.txt", root_str);
+    let session = "smoke-snapshot-session";
+    let scope = "smoke-tc";
+
+    // The script opens an auto-on-write snapshot keyed by the tool-call id,
+    // performs a destructive `hostlib_tools_write_file`, then asks
+    // `hostlib_fs_restore` to roll the workspace back to the pre-image.
+    let source = format!(
+        r#"
+let _enable = hostlib_enable("tools:deterministic")
+let snap = hostlib_fs_snapshot({{
+    session_id: "{session}",
+    scope_id: "{scope}",
+    root: "{root}",
+}})
+let _wrote = hostlib_tools_write_file({{ path: "{target}", content: "clobbered" }})
+let before_restore = hostlib_tools_read_file({{ path: "{target}" }})
+let restored = hostlib_fs_restore({{
+    session_id: "{session}",
+    snapshot_id: "{scope}",
+}})
+let after_restore = hostlib_tools_read_file({{ path: "{target}" }})
+let listed = hostlib_fs_list_snapshots({{ session_id: "{session}" }})
+let _dropped = hostlib_fs_drop_snapshot({{
+    session_id: "{session}",
+    snapshot_id: "{scope}",
+}})
+let listed_after = hostlib_fs_list_snapshots({{ session_id: "{session}" }})
+
+return {{
+    snapshot_id: snap.snapshot_id,
+    before_restore: before_restore.content,
+    restored_count: len(restored.restored_paths),
+    after_restore: after_restore.content,
+    listed_count: len(listed.snapshots),
+    listed_after_count: len(listed_after.snapshots),
+}}
+"#,
+        root = root_str,
+        target = target,
+        session = session,
+        scope = scope,
+    );
+
+    let (result, _) = run_harn(&source);
+    let dict = match &result {
+        VmValue::Dict(d) => d,
+        other => panic!("expected dict, got {other:?}"),
+    };
+    let get = |k: &str| dict.get(k).unwrap_or_else(|| panic!("missing {k}"));
+
+    assert!(matches!(get("snapshot_id"), VmValue::String(s) if s.as_ref() == scope));
+    assert!(matches!(get("before_restore"), VmValue::String(s) if s.as_ref() == "clobbered"));
+    assert!(matches!(get("restored_count"), VmValue::Int(1)));
+    assert!(matches!(get("after_restore"), VmValue::String(s) if s.as_ref() == original));
+    assert!(matches!(get("listed_count"), VmValue::Int(1)));
+    assert!(matches!(get("listed_after_count"), VmValue::Int(0)));
+}
+
+#[test]
 fn end_to_end_code_index_via_harn_script() {
     let dir = TempDir::new().unwrap();
     let root = dir.path();

--- a/crates/harn-serve/src/adapters/acp/mod.rs
+++ b/crates/harn-serve/src/adapters/acp/mod.rs
@@ -1782,6 +1782,118 @@ impl AcpServer {
         );
     }
 
+    #[cfg(feature = "hostlib")]
+    fn handle_session_restore_tool_call(
+        &mut self,
+        id: &serde_json::Value,
+        params: &serde_json::Value,
+    ) {
+        let Some(session_id) = params
+            .get("sessionId")
+            .or_else(|| params.get("session_id"))
+            .and_then(serde_json::Value::as_str)
+        else {
+            self.send_error(id, -32602, "session/restore_tool_call requires sessionId");
+            return;
+        };
+        let Some(tool_call_id) = params
+            .get("toolCallId")
+            .or_else(|| params.get("tool_call_id"))
+            .and_then(serde_json::Value::as_str)
+        else {
+            self.send_error(id, -32602, "session/restore_tool_call requires toolCallId");
+            return;
+        };
+        if !self.sessions.contains_key(session_id) {
+            self.send_error(id, -32602, &format!("Unknown session: {session_id}"));
+            return;
+        }
+        let paths = params
+            .get("paths")
+            .and_then(serde_json::Value::as_array)
+            .map(|values| {
+                values
+                    .iter()
+                    .filter_map(serde_json::Value::as_str)
+                    .map(str::to_string)
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        match harn_hostlib::fs_snapshot::restore(session_id, tool_call_id, &paths) {
+            Ok(result) => {
+                self.send_response(
+                    id,
+                    serde_json::json!({
+                        "toolCallId": &result.snapshot_id,
+                        "restoredPaths": &result.restored_paths,
+                        "skippedPathsWithReasons": result
+                            .skipped_paths_with_reasons
+                            .iter()
+                            .map(|(path, reason)| serde_json::json!({
+                                "path": path,
+                                "reason": reason,
+                            }))
+                            .collect::<Vec<_>>(),
+                    }),
+                );
+                let mut update = serde_json::json!({
+                    "sessionUpdate": "tool_call_update",
+                    "toolCallId": &result.snapshot_id,
+                    "status": "restored",
+                });
+                let mut harn_meta = serde_json::Map::new();
+                harn_meta.insert(
+                    "kind".to_string(),
+                    serde_json::Value::String("tool_call_restored".to_string()),
+                );
+                harn_meta.insert(
+                    "restoredPaths".to_string(),
+                    serde_json::to_value(&result.restored_paths).unwrap_or_default(),
+                );
+                if !result.skipped_paths_with_reasons.is_empty() {
+                    harn_meta.insert(
+                        "skippedPathsWithReasons".to_string(),
+                        serde_json::to_value(
+                            result
+                                .skipped_paths_with_reasons
+                                .iter()
+                                .map(|(path, reason)| {
+                                    serde_json::json!({
+                                        "path": path,
+                                        "reason": reason,
+                                    })
+                                })
+                                .collect::<Vec<_>>(),
+                        )
+                        .unwrap_or_default(),
+                    );
+                }
+                events::merge_harn_meta(&mut update, harn_meta);
+                self.send_notification(
+                    "session/update",
+                    serde_json::json!({
+                        "sessionId": session_id,
+                        "update": update,
+                    }),
+                );
+            }
+            Err(error) => self.send_error(id, -32000, &error.to_string()),
+        }
+    }
+
+    #[cfg(not(feature = "hostlib"))]
+    fn handle_session_restore_tool_call(
+        &mut self,
+        id: &serde_json::Value,
+        _params: &serde_json::Value,
+    ) {
+        self.send_error(
+            id,
+            -32601,
+            "session/restore_tool_call requires the hostlib feature",
+        );
+    }
+
     fn handle_session_set_mode(&mut self, id: &serde_json::Value, params: &serde_json::Value) {
         let Some(session_id) = params
             .get("sessionId")
@@ -1983,6 +2095,12 @@ impl AcpServer {
                     return;
                 }
                 self.handle_session_fs_commit_staged(&id, &params);
+            }
+            "session/restore_tool_call" => {
+                if self.reject_unauthenticated(&id) {
+                    return;
+                }
+                self.handle_session_restore_tool_call(&id, &params);
             }
             "session/prompt" => {
                 if self.reject_unauthenticated(&id) {

--- a/crates/harn-serve/src/adapters/acp/mod.rs
+++ b/crates/harn-serve/src/adapters/acp/mod.rs
@@ -1235,6 +1235,10 @@ impl AcpServer {
             .unwrap_or_else(|error| error.into_inner())
             .remove(session_id);
         clear_session_sinks(session_id);
+        #[cfg(feature = "hostlib")]
+        {
+            harn_hostlib::fs_snapshot::drop_session_snapshots(session_id);
+        }
         harn_vm::agent_sessions::close_with_status(
             session_id,
             "client_request",

--- a/crates/harn-serve/src/adapters/acp/schema.rs
+++ b/crates/harn-serve/src/adapters/acp/schema.rs
@@ -179,6 +179,7 @@ pub(super) fn acp_agent_capabilities() -> serde_json::Value {
             "close": {},
             "list": {},
             "resume": {},
+            "restoreToolCall": {},
         },
     })
 }

--- a/crates/harn-serve/src/adapters/acp/tests.rs
+++ b/crates/harn-serve/src/adapters/acp/tests.rs
@@ -220,6 +220,82 @@ async fn acp_fs_mode_and_commit_staged_apply_deferred_hostlib_writes() {
     );
 }
 
+#[cfg(feature = "hostlib")]
+#[tokio::test(flavor = "current_thread")]
+async fn acp_session_restore_tool_call_restores_pre_image_and_emits_update() {
+    use harn_hostlib::tools::permissions;
+
+    permissions::reset();
+    permissions::enable_for_test();
+    harn_hostlib::fs_snapshot::reset_for_test();
+    harn_vm::agent_sessions::reset_session_store();
+
+    let dir = tempfile::TempDir::new().unwrap();
+    let file = dir.path().join("subject.txt");
+    std::fs::write(&file, b"pre").unwrap();
+
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let mut server = AcpServer::new_with_output(AcpServerConfig::new(None), AcpOutput::Channel(tx));
+
+    server
+        .handle_incoming_message(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "session/new",
+            "params": {"cwd": dir.path().to_string_lossy()},
+        }))
+        .await;
+    let created = recv_json(&mut rx).await;
+    let session_id = created["result"]["sessionId"]
+        .as_str()
+        .expect("session id")
+        .to_string();
+
+    // Take an explicit snapshot keyed by the synthetic tool-call id.
+    let snapshot = harn_hostlib::fs_snapshot::snapshot(
+        &session_id,
+        "tc-acp-restore",
+        &[file.to_string_lossy().into_owned()],
+        Some(dir.path()),
+    )
+    .expect("snapshot");
+    assert_eq!(snapshot.captured_paths.len(), 1);
+
+    // Clobber the on-disk file, then ask ACP to restore the tool call.
+    std::fs::write(&file, b"clobbered").unwrap();
+
+    server
+        .handle_incoming_message(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "session/restore_tool_call",
+            "params": {
+                "sessionId": session_id.clone(),
+                "toolCallId": "tc-acp-restore",
+            },
+        }))
+        .await;
+    let response = recv_json(&mut rx).await;
+    assert_eq!(response["result"]["toolCallId"], "tc-acp-restore");
+    let restored = response["result"]["restoredPaths"].as_array().unwrap();
+    assert_eq!(restored.len(), 1);
+
+    let update = recv_json(&mut rx).await;
+    assert_eq!(update["method"], "session/update");
+    assert_eq!(
+        update["params"]["update"]["sessionUpdate"],
+        "tool_call_update"
+    );
+    assert_eq!(update["params"]["update"]["status"], "restored");
+    assert_eq!(update["params"]["update"]["toolCallId"], "tc-acp-restore");
+    assert_eq!(
+        update["params"]["update"]["_meta"]["harn"]["kind"],
+        "tool_call_restored"
+    );
+
+    assert_eq!(std::fs::read(&file).unwrap(), b"pre");
+}
+
 #[test]
 fn normalize_host_capabilities_wraps_array_entries_in_ops_dicts() {
     let mut root = BTreeMap::new();
@@ -368,6 +444,7 @@ fn acp_agent_capabilities_use_canonical_initialize_shape() {
             "close": {},
             "list": {},
             "resume": {},
+            "restoreToolCall": {},
         })
     );
     assert!(

--- a/crates/harn-serve/src/adapters/acp/tests.rs
+++ b/crates/harn-serve/src/adapters/acp/tests.rs
@@ -225,10 +225,7 @@ async fn acp_fs_mode_and_commit_staged_apply_deferred_hostlib_writes() {
 async fn acp_session_restore_tool_call_restores_pre_image_and_emits_update() {
     use harn_hostlib::tools::permissions;
 
-    permissions::reset();
     permissions::enable_for_test();
-    harn_hostlib::fs_snapshot::reset_for_test();
-    harn_vm::agent_sessions::reset_session_store();
 
     let dir = tempfile::TempDir::new().unwrap();
     let file = dir.path().join("subject.txt");
@@ -251,10 +248,18 @@ async fn acp_session_restore_tool_call_restores_pre_image_and_emits_update() {
         .expect("session id")
         .to_string();
 
-    // Take an explicit snapshot keyed by the synthetic tool-call id.
+    // session/new returns a fresh UUID per call so this test's snapshot
+    // bundle cannot collide with another test running in the same
+    // process. Synthesize a unique tool-call id to match.
+    let tool_call_id = format!(
+        "tc-acp-restore-{}-{}",
+        std::process::id(),
+        ACP_RESTORE_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
+    );
+
     let snapshot = harn_hostlib::fs_snapshot::snapshot(
         &session_id,
-        "tc-acp-restore",
+        &tool_call_id,
         &[file.to_string_lossy().into_owned()],
         Some(dir.path()),
     )
@@ -271,12 +276,12 @@ async fn acp_session_restore_tool_call_restores_pre_image_and_emits_update() {
             "method": "session/restore_tool_call",
             "params": {
                 "sessionId": session_id.clone(),
-                "toolCallId": "tc-acp-restore",
+                "toolCallId": tool_call_id.clone(),
             },
         }))
         .await;
     let response = recv_json(&mut rx).await;
-    assert_eq!(response["result"]["toolCallId"], "tc-acp-restore");
+    assert_eq!(response["result"]["toolCallId"], tool_call_id);
     let restored = response["result"]["restoredPaths"].as_array().unwrap();
     assert_eq!(restored.len(), 1);
 
@@ -287,14 +292,19 @@ async fn acp_session_restore_tool_call_restores_pre_image_and_emits_update() {
         "tool_call_update"
     );
     assert_eq!(update["params"]["update"]["status"], "restored");
-    assert_eq!(update["params"]["update"]["toolCallId"], "tc-acp-restore");
+    assert_eq!(update["params"]["update"]["toolCallId"], tool_call_id);
     assert_eq!(
         update["params"]["update"]["_meta"]["harn"]["kind"],
         "tool_call_restored"
     );
 
     assert_eq!(std::fs::read(&file).unwrap(), b"pre");
+
+    harn_hostlib::fs_snapshot::drop_session_snapshots(&session_id);
 }
+
+#[cfg(feature = "hostlib")]
+static ACP_RESTORE_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
 #[test]
 fn normalize_host_capabilities_wraps_array_entries_in_ops_dicts() {

--- a/crates/harn-serve/src/adapters/acp/tests/sessions.rs
+++ b/crates/harn-serve/src/adapters/acp/tests/sessions.rs
@@ -148,6 +148,7 @@ async fn acp_server_handles_session_flow_and_prompt_updates() {
                     "close": {},
                     "list": {},
                     "resume": {},
+                    "restoreToolCall": {},
                 })
             );
             assert!(

--- a/crates/harn-vm/src/agent_sessions.rs
+++ b/crates/harn-vm/src/agent_sessions.rs
@@ -99,6 +99,7 @@ thread_local! {
     static SESSIONS: RefCell<HashMap<String, SessionState>> = RefCell::new(HashMap::new());
     static SESSION_CAP: Cell<usize> = const { Cell::new(DEFAULT_SESSION_CAP) };
     static CURRENT_SESSION_STACK: RefCell<Vec<String>> = const { RefCell::new(Vec::new()) };
+    static CURRENT_TOOL_CALL_STACK: RefCell<Vec<String>> = const { RefCell::new(Vec::new()) };
 }
 
 pub struct CurrentSessionGuard {
@@ -109,6 +110,23 @@ impl Drop for CurrentSessionGuard {
     fn drop(&mut self) {
         if self.active {
             pop_current_session();
+        }
+    }
+}
+
+/// RAII guard that scopes the active tool-call id for the running thread.
+///
+/// Set on entry to a tool dispatch and dropped on exit, so any hostlib
+/// builtin invoked under it (e.g. `tools/write_file`) can resolve the
+/// owning tool call without threading the id through every parameter.
+pub struct CurrentToolCallGuard {
+    active: bool,
+}
+
+impl Drop for CurrentToolCallGuard {
+    fn drop(&mut self) {
+        if self.active {
+            pop_current_tool_call();
         }
     }
 }
@@ -127,6 +145,7 @@ pub fn session_cap() -> usize {
 pub fn reset_session_store() {
     SESSIONS.with(|s| s.borrow_mut().clear());
     CURRENT_SESSION_STACK.with(|stack| stack.borrow_mut().clear());
+    CURRENT_TOOL_CALL_STACK.with(|stack| stack.borrow_mut().clear());
 }
 
 pub(crate) fn push_current_session(id: String) {
@@ -153,6 +172,37 @@ pub fn enter_current_session(id: impl Into<String>) -> CurrentSessionGuard {
     }
     push_current_session(id);
     CurrentSessionGuard { active: true }
+}
+
+fn push_current_tool_call(id: String) {
+    if id.is_empty() {
+        return;
+    }
+    CURRENT_TOOL_CALL_STACK.with(|stack| stack.borrow_mut().push(id));
+}
+
+fn pop_current_tool_call() {
+    CURRENT_TOOL_CALL_STACK.with(|stack| {
+        let _ = stack.borrow_mut().pop();
+    });
+}
+
+/// Return the active tool-call id for the current thread, if any.
+///
+/// Hostlib builtins consult this to attribute side-effect snapshots to
+/// the owning ACP `toolCallId` without callers passing it explicitly.
+pub fn current_tool_call_id() -> Option<String> {
+    CURRENT_TOOL_CALL_STACK.with(|stack| stack.borrow().last().cloned())
+}
+
+/// Scope the active tool-call id for the duration of the returned guard.
+pub fn enter_current_tool_call(id: impl Into<String>) -> CurrentToolCallGuard {
+    let id = id.into();
+    if id.trim().is_empty() {
+        return CurrentToolCallGuard { active: false };
+    }
+    push_current_tool_call(id);
+    CurrentToolCallGuard { active: true }
 }
 
 pub fn exists(id: &str) -> bool {

--- a/crates/harn-vm/src/llm/agent_host_primitives.rs
+++ b/crates/harn-vm/src/llm/agent_host_primitives.rs
@@ -670,6 +670,10 @@ async fn host_agent_dispatch_tool_call(
     } else {
         Some(&session_mcp)
     };
+    // Scope the active tool-call id so synchronous hostlib mutations
+    // triggered by the tool handler attribute their FS pre-images to this
+    // call. Empty tool ids are silently ignored by the guard.
+    let _tool_call_guard = crate::agent_sessions::enter_current_tool_call(tool_id.clone());
     let outcome = agent_tools::dispatch_tool_execution_with_mcp(
         &tool_name,
         &tool_args,

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -182,6 +182,7 @@
 - [Testing](./testing.md)
 - [Secret store (hostlib)](./hostlib/secret_store.md)
 - [Staged filesystem (hostlib)](./hostlib/staged-fs.md)
+- [Per-tool-call FS snapshots (hostlib)](./hostlib/fs-snapshot.md)
 
 # Migrations
 

--- a/docs/src/hostlib/fs-snapshot.md
+++ b/docs/src/hostlib/fs-snapshot.md
@@ -50,10 +50,13 @@ Snapshot manifests record the snapshot id, originating scope id,
 capture timestamp, workspace root, and per-path entries. File bodies
 are content-addressed by SHA-256.
 
-When a session bundle exceeds the configurable byte cap
+When a session bundle exceeds the per-session byte cap
 (`harn_hostlib::fs_snapshot::DEFAULT_SESSION_BYTE_CAP`, 1 GiB) the
 oldest snapshots are evicted in insertion order. Embedders can override
-the cap with `harn_hostlib::fs_snapshot::set_session_byte_cap`.
+the cap per session with
+`harn_hostlib::fs_snapshot::configure_session_byte_cap`. The ACP server
+also calls `harn_hostlib::fs_snapshot::drop_session_snapshots` on
+`session/close` so closed sessions never leak their snapshot bundles.
 
 Snapshots are session-scoped and ephemeral. Durable rollback across
 process restarts is out of scope; consumers that need it bundle the

--- a/docs/src/hostlib/fs-snapshot.md
+++ b/docs/src/hostlib/fs-snapshot.md
@@ -1,0 +1,109 @@
+# Per-tool-call filesystem snapshots (hostlib)
+
+`harn-hostlib` ships a Gemini-style `/restore` primitive paralleling the
+[staged filesystem mode](staged-fs.md): a snapshot captures the
+pre-image of paths a single mutating tool call is about to touch, so a
+client can surgically roll the change back without affecting untracked
+work.
+
+The capability is registered by `harn_hostlib::install_default` as part
+of the `fs` module:
+
+| Method | Result |
+|--------|--------|
+| `hostlib_fs_snapshot` | Register (and optionally pre-capture paths for) a snapshot keyed by `scope_id` — canonically the ACP `toolCallId`. |
+| `hostlib_fs_restore` | Write the captured pre-image back onto disk; delete paths the snapshot saw as absent. |
+| `hostlib_fs_list_snapshots` | List the snapshots registered for a session, sorted by capture time. |
+| `hostlib_fs_drop_snapshot` | Remove a snapshot's in-memory and on-disk state. |
+
+## Capture modes
+
+**Explicit.** Pass a `paths` list to `hostlib_fs_snapshot`; the bytes
+are copied into the snapshot immediately:
+
+```text
+hostlib_fs_snapshot({
+  session_id: "sess_abc",
+  scope_id: "tc_42",
+  paths: ["/work/src/lib.rs"],
+})
+```
+
+**Auto-on-write.** Omit `paths` and the snapshot is "open" — the
+mutating tool builtins (`hostlib_tools_write_file`,
+`hostlib_tools_delete_file`) lazy-capture each path's pre-image into
+the active open snapshot bound to the current
+`harn_vm::agent_sessions::current_tool_call_id`. The agent loop sets
+that thread-local automatically when it dispatches a tool call, so a
+single `hostlib_fs_snapshot({session_id, scope_id})` registration is
+enough to roll the next mutation back.
+
+## Storage layout
+
+```text
+<workspace>/.harn/state/snapshots/<session_id>/<snapshot_id>/
+  manifest.json     # path -> { kind: "file" | "absent", body_hash?, mode? }
+  bodies/<sha256>   # content-addressed; deduped across snapshots
+```
+
+Snapshot manifests record the snapshot id, originating scope id,
+capture timestamp, workspace root, and per-path entries. File bodies
+are content-addressed by SHA-256.
+
+When a session bundle exceeds the configurable byte cap
+(`harn_hostlib::fs_snapshot::DEFAULT_SESSION_BYTE_CAP`, 1 GiB) the
+oldest snapshots are evicted in insertion order. Embedders can override
+the cap with `harn_hostlib::fs_snapshot::set_session_byte_cap`.
+
+Snapshots are session-scoped and ephemeral. Durable rollback across
+process restarts is out of scope; consumers that need it bundle the
+relevant state into a session via `session/load`.
+
+## ACP surface
+
+The ACP adapter advertises the primitive in the `initialize` response
+under `agentCapabilities.sessionCapabilities`:
+
+```jsonc
+{
+  "sessionCapabilities": {
+    "close": {},
+    "list": {},
+    "resume": {},
+    "restoreToolCall": {}
+  }
+}
+```
+
+Clients drive a restore with:
+
+```jsonc
+{
+  "method": "session/restore_tool_call",
+  "params": {
+    "sessionId": "sess_abc",
+    "toolCallId": "tc_42"
+  }
+}
+```
+
+The server routes the call through `harn_hostlib::fs_snapshot::restore`
+and emits a canonical `session/update` carrying the restored paths and
+a `_meta.harn.kind = "tool_call_restored"` discriminator:
+
+```jsonc
+{
+  "sessionId": "sess_abc",
+  "update": {
+    "sessionUpdate": "tool_call_update",
+    "toolCallId": "tc_42",
+    "status": "restored",
+    "_meta": {
+      "harn": {
+        "kind": "tool_call_restored",
+        "restoredPaths": ["/work/src/lib.rs"]
+      }
+    }
+  }
+}
+```


### PR DESCRIPTION
## Summary

Closes #1720. Lands the Gemini-style `/restore` primitives proposed in
the issue:

- **Hostlib builtins.** `hostlib_fs_snapshot`, `hostlib_fs_restore`,
  `hostlib_fs_list_snapshots`, and `hostlib_fs_drop_snapshot` under
  the existing `fs/` schema bucket. Snapshots are keyed by the
  caller-supplied `scope_id` (canonically the ACP `toolCallId`) and
  stored content-addressed under
  `.harn/state/snapshots/<session>/<scope>/`.
- **Auto-on-write hook.** `tools/write_file` and `tools/delete_file`
  lazy-capture pre-images into the open snapshot whose id matches
  the current `harn_vm::agent_sessions::current_tool_call_id`. The
  agent loop sets that thread-local around tool dispatch, so a single
  `hostlib_fs_snapshot({session_id, scope_id})` registration is enough
  to roll the next mutation back.
- **Per-session byte cap.** Default 1 GiB; oldest snapshots evict
  insertion-order. Overridable via
  `harn_hostlib::fs_snapshot::set_session_byte_cap` for tests.
- **ACP capability + method.** The ACP server advertises
  `{ sessionCapabilities: { restoreToolCall: {} } }` in the
  initialize response and exposes a new `session/restore_tool_call`
  method backed by `fs_snapshot::restore`. Each restore emits a
  canonical `session/update` with
  `sessionUpdate: \"tool_call_update\"`, `status: \"restored\"`, and
  `_meta.harn.kind = \"tool_call_restored\"`.

The trust-boundary stays clean: snapshot bytes live in hostlib (binary
work, on-disk dedup) while ACP owns lifecycle and notification
plumbing. The ACP surface mirrors the existing `session/fs_mode` /
`session/fs_commit_staged` shape from #1722 so consumers learn one
pattern.

## Test plan
- [x] Unit tests in `crates/harn-hostlib/src/fs_snapshot.rs` (round-trip,
      delete-restore, absent-restore, list/drop, auto-capture keyed by
      `current_tool_call_id`, byte-cap eviction).
- [x] Integration tests in `crates/harn-hostlib/tests/fs_snapshot.rs`
      drive the builtins through their JSON surface, including
      auto-capture from `tools/write_file` and `tools/delete_file`.
- [x] End-to-end Harn-script test in
      `crates/harn-hostlib/tests/smoke_harn_script.rs` exercises the
      full lexer + parser + compiler + VM pipeline.
- [x] ACP integration test
      (`acp_session_restore_tool_call_restores_pre_image_and_emits_update`)
      drives `session/restore_tool_call` through `AcpServer` and
      asserts the restored bytes plus the `tool_call_restored`
      session/update.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all` clean.
- [x] Existing `acp_server_handles_session_flow_and_prompt_updates`,
      `acp_agent_capabilities_use_canonical_initialize_shape`,
      `acp_server_cli`, and the orchestrator-listener tests updated to
      assert the new `restoreToolCall: {}` capability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)