### PR TITLE
Add harn fix apply mode (#1752)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,11 +172,12 @@ condensed series summaries instead of full per-patch history.
   auto-invokes `fn main` when present with the `harness` global set by
   the run path (CLI, conformance, bench, playground), and the
   typechecker enforces the new convention via `HARN-NAM-101`: any
-  `fn main` with a signature other than `main(harness: Harness)` is
-  rejected at parse time. `harness.stdio.println` / `print` / `eprintln` /
-  `eprint` and `harness.clock.now_ms` / `monotonic_ms` / `sleep_ms` are
-  wired end-to-end so `examples/hello_v2.harn` runs against the new
-  shape today.
+  `fn main` with a signature other than `main(harness: Harness)` or the
+  unused-capability opt-out `main(_harness: Harness)` is rejected at
+  parse time. `harness.stdio.println` / `print` / `eprintln` / `eprint`
+  and `harness.clock.now_ms` / `monotonic_ms` / `sleep_ms` are wired
+  end-to-end so `examples/hello_v2.harn` runs against the new shape
+  today.
 - **`harn fix --plan --json` repair plans (#1749).** Adds plan-only
   `harn fix` mode for diagnostics with registered repair classifiers.
   `harn fix --plan <path>` prints a summary table and
@@ -186,8 +187,18 @@ condensed series summaries instead of full per-patch history.
   lint, and preflight diagnostics, reports concrete `FixEdit` entries
   when available, marks overlapping edits via `applies_cleanly: false`
   plus `conflicts_with`, and never writes files. `--safety <class>`
-  filters proposals by maximum autonomy class; `--apply` remains
-  reserved for #1752.
+  filters proposals by maximum autonomy class.
+- **`harn fix --apply --safety <class>` guarded repair application
+  (#1752).** Extends `harn fix` with the apply half of the repair
+  contract. Apply mode requires an explicit ceiling from `format-only`
+  through `capability-changing`, rejects `needs-human` as propose-only,
+  filters out conflicts and above-ceiling repairs, writes accepted
+  `FixEdit`s bottom-up per file, then reruns the same diagnostic passes
+  to report `post_apply_diagnostics_count`. `--dry-run` reports the same
+  apply set without writing, and `--apply --json` emits a
+  schema-versioned result with `applied[]`, `skipped[]`, skip reasons,
+  and the post-apply diagnostic count. The `harn --json-schemas` catalog
+  now includes `fix apply`.
 - **`with_scoped_executor` tool-caller middleware (#1702).** Narrows the
   active `CapabilityPolicy` for the duration of one tool dispatch:
   `compose_tool_callers([..., with_scoped_executor({stage, allowed_tools,

--- a/crates/harn-cli/src/cli/fix.rs
+++ b/crates/harn-cli/src/cli/fix.rs
@@ -8,9 +8,12 @@ pub(crate) struct FixArgs {
     /// Emit a repair plan without writing files.
     #[arg(long, conflicts_with = "apply")]
     pub plan: bool,
-    /// Apply repairs. Reserved for E1.5; currently returns an error.
+    /// Apply clean repairs at or below the declared safety ceiling.
     #[arg(long, conflicts_with = "plan")]
     pub apply: bool,
+    /// With --apply, report what would change without writing files.
+    #[arg(long, requires = "apply")]
+    pub dry_run: bool,
     /// Maximum repair safety class to include.
     #[arg(long, value_parser = parse_repair_safety, value_name = "SAFETY")]
     pub safety: Option<RepairSafety>,

--- a/crates/harn-cli/src/cli/mod.rs
+++ b/crates/harn-cli/src/cli/mod.rs
@@ -280,7 +280,7 @@ SCRIPTING
     /// legacy `--invariant <NAME> <FUNCTION> <FILE>` form to walk the
     /// control-flow path behind a Harn invariant violation.
     Explain(ExplainArgs),
-    /// Emit repair plans for diagnostics without editing files.
+    /// Plan or apply repair-bearing diagnostics under an explicit safety ceiling.
     Fix(FixArgs),
     /// Export machine-readable Harn contracts and bundle manifests.
     Contracts(ContractsArgs),

--- a/crates/harn-cli/src/cli/tests.rs
+++ b/crates/harn-cli/src/cli/tests.rs
@@ -118,6 +118,32 @@ fn test_parses_fix_plan_json_args() {
 }
 
 #[test]
+fn test_parses_fix_apply_dry_run_args() {
+    let cli = Cli::parse_from([
+        "harn",
+        "fix",
+        "--apply",
+        "--dry-run",
+        "--json",
+        "--safety",
+        "scope-local",
+        "src/",
+    ]);
+
+    let Command::Fix(args) = cli.command.unwrap() else {
+        panic!("expected fix command");
+    };
+    assert!(args.apply);
+    assert!(args.dry_run);
+    assert!(args.json);
+    assert_eq!(
+        args.safety.map(|safety| safety.as_str()),
+        Some("scope-local")
+    );
+    assert_eq!(args.path, PathBuf::from("src/"));
+}
+
+#[test]
 fn test_parses_agents_conformance_target_url() {
     let cli = Cli::parse_from([
         "harn",

--- a/crates/harn-cli/src/commands/fix.rs
+++ b/crates/harn-cli/src/commands/fix.rs
@@ -1,6 +1,6 @@
-//! `harn fix --plan`: propose repair-bearing diagnostics without edits.
+//! `harn fix`: propose or apply repair-bearing diagnostics.
 
-use std::collections::{BTreeSet, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::path::Path;
 
 use harn_lexer::{FixEdit, Span};
@@ -15,6 +15,7 @@ use crate::package::{self, CheckConfig, PreflightSeverity};
 use crate::{commands, parse_source_file};
 
 pub(crate) const FIX_PLAN_SCHEMA_VERSION: u32 = 1;
+pub(crate) const FIX_APPLY_SCHEMA_VERSION: u32 = 1;
 
 #[derive(Debug, Clone, Serialize)]
 pub(crate) struct RepairPlan {
@@ -25,6 +26,34 @@ pub(crate) struct RepairPlan {
     pub repairs: Vec<RepairWire>,
     #[serde(rename = "safetyLevels")]
     pub safety_levels: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct ApplyResult {
+    #[serde(rename = "schemaVersion")]
+    pub schema_version: u32,
+    pub applied: Vec<AppliedRepairWire>,
+    pub skipped: Vec<SkippedRepairWire>,
+    #[serde(rename = "post_apply_diagnostics_count")]
+    pub post_apply_diagnostics_count: usize,
+    #[serde(rename = "dryRun")]
+    pub dry_run: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct AppliedRepairWire {
+    pub diagnostic_code: String,
+    pub repair_id: String,
+    pub path: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct SkippedRepairWire {
+    pub diagnostic_index: usize,
+    pub diagnostic_code: String,
+    pub repair_id: String,
+    pub path: String,
+    pub reason: &'static str,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -85,10 +114,30 @@ struct RepairCandidate {
 
 pub(crate) fn run(args: &FixArgs) -> Result<(), String> {
     if args.apply {
-        return Err("`harn fix --apply` is tracked by #1752; use `--plan` for now".to_string());
+        let safety = args.safety.ok_or_else(|| {
+            "`harn fix --apply` requires `--safety <format-only|behavior-preserving|scope-local|surface-changing|capability-changing>`"
+                .to_string()
+        })?;
+        if safety == RepairSafety::NeedsHuman {
+            return Err(
+                "`harn fix --apply --safety needs-human` is not allowed; use `harn fix --plan --json` to inspect propose-only repairs"
+                    .to_string(),
+            );
+        }
+        let result = apply_repairs(&args.path, safety, args.dry_run)?;
+        if args.json {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&result)
+                    .map_err(|error| format!("failed to serialize apply result: {error}"))?
+            );
+        } else {
+            print_apply_result(&result);
+        }
+        return Ok(());
     }
     if !args.plan {
-        return Err("`harn fix` requires `--plan` until apply mode lands".to_string());
+        return Err("`harn fix` requires `--plan` or `--apply`".to_string());
     }
 
     let plan = build_plan(&args.path, args.safety)?;
@@ -184,6 +233,175 @@ pub(crate) fn build_plan(
         repairs,
         safety_levels,
     })
+}
+
+pub(crate) fn apply_repairs(
+    target: &Path,
+    safety_ceiling: RepairSafety,
+    dry_run: bool,
+) -> Result<ApplyResult, String> {
+    let plan = build_plan(target, None)?;
+    let mut edits_by_file: BTreeMap<String, Vec<FixEditWire>> = BTreeMap::new();
+    let mut applied = Vec::new();
+    let mut skipped = Vec::new();
+
+    for repair in &plan.repairs {
+        let path = repair_path(&plan, repair)?;
+        let repair_safety = repair.repair.safety.parse::<RepairSafety>().map_err(|_| {
+            format!(
+                "internal error: unknown repair safety `{}`",
+                repair.repair.safety
+            )
+        })?;
+
+        let skip_reason = if repair_safety == RepairSafety::NeedsHuman {
+            Some("needs_human")
+        } else if !repair_safety.is_at_most(safety_ceiling) {
+            Some("above_safety_ceiling")
+        } else if !repair.applies_cleanly {
+            Some("conflict")
+        } else if repair.edits.is_empty() {
+            Some("no_edits")
+        } else {
+            None
+        };
+
+        if let Some(reason) = skip_reason {
+            skipped.push(SkippedRepairWire {
+                diagnostic_index: repair.diagnostic_index,
+                diagnostic_code: repair.diagnostic_code.clone(),
+                repair_id: repair.repair.id.clone(),
+                path,
+                reason,
+            });
+            continue;
+        }
+
+        edits_by_file
+            .entry(path.clone())
+            .or_default()
+            .extend(repair.edits.iter().cloned());
+        applied.push(AppliedRepairWire {
+            diagnostic_code: repair.diagnostic_code.clone(),
+            repair_id: repair.repair.id.clone(),
+            path,
+        });
+    }
+
+    if !dry_run {
+        for (path, edits) in &edits_by_file {
+            apply_file_edits(Path::new(path), edits)?;
+        }
+    }
+
+    let post_apply_diagnostics_count = count_remaining_diagnostics(target)?;
+    Ok(ApplyResult {
+        schema_version: FIX_APPLY_SCHEMA_VERSION,
+        applied,
+        skipped,
+        post_apply_diagnostics_count,
+        dry_run,
+    })
+}
+
+fn repair_path(plan: &RepairPlan, repair: &RepairWire) -> Result<String, String> {
+    plan.diagnostics
+        .get(repair.diagnostic_index)
+        .map(|diagnostic| diagnostic.file.clone())
+        .ok_or_else(|| {
+            format!(
+                "internal error: repair references missing diagnostic index {}",
+                repair.diagnostic_index
+            )
+        })
+}
+
+fn apply_file_edits(path: &Path, edits: &[FixEditWire]) -> Result<(), String> {
+    if edits.is_empty() {
+        return Ok(());
+    }
+    let mut result = std::fs::read_to_string(path)
+        .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
+    let mut sorted = edits.to_vec();
+    sorted.sort_by_key(|edit| std::cmp::Reverse(edit.span.start));
+    for edit in sorted {
+        if edit.span.start > edit.span.end || edit.span.end > result.len() {
+            return Err(format!(
+                "repair edit span {}..{} is outside {} ({} bytes)",
+                edit.span.start,
+                edit.span.end,
+                path.display(),
+                result.len()
+            ));
+        }
+        if !result.is_char_boundary(edit.span.start) || !result.is_char_boundary(edit.span.end) {
+            return Err(format!(
+                "repair edit span {}..{} is not on UTF-8 character boundaries in {}",
+                edit.span.start,
+                edit.span.end,
+                path.display()
+            ));
+        }
+        result.replace_range(edit.span.start..edit.span.end, &edit.replacement);
+    }
+    std::fs::write(path, result)
+        .map_err(|error| format!("failed to write {}: {error}", path.display()))
+}
+
+fn count_remaining_diagnostics(target: &Path) -> Result<usize, String> {
+    if let Err(error) = package::validate_runtime_manifest_extensions(target) {
+        return Err(format!("manifest extension validation failed: {error}"));
+    }
+
+    let target_string = target.to_string_lossy().into_owned();
+    let target_refs = [target_string.as_str()];
+    let files = commands::check::collect_harn_targets(&target_refs);
+    let module_graph = commands::check::build_module_graph(&files);
+    let cross_file_imports = commands::check::collect_cross_file_imports(&module_graph);
+    let mut count = 0;
+
+    for file in &files {
+        let path_str = file.to_string_lossy().into_owned();
+        let (source, program) = parse_source_file(&path_str);
+        let mut config = package::load_check_config(Some(file));
+        commands::check::apply_harn_lint_config(file, &mut config);
+
+        count += type_check(file, &config, &module_graph, &program, &source)
+            .iter()
+            .filter(|diag| !harn_lint::type_diagnostic_lint_disabled(diag, &config.disable_rules))
+            .count();
+
+        let persona_step_allowlist = commands::check::harn_lint_persona_step_allowlist(file);
+        let options = harn_lint::LintOptions {
+            file_path: Some(file),
+            require_file_header: commands::check::harn_lint_require_file_header(file),
+            complexity_threshold: commands::check::harn_lint_complexity_threshold(file),
+            persona_step_allowlist: &persona_step_allowlist,
+        };
+        count += harn_lint::lint_with_module_graph(
+            &program,
+            &config.disable_rules,
+            Some(&source),
+            &cross_file_imports,
+            &module_graph,
+            file,
+            &options,
+        )
+        .len();
+
+        let preflight_severity = PreflightSeverity::from_opt(config.preflight_severity.as_deref());
+        if preflight_severity != PreflightSeverity::Off {
+            count +=
+                commands::check::collect_preflight_diagnostics(file, &source, &program, &config)
+                    .into_iter()
+                    .filter(|diag| {
+                        !commands::check::is_preflight_allowed(&diag.tags, &config.preflight_allow)
+                    })
+                    .count();
+        }
+    }
+
+    Ok(count)
 }
 
 fn collect_file_candidates(
@@ -380,6 +598,26 @@ fn print_human_plan(plan: &RepairPlan) {
     }
 }
 
+fn print_apply_result(result: &ApplyResult) {
+    let verb = if result.dry_run {
+        "would apply"
+    } else {
+        "applied"
+    };
+    println!(
+        "{verb} {} repair(s), skipped {}; post-apply diagnostics: {}",
+        result.applied.len(),
+        result.skipped.len(),
+        result.post_apply_diagnostics_count
+    );
+    for skipped in &result.skipped {
+        println!(
+            "skipped {} {} in {}: {}",
+            skipped.diagnostic_code, skipped.repair_id, skipped.path, skipped.reason
+        );
+    }
+}
+
 fn severity_label(severity: DiagnosticSeverity) -> &'static str {
     match severity {
         DiagnosticSeverity::Error => "error",
@@ -429,6 +667,7 @@ impl From<&Repair> for RepairMetadataWire {
 mod tests {
     use super::*;
     use std::fs;
+    use std::path::PathBuf;
 
     fn candidate(file: &str, start: usize, end: usize) -> RepairCandidate {
         RepairCandidate {
@@ -491,5 +730,79 @@ mod tests {
         let encoded = serde_json::to_value(&plan).unwrap();
         assert_eq!(encoded["schemaVersion"], FIX_PLAN_SCHEMA_VERSION);
         assert!(encoded["repairs"].as_array().is_some());
+    }
+
+    #[test]
+    fn apply_writes_clean_repairs_and_reports_post_check_count() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let script = temp.path().join("repair_demo.harn");
+        fs::write(
+            &script,
+            "pipeline main() { let count = 1; let greeting = \"hello \" + count; greeting }\n",
+        )
+        .unwrap();
+
+        let result = apply_repairs(&script, RepairSafety::BehaviorPreserving, false).unwrap();
+
+        assert_eq!(result.schema_version, FIX_APPLY_SCHEMA_VERSION);
+        assert_eq!(result.applied.len(), 1, "{result:#?}");
+        assert!(result.skipped.is_empty(), "{result:#?}");
+        assert_eq!(result.post_apply_diagnostics_count, 0, "{result:#?}");
+        let updated = fs::read_to_string(&script).unwrap();
+        assert!(updated.contains("\"hello ${count}\""), "{updated}");
+    }
+
+    #[test]
+    fn apply_dry_run_reports_without_writing() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let script = temp.path().join("repair_demo.harn");
+        let source =
+            "pipeline main() { let count = 1; let greeting = \"hello \" + count; greeting }\n";
+        fs::write(&script, source).unwrap();
+
+        let result = apply_repairs(&script, RepairSafety::BehaviorPreserving, true).unwrap();
+
+        assert!(result.dry_run);
+        assert_eq!(result.applied.len(), 1, "{result:#?}");
+        assert_eq!(fs::read_to_string(&script).unwrap(), source);
+    }
+
+    #[test]
+    fn apply_skips_repairs_above_safety_ceiling() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let script = temp.path().join("repair_demo.harn");
+        let source =
+            "pipeline main() { let count = 1; let greeting = \"hello \" + count; greeting }\n";
+        fs::write(&script, source).unwrap();
+
+        let result = apply_repairs(&script, RepairSafety::FormatOnly, false).unwrap();
+
+        assert!(result.applied.is_empty(), "{result:#?}");
+        assert!(
+            result.skipped.iter().any(|skipped| {
+                skipped.repair_id == "style/string-interpolation"
+                    && skipped.reason == "above_safety_ceiling"
+            }),
+            "{result:#?}"
+        );
+        assert_eq!(fs::read_to_string(&script).unwrap(), source);
+    }
+
+    #[test]
+    fn apply_rejects_needs_human_safety_ceiling() {
+        let args = FixArgs {
+            plan: false,
+            apply: true,
+            dry_run: false,
+            safety: Some(RepairSafety::NeedsHuman),
+            json: false,
+            path: PathBuf::from("repair_demo.harn"),
+        };
+
+        let error = run(&args).unwrap_err();
+        assert!(
+            error.contains("needs-human") && error.contains("--plan --json"),
+            "unexpected error: {error}"
+        );
     }
 }

--- a/crates/harn-cli/src/json_envelope.rs
+++ b/crates/harn-cli/src/json_envelope.rs
@@ -177,6 +177,12 @@ pub fn catalog() -> Vec<SchemaEntry> {
             schema_json: None,
         },
         SchemaEntry {
+            command: "fix apply",
+            schema_version: crate::commands::fix::FIX_APPLY_SCHEMA_VERSION,
+            description: "Apply clean repair edits at or below a declared safety ceiling.",
+            schema_json: None,
+        },
+        SchemaEntry {
             command: "skills list",
             schema_version: 1,
             description: "Embedded canonical Harn skill corpus, frontmatter only.",
@@ -284,6 +290,14 @@ mod tests {
         assert_eq!(
             entry.schema_version,
             crate::commands::fix::FIX_PLAN_SCHEMA_VERSION
+        );
+        let entry = entries
+            .iter()
+            .find(|entry| entry.command == "fix apply")
+            .expect("fix apply schema should be registered");
+        assert_eq!(
+            entry.schema_version,
+            crate::commands::fix::FIX_APPLY_SCHEMA_VERSION
         );
     }
 

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -522,23 +522,30 @@ action that VS Code can run on save:
 
 ## harn fix
 
-Emit a repair plan for one `.harn` file or directory without editing files.
-Plan mode runs the same type-check, lint, and preflight diagnostic passes used
-by `harn check`, keeps diagnostics that carry a registered repair classifier,
-and reports the concrete `FixEdit` edits when a diagnostic already has a
+Emit a repair plan for one `.harn` file or directory, or apply clean
+machine-applicable repairs under an explicit safety ceiling. Plan mode runs
+the same type-check, lint, and preflight diagnostic passes used by
+`harn check`, keeps diagnostics that carry a registered repair classifier, and
+reports the concrete `FixEdit` edits when a diagnostic already has a
 machine-applicable fix.
 
 ```bash
 harn fix --plan main.harn
 harn fix --plan --json main.harn
 harn fix --plan --json --safety behavior-preserving src/
+harn fix --apply --safety behavior-preserving main.harn
+harn fix --apply --dry-run --json --safety scope-local src/
 ```
 
 `--json` returns a `RepairPlan` with `schemaVersion: 1`, `diagnostics[]`,
 `repairs[]`, and `safetyLevels[]`. Each repair includes the diagnostic code,
 repair `{id, summary, safety}`, candidate edits, `applies_cleanly`, and
-`conflicts_with` indexes for overlapping edit ranges. `--apply` is reserved for
-the apply-mode ticket and currently exits with an error.
+`conflicts_with` indexes for overlapping edit ranges. Apply mode requires
+`--safety <format-only|behavior-preserving|scope-local|surface-changing|capability-changing>`;
+`needs-human` repairs are propose-only and are never auto-applied.
+`--apply --json` returns `schemaVersion`, `applied[]`, `skipped[]`, and
+`post_apply_diagnostics_count`. `--dry-run` reports the same apply set without
+writing files.
 
 ## harn check
 


### PR DESCRIPTION
## Summary
- implement `harn fix --apply --safety <class>` with guarded repair application, dry-run, JSON output, skip reasons, and post-apply diagnostic counts
- register the `fix apply` JSON schema catalog entry and document the CLI behavior
- add parser/unit coverage for apply, dry-run, above-ceiling skips, and `needs-human` rejection

Closes #1752.

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `make lint-test-patterns`
- `CARGO_TARGET_DIR=/tmp/harn-target-1752 HARN_LLM_CALLS_DISABLED=1 cargo test -p harn-cli --lib fix`
- `CARGO_TARGET_DIR=/tmp/harn-target-1752 HARN_LLM_CALLS_DISABLED=1 cargo clippy -p harn-cli --all-targets -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/harn-target-1752 HARN_LLM_CALLS_DISABLED=1 make check-docs-snippets`
- `make lint-md`
- CLI smoke: `harn fix --apply --dry-run --json` leaves file unchanged; `harn fix --apply --json` writes one repair and reports `post_apply_diagnostics_count: 0`