### PR TITLE
Refactor daemon idle onto await-resumption metadata

### DIFF
--- a/conformance/tests/agents/agent_daemon_await_resumption.expected
+++ b/conformance/tests/agents/agent_daemon_await_resumption.expected
@@ -1,0 +1,7 @@
+budget_exhausted
+true
+daemon_idle
+daemon idle
+self
+1
+resume_with_input

--- a/conformance/tests/agents/agent_daemon_await_resumption.harn
+++ b/conformance/tests/agents/agent_daemon_await_resumption.harn
@@ -1,0 +1,25 @@
+import { agent_capture_events } from "std/agent/events"
+
+pipeline test(task) {
+  let session_id = "daemon-await-resumption-" + uuid()
+  llm_mock({text: "daemon idle"})
+  let captured = agent_capture_events(
+    session_id,
+    fn() { return agent_loop(
+      "Poll for background work",
+      nil,
+      {provider: "mock", daemon: true, max_iterations: 1, wake_interval_ms: 1, session_id: session_id},
+    ) },
+  )
+  let audit = captured.events
+    .filter(
+    { event -> event.type == "tool_call_audit" && event.tool_name == "agent_await_resumption" },
+  )
+  println(captured.result.status)
+  println(len(audit) == 1)
+  println(audit[0]?.audit?.status)
+  println(audit[0]?.audit?.reason)
+  println(audit[0]?.audit?.initiator)
+  println(audit[0]?.audit?.conditions?.timeout?.duration_minutes)
+  println(audit[0]?.audit?.conditions?.timeout?.on_timeout)
+}

--- a/crates/harn-stdlib/src/stdlib/agent/daemon.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/daemon.harn
@@ -1,6 +1,7 @@
 // @harn-entrypoint-category agent.stdlib
 import { daemon_timer_feedback_prompt, daemon_watch_feedback_prompt } from "std/agent/prompts"
