### PR TITLE
Add harness unsettled state foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,15 @@ condensed series summaries instead of full per-patch history.
   sorts results by rule priority, catalogue priority, then declaration
   order so downstream mode callbacks (TH-03) and the
   `preset_run_command` wrapper (TH-02) layer cleanly on top.
+- **Harness unsettled-state snapshot foundation (#1857).** Adds
+  `harness.unsettled_state()`, `harness.is_empty(state?)`,
+  `harness.counts(state?)`, and `harness.summary(state?)`, plus matching
+  `std/lifecycle` helpers for `on_finish` callbacks. Suspended subagents
+  and in-flight LLM calls now enumerate from live VM registries; trigger
+  and handoff buckets are stable typed empty lists until their per-item
+  registries land. Root harness action methods are present, with worker
+  resume/cancel delegated to host worker primitives and not-yet-backed
+  actions returning typed unsupported results.
 - **`harn check --json` and `harn fmt --json` (#1759).** Adds
   standard `JsonEnvelope` reports for static checks and formatter
   runs, including per-file status, diagnostics, summary counts, and

--- a/conformance/tests/hooks_session/pipeline_on_finish_unsettled_state.expected
+++ b/conformance/tests/hooks_session/pipeline_on_finish_unsettled_state.expected
@@ -1,0 +1,9 @@
+empty=true/true
+counts=0,0,0,0
+suspended_decision=none
+trigger_decision=none
+handoff_decision=none
+llm_decision=none
+summary=no unsettled work
+unsupported=unsupported
+wait=settled

--- a/conformance/tests/hooks_session/pipeline_on_finish_unsettled_state.harn
+++ b/conformance/tests/hooks_session/pipeline_on_finish_unsettled_state.harn
@@ -1,0 +1,55 @@
+/**
+ * P-04 foundation: an on_finish callback can enumerate the harness
+ * unsettled-state shape and make deterministic per-category decisions.
+ */
+import { counts, is_empty, summary, unsettled_state } from "std/lifecycle"
+
+pipeline default() {
+  pipeline_on_finish(
+    { harness, return_value ->
+      let state = harness.unsettled_state()
+      let helper_state = unsettled_state(harness)
+      let direct_counts = harness.counts(state)
+      let helper_counts = counts(helper_state)
+      println("empty=" + to_string(harness.is_empty(state)) + "/" + to_string(is_empty(state)))
+      println(
+        "counts=" + to_string(direct_counts.suspended) + "," + to_string(helper_counts.queued)
+          + ","
+          + to_string(helper_counts.partial)
+          + ","
+          + to_string(direct_counts.in_flight),
+      )
+      let suspended_decision = if direct_counts.suspended == 0 {
+        "none"
+      } else {
+        "resume"
+      }
+      let trigger_decision = if helper_counts.queued == 0 {
+        "none"
+      } else {
+        "ack"
+      }
+      let handoff_decision = if helper_counts.partial == 0 {
+        "none"
+      } else {
+        "ack"
+      }
+      let llm_decision = if direct_counts.in_flight == 0 {
+        "none"
+      } else {
+        "wait"
+      }
+      println("suspended_decision=" + suspended_decision)
+      println("trigger_decision=" + trigger_decision)
+      println("handoff_decision=" + handoff_decision)
+      println("llm_decision=" + llm_decision)
+      println("summary=" + summary(state))
+      let ack = harness.acknowledge_trigger("missing-trigger")
+      let wait = harness.wait_for_any_settlement(0)
+      println("unsupported=" + ack.status)
+      println("wait=" + wait.status)
+      return return_value
+    },
+  )
+  return 5
+}

--- a/crates/harn-stdlib/src/stdlib/stdlib_lifecycle.harn
+++ b/crates/harn-stdlib/src/stdlib/stdlib_lifecycle.harn
@@ -25,6 +25,40 @@
  *
  * Tracking: harn#1854 (P-01), harn#1853 (epic).
  */
+pub fn unsettled_state(harness) {
+  return harness.unsettled_state()
+}
+
+pub fn is_empty(state) {
+  return len(state?.suspended_subagents ?? []) == 0
+    && len(state?.queued_triggers ?? []) == 0
+    && len(state?.partial_handoffs ?? []) == 0
+    && len(state?.in_flight_llm_calls ?? []) == 0
+}
+
+pub fn counts(state) {
+  return {
+    suspended: len(state?.suspended_subagents ?? []),
+    queued: len(state?.queued_triggers ?? []),
+    partial: len(state?.partial_handoffs ?? []),
+    in_flight: len(state?.in_flight_llm_calls ?? []),
+  }
+}
+
+pub fn summary(state) {
+  let c = counts(state)
+  if c.suspended == 0 && c.queued == 0 && c.partial == 0 && c.in_flight == 0 {
+    return "no unsettled work"
+  }
+  return "unsettled work: " + to_string(c.suspended) + " suspended subagents, "
+    + to_string(c.queued)
+    + " queued triggers, "
+    + to_string(c.partial)
+    + " partial handoffs, "
+    + to_string(c.in_flight)
+    + " in-flight llm calls"
+}
+
 pub fn on_finish_abandon(_harness, return_value) {
   return return_value
 }

--- a/crates/harn-vm/src/llm/call.rs
+++ b/crates/harn-vm/src/llm/call.rs
@@ -1,3 +1,5 @@
+use std::cell::RefCell;
+use std::collections::BTreeMap;
 use std::rc::Rc;
 
 use crate::stdlib::{json_to_vm_value, schema_result_value};
@@ -10,6 +12,77 @@ use super::{
     api::{parse_schema_stream_abort, schema_stream_aborted_result_value, SchemaStreamAbort},
     helpers, routing, structural_experiments,
 };
+
+thread_local! {
+    static IN_FLIGHT_LLM_CALLS: RefCell<BTreeMap<String, InFlightLlmCall>> = const { RefCell::new(BTreeMap::new()) };
+}
+
+#[derive(Clone, Debug)]
+struct InFlightLlmCall {
+    call_id: String,
+    model: String,
+    role: String,
+    started_at_ms: i64,
+}
+
+struct InFlightLlmCallGuard {
+    call_id: String,
+}
+
+impl InFlightLlmCallGuard {
+    fn enter(opts: &api::LlmCallOptions) -> Self {
+        let call_id = format!("llm_call_{}", uuid::Uuid::now_v7());
+        let started_at_ms = crate::stdlib::clock::now_wall_ms();
+        let role = opts
+            .messages
+            .last()
+            .and_then(|message| message.get("role"))
+            .and_then(|role| role.as_str())
+            .unwrap_or("user")
+            .to_string();
+        let snapshot = InFlightLlmCall {
+            call_id: call_id.clone(),
+            model: opts.model.clone(),
+            role,
+            started_at_ms,
+        };
+        IN_FLIGHT_LLM_CALLS.with(|calls| {
+            calls.borrow_mut().insert(call_id.clone(), snapshot);
+        });
+        Self { call_id }
+    }
+}
+
+impl Drop for InFlightLlmCallGuard {
+    fn drop(&mut self) {
+        IN_FLIGHT_LLM_CALLS.with(|calls| {
+            calls.borrow_mut().remove(&self.call_id);
+        });
+    }
+}
+
+pub(crate) fn snapshot_in_flight_llm_calls() -> Vec<serde_json::Value> {
+    let now_ms = crate::stdlib::clock::now_wall_ms();
+    IN_FLIGHT_LLM_CALLS.with(|calls| {
+        calls
+            .borrow()
+            .values()
+            .map(|call| {
+                serde_json::json!({
+                    "call_id": call.call_id.clone(),
+                    "model": call.model.clone(),
+                    "role": call.role.clone(),
+                    "started_at_ms": call.started_at_ms,
+                    "age_ms": now_ms.saturating_sub(call.started_at_ms).max(0),
+                })
+            })
+            .collect()
+    })
+}
+
+pub(crate) fn clear_in_flight_llm_calls() {
+    IN_FLIGHT_LLM_CALLS.with(|calls| calls.borrow_mut().clear());
+}
 
 fn output_validation_mode(opts: &api::LlmCallOptions) -> &str {
     opts.output_validation.as_deref().unwrap_or("off")
@@ -361,6 +434,7 @@ pub(crate) async fn execute_llm_call(
     options: Option<std::collections::BTreeMap<String, VmValue>>,
     bridge: Option<&Rc<crate::bridge::HostBridge>>,
 ) -> Result<VmValue, VmError> {
+    let _in_flight_guard = InFlightLlmCallGuard::enter(&opts);
     if let Some(policy) = opts.routing_policy.clone() {
         return execute_with_routing_policy(policy, opts, bridge).await;
     }

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -52,6 +52,8 @@ mod transcript_stats;
 
 use std::sync::OnceLock;
 
+pub(crate) use call::snapshot_in_flight_llm_calls;
+
 /// Streaming client: no overall request timeout (per-chunk idle timeout
 /// handles stalls), connection pooling and TLS session reuse.
 pub(crate) fn shared_streaming_client() -> &'static reqwest::Client {
@@ -259,6 +261,7 @@ pub use self::trace::{
 
 /// Reset all thread-local LLM state (cost, trace, mock, rate limits). Call between test runs.
 pub fn reset_llm_state() {
+    call::clear_in_flight_llm_calls();
     cost::reset_cost_state();
     trace::reset_trace_state();
     trace::reset_agent_trace_state();

--- a/crates/harn-vm/src/orchestration/pipeline_lifecycle.rs
+++ b/crates/harn-vm/src/orchestration/pipeline_lifecycle.rs
@@ -7,9 +7,8 @@
 //! registered closure with `take_pipeline_on_finish` exactly once, so a stale
 //! registration cannot leak across consecutive runs.
 //!
-//! P-04 will populate `unsettled_state_snapshot` with suspended subagents,
-//! queued triggers, partial handoffs, and in-flight LLM calls. For P-01 the
-//! snapshot is always empty and `OnUnsettledDetected` therefore never fires.
+//! `unsettled_state_snapshot` exposes the pipeline-finish harness view of
+//! work that can outlive the main pipeline body.
 
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -39,9 +38,11 @@ pub fn clear_pipeline_on_finish() {
 }
 
 /// Snapshot of unsettled work that the pipeline `on_finish` harness exposes.
-/// P-04 populates the four buckets; P-01 ships an always-empty snapshot so
-/// the lifecycle wiring is exercised without depending on suspend/resume,
-/// reactive triggers, handoff envelopes, or in-flight LLM tracking.
+///
+/// Buckets intentionally stay JSON-shaped at this boundary: each producer
+/// owns its richer Rust types, while callbacks need a stable Harn dict/list
+/// contract. Producers without a durable per-item registry yet return a typed
+/// empty list rather than inventing storage in the lifecycle layer.
 #[derive(Debug, Default, Clone)]
 pub struct UnsettledStateSnapshot {
     pub suspended_subagents: Vec<serde_json::Value>,
@@ -66,10 +67,38 @@ impl UnsettledStateSnapshot {
             "in_flight_llm_calls": self.in_flight_llm_calls,
         })
     }
+
+    pub fn counts_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "suspended": self.suspended_subagents.len(),
+            "queued": self.queued_triggers.len(),
+            "partial": self.partial_handoffs.len(),
+            "in_flight": self.in_flight_llm_calls.len(),
+        })
+    }
+
+    pub fn summary(&self) -> String {
+        let suspended = self.suspended_subagents.len();
+        let queued = self.queued_triggers.len();
+        let partial = self.partial_handoffs.len();
+        let in_flight = self.in_flight_llm_calls.len();
+        if suspended == 0 && queued == 0 && partial == 0 && in_flight == 0 {
+            "no unsettled work".to_string()
+        } else {
+            format!(
+                "unsettled work: {suspended} suspended subagents, {queued} queued triggers, {partial} partial handoffs, {in_flight} in-flight llm calls"
+            )
+        }
+    }
 }
 
-/// Return the current unsettled-state snapshot. Always empty until P-04
-/// wires in the per-bucket producers.
+/// Return the current unsettled-state snapshot. This is a single synchronous
+/// collection point for all currently available per-thread registries.
 pub fn unsettled_state_snapshot() -> UnsettledStateSnapshot {
-    UnsettledStateSnapshot::default()
+    UnsettledStateSnapshot {
+        suspended_subagents: crate::stdlib::agents::snapshot_suspended_subagents(),
+        queued_triggers: Vec::new(),
+        partial_handoffs: Vec::new(),
+        in_flight_llm_calls: crate::llm::snapshot_in_flight_llm_calls(),
+    }
 }

--- a/crates/harn-vm/src/stdlib.rs
+++ b/crates/harn-vm/src/stdlib.rs
@@ -2,7 +2,7 @@
 
 mod agent_sessions;
 pub mod agent_state;
-mod agents;
+pub(crate) mod agents;
 mod agents_daemon;
 pub(crate) mod assemble;
 pub mod asset_paths;

--- a/crates/harn-vm/src/stdlib/agents.rs
+++ b/crates/harn-vm/src/stdlib/agents.rs
@@ -578,3 +578,41 @@ fn list_agents_builtin(_args: &[VmValue], _out: &mut String) -> Result<VmValue, 
     })?;
     Ok(VmValue::List(Rc::new(workers)))
 }
