### PR TITLE
Add harn pack SBOM JSON summary

### DIFF
--- a/crates/harn-cli/src/commands/pack.rs
+++ b/crates/harn-cli/src/commands/pack.rs
@@ -15,11 +15,10 @@ use harn_parser::DiagnosticSeverity;
 use harn_vm::bytecode_cache;
 use harn_vm::module_artifact;
 use harn_vm::orchestration::{
-    build_harnpack, current_provider_catalog_hash_blake3, load_workflow_bundle_any_version,
-    workflow_bundle_hash, CatchupPolicySpec, ConnectorRequirement, EnvironmentRequirements,
-    HarnpackEntry, ModuleEntry, RetryPolicySpec, SBOMDoc, SBOMPackage, SBOMRelationship, ToolEntry,
-    WorkflowBundle, WorkflowBundlePolicy, WorkflowBundleReplayMetadata, WorkflowBundleTrigger,
-    WORKFLOW_BUNDLE_SCHEMA_VERSION,
+    build_harnpack, load_workflow_bundle_any_version, workflow_bundle_hash, CatchupPolicySpec,
+    ConnectorRequirement, EnvironmentRequirements, HarnpackEntry, ModuleEntry, RetryPolicySpec,
+    SBOMDoc, SBOMPackage, SBOMRelationship, ToolEntry, WorkflowBundle, WorkflowBundlePolicy,
+    WorkflowBundleReplayMetadata, WorkflowBundleTrigger, WORKFLOW_BUNDLE_SCHEMA_VERSION,
 };
 use harn_vm::Compiler;
 use serde::Serialize;
@@ -31,7 +30,8 @@ use crate::parse_source_file;
 
 /// Stable schema version for the `harn pack --json` envelope. Bump when
 /// [`PackJsonData`] changes shape in a way that agents need to detect.
-pub const PACK_SCHEMA_VERSION: u32 = 1;
+pub const PACK_SCHEMA_VERSION: u32 = 2;
+pub const PACK_SBOM_ARCHIVE_PATH: &str = "sbom.spdx.json";
 
 /// JSON payload emitted under `JsonEnvelope.data` for `harn pack`.
 #[derive(Debug, Clone, Serialize)]
@@ -39,7 +39,31 @@ pub struct PackJsonData {
     pub bundle_hash: String,
     pub output_path: PathBuf,
     pub size_bytes: u64,
+    pub signature: PackSignatureSummary,
+    pub sbom_summary: PackSbomSummary,
+    pub debug_symbol_metadata: PackDebugSymbolMetadata,
     pub manifest: WorkflowBundle,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PackSignatureSummary {
+    pub algorithm: String,
+    pub key_id: Option<String>,
+    pub present: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PackSbomSummary {
+    pub components: usize,
+    pub stdlib_modules: usize,
+    pub providers: usize,
+    pub tools: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PackDebugSymbolMetadata {
+    pub harnbc_count: usize,
+    pub total_bytes: u64,
 }
 
 struct PackJsonOutput(PackJsonData);
@@ -86,6 +110,65 @@ pub fn run_to_envelope(args: &PackArgs) -> JsonEnvelope<PackJsonData> {
         Ok(outcome) => PackJsonOutput(outcome.json).into_envelope(),
         Err(err) => JsonEnvelope::err(PACK_SCHEMA_VERSION, err.code, err.message),
     }
+}
+
+pub fn json_schema() -> serde_json::Value {
+    serde_json::json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "harn pack --json",
+        "type": "object",
+        "required": ["schemaVersion", "ok", "data", "warnings"],
+        "properties": {
+            "schemaVersion": { "const": PACK_SCHEMA_VERSION },
+            "ok": { "const": true },
+            "warnings": { "type": "array" },
+            "data": {
+                "type": "object",
+                "required": [
+                    "bundle_hash",
+                    "output_path",
+                    "size_bytes",
+                    "signature",
+                    "sbom_summary",
+                    "debug_symbol_metadata",
+                    "manifest"
+                ],
+                "properties": {
+                    "bundle_hash": { "type": "string", "pattern": "^blake3:" },
+                    "output_path": { "type": "string", "minLength": 1 },
+                    "size_bytes": { "type": "integer", "minimum": 1 },
+                    "signature": {
+                        "type": "object",
+                        "required": ["algorithm", "key_id", "present"],
+                        "properties": {
+                            "algorithm": { "const": "ed25519" },
+                            "key_id": { "type": ["string", "null"] },
+                            "present": { "type": "boolean" }
+                        }
+                    },
+                    "sbom_summary": {
+                        "type": "object",
+                        "required": ["components", "stdlib_modules", "providers", "tools"],
+                        "properties": {
+                            "components": { "type": "integer", "minimum": 1 },
+                            "stdlib_modules": { "type": "integer", "minimum": 0 },
+                            "providers": { "type": "integer", "minimum": 0 },
+                            "tools": { "type": "integer", "minimum": 0 }
+                        }
+                    },
+                    "debug_symbol_metadata": {
+                        "type": "object",
+                        "required": ["harnbc_count", "total_bytes"],
+                        "properties": {
+                            "harnbc_count": { "type": "integer", "minimum": 1 },
+                            "total_bytes": { "type": "integer", "minimum": 1 }
+                        }
+                    },
+                    "manifest": { "type": "object" }
+                }
+            }
+        }
+    })
 }
 
 /// Outcome of [`build`]. Used by tests; the dispatcher consumes it
