### PR TITLE
Split embedded Harn skills by focus area

### DIFF
--- a/crates/harn-skills/src/corpus/harn-agent/SKILL.md
+++ b/crates/harn-skills/src/corpus/harn-agent/SKILL.md
@@ -7,10 +7,95 @@ when_to_use: Use when designing autonomous agent sessions, delegated workers, ap
 
 # Harn agent
 
-This embedded stub reserves the canonical `harn-agent` skill in the bundled corpus.
+Use this skill when designing autonomous Harn sessions, delegated workers, task decomposition, or approval-aware host interactions.
 
-Use this skill for autonomous Harn sessions, delegated workers, capability boundaries, approval-aware execution,
-and host interaction patterns.
+Pair it with [[harn-orchestration]] for workflow design and [[harn-diagnostics]] for repair/autonomy decisions.
 
-The detailed agent workflow guidance is supplied by the granular skill corpus; until then, use the repository
-docs and conformance tests as the source of truth.
+## Start here
+
+- Use `docs/llm/harn-quickref.md` for `agent_loop`.
+- Use the same quickref for tool formats, model options, and prompt templates.
+- Use [[harn-tracing]] when transcripts, replay, or receipts matter.
+- Agent session runtime code is mainly under `crates/harn-vm/src/agent_sessions*`.
+- Bridge behavior lives near `crates/harn-vm/src/bridge.rs`.
+- ACP behavior crosses VM and CLI integration tests.
+- Keep autonomous behavior inspectable.
+- Keep worktree-backed execution preferred for background edits.
+
+## Agent loop design
+
+- Give each loop a concrete task.
+- Give each loop an explicit stop condition.
+- Give each loop a narrow tool surface.
+- Carry a session id when transcript continuity matters.
+- Persist useful transcript deltas.
+- Persist recovery advice when failure can be resumed.
+- Persist mutation-session metadata when edits happen.
+- Keep handoff artifacts structured.
+- Avoid prose-only protocols for downstream automation.
+- Bound retries and tool-call loops.
+
+## Capability boundaries
+
+- Shell access should be explicit.
+- Filesystem mutation should be explicit.
+- Network access should be explicit.
+- MCP access should be explicit.
+- Host calls should be explicit.
+- Secrets should stay in host-managed capability stores.
+- Approval UX belongs to hosts.
+- Concrete file mutation belongs to hosts.
+- Undo and redo semantics belong to hosts.
+- Harn should record what happened and why.
+
+## Autonomy and repair
+
+- Use `harn check` before applying broad edits.
+- Use `harn lint` before merging user-facing Harn code.
+- Use `harn fix --plan` to inspect available repairs.
+- Use `harn fix --apply` only within the permitted safety ceiling.
+- Format-only repairs are safer than semantic rewrites.
+- Capability-affecting repairs should escalate.
+- Cross-file repairs should usually be reviewed.
+- When a diagnostic code is known, use the code, not message scraping.
+- If a tool result is ambiguous, ask for a smaller next step.
+- Do not continue autonomous mutation after a trust-boundary violation.
+
+## Delegation patterns
+
+- Split independent read-only investigation from implementation.
+- Give delegated workers a clear file ownership boundary.
+- Tell workers they are not alone in the codebase.
+- Avoid overlapping write sets.
+- Ask explorers specific codebase questions.
+- Ask workers to edit files directly only inside their scope.
+- Keep integration decisions in the coordinating session.
+- Review worker diffs before publishing.
+- Rerun the narrow tests that cover integrated changes.
+- Use [[harn-testing]] to pick the verification level.
+
+## Common gotchas
+
+- Do not assume ambient cwd state is safe for autonomous edits.
+- Do not hide generated files in source changes.
+- Do not widen capabilities to make a test pass.
+- Do not conflate user approval with tool availability.
+- Do not let compaction lose session intent.
+- Do not let retry loops mask real diagnostics.
+- Do not trust stale provider state.
+- Do not record private prompt content in public summaries.
+- Do not drop user or other-agent work when rebasing.
+- Do not commit temporary logging.
+
+## Verify
+
+- Agent session changes: targeted `cargo test -p harn-vm agent`.
+- Bridge or ACP behavior: `cargo test -p harn-cli --test acp_server_cli` when feasible.
+- Orchestration behavior: `cargo test -p harn-vm orchestration`.
+- Repair/autonomy behavior: targeted `harn fix` tests.
+- Transcript changes: targeted replay or record tests.
+- Harn workflow examples: `cargo run --quiet --bin harn -- check <path>`.
+- Conformance changes: `cargo run --quiet --bin harn -- test conformance --filter <name>`.
+- Flake guard for tests: `make lint-test-patterns`.
+- Broad shared behavior: `make test`.
+- Release-facing changes: run the release gate requested by the repo docs.

--- a/crates/harn-skills/src/corpus/harn-diagnostics/SKILL.md
+++ b/crates/harn-skills/src/corpus/harn-diagnostics/SKILL.md
@@ -7,10 +7,101 @@ when_to_use: Use when working on typechecker diagnostics, lint diagnostics, harn
 
 # Harn diagnostics
 
