### PR TITLE
Add reminder lifecycle EventLog events (R-02, #1817)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,12 @@ condensed series summaries instead of full per-patch history.
   reminder options, appends a typed reminder event, and replaces older
   pending reminders with the same `dedupe_key`; clearing removes
   reminders by `id`, `tag`, or `dedupe_key` and reports the removal
-  count. This lands the deterministic transcript model without the later
-  EventLog expiry hooks or provider-rendering framework.
+  count. Both transforms also append lifecycle events on the
+  `transcript.reminder` EventLog topic — `injected`, `deduped` (per
+  replaced reminder), and `expired` with `reason: "cleared"` (per
+  removed reminder) — so observability tools and ACP clients can track
+  reminder state without scanning transcripts. Post-turn TTL decrement
+  and the provider-rendering framework land in later R-* tickets.
 - **OAuth provider catalogue records (#1905).** Adds
   `std/oauth/providers` with ten preconfigured OAuth provider records
   (GitHub, Slack, Linear, Notion, Google, Microsoft, Atlassian,

--- a/conformance/tests/pool/queue_strategy_submit.harn
+++ b/conformance/tests/pool/queue_strategy_submit.harn
@@ -1,12 +1,4 @@
-import {
-  QueueStrategy,
-  fair_round_robin,
-  fifo,
-  lifo,
-  pool_create,
-  pool_wait,
-  priority,
-} from "std/lifecycle/pool"
+import { QueueStrategy, fifo, lifo, pool_create, pool_wait, priority } from "std/lifecycle/pool"
 
 fn stamp(order) {
   return { -> atomic_add(order, 1) }
@@ -16,10 +8,14 @@ pipeline default() {
   let fifo_pool = pool_create({name: "queue-strategy-fifo", max_concurrent: 1, queue: fifo()})
   let fifo_order = atomic(0)
   let fifo_gate = channel(nil, 1)
-  let fifo_warmup = fifo_pool.submit({ ->
-    receive(fifo_gate)
-    return atomic_add(fifo_order, 1)
-  }, {tenant_id: "warmup"})
+  let fifo_warmup = fifo_pool
+    .submit(
+    { ->
+      receive(fifo_gate)
+      return atomic_add(fifo_order, 1)
+    },
+    {tenant_id: "warmup"},
+  )
   let fifo_a1 = fifo_pool.submit(stamp(fifo_order), {tenant_id: "a"})
   let fifo_b1 = fifo_pool.submit(stamp(fifo_order), {tenant_id: "b"})
   let fifo_a2 = fifo_pool.submit(stamp(fifo_order), {tenant_id: "a"})
@@ -29,14 +25,17 @@ pipeline default() {
   log(fifo_results[1].result)
   log(fifo_results[2].result)
   log(fifo_results[3].result)
-
   let lifo_pool = pool_create({name: "queue-strategy-lifo", max_concurrent: 1, queue: lifo()})
   let lifo_order = atomic(0)
   let lifo_gate = channel(nil, 1)
-  let lifo_warmup = lifo_pool.submit({ ->
-    receive(lifo_gate)
-    return atomic_add(lifo_order, 1)
-  }, {tenant_id: "warmup"})
+  let lifo_warmup = lifo_pool
+    .submit(
+    { ->
+      receive(lifo_gate)
+      return atomic_add(lifo_order, 1)
+    },
+    {tenant_id: "warmup"},
+  )
   let lifo_a1 = lifo_pool.submit(stamp(lifo_order), {tenant_id: "a"})
   let lifo_b1 = lifo_pool.submit(stamp(lifo_order), {tenant_id: "b"})
   let lifo_a2 = lifo_pool.submit(stamp(lifo_order), {tenant_id: "a"})
@@ -46,18 +45,17 @@ pipeline default() {
   log(lifo_results[3].result)
   log(lifo_results[2].result)
   log(lifo_results[1].result)
-
-  let priority_pool = pool_create({
-    name: "queue-strategy-priority",
-    max_concurrent: 1,
-    queue: priority(),
-  })
+  let priority_pool = pool_create({name: "queue-strategy-priority", max_concurrent: 1, queue: priority()})
   let priority_order = atomic(0)
   let priority_gate = channel(nil, 1)
-  let priority_warmup = priority_pool.submit({ ->
-    receive(priority_gate)
-    return atomic_add(priority_order, 1)
-  }, {tenant_id: "warmup", priority: 0})
+  let priority_warmup = priority_pool
+    .submit(
+    { ->
+      receive(priority_gate)
+      return atomic_add(priority_order, 1)
+    },
+    {tenant_id: "warmup", priority: 0},
+  )
   let priority_a1 = priority_pool.submit(stamp(priority_order), {tenant_id: "a", priority: 0})
   let priority_b1 = priority_pool.submit(stamp(priority_order), {tenant_id: "b", priority: 10})
   let priority_a2 = priority_pool.submit(stamp(priority_order), {tenant_id: "a", priority: 5})
@@ -67,19 +65,20 @@ pipeline default() {
   log(priority_results[2].result)
   log(priority_results[3].result)
   log(priority_results[1].result)
-
   let strategy_ns = QueueStrategy()
-  let fair_pool = pool_create({
-    name: "queue-strategy-fair",
-    max_concurrent: 1,
-    queue: strategy_ns.fair_round_robin("tenant_id"),
-  })
+  let fair_pool = pool_create(
+    {name: "queue-strategy-fair", max_concurrent: 1, queue: strategy_ns.fair_round_robin("tenant_id")},
+  )
   let fair_order = atomic(0)
   let fair_gate = channel(nil, 1)
-  let fair_warmup = fair_pool.submit({ ->
-    receive(fair_gate)
-    return atomic_add(fair_order, 1)
-  }, {tenant_id: "warmup"})
+  let fair_warmup = fair_pool
+    .submit(
+    { ->
+      receive(fair_gate)
+      return atomic_add(fair_order, 1)
+    },
+    {tenant_id: "warmup"},
+  )
   let fair_a1 = fair_pool.submit(stamp(fair_order), {tenant_id: "a"})
   let fair_a2 = fair_pool.submit(stamp(fair_order), {tenant_id: "a"})
   let fair_b1 = fair_pool.submit(stamp(fair_order), {tenant_id: "b"})

--- a/crates/harn-stdlib/src/stdlib/lifecycle/pool.harn
+++ b/crates/harn-stdlib/src/stdlib/lifecycle/pool.harn
@@ -88,12 +88,7 @@ pub fn fair_round_robin(key = "key") {
  * @example: let QueueStrategy = QueueStrategy()
  */
 pub fn QueueStrategy() {
-  return {
-    fifo: fifo(),
-    priority: priority(),
-    lifo: lifo(),
-    fair_round_robin: fair_round_robin,
-  }
+  return {fifo: fifo(), priority: priority(), lifo: lifo(), fair_round_robin: fair_round_robin}
 }
 
 fn __pool_attach_methods(snapshot) {

--- a/crates/harn-vm/src/llm/conversation.rs
+++ b/crates/harn-vm/src/llm/conversation.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 use std::rc::Rc;
 
+use crate::event_log::{active_event_log, EventLog, LogEvent, Topic};
 use crate::value::{VmError, VmValue};
 use crate::vm::{Vm, VmBuiltinArity, VmBuiltinMetadata};
 
@@ -13,6 +14,14 @@ use super::helpers::{
     vm_message_value, vm_value_to_json, ReminderPropagate, ReminderRoleHint, ReminderSource,
     SystemReminder, SYSTEM_REMINDER_EVENT_KIND,
 };
+
+/// EventLog topic for reminder lifecycle events. R-12 will layer more
+/// kinds (`fired`, `inherited`, `provider_evaluated`); R-02 owns
+/// `injected`, `deduped`, and `expired`.
+const REMINDER_LIFECYCLE_TOPIC: &str = "transcript.reminder";
+const REMINDER_KIND_INJECTED: &str = "injected";
+const REMINDER_KIND_DEDUPED: &str = "deduped";
+const REMINDER_KIND_EXPIRED: &str = "expired";
 
 const INJECT_REMINDER_KEYS: &[&str] = &[
     "body",
@@ -635,16 +644,19 @@ fn transcript_inject_reminder_builtin(args: &[VmValue]) -> Result<VmValue, VmErr
     let reminder = parse_inject_reminder_options(options, context)?;
 
     let mut preserved = transcript_extra_events(transcript);
-    let mut deduped_count = 0_i64;
+    let mut deduped_ids = Vec::new();
     if let Some(dedupe_key) = reminder.dedupe_key.as_deref() {
         preserved.retain(|event| {
-            let should_drop = reminder_payload(event)
-                .and_then(|payload| reminder_string_field(payload, "dedupe_key"))
-                .is_some_and(|key| key == dedupe_key);
-            if should_drop {
-                deduped_count += 1;
+            let Some(payload) = reminder_payload(event) else {
+                return true;
+            };
+            if reminder_string_field(payload, "dedupe_key").as_deref() != Some(dedupe_key) {
+                return true;
             }
-            !should_drop
+            if let Some(id) = reminder_string_field(payload, "id") {
+                deduped_ids.push(id);
+            }
+            false
         });
     }
 
@@ -660,13 +672,42 @@ fn transcript_inject_reminder_builtin(args: &[VmValue]) -> Result<VmValue, VmErr
         transcript_state(transcript),
     );
 
+    let mut events = Vec::with_capacity(deduped_ids.len() + 1);
+    for replaced_id in &deduped_ids {
+        events.push(LogEvent::new(
+            REMINDER_KIND_DEDUPED,
+            serde_json::json!({
+                "replaced_id": replaced_id,
+                "replacing_id": reminder_id,
+                "dedupe_key": reminder.dedupe_key,
+            }),
+        ));
+    }
+    events.push(LogEvent::new(
+        REMINDER_KIND_INJECTED,
+        serde_json::json!({
+            "reminder_id": reminder_id,
+            "tags": reminder.tags,
+            "dedupe_key": reminder.dedupe_key,
+            "ttl_turns": reminder.ttl_turns,
+            "preserve_on_compact": reminder.preserve_on_compact,
+            "propagate": reminder.propagate.as_str(),
+            "role_hint": reminder.role_hint.as_str(),
+            "source": reminder.source.as_str(),
+        }),
+    ));
+    emit_reminder_lifecycle_events(events);
+
     Ok(VmValue::Dict(Rc::new(BTreeMap::from([
         ("transcript".to_string(), next),
         (
             "reminder_id".to_string(),
             VmValue::String(Rc::from(reminder_id)),
         ),
-        ("deduped_count".to_string(), VmValue::Int(deduped_count)),
+        (
+            "deduped_count".to_string(),
+            VmValue::Int(deduped_ids.len() as i64),
+        ),
     ]))))
 }
 
@@ -677,11 +718,14 @@ fn transcript_clear_reminders_builtin(args: &[VmValue]) -> Result<VmValue, VmErr
     ensure_known_reminder_keys(context, options, CLEAR_REMINDER_KEYS)?;
     let selector = parse_clear_reminder_selector(options, context)?;
 
-    let mut removed_count = 0_i64;
+    let mut removed_ids = Vec::new();
     let mut preserved = Vec::new();
     for event in transcript_extra_events(transcript) {
-        if reminder_payload(&event).is_some_and(|payload| selector.matches(payload)) {
-            removed_count += 1;
+        let removed_id = reminder_payload(&event)
+            .filter(|payload| selector.matches(payload))
+            .map(|payload| reminder_string_field(payload, "id").unwrap_or_default());
+        if let Some(id) = removed_id {
+            removed_ids.push(id);
         } else {
             preserved.push(event);
         }
@@ -697,10 +741,54 @@ fn transcript_clear_reminders_builtin(args: &[VmValue]) -> Result<VmValue, VmErr
         transcript_state(transcript),
     );
 
+    let events = removed_ids
+        .iter()
+        .map(|removed_id| {
+            LogEvent::new(
+                REMINDER_KIND_EXPIRED,
+                serde_json::json!({
+                    "reminder_id": removed_id,
+                    "reason": "cleared",
+                }),
+            )
+        })
+        .collect();
+    emit_reminder_lifecycle_events(events);
+
     Ok(VmValue::Dict(Rc::new(BTreeMap::from([
         ("transcript".to_string(), next),
-        ("removed_count".to_string(), VmValue::Int(removed_count)),
+        (
+            "removed_count".to_string(),
+            VmValue::Int(removed_ids.len() as i64),
+        ),
     ]))))
+}
+
+/// Append a sequence of reminder lifecycle events to the active
+/// EventLog in order. The append loop runs in a single spawned task so
+/// events emitted from one builtin call land in the same order they
+/// were produced, even on a multi-thread runtime. Best-effort: when no
+/// event log is installed (e.g. unit tests that never opt in) or no
+/// tokio runtime is available, the call silently no-ops so the
+/// pure-transform builtins stay usable from any context.
+fn emit_reminder_lifecycle_events(events: Vec<LogEvent>) {
+    if events.is_empty() {
+        return;
+    }
+    let Some(log) = active_event_log() else {
+        return;
+    };
+    let Ok(topic) = Topic::new(REMINDER_LIFECYCLE_TOPIC) else {
+        return;
+    };
+    let Ok(handle) = tokio::runtime::Handle::try_current() else {
+        return;
+    };
+    handle.spawn(async move {
+        for event in events {
+            let _ = log.append(&topic, event).await;
+        }
+    });
 }
 
 fn require_reminder_options<'a>(
@@ -1119,5 +1207,101 @@ mod tests {
             }
             other => panic!("expected thrown reminder error, got {other:?}"),
         }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn lifecycle_events_round_trip_through_event_log() {
+        use crate::event_log::{install_memory_for_current_thread, reset_active_event_log, Topic};
+
+        install_memory_for_current_thread(64);
+        let log = crate::event_log::active_event_log().expect("event log installed");
+        let topic = Topic::new(REMINDER_LIFECYCLE_TOPIC).expect("lifecycle topic is valid");
+
+        let base = new_transcript_with(None, Vec::new(), None, None);
+        let first = transcript_inject_reminder_builtin(&[
+            base,
+            dict(vec![
+                ("body", vm_string("first")),
+                ("dedupe_key", vm_string("ctx")),
+                ("tags", strings(&["context"])),
+            ]),
+        ])
+        .expect("first inject");
+        let first_id = first
+            .as_dict()
+            .and_then(|dict| dict.get("reminder_id"))
+            .map(|value| value.display())
+            .expect("first reminder id");
+
+        let second = transcript_inject_reminder_builtin(&[
+            result_transcript(&first),
+            dict(vec![
+                ("body", vm_string("second")),
+                ("dedupe_key", vm_string("ctx")),
+                ("tags", strings(&["context"])),
+            ]),
+        ])
+        .expect("second inject");
+        let second_id = second
+            .as_dict()
+            .and_then(|dict| dict.get("reminder_id"))
+            .map(|value| value.display())
+            .expect("second reminder id");
+
+        let cleared = transcript_clear_reminders_builtin(&[
+            result_transcript(&second),
+            dict(vec![("dedupe_key", vm_string("ctx"))]),
+        ])
+        .expect("clear reminders");
+        let cleared_dict = cleared.as_dict().expect("result dict");
+        assert_eq!(
+            cleared_dict.get("removed_count").and_then(VmValue::as_int),
+            Some(1)
+        );
+
+        // The spawned tasks need to drain before we can read.
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+        log.flush().await.expect("flush event log");
+
+        let events = log
+            .read_range(&topic, None, 16)
+            .await
+            .expect("read lifecycle events");
+        let kinds: Vec<&str> = events
+            .iter()
+            .map(|(_, event)| event.kind.as_str())
+            .collect();
+        assert_eq!(
+            kinds,
+            vec!["injected", "deduped", "injected", "expired"],
+            "lifecycle events appear in order; got {kinds:?}"
+        );
+
+        let deduped = &events[1].1.payload;
+        assert_eq!(
+            deduped.get("replaced_id").and_then(|v| v.as_str()),
+            Some(first_id.as_str())
+        );
+        assert_eq!(
+            deduped.get("replacing_id").and_then(|v| v.as_str()),
+            Some(second_id.as_str())
+        );
+        assert_eq!(
+            deduped.get("dedupe_key").and_then(|v| v.as_str()),
+            Some("ctx")
+        );
+
+        let expired = &events[3].1.payload;
+        assert_eq!(
+            expired.get("reminder_id").and_then(|v| v.as_str()),
+            Some(second_id.as_str())
+        );
+        assert_eq!(
+            expired.get("reason").and_then(|v| v.as_str()),
+            Some("cleared")
+        );
+
+        reset_active_event_log();
     }
 }

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -1460,6 +1460,13 @@ let cleared = transcript.clear_reminders(t, {tag: "token_pressure"})
 println(cleared.removed_count)
 ```
 
+Both transforms also append lifecycle events on the
+`transcript.reminder` EventLog topic — `injected`, `deduped` (per
+replaced reminder), and `expired` with `reason: "cleared"` (per cleared
+reminder) — so observability tools and ACP clients can track reminder
+state without scanning transcripts. Emission is best-effort and
+silently no-ops when no EventLog is installed.
+
 ### `agent_turn`
 
 `agent_turn(prompt, options?)` is the high-level wrapper for the common

--- a/docs/src/system-reminders.md
+++ b/docs/src/system-reminders.md
@@ -155,10 +155,29 @@ is required. If multiple selectors are present, a reminder must match
 all of them to be removed. This builtin is also a pure transform and
 returns `{transcript, removed_count}`.
 
-`ttl_turns` is stored on reminder events today. Post-turn TTL decrement,
-expiry EventLog events, hook return variants, bridge notifications, and
+### Lifecycle events on the EventLog
+
+Both transforms append lifecycle events to the active EventLog on the
+`transcript.reminder` topic so observability tools, daemons, and ACP
+clients can see reminder state changes without scanning transcripts.
+R-02 emits three event kinds; R-12 layers in `fired`, `inherited`, and
+`provider_evaluated`.
+
+| Kind | Emitted by | Payload |
+|---|---|---|
+| `injected` | `transcript.inject_reminder` | `reminder_id`, `tags`, `dedupe_key`, `ttl_turns`, `preserve_on_compact`, `propagate`, `role_hint`, `source` |
+| `deduped` | `transcript.inject_reminder` when an older reminder is replaced | `replaced_id`, `replacing_id`, `dedupe_key` |
+| `expired` | `transcript.clear_reminders` per removed reminder | `reminder_id`, `reason: "cleared"` |
+
+Emission is best-effort: when no EventLog is installed (e.g. unit
+tests that never opt in) the calls silently no-op so the transforms
+stay usable from any context.
+
+Post-turn TTL decrement (with `reason: "ttl"`), compaction-driven
+expiry, hook return variants, bridge notifications, and
 provider-specific reminder rendering are intentionally not implemented
-by these transcript transforms.
+by these transcript transforms — they belong to later tickets in
+[epic #1815](https://github.com/burin-labs/harn/issues/1815).
 
 ## Reading reminders off a transcript
 


### PR DESCRIPTION
## Summary

Closes #1817 (R-02).

- `transcript.inject_reminder` and `transcript.clear_reminders` now publish `transcript.reminder.{injected,deduped,expired}` events on the EventLog, so observability tools, daemons, and ACP clients can track reminder state without scanning transcripts.
- Dedupe carries through to the payload (`replaced_id`, `replacing_id`, `dedupe_key`) so consumers can correlate replacements.
- The append loop runs in a single spawned task so events from one builtin call land in order even on multi-thread runtimes; emission silently no-ops without an EventLog or runtime so the pure-transform contract holds in any context.
- Docs/quickref/CHANGELOG updated to describe the lifecycle topic and event payload schema. Post-turn TTL decrement and the provider-rendering framework stay scoped to R-07/R-04/R-12 — the doc explicitly defers them.
- Drive-by `harn fmt` pass over two `.harn` files that drifted after the pool queue-strategy work (#1939).

## Test plan

- [x] `cargo test -p harn-vm --lib llm::conversation` (new `lifecycle_events_round_trip_through_event_log` covers the inject → dedupe → clear sequence and canonical event order)
- [x] `cargo run --bin harn -- test conformance --filter reminder` (all 6 reminder conformance tests pass)
- [x] `make all` (after the drive-by formatting fixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)