### PR TITLE
Add SpawnToPool trigger handler (#1889)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,20 @@ condensed series summaries instead of full per-patch history.
   guards on an arbitrary predicate. Conformance coverage at
   `conformance/tests/combinator_*.harn`. Part of the pipeline
   lifecycle epic (#1853, P-07).
+- **`SpawnToPool` trigger handler variant (#1889).** Triggers now compose
+  with named agent pools (#1883) via a new `TriggerHandlerSpec::SpawnToPool`
+  variant, surfaced through the Harn DSL as
+  `handler: SpawnToPool({pool: "pr-review", priority_from: "headers.priority",
+  key_from: "tenant_id", task_factory: { event -> { -> review(event) } }})`.
+  The dispatcher invokes `task_factory(event)` per matched event, extracts
+  priority + fair-queue key via simple dotted JSON paths into the event
+  payload (missing paths fall back to defaults rather than erroring), and
+  submits the resulting closure to the pool under its configured queue
+  strategy + backpressure policy. `drop_newest` rejections reuse the existing
+  `lifecycle.pool.audit` channel, and the dispatch result is shaped as a
+  `pool_task` handle so handlers can call `pool_wait(dispatch.result)`
+  directly. Conformance:
+  `conformance/tests/triggers/trigger_spawn_to_pool_*`.
 - **`std/oauth/storage` token storage backends (#1904).** Five
   interchangeable backends for the OAuth client (#1885 OA-03):
   `memory()` (per-VM, ephemeral), `file(path, encryption_key)` (single

--- a/conformance/tests/triggers/trigger_spawn_to_pool_caps_concurrency.expected
+++ b/conformance/tests/triggers/trigger_spawn_to_pool_caps_concurrency.expected
@@ -1,0 +1,5 @@
+true
+true
+true
+true
+true

--- a/conformance/tests/triggers/trigger_spawn_to_pool_caps_concurrency.harn
+++ b/conformance/tests/triggers/trigger_spawn_to_pool_caps_concurrency.harn
@@ -1,0 +1,71 @@
+import { pool_create, pool_wait } from "std/lifecycle/pool"
+import "std/triggers"
+
+/**
+ * Verifies the SpawnToPool trigger handler (#1889) composes triggers with
+ * named agent pools (#1883): the dispatcher submits each matched event into
+ * the named pool via its task_factory, and the pool's max_concurrent cap
+ * bounds in-flight closures regardless of the inbound event rate.
+ */
+pipeline test(task) {
+  let gate = channel(nil, 32)
+  let inflight = atomic(0)
+  let peak = atomic(0)
+  let completed = atomic(0)
+  let _pool = pool_create({name: "spawn-to-pool-cap-demo", max_concurrent: 3})
+  let task_factory = { _event -> return { ->
+    let now = atomic_add(inflight, 1) + 1
+    if now > atomic_get(peak) {
+      atomic_set(peak, now)
+    }
+    receive(gate)
+    atomic_add(inflight, -1)
+    atomic_add(completed, 1)
+    return now
+  } }
+  let unique = to_string(to_int(timestamp())) + "-" + to_string(random_int(100000, 999999))
+  let trigger_id = "trigger-spawn-to-pool-" + unique
+  let handle: TriggerHandle = trigger_register(
+    {
+      id: trigger_id,
+      kind: "issue.opened",
+      provider: "github",
+      handler: SpawnToPool({pool: "spawn-to-pool-cap-demo", task_factory: task_factory}),
+      when: nil,
+      retry: nil,
+      match: {events: ["issue.opened"]},
+      events: nil,
+      dedupe_key: nil,
+      filter: nil,
+      budget: nil,
+      manifest_path: nil,
+      package_name: "conformance",
+    },
+  )
+  // Fire 8 events. With max_concurrent=3 the pool must keep at most three
+  // closures running concurrently regardless of inbound event rate.
+  var handles = []
+  for i in 0 to 8 exclusive {
+    let dispatch: DispatchHandle = trigger_fire(
+      handle,
+      {
+        provider: "github",
+        kind: "issue.opened",
+        headers: {x_delivery: "evt-" + to_string(i) + "-" + unique},
+      },
+    )
+    if dispatch.status == "dispatched" && dispatch.result?.pool == "spawn-to-pool-cap-demo" {
+      handles = handles.push(dispatch.result)
+    }
+  }
+  println(len(handles) == 8)
+  // Release the gate so each pool task can complete.
+  for _i in 0 to 8 exclusive {
+    send(gate, "go")
+  }
+  let results = pool_wait(handles)
+  println(len(results) == 8)
+  println(atomic_get(peak) <= 3)
+  println(atomic_get(inflight) == 0)
+  println(atomic_get(completed) == 8)
+}

--- a/conformance/tests/triggers/trigger_spawn_to_pool_drop_newest_emits_audit.expected
+++ b/conformance/tests/triggers/trigger_spawn_to_pool_drop_newest_emits_audit.expected
@@ -1,0 +1,9 @@
+true
+true
+true
+true
+drop_newest_queue_full
+drop_newest
+harn.pool_drop.v1
+completed
+completed

--- a/conformance/tests/triggers/trigger_spawn_to_pool_drop_newest_emits_audit.harn
+++ b/conformance/tests/triggers/trigger_spawn_to_pool_drop_newest_emits_audit.harn
@@ -1,0 +1,76 @@
+import { Backpressure, pool_create, pool_wait } from "std/lifecycle/pool"
+import "std/triggers"
+
+/**
+ * Verifies the drop_newest backpressure path on a SpawnToPool trigger
+ * (#1889): when the pool's queue is saturated, the dispatcher still records
+ * the dispatch as successful and the pool emits its standard
+ * `lifecycle.pool.audit` event so observers can see the rejection. This
+ * matches `pool.submit({backpressure: bp.queue(1, "drop_newest")})` —
+ * composing triggers with pools shouldn't introduce a parallel audit path.
+ */
+pipeline test(task) {
+  let bp = Backpressure()
+  let gate = channel(nil, 1)
+  let _pool = pool_create(
+    {
+      name: "spawn-to-pool-drop-newest-demo",
+      max_concurrent: 1,
+      backpressure: bp.queue(1, "drop_newest"),
+    },
+  )
+  let stream = event_log.subscribe({topic: "lifecycle.pool.audit"})
+  let task_factory = { _event -> return { ->
+    receive(gate)
+    return "ok"
+  } }
+  let unique = to_string(to_int(timestamp())) + "-" + to_string(random_int(100000, 999999))
+  let trigger_id = "trigger-spawn-to-pool-dropnew-" + unique
+  let handle: TriggerHandle = trigger_register(
+    {
+      id: trigger_id,
+      kind: "issue.opened",
+      provider: "github",
+      handler: SpawnToPool({pool: "spawn-to-pool-drop-newest-demo", task_factory: task_factory}),
+      when: nil,
+      retry: nil,
+      match: {events: ["issue.opened"]},
+      events: nil,
+      dedupe_key: nil,
+      filter: nil,
+      budget: nil,
+      manifest_path: nil,
+      package_name: "conformance",
+    },
+  )
+  // First fire occupies the single active slot. Second occupies the queue.
+  // Third should be evicted by drop_newest, leaving the result as rejected.
+  let warmup = trigger_fire(
+    handle,
+    {provider: "github", kind: "issue.opened", headers: {x_delivery: "warmup-" + unique}},
+  )
+  let queued = trigger_fire(
+    handle,
+    {provider: "github", kind: "issue.opened", headers: {x_delivery: "queued-" + unique}},
+  )
+  let newest = trigger_fire(
+    handle,
+    {provider: "github", kind: "issue.opened", headers: {x_delivery: "newest-" + unique}},
+  )
+  println(warmup.status == "dispatched")
+  println(queued.status == "dispatched")
+  println(newest.status == "dispatched")
+  println(newest.result?.status == "rejected")
+  println(newest.result?.rejection_reason)
+  // The pool emits its standard audit so trigger dispatch and direct
+  // `pool.submit` callers see the same drop event.
+  let audit = stream.next().value
+  println(audit.payload.policy)
+  println(audit.headers.schema)
+  // Drain the gate so the two surviving tasks finish.
+  send(gate, "go")
+  send(gate, "go")
+  let results = pool_wait([warmup.result, queued.result])
+  println(results[0].status)
+  println(results[1].status)
+}

--- a/conformance/tests/triggers/trigger_spawn_to_pool_extracts_priority_and_key.expected
+++ b/conformance/tests/triggers/trigger_spawn_to_pool_extracts_priority_and_key.expected
@@ -1,0 +1,10 @@
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true

--- a/conformance/tests/triggers/trigger_spawn_to_pool_extracts_priority_and_key.harn
+++ b/conformance/tests/triggers/trigger_spawn_to_pool_extracts_priority_and_key.harn
@@ -1,0 +1,73 @@
+import { fair_round_robin, pool_create, pool_wait } from "std/lifecycle/pool"
+import "std/triggers"
+
+/**
+ * Verifies SpawnToPool's `priority_from` and `key_from` extractors (#1889)
+ * read dotted JSON paths from the trigger event before the pool sees it,
+ * and that the named pool then composes correctly with priority + fair
+ * round-robin queue strategies (PL-02).
+ */
+fn factory_for(tag) {
+  return { _event -> return { -> tag } }
+}
+
+pipeline test(task) {
+  let _pool = pool_create(
+    {name: "spawn-to-pool-extractor-demo", max_concurrent: 1, queue: fair_round_robin("key")},
+  )
+  let unique = to_string(to_int(timestamp())) + "-" + to_string(random_int(100000, 999999))
+  let trigger_id = "trigger-spawn-to-pool-extract-" + unique
+  let handle: TriggerHandle = trigger_register(
+    {
+      id: trigger_id,
+      kind: "issue.opened",
+      provider: "github",
+      handler: SpawnToPool(
+        {
+          pool: "spawn-to-pool-extractor-demo",
+          priority_from: "headers.priority",
+          key_from: "tenant_id",
+          task_factory: factory_for("seed"),
+        },
+      ),
+      when: nil,
+      retry: nil,
+      match: {events: ["issue.opened"]},
+      events: nil,
+      dedupe_key: nil,
+      filter: nil,
+      budget: nil,
+      manifest_path: nil,
+      package_name: "conformance",
+    },
+  )
+  let fired = trigger_fire(
+    handle,
+    {
+      provider: "github",
+      kind: "issue.opened",
+      tenant_id: "acme",
+      headers: {priority: "7", x_delivery: "evt-" + unique},
+    },
+  )
+  // The dispatcher surfaces the extracted priority + key in the dispatch
+  // result so observers (audit, action graph) can correlate the pool task
+  // back to the originating event without re-parsing the payload.
+  println(fired.status == "dispatched")
+  println(fired.result?.pool == "spawn-to-pool-extractor-demo")
+  println(fired.result?.priority == 7)
+  println(fired.result?.key == "acme")
+  // Missing paths fall back to defaults (priority 0, no key) rather than
+  // failing the dispatch.
+  let fallback = trigger_fire(
+    handle,
+    {provider: "github", kind: "issue.opened", headers: {x_delivery: "evt-fallback-" + unique}},
+  )
+  println(fallback.status == "dispatched")
+  println(fallback.result?.priority == 0)
+  println(fallback.result?.key == nil)
+  let results = pool_wait([fired.result, fallback.result])
+  println(len(results) == 2)
+  println(results[0].result == "seed")
+  println(results[1].result == "seed")
+}

--- a/crates/harn-cli/src/commands/dump_trigger_quickref.rs
+++ b/crates/harn-cli/src/commands/dump_trigger_quickref.rs
@@ -143,6 +143,26 @@ fn generate_file() -> String {
     out.push_str("Key fields: `id`, `kind`, `provider`, `handler`, `path` or `match.path`, `match.events`, `when`, `dedupe_key`, `retry`, `budget`, `secrets`, `schedule`, `timezone`, and provider-specific config tables such as `poll`.\n\n");
     out.push_str("Audit a project before deploy with `harn routes <root> --json`; it reports each declarative trigger's route path, handler module, budgets, inferred host capabilities, vendor-lock disclosure, and prompt/template overhead without executing handler code.\n\n");
 
+    out.push_str("## Handler variants\n\n");
+    out.push_str("`handler:` accepts a closure (in-process), an `a2a://` or `worker://` URI string, or a handler-variant dict. The dict form covers compositions that need more than a single callable; today only `SpawnToPool` ships, more variants will plug into the same syntax over time.\n\n");
+    out.push_str("```harn\n");
+    out.push_str("import { SpawnToPool } from \"std/triggers\"\n");
+    out.push_str("import { pool_create } from \"std/lifecycle/pool\"\n\n");
+    out.push_str("pool_create({name: \"pr-review-pool\", max_concurrent: 4})\n\n");
+    out.push_str("trigger_register({\n");
+    out.push_str("  kind: \"issue.opened\",\n");
+    out.push_str("  provider: \"github\",\n");
+    out.push_str("  handler: SpawnToPool({\n");
+    out.push_str("    pool: \"pr-review-pool\",\n");
+    out.push_str("    priority_from: \"headers.priority\",     // optional dotted JSON path\n");
+    out.push_str("    key_from: \"tenant_id\",                 // optional dotted JSON path\n");
+    out.push_str("    task_factory: { event -> { -> review(event) } },\n");
+    out.push_str("  }),\n");
+    out.push_str("  match: {events: [\"issue.opened\"]},\n");
+    out.push_str("})\n");
+    out.push_str("```\n\n");
+    out.push_str("The dispatcher invokes `task_factory(event)` per match, extracts priority + fair-queue key from the event payload (missing paths fall back to default priority 0 / null key), and submits the resulting closure to the named pool under its queue strategy + backpressure policy. Pool rejections (`drop_newest`, etc.) reuse the `lifecycle.pool.audit` channel that direct `pool.submit` calls emit on. The dispatch result is shaped as a `pool_task` handle so handlers can call `pool_wait(dispatch.result)` directly.\n\n");
+
     out.push_str("## Provider catalog\n\n");
     out.push_str("This table is generated from `std/triggers::list_providers()` / `ProviderCatalog` metadata.\n\n");
     out.push_str(

--- a/crates/harn-cli/src/commands/trigger/ops.rs
+++ b/crates/harn-cli/src/commands/trigger/ops.rs
@@ -721,6 +721,7 @@ fn handler_kind(binding: &harn_vm::triggers::registry::TriggerBinding) -> &'stat
         TriggerHandlerSpec::Worker { .. } => "worker",
         TriggerHandlerSpec::Persona { .. } => "persona",
         TriggerHandlerSpec::AutoResume { .. } => "auto_resume",
+        TriggerHandlerSpec::SpawnToPool { .. } => "spawn_to_pool",
     }
 }
 
@@ -731,6 +732,7 @@ fn handler_label(binding: &harn_vm::triggers::registry::TriggerBinding) -> Strin
         TriggerHandlerSpec::Worker { queue } => queue.clone(),
         TriggerHandlerSpec::Persona { binding } => binding.name.clone(),
         TriggerHandlerSpec::AutoResume { worker_id } => worker_id.clone(),
+        TriggerHandlerSpec::SpawnToPool { pool, .. } => pool.clone(),
     }
 }
 
@@ -741,6 +743,7 @@ fn target_uri(binding: &harn_vm::triggers::registry::TriggerBinding) -> String {
         TriggerHandlerSpec::Worker { queue } => format!("worker://{queue}"),
         TriggerHandlerSpec::Persona { binding } => format!("persona://{}", binding.name),
         TriggerHandlerSpec::AutoResume { worker_id } => format!("auto_resume://{worker_id}"),
+        TriggerHandlerSpec::SpawnToPool { pool, .. } => format!("pool://{pool}"),
     }
 }
 

--- a/crates/harn-stdlib/src/stdlib/stdlib_triggers.harn
+++ b/crates/harn-stdlib/src/stdlib/stdlib_triggers.harn
@@ -946,6 +946,33 @@ type StreamLlmClassifyPlan = {
 }
 
 /**
+ * SpawnToPool builds a handler-variant dict that routes matched events into
+ * a named agent pool (#1883) instead of spawning a fresh worker per event.
+ *
+ * The dispatcher resolves `pool` by name, invokes `task_factory(event)` to
+ * build the per-event closure, and submits that closure under the pool's
+ * queue strategy + backpressure policy. `priority_from` and `key_from` are
+ * dotted paths into the trigger event JSON (e.g. `"tenant_id"`,
+ * `"provider_payload.urgency"`). Missing paths fall back to the default
+ * priority (0) and a null fair-queue key.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: trigger_register({handler: SpawnToPool({pool: "pr-review", task_factory: { event -> { -> review(event) } }})})
+ */
+pub fn SpawnToPool(options: dict) -> dict {
+  return {
+    kind: "spawn_to_pool",
+    pool: options.pool,
+    priority_from: options?.priority_from,
+    key_from: options?.key_from,
+    task_factory: options.task_factory,
+  }
+}
+
+/**
  * list_providers.
  *
  * @effects: []

--- a/crates/harn-vm/src/stdlib.rs
+++ b/crates/harn-vm/src/stdlib.rs
@@ -43,7 +43,7 @@ mod multipart;
 mod oauth_storage;
 mod options;
 mod path;
-mod pool;
+pub(crate) mod pool;
 mod postgres;
 pub mod process;
 mod project;

--- a/crates/harn-vm/src/stdlib/pool.rs
+++ b/crates/harn-vm/src/stdlib/pool.rs
@@ -823,6 +823,87 @@ async fn pool_submit_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
         parse_submit_key(&opts, &pool.queue_strategy)?
     };
 
+    let state = submit_to_pool_entry(&entry, closure, key, priority).await?;
+    let handle = task_handle_value(&state.borrow());
+    Ok(handle)
+}
+
+/// Resolve a registered pool by name (or id) without producing a snapshot.
+/// Returns `None` when no pool matches. Used by the trigger dispatcher's
+/// SpawnToPool handler (#1889) so it can route inbound events into named
+/// pools without going through the Harn-level builtin surface.
+fn lookup_pool_by_name_or_id(name_or_id: &str) -> Option<Rc<RefCell<PoolEntry>>> {
+    let id = POOL_NAMES
+        .with(|names| names.borrow().get(name_or_id).cloned())
+        .or_else(|| {
+            POOLS.with(|pools| {
+                pools
+                    .borrow()
+                    .contains_key(name_or_id)
+                    .then(|| name_or_id.to_string())
+            })
+        })?;
+    POOLS.with(|pools| pools.borrow().get(&id).cloned())
+}
+
+/// Public submission outcome returned by [`submit_closure_to_named_pool`].
+/// The dispatcher inspects this to distinguish accepted-and-running tasks
+/// from accepted-but-dropped (drop_newest) tasks so it can emit the right
+/// audit and dispatch outcome.
+pub struct PoolSubmitOutcome {
+    /// Stable pool id (e.g. `pool_018f...`). Pair with `task_id` to build a
+    /// `pool_wait` handle on the Harn side.
+    pub pool_id: String,
+    /// Human-friendly pool name (i.e. the registration argument).
+    pub pool_name: String,
+    /// Assigned task id; also stable across the lifetime of the pool.
+    pub task_id: String,
+    /// Status the task is in once `submit_closure_to_named_pool` returns:
+    /// `"queued"`, `"running"`, or `"rejected"` (for the `drop_newest` case
+    /// when the newly-submitted task is the one that gets evicted).
+    pub status: &'static str,
+    /// Set when `status == "rejected"` so the dispatcher can surface the
+    /// pool's policy-driven drop reason in audit + action graph metadata.
+    pub rejection_reason: Option<String>,
+}
+
+/// Submit a closure to a named pool from a non-Harn caller (e.g. the trigger
+/// dispatcher). Honors the pool's queue strategy + backpressure policy in the
+/// same way as `pool.submit` from Harn code. Returns an error when the pool
+/// does not exist or the policy fails the submitter (fail_fast /
+/// fail_submitter); awaits when the policy blocks the submitter.
+pub async fn submit_closure_to_named_pool(
+    pool_name: &str,
+    closure: Rc<VmClosure>,
+    priority: i64,
+    key: Option<String>,
+) -> Result<PoolSubmitOutcome, VmError> {
+    let entry = lookup_pool_by_name_or_id(pool_name).ok_or_else(|| {
+        VmError::Runtime(format!(
+            "pool: pool '{pool_name}' not found; create it with pool_create first"
+        ))
+    })?;
+    let state = submit_to_pool_entry(&entry, closure, key, priority).await?;
+    let task = state.borrow();
+    Ok(PoolSubmitOutcome {
+        pool_id: task.pool_id.clone(),
+        pool_name: task.pool_name.clone(),
+        task_id: task.id.clone(),
+        status: task.status.as_str(),
+        rejection_reason: task.rejection_reason.clone(),
+    })
+}
+
+/// Shared inner submission loop used by both `pool.submit` (Harn builtin)
+/// and `submit_closure_to_named_pool` (dispatcher). Honors the pool's
+/// backpressure policy: blocks on `BlockSubmitter`, drops oldest/newest in
+/// the corresponding policies, and fails on `FailFast`/`FailSubmitter`.
+async fn submit_to_pool_entry(
+    entry: &Rc<RefCell<PoolEntry>>,
+    closure: Rc<VmClosure>,
+    key: Option<String>,
+    priority: i64,
+) -> Result<Rc<RefCell<TaskState>>, VmError> {
     loop {
         let attempt = {
             let mut pool = entry.borrow_mut();
@@ -833,9 +914,8 @@ async fn pool_submit_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
                 for audit in audits {
                     emit_pool_drop(audit).await;
                 }
-                dispatch_ready(&entry);
-                let handle = task_handle_value(&task.borrow());
-                return Ok(handle);
+                dispatch_ready(entry);
+                return Ok(task);
             }
             SubmitAttempt::Wait(receiver) => {
                 let _ = receiver.await;

--- a/crates/harn-vm/src/stdlib/triggers_stdlib.rs
+++ b/crates/harn-vm/src/stdlib/triggers_stdlib.rs
@@ -1802,8 +1802,99 @@ fn parse_handler_value(
                 "{builtin}: `{field_name}` string must use `a2a://` or `worker://` URI syntax"
             )))
         }
+        VmValue::Dict(map) => parse_handler_dict(map, builtin, field_name),
         other => Err(VmError::Runtime(format!(
-            "{builtin}: `{field_name}` must be a closure or handler URI string, got {}",
+            "{builtin}: `{field_name}` must be a closure, handler URI string, or handler-variant dict, got {}",
+            other.type_name()
+        ))),
+    }
+}
+
+/// Parse handler-variant dicts. Today only `SpawnToPool` (#1889) takes this
+/// shape; future variants (e.g. `ReminderInject` from #1876) plug in here so
+/// the trigger DSL keeps a single uniform `handler:` syntax.
+fn parse_handler_dict(
+    map: &BTreeMap<String, VmValue>,
+    builtin: &str,
+    field_name: &str,
+) -> Result<(TriggerHandlerSpec, serde_json::Value), VmError> {
+    let kind = map
+        .get("kind")
+        .or_else(|| map.get("_kind"))
+        .map(VmValue::display)
+        .filter(|name| !name.is_empty())
+        .ok_or_else(|| {
+            VmError::Runtime(format!(
+                "{builtin}: `{field_name}` handler dict missing `kind`"
+            ))
+        })?;
+    match kind.as_str() {
+        "spawn_to_pool" => {
+            let pool = map
+                .get("pool")
+                .map(VmValue::display)
+                .filter(|name| !name.is_empty())
+                .ok_or_else(|| {
+                    VmError::Runtime(format!(
+                        "{builtin}: SpawnToPool handler requires `pool` (string)"
+                    ))
+                })?;
+            let priority_from = optional_path_string(map, "priority_from", "SpawnToPool")?;
+            let key_from = optional_path_string(map, "key_from", "SpawnToPool")?;
+            let task_factory = map
+                .get("task_factory")
+                .ok_or_else(|| {
+                    VmError::Runtime(format!(
+                        "{builtin}: SpawnToPool handler requires `task_factory` closure"
+                    ))
+                })
+                .and_then(|value| match value {
+                    VmValue::Closure(closure) => Ok(closure.clone()),
+                    other => Err(VmError::Runtime(format!(
+                        "{builtin}: SpawnToPool.task_factory must be a closure, got {}",
+                        other.type_name()
+                    ))),
+                })?;
+            let descriptor = serde_json::json!({
+                "kind": "spawn_to_pool",
+                "pool": pool,
+                "priority_from": priority_from,
+                "key_from": key_from,
+                "task_factory": task_factory.func.name.clone(),
+            });
+            Ok((
+                TriggerHandlerSpec::SpawnToPool {
+                    pool,
+                    priority_from,
+                    key_from,
+                    task_factory,
+                },
+                descriptor,
+            ))
+        }
+        other => Err(VmError::Runtime(format!(
+            "{builtin}: unsupported handler variant '{other}'; expected 'spawn_to_pool'"
+        ))),
+    }
+}
+
+fn optional_path_string(
+    map: &BTreeMap<String, VmValue>,
+    field: &str,
+    variant: &str,
+) -> Result<Option<String>, VmError> {
+    match map.get(field) {
+        None | Some(VmValue::Nil) => Ok(None),
+        Some(VmValue::String(text)) => {
+            let trimmed = text.trim();
+            if trimmed.is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(trimmed.to_string()))
+            }
+        }
+        Some(other) => Err(VmError::Runtime(format!(
+            "{variant}: `{field}` must be a string path or nil, got {}",
             other.type_name()
         ))),
     }

--- a/crates/harn-vm/src/triggers/dispatcher/action_graph.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/action_graph.rs
@@ -71,6 +71,14 @@ pub(super) fn dispatch_success_outcome(
         DispatchUri::A2a { .. } => "completed",
         DispatchUri::Local { .. } => "success",
         DispatchUri::AutoResume { .. } => "resumed",
+        // SpawnToPool reports the same accept/reject distinction we record
+        // on the dispatch metadata so observers (run viewer, audit log) can
+        // tell the difference between "queued behind the cap" and "dropped
+        // by drop_newest" without reparsing the result blob (#1889).
+        DispatchUri::SpawnToPool { .. } => match result.get("status").and_then(|v| v.as_str()) {
+            Some("rejected") => "pool_rejected",
+            _ => "pool_enqueued",
+        },
     }
 }
 
@@ -224,6 +232,20 @@ pub(super) fn dispatch_node_metadata(
     if let DispatchUri::Persona { name } = route {
         metadata.insert("persona".to_string(), serde_json::json!(name));
     }
+    if let DispatchUri::SpawnToPool {
+        pool,
+        priority_from,
+        key_from,
+    } = route
+    {
+        metadata.insert("pool".to_string(), serde_json::json!(pool));
+        if let Some(path) = priority_from {
+            metadata.insert("priority_from".to_string(), serde_json::json!(path));
+        }
+        if let Some(path) = key_from {
+            metadata.insert("key_from".to_string(), serde_json::json!(path));
+        }
+    }
     metadata
 }
 
@@ -269,6 +291,17 @@ pub(super) fn dispatch_success_metadata(
             }
             if let Some(status) = result.get("status").and_then(|value| value.as_str()) {
                 metadata.insert("status".to_string(), serde_json::json!(status));
+            }
+        }
+        DispatchUri::SpawnToPool { pool, .. } => {
+            metadata.insert("pool".to_string(), serde_json::json!(pool));
+            for field in ["task_id", "status", "rejection_reason", "key"] {
+                if let Some(value) = result.get(field).cloned() {
+                    metadata.insert(field.to_string(), value);
+                }
+            }
+            if let Some(priority) = result.get("priority").cloned() {
+                metadata.insert("priority".to_string(), priority);
             }
         }
         DispatchUri::Local { .. } | DispatchUri::AutoResume { .. } => {}

--- a/crates/harn-vm/src/triggers/dispatcher/mod.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/mod.rs
@@ -89,9 +89,10 @@ use types::{
 use util::{
     accepted_at_ms, binding_key_from_parts, build_batched_event, cancelled_dispatch_outcome,
     current_unix_ms, decrement_in_flight, decrement_retry_queue_depth, dispatch_cancel_requested,
-    dispatch_result_status, duration_between_ms, event_headers, json_value_to_gate,
-    maybe_fail_before_outbox, now_rfc3339, now_unix_ms, queue_appended_at_ms, recv_cancel,
-    sleep_or_cancel_or_request, tenant_id, topic_for_event, unix_ms, worker_queue_priority,
+    dispatch_result_status, duration_between_ms, event_headers, extract_event_path,
+    extracted_key_value, extracted_priority_value, json_value_to_gate, maybe_fail_before_outbox,
+    now_rfc3339, now_unix_ms, queue_appended_at_ms, recv_cancel, sleep_or_cancel_or_request,
+    tenant_id, topic_for_event, unix_ms, worker_queue_priority,
 };
 
 pub const TRIGGER_ACCEPTED_AT_MS_HEADER: &str = "harn_trigger_accepted_at_ms";
@@ -2144,7 +2145,147 @@ impl Dispatcher {
                     metadata,
                 })
             }
+            DispatchUri::SpawnToPool {
+                pool,
+                priority_from,
+                key_from,
+            } => {
+                let TriggerHandlerSpec::SpawnToPool { task_factory, .. } = &binding.handler else {
+                    return Err(DispatchError::Local(format!(
+                        "trigger '{}' resolved to a pool dispatch URI but does not carry a spawn_to_pool handler",
+                        binding.id.as_str()
+                    )));
+                };
+                self.dispatch_spawn_to_pool(
+                    binding,
+                    route,
+                    event,
+                    pool,
+                    priority_from.as_deref(),
+                    key_from.as_deref(),
+                    task_factory,
+                    autonomy_tier,
+                    wait_lease,
+                    cancel_rx,
+                )
+                .await
+            }
         }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn dispatch_spawn_to_pool(
+        &self,
+        binding: &TriggerBinding,
+        route: &DispatchUri,
+        event: &TriggerEvent,
+        pool: &str,
+        priority_from: Option<&str>,
+        key_from: Option<&str>,
+        task_factory: &crate::value::VmClosure,
+        autonomy_tier: AutonomyTier,
+        wait_lease: Option<DispatchWaitLease>,
+        cancel_rx: &mut broadcast::Receiver<()>,
+    ) -> Result<DispatchCallResult, DispatchError> {
+        // Step 1: invoke task_factory(event) via the standard VM invocation
+        // path so policy intersection, cancellation, and dispatch context
+        // bookkeeping all work the same way as a Local handler.
+        let factory_value = self
+            .invoke_vm_callable(
+                task_factory,
+                &binding.binding_key(),
+                event,
+                None,
+                binding.id.as_str(),
+                &format!("{}.{}", event.provider.as_str(), event.kind),
+                autonomy_tier,
+                wait_lease,
+                cancel_rx,
+            )
+            .await?;
+
+        // Step 2: the factory must return a closure. The dispatcher submits
+        // that closure to the named pool; the pool runs it under its own
+        // queue strategy + backpressure policy.
+        let closure = match factory_value {
+            crate::value::VmValue::Closure(closure) => closure,
+            other => {
+                return Err(DispatchError::Local(format!(
+                    "trigger '{}': SpawnToPool task_factory must return a closure, got {}",
+                    binding.id.as_str(),
+                    other.type_name()
+                )));
+            }
+        };
+
+        // Step 3: derive priority + fair-queue key from the event payload
+        // using simple dotted-path extractors. Missing/non-coercible paths
+        // fall back to defaults (priority 0, null key) instead of erroring;
+        // that matches how the upstream pool builtin treats omitted options
+        // and keeps a misconfigured path from blocking the whole pipeline.
+        let event_json =
+            serde_json::to_value(event).map_err(|error| DispatchError::Serde(error.to_string()))?;
+        let priority = priority_from
+            .and_then(|path| extract_event_path(&event_json, path))
+            .and_then(extracted_priority_value)
+            .unwrap_or(0);
+        let key = key_from
+            .and_then(|path| extract_event_path(&event_json, path))
+            .and_then(extracted_key_value);
+
+        // Step 4: submit to the pool. Pool errors (pool not found,
+        // fail_fast/fail_submitter rejection) bubble up as DispatchError so
+        // the surrounding retry/DLQ machinery applies the configured policy.
+        // The dispatcher installs its own child VM on the async-builtin
+        // stack so the pool can clone an execution context when (or after)
+        // the task is scheduled to run.
+        let child_vm = self.base_vm.child_vm();
+        let _vm_guard = crate::vm::install_async_builtin_child_vm(child_vm);
+        let outcome =
+            crate::stdlib::pool::submit_closure_to_named_pool(pool, closure, priority, key.clone())
+                .await
+                .map_err(|error| DispatchError::Local(error.to_string()))?;
+
+        let mut metadata = route.dispatch_boundary_metadata();
+        metadata.insert("pool".to_string(), serde_json::json!(pool));
+        metadata.insert("priority".to_string(), serde_json::json!(priority));
+        if let Some(key) = &key {
+            metadata.insert("key".to_string(), serde_json::json!(key));
+        }
+
+        let crate::stdlib::pool::PoolSubmitOutcome {
+            pool_id,
+            pool_name,
+            task_id,
+            status,
+            rejection_reason,
+        } = outcome;
+        metadata.insert("pool_id".to_string(), serde_json::json!(pool_id));
+        metadata.insert("pool_name".to_string(), serde_json::json!(pool_name));
+        metadata.insert("task_id".to_string(), serde_json::json!(task_id));
+        metadata.insert("status".to_string(), serde_json::json!(status));
+
+        // Output dict doubles as a pool_task handle (`_type: "pool_task"`)
+        // so Harn handlers can `pool_wait(dispatch.result)` directly — the
+        // same shape `__pool_submit` returns from a pool.submit() call.
+        let mut output = serde_json::Map::new();
+        output.insert("_type".to_string(), serde_json::json!("pool_task"));
+        output.insert("id".to_string(), serde_json::json!(task_id));
+        output.insert("pool_id".to_string(), serde_json::json!(pool_id));
+        output.insert("pool".to_string(), serde_json::json!(pool_name));
+        output.insert("status".to_string(), serde_json::json!(status));
+        output.insert("priority".to_string(), serde_json::json!(priority));
+        if let Some(key) = &key {
+            output.insert("key".to_string(), serde_json::json!(key));
+        }
+        if let Some(reason) = rejection_reason {
+            output.insert("rejection_reason".to_string(), serde_json::json!(reason));
+            metadata.insert("rejection_reason".to_string(), serde_json::json!(reason));
+        }
+        Ok(DispatchCallResult {
+            output: serde_json::Value::Object(output),
+            metadata,
+        })
     }
 
     async fn apply_flow_control(

--- a/crates/harn-vm/src/triggers/dispatcher/uri.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/uri.rs
@@ -39,6 +39,15 @@ pub enum DispatchUri {
     AutoResume {
         worker_id: String,
     },
+    /// Dispatcher composes triggers with named agent pools (#1889). The
+    /// closure handed to the pool is built per-event by the binding's
+    /// `task_factory`; the descriptor here carries only routing metadata so
+    /// the URI stays serializable and comparable.
+    SpawnToPool {
+        pool: String,
+        priority_from: Option<String>,
+        key_from: Option<String>,
+    },
 }
 
 impl DispatchUri {
@@ -78,6 +87,18 @@ impl DispatchUri {
                 name: name.to_string(),
             });
         }
+        if let Some(pool) = raw.strip_prefix("pool://") {
+            if pool.is_empty() {
+                return Err(DispatchUriError::MissingTarget {
+                    scheme: "pool".to_string(),
+                });
+            }
+            return Ok(Self::SpawnToPool {
+                pool: pool.to_string(),
+                priority_from: None,
+                key_from: None,
+            });
+        }
         if let Some((scheme, _)) = raw.split_once("://") {
             return Err(DispatchUriError::UnknownScheme(scheme.to_string()));
         }
@@ -93,6 +114,7 @@ impl DispatchUri {
             Self::Worker { .. } => "worker",
             Self::Persona { .. } => "persona",
             Self::AutoResume { .. } => "auto_resume",
+            Self::SpawnToPool { .. } => "spawn_to_pool",
         }
     }
 
@@ -103,6 +125,7 @@ impl DispatchUri {
             Self::Worker { queue } => format!("worker://{queue}"),
             Self::Persona { name } => format!("persona://{name}"),
             Self::AutoResume { worker_id } => format!("auto_resume://{worker_id}"),
+            Self::SpawnToPool { pool, .. } => format!("pool://{pool}"),
         }
     }
 
@@ -113,6 +136,7 @@ impl DispatchUri {
             Self::Worker { .. } => "event_log_worker_queue",
             Self::Persona { .. } => "persona_runtime",
             Self::AutoResume { .. } => "local_process",
+            Self::SpawnToPool { .. } => "local_process",
         }
     }
 
@@ -123,6 +147,7 @@ impl DispatchUri {
             Self::Worker { .. } => "queued",
             Self::Persona { .. } => "managed_persona",
             Self::AutoResume { .. } => "in_process",
+            Self::SpawnToPool { .. } => "pool_queued",
         }
     }
 
@@ -174,6 +199,16 @@ impl From<&TriggerHandlerSpec> for DispatchUri {
             },
             TriggerHandlerSpec::AutoResume { worker_id } => Self::AutoResume {
                 worker_id: worker_id.clone(),
+            },
+            TriggerHandlerSpec::SpawnToPool {
+                pool,
+                priority_from,
+                key_from,
+                ..
+            } => Self::SpawnToPool {
+                pool: pool.clone(),
+                priority_from: priority_from.clone(),
+                key_from: key_from.clone(),
             },
         }
     }

--- a/crates/harn-vm/src/triggers/dispatcher/util.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/util.rs
@@ -393,6 +393,68 @@ pub(super) async fn recv_cancel(cancel_rx: &mut broadcast::Receiver<()>) {
     let _ = cancel_rx.recv().await;
 }
 
+/// Resolve a simple dotted JSON path (e.g. `"tenant_id"`,
+/// `"provider_payload.urgency"`, `"headers.x_priority"`) against the
+/// serialized event. Returns `None` when any segment is missing or when an
+/// array index is out of range. Used by the SpawnToPool trigger handler
+/// (#1889) to pluck priority + fair-queue key from event payloads.
+///
+/// Numeric segments index into arrays; everything else looks up object
+/// fields. Bracketed forms (`payload[0]`) are not supported; users that need
+/// richer extraction should pre-shape the event in `task_factory`.
+pub(super) fn extract_event_path(
+    value: &serde_json::Value,
+    path: &str,
+) -> Option<serde_json::Value> {
+    let trimmed = path.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let mut current = value;
+    for segment in trimmed.split('.') {
+        if segment.is_empty() {
+            return None;
+        }
+        match current {
+            serde_json::Value::Object(map) => {
+                current = map.get(segment)?;
+            }
+            serde_json::Value::Array(items) => {
+                let index = segment.parse::<usize>().ok()?;
+                current = items.get(index)?;
+            }
+            _ => return None,
+        }
+    }
+    Some(current.clone())
+}
+
+/// Coerce an extracted JSON value into an i64 priority. Floats truncate
+/// (matching the i64 cast on the Harn side), strings parse, booleans map to
+/// 0/1, and null/objects/arrays return `None` so the dispatcher falls back
+/// to the default priority instead of failing the dispatch.
+pub(super) fn extracted_priority_value(value: serde_json::Value) -> Option<i64> {
+    match value {
+        serde_json::Value::Number(n) => n.as_i64().or_else(|| n.as_f64().map(|f| f as i64)),
+        serde_json::Value::String(s) => s.trim().parse::<i64>().ok(),
+        serde_json::Value::Bool(b) => Some(if b { 1 } else { 0 }),
+        _ => None,
+    }
+}
+
+/// Coerce an extracted JSON value into a fair-queue key string. Scalars
+/// stringify; null and complex values return `None` so the pool sees no key
+/// (which round-robin treats as the default bucket).
+pub(super) fn extracted_key_value(value: serde_json::Value) -> Option<String> {
+    match value {
+        serde_json::Value::String(s) => Some(s),
+        serde_json::Value::Number(n) => Some(n.to_string()),
+        serde_json::Value::Bool(b) => Some(b.to_string()),
+        serde_json::Value::Null => None,
+        other => Some(other.to_string()),
+    }
+}
+
 pub async fn append_dispatch_cancel_request(
     event_log: &Arc<AnyEventLog>,
     request: &DispatchCancelRequest,

--- a/crates/harn-vm/src/triggers/registry.rs
+++ b/crates/harn-vm/src/triggers/registry.rs
@@ -154,6 +154,16 @@ pub enum TriggerHandlerSpec {
     AutoResume {
         worker_id: String,
     },
+    /// Composes triggers (#1870) with named agent pools (#1883). On match,
+    /// the dispatcher resolves `pool` by name, invokes `task_factory(event)`
+    /// to build the per-event closure, and submits it to the pool with the
+    /// pool's queue strategy + backpressure policy applied (PL-04 / #1889).
+    SpawnToPool {
+        pool: String,
+        priority_from: Option<String>,
+        key_from: Option<String>,
+        task_factory: Rc<VmClosure>,
+    },
 }
 
 impl std::fmt::Debug for TriggerHandlerSpec {
@@ -177,6 +187,17 @@ impl std::fmt::Debug for TriggerHandlerSpec {
                 .debug_struct("AutoResume")
                 .field("worker_id", worker_id)
                 .finish(),
+            Self::SpawnToPool {
+                pool,
+                priority_from,
+                key_from,
+                ..
+            } => f
+                .debug_struct("SpawnToPool")
+                .field("pool", pool)
+                .field("priority_from", priority_from)
+                .field("key_from", key_from)
+                .finish(),
         }
     }
 }
@@ -189,6 +210,7 @@ impl TriggerHandlerSpec {
             Self::Worker { .. } => "worker",
             Self::Persona { .. } => "persona",
             Self::AutoResume { .. } => "auto_resume",
+            Self::SpawnToPool { .. } => "spawn_to_pool",
         }
     }
 }

--- a/docs/llm/harn-triggers-quickref.md
+++ b/docs/llm/harn-triggers-quickref.md
@@ -45,6 +45,31 @@ Key fields: `id`, `kind`, `provider`, `handler`, `path` or `match.path`, `match.
 
 Audit a project before deploy with `harn routes <root> --json`; it reports each declarative trigger's route path, handler module, budgets, inferred host capabilities, vendor-lock disclosure, and prompt/template overhead without executing handler code.
 
+## Handler variants
+
+`handler:` accepts a closure (in-process), an `a2a://` or `worker://` URI string, or a handler-variant dict. The dict form covers compositions that need more than a single callable; today only `SpawnToPool` ships, more variants will plug into the same syntax over time.
+
+```harn
+import { SpawnToPool } from "std/triggers"
+import { pool_create } from "std/lifecycle/pool"
+
+pool_create({name: "pr-review-pool", max_concurrent: 4})
+
+trigger_register({
+  kind: "issue.opened",
+  provider: "github",
+  handler: SpawnToPool({
+    pool: "pr-review-pool",
+    priority_from: "headers.priority",     // optional dotted JSON path
+    key_from: "tenant_id",                 // optional dotted JSON path
+    task_factory: { event -> { -> review(event) } },
+  }),
+  match: {events: ["issue.opened"]},
+})
+```
+
+The dispatcher invokes `task_factory(event)` per match, extracts priority + fair-queue key from the event payload (missing paths fall back to default priority 0 / null key), and submits the resulting closure to the named pool under its queue strategy + backpressure policy. Pool rejections (`drop_newest`, etc.) reuse the `lifecycle.pool.audit` channel that direct `pool.submit` calls emit on. The dispatch result is shaped as a `pool_task` handle so handlers can call `pool_wait(dispatch.result)` directly.
+
 ## Provider catalog
 
 This table is generated from `std/triggers::list_providers()` / `ProviderCatalog` metadata.


### PR DESCRIPTION
## Summary

- Adds `TriggerHandlerSpec::SpawnToPool` (PL-04 from epic #1883), composing triggers (#1870) with named agent pools so high-volume event sources route into a bounded pool instead of spawning fresh workers per event.
- New `SpawnToPool({pool, priority_from?, key_from?, task_factory})` Harn-side constructor in `std/triggers`. The dispatcher invokes `task_factory(event)` per matched event, extracts priority + fair-queue key via simple dotted JSON paths into the event payload (missing/non-coercible paths fall back to default priority 0 / null key rather than failing dispatch), and submits the resulting closure to the named pool under its queue strategy + backpressure policy.
- Pool rejections (`drop_newest`, etc.) reuse the existing `lifecycle.pool.audit` channel that direct `pool.submit` calls emit on — no parallel audit path.
- The dispatch result is shaped as a `pool_task` handle (`_type: "pool_task"`) so handlers can call `pool_wait(dispatch.result)` directly.

## Scaffolding added for CH-05 (#1876)

CH-05 (the handler-variant infrastructure ticket) is still open, so this PR adds the minimal scaffolding SpawnToPool needs:

- `parse_handler_value` now accepts handler-variant dicts (`{kind: "spawn_to_pool", ...}`) alongside the existing closure / URI-string forms. A new `parse_handler_dict` helper dispatches on `kind`; ReminderInject and future variants plug in here without re-touching the trigger DSL.
- `DispatchUri::SpawnToPool` and `TriggerHandlerSpec::SpawnToPool` ride the same `pool://<name>` URI scheme; trust boundary is `local_process`, execution location is `pool_queued`.
- A `pub(crate)` API in `crates/harn-vm/src/stdlib/pool.rs` (`submit_closure_to_named_pool`) lets non-Harn callers (i.e. the dispatcher) submit to the registered pool while honoring the same queue strategy + backpressure as `pool.submit`. The pool's submit loop was refactored into a shared `submit_to_pool_entry` helper so the builtin and the dispatcher exercise byte-identical semantics.

## Test plan

- [x] `cargo run --bin harn -- test conformance --filter trigger_spawn_to_pool` (3/3 new fixtures pass: caps_concurrency, drop_newest_emits_audit, extracts_priority_and_key)
- [x] `cargo run --bin harn -- test conformance --filter pool` (9/9 pass — no regression in PL-01/02/03)
- [x] `cargo run --bin harn -- test conformance --filter trigger` (41/41 pass)
- [x] `make test` (4399 tests pass, 2 skipped)
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `make lint-harn`, `make fmt-harn`, `make check-docs-snippets`, `make lint-test-patterns`

Closes #1889. Part of epic #1883.

🤖 Generated with [Claude Code](https://claude.com/claude-code)