-This embedded stub reserves the canonical `harn-diagnostics` skill in the bundled corpus.
+Use this skill when changing errors, warnings, explain output, repair metadata, or fix application behavior.
 
-Use this skill for diagnostic code design, `harn explain`, repair plan metadata, fix-safety classes, and
-LSP-facing diagnostic behavior.
+Pair it with [[harn-language]] for syntax and type contracts and [[harn-agent]] for autonomy gating.
 
-The detailed diagnostics guidance is supplied by the granular skill corpus; until then, use the typechecker,
-linter, CLI diagnostics, and conformance coverage as the source of truth.
+## Start here
+
+- Parser diagnostics live primarily in `crates/harn-parser/`.
+- Typechecker diagnostics live in `crates/harn-parser/src/typechecker/`.
+- Lint diagnostics live in `crates/harn-lint/`.
+- CLI rendering and `harn explain` live under `crates/harn-cli/src/commands/`.
+- Repair planning and apply flows live under `crates/harn-cli/src/commands/fix.rs`.
+- Conformance `.error` fixtures are the executable spec for intentional failures.
+- LSP diagnostics should derive from the same core metadata as CLI diagnostics.
+- Do not fork diagnostic meaning between CLI, LSP, and docs.
+
+## Diagnostic categories
+
+- `TYP` covers type mismatch and typechecker failures.
+- `PAR` covers parser syntax failures.
+- `NAM` covers naming and resolution failures.
+- `CAP` covers capability and trust-boundary failures.
+- `LLM` covers LLM provider and model-call failures.
+- `ORC` covers orchestration and workflow failures.
+- `STD` covers stdlib and builtin failures.
+- `PRM` covers prompt-template failures.
+- `MOD` covers module-system and import failures.
+- `LNT` covers lint findings.
+- `FMT` covers formatter findings.
+- `IMP` covers import and package integration failures.
+- `OWN` covers ownership and lifetime-style constraints.
+- `RCV` covers recovery and resume failures.
+- `MAT` covers match and exhaustiveness failures.
+- Codes use the stable `HARN-<CAT>-<NNN>` format.
+
+## Message rules
+
+- Keep messages stable, specific, and actionable.
+- Point at the smallest useful span.
+- Do not blame the user; describe the invalid construct.
+- Mention the expected shape before the found shape when useful.
+- Include a short help string only when it reduces guesswork.
+- Avoid diagnostics that require reading compiler internals.
+- Prefer one primary error over many cascading errors.
+- Preserve existing code identifiers unless the old code was wrong.
+- Keep warnings clearly distinguishable from blocking errors.
+- Update explanations when changing a diagnostic's meaning.
+
+## Structured metadata
+
+- Preserve `code`.
+- Preserve `severity`.
+- Preserve source spans.
+- Preserve labels and notes.
+- Preserve related spans.
+- Preserve machine-applicable `FixEdit` values.
+- Preserve repair ids and summaries.
+- Preserve repair safety classes.
+- Preserve structured diagnostic details used by LSP code actions.
+- Avoid parsing human-readable messages in downstream tools.
+
+## Repair safety
+
+- Format-only edits can be auto-applied when they are byte-local and deterministic.
+- Syntax-local repairs can be auto-applied only when they cannot change intent.
+- Type or semantic repairs should usually be propose-only.
+- Cross-file edits need higher review.
+- Capability, network, shell, and mutation repairs need explicit approval.
+- `harn fix --plan` should explain why each repair is or is not safe.
+- `harn fix --apply` must respect the declared safety ceiling.
+- Do not hide skipped or rejected repairs.
+- Keep repairs idempotent.
+- Add tests for both plan and apply surfaces when safety behavior changes.
+
+## Cross-surface alignment
+
+- CLI rendering should show the stable code.
+- `harn explain` should resolve every registered code.
+- LSP diagnostics should expose matching codes and repair metadata.
+- JSON surfaces should keep codes machine-readable.
+- Conformance `.error` files should lock user-visible failures.
+- Docs should describe public diagnostics when users can act on them.
+- Generated diagnostic catalogs must stay in sync with the registry.
+- Do not hand-edit generated catalog artifacts.
+- Use [[harn-testing]] for fixture and JSON report coverage.
+- Use [[harn-tracing]] if diagnostics are stored in transcripts or receipts.
+
+## Verify
+
+- Parser/typechecker changes: `cargo test -p harn-parser <filter>`.
+- Lint changes: `cargo test -p harn-lint <filter>`.
+- CLI explain changes: `cargo test -p harn-cli --test <test-name>`.
+- Repair changes: targeted `harn fix` tests and `make lint-test-patterns`.
+- Intentional failure fixtures: `cargo run --quiet --bin harn -- test conformance --filter <name>`.
+- Rendered lint smoke: `cargo run --quiet --bin harn -- lint <path>`.
+- JSON diagnostics smoke: use the relevant `--json` command when available.
+- LSP changes: targeted `cargo test -p harn-lsp <filter>`.
+- Catalog drift: run the generator/check command documented by the touched catalog.
+- Broad gate for shared diagnostic changes: `make test`.

