### PR TITLE
Add `harn dev --watch` incremental loop via interface fingerprints (#1786)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,24 @@ condensed series summaries instead of full per-patch history.
   is regenerated from the same `DoctorReport`, so JSON and human
   surfaces never drift.
 
+- **`harn dev --watch` incremental loop gated by interface fingerprints
+  (#1786).** New `harn dev --watch [<root>]` watches every `.harn` file
+  under `<root>` (defaulting to the cwd) and re-type-checks only the
+  modules whose public surface actually moved. Each module carries a
+  BLAKE3 **interface fingerprint** over its public types, function /
+  pipeline / tool signatures, struct + enum shapes, and `pub import`
+  re-exports — bodies, doc comments, and private helpers are
+  intentionally excluded. An edit that flips a fingerprint transitively
+  invalidates importers via `ModuleGraph::importers_of`; an edit that
+  leaves the fingerprint stable only re-checks the changed file.
+  `--json` emits an NDJSON event stream (`ready` /
+  `fingerprint_changed` / `rerun` / `diagnostics` / `tests`) wrapped in
+  the canonical `JsonEnvelope`, registered under `dev` in
+  `harn --json-schemas`. `--with-tests` extends the loop to also
+  re-run `test_*` / `@test`-attributed pipelines in each invalidated
+  module. New `harn_modules::fingerprint` module exposes
+  `fingerprint_program` / `fingerprint_file` / `fingerprint_source` for
+  reuse by editors and the bytecode cache.
 - **`harn explain HARN-<CAT>-<NNN>` text + `--json` envelope (#1748).** The
   `explain` subcommand now dispatches on registered stable diagnostic codes
   in addition to its original control-flow invariant form. `harn explain

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2260,6 +2260,7 @@ dependencies = [
 name = "harn-modules"
 version = "0.8.24"
 dependencies = [
+ "blake3",
  "croner",
  "harn-lexer",
  "harn-parser",

--- a/crates/harn-cli/Cargo.toml
+++ b/crates/harn-cli/Cargo.toml
@@ -55,8 +55,8 @@ serde = { version = "1", features = ["derive"] }
 notify = "8"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "blocking", "stream"] }
 futures = "0.3"
-sha2 = "0.11"
 blake3 = "1"
+sha2 = "0.11"
 tar = { version = "0.4", default-features = false }
 flate2 = "1"
 subtle = "2.6"

--- a/crates/harn-cli/src/cli/dev.rs
+++ b/crates/harn-cli/src/cli/dev.rs
@@ -1,0 +1,38 @@
+use clap::Args;
+
+/// `harn dev --watch <root>` — incremental developer loop.
+///
+/// Watches every `.harn` file under `<root>` and only re-typechecks (and
+/// optionally re-runs tests in) the modules invalidated by the latest
+/// edit. Invalidation is gated by per-module **interface fingerprints**
+/// (BLAKE3 of the public surface), so an internal-only change rebuilds
+/// just the edited file; an edit to a public signature transitively
+/// invalidates everything that imports it.
+#[derive(Debug, Args)]
+pub(crate) struct DevArgs {
+    /// Watch the filesystem for `.harn` changes and re-run incrementally.
+    /// Currently the only supported mode — passing this flag is required
+    /// so the surface stays open for future non-watch dev sub-modes
+    /// without re-litigating the default.
+    #[arg(long)]
+    pub watch: bool,
+    /// Emit a newline-delimited JSON event stream on stdout. Each line
+    /// is a single `JsonEnvelope`-wrapped event (`ready`,
+    /// `fingerprint_changed`, `rerun`, `diagnostics`). See
+    /// `harn --json-schemas --command dev` for the catalog entry.
+    #[arg(long)]
+    pub json: bool,
+    /// Run tests (`test_*` pipelines / `@test`-attributed pipelines) in
+    /// every invalidated module after type-checking succeeds. Off by
+    /// default to keep the inner loop fast; flip on once you want a
+    /// full red/green watch.
+    #[arg(long = "with-tests")]
+    pub with_tests: bool,
+    /// Test timeout per module when `--with-tests` is set.
+    #[arg(long = "test-timeout-ms", default_value_t = 10_000, value_name = "MS")]
+    pub test_timeout_ms: u64,
+    /// Project root to watch. Defaults to the current working
+    /// directory.
+    #[arg(value_name = "ROOT")]
+    pub root: Option<String>,
+}

--- a/crates/harn-cli/src/cli/mod.rs
+++ b/crates/harn-cli/src/cli/mod.rs
@@ -19,6 +19,7 @@ mod connector;
 mod contracts;
 mod crystallize;
 mod demo;
+mod dev;
 mod doctor;
 mod dump;
 mod eval;
@@ -83,6 +84,7 @@ pub(crate) use crystallize::{
     CrystallizeValidateArgs,
 };
 pub(crate) use demo::DemoArgs;
+pub(crate) use dev::DevArgs;
 pub(crate) use doctor::DoctorArgs;
 pub(crate) use dump::{
     DumpConnectorMatrixArgs, DumpHighlightKeywordsArgs, DumpProtocolArtifactsArgs,
@@ -315,6 +317,22 @@ SCRIPTING
     Mcp(McpArgs),
     /// Watch a .harn file and re-run it on changes.
     Watch(WatchArgs),
+    /// Watch a Harn project and re-typecheck only the modules whose
+    /// public interface fingerprint actually changed.
+    ///
+    /// USAGE
+    ///     harn dev --watch [<root>]
+    ///     harn dev --watch --json
+    ///     harn dev --watch --with-tests
+    ///
+    /// On each file change, the changed module's interface fingerprint
+    /// (BLAKE3 of types + signatures + `pub import` re-exports) is
+    /// recomputed. If it matches the previous fingerprint, only that
+    /// module is re-checked. If it changed, every transitive importer
+    /// is invalidated and re-checked. `--with-tests` extends the loop
+    /// to also re-run `test_*` / `@test`-attributed pipelines in
+    /// every invalidated module.
+    Dev(DevArgs),
     /// Launch the local Harn observability portal.
     Portal(PortalArgs),
     /// Replay and inspect historical trigger dispatches from the event log.

--- a/crates/harn-cli/src/commands/dev.rs
+++ b/crates/harn-cli/src/commands/dev.rs
@@ -1,0 +1,790 @@
+//! `harn dev --watch` — incremental dev loop driven by per-module
+//! **interface fingerprints**.
+//!
+//! Implements the contract from #1786: a file edit only invalidates
+//! dependents when the changed module's public surface — types,
+//! signatures, `pub import` re-exports — actually moved. Internal-only
+//! edits leave the fingerprint stable and re-check just the edited
+//! file.
+//!
+//! Output modes:
+//! - human (default): coloured progress lines on stderr.
+//! - `--json`: NDJSON event stream on stdout, one
+//!   [`JsonEnvelope`]-wrapped event per line. Event shapes are
+//!   registered in [`crate::json_envelope::catalog`] under the `dev`
+//!   command.
+
+use std::collections::{BTreeMap, BTreeSet, HashSet, VecDeque};
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+use std::process;
+use std::time::Duration;
+
+use harn_modules::fingerprint::{fingerprint_file, fingerprint_hex, Fingerprint};
+use harn_modules::ModuleGraph;
+use harn_parser::{DiagnosticSeverity, Parser, TypeChecker, TypeDiagnostic};
+use notify::{Event, EventKind, RecursiveMode, Watcher};
+use serde::Serialize;
+use tokio::sync::mpsc;
+
+use crate::cli::DevArgs;
+use crate::json_envelope::{JsonEnvelope, JsonOutput};
+use crate::test_runner::run_test_file;
+
+/// Schema version of the `dev --json` event stream. Bump when the
+/// `DevEvent` shape changes in a way agents need to detect.
+pub const DEV_SCHEMA_VERSION: u32 = 1;
+
+/// Debounce window for filesystem notifications. `notify` typically
+/// fires several events per save (atomic-rename editors emit
+/// create+remove+modify); coalescing them avoids redundant re-checks.
+const DEBOUNCE: Duration = Duration::from_millis(200);
+
+/// Top-level entry point for `harn dev`.
+pub(crate) async fn run(args: DevArgs) {
+    if !args.watch {
+        eprintln!(
+            "error: `harn dev` currently requires `--watch`. Pass `--watch` to start the incremental loop."
+        );
+        process::exit(2);
+    }
+
+    let root = match args.root.as_deref() {
+        Some(p) => PathBuf::from(p),
+        None => std::env::current_dir().unwrap_or_else(|e| {
+            eprintln!("error: could not read current directory: {e}");
+            process::exit(1);
+        }),
+    };
+    let root = match root.canonicalize() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("error: could not canonicalize {}: {e}", root.display());
+            process::exit(1);
+        }
+    };
+
+    let mut emitter = Emitter::new(args.json);
+    let opts = RunOptions {
+        with_tests: args.with_tests,
+        test_timeout_ms: args.test_timeout_ms,
+    };
+
+    let mut state = DevState::initial_scan(&root);
+    emitter.emit(DevEvent::Ready {
+        root: root.to_string_lossy().into_owned(),
+        modules: state.fingerprints.len(),
+        fingerprints: state.fingerprint_hex_map(),
+    });
+
+    // Type-check the whole project once on startup so diagnostics surface
+    // before the user has typed a key.
+    let initial_paths: Vec<PathBuf> = state.fingerprints.keys().cloned().collect();
+    process_invalidations(&mut state, &initial_paths, &mut emitter, &opts).await;
+
+    let (tx, mut rx) = mpsc::channel::<()>(1);
+    let _watcher = match start_watcher(&root, tx.clone()) {
+        Ok(w) => w,
+        Err(e) => {
+            eprintln!(
+                "error: could not start file watcher on {}: {e}",
+                root.display()
+            );
+            process::exit(1);
+        }
+    };
+
+    if !args.json {
+        eprintln!(
+            "\x1b[2m[dev] watching {} for .harn changes (ctrl-c to stop)\x1b[0m",
+            root.display()
+        );
+    }
+
+    loop {
+        if rx.recv().await.is_none() {
+            return;
+        }
+        tokio::time::sleep(DEBOUNCE).await;
+        while rx.try_recv().is_ok() {}
+
+        let changed = state.refresh_filesystem(&root);
+        let mut invalidated = BTreeSet::<PathBuf>::new();
+        for path in &changed {
+            let (event, dependents) = state.apply_change(path);
+            if let Some(ev) = event {
+                emitter.emit(ev);
+            }
+            for d in dependents {
+                invalidated.insert(d);
+            }
+        }
+        if invalidated.is_empty() {
+            continue;
+        }
+        let ordered: Vec<PathBuf> = invalidated.into_iter().collect();
+        process_invalidations(&mut state, &ordered, &mut emitter, &opts).await;
+    }
+}
+
+struct RunOptions {
+    with_tests: bool,
+    test_timeout_ms: u64,
+}
+
+/// Cached per-watch state. `graph` is rebuilt on every change so import
+/// edits (a new `import "./x"` line) immediately participate in
+/// invalidation; rebuilding is cheap relative to the user's edit
+/// cadence and keeps the dependent-set computation honest.
+struct DevState {
+    /// Current interface fingerprints, keyed by canonical path.
+    fingerprints: BTreeMap<PathBuf, Fingerprint>,
+    /// BLAKE3 of the raw source content, keyed by canonical path. Used
+    /// to detect any edit (body-only or otherwise) so we know which
+    /// modules even need to be re-checked. The fingerprint then
+    /// decides whether dependents are invalidated too.
+    sources: BTreeMap<PathBuf, [u8; 32]>,
+    /// Module graph reflecting the on-disk set of `.harn` files.
+    graph: ModuleGraph,
+    /// Project root used for human-friendly display paths.
+    root: PathBuf,
+}
+
+impl DevState {
+    fn initial_scan(root: &Path) -> Self {
+        let files = scan_harn_files(root);
+        let mut state = Self {
+            fingerprints: BTreeMap::new(),
+            sources: BTreeMap::new(),
+            graph: ModuleGraph::default(),
+            root: root.to_path_buf(),
+        };
+        state.rebuild_graph(&files);
+        for file in &files {
+            let canon = canonical(file);
+            if let Some(fp) = fingerprint_file(file) {
+                state.fingerprints.insert(canon.clone(), fp);
+            }
+            if let Some(hash) = read_source_hash(file) {
+                state.sources.insert(canon, hash);
+            }
+        }
+        state
+    }
+
+    fn display_path(&self, path: &Path) -> String {
+        path.strip_prefix(&self.root)
+            .map(|p| p.to_string_lossy().into_owned())
+            .unwrap_or_else(|_| path.to_string_lossy().into_owned())
+    }
+
+    fn fingerprint_hex_map(&self) -> BTreeMap<String, String> {
+        self.fingerprints
+            .iter()
+            .map(|(p, fp)| (self.display_path(p), fingerprint_hex(fp)))
+            .collect()
+    }
+
+    fn rebuild_graph(&mut self, files: &[PathBuf]) {
+        let owned: Vec<PathBuf> = files.to_vec();
+        self.graph = harn_modules::build(&owned);
+    }
+
+    /// Walk the filesystem and report the files whose source content
+    /// (or existence) has changed since the last scan. Also rebuilds
+    /// `self.graph` so import additions/removals propagate.
+    fn refresh_filesystem(&mut self, root: &Path) -> Vec<PathBuf> {
+        let files = scan_harn_files(root);
+        self.rebuild_graph(&files);
+        let mut on_disk: HashSet<PathBuf> = HashSet::new();
+        let mut changed: Vec<PathBuf> = Vec::new();
+        for file in &files {
+            let canon = canonical(file);
+            on_disk.insert(canon.clone());
+            let new_hash = read_source_hash(file);
+            let prev_hash = self.sources.get(&canon).copied();
+            if prev_hash != new_hash {
+                changed.push(canon);
+            }
+        }
+        // Surface deletions so dependents can re-error.
+        let deleted: Vec<PathBuf> = self
+            .sources
+            .keys()
+            .filter(|p| !on_disk.contains(*p))
+            .cloned()
+            .collect();
+        for d in deleted {
+            changed.push(d);
+        }
+        changed.sort();
+        changed.dedup();
+        changed
+    }
+
+    /// Apply a single file change to `self.fingerprints` and return the
+    /// event to emit (if any) plus the set of paths whose
+    /// type-checking is now stale.
+    fn apply_change(&mut self, path: &Path) -> (Option<DevEvent>, Vec<PathBuf>) {
+        let canon = canonical(path);
+        let new_fp = fingerprint_file(&canon);
+        let new_hash = read_source_hash(&canon);
+        let prev_fp = self.fingerprints.get(&canon).copied();
+        match new_hash {
+            Some(hash) => {
+                self.sources.insert(canon.clone(), hash);
+            }
+            None => {
+                self.sources.remove(&canon);
+            }
+        }
+        match (prev_fp, new_fp) {
+            (Some(old), Some(new)) if old == new => {
+                // Body-only edit (or non-public surface change): rerun
+                // just this module so syntax / private-only type errors
+                // surface, but leave dependents alone.
+                (None, vec![canon])
+            }
+            (Some(old), Some(new)) => {
+                self.fingerprints.insert(canon.clone(), new);
+                let module = self.display_path(&canon);
+                let event = DevEvent::FingerprintChanged {
+                    module,
+                    old: fingerprint_hex(&old),
+                    new: fingerprint_hex(&new),
+                };
+                let mut affected = self.transitive_importers(&canon);
+                affected.insert(canon);
+                (Some(event), affected.into_iter().collect())
+            }
+            (None, Some(new)) => {
+                self.fingerprints.insert(canon.clone(), new);
+                let event = DevEvent::FingerprintChanged {
+                    module: self.display_path(&canon),
+                    old: String::new(),
+                    new: fingerprint_hex(&new),
+                };
+                (Some(event), vec![canon])
+            }
+            (Some(old), None) => {
+                self.fingerprints.remove(&canon);
+                let module = self.display_path(&canon);
+                let event = DevEvent::FingerprintChanged {
+                    module,
+                    old: fingerprint_hex(&old),
+                    new: String::new(),
+                };
+                let affected = self.transitive_importers(&canon);
+                (Some(event), affected.into_iter().collect())
+            }
+            (None, None) => (None, Vec::new()),
+        }
+    }
+
+    fn transitive_importers(&self, start: &Path) -> BTreeSet<PathBuf> {
+        let mut seen: BTreeSet<PathBuf> = BTreeSet::new();
+        let mut queue: VecDeque<PathBuf> = VecDeque::new();
+        queue.push_back(canonical(start));
+        while let Some(path) = queue.pop_front() {
+            for importer in self.graph.importers_of(&path) {
+                let canon = canonical(&importer);
+                if seen.insert(canon.clone()) {
+                    queue.push_back(canon);
+                }
+            }
+        }
+        seen
+    }
+}
+
+fn canonical(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn read_source_hash(path: &Path) -> Option<[u8; 32]> {
+    let bytes = std::fs::read(path).ok()?;
+    Some(blake3::hash(&bytes).into())
+}
+
+/// Walk `root` recursively for `.harn` files, skipping the same
+/// generated directories (`target/`, `node_modules/`, `.harn/`,
+/// `.git/`) that the rest of the toolchain ignores.
+fn scan_harn_files(root: &Path) -> Vec<PathBuf> {
+    let mut out: Vec<PathBuf> = Vec::new();
+    walk(root, &mut out);
+    out.sort();
+    out
+}
+
+fn walk(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        if path.is_dir() {
+            if matches!(
+                name,
+                "target" | "node_modules" | ".git" | ".harn" | ".harn-runs" | ".harn-cache"
+            ) {
+                continue;
+            }
+            walk(&path, out);
+        } else if path.extension().is_some_and(|ext| ext == "harn") {
+            out.push(path);
+        }
+    }
+}
+
+fn start_watcher(
+    root: &Path,
+    tx: mpsc::Sender<()>,
+) -> Result<notify::RecommendedWatcher, notify::Error> {
+    let mut watcher = notify::recommended_watcher(move |res: Result<Event, _>| {
+        if let Ok(event) = res {
+            if matches!(
+                event.kind,
+                EventKind::Modify(_) | EventKind::Create(_) | EventKind::Remove(_)
+            ) && event
+                .paths
+                .iter()
+                .any(|p| p.extension().is_some_and(|ext| ext == "harn"))
+            {
+                let _ = tx.blocking_send(());
+            }
+        }
+    })?;
+    watcher.watch(root, RecursiveMode::Recursive)?;
+    Ok(watcher)
+}
+
+async fn process_invalidations(
+    state: &mut DevState,
+    paths: &[PathBuf],
+    emitter: &mut Emitter,
+    opts: &RunOptions,
+) {
+    if paths.is_empty() {
+        return;
+    }
+    let module_names: Vec<String> = paths.iter().map(|p| state.display_path(p)).collect();
+    emitter.emit(DevEvent::Rerun {
+        modules: module_names.clone(),
+    });
+
+    for path in paths {
+        if !path.exists() {
+            // Deletion: nothing to type-check for the file itself.
+            // Dependents are re-checked separately and will produce
+            // unresolved-import diagnostics naturally.
+            continue;
+        }
+        let diags = typecheck_file(&state.graph, path);
+        let count = diags.len();
+        let serialized = diags.iter().map(serialize_diag).collect();
+        emitter.emit(DevEvent::Diagnostics {
+            module: state.display_path(path),
+            count,
+            diagnostics: serialized,
+        });
+
+        if opts.with_tests {
+            run_module_tests(path, opts.test_timeout_ms, state, emitter).await;
+        }
+    }
+}
+
+async fn run_module_tests(path: &Path, timeout_ms: u64, state: &DevState, emitter: &mut Emitter) {
+    let cli_skill_dirs: Vec<PathBuf> = Vec::new();
+    let results = match run_test_file(path, None, timeout_ms, None, &cli_skill_dirs).await {
+        Ok(r) => r,
+        Err(error) => {
+            emitter.emit(DevEvent::TestError {
+                module: state.display_path(path),
+                error,
+            });
+            return;
+        }
+    };
+    let passed = results.iter().filter(|r| r.passed).count();
+    let failed = results.len() - passed;
+    let failures = results
+        .iter()
+        .filter(|r| !r.passed)
+        .map(|r| TestFailure {
+            name: r.name.clone(),
+            error: r.error.clone().unwrap_or_default(),
+        })
+        .collect();
+    emitter.emit(DevEvent::Tests {
+        module: state.display_path(path),
+        passed,
+        failed,
+        failures,
+    });
+}
+
+fn typecheck_file(graph: &ModuleGraph, path: &Path) -> Vec<TypeDiagnostic> {
+    let Ok(source) = std::fs::read_to_string(path) else {
+        return Vec::new();
+    };
+    let mut lexer = harn_lexer::Lexer::new(&source);
+    let tokens = match lexer.tokenize() {
+        Ok(t) => t,
+        Err(e) => return vec![lex_diagnostic(format!("{e}"))],
+    };
+    let program = match Parser::new(tokens).parse() {
+        Ok(p) => p,
+        Err(e) => return vec![lex_diagnostic(format!("{e}"))],
+    };
+    let mut checker = TypeChecker::new();
+    if let Some(imported) = graph.imported_names_for_file(path) {
+        checker = checker.with_imported_names(imported);
+    }
+    if let Some(imported) = graph.imported_type_declarations_for_file(path) {
+        checker = checker.with_imported_type_decls(imported);
+    }
+    if let Some(imported) = graph.imported_callable_declarations_for_file(path) {
+        checker = checker.with_imported_callable_decls(imported);
+    }
+    checker.check_with_source(&program, &source)
+}
+
+fn lex_diagnostic(message: String) -> TypeDiagnostic {
+    TypeDiagnostic {
+        code: harn_parser::DiagnosticCode::ParserUnexpectedToken,
+        message,
+        severity: DiagnosticSeverity::Error,
+        span: None,
+        help: None,
+        related: Vec::new(),
+        fix: None,
+        details: None,
+        repair: None,
+    }
+}
+
+fn serialize_diag(d: &TypeDiagnostic) -> SerializedDiagnostic {
+    SerializedDiagnostic {
+        severity: match d.severity {
+            DiagnosticSeverity::Error => "error",
+            DiagnosticSeverity::Warning => "warning",
+        },
+        code: d.code.as_str().to_string(),
+        message: d.message.clone(),
+        line: d.span.map(|s| s.line),
+        column: d.span.map(|s| s.column),
+    }
+}
+
+/// JSON or human-friendly emitter. Owns stdout buffering: NDJSON lines
+/// are flushed after every event so a downstream agent reading the
+/// pipe sees each event as it happens, not at process exit.
+struct Emitter {
+    json: bool,
+}
+
+impl Emitter {
+    fn new(json: bool) -> Self {
+        Self { json }
+    }
+
+    fn emit(&mut self, event: DevEvent) {
+        if self.json {
+            let envelope = event.into_envelope();
+            let line = serde_json::to_string(&envelope).expect("DevEvent serializes");
+            let stdout = std::io::stdout();
+            let mut lock = stdout.lock();
+            let _ = lock.write_all(line.as_bytes());
+            let _ = lock.write_all(b"\n");
+            let _ = lock.flush();
+        } else {
+            self.print_human(&event);
+        }
+    }
+
+    fn print_human(&self, event: &DevEvent) {
+        match event {
+            DevEvent::Ready { root, modules, .. } => {
+                eprintln!("\x1b[2m[dev] ready: {modules} module(s) under {root}\x1b[0m");
+            }
+            DevEvent::FingerprintChanged { module, old, new } => {
+                let label = match (old.is_empty(), new.is_empty()) {
+                    (true, false) => "added",
+                    (false, true) => "removed",
+                    _ => "interface changed",
+                };
+                eprintln!("\x1b[33m[dev] {label}: {module}\x1b[0m");
+            }
+            DevEvent::Rerun { modules } => {
+                eprintln!("\x1b[2m[dev] rerunning {} module(s)\x1b[0m", modules.len());
+            }
+            DevEvent::Diagnostics {
+                module,
+                count,
+                diagnostics,
+            } => {
+                if *count == 0 {
+                    eprintln!("\x1b[32m[dev] {module}: ok\x1b[0m");
+                } else {
+                    eprintln!("\x1b[31m[dev] {module}: {count} diagnostic(s)\x1b[0m");
+                    for diag in diagnostics {
+                        let loc = match (diag.line, diag.column) {
+                            (Some(l), Some(c)) => format!(":{l}:{c}"),
+                            _ => String::new(),
+                        };
+                        eprintln!(
+                            "  {} {}{loc} {}: {}",
+                            diag.severity, module, diag.code, diag.message
+                        );
+                    }
+                }
+            }
+            DevEvent::Tests {
+                module,
+                passed,
+                failed,
+                failures,
+            } => {
+                if *failed == 0 {
+                    eprintln!("\x1b[32m[dev] {module}: tests passed ({passed})\x1b[0m");
+                } else {
+                    eprintln!(
+                        "\x1b[31m[dev] {module}: tests {passed} passed, {failed} failed\x1b[0m"
+                    );
+                    for f in failures {
+                        eprintln!("    - {}: {}", f.name, f.error);
+                    }
+                }
+            }
+            DevEvent::TestError { module, error } => {
+                eprintln!("\x1b[31m[dev] {module}: test runner error: {error}\x1b[0m");
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "event", rename_all = "snake_case")]
+enum DevEvent {
+    Ready {
+        root: String,
+        modules: usize,
+        fingerprints: BTreeMap<String, String>,
+    },
+    FingerprintChanged {
+        module: String,
+        old: String,
+        new: String,
+    },
+    Rerun {
+        modules: Vec<String>,
+    },
+    Diagnostics {
+        module: String,
+        count: usize,
+        diagnostics: Vec<SerializedDiagnostic>,
+    },
+    Tests {
+        module: String,
+        passed: usize,
+        failed: usize,
+        failures: Vec<TestFailure>,
+    },
+    TestError {
+        module: String,
+        error: String,
+    },
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct SerializedDiagnostic {
+    severity: &'static str,
+    code: String,
+    message: String,
+    line: Option<usize>,
+    column: Option<usize>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct TestFailure {
+    name: String,
+    error: String,
+}
+
+impl JsonOutput for DevEvent {
+    const SCHEMA_VERSION: u32 = DEV_SCHEMA_VERSION;
+    type Data = DevEvent;
+    fn into_envelope(self) -> JsonEnvelope<Self::Data> {
+        JsonEnvelope::ok(DEV_SCHEMA_VERSION, self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn write(dir: &Path, name: &str, contents: &str) -> PathBuf {
+        let path = dir.join(name);
+        fs::write(&path, contents).unwrap();
+        path
+    }
+
+    #[test]
+    fn refresh_detects_any_source_edit() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path().canonicalize().unwrap();
+        let lib = write(
+            &root,
+            "lib.harn",
+            "pub fn add(a: int, b: int) -> int { a + b }\n",
+        );
+        let mut state = DevState::initial_scan(&root);
+        assert_eq!(state.fingerprints.len(), 1);
+
+        // A body-only edit changes the source hash even though the
+        // interface fingerprint stays put.
+        write(
+            &root,
+            "lib.harn",
+            "pub fn add(a: int, b: int) -> int { let s = a + b; s }\n",
+        );
+        let changed = state.refresh_filesystem(&root);
+        assert_eq!(changed, vec![canonical(&lib)]);
+    }
+
+    #[test]
+    fn signature_change_invalidates_importers() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path().canonicalize().unwrap();
+        let lib = write(
+            &root,
+            "lib.harn",
+            "pub fn add(a: int, b: int) -> int { a + b }\n",
+        );
+        write(
+            &root,
+            "user.harn",
+            "import { add } from \"./lib\"\npub fn main() { add(1, 2) }\n",
+        );
+
+        let mut state = DevState::initial_scan(&root);
+        write(
+            &root,
+            "lib.harn",
+            "pub fn add(a: int, b: int, c: int) -> int { a + b + c }\n",
+        );
+
+        let _ = state.refresh_filesystem(&root);
+        let (event, dependents) = state.apply_change(&lib);
+        assert!(matches!(event, Some(DevEvent::FingerprintChanged { .. })));
+        let names: Vec<String> = dependents
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        assert!(names.contains(&"lib.harn".to_string()));
+        assert!(names.contains(&"user.harn".to_string()));
+    }
+
+    #[test]
+    fn body_only_edit_skips_dependents() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path().canonicalize().unwrap();
+        let lib = write(
+            &root,
+            "lib.harn",
+            "pub fn add(a: int, b: int) -> int { a + b }\n",
+        );
+        write(
+            &root,
+            "user.harn",
+            "import { add } from \"./lib\"\npub fn main() { add(1, 2) }\n",
+        );
+
+        let mut state = DevState::initial_scan(&root);
+        write(
+            &root,
+            "lib.harn",
+            "pub fn add(a: int, b: int) -> int { let s = a + b; s }\n",
+        );
+        let _ = state.refresh_filesystem(&root);
+        let (event, dependents) = state.apply_change(&lib);
+        assert!(
+            event.is_none(),
+            "body edit must not emit fingerprint_changed"
+        );
+        let names: Vec<String> = dependents
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(names, vec!["lib.harn".to_string()]);
+    }
+
+    #[test]
+    fn transitive_invalidation_walks_chain() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path().canonicalize().unwrap();
+        let leaf = write(&root, "leaf.harn", "pub fn leaf() -> int { 1 }\n");
+        write(
+            &root,
+            "mid.harn",
+            "import { leaf } from \"./leaf\"\npub fn mid() -> int { leaf() }\n",
+        );
+        write(
+            &root,
+            "top.harn",
+            "import { mid } from \"./mid\"\npub fn top() -> int { mid() }\n",
+        );
+
+        let mut state = DevState::initial_scan(&root);
+        write(&root, "leaf.harn", "pub fn leaf() -> string { \"x\" }\n");
+        let _ = state.refresh_filesystem(&root);
+        let (_, dependents) = state.apply_change(&leaf);
+        let names: Vec<String> = dependents
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        assert!(names.contains(&"mid.harn".to_string()));
+        assert!(names.contains(&"top.harn".to_string()));
+    }
+
+    #[test]
+    fn scan_skips_generated_dirs() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path().canonicalize().unwrap();
+        write(&root, "real.harn", "pub fn r() {}\n");
+        std::fs::create_dir_all(root.join("target/build")).unwrap();
+        write(
+            &root.join("target/build"),
+            "ignored.harn",
+            "pub fn i() {}\n",
+        );
+        let files = scan_harn_files(&root);
+        let names: Vec<String> = files
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        assert!(names.contains(&"real.harn".to_string()));
+        assert!(!names.contains(&"ignored.harn".to_string()));
+    }
+
+    #[test]
+    fn diagnostics_serialize_to_envelope_shape() {
+        let event = DevEvent::Diagnostics {
+            module: "x.harn".into(),
+            count: 0,
+            diagnostics: Vec::new(),
+        };
+        let envelope = event.into_envelope();
+        let value = serde_json::to_value(&envelope).unwrap();
+        assert_eq!(value["schemaVersion"], DEV_SCHEMA_VERSION);
+        assert_eq!(value["ok"], true);
+        assert_eq!(value["data"]["event"], "diagnostics");
+        assert_eq!(value["data"]["module"], "x.harn");
+    }
+}

--- a/crates/harn-cli/src/commands/mod.rs
+++ b/crates/harn-cli/src/commands/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod connector;
 pub(crate) mod contracts;
 pub(crate) mod crystallize;
 pub mod demo;
+pub(crate) mod dev;
 pub(crate) mod doctor;
 pub(crate) mod dump_highlight_keywords;
 pub(crate) mod dump_protocol_artifacts;

--- a/crates/harn-cli/src/json_envelope.rs
+++ b/crates/harn-cli/src/json_envelope.rs
@@ -188,6 +188,12 @@ pub fn catalog() -> Vec<SchemaEntry> {
             description: "Signed-ready .harnpack run-bundle build summary.",
             schema_json: None,
         },
+        SchemaEntry {
+            command: "dev",
+            schema_version: 1,
+            description: "`harn dev --watch` incremental NDJSON event stream (ready / fingerprint_changed / rerun / diagnostics / tests).",
+            schema_json: None,
+        },
     ]
 }
 

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -726,6 +726,9 @@ async fn async_main() {
                 commands::run::build_denied_builtins(args.deny.as_deref(), args.allow.as_deref());
             commands::run::run_watch(&args.file, denied).await;
         }
+        Command::Dev(args) => {
+            commands::dev::run(args).await;
+        }
         Command::Portal(args) => {
             commands::portal::run_portal(
                 &args.dir,

--- a/crates/harn-cli/tests/dev_cli.rs
+++ b/crates/harn-cli/tests/dev_cli.rs
@@ -1,0 +1,46 @@
+//! CLI smoke tests for `harn dev --watch`.
+//!
+//! Spawns the binary so we exercise the real clap parser. The
+//! incremental loop itself is covered by unit tests in
+//! `commands::dev::tests` so this file avoids long-running subprocesses
+//! and the wall-clock sleep + polling patterns banned by
+//! `make lint-test-patterns`.
+
+use std::process::Command;
+
+fn binary_path() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_BIN_EXE_harn"))
+}
+
+#[test]
+fn dev_help_advertises_watch_and_json_flags() {
+    let output = Command::new(binary_path())
+        .args(["dev", "--help"])
+        .output()
+        .expect("spawn harn dev --help");
+    assert!(output.status.success(), "exit={:?}", output.status.code());
+    let help = String::from_utf8_lossy(&output.stdout);
+    for token in ["--watch", "--json", "--with-tests", "ROOT"] {
+        assert!(
+            help.contains(token),
+            "expected `{token}` in `harn dev --help`, got:\n{help}"
+        );
+    }
+}
+
+#[test]
+fn dev_without_watch_errors_out() {
+    let output = Command::new(binary_path())
+        .args(["dev"])
+        .output()
+        .expect("spawn harn dev");
+    assert!(
+        !output.status.success(),
+        "harn dev without --watch should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--watch"),
+        "stderr should mention --watch: {stderr}"
+    );
+}

--- a/crates/harn-modules/Cargo.toml
+++ b/crates/harn-modules/Cargo.toml
@@ -12,6 +12,7 @@ include = [
 ]
 
 [dependencies]
+blake3 = "1"
 croner = "3.0.1"
 harn-lexer = { path = "../harn-lexer", version = "0.8" }
 harn-parser = { path = "../harn-parser", version = "0.8" }

--- a/crates/harn-modules/src/fingerprint.rs
+++ b/crates/harn-modules/src/fingerprint.rs
@@ -1,0 +1,444 @@
+//! Interface fingerprints — a stable hash of a module's public surface.
+//!
+//! The fingerprint covers exactly the parts of a module that downstream
+//! importers can observe:
+//!
+//! * public functions, pipelines, tools, skills (name + signature)
+//! * public structs, enums, type aliases, interfaces (full shape)
+//! * `pub import` re-exports (target path + selective names)
+//!
+//! It intentionally excludes anything internal — function bodies,
+//! comments, private helpers, local variable bindings — so an edit that
+//! changes only the implementation of a public function leaves the
+//! fingerprint stable and dependents stay valid.
+//!
+//! The hash is BLAKE3 over a canonical textual rendering of the surface
+//! (alphabetized, single source of truth so trivial reorderings don't
+//! flip the fingerprint either).
+
+use std::fmt::Write as _;
+use std::path::Path;
+
+use harn_parser::{
+    peel_attributes, EnumVariant, InterfaceMethod, Node, Parser, SNode, ShapeField, StructField,
+    TypeExpr, TypeParam, TypedParam, Variance, WhereClause,
+};
+
+use crate::read_module_source;
+
+/// A 32-byte BLAKE3 digest of a module's public surface.
+pub type Fingerprint = [u8; 32];
+
+/// Compute the interface fingerprint for `program` (the parsed top-level
+/// statements of a module). Returns the BLAKE3 digest of a canonical
+/// textual rendering — see the module docs for what's included.
+pub fn fingerprint_program(program: &[SNode]) -> Fingerprint {
+    let canonical = canonicalize_program(program);
+    blake3::hash(canonical.as_bytes()).into()
+}
+
+/// Convenience: parse `path` (real file or `<std>` virtual path) and
+/// fingerprint its public surface. Returns `None` when the source can't
+/// be read or doesn't lex/parse — callers can treat that as "no
+/// fingerprint" rather than erroring.
+pub fn fingerprint_file(path: &Path) -> Option<Fingerprint> {
+    let source = read_module_source(path)?;
+    fingerprint_source(&source)
+}
+
+/// Fingerprint an already-loaded source string. Lex + parse failures
+/// return `None`.
+pub fn fingerprint_source(source: &str) -> Option<Fingerprint> {
+    let mut lexer = harn_lexer::Lexer::new(source);
+    let tokens = lexer.tokenize().ok()?;
+    let program = Parser::new(tokens).parse().ok()?;
+    Some(fingerprint_program(&program))
+}
+
+/// Hex-encode a fingerprint for human-readable output (NDJSON events,
+/// logs, etc.).
+pub fn fingerprint_hex(fp: &Fingerprint) -> String {
+    let mut out = String::with_capacity(fp.len() * 2);
+    for b in fp {
+        write!(&mut out, "{b:02x}").expect("write to String is infallible");
+    }
+    out
+}
+
+fn canonicalize_program(program: &[SNode]) -> String {
+    let mut lines: Vec<String> = program.iter().filter_map(canonicalize_top_level).collect();
+    lines.sort();
+    lines.join("\n")
+}
+
+fn canonicalize_top_level(snode: &SNode) -> Option<String> {
+    let (_attrs, inner) = peel_attributes(snode);
+    match &inner.node {
+        Node::FnDecl {
+            name,
+            type_params,
+            params,
+            return_type,
+            where_clauses,
+            is_pub,
+            is_stream,
+            ..
+        } => is_pub.then(|| {
+            format!(
+                "fn{stream}:{name}{generics}({params}){ret}{wheres}",
+                stream = if *is_stream { "*" } else { "" },
+                generics = format_type_params(type_params),
+                params = format_typed_params(params),
+                ret = format_return(return_type),
+                wheres = format_where_clauses(where_clauses),
+            )
+        }),
+        Node::Pipeline {
+            name,
+            params,
+            return_type,
+            is_pub,
+            extends,
+            ..
+        } => is_pub.then(|| {
+            format!(
+                "pipeline:{name}({params}){ret}{extends}",
+                params = params.join(","),
+                ret = format_return(return_type),
+                extends = extends
+                    .as_deref()
+                    .map(|e| format!(" extends {e}"))
+                    .unwrap_or_default(),
+            )
+        }),
+        Node::ToolDecl {
+            name,
+            params,
+            return_type,
+            is_pub,
+            ..
+        } => is_pub.then(|| {
+            format!(
+                "tool:{name}({params}){ret}",
+                params = format_typed_params(params),
+                ret = format_return(return_type),
+            )
+        }),
+        Node::SkillDecl { name, is_pub, .. } => {
+            // Skill bodies are configuration that downstream importers
+            // observe by reading the resulting registry dict, but a
+            // skill is identified by its name from a typing perspective.
+            // The conservative thing is to hash the name only and let
+            // body edits propagate via runtime registration rather than
+            // type-time invalidation.
+            is_pub.then(|| format!("skill:{name}"))
+        }
+        Node::StructDecl {
+            name,
+            type_params,
+            fields,
+            is_pub,
+        } => is_pub.then(|| {
+            format!(
+                "struct:{name}{generics}{{{fields}}}",
+                generics = format_type_params(type_params),
+                fields = format_struct_fields(fields),
+            )
+        }),
+        Node::EnumDecl {
+            name,
+            type_params,
+            variants,
+            is_pub,
+        } => is_pub.then(|| {
+            format!(
+                "enum:{name}{generics}{{{variants}}}",
+                generics = format_type_params(type_params),
+                variants = format_enum_variants(variants),
+            )
+        }),
+        Node::InterfaceDecl {
+            name,
+            type_params,
+            associated_types,
+            methods,
+        } => Some(format!(
+            "interface:{name}{generics}{{assoc=[{assoc}]methods=[{methods}]}}",
+            generics = format_type_params(type_params),
+            assoc = format_associated_types(associated_types),
+            methods = format_interface_methods(methods),
+        )),
+        Node::TypeDecl {
+            name,
+            type_params,
+            type_expr,
+        } => Some(format!(
+            "type:{name}{generics}={ty}",
+            generics = format_type_params(type_params),
+            ty = format_type_expr(type_expr),
+        )),
+        Node::ImportDecl { path, is_pub } => is_pub.then(|| format!("pub_import_wildcard:{path}")),
+        Node::SelectiveImport {
+            names,
+            path,
+            is_pub,
+        } => is_pub.then(|| {
+            let mut sorted = names.clone();
+            sorted.sort();
+            format!("pub_import_selective:{path}::{}", sorted.join(","))
+        }),
+        _ => None,
+    }
+}
+
+fn format_type_params(params: &[TypeParam]) -> String {
+    if params.is_empty() {
+        return String::new();
+    }
+    let parts: Vec<String> = params
+        .iter()
+        .map(|p| {
+            let var = match p.variance {
+                Variance::Invariant => "",
+                Variance::Covariant => "out ",
+                Variance::Contravariant => "in ",
+            };
+            format!("{var}{}", p.name)
+        })
+        .collect();
+    format!("<{}>", parts.join(","))
+}
+
+fn format_typed_params(params: &[TypedParam]) -> String {
+    params
+        .iter()
+        .map(|p| {
+            let mut s = String::new();
+            if p.rest {
+                s.push_str("...");
+            }
+            s.push_str(&p.name);
+            if let Some(ty) = &p.type_expr {
+                s.push(':');
+                s.push_str(&format_type_expr(ty));
+            }
+            // Default values reference expressions whose shape we don't
+            // walk into; presence-only is enough — adding a default to
+            // a public parameter changes the callable contract.
+            if p.default_value.is_some() {
+                s.push_str("=?");
+            }
+            s
+        })
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn format_return(ret: &Option<TypeExpr>) -> String {
+    match ret {
+        Some(ty) => format!("->{}", format_type_expr(ty)),
+        None => String::new(),
+    }
+}
+
+fn format_where_clauses(clauses: &[WhereClause]) -> String {
+    if clauses.is_empty() {
+        return String::new();
+    }
+    let mut parts: Vec<String> = clauses
+        .iter()
+        .map(|w| format!("{}:{}", w.type_name, w.bound))
+        .collect();
+    parts.sort();
+    format!(" where {}", parts.join(","))
+}
+
+fn format_struct_fields(fields: &[StructField]) -> String {
+    let mut rendered: Vec<String> = fields
+        .iter()
+        .map(|f| {
+            let opt = if f.optional { "?" } else { "" };
+            let ty = f
+                .type_expr
+                .as_ref()
+                .map(format_type_expr)
+                .unwrap_or_default();
+            format!("{}{opt}:{ty}", f.name)
+        })
+        .collect();
+    rendered.sort();
+    rendered.join(",")
+}
+
+fn format_enum_variants(variants: &[EnumVariant]) -> String {
+    let mut rendered: Vec<String> = variants
+        .iter()
+        .map(|v| format!("{}({})", v.name, format_typed_params(&v.fields)))
+        .collect();
+    rendered.sort();
+    rendered.join(",")
+}
+
+fn format_associated_types(items: &[(String, Option<TypeExpr>)]) -> String {
+    let mut rendered: Vec<String> = items
+        .iter()
+        .map(|(name, bound)| match bound {
+            Some(ty) => format!("{name}:{}", format_type_expr(ty)),
+            None => name.clone(),
+        })
+        .collect();
+    rendered.sort();
+    rendered.join(",")
+}
+
+fn format_interface_methods(methods: &[InterfaceMethod]) -> String {
+    let mut rendered: Vec<String> = methods
+        .iter()
+        .map(|m| {
+            format!(
+                "{}{}({}){}",
+                m.name,
+                format_type_params(&m.type_params),
+                format_typed_params(&m.params),
+                format_return(&m.return_type),
+            )
+        })
+        .collect();
+    rendered.sort();
+    rendered.join(",")
+}
+
+fn format_type_expr(ty: &TypeExpr) -> String {
+    match ty {
+        TypeExpr::Named(name) => name.clone(),
+        TypeExpr::Union(parts) => {
+            let mut rendered: Vec<String> = parts.iter().map(format_type_expr).collect();
+            rendered.sort();
+            format!("({})", rendered.join("|"))
+        }
+        TypeExpr::Intersection(parts) => {
+            let mut rendered: Vec<String> = parts.iter().map(format_type_expr).collect();
+            rendered.sort();
+            format!("({})", rendered.join("&"))
+        }
+        TypeExpr::Shape(fields) => format!("{{{}}}", format_shape_fields(fields)),
+        TypeExpr::List(inner) => format!("list<{}>", format_type_expr(inner)),
+        TypeExpr::DictType(k, v) => {
+            format!("dict<{},{}>", format_type_expr(k), format_type_expr(v))
+        }
+        TypeExpr::Iter(inner) => format!("iter<{}>", format_type_expr(inner)),
+        TypeExpr::Generator(inner) => format!("Generator<{}>", format_type_expr(inner)),
+        TypeExpr::Stream(inner) => format!("Stream<{}>", format_type_expr(inner)),
+        TypeExpr::Applied { name, args } => {
+            let rendered: Vec<String> = args.iter().map(format_type_expr).collect();
+            format!("{name}<{}>", rendered.join(","))
+        }
+        TypeExpr::FnType {
+            params,
+            return_type,
+        } => {
+            let rendered: Vec<String> = params.iter().map(format_type_expr).collect();
+            format!(
+                "fn({})->{}",
+                rendered.join(","),
+                format_type_expr(return_type)
+            )
+        }
+        TypeExpr::Never => "Never".to_string(),
+        TypeExpr::LitString(s) => format!("\"{s}\""),
+        TypeExpr::LitInt(n) => n.to_string(),
+    }
+}
+
+fn format_shape_fields(fields: &[ShapeField]) -> String {
+    let mut rendered: Vec<String> = fields
+        .iter()
+        .map(|f| {
+            let opt = if f.optional { "?" } else { "" };
+            format!("{}{opt}:{}", f.name, format_type_expr(&f.type_expr))
+        })
+        .collect();
+    rendered.sort();
+    rendered.join(",")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fp(source: &str) -> Fingerprint {
+        fingerprint_source(source).expect("source parses")
+    }
+
+    #[test]
+    fn private_body_change_does_not_flip_fingerprint() {
+        let before = fp("pub fn add(a: int, b: int) -> int { a + b }\n");
+        let after = fp("pub fn add(a: int, b: int) -> int { let s = a + b; s }\n");
+        assert_eq!(before, after);
+    }
+
+    #[test]
+    fn private_helper_does_not_flip_fingerprint() {
+        let before = fp("pub fn entry() { internal() }\nfn internal() { 1 }\n");
+        let after = fp("pub fn entry() { internal() }\nfn internal() { 2 }\nfn extra() { 3 }\n");
+        assert_eq!(before, after);
+    }
+
+    #[test]
+    fn reordering_public_decls_does_not_flip_fingerprint() {
+        let a = fp("pub fn alpha() {}\npub fn beta() {}\n");
+        let b = fp("pub fn beta() {}\npub fn alpha() {}\n");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn changing_public_signature_flips_fingerprint() {
+        let before = fp("pub fn add(a: int, b: int) -> int { a + b }\n");
+        let after = fp("pub fn add(a: int, b: int, c: int) -> int { a + b + c }\n");
+        assert_ne!(before, after);
+    }
+
+    #[test]
+    fn changing_public_return_type_flips_fingerprint() {
+        let before = fp("pub fn make() -> string { \"x\" }\n");
+        let after = fp("pub fn make() -> int { 1 }\n");
+        assert_ne!(before, after);
+    }
+
+    #[test]
+    fn adding_pub_struct_field_flips_fingerprint() {
+        let before = fp("pub struct Point { x: int, y: int }\n");
+        let after = fp("pub struct Point { x: int, y: int, z: int }\n");
+        assert_ne!(before, after);
+    }
+
+    #[test]
+    fn pub_re_export_change_flips_fingerprint() {
+        let before = fp("pub import { foo } from \"./a\"\n");
+        let after = fp("pub import { foo, bar } from \"./a\"\n");
+        assert_ne!(before, after);
+    }
+
+    #[test]
+    fn adding_pub_decl_flips_fingerprint() {
+        let before = fp("pub fn alpha() {}\n");
+        let after = fp("pub fn alpha() {}\npub fn beta() {}\n");
+        assert_ne!(before, after);
+    }
+
+    #[test]
+    fn changing_only_non_pub_imports_does_not_flip_fingerprint() {
+        let before = fp("import \"./a\"\npub fn entry() {}\n");
+        let after = fp("import \"./b\"\npub fn entry() {}\n");
+        // Private imports affect what _this_ module sees but not what
+        // downstreams see, so they're outside the public surface.
+        assert_eq!(before, after);
+    }
+
+    #[test]
+    fn hex_is_64_chars() {
+        let h = fingerprint_hex(&fp("pub fn x() {}\n"));
+        assert_eq!(h.len(), 64);
+        assert!(h.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+}

--- a/crates/harn-modules/src/lib.rs
+++ b/crates/harn-modules/src/lib.rs
@@ -6,6 +6,7 @@ use harn_parser::{BindingPattern, Node, Parser, SNode};
 use serde::Deserialize;
 
 pub mod asset_paths;
+pub mod fingerprint;
 pub mod personas;
 mod stdlib;
 
@@ -385,6 +386,27 @@ impl ModuleGraph {
             }
         }
         names
+    }
+
+    /// Files that directly import `target`. Resolves `target` to a
+    /// canonical path before lookup so callers can pass either spelling.
+    pub fn importers_of(&self, target: &Path) -> Vec<PathBuf> {
+        let target = normalize_path(target);
+        let mut out: Vec<PathBuf> = self
+            .modules
+            .iter()
+            .filter(|(_, info)| {
+                info.imports.iter().any(|import| {
+                    import
+                        .path
+                        .as_ref()
+                        .is_some_and(|p| normalize_path(p) == target)
+                })
+            })
+            .map(|(path, _)| path.clone())
+            .collect();
+        out.sort();
+        out
     }
 
     /// Resolve wildcard imports for `file`.
@@ -1046,6 +1068,26 @@ mod tests {
         let path = dir.join(name);
         fs::write(&path, contents).unwrap();
         path
+    }
+
+    #[test]
+    fn importers_of_finds_direct_dependents() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let leaf = write_file(root, "leaf.harn", "pub fn leaf() { 1 }\n");
+        write_file(root, "a.harn", "import \"./leaf\"\nleaf()\n");
+        write_file(root, "b.harn", "import { leaf } from \"./leaf\"\nleaf()\n");
+        let entry = write_file(root, "entry.harn", "import \"./a\"\nimport \"./b\"\n");
+
+        let graph = build(std::slice::from_ref(&entry));
+        let importers = graph.importers_of(&leaf);
+        let names: Vec<String> = importers
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        assert!(names.contains(&"a.harn".to_string()));
+        assert!(names.contains(&"b.harn".to_string()));
+        assert!(!names.contains(&"entry.harn".to_string()));
     }
 
     #[test]

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -1123,6 +1123,53 @@ harn watch main.harn
 harn watch --deny shell main.harn
 ```
 
+## harn dev
+
+Watch a whole Harn project and re-type-check only the modules invalidated by
+the latest edit. Invalidation is gated by per-module **interface fingerprints**
+— a stable BLAKE3 hash of every module's public surface (types, function
+signatures, `pub import` re-exports). An edit that only changes a function
+body leaves the fingerprint alone, so dependents are not re-checked. An edit
+to a public signature, struct shape, or re-export bumps the fingerprint and
+every transitive importer is invalidated and re-checked.
+
+```bash
+harn dev --watch                 # watch the current directory
+harn dev --watch ./src           # watch a specific tree
+harn dev --watch --json          # NDJSON event stream for agents/editors
+harn dev --watch --with-tests    # also re-run `test_*` pipelines per module
+```
+
+| Flag | Description |
+|---|---|
+| `--watch` | Required. Starts the incremental file-watch loop. |
+| `--json` | Emit a newline-delimited JSON event stream on stdout. Every line is a `JsonEnvelope`-wrapped event (`ready`, `fingerprint_changed`, `rerun`, `diagnostics`, `tests`). See `harn --json-schemas --command dev`. |
+| `--with-tests` | After each re-check, run every `test_*` or `@test`-attributed pipeline in the invalidated modules. |
+| `--test-timeout-ms <ms>` | Per-module test timeout when `--with-tests` is set. Defaults to `10000`. |
+| `<root>` | Optional project root. Defaults to the current working directory. |
+
+`harn dev --watch --json` event shapes (one per line):
+
+```jsonc
+// First event — the initial fingerprint snapshot.
+{"event":"ready","root":"/abs/path","modules":3,"fingerprints":{"src/lib.harn":"<hex>", ...}}
+// Public-surface diff for a single module.
+{"event":"fingerprint_changed","module":"src/lib.harn","old":"<hex>","new":"<hex>"}
+// The set of modules about to be re-checked. Driven by either a body-only
+// edit (just the changed file) or a fingerprint flip (the changed file plus
+// every transitive importer).
+{"event":"rerun","modules":["src/lib.harn","src/user.harn"]}
+// One per module re-checked.
+{"event":"diagnostics","module":"src/user.harn","count":1,"diagnostics":[{"severity":"warning","code":"HARN-ORC-001","message":"Function 'add' expects 3 arguments, got 2","line":2,"column":17}]}
+// Only emitted with `--with-tests`.
+{"event":"tests","module":"src/user.harn","passed":3,"failed":0,"failures":[]}
+```
+
+The bytecode cache (`harn precompile`) keys on transitive source content, so a
+fingerprint-stable edit still busts the entry-chunk cache for the changed
+file. `harn dev`'s contribution is the dependent-pruning half: dependents whose
+imports' fingerprints didn't move are never re-precompiled.
+
 ## harn portal
 
 Launch the local Harn observability portal for persisted runs.


### PR DESCRIPTION
Closes #1786.

## Summary

- New `harn dev --watch [<root>]` subcommand that watches every `.harn` file under `<root>` (default: cwd) and re-type-checks only the modules invalidated by the latest edit.
- Invalidation is gated by per-module **interface fingerprints** — a BLAKE3 hash of every module's public surface (types, function/pipeline/tool signatures, struct + enum shapes, `pub import` re-exports). Bodies, private helpers, and comments are excluded.
- An edit that flips a fingerprint transitively invalidates importers via the new `ModuleGraph::importers_of`. An edit that leaves the fingerprint stable re-checks only the changed file.
- `--json` emits an NDJSON event stream (`ready` / `fingerprint_changed` / `rerun` / `diagnostics` / `tests`) wrapped in the canonical `JsonEnvelope` and registered under `dev` in `harn --json-schemas`.
- `--with-tests` extends the loop to also re-run `test_*` / `@test`-attributed pipelines in each invalidated module.
- New reusable `harn_modules::fingerprint` module exposes `fingerprint_program` / `fingerprint_file` / `fingerprint_source` so editors and the bytecode cache can compute the same digest.

## Exit criteria from the issue

- [x] Editing a function body re-runs that module only. (`commands::dev::tests::body_only_edit_skips_dependents`)
- [x] Editing a public signature invalidates dependents. (`commands::dev::tests::signature_change_invalidates_importers`)
- [x] `harn dev --watch --json` stream parseable as NDJSON. (`commands::dev::tests::diagnostics_serialize_to_envelope_shape`, plus the catalog entry verified by `harn --json-schemas --command dev`)

## Test plan

- [x] `cargo nextest run -p harn-cli -p harn-modules` (634 tests green)
- [x] `cargo clippy -p harn-cli -p harn-modules --all-targets` (no warnings)
- [x] `cargo fmt --all --check`
- [x] `make lint`, `make lint-md`, `make lint-test-patterns`, `make check-docs-snippets`
- [x] `harn dev --help` lists `--watch`, `--json`, `--with-tests`, `ROOT` (covered by `tests/dev_cli.rs`)
- [x] Manual end-to-end smoke against a tiny two-file project: body-only edit emits `rerun` for the changed file alone; a 3-param signature flip emits `fingerprint_changed` for `lib.harn` plus `rerun` + `diagnostics` for both `lib.harn` and `user.harn`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)