### PR TITLE
Pause tokio clock in monitor_wait_replays_recorded_terminal_result

### DIFF
--- a/crates/harn-vm/src/stdlib/monitors.rs
+++ b/crates/harn-vm/src/stdlib/monitors.rs
@@ -706,7 +706,7 @@ pipeline test(task) {
             .await;
     }
 
-    #[tokio::test(flavor = "current_thread")]
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn monitor_wait_replays_recorded_terminal_result() {
         tokio::task::LocalSet::new()
             .run_until(async {


### PR DESCRIPTION
## Summary

`monitor_wait_replays_recorded_terminal_result` was flagged as flaky by the CH-10 agent (PR #2029): passes in isolation, fails under concurrent workspace test runs.

Root cause: the test ran with real wall-clock semantics (`#[tokio::test(flavor = \"current_thread\")]` without `start_paused = true`). Under CPU contention, the `timeout: 500ms` / `poll_interval: 10ms` budget could be exhausted before the poll closure ran.

Sibling tests in the same module that drive `wait_for(...)` already use `start_paused = true` for exactly this reason — this test was the lone outlier.

## Test plan

- [x] Test passes 5/5 sequential runs.
- [x] Test passes under `--test-threads 8` parallel run.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)