### PR TITLE
Add parse and token JSON CLI surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ Pre-0.6 highlights live in [CHANGELOG-pre-0.6.md](CHANGELOG-pre-0.6.md).
 Harn had no external users before 0.6.0, so that archive intentionally keeps
 condensed series summaries instead of full per-patch history.
 
+## Unreleased
+
+### Added
+
+- **`harn parse --json` and `harn tokens --json` (#1757).** Adds
+  parser and lexer inspection commands for tooling. `harn parse` prints
+  the AST in text mode or a tagged `Program` JSON tree with byte spans
+  in `--json` mode. `harn tokens` prints the lexer stream in text mode
+  or `{ kind, lexeme, start, end, line, column }` entries in `--json`
+  mode. Both structured surfaces use the standard `JsonEnvelope` and
+  register in `harn --json-schemas`.
+
 ## v0.8.25
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2220,6 +2220,9 @@ dependencies = [
 [[package]]
 name = "harn-lexer"
 version = "0.8.25"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "harn-lint"
@@ -2287,6 +2290,7 @@ version = "0.8.25"
 dependencies = [
  "harn-lexer",
  "serde",
+ "serde_json",
  "yansi",
 ]
 

--- a/crates/harn-cli/src/cli/mod.rs
+++ b/crates/harn-cli/src/cli/mod.rs
@@ -35,6 +35,7 @@ mod models;
 mod orchestrator;
 mod pack;
 mod package;
+mod parse_tokens;
 mod persona;
 mod playground;
 mod portal;
@@ -136,6 +137,7 @@ pub(crate) use package::{
     AddArgs, InstallArgs, PackageArgs, PackageArtifactsCommand, PackageCacheCommand,
     PackageCommand, PublishArgs, RemoveArgs, UpdateArgs,
 };
+pub(crate) use parse_tokens::{ParseArgs, TokensArgs};
 pub(crate) use persona::{
     PersonaArgs, PersonaCheckArgs, PersonaCommand, PersonaControlArgs, PersonaDoctorArgs,
     PersonaInspectArgs, PersonaListArgs, PersonaNewArgs, PersonaSpendArgs, PersonaStatusArgs,
@@ -273,6 +275,10 @@ SCRIPTING
     Run(RunArgs),
     /// Type-check .harn files or directories without executing them.
     Check(CheckArgs),
+    /// Parse a .harn file and print its AST.
+    Parse(ParseArgs),
+    /// Tokenize a .harn file and print lexer tokens.
+    Tokens(TokensArgs),
     /// Inspect, validate, and emit schemas for layered Harn runtime config.
     Config(ConfigArgs),
     /// Explain a diagnostic. Pass a stable `HARN-<CAT>-<NNN>` code

--- a/crates/harn-cli/src/cli/parse_tokens.rs
+++ b/crates/harn-cli/src/cli/parse_tokens.rs
@@ -1,0 +1,21 @@
+use clap::Args;
+
+#[derive(Debug, Args)]
+pub(crate) struct ParseArgs {
+    /// Harn source file to parse.
+    pub path: String,
+
+    /// Emit the parsed AST as a versioned JSON envelope.
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct TokensArgs {
+    /// Harn source file to tokenize.
+    pub path: String,
+
+    /// Emit tokens as a versioned JSON envelope.
+    #[arg(long)]
+    pub json: bool,
+}

--- a/crates/harn-cli/src/cli/tests.rs
+++ b/crates/harn-cli/src/cli/tests.rs
@@ -94,6 +94,23 @@ fn test_parses_routes_json() {
 }
 
 #[test]
+fn test_parses_parse_and_tokens_json() {
+    let parse = Cli::parse_from(["harn", "parse", "main.harn", "--json"]);
+    let Command::Parse(parse_args) = parse.command.unwrap() else {
+        panic!("expected parse command");
+    };
+    assert_eq!(parse_args.path, "main.harn");
+    assert!(parse_args.json);
+
+    let tokens = Cli::parse_from(["harn", "tokens", "main.harn", "--json"]);
+    let Command::Tokens(tokens_args) = tokens.command.unwrap() else {
+        panic!("expected tokens command");
+    };
+    assert_eq!(tokens_args.path, "main.harn");
+    assert!(tokens_args.json);
+}
+
+#[test]
 fn test_parses_fix_plan_json_args() {
     let cli = Cli::parse_from([
         "harn",

--- a/crates/harn-cli/src/commands/mod.rs
+++ b/crates/harn-cli/src/commands/mod.rs
@@ -28,6 +28,7 @@ pub(crate) mod merge_captain_mock;
 pub(crate) mod models;
 pub mod orchestrator;
 pub mod pack;
+pub(crate) mod parse_tokens;
 pub mod persona;
 pub mod persona_doctor;
 pub mod persona_scaffold;

--- a/crates/harn-cli/src/commands/parse_tokens.rs
+++ b/crates/harn-cli/src/commands/parse_tokens.rs
@@ -1,0 +1,135 @@
+use std::fs;
+use std::process;
+
+use harn_lexer::{Lexer, Token};
+use harn_parser::ast_json::{
+    self, AstJsonProgram, TokenJson, AST_JSON_SCHEMA_VERSION, TOKEN_JSON_SCHEMA_VERSION,
+};
+use harn_parser::parse_source;
+use serde::Serialize;
+use serde_json::json;
+
+use crate::cli::{ParseArgs, TokensArgs};
+use crate::json_envelope::{self, JsonEnvelope};
+
+pub(crate) const PARSE_JSON_SCHEMA_VERSION: u32 = AST_JSON_SCHEMA_VERSION;
+pub(crate) const TOKENS_JSON_SCHEMA_VERSION: u32 = TOKEN_JSON_SCHEMA_VERSION;
+
+pub(crate) fn run_parse(args: &ParseArgs) -> Result<(), String> {
+    let source = match fs::read_to_string(&args.path) {
+        Ok(source) => source,
+        Err(error) if args.json => json_error::<AstJsonProgram>(
+            PARSE_JSON_SCHEMA_VERSION,
+            "read_failed",
+            format!("failed to read {}: {error}", args.path),
+            &args.path,
+        ),
+        Err(error) => return Err(format!("failed to read {}: {error}", args.path)),
+    };
+
+    let program = match parse_source(&source) {
+        Ok(program) => program,
+        Err(error) if args.json => json_error::<AstJsonProgram>(
+            PARSE_JSON_SCHEMA_VERSION,
+            "parse_failed",
+            error.to_string(),
+            &args.path,
+        ),
+        Err(error) => return Err(error.to_string()),
+    };
+
+    if args.json {
+        let envelope = JsonEnvelope::ok(
+            PARSE_JSON_SCHEMA_VERSION,
+            ast_json::program_to_json(&program),
+        );
+        println!("{}", json_envelope::to_string_pretty(&envelope));
+    } else {
+        println!("{program:#?}");
+    }
+    Ok(())
+}
+
+pub(crate) fn run_tokens(args: &TokensArgs) -> Result<(), String> {
+    let source = match fs::read_to_string(&args.path) {
+        Ok(source) => source,
+        Err(error) if args.json => json_error::<Vec<TokenJson>>(
+            TOKENS_JSON_SCHEMA_VERSION,
+            "read_failed",
+            format!("failed to read {}: {error}", args.path),
+            &args.path,
+        ),
+        Err(error) => return Err(format!("failed to read {}: {error}", args.path)),
+    };
+
+    let mut lexer = Lexer::new(&source);
+    let tokens = match lexer.tokenize_with_comments() {
+        Ok(tokens) => tokens,
+        Err(error) if args.json => json_error::<Vec<TokenJson>>(
+            TOKENS_JSON_SCHEMA_VERSION,
+            "lex_failed",
+            error.to_string(),
+            &args.path,
+        ),
+        Err(error) => return Err(error.to_string()),
+    };
+
+    if args.json {
+        let envelope = JsonEnvelope::ok(
+            TOKENS_JSON_SCHEMA_VERSION,
+            ast_json::tokens_to_json(&source, &tokens),
+        );
+        println!("{}", json_envelope::to_string_pretty(&envelope));
+    } else {
+        for token in &tokens {
+            println!("{}", format_token_line(&source, token));
+        }
+    }
+    Ok(())
+}
+
+fn format_token_line(source: &str, token: &Token) -> String {
+    let lexeme = source
+        .get(token.span.start..token.span.end)
+        .unwrap_or_default();
+    format!(
+        "{:>4}:{:<3} {:>6}..{:<6} {:<22} {:?}",
+        token.span.line,
+        token.span.column,
+        token.span.start,
+        token.span.end,
+        ast_json::token_kind_name(&token.kind),
+        lexeme
+    )
+}
+
+fn json_error<T: Serialize>(
+    schema_version: u32,
+    code: &'static str,
+    message: String,
+    path: &str,
+) -> ! {
+    let envelope =
+        JsonEnvelope::<T>::err(schema_version, code, message).with_details(json!({ "path": path }));
+    println!("{}", json_envelope::to_string_pretty(&envelope));
+    process::exit(1);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn text_token_line_includes_span_kind_and_lexeme() {
+        let source = "let x = 1\n";
+        let mut lexer = Lexer::new(source);
+        let tokens = lexer.tokenize().expect("tokenize");
+
+        let line = format_token_line(source, &tokens[0]);
+
+        assert!(line.contains("1:1"));
+        assert!(line.contains("0..3"));
+        assert!(line.contains("Let"));
+        assert!(line.contains("\"let\""));
+    }
+}

--- a/crates/harn-cli/src/json_envelope.rs
+++ b/crates/harn-cli/src/json_envelope.rs
@@ -164,6 +164,18 @@ pub fn catalog() -> Vec<SchemaEntry> {
             schema_json: None,
         },
         SchemaEntry {
+            command: "parse",
+            schema_version: crate::commands::parse_tokens::PARSE_JSON_SCHEMA_VERSION,
+            description: "Tagged Harn AST tree with byte spans for parser tooling.",
+            schema_json: None,
+        },
+        SchemaEntry {
+            command: "tokens",
+            schema_version: crate::commands::parse_tokens::TOKENS_JSON_SCHEMA_VERSION,
+            description: "Lexer token stream with source lexemes and byte spans.",
+            schema_json: None,
+        },
+        SchemaEntry {
             command: "time run",
             schema_version: crate::commands::time::TIME_RUN_SCHEMA_VERSION,
             description:

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -317,6 +317,16 @@ async fn async_main() {
                 process::exit(1);
             }
         }
+        Command::Parse(args) => {
+            if let Err(error) = commands::parse_tokens::run_parse(&args) {
+                command_error(&error);
+            }
+        }
+        Command::Tokens(args) => {
+            if let Err(error) = commands::parse_tokens::run_tokens(&args) {
+                command_error(&error);
+            }
+        }
         Command::Config(args) => {
             if let Err(error) = commands::config_cmd::run(args).await {
                 command_error(&error);

--- a/crates/harn-cli/tests/json_schemas_cli.rs
+++ b/crates/harn-cli/tests/json_schemas_cli.rs
@@ -41,6 +41,14 @@ fn json_schemas_lists_all_registered_commands() {
         entries.iter().any(|e| e["command"] == "time run"),
         "`time run` should be in the catalog: {entries:?}"
     );
+    assert!(
+        entries.iter().any(|e| e["command"] == "parse"),
+        "`parse` should be in the catalog: {entries:?}"
+    );
+    assert!(
+        entries.iter().any(|e| e["command"] == "tokens"),
+        "`tokens` should be in the catalog: {entries:?}"
+    );
     for entry in entries {
         assert!(
             entry.get("command").and_then(|v| v.as_str()).is_some(),

--- a/crates/harn-cli/tests/parse_tokens_cli.rs
+++ b/crates/harn-cli/tests/parse_tokens_cli.rs
@@ -1,0 +1,84 @@
+//! End-to-end smoke tests for `harn parse --json` and `harn tokens --json`.
+
+use std::process::Command;
+
+fn binary_path() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_BIN_EXE_harn"))
+}
+
+fn stdout_json(output: &std::process::Output) -> serde_json::Value {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(stdout.trim()).unwrap_or_else(|error| {
+        panic!("stdout is not JSON: {error}\nstdout:\n{stdout}");
+    })
+}
+
+#[test]
+fn parse_json_emits_program_root_and_tagged_ast_nodes() {
+    let temp = tempfile::TempDir::new().expect("tempdir");
+    let script = temp.path().join("main.harn");
+    std::fs::write(&script, "pipeline main(task) {\n  return 1\n}\n").expect("write script");
+
+    let output = Command::new(binary_path())
+        .args(["parse", script.to_str().unwrap(), "--json"])
+        .output()
+        .expect("spawn harn parse --json");
+    assert!(
+        output.status.success(),
+        "stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let parsed = stdout_json(&output);
+    assert_eq!(parsed["schemaVersion"], 1);
+    assert_eq!(parsed["ok"], true);
+    assert_eq!(parsed["data"]["kind"], "Program");
+    assert_eq!(parsed["data"]["body"][0]["kind"], "Pipeline");
+    assert_eq!(parsed["data"]["body"][0]["span"]["start"], 0);
+    assert_eq!(parsed["data"]["body"][0]["fields"]["name"], "main");
+    assert_eq!(
+        parsed["data"]["body"][0]["fields"]["body"][0]["kind"],
+        "ReturnStmt"
+    );
+}
+
+#[test]
+fn tokens_json_emits_kinds_lexemes_and_byte_spans() {
+    let temp = tempfile::TempDir::new().expect("tempdir");
+    let script = temp.path().join("main.harn");
+    let source = "let x = \"é\"\n// hi\n";
+    std::fs::write(&script, source).expect("write script");
+
+    let output = Command::new(binary_path())
+        .args(["tokens", script.to_str().unwrap(), "--json"])
+        .output()
+        .expect("spawn harn tokens --json");
+    assert!(
+        output.status.success(),
+        "stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let parsed = stdout_json(&output);
+    assert_eq!(parsed["schemaVersion"], 1);
+    assert_eq!(parsed["ok"], true);
+    let tokens = parsed["data"].as_array().expect("tokens array");
+
+    let string = tokens
+        .iter()
+        .find(|token| token["kind"] == "StringLiteral")
+        .expect("string literal token");
+    let quote = source.find('"').expect("opening quote");
+    assert_eq!(string["lexeme"], "\"é\"");
+    assert_eq!(string["start"], quote);
+    assert_eq!(string["end"], quote + "\"é\"".len());
+    assert_eq!(string["line"], 1);
+    assert_eq!(string["column"], 9);
+
+    assert!(
+        tokens
+            .iter()
+            .any(|token| token["kind"] == "LineComment" && token["lexeme"] == "// hi"),
+        "tokens should include comments: {tokens:?}"
+    );
+}

--- a/crates/harn-lexer/Cargo.toml
+++ b/crates/harn-lexer/Cargo.toml
@@ -7,4 +7,7 @@ repository.workspace = true
 homepage.workspace = true
 description = "Tokenizer with span tracking for the Harn programming language"
 
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+
 [dev-dependencies]

--- a/crates/harn-lexer/src/token.rs
+++ b/crates/harn-lexer/src/token.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 /// A segment of an interpolated string.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub enum StringSegment {
     Literal(String),
     /// An interpolated expression with its source position (line, column).
@@ -18,7 +18,7 @@ impl fmt::Display for StringSegment {
 }
 
 /// Source location for error reporting.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 pub struct Span {
     /// Byte offset from start of source (inclusive).
     pub start: usize,

--- a/crates/harn-parser/Cargo.toml
+++ b/crates/harn-parser/Cargo.toml
@@ -10,4 +10,5 @@ description = "Parser, AST, and type checker for the Harn programming language"
 [dependencies]
 harn-lexer = { path = "../harn-lexer", version = "0.8" }
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 yansi = "1"

--- a/crates/harn-parser/src/ast.rs
+++ b/crates/harn-parser/src/ast.rs
@@ -1,7 +1,7 @@
 use harn_lexer::{Span, StringSegment};
 
 /// A node wrapped with source location information.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub struct Spanned<T> {
     pub node: T,
     pub span: Span,
@@ -43,7 +43,7 @@ pub fn peel_attributes(node: &SNode) -> (&[Attribute], &SNode) {
 /// named args use `name: Some("key")`. Values are restricted to
 /// compile-time metadata expressions by the parser (literal scalars,
 /// identifiers, lists, dicts, and call-shaped sentinels).
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub struct AttributeArg {
     pub name: Option<String>,
     pub value: SNode,
@@ -51,7 +51,7 @@ pub struct AttributeArg {
 }
 
 /// An attribute attached to a declaration: `@deprecated(since: "0.8")`.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub struct Attribute {
     pub name: String,
     pub args: Vec<AttributeArg>,
@@ -87,7 +87,7 @@ impl Attribute {
 }
 
 /// AST nodes for the Harn language.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub enum Node {
     /// A declaration carrying one or more attributes (`@attr`). The inner
     /// node is always one of: FnDecl, ToolDecl, Pipeline, StructDecl,
@@ -459,7 +459,7 @@ pub enum Node {
 /// semantics: the names cannot be shadowed or rebound by user code,
 /// signatures are produced by the VM, and the audit log is recorded
 /// deterministically by the runtime.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize)]
 pub enum HitlKind {
     /// `request_approval(action: ..., args: ..., quorum: ..., reviewers: ..., ...)`.
     RequestApproval,
@@ -487,7 +487,7 @@ impl HitlKind {
 /// A single argument in a [`Node::HitlExpr`] call. `name` is `Some` when
 /// the caller used named-arg syntax (e.g. `quorum: 2`); positional
 /// arguments leave it as `None` and rely on the kind's parameter order.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub struct HitlArg {
     pub name: Option<String>,
     pub value: SNode,
@@ -495,7 +495,7 @@ pub struct HitlArg {
 }
 
 /// Parallel execution mode.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize)]
 pub enum ParallelMode {
     /// `parallel N { i -> ... }` — run N concurrent tasks.
     Count,
@@ -507,7 +507,7 @@ pub enum ParallelMode {
     Settle,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub struct MatchArm {
     pub pattern: SNode,
     /// Optional guard: `pattern if condition -> { body }`.
@@ -515,28 +515,28 @@ pub struct MatchArm {
     pub body: Vec<SNode>,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub struct SelectCase {
     pub variable: String,
     pub channel: Box<SNode>,
     pub body: Vec<SNode>,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub struct DictEntry {
     pub key: SNode,
     pub value: SNode,
 }
 
 /// An enum variant declaration.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub struct EnumVariant {
     pub name: String,
     pub fields: Vec<TypedParam>,
 }
 
 /// A struct field declaration.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub struct StructField {
     pub name: String,
     pub type_expr: Option<TypeExpr>,
@@ -544,7 +544,7 @@ pub struct StructField {
 }
 
 /// An interface method signature.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub struct InterfaceMethod {
     pub name: String,
     pub type_params: Vec<TypeParam>,
@@ -604,7 +604,7 @@ pub struct ShapeField {
 }
 
 /// A binding pattern for destructuring in let/var/for-in.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub enum BindingPattern {
     /// Simple identifier: `let x = ...`
     Identifier(String),
@@ -623,7 +623,7 @@ pub fn is_discard_name(name: &str) -> bool {
 }
 
 /// A field in a dict destructuring pattern.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub struct DictPatternField {
     /// The dict key to extract.
     pub key: String,
@@ -636,7 +636,7 @@ pub struct DictPatternField {
 }
 
 /// An element in a list destructuring pattern.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub struct ListPatternElement {
     /// The variable name to bind.
     pub name: String,
@@ -657,7 +657,7 @@ pub struct ListPatternElement {
 /// - `Contravariant` (`in T`): the parameter appears only in input
 ///   positions (consumed, not produced). `T<Super>` flows into
 ///   `T<Sub>`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 pub enum Variance {
     Invariant,
     Covariant,
@@ -665,7 +665,7 @@ pub enum Variance {
 }
 
 /// A generic type parameter on a function or pipeline declaration.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub struct TypeParam {
     pub name: String,
     pub variance: Variance,
@@ -683,14 +683,14 @@ impl TypeParam {
 }
 
 /// A where-clause constraint on a generic type parameter.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub struct WhereClause {
     pub type_name: String,
     pub bound: String,
 }
 
 /// A parameter with an optional type annotation and optional default value.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub struct TypedParam {
     pub name: String,
     pub type_expr: Option<TypeExpr>,

--- a/crates/harn-parser/src/ast_json.rs
+++ b/crates/harn-parser/src/ast_json.rs
@@ -1,0 +1,311 @@
+//! Stable JSON projections for parser-facing tooling.
+//!
+//! The core AST keeps its Rust-native shape for compiler consumers.
+//! This module owns the CLI/tooling projection so `harn parse --json`
+//! and `harn tokens --json` can evolve under explicit schema versions.
+
+use harn_lexer::{Span, Token, TokenKind};
+use serde::Serialize;
+use serde_json::{Map, Value};
+
+use crate::SNode;
+
+pub const AST_JSON_SCHEMA_VERSION: u32 = 1;
+pub const TOKEN_JSON_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct AstJsonProgram {
+    pub kind: &'static str,
+    #[serde(rename = "schemaVersion")]
+    pub schema_version: u32,
+    pub body: Vec<Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct TokenJson {
+    pub kind: &'static str,
+    pub lexeme: String,
+    pub start: usize,
+    pub end: usize,
+    pub line: usize,
+    pub column: usize,
+}
+
+pub fn program_to_json(nodes: &[SNode]) -> AstJsonProgram {
+    AstJsonProgram {
+        kind: "Program",
+        schema_version: AST_JSON_SCHEMA_VERSION,
+        body: nodes.iter().map(node_to_json).collect(),
+    }
+}
+
+pub fn node_to_json(node: &SNode) -> Value {
+    let raw = serde_json::to_value(node).expect("AST node should serialize to JSON");
+    normalize_value(raw)
+}
+
+pub fn tokens_to_json(source: &str, tokens: &[Token]) -> Vec<TokenJson> {
+    tokens
+        .iter()
+        .map(|token| token_to_json(source, token))
+        .collect()
+}
+
+pub fn token_to_json(source: &str, token: &Token) -> TokenJson {
+    TokenJson {
+        kind: token_kind_name(&token.kind),
+        lexeme: lexeme_for_span(source, token.span),
+        start: token.span.start,
+        end: token.span.end,
+        line: token.span.line,
+        column: token.span.column,
+    }
+}
+
+pub fn token_kind_name(kind: &TokenKind) -> &'static str {
+    match kind {
+        TokenKind::Pipeline => "Pipeline",
+        TokenKind::Extends => "Extends",
+        TokenKind::Override => "Override",
+        TokenKind::Let => "Let",
+        TokenKind::Var => "Var",
+        TokenKind::If => "If",
+        TokenKind::Else => "Else",
+        TokenKind::For => "For",
+        TokenKind::In => "In",
+        TokenKind::Match => "Match",
+        TokenKind::Retry => "Retry",
+        TokenKind::Parallel => "Parallel",
+        TokenKind::Return => "Return",
+        TokenKind::Import => "Import",
+        TokenKind::True => "True",
+        TokenKind::False => "False",
+        TokenKind::Nil => "Nil",
+        TokenKind::Try => "Try",
+        TokenKind::Catch => "Catch",
+        TokenKind::Throw => "Throw",
+        TokenKind::Finally => "Finally",
+        TokenKind::Fn => "Fn",
+        TokenKind::Spawn => "Spawn",
+        TokenKind::While => "While",
+        TokenKind::TypeKw => "TypeKw",
+        TokenKind::Enum => "Enum",
+        TokenKind::EvalPack => "EvalPack",
+        TokenKind::Struct => "Struct",
+        TokenKind::Interface => "Interface",
+        TokenKind::Emit => "Emit",
+        TokenKind::Pub => "Pub",
+        TokenKind::From => "From",
+        TokenKind::To => "To",
+        TokenKind::Tool => "Tool",
+        TokenKind::Exclusive => "Exclusive",
+        TokenKind::Guard => "Guard",
+        TokenKind::Require => "Require",
+        TokenKind::Deadline => "Deadline",
+        TokenKind::Defer => "Defer",
+        TokenKind::Yield => "Yield",
+        TokenKind::Mutex => "Mutex",
+        TokenKind::Break => "Break",
+        TokenKind::Continue => "Continue",
+        TokenKind::Select => "Select",
+        TokenKind::Impl => "Impl",
+        TokenKind::Skill => "Skill",
+        TokenKind::RequestApproval => "RequestApproval",
+        TokenKind::DualControl => "DualControl",
+        TokenKind::AskUser => "AskUser",
+        TokenKind::EscalateTo => "EscalateTo",
+        TokenKind::Identifier(_) => "Identifier",
+        TokenKind::StringLiteral(_) => "StringLiteral",
+        TokenKind::InterpolatedString(_) => "InterpolatedString",
+        TokenKind::RawStringLiteral(_) => "RawStringLiteral",
+        TokenKind::IntLiteral(_) => "IntLiteral",
+        TokenKind::FloatLiteral(_) => "FloatLiteral",
+        TokenKind::DurationLiteral(_) => "DurationLiteral",
+        TokenKind::Eq => "Eq",
+        TokenKind::Neq => "Neq",
+        TokenKind::And => "And",
+        TokenKind::Or => "Or",
+        TokenKind::Pipe => "Pipe",
+        TokenKind::NilCoal => "NilCoal",
+        TokenKind::Pow => "Pow",
+        TokenKind::QuestionDot => "QuestionDot",
+        TokenKind::Arrow => "Arrow",
+        TokenKind::Lte => "Lte",
+        TokenKind::Gte => "Gte",
+        TokenKind::PlusAssign => "PlusAssign",
+        TokenKind::MinusAssign => "MinusAssign",
+        TokenKind::StarAssign => "StarAssign",
+        TokenKind::SlashAssign => "SlashAssign",
+        TokenKind::PercentAssign => "PercentAssign",
+        TokenKind::Assign => "Assign",
+        TokenKind::Not => "Not",
+        TokenKind::Dot => "Dot",
+        TokenKind::Plus => "Plus",
+        TokenKind::Minus => "Minus",
+        TokenKind::Star => "Star",
+        TokenKind::Slash => "Slash",
+        TokenKind::Percent => "Percent",
+        TokenKind::Lt => "Lt",
+        TokenKind::Gt => "Gt",
+        TokenKind::Question => "Question",
+        TokenKind::Bar => "Bar",
+        TokenKind::Amp => "Amp",
+        TokenKind::LBrace => "LBrace",
+        TokenKind::RBrace => "RBrace",
+        TokenKind::LParen => "LParen",
+        TokenKind::RParen => "RParen",
+        TokenKind::LBracket => "LBracket",
+        TokenKind::RBracket => "RBracket",
+        TokenKind::Comma => "Comma",
+        TokenKind::Colon => "Colon",
+        TokenKind::Semicolon => "Semicolon",
+        TokenKind::At => "At",
+        TokenKind::LineComment { .. } => "LineComment",
+        TokenKind::BlockComment { .. } => "BlockComment",
+        TokenKind::Newline => "Newline",
+        TokenKind::Eof => "Eof",
+    }
+}
+
+fn lexeme_for_span(source: &str, span: Span) -> String {
+    source
+        .get(span.start..span.end)
+        .unwrap_or_default()
+        .to_string()
+}
+
+fn normalize_value(value: Value) -> Value {
+    match value {
+        Value::Array(values) => Value::Array(values.into_iter().map(normalize_value).collect()),
+        Value::Object(map) => normalize_object(map),
+        other => other,
+    }
+}
+
+fn normalize_object(mut map: Map<String, Value>) -> Value {
+    if is_span_map(&map) {
+        return normalize_span_map(map);
+    }
+
+    if is_spanned_map(&map) {
+        return normalize_spanned_map(map);
+    }
+
+    if map.len() == 1 {
+        let key = map.keys().next().cloned().expect("map has one key");
+        if is_variant_name(&key) {
+            let fields = map.remove(&key).expect("variant payload is present");
+            return tagged_value(key, normalize_value(fields));
+        }
+    }
+
+    for value in map.values_mut() {
+        let raw = std::mem::take(value);
+        *value = normalize_value(raw);
+    }
+    Value::Object(map)
+}
+
+fn normalize_spanned_map(mut map: Map<String, Value>) -> Value {
+    let node = map.remove("node").expect("spanned node is present");
+    let span = map.remove("span").expect("spanned span is present");
+    let mut normalized = normalize_enum_value(node);
+    if let Value::Object(object) = &mut normalized {
+        object.insert("span".to_string(), normalize_value(span));
+    }
+    normalized
+}
+
+fn normalize_enum_value(value: Value) -> Value {
+    match value {
+        Value::Object(mut map) if map.len() == 1 => {
+            let key = map.keys().next().cloned().expect("map has one key");
+            let fields = map.remove(&key).expect("variant payload is present");
+            tagged_value(key, normalize_value(fields))
+        }
+        Value::String(kind) if is_variant_name(&kind) => tagged_value(kind, Value::Null),
+        other => normalize_value(other),
+    }
+}
+
+fn tagged_value(kind: String, fields: Value) -> Value {
+    let mut object = Map::new();
+    object.insert("kind".to_string(), Value::String(kind));
+    object.insert("fields".to_string(), fields);
+    Value::Object(object)
+}
+
+fn normalize_span_map(mut map: Map<String, Value>) -> Value {
+    if let Some(end_line) = map.remove("end_line") {
+        map.insert("endLine".to_string(), end_line);
+    }
+    Value::Object(map)
+}
+
+fn is_spanned_map(map: &Map<String, Value>) -> bool {
+    map.len() == 2 && map.contains_key("node") && map.contains_key("span")
+}
+
+fn is_span_map(map: &Map<String, Value>) -> bool {
+    map.len() == 5
+        && map.contains_key("start")
+        && map.contains_key("end")
+        && map.contains_key("line")
+        && map.contains_key("column")
+        && map.contains_key("end_line")
+}
+
+fn is_variant_name(name: &str) -> bool {
+    name.chars()
+        .next()
+        .is_some_and(|ch| ch.is_ascii_uppercase())
+}
+
+#[cfg(test)]
+mod tests {
+    use harn_lexer::Lexer;
+
+    use super::*;
+    use crate::parse_source;
+
+    #[test]
+    fn program_json_projects_tagged_nodes_with_spans() {
+        let source = "pipeline main(task) {\n  return 1\n}\n";
+        let program = parse_source(source).expect("parse");
+
+        let json = program_to_json(&program);
+
+        assert_eq!(json.kind, "Program");
+        assert_eq!(json.schema_version, AST_JSON_SCHEMA_VERSION);
+        let pipeline = &json.body[0];
+        assert_eq!(pipeline["kind"], "Pipeline");
+        assert_eq!(pipeline["span"]["start"], 0);
+        assert_eq!(pipeline["span"]["line"], 1);
+        assert_eq!(pipeline["fields"]["name"], "main");
+        assert_eq!(pipeline["fields"]["body"][0]["kind"], "ReturnStmt");
+        assert_eq!(
+            pipeline["fields"]["body"][0]["fields"]["value"]["kind"],
+            "IntLiteral"
+        );
+    }
+
+    #[test]
+    fn token_json_preserves_byte_spans_and_lexemes() {
+        let source = "let x = \"é\"\n";
+        let mut lexer = Lexer::new(source);
+        let tokens = lexer.tokenize_with_comments().expect("tokenize");
+
+        let json = tokens_to_json(source, &tokens);
+        let string = json
+            .iter()
+            .find(|token| token.kind == "StringLiteral")
+            .expect("string literal token");
+
+        let quote = source.find('"').expect("opening quote");
+        assert_eq!(string.lexeme, "\"é\"");
+        assert_eq!(string.start, quote);
+        assert_eq!(string.end, quote + "\"é\"".len());
+        assert_eq!(string.line, 1);
+        assert_eq!(string.column, 9);
+    }
+}

--- a/crates/harn-parser/src/lib.rs
+++ b/crates/harn-parser/src/lib.rs
@@ -1,4 +1,5 @@
 mod ast;
+pub mod ast_json;
 pub mod builtin_signatures;
 pub mod diagnostic;
 pub mod diagnostic_codes;

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -102,6 +102,34 @@ headers, signs the receipt with an Ed25519 key loaded through the configured
 secret provider chain, and writes the receipt under `.harn/receipts/` unless
 `--receipt-out` is set.
 
+## harn parse
+
+Parse a `.harn` file without type-checking or running it.
+
+```bash
+harn parse main.harn
+harn parse main.harn --json
+harn parse examples/hello.harn --json | jq .data.kind
+```
+
+Text mode prints the debug AST. `--json` emits a `JsonEnvelope` with
+`schemaVersion: 1`; `data.kind` is `Program`, `data.body[]` contains tagged
+AST nodes, and each node carries a byte span.
+
+## harn tokens
+
+Tokenize a `.harn` file.
+
+```bash
+harn tokens main.harn
+harn tokens main.harn --json
+```
+
+Text mode prints one token per line with line/column and byte ranges.
+`--json` emits a `JsonEnvelope` with `schemaVersion: 1`; `data[]` entries are
+`{ kind, lexeme, start, end, line, column }`. `start` and `end` are byte
+offsets into the original source.
+
 ## harn verify
 
 Verify a signed Harn provenance receipt.


### PR DESCRIPTION
## Summary
- add `harn parse <path> [--json]` and `harn tokens <path> [--json]`
- expose parser-owned AST/token JSON projections with schema version 1
- register both commands in `harn --json-schemas` and document the CLI surface

Closes #1757.

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/tmp/harn-target-1757 HARN_LLM_CALLS_DISABLED=1 cargo test -p harn-parser ast_json --lib`
- `CARGO_TARGET_DIR=/tmp/harn-target-1757 HARN_LLM_CALLS_DISABLED=1 cargo test -p harn-cli test_parses_parse_and_tokens_json --lib`
- `CARGO_TARGET_DIR=/tmp/harn-target-1757 HARN_LLM_CALLS_DISABLED=1 cargo test -p harn-cli text_token_line_includes_span_kind_and_lexeme --lib`
- `CARGO_TARGET_DIR=/tmp/harn-target-1757 HARN_LLM_CALLS_DISABLED=1 cargo test -p harn-cli --test parse_tokens_cli`
- `CARGO_TARGET_DIR=/tmp/harn-target-1757 HARN_LLM_CALLS_DISABLED=1 cargo test -p harn-cli --test json_schemas_cli`
- `CARGO_TARGET_DIR=/tmp/harn-target-1757 HARN_LLM_CALLS_DISABLED=1 cargo clippy -p harn-lexer -p harn-parser -p harn-cli --all-targets -- -D warnings`
- pre-push hook: targeted local checks, markdown lint, highlight drift check
