### PR TITLE
[codex] Add WorkflowBundle schema v2 harnpack contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,17 @@ condensed series summaries instead of full per-patch history.
   short-circuiting so `try { agent_loop(...) }` can route on the
   exception.
 
+### Changed
+
+- **WorkflowBundle schema v2 / `.harnpack` foundation (#1780).** Portable
+  workflow bundles now use schema v2 with canonical package metadata
+  (`entrypoint`, transitive module hashes, Harn/stdlib versions, provider
+  catalog hash, tool manifest, SBOM, signature slot, and parent trust record
+  linkage). The VM can build/read deterministic `.harnpack` `tar.zst`
+  archives with `harnpack.json` at the root, computes BLAKE3 bundle hashes
+  over canonical manifest bytes plus sorted content hashes, and rejects v1
+  manifests with a typed schema-version error.
+
 ## v0.8.24
 
 ### Fixed

--- a/crates/harn-vm/src/orchestration/workflow_bundle.rs
+++ b/crates/harn-vm/src/orchestration/workflow_bundle.rs
@@ -1,21 +1,36 @@
-//! Portable workflow bundle contract and deterministic local receipts.
+//! Portable workflow bundle contract, `.harnpack` container helpers, and
+//! deterministic local receipts.
 
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fs;
-use std::path::Path;
+use std::io::{Cursor, Read};
+use std::path::{Component, Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use super::{validate_workflow, WorkflowEdge, WorkflowGraph};
+use crate::tool_annotations::ToolAnnotations;
 
-pub const WORKFLOW_BUNDLE_SCHEMA_VERSION: u32 = 1;
+pub const WORKFLOW_BUNDLE_SCHEMA_VERSION: u32 = 2;
 pub const WORKFLOW_BUNDLE_RECEIPT_TYPE: &str = "harn.workflow_bundle.run";
+pub const HARNPACK_MANIFEST_PATH: &str = "harnpack.json";
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+const DEFAULT_HARNPACK_FILE_MODE: u32 = 0o644;
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(default)]
 pub struct WorkflowBundle {
     pub schema_version: u32,
+    pub entrypoint: PathBuf,
+    pub transitive_modules: Vec<ModuleEntry>,
+    pub stdlib_version: String,
+    pub harn_version: String,
+    pub provider_catalog_hash: String,
+    pub tool_manifest: Vec<ToolEntry>,
+    pub sbom: SBOMDoc,
+    pub signature: Option<Ed25519Signature>,
+    pub parent_trust_record_id: Option<String>,
     pub id: String,
     pub name: Option<String>,
     pub version: String,
@@ -27,6 +42,91 @@ pub struct WorkflowBundle {
     pub environment: EnvironmentRequirements,
     pub receipts: WorkflowBundleReplayMetadata,
     pub metadata: BTreeMap<String, serde_json::Value>,
+}
+
+impl Default for WorkflowBundle {
+    fn default() -> Self {
+        Self {
+            schema_version: WORKFLOW_BUNDLE_SCHEMA_VERSION,
+            entrypoint: PathBuf::new(),
+            transitive_modules: Vec::new(),
+            stdlib_version: env!("CARGO_PKG_VERSION").to_string(),
+            harn_version: env!("CARGO_PKG_VERSION").to_string(),
+            provider_catalog_hash: String::new(),
+            tool_manifest: Vec::new(),
+            sbom: SBOMDoc::default(),
+            signature: None,
+            parent_trust_record_id: None,
+            id: String::new(),
+            name: None,
+            version: String::new(),
+            triggers: Vec::new(),
+            workflow: WorkflowGraph::default(),
+            prompt_capsules: BTreeMap::new(),
+            policy: WorkflowBundlePolicy::default(),
+            connectors: Vec::new(),
+            environment: EnvironmentRequirements::default(),
+            receipts: WorkflowBundleReplayMetadata::default(),
+            metadata: BTreeMap::new(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct ModuleEntry {
+    pub path: PathBuf,
+    pub source_hash_blake3: String,
+    pub harnbc_hash_blake3: String,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct ToolEntry {
+    pub name: String,
+    pub provider: Option<String>,
+    pub annotations: Option<ToolAnnotations>,
+    pub schema_hash_blake3: Option<String>,
+    pub metadata: BTreeMap<String, String>,
+}
+
+#[allow(clippy::upper_case_acronyms)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct SBOMDoc {
+    pub format: String,
+    pub version: String,
+    pub packages: Vec<SBOMPackage>,
+    pub relationships: Vec<SBOMRelationship>,
+}
+
+#[allow(clippy::upper_case_acronyms)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct SBOMPackage {
+    pub name: String,
+    pub version: Option<String>,
+    pub package_hash_blake3: Option<String>,
+    pub license: Option<String>,
+}
+
+#[allow(clippy::upper_case_acronyms)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct SBOMRelationship {
+    pub from: String,
+    pub to: String,
+    pub relationship_type: String,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct Ed25519Signature {
+    pub key_id: Option<String>,
+    pub public_key: String,
+    pub signature: String,
+    pub manifest_hash_blake3: String,
+    pub algorithm: String,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -281,8 +381,70 @@ pub struct WorkflowBundleRunNodeReceipt {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HarnpackEntry {
+    pub path: PathBuf,
+    pub bytes: Vec<u8>,
+    pub mode: u32,
+}
+
+impl HarnpackEntry {
+    pub fn new(path: impl Into<PathBuf>, bytes: impl Into<Vec<u8>>) -> Self {
+        Self {
+            path: path.into(),
+            bytes: bytes.into(),
+            mode: DEFAULT_HARNPACK_FILE_MODE,
+        }
+    }
+
+    pub fn with_mode(mut self, mode: u32) -> Self {
+        self.mode = mode;
+        self
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct HarnpackArchive {
+    pub manifest: WorkflowBundle,
+    pub contents: Vec<HarnpackEntry>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum WorkflowBundleErrorKind {
+    Io,
+    Json,
+    MissingSchemaVersion,
+    UnsupportedSchemaVersion { actual: u32, expected: u32 },
+    InvalidArchive,
+    DuplicateArchiveEntry,
+    UnsafeArchivePath,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct WorkflowBundleError {
+    pub kind: WorkflowBundleErrorKind,
     pub message: String,
+}
+
+impl WorkflowBundleError {
+    fn new(kind: WorkflowBundleErrorKind, message: impl Into<String>) -> Self {
+        Self {
+            kind,
+            message: message.into(),
+        }
+    }
+
+    fn unsupported_schema_version(actual: u32) -> Self {
+        Self::new(
+            WorkflowBundleErrorKind::UnsupportedSchemaVersion {
+                actual,
+                expected: WORKFLOW_BUNDLE_SCHEMA_VERSION,
+            },
+            format!(
+                "unsupported workflow bundle schema_version {actual}; expected {}",
+                WORKFLOW_BUNDLE_SCHEMA_VERSION
+            ),
+        )
+    }
 }
 
 impl std::fmt::Display for WorkflowBundleError {
@@ -295,23 +457,179 @@ impl std::error::Error for WorkflowBundleError {}
 
 impl From<std::io::Error> for WorkflowBundleError {
     fn from(error: std::io::Error) -> Self {
-        Self {
-            message: error.to_string(),
-        }
+        Self::new(WorkflowBundleErrorKind::Io, error.to_string())
     }
 }
 
 impl From<serde_json::Error> for WorkflowBundleError {
     fn from(error: serde_json::Error) -> Self {
-        Self {
-            message: error.to_string(),
-        }
+        Self::new(WorkflowBundleErrorKind::Json, error.to_string())
     }
 }
 
 pub fn load_workflow_bundle(path: &Path) -> Result<WorkflowBundle, WorkflowBundleError> {
     let bytes = fs::read(path)?;
-    serde_json::from_slice(&bytes).map_err(Into::into)
+    if path.extension().and_then(|extension| extension.to_str()) == Some("harnpack") {
+        read_harnpack(&bytes).map(|archive| archive.manifest)
+    } else {
+        parse_workflow_bundle_manifest(&bytes)
+    }
+}
+
+pub fn parse_workflow_bundle_manifest(bytes: &[u8]) -> Result<WorkflowBundle, WorkflowBundleError> {
+    let value: serde_json::Value = serde_json::from_slice(bytes)?;
+    let schema_version = value
+        .get("schema_version")
+        .and_then(serde_json::Value::as_u64)
+        .ok_or_else(|| {
+            WorkflowBundleError::new(
+                WorkflowBundleErrorKind::MissingSchemaVersion,
+                "workflow bundle manifest is missing numeric schema_version",
+            )
+        })?;
+    let actual = u32::try_from(schema_version).map_err(|_| {
+        WorkflowBundleError::new(
+            WorkflowBundleErrorKind::UnsupportedSchemaVersion {
+                actual: u32::MAX,
+                expected: WORKFLOW_BUNDLE_SCHEMA_VERSION,
+            },
+            format!(
+                "unsupported workflow bundle schema_version {schema_version}; expected {}",
+                WORKFLOW_BUNDLE_SCHEMA_VERSION
+            ),
+        )
+    })?;
+    if actual != WORKFLOW_BUNDLE_SCHEMA_VERSION {
+        return Err(WorkflowBundleError::unsupported_schema_version(actual));
+    }
+    serde_json::from_value(value).map_err(Into::into)
+}
+
+pub fn canonical_workflow_bundle_manifest_bytes(
+    bundle: &WorkflowBundle,
+) -> Result<Vec<u8>, WorkflowBundleError> {
+    serde_json::to_vec(&canonical_workflow_bundle_manifest(bundle)).map_err(Into::into)
+}
+
+pub fn workflow_bundle_hash(
+    bundle: &WorkflowBundle,
+    contents: &[HarnpackEntry],
+) -> Result<String, WorkflowBundleError> {
+    let mut hasher = blake3::Hasher::new();
+    let mut canonical = canonical_workflow_bundle_manifest(bundle);
+    canonical.signature = None;
+    let manifest_bytes = serde_json::to_vec(&canonical)?;
+    hasher.update(&manifest_bytes);
+
+    let mut content_hashes = contents
+        .iter()
+        .map(|entry| blake3_hash_bytes(&entry.bytes))
+        .collect::<Vec<_>>();
+    content_hashes.sort();
+    for content_hash in content_hashes {
+        hasher.update(b"\n");
+        hasher.update(content_hash.as_bytes());
+    }
+
+    Ok(blake3_digest_string(hasher.finalize()))
+}
+
+pub fn build_harnpack(
+    bundle: &WorkflowBundle,
+    contents: &[HarnpackEntry],
+) -> Result<Vec<u8>, WorkflowBundleError> {
+    let manifest_bytes = canonical_workflow_bundle_manifest_bytes(bundle)?;
+    let mut entries = contents
+        .iter()
+        .map(|entry| {
+            normalize_archive_path(&entry.path).map(|path| (path, entry.bytes.clone(), entry.mode))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    entries.sort_by(|left, right| left.0.cmp(&right.0));
+
+    let mut seen = BTreeSet::new();
+    for (path, _, _) in &entries {
+        if path == HARNPACK_MANIFEST_PATH {
+            return Err(WorkflowBundleError::new(
+                WorkflowBundleErrorKind::DuplicateArchiveEntry,
+                format!("archive content cannot replace {HARNPACK_MANIFEST_PATH}"),
+            ));
+        }
+        if !seen.insert(path.clone()) {
+            return Err(WorkflowBundleError::new(
+                WorkflowBundleErrorKind::DuplicateArchiveEntry,
+                format!("duplicate archive entry: {path}"),
+            ));
+        }
+    }
+
+    let mut tar_bytes = Vec::new();
+    {
+        let mut builder = tar::Builder::new(&mut tar_bytes);
+        append_harnpack_entry(
+            &mut builder,
+            HARNPACK_MANIFEST_PATH,
+            &manifest_bytes,
+            DEFAULT_HARNPACK_FILE_MODE,
+        )?;
+        for (path, bytes, mode) in entries {
+            append_harnpack_entry(&mut builder, &path, &bytes, mode)?;
+        }
+        builder.finish()?;
+    }
+
+    zstd::stream::encode_all(Cursor::new(tar_bytes), 0).map_err(Into::into)
+}
+
+pub fn read_harnpack(bytes: &[u8]) -> Result<HarnpackArchive, WorkflowBundleError> {
+    let tar_bytes = zstd::stream::decode_all(Cursor::new(bytes))?;
+    let mut archive = tar::Archive::new(Cursor::new(tar_bytes));
+    let mut manifest = None;
+    let mut contents = Vec::new();
+    let mut seen = BTreeSet::new();
+
+    for entry in archive.entries()? {
+        let mut entry = entry?;
+        if entry.header().entry_type().is_dir() {
+            continue;
+        }
+        let path = normalize_archive_path(entry.path()?.as_ref())?;
+        if !seen.insert(path.clone()) {
+            return Err(WorkflowBundleError::new(
+                WorkflowBundleErrorKind::DuplicateArchiveEntry,
+                format!("duplicate archive entry: {path}"),
+            ));
+        }
+        let mode = entry.header().mode().unwrap_or(DEFAULT_HARNPACK_FILE_MODE);
+        let mut entry_bytes = Vec::new();
+        entry.read_to_end(&mut entry_bytes)?;
+
+        if path == HARNPACK_MANIFEST_PATH {
+            manifest = Some(parse_workflow_bundle_manifest(&entry_bytes)?);
+        } else {
+            contents.push(HarnpackEntry {
+                path: PathBuf::from(path),
+                bytes: entry_bytes,
+                mode,
+            });
+        }
+    }
+
+    contents.sort_by(|left, right| left.path.cmp(&right.path));
+    Ok(HarnpackArchive {
+        manifest: manifest.ok_or_else(|| {
+            WorkflowBundleError::new(
+                WorkflowBundleErrorKind::InvalidArchive,
+                format!("harnpack archive is missing {HARNPACK_MANIFEST_PATH}"),
+            )
+        })?,
+        contents,
+    })
+}
+
+pub fn current_provider_catalog_hash_blake3() -> Result<String, WorkflowBundleError> {
+    let bytes = serde_json::to_vec(&crate::provider_catalog::artifact())?;
+    Ok(blake3_hash_bytes(&bytes))
 }
 
 pub fn workflow_graph_digest(graph: &WorkflowGraph) -> String {
@@ -326,6 +644,127 @@ pub fn workflow_graph_digest(graph: &WorkflowGraph) -> String {
     format!("sha256:{hex}")
 }
 
+fn canonical_workflow_bundle_manifest(bundle: &WorkflowBundle) -> WorkflowBundle {
+    let mut canonical = bundle.clone();
+    canonical.workflow = canonical_workflow_graph(&bundle.workflow);
+    canonical.transitive_modules.sort_by(|left, right| {
+        (
+            path_sort_key(&left.path),
+            &left.source_hash_blake3,
+            &left.harnbc_hash_blake3,
+        )
+            .cmp(&(
+                path_sort_key(&right.path),
+                &right.source_hash_blake3,
+                &right.harnbc_hash_blake3,
+            ))
+    });
+    canonical.tool_manifest.sort_by(|left, right| {
+        (&left.name, &left.provider, &left.schema_hash_blake3).cmp(&(
+            &right.name,
+            &right.provider,
+            &right.schema_hash_blake3,
+        ))
+    });
+    canonical.sbom.packages.sort_by(|left, right| {
+        (&left.name, &left.version, &left.package_hash_blake3).cmp(&(
+            &right.name,
+            &right.version,
+            &right.package_hash_blake3,
+        ))
+    });
+    canonical.sbom.relationships.sort_by(|left, right| {
+        (&left.from, &left.to, &left.relationship_type).cmp(&(
+            &right.from,
+            &right.to,
+            &right.relationship_type,
+        ))
+    });
+    canonical
+}
+
+fn append_harnpack_entry<W: std::io::Write>(
+    builder: &mut tar::Builder<W>,
+    path: &str,
+    bytes: &[u8],
+    mode: u32,
+) -> Result<(), WorkflowBundleError> {
+    let mut header = tar::Header::new_gnu();
+    header.set_path(path).map_err(|error| {
+        WorkflowBundleError::new(
+            WorkflowBundleErrorKind::UnsafeArchivePath,
+            format!("invalid archive path {path}: {error}"),
+        )
+    })?;
+    header.set_entry_type(tar::EntryType::Regular);
+    header.set_size(bytes.len() as u64);
+    header.set_mode(mode);
+    header.set_mtime(0);
+    header.set_uid(0);
+    header.set_gid(0);
+    header.set_cksum();
+    builder.append(&header, bytes)?;
+    Ok(())
+}
+
+fn normalize_archive_path(path: &Path) -> Result<String, WorkflowBundleError> {
+    let mut parts = Vec::new();
+    for component in path.components() {
+        match component {
+            Component::Normal(part) => {
+                let Some(part) = part.to_str() else {
+                    return Err(WorkflowBundleError::new(
+                        WorkflowBundleErrorKind::UnsafeArchivePath,
+                        format!("archive path is not valid UTF-8: {}", path.display()),
+                    ));
+                };
+                if part.is_empty() {
+                    return Err(WorkflowBundleError::new(
+                        WorkflowBundleErrorKind::UnsafeArchivePath,
+                        "archive path contains an empty component",
+                    ));
+                }
+                parts.push(part.to_string());
+            }
+            Component::CurDir => {}
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                return Err(WorkflowBundleError::new(
+                    WorkflowBundleErrorKind::UnsafeArchivePath,
+                    format!(
+                        "archive path must be relative and contained: {}",
+                        path.display()
+                    ),
+                ));
+            }
+        }
+    }
+    if parts.is_empty() {
+        return Err(WorkflowBundleError::new(
+            WorkflowBundleErrorKind::UnsafeArchivePath,
+            "archive path is empty",
+        ));
+    }
+    Ok(parts.join("/"))
+}
+
+fn path_sort_key(path: &Path) -> String {
+    path.components()
+        .filter_map(|component| match component {
+            Component::Normal(part) => part.to_str().map(ToOwned::to_owned),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+fn blake3_hash_bytes(bytes: &[u8]) -> String {
+    blake3_digest_string(blake3::hash(bytes))
+}
+
+fn blake3_digest_string(hash: blake3::Hash) -> String {
+    format!("blake3:{hash}")
+}
+
 pub fn validate_workflow_bundle(bundle: &WorkflowBundle) -> WorkflowBundleValidationReport {
     let canonical = canonical_workflow_graph(&bundle.workflow);
     let mut report = WorkflowBundleValidationReport {
@@ -337,6 +776,7 @@ pub fn validate_workflow_bundle(bundle: &WorkflowBundle) -> WorkflowBundleValida
         warnings: Vec::new(),
     };
 
+    validate_manifest_contract(bundle, &mut report);
     validate_bundle_identity(bundle, &canonical, &mut report);
     validate_triggers(bundle, &canonical, &mut report);
     validate_prompt_capsules(bundle, &canonical, &mut report);
@@ -855,6 +1295,253 @@ fn validate_bundle_identity(
                 Some(node_id.clone()),
             );
         }
+    }
+}
+
+fn validate_manifest_contract(
+    bundle: &WorkflowBundle,
+    report: &mut WorkflowBundleValidationReport,
+) {
+    validate_relative_path(
+        report,
+        "entrypoint",
+        &bundle.entrypoint,
+        "entrypoint is required",
+    );
+    if bundle.transitive_modules.is_empty() {
+        push_error(
+            report,
+            "transitive_modules",
+            "at least one transitive module entry is required",
+            None,
+        );
+    }
+    let mut module_paths = BTreeSet::new();
+    for (index, module) in bundle.transitive_modules.iter().enumerate() {
+        let path = format!("transitive_modules[{index}]");
+        validate_relative_path(
+            report,
+            format!("{path}.path"),
+            &module.path,
+            "module path is required",
+        );
+        if !module.path.as_os_str().is_empty() && !module_paths.insert(path_sort_key(&module.path))
+        {
+            push_error(
+                report,
+                format!("{path}.path"),
+                format!(
+                    "duplicate transitive module path: {}",
+                    module.path.display()
+                ),
+                None,
+            );
+        }
+        validate_blake3_hash(
+            report,
+            format!("{path}.source_hash_blake3"),
+            &module.source_hash_blake3,
+            true,
+        );
+        validate_blake3_hash(
+            report,
+            format!("{path}.harnbc_hash_blake3"),
+            &module.harnbc_hash_blake3,
+            true,
+        );
+    }
+    if bundle.stdlib_version.trim().is_empty() {
+        push_error(report, "stdlib_version", "stdlib_version is required", None);
+    }
+    if bundle.harn_version.trim().is_empty() {
+        push_error(report, "harn_version", "harn_version is required", None);
+    }
+    validate_blake3_hash(
+        report,
+        "provider_catalog_hash",
+        &bundle.provider_catalog_hash,
+        true,
+    );
+
+    let mut tool_names = BTreeSet::new();
+    for (index, tool) in bundle.tool_manifest.iter().enumerate() {
+        let path = format!("tool_manifest[{index}]");
+        if tool.name.trim().is_empty() {
+            push_error(
+                report,
+                format!("{path}.name"),
+                "tool manifest entry name is required",
+                None,
+            );
+        } else if !tool_names.insert(tool.name.clone()) {
+            push_error(
+                report,
+                format!("{path}.name"),
+                format!("duplicate tool manifest entry: {}", tool.name),
+                None,
+            );
+        }
+        if let Some(hash) = tool.schema_hash_blake3.as_deref() {
+            validate_blake3_hash(report, format!("{path}.schema_hash_blake3"), hash, true);
+        }
+    }
+
+    if bundle.sbom.format.trim().is_empty() {
+        push_error(report, "sbom.format", "SBOM format is required", None);
+    }
+    if bundle.sbom.version.trim().is_empty() {
+        push_error(report, "sbom.version", "SBOM version is required", None);
+    }
+    let mut sbom_packages = BTreeSet::new();
+    for (index, package) in bundle.sbom.packages.iter().enumerate() {
+        let path = format!("sbom.packages[{index}]");
+        if package.name.trim().is_empty() {
+            push_error(
+                report,
+                format!("{path}.name"),
+                "SBOM package name is required",
+                None,
+            );
+        } else if !sbom_packages.insert(package.name.clone()) {
+            push_error(
+                report,
+                format!("{path}.name"),
+                format!("duplicate SBOM package: {}", package.name),
+                None,
+            );
+        }
+        if let Some(hash) = package.package_hash_blake3.as_deref() {
+            validate_blake3_hash(report, format!("{path}.package_hash_blake3"), hash, true);
+        }
+    }
+    for (index, relationship) in bundle.sbom.relationships.iter().enumerate() {
+        let path = format!("sbom.relationships[{index}]");
+        if relationship.from.trim().is_empty() {
+            push_error(
+                report,
+                format!("{path}.from"),
+                "SBOM relationship source is required",
+                None,
+            );
+        }
+        if relationship.to.trim().is_empty() {
+            push_error(
+                report,
+                format!("{path}.to"),
+                "SBOM relationship target is required",
+                None,
+            );
+        }
+        if relationship.relationship_type.trim().is_empty() {
+            push_error(
+                report,
+                format!("{path}.relationship_type"),
+                "SBOM relationship type is required",
+                None,
+            );
+        }
+    }
+
+    if let Some(parent_id) = bundle.parent_trust_record_id.as_deref() {
+        if parent_id.trim().is_empty() {
+            push_error(
+                report,
+                "parent_trust_record_id",
+                "parent_trust_record_id cannot be empty when present",
+                None,
+            );
+        }
+    }
+    if let Some(signature) = &bundle.signature {
+        if signature.algorithm.trim().is_empty() {
+            push_error(
+                report,
+                "signature.algorithm",
+                "signature algorithm is required",
+                None,
+            );
+        } else if signature.algorithm != "ed25519" {
+            push_error(
+                report,
+                "signature.algorithm",
+                "signature algorithm must be ed25519",
+                None,
+            );
+        }
+        if signature.public_key.trim().is_empty() {
+            push_error(
+                report,
+                "signature.public_key",
+                "signature public_key is required",
+                None,
+            );
+        }
+        if signature.signature.trim().is_empty() {
+            push_error(
+                report,
+                "signature.signature",
+                "signature value is required",
+                None,
+            );
+        }
+        validate_blake3_hash(
+            report,
+            "signature.manifest_hash_blake3",
+            &signature.manifest_hash_blake3,
+            true,
+        );
+    }
+}
+
+fn validate_relative_path(
+    report: &mut WorkflowBundleValidationReport,
+    path: impl Into<String>,
+    value: &Path,
+    empty_message: &str,
+) {
+    let path = path.into();
+    if value.as_os_str().is_empty() {
+        push_error(report, path, empty_message, None);
+        return;
+    }
+    if normalize_archive_path(value).is_err() {
+        push_error(
+            report,
+            path,
+            format!("path must be relative and contained: {}", value.display()),
+            None,
+        );
+    }
+}
+
+fn validate_blake3_hash(
+    report: &mut WorkflowBundleValidationReport,
+    path: impl Into<String>,
+    value: &str,
+    required: bool,
+) {
+    let path = path.into();
+    if value.trim().is_empty() {
+        if required {
+            push_error(report, path, "BLAKE3 hash is required", None);
+        }
+        return;
+    }
+    let Some(hex) = value.strip_prefix("blake3:") else {
+        push_error(report, path, "BLAKE3 hash must use blake3:<hex>", None);
+        return;
+    };
+    if hex.len() != 64
+        || !hex
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+    {
+        push_error(
+            report,
+            path,
+            "BLAKE3 hash must contain 64 lowercase hex digits",
+            None,
+        );
     }
 }
 

--- a/crates/harn-vm/src/orchestration/workflow_bundle_tests.rs
+++ b/crates/harn-vm/src/orchestration/workflow_bundle_tests.rs
@@ -2,111 +2,7 @@ use super::*;
 use crate::orchestration::{WorkflowEdge, WorkflowNode};
 
 fn fixture_bundle() -> WorkflowBundle {
-    serde_json::from_str(
-        r#"{
-  "schema_version": 1,
-  "id": "github-pr-monitor",
-  "name": "GitHub PR monitor",
-  "version": "1.0.0",
-  "triggers": [
-    {
-      "id": "github-pr-updated",
-      "kind": "github",
-      "provider": "github",
-      "events": ["pull_request.opened", "pull_request.synchronize"],
-      "node_id": "ingest"
-    },
-    {
-      "id": "delay-log-check",
-      "kind": "delay",
-      "delay": "PT10M",
-      "node_id": "query_logs"
-    }
-  ],
-  "workflow": {
-    "_type": "workflow_graph",
-    "id": "pr_monitor_workflow",
-    "name": "PR monitor",
-    "version": 1,
-    "entry": "ingest",
-    "nodes": {
-      "ingest": {
-        "id": "ingest",
-        "kind": "action",
-        "task_label": "Normalize PR event"
-      },
-      "wait_for_deploy": {
-        "id": "wait_for_deploy",
-        "kind": "waitpoint",
-        "task_label": "Wait for deploy"
-      },
-      "query_logs": {
-        "id": "query_logs",
-        "kind": "action",
-        "task_label": "Query logs"
-      },
-      "notify": {
-        "id": "notify",
-        "kind": "notification",
-        "task_label": "Notify user"
-      }
-    },
-    "edges": [
-      {
-        "from": "ingest",
-        "to": "wait_for_deploy"
-      },
-      {
-        "from": "wait_for_deploy",
-        "to": "query_logs"
-      },
-      {
-        "from": "query_logs",
-        "to": "notify"
-      }
-    ]
-  },
-  "prompt_capsules": {
-    "query-logs": {
-      "id": "query-logs",
-      "node_id": "query_logs",
-      "trigger_id": "delay-log-check",
-      "prompt": "Query deploy logs for the pull request and summarize failures."
-    }
-  },
-  "policy": {
-    "autonomy_tier": "act_with_approval",
-    "retry": {
-      "max_attempts": 2,
-      "backoff": "exponential"
-    },
-    "catchup": {
-      "mode": "latest",
-      "max_events": 1
-    }
-  },
-  "connectors": [
-    {
-      "id": "github",
-      "provider_id": "github",
-      "scopes": ["pull_requests:read", "checks:read"],
-      "setup_required": true,
-      "status_required": true
-    }
-  ],
-  "environment": {
-    "repo_setup_profile": "default",
-    "worktree_policy": "host_managed",
-    "command_gates": ["make test"]
-  },
-  "receipts": {
-    "run_id": "bundle_run_pr_monitor_fixture",
-    "event_ids": ["github:event:42"],
-    "workflow_version": 1
-  }
-}"#,
-    )
-    .unwrap()
+    super::super::workflow_test_fixtures::pr_monitor_bundle()
 }
 
 fn graph_node_types(preview: &WorkflowBundlePreview) -> Vec<String> {
@@ -162,6 +58,103 @@ fn validates_fixture_bundle_and_previews_graph() {
         field.id == "prompt_capsule.query-logs.prompt"
             && field.json_pointer == "/prompt_capsules/query-logs/prompt"
     }));
+}
+
+#[test]
+fn v2_manifest_deserializes_and_v1_is_typed_error() {
+    let bundle = parse_workflow_bundle_manifest(
+        super::super::workflow_test_fixtures::PR_MONITOR_BUNDLE_JSON.as_bytes(),
+    )
+    .unwrap();
+    assert_eq!(bundle.schema_version, WORKFLOW_BUNDLE_SCHEMA_VERSION);
+    assert_eq!(
+        bundle.entrypoint,
+        std::path::PathBuf::from("workflows/github-pr-monitor.harn")
+    );
+    assert_eq!(bundle.transitive_modules.len(), 1);
+    assert!(current_provider_catalog_hash_blake3()
+        .unwrap()
+        .starts_with("blake3:"));
+
+    let err = parse_workflow_bundle_manifest(br#"{"schema_version":1}"#).unwrap_err();
+    assert_eq!(
+        err.kind,
+        WorkflowBundleErrorKind::UnsupportedSchemaVersion {
+            actual: 1,
+            expected: WORKFLOW_BUNDLE_SCHEMA_VERSION,
+        }
+    );
+}
+
+#[test]
+fn harnpack_build_read_and_bundle_hash_are_deterministic() {
+    let bundle = fixture_bundle();
+    let contents = vec![
+        HarnpackEntry::new("bytecode/pr_monitor.harnbc", b"bytecode-v1".to_vec()),
+        HarnpackEntry::new("sources/pr_monitor.harn", b"source-v1".to_vec()),
+    ];
+    let reversed_contents = vec![contents[1].clone(), contents[0].clone()];
+
+    let left_pack = build_harnpack(&bundle, &contents).unwrap();
+    let right_pack = build_harnpack(&bundle, &reversed_contents).unwrap();
+    assert_eq!(left_pack, right_pack);
+
+    let left_hash = workflow_bundle_hash(&bundle, &contents).unwrap();
+    let right_hash = workflow_bundle_hash(&bundle, &reversed_contents).unwrap();
+    assert_eq!(left_hash, right_hash);
+
+    let changed_hash = workflow_bundle_hash(
+        &bundle,
+        &[HarnpackEntry::new(
+            "sources/pr_monitor.harn",
+            b"source-v2".to_vec(),
+        )],
+    )
+    .unwrap();
+    assert_ne!(left_hash, changed_hash);
+
+    let archive = read_harnpack(&left_pack).unwrap();
+    assert_eq!(archive.manifest.id, bundle.id);
+    assert_eq!(
+        archive
+            .contents
+            .iter()
+            .map(|entry| entry.path.display().to_string())
+            .collect::<Vec<_>>(),
+        vec!["bytecode/pr_monitor.harnbc", "sources/pr_monitor.harn"]
+    );
+
+    let temp = tempfile::tempdir().unwrap();
+    let pack_path = temp.path().join("fixture.harnpack");
+    std::fs::write(&pack_path, left_pack).unwrap();
+    let loaded = load_workflow_bundle(&pack_path).unwrap();
+    assert_eq!(loaded.id, bundle.id);
+}
+
+#[test]
+fn validator_rejects_missing_v2_manifest_contract_fields() {
+    let mut bundle = fixture_bundle();
+    bundle.entrypoint = std::path::PathBuf::new();
+    bundle.transitive_modules.clear();
+    bundle.provider_catalog_hash = "sha256:not-blake3".to_string();
+    bundle.sbom.format.clear();
+
+    let report = validate_workflow_bundle(&bundle);
+    assert!(!report.valid);
+    for path in [
+        "entrypoint",
+        "transitive_modules",
+        "provider_catalog_hash",
+        "sbom.format",
+    ] {
+        assert!(
+            report
+                .errors
+                .iter()
+                .any(|diagnostic| diagnostic.path == path),
+            "{report:#?}"
+        );
+    }
 }
 
 #[test]

--- a/crates/harn-vm/src/orchestration/workflow_test_fixtures.rs
+++ b/crates/harn-vm/src/orchestration/workflow_test_fixtures.rs
@@ -16,7 +16,33 @@
 use super::workflow_bundle::WorkflowBundle;
 
 pub(crate) const PR_MONITOR_BUNDLE_JSON: &str = r#"{
-  "schema_version": 1,
+  "schema_version": 2,
+  "entrypoint": "workflows/github-pr-monitor.harn",
+  "transitive_modules": [
+    {
+      "path": "workflows/github-pr-monitor.harn",
+      "source_hash_blake3": "blake3:1111111111111111111111111111111111111111111111111111111111111111",
+      "harnbc_hash_blake3": "blake3:2222222222222222222222222222222222222222222222222222222222222222"
+    }
+  ],
+  "stdlib_version": "0.8.24",
+  "harn_version": "0.8.24",
+  "provider_catalog_hash": "blake3:3333333333333333333333333333333333333333333333333333333333333333",
+  "tool_manifest": [],
+  "sbom": {
+    "format": "spdx-lite",
+    "version": "2.3",
+    "packages": [
+      {
+        "name": "harn-stdlib",
+        "version": "0.8.24",
+        "package_hash_blake3": "blake3:4444444444444444444444444444444444444444444444444444444444444444"
+      }
+    ],
+    "relationships": []
+  },
+  "signature": null,
+  "parent_trust_record_id": null,
   "id": "github-pr-monitor",
   "name": "GitHub PR monitor",
   "version": "1.0.0",

--- a/docs/fixtures/workflow-bundles/github-pr-monitor.bundle.json
+++ b/docs/fixtures/workflow-bundles/github-pr-monitor.bundle.json
@@ -1,5 +1,31 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
+  "entrypoint": "workflows/github-pr-monitor.harn",
+  "transitive_modules": [
+    {
+      "path": "workflows/github-pr-monitor.harn",
+      "source_hash_blake3": "blake3:1111111111111111111111111111111111111111111111111111111111111111",
+      "harnbc_hash_blake3": "blake3:2222222222222222222222222222222222222222222222222222222222222222"
+    }
+  ],
+  "stdlib_version": "0.8.24",
+  "harn_version": "0.8.24",
+  "provider_catalog_hash": "blake3:3333333333333333333333333333333333333333333333333333333333333333",
+  "tool_manifest": [],
+  "sbom": {
+    "format": "spdx-lite",
+    "version": "2.3",
+    "packages": [
+      {
+        "name": "harn-stdlib",
+        "version": "0.8.24",
+        "package_hash_blake3": "blake3:4444444444444444444444444444444444444444444444444444444444444444"
+      }
+    ],
+    "relationships": []
+  },
+  "signature": null,
+  "parent_trust_record_id": null,
   "id": "github-pr-monitor",
   "name": "GitHub PR monitor",
   "version": "1.0.0",

--- a/docs/fixtures/workflow-bundles/quickstart-agentic.bundle.json
+++ b/docs/fixtures/workflow-bundles/quickstart-agentic.bundle.json
@@ -1,5 +1,37 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
+  "entrypoint": "workflows/quickstart-agentic.harn",
+  "transitive_modules": [
+    {
+      "path": "workflows/quickstart-agentic.harn",
+      "source_hash_blake3": "blake3:7777777777777777777777777777777777777777777777777777777777777777",
+      "harnbc_hash_blake3": "blake3:8888888888888888888888888888888888888888888888888888888888888888"
+    }
+  ],
+  "stdlib_version": "0.8.24",
+  "harn_version": "0.8.24",
+  "provider_catalog_hash": "blake3:3333333333333333333333333333333333333333333333333333333333333333",
+  "tool_manifest": [
+    {
+      "name": "github.post_comment",
+      "provider": "github",
+      "schema_hash_blake3": "blake3:9999999999999999999999999999999999999999999999999999999999999999"
+    }
+  ],
+  "sbom": {
+    "format": "spdx-lite",
+    "version": "2.3",
+    "packages": [
+      {
+        "name": "harn-stdlib",
+        "version": "0.8.24",
+        "package_hash_blake3": "blake3:4444444444444444444444444444444444444444444444444444444444444444"
+      }
+    ],
+    "relationships": []
+  },
+  "signature": null,
+  "parent_trust_record_id": null,
   "id": "quickstart-agentic",
   "name": "Quickstart agentic review",
   "version": "1.0.0",

--- a/docs/fixtures/workflow-bundles/quickstart-minimal.bundle.json
+++ b/docs/fixtures/workflow-bundles/quickstart-minimal.bundle.json
@@ -1,5 +1,31 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
+  "entrypoint": "workflows/quickstart-minimal.harn",
+  "transitive_modules": [
+    {
+      "path": "workflows/quickstart-minimal.harn",
+      "source_hash_blake3": "blake3:5555555555555555555555555555555555555555555555555555555555555555",
+      "harnbc_hash_blake3": "blake3:6666666666666666666666666666666666666666666666666666666666666666"
+    }
+  ],
+  "stdlib_version": "0.8.24",
+  "harn_version": "0.8.24",
+  "provider_catalog_hash": "blake3:3333333333333333333333333333333333333333333333333333333333333333",
+  "tool_manifest": [],
+  "sbom": {
+    "format": "spdx-lite",
+    "version": "2.3",
+    "packages": [
+      {
+        "name": "harn-stdlib",
+        "version": "0.8.24",
+        "package_hash_blake3": "blake3:4444444444444444444444444444444444444444444444444444444444444444"
+      }
+    ],
+    "relationships": []
+  },
+  "signature": null,
+  "parent_trust_record_id": null,
   "id": "quickstart-minimal",
   "name": "Quickstart minimal",
   "version": "1.0.0",

--- a/docs/src/workflow-authoring-quickstart.md
+++ b/docs/src/workflow-authoring-quickstart.md
@@ -28,8 +28,9 @@ Copy them to your workspace and edit in place.
 
 ## 1. Validate a minimal deterministic bundle
 
-A workflow bundle is JSON. The smallest viable bundle has a
-`schema_version`, identity fields, one trigger, and one node.
+A workflow bundle is JSON while authoring. The smallest viable schema v2
+bundle has canonical package metadata, identity fields, one trigger, and one
+node.
 
 ```bash
 harn workflow validate \

--- a/docs/src/workflow-bundles.md
+++ b/docs/src/workflow-bundles.md
@@ -5,7 +5,9 @@ automations. It is designed to run on a trusted laptop under Burin/Harn and to
 remain importable into Harn Cloud later without changing the workflow's durable
 identity, graph, policy, or replay metadata.
 
-The canonical on-disk format is JSON. The current schema version is `1`.
+The canonical package format is `.harnpack`: a deterministic `tar.zst` archive
+with `harnpack.json` at the archive root. The manifest can also be read as
+plain JSON during authoring. The current schema version is `2`.
 
 For an end-to-end walkthrough that authors a bundle, validates it,
 previews the graph, and runs a deterministic local receipt — all
@@ -25,7 +27,15 @@ Top-level bundle fields:
 
 | Field | Purpose |
 |---|---|
-| `schema_version` | Bundle schema version. Must be `1`. |
+| `schema_version` | Bundle schema version. Must be `2`. |
+| `entrypoint` | Relative path to the entry Harn module inside the package. |
+| `transitive_modules` | Sorted module manifest entries with source and bytecode BLAKE3 hashes. |
+| `stdlib_version` / `harn_version` | Runtime and standard library versions used to build the package. |
+| `provider_catalog_hash` | BLAKE3 hash of the provider catalog used at build time. |
+| `tool_manifest` | Tool names, providers, optional annotations, and schema hashes captured for review. |
+| `sbom` | SBOM document for package dependencies. |
+| `signature` | Optional Ed25519 signature slot; signing is filled by the signing workflow. |
+| `parent_trust_record_id` | Optional link into a parent OpenTrustGraph chain. |
 | `id` / `version` | Stable bundle identity for hosts and importers. |
 | `triggers` | Declarations for GitHub, cron, delay, manual, webhook, or MCP wakeups. |
 | `workflow` | A normalized Harn `WorkflowGraph` with stable node ids. |
@@ -46,11 +56,16 @@ Trigger kinds:
 | `webhook` | `webhook_path`. |
 | `mcp` | `mcp_tool`. |
 
-`harn workflow validate` checks schema version, stable workflow/node ids,
-workflow graph validity, trigger references, prompt capsule references, policy
-values, connector identity, and environment worktree policy. The validation
-report includes a stable `graph_digest` over canonical graph JSON so receipts
-and replay runs can pin the exact workflow graph.
+`harn workflow validate` checks schema version, manifest metadata, relative
+package paths, BLAKE3 hash syntax, stable workflow/node ids, workflow graph
+validity, trigger references, prompt capsule references, policy values,
+connector identity, and environment worktree policy. The validation report
+includes a stable `graph_digest` over canonical graph JSON so receipts and
+replay runs can pin the exact workflow graph.
+
+Bundle identity for `.harnpack` archives is BLAKE3 over the canonical manifest
+bytes plus the sorted content hashes. Re-packing the same manifest and content
+produces the same bundle hash.
 
 ## Preview
 

--- a/examples/skill-packs/workflow-authoring/SKILL.md
+++ b/examples/skill-packs/workflow-authoring/SKILL.md
@@ -56,7 +56,27 @@ truth.
 
 ```json
 {
-  "schema_version": 1,
+  "schema_version": 2,
+  "entrypoint": "workflows/<kebab-case-id>.harn",
+  "transitive_modules": [
+    {
+      "path": "workflows/<kebab-case-id>.harn",
+      "source_hash_blake3": "blake3:<64 lowercase hex digits>",
+      "harnbc_hash_blake3": "blake3:<64 lowercase hex digits>"
+    }
+  ],
+  "stdlib_version": "<harn stdlib version>",
+  "harn_version": "<harn version>",
+  "provider_catalog_hash": "blake3:<64 lowercase hex digits>",
+  "tool_manifest": [],
+  "sbom": {
+    "format": "spdx-lite",
+    "version": "2.3",
+    "packages": [],
+    "relationships": []
+  },
+  "signature": null,
+  "parent_trust_record_id": null,
   "id": "<kebab-case-id>",
   "name": "<human label>",
   "version": "1.0.0",
@@ -101,7 +121,11 @@ truth.
 
 ## Hard rules (validator enforces)
 
-- `schema_version` must be `1`.
+- `schema_version` must be `2`.
+- `entrypoint`, `transitive_modules`, `stdlib_version`, `harn_version`,
+  `provider_catalog_hash`, `tool_manifest`, `sbom`, `signature`, and
+  `parent_trust_record_id` are part of the canonical `.harnpack` manifest.
+- BLAKE3 fields use `blake3:<64 lowercase hex digits>`.
 - `id`, `version`, `workflow.id`, `workflow.entry` are non-empty.
 - Every `workflow.nodes[k].id` matches its map key `k`.
 - Every edge endpoint and `trigger.node_id` references an existing node.

--- a/examples/skill-packs/workflow-authoring/cases/pr-monitor.case.json
+++ b/examples/skill-packs/workflow-authoring/cases/pr-monitor.case.json
@@ -1,7 +1,7 @@
 {
   "id": "pr-monitor",
   "title": "Author a PR monitor workflow bundle",
-  "system_prompt": "You are authoring a portable Harn workflow bundle. Read the rules in examples/skill-packs/workflow-authoring/prompting.md. Return three blocks in order: <bundle>...</bundle> with valid WorkflowBundle JSON (schema_version: 1), <rationale>...</rationale> with up to 5 bullets, and <verify>...</verify> with the validate/preview/run commands.",
+  "system_prompt": "You are authoring a portable Harn workflow bundle. Read the rules in examples/skill-packs/workflow-authoring/prompting.md. Return three blocks in order: <bundle>...</bundle> with valid WorkflowBundle JSON (schema_version: 2), <rationale>...</rationale> with up to 5 bullets, and <verify>...</verify> with the validate/preview/run commands.",
   "user_prompt": "Create a workflow bundle for monitoring a GitHub pull request:\n- Trigger on pull_request.opened and pull_request.synchronize.\n- After a 10 minute delay, query deploy logs and summarize failures.\n- Notify the requester at the end.\n- Use act_with_approval autonomy and exponential retry.\n- Require the github connector with pull_requests:read and checks:read.\n- Identify the bundle as id=\"pr-monitor\", workflow id \"pr_monitor_workflow\", entry node \"ingest\".",
   "structural_assertions": {
     "bundle_id": "pr-monitor",

--- a/examples/skill-packs/workflow-authoring/cases/pr-repair.case.json
+++ b/examples/skill-packs/workflow-authoring/cases/pr-repair.case.json
@@ -1,7 +1,7 @@
 {
   "id": "pr-repair",
   "title": "Author a PR repair workflow bundle",
-  "system_prompt": "You are authoring a portable Harn workflow bundle. Read the rules in examples/skill-packs/workflow-authoring/prompting.md. Return three blocks in order: <bundle>...</bundle> with valid WorkflowBundle JSON (schema_version: 1), <rationale>...</rationale> with up to 5 bullets, and <verify>...</verify> with the validate/preview/run commands.",
+  "system_prompt": "You are authoring a portable Harn workflow bundle. Read the rules in examples/skill-packs/workflow-authoring/prompting.md. Return three blocks in order: <bundle>...</bundle> with valid WorkflowBundle JSON (schema_version: 2), <rationale>...</rationale> with up to 5 bullets, and <verify>...</verify> with the validate/preview/run commands.",
   "user_prompt": "Create a workflow bundle for monitoring and repairing a feature pull request:\n- Trigger on github check_suite.completed and pull_request.synchronize, plus an hourly cron sweep.\n- Workflow: ingest -> open_worktree -> repo_setup -> repair_loop (agent stage) -> verify -> approval -> notify.\n- Add a prompt capsule for the repair_loop node.\n- Autonomy act_with_approval; require approval on repair_loop and verify; exponential retry up to 3 attempts; latest catchup.\n- Require the github connector with pull_requests:read, pull_requests:write, checks:read, contents:write.\n- Use a new worktree; gate make test and make lint.\n- Identify bundle id=\"pr-repair\", workflow id \"pr_repair_workflow\", entry node \"ingest\".",
   "structural_assertions": {
     "bundle_id": "pr-repair",

--- a/examples/skill-packs/workflow-authoring/prompting.md
+++ b/examples/skill-packs/workflow-authoring/prompting.md
@@ -35,35 +35,37 @@ are advisory; the validator never reads them.
 These rules collapse the validator's surface area into a checklist. Keep the
 list in front of the model when prompting.
 
-1. `schema_version` is the integer `1`.
-2. Every `id` field is non-empty kebab-case ASCII.
-3. `workflow._type` is `"workflow_graph"` (literal).
-4. `workflow.entry` references a key in `workflow.nodes`.
-5. Every key `k` in `workflow.nodes` matches `workflow.nodes[k].id`.
-6. Every `workflow.edges[].from` and `.to` references a node key.
-7. Every `triggers[].node_id` (when set) references a node key.
-8. Trigger kind ∈ `{github, cron, delay, webhook, mcp, manual}`.
-   - `github` requires `provider: "github"` and ≥ 1 `events`.
-   - `cron` requires `schedule` (5-field cron expression).
-   - `delay` requires `delay` as an ISO-8601 duration (`PT10M`, `PT1H`).
-   - `webhook` requires `webhook_path` (string starting with `/`).
-   - `mcp` requires `mcp_tool` (string).
-   - `manual` requires no extra fields.
-9. `policy.autonomy_tier` ∈ `{shadow, suggest, act_with_approval, act_auto}`.
-10. `policy.retry.max_attempts` ≥ 1; `backoff` is one of
+1. `schema_version` is the integer `2`.
+2. `entrypoint`, `transitive_modules`, `stdlib_version`, `harn_version`,
+   `provider_catalog_hash`, `tool_manifest`, `sbom`, `signature`, and
+   `parent_trust_record_id` are present.
+3. BLAKE3 fields use `blake3:<64 lowercase hex digits>`.
+4. Every `id` field is non-empty kebab-case ASCII.
+5. `workflow._type` is `"workflow_graph"` (literal).
+6. `workflow.entry` references a key in `workflow.nodes`.
+7. Every key `k` in `workflow.nodes` matches `workflow.nodes[k].id`.
+8. Every `workflow.edges[].from` and `.to` references a node key.
+9. Every `triggers[].node_id` (when set) references a node key.
+10. Trigger kind ∈ `{github, cron, delay, webhook, mcp, manual}`.
+    `github` requires `provider: "github"` and ≥ 1 `events`; `cron`
+    requires `schedule` (5-field cron expression); `delay` requires an
+    ISO-8601 duration such as `PT10M`; `webhook` requires `webhook_path`;
+    `mcp` requires `mcp_tool`; `manual` requires no extra fields.
+11. `policy.autonomy_tier` ∈ `{shadow, suggest, act_with_approval, act_auto}`.
+12. `policy.retry.max_attempts` ≥ 1; `backoff` is one of
     `{none, fixed, exponential}`.
-11. `policy.catchup.mode` ∈ `{none, latest, all}`.
-12. `environment.worktree_policy` ∈ `{reuse_current, new_worktree, host_managed}`.
-13. Every `prompt_capsules[k].id == k` and points at a real node.
+13. `policy.catchup.mode` ∈ `{none, latest, all}`.
+14. `environment.worktree_policy` ∈ `{reuse_current, new_worktree, host_managed}`.
+15. Every `prompt_capsules[k].id == k` and points at a real node.
     At most one capsule per node.
-14. Every connector that a trigger references via `provider` appears in
+16. Every connector that a trigger references via `provider` appears in
     `connectors[]` (otherwise the validator emits a warning).
-15. Do not invent fields. Unknown top-level fields stay in `metadata`.
+17. Do not invent fields. Unknown top-level fields stay in `metadata`.
 
 ## Anti-patterns (small models fall into these)
 
 - **Inventing trigger kinds** (`pull_request`, `schedule`). Use exactly the
-  six kinds in rule 8.
+  six kinds in rule 10.
 - **String autonomy tiers in PascalCase / TitleCase.** They are snake_case.
 - **`max_attempts: 0`.** Always ≥ 1.
 - **Mixing capsule keys and ids** (`{ "review": { "id": "review-pr", ... } }`).
@@ -98,7 +100,7 @@ You are authoring a portable Harn workflow bundle. You MUST return
 examples/skill-packs/workflow-authoring/prompting.md.
 
 The <bundle> block contains a single JSON document conforming to
-WorkflowBundle (schema_version: 1). Validate against the rules in
+WorkflowBundle (schema_version: 2). Validate against the rules in
 that prompting guide. Use the recipes/ directory as concrete examples.
 ```
 

--- a/examples/skill-packs/workflow-authoring/recipes/pr-monitor/bundle.json
+++ b/examples/skill-packs/workflow-authoring/recipes/pr-monitor/bundle.json
@@ -1,5 +1,31 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
+  "entrypoint": "workflows/pr-monitor.harn",
+  "transitive_modules": [
+    {
+      "path": "workflows/pr-monitor.harn",
+      "source_hash_blake3": "blake3:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "harnbc_hash_blake3": "blake3:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    }
+  ],
+  "stdlib_version": "0.8.24",
+  "harn_version": "0.8.24",
+  "provider_catalog_hash": "blake3:3333333333333333333333333333333333333333333333333333333333333333",
+  "tool_manifest": [],
+  "sbom": {
+    "format": "spdx-lite",
+    "version": "2.3",
+    "packages": [
+      {
+        "name": "harn-stdlib",
+        "version": "0.8.24",
+        "package_hash_blake3": "blake3:4444444444444444444444444444444444444444444444444444444444444444"
+      }
+    ],
+    "relationships": []
+  },
+  "signature": null,
+  "parent_trust_record_id": null,
   "id": "pr-monitor",
   "name": "PR monitor",
   "version": "1.0.0",

--- a/examples/skill-packs/workflow-authoring/recipes/pr-repair/bundle.json
+++ b/examples/skill-packs/workflow-authoring/recipes/pr-repair/bundle.json
@@ -1,5 +1,36 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
+  "entrypoint": "workflows/pr-repair.harn",
+  "transitive_modules": [
+    {
+      "path": "workflows/pr-repair.harn",
+      "source_hash_blake3": "blake3:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "harnbc_hash_blake3": "blake3:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+    }
+  ],
+  "stdlib_version": "0.8.24",
+  "harn_version": "0.8.24",
+  "provider_catalog_hash": "blake3:3333333333333333333333333333333333333333333333333333333333333333",
+  "tool_manifest": [
+    {
+      "name": "exec",
+      "schema_hash_blake3": "blake3:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+    }
+  ],
+  "sbom": {
+    "format": "spdx-lite",
+    "version": "2.3",
+    "packages": [
+      {
+        "name": "harn-stdlib",
+        "version": "0.8.24",
+        "package_hash_blake3": "blake3:4444444444444444444444444444444444444444444444444444444444444444"
+      }
+    ],
+    "relationships": []
+  },
+  "signature": null,
+  "parent_trust_record_id": null,
   "id": "pr-repair",
   "name": "PR repair",
   "version": "1.0.0",


### PR DESCRIPTION
## Summary

- bump WorkflowBundle to schema v2 with canonical `.harnpack` manifest metadata
- add typed schema-version parsing errors plus deterministic tar.zst build/read helpers
- add BLAKE3 bundle hashing over canonical manifest bytes plus sorted content hashes
- update workflow bundle fixtures, docs, authoring skill examples, and changelog

Closes #1780

## Validation

- cargo test -p harn-vm workflow_bundle
- cargo test -p harn-cli --test workflow_cli --test workflow_patch_cli
- cargo clippy -p harn-vm --all-targets -- -D warnings
- make lint-test-patterns
- pre-commit hook: cargo clippy --workspace --all-targets -- -D warnings, markdownlint
- pre-push hook: targeted cargo check, markdownlint, changelog guard
