### PR TITLE
Add OnBudget callback strategies (#1914)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,29 @@ condensed series summaries instead of full per-patch history.
   compose with the existing `std/lifecycle/combinators`. Conformance:
   `conformance/tests/agents/resume_by_{parent_llm,local_runtime,cloud_harness,pipeline_drain,composed,default}.harn`.
   Part of epic #1836 (agent suspend/resume) and #1853 (callback-first).
+- **`OnBudget.*` callback strategies (#1914).** Adds three named callback
+  strategies for the existing `OnBudgetThreshold` lifecycle event in a
+  new `std/lifecycle/on_budget` module: `OnBudget.terminate` (emits
+  `budget_exceeded` audit, throws a structured `budget_exceeded`
+  exception so the surrounding agent loop / pipeline unwinds),
+  `OnBudget.graceful_exit` (emits `budget_graceful_exit` audit, returns
+  a deterministic `{status: "budget_exhausted", strategy:
+  "graceful_exit", reason, budget_state, message}` envelope so the
+  `on_finish` chain can drain in-flight work and surface the envelope
+  as the pipeline's value), and `OnBudget.warn_and_continue` (emits
+  `budget_warn_and_continue` audit, injects a 1-turn `budget_warning`
+  system_reminder via `tool_hooks_inject_reminder`, and returns the
+  original `budget_state` unchanged so combinator chains see a
+  passthrough). All three follow the same `(harness, budget_state) ->
+  result` shape that the rest of the lifecycle layer uses, so they
+  compose freely with `std/lifecycle/combinators` —
+  e.g. `compose([OnBudget.warn_and_continue, custom_logger])` threads
+  the dispatcher's snapshot through both entries. A
+  `OnBudget()` namespace factory mirrors the `QueueStrategy()` /
+  `Backpressure()` factories in `std/lifecycle/pool` for dotted-access
+  callers. Conformance coverage at
+  `conformance/tests/on_budget_{terminate,graceful_exit,warn_and_continue,compose}.harn`.
+  Part of epic #1853 (Pipeline lifecycle).
 - **Pool state durability (#1890).** `Pool.create({scope: ...})` now
   routes to three durability backends following the channel scope
   contract: `session` (default, in-memory only — lost on session close);

--- a/conformance/tests/on_budget_compose.expected
+++ b/conformance/tests/on_budget_compose.expected
@@ -1,0 +1,9 @@
+result_kind=thinking_tokens
+result_consumed=9000
+result_custom_observed=true
+audit_count=3
+audit_0=budget_warn_and_continue
+audit_0_strategy=warn_and_continue
+audit_1=tool_hooks.reminder_injected
+audit_2=custom_after_warn
+audit_2_kind_observed=thinking_tokens

--- a/conformance/tests/on_budget_compose.harn
+++ b/conformance/tests/on_budget_compose.harn
@@ -1,0 +1,50 @@
+/**
+ * `compose([OnBudget.warn_and_continue, custom])` threads
+ * `warn_and_continue`'s passthrough return value into a downstream
+ * custom callback. This is the canonical "first audit, then react"
+ * composition the epic calls out for callback-first strategies.
+ *
+ * Tracking: harn#1914 (P-11).
+ */
+import { lifecycle_audit_log_take } from "std/lifecycle"
+import { compose } from "std/lifecycle/combinators"
+import { warn_and_continue } from "std/lifecycle/on_budget"
+
+pipeline default() {
+  pipeline_on_finish(
+    { harness, return_value ->
+      let custom = { h, state ->
+        h
+          .emit_audit(
+          "custom_after_warn",
+          {observed_kind: state.kind, observed_threshold: state.threshold_pct},
+        )
+        return state + {custom_observed: true}
+      }
+      let chained = compose([warn_and_continue, custom])
+      let state = {
+        kind: "thinking_tokens",
+        limit: "max_thinking_tokens",
+        limit_value: 8000.0,
+        consumed_tokens: 9000,
+        threshold_pct: 1.125,
+      }
+      let result = chained(harness, state)
+      harness.stdio.println("result_kind=" + result.kind)
+      harness.stdio.println("result_consumed=" + to_string(result.consumed_tokens))
+      harness.stdio.println("result_custom_observed=" + to_string(result.custom_observed))
+      let audits = lifecycle_audit_log_take()
+      harness.stdio.println("audit_count=" + to_string(len(audits)))
+      harness.stdio.println("audit_0=" + audits[0].kind)
+      harness.stdio.println("audit_0_strategy=" + audits[0].payload.strategy)
+      harness.stdio.println("audit_1=" + audits[1].kind)
+      harness.stdio.println("audit_2=" + audits[2].kind)
+      harness.stdio.println("audit_2_kind_observed=" + audits[2].payload.observed_kind)
+      return return_value
+    },
+  )
+  return 0
+}
+// Custom callback receives the passthrough budget_state and
+// records its own audit so we can prove ordering + threading.
+// Order: warn audit -> reminder bookkeeping -> custom audit.

--- a/conformance/tests/on_budget_graceful_exit.expected
+++ b/conformance/tests/on_budget_graceful_exit.expected
@@ -1,0 +1,10 @@
+status=budget_exhausted
+strategy=graceful_exit
+reason=on_budget_graceful_exit
+state_kind=cost
+state_consumed=0.75
+message_contains_clean=true
+audit_count=1
+audit_kind=budget_graceful_exit
+audit_strategy=graceful_exit
+audit_consumed=0.75

--- a/conformance/tests/on_budget_graceful_exit.harn
+++ b/conformance/tests/on_budget_graceful_exit.harn
@@ -1,0 +1,40 @@
+/**
+ * `OnBudget.graceful_exit` emits a `budget_graceful_exit` audit entry
+ * and returns a structured exit envelope (does NOT throw) so the
+ * pipeline's `on_finish` chain or downstream combinator can drain
+ * in-flight work and surface the envelope as the pipeline's value.
+ *
+ * Tracking: harn#1914 (P-11).
+ */
+import { lifecycle_audit_log_take } from "std/lifecycle"
+import { graceful_exit } from "std/lifecycle/on_budget"
+
+pipeline default() {
+  pipeline_on_finish(
+    { harness, return_value ->
+      let state = {
+        kind: "cost",
+        limit: "total_budget_usd",
+        limit_value: 0.5,
+        consumed_cost_usd: 0.75,
+        threshold_pct: 1.5,
+      }
+      let envelope = graceful_exit(harness, state)
+      harness.stdio.println("status=" + envelope.status)
+      harness.stdio.println("strategy=" + envelope.strategy)
+      harness.stdio.println("reason=" + envelope.reason)
+      harness.stdio.println("state_kind=" + envelope.budget_state.kind)
+      harness.stdio.println("state_consumed=" + to_string(envelope.budget_state.consumed_cost_usd))
+      harness.stdio.println("message_contains_clean=" + to_string(envelope.message != nil))
+      let audits = lifecycle_audit_log_take()
+      harness.stdio.println("audit_count=" + to_string(len(audits)))
+      harness.stdio.println("audit_kind=" + audits[0].kind)
+      harness.stdio.println("audit_strategy=" + audits[0].payload.strategy)
+      harness.stdio
+        .println("audit_consumed=" + to_string(audits[0].payload.budget_state.consumed_cost_usd))
+      return return_value
+    },
+  )
+  return 0
+}
+// Default message uses the fallback (state.message was unset).

--- a/conformance/tests/on_budget_terminate.expected
+++ b/conformance/tests/on_budget_terminate.expected
@@ -1,0 +1,15 @@
+threw=true
+category=budget_exceeded
+kind=terminal
+reason=on_budget_terminate
+strategy=terminate
+state_kind=tokens
+state_limit_value=1000.0
+message_passthrough=tokens budget tripped at 150% (1500 of 1000)
+audit_count=1
+audit_kind=budget_exceeded
+audit_strategy=terminate
+audit_consumed_tokens=1500
+ns_has_terminate=true
+ns_has_graceful_exit=true
+ns_has_warn_and_continue=true

--- a/conformance/tests/on_budget_terminate.harn
+++ b/conformance/tests/on_budget_terminate.harn
@@ -1,0 +1,57 @@
+/**
+ * `OnBudget.terminate` emits a `budget_exceeded` audit entry and then
+ * throws a structured `budget_exceeded` exception so the surrounding
+ * agent loop / pipeline unwinds immediately.
+ *
+ * Tracking: harn#1914 (P-11).
+ */
+import { lifecycle_audit_log_take } from "std/lifecycle"
+import { OnBudget, terminate } from "std/lifecycle/on_budget"
+
+pipeline default() {
+  pipeline_on_finish(
+    { harness, return_value ->
+      let state = {
+        kind: "tokens",
+        limit: "max_input_tokens",
+        limit_value: 1000.0,
+        consumed_tokens: 1500,
+        consumed_cost_usd: 0.25,
+        threshold_pct: 1.5,
+        message: "tokens budget tripped at 150% (1500 of 1000)",
+      }
+      var caught = nil
+      try {
+        terminate(harness, state)
+      } catch (e) {
+        caught = e
+      }
+      harness.stdio.println("threw=" + to_string(caught != nil))
+      harness.stdio.println("category=" + caught.category)
+      harness.stdio.println("kind=" + caught.kind)
+      harness.stdio.println("reason=" + caught.reason)
+      harness.stdio.println("strategy=" + caught.strategy)
+      harness.stdio.println("state_kind=" + caught.budget_state.kind)
+      harness.stdio.println("state_limit_value=" + to_string(caught.budget_state.limit_value))
+      harness.stdio.println("message_passthrough=" + caught.message)
+      let audits = lifecycle_audit_log_take()
+      harness.stdio.println("audit_count=" + to_string(len(audits)))
+      harness.stdio.println("audit_kind=" + audits[0].kind)
+      harness.stdio.println("audit_strategy=" + audits[0].payload.strategy)
+      harness.stdio
+        .println(
+        "audit_consumed_tokens=" + to_string(audits[0].payload.budget_state.consumed_tokens),
+      )
+      let ns = OnBudget()
+      harness.stdio.println("ns_has_terminate=" + to_string(type_of(ns.terminate) == "closure"))
+      harness.stdio.println("ns_has_graceful_exit=" + to_string(type_of(ns.graceful_exit) == "closure"))
+      harness.stdio
+        .println(
+        "ns_has_warn_and_continue=" + to_string(type_of(ns.warn_and_continue) == "closure"),
+      )
+      return return_value
+    },
+  )
+  return 0
+}
+// Dotted-namespace lookup returns a callable matching the bare export.

--- a/conformance/tests/on_budget_warn_and_continue.expected
+++ b/conformance/tests/on_budget_warn_and_continue.expected
@@ -1,0 +1,11 @@
+passthrough_kind=tokens
+passthrough_consumed=4500
+same_keys=true
+audit_count=2
+audit_kind_0=budget_warn_and_continue
+audit_strategy=warn_and_continue
+audit_kind_1=tool_hooks.reminder_injected
+reminder_has_tag_0=budget_warning
+reminder_has_tag_1=on_budget
+reminder_dedupe_key=on_budget.warning
+reminder_ttl_turns=1

--- a/conformance/tests/on_budget_warn_and_continue.harn
+++ b/conformance/tests/on_budget_warn_and_continue.harn
@@ -1,0 +1,44 @@
+/**
+ * `OnBudget.warn_and_continue` emits a `budget_warn_and_continue` audit
+ * entry, injects a `budget_warning` system_reminder for the agent's
+ * next turn, and returns the original `budget_state` unchanged so
+ * combinator chains can pass it through.
+ *
+ * Tracking: harn#1914 (P-11).
+ */
+import { lifecycle_audit_log_take } from "std/lifecycle"
+import { warn_and_continue } from "std/lifecycle/on_budget"
+
+pipeline default() {
+  pipeline_on_finish(
+    { harness, return_value ->
+      let state = {
+        kind: "tokens",
+        limit: "max_output_tokens",
+        limit_value: 4096.0,
+        consumed_tokens: 4500,
+        threshold_pct: 1.1,
+      }
+      let passthrough = warn_and_continue(harness, state)
+      harness.stdio.println("passthrough_kind=" + passthrough.kind)
+      harness.stdio.println("passthrough_consumed=" + to_string(passthrough.consumed_tokens))
+      harness.stdio.println("same_keys=" + to_string(len(keys(passthrough)) == len(keys(state))))
+      let audits = lifecycle_audit_log_take()
+      harness.stdio.println("audit_count=" + to_string(len(audits)))
+      harness.stdio.println("audit_kind_0=" + audits[0].kind)
+      harness.stdio.println("audit_strategy=" + audits[0].payload.strategy)
+      harness.stdio.println("audit_kind_1=" + audits[1].kind)
+      let tags = audits[1].payload.tags
+      harness.stdio.println("reminder_has_tag_0=" + tags[0])
+      harness.stdio.println("reminder_has_tag_1=" + tags[1])
+      harness.stdio.println("reminder_dedupe_key=" + audits[1].payload.dedupe_key)
+      harness.stdio.println("reminder_ttl_turns=" + to_string(audits[1].payload.ttl_turns))
+      return return_value
+    },
+  )
+  return 0
+}
+// Passthrough is the original budget_state, dict-equal to `state`.
+// Two audit entries: the strategy's own audit + the
+// tool_hooks.reminder_injected book-keeping entry from
+// tool_hooks_inject_reminder (headless session path).

--- a/crates/harn-stdlib/src/lib.rs
+++ b/crates/harn-stdlib/src/lib.rs
@@ -214,6 +214,10 @@ pub const STDLIB_SOURCES: &[StdlibSource] = &[
         source: include_str!("stdlib/lifecycle/combinators.harn"),
     },
     StdlibSource {
+        module: "lifecycle/on_budget",
+        source: include_str!("stdlib/lifecycle/on_budget.harn"),
+    },
+    StdlibSource {
         module: "agent/prompts",
         source: include_str!("stdlib/agent/prompts.harn"),
     },

--- a/crates/harn-stdlib/src/stdlib/lifecycle/on_budget.harn
+++ b/crates/harn-stdlib/src/stdlib/lifecycle/on_budget.harn
@@ -1,0 +1,197 @@
+/**
+ * std/lifecycle/on_budget — named callback strategies for budget exhaustion.
+ *
+ * The runtime fires the `OnBudgetThreshold` lifecycle event whenever an
+ * agent loop / pipeline crosses a configured budget threshold (cents,
+ * tokens, thinking-tokens, etc.). Users register a handler closure to
+ * decide what happens next. This module ships three canonical
+ * strategies so the common cases stay one-liners:
+ *
+ *   * `OnBudget.terminate` — hard stop. Emits a `budget_exceeded` audit
+ *     entry and throws a structured `budget_exceeded` exception so the
+ *     enclosing agent loop / pipeline unwinds immediately.
+ *   * `OnBudget.graceful_exit` — schedules a clean finish. Emits a
+ *     `budget_graceful_exit` audit entry and returns a structured exit
+ *     envelope ({status, reason, budget_state, message}) so the
+ *     pipeline's `on_finish` chain can drain in-flight work and return
+ *     the envelope as the pipeline's value instead of throwing.
+ *   * `OnBudget.warn_and_continue` — soft-warn. Emits a
+ *     `budget_warn_and_continue` audit entry, injects a 1-turn
+ *     `budget_warning` system_reminder so the agent's next turn sees
+ *     the overrun, and returns `budget_state` unchanged so combinator
+ *     chains see a passthrough.
+ *
+ * All three follow the `(harness, budget_state) -> result` shape, which
+ * is identical to the `(harness, return_value) -> return_value` contract
+ * the rest of the lifecycle layer uses. That means every callback in
+ * this module composes freely with `std/lifecycle/combinators`:
+ *
+ *   import { OnBudget } from "std/lifecycle/on_budget"
+ *   import { compose, with_telemetry } from "std/lifecycle/combinators"
+ *
+ *   register_persona_hook(
+ *     "*",
+ *     "OnBudgetThreshold",
+ *     compose([OnBudget.warn_and_continue, with_telemetry(my_logger)]),
+ *   )
+ *
+ * `budget_state` is whatever the dispatcher delivers — typically a
+ * dict shaped roughly `{kind, limit, limit_value, consumed_cost_usd,
+ * consumed_tokens, threshold_pct, message?, ...}`. The callbacks treat
+ * it as opaque and copy the whole snapshot into their audit + reminder
+ * payloads so downstream consumers see the original shape.
+ *
+ * Tracking: harn#1914 (P-11), harn#1853 (epic).
+ */
+fn __on_budget_snapshot(budget_state) {
+  if budget_state == nil {
+    return {}
+  }
+  if type_of(budget_state) == "dict" {
+    return budget_state
+  }
+  return {value: budget_state}
+}
+
+fn __on_budget_default_message(state, fallback) -> string {
+  if type_of(state) == "dict" && state?.message != nil {
+    return to_string(state.message)
+  }
+  return fallback
+}
+
+fn __on_budget_emit_audit(harness, kind, strategy, state) {
+  let snapshot = __on_budget_snapshot(state)
+  let payload = {
+    strategy: strategy,
+    budget_state: snapshot,
+    message: __on_budget_default_message(snapshot, "budget threshold crossed"),
+  }
+  return harness.emit_audit(kind, payload)
+}
+
+fn __on_budget_terminate_error(state) {
+  let snapshot = __on_budget_snapshot(state)
+  return {
+    category: "budget_exceeded",
+    kind: "terminal",
+    reason: "on_budget_terminate",
+    strategy: "terminate",
+    budget_state: snapshot,
+    message: __on_budget_default_message(snapshot, "budget exceeded; OnBudget.terminate aborting"),
+  }
+}
+
+/**
+ * Hard-stop budget strategy. Emits `budget_exceeded` to the lifecycle
+ * audit log (capturing the full `budget_state` snapshot) and then
+ * throws a structured `budget_exceeded` exception so the enclosing
+ * agent loop / pipeline unwinds immediately. The exception payload
+ * carries `{category: "budget_exceeded", kind: "terminal", reason:
+ * "on_budget_terminate", strategy: "terminate", budget_state, message}`
+ * so error_boundary policies and host-side handlers can route on it
+ * the same way they route the runtime's own preflight
+ * budget-exceeded throws.
+ *
+ * Use this when crossing the budget is a fatal contract violation.
+ * Never returns; never reaches downstream combinators.
+ *
+ * @effects: [host]
+ * @allocation: heap
+ * @errors: ["budget_exceeded"]
+ * @api_stability: experimental
+ * @example: register_persona_hook("*", "OnBudgetThreshold", OnBudget.terminate)
+ */
+pub fn terminate(harness, budget_state) {
+  __on_budget_emit_audit(harness, "budget_exceeded", "terminate", budget_state)
+  throw __on_budget_terminate_error(budget_state)
+}
+
+/**
+ * Graceful-exit budget strategy. Emits `budget_graceful_exit` to the
+ * lifecycle audit log and returns a structured exit envelope shaped
+ * `{status: "budget_exhausted", strategy: "graceful_exit", reason:
+ * "on_budget_graceful_exit", budget_state, message}`. Unlike
+ * `terminate`, this does *not* throw — the envelope becomes the
+ * callback's return value, which means downstream combinators (and the
+ * pipeline's own `on_finish` chain) can drain in-flight work and
+ * return the envelope as the pipeline's value. Callers who want a
+ * hard abort should chain `OnBudget.terminate` after this preset.
+ *
+ * The envelope keys are deterministic so host-side renderers can pin
+ * on `status == "budget_exhausted"` without parsing free-form text.
+ *
+ * @effects: [host]
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: register_persona_hook("*", "OnBudgetThreshold", OnBudget.graceful_exit)
+ */
+pub fn graceful_exit(harness, budget_state) {
+  __on_budget_emit_audit(harness, "budget_graceful_exit", "graceful_exit", budget_state)
+  let snapshot = __on_budget_snapshot(budget_state)
+  return {
+    status: "budget_exhausted",
+    strategy: "graceful_exit",
+    reason: "on_budget_graceful_exit",
+    budget_state: snapshot,
+    message: __on_budget_default_message(
+      snapshot,
+      "budget exceeded; OnBudget.graceful_exit scheduling clean shutdown",
+    ),
+  }
+}
+
+/**
+ * Soft-warn budget strategy. Emits a `budget_warn_and_continue` audit
+ * entry, injects a 1-turn `budget_warning` system_reminder so the
+ * agent's next turn observes the overrun, and returns the original
+ * `budget_state` unchanged. The passthrough return value is the
+ * essential property that lets combinator chains like
+ * `compose([OnBudget.warn_and_continue, custom_logger])` thread the
+ * dispatcher's snapshot through every entry in the chain without
+ * re-shaping it.
+ *
+ * The injected reminder uses dedupe_key `on_budget.warning` so
+ * repeated triggers within a single turn collapse to one reminder
+ * (the dedupe contract on `inject_reminder`). When no active agent
+ * session exists the reminder still records a
+ * `tool_hooks.reminder_injected` audit entry, so headless pipelines
+ * and conformance fixtures can observe the side effect deterministically.
+ *
+ * @effects: [host]
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: register_persona_hook("*", "OnBudgetThreshold", OnBudget.warn_and_continue)
+ */
+pub fn warn_and_continue(harness, budget_state) {
+  __on_budget_emit_audit(harness, "budget_warn_and_continue", "warn_and_continue", budget_state)
+  let snapshot = __on_budget_snapshot(budget_state)
+  let body = __on_budget_default_message(
+    snapshot,
+    "Your budget is exhausted (OnBudget.warn_and_continue). Consider wrapping up or asking for a budget extension.",
+  )
+  tool_hooks_inject_reminder(
+    {tags: ["budget_warning", "on_budget"], body: body, dedupe_key: "on_budget.warning", ttl_turns: 1},
+  )
+  return budget_state
+}
+
+/**
+ * `OnBudget()` returns the named-strategy namespace as a dict so
+ * callers can use dotted access (e.g. `OnBudget.terminate`) after a
+ * single import. This mirrors the `QueueStrategy()` / `Backpressure()`
+ * factories in `std/lifecycle/pool` and keeps the `OnBudget.xxx`
+ * spelling consistent with the rest of the lifecycle namespace
+ * pattern.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: let OnBudget = OnBudget()
+ */
+pub fn OnBudget() {
+  return {terminate: terminate, graceful_exit: graceful_exit, warn_and_continue: warn_and_continue}
+}

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -2497,6 +2497,25 @@ Three concentric surfaces:
   - `when(predicate, callback)` — only invoke when
     `predicate(harness, return_value)` is truthy; otherwise pass the
     inbound value through unchanged.
+- `std/lifecycle/on_budget` exports three named callback strategies for
+  the `OnBudgetThreshold` event. Each takes `(harness, budget_state)`
+  and composes with the combinators above:
+  - `terminate(harness, budget_state)` — emits a `budget_exceeded`
+    audit, then throws `{category: "budget_exceeded", kind: "terminal",
+    reason: "on_budget_terminate", strategy: "terminate", budget_state,
+    message}` so the surrounding agent loop / pipeline unwinds.
+  - `graceful_exit(harness, budget_state)` — emits a
+    `budget_graceful_exit` audit; returns a deterministic envelope
+    `{status: "budget_exhausted", strategy: "graceful_exit", reason:
+    "on_budget_graceful_exit", budget_state, message}` instead of
+    throwing.
+  - `warn_and_continue(harness, budget_state)` — emits a
+    `budget_warn_and_continue` audit, injects a 1-turn
+    `budget_warning` system_reminder via `tool_hooks_inject_reminder`,
+    and returns the original `budget_state` unchanged (passthrough for
+    combinator chains).
+  - `OnBudget()` returns the namespace dict so callers can use
+    dotted access (`OnBudget.terminate`, etc.) after a single import.
 - `harness.unsettled_state()` returns a stable dict with
   `suspended_subagents`, `queued_triggers`, `partial_handoffs`, and
   `in_flight_llm_calls` lists. `harness.is_empty(state?)`,

--- a/docs/src/stdlib/lifecycle.md
+++ b/docs/src/stdlib/lifecycle.md
@@ -250,6 +250,49 @@ pipeline default() {
 }
 ```
 
+## Budget-threshold callbacks (`std/lifecycle/on_budget`)
+
+`std/lifecycle/on_budget` ships three named callback strategies for the
+`OnBudgetThreshold` lifecycle event. Each follows the same
+`(harness, budget_state) -> result` shape as the rest of the lifecycle
+layer, so they compose freely with `std/lifecycle/combinators`:
+
+- `terminate(harness, budget_state)` emits a `budget_exceeded` audit
+  entry and then throws a structured `budget_exceeded` exception so
+  the enclosing agent loop / pipeline unwinds. The thrown payload
+  carries `{category: "budget_exceeded", kind: "terminal", reason:
+  "on_budget_terminate", strategy: "terminate", budget_state,
+  message}`.
+- `graceful_exit(harness, budget_state)` emits a
+  `budget_graceful_exit` audit entry and returns a deterministic exit
+  envelope shaped `{status: "budget_exhausted", strategy:
+  "graceful_exit", reason: "on_budget_graceful_exit", budget_state,
+  message}`. Unlike `terminate` it does not throw — the envelope
+  becomes the callback's return value so downstream combinators and
+  the pipeline's `on_finish` chain can drain in-flight work and
+  surface it as the pipeline's value.
+- `warn_and_continue(harness, budget_state)` emits a
+  `budget_warn_and_continue` audit entry, injects a 1-turn
+  `budget_warning` system_reminder via `tool_hooks_inject_reminder`,
+  and returns the original `budget_state` unchanged so combinator
+  chains see a passthrough.
+
+The `OnBudget()` factory returns a dict of all three strategies so
+callers can use dotted access (`OnBudget.terminate`,
+`OnBudget.graceful_exit`, `OnBudget.warn_and_continue`) after a single
+import, mirroring the `QueueStrategy()` / `Backpressure()` factories.
+
+```harn
+import { OnBudget, warn_and_continue } from "std/lifecycle/on_budget"
+import { compose, with_telemetry } from "std/lifecycle/combinators"
+
+register_persona_hook(
+  "*",
+  "OnBudgetThreshold",
+  compose([warn_and_continue, with_telemetry(my_logger)]),
+)
+```
+
 ## Inspecting unsettled state directly
 
 Custom `on_finish` callbacks have full access to the harness:


### PR DESCRIPTION
## Summary

Adds three named callback strategies for the existing `OnBudgetThreshold` lifecycle event in a new `std/lifecycle/on_budget` module (`terminate`, `graceful_exit`, `warn_and_continue`) so the common budget-overrun reactions stay one-liners and compose with the P-07 combinators (#1860). All three take `(harness, budget_state)` and follow the same return-value contract as the rest of the lifecycle layer:

- `terminate` — emits `budget_exceeded` audit, throws structured `{category: "budget_exceeded", kind: "terminal", reason: "on_budget_terminate", strategy: "terminate", budget_state, message}` exception so the surrounding agent loop / pipeline unwinds.
- `graceful_exit` — emits `budget_graceful_exit` audit, returns a deterministic `{status: "budget_exhausted", strategy: "graceful_exit", reason, budget_state, message}` envelope (no throw) so downstream combinators and the pipeline's `on_finish` chain can drain in-flight work and surface the envelope as the pipeline's value.
- `warn_and_continue` — emits `budget_warn_and_continue` audit, injects a 1-turn `budget_warning` system_reminder via `tool_hooks_inject_reminder`, and returns the original `budget_state` unchanged so combinator chains see a passthrough.

A `OnBudget()` factory returns the three callbacks as a namespace dict (matching the `QueueStrategy()` / `Backpressure()` pattern in `std/lifecycle/pool`) so callers can use dotted access after a single import.

Closes #1914. Part of epic #1853 (Pipeline lifecycle framework).

### Deliberate scope notes

- `OnBudget.delegate_to_settlement` from the issue body is deferred. The settlement-agent loop is still the P-03 (#1856) placeholder, so this preset would only stub a `record_spawn_settlement_agent_gap` receipt today — better to ship it alongside the real drain loop than land a no-op preset now. Users can still spell it explicitly via `harness.spawn_settlement_agent(...)` in a custom callback.
- The dispatcher wiring that fires `OnBudgetThreshold` and calls the user-configured handler when the threshold is crossed remains in P-01 / #1854 (already landed). These callbacks plug into that surface — they don't add new dispatch paths.

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `make fmt-harn && make lint-harn && make lint-test-patterns` clean
- [x] `make check-docs-snippets` — 562 doc snippets checked, 0 failed
- [x] `cargo run --bin harn -- test conformance --filter on_budget` — 4 new + 1 existing pass
- [x] `cargo run --bin harn -- test conformance` — 1237/1237 pass
- [x] `make test` — 4410/4410 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)