### PR TITLE
Add protocol contribution RFCs for reminders (#1829)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,18 @@ condensed series summaries instead of full per-patch history.
   mode callbacks can hook into the same plumbing. See
   `conformance/tests/stdlib/tool_hooks_mode_callbacks.harn` for the
   executable spec. Part of epic #1884 (preset tool hooks library).
+- **Protocol contribution RFCs for reminders (#1829).** Authored three
+  upstream-proposal documents under `docs/src/protocol-contributions/`:
+  ACP `session/inject_reminder` + `SessionUpdate::ReminderEmitted` (the
+  schema-edit follow-up to [ACP #1224][acp-1224]), A2A
+  `tasks/inject_reminder`, and MCP `notifications/reminder`. Each RFC
+  describes the proposed wire format, migration path from our existing
+  `_meta.harn.reminder` envelope, reference-impl status, and open
+  questions for upstream maintainers. Upstream filings remain a
+  maintainer action — see #1829 for the outstanding work.
+
+[acp-1224]: https://github.com/agentclientprotocol/agent-client-protocol/discussions/1224
+
 - **`std/oauth/storage` token storage backends (#1904).** Five
   interchangeable backends for the OAuth client (#1885 OA-03):
   `memory()` (per-VM, ephemeral), `file(path, encryption_key)` (single

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -98,6 +98,10 @@
 - [Agents Protocol v1](./spec/agents-protocol/v1.md)
 - [Agents Protocol Receipt Format](./spec/agents-protocol/receipt-format-v1.md)
 - [Agents Protocol Replay Contract](./spec/agents-protocol/replay-v1.md)
+- [Protocol contribution RFCs](./protocol-contributions/README.md)
+  - [ACP: `session/inject_reminder`](./protocol-contributions/acp-session-inject-reminder.md)
+  - [A2A: `tasks/inject_reminder`](./protocol-contributions/a2a-message-kind-reminder.md)
+  - [MCP: `notifications/reminder`](./protocol-contributions/mcp-notifications-reminder.md)
 
 # Orchestration
 

--- a/docs/src/protocol-contributions/README.md
+++ b/docs/src/protocol-contributions/README.md
@@ -1,0 +1,60 @@
+# Protocol contribution RFCs
+
+This directory collects RFC-shaped documents that Burin Labs intends to
+contribute to upstream agent-protocol working groups. Each RFC describes
+a primitive that Harn already ships under a protocol's `_meta`
+extensibility slot, so the upstream proposal can reference a running
+reference implementation instead of starting from a design sketch.
+
+## Filing pattern
+
+The Harn convention for cross-protocol primitives is:
+
+1. **Ship the reference implementation first** under the protocol's
+   designated extensibility slot (`_meta` for ACP / MCP, the JSON-RPC
+   envelope's `metadata` for A2A). This proves the shape end-to-end
+   without disturbing upstream consumers.
+2. **Author an RFC document in this directory.** Each RFC is written as
+   a neutral standards-grade proposal: problem statement, wire-format
+   schema, compatibility story, reference-impl status, and open
+   questions for maintainers. The wire-format snippet matches the
+   upstream repo's preferred dialect (TypeScript for ACP, JSON Schema
+   for MCP, A2A JSON-RPC envelope for A2A).
+3. **Open an upstream discussion** when the RFC is ready. Use the RFC
+   doc as the source of truth for the discussion body so reviewers
+   work from a single shared text. Do not expand scope inside the
+   filed thread — drift looks bad and complicates maintainer triage.
+4. **Track outcomes here.** When a proposal lands upstream, update the
+   RFC's "Status" header and migrate the Harn `_meta` envelope to the
+   standardized field locations in a follow-up PR. When a proposal is
+   declined, record the decision in the RFC and keep the `_meta` shape
+   stable for downstream consumers.
+
+## Current RFCs
+
+| RFC | Upstream | Status | Reference impl |
+|---|---|---|---|
+| [ACP `session/inject_reminder`](./acp-session-inject-reminder.md) | agentclientprotocol/agent-client-protocol | Discussion open ([ACP #1224](https://github.com/agentclientprotocol/agent-client-protocol/discussions/1224)) | `session/remind` JSON-RPC method + `_meta.harn.reminder`-decorated transcript events |
+| [A2A `Message.kind: "Reminder"`](./a2a-message-kind-reminder.md) | a2aproject/A2A | Draft (not yet filed upstream) | `_meta.harn.reminder` on outbound A2A task messages |
+| [MCP `notifications/reminder`](./mcp-notifications-reminder.md) | modelcontextprotocol/specification | Draft (not yet filed upstream) | `_meta.harn.reminder` on MCP server-emitted notifications |
+
+## Scope
+
+Authoring RFC documents in this repository is in scope for these PRs.
+**Filing upstream discussions, issues, or PRs is the maintainer's
+explicit action — not a step any Harn contributor should take without
+the project owner asking for it.** See [#1829][1829] for the upstream
+work that remains open.
+
+[1829]: https://github.com/burin-labs/harn/issues/1829
+
+## Related
+
+- [Harn ACP/MCP extensions v1](../spec/harn-extensions/v1.md) — the
+  authoritative list of Harn-owned `_meta` fields that ride alongside
+  upstream protocol payloads today.
+- [System reminders](../system-reminders.md) — the language-level
+  reminder primitive these RFCs are proposing to standardize.
+- [Transcript architecture](../transcript-architecture.md) — the
+  underlying transcript event model that produces and consumes
+  reminders.

--- a/docs/src/protocol-contributions/a2a-message-kind-reminder.md
+++ b/docs/src/protocol-contributions/a2a-message-kind-reminder.md
@@ -1,0 +1,284 @@
+# A2A RFC: ambient reminder injection for peer agents
+
+**Upstream repo:** [a2aproject/A2A][a2a]
+**Status:** Draft (not yet filed upstream).
+**Authors:** Burin Labs
+**Reference impl:** `harn-serve` A2A adapter
+([`crates/harn-serve/src/adapters/a2a/`][a2a-dir]) + typed
+`SystemReminder` envelope
+([`crates/harn-vm/src/llm/helpers/transcript.rs`][reminder-rs]).
+**Sibling discussions:** [A2A #1857 — idempotency on `tasks/send`][a2a-1857]
+covers a different concern (request idempotency); reminder injection
+is still open.
+
+[a2a]: https://github.com/a2aproject/A2A
+[a2a-1857]: https://github.com/a2aproject/A2A/discussions/1857
+[a2a-dir]: https://github.com/burin-labs/harn/tree/main/crates/harn-serve/src/adapters/a2a
+[reminder-rs]: https://github.com/burin-labs/harn/blob/main/crates/harn-vm/src/llm/helpers/transcript.rs
+
+## Problem statement
+
+A2A models agent-to-agent communication around `Message` (immediate
+exchange) and `Task` (long-running work with streaming updates). Both
+shapes assume the originator wants to **add content the peer treats as
+turn input** — either a user-role prompt or an artifact attached to a
+task.
+
+There is no first-class shape for **ambient context injection**: a
+short-lived, non-user-authored signal an A2A caller wants the peer to
+factor into its next turn without claiming the caller said it. The
+need is the same as the ACP `session/inject_reminder` case (see the
+[sibling RFC](./acp-session-inject-reminder.md)), but A2A's transport
+and message model are different enough to warrant a separate
+discussion.
+
+Concrete A2A scenarios:
+
+- A coordinator agent telling a worker "the upstream PR you depend on
+  just merged; rebase before retrying" — without that string ending
+  up in the worker's user transcript.
+- A monitoring agent injecting "your last action exceeded the configured
+  cost budget" mid-task as a steering nudge.
+- A workflow agent forwarding a host's file-watcher event to a
+  delegated worker.
+
+Today implementors invent one of three workarounds:
+
+1. Send a `Message` of role `user` with a synthetic "System reminder:"
+   prefix. Pollutes the worker's user transcript.
+2. Attach a custom artifact to the running task. Wrong primitive —
+   artifacts are outputs, not turn-scoped context.
+3. Tunnel reminders through `metadata` on a `tasks/send` call. Works
+   today but every adopter invents their own schema.
+
+## Design decision: two shapes considered
+
+Two shapes were considered for upstream proposal:
+
+### Option A: `Message.kind: "Reminder"`
+
+Add `Reminder` to the existing `Message.kind` discriminator alongside
+`user` and `agent`. Reminder messages ride the same transports as
+ordinary messages.
+
+**Pros:** zero new RPC surface; clients that don't recognize the kind
+fall back to treating the message as opaque.
+
+**Cons:** `Message.kind` is currently a role discriminator. Adding a
+non-role value muddies the existing semantic. Implementations that
+filter messages by role (most of them) silently drop reminders.
+
+### Option B: `tasks/inject_reminder` JSON-RPC method (recommended)
+
+A dedicated JSON-RPC method, sibling to `tasks/send` and the existing
+`message/*` family. Reminders are a distinct kind of payload with a
+distinct lifecycle, so they get a distinct RPC.
+
+**Pros:** keeps `Message` purely about role-tagged content; reminder
+lifecycle (TTL, dedupe, propagation) doesn't pollute the message
+schema; capability negotiation is unambiguous (peers either implement
+the method or they don't).
+
+**Cons:** one more method on the wire surface; peers that want to
+support reminders must add a handler rather than just recognizing a
+new kind.
+
+**Recommendation: Option B.** The lifecycle fields (TTL, dedupe,
+propagate) don't belong on a `Message` and trying to attach them
+there forces every message consumer to learn about them. A dedicated
+method localizes the impact.
+
+The remainder of this RFC specifies Option B; Option A is documented
+above so the upstream discussion can revisit if maintainers prefer it.
+
+## Proposed wire format
+
+### `tasks/inject_reminder` (caller → peer)
+
+JSON-RPC request:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-019abf6b-...",
+  "method": "tasks/inject_reminder",
+  "params": {
+    "taskId": "task-019abf6b-7d51-7c1d-bb02-...",
+    "reminder": {
+      "id": "reminder-019abf6b-7d51-7c1d-bb02-...",
+      "body": "Upstream dependency PR landed; rebase before the next tool call.",
+      "tags": ["upstream", "rebase"],
+      "dedupeKey": "upstream:pr-1234",
+      "ttlTurns": 2,
+      "preserveOnCompact": true,
+      "propagate": "session",
+      "roleHint": "system",
+      "source": "coordinator-agent",
+      "firedAtTurn": 4,
+      "mode": "finish_step"
+    },
+    "metadata": {
+      "harn.reminder.origin": "workflow-coordinator"
+    }
+  }
+}
+```
+
+JSON-RPC response:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-019abf6b-...",
+  "result": {
+    "reminderId": "reminder-019abf6b-7d51-7c1d-bb02-...",
+    "dedupedCount": 1,
+    "acceptedAt": "2026-04-30T12:34:56.789Z"
+  }
+}
+```
+
+Error responses follow A2A's existing JSON-RPC error envelope:
+
+| Code | Meaning |
+|---|---|
+| `-32602` | Malformed `reminder` payload (missing `body`, unknown enum value, etc.). |
+| `-32004` | Unknown `taskId`. |
+| `-32601` | Peer does not implement `tasks/inject_reminder` (i.e., capability missing). |
+
+### Streaming notification: `tasks/reminderEmitted`
+
+Mirrors the `tasks/artifact_update` notification pattern. Sent on the
+existing `tasks/sendSubscribe` SSE channel:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "tasks/reminderEmitted",
+  "params": {
+    "taskId": "task-019abf6b-7d51-7c1d-bb02-...",
+    "reminder": {
+      "id": "reminder-019abf6b-7d51-7c1d-bb02-...",
+      "body": "Upstream dependency PR landed; rebase before the next tool call.",
+      "tags": ["upstream", "rebase"],
+      "dedupeKey": "upstream:pr-1234",
+      "source": "coordinator-agent",
+      "firedAtTurn": 5
+    },
+    "metadata": {}
+  }
+}
+```
+
+Two sibling notifications cover the rest of the lifecycle:
+`tasks/reminderDeduped` (newer reminder displaced one or more older
+ones sharing the same `dedupeKey`) and `tasks/reminderExpired` (TTL
+reached zero or compaction dropped it).
+
+### Agent card capability
+
+Peers that implement reminder injection advertise it on their agent
+card:
+
+```json
+{
+  "name": "rebase-worker",
+  "url": "https://example.com/.well-known/a2a-agent",
+  "skills": ["rebase"],
+  "capabilities": {
+    "reminders": {
+      "inject": true,
+      "emit": true,
+      "propagate": ["session", "none"],
+      "roleHints": ["system", "developer"]
+    }
+  }
+}
+```
+
+Callers MUST treat absent `capabilities.reminders` as "not
+supported" and fall back to either suppressing the reminder or
+attaching it as task metadata (the current `_meta`-style workaround).
+
+## Compatibility and migration
+
+### From the current `_meta` envelope
+
+Harn-as-A2A-peer currently:
+
+- Accepts reminders smuggled through `tasks/send`'s `metadata` map
+  under `metadata.harn.reminder`.
+- Decorates outbound `tasks/sendSubscribe` SSE events with
+  `metadata.harn.reminder` when an internal reminder fires during
+  task execution.
+
+Migration when the standardized method lands:
+
+1. Implement `tasks/inject_reminder` as the canonical inbound path.
+   Keep `metadata.harn.reminder` reads as a fall-back for one A2A
+   minor version.
+2. Replace `metadata.harn.reminder` decoration with the standardized
+   `tasks/reminderEmitted` notification.
+3. Add `capabilities.reminders` to the published agent card.
+4. Regenerate `spec/protocol-artifacts/`
+   (`make gen-protocol-artifacts`).
+
+### For other A2A peers adopting this proposal
+
+Peers that don't model reminders internally can satisfy
+`tasks/inject_reminder` by injecting the body as a synthetic
+system-role context block on the next turn, with TTL=1 and no dedupe.
+That's still strictly better than the synthetic-user-message
+workaround.
+
+## Reference implementation status
+
+| Surface | Status | Notes |
+|---|---|---|
+| `metadata.harn.reminder` inbound handling | Shipping (v0.8.x) | Harn A2A adapter accepts reminders via `tasks/send` metadata today. |
+| Outbound reminder emission on streaming tasks | Reference impl tracked in [#1828](https://github.com/burin-labs/harn/issues/1828) | Emitted as `metadata.harn.reminder` on existing SSE updates until upstream lands. |
+| Typed `SystemReminder` lifecycle envelope | Shipping | Shared with ACP and MCP adapters. |
+| Agent card `capabilities.reminders` advertisement | Pending upstream schema | Currently advertised under `capabilities._meta.harn.reminders`. |
+
+The canonical lifecycle struct ([`SystemReminder`][reminder-rs]) is
+shared verbatim with the [ACP RFC](./acp-session-inject-reminder.md);
+field names round-trip through the A2A JSON shape with conventional
+camelCase translation.
+
+## Open questions for upstream maintainers
+
+1. **Method placement.** Does `tasks/inject_reminder` belong on the
+   `tasks/*` family (as proposed), the `message/*` family, or a new
+   `session/*` family that better mirrors ACP? A2A's evolution toward
+   richer sessions argues for `session/*`; the current task-centric
+   surface argues for `tasks/*`.
+2. **Notification naming.** `tasks/reminderEmitted` vs
+   `tasks/reminder/emitted` (nested) vs `tasks/reminder_emitted`
+   (snake_case to match A2A's existing `tasks/artifact_update`).
+   We've used camelCase above; A2A's existing convention mixes both.
+3. **Lifecycle visibility.** Should `reminderDeduped` and
+   `reminderExpired` ship in the first iteration, or only
+   `reminderEmitted`? Our experience with the ACP equivalent says
+   hosts need dedupe visibility to render non-flickering UIs.
+4. **Cross-task propagation.** A2A workflows often spawn sub-tasks.
+   Should `propagate: "all"` carry the reminder into sub-tasks
+   automatically, or require the parent to re-inject? The simpler
+   "session-only" default keeps the v1 scope tight.
+5. **Push notification interaction.** A2A push notifications already
+   exist; should reminders piggyback on them or stay on the SSE
+   stream? Our reference impl uses SSE only — push payloads weren't
+   designed for short-lived turn-scoped context.
+6. **Relationship to `message/send`.** When an A2A peer is being
+   driven through `message/send` (not a task), is there a need for
+   `messages/inject_reminder` too? We've found tasks cover the
+   compelling use cases; bare `message/send` flows are short enough
+   that the inject window is small.
+
+## References
+
+- [A2A #1857 — idempotency on `tasks/send`][a2a-1857] (separate
+  concern; not a substitute for reminder injection)
+- [Sibling ACP RFC: `session/inject_reminder`](./acp-session-inject-reminder.md)
+- [Sibling MCP RFC: `notifications/reminder`](./mcp-notifications-reminder.md)
+- [System reminders user guide](../system-reminders.md)
+- [`SystemReminder` struct][reminder-rs]

--- a/docs/src/protocol-contributions/acp-session-inject-reminder.md
+++ b/docs/src/protocol-contributions/acp-session-inject-reminder.md
@@ -1,0 +1,310 @@
+# ACP RFC: `session/inject_reminder` + `SessionUpdate::ReminderEmitted`
+
+**Upstream repo:** [agentclientprotocol/agent-client-protocol][acp]
+**Discussion:** [ACP #1224 — `session/remind` ambient system-role
+context injection][acp-1224]
+**Status:** Open upstream discussion; this document is the
+schema-edit follow-up that #1224 anticipated.
+**Authors:** Burin Labs
+**Reference impl:** `harn-serve` ACP adapter
+([`crates/harn-serve/src/adapters/acp/mod.rs`][acp-mod-rs]) +
+typed `SystemReminder` envelope
+([`crates/harn-vm/src/llm/helpers/transcript.rs`][reminder-rs]).
+
+[acp]: https://github.com/agentclientprotocol/agent-client-protocol
+[acp-1224]: https://github.com/agentclientprotocol/agent-client-protocol/discussions/1224
+[acp-mod-rs]: https://github.com/burin-labs/harn/blob/main/crates/harn-serve/src/adapters/acp/mod.rs
+[reminder-rs]: https://github.com/burin-labs/harn/blob/main/crates/harn-vm/src/llm/helpers/transcript.rs
+
+## Problem statement
+
+ACP has two well-defined input channels for a session:
+
+- `session/prompt` — the user's next turn, durably appended to the
+  message list.
+- `session/inject` (per [ACP #1220][acp-1220]) — mid-turn user-role
+  steering that queues alongside the in-flight prompt.
+
+Neither models **ambient context injection**: short-lived,
+non-user-authored signals the host wants the model to see on its next
+turn without claiming the user typed them. Concrete examples a host
+might want to surface:
+
+- A file the agent is editing changed externally while it was idle.
+- A long-running build/test process finished and produced new output.
+- The host's policy engine wants to remind the agent of a constraint
+  (e.g., "this repo blocks force-pushes to main") before its next
+  tool-use turn.
+- Token-pressure or compaction-recap notes derived from transcript
+  introspection.
+
+Today every ACP host that wants this primitive invents its own
+out-of-band channel — usually a synthetic user message prefixed with
+"System reminder:". That conflates user input with system context,
+pollutes the durable transcript with strings the user never said, and
+makes audit/replay ambiguous about who said what.
+
+[acp-1220]: https://github.com/agentclientprotocol/agent-client-protocol/discussions/1220
+
+## Proposed wire format
+
+### `session/inject_reminder` (client → agent)
+
+A new JSON-RPC method on the agent side, sibling to `session/prompt`
+and `session/inject`:
+
+```typescript
+/**
+ * Inject an ambient system-role reminder into a running session.
+ *
+ * Reminders are short-lived context the host wants the model to see on
+ * its next turn. They are NOT user input — they never appear in the
+ * durable user-message stream — and they have an explicit lifecycle
+ * (TTL, dedupe, propagation to sub-agents).
+ *
+ * Distinct from `session/inject`, which is user-role mid-turn steering.
+ */
+export interface SessionInjectReminderRequest {
+  /** Target session. */
+  sessionId: SessionId
+  /** The reminder body the model will see on its next turn. */
+  body: string
+  /** Optional tags for host-side querying, clearing, and audit. */
+  tags?: string[]
+  /**
+   * Optional stable key. A newer reminder with the same dedupeKey
+   * replaces older pending reminders carrying that key.
+   */
+  dedupeKey?: string
+  /**
+   * Optional finite turn budget. After this many post-turn lifecycle
+   * passes the reminder expires and is dropped. Omit for "persist
+   * until cleared or compacted away."
+   */
+  ttlTurns?: number
+  /**
+   * When true, compaction copies this reminder forward into the
+   * compacted transcript. Defaults to false.
+   */
+  preserveOnCompact?: boolean
+  /**
+   * Sub-agent propagation policy. Defaults to "session".
+   */
+  propagate?: "all" | "session" | "none"
+  /**
+   * Preferred rendering slot. The agent's provider-capability
+   * dispatch makes the final decision; this is a hint, not a binding.
+   */
+  roleHint?: "system" | "developer" | "user_block" | "ephemeral_cache"
+  /**
+   * Delivery mode. Mirrors session/inject semantics.
+   */
+  mode?: "interrupt_immediate" | "finish_step" | "wait_for_completion"
+  /** Extension envelope for protocol-extension fields. */
+  _meta?: Record<string, unknown>
+}
+
+export interface SessionInjectReminderResponse {
+  /** Server-assigned stable id, used in subsequent ReminderEmitted updates. */
+  reminderId: string
+  /**
+   * Number of older pending reminders that were dropped because they
+   * shared the supplied dedupeKey.
+   */
+  dedupedCount?: number
+}
+```
+
+### `SessionUpdate::ReminderEmitted` (agent → client)
+
+A new discriminator on the existing `session/update` notification's
+`update` union, fired when the agent's reminder lifecycle commits a
+reminder to the next model turn (whether the source was
+`session/inject_reminder`, an internal provider, or a hook):
+
+```typescript
+export interface SessionUpdate_ReminderEmitted {
+  sessionUpdate: "reminder_emitted"
+  /** Stable id assigned to this reminder. */
+  reminderId: string
+  /** The reminder body that was rendered into the model turn. */
+  body: string
+  /** Optional tags. */
+  tags?: string[]
+  /** Optional dedupe key the reminder was registered under. */
+  dedupeKey?: string
+  /** Origin of this reminder (see source enum below). */
+  source: "host" | "provider" | "hook" | "bridge" | "inherited"
+  /** Provider id when source is "provider" or "hook". */
+  providerId?: string
+  /** Turn index when the reminder was injected (host counter). */
+  firedAtTurn?: number
+  /** Extension envelope. */
+  _meta?: Record<string, unknown>
+}
+```
+
+Two sibling lifecycle updates are recommended for completeness, mirroring
+the events Harn already emits internally:
+
+```typescript
+export interface SessionUpdate_ReminderDeduped {
+  sessionUpdate: "reminder_deduped"
+  /** The newer reminder id that won the dedupe contest. */
+  reminderId: string
+  dedupeKey: string
+  /** Reminder ids that were dropped because they shared the dedupe key. */
+  droppedReminderIds: string[]
+  _meta?: Record<string, unknown>
+}
+
+export interface SessionUpdate_ReminderExpired {
+  sessionUpdate: "reminder_expired"
+  reminderId: string
+  /** Why the reminder ended its lifecycle. */
+  phase: "ttl_expired" | "cleared" | "compacted_out"
+  expiredAtTurn?: number
+  _meta?: Record<string, unknown>
+}
+```
+
+These three updates together let an editor or notebook UI render a
+"reminders panel" alongside the transcript without polling.
+
+### Capability negotiation
+
+Agents that support reminder injection advertise it during
+`initialize`:
+
+```typescript
+export interface AgentCapabilities {
+  // ...existing fields...
+  reminders?: {
+    /** Agent accepts session/inject_reminder. */
+    inject: boolean
+    /** Agent emits reminder_emitted / reminder_deduped / reminder_expired updates. */
+    emit: boolean
+    /** Supported propagate values; absent means [\"session\"] only. */
+    propagate?: ("all" | "session" | "none")[]
+    /** Supported roleHint values; absent means [\"system\"] only. */
+    roleHints?: ("system" | "developer" | "user_block" | "ephemeral_cache")[]
+  }
+}
+```
+
+Hosts that observe an agent without `reminders.inject` should fall back
+to either suppressing the reminder, surfacing it to the user as a
+sidebar notification, or — only as a last resort — emitting it as a
+prefixed user message with a clear visual marker.
+
+## Compatibility and migration
+
+### From the current `_meta` envelope
+
+Harn ships today with:
+
+- `session/remind` JSON-RPC method (same shape as the proposed
+  `session/inject_reminder` modulo the name).
+- Per-reminder fields under `params._meta.harn.reminder` for any
+  non-standard lifecycle hints.
+- Outbound `_meta.harn.reminder` decorations on `session/update`
+  notifications so observing clients can pull reminder data out of
+  the existing tool-call/message updates.
+
+Migration steps once the upstream schema lands:
+
+1. Add `session/inject_reminder` as an alias for the existing
+   `session/remind` handler; mark `session/remind` deprecated in the
+   `_meta` extension contract.
+2. Promote per-reminder lifecycle fields from
+   `_meta.harn.reminder.*` to top-level standardized fields on
+   `SessionInjectReminderRequest`.
+3. Emit `SessionUpdate::ReminderEmitted` from the existing reminder
+   render path; drop the `_meta.harn.reminder` decoration on
+   tool-call/message updates once consumers migrate.
+4. Regenerate `spec/protocol-artifacts/` via
+   `make gen-protocol-artifacts`.
+
+No-op for older clients: the `session/remind` alias and `_meta.harn`
+fall-back stays available for at least one ACP minor version after the
+standardized fields ship.
+
+### For other ACP agents adopting this proposal
+
+Agents that don't already render reminders can implement
+`session/inject_reminder` as a thin wrapper that prepends a
+provider-specific system block (or developer-role message) on the next
+turn, with TTL=1, no dedupe, no propagation. That's strictly stronger
+than the synthetic-user-message workaround and requires no transcript
+schema work.
+
+## Reference implementation status
+
+| Surface | Status | Notes |
+|---|---|---|
+| `session/remind` JSON-RPC handler | Shipping (v0.8.x) | `crates/harn-serve/src/adapters/acp/mod.rs` |
+| Typed `SystemReminder` lifecycle envelope | Shipping | `crates/harn-vm/src/llm/helpers/transcript.rs` |
+| Dedupe lifecycle event log | Shipping | `transcript.reminder.deduped` on the EventLog |
+| Expiry lifecycle event log | Shipping | `transcript.reminder.expired` on the EventLog |
+| `SessionUpdate::ReminderEmitted` wire shape | Reference impl tracked in [#1828](https://github.com/burin-labs/harn/issues/1828) | Will emit under `_meta.harn.reminder` until upstream lands |
+| Provider-capability rendering (developer vs system vs Anthropic user block) | Shipping | See [System reminders > Capability-aware rendering](../system-reminders.md#capability-aware-rendering) |
+
+The canonical `SystemReminder` struct (verbatim from
+[`crates/harn-vm/src/llm/helpers/transcript.rs`][reminder-rs]) maps
+field-for-field to the TypeScript shape above:
+
+```rust
+pub struct SystemReminder {
+    pub id: String,
+    pub tags: Vec<String>,
+    pub dedupe_key: Option<String>,
+    pub ttl_turns: Option<i64>,
+    pub preserve_on_compact: bool,
+    pub propagate: ReminderPropagate,    // all | session | none
+    pub role_hint: ReminderRoleHint,     // system | developer | user_block | ephemeral_cache
+    pub source: ReminderSource,          // stdlib_provider | hook | bridge | in_pipeline | inherited
+    pub body: String,
+    pub fired_at_turn: i64,
+    pub originating_agent_id: Option<String>,
+}
+```
+
+## Open questions for upstream maintainers
+
+1. **Naming.** `session/inject_reminder` mirrors `session/inject` for
+   symmetry. ACP #1224 originally proposed `session/remind`. Either is
+   defensible; we recommend `session/inject_reminder` so the verb
+   pattern is consistent with the user-input sibling.
+2. **`mode` semantics.** Should reminders honor the same
+   `interrupt_immediate` / `finish_step` / `wait_for_completion`
+   delivery modes as `session/inject`, or always behave as
+   `finish_step` (i.e., commit at the next turn boundary)? Our
+   reference impl defers to whatever the host supplies and defaults to
+   `finish_step`.
+3. **`roleHint` realism.** `user_block` and `ephemeral_cache` exist
+   today because Anthropic models materially prefer a user-role
+   content block with prompt-cache annotation. Should ACP standardize
+   these hints (acknowledging provider differences) or stay
+   provider-agnostic with just `system`/`developer` and leave the
+   block-vs-system decision to the agent?
+4. **Propagation across sub-agents.** ACP doesn't currently model
+   sub-agent sessions as first-class — that's a host-side construct.
+   We've found `propagate` essential in practice; should it ship as
+   part of this proposal or wait for a sub-agent RFC?
+5. **Sibling updates.** Are `reminder_deduped` and `reminder_expired`
+   in scope for the first iteration, or should we ship only
+   `reminder_emitted` and add the lifecycle siblings in a follow-up?
+   Our experience says hosts need at least dedupe visibility to render
+   a non-flickering reminder UI.
+6. **Capability shape.** Is `agentCapabilities.reminders` the right
+   key, or should reminder support fold into existing
+   `agentCapabilities.sessionUpdate` / `agentCapabilities.input`
+   substructures?
+
+## References
+
+- [ACP #1224 — `session/remind` discussion][acp-1224]
+- [ACP #1220 — `session/inject` discussion][acp-1220]
+- [Harn ACP/MCP extensions v1](../spec/harn-extensions/v1.md)
+- [System reminders user guide](../system-reminders.md)
+- [`SystemReminder` struct][reminder-rs]

--- a/docs/src/protocol-contributions/mcp-notifications-reminder.md
+++ b/docs/src/protocol-contributions/mcp-notifications-reminder.md
@@ -1,0 +1,299 @@
+# MCP RFC: `notifications/reminder` server→host ambient context
+
+**Upstream repo:** [modelcontextprotocol/specification][mcp-spec]
+**Status:** Draft (not yet filed upstream).
+**Authors:** Burin Labs
+**Reference impl:** `harn-serve` MCP adapter
+([`crates/harn-serve/src/adapters/mcp.rs`][mcp-rs]) + typed
+`SystemReminder` envelope
+([`crates/harn-vm/src/llm/helpers/transcript.rs`][reminder-rs]).
+**Sibling discussions:** [MCP #2736 — budget caps on
+`sampling/createMessage`][mcp-2736] covers a separate concern (request
+budgeting); reminder notifications are still open.
+
+[mcp-spec]: https://github.com/modelcontextprotocol/specification
+[mcp-2736]: https://github.com/modelcontextprotocol/modelcontextprotocol/discussions/2736
+[mcp-rs]: https://github.com/burin-labs/harn/blob/main/crates/harn-serve/src/adapters/mcp.rs
+[reminder-rs]: https://github.com/burin-labs/harn/blob/main/crates/harn-vm/src/llm/helpers/transcript.rs
+
+## Problem statement
+
+MCP servers expose tools, resources, and prompts to a host. The
+existing server→host notification surface covers:
+
+- `notifications/resources/updated` — a resource changed.
+- `notifications/resources/list_changed` — the resource catalog
+  changed.
+- `notifications/tools/list_changed` — the tool catalog changed.
+- `notifications/prompts/list_changed` — the prompt catalog changed.
+- `notifications/progress` — long-running tool progress.
+
+None of these model **ambient signals the server wants the host to
+factor into the agent's next turn**. Concrete examples:
+
+- A filesystem MCP server watches `src/` and notices the user just
+  edited `lib.rs` in another editor. The host's running agent should
+  re-read `lib.rs` before the next tool call. Today there's no way
+  for the server to say so — it can only re-emit
+  `notifications/resources/updated` for every dependent resource, and
+  the host has to invent its own translation layer to turn that into
+  a model-visible nudge.
+- A build-watcher MCP server notices `cargo check` succeeded after
+  the agent's last edit. The agent should know "the change you just
+  made compiles" before deciding whether to keep editing.
+- A test-watcher MCP server notices a previously failing test now
+  passes. Same shape: a turn-scoped fact the model should see, that
+  isn't a tool result and isn't a resource read.
+- A CI/GitHub MCP server notices a PR review came in while the agent
+  was working on a sibling file.
+
+Today MCP server implementors smuggle these signals through one of:
+
+1. `notifications/resources/updated` plus an out-of-band convention
+   for "host should re-read and inject." Fragile.
+2. A custom tool the agent must explicitly call ("check for ambient
+   updates"). Loses the push semantics and burns a tool slot.
+3. `notifications/message` or `notifications/progress` with the
+   reminder text. Wrong primitive — those are about server logging
+   and tool progress, not turn-scoped context.
+
+## Proposed wire format
+
+### `notifications/reminder` (server → host)
+
+A new server-initiated notification, no `id` field (per the MCP
+notification pattern):
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/reminder",
+  "params": {
+    "reminder": {
+      "id": "0190abcd-2024-7c1d-bb02-3a0e8a44d7f0",
+      "body": "src/lib.rs changed externally; re-read it before editing.",
+      "tags": ["workspace", "file_changed"],
+      "dedupeKey": "file_changed:src/lib.rs",
+      "ttlTurns": 2,
+      "preserveOnCompact": false,
+      "propagate": "session",
+      "roleHint": "system",
+      "firedAtTurn": null
+    },
+    "_meta": {}
+  }
+}
+```
+
+JSON Schema sketch (matching the MCP spec repo's `.schema.json`
+style):
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://modelcontextprotocol.io/schemas/notifications-reminder",
+  "title": "ReminderNotification",
+  "type": "object",
+  "required": ["jsonrpc", "method", "params"],
+  "properties": {
+    "jsonrpc": { "const": "2.0" },
+    "method": { "const": "notifications/reminder" },
+    "params": {
+      "type": "object",
+      "required": ["reminder"],
+      "properties": {
+        "reminder": { "$ref": "#/$defs/ReminderSpec" },
+        "_meta": { "type": "object" }
+      }
+    }
+  },
+  "$defs": {
+    "ReminderSpec": {
+      "type": "object",
+      "required": ["id", "body"],
+      "properties": {
+        "id": { "type": "string", "description": "Stable reminder id (UUIDv7 recommended)." },
+        "body": { "type": "string", "minLength": 1 },
+        "tags": { "type": "array", "items": { "type": "string" } },
+        "dedupeKey": { "type": "string" },
+        "ttlTurns": { "type": "integer", "minimum": 1 },
+        "preserveOnCompact": { "type": "boolean", "default": false },
+        "propagate": { "enum": ["all", "session", "none"], "default": "session" },
+        "roleHint": {
+          "enum": ["system", "developer", "user_block", "ephemeral_cache"],
+          "default": "system"
+        },
+        "firedAtTurn": { "type": ["integer", "null"] }
+      }
+    }
+  }
+}
+```
+
+### Server capability advertisement
+
+MCP servers that can emit reminder notifications declare it during
+`initialize`:
+
+```json
+{
+  "capabilities": {
+    "reminders": {
+      "emit": true,
+      "propagate": ["session", "none"],
+      "roleHints": ["system", "developer"]
+    }
+  }
+}
+```
+
+Hosts that receive `notifications/reminder` from a server that did
+NOT declare `reminders.emit` SHOULD log and drop the notification
+(per the existing MCP rule that unknown server messages are tolerated
+but not acted on).
+
+### Host-side rendering
+
+The host is responsible for translating a reminder into the agent's
+next model turn. Recommended behavior:
+
+- Append the reminder body to a turn-scoped system or developer
+  message (host's choice; `roleHint` is advisory).
+- Honor `dedupeKey`: a newer reminder with the same key replaces
+  older pending reminders that haven't yet fired.
+- Honor `ttlTurns`: decrement after each rendered turn, drop at 0.
+- Honor `preserveOnCompact`: if the host compacts the transcript,
+  reminders flagged `true` survive the rewrite.
+- `propagate` is a hint about sub-agent inheritance, which most MCP
+  hosts won't model directly — safe to ignore in v1.
+
+## Positioning vs file-watcher / build-watcher use cases
+
+MCP already has `notifications/resources/updated`. Doesn't that cover
+the file-watcher case?
+
+No, and the distinction is important enough to call out:
+
+- **`notifications/resources/updated`** is "the contents of resource
+  URI X changed; if you have it cached, invalidate." It's a
+  cache-invalidation signal aimed at host-side state, not model
+  context. A host hearing it can re-read on demand, but the agent
+  doesn't see anything unless the host invents a synthetic nudge.
+- **`notifications/reminder`** is "tell the agent X happened, in
+  natural language, on its next turn." The host doesn't need to
+  invent the text; the server is the domain expert about why this is
+  worth surfacing.
+
+A well-behaved server would emit both: `resources/updated` so caches
+invalidate, plus `notifications/reminder` so the agent learns about
+the change in time to factor it into its next decision. The two
+together replace today's "host invents text from a list of changed
+URIs" pattern.
+
+### Build-watcher example end-to-end
+
+```text
+[agent calls cargo check]
+  -> [build-watcher MCP server runs, succeeds]
+     -> notifications/reminder: "cargo check passed after your last edit."
+        roleHint=system, ttlTurns=1, dedupeKey="cargo-check:status"
+
+[agent's next turn]
+  -> sees the reminder, decides whether to keep editing or move on
+```
+
+### Test-watcher example end-to-end
+
+```text
+[user edits test file in another editor]
+  -> file-watcher resources/updated for tests/api_test.rs
+     (host invalidates cache)
+  -> test-watcher MCP server reruns affected suite
+     -> notifications/reminder: "tests/api_test.rs now passes."
+        roleHint=system, ttlTurns=2, dedupeKey="test:tests/api_test.rs"
+```
+
+## Compatibility and migration
+
+### From the current `_meta` envelope
+
+Harn-as-MCP-server (and Harn-as-MCP-host) currently:
+
+- Accepts and emits reminders under
+  `notifications/message` with a sentinel `_meta.harn.reminder`
+  payload.
+- Treats `_meta.harn.reminder` as the canonical lifecycle envelope,
+  shared verbatim with the ACP and A2A adapters.
+
+Migration when `notifications/reminder` lands upstream:
+
+1. Implement `notifications/reminder` as the canonical inbound and
+   outbound path.
+2. Keep the `_meta.harn.reminder` reads on `notifications/message`
+   as a back-compat fall-back for one MCP minor version.
+3. Advertise `capabilities.reminders` on the server side; on the
+   host side, key off the server's advertisement to decide whether
+   to subscribe.
+4. Regenerate `spec/protocol-artifacts/`
+   (`make gen-protocol-artifacts`).
+
+### For other MCP servers and hosts
+
+Servers that don't model reminders today gain a simple opt-in path:
+emit `notifications/reminder` whenever a watcher or background
+process produces a fact the agent should know about. Hosts that don't
+implement reminder rendering can ignore the notification cleanly —
+unknown notifications are already required to be tolerated.
+
+## Reference implementation status
+
+| Surface | Status | Notes |
+|---|---|---|
+| `_meta.harn.reminder` outbound emission on MCP notifications | Reference impl tracked in [#1828](https://github.com/burin-labs/harn/issues/1828) | `crates/harn-serve/src/adapters/mcp.rs` |
+| Typed `SystemReminder` lifecycle envelope | Shipping | Shared with ACP and A2A adapters. |
+| Host-side rendering with provider capability dispatch | Shipping (v0.8.x) | See [System reminders > Capability-aware rendering](../system-reminders.md#capability-aware-rendering). |
+| `capabilities.reminders` advertisement | Pending upstream schema | Currently under `capabilities._meta.harn.reminders`. |
+
+The canonical lifecycle struct ([`SystemReminder`][reminder-rs]) is
+shared verbatim with the ACP and A2A RFCs; the JSON Schema sketch
+above is a direct projection of its Rust shape.
+
+## Open questions for upstream maintainers
+
+1. **Notification name.** `notifications/reminder` is the simplest
+   form. Alternatives: `notifications/context/reminder`,
+   `notifications/agent/reminder`. We've used the flat form for
+   symmetry with `notifications/progress` and `notifications/message`.
+2. **Scope.** Should reminders be tool-scoped (riding alongside an
+   in-flight `tools/call`), session-scoped (the proposal above), or
+   both? Our reference impl is session-scoped — the host decides
+   which agent transcript the reminder applies to.
+3. **Lifecycle visibility.** Should the host echo `reminderEmitted`
+   / `reminderDeduped` / `reminderExpired` back to the server? MCP
+   is typically asymmetric (servers push, hosts consume), so we've
+   omitted echoes; a server that needs lifecycle visibility today
+   includes its own correlation id in `_meta`.
+4. **`roleHint` realism.** Same question as the ACP RFC: `user_block`
+   and `ephemeral_cache` exist because Anthropic models materially
+   prefer those shapes. Should MCP standardize these hints
+   (acknowledging provider variance) or stay provider-agnostic with
+   just `system`/`developer`?
+5. **Relationship to `notifications/resources/updated`.** Should the
+   spec explicitly recommend the pairing "emit both when the model
+   needs to see the change"? Our experience is yes, but it may be
+   out of scope for the wire-format spec and belong in a separate
+   "best practices for ambient signals" document.
+6. **Backpressure.** A misbehaving server could spam reminders. Hosts
+   already have to rate-limit `notifications/message` and
+   `notifications/progress`; should this RFC explicitly call out a
+   recommended per-server reminder budget, or leave that to host
+   policy?
+
+## References
+
+- [MCP #2736 — budget caps on `sampling/createMessage`][mcp-2736]
+  (separate concern; not a substitute for reminder notifications)
+- [Sibling ACP RFC: `session/inject_reminder`](./acp-session-inject-reminder.md)
+- [Sibling A2A RFC: `tasks/inject_reminder`](./a2a-message-kind-reminder.md)
+- [System reminders user guide](../system-reminders.md)
+- [`SystemReminder` struct][reminder-rs]


### PR DESCRIPTION
## Summary

- Authors three RFC-shaped documents under `docs/src/protocol-contributions/` so the upstream-filing work tracked in #1829 (part of epic #1815) starts from a single shared source of truth.
  - [`acp-session-inject-reminder.md`](https://github.com/burin-labs/harn/blob/ksinder/issue-1829-protocol-contribution-rfcs/docs/src/protocol-contributions/acp-session-inject-reminder.md) — `session/inject_reminder` + `SessionUpdate::ReminderEmitted`. The schema-edit follow-up that [ACP #1224](https://github.com/agentclientprotocol/agent-client-protocol/discussions/1224) anticipated.
  - [`a2a-message-kind-reminder.md`](https://github.com/burin-labs/harn/blob/ksinder/issue-1829-protocol-contribution-rfcs/docs/src/protocol-contributions/a2a-message-kind-reminder.md) — recommends `tasks/inject_reminder` over `Message.kind: "Reminder"`; both shapes are documented with a trade-off.
  - [`mcp-notifications-reminder.md`](https://github.com/burin-labs/harn/blob/ksinder/issue-1829-protocol-contribution-rfcs/docs/src/protocol-contributions/mcp-notifications-reminder.md) — server → host `notifications/reminder` with a typed `ReminderSpec`, positioned vs `notifications/resources/updated`.
- Adds [`docs/src/protocol-contributions/README.md`](https://github.com/burin-labs/harn/blob/ksinder/issue-1829-protocol-contribution-rfcs/docs/src/protocol-contributions/README.md) as an index page documenting the burin-labs filing pattern: ship the reference impl first under `_meta`, then propose upstream from a position of running code.
- Wires the new section into the mdBook nav (`docs/src/SUMMARY.md`) under the existing Protocols category and adds a one-line CHANGELOG entry.

Each RFC has: problem statement, wire-format snippet in the upstream repo's preferred dialect (TypeScript for ACP, A2A JSON-RPC envelope for A2A, JSON Schema for MCP), compatibility/migration story from our existing `_meta.harn.reminder` envelope, reference-implementation status pointing at `SystemReminder` in `crates/harn-vm/src/llm/helpers/transcript.rs`, and a closing "Open questions for upstream maintainers" section so the upstream discussions have a concrete ask.

Refs #1829, #1815.

## Scope cut

Upstream filings remain a maintainer action — this PR ships only the RFC docs. The upstream-filing acceptance criterion on #1829 stays open.

## Test plan

- [x] `make lint-md` (446 markdown files, 0 errors)
- [x] `make check-docs-snippets` (560 checked, 164 skipped, 0 failed)
- [x] `mdbook build` (clean)
- [x] Reviewer scan of the three RFC bodies for tone (neutral standards-grade), accuracy of the `SystemReminder` field round-trip, and completeness of the "Open questions" sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)