### PR TITLE
Add trigger auto-resume bridge

### DIFF
--- a/conformance/tests/agents/agent_auto_resume_trigger.expected
+++ b/conformance/tests/agents/agent_auto_resume_trigger.expected
@@ -1,0 +1,6 @@
+suspended
+true
+true
+dispatched
+completed
+true

--- a/conformance/tests/agents/agent_auto_resume_trigger.harn
+++ b/conformance/tests/agents/agent_auto_resume_trigger.harn
@@ -1,0 +1,41 @@
+import "std/agents"
+import "std/triggers"
+
+pipeline main() {
+  llm_mock(
+    {
+      tool_calls: [
+        {
+          id: "park_until_review",
+          name: "agent_await_resumption",
+          arguments: {reason: "waiting on review", conditions: {trigger: {kind: "review.approved", provider: "github"}}},
+        },
+      ],
+      input_tokens: 7,
+      output_tokens: 3,
+    },
+  )
+  llm_mock({text: "resumed after review"})
+  let handle = sub_agent_run(
+    "Park until review approval.",
+    {provider: "mock", background: true, tool_format: "native", max_iterations: 3},
+  )
+  let suspended = wait_agent(handle)
+  let trigger_handle = suspended?.suspension?.auto_resume_trigger
+  println(suspended?.status)
+  println(trigger_handle?.id != nil)
+  println(trigger_handle?.version != nil)
+  let fired: DispatchHandle = trigger_fire(
+    trigger_handle,
+    {
+      provider: "github",
+      kind: "review.approved",
+      payload: {decision: "approved"},
+      headers: {x_delivery: "auto-resume-conformance"},
+    },
+  )
+  println(fired.status)
+  let resumed = wait_agent(handle)
+  println(resumed?.status)
+  println(contains(resumed?.task ?? "", "approved"))
+}

--- a/crates/harn-cli/src/commands/trigger/ops.rs
+++ b/crates/harn-cli/src/commands/trigger/ops.rs
@@ -720,6 +720,7 @@ fn handler_kind(binding: &harn_vm::triggers::registry::TriggerBinding) -> &'stat
         TriggerHandlerSpec::A2a { .. } => "a2a",
         TriggerHandlerSpec::Worker { .. } => "worker",
         TriggerHandlerSpec::Persona { .. } => "persona",
+        TriggerHandlerSpec::AutoResume { .. } => "auto_resume",
     }
 }
 
@@ -729,6 +730,7 @@ fn handler_label(binding: &harn_vm::triggers::registry::TriggerBinding) -> Strin
         TriggerHandlerSpec::A2a { target, .. } => target.clone(),
         TriggerHandlerSpec::Worker { queue } => queue.clone(),
         TriggerHandlerSpec::Persona { binding } => binding.name.clone(),
+        TriggerHandlerSpec::AutoResume { worker_id } => worker_id.clone(),
     }
 }
 
@@ -738,6 +740,7 @@ fn target_uri(binding: &harn_vm::triggers::registry::TriggerBinding) -> String {
         TriggerHandlerSpec::A2a { target, .. } => format!("a2a://{target}"),
         TriggerHandlerSpec::Worker { queue } => format!("worker://{queue}"),
         TriggerHandlerSpec::Persona { binding } => format!("persona://{}", binding.name),
+        TriggerHandlerSpec::AutoResume { worker_id } => format!("auto_resume://{worker_id}"),
     }
 }
 

