### PR TITLE
Add HarnessStdio read and prompt foundation

### DIFF
--- a/conformance/tests/language/harness_stdio_methods.expected
+++ b/conformance/tests/language/harness_stdio_methods.expected
@@ -1,0 +1,5 @@
+prefix:alpha
+true
+ok
+[  beta  ]
+answer: gamma

--- a/conformance/tests/language/harness_stdio_methods.harn
+++ b/conformance/tests/language/harness_stdio_methods.harn
@@ -1,0 +1,12 @@
+/** E4.2: HarnessStdio exposes the legacy stdio surface without ambient calls. */
+fn main(harness: Harness) {
+  mock_stdin("alpha\n  beta  \ngamma\n")
+  harness.stdio.print("prefix:")
+  harness.stdio.println(harness.stdio.read_line())
+  let structured = harness.stdio.read_line({trim: false})
+  harness.stdio.println(structured.ok)
+  harness.stdio.println(structured.status)
+  harness.stdio.println("[" + structured.value + "]")
+  harness.stdio.println(harness.stdio.prompt("answer: "))
+  unmock_stdin()
+}

--- a/crates/harn-lint/src/linter.rs
+++ b/crates/harn-lint/src/linter.rs
@@ -7,7 +7,7 @@ use std::collections::{HashMap, HashSet};
 
 use harn_lexer::{FixEdit, Span};
 use harn_parser::diagnostic::{
-    find_closest_match, harness_clock_replacement, renamed_stdlib_symbol,
+    find_closest_match, harness_clock_replacement, harness_stdio_replacement, renamed_stdlib_symbol,
 };
 use harn_parser::{BindingPattern, DiagnosticCode as Code, Node, SNode, TypeExpr, TypedParam};
 
@@ -238,6 +238,34 @@ impl<'a> Linter<'a> {
             severity: LintSeverity::Warning,
             suggestion: Some(suggestion),
             fix,
+        });
+    }
+
+    /// Flag ambient stdio builtins (`print`, `println`, `eprint`,
+    /// `eprintln`, `read_line`, `prompt_user`) so the E4.2 → E4.6 migration
+    /// can rewrite them to `harness.stdio.*`.
+    pub(super) fn check_ambient_stdio_builtin(&mut self, name: &str, span: Span) {
+        let Some(replacement) = harness_stdio_replacement(name) else {
+            return;
+        };
+        let harness_in_scope = self
+            .scopes
+            .iter()
+            .any(|scope| scope.contains("harness") || scope.contains("_harness"));
+        if !harness_in_scope {
+            return;
+        }
+        self.diagnostics.push(LintDiagnostic {
+            code: Code::LintAmbientStdioBuiltin,
+            rule: "ambient-stdio-builtin",
+            message: format!(
+                "ambient `{name}` is deprecated — capabilities now route through \
+                 `harness.stdio.*`"
+            ),
+            span,
+            severity: LintSeverity::Warning,
+            suggestion: Some(format!("replace `{name}` with `{replacement}`")),
+            fix: replace_identifier_text_fix(self.source, span, name, replacement),
         });
     }
 

