### PR TITLE
Add stable diagnostic code registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,7 @@ jobs:
       # go preinstalled, so no setup action is required.
       - run: make check-bindings
       - run: make lint-test-patterns
+      - run: make lint-diagnostic-codes
       - run: make lint-no-rust-prompt-prose lint-no-xfail-regression
       - run: python3 scripts/verify_release_metadata.py
       - name: Check no retroactive CHANGELOG edits

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
-.PHONY: setup install-hooks configure-merge-drivers build build-release sign-local check fmt fmt-harn fmt-harn-fix lint lint-md lint-actions lint-harn spec-lint test test-e2e test-cargo test-fast test-harn-scripts conformance protocol-conformance replay-oracle replay-bench eval-tool-calls bench-vm bench-vm-clone bench-llm bench-orchestration all release-gate release-smoke smoke-audit portal portal-check portal-demo gen-highlight check-highlight gen-protocol-artifacts check-protocol-artifacts check-bindings gen-session-bundle-schema check-session-bundle-schema gen-trigger-quickref check-trigger-quickref gen-provider-matrix check-provider-matrix gen-provider-catalog check-provider-catalog gen-connector-matrix check-connector-matrix check-trigger-examples check-docs-snippets check-docs-workflow-quickstart sync-language-spec check-language-spec lint-test-patterns check-receipt-structs lint-no-rust-prompt-prose lint-no-xfail-regression check-provider-catalog-drift
+.PHONY: setup install-hooks configure-merge-drivers build build-release sign-local check fmt fmt-harn fmt-harn-fix lint lint-md lint-actions lint-harn spec-lint test test-e2e test-cargo test-fast test-harn-scripts conformance protocol-conformance replay-oracle replay-bench eval-tool-calls bench-vm bench-vm-clone bench-llm bench-orchestration all release-gate release-smoke smoke-audit portal portal-check portal-demo gen-highlight check-highlight gen-protocol-artifacts check-protocol-artifacts check-bindings gen-session-bundle-schema check-session-bundle-schema gen-trigger-quickref check-trigger-quickref gen-provider-matrix check-provider-matrix gen-provider-catalog check-provider-catalog gen-connector-matrix check-connector-matrix check-trigger-examples check-docs-snippets check-docs-workflow-quickstart sync-language-spec check-language-spec lint-test-patterns lint-diagnostic-codes check-receipt-structs lint-no-rust-prompt-prose lint-no-xfail-regression check-provider-catalog-drift
 
 # Full quality check: format first, then lint/test in parallel.
 # Usage: make all -j       (parallel checks after formatting)
 #        make all           (sequential, also works)
 all: fmt
-	$(MAKE) lint lint-md lint-actions lint-harn spec-lint fmt-harn test test-harn-scripts conformance protocol-conformance replay-oracle replay-bench check-highlight check-protocol-artifacts check-bindings check-session-bundle-schema check-language-spec check-trigger-quickref check-provider-matrix check-provider-catalog check-connector-matrix check-trigger-examples check-docs-snippets check-docs-workflow-quickstart lint-test-patterns check-receipt-structs check-provider-catalog-drift portal-check
+	$(MAKE) lint lint-md lint-actions lint-harn spec-lint fmt-harn test test-harn-scripts conformance protocol-conformance replay-oracle replay-bench check-highlight check-protocol-artifacts check-bindings check-session-bundle-schema check-language-spec check-trigger-quickref check-provider-matrix check-provider-catalog check-connector-matrix check-trigger-examples check-docs-snippets check-docs-workflow-quickstart lint-test-patterns lint-diagnostic-codes check-receipt-structs check-provider-catalog-drift portal-check
 
 check: all
 
@@ -374,6 +374,9 @@ check-docs-workflow-quickstart:
 # See docs/src/dev/testing.md for approved alternatives and the opt-out mechanism.
 lint-test-patterns:
 	@./scripts/lint_test_patterns.sh
+
+lint-diagnostic-codes:
+	@python3 scripts/check_diagnostic_codes.py
 
 check-receipt-structs:
 	@./scripts/check_receipt_struct_duplication.py

--- a/crates/harn-cli/src/commands/check/check_cmd.rs
+++ b/crates/harn-cli/src/commands/check/check_cmd.rs
@@ -89,11 +89,12 @@ pub(crate) fn check_file_inner(
                 PreflightSeverity::Off => unreachable!(),
             }
             diagnostic_count += 1;