+
+pub(crate) fn snapshot_suspended_subagents() -> Vec<serde_json::Value> {
+    WORKER_REGISTRY.with(|registry| {
+        registry
+            .borrow()
+            .values()
+            .filter_map(|state| {
+                let worker = state.borrow();
+                if worker.status != "awaiting" || worker.mode != "sub_agent" {
+                    return None;
+                }
+                let age_ms = worker
+                    .awaiting_since
+                    .map(|started| started.elapsed().as_millis().min(i64::MAX as u128) as i64)
+                    .unwrap_or(0);
+                Some(serde_json::json!({
+                    "handle": worker.id.clone(),
+                    "session_id": if worker.audit.session_id.is_empty() {
+                        serde_json::Value::Null
+                    } else {
+                        serde_json::json!(worker.audit.session_id.clone())
+                    },
+                    "reason": "awaiting_input",
+                    "conditions": {
+                        "status": worker.status.clone(),
+                        "retriggerable": worker.carry_policy.retriggerable,
+                        "awaiting_started_at": worker.awaiting_started_at.clone(),
+                    },
+                    "age_ms": age_ms,
+                    "initiator": worker
+                        .parent_worker_id
+                        .clone()
+                        .unwrap_or_else(|| "pipeline".to_string()),
+                }))
+            })
+            .collect()
+    })
+}

