### PR TITLE
Add resume continuity reminder provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,13 @@ condensed series summaries instead of full per-patch history.
   instead of parenting across process boundaries. The OTel helper layer
   now exposes `set_span_link` beside `set_span_parent`, with no-op
   behavior in non-OTel builds.
+- **Resume-continuity system reminder provider (#1845).**
+  `agent_loop(...)` now fires the canonical `resume_continuity` provider
+  before the first turn after `resume_agent(...)`. The one-shot reminder
+  identifies the suspension turn and reason, resume cause, optional
+  resumer input, and the pre-suspend digest when resuming with
+  `continue_transcript: false`; it is dedupe-keyed, non-propagating, and
+  honors the standard reminder provider opt-out list.
 
 ## v0.8.26
 

--- a/conformance/tests/agents/agent_resume_continuity_reminder.expected
+++ b/conformance/tests/agents/agent_resume_continuity_reminder.expected
@@ -1,0 +1,9 @@
+suspended
+running
+completed
+true
+true
+true
+true
+true
+0

--- a/conformance/tests/agents/agent_resume_continuity_reminder.harn
+++ b/conformance/tests/agents/agent_resume_continuity_reminder.harn
@@ -1,0 +1,54 @@
+import "std/agents"
+
+fn resume_tools() {
+  var tools = tool_registry()
+  tools = tool_define(
+    tools,
+    "noop",
+    "Return a short observation.",
+    {handler: { _args -> "ok" }, parameters: {}, returns: {type: "string"}},
+  )
+  return tools
+}
+
+pipeline main() {
+  llm_mock_clear()
+  llm_mock(
+    {
+      tool_calls: [{id: "park_1", name: "agent_await_resumption", arguments: {reason: "waiting on review"}}],
+      input_tokens: 7,
+      output_tokens: 3,
+    },
+  )
+  let session_id = "resume-continuity-" + uuid()
+  let handle = sub_agent_run(
+    "Park until an operator resumes you.",
+    {
+      provider: "mock",
+      background: true,
+      session_id: session_id,
+      tools: resume_tools(),
+      tool_format: "native",
+      max_iterations: 3,
+    },
+  )
+  let suspended = wait_agent(handle)
+  llm_mock({tool_calls: [{id: "noop_1", name: "noop", arguments: {}}]})
+  llm_mock({text: "done"})
+  let resumed = resume_agent(suspended, "operator says go", true)
+  let completed = wait_agent(handle)
+  let calls = llm_mock_calls()
+  let resumed_system = calls[1].system
+  let next_system = calls[2].system
+  let remaining = transcript_events_by_kind(completed.transcript, "system_reminder")
+    .filter({ event -> event.reminder.dedupe_key == "resume_continuity" })
+  println(suspended.status)
+  println(resumed.status)
+  println(completed.status)
+  println(contains(resumed_system, "You were suspended at turn"))
+  println(contains(resumed_system, "waiting on review"))
+  println(contains(resumed_system, "You have been resumed by the operator"))
+  println(contains(resumed_system, "The resumer provided input: operator says go"))
+  println(!contains(next_system, "You were suspended at turn"))
+  println(len(remaining))
+}

--- a/conformance/tests/reminder_provider_resume_continuity.expected
+++ b/conformance/tests/reminder_provider_resume_continuity.expected
@@ -1,0 +1,14 @@
+1
+1
+1
+resume_continuity
+resume_continuity
+1
+true
+none
+stdlib_provider
+true
+true
+true
+true
+0

--- a/conformance/tests/reminder_provider_resume_continuity.harn
+++ b/conformance/tests/reminder_provider_resume_continuity.harn
@@ -1,0 +1,56 @@
+import { agent_reminder_providers_fire } from "std/agent/state"
+
+pipeline main() {
+  let session = agent_session_open("reminder-provider-resume-continuity")
+  agent_session_reset(session)
+  let payload = {
+    session: {id: session},
+    worker: {id: "worker-1"},
+    suspension: {reason: "waiting on review", suspended_at_turn: 2},
+    resume: {
+      initiator: "operator",
+      input_rendered: "approved",
+      input_present: true,
+      continue_transcript: false,
+      digest: "Prior digest",
+    },
+    reason: "waiting on review",
+    suspended_at_turn: 2,
+    input_rendered: "approved",
+    input_present: true,
+    continue_transcript: false,
+    digest: "Prior digest",
+    turn: 0,
+  }
+  let first = agent_reminder_providers_fire(session, "worker_resumed", payload, {})
+  let second = agent_reminder_providers_fire(
+    session,
+    "worker_resumed",
+    payload
+      + {input_rendered: "approved again", resume: payload.resume + {input_rendered: "approved again"}},
+    {},
+  )
+  let reminders = transcript_events_by_kind(agent_session_snapshot(session), "system_reminder")
+  let disabled_session = agent_session_open("reminder-provider-resume-continuity-disabled")
+  agent_session_reset(disabled_session)
+  let disabled = agent_reminder_providers_fire(
+    disabled_session,
+    "worker_resumed",
+    payload + {session: {id: disabled_session}, session_id: disabled_session},
+    {reminders: {providers: ["-resume_continuity"]}},
+  )
+  println(first.fired_count)
+  println(second.reports[0].deduped_count)
+  println(len(reminders))
+  println(reminders[0].reminder.tags[0])
+  println(reminders[0].reminder.dedupe_key)
+  println(reminders[0].reminder.ttl_turns)
+  println(reminders[0].reminder.preserve_on_compact)
+  println(reminders[0].reminder.propagate)
+  println(reminders[0].reminder.source)
+  println(contains(reminders[0].reminder.body, "You were suspended at turn 2"))
+  println(contains(reminders[0].reminder.body, "You have been resumed by the operator"))
+  println(contains(reminders[0].reminder.body, "The resumer provided input: approved again"))
+  println(contains(reminders[0].reminder.body, "Pre-suspend conversation digest: Prior digest"))
+  println(disabled.fired_count)
+}

--- a/crates/harn-lint/src/rules/reminder_provider_count.rs
+++ b/crates/harn-lint/src/rules/reminder_provider_count.rs
@@ -16,6 +16,7 @@ const CANONICAL_PROVIDERS: &[&str] = &[
     "idle_nudge",
     "tool_output_truncated",
     "post_compact_recap",
+    "resume_continuity",
 ];
 
 pub(crate) fn check_reminder_provider_count(

--- a/crates/harn-stdlib/src/stdlib/agent/loop.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/loop.harn
@@ -14,6 +14,7 @@ import { agent_skills_match } from "std/agent/skills"
 import {
   agent_emit_event,
   agent_record_native_tool_fallback,
+  agent_reminder_providers_fire,
   agent_session_drain_bridge_injections,
   agent_session_drain_feedback,
   agent_session_finalize,
@@ -34,6 +35,7 @@ import {
   list_agents,
   suspend_agent,
 } from "std/agent/workers"
+import { omit } from "std/json"
 import { llm_call_options } from "std/llm/options"
 
 fn __default_invoke_llm(message, turn_system, llm_opts) {
@@ -1531,6 +1533,26 @@ fn __agent_loop_drain_bridge_step(session_id) {
   return immediate_count + finish_step_count
 }
 
+fn __agent_loop_fire_resume_continuity(session, opts) {
+  let payload = opts?._resume_continuity
+  if type_of(payload) != "dict" {
+    return opts
+  }
+  let _ = agent_reminder_providers_fire(
+    session.session_id,
+    "worker_resumed",
+    payload
+      + {
+      session_id: session.session_id,
+      session: {id: session.session_id},
+      turn: payload?.turn ?? 0,
+      iteration: payload?.iteration ?? 0,
+    },
+    opts,
+  )
+  return omit(opts, ["_resume_continuity"])
+}
+
 @complexity(allow)
 fn __agent_loop_run(message, session, initial_opts) {
   var opts = initial_opts
@@ -1944,5 +1966,6 @@ pub fn agent_loop(message, system_prompt = nil, options = nil) {
     } catch (e) {
     }
   }
+  opts = __agent_loop_fire_resume_continuity(session, opts)
   return __agent_loop_run(message, session, opts)
 }

--- a/crates/harn-vm/src/llm/reminder_providers.rs
+++ b/crates/harn-vm/src/llm/reminder_providers.rs
@@ -16,11 +16,13 @@ const TOKEN_PRESSURE_ID: &str = "token_pressure";
 const IDLE_NUDGE_ID: &str = "idle_nudge";
 const TOOL_OUTPUT_TRUNCATED_ID: &str = "tool_output_truncated";
 const POST_COMPACT_RECAP_ID: &str = "post_compact_recap";
+const RESUME_CONTINUITY_ID: &str = "resume_continuity";
 
 const TOKEN_PRESSURE_EVENTS: &[HookEvent] = &[HookEvent::OnBudgetThreshold];
 const IDLE_NUDGE_EVENTS: &[HookEvent] = &[HookEvent::SessionIdle];
 const TOOL_OUTPUT_TRUNCATED_EVENTS: &[HookEvent] = &[HookEvent::PostToolUse];
 const POST_COMPACT_RECAP_EVENTS: &[HookEvent] = &[HookEvent::PostCompact];
+const RESUME_CONTINUITY_EVENTS: &[HookEvent] = &[HookEvent::WorkerResumed];
 
 /// Context passed to reminder providers.
 #[derive(Clone, Debug)]
@@ -53,6 +55,7 @@ struct TokenPressureProvider;
 struct IdleNudgeProvider;
 struct ToolOutputTruncatedProvider;
 struct PostCompactRecapProvider;
+struct ResumeContinuityProvider;
 
 impl ReminderProvider for TokenPressureProvider {
     fn id(&self) -> &'static str {
@@ -208,6 +211,60 @@ impl ReminderProvider for PostCompactRecapProvider {
     }
 }
 
+impl ReminderProvider for ResumeContinuityProvider {
+    fn id(&self) -> &'static str {
+        RESUME_CONTINUITY_ID
+    }
+
+    fn subscribes_to(&self) -> &'static [HookEvent] {
+        RESUME_CONTINUITY_EVENTS
+    }
+
+    fn evaluate(&self, ctx: &ProviderContext) -> Option<ReminderSpec> {
+        let reason = json_path_str(&ctx.payload, &["suspension", "reason"])
+            .or_else(|| json_str(&ctx.payload, "reason"))
+            .map(clean_inline_text)
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| "unspecified".to_string());
+        let suspended_at_turn = json_i64(&ctx.payload, "suspended_at_turn")
+            .or_else(|| json_path_i64(&ctx.payload, &["suspension", "suspended_at_turn"]))
+            .unwrap_or(0);
+        let input_presentation = if json_bool(&ctx.payload, "input_present").unwrap_or(false) {
+            let input = json_str(&ctx.payload, "input_rendered")
+                .or_else(|| json_path_str(&ctx.payload, &["resume", "input_rendered"]))
+                .map(clean_inline_text)
+                .filter(|value| !value.is_empty())
+                .unwrap_or_else(|| "<unrenderable input>".to_string());
+            format!("The resumer provided input: {input}")
+        } else {
+            "No input was provided".to_string()
+        };
+        let mut body = format!(
+            "You were suspended at turn {suspended_at_turn} for reason: '{reason}'. {}. {input_presentation}.",
+            resume_cause(ctx),
+        );
+        if !json_bool(&ctx.payload, "continue_transcript").unwrap_or(true) {
+            if let Some(digest) = json_str(&ctx.payload, "digest")
+                .or_else(|| json_path_str(&ctx.payload, &["resume", "digest"]))
+                .map(clean_inline_text)
+                .filter(|value| !value.is_empty())
+            {
+                body.push_str(" Pre-suspend conversation digest: ");
+                body.push_str(&digest);
+            }
+        }
+
+        let mut reminder = provider_reminder(body, RESUME_CONTINUITY_ID, ctx);
+        reminder.tags = vec![RESUME_CONTINUITY_ID.to_string()];
+        reminder.dedupe_key = Some(RESUME_CONTINUITY_ID.to_string());
+        reminder.ttl_turns = Some(1);
+        reminder.preserve_on_compact = true;
+        reminder.propagate = ReminderPropagate::None;
+        reminder.role_hint = ReminderRoleHint::System;
+        Some(reminder)
+    }
+}
+
 pub fn parse_provider_event(name: &str) -> Result<HookEvent, String> {
     match name.trim() {
         "PostToolUse" | "post_tool_use" => Ok(HookEvent::PostToolUse),
@@ -298,12 +355,13 @@ pub async fn evaluate_and_inject(
     }))
 }
 
