### PR TITLE
Add OAuth device flow (#1903)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,27 @@ condensed series summaries instead of full per-patch history.
   callers. Conformance coverage at
   `conformance/tests/on_budget_{terminate,graceful_exit,warn_and_continue,compose}.harn`.
   Part of epic #1853 (Pipeline lifecycle).
+- **`std/oauth/device_flow` RFC 8628 device authorization grant (#1903).**
+  Adds `OAuth.device_flow(provider, opts)` for headless contexts (CI
+  runners, daemons, IDE side panes) where a browser redirect is
+  impractical. Posts to the provider's device authorization endpoint,
+  hands `(user_code, verification_uri)` to a caller-supplied
+  `on_user_code` handler (defaults to `eprintln(...)` with the URL and
+  code), polls the token endpoint at the server-supplied `interval`,
+  honors `slow_down` by adding 5 s to the cadence, treats
+  `authorization_pending` as a soft retry, and raises a deterministic
+  error on `expired_token` / `access_denied`. On success, builds a
+  TokenSet (mirroring the `std/oauth/client` exchange path) and persists
+  it through the OA-03 storage handle so `OAuth.client(...)` reads the
+  same token + refresh metadata back. Emits an
+  `oauth.device_flow.audit` `token_obtained` event log entry whose
+  payload includes provider, storage key, and token presence flags but
+  never the access token, refresh token, device code, or user code. The
+  polling sleep routes through the standard `sleep(ms)` builtin so
+  tests under `mock_time(...)` / `advance_time(...)` exercise the
+  cadence without real wall-clock waits. Conformance:
+  `conformance/tests/stdlib/oauth_device_flow_{happy_path,pending,slow_down,expired}.harn`.
+  Part of epic #1885 (OAuth stdlib).
 - **Pool state durability (#1890).** `Pool.create({scope: ...})` now
   routes to three durability backends following the channel scope
   contract: `session` (default, in-memory only — lost on session close);

--- a/conformance/tests/stdlib/oauth_device_flow_expired.expected
+++ b/conformance/tests/stdlib/oauth_device_flow_expired.expected
@@ -1,0 +1,1 @@
+[harn] oauth device flow expired ok

--- a/conformance/tests/stdlib/oauth_device_flow_expired.harn
+++ b/conformance/tests/stdlib/oauth_device_flow_expired.harn
@@ -1,0 +1,50 @@
+// std/oauth/device_flow: `expired_token` raises a deterministic error.
+//
+// The server returns `expired_token` on the first poll. device_flow
+// must surface it as a thrown error without persisting any token to
+// storage.
+import { device_flow } from "std/oauth/device_flow"
+import { custom } from "std/oauth/providers"
+import { memory } from "std/oauth/storage"
+
+pipeline test(task) {
+  let _ = mock_time(1700000000000)
+  let store = memory()
+  let provider = custom(
+    {
+      id: "mockExpired",
+      auth_url: "https://idp.example/authorize",
+      token_url: "https://idp.example/token",
+      device_code_url: "https://idp.example/device",
+      default_scopes: ["read"],
+    },
+  )
+  http_mock_clear()
+  http_mock(
+    "POST",
+    "https://idp.example/device",
+    {
+      status: 200,
+      body: "{\"device_code\":\"DEV-EXP\",\"user_code\":\"USER-EXP\",\"verification_uri\":\"https://idp.example/activate\",\"interval\":1,\"expires_in\":900}",
+      headers: {"content-type": "application/json"},
+    },
+  )
+  http_mock(
+    "POST",
+    "https://idp.example/token",
+    {status: 400, body: "{\"error\":\"expired_token\"}", headers: {"content-type": "application/json"}},
+  )
+  var threw = false
+  try {
+    let _ = device_flow(provider, {client_id: "cli-id", storage: store, on_user_code: { _u, _v -> nil }})
+  } catch (err) {
+    if contains(to_string(err), "expired") {
+      threw = true
+    }
+  }
+  assert(threw, "expired_token should have thrown an error")
+  let stored = store.get("mockExpired")
+  assert(stored == nil, "no token persisted on expired_token error")
+  let _ = unmock_time()
+  log("oauth device flow expired ok")
+}

--- a/conformance/tests/stdlib/oauth_device_flow_happy_path.expected
+++ b/conformance/tests/stdlib/oauth_device_flow_happy_path.expected
@@ -1,0 +1,1 @@
+[harn] oauth device flow happy path ok

--- a/conformance/tests/stdlib/oauth_device_flow_happy_path.harn
+++ b/conformance/tests/stdlib/oauth_device_flow_happy_path.harn
@@ -1,0 +1,108 @@
+// std/oauth/device_flow: RFC 8628 happy path.
+//
+// Drives the full device authorization grant against the mocked
+// http_mock surface. Asserts that:
+//   - The /device call carries client_id + scopes.
+//   - The on_user_code handler is invoked with the device's user code
+//     and verification URI from the device-code response.
+//   - The token endpoint is polled and the resulting TokenSet is
+//     persisted to the storage backend so OAuth.client() reads it back.
+//   - An oauth.device_flow.audit `token_obtained` event is emitted
+//     without leaking the access_token / refresh_token / device_code /
+//     user_code.
+import { device_flow } from "std/oauth/device_flow"
+import { custom } from "std/oauth/providers"
+import { memory } from "std/oauth/storage"
+
+pipeline test(task) {
+  let topic = "oauth.device_flow.audit"
+  let cursor = event_log.latest(topic) ?? 0
+  let _ = mock_time(1700000000000)
+  let store = memory()
+  let provider = custom(
+    {
+      id: "mockDevice",
+      auth_url: "https://idp.example/authorize",
+      token_url: "https://idp.example/token",
+      device_code_url: "https://idp.example/device",
+      default_scopes: ["repo"],
+    },
+  )
+  http_mock_clear()
+  http_mock(
+    "POST",
+    "https://idp.example/device",
+    {
+      status: 200,
+      body: "{\"device_code\":\"DEV-XYZ\",\"user_code\":\"USER-123\",\"verification_uri\":\"https://idp.example/activate\",\"verification_uri_complete\":\"https://idp.example/activate?user_code=USER-123\",\"interval\":1,\"expires_in\":900}",
+      headers: {"content-type": "application/json"},
+    },
+  )
+  http_mock(
+    "POST",
+    "https://idp.example/token",
+    {
+      status: 200,
+      body: "{\"access_token\":\"AAA\",\"refresh_token\":\"RRR\",\"expires_in\":3600,\"token_type\":\"Bearer\"}",
+      headers: {"content-type": "application/json"},
+    },
+  )
+  let handler_topic = "oauth.device_flow.test.handler"
+  let handler_cursor = event_log.latest(handler_topic) ?? 0
+  let on_user_code = { user_code, verification_uri ->
+    let _ = event_log
+      .emit(
+      handler_topic,
+      "called",
+      {user_code: user_code, verification_uri: verification_uri},
+      {provider: "mockDevice"},
+    )
+    nil
+  }
+  let token_set = device_flow(
+    provider,
+    {client_id: "cli-id", scopes: ["repo", "user"], storage: store, on_user_code: on_user_code},
+  )
+  let handler_stream = event_log.subscribe({topic: handler_topic, from_cursor: handler_cursor})
+  let handler_event = handler_stream.next().value
+  assert_eq(handler_event.kind, "called", "on_user_code was invoked")
+  assert_eq(handler_event.payload.user_code, "USER-123", "on_user_code receives user_code")
+  assert_eq(
+    handler_event.payload.verification_uri,
+    "https://idp.example/activate",
+    "on_user_code receives verification_uri",
+  )
+  assert_eq(token_set.access_token, "AAA", "device_flow returns access token")
+  assert_eq(token_set.refresh_token, "RRR", "device_flow returns refresh token")
+  assert_eq(token_set.token_type, "Bearer", "token_type recorded")
+  assert_eq(token_set.expires_in, 3600, "expires_in propagated")
+  let stored = store.get("mockDevice")
+  assert_eq(stored.access_token, "AAA", "token persisted under provider id")
+  assert_eq(stored.refresh_token, "RRR", "refresh token persisted")
+  let calls = http_mock_calls({include_sensitive: true})
+  assert_eq(len(calls), 2, "device + token calls, no polling needed")
+  assert_eq(calls[0].method, "POST", "first call hits device endpoint")
+  assert(contains(calls[0].url, "/device"), "device endpoint URL")
+  assert(contains(calls[0].body, "client_id=cli-id"), "client_id in device body")
+  assert(contains(calls[0].body, "scope=repo%20user"), "scopes in device body")
+  assert_eq(calls[1].method, "POST", "second call hits token endpoint")
+  assert(contains(calls[1].url, "/token"), "token endpoint URL")
+  assert(
+    contains(calls[1].body, "grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Adevice_code"),
+    "device-code grant type in token body",
+  )
+  assert(contains(calls[1].body, "device_code=DEV-XYZ"), "device_code in token body")
+  let stream = event_log.subscribe({topic: topic, from_cursor: cursor})
+  let logged = stream.next().value
+  assert_eq(logged.kind, "token_obtained", "audit event kind")
+  assert_eq(logged.payload.provider, "mockDevice", "audit provider id")
+  assert_eq(logged.payload.storage_key, "mockDevice", "audit storage_key")
+  assert_eq(logged.payload.next.has_access_token, true, "audit records access presence")
+  assert_eq(logged.payload.next.has_refresh_token, true, "audit records refresh presence")
+  assert(logged.payload.next?.access_token == nil, "audit does NOT leak access_token")
+  assert(logged.payload.next?.refresh_token == nil, "audit does NOT leak refresh_token")
+  assert(logged.payload?.device_code == nil, "audit does NOT include device_code")
+  assert(logged.payload?.user_code == nil, "audit does NOT include user_code")
+  let _ = unmock_time()
+  log("oauth device flow happy path ok")
+}

--- a/conformance/tests/stdlib/oauth_device_flow_pending.expected
+++ b/conformance/tests/stdlib/oauth_device_flow_pending.expected
@@ -1,0 +1,1 @@
+[harn] oauth device flow pending ok

--- a/conformance/tests/stdlib/oauth_device_flow_pending.harn
+++ b/conformance/tests/stdlib/oauth_device_flow_pending.harn
@@ -1,0 +1,76 @@
+// std/oauth/device_flow: authorization_pending retries until success.
+//
+// Mocks the token endpoint to return two authorization_pending errors
+// before the final success. Asserts that the client polls at the
+// server-supplied interval honoring mock_time (no real sleep) and that
+// each retry sends the same device_code.
+import { device_flow } from "std/oauth/device_flow"
+import { custom } from "std/oauth/providers"
+import { memory } from "std/oauth/storage"
+
+pipeline test(task) {
+  let _ = mock_time(1700000000000)
+  let store = memory()
+  let provider = custom(
+    {
+      id: "mockPending",
+      auth_url: "https://idp.example/authorize",
+      token_url: "https://idp.example/token",
+      device_code_url: "https://idp.example/device",
+      default_scopes: ["read"],
+    },
+  )
+  http_mock_clear()
+  http_mock(
+    "POST",
+    "https://idp.example/device",
+    {
+      status: 200,
+      body: "{\"device_code\":\"DEV-PENDING\",\"user_code\":\"USER-PEND\",\"verification_uri\":\"https://idp.example/activate\",\"interval\":2,\"expires_in\":900}",
+      headers: {"content-type": "application/json"},
+    },
+  )
+  http_mock(
+    "POST",
+    "https://idp.example/token",
+    {
+      responses: [
+        {
+          status: 400,
+          body: "{\"error\":\"authorization_pending\"}",
+          headers: {"content-type": "application/json"},
+        },
+        {
+          status: 400,
+          body: "{\"error\":\"authorization_pending\"}",
+          headers: {"content-type": "application/json"},
+        },
+        {
+          status: 200,
+          body: "{\"access_token\":\"OK-PEND\",\"expires_in\":3600,\"token_type\":\"Bearer\"}",
+          headers: {"content-type": "application/json"},
+        },
+      ],
+    },
+  )
+  let token_set = device_flow(provider, {client_id: "cli-id", storage: store, on_user_code: { _u, _v -> nil }})
+  assert_eq(
+    token_set.access_token,
+    "OK-PEND",
+    "device_flow returns final access token after pending retries",
+  )
+  let stored = store.get("mockPending")
+  assert_eq(stored.access_token, "OK-PEND", "token persisted after pending retries")
+  let calls = http_mock_calls({include_sensitive: true})
+  // 1 device call + 3 token polls.
+  assert_eq(len(calls), 4, "device + three token polls")
+  assert(contains(calls[0].url, "/device"), "first call to device endpoint")
+  assert(contains(calls[1].url, "/token"), "first poll to token endpoint")
+  assert(contains(calls[1].body, "device_code=DEV-PENDING"), "first poll body has device_code")
+  assert(contains(calls[2].url, "/token"), "second poll to token endpoint")
+  assert(contains(calls[2].body, "device_code=DEV-PENDING"), "second poll body has device_code")
+  assert(contains(calls[3].url, "/token"), "third poll to token endpoint")
+  assert(contains(calls[3].body, "device_code=DEV-PENDING"), "third poll body has device_code")
+  let _ = unmock_time()
+  log("oauth device flow pending ok")
+}

--- a/conformance/tests/stdlib/oauth_device_flow_slow_down.expected
+++ b/conformance/tests/stdlib/oauth_device_flow_slow_down.expected
@@ -1,0 +1,1 @@
+[harn] oauth device flow slow_down ok

--- a/conformance/tests/stdlib/oauth_device_flow_slow_down.harn
+++ b/conformance/tests/stdlib/oauth_device_flow_slow_down.harn
@@ -1,0 +1,62 @@
+// std/oauth/device_flow: `slow_down` bumps the polling interval +5s.
+//
+// The server returns one `slow_down` and then succeeds. The implementation
+// must add 5 seconds to the interval after a slow_down. This test uses
+// mock_time so the actual elapsed wall-clock stays zero.
+import { device_flow } from "std/oauth/device_flow"
+import { custom } from "std/oauth/providers"
+import { memory } from "std/oauth/storage"
+
+pipeline test(task) {
+  let _ = mock_time(1700000000000)
+  let store = memory()
+  let provider = custom(
+    {
+      id: "mockSlowDown",
+      auth_url: "https://idp.example/authorize",
+      token_url: "https://idp.example/token",
+      device_code_url: "https://idp.example/device",
+      default_scopes: ["read"],
+    },
+  )
+  http_mock_clear()
+  http_mock(
+    "POST",
+    "https://idp.example/device",
+    {
+      status: 200,
+      body: "{\"device_code\":\"DEV-SLOW\",\"user_code\":\"USER-SLOW\",\"verification_uri\":\"https://idp.example/activate\",\"interval\":3,\"expires_in\":900}",
+      headers: {"content-type": "application/json"},
+    },
+  )
+  http_mock(
+    "POST",
+    "https://idp.example/token",
+    {
+      responses: [
+        {status: 400, body: "{\"error\":\"slow_down\"}", headers: {"content-type": "application/json"}},
+        {
+          status: 200,
+          body: "{\"access_token\":\"OK-SLOW\",\"expires_in\":3600,\"token_type\":\"Bearer\"}",
+          headers: {"content-type": "application/json"},
+        },
+      ],
+    },
+  )
+  let start_ts = to_int(timestamp())
+  let token_set = device_flow(provider, {client_id: "cli-id", storage: store, on_user_code: { _u, _v -> nil }})
+  let end_ts = to_int(timestamp())
+  assert_eq(token_set.access_token, "OK-SLOW", "device_flow returns token after slow_down")
+  // Initial interval=3s; slow_down bumps it to 3+5=8s; one sleep of 8s
+  // happens before the successful retry. mock_time advances on sleep, so
+  // (end - start) should be at least 8 seconds.
+  let elapsed = end_ts - start_ts
+  assert(
+    elapsed >= 8,
+    "polling honored slow_down bump (elapsed >= 8s, was " + to_string(elapsed) + ")",
+  )
+  let calls = http_mock_calls({include_sensitive: true})
+  assert_eq(len(calls), 3, "device + 2 token polls")
+  let _ = unmock_time()
+  log("oauth device flow slow_down ok")
+}

--- a/crates/harn-stdlib/src/lib.rs
+++ b/crates/harn-stdlib/src/lib.rs
@@ -498,6 +498,10 @@ pub const STDLIB_SOURCES: &[StdlibSource] = &[
         source: include_str!("stdlib/oauth/client.harn"),
     },
     StdlibSource {
+        module: "oauth/device_flow",
+        source: include_str!("stdlib/oauth/device_flow.harn"),
+    },
+    StdlibSource {
         module: "oauth/redaction",
         source: include_str!("stdlib/oauth/redaction.harn"),
     },

--- a/crates/harn-stdlib/src/stdlib/oauth/device_flow.harn
+++ b/crates/harn-stdlib/src/stdlib/oauth/device_flow.harn
@@ -1,0 +1,386 @@
+/**
+ * std/oauth/device_flow — RFC 8628 device authorization grant.
+ *
+ * `device_flow(provider, opts)` performs the full RFC 8628 dance for
+ * headless contexts (CI runners, daemons, IDE side panes) where a
+ * browser redirect is impractical. The function:
+ *
+ *   1. POSTs to the provider's device authorization endpoint and
+ *      receives a `{device_code, user_code, verification_uri, interval,
+ *      expires_in}` envelope (`verification_uri_complete` is accepted
+ *      and surfaced when present).
+ *   2. Hands `(user_code, verification_uri)` to `opts.on_user_code` —
+ *      defaults to a `stderr` message instructing the operator to open
+ *      the URL and enter the code.
+ *   3. Polls the token endpoint at the cadence the server returned
+ *      (`interval`, default 5s). Honors `slow_down` by adding 5s to the
+ *      interval, treats `authorization_pending` as a soft retry, and
+ *      raises on `expired_token`, `access_denied`, or any other terminal
+ *      error.
+ *   4. On success, builds a `TokenSet` (mirroring
+ *      `std/oauth/client.__build_token_set`) and persists it through the
+ *      caller-supplied storage handle so subsequent
+ *      `OAuth.client(...)` calls see the same token + refresh metadata.
+ *
+ *     import { providers } from "std/oauth/providers"
+ *     import { memory } from "std/oauth/storage"
+ *     import { device_flow } from "std/oauth/device_flow"
+ *
+ *     let token = device_flow(
+ *       providers().github,
+ *       {
+ *         client_id: env("GITHUB_CLIENT_ID"),
+ *         scopes: ["read:user"],
+ *         storage: memory(),
+ *         on_user_code: { user_code, verification_uri ->
+ *           eprintln("Open " + verification_uri + " and enter " + user_code)
+ *         },
+ *       },
+ *     )
+ *
+ * Audit: every successful exchange emits an `oauth.device_flow.audit`
+ * `token_obtained` event log entry containing the provider id, storage
+ * key, and token presence flags. The `device_code` and `user_code` are
+ * never persisted or logged.
+ *
+ * Cancellation: polling honors VM cancellation between intervals —
+ * each `sleep(...)` between polls is itself cancellable, so a parent
+ * fiber that aborts the script will not be stuck waiting for an
+ * outstanding poll.
+ *
+ * Concurrency / time mocking: the polling sleep routes through the
+ * standard `sleep(ms)` builtin and so honors `mock_time(...)` /
+ * `advance_time(...)` in tests.
+ */
+let __DEFAULT_INTERVAL_SECONDS = 5
+
+let __SLOW_DOWN_BUMP_SECONDS = 5
+
+let __DEFAULT_TOKEN_KEY = "access-token"
+
+let __AUDIT_TOPIC = "oauth.device_flow.audit"
+
+let __AUDIT_KIND_OBTAINED = "token_obtained"
+
+let __ERROR_AUTHORIZATION_PENDING = "authorization_pending"
+
+let __ERROR_SLOW_DOWN = "slow_down"
+
+let __ERROR_EXPIRED_TOKEN = "expired_token"
+
+let __ERROR_ACCESS_DENIED = "access_denied"
+
+fn __require_string(value, field) {
+  let text = to_string(value ?? "")
+  if text == "" {
+    throw "std/oauth/device_flow: " + field + " is required"
+  }
+  return text
+}
+
+fn __require_provider(provider) {
+  if type_of(provider) != "dict" {
+    throw "std/oauth/device_flow: provider must be a dict (use std/oauth/providers)"
+  }
+  let device_url = provider?.device_code_url
+  if device_url == nil || to_string(device_url) == "" {
+    let id = to_string(provider?.id ?? "custom")
+    throw "std/oauth/device_flow: provider `" + id + "` does not declare a device_code_url"
+  }
+  let token_url = provider?.token_url
+  if token_url == nil || to_string(token_url) == "" {
+    throw "std/oauth/device_flow: provider.token_url is required"
+  }
+  return provider
+}
+
+fn __require_storage(storage) {
+  if type_of(storage) != "dict" {
+    throw "std/oauth/device_flow: opts.storage is required (use std/oauth/storage)"
+  }
+  let g = storage?.get
+  let s = storage?.set
+  let d = storage?.delete
+  if type_of(g) != "closure" && type_of(g) != "builtin" {
+    throw "std/oauth/device_flow: opts.storage.get must be a function"
+  }
+  if type_of(s) != "closure" && type_of(s) != "builtin" {
+    throw "std/oauth/device_flow: opts.storage.set must be a function"
+  }
+  if type_of(d) != "closure" && type_of(d) != "builtin" {
+    throw "std/oauth/device_flow: opts.storage.delete must be a function"
+  }
+  return storage
+}
+
+fn __scope_separator(provider) {
+  let id = lowercase(to_string(provider?.id ?? ""))
+  if id == "linear" {
+    return ","
+  }
+  return " "
+}
+
+fn __join_scopes(scopes, separator) {
+  var parts = []
+  if scopes != nil {
+    for raw in scopes {
+      let text = trim(to_string(raw ?? ""))
+      if text != "" {
+        parts = parts + [text]
+      }
+    }
+  }
+  if len(parts) == 0 {
+    return nil
+  }
+  return join(parts, separator)
+}
+
+fn __url_encode_value(value) {
+  return url_encode(to_string(value ?? ""))
+}
+
+fn __form_body(params) {
+  var parts = []
+  for entry in params {
+    parts = parts + [url_encode(entry.key) + "=" + __url_encode_value(entry.value)]
+  }
+  return join(parts, "&")
+}
+
+fn __safe_json_parse(text) {
+  let s = to_string(text ?? "")
+  if s == "" {
+    return nil
+  }
+  try {
+    return json_parse(s)
+  } catch (_err) {
+    return nil
+  }
+}
+
+fn __now_seconds() {
+  return to_int(timestamp())
+}
+
+fn __default_on_user_code(user_code, verification_uri) {
+  let _ = eprintln(
+    "To authorize this device, open " + to_string(verification_uri) + " and enter code: "
+      + to_string(user_code),
+  )
+  return nil
+}
+
+fn __invoke_user_code_handler(handler, user_code, verification_uri) {
+  if handler == nil {
+    return __default_on_user_code(user_code, verification_uri)
+  }
+  if type_of(handler) != "closure" && type_of(handler) != "builtin" {
+    throw "std/oauth/device_flow: opts.on_user_code must be a function"
+  }
+  return handler(to_string(user_code), to_string(verification_uri))
+}
+
+fn __redact_token(token) {
+  if token == nil {
+    return nil
+  }
+  return {
+    has_access_token: token?.access_token != nil && to_string(token?.access_token) != "",
+    has_refresh_token: token?.refresh_token != nil && to_string(token?.refresh_token) != "",
+    expires_at_unix: token?.expires_at_unix,
+    issued_at_unix: token?.issued_at_unix,
+    scopes: token?.scopes,
+    token_type: token?.token_type,
+  }
+}
+
+fn __build_token_set(parsed, scopes, issued_at) {
+  var token_set = {access_token: to_string(parsed.access_token), issued_at_unix: issued_at}
+  let token_type = parsed?.token_type
+  if token_type != nil {
+    token_set = token_set + {token_type: to_string(token_type)}
+  }
+  let expires_in = parsed?.expires_in
+  if expires_in != nil {
+    let ttl_s = to_int(expires_in)
+    token_set = token_set + {expires_in: ttl_s, expires_at_unix: issued_at + ttl_s}
+  } else if parsed?.expires_at_unix != nil {
+    token_set = token_set + {expires_at_unix: to_int(parsed.expires_at_unix)}
+  }
+  let refresh = parsed?.refresh_token
+  if refresh != nil && to_string(refresh) != "" {
+    token_set = token_set + {refresh_token: to_string(refresh)}
+  }
+  let returned_scope = parsed?.scope
+  if returned_scope != nil && to_string(returned_scope) != "" {
+    token_set = token_set + {scopes: split(to_string(returned_scope), " ")}
+  } else if scopes != nil && len(scopes) > 0 {
+    token_set = token_set + {scopes: scopes}
+  }
+  return token_set
+}
+
+fn __audit_obtained(provider_id, storage_key, token_set) {
+  let payload = {
+    provider: to_string(provider_id),
+    storage_key: to_string(storage_key),
+    next: __redact_token(token_set),
+  }
+  let _ = event_log.emit(__AUDIT_TOPIC, __AUDIT_KIND_OBTAINED, payload, {provider: to_string(provider_id)})
+}
+
+fn __request_device_code(cfg) {
+  var form = [{key: "client_id", value: cfg.client_id}]
+  let scopes_str = __join_scopes(cfg.scopes, cfg.scope_separator)
+  if scopes_str != nil {
+    form = form + [{key: "scope", value: scopes_str}]
+  }
+  if cfg.audience != nil && to_string(cfg.audience) != "" {
+    form = form + [{key: "audience", value: cfg.audience}]
+  }
+  let headers = {"Content-Type": "application/x-www-form-urlencoded", Accept: "application/json"}
+  let response = http_post(cfg.device_code_url, __form_body(form), {headers: headers})
+  if !(response?.ok ?? false) {
+    let parsed = __safe_json_parse(response?.body ?? "")
+    let detail = parsed?.error_description ?? parsed?.error ?? "device authorization endpoint returned status "
+      + to_string(response?.status ?? 0)
+    throw "std/oauth/device_flow: device authorization request failed: " + to_string(detail)
+  }
+  let parsed = __safe_json_parse(response?.body ?? "")
+  if parsed == nil {
+    throw "std/oauth/device_flow: device authorization endpoint did not return JSON"
+  }
+  let device_code = to_string(parsed?.device_code ?? "")
+  let user_code = to_string(parsed?.user_code ?? "")
+  let verification_uri = to_string(parsed?.verification_uri ?? parsed?.verification_url ?? "")
+  if device_code == "" || user_code == "" || verification_uri == "" {
+    throw "std/oauth/device_flow: device authorization response missing required fields"
+  }
+  let verification_uri_complete = parsed?.verification_uri_complete
+  let interval_raw = parsed?.interval ?? __DEFAULT_INTERVAL_SECONDS
+  let interval_seconds = to_int(interval_raw)
+  let expires_in_raw = parsed?.expires_in ?? 0
+  let expires_in_seconds = to_int(expires_in_raw)
+  return {
+    device_code: device_code,
+    user_code: user_code,
+    verification_uri: verification_uri,
+    verification_uri_complete: verification_uri_complete == nil ? nil : to_string(verification_uri_complete),
+    interval_seconds: interval_seconds <= 0 ? __DEFAULT_INTERVAL_SECONDS : interval_seconds,
+    expires_in_seconds: expires_in_seconds,
+  }
+}
+
+fn __poll_once(cfg, device_code) {
+  var form = [
+    {key: "grant_type", value: "urn:ietf:params:oauth:grant-type:device_code"},
+    {key: "device_code", value: device_code},
+    {key: "client_id", value: cfg.client_id},
+  ]
+  if cfg.client_secret != nil && to_string(cfg.client_secret) != "" {
+    form = form + [{key: "client_secret", value: cfg.client_secret}]
+  }
+  let headers = {"Content-Type": "application/x-www-form-urlencoded", Accept: "application/json"}
+  let response = http_post(cfg.token_url, __form_body(form), {headers: headers})
+  let status = to_int(response?.status ?? 0)
+  let parsed = __safe_json_parse(response?.body ?? "") ?? {}
+  if response?.ok ?? false && parsed?.access_token != nil {
+    return {kind: "ok", parsed: parsed}
+  }
+  let error_code = to_string(parsed?.error ?? "")
+  if error_code == __ERROR_AUTHORIZATION_PENDING {
+    return {kind: "pending"}
+  }
+  if error_code == __ERROR_SLOW_DOWN {
+    return {kind: "slow_down"}
+  }
+  if error_code == __ERROR_EXPIRED_TOKEN {
+    throw "std/oauth/device_flow: device code expired before authorization completed"
+  }
+  if error_code == __ERROR_ACCESS_DENIED {
+    throw "std/oauth/device_flow: user denied the device authorization request"
+  }
+  let detail = parsed?.error_description ?? error_code ?? "token endpoint returned status " + to_string(status)
+  let prefix = error_code == "" ? "token endpoint error: " : "token endpoint error `" + error_code + "`: "
+  throw "std/oauth/device_flow: " + prefix + to_string(detail)
+}
+
+fn __poll_until_done(cfg, device_code, initial_interval_seconds, expires_in_seconds) {
+  var interval_seconds = initial_interval_seconds
+  var elapsed_seconds = 0
+  while true {
+    let outcome = __poll_once(cfg, device_code)
+    if outcome.kind == "ok" {
+      return outcome.parsed
+    }
+    if outcome.kind == "slow_down" {
+      interval_seconds = interval_seconds + __SLOW_DOWN_BUMP_SECONDS
+    }
+    // Sleep for the current interval and re-poll.
+    if expires_in_seconds > 0 && elapsed_seconds + interval_seconds > expires_in_seconds {
+      throw "std/oauth/device_flow: device code expired before authorization completed"
+    }
+    sleep(interval_seconds * 1000)
+    elapsed_seconds = elapsed_seconds + interval_seconds
+  }
+  throw "std/oauth/device_flow: unreachable polling exit"
+}
+
+/**
+ * device_flow runs the RFC 8628 device authorization grant against
+ * `provider` and returns the resulting TokenSet. The token is persisted
+ * to `opts.storage` under `opts.storage_key` (defaults to the provider
+ * id) so the same client / storage pair used by `OAuth.client(...)` can
+ * read it back for downstream HTTP calls.
+ *
+ * Required `opts`:
+ *   - client_id:    OAuth client identifier.
+ *   - storage:      a handle from `std/oauth/storage`.
+ *
+ * Optional `opts`:
+ *   - client_secret:    confidential-client device flows.
+ *   - scopes:           list<string>; defaults to provider.default_scopes.
+ *   - storage_key:      per-installation key; defaults to provider id.
+ *   - audience:         extra `audience=` parameter on /device.
+ *   - on_user_code:     fn(user_code, verification_uri[, verification_uri_complete]) -> any.
+ *                       Defaults to `eprintln(...)` with the URL and code.
+ *
+ * @effects: [time, net, stderr]
+ * @allocation: heap
+ * @errors: [invalid_argument]
+ * @api_stability: experimental
+ * @example: device_flow(providers().github, {client_id: id, storage: memory()})
+ */
+pub fn device_flow(provider, opts) {
+  if type_of(opts) != "dict" {
+    throw "std/oauth/device_flow: opts must be a dict"
+  }
+  let provider_record = __require_provider(provider)
+  let storage = __require_storage(opts?.storage)
+  let client_id = __require_string(opts?.client_id, "opts.client_id")
+  let client_secret = opts?.client_secret
+  let scopes = opts?.scopes ?? provider_record?.default_scopes ?? []
+  let scope_separator = __scope_separator(provider_record)
+  let storage_key = to_string(opts?.storage_key ?? provider_record?.id ?? __DEFAULT_TOKEN_KEY)
+  let cfg = {
+    provider_id: to_string(provider_record?.id ?? "custom"),
+    device_code_url: to_string(provider_record.device_code_url),
+    token_url: to_string(provider_record.token_url),
+    client_id: client_id,
+    client_secret: client_secret == nil ? nil : to_string(client_secret),
+    scopes: scopes,
+    scope_separator: scope_separator,
+    audience: opts?.audience,
+  }
+  let device = __request_device_code(cfg)
+  let _ = __invoke_user_code_handler(opts?.on_user_code, device.user_code, device.verification_uri)
+  let parsed = __poll_until_done(cfg, device.device_code, device.interval_seconds, device.expires_in_seconds)
+  let issued_at = __now_seconds()
+  let token_set = __build_token_set(parsed, scopes, issued_at)
+  storage.set(storage_key, token_set)
+  __audit_obtained(cfg.provider_id, storage_key, token_set)
+  return token_set
+}


### PR DESCRIPTION
Adds `std/oauth/device_flow` implementing **RFC 8628** device authorization grant for headless contexts (CI runners, daemons, IDE side panes) where a browser redirect is impractical.

Resolves #1903. Part of epic #1885 (OAuth stdlib), building on:
- OA-01 #1996 (`OAuth.client(...)` PKCE + transparent refresh)
- OA-03 #1987 (storage backends)
- OA-04 #1938 (providers catalogue)
- OA-06 #2001 (token redaction)

## Summary
- New `device_flow(provider, opts)` Harn function in `crates/harn-stdlib/src/stdlib/oauth/device_flow.harn`.
- Posts to provider device endpoint, hands `(user_code, verification_uri)` to `on_user_code` (default: `eprintln` to stderr), polls the token endpoint at the server-supplied `interval`.
- Honors `slow_down` (+5s to interval), `authorization_pending` (soft retry), and raises a deterministic error on `expired_token` / `access_denied` / other terminal errors.
- On success, builds a TokenSet (mirroring `std/oauth/client.__build_token_set`) and persists it through the caller-supplied OA-03 storage handle so subsequent `OAuth.client(...)` calls share the same token + refresh metadata.
- Emits an `oauth.device_flow.audit` `token_obtained` event log entry containing provider, storage key, and token presence flags. Never logs the access_token, refresh_token, device_code, or user_code.
- Polling sleep routes through the standard `sleep(ms)` builtin so tests under `mock_time(...)` / `advance_time(...)` exercise the cadence with zero wall-clock waits.

## Test plan
- [x] `cargo run --bin harn -- test conformance --filter oauth_device_flow` (4/4 pass: happy_path, pending, slow_down, expired)
- [x] `cargo run --bin harn -- test conformance --filter oauth` (9/9 pass, including the OA-01/OA-03/OA-04 fixtures)
- [x] `cargo fmt --all && cargo clippy --workspace --all-targets -- -D warnings`
- [x] `make fmt-harn && make lint-harn && make lint-test-patterns`
- [x] `make gen-highlight` (no drift)
- [x] `make test` (4418 passed)

## Conformance fixtures
- `conformance/tests/stdlib/oauth_device_flow_happy_path.harn` — full grant + on_user_code invocation + audit-event redaction assertions
- `conformance/tests/stdlib/oauth_device_flow_pending.harn` — three polls with two `authorization_pending` responses before success
- `conformance/tests/stdlib/oauth_device_flow_slow_down.harn` — server returns one `slow_down`, asserts +5s cadence bump via mocked clock
- `conformance/tests/stdlib/oauth_device_flow_expired.harn` — `expired_token` raises and persists nothing

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>