### PR TITLE
[codex] Add lifecycle span links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ condensed series summaries instead of full per-patch history.
 
 ### Added
 
+- **Lifecycle span links for suspend/resume and drain scaffolding (#1858).**
+  VM tracing now has `suspension`, `resume`, `drain`, and
+  `drain_decision` span kinds plus causal span links. Worker suspension
+  snapshots persist `prior_span_link` plus the closed pipeline span link
+  so cold resumes can link the fresh resume span to closed lifecycle spans
+  instead of parenting across process boundaries. The OTel helper layer
+  now exposes `set_span_link` beside `set_span_parent`, with no-op
+  behavior in non-OTel builds.
 - **Sub-agent reminder propagation via handoff envelopes (#1824).**
   Handoff artifacts and sub-agent requests now carry
   `reminder_propagation` beside `policy_override`; `handoff(...)` derives

--- a/crates/harn-cli/src/commands/portal/tests.rs
+++ b/crates/harn-cli/src/commands/portal/tests.rs
@@ -264,6 +264,7 @@ fn build_run_detail_joins_tool_call_audit_onto_matching_activity() {
                 "call_id".to_string(),
                 serde_json::json!("call-with-audit"),
             )]),
+            ..Default::default()
         },
         harn_vm::orchestration::RunTraceSpanRecord {
             span_id: 2,
@@ -276,6 +277,7 @@ fn build_run_detail_joins_tool_call_audit_onto_matching_activity() {
                 "call_id".to_string(),
                 serde_json::json!("call-without-audit"),
             )]),
+            ..Default::default()
         },
     ];
 

--- a/crates/harn-vm/src/observability/otel.rs
+++ b/crates/harn-vm/src/observability/otel.rs
@@ -1,6 +1,4 @@
-use std::collections::BTreeMap;
-#[cfg(feature = "otel")]
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fs::{self, OpenOptions};
 use std::io::{self, Write};
 use std::path::PathBuf;
@@ -21,6 +19,8 @@ use crate::TraceId;
 pub const OTEL_PARENT_SPAN_ID_HEADER: &str = "otel_parent_span_id";
 pub const OTEL_TRACEPARENT_HEADER: &str = "traceparent";
 pub const OTEL_TRACESTATE_HEADER: &str = "tracestate";
+pub type SpanRef = tracing::Span;
+pub type SpanId = String;
 
 static OBSERVABILITY_INIT: std::sync::OnceLock<()> = std::sync::OnceLock::new();
 
@@ -385,6 +385,37 @@ pub fn set_span_parent(
 }
 
 #[cfg(feature = "otel")]
