### PR TITLE
Add channel replay determinism (#1878)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,52 @@ condensed series summaries instead of full per-patch history.
   explicit `allow`, and cache replay), and
   `tool_hooks_llm_classifier_error_recovery`. Part of epic #1884
   (Preset tool hooks library).
+- **Channel replay determinism receipts + diagnostics (#1878).** CH-07 of
+  the channels epic (#1870) closes the audit/replay gap by giving every
+  `emit_channel(...)` and every channel-source trigger match a durable
+  receipt on the new `lifecycle.channel.audit` event-log topic. Adds
+  two receipt types: `ChannelEmitReceipt` carries the resolved name,
+  scope, scope id, the full emit payload, a canonical-JSON SHA-256
+  `payload_hash`, the signed `emitted_at` timestamp (reusing the
+  per-session HMAC salt from CH-01 / #1872), the active emit span id,
+  and the pipeline/session/tenant correlation fields; and
+  `ChannelMatchReceipt` carries the same `event_id` (so the cached
+  match keys off the emit's id rather than re-evaluating the filter
+  spec on replay), the recorded `trigger_id` + `binding_key` +
+  `handler_kind`, a `handler_result` summary recorded after the
+  dispatcher returns (`status` / `attempt_count` / `error` /
+  `dispatch_failed`), the signed `matched_at` timestamp bound to the
+  `(event_id, trigger_id)` pair, and a `batch.constituent_event_ids`
+  list for aggregation/batched triggers (CH-04 / #1875) so replay
+  reconstructs the batch from those ids. Each audit append rides the
+  active event log (`active_event_log()`) so receipts inherit the
+  pipeline's durability — in-memory in tests, durable in production.
+  The match dispatch path also resolves `event_id` from the trigger
+  event's `dedupe_key` (which carries the channel's emit id) rather
+  than the freshly-minted `trigger_evt_*` UUID, so the receipt chain
+  links emit -> match by stable id. In parallel, extends the
+  replay-oracle (`crates/harn-vm/src/orchestration/replay_oracle.rs`)
+  with a first-class `channel_receipts` section on `ReplayTraceRun`
+  (and matching `ReplayTraceRunCounts` + `replay_bench.rs` runtime-cost
+  metrics + section list) so multi-agent channel exchanges round-trip
+  byte-identically across two runs of the same workload; and adds the
+  typed `ChannelReplayDiagnostic` enum surfaced via
+  `diagnose_channel_replay_drift(...)` with three codes:
+  `HARN-REP-CHN-001` (replay matched an `event_id` with no recorded
+  emit), `HARN-REP-CHN-002` (replay emit `payload_hash` drifted from
+  the recorded hash — producer code drift), and `HARN-REP-CHN-003`
+  (batched-match `constituent_event_ids` composition drifted between
+  runs). Three new conformance fixtures under
+  `conformance/tests/triggers/trigger_channel_replay_*` cover the
+  emit-receipt shape + signed timestamp, the emit -> match
+  `event_id` linkage with `handler_result.status="succeeded"`, and the
+  payload-hash stability/drift contract (identical payloads produce
+  identical hashes; flipped fields produce different hashes; dict key
+  ordering is canonicalized so iteration order can't poison the
+  oracle). Five new unit tests under `replay_oracle::tests` cover the
+  diagnostic codes end-to-end. Unblocks CH-08 conformance and the
+  end-to-end multi-agent replay / audit / compliance use cases the
+  epic was driving toward.
 - **OTel suspend-end / resume-link wiring (S-18, #1867).** Wires the
   `SpanKind::Suspension` and `SpanKind::Resume` spans (added in P-05,
   #1858) into the cooperative `suspend_agent` / `resume_agent` paths.

--- a/conformance/tests/triggers/trigger_channel_replay_emit_receipt_carries_payload_hash.expected
+++ b/conformance/tests/triggers/trigger_channel_replay_emit_receipt_carries_payload_hash.expected
@@ -1,0 +1,13 @@
+channel_emit_receipt
+harn.channel_emit_receipt.v1
+tenant:default:ch.replay.input
+tenant
+default
+harn
+1
+true
+true
+true
+hmac-sha256
+local-session
+true

--- a/conformance/tests/triggers/trigger_channel_replay_emit_receipt_carries_payload_hash.harn
+++ b/conformance/tests/triggers/trigger_channel_replay_emit_receipt_carries_payload_hash.harn
@@ -1,0 +1,34 @@
+import "std/triggers"
+
+/**
+ * CH-07 (#1878): `emit_channel(...)` persists a durable
+ * `channel_emit_receipt` on the `lifecycle.channel.audit` topic carrying
+ * the full payload, a SHA-256 `payload_hash`, the signed `emitted_at`
+ * timestamp, and the resolved scope correlation fields. The receipt is
+ * the cached emit row replay tooling reads to reproduce the chain
+ * (drift in the producer code surfaces as `HARN-REP-CHN-002`).
+ */
+pipeline default() {
+  let audit = event_log.subscribe({topic: "lifecycle.channel.audit"})
+  let _ = emit_channel("ch.replay.input", {repo: "harn", attempt: 1})
+  let entry = audit.next().value
+  println(entry.kind)
+  println(entry.headers.schema)
+  println(entry.payload.name_resolved)
+  println(entry.payload.scope)
+  println(entry.payload.scope_id)
+  println(entry.payload.payload.repo)
+  println(entry.payload.payload.attempt)
+  println(entry.payload.inserted)
+  // Payload hash is a stable canonical-JSON SHA-256 — both runs of the
+  // same producer code must emit the same hash for the same payload.
+  let hash = entry.payload.payload_hash
+  println(starts_with(hash, "sha256:"))
+  println(len(hash) > 10)
+  // Signed timestamp carries the algorithm + key id used by the
+  // replay-oracle verifier; the actual `at_ms` is wall-clock and
+  // intentionally elided from this fixture.
+  println(entry.payload.emitted_at.algorithm)
+  println(entry.payload.emitted_at.key_id)
+  println(starts_with(entry.payload.emitted_at.signature, "sha256:"))
+}

--- a/conformance/tests/triggers/trigger_channel_replay_match_receipt_links_emit_via_event_id.expected
+++ b/conformance/tests/triggers/trigger_channel_replay_match_receipt_links_emit_via_event_id.expected
@@ -1,0 +1,12 @@
+channel_emit_receipt
+channel_match_receipt
+harn.channel_match_receipt.v1
+true
+tenant:default:ch.replay.match.input
+tenant
+true
+local
+succeeded
+hmac-sha256
+local-session
+true

--- a/conformance/tests/triggers/trigger_channel_replay_match_receipt_links_emit_via_event_id.harn
+++ b/conformance/tests/triggers/trigger_channel_replay_match_receipt_links_emit_via_event_id.harn
@@ -1,0 +1,43 @@
+import "std/triggers"
+
+fn handle_channel(event) {
+  return event.provider_payload.name
+}
+
+pipeline default() {
+  let audit = event_log.subscribe({topic: "lifecycle.channel.audit"})
+  let unique = to_string(to_int(timestamp())) + "-" + to_string(random_int(100000, 999999))
+  let _ = trigger_register(
+    {
+      id: "channel-replay-match-" + unique,
+      kind: "channel.emit",
+      provider: "channel",
+      autonomy_tier: "act_auto",
+      handler: handle_channel,
+      when: nil,
+      retry: nil,
+      match: {events: ["channel:ch.replay.match.input"]},
+      events: nil,
+      dedupe_key: nil,
+      filter: nil,
+      budget: nil,
+      manifest_path: nil,
+      package_name: "conformance",
+    },
+  )
+  let _ = emit_channel("ch.replay.match.input", {repo: "harn"})
+  let emit_entry = audit.next().value
+  let match_entry = audit.next().value
+  println(emit_entry.kind)
+  println(match_entry.kind)
+  println(match_entry.headers.schema)
+  println(emit_entry.payload.event_id == match_entry.payload.event_id)
+  println(match_entry.payload.name_resolved)
+  println(match_entry.payload.scope)
+  println(starts_with(match_entry.payload.trigger_id, "channel-replay-match-"))
+  println(match_entry.payload.handler_kind)
+  println(match_entry.payload.handler_result.status)
+  println(match_entry.payload.matched_at.algorithm)
+  println(match_entry.payload.matched_at.key_id)
+  println(starts_with(match_entry.payload.matched_at.signature, "sha256:"))
+}

--- a/conformance/tests/triggers/trigger_channel_replay_payload_hash_detects_drift.expected
+++ b/conformance/tests/triggers/trigger_channel_replay_payload_hash_detects_drift.expected
@@ -1,0 +1,4 @@
+false
+true
+false
+true

--- a/conformance/tests/triggers/trigger_channel_replay_payload_hash_detects_drift.harn
+++ b/conformance/tests/triggers/trigger_channel_replay_payload_hash_detects_drift.harn
@@ -1,0 +1,39 @@
+import "std/triggers"
+
+/**
+ * CH-07 (#1878): the SHA-256 `payload_hash` stamped on every
+ * `channel_emit_receipt` is the byte-level signal the replay-oracle
+ * uses for the `HARN-REP-CHN-002` diagnostic. Two emits of the same
+ * payload must produce identical hashes (so a clean replay stays
+ * deterministic), and any drift in the producer payload — even a
+ * single field flip — must produce a different hash.
+ */
+pipeline default() {
+  let audit = event_log
+    .subscribe({topic: "lifecycle.channel.audit", kind_prefix: "channel_emit_receipt"})
+  // Two emits with identical payloads — `payload_hash` must match
+  // so the replay oracle sees deterministic producer output.
+  let _ = emit_channel("ch.replay.hash.stable", {repo: "harn", attempt: 1})
+  let _ = emit_channel("ch.replay.hash.stable", {repo: "harn", attempt: 1})
+  let first = audit.next().value
+  let second = audit.next().value
+  // Each `emit_channel` mints a fresh `event_id` so the two emits are
+  // distinct rows in the audit log even when their payloads are
+  // identical. The replay oracle relies on `event_id` to anchor cached
+  // matches, but on `payload_hash` to detect drift.
+  println(first.payload.event_id == second.payload.event_id)
+  println(first.payload.payload_hash == second.payload.payload_hash)
+  // Now flip a single field. Hash must change — proving
+  // `HARN-REP-CHN-002` will trip on real producer drift.
+  let _ = emit_channel("ch.replay.hash.drift", {repo: "harn", attempt: 2})
+  let third = audit.next().value
+  println(third.payload.payload_hash == first.payload.payload_hash)
+  // Hashes are deterministic across key-ordering — `{a, b}` and
+  // `{b, a}` produce the same canonical-JSON hash so dict iteration
+  // order can't poison the oracle.
+  let _ = emit_channel("ch.replay.hash.order", {a: 1, b: 2})
+  let _ = emit_channel("ch.replay.hash.order", {b: 2, a: 1})
+  let key_first = audit.next().value
+  let key_second = audit.next().value
+  println(key_first.payload.payload_hash == key_second.payload.payload_hash)
+}

--- a/crates/harn-vm/src/channels.rs
+++ b/crates/harn-vm/src/channels.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex, OnceLock};
 
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use time::format_description::well_known::Rfc3339;
 
 use crate::event_log::{
@@ -27,6 +28,20 @@ const EMITTED_BY_HEADER: &str = "harn.channel.emitted_by";
 pub(crate) const CHANNEL_TRANSCRIPT_TOPIC: &str = "transcript.channel.lifecycle";
 pub(crate) const CHANNEL_EMIT_TRANSCRIPT_KIND: &str = "transcript.channel.emit";
 pub(crate) const CHANNEL_MATCH_TRANSCRIPT_KIND: &str = "transcript.channel.match";
+
+/// CH-07 (#1878): durable audit topic for the replay-determinism receipts
+/// emitted alongside every channel emit + every channel match. Consumers
+/// drive replay/audit tooling off this topic instead of the lossy
+/// `transcript.channel.lifecycle` summary topic — receipts carry the full
+/// payload, signed timestamps, and cached match linkage so the
+/// `replay_oracle` can byte-compare two runs of the same workload.
+pub const CHANNEL_AUDIT_TOPIC: &str = "lifecycle.channel.audit";
+pub(crate) const CHANNEL_EMIT_RECEIPT_KIND: &str = "channel_emit_receipt";
+pub(crate) const CHANNEL_MATCH_RECEIPT_KIND: &str = "channel_match_receipt";
+/// CH-07 (#1878): receipt schema header so downstream tooling can
+/// version-gate parsers (mirrors `harn.pool_submit.v1` from PL-06 / #1891).
+const CHANNEL_EMIT_RECEIPT_SCHEMA: &str = "harn.channel_emit_receipt.v1";
+const CHANNEL_MATCH_RECEIPT_SCHEMA: &str = "harn.channel_match_receipt.v1";
 
 /// CH-06 (#1877): per-event headers stamped on the `TriggerEvent` so the
 /// channel-match dispatcher can link the `ChannelMatch` span back to the
@@ -104,13 +119,13 @@ struct ResolvedChannel {
     retention: &'static str,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
-struct SignedTimestamp {
-    at_ms: i64,
-    at: String,
-    algorithm: String,
-    key_id: String,
-    signature: String,
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct SignedTimestamp {
+    pub at_ms: i64,
+    pub at: String,
+    pub algorithm: String,
+    pub key_id: String,
+    pub signature: String,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -131,6 +146,110 @@ struct StoredChannelEvent {
     retention: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     ttl_ms: Option<i64>,
+}
+
+/// CH-07 (#1878): durable replay-determinism receipt for a single
+/// `emit_channel(...)` call. Pairs 1:1 with the `ChannelEmit` span (CH-06
+/// / #1877) and with the durable journal append. Persisted to the
+/// `lifecycle.channel.audit` event-log topic so the `replay_oracle` can
+/// reproduce the entire emit chain across two runs of the same workload.
+///
+/// `payload_hash` lets the oracle detect producer-side drift
+/// (`HARN-REP-CHN-002`) without having to canonicalize the full payload
+/// during comparison; `payload` carries the verbatim value for byte
+/// equality + replay reconstruction.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct ChannelEmitReceipt {
+    pub event_id: String,
+    pub name_resolved: String,
+    pub scope: String,
+    pub scope_id: String,
+    pub payload_hash: String,
+    pub payload: serde_json::Value,
+    pub emitted_at: SignedTimestamp,
+    pub emitted_by: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pipeline_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tenant_id: Option<String>,
+    pub topic: String,
+    pub inserted: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub span_id: Option<u64>,
+}
+
+/// CH-07 (#1878): durable replay-determinism receipt for a single channel
+/// match — one per `(binding, event)` pair the dispatcher fires. For
+/// aggregation/batched triggers (CH-04 / #1875) the receipt carries
+/// `batch.constituent_event_ids` so the replay oracle can verify the
+/// full batch composition matches across runs (`HARN-REP-CHN-003`).
+///
+/// `event_id` doubles as the cached-match key: on replay the dispatcher
+/// looks up the recorded match by `event_id` instead of re-evaluating
+/// the filter spec, preserving "the journal IS the spec" determinism.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct ChannelMatchReceipt {
+    pub event_id: String,
+    pub trigger_id: String,
+    pub binding_key: String,
+    pub name_resolved: String,
+    pub scope: String,
+    pub scope_id: String,
+    pub matched_at: SignedTimestamp,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub matched_in_session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub batch: Option<ChannelMatchBatchInfo>,
+    pub handler_kind: String,
+    pub handler_result: ChannelMatchResultSummary,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub span_id: Option<u64>,
+}
+
+/// CH-07 (#1878): batched-dispatch summary stamped onto
+/// `ChannelMatchReceipt`. The `constituent_event_ids` list is the full
+/// recorded composition; replay reconstructs the batch from those ids.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct ChannelMatchBatchInfo {
+    pub count: usize,
+    pub constituent_event_ids: Vec<String>,
+}
+
+/// CH-07 (#1878): summary of the handler invocation outcome. Mirrors the
+/// shape of the dispatcher's `DispatchOutcome` but kept lightweight so
+/// the receipt stays compact and self-contained — replay tooling never
+/// needs to cross-reference the dispatcher log to interpret a match.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+pub struct ChannelMatchResultSummary {
+    pub status: String,
+    pub attempt_count: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dispatch_failed: Option<bool>,
+}
+
+impl ChannelMatchResultSummary {
+    fn from_dispatch(
+        outcome: &Result<crate::triggers::DispatchOutcome, crate::triggers::DispatchError>,
+    ) -> Self {
+        match outcome {
+            Ok(outcome) => Self {
+                status: outcome.status.as_str().to_string(),
+                attempt_count: outcome.attempt_count,
+                error: outcome.error.clone(),
+                dispatch_failed: None,
+            },
+            Err(error) => Self {
+                status: "dispatch_error".to_string(),
+                attempt_count: 0,
+                error: Some(error.to_string()),
+                dispatch_failed: Some(true),
+            },
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -245,6 +364,11 @@ pub(crate) async fn emit_channel_from_vm(args: Vec<VmValue>) -> Result<VmValue, 
     // CH-06 (#1877): emit the transcript event whether the append was fresh
     // or idempotent — both outcomes are first-class observability signals.
     emit_channel_emit_transcript(&record, &resolved, outcome.inserted, emit_span_id);
+    // CH-07 (#1878): persist the durable emit receipt on the
+    // `lifecycle.channel.audit` topic so the replay oracle has the full
+    // emit chain (payload hash, signed timestamp, scope correlation)
+    // independently of the lossy transcript summary topic.
+    record_channel_emit_receipt(&record, &resolved, outcome.inserted, emit_span_id).await;
     // CH-02 (#1872): fan out the emit to channel-source triggers. Only fresh
     // appends fan out; idempotent duplicates short-circuit because the producer
     // already saw the original delivery.
@@ -629,6 +753,217 @@ fn signing_salt() -> &'static [u8] {
             .into_bytes()
         })
         .as_slice()
+}
+
+/// CH-07 (#1878): signed timestamp for a channel match. Mirrors the emit
+/// timestamp algorithm in `signed_timestamp` so the replay oracle can
+/// verify match timestamps with the same `signing_salt()` key material.
+/// Including `event_id` + `trigger_id` in the signing material binds the
+/// timestamp to this specific (emit, binding) pair so a replayed match
+/// can't be re-stamped onto a different binding.
+fn signed_match_timestamp(
+    resolved: &ResolvedChannel,
+    event_id: &str,
+    trigger_id: &str,
+) -> SignedTimestamp {
+    let at = crate::clock_mock::now_utc();
+    let at_ms = (at.unix_timestamp_nanos() / 1_000_000) as i64;
+    let at_text = at.format(&Rfc3339).unwrap_or_else(|_| at.to_string());
+    let material = format!(
+        "harn.channel.match_timestamp.v1\nat_ms={at_ms}\nevent_id={event_id}\ntrigger_id={trigger_id}\nname={}\nscope={}\nscope_id={}\n",
+        resolved.resolved_name,
+        resolved.scope.as_str(),
+        resolved.scope_id
+    );
+    let signature = hex::encode(crate::connectors::hmac::hmac_sha256(
+        signing_salt(),
+        material.as_bytes(),
+    ));
+    SignedTimestamp {
+        at_ms,
+        at: at_text,
+        algorithm: "hmac-sha256".to_string(),
+        key_id: "local-session".to_string(),
+        signature: format!("sha256:{signature}"),
+    }
+}
+
+/// CH-07 (#1878): SHA-256 of the canonical JSON encoding of a channel
+/// emit payload. `serde_json::to_string` sorts object keys
+/// deterministically when the value originates from `serde_json::Value`
+/// (BTreeMap-backed `Map` with `preserve_order` disabled — the default
+/// for this crate). Used by the replay oracle to detect producer-side
+/// drift (`HARN-REP-CHN-002`).
+pub fn channel_payload_hash(payload: &serde_json::Value) -> String {
+    let canonical = canonical_json_string(payload);
+    let digest = Sha256::digest(canonical.as_bytes());
+    format!("sha256:{}", hex::encode(digest))
+}
+
+/// CH-07 (#1878): canonicalize a JSON value to a deterministic string so
+/// the SHA-256 hash on `ChannelEmitReceipt.payload_hash` is stable
+/// across reruns. Recursively sorts object keys; arrays preserve their
+/// (semantically meaningful) order. Mirrors the canonicalization rule
+/// `replay_oracle::canonicalize_run` relies on for cross-run diffs.
+fn canonical_json_string(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::Object(map) => {
+            let mut sorted: std::collections::BTreeMap<&String, &serde_json::Value> =
+                std::collections::BTreeMap::new();
+            for (key, value) in map {
+                sorted.insert(key, value);
+            }
+            let parts: Vec<String> = sorted
+                .iter()
+                .map(|(key, value)| {
+                    format!(
+                        "{}:{}",
+                        serde_json::to_string(key).unwrap_or_else(|_| key.to_string()),
+                        canonical_json_string(value)
+                    )
+                })
+                .collect();
+            format!("{{{}}}", parts.join(","))
+        }
+        serde_json::Value::Array(items) => {
+            let parts: Vec<String> = items.iter().map(canonical_json_string).collect();
+            format!("[{}]", parts.join(","))
+        }
+        other => serde_json::to_string(other).unwrap_or_else(|_| "null".to_string()),
+    }
+}
+
+/// CH-07 (#1878): append a channel audit receipt to the durable
+/// `lifecycle.channel.audit` topic. Mirrors `emit_pool_*_receipt`
+/// (PL-06 / #1891). The audit log uses `active_event_log()` so receipts
+/// inherit the pipeline's durability (in-memory in tests; durable
+/// SQLite/etc. in production). Best-effort: receipt append errors do not
+/// fail the emit/match — the emit's user-visible receipt is the source
+/// of truth for caller behavior. Audit consumers learn about gaps via
+/// the canonical event-log read API.
+async fn append_channel_audit_event(
+    kind: &'static str,
+    schema: &'static str,
+    payload: serde_json::Value,
+) {
+    let topic = match Topic::new(CHANNEL_AUDIT_TOPIC) {
+        Ok(topic) => topic,
+        Err(_) => return,
+    };
+    let log = active_event_log()
+        .unwrap_or_else(|| install_memory_for_current_thread(CHANNEL_QUEUE_DEPTH));
+    let mut headers = BTreeMap::new();
+    headers.insert("schema".to_string(), schema.to_string());
+    let _ = log
+        .append(&topic, LogEvent::new(kind, payload).with_headers(headers))
+        .await;
+}
+
+/// CH-07 (#1878): build + persist the emit receipt on the audit topic.
+/// Called from `emit_channel_from_vm` immediately after the durable
+/// journal append succeeds (whether the append was fresh or
+/// idempotent-suppressed — both outcomes are first-class audit signals).
+async fn record_channel_emit_receipt(
+    record: &StoredChannelEvent,
+    resolved: &ResolvedChannel,
+    inserted: bool,
+    span_id: u64,
+) {
+    let receipt = ChannelEmitReceipt {
+        event_id: record.id.clone(),
+        name_resolved: resolved.resolved_name.clone(),
+        scope: resolved.scope.as_str().to_string(),
+        scope_id: resolved.scope_id.clone(),
+        payload_hash: channel_payload_hash(&record.payload),
+        payload: record.payload.clone(),
+        emitted_at: record.emitted_at.clone(),
+        emitted_by: record.emitted_by.clone(),
+        pipeline_id: record.pipeline_id.clone(),
+        session_id: record.session_id.clone(),
+        tenant_id: record.tenant_id.clone(),
+        topic: resolved.topic.as_str().to_string(),
+        inserted,
+        span_id: if span_id == 0 { None } else { Some(span_id) },
+    };
+    let payload = match serde_json::to_value(&receipt) {
+        Ok(value) => value,
+        Err(_) => return,
+    };
+    append_channel_audit_event(
+        CHANNEL_EMIT_RECEIPT_KIND,
+        CHANNEL_EMIT_RECEIPT_SCHEMA,
+        payload,
+    )
+    .await;
+}
+
+/// CH-07 (#1878): build + persist the match receipt on the audit topic.
+/// Called from `fire_channel_match` after the dispatcher returns, so
+/// `handler_result` reflects the recorded outcome (succeeded / failed /
+/// dlq / cancelled / ...) and replay tooling can verify the same handler
+/// shape fires on every replay.
+#[allow(clippy::too_many_arguments)]
+async fn record_channel_match_receipt(
+    trigger_id: &str,
+    binding_key: &str,
+    handler_kind: &str,
+    resolved: &ResolvedChannel,
+    event_id: &str,
+    matched_in_session_id: Option<&str>,
+    batch: Option<ChannelMatchBatchInfo>,
+    span_id: u64,
+    dispatch_outcome: &Result<crate::triggers::DispatchOutcome, crate::triggers::DispatchError>,
+) {
+    let receipt = ChannelMatchReceipt {
+        event_id: event_id.to_string(),
+        trigger_id: trigger_id.to_string(),
+        binding_key: binding_key.to_string(),
+        name_resolved: resolved.resolved_name.clone(),
+        scope: resolved.scope.as_str().to_string(),
+        scope_id: resolved.scope_id.clone(),
+        matched_at: signed_match_timestamp(resolved, event_id, trigger_id),
+        matched_in_session_id: matched_in_session_id.map(|s| s.to_string()),
+        batch,
+        handler_kind: handler_kind.to_string(),
+        handler_result: ChannelMatchResultSummary::from_dispatch(dispatch_outcome),
+        span_id: if span_id == 0 { None } else { Some(span_id) },
+    };
+    let payload = match serde_json::to_value(&receipt) {
+        Ok(value) => value,
+        Err(_) => return,
+    };
+    append_channel_audit_event(
+        CHANNEL_MATCH_RECEIPT_KIND,
+        CHANNEL_MATCH_RECEIPT_SCHEMA,
+        payload,
+    )
+    .await;
+}
+
+/// CH-07 (#1878): extract `ChannelMatchBatchInfo` from the transcript
+/// `batch_summary` JSON the dispatcher already builds for batched
+/// triggers. Returns `None` for non-batched dispatch.
+fn batch_info_from_summary(
+    batch_summary: Option<&serde_json::Value>,
+) -> Option<ChannelMatchBatchInfo> {
+    let summary = batch_summary?.as_object()?;
+    let count = summary
+        .get("count")
+        .and_then(|v| v.as_u64())
+        .map(|n| n as usize)?;
+    let constituent_event_ids = summary
+        .get("constituent_event_ids")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .collect()
+        })
+        .unwrap_or_default();
+    Some(ChannelMatchBatchInfo {
+        count,
+        constituent_event_ids,
+    })
 }
 
 fn emitted_by(context: &ChannelContext) -> String {
@@ -1348,7 +1683,16 @@ async fn fire_channel_match(
 ) {
     let trigger_id = binding.id.as_str().to_string();
     let handler_kind = binding.handler.kind().to_string();
-    let event_id = event.id.0.clone();
+    // CH-07 (#1878): use the channel emit's id (carried as the trigger
+    // event's `dedupe_key`) so the match receipt links back to the
+    // original `ChannelEmitReceipt.event_id`. `TriggerEvent::new` mints
+    // a fresh `trigger_evt_*` id for its own `event.id` field that does
+    // not correlate to the emit chain.
+    let event_id = if event.dedupe_key.is_empty() {
+        event.id.0.clone()
+    } else {
+        event.dedupe_key.clone()
+    };
     let mut match_span = ChannelSpanGuard::start_detached(
         crate::tracing::SpanKind::ChannelMatch,
         format!("channel.match {}", resolved.resolved_name),
@@ -1373,12 +1717,33 @@ async fn fire_channel_match(
         matched_at_ms,
         matched_in_session_id.as_deref(),
         span_id,
-        batch_summary,
+        batch_summary.clone(),
     );
-    let _ = dispatcher
-        .dispatch(&binding, event)
-        .await
-        .map_err(|error| VmError::Runtime(format!("emit_channel dispatch: {error}")));
+    // CH-07 (#1878): capture the dispatch outcome BEFORE writing the
+    // match receipt so the receipt records the recorded handler result
+    // (succeeded/failed/dlq/...) — replay tooling treats the receipt as
+    // the cached match: on replay the dispatcher looks up the receipt
+    // by `event_id` instead of re-evaluating the filter spec.
+    let dispatch_outcome = dispatcher.dispatch(&binding, event).await;
+    let binding_key = binding.binding_key();
+    let batch_info = batch_info_from_summary(batch_summary.as_ref());
+    record_channel_match_receipt(
+        &trigger_id,
+        &binding_key,
+        &handler_kind,
+        resolved,
+        &event_id,
+        matched_in_session_id.as_deref(),
+        batch_info,
+        span_id,
+        &dispatch_outcome,
+    )
+    .await;
+    // Pre-CH-07 the dispatch error was discarded with `let _ = ...`. The
+    // CH-07 match receipt now records the failure with
+    // `dispatch_failed: true` so audit consumers don't lose the signal —
+    // we keep the same fire-and-forget callsite semantics here.
+    drop(dispatch_outcome);
     match_span.end();
 }
 
@@ -1766,5 +2131,36 @@ mod tests {
         assert!(channel_filter_matches("", &payload));
         // Non-dict filter → permissive (back-compat with legacy `filter:` field).
         assert!(channel_filter_matches("just-a-string", &payload));
+    }
+
+    // CH-07 (#1878): `channel_payload_hash` is the byte signal the
+    // replay-oracle's `HARN-REP-CHN-002` diagnostic compares across
+    // runs. The hash MUST be deterministic across object-key iteration
+    // order (so the test in `replay_oracle` and the conformance fixture
+    // both rely on canonical ordering) and MUST change when the payload
+    // changes.
+    #[test]
+    fn channel_payload_hash_is_deterministic_across_key_order() {
+        let a = serde_json::json!({"a": 1, "b": 2, "nested": {"x": 10, "y": 20}});
+        let b = serde_json::json!({"nested": {"y": 20, "x": 10}, "b": 2, "a": 1});
+        assert_eq!(channel_payload_hash(&a), channel_payload_hash(&b));
+    }
+
+    #[test]
+    fn channel_payload_hash_changes_with_value_drift() {
+        let baseline = serde_json::json!({"repo": "harn", "attempt": 1});
+        let drifted = serde_json::json!({"repo": "harn", "attempt": 2});
+        assert_ne!(
+            channel_payload_hash(&baseline),
+            channel_payload_hash(&drifted)
+        );
+    }
+
+    #[test]
+    fn channel_payload_hash_is_sha256_prefixed_hex() {
+        let value = serde_json::json!({"k": "v"});
+        let hash = channel_payload_hash(&value);
+        assert!(hash.starts_with("sha256:"));
+        assert_eq!(hash.len(), "sha256:".len() + 64);
     }
 }

--- a/crates/harn-vm/src/orchestration/replay_bench.rs
+++ b/crates/harn-vm/src/orchestration/replay_bench.rs
@@ -17,7 +17,7 @@ pub const OPENCODE_JSONL_ADAPTER_ID: &str = "opencode-jsonl";
 pub const OPENCODE_JSONL_ADAPTER_SCHEMA_VERSION: &str =
     "harn.replay_benchmark.adapter.opencode_jsonl.v1";
 
-const REPLAY_TRACE_SECTIONS: [&str; 10] = [
+const REPLAY_TRACE_SECTIONS: [&str; 11] = [
     "event_log_entries",
     "trigger_firings",
     "llm_interactions",
@@ -28,6 +28,8 @@ const REPLAY_TRACE_SECTIONS: [&str; 10] = [
     "agent_transcript_deltas",
     "final_artifacts",
     "policy_decisions",
+    // CH-07 (#1878): channel emit/match audit receipts.
+    "channel_receipts",
 ];
 
 const TOOL_DRIFT_SECTIONS: [&str; 3] = [
@@ -127,6 +129,9 @@ pub struct ReplayRuntimeCostMetrics {
     pub agent_transcript_deltas: usize,
     pub final_artifacts: usize,
     pub policy_decisions: usize,
+    /// CH-07 (#1878): channel emit/match audit receipts.
+    #[serde(default)]
+    pub channel_receipts: usize,
     pub llm_input_tokens: u64,
     pub llm_output_tokens: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -320,6 +325,7 @@ fn summarize_replay_benchmark(fixtures: &[ReplayBenchmarkFixtureReport]) -> Repl
             acc.agent_transcript_deltas += runtime.agent_transcript_deltas;
             acc.final_artifacts += runtime.final_artifacts;
             acc.policy_decisions += runtime.policy_decisions;
+            acc.channel_receipts += runtime.channel_receipts;
             acc.llm_input_tokens += runtime.llm_input_tokens;
             acc.llm_output_tokens += runtime.llm_output_tokens;
             acc.observed_cost_usd =
@@ -440,6 +446,8 @@ fn counts_by_section(counts: &ReplayTraceRunCounts) -> BTreeMap<&'static str, us
         ("agent_transcript_deltas", counts.agent_transcript_deltas),
         ("final_artifacts", counts.final_artifacts),
         ("policy_decisions", counts.policy_decisions),
+        // CH-07 (#1878).
+        ("channel_receipts", counts.channel_receipts),
     ])
 }
 
@@ -514,6 +522,7 @@ fn runtime_cost_metrics(
         agent_transcript_deltas: first.agent_transcript_deltas + second.agent_transcript_deltas,
         final_artifacts: first.final_artifacts + second.final_artifacts,
         policy_decisions: first.policy_decisions + second.policy_decisions,
+        channel_receipts: first.channel_receipts + second.channel_receipts,
         llm_input_tokens: token_total(first_run, "input_tokens")
             + token_total(second_run, "input_tokens"),
         llm_output_tokens: token_total(first_run, "output_tokens")
@@ -533,6 +542,7 @@ fn trace_material_count(counts: &ReplayTraceRunCounts) -> usize {
         + counts.agent_transcript_deltas
         + counts.final_artifacts
         + counts.policy_decisions
+        + counts.channel_receipts
 }
 
 fn token_total(run: &ReplayTraceRun, token_key: &str) -> u64 {

--- a/crates/harn-vm/src/orchestration/replay_oracle.rs
+++ b/crates/harn-vm/src/orchestration/replay_oracle.rs
@@ -64,6 +64,13 @@ pub struct ReplayTraceRun {
     pub agent_transcript_deltas: Vec<JsonValue>,
     pub final_artifacts: Vec<JsonValue>,
     pub policy_decisions: Vec<JsonValue>,
+    /// CH-07 (#1878): durable channel emit/match receipts captured from
+    /// the `lifecycle.channel.audit` topic. First-class replay material
+    /// alongside `effect_receipts` so multi-agent channel exchanges
+    /// round-trip byte-identically across two runs of the same
+    /// workload. Each entry is the JSON-encoded
+    /// `ChannelEmitReceipt` / `ChannelMatchReceipt`.
+    pub channel_receipts: Vec<JsonValue>,
 }
 
 impl ReplayTraceRun {
@@ -79,6 +86,7 @@ impl ReplayTraceRun {
             agent_transcript_deltas: self.agent_transcript_deltas.len(),
             final_artifacts: self.final_artifacts.len(),
             policy_decisions: self.policy_decisions.len(),
+            channel_receipts: self.channel_receipts.len(),
         }
     }
 }
@@ -96,6 +104,8 @@ pub struct ReplayTraceRunCounts {
     pub agent_transcript_deltas: usize,
     pub final_artifacts: usize,
     pub policy_decisions: usize,
+    /// CH-07 (#1878).
+    pub channel_receipts: usize,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
@@ -249,6 +259,7 @@ fn trace_material_count(run: &ReplayTraceRun) -> usize {
         + counts.agent_transcript_deltas
         + counts.final_artifacts
         + counts.policy_decisions
+        + counts.channel_receipts
 }
 
 fn apply_allowlist_rule(
@@ -464,6 +475,254 @@ fn divergence(
     }
 }
 
+/// CH-07 (#1878): typed channel replay diagnostic codes. Surfaced by
+/// `diagnose_channel_replay_drift` so audit/compliance tooling can
+/// distinguish "missing match cache" from "producer drift" from
+/// "batch composition drift" without parsing free-form messages.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "code")]
+pub enum ChannelReplayDiagnostic {
+    /// `HARN-REP-CHN-001`: replay encountered a match for an `event_id`
+    /// that isn't in the recorded emit log. Either the replay generated a
+    /// new emit between baseline and replay, or the baseline lost an
+    /// emit receipt mid-flight.
+    #[serde(rename = "HARN-REP-CHN-001")]
+    MatchWithoutEmit {
+        event_id: String,
+        trigger_id: String,
+    },
+    /// `HARN-REP-CHN-002`: the replay's emit `payload_hash` doesn't
+    /// match the recorded hash for the same `event_id`. Producer code
+    /// drifted between runs.
+    #[serde(rename = "HARN-REP-CHN-002")]
+    PayloadHashMismatch {
+        event_id: String,
+        recorded_hash: String,
+        replay_hash: String,
+    },
+    /// `HARN-REP-CHN-003`: the replay's batched-match composition
+    /// (`constituent_event_ids`) doesn't match the recorded batch.
+    /// Aggregation policy or upstream emit ordering drifted.
+    #[serde(rename = "HARN-REP-CHN-003")]
+    BatchCompositionDrift {
+        event_id: String,
+        trigger_id: String,
+        recorded: Vec<String>,
+        replay: Vec<String>,
+    },
+}
+
+impl ChannelReplayDiagnostic {
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::MatchWithoutEmit { .. } => "HARN-REP-CHN-001",
+            Self::PayloadHashMismatch { .. } => "HARN-REP-CHN-002",
+            Self::BatchCompositionDrift { .. } => "HARN-REP-CHN-003",
+        }
+    }
+
+    pub fn message(&self) -> String {
+        match self {
+            Self::MatchWithoutEmit {
+                event_id,
+                trigger_id,
+            } => format!(
+                "HARN-REP-CHN-001: replay matched event {event_id} for trigger \
+                 {trigger_id} but no corresponding emit receipt was recorded"
+            ),
+            Self::PayloadHashMismatch {
+                event_id,
+                recorded_hash,
+                replay_hash,
+            } => format!(
+                "HARN-REP-CHN-002: emit payload drift for event {event_id} \
+                 (recorded {recorded_hash}, replay {replay_hash})"
+            ),
+            Self::BatchCompositionDrift {
+                event_id,
+                trigger_id,
+                recorded,
+                replay,
+            } => format!(
+                "HARN-REP-CHN-003: batched-match composition drift for trigger {trigger_id} \
+                 anchor event {event_id} (recorded {recorded:?}, replay {replay:?})"
+            ),
+        }
+    }
+}
+
+/// CH-07 (#1878): compare two captured channel-receipt sequences and
+/// return the first replay-determinism violation, if any. Designed to
+/// run after `run_replay_oracle_trace` so the canonical JSON diff catches
+/// structural drift first; this function adds the channel-specific typed
+/// codes (HARN-REP-CHN-001/002/003) that downstream audit tooling
+/// consumes.
+///
+/// Returns `Ok(None)` when the two runs are channel-determinism
+/// equivalent. Returns `Err(ReplayOracleError::Serialization)` only
+/// when a receipt entry can't be parsed.
+pub fn diagnose_channel_replay_drift(
+    recorded_receipts: &[JsonValue],
+    replay_receipts: &[JsonValue],
+) -> Result<Option<ChannelReplayDiagnostic>, ReplayOracleError> {
+    let recorded = ChannelReceiptIndex::from_entries(recorded_receipts)?;
+    let replay = ChannelReceiptIndex::from_entries(replay_receipts)?;
+
+    // HARN-REP-CHN-002: producer drift. Walk each replay emit and check
+    // its hash against the recorded one.
+    for (event_id, replay_hash) in &replay.emit_hashes {
+        if let Some(recorded_hash) = recorded.emit_hashes.get(event_id) {
+            if recorded_hash != replay_hash {
+                return Ok(Some(ChannelReplayDiagnostic::PayloadHashMismatch {
+                    event_id: event_id.clone(),
+                    recorded_hash: recorded_hash.clone(),
+                    replay_hash: replay_hash.clone(),
+                }));
+            }
+        }
+    }
+
+    // HARN-REP-CHN-001: replay matched an event_id that no recorded
+    // emit announced. Indicates either an extra emit on replay or a lost
+    // emit receipt in the baseline.
+    for (event_id, trigger_id) in &replay.match_triggers {
+        if !recorded.emit_hashes.contains_key(event_id) {
+            return Ok(Some(ChannelReplayDiagnostic::MatchWithoutEmit {
+                event_id: event_id.clone(),
+                trigger_id: trigger_id.clone(),
+            }));
+        }
+    }
+
+    // HARN-REP-CHN-003: batched-match composition drift. Compare the
+    // `constituent_event_ids` for matching (event_id, trigger_id) pairs.
+    for ((event_id, trigger_id), recorded_batch) in &recorded.match_batches {
+        if let Some(replay_batch) = replay
+            .match_batches
+            .get(&(event_id.clone(), trigger_id.clone()))
+        {
+            if recorded_batch != replay_batch {
+                return Ok(Some(ChannelReplayDiagnostic::BatchCompositionDrift {
+                    event_id: event_id.clone(),
+                    trigger_id: trigger_id.clone(),
+                    recorded: recorded_batch.clone(),
+                    replay: replay_batch.clone(),
+                }));
+            }
+        }
+    }
+
+    Ok(None)
+}
+
+/// Internal index for `diagnose_channel_replay_drift`. Separates the
+/// emit-hash lookup from the match-trigger / match-batch lookups so each
+/// diagnostic walks the relevant slice only.
+struct ChannelReceiptIndex {
+    /// `event_id` -> `payload_hash` for every emit receipt in the run.
+    emit_hashes: std::collections::BTreeMap<String, String>,
+    /// `event_id` -> first observed `trigger_id` for every match
+    /// receipt. Used by HARN-REP-CHN-001 — we only need to know that
+    /// *some* match fired, not which one.
+    match_triggers: std::collections::BTreeMap<String, String>,
+    /// `(event_id, trigger_id)` -> sorted `constituent_event_ids` for
+    /// every batched-match receipt. Empty list for non-batched matches
+    /// (those don't carry a `batch.constituent_event_ids` array).
+    match_batches: std::collections::BTreeMap<(String, String), Vec<String>>,
+}
+
+impl ChannelReceiptIndex {
+    fn from_entries(entries: &[JsonValue]) -> Result<Self, ReplayOracleError> {
+        let mut emit_hashes = std::collections::BTreeMap::new();
+        let mut match_triggers = std::collections::BTreeMap::new();
+        let mut match_batches = std::collections::BTreeMap::new();
+        for entry in entries {
+            let map = entry.as_object().ok_or_else(|| {
+                ReplayOracleError::Serialization(format!(
+                    "channel receipt entry is not an object: {entry}"
+                ))
+            })?;
+            // Tolerate two shapes: the raw receipt JSON
+            // (`ChannelEmitReceipt`/`ChannelMatchReceipt`), and an
+            // `event_log.subscribe(...)` envelope where the receipt
+            // lives under `payload` and `kind` classifies the variant.
+            let (kind, payload) = if let Some(kind) = map.get("kind").and_then(|v| v.as_str()) {
+                let payload = map.get("payload").cloned().unwrap_or_else(|| entry.clone());
+                (Some(kind.to_string()), payload)
+            } else if map.contains_key("payload_hash") {
+                (Some("channel_emit_receipt".to_string()), entry.clone())
+            } else if map.contains_key("matched_at") {
+                (Some("channel_match_receipt".to_string()), entry.clone())
+            } else {
+                (None, entry.clone())
+            };
+            let Some(kind) = kind else {
+                continue;
+            };
+            let payload_map = payload.as_object();
+            match kind.as_str() {
+                "channel_emit_receipt" => {
+                    let Some(payload_map) = payload_map else {
+                        continue;
+                    };
+                    let event_id = match payload_map.get("event_id").and_then(|v| v.as_str()) {
+                        Some(value) => value.to_string(),
+                        None => continue,
+                    };
+                    let hash = payload_map
+                        .get("payload_hash")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or_default()
+                        .to_string();
+                    emit_hashes.entry(event_id).or_insert(hash);
+                }
+                "channel_match_receipt" => {
+                    let Some(payload_map) = payload_map else {
+                        continue;
+                    };
+                    let event_id = match payload_map.get("event_id").and_then(|v| v.as_str()) {
+                        Some(value) => value.to_string(),
+                        None => continue,
+                    };
+                    let trigger_id = payload_map
+                        .get("trigger_id")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or_default()
+                        .to_string();
+                    match_triggers
+                        .entry(event_id.clone())
+                        .or_insert(trigger_id.clone());
+                    let batch_ids = payload_map
+                        .get("batch")
+                        .and_then(|v| v.as_object())
+                        .and_then(|b| b.get("constituent_event_ids"))
+                        .and_then(|v| v.as_array())
+                        .map(|arr| {
+                            let mut ids: Vec<String> = arr
+                                .iter()
+                                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                                .collect();
+                            ids.sort();
+                            ids
+                        })
+                        .unwrap_or_default();
+                    if !batch_ids.is_empty() {
+                        match_batches
+                            .entry((event_id, trigger_id))
+                            .or_insert(batch_ids);
+                    }
+                }
+                _ => {}
+            }
+        }
+        Ok(Self {
+            emit_hashes,
+            match_triggers,
+            match_batches,
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -563,6 +822,119 @@ mod tests {
 
         assert!(report.passed);
         assert!(report.divergence.is_some());
+    }
+
+    fn channel_emit_receipt(event_id: &str, payload_hash: &str) -> JsonValue {
+        json!({
+            "kind": "channel_emit_receipt",
+            "payload": {
+                "event_id": event_id,
+                "payload_hash": payload_hash,
+                "name_resolved": "tenant:default:ch.test",
+                "scope": "tenant",
+                "scope_id": "default",
+                "topic": "channels.tenant.default.ch.test",
+                "inserted": true,
+            },
+        })
+    }
+
+    fn channel_match_receipt(
+        event_id: &str,
+        trigger_id: &str,
+        constituent_ids: Option<Vec<&str>>,
+    ) -> JsonValue {
+        let mut payload = serde_json::Map::new();
+        payload.insert("event_id".to_string(), json!(event_id));
+        payload.insert("trigger_id".to_string(), json!(trigger_id));
+        payload.insert("handler_kind".to_string(), json!("local"));
+        if let Some(ids) = constituent_ids {
+            payload.insert(
+                "batch".to_string(),
+                json!({
+                    "count": ids.len(),
+                    "constituent_event_ids": ids,
+                }),
+            );
+        }
+        json!({
+            "kind": "channel_match_receipt",
+            "payload": JsonValue::Object(payload),
+        })
+    }
+
+    #[test]
+    fn channel_replay_diagnostic_clean_runs_have_no_drift() {
+        let recorded = vec![
+            channel_emit_receipt("evt-1", "sha256:a"),
+            channel_match_receipt("evt-1", "trig-x", None),
+        ];
+        let replay = recorded.clone();
+        let diagnostic = diagnose_channel_replay_drift(&recorded, &replay).unwrap();
+        assert!(diagnostic.is_none(), "{diagnostic:?}");
+    }
+
+    #[test]
+    fn channel_replay_diagnostic_001_match_without_emit() {
+        let recorded = vec![channel_emit_receipt("evt-1", "sha256:a")];
+        // Replay matched a different event id with no emit recorded for it.
+        let replay = vec![
+            channel_emit_receipt("evt-1", "sha256:a"),
+            channel_match_receipt("evt-2", "trig-x", None),
+        ];
+        let diagnostic = diagnose_channel_replay_drift(&recorded, &replay)
+            .unwrap()
+            .expect("drift");
+        assert_eq!(diagnostic.code(), "HARN-REP-CHN-001");
+        assert!(matches!(
+            diagnostic,
+            ChannelReplayDiagnostic::MatchWithoutEmit { ref event_id, .. } if event_id == "evt-2"
+        ));
+    }
+
+    #[test]
+    fn channel_replay_diagnostic_002_payload_hash_drift() {
+        let recorded = vec![channel_emit_receipt("evt-1", "sha256:a")];
+        let replay = vec![channel_emit_receipt("evt-1", "sha256:b")];
+        let diagnostic = diagnose_channel_replay_drift(&recorded, &replay)
+            .unwrap()
+            .expect("drift");
+        assert_eq!(diagnostic.code(), "HARN-REP-CHN-002");
+        let message = diagnostic.message();
+        assert!(message.contains("HARN-REP-CHN-002"));
+        assert!(message.contains("evt-1"));
+    }
+
+    #[test]
+    fn channel_replay_diagnostic_003_batch_composition_drift() {
+        let recorded = vec![
+            channel_emit_receipt("evt-1", "sha256:a"),
+            channel_emit_receipt("evt-2", "sha256:b"),
+            channel_emit_receipt("evt-3", "sha256:c"),
+            channel_match_receipt("evt-1", "trig-x", Some(vec!["evt-1", "evt-2", "evt-3"])),
+        ];
+        let replay = vec![
+            channel_emit_receipt("evt-1", "sha256:a"),
+            channel_emit_receipt("evt-2", "sha256:b"),
+            channel_emit_receipt("evt-3", "sha256:c"),
+            // Replay aggregated a different subset.
+            channel_match_receipt("evt-1", "trig-x", Some(vec!["evt-1", "evt-2"])),
+        ];
+        let diagnostic = diagnose_channel_replay_drift(&recorded, &replay)
+            .unwrap()
+            .expect("drift");
+        assert_eq!(diagnostic.code(), "HARN-REP-CHN-003");
+    }
+
+    #[test]
+    fn channel_receipts_count_first_class_replay_material() {
+        let mut trace = base_trace();
+        trace.first_run.channel_receipts = vec![channel_emit_receipt("evt-1", "sha256:a")];
+        trace.second_run.channel_receipts = trace.first_run.channel_receipts.clone();
+        let report = run_replay_oracle_trace(&trace).expect("oracle succeeds");
+        assert!(report.passed, "{report:?}");
+        assert_eq!(report.first_run_counts.channel_receipts, 1);
+        assert_eq!(report.second_run_counts.channel_receipts, 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

CH-07 of the channels epic (#1870) — closes #1878. Gives every
`emit_channel(...)` and every channel-source trigger match a
durable receipt on a new `lifecycle.channel.audit` event-log topic,
plus three typed `HARN-REP-CHN-*` replay-oracle diagnostics so audit
tooling can pinpoint cross-run channel drift.

- New `ChannelEmitReceipt` + `ChannelMatchReceipt` types (full
  payload, canonical-JSON SHA-256 `payload_hash`, signed
  `emitted_at` / `matched_at` timestamps reusing CH-01's HMAC salt,
  `batch.constituent_event_ids` for aggregated dispatch). Match
  receipts link back to the emit by stable `event_id` (resolved
  from the trigger event's `dedupe_key` — no more
  `trigger_evt_*`-only chains).
- `ReplayTraceRun.channel_receipts` is now a first-class
  replay-oracle section (also threaded through `replay_bench`
  runtime cost + section list); `diagnose_channel_replay_drift(...)`
  surfaces `HARN-REP-CHN-001` (match without emit),
  `HARN-REP-CHN-002` (payload hash drift), `HARN-REP-CHN-003`
  (batched composition drift).

## Test plan

- [x] `cargo fmt --all && cargo clippy --workspace --all-targets -- -D warnings`
- [x] `make fmt-harn && make lint-harn && make lint-test-patterns`
- [x] `cargo nextest run -p harn-vm` (2331 passed, 2 skipped)
- [x] `cargo run --bin harn -- test conformance` (1284 passed, 2 @xfail skipped, 0 failed)
- [x] `cargo run --bin harn -- test conformance --filter trigger_channel_replay` (3 new fixtures pass)
- [x] `cargo test -p harn-vm --lib channels` (3 new payload-hash tests pass; 19 total)
- [x] `cargo test -p harn-vm --lib replay_oracle` (5 new diagnostic tests pass; 10 total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)