### PR TITLE
Add harness.clock surface + bindings/thread-harness-clock repair (#1768)

### DIFF
--- a/conformance/tests/language/harness_clock_methods.expected
+++ b/conformance/tests/language/harness_clock_methods.expected
@@ -1,0 +1,6 @@
+true
+true
+true
+true
+true
+true

--- a/conformance/tests/language/harness_clock_methods.harn
+++ b/conformance/tests/language/harness_clock_methods.harn
@@ -1,0 +1,27 @@
+/**
+ * E4.3: the `harness.clock.*` sub-handle is the canonical surface for
+ * wall-clock reads, monotonic reads, and cooperative sleeps. This test
+ * pins the script under `mock_time(...)` so every observation is
+ * deterministic — the same fixture that proves replay determinism.
+ *
+ * `harness.clock` aliases `monotonic_ms` and `elapsed` to the same
+ * monotonic counter, and `timestamp` returns the wall-clock as seconds.
+ * `sleep_ms(...)` advances the active mock instead of suspending the
+ * runtime (the existing parallel-mock-clock fixture pins this for the
+ * ambient builtin; the harness path must behave identically).
+ */
+fn main(harness: Harness) {
+  mock_time(1700000000000)
+  let wall_ms = harness.clock.now_ms()
+  let ts = harness.clock.timestamp()
+  let mono = harness.clock.monotonic_ms()
+  let elapsed = harness.clock.elapsed()
+  harness.stdio.println(wall_ms == 1700000000000)
+  harness.stdio.println(ts == 1700000000.0)
+  harness.stdio.println(mono == 0)
+  harness.stdio.println(elapsed == 0)
+  harness.clock.sleep_ms(250)
+  harness.stdio.println(harness.clock.monotonic_ms() == 250)
+  harness.stdio.println(harness.clock.now_ms() == 1700000000250)
+  unmock_time()
+}

--- a/crates/harn-lint/src/linter.rs
+++ b/crates/harn-lint/src/linter.rs
@@ -6,7 +6,9 @@
 use std::collections::{HashMap, HashSet};
 
 use harn_lexer::{FixEdit, Span};
-use harn_parser::diagnostic::{find_closest_match, renamed_stdlib_symbol};
+use harn_parser::diagnostic::{
+    find_closest_match, harness_clock_replacement, renamed_stdlib_symbol,
+};
 use harn_parser::{BindingPattern, DiagnosticCode as Code, Node, SNode, TypeExpr, TypedParam};
 
 use crate::complexity::cyclomatic_complexity;
@@ -195,6 +197,47 @@ impl<'a> Linter<'a> {
             severity: LintSeverity::Warning,
             suggestion: Some(format!("replace `{name}` with `{replacement}`")),
             fix: replace_identifier_text_fix(self.source, span, name, replacement),
+        });
+    }
+
+    /// Flag ambient clock builtins (`now_ms`, `monotonic_ms`, `sleep_ms`,
+    /// `timestamp`, `elapsed`) so the E4.3 → E4.6 migration can rewrite
+    /// them to `harness.clock.*`. When `harness` (or `_harness`) is in
+    /// scope the lint emits a `bindings/thread-harness-clock` FixEdit;
+    /// otherwise the suggestion points users at the
+    /// `bindings/thread-harness` repair that adds the parameter.
+    pub(super) fn check_ambient_clock_builtin(&mut self, name: &str, span: Span) {
+        let Some(replacement) = harness_clock_replacement(name) else {
+            return;
+        };
+        let harness_in_scope = self
+            .scopes
+            .iter()
+            .any(|scope| scope.contains("harness") || scope.contains("_harness"));
+        let fix = if harness_in_scope {
+            replace_identifier_text_fix(self.source, span, name, replacement)
+        } else {
+            None
+        };
+        let suggestion = if harness_in_scope {
+            format!("replace `{name}` with `{replacement}`")
+        } else {
+            format!(
+                "thread `harness: Harness` through the enclosing fn (see repair \
+                 `bindings/thread-harness`), then call `{replacement}`"
+            )
+        };
+        self.diagnostics.push(LintDiagnostic {
+            code: Code::LintAmbientClockBuiltin,
+            rule: "ambient-clock-builtin",
+            message: format!(
+                "ambient `{name}` is deprecated — capabilities now route through \
+                 `harness.clock.*`"
+            ),
+            span,
+            severity: LintSeverity::Warning,
+            suggestion: Some(suggestion),
+            fix,
         });
     }
 

