### PR TITLE
Add Combinator stdlib (#1860)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,24 @@ condensed series summaries instead of full per-patch history.
   return-semantics table and `conformance/tests/hooks_session/
   lifecycle_hook_events_*` for executable spec coverage. Settlement
   agent spawning itself remains the P-03 deferred stub (harn#1856).
+- **`std/lifecycle/combinators` callback combinator stdlib (#1860).**
+  Six pure factories for wrapping `(harness, return_value)`-shaped
+  callbacks (hook handlers, `resume_by`, `on_finish`, anywhere a
+  function-shaped value reaches user code). `compose(callbacks)` runs
+  callbacks sequentially and threads the return value through the
+  chain; `first_available(callbacks)` returns the first non-nil
+  responder; `with_telemetry(cb, span_name?)` opens a
+  `SpanKind::FnCall` OTel span (via new `__lifecycle_span_start` /
+  `__lifecycle_span_end` bridge builtins) and emits paired
+  `{span_name}_started` / `_completed` / `_errored` audits;
+  `with_timeout(cb, ms)` is a soft, clock-aware deadline that
+  measures via `harness.clock.now_ms()` and returns a
+  `{__timed_out, timeout_ms, elapsed_ms, return_value}` sentinel on
+  overrun; `if_unsettled(cb)` only fires when `harness.unsettled_state()`
+  has pending work (one snapshot per call); `when(predicate, cb)`
+  guards on an arbitrary predicate. Conformance coverage at
+  `conformance/tests/combinator_*.harn`. Part of the pipeline
+  lifecycle epic (#1853, P-07).
 - **`std/oauth/storage` token storage backends (#1904).** Five
   interchangeable backends for the OAuth client (#1885 OA-03):
   `memory()` (per-VM, ephemeral), `file(path, encryption_key)` (single

--- a/conformance/tests/combinator_compose.expected
+++ b/conformance/tests/combinator_compose.expected
@@ -1,0 +1,7 @@
+result=22
+audit_count=3
+a_value=0
+b_value=1
+c_value=11
+kind_order=step_a,step_b,step_c
+empty=42

--- a/conformance/tests/combinator_compose.harn
+++ b/conformance/tests/combinator_compose.harn
@@ -1,0 +1,43 @@
+import { lifecycle_audit_log_take } from "std/lifecycle"
+/**
+ * `compose([cb1, cb2, cb3])` invokes each callback sequentially with
+ * `(harness, return_value)`, threading the return value through the
+ * chain. The composed callback's final value is `cb3`'s return value.
+ * Order is observable via the audit log.
+ *
+ * Tracking: harn#1860 (P-07).
+ */
+import { compose } from "std/lifecycle/combinators"
+
+pipeline default() {
+  let log_a = { harness, return_value ->
+    harness.emit_audit("step_a", {value: return_value})
+    return return_value + 1
+  }
+  let log_b = { harness, return_value ->
+    harness.emit_audit("step_b", {value: return_value})
+    return return_value + 10
+  }
+  let log_c = { harness, return_value ->
+    harness.emit_audit("step_c", {value: return_value})
+    return return_value * 2
+  }
+  pipeline_on_finish(
+    { harness, return_value ->
+      let chained = compose([log_a, log_b, log_c])
+      let result = chained(harness, return_value)
+      let audits = lifecycle_audit_log_take()
+      harness.stdio.println("result=" + to_string(result))
+      harness.stdio.println("audit_count=" + to_string(len(audits)))
+      harness.stdio.println("a_value=" + to_string(audits[0].payload.value))
+      harness.stdio.println("b_value=" + to_string(audits[1].payload.value))
+      harness.stdio.println("c_value=" + to_string(audits[2].payload.value))
+      harness.stdio.println("kind_order=" + audits[0].kind + "," + audits[1].kind + "," + audits[2].kind)
+      let empty_chain = compose([])
+      harness.stdio.println("empty=" + to_string(empty_chain(harness, 42)))
+      return return_value
+    },
+  )
+  return 0
+}
+// Empty list returns the inbound value unchanged.

--- a/conformance/tests/combinator_first_available.expected
+++ b/conformance/tests/combinator_first_available.expected
@@ -1,0 +1,6 @@
+result=from_value
+audit_count=2
+kind_order=nil_called,value_called
+none=true
+trailing_count=2
+empty=true

--- a/conformance/tests/combinator_first_available.harn
+++ b/conformance/tests/combinator_first_available.harn
@@ -1,0 +1,45 @@
+import { lifecycle_audit_log_take } from "std/lifecycle"
+/**
+ * `first_available([cb1, cb2, cb3])` invokes callbacks in order and
+ * returns the first non-nil result. Callbacks past the first non-nil
+ * responder are not invoked. An all-nil chain returns nil.
+ *
+ * Tracking: harn#1860 (P-07).
+ */
+import { first_available } from "std/lifecycle/combinators"
+
+pipeline default() {
+  let nil_cb = { harness, _return_value ->
+    harness.emit_audit("nil_called", {})
+    return nil
+  }
+  let value_cb = { harness, _return_value ->
+    harness.emit_audit("value_called", {})
+    return "from_value"
+  }
+  let never_cb = { harness, _return_value ->
+    harness.emit_audit("never_called", {})
+    return "never"
+  }
+  pipeline_on_finish(
+    { harness, return_value ->
+      let chain = first_available([nil_cb, value_cb, never_cb])
+      let result = chain(harness, return_value)
+      let audits = lifecycle_audit_log_take()
+      harness.stdio.println("result=" + result)
+      harness.stdio.println("audit_count=" + to_string(len(audits)))
+      harness.stdio.println("kind_order=" + audits[0].kind + "," + audits[1].kind)
+      let only_nils = first_available([nil_cb, nil_cb])
+      let none = only_nils(harness, return_value)
+      let trailing = lifecycle_audit_log_take()
+      harness.stdio.println("none=" + to_string(none == nil))
+      harness.stdio.println("trailing_count=" + to_string(len(trailing)))
+      let empty = first_available([])
+      harness.stdio.println("empty=" + to_string(empty(harness, return_value) == nil))
+      return return_value
+    },
+  )
+  return 0
+}
+// All-nil chain returns nil and visits every callback.
+// Empty list returns nil immediately.

--- a/conformance/tests/combinator_if_unsettled.expected
+++ b/conformance/tests/combinator_if_unsettled.expected
@@ -1,0 +1,4 @@
+initial=7
+initial_audit_count=0
+triggered=handled
+triggered_audit_kind=ran

--- a/conformance/tests/combinator_if_unsettled.harn
+++ b/conformance/tests/combinator_if_unsettled.harn
@@ -1,0 +1,34 @@
+import { lifecycle_audit_log_take } from "std/lifecycle"
+/**
+ * `if_unsettled(callback)` invokes the wrapped callback only when
+ * `harness.unsettled_state()` reports pending work. With an empty
+ * snapshot the wrapper short-circuits to the inbound return value.
+ *
+ * Tracking: harn#1860 (P-07).
+ */
+import { if_unsettled } from "std/lifecycle/combinators"
+
+pipeline default() {
+  let cb = { harness, return_value ->
+    harness.emit_audit("ran", {})
+    return "handled"
+  }
+  pipeline_on_finish(
+    { harness, return_value ->
+      let guarded = if_unsettled(cb)
+      let initial = guarded(harness, return_value)
+      let initial_audits = lifecycle_audit_log_take()
+      harness.stdio.println("initial=" + to_string(initial))
+      harness.stdio.println("initial_audit_count=" + to_string(len(initial_audits)))
+      harness.handoff_to("staging-pipeline", {note: "if_unsettled test"})
+      let triggered = guarded(harness, return_value)
+      let triggered_audits = lifecycle_audit_log_take()
+      harness.stdio.println("triggered=" + triggered)
+      harness.stdio.println("triggered_audit_kind=" + triggered_audits[0].kind)
+      return return_value
+    },
+  )
+  return 7
+}
+// No unsettled work yet — wrapper short-circuits.
+// Induce an unsettled handoff envelope; wrapper invokes callback now.

--- a/conformance/tests/combinator_when.expected
+++ b/conformance/tests/combinator_when.expected
@@ -1,0 +1,4 @@
+truthy=seed_handled
+truthy_audit_kind=ran
+falsy=seed
+falsy_audit_count=0

--- a/conformance/tests/combinator_when.harn
+++ b/conformance/tests/combinator_when.harn
@@ -1,0 +1,34 @@
+import { lifecycle_audit_log_take } from "std/lifecycle"
+/**
+ * `when(predicate, callback)` invokes the wrapped callback only when
+ * `predicate(harness, return_value)` returns truthy. False predicates
+ * short-circuit to the inbound return value.
+ *
+ * Tracking: harn#1860 (P-07).
+ */
+import { when } from "std/lifecycle/combinators"
+
+pipeline default() {
+  let cb = { harness, return_value ->
+    harness.emit_audit("ran", {value: return_value})
+    return return_value + "_handled"
+  }
+  let is_truthy_seed = { _harness, return_value -> return return_value == "seed" }
+  let always_false = { _harness, _return_value -> return false }
+  pipeline_on_finish(
+    { harness, return_value ->
+      let truthy_guard = when(is_truthy_seed, cb)
+      let truthy_result = truthy_guard(harness, return_value)
+      let truthy_audits = lifecycle_audit_log_take()
+      harness.stdio.println("truthy=" + truthy_result)
+      harness.stdio.println("truthy_audit_kind=" + truthy_audits[0].kind)
+      let falsy_guard = when(always_false, cb)
+      let falsy_result = falsy_guard(harness, return_value)
+      let falsy_audits = lifecycle_audit_log_take()
+      harness.stdio.println("falsy=" + falsy_result)
+      harness.stdio.println("falsy_audit_count=" + to_string(len(falsy_audits)))
+      return return_value
+    },
+  )
+  return "seed"
+}

--- a/conformance/tests/combinator_with_telemetry.expected
+++ b/conformance/tests/combinator_with_telemetry.expected
@@ -1,0 +1,8 @@
+result=seed_done
+audit_count=2
+started_kind=happy_cb_started
+completed_kind=happy_cb_completed
+completed_summary=string:seed_done
+errored_kind=sad_cb_errored
+errored_message=boom
+rethrew=true

--- a/conformance/tests/combinator_with_telemetry.harn
+++ b/conformance/tests/combinator_with_telemetry.harn
@@ -1,0 +1,41 @@
+import { lifecycle_audit_log_take } from "std/lifecycle"
+/**
+ * `with_telemetry(callback, span_name?)` wraps a callback so each
+ * invocation emits a `{span_name}_started` audit entry, runs the
+ * callback, and emits either `{span_name}_completed` (with a result
+ * summary) or `{span_name}_errored` (with a stringified error and a
+ * re-thrown exception) before closing the wrapping trace span.
+ *
+ * Tracking: harn#1860 (P-07).
+ */
+import { with_telemetry } from "std/lifecycle/combinators"
+
+pipeline default() {
+  let happy = { _harness, return_value -> return return_value + "_done" }
+  let sad = { _harness, _return_value ->
+    throw "boom"
+  }
+  pipeline_on_finish(
+    { harness, return_value ->
+      let wrapped = with_telemetry(happy, "happy_cb")
+      let result = wrapped(harness, return_value)
+      let audits = lifecycle_audit_log_take()
+      harness.stdio.println("result=" + result)
+      harness.stdio.println("audit_count=" + to_string(len(audits)))
+      harness.stdio.println("started_kind=" + audits[0].kind)
+      harness.stdio.println("completed_kind=" + audits[1].kind)
+      harness.stdio.println("completed_summary=" + audits[1].payload.result_summary)
+      let wrapped_err = with_telemetry(sad, "sad_cb")
+      let result_outcome = try {
+        wrapped_err(harness, return_value)
+      }
+      let trailing = lifecycle_audit_log_take()
+      harness.stdio.println("errored_kind=" + trailing[1].kind)
+      harness.stdio.println("errored_message=" + trailing[1].payload.error)
+      harness.stdio.println("rethrew=" + to_string(is_err(result_outcome)))
+      return return_value
+    },
+  )
+  return "seed"
+}
+// Throwing callback emits `_errored` and re-throws.

--- a/conformance/tests/combinator_with_timeout.expected
+++ b/conformance/tests/combinator_with_timeout.expected
@@ -1,0 +1,10 @@
+fast=seed_fast
+fast_audit_count=0
+slow_timed_out=true
+slow_timeout_ms=500
+slow_elapsed_ge=true
+slow_return_value=seed_slow
+slow_audit_kind=lifecycle_callback_timed_out
+slow_audit_timeout=500
+unbounded=seed_slow
+unbounded_audit_count=0

--- a/conformance/tests/combinator_with_timeout.harn
+++ b/conformance/tests/combinator_with_timeout.harn
@@ -1,0 +1,51 @@
+import { lifecycle_audit_log_take } from "std/lifecycle"
+/**
+ * `with_timeout(callback, ms)` is a soft, clock-aware deadline. Under
+ * the deadline the wrapper passes the callback's return value through
+ * unchanged. When the callback overruns the deadline the wrapper
+ * emits a `lifecycle_callback_timed_out` audit entry and returns a
+ * sentinel dict `{__timed_out: true, timeout_ms, elapsed_ms,
+ * return_value}` so downstream composition can detect the overrun.
+ *
+ * Tracking: harn#1860 (P-07).
+ */
+import { with_timeout } from "std/lifecycle/combinators"
+
+pipeline default() {
+  let fast = { _harness, return_value -> return return_value + "_fast" }
+  let slow = { _harness, return_value ->
+    let _ = advance_time(2000)
+    return return_value + "_slow"
+  }
+  pipeline_on_finish(
+    { harness, return_value ->
+      let _ = mock_time(0)
+      let fast_wrap = with_timeout(fast, 500)
+      let fast_result = fast_wrap(harness, return_value)
+      let fast_audits = lifecycle_audit_log_take()
+      harness.stdio.println("fast=" + fast_result)
+      harness.stdio.println("fast_audit_count=" + to_string(len(fast_audits)))
+      let slow_wrap = with_timeout(slow, 500)
+      let slow_result = slow_wrap(harness, return_value)
+      let slow_audits = lifecycle_audit_log_take()
+      harness.stdio.println("slow_timed_out=" + to_string(slow_result.__timed_out))
+      harness.stdio.println("slow_timeout_ms=" + to_string(slow_result.timeout_ms))
+      harness.stdio.println("slow_elapsed_ge=" + to_string(slow_result.elapsed_ms >= 500))
+      harness.stdio.println("slow_return_value=" + slow_result.return_value)
+      harness.stdio.println("slow_audit_kind=" + slow_audits[0].kind)
+      harness.stdio.println("slow_audit_timeout=" + to_string(slow_audits[0].payload.timeout_ms))
+      let no_deadline = with_timeout(slow, 0)
+      let _ = advance_time(1000)
+      let unbounded = no_deadline(harness, return_value)
+      let trailing = lifecycle_audit_log_take()
+      harness.stdio.println("unbounded=" + unbounded)
+      harness.stdio.println("unbounded_audit_count=" + to_string(len(trailing)))
+      let _ = unmock_time()
+      return return_value
+    },
+  )
+  return "seed"
+}
+// Callback finishes under the deadline; value flows through unchanged.
+// Callback overruns; sentinel + audit fire.
+// Zero/negative deadline disables the check; value flows through unchanged.

--- a/crates/harn-parser/src/builtin_signatures/signatures/stdlib.rs
+++ b/crates/harn-parser/src/builtin_signatures/signatures/stdlib.rs
@@ -226,6 +226,16 @@ pub(crate) const SIGNATURES: &[BuiltinSignature] = &[
         TY_BOOL,
     ),
     BuiltinSignature::simple(
+        "__lifecycle_span_end",
+        &[Param::new("span_id", TY_INT)],
+        TY_NIL,
+    ),
+    BuiltinSignature::simple(
+        "__lifecycle_span_start",
+        &[Param::new("name", TY_STRING)],
+        TY_INT,
+    ),
+    BuiltinSignature::simple(
         "__llm_cache_key",
         &[
             Param::new("prompt", TY_ANY),

--- a/crates/harn-stdlib/src/lib.rs
+++ b/crates/harn-stdlib/src/lib.rs
@@ -210,6 +210,10 @@ pub const STDLIB_SOURCES: &[StdlibSource] = &[
         source: include_str!("stdlib/lifecycle/pool.harn"),
     },
     StdlibSource {
+        module: "lifecycle/combinators",
+        source: include_str!("stdlib/lifecycle/combinators.harn"),
+    },
+    StdlibSource {
         module: "agent/prompts",
         source: include_str!("stdlib/agent/prompts.harn"),
     },

--- a/crates/harn-stdlib/src/stdlib/lifecycle/combinators.harn
+++ b/crates/harn-stdlib/src/stdlib/lifecycle/combinators.harn
@@ -1,0 +1,264 @@
+/**
+ * std/lifecycle/combinators — function-shaped wrappers for lifecycle
+ * callbacks (P-07, harn#1860). The six combinators here are not
+ * lifecycle-specific: they wrap any `(harness, return_value) ->
+ * return_value` shape and apply equally to hook handlers,
+ * `resume_by` callbacks, `on_finish` callbacks, and any other
+ * function-shaped value the runtime hands to user code.
+ *
+ * Import:
+ *   import {
+ *     compose, first_available, with_telemetry, with_timeout,
+ *     if_unsettled, when,
+ *   } from "std/lifecycle/combinators"
+ *
+ * All six are pure factories: each accepts a callback (or a list of
+ * callbacks) plus options, and returns a closure with no captured
+ * mutable state. They compose freely — `compose(with_telemetry(drain),
+ * with_timeout(drain, 60s))` is meaningful.
+ *
+ * Tracking: harn#1860 (P-07), harn#1853 (epic).
+ */
+import { is_empty, unsettled_state } from "std/lifecycle"
+
+fn __resolve_timeout_ms(ms) {
+  if type_of(ms) == "int" {
+    return ms
+  }
+  if type_of(ms) == "float" {
+    return to_int(ms)
+  }
+  if type_of(ms) == "dict" {
+    if ms?.ms != nil {
+      return to_int(ms.ms)
+    }
+    if ms?.duration_ms != nil {
+      return to_int(ms.duration_ms)
+    }
+    if ms?.seconds != nil {
+      return to_int(ms.seconds * 1000.0)
+    }
+  }
+  return 0
+}
+
+fn __summarize_result(value) -> string {
+  let kind = type_of(value)
+  if value == nil {
+    return "nil"
+  }
+  if kind == "string" {
+    let s = value
+    if len(s) > 80 {
+      return kind + ":" + substring(s, 0, 80) + "..."
+    }
+    return kind + ":" + s
+  }
+  if kind == "int" || kind == "float" || kind == "bool" {
+    return kind + ":" + to_string(value)
+  }
+  if kind == "list" {
+    return "list:len=" + to_string(len(value))
+  }
+  if kind == "dict" {
+    return "dict:keys=" + to_string(len(keys(value)))
+  }
+  return kind
+}
+
+fn __stringify_error(err) -> string {
+  if err == nil {
+    return ""
+  }
+  if type_of(err) == "string" {
+    return err
+  }
+  if type_of(err) == "dict" {
+    return err?.message ?? json_stringify(err)
+  }
+  return to_string(err)
+}
+
+/**
+ * compose(callbacks) returns a callback that invokes every entry in
+ * `callbacks` sequentially with `(harness, return_value)`. Each
+ * callback's return value becomes the next callback's `return_value`,
+ * so this composes naturally with `pipeline_on_finish` chains where a
+ * later step wraps, redacts, or augments an earlier step's output.
+ * The composed callback returns the last entry's return value. An
+ * empty list returns `return_value` unchanged. Errors propagate; the
+ * composition stops at the first throw.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: pipeline_on_finish(compose([on_finish_drain, audit_callback]))
+ */
+pub fn compose(callbacks) {
+  return { harness, return_value ->
+    if type_of(callbacks) != "list" || len(callbacks) == 0 {
+      return return_value
+    }
+    var current = return_value
+    for cb in callbacks {
+      current = cb(harness, current)
+    }
+    return current
+  }
+}
+
+/**
+ * first_available(callbacks) returns a callback that invokes each
+ * entry in order with `(harness, return_value)` and returns the first
+ * non-nil result. If every callback returns nil (or the list is
+ * empty), the composed callback returns nil. Errors propagate; on a
+ * throw the chain stops at the throwing callback. Use this for
+ * fallback chains like `[cloud_handle, local_handle, parent_handle]`
+ * where the first responder wins.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: pipeline_on_finish(first_available([cloud_drain, local_drain]))
+ */
+pub fn first_available(callbacks) {
+  return { harness, return_value ->
+    if type_of(callbacks) != "list" || len(callbacks) == 0 {
+      return nil
+    }
+    for cb in callbacks {
+      let result = cb(harness, return_value)
+      if result != nil {
+        return result
+      }
+    }
+    return nil
+  }
+}
+
+/**
+ * with_telemetry(callback, span_name?) wraps `callback` so each
+ * invocation opens a `SpanKind::FnCall` OTel span named `span_name`
+ * (linked to the active parent span via the standard VM tracing
+ * stack) and emits paired `{span_name}_started` /
+ * `{span_name}_completed` audit entries on the supplied harness. If
+ * the wrapped callback throws, the wrapper emits
+ * `{span_name}_errored` (with a stringified error), closes the span,
+ * and re-throws. The default `span_name` is `"lifecycle_callback"`.
+ *
+ * @effects: [host]
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: pipeline_on_finish(with_telemetry(on_finish_drain, "drain"))
+ */
+pub fn with_telemetry(callback, span_name = "lifecycle_callback") {
+  let label = if type_of(span_name) == "string" {
+    span_name
+  } else {
+    "lifecycle_callback"
+  }
+  return { harness, return_value ->
+    let span = __lifecycle_span_start(label)
+    harness.emit_audit(label + "_started", {})
+    try {
+      let result = callback(harness, return_value)
+      harness
+        .emit_audit(label + "_completed", {result_summary: __summarize_result(result)})
+      __lifecycle_span_end(span)
+      return result
+    } catch (e) {
+      harness.emit_audit(label + "_errored", {error: __stringify_error(e)})
+      __lifecycle_span_end(span)
+      throw e
+    }
+  }
+}
+
+/**
+ * with_timeout(callback, ms) wraps `callback` with a soft, clock-aware
+ * deadline. `ms` may be an int / float (milliseconds), or a dict with
+ * one of `{ms, duration_ms, seconds}`. The wrapper measures elapsed
+ * time around the callback with `now_ms()` (mockable in tests via
+ * `mock_time` / `advance_time`). If the callback overruns the
+ * deadline, the wrapper emits a `{lifecycle_callback,timed_out}`
+ * audit entry and returns a sentinel dict shaped
+ * `{__timed_out: true, timeout_ms, elapsed_ms, return_value}` so
+ * downstream composition (`compose`, `first_available`) can detect
+ * the timeout without relying on an exception. Callbacks that
+ * complete under the deadline pass their value through unchanged.
+ *
+ * This is a soft deadline by design: lifecycle callbacks own user
+ * state and side-effects, so cooperative cancellation (or letting
+ * the callback complete and recording the overrun) is safer than a
+ * hard thread-kill.
+ *
+ * @effects: [host]
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: pipeline_on_finish(with_timeout(on_finish_drain, 30000))
+ */
+pub fn with_timeout(callback, ms) {
+  let timeout_ms = __resolve_timeout_ms(ms)
+  return { harness, return_value ->
+    let start = harness.clock.now_ms()
+    let result = callback(harness, return_value)
+    let elapsed = harness.clock.now_ms() - start
+    if timeout_ms <= 0 || elapsed <= timeout_ms {
+      return result
+    }
+    harness
+      .emit_audit("lifecycle_callback_timed_out", {timeout_ms: timeout_ms, elapsed_ms: elapsed})
+    return {__timed_out: true, timeout_ms: timeout_ms, elapsed_ms: elapsed, return_value: result}
+  }
+}
+
+/**
+ * if_unsettled(callback) returns a callback that only invokes `callback`
+ * when `harness.unsettled_state()` reports at least one bucket with
+ * pending work. When everything is settled the wrapper short-circuits
+ * to the inbound `return_value`. Exactly one `unsettled_state()`
+ * snapshot is taken per invocation so the decision is consistent and
+ * cheap.
+ *
+ * @effects: [host]
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: pipeline_on_finish(if_unsettled(on_finish_drain))
+ */
+pub fn if_unsettled(callback) {
+  return { harness, return_value ->
+    let state = unsettled_state(harness)
+    if is_empty(state) {
+      return return_value
+    }
+    return callback(harness, return_value)
+  }
+}
+
+/**
+ * when(predicate, callback) returns a callback that invokes
+ * `callback(harness, return_value)` only when
+ * `predicate(harness, return_value)` returns truthy. Predicates may
+ * inspect the harness, the inbound return value, or external state.
+ * When the predicate is false the wrapper short-circuits to the
+ * inbound `return_value`.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: pipeline_on_finish(when({ h, rv -> rv == nil }, fallback_cb))
+ */
+pub fn when(predicate, callback) {
+  return { harness, return_value ->
+    if predicate(harness, return_value) {
+      return callback(harness, return_value)
+    }
+    return return_value
+  }
+}

--- a/crates/harn-vm/src/stdlib/tracing.rs
+++ b/crates/harn-vm/src/stdlib/tracing.rs
@@ -154,6 +154,28 @@ pub(crate) fn register_tracing_builtins(vm: &mut Vm) {
         Ok(VmValue::String(Rc::from(crate::tracing::format_summary())))
     });
 
+    // Bridge into the OTel-aware span system from Harn for lifecycle
+    // combinators (`std/lifecycle/combinators::with_telemetry`). Emits a
+    // `SpanKind::FnCall` span linked to the current parent span and
+    // returns the numeric span id; pair with `__lifecycle_span_end`.
+    vm.register_builtin("__lifecycle_span_start", |args, _out| {
+        let name = args.first().map(|a| a.display()).unwrap_or_default();
+        let id = crate::tracing::span_start(crate::tracing::SpanKind::FnCall, name);
+        Ok(VmValue::Int(id as i64))
+    });
+
+    vm.register_builtin("__lifecycle_span_end", |args, _out| {
+        let span_id = match args.first().and_then(|v| v.as_int()) {
+            Some(id) => id,
+            None => return Ok(VmValue::Nil),
+        };
+        if span_id < 0 {
+            return Ok(VmValue::Nil);
+        }
+        crate::tracing::span_end(span_id as u64);
+        Ok(VmValue::Nil)
+    });
+
     vm.register_builtin("llm_usage", |_args, _out| {
         let (total_input, total_output, total_duration, call_count) =
             crate::llm::peek_trace_summary();

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -2473,6 +2473,25 @@ Three concentric surfaces:
 
   Presets are pure functions / pure factories; they compose freely. See
   `docs/src/stdlib/lifecycle.md` for an example chain.
+- `std/lifecycle/combinators` exports six pure factories that wrap any
+  `(harness, return_value) -> return_value`-shaped callback (hook
+  handler, `resume_by`, `on_finish`, ...):
+  - `compose(callbacks)` — invoke each callback sequentially, threading
+    each return value into the next callback's `return_value`; returns
+    the last entry's value.
+  - `first_available(callbacks)` — invoke in order; return the first
+    non-nil result. Skips remaining callbacks after the first non-nil.
+  - `with_telemetry(callback, span_name?)` — wrap with a `SpanKind::FnCall`
+    OTel span and paired `{span_name}_started` / `_completed` /
+    `_errored` audit entries.
+  - `with_timeout(callback, ms)` — soft, clock-aware deadline; on
+    overrun returns `{__timed_out: true, timeout_ms, elapsed_ms,
+    return_value}` and emits a `lifecycle_callback_timed_out` audit.
+  - `if_unsettled(callback)` — only invoke when
+    `harness.unsettled_state()` is non-empty; one snapshot per call.
+  - `when(predicate, callback)` — only invoke when
+    `predicate(harness, return_value)` is truthy; otherwise pass the
+    inbound value through unchanged.
 - `harness.unsettled_state()` returns a stable dict with
   `suspended_subagents`, `queued_triggers`, `partial_handoffs`, and
   `in_flight_llm_calls` lists. `harness.is_empty(state?)`,

--- a/docs/src/stdlib/lifecycle.md
+++ b/docs/src/stdlib/lifecycle.md
@@ -203,6 +203,53 @@ entries live on a per-pipeline-run audit log that conformance fixtures
 and replay oracles can drain via `lifecycle_audit_log_take()` (or peek
 at without consuming via `lifecycle_audit_log_snapshot()`).
 
+## Callback combinators (`std/lifecycle/combinators`)
+
+The combinators in `std/lifecycle/combinators` wrap any
+`(harness, return_value) -> return_value`-shaped callback — hook
+handlers, `resume_by` callbacks, the presets above, and any custom
+`on_finish` body. All six are pure factories that return closures with
+no captured mutable state, so they nest freely:
+
+- `compose([cb, ...])` runs each callback sequentially, threading the
+  prior callback's return value into the next callback's
+  `return_value`.
+- `first_available([cb, ...])` invokes callbacks in order and returns
+  the first non-nil result (fallback chains).
+- `with_telemetry(cb, span_name?)` opens a `SpanKind::FnCall` OTel
+  span and emits paired `{span_name}_started` / `_completed` /
+  `_errored` audit entries.
+- `with_timeout(cb, ms)` is a soft, clock-aware deadline. On overrun
+  the wrapper returns a sentinel dict
+  `{__timed_out: true, timeout_ms, elapsed_ms, return_value}` and
+  emits a `lifecycle_callback_timed_out` audit.
+- `if_unsettled(cb)` invokes the wrapped callback only when
+  `harness.unsettled_state()` reports pending work (exactly one
+  snapshot per call).
+- `when(predicate, cb)` guards on an arbitrary
+  `predicate(harness, return_value)` and short-circuits to the
+  inbound return value when false.
+
+A realistic composition wraps `on_finish_drain` with telemetry, a
+soft deadline, and an unsettled-state guard so the drain only runs
+when there is real work to do:
+
+```harn
+import {
+  compose, if_unsettled, with_telemetry, with_timeout,
+} from "std/lifecycle/combinators"
+import { on_finish_drain } from "std/lifecycle"
+
+pipeline default() {
+  pipeline_on_finish(
+    if_unsettled(
+      with_telemetry(with_timeout(on_finish_drain, 30000), "drain"),
+    ),
+  )
+  return "ok"
+}
+```
+
 ## Inspecting unsettled state directly
 
 Custom `on_finish` callbacks have full access to the harness:


### PR DESCRIPTION
## Summary

- Adds six pure-factory combinators in `std/lifecycle/combinators` (`compose`, `first_available`, `with_telemetry`, `with_timeout`, `if_unsettled`, `when`) that wrap any `(harness, return_value)`-shaped callback (hook handlers, `resume_by`, `on_finish`, anywhere a function-shaped value is supplied to the runtime).
- Wires `with_telemetry` to the existing OTel span system via two new bridge builtins (`__lifecycle_span_start` / `__lifecycle_span_end`) that route into `SpanKind::FnCall`, plus paired `{name}_started` / `_completed` / `_errored` audit entries on the harness.
- Uses a soft, clock-aware deadline for `with_timeout` (measured against `harness.clock.now_ms()`, mockable via `mock_time` / `advance_time`); on overrun returns a `{__timed_out, timeout_ms, elapsed_ms, return_value}` sentinel so `compose` / `first_available` can detect the overrun without exceptions.
- Conformance fixtures at `conformance/tests/combinator_*.harn` cover each combinator. Quickref entry, `docs/src/stdlib/lifecycle.md` cookbook section, and `CHANGELOG.md ## Unreleased` updated.

Closes #1860. Part of epic #1853 (Pipeline lifecycle).

## Test plan

- [x] `cargo fmt --all && cargo clippy --workspace --all-targets`
- [x] `make fmt-harn && make lint-harn`
- [x] `cargo run --bin harn -- test conformance --filter combinator` (6 new tests pass)
- [x] `cargo run --bin harn -- test conformance` (1179/1179 pass)
- [x] `make test` (4399/4399 Rust tests pass)
- [x] `make check-docs-snippets`
- [x] Markdown lint clean