### PR TITLE
Add JsonEnvelope foundation + harn --json-schemas catalog (#1754)

### DIFF
--- a/crates/harn-cli/src/cli/mod.rs
+++ b/crates/harn-cli/src/cli/mod.rs
@@ -209,6 +209,22 @@ use clap::{Parser, Subcommand};
     arg_required_else_help = true
 )]
 pub(crate) struct Cli {
+    /// Emit the JSON-schema catalog for every `harn` subcommand that
+    /// exposes a structured `--json` envelope. Pair with
+    /// `--command <name>` to print just one entry.
+    #[arg(long = "json-schemas", global = false)]
+    pub json_schemas: bool,
+
+    /// When combined with `--json-schemas`, restrict the catalog to a
+    /// single command name (e.g. `--command run`).
+    #[arg(
+        long = "command",
+        requires = "json_schemas",
+        value_name = "COMMAND",
+        global = false
+    )]
+    pub schema_command: Option<String>,
+
     #[command(subcommand)]
     pub command: Option<Command>,
 }

--- a/crates/harn-cli/src/commands/json_schemas.rs
+++ b/crates/harn-cli/src/commands/json_schemas.rs
@@ -1,0 +1,79 @@
+//! `harn --json-schemas` — enumerate the JSON contract every
+//! subcommand exposes (or filter to one with `--command <name>`).
+//!
+//! Output is always wrapped in a [`JsonEnvelope`] so the catalog
+//! itself conforms to the contract it advertises.
+
+use std::process;
+
+use crate::json_envelope::{
+    catalog, to_string_pretty, JsonEnvelope, SchemaEntry, CATALOG_SCHEMA_VERSION,
+};
+
+pub(crate) fn run(filter: Option<&str>) {
+    let envelope = build(filter);
+    let ok = envelope.ok;
+    println!("{}", to_string_pretty(&envelope));
+    if !ok {
+        process::exit(1);
+    }
+}
+
+fn build(filter: Option<&str>) -> JsonEnvelope<Vec<SchemaEntry>> {
+    let entries = catalog();
+    match filter {
+        Some(name) => {
+            let matched: Vec<SchemaEntry> =
+                entries.into_iter().filter(|e| e.command == name).collect();
+            if matched.is_empty() {
+                JsonEnvelope::err(
+                    CATALOG_SCHEMA_VERSION,
+                    "schema_not_found",
+                    format!("no JSON schema registered for command '{name}'"),
+                )
+            } else {
+                JsonEnvelope::ok(CATALOG_SCHEMA_VERSION, matched)
+            }
+        }
+        None => JsonEnvelope::ok(CATALOG_SCHEMA_VERSION, entries),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tests::common::json_envelope::assert_envelope;
+
+    #[test]
+    fn unfiltered_catalog_returns_all_entries() {
+        let envelope = build(None);
+        let value = serde_json::to_value(&envelope).unwrap();
+        let data = assert_envelope(&value, CATALOG_SCHEMA_VERSION);
+        let arr = data.as_array().expect("data is an array");
+        assert!(!arr.is_empty(), "catalog must ship with seed entries");
+        assert!(arr.iter().any(|e| e["command"] == "doctor"));
+    }
+
+    #[test]
+    fn known_filter_returns_singleton() {
+        let envelope = build(Some("doctor"));
+        let value = serde_json::to_value(&envelope).unwrap();
+        let data = assert_envelope(&value, CATALOG_SCHEMA_VERSION);
+        let arr = data.as_array().expect("data is an array");
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["command"], "doctor");
+    }
+
+    #[test]
+    fn unknown_filter_returns_error_envelope() {
+        let envelope = build(Some("definitely-not-real"));
+        let value = serde_json::to_value(&envelope).unwrap();
+        assert_eq!(value["schemaVersion"], CATALOG_SCHEMA_VERSION);
+        assert_eq!(value["ok"], false);
+        assert_eq!(value["error"]["code"], "schema_not_found");
+        assert!(value["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("definitely-not-real"));
+    }
+}

--- a/crates/harn-cli/src/commands/mod.rs
+++ b/crates/harn-cli/src/commands/mod.rs
@@ -18,6 +18,7 @@ pub(crate) mod explain;
 pub mod flow;
 pub(crate) mod hardware;
 pub(crate) mod init;
+pub(crate) mod json_schemas;
 pub(crate) mod local;
 pub(crate) mod mcp;
 pub(crate) mod merge_captain;

--- a/crates/harn-cli/src/json_envelope.rs
+++ b/crates/harn-cli/src/json_envelope.rs
@@ -1,0 +1,238 @@
+//! Canonical JSON envelope for `harn` CLI commands.
+//!
+//! Every `--json` mode returns a [`JsonEnvelope<T>`] — a versioned
+//! wrapper that exposes `schemaVersion`, `ok`, and either `data` or
+//! `error`. Soft signals attach as `warnings` so `ok: true` stays
+//! stable as long as the command succeeds.
+//!
+//! Schema versions are per-command and monotonically increasing.
+//! [`catalog`] returns the registry consumed by `harn --json-schemas`.
+//! New commands extend the catalog (and bump their own
+//! [`JsonOutput::SCHEMA_VERSION`]) when their JSON shape changes in a
+//! way agents need to detect.
+//!
+//! See epic #1753 (`--json` everywhere) for the broader contract.
+
+use serde::{Deserialize, Serialize};
+
+/// Schema version of the `harn --json-schemas` catalog itself. Bump
+/// when the shape of [`SchemaEntry`] or the catalog envelope changes.
+pub const CATALOG_SCHEMA_VERSION: u32 = 1;
+
+/// Versioned wrapper for every `--json` CLI output. All five fields
+/// are always serialized so consumers can rely on a flat shape:
+/// missing payloads surface as `null` and the empty `warnings` array
+/// is `[]` rather than absent.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JsonEnvelope<T: Serialize> {
+    #[serde(rename = "schemaVersion")]
+    pub schema_version: u32,
+    pub ok: bool,
+    pub data: Option<T>,
+    pub error: Option<JsonError>,
+    #[serde(default)]
+    pub warnings: Vec<JsonWarning>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JsonError {
+    pub code: String,
+    pub message: String,
+    /// Free-form structured context. `null` when the error has no
+    /// structured payload — the field is always present so consumers
+    /// can read `error.details` without an existence check.
+    #[serde(default)]
+    pub details: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JsonWarning {
+    pub code: String,
+    pub message: String,
+}
+
+/// Implemented by every CLI command that exposes a `--json` mode. The
+/// associated `SCHEMA_VERSION` is also surfaced in [`catalog`] so
+/// agents can negotiate per-command compatibility without parsing
+/// every payload.
+pub trait JsonOutput {
+    const SCHEMA_VERSION: u32;
+    type Data: Serialize;
+    fn into_envelope(self) -> JsonEnvelope<Self::Data>;
+}
+
+impl<T: Serialize> JsonEnvelope<T> {
+    pub fn ok(schema_version: u32, data: T) -> Self {
+        Self {
+            schema_version,
+            ok: true,
+            data: Some(data),
+            error: None,
+            warnings: Vec::new(),
+        }
+    }
+
+    pub fn err(
+        schema_version: u32,
+        code: impl Into<String>,
+        message: impl Into<String>,
+    ) -> JsonEnvelope<T> {
+        Self {
+            schema_version,
+            ok: false,
+            data: None,
+            error: Some(JsonError {
+                code: code.into(),
+                message: message.into(),
+                details: serde_json::Value::Null,
+            }),
+            warnings: Vec::new(),
+        }
+    }
+
+    pub fn with_details(mut self, details: serde_json::Value) -> Self {
+        if let Some(err) = self.error.as_mut() {
+            err.details = details;
+        }
+        self
+    }
+
+    pub fn with_warning(mut self, code: impl Into<String>, message: impl Into<String>) -> Self {
+        self.warnings.push(JsonWarning {
+            code: code.into(),
+            message: message.into(),
+        });
+        self
+    }
+}
+
+/// One row of the `harn --json-schemas` catalog. `schema_json` is
+/// inline when small; richer schemas live behind a future
+/// `schema_url` field documented per-command.
+#[derive(Debug, Clone, Serialize)]
+pub struct SchemaEntry {
+    pub command: &'static str,
+    #[serde(rename = "schemaVersion")]
+    pub schema_version: u32,
+    pub description: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "schemaJson")]
+    pub schema_json: Option<serde_json::Value>,
+}
+
+/// Static catalog of commands that already emit a stable JSON shape.
+///
+/// E2.1 only registers the commands that ship a `schema_version` in
+/// their JSON today (doctor, session export, the provider catalog).
+/// E2.2–E2.6 will add `run`, `test`, `parse`, `tokens`, `graph`, and
+/// `fmt` as they migrate to [`JsonEnvelope`].
+pub fn catalog() -> Vec<SchemaEntry> {
+    vec![
+        SchemaEntry {
+            command: "doctor",
+            schema_version: 1,
+            description: "Diagnose toolchain, providers, MCP, and manifest health.",
+            schema_json: None,
+        },
+        SchemaEntry {
+            command: "session export",
+            schema_version: 1,
+            description: "Portable Harn session bundle export.",
+            schema_json: None,
+        },
+        SchemaEntry {
+            command: "provider-catalog",
+            schema_version: 1,
+            description: "Resolved provider/model catalog snapshot.",
+            schema_json: None,
+        },
+        SchemaEntry {
+            command: "connect status",
+            schema_version: 1,
+            description: "Outbound-connector readiness report.",
+            schema_json: None,
+        },
+        SchemaEntry {
+            command: "connect setup-plan",
+            schema_version: 1,
+            description: "Step-by-step plan to bring a connector online.",
+            schema_json: None,
+        },
+    ]
+}
+
+/// Encode an envelope as JSON. Uses pretty form so humans tailing the
+/// terminal can still read it; agents `jq`-pipe either form.
+pub fn to_string_pretty<T: Serialize>(envelope: &JsonEnvelope<T>) -> String {
+    serde_json::to_string_pretty(envelope).expect("JsonEnvelope serializes")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[derive(Serialize)]
+    struct Payload {
+        value: u32,
+    }
+
+    #[test]
+    fn ok_envelope_round_trips() {
+        let env = JsonEnvelope::ok(7, Payload { value: 42 });
+        let v: serde_json::Value = serde_json::to_value(&env).unwrap();
+        assert_eq!(v["schemaVersion"], 7);
+        assert_eq!(v["ok"], true);
+        assert_eq!(v["data"]["value"], 42);
+        // All envelope fields are always serialized; absent payloads
+        // surface as JSON `null` / `[]`.
+        assert!(v["error"].is_null());
+        assert_eq!(v["warnings"], json!([]));
+    }
+
+    #[test]
+    fn err_envelope_carries_details() {
+        let env: JsonEnvelope<()> = JsonEnvelope::err(2, "io", "disk full")
+            .with_details(json!({ "path": "/var/log/harn" }));
+        let v: serde_json::Value = serde_json::to_value(&env).unwrap();
+        assert_eq!(v["schemaVersion"], 2);
+        assert_eq!(v["ok"], false);
+        assert_eq!(v["error"]["code"], "io");
+        assert_eq!(v["error"]["message"], "disk full");
+        assert_eq!(v["error"]["details"]["path"], "/var/log/harn");
+        assert!(v["data"].is_null());
+    }
+
+    #[test]
+    fn warnings_serialize_when_present() {
+        let env = JsonEnvelope::ok(1, Payload { value: 1 })
+            .with_warning("deprecated.flag", "--format=json is deprecated");
+        let v: serde_json::Value = serde_json::to_value(&env).unwrap();
+        assert_eq!(v["warnings"][0]["code"], "deprecated.flag");
+        assert_eq!(v["warnings"][0]["message"], "--format=json is deprecated");
+    }
+
+    #[test]
+    fn catalog_is_nonempty_and_unique() {
+        let entries = catalog();
+        assert!(!entries.is_empty(), "catalog should ship with E2.1 seeds");
+        let mut commands: Vec<_> = entries.iter().map(|e| e.command).collect();
+        commands.sort();
+        let unique_count = {
+            let mut deduped = commands.clone();
+            deduped.dedup();
+            deduped.len()
+        };
+        assert_eq!(commands.len(), unique_count, "command names must be unique");
+    }
+
+    #[test]
+    fn schema_versions_are_positive() {
+        for entry in catalog() {
+            assert!(
+                entry.schema_version >= 1,
+                "{} should have schemaVersion >= 1",
+                entry.command
+            );
+        }
+    }
+}

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -6,6 +6,7 @@ pub mod commands;
 pub mod config;
 pub mod env_guard;
 pub mod format;
+pub mod json_envelope;
 pub mod package;
 mod provider_bootstrap;
 pub mod skill_loader;
@@ -95,7 +96,20 @@ async fn async_main() {
         }
     };
 
