### PR TITLE
Implement harness unsettled-state enumeration

### DIFF
--- a/conformance/tests/hooks_session/harness_unsettled_handoff_actions.expected
+++ b/conformance/tests/hooks_session/harness_unsettled_handoff_actions.expected
@@ -1,0 +1,7 @@
+handoff=queued
+partial=1
+to=nightly-drain
+summary=object(keys=work)
+ack=acknowledged
+after=0
+final=finalized

--- a/conformance/tests/hooks_session/harness_unsettled_handoff_actions.harn
+++ b/conformance/tests/hooks_session/harness_unsettled_handoff_actions.harn
@@ -1,0 +1,26 @@
+/**
+ * P-04 action surface: a custom on_finish callback can create, inspect,
+ * acknowledge, and finalize partial handoff state through the Harness API.
+ */
+pipeline default() {
+  pipeline_on_finish(
+    { harness, return_value ->
+      let queued = harness.handoff_to("nightly-drain", {work: "finish"})
+      harness.stdio.println("handoff=" + queued.status)
+      let state = harness.unsettled_state()
+      let counts = harness.counts(state)
+      let handoff = state.partial_handoffs[0]
+      harness.stdio.println("partial=" + to_string(counts.partial))
+      harness.stdio.println("to=" + handoff.to)
+      harness.stdio.println("summary=" + handoff.payload_summary)
+      let ack = harness.acknowledge_handoff(handoff.envelope_id, {decision: "accepted"})
+      let after = harness.counts(harness.unsettled_state())
+      harness.stdio.println("ack=" + ack.status)
+      harness.stdio.println("after=" + to_string(after.partial))
+      let finalized = harness.finalize({status: "completed"})
+      harness.stdio.println("final=" + finalized.status)
+      return return_value
+    },
+  )
+  return "ok"
+}

--- a/conformance/tests/hooks_session/pipeline_on_finish_unsettled_state.expected
+++ b/conformance/tests/hooks_session/pipeline_on_finish_unsettled_state.expected
@@ -5,5 +5,5 @@ trigger_decision=none
 handoff_decision=none
 llm_decision=none
 summary=no unsettled work
-unsupported=unsupported
+ack=not_found
 wait=settled