+pub fn set_span_link(
+    span: &SpanRef,
+    linked_trace_id: &TraceId,
+    linked_span_id: &SpanId,
+    attributes: Option<HashMap<String, String>>,
+) -> Result<(), String> {
+    use tracing_opentelemetry::OpenTelemetrySpanExt as _;
+
+    let attributes = attributes
+        .unwrap_or_default()
+        .into_iter()
+        .map(|(key, value)| opentelemetry::KeyValue::new(key, value))
+        .collect();
+    span.add_link_with_attributes(
+        span_context(linked_trace_id, Some(linked_span_id.as_str())),
+        attributes,
+    );
+    Ok(())
+}
+
+#[cfg(not(feature = "otel"))]
+pub fn set_span_link(
+    _span: &SpanRef,
+    _linked_trace_id: &TraceId,
+    _linked_span_id: &SpanId,
+    _attributes: Option<HashMap<String, String>>,
+) -> Result<(), String> {
+    Ok(())
+}
+
+#[cfg(feature = "otel")]
 pub fn current_span_id_hex(span: &tracing::Span) -> Option<String> {
     use opentelemetry::trace::TraceContextExt as _;
     use tracing_opentelemetry::OpenTelemetrySpanExt as _;
@@ -399,6 +430,27 @@ pub fn current_span_id_hex(span: &tracing::Span) -> Option<String> {
 
 #[cfg(not(feature = "otel"))]
 pub fn current_span_id_hex(_span: &tracing::Span) -> Option<String> {
+    None
+}
+
+#[cfg(feature = "otel")]
+pub fn current_span_context_hex(span: &tracing::Span) -> Option<(String, String)> {
+    use opentelemetry::trace::TraceContextExt as _;
+    use tracing_opentelemetry::OpenTelemetrySpanExt as _;
+
+    let context = span.context();
+    let binding = context.span();
+    let span_context = binding.span_context();
+    span_context.is_valid().then(|| {
+        (
+            span_context.trace_id().to_string(),
+            span_context.span_id().to_string(),
+        )
+    })
+}
+
+#[cfg(not(feature = "otel"))]
+pub fn current_span_context_hex(_span: &tracing::Span) -> Option<(String, String)> {
     None
 }
 
@@ -651,6 +703,40 @@ fn parse_headers(raw: &str) -> HashMap<String, String> {
 #[cfg(all(test, feature = "otel"))]
 mod tests {
     use super::*;
+    use opentelemetry::trace::TracerProvider as _;
+    use opentelemetry_sdk::error::OTelSdkResult;
+    use opentelemetry_sdk::trace::{SdkTracerProvider, SpanData, SpanExporter, Tracer};
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Clone, Default, Debug)]
+    struct TestExporter(Arc<Mutex<Vec<SpanData>>>);
+
+    impl SpanExporter for TestExporter {
+        async fn export(&self, mut batch: Vec<SpanData>) -> OTelSdkResult {
+            let mut spans = self.0.lock().expect("test exporter lock");
+            spans.append(&mut batch);
+            Ok(())
+        }
+    }
+
+    fn test_tracer() -> (
+        Tracer,
+        SdkTracerProvider,
+        TestExporter,
+        impl tracing::Subscriber,
+    ) {
+        let exporter = TestExporter::default();
+        let provider = SdkTracerProvider::builder()
+            .with_simple_exporter(exporter.clone())
+            .build();
+        let tracer = provider.tracer("harn-test");
+        let subscriber = tracing_subscriber::registry().with(
+            tracing_opentelemetry::layer()
+                .with_tracer(tracer.clone())
+                .with_filter(LevelFilter::INFO),
+        );
+        (tracer, provider, exporter, subscriber)
+    }
 
     #[test]
     fn normalizes_trace_endpoint_suffix() {
@@ -709,5 +795,40 @@ mod tests {
         assert!(error.contains("forwarder"), "{error}");
         assert!(error.contains("batch"), "{error}");
         assert!(error.contains("simple"), "{error}");
+    }
+
+    #[test]
+    fn set_span_link_exports_link_without_parenting() {
+        let (_tracer, provider, exporter, subscriber) = test_tracer();
+        let linked_trace_id = TraceId("1234567890abcdef1234567890abcdef".to_string());
+        let linked_span_id: SpanId = "1234567890abcdef".to_string();
+
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!(target: "harn.vm.lifecycle", "resume");
+            set_span_link(
+                &span,
+                &linked_trace_id,
+                &linked_span_id,
+                Some(HashMap::from([(
+                    "harn.link.kind".to_string(),
+                    "suspension".to_string(),
+                )])),
+            )
+            .expect("set span link");
+            span.in_scope(|| {});
+        });
+
+        provider.force_flush().expect("flush spans");
+        drop(provider);
+        let spans = exporter.0.lock().expect("exported spans lock");
+        assert_eq!(spans.len(), 1);
+        let resume = &spans[0];
+        assert_eq!(resume.parent_span_id, opentelemetry::trace::SpanId::INVALID);
+        assert_eq!(resume.links.len(), 1);
+        let link = &resume.links[0];
+        assert_eq!(link.span_context.trace_id().to_string(), linked_trace_id.0);
+        assert_eq!(link.span_context.span_id().to_string(), linked_span_id);
+        assert_eq!(link.attributes.len(), 1);
+        assert_eq!(link.attributes[0].key.as_str(), "harn.link.kind");
     }
 }