-import { agent_session_inject_feedback } from "std/agent/state"
+import { agent_emit_event, agent_session_inject_feedback } from "std/agent/state"
+import { agent_await_resumption } from "std/agent/workers"
 
 fn __daemon_compaction_summary(opts) {
   if !(opts?.consolidate_on_idle ?? false) {
@@ -45,6 +46,52 @@ fn __agent_daemon_feedback(wake, opts) {
   return nil
 }
 
+fn __agent_daemon_timeout_condition(timeout_ms) {
+  if timeout_ms <= 0 {
+    return nil
+  }
+  return {
+    duration_minutes: to_int(max(1, ceil(timeout_ms * 1.0 / 60000.0))),
+    on_timeout: "resume_with_input",
+  }
+}
+
+fn __agent_daemon_raw_resume_conditions(opts, timeout_ms) {
+  var conditions = {}
+  let timeout = __agent_daemon_timeout_condition(timeout_ms)
+  if timeout != nil {
+    conditions = conditions + {timeout: timeout}
+  }
+  let event_topic = opts?.resume_event_topic ?? opts?.daemon_event_topic ?? nil
+  if event_topic != nil {
+    conditions = conditions + {on_event: event_topic}
+  }
+  if len(conditions.keys()) == 0 {
+    return nil
+  }
+  return conditions
+}
+
+fn __agent_daemon_await_resumption(session, opts, iteration, timeout_ms) {
+  let request = agent_await_resumption("daemon idle", __agent_daemon_raw_resume_conditions(opts, timeout_ms))
+  agent_emit_event(
+    session.session_id,
+    "tool_call_audit",
+    {
+      tool_call_id: "daemon_idle:" + to_string(iteration),
+      tool_name: "agent_await_resumption",
+      audit: {
+        layer: "agent_lifecycle",
+        status: "daemon_idle",
+        initiator: "self",
+        reason: request.reason,
+        conditions: request.conditions,
+      },
+    },
+  )
+  return request
+}
+
 /**
  * agent_daemon_snapshot.
  *
@@ -75,6 +122,7 @@ pub fn agent_daemon_snapshot(session, opts, daemon_state = "idle", iteration = 0
 pub fn agent_daemon_step(session, opts, iteration) {
   let snapshot = agent_daemon_snapshot(session, opts, "idle", iteration)
   let timeout = opts?.wake_interval_ms ?? 0
+  __agent_daemon_await_resumption(session, opts, iteration, timeout)
   __host_fire_session_hook(
     "session_idle",
     {

--- a/crates/harn-stdlib/src/stdlib/agent/loop.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/loop.harn
@@ -28,9 +28,9 @@ import {
   agent_tool_search_record_results,
 } from "std/agent/tool_search"
 import {
+  agent_await_resumption,
   agent_lifecycle_tools,
   list_agents,
-  parse_resume_conditions,
   suspend_agent,
 } from "std/agent/workers"
 import { llm_call_options } from "std/llm/options"
@@ -386,11 +386,7 @@ fn __agent_await_resumption_call(tool_calls) {
 
 fn __agent_await_resumption_args(call) {
   let args = __tool_call_args(call)
-  let reason = trim(to_string(args?.reason ?? ""))
-  if reason == "" {
-    throw "agent_await_resumption: reason is required"
-  }
-  return {reason: reason, conditions: parse_resume_conditions(args?.conditions ?? nil)}
+  return agent_await_resumption(args?.reason ?? "", args?.conditions ?? nil)
 }
 
 fn __agent_loop_await_resumption(session, iteration, call, opts) {

--- a/crates/harn-stdlib/src/stdlib/agent/workers.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/workers.harn
@@ -8,6 +8,8 @@ type ResumeTimeoutSpec = {duration_minutes: int, on_timeout: ResumeTimeoutAction
 
 type ResumeConditions = {trigger: dict?, timeout: ResumeTimeoutSpec?, on_event: string?}
 
+type AgentAwaitResumptionRequest = {reason: string, conditions: ResumeConditions?}
+
 fn __agent_option_keys() {
   return [
     "provider",
@@ -375,6 +377,28 @@ pub fn spawn_agent(config) {
  */
 pub fn parse_resume_conditions(conditions = nil) -> ResumeConditions? {
   return __host_resume_conditions_parse(conditions)
+}
+
+/**
+ * agent_await_resumption.
+ *
+ * Build the normalized request used by the model-facing
+ * `agent_await_resumption` lifecycle tool. `agent_loop` decides whether that
+ * request becomes a worker suspension, a top-level suspension checkpoint, or
+ * daemon idle metadata.
+ *
+ * @effects: [host]
+ * @allocation: heap
+ * @errors: [HARN-SUS-002]
+ * @api_stability: experimental
+ * @example: agent_await_resumption("waiting on review", {timeout: {duration_minutes: 5}})
+ */
+pub fn agent_await_resumption(reason, conditions = nil) -> AgentAwaitResumptionRequest {
+  let normalized_reason = trim(to_string(reason ?? ""))
+  if normalized_reason == "" {
+    throw "agent_await_resumption: reason is required"
+  }
+  return {reason: normalized_reason, conditions: parse_resume_conditions(conditions)}
 }
 
 /**

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -1829,7 +1829,8 @@ sentinel-only completion gate.
 
 Self-parking agents use a shared `ResumeConditions` shape for
 `agent_await_resumption(reason, conditions?)` and `spawn_agent({options: {resume_when:
-...}})`. Call `parse_resume_conditions(conditions?)` from
+...}})`. Call `parse_resume_conditions(conditions?)` or
+`agent_await_resumption(reason, conditions?)` from
 `std/agent/workers` when you need to validate or normalize the shape
 without spawning a worker.
 

--- a/docs/src/llm/agent_loop.md
+++ b/docs/src/llm/agent_loop.md
@@ -598,6 +598,11 @@ terminating on a text-only turn. Idle daemons can be woken by queued human
 messages, `agent/resume` bridge notifications, `wake_interval_ms`, or watched
 file changes from `watch_paths`.
 
+Daemon idle is a special case of `agent_await_resumption`: the stdlib records
+the same lifecycle audit and normalized `ResumeConditions` metadata, with
+`timeout` / `on_event` preconfigured from daemon options, while keeping the
+existing in-process idle wait so daemon-mode return behavior is unchanged.
+
 For MCP server tool catalogs, see [MCP server tools](./tools.md#mcp-server-tools).
 
 Native-tool stages also expose structured fallback / retry metadata in the
@@ -997,6 +1002,7 @@ Worker lifecycle builtins:
 | `suspend_agent(worker, reason?, options?)` | Cooperatively suspend a worker, persist a resumable snapshot, and return `status: "suspended"` with `suspension` metadata |
 | `resume_agent(worker_or_snapshot, resume_input?, continue_transcript?)` | Resume a suspended worker, optionally with new input; set `continue_transcript=false` to resume from the prior summary plus new input only |
 | `parse_resume_conditions(conditions?)` | Validate `trigger`, `timeout`, and `on_event` resume conditions for self-park and `spawn_agent({options: {resume_when}})` |
+| `agent_await_resumption(reason, conditions?)` | Normalize the lifecycle-tool request used by `agent_loop` and daemon idle; `agent_loop` performs the actual suspension when the model calls the tool |
 | `wait_agent(handle_or_list)` | Wait for one worker or a list of workers to finish |
 | `close_agent(handle)` | Cancel a worker and mark it terminal |
 | `list_agents()` | Return summaries for all known workers in the current runtime |

--- a/docs/src/stdlib/daemon.md
+++ b/docs/src/stdlib/daemon.md
@@ -4,6 +4,12 @@ Harn's daemon builtins wrap the existing `agent_loop(..., {daemon: true})`
 runtime so scripts can manage long-lived assistants without hand-assembling
 snapshot paths and resume options.
 
+Daemon idle is implemented as a special case of `agent_await_resumption` with
+`timeout` / `on_event` resume conditions preconfigured from daemon options. The
+runtime still waits in-process at the idle boundary, so existing daemon loops
+keep their `active -> idle -> active` behavior instead of returning a suspended
+handle to the caller.
+
 ## Builtins
 
 ### `daemon_spawn(config)`


### PR DESCRIPTION
Closes #1843.

## Summary
- Add a shared `agent_await_resumption(reason, conditions?)` stdlib normalizer for the lifecycle-tool request.
- Route daemon idle through that helper so daemon idle records the same normalized ResumeConditions metadata and lifecycle audit shape.
- Preserve existing daemon in-process idle wait and `{snapshot, wake}` return behavior.
- Document daemon idle as a special case of `agent_await_resumption`.

## Verification
- `CARGO_TARGET_DIR=/tmp/harn-target-1843 cargo run --quiet --bin harn -- fmt --check crates/harn-stdlib/src/stdlib/agent/workers.harn crates/harn-stdlib/src/stdlib/agent/loop.harn crates/harn-stdlib/src/stdlib/agent/daemon.harn conformance/tests/agents/agent_daemon_await_resumption.harn`
- `CARGO_TARGET_DIR=/tmp/harn-target-1843 cargo run --quiet --bin harn -- lint crates/harn-stdlib/src/stdlib/agent/workers.harn crates/harn-stdlib/src/stdlib/agent/loop.harn crates/harn-stdlib/src/stdlib/agent/daemon.harn conformance/tests/agents/agent_daemon_await_resumption.harn`
- `CARGO_TARGET_DIR=/tmp/harn-target-1843 cargo run --quiet --bin harn -- test conformance --filter agent_daemon_await_resumption`
- `CARGO_TARGET_DIR=/tmp/harn-target-1843 cargo run --quiet --bin harn -- test conformance --filter agent_daemon_mode`
- `CARGO_TARGET_DIR=/tmp/harn-target-1843 cargo run --quiet --bin harn -- test conformance --filter daemon_stdlib_wrappers`
- `CARGO_TARGET_DIR=/tmp/harn-target-1843 cargo run --quiet --bin harn -- test conformance --filter agent_await_resumption`
- `CARGO_TARGET_DIR=/tmp/harn-target-1843 cargo run --quiet --bin harn -- test conformance --filter session_idle`
- `CARGO_TARGET_DIR=/tmp/harn-target-1843 cargo check --workspace --tests`
- `make lint-test-patterns`
- `npx markdownlint-cli2 docs/llm/harn-quickref.md docs/src/llm/agent_loop.md docs/src/stdlib/daemon.md`
- `CARGO_TARGET_DIR=/tmp/harn-target-1843 make conformance` (`1133 passed, 0 failed`)
