### PR TITLE
Add structured repair classifier + 6-class safety taxonomy on diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,19 @@ condensed series summaries instead of full per-patch history.
   to `harn skills resolved` (same flags as the old `list`), and
   `harn skills list / get` register in the `harn --json-schemas`
   catalog as schema-version 1.
+- **Repair classifier on diagnostics (#1747).** `TypeDiagnostic` grows a
+  structured `repair: Option<Repair>` field carrying a namespaced repair
+  id (`bindings/make-mutable`, `imports/fix-path`, …), a one-line
+  summary, and a six-level `RepairSafety` taxonomy
+  (`format-only` → `behavior-preserving` → `scope-local` →
+  `surface-changing` → `capability-changing` → `needs-human`). Agents
+  and IDEs dispatch on `repair.safety` to decide whether to auto-apply,
+  propose, or escalate. The catalog maps ≥20 diagnostic codes to
+  templates via `Code::repair_template()`; `LintDiagnostic` and
+  `FormatError` expose the same handle through derived
+  `.repair()` methods. The CLI now renders a `repair: ID [SAFETY] —
+  SUMMARY` line, and the LSP attaches the same payload to
+  `Diagnostic.data` as `{"repair": {"id", "summary", "safety"}}`.
 - **`with_scoped_executor` tool-caller middleware (#1702).** Narrows the
   active `CapabilityPolicy` for the duration of one tool dispatch:
   `compose_tool_callers([..., with_scoped_executor({stage, allowed_tools,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2250,6 +2250,7 @@ dependencies = [
  "harn-modules",
  "harn-parser",
  "harn-vm",
+ "serde_json",
  "tokio",
  "tower-lsp",
 ]

--- a/crates/harn-cli/src/commands/explain.rs
+++ b/crates/harn-cli/src/commands/explain.rs
@@ -18,8 +18,9 @@ struct ExplainEnvelope<'a> {
     summary: &'a str,
     body: &'a str,
     /// Repair shapes available for this code, sourced from the per-code
-    /// registry. Empty until the `Repair` struct lands on `TypeDiagnostic`
-    /// (epic #1745, E1.2).
+    /// registry. Each entry carries the namespaced repair id, safety
+    /// class, and a one-line summary; today the catalog binds at most
+    /// one repair per code, so this is a `Vec` for forward compatibility.
     repairs: Vec<RepairEnvelope<'a>>,
     related: Vec<&'a str>,
     #[serde(rename = "apiStability")]
@@ -61,6 +62,13 @@ fn print_code_text(code: Code) -> i32 {
     println!("{} — {}", code, code.summary());
     println!();
     println!("{}", code.explanation().trim_end());
+    if let Some(template) = code.repair_template() {
+        println!();
+        println!(
+            "Repair: {} [{}] — {}",
+            template.id, template.safety, template.summary
+        );
+    }
     let related = code.related();
     if !related.is_empty() {
         println!();
@@ -74,13 +82,23 @@ fn print_code_text(code: Code) -> i32 {
 
 fn build_envelope(code: Code) -> ExplainEnvelope<'static> {
     let related_strs: Vec<&'static str> = code.related().iter().map(|c| c.as_str()).collect();
+    let repairs = code
+        .repair_template()
+        .map(|template| {
+            vec![RepairEnvelope {
+                id: template.id,
+                safety: template.safety.as_str(),
+                summary: template.summary,
+            }]
+        })
+        .unwrap_or_default();
     ExplainEnvelope {
         schema_version: 1,
         code: code.as_str(),
         category: code.category().as_str(),
         summary: code.summary(),
         body: code.explanation(),
-        repairs: Vec::new(),
+        repairs,
         related: related_strs,
         api_stability: "stable",
     }
@@ -223,6 +241,37 @@ mod tests {
                 entry.identifier
             );
         }
+    }
+
+    #[test]
+    fn explain_envelope_surfaces_repair_when_registered() {
+        // HARN-OWN-001 (immutable assignment) is mapped to
+        // `bindings/make-mutable` / scope-local in the registry. The
+        // envelope must surface that so IDE clients and agents can
+        // dispatch on safety without parsing prose.
+        let envelope =
+            super::build_envelope(harn_parser::diagnostic_codes::Code::ImmutableAssignment);
+        let value: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&envelope).unwrap()).unwrap();
+        let repairs = value["repairs"]
+            .as_array()
+            .expect("repairs should always be an array");
+        assert_eq!(repairs.len(), 1, "expected one registered repair");
+        assert_eq!(repairs[0]["id"], "bindings/make-mutable");
+        assert_eq!(repairs[0]["safety"], "scope-local");
+    }
+
+    #[test]
+    fn explain_envelope_repairs_empty_when_no_template_registered() {
+        // Parser errors don't have a registered repair shape (they're
+        // diagnose-only). Envelope `repairs` should still be an empty
+        // array, not absent — the schema contract is that the field
+        // exists for every code.
+        let envelope =
+            super::build_envelope(harn_parser::diagnostic_codes::Code::ParserUnexpectedToken);
+        let value: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&envelope).unwrap()).unwrap();
+        assert_eq!(value["repairs"], serde_json::json!([]));
     }
 
     #[test]

--- a/crates/harn-fmt/src/lib.rs
+++ b/crates/harn-fmt/src/lib.rs
@@ -8,7 +8,7 @@ use std::collections::BTreeMap;
 use std::fmt;
 
 use harn_lexer::{Lexer, TokenKind};
-use harn_parser::{DiagnosticCode as Code, Parser};
+use harn_parser::{DiagnosticCode as Code, Parser, Repair};
 
 pub(crate) use formatter::{Comment, Formatter};
 pub use trailing_comma::{
@@ -32,6 +32,14 @@ impl FormatError {
             code,
             message: message.into(),
         }
+    }
+
+    /// Materialize the structured repair classifier for this error.
+    /// Derived from the central diagnostic-code registry so the autonomy
+    /// surface is identical to `TypeDiagnostic::repair` and
+    /// `LintDiagnostic::repair`.
+    pub fn repair(&self) -> Option<Repair> {
+        self.code.repair_template().map(Repair::from_template)
     }
 }
 

--- a/crates/harn-lint/src/diagnostic.rs
+++ b/crates/harn-lint/src/diagnostic.rs
@@ -3,7 +3,7 @@
 //! surface is easy to locate and audit.
 
 use harn_lexer::{FixEdit, Span};
-use harn_parser::DiagnosticCode as Code;
+use harn_parser::{DiagnosticCode as Code, Repair};
 
 /// A lint diagnostic reported by the linter.
 #[derive(Debug, Clone)]
@@ -16,6 +16,20 @@ pub struct LintDiagnostic {
     pub suggestion: Option<String>,
     /// Machine-applicable fix edits (applied in order, non-overlapping).
     pub fix: Option<Vec<FixEdit>>,
+}
+
+impl LintDiagnostic {
+    /// Materialize the structured [`Repair`] for this lint, derived from
+    /// the central diagnostic-code registry. Returns `None` when no
+    /// actionable repair shape is registered.
+    ///
+    /// `LintDiagnostic` does not store `repair` inline (unlike
+    /// `TypeDiagnostic`) because every lint's safety class is purely a
+    /// function of its `code`; storing a per-site copy would invite
+    /// drift. Callers that need the dispatch handle ask for it here.
+    pub fn repair(&self) -> Option<Repair> {
+        self.code.repair_template().map(Repair::from_template)
+    }
 }
 
 /// Severity level for lint diagnostics.

--- a/crates/harn-lsp/Cargo.toml
+++ b/crates/harn-lsp/Cargo.toml
@@ -21,3 +21,4 @@ harn-fmt = { path = "../harn-fmt", version = "0.8" }
 harn-vm = { path = "../harn-vm", version = "0.8" }
 tower-lsp = "0.20"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "io-std"] }
+serde_json = "1"

--- a/crates/harn-lsp/src/document.rs
+++ b/crates/harn-lsp/src/document.rs
@@ -2,7 +2,9 @@ use harn_lexer::Lexer;
 use harn_parser::{Parser, SNode, TypeChecker};
 use tower_lsp::lsp_types::*;
 
-use crate::helpers::{lexer_error_to_diagnostic, parser_error_to_diagnostic, span_to_range};
+use crate::helpers::{
+    lexer_error_to_diagnostic, parser_error_to_diagnostic, repair_data_value, span_to_range,
+};
 use crate::symbols::{build_symbol_table, SymbolInfo};
 
 pub(crate) struct DocumentState {
@@ -97,6 +99,7 @@ impl DocumentState {
                 source: Some("harn-typecheck".to_string()),
                 code: Some(NumberOrString::String(diag.code.to_string())),
                 message: diag.message.clone(),
+                data: repair_data_value(diag.repair.as_ref()),
                 ..Default::default()
             });
         }
@@ -122,12 +125,14 @@ impl DocumentState {
                 harn_lint::LintSeverity::Error => DiagnosticSeverity::ERROR,
             };
             let range = span_to_range(&ld.span);
+            let lint_repair = ld.repair();
             self.diagnostics.push(Diagnostic {
                 range,
                 severity: Some(severity),
                 source: Some("harn-lint".to_string()),
                 code: Some(NumberOrString::String(ld.code.to_string())),
                 message: format!("[{}] {}", ld.rule, ld.message),
+                data: repair_data_value(lint_repair.as_ref()),
                 ..Default::default()
             });
         }
@@ -190,6 +195,35 @@ fn handler() {
                 .iter()
                 .map(|diag| (&diag.source, &diag.message))
                 .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn typecheck_diagnostics_carry_repair_data_envelope() {
+        // A `let x = 1; x = 2` reassigns an immutable binding —
+        // HARN-OWN-001 with a `bindings/make-mutable` repair. The
+        // LSP-side code-action provider reads the safety class from
+        // `Diagnostic.data` to decide whether to auto-apply.
+        let state = DocumentState::new("pipeline main() {\n  let x = 1\n  x = 2\n}\n".to_string());
+        let diag = state
+            .diagnostics
+            .iter()
+            .find(|d| {
+                matches!(
+                    d.code.as_ref(),
+                    Some(tower_lsp::lsp_types::NumberOrString::String(code)) if code == "HARN-OWN-001"
+                )
+            })
+            .expect("expected ImmutableAssignment diagnostic");
+        let data = diag.data.as_ref().expect("repair data should be attached");
+        let repair = data.get("repair").expect("data.repair should be present");
+        assert_eq!(
+            repair.get("id").and_then(|v| v.as_str()),
+            Some("bindings/make-mutable")
+        );
+        assert_eq!(
+            repair.get("safety").and_then(|v| v.as_str()),
+            Some("scope-local")
         );
     }
 }

--- a/crates/harn-lsp/src/helpers.rs
+++ b/crates/harn-lsp/src/helpers.rs
@@ -1,8 +1,27 @@
 use harn_lexer::{LexerError, Span};
-use harn_parser::{diagnostic, ParserError, TypeExpr};
+use harn_parser::{diagnostic, ParserError, Repair, TypeExpr};
 use tower_lsp::lsp_types::*;
 
 use crate::symbols::SymbolInfo;
+
+/// Serialize a [`Repair`] into the JSON envelope that rides on
+/// `Diagnostic.data`. Code-action providers and IDE clients read this
+/// without re-deriving from the code registry, so the field names here
+/// are the contract surface:
+///
+/// ```json
+/// { "repair": { "id": "...", "summary": "...", "safety": "..." } }
+/// ```
+pub(crate) fn repair_data_value(repair: Option<&Repair>) -> Option<serde_json::Value> {
+    let repair = repair?;
+    Some(serde_json::json!({
+        "repair": {
+            "id": repair.id.as_str(),
+            "summary": repair.summary,
+            "safety": repair.safety.as_str(),
+        }
+    }))
+}
 
 /// Convert a 1-based Span to a 0-based LSP Range.
 pub(crate) fn span_to_range(span: &Span) -> Range {

--- a/crates/harn-parser/src/diagnostic.rs
+++ b/crates/harn-parser/src/diagnostic.rs
@@ -3,6 +3,7 @@ use std::io::IsTerminal;
 use harn_lexer::Span;
 use yansi::{Color, Paint};
 
+use crate::diagnostic_codes::Repair;
 use crate::ParserError;
 
 pub struct RelatedSpanLabel<'a> {
@@ -129,6 +130,7 @@ pub fn render_diagnostic(
         label,
         help,
         related: &[],
+        repair: None,
     })
 }
 
@@ -142,6 +144,7 @@ pub fn render_diagnostic_with_code(
     label: Option<&str>,
     help: Option<&str>,
 ) -> String {
+    let repair_owned = code.repair_template().map(Repair::from_template);
     render_diagnostic_inner(RenderDiagnostic {
         source,
         filename,
@@ -152,6 +155,7 @@ pub fn render_diagnostic_with_code(
         label,
         help,
         related: &[],
+        repair: repair_owned.as_ref(),
     })
 }
 
@@ -175,6 +179,7 @@ pub fn render_diagnostic_with_related(
         label,
         help,
         related,
+        repair: None,
     })
 }
 