--- a/crates/harn-lint/src/linter/walk.rs
+++ b/crates/harn-lint/src/linter/walk.rs
@@ -279,6 +279,7 @@ impl<'a> Linter<'a> {
 
             Node::FunctionCall { name, args, .. } => {
                 self.check_renamed_stdlib_symbol(name, snode.span);
+                self.check_ambient_clock_builtin(name, snode.span);
                 self.references.insert(name.clone());
                 self.function_references.insert(name.clone());
                 self.function_calls.push((name.clone(), snode.span));

--- a/crates/harn-lint/src/tests/ambient_clock.rs
+++ b/crates/harn-lint/src/tests/ambient_clock.rs
@@ -1,0 +1,82 @@
+//! HARN-LNT-052 — ambient clock builtins now route through
+//! `harness.clock.*`. The lint owns the `bindings/thread-harness-clock`
+//! repair that the E4.3 → E4.6 migration leans on.
+
+use super::*;
+
+#[test]
+fn ambient_clock_call_inside_main_emits_lint_and_fixes_to_harness_clock() {
+    let source =
+        "fn main(harness: Harness) {\n  let ms = now_ms()\n  harness.stdio.println(ms)\n}\n";
+    let diags = lint_source(source);
+    assert_eq!(
+        count_rule(&diags, "ambient-clock-builtin"),
+        1,
+        "expected one ambient-clock lint, got: {diags:?}"
+    );
+    let fixed = apply_fixes(source, &diags);
+    assert!(
+        fixed.contains("harness.clock.now_ms()"),
+        "expected rewrite to harness.clock.now_ms(), got: {fixed}"
+    );
+    assert!(
+        !fixed.contains(" now_ms("),
+        "ambient call should be gone, got: {fixed}"
+    );
+}
+
+#[test]
+fn ambient_clock_lints_all_five_names_inside_main() {
+    let source = r#"fn main(harness: Harness) {
+  let a = now_ms()
+  let b = monotonic_ms()
+  let c = timestamp()
+  let d = elapsed()
+  sleep_ms(0)
+}
+"#;
+    let diags = lint_source(source);
+    assert_eq!(
+        count_rule(&diags, "ambient-clock-builtin"),
+        5,
+        "expected one lint per ambient call, got: {diags:?}"
+    );
+}
+
+#[test]
+fn ambient_clock_lint_without_harness_in_scope_emits_no_fix() {
+    let source = "fn helper() {\n  let ms = now_ms()\n}\n";
+    let diags = lint_source(source);
+    let entries: Vec<&LintDiagnostic> = diags
+        .iter()
+        .filter(|d| d.rule == "ambient-clock-builtin")
+        .collect();
+    assert_eq!(entries.len(), 1, "expected one lint, got: {diags:?}");
+    assert!(
+        entries[0].fix.is_none(),
+        "should not auto-fix without `harness` in scope, got: {:?}",
+        entries[0].fix
+    );
+    assert!(
+        entries[0]
+            .suggestion
+            .as_ref()
+            .is_some_and(|s| s.contains("bindings/thread-harness")),
+        "suggestion should point at the surface-changing repair, got: {:?}",
+        entries[0].suggestion
+    );
+}
+
+#[test]
+fn underscore_harness_param_satisfies_in_scope_check() {
+    let source = "fn main(_harness: Harness) {\n  let ms = now_ms()\n}\n";
+    let diags = lint_source(source);
+    let entry = diags
+        .iter()
+        .find(|d| d.rule == "ambient-clock-builtin")
+        .expect("ambient-clock lint");
+    assert!(
+        entry.fix.is_some(),
+        "_harness should count as in-scope for the lint's fix"
+    );
+}

--- a/crates/harn-lint/src/tests/mod.rs
+++ b/crates/harn-lint/src/tests/mod.rs
@@ -71,6 +71,7 @@ pub(super) fn lint_with_require_header(
     lint_with_options(&program, &[], Some(source), &HashSet::new(), &options)
 }
 
+mod ambient_clock;
 mod assert_pipeline;
 mod autofix;
 mod boolean_patterns;

--- a/crates/harn-parser/src/diagnostic.rs
+++ b/crates/harn-parser/src/diagnostic.rs
@@ -101,6 +101,23 @@ pub fn renamed_stdlib_symbol(name: &str) -> Option<&'static str> {
     }
 }
 
