### PR TITLE
Add OAuth provider catalogue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ condensed series summaries instead of full per-patch history.
   reminders by `id`, `tag`, or `dedupe_key` and reports the removal
   count. This lands the deterministic transcript model without the later
   EventLog expiry hooks or provider-rendering framework.
+- **OAuth provider catalogue records (#1905).** Adds
+  `std/oauth/providers` with ten preconfigured OAuth provider records
+  (GitHub, Slack, Linear, Notion, Google, Microsoft, Atlassian,
+  Discord, GitLab, Bitbucket), the `github_enterprise(base_url, ...)`
+  and `custom(config, ...)` factories, and override-friendly endpoint
+  fields for future OAuth orchestration work. The catalogue is static
+  and offline-only; it does not start a live OAuth flow.
 - **Pipeline `on_finish` callback + finish lifecycle hooks (#1854).**
   Adds the `pipeline_on_finish(callback)` builtin and three new
   session-level hook events — `PreFinish`, `PostFinish`, and

--- a/conformance/tests/stdlib/oauth_provider_catalog.expected
+++ b/conformance/tests/stdlib/oauth_provider_catalog.expected
@@ -1,0 +1,1 @@
+[harn] oauth provider catalog ok

--- a/conformance/tests/stdlib/oauth_provider_catalog.harn
+++ b/conformance/tests/stdlib/oauth_provider_catalog.harn
@@ -1,0 +1,152 @@
+import {
+  custom,
+  github,
+  github_enterprise,
+  provider,
+  provider_catalog,
+  provider_names,
+  providers,
+} from "std/oauth/providers"
+
+fn missing_core_fields(record) {
+  var missing = []
+  for field in [
+    "auth_url",
+    "token_url",
+    "device_code_url",
+    "revoke_url",
+    "userinfo_url",
+    "default_scopes",
+    "pkce_required",
+    "refresh_handling",
+    "documented_quirks",
+  ] {
+    if !record.keys().contains(field) {
+      missing = missing + [field]
+    }
+  }
+  return missing
+}
+
+fn mock_flow_for_provider(name) {
+  let base = "https://mock-oauth.example/" + name
+  let record = provider(
+    name,
+    {
+      auth_url: base + "/authorize",
+      token_url: base + "/token",
+      device_code_url: base + "/device",
+      revoke_url: base + "/revoke",
+      userinfo_url: base + "/userinfo",
+    },
+  )
+  let userinfo_url = record.userinfo_url ?? ""
+  let revoke_url = record.revoke_url ?? ""
+  require record.auth_url == base + "/authorize", name + " auth override"
+  require record.token_url == base + "/token", name + " token override"
+  require userinfo_url == base + "/userinfo", name + " userinfo override"
+  require revoke_url == base + "/revoke", name + " revoke override"
+  http_mock_clear()
+  http_mock(
+    "POST",
+    record.token_url,
+    {
+      status: 200,
+      body: "{\"access_token\":\"access-" + name + "\",\"refresh_token\":\"refresh-"
+        + name
+        + "\",\"expires_in\":3600}",
+      headers: {"content-type": "application/json"},
+    },
+  )
+  http_mock(
+    "GET",
+    userinfo_url,
+    {
+      status: 200,
+      body: "{\"provider\":\"" + name + "\",\"sub\":\"user-" + name + "\"}",
+      headers: {"content-type": "application/json"},
+    },
+  )
+  http_mock("POST", revoke_url, {status: 200, body: "{\"revoked\":true}", headers: {}})
+  let token_resp = http_post(
+    record.token_url,
+    "grant_type=authorization_code&code=code-" + name
+      + "&redirect_uri=https%3A%2F%2Fapp.example%2Fcallback",
+    {headers: {"Content-Type": "application/x-www-form-urlencoded"}},
+  )
+  require token_resp.status == 200, name + " token response"
+  let token = json_parse(token_resp.body)
+  require token.access_token == "access-" + name, name + " access token"
+  let profile_resp = http_get(userinfo_url, {headers: {Authorization: "Bearer " + token.access_token}})
+  require profile_resp.status == 200, name + " userinfo response"
+  let profile = json_parse(profile_resp.body)
+  require profile.provider == name, name + " profile provider"
+  let revoke_resp = http_post(
+    revoke_url,
+    "token=" + token.access_token,
+    {headers: {"Content-Type": "application/x-www-form-urlencoded"}},
+  )
+  require revoke_resp.status == 200, name + " revoke response"
+  let calls = http_mock_calls({include_sensitive: true})
+  require len(calls) == 3, name + " mock flow call count"
+  require calls[0].method == "POST", name + " token call method"
+  require contains(calls[0].body, "grant_type=authorization_code"), name + " token grant body"
+  require calls[1].headers.authorization == "Bearer access-" + name, name + " userinfo bearer"
+  require contains(calls[2].body, "token=access-" + name), name + " revoke body"
+  http_mock_clear()
+}
+
+pipeline test(task) {
+  let names = provider_names()
+  assert_eq(len(names), 10, "ten named providers")
+  assert(names.contains("github"), "github named provider")
+  assert(names.contains("bitbucket"), "bitbucket named provider")
+  let catalog = provider_catalog()
+  assert_eq(len(catalog.keys()), 10, "catalogue contains ten provider records")
+  for name in names {
+    assert_eq(missing_core_fields(catalog[name]), [], name + " carries core fields")
+    assert_eq(catalog[name].id, name, name + " id")
+    mock_flow_for_provider(name)
+  }
+  let gh = github()
+  assert_eq(gh.auth_url, "https://github.com/login/oauth/authorize", "github auth url")
+  assert_eq(gh.device_code_url, "https://github.com/login/device/code", "github device url")
+  assert(gh.default_scopes.contains("read:user"), "github default scope")
+  let ghes = github_enterprise("https://ghe.example.com/")
+  assert_eq(ghes.auth_url, "https://ghe.example.com/login/oauth/authorize", "ghes auth url")
+  assert_eq(ghes.token_url, "https://ghe.example.com/login/oauth/access_token", "ghes token url")
+  assert_eq(ghes.userinfo_url, "https://ghe.example.com/api/v3/user", "ghes api url")
+  let discord_override = provider(
+    "discord",
+    {auth_url: "https://discord.example/oauth2/authorize", default_scopes: ["identify"]},
+  )
+  assert_eq(
+    discord_override.auth_url,
+    "https://discord.example/oauth2/authorize",
+    "override auth url",
+  )
+  assert_eq(discord_override.default_scopes, ["identify"], "override scopes")
+  let namespace = providers()
+  assert_eq(namespace.github.id, "github", "Providers exposes github record")
+  assert_eq(
+    namespace.github_enterprise("https://gh.example").token_url,
+    "https://gh.example/login/oauth/access_token",
+    "Providers exposes GHES factory",
+  )
+  let custom_provider = custom(
+    {
+      id: "acme",
+      label: "Acme",
+      auth_url: "https://idp.example/authorize",
+      token_url: "https://idp.example/token",
+      default_scopes: ["read"],
+      pkce_required: true,
+    },
+    {revoke_url: "https://idp.example/revoke"},
+  )
+  assert_eq(custom_provider.id, "acme", "custom id")
+  assert_eq(custom_provider.default_scopes, ["read"], "custom scopes")
+  assert_eq(custom_provider.revoke_url, "https://idp.example/revoke", "custom override")
+  assert_eq(custom_provider.refresh_handling.refresh_grant, "custom", "custom refresh mode")
+  log("oauth provider catalog ok")
+}

--- a/crates/harn-stdlib/src/lib.rs
+++ b/crates/harn-stdlib/src/lib.rs
@@ -466,6 +466,10 @@ pub const STDLIB_SOURCES: &[StdlibSource] = &[
         source: include_str!("stdlib/stdlib_connectors_shared.harn"),
     },
     StdlibSource {
+        module: "oauth/providers",
+        source: include_str!("stdlib/oauth/providers.harn"),
+    },
+    StdlibSource {
         module: "connectors/github",
         source: include_str!("stdlib/stdlib_connectors_github.harn"),
     },

--- a/crates/harn-stdlib/src/stdlib/oauth/providers.harn
+++ b/crates/harn-stdlib/src/stdlib/oauth/providers.harn
@@ -1,0 +1,617 @@
+import { merge } from "std/json"
+
+type OAuthRefreshHandling = {
+  strategy: string,
+  expires_in_field?: string,
+  expires_at_field?: string,
+  refresh_grant: string,
+  rotates_refresh_token: bool,
+  notes: list<string>,
+}
+
+type OAuthProvider = {
+  id: string,
+  label: string,
+  auth_url: string,
+  token_url: string,
+  device_code_url: string?,
+  revoke_url: string?,
+  userinfo_url: string?,
+  default_scopes: list<string>,
+  pkce_required: bool,
+  refresh_handling: OAuthRefreshHandling,
+  documented_quirks: list<string>,
+  documentation_url: string?,
+}
+
+fn __refresh(strategy, refresh_grant, rotates_refresh_token, notes) {
+  return {
+    strategy: strategy,
+    expires_in_field: "expires_in",
+    expires_at_field: nil,
+    refresh_grant: refresh_grant,
+    rotates_refresh_token: rotates_refresh_token,
+    notes: notes,
+  }
+}
+
+fn __with_overrides(record, overrides = nil) {
+  return merge(record, overrides ?? {})
+}
+
+fn __trim_trailing_slash(value) {
+  var text = trim(to_string(value ?? ""))
+  while ends_with(text, "/") {
+    text = substring(text, 0, len(text) - 1)
+  }
+  return text
+}
+
+fn __require_url(value, field) {
+  let text = trim(to_string(value ?? ""))
+  if text == "" {
+    throw "std/oauth/providers: " + field + " is required"
+  }
+  return text
+}
+
+fn __github_record() {
+  return {
+    id: "github",
+    label: "GitHub",
+    auth_url: "https://github.com/login/oauth/authorize",
+    token_url: "https://github.com/login/oauth/access_token",
+    device_code_url: "https://github.com/login/device/code",
+    revoke_url: "https://api.github.com/applications/{client_id}/token",
+    userinfo_url: "https://api.github.com/user",
+    default_scopes: ["read:user", "user:email"],
+    pkce_required: true,
+    refresh_handling: __refresh(
+      "use expires_in/expires_at when returned; otherwise treat OAuth app tokens as provider-revoked",
+      "provider_optional",
+      true,
+      [
+        "GitHub strongly recommends PKCE for code flow.",
+        "OAuth app access tokens may be long-lived; expiring user tokens return refresh metadata when enabled.",
+      ],
+    ),
+    documented_quirks: [
+      "Device flow must be enabled on the app registration before use.",
+      "Revocation uses the REST API app-token endpoint with client authentication.",
+    ],
+    documentation_url: "https://docs.github.com/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps",
+  }
+}
+
+/**
+ * github returns the preconfigured GitHub OAuth provider record.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: github()
+ */
+pub fn github(overrides = nil) -> OAuthProvider {
+  return __with_overrides(__github_record(), overrides)
+}
+
+/**
+ * github_enterprise builds a GitHub Enterprise Server provider from its web base URL.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: [invalid_argument]
+ * @api_stability: experimental
+ * @example: github_enterprise("https://ghe.example.com")
+ */
+pub fn github_enterprise(base_url, overrides = nil) -> OAuthProvider {
+  let web_url = __trim_trailing_slash(base_url)
+  if web_url == "" {
+    throw "std/oauth/providers: github_enterprise base_url is required"
+  }
+  let api_url = __trim_trailing_slash(overrides?.api_url ?? (web_url + "/api/v3"))
+  return __with_overrides(
+    __github_record()
+      + {
+      id: "github_enterprise",
+      label: "GitHub Enterprise Server",
+      auth_url: web_url + "/login/oauth/authorize",
+      token_url: web_url + "/login/oauth/access_token",
+      device_code_url: web_url + "/login/device/code",
+      revoke_url: api_url + "/applications/{client_id}/token",
+      userinfo_url: api_url + "/user",
+      documentation_url: "https://docs.github.com/en/enterprise-server@latest/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps",
+      documented_quirks: __github_record().documented_quirks
+        + ["Use the instance web base URL for browser/device endpoints and /api/v3 for REST endpoints."],
+    },
+    overrides,
+  )
+}
+
+/**
+ * slack returns the preconfigured Slack OAuth v2 provider record.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: slack()
+ */
+pub fn slack(overrides = nil) -> OAuthProvider {
+  return __with_overrides(
+    {
+      id: "slack",
+      label: "Slack",
+      auth_url: "https://slack.com/oauth/v2/authorize",
+      token_url: "https://slack.com/api/oauth.v2.access",
+      device_code_url: nil,
+      revoke_url: "https://slack.com/api/auth.revoke",
+      userinfo_url: "https://slack.com/api/users.identity",
+      default_scopes: ["identity.basic"],
+      pkce_required: false,
+      refresh_handling: __refresh(
+        "use oauth.v2.access with grant_type=refresh_token when token rotation is enabled",
+        "standard_refresh_token",
+        true,
+        [
+          "Refresh tokens are single-use when token rotation is enabled.",
+          "GovSlack installs use slack-gov.com endpoints instead of slack.com.",
+        ],
+      ),
+      documented_quirks: [
+        "Slack bot/user API scopes are separate from Sign in with Slack identity scopes.",
+        "auth.revoke revokes a single rotated token without removing the installation.",
+      ],
+      documentation_url: "https://docs.slack.dev/authentication/installing-with-oauth",
+    },
+    overrides,
+  )
+}
+
+/**
+ * linear returns the preconfigured Linear OAuth provider record.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: linear()
+ */
+pub fn linear(overrides = nil) -> OAuthProvider {
+  return __with_overrides(
+    {
+      id: "linear",
+      label: "Linear",
+      auth_url: "https://linear.app/oauth/authorize",
+      token_url: "https://api.linear.app/oauth/token",
+      device_code_url: nil,
+      revoke_url: nil,
+      userinfo_url: "https://api.linear.app/graphql",
+      default_scopes: ["read"],
+      pkce_required: true,
+      refresh_handling: __refresh(
+        "use expires_in and refresh with grant_type=refresh_token",
+        "standard_refresh_token",
+        true,
+        ["Linear OAuth apps use rotating refresh tokens and return a replacement refresh_token on refresh."],
+      ),
+      documented_quirks: [
+        "Scopes are comma-separated in the authorization request.",
+        "Use a viewer query against the GraphQL API for user info.",
+      ],
+      documentation_url: "https://linear.app/developers/oauth-2-0-authentication",
+    },
+    overrides,
+  )
+}
+
+/**
+ * notion returns the preconfigured Notion public-connection OAuth provider record.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: notion()
+ */
+pub fn notion(overrides = nil) -> OAuthProvider {
+  return __with_overrides(
+    {
+      id: "notion",
+      label: "Notion",
+      auth_url: "https://api.notion.com/v1/oauth/authorize",
+      token_url: "https://api.notion.com/v1/oauth/token",
+      device_code_url: nil,
+      revoke_url: nil,
+      userinfo_url: "https://api.notion.com/v1/users/me",
+      default_scopes: [],
+      pkce_required: false,
+      refresh_handling: __refresh(
+        "use token response expiry metadata and refresh through the Notion token endpoint when a refresh token is issued",
+        "standard_refresh_token",
+        true,
+        [
+          "Page/database access is selected by the user during the Notion page-picker flow, not by OAuth scopes.",
+        ],
+      ),
+      documented_quirks: [
+        "The authorize URL requires owner=user for user-owned public-connection installs.",
+        "Notion-Version must be sent on API requests after OAuth completes.",
+      ],
+      documentation_url: "https://developers.notion.com/docs/authorization",
+    },
+    overrides,
+  )
+}
+
+/**
+ * google returns the preconfigured Google OAuth/OIDC provider record.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: google()
+ */
+pub fn google(overrides = nil) -> OAuthProvider {
+  return __with_overrides(
+    {
+      id: "google",
+      label: "Google",
+      auth_url: "https://accounts.google.com/o/oauth2/v2/auth",
+      token_url: "https://oauth2.googleapis.com/token",
+      device_code_url: "https://oauth2.googleapis.com/device/code",
+      revoke_url: "https://oauth2.googleapis.com/revoke",
+      userinfo_url: "https://openidconnect.googleapis.com/v1/userinfo",
+      default_scopes: ["openid", "email", "profile"],
+      pkce_required: true,
+      refresh_handling: __refresh(
+        "request offline access for refresh tokens and use expires_in for access-token expiry",
+        "standard_refresh_token",
+        false,
+        [
+          "Refresh tokens are not returned on every grant; request offline access and persist existing refresh tokens.",
+        ],
+      ),
+      documented_quirks: [
+        "Incremental authorization is preferred for product-specific Google API scopes.",
+        "Revocation accepts either access or refresh tokens.",
+      ],
+      documentation_url: "https://developers.google.com/identity/protocols/oauth2/web-server",
+    },
+    overrides,
+  )
+}
+
+/**
+ * microsoft returns the preconfigured Microsoft identity platform provider record.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: microsoft()
+ */
+pub fn microsoft(overrides = nil) -> OAuthProvider {
+  return __with_overrides(
+    {
+      id: "microsoft",
+      label: "Microsoft",
+      auth_url: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+      token_url: "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+      device_code_url: "https://login.microsoftonline.com/common/oauth2/v2.0/devicecode",
+      revoke_url: nil,
+      userinfo_url: "https://graph.microsoft.com/v1.0/me",
+      default_scopes: ["openid", "profile", "email", "offline_access", "User.Read"],
+      pkce_required: true,
+      refresh_handling: __refresh(
+        "use expires_in and refresh with grant_type=refresh_token; persist replacement refresh tokens when returned",
+        "standard_refresh_token",
+        true,
+        ["Use a tenant-specific URL instead of /common when an app is single-tenant or tenant-pinned."],
+      ),
+      documented_quirks: [
+        "Graph delegated scopes such as User.Read are resource permissions, not OIDC claims.",
+        "The Graph /me endpoint requires a Graph access token with User.Read or a stronger delegated permission.",
+      ],
+      documentation_url: "https://learn.microsoft.com/en-us/graph/auth-v2-user",
+    },
+    overrides,
+  )
+}
+
+/**
+ * atlassian returns the preconfigured Atlassian Cloud OAuth 2.0 3LO provider record.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: atlassian()
+ */
+pub fn atlassian(overrides = nil) -> OAuthProvider {
+  return __with_overrides(
+    {
+      id: "atlassian",
+      label: "Atlassian",
+      auth_url: "https://auth.atlassian.com/authorize",
+      token_url: "https://auth.atlassian.com/oauth/token",
+      device_code_url: nil,
+      revoke_url: nil,
+      userinfo_url: "https://api.atlassian.com/me",
+      default_scopes: ["read:me", "offline_access"],
+      pkce_required: false,
+      refresh_handling: __refresh(
+        "request offline_access and use rotating refresh tokens through auth.atlassian.com/oauth/token",
+        "standard_refresh_token",
+        true,
+        ["Rotating refresh tokens issue a new limited-life refresh token on each refresh."],
+      ),
+      documented_quirks: [
+        "Authorization requests need audience=api.atlassian.com for product API access.",
+        "Product API calls use api.atlassian.com rather than the customer atlassian.net host.",
+      ],
+      documentation_url: "https://developer.atlassian.com/cloud/oauth/getting-started/implementing-oauth-3lo/",
+    },
+    overrides,
+  )
+}
+
+/**
+ * discord returns the preconfigured Discord OAuth provider record.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: discord()
+ */
+pub fn discord(overrides = nil) -> OAuthProvider {
+  return __with_overrides(
+    {
+      id: "discord",
+      label: "Discord",
+      auth_url: "https://discord.com/oauth2/authorize",
+      token_url: "https://discord.com/api/oauth2/token",
+      device_code_url: nil,
+      revoke_url: "https://discord.com/api/oauth2/token/revoke",
+      userinfo_url: "https://discord.com/api/users/@me",
+      default_scopes: ["identify", "email"],
+      pkce_required: false,
+      refresh_handling: __refresh(
+        "use expires_in and refresh with grant_type=refresh_token",
+        "standard_refresh_token",
+        false,
+        ["Persist a replacement refresh_token if Discord returns one during refresh."],
+      ),
+      documented_quirks: [
+        "Token and revocation endpoints require application/x-www-form-urlencoded bodies.",
+        "The identify scope is enough for /users/@me without email; email adds the email field.",
+      ],
+      documentation_url: "https://docs.discord.com/developers/topics/oauth2",
+    },
+    overrides,
+  )
+}
+
+/**
+ * gitlab returns the preconfigured GitLab.com OAuth provider record.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: gitlab()
+ */
+pub fn gitlab(overrides = nil) -> OAuthProvider {
+  return __with_overrides(
+    {
+      id: "gitlab",
+      label: "GitLab",
+      auth_url: "https://gitlab.com/oauth/authorize",
+      token_url: "https://gitlab.com/oauth/token",
+      device_code_url: "https://gitlab.com/oauth/authorize_device",
+      revoke_url: "https://gitlab.com/oauth/revoke",
+      userinfo_url: "https://gitlab.com/oauth/userinfo",
+      default_scopes: ["read_user", "openid", "profile", "email"],
+      pkce_required: true,
+      refresh_handling: __refresh(
+        "use expires_in and refresh with grant_type=refresh_token",
+        "standard_refresh_token",
+        true,
+        ["Refreshing invalidates the existing access token and refresh token and returns replacements."],
+      ),
+      documented_quirks: [
+        "Device authorization grant is available on GitLab 17.1+ and generally available in 17.9+.",
+        "Self-managed GitLab instances use the same /oauth paths on the instance base URL.",
+      ],
+      documentation_url: "https://docs.gitlab.com/api/oauth2/",
+    },
+    overrides,
+  )
+}
+
+/**
+ * bitbucket returns the preconfigured Bitbucket Cloud OAuth provider record.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: bitbucket()
+ */
+pub fn bitbucket(overrides = nil) -> OAuthProvider {
+  return __with_overrides(
+    {
+      id: "bitbucket",
+      label: "Bitbucket Cloud",
+      auth_url: "https://bitbucket.org/site/oauth2/authorize",
+      token_url: "https://bitbucket.org/site/oauth2/access_token",
+      device_code_url: nil,
+      revoke_url: nil,
+      userinfo_url: "https://api.bitbucket.org/2.0/user",
+      default_scopes: ["account"],
+      pkce_required: false,
+      refresh_handling: __refresh(
+        "use expires_in and refresh with grant_type=refresh_token",
+        "standard_refresh_token",
+        true,
+        [
+          "A refreshed Bitbucket token response includes a new refresh token; the old one expires shortly after use.",
+        ],
+      ),
+      documented_quirks: [
+        "Bitbucket Cloud OAuth supports authorization-code and client-credentials grants, not device flow.",
+        "OAuth API requests should use api.bitbucket.org with a Bearer token.",
+      ],
+      documentation_url: "https://developer.atlassian.com/cloud/bitbucket/rest/intro/",
+    },
+    overrides,
+  )
+}
+
+/**
+ * provider_names returns the ten named provider keys in the catalogue.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: provider_names()
+ */
+pub fn provider_names() -> list<string> {
+  return [
+    "github",
+    "slack",
+    "linear",
+    "notion",
+    "google",
+    "microsoft",
+    "atlassian",
+    "discord",
+    "gitlab",
+    "bitbucket",
+  ]
+}
+
+/**
+ * provider returns one named provider record with optional field overrides.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: [invalid_argument]
+ * @api_stability: experimental
+ * @example: provider("github", {default_scopes: ["read:user"]})
+ */
+pub fn provider(name, overrides = nil) -> OAuthProvider {
+  let key = lowercase(trim(to_string(name ?? "")))
+  if key == "github" {
+    return github(overrides)
+  }
+  if key == "slack" {
+    return slack(overrides)
+  }
+  if key == "linear" {
+    return linear(overrides)
+  }
+  if key == "notion" {
+    return notion(overrides)
+  }
+  if key == "google" {
+    return google(overrides)
+  }
+  if key == "microsoft" {
+    return microsoft(overrides)
+  }
+  if key == "atlassian" {
+    return atlassian(overrides)
+  }
+  if key == "discord" {
+    return discord(overrides)
+  }
+  if key == "gitlab" {
+    return gitlab(overrides)
+  }
+  if key == "bitbucket" {
+    return bitbucket(overrides)
+  }
+  throw "std/oauth/providers: unknown provider `" + key + "`"
+}
+
+/**
+ * provider_catalog returns the ten named provider records, with per-provider overrides.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: [invalid_argument]
+ * @api_stability: experimental
+ * @example: provider_catalog({github: {default_scopes: ["read:user"]}})
+ */
+pub fn provider_catalog(overrides = nil) {
+  var out = {}
+  for name in provider_names() {
+    out = out + {[name]: provider(name, overrides?[name])}
+  }
+  return out
+}
+
+/**
+ * providers returns the issue-style provider namespace: ten static records plus
+ * github_enterprise(base_url, overrides?) and custom(config, overrides?) factories.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: [invalid_argument]
+ * @api_stability: experimental
+ * @example: providers().github_enterprise("https://ghe.example.com")
+ */
+pub fn providers(overrides = nil) {
+  return provider_catalog(overrides)
+    + {
+    github_enterprise: { base_url, factory_overrides = nil -> github_enterprise(base_url, factory_overrides) },
+    custom: { config, factory_overrides = nil -> custom(config, factory_overrides) },
+  }
+}
+
+/**
+ * custom builds an OAuth provider record for enterprise or niche providers.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: [invalid_argument]
+ * @api_stability: experimental
+ * @example: custom({id: "acme", auth_url: "https://idp.example/authorize", token_url: "https://idp.example/token"})
+ */
+pub fn custom(config, overrides = nil) -> OAuthProvider {
+  if type_of(config) != "dict" {
+    throw "std/oauth/providers: custom config must be a dict"
+  }
+  let id = trim(to_string(config?.id ?? config?.name ?? "custom"))
+  if id == "" {
+    throw "std/oauth/providers: custom id is required"
+  }
+  return __with_overrides(
+    {
+      id: id,
+      label: to_string(config?.label ?? id),
+      auth_url: __require_url(config?.auth_url, "custom auth_url"),
+      token_url: __require_url(config?.token_url, "custom token_url"),
+      device_code_url: config?.device_code_url,
+      revoke_url: config?.revoke_url,
+      userinfo_url: config?.userinfo_url,
+      default_scopes: config?.default_scopes ?? [],
+      pkce_required: config?.pkce_required ?? false,
+      refresh_handling: config?.refresh_handling
+        ?? __refresh(
+        "custom provider; use token response metadata and provider documentation",
+        "custom",
+        false,
+        ["Validate endpoint, scope, refresh, and revocation behavior against the provider's primary docs."],
+      ),
+      documented_quirks: config?.documented_quirks ?? [],
+      documentation_url: config?.documentation_url,
+    },
+    overrides,
+  )
+}

--- a/docs/src/modules.md
+++ b/docs/src/modules.md
@@ -117,6 +117,7 @@ import "std/llm/budget"
 import "std/llm/prompts"
 import "std/math"
 import "std/monitors"
+import "std/oauth/providers"
 import "std/path"
 import "std/personas/bulletins"
 import "std/personas/prelude"
@@ -150,6 +151,19 @@ Connector package helpers for common provider plumbing:
 | `oauth2_token_refresh(client_id, client_secret, refresh_token, token_url, options?)` | Refresh an OAuth2 access token with form-encoded `grant_type=refresh_token` |
 | `rate_limit_token_bucket(state?, config?, now_ms?)` | Pure token-bucket transition for package-local quota decisions |
 | `paginate_cursor(initial_url, fetch_fn, cursor_path, options?)` | Collect cursor-paginated pages from a package-supplied fetch closure |
+
+### std/oauth/providers
+
+Static OAuth provider records and factory helpers for auth orchestration:
+
+| Function | Description |
+|---|---|
+| `provider_names()` | Return the ten named provider keys |
+| `provider(name, overrides?)` | Return one provider record with optional endpoint/scope overrides |
+| `provider_catalog(overrides?)` | Return all ten provider records, with optional per-provider overrides |
+| `providers(overrides?)` | Return a namespace containing the ten records plus `github_enterprise` and `custom` factories |
+| `github_enterprise(base_url, overrides?)` | Build a GitHub Enterprise Server record from an instance web base URL |
+| `custom(config, overrides?)` | Build a provider record for enterprise or niche OAuth providers |
 
 ### std/triage
 


### PR DESCRIPTION
## Summary

Closes #1905.

Adds `std/oauth/providers`, with ten built-in OAuth provider records plus `github_enterprise(...)` and `custom(...)` factories. The records include endpoint fields, default scopes, PKCE requirements, refresh handling metadata, documented quirks, and override-friendly construction for enterprise/self-hosted variants.

The conformance fixture now exercises every named provider through deterministic mock OAuth endpoints: authorization-code token exchange, userinfo, and revoke calls all complete against `http_mock` using per-provider overrides.

## Validation

- `/tmp/harn-target-1905-oauth-providers/debug/harn fmt --check crates/harn-stdlib/src/stdlib/oauth/providers.harn conformance/tests/stdlib/oauth_provider_catalog.harn`
- `/tmp/harn-target-1905-oauth-providers/debug/harn check crates/harn-stdlib/src/stdlib/oauth/providers.harn`
- `/tmp/harn-target-1905-oauth-providers/debug/harn lint crates/harn-stdlib/src/stdlib/oauth/providers.harn`
- `/tmp/harn-target-1905-oauth-providers/debug/harn check conformance/tests/stdlib/oauth_provider_catalog.harn`
- `/tmp/harn-target-1905-oauth-providers/debug/harn lint conformance/tests/stdlib/oauth_provider_catalog.harn`
- `HARN_LLM_CALLS_DISABLED=1 /tmp/harn-target-1905-oauth-providers/debug/harn test conformance --filter oauth_provider_catalog`
- `CARGO_TARGET_DIR=/tmp/harn-target-1905-oauth-providers CARGO_INCREMENTAL=1 cargo test -p harn-stdlib -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-1905-oauth-providers CARGO_INCREMENTAL=1 make lint-harn`
- `CARGO_TARGET_DIR=/tmp/harn-target-1905-oauth-providers CARGO_INCREMENTAL=1 cargo test -p harn-cli commands::dump_highlight_keywords::tests::committed_keyword_file_matches_generator -- --nocapture`
- `make lint-test-patterns`
- `cargo fmt --check --package harn-stdlib`
- `git diff --check`
