### PR TITLE
Sign harnpack release records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -220,8 +220,12 @@ condensed series summaries instead of full per-patch history.
   archive) and re-emits it under the v2 manifest, preserving the prior
   bundle's id, name, version, triggers, workflow graph, and prompt
   capsules while populating the new v2 fields from the entrypoint walk.
-  Signing (E6.3) and full SBOM enumeration (E6.4) land in follow-ups;
-  today the bundle ships unsigned. Companion: `harn-vm` exposes
+  `--sign --key <path>` signs the canonical bundle hash with an
+  Ed25519 PKCS#8 PEM key, embeds the manifest signature, and emits an
+  OpenTrustGraph `release` record; `--unsigned` skips the manifest
+  signature but still emits the release record at autonomy tier
+  `suggest`. Full SBOM enumeration (E6.4) lands in a follow-up.
+  Companion: `harn-vm` exposes
   `read_workflow_bundle_manifest_any_version` and
   `load_workflow_bundle_any_version` for relaxed-schema reads, and
   `bytecode_cache::serialize_chunk_artifact` /

--- a/crates/harn-cli/src/cli/pack.rs
+++ b/crates/harn-cli/src/cli/pack.rs
@@ -22,9 +22,21 @@ pub struct PackArgs {
     #[arg(long, value_name = "OLD_BUNDLE")]
     pub upgrade: Option<PathBuf>,
 
-    /// Mark the bundle as unsigned. Signing lands in E6.3; today this
-    /// flag is documentary so scripts can opt into the future
-    /// `--sign`/`--unsigned` split without breaking.
+    /// Sign the bundle hash and embed an Ed25519 signature in the manifest.
+    #[arg(
+        long,
+        default_value_t = false,
+        conflicts_with = "unsigned",
+        requires = "key"
+    )]
+    pub sign: bool,
+
+    /// Ed25519 private key PEM used with `--sign`.
+    #[arg(long, value_name = "PATH", requires = "sign")]
+    pub key: Option<PathBuf>,
+
+    /// Mark the bundle as unsigned. This still emits an OpenTrustGraph
+    /// release record at autonomy tier `suggest`.
     #[arg(long, default_value_t = false)]
     pub unsigned: bool,
 

--- a/crates/harn-cli/src/cli/tests.rs
+++ b/crates/harn-cli/src/cli/tests.rs
@@ -1717,6 +1717,29 @@ fn test_parses_new_package_kind() {
 }
 
 #[test]