--- a/crates/harn-vm/src/orchestration/records/types.rs
+++ b/crates/harn-vm/src/orchestration/records/types.rs
@@ -682,6 +682,7 @@ pub fn tool_fixture_hash(tool_name: &str, args: &serde_json::Value) -> String {
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(default)]
 pub struct RunTraceSpanRecord {
+    pub trace_id: String,
     pub span_id: u64,
     pub parent_id: Option<u64>,
     pub kind: String,
@@ -689,6 +690,7 @@ pub struct RunTraceSpanRecord {
     pub start_ms: u64,
     pub duration_ms: u64,
     pub metadata: BTreeMap<String, serde_json::Value>,
+    pub links: Vec<crate::tracing::SpanLink>,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/harn-vm/src/profile.rs
+++ b/crates/harn-vm/src/profile.rs
@@ -355,6 +355,7 @@ mod tests {
 
     fn span(span_id: u64, parent_id: Option<u64>, kind: SpanKind, name: &str, dur: u64) -> Span {
         Span {
+            trace_id: "trace_test".to_string(),
             span_id,
             parent_id,
             kind,
@@ -362,6 +363,7 @@ mod tests {
             start_ms: 0,
             duration_ms: dur,
             metadata: BTreeMap::new(),
+            links: Vec::new(),
         }
     }
 

--- a/crates/harn-vm/src/stdlib/agents.rs
+++ b/crates/harn-vm/src/stdlib/agents.rs
@@ -13,7 +13,7 @@ mod sub_agent;
 pub(super) mod workflow;
 
 use std::cell::RefCell;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -135,6 +135,85 @@ struct WorkerReplayCarry {
     resume_workflow: bool,
     child_run_path: Option<String>,
     reset_sub_agent_session: bool,
+}
+
+struct LifecycleSpanGuard {
+    span_id: u64,
+    otel_span: tracing::Span,
+}
+
+impl LifecycleSpanGuard {
+    fn start(
+        kind: crate::tracing::SpanKind,
+        name: String,
+        links: Vec<crate::tracing::SpanLink>,
+    ) -> Self {
+        Self::start_with_parenting(kind, name, links, true)
+    }
+
+    fn start_detached(
+        kind: crate::tracing::SpanKind,
+        name: String,
+        links: Vec<crate::tracing::SpanLink>,
+    ) -> Self {
+        Self::start_with_parenting(kind, name, links, false)
+    }
+
+    fn start_with_parenting(
+        kind: crate::tracing::SpanKind,
+        name: String,
+        links: Vec<crate::tracing::SpanLink>,
+        inherit_parent: bool,
+    ) -> Self {
+        let span_id = if inherit_parent {
+            crate::tracing::span_start_with_links(kind, name.clone(), links.clone())
+        } else {
+            crate::tracing::span_start_detached_with_links(kind, name.clone(), links.clone())
+        };
+        let otel_span = tracing::info_span!(
+            target: "harn.vm.lifecycle",
+            "harn.lifecycle",
+            harn.kind = kind.as_str(),
+            harn.name = %name,
+        );
+        for link in links {
+            let trace_id = crate::TraceId(link.trace_id);
+            let mut attributes: HashMap<String, String> = link.attributes.into_iter().collect();
+            attributes
+                .entry("harn.link.kind".to_string())
+                .or_insert_with(|| "causal".to_string());
+            let _ = crate::observability::otel::set_span_link(
+                &otel_span,
+                &trace_id,
+                &link.span_id,
+                Some(attributes),
+            );
+        }
+        Self { span_id, otel_span }
+    }
+
+    fn link(&self) -> Option<crate::tracing::SpanLink> {
+        crate::observability::otel::current_span_context_hex(&self.otel_span)
+            .map(|(trace_id, span_id)| crate::tracing::SpanLink::new(trace_id, span_id))
+            .or_else(|| crate::tracing::span_link(self.span_id))
+    }
+
+    fn set_metadata(&self, key: &str, value: serde_json::Value) {
+        crate::tracing::span_set_metadata(self.span_id, key, value);
+    }
+
+    fn end(&mut self) {
+        if self.span_id != 0 {
+            crate::tracing::span_end(self.span_id);
+            self.span_id = 0;
+        }
+    }
+}
+
+impl Drop for LifecycleSpanGuard {
+    fn drop(&mut self) {
+        self.end();
+    }
 }
 
 fn restart_worker_run(
@@ -557,6 +636,7 @@ async fn suspend_agent_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
         .cloned();
     let conditions = conditions_value.as_ref().map(crate::llm::vm_value_to_json);
 
+    let mut suspension_span: Option<LifecycleSpanGuard> = None;
     let (mut snapshot, mut summary, should_emit) = with_worker_state(&worker_id, |state| {
         let mut worker = state.borrow_mut();
         if worker.status == "suspended" {
@@ -575,6 +655,21 @@ async fn suspend_agent_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
                 ),
             ));
         }
+        let pipeline_span_link = crate::tracing::current_span_link();
+        let span = LifecycleSpanGuard::start(
+            crate::tracing::SpanKind::Suspension,
+            format!("suspend {}", worker.id),
+            Vec::new(),
+        );
+        span.set_metadata("worker_id", serde_json::json!(worker.id));
+        if let Some(pipeline_span_link) = &pipeline_span_link {
+            span.set_metadata(
+                "pipeline_span_id",
+                serde_json::json!(pipeline_span_link.span_id),
+            );
+        }
+        let prior_span_link = span.link();
+        suspension_span = Some(span);
         worker.suspend_signal.store(true, Ordering::SeqCst);
         worker.status = "suspended".to_string();
         worker.awaiting_started_at = None;
@@ -584,6 +679,8 @@ async fn suspend_agent_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
             initiator,
             suspended_at: uuid::Uuid::now_v7().to_string(),
             snapshot_ref: worker.snapshot_path.clone(),
+            prior_span_link,
+            pipeline_span_link,
             conditions: conditions.clone(),
             auto_resume_trigger: None,
         });
@@ -612,6 +709,9 @@ async fn suspend_agent_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
                 persist_worker_state_snapshot(&worker)?;
                 Ok((worker_event_snapshot(&worker), worker_summary(&worker)?))
             })?;
+        }
+        if let Some(span) = suspension_span.as_mut() {
+            span.end();
         }
         emit_worker_event(&snapshot, crate::agent_events::WorkerEvent::WorkerSuspended).await?;
     }
@@ -647,6 +747,20 @@ async fn top_level_agent_suspend_builtin(args: Vec<VmValue>) -> Result<VmValue, 
     let snapshot_path = worker_snapshot_path(&worker_id);
     let now = uuid::Uuid::now_v7().to_string();
     let name = "top-level-agent".to_string();
