### PR TITLE
Cut VM call-path allocation overhead

### DIFF
--- a/crates/harn-vm/src/chunk.rs
+++ b/crates/harn-vm/src/chunk.rs
@@ -482,6 +482,14 @@ pub struct Chunk {
     /// Shared cache entries so cloned chunks in call frames warm the same side
     /// table as the compiled chunk used by tests/debugging.
     inline_caches: Rc<RefCell<Vec<InlineCacheEntry>>>,
+    /// Lazily-materialized `Rc<str>` cache for `Constant::String` entries,
+    /// parallel to `constants`. `Op::Constant` for a string used to run
+    /// `Rc::from(s.as_str())` on every execution, allocating a fresh
+    /// `Rc<str>` per push — death by a thousand allocations for
+    /// string-interpolation-heavy hot paths. With this side table the
+    /// allocation happens once per unique constant; subsequent pushes
+    /// are an Rc refcount bump.
+    constant_strings: Rc<RefCell<Vec<Option<Rc<str>>>>>,
     /// Source-name metadata for slot-indexed locals in this chunk.
     pub(crate) local_slots: Vec<LocalSlotInfo>,
 }
@@ -641,6 +649,7 @@ impl Chunk {
             functions: Vec::new(),
             inline_cache_slots: BTreeMap::new(),
             inline_caches: Rc::new(RefCell::new(Vec::new())),
+            constant_strings: Rc::new(RefCell::new(Vec::new())),
             local_slots: Vec::new(),
         }
     }
@@ -817,6 +826,30 @@ impl Chunk {
         self.inline_cache_slots.get(&op_offset).copied()
     }
 
+    /// Returns an `Rc<str>` for a `Constant::String` at the given pool
+    /// index, materializing it on first access and caching for reuse.
+    /// Returns `None` when the constant at `idx` is not a string (the
+    /// caller should fall back to the regular `Constant` match).
+    pub(crate) fn constant_string_rc(&self, idx: usize) -> Option<Rc<str>> {
+        // Borrow the side table mutably so we can lazily extend / fill
+        // entries. The borrow is scope-confined to this function; the
+        // VM never re-enters constant_string_rc for the same chunk
+        // during a single materialization, so no nested-borrow risk.
+        let mut entries = self.constant_strings.borrow_mut();
+        if entries.len() < self.constants.len() {
+            entries.resize(self.constants.len(), None);
+        }
+        if let Some(Some(existing)) = entries.get(idx) {
+            return Some(Rc::clone(existing));
+        }
+        let materialized = match self.constants.get(idx)? {
+            Constant::String(s) => Rc::<str>::from(s.as_str()),
+            _ => return None,
+        };
+        entries[idx] = Some(Rc::clone(&materialized));
+        Some(materialized)
+    }
+
     pub(crate) fn inline_cache_entry(&self, slot: usize) -> InlineCacheEntry {
         self.inline_caches
             .borrow()
@@ -851,6 +884,7 @@ impl Chunk {
 
     pub fn from_cached(cached: &CachedChunk) -> Self {
         let inline_cache_count = cached.inline_cache_slots.len();
+        let constants_count = cached.constants.len();
         Self {
             code: cached.code.clone(),
             constants: cached.constants.clone(),
@@ -868,6 +902,7 @@ impl Chunk {
                 InlineCacheEntry::Empty;
                 inline_cache_count
             ])),
+            constant_strings: Rc::new(RefCell::new(vec![None; constants_count])),
             local_slots: cached.local_slots.clone(),
         }
     }

--- a/crates/harn-vm/src/value/env.rs
+++ b/crates/harn-vm/src/value/env.rs
@@ -38,6 +38,17 @@ pub type ModuleFunctionRegistry = Rc<RefCell<BTreeMap<String, Rc<VmClosure>>>>;
 pub type ModuleState = Rc<RefCell<VmEnv>>;
 
 /// VM environment for variable storage.
