### PR TITLE
Add `harn run <bundle.harnpack>` verify/replay/execute (#1784)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,22 @@ condensed series summaries instead of full per-patch history.
   resolves to the persisted JSONL for any session that opts into the
   local sink. Cloud-only sinks omit the URI (nothing wrote to disk).
   Closes #1693.
+- **`harn run <bundle.harnpack>` verify + replay + execute (#1784).**
+  Closes the `.harnpack` epic (#1779) by wiring the `harn run` command
+  to accept a signed content-addressed bundle. Detection is by
+  `.harnpack` extension or zstd magic header; the runner verifies the
+  embedded Ed25519 signature through the OpenTrustGraph trust store,
+  re-derives the bundle hash, checks `harn_version` compatibility
+  (patch mismatch warns, minor/major refuses), replays the archive into
+  `$HARN_CACHE_DIR/packs/<bundle_hash>/` (atomic, so concurrent runs
+  share a cache slot), and executes the manifest entrypoint with
+  `Harness::real()`. Unsigned bundles are refused by default; pass
+  `--allow-unsigned` to override (intended for local development).
+  `--dry-run-verify` performs verification and replay without executing,
+  useful for deployment gates. A new `pack_run` event flows through the
+  `harn run --json` NDJSON stream carrying the bundle hash, signature
+  outcome, signing key id, cache-hit status, and dry-run flag so agents
+  can audit pack execution without rereading the archive.
 - **Transcript reminder transforms (#1817).** Adds
   `transcript.inject_reminder(transcript, options)` and
   `transcript.clear_reminders(transcript, selector)` over pending

--- a/crates/harn-cli/src/cli/run.rs
+++ b/crates/harn-cli/src/cli/run.rs
@@ -64,6 +64,18 @@ pub(crate) struct RunArgs {
     /// See `docs/src/cli/run-json.md`.
     #[arg(long = "json", action = clap::ArgAction::SetTrue)]
     pub json: bool,
+    /// When running a `.harnpack`, accept bundles that carry no Ed25519
+    /// signature. The default refuses unsigned packs so a missing
+    /// signature can't be silently glossed over. Only meaningful for
+    /// `.harnpack` inputs; ignored for `.harn` sources.
+    #[arg(long = "allow-unsigned", action = clap::ArgAction::SetTrue)]
+    pub allow_unsigned: bool,
+    /// Verify the embedded signature and replay a `.harnpack` into the
+    /// content-addressed cache without executing the entrypoint. Exits
+    /// 0 on verify success, 1 on signature failure. Only meaningful
+    /// for `.harnpack` inputs.
+    #[arg(long = "dry-run-verify", action = clap::ArgAction::SetTrue)]
+    pub dry_run_verify: bool,
     /// Suppress `stdout` / `stderr` events when `--json` is active.
     /// Transcript, tool, hook, persona-stage, and the final result
     /// events still flow.

--- a/crates/harn-cli/src/commands/run.rs
+++ b/crates/harn-cli/src/commands/run.rs
@@ -20,8 +20,10 @@ use crate::skill_loader::{
 };
 
 mod explain_cost;
+pub mod harnpack;
 pub mod json_events;
 
+use self::harnpack::{HarnpackError, HarnpackRunOptions, PreparedHarnpack};
 use self::json_events::NdjsonEmitter;
 
 /// JSON event-stream configuration for `--json` runs.
@@ -389,6 +391,7 @@ struct ExecuteRunInputs<'a> {
     interrupt_tokens: Option<RunInterruptTokens>,
     json: Option<(RunJsonOptions, Box<dyn io::Write + Send>)>,
     timing: Option<&'a mut RunTiming>,
+    harnpack: HarnpackRunOptions,
 }
 
 /// Captured outcome of an in-process `execute_run` invocation. Tests use this
@@ -464,6 +467,7 @@ pub(crate) async fn run_file(
         attestation,
         profile,
         None,
+        HarnpackRunOptions::default(),
     )
     .await;
 }
@@ -492,6 +496,7 @@ pub(crate) async fn run_file_with_skill_dirs(
     attestation: Option<RunAttestationOptions>,
     profile: RunProfileOptions,
     json: Option<RunJsonOptions>,
+    harnpack: HarnpackRunOptions,
 ) {
     // Graceful shutdown: flush run records before exit on SIGINT/SIGTERM.
     let interrupt_tokens = install_signal_shutdown_handler();
@@ -511,6 +516,7 @@ pub(crate) async fn run_file_with_skill_dirs(
         interrupt_tokens: Some(interrupt_tokens.clone()),
         json: json_with_stdout,
         timing: None,
+        harnpack,
     })
     .await;
 
@@ -662,6 +668,36 @@ pub async fn execute_run(
     attestation: Option<RunAttestationOptions>,
     profile: RunProfileOptions,
 ) -> RunOutcome {
+    execute_run_with_harnpack_options(
+        path,
+        trace,
+        denied_builtins,
+        script_argv,
+        skill_dirs_raw,
+        llm_mock_mode,
+        attestation,
+        profile,
+        HarnpackRunOptions::default(),
+    )
+    .await
+}
+
+/// [`execute_run`] for callers that want to opt-in to the `.harnpack`
+/// verify-replay-execute path. Used by `harn run <bundle.harnpack>`
+/// integration tests and by the binary entry once it has parsed the
+/// `--allow-unsigned` / `--dry-run-verify` flags.
+#[allow(clippy::too_many_arguments)]
+pub async fn execute_run_with_harnpack_options(
+    path: &str,
+    trace: bool,
+    denied_builtins: HashSet<String>,
+    script_argv: Vec<String>,
+    skill_dirs_raw: Vec<String>,
+    llm_mock_mode: CliLlmMockMode,
+    attestation: Option<RunAttestationOptions>,
+    profile: RunProfileOptions,
+    harnpack: HarnpackRunOptions,
+) -> RunOutcome {
     execute_run_inner(ExecuteRunInputs {
         path,
         trace,
@@ -674,6 +710,7 @@ pub async fn execute_run(
         interrupt_tokens: None,
         json: None,
         timing: None,
+        harnpack,
     })
     .await
 }
@@ -708,6 +745,7 @@ pub async fn execute_run_json(
         interrupt_tokens: None,
         json: Some((options, out)),
         timing: None,
+        harnpack: HarnpackRunOptions::default(),
     })
     .await
 }
@@ -732,6 +770,7 @@ pub(crate) async fn execute_run_with_timing(
         interrupt_tokens: None,
         json: None,
         timing,
+        harnpack: HarnpackRunOptions::default(),
     })
     .await
 }