--- a/crates/harn-skills/src/corpus/harn-language/SKILL.md
+++ b/crates/harn-skills/src/corpus/harn-language/SKILL.md
@@ -7,10 +7,98 @@ when_to_use: Use when writing, reviewing, or explaining Harn source code and lan
 
 # Harn language
 
-This embedded stub reserves the canonical `harn-language` skill in the bundled corpus.
+Use this skill when writing, reviewing, or explaining `.harn` source code.
 
-Use this skill for Harn syntax, module structure, imports, typechecker expectations, public language behavior,
-and script authoring conventions.
+Pair it with [[harn-testing]] for fixtures and [[harn-diagnostics]] for user-facing errors.
 
-The detailed language reference remains in `docs/llm/harn-quickref.md` until the granular skill corpus carries
-the full language guidance.
+## Start here
+
+- Read `docs/llm/harn-quickref.md` before editing `.harn` files.
+- Use `docs/llm/harn-triggers-quickref.md` when trigger manifests are involved.
+- Treat `spec/HARN_SPEC.md` as the canonical language reference.
+- Edit `spec/HARN_SPEC.md`, not `docs/src/language-spec.md`, for spec changes.
+- Regenerate generated spec docs with `make sync-language-spec`.
+- Check user-visible behavior with conformance fixtures under `conformance/tests/`.
+- Keep examples small enough for agents to copy without hidden setup.
+- Prefer existing syntax and stdlib helpers over new host-side shortcuts.
+
+## Syntax checklist
+
+- Imports go first.
+- `pipeline` is the usual entry-point construct.
+- `fn` is for reusable pure or host-backed logic.
+- `let` binds values; avoid mutation unless the language surface requires it.
+- Use explicit type annotations at boundaries.
+- Use `match` for variant-sensitive behavior.
+- Use `for` for straightforward iteration.
+- Use `parallel each` for bounded fan-out work.
+- Use `parallel settle` when collecting settled outcomes matters.
+- Always set `max_concurrent` on broad parallel work.
+- Use triple-quoted strings for long prompts in Harn source.
+- Heredoc syntax is for LLM tool-call argument JSON, not general strings.
+- Keep comments factual and close to non-obvious logic.
+
+## Types and boundaries
+
+- Treat `unknown` as the type for untrusted inputs.
+- Narrow `unknown` with `type_of`, `schema_is`, or validated helpers.
+- Use `any` only as an explicit escape hatch.
+- Do not erase types merely to silence the typechecker.
+- Keep struct and enum names stable when they are user-facing.
+- Add conformance coverage before changing type inference behavior.
+- Preserve diagnostic codes and spans when refactoring typechecker logic.
+- Keep imported callable declarations aligned with module graph behavior.
+- Watch for strict-types behavior when changing boundary APIs.
+- Update examples when public type syntax changes.
+
+## Modules and imports
+
+- Keep import paths explicit and readable.
+- Avoid relying on the current working directory in examples.
+- When touching module resolution, inspect `crates/harn-modules`.
+- Cross-file checks should use the same module graph as the CLI.
+- Public symbols should remain discoverable by editor tooling.
+- Avoid duplicate import spellings for the same file.
+- Prefer canonical relative paths in fixtures.
+- Add a cycle regression when changing import traversal.
+- Keep generated docs and tree-sitter grammar in sync after syntax changes.
+- Use [[harn-orchestration]] when module behavior affects workflows.
+
+## Prompt templates
+
+- The template engine lives in `crates/harn-vm/src/stdlib/template.rs`.
+- Do not add a second prompt-template parser.
+- Keep host-call and script-call rendering behavior identical.
+- Preserve pre-v2 `{{name}}` missing-identifier passthrough.
+- New template constructs should fail with useful parse diagnostics.
+- Update `docs/src/prompt-templating.md` for template syntax changes.
+- Update `docs/llm/harn-quickref.md` when agents need the new syntax.
+- Update VS Code grammar when `.harn.prompt` syntax changes.
+- Add conformance fixtures under `conformance/tests/template_*`.
+- Use [[harn-diagnostics]] for template parse and lint diagnostics.
+
+## Simpler first
+
+- Can this be ordinary Harn instead of Rust?
+- Can a stdlib helper express this without a new language form?
+- Can the typechecker infer it without a new annotation?
+- Can a conformance fixture capture the behavior without a large harness?
+- Can docs describe the rule in one sentence?
+- Can the formatter preserve the style without special cases?
+- Can the linter derive the rule from existing AST structure?
+- Can the tree-sitter grammar remain a direct mirror of parser syntax?
+- Can existing examples be updated mechanically?
+- Can user-visible behavior stay backward compatible?
+
+## Verify
+
+- Narrow script check: `cargo run --quiet --bin harn -- check <path>`.
+- Narrow lint check: `cargo run --quiet --bin harn -- lint <path>`.
+- Narrow format check: `cargo run --quiet --bin harn -- fmt --check <path>`.
+- Narrow conformance case: `cargo run --quiet --bin harn -- test conformance --filter <name>`.
+- Parser changes: `cargo test -p harn-parser <filter>`.
+- Formatter changes: `cargo test -p harn-fmt <filter>`.
+- Linter changes: `cargo test -p harn-lint <filter>`.
+- Syntax or keyword changes: `make conformance`.
+- Harn fixture changes: `make lint-harn` and `make fmt-harn`.
+- Tree-sitter changes: `(cd tree-sitter-harn && npm test)`.