--- a/crates/harn-vm/src/stdlib.rs
+++ b/crates/harn-vm/src/stdlib.rs
@@ -254,6 +254,7 @@ pub fn reset_stdlib_state() {
     monitors::reset_monitor_state();
     waitpoints::reset_waitpoint_state();
     waitpoint::reset_waitpoint_state();
+    triggers_stdlib::reset_auto_resume_timeouts();
     postgres::reset_postgres_state();
     supervisor::reset_supervisor_state();
     agents::records::reset_eval_metrics();

--- a/crates/harn-vm/src/stdlib/agents.rs
+++ b/crates/harn-vm/src/stdlib/agents.rs
@@ -536,12 +536,14 @@ async fn suspend_agent_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
         .map(|value| value.display())
         .map(|text| SuspendInitiator::parse(&text))
         .unwrap_or_default();
-    let conditions = options
+    let conditions_value = options
         .and_then(|value| value.as_dict())
         .and_then(|dict| dict.get("conditions"))
-        .map(crate::llm::vm_value_to_json);
+        .filter(|value| !is_nil(value))
+        .cloned();
+    let conditions = conditions_value.as_ref().map(crate::llm::vm_value_to_json);
 
-    let (snapshot, summary, should_emit) = with_worker_state(&worker_id, |state| {
+    let (mut snapshot, mut summary, should_emit) = with_worker_state(&worker_id, |state| {
         let mut worker = state.borrow_mut();
         if worker.status == "suspended" {
             return Ok((
@@ -569,6 +571,7 @@ async fn suspend_agent_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
             suspended_at: uuid::Uuid::now_v7().to_string(),
             snapshot_ref: worker.snapshot_path.clone(),
             conditions: conditions.clone(),
+            auto_resume_trigger: None,
         });
         // Always persist on suspend — the cooperative-pause contract
         // demands a durable resumable handle, independent of the
@@ -581,6 +584,21 @@ async fn suspend_agent_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
         ))
     })?;
     if should_emit {
+        if let Some(auto_resume_trigger) = super::triggers_stdlib::register_auto_resume_trigger(
+            &worker_id,
+            conditions_value.as_ref(),
+        )
+        .await?
+        {
+            (snapshot, summary) = with_worker_state(&worker_id, |state| {
+                let mut worker = state.borrow_mut();
+                if let Some(suspension) = worker.suspension.as_mut() {
+                    suspension.auto_resume_trigger = Some(auto_resume_trigger);
+                }
+                persist_worker_state_snapshot(&worker)?;
+                Ok((worker_event_snapshot(&worker), worker_summary(&worker)?))
+            })?;
+        }
         emit_worker_event(&snapshot, crate::agent_events::WorkerEvent::WorkerSuspended).await?;
     }
     Ok(summary)
@@ -760,6 +778,15 @@ fn apply_resume_task_to_config(config: &mut WorkerConfig, task: &str) {
     }
 }
 
+async fn unregister_suspension_auto_resume(
+    suspension: Option<WorkerSuspension>,
+) -> Result<(), VmError> {
+    let Some(handle) = suspension.and_then(|suspension| suspension.auto_resume_trigger) else {
+        return Ok(());
+    };
+    super::triggers_stdlib::unregister_auto_resume_trigger(&handle).await
+}
+
 async fn join_checkpointed_worker_handle(state: Rc<RefCell<WorkerState>>) -> Result<(), VmError> {
     let handle = {
         let mut worker = state.borrow_mut();
@@ -787,7 +814,7 @@ async fn warm_resume_worker(
     options: WorkerResumeOptions,
 ) -> Result<VmValue, VmError> {
     join_checkpointed_worker_handle(state.clone()).await?;
-    let snapshot = {
+    let (snapshot, suspension) = {
         let mut worker = state.borrow_mut();
         if worker.status != "suspended" {
             // Non-suspended warm resume is a no-op: the worker is either
@@ -799,7 +826,7 @@ async fn warm_resume_worker(
             return worker_summary(&worker);
         }
         worker.suspend_signal.store(false, Ordering::SeqCst);
-        worker.suspension = None;
+        let suspension = worker.suspension.take();
         worker.status = "running".to_string();
         worker.finished_at = None;
         worker.latest_error = None;
@@ -810,13 +837,78 @@ async fn warm_resume_worker(
         if worker.carry_policy.persist_state {
             persist_worker_state_snapshot(&worker)?;
         }
-        worker_event_snapshot(&worker)
+        (worker_event_snapshot(&worker), suspension)
     };
+    unregister_suspension_auto_resume(suspension).await?;
     emit_worker_event(&snapshot, crate::agent_events::WorkerEvent::WorkerResumed).await?;
     if crate::vm::clone_async_builtin_child_vm().is_some() {
         respawn_worker_task(state.clone())?;
     }
     let summary = worker_summary(&state.borrow())?;
+    Ok(summary)
+}
+
+pub(crate) async fn resume_worker_from_auto_resume_trigger(
+    worker_id: &str,
+    event: &crate::triggers::TriggerEvent,
+) -> Result<VmValue, VmError> {
+    let payload = auto_resume_event_payload(event);
+    let timeout_action = auto_resume_timeout_action(&payload);
+    if timeout_action.as_deref() == Some("fail") {
+        return fail_suspended_worker_from_auto_resume_timeout(worker_id).await;
+    }
+    let resume_input = match timeout_action.as_deref() {
+        Some("resume_with_summary") => None,
+        _ => Some(crate::stdlib::json_to_vm_value(&payload)),
+    };
+    let options = WorkerResumeOptions {
+        resume_input,
+        continue_transcript: timeout_action.as_deref() != Some("resume_with_summary"),
+    };
+    let state = with_worker_state(worker_id, |state| Ok(state.clone()))?;
+    warm_resume_worker(state, options).await
+}
+
+fn auto_resume_event_payload(event: &crate::triggers::TriggerEvent) -> serde_json::Value {
+    let payload = serde_json::to_value(&event.provider_payload).unwrap_or(serde_json::Value::Null);
+    payload.get("raw").cloned().unwrap_or(payload)
+}
+
+fn auto_resume_timeout_action(payload: &serde_json::Value) -> Option<String> {
+    if payload.get("type").and_then(|value| value.as_str()) != Some("auto_resume.timeout") {
+        return None;
+    }
+    payload
+        .get("on_timeout")
+        .and_then(|value| value.as_str())
+        .map(str::to_string)
+}
+
+async fn fail_suspended_worker_from_auto_resume_timeout(
+    worker_id: &str,
+) -> Result<VmValue, VmError> {
+    let state = with_worker_state(worker_id, |state| Ok(state.clone()))?;
+    let (snapshot, summary, suspension) = {
+        let mut worker = state.borrow_mut();
+        if worker.status != "suspended" {
+            return worker_summary(&worker);
+        }
+        worker.suspend_signal.store(false, Ordering::SeqCst);
+        let suspension = worker.suspension.take();
+        worker.status = "failed".to_string();
+        worker.finished_at = Some(uuid::Uuid::now_v7().to_string());
+        worker.latest_error = Some("auto-resume timeout expired".to_string());
+        if worker.carry_policy.persist_state {
+            persist_worker_state_snapshot(&worker)?;
+        }
+        (
+            worker_event_snapshot(&worker),
+            worker_summary(&worker)?,
+            suspension,
+        )
+    };
+    unregister_suspension_auto_resume(suspension).await?;
+    emit_worker_event(&snapshot, crate::agent_events::WorkerEvent::WorkerFailed).await?;
     Ok(summary)
 }
 
@@ -865,7 +957,7 @@ async fn close_agent_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
         .ok_or_else(|| VmError::Runtime("close_agent: missing worker handle".to_string()))?;
     let worker_id = worker_id_from_value(target)?;
     let state = with_worker_state(&worker_id, |state| Ok(state.clone()))?;
-    let (snapshot, summary) = {
+    let (snapshot, summary, suspension) = {
         let mut worker = state.borrow_mut();
         worker.cancel_token.store(true, Ordering::SeqCst);
         worker.suspend_signal.store(false, Ordering::SeqCst);
@@ -880,15 +972,16 @@ async fn close_agent_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
         // closed the cooperative-pause contract no longer applies, and
         // a stale `suspension` would mislead observers reading the
         // worker summary post-cancel.
-        worker.suspension = None;
+        let suspension = worker.suspension.take();
         worker.latest_error = Some("worker cancelled".to_string());
         if worker.carry_policy.persist_state {
             persist_worker_state_snapshot(&worker)?;
         }
         let snapshot = worker_event_snapshot(&worker);
         let summary = worker_summary(&worker)?;
-        (snapshot, summary)
+        (snapshot, summary, suspension)
     };
+    unregister_suspension_auto_resume(suspension).await?;
     emit_worker_event(&snapshot, crate::agent_events::WorkerEvent::WorkerCancelled).await?;
     Ok(summary)
 }
@@ -1219,6 +1312,67 @@ mod suspend_tests {
             .unwrap_or_default()
     }
 
+    fn auto_resume_conditions(kind: &str) -> VmValue {
+        VmValue::Dict(Rc::new(BTreeMap::from([(
+            "trigger".to_string(),
+            VmValue::Dict(Rc::new(BTreeMap::from([
+                (
+                    "kind".to_string(),
+                    VmValue::String(Rc::from(kind.to_string())),
+                ),
+                ("provider".to_string(), VmValue::String(Rc::from("github"))),
+            ]))),
+        )])))
+    }
+
+    fn auto_resume_conditions_with_timeout(kind: &str, on_timeout: &str) -> VmValue {
+        VmValue::Dict(Rc::new(BTreeMap::from([
+            (
+                "trigger".to_string(),
+                VmValue::Dict(Rc::new(BTreeMap::from([
+                    (
+                        "kind".to_string(),
+                        VmValue::String(Rc::from(kind.to_string())),
+                    ),
+                    ("provider".to_string(), VmValue::String(Rc::from("github"))),
+                ]))),
+            ),
+            (
+                "timeout".to_string(),
+                VmValue::Dict(Rc::new(BTreeMap::from([
+                    ("duration_minutes".to_string(), VmValue::Int(1)),
+                    (
+                        "on_timeout".to_string(),
+                        VmValue::String(Rc::from(on_timeout.to_string())),
+                    ),
+                ]))),
+            ),
+        ])))
+    }
+
+    fn suspend_options(conditions: VmValue) -> VmValue {
+        VmValue::Dict(Rc::new(BTreeMap::from([
+            ("initiator".to_string(), VmValue::String(Rc::from("self"))),
+            ("conditions".to_string(), conditions),
+        ])))
+    }
+
+    fn auto_resume_trigger_id(summary: &VmValue) -> String {
+        let json = crate::llm::vm_value_to_json(summary);
+        json["suspension"]["auto_resume_trigger"]["id"]
+            .as_str()
+            .expect("auto-resume trigger id")
+            .to_string()
+    }
+
+    fn worker_status_and_task(worker_id: &str) -> (String, String) {
+        WORKER_REGISTRY.with(|registry| {
+            let state = registry.borrow().get(worker_id).cloned().unwrap();
+            let worker = state.borrow();
+            (worker.status.clone(), worker.task.clone())
+        })
+    }
+
     #[test]
     fn resume_conditions_parse_round_trips_each_shape() {
         let trigger = VmValue::Dict(Rc::new(BTreeMap::from([(
@@ -1388,6 +1542,155 @@ mod suspend_tests {
         assert_eq!(summary_status(&closed), "cancelled");
 
         teardown(&dir, &worker_id);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn suspend_registers_auto_resume_trigger_and_operator_resume_unregisters() {
+        let _guard = suspend_test_lock().await;
+        crate::triggers::clear_trigger_registry();
+        crate::stdlib::triggers_stdlib::reset_auto_resume_timeouts();
+        let (worker_id, dir) = seed_test_worker("worker-auto-resume-register");
+
+        let suspended = suspend_agent_builtin(vec![
+            handle_value(&worker_id),
+            VmValue::String(Rc::from("waiting for review")),
+            suspend_options(auto_resume_conditions("review.approved")),
+        ])
+        .await
+        .expect("suspend with auto-resume trigger");
+        assert_eq!(summary_status(&suspended), "suspended");
+        let trigger_id = auto_resume_trigger_id(&suspended);
+        let binding = crate::triggers::resolve_live_trigger_binding(&trigger_id, None)
+            .expect("registered auto-resume binding");
+        assert_eq!(binding.kind, "auto_resume");
+        assert_eq!(binding.handler.kind(), "auto_resume");
+        assert_eq!(binding.match_events, vec!["review.approved".to_string()]);
+
+        let resumed = resume_agent_builtin(vec![handle_value(&worker_id)])
+            .await
+            .expect("operator resume");
+        assert_eq!(summary_status(&resumed), "running");
+        let snapshot = crate::triggers::snapshot_trigger_bindings()
+            .into_iter()
+            .find(|binding| binding.id == trigger_id)
+            .expect("auto-resume binding snapshot");
+        assert_eq!(snapshot.state, crate::triggers::TriggerState::Terminated);
+
+        teardown(&dir, &worker_id);
+        crate::triggers::clear_trigger_registry();
+        crate::stdlib::triggers_stdlib::reset_auto_resume_timeouts();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn matching_trigger_event_auto_resumes_worker_and_unregisters() {
+        let _guard = suspend_test_lock().await;
+        crate::triggers::clear_trigger_registry();
+        crate::stdlib::triggers_stdlib::reset_auto_resume_timeouts();
+        let log = crate::event_log::install_memory_for_current_thread(128);
+        let (worker_id, dir) = seed_test_worker("worker-auto-resume-dispatch");
+
+        let suspended = suspend_agent_builtin(vec![
+            handle_value(&worker_id),
+            VmValue::String(Rc::from("waiting for review")),
+            suspend_options(auto_resume_conditions("review.approved")),
+        ])
+        .await
+        .expect("suspend with auto-resume trigger");
+        let trigger_id = auto_resume_trigger_id(&suspended);
+        let event = crate::triggers::TriggerEvent::new(
+            crate::triggers::ProviderId::from("github"),
+            "review.approved",
+            None,
+            "delivery-auto-resume",
+            None,
+            BTreeMap::new(),
+            crate::triggers::ProviderPayload::Extension(
+                crate::triggers::ExtensionProviderPayload {
+                    provider: "github".to_string(),
+                    schema_name: "ReviewEvent".to_string(),
+                    raw: serde_json::json!({"decision": "approved"}),
+                },
+            ),
+            crate::triggers::SignatureStatus::Unsigned,
+        );
+        let dispatcher = crate::triggers::Dispatcher::with_event_log(crate::Vm::new(), log);
+        let outcomes = dispatcher
+            .dispatch_event(event)
+            .await
+            .expect("dispatch auto-resume event");
+        assert_eq!(outcomes.len(), 1);
+        assert_eq!(
+            outcomes[0].status,
+            crate::triggers::DispatchStatus::Succeeded
+        );
+        assert_eq!(outcomes[0].handler_kind, "auto_resume");
+
+        let (status, task) = worker_status_and_task(&worker_id);
+        assert_eq!(status, "running");
+        assert!(
+            task.contains("approved"),
+            "resume input should carry trigger payload, got: {task}"
+        );
+        let snapshot = crate::triggers::snapshot_trigger_bindings()
+            .into_iter()
+            .find(|binding| binding.id == trigger_id)
+            .expect("auto-resume binding snapshot");
+        assert_eq!(snapshot.state, crate::triggers::TriggerState::Terminated);
+
+        teardown(&dir, &worker_id);
+        crate::triggers::clear_trigger_registry();
+        crate::stdlib::triggers_stdlib::reset_auto_resume_timeouts();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn auto_resume_timeout_dispatches_synthetic_resume_input() {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let _guard = suspend_test_lock().await;
+                crate::triggers::clear_trigger_registry();
+                crate::stdlib::triggers_stdlib::reset_auto_resume_timeouts();
+                let log = crate::event_log::install_memory_for_current_thread(128);
+                drop(log);
+                let clock = crate::triggers::test_util::clock::MockClock::at_wall_ms(0);
+                let _clock_guard =
+                    crate::triggers::test_util::clock::install_override(clock.clone());
+                let (worker_id, dir) = seed_test_worker("worker-auto-resume-timeout");
+
+                let suspended = suspend_agent_builtin(vec![
+                    handle_value(&worker_id),
+                    VmValue::String(Rc::from("waiting for review or timeout")),
+                    suspend_options(auto_resume_conditions_with_timeout(
+                        "review.approved",
+                        "resume_with_input",
+                    )),
+                ])
+                .await
+                .expect("suspend with auto-resume timeout");
+                let trigger_id = auto_resume_trigger_id(&suspended);
+
+                tokio::task::yield_now().await;
+                clock.advance_std(std::time::Duration::from_secs(60)).await;
+                tokio::task::yield_now().await;
+                tokio::task::yield_now().await;
+
+                let (status, task) = worker_status_and_task(&worker_id);
+                assert_eq!(status, "running");
+                assert!(
+                    task.contains("auto_resume.timeout"),
+                    "timeout resume input should name synthetic event, got: {task}"
+                );
+                let snapshot = crate::triggers::snapshot_trigger_bindings()
+                    .into_iter()
+                    .find(|binding| binding.id == trigger_id)
+                    .expect("auto-resume binding snapshot");
+                assert_eq!(snapshot.state, crate::triggers::TriggerState::Terminated);
+
+                teardown(&dir, &worker_id);
+                crate::triggers::clear_trigger_registry();
+                crate::stdlib::triggers_stdlib::reset_auto_resume_timeouts();
+            })
+            .await;
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/harn-vm/src/stdlib/agents_workers/mod.rs
+++ b/crates/harn-vm/src/stdlib/agents_workers/mod.rs
@@ -139,6 +139,8 @@ pub(crate) struct WorkerSuspension {
     pub(crate) snapshot_ref: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) conditions: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) auto_resume_trigger: Option<crate::stdlib::triggers_stdlib::AutoResumeTriggerHandle>,
 }
 
 #[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize, PartialEq, Eq)]

--- a/crates/harn-vm/src/stdlib/triggers_stdlib.rs
+++ b/crates/harn-vm/src/stdlib/triggers_stdlib.rs
@@ -1,5 +1,7 @@
+use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::rc::Rc;
+use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
@@ -12,13 +14,14 @@ use crate::triggers::dispatcher::current_dispatch_context;
 use crate::triggers::dispatcher::DEFAULT_MAX_ATTEMPTS;
 use crate::triggers::test_util::{clock, run_trigger_harness_fixture};
 use crate::triggers::{
-    deregister_webhook_intake, dynamic_register, feed_webhook_intake, recent_webhook_deliveries,
-    register_webhook_intake, registered_provider_metadata, resolve_live_or_as_of,
-    resolve_live_trigger_binding, snapshot_trigger_bindings, snapshot_webhook_intakes,
-    HmacAlgorithm, RecordedTriggerBinding, RetryPolicy, SignatureEncoding, TriggerBindingSnapshot,
-    TriggerBindingSource, TriggerBindingSpec, TriggerEvent, TriggerEventId, TriggerHandlerSpec,
-    TriggerPredicateSpec, TriggerRegistryError, TriggerRetryConfig, WebhookIntakeConfig,
-    WebhookIntakeError, WebhookIntakeRequest, TRIGGERS_LIFECYCLE_TOPIC, TRIGGER_DLQ_TOPIC,
+    deregister_webhook_intake, dynamic_deregister, dynamic_register, feed_webhook_intake,
+    recent_webhook_deliveries, register_webhook_intake, registered_provider_metadata,
+    resolve_live_or_as_of, resolve_live_trigger_binding, snapshot_trigger_bindings,
+    snapshot_webhook_intakes, HmacAlgorithm, RecordedTriggerBinding, RetryPolicy,
+    SignatureEncoding, TriggerBindingSnapshot, TriggerBindingSource, TriggerBindingSpec,
+    TriggerEvent, TriggerEventId, TriggerHandlerSpec, TriggerPredicateSpec, TriggerRegistryError,
+    TriggerRetryConfig, WebhookIntakeConfig, WebhookIntakeError, WebhookIntakeRequest,
+    TRIGGERS_LIFECYCLE_TOPIC, TRIGGER_DLQ_TOPIC,
 };
 use crate::trust_graph::{
     group_trust_records_by_trace, policy_for_agent, query_trust_graph_records, query_trust_records,
@@ -32,6 +35,17 @@ use crate::TriggerPredicateBudget;
 const ACTION_GRAPH_TOPIC: &str = "observability.action_graph";
 const TRIGGER_EVENTS_TOPIC: &str = "triggers.events";
 const TRIGGER_EVENT_LOG_QUEUE_DEPTH: usize = 128;
+
+thread_local! {
+    static AUTO_RESUME_TIMEOUTS: RefCell<BTreeMap<String, tokio::task::JoinHandle<()>>> =
+        const { RefCell::new(BTreeMap::new()) };
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct AutoResumeTriggerHandle {
+    pub(crate) id: String,
+    pub(crate) version: u32,
+}
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 struct TriggerEventRecord {
@@ -1180,6 +1194,220 @@ pub(crate) fn validate_resume_trigger_spec(
         .entry("handler".to_string())
         .or_insert_with(|| VmValue::String(Rc::from("worker://__resume_auto_resume__")));
     parse_trigger_config(&normalized).map(|_| ())
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct AutoResumeTimeoutSpec {
+    duration_minutes: u64,
+    on_timeout: String,
+}
+
+pub(crate) async fn register_auto_resume_trigger(
+    worker_id: &str,
+    conditions: Option<&VmValue>,
+) -> Result<Option<AutoResumeTriggerHandle>, VmError> {
+    let Some(VmValue::Dict(conditions)) = conditions else {
+        return Ok(None);
+    };
+    let Some(trigger) = conditions.get("trigger") else {
+        return Ok(None);
+    };
+    let VmValue::Dict(trigger_config) = trigger else {
+        if matches!(trigger, VmValue::Nil) {
+            return Ok(None);
+        }
+        return Err(VmError::Runtime(format!(
+            "auto_resume: conditions.trigger must be a dict or nil, got {}",
+            trigger.type_name()
+        )));
+    };
+
+    let mut normalized = trigger_config.as_ref().clone();
+    normalized.insert(
+        "handler".to_string(),
+        VmValue::String(Rc::from("worker://__resume_auto_resume__")),
+    );
+    let mut spec = parse_trigger_config(&normalized)?;
+    let source_kind = spec.kind.clone();
+    if spec.match_events.is_empty() {
+        spec.match_events.push(source_kind);
+    }
+    spec.id = format!(
+        "auto_resume_{}_{}",
+        sanitize_auto_resume_id(worker_id),
+        Uuid::now_v7()
+    );
+    spec.kind = "auto_resume".to_string();
+    spec.handler = TriggerHandlerSpec::AutoResume {
+        worker_id: worker_id.to_string(),
+    };
+    spec.definition_fingerprint = serde_json::to_string(&serde_json::json!({
+        "kind": "auto_resume",
+        "worker_id": worker_id,
+        "trigger": crate::llm::vm_value_to_json(trigger),
+        "match_events": spec.match_events,
+    }))
+    .unwrap_or_else(|_| format!("auto_resume:{worker_id}"));
+
+    let id = dynamic_register(spec)
+        .await
+        .map_err(trigger_registry_error)?;
+    let binding =
+        resolve_live_trigger_binding(id.as_str(), None).map_err(trigger_registry_error)?;
+    let handle = AutoResumeTriggerHandle {
+        id: id.as_str().to_string(),
+        version: binding.version,
+    };
+    if let Some(timeout) = auto_resume_timeout_spec(conditions)? {
+        schedule_auto_resume_timeout(handle.clone(), worker_id.to_string(), timeout);
+    }
+    Ok(Some(handle))
+}
+
+pub(crate) async fn unregister_auto_resume_trigger(
+    handle: &AutoResumeTriggerHandle,
+) -> Result<(), VmError> {
+    cancel_auto_resume_timeout(handle.id.as_str());
+    match dynamic_deregister(handle.id.as_str()).await {
+        Ok(()) | Err(TriggerRegistryError::UnknownId(_)) => Ok(()),
+        Err(error) => Err(trigger_registry_error(error)),
+    }
+}
+
+pub(crate) fn reset_auto_resume_timeouts() {
+    AUTO_RESUME_TIMEOUTS.with(|slot| {
+        let mut tasks = slot.borrow_mut();
+        for (_, task) in std::mem::take(&mut *tasks) {
+            task.abort();
+        }
+    });
+}
+
+fn sanitize_auto_resume_id(worker_id: &str) -> String {
+    worker_id
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '_' || ch == '-' {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+fn auto_resume_timeout_spec(
+    conditions: &BTreeMap<String, VmValue>,
+) -> Result<Option<AutoResumeTimeoutSpec>, VmError> {
+    let Some(timeout) = conditions.get("timeout") else {
+        return Ok(None);
+    };
+    let VmValue::Dict(timeout) = timeout else {
+        if matches!(timeout, VmValue::Nil) {
+            return Ok(None);
+        }
+        return Err(VmError::Runtime(format!(
+            "auto_resume: conditions.timeout must be a dict or nil, got {}",
+            timeout.type_name()
+        )));
+    };
+    let duration_minutes = timeout
+        .get("duration_minutes")
+        .and_then(VmValue::as_int)
+        .filter(|value| *value > 0)
+        .ok_or_else(|| {
+            VmError::Runtime(
+                "auto_resume: conditions.timeout.duration_minutes must be a positive int"
+                    .to_string(),
+            )
+        })? as u64;
+    let on_timeout = match timeout.get("on_timeout") {
+        Some(VmValue::String(value))
+            if matches!(
+                value.as_ref(),
+                "resume_with_summary" | "resume_with_input" | "fail"
+            ) =>
+        {
+            value.to_string()
+        }
+        Some(VmValue::Nil) | None => "resume_with_summary".to_string(),
+        Some(other) => {
+            return Err(VmError::Runtime(format!(
+                "auto_resume: conditions.timeout.on_timeout must be resume_with_summary, resume_with_input, or fail; got {}",
+                other.type_name()
+            )))
+        }
+    };
+    Ok(Some(AutoResumeTimeoutSpec {
+        duration_minutes,
+        on_timeout,
+    }))
+}
+
+fn cancel_auto_resume_timeout(trigger_id: &str) {
+    AUTO_RESUME_TIMEOUTS.with(|slot| {
+        if let Some(task) = slot.borrow_mut().remove(trigger_id) {
+            task.abort();
+        }
+    });
+}
+
+fn schedule_auto_resume_timeout(
+    handle: AutoResumeTriggerHandle,
+    worker_id: String,
+    timeout: AutoResumeTimeoutSpec,
+) {
+    cancel_auto_resume_timeout(handle.id.as_str());
+    let event_log = ensure_trigger_event_log();
+    let base_vm = crate::vm::clone_async_builtin_child_vm().unwrap_or_else(Vm::new);
+    let event = auto_resume_timeout_event(&handle, &worker_id, &timeout);
+    let trigger_id = handle.id.clone();
+    let version = handle.version;
+    let task_trigger_id = trigger_id.clone();
+    let task = tokio::task::spawn_local(async move {
+        clock::sleep(Duration::from_secs(
+            timeout.duration_minutes.saturating_mul(60),
+        ))
+        .await;
+        AUTO_RESUME_TIMEOUTS.with(|slot| {
+            slot.borrow_mut().remove(task_trigger_id.as_str());
+        });
+        let Ok(binding) = resolve_live_trigger_binding(trigger_id.as_str(), Some(version)) else {
+            return;
+        };
+        let dispatcher = crate::triggers::Dispatcher::with_event_log(base_vm, event_log);
+        let _ = dispatcher.dispatch(&binding, event).await;
+    });
+    AUTO_RESUME_TIMEOUTS.with(|slot| {
+        slot.borrow_mut().insert(handle.id.clone(), task);
+    });
+}
+
+fn auto_resume_timeout_event(
+    handle: &AutoResumeTriggerHandle,
+    worker_id: &str,
+    timeout: &AutoResumeTimeoutSpec,
+) -> TriggerEvent {
+    let raw = serde_json::json!({
+        "type": "auto_resume.timeout",
+        "worker_id": worker_id,
+        "trigger_id": handle.id,
+        "on_timeout": timeout.on_timeout,
+    });
+    TriggerEvent::new(
+        crate::triggers::ProviderId::from("harn"),
+        "auto_resume.timeout",
+        None,
+        format!("auto_resume_timeout:{}:{}", handle.id, Uuid::now_v7()),
+        None,
+        BTreeMap::new(),
+        crate::triggers::ProviderPayload::Extension(crate::triggers::ExtensionProviderPayload {
+            provider: "harn".to_string(),
+            schema_name: "AutoResumeTimeout".to_string(),
+            raw,
+        }),
+        crate::triggers::SignatureStatus::Unsigned,
+    )
 }
 
 fn parse_duration_millis(raw: &str) -> Result<u64, VmError> {

--- a/crates/harn-vm/src/triggers/dispatcher/action_graph.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/action_graph.rs
@@ -70,6 +70,7 @@ pub(super) fn dispatch_success_outcome(
         }
         DispatchUri::A2a { .. } => "completed",
         DispatchUri::Local { .. } => "success",
+        DispatchUri::AutoResume { .. } => "resumed",
     }
 }
 
@@ -270,7 +271,7 @@ pub(super) fn dispatch_success_metadata(
                 metadata.insert("status".to_string(), serde_json::json!(status));
             }
         }
-        DispatchUri::Local { .. } => {}
+        DispatchUri::Local { .. } | DispatchUri::AutoResume { .. } => {}
     }
     metadata
 }

--- a/crates/harn-vm/src/triggers/dispatcher/mod.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/mod.rs
@@ -2131,6 +2131,19 @@ impl Dispatcher {
                     metadata: route.dispatch_boundary_metadata(),
                 })
             }
+            DispatchUri::AutoResume { worker_id } => {
+                let value =
+                    crate::stdlib::agents::resume_worker_from_auto_resume_trigger(worker_id, event)
+                        .await
+                        .map_err(|error| DispatchError::Local(error.to_string()))?;
+                let mut metadata = route.dispatch_boundary_metadata();
+                metadata.insert("worker_id".to_string(), serde_json::json!(worker_id));
+                metadata.insert("resume_kind".to_string(), serde_json::json!("auto_resume"));
+                Ok(DispatchCallResult {
+                    output: vm_value_to_json(&value),
+                    metadata,
+                })
+            }
         }
     }
 

--- a/crates/harn-vm/src/triggers/dispatcher/uri.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/uri.rs
@@ -36,6 +36,9 @@ pub enum DispatchUri {
     Persona {
         name: String,
     },
+    AutoResume {
+        worker_id: String,
+    },
 }
 
 impl DispatchUri {
@@ -89,6 +92,7 @@ impl DispatchUri {
             Self::A2a { .. } => "a2a",
             Self::Worker { .. } => "worker",
             Self::Persona { .. } => "persona",
+            Self::AutoResume { .. } => "auto_resume",
         }
     }
 
@@ -98,6 +102,7 @@ impl DispatchUri {
             Self::A2a { target, .. } => format!("a2a://{target}"),
             Self::Worker { queue } => format!("worker://{queue}"),
             Self::Persona { name } => format!("persona://{name}"),
+            Self::AutoResume { worker_id } => format!("auto_resume://{worker_id}"),
         }
     }
 
@@ -107,6 +112,7 @@ impl DispatchUri {
             Self::A2a { .. } => "federated_a2a",
             Self::Worker { .. } => "event_log_worker_queue",
             Self::Persona { .. } => "persona_runtime",
+            Self::AutoResume { .. } => "local_process",
         }
     }
 
@@ -116,6 +122,7 @@ impl DispatchUri {
             Self::A2a { .. } => "remote",
             Self::Worker { .. } => "queued",
             Self::Persona { .. } => "managed_persona",
+            Self::AutoResume { .. } => "in_process",
         }
     }
 
@@ -164,6 +171,9 @@ impl From<&TriggerHandlerSpec> for DispatchUri {
             },
             TriggerHandlerSpec::Persona { binding } => Self::Persona {
                 name: binding.name.clone(),
+            },
+            TriggerHandlerSpec::AutoResume { worker_id } => Self::AutoResume {
+                worker_id: worker_id.clone(),
             },
         }
     }

--- a/crates/harn-vm/src/triggers/registry.rs
+++ b/crates/harn-vm/src/triggers/registry.rs
@@ -151,6 +151,9 @@ pub enum TriggerHandlerSpec {
     Persona {
         binding: crate::PersonaRuntimeBinding,
     },
+    AutoResume {
+        worker_id: String,
+    },
 }
 
 impl std::fmt::Debug for TriggerHandlerSpec {
@@ -170,6 +173,10 @@ impl std::fmt::Debug for TriggerHandlerSpec {
                 .debug_struct("Persona")
                 .field("name", &binding.name)
                 .finish(),
+            Self::AutoResume { worker_id } => f
+                .debug_struct("AutoResume")
+                .field("worker_id", worker_id)
+                .finish(),
         }
     }
 }
@@ -181,6 +188,7 @@ impl TriggerHandlerSpec {
             Self::A2a { .. } => "a2a",
             Self::Worker { .. } => "worker",
             Self::Persona { .. } => "persona",
+            Self::AutoResume { .. } => "auto_resume",
         }
     }
 }


### PR DESCRIPTION
## Summary
- register `conditions.trigger` suspensions as dynamic `auto_resume` trigger bindings
- route matching dispatcher events and timeout events back through warm `resume_agent` semantics
- unregister auto-resume bindings on resume/close and cover the behavior with Rust + conformance tests

Closes #1842.

## Verification
- CARGO_TARGET_DIR=/tmp/harn-target-1842 cargo test -p harn-vm auto_resume -- --nocapture
- CARGO_TARGET_DIR=/tmp/harn-target-1842 cargo run --quiet --bin harn -- test conformance --filter agent_auto_resume_trigger
- CARGO_TARGET_DIR=/tmp/harn-target-1842 cargo check --workspace --tests
- CARGO_TARGET_DIR=/tmp/harn-target-1842 make conformance
- make lint-test-patterns