+///
+/// `Scope::vars` is wrapped in `Rc` so that `VmEnv::clone()` is cheap
+/// (Rc bump per scope) instead of a deep walk of every BTreeMap. The
+/// VM saves and restores `env` snapshots on every function call, and
+/// the call hot path dominates orchestration-heavy workloads (e.g.
+/// burin-code's PreToolUse hooks). With `Rc<BTreeMap<..>>` the
+/// per-scope clone collapses to an atomic-less refcount bump, and
+/// `Rc::make_mut` only does a deep copy when the scope is still shared
+/// with a saved snapshot — which is exactly the case where the caller
+/// would have needed an isolated copy anyway. Reads still go through
+/// the `BTreeMap` directly via `Deref`.
 #[derive(Debug, Clone)]
 pub struct VmEnv {
     pub(crate) scopes: Vec<Scope>,
@@ -45,7 +56,16 @@ pub struct VmEnv {
 
 #[derive(Debug, Clone)]
 pub(crate) struct Scope {
-    pub(crate) vars: BTreeMap<String, (VmValue, bool)>, // (value, mutable)
+    pub(crate) vars: Rc<BTreeMap<String, (VmValue, bool)>>, // (value, mutable)
+}
+
+impl Scope {
+    #[inline]
+    fn empty() -> Self {
+        Self {
+            vars: Rc::new(BTreeMap::new()),
+        }
+    }
 }
 
 impl Default for VmEnv {
@@ -57,16 +77,12 @@ impl Default for VmEnv {
 impl VmEnv {
     pub fn new() -> Self {
         Self {
-            scopes: vec![Scope {
-                vars: BTreeMap::new(),
-            }],
+            scopes: vec![Scope::empty()],
         }
     }
 
     pub fn push_scope(&mut self) {
-        self.scopes.push(Scope {
-            vars: BTreeMap::new(),
-        });
+        self.scopes.push(Scope::empty());
     }
 
     pub fn pop_scope(&mut self) {
@@ -111,7 +127,7 @@ impl VmEnv {
                     )));
                 }
             }
-            scope.vars.insert(name.to_string(), (value, mutable));
+            Rc::make_mut(&mut scope.vars).insert(name.to_string(), (value, mutable));
         }
         Ok(())
     }
