### PR TITLE
Add hook-emitted system reminders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,16 @@ condensed series summaries instead of full per-patch history.
   post-turn processing now decrements finite `ttl_turns`, removes
   expired reminders, and emits `transcript.reminder.expired`; provider
   rendering remains a follow-up.
+- **Hook-emitted system reminders (#1819).** Tool, persona, step, and
+  session hooks can now return typed reminder effects using
+  `{reminder: {body, tags?, dedupe_key?, ttl_turns?,
+  preserve_on_compact?, propagate?, role_hint?}, then?}`, a bare
+  reminder spec, or a session-level effect list. Hook reminders inject
+  into the active session transcript as `system_reminder` events, use
+  `source: "hook"`, honor `dedupe_key`, and compose with existing
+  allow/deny/modify/block/decision return shapes. `register_tool_hook`
+  also accepts `pre` and `post` closures alongside the legacy `deny`
+  and `max_output` shortcuts.
 - **OAuth provider catalogue records (#1905).** Adds
   `std/oauth/providers` with ten preconfigured OAuth provider records
   (GitHub, Slack, Linear, Notion, Google, Microsoft, Atlassian,

--- a/conformance/tests/hook_emits_reminder_persona.expected
+++ b/conformance/tests/hook_emits_reminder_persona.expected
@@ -1,0 +1,5 @@
+done
+1
+persona hook reminder
+hook
+persona

--- a/conformance/tests/hook_emits_reminder_persona.harn
+++ b/conformance/tests/hook_emits_reminder_persona.harn
@@ -1,0 +1,55 @@
+@persona(name: "hooked_persona")
+fn hooked_persona(input) -> string {
+  return persona_work(input)
+}
+
+@step(name: "persona_work")
+fn persona_work(input) -> string {
+  return "persona:" + input
+}
+
+fn persona_hook_tools() {
+  let registry = tool_registry()
+  return tool_define(
+    registry,
+    "persona_hook_tool",
+    "Call a Harn persona",
+    {parameters: {}, handler: { _args -> hooked_persona("tool") }},
+  )
+}
+
+pipeline main() {
+  clear_persona_hooks()
+  register_persona_hook(
+    "hooked_*",
+    "PreStep",
+    { ctx ->
+      if ctx.persona == "hooked_persona" {
+        return {body: "persona hook reminder", tags: ["persona"]}
+      }
+      return nil
+    },
+  )
+  llm_mock_clear()
+  llm_mock({tool_calls: [{id: "persona_1", name: "persona_hook_tool", arguments: {}}]})
+  llm_mock({text: "<done>##DONE##</done>"})
+  let result = agent_loop(
+    "call the persona hook tool",
+    nil,
+    {
+      provider: "mock",
+      tools: persona_hook_tools(),
+      tool_format: "native",
+      max_iterations: 2,
+      loop_until_done: true,
+      session_id: "hook-reminder-persona",
+    },
+  )
+  let events = transcript_events_by_kind(result.transcript, "system_reminder")
+  println(result.status)
+  println(len(events))
+  println(events[0].reminder.body)
+  println(events[0].reminder.source)
+  println(events[0].reminder.tags[0])
+  clear_persona_hooks()
+}

--- a/conformance/tests/hook_emits_reminder_session.expected
+++ b/conformance/tests/hook_emits_reminder_session.expected
@@ -1,0 +1,5 @@
+done
+1
+session reminder fresh
+hook
+session

--- a/conformance/tests/hook_emits_reminder_session.harn
+++ b/conformance/tests/hook_emits_reminder_session.harn
@@ -1,0 +1,20 @@
+pipeline main() {
+  clear_session_hooks()
+  register_session_hook(
+    "post_turn",
+    { _event -> return [
+      {reminder: {body: "session reminder stale", dedupe_key: "session-hook", tags: ["session"]}},
+      {reminder: {body: "session reminder fresh", dedupe_key: "session-hook", tags: ["session"]}},
+    ] },
+  )
+  llm_mock_clear()
+  llm_mock({text: "done"})
+  let result = agent_loop("session hook reminder", nil, {provider: "mock", session_id: "hook-reminder-session"})
+  let events = transcript_events_by_kind(result.transcript, "system_reminder")
+  println(result.status)
+  println(len(events))
+  println(events[0].reminder.body)
+  println(events[0].reminder.source)
+  println(events[0].reminder.tags[0])
+  clear_session_hooks()
+}

--- a/conformance/tests/hook_emits_reminder_step.expected
+++ b/conformance/tests/hook_emits_reminder_step.expected
@@ -1,0 +1,5 @@
+done
+1
+step hook reminder
+hook
+step

--- a/conformance/tests/hook_emits_reminder_step.harn
+++ b/conformance/tests/hook_emits_reminder_step.harn
@@ -1,0 +1,51 @@
+@step(name: "watched_step")
+fn watched_step(input) -> string {
+  return "step:" + input
+}
+
+@persona(name: "step_hook_persona")
+fn step_hook_persona(input) -> string {
+  return watched_step(input)
+}
+
+fn step_hook_tools() {
+  let registry = tool_registry()
+  return tool_define(
+    registry,
+    "step_hook_tool",
+    "Call a Harn step",
+    {parameters: {}, handler: { _args -> step_hook_persona("tool") }},
+  )
+}
+
+pipeline main() {
+  clear_persona_hooks()
+  register_step_hook(
+    "step_hook_persona",
+    "watched_step",
+    "PreStep",
+    { _ctx -> return {reminder: {body: "step hook reminder", tags: ["step"]}} },
+  )
+  llm_mock_clear()
+  llm_mock({tool_calls: [{id: "step_1", name: "step_hook_tool", arguments: {}}]})
+  llm_mock({text: "<done>##DONE##</done>"})
+  let result = agent_loop(
+    "call the step hook tool",
+    nil,
+    {
+      provider: "mock",
+      tools: step_hook_tools(),
+      tool_format: "native",
+      max_iterations: 2,
+      loop_until_done: true,
+      session_id: "hook-reminder-step",
+    },
+  )
+  let events = transcript_events_by_kind(result.transcript, "system_reminder")
+  println(result.status)
+  println(len(events))
+  println(events[0].reminder.body)
+  println(events[0].reminder.source)
+  println(events[0].reminder.tags[0])
+  clear_persona_hooks()
+}

--- a/conformance/tests/hook_emits_reminder_tool.expected
+++ b/conformance/tests/hook_emits_reminder_tool.expected
@@ -1,0 +1,6 @@
+done
+2
+pre tool reminder
+developer
+post tool reminder
+hook

--- a/conformance/tests/hook_emits_reminder_tool.harn
+++ b/conformance/tests/hook_emits_reminder_tool.harn
@@ -1,0 +1,46 @@
+fn hook_reminder_tools() {
+  let registry = tool_registry()
+  return tool_define(
+    registry,
+    "hooked_tool",
+    "Return a marker",
+    {parameters: {}, handler: { _args -> "tool-result" }},
+  )
+}
+
+pipeline main() {
+  clear_tool_hooks()
+  register_tool_hook(
+    {
+      pattern: "hooked_tool",
+      pre: { _event -> return {reminder: {body: "pre tool reminder", tags: ["tool"], role_hint: "developer"}} },
+      post: { event -> return {
+        reminder: {body: "post tool reminder", tags: ["tool"], dedupe_key: "post-tool"},
+        then: {result: event.result.text + ":post-hook"},
+      } },
+    },
+  )
+  llm_mock_clear()
+  llm_mock({tool_calls: [{id: "tool_1", name: "hooked_tool", arguments: {}}]})
+  llm_mock({text: "<done>##DONE##</done>"})
+  let result = agent_loop(
+    "call the hooked tool",
+    nil,
+    {
+      provider: "mock",
+      tools: hook_reminder_tools(),
+      tool_format: "native",
+      max_iterations: 2,
+      loop_until_done: true,
+      session_id: "hook-reminder-tool",
+    },
+  )
+  let events = transcript_events_by_kind(result.transcript, "system_reminder")
+  println(result.status)
+  println(len(events))
+  println(events[0].reminder.body)
+  println(events[0].reminder.role_hint)
+  println(events[1].reminder.body)
+  println(events[1].reminder.source)
+  clear_tool_hooks()
+}

--- a/crates/harn-vm/src/agent_sessions.rs
+++ b/crates/harn-vm/src/agent_sessions.rs
@@ -96,6 +96,12 @@ pub struct SessionTruncateResult {
     pub new_tip_turn_id: Option<String>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReminderInjectionReport {
+    pub reminder_id: String,
+    pub deduped_count: usize,
+}
+
 thread_local! {
     static SESSIONS: RefCell<HashMap<String, SessionState>> = RefCell::new(HashMap::new());
     static SESSION_CAP: Cell<usize> = const { Cell::new(DEFAULT_SESSION_CAP) };
@@ -871,6 +877,81 @@ pub fn apply_reminder_post_turn(id: &str, turn: i64) -> Result<serde_json::Value
         "decremented_count": report.decremented_count,
         "remaining_count": report.remaining_count,
     }))
+}
+
+/// Inject a typed system reminder into the session transcript's event
+/// stream. This mirrors `transcript.inject_reminder` for live sessions:
+/// reminders with the same `dedupe_key` are replaced before the new
+/// reminder event is appended.
+pub fn inject_reminder(
+    id: &str,
+    reminder: crate::llm::helpers::SystemReminder,
+) -> Result<ReminderInjectionReport, String> {
+    let reminder_id = reminder.id.clone();
+    let dedupe_key = reminder.dedupe_key.clone();
+    let mut deduped_reminder_ids = Vec::new();
+    SESSIONS.with(|s| {
+        let mut map = s.borrow_mut();
+        let Some(state) = map.get_mut(id) else {
+            return Err(format!(
+                "agent_session_inject_reminder: unknown session id '{id}'"
+            ));
+        };
+        let dict = state
+            .transcript
+            .as_dict()
+            .cloned()
+            .unwrap_or_else(BTreeMap::new);
+        let mut events: Vec<VmValue> = match dict.get("events") {
+            Some(VmValue::List(list)) => list.iter().cloned().collect(),
+            _ => dict
+                .get("messages")
+                .and_then(|value| match value {
+                    VmValue::List(list) => Some(list.iter().cloned().collect::<Vec<_>>()),
+                    _ => None,
+                })
+                .map(|messages| crate::llm::helpers::transcript_events_from_messages(&messages))
+                .unwrap_or_default(),
+        };
+        if let Some(expected_key) = dedupe_key.as_deref() {
+            events.retain(|event| {
+                let Some(existing) = crate::llm::helpers::reminder_from_event(event) else {
+                    return true;
+                };
+                if existing.dedupe_key.as_deref() == Some(expected_key) {
+                    deduped_reminder_ids.push(existing.id);
+                    false
+                } else {
+                    true
+                }
+            });
+        }
+        events.push(crate::llm::helpers::transcript_reminder_event(&reminder));
+        let mut next = dict;
+        next.insert("events".to_string(), VmValue::List(Rc::new(events)));
+        state.transcript = VmValue::Dict(Rc::new(next));
+        state.last_accessed = Instant::now();
+        Ok(())
+    })?;
+
+    if !deduped_reminder_ids.is_empty() {
+        let dropped_count = deduped_reminder_ids.len();
+        crate::llm::helpers::emit_reminder_lifecycle_event(
+            crate::llm::helpers::REMINDER_DEDUPED_EVENT_KIND,
+            serde_json::json!({
+                "transcript_id": id,
+                "reminder_id": &reminder_id,
+                "dedupe_key": &dedupe_key,
+                "dropped_reminder_ids": &deduped_reminder_ids,
+                "dropped_count": dropped_count,
+            }),
+        );
+    }
+
+    Ok(ReminderInjectionReport {
+        reminder_id,
+        deduped_count: deduped_reminder_ids.len(),
+    })
 }
 
 /// Append a transcript event to the session without mutating its

--- a/crates/harn-vm/src/llm/agent_host_primitives.rs
+++ b/crates/harn-vm/src/llm/agent_host_primitives.rs
@@ -653,20 +653,17 @@ async fn host_agent_dispatch_tool_call(
         Some(_) => {}
     }
 
-    match crate::orchestration::run_pre_tool_hooks(&tool_name, &tool_args).await? {
-        crate::orchestration::PreToolAction::Allow => {}
-        crate::orchestration::PreToolAction::Deny(reason) => {
-            return Ok(json_to_vm_value(&agent_primitive_denied_tool(
-                &tool_name,
-                &tool_id,
-                &tool_args,
-                reason,
-                crate::agent_events::ToolCallErrorCategory::PermissionDenied,
-            )));
-        }
-        crate::orchestration::PreToolAction::Modify(new_args) => {
-            tool_args = new_args;
-        }
+    let pre_tool_action = crate::orchestration::run_pre_tool_hooks(&tool_name, &tool_args).await?;
+    if let Some(reason) =
+        crate::orchestration::apply_pre_tool_action(pre_tool_action, &mut tool_args)?
+    {
+        return Ok(json_to_vm_value(&agent_primitive_denied_tool(
+            &tool_name,
+            &tool_id,
+            &tool_args,
+            reason,
+            crate::agent_events::ToolCallErrorCategory::PermissionDenied,
+        )));
     }
 
     let tool_schemas = tools::collect_tool_schemas(tools, None);

--- a/crates/harn-vm/src/llm/helpers/mod.rs
+++ b/crates/harn-vm/src/llm/helpers/mod.rs
@@ -29,9 +29,9 @@ pub(crate) use transcript::transcript_to_vm_with_events;
 pub(crate) use transcript::{
     apply_reminder_post_turn, emit_reminder_lifecycle_event, is_transcript_value,
     new_transcript_with, new_transcript_with_events, normalize_transcript_asset,
-    transcript_asset_list, transcript_drain_decision_event_from_value, transcript_event,
-    transcript_event_from_message, transcript_events_from_messages, transcript_id,
-    transcript_message_list, transcript_reminder_event_from_value,
+    reminder_from_event, transcript_asset_list, transcript_drain_decision_event_from_value,
+    transcript_event, transcript_event_from_message, transcript_events_from_messages,
+    transcript_id, transcript_message_list, transcript_reminder_event_from_value,
     transcript_resumption_event_from_value, transcript_summary_text,
     transcript_suspension_event_from_value, transcript_to_vm_with_event_prefix,
 };

--- a/crates/harn-vm/src/llm/helpers/transcript.rs
+++ b/crates/harn-vm/src/llm/helpers/transcript.rs
@@ -844,7 +844,7 @@ fn reminder_from_vm_value(value: &VmValue) -> SystemReminder {
     }
 }
 
-fn reminder_from_event(event: &VmValue) -> Option<SystemReminder> {
+pub(crate) fn reminder_from_event(event: &VmValue) -> Option<SystemReminder> {
     let dict = event.as_dict()?;
     if dict.get("kind").map(|value| value.display()).as_deref() != Some(SYSTEM_REMINDER_EVENT_KIND)
     {

--- a/crates/harn-vm/src/orchestration/hooks.rs
+++ b/crates/harn-vm/src/orchestration/hooks.rs
@@ -1,12 +1,14 @@
 //! Runtime lifecycle hooks — tool, agent-turn, and worker interception.
 
 use std::cell::RefCell;
+use std::collections::BTreeMap;
 use std::rc::Rc;
 
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 
 use crate::agent_events::WorkerEvent;
+use crate::llm::helpers::{ReminderPropagate, ReminderRoleHint, ReminderSource, SystemReminder};
 use crate::value::{VmClosure, VmError, VmValue};
 
 /// Manifest / runtime hook event names.
@@ -189,6 +191,22 @@ impl HookControl {
     }
 }
 
+pub type ReminderSpec = SystemReminder;
+
+/// Side effect emitted by a hook in addition to any control/action
+/// result. Reminder effects are appended to the active session
+/// transcript's pending reminder event set.
+#[derive(Clone, Debug)]
+pub enum HookEffect {
+    Reminder(ReminderSpec),
+}
+
+#[derive(Clone, Debug)]
+struct HookOutcome {
+    control: HookControl,
+    effects: Vec<HookEffect>,
+}
+
 /// Action returned by a PreToolUse hook.
 #[derive(Clone, Debug)]
 pub enum PreToolAction {
@@ -198,6 +216,11 @@ pub enum PreToolAction {
     Deny(String),
     /// Allow but replace the arguments.
     Modify(serde_json::Value),
+    /// Inject a reminder, then continue with the inner pre-tool action.
+    Reminder {
+        spec: ReminderSpec,
+        then: Box<PreToolAction>,
+    },
 }
 
 /// Action returned by a PostToolUse hook.
@@ -207,6 +230,11 @@ pub enum PostToolAction {
     Pass,
     /// Replace the result text.
     Modify(String),
+    /// Inject a reminder, then continue with the inner post-tool action.
+    Reminder {
+        spec: ReminderSpec,
+        then: Box<PostToolAction>,
+    },
 }
 
 /// Callback types for legacy tool lifecycle hooks.
@@ -647,6 +675,7 @@ async fn invoke_vm_lifecycle_hooks(
         let raw = vm
             .call_closure_pub(&registration.closure, &[arg.clone()])
             .await?;
+        let effects = parse_hook_effects(event, &raw)?;
         record_hook_returned(
             &session_id,
             event,
@@ -654,21 +683,404 @@ async fn invoke_vm_lifecycle_hooks(
             &HookControl::Allow,
             &raw,
         );
+        inject_hook_effects(session_id.as_str(), effects)?;
     }
     Ok(())
 }
 
+fn reminder_error(context: &str, message: impl Into<String>) -> VmError {
+    VmError::Runtime(format!("{context}: {}", message.into()))
+}
+
+fn required_reminder_spec_string(
+    options: &BTreeMap<String, VmValue>,
+    key: &str,
+    context: &str,
+) -> Result<String, VmError> {
+    match options.get(key) {
+        Some(VmValue::String(value)) if !value.trim().is_empty() => Ok(value.to_string()),
+        Some(VmValue::String(_)) | None | Some(VmValue::Nil) => Err(reminder_error(
+            context,
+            format!("`{key}` must be a non-empty string"),
+        )),
+        Some(other) => Err(reminder_error(
+            context,
+            format!("`{key}` must be a string, got {}", other.type_name()),
+        )),
+    }
+}
+
+fn optional_reminder_spec_string(
+    options: &BTreeMap<String, VmValue>,
+    key: &str,
+    context: &str,
+) -> Result<Option<String>, VmError> {
+    match options.get(key) {
+        None | Some(VmValue::Nil) => Ok(None),
+        Some(VmValue::String(value)) => {
+            let trimmed = value.trim();
+            if trimmed.is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(trimmed.to_string()))
+            }
+        }
+        Some(other) => Err(reminder_error(
+            context,
+            format!("`{key}` must be a string or nil, got {}", other.type_name()),
+        )),
+    }
+}
+
+fn optional_reminder_spec_bool(
+    options: &BTreeMap<String, VmValue>,
+    key: &str,
+    context: &str,
+) -> Result<Option<bool>, VmError> {
+    match options.get(key) {
+        None | Some(VmValue::Nil) => Ok(None),
+        Some(VmValue::Bool(value)) => Ok(Some(*value)),
+        Some(other) => Err(reminder_error(
+            context,
+            format!("`{key}` must be a bool or nil, got {}", other.type_name()),
+        )),
+    }
+}
+
+fn reminder_spec_tags(
+    options: &BTreeMap<String, VmValue>,
+    context: &str,
+) -> Result<Vec<String>, VmError> {
+    match options.get("tags") {
+        None | Some(VmValue::Nil) => Ok(Vec::new()),
+        Some(VmValue::List(values)) => {
+            let mut tags = Vec::new();
+            for value in values.iter() {
+                let VmValue::String(tag) = value else {
+                    return Err(reminder_error(
+                        context,
+                        format!("`tags` entries must be strings, got {}", value.type_name()),
+                    ));
+                };
+                let trimmed = tag.trim();
+                if trimmed.is_empty() {
+                    return Err(reminder_error(
+                        context,
+                        "`tags` entries must be non-empty strings",
+                    ));
+                }
+                if !tags.iter().any(|existing| existing == trimmed) {
+                    tags.push(trimmed.to_string());
+                }
+            }
+            Ok(tags)
+        }
+        Some(other) => Err(reminder_error(
+            context,
+            format!("`tags` must be a list or nil, got {}", other.type_name()),
+        )),
+    }
+}
+
+fn optional_reminder_spec_ttl(
+    options: &BTreeMap<String, VmValue>,
+    context: &str,
+) -> Result<Option<i64>, VmError> {
+    match options.get("ttl_turns") {
+        None | Some(VmValue::Nil) => Ok(None),
+        Some(VmValue::Int(value)) if *value > 0 => Ok(Some(*value)),
+        Some(VmValue::Int(_)) => Err(reminder_error(context, "`ttl_turns` must be > 0")),
+        Some(other) => Err(reminder_error(
+            context,
+            format!(
+                "`ttl_turns` must be an int or nil, got {}",
+                other.type_name()
+            ),
+        )),
+    }
+}
+
+fn optional_reminder_spec_propagate(
+    options: &BTreeMap<String, VmValue>,
+    context: &str,
+) -> Result<Option<ReminderPropagate>, VmError> {
+    optional_reminder_spec_string(options, "propagate", context)?
+        .map(|value| match value.as_str() {
+            "all" => Ok(ReminderPropagate::All),
+            "session" => Ok(ReminderPropagate::Session),
+            "none" => Ok(ReminderPropagate::None),
+            _ => Err(reminder_error(
+                context,
+                "`propagate` must be one of all, session, or none",
+            )),
+        })
+        .transpose()
+}
+
+fn optional_reminder_spec_role_hint(
+    options: &BTreeMap<String, VmValue>,
+    context: &str,
+) -> Result<Option<ReminderRoleHint>, VmError> {
+    optional_reminder_spec_string(options, "role_hint", context)?
+        .map(|value| match value.as_str() {
+            "system" => Ok(ReminderRoleHint::System),
+            "developer" => Ok(ReminderRoleHint::Developer),
+            "user_block" => Ok(ReminderRoleHint::UserBlock),
+            "ephemeral_cache" => Ok(ReminderRoleHint::EphemeralCache),
+            _ => Err(reminder_error(
+                context,
+                "`role_hint` must be one of system, developer, user_block, or ephemeral_cache",
+            )),
+        })
+        .transpose()
+}
+
+fn parse_reminder_spec(value: &VmValue, context: &str) -> Result<ReminderSpec, VmError> {
+    let Some(options) = value.as_dict() else {
+        return Err(reminder_error(
+            context,
+            format!("reminder spec must be a dict, got {}", value.type_name()),
+        ));
+    };
+    const ALLOWED: &[&str] = &[
+        "body",
+        "tags",
+        "dedupe_key",
+        "ttl_turns",
+        "preserve_on_compact",
+        "propagate",
+        "role_hint",
+    ];
+    let unknown = options
+        .keys()
+        .filter(|key| !ALLOWED.contains(&key.as_str()))
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    if !unknown.is_empty() {
+        return Err(reminder_error(
+            context,
+            format!("unknown reminder option(s): {}", unknown.join(", ")),
+        ));
+    }
+    Ok(SystemReminder {
+        id: uuid::Uuid::now_v7().to_string(),
+        tags: reminder_spec_tags(options, context)?,
+        dedupe_key: optional_reminder_spec_string(options, "dedupe_key", context)?,
+        ttl_turns: optional_reminder_spec_ttl(options, context)?,
+        preserve_on_compact: optional_reminder_spec_bool(options, "preserve_on_compact", context)?
+            .unwrap_or(false),
+        propagate: optional_reminder_spec_propagate(options, context)?
+            .unwrap_or(ReminderPropagate::Session),
+        role_hint: optional_reminder_spec_role_hint(options, context)?
+            .unwrap_or(ReminderRoleHint::System),
+        source: ReminderSource::Hook,
+        body: required_reminder_spec_string(options, "body", context)?,
+        fired_at_turn: 0,
+    })
+}
+
+fn looks_like_reminder_spec(map: &BTreeMap<String, VmValue>) -> bool {
+    map.contains_key("body")
+        && !map.contains_key("deny")
+        && !map.contains_key("args")
+        && !map.contains_key("result")
+        && !map.contains_key("output")
+        && !map.contains_key("modify")
+        && !map.contains_key("block")
+        && !map.contains_key("decision")
+        && !map.contains_key("action")
+        && !map.contains_key("control")
+}
+
+fn parse_hook_effect_item(event: HookEvent, value: &VmValue) -> Result<HookEffect, VmError> {
+    let context = format!("{} hook reminder", event.as_str());
+    if let Some(map) = value.as_dict() {
+        if let Some(reminder) = map.get("reminder") {
+            return Ok(HookEffect::Reminder(parse_reminder_spec(
+                reminder, &context,
+            )?));
+        }
+        if matches!(
+            map.get("type")
+                .or_else(|| map.get("kind"))
+                .map(|value| value.display())
+                .as_deref(),
+            Some("reminder" | "Reminder")
+        ) {
+            let spec = map
+                .get("spec")
+                .or_else(|| map.get("reminder"))
+                .ok_or_else(|| reminder_error(&context, "reminder effect missing `spec`"))?;
+            return Ok(HookEffect::Reminder(parse_reminder_spec(spec, &context)?));
+        }
+        if looks_like_reminder_spec(map) {
+            return Ok(HookEffect::Reminder(parse_reminder_spec(value, &context)?));
+        }
+    }
+    Err(reminder_error(
+        &context,
+        "hook effect must be {reminder: {...}} or a reminder spec",
+    ))
+}
+
+pub fn parse_hook_effects(event: HookEvent, value: &VmValue) -> Result<Vec<HookEffect>, VmError> {
+    let Some(map) = value.as_dict() else {
+        if let VmValue::List(items) = value {
+            return items
+                .iter()
+                .map(|item| parse_hook_effect_item(event, item))
+                .collect();
+        }
+        return Ok(Vec::new());
+    };
+
+    let mut effects = Vec::new();
+    if let Some(items) = map.get("effects") {
+        match items {
+            VmValue::List(list) => {
+                for item in list.iter() {
+                    effects.push(parse_hook_effect_item(event, item)?);
+                }
+            }
+            other => effects.push(parse_hook_effect_item(event, other)?),
+        }
+    }
+    if let Some(reminder) = map.get("reminder") {
+        let context = format!("{} hook reminder", event.as_str());
+        effects.push(HookEffect::Reminder(parse_reminder_spec(
+            reminder, &context,
+        )?));
+    } else if effects.is_empty() && looks_like_reminder_spec(map) {
+        let context = format!("{} hook reminder", event.as_str());
+        effects.push(HookEffect::Reminder(parse_reminder_spec(value, &context)?));
+    }
+    Ok(effects)
+}
+
+fn action_value_after_effects(value: VmValue, default_action: VmValue) -> VmValue {
+    let VmValue::Dict(map) = value else {
+        return value;
+    };
+    if let Some(then) = map.get("then") {
+        return then.clone();
+    }
+    let has_effects = map.contains_key("effects")
+        || map.contains_key("reminder")
+        || looks_like_reminder_spec(map.as_ref());
+    if !has_effects {
+        return VmValue::Dict(map);
+    }
+    let mut action = map.as_ref().clone();
+    action.remove("effects");
+    action.remove("reminder");
+    action.remove("then");
+    if action.keys().any(|key| {
+        matches!(
+            key.as_str(),
+            "deny" | "args" | "result" | "output" | "modify" | "block" | "decision" | "action"
+        )
+    }) {
+        VmValue::Dict(Rc::new(action))
+    } else {
+        default_action
+    }
+}
+
+pub fn collect_hook_effects_and_action(
+    event: HookEvent,
+    value: VmValue,
+    default_action: VmValue,
+) -> Result<(VmValue, Vec<HookEffect>), VmError> {
+    let mut current = value;
+    let mut effects = Vec::new();
+    for _ in 0..32 {
+        let current_effects = parse_hook_effects(event, &current)?;
+        if current_effects.is_empty() {
+            return Ok((current, effects));
+        }
+        effects.extend(current_effects);
+        current = action_value_after_effects(current, default_action.clone());
+    }
+    Err(VmError::Runtime(format!(
+        "{} hook reminder return nested too deeply",
+        event.as_str()
+    )))
+}
+
+fn inject_hook_effects(session_id: &str, effects: Vec<HookEffect>) -> Result<(), VmError> {
+    if effects.is_empty() {
+        return Ok(());
+    }
+    let target_session = if session_id.is_empty() {
+        crate::agent_sessions::current_session_id().unwrap_or_default()
+    } else {
+        session_id.to_string()
+    };
+    if target_session.is_empty() {
+        return Ok(());
+    }
+    for effect in effects {
+        match effect {
+            HookEffect::Reminder(spec) => {
+                crate::agent_sessions::inject_reminder(&target_session, spec)
+                    .map_err(VmError::Runtime)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+pub fn inject_hook_effects_into_current_session(effects: Vec<HookEffect>) -> Result<(), VmError> {
+    inject_hook_effects("", effects)
+}
+
+fn wrap_pre_tool_effects(effects: Vec<HookEffect>, mut action: PreToolAction) -> PreToolAction {
+    for effect in effects.into_iter().rev() {
+        match effect {
+            HookEffect::Reminder(spec) => {
+                action = PreToolAction::Reminder {
+                    spec,
+                    then: Box::new(action),
+                };
+            }
+        }
+    }
+    action
+}
+
+fn wrap_post_tool_effects(effects: Vec<HookEffect>, mut action: PostToolAction) -> PostToolAction {
+    for effect in effects.into_iter().rev() {
+        match effect {
+            HookEffect::Reminder(spec) => {
+                action = PostToolAction::Reminder {
+                    spec,
+                    then: Box::new(action),
+                };
+            }
+        }
+    }
+    action
+}
+
 fn parse_pre_tool_result(value: VmValue) -> Result<PreToolAction, VmError> {
+    let (value, effects) =
+        collect_hook_effects_and_action(HookEvent::PreToolUse, value, VmValue::Nil)?;
     match value {
-        VmValue::Nil => Ok(PreToolAction::Allow),
+        VmValue::Nil => Ok(wrap_pre_tool_effects(effects, PreToolAction::Allow)),
         VmValue::Dict(map) => {
             if let Some(reason) = map.get("deny") {
-                return Ok(PreToolAction::Deny(reason.display()));
+                return Ok(wrap_pre_tool_effects(
+                    effects,
+                    PreToolAction::Deny(reason.display()),
+                ));
             }
             if let Some(args) = map.get("args") {
-                return Ok(PreToolAction::Modify(crate::llm::vm_value_to_json(args)));
+                return Ok(wrap_pre_tool_effects(
+                    effects,
+                    PreToolAction::Modify(crate::llm::vm_value_to_json(args)),
+                ));
             }
-            Ok(PreToolAction::Allow)
+            Ok(wrap_pre_tool_effects(effects, PreToolAction::Allow))
         }
         other => Err(VmError::Runtime(format!(
             "PreToolUse hook must return nil or {{deny, args}}, got {}",
@@ -678,19 +1090,56 @@ fn parse_pre_tool_result(value: VmValue) -> Result<PreToolAction, VmError> {
 }
 
 fn parse_post_tool_result(value: VmValue) -> Result<PostToolAction, VmError> {
+    let (value, effects) =
+        collect_hook_effects_and_action(HookEvent::PostToolUse, value, VmValue::Nil)?;
     match value {
-        VmValue::Nil => Ok(PostToolAction::Pass),
-        VmValue::String(text) => Ok(PostToolAction::Modify(text.to_string())),
+        VmValue::Nil => Ok(wrap_post_tool_effects(effects, PostToolAction::Pass)),
+        VmValue::String(text) => Ok(wrap_post_tool_effects(
+            effects,
+            PostToolAction::Modify(text.to_string()),
+        )),
         VmValue::Dict(map) => {
             if let Some(result) = map.get("result") {
-                return Ok(PostToolAction::Modify(result.display()));
+                return Ok(wrap_post_tool_effects(
+                    effects,
+                    PostToolAction::Modify(result.display()),
+                ));
             }
-            Ok(PostToolAction::Pass)
+            Ok(wrap_post_tool_effects(effects, PostToolAction::Pass))
         }
         other => Err(VmError::Runtime(format!(
             "PostToolUse hook must return nil, string, or {{result}}, got {}",
             other.type_name()
         ))),
+    }
+}
+
+pub fn apply_pre_tool_action(
+    action: PreToolAction,
+    current_args: &mut serde_json::Value,
+) -> Result<Option<String>, VmError> {
+    match action {
+        PreToolAction::Allow => Ok(None),
+        PreToolAction::Deny(reason) => Ok(Some(reason)),
+        PreToolAction::Modify(new_args) => {
+            *current_args = new_args;
+            Ok(None)
+        }
+        PreToolAction::Reminder { spec, then } => {
+            inject_hook_effects_into_current_session(vec![HookEffect::Reminder(spec)])?;
+            apply_pre_tool_action(*then, current_args)
+        }
+    }
+}
+
+fn apply_post_tool_action(action: PostToolAction, current: String) -> Result<String, VmError> {
+    match action {
+        PostToolAction::Pass => Ok(current),
+        PostToolAction::Modify(new_result) => Ok(new_result),
+        PostToolAction::Reminder { spec, then } => {
+            inject_hook_effects_into_current_session(vec![HookEffect::Reminder(spec)])?;
+            apply_post_tool_action(*then, current)
+        }
     }
 }
 
@@ -730,12 +1179,8 @@ pub async fn run_pre_tool_hooks(
             }
             RuntimeHookHandler::NativePostTool(_) => continue,
         };
-        match action {
-            PreToolAction::Allow => {}
-            PreToolAction::Deny(reason) => return Ok(PreToolAction::Deny(reason)),
-            PreToolAction::Modify(new_args) => {
-                current_args = new_args;
-            }
+        if let Some(reason) = apply_pre_tool_action(action, &mut current_args)? {
+            return Ok(PreToolAction::Deny(reason));
         }
     }
     if current_args != *args {
@@ -790,6 +1235,10 @@ pub async fn run_post_tool_hooks(
             PostToolAction::Modify(new_result) => {
                 current = new_result;
             }
+            PostToolAction::Reminder { spec, then } => {
+                inject_hook_effects_into_current_session(vec![HookEffect::Reminder(spec)])?;
+                current = apply_post_tool_action(*then, current)?;
+            }
         }
     }
     Ok(current)
@@ -836,20 +1285,37 @@ pub async fn run_lifecycle_hooks_with_control(
         let raw = vm
             .call_closure_pub(&registration.closure, &[arg.clone()])
             .await?;
-        let control = parse_hook_control(event, &raw)?;
+        let outcome = parse_hook_outcome(event, &raw)?;
         record_hook_returned(
             &session_id,
             event,
             &registration.handler_name,
-            &control,
+            &outcome.control,
             &raw,
         );
-        if !matches!(control, HookControl::Allow) {
-            record_hook_vetoed(&session_id, event, &registration.handler_name, &control);
-            return Ok(control);
+        inject_hook_effects(session_id.as_str(), outcome.effects)?;
+        if !matches!(outcome.control, HookControl::Allow) {
+            record_hook_vetoed(
+                &session_id,
+                event,
+                &registration.handler_name,
+                &outcome.control,
+            );
+            return Ok(outcome.control);
         }
     }
     Ok(HookControl::Allow)
+}
+
+fn parse_hook_outcome(event: HookEvent, value: &VmValue) -> Result<HookOutcome, VmError> {
+    let effects = parse_hook_effects(event, value)?;
+    let action_value = if matches!(value, VmValue::List(_)) {
+        VmValue::Nil
+    } else {
+        action_value_after_effects(value.clone(), VmValue::Nil)
+    };
+    let control = parse_hook_control(event, &action_value)?;
+    Ok(HookOutcome { control, effects })
 }
 
 fn parse_hook_control(event: HookEvent, value: &VmValue) -> Result<HookControl, VmError> {

--- a/crates/harn-vm/src/stdlib/workflow/hooks.rs
+++ b/crates/harn-vm/src/stdlib/workflow/hooks.rs
@@ -25,6 +25,26 @@ pub(super) fn register_tool_hook_builtin(
         VmValue::Int(n) => Some(*n as usize),
         _ => None,
     });
+    let pre_handler = match config.get("pre") {
+        Some(VmValue::Closure(closure)) => Some(closure.clone()),
+        Some(VmValue::Nil) | None => None,
+        Some(other) => {
+            return Err(VmError::Runtime(format!(
+                "register_tool_hook: pre must be a closure, got {}",
+                other.type_name()
+            )));
+        }
+    };
+    let post_handler = match config.get("post") {
+        Some(VmValue::Closure(closure)) => Some(closure.clone()),
+        Some(VmValue::Nil) | None => None,
+        Some(other) => {
+            return Err(VmError::Runtime(format!(
+                "register_tool_hook: post must be a closure, got {}",
+                other.type_name()
+            )));
+        }
+    };
 
     let pre: Option<crate::orchestration::PreToolHookFn> = deny_reason.map(|reason| {
         Rc::new(move |_name: &str, _args: &serde_json::Value| {
@@ -44,7 +64,27 @@ pub(super) fn register_tool_hook_builtin(
         }) as _
     });
 
-    crate::orchestration::register_tool_hook(crate::orchestration::ToolHook { pattern, pre, post });
+    crate::orchestration::register_tool_hook(crate::orchestration::ToolHook {
+        pattern: pattern.clone(),
+        pre,
+        post,
+    });
+    if let Some(handler) = pre_handler {
+        crate::orchestration::register_vm_hook(
+            crate::orchestration::HookEvent::PreToolUse,
+            pattern.clone(),
+            format!("tool_hook::{}::pre", pattern),
+            handler,
+        );
+    }
+    if let Some(handler) = post_handler {
+        crate::orchestration::register_vm_hook(
+            crate::orchestration::HookEvent::PostToolUse,
+            pattern.clone(),
+            format!("tool_hook::{}::post", pattern),
+            handler,
+        );
+    }
     Ok(VmValue::Nil)
 }
 

--- a/crates/harn-vm/src/vm/execution.rs
+++ b/crates/harn-vm/src/vm/execution.rs
@@ -97,8 +97,15 @@ impl Vm {
         }
         let arg = crate::stdlib::json_to_vm_value(payload);
         for invocation in invocations {
-            self.call_closure_pub(&invocation.closure, &[arg.clone()])
+            let raw = self
+                .call_closure_pub(&invocation.closure, &[arg.clone()])
                 .await?;
+            let (_action, effects) = crate::orchestration::collect_hook_effects_and_action(
+                event,
+                raw,
+                crate::value::VmValue::Nil,
+            )?;
+            crate::orchestration::inject_hook_effects_into_current_session(effects)?;
         }
         Ok(())
     }

--- a/crates/harn-vm/src/vm/ops/call.rs
+++ b/crates/harn-vm/src/vm/ops/call.rs
@@ -139,6 +139,12 @@ impl super::super::Vm {
                 None,
             );
             let raw = self.call_lifecycle_hook(&hook.closure, payload).await?;
+            let (raw, effects) = crate::orchestration::collect_hook_effects_and_action(
+                HookEvent::PreStep,
+                raw,
+                VmValue::Nil,
+            )?;
+            crate::orchestration::inject_hook_effects_into_current_session(effects)?;
             match Self::parse_step_pre_hook_result(raw, args)? {
                 StepPreHookAction::Allow(next_args) => args = next_args,
                 StepPreHookAction::Deny(reason) => {
@@ -162,6 +168,12 @@ impl super::super::Vm {
                 None,
             );
             let raw = self.call_lifecycle_hook(&hook.handler, payload).await?;
+            let (raw, effects) = crate::orchestration::collect_hook_effects_and_action(
+                HookEvent::PreStep,
+                raw,
+                VmValue::Nil,
+            )?;
+            crate::orchestration::inject_hook_effects_into_current_session(effects)?;
             match Self::parse_step_pre_hook_result(raw, args)? {
                 StepPreHookAction::Allow(next_args) => args = next_args,
                 StepPreHookAction::Deny(reason) => {
@@ -225,6 +237,12 @@ impl super::super::Vm {
                     Some(current.clone()),
                 );
                 let raw = self.call_lifecycle_hook(&hook.closure, payload).await?;
+                let (raw, effects) = crate::orchestration::collect_hook_effects_and_action(
+                    HookEvent::PostStep,
+                    raw,
+                    VmValue::Nil,
+                )?;
+                crate::orchestration::inject_hook_effects_into_current_session(effects)?;
                 current = Self::parse_step_post_hook_result(raw, current)?;
             }
             for hook in hooks {
@@ -237,6 +255,12 @@ impl super::super::Vm {
                     Some(current.clone()),
                 );
                 let raw = self.call_lifecycle_hook(&hook.handler, payload).await?;
+                let (raw, effects) = crate::orchestration::collect_hook_effects_and_action(
+                    HookEvent::PostStep,
+                    raw,
+                    VmValue::Nil,
+                )?;
+                crate::orchestration::inject_hook_effects_into_current_session(effects)?;
                 current = Self::parse_step_post_hook_result(raw, current)?;
             }
             Ok::<VmValue, VmError>(current)

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -2317,8 +2317,10 @@ removed — call the lifecycle verbs explicitly.
 
 Three concentric surfaces:
 
-- `register_tool_hook({pattern, deny?, max_output?})` — tool-level
-  `PreToolUse` / `PostToolUse`.
+- `register_tool_hook({pattern, deny?, max_output?, pre?, post?})` — tool-level
+  `PreToolUse` / `PostToolUse`. `pre` and `post` are closures that
+  receive `{event, tool, result?}` payloads; `pre` can return `{deny}`
+  or `{args}`, and `post` can return a string or `{result}`.
 - `register_persona_hook(persona_pattern, event, handler)` — persona
   `PreStep` / `PostStep` / `OnApprovalRequested` / `OnHandoffEmitted` /
   `OnPersonaPaused` / `OnPersonaResumed` / `OnBudgetThreshold(pct)`.
@@ -2330,6 +2332,12 @@ Three concentric surfaces:
   `{block: true, reason}`; short-circuit a permission with
   `{decision: "allow"|"deny"|"ask", reason}`. Tape captures every
   invocation under `hook_call` / `hook_returned` / `hook_vetoed`.
+- Any tool, persona, step, or session hook can also emit a typed reminder
+  for the active session transcript. Return `{reminder: {body, tags?,
+  dedupe_key?, ttl_turns?, preserve_on_compact?, propagate?, role_hint?},
+  then?}` to combine the reminder with an existing action, return a bare
+  reminder spec such as `{body: "Refresh context", tags: ["context"]}`,
+  or return a session-hook effect list like `[{reminder: {...}}]`.
 - `pipeline_on_finish(callback)` — register a `fn(harness, return_value)`
   callback that runs between `pre_finish` and `post_finish` on the main
   VM (its stdout reaches the host capture buffer). The callback's

--- a/docs/src/builtins.md
+++ b/docs/src/builtins.md
@@ -2443,7 +2443,7 @@ directory. `workflow.update(...)` polls for a response until
 
 | Function | Parameters | Returns | Description |
 |---|---|---|---|
-| `register_tool_hook(config)` | config: dict | nil | Register a pre/post hook for tool calls matching `pattern` (glob). `deny` string blocks matching tools; `max_output` int truncates results |
+| `register_tool_hook(config)` | config: dict | nil | Register a pre/post hook for tool calls matching `pattern` (glob). `deny` string blocks matching tools; `max_output` int truncates results; `pre`/`post` closures can return tool actions or reminder effects |
 | `clear_tool_hooks()` | none | nil | Remove all registered tool hooks |
 
 ### Session lifecycle hooks

--- a/docs/src/extensibility/hooks.md
+++ b/docs/src/extensibility/hooks.md
@@ -13,11 +13,20 @@ byte.
 `PreToolUse` and `PostToolUse` fire around each tool dispatch.
 `PreToolUse` returns `{deny: reason}` to refuse the call or
 `{args: replacement}` to rewrite the arguments; `PostToolUse` returns a
-string or `{result: replacement}` to rewrite the result.
+string or `{result: replacement}` to rewrite the result. For custom
+logic, pass `pre` and/or `post` closures in the config table.
 
 ```harn
 register_tool_hook({pattern: "exec_*", deny: "exec is gated"})
 register_tool_hook({pattern: "*", max_output: 4000})
+register_tool_hook(
+  {
+    pattern: "fetch_*",
+    pre: { event ->
+      return {reminder: {body: "Network fetch is about to run", tags: ["tool"]}}
+    },
+  },
+)
 ```
 
 ## Persona / step lifecycle hooks (`register_persona_hook`, `register_step_hook`)
@@ -28,6 +37,20 @@ Persona-scoped hooks observe `PreStep`, `PostStep`,
 matching pair (`persona_pattern`, `step_name`) and accept the same
 events; both can deny via `{deny: reason}` or rewrite via `{args}` /
 `{output}`.
+
+Hook closures may also return a reminder effect for the active session
+transcript. The reminder spec uses the same keys as
+`transcript.inject_reminder`: `body`, `tags`, `dedupe_key`,
+`ttl_turns`, `preserve_on_compact`, `propagate`, and `role_hint`.
+
+```harn,ignore
+register_step_hook("merge_*", "audit", "PreStep", { ctx ->
+  return {
+    reminder: {body: "Audit step is running", tags: ["audit"]},
+    then: {args: ctx.step.args},
+  }
+})
+```
 
 ## Session lifecycle hooks (`register_session_hook`)
 
@@ -61,6 +84,9 @@ tool call.
 | `false` | Veto (same as `{block: true}`) |
 | `{block: true, reason: ...}` | Veto |
 | `{decision: "allow"\|"deny"\|"ask", reason?: ...}` | Permission short-circuit (only honoured for `permission_asked`) |
+| `{reminder: {...}, then?: ...}` | Inject a `system_reminder`, then apply the optional inner control/action |
+| `{body: "...", tags?: [...], dedupe_key?: ...}` | Inject a reminder and otherwise allow/pass |
+| `[{reminder: {...}}, ...]` | Session hook effect list; reminders are injected in order and deduped by `dedupe_key` |
 
 Any other return shape raises a runtime error so misuse fails loudly.
 

--- a/docs/src/system-reminders.md
+++ b/docs/src/system-reminders.md
@@ -12,8 +12,10 @@ message history.
 R-01 shipped the **schema and event envelope**. R-02 adds deterministic
 in-Harn transcript transforms for injecting and clearing pending reminder
 events, plus EventLog-backed dedupe and post-turn TTL expiry audit
-records. The rest of the lifecycle (stdlib providers, hook return
-variants, the bridge `agent/inject_reminder` notification, compaction
+records. R-03 lets tool, persona, step, and session hooks return reminder
+effects that inject into the active session transcript. The rest of the
+lifecycle (stdlib providers, the bridge `agent/inject_reminder`
+notification, compaction
 honoring TTL + `preserve_on_compact`, sub-agent propagation, and
 capability-aware rendering) lands in later tickets under epic
 [#1815](https://github.com/burin-labs/harn/issues/1815).
@@ -163,8 +165,11 @@ values. A reminder with `ttl_turns: 1` expires at the next post-turn
 boundary, is removed from the session transcript events, and emits a
 `transcript.reminder.expired` record on
 `transcript.reminder.lifecycle` when an active EventLog is installed.
-Hook return variants, bridge notifications, and provider-specific
-reminder rendering are intentionally left to follow-up tickets.
+Hooks can inject reminders by returning `{reminder: {...}, then?: ...}`,
+a bare reminder spec such as `{body: "Refresh context"}`, or a
+session-hook effect list such as `[{reminder: {...}}]`. Bridge
+notifications and provider-specific reminder rendering are intentionally
+left to follow-up tickets.
 
 ## Reading reminders off a transcript
 
@@ -185,6 +190,6 @@ for evt in reminders {
 - Transform builtins: [#1817 — `transcript.inject_reminder()` + `transcript.clear_reminders()`](https://github.com/burin-labs/harn/issues/1817).
 - Capability flags driving the `role_hint` → wire-role dispatch:
   [#1665](https://github.com/burin-labs/harn/issues/1665).
-- Hook return variants that will surface `Reminder{...}` alongside
-  `Allow` / `Deny` / `Modify`: see
+- Hook return variants that surface reminders alongside `Allow` /
+  `Deny` / `Modify`: see
   [Hooks (tool, persona, session lifecycle)](./extensibility/hooks.md).


### PR DESCRIPTION
Closes #1819.

## Summary
- add hook reminder effects for tool, persona, step, and session hooks
- inject hook reminders into the active session transcript with dedupe support and `source: "hook"`
- allow `register_tool_hook` configs to provide `pre`/`post` closures alongside existing shortcuts
- document the new return shapes and add conformance coverage for each hook surface

## Verification
- `CARGO_TARGET_DIR=/tmp/harn-target-1819-check cargo check -p harn-vm`
- `CARGO_TARGET_DIR=/tmp/harn-target-1819-check cargo run --quiet --bin harn -- test conformance --filter hook_emits_reminder_`
- `CARGO_TARGET_DIR=/tmp/harn-target-1819-check cargo run --quiet --bin harn -- lint conformance/tests/hook_emits_reminder_session.harn conformance/tests/hook_emits_reminder_tool.harn conformance/tests/hook_emits_reminder_step.harn conformance/tests/hook_emits_reminder_persona.harn`
- `CARGO_TARGET_DIR=/tmp/harn-target-1819-check cargo run --quiet --bin harn -- fmt --check conformance/tests/hook_emits_reminder_session.harn conformance/tests/hook_emits_reminder_tool.harn conformance/tests/hook_emits_reminder_step.harn conformance/tests/hook_emits_reminder_persona.harn`
- `CARGO_TARGET_DIR=/tmp/harn-target-1819-docs make check-docs-snippets`
- `CARGO_TARGET_DIR=/tmp/harn-target-1819-check cargo test -p harn-vm orchestration::tests::pre_tool_hook -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-1819-check cargo test -p harn-vm orchestration::tests::post_tool_hook_modifies_result -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-1819-check cargo test -p harn-vm orchestration::tests::lifecycle_hook_patterns_match_payload_shapes -- --nocapture`
- `make lint-test-patterns`
- pre-commit hook
- pre-push hook