### PR TITLE
Add `harn pack <entrypoint>` for .harnpack bundles (#1781)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,29 @@ condensed series summaries instead of full per-patch history.
   `.repair()` methods. The CLI now renders a `repair: ID [SAFETY] —
   SUMMARY` line, and the LSP attaches the same payload to
   `Diagnostic.data` as `{"repair": {"id", "summary", "safety"}}`.
+- **`harn pack <entrypoint>` builds a `.harnpack` run bundle (#1781).**
+  New top-level CLI subcommand that walks the entrypoint's transitive
+  imports, precompiles every module into the bytecode-cache header
+  format, snapshots the provider catalog hash + stdlib pin, generates a
+  minimal SBOM (one entry per module + stdlib dep), and assembles a v2
+  `WorkflowBundle` manifest. The result is a deterministic tar.zst
+  archive written to `<entrypoint>.harnpack` (overridable with
+  `--out <path>`). `--json` emits the canonical `JsonEnvelope`
+  containing `bundle_hash` (BLAKE3 over the canonical manifest + sorted
+  content hashes), `output_path`, `size_bytes`, and the full manifest;
+  the catalog row is registered with `harn --json-schemas`.
+  `--upgrade <old.harnpack>` reads an older bundle (v1 JSON or v2
+  archive) and re-emits it under the v2 manifest, preserving the prior
+  bundle's id, name, version, triggers, workflow graph, and prompt
+  capsules while populating the new v2 fields from the entrypoint walk.
+  Signing (E6.3) and full SBOM enumeration (E6.4) land in follow-ups;
+  today the bundle ships unsigned. Companion: `harn-vm` exposes
+  `read_workflow_bundle_manifest_any_version` and
+  `load_workflow_bundle_any_version` for relaxed-schema reads, and
+  `bytecode_cache::serialize_chunk_artifact` /
+  `serialize_module_artifact` so in-memory consumers can package
+  bytecode bytes byte-identical to the on-disk `.harnbc`/`.harnmod`
+  files.
 - **`with_scoped_executor` tool-caller middleware (#1702).** Narrows the
   active `CapabilityPolicy` for the duration of one tool dispatch:
   `compose_tool_callers([..., with_scoped_executor({stage, allowed_tools,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2069,6 +2069,7 @@ dependencies = [
  "axum",
  "axum-server",
  "base64",
+ "blake3",
  "chrono-tz",
  "clap",
  "clap_complete",

--- a/crates/harn-cli/Cargo.toml
+++ b/crates/harn-cli/Cargo.toml
@@ -56,6 +56,7 @@ notify = "8"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "blocking", "stream"] }
 futures = "0.3"
 sha2 = "0.11"
+blake3 = "1"
 tar = { version = "0.4", default-features = false }
 flate2 = "1"
 subtle = "2.6"

--- a/crates/harn-cli/src/cli/mod.rs
+++ b/crates/harn-cli/src/cli/mod.rs
@@ -31,6 +31,7 @@ mod mcp;
 mod merge_captain;
 mod models;
 mod orchestrator;
+mod pack;
 mod package;
 mod persona;
 mod playground;
@@ -125,6 +126,7 @@ pub(crate) use orchestrator::{
     OrchestratorTenantCreateArgs, OrchestratorTenantDeleteArgs, OrchestratorTenantLsArgs,
     OrchestratorTenantSuspendArgs,
 };
+pub use pack::PackArgs;
 pub(crate) use package::{
     AddArgs, InstallArgs, PackageArgs, PackageArtifactsCommand, PackageCacheCommand,
     PackageCommand, PublishArgs, RemoveArgs, UpdateArgs,
@@ -362,6 +364,20 @@ SCRIPTING
     /// `<name>.harnbc` by default; pass `--out DIR` to redirect them
     /// into a sibling tree.
     Precompile(PrecompileArgs),
+    /// Build a signed-ready `.harnpack` run bundle from a Harn entrypoint.
+    ///
+    /// `harn pack <entrypoint>` walks the entrypoint's transitive imports,
+    /// precompiles every module, snapshots the provider catalog and
+    /// stdlib pin, generates a minimal SBOM, and emits a deterministic
+    /// tar.zst container under `<entrypoint>.harnpack` (or `--out`).
+    ///
+    /// `--upgrade <old.harnpack>` reads an existing bundle (v1 or v2) and
+    /// re-emits it under the v2 manifest, preserving the prior bundle's
+    /// workflow graph, triggers, and prompt capsules.
+    ///
+    /// Signing (E6.3) and richer SBOM enumeration (E6.4) land in
+    /// follow-ups; today the bundle ships unsigned with a stdlib-pin SBOM.
+    Pack(PackArgs),
     /// Render a .harn file as a Mermaid workflow graph.
     Viz(VizArgs),
     /// Install dependencies declared in harn.toml.

--- a/crates/harn-cli/src/cli/pack.rs
+++ b/crates/harn-cli/src/cli/pack.rs
@@ -1,0 +1,35 @@
+use std::path::PathBuf;
+
+use clap::Args;
+
+#[derive(Debug, Args)]
+#[command(arg_required_else_help = true)]
+pub struct PackArgs {
+    /// Entrypoint `.harn` file to pack. Transitive imports under the
+    /// entrypoint's directory are bundled alongside it.
+    pub entrypoint: PathBuf,
+
+    /// Output `.harnpack` path. Defaults to the entrypoint stem with
+    /// the `.harnpack` extension next to the entrypoint.
+    #[arg(long, value_name = "PATH")]
+    pub out: Option<PathBuf>,
+
+    /// Read an existing `.harnpack` and re-emit it under the v2
+    /// manifest, preserving the prior bundle's id, name, version,
+    /// triggers, workflow graph, and prompt capsules. The new
+    /// `<entrypoint>` argument supplies the transitive-modules /
+    /// SBOM payload that v1 lacked.
+    #[arg(long, value_name = "OLD_BUNDLE")]
+    pub upgrade: Option<PathBuf>,
+
+    /// Mark the bundle as unsigned. Signing lands in E6.3; today this
+    /// flag is documentary so scripts can opt into the future
+    /// `--sign`/`--unsigned` split without breaking.
+    #[arg(long, default_value_t = false)]
+    pub unsigned: bool,
+
+    /// Emit a `JsonEnvelope` summary instead of a human-readable
+    /// one-liner. Schema: `harn --json-schemas --command pack`.
+    #[arg(long, default_value_t = false)]
+    pub json: bool,
+}

--- a/crates/harn-cli/src/commands/mod.rs
+++ b/crates/harn-cli/src/commands/mod.rs
@@ -25,6 +25,7 @@ pub(crate) mod merge_captain;
 pub(crate) mod merge_captain_mock;
 pub(crate) mod models;
 pub mod orchestrator;
+pub mod pack;
 pub mod persona;
 pub mod persona_doctor;
 pub mod persona_scaffold;

--- a/crates/harn-cli/src/commands/pack.rs
+++ b/crates/harn-cli/src/commands/pack.rs
@@ -1,0 +1,559 @@
+//! `harn pack <entrypoint>` — build a signed-ready `.harnpack` from a
+//! Harn entrypoint.
+//!
+//! Walks the entrypoint's transitive imports, precompiles every module
+//! into a `.harnbc` artifact, snapshots the provider catalog and
+//! stdlib pin, generates a minimal SBOM, assembles a v2 `WorkflowBundle`
+//! manifest, and emits a deterministic tar.zst archive. Signing lands
+//! in E6.3; SBOM body and CLI `--json` polish in E6.4.
+
+use std::collections::BTreeMap;
+use std::path::{Component, Path, PathBuf};
+use std::process;
+
+use harn_parser::DiagnosticSeverity;
+use harn_vm::bytecode_cache;
+use harn_vm::module_artifact;
+use harn_vm::orchestration::{
+    build_harnpack, current_provider_catalog_hash_blake3, load_workflow_bundle_any_version,
+    workflow_bundle_hash, CatchupPolicySpec, ConnectorRequirement, EnvironmentRequirements,
+    HarnpackEntry, ModuleEntry, RetryPolicySpec, SBOMDoc, SBOMPackage, SBOMRelationship, ToolEntry,
+    WorkflowBundle, WorkflowBundlePolicy, WorkflowBundleReplayMetadata, WorkflowBundleTrigger,
+    WORKFLOW_BUNDLE_SCHEMA_VERSION,
+};
+use harn_vm::Compiler;
+use serde::Serialize;
+
+use crate::cli::PackArgs;
+use crate::command_error;
+use crate::json_envelope::{to_string_pretty, JsonEnvelope, JsonOutput};
+use crate::parse_source_file;
+
+/// Stable schema version for the `harn pack --json` envelope. Bump when
+/// [`PackJsonData`] changes shape in a way that agents need to detect.
+pub const PACK_SCHEMA_VERSION: u32 = 1;
+
+/// JSON payload emitted under `JsonEnvelope.data` for `harn pack`.
+#[derive(Debug, Clone, Serialize)]
+pub struct PackJsonData {
+    pub bundle_hash: String,
+    pub output_path: PathBuf,
+    pub size_bytes: u64,
+    pub manifest: WorkflowBundle,
+}
+
+struct PackJsonOutput(PackJsonData);
+
+impl JsonOutput for PackJsonOutput {
+    const SCHEMA_VERSION: u32 = PACK_SCHEMA_VERSION;
+    type Data = PackJsonData;
+    fn into_envelope(self) -> JsonEnvelope<Self::Data> {
+        JsonEnvelope::ok(Self::SCHEMA_VERSION, self.0)
+    }
+}
+
+pub fn run(args: PackArgs) {
+    match build(&args) {
+        Ok(outcome) => {
+            if args.json {
+                let envelope = PackJsonOutput(outcome.json).into_envelope();
+                println!("{}", to_string_pretty(&envelope));
+            } else {
+                println!(
+                    "wrote {} ({} bytes, bundle_hash {})",
+                    outcome.output_path.display(),
+                    outcome.size_bytes,
+                    outcome.bundle_hash
+                );
+            }
+        }
+        Err(err) => {
+            if args.json {
+                let envelope: JsonEnvelope<PackJsonData> =
+                    JsonEnvelope::err(PACK_SCHEMA_VERSION, err.code, err.message);
+                println!("{}", to_string_pretty(&envelope));
+                process::exit(1);
+            }
+            command_error(&err.message);
+        }
+    }
+}
+
+/// Programmatic entrypoint used by tests and other CLI command code
+/// that needs the JSON envelope without going through stdout.
+pub fn run_to_envelope(args: &PackArgs) -> JsonEnvelope<PackJsonData> {
+    match build(args) {
+        Ok(outcome) => PackJsonOutput(outcome.json).into_envelope(),
+        Err(err) => JsonEnvelope::err(PACK_SCHEMA_VERSION, err.code, err.message),
+    }
+}
+
+/// Outcome of [`build`]. Used by tests; the dispatcher consumes it
+/// directly via [`run`].
+pub struct PackOutcome {
+    pub bundle_hash: String,
+    pub output_path: PathBuf,
+    pub size_bytes: u64,
+    pub json: PackJsonData,
+}
+
+#[derive(Debug)]
+pub struct PackError {
+    pub code: &'static str,
+    pub message: String,
+}
+
+impl std::fmt::Display for PackError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.code, self.message)
+    }
+}
+
+impl std::error::Error for PackError {}
+
+impl PackError {
+    fn new(code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+        }
+    }
+}
+
+pub fn build(args: &PackArgs) -> Result<PackOutcome, PackError> {
+    if let Some(upgrade) = &args.upgrade {
+        if !upgrade.exists() {
+            return Err(PackError::new(
+                "upgrade.not_found",
+                format!(
+                    "--upgrade source bundle does not exist: {}",
+                    upgrade.display()
+                ),
+            ));
+        }
+    }
+    let entrypoint = args
+        .entrypoint
+        .canonicalize()
+        .unwrap_or_else(|_| args.entrypoint.clone());
+    if !entrypoint.exists() {
+        return Err(PackError::new(
+            "entrypoint.not_found",
+            format!("entrypoint does not exist: {}", args.entrypoint.display()),
+        ));
+    }
+    if !entrypoint.is_file() || entrypoint.extension().and_then(|ext| ext.to_str()) != Some("harn")
+    {
+        return Err(PackError::new(
+            "entrypoint.invalid",
+            format!(
+                "entrypoint must be a .harn file: {}",
+                args.entrypoint.display()
+            ),
+        ));
+    }
+    let project_root = entrypoint
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("."));
+    let entrypoint_rel = relativize(&project_root, &entrypoint).ok_or_else(|| {
+        PackError::new(
+            "entrypoint.outside_root",
+            format!(
+                "entrypoint {} could not be relativized against {}",
+                entrypoint.display(),
+                project_root.display()
+            ),
+        )
+    })?;
+
+    let prior = match &args.upgrade {
+        Some(path) => Some(load_workflow_bundle_any_version(path).map_err(|err| {
+            PackError::new(
+                "upgrade.read_failed",
+                format!("failed to read --upgrade source {}: {err}", path.display()),
+            )
+        })?),
+        None => None,
+    };
+
+    let graph = harn_modules::build(std::slice::from_ref(&entrypoint));
+    let mut module_paths = graph.module_paths();
+    // The entrypoint is always present in the graph; ensure deterministic order.
+    module_paths.sort();
+
+    let mut transitive_modules = Vec::new();
+    let mut contents = Vec::new();
+    let mut sbom_packages = Vec::new();
+    let mut sbom_relationships = Vec::new();
+
+    let stdlib_version = bytecode_cache::HARN_VERSION.to_string();
+    let harn_version = bytecode_cache::HARN_VERSION.to_string();
+
+    sbom_packages.push(SBOMPackage {
+        name: "harn-stdlib".to_string(),
+        version: Some(stdlib_version.clone()),
+        package_hash_blake3: None,
+        license: None,
+    });
+
+    for module_path in &module_paths {
+        let module_str = module_path.to_string_lossy().to_string();
+        if module_str.starts_with("<std>/") {
+            let stdlib_name = module_str.trim_start_matches("<std>/").to_string();
+            sbom_packages.push(SBOMPackage {
+                name: format!("std/{stdlib_name}"),
+                version: Some(stdlib_version.clone()),
+                package_hash_blake3: None,
+                license: None,
+            });
+            sbom_relationships.push(SBOMRelationship {
+                from: format!("entrypoint:{}", entrypoint_rel.display()),
+                to: format!("std/{stdlib_name}"),
+                relationship_type: "depends_on".to_string(),
+            });
+            continue;
+        }
+
+        let source = std::fs::read_to_string(module_path).map_err(|err| {
+            PackError::new(
+                "module.read_failed",
+                format!("failed to read {}: {err}", module_path.display()),
+            )
+        })?;
+
+        let (parsed_source, program) = parse_source_file(&module_str);
+        debug_assert_eq!(parsed_source, source);
+        type_check_or_fail(&source, &module_str, &program)?;
+
+        let entry_chunk = Compiler::new().compile(&program).map_err(|err| {
+            PackError::new(
+                "module.compile_failed",
+                format!("compile error in {}: {err}", module_path.display()),
+            )
+        })?;
+
+        let module_artifact_opt =
+            module_artifact::compile_module_artifact(&program, Some(module_str.clone())).ok();
+
+        let cache_key = bytecode_cache::CacheKey::from_source(module_path, &source);
+        let chunk_bytes = bytecode_cache::serialize_chunk_artifact(&cache_key, &entry_chunk)
+            .map_err(|err| {
+                PackError::new(
+                    "module.serialize_failed",
+                    format!(
+                        "failed to serialize chunk for {}: {err}",
+                        module_path.display()
+                    ),
+                )
+            })?;
+
+        let module_artifact_bytes = match module_artifact_opt.as_ref() {
+            Some(artifact) => Some(
+                bytecode_cache::serialize_module_artifact(&cache_key, artifact).map_err(|err| {
+                    PackError::new(
+                        "module.serialize_failed",
+                        format!(
+                            "failed to serialize module artifact for {}: {err}",
+                            module_path.display()
+                        ),
+                    )
+                })?,
+            ),
+            None => None,
+        };
+
+        let rel = relativize(&project_root, module_path).unwrap_or_else(|| {
+            PathBuf::from(
+                module_path
+                    .file_name()
+                    .map(|name| name.to_string_lossy().into_owned())
+                    .unwrap_or_else(|| module_str.clone()),
+            )
+        });
+        let source_archive_path = PathBuf::from("sources").join(&rel);
+        let chunk_archive_path = adjacent_with_extension(&rel, bytecode_cache::CACHE_EXTENSION)
+            .ok_or_else(|| {
+                PackError::new(
+                    "module.invalid_path",
+                    format!("module path has no stem: {}", module_path.display()),
+                )
+            })?;
+        let chunk_archive_path = PathBuf::from("bytecode").join(chunk_archive_path);
+
+        let source_hash = blake3_hash(source.as_bytes());
+        let harnbc_hash = blake3_hash(&chunk_bytes);
+
+        transitive_modules.push(ModuleEntry {
+            path: rel.clone(),
+            source_hash_blake3: source_hash.clone(),
+            harnbc_hash_blake3: harnbc_hash.clone(),
+        });
+
+        contents.push(HarnpackEntry::new(
+            source_archive_path,
+            source.as_bytes().to_vec(),
+        ));
+        contents.push(HarnpackEntry::new(chunk_archive_path, chunk_bytes));
+        if let Some(artifact_bytes) = module_artifact_bytes {
+            let module_rel = adjacent_with_extension(&rel, bytecode_cache::MODULE_CACHE_EXTENSION)
+                .ok_or_else(|| {
+                    PackError::new(
+                        "module.invalid_path",
+                        format!("module path has no stem: {}", module_path.display()),
+                    )
+                })?;
+            let module_archive_path = PathBuf::from("bytecode").join(module_rel);
+            contents.push(HarnpackEntry::new(module_archive_path, artifact_bytes));
+        }
+
+        if module_path != &entrypoint {
+            sbom_relationships.push(SBOMRelationship {
+                from: format!("entrypoint:{}", entrypoint_rel.display()),
+                to: format!("module:{}", rel.display()),
+                relationship_type: "depends_on".to_string(),
+            });
+        }
+        sbom_packages.push(SBOMPackage {
+            name: format!("module:{}", rel.display()),
+            version: Some(harn_version.clone()),
+            package_hash_blake3: Some(source_hash),
+            license: None,
+        });
+    }
+
+    if transitive_modules.is_empty() {
+        return Err(PackError::new(
+            "pack.no_modules",
+            format!(
+                "no Harn modules resolved from entrypoint {}",
+                entrypoint.display()
+            ),
+        ));
+    }
+
+    let provider_catalog_hash = current_provider_catalog_hash_blake3().map_err(|err| {
+        PackError::new(
+            "provider_catalog.failed",
+            format!("failed to snapshot provider catalog: {err}"),
+        )
+    })?;
+
+    // E6.4 populates `tool_manifest` from the static module walk; today
+    // it stays empty so the v2 manifest is consistently deterministic.
+    let tool_manifest: Vec<ToolEntry> = Vec::new();
+    let bundle = assemble_bundle(
+        &entrypoint_rel,
+        transitive_modules,
+        stdlib_version,
+        harn_version,
+        provider_catalog_hash,
+        tool_manifest,
+        SBOMDoc {
+            format: "spdx-lite".to_string(),
+            version: "2.3".to_string(),
+            packages: sbom_packages,
+            relationships: sbom_relationships,
+        },
+        prior.as_ref(),
+    );
+
+    let archive_bytes = build_harnpack(&bundle, &contents).map_err(|err| {
+        PackError::new(
+            "pack.archive_failed",
+            format!("failed to assemble .harnpack archive: {err}"),
+        )
+    })?;
+    let bundle_hash = workflow_bundle_hash(&bundle, &contents).map_err(|err| {
+        PackError::new(
+            "pack.hash_failed",
+            format!("failed to compute bundle hash: {err}"),
+        )
+    })?;
+
+    let output_path = resolve_output_path(&args.out, &entrypoint);
+    if let Some(parent) = output_path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent).map_err(|err| {
+                PackError::new(
+                    "pack.output_dir_failed",
+                    format!("failed to create output dir {}: {err}", parent.display()),
+                )
+            })?;
+        }
+    }
+    std::fs::write(&output_path, &archive_bytes).map_err(|err| {
+        PackError::new(
+            "pack.write_failed",
+            format!("failed to write {}: {err}", output_path.display()),
+        )
+    })?;
+    let size_bytes = archive_bytes.len() as u64;
+
+    Ok(PackOutcome {
+        bundle_hash: bundle_hash.clone(),
+        output_path: output_path.clone(),
+        size_bytes,
+        json: PackJsonData {
+            bundle_hash,
+            output_path,
+            size_bytes,
+            manifest: bundle,
+        },
+    })
+}
+
+fn assemble_bundle(
+    entrypoint_rel: &Path,
+    transitive_modules: Vec<ModuleEntry>,
+    stdlib_version: String,
+    harn_version: String,
+    provider_catalog_hash: String,
+    tool_manifest: Vec<ToolEntry>,
+    sbom: SBOMDoc,
+    prior: Option<&WorkflowBundle>,
+) -> WorkflowBundle {
+    let stem = entrypoint_rel
+        .file_stem()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "harnpack".to_string());
+
+    let mut bundle = prior.cloned().unwrap_or_else(|| WorkflowBundle {
+        id: stem.clone(),
+        name: Some(stem.clone()),
+        version: "0.0.0".to_string(),
+        workflow: degenerate_workflow(&stem),
+        triggers: vec![WorkflowBundleTrigger {
+            id: "manual".to_string(),
+            kind: "manual".to_string(),
+            node_id: Some("entry".to_string()),
+            ..WorkflowBundleTrigger::default()
+        }],
+        policy: WorkflowBundlePolicy {
+            autonomy_tier: "act_with_approval".to_string(),
+            tool_policy: BTreeMap::new(),
+            approval_required: Vec::new(),
+            retry: RetryPolicySpec {
+                max_attempts: 1,
+                backoff: "none".to_string(),
+            },
+            catchup: CatchupPolicySpec {
+                mode: "none".to_string(),
+                max_events: None,
+            },
+        },
+        connectors: Vec::<ConnectorRequirement>::new(),
+        environment: EnvironmentRequirements::default(),
+        receipts: WorkflowBundleReplayMetadata::default(),
+        ..WorkflowBundle::default()
+    });
+
+    bundle.schema_version = WORKFLOW_BUNDLE_SCHEMA_VERSION;
+    bundle.entrypoint = entrypoint_rel.to_path_buf();
+    bundle.transitive_modules = transitive_modules;
+    bundle.stdlib_version = stdlib_version;
+    bundle.harn_version = harn_version;
+    bundle.provider_catalog_hash = provider_catalog_hash;
+    bundle.tool_manifest = tool_manifest;
+    bundle.sbom = sbom;
+    bundle.signature = None;
+    bundle
+}
+
+fn degenerate_workflow(stem: &str) -> harn_vm::orchestration::WorkflowGraph {
+    use harn_vm::orchestration::{WorkflowGraph, WorkflowNode};
+    let mut nodes = BTreeMap::new();
+    nodes.insert(
+        "entry".to_string(),
+        WorkflowNode {
+            id: Some("entry".to_string()),
+            kind: "action".to_string(),
+            task_label: Some(stem.to_string()),
+            ..WorkflowNode::default()
+        },
+    );
+    WorkflowGraph {
+        type_name: "workflow_graph".to_string(),
+        id: format!("{stem}_pack"),
+        name: Some(stem.to_string()),
+        version: 1,
+        entry: "entry".to_string(),
+        nodes,
+        ..WorkflowGraph::default()
+    }
+}
+
+fn type_check_or_fail(
+    source: &str,
+    path: &str,
+    program: &[harn_parser::SNode],
+) -> Result<(), PackError> {
+    let mut had_error = false;
+    let mut messages = String::new();
+    for diag in harn_parser::TypeChecker::new().check_with_source(program, source) {
+        let rendered = harn_parser::diagnostic::render_type_diagnostic(source, path, &diag);
+        if matches!(diag.severity, DiagnosticSeverity::Error) {
+            had_error = true;
+        }
+        messages.push_str(&rendered);
+    }
+    if had_error {
+        return Err(PackError::new(
+            "module.type_error",
+            format!("type errors in {path}:\n{messages}"),
+        ));
+    }
+    if !messages.is_empty() {
+        eprint!("{messages}");
+    }
+    Ok(())
+}
+
+fn relativize(root: &Path, target: &Path) -> Option<PathBuf> {
+    let root_canon = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
+    let target_canon = target
+        .canonicalize()
+        .unwrap_or_else(|_| target.to_path_buf());
+    if let Ok(rel) = target_canon.strip_prefix(&root_canon) {
+        return Some(rel.to_path_buf());
+    }
+    // Fallback: keep the filename so deeply-nested entrypoints still
+    // pack as relative paths.
+    target.file_name().map(PathBuf::from)
+}
+
+fn adjacent_with_extension(rel: &Path, extension: &str) -> Option<PathBuf> {
+    let stem = rel.file_stem()?.to_string_lossy().into_owned();
+    if stem.is_empty() {
+        return None;
+    }
+    let parent_components: Vec<Component<'_>> = rel
+        .parent()
+        .map(|p| p.components().collect())
+        .unwrap_or_default();
+    let mut adjacent = PathBuf::new();
+    for component in parent_components {
+        adjacent.push(component.as_os_str());
+    }
+    let mut filename = stem;
+    filename.push('.');
+    filename.push_str(extension);
+    adjacent.push(filename);
+    Some(adjacent)
+}
+
+fn blake3_hash(bytes: &[u8]) -> String {
+    format!("blake3:{}", blake3::hash(bytes))
+}
+
+fn resolve_output_path(out: &Option<PathBuf>, entrypoint: &Path) -> PathBuf {
+    if let Some(path) = out {
+        return path.clone();
+    }
+    let stem = entrypoint
+        .file_stem()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "bundle".to_string());
+    let parent = entrypoint.parent().unwrap_or_else(|| Path::new("."));
+    parent.join(format!("{stem}.harnpack"))
+}

--- a/crates/harn-cli/src/json_envelope.rs
+++ b/crates/harn-cli/src/json_envelope.rs
@@ -182,6 +182,12 @@ pub fn catalog() -> Vec<SchemaEntry> {
             description: "One embedded skill's frontmatter (and body with --full).",
             schema_json: None,
         },
+        SchemaEntry {
+            command: "pack",
+            schema_version: crate::commands::pack::PACK_SCHEMA_VERSION,
+            description: "Signed-ready .harnpack run-bundle build summary.",
+            schema_json: None,
+        },
     ]
 }
 

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -872,6 +872,7 @@ async fn async_main() {
         Command::Repl => commands::repl::run_repl().await,
         Command::Bench(args) => commands::bench::run(args).await,
         Command::Precompile(args) => commands::precompile::run(args),
+        Command::Pack(args) => commands::pack::run(args),
         Command::TestBench(args) => commands::test_bench::run(args.command).await,
         Command::Viz(args) => commands::viz::run_viz(&args.file, args.output.as_deref()),
         Command::Install(args) => package::install_packages(

--- a/crates/harn-cli/tests/pack_cli.rs
+++ b/crates/harn-cli/tests/pack_cli.rs
@@ -1,0 +1,208 @@
+//! Integration coverage for `harn pack` (#1781).
+//!
+//! Exercises the exit criteria spelled out on the issue:
+//!  - producing a valid `.harnpack` archive from a single entrypoint,
+//!  - bit-for-bit determinism across repeated invocations,
+//!  - the `--json` `JsonEnvelope` shape and schema version, and
+//!  - the `--upgrade` path for older bundle schemas.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use harn_cli::cli::PackArgs;
+use harn_cli::commands::pack;
+use harn_cli::tests::common::cwd_lock;
+use harn_vm::orchestration::{load_workflow_bundle, read_harnpack, WORKFLOW_BUNDLE_SCHEMA_VERSION};
+use tempfile::TempDir;
+use tokio::runtime::Builder;
+
+fn run_pack(args: &PackArgs) {
+    Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("tokio current-thread runtime")
+        .block_on(async {
+            let _cwd_guard = cwd_lock::lock_cwd_async().await;
+            harn_vm::reset_thread_local_state();
+            pack::build(args).expect("pack succeeds");
+        });
+}
+
+fn pack_args(entrypoint: PathBuf, out: PathBuf) -> PackArgs {
+    PackArgs {
+        entrypoint,
+        out: Some(out),
+        upgrade: None,
+        unsigned: true,
+        json: false,
+    }
+}
+
+#[test]
+fn pack_writes_valid_harnpack_archive() {
+    let workdir = TempDir::new().unwrap();
+    let entry = workdir.path().join("hello.harn");
+    fs::write(&entry, "println(\"hi\")\n").unwrap();
+    let out = workdir.path().join("hello.harnpack");
+
+    run_pack(&pack_args(entry.clone(), out.clone()));
+
+    assert!(out.exists(), "expected pack to write {}", out.display());
+    let bytes = fs::read(&out).unwrap();
+    let archive = read_harnpack(&bytes).expect("archive parses");
+    assert_eq!(
+        archive.manifest.schema_version,
+        WORKFLOW_BUNDLE_SCHEMA_VERSION
+    );
+    assert_eq!(archive.manifest.entrypoint, PathBuf::from("hello.harn"));
+    assert!(
+        !archive.manifest.transitive_modules.is_empty(),
+        "transitive_modules must include at least the entrypoint"
+    );
+    assert!(archive
+        .contents
+        .iter()
+        .any(|entry| entry.path == Path::new("sources/hello.harn")));
+    assert!(archive
+        .contents
+        .iter()
+        .any(|entry| entry.path == Path::new("bytecode/hello.harnbc")));
+    let report = harn_vm::orchestration::validate_workflow_bundle(&archive.manifest);
+    assert!(report.valid, "{report:#?}");
+}
+
+#[test]
+fn pack_is_deterministic_across_runs() {
+    let workdir = TempDir::new().unwrap();
+    let entry = workdir.path().join("hello.harn");
+    fs::write(&entry, "println(\"hi\")\n").unwrap();
+    let out_a = workdir.path().join("a.harnpack");
+    let out_b = workdir.path().join("b.harnpack");
+
+    run_pack(&pack_args(entry.clone(), out_a.clone()));
+    run_pack(&pack_args(entry.clone(), out_b.clone()));
+
+    let bytes_a = fs::read(&out_a).unwrap();
+    let bytes_b = fs::read(&out_b).unwrap();
+    assert_eq!(
+        bytes_a, bytes_b,
+        "harn pack must produce byte-identical archives for the same source"
+    );
+}
+
+#[test]
+fn pack_resolves_transitive_imports() {
+    let workdir = TempDir::new().unwrap();
+    let lib = workdir.path().join("lib.harn");
+    fs::write(&lib, "pub fn greet() -> string { return \"howdy\" }\n").unwrap();
+    let entry = workdir.path().join("entry.harn");
+    fs::write(
+        &entry,
+        "import { greet } from \"./lib\"\nprintln(greet())\n",
+    )
+    .unwrap();
+
+    let out = workdir.path().join("entry.harnpack");
+    run_pack(&pack_args(entry.clone(), out.clone()));
+
+    let archive = read_harnpack(&fs::read(&out).unwrap()).unwrap();
+    let paths: Vec<String> = archive
+        .manifest
+        .transitive_modules
+        .iter()
+        .map(|module| module.path.display().to_string())
+        .collect();
+    assert!(paths.iter().any(|p| p == "entry.harn"), "{paths:?}");
+    assert!(paths.iter().any(|p| p == "lib.harn"), "{paths:?}");
+    let archive_paths: Vec<String> = archive
+        .contents
+        .iter()
+        .map(|entry| entry.path.display().to_string())
+        .collect();
+    assert!(archive_paths.iter().any(|p| p == "sources/lib.harn"));
+    assert!(archive_paths.iter().any(|p| p == "bytecode/lib.harnbc"));
+}
+
+#[test]
+fn pack_json_envelope_carries_pack_schema() {
+    let workdir = TempDir::new().unwrap();
+    let entry = workdir.path().join("hello.harn");
+    fs::write(&entry, "println(\"hi\")\n").unwrap();
+    let out = workdir.path().join("hello.harnpack");
+
+    let envelope = Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(async {
+            let _cwd_guard = cwd_lock::lock_cwd_async().await;
+            harn_vm::reset_thread_local_state();
+            pack::run_to_envelope(&PackArgs {
+                entrypoint: entry.clone(),
+                out: Some(out.clone()),
+                upgrade: None,
+                unsigned: true,
+                json: true,
+            })
+        });
+
+    let value = serde_json::to_value(&envelope).unwrap();
+    assert_eq!(value["schemaVersion"], pack::PACK_SCHEMA_VERSION);
+    assert_eq!(value["ok"], true);
+    assert_eq!(value["data"]["output_path"], out.display().to_string());
+    assert!(value["data"]["bundle_hash"]
+        .as_str()
+        .is_some_and(|s| s.starts_with("blake3:")));
+    assert!(value["data"]["size_bytes"].as_u64().unwrap() > 0);
+    assert_eq!(
+        value["data"]["manifest"]["schema_version"],
+        WORKFLOW_BUNDLE_SCHEMA_VERSION
+    );
+}
+
+#[test]
+fn pack_upgrade_replaces_schema_version_keeping_workflow() {
+    let workdir = TempDir::new().unwrap();
+    let v1 = workdir.path().join("legacy.json");
+    fs::write(
+        &v1,
+        r#"{
+          "schema_version": 1,
+          "id": "legacy-monitor",
+          "name": "Legacy monitor",
+          "version": "1.0.0",
+          "workflow": {
+            "_type": "workflow_graph",
+            "id": "legacy_workflow",
+            "version": 1,
+            "entry": "step",
+            "nodes": { "step": { "id": "step", "kind": "action" } },
+            "edges": []
+          },
+          "triggers": [{ "id": "manual", "kind": "manual", "node_id": "step" }]
+        }"#,
+    )
+    .unwrap();
+
+    let entry = workdir.path().join("entry.harn");
+    fs::write(&entry, "println(\"upgrade\")\n").unwrap();
+    let out = workdir.path().join("legacy.harnpack");
+
+    run_pack(&PackArgs {
+        entrypoint: entry.clone(),
+        out: Some(out.clone()),
+        upgrade: Some(v1.clone()),
+        unsigned: true,
+        json: false,
+    });
+
+    let bundle = load_workflow_bundle(&out).unwrap();
+    assert_eq!(bundle.schema_version, WORKFLOW_BUNDLE_SCHEMA_VERSION);
+    assert_eq!(bundle.id, "legacy-monitor");
+    assert_eq!(bundle.workflow.id, "legacy_workflow");
+    assert_eq!(bundle.workflow.entry, "step");
+    assert_eq!(bundle.triggers.len(), 1);
+    assert_eq!(bundle.triggers[0].id, "manual");
+    assert!(!bundle.transitive_modules.is_empty(), "v2 fields populated");
+    assert!(bundle.provider_catalog_hash.starts_with("blake3:"));
+}

--- a/crates/harn-modules/src/lib.rs
+++ b/crates/harn-modules/src/lib.rs
@@ -360,6 +360,22 @@ fn finalize_package_target(package_root: &Path, path: &Path) -> Option<PathBuf> 
 }
 
 impl ModuleGraph {
+    /// Sorted list of every module path discovered by [`build`]. Includes
+    /// `<std>/<name>` virtual paths for stdlib modules reached transitively.
+    /// Callers that want only real-disk modules can filter for paths whose
+    /// string form does not start with `<std>/`.
+    pub fn module_paths(&self) -> Vec<PathBuf> {
+        let mut paths: Vec<PathBuf> = self.modules.keys().cloned().collect();
+        paths.sort();
+        paths
+    }
+
+    /// True when `path` (or its canonical form) was discovered during the
+    /// module-graph walk.
+    pub fn contains_module(&self, path: &Path) -> bool {
+        self.modules.contains_key(path) || self.modules.contains_key(&normalize_path(path))
+    }
+
     /// Collect every name used in selective imports from all files.
     pub fn all_selective_import_names(&self) -> HashSet<&str> {
         let mut names = HashSet::new();

--- a/crates/harn-vm/src/bytecode_cache.rs
+++ b/crates/harn-vm/src/bytecode_cache.rs
@@ -305,19 +305,36 @@ fn ensure_parent_dir(path: &Path) -> io::Result<()> {
 }
 
 fn write_atomic_chunk(target: &Path, key: &CacheKey, chunk: &Chunk) -> io::Result<()> {
-    let cached = chunk.freeze_for_cache();
-    let payload = bincode::serialize(&cached)
-        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
-    write_atomic(target, key, KIND_ENTRY_CHUNK, &payload)
+    let buf = serialize_chunk_artifact(key, chunk)?;
+    write_atomic(target, &buf)
 }
 
 fn write_atomic_module(target: &Path, key: &CacheKey, artifact: &ModuleArtifact) -> io::Result<()> {
-    let payload = bincode::serialize(artifact)
-        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
-    write_atomic(target, key, KIND_MODULE_ARTIFACT, &payload)
+    let buf = serialize_module_artifact(key, artifact)?;
+    write_atomic(target, &buf)
 }
 
-fn write_atomic(target: &Path, key: &CacheKey, kind: u8, payload: &[u8]) -> io::Result<()> {
+/// Serialize an entry-chunk artifact (header + payload) to bytes. The
+/// resulting buffer is byte-identical to the file [`store_at`] would
+/// have written for the same `(key, chunk)`. Use this when packaging
+/// artifacts into a container (e.g. `harn pack`) without going through
+/// the filesystem.
+pub fn serialize_chunk_artifact(key: &CacheKey, chunk: &Chunk) -> io::Result<Vec<u8>> {
+    let cached = chunk.freeze_for_cache();
+    let payload = bincode::serialize(&cached)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+    Ok(encode_artifact(key, KIND_ENTRY_CHUNK, &payload))
+}
+
+/// Serialize a module artifact (header + payload) to bytes. Companion
+/// to [`serialize_chunk_artifact`] for the `.harnmod` family.
+pub fn serialize_module_artifact(key: &CacheKey, artifact: &ModuleArtifact) -> io::Result<Vec<u8>> {
+    let payload = bincode::serialize(artifact)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+    Ok(encode_artifact(key, KIND_MODULE_ARTIFACT, &payload))
+}
+
+fn encode_artifact(key: &CacheKey, kind: u8, payload: &[u8]) -> Vec<u8> {
     let mut buf: Vec<u8> = Vec::with_capacity(payload.len() + 128);
     buf.extend_from_slice(MAGIC);
     buf.extend_from_slice(&SCHEMA_VERSION.to_le_bytes());
@@ -329,14 +346,17 @@ fn write_atomic(target: &Path, key: &CacheKey, kind: u8, payload: &[u8]) -> io::
     buf.extend_from_slice(&key.source_hash);
     buf.extend_from_slice(&key.import_graph_hash);
     buf.extend_from_slice(payload);
+    buf
+}
 
+fn write_atomic(target: &Path, buf: &[u8]) -> io::Result<()> {
     let tmp_name = match target.file_name() {
         Some(name) => format!(".{}.{}.tmp", name.to_string_lossy(), std::process::id(),),
         None => format!(".harn-cache.{}.tmp", std::process::id()),
     };
     let tmp_path = target.with_file_name(tmp_name);
     let mut tmp_file = fs::File::create(&tmp_path)?;
-    tmp_file.write_all(&buf)?;
+    tmp_file.write_all(buf)?;
     tmp_file.sync_all()?;
     drop(tmp_file);
     match fs::rename(&tmp_path, target) {
@@ -715,6 +735,23 @@ mod tests {
         store_at(&path, &key, &chunk).expect("write");
         let loaded = read_chunk_if_matches(&path, &key).unwrap();
         assert!(loaded.is_some(), "expected cached chunk to load");
+    }
+
+    #[test]
+    fn serialize_chunk_artifact_matches_store_at() {
+        // `serialize_chunk_artifact` packages an artifact into a buffer for
+        // in-memory consumers (e.g. `harn pack` writing into a tar.zst
+        // bundle). The contract is: the resulting bytes match what
+        // `store_at` would have written for the same key+chunk, so the
+        // shipped artifact is byte-identical to the on-disk cache form.
+        let chunk = compile_source("println(\"hi\")").expect("compile");
+        let key = CacheKey::from_source(Path::new("/tmp/pack.harn"), "println(\"hi\")");
+        let tmp = tempfile::tempdir().unwrap();
+        let on_disk = tmp.path().join("pack.harnbc");
+        store_at(&on_disk, &key, &chunk).expect("write");
+        let on_disk_bytes = std::fs::read(&on_disk).unwrap();
+        let in_memory_bytes = serialize_chunk_artifact(&key, &chunk).expect("serialize");
+        assert_eq!(in_memory_bytes, on_disk_bytes);
     }
 
     #[test]

--- a/crates/harn-vm/src/orchestration/workflow_bundle.rs
+++ b/crates/harn-vm/src/orchestration/workflow_bundle.rs
@@ -476,6 +476,55 @@ pub fn load_workflow_bundle(path: &Path) -> Result<WorkflowBundle, WorkflowBundl
     }
 }
 
+/// Read a manifest from any prior or current schema version without
+/// rejecting on a `schema_version` mismatch. Used by `harn pack
+/// --upgrade` to read v1 bundles before re-emitting them under the v2
+/// shape. Fields the older schema didn't carry deserialize to their
+/// type defaults via `#[serde(default)]`.
+pub fn read_workflow_bundle_manifest_any_version(
+    bytes: &[u8],
+) -> Result<WorkflowBundle, WorkflowBundleError> {
+    let value: serde_json::Value = serde_json::from_slice(bytes)?;
+    if value.get("schema_version").is_none() {
+        return Err(WorkflowBundleError::new(
+            WorkflowBundleErrorKind::MissingSchemaVersion,
+            "workflow bundle manifest is missing schema_version",
+        ));
+    }
+    serde_json::from_value(value).map_err(Into::into)
+}
+
+/// Variant of [`load_workflow_bundle`] that accepts any historical
+/// schema version. Reads the manifest from a `.harnpack` archive or a
+/// bare JSON manifest as appropriate.
+pub fn load_workflow_bundle_any_version(
+    path: &Path,
+) -> Result<WorkflowBundle, WorkflowBundleError> {
+    let bytes = fs::read(path)?;
+    if path.extension().and_then(|extension| extension.to_str()) == Some("harnpack") {
+        let tar_bytes = zstd::stream::decode_all(Cursor::new(bytes))?;
+        let mut archive = tar::Archive::new(Cursor::new(tar_bytes));
+        for entry in archive.entries()? {
+            let mut entry = entry?;
+            if entry.header().entry_type().is_dir() {
+                continue;
+            }
+            let path = normalize_archive_path(entry.path()?.as_ref())?;
+            if path == HARNPACK_MANIFEST_PATH {
+                let mut entry_bytes = Vec::new();
+                entry.read_to_end(&mut entry_bytes)?;
+                return read_workflow_bundle_manifest_any_version(&entry_bytes);
+            }
+        }
+        Err(WorkflowBundleError::new(
+            WorkflowBundleErrorKind::InvalidArchive,
+            format!("harnpack archive is missing {HARNPACK_MANIFEST_PATH}"),
+        ))
+    } else {
+        read_workflow_bundle_manifest_any_version(&bytes)
+    }
+}
+
 pub fn parse_workflow_bundle_manifest(bytes: &[u8]) -> Result<WorkflowBundle, WorkflowBundleError> {
     let value: serde_json::Value = serde_json::from_slice(bytes)?;
     let schema_version = value

--- a/crates/harn-vm/src/orchestration/workflow_bundle_tests.rs
+++ b/crates/harn-vm/src/orchestration/workflow_bundle_tests.rs
@@ -132,6 +132,109 @@ fn harnpack_build_read_and_bundle_hash_are_deterministic() {
 }
 
 #[test]
+fn read_manifest_any_version_accepts_v1_payload() {
+    // A minimal v1 manifest: only the pre-v2 fields. The relaxed parser
+    // must accept it and default the v2-only fields, so `harn pack
+    // --upgrade <old>` can keep the original workflow/triggers and
+    // bolt on the new metadata.
+    let v1 = r#"{
+      "schema_version": 1,
+      "id": "legacy",
+      "version": "1.0.0",
+      "workflow": {
+        "_type": "workflow_graph",
+        "id": "wf",
+        "version": 1,
+        "entry": "step",
+        "nodes": { "step": { "id": "step", "kind": "action" } }
+      },
+      "triggers": [{ "id": "manual", "kind": "manual", "node_id": "step" }]
+    }"#;
+    let bundle = read_workflow_bundle_manifest_any_version(v1.as_bytes()).unwrap();
+    assert_eq!(bundle.schema_version, 1);
+    assert_eq!(bundle.id, "legacy");
+    assert_eq!(bundle.workflow.id, "wf");
+    assert_eq!(bundle.triggers.len(), 1);
+    assert!(bundle.transitive_modules.is_empty());
+    assert!(bundle.entrypoint.as_os_str().is_empty());
+
+    // The strict parser still rejects v1 so callers that aren't
+    // explicitly migrating cannot accidentally interpret one.
+    let strict = parse_workflow_bundle_manifest(v1.as_bytes()).unwrap_err();
+    assert_eq!(
+        strict.kind,
+        WorkflowBundleErrorKind::UnsupportedSchemaVersion {
+            actual: 1,
+            expected: WORKFLOW_BUNDLE_SCHEMA_VERSION,
+        }
+    );
+}
+
+#[test]
+fn load_any_version_reads_v1_harnpack_archive() {
+    // Round-trip: assemble a v2 harnpack, hand-roll a manifest
+    // override to schema_version=1, repack, and confirm
+    // load_workflow_bundle_any_version returns it.
+    let bundle = fixture_bundle();
+    let contents = vec![HarnpackEntry::new(
+        "sources/legacy.harn",
+        b"// placeholder".to_vec(),
+    )];
+    let temp = tempfile::tempdir().unwrap();
+    let pack_path = temp.path().join("legacy.harnpack");
+    // Build with the current schema first to reuse the canonicalizer.
+    let archive = build_harnpack(&bundle, &contents).unwrap();
+    // Patch the manifest's schema_version to 1 by rewriting the
+    // archive's manifest entry, then write it to disk.
+    let opened = read_harnpack(&archive).unwrap();
+    let mut downgraded = opened.manifest;
+    downgraded.schema_version = 1;
+    let mut tar_bytes = Vec::new();
+    {
+        let mut builder = tar::Builder::new(&mut tar_bytes);
+        let manifest_bytes = serde_json::to_vec(&downgraded).unwrap();
+        let mut header = tar::Header::new_gnu();
+        header.set_path(HARNPACK_MANIFEST_PATH).unwrap();
+        header.set_entry_type(tar::EntryType::Regular);
+        header.set_size(manifest_bytes.len() as u64);
+        header.set_mode(0o644);
+        header.set_mtime(0);
+        header.set_cksum();
+        builder.append(&header, manifest_bytes.as_slice()).unwrap();
+        for entry in &opened.contents {
+            let mut header = tar::Header::new_gnu();
+            header
+                .set_path(entry.path.to_string_lossy().to_string())
+                .unwrap();
+            header.set_entry_type(tar::EntryType::Regular);
+            header.set_size(entry.bytes.len() as u64);
+            header.set_mode(entry.mode);
+            header.set_mtime(0);
+            header.set_cksum();
+            builder.append(&header, entry.bytes.as_slice()).unwrap();
+        }
+        builder.finish().unwrap();
+    }
+    let zstd_bytes = zstd::stream::encode_all(std::io::Cursor::new(tar_bytes), 0).unwrap();
+    std::fs::write(&pack_path, &zstd_bytes).unwrap();
+
+    // The strict loader rejects the downgraded archive…
+    let strict = load_workflow_bundle(&pack_path).unwrap_err();
+    assert_eq!(
+        strict.kind,
+        WorkflowBundleErrorKind::UnsupportedSchemaVersion {
+            actual: 1,
+            expected: WORKFLOW_BUNDLE_SCHEMA_VERSION,
+        }
+    );
+    // …the relaxed loader accepts it.
+    let loaded = load_workflow_bundle_any_version(&pack_path).unwrap();
+    assert_eq!(loaded.schema_version, 1);
+    assert_eq!(loaded.id, bundle.id);
+    assert_eq!(loaded.workflow.id, bundle.workflow.id);
+}
+
+#[test]
 fn validator_rejects_missing_v2_manifest_contract_fields() {
     let mut bundle = fixture_bundle();
     bundle.entrypoint = std::path::PathBuf::new();

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -1809,6 +1809,42 @@ Remove one dependency from `harn.toml`, `harn.lock`, and
 harn remove my-lib
 ```
 
+## harn pack
+
+Build a signed-ready `.harnpack` run bundle from a Harn entrypoint
+([#1781][issue-1781]). The bundle is a deterministic tar.zst archive
+containing a v2 `WorkflowBundle` manifest (`harnpack.json`), every
+transitively-imported `.harn` source under `sources/`, every module's
+precompiled `.harnbc`/`.harnmod` artifact under `bytecode/`, a
+provider-catalog hash + stdlib version pin, a minimal SPDX-lite SBOM,
+and a (future) Ed25519 signature slot.
+
+```bash
+harn pack examples/hello.harn
+harn pack examples/hello.harn --out /tmp/hello.harnpack
+harn pack examples/hello.harn --unsigned --json
+harn pack workflows/new-entry.harn --upgrade old.harnpack --out new.harnpack
+```
+
+Output paths default to `<entrypoint>.harnpack` next to the entrypoint.
+`--json` emits a `JsonEnvelope` with `bundle_hash` (BLAKE3 over the
+canonical manifest bytes plus sorted content hashes), `output_path`,
+`size_bytes`, and the full manifest; see the catalog row at
+`harn --json-schemas --command pack` for the schema version. Repacking
+the same source produces a byte-identical archive.
+
+`--upgrade <old.harnpack>` reads a prior bundle (v1 JSON or v2 archive)
+and re-emits it under the v2 manifest, preserving the prior bundle's
+id, name, version, triggers, workflow graph, and prompt capsules. The
+new `<entrypoint>` argument supplies the transitive-module + SBOM
+payload that the older schema lacked.
+
+Signing (`--sign --key <path>`) and richer SBOM enumeration land in
+follow-ups (E6.3 and E6.4). Today the bundle ships unsigned; pass
+`--unsigned` to make that intent explicit.
+
+[issue-1781]: https://github.com/burin-labs/harn/issues/1781
+
 ## harn package list
 
 List packages from the current `harn.lock`.


### PR DESCRIPTION
## Summary

Closes #1781. Implements **E6.2** of the [`.harnpack` epic (#1779)][epic]:
a new top-level `harn pack <entrypoint>` CLI subcommand that walks an
entrypoint's transitive imports, precompiles each module via the
existing bytecode-cache infrastructure, snapshots the provider catalog
hash + stdlib pin, generates a minimal SPDX-lite SBOM, and assembles
the v2 `WorkflowBundle` manifest into a deterministic `.harnpack`
tar.zst archive (built on top of `build_harnpack` from E6.1).

[epic]: https://github.com/burin-labs/harn/issues/1779

### CLI surface

```bash
harn pack examples/hello.harn
harn pack examples/hello.harn --out /tmp/hello.harnpack
harn pack examples/hello.harn --unsigned --json
harn pack new-entry.harn --upgrade old.harnpack --out new.harnpack
```

- ``--out <path>`` overrides the default ``<entrypoint>.harnpack``.
- ``--unsigned`` is documentary today; signing lands in E6.3.
- ``--json`` emits a canonical ``JsonEnvelope`` (registered at
  ``harn --json-schemas --command pack``, ``schemaVersion: 1``) with
  ``bundle_hash`` (BLAKE3 over canonical manifest + sorted content
  hashes), ``output_path``, ``size_bytes``, and the full manifest.
- ``--upgrade <old.harnpack>`` reads an older bundle (v1 JSON or v2
  archive) and re-emits it under the v2 manifest, preserving the prior
  bundle's id, name, version, triggers, workflow graph, and prompt
  capsules while populating the new v2 fields from the entrypoint walk.

### Plumbing additions

- ``harn_vm::orchestration::read_workflow_bundle_manifest_any_version``
  and ``load_workflow_bundle_any_version`` — schema-relaxed readers
  used by the ``--upgrade`` path.
- ``harn_vm::bytecode_cache::serialize_chunk_artifact`` /
  ``serialize_module_artifact`` — package an artifact byte-for-byte
  identical to the on-disk ``.harnbc`` / ``.harnmod`` form so the
  ``harn pack`` builder can stream bytes into the archive without
  going through the filesystem.
- ``harn_modules::ModuleGraph::module_paths`` /
  ``contains_module`` — public accessors so callers can enumerate the
  modules ``harn_modules::build`` discovered.

### Exit criteria

- [x] ``harn pack examples/hello.harn --out /tmp/hello.harnpack``
  produces a valid file.
- [x] ``harn pack`` is deterministic across runs (byte-identical archive
  bytes for the same source).
- [x] ``--json`` envelope conforms to the ``JsonEnvelope`` contract
  from #1754 (``schemaVersion``, ``ok``, ``data``, ``error``,
  ``warnings``).

## Test plan

- [x] ``cargo test -p harn-cli --test pack_cli`` — 5 tests
  (valid-archive, determinism, transitive imports, JSON envelope, v1
  upgrade).
- [x] ``cargo test -p harn-vm --lib workflow_bundle`` — adds
  ``read_manifest_any_version_accepts_v1_payload`` and
  ``load_any_version_reads_v1_harnpack_archive``.
- [x] ``cargo test -p harn-vm --lib bytecode_cache`` — adds
  ``serialize_chunk_artifact_matches_store_at``.
- [x] ``cargo clippy --workspace --all-targets -- -D warnings``.
- [x] ``make check-docs-snippets`` (537 checked, 0 failed).
- [x] ``make lint-md`` (266 files, 0 errors).
- [x] ``make lint-test-patterns`` (no wall-clock violations).
- [x] Manual end-to-end: ``cargo run --bin harn -- pack
  examples/hello.harn --out /tmp/hello.harnpack`` → 1952-byte archive
  with identical bundle hash on re-run; ``harn workflow validate
  --bundle /tmp/upgraded.harnpack`` returns ``valid``.

🤖 Generated with [Claude Code](https://claude.com/claude-code)