-fn canonical_providers() -> [&'static dyn ReminderProvider; 4] {
+fn canonical_providers() -> [&'static dyn ReminderProvider; 5] {
     [
         &TokenPressureProvider,
         &IdleNudgeProvider,
         &ToolOutputTruncatedProvider,
         &PostCompactRecapProvider,
+        &ResumeContinuityProvider,
     ]
 }
 
@@ -370,12 +428,13 @@ fn enabled_provider_ids(
     enabled
 }
 
-fn canonical_provider_ids() -> [&'static str; 4] {
+fn canonical_provider_ids() -> [&'static str; 5] {
     [
         TOKEN_PRESSURE_ID,
         IDLE_NUDGE_ID,
         TOOL_OUTPUT_TRUNCATED_ID,
         POST_COMPACT_RECAP_ID,
+        RESUME_CONTINUITY_ID,
     ]
 }
 
@@ -482,6 +541,32 @@ fn model_context_window(ctx: &ProviderContext) -> Option<i64> {
         })
 }
 
+fn resume_cause(ctx: &ProviderContext) -> String {
+    let initiator = json_path_str(&ctx.payload, &["resume", "initiator"])
+        .or_else(|| json_str(&ctx.payload, "initiator"))
+        .unwrap_or_else(|| "operator".to_string());
+    match initiator.as_str() {
+        "parent" => "You have been resumed by your parent agent".to_string(),
+        "timeout" => "Your timeout elapsed; resuming with summary".to_string(),
+        "triggered" | "trigger" => {
+            let trigger_id = json_path_str(&ctx.payload, &["resume", "trigger", "id"])
+                .or_else(|| json_path_str(&ctx.payload, &["trigger", "id"]))
+                .or_else(|| json_str(&ctx.payload, "trigger_id"))
+                .unwrap_or_else(|| "unknown".to_string());
+            let event_id = json_path_str(&ctx.payload, &["resume", "trigger", "event_id"])
+                .or_else(|| json_path_str(&ctx.payload, &["trigger", "event_id"]))
+                .or_else(|| json_str(&ctx.payload, "event_id"))
+                .unwrap_or_else(|| "unknown".to_string());
+            format!("You have been resumed by trigger {trigger_id} matching event {event_id}")
+        }
+        _ => "You have been resumed by the operator".to_string(),
+    }
+}
+
+fn clean_inline_text(value: String) -> String {
+    value.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
 fn provider_config_i64(ctx: &ProviderContext, provider_id: &str, keys: &[&str]) -> Option<i64> {
     let config = provider_config_json(ctx, provider_id)?;
     for key in keys {
@@ -506,6 +591,36 @@ fn provider_config_json<'a>(ctx: &'a ProviderContext, provider_id: &str) -> Opti
 
 fn json_i64(value: &JsonValue, key: &str) -> Option<i64> {
     value.get(key).and_then(|value| {
+        value
+            .as_i64()
+            .or_else(|| value.as_u64().and_then(|value| i64::try_from(value).ok()))
+            .or_else(|| value.as_f64().map(|value| value as i64))
+    })
+}
+
+fn json_path<'a>(value: &'a JsonValue, path: &[&str]) -> Option<&'a JsonValue> {
+    let mut current = value;
+    for key in path {
+        current = current.get(*key)?;
+    }
+    Some(current)
+}
+
+fn json_str(value: &JsonValue, key: &str) -> Option<String> {
+    value
+        .get(key)
+        .and_then(JsonValue::as_str)
+        .map(str::to_string)
+}
+
+fn json_path_str(value: &JsonValue, path: &[&str]) -> Option<String> {
+    json_path(value, path)
+        .and_then(JsonValue::as_str)
+        .map(str::to_string)
+}
+
+fn json_path_i64(value: &JsonValue, path: &[&str]) -> Option<i64> {
+    json_path(value, path).and_then(|value| {
         value
             .as_i64()
             .or_else(|| value.as_u64().and_then(|value| i64::try_from(value).ok()))

--- a/crates/harn-vm/src/stdlib/agents.rs
+++ b/crates/harn-vm/src/stdlib/agents.rs
@@ -685,6 +685,7 @@ async fn suspend_agent_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
             snapshot_ref: worker.snapshot_path.clone(),
             prior_span_link,
             pipeline_span_link,
+            suspended_at_turn: None,
             conditions: conditions.clone(),
             auto_resume_trigger: None,
         });
@@ -810,6 +811,7 @@ async fn top_level_agent_suspend_builtin(args: Vec<VmValue>) -> Result<VmValue, 
             snapshot_ref: snapshot_path.clone(),
             prior_span_link,
             pipeline_span_link,
+            suspended_at_turn: args.get(6).and_then(VmValue::as_int),
             conditions,
             auto_resume_trigger: None,
         }),
