### PR TITLE
Add LSP repair metadata to code actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ condensed series summaries instead of full per-patch history.
   or `{ kind, lexeme, start, end, line, column }` entries in `--json`
   mode. Both structured surfaces use the standard `JsonEnvelope` and
   register in `harn --json-schemas`.
+- **LSP repair metadata for quick fixes (#1750).** Harn LSP diagnostics now
+  include flat `data.code`, `data.repair_id`, and `data.safety` fields
+  alongside the existing nested repair envelope. Repair-backed code actions use
+  `quickfix.harn.<safety>` kinds and carry `{ repair_id, safety,
+  diagnostic_code }` data so IDE clients can dispatch without parsing
+  diagnostic prose.
 
 ## v0.8.25
 

--- a/crates/harn-lsp/src/document.rs
+++ b/crates/harn-lsp/src/document.rs
@@ -3,7 +3,7 @@ use harn_parser::{Parser, SNode, TypeChecker};
 use tower_lsp::lsp_types::*;
 
 use crate::helpers::{
-    lexer_error_to_diagnostic, parser_error_to_diagnostic, repair_data_value, span_to_range,
+    diagnostic_data_value, lexer_error_to_diagnostic, parser_error_to_diagnostic, span_to_range,
 };
 use crate::symbols::{build_symbol_table, SymbolInfo};
 
@@ -99,7 +99,10 @@ impl DocumentState {
                 source: Some("harn-typecheck".to_string()),
                 code: Some(NumberOrString::String(diag.code.to_string())),
                 message: diag.message.clone(),
-                data: repair_data_value(diag.repair.as_ref()),
+                data: Some(diagnostic_data_value(
+                    diag.code.to_string(),
+                    diag.repair.as_ref(),
+                )),
                 ..Default::default()
             });
         }
@@ -132,7 +135,10 @@ impl DocumentState {
                 source: Some("harn-lint".to_string()),
                 code: Some(NumberOrString::String(ld.code.to_string())),
                 message: format!("[{}] {}", ld.rule, ld.message),
-                data: repair_data_value(lint_repair.as_ref()),
+                data: Some(diagnostic_data_value(
+                    ld.code.to_string(),
+                    lint_repair.as_ref(),
+                )),
                 ..Default::default()
             });
         }
@@ -216,6 +222,14 @@ fn handler() {
             })
             .expect("expected ImmutableAssignment diagnostic");
         let data = diag.data.as_ref().expect("repair data should be attached");
