### PR TITLE
Fix owned diagnostic docs snippets

### DIFF
--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-OWN-003.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-OWN-003.md
@@ -16,7 +16,7 @@ drop never fires, and the resource leaks until the runtime garbage-collects
 the handle (which, for OS resources, may be never).
 
 ```harn
-fn open_log(): channel {
+fn open_log() -> channel {
   let ch: owned<channel> = channel("log", 64)
   return ch    // HARN-OWN-003: `ch` escapes; auto-drop is bypassed
 }
@@ -29,7 +29,7 @@ fn open_log(): channel {
   dropping it (or transferring it on again):
 
   ```harn
-  fn open_log(): owned<channel> {
+  fn open_log() -> owned<channel> {
     let ch: owned<channel> = channel("log", 64)
     return ch    // OK — ownership flows to the caller
   }
@@ -39,7 +39,7 @@ fn open_log(): channel {
   exit triggers the auto-drop, then returning a non-owned summary:
 
   ```harn
-  fn write_log(msg: string): nil {
+  fn write_log(msg: string) -> nil {
     {
       let ch: owned<channel> = channel("log", 64)
       send(ch, msg)

--- a/docs/src/diagnostics.md
+++ b/docs/src/diagnostics.md
@@ -4788,7 +4788,7 @@ drop never fires, and the resource leaks until the runtime garbage-collects
 the handle (which, for OS resources, may be never).
 
 ```harn
-fn open_log(): channel {
+fn open_log() -> channel {
   let ch: owned<channel> = channel("log", 64)
   return ch    // HARN-OWN-003: `ch` escapes; auto-drop is bypassed
 }
@@ -4801,7 +4801,7 @@ fn open_log(): channel {
   dropping it (or transferring it on again):
 
   ```harn
-  fn open_log(): owned<channel> {
+  fn open_log() -> owned<channel> {
     let ch: owned<channel> = channel("log", 64)
     return ch    // OK — ownership flows to the caller
   }
@@ -4811,7 +4811,7 @@ fn open_log(): channel {
   exit triggers the auto-drop, then returning a non-owned summary:
 
   ```harn
-  fn write_log(msg: string): nil {
+  fn write_log(msg: string) -> nil {
     {
       let ch: owned<channel> = channel("log", 64)
       send(ch, msg)


### PR DESCRIPTION
Fixes the post-merge CI failure in `make check-docs-snippets` by updating the generated HARN-OWN-003 examples to use current function return syntax and regenerating `docs/src/diagnostics.md`.\n\nValidation:\n- `make check-docs-snippets`\n- `make check-diagnostics-catalog`\n- `git diff --check`