+    let pipeline_span_link = crate::tracing::current_span_link();
+    let mut suspension_span = LifecycleSpanGuard::start(
+        crate::tracing::SpanKind::Suspension,
+        format!("suspend {worker_id}"),
+        Vec::new(),
+    );
+    suspension_span.set_metadata("worker_id", serde_json::json!(worker_id));
+    if let Some(pipeline_span_link) = &pipeline_span_link {
+        suspension_span.set_metadata(
+            "pipeline_span_id",
+            serde_json::json!(pipeline_span_link.span_id),
+        );
+    }
+    let prior_span_link = suspension_span.link();
     let config = WorkerConfig::SubAgent {
         spec: Box::new(SubAgentRunSpec {
             name: name.clone(),
@@ -690,6 +804,8 @@ async fn top_level_agent_suspend_builtin(args: Vec<VmValue>) -> Result<VmValue, 
             initiator: SuspendInitiator::SelfInitiated,
             suspended_at: now,
             snapshot_ref: snapshot_path.clone(),
+            prior_span_link,
+            pipeline_span_link,
             conditions,
             auto_resume_trigger: None,
         }),
@@ -735,6 +851,7 @@ async fn top_level_agent_suspend_builtin(args: Vec<VmValue>) -> Result<VmValue, 
             Ok((worker_event_snapshot(&worker), worker_summary(&worker)?))
         })?;
     }
+    suspension_span.end();
     emit_worker_event(&snapshot, WorkerEvent::WorkerSuspended).await?;
     Ok(summary)
 }