--- a/crates/harn-skills/src/corpus/harn-orchestration/SKILL.md
+++ b/crates/harn-skills/src/corpus/harn-orchestration/SKILL.md
@@ -7,10 +7,95 @@ when_to_use: Use when building or reviewing agent orchestration, persona handoff
 
 # Harn orchestration
 
-This embedded stub reserves the canonical `harn-orchestration` skill in the bundled corpus.
+Use this skill when designing or changing workflows that coordinate agents, tools, sessions, approvals, and host capabilities.
 
-Use this skill for `agent_loop`, tool-caller middleware, handoff artifacts, persona routing, orchestration
-control flow, and runtime behavior that composes host capabilities.
+Pair it with [[harn-agent]] for autonomous execution and [[harn-tracing]] for transcript and replay contracts.
 
-The detailed orchestration guidance is supplied by the granular skill corpus; until then, use the stdlib
-orchestration files and integration tests as the source of truth.
+## Start here
+
+- Use `docs/llm/harn-quickref.md` for `agent_loop`, `llm_call`, streams, and concurrency.
+- Use `docs/llm/harn-triggers-quickref.md` for trigger manifests and route audits.
+- Runtime orchestration code lives under `crates/harn-vm/src/orchestration/`.
+- CLI workflow entry points live under `crates/harn-cli/src/commands/`.
+- Host capability contracts cross the VM and host bridge.
+- Persona and workflow examples are useful only when they remain executable.
+- Prefer existing orchestration primitives before adding Rust-only control flow.
+- Keep user-visible workflows testable without live credentials.
+
+## Core surfaces
+
+- `agent_loop` drives iterative LLM/tool workflows.
+- `llm_call` and `llm_stream_call` perform direct model calls.
+- Tool middleware should preserve structured tool names and arguments.
+- `agent_spawn` and handoffs should carry explicit session context.
+- Hooks should return typed decisions, not prose protocols.
+- Triggers connect external events to Harn workflows.
+- Connectors normalize external payloads before script code sees them.
+- Daemon mode should keep restart and replay behavior clear.
+- Receipts should describe work done and decisions made.
+- Mutation sessions belong at the host boundary.
+
+## Trust boundary
+
+- Harn owns orchestration.
+- Harn owns transcript lifecycle.
+- Harn owns replay and eval contracts.
+- Harn owns delegated-worker lineage.
+- Harn owns mutation-session audit metadata.
+- Hosts own approval UX.
+- Hosts own concrete file mutations.
+- Hosts own undo and redo semantics.
+- Do not silently widen shell, filesystem, network, MCP, or host-call access.
+- Keep capabilities explicit in script inputs, manifests, and receipts.
+
+## Design rules
+
+- Keep orchestration in Harn when the logic is workflow composition.
+- Rust should provide durable primitives, not one-off process plans.
+- Carry session ids through workflow stages when transcript continuity matters.
+- Avoid ambient global state in long-running workflows.
+- Make retry, resume, and cancellation behavior visible.
+- Prefer deterministic handoff artifacts over free-form summaries.
+- Bound fan-out with `max_concurrent`.
+- Preserve ordering when downstream replay depends on it.
+- Keep tool-call schemas narrow.
+- Use [[harn-providers]] when provider routing affects orchestration behavior.
+
+## Trigger and channel work
+
+- Route external events through declared trigger sources.
+- Keep connector payload schemas explicit.
+- Avoid hidden coupling between tenant, org, pipeline, and session scopes.
+- Use batch filters only when they reduce real event noise.
+- Make back-pressure behavior observable.
+- Store enough event data for replay without leaking secrets.
+- Use typed handler variants for reminder injection and lifecycle hooks.
+- Keep route audits stable for CI.
+- Add conformance or integration coverage for new trigger semantics.
+- Update trigger quickrefs when users need a new manifest shape.
+
+## Simpler first
+
+- Can this be a Harn pipeline instead of a Rust command?
+- Can this be a stdlib helper instead of a new VM subsystem?
+- Can this reuse transcript/session builtins?
+- Can this be represented as a hook event?
+- Can this be a manifest option instead of imperative setup?
+- Can the host provide one capability instead of several ad hoc calls?
+- Can replay assert the behavior deterministically?
+- Can the portal read an additive event field?
+- Can the failure be reported as a diagnostic?
+- Can docs explain the workflow in a small example?
+
+## Verify
+
+- Runtime orchestration: `cargo test -p harn-vm orchestration`.
+- Agent/session behavior: `cargo test -p harn-vm agent`.
+- CLI workflow commands: `cargo test -p harn-cli --test <test-name>`.
+- Trigger manifests: use the relevant trigger/orchestrator checks.
+- Harn examples: `cargo run --quiet --bin harn -- check <path>`.
+- Conformance: `cargo run --quiet --bin harn -- test conformance --filter <name>`.
+- Replay behavior: targeted replay or event-log tests.
+- Portal-facing changes: `npm run portal:lint`, `portal:test`, and `portal:build`.
+- Broad shared changes: `make test`.
+- Docs snippets: `make check-docs-snippets`.