@@ -752,6 +791,7 @@ async fn execute_run_inner(inputs: ExecuteRunInputs<'_>) -> RunOutcome {
         interrupt_tokens,
         json,
         mut timing,
+        harnpack,
     } = inputs;
 
     // `--json` installs an in-process sink that diverts every
@@ -764,8 +804,34 @@ async fn execute_run_inner(inputs: ExecuteRunInputs<'_>) -> RunOutcome {
     let mut stderr = String::new();
     let mut stdout = String::new();
 
+    // `.harnpack` preflight: verify signature + replay archive into the
+    // content-addressed cache before we touch the chunk loader. The
+    // outcome path (entrypoint inside the unpacked tree) replaces the
+    // CLI-supplied `path` for everything below.
+    let owned_run_path: String;
+    let resolved_path: &str = if harnpack::looks_like_harnpack(Path::new(path)) {
+        let outcome = match harnpack::prepare_harnpack(Path::new(path), &harnpack, &mut stderr) {
+            Ok(prepared) => prepared,
+            Err(err) => return finalize_harnpack_error(stderr, json_session, err),
+        };
+        harn_vm::run_events::emit(harn_vm::run_events::RunEvent::PackRun {
+            bundle_hash: outcome.bundle_hash.clone(),
+            signature_verified: outcome.signature_verified,
+            key_id: outcome.key_id.clone(),
+            cache_hit: outcome.cache_hit,
+            dry_run_verify: harnpack.dry_run_verify,
+        });
+        if harnpack.dry_run_verify {
+            return finalize_harnpack_dry_run(stderr, json_session, &outcome);
+        }
+        owned_run_path = outcome.entrypoint_path.to_string_lossy().into_owned();
+        owned_run_path.as_str()
+    } else {
+        path
+    };
+
     let Some(LoadedChunk { source, chunk }) =
-        compile_or_load_chunk_with_timing(path, &mut stderr, timing.as_deref_mut())
+        compile_or_load_chunk_with_timing(resolved_path, &mut stderr, timing.as_deref_mut())
     else {
         if let Some(session) = json_session {
             return session.finalize_error("compile_error", stderr, 1);
@@ -776,6 +842,7 @@ async fn execute_run_inner(inputs: ExecuteRunInputs<'_>) -> RunOutcome {
             exit_code: 1,
         };
     };
+    let path = resolved_path;
 
     // Bracket the VM-setup phase explicitly. `run_setup` covers
     // everything between the bytecode compile and the first VM
@@ -1214,6 +1281,57 @@ impl Drop for JsonRunSession {
             }
             None => harn_vm::run_events::clear_sink(),
         }
+    }
+}
+
+/// Translate a preflight failure into either the `--json` error event
+/// stream or a plain stderr message plus exit-code 1. Keeps the
+/// `.harnpack` verify path's error reporting consistent with the rest
+/// of `harn run`.
+fn finalize_harnpack_error(
+    mut stderr: String,
+    json_session: Option<JsonRunSession>,
+    err: HarnpackError,
+) -> RunOutcome {
+    stderr.push_str(&format!("error: {}\n", err.message));
+    if let Some(session) = json_session {
+        return session.finalize_error(err.code, err.message, 1);
+    }
+    RunOutcome {
+        stdout: String::new(),
+        stderr,
+        exit_code: 1,
+    }
+}
+
+/// Successful `--dry-run-verify` path. Reports the bundle hash and
+/// signature outcome on stderr (since stdout belongs to the script) and
+/// emits a terminal `result` event when `--json` is active so consumers
+/// see the run complete.
+fn finalize_harnpack_dry_run(
+    mut stderr: String,
+    json_session: Option<JsonRunSession>,
+    prepared: &PreparedHarnpack,
+) -> RunOutcome {
+    let summary = format!(
+        "[harn] harnpack verify ok: bundle_hash={}, signature_verified={}, cache_hit={}\n",
+        prepared.bundle_hash, prepared.signature_verified, prepared.cache_hit
+    );
+    stderr.push_str(&summary);
+    if let Some(session) = json_session {
+        let value = serde_json::json!({
+            "bundle_hash": prepared.bundle_hash,
+            "signature_verified": prepared.signature_verified,
+            "key_id": prepared.key_id,
+            "cache_hit": prepared.cache_hit,
+            "dry_run_verify": true,
+        });
+        return session.finalize_result(value, 0);
+    }
+    RunOutcome {
+        stdout: String::new(),
+        stderr,
+        exit_code: 0,
     }
 }
 