@@ -188,6 +193,7 @@ struct RenderDiagnostic<'a> {
     label: Option<&'a str>,
     help: Option<&'a str>,
     related: &'a [RelatedSpanLabel<'a>],
+    repair: Option<&'a Repair>,
 }
 
 fn render_diagnostic_inner(input: RenderDiagnostic<'_>) -> String {
@@ -268,6 +274,18 @@ fn render_diagnostic_inner(input: RenderDiagnostic<'_>) -> String {
         ));
     }
 
+    if let Some(repair) = input.repair {
+        let repair_prefix = style_fragment("repair", Color::Cyan, true);
+        out.push_str(&format!(
+            "{:>width$} = {repair_prefix}: {} [{}] — {}\n",
+            " ",
+            repair.id,
+            repair.safety,
+            repair.summary,
+            width = gutter_width + 1,
+        ));
+    }
+
     for item in related {
         out.push_str(&format!(
             "{:>width$} = {note_prefix}: {}\n",
@@ -325,8 +343,15 @@ pub fn render_type_diagnostic(
             label: primary_label.as_deref(),
             help: diag.help.as_deref(),
             related: &related,
+            repair: diag.repair.as_ref(),
         }),
-        None => format!("{severity}[{}]: {}\n", diag.code, diag.message),
+        None => match diag.repair.as_ref() {
+            Some(repair) => format!(
+                "{severity}[{}]: {}\n  = repair: {} [{}] — {}\n",
+                diag.code, diag.message, repair.id, repair.safety, repair.summary,
+            ),
+            None => format!("{severity}[{}]: {}\n", diag.code, diag.message),
+        },
     }
 }
 

--- a/crates/harn-parser/src/diagnostic_codes.rs
+++ b/crates/harn-parser/src/diagnostic_codes.rs
@@ -436,9 +436,566 @@ impl FromStr for Code {
     }
 }
 