+fn test_parses_pack_signing_flags() {
+    let cli = Cli::parse_from([
+        "harn",
+        "pack",
+        "examples/hello.harn",
+        "--sign",
+        "--key",
+        "release.pem",
+        "--out",
+        "hello.harnpack",
+    ]);
+
+    let Command::Pack(args) = cli.command.unwrap() else {
+        panic!("expected pack command");
+    };
+    assert_eq!(args.entrypoint, PathBuf::from("examples/hello.harn"));
+    assert_eq!(args.key, Some(PathBuf::from("release.pem")));
+    assert_eq!(args.out, Some(PathBuf::from("hello.harnpack")));
+    assert!(args.sign);
+    assert!(!args.unsigned);
+}
+
+#[test]
 fn test_parses_pipeline_lab_template() {
     let cli = Cli::parse_from([
         "harn",

--- a/crates/harn-cli/src/commands/pack.rs
+++ b/crates/harn-cli/src/commands/pack.rs
@@ -11,22 +11,26 @@ use std::collections::BTreeMap;
 use std::path::{Component, Path, PathBuf};
 use std::process;
 
+use ed25519_dalek::Signer;
 use harn_parser::DiagnosticSeverity;
 use harn_vm::bytecode_cache;
 use harn_vm::module_artifact;
 use harn_vm::orchestration::{
     build_harnpack, load_workflow_bundle_any_version, workflow_bundle_hash, CatchupPolicySpec,
-    ConnectorRequirement, EnvironmentRequirements, HarnpackEntry, ModuleEntry, RetryPolicySpec,
-    SBOMDoc, SBOMPackage, SBOMRelationship, ToolEntry, WorkflowBundle, WorkflowBundlePolicy,
-    WorkflowBundleReplayMetadata, WorkflowBundleTrigger, WORKFLOW_BUNDLE_SCHEMA_VERSION,
+    ConnectorRequirement, Ed25519Signature, EnvironmentRequirements, HarnpackEntry, ModuleEntry,
+    RetryPolicySpec, SBOMDoc, SBOMPackage, SBOMRelationship, ToolEntry, WorkflowBundle,
+    WorkflowBundlePolicy, WorkflowBundleReplayMetadata, WorkflowBundleTrigger,
+    WORKFLOW_BUNDLE_SCHEMA_VERSION,
 };
 use harn_vm::Compiler;
+use harn_vm::{AutonomyTier, TrustRecord};
 use serde::Serialize;
 
 use crate::cli::PackArgs;
 use crate::command_error;
 use crate::json_envelope::{to_string_pretty, JsonEnvelope, JsonOutput};
 use crate::parse_source_file;
+use crate::skill_provenance;
 
 /// Stable schema version for the `harn pack --json` envelope. Bump when
 /// [`PackJsonData`] changes shape in a way that agents need to detect.
@@ -204,6 +208,24 @@ impl PackError {
 }
 
 pub fn build(args: &PackArgs) -> Result<PackOutcome, PackError> {
+    if args.sign && args.unsigned {
+        return Err(PackError::new(
+            "pack.sign_conflict",
+            "--sign and --unsigned cannot be used together",
+        ));
+    }
+    if args.sign && args.key.is_none() {
+        return Err(PackError::new(
+            "pack.sign_missing_key",
+            "--sign requires --key <path>",
+        ));
+    }
+    if !args.sign && args.key.is_some() {
+        return Err(PackError::new(
+            "pack.key_without_sign",
+            "--key requires --sign",
+        ));
+    }
     if let Some(upgrade) = &args.upgrade {
         if !upgrade.exists() {
             return Err(PackError::new(
@@ -498,16 +520,21 @@ pub fn build(args: &PackArgs) -> Result<PackOutcome, PackError> {
     })?;
     contents.push(HarnpackEntry::new(PACK_SBOM_ARCHIVE_PATH, sbom_bytes));
 
-    let archive_bytes = build_harnpack(&bundle, &contents).map_err(|err| {
-        PackError::new(
-            "pack.archive_failed",
-            format!("failed to assemble .harnpack archive: {err}"),
-        )
-    })?;
+    if args.sign {
+        let key_path = args.key.as_ref().expect("checked above");
+        sign_bundle(&mut bundle, &contents, key_path)?;
+    }
+
     let bundle_hash = workflow_bundle_hash(&bundle, &contents).map_err(|err| {
         PackError::new(
             "pack.hash_failed",
             format!("failed to compute bundle hash: {err}"),
+        )
+    })?;
+    let archive_bytes = build_harnpack(&bundle, &contents).map_err(|err| {
+        PackError::new(
+            "pack.archive_failed",
+            format!("failed to assemble .harnpack archive: {err}"),
         )
     })?;
 
@@ -529,6 +556,7 @@ pub fn build(args: &PackArgs) -> Result<PackOutcome, PackError> {
         )
     })?;
     let size_bytes = archive_bytes.len() as u64;
+    emit_release_trust_record(&project_root, &bundle_hash, &bundle.harn_version, args.sign)?;
 
     Ok(PackOutcome {
         bundle_hash: bundle_hash.clone(),
@@ -543,6 +571,96 @@ pub fn build(args: &PackArgs) -> Result<PackOutcome, PackError> {
             debug_symbol_metadata,
             manifest: bundle,
         },
+    })
+}
+
+fn sign_bundle(
+    bundle: &mut WorkflowBundle,
+    contents: &[HarnpackEntry],
+    key_path: &Path,
+) -> Result<(), PackError> {
+    let signing_key = skill_provenance::load_ed25519_signing_key(key_path).map_err(|err| {
+        PackError::new(
+            "pack.sign_key_failed",
+            format!("failed to load signing key {}: {err}", key_path.display()),
+        )
+    })?;
+    let bundle_hash = workflow_bundle_hash(bundle, contents).map_err(|err| {
+        PackError::new(
+            "pack.hash_failed",
+            format!("failed to compute bundle hash before signing: {err}"),
+        )
+    })?;
+    let verifying_key = signing_key.verifying_key();
+    let signature = signing_key.sign(bundle_hash.as_bytes());
+    bundle.signature = Some(Ed25519Signature {
+        key_id: Some(skill_provenance::fingerprint_for_key(&verifying_key)),
+        public_key: hex_encode(&verifying_key.to_bytes()),
+        signature: hex_encode(&signature.to_bytes()),
+        manifest_hash_blake3: bundle_hash,
+        algorithm: "ed25519".to_string(),
+    });
+    Ok(())
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        out.push_str(&format!("{byte:02x}"));
+    }
+    out
+}
+
+fn emit_release_trust_record(
+    project_root: &Path,
+    bundle_hash: &str,
+    harn_version: &str,
+    signed: bool,
+) -> Result<TrustRecord, PackError> {
+    let log = harn_vm::event_log::install_default_for_base_dir(project_root).map_err(|err| {
+        PackError::new(
+            "pack.trust_log_failed",
+            format!(
+                "failed to open OpenTrustGraph event log under {}: {err}",
+                project_root.display()
+            ),
+        )
+    })?;
+    let parent_trust_record_id = futures::executor::block_on(harn_vm::query_trust_records(
+        &log,
+        &harn_vm::TrustQueryFilters::default(),
+    ))
+    .map_err(|err| {
+        PackError::new(
+            "pack.trust_query_failed",
+            format!("failed to query prior OpenTrustGraph records: {err}"),
+        )
+    })?
+    .last()
+    .map(|record| record.record_id.clone());
+    let mut record = TrustRecord::release(
+        std::env::var("USER")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| "harn-pack".to_string()),
+        bundle_hash.to_string(),
+        harn_version.to_string(),
+        parent_trust_record_id,
+        format!("harnpack-release-{}", uuid::Uuid::now_v7()),
+        if signed {
+            AutonomyTier::ActAuto
+        } else {
+            AutonomyTier::Suggest
+        },
+    );
+    record
+        .metadata
+        .insert("signed".to_string(), serde_json::json!(signed));
+    futures::executor::block_on(harn_vm::append_trust_record(&log, &record)).map_err(|err| {
+        PackError::new(
+            "pack.trust_record_failed",
+            format!("failed to append OpenTrustGraph release record: {err}"),
+        )
     })
 }
 

--- a/crates/harn-cli/src/skill_provenance.rs
+++ b/crates/harn-cli/src/skill_provenance.rs
@@ -208,10 +208,7 @@ pub(crate) fn sign_skill(
     let private_key_path = private_key_path.as_ref();
     let skill_bytes = fs::read(skill_path)
         .map_err(|error| format!("failed to read {}: {error}", skill_path.display()))?;
-    let private_pem = fs::read_to_string(private_key_path)
-        .map_err(|error| format!("failed to read {}: {error}", private_key_path.display()))?;
-    let signing_key = SigningKey::from_pkcs8_pem(&private_pem)
-        .map_err(|error| format!("failed to parse {}: {error}", private_key_path.display()))?;
+    let signing_key = load_ed25519_signing_key(private_key_path)?;
     let signature = signing_key.sign(&skill_bytes);
     let signer_fingerprint = fingerprint_for_key(&signing_key.verifying_key());
     let skill_sha256 = sha256_hex(&skill_bytes);
@@ -269,10 +266,7 @@ pub(crate) fn endorse_skill(
         ));
     }
 
-    let private_pem = fs::read_to_string(private_key_path)
-        .map_err(|error| format!("failed to read {}: {error}", private_key_path.display()))?;
-    let signing_key = SigningKey::from_pkcs8_pem(&private_pem)
-        .map_err(|error| format!("failed to parse {}: {error}", private_key_path.display()))?;
+    let signing_key = load_ed25519_signing_key(private_key_path)?;
     let endorser_fingerprint = fingerprint_for_key(&signing_key.verifying_key());
     if endorser_fingerprint == envelope.signer_fingerprint {
         return Err(
@@ -619,6 +613,13 @@ pub(crate) fn signature_path_for(skill_path: &Path) -> PathBuf {
     append_suffix(skill_path, ".sig")
 }
 
+pub(crate) fn load_ed25519_signing_key(private_key_path: &Path) -> Result<SigningKey, String> {
+    let private_pem = fs::read_to_string(private_key_path)
+        .map_err(|error| format!("failed to read {}: {error}", private_key_path.display()))?;
+    SigningKey::from_pkcs8_pem(&private_pem)
+        .map_err(|error| format!("failed to parse {}: {error}", private_key_path.display()))
+}
+
 fn read_signature_envelope(signature_path: &Path) -> Result<SkillSignatureEnvelope, String> {
     let signature_raw = fs::read_to_string(signature_path)
         .map_err(|error| format!("failed to read {}: {error}", signature_path.display()))?;
@@ -739,7 +740,7 @@ fn sha256_hex(bytes: &[u8]) -> String {
     hex_encode(&digest)
 }
 
-fn fingerprint_for_key(key: &VerifyingKey) -> String {
+pub(crate) fn fingerprint_for_key(key: &VerifyingKey) -> String {
     let digest = Sha256::digest(key.as_bytes());
     hex_encode(&digest)
 }

--- a/crates/harn-cli/tests/pack_cli.rs
+++ b/crates/harn-cli/tests/pack_cli.rs
@@ -13,12 +13,19 @@ use harn_cli::cli::PackArgs;
 use harn_cli::commands::pack;
 use harn_cli::tests::common::cwd_lock;
 use harn_vm::orchestration::{
-    load_workflow_bundle, read_harnpack, SBOMDoc, WORKFLOW_BUNDLE_SCHEMA_VERSION,
+    load_workflow_bundle, read_harnpack, verify_workflow_bundle_signature, SBOMDoc,
+    WORKFLOW_BUNDLE_SCHEMA_VERSION,
 };
 use tempfile::TempDir;
 use tokio::runtime::Builder;
 
+const TEST_ED25519_PRIVATE_KEY: &str = "-----BEGIN PRIVATE KEY-----\nMC4CAQAwBQYDK2VwBCIEIDmsNDO8iZqiMmA/b7I7lwGXNKe68o+gDno6R5riUcDC\n-----END PRIVATE KEY-----\n";
+
 fn run_pack(args: &PackArgs) {
+    let _ = build_pack(args);
+}
+
+fn build_pack(args: &PackArgs) -> pack::PackOutcome {
     Builder::new_current_thread()
         .enable_all()
         .build()
@@ -26,8 +33,8 @@ fn run_pack(args: &PackArgs) {
         .block_on(async {
             let _cwd_guard = cwd_lock::lock_cwd_async().await;
             harn_vm::reset_thread_local_state();
-            pack::build(args).expect("pack succeeds");
-        });
+            pack::build(args).expect("pack succeeds")
+        })
 }
 
 fn pack_args(entrypoint: PathBuf, out: PathBuf) -> PackArgs {
@@ -35,6 +42,8 @@ fn pack_args(entrypoint: PathBuf, out: PathBuf) -> PackArgs {
         entrypoint,
         out: Some(out),
         upgrade: None,
+        sign: false,
+        key: None,
         unsigned: true,
         json: false,
     }
@@ -174,6 +183,8 @@ fn pack_json_envelope_carries_pack_schema() {
                 entrypoint: entry.clone(),
                 out: Some(out.clone()),
                 upgrade: None,
+                sign: false,
+                key: None,
                 unsigned: true,
                 json: true,
             })
@@ -253,6 +264,8 @@ fn pack_upgrade_replaces_schema_version_keeping_workflow() {
         entrypoint: entry.clone(),
         out: Some(out.clone()),
         upgrade: Some(v1.clone()),
+        sign: false,
+        key: None,
         unsigned: true,
         json: false,
     });
@@ -266,4 +279,121 @@ fn pack_upgrade_replaces_schema_version_keeping_workflow() {
     assert_eq!(bundle.triggers[0].id, "manual");
     assert!(!bundle.transitive_modules.is_empty(), "v2 fields populated");
     assert!(bundle.provider_catalog_hash.starts_with("blake3:"));
+}
+
+#[test]
+fn pack_signs_manifest_and_emits_release_trust_record() {
+    let workdir = TempDir::new().unwrap();
+    let entry = workdir.path().join("hello.harn");
+    fs::write(&entry, "println(\"signed\")\n").unwrap();
+    let key = workdir.path().join("release-key.pem");
+    fs::write(&key, TEST_ED25519_PRIVATE_KEY).unwrap();
+    let out = workdir.path().join("hello.harnpack");
+
+    let outcome = build_pack(&PackArgs {
+        entrypoint: entry.clone(),
+        out: Some(out.clone()),
+        upgrade: None,
+        sign: true,
+        key: Some(key),
+        unsigned: false,
+        json: false,
+    });
+
+    let archive = read_harnpack(&fs::read(&out).unwrap()).unwrap();
+    let signature = archive
+        .manifest
+        .signature
+        .as_ref()
+        .expect("signed pack embeds signature");
+    assert_eq!(signature.algorithm, "ed25519");
+    assert_eq!(signature.manifest_hash_blake3, outcome.bundle_hash);
+    assert!(signature.key_id.is_some());
+    verify_workflow_bundle_signature(&archive.manifest, &archive.contents)
+        .expect("signature verifies");
+
+    let log = harn_vm::event_log::install_default_for_base_dir(workdir.path()).unwrap();
+    assert!(
+        futures::executor::block_on(harn_vm::verify_trust_chain(&log))
+            .unwrap()
+            .verified
+    );
+    let records = release_records(&log);
+    let record = records.last().expect("release trust record emitted");
+    assert_eq!(record.autonomy_tier, harn_vm::AutonomyTier::ActAuto);
+    assert_eq!(record.metadata["bundle_hash"], outcome.bundle_hash);
+    assert_eq!(
+        record.metadata["harn_version"],
+        archive.manifest.harn_version
+    );
+    assert_eq!(record.metadata["signed"], true);
+    assert_eq!(record.metadata["action_kind"]["kind"], "release");
+}
+
+#[test]
+fn pack_unsigned_emits_suggest_release_trust_record() {
+    let workdir = TempDir::new().unwrap();
+    let entry = workdir.path().join("hello.harn");
+    fs::write(&entry, "println(\"unsigned\")\n").unwrap();
+    let out = workdir.path().join("hello.harnpack");
+
+    let outcome = build_pack(&pack_args(entry.clone(), out.clone()));
+
+    let archive = read_harnpack(&fs::read(&out).unwrap()).unwrap();
+    assert!(archive.manifest.signature.is_none());
+    let log = harn_vm::event_log::install_default_for_base_dir(workdir.path()).unwrap();
+    assert!(
+        futures::executor::block_on(harn_vm::verify_trust_chain(&log))
+            .unwrap()
+            .verified
+    );
+    let records = release_records(&log);
+    let record = records.last().expect("release trust record emitted");
+    assert_eq!(record.autonomy_tier, harn_vm::AutonomyTier::Suggest);
+    assert_eq!(record.metadata["bundle_hash"], outcome.bundle_hash);
+    assert_eq!(record.metadata["signed"], false);
+}
+
+#[test]
+fn workflow_bundle_signature_verifier_rejects_content_mismatch() {
+    let workdir = TempDir::new().unwrap();
+    let entry = workdir.path().join("hello.harn");
+    fs::write(&entry, "println(\"signed\")\n").unwrap();
+    let key = workdir.path().join("release-key.pem");
+    fs::write(&key, TEST_ED25519_PRIVATE_KEY).unwrap();
+    let out = workdir.path().join("hello.harnpack");
+
+    run_pack(&PackArgs {
+        entrypoint: entry.clone(),
+        out: Some(out.clone()),
+        upgrade: None,
+        sign: true,
+        key: Some(key),
+        unsigned: false,
+        json: false,
+    });
+
+    let mut archive = read_harnpack(&fs::read(&out).unwrap()).unwrap();
+    let source = archive
+        .contents
+        .iter_mut()
+        .find(|entry| entry.path == Path::new("sources/hello.harn"))
+        .expect("source entry present");
+    source.bytes = b"println(\"tampered\")\n".to_vec();
+    let error = verify_workflow_bundle_signature(&archive.manifest, &archive.contents)
+        .expect_err("tampered content must fail verification");
+    assert!(error.message.contains("signature hash mismatch"));
+}
+
+fn release_records(
+    log: &std::sync::Arc<harn_vm::event_log::AnyEventLog>,
+) -> Vec<harn_vm::TrustRecord> {
+    futures::executor::block_on(harn_vm::query_trust_records(
+        log,
+        &harn_vm::TrustQueryFilters {
+            action: Some(harn_vm::TRUST_ACTION_RELEASE.to_string()),
+            ..harn_vm::TrustQueryFilters::default()
+        },
+    ))
+    .unwrap()
 }

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -281,10 +281,11 @@ pub use trust_graph::{
     query_trust_graph_records, query_trust_records, resolve_agent_autonomy_tier,
     summarize_trust_records, topic_for_agent, trust_score_for, verify_trust_chain, AutonomyTier,
     TrustAgentSummary, TrustChainExport, TrustChainExportMetadata, TrustChainExportProducer,
-    TrustChainReport, TrustGraphRecord, TrustOutcome, TrustQueryFilters, TrustRecord, TrustScore,
-    TrustTraceGroup, OPENTRUSTGRAPH_CHAIN_SCHEMA_V0, OPENTRUSTGRAPH_SCHEMA_V0,
-    TRUST_GRAPH_GLOBAL_TOPIC, TRUST_GRAPH_LEGACY_GLOBAL_TOPIC, TRUST_GRAPH_LEGACY_TOPIC_PREFIX,
-    TRUST_GRAPH_RECORDS_TOPIC, TRUST_GRAPH_TOPIC_PREFIX,
+    TrustChainReport, TrustGraphRecord, TrustOutcome, TrustQueryFilters, TrustRecord,
+    TrustRecordActionKind, TrustScore, TrustTraceGroup, OPENTRUSTGRAPH_CHAIN_SCHEMA_V0,
+    OPENTRUSTGRAPH_SCHEMA_V0, TRUST_ACTION_RELEASE, TRUST_GRAPH_GLOBAL_TOPIC,
+    TRUST_GRAPH_LEGACY_GLOBAL_TOPIC, TRUST_GRAPH_LEGACY_TOPIC_PREFIX, TRUST_GRAPH_RECORDS_TOPIC,
+    TRUST_GRAPH_TOPIC_PREFIX,
 };
 pub use value::*;
 pub use vm::*;

--- a/crates/harn-vm/src/orchestration/workflow_bundle.rs
+++ b/crates/harn-vm/src/orchestration/workflow_bundle.rs
@@ -6,6 +6,7 @@ use std::fs;
 use std::io::{Cursor, Read};
 use std::path::{Component, Path, PathBuf};
 
+use ed25519_dalek::{Signature, Verifier, VerifyingKey};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
@@ -417,6 +418,7 @@ pub enum WorkflowBundleErrorKind {
     InvalidArchive,
     DuplicateArchiveEntry,
     UnsafeArchivePath,
+    InvalidSignature,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -583,6 +585,58 @@ pub fn workflow_bundle_hash(
     Ok(blake3_digest_string(hasher.finalize()))
 }
 
+pub fn verify_workflow_bundle_signature(
+    bundle: &WorkflowBundle,
+    contents: &[HarnpackEntry],
+) -> Result<(), WorkflowBundleError> {
+    let signature = bundle.signature.as_ref().ok_or_else(|| {
+        WorkflowBundleError::new(
+            WorkflowBundleErrorKind::InvalidSignature,
+            "workflow bundle is unsigned",
+        )
+    })?;
+    if signature.algorithm != "ed25519" {
+        return Err(WorkflowBundleError::new(
+            WorkflowBundleErrorKind::InvalidSignature,
+            format!(
+                "unsupported workflow bundle signature algorithm {}",
+                signature.algorithm
+            ),
+        ));
+    }
+    let expected_hash = workflow_bundle_hash(bundle, contents)?;
+    if signature.manifest_hash_blake3 != expected_hash {
+        return Err(WorkflowBundleError::new(
+            WorkflowBundleErrorKind::InvalidSignature,
+            format!(
+                "workflow bundle signature hash mismatch; expected {expected_hash}, found {}",
+                signature.manifest_hash_blake3
+            ),
+        ));
+    }
+    let public_key_bytes = decode_hex_exact::<32>(
+        "workflow bundle signature public_key",
+        &signature.public_key,
+    )?;
+    let signature_bytes =
+        decode_hex_exact::<64>("workflow bundle signature", &signature.signature)?;
+    let verifying_key = VerifyingKey::from_bytes(&public_key_bytes).map_err(|error| {
+        WorkflowBundleError::new(
+            WorkflowBundleErrorKind::InvalidSignature,
+            format!("workflow bundle signature public_key is invalid Ed25519: {error}"),
+        )
+    })?;
+    let ed25519_signature = Signature::from_bytes(&signature_bytes);
+    verifying_key
+        .verify(expected_hash.as_bytes(), &ed25519_signature)
+        .map_err(|error| {
+            WorkflowBundleError::new(
+                WorkflowBundleErrorKind::InvalidSignature,
+                format!("workflow bundle signature failed Ed25519 verification: {error}"),
+            )
+        })
+}
+
 pub fn build_harnpack(
     bundle: &WorkflowBundle,
     contents: &[HarnpackEntry],
@@ -730,6 +784,24 @@ fn canonical_workflow_bundle_manifest(bundle: &WorkflowBundle) -> WorkflowBundle
         ))
     });
     canonical
+}
+
+fn decode_hex_exact<const N: usize>(
+    label: &str,
+    value: &str,
+) -> Result<[u8; N], WorkflowBundleError> {
+    let bytes = hex::decode(value).map_err(|error| {
+        WorkflowBundleError::new(
+            WorkflowBundleErrorKind::InvalidSignature,
+            format!("{label} is not hex: {error}"),
+        )
+    })?;
+    bytes.try_into().map_err(|bytes: Vec<u8>| {
+        WorkflowBundleError::new(
+            WorkflowBundleErrorKind::InvalidSignature,
+            format!("{label} must decode to {N} bytes, got {}", bytes.len()),
+        )
+    })
 }
 
 fn append_harnpack_entry<W: std::io::Write>(

--- a/crates/harn-vm/src/trust_graph.rs
+++ b/crates/harn-vm/src/trust_graph.rs
@@ -20,6 +20,7 @@ pub const TRUST_GRAPH_LEGACY_GLOBAL_TOPIC: &str = "trust.graph";
 pub const TRUST_GRAPH_TOPIC_PREFIX: &str = "trust_graph.";
 pub const TRUST_GRAPH_LEGACY_TOPIC_PREFIX: &str = "trust.graph.";
 pub const TRUST_GRAPH_EVENT_KIND: &str = "trust_recorded";
+pub const TRUST_ACTION_RELEASE: &str = "release";
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -85,6 +86,16 @@ pub struct TrustRecord {
     pub metadata: BTreeMap<String, serde_json::Value>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum TrustRecordActionKind {
+    Release {
+        bundle_hash: String,
+        harn_version: String,
+        parent_trust_record_id: Option<String>,
+    },
+}
+
 impl TrustRecord {
     pub fn new(
         agent: impl Into<String>,
@@ -110,6 +121,47 @@ impl TrustRecord {
             entry_hash: String::new(),
             metadata: BTreeMap::new(),
         }
+    }
+
+    pub fn release(
+        agent: impl Into<String>,
+        bundle_hash: impl Into<String>,
+        harn_version: impl Into<String>,
+        parent_trust_record_id: Option<String>,
+        trace_id: impl Into<String>,
+        autonomy_tier: AutonomyTier,
+    ) -> Self {
+        let bundle_hash = bundle_hash.into();
+        let harn_version = harn_version.into();
+        let action_kind = TrustRecordActionKind::Release {
+            bundle_hash: bundle_hash.clone(),
+            harn_version: harn_version.clone(),
+            parent_trust_record_id: parent_trust_record_id.clone(),
+        };
+        let mut record = Self::new(
+            agent,
+            TRUST_ACTION_RELEASE,
+            None,
+            TrustOutcome::Success,
+            trace_id,
+            autonomy_tier,
+        );
+        record
+            .metadata
+            .insert("action_kind".to_string(), serde_json::json!(action_kind));
+        record
+            .metadata
+            .insert("bundle_hash".to_string(), serde_json::json!(bundle_hash));
+        record
+            .metadata
+            .insert("harn_version".to_string(), serde_json::json!(harn_version));
+        record.metadata.insert(
+            "parent_trust_record_id".to_string(),
+            parent_trust_record_id
+                .map(serde_json::Value::String)
+                .unwrap_or(serde_json::Value::Null),
+        );
+        record
     }
 }
 

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -1934,17 +1934,18 @@ harn remove my-lib
 
 ## harn pack
 
-Build a signed-ready `.harnpack` run bundle from a Harn entrypoint
+Build a `.harnpack` run bundle from a Harn entrypoint
 ([#1781][issue-1781]). The bundle is a deterministic tar.zst archive
 containing a v2 `WorkflowBundle` manifest (`harnpack.json`), every
 transitively-imported `.harn` source under `sources/`, every module's
 precompiled `.harnbc`/`.harnmod` artifact under `bytecode/`, a
 provider-catalog hash + stdlib version pin, an archived SPDX-lite 2.3
-SBOM (`sbom.spdx.json`), and a (future) Ed25519 signature slot.
+SBOM (`sbom.spdx.json`), and an optional Ed25519 signature slot.
 
 ```bash
 harn pack examples/hello.harn
 harn pack examples/hello.harn --out /tmp/hello.harnpack
+harn pack examples/hello.harn --sign --key ~/.harn/release-ed25519.pem
 harn pack examples/hello.harn --unsigned --json
 harn pack workflows/new-entry.harn --upgrade old.harnpack --out new.harnpack
 ```
@@ -1964,8 +1965,11 @@ id, name, version, triggers, workflow graph, and prompt capsules. The
 new `<entrypoint>` argument supplies the transitive-module + SBOM
 payload that the older schema lacked.
 
-Signing (`--sign --key <path>`) lands in a follow-up. Today the bundle
-ships unsigned; pass `--unsigned` to make that intent explicit.
+`--sign --key <path>` loads an Ed25519 PKCS#8 PEM private key, signs the
+canonical bundle hash, embeds the signature in the manifest, and appends an
+OpenTrustGraph `release` record. `--unsigned` skips the manifest signature but
+still appends the release record at autonomy tier `suggest`; this is also the
+default when neither signing flag is provided.
 
 [issue-1781]: https://github.com/burin-labs/harn/issues/1781
 

--- a/docs/src/workflow-bundles.md
+++ b/docs/src/workflow-bundles.md
@@ -34,7 +34,7 @@ Top-level bundle fields:
 | `provider_catalog_hash` | BLAKE3 hash of the provider catalog used at build time. |
 | `tool_manifest` | Tool names, providers, optional annotations, and schema hashes captured for review. |
 | `sbom` | SBOM document for package dependencies. |
-| `signature` | Optional Ed25519 signature slot; signing is filled by the signing workflow. |
+| `signature` | Optional Ed25519 signature over the canonical bundle hash. |
 | `parent_trust_record_id` | Optional link into a parent OpenTrustGraph chain. |
 | `id` / `version` | Stable bundle identity for hosts and importers. |
 | `triggers` | Declarations for GitHub, cron, delay, manual, webhook, or MCP wakeups. |
@@ -67,11 +67,13 @@ Bundle identity for `.harnpack` archives is BLAKE3 over the canonical manifest
 bytes plus the sorted content hashes. Re-packing the same manifest and content
 produces the same bundle hash.
 
+`harn pack --sign --key <private.pem>` signs the canonical bundle hash with an
+Ed25519 PKCS#8 PEM key, embeds the signature in `harnpack.json`, and appends an
+OpenTrustGraph `release` record. `harn pack --unsigned` skips the manifest
+signature but still appends the release record at autonomy tier `suggest`.
 `harn pack --json` emits a `JsonEnvelope` summary with the bundle hash, output
 path, archive size, signature presence, SBOM counts, bytecode/debug-symbol
-metadata, and the full manifest. Signing is represented as `{ present: false,
-algorithm: "ed25519" }` until the signing workflow fills the manifest
-signature slot.
+metadata, and the full manifest.
 
 ## Preview
 


### PR DESCRIPTION
## Summary
- add `harn pack --sign --key <path>` and `--unsigned` release-record behavior
- embed Ed25519 manifest signatures over the canonical bundle hash and add verification/tamper coverage
- extend OpenTrustGraph release action metadata for signed/unsigned harnpack records
- update pack docs and CLI reference

Closes #1782.

## Validation
- `CARGO_TARGET_DIR=/tmp/harn-target-1782-sign-harnpack CARGO_BUILD_JOBS=3 HARN_LLM_CALLS_DISABLED=1 cargo test -p harn-cli --test pack_cli`
- `CARGO_TARGET_DIR=/tmp/harn-target-1782-sign-harnpack CARGO_BUILD_JOBS=3 HARN_LLM_CALLS_DISABLED=1 cargo test -p harn-cli cli::tests::test_parses_pack_signing_flags`
- `CARGO_TARGET_DIR=/tmp/harn-target-1782-sign-harnpack CARGO_BUILD_JOBS=3 HARN_LLM_CALLS_DISABLED=1 cargo test -p harn-vm harnpack_build_read_and_bundle_hash_are_deterministic`
- `make lint-test-patterns`
- `git diff --check`