@@ -875,6 +877,8 @@ async fn top_level_agent_suspend_builtin(args: Vec<VmValue>) -> Result<VmValue, 
 struct WorkerResumeOptions {
     resume_input: Option<VmValue>,
     continue_transcript: bool,
+    initiator: Option<String>,
+    trigger_event: Option<serde_json::Value>,
 }
 
 impl Default for WorkerResumeOptions {
@@ -882,6 +886,8 @@ impl Default for WorkerResumeOptions {
         Self {
             resume_input: None,
             continue_transcript: true,
+            initiator: None,
+            trigger_event: None,
         }
     }
 }
@@ -922,7 +928,10 @@ fn parse_resume_options(args: &[VmValue]) -> WorkerResumeOptions {
     if let VmValue::Dict(dict) = raw {
         let has_options = dict.contains_key("input")
             || dict.contains_key("resume_input")
-            || dict.contains_key("continue_transcript");
+            || dict.contains_key("continue_transcript")
+            || dict.contains_key("initiator")
+            || dict.contains_key("resume_initiator")
+            || dict.contains_key("trigger_event");
         if has_options {
             options.resume_input = dict
                 .get("input")
@@ -935,6 +944,16 @@ fn parse_resume_options(args: &[VmValue]) -> WorkerResumeOptions {
             {
                 options.continue_transcript = flag.is_truthy();
             }
+            options.initiator = dict
+                .get("initiator")
+                .or_else(|| dict.get("resume_initiator"))
+                .filter(|value| !is_nil(value))
+                .map(VmValue::display)
+                .filter(|value| !value.trim().is_empty());
+            options.trigger_event = dict
+                .get("trigger_event")
+                .filter(|value| !is_nil(value))
+                .map(crate::llm::vm_value_to_json);
         } else {
             options.resume_input = Some(raw.clone());
         }
@@ -960,11 +979,14 @@ fn summary_message(summary: &str) -> VmValue {
     ])))
 }
 