--- a/conformance/tests/hooks_session/pipeline_on_finish_unsettled_state.harn
+++ b/conformance/tests/hooks_session/pipeline_on_finish_unsettled_state.harn
@@ -11,8 +11,10 @@ pipeline default() {
       let helper_state = unsettled_state(harness)
       let direct_counts = harness.counts(state)
       let helper_counts = counts(helper_state)
-      println("empty=" + to_string(harness.is_empty(state)) + "/" + to_string(is_empty(state)))
-      println(
+      harness.stdio
+        .println("empty=" + to_string(harness.is_empty(state)) + "/" + to_string(is_empty(state)))
+      harness.stdio
+        .println(
         "counts=" + to_string(direct_counts.suspended) + "," + to_string(helper_counts.queued)
           + ","
           + to_string(helper_counts.partial)
@@ -39,15 +41,15 @@ pipeline default() {
       } else {
         "wait"
       }
-      println("suspended_decision=" + suspended_decision)
-      println("trigger_decision=" + trigger_decision)
-      println("handoff_decision=" + handoff_decision)
-      println("llm_decision=" + llm_decision)
-      println("summary=" + summary(state))
+      harness.stdio.println("suspended_decision=" + suspended_decision)
+      harness.stdio.println("trigger_decision=" + trigger_decision)
+      harness.stdio.println("handoff_decision=" + handoff_decision)
+      harness.stdio.println("llm_decision=" + llm_decision)
+      harness.stdio.println("summary=" + summary(state))
       let ack = harness.acknowledge_trigger("missing-trigger")
       let wait = harness.wait_for_any_settlement(0)
-      println("unsupported=" + ack.status)
-      println("wait=" + wait.status)
+      harness.stdio.println("ack=" + ack.status)
+      harness.stdio.println("wait=" + wait.status)
       return return_value
     },
   )

--- a/crates/harn-vm/src/event_log/mod.rs
+++ b/crates/harn-vm/src/event_log/mod.rs
@@ -684,7 +684,7 @@ struct MemoryState {
 }
 
 pub struct MemoryEventLog {
-    state: tokio::sync::Mutex<MemoryState>,
+    state: Mutex<MemoryState>,
     broadcasts: BroadcastMap,
     queue_depth: usize,
 }
@@ -692,14 +692,20 @@ pub struct MemoryEventLog {
 impl MemoryEventLog {
     pub fn new(queue_depth: usize) -> Self {
         Self {
-            state: tokio::sync::Mutex::new(MemoryState::default()),
+            state: Mutex::new(MemoryState::default()),
             broadcasts: BroadcastMap::default(),
             queue_depth: queue_depth.max(1),
         }
     }
 
+    fn state(&self) -> Result<std::sync::MutexGuard<'_, MemoryState>, LogError> {
+        self.state
+            .lock()
+            .map_err(|_| LogError::Io("memory event log state poisoned".to_string()))
+    }
+
     async fn topics(&self) -> Result<Vec<Topic>, LogError> {
-        let state = self.state.lock().await;
+        let state = self.state()?;
         let mut topics = state
             .topics
             .keys()
@@ -716,7 +722,7 @@ impl MemoryEventLog {
         value: &str,
         event: LogEvent,
     ) -> Result<AppendOutcome, LogError> {
-        let mut state = self.state.lock().await;
+        let mut state = self.state()?;
         if let Some((event_id, existing)) = state
             .topics
             .get(topic.as_str())
@@ -771,7 +777,7 @@ impl EventLog for MemoryEventLog {
     }
 
     async fn append(&self, topic: &Topic, event: LogEvent) -> Result<EventId, LogError> {
-        let mut state = self.state.lock().await;
+        let mut state = self.state()?;
         let event_id = state.latest.get(topic.as_str()).copied().unwrap_or(0) + 1;
         let previous = state
             .topics
@@ -802,7 +808,7 @@ impl EventLog for MemoryEventLog {
         limit: usize,
     ) -> Result<Vec<(EventId, LogEvent)>, LogError> {
         let from = from.unwrap_or(0);
-        let state = self.state.lock().await;
+        let state = self.state()?;
         let events = state
             .topics
             .get(topic.as_str())
@@ -831,7 +837,7 @@ impl EventLog for MemoryEventLog {
         consumer: &ConsumerId,
         up_to: EventId,
     ) -> Result<(), LogError> {
-        let mut state = self.state.lock().await;
+        let mut state = self.state()?;
         state.consumers.insert(
             (topic.as_str().to_string(), consumer.as_str().to_string()),
             up_to,
@@ -844,7 +850,7 @@ impl EventLog for MemoryEventLog {
         topic: &Topic,
         consumer: &ConsumerId,
     ) -> Result<Option<EventId>, LogError> {
-        let state = self.state.lock().await;
+        let state = self.state()?;
         Ok(state
             .consumers
             .get(&(topic.as_str().to_string(), consumer.as_str().to_string()))
@@ -852,12 +858,12 @@ impl EventLog for MemoryEventLog {
     }
 
     async fn latest(&self, topic: &Topic) -> Result<Option<EventId>, LogError> {
-        let state = self.state.lock().await;
+        let state = self.state()?;
         Ok(state.latest.get(topic.as_str()).copied())
     }
 
     async fn compact(&self, topic: &Topic, before: EventId) -> Result<CompactReport, LogError> {
-        let mut state = self.state.lock().await;
+        let mut state = self.state()?;
         let Some(events) = state.topics.get_mut(topic.as_str()) else {
             return Ok(CompactReport::default());
         };

--- a/crates/harn-vm/src/llm/agent_observe.rs
+++ b/crates/harn-vm/src/llm/agent_observe.rs
@@ -870,6 +870,7 @@ pub(crate) async fn observed_llm_call(
     offthread: bool,
     streaming_detector: Option<StreamingDetectorContext>,
 ) -> Result<super::api::LlmResult, VmError> {
+    let _in_flight_guard = super::call::InFlightLlmCallGuard::enter(opts);
     let effective_tool_format = tool_format
         .map(str::to_string)
         .or_else(|| {

--- a/crates/harn-vm/src/llm/call.rs
+++ b/crates/harn-vm/src/llm/call.rs
@@ -25,12 +25,12 @@ struct InFlightLlmCall {
     started_at_ms: i64,
 }
 
-struct InFlightLlmCallGuard {
+pub(crate) struct InFlightLlmCallGuard {
     call_id: String,
 }
 
 impl InFlightLlmCallGuard {
-    fn enter(opts: &api::LlmCallOptions) -> Self {
+    pub(crate) fn enter(opts: &api::LlmCallOptions) -> Self {
         let call_id = format!("llm_call_{}", uuid::Uuid::now_v7());
         let started_at_ms = crate::stdlib::clock::now_wall_ms();
         let role = opts
@@ -62,10 +62,13 @@ impl Drop for InFlightLlmCallGuard {
 }
 
 pub(crate) fn snapshot_in_flight_llm_calls() -> Vec<serde_json::Value> {
-    let now_ms = crate::stdlib::clock::now_wall_ms();
     IN_FLIGHT_LLM_CALLS.with(|calls| {
+        let calls = calls.borrow();
+        if calls.is_empty() {
+            return Vec::new();
+        }
+        let now_ms = crate::stdlib::clock::now_wall_ms();
         calls
-            .borrow()
             .values()
             .map(|call| {
                 serde_json::json!({
@@ -434,7 +437,6 @@ pub(crate) async fn execute_llm_call(
     options: Option<std::collections::BTreeMap<String, VmValue>>,
     bridge: Option<&Rc<crate::bridge::HostBridge>>,
 ) -> Result<VmValue, VmError> {
-    let _in_flight_guard = InFlightLlmCallGuard::enter(&opts);
     if let Some(policy) = opts.routing_policy.clone() {
         return execute_with_routing_policy(policy, opts, bridge).await;
     }
@@ -920,6 +922,26 @@ mod schema_stream_abort_retry_tests {
         opts.tool_choice = None;
         opts.provider_overrides = None;
         opts
+    }
+
+    #[test]
+    fn in_flight_llm_guard_snapshots_and_clears() {
+        clear_in_flight_llm_calls();
+        let mut opts = fake_opts_with_schema();
+        opts.messages = vec![serde_json::json!({"role": "assistant", "content": "thinking"})];
+
+        let guard = InFlightLlmCallGuard::enter(&opts);
+        let calls = snapshot_in_flight_llm_calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0]["model"], "fake-stream");
+        assert_eq!(calls[0]["role"], "assistant");
+        assert!(
+            calls[0]["age_ms"].as_i64().unwrap_or(-1) >= 0,
+            "age must be a non-negative duration"
+        );
+
+        drop(guard);
+        assert!(snapshot_in_flight_llm_calls().is_empty());
     }
 
     #[test]

--- a/crates/harn-vm/src/orchestration/pipeline_lifecycle.rs
+++ b/crates/harn-vm/src/orchestration/pipeline_lifecycle.rs
@@ -17,16 +17,21 @@
 //! want deterministic ordering for replay/conformance.
 
 use std::cell::RefCell;
+use std::collections::{BTreeMap, BTreeSet};
 use std::rc::Rc;
 
 use serde_json::Value;
 
+use crate::event_log::{EventLog, LogEvent, Topic};
 use crate::value::VmClosure;
+
+pub const LIFECYCLE_AUDIT_TOPIC: &str = "pipeline.lifecycle.audit";
 
 thread_local! {
     static PIPELINE_ON_FINISH: RefCell<Option<Rc<VmClosure>>> = const { RefCell::new(None) };
     static LIFECYCLE_AUDIT_LOG: RefCell<Vec<LifecycleAuditEntry>> = const { RefCell::new(Vec::new()) };
     static PARTIAL_HANDOFF_REGISTRY: RefCell<Vec<PartialHandoffEnvelope>> = const { RefCell::new(Vec::new()) };
+    static PIPELINE_DISPOSITION: RefCell<Option<Value>> = const { RefCell::new(None) };
     static LIFECYCLE_SEQ: RefCell<u64> = const { RefCell::new(0) };
 }
 
@@ -52,6 +57,7 @@ pub fn clear_pipeline_on_finish() {
     PIPELINE_ON_FINISH.with(|slot| *slot.borrow_mut() = None);
     LIFECYCLE_AUDIT_LOG.with(|log| log.borrow_mut().clear());
     PARTIAL_HANDOFF_REGISTRY.with(|reg| reg.borrow_mut().clear());
+    PIPELINE_DISPOSITION.with(|slot| *slot.borrow_mut() = None);
     LIFECYCLE_SEQ.with(|seq| *seq.borrow_mut() = 0);
 }
 
@@ -110,12 +116,24 @@ impl UnsettledStateSnapshot {
     }
 }
 
-/// Return the current unsettled-state snapshot. This is a single synchronous
-/// collection point for all currently available per-thread registries.
+/// Return the current unsettled-state snapshot. This synchronous variant only
+/// reads in-memory registries; VM lifecycle code should prefer
+/// `unsettled_state_snapshot_async` so event-log-backed trigger queues are
+/// included when available.
 pub fn unsettled_state_snapshot() -> UnsettledStateSnapshot {
+    unsettled_state_snapshot_base(Vec::new())
+}
+
+/// Return the current unsettled-state snapshot, including event-log-backed
+/// trigger queues when an active event log is installed for this thread.
+pub async fn unsettled_state_snapshot_async() -> UnsettledStateSnapshot {
+    unsettled_state_snapshot_base(queued_trigger_snapshot_json().await)
+}
+
+fn unsettled_state_snapshot_base(queued_triggers: Vec<Value>) -> UnsettledStateSnapshot {
     UnsettledStateSnapshot {
         suspended_subagents: crate::stdlib::agents::snapshot_suspended_subagents(),
-        queued_triggers: Vec::new(),
+        queued_triggers,
         partial_handoffs: partial_handoff_snapshot_json(),
         in_flight_llm_calls: crate::llm::snapshot_in_flight_llm_calls(),
     }
@@ -154,6 +172,7 @@ pub fn record_lifecycle_audit(kind: impl Into<String>, payload: Value) -> Lifecy
             .and_then(|session| session.run_id.or(Some(session.session_id))),
     };
     LIFECYCLE_AUDIT_LOG.with(|log| log.borrow_mut().push(entry.clone()));
+    persist_lifecycle_audit_entry(&entry);
     entry
 }
 
@@ -178,12 +197,22 @@ pub struct PartialHandoffEnvelope {
     pub origin_pipeline: Option<String>,
     pub payload: Value,
     pub seq: u64,
+    pub queued_at_ms: i64,
 }
 
 impl PartialHandoffEnvelope {
     pub fn to_json(&self) -> Value {
+        self.to_json_at(crate::stdlib::clock::now_wall_ms())
+    }
+
+    pub fn to_json_at(&self, now_ms: i64) -> Value {
         serde_json::json!({
             "envelope_id": self.envelope_id,
+            "from": self.origin_pipeline,
+            "to": self.target_pipeline,
+            "payload_summary": payload_summary(&self.payload),
+            "queued_at_ms": self.queued_at_ms,
+            "age_ms": now_ms.saturating_sub(self.queued_at_ms).max(0),
             "target_pipeline": self.target_pipeline,
             "origin_pipeline": self.origin_pipeline,
             "payload": self.payload,
@@ -207,13 +236,57 @@ pub fn record_partial_handoff(
             .and_then(|session| session.run_id.or(Some(session.session_id))),
         payload,
         seq,
+        queued_at_ms: crate::stdlib::clock::now_wall_ms(),
     };
     PARTIAL_HANDOFF_REGISTRY.with(|reg| reg.borrow_mut().push(envelope.clone()));
     envelope
 }
 
+/// Acknowledge a partial handoff envelope by removing it from the unsettled
+/// registry and recording the settlement decision in the lifecycle audit log.
+pub fn acknowledge_partial_handoff(
+    envelope_id: &str,
+    decision: Value,
+) -> Option<PartialHandoffEnvelope> {
+    let removed = PARTIAL_HANDOFF_REGISTRY.with(|reg| {
+        let mut reg = reg.borrow_mut();
+        let index = reg
+            .iter()
+            .position(|entry| entry.envelope_id == envelope_id)?;
+        Some(reg.remove(index))
+    })?;
+    record_lifecycle_audit(
+        "handoff_acknowledged",
+        serde_json::json!({
+            "envelope_id": envelope_id,
+            "decision": decision,
+        }),
+    );
+    Some(removed)
+}
+
+pub fn finalize_pipeline_disposition(disposition: Value) -> Value {
+    PIPELINE_DISPOSITION.with(|slot| *slot.borrow_mut() = Some(disposition.clone()));
+    let entry = record_lifecycle_audit(
+        "pipeline_finalized",
+        serde_json::json!({
+            "disposition": disposition,
+        }),
+    );
+    serde_json::json!({
+        "status": "finalized",
+        "method": "finalize",
+        "entry": entry.to_json(),
+    })
+}
+
+pub fn pipeline_disposition_snapshot() -> Option<Value> {
+    PIPELINE_DISPOSITION.with(|slot| slot.borrow().clone())
+}
+
 fn partial_handoff_snapshot_json() -> Vec<Value> {
-    PARTIAL_HANDOFF_REGISTRY.with(|reg| reg.borrow().iter().map(|e| e.to_json()).collect())
+    let now_ms = crate::stdlib::clock::now_wall_ms();
+    PARTIAL_HANDOFF_REGISTRY.with(|reg| reg.borrow().iter().map(|e| e.to_json_at(now_ms)).collect())
 }
 
 fn next_seq() -> u64 {
@@ -222,4 +295,267 @@ fn next_seq() -> u64 {
         *slot += 1;
         *slot
     })
+}
+
+fn persist_lifecycle_audit_entry(entry: &LifecycleAuditEntry) {
+    let Some(log) = crate::event_log::active_event_log() else {
+        return;
+    };
+    let Ok(topic) = Topic::new(LIFECYCLE_AUDIT_TOPIC) else {
+        return;
+    };
+    let mut headers = BTreeMap::new();
+    headers.insert("kind".to_string(), entry.kind.clone());
+    headers.insert("seq".to_string(), entry.seq.to_string());
+    if let Some(pipeline_id) = entry.pipeline_id.as_ref() {
+        headers.insert("pipeline_id".to_string(), pipeline_id.clone());
+    }
+    let _ = futures::executor::block_on(log.append(
+        &topic,
+        LogEvent::new("lifecycle_audit", entry.to_json()).with_headers(headers),
+    ));
+}
+
+async fn queued_trigger_snapshot_json() -> Vec<Value> {
+    let Some(log) = crate::event_log::active_event_log() else {
+        return Vec::new();
+    };
+    let now_ms = lifecycle_now_ms();
+    let mut out = Vec::new();
+    out.extend(snapshot_inbox_triggers(log.as_ref(), now_ms).await);
+    out.extend(snapshot_worker_queue_triggers(log, now_ms).await);
+    out.sort_by(|left, right| {
+        let left_key = (
+            left.get("queued_at_ms")
+                .and_then(Value::as_i64)
+                .unwrap_or(i64::MAX),
+            left.get("id").and_then(Value::as_str).unwrap_or_default(),
+        );
+        let right_key = (
+            right
+                .get("queued_at_ms")
+                .and_then(Value::as_i64)
+                .unwrap_or(i64::MAX),
+            right.get("id").and_then(Value::as_str).unwrap_or_default(),
+        );
+        left_key.cmp(&right_key)
+    });
+    out
+}
+
+fn lifecycle_now_ms() -> i64 {
+    crate::clock_mock::now_ms()
+}
+
+async fn snapshot_inbox_triggers(log: &crate::event_log::AnyEventLog, now_ms: i64) -> Vec<Value> {
+    let Ok(inbox_topic) = Topic::new(crate::triggers::TRIGGER_INBOX_ENVELOPES_TOPIC) else {
+        return Vec::new();
+    };
+    let Ok(outbox_topic) = Topic::new(crate::triggers::TRIGGER_OUTBOX_TOPIC) else {
+        return Vec::new();
+    };
+    let Ok(cancel_topic) = Topic::new(crate::triggers::TRIGGER_CANCEL_REQUESTS_TOPIC) else {
+        return Vec::new();
+    };
+    let inbox = log
+        .read_range(&inbox_topic, None, usize::MAX)
+        .await
+        .unwrap_or_default();
+    let outbox = log
+        .read_range(&outbox_topic, None, usize::MAX)
+        .await
+        .unwrap_or_default();
+    let cancels = log
+        .read_range(&cancel_topic, None, usize::MAX)
+        .await
+        .unwrap_or_default();
+
+    let completed_events = outbox
+        .into_iter()
+        .filter_map(|(_, event)| {
+            let event_id = event
+                .headers
+                .get("event_id")
+                .cloned()
+                .or_else(|| json_string(&event.payload, &["event_id"]))?;
+            let binding_key = event
+                .headers
+                .get("binding_key")
+                .cloned()
+                .or_else(|| json_string(&event.payload, &["binding_key"]))
+                .unwrap_or_default();
+            Some((binding_key, event_id))
+        })
+        .collect::<BTreeSet<_>>();
+    let cancelled_events = cancels
+        .into_iter()
+        .filter(|(_, event)| event.kind == "dispatch_cancel_requested")
+        .filter_map(|(_, event)| {
+            let event_id = json_string(&event.payload, &["event_id"])?;
+            let binding_key = json_string(&event.payload, &["binding_key"]).unwrap_or_default();
+            Some((binding_key, event_id))
+        })
+        .collect::<BTreeSet<_>>();
+
+    inbox
+        .into_iter()
+        .filter(|(_, event)| event.kind == "event_ingested")
+        .filter_map(|(_, event)| {
+            let trigger = event
+                .payload
+                .get("event")
+                .cloned()
+                .unwrap_or_else(|| event.payload.clone());
+            let event_id = json_string(&trigger, &["id"])?;
+            let binding_key = event
+                .headers
+                .get("binding_key")
+                .cloned()
+                .or_else(|| {
+                    let trigger_id = event
+                        .headers
+                        .get("trigger_id")
+                        .cloned()
+                        .or_else(|| json_string(&event.payload, &["trigger_id"]))?;
+                    let version = json_u64(&event.payload, &["binding_version"])?;
+                    Some(format!("{trigger_id}@v{version}"))
+                });
+            if event_is_settled(&completed_events, binding_key.as_deref(), &event_id)
+                || event_is_settled(&cancelled_events, binding_key.as_deref(), &event_id)
+            {
+                return None;
+            }
+            let trigger_id = event
+                .headers
+                .get("trigger_id")
+                .cloned()
+                .or_else(|| json_string(&event.payload, &["trigger_id"]));
+            let queued_at_ms = event.occurred_at_ms;
+            let provider = json_string(&trigger, &["provider"]).unwrap_or_default();
+            let kind = json_string(&trigger, &["kind"]).unwrap_or_default();
+            let id = binding_key
+                .as_ref()
+                .map(|key| format!("trigger://{key}/{event_id}"))
+                .unwrap_or_else(|| format!("trigger://{event_id}"));
+            Some(serde_json::json!({
+                "id": id,
+                "event_id": event_id,
+                "trigger_id": trigger_id,
+                "binding_key": binding_key,
+                "spec_summary": trigger_spec_summary(provider.as_str(), kind.as_str(), trigger_id.as_deref()),
+                "queued_at_ms": queued_at_ms,
+                "age_ms": now_ms.saturating_sub(queued_at_ms).max(0),
+                "source": "trigger_inbox",
+            }))
+        })
+        .collect()
+}
+
+fn event_is_settled(
+    settled_events: &BTreeSet<(String, String)>,
+    binding_key: Option<&str>,
+    event_id: &str,
+) -> bool {
+    let scoped_key = binding_key.unwrap_or_default().to_string();
+    settled_events.contains(&(scoped_key, event_id.to_string()))
+        || settled_events.contains(&(String::new(), event_id.to_string()))
+}
+
+async fn snapshot_worker_queue_triggers(
+    log: std::sync::Arc<crate::event_log::AnyEventLog>,
+    now_ms: i64,
+) -> Vec<Value> {
+    let queue = crate::triggers::WorkerQueue::new(log);
+    let Ok(queues) = queue.known_queues().await else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for queue_name in queues {
+        let Ok(state) = queue.queue_state(&queue_name).await else {
+            continue;
+        };
+        let queue_label = state.queue.clone();
+        for job in state.jobs {
+            if job.acked || job.purged {
+                continue;
+            }
+            let event_id = job.job.event.id.0.clone();
+            let id = format!("worker://{}/{}", queue_label, job.job_event_id);
+            out.push(serde_json::json!({
+                "id": id,
+                "event_id": event_id,
+                "trigger_id": job.job.trigger_id,
+                "binding_key": job.job.binding_key,
+                "spec_summary": trigger_spec_summary(
+                    job.job.event.provider.0.as_str(),
+                    job.job.event.kind.as_str(),
+                    Some(job.job.trigger_id.as_str())
+                ),
+                "queued_at_ms": job.enqueued_at_ms,
+                "age_ms": now_ms.saturating_sub(job.enqueued_at_ms).max(0),
+                "source": "worker_queue",
+                "queue": queue_label.clone(),
+                "job_event_id": job.job_event_id,
+                "claimed": job.active_claim.is_some(),
+            }));
+        }
+    }
+    out
+}
+
+fn trigger_spec_summary(provider: &str, kind: &str, trigger_id: Option<&str>) -> String {
+    match (
+        trigger_id.filter(|id| !id.is_empty()),
+        provider.is_empty(),
+        kind.is_empty(),
+    ) {
+        (Some(id), false, false) => format!("{id}: {provider}.{kind}"),
+        (Some(id), _, _) => id.to_string(),
+        (None, false, false) => format!("{provider}.{kind}"),
+        (None, false, true) => provider.to_string(),
+        (None, true, false) => kind.to_string(),
+        (None, true, true) => "trigger event".to_string(),
+    }
+}
+
+fn json_string(value: &Value, path: &[&str]) -> Option<String> {
+    let mut cursor = value;
+    for key in path {
+        cursor = cursor.get(*key)?;
+    }
+    cursor.as_str().map(ToString::to_string)
+}
+
+fn json_u64(value: &Value, path: &[&str]) -> Option<u64> {
+    let mut cursor = value;
+    for key in path {
+        cursor = cursor.get(*key)?;
+    }
+    cursor.as_u64()
+}
+
+fn payload_summary(payload: &Value) -> String {
+    match payload {
+        Value::Null => "nil".to_string(),
+        Value::Bool(value) => value.to_string(),
+        Value::Number(value) => value.to_string(),
+        Value::String(value) => {
+            let mut chars = value.chars();
+            let preview: String = chars.by_ref().take(80).collect();
+            if chars.next().is_some() {
+                format!("{preview}...")
+            } else {
+                preview
+            }
+        }
+        Value::Array(items) => format!("list(len={})", items.len()),
+        Value::Object(map) => {
+            let keys = map.keys().take(6).cloned().collect::<Vec<_>>().join(",");
+            if map.len() > 6 {
+                format!("object(keys={keys},...)")
+            } else {
+                format!("object(keys={keys})")
+            }
+        }
+    }
 }

--- a/crates/harn-vm/src/orchestration/tests.rs
+++ b/crates/harn-vm/src/orchestration/tests.rs
@@ -1447,6 +1447,24 @@ fn record_lifecycle_audit_assigns_monotonic_seq() {
     );
 }
 
+#[tokio::test(flavor = "current_thread")]
+async fn record_lifecycle_audit_persists_to_active_event_log() {
+    crate::event_log::reset_active_event_log();
+    let log = crate::event_log::install_memory_for_current_thread(32);
+    clear_pipeline_on_finish();
+
+    let entry = record_lifecycle_audit("first", serde_json::json!({"x": 1}));
+    let topic = crate::event_log::Topic::new(LIFECYCLE_AUDIT_TOPIC).unwrap();
+    let events = log.read_range(&topic, None, usize::MAX).await.unwrap();
+
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].1.kind, "lifecycle_audit");
+    assert_eq!(events[0].1.payload["seq"], serde_json::json!(entry.seq));
+    assert_eq!(events[0].1.payload["kind"], "first");
+
+    crate::event_log::reset_active_event_log();
+}
+
 #[test]
 fn record_partial_handoff_appears_in_unsettled_snapshot() {
     clear_pipeline_on_finish();
@@ -1461,6 +1479,163 @@ fn record_partial_handoff_appears_in_unsettled_snapshot() {
         snapshot.partial_handoffs[0]["target_pipeline"],
         "downstream"
     );
+}
+
+#[test]
+fn acknowledge_partial_handoff_removes_envelope_and_audits() {
+    clear_pipeline_on_finish();
+    let envelope = record_partial_handoff("downstream", serde_json::json!({"note": "x"}));
+
+    let removed = acknowledge_partial_handoff(
+        &envelope.envelope_id,
+        serde_json::json!({"decision": "accepted"}),
+    )
+    .expect("handoff should be acknowledged");
+
+    assert_eq!(removed.envelope_id, envelope.envelope_id);
+    assert!(unsettled_state_snapshot().partial_handoffs.is_empty());
+    assert_eq!(
+        lifecycle_audit_log_snapshot()
+            .last()
+            .map(|entry| entry.kind.as_str()),
+        Some("handoff_acknowledged")
+    );
+}
+
+#[test]
+fn finalize_pipeline_records_disposition() {
+    clear_pipeline_on_finish();
+    let receipt = finalize_pipeline_disposition(serde_json::json!({"status": "completed"}));
+
+    assert_eq!(receipt["status"], "finalized");
+    assert_eq!(
+        pipeline_disposition_snapshot(),
+        Some(serde_json::json!({"status": "completed"}))
+    );
+    assert_eq!(
+        lifecycle_audit_log_snapshot()
+            .last()
+            .map(|entry| entry.kind.as_str()),
+        Some("pipeline_finalized")
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn unsettled_state_snapshot_async_includes_worker_queue_triggers() {
+    crate::event_log::reset_active_event_log();
+    let log = crate::event_log::install_memory_for_current_thread(64);
+    clear_pipeline_on_finish();
+    let queue = crate::triggers::WorkerQueue::new(log);
+    let job = crate::triggers::WorkerQueueJob {
+        queue: "triage".to_string(),
+        trigger_id: "incoming-review-task".to_string(),
+        binding_key: "incoming-review-task@v1".to_string(),
+        binding_version: 1,
+        event: crate::triggers::TriggerEvent {
+            id: crate::triggers::TriggerEventId("evt-1".to_string()),
+            provider: crate::triggers::ProviderId::from("github"),
+            kind: "issues.opened".to_string(),
+            trace_id: crate::triggers::TraceId("trace-test".to_string()),
+            dedupe_key: "evt-1".to_string(),
+            tenant_id: None,
+            headers: BTreeMap::new(),
+            batch: None,
+            raw_body: None,
+            provider_payload: crate::triggers::ProviderPayload::Known(
+                crate::triggers::event::KnownProviderPayload::Webhook(
+                    crate::triggers::GenericWebhookPayload {
+                        source: Some("lifecycle-test".to_string()),
+                        content_type: Some("application/json".to_string()),
+                        raw: serde_json::json!({"id": "evt-1"}),
+                    },
+                ),
+            ),
+            signature_status: crate::triggers::SignatureStatus::Verified,
+            received_at: time::OffsetDateTime::now_utc(),
+            occurred_at: None,
+            dedupe_claimed: false,
+        },
+        replay_of_event_id: None,
+        priority: crate::triggers::WorkerQueuePriority::Normal,
+    };
+    let receipt = queue.enqueue(&job).await.unwrap();
+
+    let snapshot = unsettled_state_snapshot_async().await;
+    assert_eq!(snapshot.queued_triggers.len(), 1);
+    assert_eq!(
+        snapshot.queued_triggers[0]["id"],
+        format!("worker://triage/{}", receipt.job_event_id)
+    );
+    assert_eq!(snapshot.queued_triggers[0]["source"], "worker_queue");
+
+    queue
+        .ack_job("triage", receipt.job_event_id, "pipeline_lifecycle")
+        .await
+        .unwrap();
+    assert!(unsettled_state_snapshot_async()
+        .await
+        .queued_triggers
+        .is_empty());
+    crate::event_log::reset_active_event_log();
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn unsettled_state_snapshot_async_includes_uncancelled_trigger_inbox_events() {
+    crate::event_log::reset_active_event_log();
+    let log = crate::event_log::install_memory_for_current_thread(64);
+    clear_pipeline_on_finish();
+    let topic = crate::event_log::Topic::new(crate::triggers::TRIGGER_INBOX_ENVELOPES_TOPIC)
+        .expect("static trigger inbox topic");
+    let mut headers = BTreeMap::new();
+    headers.insert(
+        "binding_key".to_string(),
+        "incoming-review-task@v1".to_string(),
+    );
+    headers.insert("trigger_id".to_string(), "incoming-review-task".to_string());
+    log.append(
+        &topic,
+        crate::event_log::LogEvent::new(
+            "event_ingested",
+            serde_json::json!({
+                "trigger_id": "incoming-review-task",
+                "binding_version": 1,
+                "event": {
+                    "id": "evt-inbox",
+                    "provider": "github",
+                    "kind": "issues.opened",
+                },
+            }),
+        )
+        .with_headers(headers),
+    )
+    .await
+    .unwrap();
+
+    let snapshot = unsettled_state_snapshot_async().await;
+    assert_eq!(snapshot.queued_triggers.len(), 1);
+    assert_eq!(
+        snapshot.queued_triggers[0]["id"],
+        "trigger://incoming-review-task@v1/evt-inbox"
+    );
+    assert_eq!(snapshot.queued_triggers[0]["source"], "trigger_inbox");
+
+    crate::triggers::append_dispatch_cancel_request(
+        &log,
+        &crate::triggers::DispatchCancelRequest {
+            binding_key: "incoming-review-task@v1".to_string(),
+            event_id: "evt-inbox".to_string(),
+            requested_at: time::OffsetDateTime::now_utc(),
+            requested_by: Some("test".to_string()),
+            audit_id: None,
+        },
+    )
+    .await
+    .unwrap();
+    assert!(unsettled_state_snapshot_async()
+        .await
+        .queued_triggers
+        .is_empty());
+    crate::event_log::reset_active_event_log();
 }
 
 #[test]

--- a/crates/harn-vm/src/stdlib.rs
+++ b/crates/harn-vm/src/stdlib.rs
@@ -259,6 +259,7 @@ pub fn reset_stdlib_state() {
     waitpoints::reset_waitpoint_state();
     waitpoint::reset_waitpoint_state();
     triggers_stdlib::reset_auto_resume_timeouts();
+    agents::reset_agent_worker_state();
     postgres::reset_postgres_state();
     supervisor::reset_supervisor_state();
     agents::records::reset_eval_metrics();

--- a/crates/harn-vm/src/stdlib/agents.rs
+++ b/crates/harn-vm/src/stdlib/agents.rs
@@ -23,11 +23,11 @@ use harn_parser::diagnostic_codes::Code;
 use self::agents_workers::{
     apply_worker_artifact_policy, apply_worker_transcript_policy, emit_worker_event,
     ensure_worker_config_session_ids, load_worker_state_snapshot, next_worker_id,
-    parse_worker_config, persist_worker_state_snapshot, spawn_worker_task, with_worker_state,
-    worker_event_snapshot, worker_id_from_value, worker_request_for_config, worker_snapshot_path,
-    worker_summary, worker_trigger_payload_text, worker_wait_blocks, SuspendInitiator,
-    WorkerCarryPolicy, WorkerConfig, WorkerExecutionProfile, WorkerState, WorkerSuspension,
-    WORKER_REGISTRY,
+    parse_worker_config, persist_worker_state_snapshot, reset_worker_registry, spawn_worker_task,
+    with_worker_state, worker_event_snapshot, worker_id_from_value, worker_request_for_config,
+    worker_snapshot_path, worker_summary, worker_trigger_payload_text, worker_wait_blocks,
+    SuspendInitiator, WorkerCarryPolicy, WorkerConfig, WorkerExecutionProfile, WorkerState,
+    WorkerSuspension, WORKER_REGISTRY,
 };
 use self::sub_agent::{execute_sub_agent, parse_sub_agent_request};
 use crate::agent_events::WorkerEvent;
@@ -102,6 +102,10 @@ const AGENT_PRIMITIVES: BuiltinGroup<'static> = BuiltinGroup::new()
     .category("agent.worker")
     .sync(AGENT_SYNC_PRIMITIVES)
     .async_(AGENT_ASYNC_PRIMITIVES);
+
+pub(crate) fn reset_agent_worker_state() {
+    reset_worker_registry();
+}
 
 pub(crate) use self::records::{parse_artifact_list, parse_context_policy};
 fn to_vm<T: serde::Serialize>(value: &T) -> Result<VmValue, VmError> {
@@ -1504,6 +1508,41 @@ pub(crate) fn snapshot_suspended_subagents() -> Vec<serde_json::Value> {
             .values()
             .filter_map(|state| {
                 let worker = state.borrow();
+                if worker.status == "suspended" {
+                    let suspension = worker.suspension.as_ref();
+                    let suspended_at_ms =
+                        suspension.and_then(|value| uuid_v7_unix_ms(&value.suspended_at));
+                    let age_ms = suspended_at_ms
+                        .map(|started| crate::stdlib::clock::now_wall_ms().saturating_sub(started))
+                        .unwrap_or(0)
+                        .max(0);
+                    return Some(serde_json::json!({
+                        "handle": worker.id.clone(),
+                        "session_id": worker_session_id_json(&worker),
+                        "reason": suspension
+                            .map(|value| value.reason.clone())
+                            .filter(|value| !value.trim().is_empty())
+                            .unwrap_or_else(|| "suspended".to_string()),
+                        "conditions": suspension
+                            .and_then(|value| value.conditions.clone())
+                            .unwrap_or(serde_json::Value::Null),
+                        "age_ms": age_ms,
+                        "initiator": suspension
+                            .and_then(|value| serde_json::to_value(value.initiator).ok())
+                            .unwrap_or_else(|| serde_json::json!("operator")),
+                        "mode": worker.mode.clone(),
+                        "status": worker.status.clone(),
+                        "suspended_at": suspension
+                            .map(|value| value.suspended_at.clone())
+                            .unwrap_or_default(),
+                        "snapshot_ref": suspension
+                            .map(|value| value.snapshot_ref.clone())
+                            .unwrap_or_else(|| worker.snapshot_path.clone()),
+                        "auto_resume_trigger": suspension
+                            .and_then(|value| value.auto_resume_trigger.as_ref())
+                            .and_then(|value| serde_json::to_value(value).ok()),
+                    }));
+                }
                 if worker.status != "awaiting" || worker.mode != "sub_agent" {
                     return None;
                 }
@@ -1513,11 +1552,7 @@ pub(crate) fn snapshot_suspended_subagents() -> Vec<serde_json::Value> {
                     .unwrap_or(0);
                 Some(serde_json::json!({
                     "handle": worker.id.clone(),
-                    "session_id": if worker.audit.session_id.is_empty() {
-                        serde_json::Value::Null
-                    } else {
-                        serde_json::json!(worker.audit.session_id.clone())
-                    },
+                    "session_id": worker_session_id_json(&worker),
                     "reason": "awaiting_input",
                     "conditions": {
                         "status": worker.status.clone(),
@@ -1529,10 +1564,37 @@ pub(crate) fn snapshot_suspended_subagents() -> Vec<serde_json::Value> {
                         .parent_worker_id
                         .clone()
                         .unwrap_or_else(|| "pipeline".to_string()),
+                    "mode": worker.mode.clone(),
+                    "status": worker.status.clone(),
                 }))
             })
             .collect()
     })
+}
+
+fn worker_session_id_json(worker: &WorkerState) -> serde_json::Value {
+    let session_id = if worker.audit.session_id.is_empty() {
+        match &worker.config {
+            WorkerConfig::SubAgent { spec } if !spec.session_id.is_empty() => {
+                Some(spec.session_id.clone())
+            }
+            _ => None,
+        }
+    } else {
+        Some(worker.audit.session_id.clone())
+    };
+    session_id
+        .map(serde_json::Value::String)
+        .unwrap_or(serde_json::Value::Null)
+}
+
+fn uuid_v7_unix_ms(value: &str) -> Option<i64> {
+    let uuid = uuid::Uuid::parse_str(value).ok()?;
+    let (seconds, nanos) = uuid.get_timestamp()?.to_unix();
+    let millis = seconds
+        .checked_mul(1_000)?
+        .checked_add(u64::from(nanos / 1_000_000))?;
+    i64::try_from(millis).ok()
 }
 
 #[cfg(test)]
@@ -1811,6 +1873,72 @@ mod suspend_tests {
                 && event_error.to_string().contains("on_event"),
             "expected HARN-SUS-002 on_event field error, got: {event_error}"
         );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn suspended_subagent_snapshot_includes_active_suspension_metadata() {
+        let _guard = suspend_test_lock().await;
+        let (worker_id, dir) = seed_test_worker("worker-suspend-snapshot");
+
+        suspend_agent_builtin(vec![
+            handle_value(&worker_id),
+            VmValue::String(Rc::from("waiting on external review")),
+            VmValue::Dict(Rc::new(BTreeMap::from([(
+                "initiator".to_string(),
+                VmValue::String(Rc::from("parent")),
+            )]))),
+        ])
+        .await
+        .expect("suspend worker");
+
+        let snapshot = snapshot_suspended_subagents();
+        let item = snapshot
+            .iter()
+            .find(|item| item["handle"] == worker_id)
+            .expect("suspended worker should be in unsettled snapshot");
+        assert_eq!(item["status"], "suspended");
+        assert_eq!(item["reason"], "waiting on external review");
+        assert_eq!(item["initiator"], "parent");
+        assert!(
+            item["age_ms"].as_i64().unwrap_or(-1) >= 0,
+            "snapshot age must be a non-negative duration"
+        );
+        assert!(
+            item["snapshot_ref"]
+                .as_str()
+                .is_some_and(|path| !path.is_empty()),
+            "suspended workers should expose their durable snapshot path"
+        );
+
+        teardown(&dir, &worker_id);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn reset_agent_worker_state_clears_suspended_snapshot() {
+        let _guard = suspend_test_lock().await;
+        let (worker_id, dir) = seed_test_worker("worker-reset-snapshot");
+
+        suspend_agent_builtin(vec![
+            handle_value(&worker_id),
+            VmValue::String(Rc::from("waiting on external review")),
+        ])
+        .await
+        .expect("suspend worker");
+        assert!(
+            snapshot_suspended_subagents()
+                .iter()
+                .any(|item| item["handle"] == worker_id),
+            "seeded suspension should be visible before reset"
+        );
+
+        reset_agent_worker_state();
+
+        assert!(
+            snapshot_suspended_subagents().is_empty(),
+            "stdlib reset should not leave workers visible to later lifecycle snapshots"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+        unsafe { std::env::remove_var("HARN_WORKER_STATE_DIR") };
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/harn-vm/src/stdlib/agents_workers/mod.rs
+++ b/crates/harn-vm/src/stdlib/agents_workers/mod.rs
@@ -2,7 +2,7 @@ use super::*;
 use std::cell::{Cell, RefCell};
 use std::collections::BTreeMap;
 use std::rc::Rc;
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -220,6 +220,22 @@ pub(super) fn next_worker_id() -> String {
         counter.set(next);
         format!("worker_{}", uuid::Uuid::now_v7())
     })
+}
+
+pub(super) fn reset_worker_registry() {
+    WORKER_REGISTRY.with(|registry| {
+        let mut registry = registry.borrow_mut();
+        for state in registry.values() {
+            let mut worker = state.borrow_mut();
+            worker.cancel_token.store(true, Ordering::SeqCst);
+            worker.suspend_signal.store(true, Ordering::SeqCst);
+            if let Some(handle) = worker.handle.take() {
+                handle.abort();
+            }
+        }
+        registry.clear();
+    });
+    WORKER_COUNTER.with(|counter| counter.set(0));
 }
 
 pub(super) fn worker_trigger_payload_text(value: &VmValue) -> String {

--- a/crates/harn-vm/src/triggers/worker_queue.rs
+++ b/crates/harn-vm/src/triggers/worker_queue.rs
@@ -738,6 +738,47 @@ impl WorkerQueue {
             .await
     }
 
+    pub async fn ack_job(
+        &self,
+        queue: &str,
+        job_event_id: u64,
+        consumer_id: &str,
+    ) -> Result<bool, LogError> {
+        let queue_name = queue.trim();
+        if queue_name.is_empty() {
+            return Err(LogError::Config(
+                "worker queue name cannot be empty".to_string(),
+            ));
+        }
+        let state = self.queue_state(queue_name).await?;
+        let Some(job) = state
+            .jobs
+            .iter()
+            .find(|job| job.job_event_id == job_event_id)
+        else {
+            return Ok(false);
+        };
+        if job.acked || job.purged {
+            return Ok(false);
+        }
+        self.event_log
+            .append(
+                &claims_topic(queue_name)?,
+                LogEvent::new(
+                    "job_acked",
+                    serde_json::to_value(WorkerQueueAckRecord {
+                        job_event_id,
+                        claim_id: String::new(),
+                        consumer_id: consumer_id.to_string(),
+                        acked_at_ms: now_ms(),
+                    })
+                    .map_err(|error| LogError::Serde(error.to_string()))?,
+                ),
+            )
+            .await?;
+        Ok(true)
+    }
+
     pub async fn purge_unclaimed(
         &self,
         queue: &str,
@@ -996,6 +1037,37 @@ mod tests {
         assert_eq!(summary.in_flight, 0);
         assert_eq!(summary.acked, 1);
         assert_eq!(summary.responses, 1);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn ack_job_acknowledges_without_active_claim() {
+        let log = Arc::new(AnyEventLog::Memory(MemoryEventLog::new(32)));
+        let queue = WorkerQueue::new(log);
+        let receipt = queue
+            .enqueue(&test_job(
+                "triage",
+                "incoming-review-task",
+                "evt-1",
+                WorkerQueuePriority::Normal,
+            ))
+            .await
+            .unwrap();
+
+        assert!(queue
+            .ack_job("triage", receipt.job_event_id, "pipeline_lifecycle")
+            .await
+            .unwrap());
+        let state = queue.queue_state("triage").await.unwrap();
+        let summary = state.summary(now_ms());
+        assert_eq!(summary.ready, 0);
+        assert_eq!(summary.acked, 1);
+        assert!(
+            !queue
+                .ack_job("triage", receipt.job_event_id, "pipeline_lifecycle")
+                .await
+                .unwrap(),
+            "already acknowledged jobs should not produce a second settlement"
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/harn-vm/src/vm/execution.rs
+++ b/crates/harn-vm/src/vm/execution.rs
@@ -37,10 +37,12 @@ impl Vm {
     ///
     /// Tracked: <https://github.com/burin-labs/harn/issues/1854>.
     async fn run_pipeline_finish_lifecycle(&mut self, value: VmValue) -> Result<VmValue, VmError> {
-        use crate::orchestration::{take_pipeline_on_finish, unsettled_state_snapshot, HookEvent};
+        use crate::orchestration::{
+            take_pipeline_on_finish, unsettled_state_snapshot_async, HookEvent,
+        };
 
         let on_finish = take_pipeline_on_finish();
-        let unsettled = unsettled_state_snapshot();
+        let unsettled = unsettled_state_snapshot_async().await;
 
         let pre_payload = serde_json::json!({
             "event": HookEvent::PreFinish.as_str(),

--- a/crates/harn-vm/src/vm/methods/harness.rs
+++ b/crates/harn-vm/src/vm/methods/harness.rs
@@ -50,13 +50,15 @@ impl crate::vm::Vm {
     ) -> Result<VmValue, VmError> {
         match method {
             "unsettled_state" => {
-                let snapshot = crate::orchestration::unsettled_state_snapshot();
+                let snapshot = crate::orchestration::unsettled_state_snapshot_async().await;
                 Ok(crate::stdlib::json_to_vm_value(&snapshot.to_json()))
             }
             "is_empty" => {
                 let empty = match args.first() {
                     Some(state) => state_counts(state)?.is_empty(),
-                    None => crate::orchestration::unsettled_state_snapshot().is_empty(),
+                    None => crate::orchestration::unsettled_state_snapshot_async()
+                        .await
+                        .is_empty(),
                 };
                 Ok(VmValue::Bool(empty))
             }
@@ -65,7 +67,7 @@ impl crate::vm::Vm {
                     &state_counts(state)?.to_json(),
                 )),
                 None => {
-                    let snapshot = crate::orchestration::unsettled_state_snapshot();
+                    let snapshot = crate::orchestration::unsettled_state_snapshot_async().await;
                     Ok(crate::stdlib::json_to_vm_value(&snapshot.counts_json()))
                 }
             },
@@ -74,7 +76,7 @@ impl crate::vm::Vm {
                     state_counts(state)?.summary().as_str(),
                 ))),
                 None => {
-                    let snapshot = crate::orchestration::unsettled_state_snapshot();
+                    let snapshot = crate::orchestration::unsettled_state_snapshot_async().await;
                     Ok(VmValue::String(std::rc::Rc::from(snapshot.summary())))
                 }
             },
@@ -83,8 +85,23 @@ impl crate::vm::Vm {
                     VmError::TypeError("Harness.resume_subagent expects a handle".to_string())
                 })?;
                 if let Some(input) = args.get(1).cloned() {
-                    self.call_named_builtin("__host_worker_send_input", vec![handle_arg, input])
+                    match self
+                        .call_named_builtin(
+                            "__host_worker_resume",
+                            vec![handle_arg.clone(), input.clone()],
+                        )
                         .await
+                    {
+                        Ok(value) => Ok(value),
+                        Err(error) if error.to_string().contains("not suspended") => {
+                            self.call_named_builtin(
+                                "__host_worker_send_input",
+                                vec![handle_arg, input],
+                            )
+                            .await
+                        }
+                        Err(error) => Err(error),
+                    }
                 } else {
                     self.call_named_builtin("__host_worker_resume", vec![handle_arg])
                         .await
@@ -98,7 +115,7 @@ impl crate::vm::Vm {
                     .await
             }
             "wait_for_any_settlement" => {
-                let snapshot = crate::orchestration::unsettled_state_snapshot();
+                let snapshot = crate::orchestration::unsettled_state_snapshot_async().await;
                 let status = if snapshot.is_empty() {
                     "settled"
                 } else {
@@ -106,7 +123,7 @@ impl crate::vm::Vm {
                 };
                 Ok(crate::stdlib::json_to_vm_value(&serde_json::json!({
                     "status": status,
-                    "timed_out": false,
+                    "timed_out": !snapshot.is_empty(),
                     "state": snapshot.to_json(),
                 })))
             }
@@ -116,18 +133,10 @@ impl crate::vm::Vm {
                 .unwrap_or(VmValue::Nil)),
             "handoff_to" => Ok(record_handoff_envelope(args)),
             "emit_audit" => Ok(record_emit_audit(args)),
-            "acknowledge_trigger" | "defer_trigger" => Ok(unsupported_harness_action(
-                method,
-                "queued trigger items do not have an acknowledgement registry on this branch",
-            )),
-            "acknowledge_handoff" => Ok(unsupported_harness_action(
-                method,
-                "partial handoff envelopes do not have an acknowledgement registry on this branch",
-            )),
-            "finalize" => Ok(unsupported_harness_action(
-                method,
-                "pipeline disposition persistence is not available on this branch",
-            )),
+            "acknowledge_trigger" => Ok(acknowledge_trigger(args).await),
+            "defer_trigger" => Ok(defer_trigger(args).await),
+            "acknowledge_handoff" => Ok(acknowledge_handoff(args)),
+            "finalize" => Ok(finalize_pipeline(args)),
             "spawn_settlement_agent" => Ok(record_spawn_settlement_agent_gap(args)),
             _ => Err(method_unsupported(handle, method)),
         }
@@ -386,6 +395,245 @@ fn unsupported_harness_action(method: &str, reason: &str) -> VmValue {
         "method": method,
         "reason": reason,
     }))
+}
+
+async fn acknowledge_trigger(args: &[VmValue]) -> VmValue {
+    let Some(id) = args
+        .first()
+        .map(vm_value_string)
+        .filter(|id| !id.is_empty())
+    else {
+        return json_receipt("rejected", "acknowledge_trigger", "missing trigger id");
+    };
+    let receipt = acknowledge_trigger_id(&id).await;
+    crate::stdlib::json_to_vm_value(&receipt)
+}
+
+async fn defer_trigger(args: &[VmValue]) -> VmValue {
+    let Some(id) = args
+        .first()
+        .map(vm_value_string)
+        .filter(|id| !id.is_empty())
+    else {
+        return json_receipt("rejected", "defer_trigger", "missing trigger id");
+    };
+    let target = args
+        .get(1)
+        .map(vm_value_string)
+        .filter(|target| !target.trim().is_empty())
+        .unwrap_or_else(|| "deferred-triggers".to_string());
+    let acknowledgement = acknowledge_trigger_id(&id).await;
+    if acknowledgement
+        .get("status")
+        .and_then(serde_json::Value::as_str)
+        != Some("acknowledged")
+    {
+        return crate::stdlib::json_to_vm_value(&serde_json::json!({
+            "status": acknowledgement
+                .get("status")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("rejected"),
+            "method": "defer_trigger",
+            "trigger_id": id,
+            "acknowledgement": acknowledgement,
+        }));
+    }
+    let envelope = crate::orchestration::record_partial_handoff(
+        target,
+        serde_json::json!({
+            "deferred_trigger": acknowledgement.get("item").cloned().unwrap_or(serde_json::Value::Null),
+            "acknowledgement": acknowledgement.clone(),
+        }),
+    );
+    crate::orchestration::record_lifecycle_audit(
+        "trigger_deferred",
+        serde_json::json!({
+            "trigger_id": id,
+            "envelope_id": envelope.envelope_id.clone(),
+        }),
+    );
+    crate::stdlib::json_to_vm_value(&serde_json::json!({
+        "status": "deferred",
+        "method": "defer_trigger",
+        "trigger_id": id,
+        "acknowledgement": acknowledgement,
+        "envelope": envelope.to_json(),
+    }))
+}
+
+async fn acknowledge_trigger_id(id: &str) -> serde_json::Value {
+    let snapshot = crate::orchestration::unsettled_state_snapshot_async().await;
+    let Some(item) = snapshot
+        .queued_triggers
+        .iter()
+        .find(|item| item.get("id").and_then(serde_json::Value::as_str) == Some(id))
+        .cloned()
+    else {
+        return serde_json::json!({
+            "status": "not_found",
+            "method": "acknowledge_trigger",
+            "trigger_id": id,
+        });
+    };
+    let Some(log) = crate::event_log::active_event_log() else {
+        return serde_json::json!({
+            "status": "rejected",
+            "method": "acknowledge_trigger",
+            "trigger_id": id,
+            "reason": "no active event log is installed",
+            "item": item,
+        });
+    };
+    let result = match item.get("source").and_then(serde_json::Value::as_str) {
+        Some("worker_queue") => {
+            let queue = item
+                .get("queue")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default();
+            let job_event_id = item
+                .get("job_event_id")
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or_default();
+            match crate::triggers::WorkerQueue::new(log)
+                .ack_job(queue, job_event_id, "pipeline_lifecycle")
+                .await
+            {
+                Ok(true) => serde_json::json!({"status": "acknowledged"}),
+                Ok(false) => serde_json::json!({"status": "not_found"}),
+                Err(error) => serde_json::json!({
+                    "status": "rejected",
+                    "reason": error.to_string(),
+                }),
+            }
+        }
+        Some("trigger_inbox") => {
+            let Some(binding_key) = item
+                .get("binding_key")
+                .and_then(serde_json::Value::as_str)
+                .filter(|value| !value.is_empty())
+            else {
+                return serde_json::json!({
+                    "status": "rejected",
+                    "method": "acknowledge_trigger",
+                    "trigger_id": id,
+                    "reason": "queued trigger is missing binding_key",
+                    "item": item,
+                });
+            };
+            let Some(event_id) = item
+                .get("event_id")
+                .and_then(serde_json::Value::as_str)
+                .filter(|value| !value.is_empty())
+            else {
+                return serde_json::json!({
+                    "status": "rejected",
+                    "method": "acknowledge_trigger",
+                    "trigger_id": id,
+                    "reason": "queued trigger is missing event_id",
+                    "item": item,
+                });
+            };
+            let request = crate::triggers::DispatchCancelRequest {
+                binding_key: binding_key.to_string(),
+                event_id: event_id.to_string(),
+                requested_at: crate::clock_mock::now_utc(),
+                requested_by: Some("pipeline_lifecycle".to_string()),
+                audit_id: None,
+            };
+            match crate::triggers::append_dispatch_cancel_request(&log, &request).await {
+                Ok(_) => serde_json::json!({"status": "acknowledged"}),
+                Err(error) => serde_json::json!({
+                    "status": "rejected",
+                    "reason": error.to_string(),
+                }),
+            }
+        }
+        Some(source) => serde_json::json!({
+            "status": "rejected",
+            "reason": format!("unknown queued trigger source `{source}`"),
+        }),
+        None => serde_json::json!({
+            "status": "rejected",
+            "reason": "queued trigger is missing source",
+        }),
+    };
+    if result.get("status").and_then(serde_json::Value::as_str) == Some("acknowledged") {
+        crate::orchestration::record_lifecycle_audit(
+            "trigger_acknowledged",
+            serde_json::json!({
+                "trigger_id": id,
+                "item": item.clone(),
+            }),
+        );
+    }
+    let mut receipt = serde_json::Map::new();
+    receipt.insert(
+        "status".to_string(),
+        result
+            .get("status")
+            .cloned()
+            .unwrap_or_else(|| serde_json::json!("rejected")),
+    );
+    receipt.insert(
+        "method".to_string(),
+        serde_json::json!("acknowledge_trigger"),
+    );
+    receipt.insert("trigger_id".to_string(), serde_json::json!(id));
+    receipt.insert("item".to_string(), item);
+    if let Some(reason) = result.get("reason").cloned() {
+        receipt.insert("reason".to_string(), reason);
+    }
+    serde_json::Value::Object(receipt)
+}
+
+fn acknowledge_handoff(args: &[VmValue]) -> VmValue {
+    let Some(envelope_id) = args
+        .first()
+        .map(vm_value_string)
+        .filter(|id| !id.is_empty())
+    else {
+        return json_receipt("rejected", "acknowledge_handoff", "missing envelope id");
+    };
+    let decision = args
+        .get(1)
+        .map(crate::llm::vm_value_to_json)
+        .unwrap_or(serde_json::Value::Null);
+    match crate::orchestration::acknowledge_partial_handoff(&envelope_id, decision) {
+        Some(envelope) => crate::stdlib::json_to_vm_value(&serde_json::json!({
+            "status": "acknowledged",
+            "method": "acknowledge_handoff",
+            "envelope": envelope.to_json(),
+        })),
+        None => crate::stdlib::json_to_vm_value(&serde_json::json!({
+            "status": "not_found",
+            "method": "acknowledge_handoff",
+            "envelope_id": envelope_id,
+        })),
+    }
+}
+
+fn finalize_pipeline(args: &[VmValue]) -> VmValue {
+    let disposition = args
+        .first()
+        .map(crate::llm::vm_value_to_json)
+        .unwrap_or(serde_json::Value::Null);
+    let receipt = crate::orchestration::finalize_pipeline_disposition(disposition);
+    crate::stdlib::json_to_vm_value(&receipt)
+}
+
+fn json_receipt(status: &str, method: &str, reason: &str) -> VmValue {
+    crate::stdlib::json_to_vm_value(&serde_json::json!({
+        "status": status,
+        "method": method,
+        "reason": reason,
+    }))
+}
+
+fn vm_value_string(value: &VmValue) -> String {
+    match value {
+        VmValue::String(text) => text.as_ref().to_string(),
+        other => other.display(),
+    }
 }
 
 fn record_emit_audit(args: &[VmValue]) -> VmValue {

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -2449,20 +2449,23 @@ Three concentric surfaces:
   `in_flight_llm_calls` lists. `harness.is_empty(state?)`,
   `harness.counts(state?)`, and `harness.summary(state?)` summarize that
   shape; `std/lifecycle` exports equivalent `unsettled_state(harness)`,
-  `is_empty(state)`, `counts(state)`, and `summary(state)` helpers. On
-  this branch, suspended subagents, in-flight LLM calls, and partial
-  handoffs are populated from live VM registries (the partial-handoff
-  registry is written by `harness.handoff_to`); the queued-trigger
-  bucket stays a typed empty list until its per-item registry lands.
+  `is_empty(state)`, `counts(state)`, and `summary(state)` helpers.
+  Suspended subagents, partial handoffs, and in-flight LLM calls are
+  populated from live VM registries, while queued triggers are
+  reconstructed from the active trigger inbox and worker-queue event-log
+  records.
 - Lifecycle action methods exist on the root harness for drain callbacks:
   `resume_subagent`, `cancel_subagent`, `handoff_to`, `acknowledge_trigger`,
   `defer_trigger`, `acknowledge_handoff`, `wait_for_any_settlement`,
   `emit_audit`, `finalize`, `spawn_settlement_agent`, and
   `current_pipeline_id`. `resume_subagent` and `cancel_subagent` delegate
-  to host worker primitives; `emit_audit` and `handoff_to` record into
-  the per-pipeline-run lifecycle audit log and partial-handoff registry;
-  methods whose backing registries are not yet present return a typed
-  `{status: "unsupported", method, reason}` result.
+  to host worker primitives; trigger acknowledgements use existing
+  dispatcher cancel requests or worker-queue ack records; handoff
+  acknowledgement removes the partial envelope; `emit_audit`,
+  `handoff_to`, and `finalize` record into the per-pipeline-run lifecycle
+  registries. `spawn_settlement_agent` remains the P-03 handoff point and
+  returns a typed `{status: "unsupported", method, reason}` receipt until
+  harn#1856 lands.
 - `pipeline_lifecycle_audit_log_take()` and
   `pipeline_lifecycle_audit_log_snapshot()` drain or peek at the
   per-pipeline-run audit log that `harness.emit_audit` writes. Each

--- a/docs/src/stdlib/lifecycle.md
+++ b/docs/src/stdlib/lifecycle.md
@@ -16,6 +16,83 @@ pipeline default() {
 }
 ```
 
+## Harness lifecycle methods
+
+`harness.unsettled_state()` returns one snapshot dict with four lists:
+`suspended_subagents`, `queued_triggers`, `partial_handoffs`, and
+`in_flight_llm_calls`. Suspended subagents come from the host worker
+registry, queued triggers come from the trigger inbox and worker queue
+event-log records, partial handoffs come from `harness.handoff_to`, and
+in-flight LLM calls come from the live LLM call registry.
+
+`harness.is_empty(state?)` returns `true` when every unsettled bucket is
+empty. Pass an already-captured snapshot to keep decisions consistent
+inside one callback, or omit the argument to ask the harness for a fresh
+snapshot.
+
+`harness.counts(state?)` returns `{suspended, queued, partial,
+in_flight}` for either the supplied snapshot or a fresh harness snapshot.
+Use it for audit payloads and branch decisions instead of recomputing
+bucket lengths manually.
+
+`harness.summary(state?)` returns a single operator-readable line such
+as `no unsettled work` or a per-bucket count summary. It is intended for
+logs and audit records, not as a machine-readable contract.
+
+`harness.resume_subagent(handle, input?)` delegates to the host worker
+resume primitive for suspended workers. When `input` is supplied and the
+worker is an awaiting retriggerable subagent, the harness falls back to
+the existing send-input primitive.
+
+`harness.cancel_subagent(handle, reason?)` delegates to
+`__host_worker_close` and returns that primitive's worker summary or
+error. The optional reason is reserved for callers that want to include
+the reason in their own audit payload before cancelling.
+
+`harness.handoff_to(target_pipeline, payload?)` records a partial
+handoff envelope and returns `{status: "queued", envelope}`. The envelope
+appears in subsequent `partial_handoffs` snapshots with `from`, `to`,
+`payload_summary`, `queued_at_ms`, and `age_ms` fields.
+
+`harness.acknowledge_trigger(id)` settles one queued trigger item. Worker
+queue items are acknowledged with the existing queue ack event, while
+trigger inbox items are settled by appending the existing dispatcher
+cancel request; missing ids return `{status: "not_found"}`.
+
+`harness.defer_trigger(id, target_pipeline?)` acknowledges the queued
+trigger and records a partial handoff envelope for the supplied target
+(default `deferred-triggers`). If the trigger cannot be acknowledged,
+the returned receipt keeps the failed acknowledgement result.
+
+`harness.acknowledge_handoff(envelope_id, decision?)` removes a partial
+handoff envelope from the unsettled registry and emits a
+`handoff_acknowledged` lifecycle audit entry with the caller's decision
+payload.
+
+`harness.wait_for_any_settlement(max_duration?)` takes a fresh snapshot
+and returns `{status, timed_out, state}`. It returns `settled` when the
+snapshot is empty and `unsettled` otherwise; callers that need a richer
+drain loop should delegate to the drain preset or settlement agent.
+
+`harness.emit_audit(kind, payload?)` records a typed
+`LifecycleAuditEntry` with a monotonic per-run `seq` number. When an
+active event log exists, the same entry is persisted to the
+`pipeline.lifecycle.audit` topic alongside run-record data.
+
+`harness.finalize(disposition?)` stores the pipeline disposition for the
+current lifecycle run and emits a `pipeline_finalized` audit entry. The
+receipt is shaped `{status: "finalized", method: "finalize", entry}`.
+
+`harness.spawn_settlement_agent(unsettled, return_value)` is the handoff
+point used by `on_finish_drain` when unsettled work remains. The
+settlement-agent loop and constrained drain tool surface are tracked by
+harn#1856; until that lands this method returns a typed unsupported
+receipt rather than silently dropping the work.
+
+`harness.current_pipeline_id()` returns the current run id when a
+mutation session is installed, otherwise the session id, otherwise
+`nil`. Handoff producers use this to stamp the origin pipeline.
+
 Four canonical presets ship from `std/lifecycle`. Each is a pure
 function (or a pure factory returning one) with no captured state, so
 chaining and reuse are safe.


### PR DESCRIPTION
## Summary
- Enumerate unsettled harness state from suspended subagents, in-flight LLM calls, pending approvals, partial handoffs, and queued trigger work from event-log backed sources.
- Implement harness lifecycle actions for trigger acknowledgement/defer, handoff acknowledgement, deterministic settlement waits, resume, and final disposition auditing.
- Persist lifecycle audit/disposition records, cover direct observed LLM calls, and add conformance/docs coverage for the harness methods.

Fixes #1857

## Verification
- `cargo test -p harn-vm unsettled_state_snapshot -- --nocapture`
- `cargo test -p harn-vm ack_job -- --nocapture`
- focused harn-vm tests for suspended subagent metadata, LLM guards, lifecycle audit persistence, handoff ack, finalize, and trigger inbox snapshots
- `cargo test -p harn-vm --lib`
- `HARN_LLM_CALLS_DISABLED=1 cargo run --quiet --bin harn -- test conformance --filter 'pipeline_on_finish_unsettled_state|harness_unsettled_handoff_actions|on_finish'`
- pre-commit hook: Rust fmt, Harn fmt/lint, workspace clippy all targets, generated highlight check, markdownlint
- pre-push hook: targeted checks, Harn fmt/lint, markdownlint, generated highlight check
