### PR TITLE
[codex] Embed canonical Harn skill stubs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2090,6 +2090,7 @@ dependencies = [
  "harn-modules",
  "harn-parser",
  "harn-serve",
+ "harn-skills",
  "harn-vm",
  "hmac 0.13.0",
  "include_dir",
@@ -2323,6 +2324,10 @@ dependencies = [
  "url",
  "uuid",
 ]
+
+[[package]]
+name = "harn-skills"
+version = "0.8.24"
 
 [[package]]
 name = "harn-stdlib"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/harn-ir",
     "crates/harn-cli",
     "crates/harn-serve",
+    "crates/harn-skills",
     "crates/harn-lsp",
     "crates/harn-modules",
     "crates/harn-stdlib",

--- a/crates/harn-cli/Cargo.toml
+++ b/crates/harn-cli/Cargo.toml
@@ -42,6 +42,7 @@ harn-lint = { path = "../harn-lint", version = "0.8" }
 harn-modules = { path = "../harn-modules", version = "0.8" }
 harn-fmt = { path = "../harn-fmt", version = "0.8" }
 harn-serve = { path = "../harn-serve", version = "0.8" }
+harn-skills = { path = "../harn-skills", version = "0.8" }
 async-trait = "0.1"
 axum = { version = "0.8", features = ["ws"] }
 axum-server = { version = "0.8", features = ["tls-rustls"] }

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -14,6 +14,8 @@ pub mod test_runner;
 #[doc(hidden)]
 pub mod tests;
 
+pub use harn_skills::{get_embedded_skill, list_embedded_skills, EmbeddedSkill, SkillFrontmatter};
+
 use clap::{error::ErrorKind, CommandFactory, Parser as ClapParser};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;

--- a/crates/harn-skills/Cargo.toml
+++ b/crates/harn-skills/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "harn-skills"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Embedded skill corpus for the Harn CLI and runtime"
+include = ["src/**/*", "Cargo.toml"]
+
+[dependencies]

--- a/crates/harn-skills/src/corpus/harn-agent/SKILL.md
+++ b/crates/harn-skills/src/corpus/harn-agent/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: harn-agent
+short: Autonomous Harn agent workflows and safe task execution.
+description: Use for autonomous Harn agent work, task decomposition, capability boundaries, and host interaction patterns.
+when_to_use: Use when designing autonomous agent sessions, delegated workers, approval boundaries, or host capability usage.
+---
+
+# Harn agent
+
+This embedded stub reserves the canonical `harn-agent` skill in the bundled corpus.
+
+Use this skill for autonomous Harn sessions, delegated workers, capability boundaries, approval-aware execution,
+and host interaction patterns.
+
+The detailed agent workflow guidance is supplied by the granular skill corpus; until then, use the repository
+docs and conformance tests as the source of truth.

--- a/crates/harn-skills/src/corpus/harn-diagnostics/SKILL.md
+++ b/crates/harn-skills/src/corpus/harn-diagnostics/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: harn-diagnostics
+short: Diagnostics, explain output, repair plans, and fix-safety classes.
+description: Use for Harn diagnostics, error codes, explain output, repair metadata, and fix application safety.
+when_to_use: Use when working on typechecker diagnostics, lint diagnostics, harn explain, or repair flows.
+---
+
+# Harn diagnostics
+
+This embedded stub reserves the canonical `harn-diagnostics` skill in the bundled corpus.
+
+Use this skill for diagnostic code design, `harn explain`, repair plan metadata, fix-safety classes, and
+LSP-facing diagnostic behavior.
+
+The detailed diagnostics guidance is supplied by the granular skill corpus; until then, use the typechecker,
+linter, CLI diagnostics, and conformance coverage as the source of truth.

--- a/crates/harn-skills/src/corpus/harn-language/SKILL.md
+++ b/crates/harn-skills/src/corpus/harn-language/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: harn-language
+short: Harn syntax, modules, types, diagnostics, and script structure.
+description: Use for Harn language syntax, typechecking, modules, imports, and idiomatic script authoring.
+when_to_use: Use when writing, reviewing, or explaining Harn source code and language-level behavior.
+---
+
+# Harn language
+
+This embedded stub reserves the canonical `harn-language` skill in the bundled corpus.
+
+Use this skill for Harn syntax, module structure, imports, typechecker expectations, public language behavior,
+and script authoring conventions.
+
+The detailed language reference remains in `docs/llm/harn-quickref.md` until the granular skill corpus carries
+the full language guidance.

--- a/crates/harn-skills/src/corpus/harn-orchestration/SKILL.md
+++ b/crates/harn-skills/src/corpus/harn-orchestration/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: harn-orchestration
+short: Agent loops, tool middleware, handoffs, and orchestration patterns.
+description: Use for Harn orchestration workflows, agent_loop usage, tool middleware, and handoff design.
+when_to_use: Use when building or reviewing agent orchestration, persona handoffs, tool dispatch, or runtime control flow.
+---
+
+# Harn orchestration
+
+This embedded stub reserves the canonical `harn-orchestration` skill in the bundled corpus.
+
+Use this skill for `agent_loop`, tool-caller middleware, handoff artifacts, persona routing, orchestration
+control flow, and runtime behavior that composes host capabilities.
+
+The detailed orchestration guidance is supplied by the granular skill corpus; until then, use the stdlib
+orchestration files and integration tests as the source of truth.

--- a/crates/harn-skills/src/corpus/harn-providers/SKILL.md
+++ b/crates/harn-skills/src/corpus/harn-providers/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: harn-providers
+short: LLM provider configuration, model routing, and provider capability behavior.
+description: Use for Harn provider setup, model routing, provider capability matrices, and llm_call options.
+when_to_use: Use when wiring or debugging LLM providers, model routes, provider readiness, or structured-output capabilities.
+---
+
+# Harn providers
+
+This embedded stub reserves the canonical `harn-providers` skill in the bundled corpus.
+
+Use this skill for provider configuration, model routing, provider readiness checks, provider capability
+matrices, structured-output support, and `llm_call` option behavior.
+
+The detailed provider guidance is supplied by the granular skill corpus; until then, use the provider catalog,
+CLI provider commands, and provider tests as the source of truth.

--- a/crates/harn-skills/src/corpus/harn-testing/SKILL.md
+++ b/crates/harn-skills/src/corpus/harn-testing/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: harn-testing
+short: Conformance tests, evals, deterministic fixtures, and test authoring.
+description: Use for Harn conformance tests, eval harnesses, deterministic fixtures, and language/runtime test coverage.
+when_to_use: Use when adding or reviewing conformance cases, eval fixtures, mock providers, replay fixtures, or deterministic tests.
+---
+
+# Harn testing
+
+This embedded stub reserves the canonical `harn-testing` skill in the bundled corpus.
+
+Use this skill for conformance tests, eval harnesses, deterministic replay fixtures, mock providers, and test
+coverage for language or runtime behavior.
+
+The detailed testing guidance is supplied by the granular skill corpus; until then, use `conformance/tests/`,
+eval fixtures, and `docs/src/dev/testing.md` as the source of truth.

--- a/crates/harn-skills/src/corpus/harn-tracing/SKILL.md
+++ b/crates/harn-skills/src/corpus/harn-tracing/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: harn-tracing
+short: Transcripts, receipts, traces, replay, and observability surfaces.
+description: Use for Harn tracing, transcript lifecycle, run records, receipts, replay, and observability workflows.
+when_to_use: Use when inspecting or changing run records, transcripts, replay paths, receipts, telemetry, or portal activity data.
+---
+
+# Harn tracing
+
+This embedded stub reserves the canonical `harn-tracing` skill in the bundled corpus.
+
+Use this skill for transcripts, receipts, run records, trace import/export, replay, observability sinks, and
+portal-facing activity data.
+
+The detailed tracing guidance is supplied by the granular skill corpus; until then, use the transcript,
+receipt, replay, and portal schemas as the source of truth.

--- a/crates/harn-skills/src/lib.rs
+++ b/crates/harn-skills/src/lib.rs
@@ -1,0 +1,160 @@
+//! Embedded Harn skill corpus.
+//!
+//! This crate exposes the bundled corpus as metadata plus `SKILL.md`
+//! bodies. CLI commands that enumerate, dump, or install these skills
+//! are layered above this foundation.
+
+use std::sync::OnceLock;
+
+/// Frontmatter fields embedded with each bundled skill.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SkillFrontmatter {
+    pub name: &'static str,
+    pub short: &'static str,
+    pub description: &'static str,
+    pub when_to_use: Option<&'static str>,
+}
+
+/// A single skill embedded into the Harn build.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EmbeddedSkill {
+    pub name: &'static str,
+    pub frontmatter: SkillFrontmatter,
+    pub body: &'static str,
+}
+
+const SOURCES: &[&str] = &[
+    include_str!("corpus/harn-agent/SKILL.md"),
+    include_str!("corpus/harn-diagnostics/SKILL.md"),
+    include_str!("corpus/harn-language/SKILL.md"),
+    include_str!("corpus/harn-orchestration/SKILL.md"),
+    include_str!("corpus/harn-providers/SKILL.md"),
+    include_str!("corpus/harn-testing/SKILL.md"),
+    include_str!("corpus/harn-tracing/SKILL.md"),
+];
+
+static EMBEDDED_SKILLS: OnceLock<Box<[EmbeddedSkill]>> = OnceLock::new();
+
+/// Return every skill bundled into this build.
+pub fn list_embedded_skills() -> &'static [EmbeddedSkill] {
+    EMBEDDED_SKILLS
+        .get_or_init(|| SOURCES.iter().map(|source| parse_skill(source)).collect())
+        .as_ref()
+}
+
+/// Return one bundled skill by canonical skill name.
+pub fn get_embedded_skill(name: &str) -> Option<&'static EmbeddedSkill> {
+    list_embedded_skills()
+        .iter()
+        .find(|skill| skill.name == name)
+}
+
+fn parse_skill(source: &'static str) -> EmbeddedSkill {
+    let (frontmatter, body) = split_frontmatter(source);
+    let frontmatter = parse_frontmatter(frontmatter);
+    EmbeddedSkill {
+        name: frontmatter.name,
+        frontmatter,
+        body,
+    }
+}
+
+fn split_frontmatter(source: &'static str) -> (&'static str, &'static str) {
+    let Some(after_open) = source.strip_prefix("---\n") else {
+        panic!("embedded skill source is missing opening frontmatter delimiter");
+    };
+    let Some(close_offset) = after_open.find("\n---\n") else {
+        panic!("embedded skill source is missing closing frontmatter delimiter");
+    };
+    (
+        &after_open[..close_offset],
+        &after_open[close_offset + "\n---\n".len()..],
+    )
+}
+
+fn parse_frontmatter(frontmatter: &'static str) -> SkillFrontmatter {
+    let mut name = None;
+    let mut short = None;
+    let mut description = None;
+    let mut when_to_use = None;
+
+    for line in frontmatter.lines() {
+        let Some((key, value)) = line.split_once(':') else {
+            continue;
+        };
+        let value = value.trim();
+        match key {
+            "name" => name = Some(value),
+            "short" => short = Some(value),
+            "description" => description = Some(value),
+            "when_to_use" => when_to_use = Some(value),
+            _ => {}
+        }
+    }
+
+    SkillFrontmatter {
+        name: name.expect("embedded skill frontmatter is missing `name`"),
+        short: short.expect("embedded skill frontmatter is missing `short`"),
+        description: description.expect("embedded skill frontmatter is missing `description`"),
+        when_to_use,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeSet;
+
+    #[test]
+    fn lists_expected_initial_corpus() {
+        let skills = list_embedded_skills();
+        assert!(skills.len() >= 7);
+        assert_eq!(skills.len(), SOURCES.len());
+    }
+
+    #[test]
+    fn can_fetch_harn_language_skill() {
+        let skill = get_embedded_skill("harn-language").expect("harn-language skill is embedded");
+        assert_eq!(skill.frontmatter.name, "harn-language");
+        assert!(skill.body.contains("Harn language"));
+    }
+
+    #[test]
+    fn skills_have_unique_names_and_body_only_content() {
+        let mut names = BTreeSet::new();
+        for skill in list_embedded_skills() {
+            assert_eq!(skill.name, skill.frontmatter.name);
+            assert!(names.insert(skill.name), "duplicate skill {}", skill.name);
+            assert!(
+                !skill.body.trim().is_empty(),
+                "{} body is empty",
+                skill.name
+            );
+            assert!(
+                !skill.body.trim_start().starts_with("---"),
+                "{} body includes frontmatter",
+                skill.name
+            );
+        }
+    }
+
+    #[test]
+    fn skills_are_sorted_by_name() {
+        let names: Vec<&str> = list_embedded_skills()
+            .iter()
+            .map(|skill| skill.name)
+            .collect();
+        let mut sorted = names.clone();
+        sorted.sort_unstable();
+        assert_eq!(names, sorted);
+    }
+
+    #[test]
+    fn embedded_corpus_stays_within_binary_budget() {
+        let bytes: usize = SOURCES.iter().map(|source| source.len()).sum();
+        assert!(
+            bytes <= 200 * 1024,
+            "embedded corpus is {bytes} bytes, expected <= 200 KiB"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Closes #1761.

Adds a new `harn-skills` workspace crate that embeds the initial canonical Harn skill corpus at compile time. The crate exposes the foundational Rust API for later CLI surfaces:

- `list_embedded_skills() -> &'static [EmbeddedSkill]`
- `get_embedded_skill(name: &str) -> Option<&'static EmbeddedSkill>`
- `EmbeddedSkill` and `SkillFrontmatter`

The initial corpus includes seven placeholder `SKILL.md` stubs for the planned granular skills: language, orchestration, diagnostics, providers, tracing, testing, and agent. `harn-cli` depends on and re-exports the API so the corpus is available from the binary crate without adding the E3.2 CLI commands yet.

## Validation

- `cargo test -p harn-skills`
- `cargo check -p harn-cli`
- Pre-commit hook: `cargo clippy --workspace --all-targets -- -D warnings`, markdown lint, and repo ratchets
- Pre-push hook: targeted local checks and markdown lint

## Review notes

Fresh diff review after rebasing on `origin/main` found no whitespace, DRY, or cross-crate drift issues. The embedded frontmatter is parsed from the `SKILL.md` source strings so the stubs remain the single metadata source of truth.