+/// Autonomy ceiling of a proposed repair.
+///
+/// Agents and IDEs dispatch on this class to decide whether to auto-apply
+/// a fix, propose it as a suggestion, or escalate to a human. Variants
+/// are ordered from least to most disruptive — call sites can compare
+/// with `<=` to enforce a configured ceiling like
+/// `"apply anything up to behavior-preserving"`.
+///
+/// The wire-format strings (`format-only`, `behavior-preserving`, …) are
+/// the contract surface; renaming a variant string is a breaking change.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum RepairSafety {
+    /// Whitespace, trivia, or canonical layout only. No code structure
+    /// changes; safe to auto-apply.
+    FormatOnly,
+    /// Intended not to change observable runtime behavior (e.g. delete an
+    /// unreachable branch, drop a redundant cast).
+    BehaviorPreserving,
+    /// Confined to the current local scope or file. Runtime behavior may
+    /// change, but the blast radius does not cross a declaration boundary
+    /// or a public surface.
+    ScopeLocal,
+    /// Touches a signature, export, or call-site surface that other files
+    /// or external consumers can observe.
+    SurfaceChanging,
+    /// Required capabilities or sandbox profile may change as a result of
+    /// applying the repair (e.g. swapping `provider: "openai"` for a
+    /// capability flag widens the routing surface).
+    CapabilityChanging,
+    /// Planning hint only — agents should propose, never auto-apply.
+    /// Aligned with the `AutonomyTier::Suggest`/`ActWithApproval` rungs
+    /// in `trust_graph.rs`.
+    NeedsHuman,
+}
+
+impl RepairSafety {
+    pub const ALL: &'static [RepairSafety] = &[
+        RepairSafety::FormatOnly,
+        RepairSafety::BehaviorPreserving,
+        RepairSafety::ScopeLocal,
+        RepairSafety::SurfaceChanging,
+        RepairSafety::CapabilityChanging,
+        RepairSafety::NeedsHuman,
+    ];
+
+    /// Stable wire-format string. The contract surface — do not rename
+    /// without coordinating with `harn fix --safety <…>` callers and
+    /// downstream LSP/IDE clients.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            RepairSafety::FormatOnly => "format-only",
+            RepairSafety::BehaviorPreserving => "behavior-preserving",
+            RepairSafety::ScopeLocal => "scope-local",
+            RepairSafety::SurfaceChanging => "surface-changing",
+            RepairSafety::CapabilityChanging => "capability-changing",
+            RepairSafety::NeedsHuman => "needs-human",
+        }
+    }
+
+    /// True when `self` sits at or below `ceiling`. Used by
+    /// `harn fix --apply --safety <ceiling>` and IDE auto-apply policies
+    /// to decide whether a repair clears the configured autonomy bar.
+    pub const fn is_at_most(self, ceiling: RepairSafety) -> bool {
+        (self as u8) <= (ceiling as u8)
+    }
+}
+
+impl fmt::Display for RepairSafety {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Error returned when parsing an unknown repair-safety string.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ParseRepairSafetyError;
+
+impl fmt::Display for ParseRepairSafetyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("unknown Harn repair-safety class")
+    }
+}
+
+impl std::error::Error for ParseRepairSafetyError {}
+
+impl FromStr for RepairSafety {
+    type Err = ParseRepairSafetyError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        RepairSafety::ALL
+            .iter()
+            .copied()
+            .find(|safety| safety.as_str() == value)
+            .ok_or(ParseRepairSafetyError)
+    }
+}
+
+/// Namespaced kebab-case repair identifier (e.g. `imports/fix-path`).
+///
+/// Wraps a `Cow` so registry-driven values reuse a `'static` literal and
+/// per-site overrides can still attach an owned string. The wire-format
+/// string is the contract surface — never normalize or reformat on read.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct RepairId(std::borrow::Cow<'static, str>);
+
+impl RepairId {
+    pub const fn from_static(s: &'static str) -> Self {
+        RepairId(std::borrow::Cow::Borrowed(s))
+    }
+
+    pub fn from_owned(s: String) -> Self {
+        RepairId(std::borrow::Cow::Owned(s))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for RepairId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// A structured repair proposal attached to a diagnostic.
+///
+/// `id` and `summary` are agent-readable metadata; `safety` is the
+/// dispatch dimension that decides whether the repair clears an
+/// autonomy ceiling. The concrete edits, when known statically, live on
+/// the diagnostic's `fix: Option<Vec<FixEdit>>`; this `Repair` is the
+/// classifier above those edits, not a replacement for them.
+#[derive(Debug, Clone)]
+pub struct Repair {
+    pub id: RepairId,
+    pub summary: String,
+    pub safety: RepairSafety,
+}
+
+impl Repair {
+    pub fn from_template(template: &RepairTemplate) -> Self {
+        Repair {
+            id: RepairId::from_static(template.id),
+            summary: template.summary.to_string(),
+            safety: template.safety,
+        }
+    }
+}
+
+/// Static-lifetime repair template bound to a diagnostic code.
+///
+/// Stored in the registry alongside `Code`. Construction sites can
+/// materialize a `Repair` via [`Repair::from_template`] or override
+/// `summary` for instance-specific detail by building a `Repair`
+/// directly.
+#[derive(Debug, Clone, Copy)]
+pub struct RepairTemplate {
+    pub id: &'static str,
+    pub summary: &'static str,
+    pub safety: RepairSafety,
+}
+
+impl Code {
+    /// Look up the default repair template attached to this diagnostic
+    /// code, or `None` if no actionable fix shape is registered.
+    pub const fn repair_template(self) -> Option<&'static RepairTemplate> {
+        match self {
+            // --- TYP: type mismatches & coercions -------------------------
+            Code::TypeMismatch
+            | Code::ReturnTypeMismatch
+            | Code::AssignmentTypeMismatch
+            | Code::ArgumentTypeMismatch
+            | Code::VariableTypeMismatch
+            | Code::ClosureReturnTypeMismatch
+            | Code::FieldTypeMismatch
+            | Code::MethodTypeMismatch
+            | Code::InvalidIndexType => Some(&REPAIR_INSERT_EXPLICIT_CONVERSION),
+            Code::StringInterpolationRewrite => Some(&REPAIR_REWRITE_STRING_INTERPOLATION),
+            Code::UnknownTypeName => Some(&REPAIR_IMPORTS_FIX_PATH),
+            Code::InvalidCast => Some(&REPAIR_CASTS_REMOVE_UNCHECKED),
+
+            // --- NAM / IMP: imports & names -------------------------------
+            Code::UndefinedVariable
+            | Code::UndefinedFunction
+            | Code::UnknownField
+            | Code::UnknownMethod
+            | Code::UnknownBuiltin
+            | Code::UnknownDeclaration => Some(&REPAIR_BINDINGS_RENAME_TO_CLOSEST),
+            Code::DeprecatedFunction => Some(&REPAIR_STDLIB_MIGRATE_RENAMED),
+            Code::ModuleImportUnresolved | Code::ImportResolutionFailed => {
+                Some(&REPAIR_IMPORTS_FIX_PATH)
+            }
+            Code::ModuleImportUnused => Some(&REPAIR_IMPORTS_REMOVE_UNUSED),
+            Code::ModuleImportOrder => Some(&REPAIR_IMPORTS_REORDER),
+
+            // --- CAP / RCV: capabilities & error recovery -----------------
+            Code::CapabilityResultUnchecked => Some(&REPAIR_ERRORS_CHECK_OR_RESCUE),
+            Code::CapabilityBindingInvalid => Some(&REPAIR_MANUAL_REVIEW_CAPABILITY),
+            Code::RescueOutsideFunction | Code::TryOutsideFunction => {
+                Some(&REPAIR_ERRORS_WRAP_IN_FN)
+            }
+
+            // --- LLM / PRM: model + prompt contract -----------------------
+            Code::DeprecatedLlmOption => Some(&REPAIR_LLM_MIGRATE_DEPRECATED_OPTION),
+            Code::LlmSchemaMissing => Some(&REPAIR_LLM_ADD_SCHEMA),
+            Code::LlmProviderIdentityBranch | Code::PromptProviderIdentityBranch => {
+                Some(&REPAIR_LLM_USE_CAPABILITY_FLAG)
+            }
+            Code::PromptInjectionRisk => Some(&REPAIR_PROMPTS_ESCAPE_INJECTION),
+            Code::PromptToolSurfaceUnknown | Code::PromptToolSurfaceDeferredReference => {
+                Some(&REPAIR_PROMPTS_ADD_TOOL_TO_SURFACE)
+            }
+            Code::PromptVariantExplosion => Some(&REPAIR_MANUAL_NEEDS_HUMAN),
+
+            // --- STD: stdlib usage ----------------------------------------
+            Code::DeprecatedStdlibSymbol => Some(&REPAIR_STDLIB_MIGRATE_RENAMED),
+
+            // --- OWN: ownership & mutability ------------------------------
+            Code::ImmutableAssignment => Some(&REPAIR_BINDINGS_MAKE_MUTABLE),
+            Code::MutableNeverReassigned => Some(&REPAIR_BINDINGS_MAKE_IMMUTABLE),
+
+            // --- MAT: match exhaustiveness --------------------------------
+            Code::NonExhaustiveMatch => Some(&REPAIR_MATCH_ADD_MISSING_ARMS),
+            Code::DuplicateMatchArm => Some(&REPAIR_MATCH_REMOVE_DUPLICATE_ARM),
+
+            // --- ORC: orchestration ---------------------------------------
+            Code::UnreachableCode => Some(&REPAIR_DEAD_CODE_REMOVE),
+
+            // --- FMT: formatter -------------------------------------------
+            Code::FormatterWouldReformat | Code::FormatterTrailingComma => {
+                Some(&REPAIR_FORMAT_REFORMAT)
+            }
+
+            // --- LNT: lints with structured fixes -------------------------
+            Code::LintUnusedVariable
+            | Code::LintUnusedPatternBinding
+            | Code::LintUnusedParameter => Some(&REPAIR_BINDINGS_RENAME_UNUSED),
+            Code::LintUnusedImport => Some(&REPAIR_IMPORTS_REMOVE_UNUSED),
+            Code::LintUnusedFunction | Code::LintUnusedType => {
+                Some(&REPAIR_DECLARATIONS_REMOVE_UNUSED)
+            }
+            Code::LintMutableNeverReassigned => Some(&REPAIR_BINDINGS_MAKE_IMMUTABLE),
+            Code::LintImportOrder => Some(&REPAIR_IMPORTS_REORDER),
+            Code::LintBlankLineBetweenItems
+            | Code::LintTrailingComma
+            | Code::LintUnnecessaryParentheses
+            | Code::LintRequireFileHeader => Some(&REPAIR_FORMAT_REFORMAT),
+            Code::LintLegacyDocComment => Some(&REPAIR_DOC_COMMENT_MIGRATE),
+            Code::LintEmptyBlock => Some(&REPAIR_BLOCK_REMOVE_EMPTY),
+            Code::LintUnnecessaryElseReturn | Code::LintLetThenReturn => {
+                Some(&REPAIR_CONTROL_FLOW_FLATTEN)
+            }
+            Code::LintRedundantNilTernary
+            | Code::LintUnnecessarySafeNavigation
+            | Code::LintPreferOptionalShorthand
+            | Code::LintComparisonToBool
+            | Code::LintPointlessComparison
+            | Code::LintConstantLogicalOperand => Some(&REPAIR_EXPRESSION_SIMPLIFY),
+            Code::LintUnnecessaryCast => Some(&REPAIR_CASTS_REMOVE_REDUNDANT),
+            Code::LintRedundantClone => Some(&REPAIR_CLONE_REMOVE_REDUNDANT),
+            Code::LintEagerCollectionConversion => Some(&REPAIR_COLLECTION_PREFER_LAZY),
+            Code::LintDeadCodeAfterReturn => Some(&REPAIR_DEAD_CODE_REMOVE),
+            Code::LintRenamedStdlibSymbol => Some(&REPAIR_STDLIB_MIGRATE_RENAMED),
+            Code::LintDeprecatedLlmOptions => Some(&REPAIR_LLM_MIGRATE_DEPRECATED_OPTION),
+            Code::LintTemplateProviderIdentityBranch => Some(&REPAIR_LLM_USE_CAPABILITY_FLAG),
+            Code::LintPromptInjectionRisk => Some(&REPAIR_PROMPTS_ESCAPE_INJECTION),
+            Code::LintShadowVariable => Some(&REPAIR_BINDINGS_RENAME_SHADOW),
+            Code::LintNamingConvention => Some(&REPAIR_STYLE_RENAME_TO_CONVENTION),
+            Code::LintUnhandledApprovalResult => Some(&REPAIR_ERRORS_CHECK_OR_RESCUE),
+            Code::LintMissingHarndoc => Some(&REPAIR_DOC_ADD_HARNDOC),
+            Code::LintDuplicateMatchArm => Some(&REPAIR_MATCH_REMOVE_DUPLICATE_ARM),
+            Code::LintUntypedDictAccess => Some(&REPAIR_TYPES_ADD_SHAPE_ANNOTATION),
+            Code::LintMcpToolAnnotations => Some(&REPAIR_MANUAL_NEEDS_HUMAN),
+            Code::LintTemplateVariantExplosion | Code::LintLongRunningWithoutCleanup => {
+                Some(&REPAIR_MANUAL_NEEDS_HUMAN)
+            }
+
+            // Everything else: no statically known repair shape. Agents
+            // should treat these as "diagnose only" until a repair is
+            // registered.
+            _ => None,
+        }
+    }
+}
+
+// Repair-id catalog. Each `RepairTemplate` carries a kebab-case
+// namespaced id (`<namespace>/<verb-noun>`), a one-line summary written
+// in the imperative voice, and a `RepairSafety` class.
+//
+// Conventions:
+//   - Namespaces stay short: `bindings/`, `imports/`, `errors/`, `casts/`,
+//     `format/`, `llm/`, `prompts/`, `match/`, `stdlib/`, `lint/`,
+//     `doc/`, `style/`, `types/`, `manual/`.
+//   - Summary starts with a verb ("Replace…", "Remove…", "Insert…").
+//   - Safety must be the most permissive class that is still always true
+//     for every site this template attaches to. When unsure, pick the
+//     stricter class — agents tighten too-loose policies later, never
+//     too-tight ones.
+
+const REPAIR_INSERT_EXPLICIT_CONVERSION: RepairTemplate = RepairTemplate {
+    id: "casts/insert-explicit-conversion",
+    summary: "Insert an explicit conversion or correct the operand type",
+    safety: RepairSafety::ScopeLocal,
+};
+
+const REPAIR_REWRITE_STRING_INTERPOLATION: RepairTemplate = RepairTemplate {
+    id: "style/string-interpolation",
+    summary: "Rewrite string concatenation as an interpolation literal",
+    safety: RepairSafety::BehaviorPreserving,
+};
+
+const REPAIR_CASTS_REMOVE_UNCHECKED: RepairTemplate = RepairTemplate {
+    id: "casts/remove-unchecked",
+    summary: "Remove the unchecked cast or guard it with a type test",
+    safety: RepairSafety::ScopeLocal,
+};
+
+const REPAIR_CASTS_REMOVE_REDUNDANT: RepairTemplate = RepairTemplate {
+    id: "casts/remove-redundant",
+    summary: "Remove the redundant cast",
+    safety: RepairSafety::BehaviorPreserving,
+};
+
+const REPAIR_BINDINGS_RENAME_TO_CLOSEST: RepairTemplate = RepairTemplate {
+    id: "bindings/rename-to-closest",
+    summary: "Rename to the closest in-scope identifier",
+    safety: RepairSafety::ScopeLocal,
+};
+
+const REPAIR_BINDINGS_MAKE_MUTABLE: RepairTemplate = RepairTemplate {
+    id: "bindings/make-mutable",
+    summary: "Mark the binding `mut` so it can be reassigned",
+    safety: RepairSafety::ScopeLocal,
+};
+
+const REPAIR_BINDINGS_MAKE_IMMUTABLE: RepairTemplate = RepairTemplate {
+    id: "bindings/make-immutable",
+    summary: "Drop `mut` since the binding is never reassigned",
+    safety: RepairSafety::BehaviorPreserving,
+};
+
+const REPAIR_BINDINGS_RENAME_UNUSED: RepairTemplate = RepairTemplate {
+    id: "bindings/rename-unused",
+    summary: "Prefix the unused binding with `_` to silence the lint",
+    safety: RepairSafety::BehaviorPreserving,
+};
+
+const REPAIR_BINDINGS_RENAME_SHADOW: RepairTemplate = RepairTemplate {
+    id: "bindings/rename-shadow",
+    summary: "Rename the shadowing binding to a distinct name",
+    safety: RepairSafety::ScopeLocal,
+};
+
+const REPAIR_DECLARATIONS_REMOVE_UNUSED: RepairTemplate = RepairTemplate {
+    id: "declarations/remove-unused",
+    summary: "Remove the unused declaration",
+    safety: RepairSafety::SurfaceChanging,
+};
+
+const REPAIR_IMPORTS_FIX_PATH: RepairTemplate = RepairTemplate {
+    id: "imports/fix-path",
+    summary: "Replace the import path with a resolvable target",
+    safety: RepairSafety::ScopeLocal,
+};
+
+const REPAIR_IMPORTS_REMOVE_UNUSED: RepairTemplate = RepairTemplate {
+    id: "imports/remove-unused",
+    summary: "Remove the unused import",
+    safety: RepairSafety::BehaviorPreserving,
+};
+
+const REPAIR_IMPORTS_REORDER: RepairTemplate = RepairTemplate {
+    id: "imports/reorder",
+    summary: "Reorder imports into canonical grouping",
+    safety: RepairSafety::FormatOnly,
+};
+
+const REPAIR_ERRORS_CHECK_OR_RESCUE: RepairTemplate = RepairTemplate {
+    id: "errors/check-or-rescue",
+    summary: "Check the result or wrap the call in a `rescue` block",
+    safety: RepairSafety::ScopeLocal,
+};
+
+const REPAIR_ERRORS_WRAP_IN_FN: RepairTemplate = RepairTemplate {
+    id: "errors/wrap-in-fn",
+    summary: "Move the construct inside a function body",
+    safety: RepairSafety::SurfaceChanging,
+};
+
+const REPAIR_MATCH_ADD_MISSING_ARMS: RepairTemplate = RepairTemplate {
+    id: "match/add-missing-arms",
+    summary: "Add arms covering the missing variants",
+    safety: RepairSafety::ScopeLocal,
+};
+
+const REPAIR_MATCH_REMOVE_DUPLICATE_ARM: RepairTemplate = RepairTemplate {
+    id: "match/remove-duplicate-arm",
+    summary: "Remove the duplicated match arm",
+    safety: RepairSafety::BehaviorPreserving,
+};
+
+const REPAIR_FORMAT_REFORMAT: RepairTemplate = RepairTemplate {
+    id: "format/reformat",
+    summary: "Apply canonical formatting",
+    safety: RepairSafety::FormatOnly,
+};
+
+const REPAIR_DOC_COMMENT_MIGRATE: RepairTemplate = RepairTemplate {
+    id: "doc/migrate-comment-style",
+    summary: "Migrate the legacy comment to canonical doc syntax",
+    safety: RepairSafety::FormatOnly,
+};
+
+const REPAIR_DOC_ADD_HARNDOC: RepairTemplate = RepairTemplate {
+    id: "doc/add-harndoc",
+    summary: "Add a `///` doc comment describing this declaration",
+    safety: RepairSafety::BehaviorPreserving,
+};
+
+const REPAIR_BLOCK_REMOVE_EMPTY: RepairTemplate = RepairTemplate {
+    id: "blocks/remove-empty",
+    summary: "Remove the empty block or fill in an explicit body",
+    safety: RepairSafety::ScopeLocal,
+};
+
+const REPAIR_CONTROL_FLOW_FLATTEN: RepairTemplate = RepairTemplate {
+    id: "control-flow/flatten",
+    summary: "Flatten the unnecessary control flow construct",
+    safety: RepairSafety::BehaviorPreserving,
+};
+
+const REPAIR_EXPRESSION_SIMPLIFY: RepairTemplate = RepairTemplate {
+    id: "expressions/simplify",
+    summary: "Simplify the expression to its canonical form",
+    safety: RepairSafety::BehaviorPreserving,
+};
+
+const REPAIR_CLONE_REMOVE_REDUNDANT: RepairTemplate = RepairTemplate {
+    id: "clones/remove-redundant",
+    summary: "Remove the redundant clone",
+    safety: RepairSafety::BehaviorPreserving,
+};
+
+const REPAIR_COLLECTION_PREFER_LAZY: RepairTemplate = RepairTemplate {
+    id: "collections/prefer-lazy",
+    summary: "Replace the eager collection step with a lazy variant",
+    safety: RepairSafety::ScopeLocal,
+};
+
+const REPAIR_DEAD_CODE_REMOVE: RepairTemplate = RepairTemplate {
+    id: "control-flow/remove-dead",
+    summary: "Remove the unreachable code",
+    safety: RepairSafety::BehaviorPreserving,
+};
+
+const REPAIR_STDLIB_MIGRATE_RENAMED: RepairTemplate = RepairTemplate {
+    id: "stdlib/migrate-renamed",
+    summary: "Rename the call to the renamed stdlib symbol",
+    safety: RepairSafety::ScopeLocal,
+};
+
+const REPAIR_LLM_MIGRATE_DEPRECATED_OPTION: RepairTemplate = RepairTemplate {
+    id: "llm/migrate-deprecated-option",
+    summary: "Replace the deprecated option with its supported equivalent",
+    safety: RepairSafety::ScopeLocal,
+};
+
+const REPAIR_LLM_ADD_SCHEMA: RepairTemplate = RepairTemplate {
+    id: "llm/add-schema",
+    summary: "Add a typed output schema to the LLM call",
+    safety: RepairSafety::SurfaceChanging,
+};
+
+const REPAIR_LLM_USE_CAPABILITY_FLAG: RepairTemplate = RepairTemplate {
+    id: "llm/use-capability-flag",
+    summary: "Branch on a capability flag instead of provider identity",
+    safety: RepairSafety::CapabilityChanging,
+};
+
+const REPAIR_PROMPTS_ESCAPE_INJECTION: RepairTemplate = RepairTemplate {
+    id: "prompts/escape-injection",
+    summary: "Pass the untrusted input through a structured placeholder",
+    safety: RepairSafety::ScopeLocal,
+};
+
+const REPAIR_PROMPTS_ADD_TOOL_TO_SURFACE: RepairTemplate = RepairTemplate {
+    id: "prompts/add-tool-to-surface",
+    summary: "Add the referenced tool to the declared tool surface",
+    safety: RepairSafety::SurfaceChanging,
+};
+
+const REPAIR_STYLE_RENAME_TO_CONVENTION: RepairTemplate = RepairTemplate {
+    id: "style/rename-to-convention",
+    summary: "Rename to match the casing convention for this kind",
+    safety: RepairSafety::SurfaceChanging,
+};
+
+const REPAIR_TYPES_ADD_SHAPE_ANNOTATION: RepairTemplate = RepairTemplate {
+    id: "types/add-shape-annotation",
+    summary: "Annotate the dict with a concrete shape type",
+    safety: RepairSafety::SurfaceChanging,
+};
+
+const REPAIR_MANUAL_REVIEW_CAPABILITY: RepairTemplate = RepairTemplate {
+    id: "manual/review-capability-binding",
+    summary: "Review the capability binding; the fix is not mechanical",
+    safety: RepairSafety::NeedsHuman,
+};
+
+const REPAIR_MANUAL_NEEDS_HUMAN: RepairTemplate = RepairTemplate {
+    id: "manual/needs-human",
+    summary: "Plan a human-led change; auto-apply is not safe here",
+    safety: RepairSafety::NeedsHuman,
+};
+
+/// Every distinct repair template registered by [`Code::repair_template`],
+/// in source order. Used by the catalog wire-up in E1.7 and by tests
+/// asserting the catalog is healthy.
+pub const REPAIR_REGISTRY: &[&RepairTemplate] = &[
+    &REPAIR_INSERT_EXPLICIT_CONVERSION,
+    &REPAIR_REWRITE_STRING_INTERPOLATION,
+    &REPAIR_CASTS_REMOVE_UNCHECKED,
+    &REPAIR_CASTS_REMOVE_REDUNDANT,
+    &REPAIR_BINDINGS_RENAME_TO_CLOSEST,
+    &REPAIR_BINDINGS_MAKE_MUTABLE,
+    &REPAIR_BINDINGS_MAKE_IMMUTABLE,
+    &REPAIR_BINDINGS_RENAME_UNUSED,
+    &REPAIR_BINDINGS_RENAME_SHADOW,
+    &REPAIR_DECLARATIONS_REMOVE_UNUSED,
+    &REPAIR_IMPORTS_FIX_PATH,
+    &REPAIR_IMPORTS_REMOVE_UNUSED,
+    &REPAIR_IMPORTS_REORDER,
+    &REPAIR_ERRORS_CHECK_OR_RESCUE,
+    &REPAIR_ERRORS_WRAP_IN_FN,
+    &REPAIR_MATCH_ADD_MISSING_ARMS,
+    &REPAIR_MATCH_REMOVE_DUPLICATE_ARM,
+    &REPAIR_FORMAT_REFORMAT,
+    &REPAIR_DOC_COMMENT_MIGRATE,
+    &REPAIR_DOC_ADD_HARNDOC,
+    &REPAIR_BLOCK_REMOVE_EMPTY,
+    &REPAIR_CONTROL_FLOW_FLATTEN,
+    &REPAIR_EXPRESSION_SIMPLIFY,
+    &REPAIR_CLONE_REMOVE_REDUNDANT,
+    &REPAIR_COLLECTION_PREFER_LAZY,
+    &REPAIR_DEAD_CODE_REMOVE,
+    &REPAIR_STDLIB_MIGRATE_RENAMED,
+    &REPAIR_LLM_MIGRATE_DEPRECATED_OPTION,
+    &REPAIR_LLM_ADD_SCHEMA,
+    &REPAIR_LLM_USE_CAPABILITY_FLAG,
+    &REPAIR_PROMPTS_ESCAPE_INJECTION,
+    &REPAIR_PROMPTS_ADD_TOOL_TO_SURFACE,
+    &REPAIR_STYLE_RENAME_TO_CONVENTION,
+    &REPAIR_TYPES_ADD_SHAPE_ANNOTATION,
+    &REPAIR_MANUAL_REVIEW_CAPABILITY,
+    &REPAIR_MANUAL_NEEDS_HUMAN,
+];
+
 #[cfg(test)]
 mod tests {
-    use super::{Category, Code};
+    use super::{Category, Code, ParseRepairSafetyError, RepairSafety, REPAIR_REGISTRY};
     use std::collections::HashSet;
     use std::str::FromStr;
 
@@ -513,6 +1070,182 @@ mod tests {
                     other
                 );
             }
+        }
+    }
+
+    #[test]
+    fn repair_safety_string_roundtrip() {
+        for safety in RepairSafety::ALL {
+            let parsed = RepairSafety::from_str(safety.as_str()).unwrap();
+            assert_eq!(parsed, *safety);
+            assert_eq!(parsed.to_string(), safety.as_str());
+        }
+        assert_eq!(
+            RepairSafety::from_str("not-a-safety-class"),
+            Err(ParseRepairSafetyError)
+        );
+    }
+
+    #[test]
+    fn repair_safety_ordering_is_monotonic_low_to_high() {
+        // The is_at_most ceiling check relies on this ordering being
+        // least-to-most disruptive; a regression here flips the meaning
+        // of `harn fix --safety <ceiling>` for every caller.
+        let order = RepairSafety::ALL;
+        for window in order.windows(2) {
+            assert!(
+                window[0] < window[1],
+                "{:?} should be safer than {:?}",
+                window[0],
+                window[1]
+            );
+            assert!(window[0].is_at_most(window[1]));
+            assert!(!window[1].is_at_most(window[0]));
+        }
+    }
+
+    #[test]
+    fn repair_registry_has_at_least_twenty_entries() {
+        assert!(
+            REPAIR_REGISTRY.len() >= 20,
+            "expected ≥20 repair templates, found {}",
+            REPAIR_REGISTRY.len()
+        );
+    }
+
+    #[test]
+    fn repair_ids_are_kebab_case_namespaced_and_unique() {
+        let mut seen = HashSet::new();
+        for template in REPAIR_REGISTRY {
+            assert!(
+                seen.insert(template.id),
+                "duplicate repair id {}",
+                template.id
+            );
+            let (namespace, leaf) = template.id.split_once('/').unwrap_or_else(|| {
+                panic!(
+                    "repair id `{}` is missing `<namespace>/` prefix",
+                    template.id
+                )
+            });
+            assert!(
+                !namespace.is_empty() && !leaf.is_empty(),
+                "repair id `{}` has empty namespace or leaf",
+                template.id
+            );
+            for ch in template.id.chars() {
+                assert!(
+                    ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '-' || ch == '/',
+                    "repair id `{}` has non-kebab character {ch:?}",
+                    template.id
+                );
+            }
+            assert!(
+                !template.summary.is_empty(),
+                "repair {} has empty summary",
+                template.id
+            );
+            // Summaries are imperative: start with a capital ASCII letter.
+            let first = template.summary.chars().next().unwrap();
+            assert!(
+                first.is_ascii_uppercase(),
+                "repair {} summary `{}` should start with a capital",
+                template.id,
+                template.summary
+            );
+        }
+    }
+
+    #[test]
+    fn manual_namespace_is_needs_human() {
+        for template in REPAIR_REGISTRY {
+            if let Some(("manual", _)) = template.id.split_once('/') {
+                assert_eq!(
+                    template.safety,
+                    RepairSafety::NeedsHuman,
+                    "manual/* repair {} must be NeedsHuman",
+                    template.id
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn known_codes_carry_expected_safety_class() {
+        // Spot-check: the autonomy contract for several representative
+        // diagnostics. Lock in the safety class so cross-repo agents that
+        // dispatch on these don't silently drift when the catalog moves.
+        let expected: &[(Code, RepairSafety, &str)] = &[
+            (
+                Code::FormatterWouldReformat,
+                RepairSafety::FormatOnly,
+                "format/reformat",
+            ),
+            (
+                Code::ModuleImportUnused,
+                RepairSafety::BehaviorPreserving,
+                "imports/remove-unused",
+            ),
+            (
+                Code::ImmutableAssignment,
+                RepairSafety::ScopeLocal,
+                "bindings/make-mutable",
+            ),
+            (
+                Code::LintUnusedFunction,
+                RepairSafety::SurfaceChanging,
+                "declarations/remove-unused",
+            ),
+            (
+                Code::LlmProviderIdentityBranch,
+                RepairSafety::CapabilityChanging,
+                "llm/use-capability-flag",
+            ),
+            (
+                Code::PromptVariantExplosion,
+                RepairSafety::NeedsHuman,
+                "manual/needs-human",
+            ),
+            (
+                Code::NonExhaustiveMatch,
+                RepairSafety::ScopeLocal,
+                "match/add-missing-arms",
+            ),
+        ];
+        for (code, safety, repair_id) in expected {
+            let template = code
+                .repair_template()
+                .unwrap_or_else(|| panic!("{code} should have a repair template"));
+            assert_eq!(template.safety, *safety, "{code} safety class drifted");
+            assert_eq!(template.id, *repair_id, "{code} repair id drifted");
+        }
+    }
+
+    #[test]
+    fn repair_templates_cover_at_least_twenty_codes() {
+        let covered = Code::ALL
+            .iter()
+            .filter(|code| code.repair_template().is_some())
+            .count();
+        assert!(
+            covered >= 20,
+            "expected ≥20 codes with a repair template, found {covered}"
+        );
+    }
+
+    #[test]
+    fn every_registered_repair_is_referenced_by_some_code() {
+        let referenced: HashSet<&'static str> = Code::ALL
+            .iter()
+            .filter_map(|code| code.repair_template())
+            .map(|template| template.id)
+            .collect();
+        for template in REPAIR_REGISTRY {
+            assert!(
+                referenced.contains(template.id),
+                "repair {} is in REPAIR_REGISTRY but no Code maps to it",
+                template.id
+            );
         }
     }
 }

--- a/crates/harn-parser/src/lib.rs
+++ b/crates/harn-parser/src/lib.rs
@@ -7,7 +7,10 @@ pub mod typechecker;
 pub mod visit;
 
 pub use ast::*;
-pub use diagnostic_codes::{Category as DiagnosticCodeCategory, Code as DiagnosticCode};
+pub use diagnostic_codes::{
+    Category as DiagnosticCodeCategory, Code as DiagnosticCode, ParseRepairSafetyError, Repair,
+    RepairId, RepairSafety, RepairTemplate, REPAIR_REGISTRY,
+};
 pub use parser::*;
 pub use typechecker::{
     block_definitely_exits, format_type, stmt_definitely_exits, DiagnosticDetails,

--- a/crates/harn-parser/src/typechecker/mod.rs
+++ b/crates/harn-parser/src/typechecker/mod.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use crate::ast::*;
 use crate::builtin_signatures;
-use crate::diagnostic_codes::Code;
+use crate::diagnostic_codes::{Code, Repair};
 use harn_lexer::{FixEdit, Span};
 
 type TypeMismatchEvidence = (Option<(Span, String)>, Option<Span>);
@@ -47,6 +47,12 @@ pub struct TypeDiagnostic {
     /// need more than a static `FixEdit`. Out-of-band from `fix` so the
     /// string-based rendering pipeline doesn't have to care.
     pub details: Option<DiagnosticDetails>,
+    /// Structured repair classifier — id, summary, and safety class.
+    /// Agents and IDEs dispatch on `repair.safety` to decide whether to
+    /// auto-apply, propose, or escalate. `None` when no repair shape is
+    /// registered for this code; populated automatically from
+    /// [`Code::repair_template`] by the builder helpers.
+    pub repair: Option<Repair>,
 }
 
 #[derive(Debug, Clone)]
@@ -314,6 +320,7 @@ impl TypeChecker {
             related: Vec::new(),
             fix: None,
             details: None,
+            repair: default_repair(code),
         });
     }
 
@@ -334,6 +341,7 @@ impl TypeChecker {
             related: Vec::new(),
             fix: None,
             details: None,
+            repair: default_repair(code),
         });
     }
 
