### PR TITLE
Add max_concurrent_tools to agent_loop for in-turn parallel dispatch (#1699)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,18 @@ condensed series summaries instead of full per-patch history.
   persona manifest. Opt-in `on_violation: "raise"` throws instead of
   short-circuiting so `try { agent_loop(...) }` can route on the
   exception.
+- **In-turn parallel tool dispatch (#1699).** `agent_loop` now accepts a
+  `max_concurrent_tools: N` option (default 1). When a planner emits
+  multiple tool calls in a single turn and the loop is configured with
+  a `tool_caller` middleware, siblings dispatch concurrently via
+  `parallel settle` capped at `N`. Each sibling invokes its own caller
+  chain in a fresh closure scope so `audit.layers` histories never
+  cross-talk between concurrent calls. Results inject in source order
+  regardless of completion order so text tool-call parsers keyed on
+  declaration order keep working. The tool-call envelope grows
+  `turn.tool_call_index`, and `with_audit_log` receipts grow an
+  `emit_order` field equal to that index so completion-ordered
+  receipts can be re-sorted to source order.
 
 ## v0.8.24
 

--- a/conformance/tests/integration/agent_loop_parallel_dispatch.expected
+++ b/conformance/tests/integration/agent_loop_parallel_dispatch.expected
@@ -1,0 +1,12 @@
+serial.status=done
+serial.observed=4
+serial.peak=1
+parallel.status=done
+parallel.observed=4
+parallel.peak=4
+capped.status=done
+capped.observed=4
+capped.peak=2
+audit.status=done
+audit.receipt_count=3
+audit.emit_bitmask=7

--- a/conformance/tests/integration/agent_loop_parallel_dispatch.harn
+++ b/conformance/tests/integration/agent_loop_parallel_dispatch.harn
@@ -1,0 +1,165 @@
+/**
+ * In-turn parallel tool dispatch (`max_concurrent_tools`).
+ *
+ * When the planner emits multiple tool calls in a single turn and the
+ * loop is configured with a `tool_caller` middleware, the dispatch
+ * fans out via `parallel settle` capped at `max_concurrent_tools`.
+ * Results are still injected in source order so text tool-call
+ * parsers keyed on declaration order keep working.
+ *
+ * To assert real concurrency (vs serial) we count peak in-flight tool
+ * handlers via atomics — the handler bumps the counter, yields a few
+ * times so siblings can arrive, then decrements. With cap=1 only one
+ * handler is ever in-flight; with cap=4 all four reach in-flight=4.
+ */
+import { compose_tool_callers, with_audit_log, with_required_reason } from "std/llm/tool_middleware"
+
+let in_flight = atomic(0)
+
+let peak = atomic(0)
+
+let observed = atomic(0)
+
+fn fanout_tools() {
+  let r = tool_registry()
+  return tool_define(
+    r,
+    "fanout_echo",
+    "Echo, but track concurrent in-flight handlers",
+    {
+      handler: { args ->
+        let now = atomic_add(in_flight, 1) + 1
+        if now > atomic_get(peak) {
+          atomic_set(peak, now)
+        }
+        var spins = 0
+        while spins < 20 {
+          yield_now()
+          spins = spins + 1
+        }
+        atomic_add(in_flight, -1)
+        return "echoed:" + to_string(args?.msg ?? "")
+      },
+      parameters: {msg: {type: "string"}},
+    },
+  )
+}
+
+fn run(cap) {
+  llm_mock_clear()
+  atomic_set(in_flight, 0)
+  atomic_set(peak, 0)
+  atomic_set(observed, 0)
+  llm_mock(
+    {
+      tool_calls: [
+        {id: "c1", name: "fanout_echo", arguments: {msg: "alpha", reason: "first"}},
+        {id: "c2", name: "fanout_echo", arguments: {msg: "bravo", reason: "second"}},
+        {id: "c3", name: "fanout_echo", arguments: {msg: "charlie", reason: "third"}},
+        {id: "c4", name: "fanout_echo", arguments: {msg: "delta", reason: "fourth"}},
+      ],
+    },
+  )
+  llm_mock({text: "##DONE##"})
+  let mw = with_required_reason()
+  let counting_caller = { call, next ->
+    let _ = atomic_add(observed, 1)
+    return mw.caller(call, next)
+  }
+  let result = agent_loop(
+    "fan out",
+    nil,
+    {
+      provider: "mock",
+      tools: fanout_tools(),
+      tool_format: "native",
+      max_iterations: 3,
+      loop_until_done: true,
+      max_concurrent_tools: cap,
+      tool_caller: counting_caller,
+    },
+  )
+  return {status: result.status, observed: atomic_get(observed), peak: atomic_get(peak)}
+}
+
+let audit_receipt_count = atomic(0)
+
+let audit_emit_order_bitmask = atomic(0)
+
+fn run_with_audit(cap) {
+  llm_mock_clear()
+  atomic_set(in_flight, 0)
+  atomic_set(peak, 0)
+  atomic_set(observed, 0)
+  atomic_set(audit_receipt_count, 0)
+  atomic_set(audit_emit_order_bitmask, 0)
+  llm_mock(
+    {
+      tool_calls: [
+        {id: "a1", name: "fanout_echo", arguments: {msg: "first", reason: "r1"}},
+        {id: "a2", name: "fanout_echo", arguments: {msg: "second", reason: "r2"}},
+        {id: "a3", name: "fanout_echo", arguments: {msg: "third", reason: "r3"}},
+      ],
+    },
+  )
+  llm_mock({text: "##DONE##"})
+  let reason = with_required_reason()
+  // Add each receipt's bit (1 << emit_order) to the bitmask atomic.
+  // For 3 unique calls the bits are disjoint, so atomic_add == OR. The
+  // expected mask for emit_orders {0, 1, 2} is 1+2+4 = 7.
+  let audit_sink = { receipt ->
+    atomic_add(audit_receipt_count, 1)
+    var shifted = 1
+    var n = receipt.emit_order
+    while n > 0 {
+      shifted = shifted * 2
+      n = n - 1
+    }
+    atomic_add(audit_emit_order_bitmask, shifted)
+  }
+  let caller = compose_tool_callers([with_audit_log({sink: audit_sink}), reason.caller])
+  let result = agent_loop(
+    "audit fan-out",
+    nil,
+    {
+      provider: "mock",
+      tools: fanout_tools(),
+      tool_format: "native",
+      max_iterations: 3,
+      loop_until_done: true,
+      max_concurrent_tools: cap,
+      tool_caller: caller,
+    },
+  )
+  return {
+    status: result.status,
+    receipt_count: atomic_get(audit_receipt_count),
+    emit_bitmask: atomic_get(audit_emit_order_bitmask),
+  }
+}
+
+pipeline default() {
+  // Default (cap=1, sequential): peak in-flight is exactly 1.
+  let serial = run(1)
+  println("serial.status=" + serial.status)
+  println("serial.observed=" + to_string(serial.observed))
+  println("serial.peak=" + to_string(serial.peak))
+  // cap=4: all four handlers reach in_flight simultaneously.
+  let concurrent = run(4)
+  println("parallel.status=" + concurrent.status)
+  println("parallel.observed=" + to_string(concurrent.observed))
+  println("parallel.peak=" + to_string(concurrent.peak))
+  // Intermediate cap=2: peak in-flight is exactly 2.
+  let capped = run(2)
+  println("capped.status=" + capped.status)
+  println("capped.observed=" + to_string(capped.observed))
+  println("capped.peak=" + to_string(capped.peak))
+  // `with_audit_log` receipts carry each call's source-batch position
+  // as `emit_order`. With 3 parallel calls we should see all three
+  // distinct positions (bits 0, 1, 2 → bitmask 7), regardless of
+  // completion order.
+  let audited = run_with_audit(3)
+  println("audit.status=" + audited.status)
+  println("audit.receipt_count=" + to_string(audited.receipt_count))
+  println("audit.emit_bitmask=" + to_string(audited.emit_bitmask))
+}

--- a/crates/harn-stdlib/src/stdlib/agent/loop.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/loop.harn
@@ -245,6 +245,7 @@ fn __tool_envelope(call, tools, options) {
       run_id: options?.run_id ?? options?._run_id,
       model: options?.model,
       provider: options?.provider,
+      tool_call_index: options?._tool_call_index ?? 0,
     },
   }
 }