--- a/crates/harn-lint/src/linter/walk.rs
+++ b/crates/harn-lint/src/linter/walk.rs
@@ -280,6 +280,7 @@ impl<'a> Linter<'a> {
             Node::FunctionCall { name, args, .. } => {
                 self.check_renamed_stdlib_symbol(name, snode.span);
                 self.check_ambient_clock_builtin(name, snode.span);
+                self.check_ambient_stdio_builtin(name, snode.span);
                 self.references.insert(name.clone());
                 self.function_references.insert(name.clone());
                 self.function_calls.push((name.clone(), snode.span));

--- a/crates/harn-lint/src/tests/ambient_stdio.rs
+++ b/crates/harn-lint/src/tests/ambient_stdio.rs
@@ -1,0 +1,68 @@
+//! HARN-LNT-053 — ambient stdio builtins now route through
+//! `harness.stdio.*`.
+
+use super::*;
+
+#[test]
+fn ambient_stdio_call_inside_main_emits_lint_and_fixes_to_harness_stdio() {
+    let source = "fn main(harness: Harness) {\n  println(\"hi\")\n}\n";
+    let diags = lint_source(source);
+    assert_eq!(
+        count_rule(&diags, "ambient-stdio-builtin"),
+        1,
+        "expected one ambient-stdio lint, got: {diags:?}"
+    );
+    let fixed = apply_fixes(source, &diags);
+    assert!(
+        fixed.contains("harness.stdio.println(\"hi\")"),
+        "expected rewrite to harness.stdio.println(), got: {fixed}"
+    );
+    assert!(
+        !fixed.contains(" println("),
+        "ambient call should be gone, got: {fixed}"
+    );
+}
+
+#[test]
+fn ambient_stdio_lints_all_supported_names_inside_main() {
+    let source = r#"fn main(harness: Harness) {
+  print("a")
+  println("b")
+  eprint("c")
+  eprintln("d")
+  let line = read_line()
+  let answer = prompt_user("q?")
+}
+"#;
+    let diags = lint_source(source);
+    assert_eq!(
+        count_rule(&diags, "ambient-stdio-builtin"),
+        6,
+        "expected one lint per ambient stdio call, got: {diags:?}"
+    );
+    let fixed = apply_fixes(source, &diags);
+    for expected in [
+        "harness.stdio.print",
+        "harness.stdio.println",
+        "harness.stdio.eprint",
+        "harness.stdio.eprintln",
+        "harness.stdio.read_line",
+        "harness.stdio.prompt",
+    ] {
+        assert!(
+            fixed.contains(expected),
+            "expected {expected} in fixed source, got: {fixed}"
+        );
+    }
+}
+
+#[test]
+fn ambient_stdio_lint_waits_until_harness_is_in_scope() {
+    let source = "fn helper() {\n  println(\"hi\")\n}\n";
+    let diags = lint_source(source);
+    assert_eq!(
+        count_rule(&diags, "ambient-stdio-builtin"),
+        0,
+        "stdio migration lint should not flood pre-harness files: {diags:?}"
+    );
+}

--- a/crates/harn-lint/src/tests/mod.rs
+++ b/crates/harn-lint/src/tests/mod.rs
@@ -72,6 +72,7 @@ pub(super) fn lint_with_require_header(
 }
 
 mod ambient_clock;
+mod ambient_stdio;
 mod assert_pipeline;
 mod autofix;
 mod boolean_patterns;

--- a/crates/harn-parser/src/diagnostic.rs
+++ b/crates/harn-parser/src/diagnostic.rs
@@ -118,6 +118,21 @@ pub fn harness_clock_replacement(name: &str) -> Option<&'static str> {
     }
 }
 
+/// Map an ambient stdio-capability builtin to its `harness.stdio.*`
+/// replacement so the `bindings/thread-harness-stdio` repair can replace
+/// the call when a harness binding is already in scope.
+pub fn harness_stdio_replacement(name: &str) -> Option<&'static str> {
+    match name {
+        "print" => Some("harness.stdio.print"),
+        "println" => Some("harness.stdio.println"),
+        "eprint" => Some("harness.stdio.eprint"),
+        "eprintln" => Some("harness.stdio.eprintln"),
+        "read_line" => Some("harness.stdio.read_line"),
+        "prompt_user" => Some("harness.stdio.prompt"),
+        _ => None,
+    }
+}
+
 /// Render a Rust-style diagnostic message.
 ///
 /// Example output:

