### PR TITLE
Add OAuth conformance suite (#1908)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,33 @@ condensed series summaries instead of full per-patch history.
   scenario — pool tasks visible in `harness.unsettled_state()` so on_finish
   presets can act on them — and is marked `@xfail` referencing follow-up
   #2007 until the runtime wiring lands.
+- **OAuth conformance suite + explicit revoke + `HARN-OAU-002` (#1908).**
+  Closes the OA-07 gap-fill on top of the OA-01..OA-06 surface: adds
+  three new conformance fixtures — `oauth_refresh_token_expired`
+  (server returns `invalid_grant` on the refresh-grant call, raises
+  the dedicated `HARN-OAU-002` diagnostic and leaves the stored
+  TokenSet untouched), `oauth_revoke` (RFC 7009 best-effort POST to
+  the provider's `revoke_url`, authoritative local storage delete,
+  `oauth.client.audit` `token_revoked` event with redacted prev shape,
+  and a forced `HARN-OAU-002` on the next `token(cli)` call), and
+  `oauth_pkce_validates` (mocks the server's mismatched-verifier
+  rejection and asserts the error_description threads through with
+  no audit and no persisted TokenSet). Promotes the previously
+  private `cli.revoke()` storage-delete shim into a real
+  `pub fn revoke(cli)` that issues the RFC 7009 token-revocation POST
+  on a best-effort basis (network failures never block the local
+  discard) and emits an audit event. Tags both the
+  no-refresh-token-in-storage and the failed-refresh-grant paths in
+  `std/oauth/client` with the new `HARN-OAU-002` diagnostic prefix so
+  scripts can pattern-match on a single, stable string instead of
+  parsing freeform error text. The fifteen `oauth_*` conformance
+  fixtures together cover authorization-code + PKCE, device flow
+  (happy/pending/slow-down/expired), refresh on 401, pre-emptive
+  refresh at 75 % TTL, refresh-token expiry, revoke, PKCE mismatch,
+  storage round-trip across all four backends (memory/file/cloud
+  session/cloud org/custom), the provider catalogue against ten
+  preconfigured providers, and the OA-06 redaction patterns. Part of
+  epic #1885 (OAuth stdlib).
 - **Channel scope resolver completes the four-tier hierarchy (#1874).**
   Formalises the `session < pipeline < tenant < org` scope chain for
   `emit_channel(...)` and `channel_events(...)`, building on the producer

--- a/conformance/tests/stdlib/oauth_pkce_validates.expected
+++ b/conformance/tests/stdlib/oauth_pkce_validates.expected
@@ -1,0 +1,1 @@
+[harn] oauth pkce validates ok

--- a/conformance/tests/stdlib/oauth_pkce_validates.harn
+++ b/conformance/tests/stdlib/oauth_pkce_validates.harn
@@ -1,0 +1,73 @@
+// std/oauth/client: PKCE verifier mismatch surfaces the server's
+// rejection.
+//
+// RFC 7636 §4.6 puts PKCE validation on the authorization server: the
+// client always sends `code_verifier`, the server recomputes the
+// challenge from it, and on mismatch returns `invalid_grant`. This
+// fixture mocks that rejection (status 400, `invalid_grant`,
+// description "PKCE code_verifier mismatch") and asserts that:
+//
+//   - exchange_code() propagates the server's error_description so the
+//     operator sees the real cause instead of a generic 4xx,
+//   - no TokenSet is persisted to storage on a failed exchange,
+//   - no `token_exchanged` audit event is emitted (audit is the
+//     compliance contract — failures must not show up as successes),
+//   - the client did POST a `code_verifier=` form parameter so we know
+//     the contract on the wire is intact end-to-end.
+import { client, exchange_code, start_authorization } from "std/oauth/client"
+import { custom } from "std/oauth/providers"
+import { memory } from "std/oauth/storage"
+
+pipeline test(task) {
+  let topic = "oauth.client.audit"
+  let cursor = event_log.latest(topic) ?? 0
+  let store = memory()
+  let provider = custom(
+    {
+      id: "mockPkce",
+      auth_url: "https://idp.example/authorize",
+      token_url: "https://idp.example/token",
+      default_scopes: ["read"],
+    },
+  )
+  let cli = client(
+    provider,
+    {client_id: "cli-id", redirect_uri: "http://127.0.0.1:9999/cb", scopes: ["read"], storage: store},
+  )
+  let pkce = start_authorization(cli)
+  http_mock_clear()
+  http_mock(
+    "POST",
+    "https://idp.example/token",
+    {
+      status: 400,
+      body: "{\"error\":\"invalid_grant\",\"error_description\":\"PKCE code_verifier mismatch\"}",
+      headers: {"content-type": "application/json"},
+    },
+  )
+  var threw = false
+  var msg = ""
+  try {
+    let _ = exchange_code(cli, pkce, "auth-code-123", pkce.state)
+  } catch (err) {
+    msg = to_string(err)
+    threw = true
+  }
+  assert(threw, "PKCE mismatch should have thrown")
+  assert(
+    contains(msg, "PKCE code_verifier mismatch") || contains(msg, "invalid_grant"),
+    "server error_description must be surfaced, got: " + msg,
+  )
+  let after = store.get("mockPkce")
+  assert(after == nil, "no TokenSet persisted on failed exchange")
+  // Confirm the client did send the verifier on the wire so the
+  // server had something to validate against.
+  let calls = http_mock_calls({include_sensitive: true})
+  assert_eq(len(calls), 1, "one POST to token endpoint")
+  assert(contains(calls[0].body, "code_verifier=" + pkce.code_verifier), "code_verifier sent in body")
+  assert(contains(calls[0].body, "grant_type=authorization_code"), "auth-code grant type")
+  // No audit event must fire on a failed exchange.
+  let latest_after = event_log.latest(topic) ?? 0
+  assert_eq(latest_after, cursor, "no token_exchanged audit on failed exchange")
+  log("oauth pkce validates ok")
+}

--- a/conformance/tests/stdlib/oauth_refresh_token_expired.expected
+++ b/conformance/tests/stdlib/oauth_refresh_token_expired.expected
@@ -1,0 +1,1 @@
+[harn] oauth refresh token expired ok

--- a/conformance/tests/stdlib/oauth_refresh_token_expired.harn
+++ b/conformance/tests/stdlib/oauth_refresh_token_expired.harn
@@ -1,0 +1,88 @@
+// std/oauth/client: refresh token also expired -> HARN-OAU-002.
+//
+// Seeds an expired access token whose refresh token has also been
+// invalidated by the server (the canonical "invalid_grant" response
+// from the token endpoint per RFC 6749 §5.2). Asserts that `token(cli)`
+// raises an error tagged with the dedicated `HARN-OAU-002` diagnostic
+// so scripts can pattern-match on it and re-run authorization rather
+// than retrying. Also asserts the stored TokenSet is left unchanged
+// (a failed refresh must not stomp the credential we already have on
+// disk) and no `token_refreshed` audit event is emitted on the
+// failed path.
+import { client, token } from "std/oauth/client"
+import { custom } from "std/oauth/providers"
+import { memory } from "std/oauth/storage"
+
+pipeline test(task) {
+  let topic = "oauth.client.audit"
+  let cursor = event_log.latest(topic) ?? 0
+  let _ = mock_time(1700000000000)
+  let store = memory()
+  let provider = custom(
+    {
+      id: "mockExpiredRefresh",
+      auth_url: "https://idp.example/authorize",
+      token_url: "https://idp.example/token",
+      default_scopes: ["read"],
+    },
+  )
+  let now = to_int(timestamp())
+  let stored = {
+    access_token: "ACCESS-STALE",
+    refresh_token: "REFRESH-DEAD",
+    issued_at_unix: now - 3600,
+    expires_at_unix: now - 1800,
+    token_type: "Bearer",
+  }
+  store.set("mockExpiredRefresh", stored)
+  let cli = client(provider, {client_id: "cli-id", redirect_uri: "http://127.0.0.1:9999/cb", storage: store})
+  http_mock_clear()
+  http_mock(
+    "POST",
+    "https://idp.example/token",
+    {
+      status: 400,
+      body: "{\"error\":\"invalid_grant\",\"error_description\":\"refresh token expired\"}",
+      headers: {"content-type": "application/json"},
+    },
+  )
+  var threw = false
+  var caught_message = ""
+  try {
+    let _ = token(cli)
+  } catch (err) {
+    caught_message = to_string(err)
+    threw = true
+  }
+  assert(threw, "expired refresh token should have thrown")
+  assert(
+    contains(caught_message, "HARN-OAU-002"),
+    "error message must carry HARN-OAU-002 diagnostic, got: " + caught_message,
+  )
+  assert(
+    contains(caught_message, "invalid_grant") || contains(caught_message, "refresh token expired"),
+    "underlying server error_description should be threaded through, got: " + caught_message,
+  )
+  // Storage MUST NOT be wiped on a failed refresh — the caller still
+  // owns the (now-useless) previous credential and can re-run
+  // authorization without losing scope/expiry metadata for audit.
+  let after = store.get("mockExpiredRefresh")
+  assert_eq(after.access_token, "ACCESS-STALE", "storage access token unchanged after failed refresh")
+  assert_eq(
+    after.refresh_token,
+    "REFRESH-DEAD",
+    "storage refresh token unchanged after failed refresh",
+  )
+  // Confirm we did try to refresh exactly once — no silent retry.
+  let calls = http_mock_calls({include_sensitive: true})
+  assert_eq(len(calls), 1, "exactly one POST to the token endpoint")
+  assert(contains(calls[0].body, "grant_type=refresh_token"), "refresh grant used")
+  assert(contains(calls[0].body, "refresh_token=REFRESH-DEAD"), "old refresh token sent")
+  // No token_refreshed audit should fire because the refresh failed:
+  // event_log.latest() on the topic must not have advanced past the
+  // cursor captured before the call.
+  let latest_after = event_log.latest(topic) ?? 0
+  assert_eq(latest_after, cursor, "no audit events emitted on failed refresh")
+  let _ = unmock_time()
+  log("oauth refresh token expired ok")
+}

--- a/conformance/tests/stdlib/oauth_revoke.expected
+++ b/conformance/tests/stdlib/oauth_revoke.expected
@@ -1,0 +1,1 @@
+[harn] oauth revoke ok

--- a/conformance/tests/stdlib/oauth_revoke.harn
+++ b/conformance/tests/stdlib/oauth_revoke.harn
@@ -1,0 +1,83 @@
+// std/oauth/client: explicit revoke() POSTs the RFC 7009 hint, deletes
+// the stored TokenSet, and forces a re-authorization on subsequent use.
+//
+// Seeds a TokenSet, calls revoke(cli) once, then asserts:
+//   - The provider's revoke_url received a POST containing
+//     `token=<access_token>` and `client_id=<id>` (RFC 7009 §2.1).
+//   - Storage is empty afterwards (the storage delete is the
+//     authoritative local discard).
+//   - An `oauth.client.audit` `token_revoked` event is emitted with
+//     provider/storage_key + redacted prev token shape; the access
+//     token is never carried in the audit payload.
+//   - A subsequent `token(cli)` raises `HARN-OAU-002` (no refresh
+//     token available; re-run authorization) instead of silently
+//     succeeding.
+import { client, revoke, token } from "std/oauth/client"
+import { custom } from "std/oauth/providers"
+import { memory } from "std/oauth/storage"
+
+pipeline test(task) {
+  let topic = "oauth.client.audit"
+  let cursor = event_log.latest(topic) ?? 0
+  let _ = mock_time(1700000000000)
+  let store = memory()
+  let provider = custom(
+    {
+      id: "mockRevoke",
+      auth_url: "https://idp.example/authorize",
+      token_url: "https://idp.example/token",
+      revoke_url: "https://idp.example/revoke",
+      default_scopes: ["read"],
+    },
+  )
+  let now = to_int(timestamp())
+  let stored = {
+    access_token: "ACCESS-LIVE",
+    refresh_token: "REFRESH-LIVE",
+    issued_at_unix: now,
+    expires_at_unix: now + 3600,
+    token_type: "Bearer",
+  }
+  store.set("mockRevoke", stored)
+  let cli = client(provider, {client_id: "cli-id", redirect_uri: "http://127.0.0.1:9999/cb", storage: store})
+  http_mock_clear()
+  http_mock("POST", "https://idp.example/revoke", {status: 200, body: "", headers: {}})
+  revoke(cli)
+  let calls = http_mock_calls({include_sensitive: true})
+  assert_eq(len(calls), 1, "exactly one POST to the revoke endpoint")
+  assert_eq(calls[0].method, "POST", "revoke is a POST")
+  assert(contains(calls[0].url, "/revoke"), "hit revoke endpoint")
+  assert(contains(calls[0].body, "token=ACCESS-LIVE"), "RFC 7009 token= form param")
+  assert(contains(calls[0].body, "client_id=cli-id"), "client_id included in revoke body")
+  let after = store.get("mockRevoke")
+  assert(after == nil, "storage cleared after revoke")
+  let stream = event_log.subscribe({topic: topic, from_cursor: cursor})
+  let logged = stream.next().value
+  assert_eq(logged.kind, "token_revoked", "audit event kind")
+  assert_eq(logged.payload.provider, "mockRevoke", "audit provider id")
+  assert_eq(logged.payload.storage_key, "mockRevoke", "audit storage_key")
+  assert_eq(
+    logged.payload.revoke_endpoint,
+    "https://idp.example/revoke",
+    "audit records contacted endpoint",
+  )
+  assert_eq(logged.payload.prev.has_access_token, true, "audit records prev access presence")
+  assert_eq(logged.payload.prev.has_refresh_token, true, "audit records prev refresh presence")
+  assert(logged.payload.prev?.access_token == nil, "audit NEVER includes prev access token")
+  assert(logged.payload.prev?.refresh_token == nil, "audit NEVER includes prev refresh token")
+  // Subsequent use must force re-authorization with the HARN-OAU-002
+  // diagnostic so callers can distinguish "no token at all" from a
+  // transient network failure.
+  var threw = false
+  var msg = ""
+  try {
+    let _ = token(cli)
+  } catch (err) {
+    msg = to_string(err)
+    threw = true
+  }
+  assert(threw, "post-revoke token() should have thrown")
+  assert(contains(msg, "HARN-OAU-002"), "post-revoke error must carry HARN-OAU-002, got: " + msg)
+  let _ = unmock_time()
+  log("oauth revoke ok")
+}

--- a/crates/harn-stdlib/src/stdlib/oauth/client.harn
+++ b/crates/harn-stdlib/src/stdlib/oauth/client.harn
@@ -70,6 +70,10 @@ let __AUDIT_KIND_REFRESH = "token_refreshed"
 
 let __AUDIT_KIND_EXCHANGE = "token_exchanged"
 
+let __AUDIT_KIND_REVOKED = "token_revoked"
+
+let __DIAGNOSTIC_REFRESH_EXPIRED = "HARN-OAU-002"
+
 type OAuthClient = dict
 
 fn __require_string(value, field) {
@@ -366,10 +370,55 @@ fn __audit_exchange(provider_id, storage_key, next) {
   let _ = event_log.emit(__AUDIT_TOPIC, __AUDIT_KIND_EXCHANGE, payload, {provider: to_string(provider_id)})
 }
 
+fn __audit_revoked(provider_id, storage_key, prev, revoke_url_used) {
+  // Audit MUST NOT include the access token. Records presence + the
+  // (sanitised) endpoint that was contacted so compliance reviewers
+  // can confirm the RFC 7009 hint was used.
+  let payload = {
+    provider: to_string(provider_id),
+    storage_key: to_string(storage_key),
+    revoke_endpoint: __redact_endpoint(revoke_url_used),
+    prev: __redact_token(prev),
+  }
+  let _ = event_log.emit(__AUDIT_TOPIC, __AUDIT_KIND_REVOKED, payload, {provider: to_string(provider_id)})
+}
+
+fn __try_revoke_remote(cfg, token_value) {
+  // Best-effort RFC 7009 revoke. We never let a remote failure block
+  // the local storage delete: revocation is a hygiene step on top of
+  // discarding the credential locally, and the storage delete is the
+  // authoritative client-side action.
+  if cfg.revoke_url == nil {
+    return nil
+  }
+  let url_text = to_string(cfg.revoke_url)
+  if url_text == "" {
+    return nil
+  }
+  let headers = {"Content-Type": "application/x-www-form-urlencoded", Accept: "application/json"}
+  let body = __form_body([{key: "token", value: token_value}, {key: "client_id", value: cfg.client_id}])
+  try {
+    let _ = http_post(url_text, body, {headers: headers})
+  } catch (_err) {
+    let _ = nil
+  }
+  return url_text
+}
+
+fn __revoke_locked(cfg) {
+  let prev = cfg.storage.get(cfg.storage_key)
+  let access = prev?.access_token
+  let remote_url = access == nil || to_string(access) == "" ? nil : __try_revoke_remote(cfg, to_string(access))
+  cfg.storage.delete(cfg.storage_key)
+  __audit_revoked(cfg.provider_id, cfg.storage_key, prev, remote_url)
+  return nil
+}
+
 fn __refresh_locked(cfg, prev_token, reason) {
   let refresh = prev_token?.refresh_token
   if refresh == nil || to_string(refresh) == "" {
-    throw "std/oauth/client: no refresh_token available; re-run authorization"
+    throw __DIAGNOSTIC_REFRESH_EXPIRED
+      + ": std/oauth/client: no refresh_token available; re-run authorization"
   }
   var form = [{key: "grant_type", value: "refresh_token"}, {key: "refresh_token", value: refresh}]
   let scopes_str = __join_scopes(cfg.scopes, cfg.scope_separator)
@@ -377,7 +426,16 @@ fn __refresh_locked(cfg, prev_token, reason) {
     form = form + [{key: "scope", value: scopes_str}]
   }
   let issued_at = __now_seconds()
-  let parsed = __post_token_request(cfg.token_url, cfg.client_id, cfg.client_secret, cfg.token_auth_method, form)
+  var parsed = nil
+  try {
+    parsed = __post_token_request(cfg.token_url, cfg.client_id, cfg.client_secret, cfg.token_auth_method, form)
+  } catch (err) {
+    // Refresh-grant failures are special: the stored refresh token is
+    // gone (expired, revoked, or rotated by another caller). Surface
+    // the dedicated HARN-OAU-002 diagnostic so scripts can pattern-
+    // match on it and re-run authorization rather than retrying.
+    throw __DIAGNOSTIC_REFRESH_EXPIRED + ": std/oauth/client: refresh failed (" + to_string(err) + ")"
+  }
   let next_token = __build_token_set(parsed, cfg.scopes, issued_at, refresh)
   cfg.storage.set(cfg.storage_key, next_token)
   __audit_refresh(cfg.provider_id, cfg.storage_key, prev_token, next_token, reason)
@@ -387,7 +445,8 @@ fn __refresh_locked(cfg, prev_token, reason) {
 fn __maybe_refresh(cfg, reason) {
   let stored = cfg.storage.get(cfg.storage_key)
   if stored == nil {
-    throw "std/oauth/client: no token in storage; run authorization first"
+    throw __DIAGNOSTIC_REFRESH_EXPIRED
+      + ": std/oauth/client: no token in storage; run authorization first"
   }
   let now_s = __now_seconds()
   if !__token_is_stale(stored, now_s) && reason != "forced" && reason != "post_401" {
@@ -567,7 +626,7 @@ pub fn client(provider, opts) -> OAuthClient {
     token: { -> __get_valid_token(cfg).access_token },
     current_token: { -> cfg.storage.get(cfg.storage_key) },
     request: { method, url, http_opts = nil -> __token_request(cfg, method, url, http_opts) },
-    revoke: { -> cfg.storage.delete(cfg.storage_key) },
+    revoke: { -> __revoke_locked(cfg) },
   }
 }
 
@@ -665,4 +724,28 @@ pub fn exchange_code(cli, pkce, code, state) {
     throw "std/oauth/client: exchange_code() requires an OAuth client handle"
   }
   return cli.exchange_code(pkce, code, state)
+}
+
+/**
+ * revoke discards the locally-stored token and, when the provider
+ * declares a `revoke_url`, sends a best-effort RFC 7009 revocation
+ * POST so the server can invalidate the access token. The storage
+ * delete is authoritative on the client side — remote revocation
+ * failures are swallowed and never block the local discard.
+ *
+ * Subsequent calls to `token(cli)` or `request(cli, ...)` will throw
+ * `HARN-OAU-002` (no refresh_token available) until a new
+ * authorization flow is run.
+ *
+ * @effects: [time, net]
+ * @allocation: heap
+ * @errors: [invalid_argument]
+ * @api_stability: experimental
+ * @example: revoke(cli)
+ */
+pub fn revoke(cli) {
+  if type_of(cli) != "dict" || cli?._namespace != "oauth_client" {
+    throw "std/oauth/client: revoke() requires an OAuth client handle"
+  }
+  return cli.revoke()
 }


### PR DESCRIPTION
Closes #1908. Part of epic #1885 (OAuth stdlib).

## Summary

Gap-fill on top of the existing OA-01..OA-06 OAuth surface: adds the
three remaining conformance fixtures the OA-07 spec called for, plus
the small surface changes those fixtures depend on (a real public
`revoke(cli)` and the `HARN-OAU-002` diagnostic tag on
re-authorization-required error paths).

## New fixtures

| Fixture | Asserts |
|---|---|
| `oauth_refresh_token_expired` | Server returns `invalid_grant` on the refresh-grant call. `token(cli)` raises an error tagged with `HARN-OAU-002`, the stored TokenSet is left untouched, and no `token_refreshed` audit event is emitted. |
| `oauth_revoke` | `revoke(cli)` issues a best-effort RFC 7009 POST to the provider's `revoke_url` (with `token=...&client_id=...`), deletes the storage entry, emits a `token_revoked` audit event with the redacted prev token shape, and the next `token(cli)` raises `HARN-OAU-002`. |
| `oauth_pkce_validates` | Mocks the server's mismatched-`code_verifier` rejection. `exchange_code(...)` propagates the server's `error_description`, persists no TokenSet, and emits no audit event. The fixture also asserts the client did send `code_verifier=` on the wire so the contract is exercised end-to-end. |

## Already covered (no new fixture needed)

| Spec item | Existing fixture |
|---|---|
| `oauth_authcode_pkce_basic` | `oauth_client_auth_code` |
| `oauth_device_flow_basic` | `oauth_device_flow_happy_path` |
| `oauth_refresh_on_401` | `oauth_client_refresh_on_401` |
| `oauth_refresh_preemptive` | `oauth_client_refresh_near_ttl` |
| `oauth_storage_memory` / `_file` / `_cloud` / custom | `oauth_storage` (exercises all four backends in one fixture; deliberate single-file design to share setup) |
| `oauth_redaction_patterns` | `token_redaction_default_patterns` + `_custom_pattern` + `_tool_passthrough` (from OA-06) |
| `oauth_provider_*` | `oauth_provider_catalog` drives all ten preconfigured providers through one end-to-end mock flow |

## Surface changes (`crates/harn-stdlib/src/stdlib/oauth/client.harn`)

- `pub fn revoke(cli)` is now a real top-level entry: best-effort RFC 7009 POST to the provider's `revoke_url` (with `token` + `client_id` form fields), authoritative local storage delete, and a `token_revoked` `oauth.client.audit` event whose payload carries the contacted endpoint and the redacted prev token shape (never the access/refresh tokens). Remote failures are swallowed so they never block the local discard.
- New `HARN-OAU-002` diagnostic prefix is applied to two error paths that require re-running authorization:
  - `__refresh_locked` when the server rejects the refresh grant (wrapped via try/catch so the original `error_description` is preserved in the message).
  - `__maybe_refresh` when there is no token in storage at all (e.g. immediately after `revoke(cli)`).

## Gate results

- `cargo fmt --all`: clean
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `make fmt-harn`: OK
- `make lint-harn`: OK (only pre-existing `HARN-LNT-052` ambient-clock warnings, matches surrounding code)
- `make lint-test-patterns`: OK
- `cargo run --bin harn -- test conformance --filter oauth`: 12 passed, 0 failed
- `cargo run --bin harn -- test conformance --filter stdlib`: 242 passed, 0 failed
- `make test`: 4424 passed, 2 skipped

## Test plan

- [x] `cargo run --bin harn -- test conformance --filter oauth` passes locally
- [x] `make test` passes locally
- [x] CHANGELOG has exactly one `## Unreleased` and one `## v0.8.26`
- [ ] CI green on the PR