--- a/crates/harn-vm/src/vm/methods/harness.rs
+++ b/crates/harn-vm/src/vm/methods/harness.rs
@@ -30,7 +30,7 @@ impl crate::vm::Vm {
             return self.call_mock_harness_method(handle, method, args).await;
         }
         match handle.kind() {
-            HarnessKind::Root => Err(method_unsupported(handle, method)),
+            HarnessKind::Root => self.call_harness_root_method(handle, method, args).await,
             HarnessKind::Stdio => self.call_harness_stdio_method(handle, method, args),
             HarnessKind::Clock => self.call_harness_clock_method(handle, method, args).await,
             HarnessKind::Fs | HarnessKind::Env | HarnessKind::Random | HarnessKind::Net => {
@@ -39,6 +39,106 @@ impl crate::vm::Vm {
                 handle.type_name(),
             )))
             }
+        }
+    }
+
+    async fn call_harness_root_method(
+        &mut self,
+        handle: &VmHarness,
+        method: &str,
+        args: &[VmValue],
+    ) -> Result<VmValue, VmError> {
+        match method {
+            "unsettled_state" => {
+                let snapshot = crate::orchestration::unsettled_state_snapshot();
+                Ok(crate::stdlib::json_to_vm_value(&snapshot.to_json()))
+            }
+            "is_empty" => {
+                let empty = match args.first() {
+                    Some(state) => state_counts(state)?.is_empty(),
+                    None => crate::orchestration::unsettled_state_snapshot().is_empty(),
+                };
+                Ok(VmValue::Bool(empty))
+            }
+            "counts" => match args.first() {
+                Some(state) => Ok(crate::stdlib::json_to_vm_value(
+                    &state_counts(state)?.to_json(),
+                )),
+                None => {
+                    let snapshot = crate::orchestration::unsettled_state_snapshot();
+                    Ok(crate::stdlib::json_to_vm_value(&snapshot.counts_json()))
+                }
+            },
+            "summary" => match args.first() {
+                Some(state) => Ok(VmValue::String(std::rc::Rc::from(
+                    state_counts(state)?.summary().as_str(),
+                ))),
+                None => {
+                    let snapshot = crate::orchestration::unsettled_state_snapshot();
+                    Ok(VmValue::String(std::rc::Rc::from(snapshot.summary())))
+                }
+            },
+            "resume_subagent" => {
+                let handle_arg = args.first().cloned().ok_or_else(|| {
+                    VmError::TypeError("Harness.resume_subagent expects a handle".to_string())
+                })?;
+                if let Some(input) = args.get(1).cloned() {
+                    self.call_named_builtin("__host_worker_send_input", vec![handle_arg, input])
+                        .await
+                } else {
+                    self.call_named_builtin("__host_worker_resume", vec![handle_arg])
+                        .await
+                }
+            }
+            "cancel_subagent" => {
+                let handle_arg = args.first().cloned().ok_or_else(|| {
+                    VmError::TypeError("Harness.cancel_subagent expects a handle".to_string())
+                })?;
+                self.call_named_builtin("__host_worker_close", vec![handle_arg])
+                    .await
+            }
+            "wait_for_any_settlement" => {
+                let snapshot = crate::orchestration::unsettled_state_snapshot();
+                let status = if snapshot.is_empty() {
+                    "settled"
+                } else {
+                    "unsettled"
+                };
+                Ok(crate::stdlib::json_to_vm_value(&serde_json::json!({
+                    "status": status,
+                    "timed_out": false,
+                    "state": snapshot.to_json(),
+                })))
+            }
+            "current_pipeline_id" => Ok(crate::orchestration::current_mutation_session()
+                .and_then(|session| session.run_id.or(Some(session.session_id)))
+                .map(|id| VmValue::String(std::rc::Rc::from(id)))
+                .unwrap_or(VmValue::Nil)),
+            "handoff_to" => Ok(unsupported_harness_action(
+                method,
+                "partial handoff envelopes do not have a VM-level registry on this branch",
+            )),
+            "acknowledge_trigger" | "defer_trigger" => Ok(unsupported_harness_action(
+                method,
+                "queued trigger items do not have an acknowledgement registry on this branch",
+            )),
+            "acknowledge_handoff" => Ok(unsupported_harness_action(
+                method,
+                "partial handoff envelopes do not have an acknowledgement registry on this branch",
+            )),
+            "emit_audit" => Ok(unsupported_harness_action(
+                method,
+                "LifecycleAuditEntry persistence is not available on this branch",
+            )),
+            "finalize" => Ok(unsupported_harness_action(
+                method,
+                "pipeline disposition persistence is not available on this branch",
+            )),
+            "spawn_settlement_agent" => Ok(unsupported_harness_action(
+                method,
+                "settlement-agent spawning is deferred to the drain implementation",
+            )),
+            _ => Err(method_unsupported(handle, method)),
         }
     }
 