@@ -186,6 +269,10 @@ pub fn build(args: &PackArgs) -> Result<PackOutcome, PackError> {
     let mut contents = Vec::new();
     let mut sbom_packages = Vec::new();
     let mut sbom_relationships = Vec::new();
+    let mut debug_symbol_metadata = PackDebugSymbolMetadata {
+        harnbc_count: 0,
+        total_bytes: 0,
+    };
 
     let stdlib_version = bytecode_cache::HARN_VERSION.to_string();
     let harn_version = bytecode_cache::HARN_VERSION.to_string();
@@ -283,6 +370,8 @@ pub fn build(args: &PackArgs) -> Result<PackOutcome, PackError> {
 
         let source_hash = blake3_hash(source.as_bytes());
         let harnbc_hash = blake3_hash(&chunk_bytes);
+        debug_symbol_metadata.harnbc_count += 1;
+        debug_symbol_metadata.total_bytes += chunk_bytes.len() as u64;
 
         transitive_modules.push(ModuleEntry {
             path: rel.clone(),
@@ -296,6 +385,7 @@ pub fn build(args: &PackArgs) -> Result<PackOutcome, PackError> {
         ));
         contents.push(HarnpackEntry::new(chunk_archive_path, chunk_bytes));
         if let Some(artifact_bytes) = module_artifact_bytes {
+            debug_symbol_metadata.total_bytes += artifact_bytes.len() as u64;
             let module_rel = adjacent_with_extension(&rel, bytecode_cache::MODULE_CACHE_EXTENSION)
                 .ok_or_else(|| {
                     PackError::new(
@@ -332,17 +422,59 @@ pub fn build(args: &PackArgs) -> Result<PackOutcome, PackError> {
         ));
     }
 
-    let provider_catalog_hash = current_provider_catalog_hash_blake3().map_err(|err| {
+    let provider_catalog = harn_vm::provider_catalog::artifact();
+    let provider_catalog_bytes = serde_json::to_vec(&provider_catalog).map_err(|err| {
         PackError::new(
             "provider_catalog.failed",
-            format!("failed to snapshot provider catalog: {err}"),
+            format!("failed to serialize provider catalog snapshot: {err}"),
         )
     })?;
+    let provider_catalog_hash = blake3_hash(&provider_catalog_bytes);
+    sbom_packages.push(SBOMPackage {
+        name: "harn-provider-catalog".to_string(),
+        version: Some(harn_version.clone()),
+        package_hash_blake3: Some(provider_catalog_hash.clone()),
+        license: None,
+    });
+    sbom_relationships.push(SBOMRelationship {
+        from: format!("entrypoint:{}", entrypoint_rel.display()),
+        to: "harn-provider-catalog".to_string(),
+        relationship_type: "depends_on".to_string(),
+    });
+    for provider in &provider_catalog.providers {
+        let provider_name = format!("provider:{}", provider.id);
+        sbom_packages.push(SBOMPackage {
+            name: provider_name.clone(),
+            version: None,
+            package_hash_blake3: None,
+            license: None,
+        });
+        sbom_relationships.push(SBOMRelationship {
+            from: "harn-provider-catalog".to_string(),
+            to: provider_name,
+            relationship_type: "contains".to_string(),
+        });
+    }
 
-    // E6.4 populates `tool_manifest` from the static module walk; today
-    // it stays empty so the v2 manifest is consistently deterministic.
+    // The static module walk does not yet discover tool definitions, but
+    // the SBOM path below is wired so future tool manifest entries are
+    // reflected in both the manifest and JSON summary without another
+    // archive format change.
     let tool_manifest: Vec<ToolEntry> = Vec::new();
-    let bundle = assemble_bundle(
+    for tool in &tool_manifest {
+        sbom_packages.push(SBOMPackage {
+            name: format!("tool:{}", tool.name),
+            version: None,
+            package_hash_blake3: tool.schema_hash_blake3.clone(),
+            license: None,
+        });
+        sbom_relationships.push(SBOMRelationship {
+            from: format!("entrypoint:{}", entrypoint_rel.display()),
+            to: format!("tool:{}", tool.name),
+            relationship_type: "depends_on".to_string(),
+        });
+    }
+    let mut bundle = assemble_bundle(
         &entrypoint_rel,
         transitive_modules,
         stdlib_version,
@@ -357,6 +489,14 @@ pub fn build(args: &PackArgs) -> Result<PackOutcome, PackError> {
         },
         prior.as_ref(),
     );
+    sort_sbom_doc(&mut bundle.sbom);
+    let sbom_bytes = serde_json::to_vec_pretty(&bundle.sbom).map_err(|err| {
+        PackError::new(
+            "pack.sbom_failed",
+            format!("failed to render SBOM document: {err}"),
+        )
+    })?;
+    contents.push(HarnpackEntry::new(PACK_SBOM_ARCHIVE_PATH, sbom_bytes));
 
     let archive_bytes = build_harnpack(&bundle, &contents).map_err(|err| {
         PackError::new(
@@ -398,9 +538,65 @@ pub fn build(args: &PackArgs) -> Result<PackOutcome, PackError> {
             bundle_hash,
             output_path,
             size_bytes,
+            signature: signature_summary(&bundle),
+            sbom_summary: sbom_summary(&bundle),
+            debug_symbol_metadata,
             manifest: bundle,
         },
     })
+}
+
+fn signature_summary(bundle: &WorkflowBundle) -> PackSignatureSummary {
+    match &bundle.signature {
+        Some(signature) => PackSignatureSummary {
+            algorithm: signature.algorithm.clone(),
+            key_id: signature.key_id.clone(),
+            present: true,
+        },
+        None => PackSignatureSummary {
+            algorithm: "ed25519".to_string(),
+            key_id: None,
+            present: false,
+        },
+    }
+}
+
+fn sbom_summary(bundle: &WorkflowBundle) -> PackSbomSummary {
+    let stdlib_modules = bundle
+        .sbom
+        .packages
+        .iter()
+        .filter(|package| package.name.starts_with("std/"))
+        .count();
+    let providers = bundle
+        .sbom
+        .packages
+        .iter()
+        .filter(|package| package.name.starts_with("provider:"))
+        .count();
+    PackSbomSummary {
+        components: bundle.sbom.packages.len(),
+        stdlib_modules,
+        providers,
+        tools: bundle.tool_manifest.len(),
+    }
+}
+
+fn sort_sbom_doc(sbom: &mut SBOMDoc) {
+    sbom.packages.sort_by(|left, right| {
+        (&left.name, &left.version, &left.package_hash_blake3).cmp(&(
+            &right.name,
+            &right.version,
+            &right.package_hash_blake3,
+        ))
+    });
+    sbom.relationships.sort_by(|left, right| {
+        (&left.from, &left.to, &left.relationship_type).cmp(&(
+            &right.from,
+            &right.to,
+            &right.relationship_type,
+        ))
+    });
 }
 
 fn assemble_bundle(

--- a/crates/harn-cli/src/json_envelope.rs
+++ b/crates/harn-cli/src/json_envelope.rs
@@ -241,7 +241,7 @@ pub fn catalog() -> Vec<SchemaEntry> {
             command: "pack",
             schema_version: crate::commands::pack::PACK_SCHEMA_VERSION,
             description: "Signed-ready .harnpack run-bundle build summary.",
-            schema_json: None,
+            schema_json: Some(crate::commands::pack::json_schema()),
         },
         SchemaEntry {
             command: "dev",

--- a/crates/harn-cli/tests/pack_cli.rs
+++ b/crates/harn-cli/tests/pack_cli.rs
@@ -12,7 +12,9 @@ use std::path::{Path, PathBuf};
 use harn_cli::cli::PackArgs;
 use harn_cli::commands::pack;
 use harn_cli::tests::common::cwd_lock;
-use harn_vm::orchestration::{load_workflow_bundle, read_harnpack, WORKFLOW_BUNDLE_SCHEMA_VERSION};
+use harn_vm::orchestration::{
+    load_workflow_bundle, read_harnpack, SBOMDoc, WORKFLOW_BUNDLE_SCHEMA_VERSION,
+};
 use tempfile::TempDir;
 use tokio::runtime::Builder;
 
@@ -67,6 +69,37 @@ fn pack_writes_valid_harnpack_archive() {
         .contents
         .iter()
         .any(|entry| entry.path == Path::new("bytecode/hello.harnbc")));
+    let sbom_entry = archive
+        .contents
+        .iter()
+        .find(|entry| entry.path == Path::new(pack::PACK_SBOM_ARCHIVE_PATH))
+        .expect("harnpack contains archived SBOM document");
+    let sbom_doc: SBOMDoc = serde_json::from_slice(&sbom_entry.bytes).unwrap();
+    assert_eq!(sbom_doc.format, "spdx-lite");
+    assert_eq!(sbom_doc.version, "2.3");
+    let sbom_value: serde_json::Value = serde_json::from_slice(&sbom_entry.bytes).unwrap();
+    assert_eq!(
+        sbom_value,
+        serde_json::to_value(&archive.manifest.sbom).unwrap()
+    );
+    assert!(
+        archive
+            .manifest
+            .sbom
+            .packages
+            .iter()
+            .any(|package| package.name == "harn-provider-catalog"),
+        "SBOM must carry provider catalog component"
+    );
+    assert!(
+        archive
+            .manifest
+            .sbom
+            .packages
+            .iter()
+            .any(|package| package.name.starts_with("provider:")),
+        "SBOM must enumerate provider catalog entries"
+    );
     let report = harn_vm::orchestration::validate_workflow_bundle(&archive.manifest);
     assert!(report.valid, "{report:#?}");
 }
@@ -147,6 +180,9 @@ fn pack_json_envelope_carries_pack_schema() {
         });
 
     let value = serde_json::to_value(&envelope).unwrap();
+    jsonschema::draft202012::meta::validate(&pack::json_schema()).unwrap();
+    let validator = jsonschema::draft202012::new(&pack::json_schema()).unwrap();
+    validator.validate(&value).unwrap();
     assert_eq!(value["schemaVersion"], pack::PACK_SCHEMA_VERSION);
     assert_eq!(value["ok"], true);
     assert_eq!(value["data"]["output_path"], out.display().to_string());
@@ -154,6 +190,31 @@ fn pack_json_envelope_carries_pack_schema() {
         .as_str()
         .is_some_and(|s| s.starts_with("blake3:")));
     assert!(value["data"]["size_bytes"].as_u64().unwrap() > 0);
+    assert_eq!(value["data"]["signature"]["algorithm"], "ed25519");
+    assert_eq!(value["data"]["signature"]["present"], false);
+    assert!(
+        value["data"]["sbom_summary"]["components"]
+            .as_u64()
+            .unwrap()
+            > 0
+    );
+    assert!(value["data"]["sbom_summary"]["providers"].as_u64().unwrap() > 0);
+    assert_eq!(
+        value["data"]["sbom_summary"]["components"]
+            .as_u64()
+            .unwrap(),
+        value["data"]["manifest"]["sbom"]["packages"]
+            .as_array()
+            .unwrap()
+            .len() as u64
+    );
+    assert_eq!(value["data"]["debug_symbol_metadata"]["harnbc_count"], 1);
+    assert!(
+        value["data"]["debug_symbol_metadata"]["total_bytes"]
+            .as_u64()
+            .unwrap()
+            > 0
+    );
     assert_eq!(
         value["data"]["manifest"]["schema_version"],
         WORKFLOW_BUNDLE_SCHEMA_VERSION

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -1939,8 +1939,8 @@ Build a signed-ready `.harnpack` run bundle from a Harn entrypoint
 containing a v2 `WorkflowBundle` manifest (`harnpack.json`), every
 transitively-imported `.harn` source under `sources/`, every module's
 precompiled `.harnbc`/`.harnmod` artifact under `bytecode/`, a
-provider-catalog hash + stdlib version pin, a minimal SPDX-lite SBOM,
-and a (future) Ed25519 signature slot.
+provider-catalog hash + stdlib version pin, an archived SPDX-lite 2.3
+SBOM (`sbom.spdx.json`), and a (future) Ed25519 signature slot.
 
 ```bash
 harn pack examples/hello.harn
@@ -1952,9 +1952,11 @@ harn pack workflows/new-entry.harn --upgrade old.harnpack --out new.harnpack
 Output paths default to `<entrypoint>.harnpack` next to the entrypoint.
 `--json` emits a `JsonEnvelope` with `bundle_hash` (BLAKE3 over the
 canonical manifest bytes plus sorted content hashes), `output_path`,
-`size_bytes`, and the full manifest; see the catalog row at
-`harn --json-schemas --command pack` for the schema version. Repacking
-the same source produces a byte-identical archive.
+`size_bytes`, signature status, SBOM counts, bytecode/debug-symbol
+metadata, and the full manifest; see the catalog row at
+`harn --json-schemas --command pack` for the schema version and inline
+JSON Schema. Repacking the same source produces a byte-identical
+archive.
 
 `--upgrade <old.harnpack>` reads a prior bundle (v1 JSON or v2 archive)
 and re-emits it under the v2 manifest, preserving the prior bundle's
@@ -1962,9 +1964,8 @@ id, name, version, triggers, workflow graph, and prompt capsules. The
 new `<entrypoint>` argument supplies the transitive-module + SBOM
 payload that the older schema lacked.
 
-Signing (`--sign --key <path>`) and richer SBOM enumeration land in
-follow-ups (E6.3 and E6.4). Today the bundle ships unsigned; pass
-`--unsigned` to make that intent explicit.
+Signing (`--sign --key <path>`) lands in a follow-up. Today the bundle
+ships unsigned; pass `--unsigned` to make that intent explicit.
 
 [issue-1781]: https://github.com/burin-labs/harn/issues/1781
 

--- a/docs/src/workflow-bundles.md
+++ b/docs/src/workflow-bundles.md
@@ -6,8 +6,8 @@ remain importable into Harn Cloud later without changing the workflow's durable
 identity, graph, policy, or replay metadata.
 
 The canonical package format is `.harnpack`: a deterministic `tar.zst` archive
-with `harnpack.json` at the archive root. The manifest can also be read as
-plain JSON during authoring. The current schema version is `2`.
+with `harnpack.json` and `sbom.spdx.json` at the archive root. The manifest can
+also be read as plain JSON during authoring. The current schema version is `2`.
 
 For an end-to-end walkthrough that authors a bundle, validates it,
 previews the graph, and runs a deterministic local receipt — all
@@ -66,6 +66,12 @@ replay runs can pin the exact workflow graph.
 Bundle identity for `.harnpack` archives is BLAKE3 over the canonical manifest
 bytes plus the sorted content hashes. Re-packing the same manifest and content
 produces the same bundle hash.
+
+`harn pack --json` emits a `JsonEnvelope` summary with the bundle hash, output
+path, archive size, signature presence, SBOM counts, bytecode/debug-symbol
+metadata, and the full manifest. Signing is represented as `{ present: false,
+algorithm: "ed25519" }` until the signing workflow fills the manifest
+signature slot.
 
 ## Preview
 


### PR DESCRIPTION
## Summary

- archive the generated SBOM as sbom.spdx.json inside .harnpack bundles
- include provider catalog/provider components in the SBOM and keep package ordering deterministic
- expand harn pack --json with signature, SBOM, and bytecode/debug-symbol metadata summaries
- register and validate the pack JSON envelope schema in harn --json-schemas

Closes #1783

## Verification

- cargo fmt --package harn-cli --check
- git diff --check origin/main..HEAD && git diff --check
- CARGO_TARGET_DIR=/tmp/harn-target-1783-sbom-json CARGO_BUILD_JOBS=4 HARN_LLM_CALLS_DISABLED=1 cargo test -p harn-cli --test pack_cli --test json_schemas_cli
- make lint-test-patterns