+        assert_eq!(
+            data.get("code").and_then(|v| v.as_str()),
+            Some("HARN-OWN-001")
+        );
+        assert_eq!(
+            data.get("repair_id").and_then(|v| v.as_str()),
+            Some("bindings/make-mutable")
+        );
         let repair = data.get("repair").expect("data.repair should be present");
         assert_eq!(
             repair.get("id").and_then(|v| v.as_str()),

--- a/crates/harn-lsp/src/handlers/formatting.rs
+++ b/crates/harn-lsp/src/handlers/formatting.rs
@@ -6,8 +6,9 @@ use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
 
 use crate::helpers::{
-    extract_backtick_name, find_word_in_region, lsp_position_to_offset, offset_to_position,
-    span_to_range,
+    diagnostic_repair_code_action_data, diagnostic_repair_code_action_kind, extract_backtick_name,
+    find_word_in_region, lsp_position_to_offset, offset_to_position, repair_code_action_data,
+    repair_code_action_kind, span_to_range,
 };
 use crate::HarnLsp;
 
@@ -53,13 +54,12 @@ impl HarnLsp {
         params: CodeActionParams,
     ) -> Result<Option<CodeActionResponse>> {
         let uri = &params.text_document.uri;
-        let mut actions = Vec::new();
 
         let (source, lint_diags, type_diags) = {
             let docs = self.documents.lock().unwrap();
             let state = match docs.get(uri) {
                 Some(s) => s,
-                None => return Ok(Some(actions)),
+                None => return Ok(Some(Vec::new())),
             };
             (
                 state.source.clone(),
@@ -68,49 +68,96 @@ impl HarnLsp {
             )
         };
 
-        for diag in &params.context.diagnostics {
-            let msg = &diag.message;
+        let actions = build_code_actions(uri, &source, &lint_diags, &type_diags, &params.context);
 
-            if let Some(ld) = lint_diags.iter().find(|ld| {
-                msg.contains(&format!("[{}]", ld.rule)) && span_to_range(&ld.span) == diag.range
+        Ok(Some(actions))
+    }
+}
+
+fn build_code_actions(
+    uri: &Url,
+    source: &str,
+    lint_diags: &[harn_lint::LintDiagnostic],
+    type_diags: &[harn_parser::TypeDiagnostic],
+    context: &CodeActionContext,
+) -> CodeActionResponse {
+    let mut actions = Vec::new();
+
+    for diag in &context.diagnostics {
+        let msg = &diag.message;
+
+        if let Some(ld) = lint_diags.iter().find(|ld| {
+            msg.contains(&format!("[{}]", ld.rule)) && span_to_range(&ld.span) == diag.range
+        }) {
+            if let Some(ref fix_edits) = ld.fix {
+                let repair = ld.repair();
+                let text_edits: Vec<TextEdit> = fix_edits
+                    .iter()
+                    .map(|fe| TextEdit {
+                        range: Range {
+                            start: offset_to_position(source, fe.span.start),
+                            end: offset_to_position(source, fe.span.end),
+                        },
+                        new_text: fe.replacement.clone(),
+                    })
+                    .collect();
+
+                let title = match ld.rule {
+                    "mutable-never-reassigned" => "Change `var` to `let`".to_string(),
+                    "comparison-to-bool" => "Simplify boolean comparison".to_string(),
+                    "unnecessary-else-return" => "Remove unnecessary else".to_string(),
+                    "unused-import" => {
+                        let name = extract_backtick_name(msg).unwrap_or_else(|| "name".to_string());
+                        format!("Remove unused import `{name}`")
+                    }
+                    "invalid-binary-op-literal" => "Convert to string interpolation".to_string(),
+                    "unnecessary-cast" => "Remove unnecessary cast".to_string(),
+                    _ => ld
+                        .suggestion
+                        .clone()
+                        .unwrap_or_else(|| "Apply fix".to_string()),
+                };
+
+                let mut changes = HashMap::new();
+                changes.insert(uri.clone(), text_edits);
+                actions.push(CodeActionOrCommand::CodeAction(CodeAction {
+                    title,
+                    kind: Some(repair_code_action_kind(repair.as_ref())),
+                    diagnostics: Some(vec![diag.clone()]),
+                    data: repair_code_action_data(diag, repair.as_ref()),
+                    edit: Some(WorkspaceEdit {
+                        changes: Some(changes),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }));
+                continue;
+            }
+        }
+
+        if diag.source.as_deref() == Some("harn-typecheck") {
+            if let Some(td) = type_diags.iter().find(|td| {
+                td.message == *msg && td.span.as_ref().map(span_to_range) == Some(diag.range)
             }) {
-                if let Some(ref fix_edits) = ld.fix {
+                if let Some(ref fix_edits) = td.fix {
                     let text_edits: Vec<TextEdit> = fix_edits
                         .iter()
                         .map(|fe| TextEdit {
                             range: Range {
-                                start: offset_to_position(&source, fe.span.start),
-                                end: offset_to_position(&source, fe.span.end),
+                                start: offset_to_position(source, fe.span.start),
+                                end: offset_to_position(source, fe.span.end),
                             },
                             new_text: fe.replacement.clone(),
                         })
                         .collect();
 
-                    let title = match ld.rule {
-                        "mutable-never-reassigned" => "Change `var` to `let`".to_string(),
-                        "comparison-to-bool" => "Simplify boolean comparison".to_string(),
-                        "unnecessary-else-return" => "Remove unnecessary else".to_string(),
-                        "unused-import" => {
-                            let name =
-                                extract_backtick_name(msg).unwrap_or_else(|| "name".to_string());
-                            format!("Remove unused import `{name}`")
-                        }
-                        "invalid-binary-op-literal" => {
-                            "Convert to string interpolation".to_string()
-                        }
-                        "unnecessary-cast" => "Remove unnecessary cast".to_string(),
-                        _ => ld
-                            .suggestion
-                            .clone()
-                            .unwrap_or_else(|| "Apply fix".to_string()),
-                    };
-
                     let mut changes = HashMap::new();
                     changes.insert(uri.clone(), text_edits);
                     actions.push(CodeActionOrCommand::CodeAction(CodeAction {
-                        title,
-                        kind: Some(CodeActionKind::QUICKFIX),
+                        title: "Convert to string interpolation".to_string(),
+                        kind: Some(repair_code_action_kind(td.repair.as_ref())),
                         diagnostics: Some(vec![diag.clone()]),
+                        data: repair_code_action_data(diag, td.repair.as_ref()),
                         edit: Some(WorkspaceEdit {
                             changes: Some(changes),
                             ..Default::default()
@@ -119,170 +166,139 @@ impl HarnLsp {
                     }));
                     continue;
                 }
-            }
 
-            if diag.source.as_deref() == Some("harn-typecheck") {
-                if let Some(td) = type_diags.iter().find(|td| {
-                    td.message == *msg && td.span.as_ref().map(span_to_range) == Some(diag.range)
-                }) {
-                    if let Some(ref fix_edits) = td.fix {
-                        let text_edits: Vec<TextEdit> = fix_edits
-                            .iter()
-                            .map(|fe| TextEdit {
-                                range: Range {
-                                    start: offset_to_position(&source, fe.span.start),
-                                    end: offset_to_position(&source, fe.span.end),
-                                },
-                                new_text: fe.replacement.clone(),
-                            })
-                            .collect();
-
+                // Non-exhaustive match: synthesise an "Add missing
+                // arms" quick-fix from the structured details on
+                // the diagnostic. The diagnostic's span covers the
+                // whole `match` expression, so the closing `}`
+                // sits at `span.end - 1`. We insert `arm_indent`
+                // + pattern + `-> { unreachable(...) }` right
+                // before the `}`, using the closing brace's
+                // column as the reference indent.
+                if let (
+                    Some(harn_parser::DiagnosticDetails::NonExhaustiveMatch { missing }),
+                    Some(span),
+                ) = (td.details.as_ref(), td.span.as_ref())
+                {
+                    if let Some(edit) = build_missing_arms_edit(source, span, missing) {
                         let mut changes = HashMap::new();
-                        changes.insert(uri.clone(), text_edits);
+                        changes.insert(uri.clone(), vec![edit]);
                         actions.push(CodeActionOrCommand::CodeAction(CodeAction {
-                            title: "Convert to string interpolation".to_string(),
-                            kind: Some(CodeActionKind::QUICKFIX),
+                            title: if missing.len() == 1 {
+                                format!("Add missing match arm {}", missing[0])
+                            } else {
+                                format!("Add missing match arms ({})", missing.len())
+                            },
+                            kind: Some(repair_code_action_kind(td.repair.as_ref())),
                             diagnostics: Some(vec![diag.clone()]),
+                            data: repair_code_action_data(diag, td.repair.as_ref()),
                             edit: Some(WorkspaceEdit {
                                 changes: Some(changes),
                                 ..Default::default()
                             }),
+                            is_preferred: Some(true),
                             ..Default::default()
                         }));
                         continue;
                     }
-
-                    // Non-exhaustive match: synthesise an "Add missing
-                    // arms" quick-fix from the structured details on
-                    // the diagnostic. The diagnostic's span covers the
-                    // whole `match` expression, so the closing `}`
-                    // sits at `span.end - 1`. We insert `arm_indent`
-                    // + pattern + `-> { unreachable(...) }` right
-                    // before the `}`, using the closing brace's
-                    // column as the reference indent.
-                    if let (
-                        Some(harn_parser::DiagnosticDetails::NonExhaustiveMatch { missing }),
-                        Some(span),
-                    ) = (td.details.as_ref(), td.span.as_ref())
-                    {
-                        if let Some(edit) = build_missing_arms_edit(&source, span, missing) {
-                            let mut changes = HashMap::new();
-                            changes.insert(uri.clone(), vec![edit]);
-                            actions.push(CodeActionOrCommand::CodeAction(CodeAction {
-                                title: if missing.len() == 1 {
-                                    format!("Add missing match arm {}", missing[0])
-                                } else {
-                                    format!("Add missing match arms ({})", missing.len())
-                                },
-                                kind: Some(CodeActionKind::QUICKFIX),
-                                diagnostics: Some(vec![diag.clone()]),
-                                edit: Some(WorkspaceEdit {
-                                    changes: Some(changes),
-                                    ..Default::default()
-                                }),
-                                is_preferred: Some(true),
-                                ..Default::default()
-                            }));
-                            continue;
-                        }
-                    }
                 }
             }
+        }
 
-            // Fallback manual code actions for rules without structured fixes.
-            if msg.contains("[unused-variable]") || msg.contains("[unused-parameter]") {
-                if let Some(name) = extract_backtick_name(msg) {
-                    let offset = lsp_position_to_offset(&source, diag.range.start);
-                    let end_offset = lsp_position_to_offset(&source, diag.range.end)
-                        .max(offset + 1)
-                        .min(source.len());
-                    let search_region = &source[offset..end_offset];
-                    if let Some(name_pos) = find_word_in_region(search_region, &name) {
-                        let abs_pos = offset + name_pos;
-                        let start = offset_to_position(&source, abs_pos);
-                        let end = offset_to_position(&source, abs_pos + name.len());
-                        let edit_range = Range { start, end };
+        // Fallback manual code actions for rules without structured fixes.
+        if msg.contains("[unused-variable]") || msg.contains("[unused-parameter]") {
+            if let Some(name) = extract_backtick_name(msg) {
+                let offset = lsp_position_to_offset(source, diag.range.start);
+                let end_offset = lsp_position_to_offset(source, diag.range.end)
+                    .max(offset + 1)
+                    .min(source.len());
+                let search_region = &source[offset..end_offset];
+                if let Some(name_pos) = find_word_in_region(search_region, &name) {
+                    let abs_pos = offset + name_pos;
+                    let start = offset_to_position(source, abs_pos);
+                    let end = offset_to_position(source, abs_pos + name.len());
+                    let edit_range = Range { start, end };
 
-                        let mut changes = HashMap::new();
-                        changes.insert(
-                            uri.clone(),
-                            vec![TextEdit {
-                                range: edit_range,
-                                new_text: format!("_{name}"),
-                            }],
-                        );
-                        let label = if msg.contains("[unused-variable]") {
-                            "variable"
-                        } else {
-                            "parameter"
-                        };
-                        actions.push(CodeActionOrCommand::CodeAction(CodeAction {
-                            title: format!("Prefix {label} `{name}` with `_`"),
-                            kind: Some(CodeActionKind::QUICKFIX),
-                            diagnostics: Some(vec![diag.clone()]),
-                            edit: Some(WorkspaceEdit {
-                                changes: Some(changes),
-                                ..Default::default()
-                            }),
+                    let mut changes = HashMap::new();
+                    changes.insert(
+                        uri.clone(),
+                        vec![TextEdit {
+                            range: edit_range,
+                            new_text: format!("_{name}"),
+                        }],
+                    );
+                    let label = if msg.contains("[unused-variable]") {
+                        "variable"
+                    } else {
+                        "parameter"
+                    };
+                    actions.push(CodeActionOrCommand::CodeAction(CodeAction {
+                        title: format!("Prefix {label} `{name}` with `_`"),
+                        kind: Some(diagnostic_repair_code_action_kind(diag)),
+                        diagnostics: Some(vec![diag.clone()]),
+                        data: diagnostic_repair_code_action_data(diag),
+                        edit: Some(WorkspaceEdit {
+                            changes: Some(changes),
                             ..Default::default()
-                        }));
-                    }
-                }
-            }
-        }
-
-        if fix_all_requested(params.context.only.as_deref()) {
-            let mut all_edits: Vec<harn_lexer::FixEdit> = Vec::new();
-            for ld in &lint_diags {
-                if let Some(fix) = &ld.fix {
-                    all_edits.extend(fix.iter().cloned());
-                }
-            }
-            for td in &type_diags {
-                if let Some(fix) = &td.fix {
-                    all_edits.extend(fix.iter().cloned());
-                }
-            }
-            // Apply fixes right-to-left and drop overlaps to mirror the
-            // CLI's `harn lint --fix` semantics; this keeps the on-save
-            // path consistent with what `harn lint --fix` would produce.
-            all_edits.sort_by_key(|e| std::cmp::Reverse(e.span.start));
-            let mut accepted: Vec<harn_lexer::FixEdit> = Vec::new();
-            for edit in all_edits {
-                let overlaps = accepted
-                    .iter()
-                    .any(|prev| edit.span.start < prev.span.end && edit.span.end > prev.span.start);
-                if !overlaps {
-                    accepted.push(edit);
-                }
-            }
-            if !accepted.is_empty() {
-                let text_edits: Vec<TextEdit> = accepted
-                    .iter()
-                    .map(|fe| TextEdit {
-                        range: Range {
-                            start: offset_to_position(&source, fe.span.start),
-                            end: offset_to_position(&source, fe.span.end),
-                        },
-                        new_text: fe.replacement.clone(),
-                    })
-                    .collect();
-                let mut changes = HashMap::new();
-                changes.insert(uri.clone(), text_edits);
-                actions.push(CodeActionOrCommand::CodeAction(CodeAction {
-                    title: "Apply all Harn autofixes".to_string(),
-                    kind: Some(CodeActionKind::new("source.fixAll.harn")),
-                    edit: Some(WorkspaceEdit {
-                        changes: Some(changes),
+                        }),
                         ..Default::default()
-                    }),
-                    ..Default::default()
-                }));
+                    }));
+                }
             }
         }
-
-        Ok(Some(actions))
     }
+
+    if fix_all_requested(context.only.as_deref()) {
+        let mut all_edits: Vec<harn_lexer::FixEdit> = Vec::new();
+        for ld in lint_diags {
+            if let Some(fix) = &ld.fix {
+                all_edits.extend(fix.iter().cloned());
+            }
+        }
+        for td in type_diags {
+            if let Some(fix) = &td.fix {
+                all_edits.extend(fix.iter().cloned());
+            }
+        }
+        // Apply fixes right-to-left and drop overlaps to mirror the
+        // CLI's `harn lint --fix` semantics; this keeps the on-save
+        // path consistent with what `harn lint --fix` would produce.
+        all_edits.sort_by_key(|e| std::cmp::Reverse(e.span.start));
+        let mut accepted: Vec<harn_lexer::FixEdit> = Vec::new();
+        for edit in all_edits {
+            let overlaps = accepted
+                .iter()
+                .any(|prev| edit.span.start < prev.span.end && edit.span.end > prev.span.start);
+            if !overlaps {
+                accepted.push(edit);
+            }
+        }
+        if !accepted.is_empty() {
+            let text_edits: Vec<TextEdit> = accepted
+                .iter()
+                .map(|fe| TextEdit {
+                    range: Range {
+                        start: offset_to_position(source, fe.span.start),
+                        end: offset_to_position(source, fe.span.end),
+                    },
+                    new_text: fe.replacement.clone(),
+                })
+                .collect();
+            let mut changes = HashMap::new();
+            changes.insert(uri.clone(), text_edits);
+            actions.push(CodeActionOrCommand::CodeAction(CodeAction {
+                title: "Apply all Harn autofixes".to_string(),
+                kind: Some(CodeActionKind::new("source.fixAll.harn")),
+                edit: Some(WorkspaceEdit {
+                    changes: Some(changes),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }));
+        }
+    }
+
+    actions
 }
 
 fn format_whole_document_edit(source: &str) -> Option<TextEdit> {
@@ -384,8 +400,67 @@ pub(super) fn build_missing_arms_edit(
 
 #[cfg(test)]
 mod tests {
-    use super::{build_missing_arms_edit, format_whole_document_edit};
+    use super::{build_code_actions, build_missing_arms_edit, format_whole_document_edit};
+    use crate::document::DocumentState;
     use harn_lexer::Span;
+    use tower_lsp::lsp_types::{CodeActionContext, CodeActionOrCommand, NumberOrString, Url};
+
+    #[test]
+    fn repair_quickfix_actions_carry_safety_kind_and_flat_data() {
+        let source =
+            "pipeline main() { let count = 1; let greeting = \"hello \" + count; greeting }\n";
+        let state = DocumentState::new(source.to_string());
+        let diagnostic = state
+            .diagnostics
+            .iter()
+            .find(|diagnostic| {
+                matches!(
+                    diagnostic.code.as_ref(),
+                    Some(NumberOrString::String(code)) if code == "HARN-TYP-003"
+                )
+            })
+            .expect("expected string-interpolation repair diagnostic")
+            .clone();
+        let uri = Url::parse("file:///workspace/main.harn").unwrap();
+        let context = CodeActionContext {
+            diagnostics: vec![diagnostic],
+            only: None,
+            trigger_kind: None,
+        };
+
+        let actions = build_code_actions(
+            &uri,
+            &state.source,
+            &state.lint_diagnostics,
+            &state.type_diagnostics,
+            &context,
+        );
+
+        let action = actions
+            .into_iter()
+            .find_map(|action| match action {
+                CodeActionOrCommand::CodeAction(action) => Some(action),
+                CodeActionOrCommand::Command(_) => None,
+            })
+            .expect("expected a code action");
+        assert_eq!(
+            action.kind.as_ref().map(|kind| kind.as_str()),
+            Some("quickfix.harn.behavior-preserving")
+        );
+        let data = action.data.as_ref().expect("repair action data");
+        assert_eq!(
+            data.get("repair_id").and_then(|value| value.as_str()),
+            Some("style/string-interpolation")
+        );
+        assert_eq!(
+            data.get("safety").and_then(|value| value.as_str()),
+            Some("behavior-preserving")
+        );
+        assert_eq!(
+            data.get("diagnostic_code").and_then(|value| value.as_str()),
+            Some("HARN-TYP-003")
+        );
+    }
 
     #[test]
     fn missing_arms_edit_inserts_each_variant_before_close_brace() {

--- a/crates/harn-lsp/src/helpers.rs
+++ b/crates/harn-lsp/src/helpers.rs
@@ -1,5 +1,6 @@
 use harn_lexer::{LexerError, Span};
 use harn_parser::{diagnostic, ParserError, Repair, TypeExpr};
+use serde_json::{Map, Value};
 use tower_lsp::lsp_types::*;
 
 use crate::symbols::SymbolInfo;
@@ -21,6 +22,96 @@ pub(crate) fn repair_data_value(repair: Option<&Repair>) -> Option<serde_json::V
             "safety": repair.safety.as_str(),
         }
     }))
+}
+
+/// Serialize the stable diagnostic metadata that rides on
+/// `Diagnostic.data`. The nested `repair` envelope is retained for
+/// existing clients; the flat fields are the newer code-action contract
+/// consumed by IDEs that dispatch directly on repair safety.
+pub(crate) fn diagnostic_data_value(
+    code: impl Into<String>,
+    repair: Option<&Repair>,
+) -> serde_json::Value {
+    let code = code.into();
+    let mut data = Map::new();
+    data.insert("code".to_string(), Value::String(code));
+    if let Some(repair) = repair {
+        data.insert(
+            "repair_id".to_string(),
+            Value::String(repair.id.as_str().to_string()),
+        );
+        data.insert(
+            "safety".to_string(),
+            Value::String(repair.safety.as_str().to_string()),
+        );
+        if let Some(mut repair_data) = repair_data_value(Some(repair)) {
+            if let Some(repair_payload) = repair_data.get_mut("repair") {
+                data.insert("repair".to_string(), std::mem::take(repair_payload));
+            }
+        }
+    }
+    Value::Object(data)
+}
+
+pub(crate) fn repair_code_action_kind(repair: Option<&Repair>) -> CodeActionKind {
+    repair
+        .map(|repair| repair_code_action_kind_for_safety(repair.safety.as_str()))
+        .unwrap_or(CodeActionKind::QUICKFIX)
+}
+
+pub(crate) fn repair_code_action_data(
+    diagnostic: &Diagnostic,
+    repair: Option<&Repair>,
+) -> Option<serde_json::Value> {
+    let repair = repair?;
+    Some(serde_json::json!({
+        "repair_id": repair.id.as_str(),
+        "safety": repair.safety.as_str(),
+        "diagnostic_code": diagnostic_code_string(diagnostic.code.as_ref()),
+    }))
+}
+
+pub(crate) fn diagnostic_repair_code_action_kind(diagnostic: &Diagnostic) -> CodeActionKind {
+    diagnostic
+        .data
+        .as_ref()
+        .and_then(|data| data.get("safety"))
+        .and_then(|value| value.as_str())
+        .map(repair_code_action_kind_for_safety)
+        .unwrap_or(CodeActionKind::QUICKFIX)
+}
+
+pub(crate) fn diagnostic_repair_code_action_data(
+    diagnostic: &Diagnostic,
+) -> Option<serde_json::Value> {
+    let data = diagnostic.data.as_ref()?;
+    let repair_id = data.get("repair_id")?.as_str()?;
+    let safety = data.get("safety")?.as_str()?;
+    Some(serde_json::json!({
+        "repair_id": repair_id,
+        "safety": safety,
+        "diagnostic_code": diagnostic_code_string(diagnostic.code.as_ref()),
+    }))
+}
+
+fn diagnostic_code_string(code: Option<&NumberOrString>) -> Option<String> {
+    match code {
+        Some(NumberOrString::String(code)) => Some(code.clone()),
+        Some(NumberOrString::Number(code)) => Some(code.to_string()),
+        None => None,
+    }
+}
+
+fn repair_code_action_kind_for_safety(safety: &str) -> CodeActionKind {
+    match safety {
+        "format-only" => CodeActionKind::new("quickfix.harn.format-only"),
+        "behavior-preserving" => CodeActionKind::new("quickfix.harn.behavior-preserving"),
+        "scope-local" => CodeActionKind::new("quickfix.harn.scope-local"),
+        "surface-changing" => CodeActionKind::new("quickfix.harn.surface-changing"),
+        "capability-changing" => CodeActionKind::new("quickfix.harn.capability-changing"),
+        "needs-human" => CodeActionKind::new("quickfix.harn.needs-human"),
+        _ => CodeActionKind::QUICKFIX,
+    }
 }
 
 /// Convert a 1-based Span to a 0-based LSP Range.


### PR DESCRIPTION
## Summary
- add flat `Diagnostic.data` metadata for Harn diagnostic code, repair id, and safety
- emit repair safety-specific code-action kinds such as `quickfix.harn.behavior-preserving`
- attach `{ repair_id, safety, diagnostic_code }` to repair-backed code actions and cover the shape in LSP tests

Closes #1750

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/tmp/harn-target-1750 HARN_LLM_CALLS_DISABLED=1 cargo test -p harn-lsp --bin harn-lsp`
- `CARGO_TARGET_DIR=/tmp/harn-target-1750 HARN_LLM_CALLS_DISABLED=1 cargo clippy -p harn-lsp --all-targets -- -D warnings`
- pre-commit hook: workspace clippy + markdown lint passed
- pre-push hook: targeted local checks + markdown lint + changelog check passed
