### PR TITLE
Add HARN_SKILLS_DIR canonical skill override

### DIFF
--- a/.claude/skills/harn-scripting/SKILL.md
+++ b/.claude/skills/harn-scripting/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: harn-scripting
+description: Pointer skill - fetch the harn-* inner skill matching your task via the local harn binary
+---
+
+Before writing or editing `.harn` code, list the available inner skills with
+`harn skills list --json` and fetch the narrowest match with
+`harn skills get <name> --full`. The canonical content ships in the binary
+itself, so the docs always match the binary version in use.

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ conformance/tests/**/.harn/events.sqlite-wal
 # .claude/ is local-only except for shared skill definitions
 .claude/*
 !.claude/commands/
+!.claude/skills/
+!.claude/skills/harn-scripting/
+!.claude/skills/harn-scripting/SKILL.md
 # `merge-captain` covers the Harn-triad lay of the land (including the
 # private harn-cloud repo + business goals); it lives in burin-code's
 # local `.claude/commands/` only, never in the public harn repo.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,18 +4,15 @@ This repository implements Harn, a programming language and runtime for orchestr
 
 ## For agents writing Harn scripts
 
-Before writing or editing `.harn` code, read the one-page Harn quickref. It covers syntax,
-concurrency primitives (`parallel each` / `parallel settle` with `max_concurrent`), the
-`llm_call` options table (including `schema_retries` + `provider: "auto"`), and the gotchas
-that repeatedly trip up first-time scripters.
+Before writing or editing `.harn` code, list the embedded Harn skills with
+`harn skills list --json` and fetch the narrowest matching guide with
+`harn skills get <name> --full`. Start with `harn-language` for syntax,
+types, concurrency primitives, `llm_call`, and first-time scripting gotchas;
+use `harn-orchestration` for trigger or agent workflow changes.
 
-- In-repo: `docs/llm/harn-quickref.md`
-- Trigger/orchestrator add-on: `docs/llm/harn-triggers-quickref.md`
-- Canonical URL: <https://harnlang.com/docs/llm/harn-quickref.html>
-- Trigger/orchestrator URL: <https://harnlang.com/docs/llm/harn-triggers-quickref.html>
-
-Claude Code users get these autoloaded via the `harn-scripting` skill
-at `.claude/skills/harn-scripting/SKILL.md`.
+Claude Code users get this discovery reminder via the `harn-scripting` stub
+at `.claude/skills/harn-scripting/SKILL.md`; the full content ships in the
+local `harn` binary so it matches the version in use.
 
 ## Dev environment tips
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2331,6 +2331,9 @@ dependencies = [
 [[package]]
 name = "harn-skills"
 version = "0.8.25"
+dependencies = [
+ "tempfile",
+]
 
 [[package]]
 name = "harn-stdlib"

--- a/crates/harn-cli/src/cli/skills.rs
+++ b/crates/harn-cli/src/cli/skills.rs
@@ -8,11 +8,11 @@ pub(crate) struct SkillsArgs {
 
 #[derive(Debug, Subcommand)]
 pub(crate) enum SkillsCommand {
-    /// List the embedded canonical Harn skill corpus.
+    /// List the active canonical Harn skill corpus.
     List(SkillsListArgs),
-    /// Print one embedded skill's frontmatter (or full body with `--full`).
+    /// Print one canonical skill's frontmatter (or full body with `--full`).
     Get(SkillsGetArgs),
-    /// Write the embedded skill corpus to disk for offline review.
+    /// Write the active canonical skill corpus to disk for offline review.
     Dump(SkillsDumpArgs),
     /// Show layered-resolution skills discovered from the filesystem.
     Resolved(SkillsResolvedArgs),
@@ -29,14 +29,14 @@ pub(crate) enum SkillsCommand {
 
 #[derive(Debug, Args)]
 pub(crate) struct SkillsListArgs {
-    /// Emit a [`JsonEnvelope`]-wrapped catalog of embedded skills.
+    /// Emit a [`JsonEnvelope`]-wrapped catalog of canonical skills.
     #[arg(long)]
     pub json: bool,
 }
 
 #[derive(Debug, Args)]
 pub(crate) struct SkillsGetArgs {
-    /// Embedded skill name (e.g. `harn-language`).
+    /// Canonical skill name (e.g. `harn-language`).
     pub name: String,
     /// Include the full SKILL.md body alongside the frontmatter.
     #[arg(long)]

--- a/crates/harn-cli/src/commands/skills.rs
+++ b/crates/harn-cli/src/commands/skills.rs
@@ -2,10 +2,10 @@
 //!
 //! Two complementary surfaces share this namespace:
 //!
-//! - `list` / `get` / `dump` operate on the **embedded corpus** shipped
-//!   inside the `harn` binary (see [`harn_skills`]). These are the
-//!   canonical Harn skills — `harn-language`, `harn-orchestration`,
-//!   etc. — and are always available without a project on disk.
+//! - `list` / `get` / `dump` operate on the **canonical corpus** from
+//!   [`harn_skills`]. By default this is the embedded corpus shipped
+//!   inside the `harn` binary; `HARN_SKILLS_DIR` can point at a
+//!   recursive `SKILL.md` tree while iterating locally.
 //! - `resolved` / `inspect` / `match` / `install` / `new` operate on
 //!   the **layered FS discovery** implemented in `harn_vm::skills`, so
 //!   what the user sees there is byte-for-byte what `harn run` /
@@ -23,7 +23,10 @@ use std::{fs, process};
 
 use serde::Serialize;
 
-use harn_skills::{get_embedded_skill, list_embedded_skills, EmbeddedSkill, SkillFrontmatter};
+use harn_skills::{
+    resolve_skill_corpus_from_env, DiskSkill, DiskSkillFrontmatter, EmbeddedSkill, SkillCorpus,
+    SkillFrontmatter,
+};
 use harn_vm::skills::{
     build_fs_discovery, default_system_dirs, default_user_dir, parse_env_skills_path,
     DiscoveryOptions, FsLayerConfig, Layer, LayeredDiscovery, ManifestSource, Skill,
@@ -49,20 +52,29 @@ pub(crate) const SKILLS_GET_SCHEMA_VERSION: u32 = 1;
 /// no body, to keep `list` cheap to consume.
 #[derive(Debug, Clone, Serialize)]
 pub struct ListedSkill {
-    pub name: &'static str,
-    pub short: &'static str,
-    pub description: &'static str,
+    pub name: String,
+    pub short: String,
+    pub description: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub when_to_use: Option<&'static str>,
+    pub when_to_use: Option<String>,
 }
 
 impl ListedSkill {
     fn from_embedded(skill: &EmbeddedSkill) -> Self {
         Self {
-            name: skill.name,
-            short: skill.frontmatter.short,
-            description: skill.frontmatter.description,
-            when_to_use: skill.frontmatter.when_to_use,
+            name: skill.name.to_string(),
+            short: skill.frontmatter.short.to_string(),
+            description: skill.frontmatter.description.to_string(),
+            when_to_use: skill.frontmatter.when_to_use.map(str::to_string),
+        }
+    }
+
+    fn from_disk(skill: &DiskSkill) -> Self {
+        Self {
+            name: skill.name.clone(),
+            short: skill.frontmatter.short.clone(),
+            description: skill.frontmatter.description.clone(),
+            when_to_use: skill.frontmatter.when_to_use.clone(),
         }
     }
 }
@@ -89,23 +101,33 @@ impl JsonOutput for SkillsListPayload {
 /// JSON shape encodes the distinction unambiguously.
 #[derive(Debug, Clone, Serialize)]
 pub struct SkillsGetPayload {
-    pub name: &'static str,
-    pub short: &'static str,
-    pub description: &'static str,
+    pub name: String,
+    pub short: String,
+    pub description: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub when_to_use: Option<&'static str>,
+    pub when_to_use: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub body: Option<&'static str>,
+    pub body: Option<String>,
 }
 
 impl SkillsGetPayload {
     fn from_embedded(skill: &EmbeddedSkill, include_body: bool) -> Self {
         Self {
-            name: skill.name,
-            short: skill.frontmatter.short,
-            description: skill.frontmatter.description,
-            when_to_use: skill.frontmatter.when_to_use,
-            body: include_body.then_some(skill.body),
+            name: skill.name.to_string(),
+            short: skill.frontmatter.short.to_string(),
+            description: skill.frontmatter.description.to_string(),
+            when_to_use: skill.frontmatter.when_to_use.map(str::to_string),
+            body: include_body.then(|| skill.body.to_string()),
+        }
+    }
+
+    fn from_disk(skill: &DiskSkill, include_body: bool) -> Self {
+        Self {
+            name: skill.name.clone(),
+            short: skill.frontmatter.short.clone(),
+            description: skill.frontmatter.description.clone(),
+            when_to_use: skill.frontmatter.when_to_use.clone(),
+            body: include_body.then(|| skill.body.clone()),
         }
     }
 }
@@ -119,14 +141,14 @@ impl JsonOutput for SkillsGetPayload {
     }
 }
 
-/// `harn skills list` — surfaces the embedded canonical Harn skill
+/// `harn skills list` — surfaces the active canonical Harn skill
 /// corpus. FS-discovered skills live under `harn skills resolved`.
 pub(crate) fn run_list(args: &SkillsListArgs) {
-    let skills = list_embedded_skills();
+    let corpus = resolve_skill_corpus_or_exit();
 
     if args.json {
         let payload = SkillsListPayload {
-            skills: skills.iter().map(ListedSkill::from_embedded).collect(),
+            skills: list_payload_entries(&corpus),
         };
         println!(
             "{}",
@@ -135,18 +157,23 @@ pub(crate) fn run_list(args: &SkillsListArgs) {
         return;
     }
 
-    if skills.is_empty() {
-        println!("No embedded skills bundled with this `harn` build.");
+    if corpus.is_empty() {
+        println!("No canonical skills available for this `harn` build.");
         return;
     }
 
-    println!("Embedded canonical skills ({}):", skills.len());
-    let name_width = skills.iter().map(|s| s.name.len()).max().unwrap_or(4);
-    for skill in skills {
-        let short = if skill.frontmatter.short.is_empty() {
+    if corpus.is_disk() {
+        println!("Disk canonical skills ({}):", corpus.len());
+    } else {
+        println!("Embedded canonical skills ({}):", corpus.len());
+    }
+    let entries = list_payload_entries(&corpus);
+    let name_width = entries.iter().map(|s| s.name.len()).max().unwrap_or(4);
+    for skill in entries {
+        let short = if skill.short.is_empty() {
             "(no short description)"
         } else {
-            skill.frontmatter.short
+            &skill.short
         };
         println!(
             "  {:<name_width$}  {}",
@@ -160,41 +187,68 @@ pub(crate) fn run_list(args: &SkillsListArgs) {
     println!("Run `harn skills get <name> --full` to include the body.");
 }
 
-/// `harn skills get <name>` — embedded skill frontmatter, or full
+/// `harn skills get <name>` — canonical skill frontmatter, or full
 /// SKILL.md body when `--full` is passed.
 pub(crate) fn run_get(args: &SkillsGetArgs) {
-    let Some(skill) = get_embedded_skill(&args.name) else {
-        emit_get_not_found(&args.name, args.json);
-        process::exit(1);
-    };
+    let corpus = resolve_skill_corpus_or_exit();
 
-    if args.json {
-        let payload = SkillsGetPayload::from_embedded(skill, args.full);
-        println!(
-            "{}",
-            json_envelope::to_string_pretty(&payload.into_envelope())
-        );
-        return;
-    }
-
-    print_skill_frontmatter(&skill.frontmatter);
-    if args.full {
-        println!();
-        println!("---- SKILL.md body ----");
-        print!("{}", skill.body);
-        if !skill.body.ends_with('\n') {
-            println!();
+    match &corpus {
+        SkillCorpus::Embedded(skills) => {
+            let Some(skill) = skills.iter().find(|skill| skill.name == args.name) else {
+                emit_get_not_found(&args.name, args.json, &corpus);
+                process::exit(1);
+            };
+            if args.json {
+                let payload = SkillsGetPayload::from_embedded(skill, args.full);
+                println!(
+                    "{}",
+                    json_envelope::to_string_pretty(&payload.into_envelope())
+                );
+                return;
+            }
+            print_skill_frontmatter(&skill.frontmatter);
+            if args.full {
+                println!();
+                println!("---- SKILL.md body ----");
+                print!("{}", skill.body);
+                if !skill.body.ends_with('\n') {
+                    println!();
+                }
+            }
+        }
+        SkillCorpus::Disk(skills) => {
+            let Some(skill) = skills.iter().find(|skill| skill.name == args.name) else {
+                emit_get_not_found(&args.name, args.json, &corpus);
+                process::exit(1);
+            };
+            if args.json {
+                let payload = SkillsGetPayload::from_disk(skill, args.full);
+                println!(
+                    "{}",
+                    json_envelope::to_string_pretty(&payload.into_envelope())
+                );
+                return;
+            }
+            print_disk_skill_frontmatter(&skill.frontmatter);
+            if args.full {
+                println!();
+                println!("---- SKILL.md body ----");
+                print!("{}", skill.body);
+                if !skill.body.ends_with('\n') {
+                    println!();
+                }
+            }
         }
     }
 }
 
-/// `harn skills dump --all` — write every embedded skill to disk so
-/// agents and CI can review the corpus offline.
+/// `harn skills dump --all` — write every canonical skill to disk so
+/// agents and CI can review the active corpus offline.
 pub(crate) fn run_dump(args: &SkillsDumpArgs) {
     if !args.all {
         eprintln!(
             "error: `harn skills dump` requires `--all`. \
-             Pass `--all` to write every embedded skill."
+             Pass `--all` to write every canonical skill."
         );
         process::exit(2);
     }
@@ -210,7 +264,8 @@ pub(crate) fn run_dump(args: &SkillsDumpArgs) {
         process::exit(1);
     }
 
-    let skills = list_embedded_skills();
+    let corpus = resolve_skill_corpus_or_exit();
+    let skills = dump_entries(&corpus);
     let mut written = Vec::with_capacity(skills.len());
     for skill in skills {
         let skill_dir = out_dir.join(skill.name);
@@ -228,8 +283,8 @@ pub(crate) fn run_dump(args: &SkillsDumpArgs) {
             process::exit(1);
         }
 
-        // Byte-for-byte mirror the binary's canonical source so on-disk
-        // copies stay diff-stable against the embedded record.
+        // Byte-for-byte mirror the active canonical source so dumped
+        // copies stay diff-stable against their origin.
         if let Err(error) = fs::write(&dest, skill.source) {
             eprintln!("error: failed to write {}: {error}", dest.display());
             process::exit(1);
@@ -240,6 +295,16 @@ pub(crate) fn run_dump(args: &SkillsDumpArgs) {
     println!("Wrote {} skill(s) to {}", written.len(), out_dir.display());
     for path in &written {
         println!("  {}", path.display());
+    }
+}
+
+fn resolve_skill_corpus_or_exit() -> SkillCorpus {
+    match resolve_skill_corpus_from_env() {
+        Ok(corpus) => corpus,
+        Err(error) => {
+            eprintln!("error: failed to load HARN_SKILLS_DIR: {error}");
+            process::exit(1);
+        }
     }
 }
 
@@ -256,23 +321,73 @@ fn print_skill_frontmatter(frontmatter: &SkillFrontmatter) {
     }
 }
 
-fn emit_get_not_found(name: &str, json: bool) {
+fn print_disk_skill_frontmatter(frontmatter: &DiskSkillFrontmatter) {
+    println!("name:        {}", frontmatter.name);
+    if !frontmatter.short.is_empty() {
+        println!("short:       {}", frontmatter.short);
+    }
+    if !frontmatter.description.is_empty() {
+        println!("description: {}", frontmatter.description);
+    }
+    if let Some(when) = &frontmatter.when_to_use {
+        println!("when_to_use: {when}");
+    }
+}
+
+fn list_payload_entries(corpus: &SkillCorpus) -> Vec<ListedSkill> {
+    match corpus {
+        SkillCorpus::Embedded(skills) => skills.iter().map(ListedSkill::from_embedded).collect(),
+        SkillCorpus::Disk(skills) => skills.iter().map(ListedSkill::from_disk).collect(),
+    }
+}
+
+fn available_skill_names(corpus: &SkillCorpus) -> Vec<String> {
+    match corpus {
+        SkillCorpus::Embedded(skills) => {
+            skills.iter().map(|skill| skill.name.to_string()).collect()
+        }
+        SkillCorpus::Disk(skills) => skills.iter().map(|skill| skill.name.clone()).collect(),
+    }
+}
+
+struct DumpEntry<'a> {
+    name: &'a str,
+    source: &'a str,
+}
+
+fn dump_entries(corpus: &SkillCorpus) -> Vec<DumpEntry<'_>> {
+    match corpus {
+        SkillCorpus::Embedded(skills) => skills
+            .iter()
+            .map(|skill| DumpEntry {
+                name: skill.name,
+                source: skill.source,
+            })
+            .collect(),
+        SkillCorpus::Disk(skills) => skills
+            .iter()
+            .map(|skill| DumpEntry {
+                name: skill.name.as_str(),
+                source: skill.source.as_str(),
+            })
+            .collect(),
+    }
+}
+
+fn emit_get_not_found(name: &str, json: bool, corpus: &SkillCorpus) {
     if json {
         let envelope: JsonEnvelope<SkillsGetPayload> = JsonEnvelope::err(
             SKILLS_GET_SCHEMA_VERSION,
             "skill_not_found",
-            format!("no embedded skill named `{name}`"),
+            format!("no skill named `{name}`"),
         )
         .with_details(serde_json::json!({
             "requested": name,
-            "available": list_embedded_skills()
-                .iter()
-                .map(|s| s.name)
-                .collect::<Vec<_>>(),
+            "available": available_skill_names(corpus),
         }));
         println!("{}", json_envelope::to_string_pretty(&envelope));
     } else {
-        eprintln!("error: no embedded skill named `{name}`.");
+        eprintln!("error: no skill named `{name}`.");
         eprintln!("hint: run `harn skills list` to see what ships with this binary.");
     }
 }

--- a/crates/harn-cli/src/json_envelope.rs
+++ b/crates/harn-cli/src/json_envelope.rs
@@ -221,13 +221,13 @@ pub fn catalog() -> Vec<SchemaEntry> {
         SchemaEntry {
             command: "skills list",
             schema_version: 1,
-            description: "Embedded canonical Harn skill corpus, frontmatter only.",
+            description: "Canonical Harn skill corpus, frontmatter only.",
             schema_json: None,
         },
         SchemaEntry {
             command: "skills get",
             schema_version: 1,
-            description: "One embedded skill's frontmatter (and body with --full).",
+            description: "One canonical skill's frontmatter (and body with --full).",
             schema_json: None,
         },
         SchemaEntry {

--- a/crates/harn-cli/tests/skills_cli.rs
+++ b/crates/harn-cli/tests/skills_cli.rs
@@ -1,5 +1,5 @@
 //! End-to-end coverage for `harn skills list / get / dump` against
-//! the embedded canonical skill corpus shipped with the binary.
+//! the canonical skill corpus shipped with the binary or loaded from disk.
 //!
 //! These spawn the real `harn` binary so we exercise the clap parser
 //! and `JsonEnvelope` serialization paths that agents and CI consume.
@@ -7,7 +7,9 @@
 mod test_util;
 
 use std::collections::BTreeSet;
-use std::process::Output;
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Output};
 
 use harn_cli::json_envelope::CATALOG_SCHEMA_VERSION;
 use harn_cli::tests::common::json_envelope::assert_envelope;
@@ -31,7 +33,7 @@ fn parse_json_stdout(out: &Output) -> Value {
 
 #[test]
 fn list_json_matches_embedded_corpus_count() {
-    let output = harn_e2e_command()
+    let output = harn_command_without_skills_dir()
         .args(["skills", "list", "--json"])
         .output()
         .expect("spawn harn skills list --json");
@@ -76,7 +78,7 @@ fn list_json_matches_embedded_corpus_count() {
 
 #[test]
 fn list_human_output_mentions_embedded_skills() {
-    let output = harn_e2e_command()
+    let output = harn_command_without_skills_dir()
         .args(["skills", "list"])
         .output()
         .expect("spawn harn skills list");
@@ -93,8 +95,61 @@ fn list_human_output_mentions_embedded_skills() {
 }
 
 #[test]
+fn list_json_uses_harn_skills_dir_when_it_contains_skills() {
+    let temp = TempDir::new().expect("temp dir");
+    write_disk_skill(&temp.path().join("custom").join("SKILL.md"), "custom-harn");
+
+    let output = harn_command_without_skills_dir()
+        .env("HARN_SKILLS_DIR", temp.path())
+        .args(["skills", "list", "--json"])
+        .output()
+        .expect("spawn harn skills list --json");
+    assert!(output.status.success(), "exit={:?}", output.status.code());
+
+    let parsed = parse_json_stdout(&output);
+    let data = assert_envelope(&parsed, SKILLS_LIST_SCHEMA_VERSION);
+    let skills = data["skills"].as_array().expect("data.skills is an array");
+    assert_eq!(skills.len(), 1, "expected only disk skill: {parsed}");
+    assert_eq!(skills[0]["name"], "custom-harn");
+}
+
+#[test]
+fn list_json_falls_back_to_embedded_when_harn_skills_dir_is_empty() {
+    let temp = TempDir::new().expect("temp dir");
+
+    let output = harn_command_without_skills_dir()
+        .env("HARN_SKILLS_DIR", temp.path())
+        .args(["skills", "list", "--json"])
+        .output()
+        .expect("spawn harn skills list --json");
+    assert!(output.status.success(), "exit={:?}", output.status.code());
+
+    let parsed = parse_json_stdout(&output);
+    let data = assert_envelope(&parsed, SKILLS_LIST_SCHEMA_VERSION);
+    let skills = data["skills"].as_array().expect("data.skills is an array");
+    assert_eq!(skills.len(), list_embedded_skills().len());
+}
+
+#[test]
+fn list_json_falls_back_to_embedded_when_harn_skills_dir_is_missing() {
+    let temp = TempDir::new().expect("temp dir");
+
+    let output = harn_command_without_skills_dir()
+        .env("HARN_SKILLS_DIR", temp.path().join("missing"))
+        .args(["skills", "list", "--json"])
+        .output()
+        .expect("spawn harn skills list --json");
+    assert!(output.status.success(), "exit={:?}", output.status.code());
+
+    let parsed = parse_json_stdout(&output);
+    let data = assert_envelope(&parsed, SKILLS_LIST_SCHEMA_VERSION);
+    let skills = data["skills"].as_array().expect("data.skills is an array");
+    assert_eq!(skills.len(), list_embedded_skills().len());
+}
+
+#[test]
 fn get_returns_frontmatter_without_body_by_default() {
-    let output = harn_e2e_command()
+    let output = harn_command_without_skills_dir()
         .args(["skills", "get", "harn-language", "--json"])
         .output()
         .expect("spawn harn skills get --json");
@@ -116,7 +171,7 @@ fn get_returns_frontmatter_without_body_by_default() {
 
 #[test]
 fn get_full_includes_body() {
-    let output = harn_e2e_command()
+    let output = harn_command_without_skills_dir()
         .args(["skills", "get", "harn-language", "--full", "--json"])
         .output()
         .expect("spawn harn skills get --full --json");
@@ -135,8 +190,34 @@ fn get_full_includes_body() {
 }
 
 #[test]
+fn get_full_uses_harn_skills_dir_body() {
+    let temp = TempDir::new().expect("temp dir");
+    write_disk_skill(
+        &temp.path().join("nested").join("custom").join("SKILL.md"),
+        "custom-harn",
+    );
+
+    let output = harn_command_without_skills_dir()
+        .env("HARN_SKILLS_DIR", temp.path())
+        .args(["skills", "get", "custom-harn", "--full", "--json"])
+        .output()
+        .expect("spawn harn skills get --full --json");
+    assert!(output.status.success(), "exit={:?}", output.status.code());
+
+    let parsed = parse_json_stdout(&output);
+    let data = assert_envelope(&parsed, SKILLS_GET_SCHEMA_VERSION);
+    assert_eq!(data["name"], "custom-harn");
+    assert_eq!(data["short"], "custom short");
+    let body = data["body"].as_str().expect("body is present");
+    assert!(
+        body.contains("Custom disk body"),
+        "body should come from HARN_SKILLS_DIR: {body}"
+    );
+}
+
+#[test]
 fn get_unknown_skill_emits_error_envelope_and_nonzero_exit() {
-    let output = harn_e2e_command()
+    let output = harn_command_without_skills_dir()
         .args(["skills", "get", "not-a-real-skill", "--json"])
         .output()
         .expect("spawn harn skills get not-a-real-skill --json");
@@ -155,7 +236,7 @@ fn get_unknown_skill_emits_error_envelope_and_nonzero_exit() {
 
 #[test]
 fn get_human_prints_frontmatter() {
-    let output = harn_e2e_command()
+    let output = harn_command_without_skills_dir()
         .args(["skills", "get", "harn-language"])
         .output()
         .expect("spawn harn skills get harn-language");
@@ -177,7 +258,7 @@ fn get_human_prints_frontmatter() {
 
 #[test]
 fn dump_requires_all_flag() {
-    let output = harn_e2e_command()
+    let output = harn_command_without_skills_dir()
         .args(["skills", "dump"])
         .output()
         .expect("spawn harn skills dump (no --all)");
@@ -194,7 +275,7 @@ fn dump_all_writes_every_skill_to_out_dir() {
     let temp = TempDir::new().expect("temp dir");
     let out = temp.path().join("dump-target");
 
-    let output = harn_e2e_command()
+    let output = harn_command_without_skills_dir()
         .args(["skills", "dump", "--all", "--out"])
         .arg(&out)
         .output()
@@ -219,12 +300,41 @@ fn dump_all_writes_every_skill_to_out_dir() {
 }
 
 #[test]
+fn dump_all_uses_harn_skills_dir_when_it_contains_skills() {
+    let temp = TempDir::new().expect("temp dir");
+    let source = temp
+        .path()
+        .join("disk-skills")
+        .join("custom")
+        .join("SKILL.md");
+    let out = temp.path().join("dump-target");
+    write_disk_skill(&source, "custom-harn");
+
+    let output = harn_command_without_skills_dir()
+        .env("HARN_SKILLS_DIR", temp.path().join("disk-skills"))
+        .args(["skills", "dump", "--all", "--out"])
+        .arg(&out)
+        .output()
+        .expect("spawn harn skills dump --all --out <dir>");
+    assert!(output.status.success(), "exit={:?}", output.status.code());
+
+    let dumped = out.join("custom-harn").join("SKILL.md");
+    let dumped_source = fs::read_to_string(&dumped).expect("read dumped disk skill");
+    let original_source = fs::read_to_string(&source).expect("read source disk skill");
+    assert_eq!(dumped_source, original_source);
+    assert!(
+        !out.join("harn-language").exists(),
+        "disk override should dump only disk skills"
+    );
+}
+
+#[test]
 fn dump_refuses_to_overwrite_without_force() {
     let temp = TempDir::new().expect("temp dir");
     let out = temp.path().join("dump-target");
 
     // First dump succeeds.
-    let first = harn_e2e_command()
+    let first = harn_command_without_skills_dir()
         .args(["skills", "dump", "--all", "--out"])
         .arg(&out)
         .output()
@@ -232,7 +342,7 @@ fn dump_refuses_to_overwrite_without_force() {
     assert!(first.status.success(), "first dump should succeed");
 
     // Second dump without --force should refuse.
-    let second = harn_e2e_command()
+    let second = harn_command_without_skills_dir()
         .args(["skills", "dump", "--all", "--out"])
         .arg(&out)
         .output()
@@ -243,7 +353,7 @@ fn dump_refuses_to_overwrite_without_force() {
     );
 
     // Third dump with --force should succeed.
-    let third = harn_e2e_command()
+    let third = harn_command_without_skills_dir()
         .args(["skills", "dump", "--all", "--force", "--out"])
         .arg(&out)
         .output()
@@ -253,7 +363,7 @@ fn dump_refuses_to_overwrite_without_force() {
 
 #[test]
 fn json_schemas_catalog_lists_skills_list_and_get() {
-    let output = harn_e2e_command()
+    let output = harn_command_without_skills_dir()
         .args(["--json-schemas"])
         .output()
         .expect("spawn harn --json-schemas");
@@ -269,4 +379,21 @@ fn json_schemas_catalog_lists_skills_list_and_get() {
         .collect();
     assert!(commands.contains("skills list"), "missing skills list");
     assert!(commands.contains("skills get"), "missing skills get");
+}
+
+fn write_disk_skill(path: &Path, name: &str) {
+    fs::create_dir_all(path.parent().expect("skill parent")).expect("create skill parent");
+    fs::write(
+        path,
+        format!(
+            "---\nname: {name}\nshort: custom short\ndescription: custom description\n---\n# Custom disk skill\n\nCustom disk body\n"
+        ),
+    )
+    .expect("write disk skill");
+}
+
+fn harn_command_without_skills_dir() -> Command {
+    let mut command = harn_e2e_command();
+    command.env_remove("HARN_SKILLS_DIR");
+    command
 }

--- a/crates/harn-skills/Cargo.toml
+++ b/crates/harn-skills/Cargo.toml
@@ -9,3 +9,6 @@ description = "Embedded skill corpus for the Harn CLI and runtime"
 include = ["src/**/*", "Cargo.toml"]
 
 [dependencies]
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/harn-skills/src/lib.rs
+++ b/crates/harn-skills/src/lib.rs
@@ -4,7 +4,16 @@
 //! bodies. CLI commands that enumerate, dump, or install these skills
 //! are layered above this foundation.
 
