### PR TITLE
Add `harn run --json` NDJSON event stream (#1755)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,15 @@ condensed series summaries instead of full per-patch history.
   build — the CI gate required by the epic. The legacy
   `harn explain --invariant <NAME> <FUNCTION> <FILE>` form continues to
   work; both forms share one dispatcher.
+- **`harn run --json` event stream (#1755).** Adds a versioned NDJSON
+  surface to `harn run`: one `JsonEnvelope` per line, each carrying a
+  typed `RunEvent` with a strictly monotonic `seq`. Variants cover
+  `stdout`, `stderr`, `transcript`, `tool_call`, `tool_result`, `hook`,
+  `persona_stage`, plus a terminal `result` / `error` event. `--quiet`
+  drops the noisy `stdout` / `stderr` events while keeping the
+  structured stream intact. The `run` command is now listed in
+  `harn --json-schemas` with `schemaVersion: 1`. Foundation for the
+  `--json` epic (#1753) and the burin-code TUI replatform.
 - **`with_scoped_executor` tool-caller middleware (#1702).** Narrows the
   active `CapabilityPolicy` for the duration of one tool dispatch:
   `compose_tool_callers([..., with_scoped_executor({stage, allowed_tools,

--- a/crates/harn-cli/src/cli/run.rs
+++ b/crates/harn-cli/src/cli/run.rs
@@ -59,6 +59,16 @@ pub(crate) struct RunArgs {
     /// Agent id used to look up or generate the receipt signing key.
     #[arg(long = "attest-agent", value_name = "ID", requires = "attest")]
     pub attest_agent: Option<String>,
+    /// Emit a versioned NDJSON event stream on stdout (epic #1753).
+    /// One `JsonEnvelope<RunEvent>` per line with monotonic `seq`.
+    /// See `docs/src/cli/run-json.md`.
+    #[arg(long = "json", action = clap::ArgAction::SetTrue)]
+    pub json: bool,
+    /// Suppress `stdout` / `stderr` events when `--json` is active.
+    /// Transcript, tool, hook, persona-stage, and the final result
+    /// events still flow.
+    #[arg(long = "quiet", action = clap::ArgAction::SetTrue, requires = "json")]
+    pub quiet: bool,
     /// Path to the .harn file to execute.
     pub file: Option<String>,
     /// Positional arguments passed to the pipeline as the global `argv`

--- a/crates/harn-cli/src/commands/run.rs
+++ b/crates/harn-cli/src/commands/run.rs
@@ -18,6 +18,17 @@ use crate::skill_loader::{
 };
 
 mod explain_cost;
+pub mod json_events;
+
+use self::json_events::NdjsonEmitter;
+
+/// JSON event-stream configuration for `--json` runs.
+#[derive(Clone, Default)]
+pub struct RunJsonOptions {
+    /// Suppress `stdout` / `stderr` events. Transcript, tool, hook,
+    /// persona, and the terminal result/error events still flow.
+    pub quiet: bool,
+}
 
 pub(crate) enum RunFileMcpServeMode {
     Stdio,
@@ -332,6 +343,7 @@ struct ExecuteRunInputs<'a> {
     attestation: Option<RunAttestationOptions>,
     profile: RunProfileOptions,
     interrupt_tokens: Option<RunInterruptTokens>,
+    json: Option<(RunJsonOptions, Box<dyn io::Write + Send>)>,
 }
 
 /// Captured outcome of an in-process `execute_run` invocation. Tests use this
@@ -406,6 +418,7 @@ pub(crate) async fn run_file(
         llm_mock_mode,
         attestation,
         profile,
+        None,
     )
     .await;
 }
@@ -423,6 +436,7 @@ pub(crate) fn run_explain_cost_file_with_skill_dirs(path: &str) {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn run_file_with_skill_dirs(
     path: &str,
     trace: bool,
@@ -432,11 +446,14 @@ pub(crate) async fn run_file_with_skill_dirs(
     llm_mock_mode: CliLlmMockMode,
     attestation: Option<RunAttestationOptions>,
     profile: RunProfileOptions,
+    json: Option<RunJsonOptions>,
 ) {
     // Graceful shutdown: flush run records before exit on SIGINT/SIGTERM.
     let interrupt_tokens = install_signal_shutdown_handler();
 
     let _stdout_passthrough = StdoutPassthroughGuard::enable();
+    let json_with_stdout =
+        json.map(|opts| (opts, Box::new(io::stdout()) as Box<dyn io::Write + Send>));
     let outcome = execute_run_inner(ExecuteRunInputs {
         path,
         trace,
@@ -447,6 +464,7 @@ pub(crate) async fn run_file_with_skill_dirs(
         attestation,
         profile,
         interrupt_tokens: Some(interrupt_tokens.clone()),
+        json: json_with_stdout,
     })
     .await;
 
@@ -608,6 +626,40 @@ pub async fn execute_run(
         attestation,
         profile,
         interrupt_tokens: None,
+        json: None,
+    })
+    .await
+}
+
+/// `execute_run` variant for `--json` mode. Returns once the run is
+/// complete; the NDJSON event stream — including the terminal `result`
+/// or `error` event — has already been written to `out` and flushed.
+/// `out` must be `Send` because the run-event sink may be called from
+/// any worker thread the VM spawns.
+#[allow(clippy::too_many_arguments)]
+pub async fn execute_run_json(
+    path: &str,
+    trace: bool,
+    denied_builtins: HashSet<String>,
+    script_argv: Vec<String>,
+    skill_dirs_raw: Vec<String>,
+    llm_mock_mode: CliLlmMockMode,
+    attestation: Option<RunAttestationOptions>,
+    profile: RunProfileOptions,
+    out: Box<dyn io::Write + Send>,
+    options: RunJsonOptions,
+) -> RunOutcome {
+    execute_run_inner(ExecuteRunInputs {
+        path,
+        trace,
+        denied_builtins,
+        script_argv,
+        skill_dirs_raw,
+        llm_mock_mode,
+        attestation,
+        profile,
+        interrupt_tokens: None,
+        json: Some((options, out)),
     })
     .await
 }
@@ -623,13 +675,24 @@ async fn execute_run_inner(inputs: ExecuteRunInputs<'_>) -> RunOutcome {
         attestation,
         profile,
         interrupt_tokens,
+        json,
     } = inputs;
+
+    // `--json` installs an in-process sink that diverts every
+    // observable VM event (stdout, stderr, transcript, tool, hook,
+    // persona) into a single NDJSON stream on `out`. The sink stays
+    // active until we drop the guard below — fatal errors emit a
+    // terminal `error` event on the same stream before bailing.
+    let json_session = json.map(|(options, out)| JsonRunSession::install(options, out));
 
     let mut stderr = String::new();
     let mut stdout = String::new();
 
     let Some(LoadedChunk { source, chunk }) = compile_or_load_chunk_for_run(path, &mut stderr)
     else {
+        if let Some(session) = json_session {
+            return session.finalize_error("compile_error", stderr, 1);
+        }
         return RunOutcome {
             stdout,
             stderr,
@@ -645,6 +708,9 @@ async fn execute_run_inner(inputs: ExecuteRunInputs<'_>) -> RunOutcome {
     }
     if let Err(error) = install_cli_llm_mock_mode(&llm_mock_mode) {
         stderr.push_str(&format!("error: {error}\n"));
+        if let Some(session) = json_session {
+            return session.finalize_error("llm_mock_install", error, 1);
+        }
         return RunOutcome {
             stdout,
             stderr,
@@ -736,6 +802,9 @@ async fn execute_run_inner(inputs: ExecuteRunInputs<'_>) -> RunOutcome {
         stderr.push_str(&format!(
             "error: failed to install manifest triggers: {error}\n"
         ));
+        if let Some(session) = json_session {
+            return session.finalize_error("manifest_triggers", error.to_string(), 1);
+        }
         return RunOutcome {
             stdout,
             stderr,
@@ -746,6 +815,9 @@ async fn execute_run_inner(inputs: ExecuteRunInputs<'_>) -> RunOutcome {
         stderr.push_str(&format!(
             "error: failed to install manifest hooks: {error}\n"
         ));
+        if let Some(session) = json_session {
+            return session.finalize_error("manifest_hooks", error.to_string(), 1);
+        }
         return RunOutcome {
             stdout,
             stderr,
@@ -765,6 +837,9 @@ async fn execute_run_inner(inputs: ExecuteRunInputs<'_>) -> RunOutcome {
         .await;
     if let Err(error) = persist_cli_llm_mock_recording(&llm_mock_mode) {
         stderr.push_str(&format!("error: {error}\n"));
+        if let Some(session) = json_session {
+            return session.finalize_error("llm_mock_record", error, 1);
+        }
         return RunOutcome {
             stdout,
             stderr,
@@ -796,6 +871,9 @@ async fn execute_run_inner(inputs: ExecuteRunInputs<'_>) -> RunOutcome {
             stderr.push_str(&format!(
                 "error: failed to emit provenance receipt: {error}\n"
             ));
+            if let Some(session) = json_session {
+                return session.finalize_error("attestation", error.to_string(), 1);
+            }
             return RunOutcome {
                 stdout,
                 stderr,
@@ -819,6 +897,10 @@ async fn execute_run_inner(inputs: ExecuteRunInputs<'_>) -> RunOutcome {
             if exit_code != 0 {
                 stderr.push_str(&render_return_value_error(&return_value));
             }
+            if let Some(session) = json_session {
+                let value = harn_vm::llm::vm_value_to_json(&return_value);
+                return session.finalize_result(value, exit_code);
+            }
             RunOutcome {
                 stdout,
                 stderr,
@@ -831,6 +913,9 @@ async fn execute_run_inner(inputs: ExecuteRunInputs<'_>) -> RunOutcome {
                 if let Err(error) = render_and_persist_profile(&profile, &mut stderr) {
                     stderr.push_str(&format!("warning: failed to write profile: {error}\n"));
                 }
+            }
+            if let Some(session) = json_session {
+                return session.finalize_error("runtime", rendered_error, 1);
             }
             RunOutcome {
                 stdout,
@@ -972,6 +1057,69 @@ fn exit_code_from_return_value(value: &harn_vm::VmValue) -> i32 {
             fields,
         } if enum_name.as_ref() == "Result" && variant.as_ref() == "Err" => 1,
         _ => 0,
+    }
+}
+
+/// State for a single `harn run --json` invocation. Installs the
+/// run-event sink in [`Self::install`] and removes it in [`Drop`], so
+/// every exit path through `execute_run_inner` cleans up correctly
+/// even if a panic unwinds out of the VM. Save-and-restore of any
+/// previously installed sink keeps the helper safe to nest (rare, but
+/// in-process embeddings can call into `harn run` from a host that
+/// already had a sink wired).
+///
+/// `finalize_result` / `finalize_error` emit the terminal event and
+/// build a [`RunOutcome`] whose stdout/stderr captured-buffer fields
+/// stay **empty** — the canonical stream is on `out`.
+/// `outcome.exit_code` still carries the process exit code so the
+/// binary entry can `process::exit(...)`.
+struct JsonRunSession {
+    emitter: self::json_events::NdjsonEmitter,
+    prior_sink: Option<Arc<dyn harn_vm::run_events::RunEventSink>>,
+}
+
+impl JsonRunSession {
+    fn install(options: RunJsonOptions, out: Box<dyn io::Write + Send>) -> Self {
+        let emitter = NdjsonEmitter::new(out, options.quiet);
+        let prior_sink = harn_vm::run_events::install_sink(emitter.sink());
+        Self {
+            emitter,
+            prior_sink,
+        }
+    }
+
+    fn finalize_result(self, value: serde_json::Value, exit_code: i32) -> RunOutcome {
+        self.emitter.emit_result(value, exit_code);
+        RunOutcome {
+            stdout: String::new(),
+            stderr: String::new(),
+            exit_code,
+        }
+    }
+
+    fn finalize_error(
+        self,
+        code: impl Into<String>,
+        message: impl Into<String>,
+        exit_code: i32,
+    ) -> RunOutcome {
+        self.emitter.emit_error(code, message);
+        RunOutcome {
+            stdout: String::new(),
+            stderr: String::new(),
+            exit_code,
+        }
+    }
+}
+
+impl Drop for JsonRunSession {
+    fn drop(&mut self) {
+        match self.prior_sink.take() {
+            Some(prior) => {
+                harn_vm::run_events::install_sink(prior);
+            }
+            None => harn_vm::run_events::clear_sink(),
+        }
     }
 }
 

--- a/crates/harn-cli/src/commands/run/json_events.rs
+++ b/crates/harn-cli/src/commands/run/json_events.rs
@@ -1,0 +1,355 @@
+//! `harn run --json`: NDJSON event-stream emitter.
+//!
+//! Each line is a [`JsonEnvelope`] wrapping a [`RunEventWire`]. Wire
+//! events tag themselves with `event_type` for cheap discrimination
+//! by `jq`-style consumers and carry a strictly monotonic `seq`
+//! starting at `1`. See issue #1755 / epic #1753.
+
+use std::io::Write;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+use harn_vm::run_events::{RunEvent, RunEventSink};
+use serde::Serialize;
+
+use crate::json_envelope::{JsonEnvelope, JsonError};
+
+/// Schema version for the `harn run --json` event stream. Bump on any
+/// breaking change to the wire shape; agents key off this to negotiate
+/// compatibility.
+pub const RUN_JSON_SCHEMA_VERSION: u32 = 1;
+
+/// Wire form of a single event emitted by `harn run --json`. The
+/// `event_type` tag is flat so consumers can `jq '.data.event_type'`.
+/// `seq` is monotonic and process-local — the first event in a run is
+/// `seq=1`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "event_type", rename_all = "snake_case")]
+pub enum RunEventWire {
+    Stdout {
+        seq: u64,
+        payload: String,
+    },
+    Stderr {
+        seq: u64,
+        payload: String,
+    },
+    Transcript {
+        seq: u64,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        agent_id: Option<String>,
+        kind: String,
+        payload: serde_json::Value,
+    },
+    ToolCall {
+        seq: u64,
+        call_id: String,
+        name: String,
+        args: serde_json::Value,
+        started_at: String,
+    },
+    ToolResult {
+        seq: u64,
+        call_id: String,
+        ok: bool,
+        result: serde_json::Value,
+    },
+    Hook {
+        seq: u64,
+        name: String,
+        phase: String,
+        #[serde(skip_serializing_if = "serde_json::Value::is_null")]
+        payload: serde_json::Value,
+    },
+    PersonaStage {
+        seq: u64,
+        persona: String,
+        stage: String,
+        transition: String,
+    },
+    Result {
+        seq: u64,
+        value: serde_json::Value,
+        exit_code: i32,
+    },
+    Error {
+        seq: u64,
+        error: JsonError,
+    },
+}
+
+impl RunEventWire {
+    /// The monotonic sequence number assigned at emission.
+    pub fn seq(&self) -> u64 {
+        match self {
+            Self::Stdout { seq, .. }
+            | Self::Stderr { seq, .. }
+            | Self::Transcript { seq, .. }
+            | Self::ToolCall { seq, .. }
+            | Self::ToolResult { seq, .. }
+            | Self::Hook { seq, .. }
+            | Self::PersonaStage { seq, .. }
+            | Self::Result { seq, .. }
+            | Self::Error { seq, .. } => *seq,
+        }
+    }
+}
+
+/// Writer that drains [`RunEvent`]s, assigns monotonic seq numbers,
+/// wraps them in [`JsonEnvelope`]s, and emits one NDJSON line per
+/// event. Lines are flushed per event so streaming consumers see them
+/// as the run progresses.
+pub struct NdjsonEmitter {
+    inner: Arc<NdjsonEmitterInner>,
+}
+
+struct NdjsonEmitterInner {
+    seq: AtomicU64,
+    quiet: bool,
+    /// Output sink. Behind a Mutex so concurrent emits stay
+    /// line-atomic; serde line writes are tiny so contention is
+    /// negligible.
+    out: Mutex<Box<dyn Write + Send>>,
+}
+
+impl NdjsonEmitter {
+    /// Build an emitter that writes to `out`. `quiet` suppresses
+    /// `Stdout` and `Stderr` events (transcript/tool/hook/persona/
+    /// result events still flow).
+    pub fn new(out: Box<dyn Write + Send>, quiet: bool) -> Self {
+        Self {
+            inner: Arc::new(NdjsonEmitterInner {
+                seq: AtomicU64::new(0),
+                quiet,
+                out: Mutex::new(out),
+            }),
+        }
+    }
+
+    /// Build a thread-safe sink that forwards [`RunEvent`]s into this
+    /// emitter, applying seq numbering and `quiet` filtering.
+    pub fn sink(&self) -> Arc<dyn RunEventSink> {
+        Arc::new(NdjsonSink {
+            inner: self.inner.clone(),
+        })
+    }
+
+    /// Next monotonic seq value. The first event in a run is `seq=1`.
+    fn next_seq(&self) -> u64 {
+        self.inner.seq.fetch_add(1, Ordering::SeqCst) + 1
+    }
+
+    fn write_envelope(inner: &NdjsonEmitterInner, event: RunEventWire) {
+        let envelope = JsonEnvelope::ok(RUN_JSON_SCHEMA_VERSION, event);
+        let line = serde_json::to_string(&envelope)
+            .unwrap_or_else(|_| r#"{"schemaVersion":1,"ok":false}"#.to_string());
+        if let Ok(mut out) = inner.out.lock() {
+            let _ = writeln!(out, "{line}");
+            let _ = out.flush();
+        }
+    }
+
+    /// Emit the terminal `Result` event for a run.
+    pub fn emit_result(&self, value: serde_json::Value, exit_code: i32) {
+        let event = RunEventWire::Result {
+            seq: self.next_seq(),
+            value,
+            exit_code,
+        };
+        Self::write_envelope(&self.inner, event);
+    }
+
+    /// Emit the terminal `Error` event for a fatal run failure (e.g.
+    /// compile error before the VM started).
+    pub fn emit_error(&self, code: impl Into<String>, message: impl Into<String>) {
+        let event = RunEventWire::Error {
+            seq: self.next_seq(),
+            error: JsonError {
+                code: code.into(),
+                message: message.into(),
+                details: serde_json::Value::Null,
+            },
+        };
+        Self::write_envelope(&self.inner, event);
+    }
+}
+
+struct NdjsonSink {
+    inner: Arc<NdjsonEmitterInner>,
+}
+
+impl RunEventSink for NdjsonSink {
+    fn emit(&self, event: RunEvent) {
+        let seq = self.inner.seq.fetch_add(1, Ordering::SeqCst) + 1;
+        let wire = match event {
+            RunEvent::Stdout { payload } => {
+                if self.inner.quiet {
+                    // Undo the seq bump so monotonicity stays tight.
+                    self.inner.seq.fetch_sub(1, Ordering::SeqCst);
+                    return;
+                }
+                RunEventWire::Stdout { seq, payload }
+            }
+            RunEvent::Stderr { payload } => {
+                if self.inner.quiet {
+                    self.inner.seq.fetch_sub(1, Ordering::SeqCst);
+                    return;
+                }
+                RunEventWire::Stderr { seq, payload }
+            }
+            RunEvent::Transcript {
+                agent_id,
+                kind,
+                payload,
+            } => RunEventWire::Transcript {
+                seq,
+                agent_id,
+                kind,
+                payload,
+            },
+            RunEvent::ToolCall {
+                call_id,
+                name,
+                args,
+                started_at,
+            } => RunEventWire::ToolCall {
+                seq,
+                call_id,
+                name,
+                args,
+                started_at,
+            },
+            RunEvent::ToolResult {
+                call_id,
+                ok,
+                result,
+            } => RunEventWire::ToolResult {
+                seq,
+                call_id,
+                ok,
+                result,
+            },
+            RunEvent::Hook {
+                name,
+                phase,
+                payload,
+            } => RunEventWire::Hook {
+                seq,
+                name,
+                phase,
+                payload,
+            },
+            RunEvent::PersonaStage {
+                persona,
+                stage,
+                transition,
+            } => RunEventWire::PersonaStage {
+                seq,
+                persona,
+                stage,
+                transition,
+            },
+        };
+        NdjsonEmitter::write_envelope(&self.inner, wire);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `harn_vm::run_events::install_sink` writes a process-global
+    /// slot, so any test that swaps the sink must serialize against
+    /// peers.
+    static SINK_LOCK: Mutex<()> = Mutex::new(());
+
+    struct BufWriter(Arc<Mutex<Vec<u8>>>);
+    impl Write for BufWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn emits_monotonic_seq_across_events() {
+        let _guard = SINK_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let buf = Arc::new(Mutex::new(Vec::<u8>::new()));
+        let emitter = NdjsonEmitter::new(Box::new(BufWriter(buf.clone())), false);
+        let sink = emitter.sink();
+        let prior = harn_vm::run_events::install_sink(sink);
+        harn_vm::run_events::emit(RunEvent::Stdout {
+            payload: "hello\n".into(),
+        });
+        harn_vm::run_events::emit(RunEvent::Stderr {
+            payload: "warn\n".into(),
+        });
+        harn_vm::run_events::clear_sink();
+        emitter.emit_result(serde_json::Value::Null, 0);
+        if let Some(prior) = prior {
+            harn_vm::run_events::install_sink(prior);
+        }
+
+        let raw = String::from_utf8(buf.lock().unwrap().clone()).expect("utf8");
+        let lines: Vec<&str> = raw.lines().filter(|line| !line.is_empty()).collect();
+        assert_eq!(lines.len(), 3, "expected 3 NDJSON lines, got:\n{raw}");
+        let seqs: Vec<u64> = lines
+            .iter()
+            .map(|line| {
+                let v: serde_json::Value = serde_json::from_str(line).expect("valid json");
+                v["data"]["seq"].as_u64().expect("seq present")
+            })
+            .collect();
+        assert_eq!(seqs, vec![1, 2, 3]);
+        let types: Vec<String> = lines
+            .iter()
+            .map(|line| {
+                let v: serde_json::Value = serde_json::from_str(line).expect("valid json");
+                v["data"]["event_type"].as_str().expect("type").to_string()
+            })
+            .collect();
+        assert_eq!(types, vec!["stdout", "stderr", "result"]);
+    }
+
+    #[test]
+    fn quiet_drops_stdout_and_stderr_without_gaps() {
+        let _guard = SINK_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let buf = Arc::new(Mutex::new(Vec::<u8>::new()));
+        let emitter = NdjsonEmitter::new(Box::new(BufWriter(buf.clone())), true);
+        let sink = emitter.sink();
+        let prior = harn_vm::run_events::install_sink(sink);
+        harn_vm::run_events::emit(RunEvent::Stdout {
+            payload: "ignored\n".into(),
+        });
+        harn_vm::run_events::emit(RunEvent::Hook {
+            name: "PreRun".into(),
+            phase: "allow".into(),
+            payload: serde_json::Value::Null,
+        });
+        harn_vm::run_events::clear_sink();
+        emitter.emit_result(serde_json::Value::Null, 0);
+        if let Some(prior) = prior {
+            harn_vm::run_events::install_sink(prior);
+        }
+
+        let raw = String::from_utf8(buf.lock().unwrap().clone()).expect("utf8");
+        let lines: Vec<&str> = raw.lines().filter(|line| !line.is_empty()).collect();
+        // stdout suppressed; hook + result remain.
+        assert_eq!(lines.len(), 2, "raw:\n{raw}");
+        let seqs: Vec<u64> = lines
+            .iter()
+            .map(|line| {
+                let v: serde_json::Value = serde_json::from_str(line).expect("valid json");
+                v["data"]["seq"].as_u64().expect("seq")
+            })
+            .collect();
+        assert_eq!(
+            seqs,
+            vec![1, 2],
+            "seq must stay contiguous after quiet filtering"
+        );
+    }
+}

--- a/crates/harn-cli/src/json_envelope.rs
+++ b/crates/harn-cli/src/json_envelope.rs
@@ -157,6 +157,12 @@ pub fn catalog() -> Vec<SchemaEntry> {
             description: "Step-by-step plan to bring a connector online.",
             schema_json: None,
         },
+        SchemaEntry {
+            command: "run",
+            schema_version: crate::commands::run::json_events::RUN_JSON_SCHEMA_VERSION,
+            description: "Pipeline-run NDJSON event stream (stdout, stderr, transcript, tool, hook, persona, result, error).",
+            schema_json: None,
+        },
     ]
 }
 

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -175,6 +175,9 @@ async fn async_main() {
                 agent_id: args.attest_agent.clone(),
             });
             let profile_options = run_profile_options(&args.profile);
+            let json_options = args
+                .json
+                .then_some(commands::run::RunJsonOptions { quiet: args.quiet });
 
             match (args.eval.as_deref(), args.file.as_deref()) {
                 (Some(code), None) => {
@@ -197,6 +200,7 @@ async fn async_main() {
                             llm_mock_mode.clone(),
                             attestation.clone(),
                             profile_options.clone(),
+                            json_options.clone(),
                         )
                         .await;
                     }
@@ -215,6 +219,7 @@ async fn async_main() {
                             llm_mock_mode,
                             attestation,
                             profile_options,
+                            json_options,
                         )
                         .await
                     }

--- a/crates/harn-cli/tests/run_json_cli.rs
+++ b/crates/harn-cli/tests/run_json_cli.rs
@@ -1,0 +1,232 @@
+//! Integration tests for `harn run --json` (issue #1755).
+//!
+//! Spawns the real binary so we exercise the clap parser, the
+//! NDJSON sink installation, and the VM stdout/result plumbing
+//! end-to-end.
+
+use std::process::Command;
+
+use harn_cli::commands::run::json_events::RUN_JSON_SCHEMA_VERSION;
+use harn_cli::tests::common::json_envelope::assert_envelope;
+use serde_json::Value;
+
+fn binary_path() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_BIN_EXE_harn"))
+}
+
+fn write_script(dir: &std::path::Path, name: &str, body: &str) -> std::path::PathBuf {
+    let path = dir.join(name);
+    std::fs::write(&path, body).expect("write script");
+    path
+}
+
+fn parse_ndjson(stdout: &[u8]) -> Vec<Value> {
+    let text = String::from_utf8_lossy(stdout);
+    text.lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| {
+            serde_json::from_str::<Value>(line)
+                .unwrap_or_else(|error| panic!("ndjson line not valid JSON ({error}): {line}"))
+        })
+        .collect()
+}
+
+#[test]
+fn run_json_emits_monotonic_seq_with_typed_events() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let script = write_script(
+        tmp.path(),
+        "hello.harn",
+        r#"
+pipeline main(_) {
+    println("hello")
+    println("world")
+    println("!")
+}
+"#,
+    );
+
+    let output = Command::new(binary_path())
+        .arg("run")
+        .arg("--json")
+        .arg(&script)
+        // Pin the event-log backend to memory so the run does not
+        // touch ~/.harn/event-log; keeps test hermetic.
+        .env("HARN_EVENT_LOG_BACKEND", "memory")
+        .output()
+        .expect("spawn harn run --json");
+
+    assert!(
+        output.status.success(),
+        "exit={:?} stderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let lines = parse_ndjson(&output.stdout);
+    assert!(
+        lines.len() >= 4,
+        "expected ≥4 events (3 stdout + 1 result), got {}:\n{}",
+        lines.len(),
+        String::from_utf8_lossy(&output.stdout)
+    );
+
+    // Every line is a versioned envelope.
+    for line in &lines {
+        let _ = assert_envelope(line, RUN_JSON_SCHEMA_VERSION);
+    }
+
+    // seq is monotonic, contiguous, and starts at 1.
+    let seqs: Vec<u64> = lines
+        .iter()
+        .map(|line| {
+            line["data"]["seq"]
+                .as_u64()
+                .unwrap_or_else(|| panic!("data.seq missing on {line}"))
+        })
+        .collect();
+    assert_eq!(
+        seqs,
+        (1..=seqs.len() as u64).collect::<Vec<_>>(),
+        "seq must be 1..=N contiguous"
+    );
+
+    let types: Vec<&str> = lines
+        .iter()
+        .map(|line| line["data"]["event_type"].as_str().expect("event_type"))
+        .collect();
+
+    // First three are stdout events with the println payloads.
+    assert_eq!(types[0], "stdout", "first event type: {types:?}");
+    assert_eq!(types[1], "stdout");
+    assert_eq!(types[2], "stdout");
+    assert_eq!(
+        lines[0]["data"]["payload"].as_str(),
+        Some("hello\n"),
+        "{lines:?}"
+    );
+    assert_eq!(lines[1]["data"]["payload"].as_str(), Some("world\n"));
+    assert_eq!(lines[2]["data"]["payload"].as_str(), Some("!\n"));
+
+    // Terminal event is the result.
+    let last = lines.last().expect("at least one event");
+    assert_eq!(last["data"]["event_type"], "result");
+    assert_eq!(last["data"]["exit_code"], 0);
+}
+
+#[test]
+fn run_json_quiet_suppresses_stdout_events() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let script = write_script(
+        tmp.path(),
+        "quiet.harn",
+        r#"
+pipeline main(_) {
+    println("noisy")
+}
+"#,
+    );
+
+    let output = Command::new(binary_path())
+        .arg("run")
+        .arg("--json")
+        .arg("--quiet")
+        .arg(&script)
+        .env("HARN_EVENT_LOG_BACKEND", "memory")
+        .output()
+        .expect("spawn harn run --json --quiet");
+
+    assert!(
+        output.status.success(),
+        "exit={:?} stderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let lines = parse_ndjson(&output.stdout);
+    let types: Vec<&str> = lines
+        .iter()
+        .map(|line| line["data"]["event_type"].as_str().expect("event_type"))
+        .collect();
+    assert!(
+        !types.contains(&"stdout"),
+        "--quiet must drop stdout events: {types:?}"
+    );
+    // We still expect a terminal `result` event.
+    assert_eq!(types.last(), Some(&"result"), "{types:?}");
+    // seq stays tight even after filtering.
+    let seqs: Vec<u64> = lines
+        .iter()
+        .map(|line| line["data"]["seq"].as_u64().expect("seq"))
+        .collect();
+    for window in seqs.windows(2) {
+        assert!(
+            window[0] < window[1],
+            "seq not strictly monotonic: {seqs:?}"
+        );
+    }
+}
+
+#[test]
+fn run_json_emits_terminal_error_on_runtime_failure() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    // Throwing an unhandled error exits with code 1 and surfaces an
+    // `error` event on the wire stream.
+    let script = write_script(
+        tmp.path(),
+        "boom.harn",
+        r#"
+pipeline main(_) {
+    throw "boom"
+}
+"#,
+    );
+
+    let output = Command::new(binary_path())
+        .arg("run")
+        .arg("--json")
+        .arg(&script)
+        .env("HARN_EVENT_LOG_BACKEND", "memory")
+        .output()
+        .expect("spawn harn run --json (failing)");
+
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(output.status.code(), Some(1));
+
+    let lines = parse_ndjson(&output.stdout);
+    let last = lines.last().expect("at least one event on failure");
+    assert_eq!(last["data"]["event_type"], "error", "lines: {lines:?}");
+    assert_eq!(last["data"]["error"]["code"], "runtime");
+    assert!(
+        last["data"]["error"]["message"]
+            .as_str()
+            .map(|s| !s.is_empty())
+            .unwrap_or(false),
+        "error.message must be non-empty: {last}"
+    );
+}
+
+#[test]
+fn json_schemas_includes_run_command() {
+    // E2.2 exit criterion: the `run` schema must register in the
+    // catalog so agents can discover it.
+    let output = Command::new(binary_path())
+        .args(["--json-schemas"])
+        .output()
+        .expect("spawn harn --json-schemas");
+    assert!(output.status.success());
+    let value: Value = serde_json::from_slice(&output.stdout).expect("valid JSON catalog");
+    let entries = value["data"].as_array().expect("data array");
+    let run_entry = entries
+        .iter()
+        .find(|entry| entry["command"] == "run")
+        .unwrap_or_else(|| panic!("`run` not in catalog: {value}"));
+    assert_eq!(
+        run_entry["schemaVersion"].as_u64(),
+        Some(u64::from(RUN_JSON_SCHEMA_VERSION))
+    );
+}

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -49,6 +49,7 @@ pub mod provider_catalog;
 pub mod receipts;
 pub mod record_filter;
 pub mod redact;
+pub mod run_events;
 pub mod runtime_context;
 pub mod runtime_paths;
 pub mod schema;

--- a/crates/harn-vm/src/llm/agent_observe.rs
+++ b/crates/harn-vm/src/llm/agent_observe.rs
@@ -257,6 +257,7 @@ pub(crate) fn parse_retry_after(msg: &str) -> Option<u64> {
 pub(super) fn append_llm_transcript_entry(entry: &serde_json::Value) {
     let mut redacted = entry.clone();
     crate::redact::current_policy().redact_json_in_place(&mut redacted);
+    forward_transcript_run_events(&redacted);
     append_llm_transcript_event_log(&redacted);
     let Some(dir) = current_transcript_dir() else {
         return;
@@ -279,6 +280,92 @@ pub(super) fn append_llm_transcript_entry(entry: &serde_json::Value) {
         let _ = f.write_all(line.as_bytes());
         let _ = f.write_all(b"\n");
     }
+}
+
+/// Fan transcript entries out to the run-events sink (`harn run
+/// --json`). [`RunEvent::Transcript`] mirrors the raw entry; tool
+/// calls and tool results carried inside the transcript stream are
+/// also surfaced as their own [`RunEvent::ToolCall`] /
+/// [`RunEvent::ToolResult`] variants so consumers don't have to
+/// re-parse the transcript shape.
+///
+/// `tool_call` events are emitted once per logical call, keyed off
+/// `interpreted_response` (the post-parse view that resolves the final
+/// tool selection). Earlier-stage entries (`provider_call_response`)
+/// still appear as `transcript` events for replay, but their
+/// `tool_calls` arrays are not promoted to avoid duplicate
+/// `tool_call` events for the same `call_id`.
+fn forward_transcript_run_events(entry: &serde_json::Value) {
+    if !crate::run_events::sink_active() {
+        return;
+    }
+    let kind = entry
+        .get("type")
+        .and_then(|value| value.as_str())
+        .unwrap_or("transcript_event")
+        .to_string();
+    let agent_id = entry
+        .get("agent_id")
+        .and_then(|value| value.as_str())
+        .map(str::to_string);
+
+    if kind == "interpreted_response" {
+        if let Some(calls) = entry.get("tool_calls").and_then(|value| value.as_array()) {
+            for call in calls {
+                let name = call
+                    .get("name")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let id = call
+                    .get("id")
+                    .or_else(|| call.get("call_id"))
+                    .and_then(|value| value.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let args = call
+                    .get("arguments")
+                    .or_else(|| call.get("args"))
+                    .cloned()
+                    .unwrap_or(serde_json::Value::Null);
+                crate::run_events::emit(crate::run_events::RunEvent::ToolCall {
+                    call_id: id,
+                    name,
+                    args,
+                    started_at: chrono_now(),
+                });
+            }
+        }
+    }
+
+    if kind == "tool_result" {
+        let call_id = entry
+            .get("call_id")
+            .or_else(|| entry.get("id"))
+            .and_then(|value| value.as_str())
+            .unwrap_or("")
+            .to_string();
+        let ok = entry
+            .get("ok")
+            .and_then(|value| value.as_bool())
+            .unwrap_or(true);
+        let result = entry
+            .get("result")
+            .or_else(|| entry.get("content"))
+            .cloned()
+            .unwrap_or(serde_json::Value::Null);
+        crate::run_events::emit(crate::run_events::RunEvent::ToolResult {
+            call_id,
+            ok,
+            result,
+        });
+    }
+
+    crate::run_events::emit(crate::run_events::RunEvent::Transcript {
+        agent_id,
+        kind,
+        payload: entry.clone(),
+    });
 }
 
 fn append_llm_transcript_event_log(entry: &serde_json::Value) {

--- a/crates/harn-vm/src/personas.rs
+++ b/crates/harn-vm/src/personas.rs
@@ -1662,6 +1662,7 @@ async fn append_persona_event(
 ) -> Result<u64, String> {
     let mut headers = BTreeMap::new();
     headers.insert("persona".to_string(), persona.to_string());
+    forward_persona_run_event(persona, kind, &payload);
     let event = LogEvent {
         kind: kind.to_string(),
         payload,
@@ -1671,6 +1672,36 @@ async fn append_persona_event(
     log.append(&runtime_topic()?, event)
         .await
         .map_err(|error| error.to_string())
+}
+
+/// Mirror persona-stage transitions onto the run-events sink for
+/// `harn run --json`. Both `persona.stage.*` (per-stage moves) and
+/// `persona.run.*` (whole-run lifecycle) kinds are surfaced as
+/// [`crate::run_events::RunEvent::PersonaStage`]; the `transition`
+/// field carries the suffix (`started`, `completed`, `handoff_started`,
+/// `failed`, ...) and `stage` carries the named stage when present.
+fn forward_persona_run_event(persona: &str, kind: &str, payload: &serde_json::Value) {
+    if !crate::run_events::sink_active() {
+        return;
+    }
+    let transition = kind
+        .strip_prefix("persona.stage.")
+        .or_else(|| kind.strip_prefix("persona.run."));
+    let Some(transition) = transition else {
+        return;
+    };
+    let stage = payload
+        .get("stage")
+        .or_else(|| payload.get("to"))
+        .or_else(|| payload.get("name"))
+        .and_then(|value| value.as_str())
+        .unwrap_or("")
+        .to_string();
+    crate::run_events::emit(crate::run_events::RunEvent::PersonaStage {
+        persona: persona.to_string(),
+        stage,
+        transition: transition.to_string(),
+    });
 }
 
 struct PersonaValueEventDelta {

--- a/crates/harn-vm/src/run_events.rs
+++ b/crates/harn-vm/src/run_events.rs
@@ -1,0 +1,170 @@
+//! Run-event sink: an in-process bus the CLI installs to capture every
+//! observable side effect of a `harn run` invocation as a single
+//! ordered stream.
+//!
+//! Concrete sinks live in `harn-cli` (`harn run --json` writes them as
+//! NDJSON). The VM only knows it should call [`emit`] from a handful of
+//! observability checkpoints; sinks fan-out from there.
+//!
+//! Variants intentionally mirror the surface area of the run command
+//! rather than the on-disk event log. Stdout/stderr writes are captured
+//! here because they never enter the event log; transcript / persona /
+//! hook / tool events are forwarded here in addition to their existing
+//! persistent topics so a single subscriber can see the whole run
+//! without joining across topics.
+
+use std::sync::{Arc, OnceLock, RwLock};
+
+use serde::Serialize;
+
+/// One observable event from a running pipeline. Variants are
+/// `#[serde(tag = "event_type")]` so wire consumers (notably the CLI
+/// `--json` NDJSON stream) can discriminate without inspecting the
+/// payload shape.
+#[derive(Clone, Debug, Serialize)]
+#[serde(tag = "event_type", rename_all = "snake_case")]
+pub enum RunEvent {
+    /// Bytes written to stdout (raw, including any trailing newlines).
+    Stdout { payload: String },
+    /// Bytes written to stderr (raw, including any trailing newlines).
+    Stderr { payload: String },
+    /// One append on a transcript stream (`agent.transcript.llm` topic).
+    /// `kind` mirrors the transcript entry's `type` field.
+    Transcript {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        agent_id: Option<String>,
+        kind: String,
+        payload: serde_json::Value,
+    },
+    /// A model-issued tool call. `call_id` matches the transcript
+    /// `call_id`; agents reconcile [`Self::ToolCall`] /
+    /// [`Self::ToolResult`] pairs by it.
+    ToolCall {
+        call_id: String,
+        name: String,
+        args: serde_json::Value,
+        /// RFC 3339 timestamp captured at emission.
+        started_at: String,
+    },
+    /// Outcome of a tool call.
+    ToolResult {
+        call_id: String,
+        ok: bool,
+        result: serde_json::Value,
+    },
+    /// A workflow hook fired during the run.
+    Hook {
+        name: String,
+        phase: String,
+        #[serde(skip_serializing_if = "serde_json::Value::is_null")]
+        payload: serde_json::Value,
+    },
+    /// A persona-stage transition. Mirrors the `persona.runtime.events`
+    /// topic; the `transition` field captures the stage state change
+    /// (`"started"`, `"completed"`, `"handoff"`, ...).
+    PersonaStage {
+        persona: String,
+        stage: String,
+        transition: String,
+    },
+}
+
+/// Receiver of [`RunEvent`]s. Implementations must be cheap (the VM
+/// calls [`emit`] on hot paths like every `println`).
+pub trait RunEventSink: Send + Sync {
+    fn emit(&self, event: RunEvent);
+}
+
+fn active_slot() -> &'static RwLock<Option<Arc<dyn RunEventSink>>> {
+    static SLOT: OnceLock<RwLock<Option<Arc<dyn RunEventSink>>>> = OnceLock::new();
+    SLOT.get_or_init(|| RwLock::new(None))
+}
+
+/// Install `sink` as the process-wide run-event sink. Returns the
+/// previous sink (if any) so callers can chain. Installs are
+/// exclusive — there is one active sink at a time — to keep ordering
+/// trivially serial.
+pub fn install_sink(sink: Arc<dyn RunEventSink>) -> Option<Arc<dyn RunEventSink>> {
+    let mut guard = active_slot()
+        .write()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    guard.replace(sink)
+}
+
+/// Remove the active sink. No-op when none is installed.
+pub fn clear_sink() {
+    let mut guard = active_slot()
+        .write()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    *guard = None;
+}
+
+/// Whether a sink is currently installed. Useful as a fast-path gate
+/// for callers that would otherwise build a payload speculatively.
+pub fn sink_active() -> bool {
+    active_slot()
+        .read()
+        .map(|guard| guard.is_some())
+        .unwrap_or(false)
+}
+
+/// Emit `event` to the active sink. No-op when no sink is installed,
+/// so it is safe to call from every hook point unconditionally.
+pub fn emit(event: RunEvent) {
+    let guard = match active_slot().read() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    if let Some(sink) = guard.as_ref() {
+        sink.emit(event);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// The sink slot is process-global; tests that install/clear must
+    /// run serially even when nextest fans them out across threads.
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    struct CapturingSink {
+        events: Mutex<Vec<RunEvent>>,
+    }
+
+    impl RunEventSink for CapturingSink {
+        fn emit(&self, event: RunEvent) {
+            self.events.lock().unwrap().push(event);
+        }
+    }
+
+    #[test]
+    fn install_emit_clear_round_trip() {
+        let _guard = TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let sink = Arc::new(CapturingSink {
+            events: Mutex::new(Vec::new()),
+        });
+        let prior = install_sink(sink.clone());
+        assert!(sink_active());
+        emit(RunEvent::Stdout {
+            payload: "hi\n".into(),
+        });
+        clear_sink();
+        assert!(!sink_active());
+        emit(RunEvent::Stdout {
+            payload: "after-clear".into(),
+        });
+
+        let captured = sink.events.lock().unwrap();
+        assert_eq!(captured.len(), 1, "events after clear must be dropped");
+        match &captured[0] {
+            RunEvent::Stdout { payload } => assert_eq!(payload, "hi\n"),
+            other => panic!("unexpected event {other:?}"),
+        }
+
+        if let Some(prior) = prior {
+            install_sink(prior);
+        }
+    }
+}

--- a/crates/harn-vm/src/stdlib/io.rs
+++ b/crates/harn-vm/src/stdlib/io.rs
@@ -258,6 +258,12 @@ pub fn take_stderr_buffer() -> String {
 }
 
 fn write_stderr(line: &str) {
+    if crate::run_events::sink_active() {
+        crate::run_events::emit(crate::run_events::RunEvent::Stderr {
+            payload: line.to_string(),
+        });
+        return;
+    }
     let capturing = STDERR_CAPTURING.with(|c| *c.borrow());
     if capturing {
         STDERR_BUFFER.with(|s| s.borrow_mut().push_str(line));
@@ -269,6 +275,12 @@ fn write_stderr(line: &str) {
 }
 
 pub(crate) fn write_stdout(out: &mut String, text: &str) {
+    if crate::run_events::sink_active() {
+        crate::run_events::emit(crate::run_events::RunEvent::Stdout {
+            payload: text.to_string(),
+        });
+        return;
+    }
     if stdout_passthrough_enabled() {
         let mut stdout = std::io::stdout().lock();
         let _ = stdout.write_all(text.as_bytes());

--- a/crates/harn-vm/src/stdlib/workflow/hooks.rs
+++ b/crates/harn-vm/src/stdlib/workflow/hooks.rs
@@ -219,6 +219,15 @@ pub(super) async fn fire_session_hook_builtin(args: Vec<VmValue>) -> Result<VmVa
     }
 
     let control = crate::orchestration::run_lifecycle_hooks_with_control(event, &payload).await?;
+    crate::run_events::emit(crate::run_events::RunEvent::Hook {
+        name: event_name.clone(),
+        phase: match &control {
+            crate::orchestration::HookControl::Allow => "allow".to_string(),
+            crate::orchestration::HookControl::Block { .. } => "block".to_string(),
+            crate::orchestration::HookControl::Decision { kind, .. } => format!("decision:{kind}"),
+        },
+        payload: payload.clone(),
+    });
     let mut out: BTreeMap<String, VmValue> = BTreeMap::new();
     match control {
         crate::orchestration::HookControl::Allow => {

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -32,6 +32,38 @@ harn run --attest --receipt-out receipt.json <file.harn>
 | `--attest` | Emit a signed provenance receipt after execution |
 | `--receipt-out <path>` | Write the receipt to a specific JSON path |
 | `--attest-agent <id>` | Agent id used to load or create the Ed25519 signing key |
+| `--json` | Emit a versioned NDJSON event stream on stdout instead of mixed pipeline output |
+| `--quiet` | When `--json` is set, drop `stdout` and `stderr` events (transcript/tool/hook/persona/result still flow) |
+
+### `--json` event stream
+
+`harn run --json <file>` writes one `JsonEnvelope` per line to stdout,
+each carrying a typed `RunEvent`. The stream is strictly ordered via a
+monotonic `seq` (starts at `1`) so a downstream agent can reconstruct
+the run without parsing prose. The envelope's `schemaVersion` is `1`;
+see `harn --json-schemas` for the catalog entry.
+
+Event types (the `event_type` discriminator lives at
+`data.event_type`):
+
+| `event_type` | Payload |
+|---|---|
+| `stdout` | `{ payload: string }` — bytes written via `print`/`println`/`log`, verbatim. |
+| `stderr` | `{ payload: string }` — bytes written via `eprint`/`eprintln`. |
+| `transcript` | `{ agent_id?: string, kind: string, payload: object }` — one entry from the LLM-call transcript stream. |
+| `tool_call` | `{ call_id, name, args, started_at }` — model-issued tool invocation. |
+| `tool_result` | `{ call_id, ok: bool, result }` — outcome of a tool invocation. |
+| `hook` | `{ name, phase, payload? }` — session lifecycle hook fired during the run. |
+| `persona_stage` | `{ persona, stage, transition }` — persona-stage transition (`started` / `completed` / `handoff_started` / …). |
+| `result` | `{ value, exit_code: int }` — terminal event for successful runs. |
+| `error` | `{ error: { code, message, details? } }` — terminal event when a fatal error prevents a `result`. |
+
+The stream is line-flushed per event. Streaming consumers can pipe
+through `jq -c .` for live filtering:
+
+```bash
+harn run --json examples/hello.harn | jq -c '.data | {seq, event_type}'
+```
 
 You can also run a file directly without the `run` subcommand:
 


### PR DESCRIPTION
## Summary

Wires a versioned NDJSON wire surface into `harn run` so agents can drive a pipeline end-to-end without parsing prose. Each line is a `JsonEnvelope<RunEvent>` with `schemaVersion: 1`, monotonic `seq`, and a flat `event_type` discriminator.

- Variants: `stdout`, `stderr`, `transcript`, `tool_call`, `tool_result`, `hook`, `persona_stage`, plus a terminal `result` (success) or `error` (fatal).
- `--quiet` drops `stdout`/`stderr` events while keeping the structured stream intact; seq numbers stay contiguous through the filter.
- `run` is now registered in `harn --json-schemas` so agents can discover it.

Foundation for the `--json` epic (#1753) and the burin-code TUI replatform that consumes this stream.

## Design

A single process-wide [`RunEventSink`](https://github.com/burin-labs/harn/blob/main/crates/harn-vm/src/run_events.rs) trait lives in `harn-vm`. Hook points:

| Source | File |
|---|---|
| stdout/stderr writes | `crates/harn-vm/src/stdlib/io.rs` |
| LLM transcript appends + tool calls | `crates/harn-vm/src/llm/agent_observe.rs` |
| Persona lifecycle events | `crates/harn-vm/src/personas.rs` |
| Session-level hooks | `crates/harn-vm/src/stdlib/workflow/hooks.rs` |

The CLI installs an `NdjsonEmitter` wrapping real stdout when `--json` is on. Non-JSON runs are unchanged: when no sink is installed, all the existing buffer/passthrough paths take their old branches.

## Verification

```bash
$ harn run --json examples/hello.harn | jq -s '.[].data.event_type'
"stdout"
"result"
```

```bash
$ harn run --json -e 'pipeline main(_){ println("a"); println("b"); println("c") }' | jq -c '.data | {seq, event_type}'
{"seq":1,"event_type":"stdout"}
{"seq":2,"event_type":"stdout"}
{"seq":3,"event_type":"stdout"}
{"seq":4,"event_type":"result"}
```

## Test plan

- [x] Unit: `harn_vm::run_events::tests::install_emit_clear_round_trip`
- [x] Unit: `harn_cli::commands::run::json_events::tests::{emits_monotonic_seq_across_events, quiet_drops_stdout_and_stderr_without_gaps}`
- [x] Integration (binary): `crates/harn-cli/tests/run_json_cli.rs` — seq monotonicity + types, `--quiet` filter, terminal `error` event on runtime failure, `run` present in `--json-schemas`
- [x] Full workspace `cargo nextest run` (harn-cli 580 / harn-vm 2151) green
- [x] `make conformance` (1074 / 1074) green
- [x] `make lint-md`, `make lint-test-patterns`, `make check-docs-snippets`, `cargo clippy --workspace --all-targets`, `cargo fmt --check` clean

## Out of scope

- `ToolCall`/`ToolResult` events fire from `interpreted_response` transcript entries. Filling them out across all transcript shapes is incremental work that lands as more transcript kinds are exercised.
- `PersonaStage` events fire for any `persona.stage.*` or `persona.run.*` lifecycle kind. The persona runtime currently emits the `run.*` family; granular stage kinds are wired but unused until the persona engine emits them.
- `--explain-cost --json` still routes through the static-cost path and prints plain text. Tracked separately if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)