-    match cli.command.expect("clap requires a command") {
+    if cli.json_schemas {
+        commands::json_schemas::run(cli.schema_command.as_deref());
+        return;
+    }
+
+    let Some(subcommand) = cli.command else {
+        // `arg_required_else_help` already shows help when no args are
+        // supplied. We only land here if a top-level flag (e.g. a
+        // future `--version` long flag) parsed without a subcommand.
+        let mut cmd = Cli::command();
+        cmd.print_help().ok();
+        return;
+    };
+    match subcommand {
         Command::Version => print_version(),
         Command::Upgrade(args) => {
             if let Err(error) = commands::upgrade::run(args).await {

--- a/crates/harn-cli/src/tests/common/json_envelope.rs
+++ b/crates/harn-cli/src/tests/common/json_envelope.rs
@@ -1,0 +1,118 @@
+//! Shared assertion helper for [`crate::json_envelope::JsonEnvelope`]
+//! payloads. Lives outside `#[cfg(test)]` so the integration tests in
+//! `crates/harn-cli/tests/` can reuse it alongside unit tests.
+
+use serde_json::Value;
+
+/// Assert that `value` is a well-formed [`JsonEnvelope`] whose
+/// `schemaVersion` matches `expected`. Returns a reference to the
+/// `data` field (or `null` on an error envelope) so callers can chain
+/// downstream assertions.
+///
+/// Panics with a clear message when shape invariants are violated:
+/// missing `schemaVersion`/`ok`, wrong version, or `ok`/`error`
+/// inconsistency.
+pub fn assert_envelope(value: &Value, expected_schema_version: u32) -> &Value {
+    let sv = value
+        .get("schemaVersion")
+        .and_then(Value::as_u64)
+        .unwrap_or_else(|| panic!("envelope missing `schemaVersion`: {value}"));
+    assert_eq!(
+        sv as u32, expected_schema_version,
+        "schemaVersion mismatch (got {sv}, want {expected_schema_version}) for {value}"
+    );
+
+    let ok = value
+        .get("ok")
+        .and_then(Value::as_bool)
+        .unwrap_or_else(|| panic!("envelope missing `ok`: {value}"));
+
+    if ok {
+        assert!(
+            value.get("error").map(Value::is_null).unwrap_or(true),
+            "ok=true but error present: {value}"
+        );
+    } else {
+        let err = value
+            .get("error")
+            .filter(|v| !v.is_null())
+            .unwrap_or_else(|| panic!("ok=false requires `error`: {value}"));
+        assert!(
+            err.get("code")
+                .and_then(Value::as_str)
+                .map(|s| !s.is_empty())
+                .unwrap_or(false),
+            "error.code must be a non-empty string: {value}"
+        );
+        assert!(
+            err.get("message")
+                .and_then(Value::as_str)
+                .map(|s| !s.is_empty())
+                .unwrap_or(false),
+            "error.message must be a non-empty string: {value}"
+        );
+    }
+
+    value.get("data").unwrap_or(&Value::Null)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn accepts_well_formed_ok_envelope() {
+        let v = json!({
+            "schemaVersion": 3,
+            "ok": true,
+            "data": { "value": 1 }
+        });
+        let data = assert_envelope(&v, 3);
+        assert_eq!(data["value"], 1);
+    }
+
+    #[test]
+    fn accepts_well_formed_error_envelope() {
+        let v = json!({
+            "schemaVersion": 1,
+            "ok": false,
+            "error": { "code": "io", "message": "disk full" }
+        });
+        let data = assert_envelope(&v, 1);
+        assert!(data.is_null());
+    }
+
+    #[test]
+    #[should_panic(expected = "schemaVersion mismatch")]
+    fn rejects_version_mismatch() {
+        let v = json!({ "schemaVersion": 1, "ok": true, "data": {} });
+        assert_envelope(&v, 2);
+    }
+
+    #[test]
+    #[should_panic(expected = "envelope missing `ok`")]
+    fn rejects_missing_ok() {
+        let v = json!({ "schemaVersion": 1, "data": {} });
+        assert_envelope(&v, 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "ok=true but error present")]
+    fn rejects_ok_with_error() {
+        let v = json!({
+            "schemaVersion": 1,
+            "ok": true,
+            "data": {},
+            "error": { "code": "x", "message": "y" }
+        });
+        assert_envelope(&v, 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "ok=false requires `error`")]
+    fn rejects_err_without_payload() {
+        let v = json!({ "schemaVersion": 1, "ok": false, "error": null });
+        assert_envelope(&v, 1);
+    }
+}

--- a/crates/harn-cli/src/tests/common/mod.rs
+++ b/crates/harn-cli/src/tests/common/mod.rs
@@ -1,3 +1,4 @@
 pub mod cwd_lock;
 pub mod env_lock;
 pub mod harn_state_lock;
+pub mod json_envelope;

--- a/crates/harn-cli/tests/doctor_cli.rs
+++ b/crates/harn-cli/tests/doctor_cli.rs
@@ -5,6 +5,9 @@
 
 use std::process::Command;
 
+use harn_cli::json_envelope::CATALOG_SCHEMA_VERSION;
+use harn_cli::tests::common::json_envelope::assert_envelope;
+
 fn binary_path() -> std::path::PathBuf {
     // CARGO_BIN_EXE_<name> is set by Cargo for integration tests in the
     // crate that owns the binary.
@@ -90,6 +93,29 @@ fn doctor_json_smoke() {
             "expected check '{id}' in JSON output. Saw: {seen_ids:?}"
         );
     }
+}
+
+/// `doctor` is registered in the top-level `--json-schemas` catalog so
+/// agents can discover the JSON contract before invoking the command.
+/// Exercises the shared [`assert_envelope`] helper against the real
+/// binary — when `harn doctor --json` migrates to a [`JsonEnvelope`]
+/// (Tier-3 ticket), this test stays the catalog's source of truth.
+#[test]
+fn doctor_appears_in_json_schemas_catalog() {
+    let output = Command::new(binary_path())
+        .args(["--json-schemas", "--command", "doctor"])
+        .output()
+        .expect("spawn harn --json-schemas --command doctor");
+    assert!(output.status.success(), "exit={:?}", output.status.code());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("catalog is valid JSON");
+    let data = assert_envelope(&parsed, CATALOG_SCHEMA_VERSION);
+    let entries = data.as_array().expect("data is an array");
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0]["command"], "doctor");
+    assert_eq!(entries[0]["schemaVersion"], 1);
 }
 
 /// Asserts that no check ever surfaces a literal env-var value in `detail`.

--- a/crates/harn-cli/tests/json_schemas_cli.rs
+++ b/crates/harn-cli/tests/json_schemas_cli.rs
@@ -1,0 +1,83 @@
+//! End-to-end smoke for `harn --json-schemas`.
+//!
+//! Spawns the binary so we exercise the real clap parser + envelope
+//! serialization path.
+
+use std::process::Command;
+
+use harn_cli::json_envelope::CATALOG_SCHEMA_VERSION;
+use harn_cli::tests::common::json_envelope::assert_envelope;
+
+fn binary_path() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_BIN_EXE_harn"))
+}
+
+fn parse_stdout(out: &std::process::Output) -> serde_json::Value {
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.trim_start().starts_with('{'),
+        "stdout is not JSON: {stdout}"
+    );
+    serde_json::from_str(stdout.trim()).expect("--json-schemas is valid JSON")
+}
+
+#[test]
+fn json_schemas_lists_all_registered_commands() {
+    let output = Command::new(binary_path())
+        .args(["--json-schemas"])
+        .output()
+        .expect("spawn harn --json-schemas");
+    assert!(output.status.success(), "exit={:?}", output.status.code());
+
+    let parsed = parse_stdout(&output);
+    let data = assert_envelope(&parsed, CATALOG_SCHEMA_VERSION);
+    let entries = data.as_array().expect("data is an array");
+    assert!(!entries.is_empty(), "catalog should not be empty");
+    assert!(
+        entries.iter().any(|e| e["command"] == "doctor"),
+        "doctor should be in the catalog: {entries:?}"
+    );
+    for entry in entries {
+        assert!(
+            entry.get("command").and_then(|v| v.as_str()).is_some(),
+            "entry missing command: {entry}"
+        );
+        let sv = entry
+            .get("schemaVersion")
+            .and_then(|v| v.as_u64())
+            .expect("entry has schemaVersion");
+        assert!(sv >= 1, "schemaVersion must be >= 1: {entry}");
+    }
+}
+
+#[test]
+fn json_schemas_filters_to_single_command() {
+    let output = Command::new(binary_path())
+        .args(["--json-schemas", "--command", "doctor"])
+        .output()
+        .expect("spawn harn --json-schemas --command doctor");
+    assert!(output.status.success(), "exit={:?}", output.status.code());
+
+    let parsed = parse_stdout(&output);
+    let data = assert_envelope(&parsed, CATALOG_SCHEMA_VERSION);
+    let entries = data.as_array().expect("data is an array");
+    assert_eq!(entries.len(), 1, "expected single-entry catalog");
+    assert_eq!(entries[0]["command"], "doctor");
+}
+
+#[test]
+fn json_schemas_unknown_command_returns_error_envelope_and_nonzero_exit() {
+    let output = Command::new(binary_path())
+        .args(["--json-schemas", "--command", "definitely-not-real"])
+        .output()
+        .expect("spawn harn --json-schemas --command <unknown>");
+    assert!(
+        !output.status.success(),
+        "unknown command must exit nonzero"
+    );
+
+    let parsed = parse_stdout(&output);
+    assert_eq!(parsed["schemaVersion"], CATALOG_SCHEMA_VERSION);
+    assert_eq!(parsed["ok"], false);
+    assert_eq!(parsed["error"]["code"], "schema_not_found");
+}