--- a/crates/harn-skills/src/corpus/harn-providers/SKILL.md
+++ b/crates/harn-skills/src/corpus/harn-providers/SKILL.md
@@ -7,10 +7,96 @@ when_to_use: Use when wiring or debugging LLM providers, model routes, provider 
 
 # Harn providers
 
-This embedded stub reserves the canonical `harn-providers` skill in the bundled corpus.
+Use this skill when wiring or debugging LLM providers, model routes, structured
+output, connector providers, or provider readiness.
 
-Use this skill for provider configuration, model routing, provider readiness checks, provider capability
-matrices, structured-output support, and `llm_call` option behavior.
+Pair it with [[harn-orchestration]] for workflow behavior and [[harn-testing]] for deterministic provider fixtures.
 
-The detailed provider guidance is supplied by the granular skill corpus; until then, use the provider catalog,
-CLI provider commands, and provider tests as the source of truth.
+## Start here
+
+- `docs/llm/harn-quickref.md` documents `llm_call` and `llm_stream_call`.
+- The quickref also covers `provider: "auto"`, schemas, and retries.
+- `docs/llm/harn-triggers-quickref.md` documents connector provider manifests.
+- LLM configuration and routing live under `crates/harn-vm/src/`.
+- Package/provider manifest handling lives under `crates/harn-cli/src/package/`.
+- Provider capability rows are surfaced by CLI matrix commands.
+- Mock providers are the default for deterministic tests.
+- Never require live credentials in ordinary CI.
+
+## `llm_call` options
+
+- Keep `provider` explicit when behavior depends on a vendor.
+- Use `provider: "auto"` only when capability-based routing is acceptable.
+- Keep `model` optional only when routing policy can choose safely.
+- Preserve `schema` validation behavior.
+- Preserve `schema_retries`.
+- Preserve provider-specific structured-output modes.
+- Preserve tool-call format negotiation.
+- Preserve timeout and cost controls.
+- Preserve prompt scaffolding behavior.
+- Preserve mock-provider determinism.
+
+## Capability routing
+
+- Model capabilities should be data-driven.
+- Avoid hardcoding provider quirks in caller code.
+- Capability checks should describe both positive and negative support.
+- JSON schema support is not the same as native JSON support.
+- Vision, PDF, audio, tools, cache, and streaming support vary independently.
+- Prompt scaffolding may differ by provider.
+- Tool prompting may differ by provider.
+- Assistant prefill support may differ by provider.
+- Developer-role support may differ by provider.
+- When routing changes, update the matrix tests or docs that expose it.
+
+## Connector providers
+
+- Connector packages should declare provider ids.
+- Connector packages should declare supported event kinds.
+- Connector packages should declare payload schemas.
+- Inbound normalization should be deterministic.
+- Optional polling should be explicit.
+- Connector `call` behavior should be capability-gated.
+- Keep OAuth and secret handling out of docs and fixtures.
+- Do not embed tokens in package manifests.
+- Use package validation tests for manifest shape.
+- Use trigger quickref examples for user-facing behavior.
+
+## Cost and reliability
+
+- Cost ceilings should be caller-visible.
+- Retry behavior should be bounded.
+- Provider fallback should be explicit and auditable.
+- Do not silently change the chosen provider after a partial tool exchange.
+- Record enough provider metadata for debugging.
+- Avoid logging secrets or raw private prompts in public traces.
+- Keep failure messages actionable.
+- Map provider failures to stable diagnostics where possible.
+- Preserve transcript shape when provider calls are replayed.
+- Use [[harn-tracing]] for transcript and receipt implications.
+
+## Review checklist
+
+- Does this change affect `provider: "auto"`?
+- Does this change structured-output behavior?
+- Does this affect streaming?
+- Does this affect tool calls?
+- Does this affect provider catalogs?
+- Does this affect connector manifests?
+- Does this affect offline behavior?
+- Does this require docs or CLI help updates?
+- Does this need conformance or mock-provider fixtures?
+- Does this remain deterministic without network access?
+
+## Verify
+
+- Provider config: `cargo test -p harn-vm config`.
+- LLM behavior: targeted VM provider tests.
+- Provider matrix: the relevant `harn check --provider-matrix` path.
+- Connector manifests: package validation tests.
+- Connector package: `harn connector test . --provider <id>`.
+- Mock-provider fixtures: targeted conformance or CLI tests.
+- JSON surfaces: `harn --json-schemas --command <command>`.
+- Docs snippets: `make check-docs-snippets` when examples change.
+- Broad VM changes: `cargo test -p harn-vm`.
+- Cross-crate provider changes: `make test`.