-fn summary_only_resume_transcript(transcript: Option<VmValue>) -> Option<VmValue> {
+fn summary_only_resume_transcript(
+    transcript: Option<VmValue>,
+    digest_override: Option<String>,
+) -> Option<VmValue> {
     let transcript = transcript?;
     let dict = transcript.as_dict()?;
-    let summary = crate::llm::helpers::transcript_summary_text(dict)?;
-    let summary = summary.trim();
+    let summary = digest_override.or_else(|| crate::llm::helpers::transcript_summary_text(dict));
+    let summary = summary.as_deref()?.trim();
     if summary.is_empty() {
         return None;
     }
@@ -976,11 +998,56 @@ fn summary_only_resume_transcript(transcript: Option<VmValue>) -> Option<VmValue
     ))
 }
 
-fn apply_resume_transcript_policy(worker: &mut WorkerState, continue_transcript: bool) {
+async fn resume_digest_from_transcript(
+    transcript: Option<&VmValue>,
+) -> Result<Option<String>, VmError> {
+    let Some(transcript) = transcript else {
+        return Ok(None);
+    };
+    let Some(dict) = transcript.as_dict() else {
+        return Ok(None);
+    };
+    if let Some(summary) = crate::llm::helpers::transcript_summary_text(dict) {
+        let summary = summary.trim();
+        if !summary.is_empty() {
+            return Ok(Some(summary.to_string()));
+        }
+    }
+    let messages = crate::llm::helpers::transcript_message_list(dict)?;
+    if messages.is_empty() {
+        return Ok(None);
+    }
+    let mut json_messages = messages
+        .iter()
+        .map(crate::llm::helpers::vm_value_to_json)
+        .collect::<Vec<_>>();
+    let config = crate::orchestration::AutoCompactConfig {
+        token_threshold: 0,
+        keep_last: 0,
+        compact_strategy: crate::orchestration::CompactStrategy::Truncate,
+        policy_strategy: crate::orchestration::compact_strategy_name(
+            &crate::orchestration::CompactStrategy::Truncate,
+        )
+        .to_string(),
+        ..Default::default()
+    };
+    Ok(
+        crate::orchestration::auto_compact_messages(&mut json_messages, &config, None)
+            .await?
+            .map(|summary| summary.trim().to_string())
+            .filter(|summary| !summary.is_empty()),
+    )
+}
+
+fn apply_resume_transcript_policy(
+    worker: &mut WorkerState,
+    continue_transcript: bool,
+    digest: Option<String>,
+) {
     if continue_transcript {
         return;
     }
-    worker.transcript = summary_only_resume_transcript(worker.transcript.take());
+    worker.transcript = summary_only_resume_transcript(worker.transcript.take(), digest);
 }
 
 async fn resume_agent_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
@@ -1027,7 +1094,7 @@ async fn resume_agent_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
         // are actually suspended.
         {
             let mut worker = state.borrow_mut();
-            apply_resume_transcript_policy(&mut worker, options.continue_transcript);
+            apply_resume_transcript_policy(&mut worker, options.continue_transcript, None);
             apply_resume_input(&mut worker, options.resume_input.as_ref())?;
             if worker.carry_policy.persist_state {
                 persist_worker_state_snapshot(&worker)?;
@@ -1067,6 +1134,163 @@ fn apply_resume_task_to_config(config: &mut WorkerConfig, task: &str) {
     }
 }
 
+fn resume_input_rendered(input: Option<&VmValue>) -> Option<String> {
+    let input = input?;
+    let text = input.display();
+    (!text.trim().is_empty()).then_some(text)
+}
+
+fn inferred_resume_initiator(options: &WorkerResumeOptions) -> String {
+    if let Some(initiator) = options
+        .initiator
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        return initiator.to_string();
+    }
+    if crate::agent_sessions::current_session_id().is_some() {
+        "parent".to_string()
+    } else {
+        "operator".to_string()
+    }
+}
+
+fn latest_payload_i64(payload: Option<&serde_json::Value>, key: &str) -> Option<i64> {
+    payload.and_then(|payload| {
+        payload.get(key).and_then(|value| {
+            value
+                .as_i64()
+                .or_else(|| value.as_u64().and_then(|value| i64::try_from(value).ok()))
+        })
+    })
+}
+
+fn suspended_at_turn(worker: &WorkerState, suspension: Option<&WorkerSuspension>) -> Option<i64> {
+    suspension
+        .and_then(|suspension| suspension.suspended_at_turn)
+        .or_else(|| latest_payload_i64(worker.latest_payload.as_ref(), "iterations_completed"))
+        .or_else(|| latest_payload_i64(worker.latest_payload.as_ref(), "iterations"))
+}
+
+fn install_resume_continuity_payload(
+    worker: &mut WorkerState,
+    suspension: Option<&WorkerSuspension>,
+    options: &WorkerResumeOptions,
+    digest: Option<&str>,
+) {
+    let session_id = match &worker.config {
+        WorkerConfig::SubAgent { spec } => spec.session_id.clone(),
+        _ => return,
+    };
+    let suspended_turn = suspended_at_turn(worker, suspension);
+    let trigger_id = worker
+        .suspension
+        .as_ref()
+        .or(suspension)
+        .and_then(|suspension| suspension.auto_resume_trigger.as_ref())
+        .map(|trigger| trigger.id.clone());
+    let worker_id = worker.id.clone();
+    let worker_name = worker.name.clone();
+    let worker_mode = worker.mode.clone();
+    let reason = worker
+        .suspension
+        .as_ref()
+        .or(suspension)
+        .map(|suspension| suspension.reason.clone())
+        .unwrap_or_default();
+    let suspension_initiator = worker
+        .suspension
+        .as_ref()
+        .or(suspension)
+        .map(|suspension| suspension.initiator);
+    let suspended_at = worker
+        .suspension
+        .as_ref()
+        .or(suspension)
+        .map(|suspension| suspension.suspended_at.clone());
+    let snapshot_ref = worker
+        .suspension
+        .as_ref()
+        .or(suspension)
+        .map(|suspension| suspension.snapshot_ref.clone());
+    let conditions = worker
+        .suspension
+        .as_ref()
+        .or(suspension)
+        .and_then(|suspension| suspension.conditions.clone());
+    let initiator = inferred_resume_initiator(options);
+    let input_rendered = resume_input_rendered(options.resume_input.as_ref());
+    let input_json = options
+        .resume_input
+        .as_ref()
+        .map(crate::llm::vm_value_to_json);
+    let trigger_event = options.trigger_event.clone();
+    let trigger = trigger_event.as_ref().map(|event| {
+        serde_json::json!({
+            "id": trigger_id,
+            "event_id": event.get("id").and_then(|value| value.as_str()),
+            "kind": event.get("kind").and_then(|value| value.as_str()),
+            "provider": event.get("provider").and_then(|value| value.as_str()),
+            "dedupe_key": event.get("dedupe_key").and_then(|value| value.as_str()),
+            "timeout_action": event
+                .get("provider_payload")
+                .and_then(|payload| payload.get("raw"))
+                .and_then(|raw| raw.get("on_timeout"))
+                .and_then(|value| value.as_str()),
+        })
+    });
+    let resume_initiator = if initiator == "timeout" {
+        "timeout".to_string()
+    } else if trigger.is_some() && initiator != "parent" && initiator != "operator" {
+        "triggered".to_string()
+    } else {
+        initiator
+    };
+    let payload = serde_json::json!({
+        "session_id": session_id.clone(),
+        "session": {"id": session_id},
+        "worker": {
+            "id": worker_id,
+            "name": worker_name,
+            "mode": worker_mode,
+        },
+        "suspension": {
+            "reason": reason.clone(),
+            "initiator": suspension_initiator,
+            "suspended_at": suspended_at,
+            "snapshot_ref": snapshot_ref,
+            "suspended_at_turn": suspended_turn,
+            "conditions": conditions,
+        },
+        "reason": reason,
+        "suspended_at_turn": suspended_turn.unwrap_or(0),
+        "resume": {
+            "initiator": resume_initiator.clone(),
+            "input": input_json.clone(),
+            "input_rendered": input_rendered.clone(),
+            "input_present": options.resume_input.is_some(),
+            "continue_transcript": options.continue_transcript,
+            "digest": digest,
+            "trigger": trigger,
+        },
+        "initiator": resume_initiator,
+        "input": input_json,
+        "input_rendered": input_rendered,
+        "input_present": options.resume_input.is_some(),
+        "continue_transcript": options.continue_transcript,
+        "digest": digest,
+        "turn": 0,
+        "iteration": 0,
+    });
+    if let WorkerConfig::SubAgent { spec } = &mut worker.config {
+        spec.options.insert(
+            "_resume_continuity".to_string(),
+            crate::stdlib::json_to_vm_value(&payload),
+        );
+    }
+}
+
 async fn unregister_suspension_auto_resume(
     suspension: Option<WorkerSuspension>,
 ) -> Result<(), VmError> {
@@ -1103,6 +1327,12 @@ async fn warm_resume_worker(
     options: WorkerResumeOptions,
 ) -> Result<VmValue, VmError> {
     join_checkpointed_worker_handle(state.clone()).await?;
+    let resume_digest = if options.continue_transcript {
+        None
+    } else {
+        let transcript = state.borrow().transcript.clone();
+        resume_digest_from_transcript(transcript.as_ref()).await?
+    };
     let (worker_id, span_links) = {
         let worker = state.borrow();
         if worker.status != "suspended" {
@@ -1153,10 +1383,20 @@ async fn warm_resume_worker(
         worker.status = "running".to_string();
         worker.finished_at = None;
         worker.latest_error = None;
-        apply_resume_transcript_policy(&mut worker, options.continue_transcript);
+        apply_resume_transcript_policy(
+            &mut worker,
+            options.continue_transcript,
+            resume_digest.clone(),
+        );
         apply_resume_input(&mut worker, options.resume_input.as_ref())?;
         let task = worker.task.clone();
         apply_resume_task_to_config(&mut worker.config, &task);
+        install_resume_continuity_payload(
+            &mut worker,
+            suspension.as_ref(),
+            &options,
+            resume_digest.as_deref(),
+        );
         if worker.carry_policy.persist_state {
             persist_worker_state_snapshot(&worker)?;
         }
@@ -1188,6 +1428,15 @@ pub(crate) async fn resume_worker_from_auto_resume_trigger(
     let options = WorkerResumeOptions {
         resume_input,
         continue_transcript: timeout_action.as_deref() != Some("resume_with_summary"),
+        initiator: Some(
+            if timeout_action.as_deref() == Some("resume_with_summary") {
+                "timeout"
+            } else {
+                "triggered"
+            }
+            .to_string(),
+        ),
+        trigger_event: Some(serde_json::to_value(event).unwrap_or(serde_json::Value::Null)),
     };
     let state = with_worker_state(worker_id, |state| Ok(state.clone()))?;
     warm_resume_worker(state, options).await
@@ -2265,6 +2514,27 @@ mod suspend_tests {
                 .map(VmValue::display),
             Some("Prior digest".to_string())
         );
+        let resume_context = WORKER_REGISTRY
+            .with(|registry| {
+                let state = registry.borrow().get(&worker_id).cloned().unwrap();
+                let worker = state.borrow();
+                match &worker.config {
+                    WorkerConfig::SubAgent { spec } => {
+                        spec.options.get("_resume_continuity").cloned()
+                    }
+                    _ => None,
+                }
+            })
+            .expect("resume continuity payload");
+        let resume_context = crate::llm::vm_value_to_json(&resume_context);
+        assert_eq!(
+            resume_context["continue_transcript"],
+            serde_json::json!(false)
+        );
+        assert_eq!(resume_context["reason"], "park before fresh prompt");
+        assert_eq!(resume_context["suspended_at_turn"], 0);
+        assert_eq!(resume_context["digest"], "Prior digest");
+        assert_eq!(resume_context["input_rendered"], "fresh prompt");
 
         teardown(&dir, &worker_id);
     }

--- a/crates/harn-vm/src/stdlib/agents_workers/mod.rs
+++ b/crates/harn-vm/src/stdlib/agents_workers/mod.rs
@@ -142,6 +142,8 @@ pub(crate) struct WorkerSuspension {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) pipeline_span_link: Option<crate::tracing::SpanLink>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) suspended_at_turn: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) conditions: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) auto_resume_trigger: Option<crate::stdlib::triggers_stdlib::AutoResumeTriggerHandle>,

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -1475,8 +1475,12 @@ println(cleared.removed_count)
 - `tool_output_truncated` on `post_tool_use` when tool output was
   compacted/truncated before the model saw it.
 - `post_compact_recap` on `post_compact` with the latest recap.
-- `idle_nudge` and `tool_output_truncated` use `propagate: "none"`;
-  `post_compact_recap` uses `propagate: "session"`.
+- `resume_continuity` on `worker_resumed`, visible only to the first
+  resumed turn. It names the suspend turn, reason, resume cause, and
+  optional resume input; when `continue_transcript: false`, it also
+  carries the pre-suspend digest.
+- `idle_nudge`, `tool_output_truncated`, and `resume_continuity` use
+  `propagate: "none"`; `post_compact_recap` uses `propagate: "session"`.
 
 Opt out per loop:
 

--- a/docs/src/system-reminders.md
+++ b/docs/src/system-reminders.md
@@ -256,6 +256,7 @@ but does not evaluate providers.
 | `idle_nudge` | `session_idle` | `idle_seconds` or `seconds` | Fires when daemon idle wake interval reaches the threshold, defaulting to 60 seconds. Uses tag `idle`, dedupe key `idle_nudge`, `ttl_turns: 1`, and `propagate: "none"`. |
 | `tool_output_truncated` | `post_tool_use` | none | Fires when tool output was truncated or compacted before the model saw it. Uses tag `truncation`, dedupe key `tool_output_truncated:<tool_name>`, `ttl_turns: 1`, and `propagate: "none"`. |
 | `post_compact_recap` | `post_compact` | none | Fires after compaction archives messages. Uses tag `recap`, dedupe key `post_compact_recap`, `ttl_turns: 2`, and `propagate: "session"`. |
+| `resume_continuity` | `worker_resumed` | none | Fires before the first resumed `agent_loop` turn. Uses tag and dedupe key `resume_continuity`, `ttl_turns: 1`, `preserve_on_compact: true`, and `propagate: "none"`; includes suspension reason, resume cause, optional resume input, and a pre-suspend digest for `continue_transcript: false`. |
 
 Disable every provider with `reminders: false` or
 `reminders: {enabled: false}`. Disable selected providers by prefixing the


### PR DESCRIPTION
Closes #1845.

## Summary
- Adds the canonical `resume_continuity` reminder provider on `worker_resumed`.
- Wires resumed sub-agent loops to inject a one-turn continuity reminder with suspension reason, resume cause, input, and summary-only digest context.
- Adds conformance coverage plus docs/changelog updates.

## Verification
- `cargo check -p harn-vm`
- `cargo check -p harn-lint`
- `cargo test -p harn-vm resume_can_drop_transcript_history_to_summary`
- `cargo run --quiet --bin harn -- fmt --check crates/harn-stdlib/src/stdlib/agent/loop.harn conformance/tests/agents/agent_resume_continuity_reminder.harn conformance/tests/reminder_provider_resume_continuity.harn`
- `cargo run --quiet --bin harn -- lint crates/harn-stdlib/src/stdlib/agent/loop.harn conformance/tests/agents/agent_resume_continuity_reminder.harn conformance/tests/reminder_provider_resume_continuity.harn`
- `cargo run --quiet --bin harn -- test conformance --filter resume_continuity`
- `cargo run --quiet --bin harn -- test conformance --filter agent_await_resumption`
- `cargo run --quiet --bin harn -- test conformance --filter agent_auto_resume_trigger`
- pre-commit hook: workspace clippy, staged Harn lint/format, markdown lint, highlight sync
- pre-push hook: targeted local checks, affected Harn lint/format, markdown lint, highlight check