@@ -381,6 +389,7 @@ impl TypeChecker {
             related,
             fix: None,
             details: Some(DiagnosticDetails::TypeMismatch),
+            repair: default_repair(code),
         });
     }
 
@@ -400,6 +409,7 @@ impl TypeChecker {
             related: Vec::new(),
             fix: Some(fix),
             details: None,
+            repair: default_repair(code),
         });
     }
 
@@ -424,6 +434,7 @@ impl TypeChecker {
             related: Vec::new(),
             fix: None,
             details: None,
+            repair: default_repair(code),
         });
     }
 
@@ -447,6 +458,7 @@ impl TypeChecker {
             related: Vec::new(),
             fix: None,
             details: Some(DiagnosticDetails::NonExhaustiveMatch { missing }),
+            repair: default_repair(code),
         });
     }
 
@@ -460,6 +472,7 @@ impl TypeChecker {
             related: Vec::new(),
             fix: None,
             details: None,
+            repair: default_repair(code),
         });
     }
 
@@ -480,6 +493,7 @@ impl TypeChecker {
             related: Vec::new(),
             fix: None,
             details: None,
+            repair: default_repair(code),
         });
     }
 
@@ -501,8 +515,17 @@ impl TypeChecker {
             related: Vec::new(),
             fix: Some(fix),
             details: Some(DiagnosticDetails::LintRule { rule }),
+            repair: default_repair(code),
         });
     }
