### PR TITLE
Add tool hook LLM classifier (#1898)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,40 @@ condensed series summaries instead of full per-patch history.
   `conformance/tests/pool_unsettled_state_integration.harn` (now
   asserting `pool_pending=3` end-to-end) and decrements
   `scripts/xfail_threshold.txt` from 2 to 1.
+- **Tool-hook LLM classifier (TH-05, #1898).** Adds the opt-in
+  `llm_classifier` config to `ToolHooks.preset_run_command(...)` so
+  ad-hoc commands that don't match any deterministic rule can be
+  reviewed by a small model. The classifier is given the command +
+  configurable `meta_prompt` and must return a one-line JSON verdict
+  `{kind: "rewrite"|"deny"|"allow", confidence, rewritten?,
+  explanation?}`. Confident `rewrite` / `deny` verdicts dispatch
+  through the existing `tool_hooks_mode_*` callbacks (so audit log and
+  reminder hooks fire exactly as for catalogue-matched rules);
+  sub-threshold and `allow` verdicts audit + pass through to `inner`.
+  Every invocation — including transport errors and cache hits — emits
+  a `tool_hook_classifier_verdict` lifecycle audit entry
+  (`{scope, model, command, normalized_command, kind, confidence,
+  threshold, cache_hit, action, error?}`) so operators can observe
+  classifier decisions in `pipeline_lifecycle_audit_log_take()` and
+  event-log replay. Verdicts are cached in a thread-local map keyed by
+  `<scope>:<sha256(normalized command)>` with optional
+  `cache.ttl_ms` / `cache.ttl_seconds` so repeat commands skip the
+  extra model call entirely. Transport errors (e.g. provider 5xx) are
+  handled via `llm_call_safe` and degrade silently to passthrough
+  rather than throwing. Trust contract: the raw command text + the
+  meta-prompt are sent to the configured model, so callers must redact
+  secrets in the same way they already do for `run_command`. Budget:
+  each classifier call counts against the session's standard LLM cost
+  telemetry (`peek_total_cost`, autonomy budget) — keep the classifier
+  model small (the spec defaults to `claude-haiku-4-5-20251001`). The
+  TH-02 rejection check is replaced by a config validator that throws
+  on empty `model` or out-of-range `threshold` at wrapper-build time.
+  New conformance fixtures: `tool_hooks_llm_classifier_rewrite`,
+  `tool_hooks_llm_classifier_deny`,
+  `tool_hooks_llm_classifier_passthrough` (covers below-threshold,
+  explicit `allow`, and cache replay), and
+  `tool_hooks_llm_classifier_error_recovery`. Part of epic #1884
+  (Preset tool hooks library).
 - **OTel suspend-end / resume-link wiring (S-18, #1867).** Wires the
   `SpanKind::Suspension` and `SpanKind::Resume` spans (added in P-05,
   #1858) into the cooperative `suspend_agent` / `resume_agent` paths.

--- a/conformance/tests/stdlib/tool_hooks_llm_classifier_deny.expected
+++ b/conformance/tests/stdlib/tool_hooks_llm_classifier_deny.expected
@@ -1,0 +1,12 @@
+deny
+tool_hooks/llm_classifier
+error
+rm against /etc is dangerous
+rm -rf /etc/foo
+rm -rf /etc/foo
+true
+2
+tool_hook_classifier_verdict
+deny
+deny
+tool_denied

--- a/conformance/tests/stdlib/tool_hooks_llm_classifier_deny.harn
+++ b/conformance/tests/stdlib/tool_hooks_llm_classifier_deny.harn
@@ -1,0 +1,42 @@
+import { preset_run_command } from "std/tool_hooks"
+
+/**
+ * LLM classifier — confident `deny` verdict above threshold (TH-05 #1898).
+ *
+ * The classifier returns kind=deny with confidence > threshold. The wrapper
+ * dispatches via the deny-with-explanation mode, returns the denial envelope
+ * without ever calling `inner`, and records the verdict + the `tool_denied`
+ * lifecycle audit.
+ */
+pipeline default() {
+  pipeline_lifecycle_audit_log_take()
+  __tool_hooks_classifier_cache_clear()
+  llm_mock_clear()
+  llm_mock(
+    {
+      text: "{\"kind\": \"deny\", \"confidence\": 0.95,"
+        + " \"explanation\": \"rm against /etc is dangerous\"}",
+    },
+  )
+  /* `inner` would record ran; we expect it to stay silent because the
+   * deny mode never invokes the underlying executor. */
+  let inner = { args -> {ok: true, ran: args.command} }
+  let wrapper = preset_run_command(
+    {llm_classifier: {model: "haiku", provider: "mock", threshold: 0.7}, inner: inner},
+  )
+  let result = wrapper({command: "rm -rf /etc/foo"})
+  println(result.action)
+  println(result.catalogue_id)
+  println(result.severity)
+  println(result.explanation)
+  println(result.original_command)
+  println(result.command)
+  /* `result.result` should be absent on deny since `inner` was not run. */
+  println(result?.result == nil)
+  let log = pipeline_lifecycle_audit_log_take()
+  println(len(log))
+  println(log[0].kind)
+  println(log[0].payload.kind)
+  println(log[0].payload.action)
+  println(log[1].kind)
+}

--- a/conformance/tests/stdlib/tool_hooks_llm_classifier_error_recovery.expected
+++ b/conformance/tests/stdlib/tool_hooks_llm_classifier_error_recovery.expected
@@ -1,0 +1,7 @@
+true
+echo hi
+1
+tool_hook_classifier_verdict
+error
+passthrough
+true

--- a/conformance/tests/stdlib/tool_hooks_llm_classifier_error_recovery.harn
+++ b/conformance/tests/stdlib/tool_hooks_llm_classifier_error_recovery.harn
@@ -1,0 +1,31 @@
+import { preset_run_command } from "std/tool_hooks"
+
+/**
+ * LLM classifier — non-JSON response degrades to passthrough (TH-05 #1898).
+ *
+ * Defensive contract: if the classifier returns garbage (non-JSON, missing
+ * required fields, transport error), the wrapper still runs `inner` with the
+ * original command. The verdict audit captures the error so the operator can
+ * spot the failure mode without the dispatcher blowing up.
+ */
+pipeline default() {
+  pipeline_lifecycle_audit_log_take()
+  __tool_hooks_classifier_cache_clear()
+  llm_mock_clear()
+  /* Non-JSON model output — the parser should classify as kind=error
+   * and the wrapper should passthrough rather than throw. */
+  llm_mock({text: "I am a chatty model and I do not return JSON."})
+  let inner = { args -> {ok: true, ran: args.command} }
+  let wrapper = preset_run_command(
+    {llm_classifier: {model: "haiku", provider: "mock", threshold: 0.5}, inner: inner},
+  )
+  let r = wrapper({command: "echo hi"})
+  println(r.ok)
+  println(r.ran)
+  let log = pipeline_lifecycle_audit_log_take()
+  println(len(log))
+  println(log[0].kind)
+  println(log[0].payload.kind)
+  println(log[0].payload.action)
+  println(contains(to_string(log[0].payload.error), "non-JSON"))
+}

--- a/conformance/tests/stdlib/tool_hooks_llm_classifier_passthrough.expected
+++ b/conformance/tests/stdlib/tool_hooks_llm_classifier_passthrough.expected
@@ -1,0 +1,14 @@
+true
+echo hello
+true
+ls -la
+true
+echo hello
+0
+3
+passthrough
+false
+passthrough
+false
+passthrough
+true

--- a/conformance/tests/stdlib/tool_hooks_llm_classifier_passthrough.harn
+++ b/conformance/tests/stdlib/tool_hooks_llm_classifier_passthrough.harn
@@ -1,0 +1,61 @@
+import { preset_run_command } from "std/tool_hooks"
+
+/**
+ * LLM classifier — sub-threshold verdict and cache replay (TH-05 #1898).
+ *
+ * Three scenarios in one fixture:
+ *   1. Confidence below threshold → audit + passthrough to `inner`.
+ *   2. Explicit `allow` verdict → audit + passthrough.
+ *   3. Cache hit replays the prior verdict without re-querying the model.
+ */
+pipeline default() {
+  pipeline_lifecycle_audit_log_take()
+  __tool_hooks_classifier_cache_clear()
+  llm_mock_clear()
+  /* Scenario 1: below-threshold rewrite. The classifier says rewrite but
+   * confidence (0.4) < threshold (0.8) so the wrapper falls through to
+   * `inner` with the original command. */
+  llm_mock(
+    {
+      text: "{\"kind\": \"rewrite\", \"confidence\": 0.4,"
+        + " \"rewritten\": \"never-applied\", \"explanation\": \"low confidence\"}",
+    },
+  )
+  let inner = { args -> {ok: true, ran: args.command} }
+  let wrapper = preset_run_command(
+    {
+      llm_classifier: {model: "haiku", provider: "mock", threshold: 0.8, cache: {ttl_ms: 60000}},
+      inner: inner,
+    },
+  )
+  let r1 = wrapper({command: "echo hello"})
+  println(r1.ok)
+  println(r1.ran)
+  /* Scenario 2: explicit allow verdict — auditing the fact that the
+   * classifier ran and said allow, but no command rewrite. */
+  llm_mock({text: "{\"kind\": \"allow\", \"confidence\": 0.99, \"explanation\": \"safe\"}"})
+  let r2 = wrapper({command: "ls -la"})
+  println(r2.ok)
+  println(r2.ran)
+  /* Scenario 3: cache hit. Repeat scenario 1's command — the classifier
+   * cache should return the prior low-confidence verdict without
+   * invoking the model again. Compare llm_mock_calls() before vs after. */
+  let calls_before = len(llm_mock_calls())
+  let r3 = wrapper({command: "echo hello"})
+  println(r3.ok)
+  println(r3.ran)
+  let calls_after = len(llm_mock_calls())
+  /* The mock recorder counts every invocation, so the delta must be
+   * zero on a cache hit. */
+  println(calls_after - calls_before)
+  /* Each invocation (cache hit or miss) still audits a classifier
+   * verdict — that's the "audited even on passthrough" contract. */
+  let log = pipeline_lifecycle_audit_log_take()
+  println(len(log))
+  println(log[0].payload.action)
+  println(log[0].payload.cache_hit)
+  println(log[1].payload.action)
+  println(log[1].payload.cache_hit)
+  println(log[2].payload.action)
+  println(log[2].payload.cache_hit)
+}

--- a/conformance/tests/stdlib/tool_hooks_llm_classifier_rewrite.expected
+++ b/conformance/tests/stdlib/tool_hooks_llm_classifier_rewrite.expected
@@ -1,0 +1,17 @@
+rewrite
+tool_hooks_classifier:haiku:0.8
+tool_hooks/llm_classifier
+warning
+prefer auto-fix
+npm run lint
+npm run lint -- --fix
+true
+npm run lint -- --fix
+1
+true
+3
+tool_hook_classifier_verdict
+rewrite
+rewrite
+tool_rewrite
+tool_hooks.reminder_injected

--- a/conformance/tests/stdlib/tool_hooks_llm_classifier_rewrite.harn
+++ b/conformance/tests/stdlib/tool_hooks_llm_classifier_rewrite.harn
@@ -1,0 +1,52 @@
+import { preset_run_command } from "std/tool_hooks"
+
+/**
+ * LLM classifier — confident `rewrite` verdict above threshold (TH-05 #1898).
+ *
+ * The classifier returns a structured JSON verdict with kind=rewrite and a
+ * confidence > threshold. The wrapper dispatches via the rewrite-with-audit
+ * mode so the rewritten command flows to `inner`, the envelope carries the
+ * synthetic catalogue id, and a `tool_hook_classifier_verdict` lifecycle
+ * audit entry records the verdict + scope.
+ */
+pipeline default() {
+  pipeline_lifecycle_audit_log_take()
+  __tool_hooks_classifier_cache_clear()
+  llm_mock_clear()
+  llm_mock(
+    {
+      text: "{\"kind\": \"rewrite\", \"confidence\": 0.92,"
+        + " \"rewritten\": \"npm run lint -- --fix\","
+        + " \"explanation\": \"prefer auto-fix\"}",
+    },
+  )
+  let inner = { args -> {ok: true, ran: args.command} }
+  let wrapper = preset_run_command(
+    {llm_classifier: {model: "haiku", provider: "mock", threshold: 0.8}, inner: inner},
+  )
+  let result = wrapper({command: "npm run lint"})
+  println(result.action)
+  println(result.rule_id)
+  println(result.catalogue_id)
+  println(result.severity)
+  println(result.explanation)
+  println(result.original_command)
+  println(result.command)
+  println(result.result.ok)
+  println(result.result.ran)
+  /* meta_prompt must have been forwarded to the LLM call as the
+   * `system` channel — verify via the mock recorder. */
+  let calls = llm_mock_calls()
+  println(len(calls))
+  println(contains(to_string(calls[0].system), "shell-command safety reviewer"))
+  /* `tool_hook_classifier_verdict` always fires; the rewrite mode adds
+   * `tool_rewrite` + `tool_hooks.reminder_injected`. Three audit lines
+   * means the classifier verdict + rewrite + reminder all flowed. */
+  let log = pipeline_lifecycle_audit_log_take()
+  println(len(log))
+  println(log[0].kind)
+  println(log[0].payload.kind)
+  println(log[0].payload.action)
+  println(log[1].kind)
+  println(log[2].kind)
+}

--- a/conformance/tests/stdlib/tool_hooks_preset_run_command.expected
+++ b/conformance/tests/stdlib/tool_hooks_preset_run_command.expected
@@ -28,3 +28,6 @@ rg --files
 rg --files
 true
 true
+true
+true
+closure

--- a/conformance/tests/stdlib/tool_hooks_preset_run_command.harn
+++ b/conformance/tests/stdlib/tool_hooks_preset_run_command.harn
@@ -117,11 +117,22 @@ pipeline default() {
   println(stringed.action)
   println(stringed.command)
   println(stringed.result.ran)
-  /* llm_classifier is reserved for TH-05 — non-nil rejects up front so
-   * callers don't silently miss the future hook. */
-  let llm_result = try {
-    preset_run_command({llm_classifier: {model: "local"}})
+  /* llm_classifier (TH-05): construction validates the config shape so
+   * obvious typos surface at wrapper-build time rather than first
+   * dispatch. Empty model, out-of-range threshold, etc. all throw. */
+  let bad_model = try {
+    preset_run_command({llm_classifier: {model: ""}})
   }
-  println(is_err(llm_result))
-  println(contains(to_string(unwrap_err(llm_result)), "llm_classifier"))
+  println(is_err(bad_model))
+  println(contains(to_string(unwrap_err(bad_model)), "llm_classifier.model"))
+  let bad_threshold = try {
+    preset_run_command({llm_classifier: {model: "haiku", threshold: 1.5}})
+  }
+  println(is_err(bad_threshold))
+  println(contains(to_string(unwrap_err(bad_threshold)), "threshold"))
+  /* Valid classifier config: constructor accepts and returns a closure. */
+  let cls_wrapper = preset_run_command(
+    {llm_classifier: {model: "haiku", provider: "mock", threshold: 0.5}, inner: inner},
+  )
+  println(type_of(cls_wrapper))
 }

--- a/crates/harn-parser/src/builtin_signatures/signatures/integrations.rs
+++ b/crates/harn-parser/src/builtin_signatures/signatures/integrations.rs
@@ -743,6 +743,25 @@ pub(crate) const SIGNATURES: &[BuiltinSignature] = &[
         &[Param::new("name", TY_STRING), Param::new("result", TY_ANY)],
         TY_STRING,
     ),
+    BuiltinSignature::simple("__tool_hooks_classifier_cache_clear", &[], TY_NIL),
+    BuiltinSignature::simple(
+        "__tool_hooks_classifier_cache_get",
+        &[
+            Param::new("key", TY_STRING),
+            Param::optional("now_ms", TY_INT),
+        ],
+        TY_ANY,
+    ),
+    BuiltinSignature::simple(
+        "__tool_hooks_classifier_cache_put",
+        &[
+            Param::new("key", TY_STRING),
+            Param::new("value", TY_ANY),
+            Param::optional("now_ms", TY_INT),
+            Param::optional("ttl_ms", TY_INT),
+        ],
+        TY_NIL,
+    ),
     BuiltinSignature::simple(
         "tool_hooks_emit_audit",
         &[

--- a/crates/harn-stdlib/src/stdlib/stdlib_tool_hooks.harn
+++ b/crates/harn-stdlib/src/stdlib/stdlib_tool_hooks.harn
@@ -233,6 +233,278 @@ fn __preset_no_match(args, inner) {
   return inner(args)
 }
 
+// -------------------------------------------------------------------------------------------------
+
+// TH-05 (#1898): optional LLM classifier for ad-hoc commands that don't
+// match any deterministic rule. Calls a small model with a meta-prompt,
+// parses a JSON verdict, and dispatches to the configured mode when the
+// confidence clears the threshold. Sub-threshold verdicts fall through to
+// `inner` (audited so observers can see "we asked, low confidence"). The
+// classifier is strictly opt-in — when `config.llm_classifier == nil` the
+// wrapper preserves TH-02 passthrough semantics byte-for-byte.
+
+// -------------------------------------------------------------------------------------------------
+
+fn __classifier_default_meta_prompt() -> string {
+  return "You are a shell-command safety reviewer. Given a single command and an optional"
+    + " context, decide whether it should be:\n"
+    + "  * `rewrite` — change to a safer or more idiomatic form,\n"
+    + "  * `deny` — refuse outright (irreversible or destructive),\n"
+    + "  * `allow` — pass through unchanged.\n"
+    + "Respond ONLY with a JSON object on a single line, no markdown fences, shaped:\n"
+    + "  {\"kind\": \"rewrite\" | \"deny\" | \"allow\","
+    + " \"confidence\": <0..1 float>,"
+    + " \"rewritten\": <string, only for rewrite>,"
+    + " \"explanation\": <string>,"
+    + " \"references\": [<optional doc links>]}\n"
+    + "Be conservative: when unsure, return `allow` with low confidence."
+}
+
+fn __classifier_validate_config(cfg) {
+  if type_of(cfg) != "dict" {
+    throw "preset_run_command: llm_classifier must be a dict"
+  }
+  let model = cfg?.model ?? ""
+  if type_of(model) != "string" || len(model) == 0 {
+    throw "preset_run_command: llm_classifier.model must be a non-empty string"
+  }
+  let threshold = cfg?.threshold ?? 0.8
+  let threshold_kind = type_of(threshold)
+  if threshold_kind != "float" && threshold_kind != "int" {
+    throw "preset_run_command: llm_classifier.threshold must be a number"
+  }
+  let threshold_f = to_float(threshold)
+  if threshold_f < 0.0 || threshold_f > 1.0 {
+    throw "preset_run_command: llm_classifier.threshold must be between 0 and 1"
+  }
+  let meta_prompt = cfg?.meta_prompt ?? __classifier_default_meta_prompt()
+  if type_of(meta_prompt) != "string" {
+    throw "preset_run_command: llm_classifier.meta_prompt must be a string"
+  }
+  let provider = cfg?.provider ?? nil
+  if provider != nil && type_of(provider) != "string" {
+    throw "preset_run_command: llm_classifier.provider must be a string"
+  }
+  let cache = cfg?.cache ?? nil
+  let cache_ttl_ms = if cache == nil {
+    0
+  } else {
+    if type_of(cache) != "dict" {
+      throw "preset_run_command: llm_classifier.cache must be a dict"
+    }
+    let ttl_ms = cache?.ttl_ms ?? 0
+    let ttl_seconds = cache?.ttl_seconds ?? 0
+    if type_of(ttl_ms) != "int" {
+      throw "preset_run_command: llm_classifier.cache.ttl_ms must be an int"
+    }
+    if type_of(ttl_seconds) != "int" {
+      throw "preset_run_command: llm_classifier.cache.ttl_seconds must be an int"
+    }
+    if ttl_ms > 0 {
+      ttl_ms
+    } else {
+      ttl_seconds * 1000
+    }
+  }
+  /* Stable per-config scope so independent wrappers don't share verdict
+   * cache. Caller-supplied `id` wins; otherwise we synthesize a key
+   * from (model, threshold) which keeps tests deterministic. */
+  let scope = if cfg?.id != nil {
+    to_string(cfg.id)
+  } else {
+    "tool_hooks_classifier:" + to_string(model) + ":" + to_string(threshold_f)
+  }
+  return {
+    model: model,
+    provider: provider,
+    threshold: threshold_f,
+    meta_prompt: meta_prompt,
+    cache_ttl_ms: cache_ttl_ms,
+    scope: scope,
+    llm_options: cfg?.llm_options ?? {},
+  }
+}
+
+/* Accept either ttl_ms (preferred for tests / determinism) or
+     * ttl_seconds (more readable for prod configs). The legacy spec
+     * mentions strings like "24h" — leave that as a follow-up so we
+     * don't smuggle a duration parser into stdlib here. */
+/* Forward `llm_options` verbatim so callers can pin temperature,
+     * seed, retries, etc. without us re-marshalling each knob. */
+fn __classifier_normalize_command(command) -> string {
+  /* Collapse all whitespace runs so trivial reformatting doesn't bust the
+   * cache (e.g. `cargo  build` vs `cargo build`). Trimmed for the same
+   * reason. */
+  return trim(regex_replace("\\s+", to_string(command), " "))
+}
+
+fn __classifier_cache_key(scope, command) -> string {
+  return to_string(scope) + ":" + sha256(__classifier_normalize_command(command))
+}
+
+fn __classifier_build_options(classifier_cfg) {
+  /* Merge order: caller `llm_options` first so they can override our
+   * defaults; then pin `model` (and `provider` when supplied) so the
+   * classifier never silently falls back to the default agent model. */
+  let merged = classifier_cfg.llm_options + {model: classifier_cfg.model}
+  if classifier_cfg.provider != nil {
+    return merged + {provider: classifier_cfg.provider}
+  }
+  return merged
+}
+
+fn __classifier_extract_text(envelope) -> string {
+  /* `llm_call_safe` returns `{ok, response, error}` where `response`
+   * holds the full `llm_call` result dict (`{text, data?, ...}`). We
+   * accept the text channel as the canonical verdict transport so the
+   * classifier works against providers that don't offer structured
+   * output. */
+  if envelope?.ok {
+    return to_string(envelope?.response?.text ?? "")
+  }
+  return ""
+}
+
+fn __classifier_parse_verdict(text) {
+  let trimmed = trim(to_string(text))
+  if len(trimmed) == 0 {
+    return {kind: "error", error: "empty classifier response"}
+  }
+  let parsed = try {
+    json_parse(trimmed)
+  }
+  if is_err(parsed) {
+    return {kind: "error", error: "non-JSON classifier response: " + to_string(unwrap_err(parsed))}
+  }
+  let value = unwrap(parsed)
+  if type_of(value) != "dict" {
+    return {kind: "error", error: "classifier response is not a dict"}
+  }
+  let kind = to_string(value?.kind ?? "")
+  if kind != "rewrite" && kind != "deny" && kind != "allow" {
+    return {kind: "error", error: "classifier kind must be rewrite|deny|allow"}
+  }
+  let confidence_raw = value?.confidence ?? 0.0
+  let confidence_kind = type_of(confidence_raw)
+  let confidence = if confidence_kind == "float" || confidence_kind == "int" {
+    to_float(confidence_raw)
+  } else {
+    0.0
+  }
+  return {
+    kind: kind,
+    confidence: confidence,
+    rewritten: to_string(value?.rewritten ?? ""),
+    explanation: to_string(value?.explanation ?? ""),
+    references: value?.references ?? [],
+  }
+}
+
+fn __classifier_synth_rule(verdict, classifier_cfg, original_command) {
+  /* Wrap the verdict in the same shape `tool_hooks_match` returns so the
+   * configured `mode` callback can handle it uniformly. The synthetic
+   * rule's `rewrite` is a constant closure returning the model's
+   * proposal — the default rewrite-with-audit mode forwards that text
+   * to `inner`. */
+  let rewritten = if verdict.kind == "rewrite" && len(verdict.rewritten) > 0 {
+    verdict.rewritten
+  } else {
+    original_command
+  }
+  let severity = if verdict.kind == "deny" {
+    "error"
+  } else {
+    "warning"
+  }
+  return {
+    rule_id: classifier_cfg.scope,
+    catalogue_id: "tool_hooks/llm_classifier",
+    severity: severity,
+    explanation: verdict.explanation,
+    references: verdict.references,
+    rewrite: { _cmd, _ctx -> rewritten },
+  }
+}
+
+fn __classifier_audit_payload(classifier_cfg, command, verdict, cache_hit, action) {
+  return {
+    scope: classifier_cfg.scope,
+    model: classifier_cfg.model,
+    command: command,
+    normalized_command: __classifier_normalize_command(command),
+    kind: verdict?.kind ?? "error",
+    confidence: verdict?.confidence ?? 0.0,
+    threshold: classifier_cfg.threshold,
+    rewritten: verdict?.rewritten ?? "",
+    explanation: verdict?.explanation ?? "",
+    error: verdict?.error ?? "",
+    cache_hit: cache_hit,
+    action: action,
+  }
+}
+
+fn __classifier_run(classifier_cfg, args, inner) {
+  let original_command = __preset_command_text(args)
+  let cache_key = __classifier_cache_key(classifier_cfg.scope, original_command)
+  let now = now_ms()
+  let cached = if classifier_cfg.cache_ttl_ms > 0 {
+    __tool_hooks_classifier_cache_get(cache_key, now)
+  } else {
+    nil
+  }
+  let verdict = if cached != nil {
+    cached
+  } else {
+    let envelope = llm_call_safe(
+      original_command,
+      classifier_cfg.meta_prompt,
+      __classifier_build_options(classifier_cfg),
+    )
+    let text = __classifier_extract_text(envelope)
+    let parsed = __classifier_parse_verdict(text)
+    if parsed.kind != "error" && classifier_cfg.cache_ttl_ms > 0 {
+      __tool_hooks_classifier_cache_put(cache_key, parsed, now, classifier_cfg.cache_ttl_ms)
+    }
+    parsed
+  }
+  let cache_hit = cached != nil
+  /* Error verdicts always audit + passthrough — privacy escape hatch:
+   * the audit payload echoes the command but the classifier never
+   * blocks the caller's dispatch on its own faults. */
+  if verdict.kind == "error" {
+    tool_hooks_emit_audit(
+      "tool_hook_classifier_verdict",
+      __classifier_audit_payload(classifier_cfg, original_command, verdict, cache_hit, "passthrough"),
+    )
+    return __preset_no_match(args, inner)
+  }
+  /* Below-threshold or `allow` verdicts → passthrough, audited so the
+   * observer can verify "we asked, model wasn't sure / said allow". */
+  if verdict.kind == "allow" || verdict.confidence < classifier_cfg.threshold {
+    tool_hooks_emit_audit(
+      "tool_hook_classifier_verdict",
+      __classifier_audit_payload(classifier_cfg, original_command, verdict, cache_hit, "passthrough"),
+    )
+    return __preset_no_match(args, inner)
+  }
+  /* Confident verdict: dispatch via the configured mode. We use
+   * `tool_hooks_mode_rewrite_with_audit` for `rewrite` and
+   * `tool_hooks_mode_deny_with_explanation` for `deny` regardless of
+   * the wrapper's primary `mode` — the classifier verdict expresses
+   * the desired action explicitly. */
+  let synth_rule = __classifier_synth_rule(verdict, classifier_cfg, original_command)
+  tool_hooks_emit_audit(
+    "tool_hook_classifier_verdict",
+    __classifier_audit_payload(classifier_cfg, original_command, verdict, cache_hit, verdict.kind),
+  )
+  if verdict.kind == "deny" {
+    return tool_hooks_mode_deny_with_explanation(synth_rule, args, inner)
+  }
+  return tool_hooks_mode_rewrite_with_audit(synth_rule, args, inner)
+}
+
+/* `llm_call_safe` keeps the wrapper resilient: on transport errors
+     * we audit + passthrough rather than blowing up the dispatch loop. */
 fn __preset_custom_registry(custom_rules) {
   // Build a synthetic catalogue when the caller supplied custom rules.
   // The catalogue is stack-agnostic (no `stack` field) so it survives
@@ -267,13 +539,32 @@ fn __preset_custom_registry(custom_rules) {
  *     passthrough (or, for rewrite/audit modes, with the final
  *     command). Optional — when omitted the wrapper returns decision
  *     envelopes so the caller can run the executor itself.
- *   * `llm_classifier` — TH-05 opt-in. Accepted but currently must be
- *     `nil`; pass a non-nil value and the wrapper rejects construction
- *     so callers don't silently miss the future hook.
+ *   * `llm_classifier` — TH-05 opt-in. Pass a dict shaped
+ *     `{model, threshold?, meta_prompt?, provider?, cache?, llm_options?}`
+ *     to run a small-model classifier against any command that did not
+ *     hit a deterministic rule. The classifier returns
+ *     `{kind: "rewrite"|"deny"|"allow", confidence, rewritten?,
+ *     explanation?}`; verdicts below `threshold` (default 0.8) audit
+ *     and fall through to `inner` so the loop stays usable when the
+ *     model is unsure. Every classifier invocation emits a
+ *     `tool_hook_classifier_verdict` audit (kind, confidence, scope,
+ *     cache hit/miss, action) regardless of outcome, so observers can
+ *     follow which decisions were model-driven. Cache TTL accepts
+ *     either `cache.ttl_ms` (preferred for tests) or
+ *     `cache.ttl_seconds`; omitting both disables caching.
  *
- * @effects: []
+ *     Trust contract: the classifier sends the raw command text + the
+ *     `meta_prompt` to the configured model, so callers must redact
+ *     secrets in the command (the same contract `run_command` already
+ *     has with the underlying shell). Latency cost: one extra
+ *     `llm_call_safe` per cache miss; transport errors degrade
+ *     gracefully to passthrough. Budget: each call counts against the
+ *     session's normal LLM cost telemetry (`peek_total_cost`,
+ *     autonomy budget, etc.) — keep the classifier model small.
+ *
+ * @effects: [llm]
  * @allocation: heap
- * @errors: ["preset_run_command: llm_classifier is not yet supported"]
+ * @errors: ["preset_run_command: llm_classifier.model must be a non-empty string"]
  * @api_stability: experimental
  * @example: agent_loop(message, tools: {tools: [{name: "run_command", handler: preset_run_command({stacks: ["rust"]})}]})
  */
@@ -299,8 +590,10 @@ pub fn preset_run_command(config = nil) {
   }
   let mode = cfg?.mode ?? tool_hooks_mode_rewrite_with_audit
   let inner = cfg?.inner
-  if cfg?.llm_classifier != nil {
-    throw "preset_run_command: llm_classifier is not yet supported (TH-05 / #1898)"
+  let classifier_cfg = if cfg?.llm_classifier == nil {
+    nil
+  } else {
+    __classifier_validate_config(cfg.llm_classifier)
   }
   let filtered_registry = tool_hooks_filter(registry, stacks)
   let has_custom = len(custom_rules) > 0
@@ -322,6 +615,12 @@ pub fn preset_run_command(config = nil) {
     if len(matches) > 0 {
       return mode(matches[0], args, inner)
     }
+    if classifier_cfg != nil {
+      return __classifier_run(classifier_cfg, args, inner)
+    }
     return __preset_no_match(args, inner)
   }
 }
+/* No deterministic rule matched. If the caller opted in to an LLM
+     * classifier, run it now; otherwise fall straight through to the
+     * passthrough/inner path TH-02 shipped. */

--- a/crates/harn-vm/src/stdlib/tool_hooks.rs
+++ b/crates/harn-vm/src/stdlib/tool_hooks.rs
@@ -22,6 +22,13 @@
 //!   one exists, and records a `tool_hooks.reminder_injected` audit
 //!   entry regardless so conformance and replay can verify the
 //!   side-effect even from headless pipelines.
+//! * TH-05 (#1898): `__tool_hooks_classifier_cache_get` /
+//!   `__tool_hooks_classifier_cache_put` thread-local cache helpers
+//!   backing the opt-in LLM classifier in `preset_run_command`. Keyed by
+//!   normalized-command hash + classifier scope id so independent
+//!   wrappers don't share verdicts; entries optionally expire after
+//!   `ttl_seconds` so callers can refresh long-running daemons without
+//!   restarting the process.
 //!
 //! Schema follows the established tagged-dict convention (`_type`) used by
 //! `tool_registry` and `skill_registry`. Values are plain Harn dicts so they
@@ -29,6 +36,7 @@
 //! handling, and the matching engine runs as a single linear sweep over
 //! catalogues × rules (TH-01 acceptance criterion).
 
+use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::rc::Rc;
 
@@ -934,6 +942,121 @@ pub(crate) fn register_tool_hooks_builtins(vm: &mut Vm) {
         );
         Ok(VmValue::Dict(Rc::new(out)))
     });
+
+    // TH-05 (#1898) classifier cache: thread-local map keyed by
+    // `<scope>:<normalized_command>`. Optional TTL expires entries lazily
+    // on read so we don't need a background sweeper. The Harn-side
+    // `preset_run_command` wrapper builds the keys and decides what to
+    // cache; the Rust helpers stay dumb on purpose so callers can swap
+    // hashing / scope strategies without crossing the FFI boundary.
+    vm.register_builtin("__tool_hooks_classifier_cache_get", |args, _out| {
+        let key = match args.first() {
+            Some(VmValue::String(s)) if !s.is_empty() => s.to_string(),
+            _ => {
+                return Err(err(
+                    "__tool_hooks_classifier_cache_get: key must be a non-empty string",
+                ));
+            }
+        };
+        let now_ms = match args.get(1) {
+            Some(VmValue::Int(n)) => *n,
+            Some(VmValue::Nil) | None => 0,
+            Some(other) => {
+                return Err(err(format!(
+                    "__tool_hooks_classifier_cache_get: now_ms must be an int, got {}",
+                    other.type_name()
+                )));
+            }
+        };
+        Ok(classifier_cache_get(&key, now_ms))
+    });
+
+    vm.register_builtin("__tool_hooks_classifier_cache_put", |args, _out| {
+        let key = match args.first() {
+            Some(VmValue::String(s)) if !s.is_empty() => s.to_string(),
+            _ => {
+                return Err(err(
+                    "__tool_hooks_classifier_cache_put: key must be a non-empty string",
+                ));
+            }
+        };
+        let value = args.get(1).cloned().unwrap_or(VmValue::Nil);
+        let now_ms = match args.get(2) {
+            Some(VmValue::Int(n)) => *n,
+            Some(VmValue::Nil) | None => 0,
+            Some(other) => {
+                return Err(err(format!(
+                    "__tool_hooks_classifier_cache_put: now_ms must be an int, got {}",
+                    other.type_name()
+                )));
+            }
+        };
+        let ttl_ms = match args.get(3) {
+            Some(VmValue::Int(n)) if *n > 0 => Some(*n),
+            Some(VmValue::Nil) | None => None,
+            Some(VmValue::Int(_)) => None,
+            Some(other) => {
+                return Err(err(format!(
+                    "__tool_hooks_classifier_cache_put: ttl_ms must be an int or nil, got {}",
+                    other.type_name()
+                )));
+            }
+        };
+        classifier_cache_put(key, value, now_ms, ttl_ms);
+        Ok(VmValue::Nil)
+    });
+
+    vm.register_builtin("__tool_hooks_classifier_cache_clear", |_args, _out| {
+        classifier_cache_clear();
+        Ok(VmValue::Nil)
+    });
+}
+
+#[derive(Clone)]
+struct ClassifierCacheEntry {
+    value: VmValue,
+    /// Wall-clock ms at which the entry expires. `None` means no TTL.
+    expires_at_ms: Option<i64>,
+}
+
+thread_local! {
+    static CLASSIFIER_CACHE: RefCell<BTreeMap<String, ClassifierCacheEntry>> =
+        const { RefCell::new(BTreeMap::new()) };
+}
+
+fn classifier_cache_get(key: &str, now_ms: i64) -> VmValue {
+    CLASSIFIER_CACHE.with(|cell| {
+        let mut cache = cell.borrow_mut();
+        let expired = matches!(
+            cache.get(key),
+            Some(entry) if entry.expires_at_ms.is_some_and(|exp| now_ms >= exp)
+        );
+        if expired {
+            cache.remove(key);
+            return VmValue::Nil;
+        }
+        cache
+            .get(key)
+            .map(|entry| entry.value.clone())
+            .unwrap_or(VmValue::Nil)
+    })
+}
+
+fn classifier_cache_put(key: String, value: VmValue, now_ms: i64, ttl_ms: Option<i64>) {
+    let expires_at_ms = ttl_ms.map(|t| now_ms.saturating_add(t));
+    CLASSIFIER_CACHE.with(|cell| {
+        cell.borrow_mut().insert(
+            key,
+            ClassifierCacheEntry {
+                value,
+                expires_at_ms,
+            },
+        );
+    });
+}
+
+fn classifier_cache_clear() {
+    CLASSIFIER_CACHE.with(|cell| cell.borrow_mut().clear());
 }
 
 #[cfg(test)]
@@ -1332,5 +1455,94 @@ mod tests {
             panic!("expected thrown error, got {result:?}");
         };
         assert!(message.contains("body"));
+    }
+
+    // TH-05: classifier cache helpers.
+
+    fn verdict_value(kind: &str) -> VmValue {
+        let mut dict: BTreeMap<String, VmValue> = BTreeMap::new();
+        dict.insert("kind".to_string(), VmValue::String(Rc::from(kind)));
+        dict.insert("confidence".to_string(), VmValue::Float(0.9));
+        VmValue::Dict(Rc::new(dict))
+    }
+
+    #[test]
+    fn classifier_cache_roundtrips_value() {
+        let vm = vm_with_stdlib();
+        // Clean slate so prior tests don't bleed in via the thread-local map.
+        call_sync(&vm, "__tool_hooks_classifier_cache_clear", &[]).expect("clear");
+        let put = call_sync(
+            &vm,
+            "__tool_hooks_classifier_cache_put",
+            &[
+                VmValue::String(Rc::from("scope:hashA")),
+                verdict_value("rewrite"),
+                VmValue::Int(0),
+                VmValue::Nil,
+            ],
+        )
+        .expect("put");
+        assert!(matches!(put, VmValue::Nil));
+        let got = call_sync(
+            &vm,
+            "__tool_hooks_classifier_cache_get",
+            &[VmValue::String(Rc::from("scope:hashA")), VmValue::Int(0)],
+        )
+        .expect("get");
+        let dict = got.as_dict().expect("verdict dict");
+        assert_eq!(dict_string(dict, "kind"), "rewrite");
+    }
+
+    #[test]
+    fn classifier_cache_expires_entries_after_ttl() {
+        let vm = vm_with_stdlib();
+        call_sync(&vm, "__tool_hooks_classifier_cache_clear", &[]).expect("clear");
+        call_sync(
+            &vm,
+            "__tool_hooks_classifier_cache_put",
+            &[
+                VmValue::String(Rc::from("scope:expiring")),
+                verdict_value("deny"),
+                VmValue::Int(1_000),
+                VmValue::Int(500), // 500ms TTL → expires at 1_500.
+            ],
+        )
+        .expect("put");
+        // Within window → returns the verdict.
+        let fresh = call_sync(
+            &vm,
+            "__tool_hooks_classifier_cache_get",
+            &[
+                VmValue::String(Rc::from("scope:expiring")),
+                VmValue::Int(1_200),
+            ],
+        )
+        .expect("get fresh");
+        assert!(matches!(fresh, VmValue::Dict(_)));
+        // At/after expiry → nil (and the entry is evicted on read).
+        let expired = call_sync(
+            &vm,
+            "__tool_hooks_classifier_cache_get",
+            &[
+                VmValue::String(Rc::from("scope:expiring")),
+                VmValue::Int(1_600),
+            ],
+        )
+        .expect("get expired");
+        assert!(matches!(expired, VmValue::Nil));
+    }
+
+    #[test]
+    fn classifier_cache_rejects_empty_key() {
+        let vm = vm_with_stdlib();
+        let result = call_sync(
+            &vm,
+            "__tool_hooks_classifier_cache_get",
+            &[VmValue::String(Rc::from("")), VmValue::Int(0)],
+        );
+        let Err(VmError::Thrown(VmValue::String(message))) = result else {
+            panic!("expected thrown error, got {result:?}");
+        };
+        assert!(message.contains("non-empty"));
     }
 }


### PR DESCRIPTION
## Summary

- Adds an opt-in `llm_classifier` config to `ToolHooks.preset_run_command(...)` so ad-hoc commands that miss every deterministic rule get a small-model permissions/rewrite review (TH-05 of epic #1884). Confident verdicts (>= threshold) dispatch through the existing rewrite / deny mode callbacks; sub-threshold and `allow` verdicts audit + pass through to `inner`.
- Every invocation — cache hit, transport error, or otherwise — emits a `tool_hook_classifier_verdict` lifecycle audit (`{scope, model, command, normalized_command, kind, confidence, threshold, cache_hit, action, error?}`) so operators can observe model-driven decisions in `pipeline_lifecycle_audit_log_take()` and event-log replay.
- Verdicts are cached in a thread-local map keyed by `<scope>:<sha256(normalized command)>` with optional `cache.ttl_ms` / `cache.ttl_seconds`. Transport errors are routed through `llm_call_safe` so a flaky classifier provider degrades to passthrough rather than blowing up the dispatch loop.

## Design notes

- **No new public Rust builtins.** The classifier is implemented in `stdlib_tool_hooks.harn` on top of existing `llm_call_safe` + `json_parse` + `sha256` builtins. Only three private helpers crossed the FFI boundary (`__tool_hooks_classifier_cache_{get,put,clear}`) for the thread-local cache map.
- **Trust contract documented in the doc-comment + CHANGELOG.** The raw command text + meta-prompt are sent to the configured model — callers must redact secrets the same way they already do for `run_command`. Budget: each classifier call counts against the session's standard LLM cost telemetry (`peek_total_cost`, autonomy budget).
- **Default meta-prompt** asks for a one-line JSON verdict and biases toward conservative `allow` with low confidence when unsure, so a flaky model defaults to "do nothing different" rather than "deny the command."
- TH-02's "rejects construction" check is replaced by a config validator that throws on empty `model` or out-of-range `threshold` at wrapper-build time — typos still surface early.

## Test plan

- [x] `cargo run --bin harn -- test conformance --filter tool_hooks` — 16/16 pass (12 existing + 4 new classifier fixtures).
- [x] `cargo test -p harn-vm --lib stdlib::tool_hooks` — 16/16 pass (3 new cache-helper tests).
- [x] `make test` — 4442 tests run, 4442 passed.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `make fmt-harn`, `make lint-harn`, `make lint-test-patterns`, `make check-docs-snippets`, `make gen-highlight` — all clean.
- New conformance coverage: `tool_hooks_llm_classifier_{rewrite,deny,passthrough,error_recovery}` exercises confident-rewrite dispatch, confident-deny dispatch, below-threshold + explicit-allow + cache-hit passthrough, and non-JSON model output degradation.

Closes #1898.

🤖 Generated with [Claude Code](https://claude.com/claude-code)