### PR TITLE
Add top-level agent suspend resume

### DIFF
--- a/conformance/tests/agents/agent_top_level_await_resumption_cli.expected
+++ b/conformance/tests/agents/agent_top_level_await_resumption_cli.expected
@@ -1,0 +1,10 @@
+true
+true
+true
+true
+true
+true
+result
+completed
+true
+true

--- a/conformance/tests/agents/agent_top_level_await_resumption_cli.harn
+++ b/conformance/tests/agents/agent_top_level_await_resumption_cli.harn
@@ -1,0 +1,49 @@
+import "../_common"
+
+fn first_snapshot_line(text) {
+  let matches = regex_captures("snapshot=(.+)", text)
+  if len(matches) == 0 {
+    return nil
+  }
+  return matches[0].groups[0]
+}
+
+pipeline main() {
+  let repo_root = exec("git", "rev-parse", "--show-toplevel").stdout.trim()
+  let harn_bin = env_or("HARN_CONFORMANCE_HARN_BIN", resolve_harn_bin(repo_root))
+  let root = path_join(temp_dir(), "harn-top-level-resume-" + uuid_v7())
+  mkdir(root)
+  let script = path_join(root, "top_level_suspend.harn")
+  write_file(
+    script,
+    "pipeline main() {\n"
+      + "  llm_mock({tool_calls: [{id: \"park_1\", name: \"agent_await_resumption\", arguments: {reason: \"waiting on operator\"}}]})\n"
+      + "  let result = agent_loop(\"Park until the operator resumes.\", nil, {provider: \"mock\", tool_format: \"native\", max_iterations: 2, session_id: \"top-level-\" + uuid_v7()})\n"
+      + "  println(\"status=\" + result.status)\n"
+      + "  println(\"reason=\" + result.reason)\n"
+      + "  println(\"handle_status=\" + result.handle.status)\n"
+      + "  println(\"snapshot=\" + result.handle.snapshot_path)\n"
+      + "}\n",
+  )
+  let first = exec_at(root, harn_bin, "run", script)
+  println(first.success)
+  println(contains(first.stdout, "status=suspended"))
+  println(contains(first.stdout, "reason=waiting on operator"))
+  println(contains(first.stdout, "handle_status=suspended"))
+  let snapshot = first_snapshot_line(first.stdout)
+  require snapshot != nil, "top-level suspend did not print a snapshot path"
+  let snapshot_path = if path_is_absolute(snapshot) {
+    snapshot
+  } else {
+    path_join(root, snapshot)
+  }
+  println(file_exists(snapshot_path))
+  let second = exec_at(root, harn_bin, "run", "--resume", snapshot, "--json")
+  println(second.success)
+  let lines = second.stdout.trim().split("\n")
+  let final = json_parse(lines[len(lines) - 1])
+  println(final.data.event_type)
+  println(final.data.value.status)
+  println(contains(final.data.value.result.summary, "Mock response"))
+  println(final.data.value.has_transcript)
+}

--- a/crates/harn-cli/src/cli/run.rs
+++ b/crates/harn-cli/src/cli/run.rs
@@ -26,6 +26,13 @@ pub(crate) struct RunArgs {
     /// Evaluate inline Harn code instead of a file.
     #[arg(short = 'e')]
     pub eval: Option<String>,
+    /// Resume a suspended top-level agent from a worker handle or snapshot path.
+    #[arg(
+        long = "resume",
+        value_name = "HANDLE_OR_SNAPSHOT",
+        conflicts_with_all = ["eval", "file", "explain_cost", "allow_unsigned", "dry_run_verify"]
+    )]
+    pub resume: Option<String>,
     /// Extra skill-discovery roots. Repeatable; each path is a
     /// directory of `<name>/SKILL.md` bundles, equivalent to a
     /// single-entry `$HARN_SKILLS_PATH`. Highest-priority layer —