--- a/crates/harn-skills/src/corpus/harn-testing/SKILL.md
+++ b/crates/harn-skills/src/corpus/harn-testing/SKILL.md
@@ -7,10 +7,99 @@ when_to_use: Use when adding or reviewing conformance cases, eval fixtures, mock
 
 # Harn testing
 
-This embedded stub reserves the canonical `harn-testing` skill in the bundled corpus.
+Use this skill when adding or reviewing tests for Harn language, runtime, providers, orchestration, replay, or eval behavior.
 
-Use this skill for conformance tests, eval harnesses, deterministic replay fixtures, mock providers, and test
-coverage for language or runtime behavior.
+Pair it with [[harn-language]] for syntax contracts and [[harn-tracing]] for replay or transcript assertions.
 
-The detailed testing guidance is supplied by the granular skill corpus; until then, use `conformance/tests/`,
-eval fixtures, and `docs/src/dev/testing.md` as the source of truth.
+## Start here
+
+- `conformance/tests/` is the executable spec for user-visible behavior.
+- `docs/src/dev/testing.md` lists deterministic test patterns and banned flaky patterns.
+- `docs/llm/harn-quickref.md` covers `.harn` syntax used in fixtures.
+- Use the narrowest package target that protects the changed contract.
+- Expand only when behavior crosses crates or user-facing CLI paths.
+- Prefer deterministic mocks over live services.
+- Keep fixture names descriptive and stable.
+- Put failure cases next to nearby passing cases.
+
+## Conformance fixtures
+
+- Passing `.harn` files normally pair with `.expected`.
+- Intentional failures pair with `.error`.
+- `@xfail` marks an expected failing case.
+- In JSON conformance reports, expected failing `@xfail` cases are `xfail_expected`.
+- In JSON conformance reports, passing `@xfail` cases are `xfail_unexpected_pass`.
+- Unexpected xfail passes should fail the suite.
+- `snapshotKey` identifies the selected fixture set and relevant sidecars.
+- Keep fixture sidecars checked in with the case they describe.
+- Use mock LLM tapes for provider-sensitive behavior.
+- Use process tapes for deterministic host-process behavior.
+- Keep `.expected` output minimal and user-visible.
+- Keep `.error` output stable around diagnostic codes and messages.
+
+## Determinism rules
+
+- Do not add `std::thread::sleep` to tests.
+- Do not add `tokio::time::sleep` to tests.
+- Do not add wall-clock polling loops.
+- Do not use `SystemTime::now()` in tests.
+- Do not use short `recv_timeout` waits.
+- Prefer `tokio::time::pause()` and `advance()`.
+- Prefer `mock_time` or paused clocks for time-sensitive behavior.
+- Prefer `EventLog::subscribe()` over sleep-and-check loops.
+- Prefer `OrchestratorHarness` for orchestration state machines.
+- Use replay fixtures when output order is part of the contract.
+- Keep random behavior seeded or mocked.
+- Assert on structured data before rendered prose when possible.
+
+## Layer choice
+
+- Parser syntax belongs in `harn-parser` tests or conformance.
+- Formatter behavior belongs in `harn-fmt` tests plus focused CLI smoke when needed.
+- Lint rules belong in `harn-lint` tests plus CLI coverage for flags.
+- Runtime stdlib behavior belongs in `harn-vm` tests or conformance.
+- CLI JSON contracts belong in `crates/harn-cli/tests/`.
+- Provider behavior should use mock providers unless live reachability is the point.
+- Portal changes need portal lint, tests, and build.
+- Tree-sitter changes need grammar tests and fixture updates.
+- Docs snippets need `make check-docs-snippets`.
+- Keep broad `make test` for higher-risk shared behavior.
+
+## Evals and replay
+
+- Eval fixtures should isolate model variance from runtime determinism.
+- Store model-independent expectations whenever possible.
+- Use transcripts and receipts as replay contracts.
+- Prefer structured assertions over scoring prose.
+- Keep Langfuse or OTel exports out of unit tests unless mocked.
+- Replay should not require credentials.
+- Avoid tests that depend on external network timing.
+- Keep failure output short enough for CI logs.
+- Add regression tests for every fixed flake.
+- Use [[harn-tracing]] for receipt, transcript, and replay details.
+
+## Review checklist
+
+- Does the test fail before the fix?
+- Does the test protect the user-visible contract?
+- Is the fixture name specific?
+- Is the test deterministic on macOS, Linux, and Windows?
+- Does it avoid sleeps and wall-clock time?
+- Does it avoid live credentials?
+- Does it keep generated files out of source control?
+- Does it use existing helpers instead of custom harness code?
+- Does it keep assertions stable across unrelated formatting changes?
+- Does it include both success and failure coverage when the behavior has both?
+
+## Verify
+
+- General workspace tests: `make test`.
+- Narrow Rust package: `cargo test -p <package> <filter>`.
+- Conformance suite: `cargo run --quiet --bin harn -- test conformance`.
+- Conformance JSON: `cargo run --quiet --bin harn -- test conformance --json`.
+- Targeted conformance: `cargo run --quiet --bin harn -- test conformance --filter <name>`.
+- Flake guard: `make lint-test-patterns`.
+- Harn fixture lint: `make lint-harn`.
+- Harn fixture format: `make fmt-harn`.
+- Docs snippets: `make check-docs-snippets`.
+- Portal changes: `npm run portal:lint`, `npm run portal:test`, and `npm run portal:build`.