--- a/crates/harn-cli/src/commands/run/harnpack.rs
+++ b/crates/harn-cli/src/commands/run/harnpack.rs
@@ -1,0 +1,396 @@
+//! `harn run <bundle.harnpack>` — verify the embedded OpenTrustGraph
+//! signature, replay the archive into the content-addressed pack cache,
+//! and execute the bundled entrypoint.
+//!
+//! See issue #1784 (epic #1779). The verify path reuses the helpers
+//! shipped with E6.1/E6.3 (`workflow_bundle.rs`) so signing and
+//! verification share the same canonical-hash code path.
+
+use std::fmt::Write;
+use std::fs;
+use std::io;
+use std::path::{Component, Path, PathBuf};
+
+use harn_vm::bytecode_cache;
+use harn_vm::orchestration::{
+    read_harnpack, verify_workflow_bundle_signature, workflow_bundle_hash, HarnpackEntry,
+    WorkflowBundle, WorkflowBundleError,
+};
+
+/// Zstandard magic prefix. `.harnpack` archives are zstd-compressed tar
+/// streams, so the on-disk byte signature is the zstd frame header.
+const ZSTD_MAGIC: &[u8; 4] = &[0x28, 0xb5, 0x2f, 0xfd];
+
+/// Options for [`prepare_harnpack`].
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct HarnpackRunOptions {
+    /// Run the pack even when it carries no Ed25519 signature.
+    pub allow_unsigned: bool,
+    /// Verify-only mode: stop after the cache replay and emit a
+    /// `pack_run` event without executing the entrypoint.
+    pub dry_run_verify: bool,
+}
+
+/// Outcome of [`prepare_harnpack`]. The CLI surface uses this to (a)
+/// emit the `pack_run` event before the run starts, (b) decide whether
+/// to short-circuit on `--dry-run-verify`, and (c) hand off the unpacked
+/// entrypoint path to the existing source-execution code path.
+#[derive(Debug)]
+pub struct PreparedHarnpack {
+    pub bundle_hash: String,
+    pub signature_verified: bool,
+    pub key_id: Option<String>,
+    pub cache_hit: bool,
+    pub cache_dir: PathBuf,
+    pub entrypoint_path: PathBuf,
+    pub manifest: WorkflowBundle,
+}
+
+#[derive(Debug)]
+pub struct HarnpackError {
+    pub code: &'static str,
+    pub message: String,
+}
+
+impl HarnpackError {
+    fn new(code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for HarnpackError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for HarnpackError {}
+
+impl From<WorkflowBundleError> for HarnpackError {
+    fn from(error: WorkflowBundleError) -> Self {
+        Self::new("harnpack.archive", error.message)
+    }
+}
+
+/// Detect whether `path` references a `.harnpack` bundle by extension
+/// or zstd magic header. The magic-header path keeps detection robust
+/// for renamed bundles (`./bundle` without extension) which is the
+/// failure mode that bit us when users curl bundles without `-o`.
+pub fn looks_like_harnpack(path: &Path) -> bool {
+    if path.extension().and_then(|ext| ext.to_str()) == Some("harnpack") {
+        return true;
+    }
+    match fs::File::open(path) {
+        Ok(mut file) => {
+            use std::io::Read;
+            let mut buf = [0u8; 4];
+            file.read_exact(&mut buf).is_ok() && &buf == ZSTD_MAGIC
+        }
+        Err(_) => false,
+    }
+}
+
+/// Verify the bundle at `path`, replay it into the content-addressed
+/// pack cache, and return the unpacked entrypoint to execute.
+///
+/// Errors map to user-facing exit-code-1 messages on the CLI; the
+/// [`HarnpackError::code`] discriminates failure modes for JSON
+/// callers and tests.
+pub fn prepare_harnpack<W: Write>(
+    path: &Path,
+    options: &HarnpackRunOptions,
+    stderr: &mut W,
+) -> Result<PreparedHarnpack, HarnpackError> {
+    let bytes = fs::read(path).map_err(|err| {
+        HarnpackError::new(
+            "harnpack.read_failed",
+            format!("failed to read {}: {err}", path.display()),
+        )
+    })?;
+    let archive = read_harnpack(&bytes)?;
+    let manifest = archive.manifest;
+    let contents = archive.contents;
+
+    let (signature_verified, key_id) = match manifest.signature.as_ref() {
+        Some(signature) => {
+            verify_workflow_bundle_signature(&manifest, &contents)?;
+            (true, signature.key_id.clone())
+        }
+        None => {
+            if !options.allow_unsigned {
+                return Err(HarnpackError::new(
+                    "harnpack.unsigned",
+                    format!(
+                        "refusing to run unsigned bundle {} \
+                         (re-run with --allow-unsigned to override)",
+                        path.display()
+                    ),
+                ));
+            }
+            (false, None)
+        }
+    };
+
+    check_harn_version_compat(&manifest.harn_version, stderr)?;
+    let bundle_hash = workflow_bundle_hash(&manifest, &contents)?;
+    let cache_dir = bytecode_cache::packs_cache_dir().join(sanitize_bundle_hash(&bundle_hash));
+    let cache_hit = manifest_already_replayed(&cache_dir, &manifest)?;
+    if !cache_hit {
+        replay_archive(&cache_dir, &manifest, &contents)?;
+    }
+
+    let entrypoint_path = cache_dir.join("sources").join(&manifest.entrypoint);
+    if !entrypoint_path.exists() {
+        return Err(HarnpackError::new(
+            "harnpack.missing_entrypoint",
+            format!(
+                "manifest entrypoint {} not present in unpacked bundle at {}",
+                manifest.entrypoint.display(),
+                entrypoint_path.display()
+            ),
+        ));
+    }
+
+    Ok(PreparedHarnpack {
+        bundle_hash,
+        signature_verified,
+        key_id,
+        cache_hit,
+        cache_dir,
+        entrypoint_path,
+        manifest,
+    })
+}
+
+/// Translate a `blake3:<hex>` digest into a filename-safe directory
+/// component. `:` is illegal in some path layers (Windows, `tar`
+/// member names), so swap it for `_` while keeping the algorithm
+/// prefix for forensic readability.
+fn sanitize_bundle_hash(hash: &str) -> String {
+    hash.replace(':', "_")
+}
+
+/// `harn_version` compatibility check: refuse on a major or minor
+/// mismatch, warn on a patch mismatch. The contract is documented on
+/// issue #1784.
+fn check_harn_version_compat<W: Write>(
+    bundle_version: &str,
+    stderr: &mut W,
+) -> Result<(), HarnpackError> {
+    let current_version = env!("CARGO_PKG_VERSION");
+    if bundle_version == current_version {
+        return Ok(());
+    }
+    let (Some(bundle), Some(current)) = (
+        parse_semver_triplet(bundle_version),
+        parse_semver_triplet(current_version),
+    ) else {
+        let _ = writeln!(
+            stderr,
+            "warning: harnpack harn_version {bundle_version} is not parseable; running anyway"
+        );
+        return Ok(());
+    };
+    if bundle.0 != current.0 || bundle.1 != current.1 {
+        return Err(HarnpackError::new(
+            "harnpack.version_mismatch",
+            format!(
+                "harnpack was built for harn {bundle_version}; \
+                 this runtime is {current_version} (major/minor mismatch refused)"
+            ),
+        ));
+    }
+    let _ = writeln!(
+        stderr,
+        "warning: harnpack was built for harn {bundle_version}; \
+         this runtime is {current_version} (patch mismatch)"
+    );
+    Ok(())
+}
+
+/// Parse the `major.minor.patch` triplet from a version string,
+/// ignoring any pre-release or build metadata. Returns `None` when the
+/// string can't be parsed as `<u32>.<u32>.<u32>` at the front — callers
+/// fall back to a permissive warning so unusual version pins don't
+/// strand a working bundle.
+fn parse_semver_triplet(input: &str) -> Option<(u32, u32, u32)> {
+    let core = input.split_once('-').map(|(head, _)| head).unwrap_or(input);
+    let core = core.split_once('+').map(|(head, _)| head).unwrap_or(core);
+    let mut parts = core.split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next()?.parse().ok()?;
+    let patch = parts.next()?.parse().ok()?;
+    Some((major, minor, patch))
+}
+
+/// Returns true when `cache_dir` already holds a previously-replayed
+/// archive whose `harnpack.json` matches `manifest`. Content addressing
+/// (`bundle_hash` in the directory name) makes a single positive match
+/// sufficient; we still cross-check the manifest payload to defend
+/// against partial writes from a prior crash.
+fn manifest_already_replayed(
+    cache_dir: &Path,
+    manifest: &WorkflowBundle,
+) -> Result<bool, HarnpackError> {
+    let manifest_path = cache_dir.join("harnpack.json");
+    let Ok(bytes) = fs::read(&manifest_path) else {
+        return Ok(false);
+    };
+    let cached: WorkflowBundle = match serde_json::from_slice(&bytes) {
+        Ok(value) => value,
+        Err(_) => return Ok(false),
+    };
+    Ok(&cached == manifest)
+}
+
+/// Unpack the bundle into a fresh staging directory and then rename
+/// into the content-addressed cache slot atomically. The intermediate
+/// directory keeps a crash mid-extract from leaving a half-populated
+/// `<bundle_hash>/` that future runs would mistake for a cache hit.
+fn replay_archive(
+    cache_dir: &Path,
+    manifest: &WorkflowBundle,
+    contents: &[HarnpackEntry],
+) -> Result<(), HarnpackError> {
+    let parent = cache_dir.parent().ok_or_else(|| {
+        HarnpackError::new(
+            "harnpack.replay_failed",
+            format!("pack cache path has no parent: {}", cache_dir.display()),
+        )
+    })?;
+    fs::create_dir_all(parent).map_err(|err| io_err("harnpack.replay_failed", err, parent))?;
+    let staging = tempfile::Builder::new()
+        .prefix(".staging-")
+        .tempdir_in(parent)
+        .map_err(|err| io_err("harnpack.replay_failed", err, parent))?;
+    let staging_path = staging.path().to_path_buf();
+
+    for entry in contents {
+        let dest = join_safe(&staging_path, &entry.path)?;
+        if let Some(parent) = dest.parent() {
+            fs::create_dir_all(parent)
+                .map_err(|err| io_err("harnpack.replay_failed", err, parent))?;
+        }
+        fs::write(&dest, &entry.bytes)
+            .map_err(|err| io_err("harnpack.replay_failed", err, &dest))?;
+    }
+
+    let manifest_bytes = serde_json::to_vec(manifest).map_err(|err| {
+        HarnpackError::new(
+            "harnpack.replay_failed",
+            format!("failed to encode manifest for cache: {err}"),
+        )
+    })?;
+    let manifest_path = staging_path.join("harnpack.json");
+    fs::write(&manifest_path, &manifest_bytes)
+        .map_err(|err| io_err("harnpack.replay_failed", err, &manifest_path))?;
+
+    // `rename` is atomic on the same filesystem. Two concurrent runs
+    // unpacking the same bundle hash will both attempt the rename;
+    // whichever loses sees the destination already present and treats
+    // it as authoritative (content addressing guarantees equivalence).
+    // `TempDir::into_path()` defuses the auto-cleanup so the rename
+    // owns the directory.
+    let staged = staging.keep();
+    match fs::rename(&staged, cache_dir) {
+        Ok(()) => Ok(()),
+        Err(err) if cache_dir.join("harnpack.json").exists() => {
+            let _ = fs::remove_dir_all(&staged);
+            // The other writer's tree is now in place — pretend we won.
+            let _ = err;
+            Ok(())
+        }
+        Err(err) => {
+            let _ = fs::remove_dir_all(&staged);
+            Err(io_err("harnpack.replay_failed", err, cache_dir))
+        }
+    }
+}
+
+fn io_err(code: &'static str, err: io::Error, path: &Path) -> HarnpackError {
+    HarnpackError::new(code, format!("{}: {err}", path.display()))
+}
+
+/// Join an archive-relative path onto `base` while refusing anything
+/// that would escape via `..` or absolute components. `read_harnpack`
+/// already rejects unsafe entries at archive parse time; this is
+/// belt-and-braces defense for paths we synthesize on the host side.
+fn join_safe(base: &Path, rel: &Path) -> Result<PathBuf, HarnpackError> {
+    let mut out = base.to_path_buf();
+    for component in rel.components() {
+        match component {
+            Component::Normal(part) => out.push(part),
+            Component::CurDir => {}
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                return Err(HarnpackError::new(
+                    "harnpack.unsafe_path",
+                    format!("refusing to unpack unsafe path: {}", rel.display()),
+                ));
+            }
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn semver_triplet_parses_release_versions() {
+        assert_eq!(parse_semver_triplet("1.2.3"), Some((1, 2, 3)));
+        assert_eq!(parse_semver_triplet("0.10.42"), Some((0, 10, 42)));
+        assert_eq!(parse_semver_triplet("1.2.3-rc.1"), Some((1, 2, 3)));
+        assert_eq!(parse_semver_triplet("1.2.3+build.4"), Some((1, 2, 3)));
+        assert_eq!(parse_semver_triplet("garbage"), None);
+        assert_eq!(parse_semver_triplet("1.2"), None);
+    }
+
+    #[test]
+    fn sanitize_bundle_hash_replaces_colon() {
+        assert_eq!(sanitize_bundle_hash("blake3:abc"), "blake3_abc");
+        assert_eq!(sanitize_bundle_hash("nohash"), "nohash");
+    }
+
+    #[test]
+    fn check_harn_version_compat_warns_on_patch_mismatch() {
+        let current = env!("CARGO_PKG_VERSION");
+        let (major, minor, patch) = parse_semver_triplet(current).expect("current parses");
+        let other_patch = format!("{major}.{minor}.{}", patch.wrapping_add(1));
+        let mut stderr = String::new();
+        check_harn_version_compat(&other_patch, &mut stderr).expect("patch mismatch warns");
+        assert!(stderr.contains("patch mismatch"), "stderr was {stderr}");
+    }
+
+    #[test]
+    fn check_harn_version_compat_refuses_on_minor_mismatch() {
+        let current = env!("CARGO_PKG_VERSION");
+        let (major, minor, _patch) = parse_semver_triplet(current).expect("current parses");
+        let other_minor = format!("{major}.{}.0", minor.wrapping_add(1));
+        let mut stderr = String::new();
+        let err = check_harn_version_compat(&other_minor, &mut stderr)
+            .expect_err("minor mismatch must refuse");
+        assert_eq!(err.code, "harnpack.version_mismatch");
+    }
+
+    #[test]
+    fn check_harn_version_compat_is_lenient_with_unparseable_bundle_version() {
+        let mut stderr = String::new();
+        check_harn_version_compat("not-a-version", &mut stderr).expect("permissive on parse fail");
+        assert!(stderr.contains("not parseable"));
+    }
+
+    #[test]
+    fn join_safe_refuses_traversal() {
+        let base = PathBuf::from("/tmp/cache");
+        assert!(join_safe(&base, Path::new("../escape")).is_err());
+        assert!(join_safe(&base, Path::new("/abs/path")).is_err());
+        assert_eq!(
+            join_safe(&base, Path::new("sources/hello.harn")).unwrap(),
+            base.join("sources").join("hello.harn"),
+        );
+    }
+}

--- a/crates/harn-cli/src/commands/run/json_events.rs
+++ b/crates/harn-cli/src/commands/run/json_events.rs
@@ -67,6 +67,15 @@ pub enum RunEventWire {
         stage: String,
         transition: String,
     },
+    PackRun {
+        seq: u64,
+        bundle_hash: String,
+        signature_verified: bool,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        key_id: Option<String>,
+        cache_hit: bool,
+        dry_run_verify: bool,
+    },
     Result {
         seq: u64,
         value: serde_json::Value,
@@ -89,6 +98,7 @@ impl RunEventWire {
             | Self::ToolResult { seq, .. }
             | Self::Hook { seq, .. }
             | Self::PersonaStage { seq, .. }
+            | Self::PackRun { seq, .. }
             | Self::Result { seq, .. }
             | Self::Error { seq, .. } => *seq,
         }
@@ -248,6 +258,20 @@ impl RunEventSink for NdjsonSink {
                 persona,
                 stage,
                 transition,
+            },
+            RunEvent::PackRun {
+                bundle_hash,
+                signature_verified,
+                key_id,
+                cache_hit,
+                dry_run_verify,
+            } => RunEventWire::PackRun {
+                seq,
+                bundle_hash,
+                signature_verified,
+                key_id,
+                cache_hit,
+                dry_run_verify,
             },
         };
         NdjsonEmitter::write_envelope(&self.inner, wire);

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -178,9 +178,19 @@ async fn async_main() {
             let json_options = args
                 .json
                 .then_some(commands::run::RunJsonOptions { quiet: args.quiet });
+            let harnpack_options = commands::run::harnpack::HarnpackRunOptions {
+                allow_unsigned: args.allow_unsigned,
+                dry_run_verify: args.dry_run_verify,
+            };
 
             match (args.eval.as_deref(), args.file.as_deref()) {
                 (Some(code), None) => {
+                    if args.allow_unsigned || args.dry_run_verify {
+                        command_error(
+                            "`--allow-unsigned` and `--dry-run-verify` apply to `.harnpack` inputs; \
+                             they cannot be combined with `-e`",
+                        );
+                    }
                     let (wrapped, tmp) = commands::run::prepare_eval_temp_file(code)
                         .unwrap_or_else(|e| command_error(&e));
                     let tmp_path: PathBuf = tmp.path().to_path_buf();
@@ -201,6 +211,7 @@ async fn async_main() {
                             attestation.clone(),
                             profile_options.clone(),
                             json_options.clone(),
+                            harnpack_options.clone(),
                         )
                         .await;
                     }
@@ -220,6 +231,7 @@ async fn async_main() {
                             attestation,
                             profile_options,
                             json_options,
+                            harnpack_options,
                         )
                         .await
                     }

--- a/crates/harn-cli/tests/harnpack_run.rs
+++ b/crates/harn-cli/tests/harnpack_run.rs
@@ -1,0 +1,332 @@
+//! `harn run <bundle.harnpack>` end-to-end coverage (#1784).
+//!
+//! Exercises the four exit-criteria items from the issue:
+//!  - signed `.harnpack` runs end-to-end,
+//!  - unsigned bundles are rejected without `--allow-unsigned`,
+//!  - tampered bundles fail verification, and
+//!  - the content-addressed cache prevents redundant unpack on the
+//!    second run.
+
+// The async stack inside `execute_run_with_harnpack_options` is deeply
+// nested (tokio LocalSet, VM execute, persona/hook fan-out). Layout
+// monomorphization hits the default rustc query depth, so bump it for
+// this test crate.
+#![recursion_limit = "256"]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use harn_cli::cli::PackArgs;
+use harn_cli::commands::pack;
+use harn_cli::commands::run::harnpack::HarnpackRunOptions;
+use harn_cli::commands::run::{
+    execute_run_with_harnpack_options, CliLlmMockMode, RunOutcome, RunProfileOptions,
+};
+use harn_cli::tests::common::{cwd_lock, env_lock};
+use harn_vm::orchestration::{build_harnpack, read_harnpack};
+use tempfile::TempDir;
+use tokio::runtime::Builder;
+
+const TEST_ED25519_PRIVATE_KEY: &str = "-----BEGIN PRIVATE KEY-----\nMC4CAQAwBQYDK2VwBCIEIDmsNDO8iZqiMmA/b7I7lwGXNKe68o+gDno6R5riUcDC\n-----END PRIVATE KEY-----\n";
+
+struct HarnpackFixture {
+    workdir: TempDir,
+    cache_dir: PathBuf,
+    pack_path: PathBuf,
+    key_path: PathBuf,
+}
+
+impl HarnpackFixture {
+    fn new(script: &str) -> Self {
+        let workdir = TempDir::new().expect("workdir");
+        let cache_dir = workdir.path().join("cache");
+        let entry = workdir.path().join("hello.harn");
+        fs::write(&entry, script).expect("write entry");
+        let key_path = workdir.path().join("release-key.pem");
+        fs::write(&key_path, TEST_ED25519_PRIVATE_KEY).expect("write key");
+        let pack_path = workdir.path().join("hello.harnpack");
+        Self {
+            workdir,
+            cache_dir,
+            pack_path,
+            key_path,
+        }
+    }
+
+    fn pack_args(&self, sign: bool) -> PackArgs {
+        PackArgs {
+            entrypoint: self.workdir.path().join("hello.harn"),
+            out: Some(self.pack_path.clone()),
+            upgrade: None,
+            sign,
+            key: if sign {
+                Some(self.key_path.clone())
+            } else {
+                None
+            },
+            unsigned: !sign,
+            json: false,
+        }
+    }
+}
+
+fn execute(pack_path: &Path, cache_dir: &Path, options: HarnpackRunOptions) -> RunOutcome {
+    let pack_path = pack_path.to_path_buf();
+    let cache_dir = cache_dir.to_path_buf();
+    Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("tokio current-thread runtime")
+        .block_on(async move {
+            let _env = env_lock::lock_env().lock().await;
+            let _cwd = cwd_lock::lock_cwd_async().await;
+            harn_vm::reset_thread_local_state();
+            let prev_cache = std::env::var("HARN_CACHE_DIR").ok();
+            std::env::set_var("HARN_CACHE_DIR", &cache_dir);
+            let outcome = execute_run_with_harnpack_options(
+                &pack_path.to_string_lossy(),
+                false,
+                std::collections::HashSet::new(),
+                Vec::new(),
+                Vec::new(),
+                CliLlmMockMode::Off,
+                None,
+                RunProfileOptions::default(),
+                options,
+            )
+            .await;
+            match prev_cache {
+                Some(value) => std::env::set_var("HARN_CACHE_DIR", value),
+                None => std::env::remove_var("HARN_CACHE_DIR"),
+            }
+            outcome
+        })
+}
+
+fn build_pack(args: &PackArgs) -> pack::PackOutcome {
+    Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("tokio current-thread runtime")
+        .block_on(async {
+            let _cwd_guard = cwd_lock::lock_cwd_async().await;
+            harn_vm::reset_thread_local_state();
+            pack::build(args).expect("pack succeeds")
+        })
+}
+
+#[test]
+fn signed_harnpack_runs_end_to_end_and_reuses_cache() {
+    let fixture = HarnpackFixture::new("println(\"signed-pack-greeting\")\n");
+    let outcome = build_pack(&fixture.pack_args(true));
+    let sanitized_hash = outcome.bundle_hash.replace(':', "_");
+
+    let first = execute(
+        &fixture.pack_path,
+        &fixture.cache_dir,
+        HarnpackRunOptions::default(),
+    );
+    assert_eq!(
+        first.exit_code, 0,
+        "first run failed; stderr=\n{}",
+        first.stderr
+    );
+    assert!(
+        first.stdout.contains("signed-pack-greeting"),
+        "stdout should carry pipeline output; stdout=\n{}\nstderr=\n{}",
+        first.stdout,
+        first.stderr
+    );
+
+    let cache_slot = fixture
+        .cache_dir
+        .join("packs")
+        .join(&sanitized_hash)
+        .join("harnpack.json");
+    assert!(
+        cache_slot.exists(),
+        "cache slot {} should be populated after first run",
+        cache_slot.display()
+    );
+    let cached_mtime = fs::metadata(&cache_slot)
+        .and_then(|meta| meta.modified())
+        .expect("read cache mtime");
+
+    let second = execute(
+        &fixture.pack_path,
+        &fixture.cache_dir,
+        HarnpackRunOptions::default(),
+    );
+    assert_eq!(second.exit_code, 0, "second run failed: {}", second.stderr);
+    assert!(second.stdout.contains("signed-pack-greeting"));
+    let reused_mtime = fs::metadata(&cache_slot)
+        .and_then(|meta| meta.modified())
+        .expect("read cache mtime again");
+    assert_eq!(
+        cached_mtime, reused_mtime,
+        "second run must reuse the unpacked cache instead of overwriting it"
+    );
+}
+
+#[test]
+fn unsigned_harnpack_is_rejected_by_default() {
+    let fixture = HarnpackFixture::new("println(\"unsigned\")\n");
+    build_pack(&fixture.pack_args(false));
+
+    let outcome = execute(
+        &fixture.pack_path,
+        &fixture.cache_dir,
+        HarnpackRunOptions::default(),
+    );
+    assert_eq!(outcome.exit_code, 1, "unsigned should be refused");
+    assert!(
+        outcome.stderr.contains("refusing to run unsigned bundle"),
+        "stderr should explain refusal: {}",
+        outcome.stderr
+    );
+    assert!(
+        outcome.stderr.contains("--allow-unsigned"),
+        "stderr should hint at the override: {}",
+        outcome.stderr
+    );
+    assert!(
+        outcome.stdout.is_empty(),
+        "no pipeline output should be produced on refusal: {}",
+        outcome.stdout
+    );
+}
+
+#[test]
+fn unsigned_harnpack_runs_with_allow_unsigned() {
+    let fixture = HarnpackFixture::new("println(\"local-dev\")\n");
+    build_pack(&fixture.pack_args(false));
+
+    let outcome = execute(
+        &fixture.pack_path,
+        &fixture.cache_dir,
+        HarnpackRunOptions {
+            allow_unsigned: true,
+            dry_run_verify: false,
+        },
+    );
+    assert_eq!(
+        outcome.exit_code, 0,
+        "--allow-unsigned should permit running; stderr={}",
+        outcome.stderr
+    );
+    assert!(outcome.stdout.contains("local-dev"));
+}
+
+#[test]
+fn tampered_harnpack_fails_verification() {
+    let fixture = HarnpackFixture::new("println(\"original\")\n");
+    build_pack(&fixture.pack_args(true));
+
+    // Decompose + tamper + re-emit: flip a source byte without touching
+    // the embedded signature. The bundle hash will diverge, so the
+    // signature check has to fail before the pipeline ever runs.
+    let bytes = fs::read(&fixture.pack_path).unwrap();
+    let mut archive = read_harnpack(&bytes).expect("archive parses");
+    let target = archive
+        .contents
+        .iter_mut()
+        .find(|entry| entry.path == Path::new("sources/hello.harn"))
+        .expect("source entry");
+    target.bytes = b"println(\"tampered\")\n".to_vec();
+    let tampered_bytes =
+        build_harnpack(&archive.manifest, &archive.contents).expect("rebuild archive");
+    fs::write(&fixture.pack_path, &tampered_bytes).unwrap();
+
+    let outcome = execute(
+        &fixture.pack_path,
+        &fixture.cache_dir,
+        HarnpackRunOptions::default(),
+    );
+    assert_eq!(outcome.exit_code, 1, "tampered pack must refuse");
+    assert!(
+        outcome.stderr.contains("signature hash mismatch"),
+        "stderr should mention hash mismatch: {}",
+        outcome.stderr
+    );
+    assert!(
+        outcome.stdout.is_empty(),
+        "tampered pack must not run the pipeline: {}",
+        outcome.stdout
+    );
+}
+
+#[test]
+fn dry_run_verify_returns_without_executing() {
+    let fixture =
+        HarnpackFixture::new("write_file(\"side-effect.txt\", \"oops\")\nprintln(\"ran\")\n");
+    let outcome_pack = build_pack(&fixture.pack_args(true));
+    let sanitized_hash = outcome_pack.bundle_hash.replace(':', "_");
+
+    let outcome = execute(
+        &fixture.pack_path,
+        &fixture.cache_dir,
+        HarnpackRunOptions {
+            allow_unsigned: false,
+            dry_run_verify: true,
+        },
+    );
+    assert_eq!(
+        outcome.exit_code, 0,
+        "dry-run-verify on a valid pack should succeed; stderr={}",
+        outcome.stderr
+    );
+    assert!(
+        outcome.stderr.contains("harnpack verify ok"),
+        "stderr should report the verify summary: {}",
+        outcome.stderr
+    );
+    assert!(
+        outcome.stderr.contains(&outcome_pack.bundle_hash),
+        "stderr should include the bundle hash: {}",
+        outcome.stderr
+    );
+    assert!(
+        outcome.stdout.is_empty(),
+        "dry-run-verify must not run the pipeline: {}",
+        outcome.stdout
+    );
+    assert!(
+        !fixture.workdir.path().join("side-effect.txt").exists(),
+        "dry-run-verify must not execute side effects"
+    );
+
+    // Replay still populates the cache slot so a later real run is a hit.
+    let cache_slot = fixture
+        .cache_dir
+        .join("packs")
+        .join(&sanitized_hash)
+        .join("harnpack.json");
+    assert!(
+        cache_slot.exists(),
+        "dry-run-verify still replays into the content-addressed cache"
+    );
+}
+
+#[test]
+fn missing_signature_with_dry_run_still_refuses() {
+    let fixture = HarnpackFixture::new("println(\"x\")\n");
+    build_pack(&fixture.pack_args(false));
+
+    let outcome = execute(
+        &fixture.pack_path,
+        &fixture.cache_dir,
+        HarnpackRunOptions {
+            allow_unsigned: false,
+            dry_run_verify: true,
+        },
+    );
+    assert_eq!(
+        outcome.exit_code, 1,
+        "unsigned pack must still refuse even under --dry-run-verify"
+    );
+    assert!(
+        outcome.stderr.contains("refusing to run unsigned bundle"),
+        "stderr: {}",
+        outcome.stderr
+    );
+}

--- a/crates/harn-vm/src/bytecode_cache.rs
+++ b/crates/harn-vm/src/bytecode_cache.rs
@@ -155,6 +155,29 @@ pub fn cache_dir() -> PathBuf {
     PathBuf::from(".harn-cache").join("bytecode")
 }
 
+/// Root for `.harnpack` archives unpacked by `harn run <bundle.harnpack>`.
+/// Each verified bundle is replayed into `<root>/<sanitized-bundle-hash>/`
+/// so re-runs reuse the unpacked tree. Honors `$HARN_CACHE_DIR/packs`
+/// when set, otherwise XDG / `$HOME/.cache/harn/packs`.
+pub fn packs_cache_dir() -> PathBuf {
+    if let Some(custom) = std::env::var_os(CACHE_DIR_ENV) {
+        return PathBuf::from(custom).join("packs");
+    }
+    if let Some(xdg) = std::env::var_os("XDG_CACHE_HOME") {
+        let xdg = PathBuf::from(xdg);
+        if !xdg.as_os_str().is_empty() {
+            return xdg.join("harn").join("packs");
+        }
+    }
+    if let Some(home) = std::env::var_os("HOME") {
+        return PathBuf::from(home)
+            .join(".cache")
+            .join("harn")
+            .join("packs");
+    }
+    PathBuf::from(".harn-cache").join("packs")
+}
+
 /// True when the cache is enabled by the current environment.
 pub fn cache_enabled() -> bool {
     match std::env::var(CACHE_ENABLED_ENV).ok().as_deref() {

--- a/crates/harn-vm/src/run_events.rs
+++ b/crates/harn-vm/src/run_events.rs
@@ -67,6 +67,19 @@ pub enum RunEvent {
         stage: String,
         transition: String,
     },
+    /// `harn run <bundle.harnpack>` resolved a pack to execute. Carries
+    /// the verified bundle hash, whether the embedded Ed25519 signature
+    /// verified end-to-end, the signing key fingerprint (when signed),
+    /// and whether the unpacked archive came from the content-addressed
+    /// cache or was extracted fresh on this run.
+    PackRun {
+        bundle_hash: String,
+        signature_verified: bool,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        key_id: Option<String>,
+        cache_hit: bool,
+        dry_run_verify: bool,
+    },
 }
 
 /// Receiver of [`RunEvent`]s. Implementations must be cheap (the VM

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -17,6 +17,9 @@ harn run --yes <file.harn>
 harn run --explain-cost <file.harn>
 harn run --attest <file.harn>
 harn run --attest --receipt-out receipt.json <file.harn>
+harn run <bundle.harnpack>
+harn run --dry-run-verify <bundle.harnpack>
+harn run --allow-unsigned <bundle.harnpack>
 ```
 
 | Flag | Description |
@@ -34,6 +37,8 @@ harn run --attest --receipt-out receipt.json <file.harn>
 | `--attest-agent <id>` | Agent id used to load or create the Ed25519 signing key |
 | `--json` | Emit a versioned NDJSON event stream on stdout instead of mixed pipeline output |
 | `--quiet` | When `--json` is set, drop `stdout` and `stderr` events (transcript/tool/hook/persona/result still flow) |
+| `--allow-unsigned` | When running a `.harnpack`, accept bundles that carry no Ed25519 signature (local-dev override) |
+| `--dry-run-verify` | When running a `.harnpack`, verify the signature and replay into the cache without executing the entrypoint |
 
 ### `--json` event stream
 
@@ -55,6 +60,7 @@ Event types (the `event_type` discriminator lives at
 | `tool_result` | `{ call_id, ok: bool, result }` — outcome of a tool invocation. |
 | `hook` | `{ name, phase, payload? }` — session lifecycle hook fired during the run. |
 | `persona_stage` | `{ persona, stage, transition }` — persona-stage transition (`started` / `completed` / `handoff_started` / …). |
+| `pack_run` | `{ bundle_hash, signature_verified: bool, key_id?: string, cache_hit: bool, dry_run_verify: bool }` — emitted once when `harn run <bundle.harnpack>` resolves a pack to execute. |
 | `result` | `{ value, exit_code: int }` — terminal event for successful runs. |
 | `error` | `{ error: { code, message, details? } }` — terminal event when a fatal error prevents a `result`. |
 
@@ -101,6 +107,27 @@ EventLog, stamps each record with `prev_hash` and `record_hash` provenance
 headers, signs the receipt with an Ed25519 key loaded through the configured
 secret provider chain, and writes the receipt under `.harn/receipts/` unless
 `--receipt-out` is set.
+
+### Running a `.harnpack`
+
+`harn run <bundle.harnpack>` accepts a signed content-addressed bundle
+produced by `harn pack`. Detection is by `.harnpack` extension and a
+zstd magic-byte fallback so renamed bundles still resolve. The runner:
+
+1. Reads the manifest and embedded contents.
+2. Verifies the Ed25519 signature against the bundle hash through the
+   OpenTrustGraph trust store.
+3. Checks `harn_version` compatibility — patch mismatches warn, minor
+   or major mismatches refuse the run.
+4. Replays the archive into `$HARN_CACHE_DIR/packs/<bundle_hash>/`
+   atomically (the bundle hash is content-addressed, so a second run
+   reuses the unpacked tree).
+5. Executes the manifest's entrypoint with `Harness::real()`.
+
+The verifier refuses to run an unsigned bundle. Pass `--allow-unsigned`
+to opt out (intended for local-dev only). `--dry-run-verify` performs
+verification and replay but stops before execution, useful for
+deployment gates.
 
 ## harn parse
 


### PR DESCRIPTION
## Summary

- Wires `harn run` to accept a signed `.harnpack` produced by `harn pack`. Detection is by extension or zstd magic header so renamed bundles still resolve.
- Verify path reuses E6.3 helpers: re-derive the BLAKE3 bundle hash, check the embedded Ed25519 signature, refuse on signed-tamper, refuse unsigned bundles unless `--allow-unsigned`, and bail on `harn_version` major/minor mismatch (patch mismatch warns).
- Replays the archive into `$HARN_CACHE_DIR/packs/<bundle_hash>/` atomically (tempfile staging + rename), so the second run hits the cache. `--dry-run-verify` stops after replay without executing.
- Emits a new `pack_run` event through the `harn run --json` NDJSON stream carrying `bundle_hash`, `signature_verified`, `key_id`, `cache_hit`, `dry_run_verify`.
- Closes [#1784](https://github.com/burin-labs/harn/issues/1784), which closes out the `.harnpack` epic [#1779](https://github.com/burin-labs/harn/issues/1779).

## Test plan

- [x] `cargo test -p harn-cli --test harnpack_run` — six new integration tests covering the four issue exit criteria plus `--dry-run-verify` and the unsigned-with-dry-run refusal corner case.
- [x] `cargo test -p harn-cli --lib commands::run::harnpack::` — six unit tests for semver triplet parsing, hash sanitization, version-compat check (warn / refuse / lenient), and unsafe-path traversal defense.
- [x] `cargo test -p harn-cli --test pack_cli --test bytecode_cache` — confirms no regression in the existing pack and bytecode-cache integration suites.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] `make lint-md` clean; `make lint-test-patterns` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)