### PR TITLE
Tighten diagnostic-code epic polish (#1745)

### DIFF
--- a/crates/harn-lsp/src/helpers.rs
+++ b/crates/harn-lsp/src/helpers.rs
@@ -1,5 +1,7 @@
+use std::str::FromStr;
+
 use harn_lexer::{LexerError, Span};
-use harn_parser::{diagnostic, ParserError, Repair, TypeExpr};
+use harn_parser::{diagnostic, ParserError, Repair, RepairSafety, TypeExpr};
 use serde_json::{Map, Value};
 use tower_lsp::lsp_types::*;
 
@@ -55,7 +57,7 @@ pub(crate) fn diagnostic_data_value(
 
 pub(crate) fn repair_code_action_kind(repair: Option<&Repair>) -> CodeActionKind {
     repair
-        .map(|repair| repair_code_action_kind_for_safety(repair.safety.as_str()))
+        .map(|repair| code_action_kind_for_safety(repair.safety))
         .unwrap_or(CodeActionKind::QUICKFIX)
 }
 
@@ -77,7 +79,8 @@ pub(crate) fn diagnostic_repair_code_action_kind(diagnostic: &Diagnostic) -> Cod
         .as_ref()
         .and_then(|data| data.get("safety"))
         .and_then(|value| value.as_str())
-        .map(repair_code_action_kind_for_safety)
+        .and_then(|safety| RepairSafety::from_str(safety).ok())
+        .map(code_action_kind_for_safety)
         .unwrap_or(CodeActionKind::QUICKFIX)
 }
 
@@ -102,16 +105,22 @@ fn diagnostic_code_string(code: Option<&NumberOrString>) -> Option<String> {
     }
 }
 
-fn repair_code_action_kind_for_safety(safety: &str) -> CodeActionKind {
-    match safety {
-        "format-only" => CodeActionKind::new("quickfix.harn.format-only"),
-        "behavior-preserving" => CodeActionKind::new("quickfix.harn.behavior-preserving"),
-        "scope-local" => CodeActionKind::new("quickfix.harn.scope-local"),
-        "surface-changing" => CodeActionKind::new("quickfix.harn.surface-changing"),
-        "capability-changing" => CodeActionKind::new("quickfix.harn.capability-changing"),
-        "needs-human" => CodeActionKind::new("quickfix.harn.needs-human"),
-        _ => CodeActionKind::QUICKFIX,
-    }
+/// Map a [`RepairSafety`] to its `quickfix.harn.<class>` code-action kind.
+///
+/// The string suffix matches `RepairSafety::as_str()` so IDE clients that
+/// register handlers by safety class observe the same wire-format value
+/// they consume from `Diagnostic.data.safety`. `RepairSafety::as_str()`
+/// returns a stable `&'static str` so the kind constants below avoid an
+/// allocation on the diagnostic hot path.
+fn code_action_kind_for_safety(safety: RepairSafety) -> CodeActionKind {
+    CodeActionKind::new(match safety {
+        RepairSafety::FormatOnly => "quickfix.harn.format-only",
+        RepairSafety::BehaviorPreserving => "quickfix.harn.behavior-preserving",
+        RepairSafety::ScopeLocal => "quickfix.harn.scope-local",
+        RepairSafety::SurfaceChanging => "quickfix.harn.surface-changing",
+        RepairSafety::CapabilityChanging => "quickfix.harn.capability-changing",
+        RepairSafety::NeedsHuman => "quickfix.harn.needs-human",
+    })
 }
 
 /// Convert a 1-based Span to a 0-based LSP Range.

--- a/crates/harn-parser/src/diagnostic_codes.rs
+++ b/crates/harn-parser/src/diagnostic_codes.rs
@@ -1014,6 +1014,7 @@ pub const REPAIR_REGISTRY: &[&RepairTemplate] = &[
     &REPAIR_BINDINGS_RENAME_SHADOW,
     &REPAIR_BINDINGS_THREAD_HARNESS,
     &REPAIR_BINDINGS_THREAD_HARNESS_CLOCK,
+    &REPAIR_BINDINGS_THREAD_HARNESS_STDIO,
     &REPAIR_DECLARATIONS_REMOVE_UNUSED,
     &REPAIR_IMPORTS_FIX_PATH,
     &REPAIR_IMPORTS_REMOVE_UNUSED,
@@ -1301,6 +1302,23 @@ mod tests {
                 referenced.contains(template.id),
                 "repair {} is in REPAIR_REGISTRY but no Code maps to it",
                 template.id
+            );
+        }
+    }
+
+    #[test]
+    fn every_referenced_repair_template_is_in_registry() {
+        let registered: HashSet<&'static str> =
+            REPAIR_REGISTRY.iter().map(|template| template.id).collect();
+        for code in Code::ALL {
+            let Some(template) = code.repair_template() else {
+                continue;
+            };
+            assert!(
+                registered.contains(template.id),
+                "repair {} (used by {}) is missing from REPAIR_REGISTRY",
+                template.id,
+                code
             );
         }
     }


### PR DESCRIPTION
## Summary

Two follow-up polish items closing out epic #1745 (HARN-XXX-NNN diagnostic codes + repair-id contract):

- **`REPAIR_REGISTRY` parity fix.** `REPAIR_BINDINGS_THREAD_HARNESS_STDIO` was referenced by `Code::LintAmbientStdioBuiltin` (HARN-LNT-053) but missing from the `REPAIR_REGISTRY` array. The catalog generator iterates `Code::repair_template()` per code, so the wire output was unaffected — but the registry was lying about its own coverage. Add the missing entry, and add an `every_referenced_repair_template_is_in_registry` test as the inverse of the existing `every_registered_repair_is_referenced_by_some_code` check. Future drift in either direction now fails the parser test suite.
- **LSP safety→code-action-kind mapping.** `repair_code_action_kind_for_safety(&str)` was matching on stringified `RepairSafety` wire values with a `_ => QUICKFIX` fallback, so a new safety class would silently fall through without a per-class kind. Switch to enum dispatch on `RepairSafety`; the deserialised `Diagnostic.data.safety` path now parses through `RepairSafety::from_str` first. Compile-time exhaustiveness keeps the single source of truth for the `quickfix.harn.<class>` mapping.

Parent epic: #1745 (all 7 in-repo children + 2 cross-repo children already closed).

## Test plan

- [x] `cargo test -p harn-parser diagnostic_codes` (14 tests, including the new parity test)
- [x] `cargo test -p harn-lsp` (38 tests pass; existing `repair_quickfix_actions_carry_safety_kind_and_flat_data` covers the LSP refactor)
- [x] `cargo test -p harn-cli` (full crate green)
- [x] `make check-diagnostics-catalog` (no drift — catalog generator output is unchanged)
- [x] `make lint-diagnostic-codes` (static code-registry checks pass)
- [x] `cargo fmt --check`, pre-commit + pre-push hooks pass (clippy, formatting, drift gates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)