### PR TITLE
[codex] Finish natural-language tool binder defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1238,6 +1238,15 @@ condensed series summaries instead of full per-patch history.
   `reminder_emitted` under `_meta.harn.reminder`, and hook-origin
   reminder metadata is carried on tool-call receipts.
 
+### Changed
+
+- **Natural-language tool binder defaults reflect the empirical run
+  envelope (#1696).** `with_natural_language_executor` now defaults to a
+  `500ms` wall-clock budget and `1024` response tokens. The larger token
+  budget gives reasoning binders room to emit structured JSON after their
+  reasoning preamble; the timeout remains a bounded opt-in hop and still
+  degrades to passthrough on overrun.
+
 ## v0.8.26
 
 ### Added

--- a/conformance/tests/integration/tool_binder_pipeline.expected
+++ b/conformance/tests/integration/tool_binder_pipeline.expected
@@ -12,6 +12,9 @@ ok
 hello
 false
 100
+ok
+500
+1024
 true
 timeout
 true
@@ -19,7 +22,7 @@ false
 false
 schema_violation
 schema_error
-false
+true
 true
 ok
 /var/log/syslog

--- a/conformance/tests/integration/tool_binder_pipeline.harn
+++ b/conformance/tests/integration/tool_binder_pipeline.harn
@@ -1,7 +1,7 @@
 /**
  * std/llm/tool_binder::with_natural_language_executor — middleware coverage.
  *
- * Verifies five scenarios through the composable tool-caller seam, using
+ * Verifies seven scenarios through the composable tool-caller seam, using
  * an injected `binder_fn` so the test doesn't need a live provider and
  * `mock_time` so timeout semantics are deterministic:
  *
@@ -10,10 +10,12 @@
  *   2. Passthrough when no natural-language intent is supplied.
  *   3. Successful binder dispatch — intent is bound into structured args
  *      via the binder LLM, original args are replaced before next().
- *   4. Timeout → audit.binder.status = "timeout"; envelope passes
+ *   4. Default binder limits reach the injected binder substrate.
+ *   5. Timeout → audit.binder.status = "timeout"; envelope passes
  *      through unchanged with the stripped args.
- *   5. on_failure: "reject" — schema-error from binder short-circuits
+ *   6. on_failure: "reject" — schema-error from binder short-circuits
  *      with a `schema_violation` error and never reaches next().
+ *   7. compose_tool_callers stacks cleanly with the binder.
  */
 import { with_natural_language_executor } from "std/llm/tool_binder"
 import { compose_tool_callers } from "std/llm/tool_middleware"
@@ -111,7 +113,35 @@ pipeline default() {
   // `llm_call` (which now recognizes `timeout_ms`) can apply an HTTP-level
   // backstop in addition to the middleware's post-call wall-clock check.
   println(atomic_get(captured_timeout_ms))
-  // (4) Timeout: binder takes longer than timeout_ms; envelope passes through.
+  // (4) Defaults: the production defaults should be usable with reasoning
+  // binder models without callers having to remember the empirical token
+  // and latency budget.
+  let captured_default_timeout_ms = atomic(0)
+  let captured_default_max_tokens = atomic(0)
+  let default_binder = { _prompt, _system, opts ->
+    let _ = atomic_set(captured_default_timeout_ms, to_int(opts?.timeout_ms ?? 0))
+    let _ = atomic_set(captured_default_max_tokens, to_int(opts?.max_tokens ?? 0))
+    return {
+      text: "{\"path\":\"/var/log/syslog\",\"contents\":\"hello\"}",
+      model: "mock",
+      provider: "mock",
+      input_tokens: 0,
+      output_tokens: 0,
+    }
+  }
+  let mw_defaults = with_natural_language_executor(
+    {provider: "cerebras", model: "gpt-oss-120b", binder_fn: default_binder},
+  )
+  let _ = mock_time(0)
+  let r_defaults = mw_defaults(
+    envelope("file_read", {_nl_intent: "read /var/log/syslog and append hello"}, schema),
+    next,
+  )
+  let _ = unmock_time()
+  println(r_defaults.audit.binder.status)
+  println(atomic_get(captured_default_timeout_ms))
+  println(atomic_get(captured_default_max_tokens))
+  // (5) Timeout: binder takes longer than timeout_ms; envelope passes through.
   let slow_binder = { _prompt, _system, _opts ->
     let _ = advance_time(250)
     return {
@@ -133,7 +163,7 @@ pipeline default() {
   println(r4.audit.binder.latency_ms >= 100)
   // Stripped args reach next() — intent is gone, original args (empty here) pass through.
   println(contains(r4.arguments.keys(), "_nl_intent"))
-  // (5) on_failure: "reject" — bad binder JSON short-circuits with schema_violation.
+  // (6) on_failure: "reject" — bad binder JSON short-circuits with schema_violation.
   let bad_binder = { _prompt, _system, _opts -> return {text: "not json at all", model: "mock", provider: "mock", input_tokens: 0, output_tokens: 0} }
   let was_dispatched = atomic(0)
   let watch_next = { call ->
@@ -153,8 +183,8 @@ pipeline default() {
   println(r5.ok)
   println(r5.error_category)
   println(r5.audit.binder.status)
-  println(atomic_get(was_dispatched) == 1)
-  // (6) compose_tool_callers stacks cleanly with the binder.
+  println(atomic_get(was_dispatched) == 0)
+  // (7) compose_tool_callers stacks cleanly with the binder.
   let composed = compose_tool_callers([mw_ok])
   let _ = mock_time(0)
   let r6 = composed(envelope("file_read", {_nl_intent: "read /var/log/syslog and append hello"}, schema), next)

--- a/conformance/tool-call-eval/README.md
+++ b/conformance/tool-call-eval/README.md
@@ -21,11 +21,15 @@ Run a planner+binder cell with real providers:
 ```sh
 cargo run --bin harn -- eval tool-calls \
   --dataset conformance/tool-call-eval \
-  --planner provider=openrouter,model=google/gemma-4-26b-a4b-it \
+  --planner provider=openrouter,model=meta-llama/llama-3.1-8b-instruct \
   --binder provider=cerebras,model=gpt-oss-120b \
   --judge-model anthropic:claude-haiku-4-5 \
-  --output .harn-runs/tool-call-eval/gemma-cerebras
+  --output .harn-runs/tool-call-eval/llama31-cerebras
 ```
+
+The checked-in middleware defaults use a `500ms` binder budget and `1024`
+response tokens. Keep those defaults unless the run is specifically measuring
+stricter latency behavior.
 
 The command writes:
 

--- a/crates/harn-stdlib/src/stdlib/llm/tool_binder.harn
+++ b/crates/harn-stdlib/src/stdlib/llm/tool_binder.harn
@@ -14,25 +14,26 @@
 //     with_natural_language_executor({
 //       provider: "cerebras",
 //       model: "gpt-oss-120b",
-//       timeout_ms: 100,
+//       timeout_ms: 500,
 //     }),
 //     default_tool_caller(),
 //   ])
 //   agent_loop(prompt, system, {tools: registry, tool_caller: caller})
 //
-// Contract (the parent epic — #1696 — restated here):
+// Contract:
 //
-//   - `timeout_ms` is a HARD wall-clock budget. If the binder hop overruns
-//     it, the envelope passes through unchanged and `audit.binder.status`
-//     is `"timeout"`. We do not cancel mid-flight (cancellation belongs in
-//     `agent_loop({deadline_ms})`); we observe the breach.
+//   - `timeout_ms` is a wall-clock budget for an opt-in latency hop. If the
+//     binder overruns it, the envelope passes through unchanged and
+//     `audit.binder.status` is `"timeout"`. We do not cancel mid-flight
+//     (cancellation belongs in `agent_loop({deadline_ms})`); we observe the
+//     breach.
 //   - Off by default. There is no implicit registration anywhere in the
 //     default agent pipeline. Activation requires explicit composition.
 //   - The middleware NEVER falls back to a second binder hop. Retries
 //     defeat the latency win; if the model needs more shots, raise
 //     `temperature` or pick a better model — don't retry on the hot path.
-//     `max_retries` is reserved for forward compatibility (default 0) and
-//     intentionally rejected if non-zero today.
+//     `max_retries` is accepted only as 0 so configs fail loudly instead
+//     of silently adding a second inference hop.
 //
 // Audit shape (lands under `audit.binder`, broadcast through
 // `tool_call_audit` events the same way `with_required_reason` surfaces
@@ -64,13 +65,51 @@ fn __binder_is_callable(value) -> bool {
 }
 
 fn __binder_drop_key(args, field) {
+  let source = __binder_dict(args)
   var cleaned = {}
-  for key in args.keys() {
+  for key in source.keys() {
     if key != field {
-      cleaned = cleaned + {[key]: args[key]}
+      cleaned = cleaned + {[key]: source[key]}
     }
   }
   return cleaned
+}
+
+fn __binder_positive_int(value, default_value, name) -> int {
+  if value == nil {
+    return default_value
+  }
+  let parsed = to_int(value)
+  if parsed == nil {
+    throw "with_natural_language_executor: `" + name + "` must be an integer; got "
+      + type_of(value)
+  }
+  if parsed <= 0 {
+    throw "with_natural_language_executor: `" + name + "` must be > 0; got " + to_string(parsed)
+  }
+  return parsed
+}
+
+fn __binder_int(value, default_value, name) -> int {
+  if value == nil {
+    return default_value
+  }
+  let parsed = to_int(value)
+  if parsed == nil {
+    throw "with_natural_language_executor: `" + name + "` must be an integer; got "
+      + type_of(value)
+  }
+  return parsed
+}
+
+fn __binder_bool(value, default_value, name) -> bool {
+  if value == nil {
+    return default_value
+  }
+  if type_of(value) != "bool" {
+    throw "with_natural_language_executor: `" + name + "` must be bool; got " + type_of(value)
+  }
+  return value
 }
 
 fn __binder_short_circuit(envelope, reason) {
@@ -216,11 +255,8 @@ fn __binder_validate_opts(cfg) {
   if model == "" {
     throw "with_natural_language_executor: `model` is required"
   }
-  let timeout_ms = to_int(cfg?.timeout_ms ?? 100) ?? 100
-  if timeout_ms <= 0 {
-    throw "with_natural_language_executor: `timeout_ms` must be > 0; got " + to_string(timeout_ms)
-  }
-  let max_retries = to_int(cfg?.max_retries ?? 0) ?? 0
+  let timeout_ms = __binder_positive_int(cfg?.timeout_ms, 500, "timeout_ms")
+  let max_retries = __binder_int(cfg?.max_retries, 0, "max_retries")
   if max_retries != 0 {
     throw "with_natural_language_executor: `max_retries` must be 0 — retries defeat the latency win; got "
       + to_string(max_retries)
@@ -238,15 +274,19 @@ fn __binder_validate_opts(cfg) {
   } else {
     { binder_prompt, binder_system, binder_opts -> llm_call(binder_prompt, binder_system, binder_opts) }
   }
+  let intent_field = trim(to_string(cfg?.intent_field ?? "_nl_intent"))
+  if intent_field == "" {
+    throw "with_natural_language_executor: `intent_field` must not be empty"
+  }
   return {
     provider: provider,
     model: model,
     timeout_ms: timeout_ms,
-    intent_field: to_string(cfg?.intent_field ?? "_nl_intent"),
-    passthrough_when_args_valid: cfg?.passthrough_when_args_valid ?? true,
+    intent_field: intent_field,
+    passthrough_when_args_valid: __binder_bool(cfg?.passthrough_when_args_valid, true, "passthrough_when_args_valid"),
     on_failure: on_failure,
     temperature: cfg?.temperature ?? 0.0,
-    max_tokens: to_int(cfg?.max_tokens ?? 256) ?? 256,
+    max_tokens: __binder_positive_int(cfg?.max_tokens, 1024, "max_tokens"),
     system_prompt: to_string(cfg?.system ?? __binder_default_system()),
     binder_fn: binder_fn,
   }
@@ -267,9 +307,9 @@ fn __binder_skip_reason(intent, schema_provided, already_valid) {
   return nil
 }
 
-fn __binder_passthrough(envelope, next, stripped_args, intent, ctx, skip_reason) {
+fn __binder_passthrough(envelope, next, original_args, stripped_args, intent, ctx, skip_reason) {
   let next_args = if intent == "" {
-    envelope.tool_args
+    original_args
   } else {
     stripped_args
   }
@@ -282,8 +322,8 @@ fn __binder_passthrough(envelope, next, stripped_args, intent, ctx, skip_reason)
  * with_natural_language_executor(opts) -> caller
  *
  * Intercepts a tool call, hands the planner-emitted natural-language
- * intent + the tool's JSON Schema to a sub-100ms binder LLM, and
- * replaces the envelope's `tool_args` with the binder's structured
+ * intent + the tool's JSON Schema to a latency-budgeted binder LLM,
+ * and replaces the envelope's `tool_args` with the binder's structured
  * output before dispatching downstream.
  *
  * Required options:
@@ -291,14 +331,14 @@ fn __binder_passthrough(envelope, next, stripped_args, intent, ctx, skip_reason)
  *   model:      string   // binder LLM model    (e.g. "gpt-oss-120b")
  *
  * Optional knobs (all conservative defaults):
- *   timeout_ms:                  int     (default 100; hard wall-clock budget — see header)
+ *   timeout_ms:                  int     (default 500; wall-clock budget — see header)
  *   max_retries:                 int     (default 0; non-zero rejected — retries defeat latency)
  *   intent_field:                string  (default "_nl_intent")
  *   passthrough_when_args_valid: bool    (default true; skip the hop when args already validate)
  *   on_failure:                  string  (default "passthrough"; "passthrough"|"reject"|"raise")
  *   system:                      string  (binder system prompt; sensible default supplied)
  *   temperature:                 float   (default 0.0)
- *   max_tokens:                  int     (default 256)
+ *   max_tokens:                  int     (default 1024)
  *   binder_fn:                   fn      (test hook; defaults to llm_call)
  *
  * @effects: []
@@ -310,14 +350,15 @@ fn __binder_passthrough(envelope, next, stripped_args, intent, ctx, skip_reason)
 pub fn with_natural_language_executor(opts) {
   let ctx = __binder_validate_opts(__binder_dict(opts))
   return { envelope, next ->
-    let raw_intent = envelope.tool_args?[ctx.intent_field]
+    let tool_args = __binder_dict(envelope.tool_args)
+    let raw_intent = tool_args[ctx.intent_field]
     let intent = if type_of(raw_intent) == "string" {
       trim(raw_intent)
     } else {
       ""
     }
     let schema = envelope.schema
-    let stripped_args = __binder_drop_key(envelope.tool_args, ctx.intent_field)
+    let stripped_args = __binder_drop_key(tool_args, ctx.intent_field)
     let schema_provided = schema != nil
     let already_valid = if schema_provided && ctx.passthrough_when_args_valid {
       schema_is(stripped_args, schema)
@@ -326,7 +367,7 @@ pub fn with_natural_language_executor(opts) {
     }
     let skip = __binder_skip_reason(intent, schema_provided, already_valid)
     if skip != nil {
-      return __binder_passthrough(envelope, next, stripped_args, intent, ctx, skip)
+      return __binder_passthrough(envelope, next, tool_args, stripped_args, intent, ctx, skip)
     }
     let prompt = __binder_prompt(envelope, intent, stripped_args)
     let invoke_cfg = {

--- a/crates/harn-vm/src/llm/providers.toml
+++ b/crates/harn-vm/src/llm/providers.toml
@@ -152,11 +152,12 @@ latency_p50_ms = 450
 method = "GET"
 path = "/models"
 
-# Cerebras — OpenAI-compatible wafer-scale inference. Headline ~3,000 tok/s
-# on gpt-oss-120b and ~2,100 tok/s on Llama 3.3 70B, fast enough to keep
-# binder-style single-tool-call hops under ~50ms p50. Provider-level
-# pricing here is a coarse default; per-model rows under [models.X] hold
-# the authoritative numbers from the Cerebras pricing page.
+# Cerebras — OpenAI-compatible wafer-scale inference. High token throughput
+# makes it a strong fit for latency-budgeted binder workloads; end-to-end
+# p50 still includes client/provider round-trip time, so callers should keep
+# their own wall-clock budget. Provider-level pricing here is a coarse
+# default; per-model rows under [models.X] hold the authoritative numbers
+# from the Cerebras pricing page.
 [providers.cerebras]
 base_url = "https://api.cerebras.ai/v1"
 base_url_env = "CEREBRAS_BASE_URL"
@@ -166,7 +167,7 @@ chat_endpoint = "/chat/completions"
 completion_endpoint = "/completions"
 cost_per_1k_in = 0.00025
 cost_per_1k_out = 0.00069
-latency_p50_ms = 80
+latency_p50_ms = 150
 features = ["native_tools"]
 
 [providers.cerebras.healthcheck]
@@ -884,11 +885,11 @@ context_window = 131072
 capabilities = ["tools", "streaming"]
 pricing = { input_per_mtok = 0.15, output_per_mtok = 0.60 }
 
-# Cerebras-hosted open-weight models. Pricing snapshot from
-# https://www.cerebras.ai/pricing (2026-05). The headline binder-substrate
-# candidate is gpt-oss-120b at ~3,000 tok/s; Llama 3.3 70B trails at
-# ~2,100 tok/s but is included as a fallback when the binder hop wants
-# function-calling-trained Llama instead of GPT-OSS.
+# Cerebras-hosted open-weight models. Per-model pricing mirrors the public
+# pricing catalog. The headline binder-substrate candidate is gpt-oss-120b
+# at very high token throughput; Llama 3.3 70B is included as a fallback
+# when the binder hop wants function-calling-trained Llama instead of
+# GPT-OSS.
 #
 # Catalog keys are bare wire IDs (Cerebras's /v1/chat/completions wants
 # the raw model name). Users routing via `model: "cerebras/<name>"` get

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -2975,12 +2975,15 @@ Nine opinionated modules wrap common LLM patterns:
 - `std/llm/tool_binder` — experimental natural-language tool binder
   middleware (`with_natural_language_executor`). OFF by default; opt in
   via `compose_tool_callers`. Hands the planner-emitted intent + tool
-  JSON Schema to a sub-100ms binder LLM (Cerebras GPT-OSS-120B is the
-  primary substrate) and replaces `tool_args` with the binder's
-  structured output. Hard wall-clock budget — overruns drop the hop and
-  pass through unchanged with `audit.binder.status = "timeout"`. See
-  the parent epic [#1696](https://github.com/burin-labs/harn/issues/1696)
-  for the experimental contract.
+  JSON Schema to a latency-budgeted binder LLM (Cerebras GPT-OSS-120B is
+  the primary accuracy substrate) and replaces `tool_args` with the
+  binder's structured output. Default `timeout_ms` is `500`; overruns
+  drop the hop and pass through unchanged with
+  `audit.binder.status = "timeout"`. Default `max_tokens` is `1024` so
+  reasoning binders have room to emit structured JSON after their
+  reasoning preamble. See the parent epic
+  [#1696](https://github.com/burin-labs/harn/issues/1696) for the
+  experimental contract.
 - `std/llm/ensemble` — multi-call quality strategies: `best_of_n`,
   `self_consistency`, `parallel_judge`, `debate`. Cites Wang 2022
   (arxiv:2203.11171) and Du 2023 (arxiv:2305.14325).

--- a/scripts/smoke_cerebras.harn
+++ b/scripts/smoke_cerebras.harn
@@ -3,8 +3,9 @@
  *
  * Issues `iterations` single-tool-call binder-style llm_call invocations
  * against `cerebras/gpt-oss-120b`, then reports p50, p99, and mean
- * wall-clock round-trip in milliseconds. Used as the empirical floor
- * for issue #1696's ≤100ms binder-budget claim.
+ * wall-clock round-trip in milliseconds. Keep the output tiny so the
+ * result reflects the provider + network floor before a binder prompt
+ * adds work.
  *
  * Run with `CEREBRAS_API_KEY` exported (e.g. via burin-code/.env):
  *

--- a/spec/provider-catalog/HarnProviderCatalog.swift
+++ b/spec/provider-catalog/HarnProviderCatalog.swift
@@ -349,7 +349,7 @@ public let harnProviderCatalogJSON = #"""
         "native_tools"
       ],
       "caveats": [],
-      "latency_p50_ms": 80
+      "latency_p50_ms": 150
     },
     {
       "id": "dashscope",

--- a/spec/provider-catalog/harn-provider-catalog.ts
+++ b/spec/provider-catalog/harn-provider-catalog.ts
@@ -247,7 +247,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
         "native_tools"
       ],
       "caveats": [],
-      "latency_p50_ms": 80
+      "latency_p50_ms": 150
     },
     {
       "id": "dashscope",

--- a/spec/provider-catalog/provider-catalog.json
+++ b/spec/provider-catalog/provider-catalog.json
@@ -107,7 +107,7 @@
         "native_tools"
       ],
       "caveats": [],
-      "latency_p50_ms": 80
+      "latency_p50_ms": 150
     },
     {
       "id": "dashscope",


### PR DESCRIPTION
## Summary

Closes #1696.

This finishes the parent natural-language binder epic by aligning the shipped opt-in middleware with the empirical run envelope from the child issues:

- raise `with_natural_language_executor` defaults to a 500ms wall-clock hop budget and 1024 response tokens so Cerebras/GPT-OSS-style reasoning binders can return structured JSON instead of truncating or timing out by default
- validate binder option types more strictly and normalize non-dict tool args before stripping the internal intent field
- update quickref, eval README, Cerebras latency-floor docs, and generated provider-catalog artifacts to stop claiming sub-100ms end-to-end behavior from a residential/runtime client
- add conformance coverage that asserts the new default timeout/token budget reaches the binder substrate

## Validation

- `cargo run --quiet --bin harn -- fmt --check crates/harn-stdlib/src/stdlib/llm/tool_binder.harn conformance/tests/integration/tool_binder_pipeline.harn scripts/smoke_cerebras.harn`
- `cargo run --quiet --bin harn -- check conformance/tests/integration/tool_binder_pipeline.harn`
- `cargo run --quiet --bin harn -- test conformance --filter integration/tool_binder_pipeline`
- `cargo test -q -p harn-cli eval_tool_calls --lib`
- `make check-provider-catalog`
- `cargo run --quiet --bin harn -- eval tool-calls --dataset conformance/tool-call-eval --planner mock:mock --output .harn-runs/tool-call-eval/issue-1696-smoke`
- `cargo run --quiet --bin harn -- eval tool-calls regression-check --current .harn-runs/tool-call-eval/issue-1696-smoke/summary.json --against conformance/tool-call-eval/baselines/mock-planner.summary.json --max-drop-pp 0`
- `make lint-test-patterns`
- local pre-commit and pre-push hooks passed

Note: affected Harn lint still reports the existing ambient-clock migration warnings for `now_ms`/`monotonic_ms`; the lint command exits successfully and the same warnings are already present in adjacent stdlib timing middleware.