+}
+
+/// Materialize the default [`Repair`] for a diagnostic code, or `None`
+/// if no static repair shape is registered. Cheap (one pointer
+/// dereference plus an allocation for the summary string); call sites
+/// pay nothing when the code has no repair template.
+pub(crate) fn default_repair(code: Code) -> Option<Repair> {
+    code.repair_template().map(Repair::from_template)
 }
 
 #[derive(Debug)]

--- a/crates/harn-parser/src/typechecker/tests/mod.rs
+++ b/crates/harn-parser/src/typechecker/tests/mod.rs
@@ -15,6 +15,7 @@ mod imports;
 mod interfaces;
 mod narrowing;
 mod reachability;
+mod repair;
 mod strict_types;
 mod typing;
 

--- a/crates/harn-parser/src/typechecker/tests/repair.rs
+++ b/crates/harn-parser/src/typechecker/tests/repair.rs
@@ -1,0 +1,170 @@
+//! End-to-end checks for the [`Repair`] dispatch contract.
+//!
+//! These tests drive the typechecker on real Harn source and assert that
+//! each emitted [`TypeDiagnostic`] carries the registered repair id and
+//! safety class. They lock in the autonomy contract — agents and IDEs
+//! that dispatch on `repair.safety` rely on these mappings staying
+//! stable across releases.
+
+use super::{check_source, check_source_with_source};
+use crate::diagnostic_codes::{Code, RepairSafety};
+
+/// Run the typechecker and return the first diagnostic whose code matches
+/// `code`. Panics with diagnostic context if no such diagnostic was
+/// produced — the test source is wrong if this fires.
+fn first_with_code(source: &str, code: Code) -> crate::TypeDiagnostic {
+    let diags = check_source(source);
+    diags
+        .into_iter()
+        .find(|d| d.code == code)
+        .unwrap_or_else(|| panic!("no diagnostic with code {code} emitted by source:\n{source}"))
+}
+
+fn first_with_code_with_source(source: &str, code: Code) -> crate::TypeDiagnostic {
+    let diags = check_source_with_source(source);
+    diags
+        .into_iter()
+        .find(|d| d.code == code)
+        .unwrap_or_else(|| panic!("no diagnostic with code {code} emitted by source:\n{source}"))
+}
+
+#[test]
+fn type_mismatch_attaches_scope_local_repair() {
+    let diag = first_with_code(
+        r#"
+            pipeline main() {
+                let x: int = "not an int"
+            }
+        "#,
+        Code::VariableTypeMismatch,
+    );
+    let repair = diag
+        .repair
+        .expect("VariableTypeMismatch should carry a repair");
+    assert_eq!(repair.id.as_str(), "casts/insert-explicit-conversion");
+    assert_eq!(repair.safety, RepairSafety::ScopeLocal);
+}
+
+#[test]
+fn non_exhaustive_match_attaches_scope_local_repair() {
+    let diag = first_with_code(
+        r#"
+            type Color = "red" | "green" | "blue"
+            pipeline main() {
+                let c: Color = "red"
+                match c {
+                    "red" -> { 1 }
+                    "green" -> { 2 }
+                }
+            }
+        "#,
+        Code::NonExhaustiveMatch,
+    );
+    let repair = diag
+        .repair
+        .expect("NonExhaustiveMatch should carry a repair");
+    assert_eq!(repair.id.as_str(), "match/add-missing-arms");
+    assert_eq!(repair.safety, RepairSafety::ScopeLocal);
+}
+
+#[test]
+fn immutable_assignment_attaches_scope_local_repair() {
+    let diag = first_with_code(
+        r#"
+            pipeline main() {
+                let x = 1
+                x = 2
+            }
+        "#,
+        Code::ImmutableAssignment,
+    );
+    let repair = diag
+        .repair
+        .expect("ImmutableAssignment should carry a repair");
+    assert_eq!(repair.id.as_str(), "bindings/make-mutable");
+    assert_eq!(repair.safety, RepairSafety::ScopeLocal);
+}
+
+#[test]
+fn string_interpolation_rewrite_attaches_behavior_preserving_repair() {
+    // build_interpolation_fix only runs when the checker has source text
+    // attached, so route through the source-aware helper.
+    let diag = first_with_code_with_source(
+        "pipeline main() { let count = 1; let greeting = \"hello \" + count; greeting }",
+        Code::StringInterpolationRewrite,
+    );
+    let repair = diag
+        .repair
+        .expect("StringInterpolationRewrite should carry a repair");
+    assert_eq!(repair.id.as_str(), "style/string-interpolation");
+    assert_eq!(repair.safety, RepairSafety::BehaviorPreserving);
+}
+
+#[test]
+fn try_outside_function_attaches_surface_changing_repair() {
+    let diag = first_with_code(
+        r#"
+            try* maybe_fail()
+        "#,
+        Code::TryOutsideFunction,
+    );
+    let repair = diag
+        .repair
+        .expect("TryOutsideFunction should carry a repair");
+    assert_eq!(repair.id.as_str(), "errors/wrap-in-fn");
+    assert_eq!(repair.safety, RepairSafety::SurfaceChanging);
+}
+
+#[test]
+fn diagnostics_without_registered_template_have_no_repair() {
+    // `LlmSchemaInvalid` has no registered repair template — agents
+    // should treat these as "diagnose only".
+    let diags = check_source(
+        r#"
+            pipeline main() {
+                let r = llm_call("you", "instructions", {
+                    "schema": 42,
+                })
+                r
+            }
+        "#,
+    );
+    if let Some(diag) = diags.iter().find(|d| d.code == Code::LlmSchemaInvalid) {
+        assert!(
+            diag.repair.is_none(),
+            "LlmSchemaInvalid should not carry a repair until one is registered, got {:?}",
+            diag.repair
+        );
+    }
+}
+
+#[test]
+fn every_emitted_repair_matches_registry_safety() {
+    // Defensive cross-check: every emitted diagnostic's repair (when
+    // present) must match the static registry. Catches drift if a future
+    // emitter constructs a Repair inline instead of going through the
+    // central registry-driven default.
+    let sources = [
+        "pipeline main() { let x: int = \"nope\" }",
+        "pipeline main() { let x = 1; x = 2 }",
+        "type Color = \"red\" | \"green\"\npipeline main() { let c: Color = \"red\"; match c { \"red\" -> { 1 } } }",
+    ];
+    for source in sources {
+        for diag in check_source(source) {
+            let Some(repair) = diag.repair.as_ref() else {
+                continue;
+            };
+            let template = diag
+                .code
+                .repair_template()
+                .unwrap_or_else(|| panic!("{} carried repair but registry has none", diag.code));
+            assert_eq!(
+                repair.id.as_str(),
+                template.id,
+                "{} repair id drift",
+                diag.code
+            );
+            assert_eq!(repair.safety, template.safety, "{} safety drift", diag.code);
+        }
+    }
+}