--- a/crates/harn-parser/src/diagnostic_codes.rs
+++ b/crates/harn-parser/src/diagnostic_codes.rs
@@ -283,6 +283,7 @@ diagnostic_codes! {
     LintDeprecatedLlmOptions, "HARN-LNT-050", Lnt, "deprecated LLM options lint";
     LintUnnecessarySafeNavigation, "HARN-LNT-051", Lnt, "unnecessary safe navigation lint";
     LintAmbientClockBuiltin, "HARN-LNT-052", Lnt, "ambient clock builtin replaced by `harness.clock.*`";
+    LintAmbientStdioBuiltin, "HARN-LNT-053", Lnt, "ambient stdio builtin replaced by `harness.stdio.*`";
     FormatterParseFailed, "HARN-FMT-001", Fmt, "formatter could not parse the source";
     FormatterWouldReformat, "HARN-FMT-002", Fmt, "source is not in canonical format";
     FormatterTrailingComma, "HARN-FMT-003", Fmt, "formatter normalized trailing comma layout";
@@ -401,6 +402,9 @@ impl Code {
             Code::LintTemplateProviderIdentityBranch => &[Code::PromptProviderIdentityBranch],
             Code::LintRenamedStdlibSymbol => &[Code::DeprecatedStdlibSymbol],
             Code::LintAmbientClockBuiltin => {
+                &[Code::InvalidMainSignature, Code::LintRenamedStdlibSymbol]
+            }
+            Code::LintAmbientStdioBuiltin => {
                 &[Code::InvalidMainSignature, Code::LintRenamedStdlibSymbol]
             }
             Code::LintMutableNeverReassigned => &[Code::MutableNeverReassigned],
@@ -706,6 +710,7 @@ impl Code {
             Code::LintDeadCodeAfterReturn => Some(&REPAIR_DEAD_CODE_REMOVE),
             Code::LintRenamedStdlibSymbol => Some(&REPAIR_STDLIB_MIGRATE_RENAMED),
             Code::LintAmbientClockBuiltin => Some(&REPAIR_BINDINGS_THREAD_HARNESS_CLOCK),
+            Code::LintAmbientStdioBuiltin => Some(&REPAIR_BINDINGS_THREAD_HARNESS_STDIO),
             Code::LintDeprecatedLlmOptions => Some(&REPAIR_LLM_MIGRATE_DEPRECATED_OPTION),
             Code::LintTemplateProviderIdentityBranch => Some(&REPAIR_LLM_USE_CAPABILITY_FLAG),
             Code::LintPromptInjectionRisk => Some(&REPAIR_PROMPTS_ESCAPE_INJECTION),
@@ -805,6 +810,12 @@ const REPAIR_BINDINGS_THREAD_HARNESS: RepairTemplate = RepairTemplate {
 const REPAIR_BINDINGS_THREAD_HARNESS_CLOCK: RepairTemplate = RepairTemplate {
     id: "bindings/thread-harness-clock",
     summary: "Replace the ambient clock builtin with the corresponding `harness.clock.*` method",
+    safety: RepairSafety::ScopeLocal,
+};
+
+const REPAIR_BINDINGS_THREAD_HARNESS_STDIO: RepairTemplate = RepairTemplate {
+    id: "bindings/thread-harness-stdio",
+    summary: "Replace the ambient stdio builtin with the corresponding `harness.stdio.*` method",
     safety: RepairSafety::ScopeLocal,
 };
 

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-053.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-053.md
@@ -1,0 +1,33 @@
+# HARN-LNT-053 — ambient stdio builtin replaced by `harness.stdio.*`
+
+**Category:** Lint (LNT)
+**Variant:** `Code::LintAmbientStdioBuiltin` (ambient stdio builtin)
+
+## What it means
+
+The lint fires on calls to `print`, `println`, `eprint`, `eprintln`,
+`read_line`, and `prompt_user` when a `harness` binding is already in scope.
+These were ambient stdio-capability builtins in the pre-`Harness` runtime.
+Stdio access now routes through the `harness.stdio.*` sub-handle so capability
+requirements are visible in the type system.
+
+This is a lint, not a hard error. The legacy builtins still compile while
+the in-tree corpus migration is in flight, but new code should use
+`harness.stdio.print`, `harness.stdio.println`, `harness.stdio.eprint`,
+`harness.stdio.eprintln`, `harness.stdio.read_line`, or
+`harness.stdio.prompt`.
+
+## How to fix
+
+- Run `harn fix --apply --safety scope-local` over the file. The
+  `bindings/thread-harness-stdio` repair rewrites every call site where a
+  `harness` binding is in scope.
+- If `harness` is not reachable from the call site, first thread it through
+  the enclosing function via the `bindings/thread-harness` repair, then re-run
+  `harn fix --apply` to swap the call.
+
+## Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.

--- a/crates/harn-vm/src/harness.rs
+++ b/crates/harn-vm/src/harness.rs
@@ -13,9 +13,9 @@
 //!   * [`Harness::real`], the production constructor that wraps wall-clock
 //!     time, `tokio::fs`, `std::env`, `rand::thread_rng`, and `reqwest`. The
 //!     downstream migration tickets (E4.2-E4.4) populate the per-handle
-//!     method surface against this concrete state; for E4.1 only the
-//!     `stdio.println` / `stdio.eprintln` path is wired so the new
-//!     entrypoint convention has a working hello-world steel thread.
+//!     method surface against this concrete state; the E4.2 stdio surface is
+//!     wired while filesystem, environment, randomness, and network methods
+//!     still land in later slices.
 //!   * [`VmHarness`], the compact `VmValue` payload that carries the same
 //!     state through the bytecode VM and distinguishes the root handle from
 //!     its sub-handles via [`HarnessKind`].
@@ -501,7 +501,8 @@ impl Default for Harness {
     }
 }
 
-/// stdio sub-handle: `println`, `eprintln`, `prompt`, `read_line`.
+/// stdio sub-handle: `print`, `println`, `eprint`, `eprintln`, `prompt`,
+/// `read_line`.
 #[derive(Debug, Clone)]
 pub struct HarnessStdio {
     inner: Arc<HarnessInner>,

--- a/crates/harn-vm/src/stdlib/io.rs
+++ b/crates/harn-vm/src/stdlib/io.rs
@@ -1,5 +1,6 @@
 use std::cell::RefCell;
 use std::collections::{BTreeMap, VecDeque};
+#[cfg(not(unix))]
 use std::io::BufRead;
 use std::io::{IsTerminal, Read, Write};
 use std::rc::Rc;
@@ -758,25 +759,33 @@ fn read_stdin_builtin(_args: &[VmValue], _out: &mut String) -> Result<VmValue, V
     }
 }
 
-fn read_line_builtin(_args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+pub(crate) fn read_line_legacy_value() -> VmValue {
     let options = ReadLineOptions {
         trim: false,
         ..ReadLineOptions::default()
     };
     match read_line_from_mock_or_real(&options) {
-        ReadLineOutcome::Ok(line) => Ok(VmValue::String(Rc::from(line))),
-        ReadLineOutcome::Eof => Ok(VmValue::Nil),
+        ReadLineOutcome::Ok(line) => VmValue::String(Rc::from(line)),
+        ReadLineOutcome::Eof => VmValue::Nil,
         #[cfg(unix)]
-        ReadLineOutcome::Timeout => Ok(VmValue::Nil),
+        ReadLineOutcome::Timeout => VmValue::Nil,
         #[cfg(unix)]
-        ReadLineOutcome::Interrupt => Ok(VmValue::Nil),
-        ReadLineOutcome::Error(_) => Ok(VmValue::Nil),
+        ReadLineOutcome::Interrupt => VmValue::Nil,
+        ReadLineOutcome::Error(_) => VmValue::Nil,
     }
 }
 
-fn io_read_line_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+fn read_line_builtin(_args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    Ok(read_line_legacy_value())
+}
+
+pub(crate) fn read_line_structured_value(args: &[VmValue]) -> Result<VmValue, VmError> {
     let options = parse_read_line_options(args)?;
     Ok(read_line_result(read_line_from_mock_or_real(&options)))
+}
+
+fn io_read_line_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    read_line_structured_value(args)
 }
 
 fn is_stdin_tty_builtin(_args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
@@ -876,15 +885,26 @@ fn uuid_nil_builtin(_args: &[VmValue], _out: &mut String) -> Result<VmValue, VmE
     Ok(VmValue::String(Rc::from(uuid::Uuid::nil().to_string())))
 }
 
-fn prompt_user_builtin(args: &[VmValue], out: &mut String) -> Result<VmValue, VmError> {
+pub(crate) fn prompt_user_value(args: &[VmValue], out: &mut String) -> Result<VmValue, VmError> {
     let msg = args.first().map(|a| a.display()).unwrap_or_default();
     write_stdout(out, &msg);
-    let mut input = String::new();
-    if std::io::stdin().lock().read_line(&mut input).is_ok() {
-        Ok(VmValue::String(Rc::from(input.trim_end())))
-    } else {
-        Ok(VmValue::Nil)
+    let options = ReadLineOptions {
+        trim: false,
+        ..ReadLineOptions::default()
+    };
+    match read_line_from_mock_or_real(&options) {
+        ReadLineOutcome::Ok(line) => Ok(VmValue::String(Rc::from(line.trim_end().to_string()))),
+        ReadLineOutcome::Eof => Ok(VmValue::Nil),
+        #[cfg(unix)]
+        ReadLineOutcome::Timeout => Ok(VmValue::Nil),
+        #[cfg(unix)]
+        ReadLineOutcome::Interrupt => Ok(VmValue::Nil),
+        ReadLineOutcome::Error(_) => Ok(VmValue::Nil),
     }
+}
+
+fn prompt_user_builtin(args: &[VmValue], out: &mut String) -> Result<VmValue, VmError> {
+    prompt_user_value(args, out)
 }
 
 fn log_debug_builtin(args: &[VmValue], out: &mut String) -> Result<VmValue, VmError> {

--- a/crates/harn-vm/src/vm/methods/harness.rs
+++ b/crates/harn-vm/src/vm/methods/harness.rs
@@ -1,13 +1,15 @@
 //! Method dispatch for the `Harness` capability handle and its six
-//! sub-handles. E4.1 ships the stdio surface end-to-end (`println`,
-//! `eprintln`) so the new entrypoint convention has a working
-//! hello-world; subsequent tickets (E4.2-E4.4) replace the stub bodies
-//! on the other sub-handles with real implementations.
+//! sub-handles. The stdio and clock slices are wired end-to-end; subsequent
+//! tickets replace the stub bodies on the remaining sub-handles with real
+//! implementations.
 
 use std::time::Duration;
 
 use crate::harness::{vm_string, HarnessKind, HarnessMode, VmHarness};
-use crate::stdlib::io::{write_stderr, write_stdout};
+use crate::stdlib::io::{
+    prompt_user_value, read_line_legacy_value, read_line_structured_value, write_stderr,
+    write_stdout,
+};
 use crate::value::{ErrorCategory, VmError, VmValue};
 
 impl crate::vm::Vm {
@@ -67,6 +69,14 @@ impl crate::vm::Vm {
                 write_stderr(&msg);
                 Ok(VmValue::Nil)
             }
+            "read_line" => {
+                if args.is_empty() {
+                    Ok(read_line_legacy_value())
+                } else {
+                    read_line_structured_value(args)
+                }
+            }
+            "prompt" => prompt_user_value(args, &mut self.output),
             _ => Err(method_unsupported(handle, method)),
         }
     }

--- a/docs/diagnostics-catalog.json
+++ b/docs/diagnostics-catalog.json
@@ -49,7 +49,7 @@
     {
       "id": "LNT",
       "title": "Lint rules",
-      "count": 52
+      "count": 53
     },
     {
       "id": "FMT",
@@ -1828,6 +1828,24 @@
           "id": "bindings/thread-harness-clock",
           "safety": "scope-local",
           "summary": "Replace the ambient clock builtin with the corresponding `harness.clock.*` method"
+        }
+      ],
+      "related": [
+        "HARN-NAM-101",
+        "HARN-LNT-001"
+      ],
+      "explanationPresent": true,
+      "apiStability": "stable"
+    },
+    {
+      "code": "HARN-LNT-053",
+      "category": "LNT",
+      "summary": "ambient stdio builtin replaced by `harness.stdio.*`",
+      "repairs": [
+        {
+          "id": "bindings/thread-harness-stdio",
+          "safety": "scope-local",
+          "summary": "Replace the ambient stdio builtin with the corresponding `harness.stdio.*` method"
         }
       ],
       "related": [

--- a/docs/src/diagnostics.md
+++ b/docs/src/diagnostics.md
@@ -44,7 +44,7 @@ Repairs are tagged with a six-level safety class so `harn fix --apply --safety <
 | [`STD`](#std--stdlib-usage) | Stdlib usage | 3 |
 | [`PRM`](#prm--prompt-templates) | Prompt templates | 7 |
 | [`MOD`](#mod--modules-and-exports) | Modules and exports | 6 |
-| [`LNT`](#lnt--lint-rules) | Lint rules | 52 |
+| [`LNT`](#lnt--lint-rules) | Lint rules | 53 |
 | [`FMT`](#fmt--formatter) | Formatter | 3 |
 | [`IMP`](#imp--import-resolution) | Import resolution | 3 |
 | [`OWN`](#own--ownership-and-mutability) | Ownership and mutability | 4 |
@@ -233,6 +233,7 @@ Repairs are tagged with a six-level safety class so `harn fix --apply --safety <
 | [`HARN-LNT-050`](#harn-lnt-050) | deprecated LLM options lint | `llm/migrate-deprecated-option` | `scope-local` |
 | [`HARN-LNT-051`](#harn-lnt-051) | unnecessary safe navigation lint | `expressions/simplify` | `behavior-preserving` |
 | [`HARN-LNT-052`](#harn-lnt-052) | ambient clock builtin replaced by `harness.clock.*` | `bindings/thread-harness-clock` | `scope-local` |
+| [`HARN-LNT-053`](#harn-lnt-053) | ambient stdio builtin replaced by `harness.stdio.*` | `bindings/thread-harness-stdio` | `scope-local` |
 
 ## FMT — Formatter
 
@@ -4385,6 +4386,48 @@ the migration is in flight, but every new call site should use the
 - If `harness` isn't reachable from the call site, first thread it through
   the enclosing fn via the `bindings/thread-harness` repair (which adds the
   `harness: Harness` parameter at the entrypoint), then re-run
+  `harn fix --apply` to swap the call.
+
+#### Stability
+
+This code is stable. Its identifier, category, and meaning will not change
+without a deprecation cycle. Cross-language tooling and IDE integrations can
+dispatch on it directly.
+
+### `HARN-LNT-053`
+
+**Category:** `LNT` (Lint rules) &nbsp;·&nbsp; **API stability:** `stable`
+
+ambient stdio builtin replaced by `harness.stdio.*`
+
+- **Repair:** `bindings/thread-harness-stdio` &nbsp;·&nbsp; **Safety:** `scope-local`
+- Replace the ambient stdio builtin with the corresponding `harness.stdio.*` method
+- **See also:** [`HARN-NAM-101`](#harn-nam-101), [`HARN-LNT-001`](#harn-lnt-001)
+
+**Category:** Lint (LNT)
+**Variant:** `Code::LintAmbientStdioBuiltin` (ambient stdio builtin)
+
+#### What it means
+
+The lint fires on calls to `print`, `println`, `eprint`, `eprintln`,
+`read_line`, and `prompt_user` when a `harness` binding is already in scope.
+These were ambient stdio-capability builtins in the pre-`Harness` runtime.
+Stdio access now routes through the `harness.stdio.*` sub-handle so capability
+requirements are visible in the type system.
+
+This is a lint, not a hard error. The legacy builtins still compile while
+the in-tree corpus migration is in flight, but new code should use
+`harness.stdio.print`, `harness.stdio.println`, `harness.stdio.eprint`,
+`harness.stdio.eprintln`, `harness.stdio.read_line`, or
+`harness.stdio.prompt`.
+
+#### How to fix
+
+- Run `harn fix --apply --safety scope-local` over the file. The
+  `bindings/thread-harness-stdio` repair rewrites every call site where a
+  `harness` binding is in scope.
+- If `harness` is not reachable from the call site, first thread it through
+  the enclosing function via the `bindings/thread-harness` repair, then re-run
   `harn fix --apply` to swap the call.
 
 #### Stability


### PR DESCRIPTION
## Summary
- route `harness.stdio.read_line()` and `harness.stdio.prompt()` through the existing mocked/real stdio implementation
- add the `HARN-LNT-053` ambient stdio lint and scope-local repair metadata for already-threaded `harness` call sites
- cover the new HarnessStdio methods with conformance and focused lint tests

Refs #1767. This intentionally does not remove all ambient stdio builtins yet; it lands the callable harness surface and safe in-scope lint/fix foundation so the later corpus migration can proceed without flooding current lint gates.

## Validation
- `cargo fmt --package harn-vm --package harn-lint --package harn-parser --check`
- `CARGO_TARGET_DIR=/tmp/harn-target-1767-stdio CARGO_BUILD_JOBS=3 HARN_LLM_CALLS_DISABLED=1 cargo test -p harn-lint ambient_stdio -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-1767-stdio CARGO_BUILD_JOBS=3 HARN_LLM_CALLS_DISABLED=1 cargo run --quiet --bin harn -- test conformance --filter harness_stdio_methods`
- `make lint-test-patterns`
- `git diff --check`