### PR TITLE
Fix release publish drift comparison

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -111,6 +111,11 @@ jobs:
           CARGO_VERSION="$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')"
           LATEST_TAG="$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -1)"
           LATEST_VERSION="${LATEST_TAG#v}"
+          version_gt() {
+            local left="$1"
+            local right="$2"
+            [[ "$left" != "$right" ]] && [[ "$(printf '%s\n%s\n' "$right" "$left" | sort -V | tail -n 1)" == "$left" ]]
+          }
 
           # Tag-push trigger ("tag is truth"). The release harness pushed
           # vX.Y.Z at the pinned commit before the Release PR merged.
@@ -136,9 +141,12 @@ jobs:
           if [[ -z "$LATEST_TAG" ]]; then
             DRIFT=true
             echo "::notice::No vX.Y.Z tags exist yet; treating Cargo.toml=$CARGO_VERSION as drift (first release)."
-          elif [[ "$CARGO_VERSION" != "$LATEST_VERSION" ]]; then
+          elif version_gt "$CARGO_VERSION" "$LATEST_VERSION"; then
             DRIFT=true
             echo "::notice::Cargo.toml=$CARGO_VERSION ahead of latest tag $LATEST_TAG → finalize needed."
+          elif [[ "$CARGO_VERSION" != "$LATEST_VERSION" ]]; then
+            DRIFT=false
+            echo "::notice::Cargo.toml=$CARGO_VERSION is behind latest tag $LATEST_TAG → publish job will skip."
           else
             DRIFT=false
             # No drift on push-to-main: tag was already published by the


### PR DESCRIPTION
Fixes the `Publish release` failure seen on `main` at `ad20e3f`. The workflow was treating any mismatch between `Cargo.toml` and the latest tag as publish drift; with `Cargo.toml=0.8.25` and latest tag `v0.8.26`, that incorrectly retried `v0.8.25` and failed because the tag already exists.

This changes drift detection so only a numerically newer Cargo version triggers finalize. Older Cargo versions now skip publish with a notice.

Verification:
- `make lint-actions`
- local shell comparison check for behind/equal/ahead versions
- `git diff --check`