### PR TITLE
Wire timeout_ms through llm_call for the NL tool binder (#1698 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,17 @@ condensed series summaries instead of full per-patch history.
 
 ### Changed
 
+- **`llm_call` now recognizes `timeout_ms` (#1698 follow-up).** The
+  option surface gains `timeout_ms` as a first-class alias for
+  `timeout` so `with_timeout`-style middleware, the natural-language
+  tool binder, and other callers that already think in milliseconds
+  stop having their value silently dropped at the parse layer. The
+  underlying HTTP transports still consume `Duration::from_secs(u64)`,
+  so a `timeout_ms` value is rounded UP to the nearest whole second
+  for the network-level backstop; sub-second budgets must additionally
+  be enforced at the caller (the binder middleware already does this
+  via a wall-clock post-check). When both `timeout` and `timeout_ms`
+  are set, the explicit `timeout` (seconds) wins.
 - **WorkflowBundle schema v2 / `.harnpack` foundation (#1780).** Portable
   workflow bundles now use schema v2 with canonical package metadata
   (`entrypoint`, transitive module hashes, Harn/stdlib versions, provider

--- a/conformance/tests/integration/tool_binder_pipeline.expected
+++ b/conformance/tests/integration/tool_binder_pipeline.expected
@@ -11,6 +11,7 @@ ok
 /var/log/syslog
 hello
 false
+100
 true
 timeout
 true

--- a/conformance/tests/integration/tool_binder_pipeline.harn
+++ b/conformance/tests/integration/tool_binder_pipeline.harn
@@ -80,13 +80,20 @@ pipeline default() {
   println(r2.audit.binder.status)
   println(r2.audit.binder.reason)
   // (3) Successful binder dispatch — invalid args + intent → binder rewrites.
-  let mock_binder = { _prompt, _system, _opts -> return {
-    text: "{\"path\":\"/var/log/syslog\",\"contents\":\"hello\"}",
-    model: "mock",
-    provider: "mock",
-    input_tokens: 0,
-    output_tokens: 0,
-  } }
+  // Also capture the binder opts so we can assert the configured `timeout_ms`
+  // is forwarded to the inner caller (this is how the wall-clock budget is
+  // expressed to a real `llm_call` substrate).
+  let captured_timeout_ms = atomic(0)
+  let mock_binder = { _prompt, _system, opts ->
+    let _ = atomic_set(captured_timeout_ms, to_int(opts?.timeout_ms ?? 0))
+    return {
+      text: "{\"path\":\"/var/log/syslog\",\"contents\":\"hello\"}",
+      model: "mock",
+      provider: "mock",
+      input_tokens: 0,
+      output_tokens: 0,
+    }
+  }
   let mw_ok = with_natural_language_executor(
     {provider: "cerebras", model: "gpt-oss-120b", timeout_ms: 100, binder_fn: mock_binder},
   )
@@ -100,6 +107,10 @@ pipeline default() {
   println(r3.arguments.contents)
   // Intent must be stripped before dispatch.
   println(contains(r3.arguments.keys(), "_nl_intent"))
+  // The configured `timeout_ms` must reach the binder substrate so a real
+  // `llm_call` (which now recognizes `timeout_ms`) can apply an HTTP-level
+  // backstop in addition to the middleware's post-call wall-clock check.
+  println(atomic_get(captured_timeout_ms))
   // (4) Timeout: binder takes longer than timeout_ms; envelope passes through.
   let slow_binder = { _prompt, _system, _opts ->
     let _ = advance_time(250)

--- a/crates/harn-stdlib/src/stdlib/llm/options.harn
+++ b/crates/harn-stdlib/src/stdlib/llm/options.harn
@@ -59,6 +59,7 @@ fn __llm_call_option_keys() {
     "llm_retries",
     "llm_backoff_ms",
     "timeout",
+    "timeout_ms",
     "idle_timeout",
     "stream",
     "anthropic",

--- a/crates/harn-vm/src/llm/helpers/options.rs
+++ b/crates/harn-vm/src/llm/helpers/options.rs
@@ -16,6 +16,58 @@ pub(crate) fn extract_json(text: &str) -> String {
     crate::stdlib::json::extract_json_from_text(text)
 }
 
+/// Resolve the wall-clock timeout from the (`timeout`, `timeout_ms`) pair.
+///
+/// `timeout` (canonical, seconds) wins when explicitly set. Otherwise
+/// `timeout_ms` is accepted for symmetry with the broader option surface
+/// (`with_timeout`, HTTP, command exec) and rounded UP to the nearest
+/// whole second — the underlying HTTP transports all consume
+/// `Duration::from_secs(u64)`. Sub-second budgets must be enforced at
+/// the caller (e.g. the wall-clock post-check in `std/llm/tool_binder`).
+pub(crate) fn resolve_timeout_secs(timeout: Option<i64>, timeout_ms: Option<i64>) -> Option<u64> {
+    if let Some(seconds) = timeout {
+        return Some(seconds.max(0) as u64);
+    }
+    timeout_ms.map(|ms| {
+        if ms <= 0 {
+            0
+        } else {
+            (ms as u64).div_ceil(1000)
+        }
+    })
+}
+
+#[cfg(test)]
+mod resolve_timeout_secs_tests {
+    use super::resolve_timeout_secs;
+
+    #[test]
+    fn explicit_timeout_wins_over_timeout_ms() {
+        assert_eq!(resolve_timeout_secs(Some(5), Some(100)), Some(5));
+    }
+
+    #[test]
+    fn timeout_ms_rounds_up_to_seconds() {
+        assert_eq!(resolve_timeout_secs(None, Some(1)), Some(1));
+        assert_eq!(resolve_timeout_secs(None, Some(100)), Some(1));
+        assert_eq!(resolve_timeout_secs(None, Some(1000)), Some(1));
+        assert_eq!(resolve_timeout_secs(None, Some(1001)), Some(2));
+        assert_eq!(resolve_timeout_secs(None, Some(5000)), Some(5));
+    }
+
+    #[test]
+    fn non_positive_clamps_to_zero() {
+        assert_eq!(resolve_timeout_secs(None, Some(0)), Some(0));
+        assert_eq!(resolve_timeout_secs(None, Some(-1)), Some(0));
+        assert_eq!(resolve_timeout_secs(Some(-1), None), Some(0));
+    }
+
+    #[test]
+    fn returns_none_when_neither_set() {
+        assert_eq!(resolve_timeout_secs(None, None), None);
+    }
+}
+
 pub(crate) fn expects_structured_output(opts: &crate::llm::api::LlmCallOptions) -> bool {
     opts.output_format.is_structured() || opts.output_schema.is_some()
 }
@@ -922,7 +974,10 @@ pub(crate) fn extract_llm_options(
         opt_float(&options, "frequency_penalty").or_else(|| default_float("frequency_penalty"));
     let presence_penalty =
         opt_float(&options, "presence_penalty").or_else(|| default_float("presence_penalty"));
-    let timeout = opt_int(&options, "timeout").map(|t| t as u64);
+    let timeout = resolve_timeout_secs(
+        opt_int(&options, "timeout"),
+        opt_int(&options, "timeout_ms"),
+    );
     let idle_timeout = opt_int(&options, "idle_timeout").map(|t| t as u64);
     let cache = opt_bool(&options, "cache");
     let stream = options

--- a/docs/src/llm/llm_call.md
+++ b/docs/src/llm/llm_call.md
@@ -130,7 +130,7 @@ as both LLM content and deterministic `vision_ocr(...)` context.
 | `budget` | dict | nil | Pre-flight LLM budget envelope. Supports `max_cost_usd`, `max_input_tokens`, `max_output_tokens`, and `total_budget_usd` |
 | `cache` | bool | `false` | Enable prompt caching (Anthropic) |
 | `stream` | bool | `true` | Use streaming SSE transport. Set `false` for synchronous request/response. Env: `HARN_LLM_STREAM` |
-| `timeout` | int | `120` | Request timeout in seconds |
+| `timeout` | int | `120` | Request timeout in seconds. `timeout_ms` accepted as an alias and rounded up to whole seconds (HTTP transports take `Duration::from_secs`); sub-second budgets must be enforced at the caller. |
 | `messages` | list | nil | Full message list (overrides prompt) |
 | `structural_experiment` | string/dict/closure | nil | Prompt-structure transform applied immediately before the provider call. Built-ins: `prompt_order_permutation(seed: N)`, `doubled_prompt`, `chain_of_draft`, `inverted_system`. Env: `HARN_STRUCTURAL_EXPERIMENT` |
 | `transcript` | dict | nil | Continue from a previous transcript; prompt is appended as the next user turn |


### PR DESCRIPTION
## Summary

Polish/correctness follow-up for [#1698](https://github.com/burin-labs/harn/issues/1698) (Natural-language tool binder middleware). The middleware itself shipped in [#1794](https://github.com/burin-labs/harn/pull/1794), but a fresh-eyes pass surfaced a leaky abstraction: the binder passed `timeout_ms: 100` to its inner LLM caller, but `llm_call`'s option parser only recognized `timeout` (in whole seconds) and `llm_call_options`'s allow-list stripped `timeout_ms` before transport. The middleware's wall-clock post-check still flagged overruns for the audit, but a hung binder would block for the full HTTP default (120s) before being declared `audit.binder.status = \"timeout\"`.

The same leaky shape affected [`with_timeout`](crates/harn-stdlib/src/stdlib/llm/handlers.harn:1100) — its doc-comment promises that `timeout_ms` is \"forwarded to `call.opts.timeout_ms` so providers can cancel mid-flight,\" which has been silently false since shipping.

### Fix

`llm_call` now recognizes `timeout_ms` as a first-class alias for `timeout`:

- New `resolve_timeout_secs` helper in [crates/harn-vm/src/llm/helpers/options.rs](crates/harn-vm/src/llm/helpers/options.rs) with unit coverage for the precedence + rounding edge cases.
- `\"timeout_ms\"` added to the `llm_call_options` allow-list in [crates/harn-stdlib/src/stdlib/llm/options.harn](crates/harn-stdlib/src/stdlib/llm/options.harn) so `default_llm_caller` no longer strips it before transport.
- [conformance/tests/integration/tool_binder_pipeline.harn](conformance/tests/integration/tool_binder_pipeline.harn) now asserts the binder substrate receives `opts.timeout_ms = 100`, closing the previously-untested forward path.
- CHANGELOG entry under `Unreleased / Changed`, and `docs/src/llm/llm_call.md` updated.

Sub-second budgets cannot be expressed against the existing `Duration::from_secs(u64)` HTTP plumbing (refactoring that touches every provider transport — out of scope for this PR), so `timeout_ms` rounds UP to the nearest whole second for the network-level backstop. Sub-second budgets must continue to be enforced at the caller (the binder middleware already does this via a wall-clock post-check). When both `timeout` and `timeout_ms` are set, the explicit `timeout` (seconds) wins.

### Remaining exit criterion from #1698

The empirical go/no-go matrix cell run (weak planner × Cerebras binder against [#1697](https://github.com/burin-labs/harn/issues/1697)'s harness) is the last open item from the exit criteria. The harness, dataset, provider, and middleware are all landed and ready — the run itself burns API credits and is properly a maintainer decision, not an autonomous one. Once that cell runs:
- ≥10pp lift → open follow-up issue for the full sweep
- <10pp lift → close #1698 with postmortem

## Test plan

- [x] `cargo run --quiet --bin harn -- test conformance` — all 1074 tests pass (filter runs: `tool_binder_pipeline`, `llm_handlers_with_timeout`, `tool_*`, `llm_call_*`)
- [x] `cargo test -p harn-vm --lib resolve_timeout_secs_tests` — 4 passed (precedence, rounding, clamping, neither-set)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (pre-commit hook) — clean
- [x] `make fmt-harn` / `make lint-harn` — clean
- [x] `make check-docs-snippets` — 537 checked, 0 failed
- [x] `make check-provider-catalog` / `make check-protocol-artifacts` — no drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)