### PR TITLE
Add harn fix repair-plan mode (#1749)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,17 @@ condensed series summaries instead of full per-patch history.
   `eprint` and `harness.clock.now_ms` / `monotonic_ms` / `sleep_ms` are
   wired end-to-end so `examples/hello_v2.harn` runs against the new
   shape today.
+- **`harn fix --plan --json` repair plans (#1749).** Adds plan-only
+  `harn fix` mode for diagnostics with registered repair classifiers.
+  `harn fix --plan <path>` prints a summary table and
+  `harn fix --plan --json <path>` emits a `RepairPlan` with
+  `schemaVersion: 1`, `diagnostics[]`, `repairs[]`, and
+  `safetyLevels[]`. Plan mode mirrors the check path across type-check,
+  lint, and preflight diagnostics, reports concrete `FixEdit` entries
+  when available, marks overlapping edits via `applies_cleanly: false`
+  plus `conflicts_with`, and never writes files. `--safety <class>`
+  filters proposals by maximum autonomy class; `--apply` remains
+  reserved for #1752.
 - **`with_scoped_executor` tool-caller middleware (#1702).** Narrows the
   active `CapabilityPolicy` for the duration of one tool dispatch:
   `compose_tool_callers([..., with_scoped_executor({stage, allowed_tools,

--- a/crates/harn-cli/src/cli/fix.rs
+++ b/crates/harn-cli/src/cli/fix.rs
@@ -1,0 +1,36 @@
+use std::path::PathBuf;
+
+use clap::Args;
+use harn_parser::RepairSafety;
+
+#[derive(Debug, Args)]
+pub(crate) struct FixArgs {
+    /// Emit a repair plan without writing files.
+    #[arg(long, conflicts_with = "apply")]
+    pub plan: bool,
+    /// Apply repairs. Reserved for E1.5; currently returns an error.
+    #[arg(long, conflicts_with = "plan")]
+    pub apply: bool,
+    /// Maximum repair safety class to include.
+    #[arg(long, value_parser = parse_repair_safety, value_name = "SAFETY")]
+    pub safety: Option<RepairSafety>,
+    /// Emit the machine-readable RepairPlan JSON.
+    #[arg(long)]
+    pub json: bool,
+    /// .harn file or directory to inspect.
+    #[arg(required = true)]
+    pub path: PathBuf,
+}
+
+fn parse_repair_safety(value: &str) -> Result<RepairSafety, String> {
+    value.parse::<RepairSafety>().map_err(|_| {
+        format!(
+            "unknown repair safety `{value}`; expected one of: {}",
+            RepairSafety::ALL
+                .iter()
+                .map(|safety| safety.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+    })
+}

--- a/crates/harn-cli/src/cli/mod.rs
+++ b/crates/harn-cli/src/cli/mod.rs
@@ -24,6 +24,7 @@ mod doctor;
 mod dump;
 mod eval;
 mod explain;
+mod fix;
 mod flow;
 mod init;
 mod lint_fmt;
@@ -96,6 +97,7 @@ pub use eval::{
     EvalToolCallsCommand, EvalToolCallsRegressionArgs,
 };
 pub(crate) use explain::ExplainArgs;
+pub(crate) use fix::FixArgs;
 pub(crate) use flow::{
     FlowArchivistCommand, FlowArchivistScanArgs, FlowArgs, FlowCommand, FlowReplayAuditArgs,
     FlowShipCommand, FlowShipWatchArgs,
@@ -278,6 +280,8 @@ SCRIPTING
     /// legacy `--invariant <NAME> <FUNCTION> <FILE>` form to walk the
     /// control-flow path behind a Harn invariant violation.
     Explain(ExplainArgs),
+    /// Emit repair plans for diagnostics without editing files.
+    Fix(FixArgs),
     /// Export machine-readable Harn contracts and bundle manifests.
     Contracts(ContractsArgs),
     /// Lint .harn files or directories for common issues.

--- a/crates/harn-cli/src/cli/tests.rs
+++ b/crates/harn-cli/src/cli/tests.rs
@@ -94,6 +94,30 @@ fn test_parses_routes_json() {
 }
 
 #[test]
+fn test_parses_fix_plan_json_args() {
+    let cli = Cli::parse_from([
+        "harn",
+        "fix",
+        "--plan",
+        "--json",
+        "--safety",
+        "behavior-preserving",
+        "main.harn",
+    ]);
+
+    let Command::Fix(args) = cli.command.unwrap() else {
+        panic!("expected fix command");
+    };
+    assert!(args.plan);
+    assert!(args.json);
+    assert_eq!(
+        args.safety.map(|safety| safety.as_str()),
+        Some("behavior-preserving")
+    );
+    assert_eq!(args.path, PathBuf::from("main.harn"));
+}
+
+#[test]
 fn test_parses_agents_conformance_target_url() {
     let cli = Cli::parse_from([
         "harn",

--- a/crates/harn-cli/src/commands/check/mod.rs
+++ b/crates/harn-cli/src/commands/check/mod.rs
@@ -26,4 +26,5 @@ pub(crate) use config::{
 pub(crate) use fmt::{fmt_targets, FmtMode};
 pub(crate) use host_capabilities::load_host_capabilities;
 pub(crate) use lint::{lint_file_inner, lint_fix_file};
+pub(crate) use preflight::{collect_preflight_diagnostics, is_preflight_allowed};
 pub(crate) use template_lint::{collect_prompt_targets, lint_prompt_file_inner};

--- a/crates/harn-cli/src/commands/check/preflight.rs
+++ b/crates/harn-cli/src/commands/check/preflight.rs
@@ -10,24 +10,24 @@ use super::mock_host::collect_mock_host_capabilities;
 use super::source::parse_resolved_module;
 use crate::package::CheckConfig;
 
-pub(super) struct PreflightDiagnostic {
-    pub(super) code: Code,
-    pub(super) path: String,
-    pub(super) source: String,
-    pub(super) span: harn_lexer::Span,
-    pub(super) message: String,
-    pub(super) help: Option<String>,
+pub(crate) struct PreflightDiagnostic {
+    pub(crate) code: Code,
+    pub(crate) path: String,
+    pub(crate) source: String,
+    pub(crate) span: harn_lexer::Span,
+    pub(crate) message: String,
+    pub(crate) help: Option<String>,
     /// Optional `"capability.operation"` tag used for per-capability
     /// suppression via `[check].preflight_allow`. `None` means this
     /// diagnostic is not scoped to a single host capability.
-    pub(super) tags: Option<String>,
+    pub(crate) tags: Option<String>,
 }
 
 /// Returns `true` when `tag` matches any entry in `allow`. Entries may
 /// be exact (`project.scan`), capability wildcards (`project.*` or
 /// just `project`), or a literal `*` to suppress every preflight
 /// diagnostic that carries a tag.
-pub(super) fn is_preflight_allowed(tag: &Option<String>, allow: &[String]) -> bool {
+pub(crate) fn is_preflight_allowed(tag: &Option<String>, allow: &[String]) -> bool {
     let Some(tag) = tag else { return false };
     let (cap, _) = tag.split_once('.').unwrap_or((tag.as_str(), ""));
     allow.iter().any(|entry| {
@@ -42,7 +42,7 @@ pub(super) fn is_preflight_allowed(tag: &Option<String>, allow: &[String]) -> bo
     })
 }
 
-pub(super) fn collect_preflight_diagnostics(
+pub(crate) fn collect_preflight_diagnostics(
     path: &Path,
     source: &str,
     program: &[SNode],

--- a/crates/harn-cli/src/commands/fix.rs
+++ b/crates/harn-cli/src/commands/fix.rs
@@ -1,0 +1,495 @@
+//! `harn fix --plan`: propose repair-bearing diagnostics without edits.
+
+use std::collections::{BTreeSet, HashSet};
+use std::path::Path;
+
+use harn_lexer::{FixEdit, Span};
+use harn_lint::LintSeverity;
+use harn_parser::{
+    DiagnosticCode as Code, DiagnosticSeverity, Repair, RepairSafety, SNode, TypeChecker,
+};
+use serde::Serialize;
+
+use crate::cli::FixArgs;
+use crate::package::{self, CheckConfig, PreflightSeverity};
+use crate::{commands, parse_source_file};
+
+pub(crate) const FIX_PLAN_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct RepairPlan {
+    #[serde(rename = "schemaVersion")]
+    pub schema_version: u32,
+    pub path: String,
+    pub diagnostics: Vec<DiagnosticWire>,
+    pub repairs: Vec<RepairWire>,
+    #[serde(rename = "safetyLevels")]
+    pub safety_levels: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct DiagnosticWire {
+    pub index: usize,
+    pub file: String,
+    pub source: &'static str,
+    pub severity: &'static str,
+    pub code: String,
+    pub message: String,
+    pub span: Option<SpanWire>,
+    pub repair: RepairMetadataWire,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct RepairWire {
+    pub diagnostic_index: usize,
+    pub diagnostic_code: String,
+    pub repair: RepairMetadataWire,
+    pub edits: Vec<FixEditWire>,
+    pub applies_cleanly: bool,
+    pub conflicts_with: Vec<usize>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct RepairMetadataWire {
+    pub id: String,
+    pub summary: String,
+    pub safety: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct FixEditWire {
+    pub span: SpanWire,
+    pub replacement: String,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+pub(crate) struct SpanWire {
+    pub start: usize,
+    pub end: usize,
+    pub line: usize,
+    pub column: usize,
+    pub end_line: usize,
+}
+
+#[derive(Debug, Clone)]
+struct RepairCandidate {
+    file: String,
+    source: &'static str,
+    severity: &'static str,
+    code: Code,
+    message: String,
+    span: Option<Span>,
+    repair: Repair,
+    edits: Vec<FixEdit>,
+}
+
+pub(crate) fn run(args: &FixArgs) -> Result<(), String> {
+    if args.apply {
+        return Err("`harn fix --apply` is tracked by #1752; use `--plan` for now".to_string());
+    }
+    if !args.plan {
+        return Err("`harn fix` requires `--plan` until apply mode lands".to_string());
+    }
+
+    let plan = build_plan(&args.path, args.safety)?;
+    if args.json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&plan)
+                .map_err(|error| format!("failed to serialize repair plan: {error}"))?
+        );
+    } else {
+        print_human_plan(&plan);
+    }
+    Ok(())
+}
+
+pub(crate) fn build_plan(
+    target: &Path,
+    safety_ceiling: Option<RepairSafety>,
+) -> Result<RepairPlan, String> {
+    if let Err(error) = package::validate_runtime_manifest_extensions(target) {
+        return Err(format!("manifest extension validation failed: {error}"));
+    }
+
+    let target_string = target.to_string_lossy().into_owned();
+    let target_refs = [target_string.as_str()];
+    let files = commands::check::collect_harn_targets(&target_refs);
+    if files.is_empty() {
+        return Err("no .harn files found under the given target".to_string());
+    }
+
+    let module_graph = commands::check::build_module_graph(&files);
+    let cross_file_imports = commands::check::collect_cross_file_imports(&module_graph);
+    let mut candidates = Vec::new();
+    for file in &files {
+        collect_file_candidates(
+            file,
+            safety_ceiling,
+            &cross_file_imports,
+            &module_graph,
+            &mut candidates,
+        );
+    }
+
+    let conflicts = detect_conflicts(&candidates);
+    let diagnostics = candidates
+        .iter()
+        .enumerate()
+        .map(|(index, candidate)| DiagnosticWire {
+            index,
+            file: candidate.file.clone(),
+            source: candidate.source,
+            severity: candidate.severity,
+            code: candidate.code.to_string(),
+            message: candidate.message.clone(),
+            span: candidate.span.map(SpanWire::from),
+            repair: RepairMetadataWire::from(&candidate.repair),
+        })
+        .collect::<Vec<_>>();
+    let repairs = candidates
+        .iter()
+        .enumerate()
+        .map(|(index, candidate)| {
+            let conflicts_with = conflicts[index].clone();
+            RepairWire {
+                diagnostic_index: index,
+                diagnostic_code: candidate.code.to_string(),
+                repair: RepairMetadataWire::from(&candidate.repair),
+                edits: candidate
+                    .edits
+                    .iter()
+                    .map(FixEditWire::from)
+                    .collect::<Vec<_>>(),
+                applies_cleanly: conflicts_with.is_empty(),
+                conflicts_with,
+            }
+        })
+        .collect::<Vec<_>>();
+    let present_safety = candidates
+        .iter()
+        .map(|candidate| candidate.repair.safety)
+        .collect::<BTreeSet<_>>();
+    let safety_levels = RepairSafety::ALL
+        .iter()
+        .copied()
+        .filter(|safety| present_safety.contains(safety))
+        .map(|safety| safety.as_str().to_string())
+        .collect::<Vec<_>>();
+
+    Ok(RepairPlan {
+        schema_version: FIX_PLAN_SCHEMA_VERSION,
+        path: target_string,
+        diagnostics,
+        repairs,
+        safety_levels,
+    })
+}
+
+fn collect_file_candidates(
+    file: &Path,
+    safety_ceiling: Option<RepairSafety>,
+    cross_file_imports: &HashSet<String>,
+    module_graph: &harn_modules::ModuleGraph,
+    out: &mut Vec<RepairCandidate>,
+) {
+    let path_str = file.to_string_lossy().into_owned();
+    let (source, program) = parse_source_file(&path_str);
+    let mut config = package::load_check_config(Some(file));
+    commands::check::apply_harn_lint_config(file, &mut config);
+
+    let type_diagnostics = type_check(file, &config, module_graph, &program, &source);
+    for diag in &type_diagnostics {
+        if harn_lint::type_diagnostic_lint_disabled(diag, &config.disable_rules) {
+            continue;
+        }
+        let Some(repair) = diag.repair.clone() else {
+            continue;
+        };
+        if !repair_allowed(&repair, safety_ceiling) {
+            continue;
+        }
+        out.push(RepairCandidate {
+            file: path_str.clone(),
+            source: "typecheck",
+            severity: severity_label(diag.severity),
+            code: diag.code,
+            message: diag.message.clone(),
+            span: diag.span,
+            repair,
+            edits: diag.fix.clone().unwrap_or_default(),
+        });
+    }
+
+    let persona_step_allowlist = commands::check::harn_lint_persona_step_allowlist(file);
+    let options = harn_lint::LintOptions {
+        file_path: Some(file),
+        require_file_header: commands::check::harn_lint_require_file_header(file),
+        complexity_threshold: commands::check::harn_lint_complexity_threshold(file),
+        persona_step_allowlist: &persona_step_allowlist,
+    };
+    let lint_diagnostics = harn_lint::lint_with_module_graph(
+        &program,
+        &config.disable_rules,
+        Some(&source),
+        cross_file_imports,
+        module_graph,
+        file,
+        &options,
+    );
+    for diag in &lint_diagnostics {
+        let Some(repair) = diag.repair() else {
+            continue;
+        };
+        if !repair_allowed(&repair, safety_ceiling) {
+            continue;
+        }
+        out.push(RepairCandidate {
+            file: path_str.clone(),
+            source: "lint",
+            severity: lint_severity_label(diag.severity),
+            code: diag.code,
+            message: diag.message.clone(),
+            span: Some(diag.span),
+            repair,
+            edits: diag.fix.clone().unwrap_or_default(),
+        });
+    }
+
+    collect_preflight_candidates(file, &source, &program, &config, safety_ceiling, out);
+}
+
+fn collect_preflight_candidates(
+    file: &Path,
+    source: &str,
+    program: &[SNode],
+    config: &CheckConfig,
+    safety_ceiling: Option<RepairSafety>,
+    out: &mut Vec<RepairCandidate>,
+) {
+    let preflight_severity = PreflightSeverity::from_opt(config.preflight_severity.as_deref());
+    if preflight_severity == PreflightSeverity::Off {
+        return;
+    }
+
+    for diag in commands::check::collect_preflight_diagnostics(file, source, program, config) {
+        if commands::check::is_preflight_allowed(&diag.tags, &config.preflight_allow) {
+            continue;
+        }
+        let Some(template) = diag.code.repair_template() else {
+            continue;
+        };
+        let repair = Repair::from_template(template);
+        if !repair_allowed(&repair, safety_ceiling) {
+            continue;
+        }
+        out.push(RepairCandidate {
+            file: diag.path,
+            source: "preflight",
+            severity: match preflight_severity {
+                PreflightSeverity::Warning => "warning",
+                PreflightSeverity::Error => "error",
+                PreflightSeverity::Off => unreachable!(),
+            },
+            code: diag.code,
+            message: diag.message,
+            span: Some(diag.span),
+            repair,
+            edits: Vec::new(),
+        });
+    }
+}
+
+fn type_check(
+    path: &Path,
+    config: &CheckConfig,
+    module_graph: &harn_modules::ModuleGraph,
+    program: &[SNode],
+    source: &str,
+) -> Vec<harn_parser::TypeDiagnostic> {
+    let mut checker = TypeChecker::with_strict_types(config.strict_types);
+    if let Some(imported) = module_graph.imported_names_for_file(path) {
+        checker = checker.with_imported_names(imported);
+    }
+    if let Some(imported) = module_graph.imported_type_declarations_for_file(path) {
+        checker = checker.with_imported_type_decls(imported);
+    }
+    if let Some(imported) = module_graph.imported_callable_declarations_for_file(path) {
+        checker = checker.with_imported_callable_decls(imported);
+    }
+    checker.check_with_source(program, source)
+}
+
+fn repair_allowed(repair: &Repair, safety_ceiling: Option<RepairSafety>) -> bool {
+    safety_ceiling
+        .map(|ceiling| repair.safety.is_at_most(ceiling))
+        .unwrap_or(true)
+}
+
+fn detect_conflicts(candidates: &[RepairCandidate]) -> Vec<Vec<usize>> {
+    let mut conflicts = vec![Vec::new(); candidates.len()];
+    for left in 0..candidates.len() {
+        for right in (left + 1)..candidates.len() {
+            if candidates_overlap(&candidates[left], &candidates[right]) {
+                conflicts[left].push(right);
+                conflicts[right].push(left);
+            }
+        }
+    }
+    conflicts
+}
+
+fn candidates_overlap(left: &RepairCandidate, right: &RepairCandidate) -> bool {
+    if left.file != right.file {
+        return false;
+    }
+    left.edits.iter().any(|left_edit| {
+        right
+            .edits
+            .iter()
+            .any(|right_edit| spans_overlap(left_edit.span, right_edit.span))
+    })
+}
+
+fn spans_overlap(left: Span, right: Span) -> bool {
+    left.start < right.end && left.end > right.start
+}
+
+fn print_human_plan(plan: &RepairPlan) {
+    if plan.repairs.is_empty() {
+        println!("{}: no repairable diagnostics found", plan.path);
+        return;
+    }
+    println!(
+        "{}: {} repairable diagnostic(s)",
+        plan.path,
+        plan.repairs.len()
+    );
+    println!("idx  code          safety               edits  clean  repair");
+    for repair in &plan.repairs {
+        let clean = if repair.applies_cleanly { "yes" } else { "no" };
+        println!(
+            "{:<4} {:<13} {:<20} {:<5} {:<5} {}",
+            repair.diagnostic_index,
+            repair.diagnostic_code,
+            repair.repair.safety,
+            repair.edits.len(),
+            clean,
+            repair.repair.id
+        );
+    }
+}
+
+fn severity_label(severity: DiagnosticSeverity) -> &'static str {
+    match severity {
+        DiagnosticSeverity::Error => "error",
+        DiagnosticSeverity::Warning => "warning",
+    }
+}
+
+fn lint_severity_label(severity: LintSeverity) -> &'static str {
+    match severity {
+        LintSeverity::Warning => "warning",
+        LintSeverity::Error => "error",
+    }
+}
+
+impl From<Span> for SpanWire {
+    fn from(span: Span) -> Self {
+        SpanWire {
+            start: span.start,
+            end: span.end,
+            line: span.line,
+            column: span.column,
+            end_line: span.end_line,
+        }
+    }
+}
+
+impl From<&FixEdit> for FixEditWire {
+    fn from(edit: &FixEdit) -> Self {
+        FixEditWire {
+            span: SpanWire::from(edit.span),
+            replacement: edit.replacement.clone(),
+        }
+    }
+}
+
+impl From<&Repair> for RepairMetadataWire {
+    fn from(repair: &Repair) -> Self {
+        RepairMetadataWire {
+            id: repair.id.as_str().to_string(),
+            summary: repair.summary.clone(),
+            safety: repair.safety.as_str().to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn candidate(file: &str, start: usize, end: usize) -> RepairCandidate {
+        RepairCandidate {
+            file: file.to_string(),
+            source: "typecheck",
+            severity: "warning",
+            code: Code::FormatterWouldReformat,
+            message: "test".to_string(),
+            span: Some(Span::with_offsets(start, end, 1, start + 1)),
+            repair: Repair::from_template(Code::FormatterWouldReformat.repair_template().unwrap()),
+            edits: vec![FixEdit {
+                span: Span::with_offsets(start, end, 1, start + 1),
+                replacement: "x".to_string(),
+            }],
+        }
+    }
+
+    #[test]
+    fn conflict_detection_marks_overlapping_edits() {
+        let conflicts = detect_conflicts(&[
+            candidate("a.harn", 0, 3),
+            candidate("a.harn", 2, 4),
+            candidate("a.harn", 4, 5),
+            candidate("b.harn", 2, 4),
+        ]);
+        assert_eq!(conflicts[0], vec![1]);
+        assert_eq!(conflicts[1], vec![0]);
+        assert!(conflicts[2].is_empty());
+        assert!(conflicts[3].is_empty());
+    }
+
+    #[test]
+    fn plan_reports_repairable_diagnostics_without_writing() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let script = temp.path().join("repair_demo.harn");
+        let source =
+            "pipeline main() { let count = 1; let greeting = \"hello \" + count; greeting }\n";
+        fs::write(&script, source).unwrap();
+        let before = fs::read(&script).unwrap();
+
+        let plan = build_plan(&script, Some(RepairSafety::BehaviorPreserving)).unwrap();
+
+        assert_eq!(plan.schema_version, FIX_PLAN_SCHEMA_VERSION);
+        assert!(
+            plan.repairs.iter().any(|repair| {
+                repair.repair.id == "style/string-interpolation"
+                    && repair.repair.safety == "behavior-preserving"
+                    && repair.applies_cleanly
+            }),
+            "expected string-interpolation repair in plan: {plan:#?}"
+        );
+        assert!(
+            plan.repairs
+                .iter()
+                .all(|repair| repair.repair.safety != "needs-human"),
+            "behavior-preserving ceiling must exclude needs-human repairs: {plan:#?}"
+        );
+        assert_eq!(fs::read(&script).unwrap(), before, "--plan must not write");
+
+        let encoded = serde_json::to_value(&plan).unwrap();
+        assert_eq!(encoded["schemaVersion"], FIX_PLAN_SCHEMA_VERSION);
+        assert!(encoded["repairs"].as_array().is_some());
+    }
+}

--- a/crates/harn-cli/src/commands/mod.rs
+++ b/crates/harn-cli/src/commands/mod.rs
@@ -16,6 +16,7 @@ pub mod eval_prompt;
 pub(crate) mod eval_prompt_context;
 pub(crate) mod eval_tool_calls;
 pub(crate) mod explain;
+pub(crate) mod fix;
 pub mod flow;
 pub(crate) mod hardware;
 pub(crate) mod init;

--- a/crates/harn-cli/src/json_envelope.rs
+++ b/crates/harn-cli/src/json_envelope.rs
@@ -171,6 +171,12 @@ pub fn catalog() -> Vec<SchemaEntry> {
             schema_json: None,
         },
         SchemaEntry {
+            command: "fix plan",
+            schema_version: crate::commands::fix::FIX_PLAN_SCHEMA_VERSION,
+            description: "Plan repair-bearing diagnostics without editing files.",
+            schema_json: None,
+        },
+        SchemaEntry {
             command: "skills list",
             schema_version: 1,
             description: "Embedded canonical Harn skill corpus, frontmatter only.",
@@ -266,6 +272,19 @@ mod tests {
             deduped.len()
         };
         assert_eq!(commands.len(), unique_count, "command names must be unique");
+    }
+
+    #[test]
+    fn catalog_includes_fix_plan() {
+        let entries = catalog();
+        let entry = entries
+            .iter()
+            .find(|entry| entry.command == "fix plan")
+            .expect("fix plan schema should be registered");
+        assert_eq!(
+            entry.schema_version,
+            crate::commands::fix::FIX_PLAN_SCHEMA_VERSION
+        );
     }
 
     #[test]

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -328,6 +328,11 @@ async fn async_main() {
                 process::exit(code);
             }
         }
+        Command::Fix(args) => {
+            if let Err(error) = commands::fix::run(&args) {
+                command_error(&error);
+            }
+        }
         Command::Contracts(args) => {
             commands::contracts::handle_contracts_command(args).await;
         }

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -520,6 +520,26 @@ action that VS Code can run on save:
 }
 ```
 
+## harn fix
+
+Emit a repair plan for one `.harn` file or directory without editing files.
+Plan mode runs the same type-check, lint, and preflight diagnostic passes used
+by `harn check`, keeps diagnostics that carry a registered repair classifier,
+and reports the concrete `FixEdit` edits when a diagnostic already has a
+machine-applicable fix.
+
+```bash
+harn fix --plan main.harn
+harn fix --plan --json main.harn
+harn fix --plan --json --safety behavior-preserving src/
+```
+
+`--json` returns a `RepairPlan` with `schemaVersion: 1`, `diagnostics[]`,
+`repairs[]`, and `safetyLevels[]`. Each repair includes the diagnostic code,
+repair `{id, summary, safety}`, candidate edits, `applies_cleanly`, and
+`conflicts_with` indexes for overlapping edit ranges. `--apply` is reserved for
+the apply-mode ticket and currently exits with an error.
+
 ## harn check
 
 Type-check one or more `.harn` files or directories and run preflight


### PR DESCRIPTION
## Summary

Implements `harn fix --plan` for #1749. The new command walks the same check/lint/preflight diagnostics as `harn check`, filters diagnostics with repair metadata, and emits either human-readable output or schema-versioned JSON without writing files.

- adds `FixArgs` and command wiring
- emits `RepairPlan` schema version 1 with diagnostics, repairs, safety levels, clean-apply flags, and overlap conflicts
- registers `fix plan` in `harn --json-schemas`
- documents the command in the CLI reference

## Validation

- `cargo fmt --all -- --check`
- `make lint-test-patterns`
- `git diff --check origin/main...HEAD`
- `CARGO_TARGET_DIR=/tmp/harn-target-1749 HARN_LLM_CALLS_DISABLED=1 cargo test -p harn-cli --lib fix`
- `CARGO_TARGET_DIR=/tmp/harn-target-1749 HARN_LLM_CALLS_DISABLED=1 cargo run --quiet --bin harn -- fix --plan --json --safety behavior-preserving /tmp/harn-fix-plan-smoke.harn`
- `CARGO_TARGET_DIR=/tmp/harn-target-1749 HARN_LLM_CALLS_DISABLED=1 cargo clippy -p harn-cli --all-targets -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/harn-target-1749 HARN_LLM_CALLS_DISABLED=1 make check-docs-snippets`
- `make lint-md`

Closes #1749.