### PR TITLE
Add JSON check and format reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ condensed series summaries instead of full per-patch history.
 
 ### Added
 
+- **`harn check --json` and `harn fmt --json` (#1759).** Adds
+  standard `JsonEnvelope` reports for static checks and formatter
+  runs, including per-file status, diagnostics, summary counts, and
+  schema catalog entries. Provider and connector matrix JSON output
+  now uses the same envelope; `--format=json` remains as a deprecated
+  alias for the matrix commands for one patch release. Merge Captain
+  ladder, iterate, and audit commands now accept `--json` with
+  `--format=json` kept as a deprecated alias.
 - **`harn parse --json` and `harn tokens --json` (#1757).** Adds
   parser and lexer inspection commands for tooling. `harn parse` prints
   the AST in text mode or a tagged `Program` JSON tree with byte spans

--- a/crates/harn-cli/src/cli/check.rs
+++ b/crates/harn-cli/src/cli/check.rs
@@ -13,6 +13,10 @@ pub(crate) struct CheckArgs {
     /// Print the connector package capability matrix instead of checking files.
     #[arg(long = "connector-matrix")]
     pub connector_matrix: bool,
+    /// Emit a structured `JsonEnvelope` report. For matrix commands, replaces
+    /// the deprecated `--format=json` spelling.
+    #[arg(long)]
+    pub json: bool,
     /// Output format for matrix commands.
     #[arg(long = "format", value_enum, default_value_t = CheckOutputFormat::Text, requires = "matrix")]
     pub format: CheckOutputFormat,

--- a/crates/harn-cli/src/cli/lint_fmt.rs
+++ b/crates/harn-cli/src/cli/lint_fmt.rs
@@ -18,6 +18,9 @@ pub(crate) struct FmtArgs {
     /// Check formatting without rewriting files.
     #[arg(long)]
     pub check: bool,
+    /// Emit a structured `JsonEnvelope` report instead of human-readable output.
+    #[arg(long)]
+    pub json: bool,
     /// Maximum line width before wrapping. Overrides `[fmt] line_width` in harn.toml.
     #[arg(long = "line-width")]
     pub line_width: Option<usize>,

--- a/crates/harn-cli/src/cli/merge_captain.rs
+++ b/crates/harn-cli/src/cli/merge_captain.rs
@@ -28,6 +28,9 @@ pub(crate) struct MergeCaptainLadderArgs {
     /// Write the aggregate ladder report JSON to this path.
     #[arg(long = "report-out", value_name = "PATH")]
     pub report_out: Option<String>,
+    /// Pretty-print JSON to stdout. Replaces the deprecated `--format=json`.
+    #[arg(long)]
+    pub json: bool,
     /// Output format. Defaults to `text`.
     #[arg(long, value_enum, default_value_t = MergeCaptainLadderFormat::Text)]
     pub format: MergeCaptainLadderFormat,
@@ -60,6 +63,9 @@ pub(crate) struct MergeCaptainIterateArgs {
     /// Write the Markdown summary/diff to this path.
     #[arg(long = "markdown-out", value_name = "PATH")]
     pub markdown_out: Option<String>,
+    /// Pretty-print JSON to stdout. Replaces the deprecated `--format=json`.
+    #[arg(long)]
+    pub json: bool,
     /// Output format. Defaults to `text`.
     #[arg(long, value_enum, default_value_t = MergeCaptainIterateFormat::Text)]
     pub format: MergeCaptainIterateFormat,
@@ -229,6 +235,9 @@ pub(crate) struct MergeCaptainAuditArgs {
     /// Output format. Defaults to `text`.
     #[arg(long, value_enum, default_value_t = MergeCaptainAuditFormat::Text)]
     pub format: MergeCaptainAuditFormat,
+    /// Pretty-print JSON to stdout. Replaces the deprecated `--format=json`.
+    #[arg(long)]
+    pub json: bool,
     /// Treat warnings as errors. Useful in CI gates that want to
     /// flip on incomplete-transcript / state-out-of-order findings.
     #[arg(long)]

--- a/crates/harn-cli/src/cli/tests.rs
+++ b/crates/harn-cli/src/cli/tests.rs
@@ -841,9 +841,33 @@ fn test_parses_merge_captain_ladder_args() {
     };
     assert_eq!(ladder.manifest, "personas/merge_captain/harn.eval.toml");
     assert_eq!(ladder.report_out.as_deref(), Some("ladder-report.json"));
+    assert!(!ladder.json);
     assert!(matches!(
         ladder.format,
         crate::cli::MergeCaptainLadderFormat::Json
+    ));
+}
+
+#[test]
+fn test_parses_merge_captain_ladder_json_alias() {
+    let cli = Cli::parse_from([
+        "harn",
+        "merge-captain",
+        "ladder",
+        "personas/merge_captain/harn.eval.toml",
+        "--json",
+    ]);
+
+    let Command::MergeCaptain(args) = cli.command.unwrap() else {
+        panic!("expected merge-captain command");
+    };
+    let super::MergeCaptainCommand::Ladder(ladder) = args.command else {
+        panic!("expected merge-captain ladder command");
+    };
+    assert!(ladder.json);
+    assert!(matches!(
+        ladder.format,
+        crate::cli::MergeCaptainLadderFormat::Text
     ));
 }
 
@@ -874,6 +898,7 @@ fn test_parses_merge_captain_iterate_args() {
     );
     assert_eq!(iterate.report_out.as_deref(), Some("iteration-report.json"));
     assert_eq!(iterate.markdown_out.as_deref(), Some("iteration.md"));
+    assert!(!iterate.json);
     assert!(matches!(
         iterate.format,
         crate::cli::MergeCaptainIterateFormat::Json

--- a/crates/harn-cli/src/commands/check/check_cmd.rs
+++ b/crates/harn-cli/src/commands/check/check_cmd.rs
@@ -1,13 +1,88 @@
 use std::path::Path;
 
 use harn_lint::LintSeverity;
-use harn_parser::{DiagnosticSeverity, TypeChecker};
+use harn_parser::{DiagnosticSeverity, PipelineError, TypeChecker};
+use serde::Serialize;
 
 use crate::package::{CheckConfig, PreflightSeverity};
 use crate::parse_source_file;
 
 use super::outcome::{print_lint_diagnostics, CommandOutcome};
 use super::preflight::{collect_preflight_diagnostics, is_preflight_allowed};
+
+pub(crate) const CHECK_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct CheckReport {
+    pub files: Vec<CheckFileReport>,
+    pub summary: CheckSummary,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct CheckFileReport {
+    pub path: String,
+    pub status: CheckFileStatus,
+    pub diagnostics: Vec<CheckDiagnostic>,
+}
+
+impl CheckFileReport {
+    pub(crate) fn outcome(&self) -> CommandOutcome {
+        CommandOutcome {
+            has_error: matches!(self.status, CheckFileStatus::Error),
+            has_warning: matches!(self.status, CheckFileStatus::Warning),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum CheckFileStatus {
+    Ok,
+    Warning,
+    Error,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct CheckDiagnostic {
+    pub source: &'static str,
+    pub severity: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub code: Option<String>,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub span: Option<CheckSpan>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub help: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+pub(crate) struct CheckSpan {
+    pub start: usize,
+    pub end: usize,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub(crate) struct CheckSummary {
+    pub ok: usize,
+    pub warnings: usize,
+    pub errors: usize,
+    pub diagnostics: usize,
+}
+
+impl CheckReport {
+    pub(crate) fn from_files(files: Vec<CheckFileReport>) -> Self {
+        let mut summary = CheckSummary::default();
+        for file in &files {
+            match file.status {
+                CheckFileStatus::Ok => summary.ok += 1,
+                CheckFileStatus::Warning => summary.warnings += 1,
+                CheckFileStatus::Error => summary.errors += 1,
+            }
+            summary.diagnostics += file.diagnostics.len();
+        }
+        Self { files, summary }
+    }
+}
 
 pub(crate) fn check_file_inner(
     path: &Path,
@@ -16,12 +91,56 @@ pub(crate) fn check_file_inner(
     module_graph: &harn_modules::ModuleGraph,
     check_invariants: bool,
 ) -> CommandOutcome {
+    check_file_report_inner(
+        path,
+        config,
+        externally_imported_names,
+        module_graph,
+        check_invariants,
+        true,
+    )
+    .outcome()
+}
+
+pub(crate) fn check_file_report(
+    path: &Path,
+    config: &CheckConfig,
+    externally_imported_names: &std::collections::HashSet<String>,
+    module_graph: &harn_modules::ModuleGraph,
+    check_invariants: bool,
+) -> CheckFileReport {
+    check_file_report_inner(
+        path,
+        config,
+        externally_imported_names,
+        module_graph,
+        check_invariants,
+        false,
+    )
+}
+
+fn check_file_report_inner(
+    path: &Path,
+    config: &CheckConfig,
+    externally_imported_names: &std::collections::HashSet<String>,
+    module_graph: &harn_modules::ModuleGraph,
+    check_invariants: bool,
+    emit_text: bool,
+) -> CheckFileReport {
     let path_str = path.to_string_lossy().into_owned();
-    let (source, program) = parse_source_file(&path_str);
+    let (source, program) = if emit_text {
+        parse_source_file(&path_str)
+    } else {
+        match parse_source_for_report(&path_str) {
+            Ok(parsed) => parsed,
+            Err(report) => return report,
+        }
+    };
 
     let mut has_error = false;
     let mut has_warning = false;
     let mut diagnostic_count = 0;
+    let mut diagnostics = Vec::new();
 
     let mut checker = TypeChecker::with_strict_types(config.strict_types);
     if let Some(imported) = module_graph.imported_names_for_file(path) {
@@ -43,8 +162,19 @@ pub(crate) fn check_file_inner(
             DiagnosticSeverity::Warning => has_warning = true,
         }
         diagnostic_count += 1;
-        let rendered = harn_parser::diagnostic::render_type_diagnostic(&source, &path_str, diag);
-        eprint!("{rendered}");
+        if emit_text {
+            let rendered =
+                harn_parser::diagnostic::render_type_diagnostic(&source, &path_str, diag);
+            eprint!("{rendered}");
+        }
+        diagnostics.push(CheckDiagnostic {
+            source: "type",
+            severity: type_severity_label(diag.severity),
+            code: Some(diag.code.to_string()),
+            message: diag.message.clone(),
+            span: diag.span.map(check_span),
+            help: diag.help.clone(),
+        });
     }
 
     let lint_diagnostics = harn_lint::lint_with_module_graph(
@@ -68,9 +198,24 @@ pub(crate) fn check_file_inner(
     {
         has_warning = true;
     }
-    if print_lint_diagnostics(&path_str, &source, &lint_diagnostics) {
+    if emit_text {
+        if print_lint_diagnostics(&path_str, &source, &lint_diagnostics) {
+            has_error = true;
+        }
+    } else if lint_diagnostics
+        .iter()
+        .any(|d| d.severity == LintSeverity::Error)
+    {
         has_error = true;
     }
+    diagnostics.extend(lint_diagnostics.iter().map(|diag| CheckDiagnostic {
+        source: "lint",
+        severity: lint_severity_label(diag.severity),
+        code: Some(diag.code.to_string()),
+        message: diag.message.clone(),
+        span: Some(check_span(diag.span)),
+        help: diag.suggestion.clone(),
+    }));
 
     let preflight_diagnostics = collect_preflight_diagnostics(path, &source, &program, config);
     let preflight_severity = PreflightSeverity::from_opt(config.preflight_severity.as_deref());
@@ -89,17 +234,27 @@ pub(crate) fn check_file_inner(
                 PreflightSeverity::Off => unreachable!(),
             }
             diagnostic_count += 1;
-            let rendered = harn_parser::diagnostic::render_diagnostic_with_code(
-                &diag.source,
-                &diag.path,
-                &diag.span,
-                severity_label,
-                diag.code,
-                &diag.message,
-                Some(category),
-                diag.help.as_deref(),
-            );
-            eprint!("{rendered}");
+            if emit_text {
+                let rendered = harn_parser::diagnostic::render_diagnostic_with_code(
+                    &diag.source,
+                    &diag.path,
+                    &diag.span,
+                    severity_label,
+                    diag.code,
+                    &diag.message,
+                    Some(category),
+                    diag.help.as_deref(),
+                );
+                eprint!("{rendered}");
+            }
+            diagnostics.push(CheckDiagnostic {
+                source: category,
+                severity: severity_label,
+                code: Some(diag.code.to_string()),
+                message: diag.message.clone(),
+                span: Some(check_span(diag.span)),
+                help: diag.help.clone(),
+            });
         }
     }
 
@@ -108,25 +263,119 @@ pub(crate) fn check_file_inner(
         for diag in &report.diagnostics {
             has_error = true;
             diagnostic_count += 1;
-            let rendered = harn_parser::diagnostic::render_diagnostic(
-                &source,
-                &path_str,
-                &diag.span,
-                "error",
-                &diag.message,
-                Some(&format!("invariant[{}]", diag.invariant)),
-                diag.help.as_deref(),
-            );
-            eprint!("{rendered}");
+            if emit_text {
+                let rendered = harn_parser::diagnostic::render_diagnostic(
+                    &source,
+                    &path_str,
+                    &diag.span,
+                    "error",
+                    &diag.message,
+                    Some(&format!("invariant[{}]", diag.invariant)),
+                    diag.help.as_deref(),
+                );
+                eprint!("{rendered}");
+            }
+            diagnostics.push(CheckDiagnostic {
+                source: "invariant",
+                severity: "error",
+                code: None,
+                message: diag.message.clone(),
+                span: Some(check_span(diag.span)),
+                help: diag.help.clone(),
+            });
         }
     }
 
-    if diagnostic_count == 0 {
+    if diagnostic_count == 0 && emit_text {
         println!("{path_str}: ok");
     }
 
-    CommandOutcome {
-        has_error,
-        has_warning,
+    let status = if has_error {
+        CheckFileStatus::Error
+    } else if has_warning {
+        CheckFileStatus::Warning
+    } else {
+        CheckFileStatus::Ok
+    };
+    CheckFileReport {
+        path: path_str,
+        status,
+        diagnostics,
+    }
+}
+
+fn type_severity_label(severity: DiagnosticSeverity) -> &'static str {
+    match severity {
+        DiagnosticSeverity::Error => "error",
+        DiagnosticSeverity::Warning => "warning",
+    }
+}
+
+fn lint_severity_label(severity: LintSeverity) -> &'static str {
+    match severity {
+        LintSeverity::Error => "error",
+        LintSeverity::Warning => "warning",
+    }
+}
+
+fn check_span(span: harn_lexer::Span) -> CheckSpan {
+    CheckSpan {
+        start: span.start,
+        end: span.end,
+    }
+}
+
+fn parse_source_for_report(
+    path: &str,
+) -> Result<(String, Vec<harn_parser::SNode>), CheckFileReport> {
+    let source = std::fs::read_to_string(path).map_err(|error| CheckFileReport {
+        path: path.to_string(),
+        status: CheckFileStatus::Error,
+        diagnostics: vec![CheckDiagnostic {
+            source: "io",
+            severity: "error",
+            code: None,
+            message: format!("Error reading {path}: {error}"),
+            span: None,
+            help: None,
+        }],
+    })?;
+    let program = harn_parser::parse_source(&source)
+        .map_err(|error| parse_diagnostic_report(path, &source, error))?;
+    Ok((source, program))
+}
+
+fn parse_diagnostic_report(path: &str, _source: &str, error: PipelineError) -> CheckFileReport {
+    let span = error.span().copied();
+    let diagnostic = match error {
+        PipelineError::Lex(error) => CheckDiagnostic {
+            source: "lexer",
+            severity: "error",
+            code: Some(harn_parser::diagnostic::lexer_error_code(&error).to_string()),
+            message: error.to_string(),
+            span: span.map(check_span),
+            help: None,
+        },
+        PipelineError::Parse(error) => CheckDiagnostic {
+            source: "parser",
+            severity: "error",
+            code: Some(harn_parser::diagnostic::parser_error_code(&error).to_string()),
+            message: harn_parser::diagnostic::parser_error_message(&error),
+            span: span.map(check_span),
+            help: harn_parser::diagnostic::parser_error_help(&error).map(str::to_string),
+        },
+        PipelineError::TypeCheck(error) => CheckDiagnostic {
+            source: "type",
+            severity: type_severity_label(error.severity),
+            code: Some(error.code.to_string()),
+            message: error.message.clone(),
+            span: error.span.map(check_span),
+            help: error.help.clone(),
+        },
+    };
+    CheckFileReport {
+        path: path.to_string(),
+        status: CheckFileStatus::Error,
+        diagnostics: vec![diagnostic],
     }
 }

--- a/crates/harn-cli/src/commands/check/connector_matrix.rs
+++ b/crates/harn-cli/src/commands/check/connector_matrix.rs
@@ -5,10 +5,13 @@ use std::process;
 use serde::Serialize;
 
 use crate::cli::CheckOutputFormat;
+use crate::json_envelope::{to_string_pretty, JsonEnvelope};
 use crate::package::{
     find_nearest_manifest, normalize_connector_capability, read_manifest_from_path,
     ConnectorCapabilities, Manifest,
 };
+
+pub(crate) const CONNECTOR_MATRIX_SCHEMA_VERSION: u32 = 1;
 
 const DEFAULT_CONNECTOR_MATRIX_SOURCE: &str = "conformance/fixtures/connectors/contract-v1";
 
@@ -27,11 +30,16 @@ pub(crate) struct ConnectorCapabilityMatrixRow {
     pub manifest_path: String,
 }
 
-pub(crate) fn run(format: CheckOutputFormat, filter: Option<&str>, targets: &[String]) {
+pub(crate) fn run(
+    format: CheckOutputFormat,
+    filter: Option<&str>,
+    targets: &[String],
+    deprecated_json_format: bool,
+) {
     let rows = filtered_rows(load_rows_for_cli(targets), filter);
     match format {
         CheckOutputFormat::Text => print_text(&rows),
-        CheckOutputFormat::Json => print_json(&rows),
+        CheckOutputFormat::Json => print_json(&rows, deprecated_json_format),
         CheckOutputFormat::Markdown => print!("{}", generate_markdown(&rows)),
     }
 }
@@ -365,14 +373,15 @@ fn print_row<const N: usize>(cells: &[String; N], widths: &[usize]) {
     println!();
 }
 
-fn print_json(rows: &[ConnectorCapabilityMatrixRow]) {
-    println!(
-        "{}",
-        serde_json::to_string_pretty(rows).unwrap_or_else(|error| {
-            eprintln!("error: failed to serialize connector matrix: {error}");
-            process::exit(1);
-        })
-    );
+fn print_json(rows: &[ConnectorCapabilityMatrixRow], deprecated_json_format: bool) {
+    let mut envelope = JsonEnvelope::ok(CONNECTOR_MATRIX_SCHEMA_VERSION, rows);
+    if deprecated_json_format {
+        envelope = envelope.with_warning(
+            "deprecated.flag",
+            "`harn check --connector-matrix --format=json` is deprecated; use `--json`",
+        );
+    }
+    println!("{}", to_string_pretty(&envelope));
 }
 
 fn package_cell(row: &ConnectorCapabilityMatrixRow) -> String {

--- a/crates/harn-cli/src/commands/check/fmt.rs
+++ b/crates/harn-cli/src/commands/check/fmt.rs
@@ -2,6 +2,49 @@ use std::process;
 
 use harn_fmt::{format_source_opts, FmtOptions};
 use harn_parser::DiagnosticCode as Code;
+use serde::Serialize;
+
+use crate::json_envelope::{JsonEnvelope, JsonError};
+
+pub(crate) const FMT_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct FmtReport {
+    pub files: Vec<FmtFileReport>,
+    pub summary: FmtSummary,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct FmtFileReport {
+    pub path: String,
+    pub status: FmtFileStatus,
+    pub diff_lines_changed: usize,
+    pub diagnostics: Vec<FmtDiagnostic>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum FmtFileStatus {
+    Formatted,
+    AlreadyFormatted,
+    #[allow(dead_code)]
+    Skipped,
+    Error,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct FmtDiagnostic {
+    pub code: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub(crate) struct FmtSummary {
+    pub formatted: usize,
+    pub already_formatted: usize,
+    pub skipped: usize,
+    pub errors: usize,
+}
 
 /// Whether `harn fmt` should rewrite files in place or just report drift.
 #[derive(Clone, Copy, Debug)]
@@ -28,6 +71,37 @@ impl FmtMode {
 
 /// Format one or more files or directories. Accepts multiple targets.
 pub(crate) fn fmt_targets(targets: &[&str], mode: FmtMode, opts: &FmtOptions) {
+    let report = fmt_targets_report(targets, mode, opts);
+    print_text_report(&report);
+    if report.summary.errors > 0 {
+        process::exit(1);
+    }
+}
+
+pub(crate) fn fmt_targets_json(
+    targets: &[&str],
+    mode: FmtMode,
+    opts: &FmtOptions,
+) -> JsonEnvelope<FmtReport> {
+    let report = fmt_targets_report(targets, mode, opts);
+    if report.summary.errors > 0 {
+        JsonEnvelope {
+            schema_version: FMT_SCHEMA_VERSION,
+            ok: false,
+            data: Some(report),
+            error: Some(JsonError {
+                code: "fmt_failed".to_string(),
+                message: "one or more files failed formatting checks".to_string(),
+                details: serde_json::Value::Null,
+            }),
+            warnings: Vec::new(),
+        }
+    } else {
+        JsonEnvelope::ok(FMT_SCHEMA_VERSION, report)
+    }
+}
+
+pub(crate) fn fmt_targets_report(targets: &[&str], mode: FmtMode, opts: &FmtOptions) -> FmtReport {
     let mut files = Vec::new();
     for target in targets {
         let path = std::path::Path::new(target);
@@ -38,55 +112,120 @@ pub(crate) fn fmt_targets(targets: &[&str], mode: FmtMode, opts: &FmtOptions) {
         }
     }
     if files.is_empty() {
-        eprintln!("No .harn files found");
-        process::exit(1);
+        return FmtReport {
+            files: Vec::new(),
+            summary: FmtSummary {
+                errors: 1,
+                ..FmtSummary::default()
+            },
+        };
     }
-    let mut has_error = false;
-    for file in &files {
+    let mut report = FmtReport {
+        files: Vec::new(),
+        summary: FmtSummary::default(),
+    };
+    for file in files {
         let path_str = file.to_string_lossy();
-        if !fmt_file_inner(&path_str, mode, opts) {
-            has_error = true;
+        let file_report = fmt_file_inner(&path_str, mode, opts);
+        match file_report.status {
+            FmtFileStatus::Formatted => report.summary.formatted += 1,
+            FmtFileStatus::AlreadyFormatted => report.summary.already_formatted += 1,
+            FmtFileStatus::Skipped => report.summary.skipped += 1,
+            FmtFileStatus::Error => report.summary.errors += 1,
         }
+        report.files.push(file_report);
     }
-    if has_error {
-        process::exit(1);
-    }
+    report
 }
 
-/// Format a single file. Returns true on success, false on error.
-fn fmt_file_inner(path: &str, mode: FmtMode, opts: &FmtOptions) -> bool {
+/// Format a single file.
+fn fmt_file_inner(path: &str, mode: FmtMode, opts: &FmtOptions) -> FmtFileReport {
     let source = match std::fs::read_to_string(path) {
-        Ok(s) => s,
-        Err(e) => {
-            eprintln!("Error reading {path}: {e}");
-            return false;
-        }
+        Ok(source) => source,
+        Err(error) => return fmt_error(path, "io", format!("Error reading {path}: {error}")),
     };
 
     let formatted = match format_source_opts(&source, opts) {
-        Ok(f) => f,
-        Err(e) => {
-            eprintln!("{path}: {e}");
-            return false;
-        }
+        Ok(formatted) => formatted,
+        Err(error) => return fmt_error(path, "format", format!("{path}: {error}")),
     };
 
     if mode.is_check() {
         if source != formatted {
-            eprintln!(
-                "{path}: {}: would be reformatted",
-                Code::FormatterWouldReformat
-            );
-            return false;
+            return FmtFileReport {
+                path: path.to_string(),
+                status: FmtFileStatus::Error,
+                diff_lines_changed: diff_lines_changed(&source, &formatted),
+                diagnostics: vec![FmtDiagnostic {
+                    code: Code::FormatterWouldReformat.to_string(),
+                    message: "would be reformatted".to_string(),
+                }],
+            };
         }
     } else if source != formatted {
-        match std::fs::write(path, &formatted) {
-            Ok(()) => println!("formatted {path}"),
-            Err(e) => {
-                eprintln!("Error writing {path}: {e}");
-                return false;
+        if let Err(error) = std::fs::write(path, &formatted) {
+            return fmt_error(path, "io", format!("Error writing {path}: {error}"));
+        }
+        return FmtFileReport {
+            path: path.to_string(),
+            status: FmtFileStatus::Formatted,
+            diff_lines_changed: diff_lines_changed(&source, &formatted),
+            diagnostics: Vec::new(),
+        };
+    }
+
+    FmtFileReport {
+        path: path.to_string(),
+        status: FmtFileStatus::AlreadyFormatted,
+        diff_lines_changed: 0,
+        diagnostics: Vec::new(),
+    }
+}
+
+fn fmt_error(path: &str, code: &str, message: String) -> FmtFileReport {
+    FmtFileReport {
+        path: path.to_string(),
+        status: FmtFileStatus::Error,
+        diff_lines_changed: 0,
+        diagnostics: vec![FmtDiagnostic {
+            code: code.to_string(),
+            message,
+        }],
+    }
+}
+
+fn print_text_report(report: &FmtReport) {
+    if report.files.is_empty() {
+        eprintln!("No .harn files found");
+        return;
+    }
+    for file in &report.files {
+        match file.status {
+            FmtFileStatus::Formatted => println!("formatted {}", file.path),
+            FmtFileStatus::Error => {
+                for diagnostic in &file.diagnostics {
+                    if diagnostic.code == Code::FormatterWouldReformat.to_string() {
+                        eprintln!(
+                            "{}: {}: {}",
+                            file.path,
+                            Code::FormatterWouldReformat,
+                            diagnostic.message
+                        );
+                    } else {
+                        eprintln!("{}", diagnostic.message);
+                    }
+                }
             }
+            FmtFileStatus::AlreadyFormatted | FmtFileStatus::Skipped => {}
         }
     }
-    true
+}
+
+fn diff_lines_changed(before: &str, after: &str) -> usize {
+    let before_lines: Vec<&str> = before.lines().collect();
+    let after_lines: Vec<&str> = after.lines().collect();
+    let max_len = before_lines.len().max(after_lines.len());
+    (0..max_len)
+        .filter(|index| before_lines.get(*index) != after_lines.get(*index))
+        .count()
 }

--- a/crates/harn-cli/src/commands/check/mod.rs
+++ b/crates/harn-cli/src/commands/check/mod.rs
@@ -17,13 +17,15 @@ mod template_lint;
 mod tests;
 
 pub(crate) use bundle::build_bundle_manifest;
-pub(crate) use check_cmd::check_file_inner;
+pub(crate) use check_cmd::{
+    check_file_inner, check_file_report, CheckReport, CHECK_SCHEMA_VERSION,
+};
 pub(crate) use config::{
     apply_harn_lint_config, build_module_graph, collect_cross_file_imports, collect_harn_targets,
     harn_lint_complexity_threshold, harn_lint_disabled_rules, harn_lint_persona_step_allowlist,
     harn_lint_require_file_header, harn_lint_template_variant_branch_threshold,
 };
-pub(crate) use fmt::{fmt_targets, FmtMode};
+pub(crate) use fmt::{fmt_targets, fmt_targets_json, FmtMode, FMT_SCHEMA_VERSION};
 pub(crate) use host_capabilities::load_host_capabilities;
 pub(crate) use lint::{lint_file_inner, lint_fix_file};
 pub(crate) use preflight::{collect_preflight_diagnostics, is_preflight_allowed};

--- a/crates/harn-cli/src/commands/check/provider_matrix.rs
+++ b/crates/harn-cli/src/commands/check/provider_matrix.rs
@@ -3,6 +3,9 @@ use std::process;
 use harn_vm::llm::capabilities::ProviderCapabilityMatrixRow;
 
 use crate::cli::CheckOutputFormat;
+use crate::json_envelope::{to_string_pretty, JsonEnvelope};
+
+pub(crate) const PROVIDER_MATRIX_SCHEMA_VERSION: u32 = 1;
 
 const FEATURES: &[&str] = &[
     "thinking",
@@ -24,11 +27,11 @@ const FEATURES: &[&str] = &[
     "cache",
 ];
 
-pub(crate) fn run(format: CheckOutputFormat, filter: Option<&str>) {
+pub(crate) fn run(format: CheckOutputFormat, filter: Option<&str>, deprecated_json_format: bool) {
     let rows = filtered_rows(filter);
     match format {
         CheckOutputFormat::Text => print_text(&rows),
-        CheckOutputFormat::Json => print_json(&rows),
+        CheckOutputFormat::Json => print_json(&rows, deprecated_json_format),
         CheckOutputFormat::Markdown => print!("{}", generate_markdown(&rows)),
     }
 }
@@ -186,14 +189,15 @@ fn print_row<const N: usize>(cells: &[String; N], widths: &[usize]) {
     println!();
 }
 
-fn print_json(rows: &[ProviderCapabilityMatrixRow]) {
-    println!(
-        "{}",
-        serde_json::to_string_pretty(rows).unwrap_or_else(|error| {
-            eprintln!("error: failed to serialize provider matrix: {error}");
-            process::exit(1);
-        })
-    );
+fn print_json(rows: &[ProviderCapabilityMatrixRow], deprecated_json_format: bool) {
+    let mut envelope = JsonEnvelope::ok(PROVIDER_MATRIX_SCHEMA_VERSION, rows);
+    if deprecated_json_format {
+        envelope = envelope.with_warning(
+            "deprecated.flag",
+            "`harn check --provider-matrix --format=json` is deprecated; use `--json`",
+        );
+    }
+    println!("{}", to_string_pretty(&envelope));
 }
 
 fn thinking_cell(row: &ProviderCapabilityMatrixRow) -> String {

--- a/crates/harn-cli/src/commands/merge_captain.rs
+++ b/crates/harn-cli/src/commands/merge_captain.rs
@@ -123,7 +123,10 @@ pub(crate) fn run_ladder(args: &MergeCaptainLadderArgs) -> i32 {
         }
     }
 
-    match args.format {
+    let Some(format) = ladder_output_format(args) else {
+        return 2;
+    };
+    match format {
         MergeCaptainLadderFormat::Json => print_json_value(&report),
         MergeCaptainLadderFormat::Text => print_ladder_report(&report),
     }
@@ -186,7 +189,10 @@ pub(crate) fn run_iterate(args: &MergeCaptainIterateArgs) -> i32 {
         }
     }
 
-    match args.format {
+    let Some(format) = iterate_output_format(args) else {
+        return 2;
+    };
+    match format {
         MergeCaptainIterateFormat::Json => print_json_value(&report),
         MergeCaptainIterateFormat::Text => print!("{markdown}"),
     }
@@ -236,7 +242,10 @@ fn run_iteration_diff(args: &MergeCaptainIterateArgs) -> i32 {
             return 1;
         }
     }
-    match args.format {
+    let Some(format) = iterate_output_format(args) else {
+        return 2;
+    };
+    match format {
         MergeCaptainIterateFormat::Json => print_json_value(&diff),
         MergeCaptainIterateFormat::Text => print!("{markdown}"),
     }
@@ -407,7 +416,10 @@ pub(crate) fn run_audit(args: &MergeCaptainAuditArgs) -> i32 {
     let mut report = audit_transcript(&loaded.events, golden.as_ref());
     report.source_path = Some(loaded.source_path.display().to_string());
 
-    match args.format {
+    let Some(format) = audit_output_format(args) else {
+        return 2;
+    };
+    match format {
         MergeCaptainAuditFormat::Json => {
             print_json(&report);
         }
@@ -425,6 +437,51 @@ pub(crate) fn run_audit(args: &MergeCaptainAuditArgs) -> i32 {
 
 fn print_json(report: &AuditReport) {
     print_json_value(report);
+}
+
+fn ladder_output_format(args: &MergeCaptainLadderArgs) -> Option<MergeCaptainLadderFormat> {
+    if args.json {
+        if !matches!(args.format, MergeCaptainLadderFormat::Text) {
+            eprintln!("error: merge-captain ladder accepts either --json or --format, not both");
+            return None;
+        }
+        Some(MergeCaptainLadderFormat::Json)
+    } else {
+        if matches!(args.format, MergeCaptainLadderFormat::Json) {
+            eprintln!("WARNING: `merge-captain ladder --format=json` is deprecated; use `--json`");
+        }
+        Some(args.format)
+    }
+}
+
+fn iterate_output_format(args: &MergeCaptainIterateArgs) -> Option<MergeCaptainIterateFormat> {
+    if args.json {
+        if !matches!(args.format, MergeCaptainIterateFormat::Text) {
+            eprintln!("error: merge-captain iterate accepts either --json or --format, not both");
+            return None;
+        }
+        Some(MergeCaptainIterateFormat::Json)
+    } else {
+        if matches!(args.format, MergeCaptainIterateFormat::Json) {
+            eprintln!("WARNING: `merge-captain iterate --format=json` is deprecated; use `--json`");
+        }
+        Some(args.format)
+    }
+}
+
+fn audit_output_format(args: &MergeCaptainAuditArgs) -> Option<MergeCaptainAuditFormat> {
+    if args.json {
+        if !matches!(args.format, MergeCaptainAuditFormat::Text) {
+            eprintln!("error: merge-captain audit accepts either --json or --format, not both");
+            return None;
+        }
+        Some(MergeCaptainAuditFormat::Json)
+    } else {
+        if matches!(args.format, MergeCaptainAuditFormat::Json) {
+            eprintln!("WARNING: `merge-captain audit --format=json` is deprecated; use `--json`");
+        }
+        Some(args.format)
+    }
 }
 
 fn print_json_value<T: serde::Serialize>(value: &T) {

--- a/crates/harn-cli/src/json_envelope.rs
+++ b/crates/harn-cli/src/json_envelope.rs
@@ -176,6 +176,30 @@ pub fn catalog() -> Vec<SchemaEntry> {
             schema_json: None,
         },
         SchemaEntry {
+            command: "check",
+            schema_version: crate::commands::check::CHECK_SCHEMA_VERSION,
+            description: "Per-file static check results with diagnostics and summary counts.",
+            schema_json: None,
+        },
+        SchemaEntry {
+            command: "fmt",
+            schema_version: crate::commands::check::FMT_SCHEMA_VERSION,
+            description: "Per-file formatting result report for write and check modes.",
+            schema_json: None,
+        },
+        SchemaEntry {
+            command: "check provider-matrix",
+            schema_version: crate::commands::check::provider_matrix::PROVIDER_MATRIX_SCHEMA_VERSION,
+            description: "Provider/model capability matrix rows.",
+            schema_json: None,
+        },
+        SchemaEntry {
+            command: "check connector-matrix",
+            schema_version: crate::commands::check::connector_matrix::CONNECTOR_MATRIX_SCHEMA_VERSION,
+            description: "Connector package capability matrix rows.",
+            schema_json: None,
+        },
+        SchemaEntry {
             command: "time run",
             schema_version: crate::commands::time::TIME_RUN_SCHEMA_VERSION,
             description:

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -233,18 +233,33 @@ async fn async_main() {
             }
         }
         Command::Check(args) => {
+            let json_format_alias =
+                !args.json && matches!(args.format, cli::CheckOutputFormat::Json);
+            let matrix_format = if args.json {
+                if !matches!(args.format, cli::CheckOutputFormat::Text) {
+                    command_error("`harn check` accepts either `--json` or `--format`, not both");
+                }
+                cli::CheckOutputFormat::Json
+            } else {
+                args.format
+            };
             if args.provider_matrix {
                 let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
                 let extensions = package::load_runtime_extensions(&cwd);
                 package::install_runtime_extensions(&extensions);
-                commands::check::provider_matrix::run(args.format, args.filter.as_deref());
+                commands::check::provider_matrix::run(
+                    matrix_format,
+                    args.filter.as_deref(),
+                    json_format_alias,
+                );
                 return;
             }
             if args.connector_matrix {
                 commands::check::connector_matrix::run(
-                    args.format,
+                    matrix_format,
                     args.filter.as_deref(),
                     &args.targets,
+                    json_format_alias,
                 );
                 return;
             }
@@ -272,6 +287,12 @@ async fn async_main() {
                 }
             }
             if target_strings.is_empty() {
+                if args.json {
+                    print_check_error(
+                        "missing_targets",
+                        "`harn check` requires at least one target path, or `--workspace` with `[workspace].pipelines`",
+                    );
+                }
                 command_error(
                     "`harn check` requires at least one target path, or `--workspace` with `[workspace].pipelines`",
                 );
@@ -279,17 +300,30 @@ async fn async_main() {
             for target in &target_strings {
                 if let Err(error) = package::validate_runtime_manifest_extensions(Path::new(target))
                 {
+                    if args.json {
+                        print_check_error(
+                            "manifest_extension_error",
+                            &format!("manifest extension validation failed: {error}"),
+                        );
+                    }
                     command_error(&format!("manifest extension validation failed: {error}"));
                 }
             }
             let targets: Vec<&str> = target_strings.iter().map(String::as_str).collect();
             let files = commands::check::collect_harn_targets(&targets);
             if files.is_empty() {
+                if args.json {
+                    print_check_error(
+                        "no_harn_files",
+                        "no .harn files found under the given target(s)",
+                    );
+                }
                 command_error("no .harn files found under the given target(s)");
             }
             let module_graph = commands::check::build_module_graph(&files);
             let cross_file_imports = commands::check::collect_cross_file_imports(&module_graph);
             let mut should_fail = false;
+            let mut json_files = Vec::new();
             for file in &files {
                 let mut config = package::load_check_config(Some(file));
                 if let Some(path) = args.host_capabilities.as_ref() {
@@ -304,14 +338,49 @@ async fn async_main() {
                 if let Some(sev) = args.preflight.as_deref() {
                     config.preflight_severity = Some(sev.to_string());
                 }
-                let outcome = commands::check::check_file_inner(
-                    file,
-                    &config,
-                    &cross_file_imports,
-                    &module_graph,
-                    args.invariants,
-                );
-                should_fail |= outcome.should_fail(config.strict);
+                if args.json {
+                    let report = commands::check::check_file_report(
+                        file,
+                        &config,
+                        &cross_file_imports,
+                        &module_graph,
+                        args.invariants,
+                    );
+                    should_fail |= report.outcome().should_fail(config.strict);
+                    json_files.push(report);
+                } else {
+                    let outcome = commands::check::check_file_inner(
+                        file,
+                        &config,
+                        &cross_file_imports,
+                        &module_graph,
+                        args.invariants,
+                    );
+                    should_fail |= outcome.should_fail(config.strict);
+                }
+            }
+            if args.json {
+                let report = commands::check::CheckReport::from_files(json_files);
+                let envelope = if should_fail {
+                    json_envelope::JsonEnvelope {
+                        schema_version: commands::check::CHECK_SCHEMA_VERSION,
+                        ok: false,
+                        data: Some(report),
+                        error: Some(json_envelope::JsonError {
+                            code: "check_failed".to_string(),
+                            message: "one or more files failed `harn check`".to_string(),
+                            details: serde_json::Value::Null,
+                        }),
+                        warnings: Vec::new(),
+                    }
+                } else {
+                    json_envelope::JsonEnvelope::ok(commands::check::CHECK_SCHEMA_VERSION, report)
+                };
+                println!("{}", json_envelope::to_string_pretty(&envelope));
+                if should_fail {
+                    process::exit(1);
+                }
+                return;
             }
             if should_fail {
                 process::exit(1);
@@ -449,11 +518,17 @@ async fn async_main() {
             if let Some(w) = args.separator_width {
                 opts.separator_width = w;
             }
-            commands::check::fmt_targets(
-                &targets,
-                commands::check::FmtMode::from_check_flag(args.check),
-                &opts,
-            );
+            let mode = commands::check::FmtMode::from_check_flag(args.check);
+            if args.json {
+                let envelope = commands::check::fmt_targets_json(&targets, mode, &opts);
+                let failed = !envelope.ok;
+                println!("{}", json_envelope::to_string_pretty(&envelope));
+                if failed {
+                    process::exit(1);
+                }
+            } else {
+                commands::check::fmt_targets(&targets, mode, &opts);
+            }
         }
         Command::Test(args) => {
             if args.target.as_deref() == Some("agents-conformance") {
@@ -1457,6 +1532,13 @@ fn command_error(message: &str) -> ! {
     Cli::command()
         .error(ErrorKind::ValueValidation, message)
         .exit()
+}
+
+fn print_check_error(code: &str, message: &str) -> ! {
+    let envelope: json_envelope::JsonEnvelope<commands::check::CheckReport> =
+        json_envelope::JsonEnvelope::err(commands::check::CHECK_SCHEMA_VERSION, code, message);
+    println!("{}", json_envelope::to_string_pretty(&envelope));
+    process::exit(1);
 }
 
 fn verify_provenance_receipt(path: &str, json: bool) -> Result<(), String> {

--- a/crates/harn-cli/tests/check_fmt_json_cli.rs
+++ b/crates/harn-cli/tests/check_fmt_json_cli.rs
@@ -1,0 +1,148 @@
+//! End-to-end coverage for `harn check --json` and `harn fmt --json`.
+
+use std::process::Command;
+
+use harn_cli::tests::common::json_envelope::assert_envelope;
+
+const CHECK_SCHEMA_VERSION: u32 = 1;
+const FMT_SCHEMA_VERSION: u32 = 1;
+const CATALOG_SCHEMA_VERSION: u32 = harn_cli::json_envelope::CATALOG_SCHEMA_VERSION;
+
+fn binary_path() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_BIN_EXE_harn"))
+}
+
+fn stdout_json(output: &std::process::Output) -> serde_json::Value {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(stdout.trim()).unwrap_or_else(|error| {
+        panic!("stdout is not JSON: {error}\nstdout:\n{stdout}");
+    })
+}
+
+#[test]
+fn fmt_check_json_reports_clean_and_drift_files() {
+    let temp = tempfile::TempDir::new().expect("tempdir");
+    let script = temp.path().join("main.harn");
+    std::fs::write(&script, "pipeline main(task) {\n  return 1\n}\n").expect("write script");
+
+    let clean = Command::new(binary_path())
+        .args(["fmt", "--check", "--json", script.to_str().unwrap()])
+        .output()
+        .expect("spawn harn fmt --check --json");
+    assert!(
+        clean.status.success(),
+        "stderr:\n{}",
+        String::from_utf8_lossy(&clean.stderr)
+    );
+    let parsed = stdout_json(&clean);
+    let data = assert_envelope(&parsed, FMT_SCHEMA_VERSION);
+    assert_eq!(data["summary"]["already_formatted"], 1);
+    assert_eq!(data["files"][0]["status"], "already_formatted");
+
+    std::fs::write(&script, "pipeline main(task){return 1}\n").expect("rewrite script");
+    let drift = Command::new(binary_path())
+        .args(["fmt", "--check", "--json", script.to_str().unwrap()])
+        .output()
+        .expect("spawn harn fmt --check --json");
+    assert!(!drift.status.success(), "drift should fail fmt --check");
+    let parsed = stdout_json(&drift);
+    assert_eq!(parsed["schemaVersion"], FMT_SCHEMA_VERSION);
+    assert_eq!(parsed["ok"], false);
+    assert_eq!(parsed["error"]["code"], "fmt_failed");
+    assert_eq!(parsed["data"]["summary"]["errors"], 1);
+    assert_eq!(parsed["data"]["files"][0]["status"], "error");
+    assert!(parsed["data"]["files"][0]["diagnostics"][0]["code"]
+        .as_str()
+        .unwrap()
+        .starts_with("HARN-FMT-"));
+}
+
+#[test]
+fn check_json_reports_success_and_diagnostics() {
+    let temp = tempfile::TempDir::new().expect("tempdir");
+    let script = temp.path().join("main.harn");
+    std::fs::write(&script, "pipeline main(task) {\n  return 1\n}\n").expect("write script");
+
+    let ok = Command::new(binary_path())
+        .args(["check", "--json", script.to_str().unwrap()])
+        .output()
+        .expect("spawn harn check --json");
+    assert!(
+        ok.status.success(),
+        "stderr:\n{}",
+        String::from_utf8_lossy(&ok.stderr)
+    );
+    let parsed = stdout_json(&ok);
+    let data = assert_envelope(&parsed, CHECK_SCHEMA_VERSION);
+    assert_eq!(data["summary"]["ok"], 1);
+    assert_eq!(data["files"][0]["status"], "ok");
+
+    std::fs::write(&script, "let p = Point { x: 3, y: 4 }\n").expect("rewrite script");
+    let failed = Command::new(binary_path())
+        .args(["check", "--json", script.to_str().unwrap()])
+        .output()
+        .expect("spawn failing harn check --json");
+    assert!(!failed.status.success(), "type error should fail check");
+    let parsed = stdout_json(&failed);
+    assert_eq!(parsed["schemaVersion"], CHECK_SCHEMA_VERSION);
+    assert_eq!(parsed["ok"], false);
+    assert_eq!(parsed["error"]["code"], "check_failed");
+    assert_eq!(parsed["data"]["summary"]["errors"], 1);
+    assert_eq!(parsed["data"]["files"][0]["status"], "error");
+    assert!(
+        parsed["data"]["files"][0]["diagnostics"]
+            .as_array()
+            .expect("diagnostics")
+            .iter()
+            .any(|diag| diag["code"].as_str().unwrap_or("").starts_with("HARN-TYP-")),
+        "expected a type diagnostic: {parsed}"
+    );
+}
+
+#[test]
+fn check_matrix_json_uses_envelope_and_legacy_format_warns() {
+    let output = Command::new(binary_path())
+        .args(["check", "--provider-matrix", "--json"])
+        .output()
+        .expect("spawn harn check --provider-matrix --json");
+    assert!(
+        output.status.success(),
+        "stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let parsed = stdout_json(&output);
+    let data = assert_envelope(&parsed, CHECK_SCHEMA_VERSION);
+    assert!(data.as_array().is_some(), "matrix data should be an array");
+
+    let legacy = Command::new(binary_path())
+        .args(["check", "--provider-matrix", "--format", "json"])
+        .output()
+        .expect("spawn harn check --provider-matrix --format json");
+    assert!(
+        legacy.status.success(),
+        "stderr:\n{}",
+        String::from_utf8_lossy(&legacy.stderr)
+    );
+    let parsed = stdout_json(&legacy);
+    let _ = assert_envelope(&parsed, CHECK_SCHEMA_VERSION);
+    assert_eq!(parsed["warnings"][0]["code"], "deprecated.flag");
+}
+
+#[test]
+fn check_and_fmt_are_registered_in_json_schema_catalog() {
+    for command in ["check", "fmt", "check provider-matrix"] {
+        let output = Command::new(binary_path())
+            .args(["--json-schemas", "--command", command])
+            .output()
+            .expect("spawn harn --json-schemas");
+        assert!(
+            output.status.success(),
+            "stderr:\n{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let parsed = stdout_json(&output);
+        let data = assert_envelope(&parsed, CATALOG_SCHEMA_VERSION);
+        assert_eq!(data.as_array().expect("entries").len(), 1);
+        assert_eq!(data[0]["command"], command);
+    }
+}


### PR DESCRIPTION
## Summary
- add `harn check --json` and `harn fmt --json` reports using the standard `JsonEnvelope`
- wrap provider/connector matrix JSON output in envelopes while keeping `--format=json` as a deprecated alias
- add `--json` aliases for Merge Captain ladder, iterate, and audit output
- register check/fmt/matrix schemas in `harn --json-schemas`

Closes #1759

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/tmp/harn-target-1759 HARN_LLM_CALLS_DISABLED=1 cargo test -p harn-cli --test check_fmt_json_cli`
- `CARGO_TARGET_DIR=/tmp/harn-target-1759 HARN_LLM_CALLS_DISABLED=1 cargo test -p harn-cli --test json_schemas_cli`
- `CARGO_TARGET_DIR=/tmp/harn-target-1759 HARN_LLM_CALLS_DISABLED=1 cargo test -p harn-cli --test check_cli`
- `CARGO_TARGET_DIR=/tmp/harn-target-1759 HARN_LLM_CALLS_DISABLED=1 cargo test -p harn-cli cli::tests::test_parses_merge_captain --lib`
- `CARGO_TARGET_DIR=/tmp/harn-target-1759 HARN_LLM_CALLS_DISABLED=1 cargo clippy -p harn-cli --all-targets -- -D warnings`
- pre-commit hook
- pre-push hook