--- a/crates/harn-parser/src/typechecker/tests/typing.rs
+++ b/crates/harn-parser/src/typechecker/tests/typing.rs
@@ -1191,6 +1191,7 @@ fn test_type_mismatch_render_snapshot_with_coercion_help() {
  2 |   let label: string = 42
    |                       ^^ found this type
    = help: did you mean `to_string(42)`?
+   = repair: casts/insert-explicit-conversion [scope-local] — Insert an explicit conversion or correct the operand type
    = note: expected type declared here
   --> test.harn:2:3
    |
@@ -1215,6 +1216,7 @@ fn test_type_mismatch_render_snapshot_with_nested_note() {
    |
  2 |   let item: {name: string, count: int} = {name: 1, count: 2}
    |                                          ^^^^^^^^^^^^^^^^^^^ found this type
+   = repair: casts/insert-explicit-conversion [scope-local] — Insert an explicit conversion or correct the operand type
    = note: expected type declared here
   --> test.harn:2:3
    |

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -649,21 +649,30 @@ agent or editor can ingest without parsing prose:
 ```json
 {
   "schemaVersion": 1,
-  "code": "HARN-TYP-014",
-  "category": "TYP",
-  "summary": "declaration has the wrong number of type parameters",
-  "body": "# HARN-TYP-014 — ... full markdown ...",
-  "repairs": [],
-  "related": ["HARN-TYP-013"],
+  "code": "HARN-OWN-001",
+  "category": "OWN",
+  "summary": "immutable binding is reassigned",
+  "body": "# HARN-OWN-001 — ... full markdown ...",
+  "repairs": [
+    {
+      "id": "bindings/make-mutable",
+      "safety": "scope-local",
+      "summary": "Mark the binding `mut` so it can be reassigned"
+    }
+  ],
+  "related": [],
   "apiStability": "stable"
 }
 ```
 
 `schemaVersion` is the contract LSPs, IDEs, and hosted error-page mirrors
-dispatch on; bumps will follow a deprecation cycle. `repairs` is currently
-empty and will populate once the `Repair` struct lands on
-`TypeDiagnostic` (see epic [#1745](https://github.com/burin-labs/harn/issues/1745)).
-An unknown code exits with status 2.
+dispatch on; bumps will follow a deprecation cycle. `repairs` carries the
+structured repair classifier — a namespaced kebab-case id plus a
+six-level safety class (`format-only` → `behavior-preserving` →
+`scope-local` → `surface-changing` → `capability-changing` →
+`needs-human`) — that agents use to decide whether to auto-apply,
+propose, or escalate a fix. Codes without a registered repair shape
+return `"repairs": []`. An unknown code exits with status 2.
 
 ### Form 2 — explain a control-flow invariant violation
 

--- a/scripts/check_diagnostic_codes.py
+++ b/scripts/check_diagnostic_codes.py
@@ -116,11 +116,23 @@ def category_code(category: str) -> str:
 
 
 def check_struct_literals(errors: list[str], name: str, root: Path) -> None:
+    # Patterns that precede `Foo {` in non-literal positions (and the
+    # name itself sits at `start`, so we only need to inspect what comes
+    # immediately before it).
+    non_literal_prefix = re.compile(
+        r"(?:\bimpl(?:\s*<[^>]*>)?\s+(?:[\w:]+::)?|->\s*(?:[\w:]+::)?)$"
+    )
     for path in sorted(root.rglob("*.rs")):
         text = path.read_text()
         for start, end in find_struct_literals(text, f"{name} {{"):
             prefix = text[max(0, start - 80) : start]
+            # Skip non-literal occurrences:
+            #   - the struct definition itself (`pub struct Foo { ... }`)
+            #   - inherent / trait impl blocks (`impl Foo { ... }`)
+            #   - function return-type body openings (`-> Foo {`, `-> crate::Foo {`)
             if f"pub struct {name}" in prefix:
+                continue
+            if non_literal_prefix.search(prefix):
                 continue
             block = text[start:end]
             if not re.search(r"\bcode\s*[:,]", block):
@@ -201,7 +213,10 @@ def check_unknown_code_variants(errors: list[str], code_names: set[str]) -> None
             if path == REGISTRY:
                 continue
             text = path.read_text()
-            for match in re.finditer(r"\bCode::([A-Za-z][A-Za-z0-9_]*)", text):
+            # Rust convention: enum variants are UpperCamelCase, methods
+            # are snake_case. Only flag the former — `Code::repair_template()`
+            # and other inherent methods are intentionally not variants.
+            for match in re.finditer(r"\bCode::([A-Z][A-Za-z0-9_]*)", text):
                 if match.group(1) not in code_names:
                     errors.append(
                         f"{rel(path)}:{line(text, match.start())}: unknown Code::{match.group(1)}"


### PR DESCRIPTION
## Summary

Closes #1747 (E1.2 of epic #1745).

- New `Repair { id, summary, safety }` and 6-level `RepairSafety` enum in `harn-parser`: `format-only` → `behavior-preserving` → `scope-local` → `surface-changing` → `capability-changing` → `needs-human`. Variants implement `Ord` so callers can declare an autonomy ceiling and use `is_at_most(ceiling)` to dispatch.
- Central `Code::repair_template()` registry mapping ~60 diagnostic codes to 36 namespaced repair templates (`bindings/make-mutable`, `imports/fix-path`, `errors/check-or-rescue`, `match/add-missing-arms`, `llm/use-capability-flag`, `manual/needs-human`, …).
- `TypeDiagnostic` grows `repair: Option<Repair>`, auto-populated from the registry by every constructor helper (`error_at`, `warning_at`, `type_mismatch_at`, `exhaustiveness_error_with_missing`, etc.). Single source of truth on `Code` — no per-site copies to drift.
- `LintDiagnostic` and `FormatError` expose the same dispatch handle through derived `.repair()` methods rather than storing a redundant copy.
- CLI rendering surfaces the repair as a `repair: ID [SAFETY] — SUMMARY` line beneath each diagnostic.
- `harn explain HARN-... --json` now populates the previously-empty `repairs` array in the envelope (the E1.3 commit explicitly noted this would land here).
- `harn explain` text mode prints a `Repair: ID [SAFETY] — SUMMARY` line.
- LSP attaches the repair to `Diagnostic.data` as `{"repair": {"id", "summary", "safety"}}` so code-action providers can dispatch on safety without re-deriving from the code.
- Tightens `scripts/check_diagnostic_codes.py` to skip `impl Foo {` and `-> Foo {` non-literal matches and to ignore inherent method paths like `Code::repair_template()`.

## Tests added

- Registry health: uniqueness, kebab-case namespaced ids, `manual/*` → `NeedsHuman`, ≥20 templates, every template referenced by some code, ≥20 codes carry a template.
- `RepairSafety` FromStr/Display roundtrip + ordering monotonicity.
- Spot-check: 7 known (code, safety, repair-id) tuples locked in.
- End-to-end on real Harn source: 5 representative codes carry the right safety class via the typechecker (`HARN-TYP-007`, `HARN-MAT-001`, `HARN-OWN-001`, `HARN-TYP-003`, `HARN-RCV-002`), plus a defensive cross-check that every emitted repair matches the registry.
- LSP test: `Diagnostic.data.repair.safety` is populated end-to-end for an immutable-assignment.
- `harn explain --json` envelope `repairs` array test: surfaced for a code with a registered repair; empty array for a code without one.

## Verification

- [x] `cargo fmt --all -- --check`
- [x] `make lint-diagnostic-codes` → OK
- [x] `make lint-md` → 0 errors
- [x] `make lint-test-patterns` → no violations
- [x] `make check-docs-snippets` → 537 checked, 0 failed
- [x] `cargo clippy --workspace -- -D warnings` → clean
- [x] `cargo nextest run -p harn-parser -p harn-lint -p harn-fmt -p harn-lsp -p harn-cli --lib` → 1232 passed
- [x] `cargo run --bin harn -- test conformance` → 1074 passed
- [x] `cargo run --bin harn -- check conformance/tests` → 232 coded diagnostics, 84 carry an attached repair line

## Test plan

- [ ] CI green on all gates
- [ ] Downstream consumers (burin-code / harn-cloud) replatform via the `repair` field — wired up in the cross-repo tickets pinned to epic #1745

🤖 Generated with [Claude Code](https://claude.com/claude-code)