+/// Map an ambient clock-capability builtin to its `harness.clock.*`
+/// replacement. Returns the new identifier text (including the receiver
+/// path) so the `bindings/thread-harness-clock` repair can replace the
+/// call-site identifier in place. The mapping is the source of truth for
+/// the E4.3 → E4.6 migration; downstream replatform agents query it via
+/// [`Code::repair_template`].
+pub fn harness_clock_replacement(name: &str) -> Option<&'static str> {
+    match name {
+        "now_ms" => Some("harness.clock.now_ms"),
+        "monotonic_ms" => Some("harness.clock.monotonic_ms"),
+        "sleep_ms" => Some("harness.clock.sleep_ms"),
+        "timestamp" => Some("harness.clock.timestamp"),
+        "elapsed" => Some("harness.clock.elapsed"),
+        _ => None,
+    }
+}
+
 /// Render a Rust-style diagnostic message.
 ///
 /// Example output:

--- a/crates/harn-parser/src/diagnostic_codes.rs
+++ b/crates/harn-parser/src/diagnostic_codes.rs
@@ -282,6 +282,7 @@ diagnostic_codes! {
     LintLegacyDocComment, "HARN-LNT-049", Lnt, "legacy doc comment lint";
     LintDeprecatedLlmOptions, "HARN-LNT-050", Lnt, "deprecated LLM options lint";
     LintUnnecessarySafeNavigation, "HARN-LNT-051", Lnt, "unnecessary safe navigation lint";
+    LintAmbientClockBuiltin, "HARN-LNT-052", Lnt, "ambient clock builtin replaced by `harness.clock.*`";
     FormatterParseFailed, "HARN-FMT-001", Fmt, "formatter could not parse the source";
     FormatterWouldReformat, "HARN-FMT-002", Fmt, "source is not in canonical format";
     FormatterTrailingComma, "HARN-FMT-003", Fmt, "formatter normalized trailing comma layout";
@@ -399,6 +400,9 @@ impl Code {
             Code::LintTemplateVariantExplosion => &[Code::PromptVariantExplosion],
             Code::LintTemplateProviderIdentityBranch => &[Code::PromptProviderIdentityBranch],
             Code::LintRenamedStdlibSymbol => &[Code::DeprecatedStdlibSymbol],
+            Code::LintAmbientClockBuiltin => {
+                &[Code::InvalidMainSignature, Code::LintRenamedStdlibSymbol]
+            }
             Code::LintMutableNeverReassigned => &[Code::MutableNeverReassigned],
             Code::LintUnusedImport => &[Code::ModuleImportUnused],
             Code::LintDuplicateMatchArm => &[Code::DuplicateMatchArm],
@@ -701,6 +705,7 @@ impl Code {
             Code::LintEagerCollectionConversion => Some(&REPAIR_COLLECTION_PREFER_LAZY),
             Code::LintDeadCodeAfterReturn => Some(&REPAIR_DEAD_CODE_REMOVE),
             Code::LintRenamedStdlibSymbol => Some(&REPAIR_STDLIB_MIGRATE_RENAMED),
+            Code::LintAmbientClockBuiltin => Some(&REPAIR_BINDINGS_THREAD_HARNESS_CLOCK),
             Code::LintDeprecatedLlmOptions => Some(&REPAIR_LLM_MIGRATE_DEPRECATED_OPTION),
             Code::LintTemplateProviderIdentityBranch => Some(&REPAIR_LLM_USE_CAPABILITY_FLAG),
             Code::LintPromptInjectionRisk => Some(&REPAIR_PROMPTS_ESCAPE_INJECTION),
@@ -795,6 +800,12 @@ const REPAIR_BINDINGS_THREAD_HARNESS: RepairTemplate = RepairTemplate {
     id: "bindings/thread-harness",
     summary: "Rewrite the entrypoint as `fn main(harness: Harness)` so the runtime can thread its capability handle",
     safety: RepairSafety::SurfaceChanging,
+};
+
+const REPAIR_BINDINGS_THREAD_HARNESS_CLOCK: RepairTemplate = RepairTemplate {
+    id: "bindings/thread-harness-clock",
+    summary: "Replace the ambient clock builtin with the corresponding `harness.clock.*` method",
+    safety: RepairSafety::ScopeLocal,
 };
 
 const REPAIR_DECLARATIONS_REMOVE_UNUSED: RepairTemplate = RepairTemplate {
@@ -973,6 +984,7 @@ pub const REPAIR_REGISTRY: &[&RepairTemplate] = &[
     &REPAIR_BINDINGS_RENAME_UNUSED,
     &REPAIR_BINDINGS_RENAME_SHADOW,
     &REPAIR_BINDINGS_THREAD_HARNESS,
+    &REPAIR_BINDINGS_THREAD_HARNESS_CLOCK,
     &REPAIR_DECLARATIONS_REMOVE_UNUSED,
     &REPAIR_IMPORTS_FIX_PATH,
     &REPAIR_IMPORTS_REMOVE_UNUSED,
@@ -1219,6 +1231,11 @@ mod tests {
                 Code::NonExhaustiveMatch,
                 RepairSafety::ScopeLocal,
                 "match/add-missing-arms",
+            ),
+            (
+                Code::LintAmbientClockBuiltin,
+                RepairSafety::ScopeLocal,
+                "bindings/thread-harness-clock",
             ),
         ];
         for (code, safety, repair_id) in expected {

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-052.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-052.md
@@ -1,0 +1,33 @@
+# HARN-LNT-052 — ambient clock builtin replaced by `harness.clock.*`
+
+**Category:** Lint (LNT)  
+**Variant:** `Code::LintAmbientClockBuiltin` (ambient clock builtin)
+
+## What it means
+
+The lint fires on any call to `now_ms`, `monotonic_ms`, `sleep_ms`,
+`timestamp`, or `elapsed`. These were ambient clock-capability builtins in
+the pre-`Harness` runtime. Time access now routes through the
+`harness.clock.*` sub-handle so capability requirements appear in the type
+system instead of being hidden in the stdlib surface.
+
+This is a lint, not a hard error. The legacy builtins still compile while
+the migration is in flight, but every new call site should use the
+`harness.clock.*` method that matches it (`now_ms` → `harness.clock.now_ms`,
+`sleep_ms` → `harness.clock.sleep_ms`, etc.).
+
+## How to fix
+
+- Run `harn fix --apply --safety scope-local` over the file. The
+  `bindings/thread-harness-clock` repair rewrites every call site where a
+  `harness` (or `_harness`) binding is in scope.
+- If `harness` isn't reachable from the call site, first thread it through
+  the enclosing fn via the `bindings/thread-harness` repair (which adds the
+  `harness: Harness` parameter at the entrypoint), then re-run
+  `harn fix --apply` to swap the call.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-vm/src/harness.rs
+++ b/crates/harn-vm/src/harness.rs
@@ -22,8 +22,11 @@
 
 use std::fmt;
 use std::sync::Arc;
+use std::time::Duration;
 
-use harn_clock::{Clock, RealClock};
+use async_trait::async_trait;
+use harn_clock::{Clock, PausedClock, RealClock};
+use time::OffsetDateTime;
 
 /// Six capability slices exposed by a [`Harness`].
 ///
@@ -134,17 +137,48 @@ impl Harness {
     /// environment, randomness, and network access are layered on by the
     /// E4.2-E4.4 migration tickets; the constructor only needs to succeed
     /// without panicking today (per the E4.1 exit criteria).
+    ///
+    /// The production clock is wrapped in [`MockAwareClock`] so existing
+    /// `mock_time(...)` / `advance_time(...)` test fixtures observe
+    /// `harness.clock.*` reads identically to the ambient builtins. The
+    /// shim is part of the E4.3-E4.6 migration window and goes away once
+    /// the ambient `mock_time` test utility is retired by E4.5.
     pub fn real() -> Self {
-        Self::with_clock(RealClock::arc())
+        Self::with_clock(Arc::new(MockAwareClock::new(RealClock::new())))
     }
 
-    /// Build a handle wired to a caller-supplied clock. Test bootstraps that
-    /// want deterministic time without depending on the full `NullHarness`
-    /// surface (E4.5) drive this directly.
+    /// Build a handle wired to a caller-supplied clock. Most callers want
+    /// [`Self::test`] (which constructs the `PausedClock` for you);
+    /// reach for this when an existing `Arc<dyn Clock>` is already in
+    /// hand — e.g. a `RecordedClock` wrapper.
     pub fn with_clock(clock: Arc<dyn Clock>) -> Self {
         Self {
             inner: Arc::new(HarnessInner { clock }),
         }
+    }
+
+    /// Build a deterministic test handle wired to a fresh
+    /// [`PausedClock`] pinned at the Unix epoch.
+    ///
+    /// Returns the harness paired with the underlying `PausedClock` so
+    /// tests can drive virtual time through `PausedClock::advance`
+    /// while passing the same `Harness` value into the VM. The two
+    /// share the underlying `Arc<dyn Clock>`, so the harness reflects
+    /// every advance immediately.
+    ///
+    /// Pairs with [`PausedClock::advance`] / [`PausedClock::set`] — see
+    /// [`Self::with_paused_clock`] for picking a non-epoch origin.
+    pub fn test() -> (Self, Arc<PausedClock>) {
+        Self::with_paused_clock(OffsetDateTime::UNIX_EPOCH)
+    }
+
+    /// Like [`Self::test`], but pins the paused clock's wall origin to
+    /// `origin`. Lets tests anchor virtual time to a meaningful date
+    /// without manually advancing past the epoch first.
+    pub fn with_paused_clock(origin: OffsetDateTime) -> (Self, Arc<PausedClock>) {
+        let paused = PausedClock::new(origin);
+        let as_dyn: Arc<dyn Clock> = paused.clone();
+        (Self::with_clock(as_dyn), paused)
     }
 
     /// Field access for `harness.stdio`.
@@ -320,6 +354,68 @@ impl fmt::Debug for VmHarness {
     }
 }
 
+/// Clock wrapper that consults the crate-wide `clock_mock` thread-local
+/// before delegating to an inner [`Clock`]. Used by [`Harness::real`] so
+/// `harness.clock.*` reads honor `mock_time(...)` / `advance_time(...)`
+/// during the E4.3-E4.6 migration. New tests should prefer
+/// [`Harness::test`] / [`PausedClock`] directly.
+#[derive(Debug)]
+pub struct MockAwareClock<C: Clock + 'static> {
+    inner: C,
+}
+
+impl<C: Clock + 'static> MockAwareClock<C> {
+    pub fn new(inner: C) -> Self {
+        Self { inner }
+    }
+}
+
+#[async_trait]
+impl<C: Clock + 'static> Clock for MockAwareClock<C> {
+    fn now_utc(&self) -> OffsetDateTime {
+        if let Some(mock) = crate::clock_mock::active_mock_clock() {
+            return mock.now_utc();
+        }
+        self.inner.now_utc()
+    }
+
+    fn monotonic_ms(&self) -> i64 {
+        if let Some(mock) = crate::clock_mock::active_mock_clock() {
+            return mock.monotonic_ms();
+        }
+        self.inner.monotonic_ms()
+    }
+
+    async fn sleep(&self, duration: Duration) {
+        if duration.is_zero() {
+            return;
+        }
+        if let Some(mock) = crate::clock_mock::active_mock_clock() {
+            // Single-script tests under `mock_time(...)` rely on `sleep(...)`
+            // advancing the mock and returning immediately — the same
+            // semantics as the legacy ambient `sleep_ms` builtin. Waiting
+            // on `mock.sleep` would deadlock because nothing else is
+            // driving `advance(...)` in the same task.
+            mock.advance_std_sync(duration);
+            return;
+        }
+        self.inner.sleep(duration).await;
+    }
+
+    async fn sleep_until_utc(&self, deadline: OffsetDateTime) {
+        if let Some(mock) = crate::clock_mock::active_mock_clock() {
+            let now = mock.now_utc();
+            if deadline > now {
+                if let Ok(delta) = Duration::try_from(deadline - now) {
+                    mock.advance_std_sync(delta);
+                }
+            }
+            return;
+        }
+        self.inner.sleep_until_utc(deadline).await;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -357,5 +453,31 @@ mod tests {
         assert_eq!(stdio.kind(), HarnessKind::Stdio);
         assert!(stdio.sub_handle("clock").is_none(), "nested access denied");
         assert!(root.sub_handle("not_a_field").is_none());
+    }
+
+    #[test]
+    fn test_constructor_clock_advances_under_paused_clock_advance() {
+        let (harness, paused) = Harness::test();
+        let clock = harness.clock();
+        let start_wall = clock.clock().now_utc();
+        assert_eq!(start_wall, OffsetDateTime::UNIX_EPOCH);
+        assert_eq!(clock.clock().monotonic_ms(), 0);
+
+        paused.advance(Duration::from_millis(1_500));
+        assert_eq!(clock.clock().monotonic_ms(), 1_500);
+        let after_wall = clock.clock().now_utc();
+        assert_eq!(after_wall - start_wall, time::Duration::milliseconds(1_500));
+    }
+
+    #[test]
+    fn with_paused_clock_pins_origin() {
+        let origin = OffsetDateTime::from_unix_timestamp(1_700_000_000).unwrap();
+        let (harness, paused) = Harness::with_paused_clock(origin);
+        assert_eq!(harness.clock().clock().now_utc(), origin);
+        paused.advance(Duration::from_secs(60));
+        assert_eq!(
+            harness.clock().clock().now_utc() - origin,
+            time::Duration::seconds(60)
+        );
     }
 }

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -133,7 +133,7 @@ pub use corrections::{
 };
 pub use harness::{
     Harness, HarnessClock, HarnessEnv, HarnessFs, HarnessKind, HarnessNet, HarnessRandom,
-    HarnessStdio, VmHarness,
+    HarnessStdio, MockAwareClock, VmHarness,
 };
 pub use http::{register_http_builtins, reset_http_state};
 pub use llm::register_llm_builtins;

--- a/crates/harn-vm/src/vm/methods/harness.rs
+++ b/crates/harn-vm/src/vm/methods/harness.rs
@@ -70,7 +70,10 @@ impl crate::vm::Vm {
         let clock = handle.inner().clock();
         match method {
             "now_ms" => Ok(VmValue::Int(crate::clock::now_wall_ms(clock.as_ref()))),
-            "monotonic_ms" => Ok(VmValue::Int(clock.monotonic_ms())),
+            "timestamp" => Ok(VmValue::Float(
+                crate::clock::now_wall_ms(clock.as_ref()) as f64 / 1_000.0,
+            )),
+            "monotonic_ms" | "elapsed" => Ok(VmValue::Int(clock.monotonic_ms())),
             "sleep_ms" => {
                 let ms = args
                     .first()

--- a/docs/diagnostics-catalog.json
+++ b/docs/diagnostics-catalog.json
@@ -49,7 +49,7 @@
     {
       "id": "LNT",
       "title": "Lint rules",
-      "count": 51
+      "count": 52
     },
     {
       "id": "FMT",
@@ -1816,6 +1816,24 @@
         }
       ],
       "related": [],
+      "explanationPresent": true,
+      "apiStability": "stable"
+    },
+    {
+      "code": "HARN-LNT-052",
+      "category": "LNT",
+      "summary": "ambient clock builtin replaced by `harness.clock.*`",
+      "repairs": [
+        {
+          "id": "bindings/thread-harness-clock",
+          "safety": "scope-local",
+          "summary": "Replace the ambient clock builtin with the corresponding `harness.clock.*` method"
+        }
+      ],
+      "related": [
+        "HARN-NAM-101",
+        "HARN-LNT-001"
+      ],
       "explanationPresent": true,
       "apiStability": "stable"
     },

--- a/docs/src/diagnostics.md
+++ b/docs/src/diagnostics.md
@@ -44,7 +44,7 @@ Repairs are tagged with a six-level safety class so `harn fix --apply --safety <
 | [`STD`](#std--stdlib-usage) | Stdlib usage | 3 |
 | [`PRM`](#prm--prompt-templates) | Prompt templates | 7 |
 | [`MOD`](#mod--modules-and-exports) | Modules and exports | 6 |
-| [`LNT`](#lnt--lint-rules) | Lint rules | 51 |
+| [`LNT`](#lnt--lint-rules) | Lint rules | 52 |
 | [`FMT`](#fmt--formatter) | Formatter | 3 |
 | [`IMP`](#imp--import-resolution) | Import resolution | 3 |
 | [`OWN`](#own--ownership-and-mutability) | Ownership and mutability | 4 |
@@ -232,6 +232,7 @@ Repairs are tagged with a six-level safety class so `harn fix --apply --safety <
 | [`HARN-LNT-049`](#harn-lnt-049) | legacy doc comment lint | `doc/migrate-comment-style` | `format-only` |
 | [`HARN-LNT-050`](#harn-lnt-050) | deprecated LLM options lint | `llm/migrate-deprecated-option` | `scope-local` |
 | [`HARN-LNT-051`](#harn-lnt-051) | unnecessary safe navigation lint | `expressions/simplify` | `behavior-preserving` |
+| [`HARN-LNT-052`](#harn-lnt-052) | ambient clock builtin replaced by `harness.clock.*` | `bindings/thread-harness-clock` | `scope-local` |
 
 ## FMT — Formatter
 
@@ -4343,6 +4344,48 @@ Specifically: unnecessary safe navigation lint.
 
 - Apply the lint's auto-fix where one is offered (`harn lint --fix`).
 - Suppress the lint with an attribute only when the surrounding code is intentionally non-idiomatic.
+
+#### Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.
+
+### `HARN-LNT-052`
+
+**Category:** `LNT` (Lint rules) &nbsp;·&nbsp; **API stability:** `stable`
+
+ambient clock builtin replaced by `harness.clock.*`
+
+- **Repair:** `bindings/thread-harness-clock` &nbsp;·&nbsp; **Safety:** `scope-local`
+- Replace the ambient clock builtin with the corresponding `harness.clock.*` method
+- **See also:** [`HARN-NAM-101`](#harn-nam-101), [`HARN-LNT-001`](#harn-lnt-001)
+
+**Category:** Lint (LNT)  
+**Variant:** `Code::LintAmbientClockBuiltin` (ambient clock builtin)
+
+#### What it means
+
+The lint fires on any call to `now_ms`, `monotonic_ms`, `sleep_ms`,
+`timestamp`, or `elapsed`. These were ambient clock-capability builtins in
+the pre-`Harness` runtime. Time access now routes through the
+`harness.clock.*` sub-handle so capability requirements appear in the type
+system instead of being hidden in the stdlib surface.
+
+This is a lint, not a hard error. The legacy builtins still compile while
+the migration is in flight, but every new call site should use the
+`harness.clock.*` method that matches it (`now_ms` → `harness.clock.now_ms`,
+`sleep_ms` → `harness.clock.sleep_ms`, etc.).
+
+#### How to fix
+
+- Run `harn fix --apply --safety scope-local` over the file. The
+  `bindings/thread-harness-clock` repair rewrites every call site where a
+  `harness` (or `_harness`) binding is in scope.
+- If `harness` isn't reachable from the call site, first thread it through
+  the enclosing fn via the `bindings/thread-harness` repair (which adds the
+  `harness: Harness` parameter at the entrypoint), then re-run
+  `harn fix --apply` to swap the call.
 
 #### Stability
 


### PR DESCRIPTION
## Summary

E4.3 slice of the Harness migration (parent epic #1765, closes #1768):

- New `Harness::test()` / `Harness::with_paused_clock(origin)` constructors return a `(Harness, Arc<PausedClock>)` pair so tests drive virtual time through `PausedClock::advance` without rebuilding harness wiring.
- `HarnessClock` gains `timestamp` (wall seconds, `f64`) and `elapsed` (alias for `monotonic_ms`) so every legacy ambient clock builtin has a 1:1 method.
- New `MockAwareClock<C>` wraps the production `RealClock` so `harness.clock.*` reads honor the existing `mock_time(...)` / `advance_time(...)` test fixtures during the E4.3 → E4.6 migration window. Single-script `sleep_ms` under a mock advances the mock synchronously, matching the legacy stdlib semantics. The shim retires when E4.5 ships `NullHarness`/`MockHarness`.
- Registers the `bindings/thread-harness-clock` repair template (safety: `scope-local`) plus a `HARN-LNT-052` lint that fires on every call to `now_ms`, `monotonic_ms`, `sleep_ms`, `timestamp`, `elapsed`. The lint emits a `FixEdit` that rewrites the call site to `harness.clock.<name>` when `harness` (or `_harness`) is in scope; otherwise the suggestion redirects users to the `bindings/thread-harness` repair so they thread the parameter first.
- New `harness_clock_replacement(...)` table in `harn_parser::diagnostic` is the single source of truth for the rename mapping — downstream replatform tooling (burin-code / harn-cloud) can query it instead of re-implementing.
- End-to-end verification: `harn fix --plan` / `--apply --safety scope-local` against `fn main(harness: Harness) { let ms = now_ms() }` produces `harness.clock.now_ms()` and reports zero post-apply diagnostics.

## Test plan

- [x] `cargo test -p harn-vm --lib harness` — new tests prove `Harness::test()` advances under `PausedClock::advance` and `with_paused_clock` pins a non-epoch origin.
- [x] `cargo test -p harn-lint --lib tests::ambient_clock` — 4 new tests cover lint emission, fix-edit application, no-fix-without-harness, and the `_harness` alias.
- [x] `cargo test -p harn-parser --lib diagnostic_codes` — registry tests pin the new repair id at `scope-local`.
- [x] `cargo run --bin harn -- test conformance --filter 'parallel_mock_clock|clock_mock|testbench_paused|testbench_replay_fidelity|testbench_clock_leak|llm_handlers_with_timeout|tool_binder_pipeline|harness_clock_methods|main_harness_entrypoint'` — 10 / 10 pass (existing mock_time fixtures stay green via `MockAwareClock`).
- [x] `cargo run --bin harn -- test conformance` — 1080 / 1080 pass.
- [x] `make all` — full repo gate green, including the regenerated diagnostic-code catalog (`docs/src/diagnostics.md` + `docs/diagnostics-catalog.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)