### PR TITLE
Add harn graph JSON command

### DIFF
--- a/crates/harn-cli/src/cli/graph.rs
+++ b/crates/harn-cli/src/cli/graph.rs
@@ -1,0 +1,17 @@
+use std::path::PathBuf;
+
+use clap::Parser;
+
+#[derive(Debug, Parser)]
+pub(crate) struct GraphArgs {
+    /// Harn file or directory to analyze.
+    pub root: PathBuf,
+
+    /// Emit a stable JSON envelope instead of the text tree.
+    #[arg(long)]
+    pub json: bool,
+
+    /// Focus output on one module path, import path, or basename.
+    #[arg(long, value_name = "MODULE")]
+    pub module: Option<String>,
+}

--- a/crates/harn-cli/src/cli/mod.rs
+++ b/crates/harn-cli/src/cli/mod.rs
@@ -26,6 +26,7 @@ mod eval;
 mod explain;
 mod fix;
 mod flow;
+mod graph;
 mod init;
 mod lint_fmt;
 mod local;
@@ -103,6 +104,7 @@ pub(crate) use flow::{
     FlowArchivistCommand, FlowArchivistScanArgs, FlowArgs, FlowCommand, FlowReplayAuditArgs,
     FlowShipCommand, FlowShipWatchArgs,
 };