+use std::collections::BTreeMap;
+use std::env;
+use std::fmt;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
+
+/// Environment override for canonical Harn skill discovery.
+pub const HARN_SKILLS_DIR_ENV: &str = "HARN_SKILLS_DIR";
 
 /// Frontmatter fields embedded with each bundled skill.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -27,6 +36,96 @@ pub struct EmbeddedSkill {
     /// copy is byte-identical to the binary's canonical record.
     pub source: &'static str,
 }
+
+/// Owned frontmatter fields loaded from a `SKILL.md` on disk.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiskSkillFrontmatter {
+    pub name: String,
+    pub short: String,
+    pub description: String,
+    pub when_to_use: Option<String>,
+}
+
+/// A single skill discovered recursively from `HARN_SKILLS_DIR`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiskSkill {
+    pub name: String,
+    pub frontmatter: DiskSkillFrontmatter,
+    pub body: String,
+    pub source: String,
+    pub path: PathBuf,
+}
+
+/// The active canonical corpus used by `harn skills list/get`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SkillCorpus {
+    Embedded(&'static [EmbeddedSkill]),
+    Disk(Vec<DiskSkill>),
+}
+
+impl SkillCorpus {
+    pub fn is_disk(&self) -> bool {
+        matches!(self, Self::Disk(_))
+    }
+
+    pub fn len(&self) -> usize {
+        match self {
+            Self::Embedded(skills) => skills.len(),
+            Self::Disk(skills) => skills.len(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// Error returned when disk skill discovery finds malformed files.
+#[derive(Debug)]
+pub enum SkillDiscoveryError {
+    Io {
+        path: PathBuf,
+        source: io::Error,
+    },
+    MissingFrontmatter {
+        path: PathBuf,
+    },
+    MissingField {
+        path: PathBuf,
+        field: &'static str,
+    },
+    DuplicateName {
+        name: String,
+        first: PathBuf,
+        second: PathBuf,
+    },
+}
+
+impl fmt::Display for SkillDiscoveryError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io { path, source } => write!(f, "{}: {source}", path.display()),
+            Self::MissingFrontmatter { path } => {
+                write!(f, "{}: missing SKILL.md frontmatter", path.display())
+            }
+            Self::MissingField { path, field } => {
+                write!(f, "{}: missing `{field}` frontmatter field", path.display())
+            }
+            Self::DuplicateName {
+                name,
+                first,
+                second,
+            } => write!(
+                f,
+                "duplicate skill `{name}` in {} and {}",
+                first.display(),
+                second.display()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for SkillDiscoveryError {}
 
 const SOURCES: &[&str] = &[
     include_str!("corpus/harn-agent/SKILL.md"),
@@ -54,6 +153,55 @@ pub fn get_embedded_skill(name: &str) -> Option<&'static EmbeddedSkill> {
         .find(|skill| skill.name == name)
 }
 
+/// Return the active canonical corpus. `HARN_SKILLS_DIR` wins only
+/// when it contains at least one recursively discovered `SKILL.md`;
+/// otherwise callers fall back to the embedded corpus.
+pub fn resolve_skill_corpus_from_env() -> Result<SkillCorpus, SkillDiscoveryError> {
+    let Ok(dir) = env::var(HARN_SKILLS_DIR_ENV) else {
+        return Ok(SkillCorpus::Embedded(list_embedded_skills()));
+    };
+    if dir.trim().is_empty() {
+        return Ok(SkillCorpus::Embedded(list_embedded_skills()));
+    }
+
+    let skills = list_disk_skills(dir)?;
+    if skills.is_empty() {
+        Ok(SkillCorpus::Embedded(list_embedded_skills()))
+    } else {
+        Ok(SkillCorpus::Disk(skills))
+    }
+}
+
+/// Recursively discover `SKILL.md` files under `root`.
+///
+/// A missing root is treated as an empty disk corpus so
+/// `HARN_SKILLS_DIR` can fall back cleanly to embedded skills.
+pub fn list_disk_skills(root: impl AsRef<Path>) -> Result<Vec<DiskSkill>, SkillDiscoveryError> {
+    let root = root.as_ref();
+    if !root.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut paths = Vec::new();
+    collect_skill_paths(root, &mut paths)?;
+    paths.sort();
+
+    let mut by_name: BTreeMap<String, DiskSkill> = BTreeMap::new();
+    for path in paths {
+        let skill = parse_disk_skill(&path)?;
+        if let Some(first) = by_name.get(&skill.name) {
+            return Err(SkillDiscoveryError::DuplicateName {
+                name: skill.name,
+                first: first.path.clone(),
+                second: path,
+            });
+        }
+        by_name.insert(skill.name.clone(), skill);
+    }
+
+    Ok(by_name.into_values().collect())
+}
+
 fn parse_skill(source: &'static str) -> EmbeddedSkill {
     let (frontmatter, body) = split_frontmatter(source);
     let frontmatter = parse_frontmatter(frontmatter);
@@ -63,6 +211,102 @@ fn parse_skill(source: &'static str) -> EmbeddedSkill {
         body,
         source,
     }
+}
+
+fn collect_skill_paths(dir: &Path, out: &mut Vec<PathBuf>) -> Result<(), SkillDiscoveryError> {
+    let entries = fs::read_dir(dir).map_err(|source| SkillDiscoveryError::Io {
+        path: dir.to_path_buf(),
+        source,
+    })?;
+    for entry in entries {
+        let entry = entry.map_err(|source| SkillDiscoveryError::Io {
+            path: dir.to_path_buf(),
+            source,
+        })?;
+        let path = entry.path();
+        let file_type = entry
+            .file_type()
+            .map_err(|source| SkillDiscoveryError::Io {
+                path: path.clone(),
+                source,
+            })?;
+        if file_type.is_dir() {
+            collect_skill_paths(&path, out)?;
+        } else if file_type.is_file() && entry.file_name() == "SKILL.md" {
+            out.push(path);
+        }
+    }
+    Ok(())
+}
+
+fn parse_disk_skill(path: &Path) -> Result<DiskSkill, SkillDiscoveryError> {
+    let source = fs::read_to_string(path).map_err(|source| SkillDiscoveryError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let (frontmatter, body) =
+        split_disk_frontmatter(&source).ok_or_else(|| SkillDiscoveryError::MissingFrontmatter {
+            path: path.to_path_buf(),
+        })?;
+    let frontmatter = parse_disk_frontmatter(path, frontmatter)?;
+    Ok(DiskSkill {
+        name: frontmatter.name.clone(),
+        frontmatter,
+        body: body.to_string(),
+        source,
+        path: path.to_path_buf(),
+    })
+}
+
+fn split_disk_frontmatter(source: &str) -> Option<(&str, &str)> {
+    let after_open = source.strip_prefix("---\n")?;
+    let close_offset = after_open.find("\n---\n")?;
+    Some((
+        &after_open[..close_offset],
+        &after_open[close_offset + "\n---\n".len()..],
+    ))
+}
+
+fn parse_disk_frontmatter(
+    path: &Path,
+    frontmatter: &str,
+) -> Result<DiskSkillFrontmatter, SkillDiscoveryError> {
+    let mut name = None;
+    let mut short = None;
+    let mut description = None;
+    let mut when_to_use = None;
+
+    for line in frontmatter.lines() {
+        let Some((key, value)) = line.split_once(':') else {
+            continue;
+        };
+        let value = value.trim().to_string();
+        match key {
+            "name" => name = Some(value),
+            "short" => short = Some(value),
+            "description" => description = Some(value),
+            "when_to_use" => when_to_use = Some(value),
+            _ => {}
+        }
+    }
+
+    Ok(DiskSkillFrontmatter {
+        name: require_disk_field(path, name, "name")?,
+        short: short.unwrap_or_default(),
+        description: require_disk_field(path, description, "description")?,
+        when_to_use,
+    })
+}
+
+fn require_disk_field(
+    path: &Path,
+    value: Option<String>,
+    field: &'static str,
+) -> Result<String, SkillDiscoveryError> {
+    value.ok_or_else(|| SkillDiscoveryError::MissingField {
+        path: path.to_path_buf(),
+        field,
+    })
 }
 
 fn split_frontmatter(source: &'static str) -> (&'static str, &'static str) {
@@ -110,6 +354,7 @@ fn parse_frontmatter(frontmatter: &'static str) -> SkillFrontmatter {
 mod tests {
     use super::*;
     use std::collections::BTreeSet;
+    use tempfile::TempDir;
 
     #[test]
     fn lists_expected_initial_corpus() {
@@ -275,6 +520,66 @@ mod tests {
                 "harn-diagnostics should mention diagnostic category `{category}`"
             );
         }
+    }
+
+    #[test]
+    fn disk_discovery_finds_recursive_skill_files_sorted_by_name() {
+        let temp = TempDir::new().expect("temp dir");
+        write_skill(
+            &temp.path().join("zeta").join("SKILL.md"),
+            "zeta-skill",
+            "Zeta",
+        );
+        write_skill(
+            &temp.path().join("nested").join("alpha").join("SKILL.md"),
+            "alpha-skill",
+            "Alpha",
+        );
+
+        let skills = list_disk_skills(temp.path()).expect("discover disk skills");
+        let names: Vec<&str> = skills.iter().map(|skill| skill.name.as_str()).collect();
+        assert_eq!(names, ["alpha-skill", "zeta-skill"]);
+        assert_eq!(skills[0].frontmatter.description, "Alpha description");
+        assert!(skills[0].body.contains("Alpha body"));
+    }
+
+    #[test]
+    fn disk_discovery_treats_missing_root_as_empty() {
+        let temp = TempDir::new().expect("temp dir");
+        let skills = list_disk_skills(temp.path().join("missing")).expect("discover disk skills");
+        assert!(skills.is_empty());
+    }
+
+    #[test]
+    fn disk_discovery_rejects_duplicate_skill_names() {
+        let temp = TempDir::new().expect("temp dir");
+        write_skill(
+            &temp.path().join("one").join("SKILL.md"),
+            "same-skill",
+            "One",
+        );
+        write_skill(
+            &temp.path().join("two").join("SKILL.md"),
+            "same-skill",
+            "Two",
+        );
+
+        let error = list_disk_skills(temp.path()).expect_err("duplicate name should fail");
+        assert!(
+            error.to_string().contains("duplicate skill `same-skill`"),
+            "unexpected error: {error}"
+        );
+    }
+
+    fn write_skill(path: &Path, name: &str, label: &str) {
+        fs::create_dir_all(path.parent().expect("skill parent")).expect("create skill parent");
+        fs::write(
+            path,
+            format!(
+                "---\nname: {name}\nshort: {label} short\ndescription: {label} description\n---\n# {label}\n\n{label} body\n"
+            ),
+        )
+        .expect("write SKILL.md");
     }
 
     fn bracketed_skill_references(body: &str) -> Vec<&str> {

--- a/docs/src/skills.md
+++ b/docs/src/skills.md
@@ -318,11 +318,13 @@ See [Bridge protocol](./bridge-protocol.md) for wire-format details.
 
 The `harn skills` CLI splits into two complementary surfaces:
 
-- **Embedded corpus** — the canonical Harn skills shipped *inside* the
+- **Canonical corpus** — the Harn skills normally shipped *inside* the
   `harn` binary (`harn-language`, `harn-orchestration`, `harn-testing`,
   …). Access these with `harn skills list`, `harn skills get <name>`,
-  and `harn skills dump --all`. They are always available, with no
-  project or filesystem state required.
+  and `harn skills dump --all`. Set `HARN_SKILLS_DIR` to a directory of
+  recursive `SKILL.md` files to make `list`, `get`, and `dump` read
+  from disk while iterating locally; an unset, missing, or empty
+  directory falls back to the embedded corpus.
 - **Layered FS discovery** — user-authored skills picked up from
   `--skill-dir`, `HARN_SKILLS_PATH`, project, manifest, user, packages,
   system, and host layers. Access these with `harn skills resolved`,
@@ -332,9 +334,11 @@ The `harn skills` CLI splits into two complementary surfaces:
 
 ### `harn skills list`
 
-Lists the embedded canonical skill corpus that ships with this build
-of `harn`. Pass `--json` for a versioned `JsonEnvelope` payload that
-agents and CI can pipe through `jq`.
+Lists the canonical skill corpus for this build of `harn`. By default
+that is the embedded corpus; when `HARN_SKILLS_DIR` points at one or
+more recursive `SKILL.md` files, the disk corpus is listed instead.
+Pass `--json` for a versioned `JsonEnvelope` payload that agents and
+CI can pipe through `jq`.
 
 ```text
 $ harn skills list
@@ -362,9 +366,10 @@ $ harn skills list --json | jq '.data.skills | length'
 
 ### `harn skills get <name>`
 
-Prints frontmatter for a single embedded skill. Pass `--full` to
+Prints frontmatter for a single canonical skill. Pass `--full` to
 include the SKILL.md body; pass `--json` to wrap the output in a
-`JsonEnvelope` for machine consumption.
+`JsonEnvelope` for machine consumption. `HARN_SKILLS_DIR` follows the
+same disk-override/fallback behavior as `harn skills list`.
 
 ```text
 $ harn skills get harn-language
@@ -388,10 +393,12 @@ and the list of available skills in `error.details.available`.
 
 ### `harn skills dump --all [--out <dir>]`
 
-Writes every embedded skill to disk as a `<dir>/<name>/SKILL.md` tree
-so agents and CI can review the corpus offline. Defaults the output
-directory to `./skills`. Refuses to overwrite existing files unless
-`--force` is passed.
+Writes every active canonical skill to disk as a `<dir>/<name>/SKILL.md`
+tree so agents and CI can review the corpus offline. By default that
+means the embedded corpus; when `HARN_SKILLS_DIR` contains recursive
+`SKILL.md` files, `dump` mirrors that disk corpus byte-for-byte instead.
+Defaults the output directory to `./skills`. Refuses to overwrite
+existing files unless `--force` is passed.
 
 ```text
 $ harn skills dump --all --out /tmp/skills


### PR DESCRIPTION
Closes #1764.

## Summary
- add recursive `HARN_SKILLS_DIR` discovery for canonical Harn skills, with unset, missing, or empty dirs falling back to the embedded corpus
- wire `harn skills list/get/dump` to use the active canonical corpus and keep layered FS discovery separate
- replace the in-tree Claude `harn-scripting` skill with a short discovery stub and update repo/docs guidance to `harn skills list/get`
- harden skills CLI tests against ambient `HARN_SKILLS_DIR` and cover disk override, missing/empty fallback, `get --full`, and `dump --all`

## Verification
- `cargo fmt --package harn-skills --package harn-cli --check`
- `git diff --check origin/main..HEAD`
- `CARGO_TARGET_DIR=/tmp/harn-target-1764-final HARN_LLM_CALLS_DISABLED=1 cargo test -p harn-skills`
- `CARGO_TARGET_DIR=/tmp/harn-target-1764-final HARN_LLM_CALLS_DISABLED=1 cargo test -p harn-cli --test skills_cli`
- pre-commit hook passed, including workspace clippy and markdownlint
- pre-push hook passed

## Notes
- The issue mentions `make sync-quickref`, but this repo currently has no `sync-quickref` Make target, so there was no runnable quickref regeneration check to execute.
- `/Users/ksinder/.claude/CLAUDE.md` remains out of repo scope, as the issue notes.