--- a/crates/harn-cli/src/commands/run.rs
+++ b/crates/harn-cli/src/commands/run.rs
@@ -538,6 +538,58 @@ pub(crate) async fn run_file_with_skill_dirs(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn run_resume_with_skill_dirs(
+    target: &str,
+    trace: bool,
+    denied_builtins: HashSet<String>,
+    resume_argv: Vec<String>,
+    skill_dirs_raw: Vec<String>,
+    llm_mock_mode: CliLlmMockMode,
+    attestation: Option<RunAttestationOptions>,
+    profile: RunProfileOptions,
+    json: Option<RunJsonOptions>,
+) {
+    let source = r#"import { resume_agent, wait_agent } from "std/agent/workers"
+
+pipeline main(task) {
+  let input = if len(argv) > 1 {
+    argv[1]
+  } else {
+    nil
+  }
+  let handle = resume_agent(argv[0], input, true)
+  return wait_agent(handle)
+}
+"#;
+    let tmp = create_eval_temp_file().unwrap_or_else(|e| {
+        eprintln!("error: {e}");
+        process::exit(1);
+    });
+    let tmp_path = tmp.path().to_path_buf();
+    if let Err(error) = fs::write(&tmp_path, source) {
+        eprintln!("error: failed to write temp file for --resume: {error}");
+        process::exit(1);
+    }
+    let mut argv = Vec::with_capacity(resume_argv.len() + 1);
+    argv.push(target.to_string());
+    argv.extend(resume_argv);
+    let tmp_str = tmp_path.to_string_lossy().into_owned();
+    run_file_with_skill_dirs(
+        &tmp_str,
+        trace,
+        denied_builtins,
+        argv,
+        skill_dirs_raw,
+        llm_mock_mode,
+        attestation,
+        profile,
+        json,
+        HarnpackRunOptions::default(),
+    )
+    .await;
+}
+
 pub fn execute_explain_cost(path: &str) -> RunOutcome {
     let stdout = String::new();
     let mut stderr = String::new();

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -183,6 +183,22 @@ async fn async_main() {
                 dry_run_verify: args.dry_run_verify,
             };
 
+            if let Some(resume_target) = args.resume.as_deref() {
+                commands::run::run_resume_with_skill_dirs(
+                    resume_target,
+                    args.trace,
+                    denied,
+                    args.argv.clone(),
+                    args.skill_dir.clone(),
+                    llm_mock_mode,
+                    attestation,
+                    profile_options,
+                    json_options,
+                )
+                .await;
+                return;
+            }
+
             match (args.eval.as_deref(), args.file.as_deref()) {
                 (Some(code), None) => {
                     if args.allow_unsigned || args.dry_run_verify {
@@ -239,9 +255,9 @@ async fn async_main() {
                 (Some(_), Some(_)) => command_error(
                     "`harn run` accepts either `-e <code>` or `<file.harn>`, not both",
                 ),
-                (None, None) => {
-                    command_error("`harn run` requires either `-e <code>` or `<file.harn>`")
-                }
+                (None, None) => command_error(
+                    "`harn run` requires `--resume <snapshot>`, `-e <code>`, or `<file.harn>`",
+                ),
             }
         }
         Command::Check(args) => {

--- a/crates/harn-stdlib/src/stdlib/agent/loop.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/loop.harn
@@ -393,11 +393,11 @@ fn __agent_await_resumption_args(call) {
   return {reason: reason, conditions: parse_resume_conditions(args?.conditions ?? nil)}
 }
 
-fn __agent_loop_await_resumption(session, iteration, call) {
+fn __agent_loop_await_resumption(session, iteration, call, opts) {
   let parsed = __agent_await_resumption_args(call)
   let worker = __agent_loop_current_worker()
   if worker == nil {
-    throw "agent_await_resumption: current agent_loop is not running inside a worker"
+    return __agent_loop_await_resumption_top_level(session, iteration, call, parsed, opts)
   }
   agent_emit_event(
     session.session_id,
@@ -421,6 +421,57 @@ fn __agent_loop_await_resumption(session, iteration, call) {
     throw "agent_await_resumption: suspend checkpoint did not yield"
   }
   return checkpoint
+}
+
+fn __agent_loop_await_resumption_top_level(session, iteration, call, parsed, opts) {
+  agent_session_inject(
+    session.session_id,
+    transcript_reminder_event(
+      {
+        body: __agent_loop_suspend_reminder_body(parsed.reason),
+        source: "in_pipeline",
+        tags: ["agent_loop", "top_level_suspend"],
+        dedupe_key: "top_level_suspend:" + session.session_id,
+        ttl_turns: 1,
+        fired_at_turn: iteration + 1,
+      },
+    ),
+  )
+  let handle = __host_top_level_agent_suspend(
+    session.session_id,
+    session.task,
+    session.system,
+    opts,
+    parsed.reason,
+    parsed.conditions,
+    iteration,
+  )
+  agent_emit_event(
+    session.session_id,
+    "tool_call_audit",
+    {
+      tool_call_id: to_string(call?.id ?? call?.tool_call_id ?? ""),
+      tool_name: "agent_await_resumption",
+      audit: {
+        layer: "agent_lifecycle",
+        status: "suspended",
+        initiator: "self",
+        reason: parsed.reason,
+        worker_id: handle?.id,
+        conditions: parsed.conditions,
+      },
+    },
+  )
+  return {
+    status: "suspended",
+    handle: handle,
+    worker: handle,
+    reason: parsed.reason,
+    initiator: "self",
+    conditions: parsed.conditions,
+    iterations_completed: iteration,
+    session_id: session.session_id,
+  }
 }
 
 fn __stall_diagnostics_config(value) {
@@ -1593,7 +1644,7 @@ fn __agent_loop_run(message, session, initial_opts) {
       }
       let await_call = __agent_await_resumption_call(tool_calls)
       if await_call != nil {
-        suspend_result = __agent_loop_await_resumption(session, iteration, await_call)
+        suspend_result = __agent_loop_await_resumption(session, iteration, await_call, opts)
         let _totals = agent_session_record_usage(session.session_id, llm_result)
         agent_emit_event(
           session.session_id,

--- a/crates/harn-vm/src/stdlib/agents.rs
+++ b/crates/harn-vm/src/stdlib/agents.rs
@@ -24,10 +24,12 @@ use self::agents_workers::{
     parse_worker_config, persist_worker_state_snapshot, spawn_worker_task, with_worker_state,
     worker_event_snapshot, worker_id_from_value, worker_request_for_config, worker_snapshot_path,
     worker_summary, worker_trigger_payload_text, worker_wait_blocks, SuspendInitiator,
-    WorkerConfig, WorkerState, WorkerSuspension, WORKER_REGISTRY,
+    WorkerCarryPolicy, WorkerConfig, WorkerExecutionProfile, WorkerState, WorkerSuspension,
+    WORKER_REGISTRY,
 };
 use self::sub_agent::{execute_sub_agent, parse_sub_agent_request};
-use crate::orchestration::ArtifactRecord;
+use crate::agent_events::WorkerEvent;
+use crate::orchestration::{ArtifactRecord, ContextPolicy, MutationSessionRecord};
 use crate::stdlib::registration::{
     async_builtin, register_builtin_group, AsyncBuiltin, BuiltinGroup, SyncBuiltin,
 };
@@ -79,6 +81,15 @@ const AGENT_ASYNC_PRIMITIVES: &[AsyncBuiltin] = &[
         .signature("__host_worker_suspend(worker, reason, options?)")
         .arity(VmBuiltinArity::Range { min: 1, max: 3 })
         .doc("Cooperatively suspend a host worker at the next turn boundary."),
+    async_builtin!(
+        "__host_top_level_agent_suspend",
+        top_level_agent_suspend_builtin
+    )
+    .signature(
+        "__host_top_level_agent_suspend(session_id, task, system, options, reason, conditions?, iteration?)",
+    )
+    .arity(VmBuiltinArity::Range { min: 5, max: 7 })
+    .doc("Persist a top-level agent_loop suspend checkpoint as a resumable worker."),
     async_builtin!("__host_worker_close", close_agent_builtin)
         .signature("__host_worker_close(worker)")
         .arity(VmBuiltinArity::Exact(1))
@@ -601,6 +612,126 @@ async fn suspend_agent_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
         }
         emit_worker_event(&snapshot, crate::agent_events::WorkerEvent::WorkerSuspended).await?;
     }
+    Ok(summary)
+}
+
+async fn top_level_agent_suspend_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+    let session_id = args
+        .first()
+        .map(|value| value.display())
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            VmError::Runtime("top_level_agent_suspend: missing session_id".to_string())
+        })?;
+    let task = args.get(1).map(|value| value.display()).unwrap_or_default();
+    let system = match args.get(2) {
+        Some(VmValue::String(text)) if !text.is_empty() => Some(text.to_string()),
+        _ => None,
+    };
+    let options = args
+        .get(3)
+        .and_then(VmValue::as_dict)
+        .cloned()
+        .unwrap_or_default();
+    let reason = args.get(4).map(|value| value.display()).unwrap_or_default();
+    let conditions_value = args
+        .get(5)
+        .filter(|value| !matches!(value, VmValue::Nil))
+        .cloned();
+    let conditions = conditions_value.as_ref().map(crate::llm::vm_value_to_json);
+
+    let worker_id = next_worker_id();
+    let snapshot_path = worker_snapshot_path(&worker_id);
+    let now = uuid::Uuid::now_v7().to_string();
+    let name = "top-level-agent".to_string();
+    let config = WorkerConfig::SubAgent {
+        spec: Box::new(SubAgentRunSpec {
+            name: name.clone(),
+            task: task.clone(),
+            system: system.clone(),
+            options,
+            returns_schema: None,
+            session_id: session_id.clone(),
+            parent_session_id: None,
+        }),
+    };
+    let request = worker_request_for_config(&task, &config);
+    let transcript = crate::agent_sessions::transcript(&session_id);
+    let audit = MutationSessionRecord {
+        session_id: session_id.clone(),
+        worker_id: Some(worker_id.clone()),
+        execution_kind: Some("top_level_agent".to_string()),
+        mutation_scope: "read_only".to_string(),
+        ..Default::default()
+    }
+    .normalize();
+    let worker = WorkerState {
+        id: worker_id.clone(),
+        name,
+        task: task.clone(),
+        status: "suspended".to_string(),
+        created_at: now.clone(),
+        started_at: now.clone(),
+        finished_at: None,
+        awaiting_started_at: None,
+        awaiting_since: None,
+        mode: "top_level_agent".to_string(),
+        history: vec![task],
+        config,
+        handle: None,
+        cancel_token: Arc::new(AtomicBool::new(false)),
+        suspend_signal: Arc::new(AtomicBool::new(false)),
+        suspension: Some(WorkerSuspension {
+            reason,
+            initiator: SuspendInitiator::SelfInitiated,
+            suspended_at: now,
+            snapshot_ref: snapshot_path.clone(),
+            conditions,
+            auto_resume_trigger: None,
+        }),
+        request,
+        latest_payload: None,
+        latest_error: None,
+        transcript,
+        artifacts: Vec::new(),
+        parent_worker_id: None,
+        parent_stage_id: None,
+        child_run_id: None,
+        child_run_path: None,
+        carry_policy: WorkerCarryPolicy {
+            artifact_mode: "inherit".to_string(),
+            transcript_mode: "inherit".to_string(),
+            context_policy: ContextPolicy::default(),
+            resume_workflow: true,
+            persist_state: true,
+            retriggerable: false,
+            policy: None,
+        },
+        execution: WorkerExecutionProfile::default(),
+        snapshot_path,
+        audit,
+    };
+    persist_worker_state_snapshot(&worker)?;
+    let mut snapshot = worker_event_snapshot(&worker);
+    let mut summary = worker_summary(&worker)?;
+    let state = Rc::new(RefCell::new(worker));
+    WORKER_REGISTRY.with(|registry| {
+        registry.borrow_mut().insert(worker_id.clone(), state);
+    });
+    if let Some(auto_resume_trigger) =
+        super::triggers_stdlib::register_auto_resume_trigger(&worker_id, conditions_value.as_ref())
+            .await?
+    {
+        (snapshot, summary) = with_worker_state(&worker_id, |state| {
+            let mut worker = state.borrow_mut();
+            if let Some(suspension) = worker.suspension.as_mut() {
+                suspension.auto_resume_trigger = Some(auto_resume_trigger);
+            }
+            persist_worker_state_snapshot(&worker)?;
+            Ok((worker_event_snapshot(&worker), worker_summary(&worker)?))
+        })?;
+    }
+    emit_worker_event(&snapshot, WorkerEvent::WorkerSuspended).await?;
     Ok(summary)
 }
 
@@ -1575,6 +1706,46 @@ mod suspend_tests {
             .find(|binding| binding.id == trigger_id)
             .expect("auto-resume binding snapshot");
         assert_eq!(snapshot.state, crate::triggers::TriggerState::Terminated);
+
+        teardown(&dir, &worker_id);
+        crate::triggers::clear_trigger_registry();
+        crate::stdlib::triggers_stdlib::reset_auto_resume_timeouts();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn top_level_suspend_registers_auto_resume_trigger() {
+        let _guard = suspend_test_lock().await;
+        crate::triggers::clear_trigger_registry();
+        crate::stdlib::triggers_stdlib::reset_auto_resume_timeouts();
+        let dir = std::env::temp_dir().join(format!(
+            "harn-top-level-suspend-test-{}",
+            uuid::Uuid::now_v7()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        unsafe { std::env::set_var("HARN_WORKER_STATE_DIR", &dir) };
+
+        let suspended = top_level_agent_suspend_builtin(vec![
+            VmValue::String(Rc::from("session-top-level-auto-resume")),
+            VmValue::String(Rc::from("continue the top-level task")),
+            VmValue::Nil,
+            VmValue::Dict(Rc::new(BTreeMap::new())),
+            VmValue::String(Rc::from("waiting for review")),
+            auto_resume_conditions("review.approved"),
+        ])
+        .await
+        .expect("top-level suspend with auto-resume trigger");
+        assert_eq!(summary_status(&suspended), "suspended");
+        let worker_id = suspended
+            .as_dict()
+            .and_then(|dict| dict.get("id"))
+            .map(VmValue::display)
+            .expect("worker id");
+        let trigger_id = auto_resume_trigger_id(&suspended);
+        let binding = crate::triggers::resolve_live_trigger_binding(&trigger_id, None)
+            .expect("registered top-level auto-resume binding");
+        assert_eq!(binding.kind, "auto_resume");
+        assert_eq!(binding.handler.kind(), "auto_resume");
+        assert_eq!(binding.match_events, vec!["review.approved".to_string()]);
 
         teardown(&dir, &worker_id);
         crate::triggers::clear_trigger_registry();

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -1659,8 +1659,9 @@ Parent-side tools are gated by subagent capability. Pass `subagents: true` or
 | `agent_await_resumption(reason, conditions?)` | Let the current worker self-park |
 
 Lifecycle invocations emit `tool_call_audit` telemetry with initiator and reason
-metadata. Top-level self-suspend uses the same tool surface but needs host-level
-resume plumbing beyond the current worker-backed path.
+metadata. Top-level loops use the same tool surface: `agent_loop(...)` returns a
+`status: "suspended"` payload with a persisted `handle.snapshot_path`, and the
+CLI can cold-restore it with `harn run --resume <snapshot_path>`.
 
 Pass `autonomy_budget` to cap how many autonomous decisions an agent can
 make per UTC hour / UTC day. The check fires at loop entry, before any

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -20,6 +20,7 @@ harn run --attest --receipt-out receipt.json <file.harn>
 harn run <bundle.harnpack>
 harn run --dry-run-verify <bundle.harnpack>
 harn run --allow-unsigned <bundle.harnpack>
+harn run --resume .harn/workers/worker_...json
 ```
 
 | Flag | Description |
@@ -29,6 +30,7 @@ harn run --allow-unsigned <bundle.harnpack>
 | `--profile-json <path>` | Write the categorical timing breakdown as JSON. Can also be set with `HARN_PROFILE_JSON=<path>` |
 | `--explain-cost` | Print static LLM token/cost estimates without executing the script |
 | `-e <code>` | Evaluate inline code instead of a file |
+| `--resume <handle-or-snapshot>` | Cold-restore a suspended top-level agent from its persisted worker snapshot |
 | `--deny <builtins>` | Deny specific builtins (comma-separated) |
 | `--allow <builtins>` | Allow only specific builtins (comma-separated) |
 | `--yes` | Accept first-run provider setup prompts, including local Ollama config seeding |

--- a/docs/src/llm/agent_loop.md
+++ b/docs/src/llm/agent_loop.md
@@ -1009,6 +1009,15 @@ optional `conditions` with `parse_resume_conditions(...)`, calls the same suspen
 path as `suspend_agent(...)`, returns `status: "suspended"` to the parent, and
 does not dispatch the tool as an ordinary handler result.
 
+Top-level loops use the same result shape. If a root `agent_loop(...)` parks,
+Harn persists a resumable worker snapshot and returns
+`{status: "suspended", handle, reason, initiator: "self", ...}` to the direct
+caller. The CLI can cold-restore that snapshot with:
+
+```bash
+harn run --resume .harn/workers/worker_...json
+```
+
 Parent-side lifecycle control is opt-in. Pass `subagents: true` or
 `subagent_tools: true` in `agent_loop` options, or call
 `agent_lifecycle_tools(registry, {subagents: true})`, to add


### PR DESCRIPTION
## Summary

- Persist top-level `agent_loop` self-suspends as resumable worker snapshots.
- Add `harn run --resume <handle-or-snapshot>` to cold-restore suspended top-level agents through the existing worker resume path.
- Cover the first-process suspend and second-process resume flow with a conformance fixture, and document the CLI/docs behavior.

Closes #1844

## Verification

- `CARGO_TARGET_DIR=/tmp/harn-target-1844-cargo cargo check -p harn-cli`
- `CARGO_TARGET_DIR=/tmp/harn-target-1844-cli cargo run --quiet --bin harn -- lint crates/harn-stdlib/src/stdlib/agent/loop.harn conformance/tests/agents/agent_top_level_await_resumption_cli.harn`
- `CARGO_TARGET_DIR=/tmp/harn-target-1844-cli cargo run --quiet --bin harn -- fmt --check crates/harn-stdlib/src/stdlib/agent/loop.harn conformance/tests/agents/agent_top_level_await_resumption_cli.harn`
- `CARGO_TARGET_DIR=/tmp/harn-target-1844-cli cargo run --quiet --bin harn -- test conformance --filter agent_top_level_await_resumption_cli`
- `CARGO_TARGET_DIR=/tmp/harn-target-1844-cli cargo run --quiet --bin harn -- test conformance --filter agent_await_resumption`
- `CARGO_TARGET_DIR=/tmp/harn-target-1844-cli cargo run --quiet --bin harn -- test conformance --filter agent_lifecycle_tools`
- `CARGO_TARGET_DIR=/tmp/harn-target-1844-docs make check-docs-snippets`
- `CARGO_TARGET_DIR=/tmp/harn-target-1844-cli cargo run --quiet --bin harn -- test conformance`
- pre-commit hook
- pre-push hook