+pub(crate) use graph::GraphArgs;
 pub(crate) use init::{InitArgs, NewArgs, ProjectTemplate};
 pub(crate) use lint_fmt::{FmtArgs, PathTargetsArgs};
 pub(crate) use local::{
@@ -351,6 +353,8 @@ SCRIPTING
     Trigger(TriggerArgs),
     /// Statically enumerate declared trigger routes and their requirements.
     Routes(RoutesArgs),
+    /// Statically enumerate modules, symbols, imports, capabilities, effects, and host calls.
+    Graph(GraphArgs),
     /// Inspect Harn Flow atom, slice, and predicate audit state.
     Flow(FlowArgs),
     /// Validate, preview, and run portable workflow bundles.

--- a/crates/harn-cli/src/cli/tests.rs
+++ b/crates/harn-cli/src/cli/tests.rs
@@ -94,6 +94,25 @@ fn test_parses_routes_json() {
 }
 
 #[test]
+fn test_parses_graph_json_and_module_filter() {
+    let cli = Cli::parse_from([
+        "harn",
+        "graph",
+        "fixtures/project",
+        "--json",
+        "--module",
+        "main",
+    ]);
+
+    let Command::Graph(args) = cli.command.unwrap() else {
+        panic!("expected graph command");
+    };
+    assert_eq!(args.root, PathBuf::from("fixtures/project"));
+    assert!(args.json);
+    assert_eq!(args.module.as_deref(), Some("main"));
+}
+
+#[test]
 fn test_parses_parse_and_tokens_json() {
     let parse = Cli::parse_from(["harn", "parse", "main.harn", "--json"]);
     let Command::Parse(parse_args) = parse.command.unwrap() else {

--- a/crates/harn-cli/src/commands/graph.rs
+++ b/crates/harn-cli/src/commands/graph.rs
@@ -1,0 +1,608 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use harn_ir::{CallClassification, Capability, LiteralValue, NodeSemantics};
+use harn_parser::{format_type, Node, SNode, TypeParam, TypedParam, Variance, WhereClause};
+use serde::Serialize;
+
+use crate::cli::GraphArgs;
+use crate::json_envelope::{to_string_pretty, JsonEnvelope};
+
+pub(crate) const GRAPH_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct GraphReport {
+    pub modules: Vec<GraphModule>,
+    pub graph: GraphEdges,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct GraphModule {
+    pub path: String,
+    pub public_symbols: Vec<GraphSymbol>,
+    pub imports: Vec<String>,
+    pub requires_capabilities: Vec<String>,
+    pub effects: Vec<String>,
+    pub host_calls: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct GraphSymbol {
+    pub name: String,
+    pub kind: String,
+    pub signature: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct GraphEdges {
+    pub nodes: Vec<String>,
+    pub edges: Vec<GraphEdge>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct GraphEdge {
+    pub from: String,
+    pub to: String,
+}
+
+pub(crate) fn run(args: GraphArgs) -> i32 {
+    match analyze_graph(&args.root, args.module.as_deref()) {
+        Ok(report) => {
+            if args.json {
+                let envelope = JsonEnvelope::ok(GRAPH_SCHEMA_VERSION, report);
+                println!("{}", to_string_pretty(&envelope));
+            } else {
+                print_text_report(&report);
+            }
+            0
+        }
+        Err(error) => {
+            if args.json {
+                let envelope: JsonEnvelope<GraphReport> =
+                    JsonEnvelope::err(GRAPH_SCHEMA_VERSION, "graph_error", error);
+                println!("{}", to_string_pretty(&envelope));
+            } else {
+                eprintln!("error: {error}");
+            }
+            1
+        }
+    }
+}
+
+fn analyze_graph(root: &Path, module_filter: Option<&str>) -> Result<GraphReport, String> {
+    let root_dir = graph_root_dir(root);
+    let targets = [root.to_string_lossy().to_string()];
+    let target_refs: Vec<&str> = targets.iter().map(String::as_str).collect();
+    let files = crate::commands::check::collect_harn_targets(&target_refs);
+    if files.is_empty() {
+        return Err(format!("no .harn files found under {}", root.display()));
+    }
+
+    let module_graph = crate::commands::check::build_module_graph(&files);
+    let mut module_paths = module_graph.module_paths();
+    if let Some(filter) = module_filter {
+        module_paths.retain(|path| module_matches_filter(path, filter, &root_dir));
+    }
+
+    let display_paths: BTreeMap<PathBuf, String> = module_graph
+        .module_paths()
+        .into_iter()
+        .map(|path| {
+            let display = display_module_path(&path, &root_dir);
+            (path, display)
+        })
+        .collect();
+
+    let mut modules = Vec::new();
+    let mut edges = Vec::new();
+    let mut nodes = BTreeSet::new();
+    for path in &module_paths {
+        let display_path = display_paths
+            .get(path)
+            .cloned()
+            .unwrap_or_else(|| display_module_path(path, &root_dir));
+        nodes.insert(display_path.clone());
+        let imports = module_graph.imports_for_module(path);
+        for import in &imports {
+            if let Some(resolved) = &import.resolved_path {
+                let to = display_paths
+                    .get(resolved)
+                    .cloned()
+                    .unwrap_or_else(|| display_module_path(resolved, &root_dir));
+                nodes.insert(to.clone());
+                edges.push(GraphEdge {
+                    from: display_path.clone(),
+                    to,
+                });
+            }
+        }
+        modules.push(describe_module(
+            path,
+            &display_path,
+            &root_dir,
+            &module_graph,
+            &imports,
+        )?);
+    }
+
+    modules.sort_by(|left, right| left.path.cmp(&right.path));
+    edges.sort_by(|left, right| {
+        left.from
+            .cmp(&right.from)
+            .then_with(|| left.to.cmp(&right.to))
+    });
+    edges.dedup_by(|left, right| left.from == right.from && left.to == right.to);
+
+    Ok(GraphReport {
+        modules,
+        graph: GraphEdges {
+            nodes: nodes.into_iter().collect(),
+            edges,
+        },
+    })
+}
+
+fn describe_module(
+    path: &Path,
+    display_path: &str,
+    root_dir: &Path,
+    module_graph: &harn_modules::ModuleGraph,
+    imports: &[harn_modules::ModuleImport],
+) -> Result<GraphModule, String> {
+    let source = harn_modules::read_module_source(path)
+        .ok_or_else(|| format!("failed to read {}", path.display()))?;
+    let program = harn_parser::parse_source(&source)
+        .map_err(|error| format!("failed to parse {}: {error}", path.display()))?;
+    let exports: BTreeSet<String> = module_graph.exports_for_module(path).into_iter().collect();
+    let public_symbols = public_symbols(&program, &exports);
+    let usage = module_usage(&program);
+
+    Ok(GraphModule {
+        path: display_path.to_string(),
+        public_symbols,
+        imports: imports
+            .iter()
+            .map(|import| {
+                import
+                    .resolved_path
+                    .as_deref()
+                    .map(|resolved| display_module_path(resolved, root_dir))
+                    .unwrap_or_else(|| import.raw_path.clone())
+            })
+            .collect(),
+        requires_capabilities: usage.capabilities.into_iter().collect(),
+        effects: usage.effects.into_iter().collect(),
+        host_calls: usage.host_calls.into_iter().collect(),
+    })
+}
+
+#[derive(Debug, Default)]
+struct ModuleUsage {
+    capabilities: BTreeSet<String>,
+    effects: BTreeSet<String>,
+    host_calls: BTreeSet<String>,
+}
+
+fn module_usage(program: &[SNode]) -> ModuleUsage {
+    let report = harn_ir::analyze_program(program);
+    let mut usage = ModuleUsage::default();
+    for handler in report.handlers {
+        for node in handler.nodes {
+            let NodeSemantics::Call(call) = node.semantics else {
+                continue;
+            };
+            usage.host_calls.extend(host_call_surface(&call));
+            usage.capabilities.extend(direct_capabilities(&call));
+            usage.effects.extend(direct_effects(&call));
+            if let CallClassification::Capabilities(effects) = call.classification {
+                for effect in effects {
+                    usage
+                        .capabilities
+                        .insert(capability_label(effect.capability));
+                    usage
+                        .effects
+                        .insert(effect_label(effect.capability, &effect.operation));
+                    usage.host_calls.insert(call.display_name.clone());
+                }
+            }
+        }
+    }
+    usage
+}
+
+fn direct_capabilities(call: &harn_ir::CallSemantics) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    match call.name.as_str() {
+        "read_file" | "read_file_bytes" | "read_file_result" | "read_lines" | "read_stdin" => {
+            out.insert("workspace.read_text".to_string());
+        }
+        "list_dir" | "walk_dir" | "glob" => {
+            out.insert("workspace.list".to_string());
+        }
+        "file_exists" | "stat" => {
+            out.insert("workspace.exists".to_string());
+        }
+        "write_file" | "write_file_bytes" | "append_file" | "mkdir" | "copy_file" | "move_file" => {
+            out.insert("workspace.write_text".to_string());
+        }
+        "delete_file" => {
+            out.insert("workspace.delete".to_string());
+        }
+        "apply_edit" => {
+            out.insert("workspace.apply_edit".to_string());
+        }
+        "http_get"
+        | "http_post"
+        | "http_put"
+        | "http_patch"
+        | "http_delete"
+        | "http_request"
+        | "http_download"
+        | "http_session"
+        | "http_session_request"
+        | "http_stream_open"
+        | "sse_connect"
+        | "websocket_connect"
+        | "websocket_server" => {
+            out.insert("network.http".to_string());
+        }
+        "exec" | "exec_at" | "shell" | "shell_at" => {
+            out.insert("process.exec".to_string());
+        }
+        "llm_call"
+        | "llm_call_safe"
+        | "llm_stream_call"
+        | "llm_call_structured"
+        | "llm_call_structured_safe"
+        | "llm_call_structured_result"
+        | "llm_completion"
+        | "agent_llm_turn"
+        | "agent_turn"
+        | "agent_loop" => {
+            out.insert("llm.call".to_string());
+        }
+        "spawn_agent" | "send_input" | "resume_agent" | "wait_agent" | "close_agent"
+        | "worker_trigger" => {
+            out.insert("worker.dispatch".to_string());
+        }
+        "request_approval" => {
+            out.insert("human.approval".to_string());
+        }
+        "connector_call" | "mcp_call" | "host_tool_call" => {
+            out.insert("connector.call".to_string());
+        }
+        "secret_get" => {
+            out.insert("connector.secret_get".to_string());
+        }
+        "host_call" => insert_host_call_capability(call, &mut out),
+        _ if call.name.starts_with("mcp_") => {
+            out.insert("connector.call".to_string());
+        }
+        _ => {}
+    }
+    out
+}
+
+fn direct_effects(call: &harn_ir::CallSemantics) -> BTreeSet<String> {
+    direct_capabilities(call)
+        .into_iter()
+        .map(|capability| match capability.as_str() {
+            "workspace.read_text" | "workspace.list" | "workspace.exists" => "fs.read".to_string(),
+            "workspace.write_text" | "workspace.delete" | "workspace.apply_edit" => {
+                "fs.write".to_string()
+            }
+            "network.http" => "net.http".to_string(),
+            "process.exec" => "process.exec".to_string(),
+            "llm.call" => "llm.call".to_string(),
+            "worker.dispatch" => "worker.dispatch".to_string(),
+            "human.approval" => "human.approval".to_string(),
+            "template.render" => "template.render".to_string(),
+            other if other.starts_with("connector.") => "connector.call".to_string(),
+            other => other.to_string(),
+        })
+        .collect()
+}
+
+fn host_call_surface(call: &harn_ir::CallSemantics) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    if !direct_capabilities(call).is_empty() {
+        out.insert(call.display_name.clone());
+    }
+    if call.name == "host_call" {
+        if let Some(operation) = call.literal_args.first().and_then(literal_as_str) {
+            out.insert(operation.to_string());
+        }
+    }
+    out
+}
+
+fn insert_host_call_capability(call: &harn_ir::CallSemantics, out: &mut BTreeSet<String>) {
+    let Some(operation) = call.literal_args.first().and_then(literal_as_str) else {
+        out.insert("connector.call".to_string());
+        return;
+    };
+    if operation == "template.render" {
+        out.insert("template.render".to_string());
+    } else if operation.starts_with("process.") {
+        out.insert("process.exec".to_string());
+    } else if operation.starts_with("workspace.") || operation.starts_with("connector.") {
+        out.insert(operation.to_string());
+    } else {
+        out.insert("connector.call".to_string());
+    }
+}
+
+fn literal_as_str(value: &LiteralValue) -> Option<&str> {
+    match value {
+        LiteralValue::String(value) | LiteralValue::Identifier(value) => Some(value.as_str()),
+        _ => None,
+    }
+}
+
+fn capability_label(capability: Capability) -> String {
+    match capability {
+        Capability::WorkspaceMutation => "workspace.write_text",
+        Capability::CommandExecution => "process.exec",
+        Capability::NetworkAccess => "network.http",
+        Capability::ConnectorAccess => "connector.call",
+        Capability::ModelCall => "llm.call",
+        Capability::WorkerDispatch => "worker.dispatch",
+        Capability::HumanApproval => "human.approval",
+        Capability::AutonomyPolicy => "autonomy.policy",
+    }
+    .to_string()
+}
+
+fn effect_label(capability: Capability, operation: &str) -> String {
+    match capability {
+        Capability::WorkspaceMutation => "fs.write".to_string(),
+        Capability::CommandExecution => "process.exec".to_string(),
+        Capability::NetworkAccess => "net.http".to_string(),
+        Capability::ConnectorAccess => {
+            if operation == "template.render" {
+                "template.render".to_string()
+            } else {
+                "connector.call".to_string()
+            }
+        }
+        Capability::ModelCall => "llm.call".to_string(),
+        Capability::WorkerDispatch => "worker.dispatch".to_string(),
+        Capability::HumanApproval => "human.approval".to_string(),
+        Capability::AutonomyPolicy => "autonomy.policy".to_string(),
+    }
+}
+
+fn public_symbols(program: &[SNode], exports: &BTreeSet<String>) -> Vec<GraphSymbol> {
+    let mut symbols = Vec::new();
+    for node in program {
+        collect_public_symbol(node, exports, &mut symbols);
+    }
+    symbols.sort_by(|left, right| {
+        left.name
+            .cmp(&right.name)
+            .then_with(|| left.kind.cmp(&right.kind))
+    });
+    symbols
+}
+
+fn collect_public_symbol(node: &SNode, exports: &BTreeSet<String>, out: &mut Vec<GraphSymbol>) {
+    match &node.node {
+        Node::AttributedDecl { inner, .. } => collect_public_symbol(inner, exports, out),
+        Node::FnDecl {
+            name,
+            type_params,
+            params,
+            return_type,
+            where_clauses,
+            is_stream,
+            ..
+        } if exports.contains(name) => out.push(GraphSymbol {
+            name: name.clone(),
+            kind: "fn".to_string(),
+            signature: fn_signature(
+                if *is_stream { "gen fn" } else { "fn" },
+                name,
+                type_params,
+                params,
+                return_type.as_ref(),
+                where_clauses,
+            ),
+        }),
+        Node::ToolDecl {
+            name,
+            params,
+            return_type,
+            ..
+        } if exports.contains(name) => out.push(GraphSymbol {
+            name: name.clone(),
+            kind: "tool".to_string(),
+            signature: callable_signature("tool", name, &[], params, return_type.as_ref(), &[]),
+        }),
+        Node::Pipeline {
+            name,
+            params,
+            return_type,
+            ..
+        } if exports.contains(name) => out.push(GraphSymbol {
+            name: name.clone(),
+            kind: "pipeline".to_string(),
+            signature: format!(
+                "pipeline {}({}){}",
+                name,
+                params.join(", "),
+                return_type
+                    .as_ref()
+                    .map(|ty| format!(" -> {}", format_type(ty)))
+                    .unwrap_or_default()
+            ),
+        }),
+        Node::StructDecl {
+            name, type_params, ..
+        } if exports.contains(name) => out.push(GraphSymbol {
+            name: name.clone(),
+            kind: "struct".to_string(),
+            signature: format!("struct {}{}", name, format_type_params(type_params)),
+        }),
+        Node::EnumDecl {
+            name, type_params, ..
+        } if exports.contains(name) => out.push(GraphSymbol {
+            name: name.clone(),
+            kind: "enum".to_string(),
+            signature: format!("enum {}{}", name, format_type_params(type_params)),
+        }),
+        Node::InterfaceDecl {
+            name, type_params, ..
+        } if exports.contains(name) => out.push(GraphSymbol {
+            name: name.clone(),
+            kind: "interface".to_string(),
+            signature: format!("interface {}{}", name, format_type_params(type_params)),
+        }),
+        Node::TypeDecl {
+            name,
+            type_params,
+            type_expr,
+        } if exports.contains(name) => out.push(GraphSymbol {
+            name: name.clone(),
+            kind: "type".to_string(),
+            signature: format!(
+                "type {}{} = {}",
+                name,
+                format_type_params(type_params),
+                format_type(type_expr)
+            ),
+        }),
+        Node::SkillDecl { name, .. } if exports.contains(name) => out.push(GraphSymbol {
+            name: name.clone(),
+            kind: "skill".to_string(),
+            signature: format!("skill {name}"),
+        }),
+        _ => {}
+    }
+}
+
+fn fn_signature(
+    keyword: &str,
+    name: &str,
+    type_params: &[TypeParam],
+    params: &[TypedParam],
+    return_type: Option<&harn_parser::TypeExpr>,
+    where_clauses: &[WhereClause],
+) -> String {
+    callable_signature(
+        keyword,
+        name,
+        type_params,
+        params,
+        return_type,
+        where_clauses,
+    )
+}
+
+fn callable_signature(
+    keyword: &str,
+    name: &str,
+    type_params: &[TypeParam],
+    params: &[TypedParam],
+    return_type: Option<&harn_parser::TypeExpr>,
+    where_clauses: &[WhereClause],
+) -> String {
+    let params = params
+        .iter()
+        .map(format_param)
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(
+        "{} {}{}({}){}{}",
+        keyword,
+        name,
+        format_type_params(type_params),
+        params,
+        return_type
+            .map(|ty| format!(" -> {}", format_type(ty)))
+            .unwrap_or_default(),
+        format_where_clauses(where_clauses)
+    )
+}
+
+fn format_param(param: &TypedParam) -> String {
+    let rest = if param.rest { "..." } else { "" };
+    match &param.type_expr {
+        Some(ty) => format!("{rest}{}: {}", param.name, format_type(ty)),
+        None => format!("{rest}{}", param.name),
+    }
+}
+
+fn format_type_params(params: &[TypeParam]) -> String {
+    if params.is_empty() {
+        return String::new();
+    }
+    let params = params
+        .iter()
+        .map(|param| match param.variance {
+            Variance::Invariant => param.name.clone(),
+            Variance::Covariant => format!("out {}", param.name),
+            Variance::Contravariant => format!("in {}", param.name),
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("<{params}>")
+}
+
+fn format_where_clauses(clauses: &[WhereClause]) -> String {
+    if clauses.is_empty() {
+        return String::new();
+    }
+    let clauses = clauses
+        .iter()
+        .map(|clause| format!("{}: {}", clause.type_name, clause.bound))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(" where {clauses}")
+}
+
+fn graph_root_dir(root: &Path) -> PathBuf {
+    let base = if root.is_dir() {
+        root
+    } else {
+        root.parent().unwrap_or(Path::new("."))
+    };
+    fs::canonicalize(base).unwrap_or_else(|_| base.to_path_buf())
+}
+
+fn display_module_path(path: &Path, root_dir: &Path) -> String {
+    let raw = path.to_string_lossy();
+    if raw.starts_with("<std>/") {
+        return raw.replacen("<std>/", "std/", 1);
+    }
+    let canonical = fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    canonical
+        .strip_prefix(root_dir)
+        .unwrap_or(&canonical)
+        .to_string_lossy()
+        .trim_start_matches('/')
+        .to_string()
+}
+
+fn module_matches_filter(path: &Path, filter: &str, root_dir: &Path) -> bool {
+    let display = display_module_path(path, root_dir);
+    display == filter
+        || display.strip_suffix(".harn") == Some(filter)
+        || path.file_stem().and_then(|stem| stem.to_str()) == Some(filter)
+        || path.file_name().and_then(|name| name.to_str()) == Some(filter)
+}
+
+fn print_text_report(report: &GraphReport) {
+    for module in &report.modules {
+        println!("{}", module.path);
+        for symbol in &module.public_symbols {
+            println!("  {} {}", symbol.kind, symbol.signature);
+        }
+        for import in &module.imports {
+            println!("  import {import}");
+        }
+        if !module.requires_capabilities.is_empty() {
+            println!("  requires {}", module.requires_capabilities.join(", "));
+        }
+    }
+}

--- a/crates/harn-cli/src/commands/mod.rs
+++ b/crates/harn-cli/src/commands/mod.rs
@@ -19,6 +19,7 @@ pub(crate) mod eval_tool_calls;
 pub(crate) mod explain;
 pub(crate) mod fix;
 pub mod flow;
+pub(crate) mod graph;
 pub(crate) mod hardware;
 pub(crate) mod init;
 pub(crate) mod json_schemas;

--- a/crates/harn-cli/src/json_envelope.rs
+++ b/crates/harn-cli/src/json_envelope.rs
@@ -256,6 +256,13 @@ pub fn catalog() -> Vec<SchemaEntry> {
             schema_json: None,
         },
         SchemaEntry {
+            command: "graph",
+            schema_version: crate::commands::graph::GRAPH_SCHEMA_VERSION,
+            description:
+                "Static module graph with public symbols, imports, capabilities, effects, and host-call surface.",
+            schema_json: None,
+        },
+        SchemaEntry {
             command: "explain --catalog",
             schema_version: crate::commands::diagnostics_catalog::SCHEMA_VERSION,
             description:

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -838,6 +838,12 @@ async fn async_main() {
                 process::exit(1);
             }
         }
+        Command::Graph(args) => {
+            let code = commands::graph::run(args);
+            if code != 0 {
+                process::exit(code);
+            }
+        }
         Command::Routes(args) => {
             let code = commands::routes::run(args).await;
             if code != 0 {

--- a/crates/harn-cli/tests/graph_cli.rs
+++ b/crates/harn-cli/tests/graph_cli.rs
@@ -1,0 +1,164 @@
+//! End-to-end coverage for `harn graph --json`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use tempfile::TempDir;
+
+fn binary_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_harn"))
+}
+
+fn run_harn(args: &[&str]) -> std::process::Output {
+    Command::new(binary_path())
+        .args(args)
+        .output()
+        .expect("spawn harn")
+}
+
+fn stdout_json(output: &std::process::Output) -> serde_json::Value {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(stdout.trim()).unwrap_or_else(|error| {
+        panic!("stdout is not JSON: {error}\nstdout:\n{stdout}");
+    })
+}
+
+fn write_fixture(root: &Path) {
+    fs::write(
+        root.join("main.harn"),
+        r#"
+import { format_title } from "util"
+
+pub fn main() -> string {
+  let title = format_title("Graph")
+  let body = read_file("README.md")
+  return title + body
+}
+"#,
+    )
+    .unwrap();
+    fs::write(
+        root.join("util.harn"),
+        r#"
+import { Thing } from "types"
+
+pub fn format_title(value: string) -> string {
+  let prompt = "Title: " + value
+  let _response = llm_call(prompt, {provider: "auto"})
+  return value
+}
+"#,
+    )
+    .unwrap();
+    fs::write(
+        root.join("types.harn"),
+        r#"
+type Thing = {name: string}
+"#,
+    )
+    .unwrap();
+}
+
+#[test]
+fn graph_json_reports_modules_symbols_capabilities_and_edges() {
+    let temp = TempDir::new().unwrap();
+    write_fixture(temp.path());
+
+    let root = temp.path().to_str().unwrap();
+    let output = run_harn(&["graph", root, "--json"]);
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let parsed = stdout_json(&output);
+    assert_eq!(parsed["schemaVersion"], 1);
+    assert_eq!(parsed["ok"], true);
+
+    let modules = parsed["data"]["modules"].as_array().unwrap();
+    assert_eq!(modules.len(), 3);
+    assert_eq!(
+        modules
+            .iter()
+            .map(|module| module["path"].as_str().unwrap())
+            .collect::<Vec<_>>(),
+        vec!["main.harn", "types.harn", "util.harn"]
+    );
+
+    let main = modules
+        .iter()
+        .find(|module| module["path"] == "main.harn")
+        .unwrap();
+    assert_eq!(main["imports"], serde_json::json!(["util.harn"]));
+    assert_eq!(
+        main["requires_capabilities"],
+        serde_json::json!(["workspace.read_text"])
+    );
+    assert_eq!(main["effects"], serde_json::json!(["fs.read"]));
+    assert_eq!(main["host_calls"], serde_json::json!(["read_file"]));
+    assert_eq!(main["public_symbols"][0]["name"], "main");
+    assert_eq!(main["public_symbols"][0]["kind"], "fn");
+    assert_eq!(
+        main["public_symbols"][0]["signature"],
+        "fn main() -> string"
+    );
+
+    let util = modules
+        .iter()
+        .find(|module| module["path"] == "util.harn")
+        .unwrap();
+    assert_eq!(util["imports"], serde_json::json!(["types.harn"]));
+    assert_eq!(
+        util["requires_capabilities"],
+        serde_json::json!(["llm.call"])
+    );
+    assert_eq!(util["effects"], serde_json::json!(["llm.call"]));
+    assert_eq!(util["host_calls"], serde_json::json!(["llm_call"]));
+
+    assert_eq!(
+        parsed["data"]["graph"]["nodes"],
+        serde_json::json!(["main.harn", "types.harn", "util.harn"])
+    );
+    assert_eq!(
+        parsed["data"]["graph"]["edges"],
+        serde_json::json!([
+            {"from": "main.harn", "to": "util.harn"},
+            {"from": "util.harn", "to": "types.harn"}
+        ])
+    );
+}
+
+#[test]
+fn graph_json_module_filter_focuses_modules_but_keeps_edge_targets() {
+    let temp = TempDir::new().unwrap();
+    write_fixture(temp.path());
+
+    let root = temp.path().to_str().unwrap();
+    let output = run_harn(&["graph", root, "--json", "--module", "util"]);
+    assert!(output.status.success(), "exit={:?}", output.status.code());
+
+    let parsed = stdout_json(&output);
+    let modules = parsed["data"]["modules"].as_array().unwrap();
+    assert_eq!(modules.len(), 1);
+    assert_eq!(modules[0]["path"], "util.harn");
+    assert_eq!(
+        parsed["data"]["graph"]["nodes"],
+        serde_json::json!(["types.harn", "util.harn"])
+    );
+}
+
+#[test]
+fn graph_appears_in_json_schemas_catalog() {
+    let output = run_harn(&["--json-schemas", "--command", "graph"]);
+    assert!(output.status.success(), "exit={:?}", output.status.code());
+
+    let parsed = stdout_json(&output);
+    assert_eq!(parsed["schemaVersion"], 1);
+    assert_eq!(parsed["ok"], true);
+    let entries = parsed["data"].as_array().unwrap();
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0]["command"], "graph");
+    assert_eq!(entries[0]["schemaVersion"], 1);
+}

--- a/crates/harn-modules/src/lib.rs
+++ b/crates/harn-modules/src/lib.rs
@@ -99,8 +99,20 @@ struct ModuleInfo {
 
 #[derive(Debug, Clone)]
 struct ImportRef {
+    raw_path: String,
     path: Option<PathBuf>,
     selective_names: Option<HashSet<String>>,
+}
+
+/// Public import edge summary for static module graph consumers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ModuleImport {
+    /// The import string as written in source.
+    pub raw_path: String,
+    /// Resolved module path when the import could be resolved.
+    pub resolved_path: Option<PathBuf>,
+    /// `None` for wildcard imports; otherwise the selected names.
+    pub selective_names: Option<Vec<String>>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -407,6 +419,50 @@ impl ModuleGraph {
             .collect();
         out.sort();
         out
+    }
+
+    /// Import edges declared by `file`, sorted by raw path and selected names.
+    pub fn imports_for_module(&self, file: &Path) -> Vec<ModuleImport> {
+        let file = normalize_path(file);
+        let Some(module) = self.modules.get(&file) else {
+            return Vec::new();
+        };
+        let mut imports: Vec<ModuleImport> = module
+            .imports
+            .iter()
+            .map(|import| {
+                let mut selective_names = import
+                    .selective_names
+                    .as_ref()
+                    .map(|names| names.iter().cloned().collect::<Vec<_>>());
+                if let Some(names) = selective_names.as_mut() {
+                    names.sort();
+                }
+                ModuleImport {
+                    raw_path: import.raw_path.clone(),
+                    resolved_path: import.path.as_ref().map(|path| normalize_path(path)),
+                    selective_names,
+                }
+            })
+            .collect();
+        imports.sort_by(|left, right| {
+            left.raw_path
+                .cmp(&right.raw_path)
+                .then_with(|| left.selective_names.cmp(&right.selective_names))
+                .then_with(|| left.resolved_path.cmp(&right.resolved_path))
+        });
+        imports
+    }
+
+    /// Exported symbol names for `file`, sorted alphabetically.
+    pub fn exports_for_module(&self, file: &Path) -> Vec<String> {
+        let file = normalize_path(file);
+        let Some(module) = self.modules.get(&file) else {
+            return Vec::new();
+        };
+        let mut exports: Vec<String> = module.exports.iter().cloned().collect();
+        exports.sort();
+        exports
     }
 
     /// Resolve wildcard imports for `file`.
@@ -948,6 +1004,7 @@ fn collect_module_info(file: &Path, snode: &SNode, module: &mut ModuleInfo) {
                 }
             }
             module.imports.push(ImportRef {
+                raw_path: path.clone(),
                 path: import_path,
                 selective_names: None,
             });
@@ -976,6 +1033,7 @@ fn collect_module_info(file: &Path, snode: &SNode, module: &mut ModuleInfo) {
             let names: HashSet<String> = names.iter().cloned().collect();
             module.selective_import_names.extend(names.iter().cloned());
             module.imports.push(ImportRef {
+                raw_path: path.clone(),
                 path: import_path,
                 selective_names: Some(names),
             });


### PR DESCRIPTION
## Summary

- add harn graph <root> with text and JSON output
- report modules, public symbols, import edges, required capabilities, effects, and host-call surface
- add --module filtering for focused graph inspection
- cover CLI parsing, graph integration behavior, and module import/export summaries

Closes #1758

## Verification

- cargo test -p harn-cli --test graph_cli -- --nocapture
- cargo test -p harn-cli cli::tests::test_parses_graph_json_and_module_filter
- cargo test -p harn-modules
- make lint-test-patterns
- cargo clippy -p harn-cli --all-targets -- -D warnings
- pre-commit hook passed, including workspace clippy