### PR TITLE
Add ReminderInject trigger handler (#1876)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,29 @@ condensed series summaries instead of full per-patch history.
   session/cloud org/custom), the provider catalogue against ten
   preconfigured providers, and the OA-06 redaction patterns. Part of
   epic #1885 (OAuth stdlib).
+- **`ReminderInject` trigger handler variant (#1876).** Adds a new
+  `TriggerHandlerSpec::ReminderInject` variant + the matching
+  `ReminderInject({...})` constructor in `std/triggers`, completing the
+  CH-05 leg of epic #1870 (Agent channels & periodic prompts). Unlike
+  Local/Worker/SpawnToPool handlers, ReminderInject does not spawn a
+  task: when the trigger matches, the dispatcher resolves a target
+  session (`"current"`, `"parent"`, a literal session id, or a closure
+  `event -> string?`), renders a `.harn.prompt` body template against
+  `{{ event }}` / `{{ match }}` / `{{ batch }}`, builds a
+  `SystemReminder` (#1815) carrying the rendered body plus the
+  binding's `tags` / `ttl_turns` / `dedupe_key` / `propagate` /
+  `role_hint` / `preserve_on_compact` metadata, and injects it via
+  `agent_sessions::inject_reminder`. The reminder surfaces at the
+  target session's next turn boundary — same path as
+  `transcript.inject_reminder` — so existing dedupe, TTL, and
+  capability-aware rendering all apply. Missing target sessions are
+  recorded as `triggers.reminder_inject.audit` lifecycle audit entries
+  (outcome `dropped`, reason `target_missing` or
+  `target_unknown_session`) and the dispatch returns a `dropped`
+  result rather than failing the trigger. Combined with CH-04 batching
+  this enables declarative "every N events OR every T time" reminder
+  injection without user-side counter state. Conformance:
+  `conformance/tests/triggers/trigger_reminder_inject_{targets_concrete_session,only_targets_named_session,missing_target_drops_with_audit,closure_target}.harn`.
 - **Channel scope resolver completes the four-tier hierarchy (#1874).**
   Formalises the `session < pipeline < tenant < org` scope chain for
   `emit_channel(...)` and `channel_events(...)`, building on the producer

--- a/conformance/tests/triggers/trigger_reminder_inject_closure_target.expected
+++ b/conformance/tests/triggers/trigger_reminder_inject_closure_target.expected
@@ -1,0 +1,6 @@
+true
+true
+1
+1
+Routed to acme.
+Routed to widget.

--- a/conformance/tests/triggers/trigger_reminder_inject_closure_target.harn
+++ b/conformance/tests/triggers/trigger_reminder_inject_closure_target.harn
@@ -1,0 +1,69 @@
+import "std/triggers"
+
+/**
+ * Verifies the ReminderInject (#1876) handler's closure-form target
+ * resolution: when `target` is a closure, the dispatcher runs it with the
+ * trigger event and uses the returned string as the session id. This lets
+ * a single trigger registration route different events to different
+ * sessions based on payload contents.
+ */
+pipeline test(task) {
+  let acme_session = agent_session_open("trigger-reminder-inject-closure-acme")
+  let widget_session = agent_session_open("trigger-reminder-inject-closure-widget")
+  agent_session_reset(acme_session)
+  agent_session_reset(widget_session)
+  let unique = to_string(to_int(timestamp())) + "-" + to_string(random_int(100000, 999999))
+  let handle: TriggerHandle = trigger_register(
+    {
+      id: "trigger-reminder-inject-closure-" + unique,
+      kind: "issue.opened",
+      provider: "github",
+      handler: ReminderInject(
+        {
+          target: { event ->
+            if event.tenant_id == "acme" {
+              return "trigger-reminder-inject-closure-acme"
+            }
+            return "trigger-reminder-inject-closure-widget"
+          },
+          body: "Routed to {{ event.tenant_id }}.",
+        },
+      ),
+      when: nil,
+      retry: nil,
+      match: {events: ["issue.opened"]},
+      events: nil,
+      dedupe_key: nil,
+      filter: nil,
+      budget: nil,
+      manifest_path: nil,
+      package_name: "conformance",
+    },
+  )
+  let to_acme = trigger_fire(
+    handle,
+    {
+      provider: "github",
+      kind: "issue.opened",
+      tenant_id: "acme",
+      headers: {x_delivery: "evt-acme-" + unique},
+    },
+  )
+  let to_widget = trigger_fire(
+    handle,
+    {
+      provider: "github",
+      kind: "issue.opened",
+      tenant_id: "widget",
+      headers: {x_delivery: "evt-widget-" + unique},
+    },
+  )
+  println(to_acme.result?.target_session_id == acme_session)
+  println(to_widget.result?.target_session_id == widget_session)
+  let acme_reminders = transcript_events_by_kind(agent_session_snapshot(acme_session), "system_reminder")
+  let widget_reminders = transcript_events_by_kind(agent_session_snapshot(widget_session), "system_reminder")
+  println(len(acme_reminders))
+  println(len(widget_reminders))
+  println(acme_reminders[0].reminder.body)
+  println(widget_reminders[0].reminder.body)
+}

--- a/conformance/tests/triggers/trigger_reminder_inject_missing_target_drops_with_audit.expected
+++ b/conformance/tests/triggers/trigger_reminder_inject_missing_target_drops_with_audit.expected
@@ -1,0 +1,7 @@
+true
+true
+true
+true
+1
+dropped
+target_unknown_session

--- a/conformance/tests/triggers/trigger_reminder_inject_missing_target_drops_with_audit.harn
+++ b/conformance/tests/triggers/trigger_reminder_inject_missing_target_drops_with_audit.harn
@@ -1,0 +1,53 @@
+import { lifecycle_audit_log_take } from "std/lifecycle"
+import "std/triggers"
+
+/**
+ * Verifies the ReminderInject (#1876) handler's failure-mode contract: a
+ * target session that does not exist is dropped gracefully with a
+ * `triggers.reminder_inject.audit` audit entry tagged `target_unknown_session`
+ * rather than failing the dispatch. The trigger remains active for future
+ * dispatches.
+ */
+pipeline test(task) {
+  let _ = lifecycle_audit_log_take()
+  let unique = to_string(to_int(timestamp())) + "-" + to_string(random_int(100000, 999999))
+  let handle: TriggerHandle = trigger_register(
+    {
+      id: "trigger-reminder-inject-missing-" + unique,
+      kind: "issue.opened",
+      provider: "github",
+      handler: ReminderInject({target: "does-not-exist-" + unique, body: "Should never be injected."}),
+      when: nil,
+      retry: nil,
+      match: {events: ["issue.opened"]},
+      events: nil,
+      dedupe_key: nil,
+      filter: nil,
+      budget: nil,
+      manifest_path: nil,
+      package_name: "conformance",
+    },
+  )
+  let dispatch = trigger_fire(
+    handle,
+    {provider: "github", kind: "issue.opened", headers: {x_delivery: "evt-" + unique}},
+  )
+  println(dispatch.status == "dispatched")
+  println(dispatch.result?.status == "dropped")
+  println(dispatch.result?.reason == "target_unknown_session")
+  println(dispatch.result?.target_kind == "concrete")
+  let audits = lifecycle_audit_log_take()
+  var drop_audits = 0
+  var outcome = ""
+  var reason = ""
+  for audit in audits {
+    if audit.kind == "triggers.reminder_inject.audit" {
+      drop_audits = drop_audits + 1
+      outcome = audit.payload.outcome
+      reason = audit.payload.reason
+    }
+  }
+  println(drop_audits)
+  println(outcome)
+  println(reason)
+}

--- a/conformance/tests/triggers/trigger_reminder_inject_only_targets_named_session.expected
+++ b/conformance/tests/triggers/trigger_reminder_inject_only_targets_named_session.expected
@@ -1,0 +1,5 @@
+true
+true
+1
+0
+Targeted only.

--- a/conformance/tests/triggers/trigger_reminder_inject_only_targets_named_session.harn
+++ b/conformance/tests/triggers/trigger_reminder_inject_only_targets_named_session.harn
@@ -1,0 +1,43 @@
+import "std/triggers"
+
+/**
+ * Verifies the ReminderInject (#1876) handler injects into only the
+ * specified target session: when multiple sessions are registered,
+ * other sessions' transcripts remain untouched. Guards against
+ * cross-session leakage of reminders fired from a single dispatch.
+ */
+pipeline test(task) {
+  let target = agent_session_open("trigger-reminder-inject-router-target")
+  let bystander = agent_session_open("trigger-reminder-inject-router-bystander")
+  agent_session_reset(target)
+  agent_session_reset(bystander)
+  let unique = to_string(to_int(timestamp())) + "-" + to_string(random_int(100000, 999999))
+  let handle: TriggerHandle = trigger_register(
+    {
+      id: "trigger-reminder-inject-router-" + unique,
+      kind: "issue.opened",
+      provider: "github",
+      handler: ReminderInject({target: target, body: "Targeted only."}),
+      when: nil,
+      retry: nil,
+      match: {events: ["issue.opened"]},
+      events: nil,
+      dedupe_key: nil,
+      filter: nil,
+      budget: nil,
+      manifest_path: nil,
+      package_name: "conformance",
+    },
+  )
+  let dispatch = trigger_fire(
+    handle,
+    {provider: "github", kind: "issue.opened", headers: {x_delivery: "evt-" + unique}},
+  )
+  println(dispatch.status == "dispatched")
+  println(dispatch.result?.target_session_id == target)
+  let target_reminders = transcript_events_by_kind(agent_session_snapshot(target), "system_reminder")
+  let bystander_reminders = transcript_events_by_kind(agent_session_snapshot(bystander), "system_reminder")
+  println(len(target_reminders))
+  println(len(bystander_reminders))
+  println(target_reminders[0].reminder.body)
+}

--- a/conformance/tests/triggers/trigger_reminder_inject_targets_concrete_session.expected
+++ b/conformance/tests/triggers/trigger_reminder_inject_targets_concrete_session.expected
@@ -1,0 +1,11 @@
+true
+true
+true
+true
+1
+Inject from github.issue.opened
+release_reminder
+2
+release_reminder
+1
+injected

--- a/conformance/tests/triggers/trigger_reminder_inject_targets_concrete_session.harn
+++ b/conformance/tests/triggers/trigger_reminder_inject_targets_concrete_session.harn
@@ -1,0 +1,66 @@
+import { lifecycle_audit_log_take } from "std/lifecycle"
+import "std/triggers"
+
+/**
+ * Verifies the ReminderInject (#1876) handler injects a `SystemReminder`
+ * into the named concrete target session's transcript when the trigger
+ * matches, and emits a `triggers.reminder_inject.audit` lifecycle audit
+ * entry recording the outcome.
+ */
+pipeline test(task) {
+  let _ = lifecycle_audit_log_take()
+  let target_session = agent_session_open("trigger-reminder-inject-concrete")
+  agent_session_reset(target_session)
+  let unique = to_string(to_int(timestamp())) + "-" + to_string(random_int(100000, 999999))
+  let trigger_id = "trigger-reminder-inject-concrete-" + unique
+  let handle: TriggerHandle = trigger_register(
+    {
+      id: trigger_id,
+      kind: "issue.opened",
+      provider: "github",
+      handler: ReminderInject(
+        {
+          target: target_session,
+          body: "Inject from {{ event.provider }}.{{ event.kind }}",
+          tags: ["release_reminder"],
+          ttl_turns: 2,
+          dedupe_key: "release_reminder",
+        },
+      ),
+      when: nil,
+      retry: nil,
+      match: {events: ["issue.opened"]},
+      events: nil,
+      dedupe_key: nil,
+      filter: nil,
+      budget: nil,
+      manifest_path: nil,
+      package_name: "conformance",
+    },
+  )
+  let dispatch = trigger_fire(
+    handle,
+    {provider: "github", kind: "issue.opened", headers: {x_delivery: "evt-" + unique}},
+  )
+  println(dispatch.status == "dispatched")
+  println(dispatch.result?.status == "injected")
+  println(dispatch.result?.target_kind == "concrete")
+  println(dispatch.result?.target_session_id == target_session)
+  let reminders = transcript_events_by_kind(agent_session_snapshot(target_session), "system_reminder")
+  println(len(reminders))
+  println(reminders[0].reminder.body)
+  println(reminders[0].reminder.tags[0])
+  println(reminders[0].reminder.ttl_turns)
+  println(reminders[0].reminder.dedupe_key)
+  let audits = lifecycle_audit_log_take()
+  var inject_audit_count = 0
+  var injected_outcome = ""
+  for audit in audits {
+    if audit.kind == "triggers.reminder_inject.audit" {
+      inject_audit_count = inject_audit_count + 1
+      injected_outcome = audit.payload.outcome
+    }
+  }
+  println(inject_audit_count)
+  println(injected_outcome)
+}

--- a/crates/harn-cli/src/commands/dump_trigger_quickref.rs
+++ b/crates/harn-cli/src/commands/dump_trigger_quickref.rs
@@ -144,7 +144,7 @@ fn generate_file() -> String {
     out.push_str("Audit a project before deploy with `harn routes <root> --json`; it reports each declarative trigger's route path, handler module, budgets, inferred host capabilities, vendor-lock disclosure, and prompt/template overhead without executing handler code.\n\n");
 
     out.push_str("## Handler variants\n\n");
-    out.push_str("`handler:` accepts a closure (in-process), an `a2a://` or `worker://` URI string, or a handler-variant dict. The dict form covers compositions that need more than a single callable; today only `SpawnToPool` ships, more variants will plug into the same syntax over time.\n\n");
+    out.push_str("`handler:` accepts a closure (in-process), an `a2a://` or `worker://` URI string, or a handler-variant dict. The dict form covers compositions that need more than a single callable; `SpawnToPool` and `ReminderInject` ship today, more variants will plug into the same syntax over time.\n\n");
     out.push_str("```harn\n");
     out.push_str("import { SpawnToPool } from \"std/triggers\"\n");
     out.push_str("import { pool_create } from \"std/lifecycle/pool\"\n\n");
@@ -162,6 +162,23 @@ fn generate_file() -> String {
     out.push_str("})\n");
     out.push_str("```\n\n");
     out.push_str("The dispatcher invokes `task_factory(event)` per match, extracts priority + fair-queue key from the event payload (missing paths fall back to default priority 0 / null key), and submits the resulting closure to the named pool under its queue strategy + backpressure policy. Pool rejections (`drop_newest`, etc.) reuse the `lifecycle.pool.audit` channel that direct `pool.submit` calls emit on. The dispatch result is shaped as a `pool_task` handle so handlers can call `pool_wait(dispatch.result)` directly.\n\n");
+
+    out.push_str("```harn\n");
+    out.push_str("import { ReminderInject } from \"std/triggers\"\n\n");
+    out.push_str("trigger_register({\n");
+    out.push_str("  kind: \"channel.emit\",\n");
+    out.push_str("  provider: \"channel\",\n");
+    out.push_str("  match: {events: [\"channel:pr.merged\"]},\n");
+    out.push_str("  handler: ReminderInject({\n");
+    out.push_str("    target: \"current\",                       // \"current\", \"parent\", a literal session id, or a closure\n");
+    out.push_str("    body: \"PR {{ event.provider_payload.payload.number }} merged. Consider cutting a patch release.\",\n");
+    out.push_str("    tags: [\"release_reminder\"],\n");
+    out.push_str("    ttl_turns: 1,\n");
+    out.push_str("    dedupe_key: \"release_reminder\",\n");
+    out.push_str("  }),\n");
+    out.push_str("})\n");
+    out.push_str("```\n\n");
+    out.push_str("`ReminderInject` (#1876) injects a `SystemReminder` (#1815) into the target running session at its next turn boundary — no spawn, no resume, no signal. `target` resolves at dispatch time: `\"current\"` walks the owning session, `\"parent\"` walks its parent in the session lineage, any other string is a literal session id, and a closure `event -> string?` lets the trigger pick a target dynamically. `body` is a `.harn.prompt` template rendered against `{{ event }}` (the full trigger event), `{{ match }}` (`matched_at`), and `{{ batch }}` (when flow-control batching is in effect). `tags`, `ttl_turns`, `dedupe_key`, `propagate`, `role_hint`, and `preserve_on_compact` mirror `transcript.inject_reminder`. Missing target sessions are dropped gracefully with a `triggers.reminder_inject.audit` audit entry instead of failing the dispatch.\n\n");
 
     out.push_str("## Provider catalog\n\n");
     out.push_str("This table is generated from `std/triggers::list_providers()` / `ProviderCatalog` metadata.\n\n");

--- a/crates/harn-cli/src/commands/trigger/ops.rs
+++ b/crates/harn-cli/src/commands/trigger/ops.rs
@@ -722,6 +722,7 @@ fn handler_kind(binding: &harn_vm::triggers::registry::TriggerBinding) -> &'stat
         TriggerHandlerSpec::Persona { .. } => "persona",
         TriggerHandlerSpec::AutoResume { .. } => "auto_resume",
         TriggerHandlerSpec::SpawnToPool { .. } => "spawn_to_pool",
+        TriggerHandlerSpec::ReminderInject { .. } => "reminder_inject",
     }
 }
 
@@ -733,6 +734,7 @@ fn handler_label(binding: &harn_vm::triggers::registry::TriggerBinding) -> Strin
         TriggerHandlerSpec::Persona { binding } => binding.name.clone(),
         TriggerHandlerSpec::AutoResume { worker_id } => worker_id.clone(),
         TriggerHandlerSpec::SpawnToPool { pool, .. } => pool.clone(),
+        TriggerHandlerSpec::ReminderInject { target, .. } => target.kind().to_string(),
     }
 }
 
@@ -744,6 +746,12 @@ fn target_uri(binding: &harn_vm::triggers::registry::TriggerBinding) -> String {
         TriggerHandlerSpec::Persona { binding } => format!("persona://{}", binding.name),
         TriggerHandlerSpec::AutoResume { worker_id } => format!("auto_resume://{worker_id}"),
         TriggerHandlerSpec::SpawnToPool { pool, .. } => format!("pool://{pool}"),
+        TriggerHandlerSpec::ReminderInject { target, .. } => match target {
+            harn_vm::triggers::registry::TargetExpr::Concrete(id) => {
+                format!("reminder_inject://concrete/{id}")
+            }
+            other => format!("reminder_inject://{}", other.kind()),
+        },
     }
 }
 