### PR DESCRIPTION
## Summary

E2.1 of the `--json` everywhere epic ([#1753](https://github.com/burin-labs/harn/issues/1753)). Lands the canonical JSON envelope, the `JsonOutput` trait, and a top-level `harn --json-schemas` catalog so subsequent tickets (`run`, `test`, `parse`/`tokens`, `graph`, `fmt`) can plug into the same contract without re-debating shape.

Resolves [#1754](https://github.com/burin-labs/harn/issues/1754).

### What ships

- **`crates/harn-cli/src/json_envelope.rs`** — `JsonEnvelope<T>` (`schemaVersion`, `ok`, `data`, `error`, `warnings`, all five fields always serialized), `JsonError`/`JsonWarning`, builders for `ok` / `err` / `with_details` / `with_warning`, and the `JsonOutput` trait commands will implement as they migrate.
- **Catalog + filter** — `pub fn catalog()` returns the seed `SchemaEntry` list (commands that already emit a stable `schema_version` today: `doctor`, `session export`, `provider-catalog`, `connect status`, `connect setup-plan`). E2.2–E2.6 grow it as they migrate.
- **`harn --json-schemas`** — new top-level flag emits the catalog as a `JsonEnvelope`; pair with `--command <name>` to filter. Unknown commands return an `ok: false` envelope with `error.code = "schema_not_found"` and exit non-zero so agents can detect missing schemas without parsing prose.
- **Shared test helper** — `crates/harn-cli/src/tests/common/json_envelope.rs::assert_envelope` validates envelope invariants in one place (schema version, ok/error coherence, missing-field panics). Used by the new `json_schemas_cli` integration suite *and* by `doctor_cli` (an existing test).

### Sample output

```
$ harn --json-schemas --command doctor
{
  "schemaVersion": 1,
  "ok": true,
  "data": [
    {
      "command": "doctor",
      "schemaVersion": 1,
      "description": "Diagnose toolchain, providers, MCP, and manifest health."
    }
  ],
  "error": null,
  "warnings": []
}
```

### Exit criteria

- [x] `harn --json-schemas | jq '.data | length > 0'` → `true`.
- [x] Shared `assert_envelope` helper used by ≥1 existing command's test (`doctor_cli::doctor_appears_in_json_schemas_catalog`).
- [x] Additive — no existing command's JSON shape changed.

### Backwards compatibility

Purely additive. No existing `--json` callers see a different shape; migration of existing commands stays in E2.2–E2.6 (and a Tier-3 ticket for `doctor`'s overhaul).

## Test plan

- [x] `cargo test -p harn-cli --tests --lib` (576 lib + all integration tests green).
- [x] `cargo run --bin harn -- --json-schemas | jq '.data | length > 0'` → `true`.
- [x] `cargo run --bin harn -- --json-schemas --command doctor` returns a singleton envelope.
- [x] `cargo run --bin harn -- --json-schemas --command nope` returns `ok: false`, `error.code = "schema_not_found"`, exit code 1.
- [x] `cargo run --bin harn -- --help` still lists every existing subcommand and the new `--json-schemas` / `--command` options.
- [x] `cargo fmt --check`, `cargo clippy -p harn-cli --all-targets`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)