### PR TITLE
Add `Harness` capability handle + `main(harness: Harness)` entrypoint (#1766)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,25 @@ condensed series summaries instead of full per-patch history.
   `serialize_module_artifact` so in-memory consumers can package
   bytecode bytes byte-identical to the on-disk `.harnbc`/`.harnmod`
   files.
+- **`Harness` capability handle + `main(harness: Harness)` entrypoint
+  (#1766).** First step of the E4 epic that replaces ambient stdio /
+  clock / fs / env / random / net globals with an explicit handle threaded
+  through `main`. Introduces the public `harn_vm::Harness` Rust type and
+  its six sub-handles (`HarnessStdio`, `HarnessClock`, `HarnessFs`,
+  `HarnessEnv`, `HarnessRandom`, `HarnessNet`), each carrying the same
+  refcounted `HarnessInner` and exposed at the Harn-language level via
+  field access (`harness.stdio`, `harness.clock`, etc.). `Harness::real()`
+  wires `harn-clock::RealClock` as the production backing; the
+  filesystem, environment, random, and network surfaces are stubbed and
+  land alongside the ambient-builtin migrations in E4.2-E4.4. The VM
+  auto-invokes `fn main` when present with the `harness` global set by
+  the run path (CLI, conformance, bench, playground), and the
+  typechecker enforces the new convention via `HARN-NAM-101`: any
+  `fn main` with a signature other than `main(harness: Harness)` is
+  rejected at parse time. `harness.stdio.println` / `print` / `eprintln` /
+  `eprint` and `harness.clock.now_ms` / `monotonic_ms` / `sleep_ms` are
+  wired end-to-end so `examples/hello_v2.harn` runs against the new
+  shape today.
 - **`with_scoped_executor` tool-caller middleware (#1702).** Narrows the
   active `CapabilityPolicy` for the duration of one tool dispatch:
   `compose_tool_callers([..., with_scoped_executor({stage, allowed_tools,

--- a/conformance/errors/semantic/main_missing_harness_param.error
+++ b/conformance/errors/semantic/main_missing_harness_param.error
@@ -1,0 +1,1 @@
+re:must take a single `harness: Harness` parameter

--- a/conformance/errors/semantic/main_missing_harness_param.harn
+++ b/conformance/errors/semantic/main_missing_harness_param.harn
@@ -1,0 +1,7 @@
+// HARN-NAM-101: `fn main` is the new entrypoint convention; its only
+// supported signature is `main(harness: Harness)`. A zero-arg main
+// fails the typechecker so the runtime never gets to threading a
+// `Harness` it can't bind.
+fn main() {
+  print("oops")
+}

--- a/conformance/errors/semantic/main_wrong_param_type.error
+++ b/conformance/errors/semantic/main_wrong_param_type.error
@@ -1,0 +1,1 @@
+re:parameter type must be `Harness`

--- a/conformance/errors/semantic/main_wrong_param_type.harn
+++ b/conformance/errors/semantic/main_wrong_param_type.harn
@@ -1,0 +1,6 @@
+// HARN-NAM-101: a `main` with the right arity but a non-Harness
+// param type is rejected. The runtime can only safely thread the
+// concrete capability handle.
+fn main(harness: string) {
+  print(harness)
+}

--- a/conformance/tests/language/main_harness_entrypoint.expected
+++ b/conformance/tests/language/main_harness_entrypoint.expected
@@ -1,0 +1,2 @@
+ok
+partial line

--- a/conformance/tests/language/main_harness_entrypoint.harn
+++ b/conformance/tests/language/main_harness_entrypoint.harn
@@ -1,0 +1,11 @@
+/**
+ * E4.1: the new `main(harness: Harness)` entrypoint convention is the
+ * hello-world for the explicit-capability handle. Sub-handles flow
+ * through field access (`harness.stdio`) and methods route to host
+ * implementations (`println` here is wired; the rest land in E4.2-E4.4).
+ */
+fn main(harness: Harness) {
+  harness.stdio.println("ok")
+  harness.stdio.print("partial ")
+  harness.stdio.println("line")
+}

--- a/crates/harn-cli/src/commands/bench.rs
+++ b/crates/harn-cli/src/commands/bench.rs
@@ -141,6 +141,7 @@ pub(crate) async fn run_bench(path: &str, iterations: usize, profile: RunProfile
         if !source_parent.as_os_str().is_empty() {
             vm.set_source_dir(source_parent);
         }
+        vm.set_harness(harn_vm::Harness::real());
 
         if let Some(manifest) = extensions.root_manifest.as_ref() {
             if !manifest.mcp.is_empty() {

--- a/crates/harn-cli/src/commands/playground.rs
+++ b/crates/harn-cli/src/commands/playground.rs
@@ -272,6 +272,7 @@ async fn configured_vm(
         }
     }
     vm.set_global("argv", harn_vm::VmValue::List(Rc::new(Vec::new())));
+    vm.set_harness(harn_vm::Harness::real());
 
     let loaded = load_skills(&SkillLoaderInputs {
         cli_dirs: Vec::new(),

--- a/crates/harn-cli/src/commands/run.rs
+++ b/crates/harn-cli/src/commands/run.rs
@@ -873,6 +873,11 @@ async fn execute_run_inner(inputs: ExecuteRunInputs<'_>) -> RunOutcome {
         harn_vm::VmValue::List(std::rc::Rc::new(argv_values)),
     );
 
+    // Install the script's `Harness` capability handle so the auto-call
+    // emitted by `Compiler::compile()` for `fn main(harness: Harness)`
+    // entrypoints can read it.
+    vm.set_harness(harn_vm::Harness::real());
+
     let extensions = package::load_runtime_extensions(Path::new(path));
     package::install_runtime_extensions(&extensions);
     if let Some(manifest) = extensions.root_manifest.as_ref() {

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -2539,6 +2539,7 @@ pub(crate) async fn execute_with_skill_dirs(
             });
             skill_loader::emit_loader_warnings(&loaded.loader_warnings);
             skill_loader::install_skills_global(&mut vm, &loaded);
+            vm.set_harness(harn_vm::Harness::real());
             if let Some(path) = source_path {
                 let extensions = package::load_runtime_extensions(path);
                 package::install_runtime_extensions(&extensions);

--- a/crates/harn-lint/src/linter.rs
+++ b/crates/harn-lint/src/linter.rs
@@ -1789,6 +1789,12 @@ impl<'a> Linter<'a> {
             if decl.is_pub || decl.is_method || decl.name.starts_with('_') {
                 continue;
             }
+            // `fn main` is the auto-invoked entrypoint (see E4.1): the
+            // compiler emits a synthetic call to it, so static call-graph
+            // analysis can't see any references. Treat it like `pub`.
+            if decl.name == "main" {
+                continue;
+            }
             if self.externally_imported_names.contains(&decl.name) {
                 continue;
             }

--- a/crates/harn-lint/src/tests/unused_function.rs
+++ b/crates/harn-lint/src/tests/unused_function.rs
@@ -57,6 +57,24 @@ return "ok"
 }
 
 #[test]
+fn test_main_function_exempt() {
+    let diags = lint_source(
+        r#"
+fn main(_harness: Harness) {
+}
+"#,
+    );
+    assert!(
+        !has_rule(&diags, "unused-function"),
+        "`main` is auto-invoked and should be exempt from unused-function: {diags:?}"
+    );
+    assert!(
+        !has_rule(&diags, "unused-parameter"),
+        "`_harness` should suppress the unused-parameter lint: {diags:?}"
+    );
+}
+
+#[test]
 fn test_function_passed_as_value() {
     let diags = lint_source(
         r#"

--- a/crates/harn-parser/src/diagnostic_codes.rs
+++ b/crates/harn-parser/src/diagnostic_codes.rs
@@ -192,6 +192,7 @@ diagnostic_codes! {
     UnknownDeclaration, "HARN-NAM-010", Nam, "declaration reference cannot be resolved";
     InvalidAttributeTarget, "HARN-NAM-011", Nam, "attribute is attached to an unsupported declaration";
     InvalidAttributeArgument, "HARN-NAM-012", Nam, "attribute argument is invalid";
+    InvalidMainSignature, "HARN-NAM-101", Nam, "`main` entrypoint must take a single `harness: Harness` parameter";
     CapabilityPayloadInvalid, "HARN-CAP-001", Cap, "capability payload is invalid";
     HitlMissingApprovalPolicy, "HARN-CAP-002", Cap, "human approval construct is missing policy";
     HitlInvalidApprovalArgument, "HARN-CAP-003", Cap, "human approval argument is invalid";
@@ -624,6 +625,7 @@ impl Code {
             | Code::UnknownMethod
             | Code::UnknownBuiltin
             | Code::UnknownDeclaration => Some(&REPAIR_BINDINGS_RENAME_TO_CLOSEST),
+            Code::InvalidMainSignature => Some(&REPAIR_BINDINGS_THREAD_HARNESS),
             Code::DeprecatedFunction => Some(&REPAIR_STDLIB_MIGRATE_RENAMED),
             Code::ModuleImportUnresolved | Code::ImportResolutionFailed => {
                 Some(&REPAIR_IMPORTS_FIX_PATH)
@@ -787,6 +789,12 @@ const REPAIR_BINDINGS_RENAME_SHADOW: RepairTemplate = RepairTemplate {
     id: "bindings/rename-shadow",
     summary: "Rename the shadowing binding to a distinct name",
     safety: RepairSafety::ScopeLocal,
+};
+
+const REPAIR_BINDINGS_THREAD_HARNESS: RepairTemplate = RepairTemplate {
+    id: "bindings/thread-harness",
+    summary: "Rewrite the entrypoint as `fn main(harness: Harness)` so the runtime can thread its capability handle",
+    safety: RepairSafety::SurfaceChanging,
 };
 
 const REPAIR_DECLARATIONS_REMOVE_UNUSED: RepairTemplate = RepairTemplate {
@@ -964,6 +972,7 @@ pub const REPAIR_REGISTRY: &[&RepairTemplate] = &[
     &REPAIR_BINDINGS_MAKE_IMMUTABLE,
     &REPAIR_BINDINGS_RENAME_UNUSED,
     &REPAIR_BINDINGS_RENAME_SHADOW,
+    &REPAIR_BINDINGS_THREAD_HARNESS,
     &REPAIR_DECLARATIONS_REMOVE_UNUSED,
     &REPAIR_IMPORTS_FIX_PATH,
     &REPAIR_IMPORTS_REMOVE_UNUSED,

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-NAM-101.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-NAM-101.md
@@ -1,0 +1,52 @@
+# HARN-NAM-101 — `main` entrypoint must take a single `harness: Harness` parameter
+
+**Category:** Name resolution (NAM)
+**Variant:** `Code::InvalidMainSignature` (invalid `main` signature)
+
+## What it means
+
+When a Harn program declares a top-level `fn main`, the runtime auto-invokes
+it with the script's `Harness` capability handle. The convention is therefore
+strict: the entrypoint must be exactly `fn main(harness: Harness) { ... }` —
+or `fn main(_harness: Harness) { ... }` when the handle is intentionally
+unused. It takes one parameter, named `harness` or `_harness`, typed
+`Harness`, no defaults, no rest.
+
+Any other shape (zero parameters, a renamed parameter, a missing or
+non-`Harness` type annotation, extra parameters, or a default value) fails
+this check before bytecode is emitted, so the runtime never tries to bind a
+mismatched signature.
+
+The `Harness` value gives the script typed access to its six capability
+slices via field access (`harness.stdio`, `harness.clock`, `harness.fs`,
+`harness.env`, `harness.random`, `harness.net`). Threading the handle through
+`main` replaces every ambient stdio/clock/fs/env/random/net global.
+
+## How to fix
+
+Rewrite the entrypoint with the canonical signature:
+
+```harn
+fn main(harness: Harness) {
+  harness.stdio.println("Hello, world!")
+}
+```
+
+If you do not need any capabilities — for example, a script that only does
+pure computation — prefix the parameter with `_` to mark it deliberately
+unused:
+
+```harn
+fn main(_harness: Harness) {
+  // pure logic …
+}
+```
+
+If the function does not need to be the entrypoint, rename it (e.g. `helper`,
+`run_once`) so the convention does not apply.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-parser/src/typechecker/inference/entry.rs
+++ b/crates/harn-parser/src/typechecker/inference/entry.rs
@@ -7,6 +7,7 @@
 //! check.
 
 use crate::ast::*;
+use crate::diagnostic_codes::Code;
 
 use super::super::scope::{
     EnumDeclInfo, FnSignature, ImplMethodSig, InterfaceDeclInfo, StructDeclInfo, TypeAliasInfo,
@@ -131,6 +132,9 @@ impl TypeChecker {
                         has_rest: params.last().is_some_and(|p| p.rest),
                     };
                     self.scope.define_fn(name, sig);
+                    if name == "main" {
+                        self.check_main_signature(params, snode.span);
+                    }
                     self.check_fn_body(
                         type_params,
                         params,
@@ -159,6 +163,59 @@ impl TypeChecker {
         }
 
         (self.diagnostics, self.hints)
+    }
+
+    /// Validate the entrypoint convention: a top-level `fn main` must take
+    /// a single typed parameter `harness: Harness` (no defaults, no rest,
+    /// no extras). Anything else fires `HARN-NAM-101`.
+    pub(in crate::typechecker) fn check_main_signature(
+        &mut self,
+        params: &[TypedParam],
+        span: harn_lexer::Span,
+    ) {
+        let signature_ok = matches!(
+            params,
+            [TypedParam {
+                name,
+                type_expr: Some(TypeExpr::Named(ty)),
+                default_value: None,
+                rest: false,
+            }] if matches!(name.as_str(), "harness" | "_harness") && ty == "Harness"
+        );
+        if signature_ok {
+            return;
+        }
+        let message = if params.is_empty() {
+            "`main` must take a single `harness: Harness` parameter".to_string()
+        } else if params.len() == 1 {
+            let p = &params[0];
+            match (&p.name, &p.type_expr) {
+                (name, _) if !matches!(name.as_str(), "harness" | "_harness") => {
+                    format!("`main` parameter is named `{name}`, expected `harness` or `_harness`")
+                }
+                (_, None) => {
+                    "`main(harness: Harness)` requires an explicit `Harness` type annotation"
+                        .to_string()
+                }
+                (_, Some(actual)) => format!(
+                    "`main(harness: …)` parameter type must be `Harness`, found `{}`",
+                    crate::typechecker::format_type(actual)
+                ),
+            }
+        } else {
+            format!(
+                "`main` must take exactly one parameter (`harness: Harness`), found {}",
+                params.len()
+            )
+        };
+        self.error_at_with_help(
+            Code::InvalidMainSignature,
+            message,
+            span,
+            "rewrite as `fn main(harness: Harness) { ... }` — the runtime threads its \
+             capability handle through this single parameter"
+                .to_string(),
+        );
     }
 
     /// Pre-populate placeholder signatures for every

--- a/crates/harn-parser/src/typechecker/inference/expressions.rs
+++ b/crates/harn-parser/src/typechecker/inference/expressions.rs
@@ -872,6 +872,16 @@ impl TypeChecker {
                 Self::string_property_type(property, optional)
             }
             TypeExpr::Named(name) if name == "dict" => None,
+            TypeExpr::Named(name) if name == "Harness" => match property {
+                "stdio" => Some(TypeExpr::Named("HarnessStdio".into())),
+                "clock" => Some(TypeExpr::Named("HarnessClock".into())),
+                "fs" => Some(TypeExpr::Named("HarnessFs".into())),
+                "env" => Some(TypeExpr::Named("HarnessEnv".into())),
+                "random" => Some(TypeExpr::Named("HarnessRandom".into())),
+                "net" => Some(TypeExpr::Named("HarnessNet".into())),
+                _ if optional => Some(TypeExpr::Named("nil".into())),
+                _ => None,
+            },
             TypeExpr::Named(name) if scope.get_struct(name).is_some() => {
                 self.struct_property_type(name, &[], property, scope, optional)
             }

--- a/crates/harn-parser/src/typechecker/tests/main_signature.rs
+++ b/crates/harn-parser/src/typechecker/tests/main_signature.rs
@@ -1,0 +1,100 @@
+//! HARN-NAM-101 — the `fn main(harness: Harness)` entrypoint check.
+//!
+//! Exercise both the happy path and the four classes of bad signature so
+//! regressions in `check_main_signature` surface as test failures rather
+//! than as conformance-suite drift.
+
+use super::*;
+use crate::diagnostic_codes::Code;
+
+fn nam_101(source: &str) -> Vec<String> {
+    check_source(source)
+        .into_iter()
+        .filter(|d| d.code == Code::InvalidMainSignature)
+        .map(|d| d.message)
+        .collect()
+}
+
+#[test]
+fn accepts_canonical_signature() {
+    let diags = nam_101(
+        r#"fn main(harness: Harness) {
+  harness.stdio.println("hi")
+}"#,
+    );
+    assert!(
+        diags.is_empty(),
+        "canonical `main(harness: Harness)` must not raise NAM-101: {diags:?}"
+    );
+}
+
+#[test]
+fn accepts_underscore_harness_opt_out() {
+    let diags = nam_101("fn main(_harness: Harness) {}");
+    assert!(
+        diags.is_empty(),
+        "`_harness` is the unused-capability opt-out and must not raise NAM-101: {diags:?}"
+    );
+}
+
+#[test]
+fn rejects_zero_arg_main() {
+    let diags = nam_101("fn main() {}");
+    assert_eq!(diags.len(), 1);
+    assert!(diags[0].contains("single `harness: Harness` parameter"));
+}
+
+#[test]
+fn rejects_wrong_param_name() {
+    let diags = nam_101("fn main(ctx: Harness) {}");
+    assert_eq!(diags.len(), 1);
+    assert!(
+        diags[0].contains("expected `harness` or `_harness`"),
+        "expected wrong-name diagnostic, got: {diags:?}"
+    );
+}
+
+#[test]
+fn rejects_wrong_param_type() {
+    let diags = nam_101("fn main(harness: string) {}");
+    assert_eq!(diags.len(), 1);
+    assert!(
+        diags[0].contains("type must be `Harness`"),
+        "expected wrong-type diagnostic, got: {diags:?}"
+    );
+}
+
+#[test]
+fn rejects_missing_type_annotation() {
+    let diags = nam_101("fn main(harness) {}");
+    assert_eq!(diags.len(), 1);
+    assert!(
+        diags[0].contains("explicit `Harness` type annotation"),
+        "expected missing-annotation diagnostic, got: {diags:?}"
+    );
+}
+
+#[test]
+fn rejects_extra_params() {
+    let diags = nam_101("fn main(harness: Harness, argv: list) {}");
+    assert_eq!(diags.len(), 1);
+    assert!(
+        diags[0].contains("exactly one parameter"),
+        "expected too-many-params diagnostic, got: {diags:?}"
+    );
+}
+
+#[test]
+fn rejects_main_with_default_value() {
+    // A default value flips the param into a non-canonical shape: the
+    // runtime always supplies `harness` so `harness: Harness = …` would
+    // never use its default. The check enforces the canonical shape.
+    let diags = nam_101("fn main(harness: Harness = nil) {}");
+    assert_eq!(diags.len(), 1, "default-value variant should be rejected");
+}
+
+#[test]
+fn non_main_fns_are_unrestricted() {
+    let diags = nam_101("fn helper(x: int) {}");
+    assert!(diags.is_empty(), "only `fn main` is constrained: {diags:?}");
+}

--- a/crates/harn-parser/src/typechecker/tests/mod.rs
+++ b/crates/harn-parser/src/typechecker/tests/mod.rs
@@ -13,6 +13,7 @@ use super::{DiagnosticSeverity, TypeChecker, TypeDiagnostic};
 mod exhaustiveness;
 mod imports;
 mod interfaces;
+mod main_signature;
 mod narrowing;
 mod reachability;
 mod repair;

--- a/crates/harn-vm/src/compiler/state.rs
+++ b/crates/harn-vm/src/compiler/state.rs
@@ -223,6 +223,16 @@ impl Compiler {
                     self.chunk.emit(Op::Pop, self.line);
                 }
             }
+            // E4.1 entrypoint convention: a top-level `fn main(harness: Harness)`
+            // is invoked automatically with the runtime-provided `harness`
+            // global. The typechecker rejects every other signature with
+            // HARN-NAM-101 so we don't need to re-validate the shape here.
+            if Self::has_top_level_fn_main(program) {
+                let harness_name = self.chunk.add_constant(Constant::String("harness".into()));
+                self.chunk.emit_u16(Op::GetVar, harness_name, self.line);
+                self.emit_named_call("main", 1);
+                pipeline_emits_value = true;
+            }
         }
 
         for fb in self.all_pending_finallys() {
@@ -233,6 +243,15 @@ impl Compiler {
         }
         self.chunk.emit(Op::Return, self.line);
         Ok(self.chunk)
+    }
+
+    /// True when the program declares a top-level `fn main(...)`. Drives the
+    /// auto-call wired by `compile()` for the new `main(harness: Harness)`
+    /// entrypoint convention.
+    fn has_top_level_fn_main(program: &[SNode]) -> bool {
+        program
+            .iter()
+            .any(|sn| matches!(peel_node(sn), Node::FnDecl { name, .. } if name == "main"))
     }
 
     /// Compile a specific named pipeline (for test runners).

--- a/crates/harn-vm/src/harness.rs
+++ b/crates/harn-vm/src/harness.rs
@@ -1,0 +1,361 @@
+//! Capability handle threaded into every Harn script as the `harness`
+//! parameter of `main`.
+//!
+//! `Harness` is the Harn-language analog of an explicit-capability handle: a
+//! single value the runtime hands to a script's `main` so that stdio, clock,
+//! filesystem, environment, randomness, and network access become surface in
+//! the type system instead of ambient globals. Each sub-handle (`stdio`,
+//! `clock`, `fs`, `env`, `random`, `net`) is a distinct named type that
+//! anchors the surface for its capability slice.
+//!
+//! This module defines:
+//!   * The runtime [`Harness`] value (and six sub-handle wrappers).
+//!   * [`Harness::real`], the production constructor that wraps wall-clock
+//!     time, `tokio::fs`, `std::env`, `rand::thread_rng`, and `reqwest`. The
+//!     downstream migration tickets (E4.2-E4.4) populate the per-handle
+//!     method surface against this concrete state; for E4.1 only the
+//!     `stdio.println` / `stdio.eprintln` path is wired so the new
+//!     entrypoint convention has a working hello-world steel thread.
+//!   * [`VmHarness`], the compact `VmValue` payload that carries the same
+//!     state through the bytecode VM and distinguishes the root handle from
+//!     its sub-handles via [`HarnessKind`].
+
+use std::fmt;
+use std::sync::Arc;
+
+use harn_clock::{Clock, RealClock};
+
+/// Six capability slices exposed by a [`Harness`].
+///
+/// `Root` is the parent handle; the others are the typed sub-handles users
+/// reach through field access (`harness.stdio`, `harness.clock`, ...).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum HarnessKind {
+    Root,
+    Stdio,
+    Clock,
+    Fs,
+    Env,
+    Random,
+    Net,
+}
+
+impl HarnessKind {
+    /// The Harn-language type name for this kind (`Harness`, `HarnessStdio`,
+    /// etc.). Used by the typechecker primitive registration and by
+    /// `VmValue::type_name`.
+    pub const fn type_name(self) -> &'static str {
+        match self {
+            HarnessKind::Root => "Harness",
+            HarnessKind::Stdio => "HarnessStdio",
+            HarnessKind::Clock => "HarnessClock",
+            HarnessKind::Fs => "HarnessFs",
+            HarnessKind::Env => "HarnessEnv",
+            HarnessKind::Random => "HarnessRandom",
+            HarnessKind::Net => "HarnessNet",
+        }
+    }
+
+    /// Field name a parent `Harness` exposes for this sub-handle (e.g. the
+    /// `stdio` in `harness.stdio`). Returns `None` for the root.
+    pub const fn field_name(self) -> Option<&'static str> {
+        match self {
+            HarnessKind::Root => None,
+            HarnessKind::Stdio => Some("stdio"),
+            HarnessKind::Clock => Some("clock"),
+            HarnessKind::Fs => Some("fs"),
+            HarnessKind::Env => Some("env"),
+            HarnessKind::Random => Some("random"),
+            HarnessKind::Net => Some("net"),
+        }
+    }
+
+    /// Parse the field name a script uses to reach a sub-handle.
+    pub fn from_field_name(name: &str) -> Option<Self> {
+        match name {
+            "stdio" => Some(HarnessKind::Stdio),
+            "clock" => Some(HarnessKind::Clock),
+            "fs" => Some(HarnessKind::Fs),
+            "env" => Some(HarnessKind::Env),
+            "random" => Some(HarnessKind::Random),
+            "net" => Some(HarnessKind::Net),
+            _ => None,
+        }
+    }
+
+    /// All six sub-handle kinds, in the canonical field order.
+    pub const SUB_HANDLES: &'static [HarnessKind] = &[
+        HarnessKind::Stdio,
+        HarnessKind::Clock,
+        HarnessKind::Fs,
+        HarnessKind::Env,
+        HarnessKind::Random,
+        HarnessKind::Net,
+    ];
+
+    /// Every kind a Harn-script type annotation may reference.
+    pub const ALL: &'static [HarnessKind] = &[
+        HarnessKind::Root,
+        HarnessKind::Stdio,
+        HarnessKind::Clock,
+        HarnessKind::Fs,
+        HarnessKind::Env,
+        HarnessKind::Random,
+        HarnessKind::Net,
+    ];
+}
+
+/// Shared, refcounted state backing every sub-handle of a single `Harness`.
+///
+/// Method implementations (in `crate::vm::methods::harness`) borrow this to
+/// reach the concrete OS-backed primitives. Wrapped in `Arc` so handles are
+/// `Send + Sync` for VM contexts that move work onto other tasks.
+#[derive(Debug)]
+pub struct HarnessInner {
+    clock: Arc<dyn Clock>,
+}
+
+impl HarnessInner {
+    pub fn clock(&self) -> &Arc<dyn Clock> {
+        &self.clock
+    }
+}
+
+/// The runtime handle threaded into `main(harness: Harness)`.
+///
+/// Cheap to clone; sub-handles share the same `Arc` inner state.
+#[derive(Debug, Clone)]
+pub struct Harness {
+    inner: Arc<HarnessInner>,
+}
+
+impl Harness {
+    /// Build the production handle wired to wall-clock time. Filesystem,
+    /// environment, randomness, and network access are layered on by the
+    /// E4.2-E4.4 migration tickets; the constructor only needs to succeed
+    /// without panicking today (per the E4.1 exit criteria).
+    pub fn real() -> Self {
+        Self::with_clock(RealClock::arc())
+    }
+
+    /// Build a handle wired to a caller-supplied clock. Test bootstraps that
+    /// want deterministic time without depending on the full `NullHarness`
+    /// surface (E4.5) drive this directly.
+    pub fn with_clock(clock: Arc<dyn Clock>) -> Self {
+        Self {
+            inner: Arc::new(HarnessInner { clock }),
+        }
+    }
+
+    /// Field access for `harness.stdio`.
+    pub fn stdio(&self) -> HarnessStdio {
+        HarnessStdio {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+
+    /// Field access for `harness.clock`.
+    pub fn clock(&self) -> HarnessClock {
+        HarnessClock {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+
+    /// Field access for `harness.fs`.
+    pub fn fs(&self) -> HarnessFs {
+        HarnessFs {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+
+    /// Field access for `harness.env`.
+    pub fn env(&self) -> HarnessEnv {
+        HarnessEnv {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+
+    /// Field access for `harness.random`.
+    pub fn random(&self) -> HarnessRandom {
+        HarnessRandom {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+
+    /// Field access for `harness.net`.
+    pub fn net(&self) -> HarnessNet {
+        HarnessNet {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+
+    /// Lower this handle into the `VmValue::Harness` payload.
+    pub fn into_vm_value(self) -> crate::value::VmValue {
+        crate::value::VmValue::Harness(VmHarness {
+            inner: self.inner,
+            kind: HarnessKind::Root,
+        })
+    }
+}
+
+impl Default for Harness {
+    fn default() -> Self {
+        Self::real()
+    }
+}
+
+/// stdio sub-handle: `println`, `eprintln`, `prompt`, `read_line`.
+#[derive(Debug, Clone)]
+pub struct HarnessStdio {
+    inner: Arc<HarnessInner>,
+}
+
+/// clock sub-handle: `now`, `monotonic_now`, `sleep`.
+#[derive(Debug, Clone)]
+pub struct HarnessClock {
+    inner: Arc<HarnessInner>,
+}
+
+impl HarnessClock {
+    pub fn clock(&self) -> &Arc<dyn Clock> {
+        self.inner.clock()
+    }
+}
+
+/// fs sub-handle: `read_file`, `write_file`, `exists`, `list_dir`,
+/// `delete_file`, ...
+#[derive(Debug, Clone)]
+pub struct HarnessFs {
+    inner: Arc<HarnessInner>,
+}
+
+/// env sub-handle: `get`, `set`, `vars`.
+#[derive(Debug, Clone)]
+pub struct HarnessEnv {
+    inner: Arc<HarnessInner>,
+}
+
+/// random sub-handle: `gen_u64`, `gen_range`, `gen_f64`, ...
+#[derive(Debug, Clone)]
+pub struct HarnessRandom {
+    inner: Arc<HarnessInner>,
+}
+
+/// net sub-handle: `http_get`, `http_post`, ...
+#[derive(Debug, Clone)]
+pub struct HarnessNet {
+    inner: Arc<HarnessInner>,
+}
+
+macro_rules! sub_handle_inner {
+    ($($ty:ty),* $(,)?) => {
+        $(
+            impl $ty {
+                #[allow(dead_code)]
+                pub(crate) fn inner(&self) -> &Arc<HarnessInner> {
+                    &self.inner
+                }
+            }
+        )*
+    };
+}
+sub_handle_inner!(
+    HarnessStdio,
+    HarnessFs,
+    HarnessEnv,
+    HarnessRandom,
+    HarnessNet,
+);
+
+impl HarnessClock {
+    #[allow(dead_code)]
+    pub(crate) fn inner(&self) -> &Arc<HarnessInner> {
+        &self.inner
+    }
+}
+
+/// Compact `VmValue` payload for a `Harness` or any of its sub-handles.
+///
+/// All seven variants share one `Arc<HarnessInner>`; `kind` discriminates the
+/// surface the VM exposes for property access and method dispatch.
+#[derive(Clone)]
+pub struct VmHarness {
+    inner: Arc<HarnessInner>,
+    kind: HarnessKind,
+}
+
+impl VmHarness {
+    pub fn kind(&self) -> HarnessKind {
+        self.kind
+    }
+
+    pub fn type_name(&self) -> &'static str {
+        self.kind.type_name()
+    }
+
+    pub fn inner(&self) -> &Arc<HarnessInner> {
+        &self.inner
+    }
+
+    /// Get the sub-handle reached by a field name (`stdio`, `clock`, etc.).
+    /// Returns `None` when the receiver is itself a sub-handle or the field
+    /// is unknown.
+    pub fn sub_handle(&self, field: &str) -> Option<VmHarness> {
+        if self.kind != HarnessKind::Root {
+            return None;
+        }
+        let kind = HarnessKind::from_field_name(field)?;
+        Some(VmHarness {
+            inner: Arc::clone(&self.inner),
+            kind,
+        })
+    }
+}
+
+impl fmt::Debug for VmHarness {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("VmHarness")
+            .field("kind", &self.kind)
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn real_constructs_without_panic() {
+        let _harness = Harness::real();
+    }
+
+    #[test]
+    fn sub_handles_share_inner_state() {
+        let harness = Harness::real();
+        let stdio_inner = Arc::as_ptr(harness.stdio().inner());
+        let clock_inner = Arc::as_ptr(harness.clock().inner());
+        assert_eq!(stdio_inner, clock_inner, "sub-handles share Arc<Inner>");
+    }
+
+    #[test]
+    fn kinds_round_trip_through_field_names() {
+        for kind in HarnessKind::SUB_HANDLES {
+            let field = kind.field_name().unwrap();
+            assert_eq!(HarnessKind::from_field_name(field), Some(*kind));
+        }
+        assert!(HarnessKind::from_field_name("nope").is_none());
+        assert!(HarnessKind::Root.field_name().is_none());
+    }
+
+    #[test]
+    fn vm_harness_property_access_returns_sub_handle() {
+        let root = match Harness::real().into_vm_value() {
+            crate::value::VmValue::Harness(h) => h,
+            other => panic!("expected Harness variant, got {}", other.type_name()),
+        };
+        let stdio = root.sub_handle("stdio").expect("stdio sub-handle");
+        assert_eq!(stdio.kind(), HarnessKind::Stdio);
+        assert!(stdio.sub_handle("clock").is_none(), "nested access denied");
+        assert!(root.sub_handle("not_a_field").is_none());
+    }
+}

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -25,6 +25,7 @@ pub mod egress;
 pub mod event_log;
 pub mod events;
 pub mod flow;
+pub mod harness;
 mod http;
 pub mod jsonrpc;
 pub mod llm;
@@ -129,6 +130,10 @@ pub use corrections::{
     correction_record_from_json, policy_with_corrections, query_correction_records,
     CorrectionQueryFilters, CorrectionRecord, CorrectionScope, CORRECTIONS_TOPIC,
     CORRECTION_EVENT_KIND, CORRECTION_SCHEMA_V0,
+};
+pub use harness::{
+    Harness, HarnessClock, HarnessEnv, HarnessFs, HarnessKind, HarnessNet, HarnessRandom,
+    HarnessStdio, VmHarness,
 };
 pub use http::{register_http_builtins, reset_http_state};
 pub use llm::register_llm_builtins;

--- a/crates/harn-vm/src/stdlib/io.rs
+++ b/crates/harn-vm/src/stdlib/io.rs
@@ -257,7 +257,7 @@ pub fn take_stderr_buffer() -> String {
     STDERR_BUFFER.with(|s| std::mem::take(&mut *s.borrow_mut()))
 }
 
-fn write_stderr(line: &str) {
+pub(crate) fn write_stderr(line: &str) {
     if crate::run_events::sink_active() {
         crate::run_events::emit(crate::run_events::RunEvent::Stderr {
             payload: line.to_string(),

--- a/crates/harn-vm/src/value/core.rs
+++ b/crates/harn-vm/src/value/core.rs
@@ -3,6 +3,7 @@ use std::rc::Rc;
 use std::sync::atomic::Ordering;
 use std::{cell::RefCell, future::Future, pin::Pin};
 
+use crate::harness::VmHarness;
 use crate::mcp::VmMcpClientHandle;
 use crate::BuiltinId;
 
@@ -129,6 +130,11 @@ pub enum VmValue {
     /// Accessed via `.first` / `.second`, and destructurable in
     /// `for (a, b) in ...` loops.
     Pair(Rc<(VmValue, VmValue)>),
+    /// Capability handle threaded into `main(harness: Harness)`. The same
+    /// variant carries the root handle and each typed sub-handle (`stdio`,
+    /// `clock`, `fs`, `env`, `random`, `net`) so they share one inline
+    /// payload but stay distinguishable via `VmHarness::kind`.
+    Harness(VmHarness),
 }
 
 impl VmValue {
@@ -181,6 +187,7 @@ impl VmValue {
             VmValue::Range(_) => true,
             VmValue::Iter(_) => true,
             VmValue::Pair(_) => true,
+            VmValue::Harness(_) => true,
         }
     }
 
@@ -212,6 +219,7 @@ impl VmValue {
             VmValue::Range(_) => "range",
             VmValue::Iter(_) => "iter",
             VmValue::Pair(_) => "pair",
+            VmValue::Harness(h) => h.type_name(),
         }
     }
 
@@ -473,6 +481,9 @@ impl VmValue {
                 } else {
                     out.push_str("<iter>");
                 }
+            }
+            VmValue::Harness(h) => {
+                let _ = write!(out, "<{}>", h.type_name());
             }
             VmValue::Pair(p) => {
                 out.push('(');

--- a/crates/harn-vm/src/value/structural.rs
+++ b/crates/harn-vm/src/value/structural.rs
@@ -218,6 +218,11 @@ pub fn values_equal(a: &VmValue, b: &VmValue) -> bool {
         (VmValue::Pair(a), VmValue::Pair(b)) => {
             values_equal(&a.0, &b.0) && values_equal(&a.1, &b.1)
         }
+        // Harness handles carry runtime capability state, not values. Two
+        // handles that refer to the same backing capability are still
+        // observed-distinct because the script never compares them. Returning
+        // `false` matches `Channel` / `Generator` / `Stream` precedent.
+        (VmValue::Harness(_), VmValue::Harness(_)) => false,
         _ => false,
     }
 }

--- a/crates/harn-vm/src/vm/methods/dispatch.rs
+++ b/crates/harn-vm/src/vm/methods/dispatch.rs
@@ -41,6 +41,10 @@ impl crate::vm::Vm {
                 VmValue::Generator(gen) => self.call_generator_method(gen, method).await,
                 VmValue::Stream(stream) => self.call_stream_method(stream, method).await,
                 VmValue::Iter(handle) => self.call_iter_method(handle, method, args).await,
+                VmValue::Harness(handle) => {
+                    let handle = handle.clone();
+                    self.call_harness_method(&handle, method, args).await
+                }
                 other => Err(VmError::TypeError(format!(
                     "value of type {} has no method `{method}`",
                     other.type_name()

--- a/crates/harn-vm/src/vm/methods/harness.rs
+++ b/crates/harn-vm/src/vm/methods/harness.rs
@@ -1,0 +1,102 @@
+//! Method dispatch for the `Harness` capability handle and its six
+//! sub-handles. E4.1 ships the stdio surface end-to-end (`println`,
+//! `eprintln`) so the new entrypoint convention has a working
+//! hello-world; subsequent tickets (E4.2-E4.4) replace the stub bodies
+//! on the other sub-handles with real implementations.
+
+use std::time::Duration;
+
+use crate::harness::{HarnessKind, VmHarness};
+use crate::stdlib::io::{write_stderr, write_stdout};
+use crate::value::{VmError, VmValue};
+
+impl crate::vm::Vm {
+    pub(super) async fn call_harness_method(
+        &mut self,
+        handle: &VmHarness,
+        method: &str,
+        args: &[VmValue],
+    ) -> Result<VmValue, VmError> {
+        match handle.kind() {
+            HarnessKind::Root => Err(method_unsupported(handle, method)),
+            HarnessKind::Stdio => self.call_harness_stdio_method(handle, method, args),
+            HarnessKind::Clock => self.call_harness_clock_method(handle, method, args).await,
+            HarnessKind::Fs | HarnessKind::Env | HarnessKind::Random | HarnessKind::Net => {
+                Err(VmError::TypeError(format!(
+                "{}::{method} is not yet implemented — wired by the E4.2-E4.4 migration tickets",
+                handle.type_name(),
+            )))
+            }
+        }
+    }
+
+    fn call_harness_stdio_method(
+        &mut self,
+        handle: &VmHarness,
+        method: &str,
+        args: &[VmValue],
+    ) -> Result<VmValue, VmError> {
+        match method {
+            "println" => {
+                let msg = args.first().map(|a| a.display()).unwrap_or_default();
+                write_stdout(&mut self.output, &format!("{msg}\n"));
+                Ok(VmValue::Nil)
+            }
+            "print" => {
+                let msg = args.first().map(|a| a.display()).unwrap_or_default();
+                write_stdout(&mut self.output, &msg);
+                Ok(VmValue::Nil)
+            }
+            "eprintln" => {
+                let msg = args.first().map(|a| a.display()).unwrap_or_default();
+                write_stderr(&format!("{msg}\n"));
+                Ok(VmValue::Nil)
+            }
+            "eprint" => {
+                let msg = args.first().map(|a| a.display()).unwrap_or_default();
+                write_stderr(&msg);
+                Ok(VmValue::Nil)
+            }
+            _ => Err(method_unsupported(handle, method)),
+        }
+    }
+
+    async fn call_harness_clock_method(
+        &mut self,
+        handle: &VmHarness,
+        method: &str,
+        args: &[VmValue],
+    ) -> Result<VmValue, VmError> {
+        let clock = handle.inner().clock();
+        match method {
+            "now_ms" => Ok(VmValue::Int(crate::clock::now_wall_ms(clock.as_ref()))),
+            "monotonic_ms" => Ok(VmValue::Int(clock.monotonic_ms())),
+            "sleep_ms" => {
+                let ms = args
+                    .first()
+                    .and_then(|v| match v {
+                        VmValue::Int(n) => Some(*n),
+                        VmValue::Duration(ms) => Some(*ms),
+                        _ => None,
+                    })
+                    .ok_or_else(|| {
+                        VmError::TypeError(
+                            "HarnessClock.sleep_ms expects an int or duration argument".into(),
+                        )
+                    })?;
+                if ms > 0 {
+                    clock.sleep(Duration::from_millis(ms as u64)).await;
+                }
+                Ok(VmValue::Nil)
+            }
+            _ => Err(method_unsupported(handle, method)),
+        }
+    }
+}
+
+fn method_unsupported(handle: &VmHarness, method: &str) -> VmError {
+    VmError::TypeError(format!(
+        "value of type {} has no method `{method}`",
+        handle.type_name()
+    ))
+}

--- a/crates/harn-vm/src/vm/methods/mod.rs
+++ b/crates/harn-vm/src/vm/methods/mod.rs
@@ -1,6 +1,7 @@
 mod dict;
 mod dispatch;
 mod generator;
+mod harness;
 mod iter;
 mod list;
 mod number;

--- a/crates/harn-vm/src/vm/ops/collections.rs
+++ b/crates/harn-vm/src/vm/ops/collections.rs
@@ -197,6 +197,17 @@ impl super::super::Vm {
                     )));
                 }
             },
+            VmValue::Harness(handle) => match handle.sub_handle(name) {
+                Some(sub) => VmValue::Harness(sub),
+                None if optional => VmValue::Nil,
+                None => {
+                    return Err(VmError::TypeError(format!(
+                        "cannot access property `{name}` on {} — Harness exposes `stdio`, \
+                         `clock`, `fs`, `env`, `random`, `net`",
+                        handle.type_name(),
+                    )));
+                }
+            },
             VmValue::Nil => {
                 return Err(VmError::TypeError(format!(
                     "cannot access property `{name}` on nil — use `?.{name}` for optional access, or narrow with a `!= nil` guard before reading fields"

--- a/crates/harn-vm/src/vm/state.rs
+++ b/crates/harn-vm/src/vm/state.rs
@@ -755,6 +755,15 @@ impl Vm {
         Rc::make_mut(&mut self.globals).insert(name.to_string(), value);
     }
 
+    /// Install the script's `Harness` capability handle as the `harness`
+    /// global so the auto-call emitted by `Compiler::compile()` (for
+    /// `fn main(harness: Harness)` entrypoints) can read it. Hosts that
+    /// drive the VM directly (CLI, MCP server, composition runtime) call
+    /// this once before `execute()`.
+    pub fn set_harness(&mut self, harness: crate::harness::Harness) {
+        self.set_global("harness", harness.into_vm_value());
+    }
+
     /// Get the captured output.
     pub fn output(&self) -> &str {
         &self.output

--- a/examples/hello_v2.harn
+++ b/examples/hello_v2.harn
@@ -1,0 +1,9 @@
+/**
+ * E4.1 entrypoint convention: `main` takes a single typed Harness
+ * parameter, replacing the ambient stdio/clock/fs globals. See
+ * docs/llm/harn-quickref.md for the full surface; E4.2-E4.4 land the
+ * remaining capability migrations.
+ */
+fn main(harness: Harness) {
+  harness.stdio.println("Hello, world!")
+}


### PR DESCRIPTION
## Summary

First step of the E4 epic ([#1765](https://github.com/burin-labs/harn/issues/1765)) closing [#1766](https://github.com/burin-labs/harn/issues/1766). Introduces the public `harn_vm::Harness` Rust type and six typed sub-handles (`HarnessStdio`, `HarnessClock`, `HarnessFs`, `HarnessEnv`, `HarnessRandom`, `HarnessNet`), establishes the new `fn main(harness: Harness)` entrypoint convention, and wires it through the VM, typechecker, and CLI run path.

- **New module** `crates/harn-vm/src/harness.rs` — `Harness`, `HarnessInner`, six sub-handle wrappers, `HarnessKind`, and the compact `VmHarness` payload carried by `VmValue::Harness`. `Harness::real()` wraps `harn-clock::RealClock` today; filesystem/env/random/net implementations land in E4.2-E4.4.
- **Compiler auto-call** — `Compiler::compile()` detects a top-level `fn main` and emits a synthetic call against the runtime-supplied `harness` global. The CLI (`harn run`), conformance runner, bench, and playground paths all call `vm.set_harness(Harness::real())` before execution.
- **Typechecker** — `HARN-NAM-101 InvalidMainSignature` rejects every non-canonical `fn main`. `harness.stdio` / `.clock` / ... infer to the matching sub-handle types so `let x: HarnessStdio = harness.stdio` type-checks. The `unused-function` lint exempts `fn main`.
- **Method dispatch** — `stdio.println` / `print` / `eprintln` / `eprint` and `clock.now_ms` / `monotonic_ms` / `sleep_ms` are wired end-to-end. Other sub-handles fail loudly with a stub-error so the migration boundary is explicit.

## Exit criteria (from #1766)

- [x] `cargo run --bin harn -- run examples/hello_v2.harn` prints `Hello, world!` against the new entrypoint.
- [x] Typechecker rejects `fn main() {}` (and four other malformed variants) with `HARN-NAM-101` — covered by 8 unit tests + 2 conformance error fixtures.
- [x] `Harness::real()` constructs without panicking — covered by a unit test in `harness.rs`.

## Test plan

- [x] `cargo test --workspace --lib` (2106+ tests in `harn-vm` alone; flaky MCP HTTP test passes on retry, not touched by this change).
- [x] `cargo run --bin harn -- test conformance` — 1077 / 1077 pass, including the three new fixtures.
- [x] `cargo clippy -p harn-vm -p harn-parser -p harn-lint -p harn-cli --no-deps -- -D warnings`
- [x] `cargo fmt --check`
- [x] `make lint-md`, `make lint-test-patterns`
- [x] Pre-commit hooks (clippy + ratchets + highlight regen + markdown) all green; pre-push hooks green.
- [x] `harn explain HARN-NAM-101` surfaces the new explanation page end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Closes #1766.
