### PR TITLE
Extend `harn explain` to accept HARN-<CAT>-<NNN> codes (#1748)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ condensed series summaries instead of full per-patch history.
 
 ### Added
 
+- **`harn explain HARN-<CAT>-<NNN>` text + `--json` envelope (#1748).** The
+  `explain` subcommand now dispatches on registered stable diagnostic codes
+  in addition to its original control-flow invariant form. `harn explain
+  HARN-TYP-014` prints an embedded markdown explanation plus a curated
+  `See also:` list; `harn explain HARN-TYP-014 --json` emits a stable
+  envelope `{ schemaVersion, code, category, summary, body, repairs,
+  related, apiStability }` that LSPs, IDEs, hosted error-page mirrors,
+  and agents can dispatch on without parsing prose. Every entry in the
+  diagnostic-code registry (#1746) carries an explanation markdown body
+  under `crates/harn-parser/src/diagnostic_codes/explanations/HARN-<CAT>-
+  <NNN>.md`, embedded via `include_str!` so a missing file fails the
+  build — the CI gate required by the epic. The legacy
+  `harn explain --invariant <NAME> <FUNCTION> <FILE>` form continues to
+  work; both forms share one dispatcher.
 - **`with_scoped_executor` tool-caller middleware (#1702).** Narrows the
   active `CapabilityPolicy` for the duration of one tool dispatch:
   `compose_tool_callers([..., with_scoped_executor({stage, allowed_tools,

--- a/crates/harn-cli/src/cli/explain.rs
+++ b/crates/harn-cli/src/cli/explain.rs
@@ -1,12 +1,34 @@
 use clap::Args;
 
+/// Arguments for `harn explain`.
+///
+/// `harn explain` dispatches on two forms through a single subcommand:
+///
+/// 1. **Code form (default).** A registered diagnostic identifier (e.g.
+///    `harn explain HARN-TYP-014`) prints the embedded explanation. Pair
+///    with `--json` to get the structured envelope an agent or editor can
+///    ingest without parsing prose.
+///
+/// 2. **Legacy invariant form.** When `--invariant <NAME>` is passed (e.g.
+///    `harn explain --invariant fs.writes handler path/to/script.harn`)
+///    the positional argument is treated as the handler / function /
+///    tool / pipeline name and the second positional is the source file,
+///    matching the original `harn explain` behaviour for control-flow
+///    invariants.
 #[derive(Debug, Args)]
 pub(crate) struct ExplainArgs {
-    /// The invariant name to explain, e.g. `fs.writes`.
+    /// A Harn diagnostic code (e.g. `HARN-TYP-014`) — or, with
+    /// `--invariant`, the handler / function / tool / pipeline name to
+    /// inspect.
+    pub target: String,
+    /// Path to the `.harn` source file (legacy `--invariant` form only).
+    pub file: Option<String>,
+    /// Explain the control-flow path that violates a Harn invariant
+    /// (e.g. `fs.writes`, `approval.reachability`).
     #[arg(long = "invariant", value_name = "NAME")]
-    pub invariant: String,
-    /// The handler / function / tool / pipeline name to inspect.
-    pub function: String,
-    /// Path to the `.harn` source file.
-    pub file: String,
+    pub invariant: Option<String>,
+    /// Emit a structured JSON envelope instead of human-readable text.
+    /// Only meaningful in code form.
+    #[arg(long = "json", default_value_t = false)]
+    pub json: bool,
 }

--- a/crates/harn-cli/src/cli/mod.rs
+++ b/crates/harn-cli/src/cli/mod.rs
@@ -265,9 +265,10 @@ SCRIPTING
     Check(CheckArgs),
     /// Inspect, validate, and emit schemas for layered Harn runtime config.
     Config(ConfigArgs),
-    /// Explain the control-flow path that violates a Harn invariant
-    /// (e.g. `fs.writes`, `approval.reachability`) for a specific
-    /// function or trigger handler.
+    /// Explain a diagnostic. Pass a stable `HARN-<CAT>-<NNN>` code
+    /// (optionally with `--json` for the structured envelope), or the
+    /// legacy `--invariant <NAME> <FUNCTION> <FILE>` form to walk the
+    /// control-flow path behind a Harn invariant violation.
     Explain(ExplainArgs),
     /// Export machine-readable Harn contracts and bundle manifests.
     Contracts(ContractsArgs),

--- a/crates/harn-cli/src/commands/explain.rs
+++ b/crates/harn-cli/src/commands/explain.rs
@@ -1,14 +1,119 @@
+use std::str::FromStr;
+
+use harn_parser::diagnostic_codes::Code;
+use serde::Serialize;
+
 use crate::cli::ExplainArgs;
 use crate::parse_source_file;
 
+/// JSON envelope returned by `harn explain <CODE> --json`. Stable shape —
+/// downstream tooling (LSPs, IDEs, hosted error pages, agents) can dispatch
+/// on `schemaVersion` and `code` without parsing prose.
+#[derive(Debug, Serialize)]
+struct ExplainEnvelope<'a> {
+    #[serde(rename = "schemaVersion")]
+    schema_version: u32,
+    code: &'a str,
+    category: &'a str,
+    summary: &'a str,
+    body: &'a str,
+    /// Repair shapes available for this code, sourced from the per-code
+    /// registry. Empty until the `Repair` struct lands on `TypeDiagnostic`
+    /// (epic #1745, E1.2).
+    repairs: Vec<RepairEnvelope<'a>>,
+    related: Vec<&'a str>,
+    #[serde(rename = "apiStability")]
+    api_stability: &'a str,
+}
+
+#[derive(Debug, Serialize)]
+struct RepairEnvelope<'a> {
+    id: &'a str,
+    safety: &'a str,
+    summary: &'a str,
+}
+
 pub(crate) fn run_explain(args: &ExplainArgs) -> i32 {
-    let (_, program) = parse_source_file(&args.file);
-    match harn_ir::explain_handler_invariant(&program, &args.function, &args.invariant) {
+    if let Some(invariant) = &args.invariant {
+        return run_invariant_explain(invariant, args);
+    }
+
+    let code = match Code::from_str(&args.target) {
+        Ok(code) => code,
+        Err(_) => {
+            eprintln!(
+                "Unknown Harn diagnostic code `{}`. Expected `HARN-<CAT>-<NNN>` (e.g. `HARN-TYP-014`).",
+                args.target
+            );
+            eprintln!("Run `harn explain HARN-TYP-001` for an example, or check the catalog at <https://harnlang.com/diagnostics/>.");
+            return 2;
+        }
+    };
+
+    if args.json {
+        print_code_json(code)
+    } else {
+        print_code_text(code)
+    }
+}
+
+fn print_code_text(code: Code) -> i32 {
+    println!("{} — {}", code, code.summary());
+    println!();
+    println!("{}", code.explanation().trim_end());
+    let related = code.related();
+    if !related.is_empty() {
+        println!();
+        println!("See also:");
+        for other in related {
+            println!("  - {} — {}", other, other.summary());
+        }
+    }
+    0
+}
+
+fn build_envelope(code: Code) -> ExplainEnvelope<'static> {
+    let related_strs: Vec<&'static str> = code.related().iter().map(|c| c.as_str()).collect();
+    ExplainEnvelope {
+        schema_version: 1,
+        code: code.as_str(),
+        category: code.category().as_str(),
+        summary: code.summary(),
+        body: code.explanation(),
+        repairs: Vec::new(),
+        related: related_strs,
+        api_stability: "stable",
+    }
+}
+
+fn print_code_json(code: Code) -> i32 {
+    let envelope = build_envelope(code);
+    match serde_json::to_string_pretty(&envelope) {
+        Ok(json) => {
+            println!("{json}");
+            0
+        }
+        Err(err) => {
+            eprintln!("failed to serialise explain envelope: {err}");
+            1
+        }
+    }
+}
+
+fn run_invariant_explain(invariant: &str, args: &ExplainArgs) -> i32 {
+    let Some(file) = args.file.as_deref() else {
+        eprintln!(
+            "`--invariant` requires both a function name and a path. Usage: `harn explain --invariant <NAME> <FUNCTION> <FILE>`"
+        );
+        return 2;
+    };
+    let (_, program) = parse_source_file(file);
+    match harn_ir::explain_handler_invariant(&program, &args.target, invariant) {
         Ok(diagnostics) => {
             if diagnostics.is_empty() {
                 println!(
                     "No `{}` violations found for `{}` in {}.",
-                    args.invariant, args.function, args.file
+                    invariant, args.target, file
                 );
                 return 0;
             }
@@ -21,7 +126,7 @@ pub(crate) fn run_explain(args: &ExplainArgs) -> i32 {
                     println!(
                         "  {}. {}:{}:{} {}",
                         index + 1,
-                        args.file,
+                        file,
                         step.span.line,
                         step.span.column,
                         step.label
@@ -42,17 +147,82 @@ pub(crate) fn run_explain(args: &ExplainArgs) -> i32 {
 
 #[cfg(test)]
 mod tests {
-    use std::time::{SystemTime, UNIX_EPOCH};
-
     use super::run_explain;
     use crate::cli::ExplainArgs;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
     fn unique_temp_dir(prefix: &str) -> std::path::PathBuf {
-        let nanos = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
+        let pid = std::process::id();
+        let n = TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+        std::env::temp_dir().join(format!("{prefix}-{pid}-{n}"))
+    }
+
+    fn args_for_code(code: &str, json: bool) -> ExplainArgs {
+        ExplainArgs {
+            target: code.to_string(),
+            file: None,
+            invariant: None,
+            json,
+        }
+    }
+
+    #[test]
+    fn explain_code_text_succeeds_for_registered_code() {
+        let code = run_explain(&args_for_code("HARN-TYP-014", false));
+        assert_eq!(code, 0);
+    }
+
+    #[test]
+    fn explain_code_fails_for_unknown_code() {
+        let code = run_explain(&args_for_code("HARN-ZZZ-999", false));
+        assert_eq!(code, 2);
+    }
+
+    #[test]
+    fn explain_json_envelope_round_trips_schema_and_code() {
+        let envelope =
+            super::build_envelope(harn_parser::diagnostic_codes::Code::TypeParameterArity);
+        let serialised = serde_json::to_string(&envelope).expect("serialise");
+        let value: serde_json::Value = serde_json::from_str(&serialised).expect("parse json");
+        assert_eq!(value["schemaVersion"], serde_json::json!(1));
+        assert_eq!(value["code"], serde_json::json!("HARN-TYP-014"));
+        assert_eq!(value["category"], serde_json::json!("TYP"));
+        assert_eq!(value["apiStability"], serde_json::json!("stable"));
+        assert!(
+            value["body"]
+                .as_str()
+                .is_some_and(|b| b.contains("HARN-TYP-014")),
+            "envelope body should reference the code, got: {value:?}"
+        );
+        assert!(value["related"].is_array(), "related is an array");
+        let related: Vec<String> = value["related"]
+            .as_array()
             .unwrap()
-            .as_nanos();
-        std::env::temp_dir().join(format!("{prefix}-{nanos}"))
+            .iter()
+            .map(|v| v.as_str().unwrap().to_string())
+            .collect();
+        assert!(related.contains(&"HARN-TYP-013".to_string()));
+    }
+
+    #[test]
+    fn explain_every_registered_code_emits_valid_envelope() {
+        use harn_parser::diagnostic_codes::Code;
+        for entry in Code::registry() {
+            let envelope = super::build_envelope(entry.code);
+            let serialised =
+                serde_json::to_string(&envelope).expect("serialise registered code envelope");
+            let value: serde_json::Value =
+                serde_json::from_str(&serialised).expect("parse registered code envelope");
+            assert_eq!(value["schemaVersion"], serde_json::json!(1));
+            assert_eq!(value["code"], serde_json::json!(entry.identifier));
+            assert!(
+                value["body"].as_str().is_some_and(|b| !b.trim().is_empty()),
+                "{} has empty body in envelope",
+                entry.identifier
+            );
+        }
     }
 
     #[test]
@@ -72,9 +242,10 @@ fn handler() {
         .unwrap();
 
         let code = run_explain(&ExplainArgs {
-            invariant: "approval.reachability".to_string(),
-            function: "handler".to_string(),
-            file: file.to_string_lossy().into_owned(),
+            target: "handler".to_string(),
+            file: Some(file.to_string_lossy().into_owned()),
+            invariant: Some("approval.reachability".to_string()),
+            json: false,
         });
 
         assert_eq!(code, 0);
@@ -97,9 +268,10 @@ fn handler() {
         .unwrap();
 
         let code = run_explain(&ExplainArgs {
-            invariant: "approval.reachability".to_string(),
-            function: "missing".to_string(),
-            file: file.to_string_lossy().into_owned(),
+            target: "missing".to_string(),
+            file: Some(file.to_string_lossy().into_owned()),
+            invariant: Some("approval.reachability".to_string()),
+            json: false,
         });
 
         assert_eq!(code, 1);

--- a/crates/harn-parser/src/diagnostic_codes.rs
+++ b/crates/harn-parser/src/diagnostic_codes.rs
@@ -125,6 +125,17 @@ macro_rules! diagnostic_codes {
                     $(Code::$variant => $summary,)*
                 }
             }
+
+            /// Full markdown explanation embedded at compile time. Every
+            /// registered code must ship a matching file under
+            /// `diagnostic_codes/explanations/`; missing files fail the build.
+            pub const fn explanation(self) -> &'static str {
+                match self {
+                    $(Code::$variant => include_str!(
+                        concat!("diagnostic_codes/explanations/", $identifier, ".md")
+                    ),)*
+                }
+            }
         }
 
         pub const REGISTRY: &[RegistryEntry] = &[
@@ -292,6 +303,107 @@ impl Code {
     pub const fn registry() -> &'static [RegistryEntry] {
         REGISTRY
     }
+
+    /// Codes that an agent should consider alongside this one when planning
+    /// repairs. Curated per-code — typically near-neighbours in the same
+    /// category that share a fix shape. Returns an empty slice for codes
+    /// without curated cross-references.
+    pub const fn related(self) -> &'static [Code] {
+        match self {
+            // Type mismatches form a family — surfacing the others helps an
+            // agent disambiguate between assignment, argument, return, etc.
+            Code::TypeMismatch => &[
+                Code::AssignmentTypeMismatch,
+                Code::ArgumentTypeMismatch,
+                Code::ReturnTypeMismatch,
+                Code::VariableTypeMismatch,
+                Code::FieldTypeMismatch,
+            ],
+            Code::AssignmentTypeMismatch => &[Code::TypeMismatch, Code::VariableTypeMismatch],
+            Code::ArgumentTypeMismatch => &[Code::TypeMismatch, Code::GenericTypeArgumentMismatch],
+            Code::ReturnTypeMismatch => &[Code::TypeMismatch, Code::ClosureReturnTypeMismatch],
+            Code::VariableTypeMismatch => &[Code::TypeMismatch, Code::AssignmentTypeMismatch],
+            Code::ClosureReturnTypeMismatch => &[Code::ReturnTypeMismatch],
+            Code::FieldTypeMismatch => &[Code::TypeMismatch, Code::InvalidStructLiteral],
+            Code::MethodTypeMismatch => &[Code::TypeMismatch, Code::CallableExpected],
+            // Generic type-argument family.
+            Code::GenericTypeArgumentUnsupported => &[
+                Code::GenericTypeArgumentMismatch,
+                Code::GenericTypeArgumentArity,
+            ],
+            Code::GenericTypeArgumentMismatch => &[
+                Code::GenericTypeArgumentArity,
+                Code::WhereConstraintMismatch,
+            ],
+            Code::GenericTypeArgumentArity => {
+                &[Code::GenericTypeArgumentMismatch, Code::TypeParameterArity]
+            }
+            Code::TypeParameterArity => &[Code::GenericTypeArgumentArity],
+            Code::WhereConstraintMismatch => &[Code::GenericTypeArgumentMismatch],
+            // Naming.
+            Code::UndefinedVariable => &[Code::UndefinedFunction, Code::UnknownDeclaration],
+            Code::UndefinedFunction => &[Code::UnknownBuiltin, Code::UnknownDeclaration],
+            Code::UnknownField => &[Code::UnknownMethod, Code::InvalidStructLiteral],
+            Code::UnknownMethod => &[Code::UnknownField, Code::CallableExpected],
+            Code::UnknownAttribute => {
+                &[Code::InvalidAttributeArgument, Code::InvalidAttributeTarget]
+            }
+            Code::InvalidAttributeArgument => {
+                &[Code::UnknownAttribute, Code::InvalidAttributeTarget]
+            }
+            Code::InvalidAttributeTarget => {
+                &[Code::UnknownAttribute, Code::InvalidAttributeArgument]
+            }
+            // LLM call family — schema, options, provider branching.
+            Code::LlmSchemaMissing => &[Code::LlmSchemaInvalid, Code::UnknownLlmOption],
+            Code::LlmSchemaInvalid => &[Code::LlmSchemaMissing, Code::UnknownLlmOption],
+            Code::UnknownLlmOption => &[Code::DeprecatedLlmOption, Code::LlmSchemaInvalid],
+            Code::DeprecatedLlmOption => &[Code::UnknownLlmOption],
+            Code::LlmProviderIdentityBranch => &[Code::PromptProviderIdentityBranch],
+            // Prompt-template family.
+            Code::PromptTemplateParse => &[Code::PromptTargetMissing],
+            Code::PromptInjectionRisk => &[Code::LintPromptInjectionRisk],
+            Code::PromptProviderIdentityBranch => &[
+                Code::LlmProviderIdentityBranch,
+                Code::LintTemplateProviderIdentityBranch,
+            ],
+            Code::PromptVariantExplosion => &[Code::LintTemplateVariantExplosion],
+            // Capabilities.
+            Code::CapabilityResultUnchecked => {
+                &[Code::RescueOutsideFunction, Code::TryOutsideFunction]
+            }
+            Code::CapabilityUnknownOperation => &[Code::CapabilityCallStaticNameRequired],
+            // Recovery / match.
+            Code::RescueOutsideFunction => {
+                &[Code::TryOutsideFunction, Code::InvalidRescueConstruct]
+            }
+            Code::TryOutsideFunction => &[Code::RescueOutsideFunction],
+            Code::NonExhaustiveMatch => &[Code::InvalidMatchPattern, Code::DuplicateMatchArm],
+            Code::DuplicateMatchArm => &[Code::NonExhaustiveMatch, Code::LintDuplicateMatchArm],
+            // Module / import family.
+            Code::ModuleImportUnresolved => {
+                &[Code::ImportResolutionFailed, Code::ImportSymbolMissing]
+            }
+            Code::ModuleImportUnused => &[Code::LintUnusedImport],
+            Code::ImportResolutionFailed => {
+                &[Code::ModuleImportUnresolved, Code::ImportSymbolMissing]
+            }
+            Code::ImportCycle => &[Code::ImportResolutionFailed],
+            // Ownership.
+            Code::ImmutableAssignment => &[Code::MutableNeverReassigned],
+            Code::MutableNeverReassigned => &[Code::LintMutableNeverReassigned],
+            // Lint pairs (drift between lint and runtime/typecheck codes).
+            Code::LintDeprecatedLlmOptions => &[Code::DeprecatedLlmOption, Code::UnknownLlmOption],
+            Code::LintPromptInjectionRisk => &[Code::PromptInjectionRisk],
+            Code::LintTemplateVariantExplosion => &[Code::PromptVariantExplosion],
+            Code::LintTemplateProviderIdentityBranch => &[Code::PromptProviderIdentityBranch],
+            Code::LintRenamedStdlibSymbol => &[Code::DeprecatedStdlibSymbol],
+            Code::LintMutableNeverReassigned => &[Code::MutableNeverReassigned],
+            Code::LintUnusedImport => &[Code::ModuleImportUnused],
+            Code::LintDuplicateMatchArm => &[Code::DuplicateMatchArm],
+            _ => &[],
+        }
+    }
 }
 
 impl fmt::Display for Code {
@@ -365,6 +477,42 @@ mod tests {
                     .any(|entry| entry.category == *category),
                 "missing diagnostic code category {category}"
             );
+        }
+    }
+
+    #[test]
+    fn every_code_has_non_empty_explanation() {
+        for entry in Code::registry() {
+            let body = entry.code.explanation();
+            assert!(
+                !body.trim().is_empty(),
+                "diagnostic code {} has an empty explanation file",
+                entry.identifier
+            );
+            assert!(
+                body.contains(entry.identifier),
+                "explanation for {} should reference its identifier",
+                entry.identifier
+            );
+        }
+    }
+
+    #[test]
+    fn related_codes_are_registered_and_non_self() {
+        for entry in Code::registry() {
+            for &other in entry.code.related() {
+                assert_ne!(
+                    other, entry.code,
+                    "{} lists itself as a related code",
+                    entry.identifier
+                );
+                assert!(
+                    Code::registry().iter().any(|e| e.code == other),
+                    "{} lists unregistered related code {}",
+                    entry.identifier,
+                    other
+                );
+            }
         }
     }
 }

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-CAP-001.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-CAP-001.md
@@ -1,0 +1,24 @@
+# HARN-CAP-001 — capability payload is invalid
+
+**Category:** Host capability (CAP)  
+**Variant:** `Code::CapabilityPayloadInvalid` (capability payload invalid)
+
+## What it means
+
+A host capability call (file I/O, network, HITL approval, tool host, etc.) is
+shaped in a way Harn cannot statically validate. Capabilities are the trust
+boundary between Harn scripts and the embedding host, so the check is strict by
+design.
+
+Specifically: capability payload is invalid.
+
+## How to fix
+
+- Match the capability signature documented in the Harn capability spec.
+- If approval / receipt handling is required, wire it through `human_approval` or the equivalent before calling the capability.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-CAP-002.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-CAP-002.md
@@ -1,0 +1,24 @@
+# HARN-CAP-002 — human approval construct is missing policy
+
+**Category:** Host capability (CAP)  
+**Variant:** `Code::HitlMissingApprovalPolicy` (hitl missing approval policy)
+
+## What it means
+
+A host capability call (file I/O, network, HITL approval, tool host, etc.) is
+shaped in a way Harn cannot statically validate. Capabilities are the trust
+boundary between Harn scripts and the embedding host, so the check is strict by
+design.
+
+Specifically: human approval construct is missing policy.
+
+## How to fix
+
+- Match the capability signature documented in the Harn capability spec.
+- If approval / receipt handling is required, wire it through `human_approval` or the equivalent before calling the capability.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-CAP-003.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-CAP-003.md
@@ -1,0 +1,25 @@
+# HARN-CAP-003 — human approval argument is invalid
+
+**Category:** Host capability (CAP)  
+**Variant:** `Code::HitlInvalidApprovalArgument` (hitl invalid approval
+argument)
+
+## What it means
+
+A host capability call (file I/O, network, HITL approval, tool host, etc.) is
+shaped in a way Harn cannot statically validate. Capabilities are the trust
+boundary between Harn scripts and the embedding host, so the check is strict by
+design.
+
+Specifically: human approval argument is invalid.
+
+## How to fix
+
+- Match the capability signature documented in the Harn capability spec.
+- If approval / receipt handling is required, wire it through `human_approval` or the equivalent before calling the capability.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-CAP-004.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-CAP-004.md
@@ -1,0 +1,24 @@
+# HARN-CAP-004 — capability result must be checked
+
+**Category:** Host capability (CAP)  
+**Variant:** `Code::CapabilityResultUnchecked` (capability result unchecked)
+
+## What it means
+
+A host capability call (file I/O, network, HITL approval, tool host, etc.) is
+shaped in a way Harn cannot statically validate. Capabilities are the trust
+boundary between Harn scripts and the embedding host, so the check is strict by
+design.
+
+Specifically: capability result must be checked.
+
+## How to fix
+
+- Match the capability signature documented in the Harn capability spec.
+- If approval / receipt handling is required, wire it through `human_approval` or the equivalent before calling the capability.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-CAP-005.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-CAP-005.md
@@ -1,0 +1,24 @@
+# HARN-CAP-005 — host capability operation is not declared
+
+**Category:** Host capability (CAP)  
+**Variant:** `Code::CapabilityUnknownOperation` (capability unknown operation)
+
+## What it means
+
+A host capability call (file I/O, network, HITL approval, tool host, etc.) is
+shaped in a way Harn cannot statically validate. Capabilities are the trust
+boundary between Harn scripts and the embedding host, so the check is strict by
+design.
+
+Specifically: host capability operation is not declared.
+
+## How to fix
+
+- Match the capability signature documented in the Harn capability spec.
+- If approval / receipt handling is required, wire it through `human_approval` or the equivalent before calling the capability.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-CAP-006.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-CAP-006.md
@@ -1,0 +1,25 @@
+# HARN-CAP-006 — host capability call must use a static operation name
+
+**Category:** Host capability (CAP)  
+**Variant:** `Code::CapabilityCallStaticNameRequired` (capability call static
+name required)
+
+## What it means
+
+A host capability call (file I/O, network, HITL approval, tool host, etc.) is
+shaped in a way Harn cannot statically validate. Capabilities are the trust
+boundary between Harn scripts and the embedding host, so the check is strict by
+design.
+
+Specifically: host capability call must use a static operation name.
+
+## How to fix
+
+- Match the capability signature documented in the Harn capability spec.
+- If approval / receipt handling is required, wire it through `human_approval` or the equivalent before calling the capability.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-CAP-007.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-CAP-007.md
@@ -1,0 +1,24 @@
+# HARN-CAP-007 — tool host capability binding is invalid
+
+**Category:** Host capability (CAP)  
+**Variant:** `Code::CapabilityBindingInvalid` (capability binding invalid)
+
+## What it means
+
+A host capability call (file I/O, network, HITL approval, tool host, etc.) is
+shaped in a way Harn cannot statically validate. Capabilities are the trust
+boundary between Harn scripts and the embedding host, so the check is strict by
+design.
+
+Specifically: tool host capability binding is invalid.
+
+## How to fix
+
+- Match the capability signature documented in the Harn capability spec.
+- If approval / receipt handling is required, wire it through `human_approval` or the equivalent before calling the capability.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-FMT-001.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-FMT-001.md
@@ -1,0 +1,22 @@
+# HARN-FMT-001 — formatter could not parse the source
+
+**Category:** Formatter (FMT)  
+**Variant:** `Code::FormatterParseFailed` (formatter parse failed)
+
+## What it means
+
+The formatter could not produce a canonical layout for this source — either
+because parsing failed first, or because the existing layout drifts from the
+canonical form.
+
+Specifically: formatter could not parse the source.
+
+## How to fix
+
+- Run `harn fmt` to bring the file to canonical form, or fix the parse error blocking the formatter.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-FMT-002.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-FMT-002.md
@@ -1,0 +1,22 @@
+# HARN-FMT-002 — source is not in canonical format
+
+**Category:** Formatter (FMT)  
+**Variant:** `Code::FormatterWouldReformat` (formatter would reformat)
+
+## What it means
+
+The formatter could not produce a canonical layout for this source — either
+because parsing failed first, or because the existing layout drifts from the
+canonical form.
+
+Specifically: source is not in canonical format.
+
+## How to fix
+
+- Run `harn fmt` to bring the file to canonical form, or fix the parse error blocking the formatter.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-FMT-003.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-FMT-003.md
@@ -1,0 +1,22 @@
+# HARN-FMT-003 — formatter normalized trailing comma layout
+
+**Category:** Formatter (FMT)  
+**Variant:** `Code::FormatterTrailingComma` (formatter trailing comma)
+
+## What it means
+
+The formatter could not produce a canonical layout for this source — either
+because parsing failed first, or because the existing layout drifts from the
+canonical form.
+
+Specifically: formatter normalized trailing comma layout.
+
+## How to fix
+
+- Run `harn fmt` to bring the file to canonical form, or fix the parse error blocking the formatter.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-IMP-001.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-IMP-001.md
@@ -1,0 +1,22 @@
+# HARN-IMP-001 — import target cannot be resolved
+
+**Category:** Import resolution (IMP)  
+**Variant:** `Code::ImportResolutionFailed` (import resolution failed)
+
+## What it means
+
+Import resolution failed at a deeper layer than `MOD` — the file, symbol, or
+module graph cannot be constructed. Compilation cannot proceed.
+
+Specifically: import target cannot be resolved.
+
+## How to fix
+
+- Add the missing module or symbol, or update the import path.
+- Break import cycles by extracting the shared definitions into a third module.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-IMP-002.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-IMP-002.md
@@ -1,0 +1,22 @@
+# HARN-IMP-002 — imported symbol does not exist
+
+**Category:** Import resolution (IMP)  
+**Variant:** `Code::ImportSymbolMissing` (import symbol missing)
+
+## What it means
+
+Import resolution failed at a deeper layer than `MOD` — the file, symbol, or
+module graph cannot be constructed. Compilation cannot proceed.
+
+Specifically: imported symbol does not exist.
+
+## How to fix
+
+- Add the missing module or symbol, or update the import path.
+- Break import cycles by extracting the shared definitions into a third module.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-IMP-003.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-IMP-003.md
@@ -1,0 +1,22 @@
+# HARN-IMP-003 — import graph contains a cycle
+
+**Category:** Import resolution (IMP)  
+**Variant:** `Code::ImportCycle` (import cycle)
+
+## What it means
+
+Import resolution failed at a deeper layer than `MOD` — the file, symbol, or
+module graph cannot be constructed. Compilation cannot proceed.
+
+Specifically: import graph contains a cycle.
+
+## How to fix
+
+- Add the missing module or symbol, or update the import path.
+- Break import cycles by extracting the shared definitions into a third module.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LLM-001.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LLM-001.md
@@ -1,0 +1,24 @@
+# HARN-LLM-001 — LLM option key is not recognized
+
+**Category:** LLM call (LLM)  
+**Variant:** `Code::UnknownLlmOption` (unknown llm option)
+
+## What it means
+
+The `llm_call(...)` invocation here violates the schema Harn enforces for LLM
+calls. Schema-validated, provider-portable LLM calls are a load-bearing Harn
+contract; drift in the options table is rejected at check time.
+
+Specifically: LLM option key is not recognized.
+
+## How to fix
+
+- Pass a `schema:` option that validates the model output, with `schema_retries:` as appropriate.
+- Drop or rename deprecated options to the names listed in the LLM call quickref.
+- Pick capability flags (`tool_calling: true`, etc.) instead of branching on `provider:` identity.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LLM-002.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LLM-002.md
@@ -1,0 +1,24 @@
+# HARN-LLM-002 — LLM option key is deprecated
+
+**Category:** LLM call (LLM)  
+**Variant:** `Code::DeprecatedLlmOption` (deprecated llm option)
+
+## What it means
+
+The `llm_call(...)` invocation here violates the schema Harn enforces for LLM
+calls. Schema-validated, provider-portable LLM calls are a load-bearing Harn
+contract; drift in the options table is rejected at check time.
+
+Specifically: LLM option key is deprecated.
+
+## How to fix
+
+- Pass a `schema:` option that validates the model output, with `schema_retries:` as appropriate.
+- Drop or rename deprecated options to the names listed in the LLM call quickref.
+- Pick capability flags (`tool_calling: true`, etc.) instead of branching on `provider:` identity.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LLM-003.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LLM-003.md
@@ -1,0 +1,24 @@
+# HARN-LLM-003 — LLM call is missing schema validation
+
+**Category:** LLM call (LLM)  
+**Variant:** `Code::LlmSchemaMissing` (llm schema missing)
+
+## What it means
+
+The `llm_call(...)` invocation here violates the schema Harn enforces for LLM
+calls. Schema-validated, provider-portable LLM calls are a load-bearing Harn
+contract; drift in the options table is rejected at check time.
+
+Specifically: LLM call is missing schema validation.
+
+## How to fix
+
+- Pass a `schema:` option that validates the model output, with `schema_retries:` as appropriate.
+- Drop or rename deprecated options to the names listed in the LLM call quickref.
+- Pick capability flags (`tool_calling: true`, etc.) instead of branching on `provider:` identity.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LLM-004.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LLM-004.md
@@ -1,0 +1,24 @@
+# HARN-LLM-004 — LLM schema option is invalid
+
+**Category:** LLM call (LLM)  
+**Variant:** `Code::LlmSchemaInvalid` (llm schema invalid)
+
+## What it means
+
+The `llm_call(...)` invocation here violates the schema Harn enforces for LLM
+calls. Schema-validated, provider-portable LLM calls are a load-bearing Harn
+contract; drift in the options table is rejected at check time.
+
+Specifically: LLM schema option is invalid.
+
+## How to fix
+
+- Pass a `schema:` option that validates the model output, with `schema_retries:` as appropriate.
+- Drop or rename deprecated options to the names listed in the LLM call quickref.
+- Pick capability flags (`tool_calling: true`, etc.) instead of branching on `provider:` identity.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LLM-005.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LLM-005.md
@@ -1,0 +1,24 @@
+# HARN-LLM-005 — prompt branches on provider identity instead of capability flags
+
+**Category:** LLM call (LLM)  
+**Variant:** `Code::LlmProviderIdentityBranch` (llm provider identity branch)
+
+## What it means
+
+The `llm_call(...)` invocation here violates the schema Harn enforces for LLM
+calls. Schema-validated, provider-portable LLM calls are a load-bearing Harn
+contract; drift in the options table is rejected at check time.
+
+Specifically: prompt branches on provider identity instead of capability flags.
+
+## How to fix
+
+- Pass a `schema:` option that validates the model output, with `schema_retries:` as appropriate.
+- Drop or rename deprecated options to the names listed in the LLM call quickref.
+- Pick capability flags (`tool_calling: true`, etc.) instead of branching on `provider:` identity.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-001.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-001.md
@@ -1,0 +1,23 @@
+# HARN-LNT-001 — renamed stdlib symbol lint
+
+**Category:** Lint (LNT)  
+**Variant:** `Code::LintRenamedStdlibSymbol` (lint renamed stdlib symbol)
+
+## What it means
+
+This is a lint, not a hard error. The code compiles, but Harn flags the pattern
+as likely-incorrect, unidiomatic, or risky in a production agent. Lints can
+typically be auto-fixed.
+
+Specifically: renamed stdlib symbol lint.
+
+## How to fix
+
+- Apply the lint's auto-fix where one is offered (`harn lint --fix`).
+- Suppress the lint with an attribute only when the surrounding code is intentionally non-idiomatic.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-002.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-002.md
@@ -1,0 +1,23 @@
+# HARN-LNT-002 — cyclomatic complexity lint
+
+**Category:** Lint (LNT)  
+**Variant:** `Code::LintCyclomaticComplexity` (lint cyclomatic complexity)
+
+## What it means
+
+This is a lint, not a hard error. The code compiles, but Harn flags the pattern
+as likely-incorrect, unidiomatic, or risky in a production agent. Lints can
+typically be auto-fixed.
+
+Specifically: cyclomatic complexity lint.
+
+## How to fix
+
+- Apply the lint's auto-fix where one is offered (`harn lint --fix`).
+- Suppress the lint with an attribute only when the surrounding code is intentionally non-idiomatic.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-003.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-003.md
@@ -1,0 +1,23 @@
+# HARN-LNT-003 — naming convention lint
+
+**Category:** Lint (LNT)  
+**Variant:** `Code::LintNamingConvention` (lint naming convention)
+
+## What it means
+
+This is a lint, not a hard error. The code compiles, but Harn flags the pattern
+as likely-incorrect, unidiomatic, or risky in a production agent. Lints can
+typically be auto-fixed.
+
+Specifically: naming convention lint.
+
+## How to fix
+
+- Apply the lint's auto-fix where one is offered (`harn lint --fix`).
+- Suppress the lint with an attribute only when the surrounding code is intentionally non-idiomatic.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-004.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-004.md
@@ -1,0 +1,24 @@
+# HARN-LNT-004 — eager collection conversion lint
+
+**Category:** Lint (LNT)  
+**Variant:** `Code::LintEagerCollectionConversion` (lint eager collection
+conversion)
+
+## What it means
+
+This is a lint, not a hard error. The code compiles, but Harn flags the pattern
+as likely-incorrect, unidiomatic, or risky in a production agent. Lints can
+typically be auto-fixed.
+
+Specifically: eager collection conversion lint.
+
+## How to fix
+
+- Apply the lint's auto-fix where one is offered (`harn lint --fix`).
+- Suppress the lint with an attribute only when the surrounding code is intentionally non-idiomatic.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-005.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-005.md
@@ -1,0 +1,23 @@
+# HARN-LNT-005 — redundant clone lint
+
+**Category:** Lint (LNT)  
+**Variant:** `Code::LintRedundantClone` (lint redundant clone)
+
+## What it means
+
+This is a lint, not a hard error. The code compiles, but Harn flags the pattern
+as likely-incorrect, unidiomatic, or risky in a production agent. Lints can
+typically be auto-fixed.
+
+Specifically: redundant clone lint.
+
+## How to fix
+
+- Apply the lint's auto-fix where one is offered (`harn lint --fix`).
+- Suppress the lint with an attribute only when the surrounding code is intentionally non-idiomatic.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-006.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-006.md
@@ -1,0 +1,24 @@
+# HARN-LNT-006 — long-running workflow cleanup lint
+
+**Category:** Lint (LNT)  
+**Variant:** `Code::LintLongRunningWithoutCleanup` (lint long running without
+cleanup)
+
+## What it means
+
+This is a lint, not a hard error. The code compiles, but Harn flags the pattern
+as likely-incorrect, unidiomatic, or risky in a production agent. Lints can
+typically be auto-fixed.
+
+Specifically: long-running workflow cleanup lint.
+
+## How to fix
+
+- Apply the lint's auto-fix where one is offered (`harn lint --fix`).
+- Suppress the lint with an attribute only when the surrounding code is intentionally non-idiomatic.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-007.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-007.md
@@ -1,0 +1,23 @@
+# HARN-LNT-007 — MCP tool annotations lint
+
+**Category:** Lint (LNT)  
+**Variant:** `Code::LintMcpToolAnnotations` (lint mcp tool annotations)
+
+## What it means
+
+This is a lint, not a hard error. The code compiles, but Harn flags the pattern
+as likely-incorrect, unidiomatic, or risky in a production agent. Lints can
+typically be auto-fixed.
+
+Specifically: MCP tool annotations lint.
+
+## How to fix
+
+- Apply the lint's auto-fix where one is offered (`harn lint --fix`).
+- Suppress the lint with an attribute only when the surrounding code is intentionally non-idiomatic.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-008.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-008.md
@@ -1,0 +1,24 @@
+# HARN-LNT-008 — PR open without secret scan lint
+
+**Category:** Lint (LNT)  
+**Variant:** `Code::LintPrOpenWithoutSecretScan` (lint pr open without secret
+scan)
+
+## What it means
+
+This is a lint, not a hard error. The code compiles, but Harn flags the pattern
+as likely-incorrect, unidiomatic, or risky in a production agent. Lints can
+typically be auto-fixed.
+
+Specifically: PR open without secret scan lint.
+
+## How to fix
+
+- Apply the lint's auto-fix where one is offered (`harn lint --fix`).
+- Suppress the lint with an attribute only when the surrounding code is intentionally non-idiomatic.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-009.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-009.md
@@ -1,0 +1,23 @@
+# HARN-LNT-009 — shadow variable lint
+
+**Category:** Lint (LNT)  
+**Variant:** `Code::LintShadowVariable` (lint shadow variable)
+
+## What it means
+
+This is a lint, not a hard error. The code compiles, but Harn flags the pattern
+as likely-incorrect, unidiomatic, or risky in a production agent. Lints can
+typically be auto-fixed.
+
+Specifically: shadow variable lint.
+
+## How to fix
+
+- Apply the lint's auto-fix where one is offered (`harn lint --fix`).
+- Suppress the lint with an attribute only when the surrounding code is intentionally non-idiomatic.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-010.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-010.md
@@ -1,0 +1,23 @@
+# HARN-LNT-010 — persona hook target lint
+
+**Category:** Lint (LNT)  
+**Variant:** `Code::LintPersonaHookTarget` (lint persona hook target)
+
+## What it means
+
+This is a lint, not a hard error. The code compiles, but Harn flags the pattern
+as likely-incorrect, unidiomatic, or risky in a production agent. Lints can
+typically be auto-fixed.
+
+Specifically: persona hook target lint.
+
+## How to fix
+
+- Apply the lint's auto-fix where one is offered (`harn lint --fix`).
+- Suppress the lint with an attribute only when the surrounding code is intentionally non-idiomatic.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-011.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-011.md
@@ -1,0 +1,23 @@
+# HARN-LNT-011 — dead code after return lint
+
+**Category:** Lint (LNT)  
+**Variant:** `Code::LintDeadCodeAfterReturn` (lint dead code after return)
+
+## What it means
+
+This is a lint, not a hard error. The code compiles, but Harn flags the pattern
+as likely-incorrect, unidiomatic, or risky in a production agent. Lints can
+typically be auto-fixed.
+
+Specifically: dead code after return lint.
+
+## How to fix
+
+- Apply the lint's auto-fix where one is offered (`harn lint --fix`).
+- Suppress the lint with an attribute only when the surrounding code is intentionally non-idiomatic.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-012.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-012.md
@@ -1,0 +1,23 @@
+# HARN-LNT-012 — let then return lint
+
+**Category:** Lint (LNT)  
+**Variant:** `Code::LintLetThenReturn` (lint let then return)
+
+## What it means
+
+This is a lint, not a hard error. The code compiles, but Harn flags the pattern
+as likely-incorrect, unidiomatic, or risky in a production agent. Lints can
+typically be auto-fixed.
+
+Specifically: let then return lint.
+
+## How to fix
+
+- Apply the lint's auto-fix where one is offered (`harn lint --fix`).
+- Suppress the lint with an attribute only when the surrounding code is intentionally non-idiomatic.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-013.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-013.md
@@ -1,0 +1,24 @@
+# HARN-LNT-013 — unhandled approval result lint
+
+**Category:** Lint (LNT)  
+**Variant:** `Code::LintUnhandledApprovalResult` (lint unhandled approval
+result)
+
+## What it means
+
+This is a lint, not a hard error. The code compiles, but Harn flags the pattern
+as likely-incorrect, unidiomatic, or risky in a production agent. Lints can
+typically be auto-fixed.
+
+Specifically: unhandled approval result lint.
+
+## How to fix
+
+- Apply the lint's auto-fix where one is offered (`harn lint --fix`).
+- Suppress the lint with an attribute only when the surrounding code is intentionally non-idiomatic.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-014.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-014.md
@@ -1,0 +1,23 @@
+# HARN-LNT-014 — unused variable lint
+
+**Category:** Lint (LNT)  
+**Variant:** `Code::LintUnusedVariable` (lint unused variable)
+
+## What it means
+
+This is a lint, not a hard error. The code compiles, but Harn flags the pattern
+as likely-incorrect, unidiomatic, or risky in a production agent. Lints can
+typically be auto-fixed.
+
+Specifically: unused variable lint.
+
+## How to fix
+
+- Apply the lint's auto-fix where one is offered (`harn lint --fix`).
+- Suppress the lint with an attribute only when the surrounding code is intentionally non-idiomatic.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-015.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-015.md
@@ -1,0 +1,23 @@
+# HARN-LNT-015 — unused pattern binding lint
+
+**Category:** Lint (LNT)  
+**Variant:** `Code::LintUnusedPatternBinding` (lint unused pattern binding)
+
+## What it means
+
+This is a lint, not a hard error. The code compiles, but Harn flags the pattern
+as likely-incorrect, unidiomatic, or risky in a production agent. Lints can
+typically be auto-fixed.
+
+Specifically: unused pattern binding lint.
+
+## How to fix
+
+- Apply the lint's auto-fix where one is offered (`harn lint --fix`).
+- Suppress the lint with an attribute only when the surrounding code is intentionally non-idiomatic.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-016.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-016.md
@@ -1,0 +1,23 @@
+# HARN-LNT-016 — unused parameter lint
+
+**Category:** Lint (LNT)  
+**Variant:** `Code::LintUnusedParameter` (lint unused parameter)
+
+## What it means
+
+This is a lint, not a hard error. The code compiles, but Harn flags the pattern
+as likely-incorrect, unidiomatic, or risky in a production agent. Lints can
+typically be auto-fixed.
+
+Specifically: unused parameter lint.
+
+## How to fix
+
+- Apply the lint's auto-fix where one is offered (`harn lint --fix`).
+- Suppress the lint with an attribute only when the surrounding code is intentionally non-idiomatic.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-017.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-017.md
@@ -1,0 +1,23 @@
+# HARN-LNT-017 — unused import lint
+
+**Category:** Lint (LNT)  
+**Variant:** `Code::LintUnusedImport` (lint unused import)
+
+## What it means
+
+This is a lint, not a hard error. The code compiles, but Harn flags the pattern
+as likely-incorrect, unidiomatic, or risky in a production agent. Lints can
+typically be auto-fixed.
+
+Specifically: unused import lint.
+
+## How to fix
+
+- Apply the lint's auto-fix where one is offered (`harn lint --fix`).
+- Suppress the lint with an attribute only when the surrounding code is intentionally non-idiomatic.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-018.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-018.md
@@ -1,0 +1,23 @@
+# HARN-LNT-018 — mutable never reassigned lint
+
+**Category:** Lint (LNT)  
+**Variant:** `Code::LintMutableNeverReassigned` (lint mutable never reassigned)
+
+## What it means
+
+This is a lint, not a hard error. The code compiles, but Harn flags the pattern
+as likely-incorrect, unidiomatic, or risky in a production agent. Lints can
+typically be auto-fixed.
+
+Specifically: mutable never reassigned lint.
+
+## How to fix
+
+- Apply the lint's auto-fix where one is offered (`harn lint --fix`).
+- Suppress the lint with an attribute only when the surrounding code is intentionally non-idiomatic.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-019.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-019.md
@@ -1,0 +1,23 @@
+# HARN-LNT-019 — unused function lint
+
+**Category:** Lint (LNT)  
+**Variant:** `Code::LintUnusedFunction` (lint unused function)
+
+## What it means
+
+This is a lint, not a hard error. The code compiles, but Harn flags the pattern
+as likely-incorrect, unidiomatic, or risky in a production agent. Lints can
+typically be auto-fixed.
+
+Specifically: unused function lint.
+
+## How to fix
+
+- Apply the lint's auto-fix where one is offered (`harn lint --fix`).
+- Suppress the lint with an attribute only when the surrounding code is intentionally non-idiomatic.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-020.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-020.md
@@ -1,0 +1,23 @@
+# HARN-LNT-020 — unused type lint
+
+**Category:** Lint (LNT)  
+**Variant:** `Code::LintUnusedType` (lint unused type)
+
+## What it means
+
+This is a lint, not a hard error. The code compiles, but Harn flags the pattern
+as likely-incorrect, unidiomatic, or risky in a production agent. Lints can
+typically be auto-fixed.
+
+Specifically: unused type lint.
+
+## How to fix
+
+- Apply the lint's auto-fix where one is offered (`harn lint --fix`).
+- Suppress the lint with an attribute only when the surrounding code is intentionally non-idiomatic.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-021.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-021.md
@@ -1,0 +1,24 @@
+# HARN-LNT-021 — persona body must call steps lint
+
+**Category:** Lint (LNT)  
+**Variant:** `Code::LintPersonaBodyMustCallSteps` (lint persona body must call
+steps)
+
+## What it means
+
+This is a lint, not a hard error. The code compiles, but Harn flags the pattern
+as likely-incorrect, unidiomatic, or risky in a production agent. Lints can
+typically be auto-fixed.
+
+Specifically: persona body must call steps lint.
+
+## How to fix
+
+- Apply the lint's auto-fix where one is offered (`harn lint --fix`).
+- Suppress the lint with an attribute only when the surrounding code is intentionally non-idiomatic.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-022.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-022.md
@@ -1,0 +1,23 @@
+# HARN-LNT-022 — undefined function lint
+
+**Category:** Lint (LNT)  
+**Variant:** `Code::LintUndefinedFunction` (lint undefined function)
+
+## What it means
+
+This is a lint, not a hard error. The code compiles, but Harn flags the pattern
+as likely-incorrect, unidiomatic, or risky in a production agent. Lints can
+typically be auto-fixed.
+
+Specifically: undefined function lint.
+
+## How to fix
+
+- Apply the lint's auto-fix where one is offered (`harn lint --fix`).
+- Suppress the lint with an attribute only when the surrounding code is intentionally non-idiomatic.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-023.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-023.md
@@ -1,0 +1,23 @@
+# HARN-LNT-023 — pipeline return type lint
+
+**Category:** Lint (LNT)  
+**Variant:** `Code::LintPipelineReturnType` (lint pipeline return type)
+
+## What it means
+
+This is a lint, not a hard error. The code compiles, but Harn flags the pattern
+as likely-incorrect, unidiomatic, or risky in a production agent. Lints can
+typically be auto-fixed.
+
+Specifically: pipeline return type lint.
+
+## How to fix
+
+- Apply the lint's auto-fix where one is offered (`harn lint --fix`).
+- Suppress the lint with an attribute only when the surrounding code is intentionally non-idiomatic.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-024.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-024.md
@@ -1,0 +1,23 @@
+# HARN-LNT-024 — missing harndoc lint
+
+**Category:** Lint (LNT)  
+**Variant:** `Code::LintMissingHarndoc` (lint missing harndoc)
+
+## What it means
+
+This is a lint, not a hard error. The code compiles, but Harn flags the pattern
+as likely-incorrect, unidiomatic, or risky in a production agent. Lints can
+typically be auto-fixed.
+
+Specifically: missing harndoc lint.
+
+## How to fix
+
+- Apply the lint's auto-fix where one is offered (`harn lint --fix`).
+- Suppress the lint with an attribute only when the surrounding code is intentionally non-idiomatic.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-025.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-025.md
@@ -1,0 +1,23 @@
+# HARN-LNT-025 — assert outside test lint
+
+**Category:** Lint (LNT)  
+**Variant:** `Code::LintAssertOutsideTest` (lint assert outside test)
+
+## What it means
+
+This is a lint, not a hard error. The code compiles, but Harn flags the pattern
+as likely-incorrect, unidiomatic, or risky in a production agent. Lints can
+typically be auto-fixed.
+
+Specifically: assert outside test lint.
+
+## How to fix
+
+- Apply the lint's auto-fix where one is offered (`harn lint --fix`).
+- Suppress the lint with an attribute only when the surrounding code is intentionally non-idiomatic.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-026.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-026.md
@@ -1,0 +1,23 @@
+# HARN-LNT-026 — prompt injection risk lint
+
+**Category:** Lint (LNT)  
+**Variant:** `Code::LintPromptInjectionRisk` (lint prompt injection risk)
+
+## What it means
+
+This is a lint, not a hard error. The code compiles, but Harn flags the pattern
+as likely-incorrect, unidiomatic, or risky in a production agent. Lints can
+typically be auto-fixed.
+
+Specifically: prompt injection risk lint.
+
+## How to fix
+
+- Apply the lint's auto-fix where one is offered (`harn lint --fix`).
+- Suppress the lint with an attribute only when the surrounding code is intentionally non-idiomatic.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-027.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-027.md
@@ -1,0 +1,23 @@
+# HARN-LNT-027 — connector effect policy lint
+
+**Category:** Lint (LNT)  
+**Variant:** `Code::LintConnectorEffectPolicy` (lint connector effect policy)
+
+## What it means
+
+This is a lint, not a hard error. The code compiles, but Harn flags the pattern
+as likely-incorrect, unidiomatic, or risky in a production agent. Lints can
+typically be auto-fixed.
+
+Specifically: connector effect policy lint.
+
+## How to fix
+
+- Apply the lint's auto-fix where one is offered (`harn lint --fix`).
+- Suppress the lint with an attribute only when the surrounding code is intentionally non-idiomatic.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-028.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-028.md
@@ -1,0 +1,23 @@
+# HARN-LNT-028 — unnecessary cast lint
+
+**Category:** Lint (LNT)  
+**Variant:** `Code::LintUnnecessaryCast` (lint unnecessary cast)
+
+## What it means
+
+This is a lint, not a hard error. The code compiles, but Harn flags the pattern
+as likely-incorrect, unidiomatic, or risky in a production agent. Lints can
+typically be auto-fixed.
+
+Specifically: unnecessary cast lint.
+
+## How to fix
+
+- Apply the lint's auto-fix where one is offered (`harn lint --fix`).
+- Suppress the lint with an attribute only when the surrounding code is intentionally non-idiomatic.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-029.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-029.md
@@ -1,0 +1,23 @@
+# HARN-LNT-029 — untyped dict access lint
+
+**Category:** Lint (LNT)  
+**Variant:** `Code::LintUntypedDictAccess` (lint untyped dict access)
+
+## What it means
+
+This is a lint, not a hard error. The code compiles, but Harn flags the pattern
+as likely-incorrect, unidiomatic, or risky in a production agent. Lints can
+typically be auto-fixed.
+
+Specifically: untyped dict access lint.
+
+## How to fix
+
+- Apply the lint's auto-fix where one is offered (`harn lint --fix`).
+- Suppress the lint with an attribute only when the surrounding code is intentionally non-idiomatic.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-030.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-030.md
@@ -1,0 +1,23 @@
+# HARN-LNT-030 — constant logical operand lint
+
+**Category:** Lint (LNT)  
+**Variant:** `Code::LintConstantLogicalOperand` (lint constant logical operand)
+
+## What it means
+
+This is a lint, not a hard error. The code compiles, but Harn flags the pattern
+as likely-incorrect, unidiomatic, or risky in a production agent. Lints can
+typically be auto-fixed.
+
+Specifically: constant logical operand lint.
+
+## How to fix
+
+- Apply the lint's auto-fix where one is offered (`harn lint --fix`).
+- Suppress the lint with an attribute only when the surrounding code is intentionally non-idiomatic.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-031.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-031.md
@@ -1,0 +1,23 @@
+# HARN-LNT-031 — pointless comparison lint
+
+**Category:** Lint (LNT)  
+**Variant:** `Code::LintPointlessComparison` (lint pointless comparison)
+
+## What it means
+
+This is a lint, not a hard error. The code compiles, but Harn flags the pattern
+as likely-incorrect, unidiomatic, or risky in a production agent. Lints can
+typically be auto-fixed.
+
+Specifically: pointless comparison lint.
+
+## How to fix
+
+- Apply the lint's auto-fix where one is offered (`harn lint --fix`).
+- Suppress the lint with an attribute only when the surrounding code is intentionally non-idiomatic.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-032.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-032.md
@@ -1,0 +1,23 @@
+# HARN-LNT-032 — comparison to bool lint
+
+**Category:** Lint (LNT)  
+**Variant:** `Code::LintComparisonToBool` (lint comparison to bool)
+
+## What it means
+
+This is a lint, not a hard error. The code compiles, but Harn flags the pattern
+as likely-incorrect, unidiomatic, or risky in a production agent. Lints can
+typically be auto-fixed.
+
+Specifically: comparison to bool lint.
+
+## How to fix
+
+- Apply the lint's auto-fix where one is offered (`harn lint --fix`).
+- Suppress the lint with an attribute only when the surrounding code is intentionally non-idiomatic.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-033.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-033.md
@@ -1,0 +1,23 @@
+# HARN-LNT-033 — invalid binary operator literal lint
+
+**Category:** Lint (LNT)  
+**Variant:** `Code::LintInvalidBinaryOpLiteral` (lint invalid binary op literal)
+
+## What it means
+
+This is a lint, not a hard error. The code compiles, but Harn flags the pattern
+as likely-incorrect, unidiomatic, or risky in a production agent. Lints can
+typically be auto-fixed.
+
+Specifically: invalid binary operator literal lint.
+
+## How to fix
+
+- Apply the lint's auto-fix where one is offered (`harn lint --fix`).
+- Suppress the lint with an attribute only when the surrounding code is intentionally non-idiomatic.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-034.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-034.md
@@ -1,0 +1,23 @@
+# HARN-LNT-034 — redundant nil ternary lint
+
+**Category:** Lint (LNT)  
+**Variant:** `Code::LintRedundantNilTernary` (lint redundant nil ternary)
+
+## What it means
+
+This is a lint, not a hard error. The code compiles, but Harn flags the pattern
+as likely-incorrect, unidiomatic, or risky in a production agent. Lints can
+typically be auto-fixed.
+
+Specifically: redundant nil ternary lint.
+
+## How to fix
+
+- Apply the lint's auto-fix where one is offered (`harn lint --fix`).
+- Suppress the lint with an attribute only when the surrounding code is intentionally non-idiomatic.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-035.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-035.md
@@ -1,0 +1,23 @@
+# HARN-LNT-035 — empty block lint
+
+**Category:** Lint (LNT)  
+**Variant:** `Code::LintEmptyBlock` (lint empty block)
+
+## What it means
+
+This is a lint, not a hard error. The code compiles, but Harn flags the pattern
+as likely-incorrect, unidiomatic, or risky in a production agent. Lints can
+typically be auto-fixed.
+
+Specifically: empty block lint.
+
+## How to fix
+
+- Apply the lint's auto-fix where one is offered (`harn lint --fix`).
+- Suppress the lint with an attribute only when the surrounding code is intentionally non-idiomatic.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-036.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-036.md
@@ -1,0 +1,23 @@
+# HARN-LNT-036 — unnecessary else return lint
+
+**Category:** Lint (LNT)  
+**Variant:** `Code::LintUnnecessaryElseReturn` (lint unnecessary else return)
+
+## What it means
+
+This is a lint, not a hard error. The code compiles, but Harn flags the pattern
+as likely-incorrect, unidiomatic, or risky in a production agent. Lints can
+typically be auto-fixed.
+
+Specifically: unnecessary else return lint.
+
+## How to fix
+
+- Apply the lint's auto-fix where one is offered (`harn lint --fix`).
+- Suppress the lint with an attribute only when the surrounding code is intentionally non-idiomatic.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-037.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-037.md
@@ -1,0 +1,23 @@
+# HARN-LNT-037 — duplicate match arm lint
+
+**Category:** Lint (LNT)  
+**Variant:** `Code::LintDuplicateMatchArm` (lint duplicate match arm)
+
+## What it means
+
+This is a lint, not a hard error. The code compiles, but Harn flags the pattern
+as likely-incorrect, unidiomatic, or risky in a production agent. Lints can
+typically be auto-fixed.
+
+Specifically: duplicate match arm lint.
+
+## How to fix
+
+- Apply the lint's auto-fix where one is offered (`harn lint --fix`).
+- Suppress the lint with an attribute only when the surrounding code is intentionally non-idiomatic.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-038.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-038.md
@@ -1,0 +1,23 @@
+# HARN-LNT-038 — require in test lint
+
+**Category:** Lint (LNT)  
+**Variant:** `Code::LintRequireInTest` (lint require in test)
+
+## What it means
+
+This is a lint, not a hard error. The code compiles, but Harn flags the pattern
+as likely-incorrect, unidiomatic, or risky in a production agent. Lints can
+typically be auto-fixed.
+
+Specifically: require in test lint.
+
+## How to fix
+
+- Apply the lint's auto-fix where one is offered (`harn lint --fix`).
+- Suppress the lint with an attribute only when the surrounding code is intentionally non-idiomatic.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-039.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-039.md
@@ -1,0 +1,23 @@
+# HARN-LNT-039 — break outside loop lint
+
+**Category:** Lint (LNT)  
+**Variant:** `Code::LintBreakOutsideLoop` (lint break outside loop)
+
+## What it means
+
+This is a lint, not a hard error. The code compiles, but Harn flags the pattern
+as likely-incorrect, unidiomatic, or risky in a production agent. Lints can
+typically be auto-fixed.
+
+Specifically: break outside loop lint.
+
+## How to fix
+
+- Apply the lint's auto-fix where one is offered (`harn lint --fix`).
+- Suppress the lint with an attribute only when the surrounding code is intentionally non-idiomatic.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-040.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-040.md
@@ -1,0 +1,23 @@
+# HARN-LNT-040 — template parse lint
+
+**Category:** Lint (LNT)  
+**Variant:** `Code::LintTemplateParse` (lint template parse)
+
+## What it means
+
+This is a lint, not a hard error. The code compiles, but Harn flags the pattern
+as likely-incorrect, unidiomatic, or risky in a production agent. Lints can
+typically be auto-fixed.
+
+Specifically: template parse lint.
+
+## How to fix
+
+- Apply the lint's auto-fix where one is offered (`harn lint --fix`).
+- Suppress the lint with an attribute only when the surrounding code is intentionally non-idiomatic.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-041.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-041.md
@@ -1,0 +1,23 @@
+# HARN-LNT-041 — blank line between items lint
+
+**Category:** Lint (LNT)  
+**Variant:** `Code::LintBlankLineBetweenItems` (lint blank line between items)
+
+## What it means
+
+This is a lint, not a hard error. The code compiles, but Harn flags the pattern
+as likely-incorrect, unidiomatic, or risky in a production agent. Lints can
+typically be auto-fixed.
+
+Specifically: blank line between items lint.
+
+## How to fix
+
+- Apply the lint's auto-fix where one is offered (`harn lint --fix`).
+- Suppress the lint with an attribute only when the surrounding code is intentionally non-idiomatic.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-042.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-042.md
@@ -1,0 +1,23 @@
+# HARN-LNT-042 — trailing comma lint
+
+**Category:** Lint (LNT)  
+**Variant:** `Code::LintTrailingComma` (lint trailing comma)
+
+## What it means
+
+This is a lint, not a hard error. The code compiles, but Harn flags the pattern
+as likely-incorrect, unidiomatic, or risky in a production agent. Lints can
+typically be auto-fixed.
+
+Specifically: trailing comma lint.
+
+## How to fix
+
+- Apply the lint's auto-fix where one is offered (`harn lint --fix`).
+- Suppress the lint with an attribute only when the surrounding code is intentionally non-idiomatic.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-043.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-043.md
@@ -1,0 +1,23 @@
+# HARN-LNT-043 — unnecessary parentheses lint
+
+**Category:** Lint (LNT)  
+**Variant:** `Code::LintUnnecessaryParentheses` (lint unnecessary parentheses)
+
+## What it means
+
+This is a lint, not a hard error. The code compiles, but Harn flags the pattern
+as likely-incorrect, unidiomatic, or risky in a production agent. Lints can
+typically be auto-fixed.
+
+Specifically: unnecessary parentheses lint.
+
+## How to fix
+
+- Apply the lint's auto-fix where one is offered (`harn lint --fix`).
+- Suppress the lint with an attribute only when the surrounding code is intentionally non-idiomatic.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-044.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-044.md
@@ -1,0 +1,24 @@
+# HARN-LNT-044 — template variant explosion lint
+
+**Category:** Lint (LNT)  
+**Variant:** `Code::LintTemplateVariantExplosion` (lint template variant
+explosion)
+
+## What it means
+
+This is a lint, not a hard error. The code compiles, but Harn flags the pattern
+as likely-incorrect, unidiomatic, or risky in a production agent. Lints can
+typically be auto-fixed.
+
+Specifically: template variant explosion lint.
+
+## How to fix
+
+- Apply the lint's auto-fix where one is offered (`harn lint --fix`).
+- Suppress the lint with an attribute only when the surrounding code is intentionally non-idiomatic.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-045.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-045.md
@@ -1,0 +1,23 @@
+# HARN-LNT-045 — require file header lint
+
+**Category:** Lint (LNT)  
+**Variant:** `Code::LintRequireFileHeader` (lint require file header)
+
+## What it means
+
+This is a lint, not a hard error. The code compiles, but Harn flags the pattern
+as likely-incorrect, unidiomatic, or risky in a production agent. Lints can
+typically be auto-fixed.
+
+Specifically: require file header lint.
+
+## How to fix
+
+- Apply the lint's auto-fix where one is offered (`harn lint --fix`).
+- Suppress the lint with an attribute only when the surrounding code is intentionally non-idiomatic.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-046.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-046.md
@@ -1,0 +1,24 @@
+# HARN-LNT-046 — template provider identity branch lint
+
+**Category:** Lint (LNT)  
+**Variant:** `Code::LintTemplateProviderIdentityBranch` (lint template provider
+identity branch)
+
+## What it means
+
+This is a lint, not a hard error. The code compiles, but Harn flags the pattern
+as likely-incorrect, unidiomatic, or risky in a production agent. Lints can
+typically be auto-fixed.
+
+Specifically: template provider identity branch lint.
+
+## How to fix
+
+- Apply the lint's auto-fix where one is offered (`harn lint --fix`).
+- Suppress the lint with an attribute only when the surrounding code is intentionally non-idiomatic.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-047.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-047.md
@@ -1,0 +1,23 @@
+# HARN-LNT-047 — import order lint
+
+**Category:** Lint (LNT)  
+**Variant:** `Code::LintImportOrder` (lint import order)
+
+## What it means
+
+This is a lint, not a hard error. The code compiles, but Harn flags the pattern
+as likely-incorrect, unidiomatic, or risky in a production agent. Lints can
+typically be auto-fixed.
+
+Specifically: import order lint.
+
+## How to fix
+
+- Apply the lint's auto-fix where one is offered (`harn lint --fix`).
+- Suppress the lint with an attribute only when the surrounding code is intentionally non-idiomatic.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-048.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-048.md
@@ -1,0 +1,24 @@
+# HARN-LNT-048 — prefer optional shorthand lint
+
+**Category:** Lint (LNT)  
+**Variant:** `Code::LintPreferOptionalShorthand` (lint prefer optional
+shorthand)
+
+## What it means
+
+This is a lint, not a hard error. The code compiles, but Harn flags the pattern
+as likely-incorrect, unidiomatic, or risky in a production agent. Lints can
+typically be auto-fixed.
+
+Specifically: prefer optional shorthand lint.
+
+## How to fix
+
+- Apply the lint's auto-fix where one is offered (`harn lint --fix`).
+- Suppress the lint with an attribute only when the surrounding code is intentionally non-idiomatic.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-049.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-049.md
@@ -1,0 +1,23 @@
+# HARN-LNT-049 — legacy doc comment lint
+
+**Category:** Lint (LNT)  
+**Variant:** `Code::LintLegacyDocComment` (lint legacy doc comment)
+
+## What it means
+
+This is a lint, not a hard error. The code compiles, but Harn flags the pattern
+as likely-incorrect, unidiomatic, or risky in a production agent. Lints can
+typically be auto-fixed.
+
+Specifically: legacy doc comment lint.
+
+## How to fix
+
+- Apply the lint's auto-fix where one is offered (`harn lint --fix`).
+- Suppress the lint with an attribute only when the surrounding code is intentionally non-idiomatic.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-050.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-050.md
@@ -1,0 +1,23 @@
+# HARN-LNT-050 — deprecated LLM options lint
+
+**Category:** Lint (LNT)  
+**Variant:** `Code::LintDeprecatedLlmOptions` (lint deprecated llm options)
+
+## What it means
+
+This is a lint, not a hard error. The code compiles, but Harn flags the pattern
+as likely-incorrect, unidiomatic, or risky in a production agent. Lints can
+typically be auto-fixed.
+
+Specifically: deprecated LLM options lint.
+
+## How to fix
+
+- Apply the lint's auto-fix where one is offered (`harn lint --fix`).
+- Suppress the lint with an attribute only when the surrounding code is intentionally non-idiomatic.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-051.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-051.md
@@ -1,0 +1,24 @@
+# HARN-LNT-051 — unnecessary safe navigation lint
+
+**Category:** Lint (LNT)  
+**Variant:** `Code::LintUnnecessarySafeNavigation` (lint unnecessary safe
+navigation)
+
+## What it means
+
+This is a lint, not a hard error. The code compiles, but Harn flags the pattern
+as likely-incorrect, unidiomatic, or risky in a production agent. Lints can
+typically be auto-fixed.
+
+Specifically: unnecessary safe navigation lint.
+
+## How to fix
+
+- Apply the lint's auto-fix where one is offered (`harn lint --fix`).
+- Suppress the lint with an attribute only when the surrounding code is intentionally non-idiomatic.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-MAT-001.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-MAT-001.md
@@ -1,0 +1,22 @@
+# HARN-MAT-001 — match expression is not exhaustive
+
+**Category:** Pattern match (MAT)  
+**Variant:** `Code::NonExhaustiveMatch` (non exhaustive match)
+
+## What it means
+
+A `match` expression is incomplete, ambiguous, or otherwise invalid. Harn
+enforces exhaustive matching to keep agent decision logic auditable.
+
+Specifically: match expression is not exhaustive.
+
+## How to fix
+
+- Add arms covering the remaining variants, or use a wildcard `_` arm as the explicit fallback.
+- Remove duplicate arms — each variant should appear at most once.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-MAT-002.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-MAT-002.md
@@ -1,0 +1,22 @@
+# HARN-MAT-002 — match expression contains a duplicate arm
+
+**Category:** Pattern match (MAT)  
+**Variant:** `Code::DuplicateMatchArm` (duplicate match arm)
+
+## What it means
+
+A `match` expression is incomplete, ambiguous, or otherwise invalid. Harn
+enforces exhaustive matching to keep agent decision logic auditable.
+
+Specifically: match expression contains a duplicate arm.
+
+## How to fix
+
+- Add arms covering the remaining variants, or use a wildcard `_` arm as the explicit fallback.
+- Remove duplicate arms — each variant should appear at most once.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-MAT-003.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-MAT-003.md
@@ -1,0 +1,22 @@
+# HARN-MAT-003 — match pattern is invalid
+
+**Category:** Pattern match (MAT)  
+**Variant:** `Code::InvalidMatchPattern` (invalid match pattern)
+
+## What it means
+
+A `match` expression is incomplete, ambiguous, or otherwise invalid. Harn
+enforces exhaustive matching to keep agent decision logic auditable.
+
+Specifically: match pattern is invalid.
+
+## How to fix
+
+- Add arms covering the remaining variants, or use a wildcard `_` arm as the explicit fallback.
+- Remove duplicate arms — each variant should appear at most once.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-MOD-001.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-MOD-001.md
@@ -1,0 +1,23 @@
+# HARN-MOD-001 — module import cannot be resolved
+
+**Category:** Module / import (MOD)  
+**Variant:** `Code::ModuleImportUnresolved` (module import unresolved)
+
+## What it means
+
+A module-level import declaration cannot be satisfied or has been authored in a
+non-canonical form. The module graph must resolve cleanly before any further
+checks.
+
+Specifically: module import cannot be resolved.
+
+## How to fix
+
+- Confirm the import path resolves on disk and the imported symbol is exported.
+- Run `harn lint --fix` to auto-sort / dedupe import groups.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-MOD-002.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-MOD-002.md
@@ -1,0 +1,23 @@
+# HARN-MOD-002 — module import is unused
+
+**Category:** Module / import (MOD)  
+**Variant:** `Code::ModuleImportUnused` (module import unused)
+
+## What it means
+
+A module-level import declaration cannot be satisfied or has been authored in a
+non-canonical form. The module graph must resolve cleanly before any further
+checks.
+
+Specifically: module import is unused.
+
+## How to fix
+
+- Confirm the import path resolves on disk and the imported symbol is exported.
+- Run `harn lint --fix` to auto-sort / dedupe import groups.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-MOD-003.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-MOD-003.md
@@ -1,0 +1,23 @@
+# HARN-MOD-003 — module imports are not in canonical order
+
+**Category:** Module / import (MOD)  
+**Variant:** `Code::ModuleImportOrder` (module import order)
+
+## What it means
+
+A module-level import declaration cannot be satisfied or has been authored in a
+non-canonical form. The module graph must resolve cleanly before any further
+checks.
+
+Specifically: module imports are not in canonical order.
+
+## How to fix
+
+- Confirm the import path resolves on disk and the imported symbol is exported.
+- Run `harn lint --fix` to auto-sort / dedupe import groups.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-MOD-004.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-MOD-004.md
@@ -1,0 +1,23 @@
+# HARN-MOD-004 — module export is invalid
+
+**Category:** Module / import (MOD)  
+**Variant:** `Code::ModuleExportInvalid` (module export invalid)
+
+## What it means
+
+A module-level import declaration cannot be satisfied or has been authored in a
+non-canonical form. The module graph must resolve cleanly before any further
+checks.
+
+Specifically: module export is invalid.
+
+## How to fix
+
+- Confirm the import path resolves on disk and the imported symbol is exported.
+- Run `harn lint --fix` to auto-sort / dedupe import groups.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-MOD-005.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-MOD-005.md
@@ -1,0 +1,23 @@
+# HARN-MOD-005 — module imports expose colliding names
+
+**Category:** Module / import (MOD)  
+**Variant:** `Code::ModuleImportCollision` (module import collision)
+
+## What it means
+
+A module-level import declaration cannot be satisfied or has been authored in a
+non-canonical form. The module graph must resolve cleanly before any further
+checks.
+
+Specifically: module imports expose colliding names.
+
+## How to fix
+
+- Confirm the import path resolves on disk and the imported symbol is exported.
+- Run `harn lint --fix` to auto-sort / dedupe import groups.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-MOD-006.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-MOD-006.md
@@ -1,0 +1,23 @@
+# HARN-MOD-006 — module re-exports conflict
+
+**Category:** Module / import (MOD)  
+**Variant:** `Code::ModuleReExportConflict` (module re export conflict)
+
+## What it means
+
+A module-level import declaration cannot be satisfied or has been authored in a
+non-canonical form. The module graph must resolve cleanly before any further
+checks.
+
+Specifically: module re-exports conflict.
+
+## How to fix
+
+- Confirm the import path resolves on disk and the imported symbol is exported.
+- Run `harn lint --fix` to auto-sort / dedupe import groups.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-NAM-001.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-NAM-001.md
@@ -1,0 +1,23 @@
+# HARN-NAM-001 — variable name cannot be resolved
+
+**Category:** Name resolution (NAM)  
+**Variant:** `Code::UndefinedVariable` (undefined variable)
+
+## What it means
+
+Name resolution failed: the identifier, field, or attribute referenced here does
+not match anything in the visible scope. Harn cannot proceed without a binding
+for it.
+
+Specifically: variable name cannot be resolved.
+
+## How to fix
+
+- Define the missing name, import it, or fix the typo.
+- Confirm the symbol is exported by the module you're importing from.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-NAM-002.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-NAM-002.md
@@ -1,0 +1,23 @@
+# HARN-NAM-002 — function name cannot be resolved
+
+**Category:** Name resolution (NAM)  
+**Variant:** `Code::UndefinedFunction` (undefined function)
+
+## What it means
+
+Name resolution failed: the identifier, field, or attribute referenced here does
+not match anything in the visible scope. Harn cannot proceed without a binding
+for it.
+
+Specifically: function name cannot be resolved.
+
+## How to fix
+
+- Define the missing name, import it, or fix the typo.
+- Confirm the symbol is exported by the module you're importing from.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-NAM-003.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-NAM-003.md
@@ -1,0 +1,23 @@
+# HARN-NAM-003 — attribute name is not recognized
+
+**Category:** Name resolution (NAM)  
+**Variant:** `Code::UnknownAttribute` (unknown attribute)
+
+## What it means
+
+Name resolution failed: the identifier, field, or attribute referenced here does
+not match anything in the visible scope. Harn cannot proceed without a binding
+for it.
+
+Specifically: attribute name is not recognized.
+
+## How to fix
+
+- Define the missing name, import it, or fix the typo.
+- Confirm the symbol is exported by the module you're importing from.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-NAM-004.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-NAM-004.md
@@ -1,0 +1,23 @@
+# HARN-NAM-004 — field name does not exist on the target type
+
+**Category:** Name resolution (NAM)  
+**Variant:** `Code::UnknownField` (unknown field)
+
+## What it means
+
+Name resolution failed: the identifier, field, or attribute referenced here does
+not match anything in the visible scope. Harn cannot proceed without a binding
+for it.
+
+Specifically: field name does not exist on the target type.
+
+## How to fix
+
+- Define the missing name, import it, or fix the typo.
+- Confirm the symbol is exported by the module you're importing from.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-NAM-005.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-NAM-005.md
@@ -1,0 +1,23 @@
+# HARN-NAM-005 — method name does not exist on the receiver type
+
+**Category:** Name resolution (NAM)  
+**Variant:** `Code::UnknownMethod` (unknown method)
+
+## What it means
+
+Name resolution failed: the identifier, field, or attribute referenced here does
+not match anything in the visible scope. Harn cannot proceed without a binding
+for it.
+
+Specifically: method name does not exist on the receiver type.
+
+## How to fix
+
+- Define the missing name, import it, or fix the typo.
+- Confirm the symbol is exported by the module you're importing from.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-NAM-006.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-NAM-006.md
@@ -1,0 +1,23 @@
+# HARN-NAM-006 — argument name is duplicated
+
+**Category:** Name resolution (NAM)  
+**Variant:** `Code::DuplicateArgument` (duplicate argument)
+
+## What it means
+
+Name resolution failed: the identifier, field, or attribute referenced here does
+not match anything in the visible scope. Harn cannot proceed without a binding
+for it.
+
+Specifically: argument name is duplicated.
+
+## How to fix
+
+- Define the missing name, import it, or fix the typo.
+- Confirm the symbol is exported by the module you're importing from.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-NAM-007.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-NAM-007.md
@@ -1,0 +1,23 @@
+# HARN-NAM-007 — option key is not recognized
+
+**Category:** Name resolution (NAM)  
+**Variant:** `Code::UnknownOption` (unknown option)
+
+## What it means
+
+Name resolution failed: the identifier, field, or attribute referenced here does
+not match anything in the visible scope. Harn cannot proceed without a binding
+for it.
+
+Specifically: option key is not recognized.
+
+## How to fix
+
+- Define the missing name, import it, or fix the typo.
+- Confirm the symbol is exported by the module you're importing from.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-NAM-008.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-NAM-008.md
@@ -1,0 +1,23 @@
+# HARN-NAM-008 — builtin name cannot be resolved
+
+**Category:** Name resolution (NAM)  
+**Variant:** `Code::UnknownBuiltin` (unknown builtin)
+
+## What it means
+
+Name resolution failed: the identifier, field, or attribute referenced here does
+not match anything in the visible scope. Harn cannot proceed without a binding
+for it.
+
+Specifically: builtin name cannot be resolved.
+
+## How to fix
+
+- Define the missing name, import it, or fix the typo.
+- Confirm the symbol is exported by the module you're importing from.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-NAM-009.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-NAM-009.md
@@ -1,0 +1,23 @@
+# HARN-NAM-009 — function call targets a deprecated declaration
+
+**Category:** Name resolution (NAM)  
+**Variant:** `Code::DeprecatedFunction` (deprecated function)
+
+## What it means
+
+Name resolution failed: the identifier, field, or attribute referenced here does
+not match anything in the visible scope. Harn cannot proceed without a binding
+for it.
+
+Specifically: function call targets a deprecated declaration.
+
+## How to fix
+
+- Define the missing name, import it, or fix the typo.
+- Confirm the symbol is exported by the module you're importing from.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-NAM-010.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-NAM-010.md
@@ -1,0 +1,23 @@
+# HARN-NAM-010 — declaration reference cannot be resolved
+
+**Category:** Name resolution (NAM)  
+**Variant:** `Code::UnknownDeclaration` (unknown declaration)
+
+## What it means
+
+Name resolution failed: the identifier, field, or attribute referenced here does
+not match anything in the visible scope. Harn cannot proceed without a binding
+for it.
+
+Specifically: declaration reference cannot be resolved.
+
+## How to fix
+
+- Define the missing name, import it, or fix the typo.
+- Confirm the symbol is exported by the module you're importing from.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-NAM-011.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-NAM-011.md
@@ -1,0 +1,23 @@
+# HARN-NAM-011 — attribute is attached to an unsupported declaration
+
+**Category:** Name resolution (NAM)  
+**Variant:** `Code::InvalidAttributeTarget` (invalid attribute target)
+
+## What it means
+
+Name resolution failed: the identifier, field, or attribute referenced here does
+not match anything in the visible scope. Harn cannot proceed without a binding
+for it.
+
+Specifically: attribute is attached to an unsupported declaration.
+
+## How to fix
+
+- Define the missing name, import it, or fix the typo.
+- Confirm the symbol is exported by the module you're importing from.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-NAM-012.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-NAM-012.md
@@ -1,0 +1,23 @@
+# HARN-NAM-012 — attribute argument is invalid
+
+**Category:** Name resolution (NAM)  
+**Variant:** `Code::InvalidAttributeArgument` (invalid attribute argument)
+
+## What it means
+
+Name resolution failed: the identifier, field, or attribute referenced here does
+not match anything in the visible scope. Harn cannot proceed without a binding
+for it.
+
+Specifically: attribute argument is invalid.
+
+## How to fix
+
+- Define the missing name, import it, or fix the typo.
+- Confirm the symbol is exported by the module you're importing from.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-ORC-001.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-ORC-001.md
@@ -1,0 +1,23 @@
+# HARN-ORC-001 — orchestration construct has invalid arity
+
+**Category:** Orchestration (ORC)  
+**Variant:** `Code::OrchestrationArity` (orchestration arity)
+
+## What it means
+
+An orchestration construct — agent / workflow / pipeline / tool definition, or a
+`select` block — does not satisfy the structural rules Harn enforces. These
+constructs carry runtime semantics that depend on a small set of well-formed
+shapes.
+
+Specifically: orchestration construct has invalid arity.
+
+## How to fix
+
+- Re-read the orchestration construct's spec section and align the arity / type / structure.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-ORC-002.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-ORC-002.md
@@ -1,0 +1,23 @@
+# HARN-ORC-002 — orchestration construct argument has invalid type
+
+**Category:** Orchestration (ORC)  
+**Variant:** `Code::OrchestrationType` (orchestration type)
+
+## What it means
+
+An orchestration construct — agent / workflow / pipeline / tool definition, or a
+`select` block — does not satisfy the structural rules Harn enforces. These
+constructs carry runtime semantics that depend on a small set of well-formed
+shapes.
+
+Specifically: orchestration construct argument has invalid type.
+
+## How to fix
+
+- Re-read the orchestration construct's spec section and align the arity / type / structure.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-ORC-003.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-ORC-003.md
@@ -1,0 +1,23 @@
+# HARN-ORC-003 — agent declaration is invalid
+
+**Category:** Orchestration (ORC)  
+**Variant:** `Code::AgentDefinitionInvalid` (agent definition invalid)
+
+## What it means
+
+An orchestration construct — agent / workflow / pipeline / tool definition, or a
+`select` block — does not satisfy the structural rules Harn enforces. These
+constructs carry runtime semantics that depend on a small set of well-formed
+shapes.
+
+Specifically: agent declaration is invalid.
+
+## How to fix
+
+- Re-read the orchestration construct's spec section and align the arity / type / structure.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-ORC-004.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-ORC-004.md
@@ -1,0 +1,23 @@
+# HARN-ORC-004 — workflow declaration is invalid
+
+**Category:** Orchestration (ORC)  
+**Variant:** `Code::WorkflowDefinitionInvalid` (workflow definition invalid)
+
+## What it means
+
+An orchestration construct — agent / workflow / pipeline / tool definition, or a
+`select` block — does not satisfy the structural rules Harn enforces. These
+constructs carry runtime semantics that depend on a small set of well-formed
+shapes.
+
+Specifically: workflow declaration is invalid.
+
+## How to fix
+
+- Re-read the orchestration construct's spec section and align the arity / type / structure.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-ORC-005.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-ORC-005.md
@@ -1,0 +1,23 @@
+# HARN-ORC-005 — tool declaration is invalid
+
+**Category:** Orchestration (ORC)  
+**Variant:** `Code::ToolDefinitionInvalid` (tool definition invalid)
+
+## What it means
+
+An orchestration construct — agent / workflow / pipeline / tool definition, or a
+`select` block — does not satisfy the structural rules Harn enforces. These
+constructs carry runtime semantics that depend on a small set of well-formed
+shapes.
+
+Specifically: tool declaration is invalid.
+
+## How to fix
+
+- Re-read the orchestration construct's spec section and align the arity / type / structure.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-ORC-006.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-ORC-006.md
@@ -1,0 +1,23 @@
+# HARN-ORC-006 — pipeline declaration is invalid
+
+**Category:** Orchestration (ORC)  
+**Variant:** `Code::PipelineDefinitionInvalid` (pipeline definition invalid)
+
+## What it means
+
+An orchestration construct — agent / workflow / pipeline / tool definition, or a
+`select` block — does not satisfy the structural rules Harn enforces. These
+constructs carry runtime semantics that depend on a small set of well-formed
+shapes.
+
+Specifically: pipeline declaration is invalid.
+
+## How to fix
+
+- Re-read the orchestration construct's spec section and align the arity / type / structure.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-ORC-007.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-ORC-007.md
@@ -1,0 +1,23 @@
+# HARN-ORC-007 — select construct is invalid
+
+**Category:** Orchestration (ORC)  
+**Variant:** `Code::InvalidSelectConstruct` (invalid select construct)
+
+## What it means
+
+An orchestration construct — agent / workflow / pipeline / tool definition, or a
+`select` block — does not satisfy the structural rules Harn enforces. These
+constructs carry runtime semantics that depend on a small set of well-formed
+shapes.
+
+Specifically: select construct is invalid.
+
+## How to fix
+
+- Re-read the orchestration construct's spec section and align the arity / type / structure.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-ORC-008.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-ORC-008.md
@@ -1,0 +1,23 @@
+# HARN-ORC-008 — statement cannot be reached
+
+**Category:** Orchestration (ORC)  
+**Variant:** `Code::UnreachableCode` (unreachable code)
+
+## What it means
+
+An orchestration construct — agent / workflow / pipeline / tool definition, or a
+`select` block — does not satisfy the structural rules Harn enforces. These
+constructs carry runtime semantics that depend on a small set of well-formed
+shapes.
+
+Specifically: statement cannot be reached.
+
+## How to fix
+
+- Re-read the orchestration construct's spec section and align the arity / type / structure.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-ORC-009.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-ORC-009.md
@@ -1,0 +1,24 @@
+# HARN-ORC-009 — Flow invariant attribute set is invalid
+
+**Category:** Orchestration (ORC)  
+**Variant:** `Code::FlowInvariantAttributeInvalid` (flow invariant attribute
+invalid)
+
+## What it means
+
+An orchestration construct — agent / workflow / pipeline / tool definition, or a
+`select` block — does not satisfy the structural rules Harn enforces. These
+constructs carry runtime semantics that depend on a small set of well-formed
+shapes.
+
+Specifically: Flow invariant attribute set is invalid.
+
+## How to fix
+
+- Re-read the orchestration construct's spec section and align the arity / type / structure.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-ORC-010.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-ORC-010.md
@@ -1,0 +1,23 @@
+# HARN-ORC-010 — execution target path cannot be found
+
+**Category:** Orchestration (ORC)  
+**Variant:** `Code::ExecutionTargetMissing` (execution target missing)
+
+## What it means
+
+An orchestration construct — agent / workflow / pipeline / tool definition, or a
+`select` block — does not satisfy the structural rules Harn enforces. These
+constructs carry runtime semantics that depend on a small set of well-formed
+shapes.
+
+Specifically: execution target path cannot be found.
+
+## How to fix
+
+- Re-read the orchestration construct's spec section and align the arity / type / structure.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-OWN-001.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-OWN-001.md
@@ -1,0 +1,23 @@
+# HARN-OWN-001 — immutable binding is reassigned
+
+**Category:** Ownership / mutability (OWN)  
+**Variant:** `Code::ImmutableAssignment` (immutable assignment)
+
+## What it means
+
+Harn's binding-and-mutability discipline rejects this usage. Bindings declared
+`let` may not be reassigned; bindings declared `mut` should actually be
+reassigned somewhere.
+
+Specifically: immutable binding is reassigned.
+
+## How to fix
+
+- Switch the binding kind (`let` ↔ `mut`) to match its actual use.
+- Restructure so owned values do not escape their scope.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-OWN-002.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-OWN-002.md
@@ -1,0 +1,23 @@
+# HARN-OWN-002 — mutable binding is never reassigned
+
+**Category:** Ownership / mutability (OWN)  
+**Variant:** `Code::MutableNeverReassigned` (mutable never reassigned)
+
+## What it means
+
+Harn's binding-and-mutability discipline rejects this usage. Bindings declared
+`let` may not be reassigned; bindings declared `mut` should actually be
+reassigned somewhere.
+
+Specifically: mutable binding is never reassigned.
+
+## How to fix
+
+- Switch the binding kind (`let` ↔ `mut`) to match its actual use.
+- Restructure so owned values do not escape their scope.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-OWN-003.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-OWN-003.md
@@ -1,0 +1,23 @@
+# HARN-OWN-003 — owned value escapes its valid scope
+
+**Category:** Ownership / mutability (OWN)  
+**Variant:** `Code::OwnershipEscape` (ownership escape)
+
+## What it means
+
+Harn's binding-and-mutability discipline rejects this usage. Bindings declared
+`let` may not be reassigned; bindings declared `mut` should actually be
+reassigned somewhere.
+
+Specifically: owned value escapes its valid scope.
+
+## How to fix
+
+- Switch the binding kind (`let` ↔ `mut`) to match its actual use.
+- Restructure so owned values do not escape their scope.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-OWN-004.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-OWN-004.md
@@ -1,0 +1,23 @@
+# HARN-OWN-004 — unvalidated boundary value is used directly
+
+**Category:** Ownership / mutability (OWN)  
+**Variant:** `Code::BoundaryValueUnvalidated` (boundary value unvalidated)
+
+## What it means
+
+Harn's binding-and-mutability discipline rejects this usage. Bindings declared
+`let` may not be reassigned; bindings declared `mut` should actually be
+reassigned somewhere.
+
+Specifically: unvalidated boundary value is used directly.
+
+## How to fix
+
+- Switch the binding kind (`let` ↔ `mut`) to match its actual use.
+- Restructure so owned values do not escape their scope.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-PAR-001.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-PAR-001.md
@@ -1,0 +1,22 @@
+# HARN-PAR-001 — parser found an unexpected token
+
+**Category:** Parser (PAR)  
+**Variant:** `Code::ParserUnexpectedToken` (parser unexpected token)
+
+## What it means
+
+The lexer or parser raises this before type checking even starts. Harn cannot
+build an AST from the source until the offending token sequence is repaired.
+
+Specifically: parser found an unexpected token.
+
+## How to fix
+
+- Re-read the source around the highlighted span and restore the missing token(s).
+- If the surrounding construct is a multi-line expression, check brace / bracket balance.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-PAR-002.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-PAR-002.md
@@ -1,0 +1,22 @@
+# HARN-PAR-002 — parser reached end of file while expecting syntax
+
+**Category:** Parser (PAR)  
+**Variant:** `Code::ParserUnexpectedEof` (parser unexpected eof)
+
+## What it means
+
+The lexer or parser raises this before type checking even starts. Harn cannot
+build an AST from the source until the offending token sequence is repaired.
+
+Specifically: parser reached end of file while expecting syntax.
+
+## How to fix
+
+- Re-read the source around the highlighted span and restore the missing token(s).
+- If the surrounding construct is a multi-line expression, check brace / bracket balance.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-PAR-003.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-PAR-003.md
@@ -1,0 +1,22 @@
+# HARN-PAR-003 — lexer found an unexpected character
+
+**Category:** Parser (PAR)  
+**Variant:** `Code::ParserUnexpectedCharacter` (parser unexpected character)
+
+## What it means
+
+The lexer or parser raises this before type checking even starts. Harn cannot
+build an AST from the source until the offending token sequence is repaired.
+
+Specifically: lexer found an unexpected character.
+
+## How to fix
+
+- Re-read the source around the highlighted span and restore the missing token(s).
+- If the surrounding construct is a multi-line expression, check brace / bracket balance.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-PAR-004.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-PAR-004.md
@@ -1,0 +1,22 @@
+# HARN-PAR-004 — string literal is unterminated
+
+**Category:** Parser (PAR)  
+**Variant:** `Code::ParserUnterminatedString` (parser unterminated string)
+
+## What it means
+
+The lexer or parser raises this before type checking even starts. Harn cannot
+build an AST from the source until the offending token sequence is repaired.
+
+Specifically: string literal is unterminated.
+
+## How to fix
+
+- Re-read the source around the highlighted span and restore the missing token(s).
+- If the surrounding construct is a multi-line expression, check brace / bracket balance.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-PAR-005.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-PAR-005.md
@@ -1,0 +1,23 @@
+# HARN-PAR-005 — block comment is unterminated
+
+**Category:** Parser (PAR)  
+**Variant:** `Code::ParserUnterminatedBlockComment` (parser unterminated block
+comment)
+
+## What it means
+
+The lexer or parser raises this before type checking even starts. Harn cannot
+build an AST from the source until the offending token sequence is repaired.
+
+Specifically: block comment is unterminated.
+
+## How to fix
+
+- Re-read the source around the highlighted span and restore the missing token(s).
+- If the surrounding construct is a multi-line expression, check brace / bracket balance.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-PRM-001.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-PRM-001.md
@@ -1,0 +1,23 @@
+# HARN-PRM-001 — prompt template cannot be parsed
+
+**Category:** Prompt template (PRM)  
+**Variant:** `Code::PromptTemplateParse` (prompt template parse)
+
+## What it means
+
+A prompt template (`.harn.prompt` / `.prompt`) failed validation, either because
+the template body is malformed or because it references the model surface in a
+way that violates Harn's prompt safety rules.
+
+Specifically: prompt template cannot be parsed.
+
+## How to fix
+
+- Fix the template syntax (`{{ }}`, `{% %}` are the only structural delimiters).
+- Replace identity-based branching with capability flags from the LLM call options.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-PRM-002.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-PRM-002.md
@@ -1,0 +1,23 @@
+# HARN-PRM-002 — prompt template has too many capability-aware branches
+
+**Category:** Prompt template (PRM)  
+**Variant:** `Code::PromptVariantExplosion` (prompt variant explosion)
+
+## What it means
+
+A prompt template (`.harn.prompt` / `.prompt`) failed validation, either because
+the template body is malformed or because it references the model surface in a
+way that violates Harn's prompt safety rules.
+
+Specifically: prompt template has too many capability-aware branches.
+
+## How to fix
+
+- Fix the template syntax (`{{ }}`, `{% %}` are the only structural delimiters).
+- Replace identity-based branching with capability flags from the LLM call options.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-PRM-003.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-PRM-003.md
@@ -1,0 +1,23 @@
+# HARN-PRM-003 — prompt construction risks direct injection
+
+**Category:** Prompt template (PRM)  
+**Variant:** `Code::PromptInjectionRisk` (prompt injection risk)
+
+## What it means
+
+A prompt template (`.harn.prompt` / `.prompt`) failed validation, either because
+the template body is malformed or because it references the model surface in a
+way that violates Harn's prompt safety rules.
+
+Specifically: prompt construction risks direct injection.
+
+## How to fix
+
+- Fix the template syntax (`{{ }}`, `{% %}` are the only structural delimiters).
+- Replace identity-based branching with capability flags from the LLM call options.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-PRM-004.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-PRM-004.md
@@ -1,0 +1,24 @@
+# HARN-PRM-004 — prompt template branches on provider identity
+
+**Category:** Prompt template (PRM)  
+**Variant:** `Code::PromptProviderIdentityBranch` (prompt provider identity
+branch)
+
+## What it means
+
+A prompt template (`.harn.prompt` / `.prompt`) failed validation, either because
+the template body is malformed or because it references the model surface in a
+way that violates Harn's prompt safety rules.
+
+Specifically: prompt template branches on provider identity.
+
+## How to fix
+
+- Fix the template syntax (`{{ }}`, `{% %}` are the only structural delimiters).
+- Replace identity-based branching with capability flags from the LLM call options.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-PRM-005.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-PRM-005.md
@@ -1,0 +1,23 @@
+# HARN-PRM-005 — prompt references a tool outside the declared surface
+
+**Category:** Prompt template (PRM)  
+**Variant:** `Code::PromptToolSurfaceUnknown` (prompt tool surface unknown)
+
+## What it means
+
+A prompt template (`.harn.prompt` / `.prompt`) failed validation, either because
+the template body is malformed or because it references the model surface in a
+way that violates Harn's prompt safety rules.
+
+Specifically: prompt references a tool outside the declared surface.
+
+## How to fix
+
+- Fix the template syntax (`{{ }}`, `{% %}` are the only structural delimiters).
+- Replace identity-based branching with capability flags from the LLM call options.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-PRM-006.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-PRM-006.md
@@ -1,0 +1,24 @@
+# HARN-PRM-006 — prompt references a deferred tool without tool search
+
+**Category:** Prompt template (PRM)  
+**Variant:** `Code::PromptToolSurfaceDeferredReference` (prompt tool surface
+deferred reference)
+
+## What it means
+
+A prompt template (`.harn.prompt` / `.prompt`) failed validation, either because
+the template body is malformed or because it references the model surface in a
+way that violates Harn's prompt safety rules.
+
+Specifically: prompt references a deferred tool without tool search.
+
+## How to fix
+
+- Fix the template syntax (`{{ }}`, `{% %}` are the only structural delimiters).
+- Replace identity-based branching with capability flags from the LLM call options.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-PRM-007.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-PRM-007.md
@@ -1,0 +1,23 @@
+# HARN-PRM-007 — prompt or template target cannot be found
+
+**Category:** Prompt template (PRM)  
+**Variant:** `Code::PromptTargetMissing` (prompt target missing)
+
+## What it means
+
+A prompt template (`.harn.prompt` / `.prompt`) failed validation, either because
+the template body is malformed or because it references the model surface in a
+way that violates Harn's prompt safety rules.
+
+Specifically: prompt or template target cannot be found.
+
+## How to fix
+
+- Fix the template syntax (`{{ }}`, `{% %}` are the only structural delimiters).
+- Replace identity-based branching with capability flags from the LLM call options.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-RCV-001.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-RCV-001.md
@@ -1,0 +1,22 @@
+# HARN-RCV-001 — rescue construct is outside a function body
+
+**Category:** Recovery (try / rescue) (RCV)  
+**Variant:** `Code::RescueOutsideFunction` (rescue outside function)
+
+## What it means
+
+A recovery construct (`try`, `rescue`) is in an invalid position or is shaped in
+a way Harn's structured-error handling does not support.
+
+Specifically: rescue construct is outside a function body.
+
+## How to fix
+
+- Move the construct inside a function body, or wrap it in one.
+- Use `try` / `rescue` only around expressions that can produce structured errors.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-RCV-002.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-RCV-002.md
@@ -1,0 +1,22 @@
+# HARN-RCV-002 — try construct is outside a function body
+
+**Category:** Recovery (try / rescue) (RCV)  
+**Variant:** `Code::TryOutsideFunction` (try outside function)
+
+## What it means
+
+A recovery construct (`try`, `rescue`) is in an invalid position or is shaped in
+a way Harn's structured-error handling does not support.
+
+Specifically: try construct is outside a function body.
+
+## How to fix
+
+- Move the construct inside a function body, or wrap it in one.
+- Use `try` / `rescue` only around expressions that can produce structured errors.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-RCV-003.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-RCV-003.md
@@ -1,0 +1,22 @@
+# HARN-RCV-003 — rescue construct is invalid
+
+**Category:** Recovery (try / rescue) (RCV)  
+**Variant:** `Code::InvalidRescueConstruct` (invalid rescue construct)
+
+## What it means
+
+A recovery construct (`try`, `rescue`) is in an invalid position or is shaped in
+a way Harn's structured-error handling does not support.
+
+Specifically: rescue construct is invalid.
+
+## How to fix
+
+- Move the construct inside a function body, or wrap it in one.
+- Use `try` / `rescue` only around expressions that can produce structured errors.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-STD-001.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-STD-001.md
@@ -1,0 +1,22 @@
+# HARN-STD-001 — stdlib symbol has been renamed or deprecated
+
+**Category:** Stdlib (STD)  
+**Variant:** `Code::DeprecatedStdlibSymbol` (deprecated stdlib symbol)
+
+## What it means
+
+A stdlib symbol is being used in a way Harn does not support, or has been
+renamed / deprecated since the script was written. The stdlib is the live source
+of truth for what's available.
+
+Specifically: stdlib symbol has been renamed or deprecated.
+
+## How to fix
+
+- Switch to the supported / renamed stdlib API listed in the diagnostic help text.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-STD-002.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-STD-002.md
@@ -1,0 +1,22 @@
+# HARN-STD-002 — stdlib call is invalid
+
+**Category:** Stdlib (STD)  
+**Variant:** `Code::StdlibUsageInvalid` (stdlib usage invalid)
+
+## What it means
+
+A stdlib symbol is being used in a way Harn does not support, or has been
+renamed / deprecated since the script was written. The stdlib is the live source
+of truth for what's available.
+
+Specifically: stdlib call is invalid.
+
+## How to fix
+
+- Switch to the supported / renamed stdlib API listed in the diagnostic help text.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-STD-003.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-STD-003.md
@@ -1,0 +1,22 @@
+# HARN-STD-003 — builtin call has invalid arity
+
+**Category:** Stdlib (STD)  
+**Variant:** `Code::BuiltinArity` (builtin arity)
+
+## What it means
+
+A stdlib symbol is being used in a way Harn does not support, or has been
+renamed / deprecated since the script was written. The stdlib is the live source
+of truth for what's available.
+
+Specifically: builtin call has invalid arity.
+
+## How to fix
+
+- Switch to the supported / renamed stdlib API listed in the diagnostic help text.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-TYP-001.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-TYP-001.md
@@ -1,0 +1,36 @@
+# HARN-TYP-001 — expected and actual types are incompatible
+
+**Category:** Type checker (TYP)
+**Variant:** `Code::TypeMismatch`
+
+## What it means
+
+Harn's type checker compared the inferred ("actual") type of an expression
+against the type the surrounding context expects, and the two did not unify.
+This is the most common type error — it covers any mismatch that doesn't fall
+into one of the more specific TYP codes (assignment, argument, return, etc.).
+
+## How to fix
+
+- Adjust the expression so its inferred type matches the surrounding
+  context.
+- Widen the declared type at the binding / parameter / return position to
+  accept the actual type.
+- Convert the value explicitly (`as`, a stdlib coercion, etc.) when a safe
+  conversion exists.
+- If the mismatch is between a concrete type and an optional, use
+  `?`-chaining or supply a default with `??`.
+
+## See also
+
+- HARN-TYP-004 — return-type mismatch.
+- HARN-TYP-005 — assignment-type mismatch.
+- HARN-TYP-006 — argument-type mismatch.
+- HARN-TYP-007 — let-binding initializer type mismatch.
+- HARN-TYP-009 — struct-field type mismatch.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-TYP-002.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-TYP-002.md
@@ -1,0 +1,24 @@
+# HARN-TYP-002 — binary operator is not defined for the operand types
+
+**Category:** Type checker (TYP)  
+**Variant:** `Code::InvalidBinaryOperator` (invalid binary operator)
+
+## What it means
+
+Harn's static type checker reports this when it cannot reconcile the types
+involved at this position. Type errors block compilation — Harn refuses to run a
+program whose types do not line up.
+
+Specifically: binary operator is not defined for the operand types.
+
+## How to fix
+
+- Adjust the expression so its inferred type matches the surrounding context.
+- Widen the declared type at the binding / parameter / return position to accept the actual type.
+- Convert the value explicitly (`as`, a stdlib coercion, etc.) when a safe conversion exists.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-TYP-003.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-TYP-003.md
@@ -1,0 +1,24 @@
+# HARN-TYP-003 — string concatenation should be rewritten as interpolation
+
+**Category:** Type checker (TYP)  
+**Variant:** `Code::StringInterpolationRewrite` (string interpolation rewrite)
+
+## What it means
+
+Harn's static type checker reports this when it cannot reconcile the types
+involved at this position. Type errors block compilation — Harn refuses to run a
+program whose types do not line up.
+
+Specifically: string concatenation should be rewritten as interpolation.
+
+## How to fix
+
+- Adjust the expression so its inferred type matches the surrounding context.
+- Widen the declared type at the binding / parameter / return position to accept the actual type.
+- Convert the value explicitly (`as`, a stdlib coercion, etc.) when a safe conversion exists.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-TYP-004.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-TYP-004.md
@@ -1,0 +1,24 @@
+# HARN-TYP-004 — returned expression does not match the declared return type
+
+**Category:** Type checker (TYP)  
+**Variant:** `Code::ReturnTypeMismatch` (return type mismatch)
+
+## What it means
+
+Harn's static type checker reports this when it cannot reconcile the types
+involved at this position. Type errors block compilation — Harn refuses to run a
+program whose types do not line up.
+
+Specifically: returned expression does not match the declared return type.
+
+## How to fix
+
+- Adjust the expression so its inferred type matches the surrounding context.
+- Widen the declared type at the binding / parameter / return position to accept the actual type.
+- Convert the value explicitly (`as`, a stdlib coercion, etc.) when a safe conversion exists.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-TYP-005.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-TYP-005.md
@@ -1,0 +1,24 @@
+# HARN-TYP-005 — assigned value does not match the target type
+
+**Category:** Type checker (TYP)  
+**Variant:** `Code::AssignmentTypeMismatch` (assignment type mismatch)
+
+## What it means
+
+Harn's static type checker reports this when it cannot reconcile the types
+involved at this position. Type errors block compilation — Harn refuses to run a
+program whose types do not line up.
+
+Specifically: assigned value does not match the target type.
+
+## How to fix
+
+- Adjust the expression so its inferred type matches the surrounding context.
+- Widen the declared type at the binding / parameter / return position to accept the actual type.
+- Convert the value explicitly (`as`, a stdlib coercion, etc.) when a safe conversion exists.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-TYP-006.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-TYP-006.md
@@ -1,0 +1,24 @@
+# HARN-TYP-006 — argument value does not match the parameter type
+
+**Category:** Type checker (TYP)  
+**Variant:** `Code::ArgumentTypeMismatch` (argument type mismatch)
+
+## What it means
+
+Harn's static type checker reports this when it cannot reconcile the types
+involved at this position. Type errors block compilation — Harn refuses to run a
+program whose types do not line up.
+
+Specifically: argument value does not match the parameter type.
+
+## How to fix
+
+- Adjust the expression so its inferred type matches the surrounding context.
+- Widen the declared type at the binding / parameter / return position to accept the actual type.
+- Convert the value explicitly (`as`, a stdlib coercion, etc.) when a safe conversion exists.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-TYP-007.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-TYP-007.md
@@ -1,0 +1,24 @@
+# HARN-TYP-007 — initializer does not match the declared variable type
+
+**Category:** Type checker (TYP)  
+**Variant:** `Code::VariableTypeMismatch` (variable type mismatch)
+
+## What it means
+
+Harn's static type checker reports this when it cannot reconcile the types
+involved at this position. Type errors block compilation — Harn refuses to run a
+program whose types do not line up.
+
+Specifically: initializer does not match the declared variable type.
+
+## How to fix
+
+- Adjust the expression so its inferred type matches the surrounding context.
+- Widen the declared type at the binding / parameter / return position to accept the actual type.
+- Convert the value explicitly (`as`, a stdlib coercion, etc.) when a safe conversion exists.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-TYP-008.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-TYP-008.md
@@ -1,0 +1,24 @@
+# HARN-TYP-008 — closure return expression does not match its declared type
+
+**Category:** Type checker (TYP)  
+**Variant:** `Code::ClosureReturnTypeMismatch` (closure return type mismatch)
+
+## What it means
+
+Harn's static type checker reports this when it cannot reconcile the types
+involved at this position. Type errors block compilation — Harn refuses to run a
+program whose types do not line up.
+
+Specifically: closure return expression does not match its declared type.
+
+## How to fix
+
+- Adjust the expression so its inferred type matches the surrounding context.
+- Widen the declared type at the binding / parameter / return position to accept the actual type.
+- Convert the value explicitly (`as`, a stdlib coercion, etc.) when a safe conversion exists.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-TYP-009.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-TYP-009.md
@@ -1,0 +1,24 @@
+# HARN-TYP-009 — field value does not match its declared type
+
+**Category:** Type checker (TYP)  
+**Variant:** `Code::FieldTypeMismatch` (field type mismatch)
+
+## What it means
+
+Harn's static type checker reports this when it cannot reconcile the types
+involved at this position. Type errors block compilation — Harn refuses to run a
+program whose types do not line up.
+
+Specifically: field value does not match its declared type.
+
+## How to fix
+
+- Adjust the expression so its inferred type matches the surrounding context.
+- Widen the declared type at the binding / parameter / return position to accept the actual type.
+- Convert the value explicitly (`as`, a stdlib coercion, etc.) when a safe conversion exists.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-TYP-010.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-TYP-010.md
@@ -1,0 +1,24 @@
+# HARN-TYP-010 — method receiver or result type is incompatible
+
+**Category:** Type checker (TYP)  
+**Variant:** `Code::MethodTypeMismatch` (method type mismatch)
+
+## What it means
+
+Harn's static type checker reports this when it cannot reconcile the types
+involved at this position. Type errors block compilation — Harn refuses to run a
+program whose types do not line up.
+
+Specifically: method receiver or result type is incompatible.
+
+## How to fix
+
+- Adjust the expression so its inferred type matches the surrounding context.
+- Widen the declared type at the binding / parameter / return position to accept the actual type.
+- Convert the value explicitly (`as`, a stdlib coercion, etc.) when a safe conversion exists.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-TYP-011.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-TYP-011.md
@@ -1,0 +1,25 @@
+# HARN-TYP-011 — callable does not accept type arguments
+
+**Category:** Type checker (TYP)  
+**Variant:** `Code::GenericTypeArgumentUnsupported` (generic type argument
+unsupported)
+
+## What it means
+
+Harn's static type checker reports this when it cannot reconcile the types
+involved at this position. Type errors block compilation — Harn refuses to run a
+program whose types do not line up.
+
+Specifically: callable does not accept type arguments.
+
+## How to fix
+
+- Adjust the expression so its inferred type matches the surrounding context.
+- Widen the declared type at the binding / parameter / return position to accept the actual type.
+- Convert the value explicitly (`as`, a stdlib coercion, etc.) when a safe conversion exists.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-TYP-012.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-TYP-012.md
@@ -1,0 +1,25 @@
+# HARN-TYP-012 — type argument does not satisfy the generic parameter
+
+**Category:** Type checker (TYP)  
+**Variant:** `Code::GenericTypeArgumentMismatch` (generic type argument
+mismatch)
+
+## What it means
+
+Harn's static type checker reports this when it cannot reconcile the types
+involved at this position. Type errors block compilation — Harn refuses to run a
+program whose types do not line up.
+
+Specifically: type argument does not satisfy the generic parameter.
+
+## How to fix
+
+- Adjust the expression so its inferred type matches the surrounding context.
+- Widen the declared type at the binding / parameter / return position to accept the actual type.
+- Convert the value explicitly (`as`, a stdlib coercion, etc.) when a safe conversion exists.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-TYP-013.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-TYP-013.md
@@ -1,0 +1,24 @@
+# HARN-TYP-013 — generic call has the wrong number of type arguments
+
+**Category:** Type checker (TYP)  
+**Variant:** `Code::GenericTypeArgumentArity` (generic type argument arity)
+
+## What it means
+
+Harn's static type checker reports this when it cannot reconcile the types
+involved at this position. Type errors block compilation — Harn refuses to run a
+program whose types do not line up.
+
+Specifically: generic call has the wrong number of type arguments.
+
+## How to fix
+
+- Adjust the expression so its inferred type matches the surrounding context.
+- Widen the declared type at the binding / parameter / return position to accept the actual type.
+- Convert the value explicitly (`as`, a stdlib coercion, etc.) when a safe conversion exists.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-TYP-014.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-TYP-014.md
@@ -1,0 +1,40 @@
+# HARN-TYP-014 — declaration has the wrong number of type parameters
+
+**Category:** Type checker (TYP)
+**Variant:** `Code::TypeParameterArity`
+
+## What it means
+
+A generic declaration (function, type alias, or struct) was written with a
+different number of type parameters than the use-site supplies. Harn refuses
+to silently fill in missing parameters or discard extra ones — the count must
+match exactly.
+
+## Example
+
+```harn
+fn pair<T>(a: T, b: T) -> [T; 2] { [a, b] }
+
+// HARN-TYP-014: pair takes 1 type parameter, not 2
+let xs = pair::<int, string>(1, "two")
+```
+
+## How to fix
+
+- Supply exactly as many type arguments as the declaration declares, or omit
+  the explicit list and let Harn infer them.
+- If the declaration itself is wrong, edit the `<T, U, ...>` list on the
+  declaration to match the arity the callers expect.
+- For type aliases and structs, the same rule applies: `Map<K, V>` needs two
+  arguments, not one and not three.
+
+## See also
+
+- HARN-TYP-013 — call site uses the wrong number of generic type arguments.
+- HARN-TYP-015 — type argument violates a `where`-clause constraint.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-TYP-015.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-TYP-015.md
@@ -1,0 +1,24 @@
+# HARN-TYP-015 — type argument does not satisfy a where-clause constraint
+
+**Category:** Type checker (TYP)  
+**Variant:** `Code::WhereConstraintMismatch` (where constraint mismatch)
+
+## What it means
+
+Harn's static type checker reports this when it cannot reconcile the types
+involved at this position. Type errors block compilation — Harn refuses to run a
+program whose types do not line up.
+
+Specifically: type argument does not satisfy a where-clause constraint.
+
+## How to fix
+
+- Adjust the expression so its inferred type matches the surrounding context.
+- Widen the declared type at the binding / parameter / return position to accept the actual type.
+- Convert the value explicitly (`as`, a stdlib coercion, etc.) when a safe conversion exists.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-TYP-016.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-TYP-016.md
@@ -1,0 +1,24 @@
+# HARN-TYP-016 — expression must be iterable
+
+**Category:** Type checker (TYP)  
+**Variant:** `Code::IterableExpected` (iterable expected)
+
+## What it means
+
+Harn's static type checker reports this when it cannot reconcile the types
+involved at this position. Type errors block compilation — Harn refuses to run a
+program whose types do not line up.
+
+Specifically: expression must be iterable.
+
+## How to fix
+
+- Adjust the expression so its inferred type matches the surrounding context.
+- Widen the declared type at the binding / parameter / return position to accept the actual type.
+- Convert the value explicitly (`as`, a stdlib coercion, etc.) when a safe conversion exists.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-TYP-017.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-TYP-017.md
@@ -1,0 +1,24 @@
+# HARN-TYP-017 — subscript index type is invalid
+
+**Category:** Type checker (TYP)  
+**Variant:** `Code::InvalidIndexType` (invalid index type)
+
+## What it means
+
+Harn's static type checker reports this when it cannot reconcile the types
+involved at this position. Type errors block compilation — Harn refuses to run a
+program whose types do not line up.
+
+Specifically: subscript index type is invalid.
+
+## How to fix
+
+- Adjust the expression so its inferred type matches the surrounding context.
+- Widen the declared type at the binding / parameter / return position to accept the actual type.
+- Convert the value explicitly (`as`, a stdlib coercion, etc.) when a safe conversion exists.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-TYP-018.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-TYP-018.md
@@ -1,0 +1,24 @@
+# HARN-TYP-018 — expression must be callable
+
+**Category:** Type checker (TYP)  
+**Variant:** `Code::CallableExpected` (callable expected)
+
+## What it means
+
+Harn's static type checker reports this when it cannot reconcile the types
+involved at this position. Type errors block compilation — Harn refuses to run a
+program whose types do not line up.
+
+Specifically: expression must be callable.
+
+## How to fix
+
+- Adjust the expression so its inferred type matches the surrounding context.
+- Widen the declared type at the binding / parameter / return position to accept the actual type.
+- Convert the value explicitly (`as`, a stdlib coercion, etc.) when a safe conversion exists.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-TYP-019.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-TYP-019.md
@@ -1,0 +1,24 @@
+# HARN-TYP-019 — cast cannot be proven valid
+
+**Category:** Type checker (TYP)  
+**Variant:** `Code::InvalidCast` (invalid cast)
+
+## What it means
+
+Harn's static type checker reports this when it cannot reconcile the types
+involved at this position. Type errors block compilation — Harn refuses to run a
+program whose types do not line up.
+
+Specifically: cast cannot be proven valid.
+
+## How to fix
+
+- Adjust the expression so its inferred type matches the surrounding context.
+- Widen the declared type at the binding / parameter / return position to accept the actual type.
+- Convert the value explicitly (`as`, a stdlib coercion, etc.) when a safe conversion exists.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-TYP-020.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-TYP-020.md
@@ -1,0 +1,24 @@
+# HARN-TYP-020 — type name cannot be resolved
+
+**Category:** Type checker (TYP)  
+**Variant:** `Code::UnknownTypeName` (unknown type name)
+
+## What it means
+
+Harn's static type checker reports this when it cannot reconcile the types
+involved at this position. Type errors block compilation — Harn refuses to run a
+program whose types do not line up.
+
+Specifically: type name cannot be resolved.
+
+## How to fix
+
+- Adjust the expression so its inferred type matches the surrounding context.
+- Widen the declared type at the binding / parameter / return position to accept the actual type.
+- Convert the value explicitly (`as`, a stdlib coercion, etc.) when a safe conversion exists.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-TYP-021.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-TYP-021.md
@@ -1,0 +1,24 @@
+# HARN-TYP-021 — variant type is used in an invalid position
+
+**Category:** Type checker (TYP)  
+**Variant:** `Code::InvalidVariantUse` (invalid variant use)
+
+## What it means
+
+Harn's static type checker reports this when it cannot reconcile the types
+involved at this position. Type errors block compilation — Harn refuses to run a
+program whose types do not line up.
+
+Specifically: variant type is used in an invalid position.
+
+## How to fix
+
+- Adjust the expression so its inferred type matches the surrounding context.
+- Widen the declared type at the binding / parameter / return position to accept the actual type.
+- Convert the value explicitly (`as`, a stdlib coercion, etc.) when a safe conversion exists.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-TYP-022.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-TYP-022.md
@@ -1,0 +1,24 @@
+# HARN-TYP-022 — struct literal is invalid
+
+**Category:** Type checker (TYP)  
+**Variant:** `Code::InvalidStructLiteral` (invalid struct literal)
+
+## What it means
+
+Harn's static type checker reports this when it cannot reconcile the types
+involved at this position. Type errors block compilation — Harn refuses to run a
+program whose types do not line up.
+
+Specifically: struct literal is invalid.
+
+## How to fix
+
+- Adjust the expression so its inferred type matches the surrounding context.
+- Widen the declared type at the binding / parameter / return position to accept the actual type.
+- Convert the value explicitly (`as`, a stdlib coercion, etc.) when a safe conversion exists.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-TYP-023.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-TYP-023.md
@@ -1,0 +1,24 @@
+# HARN-TYP-023 — enum construction is invalid
+
+**Category:** Type checker (TYP)  
+**Variant:** `Code::InvalidEnumConstruct` (invalid enum construct)
+
+## What it means
+
+Harn's static type checker reports this when it cannot reconcile the types
+involved at this position. Type errors block compilation — Harn refuses to run a
+program whose types do not line up.
+
+Specifically: enum construction is invalid.
+
+## How to fix
+
+- Adjust the expression so its inferred type matches the surrounding context.
+- Widen the declared type at the binding / parameter / return position to accept the actual type.
+- Convert the value explicitly (`as`, a stdlib coercion, etc.) when a safe conversion exists.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-TYP-024.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-TYP-024.md
@@ -1,0 +1,24 @@
+# HARN-TYP-024 — pattern binding is invalid for the expected type
+
+**Category:** Type checker (TYP)  
+**Variant:** `Code::InvalidPatternBinding` (invalid pattern binding)
+
+## What it means
+
+Harn's static type checker reports this when it cannot reconcile the types
+involved at this position. Type errors block compilation — Harn refuses to run a
+program whose types do not line up.
+
+Specifically: pattern binding is invalid for the expected type.
+
+## How to fix
+
+- Adjust the expression so its inferred type matches the surrounding context.
+- Widen the declared type at the binding / parameter / return position to accept the actual type.
+- Convert the value explicitly (`as`, a stdlib coercion, etc.) when a safe conversion exists.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-TYP-025.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-TYP-025.md
@@ -1,0 +1,24 @@
+# HARN-TYP-025 — optional access is invalid for the receiver type
+
+**Category:** Type checker (TYP)  
+**Variant:** `Code::InvalidOptionalAccess` (invalid optional access)
+
+## What it means
+
+Harn's static type checker reports this when it cannot reconcile the types
+involved at this position. Type errors block compilation — Harn refuses to run a
+program whose types do not line up.
+
+Specifically: optional access is invalid for the receiver type.
+
+## How to fix
+
+- Adjust the expression so its inferred type matches the surrounding context.
+- Widen the declared type at the binding / parameter / return position to accept the actual type.
+- Convert the value explicitly (`as`, a stdlib coercion, etc.) when a safe conversion exists.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -541,10 +541,41 @@ CI log filters.
 
 ## harn explain
 
-Explain the control-flow path behind one invariant violation for a single
-handler. This is the companion to `harn check --invariants`: `check`
-answers whether a handler violates its declared contract, and `explain`
-shows the path that makes the violation reachable.
+`harn explain` dispatches on two forms behind one subcommand.
+
+### Form 1 — explain a stable diagnostic code
+
+```bash
+harn explain HARN-TYP-014
+harn explain HARN-TYP-014 --json
+```
+
+Pass any identifier registered in the in-binary diagnostic-code registry
+(`HARN-<CAT>-<NNN>` — see [`crates/harn-parser/src/diagnostic_codes.rs`](https://github.com/burin-labs/harn/blob/main/crates/harn-parser/src/diagnostic_codes.rs)).
+Text mode prints the embedded markdown explanation plus a curated
+`See also:` list of related codes. `--json` emits a stable envelope an
+agent or editor can ingest without parsing prose:
+
+```json
+{
+  "schemaVersion": 1,
+  "code": "HARN-TYP-014",
+  "category": "TYP",
+  "summary": "declaration has the wrong number of type parameters",
+  "body": "# HARN-TYP-014 — ... full markdown ...",
+  "repairs": [],
+  "related": ["HARN-TYP-013"],
+  "apiStability": "stable"
+}
+```
+
+`schemaVersion` is the contract LSPs, IDEs, and hosted error-page mirrors
+dispatch on; bumps will follow a deprecation cycle. `repairs` is currently
+empty and will populate once the `Repair` struct lands on
+`TypeDiagnostic` (see epic [#1745](https://github.com/burin-labs/harn/issues/1745)).
+An unknown code exits with status 2.
+
+### Form 2 — explain a control-flow invariant violation
 
 ```bash
 harn explain --invariant fs.writes write_patch main.harn
@@ -552,8 +583,10 @@ harn explain --invariant approval.reachability deploy_agent agent.harn
 harn explain --invariant budget.remaining spend_budget budget.harn
 ```
 
-`harn explain` loads the file, rebuilds the same handler IR used by
-`check`, and prints:
+This is the companion to `harn check --invariants`: `check` answers
+whether a handler violates its declared contract, and `--invariant`-mode
+`explain` shows the path that makes the violation reachable. It loads
+the file, rebuilds the same handler IR used by `check`, and prints:
 
 - the invariant name and handler
 - the violation message plus any help text


### PR DESCRIPTION
## Summary

- `harn explain HARN-TYP-014` now prints the embedded markdown explanation for any registered stable diagnostic code (E1.3 of epic #1745).
- `harn explain HARN-TYP-014 --json` emits the stable envelope `{ schemaVersion, code, category, summary, body, repairs, related, apiStability }` LSPs / IDEs / hosted error pages / agents can dispatch on without parsing prose.
- Every entry in the diagnostic-code registry (#1746) ships an embedded markdown body via `include_str!` — a missing file now fails the build, satisfying the CI-gate exit criterion from the parent epic.

Closes #1748.

## What's in the change

- **`crates/harn-parser/src/diagnostic_codes.rs`** — adds `Code::explanation(self) -> &'static str` (resolved at compile time via `concat!` + `include_str!`) and `Code::related(self) -> &'static [Code]` (a curated near-neighbour table seeded for ~30 codes today; defaults to `&[]`). New tests assert every code has a non-empty body containing its identifier and that every `related()` entry is itself registered.
- **`crates/harn-parser/src/diagnostic_codes/explanations/HARN-<CAT>-<NNN>.md`** — 147 new markdown files, one per registered code. Two flagship codes (`HARN-TYP-001`, `HARN-TYP-014`) are hand-tuned; the rest carry a category-aware default body that explains what Harn checked and how to fix it.
- **`crates/harn-cli/src/cli/explain.rs`** — `ExplainArgs` now takes `target` (the code, or — with `--invariant` — the function name), optional positional `file`, optional `--invariant`, and `--json`. The single dispatcher in `run_explain` routes both forms.
- **`crates/harn-cli/src/commands/explain.rs`** — adds `ExplainEnvelope` + `RepairEnvelope` types, `build_envelope(code)` (unit-testable in isolation), `print_code_text`, `print_code_json`, and a new `run_invariant_explain` that preserves the legacy control-flow form. New tests cover registered-code lookup, unknown-code rejection (exit 2), envelope round-trip for the canonical `HARN-TYP-014` case, and an iteration over the full registry asserting every code emits a non-empty envelope. The pre-existing legacy tests are kept and refactored off `SystemTime::now()` (banned by `make lint-test-patterns`) onto an atomic counter + pid.
- **`docs/src/cli-reference.md`** — documents both forms and the JSON envelope shape.
- **`CHANGELOG.md`** — entry under `Unreleased / Added`.

## Backwards compatibility

Legacy `harn explain --invariant <NAME> <FUNCTION> <FILE>` continues to work — same dispatcher, same output. No alias kept beyond what the existing flag set offered. `repairs` is intentionally empty in the envelope until E1.2 (#1747) attaches the `Repair` struct to `TypeDiagnostic`.

## Test plan

- [x] `cargo build --workspace` + `cargo clippy --workspace --all-targets`
- [x] `cargo nextest run -p harn-parser` (274/274), `-p harn-cli` (582/582)
- [x] `cargo test --doc -p harn-parser`
- [x] `make lint-diagnostic-codes`, `make lint-test-patterns`, `make lint-md`, `make check-docs-snippets`
- [x] Manual smoke: `harn explain HARN-TYP-014`, `harn explain HARN-TYP-014 --json | jq .code`, `harn explain HARN-NOPE-001` (exits 2), `harn explain --invariant approval.reachability handler script.harn` (legacy form still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)