@@ -982,6 +1099,40 @@ async fn warm_resume_worker(
     options: WorkerResumeOptions,
 ) -> Result<VmValue, VmError> {
     join_checkpointed_worker_handle(state.clone()).await?;
+    let (worker_id, span_links) = {
+        let worker = state.borrow();
+        if worker.status != "suspended" {
+            return Err(diagnostic_error(
+                Code::ConcurrentResumeConflict,
+                format!(
+                    "resume_agent: worker {} changed before resume could complete (status={})",
+                    worker.id, worker.status
+                ),
+            ));
+        }
+        let mut span_links = Vec::new();
+        if let Some(suspension) = &worker.suspension {
+            if let Some(link) = suspension.prior_span_link.clone() {
+                span_links.push(link.with_attributes(BTreeMap::from([(
+                    "harn.link.kind".to_string(),
+                    "suspension".to_string(),
+                )])));
+            }
+            if let Some(link) = suspension.pipeline_span_link.clone() {
+                span_links.push(link.with_attributes(BTreeMap::from([(
+                    "harn.link.kind".to_string(),
+                    "pipeline".to_string(),
+                )])));
+            }
+        }
+        (worker.id.clone(), span_links)
+    };
+    let mut resume_span = LifecycleSpanGuard::start_detached(
+        crate::tracing::SpanKind::Resume,
+        format!("resume {worker_id}"),
+        span_links,
+    );
+    resume_span.set_metadata("worker_id", serde_json::json!(worker_id));
     let (snapshot, suspension) = {
         let mut worker = state.borrow_mut();
         if worker.status != "suspended" {
@@ -1009,6 +1160,7 @@ async fn warm_resume_worker(
     };
     unregister_suspension_auto_resume(suspension).await?;
     emit_worker_event(&snapshot, crate::agent_events::WorkerEvent::WorkerResumed).await?;
+    resume_span.end();
     if crate::vm::clone_async_builtin_child_vm().is_some() {
         respawn_worker_task(state.clone())?;
     }
@@ -2063,6 +2215,105 @@ mod suspend_tests {
         assert_eq!(summary_status(&resumed), "running");
 
         teardown(&dir, &worker_id);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn suspend_resume_links_lifecycle_spans_across_snapshot_reload() {
+        let _guard = suspend_test_lock().await;
+        crate::tracing::reset_tracing();
+        crate::tracing::set_tracing_enabled(true);
+        let (worker_id, dir) = seed_test_worker("worker-suspend-resume-trace-link");
+        let snapshot_path = WORKER_REGISTRY.with(|registry| {
+            registry
+                .borrow()
+                .get(&worker_id)
+                .unwrap()
+                .borrow()
+                .snapshot_path
+                .clone()
+        });
+
+        let pipeline_span_id =
+            crate::tracing::span_start(crate::tracing::SpanKind::Pipeline, "pipeline".to_string());
+        let pipeline_span_link =
+            crate::tracing::span_link(pipeline_span_id).expect("open pipeline span link");
+        suspend_agent_builtin(vec![
+            handle_value(&worker_id),
+            VmValue::String(Rc::from("checkpoint before restart")),
+        ])
+        .await
+        .expect("suspend");
+        crate::tracing::span_end(pipeline_span_id);
+
+        WORKER_REGISTRY.with(|registry| {
+            registry.borrow_mut().remove(&worker_id);
+        });
+        let reloaded =
+            agents_workers::load_worker_state_snapshot(&snapshot_path).expect("reload snapshot");
+        let suspension_record = reloaded.suspension.as_ref().expect("snapshot suspension");
+        let prior_span_link = suspension_record
+            .prior_span_link
+            .clone()
+            .expect("snapshot preserves prior span link");
+        let reloaded_pipeline_span_link = suspension_record
+            .pipeline_span_link
+            .clone()
+            .expect("snapshot preserves pipeline span link");
+        assert!(!prior_span_link.trace_id.is_empty());
+        assert!(!prior_span_link.span_id.is_empty());
+        assert_eq!(
+            reloaded_pipeline_span_link.trace_id,
+            pipeline_span_link.trace_id
+        );
+        assert_eq!(
+            reloaded_pipeline_span_link.span_id,
+            pipeline_span_link.span_id
+        );
+
+        WORKER_REGISTRY.with(|registry| {
+            registry
+                .borrow_mut()
+                .insert(worker_id.clone(), Rc::new(RefCell::new(reloaded)));
+        });
+        resume_agent_builtin(vec![handle_value(&worker_id)])
+            .await
+            .expect("resume after restart");
+
+        let spans = crate::tracing::peek_spans();
+        let suspension = spans
+            .iter()
+            .find(|span| span.kind == crate::tracing::SpanKind::Suspension)
+            .expect("suspension span");
+        let resume = spans
+            .iter()
+            .find(|span| span.kind == crate::tracing::SpanKind::Resume)
+            .expect("resume span");
+        assert_eq!(suspension.name, format!("suspend {worker_id}"));
+        assert_eq!(resume.name, format!("resume {worker_id}"));
+        assert_eq!(resume.parent_id, None);
+        assert_eq!(resume.links.len(), 2);
+        let suspension_link = resume
+            .links
+            .iter()
+            .find(|link| {
+                link.attributes.get("harn.link.kind").map(String::as_str) == Some("suspension")
+            })
+            .expect("resume links to suspension");
+        let pipeline_link = resume
+            .links
+            .iter()
+            .find(|link| {
+                link.attributes.get("harn.link.kind").map(String::as_str) == Some("pipeline")
+            })
+            .expect("resume links to pipeline");
+        assert_eq!(suspension_link.trace_id, prior_span_link.trace_id);
+        assert_eq!(suspension_link.span_id, prior_span_link.span_id);
+        assert_eq!(pipeline_link.trace_id, pipeline_span_link.trace_id);
+        assert_eq!(pipeline_link.span_id, pipeline_span_link.span_id);
+
+        teardown(&dir, &worker_id);
+        crate::tracing::set_tracing_enabled(false);
+        crate::tracing::reset_tracing();
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/harn-vm/src/stdlib/agents_workers/mod.rs
+++ b/crates/harn-vm/src/stdlib/agents_workers/mod.rs
@@ -138,6 +138,10 @@ pub(crate) struct WorkerSuspension {
     pub(crate) suspended_at: String,
     pub(crate) snapshot_ref: String,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) prior_span_link: Option<crate::tracing::SpanLink>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) pipeline_span_link: Option<crate::tracing::SpanLink>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) conditions: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) auto_resume_trigger: Option<crate::stdlib::triggers_stdlib::AutoResumeTriggerHandle>,

--- a/crates/harn-vm/src/stdlib/workflow/artifact.rs
+++ b/crates/harn-vm/src/stdlib/workflow/artifact.rs
@@ -64,6 +64,7 @@ pub(super) fn snapshot_trace_spans() -> Vec<RunTraceSpanRecord> {
     crate::tracing::peek_spans()
         .into_iter()
         .map(|span| RunTraceSpanRecord {
+            trace_id: span.trace_id,
             span_id: span.span_id,
             parent_id: span.parent_id,
             kind: span.kind.as_str().to_string(),
@@ -71,6 +72,7 @@ pub(super) fn snapshot_trace_spans() -> Vec<RunTraceSpanRecord> {
             start_ms: span.start_ms,
             duration_ms: span.duration_ms,
             metadata: span.metadata,
+            links: span.links,
         })
         .collect()
 }

--- a/crates/harn-vm/src/tracing.rs
+++ b/crates/harn-vm/src/tracing.rs
@@ -28,6 +28,14 @@ pub enum SpanKind {
     Step,
     /// Host-side VM setup before user bytecode starts executing.
     VmSetup,
+    /// Cooperative worker suspension while the durable checkpoint is written.
+    Suspension,
+    /// Worker resumption after a cooperative suspension.
+    Resume,
+    /// Pipeline drain / settlement phase.
+    Drain,
+    /// One drain settlement decision.
+    DrainDecision,
 }
 
 impl SpanKind {
@@ -42,13 +50,43 @@ impl SpanKind {
             Self::Spawn => "spawn",
             Self::Step => "step",
             Self::VmSetup => "vm_setup",
+            Self::Suspension => "suspension",
+            Self::Resume => "resume",
+            Self::Drain => "drain",
+            Self::DrainDecision => "drain_decision",
         }
+    }
+}
+
+/// Link to a span that is causally related but not the parent.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct SpanLink {
+    pub trace_id: String,
+    pub span_id: String,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub attributes: BTreeMap<String, String>,
+}
+
+impl SpanLink {
+    pub fn new(trace_id: impl Into<String>, span_id: impl Into<String>) -> Self {
+        Self {
+            trace_id: trace_id.into(),
+            span_id: span_id.into(),
+            attributes: BTreeMap::new(),
+        }
+    }
+
+    pub fn with_attributes(mut self, attributes: BTreeMap<String, String>) -> Self {
+        self.attributes = attributes;
+        self
     }
 }
 
 /// A completed tracing span.
 #[derive(Debug, Clone)]
 pub struct Span {
+    pub trace_id: String,
     pub span_id: u64,
     pub parent_id: Option<u64>,
     pub kind: SpanKind,
@@ -56,21 +94,25 @@ pub struct Span {
     pub start_ms: u64,
     pub duration_ms: u64,
     pub metadata: BTreeMap<String, serde_json::Value>,
+    pub links: Vec<SpanLink>,
 }
 
 /// An in-flight span (not yet completed).
 struct OpenSpan {
+    trace_id: String,
     span_id: u64,
     parent_id: Option<u64>,
     kind: SpanKind,
     name: String,
     started_at: Instant,
     metadata: BTreeMap<String, serde_json::Value>,
+    links: Vec<SpanLink>,
 }
 
 /// Thread-local span collector. Accumulates completed spans and tracks the
 /// active span stack for automatic parent assignment.
 pub struct SpanCollector {
+    trace_id: String,
     next_id: u64,
     /// Stack of open span IDs — the top is the current active span.
     active_stack: Vec<u64>,
@@ -92,6 +134,7 @@ impl SpanCollector {
     pub fn new() -> Self {
         Self {
             next_id: 1,
+            trace_id: format!("trace_{}", uuid::Uuid::now_v7()),
             active_stack: Vec::new(),
             open: BTreeMap::new(),
             completed: Vec::new(),
@@ -101,22 +144,54 @@ impl SpanCollector {
 
     /// Start a new span. Returns the span ID.
     pub fn start(&mut self, kind: SpanKind, name: String) -> u64 {
+        let parent_id = self.active_stack.last().copied();
+        self.start_with_parent(kind, name, Vec::new(), parent_id)
+    }
+
+    /// Start a new span with non-parent causal links. Returns the span ID.
+    pub fn start_with_links(&mut self, kind: SpanKind, name: String, links: Vec<SpanLink>) -> u64 {
+        let parent_id = self.active_stack.last().copied();
+        self.start_with_parent(kind, name, links, parent_id)
+    }
+
+    /// Start a root span with non-parent causal links. Returns the span ID.
+    pub fn start_detached_with_links(
+        &mut self,
+        kind: SpanKind,
+        name: String,
+        links: Vec<SpanLink>,
+    ) -> u64 {
+        self.start_with_parent(kind, name, links, None)
+    }
+
+    fn start_with_parent(
+        &mut self,
+        kind: SpanKind,
+        name: String,
+        links: Vec<SpanLink>,
+        parent_id: Option<u64>,
+    ) -> u64 {
         let id = self.next_id;
         self.next_id += 1;
-        let parent_id = self.active_stack.last().copied();
         let now = Instant::now();
 
-        crate::events::emit_span_start(id, parent_id, &name, kind.as_str(), BTreeMap::new());
+        let mut event_metadata = BTreeMap::new();
+        if !links.is_empty() {
+            event_metadata.insert("links".to_string(), serde_json::json!(links));
+        }
+        crate::events::emit_span_start(id, parent_id, &name, kind.as_str(), event_metadata);
 
         self.open.insert(
             id,
             OpenSpan {
+                trace_id: self.trace_id.clone(),
                 span_id: id,
                 parent_id,
                 kind,
                 name,
                 started_at: now,
                 metadata: BTreeMap::new(),
+                links,
             },
         );
         self.active_stack.push(id);
@@ -145,6 +220,7 @@ impl SpanCollector {
             crate::events::emit_span_end(span_id, end_meta);
 
             self.completed.push(Span {
+                trace_id: span.trace_id,
                 span_id: span.span_id,
                 parent_id: span.parent_id,
                 kind: span.kind,
@@ -152,6 +228,7 @@ impl SpanCollector {
                 start_ms,
                 duration_ms,
                 metadata: span.metadata,
+                links: span.links,
             });
 
             if let Some(pos) = self.active_stack.iter().rposition(|&id| id == span_id) {
@@ -163,6 +240,19 @@ impl SpanCollector {
     /// Get the current active span ID (if any).
     pub fn current_span_id(&self) -> Option<u64> {
         self.active_stack.last().copied()
+    }
+
+    /// Build a serializable link for an open span.
+    pub fn span_link(&self, span_id: u64) -> Option<SpanLink> {
+        self.open
+            .get(&span_id)
+            .map(|span| SpanLink::new(span.trace_id.clone(), span.span_id.to_string()))
+    }
+
+    /// Build a serializable link for the current active span.
+    pub fn current_span_link(&self) -> Option<SpanLink> {
+        self.current_span_id()
+            .and_then(|span_id| self.span_link(span_id))
     }
 
     /// Take all completed spans (drains the collector).
@@ -181,6 +271,7 @@ impl SpanCollector {
         self.open.clear();
         self.completed.clear();
         self.next_id = 1;
+        self.trace_id = format!("trace_{}", uuid::Uuid::now_v7());
         self.epoch = Instant::now();
     }
 }
@@ -211,6 +302,22 @@ pub fn span_start(kind: SpanKind, name: String) -> u64 {
     COLLECTOR.with(|c| c.borrow_mut().start(kind, name))
 }
 
+/// Start a span with non-parent causal links (no-op if tracing disabled).
+pub fn span_start_with_links(kind: SpanKind, name: String, links: Vec<SpanLink>) -> u64 {
+    if !is_tracing_enabled() {
+        return 0;
+    }
+    COLLECTOR.with(|c| c.borrow_mut().start_with_links(kind, name, links))
+}
+
+/// Start a root span with non-parent causal links (no-op if tracing disabled).
+pub fn span_start_detached_with_links(kind: SpanKind, name: String, links: Vec<SpanLink>) -> u64 {
+    if !is_tracing_enabled() {
+        return 0;
+    }
+    COLLECTOR.with(|c| c.borrow_mut().start_detached_with_links(kind, name, links))
+}
+
 /// Attach metadata to an open span (no-op if span_id is 0).
 pub fn span_set_metadata(span_id: u64, key: &str, value: serde_json::Value) {
     if span_id == 0 {
@@ -235,6 +342,22 @@ pub fn current_span_id() -> Option<u64> {
     COLLECTOR.with(|c| c.borrow().current_span_id())
 }
 
+/// Return a link reference for an open span.
+pub fn span_link(span_id: u64) -> Option<SpanLink> {
+    if span_id == 0 || !is_tracing_enabled() {
+        return None;
+    }
+    COLLECTOR.with(|c| c.borrow().span_link(span_id))
+}
+
+/// Return a link reference for the current active span.
+pub fn current_span_link() -> Option<SpanLink> {
+    if !is_tracing_enabled() {
+        return None;
+    }
+    COLLECTOR.with(|c| c.borrow().current_span_link())
+}
+
 /// Take all completed spans.
 pub fn take_spans() -> Vec<Span> {
     COLLECTOR.with(|c| c.borrow_mut().take_spans())
@@ -253,6 +376,10 @@ pub fn reset_tracing() {
 /// Convert a span to a VmValue dict for user access.
 pub fn span_to_vm_value(span: &Span) -> VmValue {
     let mut d = BTreeMap::new();
+    d.insert(
+        "trace_id".into(),
+        VmValue::String(Rc::from(span.trace_id.as_str())),
+    );
     d.insert("span_id".into(), VmValue::Int(span.span_id as i64));
     d.insert(
         "parent_id".into(),
@@ -272,6 +399,12 @@ pub fn span_to_vm_value(span: &Span) -> VmValue {
             .map(|(k, v)| (k.clone(), crate::stdlib::json_to_vm_value(v)))
             .collect();
         d.insert("metadata".into(), VmValue::Dict(Rc::new(meta)));
+    }
+    if !span.links.is_empty() {
+        d.insert(
+            "links".into(),
+            crate::stdlib::json_to_vm_value(&serde_json::json!(span.links)),
+        );
     }
 
     VmValue::Dict(Rc::new(d))
@@ -332,6 +465,7 @@ mod tests {
         let id = c.start(SpanKind::Pipeline, "main".into());
         assert_eq!(id, 1);
         assert_eq!(c.current_span_id(), Some(1));
+        assert!(c.span_link(id).is_some());
         c.end(id);
         assert_eq!(c.current_span_id(), None);
         assert_eq!(c.spans().len(), 1);
@@ -358,6 +492,41 @@ mod tests {
         c.set_metadata(id, "tokens", serde_json::json!(100));
         c.end(id);
         assert_eq!(c.spans()[0].metadata["tokens"], serde_json::json!(100));
+    }
+
+    #[test]
+    fn test_span_links_are_preserved() {
+        let mut c = SpanCollector::new();
+        let parent = c.start(SpanKind::Suspension, "suspend worker".into());
+        let link = c.span_link(parent).expect("link for open span");
+        c.end(parent);
+
+        let child = c.start_with_links(SpanKind::Resume, "resume worker".into(), vec![link]);
+        c.end(child);
+
+        assert_eq!(c.spans().len(), 2);
+        assert_eq!(c.spans()[1].parent_id, None);
+        assert_eq!(c.spans()[1].links.len(), 1);
+        assert_eq!(c.spans()[1].links[0].span_id, parent.to_string());
+    }
+
+    #[test]
+    fn test_detached_span_links_do_not_inherit_active_parent() {
+        let mut c = SpanCollector::new();
+        let pipeline = c.start(SpanKind::Pipeline, "pipeline".into());
+        let link = c.span_link(pipeline).expect("pipeline link");
+        let drain = c.start_detached_with_links(SpanKind::Drain, "drain".into(), vec![link]);
+        c.end(drain);
+        c.end(pipeline);
+
+        let drain = c
+            .spans()
+            .iter()
+            .find(|span| span.kind == SpanKind::Drain)
+            .expect("drain span");
+        assert_eq!(drain.parent_id, None);
+        assert_eq!(drain.links.len(), 1);
+        assert_eq!(drain.links[0].span_id, pipeline.to_string());
     }
 
     #[test]

--- a/crates/harn-vm/src/vm/methods/harness.rs
+++ b/crates/harn-vm/src/vm/methods/harness.rs
@@ -128,10 +128,7 @@ impl crate::vm::Vm {
                 method,
                 "pipeline disposition persistence is not available on this branch",
             )),
-            "spawn_settlement_agent" => Ok(unsupported_harness_action(
-                method,
-                "settlement-agent spawning is deferred to the drain implementation (P-03, harn#1856)",
-            )),
+            "spawn_settlement_agent" => Ok(record_spawn_settlement_agent_gap(args)),
             _ => Err(method_unsupported(handle, method)),
         }
     }
@@ -403,12 +400,77 @@ fn record_emit_audit(args: &[VmValue]) -> VmValue {
         .get(1)
         .map(crate::llm::vm_value_to_json)
         .unwrap_or(serde_json::Value::Null);
+    if kind == "drain_decision" {
+        record_drain_decision_span(&payload);
+    }
     let entry = crate::orchestration::record_lifecycle_audit(kind, payload);
     crate::stdlib::json_to_vm_value(&serde_json::json!({
         "status": "recorded",
         "method": "emit_audit",
         "entry": entry.to_json(),
     }))
+}
+
+fn record_spawn_settlement_agent_gap(args: &[VmValue]) -> VmValue {
+    let unsettled = args
+        .first()
+        .map(crate::llm::vm_value_to_json)
+        .unwrap_or(serde_json::Value::Null);
+    let links = crate::tracing::current_span_link()
+        .map(|link| {
+            link.with_attributes(std::collections::BTreeMap::from([(
+                "harn.link.kind".to_string(),
+                "pipeline".to_string(),
+            )]))
+        })
+        .into_iter()
+        .collect();
+    let span_id = crate::tracing::span_start_detached_with_links(
+        crate::tracing::SpanKind::Drain,
+        "settlement_agent".to_string(),
+        links,
+    );
+    if span_id != 0 {
+        if let Ok(counts) = state_counts(&crate::stdlib::json_to_vm_value(&unsettled)) {
+            crate::tracing::span_set_metadata(span_id, "counts", counts.to_json());
+        }
+        crate::tracing::span_set_metadata(span_id, "status", serde_json::json!("unsupported"));
+        crate::tracing::span_end(span_id);
+    }
+    unsupported_harness_action(
+        "spawn_settlement_agent",
+        "settlement-agent spawning is deferred to the drain implementation (P-03, harn#1856)",
+    )
+}
+
+fn record_drain_decision_span(payload: &serde_json::Value) {
+    let links = crate::tracing::current_span_link()
+        .map(|link| {
+            link.with_attributes(std::collections::BTreeMap::from([(
+                "harn.link.kind".to_string(),
+                "drain".to_string(),
+            )]))
+        })
+        .into_iter()
+        .collect();
+    let span_id = crate::tracing::span_start_detached_with_links(
+        crate::tracing::SpanKind::DrainDecision,
+        payload
+            .get("action")
+            .and_then(|value| value.as_str())
+            .unwrap_or("drain_decision")
+            .to_string(),
+        links,
+    );
+    if span_id != 0 {
+        if let Some(action) = payload.get("action").and_then(|value| value.as_str()) {
+            crate::tracing::span_set_metadata(span_id, "action", serde_json::json!(action));
+        }
+        if let Some(item) = payload.pointer("/item/id").and_then(|value| value.as_str()) {
+            crate::tracing::span_set_metadata(span_id, "item_id", serde_json::json!(item));
+        }
+        crate::tracing::span_end(span_id);
+    }
 }
 
 fn record_handoff_envelope(args: &[VmValue]) -> VmValue {


### PR DESCRIPTION
Closes #1858.

## Summary
- add lifecycle span kinds plus VM span links, detached linked-span starts, and trace/link serialization for run records
- add OTel set_span_link support with no-op non-OTel behavior and exporter coverage for linked-not-parented spans
- persist suspension and pipeline span links through worker snapshots so cold resume emits a fresh resume span linked to closed lifecycle spans
- add drain/drain_decision span scaffolding at the current harness boundaries; the full settlement-agent loop remains tracked by #1856

## Verification
- cargo fmt --all -- --check
- CARGO_TARGET_DIR=/tmp/harn-cargo-target-issue-1858 cargo check -p harn-vm
- CARGO_TARGET_DIR=/tmp/harn-cargo-target-issue-1858 cargo check -p harn-cli
- CARGO_TARGET_DIR=/tmp/harn-cargo-target-issue-1858 cargo test -p harn-vm --lib tracing::tests::test_span_links_are_preserved
- CARGO_TARGET_DIR=/tmp/harn-cargo-target-issue-1858 cargo test -p harn-vm --lib tracing::tests::test_detached_span_links_do_not_inherit_active_parent
- CARGO_TARGET_DIR=/tmp/harn-cargo-target-issue-1858 cargo test -p harn-vm --lib suspend_tests::suspend_resume_links_lifecycle_spans_across_snapshot_reload
- CARGO_TARGET_DIR=/tmp/harn-cargo-target-issue-1858 cargo test -p harn-vm --lib --features otel observability::otel::tests::set_span_link_exports_link_without_parenting
- git diff --check
- pre-commit hook
- pre-push hook