### PR TITLE
Add tool hooks conformance suite (#1900)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,28 @@ condensed series summaries instead of full per-patch history.
 
 ### Added
 
+- **Tool-hook conformance suite (TH-07, #1900).** Adds nine focused
+  `conformance/tests/stdlib/preset_hooks_*` fixtures that gap-fill the
+  TH-* surface against the spec's named scenarios:
+  `preset_hooks_basic_rewrite`, `preset_hooks_deny_mode`,
+  `preset_hooks_passthrough_audit`, `preset_hooks_no_match_passthrough`,
+  `preset_hooks_catalogue_composition`,
+  `preset_hooks_custom_rule_priority`,
+  `preset_hooks_per_stack_filtering`,
+  `preset_hooks_llm_classifier_confidence`, and
+  `preset_hooks_universal_rules_always_apply`. Each fixture isolates a
+  single contract (mode dispatch, rule-priority resolution across
+  catalogues, custom-rule precedence, stack filtering, LLM-classifier
+  threshold gating, universal-rule stack independence) so a regression
+  in any one surface points at the right TH-0X fix rather than a
+  broad-coverage test. The pre-existing
+  `tool_hooks_catalogue_{rust,python,typescript,swift,sql,harn,universal}`
+  fixtures already satisfy the spec's "two real-command fixtures per
+  catalogue" rider with multi-probe coverage of every shipped rule.
+  Combined suite runtime stays well under the 40-second budget
+  (~4.5s for the 9 new fixtures; ~25 fixtures total in the
+  tool/preset hook namespace). Part of epic #1884 (Preset tool hooks
+  library).
 - **Pool tasks wired into `harness.unsettled_state()` (#2007).** Closes
   the PL-07 follow-up from #2008: `UnsettledStateSnapshot` now carries a
   `pool_pending_tasks` bucket fed by a new

--- a/conformance/tests/stdlib/preset_hooks_basic_rewrite.expected
+++ b/conformance/tests/stdlib/preset_hooks_basic_rewrite.expected
@@ -1,0 +1,14 @@
+rewrite
+rust.cargo.target_dir_conflict
+harn-canon/rust
+warning
+cargo build --release
+cargo build --release --target-dir target-shared
+cargo build --release --target-dir target-shared
+2
+tool_rewrite
+rust.cargo.target_dir_conflict
+tool_hooks.reminder_injected
+tool_rewritten
+true
+true

--- a/conformance/tests/stdlib/preset_hooks_basic_rewrite.harn
+++ b/conformance/tests/stdlib/preset_hooks_basic_rewrite.harn
@@ -1,0 +1,37 @@
+import { preset_run_command } from "std/tool_hooks"
+
+/**
+ * preset_hooks_basic_rewrite (TH-07 #1900).
+ *
+ * Single-concept fixture: a registered catalogue rule matches a bare
+ * `cargo build`, the default rewrite-with-audit mode rewrites the
+ * command (`--target-dir target-shared`), forwards the rewritten
+ * command to `inner`, and queues a `tool_rewritten` reminder. Auditable
+ * via `pipeline_lifecycle_audit_log_take`.
+ */
+pipeline default() {
+  pipeline_lifecycle_audit_log_take()
+  let inner = { args -> {ok: true, ran: args.command} }
+  let wrapper = preset_run_command({stacks: ["rust"], inner: inner})
+  let result = wrapper({command: "cargo build --release"})
+  /* The envelope reports rewrite + rule provenance. */
+  println(result.action)
+  println(result.rule_id)
+  println(result.catalogue_id)
+  println(result.severity)
+  println(result.original_command)
+  println(result.command)
+  /* inner saw the rewritten command, not the original. */
+  println(result.result.ran)
+  /* Rewrite mode emits exactly two audit entries: tool_rewrite +
+   * tool_hooks.reminder_injected. The reminder body names the rewrite
+   * so an agent can paraphrase it back to the user. */
+  let log = pipeline_lifecycle_audit_log_take()
+  println(len(log))
+  println(log[0].kind)
+  println(log[0].payload.rule_id)
+  println(log[1].kind)
+  println(log[1].payload.tags[0])
+  println(contains(log[1].payload.body, "rewritten"))
+  println(contains(log[1].payload.body, "target-shared"))
+}

--- a/conformance/tests/stdlib/preset_hooks_catalogue_composition.expected
+++ b/conformance/tests/stdlib/preset_hooks_catalogue_composition.expected
@@ -1,0 +1,9 @@
+3
+deny.git_push_force_deny
+team/deny
+error
+mid.git_push_force_rewrite
+low.git_push_force_rewrite
+2
+mid.git_push_force_rewrite
+low.git_push_force_rewrite

--- a/conformance/tests/stdlib/preset_hooks_catalogue_composition.harn
+++ b/conformance/tests/stdlib/preset_hooks_catalogue_composition.harn
@@ -1,0 +1,68 @@
+/**
+ * preset_hooks_catalogue_composition (TH-07 #1900).
+ *
+ * Multiple catalogues registered against the same registry. When a
+ * command matches rules across catalogues, `tool_hooks_match` sorts
+ * the hits by combined (catalogue_priority + rule_priority), highest
+ * first, so deny-tier rules out-rank rewrites and the agent sees the
+ * blocking explanation before any rewrite suggestion.
+ */
+pipeline default() {
+  /* Three catalogues with deliberately overlapping coverage on
+   * `git push --force`:
+   *   - "low" catalogue: warning-severity rewrite rule, priority 1.
+   *   - "mid" catalogue: warning-severity rewrite rule, priority 5.
+   *   - "deny" catalogue: error-severity deny rule, priority 100. */
+  let low_rule = tool_rule(
+    {
+      id: "low.git_push_force_rewrite",
+      pattern: "git push.* --force",
+      severity: "warning",
+      explanation: "prefer --force-with-lease",
+      priority: 1,
+    },
+  )
+  let mid_rule = tool_rule(
+    {
+      id: "mid.git_push_force_rewrite",
+      pattern: "git push.* --force",
+      severity: "warning",
+      explanation: "prefer --force-with-lease (mid)",
+      priority: 5,
+    },
+  )
+  let deny_rule = tool_rule(
+    {
+      id: "deny.git_push_force_deny",
+      pattern: "git push.* --force",
+      severity: "error",
+      explanation: "force-pushing main is denied",
+      priority: 100,
+    },
+  )
+  let low_cat = catalogue({id: "team/low", stack: "git", rules: [low_rule]})
+  let mid_cat = catalogue({id: "team/mid", stack: "git", rules: [mid_rule]})
+  let deny_cat = catalogue({id: "team/deny", stack: "git", rules: [deny_rule]})
+  /* Register intentionally out-of-order so the priority-sort is the
+   * subject under test (not the registration order). */
+  let reg = tool_hooks_register(
+    tool_hooks_register(tool_hooks_register(tool_hooks_registry(), low_cat), deny_cat),
+    mid_cat,
+  )
+  let matches = tool_hooks_match(reg, "git push origin main --force", {stacks: ["git"]})
+  /* All three rules matched. */
+  println(len(matches))
+  /* Highest priority wins the first slot regardless of insertion order. */
+  println(matches[0].rule_id)
+  println(matches[0].catalogue_id)
+  println(matches[0].severity)
+  println(matches[1].rule_id)
+  println(matches[2].rule_id)
+  /* Removing the deny catalogue collapses to the rewrite rules and the
+   * mid (priority 5) rule wins over the low (priority 1) one. */
+  let pruned = tool_hooks_unregister(reg, "team/deny")
+  let pruned_matches = tool_hooks_match(pruned, "git push origin main --force", {stacks: ["git"]})
+  println(len(pruned_matches))
+  println(pruned_matches[0].rule_id)
+  println(pruned_matches[1].rule_id)
+}

--- a/conformance/tests/stdlib/preset_hooks_custom_rule_priority.expected
+++ b/conformance/tests/stdlib/preset_hooks_custom_rule_priority.expected
@@ -1,0 +1,8 @@
+deny
+custom.deny_git_push_force
+preset_run_command/custom
+error
+deny
+custom.deny_cargo_build
+preset_run_command/custom
+true

--- a/conformance/tests/stdlib/preset_hooks_custom_rule_priority.harn
+++ b/conformance/tests/stdlib/preset_hooks_custom_rule_priority.harn
@@ -1,0 +1,65 @@
+import { preset_run_command, tool_hooks_mode_deny_with_explanation } from "std/tool_hooks"
+
+/**
+ * preset_hooks_custom_rule_priority (TH-07 #1900).
+ *
+ * `preset_run_command` evaluates `custom_rules` BEFORE the registered
+ * catalogues, so an inline custom rule can short-circuit a less-strict
+ * registered rule that would otherwise have matched. Tests both
+ * variants:
+ *   1. Custom rule matches a command no registered rule would match —
+ *      the custom rule fires with `catalogue_id: preset_run_command/custom`.
+ *   2. Custom rule matches a command for which a registered rule also
+ *      fires — the custom rule wins and the registered rule never
+ *      surfaces.
+ */
+pipeline default() {
+  let inner = { args -> {ok: true, ran: args.command} }
+  let custom_rule = tool_rule(
+    {
+      id: "custom.deny_git_push_force",
+      pattern: "git push.* --force",
+      severity: "error",
+      explanation: "Use --force-with-lease",
+    },
+  )
+  let wrapper = preset_run_command(
+    {
+      stacks: ["rust"],
+      custom_rules: [custom_rule],
+      mode: tool_hooks_mode_deny_with_explanation,
+      inner: inner,
+    },
+  )
+  /* (1) Custom rule fires for a non-registered command. */
+  let r1 = wrapper({command: "git push origin main --force"})
+  println(r1.action)
+  println(r1.rule_id)
+  println(r1.catalogue_id)
+  println(r1.severity)
+  /* (2) Custom rule wins over the registered rust catalogue rule. The
+   * `cargo build` command would normally fire `rust.cargo.target_dir_conflict`,
+   * but a custom rule with the same pattern jumps the queue. */
+  let cargo_custom = tool_rule(
+    {
+      id: "custom.deny_cargo_build",
+      pattern: "^cargo build",
+      severity: "error",
+      explanation: "cargo build is forbidden here, use cargo check",
+    },
+  )
+  let wrapper2 = preset_run_command(
+    {
+      stacks: ["rust"],
+      custom_rules: [cargo_custom],
+      mode: tool_hooks_mode_deny_with_explanation,
+      inner: inner,
+    },
+  )
+  let r2 = wrapper2({command: "cargo build --release"})
+  println(r2.action)
+  println(r2.rule_id)
+  println(r2.catalogue_id)
+  /* The custom rule's explanation surfaces, not the registered one. */
+  println(contains(r2.explanation, "cargo check"))
+}

--- a/conformance/tests/stdlib/preset_hooks_deny_mode.expected
+++ b/conformance/tests/stdlib/preset_hooks_deny_mode.expected
@@ -1,0 +1,11 @@
+deny
+rust.cargo.target_dir_conflict
+harn-canon/rust
+warning
+true
+true
+1
+tool_denied
+rust.cargo.target_dir_conflict
+cargo test
+warning

--- a/conformance/tests/stdlib/preset_hooks_deny_mode.harn
+++ b/conformance/tests/stdlib/preset_hooks_deny_mode.harn
@@ -1,0 +1,32 @@
+import { preset_run_command, tool_hooks_mode_deny_with_explanation } from "std/tool_hooks"
+
+/**
+ * preset_hooks_deny_mode (TH-07 #1900).
+ *
+ * Deny-with-explanation mode: a registered rule fires, the wrapper
+ * returns a deny envelope carrying the rule's explanation, `inner` is
+ * never invoked, and a `tool_denied` lifecycle audit is logged.
+ */
+pipeline default() {
+  pipeline_lifecycle_audit_log_take()
+  /* `inner` records whether it ran into a closure-captured ref via the
+   * result envelope; on deny the envelope must omit `result` entirely. */
+  let inner = { args -> {ok: true, ran: args.command} }
+  let wrapper = preset_run_command({stacks: ["rust"], mode: tool_hooks_mode_deny_with_explanation, inner: inner})
+  let result = wrapper({command: "cargo test"})
+  println(result.action)
+  println(result.rule_id)
+  println(result.catalogue_id)
+  println(result.severity)
+  println(contains(result.explanation, "--target-dir"))
+  /* inner stays uninvoked. */
+  println(result?.result == nil)
+  /* Deny mode emits one audit entry: tool_denied with the rule, the
+   * command we refused, and the severity. */
+  let log = pipeline_lifecycle_audit_log_take()
+  println(len(log))
+  println(log[0].kind)
+  println(log[0].payload.rule_id)
+  println(log[0].payload.command)
+  println(log[0].payload.severity)
+}

--- a/conformance/tests/stdlib/preset_hooks_llm_classifier_confidence.expected
+++ b/conformance/tests/stdlib/preset_hooks_llm_classifier_confidence.expected
@@ -1,0 +1,12 @@
+rewrite
+echo confident
+echo confident
+true
+echo below
+tool_hook_classifier_verdict
+rewrite
+rewrite
+4
+tool_hook_classifier_verdict
+passthrough
+rewrite

--- a/conformance/tests/stdlib/preset_hooks_llm_classifier_confidence.harn
+++ b/conformance/tests/stdlib/preset_hooks_llm_classifier_confidence.harn
@@ -1,0 +1,63 @@
+import { preset_run_command } from "std/tool_hooks"
+
+/**
+ * preset_hooks_llm_classifier_confidence (TH-07 #1900).
+ *
+ * Synthetic classifier responses driven by `llm_mock`. Threshold
+ * gating: a high-confidence verdict above the configured threshold
+ * dispatches via the requested mode (rewrite); a verdict with the same
+ * kind but confidence below the threshold falls through to `inner`
+ * with the original command. Both invocations still emit a
+ * `tool_hook_classifier_verdict` audit so the gating decision is
+ * observable.
+ */
+pipeline default() {
+  pipeline_lifecycle_audit_log_take()
+  __tool_hooks_classifier_cache_clear()
+  llm_mock_clear()
+  /* Above threshold: classifier asks for a rewrite with confidence 0.95;
+   * threshold is 0.7 so the rewrite mode fires. */
+  llm_mock(
+    {
+      text: "{\"kind\": \"rewrite\", \"confidence\": 0.95,"
+        + " \"rewritten\": \"echo confident\","
+        + " \"explanation\": \"safe to rewrite\"}",
+    },
+  )
+  let inner = { args -> {ok: true, ran: args.command} }
+  let wrapper = preset_run_command(
+    {llm_classifier: {model: "haiku", provider: "mock", threshold: 0.7}, inner: inner},
+  )
+  let above = wrapper({command: "echo above"})
+  println(above.action)
+  println(above.command)
+  println(above.result.ran)
+  /* Below threshold: same kind, confidence 0.4. Wrapper audits the
+   * verdict but runs `inner` with the unaltered command. */
+  llm_mock(
+    {
+      text: "{\"kind\": \"rewrite\", \"confidence\": 0.4,"
+        + " \"rewritten\": \"never-applied\","
+        + " \"explanation\": \"low confidence\"}",
+    },
+  )
+  let below = wrapper({command: "echo below"})
+  println(below.ok)
+  println(below.ran)
+  /* Two classifier verdicts logged, one above-threshold (action="rewrite")
+   * and one below (action="passthrough"). */
+  let log = pipeline_lifecycle_audit_log_take()
+  println(log[0].kind)
+  println(log[0].payload.kind)
+  println(log[0].payload.action)
+  /* The below-threshold call's verdict is the last entry in the log:
+   * passthrough emits no further audit entries. Above-threshold
+   * rewrite emits classifier_verdict + tool_rewrite +
+   * tool_hooks.reminder_injected = 3, then the passthrough adds 1 for
+   * a total of 4. */
+  println(len(log))
+  let last = log[len(log) - 1]
+  println(last.kind)
+  println(last.payload.action)
+  println(last.payload.kind)
+}

--- a/conformance/tests/stdlib/preset_hooks_no_match_passthrough.expected
+++ b/conformance/tests/stdlib/preset_hooks_no_match_passthrough.expected
@@ -1,0 +1,5 @@
+true
+echo hello world
+passthrough
+echo hello world
+0

--- a/conformance/tests/stdlib/preset_hooks_no_match_passthrough.harn
+++ b/conformance/tests/stdlib/preset_hooks_no_match_passthrough.harn
@@ -1,0 +1,27 @@
+import { preset_run_command } from "std/tool_hooks"
+
+/**
+ * preset_hooks_no_match_passthrough (TH-07 #1900).
+ *
+ * No rule (registered, custom, or universal) matches the command. The
+ * wrapper bypasses mode dispatch entirely and runs `inner` with the
+ * original command. No audit entries are emitted because there is
+ * nothing to report.
+ */
+pipeline default() {
+  pipeline_lifecycle_audit_log_take()
+  let inner = { args -> {ok: true, ran: args.command} }
+  let wrapper = preset_run_command({stacks: ["rust"], inner: inner})
+  let result = wrapper({command: "echo hello world"})
+  /* `inner` ran with the command unchanged. */
+  println(result.ok)
+  println(result.ran)
+  /* When `inner` is omitted the wrapper still returns a no-match
+   * passthrough envelope so callers can drive the executor themselves. */
+  let preview_wrapper = preset_run_command({stacks: ["rust"]})
+  let preview = preview_wrapper({command: "echo hello world"})
+  println(preview.action)
+  println(preview.command)
+  /* Either way, no rule matched so the lifecycle audit log stays empty. */
+  println(len(pipeline_lifecycle_audit_log_take()))
+}

--- a/conformance/tests/stdlib/preset_hooks_passthrough_audit.expected
+++ b/conformance/tests/stdlib/preset_hooks_passthrough_audit.expected
@@ -1,0 +1,9 @@
+passthrough
+python.find_versus_rg
+find . -name '*.py'
+find . -name '*.py'
+find . -name '*.py'
+1
+tool_rule_warning
+python.find_versus_rg
+info

--- a/conformance/tests/stdlib/preset_hooks_passthrough_audit.harn
+++ b/conformance/tests/stdlib/preset_hooks_passthrough_audit.harn
@@ -1,0 +1,30 @@
+import { preset_run_command, tool_hooks_mode_passthrough_only_audit } from "std/tool_hooks"
+
+/**
+ * preset_hooks_passthrough_audit (TH-07 #1900).
+ *
+ * Passthrough-only-audit mode: a registered rule fires but the wrapper
+ * lets the original command flow through to `inner` unchanged. The
+ * audit log captures a `tool_rule_warning` entry naming the rule and
+ * severity, and no `tool_rewritten` reminder is queued (passthrough
+ * does not mutate behaviour).
+ */
+pipeline default() {
+  pipeline_lifecycle_audit_log_take()
+  let inner = { args -> {ok: true, ran: args.command} }
+  let wrapper = preset_run_command({stacks: ["python"], mode: tool_hooks_mode_passthrough_only_audit, inner: inner})
+  let result = wrapper({command: "find . -name '*.py'"})
+  println(result.action)
+  println(result.rule_id)
+  println(result.original_command)
+  /* original_command and command are identical — no rewrite applied. */
+  println(result.command)
+  println(result.result.ran)
+  /* Exactly one audit entry, kind tool_rule_warning. No
+   * tool_hooks.reminder_injected — passthrough is observability-only. */
+  let log = pipeline_lifecycle_audit_log_take()
+  println(len(log))
+  println(log[0].kind)
+  println(log[0].payload.rule_id)
+  println(log[0].payload.severity)
+}

--- a/conformance/tests/stdlib/preset_hooks_per_stack_filtering.expected
+++ b/conformance/tests/stdlib/preset_hooks_per_stack_filtering.expected
@@ -1,0 +1,8 @@
+true
+find . -name '*.py'
+true
+cargo build
+rewrite
+python.find_versus_rg
+rewrite
+rust.cargo.target_dir_conflict

--- a/conformance/tests/stdlib/preset_hooks_per_stack_filtering.harn
+++ b/conformance/tests/stdlib/preset_hooks_per_stack_filtering.harn
@@ -1,0 +1,36 @@
+import { preset_run_command } from "std/tool_hooks"
+
+/**
+ * preset_hooks_per_stack_filtering (TH-07 #1900).
+ *
+ * `preset_run_command` calls `tool_hooks_filter(registry, stacks)`
+ * before matching, so only rules whose catalogue stack is in the
+ * opt-in list (or whose catalogue is stackless, e.g. universal) get a
+ * chance to fire. Verified by running a python-flavored command
+ * against both a rust-only wrapper (no match) and a python+rust
+ * wrapper (match).
+ */
+pipeline default() {
+  let inner = { args -> {ok: true, ran: args.command} }
+  let rust_only = preset_run_command({stacks: ["rust"], inner: inner})
+  /* A python `find . -name '*.py'` command would normally fire
+   * `python.find_versus_rg`, but the python catalogue is filtered
+   * out by the rust-only opt-in, so the wrapper falls through to
+   * `inner` with the original command. */
+  let py_against_rust = rust_only({command: "find . -name '*.py'"})
+  println(py_against_rust.ok)
+  println(py_against_rust.ran)
+  /* Symmetric: a rust `cargo build` against a python-only wrapper. */
+  let py_only = preset_run_command({stacks: ["python"], inner: inner})
+  let rust_against_py = py_only({command: "cargo build"})
+  println(rust_against_py.ok)
+  println(rust_against_py.ran)
+  /* Opt-in to both stacks and each command hits its own rule. */
+  let both = preset_run_command({stacks: ["rust", "python"], inner: inner})
+  let py_hit = both({command: "find . -name '*.py'"})
+  println(py_hit.action)
+  println(py_hit.rule_id)
+  let rust_hit = both({command: "cargo build"})
+  println(rust_hit.action)
+  println(rust_hit.rule_id)
+}

--- a/conformance/tests/stdlib/preset_hooks_universal_rules_always_apply.expected
+++ b/conformance/tests/stdlib/preset_hooks_universal_rules_always_apply.expected
@@ -1,0 +1,11 @@
+deny
+universal.rm_rf_root_adjacent
+deny
+universal.git_push_force_main
+deny
+universal.rm_rf_root_adjacent
+deny
+universal.rm_rf_root_adjacent
+deny
+universal.rm_rf_root_adjacent
+ls -la

--- a/conformance/tests/stdlib/preset_hooks_universal_rules_always_apply.harn
+++ b/conformance/tests/stdlib/preset_hooks_universal_rules_always_apply.harn
@@ -1,0 +1,44 @@
+import { preset_run_command, tool_hooks_mode_deny_with_explanation } from "std/tool_hooks"
+
+/**
+ * preset_hooks_universal_rules_always_apply (TH-07 #1900).
+ *
+ * The universal catalogue (deny-tier rules: force-push to main,
+ * `rm -rf /` and root-adjacent paths) is stackless. `tool_hooks_filter`
+ * keeps stackless catalogues regardless of the `stacks: [...]` opt-in,
+ * so universal denies fire even when the agent only opted into,
+ * say, `["rust"]`. Verified across three different stack opt-ins
+ * (rust, python, an unrecognized stack) plus an empty opt-in.
+ */
+pipeline default() {
+  let inner = { args -> {ok: true, ran: args.command} }
+  /* rust-only wrapper: rm -rf / and force-push to main both denied. */
+  let rust_wrapper = preset_run_command({stacks: ["rust"], mode: tool_hooks_mode_deny_with_explanation, inner: inner})
+  let r1 = rust_wrapper({command: "rm -rf /"})
+  println(r1.action)
+  println(r1.rule_id)
+  let r2 = rust_wrapper({command: "git push --force origin main"})
+  println(r2.action)
+  println(r2.rule_id)
+  /* python-only wrapper: same universal rules still fire. */
+  let py_wrapper = preset_run_command({stacks: ["python"], mode: tool_hooks_mode_deny_with_explanation, inner: inner})
+  let r3 = py_wrapper({command: "rm -rf /"})
+  println(r3.action)
+  println(r3.rule_id)
+  /* Unrecognized stack: __cat_for_stack returns nil so only the
+   * universal catalogue ships. Universal denies still apply. */
+  let unknown_wrapper = preset_run_command(
+    {stacks: ["fictional"], mode: tool_hooks_mode_deny_with_explanation, inner: inner},
+  )
+  let r4 = unknown_wrapper({command: "rm -rf /"})
+  println(r4.action)
+  println(r4.rule_id)
+  /* Empty stack list: still picks up universal. */
+  let empty_wrapper = preset_run_command({stacks: [], mode: tool_hooks_mode_deny_with_explanation, inner: inner})
+  let r5 = empty_wrapper({command: "rm -rf /"})
+  println(r5.action)
+  println(r5.rule_id)
+  /* Sanity: a benign command on every wrapper still passes through. */
+  let benign = rust_wrapper({command: "ls -la"})
+  println(benign?.result?.ran ?? benign?.ran ?? "MISSING")
+}


### PR DESCRIPTION
## Summary

- Closes #1900 (TH-07). Gap-fills the TH-* surface with nine focused `conformance/tests/stdlib/preset_hooks_*` fixtures keyed to the spec's named scenarios: basic rewrite, deny mode, passthrough audit, no-match passthrough, catalogue composition, custom-rule priority, per-stack filtering, LLM-classifier confidence gating, and universal-rule stack independence.
- Each fixture isolates a single contract (mode dispatch, rule-priority resolution across catalogues, custom-rule precedence, stack filtering, threshold gating, universal-rule stack independence) so a regression points at the responsible TH-0X surface rather than a broad-coverage test.
- Per-catalogue real-command coverage already ships in the existing `tool_hooks_catalogue_*` fixtures (rust/python/typescript/swift/sql/harn/universal each exercise multiple probes per rule), so the "2 real-command fixtures per catalogue" rider is satisfied de facto without further additions.

## Deliberate cuts

- No new `preset_hooks_*` fixture for `tool_hooks_llm_classifier_deny` / `_passthrough` / `_error_recovery` — those scenarios already have dedicated, focused fixtures shipped under the `tool_hooks_` prefix in TH-05 (#2017). The new `preset_hooks_llm_classifier_confidence` covers the threshold-gating gate that the spec named explicitly.
- The spec uses `preset_hooks_*` naming for the new fixtures while pre-existing fixtures use `tool_hooks_*`. Both prefixes ship — no renames — so the public test surface stays additive.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `make fmt-harn` / `make lint-harn` / `make lint-test-patterns`
- [x] `cargo run --quiet --bin harn -- test conformance --filter "tool_hooks|preset_hooks"` (25 passed, 0 failed; ~4.5s for 9 new fixtures alone)
- [x] `make test` (4459 passed, 2 skipped)
- [x] `make lint-md`
- [ ] CI green

Combined runtime of the tool/preset hook conformance namespace stays well under the 40-second budget called out in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)