### PR TITLE
changelog: move post-pin #1858 bullet to ## Unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,11 +33,6 @@ condensed series summaries instead of full per-patch history.
   handling backed by the event log. A `channel_events(...)` inspection helper
   covers conformance and local diagnostics; org-scoped channels resolve but
   return `HARN-CHN-002` until org grants land.
-
-## v0.8.26
-
-### Added
-
 - **Lifecycle span links for suspend/resume and drain scaffolding (#1858).**
   VM tracing now has `suspension`, `resume`, `drain`, and
   `drain_decision` span kinds plus causal span links. Worker suspension
@@ -46,6 +41,11 @@ condensed series summaries instead of full per-patch history.
   instead of parenting across process boundaries. The OTel helper layer
   now exposes `set_span_link` beside `set_span_parent`, with no-op
   behavior in non-OTel builds.
+
+## v0.8.26
+
+### Added
+
 - **Sub-agent reminder propagation via handoff envelopes (#1824).**
   Handoff artifacts and sub-agent requests now carry
   `reminder_propagation` beside `policy_override`; `handoff(...)` derives


### PR DESCRIPTION
## Summary
- v0.8.26 release pinned at 8411e2c2 (#1975). #1976 landed on main between pin and merge with one new `### Added` bullet (#1858).
- `release-pr-drift-check` correctly warned on PR #1978 that auto-merge would absorb #1858 into v0.8.26's section. The check was not a required gate, so auto-merge fired anyway, and the merged CHANGELOG now misattributes #1858 to v0.8.26.
- The v0.8.26 binary shipped from tag commit `58a4a387` (the original pin point) and does NOT contain #1858. Only the CHANGELOG was wrong.
- This PR moves #1858 to `## Unreleased` where it belongs.

Pure paperwork — no source changes, no version bumps, no retagging.

## Follow-up
- Consider adding `release-pr-drift-check` to the required check list in branch protection so future drifts block auto-merge.

## Test plan
- [x] CHANGELOG.md head reads as: `## Unreleased` (with #1858) → `## v0.8.26` (without #1858) → `## v0.8.25` …

🤖 Generated with [Claude Code](https://claude.com/claude-code)