@@ -210,6 +310,76 @@ impl crate::vm::Vm {
             },
         }
     }
+}
+
+#[derive(Clone, Copy)]
+struct UnsettledCounts {
+    suspended: usize,
+    queued: usize,
+    partial: usize,
+    in_flight: usize,
+}
+
+impl UnsettledCounts {
+    fn is_empty(self) -> bool {
+        self.suspended == 0 && self.queued == 0 && self.partial == 0 && self.in_flight == 0
+    }
+
+    fn to_json(self) -> serde_json::Value {
+        serde_json::json!({
+            "suspended": self.suspended,
+            "queued": self.queued,
+            "partial": self.partial,
+            "in_flight": self.in_flight,
+        })
+    }
+
+    fn summary(self) -> String {
+        if self.is_empty() {
+            "no unsettled work".to_string()
+        } else {
+            format!(
+                "unsettled work: {} suspended subagents, {} queued triggers, {} partial handoffs, {} in-flight llm calls",
+                self.suspended, self.queued, self.partial, self.in_flight
+            )
+        }
+    }
+}
+
+fn state_counts(state: &VmValue) -> Result<UnsettledCounts, VmError> {
+    let Some(dict) = state.as_dict() else {
+        return Err(VmError::TypeError(
+            "Harness unsettled-state helpers expect a state dict".to_string(),
+        ));
+    };
+    Ok(UnsettledCounts {
+        suspended: state_bucket_len(dict, "suspended_subagents")?,
+        queued: state_bucket_len(dict, "queued_triggers")?,
+        partial: state_bucket_len(dict, "partial_handoffs")?,
+        in_flight: state_bucket_len(dict, "in_flight_llm_calls")?,
+    })
+}
+
+fn state_bucket_len(
+    dict: &std::collections::BTreeMap<String, VmValue>,
+    key: &str,
+) -> Result<usize, VmError> {
+    match dict.get(key) {
+        Some(VmValue::List(items)) => Ok(items.len()),
+        Some(other) => Err(VmError::TypeError(format!(
+            "unsettled-state field `{key}` must be a list, got {}",
+            other.type_name()
+        ))),
+        None => Ok(0),
+    }
+}
+
+fn unsupported_harness_action(method: &str, reason: &str) -> VmValue {
+    crate::stdlib::json_to_vm_value(&serde_json::json!({
+        "status": "unsupported",
+        "method": method,
+        "reason": reason,
+    }))
 }
 
 fn method_unsupported(handle: &VmHarness, method: &str) -> VmError {

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -2231,6 +2231,22 @@ Three concentric surfaces:
   `on_finish_drain` (settlement-agent stub — currently identical to
   `abandon`; replaced by the P-02 settlement implementation under
   harn#1853).
+- `harness.unsettled_state()` returns a stable dict with
+  `suspended_subagents`, `queued_triggers`, `partial_handoffs`, and
+  `in_flight_llm_calls` lists. `harness.is_empty(state?)`,
+  `harness.counts(state?)`, and `harness.summary(state?)` summarize that
+  shape; `std/lifecycle` exports equivalent `unsettled_state(harness)`,
+  `is_empty(state)`, `counts(state)`, and `summary(state)` helpers. On
+  this branch, suspended subagents and in-flight LLM calls are populated
+  from live VM registries; trigger and handoff buckets stay typed empty
+  lists until their per-item registries land.
+- Lifecycle action methods exist on the root harness for drain callbacks:
+  `resume_subagent`, `cancel_subagent`, `handoff_to`, `acknowledge_trigger`,
+  `defer_trigger`, `acknowledge_handoff`, `wait_for_any_settlement`,
+  `emit_audit`, `finalize`, `spawn_settlement_agent`, and
+  `current_pipeline_id`. `resume_subagent` and `cancel_subagent` delegate
+  to host worker primitives; methods whose backing registries are not yet
+  present return a typed `{status: "unsupported", method, reason}` result.
 
 ```harn
 register_session_hook("user_prompt_submit", { event ->


### PR DESCRIPTION
## Summary
- add `harness.unsettled_state()` and helper methods for empty/count/summary inspection
- enumerate suspended subagents from the existing worker registry and track in-flight LLM calls with a scoped registry
- add std/lifecycle helper functions and conformance for the pipeline on_finish usage path
- return typed unsupported responses for action APIs whose durable registries do not exist yet

Refs #1857. This lands the stable snapshot/helper foundation; queued trigger and partial handoff buckets are typed empty lists until their durable registries exist.

## Validation
- `CARGO_TARGET_DIR=/tmp/harn-target-1857-unsettled-state CARGO_BUILD_JOBS=3 HARN_LLM_CALLS_DISABLED=1 cargo test -p harn-vm orchestration::tests::unsettled_state_snapshot_starts_empty -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-1857-unsettled-state CARGO_BUILD_JOBS=3 HARN_LLM_CALLS_DISABLED=1 cargo run --quiet --bin harn -- test conformance --filter pipeline_on_finish_unsettled_state`
- `CARGO_TARGET_DIR=/tmp/harn-target-1857-unsettled-state CARGO_BUILD_JOBS=3 HARN_LLM_CALLS_DISABLED=1 cargo test -p harn-vm pipeline_ -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-1857-unsettled-state CARGO_BUILD_JOBS=3 HARN_LLM_CALLS_DISABLED=1 cargo fmt --check --package harn-vm`
- `CARGO_TARGET_DIR=/tmp/harn-target-1857-unsettled-state CARGO_BUILD_JOBS=3 HARN_LLM_CALLS_DISABLED=1 cargo run --quiet --bin harn -- fmt --check conformance/tests/hooks_session/pipeline_on_finish_unsettled_state.harn`
- `make lint-test-patterns`
- `git diff --check`