### PR TITLE
Fix batched ReminderInject template binding

### DIFF
--- a/conformance/tests/triggers/trigger_channel_reminder_inject_batched.expected
+++ b/conformance/tests/triggers/trigger_channel_reminder_inject_batched.expected
@@ -1,5 +1,5 @@
 before-threshold:0
 after-threshold:1
-Batch landed.
+Batch 1-2-3 landed.
 batched_reminder
 after-second-batch:2

--- a/conformance/tests/triggers/trigger_channel_reminder_inject_batched.harn
+++ b/conformance/tests/triggers/trigger_channel_reminder_inject_batched.harn
@@ -14,14 +14,20 @@ pipeline test(task) {
   mock_time(1000000)
   let target_session = agent_session_open("trigger-channel-reminder-batched")
   agent_session_reset(target_session)
-  let unique = to_string(to_int(timestamp())) + "-" + to_string(random_int(100000, 999999))
+  let unique = to_string(random_int(100000, 999999))
   let _handle: TriggerHandle = trigger_register(
     {
       id: "trigger-channel-reminder-batched-" + unique,
       kind: "channel.emit",
       provider: "channel",
       autonomy_tier: "act_auto",
-      handler: ReminderInject({target: target_session, body: "Batch landed.", tags: ["batched_reminder"]}),
+      handler: ReminderInject(
+        {
+          target: target_session,
+          body: "Batch {{ batch[0].provider_payload.payload.seq }}-{{ batch[1].provider_payload.payload.seq }}-{{ batch[2].provider_payload.payload.seq }} landed.",
+          tags: ["batched_reminder"],
+        },
+      ),
       when: nil,
       retry: nil,
       match: {events: ["channel:ch.reminder.batched.input"]},

--- a/crates/harn-vm/src/triggers/dispatcher/mod.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/mod.rs
@@ -2420,10 +2420,11 @@ impl Dispatcher {
                 "matched_at": event_json.get("received_at").cloned().unwrap_or(serde_json::Value::Null),
             })),
         );
-        if let Some(batch_value) = event_json
-            .get("provider_payload")
-            .and_then(|p| p.get("batch"))
-        {
+        if let Some(batch_value) = event_json.get("batch").or_else(|| {
+            event_json
+                .get("provider_payload")
+                .and_then(|payload| payload.get("batch"))
+        }) {
             bindings.insert(
                 "batch".to_string(),
                 crate::schema::json_to_vm_value(batch_value),


### PR DESCRIPTION
## Summary

- Fix `ReminderInject` template bindings for batched trigger dispatches by sourcing `batch` from top-level `event.batch` before falling back to legacy `provider_payload.batch`.
- Strengthen the batched channel `ReminderInject` conformance fixture so the injected reminder body must render constituent batch payload values.
- Remove the touched fixture's deprecated ambient `timestamp()` usage while updating it.

Fixes #2024.

## Verification

- `CARGO_TARGET_DIR=/tmp/harn-target-issue2024 cargo run --quiet --bin harn -- test conformance --filter trigger_channel_reminder_inject_batched`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue2024 cargo run --quiet --bin harn -- test conformance --filter reminder_inject`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue2024 cargo test -p harn-vm triggers::dispatcher --lib`
- `cargo fmt --check`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue2024 cargo run --quiet --bin harn -- fmt --check conformance/tests/triggers/trigger_channel_reminder_inject_batched.harn`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue2024 cargo run --quiet --bin harn -- lint conformance/tests/triggers/trigger_channel_reminder_inject_batched.harn`
- pre-commit hook: Rust format, staged Harn format/lint, workspace clippy, CI ratchets
- pre-push hook: targeted local checks, affected Harn format/lint, repo drift checks
