### PR TITLE
Add `harn time run [--json]` for phase-timed runs (#1787)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ condensed series summaries instead of full per-patch history.
 
 ### Added
 
+- **`harn time run [--json]` — phase-timed run with cache hit/miss
+  and per-LLM/tool latency (#1787).** New top-level `harn time`
+  subcommand wraps an existing subcommand and emits a structured
+  timing breakdown. `harn time run script.harn` prints a human
+  table; `harn time run script.harn --json` emits a versioned
+  `JsonEnvelope` with five fixed phases (`parse`, `typecheck`,
+  `bytecode_compile`, `run_setup`, `run_main`), a `cache: "hit" |
+  "miss"` marker on `bytecode_compile`, per-LLM-call entries
+  (model, latency, tokens), per-tool-call entries (name, latency),
+  and totals (`wall_ms`, `cpu_ms`, `cache_hits`, `cache_misses`).
+  The envelope is registered under `time run` in `harn
+  --json-schemas`. Pair with `--no-cache` to force a cold compile
+  and `-e <code>` to time an inline script. Script `stdout` is
+  routed to stderr in `--json` mode so the envelope is alone on
+  stdout for `jq`-style consumption.
 - **`harn explain HARN-<CAT>-<NNN>` text + `--json` envelope (#1748).** The
   `explain` subcommand now dispatches on registered stable diagnostic codes
   in addition to its original control-flow invariant form. `harn explain

--- a/crates/harn-cli/src/cli/mod.rs
+++ b/crates/harn-cli/src/cli/mod.rs
@@ -49,6 +49,7 @@ mod skills;
 mod supervisor;
 mod test;
 mod test_bench;
+mod time;
 mod tool;
 mod trace;
 mod trigger;
@@ -177,6 +178,7 @@ pub(crate) use test_bench::{
     TestBenchArgs, TestBenchCommand, TestBenchExportAnnotationsArgs, TestBenchFidelityArgs,
     TestBenchReplayArgs, TestBenchRunArgs, TestBenchValidateAnnotationsArgs,
 };
+pub(crate) use time::{TimeArgs, TimeCommand, TimeRunArgs};
 pub(crate) use tool::{ToolArgs, ToolCommand, ToolNewArgs};
 pub(crate) use trace::{TraceArgs, TraceCommand, TraceImportArgs};
 pub(crate) use trigger::{TriggerArgs, TriggerCancelArgs, TriggerCommand, TriggerReplayArgs};
@@ -282,6 +284,11 @@ SCRIPTING
     /// optional LLM/process tapes, fs overlay, deny-by-default network).
     #[command(name = "test-bench")]
     TestBench(TestBenchArgs),
+    /// Instrument a wrapped subcommand with phase-level wall-clock
+    /// timing (parse, typecheck, bytecode compile + cache hit/miss,
+    /// run setup, run main) plus per-LLM-call and per-tool-call
+    /// latency. Pair with `--json` for an agent-readable envelope.
+    Time(TimeArgs),
     /// Scaffold a new project with harn.toml.
     Init(InitArgs),
     /// Scaffold a new project, package, or connector from a starter template.

--- a/crates/harn-cli/src/cli/time.rs
+++ b/crates/harn-cli/src/cli/time.rs
@@ -1,0 +1,38 @@
+use clap::{Args, Subcommand};
+
+#[derive(Debug, Args)]
+pub(crate) struct TimeArgs {
+    #[command(subcommand)]
+    pub command: TimeCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum TimeCommand {
+    /// Time `harn run` with per-phase wall-clock breakdown
+    /// (parse, typecheck, bytecode compile, run setup, run main) plus
+    /// per-LLM-call and per-tool-call latency.
+    Run(TimeRunArgs),
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct TimeRunArgs {
+    /// Path to a `.harn` file. Required unless `-e` is supplied.
+    pub file: Option<String>,
+    /// Inline Harn source (replaces `<file>`). Wrapped in a `pipeline
+    /// main(task) { ... }` like `harn run -e`.
+    #[arg(short = 'e')]
+    pub eval: Option<String>,
+    /// Emit a structured `JsonEnvelope` to stdout instead of a
+    /// human-readable breakdown.
+    #[arg(long)]
+    pub json: bool,
+    /// Skip the on-disk bytecode cache so parse/typecheck/compile always
+    /// run cold. Equivalent to setting `HARN_BYTECODE_CACHE=0` for this
+    /// invocation only.
+    #[arg(long = "no-cache")]
+    pub no_cache: bool,
+    /// Positional arguments passed to the pipeline as the global `argv`
+    /// list. Place them after a `--` separator: `harn time run script.harn -- a b c`.
+    #[arg(last = true)]
+    pub argv: Vec<String>,
+}

--- a/crates/harn-cli/src/commands/mod.rs
+++ b/crates/harn-cli/src/commands/mod.rs
@@ -45,6 +45,7 @@ pub(crate) mod skills;
 pub(crate) mod supervisor;
 pub(crate) mod test;
 pub mod test_bench;
+pub mod time;
 pub(crate) mod tool;
 pub(crate) mod trace;
 pub mod trigger;

--- a/crates/harn-cli/src/commands/run.rs
+++ b/crates/harn-cli/src/commands/run.rs
@@ -5,11 +5,13 @@ use std::path::{Path, PathBuf};
 use std::process;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
+use std::time::Instant;
 
 use harn_parser::DiagnosticSeverity;
 use harn_vm::event_log::EventLog;
 
 use crate::commands::mcp::{self, AuthResolution};
+use crate::commands::time::RunTiming;
 use crate::package;
 use crate::parse_source_file;
 use crate::skill_loader::{
@@ -122,6 +124,24 @@ pub(crate) fn compile_or_load_chunk_for_run(
     path: &str,
     stderr: &mut String,
 ) -> Option<LoadedChunk> {
+    compile_or_load_chunk_with_timing(path, stderr, None)
+}
+
+/// Like [`compile_or_load_chunk_for_run`] but lets the caller observe
+/// per-phase wall-clock timings (parse, typecheck, bytecode compile +
+/// cache hit/miss). Used by `harn time run` to drive the same code
+/// path as `harn run` while reporting phase-level timing.
+//
+// The `as_deref_mut` calls reborrow the inner `&mut RunTiming` so each
+// phase can mutate it independently. Clippy's `needless_option_as_deref`
+// is correct that the surface types match — that's exactly the
+// reborrow we want.
+#[allow(clippy::needless_option_as_deref)]
+pub(crate) fn compile_or_load_chunk_with_timing(
+    path: &str,
+    stderr: &mut String,
+    mut timing: Option<&mut RunTiming>,
+) -> Option<LoadedChunk> {
     let source = match fs::read_to_string(path) {
         Ok(s) => s,
         Err(e) => {
@@ -129,14 +149,31 @@ pub(crate) fn compile_or_load_chunk_for_run(
             return None;
         }
     };
-    let lookup = harn_vm::bytecode_cache::load(Path::new(path), &source);
-    if let Some(chunk) = lookup.chunk {
-        return Some(LoadedChunk { source, chunk });
+    if let Some(t) = timing.as_deref_mut() {
+        t.input_bytes = source.len() as u64;
     }
 
+    let compile_phase_start = Instant::now();
+    let lookup = harn_vm::bytecode_cache::load(Path::new(path), &source);
+    if let Some(chunk) = lookup.chunk {
+        if let Some(t) = timing.as_deref_mut() {
+            t.cache_hit = true;
+            t.bytecode_compile = compile_phase_start.elapsed();
+        }
+        return Some(LoadedChunk { source, chunk });
+    }
+    if let Some(t) = timing.as_deref_mut() {
+        t.cache_hit = false;
+    }
+
+    let parse_start = Instant::now();
     let (parsed_source, program) = parse_source_file(path);
     debug_assert_eq!(parsed_source, source, "parse_source_file re-read drifted");
+    if let Some(t) = timing.as_deref_mut() {
+        t.parse = parse_start.elapsed();
+    }
 
+    let typecheck_start = Instant::now();
     let mut had_type_error = false;
     let type_diagnostics = typecheck_with_imports(&program, Path::new(path), &source);
     for diag in &type_diagnostics {
@@ -146,10 +183,14 @@ pub(crate) fn compile_or_load_chunk_for_run(
         }
         stderr.push_str(&rendered);
     }
+    if let Some(t) = timing.as_deref_mut() {
+        t.typecheck = typecheck_start.elapsed();
+    }
     if had_type_error {
         return None;
     }
 
+    let compile_step_start = Instant::now();
     let chunk = match harn_vm::Compiler::new().compile(&program) {
         Ok(c) => c,
         Err(e) => {
@@ -166,6 +207,9 @@ pub(crate) fn compile_or_load_chunk_for_run(
         if std::env::var_os("HARN_BYTECODE_CACHE_DEBUG").is_some() {
             eprintln!("[harn] bytecode cache write skipped: {err}");
         }
+    }
+    if let Some(t) = timing.as_deref_mut() {
+        t.bytecode_compile = compile_step_start.elapsed();
     }
 
     Some(LoadedChunk { source, chunk })
@@ -344,6 +388,7 @@ struct ExecuteRunInputs<'a> {
     profile: RunProfileOptions,
     interrupt_tokens: Option<RunInterruptTokens>,
     json: Option<(RunJsonOptions, Box<dyn io::Write + Send>)>,
+    timing: Option<&'a mut RunTiming>,
 }
 
 /// Captured outcome of an in-process `execute_run` invocation. Tests use this
@@ -465,6 +510,7 @@ pub(crate) async fn run_file_with_skill_dirs(
         profile,
         interrupt_tokens: Some(interrupt_tokens.clone()),
         json: json_with_stdout,
+        timing: None,
     })
     .await;
 
@@ -518,12 +564,12 @@ pub fn execute_explain_cost(path: &str) -> RunOutcome {
     }
 }
 
-struct StdoutPassthroughGuard {
+pub(crate) struct StdoutPassthroughGuard {
     previous: bool,
 }
 
 impl StdoutPassthroughGuard {
-    fn enable() -> Self {
+    pub(crate) fn enable() -> Self {
         Self {
             previous: harn_vm::set_stdout_passthrough(true),
         }
@@ -627,6 +673,7 @@ pub async fn execute_run(
         profile,
         interrupt_tokens: None,
         json: None,
+        timing: None,
     })
     .await
 }
@@ -660,10 +707,38 @@ pub async fn execute_run_json(
         profile,
         interrupt_tokens: None,
         json: Some((options, out)),
+        timing: None,
     })
     .await
 }
 
+/// Run a `.harn` file with the default builtin/argv set and record
+/// phase timings into `timing`. Used by `harn time run` so the
+/// instrumented run shares the exact code path as plain `harn run`.
+pub(crate) async fn execute_run_with_timing(
+    path: &str,
+    script_argv: Vec<String>,
+    timing: Option<&mut RunTiming>,
+) -> RunOutcome {
+    execute_run_inner(ExecuteRunInputs {
+        path,
+        trace: false,
+        denied_builtins: HashSet::new(),
+        script_argv,
+        skill_dirs_raw: Vec::new(),
+        llm_mock_mode: CliLlmMockMode::Off,
+        attestation: None,
+        profile: RunProfileOptions::default(),
+        interrupt_tokens: None,
+        json: None,
+        timing,
+    })
+    .await
+}
+
+// See [`compile_or_load_chunk_with_timing`] for why `as_deref_mut` is
+// the intentional reborrow pattern here.
+#[allow(clippy::needless_option_as_deref)]
 async fn execute_run_inner(inputs: ExecuteRunInputs<'_>) -> RunOutcome {
     let ExecuteRunInputs {
         path,
@@ -676,6 +751,7 @@ async fn execute_run_inner(inputs: ExecuteRunInputs<'_>) -> RunOutcome {
         profile,
         interrupt_tokens,
         json,
+        mut timing,
     } = inputs;
 
     // `--json` installs an in-process sink that diverts every
@@ -688,7 +764,8 @@ async fn execute_run_inner(inputs: ExecuteRunInputs<'_>) -> RunOutcome {
     let mut stderr = String::new();
     let mut stdout = String::new();
 
-    let Some(LoadedChunk { source, chunk }) = compile_or_load_chunk_for_run(path, &mut stderr)
+    let Some(LoadedChunk { source, chunk }) =
+        compile_or_load_chunk_with_timing(path, &mut stderr, timing.as_deref_mut())
     else {
         if let Some(session) = json_session {
             return session.finalize_error("compile_error", stderr, 1);
@@ -699,6 +776,11 @@ async fn execute_run_inner(inputs: ExecuteRunInputs<'_>) -> RunOutcome {
             exit_code: 1,
         };
     };
+
+    // Bracket the VM-setup phase explicitly. `run_setup` covers
+    // everything between the bytecode compile and the first VM
+    // instruction; `run_main` covers `vm.execute` proper.
+    let setup_start = Instant::now();
 
     if trace {
         harn_vm::llm::enable_tracing();
@@ -827,6 +909,10 @@ async fn execute_run_inner(inputs: ExecuteRunInputs<'_>) -> RunOutcome {
 
     // Run inside a LocalSet so spawn_local works for concurrency builtins.
     let local = tokio::task::LocalSet::new();
+    if let Some(t) = timing.as_deref_mut() {
+        t.run_setup = setup_start.elapsed();
+    }
+    let main_start = Instant::now();
     let execution = local
         .run_until(async {
             match vm.execute(&chunk).await {
@@ -835,6 +921,9 @@ async fn execute_run_inner(inputs: ExecuteRunInputs<'_>) -> RunOutcome {
             }
         })
         .await;
+    if let Some(t) = timing.as_deref_mut() {
+        t.run_main = main_start.elapsed();
+    }
     if let Err(error) = persist_cli_llm_mock_recording(&llm_mock_mode) {
         stderr.push_str(&format!("error: {error}\n"));
         if let Some(session) = json_session {

--- a/crates/harn-cli/src/commands/time.rs
+++ b/crates/harn-cli/src/commands/time.rs
@@ -1,0 +1,526 @@
+//! `harn time` — wrap a subcommand with structured phase timing.
+//!
+//! Today only `harn time run` is supported. The wrapper enables both VM
+//! and LLM tracing, drives the run through the same code path as
+//! `harn run`, and emits a versioned [`JsonEnvelope`] with per-phase
+//! wall-clock + cache hit/miss + per-LLM-call + per-tool-call latency.
+//!
+//! Phases are emitted in fixed order — `parse`, `typecheck`,
+//! `bytecode_compile`, `run_setup`, `run_main` — even when a cache hit
+//! lets us skip parse/typecheck. That keeps consumers' shape stable so
+//! `phases.length >= 5` is a safe assertion and `cache: "hit"` always
+//! lives on the `bytecode_compile` row.
+
+use std::fs;
+use std::path::PathBuf;
+use std::process;
+use std::time::Duration;
+
+use serde::Serialize;
+
+use crate::cli::TimeRunArgs;
+use crate::commands::run::{
+    execute_run_with_timing, prepare_eval_temp_file, StdoutPassthroughGuard,
+};
+use crate::env_guard::ScopedEnvVar;
+use crate::json_envelope::{to_string_pretty, JsonEnvelope};
+
+/// Schema version for the `harn time run --json` envelope. Bump when
+/// the [`TimingReport`] shape changes in a way agents must detect.
+pub const TIME_RUN_SCHEMA_VERSION: u32 = 1;
+
+/// Per-phase wall-clock samples recorded by the run path. Filled in by
+/// [`crate::commands::run`] when timing is requested; absent fields
+/// (e.g. parse on a cache hit) stay zero.
+#[derive(Debug, Default, Clone)]
+pub struct RunTiming {
+    pub parse: Duration,
+    pub typecheck: Duration,
+    pub bytecode_compile: Duration,
+    pub run_setup: Duration,
+    pub run_main: Duration,
+    /// Source size in bytes, captured before parse to populate the
+    /// `input_bytes` field on the parse phase row.
+    pub input_bytes: u64,
+    /// True when the bytecode cache short-circuited parse/typecheck.
+    pub cache_hit: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TimingReport {
+    /// The wrapped subcommand. Always `"run"` today; future expansions
+    /// (e.g. `"check"`) reuse the same envelope.
+    pub command: String,
+    /// Resolved script path. `None` for `-e <code>` invocations.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target: Option<String>,
+    pub phases: Vec<PhaseRecord>,
+    pub llm_calls: Vec<LlmCallTiming>,
+    pub tool_calls: Vec<ToolCallTiming>,
+    pub totals: TimingTotals,
+    /// Forwarded exit code from the wrapped subcommand. Non-zero exit
+    /// still emits a successful envelope — the wrapper's job is to
+    /// describe what happened, not to mask failures.
+    pub exit_code: i32,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PhaseRecord {
+    pub name: String,
+    pub duration_ms: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input_bytes: Option<u64>,
+    /// `"hit"` or `"miss"` on `bytecode_compile`; absent on other phases.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache: Option<String>,
+    /// Count of completed VM spans observed inside this phase. Only
+    /// populated on `run_main` today.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub events: Option<u64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct LlmCallTiming {
+    pub model: String,
+    pub latency_ms: u64,
+    /// Total tokens for the call (input + output). Per-call input/output
+    /// split is available via `harn run --trace`; this surface keeps the
+    /// shape compact for agent consumption.
+    pub tokens: i64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ToolCallTiming {
+    pub name: String,
+    pub latency_ms: u64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TimingTotals {
+    pub wall_ms: u64,
+    pub cpu_ms: u64,
+    pub cache_hits: u64,
+    pub cache_misses: u64,
+}
+
+pub(crate) async fn run(args: TimeRunArgs) {
+    // Lift the bytecode cache via env var so the existing `harn run`
+    // code path observes the override. The guard restores the previous
+    // value on drop; the CLI is single-shot, but tests reuse the
+    // process and rely on a clean revert.
+    let _cache_guard = args
+        .no_cache
+        .then(|| ScopedEnvVar::set(harn_vm::bytecode_cache::CACHE_ENABLED_ENV, "0"));
+
+    // Make sure LLM + VM tracing capture per-call durations. Both are
+    // thread-local and reset by `set_tracing_enabled(true)`.
+    harn_vm::llm::enable_tracing();
+    harn_vm::tracing::set_tracing_enabled(true);
+    let _ = harn_vm::tracing::take_spans();
+    let _ = harn_vm::llm::take_trace();
+
+    let mut timing = RunTiming::default();
+    let cpu_start = cpu_ms();
+    let wall_start = std::time::Instant::now();
+
+    // In `--json` mode stdout is owned by the envelope, so we keep
+    // script output buffered (passthrough disabled) and write it to
+    // stderr afterwards. In human mode we mirror `harn run` and stream
+    // script output directly to the terminal stdout.
+    let _stdout_guard = (!args.json).then(StdoutPassthroughGuard::enable);
+
+    let (target, outcome) = match (args.eval.as_deref(), args.file.as_deref()) {
+        (Some(code), None) => {
+            let (wrapped, tmp) = prepare_eval_temp_file(code).unwrap_or_else(|e| {
+                eprintln!("error: {e}");
+                process::exit(1);
+            });
+            let tmp_path: PathBuf = tmp.path().to_path_buf();
+            if let Err(e) = fs::write(&tmp_path, &wrapped) {
+                eprintln!("error: failed to write temp file for -e: {e}");
+                process::exit(1);
+            }
+            let path_str = tmp_path.to_string_lossy().into_owned();
+            let outcome =
+                execute_run_with_timing(&path_str, args.argv.clone(), Some(&mut timing)).await;
+            drop(tmp);
+            (None, outcome)
+        }
+        (None, Some(file)) => {
+            let outcome = execute_run_with_timing(file, args.argv.clone(), Some(&mut timing)).await;
+            (Some(file.to_string()), outcome)
+        }
+        (Some(_), Some(_)) => {
+            eprintln!(
+                "error: `harn time run` accepts either `-e <code>` or `<file.harn>`, not both"
+            );
+            process::exit(2);
+        }
+        (None, None) => {
+            eprintln!("error: `harn time run` requires either `-e <code>` or `<file.harn>`");
+            process::exit(2);
+        }
+    };
+
+    let wall_ms = wall_start.elapsed().as_millis() as u64;
+    let cpu_ms_total = cpu_ms().saturating_sub(cpu_start);
+
+    if !outcome.stderr.is_empty() {
+        eprint!("{}", outcome.stderr);
+    }
+    if !outcome.stdout.is_empty() {
+        if args.json {
+            // JSON mode owns stdout for the envelope. Script output
+            // would corrupt downstream `jq` pipelines, so mirror it to
+            // stderr where humans can still see it.
+            eprint!("{}", outcome.stdout);
+        } else {
+            // Passthrough already delivered output to the terminal in
+            // human mode, but on cache-hit paths some bytes can land
+            // in the captured buffer (stdout passthrough only catches
+            // bytes flushed after it was installed). Re-emit so they
+            // aren't lost.
+            print!("{}", outcome.stdout);
+        }
+    }
+
+    let llm_trace = harn_vm::llm::take_trace();
+    let spans = harn_vm::tracing::take_spans();
+
+    let llm_calls: Vec<LlmCallTiming> = llm_trace
+        .iter()
+        .map(|entry| LlmCallTiming {
+            model: entry.model.clone(),
+            latency_ms: entry.duration_ms,
+            tokens: entry.input_tokens + entry.output_tokens,
+        })
+        .collect();
+
+    let tool_calls: Vec<ToolCallTiming> = spans
+        .iter()
+        .filter(|span| span.kind.as_str() == "tool_call")
+        .map(|span| ToolCallTiming {
+            name: span.name.clone(),
+            latency_ms: span.duration_ms,
+        })
+        .collect();
+
+    let main_events = spans.len() as u64;
+
+    let cache_hit = timing.cache_hit;
+    let phases = vec![
+        PhaseRecord {
+            name: "parse".into(),
+            duration_ms: timing.parse.as_millis() as u64,
+            input_bytes: if cache_hit {
+                None
+            } else {
+                Some(timing.input_bytes)
+            },
+            cache: None,
+            events: None,
+        },
+        PhaseRecord {
+            name: "typecheck".into(),
+            duration_ms: timing.typecheck.as_millis() as u64,
+            input_bytes: None,
+            cache: None,
+            events: None,
+        },
+        PhaseRecord {
+            name: "bytecode_compile".into(),
+            duration_ms: timing.bytecode_compile.as_millis() as u64,
+            input_bytes: None,
+            cache: Some(if cache_hit {
+                "hit".into()
+            } else {
+                "miss".into()
+            }),
+            events: None,
+        },
+        PhaseRecord {
+            name: "run_setup".into(),
+            duration_ms: timing.run_setup.as_millis() as u64,
+            input_bytes: None,
+            cache: None,
+            events: None,
+        },
+        PhaseRecord {
+            name: "run_main".into(),
+            duration_ms: timing.run_main.as_millis() as u64,
+            input_bytes: None,
+            cache: None,
+            events: Some(main_events),
+        },
+    ];
+
+    let report = TimingReport {
+        command: "run".into(),
+        target,
+        phases,
+        llm_calls,
+        tool_calls,
+        totals: TimingTotals {
+            wall_ms,
+            cpu_ms: cpu_ms_total,
+            cache_hits: if cache_hit { 1 } else { 0 },
+            cache_misses: if cache_hit { 0 } else { 1 },
+        },
+        exit_code: outcome.exit_code,
+    };
+
+    if args.json {
+        println!(
+            "{}",
+            to_string_pretty(&JsonEnvelope::ok(TIME_RUN_SCHEMA_VERSION, &report))
+        );
+    } else {
+        eprint!("{}", render_human(&report));
+    }
+
+    if outcome.exit_code != 0 {
+        process::exit(outcome.exit_code);
+    }
+}
+
+fn render_human(report: &TimingReport) -> String {
+    use std::fmt::Write;
+
+    let mut out = String::new();
+    let _ = writeln!(out, "\n\x1b[2m─── harn time ───\x1b[0m");
+    let _ = writeln!(
+        out,
+        "  wall {} · cpu {} · {} cache",
+        format_ms(report.totals.wall_ms),
+        format_ms(report.totals.cpu_ms),
+        if report.totals.cache_hits > 0 {
+            "hit"
+        } else {
+            "miss"
+        },
+    );
+    let _ = writeln!(out, "\n  Phases:");
+    for phase in &report.phases {
+        let suffix = match (phase.input_bytes, phase.cache.as_deref(), phase.events) {
+            (Some(bytes), _, _) => format!("  ({bytes} input bytes)"),
+            (_, Some(cache), _) => format!("  (cache {cache})"),
+            (_, _, Some(events)) => format!("  ({events} events)"),
+            _ => String::new(),
+        };
+        let _ = writeln!(
+            out,
+            "    {:<18} {:>10}{suffix}",
+            phase.name,
+            format_ms(phase.duration_ms),
+        );
+    }
+    if !report.llm_calls.is_empty() {
+        let _ = writeln!(out, "\n  LLM calls:");
+        for call in &report.llm_calls {
+            let _ = writeln!(
+                out,
+                "    {:<24} {:>10}  ({} tokens)",
+                call.model,
+                format_ms(call.latency_ms),
+                call.tokens,
+            );
+        }
+    }
+    if !report.tool_calls.is_empty() {
+        let _ = writeln!(out, "\n  Tool calls:");
+        for call in &report.tool_calls {
+            let _ = writeln!(
+                out,
+                "    {:<24} {:>10}",
+                call.name,
+                format_ms(call.latency_ms),
+            );
+        }
+    }
+    out
+}
+
+fn format_ms(ms: u64) -> String {
+    if ms < 1000 {
+        format!("{ms} ms")
+    } else {
+        format!("{:.3} s", ms as f64 / 1000.0)
+    }
+}
+
+/// Total user + system CPU time consumed by the current process, in
+/// milliseconds. Falls back to `0` on platforms where `getrusage` is
+/// unavailable so the field is always present in the envelope.
+#[cfg(unix)]
+fn cpu_ms() -> u64 {
+    use std::mem::MaybeUninit;
+    // SAFETY: `getrusage` writes a fully-initialized `rusage` on success;
+    // we treat the value as live only after the syscall reports OK.
+    unsafe {
+        let mut ru = MaybeUninit::<libc::rusage>::zeroed();
+        if libc::getrusage(libc::RUSAGE_SELF, ru.as_mut_ptr()) != 0 {
+            return 0;
+        }
+        let ru = ru.assume_init();
+        let user = duration_ms(ru.ru_utime.tv_sec, ru.ru_utime.tv_usec);
+        let system = duration_ms(ru.ru_stime.tv_sec, ru.ru_stime.tv_usec);
+        user.saturating_add(system)
+    }
+}
+
+#[cfg(not(unix))]
+fn cpu_ms() -> u64 {
+    0
+}
+
+#[cfg(unix)]
+fn duration_ms(secs: libc::time_t, micros: libc::suseconds_t) -> u64 {
+    // `libc::time_t` and `libc::suseconds_t` are platform-defined
+    // (i64 + i32 on macOS, i64 + i64 on glibc Linux). Going through
+    // i128 once dodges the per-platform clippy lint on a no-op cast
+    // and gives plenty of headroom for the *1000.
+    let secs_ms = i128::from(secs).saturating_mul(1000);
+    let micros_ms = i128::from(micros) / 1000;
+    secs_ms.saturating_add(micros_ms).max(0) as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tests::common::json_envelope::assert_envelope;
+
+    fn fixture_timing(cache_hit: bool) -> RunTiming {
+        RunTiming {
+            parse: if cache_hit {
+                Duration::default()
+            } else {
+                Duration::from_millis(12)
+            },
+            typecheck: if cache_hit {
+                Duration::default()
+            } else {
+                Duration::from_millis(80)
+            },
+            bytecode_compile: Duration::from_millis(35),
+            run_setup: Duration::from_millis(8),
+            run_main: Duration::from_millis(1200),
+            input_bytes: 4096,
+            cache_hit,
+        }
+    }
+
+    fn make_report(cache_hit: bool) -> TimingReport {
+        let timing = fixture_timing(cache_hit);
+        TimingReport {
+            command: "run".into(),
+            target: Some("examples/hello.harn".into()),
+            phases: vec![
+                PhaseRecord {
+                    name: "parse".into(),
+                    duration_ms: timing.parse.as_millis() as u64,
+                    input_bytes: if cache_hit {
+                        None
+                    } else {
+                        Some(timing.input_bytes)
+                    },
+                    cache: None,
+                    events: None,
+                },
+                PhaseRecord {
+                    name: "typecheck".into(),
+                    duration_ms: timing.typecheck.as_millis() as u64,
+                    input_bytes: None,
+                    cache: None,
+                    events: None,
+                },
+                PhaseRecord {
+                    name: "bytecode_compile".into(),
+                    duration_ms: timing.bytecode_compile.as_millis() as u64,
+                    input_bytes: None,
+                    cache: Some(if cache_hit {
+                        "hit".into()
+                    } else {
+                        "miss".into()
+                    }),
+                    events: None,
+                },
+                PhaseRecord {
+                    name: "run_setup".into(),
+                    duration_ms: timing.run_setup.as_millis() as u64,
+                    input_bytes: None,
+                    cache: None,
+                    events: None,
+                },
+                PhaseRecord {
+                    name: "run_main".into(),
+                    duration_ms: timing.run_main.as_millis() as u64,
+                    input_bytes: None,
+                    cache: None,
+                    events: Some(14),
+                },
+            ],
+            llm_calls: vec![LlmCallTiming {
+                model: "claude-sonnet-4-6".into(),
+                latency_ms: 850,
+                tokens: 1500,
+            }],
+            tool_calls: vec![ToolCallTiming {
+                name: "mcp_call".into(),
+                latency_ms: 200,
+            }],
+            totals: TimingTotals {
+                wall_ms: 1335,
+                cpu_ms: 320,
+                cache_hits: if cache_hit { 1 } else { 0 },
+                cache_misses: if cache_hit { 0 } else { 1 },
+            },
+            exit_code: 0,
+        }
+    }
+
+    #[test]
+    fn miss_envelope_has_five_phases_and_cache_miss_marker() {
+        let envelope = JsonEnvelope::ok(TIME_RUN_SCHEMA_VERSION, make_report(false));
+        let value = serde_json::to_value(&envelope).unwrap();
+        let data = assert_envelope(&value, TIME_RUN_SCHEMA_VERSION);
+        let phases = data["phases"].as_array().expect("phases is array");
+        assert_eq!(phases.len(), 5);
+        assert_eq!(phases[0]["name"], "parse");
+        assert_eq!(phases[0]["input_bytes"], 4096);
+        assert_eq!(phases[2]["name"], "bytecode_compile");
+        assert_eq!(phases[2]["cache"], "miss");
+        assert_eq!(data["totals"]["cache_misses"], 1);
+        assert_eq!(data["totals"]["cache_hits"], 0);
+    }
+
+    #[test]
+    fn hit_envelope_zeros_parse_typecheck_and_marks_cache_hit() {
+        let envelope = JsonEnvelope::ok(TIME_RUN_SCHEMA_VERSION, make_report(true));
+        let value = serde_json::to_value(&envelope).unwrap();
+        let data = assert_envelope(&value, TIME_RUN_SCHEMA_VERSION);
+        let phases = data["phases"].as_array().expect("phases is array");
+        assert_eq!(phases[0]["duration_ms"], 0);
+        assert_eq!(phases[1]["duration_ms"], 0);
+        // input_bytes is omitted on a hit since the parse path didn't run.
+        assert!(phases[0].get("input_bytes").is_none());
+        assert_eq!(phases[2]["cache"], "hit");
+        assert_eq!(data["totals"]["cache_hits"], 1);
+    }
+
+    #[test]
+    fn render_human_lists_phases_and_calls() {
+        let rendered = render_human(&make_report(false));
+        assert!(rendered.contains("harn time"));
+        assert!(rendered.contains("parse"));
+        assert!(rendered.contains("bytecode_compile"));
+        assert!(rendered.contains("cache miss"));
+        assert!(rendered.contains("claude-sonnet-4-6"));
+        assert!(rendered.contains("mcp_call"));
+    }
+
+    #[test]
+    fn render_human_for_hit_includes_cache_hit_marker() {
+        let rendered = render_human(&make_report(true));
+        assert!(rendered.contains("cache hit"));
+    }
+}

--- a/crates/harn-cli/src/json_envelope.rs
+++ b/crates/harn-cli/src/json_envelope.rs
@@ -163,6 +163,13 @@ pub fn catalog() -> Vec<SchemaEntry> {
             description: "Pipeline-run NDJSON event stream (stdout, stderr, transcript, tool, hook, persona, result, error).",
             schema_json: None,
         },
+        SchemaEntry {
+            command: "time run",
+            schema_version: crate::commands::time::TIME_RUN_SCHEMA_VERSION,
+            description:
+                "Per-phase wall-clock + cache hit/miss + per-LLM/tool-call latency for `harn run`.",
+            schema_json: None,
+        },
     ]
 }
 

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -26,7 +26,7 @@ use cli::{
     Cli, Command, CompletionShell, EvalCommand, MergeCaptainCommand, MergeCaptainMockCommand,
     ModelInfoArgs, PackageArtifactsCommand, PackageCacheCommand, PackageCommand, PersonaCommand,
     PersonaSupervisionCommand, ProvidersCommand, RunsCommand, ServeCommand, SkillCommand,
-    SkillKeyCommand, SkillTrustCommand, SkillsCommand, ToolCommand,
+    SkillKeyCommand, SkillTrustCommand, SkillsCommand, TimeCommand, ToolCommand,
 };
 use harn_lexer::Lexer;
 use harn_parser::{DiagnosticSeverity, Parser, TypeChecker};
@@ -1163,6 +1163,9 @@ async fn async_main() {
         Command::DumpProtocolArtifacts(args) => {
             commands::dump_protocol_artifacts::run(&args.output_dir, args.check);
         }
+        Command::Time(args) => match args.command {
+            TimeCommand::Run(time_args) => commands::time::run(time_args).await,
+        },
     }
 }
 

--- a/crates/harn-cli/tests/json_schemas_cli.rs
+++ b/crates/harn-cli/tests/json_schemas_cli.rs
@@ -37,6 +37,10 @@ fn json_schemas_lists_all_registered_commands() {
         entries.iter().any(|e| e["command"] == "doctor"),
         "doctor should be in the catalog: {entries:?}"
     );
+    assert!(
+        entries.iter().any(|e| e["command"] == "time run"),
+        "`time run` should be in the catalog: {entries:?}"
+    );
     for entry in entries {
         assert!(
             entry.get("command").and_then(|v| v.as_str()).is_some(),

--- a/crates/harn-cli/tests/time_cli.rs
+++ b/crates/harn-cli/tests/time_cli.rs
@@ -1,0 +1,196 @@
+//! End-to-end smoke for `harn time run --json`.
+//!
+//! Spawns the binary so we exercise the actual clap parser + envelope
+//! serialization path. The first invocation is a cache miss; the
+//! second run on the same source must report `cache: "hit"` and
+//! `cache_hits == 1`.
+
+use std::process::Command;
+
+use harn_cli::commands::time::TIME_RUN_SCHEMA_VERSION;
+use harn_cli::tests::common::json_envelope::assert_envelope;
+
+fn binary_path() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_BIN_EXE_harn"))
+}
+
+fn write_hello_script(dir: &std::path::Path) -> std::path::PathBuf {
+    let path = dir.join("hello.harn");
+    std::fs::write(
+        &path,
+        "pipeline default(task) {\n  log(\"hello from harn time\")\n}\n",
+    )
+    .expect("write hello.harn");
+    path
+}
+
+fn parse_envelope(out: &std::process::Output) -> serde_json::Value {
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let trimmed = stdout.trim();
+    let start = trimmed
+        .find('{')
+        .unwrap_or_else(|| panic!("stdout has no JSON object: {stdout}"));
+    serde_json::from_str(&trimmed[start..])
+        .unwrap_or_else(|err| panic!("harn time --json output is not JSON: {err}\n{stdout}"))
+}
+
+fn run_time(script: &std::path::Path, cache_dir: &std::path::Path) -> std::process::Output {
+    Command::new(binary_path())
+        .args(["time", "run", "--json", &script.to_string_lossy()])
+        .env("HARN_CACHE_DIR", cache_dir)
+        .env("HARN_BYTECODE_CACHE", "1")
+        .output()
+        .expect("spawn harn time run")
+}
+
+#[test]
+fn time_run_json_smoke_emits_five_phases_with_cache_miss_then_hit() {
+    let workdir = tempfile::tempdir().expect("workdir");
+    let cache_dir = tempfile::tempdir().expect("cache dir");
+    let script = write_hello_script(workdir.path());
+
+    // First run: cache miss. All five phases recorded.
+    let first = run_time(&script, cache_dir.path());
+    assert!(
+        first.status.success(),
+        "first run failed (exit={:?}): stderr={}",
+        first.status.code(),
+        String::from_utf8_lossy(&first.stderr)
+    );
+    let first_value = parse_envelope(&first);
+    let data = assert_envelope(&first_value, TIME_RUN_SCHEMA_VERSION);
+
+    let phases = data["phases"].as_array().expect("phases is array");
+    assert!(
+        phases.len() >= 4,
+        "expected at least 4 phases, got {}: {phases:?}",
+        phases.len()
+    );
+
+    let names: Vec<&str> = phases
+        .iter()
+        .map(|p| p["name"].as_str().unwrap_or(""))
+        .collect();
+    assert!(names.contains(&"parse"), "missing parse phase: {names:?}");
+    assert!(
+        names.contains(&"typecheck"),
+        "missing typecheck phase: {names:?}"
+    );
+    assert!(
+        names.contains(&"bytecode_compile"),
+        "missing bytecode_compile phase: {names:?}"
+    );
+    assert!(
+        names.contains(&"run_main"),
+        "missing run_main phase: {names:?}"
+    );
+
+    let compile_phase = phases
+        .iter()
+        .find(|p| p["name"] == "bytecode_compile")
+        .expect("bytecode_compile phase present");
+    assert_eq!(
+        compile_phase["cache"], "miss",
+        "first run should report cache miss: {compile_phase}"
+    );
+
+    let totals = &data["totals"];
+    assert_eq!(totals["cache_misses"], 1);
+    assert_eq!(totals["cache_hits"], 0);
+    assert!(totals["wall_ms"].as_u64().is_some(), "wall_ms missing");
+    // cpu_ms is best-effort; on Unix it should be populated, on Windows
+    // it falls back to 0. Either way the field is present.
+    assert!(totals.get("cpu_ms").is_some(), "cpu_ms missing");
+
+    // Second run: cache hit (same source + same HARN_CACHE_DIR).
+    let second = run_time(&script, cache_dir.path());
+    assert!(
+        second.status.success(),
+        "second run failed (exit={:?}): stderr={}",
+        second.status.code(),
+        String::from_utf8_lossy(&second.stderr)
+    );
+    let second_value = parse_envelope(&second);
+    let data2 = assert_envelope(&second_value, TIME_RUN_SCHEMA_VERSION);
+    let compile_phase2 = data2["phases"]
+        .as_array()
+        .expect("phases array")
+        .iter()
+        .find(|p| p["name"] == "bytecode_compile")
+        .expect("bytecode_compile phase present");
+    assert_eq!(
+        compile_phase2["cache"], "hit",
+        "second run on same source must report cache hit: {compile_phase2}"
+    );
+    assert_eq!(data2["totals"]["cache_hits"], 1);
+    assert_eq!(data2["totals"]["cache_misses"], 0);
+}
+
+#[test]
+fn time_run_no_cache_flag_forces_miss_on_warm_cache() {
+    let workdir = tempfile::tempdir().expect("workdir");
+    let cache_dir = tempfile::tempdir().expect("cache dir");
+    let script = write_hello_script(workdir.path());
+
+    // Warm the cache.
+    let _ = run_time(&script, cache_dir.path());
+
+    let output = Command::new(binary_path())
+        .args([
+            "time",
+            "run",
+            "--json",
+            "--no-cache",
+            &script.to_string_lossy(),
+        ])
+        .env("HARN_CACHE_DIR", cache_dir.path())
+        .env("HARN_BYTECODE_CACHE", "1")
+        .output()
+        .expect("spawn harn time run --no-cache");
+    assert!(
+        output.status.success(),
+        "exit={:?}, stderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let parsed = parse_envelope(&output);
+    let data = assert_envelope(&parsed, TIME_RUN_SCHEMA_VERSION);
+    let compile_phase = data["phases"]
+        .as_array()
+        .expect("phases array")
+        .iter()
+        .find(|p| p["name"] == "bytecode_compile")
+        .expect("bytecode_compile phase present");
+    assert_eq!(compile_phase["cache"], "miss");
+}
+
+#[test]
+fn time_run_eval_mode_emits_envelope() {
+    let workdir = tempfile::tempdir().expect("workdir");
+    let cache_dir = tempfile::tempdir().expect("cache dir");
+
+    let output = Command::new(binary_path())
+        .args(["time", "run", "--json", "-e", "println(\"inline\")"])
+        .current_dir(workdir.path())
+        .env("HARN_CACHE_DIR", cache_dir.path())
+        .env("HARN_BYTECODE_CACHE", "1")
+        .output()
+        .expect("spawn harn time run -e");
+    assert!(
+        output.status.success(),
+        "exit={:?}, stderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let parsed = parse_envelope(&output);
+    let data = assert_envelope(&parsed, TIME_RUN_SCHEMA_VERSION);
+    assert_eq!(data["command"], "run");
+    // -e doesn't produce a stable file path; target should be absent.
+    assert!(
+        data.get("target").map(|v| v.is_null()).unwrap_or(true),
+        "target should be omitted for -e runs"
+    );
+    assert!(data["phases"].as_array().is_some_and(|a| !a.is_empty()));
+}

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -298,6 +298,64 @@ harn bench replay \
   --json
 ```
 
+## harn time
+
+Wrap a subcommand with phase-level wall-clock timing plus per-LLM-call
+and per-tool-call latency. Today only `harn time run` is supported.
+
+```bash
+harn time run main.harn
+harn time run main.harn --json
+harn time run main.harn --json --no-cache
+harn time run -e 'println("hi")' --json
+harn time run script.harn -- arg1 arg2
+```
+
+The output is keyed by five fixed phases — `parse`, `typecheck`,
+`bytecode_compile`, `run_setup`, `run_main` — even when a bytecode-cache
+hit lets us skip parse/typecheck. The `bytecode_compile` row carries a
+`cache: "hit" | "miss"` field so cost-and-perf eyeballs and agent
+pipelines can dispatch on cache state without a separate flag.
+
+`--json` emits a versioned `JsonEnvelope` (schema registered as
+`time run` in `harn --json-schemas`):
+
+```json
+{
+  "schemaVersion": 1,
+  "ok": true,
+  "data": {
+    "command": "run",
+    "target": "main.harn",
+    "phases": [
+      { "name": "parse", "duration_ms": 12, "input_bytes": 4096 },
+      { "name": "typecheck", "duration_ms": 80 },
+      { "name": "bytecode_compile", "duration_ms": 35, "cache": "miss" },
+      { "name": "run_setup", "duration_ms": 8 },
+      { "name": "run_main", "duration_ms": 1200, "events": 14 }
+    ],
+    "llm_calls": [
+      { "model": "claude-sonnet-4-6", "latency_ms": 850, "tokens": 1500 }
+    ],
+    "tool_calls": [{ "name": "mcp_call", "latency_ms": 200 }],
+    "totals": {
+      "wall_ms": 1335,
+      "cpu_ms": 320,
+      "cache_hits": 0,
+      "cache_misses": 1
+    },
+    "exit_code": 0
+  }
+}
+```
+
+In `--json` mode the wrapper hands stdout to the envelope: any script
+output is redirected to stderr so `harn time run … --json | jq …` works
+without filtering. Diagnostics and non-zero exit codes from the wrapped
+run still propagate through `harn time`. `--no-cache` sets
+`HARN_BYTECODE_CACHE=0` for the duration of the invocation only,
+forcing a cold parse/typecheck/compile.
+
 ## harn viz
 
 Render a `.harn` file as a Mermaid flowchart.

--- a/scripts/lint_test_patterns.sh
+++ b/scripts/lint_test_patterns.sh
@@ -387,6 +387,11 @@ NON_TEST_WALL_CLOCK_ALLOWLIST=(
   "crates/harn-cli/src/commands/run.rs"
   "crates/harn-cli/src/commands/supervisor.rs"
   "crates/harn-cli/src/commands/test.rs"
+  # `harn time run` measures real wall-clock + per-phase elapsed time
+  # for cost/perf debugging — host time is the source of truth, same
+  # shape as the allowlisted `run.rs`, `demo.rs`, and `bench.rs`
+  # entries. Wall/CPU readings are reported in the structured envelope.
+  "crates/harn-cli/src/commands/time.rs"
   "crates/harn-cli/src/commands/trigger/ops.rs"
   "crates/harn-cli/src/commands/trigger/replay.rs"
   "crates/harn-cli/src/package/registry.rs"


### PR DESCRIPTION
## Summary

Implements Tier-3 ticket [#1787](https://github.com/burin-labs/harn/issues/1787) — a new `harn time` top-level subcommand that wraps a wrapped subcommand (today: `run`) with structured phase timing.

- `harn time run script.harn` prints a human-readable phase table.
- `harn time run script.harn --json` emits a versioned `JsonEnvelope` with five fixed phases (`parse`, `typecheck`, `bytecode_compile`, `run_setup`, `run_main`), `cache: "hit" | "miss"` on `bytecode_compile`, per-LLM-call latency (`model`, `latency_ms`, `tokens`), per-tool-call latency (`name`, `latency_ms`), and totals (`wall_ms`, `cpu_ms`, `cache_hits`, `cache_misses`).
- Registered as `time run` in `harn --json-schemas` (catalog v1 entry).
- `--no-cache` lifts `HARN_BYTECODE_CACHE=0` for the invocation only; `-e <code>` works for inline scripts.

### Architecture

Rather than duplicating the run path, this PR threads an optional `&mut RunTiming` observer through `commands::run::{compile_or_load_chunk_*, execute_run_inner}`. `harn run` calls pass `None` (no-op); `harn time run` passes `Some(&mut timing)`. Each phase records into the same struct; the wrapper renders it as a `JsonEnvelope` or human table.

In `--json` mode the wrapper redirects script `stdout` to stderr so the envelope is alone on stdout for `jq` pipelines.

### Exit criteria (from #1787)

- [x] `harn time run examples/hello.harn --json | jq '.data.phases | length >= 4'` → `true`
- [x] `cache: "hit"` reported on a second run against the same source
- [x] Per-LLM-call + per-tool-call latency present in transcripts with calls (verified manually with a mock-provider script and via VM tracing spans)

## Test plan

- [x] `cargo test -p harn-cli --lib` — 586 tests, all green (4 new `commands::time::tests::*` cases cover miss/hit envelope shape + human renderer)
- [x] `cargo test -p harn-cli --test time_cli` — 3 new integration tests:
  - smoke run emits 5 phases + miss-then-hit on rerun against a shared `HARN_CACHE_DIR`
  - `--no-cache` forces a miss even with a warm cache
  - `-e` mode emits an envelope with no `target` field
- [x] `cargo test -p harn-cli --test json_schemas_cli` — verifies `time run` shows up in the schema catalog
- [x] `cargo clippy -p harn-cli --tests --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `make lint-test-patterns` (added `commands/time.rs` to `NON_TEST_WALL_CLOCK_ALLOWLIST` with one-line rationale — wall-clock IS the source of truth for this command, same shape as the existing `run.rs` / `bench.rs` / `demo.rs` entries)
- [x] `npx markdownlint-cli2` clean on `CHANGELOG.md` + `docs/src/cli-reference.md` (added "harn time" section after "harn bench")
- [x] Manual smoke: `harn time run examples/hello.harn --json` and `harn time run -e 'println("hi")' --json` produce well-formed envelopes
- [x] Confirmed `harn run --json` (the NDJSON event stream that landed in #1810) still passes after the rebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)