### PR TITLE
Add OAuth dynamic registration (#1906)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,45 @@ condensed series summaries instead of full per-patch history.
   `on_finish_preset_*`, `combinator_*`, `lifecycle_hook_events_*`,
   `lifecycle_event_shape_*`, and `on_budget_*` fixtures the lifecycle
   surface is now executable spec end-to-end.
+- **OAuth dynamic client registration + auto-hosted metadata (#1906).**
+  Closes OA-05 on epic #1885 with the worker-side dual of `std/oauth/client`:
+  a new `std/oauth/dynamic_registration` module that builds RFC 7591
+  client metadata, RFC 8414 authorization-server metadata, and runs an
+  in-process RFC 7591 dynamic registration store. `client_metadata(opts)`
+  validates + defaults a candidate document for serving at
+  `/.well-known/oauth-client.json`; `authorization_server_metadata(provider,
+  overrides?)` derives the server document from a `std/oauth/providers`
+  record for `/.well-known/oauth-authorization-server.json`;
+  `dynamic_registration_store()` + `register_client(store, metadata)` issue
+  fresh `client_id` / `client_secret` pairs (256-bit URL-safe base64) with
+  RFC 7591 §5.1 server-side latitude to reject non-HTTPS redirect URIs
+  (except RFC 8252 §7.3 loopback), fragments, and non-spec
+  `grant_types` / `response_types` / `token_endpoint_auth_method` values.
+  All rejections thread through a stable `HARN-OAU-005:` diagnostic
+  prefix. The `client_secret` is only returned by `register_client`;
+  subsequent `get_client` reads omit it, and the `oauth.dynreg.audit`
+  `client_registered` event carries only the redacted shape
+  (`redirect_uri_count`, `grant_types`, `has_client_secret`) — never the
+  credential material. `well_known_paths()` + `well_known_response()`
+  return the canonical URL paths and an HTTP envelope that embedders
+  (harn-cloud, future `harn serve --oauth-resource ...`) can mount
+  directly. New Rust builtins (`__oauth_dynreg_store_handle`,
+  `__oauth_dynreg_register`, `__oauth_dynreg_get`, `__oauth_dynreg_list`,
+  `__oauth_dynreg_validate_metadata`, `__oauth_dynreg_build_client_metadata`,
+  `__oauth_dynreg_build_authorization_server_metadata`) are registered
+  in the parser signature table and live in
+  `crates/harn-vm/src/stdlib/oauth_dynreg.rs`; `client_id_issued_at`
+  routes through `stdlib::clock` for mock-clock-deterministic
+  conformance. Three new fixtures under `conformance/tests/stdlib/`
+  (`oauth_dynamic_registration_metadata`, `..._register`, `..._rejects`)
+  cover well-known builder defaulting, happy-path registration with
+  audit-shape redaction, and the RFC 7591 §5.1 / §2 rejection matrix.
+  Intentional cut: the harn-serve port-wiring (a `/well-known` route
+  group + `POST /register` handler) is deferred to a follow-up so this
+  PR can ship the stdlib + validation surface that both harn-cloud and
+  harn-serve will share without coupling the two. Embedders consume the
+  artifacts produced here as opaque `{status, content_type, headers,
+  body}` envelopes.
 - **Pool conformance gap-fill: `pool_unsettled_state_integration` (#1892).**
   PL-07 (epic #1883) is the comprehensive pool conformance suite. Eight of
   the ten spec scenarios were already covered by fixtures landed alongside

--- a/conformance/tests/stdlib/oauth_dynamic_registration_metadata.expected
+++ b/conformance/tests/stdlib/oauth_dynamic_registration_metadata.expected
@@ -1,0 +1,1 @@
+[harn] oauth dynamic registration metadata ok

--- a/conformance/tests/stdlib/oauth_dynamic_registration_metadata.harn
+++ b/conformance/tests/stdlib/oauth_dynamic_registration_metadata.harn
@@ -1,0 +1,110 @@
+// std/oauth/dynamic_registration: well-known metadata builders.
+//
+// Exercises the OA-05 metadata documents that an embedder serves at
+// /.well-known/oauth-client.json and /.well-known/oauth-authorization-server.json.
+// Verifies RFC 7591 defaulting (response_types, grant_types,
+// token_endpoint_auth_method), RFC 8414 derivation from a provider record,
+// override merging, and the well_known_response envelope.
+import {
+  authorization_server_metadata,
+  client_metadata,
+  validate_metadata,
+  well_known_paths,
+  well_known_response,
+} from "std/oauth/dynamic_registration"
+import { custom } from "std/oauth/providers"
+
+pipeline test(task) {
+  let metadata = client_metadata(
+    {
+      redirect_uris: ["https://app.example/callback"],
+      client_name: "Harn Conformance Client",
+      scope: "read write",
+    },
+  )
+  assert_eq(metadata.redirect_uris, ["https://app.example/callback"], "redirect_uris preserved")
+  assert(metadata.grant_types.contains("authorization_code"), "grant_types default applied")
+  assert(metadata.response_types.contains("code"), "response_types default applied")
+  assert_eq(metadata.token_endpoint_auth_method, "client_secret_basic", "auth method default applied")
+  assert_eq(metadata.client_name, "Harn Conformance Client", "client_name passthrough")
+  assert_eq(metadata.scope, "read write", "scope passthrough")
+  let validation = validate_metadata({redirect_uris: ["https://app.example/callback"]})
+  assert_eq(validation.ok, true, "valid metadata reports ok=true")
+  assert_eq(len(validation.errors), 0, "valid metadata reports no errors")
+  let provider = custom(
+    {
+      id: "mock",
+      label: "Mock IdP",
+      auth_url: "https://mock-idp.example/authorize",
+      token_url: "https://mock-idp.example/token",
+      device_code_url: "https://mock-idp.example/device",
+      revoke_url: "https://mock-idp.example/revoke",
+      userinfo_url: "https://mock-idp.example/userinfo",
+      default_scopes: ["read", "write"],
+      pkce_required: true,
+    },
+  )
+  let server_metadata = authorization_server_metadata(
+    provider,
+    {registration_endpoint: "https://mock-idp.example/register"},
+  )
+  assert_eq(server_metadata.issuer, "https://mock-idp.example", "issuer derived from auth_url")
+  assert_eq(
+    server_metadata.authorization_endpoint,
+    "https://mock-idp.example/authorize",
+    "authorization_endpoint",
+  )
+  assert_eq(server_metadata.token_endpoint, "https://mock-idp.example/token", "token_endpoint")
+  assert_eq(
+    server_metadata.device_authorization_endpoint,
+    "https://mock-idp.example/device",
+    "device authorization endpoint",
+  )
+  assert_eq(
+    server_metadata.revocation_endpoint,
+    "https://mock-idp.example/revoke",
+    "revocation endpoint",
+  )
+  assert_eq(
+    server_metadata.userinfo_endpoint,
+    "https://mock-idp.example/userinfo",
+    "userinfo endpoint",
+  )
+  assert(server_metadata.response_types_supported.contains("code"), "response_types_supported")
+  assert(
+    server_metadata.grant_types_supported.contains("authorization_code"),
+    "auth code grant supported",
+  )
+  assert(
+    server_metadata.grant_types_supported.contains("urn:ietf:params:oauth:grant-type:device_code"),
+    "device code grant supported",
+  )
+  assert(server_metadata.code_challenge_methods_supported.contains("S256"), "S256 PKCE supported")
+  assert_eq(server_metadata.scopes_supported, ["read", "write"], "scopes_supported propagated")
+  assert_eq(
+    server_metadata.registration_endpoint,
+    "https://mock-idp.example/register",
+    "override merged",
+  )
+  let paths = well_known_paths()
+  assert_eq(paths.client_metadata, "/.well-known/oauth-client.json", "default client path")
+  assert_eq(
+    paths.authorization_server_metadata,
+    "/.well-known/oauth-authorization-server.json",
+    "default server path",
+  )
+  assert_eq(paths.registration, "/register", "default registration path")
+  let custom_paths = well_known_paths({registration: "/oauth/register"})
+  assert_eq(custom_paths.registration, "/oauth/register", "override registration path")
+  assert_eq(
+    custom_paths.client_metadata,
+    "/.well-known/oauth-client.json",
+    "default client path retained on partial override",
+  )
+  let response = well_known_response(metadata)
+  assert_eq(response.status, 200, "200 OK")
+  assert_eq(response.content_type, "application/json", "json content type")
+  assert_eq(response.headers["cache-control"], "no-store", "no-store cache control")
+  assert(contains(response.body, "redirect_uris"), "body carries metadata")
+  log("oauth dynamic registration metadata ok")
+}

--- a/conformance/tests/stdlib/oauth_dynamic_registration_register.expected
+++ b/conformance/tests/stdlib/oauth_dynamic_registration_register.expected
@@ -1,0 +1,1 @@
+[harn] oauth dynamic registration register ok

--- a/conformance/tests/stdlib/oauth_dynamic_registration_register.harn
+++ b/conformance/tests/stdlib/oauth_dynamic_registration_register.harn
@@ -1,0 +1,86 @@
+// std/oauth/dynamic_registration: happy path RFC 7591 registration.
+//
+// Opens an in-process registration store, registers a well-formed client,
+// then verifies the response carries client_id + client_secret (only on
+// register), the get() readback drops the secret, list() reports the id,
+// and the audit event records the registration shape without leaking
+// credential material.
+import {
+  dynamic_registration_store,
+  get_client,
+  list_clients,
+  register_client,
+} from "std/oauth/dynamic_registration"
+
+pipeline test(task) {
+  let topic = "oauth.dynreg.audit"
+  let cursor = event_log.latest(topic) ?? 0
+  let store = dynamic_registration_store()
+  assert_eq(store.kind, "oauth_dynreg_store", "store handle kind")
+  let metadata = {
+    redirect_uris: ["https://app.example/callback"],
+    grant_types: ["authorization_code", "refresh_token"],
+    client_name: "Harn Conformance App",
+    scope: "read write",
+  }
+  let response = register_client(store, metadata)
+  let client_id = response.client_id
+  assert(len(client_id) >= 32, "client_id length >= 32 (256-bit base64url)")
+  let client_secret = response.client_secret
+  assert(len(client_secret) >= 32, "client_secret length >= 32")
+  assert_eq(response.client_secret_expires_at, 0, "client_secret_expires_at=0 (non-expiring)")
+  assert(response.client_id_issued_at >= 0, "client_id_issued_at present")
+  assert_eq(response.redirect_uris, ["https://app.example/callback"], "metadata round-tripped")
+  assert_eq(response.client_name, "Harn Conformance App", "client_name preserved")
+  let fetched = get_client(store, client_id)
+  assert(fetched != nil, "get_client returns the registration")
+  assert_eq(fetched.client_id, client_id, "get returns same client_id")
+  assert(
+    fetched?.client_secret == nil,
+    "get_client must NOT include client_secret (security invariant)",
+  )
+  assert_eq(fetched.redirect_uris, ["https://app.example/callback"], "metadata preserved on get")
+  assert_eq(fetched.client_name, "Harn Conformance App", "client_name preserved on get")
+  let listed = list_clients(store)
+  assert(listed.contains(client_id), "list_clients reports registered id")
+  // Convenience closures on the store dict.
+  let response2 = store.register({redirect_uris: ["https://app.example/cb-2"]})
+  assert(response2.client_id != client_id, "fresh registration mints a different client_id")
+  let listed2 = store.list()
+  assert_eq(len(listed2), 2, "two registrations in store")
+  let fetched2 = store.get(response2.client_id)
+  assert_eq(fetched2.client_id, response2.client_id, "store.get closure works")
+  // Defaults are applied on registration.
+  let defaulted = register_client(store, {redirect_uris: ["https://app.example/cb-3"]})
+  assert(defaulted.grant_types.contains("authorization_code"), "default grant_types applied")
+  assert(defaulted.response_types.contains("code"), "default response_types applied")
+  assert_eq(
+    defaulted.token_endpoint_auth_method,
+    "client_secret_basic",
+    "default auth method applied",
+  )
+  // Audit event records the shape, NOT the secret.
+  let stream = event_log.subscribe({topic: topic, from_cursor: cursor})
+  let first = stream.next().value
+  assert_eq(first.kind, "client_registered", "audit kind")
+  assert_eq(first.payload.client_id, client_id, "audit records client_id")
+  assert_eq(first.payload.redacted.has_client_secret, true, "audit records presence flag")
+  assert_eq(
+    first.payload.redacted.redirect_uri_count,
+    1,
+    "audit records redirect_uri count, not values",
+  )
+  assert(
+    first.payload.redacted.grant_types.contains("authorization_code"),
+    "audit records grant_types enum",
+  )
+  assert(
+    first.payload?.client_secret == nil,
+    "audit must NOT include client_secret (privacy invariant)",
+  )
+  assert(
+    first.payload?.redacted?.client_secret == nil,
+    "audit redacted shape must NOT carry client_secret",
+  )
+  log("oauth dynamic registration register ok")
+}

--- a/conformance/tests/stdlib/oauth_dynamic_registration_rejects.expected
+++ b/conformance/tests/stdlib/oauth_dynamic_registration_rejects.expected
@@ -1,0 +1,1 @@
+[harn] oauth dynamic registration rejects ok

--- a/conformance/tests/stdlib/oauth_dynamic_registration_rejects.harn
+++ b/conformance/tests/stdlib/oauth_dynamic_registration_rejects.harn
@@ -1,0 +1,87 @@
+// std/oauth/dynamic_registration: RFC 7591 validation rejections.
+//
+// Asserts that the dynamic registration endpoint rejects malformed or
+// security-violating metadata per RFC 7591 §5.1 + RFC 8252 §7.3.
+// Each rejection threads through the stable HARN-OAU-005 diagnostic
+// prefix and never mutates the store.
+import {
+  dynamic_registration_store,
+  list_clients,
+  register_client,
+  validate_metadata,
+} from "std/oauth/dynamic_registration"
+
+fn expect_reject(label, metadata, marker) {
+  let validation = validate_metadata(metadata)
+  if validation.ok {
+    throw label + ": expected validate_metadata to report ok=false"
+  }
+  if len(validation.errors) == 0 {
+    throw label + ": expected at least one error"
+  }
+  let first_error = validation.errors[0]
+  if !contains(first_error, "HARN-OAU-005") {
+    throw label + ": expected HARN-OAU-005 diagnostic prefix, got `" + first_error + "`"
+  }
+  if marker != "" && !contains(first_error, marker) {
+    throw label + ": expected marker `" + marker + "` in `" + first_error + "`"
+  }
+}
+
+pipeline test(task) {
+  let store = dynamic_registration_store()
+  let cursor_before = len(list_clients(store))
+  // Missing redirect_uris.
+  expect_reject("missing redirect_uris", {}, "redirect_uris is required")
+  // Empty redirect_uris list.
+  expect_reject("empty redirect_uris", {redirect_uris: []}, "at least one")
+  // Non-loopback http (security violation per RFC 8252 §7.3).
+  expect_reject(
+    "non-loopback http",
+    {redirect_uris: ["http://attacker.example/callback"]},
+    "loopback",
+  )
+  // Fragment in redirect URI (banned by RFC 7591 §2).
+  expect_reject(
+    "fragment in redirect",
+    {redirect_uris: ["https://app.example/callback#frag"]},
+    "fragment",
+  )
+  // Unsupported scheme.
+  expect_reject("ftp scheme", {redirect_uris: ["ftp://app.example/callback"]}, "ftp")
+  // Unknown grant_type.
+  expect_reject(
+    "unknown grant_type",
+    {redirect_uris: ["https://app.example/cb"], grant_types: ["password"]},
+    "password",
+  )
+  // Unknown token_endpoint_auth_method.
+  expect_reject(
+    "unknown auth method",
+    {
+      redirect_uris: ["https://app.example/cb"],
+      token_endpoint_auth_method: "client_secret_carrier_pigeon",
+    },
+    "client_secret_carrier_pigeon",
+  )
+  // Wrong type for redirect_uris.
+  expect_reject("redirect_uris as dict", {redirect_uris: {primary: "https://app.example/cb"}}, "list")
+  // Validation never mutates the store.
+  assert_eq(len(list_clients(store)), cursor_before, "store unchanged by validation calls")
+  // register_client must also reject and not insert.
+  var caught = false
+  try {
+    let _ = register_client(store, {redirect_uris: ["http://attacker.example/cb"]})
+  } catch (err) {
+    if contains(to_string(err), "HARN-OAU-005") {
+      caught = true
+    }
+  }
+  assert(caught, "register_client must throw HARN-OAU-005 on bad metadata")
+  assert_eq(len(list_clients(store)), cursor_before, "store unchanged after rejected registration")
+  // A valid registration after rejections still works.
+  let good = register_client(store, {redirect_uris: ["https://app.example/ok"]})
+  assert(good.client_id != nil, "valid registration after rejections succeeds")
+  assert_eq(len(list_clients(store)), cursor_before + 1, "valid registration appears in store")
+  log("oauth dynamic registration rejects ok")
+}

--- a/crates/harn-parser/src/builtin_signatures/signatures/stdlib.rs
+++ b/crates/harn-parser/src/builtin_signatures/signatures/stdlib.rs
@@ -220,6 +220,46 @@ pub(crate) const SIGNATURES: &[BuiltinSignature] = &[
         ],
         TY_NIL,
     ),
+    BuiltinSignature::simple(
+        "__oauth_dynreg_build_authorization_server_metadata",
+        &[
+            Param::new("provider", TY_DICT),
+            Param::optional("overrides", TY_DICT_OR_NIL),
+        ],
+        TY_DICT,
+    ),
+    BuiltinSignature::simple(
+        "__oauth_dynreg_build_client_metadata",
+        &[Param::new("metadata", TY_DICT)],
+        TY_DICT,
+    ),
+    BuiltinSignature::simple(
+        "__oauth_dynreg_get",
+        &[
+            Param::new("handle", TY_DICT),
+            Param::new("client_id", TY_STRING),
+        ],
+        TY_DICT_OR_NIL,
+    ),
+    BuiltinSignature::simple(
+        "__oauth_dynreg_list",
+        &[Param::new("handle", TY_DICT)],
+        TY_LIST,
+    ),
+    BuiltinSignature::simple(
+        "__oauth_dynreg_register",
+        &[
+            Param::new("handle", TY_DICT),
+            Param::new("metadata", TY_DICT),
+        ],
+        TY_DICT,
+    ),
+    BuiltinSignature::simple("__oauth_dynreg_store_handle", &[], TY_DICT),
+    BuiltinSignature::simple(
+        "__oauth_dynreg_validate_metadata",
+        &[Param::new("metadata", TY_DICT)],
+        TY_DICT,
+    ),
     BuiltinSignature::simple("__token_redaction_clear_custom_patterns", &[], TY_NIL),
     BuiltinSignature::simple("__token_redaction_custom_patterns", &[], TY_LIST),
     BuiltinSignature::simple("__token_redaction_default_patterns", &[], TY_LIST),

--- a/crates/harn-stdlib/src/lib.rs
+++ b/crates/harn-stdlib/src/lib.rs
@@ -506,6 +506,10 @@ pub const STDLIB_SOURCES: &[StdlibSource] = &[
         source: include_str!("stdlib/oauth/redaction.harn"),
     },
     StdlibSource {
+        module: "oauth/dynamic_registration",
+        source: include_str!("stdlib/oauth/dynamic_registration.harn"),
+    },
+    StdlibSource {
         module: "connectors/github",
         source: include_str!("stdlib/stdlib_connectors_github.harn"),
     },

--- a/crates/harn-stdlib/src/stdlib/oauth/dynamic_registration.harn
+++ b/crates/harn-stdlib/src/stdlib/oauth/dynamic_registration.harn
@@ -1,0 +1,290 @@
+/**
+ * std/oauth/dynamic_registration (OA-05) — worker-side OAuth metadata
+ * publishing + RFC 7591 dynamic client registration.
+ *
+ * This module is the dual of `std/oauth/client`: it covers the side of
+ * the OAuth handshake where Harn *is* the resource (or auxiliary
+ * service) that other agents / services / humans register clients
+ * against. It does NOT itself host an HTTP server — it produces the
+ * RFC 7591 / RFC 8414 metadata documents, validates incoming client
+ * registrations, and stores them in an in-process catalogue. Embedders
+ * (harn-cloud, `harn serve`, custom hosts) plug those outputs into the
+ * routes they already serve.
+ *
+ * ## Surface
+ *
+ *   - `client_metadata(opts)` — build & validate an RFC 7591 client
+ *     metadata document. Returned dict is safe to serve at
+ *     `/.well-known/oauth-client.json`.
+ *   - `authorization_server_metadata(provider, overrides?)` — build an
+ *     RFC 8414 authorization-server metadata document from a provider
+ *     record (see `std/oauth/providers`). Returned dict is safe to
+ *     serve at `/.well-known/oauth-authorization-server.json`.
+ *   - `validate_metadata(metadata)` — check candidate metadata against
+ *     the RFC 7591 §2 conformance rules. Returns
+ *     `{ok: bool, errors: list<string>}`. Each error is prefixed
+ *     `HARN-OAU-005:` so callers can pattern-match.
+ *   - `dynamic_registration_store()` — opens an in-process store handle
+ *     for issuing client_ids. Backed by a thread-safe `BTreeMap` keyed
+ *     by handle id. Suitable for harn-serve and conformance fixtures;
+ *     production deployments should layer a durable backend on top via
+ *     the embedder host capabilities.
+ *   - `register_client(store, metadata)` — validate + register a
+ *     client. Returns the RFC 7591 §3.2.1 success body including the
+ *     freshly minted `client_id` and `client_secret`. Emits
+ *     `oauth.dynreg.audit` `client_registered` with no credential
+ *     material — counts + the registered redirect_uris only.
+ *   - `get_client(store, client_id)` — read back the registration
+ *     without `client_secret`. Returns nil for unknown ids.
+ *   - `list_clients(store)` — list registered client_ids.
+ *   - `well_known_paths(opts?)` — the canonical well-known URL paths;
+ *     embedders use this to mount the metadata documents.
+ *   - `well_known_response(metadata)` — wraps a metadata dict in the
+ *     `{content_type, body}` shape an HTTP layer can return without
+ *     re-serializing.
+ *
+ * ## Security
+ *
+ * Validation is strict by default per RFC 7591 §5.1 — the server is
+ * explicitly allowed to reject otherwise-conforming registrations:
+ *
+ *   - `redirect_uris` must be a non-empty list of absolute `https://`
+ *     URIs, or loopback `http://localhost` / `http://127.0.0.1` per
+ *     RFC 8252 §7.3, and may not carry a fragment.
+ *   - `grant_types`, `response_types`, `token_endpoint_auth_method`
+ *     are restricted to the spec-blessed enums.
+ *
+ * The `client_secret` is only returned from the original
+ * `register_client` call. Subsequent `get_client` reads omit it, so a
+ * stray log of the read result cannot leak credentials. Audit events
+ * carry only a counted shape (`{has_client_secret, redirect_uri_count,
+ * grant_types}`) — never the secret material.
+ *
+ * ## Disable on local runs
+ *
+ * Local `harn run` scripts that do not act as a resource server should
+ * simply not call into this module. Embedders that host the well-known
+ * endpoints (harn-cloud, `harn serve --oauth-resource ...`) read a
+ * boolean toggle from their own configuration before mounting; this
+ * module deliberately does not introduce a global on/off switch
+ * because the source of truth lives at the transport layer.
+ */
+let __AUDIT_TOPIC = "oauth.dynreg.audit"
+
+let __AUDIT_KIND_REGISTERED = "client_registered"
+
+let __DEFAULT_CLIENT_METADATA_PATH = "/.well-known/oauth-client.json"
+
+let __DEFAULT_AUTH_SERVER_METADATA_PATH = "/.well-known/oauth-authorization-server.json"
+
+let __DEFAULT_REGISTRATION_PATH = "/register"
+
+let __CONTENT_TYPE_JSON = "application/json"
+
+fn __require_dict(value, field) {
+  if type_of(value) != "dict" {
+    throw "std/oauth/dynamic_registration: " + field + " must be a dict, got " + type_of(value)
+  }
+  return value
+}
+
+fn __safe_get(dict, key) {
+  let keys = dict.keys()
+  if keys.contains(key) {
+    return dict[key]
+  }
+  return nil
+}
+
+/**
+ * validate_metadata checks an RFC 7591 candidate metadata dict and
+ * returns `{ok: bool, errors: list<string>}`. Each error is prefixed
+ * `HARN-OAU-005:` so callers can match on a stable diagnostic code.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: [invalid_argument]
+ * @api_stability: experimental
+ * @example: validate_metadata({redirect_uris: ["https://app.example/cb"]})
+ */
+pub fn validate_metadata(metadata) -> dict {
+  return __oauth_dynreg_validate_metadata(__require_dict(metadata, "metadata"))
+}
+
+/**
+ * client_metadata returns a fully-defaulted RFC 7591 client metadata
+ * dict for serving at `/.well-known/oauth-client.json`. Required field:
+ * `redirect_uris` (list of absolute https URIs, or loopback http).
+ * Optional fields are passed through verbatim. Raises an error if any
+ * field violates RFC 7591 §2.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: [invalid_argument]
+ * @api_stability: experimental
+ * @example: client_metadata({redirect_uris: ["https://app.example/cb"], client_name: "Harn"})
+ */
+pub fn client_metadata(opts) -> dict {
+  return __oauth_dynreg_build_client_metadata(__require_dict(opts, "opts"))
+}
+
+/**
+ * authorization_server_metadata returns an RFC 8414 authorization-server
+ * metadata document derived from a provider record (see
+ * `std/oauth/providers`). Pass `overrides` to set e.g. the
+ * `registration_endpoint` for the dynamic registration URL the
+ * embedding HTTP server will mount.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: [invalid_argument]
+ * @api_stability: experimental
+ * @example: authorization_server_metadata(providers().github, {registration_endpoint: "/register"})
+ */
+pub fn authorization_server_metadata(provider, overrides = nil) -> dict {
+  let provider_dict = __require_dict(provider, "provider")
+  if overrides == nil {
+    return __oauth_dynreg_build_authorization_server_metadata(provider_dict, nil)
+  }
+  return __oauth_dynreg_build_authorization_server_metadata(
+    provider_dict,
+    __require_dict(overrides, "overrides"),
+  )
+}
+
+/**
+ * dynamic_registration_store opens an in-process store handle for
+ * issuing RFC 7591 client registrations. Returned dict carries
+ * `kind: "oauth_dynreg_store"`, an opaque `id`, and three convenience
+ * closures (`register`, `get`, `list`).
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: dynamic_registration_store()
+ */
+pub fn dynamic_registration_store() -> dict {
+  let inner = __oauth_dynreg_store_handle()
+  return inner
+    + {
+    _namespace: "oauth_dynreg",
+    register: { metadata -> register_client(inner, metadata) },
+    get: { client_id -> get_client(inner, client_id) },
+    list: { -> list_clients(inner) },
+  }
+}
+
+fn __redact_shape(metadata, response) {
+  let redirect_uris = __safe_get(metadata, "redirect_uris") ?? []
+  let grant_types = __safe_get(response, "grant_types") ?? []
+  let has_secret = __safe_get(response, "client_secret") != nil
+  return {
+    redirect_uri_count: len(redirect_uris),
+    grant_types: grant_types,
+    has_client_secret: has_secret,
+    token_endpoint_auth_method: __safe_get(response, "token_endpoint_auth_method"),
+  }
+}
+
+/**
+ * register_client validates a candidate RFC 7591 metadata dict and, if
+ * acceptable, registers it on the supplied store. Returns the RFC 7591
+ * §3.2.1 success body — `{client_id, client_secret,
+ * client_id_issued_at, client_secret_expires_at, ...metadata}`. Emits
+ * an `oauth.dynreg.audit` `client_registered` event log entry with the
+ * registration *shape* (`redirect_uri_count`, `grant_types`,
+ * `has_client_secret`) — never the secret material itself.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: [invalid_argument]
+ * @api_stability: experimental
+ * @example: register_client(store, {redirect_uris: ["https://app.example/cb"]})
+ */
+pub fn register_client(store, metadata) -> dict {
+  let store_dict = __require_dict(store, "store")
+  let metadata_dict = __require_dict(metadata, "metadata")
+  let response = __oauth_dynreg_register(store_dict, metadata_dict)
+  let payload = {
+    client_id: __safe_get(response, "client_id"),
+    issued_at: __safe_get(response, "client_id_issued_at"),
+    redacted: __redact_shape(metadata_dict, response),
+  }
+  let _ = event_log.emit(__AUDIT_TOPIC, __AUDIT_KIND_REGISTERED, payload, {dynreg: "true"})
+  return response
+}
+
+/**
+ * get_client reads a previously registered client from the store. The
+ * returned dict does NOT include `client_secret` — that is only ever
+ * returned once, by `register_client`. Returns nil for unknown ids.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: get_client(store, "abc123")
+ */
+pub fn get_client(store, client_id) -> dict {
+  return __oauth_dynreg_get(__require_dict(store, "store"), client_id)
+}
+
+/**
+ * list_clients returns the list of registered client ids on the store.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: list_clients(store)
+ */
+pub fn list_clients(store) -> list<string> {
+  return __oauth_dynreg_list(__require_dict(store, "store"))
+}
+
+/**
+ * well_known_paths returns the canonical well-known URL paths used by
+ * `client_metadata` and `authorization_server_metadata`. Pass overrides
+ * to swap the default `/.well-known/oauth-*` paths for embeddings that
+ * mount under a different prefix.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: well_known_paths()
+ */
+pub fn well_known_paths(overrides = nil) -> dict {
+  let defaults = {
+    client_metadata: __DEFAULT_CLIENT_METADATA_PATH,
+    authorization_server_metadata: __DEFAULT_AUTH_SERVER_METADATA_PATH,
+    registration: __DEFAULT_REGISTRATION_PATH,
+  }
+  if overrides == nil {
+    return defaults
+  }
+  return defaults + __require_dict(overrides, "overrides")
+}
+
+/**
+ * well_known_response wraps a metadata dict as an HTTP response envelope
+ * with `content_type: "application/json"` and a `body` string. This is
+ * the shape embedders feed into harn-serve or harn-cloud route
+ * handlers — no extra serialization on the embedder side.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: [invalid_argument]
+ * @api_stability: experimental
+ * @example: well_known_response(client_metadata({redirect_uris: ["https://a/cb"]}))
+ */
+pub fn well_known_response(metadata) -> dict {
+  let dict = __require_dict(metadata, "metadata")
+  return {
+    status: 200,
+    content_type: __CONTENT_TYPE_JSON,
+    headers: {"content-type": __CONTENT_TYPE_JSON, "cache-control": "no-store"},
+    body: json_stringify(dict),
+  }
+}

--- a/crates/harn-vm/src/stdlib.rs
+++ b/crates/harn-vm/src/stdlib.rs
@@ -40,6 +40,7 @@ mod math;
 mod memory;
 mod monitors;
 mod multipart;
+mod oauth_dynreg;
 mod oauth_storage;
 mod options;
 mod path;
@@ -166,6 +167,7 @@ pub fn register_agent_stdlib(vm: &mut Vm) {
     agents::register_agent_builtins(vm);
     pool::register_pool_builtins(vm);
     oauth_storage::register_oauth_storage_builtins(vm);
+    oauth_dynreg::register_oauth_dynreg_builtins(vm);
     token_redaction::register_token_redaction_builtins(vm);
     agent_sessions::register_agent_session_builtins(vm);
     workflow_messages::register_workflow_message_builtins(vm);

--- a/crates/harn-vm/src/stdlib/oauth_dynreg.rs
+++ b/crates/harn-vm/src/stdlib/oauth_dynreg.rs
@@ -1,0 +1,994 @@
+//! `std/oauth/dynamic_registration` — RFC 7591 / RFC 8414 client metadata
+//! publishing and dynamic client registration (OA-05, issue #1906).
+//!
+//! This module is the *worker-side* counterpart to the OAuth client. It
+//! lets a Harn-hosted service:
+//!
+//!   1. Build & validate RFC 7591 *client metadata* (`build_client_metadata`)
+//!      that is served at `/.well-known/oauth-client.json` (configurable).
+//!   2. Build RFC 8414 *authorization-server metadata*
+//!      (`build_authorization_server_metadata`) served at
+//!      `/.well-known/oauth-authorization-server.json`.
+//!   3. Run an in-process dynamic-client-registration store backed by a
+//!      thread-local `BTreeMap`, with `register / get / list` operations.
+//!      Each successful `register` issues a fresh `client_id` +
+//!      `client_secret` (URL-safe base64, 256 bits of entropy each) and
+//!      stores the registration timestamp.
+//!
+//! ## Security
+//!
+//! All validation happens once in Rust so the rules are uniform across
+//! the script-facing `build_client_metadata` helper and the
+//! `register_client` registration path. The RFC 7591 §2 requirements
+//! enforced here are intentionally conservative:
+//!
+//!   * `redirect_uris` must be a non-empty list of absolute `https://`
+//!     URIs (or `http://localhost`/`http://127.0.0.1` for local-dev
+//!     redirect URIs, with no fragment).
+//!   * `grant_types`, `response_types`, and `token_endpoint_auth_method`
+//!     are restricted to the spec-blessed enums.
+//!   * `client_name`, `client_uri`, `logo_uri`, `tos_uri`, `policy_uri`,
+//!     and `software_id`/`software_version` are bounded-length strings.
+//!
+//! Servers are explicitly permitted by RFC 7591 §5.1 to reject otherwise
+//! conforming registrations; we use that latitude to refuse fragments,
+//! relative URIs, and non-`https` redirect targets that are not loopback.
+//!
+//! The freshly minted `client_secret` is *only* returned from the
+//! `register` call. Subsequent `get` reads omit it so logs and audit
+//! events never accidentally re-emit it. The Harn-side wrapper module
+//! is responsible for emitting `oauth.dynreg.audit` event-log entries
+//! with the redacted shape.
+//!
+//! ## Concurrency
+//!
+//! The store lives in a `thread_local!` `RefCell<BTreeMap<...>>` keyed
+//! by handle id (mirroring `oauth_storage`'s memory backend). The Harn
+//! VM is single-threaded per execution, so a thread-local map is the
+//! natural fit. Two `register` calls cannot mint colliding `client_id`s
+//! because they are independently drawn from 256 bits of cryptographic
+//! randomness.
+
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::rc::Rc;
+use std::sync::Mutex;
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine as _;
+use rand::Rng as _;
+use serde_json::Value as JsonValue;
+use url::Url;
+
+use crate::llm::vm_value_to_json;
+use crate::schema::json_to_vm_value;
+use crate::stdlib::clock;
+use crate::value::{VmError, VmValue};
+use crate::vm::Vm;
+
+const HANDLE_KEY_KIND: &str = "kind";
+const HANDLE_KEY_ID: &str = "id";
+const KIND_DYNREG_STORE: &str = "oauth_dynreg_store";
+
+const MAX_REDIRECT_URIS: usize = 16;
+const MAX_STRING_LEN: usize = 2048;
+const MAX_CLIENT_NAME_LEN: usize = 256;
+
+// RFC 7591 §2 — allowed grant_types we accept on registration.
+const ALLOWED_GRANT_TYPES: &[&str] = &[
+    "authorization_code",
+    "refresh_token",
+    "client_credentials",
+    "urn:ietf:params:oauth:grant-type:device_code",
+    "urn:ietf:params:oauth:grant-type:jwt-bearer",
+];
+
+const ALLOWED_RESPONSE_TYPES: &[&str] = &["code", "token", "id_token", "code id_token", "none"];
+
+const ALLOWED_AUTH_METHODS: &[&str] = &[
+    "client_secret_basic",
+    "client_secret_post",
+    "client_secret_jwt",
+    "private_key_jwt",
+    "none",
+];
+
+// A persisted client registration. Metadata is serialized to JSON so the
+// store can live in a thread-local map without holding `!Send` `VmValue`
+// payloads. The freshly minted `client_secret` is intentionally NOT
+// retained here — only the original `register` call returns it, and any
+// later credential check would happen at the transport layer (e.g. by
+// verifying a presented secret against an HMAC stored elsewhere). This
+// keeps the in-process catalogue limited to the public registration
+// shape and makes it impossible for a stray `get` to surface the secret.
+#[derive(Clone, Debug)]
+struct StoredClient {
+    metadata: JsonValue,
+    client_id: String,
+    client_id_issued_at: i64,
+}
+
+#[derive(Default)]
+struct DynregStore {
+    clients: BTreeMap<String, StoredClient>,
+}
+
+thread_local! {
+    static DYNREG_STORES: RefCell<BTreeMap<String, DynregStore>> =
+        const { RefCell::new(BTreeMap::new()) };
+}
+
+static STORE_ID_COUNTER: Mutex<u64> = Mutex::new(0);
+
+pub(crate) fn register_oauth_dynreg_builtins(vm: &mut Vm) {
+    vm.register_builtin("__oauth_dynreg_store_handle", |args, _out| {
+        if !args.is_empty() {
+            return Err(VmError::Runtime(
+                "__oauth_dynreg_store_handle: expected 0 arguments".to_string(),
+            ));
+        }
+        let id = next_store_id();
+        DYNREG_STORES.with(|stores| {
+            stores
+                .borrow_mut()
+                .insert(id.clone(), DynregStore::default());
+        });
+        Ok(store_handle(&id))
+    });
+
+    vm.register_builtin("__oauth_dynreg_validate_metadata", |args, _out| {
+        let metadata = require_dict_arg(args, 0, "__oauth_dynreg_validate_metadata", "metadata")?;
+        Ok(validate_metadata_value(&metadata))
+    });
+
+    vm.register_builtin("__oauth_dynreg_build_client_metadata", |args, _out| {
+        let metadata =
+            require_dict_arg(args, 0, "__oauth_dynreg_build_client_metadata", "metadata")?;
+        build_client_metadata_value(&metadata)
+    });
+
+    vm.register_builtin(
+        "__oauth_dynreg_build_authorization_server_metadata",
+        |args, _out| {
+            let provider = require_dict_arg(
+                args,
+                0,
+                "__oauth_dynreg_build_authorization_server_metadata",
+                "provider",
+            )?;
+            let overrides = optional_dict_arg(
+                args,
+                1,
+                "__oauth_dynreg_build_authorization_server_metadata",
+                "overrides",
+            )?;
+            build_authorization_server_metadata_value(&provider, overrides.as_ref())
+        },
+    );
+
+    vm.register_builtin("__oauth_dynreg_register", |args, _out| {
+        let handle = require_handle(args, 0, "__oauth_dynreg_register")?;
+        let metadata = require_dict_arg(args, 1, "__oauth_dynreg_register", "metadata")?;
+        register_client_value(&handle, &metadata)
+    });
+
+    vm.register_builtin("__oauth_dynreg_get", |args, _out| {
+        let handle = require_handle(args, 0, "__oauth_dynreg_get")?;
+        let client_id = required_string_arg(args, 1, "__oauth_dynreg_get", "client_id")?;
+        Ok(get_client_value(&handle, &client_id))
+    });
+
+    vm.register_builtin("__oauth_dynreg_list", |args, _out| {
+        let handle = require_handle(args, 0, "__oauth_dynreg_list")?;
+        Ok(list_clients_value(&handle))
+    });
+}
+
+fn next_store_id() -> String {
+    let mut guard = STORE_ID_COUNTER.lock().expect("dynreg counter poisoned");
+    *guard = guard.wrapping_add(1);
+    format!("dynreg-{}", *guard)
+}
+
+fn store_handle(id: &str) -> VmValue {
+    let mut fields = BTreeMap::new();
+    fields.insert(HANDLE_KEY_KIND.to_string(), string_value(KIND_DYNREG_STORE));
+    fields.insert(HANDLE_KEY_ID.to_string(), string_value(id));
+    VmValue::Dict(Rc::new(fields))
+}
+
+fn string_value(value: &str) -> VmValue {
+    VmValue::String(Rc::from(value))
+}
+
+fn handle_id(handle: &BTreeMap<String, VmValue>) -> Result<String, VmError> {
+    let kind = handle.get(HANDLE_KEY_KIND).and_then(|value| match value {
+        VmValue::String(s) => Some(s.to_string()),
+        _ => None,
+    });
+    match kind.as_deref() {
+        Some(KIND_DYNREG_STORE) => {}
+        Some(other) => {
+            return Err(VmError::Runtime(format!(
+                "oauth dynamic registration: expected store handle kind `{KIND_DYNREG_STORE}`, got `{other}`"
+            )));
+        }
+        None => {
+            return Err(VmError::Runtime(
+                "oauth dynamic registration: handle is missing `kind`".to_string(),
+            ));
+        }
+    }
+    handle
+        .get(HANDLE_KEY_ID)
+        .and_then(|value| match value {
+            VmValue::String(s) => Some(s.to_string()),
+            _ => None,
+        })
+        .ok_or_else(|| {
+            VmError::Runtime("oauth dynamic registration: handle is missing `id`".to_string())
+        })
+}
+
+// ----- Validation -----------------------------------------------------------
+
+fn validate_metadata_value(metadata: &BTreeMap<String, VmValue>) -> VmValue {
+    let mut errors: Vec<String> = Vec::new();
+    validate_metadata(metadata, &mut errors);
+    let mut out = BTreeMap::new();
+    out.insert("ok".to_string(), VmValue::Bool(errors.is_empty()));
+    out.insert(
+        "errors".to_string(),
+        VmValue::List(Rc::new(
+            errors.iter().map(|e| string_value(e)).collect::<Vec<_>>(),
+        )),
+    );
+    VmValue::Dict(Rc::new(out))
+}
+
+/// Run RFC 7591 §2 validation, pushing human-readable errors. Each error
+/// is prefixed `HARN-OAU-005: ` so callers can pattern-match consistently.
+fn validate_metadata(metadata: &BTreeMap<String, VmValue>, errors: &mut Vec<String>) {
+    // redirect_uris: required, non-empty list, https or loopback http, no
+    // fragments. RFC 7591 §2 + §5 — server may reject otherwise.
+    let redirect_uris = metadata.get("redirect_uris");
+    match redirect_uris {
+        None | Some(VmValue::Nil) => {
+            errors.push(err("redirect_uris is required"));
+        }
+        Some(VmValue::List(items)) => {
+            if items.is_empty() {
+                errors.push(err("redirect_uris must contain at least one entry"));
+            } else if items.len() > MAX_REDIRECT_URIS {
+                errors.push(err(&format!(
+                    "redirect_uris must contain at most {MAX_REDIRECT_URIS} entries"
+                )));
+            }
+            for (i, value) in items.iter().enumerate() {
+                match value {
+                    VmValue::String(s) => {
+                        if let Err(reason) = validate_redirect_uri(s) {
+                            errors.push(err(&format!("redirect_uris[{i}] {reason}")));
+                        }
+                    }
+                    other => errors.push(err(&format!(
+                        "redirect_uris[{i}] must be a string, got {}",
+                        other.type_name()
+                    ))),
+                }
+            }
+        }
+        Some(other) => errors.push(err(&format!(
+            "redirect_uris must be a list of strings, got {}",
+            other.type_name()
+        ))),
+    }
+
+    // Optional list-of-string enums.
+    validate_enum_list(metadata, "grant_types", ALLOWED_GRANT_TYPES, true, errors);
+    validate_enum_list(
+        metadata,
+        "response_types",
+        ALLOWED_RESPONSE_TYPES,
+        true,
+        errors,
+    );
+
+    // token_endpoint_auth_method: single optional string.
+    if let Some(value) = metadata.get("token_endpoint_auth_method") {
+        match value {
+            VmValue::Nil => {}
+            VmValue::String(s) => {
+                if !ALLOWED_AUTH_METHODS.contains(&s.as_ref()) {
+                    errors.push(err(&format!(
+                        "token_endpoint_auth_method `{s}` is not one of: {}",
+                        ALLOWED_AUTH_METHODS.join(", ")
+                    )));
+                }
+            }
+            other => errors.push(err(&format!(
+                "token_endpoint_auth_method must be a string, got {}",
+                other.type_name()
+            ))),
+        }
+    }
+
+    // scope: space-delimited string per RFC 7591 §2.
+    if let Some(value) = metadata.get("scope") {
+        match value {
+            VmValue::Nil => {}
+            VmValue::String(s) => {
+                if s.len() > MAX_STRING_LEN {
+                    errors.push(err(&format!("scope exceeds {MAX_STRING_LEN}-byte limit")));
+                }
+            }
+            other => errors.push(err(&format!(
+                "scope must be a string, got {}",
+                other.type_name()
+            ))),
+        }
+    }
+
+    // Bounded display strings.
+    validate_optional_bounded_string(metadata, "client_name", MAX_CLIENT_NAME_LEN, errors);
+    validate_optional_url(metadata, "client_uri", errors);
+    validate_optional_url(metadata, "logo_uri", errors);
+    validate_optional_url(metadata, "tos_uri", errors);
+    validate_optional_url(metadata, "policy_uri", errors);
+    validate_optional_url(metadata, "jwks_uri", errors);
+    validate_optional_bounded_string(metadata, "software_id", MAX_STRING_LEN, errors);
+    validate_optional_bounded_string(metadata, "software_version", MAX_STRING_LEN, errors);
+
+    // contacts: optional list of strings.
+    if let Some(value) = metadata.get("contacts") {
+        match value {
+            VmValue::Nil => {}
+            VmValue::List(items) => {
+                for (i, item) in items.iter().enumerate() {
+                    match item {
+                        VmValue::String(s) => {
+                            if s.len() > MAX_STRING_LEN {
+                                errors.push(err(&format!(
+                                    "contacts[{i}] exceeds {MAX_STRING_LEN}-byte limit"
+                                )));
+                            }
+                        }
+                        other => errors.push(err(&format!(
+                            "contacts[{i}] must be a string, got {}",
+                            other.type_name()
+                        ))),
+                    }
+                }
+            }
+            other => errors.push(err(&format!(
+                "contacts must be a list of strings, got {}",
+                other.type_name()
+            ))),
+        }
+    }
+}
+
+fn err(msg: &str) -> String {
+    format!("HARN-OAU-005: {msg}")
+}
+
+fn validate_redirect_uri(value: &str) -> Result<(), String> {
+    if value.is_empty() {
+        return Err("must be a non-empty absolute URI".to_string());
+    }
+    if value.len() > MAX_STRING_LEN {
+        return Err(format!("exceeds {MAX_STRING_LEN}-byte limit"));
+    }
+    let url = Url::parse(value).map_err(|e| format!("is not a valid absolute URI: {e}"))?;
+    if url.fragment().is_some() {
+        return Err("must not contain a URI fragment per RFC 7591 §2".to_string());
+    }
+    match url.scheme() {
+        "https" => Ok(()),
+        "http" => {
+            // Allow only loopback for development. RFC 8252 §7.3.
+            let host = url
+                .host_str()
+                .ok_or_else(|| "must specify a host".to_string())?;
+            if host == "localhost" || host == "127.0.0.1" || host == "[::1]" {
+                Ok(())
+            } else {
+                Err(format!(
+                    "scheme `http` is only allowed for loopback hosts, got `{host}`"
+                ))
+            }
+        }
+        scheme => Err(format!(
+            "scheme `{scheme}` is not allowed; use `https` or loopback `http`"
+        )),
+    }
+}
+
+fn validate_enum_list(
+    metadata: &BTreeMap<String, VmValue>,
+    field: &str,
+    allowed: &[&str],
+    optional: bool,
+    errors: &mut Vec<String>,
+) {
+    match metadata.get(field) {
+        None | Some(VmValue::Nil) => {
+            if !optional {
+                errors.push(err(&format!("{field} is required")));
+            }
+        }
+        Some(VmValue::List(items)) => {
+            for (i, item) in items.iter().enumerate() {
+                match item {
+                    VmValue::String(s) => {
+                        if !allowed.contains(&s.as_ref()) {
+                            errors.push(err(&format!(
+                                "{field}[{i}] `{s}` is not one of: {}",
+                                allowed.join(", ")
+                            )));
+                        }
+                    }
+                    other => errors.push(err(&format!(
+                        "{field}[{i}] must be a string, got {}",
+                        other.type_name()
+                    ))),
+                }
+            }
+        }
+        Some(other) => errors.push(err(&format!(
+            "{field} must be a list of strings, got {}",
+            other.type_name()
+        ))),
+    }
+}
+
+fn validate_optional_bounded_string(
+    metadata: &BTreeMap<String, VmValue>,
+    field: &str,
+    max_len: usize,
+    errors: &mut Vec<String>,
+) {
+    if let Some(value) = metadata.get(field) {
+        match value {
+            VmValue::Nil => {}
+            VmValue::String(s) => {
+                if s.len() > max_len {
+                    errors.push(err(&format!("{field} exceeds {max_len}-byte limit")));
+                }
+            }
+            other => errors.push(err(&format!(
+                "{field} must be a string, got {}",
+                other.type_name()
+            ))),
+        }
+    }
+}
+
+fn validate_optional_url(
+    metadata: &BTreeMap<String, VmValue>,
+    field: &str,
+    errors: &mut Vec<String>,
+) {
+    if let Some(value) = metadata.get(field) {
+        match value {
+            VmValue::Nil => {}
+            VmValue::String(s) => {
+                if s.len() > MAX_STRING_LEN {
+                    errors.push(err(&format!("{field} exceeds {MAX_STRING_LEN}-byte limit")));
+                } else if let Err(e) = Url::parse(s) {
+                    errors.push(err(&format!("{field} is not a valid absolute URI: {e}")));
+                }
+            }
+            other => errors.push(err(&format!(
+                "{field} must be a string, got {}",
+                other.type_name()
+            ))),
+        }
+    }
+}
+
+// ----- Metadata builders ----------------------------------------------------
+
+fn build_client_metadata_value(metadata: &BTreeMap<String, VmValue>) -> Result<VmValue, VmError> {
+    let mut errors: Vec<String> = Vec::new();
+    validate_metadata(metadata, &mut errors);
+    if !errors.is_empty() {
+        return Err(VmError::Runtime(format!(
+            "oauth dynamic registration: invalid client metadata: {}",
+            errors.join("; ")
+        )));
+    }
+
+    // Apply RFC 7591 §2 defaults when fields are omitted: response_types
+    // defaults to `["code"]`; grant_types defaults to `["authorization_code"]`;
+    // token_endpoint_auth_method defaults to `client_secret_basic`.
+    let mut out: BTreeMap<String, VmValue> = metadata.clone();
+    out.entry("response_types".to_string())
+        .or_insert_with(|| VmValue::List(Rc::new(vec![string_value("code")])));
+    out.entry("grant_types".to_string())
+        .or_insert_with(|| VmValue::List(Rc::new(vec![string_value("authorization_code")])));
+    out.entry("token_endpoint_auth_method".to_string())
+        .or_insert_with(|| string_value("client_secret_basic"));
+    Ok(VmValue::Dict(Rc::new(out)))
+}
+
+fn build_authorization_server_metadata_value(
+    provider: &BTreeMap<String, VmValue>,
+    overrides: Option<&BTreeMap<String, VmValue>>,
+) -> Result<VmValue, VmError> {
+    let auth_url = require_string_field(provider, "auth_url", "provider")?;
+    let token_url = require_string_field(provider, "token_url", "provider")?;
+    let issuer = derive_issuer(&auth_url)?;
+
+    let mut out: BTreeMap<String, VmValue> = BTreeMap::new();
+    out.insert("issuer".to_string(), string_value(&issuer));
+    out.insert(
+        "authorization_endpoint".to_string(),
+        string_value(&auth_url),
+    );
+    out.insert("token_endpoint".to_string(), string_value(&token_url));
+    if let Some(VmValue::String(s)) = provider.get("device_code_url") {
+        out.insert(
+            "device_authorization_endpoint".to_string(),
+            string_value(s.as_ref()),
+        );
+    }
+    if let Some(VmValue::String(s)) = provider.get("revoke_url") {
+        out.insert("revocation_endpoint".to_string(), string_value(s.as_ref()));
+    }
+    if let Some(VmValue::String(s)) = provider.get("userinfo_url") {
+        out.insert("userinfo_endpoint".to_string(), string_value(s.as_ref()));
+    }
+    out.insert(
+        "response_types_supported".to_string(),
+        VmValue::List(Rc::new(vec![string_value("code")])),
+    );
+    out.insert(
+        "grant_types_supported".to_string(),
+        VmValue::List(Rc::new(vec![
+            string_value("authorization_code"),
+            string_value("refresh_token"),
+            string_value("urn:ietf:params:oauth:grant-type:device_code"),
+        ])),
+    );
+    out.insert(
+        "token_endpoint_auth_methods_supported".to_string(),
+        VmValue::List(Rc::new(vec![
+            string_value("client_secret_basic"),
+            string_value("client_secret_post"),
+            string_value("none"),
+        ])),
+    );
+    if let Some(VmValue::Bool(true)) | Some(VmValue::Bool(false)) = provider.get("pkce_required") {
+        out.insert(
+            "code_challenge_methods_supported".to_string(),
+            VmValue::List(Rc::new(vec![string_value("S256")])),
+        );
+    } else {
+        out.insert(
+            "code_challenge_methods_supported".to_string(),
+            VmValue::List(Rc::new(vec![string_value("S256")])),
+        );
+    }
+    if let Some(VmValue::List(scopes)) = provider.get("default_scopes") {
+        out.insert(
+            "scopes_supported".to_string(),
+            VmValue::List(scopes.clone()),
+        );
+    }
+    // Apply caller overrides last; this lets harn-cloud add e.g.
+    // `registration_endpoint` once they wire the well-known route.
+    if let Some(overrides) = overrides {
+        for (k, v) in overrides {
+            out.insert(k.clone(), v.clone());
+        }
+    }
+    Ok(VmValue::Dict(Rc::new(out)))
+}
+
+fn derive_issuer(auth_url: &str) -> Result<String, VmError> {
+    let url = Url::parse(auth_url).map_err(|e| {
+        VmError::Runtime(format!(
+            "oauth dynamic registration: provider.auth_url is not a valid URI: {e}"
+        ))
+    })?;
+    let scheme = url.scheme();
+    let host = url.host_str().ok_or_else(|| {
+        VmError::Runtime(
+            "oauth dynamic registration: provider.auth_url is missing a host".to_string(),
+        )
+    })?;
+    match url.port() {
+        Some(port) => Ok(format!("{scheme}://{host}:{port}")),
+        None => Ok(format!("{scheme}://{host}")),
+    }
+}
+
+// ----- Registration ---------------------------------------------------------
+
+fn register_client_value(
+    handle: &BTreeMap<String, VmValue>,
+    metadata: &BTreeMap<String, VmValue>,
+) -> Result<VmValue, VmError> {
+    let mut errors: Vec<String> = Vec::new();
+    validate_metadata(metadata, &mut errors);
+    if !errors.is_empty() {
+        return Err(VmError::Runtime(format!(
+            "oauth dynamic registration: registration rejected: {}",
+            errors.join("; ")
+        )));
+    }
+    let store_id = handle_id(handle)?;
+    let client_id = random_token(32);
+    let client_secret = random_token(32);
+    let issued_at = now_unix_seconds();
+
+    let mut canonical = metadata.clone();
+    canonical
+        .entry("response_types".to_string())
+        .or_insert_with(|| VmValue::List(Rc::new(vec![string_value("code")])));
+    canonical
+        .entry("grant_types".to_string())
+        .or_insert_with(|| VmValue::List(Rc::new(vec![string_value("authorization_code")])));
+    canonical
+        .entry("token_endpoint_auth_method".to_string())
+        .or_insert_with(|| string_value("client_secret_basic"));
+
+    let canonical_dict = VmValue::Dict(Rc::new(canonical.clone()));
+    let canonical_json = vm_value_to_json(&canonical_dict);
+
+    let stored = StoredClient {
+        metadata: canonical_json,
+        client_id: client_id.clone(),
+        client_id_issued_at: issued_at,
+    };
+    DYNREG_STORES.with(|stores| -> Result<(), VmError> {
+        let mut stores = stores.borrow_mut();
+        let store = stores.get_mut(&store_id).ok_or_else(|| {
+            VmError::Runtime(format!(
+                "oauth dynamic registration: store handle `{store_id}` is no longer registered"
+            ))
+        })?;
+        store.clients.insert(client_id.clone(), stored);
+        Ok(())
+    })?;
+
+    // Build the response dict — full RFC 7591 §3.2.1 success body.
+    let mut response: BTreeMap<String, VmValue> = canonical;
+    response.insert("client_id".to_string(), string_value(&client_id));
+    response.insert("client_secret".to_string(), string_value(&client_secret));
+    response.insert("client_id_issued_at".to_string(), VmValue::Int(issued_at));
+    // Per RFC 7591 §3.2.1, `client_secret_expires_at: 0` means non-expiring.
+    response.insert("client_secret_expires_at".to_string(), VmValue::Int(0));
+    Ok(VmValue::Dict(Rc::new(response)))
+}
+
+fn get_client_value(handle: &BTreeMap<String, VmValue>, client_id: &str) -> VmValue {
+    let store_id = match handle_id(handle) {
+        Ok(v) => v,
+        Err(_) => return VmValue::Nil,
+    };
+    DYNREG_STORES.with(|stores| {
+        let stores = stores.borrow();
+        let Some(store) = stores.get(&store_id) else {
+            return VmValue::Nil;
+        };
+        let Some(client) = store.clients.get(client_id) else {
+            return VmValue::Nil;
+        };
+        // Never re-emit the client_secret — only the original `register`
+        // call returns it. Subsequent reads expose only the public
+        // metadata + id + issued_at so logs/audits cannot accidentally
+        // leak credentials.
+        let metadata_value = json_to_vm_value(&client.metadata);
+        let mut response: BTreeMap<String, VmValue> = match metadata_value {
+            VmValue::Dict(dict) => dict.as_ref().clone(),
+            _ => BTreeMap::new(),
+        };
+        response.insert("client_id".to_string(), string_value(&client.client_id));
+        response.insert(
+            "client_id_issued_at".to_string(),
+            VmValue::Int(client.client_id_issued_at),
+        );
+        response.insert("client_secret_expires_at".to_string(), VmValue::Int(0));
+        VmValue::Dict(Rc::new(response))
+    })
+}
+
+fn list_clients_value(handle: &BTreeMap<String, VmValue>) -> VmValue {
+    let store_id = match handle_id(handle) {
+        Ok(v) => v,
+        Err(_) => return VmValue::List(Rc::new(Vec::new())),
+    };
+    DYNREG_STORES.with(|stores| {
+        let stores = stores.borrow();
+        let Some(store) = stores.get(&store_id) else {
+            return VmValue::List(Rc::new(Vec::new()));
+        };
+        let ids: Vec<VmValue> = store
+            .clients
+            .keys()
+            .map(|id| string_value(id.as_str()))
+            .collect();
+        VmValue::List(Rc::new(ids))
+    })
+}
+
+// ----- Helpers --------------------------------------------------------------
+
+fn random_token(byte_len: usize) -> String {
+    let mut buf = vec![0u8; byte_len];
+    rand::rng().fill_bytes(&mut buf);
+    URL_SAFE_NO_PAD.encode(&buf)
+}
+
+fn now_unix_seconds() -> i64 {
+    // Route through `stdlib::clock` so mock-clock-based conformance / unit
+    // tests get a deterministic `client_id_issued_at` instead of the host
+    // wall clock. Falls back to the real system time when no mock is
+    // installed.
+    clock::now_wall_ms() / 1000
+}
+
+fn require_handle(
+    args: &[VmValue],
+    index: usize,
+    fn_name: &str,
+) -> Result<BTreeMap<String, VmValue>, VmError> {
+    match args.get(index) {
+        Some(VmValue::Dict(dict)) => Ok(dict.as_ref().clone()),
+        Some(other) => Err(VmError::Runtime(format!(
+            "{fn_name}: handle must be a dict, got {}",
+            other.type_name()
+        ))),
+        None => Err(VmError::Runtime(format!(
+            "{fn_name}: missing handle argument"
+        ))),
+    }
+}
+
+fn require_dict_arg(
+    args: &[VmValue],
+    index: usize,
+    fn_name: &str,
+    arg_name: &str,
+) -> Result<BTreeMap<String, VmValue>, VmError> {
+    match args.get(index) {
+        Some(VmValue::Dict(dict)) => Ok(dict.as_ref().clone()),
+        Some(other) => Err(VmError::Runtime(format!(
+            "{fn_name}: `{arg_name}` must be a dict, got {}",
+            other.type_name()
+        ))),
+        None => Err(VmError::Runtime(format!(
+            "{fn_name}: `{arg_name}` argument is required"
+        ))),
+    }
+}
+
+fn optional_dict_arg(
+    args: &[VmValue],
+    index: usize,
+    fn_name: &str,
+    arg_name: &str,
+) -> Result<Option<BTreeMap<String, VmValue>>, VmError> {
+    match args.get(index) {
+        None | Some(VmValue::Nil) => Ok(None),
+        Some(VmValue::Dict(dict)) => Ok(Some(dict.as_ref().clone())),
+        Some(other) => Err(VmError::Runtime(format!(
+            "{fn_name}: `{arg_name}` must be a dict or nil, got {}",
+            other.type_name()
+        ))),
+    }
+}
+
+fn required_string_arg(
+    args: &[VmValue],
+    index: usize,
+    fn_name: &str,
+    arg_name: &str,
+) -> Result<String, VmError> {
+    match args.get(index) {
+        Some(VmValue::String(s)) => Ok(s.to_string()),
+        Some(other) => Err(VmError::Runtime(format!(
+            "{fn_name}: `{arg_name}` must be a string, got {}",
+            other.type_name()
+        ))),
+        None => Err(VmError::Runtime(format!(
+            "{fn_name}: `{arg_name}` argument is required"
+        ))),
+    }
+}
+
+fn require_string_field(
+    metadata: &BTreeMap<String, VmValue>,
+    field: &str,
+    owner: &str,
+) -> Result<String, VmError> {
+    match metadata.get(field) {
+        Some(VmValue::String(s)) if !s.is_empty() => Ok(s.to_string()),
+        Some(VmValue::String(_)) => Err(VmError::Runtime(format!(
+            "oauth dynamic registration: {owner}.{field} must not be empty"
+        ))),
+        _ => Err(VmError::Runtime(format!(
+            "oauth dynamic registration: {owner}.{field} is required"
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn metadata_with_redirect(uri: &str) -> BTreeMap<String, VmValue> {
+        let mut m = BTreeMap::new();
+        m.insert(
+            "redirect_uris".to_string(),
+            VmValue::List(Rc::new(vec![string_value(uri)])),
+        );
+        m
+    }
+
+    #[test]
+    fn valid_metadata_passes() {
+        let m = metadata_with_redirect("https://app.example/callback");
+        let mut errors = Vec::new();
+        validate_metadata(&m, &mut errors);
+        assert!(errors.is_empty(), "expected no errors, got {errors:?}");
+    }
+
+    #[test]
+    fn loopback_http_redirect_passes() {
+        let m = metadata_with_redirect("http://127.0.0.1:8765/callback");
+        let mut errors = Vec::new();
+        validate_metadata(&m, &mut errors);
+        assert!(errors.is_empty(), "expected no errors, got {errors:?}");
+    }
+
+    #[test]
+    fn non_loopback_http_redirect_fails() {
+        let m = metadata_with_redirect("http://attacker.example/callback");
+        let mut errors = Vec::new();
+        validate_metadata(&m, &mut errors);
+        assert_eq!(errors.len(), 1, "expected single rejection, got {errors:?}");
+        assert!(errors[0].contains("HARN-OAU-005"));
+        assert!(errors[0].contains("loopback"), "got {}", errors[0]);
+    }
+
+    #[test]
+    fn fragment_in_redirect_fails() {
+        let m = metadata_with_redirect("https://app.example/callback#frag");
+        let mut errors = Vec::new();
+        validate_metadata(&m, &mut errors);
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].contains("fragment"), "got {}", errors[0]);
+    }
+
+    #[test]
+    fn empty_redirect_uris_fails() {
+        let mut m = BTreeMap::new();
+        m.insert(
+            "redirect_uris".to_string(),
+            VmValue::List(Rc::new(Vec::new())),
+        );
+        let mut errors = Vec::new();
+        validate_metadata(&m, &mut errors);
+        assert!(errors[0].contains("at least one"));
+    }
+
+    #[test]
+    fn missing_redirect_uris_fails() {
+        let m: BTreeMap<String, VmValue> = BTreeMap::new();
+        let mut errors = Vec::new();
+        validate_metadata(&m, &mut errors);
+        assert!(errors[0].contains("redirect_uris is required"));
+    }
+
+    #[test]
+    fn unknown_grant_type_fails() {
+        let mut m = metadata_with_redirect("https://app.example/cb");
+        m.insert(
+            "grant_types".to_string(),
+            VmValue::List(Rc::new(vec![string_value("password")])),
+        );
+        let mut errors = Vec::new();
+        validate_metadata(&m, &mut errors);
+        assert!(errors.iter().any(|e| e.contains("password")));
+    }
+
+    #[test]
+    fn build_applies_defaults() {
+        let m = metadata_with_redirect("https://app.example/cb");
+        let built = build_client_metadata_value(&m).expect("ok");
+        let VmValue::Dict(dict) = built else {
+            panic!("expected dict")
+        };
+        assert!(dict.contains_key("grant_types"));
+        assert!(dict.contains_key("response_types"));
+        assert!(dict.contains_key("token_endpoint_auth_method"));
+    }
+
+    #[test]
+    fn build_authorization_server_metadata_minimal() {
+        let mut provider = BTreeMap::new();
+        provider.insert(
+            "auth_url".to_string(),
+            string_value("https://idp.example/authorize"),
+        );
+        provider.insert(
+            "token_url".to_string(),
+            string_value("https://idp.example/token"),
+        );
+        let built = build_authorization_server_metadata_value(&provider, None).expect("ok");
+        let VmValue::Dict(dict) = built else {
+            panic!("expected dict")
+        };
+        assert!(
+            matches!(dict.get("issuer"), Some(VmValue::String(s)) if s.as_ref() == "https://idp.example")
+        );
+        assert!(matches!(
+            dict.get("authorization_endpoint"),
+            Some(VmValue::String(_))
+        ));
+        assert!(matches!(
+            dict.get("token_endpoint"),
+            Some(VmValue::String(_))
+        ));
+        assert!(matches!(
+            dict.get("response_types_supported"),
+            Some(VmValue::List(_))
+        ));
+    }
+
+    #[test]
+    fn register_returns_client_id_and_secret() {
+        // Fresh store.
+        let id = next_store_id();
+        DYNREG_STORES.with(|stores| {
+            stores
+                .borrow_mut()
+                .insert(id.clone(), DynregStore::default());
+        });
+        let mut handle = BTreeMap::new();
+        handle.insert("kind".to_string(), string_value(KIND_DYNREG_STORE));
+        handle.insert("id".to_string(), string_value(&id));
+        let m = metadata_with_redirect("https://app.example/cb");
+        let response = register_client_value(&handle, &m).expect("registration ok");
+        let VmValue::Dict(dict) = response else {
+            panic!("expected dict")
+        };
+        let VmValue::String(client_id) = dict.get("client_id").expect("client_id") else {
+            panic!("client_id must be a string");
+        };
+        assert!(client_id.len() >= 32);
+        assert!(matches!(dict.get("client_secret"), Some(VmValue::String(s)) if s.len() >= 32));
+        // Get reads do NOT expose the secret.
+        let fetched = get_client_value(&handle, client_id);
+        let VmValue::Dict(get_dict) = fetched else {
+            panic!("expected dict on get")
+        };
+        assert!(get_dict.get("client_id").is_some());
+        assert!(
+            get_dict.get("client_secret").is_none(),
+            "get must not leak client_secret"
+        );
+    }
+
+    #[test]
+    fn register_rejects_invalid_metadata() {
+        let id = next_store_id();
+        DYNREG_STORES.with(|stores| {
+            stores
+                .borrow_mut()
+                .insert(id.clone(), DynregStore::default());
+        });
+        let mut handle = BTreeMap::new();
+        handle.insert("kind".to_string(), string_value(KIND_DYNREG_STORE));
+        handle.insert("id".to_string(), string_value(&id));
+        let m = metadata_with_redirect("http://attacker.example/cb");
+        let err = register_client_value(&handle, &m).unwrap_err();
+        let VmError::Runtime(text) = err else {
+            panic!("expected runtime error")
+        };
+        assert!(text.contains("HARN-OAU-005"));
+    }
+}


### PR DESCRIPTION
Closes #1906 — part of OAuth stdlib epic #1885 (OA-05).

## Summary

- New `std/oauth/dynamic_registration` module: build & serve RFC 7591
  client metadata + RFC 8414 authorization-server metadata, plus an
  in-process RFC 7591 dynamic client registration store with strict
  redirect-URI validation (HTTPS or RFC 8252 §7.3 loopback only; no
  fragments; spec-blessed `grant_types` / `response_types` /
  `token_endpoint_auth_method` enums).
- `register_client` issues fresh 256-bit `client_id` + `client_secret`
  (URL-safe base64). The secret is only returned by the registration
  call; subsequent `get_client` reads omit it and the
  `oauth.dynreg.audit` `client_registered` event carries only a redacted
  shape (`redirect_uri_count`, `grant_types`, `has_client_secret`).
- Rejections share a stable `HARN-OAU-005:` diagnostic prefix.
- `well_known_paths()` + `well_known_response(metadata)` return the
  canonical URL paths + an HTTP envelope (`{status, content_type,
  headers, body}`) for embedders (harn-cloud, future
  `harn serve --oauth-resource ...`) to mount directly.
- `client_id_issued_at` routes through `stdlib::clock` so
  mock-clock-aware tests are deterministic.

## Surface

New stdlib module:

- `std/oauth/dynamic_registration` — `client_metadata`,
  `authorization_server_metadata`, `validate_metadata`,
  `dynamic_registration_store`, `register_client`, `get_client`,
  `list_clients`, `well_known_paths`, `well_known_response`.

New Rust builtins (registered in the parser signature table):

- `__oauth_dynreg_store_handle`, `__oauth_dynreg_register`,
  `__oauth_dynreg_get`, `__oauth_dynreg_list`,
  `__oauth_dynreg_validate_metadata`,
  `__oauth_dynreg_build_client_metadata`,
  `__oauth_dynreg_build_authorization_server_metadata`.

## Deliberate cut

The harn-serve port wiring — a `/.well-known/...` route group and the
`POST /register` handler — is deferred to a follow-up PR. This PR ships
the stdlib + validation surface that both harn-cloud and harn-serve will
share, so the transport layer can drop in without coupling the two crates
in a single change.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p harn-vm oauth_dynreg` (11 unit tests pass)
- [x] `cargo run --bin harn -- test conformance --filter oauth` (15/15 pass,
      including the three new `oauth_dynamic_registration_*` fixtures)
- [x] `make test` (4438 tests pass)
- [x] `make lint-test-patterns`
- [x] `make lint-harn` + `make fmt-harn`
- [x] `make lint-md`
- [x] `make gen-highlight` (no drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)