--- a/crates/harn-skills/src/corpus/harn-tracing/SKILL.md
+++ b/crates/harn-skills/src/corpus/harn-tracing/SKILL.md
@@ -7,10 +7,96 @@ when_to_use: Use when inspecting or changing run records, transcripts, replay pa
 
 # Harn tracing
 
-This embedded stub reserves the canonical `harn-tracing` skill in the bundled corpus.
+Use this skill when inspecting or changing transcripts, receipts, run records,
+replay, observability events, or portal-facing activity data.
 
-Use this skill for transcripts, receipts, run records, trace import/export, replay, observability sinks, and
-portal-facing activity data.
+Pair it with [[harn-orchestration]] for workflow events and [[harn-testing]] for deterministic replay fixtures.
 
-The detailed tracing guidance is supplied by the granular skill corpus; until then, use the transcript,
-receipt, replay, and portal schemas as the source of truth.
+## Start here
+
+- Transcript code is primarily under `crates/harn-vm/src/orchestration/`.
+- Run-record code lives near orchestration record modules.
+- Replay surfaces feed CLI audits, evals, and portal views.
+- Receipts describe durable actions and decisions.
+- OTel and Langfuse exporters are observability surfaces, not core logic.
+- The portal UI lives under `crates/harn-cli/portal/`.
+- Only edit portal code when the stored activity contract changes.
+- Treat persisted trace data as a compatibility contract.
+
+## Transcript rules
+
+- Preserve event ordering.
+- Preserve event ids.
+- Preserve cursors.
+- Preserve session ids.
+- Preserve run ids.
+- Preserve worker lineage.
+- Preserve parent-child relationships.
+- Preserve private/public transcript boundaries.
+- Do not leak secrets into public event channels.
+- Normalize old records rather than breaking replay.
+
+## Receipt rules
+
+- Keep receipts machine-readable.
+- Keep action ids stable.
+- Keep provenance fields explicit.
+- Include enough context for audit.
+- Avoid full private prompt content unless the receipt channel is private.
+- Record approvals and denials distinctly.
+- Record skipped work when it affects outcome.
+- Record replay-relevant hashes when available.
+- Human summaries may change more freely than JSON contracts.
+- Use [[harn-diagnostics]] for receipt validation failures.
+
+## Replay rules
+
+- Replay should not call live providers.
+- Replay should not require network access.
+- Replay should not depend on wall-clock time.
+- Replay should preserve deterministic ordering.
+- Replay fixtures should be small and explain the scenario.
+- Replay failures should point to the first mismatched event.
+- Cached inputs should be explicit.
+- Signed timestamps should stay verifiable.
+- Missing optional fields should have deterministic defaults.
+- Add migration coverage for persisted schema changes.
+
+## Observability rules
+
+- Spans should map to real workflow phases.
+- Span names should be stable.
+- Span attributes should avoid secrets.
+- Links should connect resume and handoff relationships.
+- Metrics should be low-cardinality.
+- Logs should be useful without full prompts.
+- OTel changes should not change runtime semantics.
+- Langfuse exports should be derived from canonical events.
+- Portal data should be derived from persisted records.
+- Backfills should be explicit and testable.
+
+## Common mistakes
+
+- Do not treat rendered text as the source of truth.
+- Do not add a second transcript schema.
+- Do not drop unknown fields during read-write paths.
+- Do not store only local filesystem paths in portable records.
+- Do not make replay depend on current provider config.
+- Do not conflate stdout, stderr, and transcript events.
+- Do not merge private and public prompt content.
+- Do not assume event delivery is immediate.
+- Do not rely on sleeps in observability tests.
+- Do not hand-edit generated run artifacts.
+
+## Verify
+
+- Run-record tests: targeted `cargo test -p harn-vm record`.
+- Replay tests: targeted `cargo test -p harn-vm replay`.
+- Orchestration events: `cargo test -p harn-vm orchestration`.
+- CLI audit or eval: `cargo test -p harn-cli --test <test-name>`.
+- Portal contract changes: `npm run portal:lint`.
+- Portal tests: `npm run portal:test`.
+- Portal build: `npm run portal:build`.
+- Trace fixture changes: targeted replay or eval fixture tests.
+- Flake guard: `make lint-test-patterns` when adding tests.
+- Broad shared changes: `make test`.