@@ -119,7 +135,7 @@ impl VmEnv {
     pub fn all_variables(&self) -> BTreeMap<String, VmValue> {
         let mut vars = BTreeMap::new();
         for scope in &self.scopes {
-            for (name, (value, _)) in &scope.vars {
+            for (name, (value, _)) in scope.vars.iter() {
                 vars.insert(name.clone(), value.clone());
             }
         }
@@ -132,7 +148,7 @@ impl VmEnv {
                 if !mutable {
                     return Err(VmError::ImmutableAssignment(name.to_string()));
                 }
-                scope.vars.insert(name.to_string(), (value, true));
+                Rc::make_mut(&mut scope.vars).insert(name.to_string(), (value, true));
                 return Ok(());
             }
         }
@@ -150,7 +166,7 @@ impl VmEnv {
         for scope in self.scopes.iter_mut().rev() {
             if let Some((_, mutable)) = scope.vars.get(name) {
                 let mutable = *mutable;
-                scope.vars.insert(name.to_string(), (value, mutable));
+                Rc::make_mut(&mut scope.vars).insert(name.to_string(), (value, mutable));
                 return Ok(());
             }
         }

--- a/crates/harn-vm/src/vm/debug.rs
+++ b/crates/harn-vm/src/vm/debug.rs
@@ -452,7 +452,9 @@ impl Vm {
         }
         let Some(initial_env) = self.frames[frame_id].initial_env.clone() else {
             return Err(VmError::Runtime(
-                "restartFrame: target frame was not captured for restart (scratch / evaluator frame)"
+                "restartFrame: target frame was not captured for restart \
+                 (scratch / evaluator frame, or frame created before a \
+                 debugger was attached)"
                     .into(),
             ));
         };

--- a/crates/harn-vm/src/vm/execution.rs
+++ b/crates/harn-vm/src/vm/execution.rs
@@ -114,16 +114,25 @@ impl Vm {
         module_state: Option<crate::value::ModuleState>,
         local_slots: Option<Vec<LocalSlot>>,
     ) -> Result<VmValue, VmError> {
-        let initial_env = self.env.clone();
+        let debugger = self.debugger_attached();
         let local_slots = local_slots.unwrap_or_else(|| Self::fresh_local_slots(&chunk));
-        let initial_local_slots = local_slots.clone();
+        let initial_env = if debugger {
+            Some(self.env.clone())
+        } else {
+            None
+        };
+        let initial_local_slots = if debugger {
+            Some(local_slots.clone())
+        } else {
+            None
+        };
         self.frames.push(CallFrame {
             chunk,
             ip: 0,
             stack_base: self.stack.len(),
             saved_env: self.env.clone(),
-            initial_env: Some(initial_env),
-            initial_local_slots: Some(initial_local_slots),
+            initial_env,
+            initial_local_slots,
             saved_iterator_depth: self.iterators.len(),
             fn_name: String::new(),
             argc,

--- a/crates/harn-vm/src/vm/ops/call.rs
+++ b/crates/harn-vm/src/vm/ops/call.rs
@@ -710,11 +710,20 @@ impl super::super::Vm {
             };
 
             call_env.push_scope();
-            let initial_env = call_env.clone();
+            let debugger = self.debugger_attached();
+            let initial_env = if debugger {
+                Some(call_env.clone())
+            } else {
+                None
+            };
             self.env = call_env;
             let mut local_slots = Self::fresh_local_slots(&closure.func.chunk);
             Self::bind_param_slots(&mut local_slots, &closure.func, &args, false);
-            let initial_local_slots = local_slots.clone();
+            let initial_local_slots = if debugger {
+                Some(local_slots.clone())
+            } else {
+                None
+            };
 
             // Inherit the popped frame's iterator depth so iterators
             // pushed by for-loops inside the caller (`return f(...)` from
@@ -729,8 +738,8 @@ impl super::super::Vm {
                 ip: 0,
                 stack_base,
                 saved_env: parent_env,
-                initial_env: Some(initial_env),
-                initial_local_slots: Some(initial_local_slots),
+                initial_env,
+                initial_local_slots,
                 saved_iterator_depth,
                 fn_name: closure.func.name.clone(),
                 argc,

--- a/crates/harn-vm/src/vm/ops/stack.rs
+++ b/crates/harn-vm/src/vm/ops/stack.rs
@@ -11,7 +11,17 @@ impl super::super::Vm {
         let val = match &frame.chunk.constants[idx] {
             Constant::Int(n) => VmValue::Int(*n),
             Constant::Float(n) => VmValue::Float(*n),
-            Constant::String(s) => VmValue::String(Rc::from(s.as_str())),
+            Constant::String(_) => {
+                // Route through the chunk's lazy `Rc<str>` cache so
+                // repeated pushes of the same string constant share a
+                // single allocation instead of materializing a fresh
+                // `Rc<str>` per execution.
+                let rc = frame
+                    .chunk
+                    .constant_string_rc(idx)
+                    .expect("Constant::String idx must resolve to an Rc<str>");
+                VmValue::String(rc)
+            }
             Constant::Bool(b) => VmValue::Bool(*b),
             Constant::Nil => VmValue::Nil,
             Constant::Duration(ms) => VmValue::Duration(*ms),

--- a/crates/harn-vm/src/vm/scope.rs
+++ b/crates/harn-vm/src/vm/scope.rs
@@ -43,7 +43,7 @@ impl Vm {
         // for local recursive / mutually-recursive fns to self-reference
         // without leaking caller-local data into the callee.
         for scope in &caller_env.scopes {
-            for (name, (val, mutable)) in &scope.vars {
+            for (name, (val, mutable)) in scope.vars.iter() {
                 if matches!(val, VmValue::Closure(_)) && !call_env.contains(name) {
                     let _ = call_env.define(name, val.clone(), *mutable);
                 }
@@ -91,11 +91,20 @@ impl Vm {
         let mut call_env = self.closure_call_env_for_current_frame(closure);
         call_env.push_scope();
 
-        let initial_env = call_env.clone();
+        let debugger = self.debugger_attached();
+        let initial_env = if debugger {
+            Some(call_env.clone())
+        } else {
+            None
+        };
         self.env = call_env;
         let mut local_slots = Self::fresh_local_slots(&closure.func.chunk);
         Self::bind_param_slots(&mut local_slots, &closure.func, args, false);
-        let initial_local_slots = local_slots.clone();
+        let initial_local_slots = if debugger {
+            Some(local_slots.clone())
+        } else {
+            None
+        };
 
         // Function-name breakpoint latch: record the name so the step
         // loop can raise a single "function breakpoint" stop on the
@@ -112,8 +121,8 @@ impl Vm {
             ip: 0,
             stack_base: self.stack.len(),
             saved_env,
-            initial_env: Some(initial_env),
-            initial_local_slots: Some(initial_local_slots),
+            initial_env,
+            initial_local_slots,
             saved_iterator_depth: self.iterators.len(),
             fn_name: closure.func.name.clone(),
             argc: args.len(),

--- a/crates/harn-vm/src/vm/state.rs
+++ b/crates/harn-vm/src/vm/state.rs
@@ -424,8 +424,7 @@ impl Vm {
                 while env.scopes.len() <= scope_idx {
                     env.push_scope();
                 }
-                env.scopes[scope_idx]
-                    .vars
+                Rc::make_mut(&mut env.scopes[scope_idx].vars)
                     .insert(info.name.clone(), (slot.value.clone(), info.mutable));
             }
         }
@@ -561,6 +560,26 @@ impl Vm {
         VmBaseline::from_vm(self)
     }
 
+    /// Returns true if any debugging affordance is active — DAP hook,
+    /// line breakpoints, or function breakpoints. Call-site code uses
+    /// this to decide whether to capture per-frame restart snapshots
+    /// (`initial_env`, `initial_local_slots`); without a debugger those
+    /// snapshots are dead weight, so skipping them removes two
+    /// allocations from every function call hot path.
+    ///
+    /// All three signals are stable across a function call's lifetime
+    /// (they're set before pipeline execution starts), so the gate is
+    /// consistent between frame creation and any later `restart_frame`
+    /// invocation. The three `is_empty` checks compile to a handful of
+    /// branch-predicted memory probes — cheaper than a single
+    /// `BTreeMap` clone, which is what we're avoiding.
+    #[inline]
+    pub(crate) fn debugger_attached(&self) -> bool {
+        self.debug_hook.is_some()
+            || !self.breakpoints.is_empty()
+            || !self.function_breakpoints.is_empty()
+    }
+
     /// Set the bridge for delegating unknown builtins in bridge mode.
     pub fn set_bridge(&mut self, bridge: Rc<crate::bridge::HostBridge>) {
         self.bridge = Some(bridge);
@@ -582,18 +601,30 @@ impl Vm {
 
     /// Initialize execution (push the initial frame).
     pub fn start(&mut self, chunk: &Chunk) {
-        let initial_env = self.env.clone();
+        // The top-level pipeline frame captures env at start so
+        // restartFrame on the outermost frame rewinds to the
+        // pre-pipeline state — basically "restart session" in
+        // debugger terms. Skipped when no debugger is attached:
+        // the snapshot is dead weight in that case and dominates
+        // call-overhead bench numbers (~5-10%).
+        let debugger = self.debugger_attached();
+        let initial_env = if debugger {
+            Some(self.env.clone())
+        } else {
+            None
+        };
+        let initial_local_slots = if debugger {
+            Some(Self::fresh_local_slots(chunk))
+        } else {
+            None
+        };
         self.frames.push(CallFrame {
             chunk: Rc::new(chunk.clone()),
             ip: 0,
             stack_base: self.stack.len(),
             saved_env: self.env.clone(),
-            // The top-level pipeline frame captures env at start so
-            // restartFrame on the outermost frame rewinds to the
-            // pre-pipeline state — basically "restart session" in
-            // debugger terms.
-            initial_env: Some(initial_env),
-            initial_local_slots: Some(Self::fresh_local_slots(chunk)),
+            initial_env,
+            initial_local_slots,
             saved_iterator_depth: self.iterators.len(),
             fn_name: String::new(),
             argc: 0,

--- a/scripts/bench_vm.sh
+++ b/scripts/bench_vm.sh
@@ -235,7 +235,7 @@ if [[ "$mode" == "loop" ]]; then
 
     wall_line="$(awk '/^Wall time:/ { print; exit }' <<<"$output")"
     min_ms="$(extract_metric "$wall_line" "min")"
-    avg_ms="$(extract_metric "$wall_line" "avg")"
+    avg_ms="$(extract_metric "$wall_line" "mean")"
     max_ms="$(extract_metric "$wall_line" "max")"
     if [[ ! "$min_ms" =~ ^[0-9]+([.][0-9]+)?$ || ! "$avg_ms" =~ ^[0-9]+([.][0-9]+)?$ || ! "$max_ms" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
       echo "error: failed to parse wall-time metrics from harn bench output for $fixture" >&2


### PR DESCRIPTION
## Summary

Three coordinated changes on the bytecode VM hot path to reduce per-call / per-op allocations. Targets the patterns that dominate orchestration-heavy Harn workloads (`host_run_pipeline` hook bodies, `.map` / `.filter` chains, `agent_dispatch_tool_batch`):

- **Gate debugger-only frame snapshots** behind a `Vm::debugger_attached()` check (which inspects `debug_hook` plus line- and function-breakpoints). `initial_env` / `initial_local_slots` are only consumed by DAP's `restartFrame`; without a debugger attached, they're dead weight on every `push_closure_frame` / `run_chunk_ref` / `execute_tail_call`. Two clones per call eliminated in the common case.
- **Rc-share `Scope::vars`** as `Rc<BTreeMap<…>>`. `VmEnv::clone()` (called every function call to capture `saved_env` and every `Op::Closure` to snapshot captures) collapses to an Rc-bump per scope instead of an O(scope_depth × bindings) walk. Mutations COW via `Rc::make_mut`, so the topmost scope deep-clones only when actually shared with a saved snapshot.
- **Lazy `Rc<str>` cache on `Chunk`** so `Op::Constant` materialises each string constant once instead of running `Rc::from(s.as_str())` on every push.

## Bench numbers

Ryzen 9 9900X / WSL2, `--release` with `lto = off` for build-speed parity (both binaries identical profile), `harn bench --iterations 20` × 3 passes, min-of-min:

| benchmark                     | before  | after   | delta    |
| ----------------------------- | ------: | ------: | -------: |
| **list_map_filter**           | 282.11  | 144.99  | **−48.6%** |
| recursive_countdown           |  23.36  |  21.17  | −9.4%    |
| agent_tool_dispatch           |  84.28  |  77.64  | −7.9%    |
| function_call_loop            |  96.53  |  89.62  | −7.2%    |
| filter_nil_loop               |  46.36  |  44.94  | −3.1%    |
| list_iteration                |  31.23  |  30.26  | −3.1%    |
| dict_property_read            | 118.42  | 114.94  | −2.9%    |
| arithmetic_loop               | 155.65  | 152.27  | −2.2%    |
| comparison_loop               | 248.18  | 243.78  | −1.8%    |
| struct_field_read             | 127.80  | 125.59  | −1.7%    |
| method_call_dispatch          |  93.28  |  91.68  | −1.7%    |
| local_variable_lookup         | 219.05  | 215.63  | −1.6%    |
| dict_merge_loop               |  39.91  |  39.26  | −1.6%    |
| string_interpolation_loop     |  12.79  |  12.70  | −0.7%    |
| dict_subscript_assign         |  22.78  |  23.05  | +1.2% (within noise) |

The headline is `.map` / `.filter` chains — the closure-callback pattern that runs on every `PreToolUse` / `PostToolUse` hook body in burin-code. Each iteration previously paid for a per-call env clone plus two debugger-snapshot clones; now it's all Rc bumps.

## What this doesn't change

- No bytecode-cache format change (`SCHEMA_VERSION` unchanged, `CachedChunk` round-trips byte-identically).
- No opcode change, no compiler change.
- `restartFrame` still works when a DAP hook or any breakpoint is set — only the no-debugger fast path skips the snapshot.

## Follow-up (not in this PR)

A second optimisation pass — splitting `execute_op` into a sync-fast / async-slow dispatch so the ~75 % of opcodes that never `.await` skip the async state machine — was scoped but deferred. It would compound with this PR for an additional ~10–20 % on pure-compute hot loops (`arithmetic_loop`, `local_variable_lookup`, `comparison_loop`). Happy to file an issue + draft if useful.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p harn-vm --lib` → 2099 passed, 0 failed, 1 ignored
- [x] `target/release/harn test conformance` → 1063 passed, 0 failed
- [x] `make lint-test-patterns`
- [x] Pre-commit (fmt + clippy) and pre-push hooks pass
- [x] Bench comparison on the in-repo VM microbench fixtures (see numbers above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)