### PR TITLE
Fix reminder_compact_expire_at_pre_compact fixture cursor + filter

### DIFF
--- a/conformance/tests/reminder_compact_expire_at_pre_compact.harn
+++ b/conformance/tests/reminder_compact_expire_at_pre_compact.harn
@@ -1,6 +1,5 @@
 pipeline main() {
   let topic = "transcript.reminder.lifecycle"
-  let cursor = event_log.latest(topic)
   let base = transcript_from_messages(
     [
       {role: "user", content: "one"},
@@ -14,9 +13,11 @@ pipeline main() {
     base,
     {body: "expire at compaction boundary", dedupe_key: "ttl", ttl_turns: 1, preserve_on_compact: true},
   ).transcript
+  let cursor = event_log.latest(topic)
   let compacted = transcript_compact(with_reminder, {strategy: "truncate", keep_last: 1, target_tokens: 1})
   let reminders = transcript_events_by_kind(compacted, "system_reminder")
-  let stream = event_log.subscribe({topic: topic, from_cursor: cursor})
+  let stream = event_log
+    .subscribe({topic: topic, from_cursor: cursor, kind_prefix: "transcript.reminder.expired"})
   let logged = stream.next().value
   println(len(reminders))
   println(logged.kind)


### PR DESCRIPTION
## Summary

Fix-forward for a fixture introduced in R-10 (#1991) that was reporting a pre-existing failure on `main`.

The fixture captured the event-log cursor BEFORE `inject_reminder`, so the first `stream.next()` returned the injected event (`transcript.reminder.injected`) instead of the expired one (`transcript.reminder.expired`).

The fix:
1. Move the cursor capture to after the inject so it begins after the injection events.
2. Add `kind_prefix: "transcript.reminder.expired"` so the stream only surfaces the event the assertions care about.

The underlying behavior (TTL ≤ 1 reminder dropped at the pre-compact boundary, with `preserve_on_compact: true` honored only for non-expired reminders) is correct. This was purely a test harness issue.

## Test plan

- [x] `cargo run --bin harn -- run conformance/tests/reminder_compact_expire_at_pre_compact.harn` returns the expected output.
- [x] `cargo run --bin harn -- test conformance --filter reminder_compact` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)