### PR TITLE
Run release smoke outside main push path

### DIFF
--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -16,7 +16,6 @@ on:
   schedule:
     - cron: '17 9 * * *'
   push:
-    branches: [main]
     tags: ['v*']
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary
- stop running the cross-platform release smoke matrix on every `main` push
- keep release smoke on version tags, daily schedule, and manual dispatch

This removes another non-required runner-heavy workflow from the merge/admin-merge critical path while preserving release and periodic coverage.

## Validation
- `make lint-actions`
- `git diff --check`