### PR TITLE
Wire embedded skill corpus through `harn skills list/get/dump` (#1762)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,19 @@ condensed series summaries instead of full per-patch history.
   the in-process `FakeLlmProvider` all route through the shared
   `StreamSchemaWatch` helper so script-driven and test-driven paths
   exercise the same logic.
+- **`harn skills list / get / dump` over the embedded corpus (#1762).**
+  Wires the `harn-skills` bundled corpus (#1761) through the CLI:
+  `harn skills list [--json]` returns the canonical Harn skills shipped
+  with this build, `harn skills get <name> [--full] [--json]` prints
+  one skill's frontmatter (and SKILL.md body when `--full` is passed),
+  and `harn skills dump --all [--out <dir>] [--force]` writes every
+  skill to disk as byte-stable copies of the embedded source. `--json`
+  output uses the canonical `JsonEnvelope` shape from #1754, with a
+  `skill_not_found` error envelope and `error.details.available`
+  payload on unknown lookups. The legacy FS-discovery list view moves
+  to `harn skills resolved` (same flags as the old `list`), and
+  `harn skills list / get` register in the `harn --json-schemas`
+  catalog as schema-version 1.
 - **`with_scoped_executor` tool-caller middleware (#1702).** Narrows the
   active `CapabilityPolicy` for the duration of one tool dispatch:
   `compose_tool_callers([..., with_scoped_executor({stage, allowed_tools,

--- a/crates/harn-cli/src/cli/mod.rs
+++ b/crates/harn-cli/src/cli/mod.rs
@@ -164,8 +164,8 @@ pub(crate) use skill::{
     SkillWhoSignedArgs,
 };
 pub(crate) use skills::{
-    SkillsArgs, SkillsCommand, SkillsInspectArgs, SkillsInstallArgs, SkillsListArgs,
-    SkillsMatchArgs, SkillsNewArgs,
+    SkillsArgs, SkillsCommand, SkillsDumpArgs, SkillsGetArgs, SkillsInspectArgs, SkillsInstallArgs,
+    SkillsListArgs, SkillsMatchArgs, SkillsNewArgs, SkillsResolvedArgs,
 };
 pub(crate) use supervisor::{
     SupervisorArgs, SupervisorCommand, SupervisorDlqCommand, SupervisorDlqListArgs,
@@ -410,7 +410,8 @@ SCRIPTING
     /// provider (or `HARN_LLM_PROVIDER=mock` for offline use).
     #[command(name = "try")]
     Try(TryArgs),
-    /// Manage and inspect Harn skills (list, inspect, match, install, new).
+    /// Manage and inspect Harn skills (list/get/dump for the embedded
+    /// corpus; resolved/inspect/match/install/new for FS-resolved skills).
     Skills(SkillsArgs),
     /// Manage skill provenance: keys, signatures, verification, and trust policy.
     Skill(SkillArgs),

--- a/crates/harn-cli/src/cli/skills.rs
+++ b/crates/harn-cli/src/cli/skills.rs
@@ -8,8 +8,14 @@ pub(crate) struct SkillsArgs {
 
 #[derive(Debug, Subcommand)]
 pub(crate) enum SkillsCommand {
-    /// Show resolved skills in priority order, with collision warnings.
+    /// List the embedded canonical Harn skill corpus.
     List(SkillsListArgs),
+    /// Print one embedded skill's frontmatter (or full body with `--full`).
+    Get(SkillsGetArgs),
+    /// Write the embedded skill corpus to disk for offline review.
+    Dump(SkillsDumpArgs),
+    /// Show layered-resolution skills discovered from the filesystem.
+    Resolved(SkillsResolvedArgs),
     /// Dump the resolved SKILL.md plus bundled files and metadata for one skill.
     Inspect(SkillsInspectArgs),
     /// Run the metadata matcher against a prompt and show ranked candidates.
@@ -23,6 +29,40 @@ pub(crate) enum SkillsCommand {
 
 #[derive(Debug, Args)]
 pub(crate) struct SkillsListArgs {
+    /// Emit a [`JsonEnvelope`]-wrapped catalog of embedded skills.
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct SkillsGetArgs {
+    /// Embedded skill name (e.g. `harn-language`).
+    pub name: String,
+    /// Include the full SKILL.md body alongside the frontmatter.
+    #[arg(long)]
+    pub full: bool,
+    /// Emit a [`JsonEnvelope`]-wrapped record instead of human-readable text.
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct SkillsDumpArgs {
+    /// Required selector — reserved for future filters.
+    /// Today only `--all` is accepted; without it `dump` refuses to run.
+    #[arg(long)]
+    pub all: bool,
+    /// Destination directory. Defaults to `./skills` in the current
+    /// working directory. Each skill is written to `<dir>/<name>/SKILL.md`.
+    #[arg(long = "out", value_name = "DIR")]
+    pub out: Option<String>,
+    /// Overwrite existing files in the destination instead of refusing.
+    #[arg(long)]
+    pub force: bool,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct SkillsResolvedArgs {
     /// Emit newline-delimited JSON (one record per skill) instead of a table.
     #[arg(long)]
     pub json: bool,

--- a/crates/harn-cli/src/cli/tests.rs
+++ b/crates/harn-cli/src/cli/tests.rs
@@ -2154,7 +2154,7 @@ fn test_profile_env_aliases_apply_to_supported_commands() {
 
 #[test]
 fn test_parses_skills_subcommands() {
-    let cli = Cli::parse_from(["harn", "skills", "list", "--json", "--all"]);
+    let cli = Cli::parse_from(["harn", "skills", "list", "--json"]);
     let Command::Skills(args) = cli.command.unwrap() else {
         panic!("expected skills command");
     };
@@ -2162,7 +2162,46 @@ fn test_parses_skills_subcommands() {
         panic!("expected skills list");
     };
     assert!(list.json);
-    assert!(list.all);
+
+    let cli = Cli::parse_from(["harn", "skills", "get", "harn-language", "--full", "--json"]);
+    let Command::Skills(args) = cli.command.unwrap() else {
+        panic!("expected skills command");
+    };
+    let SkillsCommand::Get(get) = args.command else {
+        panic!("expected skills get");
+    };
+    assert_eq!(get.name, "harn-language");
+    assert!(get.full);
+    assert!(get.json);
+
+    let cli = Cli::parse_from([
+        "harn",
+        "skills",
+        "dump",
+        "--all",
+        "--out",
+        "/tmp/skills",
+        "--force",
+    ]);
+    let Command::Skills(args) = cli.command.unwrap() else {
+        panic!("expected skills command");
+    };
+    let SkillsCommand::Dump(dump) = args.command else {
+        panic!("expected skills dump");
+    };
+    assert!(dump.all);
+    assert_eq!(dump.out.as_deref(), Some("/tmp/skills"));
+    assert!(dump.force);
+
+    let cli = Cli::parse_from(["harn", "skills", "resolved", "--json", "--all"]);
+    let Command::Skills(args) = cli.command.unwrap() else {
+        panic!("expected skills command");
+    };
+    let SkillsCommand::Resolved(resolved) = args.command else {
+        panic!("expected skills resolved");
+    };
+    assert!(resolved.json);
+    assert!(resolved.all);
 
     let cli = Cli::parse_from(["harn", "skills", "match", "deploy the app", "--top-n", "3"]);
     let Command::Skills(args) = cli.command.unwrap() else {

--- a/crates/harn-cli/src/commands/skills.rs
+++ b/crates/harn-cli/src/commands/skills.rs
@@ -1,7 +1,15 @@
-//! `harn skills` CLI subcommands: `list`, `inspect`, `match`, `install`,
-//! `new`. These sit on top of the layered discovery already implemented
-//! in `harn_vm::skills` so what the user sees here is byte-for-byte the
-//! registry that `harn run` / `harn test` / `harn check` hand to the VM.
+//! `harn skills` CLI subcommands.
+//!
+//! Two complementary surfaces share this namespace:
+//!
+//! - `list` / `get` / `dump` operate on the **embedded corpus** shipped
+//!   inside the `harn` binary (see [`harn_skills`]). These are the
+//!   canonical Harn skills — `harn-language`, `harn-orchestration`,
+//!   etc. — and are always available without a project on disk.
+//! - `resolved` / `inspect` / `match` / `install` / `new` operate on
+//!   the **layered FS discovery** implemented in `harn_vm::skills`, so
+//!   what the user sees there is byte-for-byte what `harn run` /
+//!   `harn test` / `harn check` hand to the VM.
 //!
 //! Install resolves a git URL or local path into
 //! `.harn/skills-cache/<namespace?>/<name>/` — mirroring
@@ -13,6 +21,9 @@ use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use std::{fs, process};
 
+use serde::Serialize;
+
+use harn_skills::{get_embedded_skill, list_embedded_skills, EmbeddedSkill, SkillFrontmatter};
 use harn_vm::skills::{
     build_fs_discovery, default_system_dirs, default_user_dir, parse_env_skills_path,
     DiscoveryOptions, FsLayerConfig, Layer, LayeredDiscovery, ManifestSource, Skill,
@@ -20,14 +31,257 @@ use harn_vm::skills::{
 };
 
 use crate::cli::{
-    SkillsInspectArgs, SkillsInstallArgs, SkillsListArgs, SkillsMatchArgs, SkillsNewArgs,
+    SkillsDumpArgs, SkillsGetArgs, SkillsInspectArgs, SkillsInstallArgs, SkillsListArgs,
+    SkillsMatchArgs, SkillsNewArgs, SkillsResolvedArgs,
 };
+use crate::json_envelope::{self, JsonEnvelope, JsonOutput};
 use crate::package::{load_skills_config, resolve_skills_paths, SkillSourceEntry};
 use crate::skill_loader::canonicalize_cli_dirs;
 
 const SKILLS_CACHE_DIR: &str = ".harn/skills-cache";
 
+/// `JsonEnvelope` schemaVersion for `harn skills list --json`.
+pub(crate) const SKILLS_LIST_SCHEMA_VERSION: u32 = 1;
+/// `JsonEnvelope` schemaVersion for `harn skills get --json`.
+pub(crate) const SKILLS_GET_SCHEMA_VERSION: u32 = 1;
+
+/// One row in the `skills list --json` payload — frontmatter only,
+/// no body, to keep `list` cheap to consume.
+#[derive(Debug, Clone, Serialize)]
+pub struct ListedSkill {
+    pub name: &'static str,
+    pub short: &'static str,
+    pub description: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub when_to_use: Option<&'static str>,
+}
+
+impl ListedSkill {
+    fn from_embedded(skill: &EmbeddedSkill) -> Self {
+        Self {
+            name: skill.name,
+            short: skill.frontmatter.short,
+            description: skill.frontmatter.description,
+            when_to_use: skill.frontmatter.when_to_use,
+        }
+    }
+}
+
+/// Top-level payload for `skills list --json`. A struct (not a bare
+/// array) lets the envelope carry top-level metadata (resolution
+/// source, total counts, etc.) without a breaking schema bump.
+#[derive(Debug, Clone, Serialize)]
+pub struct SkillsListPayload {
+    pub skills: Vec<ListedSkill>,
+}
+
+impl JsonOutput for SkillsListPayload {
+    const SCHEMA_VERSION: u32 = SKILLS_LIST_SCHEMA_VERSION;
+    type Data = Self;
+
+    fn into_envelope(self) -> JsonEnvelope<Self::Data> {
+        JsonEnvelope::ok(Self::SCHEMA_VERSION, self)
+    }
+}
+
+/// Payload for `skills get --json`. `body` is only present when the
+/// caller passed `--full` — `Option` rather than empty string so the
+/// JSON shape encodes the distinction unambiguously.
+#[derive(Debug, Clone, Serialize)]
+pub struct SkillsGetPayload {
+    pub name: &'static str,
+    pub short: &'static str,
+    pub description: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub when_to_use: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub body: Option<&'static str>,
+}
+
+impl SkillsGetPayload {
+    fn from_embedded(skill: &EmbeddedSkill, include_body: bool) -> Self {
+        Self {
+            name: skill.name,
+            short: skill.frontmatter.short,
+            description: skill.frontmatter.description,
+            when_to_use: skill.frontmatter.when_to_use,
+            body: include_body.then_some(skill.body),
+        }
+    }
+}
+
+impl JsonOutput for SkillsGetPayload {
+    const SCHEMA_VERSION: u32 = SKILLS_GET_SCHEMA_VERSION;
+    type Data = Self;
+
+    fn into_envelope(self) -> JsonEnvelope<Self::Data> {
+        JsonEnvelope::ok(Self::SCHEMA_VERSION, self)
+    }
+}
+
+/// `harn skills list` — surfaces the embedded canonical Harn skill
+/// corpus. FS-discovered skills live under `harn skills resolved`.
 pub(crate) fn run_list(args: &SkillsListArgs) {
+    let skills = list_embedded_skills();
+
+    if args.json {
+        let payload = SkillsListPayload {
+            skills: skills.iter().map(ListedSkill::from_embedded).collect(),
+        };
+        println!(
+            "{}",
+            json_envelope::to_string_pretty(&payload.into_envelope())
+        );
+        return;
+    }
+
+    if skills.is_empty() {
+        println!("No embedded skills bundled with this `harn` build.");
+        return;
+    }
+
+    println!("Embedded canonical skills ({}):", skills.len());
+    let name_width = skills.iter().map(|s| s.name.len()).max().unwrap_or(4);
+    for skill in skills {
+        let short = if skill.frontmatter.short.is_empty() {
+            "(no short description)"
+        } else {
+            skill.frontmatter.short
+        };
+        println!(
+            "  {:<name_width$}  {}",
+            skill.name,
+            truncate(short, 72),
+            name_width = name_width
+        );
+    }
+    println!();
+    println!("Run `harn skills get <name>` for one entry's frontmatter.");
+    println!("Run `harn skills get <name> --full` to include the body.");
+}
+
+/// `harn skills get <name>` — embedded skill frontmatter, or full
+/// SKILL.md body when `--full` is passed.
+pub(crate) fn run_get(args: &SkillsGetArgs) {
+    let Some(skill) = get_embedded_skill(&args.name) else {
+        emit_get_not_found(&args.name, args.json);
+        process::exit(1);
+    };
+
+    if args.json {
+        let payload = SkillsGetPayload::from_embedded(skill, args.full);
+        println!(
+            "{}",
+            json_envelope::to_string_pretty(&payload.into_envelope())
+        );
+        return;
+    }
+
+    print_skill_frontmatter(&skill.frontmatter);
+    if args.full {
+        println!();
+        println!("---- SKILL.md body ----");
+        print!("{}", skill.body);
+        if !skill.body.ends_with('\n') {
+            println!();
+        }
+    }
+}
+
+/// `harn skills dump --all` — write every embedded skill to disk so
+/// agents and CI can review the corpus offline.
+pub(crate) fn run_dump(args: &SkillsDumpArgs) {
+    if !args.all {
+        eprintln!(
+            "error: `harn skills dump` requires `--all`. \
+             Pass `--all` to write every embedded skill."
+        );
+        process::exit(2);
+    }
+
+    let out_dir = args
+        .out
+        .as_deref()
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("skills"));
+
+    if let Err(error) = fs::create_dir_all(&out_dir) {
+        eprintln!("error: failed to create {}: {error}", out_dir.display());
+        process::exit(1);
+    }
+
+    let skills = list_embedded_skills();
+    let mut written = Vec::with_capacity(skills.len());
+    for skill in skills {
+        let skill_dir = out_dir.join(skill.name);
+        if let Err(error) = fs::create_dir_all(&skill_dir) {
+            eprintln!("error: failed to create {}: {error}", skill_dir.display());
+            process::exit(1);
+        }
+
+        let dest = skill_dir.join("SKILL.md");
+        if dest.exists() && !args.force {
+            eprintln!(
+                "error: {} already exists. Pass --force to overwrite.",
+                dest.display()
+            );
+            process::exit(1);
+        }
+
+        // Byte-for-byte mirror the binary's canonical source so on-disk
+        // copies stay diff-stable against the embedded record.
+        if let Err(error) = fs::write(&dest, skill.source) {
+            eprintln!("error: failed to write {}: {error}", dest.display());
+            process::exit(1);
+        }
+        written.push(dest);
+    }
+
+    println!("Wrote {} skill(s) to {}", written.len(), out_dir.display());
+    for path in &written {
+        println!("  {}", path.display());
+    }
+}
+
+fn print_skill_frontmatter(frontmatter: &SkillFrontmatter) {
+    println!("name:        {}", frontmatter.name);
+    if !frontmatter.short.is_empty() {
+        println!("short:       {}", frontmatter.short);
+    }
+    if !frontmatter.description.is_empty() {
+        println!("description: {}", frontmatter.description);
+    }
+    if let Some(when) = frontmatter.when_to_use {
+        println!("when_to_use: {when}");
+    }
+}
+
+fn emit_get_not_found(name: &str, json: bool) {
+    if json {
+        let envelope: JsonEnvelope<SkillsGetPayload> = JsonEnvelope::err(
+            SKILLS_GET_SCHEMA_VERSION,
+            "skill_not_found",
+            format!("no embedded skill named `{name}`"),
+        )
+        .with_details(serde_json::json!({
+            "requested": name,
+            "available": list_embedded_skills()
+                .iter()
+                .map(|s| s.name)
+                .collect::<Vec<_>>(),
+        }));
+        println!("{}", json_envelope::to_string_pretty(&envelope));
+    } else {
+        eprintln!("error: no embedded skill named `{name}`.");
+        eprintln!("hint: run `harn skills list` to see what ships with this binary.");
+    }
+}
+
+/// `harn skills resolved` — FS-layered discovery view. The
+/// counterpart to the embedded `list`/`get`/`dump` surface: walks the
+/// project, manifest, user, package, and host layers the same way the
+/// VM does, and reports collisions and shadowing.
+pub(crate) fn run_resolved(args: &SkillsResolvedArgs) {
     let discovery = build_discovery(&args.skill_dir, args.from.as_deref());
     let report = discovery.build_report();
 
@@ -430,7 +684,7 @@ They are accessible to the skill body via `${{HARN_SKILL_DIR}}/files/<name>`.\n"
     println!("  files/README.md");
     println!();
     println!(
-        "Edit the SKILL.md frontmatter and body, then run `harn skills list` to verify it's picked up."
+        "Edit the SKILL.md frontmatter and body, then run `harn skills resolved` to verify it's picked up."
     );
 }
 

--- a/crates/harn-cli/src/json_envelope.rs
+++ b/crates/harn-cli/src/json_envelope.rs
@@ -121,10 +121,10 @@ pub struct SchemaEntry {
 
 /// Static catalog of commands that already emit a stable JSON shape.
 ///
-/// E2.1 only registers the commands that ship a `schema_version` in
-/// their JSON today (doctor, session export, the provider catalog).
-/// E2.2–E2.6 will add `run`, `test`, `parse`, `tokens`, `graph`, and
-/// `fmt` as they migrate to [`JsonEnvelope`].
+/// E2.1 seeds the commands that ship a `schema_version` today (doctor,
+/// session export, the provider catalog). New commands register here as
+/// they migrate to [`JsonEnvelope`] — for example, the `skills` family
+/// added in E3.2.
 pub fn catalog() -> Vec<SchemaEntry> {
     vec![
         SchemaEntry {
@@ -168,6 +168,18 @@ pub fn catalog() -> Vec<SchemaEntry> {
             schema_version: crate::commands::time::TIME_RUN_SCHEMA_VERSION,
             description:
                 "Per-phase wall-clock + cache hit/miss + per-LLM/tool-call latency for `harn run`.",
+            schema_json: None,
+        },
+        SchemaEntry {
+            command: "skills list",
+            schema_version: 1,
+            description: "Embedded canonical Harn skill corpus, frontmatter only.",
+            schema_json: None,
+        },
+        SchemaEntry {
+            command: "skills get",
+            schema_version: 1,
+            description: "One embedded skill's frontmatter (and body with --full).",
             schema_json: None,
         },
     ]

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -1138,6 +1138,9 @@ async fn async_main() {
         Command::ProviderToolProbe(args) => commands::provider::run_provider_tool_probe(args).await,
         Command::Skills(args) => match args.command {
             SkillsCommand::List(list) => commands::skills::run_list(&list),
+            SkillsCommand::Get(get) => commands::skills::run_get(&get),
+            SkillsCommand::Dump(dump) => commands::skills::run_dump(&dump),
+            SkillsCommand::Resolved(resolved) => commands::skills::run_resolved(&resolved),
             SkillsCommand::Inspect(inspect) => commands::skills::run_inspect(&inspect),
             SkillsCommand::Match(matcher) => commands::skills::run_match(&matcher),
             SkillsCommand::Install(install) => commands::skills::run_install(&install),

--- a/crates/harn-cli/tests/skills_cli.rs
+++ b/crates/harn-cli/tests/skills_cli.rs
@@ -1,0 +1,272 @@
+//! End-to-end coverage for `harn skills list / get / dump` against
+//! the embedded canonical skill corpus shipped with the binary.
+//!
+//! These spawn the real `harn` binary so we exercise the clap parser
+//! and `JsonEnvelope` serialization paths that agents and CI consume.
+
+mod test_util;
+
+use std::collections::BTreeSet;
+use std::process::Output;
+
+use harn_cli::json_envelope::CATALOG_SCHEMA_VERSION;
+use harn_cli::tests::common::json_envelope::assert_envelope;
+use harn_skills::list_embedded_skills;
+use serde_json::Value;
+use tempfile::TempDir;
+
+use test_util::process::harn_e2e_command;
+
+const SKILLS_LIST_SCHEMA_VERSION: u32 = 1;
+const SKILLS_GET_SCHEMA_VERSION: u32 = 1;
+
+fn parse_json_stdout(out: &Output) -> Value {
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.trim_start().starts_with('{'),
+        "stdout is not JSON:\n{stdout}"
+    );
+    serde_json::from_str(stdout.trim()).expect("stdout parses as JSON")
+}
+
+#[test]
+fn list_json_matches_embedded_corpus_count() {
+    let output = harn_e2e_command()
+        .args(["skills", "list", "--json"])
+        .output()
+        .expect("spawn harn skills list --json");
+    assert!(output.status.success(), "exit={:?}", output.status.code());
+
+    let parsed = parse_json_stdout(&output);
+    let data = assert_envelope(&parsed, SKILLS_LIST_SCHEMA_VERSION);
+
+    let skills = data
+        .get("skills")
+        .and_then(Value::as_array)
+        .expect("data.skills is an array");
+    let embedded_count = list_embedded_skills().len();
+    assert_eq!(
+        skills.len(),
+        embedded_count,
+        "expected {} skills, got {}: {parsed}",
+        embedded_count,
+        skills.len()
+    );
+
+    // Every entry advertises a stable name + short.
+    for entry in skills {
+        assert!(
+            entry.get("name").and_then(Value::as_str).is_some(),
+            "missing name: {entry}"
+        );
+        assert!(
+            entry.get("short").and_then(Value::as_str).is_some(),
+            "missing short: {entry}"
+        );
+    }
+
+    // Cross-check against the in-process corpus: names match exactly.
+    let advertised: BTreeSet<&str> = skills
+        .iter()
+        .filter_map(|e| e.get("name").and_then(Value::as_str))
+        .collect();
+    let embedded: BTreeSet<&str> = list_embedded_skills().iter().map(|s| s.name).collect();
+    assert_eq!(advertised, embedded);
+}
+
+#[test]
+fn list_human_output_mentions_embedded_skills() {
+    let output = harn_e2e_command()
+        .args(["skills", "list"])
+        .output()
+        .expect("spawn harn skills list");
+    assert!(output.status.success(), "exit={:?}", output.status.code());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Embedded canonical skills"),
+        "human output should call out the embedded corpus:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("harn-language"),
+        "human output should list the harn-language skill:\n{stdout}"
+    );
+}
+
+#[test]
+fn get_returns_frontmatter_without_body_by_default() {
+    let output = harn_e2e_command()
+        .args(["skills", "get", "harn-language", "--json"])
+        .output()
+        .expect("spawn harn skills get --json");
+    assert!(output.status.success(), "exit={:?}", output.status.code());
+
+    let parsed = parse_json_stdout(&output);
+    let data = assert_envelope(&parsed, SKILLS_GET_SCHEMA_VERSION);
+    assert_eq!(data["name"], "harn-language");
+    assert!(
+        data.get("short").and_then(Value::as_str).is_some(),
+        "short missing: {data}"
+    );
+    // Without --full, body is omitted.
+    assert!(
+        data.get("body").is_none() || data["body"].is_null(),
+        "body should be absent without --full: {data}"
+    );
+}
+
+#[test]
+fn get_full_includes_body() {
+    let output = harn_e2e_command()
+        .args(["skills", "get", "harn-language", "--full", "--json"])
+        .output()
+        .expect("spawn harn skills get --full --json");
+    assert!(output.status.success(), "exit={:?}", output.status.code());
+
+    let parsed = parse_json_stdout(&output);
+    let data = assert_envelope(&parsed, SKILLS_GET_SCHEMA_VERSION);
+    let body = data
+        .get("body")
+        .and_then(Value::as_str)
+        .expect("body present with --full");
+    assert!(
+        body.contains("Harn language"),
+        "body should contain skill content: {body}"
+    );
+}
+
+#[test]
+fn get_unknown_skill_emits_error_envelope_and_nonzero_exit() {
+    let output = harn_e2e_command()
+        .args(["skills", "get", "not-a-real-skill", "--json"])
+        .output()
+        .expect("spawn harn skills get not-a-real-skill --json");
+    assert!(!output.status.success(), "expected nonzero exit");
+
+    let parsed = parse_json_stdout(&output);
+    assert_eq!(parsed["schemaVersion"], SKILLS_GET_SCHEMA_VERSION);
+    assert_eq!(parsed["ok"], false);
+    assert_eq!(parsed["error"]["code"], "skill_not_found");
+    // Details enumerate available skills so callers can recover.
+    let available = parsed["error"]["details"]["available"]
+        .as_array()
+        .expect("error.details.available is an array");
+    assert!(!available.is_empty());
+}
+
+#[test]
+fn get_human_prints_frontmatter() {
+    let output = harn_e2e_command()
+        .args(["skills", "get", "harn-language"])
+        .output()
+        .expect("spawn harn skills get harn-language");
+    assert!(output.status.success(), "exit={:?}", output.status.code());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("name:"),
+        "frontmatter missing name: {stdout}"
+    );
+    assert!(
+        stdout.contains("harn-language"),
+        "frontmatter should print the requested name: {stdout}"
+    );
+    assert!(
+        !stdout.contains("---- SKILL.md body ----"),
+        "body block leaked without --full: {stdout}"
+    );
+}
+
+#[test]
+fn dump_requires_all_flag() {
+    let output = harn_e2e_command()
+        .args(["skills", "dump"])
+        .output()
+        .expect("spawn harn skills dump (no --all)");
+    assert!(!output.status.success(), "dump without --all should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--all"),
+        "stderr should hint at --all: {stderr}"
+    );
+}
+
+#[test]
+fn dump_all_writes_every_skill_to_out_dir() {
+    let temp = TempDir::new().expect("temp dir");
+    let out = temp.path().join("dump-target");
+
+    let output = harn_e2e_command()
+        .args(["skills", "dump", "--all", "--out"])
+        .arg(&out)
+        .output()
+        .expect("spawn harn skills dump --all --out <dir>");
+    assert!(output.status.success(), "exit={:?}", output.status.code());
+
+    for skill in list_embedded_skills() {
+        let path = out.join(skill.name).join("SKILL.md");
+        assert!(
+            path.exists(),
+            "missing dumped SKILL.md for {} at {}",
+            skill.name,
+            path.display()
+        );
+        let on_disk = std::fs::read_to_string(&path).expect("read dumped SKILL.md");
+        assert_eq!(
+            on_disk, skill.source,
+            "dumped SKILL.md for `{}` must mirror the embedded source byte-for-byte",
+            skill.name
+        );
+    }
+}
+
+#[test]
+fn dump_refuses_to_overwrite_without_force() {
+    let temp = TempDir::new().expect("temp dir");
+    let out = temp.path().join("dump-target");
+
+    // First dump succeeds.
+    let first = harn_e2e_command()
+        .args(["skills", "dump", "--all", "--out"])
+        .arg(&out)
+        .output()
+        .expect("spawn first dump");
+    assert!(first.status.success(), "first dump should succeed");
+
+    // Second dump without --force should refuse.
+    let second = harn_e2e_command()
+        .args(["skills", "dump", "--all", "--out"])
+        .arg(&out)
+        .output()
+        .expect("spawn second dump");
+    assert!(
+        !second.status.success(),
+        "second dump without --force should fail"
+    );
+
+    // Third dump with --force should succeed.
+    let third = harn_e2e_command()
+        .args(["skills", "dump", "--all", "--force", "--out"])
+        .arg(&out)
+        .output()
+        .expect("spawn forced dump");
+    assert!(third.status.success(), "forced dump should succeed");
+}
+
+#[test]
+fn json_schemas_catalog_lists_skills_list_and_get() {
+    let output = harn_e2e_command()
+        .args(["--json-schemas"])
+        .output()
+        .expect("spawn harn --json-schemas");
+    assert!(output.status.success(), "exit={:?}", output.status.code());
+
+    let parsed = parse_json_stdout(&output);
+    let data = assert_envelope(&parsed, CATALOG_SCHEMA_VERSION);
+    let commands: BTreeSet<&str> = data
+        .as_array()
+        .expect("data is array")
+        .iter()
+        .filter_map(|e| e["command"].as_str())
+        .collect();
+    assert!(commands.contains("skills list"), "missing skills list");
+    assert!(commands.contains("skills get"), "missing skills get");
+}

--- a/crates/harn-skills/src/lib.rs
+++ b/crates/harn-skills/src/lib.rs
@@ -21,6 +21,11 @@ pub struct EmbeddedSkill {
     pub name: &'static str,
     pub frontmatter: SkillFrontmatter,
     pub body: &'static str,
+    /// The full original SKILL.md source — frontmatter delimiter,
+    /// frontmatter block, blank line, and body — exactly as embedded.
+    /// Use this when round-tripping a skill back to disk so the dumped
+    /// copy is byte-identical to the binary's canonical record.
+    pub source: &'static str,
 }
 
 const SOURCES: &[&str] = &[
@@ -56,6 +61,7 @@ fn parse_skill(source: &'static str) -> EmbeddedSkill {
         name: frontmatter.name,
         frontmatter,
         body,
+        source,
     }
 }
 
@@ -147,6 +153,27 @@ mod tests {
         let mut sorted = names.clone();
         sorted.sort_unstable();
         assert_eq!(names, sorted);
+    }
+
+    #[test]
+    fn source_round_trips_to_frontmatter_and_body() {
+        for skill in list_embedded_skills() {
+            assert!(
+                skill.source.starts_with("---\n"),
+                "{} source missing opening fence",
+                skill.name
+            );
+            assert!(
+                skill.source.ends_with(skill.body),
+                "{} source must end with the body so dump output is byte-stable",
+                skill.name
+            );
+            assert!(
+                skill.source.contains(&format!("name: {}\n", skill.name)),
+                "{} source missing canonical name field",
+                skill.name
+            );
+        }
     }
 
     #[test]

--- a/docs/src/skills.md
+++ b/docs/src/skills.md
@@ -316,19 +316,99 @@ See [Bridge protocol](./bridge-protocol.md) for wire-format details.
 
 ## Managing skills
 
-The `harn skills` CLI manages and inspects skills without running a
-pipeline. Each subcommand resolves the layered catalog the same way
-`harn run` does (`--skill-dir`, `HARN_SKILLS_PATH`, project, manifest,
-user, packages, system, host), so what you see here is exactly what
-pipelines see.
+The `harn skills` CLI splits into two complementary surfaces:
+
+- **Embedded corpus** — the canonical Harn skills shipped *inside* the
+  `harn` binary (`harn-language`, `harn-orchestration`, `harn-testing`,
+  …). Access these with `harn skills list`, `harn skills get <name>`,
+  and `harn skills dump --all`. They are always available, with no
+  project or filesystem state required.
+- **Layered FS discovery** — user-authored skills picked up from
+  `--skill-dir`, `HARN_SKILLS_PATH`, project, manifest, user, packages,
+  system, and host layers. Access these with `harn skills resolved`,
+  `harn skills inspect <name>`, and `harn skills match`. What you see
+  there is byte-for-byte the registry that `harn run` / `harn test` /
+  `harn check` hand to the VM.
 
 ### `harn skills list`
 
-Prints every resolved skill with the layer it came from. Pass
-`--all` to include shadowed entries; pass `--json` for machine output.
+Lists the embedded canonical skill corpus that ships with this build
+of `harn`. Pass `--json` for a versioned `JsonEnvelope` payload that
+agents and CI can pipe through `jq`.
 
 ```text
 $ harn skills list
+Embedded canonical skills (7):
+  harn-agent          Agent runtime, supervisor wiring, and tool callers.
+  harn-diagnostics    Diagnostic codes, severity rules, suppression hints.
+  harn-language       Harn syntax, modules, types, diagnostics, script structure.
+  harn-orchestration  Triggers, orchestrator handoffs, parallelism primitives.
+  harn-providers      Provider catalog, model packs, fallback policy.
+  harn-testing        Conformance suite, deterministic test patterns.
+  harn-tracing        Transcripts, eval replay, observability surfaces.
+
+Run `harn skills get <name>` for one entry's frontmatter.
+Run `harn skills get <name> --full` to include the body.
+```
+
+The `--json` output uses the standard envelope (`schemaVersion`, `ok`,
+`data`, `error`, `warnings`). The `data.skills` array contains the
+same frontmatter fields shown above:
+
+```bash
+$ harn skills list --json | jq '.data.skills | length'
+7
+```
+
+### `harn skills get <name>`
+
+Prints frontmatter for a single embedded skill. Pass `--full` to
+include the SKILL.md body; pass `--json` to wrap the output in a
+`JsonEnvelope` for machine consumption.
+
+```text
+$ harn skills get harn-language
+name:        harn-language
+short:       Harn syntax, modules, types, diagnostics, and script structure.
+description: Use for Harn language syntax, typechecking, modules, imports, and idiomatic script authoring.
+when_to_use: Use when writing, reviewing, or explaining Harn source code and language-level behavior.
+
+$ harn skills get harn-language --full --json | jq '.data | keys'
+[
+  "body",
+  "description",
+  "name",
+  "short",
+  "when_to_use"
+]
+```
+
+Unknown names return `ok: false` with a `skill_not_found` error code
+and the list of available skills in `error.details.available`.
+
+### `harn skills dump --all [--out <dir>]`
+
+Writes every embedded skill to disk as a `<dir>/<name>/SKILL.md` tree
+so agents and CI can review the corpus offline. Defaults the output
+directory to `./skills`. Refuses to overwrite existing files unless
+`--force` is passed.
+
+```text
+$ harn skills dump --all --out /tmp/skills
+Wrote 7 skill(s) to /tmp/skills
+  /tmp/skills/harn-agent/SKILL.md
+  /tmp/skills/harn-diagnostics/SKILL.md
+  …
+```
+
+### `harn skills resolved`
+
+Prints every FS-resolved skill with the layer it came from. Pass
+`--all` to include shadowed entries; pass `--json` for newline-delimited
+JSON records:
+
+```text
+$ harn skills resolved
 Resolved skills (3):
   deploy         [cli]       Deploy to production when release work is requested
   review         [project]   Review a pull request when asked for code review help
@@ -410,7 +490,7 @@ Scaffolded skill 'deploy' at .harn/skills/deploy
   SKILL.md
   files/README.md
 
-Edit the SKILL.md frontmatter and body, then run `harn skills list`
+Edit the SKILL.md frontmatter and body, then run `harn skills resolved`
 to verify the compact card is picked up.
 ```
 

--- a/scripts/lint_test_patterns.sh
+++ b/scripts/lint_test_patterns.sh
@@ -146,6 +146,7 @@ is_e2e_subprocess_path() {
     crates/harn-cli/tests/persona_cli.rs | \
     crates/harn-cli/tests/run_eval_imports.rs | \
     crates/harn-cli/tests/run_exit_codes.rs | \
+    crates/harn-cli/tests/skills_cli.rs | \
     crates/harn-cli/tests/trigger_replay_cli.rs | \
     crates/harn-cli/tests/orchestrator_http.rs | \
     crates/harn-cli/tests/orchestrator_http/* | \


### PR DESCRIPTION
## Summary

E3.2 of [#1760](https://github.com/burin-labs/harn/issues/1760). Wires the binary-bundled canonical skill corpus from [#1761](https://github.com/burin-labs/harn/issues/1761) into the existing `harn skills` subcommand so agents can fetch the docs that match the binary they're driving.

Closes [#1762](https://github.com/burin-labs/harn/issues/1762).

## What ships

- **`harn skills list [--json]`** — frontmatter for every embedded skill. `--json` emits a canonical [`JsonEnvelope`](https://github.com/burin-labs/harn/pull/1796) payload with `data.skills: [{name, short, description, when_to_use?}]`.
- **`harn skills get <name> [--full] [--json]`** — one skill's frontmatter (or full SKILL.md body when `--full`). Unknown names emit a `skill_not_found` error envelope whose `error.details.available` lists the corpus so callers can recover.
- **`harn skills dump --all [--out DIR] [--force]`** — write every embedded skill as a `<dir>/<name>/SKILL.md` tree. Defaults `--out` to `./skills` and refuses to overwrite without `--force`.
- **`harn skills resolved`** — the old FS-layered discovery view, renamed from `harn skills list` so the new command can return the embedded corpus per the exit-criteria contract.

## Implementation notes

- `harn-skills` gains `EmbeddedSkill.source` (the original SKILL.md bytes). `dump` writes that string through unchanged so on-disk copies are byte-identical to the binary's record. The integration test asserts the round-trip.
- `harn --json-schemas` catalog registers `skills list` and `skills get` at schema-version 1.
- Per the parent epic's "user authorized direct breakage" clause, the old `harn skills list` (FS view) is renamed in-place to `harn skills resolved` rather than carrying a `--legacy` flag.
- The docs in `docs/src/skills.md` now split the embedded-corpus surface and FS-layered surface into distinct sections.

## Exit criteria

- [x] `harn skills list --json | jq '.data.skills | length'` matches `list_embedded_skills().len()`.
- [x] `harn skills get harn-language --full` prints the full body.
- [x] `harn skills dump --all --out /tmp/skills` writes all SKILL.md files (byte-stable mirror of `EmbeddedSkill.source`).

## Test plan

- [x] `cargo test -p harn-skills` (6 unit tests, including new `source_round_trips_to_frontmatter_and_body`).
- [x] `cargo test -p harn-cli --test skills_cli` (10 end-to-end tests covering list/get/dump human + `--json` paths, error envelope, byte-stable dump, `--force` semantics, and `--json-schemas` catalog registration).
- [x] `cargo test -p harn-cli` (full crate suite).
- [x] `cargo clippy --workspace --all-targets -- -D warnings`.
- [x] `make lint-md`.
- [x] Pre-commit + pre-push hooks (fmt, clippy, markdown lint, targeted package checks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)