### PR TITLE
Format reminder diagnostic fixtures

### DIFF
--- a/conformance/tests/reminder_hook_worker_unsupported_event.harn
+++ b/conformance/tests/reminder_hook_worker_unsupported_event.harn
@@ -6,9 +6,7 @@ pipeline main() {
     {
       id: "worker_spawn_reminder",
       subscribes_to: ["WorkerSpawned"],
-      evaluate: { _ctx ->
-        return {reminder: {body: "worker spawned"}}
-      },
+      evaluate: { _ctx -> return {reminder: {body: "worker spawned"}} },
     },
   )
   let session = agent_session_open("reminder-hook-worker-unsupported-event")

--- a/conformance/tests/reminder_provider_malformed_spec.harn
+++ b/conformance/tests/reminder_provider_malformed_spec.harn
@@ -6,9 +6,7 @@ pipeline main() {
     {
       id: "malformed_spec",
       subscribes_to: ["session_idle"],
-      evaluate: { _ctx ->
-        return {reminder: {tags: ["bad"]}}
-      },
+      evaluate: { _ctx -> return {reminder: {tags: ["bad"]}} },
     },
   )
   let session = agent_session_open("reminder-provider-malformed-spec")


### PR DESCRIPTION
Fixes the `make fmt-harn` failure on `main` after #1976 by applying `harn fmt` to the two reminder diagnostic conformance fixtures.

Verification:
- `CARGO_TARGET_DIR=/tmp/harn-target-1825 cargo run --quiet --bin harn -- fmt --check conformance/tests/reminder_provider_malformed_spec.harn conformance/tests/reminder_hook_worker_unsupported_event.harn`
- `CARGO_TARGET_DIR=/tmp/harn-target-1825 cargo run --quiet --bin harn -- test conformance --filter reminder_provider_malformed_spec`
- `CARGO_TARGET_DIR=/tmp/harn-target-1825 cargo run --quiet --bin harn -- test conformance --filter reminder_hook_worker_unsupported_event`
- `git diff --check`