### PR TITLE
Regenerate testbench replay-fidelity tape after pipeline-lifecycle work

### DIFF
--- a/conformance/tests/testbench/testbench_replay_fidelity.harn
+++ b/conformance/tests/testbench/testbench_replay_fidelity.harn
@@ -8,6 +8,17 @@
  * A byte-identical comparison passing means: given the same fixture and
  * the same paused clock, the runtime always produces the same sequence
  * of host-boundary events.
+ *
+ * REGENERATING THE TAPE: when a deliberate runtime change adds or
+ * removes a host-boundary record (e.g. a new lifecycle hook reads the
+ * clock), this fixture fails with a "missing_in_recorded" /
+ * "missing_in_replay" divergence. To regenerate: temporarily edit
+ * crates/harn-cli/src/commands/test.rs to `std::fs::copy(tape_path,
+ * "/tmp/actual.tape")` on divergence, run the filter, then
+ * `cp /tmp/actual.tape conformance/tests/testbench/testbench_replay_fidelity.testbench-tape`
+ * (normalize the absolute script_path to the relative form first).
+ * Revert the debug edit before committing. The brittleness here is the
+ * point — every regen requires explicit review.
  */
 pipeline test(task) {
   llm_mock_clear()

--- a/conformance/tests/testbench/testbench_replay_fidelity.testbench-tape
+++ b/conformance/tests/testbench/testbench_replay_fidelity.testbench-tape
@@ -1,4 +1,4 @@
-{"type":"header","version":1,"harn_version":"0.8.25","started_at_unix_ms":1767225600000,"script_path":"conformance/tests/testbench/testbench_replay_fidelity.harn","argv":[]}
+{"type":"header","version":1,"harn_version":"0.8.26","started_at_unix_ms":1767225600000,"script_path":"conformance/tests/testbench/testbench_replay_fidelity.harn","argv":[]}
 {"type":"record","seq":0,"virtual_time_ms":1767225600000,"monotonic_ms":0,"kind":{"kind":"clock_read","source":"wall","value_ms":1767225600000}}
 {"type":"record","seq":1,"virtual_time_ms":1767225600000,"monotonic_ms":0,"kind":{"kind":"clock_read","source":"wall","value_ms":1767225600000}}
 {"type":"record","seq":2,"virtual_time_ms":1767225600000,"monotonic_ms":0,"kind":{"kind":"llm_call","request_digest":"1607d6150c963e65098bea59ce798c9636678073c0bdf512742e8223c11c07af","response":{"content_hash":"6cf31d98f9d2b511b7e99d34c96e943d0968fad9cb59d0d9311a3c48f7c3c97f","text":"{\"text\":\"fidelity-response\",\"tool_calls\":[],\"input_tokens\":5,\"output_tokens\":3,\"cache_read_tokens\":0,\"cache_write_tokens\":0,\"model\":\"mock\",\"provider\":\"mock\",\"thinking\":null,\"thinking_summary\":null,\"stop_reason\":null,\"blocks\":[{\"text\":\"fidelity-response\",\"type\":\"output_text\",\"visibility\":\"public\"}],\"logprobs\":[]}"}}}
@@ -6,3 +6,4 @@
 {"type":"record","seq":4,"virtual_time_ms":1767225601000,"monotonic_ms":1000,"kind":{"kind":"clock_read","source":"wall","value_ms":1767225601000}}
 {"type":"record","seq":5,"virtual_time_ms":1767225601000,"monotonic_ms":1000,"kind":{"kind":"clock_read","source":"wall","value_ms":1767225601000}}
 {"type":"record","seq":6,"virtual_time_ms":1767225600000,"monotonic_ms":0,"kind":{"kind":"clock_read","source":"wall","value_ms":1767225600000}}
+{"type":"record","seq":7,"virtual_time_ms":1767225600000,"monotonic_ms":0,"kind":{"kind":"clock_read","source":"wall","value_ms":1767225600000}}


### PR DESCRIPTION
## Summary

Main CI has been red due to `testbench_replay_fidelity.harn` failing with a `missing_in_recorded` divergence at seq=7. The recent pipeline-lifecycle work (P-06 #1993, P-08 #2018, P-09 #2013, etc.) added one extra `clock_read` host-boundary record at pipeline finalize. The golden tape was authored at v0.8.25 and no longer matched.

## Changes

- Regenerated the golden tape against the current runtime (records seq 0-7 instead of 0-6).
- Added a "REGENERATING THE TAPE" comment to the fixture documenting the manual regen procedure so future host-boundary additions don't leave the test failing for hours.
- The fixture's brittleness is intentional — every new host-boundary read should be reviewed explicitly.

## Follow-up

Filed #2020 to reduce the brittleness architecturally — separate user-script vs runtime-finalize records so legitimate observability additions don't force regen.

## Test plan

- [x] `cargo run --bin harn -- test conformance --filter testbench_replay_fidelity` passes
- [x] `cargo run --bin harn -- test conformance` — 1292 passed, 0 failed, 1 skipped (pre-existing xfail)
- [x] `cargo run --bin harn -- test conformance --filter testbench` — 8/8 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)