--- a/crates/harn-stdlib/src/stdlib/stdlib_triggers.harn
+++ b/crates/harn-stdlib/src/stdlib/stdlib_triggers.harn
@@ -973,6 +973,48 @@ pub fn SpawnToPool(options: dict) -> dict {
 }
 
 /**
+ * ReminderInject builds a handler-variant dict that injects a
+ * `SystemReminder` (#1815) into the target running session when the trigger
+ * matches (#1876). Unlike Local/Worker handlers, no new task is spawned —
+ * the reminder appears at the target session's next turn boundary.
+ *
+ * `target` accepts the string `"current"` (the trigger's owning session,
+ * the default), `"parent"` (the parent of the owning session), any other
+ * string as a concrete session id, or a closure `event -> string?` that
+ * returns the session id at dispatch time. The closure form lets the
+ * trigger pick a target dynamically from the event payload.
+ *
+ * `body` is a `.harn.prompt` template rendered against `{{ event }}`,
+ * `{{ match }}` (`matched_at`), and `{{ batch }}` when flow-control
+ * batching is in effect.
+ *
+ * `tags`, `ttl_turns`, `dedupe_key`, `propagate`, `role_hint`, and
+ * `preserve_on_compact` mirror `transcript.inject_reminder` (#1815 R-02);
+ * see `docs/src/system-reminders.md`. Missing target sessions are dropped
+ * gracefully with a `triggers.reminder_inject.audit` audit entry instead
+ * of failing the dispatch.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: trigger_register({handler: ReminderInject({target: "current", body: "{{ event.kind }} arrived"})})
+ */
+pub fn ReminderInject(options: dict) -> dict {
+  return {
+    kind: "reminder_inject",
+    target: options?.target,
+    body: options.body,
+    tags: options?.tags,
+    ttl_turns: options?.ttl_turns,
+    dedupe_key: options?.dedupe_key,
+    propagate: options?.propagate,
+    role_hint: options?.role_hint,
+    preserve_on_compact: options?.preserve_on_compact,
+  }
+}
+
+/**
  * list_providers.
  *
  * @effects: []

--- a/crates/harn-vm/src/stdlib/triggers_stdlib.rs
+++ b/crates/harn-vm/src/stdlib/triggers_stdlib.rs
@@ -13,6 +13,7 @@ use crate::event_log::{
 };
 use crate::triggers::dispatcher::current_dispatch_context;
 use crate::triggers::dispatcher::DEFAULT_MAX_ATTEMPTS;
+use crate::triggers::registry::TargetExpr;
 use crate::triggers::test_util::{clock, run_trigger_harness_fixture};
 use crate::triggers::{
     deregister_webhook_intake, dynamic_deregister, dynamic_register, feed_webhook_intake,
@@ -1828,9 +1829,9 @@ fn parse_handler_value(
     }
 }
 
-/// Parse handler-variant dicts. Today only `SpawnToPool` (#1889) takes this
-/// shape; future variants (e.g. `ReminderInject` from #1876) plug in here so
-/// the trigger DSL keeps a single uniform `handler:` syntax.
+/// Parse handler-variant dicts. `SpawnToPool` (#1889) and `ReminderInject`
+/// (#1876) both ship as dict-shaped handlers so the trigger DSL keeps a
+/// single uniform `handler:` syntax; future variants plug in here too.
 fn parse_handler_dict(
     map: &BTreeMap<String, VmValue>,
     builtin: &str,
@@ -1890,8 +1891,203 @@ fn parse_handler_dict(
                 descriptor,
             ))
         }
+        "reminder_inject" => parse_reminder_inject_handler(map, builtin),
         other => Err(VmError::Runtime(format!(
-            "{builtin}: unsupported handler variant '{other}'; expected 'spawn_to_pool'"
+            "{builtin}: unsupported handler variant '{other}'; expected 'spawn_to_pool' or 'reminder_inject'"
+        ))),
+    }
+}
+
+/// Parse the ReminderInject (#1876) handler dict. `target` resolution is
+/// one of: a string literal (`"current"`, `"parent"`, or any other value
+/// interpreted as a concrete session id), or a closure that returns the
+/// session id at dispatch time. Reminder metadata mirrors the
+/// `transcript.inject_reminder` (#1815 R-02) shape so authors can reuse
+/// the same mental model.
+fn parse_reminder_inject_handler(
+    map: &BTreeMap<String, VmValue>,
+    builtin: &str,
+) -> Result<(TriggerHandlerSpec, serde_json::Value), VmError> {
+    let target_value = map.get("target").or_else(|| map.get("target_session_id"));
+    let target = match target_value {
+        None | Some(VmValue::Nil) => TargetExpr::Current,
+        Some(VmValue::String(s)) => match s.as_ref() {
+            "current" => TargetExpr::Current,
+            "parent" => TargetExpr::Parent,
+            other if !other.is_empty() => TargetExpr::Concrete(other.to_string()),
+            _ => {
+                return Err(VmError::Runtime(format!(
+                    "{builtin}: ReminderInject `target` string must be 'current', 'parent', or a non-empty session id"
+                )));
+            }
+        },
+        Some(VmValue::Closure(closure)) => TargetExpr::Closure(closure.clone()),
+        Some(other) => {
+            return Err(VmError::Runtime(format!(
+                "{builtin}: ReminderInject `target` must be a string ('current'/'parent'/session id) or a closure returning a session id, got {}",
+                other.type_name()
+            )));
+        }
+    };
+
+    let body = match map.get("body") {
+        Some(VmValue::String(s)) => s.to_string(),
+        None | Some(VmValue::Nil) => {
+            return Err(VmError::Runtime(format!(
+                "{builtin}: ReminderInject handler requires `body` (string template)"
+            )));
+        }
+        Some(other) => {
+            return Err(VmError::Runtime(format!(
+                "{builtin}: ReminderInject `body` must be a string, got {}",
+                other.type_name()
+            )));
+        }
+    };
+
+    let tags = parse_reminder_tags(map, builtin)?;
+    let ttl_turns = parse_reminder_ttl_turns(map, builtin)?;
+    let dedupe_key = optional_path_string(map, "dedupe_key", "ReminderInject")?;
+    let propagate = parse_reminder_propagate(map, builtin)?;
+    let role_hint = parse_reminder_role_hint(map, builtin)?;
+    let preserve_on_compact = match map.get("preserve_on_compact") {
+        None | Some(VmValue::Nil) => false,
+        Some(VmValue::Bool(b)) => *b,
+        Some(other) => {
+            return Err(VmError::Runtime(format!(
+                "{builtin}: ReminderInject `preserve_on_compact` must be a bool, got {}",
+                other.type_name()
+            )));
+        }
+    };
+
+    let descriptor = serde_json::json!({
+        "kind": "reminder_inject",
+        "target": target.kind(),
+        "target_session_id": match &target {
+            TargetExpr::Concrete(id) => serde_json::Value::String(id.clone()),
+            _ => serde_json::Value::Null,
+        },
+        "body": &body,
+        "tags": &tags,
+        "ttl_turns": ttl_turns,
+        "dedupe_key": &dedupe_key,
+        "propagate": propagate.as_str(),
+        "role_hint": role_hint.as_str(),
+        "preserve_on_compact": preserve_on_compact,
+    });
+
+    Ok((
+        TriggerHandlerSpec::ReminderInject {
+            target,
+            body,
+            tags,
+            ttl_turns,
+            dedupe_key,
+            propagate,
+            role_hint,
+            preserve_on_compact,
+        },
+        descriptor,
+    ))
+}
+
+fn parse_reminder_tags(
+    map: &BTreeMap<String, VmValue>,
+    builtin: &str,
+) -> Result<Vec<String>, VmError> {
+    match map.get("tags") {
+        None | Some(VmValue::Nil) => Ok(Vec::new()),
+        Some(VmValue::List(list)) => {
+            let mut tags = Vec::with_capacity(list.len());
+            for item in list.iter() {
+                let VmValue::String(text) = item else {
+                    return Err(VmError::Runtime(format!(
+                        "{builtin}: ReminderInject `tags` entries must be strings, got {}",
+                        item.type_name()
+                    )));
+                };
+                let trimmed = text.trim();
+                if trimmed.is_empty() {
+                    return Err(VmError::Runtime(format!(
+                        "{builtin}: ReminderInject `tags` entries must be non-empty strings"
+                    )));
+                }
+                let tag = trimmed.to_string();
+                if !tags.contains(&tag) {
+                    tags.push(tag);
+                }
+            }
+            Ok(tags)
+        }
+        Some(other) => Err(VmError::Runtime(format!(
+            "{builtin}: ReminderInject `tags` must be a list of strings, got {}",
+            other.type_name()
+        ))),
+    }
+}
+
+fn parse_reminder_ttl_turns(
+    map: &BTreeMap<String, VmValue>,
+    builtin: &str,
+) -> Result<Option<i64>, VmError> {
+    match map.get("ttl_turns") {
+        None | Some(VmValue::Nil) => Ok(None),
+        Some(VmValue::Int(value)) => {
+            if *value <= 0 {
+                Err(VmError::Runtime(format!(
+                    "{builtin}: ReminderInject `ttl_turns` must be > 0"
+                )))
+            } else {
+                Ok(Some(*value))
+            }
+        }
+        Some(other) => Err(VmError::Runtime(format!(
+            "{builtin}: ReminderInject `ttl_turns` must be an int or nil, got {}",
+            other.type_name()
+        ))),
+    }
+}
+
+fn parse_reminder_propagate(
+    map: &BTreeMap<String, VmValue>,
+    builtin: &str,
+) -> Result<crate::llm::helpers::ReminderPropagate, VmError> {
+    match map.get("propagate") {
+        None | Some(VmValue::Nil) => Ok(crate::llm::helpers::ReminderPropagate::Session),
+        Some(VmValue::String(s)) => match s.as_ref() {
+            "all" => Ok(crate::llm::helpers::ReminderPropagate::All),
+            "session" => Ok(crate::llm::helpers::ReminderPropagate::Session),
+            "none" => Ok(crate::llm::helpers::ReminderPropagate::None),
+            other => Err(VmError::Runtime(format!(
+                "{builtin}: ReminderInject `propagate` must be 'all', 'session', or 'none', got '{other}'"
+            ))),
+        },
+        Some(other) => Err(VmError::Runtime(format!(
+            "{builtin}: ReminderInject `propagate` must be a string, got {}",
+            other.type_name()
+        ))),
+    }
+}
+
+fn parse_reminder_role_hint(
+    map: &BTreeMap<String, VmValue>,
+    builtin: &str,
+) -> Result<crate::llm::helpers::ReminderRoleHint, VmError> {
+    match map.get("role_hint") {
+        None | Some(VmValue::Nil) => Ok(crate::llm::helpers::ReminderRoleHint::System),
+        Some(VmValue::String(s)) => match s.as_ref() {
+            "system" => Ok(crate::llm::helpers::ReminderRoleHint::System),
+            "developer" => Ok(crate::llm::helpers::ReminderRoleHint::Developer),
+            "user_block" => Ok(crate::llm::helpers::ReminderRoleHint::UserBlock),
+            "ephemeral_cache" => Ok(crate::llm::helpers::ReminderRoleHint::EphemeralCache),
+            other => Err(VmError::Runtime(format!(
+                "{builtin}: ReminderInject `role_hint` must be 'system', 'developer', 'user_block', or 'ephemeral_cache', got '{other}'"
+            ))),
+        },
+        Some(other) => Err(VmError::Runtime(format!(
+            "{builtin}: ReminderInject `role_hint` must be a string, got {}",
+            other.type_name()
         ))),
     }
 }

--- a/crates/harn-vm/src/triggers/dispatcher/action_graph.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/action_graph.rs
@@ -79,6 +79,15 @@ pub(super) fn dispatch_success_outcome(
             Some("rejected") => "pool_rejected",
             _ => "pool_enqueued",
         },
+        // ReminderInject (#1876) — `injected` for a normal inject, `dropped`
+        // for a graceful no-op (target missing or unknown session). The
+        // dispatcher emits a `triggers.reminder_inject.audit` audit entry for
+        // both shapes, so observers don't need to re-derive the outcome from
+        // the result blob.
+        DispatchUri::ReminderInject { .. } => match result.get("status").and_then(|v| v.as_str()) {
+            Some("dropped") => "reminder_dropped",
+            _ => "reminder_injected",
+        },
     }
 }
 
@@ -246,6 +255,16 @@ pub(super) fn dispatch_node_metadata(
             metadata.insert("key_from".to_string(), serde_json::json!(path));
         }
     }
+    if let DispatchUri::ReminderInject {
+        target_kind,
+        target_session_id,
+    } = route
+    {
+        metadata.insert("target_kind".to_string(), serde_json::json!(target_kind));
+        if let Some(id) = target_session_id {
+            metadata.insert("target_session_id".to_string(), serde_json::json!(id));
+        }
+    }
     metadata
 }
 
@@ -302,6 +321,20 @@ pub(super) fn dispatch_success_metadata(
             }
             if let Some(priority) = result.get("priority").cloned() {
                 metadata.insert("priority".to_string(), priority);
+            }
+        }
+        DispatchUri::ReminderInject { .. } => {
+            for field in [
+                "status",
+                "target_session_id",
+                "target_kind",
+                "reminder_id",
+                "deduped_count",
+                "reason",
+            ] {
+                if let Some(value) = result.get(field).cloned() {
+                    metadata.insert(field.to_string(), value);
+                }
             }
         }
         DispatchUri::Local { .. } | DispatchUri::AutoResume { .. } => {}

--- a/crates/harn-vm/src/triggers/dispatcher/mod.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/mod.rs
@@ -31,7 +31,7 @@ use crate::vm::Vm;
 
 use self::uri::DispatchUri;
 use super::registry::{
-    binding_autonomy_budget_would_exceed, matching_bindings, note_autonomous_decision,
+    binding_autonomy_budget_would_exceed, matching_bindings, note_autonomous_decision, TargetExpr,
     TriggerBinding, TriggerBudgetExhaustionStrategy, TriggerHandlerSpec,
 };
 use super::{
@@ -2170,6 +2170,41 @@ impl Dispatcher {
                 )
                 .await
             }
+            DispatchUri::ReminderInject { .. } => {
+                let TriggerHandlerSpec::ReminderInject {
+                    target,
+                    body,
+                    tags,
+                    ttl_turns,
+                    dedupe_key,
+                    propagate,
+                    role_hint,
+                    preserve_on_compact,
+                } = &binding.handler
+                else {
+                    return Err(DispatchError::Local(format!(
+                        "trigger '{}' resolved to a reminder_inject dispatch URI but does not carry a reminder_inject handler",
+                        binding.id.as_str()
+                    )));
+                };
+                self.dispatch_reminder_inject(
+                    binding,
+                    route,
+                    event,
+                    target,
+                    body,
+                    tags,
+                    *ttl_turns,
+                    dedupe_key.as_deref(),
+                    *propagate,
+                    *role_hint,
+                    *preserve_on_compact,
+                    autonomy_tier,
+                    wait_lease,
+                    cancel_rx,
+                )
+                .await
+            }
         }
     }
 
@@ -2282,6 +2317,261 @@ impl Dispatcher {
             output.insert("rejection_reason".to_string(), serde_json::json!(reason));
             metadata.insert("rejection_reason".to_string(), serde_json::json!(reason));
         }
+        Ok(DispatchCallResult {
+            output: serde_json::Value::Object(output),
+            metadata,
+        })
+    }
+
+    /// ReminderInject (#1876) — resolve the target running session, render
+    /// the body template against the event payload, build a `SystemReminder`
+    /// from the binding's reminder metadata, and inject it via the existing
+    /// `agent_sessions::inject_reminder` pipeline. Missing-target dispatches
+    /// emit a `triggers.reminder_inject.audit` audit entry tagged
+    /// `target_missing` and return a `dropped` outcome instead of failing
+    /// the dispatch — that matches the "drop the reminder + emit audit"
+    /// failure-mode contract in the #1876 spec.
+    #[allow(clippy::too_many_arguments)]
+    async fn dispatch_reminder_inject(
+        &self,
+        binding: &TriggerBinding,
+        route: &DispatchUri,
+        event: &TriggerEvent,
+        target: &TargetExpr,
+        body_template: &str,
+        tags: &[String],
+        ttl_turns: Option<i64>,
+        dedupe_key: Option<&str>,
+        propagate: crate::llm::helpers::ReminderPropagate,
+        role_hint: crate::llm::helpers::ReminderRoleHint,
+        preserve_on_compact: bool,
+        autonomy_tier: AutonomyTier,
+        wait_lease: Option<DispatchWaitLease>,
+        cancel_rx: &mut broadcast::Receiver<()>,
+    ) -> Result<DispatchCallResult, DispatchError> {
+        // Step 1: resolve the target session. Closure resolution runs through
+        // the standard VM invocation path so dispatch context, cancellation,
+        // and policy intersection apply uniformly with other handler variants.
+        let resolved_target = match target {
+            TargetExpr::Current => crate::agent_sessions::current_session_id(),
+            TargetExpr::Parent => crate::agent_sessions::current_session_id()
+                .and_then(|id| crate::agent_sessions::parent_id(&id)),
+            TargetExpr::Concrete(id) => Some(id.clone()),
+            TargetExpr::Closure(closure) => {
+                let value = self
+                    .invoke_vm_callable(
+                        closure,
+                        &binding.binding_key(),
+                        event,
+                        None,
+                        binding.id.as_str(),
+                        &format!("{}.{}", event.provider.as_str(), event.kind),
+                        autonomy_tier,
+                        wait_lease,
+                        cancel_rx,
+                    )
+                    .await?;
+                match value {
+                    crate::value::VmValue::String(s) => {
+                        let id = s.trim().to_string();
+                        if id.is_empty() {
+                            None
+                        } else {
+                            Some(id)
+                        }
+                    }
+                    crate::value::VmValue::Nil => None,
+                    other => {
+                        return Err(DispatchError::Local(format!(
+                            "trigger '{}': ReminderInject target closure must return a string session id or nil, got {}",
+                            binding.id.as_str(),
+                            other.type_name()
+                        )));
+                    }
+                }
+            }
+        };
+
+        // Step 2: render the body template. Bindings expose `event` (with the
+        // full serialized event), `match` (matched_at), and a top-level
+        // `batch` projection when flow-control batching turned this dispatch
+        // into a synthetic batched event. Missing identifiers preserve the
+        // pre-v2 silent-passthrough contract in the template engine, so
+        // body strings without `{{ ... }}` round-trip unchanged.
+        let event_json =
+            serde_json::to_value(event).map_err(|error| DispatchError::Serde(error.to_string()))?;
+        let mut bindings = BTreeMap::new();
+        bindings.insert(
+            "event".to_string(),
+            crate::schema::json_to_vm_value(&event_json),
+        );
+        bindings.insert(
+            "match".to_string(),
+            crate::schema::json_to_vm_value(&serde_json::json!({
+                "matched_at": event_json.get("received_at").cloned().unwrap_or(serde_json::Value::Null),
+            })),
+        );
+        if let Some(batch_value) = event_json
+            .get("provider_payload")
+            .and_then(|p| p.get("batch"))
+        {
+            bindings.insert(
+                "batch".to_string(),
+                crate::schema::json_to_vm_value(batch_value),
+            );
+        }
+        let rendered_body = crate::stdlib::template::render_template_to_string(
+            body_template,
+            Some(&bindings),
+            None,
+            None,
+        )
+        .map_err(|error| {
+            DispatchError::Local(format!(
+                "trigger '{}': ReminderInject template render failed: {error}",
+                binding.id.as_str()
+            ))
+        })?;
+
+        // Step 3: handle missing target as a graceful drop with audit + a
+        // `dropped` dispatch result. The action-graph success_outcome maps
+        // `status: "dropped"` to a distinct `dropped` label so observers
+        // can tell a no-op from a successful inject without re-reading the
+        // result blob.
+        let target_kind = target.kind();
+        let Some(target_session_id) = resolved_target else {
+            crate::orchestration::record_lifecycle_audit(
+                "triggers.reminder_inject.audit",
+                serde_json::json!({
+                    "trigger_id": binding.id.as_str(),
+                    "binding_key": binding.binding_key(),
+                    "event_id": event.id.0,
+                    "outcome": "dropped",
+                    "reason": "target_missing",
+                    "target_kind": target_kind,
+                }),
+            );
+            let mut metadata = route.dispatch_boundary_metadata();
+            metadata.insert("target_kind".to_string(), serde_json::json!(target_kind));
+            metadata.insert("status".to_string(), serde_json::json!("dropped"));
+            metadata.insert(
+                "rejection_reason".to_string(),
+                serde_json::json!("target_missing"),
+            );
+            let mut output = serde_json::Map::new();
+            output.insert("status".to_string(), serde_json::json!("dropped"));
+            output.insert("reason".to_string(), serde_json::json!("target_missing"));
+            output.insert("target_kind".to_string(), serde_json::json!(target_kind));
+            return Ok(DispatchCallResult {
+                output: serde_json::Value::Object(output),
+                metadata,
+            });
+        };
+
+        // Step 4: target must exist as a registered session. Same graceful
+        // drop semantics as a fully-missing target.
+        if !crate::agent_sessions::exists(&target_session_id) {
+            crate::orchestration::record_lifecycle_audit(
+                "triggers.reminder_inject.audit",
+                serde_json::json!({
+                    "trigger_id": binding.id.as_str(),
+                    "binding_key": binding.binding_key(),
+                    "event_id": event.id.0,
+                    "outcome": "dropped",
+                    "reason": "target_unknown_session",
+                    "target_kind": target_kind,
+                    "target_session_id": &target_session_id,
+                }),
+            );
+            let mut metadata = route.dispatch_boundary_metadata();
+            metadata.insert("target_kind".to_string(), serde_json::json!(target_kind));
+            metadata.insert(
+                "target_session_id".to_string(),
+                serde_json::json!(&target_session_id),
+            );
+            metadata.insert("status".to_string(), serde_json::json!("dropped"));
+            metadata.insert(
+                "rejection_reason".to_string(),
+                serde_json::json!("target_unknown_session"),
+            );
+            let mut output = serde_json::Map::new();
+            output.insert("status".to_string(), serde_json::json!("dropped"));
+            output.insert(
+                "reason".to_string(),
+                serde_json::json!("target_unknown_session"),
+            );
+            output.insert("target_kind".to_string(), serde_json::json!(target_kind));
+            output.insert(
+                "target_session_id".to_string(),
+                serde_json::json!(&target_session_id),
+            );
+            return Ok(DispatchCallResult {
+                output: serde_json::Value::Object(output),
+                metadata,
+            });
+        }
+
+        // Step 5: build the SystemReminder + inject via the canonical
+        // agent_sessions pipeline. Reminders are sourced as `in_pipeline`
+        // so the rendering machinery treats them the same as any other
+        // dispatch-side reminder.
+        let reminder = crate::llm::helpers::SystemReminder {
+            id: uuid::Uuid::now_v7().to_string(),
+            tags: tags.to_vec(),
+            dedupe_key: dedupe_key.map(str::to_string),
+            ttl_turns,
+            preserve_on_compact,
+            propagate,
+            role_hint,
+            source: crate::llm::helpers::ReminderSource::InPipeline,
+            body: rendered_body,
+            fired_at_turn: 0,
+            originating_agent_id: None,
+        };
+        let reminder_id = reminder.id.clone();
+        let report = crate::agent_sessions::inject_reminder(&target_session_id, reminder)
+            .map_err(DispatchError::Local)?;
+
+        crate::orchestration::record_lifecycle_audit(
+            "triggers.reminder_inject.audit",
+            serde_json::json!({
+                "trigger_id": binding.id.as_str(),
+                "binding_key": binding.binding_key(),
+                "event_id": event.id.0,
+                "outcome": "injected",
+                "target_kind": target_kind,
+                "target_session_id": &target_session_id,
+                "reminder_id": &reminder_id,
+                "deduped_count": report.deduped_count,
+            }),
+        );
+
+        let mut metadata = route.dispatch_boundary_metadata();
+        metadata.insert("target_kind".to_string(), serde_json::json!(target_kind));
+        metadata.insert(
+            "target_session_id".to_string(),
+            serde_json::json!(&target_session_id),
+        );
+        metadata.insert("status".to_string(), serde_json::json!("injected"));
+        metadata.insert("reminder_id".to_string(), serde_json::json!(&reminder_id));
+        if report.deduped_count > 0 {
+            metadata.insert(
+                "deduped_count".to_string(),
+                serde_json::json!(report.deduped_count),
+            );
+        }
+        let mut output = serde_json::Map::new();
+        output.insert("status".to_string(), serde_json::json!("injected"));
+        output.insert(
+            "target_session_id".to_string(),
+            serde_json::json!(&target_session_id),
+        );
+        output.insert("target_kind".to_string(), serde_json::json!(target_kind));
+        output.insert("reminder_id".to_string(), serde_json::json!(&reminder_id));
+        output.insert(
+            "deduped_count".to_string(),
+            serde_json::json!(report.deduped_count),
+        );
         Ok(DispatchCallResult {
             output: serde_json::Value::Object(output),
             metadata,

--- a/crates/harn-vm/src/triggers/dispatcher/uri.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/uri.rs
@@ -48,6 +48,15 @@ pub enum DispatchUri {
         priority_from: Option<String>,
         key_from: Option<String>,
     },
+    /// Dispatcher injects a `SystemReminder` into the target running session
+    /// when the trigger matches (#1876). The descriptor carries the
+    /// resolution-mode label and (for the `Concrete` form) the literal
+    /// session id so the URI stays serializable and comparable; the body
+    /// template + reminder metadata live on the `TriggerHandlerSpec`.
+    ReminderInject {
+        target_kind: &'static str,
+        target_session_id: Option<String>,
+    },
 }
 
 impl DispatchUri {
@@ -115,6 +124,7 @@ impl DispatchUri {
             Self::Persona { .. } => "persona",
             Self::AutoResume { .. } => "auto_resume",
             Self::SpawnToPool { .. } => "spawn_to_pool",
+            Self::ReminderInject { .. } => "reminder_inject",
         }
     }
 
@@ -126,6 +136,13 @@ impl DispatchUri {
             Self::Persona { name } => format!("persona://{name}"),
             Self::AutoResume { worker_id } => format!("auto_resume://{worker_id}"),
             Self::SpawnToPool { pool, .. } => format!("pool://{pool}"),
+            Self::ReminderInject {
+                target_kind,
+                target_session_id,
+            } => match target_session_id {
+                Some(id) => format!("reminder_inject://{target_kind}/{id}"),
+                None => format!("reminder_inject://{target_kind}"),
+            },
         }
     }
 
@@ -137,6 +154,7 @@ impl DispatchUri {
             Self::Persona { .. } => "persona_runtime",
             Self::AutoResume { .. } => "local_process",
             Self::SpawnToPool { .. } => "local_process",
+            Self::ReminderInject { .. } => "local_process",
         }
     }
 
@@ -148,6 +166,7 @@ impl DispatchUri {
             Self::Persona { .. } => "managed_persona",
             Self::AutoResume { .. } => "in_process",
             Self::SpawnToPool { .. } => "pool_queued",
+            Self::ReminderInject { .. } => "in_process",
         }
     }
 
@@ -210,6 +229,16 @@ impl From<&TriggerHandlerSpec> for DispatchUri {
                 priority_from: priority_from.clone(),
                 key_from: key_from.clone(),
             },
+            TriggerHandlerSpec::ReminderInject { target, .. } => {
+                let target_session_id = match target {
+                    crate::triggers::registry::TargetExpr::Concrete(id) => Some(id.clone()),
+                    _ => None,
+                };
+                Self::ReminderInject {
+                    target_kind: target.kind(),
+                    target_session_id,
+                }
+            }
         }
     }
 }

--- a/crates/harn-vm/src/triggers/registry.rs
+++ b/crates/harn-vm/src/triggers/registry.rs
@@ -164,6 +164,60 @@ pub enum TriggerHandlerSpec {
         key_from: Option<String>,
         task_factory: Rc<VmClosure>,
     },
+    /// Composes triggers (#1870) with the reminder pipeline (#1815) by
+    /// injecting a `SystemReminder` into a target agent session's transcript
+    /// when the trigger matches (CH-05 / #1876). The reminder appears at the
+    /// session's next turn boundary — same as any other reminder. No spawn,
+    /// no resume, no signal. `body` is a prompt-template string rendered
+    /// against `{event}` / `{batch.events}` per match. `target` resolution
+    /// happens at dispatch time via [`TargetExpr`]; missing-target dispatches
+    /// are recorded as audit events rather than crashing the trigger.
+    ReminderInject {
+        target: TargetExpr,
+        body: String,
+        tags: Vec<String>,
+        ttl_turns: Option<i64>,
+        dedupe_key: Option<String>,
+        propagate: crate::llm::helpers::ReminderPropagate,
+        role_hint: crate::llm::helpers::ReminderRoleHint,
+        preserve_on_compact: bool,
+    },
+}
+
+/// Resolution mode for the target session of a [`TriggerHandlerSpec::ReminderInject`]
+/// dispatch. `Current` walks the current-session thread-local; `Parent` resolves
+/// the active session's parent in the agent-session lineage; `Concrete` carries
+/// a literal session id from the registration; `Closure` defers resolution to
+/// a user closure that runs at dispatch time with the event payload bound to
+/// its first argument and must return the session id as a string.
+#[derive(Clone)]
+pub enum TargetExpr {
+    Current,
+    Parent,
+    Concrete(String),
+    Closure(Rc<VmClosure>),
+}
+
+impl TargetExpr {
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Self::Current => "current",
+            Self::Parent => "parent",
+            Self::Concrete(_) => "concrete",
+            Self::Closure(_) => "closure",
+        }
+    }
+}
+
+impl std::fmt::Debug for TargetExpr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Current => f.write_str("Current"),
+            Self::Parent => f.write_str("Parent"),
+            Self::Concrete(id) => f.debug_tuple("Concrete").field(id).finish(),
+            Self::Closure(_) => f.write_str("Closure(<vm_closure>)"),
+        }
+    }
 }
 
 impl std::fmt::Debug for TriggerHandlerSpec {
@@ -198,6 +252,26 @@ impl std::fmt::Debug for TriggerHandlerSpec {
                 .field("priority_from", priority_from)
                 .field("key_from", key_from)
                 .finish(),
+            Self::ReminderInject {
+                target,
+                body,
+                tags,
+                ttl_turns,
+                dedupe_key,
+                propagate,
+                role_hint,
+                preserve_on_compact,
+            } => f
+                .debug_struct("ReminderInject")
+                .field("target", target)
+                .field("body", body)
+                .field("tags", tags)
+                .field("ttl_turns", ttl_turns)
+                .field("dedupe_key", dedupe_key)
+                .field("propagate", propagate)
+                .field("role_hint", role_hint)
+                .field("preserve_on_compact", preserve_on_compact)
+                .finish(),
         }
     }
 }
@@ -211,6 +285,7 @@ impl TriggerHandlerSpec {
             Self::Persona { .. } => "persona",
             Self::AutoResume { .. } => "auto_resume",
             Self::SpawnToPool { .. } => "spawn_to_pool",
+            Self::ReminderInject { .. } => "reminder_inject",
         }
     }
 }

--- a/docs/llm/harn-triggers-quickref.md
+++ b/docs/llm/harn-triggers-quickref.md
@@ -47,7 +47,7 @@ Audit a project before deploy with `harn routes <root> --json`; it reports each 
 
 ## Handler variants
 
-`handler:` accepts a closure (in-process), an `a2a://` or `worker://` URI string, or a handler-variant dict. The dict form covers compositions that need more than a single callable; today only `SpawnToPool` ships, more variants will plug into the same syntax over time.
+`handler:` accepts a closure (in-process), an `a2a://` or `worker://` URI string, or a handler-variant dict. The dict form covers compositions that need more than a single callable; `SpawnToPool` and `ReminderInject` ship today, more variants will plug into the same syntax over time.
 
 ```harn
 import { SpawnToPool } from "std/triggers"
@@ -69,6 +69,25 @@ trigger_register({
 ```
 
 The dispatcher invokes `task_factory(event)` per match, extracts priority + fair-queue key from the event payload (missing paths fall back to default priority 0 / null key), and submits the resulting closure to the named pool under its queue strategy + backpressure policy. Pool rejections (`drop_newest`, etc.) reuse the `lifecycle.pool.audit` channel that direct `pool.submit` calls emit on. The dispatch result is shaped as a `pool_task` handle so handlers can call `pool_wait(dispatch.result)` directly.
+
+```harn
+import { ReminderInject } from "std/triggers"
+
+trigger_register({
+  kind: "channel.emit",
+  provider: "channel",
+  match: {events: ["channel:pr.merged"]},
+  handler: ReminderInject({
+    target: "current",                       // "current", "parent", a literal session id, or a closure
+    body: "PR {{ event.provider_payload.payload.number }} merged. Consider cutting a patch release.",
+    tags: ["release_reminder"],
+    ttl_turns: 1,
+    dedupe_key: "release_reminder",
+  }),
+})
+```
+
+`ReminderInject` (#1876) injects a `SystemReminder` (#1815) into the target running session at its next turn boundary — no spawn, no resume, no signal. `target` resolves at dispatch time: `"current"` walks the owning session, `"parent"` walks its parent in the session lineage, any other string is a literal session id, and a closure `event -> string?` lets the trigger pick a target dynamically. `body` is a `.harn.prompt` template rendered against `{{ event }}` (the full trigger event), `{{ match }}` (`matched_at`), and `{{ batch }}` (when flow-control batching is in effect). `tags`, `ttl_turns`, `dedupe_key`, `propagate`, `role_hint`, and `preserve_on_compact` mirror `transcript.inject_reminder`. Missing target sessions are dropped gracefully with a `triggers.reminder_inject.audit` audit entry instead of failing the dispatch.
 
 ## Provider catalog
 


### PR DESCRIPTION
## Summary

- Adds `TriggerHandlerSpec::ReminderInject` (the CH-05 ticket of epic #1870 — Agent channels & periodic prompts) plus the matching `ReminderInject({...})` constructor in `std/triggers`. Unlike Local/Worker/SpawnToPool handlers, ReminderInject does not spawn a task: when the trigger matches, the dispatcher resolves a target session, renders a body template, builds a `SystemReminder` (#1815), and injects it via the canonical `agent_sessions::inject_reminder` pipeline so the reminder surfaces at the target session's next turn boundary.
- Target resolution covers all four `TargetExpr` modes from the spec: `Current` (the session the trigger registration belongs to, the default), `Parent` (its parent in the agent-session lineage), `Concrete(SessionId)` (a literal id), and `Closure(VmClosure)` (a user closure `event -> string?` evaluated at dispatch time via the standard VM invocation path).
- Body is a `.harn.prompt` template rendered against `{{ event }}` (full serialized trigger event), `{{ match }}` (`matched_at`), and `{{ batch }}` (when flow-control batching turned the dispatch into a synthetic batched event). Reminder metadata (`tags`, `ttl_turns`, `dedupe_key`, `propagate`, `role_hint`, `preserve_on_compact`) mirrors `transcript.inject_reminder` (#1815 R-02).
- Missing-target dispatches are recorded as `triggers.reminder_inject.audit` lifecycle audit entries (outcome `dropped`, reason `target_missing` or `target_unknown_session`) and return a `dropped` dispatch result rather than failing the trigger — matching the failure-mode contract in the #1876 spec.
- Dispatcher result shape includes `status` / `target_session_id` / `target_kind` / `reminder_id` / `deduped_count` so observers can correlate the inject back to the originating trigger event without re-parsing payloads. The action-graph `dispatch_success_outcome` reports `reminder_injected` vs `reminder_dropped` so audit consumers don't need to re-derive the outcome from the result blob.
- Slots into the handler-variant dict scaffolding the PL-04 (#1995) PR added: `parse_handler_dict` now dispatches on `kind: "reminder_inject"` alongside `"spawn_to_pool"`, and a new `DispatchUri::ReminderInject` keeps the URI surface serializable + comparable.

## Test plan

- [x] `cargo run --bin harn -- test conformance --filter trigger_reminder_inject` (4/4 new fixtures pass: targets_concrete_session, only_targets_named_session, missing_target_drops_with_audit, closure_target)
- [x] `cargo run --bin harn -- test conformance --filter trigger` (50/50 pass — no regression in SpawnToPool, channel-source, webhook, etc.)
- [x] `cargo run --bin harn -- test conformance --filter reminder` (68/68 pass)
- [x] `cargo run --bin harn -- test conformance` (full 1260-test suite passes)
- [x] `make test` (4424 tests pass, 2 skipped)
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `make fmt-harn`, `make lint-harn`, `make lint-test-patterns`, `make check-trigger-quickref`, `make check-docs-snippets`

Closes #1876. Part of epic #1870.

🤖 Generated with [Claude Code](https://claude.com/claude-code)