### PR TITLE
Add harn routes trigger inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,12 @@ condensed series summaries instead of full per-patch history.
   module. New `harn_modules::fingerprint` module exposes
   `fingerprint_program` / `fingerprint_file` / `fingerprint_source` for
   reuse by editors and the bytecode cache.
+- **`harn routes <root> [--json]` static trigger inventory (#1788).** New
+  top-level command audits declarative trigger projects without executing
+  handlers, reporting route paths, handler modules, declared budgets, inferred
+  host capabilities, vendor-lock disclosure, and template framework-overhead
+  tokens. The JSON mode uses the standard `{ schemaVersion, ok, data, error,
+  warnings }` envelope and is registered in `harn --json-schemas`.
 - **`harn explain HARN-<CAT>-<NNN>` text + `--json` envelope (#1748).** The
   `explain` subcommand now dispatches on registered stable diagnostic codes
   in addition to its original control-flow invariant form. `harn explain

--- a/crates/harn-cli/src/cli/mod.rs
+++ b/crates/harn-cli/src/cli/mod.rs
@@ -42,6 +42,7 @@ mod profile;
 mod provider;
 mod providers;
 mod quickstart;
+mod routes;
 mod run;
 mod runs;
 mod serve;
@@ -152,6 +153,7 @@ pub(crate) use providers::{
     ProvidersValidateArgs,
 };
 pub(crate) use quickstart::QuickstartArgs;
+pub(crate) use routes::RoutesArgs;
 pub(crate) use run::RunArgs;
 pub(crate) use runs::{ReplayArgs, RunsArgs, RunsCommand};
 pub(crate) use serve::{
@@ -337,6 +339,8 @@ SCRIPTING
     Portal(PortalArgs),
     /// Replay and inspect historical trigger dispatches from the event log.
     Trigger(TriggerArgs),
+    /// Statically enumerate declared trigger routes and their requirements.
+    Routes(RoutesArgs),
     /// Inspect Harn Flow atom, slice, and predicate audit state.
     Flow(FlowArgs),
     /// Validate, preview, and run portable workflow bundles.

--- a/crates/harn-cli/src/cli/routes.rs
+++ b/crates/harn-cli/src/cli/routes.rs
@@ -1,0 +1,13 @@
+use std::path::PathBuf;
+
+use clap::Parser;
+
+#[derive(Debug, Parser)]
+pub(crate) struct RoutesArgs {
+    /// Project root, harn.toml path, or file inside the project.
+    pub root: PathBuf,
+
+    /// Emit a stable JSON envelope instead of the text table.
+    #[arg(long)]
+    pub json: bool,
+}

--- a/crates/harn-cli/src/cli/tests.rs
+++ b/crates/harn-cli/src/cli/tests.rs
@@ -83,6 +83,17 @@ fn test_parses_config_validate_and_schema() {
 }
 
 #[test]
+fn test_parses_routes_json() {
+    let cli = Cli::parse_from(["harn", "routes", "fixtures/project", "--json"]);
+
+    let Command::Routes(args) = cli.command.unwrap() else {
+        panic!("expected routes command");
+    };
+    assert_eq!(args.root, PathBuf::from("fixtures/project"));
+    assert!(args.json);
+}
+
+#[test]
 fn test_parses_agents_conformance_target_url() {
     let cli = Cli::parse_from([
         "harn",

--- a/crates/harn-cli/src/commands/dump_trigger_quickref.rs
+++ b/crates/harn-cli/src/commands/dump_trigger_quickref.rs
@@ -139,7 +139,8 @@ fn generate_file() -> String {
     out.push_str("[[triggers]]\n");
     out.push_str("id = \"github-prs\"\nkind = \"webhook\"\nprovider = \"github\"\nmatch = { path = \"/hooks/github\", events = [\"pull_request.opened\"] }\nhandler = \"handlers::on_pull_request\"\nwhen = \"handlers::should_handle\"\ndedupe_key = \"event.dedupe_key\"\nretry = { max = 7, backoff = \"svix\" }\nbudget = { daily_cost_usd = 5.00, max_concurrent = 4 }\nsecrets = { signing_secret = \"github/webhook-secret\" }\n\n");
     out.push_str("[[triggers]]\nid = \"weekday-digest\"\nkind = \"cron\"\nprovider = \"cron\"\nschedule = \"0 9 * * 1-5\"\ntimezone = \"America/Los_Angeles\"\nhandler = \"handlers::send_digest\"\n```\n\n");
-    out.push_str("Key fields: `id`, `kind`, `provider`, `handler`, `match.events`, `match.path`, `when`, `dedupe_key`, `retry`, `budget`, `secrets`, `schedule`, `timezone`, and provider-specific config tables such as `poll`.\n\n");
+    out.push_str("Key fields: `id`, `kind`, `provider`, `handler`, `path` or `match.path`, `match.events`, `when`, `dedupe_key`, `retry`, `budget`, `secrets`, `schedule`, `timezone`, and provider-specific config tables such as `poll`.\n\n");
+    out.push_str("Audit a project before deploy with `harn routes <root> --json`; it reports each declarative trigger's route path, handler module, budgets, inferred host capabilities, vendor-lock disclosure, and prompt/template overhead without executing handler code.\n\n");
 
     out.push_str("## Provider catalog\n\n");
     out.push_str("This table is generated from `std/triggers::list_providers()` / `ProviderCatalog` metadata.\n\n");

--- a/crates/harn-cli/src/commands/mod.rs
+++ b/crates/harn-cli/src/commands/mod.rs
@@ -39,6 +39,7 @@ pub(crate) mod provider;
 pub(crate) mod providers;
 pub(crate) mod quickstart;
 pub(crate) mod repl;
+pub(crate) mod routes;
 pub mod run;
 pub(crate) mod serve;
 pub(crate) mod session;

--- a/crates/harn-cli/src/commands/orchestrator/listener/routes.rs
+++ b/crates/harn-cli/src/commands/orchestrator/listener/routes.rs
@@ -129,7 +129,7 @@ impl RouteConfig {
                 }))
             }
             TriggerKind::Stream => {
-                if !trigger.config.kind_specific.contains_key("path") {
+                if !has_trigger_path(trigger) {
                     return Ok(None);
                 }
                 Ok(Some(Self {
@@ -970,12 +970,36 @@ fn trigger_path(trigger: &CollectedManifestTrigger) -> Result<String, Orchestrat
         .kind_specific
         .get("path")
         .and_then(JsonValueExt::as_toml_str)
+        .or_else(|| {
+            trigger
+                .config
+                .match_
+                .extra
+                .get("path")
+                .and_then(JsonValueExt::as_toml_str)
+        })
         .map(str::to_string)
         .unwrap_or_else(|| format!("/triggers/{}", trigger.config.id));
     if !path.starts_with('/') {
         return Err(format!("trigger '{}' path must start with '/'", trigger.config.id).into());
     }
     Ok(path)
+}
+
+fn has_trigger_path(trigger: &CollectedManifestTrigger) -> bool {
+    trigger
+        .config
+        .kind_specific
+        .get("path")
+        .and_then(JsonValueExt::as_toml_str)
+        .is_some()
+        || trigger
+            .config
+            .match_
+            .extra
+            .get("path")
+            .and_then(JsonValueExt::as_toml_str)
+            .is_some()
 }
 
 fn parse_secret_id(raw: Option<&str>) -> Option<SecretId> {

--- a/crates/harn-cli/src/commands/routes.rs
+++ b/crates/harn-cli/src/commands/routes.rs
@@ -1,0 +1,747 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use harn_ir::{CallClassification, Capability, LiteralValue, NodeSemantics};
+use harn_parser::{Node, SNode};
+use serde::Serialize;
+
+use crate::cli::RoutesArgs;
+use crate::json_envelope::{to_string_pretty, JsonEnvelope};
+use crate::package::{
+    self, parse_duration_millis, parse_local_trigger_ref, parse_trigger_handler_uri,
+    trigger_kind_label, ResolvedTriggerConfig, RuntimeExtensions, TriggerFunctionRef,
+    TriggerHandlerUri, TriggerKind,
+};
+
+const ROUTES_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct RoutesReport {
+    pub triggers: Vec<RouteTrigger>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct RouteTrigger {
+    pub id: String,
+    pub kind: String,
+    pub provider: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    pub module: String,
+    pub handler: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub events: Vec<String>,
+    pub requires_capabilities: Vec<String>,
+    pub budgets: RouteBudgets,
+    pub vendor_locked: bool,
+    pub framework_overhead_tokens: u64,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub(crate) struct RouteBudgets {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_latency_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_cost_usd: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_tokens: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub daily_cost_usd: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hourly_cost_usd: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_concurrent: Option<u32>,
+}
+
+#[derive(Debug)]
+struct ParsedModule {
+    path: PathBuf,
+    report: harn_ir::AnalysisReport,
+    vendor_locked: bool,
+}
+
+#[derive(Debug, Default)]
+struct ModuleCache {
+    modules: BTreeMap<PathBuf, ParsedModule>,
+}
+
+#[derive(Debug, Default)]
+struct LocalRouteAnalysis {
+    module: Option<String>,
+    capabilities: BTreeSet<String>,
+    vendor_locked: bool,
+    framework_overhead_tokens: u64,
+}
+
+pub(crate) async fn run(args: RoutesArgs) -> i32 {
+    match analyze_routes(&args.root).await {
+        Ok(report) => {
+            if args.json {
+                let envelope = JsonEnvelope::ok(ROUTES_SCHEMA_VERSION, report);
+                println!("{}", to_string_pretty(&envelope));
+            } else {
+                print_text_report(&report);
+            }
+            0
+        }
+        Err(error) => {
+            if args.json {
+                let envelope: JsonEnvelope<RoutesReport> =
+                    JsonEnvelope::err(ROUTES_SCHEMA_VERSION, "routes_error", error);
+                println!("{}", to_string_pretty(&envelope));
+            } else {
+                eprintln!("error: {error}");
+            }
+            1
+        }
+    }
+}
+
+async fn analyze_routes(root: &Path) -> Result<RoutesReport, String> {
+    let extensions =
+        package::try_load_runtime_extensions(root).map_err(|error| error.to_string())?;
+    let Some(manifest_dir) = extensions.root_manifest_dir.as_deref() else {
+        return Err(format!("no harn.toml found from {}", root.display()));
+    };
+    let manifest_dir = manifest_dir
+        .canonicalize()
+        .unwrap_or_else(|_| manifest_dir.to_path_buf());
+
+    validate_route_inputs(&extensions).await?;
+
+    let mut cache = ModuleCache::default();
+    let mut triggers = Vec::new();
+    for trigger in &extensions.triggers {
+        triggers.push(describe_trigger(trigger, &manifest_dir, &mut cache)?);
+    }
+    triggers.sort_by(|left, right| left.id.cmp(&right.id));
+    Ok(RoutesReport { triggers })
+}
+
+async fn validate_route_inputs(extensions: &RuntimeExtensions) -> Result<(), String> {
+    let _guard = package::lock_manifest_provider_schemas().await;
+    let provider_catalog = package::build_manifest_provider_catalog(extensions)
+        .await
+        .map_err(|error| error.to_string())?;
+    package::validate_orchestrator_budget(extensions.root_manifest.as_ref())
+        .map_err(|error| error.to_string())?;
+    package::validate_static_trigger_configs(&extensions.triggers, &provider_catalog)
+        .map_err(|error| error.to_string())
+}
+
+fn describe_trigger(
+    trigger: &ResolvedTriggerConfig,
+    manifest_dir: &Path,
+    cache: &mut ModuleCache,
+) -> Result<RouteTrigger, String> {
+    let handler_uri = parse_trigger_handler_uri(trigger).map_err(|error| error.to_string())?;
+    let mut capabilities = BTreeSet::new();
+    let mut module = None;
+    let mut vendor_locked = false;
+    let mut framework_overhead_tokens = 0u64;
+    let handler = match &handler_uri {
+        TriggerHandlerUri::Local(reference) => {
+            let local = analyze_local_function(trigger, reference, manifest_dir, cache)?;
+            module = local.module;
+            capabilities.extend(local.capabilities);
+            vendor_locked |= local.vendor_locked;
+            framework_overhead_tokens =
+                framework_overhead_tokens.saturating_add(local.framework_overhead_tokens);
+            reference.function_name.clone()
+        }
+        TriggerHandlerUri::A2a { target, .. } => {
+            capabilities.insert("worker.dispatch".to_string());
+            format!("a2a://{target}")
+        }
+        TriggerHandlerUri::Worker { queue } => {
+            capabilities.insert("worker.dispatch".to_string());
+            format!("worker://{queue}")
+        }
+        TriggerHandlerUri::Persona { name } => {
+            capabilities.insert("persona.dispatch".to_string());
+            format!("persona://{name}")
+        }
+    };
+
+    if let Some(when_raw) = trigger.when.as_deref() {
+        let reference = parse_local_trigger_ref(when_raw, "when", trigger)
+            .map_err(|error| error.to_string())?;
+        let local = analyze_local_function(trigger, &reference, manifest_dir, cache)?;
+        if module.is_none() {
+            module = local.module;
+        }
+        capabilities.extend(local.capabilities);
+        vendor_locked |= local.vendor_locked;
+        framework_overhead_tokens =
+            framework_overhead_tokens.saturating_add(local.framework_overhead_tokens);
+    }
+
+    Ok(RouteTrigger {
+        id: trigger.id.clone(),
+        kind: trigger_kind_label(trigger.kind).to_string(),
+        provider: trigger.provider.as_str().to_string(),
+        path: trigger_path(trigger)?,
+        module: module.unwrap_or_else(|| "-".to_string()),
+        handler,
+        events: trigger.match_.events.clone(),
+        requires_capabilities: capabilities.into_iter().collect(),
+        budgets: route_budgets(trigger),
+        vendor_locked,
+        framework_overhead_tokens,
+    })
+}
+
+fn analyze_local_function(
+    trigger: &ResolvedTriggerConfig,
+    reference: &TriggerFunctionRef,
+    manifest_dir: &Path,
+    cache: &mut ModuleCache,
+) -> Result<LocalRouteAnalysis, String> {
+    let module_path = package::manifest_module_source_path(
+        &trigger.manifest_dir,
+        trigger.package_name.as_deref(),
+        &trigger.exports,
+        reference.module_name.as_deref(),
+    )
+    .map_err(|error| error.to_string())?;
+    let module = cache.load(&module_path)?;
+    let Some(handler) = module.report.handler(&reference.function_name) else {
+        return Err(format!(
+            "{}: handler '{}' was not found in {}",
+            package::manifest_trigger_location(trigger),
+            reference.function_name,
+            module.path.display()
+        ));
+    };
+
+    let mut capabilities = capabilities_for_handler(handler);
+    let framework_overhead_tokens =
+        template_overhead_tokens_for_handler(handler, &module.path, manifest_dir);
+    if framework_overhead_tokens > 0 || handler_uses_template_rendering(handler) {
+        capabilities.insert("template.render".to_string());
+    }
+
+    Ok(LocalRouteAnalysis {
+        module: Some(display_module_path(&module.path, manifest_dir)),
+        capabilities,
+        vendor_locked: module.vendor_locked,
+        framework_overhead_tokens,
+    })
+}
+
+impl ModuleCache {
+    fn load(&mut self, path: &Path) -> Result<&ParsedModule, String> {
+        let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+        if !self.modules.contains_key(&canonical) {
+            let source = fs::read_to_string(&canonical)
+                .map_err(|error| format!("failed to read {}: {error}", canonical.display()))?;
+            let program = harn_parser::parse_source(&source)
+                .map_err(|error| format!("failed to parse {}: {error}", canonical.display()))?;
+            let vendor_locked = module_vendor_locked(&program);
+            let report = harn_ir::analyze_program(&program);
+            self.modules.insert(
+                canonical.clone(),
+                ParsedModule {
+                    path: canonical.clone(),
+                    report,
+                    vendor_locked,
+                },
+            );
+        }
+        Ok(self
+            .modules
+            .get(&canonical)
+            .expect("parsed module inserted before lookup"))
+    }
+}
+
+fn capabilities_for_handler(handler: &harn_ir::HandlerIr) -> BTreeSet<String> {
+    let mut capabilities = BTreeSet::new();
+    for node in &handler.nodes {
+        let NodeSemantics::Call(call) = &node.semantics else {
+            continue;
+        };
+        let direct = direct_call_capabilities(call);
+        let use_ir_classification = call.name != "host_call" || direct.is_empty();
+        capabilities.extend(direct);
+        if use_ir_classification {
+            if let CallClassification::Capabilities(effects) = &call.classification {
+                for effect in effects {
+                    capabilities.insert(capability_label(effect.capability).to_string());
+                }
+            }
+        }
+    }
+    capabilities
+}
+
+fn direct_call_capabilities(call: &harn_ir::CallSemantics) -> BTreeSet<String> {
+    let mut capabilities = BTreeSet::new();
+    match call.name.as_str() {
+        "read_file" | "read_file_bytes" | "read_file_result" | "read_lines" | "read_stdin" => {
+            capabilities.insert("workspace.read_text".to_string());
+        }
+        "list_dir" | "walk_dir" | "glob" => {
+            capabilities.insert("workspace.list".to_string());
+        }
+        "file_exists" | "stat" => {
+            capabilities.insert("workspace.exists".to_string());
+        }
+        "write_file" | "write_file_bytes" | "append_file" | "mkdir" | "copy_file" | "move_file" => {
+            capabilities.insert("workspace.write_text".to_string());
+        }
+        "delete_file" => {
+            capabilities.insert("workspace.delete".to_string());
+        }
+        "apply_edit" => {
+            capabilities.insert("workspace.apply_edit".to_string());
+        }
+        "http_get"
+        | "http_post"
+        | "http_put"
+        | "http_patch"
+        | "http_delete"
+        | "http_request"
+        | "http_download"
+        | "http_session"
+        | "http_session_request"
+        | "http_stream_open"
+        | "sse_connect"
+        | "websocket_connect"
+        | "websocket_server" => {
+            capabilities.insert("network.http".to_string());
+        }
+        "exec" | "exec_at" | "shell" | "shell_at" => {
+            capabilities.insert("process.exec".to_string());
+        }
+        "llm_call"
+        | "llm_call_safe"
+        | "llm_stream_call"
+        | "llm_call_structured"
+        | "llm_call_structured_safe"
+        | "llm_call_structured_result"
+        | "llm_completion"
+        | "agent_llm_turn"
+        | "agent_turn"
+        | "agent_loop" => {
+            capabilities.insert("llm.call".to_string());
+        }
+        "spawn_agent" | "send_input" | "resume_agent" | "wait_agent" | "close_agent"
+        | "worker_trigger" => {
+            capabilities.insert("worker.dispatch".to_string());
+        }
+        "request_approval" => {
+            capabilities.insert("human.approval".to_string());
+        }
+        "connector_call" | "mcp_call" | "host_tool_call" => {
+            capabilities.insert("connector.call".to_string());
+        }
+        "secret_get" => {
+            capabilities.insert("connector.secret_get".to_string());
+        }
+        "event_log_emit" => {
+            capabilities.insert("connector.event_log_emit".to_string());
+        }
+        "metrics_inc" => {
+            capabilities.insert("connector.metrics_inc".to_string());
+        }
+        "host_call" => insert_host_call_capability(call, &mut capabilities),
+        _ if call.name.starts_with("mcp_") => {
+            capabilities.insert("connector.call".to_string());
+        }
+        _ => {}
+    }
+    capabilities
+}
+
+fn insert_host_call_capability(call: &harn_ir::CallSemantics, capabilities: &mut BTreeSet<String>) {
+    let Some(operation) = call.literal_args.first().and_then(literal_as_str) else {
+        capabilities.insert("connector.call".to_string());
+        return;
+    };
+    if operation == "template.render" {
+        capabilities.insert("template.render".to_string());
+    } else if operation.starts_with("process.") {
+        capabilities.insert("process.exec".to_string());
+    } else if operation.starts_with("workspace.") || operation.starts_with("connector.") {
+        capabilities.insert(operation.to_string());
+    } else {
+        capabilities.insert("connector.call".to_string());
+    }
+}
+
+fn capability_label(capability: Capability) -> &'static str {
+    match capability {
+        Capability::WorkspaceMutation => "workspace.write_text",
+        Capability::CommandExecution => "process.exec",
+        Capability::NetworkAccess => "network.http",
+        Capability::ConnectorAccess => "connector.call",
+        Capability::ModelCall => "llm.call",
+        Capability::WorkerDispatch => "worker.dispatch",
+        Capability::HumanApproval => "human.approval",
+        Capability::AutonomyPolicy => "autonomy.policy",
+    }
+}
+
+fn template_overhead_tokens_for_handler(
+    handler: &harn_ir::HandlerIr,
+    module_path: &Path,
+    manifest_dir: &Path,
+) -> u64 {
+    let mut total = 0u64;
+    for node in &handler.nodes {
+        let NodeSemantics::Call(call) = &node.semantics else {
+            continue;
+        };
+        match call.name.as_str() {
+            "render" | "render_prompt" => {
+                if let Some(path) = call.literal_args.first().and_then(literal_as_str) {
+                    total = total.saturating_add(template_file_overhead_tokens(
+                        path,
+                        module_path,
+                        manifest_dir,
+                    ));
+                }
+            }
+            "render_string" => {
+                if let Some(body) = call.literal_args.first().and_then(literal_as_str) {
+                    total = total.saturating_add(estimate_template_markup_tokens(body));
+                }
+            }
+            "host_call" => {
+                let Some("template.render") = call.literal_args.first().and_then(literal_as_str)
+                else {
+                    continue;
+                };
+                if let Some(body) = call
+                    .literal_args
+                    .get(1)
+                    .and_then(host_render_inline_template_arg)
+                {
+                    total = total.saturating_add(estimate_template_markup_tokens(body));
+                } else if let Some(path) = call.literal_args.get(1).and_then(host_render_path_arg) {
+                    total = total.saturating_add(template_file_overhead_tokens(
+                        path,
+                        module_path,
+                        manifest_dir,
+                    ));
+                }
+            }
+            _ => {}
+        }
+    }
+    total
+}
+
+fn handler_uses_template_rendering(handler: &harn_ir::HandlerIr) -> bool {
+    handler.nodes.iter().any(|node| {
+        let NodeSemantics::Call(call) = &node.semantics else {
+            return false;
+        };
+        matches!(
+            call.name.as_str(),
+            "render" | "render_prompt" | "render_string"
+        ) || (call.name == "host_call"
+            && matches!(
+                call.literal_args.first().and_then(literal_as_str),
+                Some("template.render")
+            ))
+    })
+}
+
+fn host_render_path_arg(value: &LiteralValue) -> Option<&str> {
+    let LiteralValue::Dict(entries) = value else {
+        return None;
+    };
+    entries
+        .get("path")
+        .or_else(|| entries.get("template_path"))
+        .and_then(literal_as_str)
+}
+
+fn host_render_inline_template_arg(value: &LiteralValue) -> Option<&str> {
+    let LiteralValue::Dict(entries) = value else {
+        return None;
+    };
+    entries
+        .get("template")
+        .or_else(|| entries.get("source"))
+        .or_else(|| entries.get("body"))
+        .and_then(literal_as_str)
+}
+
+fn literal_as_str(value: &LiteralValue) -> Option<&str> {
+    match value {
+        LiteralValue::String(value) | LiteralValue::Identifier(value) => Some(value.as_str()),
+        _ => None,
+    }
+}
+
+fn module_vendor_locked(program: &[SNode]) -> bool {
+    program.iter().any(import_is_vendor_locked)
+}
+
+fn import_is_vendor_locked(node: &SNode) -> bool {
+    let (_, inner) = harn_parser::peel_attributes(node);
+    match &inner.node {
+        Node::ImportDecl { path, .. } => import_path_or_names_vendor_locked(path, &[]),
+        Node::SelectiveImport { names, path, .. } => {
+            import_path_or_names_vendor_locked(path, names)
+        }
+        _ => false,
+    }
+}
+
+fn import_path_or_names_vendor_locked(path: &str, names: &[String]) -> bool {
+    direct_vendor_token(path) || names.iter().any(|name| direct_vendor_token(name))
+}
+
+fn direct_vendor_token(value: &str) -> bool {
+    const VENDORS: &[&str] = &[
+        "anthropic",
+        "openai",
+        "gemini",
+        "bedrock",
+        "openrouter",
+        "together",
+        "huggingface",
+        "ollama",
+        "github",
+        "gitlab",
+        "slack",
+        "linear",
+        "notion",
+        "kafka",
+        "nats",
+        "pulsar",
+        "postgres",
+    ];
+    let normalized: String = value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() {
+                ch.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    normalized
+        .split('-')
+        .filter(|token| !token.is_empty())
+        .any(|token| VENDORS.contains(&token))
+}
+
+fn template_file_overhead_tokens(
+    template_ref: &str,
+    module_path: &Path,
+    manifest_dir: &Path,
+) -> u64 {
+    let Some(body) = resolve_template_body(template_ref, module_path, manifest_dir) else {
+        return 0;
+    };
+    estimate_template_markup_tokens(&body)
+}
+
+fn resolve_template_body(
+    template_ref: &str,
+    module_path: &Path,
+    manifest_dir: &Path,
+) -> Option<String> {
+    if harn_modules::asset_paths::stdlib_prompt_asset_path(template_ref).is_some() {
+        return harn_vm::stdlib_modules::get_stdlib_prompt_asset(template_ref).map(str::to_string);
+    }
+    let module_dir = module_path.parent().unwrap_or(manifest_dir);
+    if let Some(asset_ref) = harn_modules::asset_paths::parse(template_ref) {
+        return harn_modules::asset_paths::resolve(&asset_ref, module_dir)
+            .ok()
+            .and_then(|path| fs::read_to_string(path).ok());
+    }
+    let candidate = if Path::new(template_ref).is_absolute() {
+        PathBuf::from(template_ref)
+    } else {
+        module_dir.join(template_ref)
+    };
+    fs::read_to_string(candidate).ok()
+}
+
+fn estimate_template_markup_tokens(body: &str) -> u64 {
+    let mut markup_chars = 0usize;
+    let mut rest = body;
+    while let Some(start) = rest.find("{{") {
+        let after_start = &rest[start + 2..];
+        let Some(end) = after_start.find("}}") else {
+            break;
+        };
+        markup_chars = markup_chars.saturating_add(end + 4);
+        rest = &after_start[end + 2..];
+    }
+    if markup_chars == 0 {
+        0
+    } else {
+        ((markup_chars as u64).saturating_add(3)) / 4
+    }
+}
+
+fn trigger_path(trigger: &ResolvedTriggerConfig) -> Result<Option<String>, String> {
+    let configured = toml_table_string(&trigger.kind_specific, "path")
+        .or_else(|| toml_table_string(&trigger.match_.extra, "path"));
+    let path = match trigger.kind {
+        TriggerKind::Webhook | TriggerKind::A2aPush => {
+            Some(configured.unwrap_or_else(|| format!("/triggers/{}", trigger.id)))
+        }
+        TriggerKind::Stream => configured,
+        TriggerKind::Cron | TriggerKind::Poll | TriggerKind::Predicate => configured,
+    };
+    let path_requires_slash = matches!(
+        trigger.kind,
+        TriggerKind::Webhook | TriggerKind::A2aPush | TriggerKind::Stream
+    );
+    if path_requires_slash && path.as_deref().is_some_and(|path| !path.starts_with('/')) {
+        return Err(format!("trigger '{}' path must start with '/'", trigger.id));
+    }
+    Ok(path)
+}
+
+fn route_budgets(trigger: &ResolvedTriggerConfig) -> RouteBudgets {
+    RouteBudgets {
+        max_latency_ms: latency_budget_ms(trigger),
+        max_cost_usd: trigger.budget.max_cost_usd.or_else(|| {
+            trigger
+                .when_budget
+                .as_ref()
+                .and_then(|budget| budget.max_cost_usd)
+        }),
+        max_tokens: trigger.budget.max_tokens.or_else(|| {
+            trigger
+                .when_budget
+                .as_ref()
+                .and_then(|budget| budget.tokens_max)
+        }),
+        daily_cost_usd: trigger.budget.daily_cost_usd,
+        hourly_cost_usd: trigger.budget.hourly_cost_usd,
+        max_concurrent: trigger
+            .concurrency
+            .as_ref()
+            .map(|concurrency| concurrency.max)
+            .or(trigger.budget.max_concurrent),
+    }
+}
+
+fn latency_budget_ms(trigger: &ResolvedTriggerConfig) -> Option<u64> {
+    for field in [
+        "max_latency_ms",
+        "max-latency-ms",
+        "latency_ms",
+        "timeout_ms",
+        "timeout-ms",
+        "timeout",
+    ] {
+        if let Some(value) = trigger.kind_specific.get(field).and_then(toml_duration_ms) {
+            return Some(value);
+        }
+    }
+    trigger
+        .when_budget
+        .as_ref()
+        .and_then(|budget| budget.timeout.as_deref())
+        .and_then(|raw| parse_duration_millis(raw).ok())
+}
+
+fn toml_table_string(table: &BTreeMap<String, toml::Value>, key: &str) -> Option<String> {
+    table
+        .get(key)
+        .and_then(toml_string)
+        .filter(|value| !value.trim().is_empty())
+}
+
+fn toml_string(value: &toml::Value) -> Option<String> {
+    match value {
+        toml::Value::String(value) => Some(value.clone()),
+        toml::Value::Integer(value) => Some(value.to_string()),
+        _ => None,
+    }
+}
+
+fn toml_duration_ms(value: &toml::Value) -> Option<u64> {
+    match value {
+        toml::Value::Integer(value) if *value >= 0 => Some(*value as u64),
+        toml::Value::String(value) => parse_duration_millis(value).ok(),
+        _ => None,
+    }
+}
+
+fn display_module_path(path: &Path, manifest_dir: &Path) -> String {
+    path.strip_prefix(manifest_dir)
+        .unwrap_or(path)
+        .display()
+        .to_string()
+}
+
+fn print_text_report(report: &RoutesReport) {
+    println!(
+        "{:<28} {:<10} {:<12} {:<24} {:<22} {:<18} {:<7} {:>8}  capabilities",
+        "id", "kind", "provider", "path", "module", "handler", "vendor", "fw_tokens"
+    );
+    for trigger in &report.triggers {
+        let capabilities = if trigger.requires_capabilities.is_empty() {
+            "-".to_string()
+        } else {
+            trigger.requires_capabilities.join(",")
+        };
+        println!(
+            "{:<28} {:<10} {:<12} {:<24} {:<22} {:<18} {:<7} {:>8}  {}",
+            truncate(&trigger.id, 28),
+            trigger.kind.as_str(),
+            truncate(&trigger.provider, 12),
+            truncate(trigger.path.as_deref().unwrap_or("-"), 24),
+            truncate(&trigger.module, 22),
+            truncate(&trigger.handler, 18),
+            if trigger.vendor_locked { "yes" } else { "no" },
+            trigger.framework_overhead_tokens,
+            capabilities
+        );
+    }
+}
+
+fn truncate(value: &str, width: usize) -> String {
+    if value.chars().count() <= width {
+        return value.to_string();
+    }
+    if width <= 3 {
+        return ".".repeat(width);
+    }
+    value
+        .chars()
+        .take(width.saturating_sub(3))
+        .collect::<String>()
+        + "..."
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn estimates_template_markup_only() {
+        assert_eq!(estimate_template_markup_tokens("plain text"), 0);
+        assert_eq!(estimate_template_markup_tokens("hello {{ name }}"), 3);
+        assert!(estimate_template_markup_tokens("{{ if ok }}yes{{ endif }}") > 0);
+    }
+
+    #[test]
+    fn detects_vendor_specific_imports() {
+        let portable = harn_parser::parse_source(r#"import "std/triggers""#).unwrap();
+        assert!(!module_vendor_locked(&portable));
+
+        let vendor_path =
+            harn_parser::parse_source(r#"import { post_message } from "std/connectors/slack""#)
+                .unwrap();
+        assert!(module_vendor_locked(&vendor_path));
+
+        let vendor_name =
+            harn_parser::parse_source(r#"import { github_call } from "std/connectors""#).unwrap();
+        assert!(module_vendor_locked(&vendor_name));
+    }
+}

--- a/crates/harn-cli/src/json_envelope.rs
+++ b/crates/harn-cli/src/json_envelope.rs
@@ -194,6 +194,12 @@ pub fn catalog() -> Vec<SchemaEntry> {
             description: "`harn dev --watch` incremental NDJSON event stream (ready / fingerprint_changed / rerun / diagnostics / tests).",
             schema_json: None,
         },
+        SchemaEntry {
+            command: "routes",
+            schema_version: 1,
+            description: "Static trigger route, budget, capability, and vendor-lock inventory.",
+            schema_json: None,
+        },
     ]
 }
 

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -747,6 +747,12 @@ async fn async_main() {
                 process::exit(1);
             }
         }
+        Command::Routes(args) => {
+            let code = commands::routes::run(args).await;
+            if code != 0 {
+                process::exit(code);
+            }
+        }
         Command::Flow(args) => match commands::flow::run_flow(&args) {
             Ok(code) => {
                 if code != 0 {

--- a/crates/harn-cli/tests/routes_cli.rs
+++ b/crates/harn-cli/tests/routes_cli.rs
@@ -1,0 +1,171 @@
+//! End-to-end coverage for `harn routes --json`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use tempfile::TempDir;
+
+fn binary_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_harn"))
+}
+
+fn run_harn(args: &[&str]) -> std::process::Output {
+    Command::new(binary_path())
+        .args(args)
+        .output()
+        .expect("spawn harn")
+}
+
+fn stdout_json(output: &std::process::Output) -> serde_json::Value {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(stdout.trim()).unwrap_or_else(|error| {
+        panic!("stdout is not JSON: {error}\nstdout:\n{stdout}");
+    })
+}
+
+fn write_fixture(root: &Path) {
+    fs::create_dir_all(root.join("prompts")).unwrap();
+    fs::write(
+        root.join("harn.toml"),
+        r#"
+[package]
+name = "routes-fixture"
+
+[exports]
+handlers = "lib.harn"
+
+[[triggers]]
+id = "webhook-review"
+kind = "webhook"
+provider = "webhook"
+path = "/hooks/review"
+match = { events = ["review.created"] }
+handler = "handlers::on_review"
+when = "handlers::should_handle"
+when_budget = { max_cost_usd = 0.01, tokens_max = 20, timeout = "3s" }
+budget = { max_cost_usd = 0.20, max_tokens = 1000, daily_cost_usd = 5.0, max_concurrent = 2 }
+timeout = "4s"
+secrets = { signing_secret = "webhook/signing-secret" }
+
+[[triggers]]
+id = "match-path"
+kind = "webhook"
+provider = "webhook"
+match = { path = "/hooks/from-match", events = ["review.updated"] }
+handler = "handlers::portable"
+secrets = { signing_secret = "webhook/signing-secret" }
+
+[[triggers]]
+id = "daily"
+kind = "cron"
+provider = "cron"
+match = { events = ["cron.tick"] }
+schedule = "0 9 * * *"
+handler = "worker://daily"
+budget = { max_cost_usd = 0.02 }
+"#,
+    )
+    .unwrap();
+    fs::write(
+        root.join("lib.harn"),
+        r#"
+import "std/triggers"
+import { post_message } from "std/connectors/slack"
+
+pub fn on_review(event: TriggerEvent) -> dict {
+  let body = read_file("README.md")
+  let prompt = render_prompt("prompts/review.harn.prompt", {body: body})
+  http_post("https://example.test/hook", prompt)
+  return {ok: true}
+}
+
+pub fn should_handle(event: TriggerEvent) -> bool {
+  return true
+}
+
+pub fn portable(event: TriggerEvent) -> dict {
+  return {ok: true}
+}
+"#,
+    )
+    .unwrap();
+    fs::write(
+        root.join("prompts/review.harn.prompt"),
+        "Review {{ body }}\n{{ if body }}has body{{ endif }}\n",
+    )
+    .unwrap();
+}
+
+#[test]
+fn routes_json_reports_manifest_trigger_inventory() {
+    let temp = TempDir::new().unwrap();
+    write_fixture(temp.path());
+
+    let root = temp.path().to_str().unwrap();
+    let output = run_harn(&["routes", root, "--json"]);
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let parsed = stdout_json(&output);
+    assert_eq!(parsed["schemaVersion"], 1);
+    assert_eq!(parsed["ok"], true);
+
+    let triggers = parsed["data"]["triggers"].as_array().unwrap();
+    assert_eq!(triggers.len(), 3);
+
+    let webhook = triggers
+        .iter()
+        .find(|trigger| trigger["id"] == "webhook-review")
+        .unwrap();
+    assert_eq!(webhook["kind"], "webhook");
+    assert_eq!(webhook["provider"], "webhook");
+    assert_eq!(webhook["path"], "/hooks/review");
+    assert_eq!(webhook["module"], "lib.harn");
+    assert_eq!(webhook["handler"], "on_review");
+    assert_eq!(webhook["events"], serde_json::json!(["review.created"]));
+    assert_eq!(webhook["budgets"]["max_latency_ms"], 4000);
+    assert_eq!(webhook["budgets"]["max_cost_usd"], 0.20);
+    assert_eq!(webhook["budgets"]["max_tokens"], 1000);
+    assert_eq!(webhook["budgets"]["max_concurrent"], 2);
+    assert_eq!(webhook["vendor_locked"], true);
+    assert!(webhook["framework_overhead_tokens"].as_u64().unwrap() > 0);
+    assert_eq!(
+        webhook["requires_capabilities"],
+        serde_json::json!(["network.http", "template.render", "workspace.read_text"])
+    );
+
+    let match_path = triggers
+        .iter()
+        .find(|trigger| trigger["id"] == "match-path")
+        .unwrap();
+    assert_eq!(match_path["path"], "/hooks/from-match");
+
+    let cron = triggers
+        .iter()
+        .find(|trigger| trigger["id"] == "daily")
+        .unwrap();
+    assert!(cron.get("path").is_none());
+    assert_eq!(cron["handler"], "worker://daily");
+    assert_eq!(
+        cron["requires_capabilities"],
+        serde_json::json!(["worker.dispatch"])
+    );
+}
+
+#[test]
+fn routes_appears_in_json_schemas_catalog() {
+    let output = run_harn(&["--json-schemas", "--command", "routes"]);
+    assert!(output.status.success(), "exit={:?}", output.status.code());
+
+    let parsed = stdout_json(&output);
+    assert_eq!(parsed["schemaVersion"], 1);
+    assert_eq!(parsed["ok"], true);
+    let entries = parsed["data"].as_array().unwrap();
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0]["command"], "routes");
+    assert_eq!(entries[0]["schemaVersion"], 1);
+}

--- a/docs/llm/harn-triggers-quickref.md
+++ b/docs/llm/harn-triggers-quickref.md
@@ -39,7 +39,9 @@ timezone = "America/Los_Angeles"
 handler = "handlers::send_digest"
 ```
 
-Key fields: `id`, `kind`, `provider`, `handler`, `match.events`, `match.path`, `when`, `dedupe_key`, `retry`, `budget`, `secrets`, `schedule`, `timezone`, and provider-specific config tables such as `poll`.
+Key fields: `id`, `kind`, `provider`, `handler`, `path` or `match.path`, `match.events`, `when`, `dedupe_key`, `retry`, `budget`, `secrets`, `schedule`, `timezone`, and provider-specific config tables such as `poll`.
+
+Audit a project before deploy with `harn routes <root> --json`; it reports each declarative trigger's route path, handler module, budgets, inferred host capabilities, vendor-lock disclosure, and prompt/template overhead without executing handler code.
 
 ## Provider catalog
 

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -1420,6 +1420,27 @@ under `deploy/<provider>/`, optionally builds/pushes `--image` with
 `--build`, and syncs locally available secrets unless `--no-secret-sync` is
 set.
 
+## harn routes
+
+Static trigger-surface inventory for a project manifest.
+
+```bash
+# Human-readable table of declared trigger routes.
+harn routes .
+
+# Stable JSON envelope for automation and deployment audits.
+harn routes . --json
+```
+
+`harn routes <root>` loads the nearest `harn.toml`, validates the manifest
+trigger declarations, and reads local handler source without executing it. The
+report includes trigger kind/provider, HTTP route path when the binding exposes
+one, local module and handler, match events, declared budgets, statically
+required host capabilities, vendor-lock disclosure from provider-specific
+imports, and template framework overhead tokens for non-trivial
+`render(...)` / `render_prompt(...)` / `render_string(...)` use. Webhook and
+A2A-push triggers default to `/triggers/<id>` when no path is declared.
+
 ## harn trigger replay
 
 Replay a persisted `TriggerEvent` from a standalone EventLog snapshot

--- a/docs/src/triggers.md
+++ b/docs/src/triggers.md
@@ -17,6 +17,12 @@ multiple `[[triggers.sources]]` entries. `kind = "stream"` covers cataloged
 continuous sources such as Kafka, NATS JetStream, Pulsar, Postgres CDC, email,
 and WebSocket ingest, including tumbling, sliding, and session window metadata.
 
+Use `harn routes <root> --json` before deploying a trigger project to audit the
+static ingress surface. The command reports each declarative trigger's route
+path, handler module, declared budgets, statically required capabilities,
+vendor-lock disclosure, and prompt/template overhead without executing handler
+code.
+
 ## Streaming trigger admission
 
 Continuous sources should enter Harn through the connector-facing stream

--- a/docs/src/triggers/manifest.md
+++ b/docs/src/triggers/manifest.md
@@ -8,6 +8,8 @@ Each entry declares:
 - a stable trigger `id`
 - a trigger `kind` such as `webhook`, `cron`, or `a2a-push`
 - a `provider` from the registered trigger provider catalog
+- an optional HTTP `path`, either as top-level `path = "/..."` or
+  `match = { path = "/...", ... }`
 - an `autonomy_tier` (or `tier`) that defines the default execution mode
 - a delivery `handler`
 - optional dedupe, retry, budget, flow-control, secret, and predicate settings
@@ -36,6 +38,11 @@ concurrency = { max = 10 }
 secrets = { signing_secret = "github/webhook-secret" }
 filter = "event.kind"
 ```
+
+Run `harn routes <root> --json` to inspect the manifest's static trigger
+inventory. The JSON envelope reports route paths, local handler modules,
+declared budgets, inferred host capabilities, vendor-lock disclosure, and
+template overhead before the orchestrator starts.
 
 Supported autonomy tiers:
 


### PR DESCRIPTION
## Summary

- Add top-level `harn routes <root> [--json]` for static manifest trigger inventory.
- Report trigger path/module/handler/events, declared budgets, inferred host capabilities, vendor-lock disclosure, and prompt/template overhead tokens.
- Register the JSON schema catalog entry, document the command, regenerate the trigger quickref, and align orchestrator HTTP route path resolution with `match.path`.

Closes #1788

## Verification

- `CARGO_TARGET_DIR=/tmp/harn-target-issue-1788 cargo test -p harn-cli routes --lib -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-1788 cargo test -p harn-cli --test routes_cli -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-1788 cargo check -p harn-cli --tests`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-1788 cargo clippy -p harn-cli --tests -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-1788 cargo run --quiet --bin harn -- dump-trigger-quickref --check`
- `cargo fmt --all --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-1788 cargo run --quiet --bin harn -- routes examples/triggers/slack-keyword-router --json`
- pre-commit hook: formatting, workspace clippy, markdown lint
- pre-push hook: targeted local checks, markdown lint, changelog check