@@ -624,12 +625,21 @@ fn __detect_native_fallback(llm_result, parsed, turn_opts, fallback_index, sessi
   return {triggered: true, accepted: accepted, fallback_index: new_index, calls: resolved_calls}
 }
 
+fn __resolve_max_concurrent_tools(turn_opts) {
+  let raw = turn_opts?.max_concurrent_tools
+  if type_of(raw) == "int" && raw > 1 {
+    return raw
+  }
+  return 1
+}
+
 fn __dispatch_tool_calls(session_id, tool_calls, turn_opts) {
   if len(tool_calls) == 0 {
     return {dispatch: nil, turn_opts: turn_opts}
   }
   agent_tool_search_emit_queries(session_id, tool_calls, turn_opts)
   let tools = turn_opts?.tools
+  let cap = __resolve_max_concurrent_tools(turn_opts)
   let dispatch_options = {
     session_id: session_id,
     tool_format: turn_opts.tool_format,
@@ -639,12 +649,13 @@ fn __dispatch_tool_calls(session_id, tool_calls, turn_opts) {
     permissions: turn_opts?.permissions,
     _turn_iteration: turn_opts?._turn_iteration ?? 0,
     _tool_caller: turn_opts?._tool_caller,
+    _max_concurrent_tools: cap,
   }
   let caller = turn_opts?._tool_caller
   let dispatch = if caller == nil {
     agent_dispatch_tool_batch(tool_calls, tools, dispatch_options)
   } else {
-    __dispatch_tool_calls_with_middleware(tool_calls, tools, dispatch_options)
+    __dispatch_tool_calls_with_middleware(tool_calls, tools, dispatch_options, cap)
   }
   agent_session_record_tool_results(session_id, dispatch)
   return {
@@ -653,13 +664,58 @@ fn __dispatch_tool_calls(session_id, tool_calls, turn_opts) {
   }
 }
 
-fn __dispatch_tool_calls_with_middleware(tool_calls, tools, options) {
-  // Middleware-enabled path: dispatch sequentially so each call observes
-  // the audit-log/consent/redaction order in source order. Authors that
-  // want concurrency can wrap the inner call themselves.
+fn __invoke_tool_with_index(call, index, tools, options) {
+  return __invoke_tool(call, tools, options + {_tool_call_index: index})
+}
+
+fn __dispatch_tool_calls_with_middleware(tool_calls, tools, options, cap) {
+  // Middleware-enabled path. Each call invokes its own caller chain
+  // inside a fresh closure scope, so `audit.layers` histories stay
+  // independent across siblings. When `max_concurrent_tools > 1`,
+  // dispatch siblings concurrently via `parallel settle` with the
+  // requested cap; results come back in source order regardless of
+  // completion order so text tool-call parsers that key on
+  // declaration order still match.
+  if cap <= 1 || len(tool_calls) <= 1 {
+    var results = []
+    for (index, call) in iter(tool_calls).enumerate() {
+      results = results.push(__invoke_tool_with_index(call, index, tools, options))
+    }
+    return results
+  }
+  var indexed = []
+  for (index, call) in iter(tool_calls).enumerate() {
+    indexed = indexed.push({index: index, call: call})
+  }
+  let settled = parallel settle indexed with { max_concurrent: cap } { entry ->
+    __invoke_tool_with_index(entry.call, entry.index, tools, options)
+  }
   var results = []
-  for call in tool_calls {
-    results = results.push(__invoke_tool(call, tools, options))
+  for r in settled.results {
+    if is_ok(r) {
+      results = results.push(unwrap(r))
+    } else {
+      // `__invoke_tool` traps its own middleware exceptions, so a thrown
+      // value here is a VM-level bug (e.g. parallel-task plumbing). Surface
+      // it as a synthetic error result rather than tear down the loop.
+      let err = unwrap_err(r)
+      results = results
+        .push(
+        {
+          ok: false,
+          status: "error",
+          tool_name: "",
+          tool_call_id: "",
+          arguments: {},
+          result: nil,
+          rendered_result: to_string(err),
+          observation: to_string(err),
+          error: to_string(err),
+          error_category: "tool_parallel_dispatch_exception",
+          executor: nil,
+        },
+      )
+    }
   }
   return results
 }

--- a/crates/harn-stdlib/src/stdlib/agent/options.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/options.harn
@@ -243,6 +243,18 @@ fn __validate_tool_caller(value) {
   }
 }
 
+fn __validate_max_concurrent_tools(value) {
+  if value == nil {
+    return
+  }
+  if type_of(value) != "int" {
+    throw "agent_loop: `max_concurrent_tools` must be an integer or nil; got " + type_of(value)
+  }
+  if value < 1 {
+    throw "agent_loop: `max_concurrent_tools` must be >= 1; got " + to_string(value)
+  }
+}
+
 fn __validate_removed_agent_loop_options(opts) {
   if __has_key(opts, "persistent") {
     throw "agent_loop: `persistent` was removed; use `loop_until_done` for completion looping and `session_id` for transcript persistence"
@@ -274,6 +286,9 @@ fn __validate_agent_loop_callback_options(opts) {
   }
   if __has_key(opts, "tool_caller") {
     __validate_tool_caller(opts.tool_caller)
+  }
+  if __has_key(opts, "max_concurrent_tools") {
+    __validate_max_concurrent_tools(opts.max_concurrent_tools)
   }
 }
 

--- a/crates/harn-stdlib/src/stdlib/llm/tool_middleware.harn
+++ b/crates/harn-stdlib/src/stdlib/llm/tool_middleware.harn
@@ -565,6 +565,7 @@ fn __tool_mw_tool_call_receipt(call, result, duration_ms, redact_keys) {
     tool_name: to_string(call?.tool_name ?? ""),
     iteration: iteration,
     turn_index: turn_index,
+    emit_order: __tool_mw_nonnegative_int(turn?.tool_call_index),
     reason: __tool_mw_optional_text(audit?.summary),
     kind: __tool_mw_receipt_kind(call, audit),
     executor: __tool_mw_receipt_executor(result?.executor ?? call?.declared_executor),

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -892,6 +892,7 @@ println(response.logprobs)       // present when requested and returned
 | `llm_backoff_ms` | int | 250 | (deprecated; see `with_retry`) Base exponential backoff in milliseconds. |
 | `llm_caller` | closure | nil | (`agent_loop` only) Custom caller wrapping the per-turn `llm_call`. See "Composable LLM callers" below. |
 | `tool_caller` | closure | nil | (`agent_loop` only) Custom caller wrapping every tool dispatch. Signature `fn(call, next) -> result_dict`. See "Composable tool middleware" below. |
+| `max_concurrent_tools` | int | 1 | (`agent_loop` only) When a planner emits N tool calls in one turn AND a `tool_caller` is configured, dispatch siblings concurrently capped at this count via `parallel settle`. Results inject in source order regardless of completion order. Each sibling invokes its own middleware chain in a fresh scope, so `audit.layers` histories never cross-talk. With `with_audit_log`, each receipt carries an `emit_order` field so consumers can sort completion-ordered events back to source order. |
 | `progress_tool` | bool \| dict | false | (`agent_loop` only) Expose an opt-in progress-reporting tool. `true` installs `agent_progress`; dict form may set `name`, `description`, and `system_prompt_nudge`. ACP clients receive entries as canonical `plan` updates; A2A clients receive non-terminal `working` status updates; message-only reports surface as Harn progress narration. |
 | `stream` | bool | true | SSE streaming transport. |
 
@@ -2531,7 +2532,19 @@ The caller signature is `fn(call, next) -> result_dict` where
 `call = {tool_name, tool_args, call_id, declared_executor, schema, description, turn}`
 and `next(call)` runs the default dispatch (with any envelope mutations
 the layer applied — typically `tool_args` rewrites). Short-circuit by
-returning a result dict without calling `next`.
+returning a result dict without calling `next`. `call.turn.tool_call_index`
+is the call's position in the turn's emitted batch — useful when middleware
+fans out (`max_concurrent_tools > 1`) and needs to reorder completions
+back to source order.
+
+For multi-tool turns, set `max_concurrent_tools: N` on `agent_loop` to
+fan out dispatch across siblings (capped at N) via `parallel settle`.
+Each sibling invokes its own caller chain in a fresh scope, so
+`audit.layers` histories don't cross-talk. Results inject in source
+order regardless of completion order so text tool-call parsers keep
+working. `with_audit_log` receipts carry an `emit_order` field equal
+to `turn.tool_call_index` so consumers can re-sort to source order
+if they store events in completion order.
 
 Middleware-attached metadata rides on `result.audit` (free-form dict
 aligned with A2A `metadata` / ACP `kind` / OpenAI `summary_text` / OTel


### PR DESCRIPTION
## Summary

- Adds `max_concurrent_tools: int` (default 1) to `agent_loop`. When the planner emits multiple tool calls in one turn AND a `tool_caller` middleware is configured, siblings dispatch concurrently via `parallel settle` capped at the requested count. Results inject in source order regardless of completion order so text tool-call parsers keyed on declaration order keep working.
- Each sibling invokes its own caller chain in a fresh closure scope, so `audit.layers` histories never cross-talk between concurrent calls.
- The tool-call envelope grows `turn.tool_call_index`; `with_audit_log` receipts grow an `emit_order` field equal to that index — completion-ordered receipts can be re-sorted to source order without reconstructing the batch.

Closes part of #1699. The companion `prefetch_next_turn` option from the same issue is deferred to a follow-up PR because it needs cross-turn speculative state (fingerprint of pending messages + a `tokio::task::JoinSet`-equivalent background tracker) that warrants its own focused change.

## Approach

- New harn-level helper `__resolve_max_concurrent_tools(turn_opts)` reads the option (default 1) and threads `cap` through `__dispatch_tool_calls` → `__dispatch_tool_calls_with_middleware`.
- `__invoke_tool_with_index(call, index, tools, options)` injects `_tool_call_index` into options before delegating to `__invoke_tool`, which propagates it into the envelope as `turn.tool_call_index`.
- The middleware dispatch branches on cap: `cap <= 1` (or only one call) keeps today's sequential `for` loop; `cap > 1` builds an `[{index, call}]` list and runs `parallel settle … with { max_concurrent: cap }`. A defensive `is_err` branch surfaces any VM-task plumbing exception as a synthetic error result rather than tearing down the loop.
- `with_audit_log` receipts pick up `emit_order: turn.tool_call_index` (defaults to 0, so the field is always present even for non-fanout dispatch).

The no-middleware host path (`agent_dispatch_tool_batch`) is intentionally left alone — it already parallelizes the read-only prefix in Rust. The new option targets the middleware path where serial dispatch was previously unavoidable.

## Test plan

- [x] New conformance test `conformance/tests/integration/agent_loop_parallel_dispatch.harn` covering:
  - cap=1 (default): peak in-flight = 1, status=done, 4 calls observed
  - cap=4: peak in-flight = 4 (proven via atomic counter + `yield_now()` spins so siblings can arrive)
  - cap=2: peak in-flight = 2 (bounded by cap)
  - `with_audit_log` receipts under cap=3: 3 receipts emitted with `emit_order` bits 0,1,2 set (bitmask 7), confirming source-batch index survives concurrent completion ordering
- [x] Existing `agent_loop_tool_caller_observes` still passes (sequential middleware behavior unchanged at the default cap)
- [x] Existing `tool_call_receipts_local_sink` still passes (receipts gain `emit_order` without breaking the existing local-sink schema)
- [x] `make all` clean (cargo + nextest + conformance + harn lint/fmt + markdown + docs snippets + wall-clock pattern check + provider catalog + portal build)
- [x] Validation: `agent_loop_options({max_concurrent_tools: 0})` throws `must be >= 1`; `{max_concurrent_tools: "x"}` throws `must be an integer or nil`

🤖 Generated with [Claude Code](https://claude.com/claude-code)