### PR TITLE
Wire OTel suspend-end / resume-link (#1867)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,26 @@ condensed series summaries instead of full per-patch history.
 
 ### Added
 
+- **OTel suspend-end / resume-link wiring (S-18, #1867).** Wires the
+  `SpanKind::Suspension` and `SpanKind::Resume` spans (added in P-05,
+  #1858) into the cooperative `suspend_agent` / `resume_agent` paths.
+  The suspension span is now closed before the snapshot is persisted
+  (Temporal community best-practice — never carry one root span across
+  a multi-day pause) and the resume path opens a fresh detached
+  `SpanKind::Resume` span that links — not parents — back to the prior
+  suspension span and the pipeline span that was active at suspend
+  time. Adds the canonical attribute bag to both spans: suspend carries
+  `handle`, `reason`, `initiator`, `has_conditions`, `pipeline_id`
+  (alias of `pipeline_span_id`), and `parent_worker_id`; resume carries
+  `handle`, `initiator`, `continue_transcript`, `had_resume_input`, and
+  `linked_suspension_count`. Privacy: the `resume_input` value itself
+  is deliberately never serialised onto resume-span attributes — only a
+  boolean flag — and the existing `WorkerSuspension` JSON round-trip
+  already preserved `prior_span_link` + `pipeline_span_link` from
+  P-05, so cross-process cold resume continues to link to the closed
+  pre-restart span. New `suspend_otel_links` conformance fixture
+  exercises the warm suspend → resume cycle from script land. Part of
+  epic #1836 (Agent suspend/resume).
 - **Pool conformance gap-fill: `pool_unsettled_state_integration` (#1892).**
   PL-07 (epic #1883) is the comprehensive pool conformance suite. Eight of
   the ten spec scenarios were already covered by fixtures landed alongside

--- a/conformance/tests/agents/suspend_otel_links.expected
+++ b/conformance/tests/agents/suspend_otel_links.expected
@@ -1,0 +1,14 @@
+suspended
+running
+completed
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true

--- a/conformance/tests/agents/suspend_otel_links.harn
+++ b/conformance/tests/agents/suspend_otel_links.harn
@@ -1,0 +1,66 @@
+import "std/agents"
+
+/**
+ * S-18 (#1867): the cooperative suspend path ends the in-flight
+ * lifecycle span and persists its link into the worker snapshot.
+ * The matching resume path opens a fresh `SpanKind::Resume` span that
+ * links — not parents — back to the prior suspension and to the
+ * pipeline span that was active when suspend ran. This is the
+ * Temporal-community-recommended shape: never carry one root span
+ * across a multi-day pause.
+ *
+ * The fixture mirrors the runtime contract:
+ *   1. Suspend produces a closed `suspension` span carrying the
+ *      canonical attribute bag (`handle`, `reason`, `initiator`,
+ *      `pipeline_id`).
+ *   2. Resume produces a closed `resume` span carrying its own
+ *      attribute bag plus outbound links back to the suspension and
+ *      the pipeline.
+ *   3. The resume span is detached (no parent) so future pipelines
+ *      do not become re-children of the original parent on warm
+ *      resume.
+ *
+ * The worker is driven into a suspended state via a model-issued
+ * `agent_await_resumption` tool call, matching the auto-resume
+ * conformance fixture.
+ */
+pipeline main() {
+  enable_tracing(true)
+  llm_mock(
+    {
+      tool_calls: [
+        {id: "park_until_review", name: "agent_await_resumption", arguments: {reason: "waiting on review"}},
+      ],
+      input_tokens: 7,
+      output_tokens: 3,
+    },
+  )
+  llm_mock({text: "resumed and finished"})
+  let handle = sub_agent_run(
+    "Park until review.",
+    {provider: "mock", background: true, tool_format: "native", max_iterations: 3},
+  )
+  let suspended = wait_agent(handle)
+  println(suspended?.status)
+  let resumed_handle = resume_agent(handle)
+  println(resumed_handle?.status)
+  let resumed = wait_agent(handle)
+  println(resumed?.status)
+  let spans = trace_spans()
+  let suspension_spans = spans.filter({ s -> s.kind == "suspension" })
+  let resume_spans = spans.filter({ s -> s.kind == "resume" })
+  println(len(suspension_spans) >= 1)
+  println(len(resume_spans) >= 1)
+  let suspension = suspension_spans[0]
+  let resume = resume_spans[0]
+  println(suspension.metadata?.handle != nil)
+  println(suspension.metadata?.reason != nil)
+  println(suspension.metadata?.initiator != nil)
+  println(resume.metadata?.handle != nil)
+  println(resume.metadata?.continue_transcript != nil)
+  println(resume.metadata?.had_resume_input != nil)
+  println(resume.parent_id == nil)
+  println(resume.links != nil)
+  println(len(resume.links) >= 1)
+  enable_tracing(false)
+}

--- a/crates/harn-vm/src/stdlib/agents.rs
+++ b/crates/harn-vm/src/stdlib/agents.rs
@@ -220,6 +220,78 @@ impl Drop for LifecycleSpanGuard {
     }
 }
 
+/// S-18 (harn#1867): apply the canonical attribute bag to a suspension
+/// lifecycle span. Kept in one helper so suspend_agent_builtin and
+/// top_level_agent_suspend_builtin emit identically shaped spans for
+/// OTel exporters and downstream queries.
+///
+/// Privacy: `reason` is a short human-facing label already broadcast on
+/// WorkerSuspended events and PreSuspend/PostSuspend hook payloads, so
+/// mirroring it onto the span attributes does not widen exposure.
+/// Conditions are summarised as a boolean — the condition payload itself
+/// is intentionally NOT placed on the span.
+fn annotate_suspension_span(
+    span: &LifecycleSpanGuard,
+    worker_id: &str,
+    reason: &str,
+    initiator: SuspendInitiator,
+    pipeline_span_link: Option<&crate::tracing::SpanLink>,
+    parent_worker_id: Option<&str>,
+    has_conditions: bool,
+) {
+    span.set_metadata("worker_id", serde_json::json!(worker_id));
+    // `handle` is the canonical OTel attribute name per the issue spec
+    // (#1867 acceptance criteria); we keep `worker_id` for back-compat
+    // with the P-05/P-06 attributes already shipped.
+    span.set_metadata("handle", serde_json::json!(worker_id));
+    span.set_metadata("reason", serde_json::json!(reason));
+    span.set_metadata(
+        "initiator",
+        serde_json::json!(serde_json::to_value(initiator).unwrap_or(serde_json::Value::Null)),
+    );
+    span.set_metadata("has_conditions", serde_json::json!(has_conditions));
+    if let Some(pipeline_span_link) = pipeline_span_link {
+        // `pipeline_id` is the issue's spec-level attribute; we use the
+        // active pipeline span's id since worker state does not carry a
+        // distinct pipeline identifier. `pipeline_span_id` is preserved
+        // for back-compat with the P-05 attribute.
+        span.set_metadata(
+            "pipeline_span_id",
+            serde_json::json!(pipeline_span_link.span_id),
+        );
+        span.set_metadata("pipeline_id", serde_json::json!(pipeline_span_link.span_id));
+    }
+    if let Some(parent_worker_id) = parent_worker_id {
+        span.set_metadata("parent_worker_id", serde_json::json!(parent_worker_id));
+    }
+}
+
+/// S-18 (harn#1867): apply the canonical attribute bag to a resume
+/// lifecycle span. Booleans describe the shape of the resume (transcript
+/// continuity, fresh resume input) without exposing transcript text or
+/// the resume payload itself.
+fn annotate_resume_span(
+    span: &LifecycleSpanGuard,
+    worker_id: &str,
+    initiator: &str,
+    continue_transcript: bool,
+    had_resume_input: bool,
+    linked_suspension_count: usize,
+) {
+    span.set_metadata("worker_id", serde_json::json!(worker_id));
+    span.set_metadata("handle", serde_json::json!(worker_id));
+    span.set_metadata("initiator", serde_json::json!(initiator));
+    span.set_metadata(
+        "continue_transcript",
+        serde_json::json!(continue_transcript),
+    );
+    span.set_metadata("had_resume_input", serde_json::json!(had_resume_input));
+    span.set_metadata(
+        "linked_suspension_count",
+        serde_json::json!(linked_suspension_count),
+    );
+}
+
 fn restart_worker_run(
     worker: &mut WorkerState,
     next_task: &str,
@@ -708,13 +780,22 @@ async fn suspend_agent_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
             format!("suspend {}", worker.id),
             Vec::new(),
         );
-        span.set_metadata("worker_id", serde_json::json!(worker.id));
-        if let Some(pipeline_span_link) = &pipeline_span_link {
-            span.set_metadata(
-                "pipeline_span_id",
-                serde_json::json!(pipeline_span_link.span_id),
-            );
-        }
+        // S-18 (harn#1867): attach the structured suspend metadata that
+        // OTel consumers need to render a paused agent without joining
+        // back to the worker registry. `reason` and `initiator` are already
+        // public via WorkerSuspended events and PreSuspend/PostSuspend
+        // hook payloads; we deliberately do NOT include transcript
+        // content, resume_input, or condition payloads (see issue #1867
+        // privacy callout).
+        annotate_suspension_span(
+            &span,
+            &worker.id,
+            &reason,
+            initiator,
+            pipeline_span_link.as_ref(),
+            worker.parent_worker_id.as_deref(),
+            conditions.is_some(),
+        );
         let prior_span_link = span.link();
         suspension_span = Some(span);
         worker.suspend_signal.store(true, Ordering::SeqCst);
@@ -814,13 +895,20 @@ async fn top_level_agent_suspend_builtin(args: Vec<VmValue>) -> Result<VmValue, 
         format!("suspend {worker_id}"),
         Vec::new(),
     );
-    suspension_span.set_metadata("worker_id", serde_json::json!(worker_id));
-    if let Some(pipeline_span_link) = &pipeline_span_link {
-        suspension_span.set_metadata(
-            "pipeline_span_id",
-            serde_json::json!(pipeline_span_link.span_id),
-        );
-    }
+    // S-18 (harn#1867): mirror the metadata captured in
+    // `suspend_agent_builtin` for top-level (script-level) suspensions.
+    // The initiator for the top-level path is always `SelfInitiated`
+    // because only the active agent loop can drive the synchronous
+    // checkpoint return path.
+    annotate_suspension_span(
+        &suspension_span,
+        &worker_id,
+        &reason,
+        SuspendInitiator::SelfInitiated,
+        pipeline_span_link.as_ref(),
+        None,
+        conditions.is_some(),
+    );
     let prior_span_link = suspension_span.link();
     let config = WorkerConfig::SubAgent {
         spec: Box::new(SubAgentRunSpec {
@@ -1459,12 +1547,25 @@ async fn warm_resume_worker(
         }
         (worker.id.clone(), span_links)
     };
+    let link_count = span_links.len();
     let mut resume_span = LifecycleSpanGuard::start_detached(
         crate::tracing::SpanKind::Resume,
         format!("resume {worker_id}"),
         span_links,
     );
-    resume_span.set_metadata("worker_id", serde_json::json!(worker_id));
+    // S-18 (harn#1867): annotate the resume span with the per-resume
+    // shape (initiator, transcript continuity, presence of fresh input)
+    // and a count of the linked-not-parented prior spans. We do NOT
+    // include the resume_input value itself — it can contain transcript
+    // text or user data — only a boolean flag.
+    annotate_resume_span(
+        &resume_span,
+        &worker_id,
+        &inferred_resume_initiator(&options),
+        options.continue_transcript,
+        options.resume_input.is_some(),
+        link_count,
+    );
     let (snapshot, suspension) = {
         let mut worker = state.borrow_mut();
         if worker.status != "suspended" {
@@ -2817,6 +2918,150 @@ mod suspend_tests {
         assert_eq!(suspension_link.span_id, prior_span_link.span_id);
         assert_eq!(pipeline_link.trace_id, pipeline_span_link.trace_id);
         assert_eq!(pipeline_link.span_id, pipeline_span_link.span_id);
+
+        teardown(&dir, &worker_id);
+        crate::tracing::set_tracing_enabled(false);
+        crate::tracing::reset_tracing();
+    }
+
+    /// S-18 (harn#1867): verify the suspension / resume spans carry the
+    /// documented attribute bag (`handle`, `reason`, `initiator`,
+    /// `pipeline_id` on suspend; `handle`, `initiator`,
+    /// `continue_transcript`, `had_resume_input`,
+    /// `linked_suspension_count` on resume). These attributes let OTel
+    /// consumers slice paused agents without joining back to the worker
+    /// registry. The test also doubles as a privacy check: resume_input
+    /// content must not appear on the resume span.
+    #[tokio::test(flavor = "current_thread")]
+    async fn suspend_resume_spans_carry_canonical_attribute_bag() {
+        let _guard = suspend_test_lock().await;
+        crate::tracing::reset_tracing();
+        crate::tracing::set_tracing_enabled(true);
+        let (worker_id, dir) = seed_test_worker("worker-suspend-resume-attributes");
+
+        let pipeline_span_id =
+            crate::tracing::span_start(crate::tracing::SpanKind::Pipeline, "pipeline".to_string());
+        suspend_agent_builtin(vec![
+            handle_value(&worker_id),
+            VmValue::String(Rc::from("waiting on review")),
+            VmValue::Dict(Rc::new(BTreeMap::from([(
+                "initiator".to_string(),
+                VmValue::String(Rc::from("triggered")),
+            )]))),
+        ])
+        .await
+        .expect("suspend");
+        crate::tracing::span_end(pipeline_span_id);
+
+        resume_agent_builtin(vec![
+            handle_value(&worker_id),
+            VmValue::Dict(Rc::new(BTreeMap::from([
+                (
+                    "input".to_string(),
+                    VmValue::String(Rc::from("CONFIDENTIAL_DO_NOT_LEAK_INTO_SPAN_ATTRS")),
+                ),
+                ("continue_transcript".to_string(), VmValue::Bool(false)),
+            ]))),
+        ])
+        .await
+        .expect("resume");
+
+        let spans = crate::tracing::peek_spans();
+        let suspension = spans
+            .iter()
+            .find(|span| span.kind == crate::tracing::SpanKind::Suspension)
+            .expect("suspension span");
+        assert_eq!(
+            suspension.metadata.get("handle").and_then(|v| v.as_str()),
+            Some(worker_id.as_str()),
+            "suspend span exposes handle"
+        );
+        assert_eq!(
+            suspension
+                .metadata
+                .get("worker_id")
+                .and_then(|v| v.as_str()),
+            Some(worker_id.as_str()),
+            "suspend span preserves back-compat worker_id"
+        );
+        assert_eq!(
+            suspension.metadata.get("reason").and_then(|v| v.as_str()),
+            Some("waiting on review")
+        );
+        assert_eq!(
+            suspension
+                .metadata
+                .get("initiator")
+                .and_then(|v| v.as_str()),
+            Some("triggered"),
+            "initiator parsed and exposed"
+        );
+        assert_eq!(
+            suspension
+                .metadata
+                .get("pipeline_id")
+                .and_then(|v| v.as_str()),
+            Some(pipeline_span_id.to_string()).as_deref(),
+            "pipeline_id alias of pipeline_span_id is present"
+        );
+        assert_eq!(
+            suspension
+                .metadata
+                .get("pipeline_span_id")
+                .and_then(|v| v.as_str()),
+            Some(pipeline_span_id.to_string()).as_deref(),
+            "back-compat pipeline_span_id is present"
+        );
+        assert_eq!(
+            suspension
+                .metadata
+                .get("has_conditions")
+                .and_then(|v| v.as_bool()),
+            Some(false)
+        );
+
+        let resume = spans
+            .iter()
+            .find(|span| span.kind == crate::tracing::SpanKind::Resume)
+            .expect("resume span");
+        assert_eq!(
+            resume.metadata.get("handle").and_then(|v| v.as_str()),
+            Some(worker_id.as_str())
+        );
+        assert!(
+            resume.metadata.contains_key("initiator"),
+            "resume span has initiator"
+        );
+        assert_eq!(
+            resume
+                .metadata
+                .get("continue_transcript")
+                .and_then(|v| v.as_bool()),
+            Some(false)
+        );
+        assert_eq!(
+            resume
+                .metadata
+                .get("had_resume_input")
+                .and_then(|v| v.as_bool()),
+            Some(true),
+            "resume span flags presence of resume_input without leaking value"
+        );
+        assert_eq!(
+            resume
+                .metadata
+                .get("linked_suspension_count")
+                .and_then(|v| v.as_u64()),
+            Some(2)
+        );
+
+        // Privacy guard: the resume_input value itself must not be
+        // serialised into any resume-span attribute.
+        let serialized = serde_json::to_string(&resume.metadata).expect("serialize metadata");
+        assert!(
+            !serialized.contains("CONFIDENTIAL_DO_NOT_LEAK_INTO_SPAN_ATTRS"),
+            "resume_input content leaked into span metadata: {serialized}"
+        );
 
         teardown(&dir, &worker_id);
         crate::tracing::set_tracing_enabled(false);


### PR DESCRIPTION
## Summary

S-18 wires the `SpanKind::Suspension` and `SpanKind::Resume` spans (added in P-05, #1858) into the cooperative `suspend_agent` / `resume_agent` paths so OTel exporters see the documented linked-not-parented shape across a suspension.

- The suspension span is closed before the snapshot is persisted (Temporal community best-practice: never carry one root span across a multi-day pause).
- The resume path opens a fresh detached `SpanKind::Resume` span that links — not parents — back to the prior suspension span and the pre-suspend pipeline span via `SpanLink`.
- Adds the canonical attribute bag to both spans:
  - Suspend: `handle`, `reason`, `initiator`, `has_conditions`, `pipeline_id` (alias of `pipeline_span_id`), `parent_worker_id`.
  - Resume: `handle`, `initiator`, `continue_transcript`, `had_resume_input`, `linked_suspension_count`.
- Privacy: the `resume_input` value is deliberately never serialised onto resume-span attributes — only a boolean flag.

Cross-process cold resume continues to link to the closed pre-restart span because `WorkerSuspension` already serialised `prior_span_link` + `pipeline_span_link` under P-05 (existing `suspend_resume_links_lifecycle_spans_across_snapshot_reload` Rust test covers that path).

Closes #1867. Part of epic #1836 (Agent suspend/resume).

## Test plan

- [x] `cargo fmt --all` clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] New unit test `suspend_resume_spans_carry_canonical_attribute_bag` covers attribute bag + privacy guard against `resume_input` leakage.
- [x] Existing cross-process Rust test `suspend_resume_links_lifecycle_spans_across_snapshot_reload` still passes.
- [x] New conformance fixture `tests/agents/suspend_otel_links.harn` exercises warm suspend → resume from script land.
- [x] `make test` (all 4428 tests pass).
- [x] `make fmt-harn`, `make lint-harn`, `make lint-test-patterns` clean.
- [x] CHANGELOG has a single `## Unreleased` section; no retroactive edits to `## v0.8.26`.