-            let rendered = harn_parser::diagnostic::render_diagnostic(
+            let rendered = harn_parser::diagnostic::render_diagnostic_with_code(
                 &diag.source,
                 &diag.path,
                 &diag.span,
                 severity_label,
+                diag.code,
                 &diag.message,
                 Some(category),
                 diag.help.as_deref(),

--- a/crates/harn-cli/src/commands/check/fmt.rs
+++ b/crates/harn-cli/src/commands/check/fmt.rs
@@ -1,6 +1,7 @@
 use std::process;
 
 use harn_fmt::{format_source_opts, FmtOptions};
+use harn_parser::DiagnosticCode as Code;
 
 /// Whether `harn fmt` should rewrite files in place or just report drift.
 #[derive(Clone, Copy, Debug)]
@@ -72,7 +73,10 @@ fn fmt_file_inner(path: &str, mode: FmtMode, opts: &FmtOptions) -> bool {
 
     if mode.is_check() {
         if source != formatted {
-            eprintln!("{path}: would be reformatted");
+            eprintln!(
+                "{path}: {}: would be reformatted",
+                Code::FormatterWouldReformat
+            );
             return false;
         }
     } else if source != formatted {

--- a/crates/harn-cli/src/commands/check/imports.rs
+++ b/crates/harn-cli/src/commands/check/imports.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use harn_modules::resolve_import_path;
-use harn_parser::{Node, SNode};
+use harn_parser::{DiagnosticCode as Code, Node, SNode};
 
 use super::preflight::PreflightDiagnostic;
 use super::source::parse_resolved_module;
@@ -38,6 +38,7 @@ pub(super) fn scan_import_collisions(
                     if let Some(existing) = imported_names.get(&name) {
                         if existing.module_path != import_str {
                             diagnostics.push(PreflightDiagnostic {
+                                code: Code::ModuleImportCollision,
                                 path: file_path.display().to_string(),
                                 source: source.to_string(),
                                 span: node.span,
@@ -69,6 +70,7 @@ pub(super) fn scan_import_collisions(
                     if let Some(existing) = imported_names.get(name) {
                         if existing.module_path != module_path {
                             diagnostics.push(PreflightDiagnostic {
+                                code: Code::ModuleImportCollision,
                                 path: file_path.display().to_string(),
                                 source: source.to_string(),
                                 span: node.span,
@@ -157,6 +159,7 @@ pub(super) fn scan_re_export_conflicts(
             .map(|p: &PathBuf| p.display().to_string())
             .collect();
         diagnostics.push(PreflightDiagnostic {
+            code: Code::ModuleReExportConflict,
             path: file_path.display().to_string(),
             source: source.to_string(),
             span,

--- a/crates/harn-cli/src/commands/check/outcome.rs
+++ b/crates/harn-cli/src/commands/check/outcome.rs
@@ -26,11 +26,12 @@ pub(super) fn print_lint_diagnostics(
                 "error"
             }
         };
-        let rendered = harn_parser::diagnostic::render_diagnostic(
+        let rendered = harn_parser::diagnostic::render_diagnostic_with_code(
             source,
             path,
             &diag.span,
             severity,
+            diag.code,
             &diag.message,
             Some(&format!("lint[{}]", diag.rule)),
             diag.suggestion.as_deref(),

--- a/crates/harn-cli/src/commands/check/preflight.rs
+++ b/crates/harn-cli/src/commands/check/preflight.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use harn_modules::resolve_import_path;
-use harn_parser::{Node, SNode};
+use harn_parser::{DiagnosticCode as Code, Node, SNode};
 
 use super::host_capabilities::{is_known_host_operation, load_host_capabilities};
 use super::imports::{scan_import_collisions, scan_re_export_conflicts};
@@ -11,6 +11,7 @@ use super::source::parse_resolved_module;
 use crate::package::CheckConfig;
 
 pub(super) struct PreflightDiagnostic {
+    pub(super) code: Code,
     pub(super) path: String,
     pub(super) source: String,
     pub(super) span: harn_lexer::Span,
@@ -127,6 +128,7 @@ fn scan_static_tool_surface_preflight(
         for reference in harn_vm::tool_surface::prompt_tool_references(&body) {
             if !tool_names.contains(&reference) {
                 diagnostics.push(PreflightDiagnostic {
+                    code: Code::PromptToolSurfaceUnknown,
                     path: file_path.display().to_string(),
                     source: source.to_string(),
                     span: harn_lexer::Span::with_offsets(0, 0, 1, 1),
@@ -142,6 +144,7 @@ fn scan_static_tool_surface_preflight(
                 });
             } else if deferred.contains(&reference) && !tool_search_active {
                 diagnostics.push(PreflightDiagnostic {
+                    code: Code::PromptToolSurfaceDeferredReference,
                     path: file_path.display().to_string(),
                     source: source.to_string(),
                     span: harn_lexer::Span::with_offsets(0, 0, 1, 1),
@@ -749,6 +752,7 @@ fn scan_node_preflight(
                     }
                 }
                 None => diagnostics.push(PreflightDiagnostic {
+                    code: Code::ModuleImportUnresolved,
                     path: file_path.display().to_string(),
                     source: source.to_string(),
                     span: node.span,
@@ -787,6 +791,7 @@ fn scan_node_preflight(
                         // user sees the structural cause, not a generic
                         // "render target does not exist" message.
                         diagnostics.push(PreflightDiagnostic {
+                            code: Code::ImportResolutionFailed,
                             path: file_path.display().to_string(),
                             source: source.to_string(),
                             span: args[0].span,
@@ -805,6 +810,7 @@ fn scan_node_preflight(
                         if let Err(err) = harn_vm::stdlib::template::validate_template_syntax(&body)
                         {
                             diagnostics.push(PreflightDiagnostic {
+                                code: Code::PromptTemplateParse,
                                 path: file_path.display().to_string(),
                                 source: source.to_string(),
                                 span: args[0].span,
@@ -822,6 +828,7 @@ fn scan_node_preflight(
                     }
                 } else {
                     diagnostics.push(PreflightDiagnostic {
+                        code: Code::PromptTargetMissing,
                         path: file_path.display().to_string(),
                         source: source.to_string(),
                         span: args[0].span,
@@ -841,6 +848,7 @@ fn scan_node_preflight(
                 let resolved = resolve_source_relative(file_path, &dir);
                 if !resolved.is_dir() {
                     diagnostics.push(PreflightDiagnostic {
+                        code: Code::ExecutionTargetMissing,
                         path: file_path.display().to_string(),
                         source: source.to_string(),
                         span: args[0].span,
@@ -874,6 +882,7 @@ fn scan_node_preflight(
         }
         Node::FunctionCall { name, args, .. } if name == "host_invoke" => {
             diagnostics.push(PreflightDiagnostic {
+                code: Code::DeprecatedStdlibSymbol,
                 path: file_path.display().to_string(),
                 source: source.to_string(),
                 span: node.span,
@@ -923,6 +932,7 @@ fn scan_node_preflight(
             if let Some((cap, op, params_arg)) = parse_host_call_args(args) {
                 if !is_known_host_operation(host_capabilities, &cap, &op) {
                     diagnostics.push(PreflightDiagnostic {
+                        code: Code::CapabilityUnknownOperation,
                         path: file_path.display().to_string(),
                         source: source.to_string(),
                         span: node.span,
@@ -954,6 +964,7 @@ fn scan_node_preflight(
                                     harn_modules::asset_paths::resolve(&asset_ref, anchor)
                                 {
                                     diagnostics.push(PreflightDiagnostic {
+                                        code: Code::ImportResolutionFailed,
                                         path: file_path.display().to_string(),
                                         source: source.to_string(),
                                         span: params_arg.map(|arg| arg.span).unwrap_or(node.span),
@@ -970,6 +981,7 @@ fn scan_node_preflight(
                                 resolve_preflight_target(file_path, &template_path, config);
                             if !resolved.iter().any(|path| path.exists()) {
                                 diagnostics.push(PreflightDiagnostic {
+                                    code: Code::PromptTargetMissing,
                                     path: file_path.display().to_string(),
                                     source: source.to_string(),
                                     span: params_arg.map(|arg| arg.span).unwrap_or(node.span),
@@ -990,6 +1002,7 @@ fn scan_node_preflight(
                 }
             } else if let Some(arg) = args.first() {
                 diagnostics.push(PreflightDiagnostic {
+                    code: Code::CapabilityCallStaticNameRequired,
                     path: file_path.display().to_string(),
                     source: source.to_string(),
                     span: arg.span,
@@ -1866,6 +1879,7 @@ fn scan_stdlib_prompt_target(
     }
     let Some(body) = harn_vm::stdlib_modules::get_stdlib_prompt_asset(template_path) else {
         diagnostics.push(PreflightDiagnostic {
+            code: Code::PromptTargetMissing,
             path: file_path.display().to_string(),
             source: source.to_string(),
             span,
@@ -1882,6 +1896,7 @@ fn scan_stdlib_prompt_target(
     };
     if let Err(err) = harn_vm::stdlib::template::validate_template_syntax(body) {
         diagnostics.push(PreflightDiagnostic {
+            code: Code::PromptTemplateParse,
             path: file_path.display().to_string(),
             source: source.to_string(),
             span,
@@ -2066,6 +2081,7 @@ fn scan_tool_define_preflight(
         && executor != "provider_native"
     {
         diagnostics.push(PreflightDiagnostic {
+            code: Code::ToolDefinitionInvalid,
             path: file_path.display().to_string(),
             source: source.to_string(),
             span: executor_node.span,
@@ -2086,6 +2102,7 @@ fn scan_tool_define_preflight(
     }
     let Some(capability_node) = dict_literal_field(config_arg, "host_capability") else {
         diagnostics.push(PreflightDiagnostic {
+            code: Code::CapabilityBindingInvalid,
             path: file_path.display().to_string(),
             source: source.to_string(),
             span: node.span,
@@ -2107,6 +2124,7 @@ fn scan_tool_define_preflight(
     };
     let Some((cap, op)) = capability.split_once('.') else {
         diagnostics.push(PreflightDiagnostic {
+            code: Code::CapabilityBindingInvalid,
             path: file_path.display().to_string(),
             source: source.to_string(),
             span: capability_node.span,
@@ -2125,6 +2143,7 @@ fn scan_tool_define_preflight(
     };
     if !is_known_host_operation(host_capabilities, cap, op) {
         diagnostics.push(PreflightDiagnostic {
+            code: Code::CapabilityUnknownOperation,
             path: file_path.display().to_string(),
             source: source.to_string(),
             span: capability_node.span,
@@ -2165,6 +2184,7 @@ fn scan_spawn_agent_preflight(
         let resolved = resolve_source_relative(file_path, &cwd);
         if !resolved.is_dir() {
             diagnostics.push(PreflightDiagnostic {
+                code: Code::ExecutionTargetMissing,
                 path: file_path.display().to_string(),
                 source: source.to_string(),
                 span: execution.span,
@@ -2188,6 +2208,7 @@ fn scan_spawn_agent_preflight(
         let resolved = resolve_source_relative(file_path, &repo);
         if !resolved.is_dir() {
             diagnostics.push(PreflightDiagnostic {
+                code: Code::ExecutionTargetMissing,
                 path: file_path.display().to_string(),
                 source: source.to_string(),
                 span: worktree.span,

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -2326,11 +2326,12 @@ pub(crate) fn parse_source_file(path: &str) -> (String, Vec<harn_parser::SNode>)
     let tokens = match lexer.tokenize() {
         Ok(t) => t,
         Err(e) => {
-            let diagnostic = harn_parser::diagnostic::render_diagnostic(
+            let diagnostic = harn_parser::diagnostic::render_diagnostic_with_code(
                 &source,
                 path,
                 &error_span_from_lex(&e),
                 "error",
+                harn_parser::diagnostic::lexer_error_code(&e),
                 &e.to_string(),
                 Some("here"),
                 None,
@@ -2346,11 +2347,12 @@ pub(crate) fn parse_source_file(path: &str) -> (String, Vec<harn_parser::SNode>)
         Err(err) => {
             if parser.all_errors().is_empty() {
                 let span = error_span_from_parse(&err);
-                let diagnostic = harn_parser::diagnostic::render_diagnostic(
+                let diagnostic = harn_parser::diagnostic::render_diagnostic_with_code(
                     &source,
                     path,
                     &span,
                     "error",
+                    harn_parser::diagnostic::parser_error_code(&err),
                     &harn_parser::diagnostic::parser_error_message(&err),
                     Some(harn_parser::diagnostic::parser_error_label(&err)),
                     harn_parser::diagnostic::parser_error_help(&err),
@@ -2359,11 +2361,12 @@ pub(crate) fn parse_source_file(path: &str) -> (String, Vec<harn_parser::SNode>)
             } else {
                 for e in parser.all_errors() {
                     let span = error_span_from_parse(e);
-                    let diagnostic = harn_parser::diagnostic::render_diagnostic(
+                    let diagnostic = harn_parser::diagnostic::render_diagnostic_with_code(
                         &source,
                         path,
                         &span,
                         "error",
+                        harn_parser::diagnostic::parser_error_code(e),
                         &harn_parser::diagnostic::parser_error_message(e),
                         Some(harn_parser::diagnostic::parser_error_label(e)),
                         harn_parser::diagnostic::parser_error_help(e),

--- a/crates/harn-fmt/src/lib.rs
+++ b/crates/harn-fmt/src/lib.rs
@@ -5,9 +5,10 @@ mod tests;
 mod trailing_comma;
 
 use std::collections::BTreeMap;
+use std::fmt;
 
 use harn_lexer::{Lexer, TokenKind};
-use harn_parser::Parser;
+use harn_parser::{DiagnosticCode as Code, Parser};
 
 pub(crate) use formatter::{Comment, Formatter};
 pub use trailing_comma::{
@@ -17,6 +18,30 @@ pub use trailing_comma::{
 /// `FmtOptions::separator_width` value that resolves section-header bars from
 /// `line_width` minus the current indent.
 pub const AUTO_SEPARATOR_WIDTH: usize = 0;
+
+/// Error returned when formatting cannot proceed.
+#[derive(Debug, Clone)]
+pub struct FormatError {
+    pub code: Code,
+    pub message: String,
+}
+
+impl FormatError {
+    fn new(code: Code, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for FormatError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}: {}", self.code, self.message)
+    }
+}
+
+impl std::error::Error for FormatError {}
 
 /// Options controlling formatter behavior.
 #[derive(Debug, Clone)]
@@ -40,12 +65,12 @@ impl Default for FmtOptions {
 }
 
 /// Format Harn source code to canonical style using default options.
-pub fn format_source(source: &str) -> Result<String, String> {
+pub fn format_source(source: &str) -> Result<String, FormatError> {
     format_source_opts(source, &FmtOptions::default())
 }
 
 /// Format Harn source code with explicit options.
-pub fn format_source_opts(source: &str, opts: &FmtOptions) -> Result<String, String> {
+pub fn format_source_opts(source: &str, opts: &FmtOptions) -> Result<String, FormatError> {
     // Preserve a shebang line (`#!...`) at offset 0 — the lexer skips it
     // entirely, so without explicit reattachment the formatter would drop it.
     let (shebang, source_for_lex) = match source.starts_with("#!") {
@@ -58,7 +83,9 @@ pub fn format_source_opts(source: &str, opts: &FmtOptions) -> Result<String, Str
 
     // Lex with comments preserved, then split into (comments by line, parser tokens).
     let mut lexer = Lexer::new(source_for_lex);
-    let all_tokens = lexer.tokenize_with_comments().map_err(|e| e.to_string())?;
+    let all_tokens = lexer
+        .tokenize_with_comments()
+        .map_err(|e| FormatError::new(Code::FormatterParseFailed, e.to_string()))?;
 
     let mut comments: BTreeMap<usize, Vec<Comment>> = BTreeMap::new();
     let mut parser_tokens = Vec::with_capacity(all_tokens.len());
@@ -83,7 +110,9 @@ pub fn format_source_opts(source: &str, opts: &FmtOptions) -> Result<String, Str
     }
 
     let mut parser = Parser::new(parser_tokens);
-    let program = parser.parse().map_err(|e| e.to_string())?;
+    let program = parser
+        .parse()
+        .map_err(|e| FormatError::new(Code::FormatterParseFailed, e.to_string()))?;
 
     let mut fmt = Formatter::new(
         source_for_lex,

--- a/crates/harn-lint/src/diagnostic.rs
+++ b/crates/harn-lint/src/diagnostic.rs
@@ -3,10 +3,12 @@
 //! surface is easy to locate and audit.
 
 use harn_lexer::{FixEdit, Span};
+use harn_parser::DiagnosticCode as Code;
 
 /// A lint diagnostic reported by the linter.
 #[derive(Debug, Clone)]
 pub struct LintDiagnostic {
+    pub code: Code,
     pub rule: &'static str,
     pub message: String,
     pub span: Span,

--- a/crates/harn-lint/src/harndoc.rs
+++ b/crates/harn-lint/src/harndoc.rs
@@ -3,7 +3,7 @@
 //! construction isolated from the linter walk.
 
 use harn_lexer::{FixEdit, Span};
-use harn_parser::{Node, SNode};
+use harn_parser::{DiagnosticCode as Code, Node, SNode};
 
 use crate::diagnostic::{LintDiagnostic, LintSeverity};
 use crate::naming::{is_documentable_item, item_is_pub};
@@ -241,6 +241,7 @@ fn check_one_item(
         ),
     };
     diagnostics.push(LintDiagnostic {
+        code: Code::LintLegacyDocComment,
         rule: "legacy-doc-comment",
         message: format!("{prefix} doc comment(s) above this item should use `/** */` form"),
         span: Span::with_offsets(first.start_byte, last.end_byte, first.line, 1),

--- a/crates/harn-lint/src/lib.rs
+++ b/crates/harn-lint/src/lib.rs
@@ -8,7 +8,7 @@ use std::collections::HashSet;
 use std::path::Path;
 
 use harn_modules::WildcardResolution;
-use harn_parser::SNode;
+use harn_parser::{DiagnosticCode as Code, SNode};
 
 mod complexity;
 mod decls;
@@ -49,6 +49,7 @@ pub fn lint_prompt_template(
         Ok(constructs) => constructs,
         Err(message) => {
             return vec![LintDiagnostic {
+                code: Code::LintTemplateParse,
                 rule: "template-parse",
                 message: format!("template did not parse: {message}"),
                 span: harn_lexer::Span::dummy(),
@@ -240,6 +241,7 @@ fn type_diagnostic_as_lint(diagnostic: &harn_parser::TypeDiagnostic) -> Option<L
     let rule = type_diagnostic_lint_rule(diagnostic)?;
     let span = diagnostic.span?;
     Some(LintDiagnostic {
+        code: diagnostic.code,
         rule,
         message: diagnostic.message.clone(),
         span,

--- a/crates/harn-lint/src/linter.rs
+++ b/crates/harn-lint/src/linter.rs
@@ -7,7 +7,7 @@ use std::collections::{HashMap, HashSet};
 
 use harn_lexer::{FixEdit, Span};
 use harn_parser::diagnostic::{find_closest_match, renamed_stdlib_symbol};
-use harn_parser::{BindingPattern, Node, SNode, TypeExpr, TypedParam};
+use harn_parser::{BindingPattern, DiagnosticCode as Code, Node, SNode, TypeExpr, TypedParam};
 
 use crate::complexity::cyclomatic_complexity;
 use crate::decls::{Declaration, FnDeclaration, ImportInfo, ParamDeclaration, TypeDeclaration};
@@ -188,6 +188,7 @@ impl<'a> Linter<'a> {
             return;
         };
         self.diagnostics.push(LintDiagnostic {
+            code: Code::LintRenamedStdlibSymbol,
             rule: "renamed-stdlib-symbol",
             message: format!("`{name}` was renamed to `{replacement}`"),
             span,
@@ -211,6 +212,7 @@ impl<'a> Linter<'a> {
             return;
         }
         self.diagnostics.push(LintDiagnostic {
+            code: Code::LintCyclomaticComplexity,
             rule: "cyclomatic-complexity",
             message: format!(
                 "function `{name}` has cyclomatic complexity {complexity} (> {threshold})"
@@ -229,6 +231,7 @@ impl<'a> Linter<'a> {
             return;
         }
         self.diagnostics.push(LintDiagnostic {
+            code: Code::LintNamingConvention,
             rule: "naming-convention",
             message: format!("function `{name}` should use snake_case"),
             span,
@@ -246,6 +249,7 @@ impl<'a> Linter<'a> {
             return;
         }
         self.diagnostics.push(LintDiagnostic {
+            code: Code::LintNamingConvention,
             rule: "naming-convention",
             message: format!("{kind} `{name}` should use PascalCase"),
             span,
@@ -405,6 +409,7 @@ impl<'a> Linter<'a> {
         );
         let fix = append_sink_fix(value.span, sink);
         self.diagnostics.push(LintDiagnostic {
+            code: Code::LintEagerCollectionConversion,
             rule: "eager-collection-conversion",
             message,
             span: value.span,
@@ -444,6 +449,7 @@ impl<'a> Linter<'a> {
             };
             let fix = remove_method_call_wrapper_fix(self.source, arg.span, receiver.span);
             self.diagnostics.push(LintDiagnostic {
+                code: Code::LintRedundantClone,
                 rule: "redundant-clone",
                 message,
                 span: arg.span,
@@ -569,6 +575,7 @@ impl<'a> Linter<'a> {
             return;
         }
         self.diagnostics.push(LintDiagnostic {
+            code: Code::LintLongRunningWithoutCleanup,
             rule: "long-running-without-cleanup",
             message: format!(
                 "`{name}` starts long-running work without a defer/finally cleanup path"
@@ -830,6 +837,7 @@ impl<'a> Linter<'a> {
 
     fn warn_missing_mcp_tool_annotations(&mut self, span: Span) {
         self.diagnostics.push(LintDiagnostic {
+            code: Code::LintMcpToolAnnotations,
             rule: "mcp-tool-annotations",
             message: "MCP-exposed `tool_define` registration has no `annotations`".to_string(),
             span,
@@ -844,6 +852,7 @@ impl<'a> Linter<'a> {
 
     fn warn_missing_secret_scan(&mut self, span: Span) {
         self.diagnostics.push(LintDiagnostic {
+            code: Code::LintPrOpenWithoutSecretScan,
             rule: "pr-open-without-secret-scan",
             message: "PR-open flow calls `git::push_pr` without a preceding `secret_scan(...)` in the same handler".to_string(),
             span,
@@ -1107,6 +1116,7 @@ impl<'a> Linter<'a> {
             if let Some(scope) = self.scopes.last() {
                 if scope.contains(name) {
                     self.diagnostics.push(LintDiagnostic {
+                        code: Code::LintShadowVariable,
                         rule: "shadow-variable",
                         message: format!(
                             "cannot redeclare immutable variable `{name}` in the same scope"
@@ -1126,6 +1136,7 @@ impl<'a> Linter<'a> {
             let outer = &self.scopes[..self.scopes.len() - 1];
             if outer.iter().any(|s| s.contains(name)) {
                 self.diagnostics.push(LintDiagnostic {
+                    code: Code::LintShadowVariable,
                     rule: "shadow-variable",
                     message: format!("variable `{name}` shadows a variable in an outer scope"),
                     span,
@@ -1159,6 +1170,7 @@ impl<'a> Linter<'a> {
             let outer = &self.scopes[..self.scopes.len() - 1];
             if outer.iter().any(|s| s.contains(name)) {
                 self.diagnostics.push(LintDiagnostic {
+                    code: Code::LintShadowVariable,
                     rule: "shadow-variable",
                     message: format!("variable `{name}` shadows a variable in an outer scope"),
                     span,
@@ -1447,6 +1459,7 @@ impl<'a> Linter<'a> {
             .collect();
         if matching_personas.is_empty() {
             self.diagnostics.push(LintDiagnostic {
+                code: Code::LintPersonaHookTarget,
                 rule: "persona-hook-target",
                 message: format!(
                     "`register_step_hook` pattern `{persona_pattern}` does not match a statically declared `@persona`"
@@ -1466,6 +1479,7 @@ impl<'a> Linter<'a> {
             return;
         }
         self.diagnostics.push(LintDiagnostic {
+            code: Code::LintPersonaHookTarget,
             rule: "persona-hook-target",
             message: format!(
                 "`register_step_hook` targets step `{step_name}`, but it is not declared by persona(s): {}",
@@ -1501,6 +1515,7 @@ impl<'a> Linter<'a> {
         for (idx, node) in nodes.iter().enumerate() {
             if found_terminator {
                 self.diagnostics.push(LintDiagnostic {
+                    code: Code::LintDeadCodeAfterReturn,
                     rule: "dead-code-after-return",
                     message: "unreachable code after a terminating statement".to_string(),
                     span: node.span,
@@ -1564,6 +1579,7 @@ impl<'a> Linter<'a> {
             }])
         });
         self.diagnostics.push(LintDiagnostic {
+            code: Code::LintLetThenReturn,
             rule: "let-then-return",
             message: format!("binding `{name}` is immediately returned"),
             span: Span::with_offsets(
@@ -1596,6 +1612,7 @@ impl<'a> Linter<'a> {
             _ => return,
         };
         self.diagnostics.push(LintDiagnostic {
+            code: Code::LintUnhandledApprovalResult,
             rule: "unhandled-approval-result",
             message: format!("approval result from `{name}` is discarded"),
             span: node.span,
@@ -1615,8 +1632,9 @@ impl<'a> Linter<'a> {
                 continue;
             }
             if !self.references.contains(&decl.name) {
-                let (rule, message, suggestion, fix) = if decl.is_simple_ident {
+                let (code, rule, message, suggestion, fix) = if decl.is_simple_ident {
                     (
+                        Code::LintUnusedVariable,
                         "unused-variable",
                         format!("variable `{}` is declared but never used", decl.name),
                         format!("prefix with underscore: `_{}`", decl.name),
@@ -1624,6 +1642,7 @@ impl<'a> Linter<'a> {
                     )
                 } else {
                     (
+                        Code::LintUnusedPatternBinding,
                         "unused-pattern-binding",
                         format!("pattern binding `{}` is never used", decl.name),
                         "rename the binding with an underscore prefix or remove it from the pattern"
@@ -1632,6 +1651,7 @@ impl<'a> Linter<'a> {
                     )
                 };
                 self.diagnostics.push(LintDiagnostic {
+                    code,
                     rule,
                     message,
                     span: decl.span,
@@ -1648,6 +1668,7 @@ impl<'a> Linter<'a> {
             }
             if !self.references.contains(&decl.name) {
                 self.diagnostics.push(LintDiagnostic {
+                    code: Code::LintUnusedParameter,
                     rule: "unused-parameter",
                     message: format!("parameter `{}` is declared but never used", decl.name),
                     span: decl.span,
@@ -1719,6 +1740,7 @@ impl<'a> Linter<'a> {
                     }
                 });
                 self.diagnostics.push(LintDiagnostic {
+                    code: Code::LintUnusedImport,
                     rule: "unused-import",
                     message: format!("imported name `{name}` is never used"),
                     span: import.span,
@@ -1749,6 +1771,7 @@ impl<'a> Linter<'a> {
                     }])
                 });
                 self.diagnostics.push(LintDiagnostic {
+                    code: Code::LintMutableNeverReassigned,
                     rule: "mutable-never-reassigned",
                     message: format!(
                         "variable `{}` is declared as `var` but never reassigned",
@@ -1771,6 +1794,7 @@ impl<'a> Linter<'a> {
             }
             if !self.function_references.contains(&decl.name) {
                 self.diagnostics.push(LintDiagnostic {
+                    code: Code::LintUnusedFunction,
                     rule: "unused-function",
                     message: format!("function `{}` is declared but never used", decl.name),
                     span: decl.span,
@@ -1790,6 +1814,7 @@ impl<'a> Linter<'a> {
             }
             if !self.type_references.contains(&decl.name) {
                 self.diagnostics.push(LintDiagnostic {
+                    code: Code::LintUnusedType,
                     rule: "unused-type",
                     message: format!(
                         "{} `{}` is declared but never referenced",
@@ -1820,6 +1845,7 @@ impl<'a> Linter<'a> {
                 continue;
             }
             self.diagnostics.push(LintDiagnostic {
+                code: Code::LintPersonaBodyMustCallSteps,
                 rule: "persona-body-must-call-steps",
                 message: format!(
                     "`@persona` function `{persona_name}` calls `{name}`, which is not declared `@step`"
@@ -1877,6 +1903,7 @@ impl<'a> Linter<'a> {
                 format!("check the spelling or import `{name}`")
             };
             self.diagnostics.push(LintDiagnostic {
+                code: Code::LintUndefinedFunction,
                 rule: "undefined-function",
                 message: format!("function `{name}` is not defined"),
                 span: *span,

--- a/crates/harn-lint/src/linter/walk.rs
+++ b/crates/harn-lint/src/linter/walk.rs
@@ -3,7 +3,7 @@
 //! state-tracking plumbing.
 
 use harn_lexer::{FixEdit, Span, StringSegment};
-use harn_parser::{BindingPattern, Node, SNode};
+use harn_parser::{BindingPattern, DiagnosticCode as Code, Node, SNode};
 
 use super::Linter;
 use crate::decls::{FnDeclaration, ImportInfo, TypeDeclaration};
@@ -33,6 +33,7 @@ impl<'a> Linter<'a> {
                     && !Self::is_test_pipeline_name(name)
                 {
                     self.diagnostics.push(LintDiagnostic {
+                        code: Code::LintPipelineReturnType,
                         rule: "pipeline-return-type",
                         message: format!(
                             "public pipeline `{name}` has no declared return type; \
@@ -91,6 +92,7 @@ impl<'a> Linter<'a> {
                         .is_none()
                 {
                     self.diagnostics.push(LintDiagnostic {
+                        code: Code::LintMissingHarndoc,
                         rule: "missing-harndoc",
                         message: format!(
                             "public function `{name}` is missing a `/** */` doc comment"
@@ -290,6 +292,7 @@ impl<'a> Linter<'a> {
                 }
                 if Self::is_assert_builtin(name) && !self.in_test_pipeline() {
                     self.diagnostics.push(LintDiagnostic {
+                        code: Code::LintAssertOutsideTest,
                         rule: "assert-outside-test",
                         message: format!(
                             "`{name}` is intended for test pipelines, not production control flow"
@@ -304,6 +307,7 @@ impl<'a> Linter<'a> {
                 }
                 if name == "llm_call" && args.get(1).is_some_and(Self::has_interpolation) {
                     self.diagnostics.push(LintDiagnostic {
+                        code: Code::LintPromptInjectionRisk,
                         rule: "prompt-injection-risk",
                         message:
                             "interpolated data in the `llm_call` system prompt can smuggle untrusted instructions"
@@ -322,6 +326,7 @@ impl<'a> Linter<'a> {
                         harn_vm::connector_export_denied_builtin_reason(export, name)
                     {
                         self.diagnostics.push(LintDiagnostic {
+                            code: Code::LintConnectorEffectPolicy,
                             rule: "connector-effect-policy",
                             message: format!(
                                 "connector export `{export}` calls disallowed builtin `{name}`: {reason}"
@@ -341,6 +346,7 @@ impl<'a> Linter<'a> {
                     let fix = unnecessary_cast_fix(self.source, snode.span, inner.span);
                     let article = if matches!(target, "int") { "an" } else { "a" };
                     self.diagnostics.push(LintDiagnostic {
+                        code: Code::LintUnnecessaryCast,
                         rule: "unnecessary-cast",
                         message: format!(
                             "`{name}` is a no-op here — its argument is already {article} {target}"
@@ -380,6 +386,7 @@ impl<'a> Linter<'a> {
                 if let Node::FunctionCall { name, .. } = &object.node {
                     if Self::is_boundary_api(name) {
                         self.diagnostics.push(LintDiagnostic {
+                            code: Code::LintUntypedDictAccess,
                             rule: "untyped-dict-access",
                             message: format!(
                                 "property access on raw `{}()` result without schema validation",
@@ -403,6 +410,7 @@ impl<'a> Linter<'a> {
                 if let Node::FunctionCall { name, .. } = &object.node {
                     if Self::is_boundary_api(name) {
                         self.diagnostics.push(LintDiagnostic {
+                            code: Code::LintUntypedDictAccess,
                             rule: "untyped-dict-access",
                             message: format!(
                                 "subscript access on raw `{}()` result without schema validation",
@@ -437,6 +445,7 @@ impl<'a> Linter<'a> {
                     Self::constant_logical_reduction(op, left, right)
                 {
                     self.diagnostics.push(LintDiagnostic {
+                        code: Code::LintConstantLogicalOperand,
                         rule: "constant-logical-operand",
                         message,
                         span: snode.span,
@@ -454,6 +463,7 @@ impl<'a> Linter<'a> {
                 if is_pointless_self_comparison {
                     let replacement = if op == "==" { "true" } else { "false" };
                     self.diagnostics.push(LintDiagnostic {
+                        code: Code::LintPointlessComparison,
                         rule: "pointless-comparison",
                         message: format!("expression is compared to itself with `{op}`"),
                         span: snode.span,
@@ -499,6 +509,7 @@ impl<'a> Linter<'a> {
                             }])
                         });
                         self.diagnostics.push(LintDiagnostic {
+                            code: Code::LintComparisonToBool,
                             rule: "comparison-to-bool",
                             message: msg.to_string(),
                             span: snode.span,
@@ -543,6 +554,7 @@ impl<'a> Linter<'a> {
                             None
                         };
                         self.diagnostics.push(LintDiagnostic {
+                            code: Code::LintInvalidBinaryOpLiteral,
                             rule: "invalid-binary-op-literal",
                             message: format!(
                                 "operator '{}' used with boolean or nil literal — this will cause a runtime error",
@@ -592,6 +604,7 @@ impl<'a> Linter<'a> {
                         }])
                     });
                     self.diagnostics.push(LintDiagnostic {
+                        code: Code::LintRedundantNilTernary,
                         rule: "redundant-nil-ternary",
                         message: format!(
                             "ternary nil check over `{ident}` can be replaced with `{ident} ?? <fallback>`"
@@ -612,6 +625,7 @@ impl<'a> Linter<'a> {
                 self.lint_node(condition);
                 if let Node::BoolLiteral(value) = &condition.node {
                     self.diagnostics.push(LintDiagnostic {
+                        code: Code::LintPointlessComparison,
                         rule: "pointless-comparison",
                         message: format!("if condition is always `{value}`"),
                         span: condition.span,
@@ -633,6 +647,7 @@ impl<'a> Linter<'a> {
                         None
                     };
                     self.diagnostics.push(LintDiagnostic {
+                        code: Code::LintEmptyBlock,
                         rule: "empty-block",
                         message: "if block has an empty body".to_string(),
                         span: snode.span,
@@ -676,6 +691,7 @@ impl<'a> Linter<'a> {
                             }])
                         });
                         self.diagnostics.push(LintDiagnostic {
+                            code: Code::LintUnnecessaryElseReturn,
                             rule: "unnecessary-else-return",
                             message: "both if and else branches return — else is unnecessary"
                                 .to_string(),
@@ -712,6 +728,7 @@ impl<'a> Linter<'a> {
                         None
                     };
                     self.diagnostics.push(LintDiagnostic {
+                        code: Code::LintEmptyBlock,
                         rule: "empty-block",
                         message: "for loop has an empty body".to_string(),
                         span: snode.span,
@@ -746,6 +763,7 @@ impl<'a> Linter<'a> {
                 self.lint_node(condition);
                 if body.is_empty() {
                     self.diagnostics.push(LintDiagnostic {
+                        code: Code::LintEmptyBlock,
                         rule: "empty-block",
                         message: "while loop has an empty body".to_string(),
                         span: snode.span,
@@ -771,6 +789,7 @@ impl<'a> Linter<'a> {
             } => {
                 if body.is_empty() {
                     self.diagnostics.push(LintDiagnostic {
+                        code: Code::LintEmptyBlock,
                         rule: "empty-block",
                         message: "try block has an empty body".to_string(),
                         span: snode.span,
@@ -812,6 +831,7 @@ impl<'a> Linter<'a> {
                     for earlier in &arms[..i] {
                         if arm.pattern.node == earlier.pattern.node && arm.guard == earlier.guard {
                             self.diagnostics.push(LintDiagnostic {
+                                code: Code::LintDuplicateMatchArm,
                                 rule: "duplicate-match-arm",
                                 message: "duplicate match arm pattern".to_string(),
                                 span: arm.pattern.span,
@@ -906,6 +926,7 @@ impl<'a> Linter<'a> {
             Node::RequireStmt { condition, message } => {
                 if self.in_test_pipeline() {
                     self.diagnostics.push(LintDiagnostic {
+                        code: Code::LintRequireInTest,
                         rule: "require-in-test",
                         message: "`require` in a test pipeline should usually be an assertion"
                             .to_string(),
@@ -1159,6 +1180,7 @@ impl<'a> Linter<'a> {
                         "continue"
                     };
                     self.diagnostics.push(LintDiagnostic {
+                        code: Code::LintBreakOutsideLoop,
                         rule: "break-outside-loop",
                         message: format!("`{keyword}` used outside of a loop"),
                         span: snode.span,

--- a/crates/harn-lint/src/rules/blank_lines.rs
+++ b/crates/harn-lint/src/rules/blank_lines.rs
@@ -3,7 +3,7 @@
 //! an item treated as part of that item.
 
 use harn_lexer::{FixEdit, Span};
-use harn_parser::SNode;
+use harn_parser::{DiagnosticCode as Code, SNode};
 
 use crate::diagnostic::{LintDiagnostic, LintSeverity};
 use crate::harndoc::{collect_comment_tokens, LegacyCommentTok};
@@ -68,6 +68,7 @@ pub(crate) fn check_blank_line_between_items(
             };
             let span = Span::with_offsets(insert_offset, insert_offset, insert_line, 1);
             diagnostics.push(LintDiagnostic {
+                code: Code::LintBlankLineBetweenItems,
                 rule: "blank-line-between-items",
                 message: "top-level items should be separated by a blank line".to_string(),
                 span,

--- a/crates/harn-lint/src/rules/deprecated_llm_options.rs
+++ b/crates/harn-lint/src/rules/deprecated_llm_options.rs
@@ -6,7 +6,7 @@
 //! `std/llm/handlers`.
 
 use harn_lexer::Span;
-use harn_parser::{DictEntry, MatchArm, Node, SNode, SelectCase};
+use harn_parser::{DiagnosticCode as Code, DictEntry, MatchArm, Node, SNode, SelectCase};
 
 use crate::diagnostic::{LintDiagnostic, LintSeverity};
 
@@ -317,6 +317,7 @@ fn make_diagnostic(key: &str, span: Span) -> LintDiagnostic {
         "remove `{key}` from this options dict and wrap the call with `with_retry(default_llm_caller(), {{max_attempts: N+1}})` from `std/llm/handlers`."
     ));
     LintDiagnostic {
+        code: Code::LintDeprecatedLlmOptions,
         rule: RULE_NAME,
         message,
         span,

--- a/crates/harn-lint/src/rules/file_header.rs
+++ b/crates/harn-lint/src/rules/file_header.rs
@@ -3,6 +3,7 @@
 //! title from the filename when autofixing.
 
 use harn_lexer::{FixEdit, Span};
+use harn_parser::DiagnosticCode as Code;
 
 use crate::diagnostic::{LintDiagnostic, LintSeverity};
 
@@ -26,6 +27,7 @@ pub(crate) fn check_require_file_header(
     let header = format!("/**\n * {title}\n */\n\n");
     let span = Span::with_offsets(0, 0, 1, 1);
     diagnostics.push(LintDiagnostic {
+        code: Code::LintRequireFileHeader,
         rule: "require-file-header",
         message: "file is missing a `/** */` header doc block".to_string(),
         span,

--- a/crates/harn-lint/src/rules/import_order.rs
+++ b/crates/harn-lint/src/rules/import_order.rs
@@ -3,7 +3,7 @@
 //! after bare imports for the same path.
 
 use harn_lexer::{FixEdit, Span};
-use harn_parser::{Node, SNode};
+use harn_parser::{DiagnosticCode as Code, Node, SNode};
 
 use crate::diagnostic::{LintDiagnostic, LintSeverity};
 use crate::naming::is_import_item;
@@ -59,6 +59,7 @@ pub(crate) fn check_import_order(
         }])
     };
     diagnostics.push(LintDiagnostic {
+        code: Code::LintImportOrder,
         rule: "import-order",
         message: "imports are not in canonical order (stdlib first, then alphabetical by path)"
             .to_string(),

--- a/crates/harn-lint/src/rules/optional_shorthand.rs
+++ b/crates/harn-lint/src/rules/optional_shorthand.rs
@@ -8,8 +8,8 @@ use std::collections::HashSet;
 
 use harn_lexer::{FixEdit, Span, TokenKind};
 use harn_parser::{
-    format_type, EnumVariant, InterfaceMethod, MatchArm, Node, SNode, ShapeField, StructField,
-    TypeExpr, TypedParam,
+    format_type, DiagnosticCode as Code, EnumVariant, InterfaceMethod, MatchArm, Node, SNode,
+    ShapeField, StructField, TypeExpr, TypedParam,
 };
 
 use crate::diagnostic::{LintDiagnostic, LintSeverity};
@@ -521,6 +521,7 @@ impl<'a, 'd> State<'a, 'd> {
         );
         let replacement = format!("{inner_text}?");
         self.diagnostics.push(LintDiagnostic {
+            code: Code::LintPreferOptionalShorthand,
             rule: "prefer-optional-shorthand",
             message: format!("prefer `{inner_text}?` over `{inner_text} | nil`"),
             span,

--- a/crates/harn-lint/src/rules/template_provider_identity.rs
+++ b/crates/harn-lint/src/rules/template_provider_identity.rs
@@ -13,6 +13,7 @@
 //! that matches the branch's intent.
 
 use harn_lexer::Span;
+use harn_parser::DiagnosticCode as Code;
 use harn_vm::stdlib::template::lint::{ConditionShape, IdentityField, LintConstruct};
 
 use crate::diagnostic::{LintDiagnostic, LintSeverity};
@@ -63,6 +64,7 @@ fn make_diagnostic(field: IdentityField, line: usize, col: usize, source: &str) 
         suggestion_text,
     );
     LintDiagnostic {
+        code: Code::LintTemplateProviderIdentityBranch,
         rule: RULE_NAME,
         message,
         span,

--- a/crates/harn-lint/src/rules/template_variant_explosion.rs
+++ b/crates/harn-lint/src/rules/template_variant_explosion.rs
@@ -10,6 +10,7 @@
 //! `[lint] template_variant_branch_threshold` in `harn.toml`.
 
 use harn_lexer::Span;
+use harn_parser::DiagnosticCode as Code;
 use harn_vm::stdlib::template::lint::{ConditionShape, LintConstruct};
 
 use crate::diagnostic::{LintDiagnostic, LintSeverity};
@@ -55,6 +56,7 @@ pub(crate) fn check(
          one shared place instead of being scattered across the prompt.",
     );
     vec![LintDiagnostic {
+        code: Code::LintTemplateVariantExplosion,
         rule: RULE_NAME,
         message,
         span,

--- a/crates/harn-lint/src/rules/trailing_comma.rs
+++ b/crates/harn-lint/src/rules/trailing_comma.rs
@@ -6,6 +6,7 @@
 //! a post-pass, and `harn lint --fix` surfaces the same diagnostics.
 
 use harn_fmt::{trailing_comma_issues, TrailingCommaKind};
+use harn_parser::DiagnosticCode as Code;
 
 use crate::diagnostic::{LintDiagnostic, LintSeverity};
 
@@ -22,6 +23,7 @@ pub(crate) fn check_trailing_comma(source: &str, diagnostics: &mut Vec<LintDiagn
             ),
         };
         diagnostics.push(LintDiagnostic {
+            code: Code::LintTrailingComma,
             rule: "trailing-comma",
             message: message.to_string(),
             span: issue.edit.span,

--- a/crates/harn-lint/src/rules/unnecessary_parentheses.rs
+++ b/crates/harn-lint/src/rules/unnecessary_parentheses.rs
@@ -5,7 +5,7 @@
 use std::collections::HashSet;
 
 use harn_lexer::{FixEdit, Span, Token, TokenKind};
-use harn_parser::{Node, SNode};
+use harn_parser::{DiagnosticCode as Code, Node, SNode};
 
 use crate::diagnostic::{LintDiagnostic, LintSeverity};
 use crate::rules::ast_walk::collect_expression_spans;
@@ -38,6 +38,7 @@ pub(crate) fn check_unnecessary_parentheses(
                 {
                     let open = &tokens[open_idx];
                     diagnostics.push(LintDiagnostic {
+                        code: Code::LintUnnecessaryParentheses,
                         rule: "unnecessary-parentheses",
                         message: "unnecessary parentheses around a single value".to_string(),
                         span: Span::merge(open.span, token.span),

--- a/crates/harn-lsp/src/document.rs
+++ b/crates/harn-lsp/src/document.rs
@@ -95,6 +95,7 @@ impl DocumentState {
                 range,
                 severity: Some(severity),
                 source: Some("harn-typecheck".to_string()),
+                code: Some(NumberOrString::String(diag.code.to_string())),
                 message: diag.message.clone(),
                 ..Default::default()
             });
@@ -125,6 +126,7 @@ impl DocumentState {
                 range,
                 severity: Some(severity),
                 source: Some("harn-lint".to_string()),
+                code: Some(NumberOrString::String(ld.code.to_string())),
                 message: format!("[{}] {}", ld.rule, ld.message),
                 ..Default::default()
             });

--- a/crates/harn-lsp/src/helpers.rs
+++ b/crates/harn-lsp/src/helpers.rs
@@ -294,6 +294,9 @@ pub(crate) fn lexer_error_to_diagnostic(err: &LexerError) -> Diagnostic {
         },
         severity: Some(DiagnosticSeverity::ERROR),
         source: Some("harn".to_string()),
+        code: Some(NumberOrString::String(
+            diagnostic::lexer_error_code(err).to_string(),
+        )),
         message,
         ..Default::default()
     }
@@ -308,6 +311,9 @@ pub(crate) fn parser_error_to_diagnostic(err: &ParserError) -> Diagnostic {
             },
             severity: Some(DiagnosticSeverity::ERROR),
             source: Some("harn".to_string()),
+            code: Some(NumberOrString::String(
+                diagnostic::parser_error_code(err).to_string(),
+            )),
             message: diagnostic::parser_error_message(err),
             ..Default::default()
         },
@@ -321,6 +327,9 @@ pub(crate) fn parser_error_to_diagnostic(err: &ParserError) -> Diagnostic {
             },
             severity: Some(DiagnosticSeverity::ERROR),
             source: Some("harn".to_string()),
+            code: Some(NumberOrString::String(
+                diagnostic::parser_error_code(err).to_string(),
+            )),
             message: diagnostic::parser_error_message(err),
             ..Default::default()
         },

--- a/crates/harn-parser/src/diagnostic.rs
+++ b/crates/harn-parser/src/diagnostic.rs
@@ -119,7 +119,40 @@ pub fn render_diagnostic(
     label: Option<&str>,
     help: Option<&str>,
 ) -> String {
-    render_diagnostic_with_related(source, filename, span, severity, message, label, help, &[])
+    render_diagnostic_inner(RenderDiagnostic {
+        source,
+        filename,
+        span,
+        severity,
+        code: None,
+        message,
+        label,
+        help,
+        related: &[],
+    })
+}
+
+pub fn render_diagnostic_with_code(
+    source: &str,
+    filename: &str,
+    span: &Span,
+    severity: &str,
+    code: crate::diagnostic_codes::Code,
+    message: &str,
+    label: Option<&str>,
+    help: Option<&str>,
+) -> String {
+    render_diagnostic_inner(RenderDiagnostic {
+        source,
+        filename,
+        span,
+        severity,
+        code: Some(code.as_str()),
+        message,
+        label,
+        help,
+        related: &[],
+    })
 }
 
 pub fn render_diagnostic_with_related(
@@ -132,8 +165,41 @@ pub fn render_diagnostic_with_related(
     help: Option<&str>,
     related: &[RelatedSpanLabel<'_>],
 ) -> String {
+    render_diagnostic_inner(RenderDiagnostic {
+        source,
+        filename,
+        span,
+        severity,
+        code: None,
+        message,
+        label,
+        help,
+        related,
+    })
+}
+
+struct RenderDiagnostic<'a> {
+    source: &'a str,
+    filename: &'a str,
+    span: &'a Span,
+    severity: &'a str,
+    code: Option<&'a str>,
+    message: &'a str,
+    label: Option<&'a str>,
+    help: Option<&'a str>,
+    related: &'a [RelatedSpanLabel<'a>],
+}
+
+fn render_diagnostic_inner(input: RenderDiagnostic<'_>) -> String {
     let mut out = String::new();
-    let filename = normalize_diagnostic_path(filename);
+    let source = input.source;
+    let span = input.span;
+    let severity = input.severity;
+    let message = input.message;
+    let label = input.label;
+    let help = input.help;
+    let related = input.related;
+    let filename = normalize_diagnostic_path(input.filename);
     let severity_color = severity_color(severity);
     let gutter = style_fragment("|", Color::Blue, false);
     let arrow = style_fragment("-->", Color::Blue, true);
@@ -141,6 +207,11 @@ pub fn render_diagnostic_with_related(
     let note_prefix = style_fragment("note", Color::Magenta, true);
 
     out.push_str(&style_fragment(severity, severity_color, true));
+    if let Some(code) = input.code {
+        out.push('[');
+        out.push_str(code);
+        out.push(']');
+    }
     out.push_str(": ");
     out.push_str(message);
     out.push('\n');
@@ -244,17 +315,43 @@ pub fn render_type_diagnostic(
         .collect::<Vec<_>>();
     let primary_label = type_diagnostic_primary_label(diag);
     match &diag.span {
-        Some(span) => render_diagnostic_with_related(
+        Some(span) => render_diagnostic_inner(RenderDiagnostic {
             source,
             filename,
             span,
             severity,
-            &diag.message,
-            primary_label.as_deref(),
-            diag.help.as_deref(),
-            &related,
-        ),
-        None => format!("{severity}: {}\n", diag.message),
+            code: Some(diag.code.as_str()),
+            message: &diag.message,
+            label: primary_label.as_deref(),
+            help: diag.help.as_deref(),
+            related: &related,
+        }),
+        None => format!("{severity}[{}]: {}\n", diag.code, diag.message),
+    }
+}
+
+pub fn lexer_error_code(err: &harn_lexer::LexerError) -> crate::diagnostic_codes::Code {
+    match err {
+        harn_lexer::LexerError::UnexpectedCharacter(_, _) => {
+            crate::diagnostic_codes::Code::ParserUnexpectedCharacter
+        }
+        harn_lexer::LexerError::UnterminatedString(_) => {
+            crate::diagnostic_codes::Code::ParserUnterminatedString
+        }
+        harn_lexer::LexerError::UnterminatedBlockComment(_) => {
+            crate::diagnostic_codes::Code::ParserUnterminatedBlockComment
+        }
+    }
+}
+
+pub fn parser_error_code(err: &crate::parser::ParserError) -> crate::diagnostic_codes::Code {
+    match err {
+        crate::parser::ParserError::Unexpected { .. } => {
+            crate::diagnostic_codes::Code::ParserUnexpectedToken
+        }
+        crate::parser::ParserError::UnexpectedEof { .. } => {
+            crate::diagnostic_codes::Code::ParserUnexpectedEof
+        }
     }
 }
 

--- a/crates/harn-parser/src/diagnostic_codes.rs
+++ b/crates/harn-parser/src/diagnostic_codes.rs
@@ -1,0 +1,370 @@
+//! Stable diagnostic code registry.
+//!
+//! Codes use `HARN-<CATEGORY>-<NNN>` identifiers so CLI output, editor
+//! diagnostics, docs, and future `harn explain` lookups can refer to one
+//! durable namespace.
+//!
+//! ```
+//! use harn_parser::diagnostic_codes::Category;
+//!
+//! let categories: Vec<_> = Category::ALL.iter().map(|category| category.as_str()).collect();
+//! assert_eq!(
+//!     categories,
+//!     [
+//!         "TYP", "PAR", "NAM", "CAP", "LLM", "ORC", "STD", "PRM",
+//!         "MOD", "LNT", "FMT", "IMP", "OWN", "RCV", "MAT",
+//!     ],
+//! );
+//! ```
+
+use std::fmt;
+use std::str::FromStr;
+
+/// Top-level diagnostic category used in a stable Harn diagnostic code.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum Category {
+    Typ,
+    Par,
+    Nam,
+    Cap,
+    Llm,
+    Orc,
+    Std,
+    Prm,
+    Mod,
+    Lnt,
+    Fmt,
+    Imp,
+    Own,
+    Rcv,
+    Mat,
+}
+
+impl Category {
+    pub const ALL: &'static [Category] = &[
+        Category::Typ,
+        Category::Par,
+        Category::Nam,
+        Category::Cap,
+        Category::Llm,
+        Category::Orc,
+        Category::Std,
+        Category::Prm,
+        Category::Mod,
+        Category::Lnt,
+        Category::Fmt,
+        Category::Imp,
+        Category::Own,
+        Category::Rcv,
+        Category::Mat,
+    ];
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Category::Typ => "TYP",
+            Category::Par => "PAR",
+            Category::Nam => "NAM",
+            Category::Cap => "CAP",
+            Category::Llm => "LLM",
+            Category::Orc => "ORC",
+            Category::Std => "STD",
+            Category::Prm => "PRM",
+            Category::Mod => "MOD",
+            Category::Lnt => "LNT",
+            Category::Fmt => "FMT",
+            Category::Imp => "IMP",
+            Category::Own => "OWN",
+            Category::Rcv => "RCV",
+            Category::Mat => "MAT",
+        }
+    }
+}
+
+impl fmt::Display for Category {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// One registered diagnostic code.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RegistryEntry {
+    pub code: Code,
+    pub identifier: &'static str,
+    pub category: Category,
+    pub summary: &'static str,
+}
+
+macro_rules! diagnostic_codes {
+    ($($variant:ident, $identifier:literal, $category:ident, $summary:literal;)*) => {
+        /// Stable diagnostic identifier.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+        pub enum Code {
+            $($variant,)*
+        }
+
+        impl Code {
+            pub const ALL: &'static [Code] = &[
+                $(Code::$variant,)*
+            ];
+
+            pub const fn as_str(self) -> &'static str {
+                match self {
+                    $(Code::$variant => $identifier,)*
+                }
+            }
+
+            pub const fn category(self) -> Category {
+                match self {
+                    $(Code::$variant => Category::$category,)*
+                }
+            }
+
+            pub const fn summary(self) -> &'static str {
+                match self {
+                    $(Code::$variant => $summary,)*
+                }
+            }
+        }
+
+        pub const REGISTRY: &[RegistryEntry] = &[
+            $(RegistryEntry {
+                code: Code::$variant,
+                identifier: $identifier,
+                category: Category::$category,
+                summary: $summary,
+            },)*
+        ];
+    };
+}
+
+diagnostic_codes! {
+    TypeMismatch, "HARN-TYP-001", Typ, "expected and actual types are incompatible";
+    InvalidBinaryOperator, "HARN-TYP-002", Typ, "binary operator is not defined for the operand types";
+    StringInterpolationRewrite, "HARN-TYP-003", Typ, "string concatenation should be rewritten as interpolation";
+    ReturnTypeMismatch, "HARN-TYP-004", Typ, "returned expression does not match the declared return type";
+    AssignmentTypeMismatch, "HARN-TYP-005", Typ, "assigned value does not match the target type";
+    ArgumentTypeMismatch, "HARN-TYP-006", Typ, "argument value does not match the parameter type";
+    VariableTypeMismatch, "HARN-TYP-007", Typ, "initializer does not match the declared variable type";
+    ClosureReturnTypeMismatch, "HARN-TYP-008", Typ, "closure return expression does not match its declared type";
+    FieldTypeMismatch, "HARN-TYP-009", Typ, "field value does not match its declared type";
+    MethodTypeMismatch, "HARN-TYP-010", Typ, "method receiver or result type is incompatible";
+    GenericTypeArgumentUnsupported, "HARN-TYP-011", Typ, "callable does not accept type arguments";
+    GenericTypeArgumentMismatch, "HARN-TYP-012", Typ, "type argument does not satisfy the generic parameter";
+    GenericTypeArgumentArity, "HARN-TYP-013", Typ, "generic call has the wrong number of type arguments";
+    TypeParameterArity, "HARN-TYP-014", Typ, "declaration has the wrong number of type parameters";
+    WhereConstraintMismatch, "HARN-TYP-015", Typ, "type argument does not satisfy a where-clause constraint";
+    IterableExpected, "HARN-TYP-016", Typ, "expression must be iterable";
+    InvalidIndexType, "HARN-TYP-017", Typ, "subscript index type is invalid";
+    CallableExpected, "HARN-TYP-018", Typ, "expression must be callable";
+    InvalidCast, "HARN-TYP-019", Typ, "cast cannot be proven valid";
+    UnknownTypeName, "HARN-TYP-020", Typ, "type name cannot be resolved";
+    InvalidVariantUse, "HARN-TYP-021", Typ, "variant type is used in an invalid position";
+    InvalidStructLiteral, "HARN-TYP-022", Typ, "struct literal is invalid";
+    InvalidEnumConstruct, "HARN-TYP-023", Typ, "enum construction is invalid";
+    InvalidPatternBinding, "HARN-TYP-024", Typ, "pattern binding is invalid for the expected type";
+    InvalidOptionalAccess, "HARN-TYP-025", Typ, "optional access is invalid for the receiver type";
+    ParserUnexpectedToken, "HARN-PAR-001", Par, "parser found an unexpected token";
+    ParserUnexpectedEof, "HARN-PAR-002", Par, "parser reached end of file while expecting syntax";
+    ParserUnexpectedCharacter, "HARN-PAR-003", Par, "lexer found an unexpected character";
+    ParserUnterminatedString, "HARN-PAR-004", Par, "string literal is unterminated";
+    ParserUnterminatedBlockComment, "HARN-PAR-005", Par, "block comment is unterminated";
+    UndefinedVariable, "HARN-NAM-001", Nam, "variable name cannot be resolved";
+    UndefinedFunction, "HARN-NAM-002", Nam, "function name cannot be resolved";
+    UnknownAttribute, "HARN-NAM-003", Nam, "attribute name is not recognized";
+    UnknownField, "HARN-NAM-004", Nam, "field name does not exist on the target type";
+    UnknownMethod, "HARN-NAM-005", Nam, "method name does not exist on the receiver type";
+    DuplicateArgument, "HARN-NAM-006", Nam, "argument name is duplicated";
+    UnknownOption, "HARN-NAM-007", Nam, "option key is not recognized";
+    UnknownBuiltin, "HARN-NAM-008", Nam, "builtin name cannot be resolved";
+    DeprecatedFunction, "HARN-NAM-009", Nam, "function call targets a deprecated declaration";
+    UnknownDeclaration, "HARN-NAM-010", Nam, "declaration reference cannot be resolved";
+    InvalidAttributeTarget, "HARN-NAM-011", Nam, "attribute is attached to an unsupported declaration";
+    InvalidAttributeArgument, "HARN-NAM-012", Nam, "attribute argument is invalid";
+    CapabilityPayloadInvalid, "HARN-CAP-001", Cap, "capability payload is invalid";
+    HitlMissingApprovalPolicy, "HARN-CAP-002", Cap, "human approval construct is missing policy";
+    HitlInvalidApprovalArgument, "HARN-CAP-003", Cap, "human approval argument is invalid";
+    CapabilityResultUnchecked, "HARN-CAP-004", Cap, "capability result must be checked";
+    CapabilityUnknownOperation, "HARN-CAP-005", Cap, "host capability operation is not declared";
+    CapabilityCallStaticNameRequired, "HARN-CAP-006", Cap, "host capability call must use a static operation name";
+    CapabilityBindingInvalid, "HARN-CAP-007", Cap, "tool host capability binding is invalid";
+    UnknownLlmOption, "HARN-LLM-001", Llm, "LLM option key is not recognized";
+    DeprecatedLlmOption, "HARN-LLM-002", Llm, "LLM option key is deprecated";
+    LlmSchemaMissing, "HARN-LLM-003", Llm, "LLM call is missing schema validation";
+    LlmSchemaInvalid, "HARN-LLM-004", Llm, "LLM schema option is invalid";
+    LlmProviderIdentityBranch, "HARN-LLM-005", Llm, "prompt branches on provider identity instead of capability flags";
+    OrchestrationArity, "HARN-ORC-001", Orc, "orchestration construct has invalid arity";
+    OrchestrationType, "HARN-ORC-002", Orc, "orchestration construct argument has invalid type";
+    AgentDefinitionInvalid, "HARN-ORC-003", Orc, "agent declaration is invalid";
+    WorkflowDefinitionInvalid, "HARN-ORC-004", Orc, "workflow declaration is invalid";
+    ToolDefinitionInvalid, "HARN-ORC-005", Orc, "tool declaration is invalid";
+    PipelineDefinitionInvalid, "HARN-ORC-006", Orc, "pipeline declaration is invalid";
+    InvalidSelectConstruct, "HARN-ORC-007", Orc, "select construct is invalid";
+    UnreachableCode, "HARN-ORC-008", Orc, "statement cannot be reached";
+    FlowInvariantAttributeInvalid, "HARN-ORC-009", Orc, "Flow invariant attribute set is invalid";
+    ExecutionTargetMissing, "HARN-ORC-010", Orc, "execution target path cannot be found";
+    DeprecatedStdlibSymbol, "HARN-STD-001", Std, "stdlib symbol has been renamed or deprecated";
+    StdlibUsageInvalid, "HARN-STD-002", Std, "stdlib call is invalid";
+    BuiltinArity, "HARN-STD-003", Std, "builtin call has invalid arity";
+    PromptTemplateParse, "HARN-PRM-001", Prm, "prompt template cannot be parsed";
+    PromptVariantExplosion, "HARN-PRM-002", Prm, "prompt template has too many capability-aware branches";
+    PromptInjectionRisk, "HARN-PRM-003", Prm, "prompt construction risks direct injection";
+    PromptProviderIdentityBranch, "HARN-PRM-004", Prm, "prompt template branches on provider identity";
+    PromptToolSurfaceUnknown, "HARN-PRM-005", Prm, "prompt references a tool outside the declared surface";
+    PromptToolSurfaceDeferredReference, "HARN-PRM-006", Prm, "prompt references a deferred tool without tool search";
+    PromptTargetMissing, "HARN-PRM-007", Prm, "prompt or template target cannot be found";
+    ModuleImportUnresolved, "HARN-MOD-001", Mod, "module import cannot be resolved";
+    ModuleImportUnused, "HARN-MOD-002", Mod, "module import is unused";
+    ModuleImportOrder, "HARN-MOD-003", Mod, "module imports are not in canonical order";
+    ModuleExportInvalid, "HARN-MOD-004", Mod, "module export is invalid";
+    ModuleImportCollision, "HARN-MOD-005", Mod, "module imports expose colliding names";
+    ModuleReExportConflict, "HARN-MOD-006", Mod, "module re-exports conflict";
+    LintRenamedStdlibSymbol, "HARN-LNT-001", Lnt, "renamed stdlib symbol lint";
+    LintCyclomaticComplexity, "HARN-LNT-002", Lnt, "cyclomatic complexity lint";
+    LintNamingConvention, "HARN-LNT-003", Lnt, "naming convention lint";
+    LintEagerCollectionConversion, "HARN-LNT-004", Lnt, "eager collection conversion lint";
+    LintRedundantClone, "HARN-LNT-005", Lnt, "redundant clone lint";
+    LintLongRunningWithoutCleanup, "HARN-LNT-006", Lnt, "long-running workflow cleanup lint";
+    LintMcpToolAnnotations, "HARN-LNT-007", Lnt, "MCP tool annotations lint";
+    LintPrOpenWithoutSecretScan, "HARN-LNT-008", Lnt, "PR open without secret scan lint";
+    LintShadowVariable, "HARN-LNT-009", Lnt, "shadow variable lint";
+    LintPersonaHookTarget, "HARN-LNT-010", Lnt, "persona hook target lint";
+    LintDeadCodeAfterReturn, "HARN-LNT-011", Lnt, "dead code after return lint";
+    LintLetThenReturn, "HARN-LNT-012", Lnt, "let then return lint";
+    LintUnhandledApprovalResult, "HARN-LNT-013", Lnt, "unhandled approval result lint";
+    LintUnusedVariable, "HARN-LNT-014", Lnt, "unused variable lint";
+    LintUnusedPatternBinding, "HARN-LNT-015", Lnt, "unused pattern binding lint";
+    LintUnusedParameter, "HARN-LNT-016", Lnt, "unused parameter lint";
+    LintUnusedImport, "HARN-LNT-017", Lnt, "unused import lint";
+    LintMutableNeverReassigned, "HARN-LNT-018", Lnt, "mutable never reassigned lint";
+    LintUnusedFunction, "HARN-LNT-019", Lnt, "unused function lint";
+    LintUnusedType, "HARN-LNT-020", Lnt, "unused type lint";
+    LintPersonaBodyMustCallSteps, "HARN-LNT-021", Lnt, "persona body must call steps lint";
+    LintUndefinedFunction, "HARN-LNT-022", Lnt, "undefined function lint";
+    LintPipelineReturnType, "HARN-LNT-023", Lnt, "pipeline return type lint";
+    LintMissingHarndoc, "HARN-LNT-024", Lnt, "missing harndoc lint";
+    LintAssertOutsideTest, "HARN-LNT-025", Lnt, "assert outside test lint";
+    LintPromptInjectionRisk, "HARN-LNT-026", Lnt, "prompt injection risk lint";
+    LintConnectorEffectPolicy, "HARN-LNT-027", Lnt, "connector effect policy lint";
+    LintUnnecessaryCast, "HARN-LNT-028", Lnt, "unnecessary cast lint";
+    LintUntypedDictAccess, "HARN-LNT-029", Lnt, "untyped dict access lint";
+    LintConstantLogicalOperand, "HARN-LNT-030", Lnt, "constant logical operand lint";
+    LintPointlessComparison, "HARN-LNT-031", Lnt, "pointless comparison lint";
+    LintComparisonToBool, "HARN-LNT-032", Lnt, "comparison to bool lint";
+    LintInvalidBinaryOpLiteral, "HARN-LNT-033", Lnt, "invalid binary operator literal lint";
+    LintRedundantNilTernary, "HARN-LNT-034", Lnt, "redundant nil ternary lint";
+    LintEmptyBlock, "HARN-LNT-035", Lnt, "empty block lint";
+    LintUnnecessaryElseReturn, "HARN-LNT-036", Lnt, "unnecessary else return lint";
+    LintDuplicateMatchArm, "HARN-LNT-037", Lnt, "duplicate match arm lint";
+    LintRequireInTest, "HARN-LNT-038", Lnt, "require in test lint";
+    LintBreakOutsideLoop, "HARN-LNT-039", Lnt, "break outside loop lint";
+    LintTemplateParse, "HARN-LNT-040", Lnt, "template parse lint";
+    LintBlankLineBetweenItems, "HARN-LNT-041", Lnt, "blank line between items lint";
+    LintTrailingComma, "HARN-LNT-042", Lnt, "trailing comma lint";
+    LintUnnecessaryParentheses, "HARN-LNT-043", Lnt, "unnecessary parentheses lint";
+    LintTemplateVariantExplosion, "HARN-LNT-044", Lnt, "template variant explosion lint";
+    LintRequireFileHeader, "HARN-LNT-045", Lnt, "require file header lint";
+    LintTemplateProviderIdentityBranch, "HARN-LNT-046", Lnt, "template provider identity branch lint";
+    LintImportOrder, "HARN-LNT-047", Lnt, "import order lint";
+    LintPreferOptionalShorthand, "HARN-LNT-048", Lnt, "prefer optional shorthand lint";
+    LintLegacyDocComment, "HARN-LNT-049", Lnt, "legacy doc comment lint";
+    LintDeprecatedLlmOptions, "HARN-LNT-050", Lnt, "deprecated LLM options lint";
+    LintUnnecessarySafeNavigation, "HARN-LNT-051", Lnt, "unnecessary safe navigation lint";
+    FormatterParseFailed, "HARN-FMT-001", Fmt, "formatter could not parse the source";
+    FormatterWouldReformat, "HARN-FMT-002", Fmt, "source is not in canonical format";
+    FormatterTrailingComma, "HARN-FMT-003", Fmt, "formatter normalized trailing comma layout";
+    ImportResolutionFailed, "HARN-IMP-001", Imp, "import target cannot be resolved";
+    ImportSymbolMissing, "HARN-IMP-002", Imp, "imported symbol does not exist";
+    ImportCycle, "HARN-IMP-003", Imp, "import graph contains a cycle";
+    ImmutableAssignment, "HARN-OWN-001", Own, "immutable binding is reassigned";
+    MutableNeverReassigned, "HARN-OWN-002", Own, "mutable binding is never reassigned";
+    OwnershipEscape, "HARN-OWN-003", Own, "owned value escapes its valid scope";
+    BoundaryValueUnvalidated, "HARN-OWN-004", Own, "unvalidated boundary value is used directly";
+    RescueOutsideFunction, "HARN-RCV-001", Rcv, "rescue construct is outside a function body";
+    TryOutsideFunction, "HARN-RCV-002", Rcv, "try construct is outside a function body";
+    InvalidRescueConstruct, "HARN-RCV-003", Rcv, "rescue construct is invalid";
+    NonExhaustiveMatch, "HARN-MAT-001", Mat, "match expression is not exhaustive";
+    DuplicateMatchArm, "HARN-MAT-002", Mat, "match expression contains a duplicate arm";
+    InvalidMatchPattern, "HARN-MAT-003", Mat, "match pattern is invalid";
+}
+
+impl Code {
+    pub const fn registry() -> &'static [RegistryEntry] {
+        REGISTRY
+    }
+}
+
+impl fmt::Display for Code {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Error returned when parsing an unknown diagnostic code.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ParseCodeError;
+
+impl fmt::Display for ParseCodeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("unknown Harn diagnostic code")
+    }
+}
+
+impl std::error::Error for ParseCodeError {}
+
+impl FromStr for Code {
+    type Err = ParseCodeError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Code::ALL
+            .iter()
+            .copied()
+            .find(|code| code.as_str() == value)
+            .ok_or(ParseCodeError)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Category, Code};
+    use std::collections::HashSet;
+    use std::str::FromStr;
+
+    #[test]
+    fn parses_registered_code() {
+        assert_eq!(Code::from_str("HARN-TYP-014"), Ok(Code::TypeParameterArity));
+    }
+
+    #[test]
+    fn registry_has_unique_identifiers() {
+        let mut seen = HashSet::new();
+        for entry in Code::registry() {
+            assert!(
+                seen.insert(entry.identifier),
+                "duplicate diagnostic code {}",
+                entry.identifier
+            );
+            assert_eq!(entry.code.as_str(), entry.identifier);
+            assert_eq!(entry.code.category(), entry.category);
+            let expected_prefix = format!("HARN-{}-", entry.category);
+            assert!(entry.identifier.starts_with(&expected_prefix));
+            let suffix = entry.identifier.trim_start_matches(&expected_prefix);
+            assert_eq!(suffix.len(), 3);
+            assert!(suffix.chars().all(|ch| ch.is_ascii_digit()));
+            assert!(!entry.summary.is_empty());
+        }
+        assert!(Code::registry().len() >= 40);
+    }
+
+    #[test]
+    fn every_category_is_populated() {
+        for category in Category::ALL {
+            assert!(
+                Code::registry()
+                    .iter()
+                    .any(|entry| entry.category == *category),
+                "missing diagnostic code category {category}"
+            );
+        }
+    }
+}

--- a/crates/harn-parser/src/lib.rs
+++ b/crates/harn-parser/src/lib.rs
@@ -1,11 +1,13 @@
 mod ast;
 pub mod builtin_signatures;
 pub mod diagnostic;
+pub mod diagnostic_codes;
 mod parser;
 pub mod typechecker;
 pub mod visit;
 
 pub use ast::*;
+pub use diagnostic_codes::{Category as DiagnosticCodeCategory, Code as DiagnosticCode};
 pub use parser::*;
 pub use typechecker::{
     block_definitely_exits, format_type, stmt_definitely_exits, DiagnosticDetails,

--- a/crates/harn-parser/src/typechecker/inference/binary_ops.rs
+++ b/crates/harn-parser/src/typechecker/inference/binary_ops.rs
@@ -7,6 +7,7 @@
 //! `super::super::binary_ops::infer_binary_op_type`.
 
 use crate::ast::*;
+use crate::diagnostic_codes::Code;
 use harn_lexer::{FixEdit, Span};
 
 use super::super::scope::TypeScope;
@@ -42,9 +43,14 @@ impl TypeChecker {
                                     None
                                 };
                                 if let Some(fix) = fix {
-                                    self.error_at_with_fix(msg, span, fix);
+                                    self.error_at_with_fix(
+                                        Code::StringInterpolationRewrite,
+                                        msg,
+                                        span,
+                                        fix,
+                                    );
                                 } else {
-                                    self.error_at(msg, span);
+                                    self.error_at(Code::InvalidBinaryOperator, msg, span);
                                 }
                             }
                         }
@@ -52,6 +58,7 @@ impl TypeChecker {
                             let numeric = ["int", "float"];
                             if !numeric.contains(&l.as_str()) || !numeric.contains(&r.as_str()) {
                                 self.error_at(
+                                    Code::InvalidBinaryOperator,
                                     format!(
                                         "can't use '{}' on {} and {} (needs numeric operands)",
                                         op, l, r
@@ -68,6 +75,7 @@ impl TypeChecker {
                                 (l == "string" && r == "int") || (l == "int" && r == "string");
                             if !is_numeric && !is_string_repeat {
                                 self.error_at(
+                                    Code::InvalidBinaryOperator,
                                     format!("can't multiply {} and {} (try string * int)", l, r),
                                     span,
                                 );

--- a/crates/harn-parser/src/typechecker/inference/calls.rs
+++ b/crates/harn-parser/src/typechecker/inference/calls.rs
@@ -16,6 +16,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use crate::ast::*;
 use crate::builtin_signatures;
+use crate::diagnostic_codes::Code;
 use harn_lexer::Span;
 
 use super::super::format::format_type;
@@ -117,7 +118,7 @@ impl TypeChecker {
                     }
                     None => format!("unknown `{builtin_name}` option `{key}`"),
                 };
-            self.warning_at(message, entry.key.span);
+            self.warning_at(Code::UnknownLlmOption, message, entry.key.span);
         }
     }
 
@@ -214,7 +215,7 @@ impl TypeChecker {
             {
                 message.push_str(&format!(" — did you mean `{candidate}`?"));
             }
-            self.error_at(message, entry.key.span);
+            self.error_at(Code::UnknownOption, message, entry.key.span);
         }
     }
 
@@ -235,6 +236,7 @@ impl TypeChecker {
         if !type_args.is_empty() {
             if !sig.is_generic() {
                 self.error_at(
+                    Code::GenericTypeArgumentUnsupported,
                     format!(
                         "Builtin function '{}' does not declare type parameters",
                         name
@@ -243,6 +245,7 @@ impl TypeChecker {
                 );
             } else if type_args.len() != sig.type_params.len() {
                 self.error_at(
+                    Code::GenericTypeArgumentArity,
                     format!(
                         "Builtin function '{}' expects {} type arguments, got {}",
                         name,
@@ -275,6 +278,7 @@ impl TypeChecker {
                 };
                 let arg_word = if single_arg { "argument" } else { "arguments" };
                 self.warning_at(
+                    Code::BuiltinArity,
                     format!(
                         "Builtin function '{}' expects {} {}, got {}",
                         name,
@@ -318,7 +322,7 @@ impl TypeChecker {
             if let Err(message) =
                 self.bind_from_arg_node(&param_ty, arg, &type_param_set, &mut type_bindings, scope)
             {
-                self.error_at(message, arg.span);
+                self.error_at(Code::ArgumentTypeMismatch, message, arg.span);
             }
         }
 
@@ -349,12 +353,12 @@ impl TypeChecker {
                         }));
                 if !compatible {
                     self.type_mismatch_at(
+                        Code::ArgumentTypeMismatch,
                         format!("argument {} `{}`", i + 1, param.name),
                         &expected,
                         actual,
                         arg.span,
-                        None,
-                        Some(arg.span),
+                        (None, Some(arg.span)),
                         &call_scope,
                     );
                 }
@@ -366,7 +370,7 @@ impl TypeChecker {
                 if let Some(concrete_type) = type_bindings.get(*type_param) {
                     let concrete_name = format_type(concrete_type);
                     let Some(base_type_name) = Self::base_type_name(concrete_type) else {
-                        self.error_at(
+                        self.error_at(Code::WhereConstraintMismatch,
                             format!(
                                 "Type '{}' does not satisfy interface '{}': only named types can satisfy interfaces (required by constraint `where {}: {}`)",
                                 concrete_name, bound, type_param, bound
@@ -382,6 +386,7 @@ impl TypeChecker {
                         scope,
                     ) {
                         self.error_at(
+                            Code::WhereConstraintMismatch,
                             format!(
                                 "Type '{}' does not satisfy interface '{}': {} \
                                  (required by constraint `where {}: {}`)",
@@ -767,10 +772,13 @@ impl TypeChecker {
                         msg.push_str(&format!(" (since {s})"));
                     }
                     match use_hint {
-                        Some(h) => {
-                            self.warning_at_with_help(msg, node.span, format!("use `{h}` instead"))
-                        }
-                        None => self.warning_at(msg, node.span),
+                        Some(h) => self.warning_at_with_help(
+                            Code::DeprecatedFunction,
+                            msg,
+                            node.span,
+                            format!("use `{h}` instead"),
+                        ),
+                        None => self.warning_at(Code::DeprecatedFunction, msg, node.span),
                     }
                 }
                 for a in args {
@@ -1079,10 +1087,13 @@ impl TypeChecker {
                     None => format!("call target `{name}` is not defined or imported"),
                 };
                 match suggestion {
-                    Some(s) => {
-                        self.error_at_with_help(message, span, format!("did you mean `{s}`?"))
-                    }
-                    None => self.error_at(message, span),
+                    Some(s) => self.error_at_with_help(
+                        Code::UndefinedFunction,
+                        message,
+                        span,
+                        format!("did you mean `{s}`?"),
+                    ),
+                    None => self.error_at(Code::UndefinedFunction, message, span),
                 }
             }
         }
@@ -1098,8 +1109,8 @@ impl TypeChecker {
             }
             let help = use_hint.map(|h| format!("use `{h}` instead"));
             match help {
-                Some(h) => self.warning_at_with_help(msg, span, h),
-                None => self.warning_at(msg, span),
+                Some(h) => self.warning_at_with_help(Code::DeprecatedFunction, msg, span, h),
+                None => self.warning_at(Code::DeprecatedFunction, msg, span),
             }
         }
         // Special-case: unreachable(x) — when the argument is a variable,
@@ -1110,7 +1121,7 @@ impl TypeChecker {
                     let arg_type = self.infer_type(arg, scope);
                     if let Some(ref ty) = arg_type {
                         if !matches!(ty, TypeExpr::Never) {
-                            self.error_at(
+                            self.error_at(Code::NonExhaustiveMatch,
                                 format!(
                                     "unreachable() argument has type `{}` — not all cases are handled",
                                     format_type(ty)
@@ -1142,11 +1153,13 @@ impl TypeChecker {
             if !type_args.is_empty() {
                 if sig.type_param_names.is_empty() {
                     self.error_at(
+                        Code::GenericTypeArgumentUnsupported,
                         format!("Function '{}' does not declare type parameters", name),
                         span,
                     );
                 } else if type_args.len() != sig.type_param_names.len() {
                     self.error_at(
+                        Code::GenericTypeArgumentArity,
                         format!(
                             "Function '{}' expects {} type arguments, got {}",
                             name,
@@ -1177,6 +1190,7 @@ impl TypeChecker {
                     };
                     let arg_word = if single_arg { "argument" } else { "arguments" };
                     self.warning_at(
+                        Code::OrchestrationArity,
                         format!(
                             "Function '{}' expects {} {}, got {}",
                             name,
@@ -1219,7 +1233,7 @@ impl TypeChecker {
                         &mut type_bindings,
                         scope,
                     ) {
-                        self.error_at(message, arg.span);
+                        self.error_at(Code::ArgumentTypeMismatch, message, arg.span);
                     }
                 }
             }
@@ -1240,14 +1254,17 @@ impl TypeChecker {
                         );
                         if !self.types_compatible(&expected, actual, &call_scope) {
                             self.type_mismatch_at(
+                                Code::ArgumentTypeMismatch,
                                 format!("argument {} `{}`", i + 1, param_name),
                                 &expected,
                                 actual,
                                 arg.span,
-                                sig.definition_span.map(|span| {
-                                    (span, format!("parameter `{param_name}` declared here"))
-                                }),
-                                Some(arg.span),
+                                (
+                                    sig.definition_span.map(|span| {
+                                        (span, format!("parameter `{param_name}` declared here"))
+                                    }),
+                                    Some(arg.span),
+                                ),
                                 &call_scope,
                             );
                         }
@@ -1259,7 +1276,7 @@ impl TypeChecker {
                     if let Some(concrete_type) = type_bindings.get(type_param) {
                         let concrete_name = format_type(concrete_type);
                         let Some(base_type_name) = Self::base_type_name(concrete_type) else {
-                            self.error_at(
+                            self.error_at(Code::WhereConstraintMismatch,
                                 format!(
                                     "Type '{}' does not satisfy interface '{}': only named types can satisfy interfaces (required by constraint `where {}: {}`)",
                                     concrete_name, bound, type_param, bound
@@ -1275,6 +1292,7 @@ impl TypeChecker {
                             scope,
                         ) {
                             self.error_at(
+                                Code::WhereConstraintMismatch,
                                 format!(
                                     "Type '{}' does not satisfy interface '{}': {} \
                                      (required by constraint `where {}: {}`)",

--- a/crates/harn-parser/src/typechecker/inference/decls.rs
+++ b/crates/harn-parser/src/typechecker/inference/decls.rs
@@ -7,6 +7,7 @@
 //! every reachable return matches the declared return type.
 
 use crate::ast::*;
+use crate::diagnostic_codes::Code;
 use harn_lexer::Span;
 
 use super::super::format::format_type;
@@ -178,6 +179,7 @@ impl TypeChecker {
         if is_stream && !matches!(return_type, None | Some(TypeExpr::Stream(_))) {
             if let Some(actual) = return_type {
                 self.error_at(
+                    Code::ReturnTypeMismatch,
                     format!(
                         "`gen fn` must return Stream<T>, found {}",
                         format_type(actual)
@@ -214,12 +216,15 @@ impl TypeChecker {
                 if let Some(actual) = &inferred {
                     if !self.types_compatible(expected, actual, scope) {
                         self.type_mismatch_at(
+                            Code::ReturnTypeMismatch,
                             "return value",
                             expected,
                             actual,
                             val.span,
-                            Some((expected_span, "return type declared here".to_string())),
-                            Some(val.span),
+                            (
+                                Some((expected_span, "return type declared here".to_string())),
+                                Some(val.span),
+                            ),
                             scope,
                         );
                     }

--- a/crates/harn-parser/src/typechecker/inference/expressions.rs
+++ b/crates/harn-parser/src/typechecker/inference/expressions.rs
@@ -14,6 +14,7 @@ use std::collections::BTreeMap;
 
 use crate::ast::*;
 use crate::builtin_signatures;
+use crate::diagnostic_codes::Code;
 use harn_lexer::{FixEdit, Span};
 
 use super::super::binary_ops::infer_binary_op_type;
@@ -1139,6 +1140,7 @@ impl TypeChecker {
             SafeNavigationKind::Subscript => "`?[]`".to_string(),
         };
         self.lint_warning_at_with_fix(
+            Code::LintUnnecessarySafeNavigation,
             UNNECESSARY_SAFE_NAVIGATION_RULE,
             format!("{access} is unnecessary because the receiver cannot be nil"),
             span,

--- a/crates/harn-parser/src/typechecker/inference/flow.rs
+++ b/crates/harn-parser/src/typechecker/inference/flow.rs
@@ -14,6 +14,7 @@
 //! extraction populates.
 
 use crate::ast::*;
+use crate::diagnostic_codes::Code;
 use harn_lexer::Span;
 
 use super::super::exits::block_definitely_exits;
@@ -597,6 +598,7 @@ impl TypeChecker {
                 missing.iter().map(|s| format!("\"{}\"", s)).collect();
             let missing_str = missing_literals.join(", ");
             self.exhaustiveness_error_with_missing(
+                Code::NonExhaustiveMatch,
                 format!(
                     "Non-exhaustive match on enum {}: missing variants {}",
                     enum_name, missing_str
@@ -669,6 +671,7 @@ impl TypeChecker {
         }
         if !missing.is_empty() {
             self.exhaustiveness_error_with_missing(
+                Code::NonExhaustiveMatch,
                 format!(
                     "Non-exhaustive match on tagged shape union: missing variants {}",
                     missing.join(", ")
@@ -773,6 +776,7 @@ impl TypeChecker {
                 .collect::<Vec<_>>()
                 .join(", ");
             self.exhaustiveness_error_at(
+                Code::NonExhaustiveMatch,
                 format!(
                     "Non-exhaustive match on union type: missing {}",
                     missing_str
@@ -816,6 +820,7 @@ impl TypeChecker {
         }
         if !missing.is_empty() {
             self.exhaustiveness_error_with_missing(
+                Code::NonExhaustiveMatch,
                 format!(
                     "Non-exhaustive match on literal union: missing {}",
                     missing.join(", ")
@@ -873,7 +878,7 @@ impl TypeChecker {
                 .map(|s| s.to_string())
                 .collect::<Vec<_>>()
                 .join(", ");
-            self.warning_at(
+            self.warning_at(Code::NonExhaustiveMatch,
                 format!(
                     "`{site}` reached but `{var}: unknown` was not fully narrowed — uncovered concrete type(s): {missing}",
                     site = site_label,

--- a/crates/harn-parser/src/typechecker/inference/hitl.rs
+++ b/crates/harn-parser/src/typechecker/inference/hitl.rs
@@ -19,6 +19,7 @@
 use harn_lexer::Span;
 
 use crate::ast::{HitlArg, HitlKind, Node, ShapeField, TypeExpr};
+use crate::diagnostic_codes::Code;
 
 use super::super::scope::TypeScope;
 use super::super::TypeChecker;
@@ -150,6 +151,7 @@ impl TypeChecker {
                 if !params.iter().any(|p| p.name == name) {
                     let allowed = params.iter().map(|p| p.name).collect::<Vec<_>>().join(", ");
                     self.error_at(
+                        Code::HitlInvalidApprovalArgument,
                         format!("{kw}: unknown argument `{name}` (expected one of: {allowed})"),
                         arg.span,
                     );
@@ -165,6 +167,7 @@ impl TypeChecker {
                 Some(_) => seen_named = true,
                 None if seen_named => {
                     self.error_at(
+                        Code::HitlInvalidApprovalArgument,
                         format!("{kw}: positional argument cannot follow a named argument"),
                         arg.span,
                     );
@@ -181,7 +184,11 @@ impl TypeChecker {
                     .skip(i + 1)
                     .any(|other| other.name.as_deref() == Some(name))
                 {
-                    self.error_at(format!("{kw}: duplicate argument `{name}`"), arg.span);
+                    self.error_at(
+                        Code::DuplicateArgument,
+                        format!("{kw}: duplicate argument `{name}`"),
+                        arg.span,
+                    );
                 }
             }
         }
@@ -197,6 +204,7 @@ impl TypeChecker {
             let by_name = args.iter().any(|a| a.name.as_deref() == Some(p.name));
             if !by_position && !by_name {
                 self.error_at(
+                    Code::HitlMissingApprovalPolicy,
                     format!("{kw}: missing required argument `{}`", p.name),
                     span,
                 );
@@ -206,6 +214,7 @@ impl TypeChecker {
         // Reject excess positional args.
         if positional_count > params.len() {
             self.error_at(
+                Code::HitlInvalidApprovalArgument,
                 format!(
                     "{kw}: too many positional arguments (max {} positional, got {})",
                     params.len(),

--- a/crates/harn-parser/src/typechecker/inference/statements.rs
+++ b/crates/harn-parser/src/typechecker/inference/statements.rs
@@ -15,6 +15,7 @@ use harn_lexer::Span;
 
 use crate::ast::*;
 use crate::builtin_signatures;
+use crate::diagnostic_codes::Code;
 
 use super::super::binary_ops::infer_binary_op_type;
 use super::super::exits::stmt_definitely_exits;
@@ -58,7 +59,11 @@ impl TypeChecker {
         let mut definitely_exited = false;
         for stmt in stmts {
             if definitely_exited {
-                self.warning_at("unreachable code".to_string(), stmt.span);
+                self.warning_at(
+                    Code::UnreachableCode,
+                    "unreachable code".to_string(),
+                    stmt.span,
+                );
                 break; // warn once per block
             }
             self.check_node(stmt, scope);
@@ -197,6 +202,7 @@ impl TypeChecker {
             return;
         }
         self.warning_at(
+            Code::UnknownMethod,
             format!(
                 "Method '{}' not found in interface '{}' (constraint on '{}')",
                 method, iface_name, type_name
@@ -250,7 +256,7 @@ impl TypeChecker {
         }
         match &resolved {
             TypeExpr::Named(name) if name == "nil" && !optional => {
-                self.error_at_with_help(
+                self.error_at_with_help(Code::InvalidOptionalAccess,
                     format!(
                         "cannot access property `{property}` on `nil`; the value is statically known to be nil here"
                     ),
@@ -259,7 +265,7 @@ impl TypeChecker {
                 );
             }
             TypeExpr::Named(name) if matches!(name.as_str(), "unknown") => {
-                self.warning_at_with_help(
+                self.warning_at_with_help(Code::UnknownField,
                     format!("property access `.{property}` on an `unknown` value will fail at runtime if the value is not a shape with that field"),
                     span,
                     "narrow with `is_a`/`type_of`, validate with `assert_shape`, or annotate with a shape type before accessing fields"
@@ -280,7 +286,7 @@ impl TypeChecker {
                     msg.push_str(&format!(" — did you mean `{close}`?"));
                 }
                 let help = format!("available fields: {}", actual.join(", "));
-                self.error_at_with_help(msg, span, help);
+                self.error_at_with_help(Code::UnknownField, msg, span, help);
             }
             TypeExpr::Named(name) if scope.get_struct(name).is_some() => {
                 self.check_struct_property(name, property, scope, span);
@@ -334,7 +340,7 @@ impl TypeChecker {
         } else {
             format!("available fields: {}", field_names.join(", "))
         };
-        self.error_at_with_help(msg, span, help);
+        self.error_at_with_help(Code::UnknownField, msg, span, help);
     }
 
     /// If `ty` is a `T | nil` union (any width), emit a hint to use `?.`
@@ -380,7 +386,7 @@ impl TypeChecker {
         if !non_nil_admits_property {
             return;
         }
-        self.error_at_with_help(
+        self.error_at_with_help(Code::InvalidOptionalAccess,
             format!(
                 "cannot access property `{property}` on nilable type `{ty}`; the value may be nil at runtime",
                 ty = format_type(ty)
@@ -407,7 +413,7 @@ impl TypeChecker {
                 let has_schema = (name == "llm_call" || name == "llm_completion")
                     && Self::llm_call_has_typed_schema_option(args, scope);
                 if !has_schema {
-                    self.warning_at_with_help(
+                    self.warning_at_with_help(Code::BoundaryValueUnvalidated,
                         format!("{} on unvalidated `{}()` result", kind.direct_label(), name),
                         span,
                         "assign to a variable and validate with schema_expect() or a type annotation first".to_string(),
@@ -417,7 +423,7 @@ impl TypeChecker {
         }
         if let Node::Identifier(name) = &object.node {
             if let Some(source) = scope.is_untyped_source(name) {
-                self.warning_at_with_help(
+                self.warning_at_with_help(Code::BoundaryValueUnvalidated,
                     format!(
                         "{} on unvalidated value '{}' from `{}`",
                         kind.variable_label(),
@@ -446,12 +452,15 @@ impl TypeChecker {
                         if let Some(actual) = &inferred {
                             if !self.types_compatible(expected, actual, scope) {
                                 self.type_mismatch_at(
+                                    Code::VariableTypeMismatch,
                                     format!("let binding `{name}`"),
                                     expected,
                                     actual,
                                     value.span,
-                                    Some((span, "expected type declared here".to_string())),
-                                    Some(value.span),
+                                    (
+                                        Some((span, "expected type declared here".to_string())),
+                                        Some(value.span),
+                                    ),
                                     scope,
                                 );
                             }
@@ -504,12 +513,15 @@ impl TypeChecker {
                         if let Some(actual) = &inferred {
                             if !self.types_compatible(expected, actual, scope) {
                                 self.type_mismatch_at(
+                                    Code::VariableTypeMismatch,
                                     format!("var binding `{name}`"),
                                     expected,
                                     actual,
                                     value.span,
-                                    Some((span, "expected type declared here".to_string())),
-                                    Some(value.span),
+                                    (
+                                        Some((span, "expected type declared here".to_string())),
+                                        Some(value.span),
+                                    ),
                                     scope,
                                 );
                             }
@@ -817,7 +829,7 @@ impl TypeChecker {
 
             Node::TryStar { operand } => {
                 if self.fn_depth == 0 {
-                    self.error_at(
+                    self.error_at(Code::TryOutsideFunction,
                         "try* requires an enclosing function (fn, tool, or pipeline) so the rethrow has a target".to_string(),
                         span,
                     );
@@ -839,7 +851,7 @@ impl TypeChecker {
                     let mut widened_slot_type: Option<TypeExpr> = None;
                     // Compile-time immutability check
                     if scope.get_var(name).is_some() && !scope.is_mutable(name) {
-                        self.warning_at(
+                        self.warning_at(Code::ImmutableAssignment,
                             format!(
                                 "Cannot assign to '{}': variable is immutable (declared with 'let')",
                                 name
@@ -872,15 +884,18 @@ impl TypeChecker {
                                     widened_slot_type = Some(Self::union_with_nil(actual));
                                 } else {
                                     self.type_mismatch_at(
+                                        Code::AssignmentTypeMismatch,
                                         format!("assignment to `{name}`"),
                                         check_type,
                                         actual,
                                         value.span,
-                                        Some((
-                                            target.span,
-                                            format!("`{name}` has this expected type"),
-                                        )),
-                                        Some(value.span),
+                                        (
+                                            Some((
+                                                target.span,
+                                                format!("`{name}` has this expected type"),
+                                            )),
+                                            Some(value.span),
+                                        ),
                                         scope,
                                     );
                                 }
@@ -1063,7 +1078,7 @@ impl TypeChecker {
                                     Node::BoolLiteral(_) => "bool",
                                     _ => unreachable!(),
                                 };
-                                self.warning_at(
+                                self.warning_at(Code::InvalidMatchPattern,
                                     format!(
                                         "Match pattern type mismatch: matching {} against {} literal",
                                         value_type_name, pattern_type
@@ -1148,6 +1163,7 @@ impl TypeChecker {
                             let numeric = ["int", "float"];
                             if !numeric.contains(&l.as_str()) || !numeric.contains(&r.as_str()) {
                                 self.error_at(
+                                    Code::InvalidBinaryOperator,
                                     format!(
                                         "can't use '{}' on {} and {} (needs numeric operands)",
                                         op, l, r
@@ -1164,6 +1180,7 @@ impl TypeChecker {
                                 (l == "string" && r == "int") || (l == "int" && r == "string");
                             if !is_numeric && !is_string_repeat {
                                 self.error_at(
+                                    Code::InvalidBinaryOperator,
                                     format!("can't multiply {} and {} (try string * int)", l, r),
                                     span,
                                 );
@@ -1186,9 +1203,14 @@ impl TypeChecker {
                                     None
                                 };
                                 if let Some(fix) = fix {
-                                    self.error_at_with_fix(msg, span, fix);
+                                    self.error_at_with_fix(
+                                        Code::StringInterpolationRewrite,
+                                        msg,
+                                        span,
+                                        fix,
+                                    );
                                 } else {
-                                    self.error_at(msg, span);
+                                    self.error_at(Code::InvalidBinaryOperator, msg, span);
                                 }
                             }
                         }
@@ -1198,6 +1220,7 @@ impl TypeChecker {
                                 || !comparable.contains(&r.as_str())
                             {
                                 self.warning_at(
+                                    Code::InvalidBinaryOperator,
                                     format!(
                                         "Comparison '{}' may not be meaningful for types {} and {}",
                                         op, l, r
@@ -1205,7 +1228,7 @@ impl TypeChecker {
                                     span,
                                 );
                             } else if (l == "string") != (r == "string") {
-                                self.warning_at(
+                                self.warning_at(Code::InvalidBinaryOperator,
                                     format!(
                                         "Comparing {} with {} using '{}' may give unexpected results",
                                         l, r, op
@@ -1346,6 +1369,7 @@ impl TypeChecker {
                         if let Some(ty) = self.infer_type(value, scope) {
                             if !matches!(ty, TypeExpr::Named(ref n) if n == "int") {
                                 self.error_at(
+                                    Code::OrchestrationType,
                                     format!(
                                         "`max_concurrent` on `parallel` must be int, got {ty:?}"
                                     ),
@@ -1474,6 +1498,7 @@ impl TypeChecker {
             Node::YieldExpr { value } => {
                 if self.stream_fn_depth > 0 {
                     self.error_at(
+                        Code::OrchestrationType,
                         "`yield` is not a stream emit; use `emit` inside `gen fn`".to_string(),
                         span,
                     );
@@ -1487,6 +1512,7 @@ impl TypeChecker {
                 self.check_node(value, scope);
                 if self.stream_fn_depth == 0 {
                     self.error_at(
+                        Code::OrchestrationType,
                         "`emit` can only be used inside a `gen fn`".to_string(),
                         span,
                     );
@@ -1494,12 +1520,15 @@ impl TypeChecker {
                     if let Some(actual) = self.infer_type(value, scope) {
                         if !self.types_compatible(&expected, &actual, scope) {
                             self.type_mismatch_at(
+                                Code::ReturnTypeMismatch,
                                 "`emit` value",
                                 &expected,
                                 &actual,
                                 span,
-                                Some((span, "stream emit type expected here".to_string())),
-                                Some(value.span),
+                                (
+                                    Some((span, "stream emit type expected here".to_string())),
+                                    Some(value.span),
+                                ),
                                 scope,
                             );
                         }
@@ -1522,6 +1551,7 @@ impl TypeChecker {
                         if let Node::StringLiteral(key) | Node::Identifier(key) = &entry.key.node {
                             if !struct_info.fields.iter().any(|field| field.name == *key) {
                                 self.warning_at(
+                                    Code::UnknownField,
                                     format!("Unknown field '{}' in struct '{}'", key, struct_name),
                                     entry.key.span,
                                 );
@@ -1539,6 +1569,7 @@ impl TypeChecker {
                     for field in &struct_info.fields {
                         if !field.optional && !provided.contains(&field.name) {
                             self.warning_at(
+                                Code::FieldTypeMismatch,
                                 format!(
                                     "Missing field '{}' in struct '{}' construction",
                                     field.name, struct_name
@@ -1562,12 +1593,15 @@ impl TypeChecker {
                         let expected = Self::apply_type_bindings(expected_type, &type_bindings);
                         if !self.types_compatible(&expected, &actual_type, scope) {
                             self.type_mismatch_at(
+                                Code::FieldTypeMismatch,
                                 format!("field `{}` in struct `{struct_name}`", field.name),
                                 &expected,
                                 &actual_type,
                                 entry.value.span,
-                                Some((span, format!("struct `{struct_name}` expected here"))),
-                                Some(entry.value.span),
+                                (
+                                    Some((span, format!("struct `{struct_name}` expected here"))),
+                                    Some(entry.value.span),
+                                ),
                                 scope,
                             );
                         }
@@ -1587,11 +1621,13 @@ impl TypeChecker {
                     };
                     match suggestion {
                         Some(candidate) => self.error_at_with_help(
+                            Code::UnknownTypeName,
                             message,
                             span,
                             format!("declare `struct {candidate} {{ ... }}` or fix the type name"),
                         ),
                         None => self.error_at_with_help(
+                            Code::UnknownTypeName,
                             message,
                             span,
                             format!(
@@ -1617,6 +1653,7 @@ impl TypeChecker {
                         .find(|enum_variant| enum_variant.name == *variant)
                     else {
                         self.warning_at(
+                            Code::InvalidEnumConstruct,
                             format!("Unknown variant '{}' in enum '{}'", variant, enum_name),
                             span,
                         );
@@ -1626,6 +1663,7 @@ impl TypeChecker {
                         let n = enum_variant.fields.len();
                         let arg_word = if n == 1 { "argument" } else { "arguments" };
                         self.warning_at(
+                            Code::OrchestrationArity,
                             format!(
                                 "{}.{} expects {} {}, got {}",
                                 enum_name,
@@ -1656,7 +1694,7 @@ impl TypeChecker {
                             &type_param_set,
                             &mut type_bindings,
                         ) {
-                            self.error_at(message, arg.span);
+                            self.error_at(Code::GenericTypeArgumentMismatch, message, arg.span);
                         }
                     }
                     for (field, arg) in enum_variant.fields.iter().zip(args.iter()) {
@@ -1669,15 +1707,20 @@ impl TypeChecker {
                         let expected = Self::apply_type_bindings(expected_type, &type_bindings);
                         if !self.types_compatible(&expected, &actual_type, scope) {
                             self.type_mismatch_at(
+                                Code::ArgumentTypeMismatch,
                                 format!("{}.{} argument `{}`", enum_name, variant, field.name),
                                 &expected,
                                 &actual_type,
                                 arg.span,
-                                Some((
-                                    span,
-                                    format!("enum variant `{enum_name}.{variant}` expected here"),
-                                )),
-                                Some(arg.span),
+                                (
+                                    Some((
+                                        span,
+                                        format!(
+                                            "enum variant `{enum_name}.{variant}` expected here"
+                                        ),
+                                    )),
+                                    Some(arg.span),
+                                ),
                                 scope,
                             );
                         }
@@ -1734,6 +1777,7 @@ impl TypeChecker {
                     let is_wildcard = matches!(&alt.node, Node::Identifier(name) if name == "_");
                     if !is_literal && !is_wildcard {
                         self.error_at(
+                            Code::InvalidMatchPattern,
                             "Or-pattern alternatives must be literal patterns \
                              (string, int, float, bool, nil, or `_`). Identifier \
                              bindings and destructuring patterns are not allowed \
@@ -1774,25 +1818,32 @@ impl TypeChecker {
                 | "deterministic" | "semantic" | "archivist" | "retroactive" | "persona"
                 | "step" | "trigger" | "handoff" | "budget" | "command" => {}
                 other => {
-                    self.warning_at(format!("unknown attribute `@{}`", other), attr.span);
+                    self.warning_at(
+                        Code::UnknownAttribute,
+                        format!("unknown attribute `@{}`", other),
+                        attr.span,
+                    );
                 }
             }
             self.validate_standard_attribute_args(attr);
             // `@test` marks test pipelines discovered by `harn test`.
             if attr.name == "test" && !matches!(inner.node, Node::Pipeline { .. }) {
                 self.warning_at(
+                    Code::InvalidAttributeTarget,
                     "`@test` only applies to pipeline declarations".to_string(),
                     attr.span,
                 );
             }
             if attr.name == "acp_tool" && !matches!(inner.node, Node::FnDecl { .. }) {
                 self.warning_at(
+                    Code::InvalidAttributeTarget,
                     "`@acp_tool` only applies to function declarations".to_string(),
                     attr.span,
                 );
             }
             if attr.name == "acp_skill" && !matches!(inner.node, Node::FnDecl { .. }) {
                 self.warning_at(
+                    Code::InvalidAttributeTarget,
                     "`@acp_skill` only applies to function declarations".to_string(),
                     attr.span,
                 );
@@ -1805,6 +1856,7 @@ impl TypeChecker {
                 Node::FnDecl { .. } | Node::ToolDecl { .. } | Node::Pipeline { .. }
             ) {
                 self.warning_at(
+                    Code::InvalidAttributeTarget,
                     format!(
                         "`@{}` only applies to function, tool, or pipeline declarations",
                         attr.name
@@ -1814,12 +1866,14 @@ impl TypeChecker {
             }
             if attr.name == "command" && !matches!(inner.node, Node::Pipeline { .. }) {
                 self.warning_at(
+                    Code::InvalidAttributeTarget,
                     "`@command` only applies to pipeline declarations".to_string(),
                     attr.span,
                 );
             }
             if attr.name == "step" && !matches!(inner.node, Node::FnDecl { .. }) {
                 self.warning_at(
+                    Code::InvalidAttributeTarget,
                     "`@step` only applies to function declarations".to_string(),
                     attr.span,
                 );
@@ -1830,6 +1884,7 @@ impl TypeChecker {
             ) && !matches!(inner.node, Node::FnDecl { .. })
             {
                 self.warning_at(
+                    Code::InvalidAttributeTarget,
                     format!("`@{}` only applies to function declarations", attr.name),
                     attr.span,
                 );
@@ -1841,6 +1896,7 @@ impl TypeChecker {
                 )
             {
                 self.warning_at(
+                    Code::InvalidAttributeTarget,
                     "`@invariant` only applies to function, tool, or pipeline declarations"
                         .to_string(),
                     attr.span,
@@ -1862,6 +1918,7 @@ impl TypeChecker {
 
         if let (Some(det), Some(sem)) = (deterministic, semantic) {
             self.warning_at(
+                Code::FlowInvariantAttributeInvalid,
                 "`@deterministic` and `@semantic` are mutually exclusive; \
                  a Flow predicate is one mode or the other"
                     .to_string(),
@@ -1872,6 +1929,7 @@ impl TypeChecker {
         if let Some(inv) = flow_invariant {
             if deterministic.is_none() && semantic.is_none() {
                 self.warning_at(
+                    Code::FlowInvariantAttributeInvalid,
                     "Flow `@invariant` requires exactly one of `@deterministic` \
                      (default) or `@semantic`"
                         .to_string(),
@@ -1880,6 +1938,7 @@ impl TypeChecker {
             }
             if archivist.is_none() {
                 self.warning_at(
+                    Code::FlowInvariantAttributeInvalid,
                     "Flow `@invariant` is missing `@archivist(...)` provenance \
                      (evidence, confidence, source_date, coverage_examples)"
                         .to_string(),
@@ -1889,6 +1948,7 @@ impl TypeChecker {
         } else {
             if let Some(arch) = archivist {
                 self.warning_at(
+                    Code::FlowInvariantAttributeInvalid,
                     "`@archivist(...)` only applies to Flow predicates marked \
                      with `@invariant`"
                         .to_string(),
@@ -1897,6 +1957,7 @@ impl TypeChecker {
             }
             if let Some(retro) = retroactive {
                 self.warning_at(
+                    Code::FlowInvariantAttributeInvalid,
                     "`@retroactive` only applies to Flow predicates marked \
                      with `@invariant`"
                         .to_string(),
@@ -1920,7 +1981,11 @@ impl TypeChecker {
             "deprecated" => self.validate_deprecated_args(attr),
             "command" => self.validate_command_args(attr),
             "test" if !attr.args.is_empty() => {
-                self.warning_at("`@test` does not accept arguments".to_string(), attr.span);
+                self.warning_at(
+                    Code::InvalidAttributeArgument,
+                    "`@test` does not accept arguments".to_string(),
+                    attr.span,
+                );
             }
             _ => {}
         }
@@ -1934,6 +1999,7 @@ impl TypeChecker {
             };
             if !KNOWN_KEYS.contains(&name) {
                 self.warning_at(
+                    Code::InvalidAttributeArgument,
                     format!("unknown `@command` argument `{name}`; expected one of {KNOWN_KEYS:?}"),
                     arg.span,
                 );
@@ -1960,6 +2026,7 @@ impl TypeChecker {
             };
             if !KNOWN_KEYS.contains(&name) {
                 self.warning_at(
+                    Code::InvalidAttributeArgument,
                     format!("unknown `@step` argument `{name}`; expected one of {KNOWN_KEYS:?}"),
                     arg.span,
                 );
@@ -1995,6 +2062,7 @@ impl TypeChecker {
         }
         if !has_name {
             self.warning_at(
+                Code::InvalidAttributeArgument,
                 "`@step(...)` should declare `name: \"...\"` for stable supervision metadata"
                     .to_string(),
                 attr.span,
@@ -2006,6 +2074,7 @@ impl TypeChecker {
         const NUMBER_KEYS: &[&str] = &["max_tokens", "max_usd"];
         let Node::DictLiteral(entries) = &value.node else {
             self.warning_at(
+                Code::InvalidAttributeArgument,
                 "`@step(budget: ...)` must be a dict such as `{ max_tokens: 1000, max_usd: 0.05 }`"
                     .to_string(),
                 span,
@@ -2015,13 +2084,14 @@ impl TypeChecker {
         for entry in entries {
             let Some(field_name) = attr_key_name(&entry.key.node) else {
                 self.warning_at(
+                    Code::InvalidAttributeArgument,
                     "`@step(budget: ...)` field names must be strings or identifiers".to_string(),
                     entry.key.span,
                 );
                 continue;
             };
             if !NUMBER_KEYS.contains(&field_name) {
-                self.warning_at(
+                self.warning_at(Code::InvalidAttributeArgument,
                     format!(
                         "unknown `@step(budget: ...)` field `{field_name}`; expected one of {NUMBER_KEYS:?}"
                     ),
@@ -2032,12 +2102,14 @@ impl TypeChecker {
             match (field_name, &entry.value.node) {
                 ("max_tokens", Node::IntLiteral(value)) if *value >= 1 => {}
                 ("max_tokens", _) => self.warning_at(
+                    Code::InvalidAttributeArgument,
                     "`@step(budget: { max_tokens: ... })` must be a positive integer".to_string(),
                     entry.value.span,
                 ),
                 ("max_usd", Node::IntLiteral(value)) if *value >= 0 => {}
                 ("max_usd", Node::FloatLiteral(value)) if value.is_finite() && *value >= 0.0 => {}
                 ("max_usd", _) => self.warning_at(
+                    Code::InvalidAttributeArgument,
                     "`@step(budget: { max_usd: ... })` must be a non-negative number".to_string(),
                     entry.value.span,
                 ),
@@ -2069,6 +2141,7 @@ impl TypeChecker {
             };
             if !KNOWN_KEYS.contains(&name) {
                 self.warning_at(
+                    Code::InvalidAttributeArgument,
                     format!("unknown `@persona` argument `{name}`; expected one of {KNOWN_KEYS:?}"),
                     arg.span,
                 );
@@ -2088,6 +2161,7 @@ impl TypeChecker {
                         && !matches!(arg.value.node, Node::BoolLiteral(_))
                     {
                         self.warning_at(
+                            Code::InvalidAttributeArgument,
                             "`@persona(receipts: ...)` must be a string/symbol or bool".to_string(),
                             arg.span,
                         );
@@ -2101,6 +2175,7 @@ impl TypeChecker {
     fn expect_persona_stages(&mut self, owner: &str, value: &SNode, span: Span) {
         let Node::ListLiteral(entries) = &value.node else {
             self.warning_at(
+                Code::InvalidAttributeArgument,
                 format!("`{owner}(stages: ...)` must be a list of stage dicts"),
                 span,
             );
@@ -2115,6 +2190,7 @@ impl TypeChecker {
         for entry in entries {
             let Node::DictLiteral(fields) = &entry.node else {
                 self.warning_at(
+                    Code::InvalidAttributeArgument,
                     format!("`{owner}(stages: ...)` entries must be dict literals"),
                     entry.span,
                 );
@@ -2124,6 +2200,7 @@ impl TypeChecker {
             for dict_entry in fields {
                 let Some(key) = dict_entry_key_str(&dict_entry.key) else {
                     self.warning_at(
+                        Code::InvalidAttributeArgument,
                         format!("`{owner}(stages: ...)` stage keys must be identifiers"),
                         dict_entry.key.span,
                     );
@@ -2131,6 +2208,7 @@ impl TypeChecker {
                 };
                 if !KNOWN_STAGE_KEYS.contains(&key.as_str()) {
                     self.warning_at(
+                        Code::InvalidAttributeArgument,
                         format!("unknown stage key `{key}`; expected one of {KNOWN_STAGE_KEYS:?}"),
                         dict_entry.key.span,
                     );
@@ -2140,6 +2218,7 @@ impl TypeChecker {
                     "name" | "side_effect_level" => {
                         if !is_symbol_like(&dict_entry.value.node) {
                             self.warning_at(
+                                Code::InvalidAttributeArgument,
                                 format!("stage `{key}` must be a string"),
                                 dict_entry.value.span,
                             );
@@ -2157,6 +2236,7 @@ impl TypeChecker {
                     "max_iterations" if !matches!(dict_entry.value.node, Node::IntLiteral(n) if n >= 0) =>
                     {
                         self.warning_at(
+                            Code::InvalidAttributeArgument,
                             "stage `max_iterations` must be a non-negative integer".to_string(),
                             dict_entry.value.span,
                         );
@@ -2166,6 +2246,7 @@ impl TypeChecker {
             }
             if !saw_name {
                 self.warning_at(
+                    Code::InvalidAttributeArgument,
                     format!("`{owner}(stages: ...)` entry missing required `name`"),
                     entry.span,
                 );
@@ -2180,7 +2261,7 @@ impl TypeChecker {
         for arg in &attr.args {
             if arg.name.is_none() {
                 if !is_trigger_spec(&arg.value.node) {
-                    self.warning_at(
+                    self.warning_at(Code::InvalidAttributeArgument,
                         "`@trigger(...)` positional arguments must be strings, dotted trigger ids, or schedule(...)"
                             .to_string(),
                         arg.span,
@@ -2191,6 +2272,7 @@ impl TypeChecker {
             let name = arg.name.as_deref().unwrap();
             if !KNOWN_KEYS.contains(&name) {
                 self.warning_at(
+                    Code::InvalidAttributeArgument,
                     format!("unknown `@trigger` argument `{name}`; expected one of {KNOWN_KEYS:?}"),
                     arg.span,
                 );
@@ -2200,6 +2282,7 @@ impl TypeChecker {
                 "schedule" => {
                     if !is_trigger_spec(&arg.value.node) {
                         self.warning_at(
+                            Code::InvalidAttributeArgument,
                             "`@trigger(schedule: ...)` must be a string/symbol or schedule(...)"
                                 .to_string(),
                             arg.span,
@@ -2220,6 +2303,7 @@ impl TypeChecker {
             };
             if !KNOWN_KEYS.contains(&name) {
                 self.warning_at(
+                    Code::InvalidAttributeArgument,
                     format!("unknown `@handoff` argument `{name}`; expected one of {KNOWN_KEYS:?}"),
                     arg.span,
                 );
@@ -2254,6 +2338,7 @@ impl TypeChecker {
             };
             if !KNOWN_KEYS.contains(&name) {
                 self.warning_at(
+                    Code::InvalidAttributeArgument,
                     format!(
                         "unknown `@deprecated` argument `{name}`; expected one of {KNOWN_KEYS:?}"
                     ),
@@ -2270,6 +2355,7 @@ impl TypeChecker {
             Some(name) => Some(name),
             None => {
                 self.warning_at(
+                    Code::InvalidAttributeArgument,
                     format!("`{attr_name}(...)` arguments must be named"),
                     arg.span,
                 );
@@ -2281,6 +2367,7 @@ impl TypeChecker {
     fn expect_symbol_like(&mut self, attr_name: &str, key: &str, value: &SNode, span: Span) {
         if !is_symbol_like(&value.node) {
             self.warning_at(
+                Code::InvalidAttributeArgument,
                 format!("`{attr_name}({key}: ...)` must be a string or symbol"),
                 span,
             );
@@ -2297,6 +2384,7 @@ impl TypeChecker {
     ) {
         let Some(value) = symbol_like_value(&value.node) else {
             self.warning_at(
+                Code::InvalidAttributeArgument,
                 format!("`{attr_name}({key}: ...)` must be one of {allowed:?}"),
                 span,
             );
@@ -2304,6 +2392,7 @@ impl TypeChecker {
         };
         if !allowed.contains(&value) {
             self.warning_at(
+                Code::InvalidAttributeArgument,
                 format!("`{attr_name}({key}: ...)` must be one of {allowed:?}"),
                 span,
             );
@@ -2313,6 +2402,7 @@ impl TypeChecker {
     fn expect_list_of_symbols(&mut self, attr_name: &str, key: &str, value: &SNode, span: Span) {
         let Node::ListLiteral(items) = &value.node else {
             self.warning_at(
+                Code::InvalidAttributeArgument,
                 format!("`{attr_name}({key}: ...)` must be a list of strings or symbols"),
                 span,
             );
@@ -2320,6 +2410,7 @@ impl TypeChecker {
         };
         if items.iter().any(|item| !is_symbol_like(&item.node)) {
             self.warning_at(
+                Code::InvalidAttributeArgument,
                 format!("`{attr_name}({key}: ...)` must contain only strings or symbols"),
                 span,
             );
@@ -2334,7 +2425,7 @@ impl TypeChecker {
         span: Span,
     ) {
         let Node::ListLiteral(items) = &value.node else {
-            self.warning_at(
+            self.warning_at(Code::InvalidAttributeArgument,
                 format!(
                     "`{attr_name}({key}: ...)` must be a list of strings, dotted trigger ids, or schedule(...)"
                 ),
@@ -2343,7 +2434,7 @@ impl TypeChecker {
             return;
         };
         if items.iter().any(|item| !is_trigger_spec(&item.node)) {
-            self.warning_at(
+            self.warning_at(Code::InvalidAttributeArgument,
                 format!(
                     "`{attr_name}({key}: ...)` must contain only strings, dotted trigger ids, or schedule(...)"
                 ),
@@ -2355,6 +2446,7 @@ impl TypeChecker {
     fn expect_budget_dict(&mut self, attr_name: &str, key: &str, value: &SNode, span: Span) {
         let Node::DictLiteral(entries) = &value.node else {
             self.warning_at(
+                Code::InvalidAttributeArgument,
                 format!("`{attr_name}({key}: ...)` must be a dict of budget fields"),
                 span,
             );
@@ -2363,6 +2455,7 @@ impl TypeChecker {
         for entry in entries {
             let Some(field_name) = attr_key_name(&entry.key.node) else {
                 self.warning_at(
+                    Code::InvalidAttributeArgument,
                     "budget field names must be strings or identifiers".to_string(),
                     entry.key.span,
                 );
@@ -2375,6 +2468,7 @@ impl TypeChecker {
     fn expect_step_retry_dict(&mut self, value: &SNode, span: Span) {
         let Node::DictLiteral(entries) = &value.node else {
             self.warning_at(
+                Code::InvalidAttributeArgument,
                 "`@step(retry: ...)` must be a dict such as `{ max_attempts: 3 }`".to_string(),
                 span,
             );
@@ -2383,6 +2477,7 @@ impl TypeChecker {
         for entry in entries {
             let Some(field_name) = attr_key_name(&entry.key.node) else {
                 self.warning_at(
+                    Code::InvalidAttributeArgument,
                     "`@step(retry: ...)` field names must be strings or identifiers".to_string(),
                     entry.key.span,
                 );
@@ -2392,6 +2487,7 @@ impl TypeChecker {
                 "max_attempts" => {
                     if !matches!(entry.value.node, Node::IntLiteral(i) if i >= 1) {
                         self.warning_at(
+                            Code::InvalidAttributeArgument,
                             "`@step(retry: { max_attempts: ... })` must be a positive integer"
                                 .to_string(),
                             entry.value.span,
@@ -2400,6 +2496,7 @@ impl TypeChecker {
                 }
                 other => {
                     self.warning_at(
+                        Code::InvalidAttributeArgument,
                         format!(
                             "unknown `@step(retry: ...)` field `{other}`; expected `max_attempts`"
                         ),
@@ -2423,12 +2520,16 @@ impl TypeChecker {
         const STRING_KEYS: &[&str] = &["on_exhausted", "on_budget_exhausted"];
         if NUMBER_KEYS.contains(&key) {
             if !matches!(value.node, Node::IntLiteral(_) | Node::FloatLiteral(_)) {
-                self.warning_at(format!("`{attr_name}({key}: ...)` must be a number"), span);
+                self.warning_at(
+                    Code::InvalidAttributeArgument,
+                    format!("`{attr_name}({key}: ...)` must be a number"),
+                    span,
+                );
             }
         } else if STRING_KEYS.contains(&key) {
             self.expect_symbol_like(attr_name, key, value, span);
         } else {
-            self.warning_at(
+            self.warning_at(Code::InvalidAttributeArgument,
                 format!(
                     "unknown `{attr_name}` budget field `{key}`; expected one of {NUMBER_KEYS:?} or {STRING_KEYS:?}"
                 ),
@@ -2455,6 +2556,7 @@ impl TypeChecker {
         for arg in &attr.args {
             let Some(name) = arg.name.as_deref() else {
                 self.warning_at(
+                    Code::InvalidAttributeArgument,
                     "`@archivist(...)` arguments must be named (e.g. \
                      `evidence: [...], confidence: 0.9`)"
                         .to_string(),
@@ -2464,6 +2566,7 @@ impl TypeChecker {
             };
             if !KNOWN_KEYS.contains(&name) {
                 self.warning_at(
+                    Code::InvalidAttributeArgument,
                     format!(
                         "unknown `@archivist` argument `{name}`; expected one of \
                          {KNOWN_KEYS:?}"
@@ -2485,6 +2588,7 @@ impl TypeChecker {
                     Node::Identifier(_) => {}
                     _ => {
                         self.warning_at(
+                            Code::InvalidAttributeArgument,
                             "`@archivist(confidence: ...)` must be a float in \
                              [0.0, 1.0]"
                                 .to_string(),
@@ -2497,6 +2601,7 @@ impl TypeChecker {
 
         if !has_evidence {
             self.warning_at(
+                Code::InvalidAttributeArgument,
                 "`@archivist(...)` should declare `evidence: [...]` so \
                  predicates can be audited"
                     .to_string(),

--- a/crates/harn-parser/src/typechecker/inference/variance.rs
+++ b/crates/harn-parser/src/typechecker/inference/variance.rs
@@ -9,6 +9,7 @@
 use std::collections::BTreeMap;
 
 use crate::ast::*;
+use crate::diagnostic_codes::Code;
 use harn_lexer::Span;
 
 use super::super::scope::Polarity;
@@ -189,6 +190,7 @@ impl TypeChecker {
                             Polarity::Invariant => "invariant",
                         };
                         self.error_at(
+                            Code::GenericTypeArgumentMismatch,
                             format!(
                                 "type parameter '{name}' is declared '{marker}' \
                                  ({declared_word}) but appears in a \

--- a/crates/harn-parser/src/typechecker/mod.rs
+++ b/crates/harn-parser/src/typechecker/mod.rs
@@ -2,7 +2,10 @@ use std::collections::HashSet;
 
 use crate::ast::*;
 use crate::builtin_signatures;
+use crate::diagnostic_codes::Code;
 use harn_lexer::{FixEdit, Span};
+
+type TypeMismatchEvidence = (Option<(Span, String)>, Option<Span>);
 
 mod binary_ops;
 mod exits;
@@ -31,6 +34,7 @@ pub struct InlayHintInfo {
 /// A diagnostic produced by the type checker.
 #[derive(Debug, Clone)]
 pub struct TypeDiagnostic {
+    pub code: Code,
     pub message: String,
     pub severity: DiagnosticSeverity,
     pub span: Option<Span>,
@@ -300,8 +304,9 @@ impl TypeChecker {
         self.check_inner(program)
     }
 
-    pub(in crate::typechecker) fn error_at(&mut self, message: String, span: Span) {
+    pub(in crate::typechecker) fn error_at(&mut self, code: Code, message: String, span: Span) {
         self.diagnostics.push(TypeDiagnostic {
+            code,
             message,
             severity: DiagnosticSeverity::Error,
             span: Some(span),
@@ -315,11 +320,13 @@ impl TypeChecker {
     #[allow(dead_code)]
     pub(in crate::typechecker) fn error_at_with_help(
         &mut self,
+        code: Code,
         message: String,
         span: Span,
         help: String,
     ) {
         self.diagnostics.push(TypeDiagnostic {
+            code,
             message,
             severity: DiagnosticSeverity::Error,
             span: Some(span),
@@ -332,14 +339,15 @@ impl TypeChecker {
 
     pub(in crate::typechecker) fn type_mismatch_at(
         &mut self,
+        code: Code,
         context: impl Into<String>,
         expected: &TypeExpr,
         actual: &TypeExpr,
         span: Span,
-        expected_origin: Option<(Span, String)>,
-        value_span: Option<Span>,
+        evidence: TypeMismatchEvidence,
         scope: &TypeScope,
     ) {
+        let (expected_origin, value_span) = evidence;
         let nested_mismatch = first_nested_mismatch(expected, actual, scope);
         let mut message = format!(
             "{}: expected {}, found {}",
@@ -365,6 +373,7 @@ impl TypeChecker {
         }
 
         self.diagnostics.push(TypeDiagnostic {
+            code,
             message,
             severity: DiagnosticSeverity::Error,
             span: Some(span),
@@ -377,11 +386,13 @@ impl TypeChecker {
 
     pub(in crate::typechecker) fn error_at_with_fix(
         &mut self,
+        code: Code,
         message: String,
         span: Span,
         fix: Vec<FixEdit>,
     ) {
         self.diagnostics.push(TypeDiagnostic {
+            code,
             message,
             severity: DiagnosticSeverity::Error,
             span: Some(span),
@@ -398,8 +409,14 @@ impl TypeChecker {
     /// Partial `if/elif/else` chains are intentionally allowed and are
     /// instead handled by `check_unknown_exhaustiveness`, which stays a
     /// warning so the `unreachable()` opt-in pattern continues to work.
-    pub(in crate::typechecker) fn exhaustiveness_error_at(&mut self, message: String, span: Span) {
+    pub(in crate::typechecker) fn exhaustiveness_error_at(
+        &mut self,
+        code: Code,
+        message: String,
+        span: Span,
+    ) {
         self.diagnostics.push(TypeDiagnostic {
+            code,
             message,
             severity: DiagnosticSeverity::Error,
             span: Some(span),
@@ -416,11 +433,13 @@ impl TypeChecker {
     /// without string-parsing the message.
     pub(in crate::typechecker) fn exhaustiveness_error_with_missing(
         &mut self,
+        code: Code,
         message: String,
         span: Span,
         missing: Vec<String>,
     ) {
         self.diagnostics.push(TypeDiagnostic {
+            code,
             message,
             severity: DiagnosticSeverity::Error,
             span: Some(span),
@@ -431,8 +450,9 @@ impl TypeChecker {
         });
     }
 
-    pub(in crate::typechecker) fn warning_at(&mut self, message: String, span: Span) {
+    pub(in crate::typechecker) fn warning_at(&mut self, code: Code, message: String, span: Span) {
         self.diagnostics.push(TypeDiagnostic {
+            code,
             message,
             severity: DiagnosticSeverity::Warning,
             span: Some(span),
@@ -446,11 +466,13 @@ impl TypeChecker {
     #[allow(dead_code)]
     pub(in crate::typechecker) fn warning_at_with_help(
         &mut self,
+        code: Code,
         message: String,
         span: Span,
         help: String,
     ) {
         self.diagnostics.push(TypeDiagnostic {
+            code,
             message,
             severity: DiagnosticSeverity::Warning,
             span: Some(span),
@@ -463,6 +485,7 @@ impl TypeChecker {
 
     pub(in crate::typechecker) fn lint_warning_at_with_fix(
         &mut self,
+        code: Code,
         rule: &'static str,
         message: String,
         span: Span,
@@ -470,6 +493,7 @@ impl TypeChecker {
         fix: Vec<FixEdit>,
     ) {
         self.diagnostics.push(TypeDiagnostic {
+            code,
             message,
             severity: DiagnosticSeverity::Warning,
             span: Some(span),

--- a/crates/harn-parser/src/typechecker/tests/typing.rs
+++ b/crates/harn-parser/src/typechecker/tests/typing.rs
@@ -1185,7 +1185,7 @@ fn test_type_mismatch_render_snapshot_with_coercion_help() {
     let rendered = crate::diagnostic::render_type_diagnostic(source, "test.harn", &diags[0]);
     assert_eq!(
         rendered,
-        r#"error: let binding `label`: expected string, found int
+        r#"error[HARN-TYP-007]: let binding `label`: expected string, found int
   --> test.harn:2:23
    |
  2 |   let label: string = 42
@@ -1210,7 +1210,7 @@ fn test_type_mismatch_render_snapshot_with_nested_note() {
     let rendered = crate::diagnostic::render_type_diagnostic(source, "test.harn", &diags[0]);
     assert_eq!(
         rendered,
-        r#"error: let binding `item`: expected {name: string, count: int}, found {name: int, count: int} (field 'name' has type int, expected string)
+        r#"error[HARN-TYP-007]: let binding `item`: expected {name: string, count: int}, found {name: int, count: int} (field 'name' has type int, expected string)
   --> test.harn:2:42
    |
  2 |   let item: {name: string, count: int} = {name: 1, count: 2}

--- a/scripts/check_diagnostic_codes.py
+++ b/scripts/check_diagnostic_codes.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Static checks for stable Harn diagnostic codes."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+REGISTRY = ROOT / "crates/harn-parser/src/diagnostic_codes.rs"
+CATEGORIES = {
+    "Typ",
+    "Par",
+    "Nam",
+    "Cap",
+    "Llm",
+    "Orc",
+    "Std",
+    "Prm",
+    "Mod",
+    "Lnt",
+    "Fmt",
+    "Imp",
+    "Own",
+    "Rcv",
+    "Mat",
+}
+HELPERS = [
+    "error_at_with_help",
+    "error_at_with_fix",
+    "error_at",
+    "type_mismatch_at",
+    "exhaustiveness_error_with_missing",
+    "exhaustiveness_error_at",
+    "warning_at_with_help",
+    "warning_at",
+    "lint_warning_at_with_fix",
+]
+
+
+def main() -> int:
+    errors: list[str] = []
+    code_names = check_registry(errors)
+    check_struct_literals(errors, "LintDiagnostic", ROOT / "crates/harn-lint/src")
+    check_struct_literals(errors, "TypeDiagnostic", ROOT / "crates/harn-parser/src")
+    check_struct_literals(errors, "PreflightDiagnostic", ROOT / "crates/harn-cli/src/commands/check")
+    check_typechecker_helper_calls(errors)
+    check_code_constructor_calls(errors, ROOT / "crates/harn-fmt/src", "FormatError::new")
+    check_unknown_code_variants(errors, code_names)
+    if errors:
+        print("diagnostic code check failed:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+    print("diagnostic codes: OK")
+    return 0
+
+
+def check_registry(errors: list[str]) -> set[str]:
+    text = REGISTRY.read_text()
+    entries = re.findall(
+        r"^\s*([A-Za-z][A-Za-z0-9_]*),\s+\"([^\"]+)\",\s+([A-Za-z]+),",
+        text,
+        re.MULTILINE,
+    )
+    if len(entries) < 40:
+        errors.append(f"{REGISTRY}: expected at least 40 registered codes, found {len(entries)}")
+    seen_ids: set[str] = set()
+    seen_variants: set[str] = set()
+    seen_categories: set[str] = set()
+    for variant, identifier, category in entries:
+        if identifier in seen_ids:
+            errors.append(f"{REGISTRY}: duplicate diagnostic identifier {identifier}")
+        seen_ids.add(identifier)
+        if variant in seen_variants:
+            errors.append(f"{REGISTRY}: duplicate diagnostic variant {variant}")
+        seen_variants.add(variant)
+        if category not in CATEGORIES:
+            errors.append(f"{REGISTRY}: unknown category enum variant {category}")
+            continue
+        match = re.fullmatch(r"HARN-([A-Z]{3})-\d{3}", identifier)
+        if match is None:
+            errors.append(f"{REGISTRY}: malformed diagnostic identifier {identifier}")
+            continue
+        category_text = match.group(1)
+        if category_text != category_code(category):
+            errors.append(
+                f"{REGISTRY}: identifier {identifier} does not match category {category}"
+            )
+        seen_categories.add(category)
+    missing = CATEGORIES - seen_categories
+    if missing:
+        errors.append(f"{REGISTRY}: missing populated categories {sorted(missing)}")
+    return seen_variants
+
+
+def category_code(category: str) -> str:
+    return {
+        "Typ": "TYP",
+        "Par": "PAR",
+        "Nam": "NAM",
+        "Cap": "CAP",
+        "Llm": "LLM",
+        "Orc": "ORC",
+        "Std": "STD",
+        "Prm": "PRM",
+        "Mod": "MOD",
+        "Lnt": "LNT",
+        "Fmt": "FMT",
+        "Imp": "IMP",
+        "Own": "OWN",
+        "Rcv": "RCV",
+        "Mat": "MAT",
+    }[category]
+
+
+def check_struct_literals(errors: list[str], name: str, root: Path) -> None:
+    for path in sorted(root.rglob("*.rs")):
+        text = path.read_text()
+        for start, end in find_struct_literals(text, f"{name} {{"):
+            prefix = text[max(0, start - 80) : start]
+            if f"pub struct {name}" in prefix:
+                continue
+            block = text[start:end]
+            if not re.search(r"\bcode\s*[:,]", block):
+                errors.append(f"{rel(path)}:{line(text, start)}: {name} literal missing code")
+
+
+def find_struct_literals(text: str, needle: str) -> list[tuple[int, int]]:
+    out: list[tuple[int, int]] = []
+    start = 0
+    while True:
+        idx = text.find(needle, start)
+        if idx < 0:
+            return out
+        brace = text.find("{", idx)
+        depth = 0
+        end = None
+        for pos in range(brace, len(text)):
+            char = text[pos]
+            if char == "{":
+                depth += 1
+            elif char == "}":
+                depth -= 1
+                if depth == 0:
+                    end = pos + 1
+                    break
+        if end is None:
+            out.append((idx, len(text)))
+            return out
+        out.append((idx, end))
+        start = end
+
+
+def check_typechecker_helper_calls(errors: list[str]) -> None:
+    root = ROOT / "crates/harn-parser/src/typechecker"
+    for path in sorted(root.rglob("*.rs")):
+        if path.name == "mod.rs":
+            continue
+        text = path.read_text()
+        for helper in HELPERS:
+            needle = f"self.{helper}("
+            start = 0
+            while True:
+                idx = text.find(needle, start)
+                if idx < 0:
+                    break
+                arg = first_non_ws(text, idx + len(needle))
+                if not text.startswith("Code::", arg):
+                    errors.append(
+                        f"{rel(path)}:{line(text, idx)}: self.{helper} must pass Code::* first"
+                    )
+                start = idx + len(needle)
+
+
+def check_code_constructor_calls(errors: list[str], root: Path, needle: str) -> None:
+    for path in sorted(root.rglob("*.rs")):
+        text = path.read_text()
+        start = 0
+        call = f"{needle}("
+        while True:
+            idx = text.find(call, start)
+            if idx < 0:
+                break
+            arg = first_non_ws(text, idx + len(call))
+            if not text.startswith("Code::", arg):
+                errors.append(f"{rel(path)}:{line(text, idx)}: {needle} must pass Code::* first")
+            start = idx + len(call)
+
+
+def check_unknown_code_variants(errors: list[str], code_names: set[str]) -> None:
+    for root in [
+        ROOT / "crates/harn-parser/src",
+        ROOT / "crates/harn-lint/src",
+        ROOT / "crates/harn-fmt/src",
+        ROOT / "crates/harn-cli/src/commands/check",
+        ROOT / "crates/harn-lsp/src",
+    ]:
+        for path in sorted(root.rglob("*.rs")):
+            if path == REGISTRY:
+                continue
+            text = path.read_text()
+            for match in re.finditer(r"\bCode::([A-Za-z][A-Za-z0-9_]*)", text):
+                if match.group(1) not in code_names:
+                    errors.append(
+                        f"{rel(path)}:{line(text, match.start())}: unknown Code::{match.group(1)}"
+                    )
+
+
+def first_non_ws(text: str, offset: int) -> int:
+    while offset < len(text) and text[offset].isspace():
+        offset += 1
+    return offset
+
+
+def line(text: str, offset: int) -> int:
+    return text.count("\n", 0, offset) + 1
+
+
+def rel(path: Path) -> str:
+    return str(path.relative_to(ROOT))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Add a central `DiagnosticCode` registry with stable `HARN-<CAT>-<NNN>` identifiers, category metadata, `Display`, and `FromStr` support.
- Require codes on type, lint, formatter, and `harn check` preflight diagnostics, and render those codes in CLI/LSP output.
- Add a static diagnostic-code gate wired into `make all` and CI to catch missing or unregistered diagnostic codes.

Closes #1746

## Verification

- `cargo fmt --all -- --check`
- `make lint-diagnostic-codes`
- `CARGO_TARGET_DIR=/tmp/harn-target-1746 HARN_LLM_CALLS_DISABLED=1 cargo test -p harn-parser -p harn-lint -p harn-fmt`
- `CARGO_TARGET_DIR=/tmp/harn-target-1746 HARN_LLM_CALLS_DISABLED=1 cargo test -p harn-cli preflight`
- `CARGO_TARGET_DIR=/tmp/harn-target-1746 HARN_LLM_CALLS_DISABLED=1 cargo build --workspace`
- `CARGO_TARGET_DIR=/tmp/harn-target-1746 HARN_LLM_CALLS_DISABLED=1 cargo run --quiet --bin harn -- check conformance/tests` output scan: `coded=231`, `uncoded=0`