--- a/crates/harn-skills/src/lib.rs
+++ b/crates/harn-skills/src/lib.rs
@@ -114,7 +114,19 @@ mod tests {
     #[test]
     fn lists_expected_initial_corpus() {
         let skills = list_embedded_skills();
-        assert!(skills.len() >= 7);
+        let names: Vec<&str> = skills.iter().map(|skill| skill.name).collect();
+        assert_eq!(
+            names,
+            [
+                "harn-agent",
+                "harn-diagnostics",
+                "harn-language",
+                "harn-orchestration",
+                "harn-providers",
+                "harn-testing",
+                "harn-tracing",
+            ]
+        );
         assert_eq!(skills.len(), SOURCES.len());
     }
 
@@ -183,5 +195,99 @@ mod tests {
             bytes <= 200 * 1024,
             "embedded corpus is {bytes} bytes, expected <= 200 KiB"
         );
+    }
+
+    #[test]
+    fn skill_bodies_are_focused_and_not_placeholders() {
+        let expectations = [
+            ("harn-agent", ["agent_loop", "session id", "approval"]),
+            ("harn-diagnostics", ["diagnostic", "repair", "conformance"]),
+            ("harn-language", ["quickref", "type", "conformance"]),
+            ("harn-orchestration", ["agent_loop", "workflow", "host"]),
+            ("harn-providers", ["llm_call", "provider", "schema"]),
+            (
+                "harn-testing",
+                ["conformance", "deterministic", "mock_time"],
+            ),
+            ("harn-tracing", ["replay", "receipts", "transcript"]),
+        ];
+
+        for (name, terms) in expectations {
+            let skill = get_embedded_skill(name).expect("expected embedded skill");
+            let body = skill.body.to_ascii_lowercase();
+            assert!(
+                !body.contains("embedded stub") && !body.contains("placeholder"),
+                "{name} should contain real guidance, not stub wording"
+            );
+            for term in terms {
+                assert!(
+                    body.contains(term),
+                    "{name} body should mention focused term `{term}`"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn skill_bodies_match_split_skill_contract() {
+        for skill in list_embedded_skills() {
+            let lines = skill.body.lines().count();
+            assert!(
+                lines >= 80,
+                "{} body is {lines} lines, expected at least 80",
+                skill.name
+            );
+            assert!(
+                lines <= 300,
+                "{} body is {lines} lines, expected at most 300",
+                skill.name
+            );
+        }
+    }
+
+    #[test]
+    fn skill_cross_links_resolve_to_embedded_skills() {
+        let names: BTreeSet<&str> = list_embedded_skills()
+            .iter()
+            .map(|skill| skill.name)
+            .collect();
+        for skill in list_embedded_skills() {
+            for reference in bracketed_skill_references(skill.body) {
+                assert!(
+                    names.contains(reference),
+                    "{} links to unknown embedded skill [[{}]]",
+                    skill.name,
+                    reference
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn diagnostics_skill_mentions_all_code_categories() {
+        let skill = get_embedded_skill("harn-diagnostics").expect("diagnostics skill");
+        for category in [
+            "TYP", "PAR", "NAM", "CAP", "LLM", "ORC", "STD", "PRM", "MOD", "LNT", "FMT", "IMP",
+            "OWN", "RCV", "MAT",
+        ] {
+            assert!(
+                skill.body.contains(&format!("`{category}`")),
+                "harn-diagnostics should mention diagnostic category `{category}`"
+            );
+        }
+    }
+
+    fn bracketed_skill_references(body: &str) -> Vec<&str> {
+        let mut references = Vec::new();
+        let mut rest = body;
+        while let Some(start) = rest.find("[[") {
+            rest = &rest[start + 2..];
+            let Some(end) = rest.find("]]") else {
+                break;
+            };
+            references.push(&rest[..end]);
+            rest = &rest[end + 2..];
+        }
+        references
     }
 }


### PR DESCRIPTION
## Summary
- replace the seven embedded Harn skill stubs with focused bodies for language, orchestration, diagnostics, providers, tracing, testing, and agent workflows
- add cross-skill references and diagnostics guidance covering all 15 code category prefixes
- strengthen harn-skills corpus tests for exact names, body size bounds, cross-link resolution, and non-placeholder content

Closes #1763

## Verification
- `cargo fmt --package harn-skills --check`
- `git diff --check`
- `npx markdownlint-cli2 "crates/harn-skills/src/corpus/**/*.md"`
- `CARGO_TARGET_DIR=/tmp/harn-target-1763 HARN_LLM_CALLS_DISABLED=1 cargo test -p harn-skills`
- `CARGO_TARGET_DIR=/tmp/harn-target-1763 HARN_LLM_CALLS_DISABLED=1 cargo test -p harn-cli --test skills_cli`
- pre-commit hook
- pre-push hook