### PR TITLE
Add OAuth token redaction (#1907)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,23 @@ condensed series summaries instead of full per-patch history.
   Conformance coverage:
   `conformance/tests/triggers/trigger_source_channel_{basic,session,wildcard,filter,fan_out}.harn`.
   Part of epic #1870.
+- **OAuth token redaction in transcripts and audit (#1907).** Persisted
+  transcripts, audit receipts, OTel span attributes, and system reminders
+  now route through a named token-pattern catalog so a leaked OAuth bearer,
+  GitHub PAT (classic or fine-grained), Slack `xox*`, AWS `AKIA…`, Stripe
+  key, OpenAI `sk-…`, JWT, GitLab `glpat-…`, or npm `npm_…` token is
+  scrubbed to `<redacted:<pattern>:<len>>` on every display sink. The
+  underlying tool/host call still receives the raw token — redaction is
+  display-only. Each redaction synchronously records an `HARN-OAU-001`
+  audit entry in a per-thread ring drainable via the new
+  `std/oauth/redaction` stdlib (`register_pattern`, `redact`,
+  `default_patterns`, `custom_patterns`, `clear_custom_patterns`,
+  `drain_audit`). When a multi-threaded Tokio runtime is available the
+  default sink also appends to the `audit.token_redaction` event-log
+  topic. Inputs over 256 KiB short-circuit to a passthrough as defense
+  against catastrophic regex behavior. Conformance:
+  `conformance/tests/stdlib/token_redaction_{default_patterns,custom_pattern,tool_passthrough}.harn`.
+  Part of epic #1885 (OAuth stdlib).
 - **Tool-hook mode callback side effects (#1896).** The three shipped
   `tool_hooks_mode_*` callbacks (`rewrite_with_audit`,
   `deny_with_explanation`, `passthrough_only_audit`) now emit lifecycle

--- a/conformance/tests/stdlib/token_redaction_custom_pattern.expected
+++ b/conformance/tests/stdlib/token_redaction_custom_pattern.expected
@@ -1,0 +1,1 @@
+[harn] token_redaction custom ok

--- a/conformance/tests/stdlib/token_redaction_custom_pattern.harn
+++ b/conformance/tests/stdlib/token_redaction_custom_pattern.harn
@@ -1,0 +1,42 @@
+// std/oauth/redaction (OA-06): register a per-tenant token pattern,
+// confirm it is introspectable, redacts on the next persistence sink
+// pass, and can be cleared so subsequent scans do not match.
+import {
+  clear_custom_patterns,
+  custom_patterns,
+  redact,
+  register_pattern,
+} from "std/oauth/redaction"
+
+pipeline test(task) {
+  // Start from a clean thread — prior conformance cases may have
+  // installed their own patterns.
+  clear_custom_patterns()
+  if len(custom_patterns()) != 0 {
+    throw "custom_patterns should start empty: " + to_string(custom_patterns())
+  }
+  register_pattern("acme_api_key", "\\bACME-[A-Z0-9]{12}\\b")
+  let names = custom_patterns()
+  if !contains(to_string(names), "acme_api_key") {
+    throw "expected acme_api_key in custom_patterns, got: " + to_string(names)
+  }
+  // Redaction wraps the match with the named placeholder.
+  let scrubbed = redact("token ACME-ABCDEF123456 tail")
+  if contains(scrubbed, "ACME-ABCDEF123456") {
+    throw "raw acme token leaked: " + scrubbed
+  }
+  if !contains(scrubbed, "<redacted:acme_api_key:") {
+    throw "expected named acme_api_key placeholder, got: " + scrubbed
+  }
+  // Clearing custom patterns drops the rule so a follow-up scan no
+  // longer recognizes the same input.
+  clear_custom_patterns()
+  if len(custom_patterns()) != 0 {
+    throw "custom patterns should be empty after clear: " + to_string(custom_patterns())
+  }
+  let after = redact("token ACME-ABCDEF123456 tail")
+  if !contains(after, "ACME-ABCDEF123456") {
+    throw "after clearing, ACME tokens should not be scrubbed: " + after
+  }
+  log("token_redaction custom ok")
+}

--- a/conformance/tests/stdlib/token_redaction_default_patterns.expected
+++ b/conformance/tests/stdlib/token_redaction_default_patterns.expected
@@ -1,0 +1,1 @@
+[harn] token_redaction defaults ok

--- a/conformance/tests/stdlib/token_redaction_default_patterns.harn
+++ b/conformance/tests/stdlib/token_redaction_default_patterns.harn
@@ -1,0 +1,72 @@
+// std/oauth/redaction (OA-06): default OAuth token catalog scrubs every
+// shipped provider into the `<redacted:<pattern>:<len>>` placeholder
+// without the raw token leaking through.
+import { default_patterns, redact } from "std/oauth/redaction"
+
+fn expect_redacted(label, input, expected_pattern, expected_raw_substring) {
+  let out = redact(input)
+  if contains(out, expected_raw_substring) {
+    throw label + ": raw token leaked into redacted output: " + out
+  }
+  let needle = "<redacted:" + expected_pattern + ":"
+  if !contains(out, needle) {
+    throw label + ": expected `" + needle + "` in output, got `" + out + "`"
+  }
+}
+
+pipeline test(task) {
+  // The catalog must include every default provider so audit
+  // consumers can rely on the names being stable across releases.
+  let catalog = default_patterns()
+  let expected_names = ["jwt", "github_token", "github_pat_fine", "slack_token", "aws_access_key", "bearer_token"]
+  for name in expected_names {
+    if !contains(to_string(catalog), name) {
+      throw "default catalog missing `" + name + "`: " + to_string(catalog)
+    }
+  }
+  // JWT: three base64url segments; the leading `eyJ` anchors the
+  // regex so unrelated dotted strings do not chew the placeholder.
+  expect_redacted(
+    "jwt",
+    "auth=eyJabcd1234.eyJefghPayload.signature_pad_extra now",
+    "jwt",
+    "eyJabcd1234.eyJefghPayload.signature_pad_extra",
+  )
+  // GitHub classic OAuth/app/installation token.
+  expect_redacted(
+    "github_token",
+    "header ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa trailer",
+    "github_token",
+    "ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  )
+  // GitHub fine-grained PAT.
+  expect_redacted(
+    "github_pat_fine",
+    "value github_pat_aaaaaaaaaaaaaaaaaaaaaa end",
+    "github_pat_fine",
+    "github_pat_aaaaaaaaaaaaaaaaaaaaaa",
+  )
+  // Slack token (any of `xox[bpsar]-...`).
+  expect_redacted(
+    "slack_token",
+    "slack=xoxb-1234567890-abcdefABC ok",
+    "slack_token",
+    "xoxb-1234567890-abcdefABC",
+  )
+  // AWS access key id.
+  expect_redacted(
+    "aws_access_key",
+    "creds AKIAABCDEFGHIJKLMNOP go",
+    "aws_access_key",
+    "AKIAABCDEFGHIJKLMNOP",
+  )
+  // `Authorization: Bearer <token>` header form. Using a non-prefixed
+  // opaque token here so no earlier provider-specific pattern wins.
+  expect_redacted(
+    "bearer_token",
+    "Authorization: Bearer abcdef123456_extra-pad",
+    "bearer_token",
+    "abcdef123456_extra-pad",
+  )
+  log("token_redaction defaults ok")
+}

--- a/conformance/tests/stdlib/token_redaction_tool_passthrough.expected
+++ b/conformance/tests/stdlib/token_redaction_tool_passthrough.expected
@@ -1,0 +1,1 @@
+[harn] token_redaction passthrough ok

--- a/conformance/tests/stdlib/token_redaction_tool_passthrough.harn
+++ b/conformance/tests/stdlib/token_redaction_tool_passthrough.harn
@@ -1,0 +1,62 @@
+// std/oauth/redaction (OA-06): redaction is display-only. The
+// underlying variable still holds the raw token so a downstream
+// tool/host call receives the real bytes, while the persisted
+// transcript or audit projection shows the named placeholder. Each
+// redaction is auditable as HARN-OAU-001.
+import { drain_audit, redact } from "std/oauth/redaction"
+
+pipeline test(task) {
+  // Drop any audit entries left by earlier conformance cases so we
+  // can attribute the entries appended below to this scan.
+  let _ = drain_audit()
+  // Synthesize a token at runtime so the file does not itself
+  // contain a string that secret scanners flag in code review.
+  let token = "ghp_" + "1234567890abcdefghijklmnopqrstuvwxyz"
+  let header = "Authorization: Bearer " + token
+  // The variable still carries the original bytes — a tool call
+  // forwarding `token` would see the real secret.
+  if !contains(header, token) {
+    throw "original token must remain in the in-memory variable"
+  }
+  if len(token) != 40 {
+    throw "raw token length should be 40, got " + to_string(len(token))
+  }
+  // The display projection (via `redact`) hides the secret behind
+  // the canonical `<redacted:<pattern>:<len>>` placeholder. The
+  // catalog runs default patterns in order, so a `Bearer ghp_…`
+  // string is attributed to whichever specific pattern fires first
+  // (typically `github_token` for `ghp_*` prefixes).
+  let display = redact(header)
+  if contains(display, token) {
+    throw "redacted display leaked the raw token: " + display
+  }
+  if !contains(display, "<redacted:") {
+    throw "expected named placeholder in display, got: " + display
+  }
+  // The OA-06 contract emits one HARN-OAU-001 audit entry per
+  // pattern that matched. At least one entry must reference a
+  // catalog pattern with the canonical diagnostic code.
+  let entries = drain_audit()
+  if len(entries) == 0 {
+    throw "expected at least one HARN-OAU-001 audit entry"
+  }
+  var found = false
+  for entry in entries {
+    if entry.code == "HARN-OAU-001" {
+      if entry.match_count <= 0 {
+        throw "audit entry must report a positive match_count, got " + to_string(entry.match_count)
+      }
+      if entry.bytes_redacted <= 0 {
+        throw "audit entry must report positive bytes_redacted, got " + to_string(entry.bytes_redacted)
+      }
+      if entry.pattern == "" {
+        throw "audit entry must name a pattern"
+      }
+      found = true
+    }
+  }
+  if !found {
+    throw "expected HARN-OAU-001 audit entry, got " + to_string(entries)
+  }
+  log("token_redaction passthrough ok")
+}

--- a/crates/harn-parser/src/builtin_signatures/signatures/stdlib.rs
+++ b/crates/harn-parser/src/builtin_signatures/signatures/stdlib.rs
@@ -220,6 +220,23 @@ pub(crate) const SIGNATURES: &[BuiltinSignature] = &[
         ],
         TY_NIL,
     ),
+    BuiltinSignature::simple("__token_redaction_clear_custom_patterns", &[], TY_NIL),
+    BuiltinSignature::simple("__token_redaction_custom_patterns", &[], TY_LIST),
+    BuiltinSignature::simple("__token_redaction_default_patterns", &[], TY_LIST),
+    BuiltinSignature::simple("__token_redaction_drain_audit", &[], TY_LIST),
+    BuiltinSignature::simple(
+        "__token_redaction_redact",
+        &[Param::new("text", TY_STRING)],
+        TY_STRING,
+    ),
+    BuiltinSignature::simple(
+        "__token_redaction_register_pattern",
+        &[
+            Param::new("name", TY_STRING),
+            Param::new("regex", TY_STRING),
+        ],
+        TY_NIL,
+    ),
     BuiltinSignature::simple(
         "__ansi_enabled",
         &[Param::optional("stream", TY_STRING)],

--- a/crates/harn-stdlib/src/lib.rs
+++ b/crates/harn-stdlib/src/lib.rs
@@ -490,6 +490,10 @@ pub const STDLIB_SOURCES: &[StdlibSource] = &[
         source: include_str!("stdlib/oauth/client.harn"),
     },
     StdlibSource {
+        module: "oauth/redaction",
+        source: include_str!("stdlib/oauth/redaction.harn"),
+    },
+    StdlibSource {
         module: "connectors/github",
         source: include_str!("stdlib/stdlib_connectors_github.harn"),
     },

--- a/crates/harn-stdlib/src/stdlib/oauth/redaction.harn
+++ b/crates/harn-stdlib/src/stdlib/oauth/redaction.harn
@@ -1,0 +1,138 @@
+/**
+ * std/oauth/redaction (OA-06) — OAuth token redaction.
+ *
+ * The Harn runtime ships with a catalog of high-confidence token
+ * patterns (JWT, GitHub PAT classic + fine-grained, Slack `xox*`,
+ * AWS `AKIA`, OpenAI `sk-`, Stripe `sk_live_`/`sk_test_`, GitLab
+ * `glpat-`, npm `npm_`, and `Authorization: Bearer ...` headers).
+ * Any of those that leak into a persisted transcript, an audit
+ * receipt, an OTel span attribute, or a system reminder are
+ * automatically replaced with `<redacted:<pattern>:<len>>` and an
+ * `HARN-OAU-001` audit event is recorded for compliance review.
+ *
+ * The original token still flows to the underlying tool — redaction
+ * is display-only.
+ *
+ * This module exposes the script-facing surface so callers can:
+ *
+ *   - inspect the default catalog,
+ *   - register a custom pattern for in-house token shapes,
+ *   - test whether a string would be redacted,
+ *   - drain the per-thread audit ring for compliance reporting.
+ *
+ * ## Custom patterns
+ *
+ *     import { register_pattern } from "std/oauth/redaction"
+ *     register_pattern("acme_api_key", "\\bACME-[A-Z0-9]{12}\\b")
+ *
+ * ## Inspection
+ *
+ *     import { default_patterns, custom_patterns, redact } from "std/oauth/redaction"
+ *     let names = default_patterns()
+ *     let display = redact("Bearer ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+ *
+ * ## Audit
+ *
+ *     import { drain_audit } from "std/oauth/redaction"
+ *     for entry in drain_audit() {
+ *       // entry.code == "HARN-OAU-001"
+ *       // entry.pattern, entry.match_count, entry.bytes_redacted
+ *     }
+ */
+/**
+ * Register a custom named redaction pattern on the current execution
+ * thread. Subsequent persistence sinks (transcripts, audit receipts,
+ * OTel spans, system reminders) will replace matches of the regex with
+ * `<redacted:<name>:<len>>`.
+ *
+ * - `name` must be non-empty and is used as the placeholder identifier
+ *   and the audit-event `pattern` field.
+ * - `regex_source` is a Rust-regex source string. Anchoring with `\b`
+ *   keeps matches from chewing unrelated identifiers.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: [invalid_argument]
+ * @api_stability: experimental
+ * @example: register_pattern("acme_api_key", "\\bACME-[A-Z0-9]{12}\\b")
+ */
+pub fn register_pattern(name, regex_source) {
+  return __token_redaction_register_pattern(name, regex_source)
+}
+
+/**
+ * Clear every custom pattern registered on the calling thread.
+ * Default patterns are unaffected.
+ *
+ * @effects: []
+ * @allocation: none
+ * @errors: []
+ * @api_stability: experimental
+ * @example: clear_custom_patterns()
+ */
+pub fn clear_custom_patterns() {
+  return __token_redaction_clear_custom_patterns()
+}
+
+/**
+ * Apply the active redaction policy to a string and return the
+ * scrubbed form. Convenient for tests; production sinks invoke the
+ * policy automatically. Each pattern that matched is recorded in the
+ * per-thread audit ring as an `HARN-OAU-001` entry.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: redact("Authorization: Bearer abcdef1234567890")
+ */
+pub fn redact(text) {
+  return __token_redaction_redact(text)
+}
+
+/**
+ * Names of every default pattern in catalog order.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: stable
+ * @example: default_patterns()
+ */
+pub fn default_patterns() {
+  return __token_redaction_default_patterns()
+}
+
+/**
+ * Names of every custom pattern installed on the current thread.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: custom_patterns()
+ */
+pub fn custom_patterns() {
+  return __token_redaction_custom_patterns()
+}
+
+/**
+ * Drain every pending `HARN-OAU-001` audit entry recorded since the
+ * last drain on the calling thread. Each entry is a dict with
+ * `code`, `pattern`, `match_count`, and `bytes_redacted` fields.
+ *
+ * Audit entries are also forwarded to the live event-sink pipeline
+ * (Stderr/Otel/etc.) and, when a multi-threaded Tokio runtime is
+ * available, appended to the `audit.token_redaction` event-log
+ * topic. The synchronous drain returned here is the authoritative
+ * compliance contract — it works on every execution backend.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: drain_audit()
+ */
+pub fn drain_audit() {
+  return __token_redaction_drain_audit()
+}

--- a/crates/harn-vm/src/events.rs
+++ b/crates/harn-vm/src/events.rs
@@ -259,12 +259,21 @@ impl EventSink for OtelSink {
     fn emit_log(&self, event: &LogEvent) {
         use opentelemetry::trace::{Tracer, TracerProvider};
         let tracer = self.provider.tracer("harn");
+        // Apply the unified redaction policy to attribute values
+        // before they leave the process. The active policy includes
+        // the OAuth token catalog (HARN-OAU-001) so a Bearer header
+        // or provider token that snuck into a log message gets
+        // scrubbed before it lands at the OTel collector.
+        let policy = crate::redact::current_policy();
         // Log events are zero-duration spans — start and immediately drop.
         let _span = tracer
             .span_builder(format!("log.{}", event.category))
             .with_attributes(vec![
                 opentelemetry::KeyValue::new("level", format!("{:?}", event.level)),
-                opentelemetry::KeyValue::new("message", event.message.clone()),
+                opentelemetry::KeyValue::new(
+                    "message",
+                    policy.redact_string(&event.message).into_owned(),
+                ),
                 opentelemetry::KeyValue::new("category", event.category.clone()),
             ])
             .start(&tracer);
@@ -286,11 +295,16 @@ impl EventSink for OtelSink {
     fn emit_span_end(&self, span_id: u64, metadata: &BTreeMap<String, serde_json::Value>) {
         use opentelemetry::trace::Span;
         if let Some(mut span) = self.active_spans.borrow_mut().remove(&span_id) {
+            // OTel span attributes are the fourth sink covered by the
+            // OA-06 token-redaction policy (transcripts, audit
+            // receipts, OTel, and system reminders). Stringify the
+            // value, then route through the active redaction policy
+            // so a leaked Bearer token never reaches the collector.
+            let policy = crate::redact::current_policy();
             for (key, value) in metadata {
-                span.set_attribute(opentelemetry::KeyValue::new(
-                    key.clone(),
-                    format!("{value}"),
-                ));
+                let raw = format!("{value}");
+                let redacted = policy.redact_string(&raw).into_owned();
+                span.set_attribute(opentelemetry::KeyValue::new(key.clone(), redacted));
             }
             span.end();
         }

--- a/crates/harn-vm/src/redact/mod.rs
+++ b/crates/harn-vm/src/redact/mod.rs
@@ -39,7 +39,11 @@ use std::collections::{BTreeMap, BTreeSet};
 use serde_json::Value as JsonValue;
 use url::Url;
 
-pub use patterns::scan_secret_patterns;
+pub use patterns::{
+    clear_audit_ring, clear_custom_patterns, custom_pattern_names, default_pattern_names,
+    drain_audit_ring, install_audit_sink, register_custom_pattern, scan_secret_patterns, AuditSink,
+    NamedPattern, RedactionEvent, TOKEN_REDACTION_AUDIT_TOPIC, TOKEN_REDACTION_DIAGNOSTIC,
+};
 
 /// Placeholder string used everywhere a redacted value would otherwise
 /// appear. Kept as a single constant so portal CSS, downstream parsers,
@@ -439,11 +443,15 @@ pub fn pop_policy() {
     });
 }
 
-/// Drop all installed policies. Used by `reset_thread_local_state` so
-/// test runs that share a thread cannot leak policy overrides into
-/// each other.
+/// Drop all installed policies, custom token-redaction patterns, the
+/// audit sink, and the per-thread audit ring. Used by
+/// `reset_thread_local_state` so test runs that share a thread cannot
+/// leak policy overrides into each other.
 pub fn clear_policy_stack() {
     REDACTION_POLICY_STACK.with(|stack| stack.borrow_mut().clear());
+    patterns::clear_custom_patterns();
+    let _ = patterns::install_audit_sink(None);
+    patterns::clear_audit_ring();
 }
 
 /// Return the currently installed policy, falling back to
@@ -573,7 +581,13 @@ mod tests {
         assert_eq!(value["list"][0]["auth_token"], REDACTED_PLACEHOLDER);
         assert_eq!(value["list"][0]["name"], "alice");
         let free_form = value["free_form"].as_str().unwrap();
-        assert!(free_form.contains(REDACTED_PLACEHOLDER));
+        // Free-form pattern matches now produce the OA-06 named
+        // placeholder `<redacted:<pattern>:<len>>` so audit logs can
+        // attribute leaks to a specific provider.
+        assert!(
+            free_form.contains("<redacted:"),
+            "expected named placeholder, got: {free_form}"
+        );
         assert!(!free_form.contains("ghp_abcdefghijklmnopqrstuvwxyz0123456789ABCD"));
     }
 
@@ -595,7 +609,10 @@ mod tests {
         let input =
             "use sk-proj-abcdefghijklmnopqrstuvwxyz0123456789ABCD or AKIAABCDEFGHIJKLMNOP for now";
         let out = policy.redact_string(input);
-        assert!(out.contains(REDACTED_PLACEHOLDER));
+        // Each provider pattern emits its own `<redacted:<name>:<len>>`
+        // placeholder so audit logs can attribute the leak.
+        assert!(out.contains("<redacted:openai_key:"));
+        assert!(out.contains("<redacted:aws_access_key:"));
         assert!(!out.contains("AKIAABCDEFGHIJKLMNOP"));
         assert!(!out.contains("sk-proj-abcdefghijklmnopqrstuvwxyz0123456789ABCD"));
     }

--- a/crates/harn-vm/src/redact/patterns.rs
+++ b/crates/harn-vm/src/redact/patterns.rs
@@ -1,114 +1,490 @@
 //! Free-form string secret patterns reused for redaction.
 //!
-//! The [`crate::stdlib::secret_scan`] module defines the canonical set
-//! of high-confidence secret regexes that the `secret_scan` builtin
-//! reports to scripts. This module borrows that same set so a string
-//! that scanning would flag is also a string that redaction will
-//! scrub — there is one definition, not two.
+//! Each pattern is named so the replacement placeholder is
+//! `<redacted:<pattern_name>:<len>>` and audit events can attribute the
+//! redaction to a specific provider. The [`crate::stdlib::secret_scan`]
+//! module defines the canonical set of high-confidence secret regexes
+//! that the `secret_scan` builtin reports to scripts; this module
+//! borrows from that same set so a string that scanning would flag is
+//! also a string that redaction will scrub — there is one definition,
+//! not two.
+//!
+//! # Custom patterns
+//!
+//! Hosts and scripts can register additional named patterns through
+//! [`register_custom_pattern`]. Custom patterns live on a thread-local
+//! stack so test pollution stays contained and so a per-orchestrator
+//! override can be installed alongside the existing
+//! [`crate::redact::PolicyGuard`].
+//!
+//! # Audit
+//!
+//! Every redaction synchronously records a [`RedactionEvent`] in a
+//! per-thread ring drainable via [`drain_audit_ring`], and also fires
+//! an optional [`AuditSink`] callback. The default sink installed by
+//! the [`crate::stdlib::token_redaction`] stdlib forwards events to
+//! the live events pipeline and, on a multi-threaded Tokio runtime,
+//! to the `audit.token_redaction` event-log topic. Audit entries
+//! carry the diagnostic identifier `HARN-OAU-001` from the OA-06
+//! epic — they never include the raw token.
 
 use std::borrow::Cow;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
 use std::sync::LazyLock;
 
 use regex::Regex;
 
-struct Pattern {
-    /// Regex against the full input.
-    regex: Regex,
+/// Stable identifier emitted in audit logs for every token-redaction
+/// event. Part of the OA-06 epic's compliance contract.
+pub const TOKEN_REDACTION_DIAGNOSTIC: &str = "HARN-OAU-001";
+
+/// Event-log topic used for token-redaction audit events.
+pub const TOKEN_REDACTION_AUDIT_TOPIC: &str = "audit.token_redaction";
+
+/// Upper bound on input length scanned by the secret detector. Inputs
+/// above this size short-circuit to "no redaction" so a pathological
+/// caller cannot trigger catastrophic regex behavior on the persistence
+/// hot path. Persisted JSON payloads larger than this are already
+/// abnormal; the receipt/event-log layers already cap message sizes
+/// well below this in practice.
+const MAX_SCAN_INPUT_BYTES: usize = 256 * 1024;
+
+/// One redaction pattern with a stable display name.
+#[derive(Clone)]
+pub struct NamedPattern {
+    /// Short, kebab-case identifier (e.g. `"github_pat_classic"`).
+    /// Stable across versions — emitted in audit events and in the
+    /// `<redacted:name:len>` placeholder.
+    pub name: &'static str,
+    /// Compiled regex. Always anchored on `\b` or non-word boundaries
+    /// so it does not chew unrelated identifiers.
+    pub regex: Regex,
 }
 
-static SECRET_PATTERNS: LazyLock<Vec<Pattern>> = LazyLock::new(|| {
+impl std::fmt::Debug for NamedPattern {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("NamedPattern")
+            .field("name", &self.name)
+            .field("regex", &self.regex.as_str())
+            .finish()
+    }
+}
+
+/// Default token patterns shipped with Harn. Order matters only for
+/// audit attribution when multiple patterns would match the same
+/// substring — earlier patterns win.
+pub static DEFAULT_PATTERNS: LazyLock<Vec<NamedPattern>> = LazyLock::new(|| {
     vec![
-        // AWS IAM-style access key ids (gitleaks).
-        Pattern {
-            regex: Regex::new(r"\b(?:AKIA|ASIA|AGPA|AIDA|ANPA|AROA|AIPA)[A-Z0-9]{16}\b").unwrap(),
+        // JWT — three base64url segments separated by `.`. Required
+        // prefix `eyJ` keeps the regex from chewing arbitrary
+        // dotted base64.
+        NamedPattern {
+            name: "jwt",
+            regex: Regex::new(r"\beyJ[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]{4,}\b")
+                .expect("jwt regex compiles"),
         },
-        // GitHub OAuth/PAT/server/refresh tokens.
-        Pattern {
-            regex: Regex::new(r"\bgh(?:p|o|u|s|r)_[A-Za-z0-9]{36,255}\b").unwrap(),
+        // GitHub OAuth / app installation tokens (ghp_, gho_, ghu_,
+        // ghs_, ghr_).
+        NamedPattern {
+            name: "github_token",
+            regex: Regex::new(r"\bgh[pousr]_[A-Za-z0-9]{36,255}\b")
+                .expect("github_token regex compiles"),
         },
-        // GitHub fine-grained PAT.
-        Pattern {
-            regex: Regex::new(r"\bgithub_pat_[A-Za-z0-9_]{20,255}\b").unwrap(),
+        // GitHub fine-grained personal access token.
+        NamedPattern {
+            name: "github_pat_fine",
+            regex: Regex::new(r"\bgithub_pat_[A-Za-z0-9_]{20,255}\b")
+                .expect("github_pat_fine regex compiles"),
+        },
+        // Slack tokens (xoxb / xoxp / xoxa / xoxs / xoxr).
+        NamedPattern {
+            name: "slack_token",
+            regex: Regex::new(r"\bxox[abprs]-[A-Za-z0-9-]{10,255}\b")
+                .expect("slack_token regex compiles"),
+        },
+        // AWS access key ids (gitleaks family).
+        NamedPattern {
+            name: "aws_access_key",
+            regex: Regex::new(r"\b(?:AKIA|ASIA|AGPA|AIDA|ANPA|AROA|AIPA)[A-Z0-9]{16}\b")
+                .expect("aws_access_key regex compiles"),
         },
         // GitLab personal access token.
-        Pattern {
-            regex: Regex::new(r"\bglpat-[A-Za-z0-9_-]{20,255}\b").unwrap(),
+        NamedPattern {
+            name: "gitlab_token",
+            regex: Regex::new(r"\bglpat-[A-Za-z0-9_-]{20,255}\b")
+                .expect("gitlab_token regex compiles"),
         },
         // npm access token.
-        Pattern {
-            regex: Regex::new(r"\bnpm_[A-Za-z0-9]{36}\b").unwrap(),
+        NamedPattern {
+            name: "npm_token",
+            regex: Regex::new(r"\bnpm_[A-Za-z0-9]{36}\b").expect("npm_token regex compiles"),
         },
         // OpenAI / Anthropic-style sk- keys (long, project, etc).
-        Pattern {
-            regex: Regex::new(r"\bsk-[A-Za-z0-9_-]{20,255}\b").unwrap(),
-        },
-        // Slack tokens.
-        Pattern {
-            regex: Regex::new(r"\bxox(?:a|b|p|r|s)-[A-Za-z0-9-]{10,255}\b").unwrap(),
+        NamedPattern {
+            name: "openai_key",
+            regex: Regex::new(r"\bsk-[A-Za-z0-9_-]{20,255}\b").expect("openai_key regex compiles"),
         },
         // Stripe live/test keys.
-        Pattern {
-            regex: Regex::new(r"\b(?:rk|sk)_(?:live|test)_[0-9A-Za-z]{16,255}\b").unwrap(),
+        NamedPattern {
+            name: "stripe_key",
+            regex: Regex::new(r"\b(?:rk|sk)_(?:live|test)_[0-9A-Za-z]{16,255}\b")
+                .expect("stripe_key regex compiles"),
         },
-        // Bearer tokens in free text.
-        Pattern {
-            regex: Regex::new(r"(?i)\bBearer\s+[A-Za-z0-9._\-+/=]{12,}").unwrap(),
+        // `Authorization: Bearer <token>` header form as well as
+        // bare `Bearer xyz` substrings in free text.
+        NamedPattern {
+            name: "bearer_token",
+            regex: Regex::new(r"(?i)\bBearer\s+[A-Za-z0-9._\-+/=]{12,}")
+                .expect("bearer_token regex compiles"),
         },
     ]
 });
 
-/// Replace any high-confidence secret matches in `input` with
-/// `placeholder`. Returns `Cow::Borrowed` when nothing matched, so
-/// callers paying for a clone only pay when there was real work.
+thread_local! {
+    /// Custom token patterns installed by stdlib callers. Stored on a
+    /// per-thread stack the same way [`crate::redact::PolicyGuard`]
+    /// stores active policies; `reset_thread_local_state` clears them.
+    static CUSTOM_PATTERNS: RefCell<Vec<NamedPattern>> = const { RefCell::new(Vec::new()) };
+
+    /// Callback that receives one entry per pattern that matched.
+    /// Set by callers that want to audit redactions
+    /// (`stdlib::token_redaction` installs a default sink that
+    /// forwards to the event log when a runtime is available).
+    /// `None` means "no extra audit collection on this thread".
+    /// Every redaction also lands in [`AUDIT_RING`] regardless of
+    /// whether a sink is installed.
+    static AUDIT_SINK: RefCell<Option<AuditSink>> = const { RefCell::new(None) };
+
+    /// Authoritative per-thread audit ring. Always populated on
+    /// every redaction so the synchronous compliance contract holds
+    /// in every execution context (sync host calls, single-threaded
+    /// LocalSet, multi-thread runtime). Drained by stdlib via
+    /// [`drain_audit_ring`].
+    static AUDIT_RING: RefCell<Vec<RedactionEvent>> = const { RefCell::new(Vec::new()) };
+}
+
+/// Per-redaction event passed to an installed [`AuditSink`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RedactionEvent {
+    pub pattern_name: String,
+    pub match_count: usize,
+    /// Total bytes redacted across all matches of this pattern.
+    pub bytes_redacted: usize,
+}
+
+/// Thread-local callback invoked once per pattern that matched during a
+/// single `scan_secret_patterns` call.
+pub type AuditSink = std::rc::Rc<dyn Fn(&RedactionEvent)>;
+
+/// Register a custom named pattern on the calling thread. Returns an
+/// error if the regex fails to compile. The pattern is appended after
+/// the default catalog, so default patterns still win when multiple
+/// would match the same substring.
+pub fn register_custom_pattern(name: impl Into<String>, regex_source: &str) -> Result<(), String> {
+    let regex = Regex::new(regex_source).map_err(|error| format!("invalid regex: {error}"))?;
+    // Leak the name to `'static` so the pattern's name field stays
+    // borrow-free and serialization can carry the same lifetime as
+    // the default catalog. Custom patterns are rare and never freed
+    // — the leak is bounded by the number of distinct user-supplied
+    // names per process.
+    let name_static: &'static str = Box::leak(name.into().into_boxed_str());
+    CUSTOM_PATTERNS.with(|cell| {
+        cell.borrow_mut().push(NamedPattern {
+            name: name_static,
+            regex,
+        });
+    });
+    Ok(())
+}
+
+/// Drop all custom patterns installed via [`register_custom_pattern`]
+/// on the calling thread. Idempotent.
+pub fn clear_custom_patterns() {
+    CUSTOM_PATTERNS.with(|cell| cell.borrow_mut().clear());
+}
+
+/// Return the names of every default pattern, in catalog order.
+pub fn default_pattern_names() -> Vec<&'static str> {
+    DEFAULT_PATTERNS.iter().map(|p| p.name).collect()
+}
+
+/// Return the names of every custom pattern currently installed on the
+/// calling thread.
+pub fn custom_pattern_names() -> Vec<String> {
+    CUSTOM_PATTERNS.with(|cell| cell.borrow().iter().map(|p| p.name.to_string()).collect())
+}
+
+/// Install a per-thread audit sink. The previous sink (if any) is
+/// returned so callers can chain or restore.
+pub fn install_audit_sink(sink: Option<AuditSink>) -> Option<AuditSink> {
+    AUDIT_SINK.with(|cell| std::mem::replace(&mut *cell.borrow_mut(), sink))
+}
+
+fn emit_audit(events: &[RedactionEvent]) {
+    if events.is_empty() {
+        return;
+    }
+    // Always push to the per-thread ring so a synchronous
+    // `drain_audit_ring` call returns every event recorded since
+    // the last drain, regardless of whether an extra sink is
+    // installed on this thread.
+    AUDIT_RING.with(|ring| {
+        let mut ring = ring.borrow_mut();
+        for event in events {
+            // Bounded cap: 1024 entries is well above any realistic
+            // per-step audit pressure but small enough to be a
+            // no-op for normal workloads and to keep a runaway
+            // sink from OOMing the process.
+            if ring.len() >= 1024 {
+                ring.remove(0);
+            }
+            ring.push(event.clone());
+        }
+    });
+    let sink = AUDIT_SINK.with(|cell| cell.borrow().clone());
+    if let Some(sink) = sink {
+        for event in events {
+            sink(event);
+        }
+    }
+}
+
+/// Drain every audit event recorded on the calling thread since the
+/// last drain. The returned vec is in the order events fired.
+pub fn drain_audit_ring() -> Vec<RedactionEvent> {
+    AUDIT_RING.with(|ring| std::mem::take(&mut *ring.borrow_mut()))
+}
+
+/// Clear the per-thread audit ring without returning its contents.
+/// Used by `clear_policy_stack` so tests sharing a thread cannot
+/// leak audit events into each other.
+pub fn clear_audit_ring() {
+    AUDIT_RING.with(|ring| ring.borrow_mut().clear());
+}
+
+/// Build the per-match replacement string in the canonical
+/// `<redacted:<name>:<len>>` form. Length reflects the redacted match
+/// in UTF-8 bytes.
+fn replacement_for(name: &str, matched: &str) -> String {
+    format!("<redacted:{name}:{}>", matched.len())
+}
+
+/// Replace any high-confidence secret matches in `input` with the
+/// canonical `<redacted:<pattern_name>:<len>>` placeholder. Returns
+/// `Cow::Borrowed` when nothing matched, so callers paying for a clone
+/// only pay when there was real work.
+///
+/// The legacy `placeholder` argument is kept for callers that want a
+/// flat `[redacted]` form (e.g. headers and URL params). When the
+/// placeholder is the canonical `[redacted]` constant the named form
+/// is used; any other placeholder is substituted verbatim so callers
+/// that need a specific marker (URL-param escaping, etc.) still get
+/// it byte-for-byte.
 pub fn scan_secret_patterns<'a>(input: &'a str, placeholder: &str) -> Cow<'a, str> {
     if input.is_empty() {
         return Cow::Borrowed(input);
     }
+    // Length cap is defense-in-depth against catastrophic regex
+    // behavior. None of the default patterns have nested
+    // quantifiers, but custom patterns can be arbitrary so the cap
+    // keeps a malicious script from blocking the persistence path.
+    if input.len() > MAX_SCAN_INPUT_BYTES {
+        return Cow::Borrowed(input);
+    }
+    let use_named_placeholder = placeholder == crate::redact::REDACTED_PLACEHOLDER;
+
     let mut owned: Option<String> = None;
-    for pattern in SECRET_PATTERNS.iter() {
+    let mut audit_events: BTreeMap<&'static str, RedactionEvent> = BTreeMap::new();
+
+    // Drive defaults then custom patterns. We collect custom
+    // patterns into a Vec so the closure does not borrow the
+    // thread-local across the regex calls.
+    let custom: Vec<NamedPattern> = CUSTOM_PATTERNS.with(|cell| cell.borrow().clone());
+    let all_patterns = DEFAULT_PATTERNS.iter().chain(custom.iter());
+
+    for pattern in all_patterns {
         let target: &str = owned.as_deref().unwrap_or(input);
-        if !pattern.regex.is_match(target) {
+        let matches: Vec<(usize, usize)> = pattern
+            .regex
+            .find_iter(target)
+            .map(|m| (m.start(), m.end()))
+            .collect();
+        if matches.is_empty() {
             continue;
         }
-        let replaced = pattern.regex.replace_all(target, placeholder).into_owned();
-        owned = Some(replaced);
-    }
-    if let Some(value) = owned {
-        if value == input {
-            Cow::Borrowed(input)
-        } else {
-            Cow::Owned(value)
+        let total_bytes: usize = matches.iter().map(|(s, e)| e - s).sum();
+        audit_events.insert(
+            pattern.name,
+            RedactionEvent {
+                pattern_name: pattern.name.to_string(),
+                match_count: matches.len(),
+                bytes_redacted: total_bytes,
+            },
+        );
+
+        // Walk matches in reverse so we can splice without
+        // recomputing offsets after each cut.
+        let mut buffer = target.to_string();
+        for (start, end) in matches.into_iter().rev() {
+            let matched_slice = &buffer[start..end];
+            let replacement = if use_named_placeholder {
+                replacement_for(pattern.name, matched_slice)
+            } else {
+                placeholder.to_string()
+            };
+            buffer.replace_range(start..end, &replacement);
         }
-    } else {
-        Cow::Borrowed(input)
+        owned = Some(buffer);
     }
+
+    let result = match owned {
+        Some(value) if value == input => Cow::Borrowed(input),
+        Some(value) => Cow::Owned(value),
+        None => Cow::Borrowed(input),
+    };
+
+    if matches!(result, Cow::Owned(_)) {
+        let events: Vec<RedactionEvent> = audit_events.into_values().collect();
+        emit_audit(&events);
+    }
+
+    result
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    fn run_clean() {
+        clear_custom_patterns();
+        install_audit_sink(None);
+        clear_audit_ring();
+    }
+
     #[test]
     fn returns_borrowed_when_clean() {
-        let out = scan_secret_patterns("just plain text", "[redacted]");
+        run_clean();
+        let out = scan_secret_patterns("just plain text", crate::redact::REDACTED_PLACEHOLDER);
         assert!(matches!(out, Cow::Borrowed(_)));
     }
 
     #[test]
-    fn replaces_aws_and_github_tokens() {
+    fn replaces_aws_and_github_tokens_with_named_placeholder() {
+        run_clean();
         let input = "AKIAABCDEFGHIJKLMNOP and ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-        let out = scan_secret_patterns(input, "[redacted]");
-        assert!(out.contains("[redacted]"));
+        let out = scan_secret_patterns(input, crate::redact::REDACTED_PLACEHOLDER);
+        let rendered = out.into_owned();
+        assert!(rendered.contains("<redacted:aws_access_key:20>"));
+        assert!(rendered.contains("<redacted:github_token:40>"));
+        assert!(!rendered.contains("AKIAABCDEFGHIJKLMNOP"));
+    }
+
+    #[test]
+    fn legacy_placeholder_path_still_works_for_url_param_values() {
+        run_clean();
+        let input = "AKIAABCDEFGHIJKLMNOP";
+        // A non-`[redacted]` placeholder is used verbatim — this is
+        // the URL-param escaping path.
+        let out = scan_secret_patterns(input, "%5Bredacted%5D");
+        assert!(out.contains("%5Bredacted%5D"));
         assert!(!out.contains("AKIAABCDEFGHIJKLMNOP"));
-        assert!(!out.contains("ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
     }
 
     #[test]
     fn replaces_bearer_token_inside_text() {
+        run_clean();
         let input = "header: Authorization: Bearer abcDEFghi123_-+/=xyz tail";
-        let out = scan_secret_patterns(input, "[redacted]");
-        assert!(out.contains("[redacted]"));
-        assert!(!out.contains("Bearer abcDEFghi123_-+/=xyz"));
+        let out = scan_secret_patterns(input, crate::redact::REDACTED_PLACEHOLDER);
+        assert!(out.contains("<redacted:bearer_token:"));
+        assert!(!out.contains("abcDEFghi123_-+/=xyz"));
         assert!(out.contains("tail"));
+    }
+
+    #[test]
+    fn replaces_jwt_tokens() {
+        run_clean();
+        let input = "token=eyJabcd.eyJefgh.signature_pad here";
+        let out = scan_secret_patterns(input, crate::redact::REDACTED_PLACEHOLDER);
+        assert!(out.contains("<redacted:jwt:"));
+        assert!(!out.contains("eyJabcd.eyJefgh.signature_pad"));
+    }
+
+    #[test]
+    fn custom_pattern_redacts_and_is_introspectable() {
+        run_clean();
+        register_custom_pattern("acme_token", r"\bACME-[A-Z0-9]{8}\b").unwrap();
+        assert_eq!(custom_pattern_names(), vec!["acme_token".to_string()]);
+        let out = scan_secret_patterns(
+            "header ACME-12345678 trailer",
+            crate::redact::REDACTED_PLACEHOLDER,
+        );
+        assert!(
+            out.contains("<redacted:acme_token:13>"),
+            "expected acme_token redaction, got: {out}"
+        );
+        clear_custom_patterns();
+        assert!(custom_pattern_names().is_empty());
+    }
+
+    #[test]
+    fn audit_sink_receives_one_event_per_matching_pattern() {
+        use std::cell::RefCell;
+        use std::rc::Rc;
+        run_clean();
+        let captured: Rc<RefCell<Vec<RedactionEvent>>> = Rc::new(RefCell::new(Vec::new()));
+        let sink_captured = captured.clone();
+        install_audit_sink(Some(Rc::new(move |event| {
+            sink_captured.borrow_mut().push(event.clone());
+        })));
+        let input =
+            "AKIAABCDEFGHIJKLMNOP AKIA0000000000000000 ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let out = scan_secret_patterns(input, crate::redact::REDACTED_PLACEHOLDER);
+        assert!(matches!(out, Cow::Owned(_)));
+        let events = captured.borrow();
+        assert_eq!(events.len(), 2);
+        let by_name: BTreeMap<&str, &RedactionEvent> = events
+            .iter()
+            .map(|event| (event.pattern_name.as_str(), event))
+            .collect();
+        assert_eq!(by_name.get("aws_access_key").unwrap().match_count, 2);
+        assert_eq!(by_name.get("github_token").unwrap().match_count, 1);
+        // The synchronous ring captures the same events so a
+        // compliance drain returns them regardless of which sink
+        // (if any) is installed.
+        drop(events);
+        install_audit_sink(None);
+        let ring = drain_audit_ring();
+        assert_eq!(ring.len(), 2);
+    }
+
+    #[test]
+    fn audit_ring_records_events_even_without_a_sink() {
+        run_clean();
+        let _ = scan_secret_patterns("AKIAABCDEFGHIJKLMNOP", crate::redact::REDACTED_PLACEHOLDER);
+        let ring = drain_audit_ring();
+        assert_eq!(ring.len(), 1);
+        assert_eq!(ring[0].pattern_name, "aws_access_key");
+        // Drain is destructive.
+        assert!(drain_audit_ring().is_empty());
+    }
+
+    #[test]
+    fn input_above_cap_is_passthrough() {
+        run_clean();
+        let huge = "AKIAABCDEFGHIJKLMNOP".repeat(MAX_SCAN_INPUT_BYTES / 20 + 1);
+        let out = scan_secret_patterns(&huge, crate::redact::REDACTED_PLACEHOLDER);
+        assert!(matches!(out, Cow::Borrowed(_)));
+    }
+
+    #[test]
+    fn default_pattern_names_are_stable() {
+        let names = default_pattern_names();
+        assert!(names.contains(&"jwt"));
+        assert!(names.contains(&"github_token"));
+        assert!(names.contains(&"github_pat_fine"));
+        assert!(names.contains(&"slack_token"));
+        assert!(names.contains(&"aws_access_key"));
+        assert!(names.contains(&"bearer_token"));
     }
 }

--- a/crates/harn-vm/src/session_bundle.rs
+++ b/crates/harn-vm/src/session_bundle.rs
@@ -937,12 +937,17 @@ fn redact_json_with_manifest(
         JsonValue::String(text) => {
             let redacted = policy.redact_string(text);
             if let Cow::Owned(replacement) = redacted {
+                // Record the actual replacement string (now a named
+                // `<redacted:<pattern>:<len>>` placeholder from the
+                // OA-06 catalog) in the manifest so audit consumers
+                // can attribute the leak to a specific provider.
+                let manifest_replacement = replacement.clone();
                 *text = replacement;
                 entries.push(RedactionEntry {
                     path: path.to_string(),
                     class: "secret_pattern_or_url".to_string(),
                     action: "replaced".to_string(),
-                    replacement: Some(REDACTED_PLACEHOLDER.to_string()),
+                    replacement: Some(manifest_replacement),
                 });
             }
         }

--- a/crates/harn-vm/src/stdlib.rs
+++ b/crates/harn-vm/src/stdlib.rs
@@ -63,6 +63,7 @@ pub(crate) mod supervisor;
 pub mod template;
 mod testbench;
 mod testing;
+pub mod token_redaction;
 pub(crate) mod tool_hooks;
 pub(crate) mod tools;
 pub mod tracing;
@@ -165,6 +166,7 @@ pub fn register_agent_stdlib(vm: &mut Vm) {
     agents::register_agent_builtins(vm);
     pool::register_pool_builtins(vm);
     oauth_storage::register_oauth_storage_builtins(vm);
+    token_redaction::register_token_redaction_builtins(vm);
     agent_sessions::register_agent_session_builtins(vm);
     workflow_messages::register_workflow_message_builtins(vm);
     transcript_compact::register_transcript_compaction_builtins(vm);

--- a/crates/harn-vm/src/stdlib/token_redaction.rs
+++ b/crates/harn-vm/src/stdlib/token_redaction.rs
@@ -1,0 +1,247 @@
+//! `std/oauth/redaction` (OA-06) — OAuth token redaction stdlib.
+//!
+//! Lets scripts register custom redaction patterns alongside the
+//! built-in OAuth token catalog, probe whether a given string would
+//! be scrubbed, and drain the per-thread audit ring for compliance
+//! reporting.
+//!
+//! The actual redaction happens at READ/SERIALIZE time on the four
+//! sinks (transcript events, audit receipts, OTel span attributes,
+//! system reminders) via [`crate::redact::RedactionPolicy`]. Every
+//! redaction synchronously records a [`crate::redact::RedactionEvent`]
+//! in a per-thread ring; this module exposes the ring drain plus an
+//! optional process-wide async forwarder that appends events to the
+//! `audit.token_redaction` event-log topic.
+
+use std::collections::BTreeMap;
+use std::rc::Rc;
+use std::sync::Once;
+
+use serde_json::Value as JsonValue;
+
+use crate::event_log::{active_event_log, EventLog, LogEvent, Topic};
+use crate::redact::{
+    self, custom_pattern_names, default_pattern_names, drain_audit_ring, install_audit_sink,
+    register_custom_pattern, RedactionEvent, TOKEN_REDACTION_AUDIT_TOPIC,
+    TOKEN_REDACTION_DIAGNOSTIC,
+};
+use crate::value::{VmError, VmValue};
+use crate::vm::Vm;
+
+static AUDIT_SINK_INIT: Once = Once::new();
+
+/// Install the process-wide audit forwarder that pushes each
+/// redaction event to:
+///
+///   * the live `events::log_info_meta` sink pipeline (Stderr/Otel),
+///   * the active [`crate::event_log::EventLog`] under
+///     [`TOKEN_REDACTION_AUDIT_TOPIC`], best-effort.
+///
+/// The synchronous per-thread audit ring (see
+/// [`crate::redact::drain_audit_ring`]) is the authoritative
+/// compliance contract; this forwarder is an optional convenience for
+/// streaming consumers.
+///
+/// Safe to call multiple times — only the first call wires the sink.
+/// Per-thread because [`install_audit_sink`] is itself thread-local,
+/// `register_token_redaction_builtins` always re-installs on the
+/// current thread.
+pub fn ensure_audit_sink() {
+    AUDIT_SINK_INIT.call_once(|| {
+        install_audit_sink(Some(Rc::new(|event: &RedactionEvent| {
+            forward_event_to_log(event);
+            forward_event_to_events_sink(event);
+        })));
+    });
+}
+
+fn forward_event_to_log(event: &RedactionEvent) {
+    let Some(log) = active_event_log() else {
+        return;
+    };
+    let topic = match Topic::new(TOKEN_REDACTION_AUDIT_TOPIC) {
+        Ok(topic) => topic,
+        Err(_) => return,
+    };
+    let payload = serde_json::json!({
+        "code": TOKEN_REDACTION_DIAGNOSTIC,
+        "pattern": event.pattern_name,
+        "match_count": event.match_count,
+        "bytes_redacted": event.bytes_redacted,
+    });
+    let log_event = LogEvent::new("token_redaction", payload);
+    let log_ref = log.clone();
+    let topic_clone = topic.clone();
+    let owned = log_event.clone();
+    let task = async move {
+        if let Err(error) = log_ref.append(&topic_clone, owned).await {
+            crate::events::log_warn(
+                "token_redaction.audit",
+                &format!("failed to append token redaction audit event: {error}"),
+            );
+        }
+    };
+    // The append is best-effort. `handle.spawn` requires a multi-
+    // threaded runtime; on a current-thread runtime (the common VM
+    // path) the audit ring already recorded the event and there is
+    // nothing more to do here without panicking on the spawn.
+    if let Ok(handle) = tokio::runtime::Handle::try_current() {
+        let metrics = handle.metrics();
+        if metrics.num_workers() > 1 {
+            handle.spawn(task);
+        }
+    }
+}
+
+fn forward_event_to_events_sink(event: &RedactionEvent) {
+    let metadata: BTreeMap<String, JsonValue> = BTreeMap::from([
+        (
+            "code".to_string(),
+            JsonValue::String(TOKEN_REDACTION_DIAGNOSTIC.to_string()),
+        ),
+        (
+            "pattern".to_string(),
+            JsonValue::String(event.pattern_name.clone()),
+        ),
+        (
+            "match_count".to_string(),
+            JsonValue::Number(event.match_count.into()),
+        ),
+        (
+            "bytes_redacted".to_string(),
+            JsonValue::Number(event.bytes_redacted.into()),
+        ),
+    ]);
+    crate::events::log_info_meta(
+        "token_redaction.audit",
+        "redacted token in persistence sink",
+        metadata,
+    );
+}
+
+pub(crate) fn register_token_redaction_builtins(vm: &mut Vm) {
+    ensure_audit_sink();
+
+    vm.register_builtin("__token_redaction_register_pattern", |args, _out| {
+        let name = required_string_arg(args, 0, "__token_redaction_register_pattern", "name")?;
+        let regex_source =
+            required_string_arg(args, 1, "__token_redaction_register_pattern", "regex")?;
+        if name.is_empty() {
+            return Err(VmError::Runtime(
+                "__token_redaction_register_pattern: `name` must not be empty".to_string(),
+            ));
+        }
+        register_custom_pattern(&name, &regex_source).map_err(|message| {
+            VmError::Runtime(format!("token_redaction.register_pattern: {message}"))
+        })?;
+        Ok(VmValue::Nil)
+    });
+
+    vm.register_builtin("__token_redaction_clear_custom_patterns", |args, _out| {
+        if !args.is_empty() {
+            return Err(VmError::Runtime(
+                "__token_redaction_clear_custom_patterns: expected 0 arguments".to_string(),
+            ));
+        }
+        redact::clear_custom_patterns();
+        Ok(VmValue::Nil)
+    });
+
+    vm.register_builtin("__token_redaction_redact", |args, _out| {
+        let text = required_string_arg(args, 0, "__token_redaction_redact", "text")?;
+        let policy = redact::current_policy();
+        let redacted = policy.redact_string(&text).into_owned();
+        Ok(VmValue::String(Rc::from(redacted.as_str())))
+    });
+
+    vm.register_builtin("__token_redaction_default_patterns", |args, _out| {
+        if !args.is_empty() {
+            return Err(VmError::Runtime(
+                "__token_redaction_default_patterns: expected 0 arguments".to_string(),
+            ));
+        }
+        let names: Vec<VmValue> = default_pattern_names()
+            .into_iter()
+            .map(|name| VmValue::String(Rc::from(name)))
+            .collect();
+        Ok(VmValue::List(Rc::new(names)))
+    });
+
+    vm.register_builtin("__token_redaction_custom_patterns", |args, _out| {
+        if !args.is_empty() {
+            return Err(VmError::Runtime(
+                "__token_redaction_custom_patterns: expected 0 arguments".to_string(),
+            ));
+        }
+        let names: Vec<VmValue> = custom_pattern_names()
+            .into_iter()
+            .map(|name| VmValue::String(Rc::from(name.as_str())))
+            .collect();
+        Ok(VmValue::List(Rc::new(names)))
+    });
+
+    vm.register_builtin("__token_redaction_drain_audit", |args, _out| {
+        if !args.is_empty() {
+            return Err(VmError::Runtime(
+                "__token_redaction_drain_audit: expected 0 arguments".to_string(),
+            ));
+        }
+        let events = drain_audit_ring();
+        let list: Vec<VmValue> = events
+            .into_iter()
+            .map(|event| {
+                let mut entry: BTreeMap<String, VmValue> = BTreeMap::new();
+                entry.insert(
+                    "code".to_string(),
+                    VmValue::String(Rc::from(TOKEN_REDACTION_DIAGNOSTIC)),
+                );
+                entry.insert(
+                    "pattern".to_string(),
+                    VmValue::String(Rc::from(event.pattern_name.as_str())),
+                );
+                entry.insert(
+                    "match_count".to_string(),
+                    VmValue::Int(event.match_count as i64),
+                );
+                entry.insert(
+                    "bytes_redacted".to_string(),
+                    VmValue::Int(event.bytes_redacted as i64),
+                );
+                VmValue::Dict(Rc::new(entry))
+            })
+            .collect();
+        Ok(VmValue::List(Rc::new(list)))
+    });
+}
+
+fn required_string_arg(
+    args: &[VmValue],
+    index: usize,
+    fn_name: &str,
+    arg_name: &str,
+) -> Result<String, VmError> {
+    match args.get(index) {
+        Some(VmValue::String(s)) => Ok(s.to_string()),
+        Some(other) => Err(VmError::Runtime(format!(
+            "{fn_name}: `{arg_name}` must be a string, got {}",
+            other.type_name()
+        ))),
+        None => Err(VmError::Runtime(format!(
+            "{fn_name}: `{arg_name}` argument is required"
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ensure_audit_sink_is_idempotent() {
+        ensure_audit_sink();
+        ensure_audit_sink();
+        // Trigger one redaction to confirm the sink does not panic
+        // when invoked from a non-tokio context.
+        let _ = redact::scan_secret_patterns("AKIAABCDEFGHIJKLMNOP", redact::REDACTED_PLACEHOLDER);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a named OAuth token pattern catalog (JWT, GitHub PAT classic + fine-grained, Slack `xox*`, AWS `AKIA…`, Stripe key, OpenAI `sk-…`, GitLab `glpat-…`, npm `npm_…`, and `Authorization: Bearer …`) plus a `std/oauth/redaction` stdlib so scripts can register custom in-house patterns, drain `HARN-OAU-001` audit entries, and probe whether a string would be scrubbed.
- Pivots the existing unified `RedactionPolicy` from a flat `[redacted]` placeholder to the canonical `<redacted:<pattern>:<len>>` form for free-form pattern matches, so audit logs and bundle manifests attribute each leak to a specific provider. Header / sensitive-field redactions still use the legacy `[redacted]` marker so portal renderers and downstream parsers stay backward-compatible.
- Routes OTel span attributes (log messages and end-span metadata) through the active policy, completing the four sinks named in OA-06: transcripts, audit receipts, OTel, and system reminders.
- Records every redaction synchronously in a per-thread audit ring (drainable via `std/oauth/redaction::drain_audit`) so the compliance contract holds in sync hosts, single-threaded LocalSet runs, and multi-threaded runtimes. The optional async forwarder appends to the `audit.token_redaction` event-log topic on multi-thread runtimes; the live `events::log_info_meta` sink fires unconditionally.
- Defense-in-depth: 256 KiB cap on per-input scans (avoids catastrophic regex behavior), 1024-entry cap on the audit ring (no OOM if scripts forget to drain), audit payload carries only `{code, pattern, match_count, bytes_redacted}` — never the raw token.

Closes #1907. Part of epic #1885 (OAuth stdlib).

## Test plan

- [x] `cargo fmt --all && cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p harn-vm` (2248 / 0 failed)
- [x] `cargo test -p harn-parser` (alignment OK)
- [x] `make test` (4412 / 0 failed)
- [x] `make fmt-harn && make lint-harn && make lint-test-patterns`
- [x] `make gen-highlight` (no drift)
- [x] `cargo run --bin harn -- test conformance --filter token_redaction` (3 / 3 pass)
- [x] Full conformance: 1217 pass + 1 unrelated pre-existing `reminder_compact_expire_at_pre_compact` flake (same failure on `main` before any change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)