### PR TITLE
Add channels docs + cookbook (#1880)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,30 @@ condensed series summaries instead of full per-patch history.
 
 [acp-1726]: https://github.com/agentclientprotocol/agent-client-protocol/discussions/1726
 
+- **Channels docs + cookbook (CH-09, #1880).** Adds the user-facing
+  reference + cookbook for durable agent channels (epic #1870). New
+  mdBook page `docs/src/agent-channels.md` covers the emit surface
+  (scopes, idempotency, signed timestamps), the `channel.emit`
+  trigger source, the `batch { count, window, key, expire_action }`
+  aggregation primitive, the `ReminderInject` handler variant, the
+  guardrails middleware layer (CH-11), three observability topics,
+  the `HARN-CHN-*` diagnostic codes, and a SOTA comparison table
+  (Inngest, Temporal, Restate, A2A) explaining the design rationale.
+  New `docs/src/cookbooks/channels.md` ships five end-to-end recipes:
+  release handshake (PR agent → batched release agent →
+  merge-captain subscribers), periodic check-in via batched tool-call
+  counting + `ReminderInject`, multi-agent feedback loop (planner +
+  reviewers), tenant-scoped pipeline progress dashboard, and
+  cross-pipeline coordination via drain handoff. Extends the "Durable
+  agent channels" section in `docs/llm/harn-quickref.md` with the
+  trigger + batch + ReminderInject surface, a four-row pick-the-right-
+  primitive comparison table (handoffs vs triggers vs suspend/resume
+  vs channels vs channels+batch+reminder), the `HARN-CHN-*` and
+  `HARN-REP-CHN-*` code lists, and a guardrails one-liner. Adds a
+  "Durable agent channels" subsection to `spec/HARN_SPEC.md` (with
+  formal `ChannelScope`, `BatchFilter`, `ReminderInjectHandler`
+  shapes) plus the `HARN-CHN-*` block in the diagnostic appendix.
+  Wires the new pages into `docs/src/SUMMARY.md` under Orchestration.
 - **OAuth docs + provider cookbook (OA-08, #1909).** Adds
   `docs/src/oauth.md` as the user-facing reference for the full OAuth
   stack (`std/oauth/{providers,storage,client,device_flow,dynamic_registration,redaction}`),

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -1752,6 +1752,75 @@ Each stored event includes `id`, fully resolved `name`, `payload`,
 original `event_id`. Use `channel_events(name, options?)` for tests and local
 inspection.
 
+Subscribe to channel emits with a `channel.emit` trigger (provider
+`channel`). `match.events` accepts `"channel:<name>"` selectors:
+
+```harn,ignore
+import { trigger_register } from "std/triggers"
+
+trigger_register({
+  id: "release-on-pr-merge",
+  kind: "channel.emit",
+  provider: "channel",
+  match: {events: ["channel:pr.merged"]},
+  handler: { event -> kick_release(event.provider_payload.payload) },
+})
+```
+
+Add `batch: {count, window, key?, expire_action?}` to fire after N
+matching emits (Inngest-shape fire-after-N — no other major durable-
+execution platform owns this primitive). `key` is a dotted JSON path
+that partitions counters; `expire_action` is `"fire_partial"` (default)
+or `"discard"`. On dispatch `event.batch` holds the constituent events;
+the buffer is per-process thread-local, capped at 1024 events per
+partition, and replay reconstructs the batch from the recorded
+`constituent_event_ids`.
+
+```harn,ignore
+trigger_register({
+  id: "release-on-3-merges",
+  kind: "channel.emit",
+  provider: "channel",
+  match: {events: ["channel:pr.merged"]},
+  batch: {count: 3, window: "1h", key: "repo"},
+  handler: { event -> cut_release(event.batch) },
+})
+```
+
+Pair `batch` with `ReminderInject({target, body, tags?, ttl_turns?,
+dedupe_key?})` to land a periodic reminder on a running session
+without spawning or resuming it. `target` is `"current"`, `"parent"`,
+a literal session id, or a closure; `body` is a `.harn.prompt`
+template against `{{ event }}`, `{{ match }}`, and `{{ batch }}`.
+Missing targets drop gracefully with a `triggers.reminder_inject.audit`
+audit entry. See `docs/src/agent-channels.md` for the full surface
+and `docs/src/cookbooks/channels.md` for runnable recipes.
+
+Pick the right primitive:
+
+| Goal | Use |
+|---|---|
+| Hand off to one specific agent | Handoffs (`handoff(...)`, `@handoff`) |
+| Wait for an external event (GitHub, Slack, cron) | Provider trigger |
+| Park one agent until a specific event with a declared resume condition | Suspend/resume (`agent_await_resumption(reason, conditions)`) |
+| Emit a typed event to many subscribers | **Channels** (`emit_channel(...)`) |
+| Periodic reminder into a running loop | **Channels + `batch` + `ReminderInject`** |
+
+Diagnostic codes: `HARN-CHN-001` (`pipeline:` outside a pipeline),
+`HARN-CHN-002` (cross-tenant emit / disabled `org:`), `HARN-CHN-003`
+(malformed name), `HARN-CHN-004` (scope ambiguous —
+`options.session_id`/`pipeline_id` conflicts with active context),
+`HARN-CHN-005` (malformed `batch` config). Replay-oracle codes are
+`HARN-REP-CHN-001..003` — see `docs/src/observability/replay-benchmarks.md`.
+
+Channel guardrails (`channel_guardrail_register(config)` and
+`std/channel_guardrails` presets) run before the durable journal
+append. Each guardrail returns `allow` / `warn` / `block`; worst
+verdict wins; blocked emits never persist but the block decision does
+on `lifecycle.channel.audit`. Built-ins ship `prompt_injection_scanner`
+and `llm_risk_classifier`; `register_guardrail` accepts any custom
+closure.
+
 Pass `autonomy_budget` to cap how many autonomous decisions an agent can
 make per UTC hour / UTC day. The check fires at loop entry, before any
 LLM/MCP work — scripts can't bypass it. When the cap is exhausted,

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -116,6 +116,8 @@
 - [Trigger dispatcher](./triggers/dispatcher.md)
 - [Trigger registry](./triggers/registry.md)
 - [Webhook intake substrate](./triggers/webhook-intake.md)
+- [Agent channels](./agent-channels.md)
+  - [Channel cookbook](./cookbooks/channels.md)
 - [Orchestrator](./orchestrator.md)
 - [Hot reload](./orchestrator/hot-reload.md)
 - [Orchestrator DLQ management](./orchestrator/dlq.md)

--- a/docs/src/agent-channels.md
+++ b/docs/src/agent-channels.md
@@ -1,0 +1,384 @@
+# Agent channels
+
+Agent channels are a typed, durable pub/sub primitive for orchestrating
+multiple agents (and the triggers that watch them). One agent calls
+`emit_channel(name, payload)`; any number of subscribers — declared as
+`channel.emit` triggers — react. Channel events land on the active
+EventLog, so they survive process restarts, feed the replay oracle, and
+show up in the action graph alongside webhook and cron events.
+
+This page covers the channel surface end to end. For a one-screen LLM
+quickref see the "Durable agent channels" section in
+`docs/llm/harn-quickref.md`. For runnable patterns see
+[Channel cookbook](./cookbooks/channels.md).
+
+## When to use channels
+
+Channels are one of four ways to wire agents to events in Harn. Pick the
+narrowest one that fits.
+
+| Goal | Use | Why |
+|---|---|---|
+| Hand off a request to one specific agent | Handoffs (`handoff(...)`, `@handoff`) | Single producer, single typed receiver. No fan-out, no buffering. |
+| React to an external system (GitHub, Slack, cron, Kafka) | Triggers with a provider source | The trigger system already owns signature checks, dedupe, replay, and DLQ for external traffic. |
+| Park one running agent until a specific external event arrives | Suspend/resume with `agent_await_resumption(reason, conditions)` | The waiting agent keeps its transcript; you only need a resume condition, not a long-lived subscriber. |
+| Emit a typed event to N subscribers — including triggers that may not exist yet | **Channels** (`emit_channel(...)` + `channel.emit` trigger) | One producer, many consumers, durable journal, replay-compatible. |
+| Inject a periodic prompt into a running agent loop | **Channels + `batch` + `ReminderInject`** | Aggregate N emits into one reminder, dropped onto the target session at its next turn boundary. |
+
+Two anti-patterns worth calling out:
+
+- **Channels are not in-process queues.** They write to the durable
+  EventLog and fire the trigger dispatcher. If you want a fast
+  intra-pipeline mailbox, use `channel(...)` / `send` / `receive` (the
+  concurrency channel primitive — see `docs/src/concurrency.md`).
+- **Channels are not RPC.** There is no return value beyond the emit
+  receipt. If you need an answer back, the consumer emits a second
+  channel and the original producer subscribes to it (recipe 3 below).
+
+## Emit a channel
+
+`emit_channel(name, payload, options?)` appends one channel event and
+returns a receipt:
+
+```harn,ignore
+let receipt = emit_channel("pr.merged", {
+  repo: "burin-labs/harn",
+  number: 1984,
+  sha: "3e949640",
+})
+println(receipt.event_id)
+println(receipt.name_resolved)  // "tenant:default:pr.merged"
+println(receipt.emitted_at.signature.starts_with("sha256:"))
+```
+
+The receipt shape is:
+
+```text
+{
+  event_id: string,           // log id, unique per emit
+  id: string,                 // idempotency id (= options.id when set)
+  name_resolved: string,      // "<scope>:<scope_id>:<name>"
+  scope: "session" | "pipeline" | "tenant",
+  scope_id: string,
+  emitted_at: {at_ms, at, algorithm, key_id, signature},
+  emitted_by: string,
+  retention: "process" | "durable",
+  duplicate: bool,            // true when options.id collided with a prior emit
+}
+```
+
+### Scopes
+
+A bare name resolves to **tenant** scope: `emit_channel("pr.merged",
+payload)` is `tenant:<current-tenant-or-default>:pr.merged`. Add a
+prefix to pick a different scope:
+
+| Prefix | Resolved name | When |
+|---|---|---|
+| (none) | `tenant:<current>:<name>` | Default. Cross-session, cross-pipeline within a tenant. |
+| `session:<name>` | `session:<current-session>:<name>` | In-process, single agent session. Cleared with `reset_channel_state()`. |
+| `pipeline:<name>` | `pipeline:<current-pipeline>:<name>` | Scoped to one pipeline run. Requires an active pipeline context. |
+| `tenant:<tenant_id>:<name>` | `tenant:<tenant_id>:<name>` | Explicit tenant — must match the active tenant or fail `HARN-CHN-002`. |
+| `org:<org_id>:<name>` | — | Reserved. Currently fails `HARN-CHN-002` until org grants ship. |
+
+Scope id can also be passed as an option:
+
+```harn,ignore
+emit_channel("worker.ready", {worker: "lint"}, {
+  scope: "session",
+  session_id: "review-bot-123",
+  id: "worker-ready-lint",  // idempotency key
+  ttl: 10m,                 // event-log retention hint
+})
+```
+
+Cross-scope isolation is automatic: distinct `tenant_id`, `session_id`,
+or `pipeline_id` values resolve to distinct topics, so a reader against
+the wrong scope id sees an empty view.
+
+### Idempotency
+
+Setting `options.id` makes the emit idempotent. Re-emitting the same
+(`name_resolved`, `id`) pair is a no-op on the journal; the receipt is
+returned with `duplicate: true` and the original `event_id`. This is
+load-bearing for replay determinism (CH-07): a replayed pipeline that
+re-emits the same event sees the same receipt.
+
+### Signed timestamps
+
+Every emit carries `emitted_at = {at_ms, at, algorithm, key_id,
+signature}`. The signature is HMAC-SHA-256 over the canonical material
+`(at_ms, event_id, name_resolved, scope, scope_id, emitted_by)`, with a
+per-process salt. The replay oracle uses this to detect timestamp
+tampering during cross-run comparisons.
+
+### Reading events back
+
+`channel_events(name, options?)` returns the stored events oldest-first
+for tests, diagnostics, and local orchestration inspection:
+
+```harn,ignore
+let events = channel_events("pr.merged", {limit: 10})
+for event in events {
+  println(event.payload.repo)
+}
+```
+
+`from_cursor` (or `cursor`) resumes after a specific event id; `limit`
+caps the returned size. This is **not** a subscription — for live
+delivery, register a trigger (next section) or subscribe to the
+EventLog topic directly with `event_log.subscribe`.
+
+## Subscribe via triggers
+
+A `channel.emit` trigger reacts to one or more channel names. Inside
+the trigger, `match.events` lists the channel selectors:
+
+```harn,ignore
+import { trigger_register } from "std/triggers"
+
+trigger_register({
+  id: "release-on-pr-merge",
+  kind: "channel.emit",
+  provider: "channel",
+  handler: { event ->
+    println("PR merged: " + to_string(event.provider_payload.payload.number))
+  },
+  match: {events: ["channel:pr.merged"]},
+})
+```
+
+Selector forms:
+
+- `"channel:<name>"` — bare name; subscribes within the current scope
+  (tenant by default).
+- `"channel:session:<name>"`, `"channel:pipeline:<name>"`,
+  `"channel:tenant:<tenant_id>:<name>"` — explicit scope match.
+
+Trigger handlers can be:
+
+- A closure `event -> any`.
+- A handler-variant dict like `SpawnToPool({...})`, `ReminderInject({...})`,
+  or `InterruptAndSuspend({...})`.
+- An `a2a://` or `worker://` URI (forwards the event to a remote worker).
+
+See `docs/src/triggers.md` for the full trigger surface; see
+`docs/llm/harn-triggers-quickref.md` for the manifest equivalent.
+
+### Filtering
+
+A `when` predicate runs before dispatch:
+
+```harn,ignore
+trigger_register({
+  id: "release-on-prod-merge",
+  kind: "channel.emit",
+  provider: "channel",
+  match: {events: ["channel:pr.merged"]},
+  when: { event -> event.provider_payload.payload.target_branch == "main" },
+  handler: { event -> kick_release(event) },
+})
+```
+
+The trigger event's `provider_payload.payload` is the channel emit's
+`payload` argument verbatim.
+
+## Batching: aggregate N emits before firing
+
+`batch { count, window, key, expire_action }` turns a trigger into a
+fire-after-N-events aggregator. The trigger only dispatches once
+`count` events have arrived (or the window expires, depending on
+`expire_action`).
+
+```harn,ignore
+trigger_register({
+  id: "release-on-3-merges",
+  kind: "channel.emit",
+  provider: "channel",
+  match: {events: ["channel:pr.merged"]},
+  batch: {count: 3, window: "1h", key: "repo", expire_action: "fire_partial"},
+  handler: { event ->
+    let merged = event.batch
+    println("Cutting release with " + to_string(len(merged)) + " merged PRs")
+  },
+})
+```
+
+Batch options:
+
+| Option | Type | Default | Notes |
+|---|---|---|---|
+| `count` | positive int | required | Fire after this many events. |
+| `window` | duration string (`"10m"`, `"1h"`) | required | Time budget; counter resets on every fire. |
+| `key` | string dotted JSON path | none | Each distinct value at this path keeps an independent counter. Missing paths fall back to one shared bucket. |
+| `expire_action` | `"fire_partial"` \| `"discard"` | `"fire_partial"` | When the window elapses with fewer than `count` events, fire with the partial buffer or drop it silently. |
+
+On dispatch the handler receives a `TriggerEvent` whose `event.batch`
+is the full list of constituent channel events; `event` itself is the
+*last* event that closed the batch. Replay reconstructs the batch from
+the recorded `constituent_event_ids` on the match receipt.
+
+State is per-process and lives in a thread-local registry keyed by
+`(binding, partition_key)`. The buffer is capped at 1024 events per
+partition; overflow drops the oldest entries with a structured
+`triggers.aggregation.buffer_overflow` warning.
+
+Window expiration is driven by two mechanisms:
+
+1. **Implicit sweep** — every channel emit first drains expired buffers
+   before fanning the new event out, so wall-clock advance is enough
+   when emits keep arriving.
+2. **Explicit flush** — `flush_trigger_aggregations()` drains every
+   expired buffer immediately. Tests pair this with `mock_time(ms)` /
+   `advance_time(ms)` for deterministic coverage.
+
+Diagnostic codes:
+
+| Code | When |
+|---|---|
+| `HARN-CHN-005` | Malformed `batch` config (missing `count`/`window`, non-positive count, unknown `expire_action`, bad `key` type). |
+
+## Periodic reminders: `ReminderInject`
+
+`ReminderInject` (#1876) is a handler variant that injects a typed
+[`system_reminder`](./system-reminders.md) into the target session's
+transcript at the next turn boundary — no spawn, no resume, no signal.
+Pair it with `batch` to land a single reminder per N emits, useful for
+"reflect every 30 tool calls" or "after 3 build failures, ask the agent
+to step back."
+
+```harn,ignore
+import { ReminderInject } from "std/triggers"
+
+trigger_register({
+  id: "reflect-after-30-tools",
+  kind: "channel.emit",
+  provider: "channel",
+  match: {events: ["channel:tool_call.completed"]},
+  batch: {count: 30, window: "1h"},
+  handler: ReminderInject({
+    target: "current",
+    body: "You've used 30 tools without a checkpoint. Take a turn to reflect on progress and adjust the plan.",
+    tags: ["reflection_nudge"],
+    ttl_turns: 1,
+    dedupe_key: "reflection_nudge",
+  }),
+})
+```
+
+`ReminderInject` options:
+
+| Option | Notes |
+|---|---|
+| `target` | `"current"` walks the owning session, `"parent"` walks its parent in the session lineage, any other string is a literal session id, and a closure `event -> string?` lets the trigger pick a target dynamically. |
+| `body` | A `.harn.prompt` template rendered against `{{ event }}` (full trigger event), `{{ match }}` (`matched_at`), and `{{ batch }}` (when batching is in effect). |
+| `tags`, `ttl_turns`, `dedupe_key`, `propagate`, `role_hint`, `preserve_on_compact` | Mirror `transcript.inject_reminder` semantics — see [system reminders](./system-reminders.md). |
+
+Missing target sessions are dropped gracefully with a
+`triggers.reminder_inject.audit` audit entry rather than failing
+dispatch.
+
+## Guardrails
+
+Channel emits run through a pluggable guardrail middleware layer before
+the durable journal append (CH-11). Each guardrail returns one of:
+
+- `allow` — silent passthrough.
+- `warn` — emit proceeds and a `channel_guardrail_warning` lifecycle
+  audit is recorded.
+- `block` — emit is dropped, the caller receives a synthetic
+  `{blocked: true, block_reason, guardrail_fired}` receipt, and a
+  `channel_guardrail_blocked` audit is persisted to both the
+  `lifecycle.channel.audit` topic and the in-process lifecycle audit
+  log.
+
+Worst verdict wins; a `block` short-circuits remaining guardrails.
+
+Register guardrails with `channel_guardrail_register(config)`:
+
+```harn,ignore
+import { prompt_injection_scanner, register_guardrail } from "std/channel_guardrails"
+
+// Built-in: heuristic prompt-injection signature scan.
+let pi_id = prompt_injection_scanner({})
+
+// Custom: any closure returning nil / "allow" | "warn" | "block" / {verdict, reason?}.
+let custom_id = register_guardrail({
+  id: "block-secrets-in-payload",
+  applies_to: ["channel:learnings.*"],
+  evaluate: { payload, context ->
+    if to_string(payload).contains("sk-") {
+      return {verdict: "block", reason: "looks like an API key"}
+    }
+    return "allow"
+  },
+})
+```
+
+The registry is thread-local so peer pipelines on other threads cannot
+poison each other; `reset_channel_state()` clears it.
+
+## Observability
+
+Channels produce three observable streams. Pick the one that matches the
+consumer:
+
+| Topic | Purpose | Schema |
+|---|---|---|
+| `lifecycle.channel.audit` | Durable replay/audit. Receipts for every emit + every match + every guardrail verdict. | `harn.channel_emit_receipt.v1`, `harn.channel_match_receipt.v1`, `harn.channel_guardrail_audit.v1` |
+| `transcript.channel.lifecycle` | Live transcript rendering. One event per emit and per match, summarized for UI. | `transcript.channel.emit`, `transcript.channel.match` |
+| Per-channel `channels.<scope>.<scope_id>.<name>` | The events themselves, for `event_log.subscribe(...)`. | The `StoredChannelEvent` envelope. |
+
+OTel spans wrap every emit (`channel.emit <resolved_name>`) and every
+match (`channel.match <resolved_name>`). Match spans link back to the
+emit span via trace/span ids propagated on the trigger event headers,
+which also carries through `batch` aggregation so a batched match links
+to all constituent emits.
+
+The replay oracle uses the `lifecycle.channel.audit` topic to detect:
+
+- `HARN-REP-CHN-001` — replay matched an `event_id` that has no recorded receipt.
+- `HARN-REP-CHN-002` — payload hash drift on a replayed emit.
+- `HARN-REP-CHN-003` — batched match constituent ids differ across runs.
+
+See `docs/src/observability/replay-benchmarks.md` for the oracle
+interface.
+
+## Diagnostic codes
+
+| Code | When |
+|---|---|
+| `HARN-CHN-001` | `pipeline:` scope used outside any pipeline context. |
+| `HARN-CHN-002` | Cross-tenant emit without a grant, or `org:` scope (disabled in v1). |
+| `HARN-CHN-003` | Malformed channel name, scope prefix, or scope id. |
+| `HARN-CHN-004` | Scope ambiguous — explicit `options.session_id` or `options.pipeline_id` conflicts with the active runtime context. |
+| `HARN-CHN-005` | Malformed `batch` config on a `trigger_register` call. |
+
+## Design rationale
+
+Channels close two gaps that no major durable-execution platform owns
+end to end:
+
+| System | Pub/sub between agents? | Fire-after-N-events? | Periodic reminders? |
+|---|---|---|---|
+| Inngest | Yes (events) | **Yes (`step.waitForEvent` + count)** | No |
+| Temporal | Signals (per-workflow) | No first-class primitive | No |
+| Restate | Awakeables (per-invocation) | No | No |
+| A2A | Push notifications | No | No |
+| **Harn** | **Yes** | **Yes** | **Yes (`ReminderInject`)** |
+
+The wager is that agent orchestration needs all three — typed pub/sub,
+declarative batching, and turn-boundary reminder injection — and that
+hosting them in one primitive (durable channels) keeps the trust
+boundary (Harn owns the journal; hosts own UX) and the replay model
+(`lifecycle.channel.audit` is the byte-comparable spec) intact.
+
+Cross-references:
+
+- [Channel cookbook](./cookbooks/channels.md) — five end-to-end recipes.
+- [System reminders](./system-reminders.md) — the reminder primitive
+  `ReminderInject` injects into.
+- [Triggers](./triggers.md) — the general trigger surface that channel
+  subscriptions plug into.
+- Issue [#1870](https://github.com/burin-labs/harn/issues/1870) — the
+  epic this primitive lands under.

--- a/docs/src/cookbooks/channels.md
+++ b/docs/src/cookbooks/channels.md
@@ -1,0 +1,350 @@
+# Channel cookbook
+
+Five end-to-end patterns for agent channels (#1870). Each recipe is a
+complete, copy-paste starting point. For the surface reference see
+[Agent channels](../agent-channels.md); for the LLM-friendly quickref
+see the "Durable agent channels" section in `docs/llm/harn-quickref.md`.
+
+The recipes use `harn,ignore` fences because they show full
+multi-agent topologies (publisher pipeline + subscriber pipeline). Each
+fragment type-checks; the orchestration loop assumes a host that runs
+both pipelines (such as `harn orchestrator`).
+
+## 1. Release handshake
+
+One agent waits for another's emit before proceeding. The PR agent
+emits `pr.merged` on each merge; a release agent batches three of them
+into a single release run; downstream merge-captain agents in
+burin-code and harn-cloud subscribe to the release's
+`harn-release.shipped` event so they can rebase their queues.
+
+```harn,ignore
+import { trigger_register } from "std/triggers"
+
+// --- harn-pr-agent ---
+pipeline pr_agent_on_merge(pr) {
+  emit_channel("pr.merged", {
+    repo: "burin-labs/harn",
+    number: pr.number,
+    sha: pr.merge_commit_sha,
+    target_branch: pr.target_branch,
+  })
+}
+
+// --- release agent ---
+pipeline release_agent_setup() {
+  trigger_register({
+    id: "release-after-3-merges",
+    kind: "channel.emit",
+    provider: "channel",
+    match: {events: ["channel:pr.merged"]},
+    when: { event -> event.provider_payload.payload.target_branch == "main" },
+    batch: {count: 3, window: "2h", key: "repo", expire_action: "fire_partial"},
+    handler: { event ->
+      let merged = event.batch
+      let repo = merged[0].provider_payload.payload.repo
+      let shas = merged
+        |> map({ e -> e.provider_payload.payload.sha })
+      let release = cut_release(repo, shas)
+      emit_channel("harn-release.shipped", {
+        repo: repo,
+        version: release.version,
+        merged_prs: len(merged),
+      })
+    },
+  })
+}
+
+// --- merge captains in burin-code / harn-cloud ---
+pipeline merge_captain_setup() {
+  trigger_register({
+    id: "rebase-on-harn-release",
+    kind: "channel.emit",
+    provider: "channel",
+    match: {events: ["channel:harn-release.shipped"]},
+    handler: { event ->
+      let release = event.provider_payload.payload
+      rebase_queued_prs_against(release.version)
+    },
+  })
+}
+```
+
+Why channels over a direct handoff: there is no single named recipient.
+The release agent doesn't know about merge captains, and each
+downstream service registers its own subscriber. The journal is the
+contract.
+
+Why `batch` over a counter in the handler: the count is process state;
+the buffer is durable. A restart between PRs 2 and 3 doesn't lose the
+batch.
+
+Why a signed receipt: the replay oracle verifies the same three SHAs
+fire the same release across two runs of the same pipeline. See
+[CH-07 replay receipts](../agent-channels.md#observability).
+
+## 2. Periodic check-in via tool-call counting
+
+Inject a reflection prompt into a running agent loop every 30 tool
+calls. The agent emits `tool_call.completed` on each tool use (via a
+tool hook); a batched trigger drops a reminder onto the same session
+when the counter hits 30.
+
+```harn,ignore
+import { trigger_register, ReminderInject } from "std/triggers"
+
+pipeline reflection_agent(task) {
+  // 1. Emit a channel event from a tool hook so we don't have to
+  //    instrument every tool definition by hand.
+  register_tool_hook({
+    pattern: "*",
+    post: { ctx ->
+      emit_channel("tool_call.completed", {
+        tool: ctx.tool_name,
+        session: ctx.session_id,
+      })
+      return nil
+    },
+  })
+
+  // 2. Subscribe to the channel with a batched ReminderInject. The
+  //    reminder lands on the *same* session at the next turn boundary.
+  trigger_register({
+    id: "reflect-every-30-tools",
+    kind: "channel.emit",
+    provider: "channel",
+    match: {events: ["channel:tool_call.completed"]},
+    batch: {count: 30, window: "1h", key: "session"},
+    handler: ReminderInject({
+      target: "current",
+      body: "You have used 30 tools without a checkpoint. Take this turn to summarize progress, re-read the spec, and adjust the plan if needed.",
+      tags: ["reflection_nudge"],
+      ttl_turns: 1,
+      dedupe_key: "reflection_nudge",
+    }),
+  })
+
+  // 3. Run the loop. The reflection nudge arrives transparently.
+  agent_loop(task, "You are a careful engineering agent. Reflect when nudged.")
+}
+```
+
+Why channels + `batch` + `ReminderInject` over a `post_turn_callback`
+counter: the callback runs after every turn; this fires after every 30
+tool *uses* regardless of how they distribute across turns. Two tools
+in turn N and 28 across turn N+1 trips at the same point. The batch
+counter resets cleanly after fire, and the durable buffer survives a
+worker restart.
+
+Why `dedupe_key`: if the agent stalls mid-reflection and 30 more tools
+are dispatched, the next reminder replaces (rather than stacks on) the
+pending one.
+
+## 3. Multi-agent feedback loop
+
+A planner agent drafts a plan; reviewer agents critique it; the
+planner subscribes to the critiques and revises. Channels make this a
+declarative cycle rather than a hand-rolled coordination dance.
+
+```harn,ignore
+import { trigger_register, ReminderInject } from "std/triggers"
+
+// --- planner ---
+pipeline planner_loop(task) {
+  let session = agent_session_open("planner")
+  let draft = llm_call(task, "Write a one-page plan.", {session_id: session})
+  emit_channel("plan.draft", {
+    plan: draft,
+    revision: 1,
+    session_id: session,
+  })
+
+  // Watch for reviewer feedback addressed at our session.
+  trigger_register({
+    id: "planner-on-feedback-" + session,
+    kind: "channel.emit",
+    provider: "channel",
+    match: {events: ["channel:plan.feedback"]},
+    when: { event -> event.provider_payload.payload.target_session == session },
+    handler: ReminderInject({
+      target: session,
+      body: "Reviewer feedback: {{ event.provider_payload.payload.critique }}",
+      tags: ["plan_feedback"],
+      ttl_turns: 2,
+    }),
+  })
+
+  agent_loop(task, "Revise the plan when reminders arrive. Re-emit plan.draft when revision is complete.", {session_id: session})
+}
+
+// --- reviewers ---
+pipeline reviewer_setup() {
+  trigger_register({
+    id: "reviewer-on-draft",
+    kind: "channel.emit",
+    provider: "channel",
+    match: {events: ["channel:plan.draft"]},
+    handler: { event ->
+      let draft = event.provider_payload.payload
+      let critique = llm_call(
+        "Critique this plan in 3 bullets:\n" + draft.plan,
+        "You are a careful reviewer.",
+      )
+      emit_channel("plan.feedback", {
+        target_session: draft.session_id,
+        critique: critique,
+        revision: draft.revision,
+      })
+    },
+  })
+}
+```
+
+Why channels over handoffs: both directions are 1-to-N — multiple
+reviewers, multiple revision rounds — and neither side knows the
+others' session ids ahead of time. The `target_session` field in the
+feedback payload + a `when` predicate routes each critique back to the
+right planner without a central registry.
+
+Why `ReminderInject` for the inbound feedback: the planner is *already
+running* in `agent_loop`. Spawning a new task would lose its
+transcript; injecting a reminder lets it incorporate the critique on
+the next turn.
+
+## 4. Pipeline progress dashboard
+
+Every step in every pipeline emits `pipeline.step.completed`; a
+monitoring agent tenant-wide subscribes and maintains a live
+dashboard. The producers don't know the monitor exists — they just
+emit.
+
+```harn,ignore
+import { trigger_register } from "std/triggers"
+import { register_step_hook } from "std/hooks"
+
+// --- producers: any pipeline registering this hook gets free instrumentation ---
+pipeline producer_setup() {
+  register_step_hook({
+    pattern: "*",
+    post: { ctx ->
+      emit_channel("pipeline.step.completed", {
+        pipeline: ctx.pipeline_name,
+        step: ctx.step_name,
+        duration_ms: ctx.duration_ms,
+        success: ctx.success,
+      })
+      return nil
+    },
+  })
+}
+
+// --- dashboard: one subscriber, scoped to the whole tenant ---
+pipeline dashboard_setup() {
+  trigger_register({
+    id: "dashboard-on-step",
+    kind: "channel.emit",
+    provider: "channel",
+    // Bare channel names default to tenant scope, so this catches
+    // emits from any pipeline running for this tenant.
+    match: {events: ["channel:pipeline.step.completed"]},
+    handler: { event ->
+      let row = event.provider_payload.payload
+      dashboard_upsert(row.pipeline, row.step, {
+        last_run_at: event.occurred_at,
+        last_duration_ms: row.duration_ms,
+        last_success: row.success,
+      })
+    },
+  })
+}
+```
+
+Why tenant scope: a bare `emit_channel("pipeline.step.completed",
+...)` resolves to `tenant:<current>:pipeline.step.completed`. The
+dashboard subscribes to the same name without prefix and automatically
+receives emits from every pipeline running for that tenant. Cross-
+tenant isolation is automatic — a sibling tenant's emits go to a
+different topic.
+
+Why a trigger over `event_log.subscribe`: triggers carry the
+dispatcher's retry policy, DLQ routing, and replay receipts. If the
+dashboard handler throws, the channel emit still lands cleanly on
+`lifecycle.channel.audit`; the failed match goes to `trigger.dlq`.
+
+## 5. Cross-pipeline coordination via drain handoff
+
+Pipeline A processes work synchronously up to a watermark, then drains
+deferred items by emitting a channel event. A nightly settlement
+pipeline (B) subscribes and picks up the deferred work.
+
+```harn,ignore
+import { trigger_register } from "std/triggers"
+import { pipeline_on_finish } from "std/lifecycle"
+
+// --- pipeline A: live ingest ---
+pipeline ingest_pipeline(events) {
+  let deferred = []
+  for event in events {
+    let result = try_process_now(event)
+    if result.deferred {
+      deferred = deferred + [event]
+    }
+  }
+
+  // On clean drain, hand the deferred bucket off to pipeline B.
+  pipeline_on_finish({ ctx ->
+    if ctx.status == "completed" && len(deferred) > 0 {
+      emit_channel("pipeline.drained", {
+        source_pipeline: "ingest",
+        deferred_count: len(deferred),
+        deferred_payload: deferred,
+        drained_at: timestamp(),
+      })
+    }
+  })
+}
+
+// --- pipeline B: nightly settlement ---
+pipeline settlement_setup() {
+  trigger_register({
+    id: "settlement-on-drain",
+    kind: "channel.emit",
+    provider: "channel",
+    match: {events: ["channel:pipeline.drained"]},
+    when: { event -> event.provider_payload.payload.source_pipeline == "ingest" },
+    handler: { event ->
+      let bucket = event.provider_payload.payload.deferred_payload
+      for deferred in bucket {
+        settle(deferred)
+      }
+    },
+  })
+}
+```
+
+Why channels over a queue table: the `lifecycle.channel.audit` receipt
+is the durable contract. Pipeline B doesn't need a polling loop or a
+DB cursor; the dispatcher delivers exactly once per emit (subject to
+the normal trigger retry policy), and the replay oracle can reproduce
+the handoff across two runs.
+
+Why `pipeline_on_finish` rather than emitting inline: a partial drain
+on a failure mid-loop would publish an inconsistent bucket. Emitting
+from the finish hook ensures pipeline A reached a clean terminal state
+first.
+
+## Picking the right primitive
+
+For any of these recipes, the wrong tool is also worth knowing:
+
+- **Don't use `channel(...) + send/receive`** (the in-process
+  concurrency channel) for cross-pipeline or cross-process pub/sub —
+  it lives only inside one VM. Reach for `emit_channel` whenever the
+  publisher and subscriber could be different runs.
+- **Don't use a webhook trigger for in-cluster events.** Webhook
+  triggers carry HMAC verification and delivery-id dedupe that are
+  pointless for trusted internal emits. Channels short-circuit both.
+- **Don't use suspend/resume for "wake me when N things happen."** A
+  suspended worker holds its transcript and process slot. Use a
+  `batch` trigger + `ReminderInject` so the worker keeps running and
+  only the reminder arrives.

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -1911,6 +1911,175 @@ Regular functions that contain `yield` keep producing `Generator<T>`;
 `gen fn` produces `Stream<T>`. Throws inside a stream body propagate to
 the consumer at the pull site (`for`, `.next()`, or `.iter()`).
 
+### Durable agent channels
+
+Durable agent channels (epic #1870) are distinct from the in-process
+`channel(...)` primitive above. Where in-process channels are typed
+mailboxes between concurrent tasks inside one VM, durable channels are
+a typed pub/sub primitive that writes to the active EventLog and fans
+each emit out to every matching `channel.emit` trigger binding. They
+survive process restarts, feed the replay oracle, and show up in the
+action graph alongside webhook and cron events.
+
+#### Emit
+
+The runtime exposes two builtins. `emit_channel(name, payload,
+options?)` appends one event to the channel's EventLog topic and
+returns a `ChannelEmitReceipt`. `channel_events(name, options?)` reads
+the topic oldest-first for tests and diagnostics. Reference shapes are
+in `docs/src/builtins.md`; full prose is in `docs/src/agent-channels.md`.
+
+A channel `name` resolves into the canonical form
+`<scope>:<scope_id>:<name>`. Bare names default to **tenant** scope
+(`tenant:<current-tenant-or-default>:<name>`). Prefixes select an
+explicit scope: `session:<name>`, `pipeline:<name>`, `tenant:<name>`,
+`tenant:<tenant_id>:<name>`. The `org:<org_id>:<name>` prefix is
+reserved but currently rejected with `HARN-CHN-002` until org grants
+ship.
+
+#### `ChannelScope`
+
+The scope enum is:
+
+```text
+ChannelScope ::= "session" | "pipeline" | "tenant" | "org"
+```
+
+- `session` events live in a per-process in-memory log; they are
+  cleared by `reset_channel_state()` and do not cross process boundaries.
+- `pipeline` and `tenant` events use the active durable EventLog; the
+  resolver returns `HARN-CHN-001` if `pipeline:` is used without an
+  active pipeline context.
+- `org` is reserved; v1 always returns `HARN-CHN-002`.
+
+Cross-scope isolation is automatic: distinct `tenant_id`, `session_id`,
+or `pipeline_id` values resolve to distinct topics, so readers against
+the wrong scope id see an empty view. Explicit `options.session_id` or
+`options.pipeline_id` that conflict with the active runtime context
+fail with `HARN-CHN-004` rather than silently overriding.
+
+#### Idempotency and signed timestamps
+
+`options.id` makes the emit idempotent. Re-emitting the same
+(`name_resolved`, `id`) pair returns the original `event_id` with
+`duplicate: true`. The receipt's `emitted_at` field is a signed
+timestamp: HMAC-SHA-256 over `(at_ms, event_id, name_resolved, scope,
+scope_id, emitted_by)` with a per-process salt and `algorithm:
+"hmac-sha256"`. The replay oracle uses this to detect timestamp
+tampering across runs.
+
+#### `channel.emit` trigger source
+
+Trigger bindings subscribe to channel events with `provider: "channel"`,
+`kind: "channel.emit"`, and `match.events: ["channel:<selector>"]`.
+The selector accepts the same scope prefixes as `emit_channel`:
+
+```text
+ChannelSelector ::= "channel:" Name
+                  | "channel:session:" Name
+                  | "channel:pipeline:" Name
+                  | "channel:tenant:" TenantId ":" Name
+```
+
+The dispatched `TriggerEvent` carries the emit's `payload` verbatim at
+`event.provider_payload.payload`; `event.batch` is `nil` for ordinary
+single-event dispatches and populated for batched bindings (next
+section).
+
+#### `batch { count, window, key?, expire_action? }` (`BatchFilter`)
+
+A trigger binding may declare aggregation:
+
+```text
+BatchFilter ::= {
+  count: int (> 0),
+  window: DurationString,
+  key?: string,                  // dotted JSON path into payload
+  expire_action?: "fire_partial" | "discard"   // default "fire_partial"
+}
+```
+
+Semantics:
+
+- Each filter-passing event increments a per-(`binding`, `partition_key`)
+  counter. Reaching `count` invokes the handler with `event.batch`
+  populated to the buffered list and resets the counter.
+- `key` partitions counters by the stringified value at that JSON path
+  into the channel payload. Missing paths fall back to one shared
+  bucket (matches `SpawnToPool`'s "missing path = default" pattern).
+- When the window elapses without reaching `count`, `expire_action`
+  decides: `fire_partial` invokes the handler with whatever was
+  buffered; `discard` drops the buffer silently.
+- Buffers are per-process thread-local and capped at 1024 events per
+  partition. Overflow drops the oldest entries with a structured
+  `triggers.aggregation.buffer_overflow` warning.
+- Window expiration is driven by an implicit sweep at every emit and
+  by the explicit `flush_trigger_aggregations()` builtin; the latter
+  is the test affordance and pairs with `mock_time(...)` /
+  `advance_time(...)`.
+
+Malformed configs (missing fields, non-positive `count`, unknown
+`expire_action`, wrong-typed `key`) raise `HARN-CHN-005`.
+
+#### `ReminderInjectHandler`
+
+`ReminderInject(options)` (from `std/triggers`) constructs a handler-
+variant dict that, on match, injects a `SystemReminder` event (see
+`docs/src/system-reminders.md`) into the target session's transcript
+at the next turn boundary. It is the orthogonal counterpart to
+`SpawnToPool` — no spawn, no resume, no signal; the target session
+keeps running and receives the typed context at the next post-turn
+lifecycle pass.
+
+```text
+ReminderInjectHandler ::= {
+  kind: "reminder_inject",
+  target: "current" | "parent" | SessionId | (event -> SessionId?),
+  body: PromptTemplate,                    // .harn.prompt
+  tags?: list<string>,
+  ttl_turns?: int,
+  dedupe_key?: string,
+  propagate?: "none" | "session",
+  role_hint?: "user" | "developer",
+  preserve_on_compact?: bool
+}
+```
+
+`body` is rendered against `{{ event }}` (the full `TriggerEvent`),
+`{{ match }}` (`matched_at`), and `{{ batch }}` (the constituent list
+when batching is in effect). Missing target sessions are dropped
+gracefully with a `triggers.reminder_inject.audit` audit entry rather
+than failing dispatch.
+
+#### Observability
+
+Channel activity is published on three EventLog topics:
+
+| Topic | Schema | Purpose |
+|---|---|---|
+| `lifecycle.channel.audit` | `harn.channel_emit_receipt.v1`, `harn.channel_match_receipt.v1`, `harn.channel_guardrail_audit.v1` | Durable replay/audit. One receipt per emit, per match, and per guardrail verdict. |
+| `transcript.channel.lifecycle` | `transcript.channel.emit`, `transcript.channel.match` | Per-emit and per-match transcript events for live rendering. |
+| `channels.<scope>.<scope_id>.<name>` | `StoredChannelEvent` | The events themselves, addressable via `event_log.subscribe(...)`. |
+
+Every emit opens an OTel `channel.emit <name_resolved>` span; every
+match opens `channel.match <name_resolved>` and links back to the
+emit span via trace/span ids propagated on the trigger event headers
+(this propagation passes through `batch` aggregation, so a batched
+match links to all constituent emit spans).
+
+#### Replay determinism
+
+The replay oracle consumes `lifecycle.channel.audit` to detect:
+
+- `HARN-REP-CHN-001` — replay matched an `event_id` with no recorded receipt.
+- `HARN-REP-CHN-002` — payload hash drift on a replayed emit (producer-
+  side nondeterminism).
+- `HARN-REP-CHN-003` — batched match constituent ids differ across runs.
+
+See `docs/src/observability/replay-benchmarks.md` for the oracle
+interface. The user-facing reference is `docs/src/agent-channels.md`;
+runnable patterns live in `docs/src/cookbooks/channels.md`.
+
 ## Error model
 
 ### throw
@@ -4551,6 +4720,16 @@ programs.
 | `HARN-OAU-001` | A persisted sink redacted an OAuth-shaped token (transcript / receipt / OTel / system reminder). The original value still flows through to the tool — redaction is display-only. |
 | `HARN-OAU-002` | `std/oauth/client` cannot refresh because no `refresh_token` is in storage (or the server rejected the refresh). Re-run `start_authorization` / `device_flow`. |
 | `HARN-OAU-005` | `std/oauth/dynamic_registration` rejected a candidate client metadata document under RFC 7591 §2. |
+
+#### Durable agent channels diagnostics (`HARN-CHN-*`)
+
+| Code | Description |
+|---|---|
+| `HARN-CHN-001` | `pipeline:` scope used outside any active pipeline context. |
+| `HARN-CHN-002` | Cross-tenant `emit_channel` without a grant, or `org:` scope (disabled in v1 until org grants are available). |
+| `HARN-CHN-003` | Malformed channel name, scope prefix, or scope id. |
+| `HARN-CHN-004` | Scope ambiguous — explicit `options.session_id` or `options.pipeline_id` conflicts with the active runtime context. |
+| `HARN-CHN-005` | Malformed `batch` config on a `trigger_register` call (missing `count`/`window`, non-positive `count`, unknown `expire_action`, or wrong-typed `key`). |
 
 ## OAuth
 

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -1909,6 +1909,175 @@ Regular functions that contain `yield` keep producing `Generator<T>`;
 `gen fn` produces `Stream<T>`. Throws inside a stream body propagate to
 the consumer at the pull site (`for`, `.next()`, or `.iter()`).
 
+### Durable agent channels
+
+Durable agent channels (epic #1870) are distinct from the in-process
+`channel(...)` primitive above. Where in-process channels are typed
+mailboxes between concurrent tasks inside one VM, durable channels are
+a typed pub/sub primitive that writes to the active EventLog and fans
+each emit out to every matching `channel.emit` trigger binding. They
+survive process restarts, feed the replay oracle, and show up in the
+action graph alongside webhook and cron events.
+
+#### Emit
+
+The runtime exposes two builtins. `emit_channel(name, payload,
+options?)` appends one event to the channel's EventLog topic and
+returns a `ChannelEmitReceipt`. `channel_events(name, options?)` reads
+the topic oldest-first for tests and diagnostics. Reference shapes are
+in `docs/src/builtins.md`; full prose is in `docs/src/agent-channels.md`.
+
+A channel `name` resolves into the canonical form
+`<scope>:<scope_id>:<name>`. Bare names default to **tenant** scope
+(`tenant:<current-tenant-or-default>:<name>`). Prefixes select an
+explicit scope: `session:<name>`, `pipeline:<name>`, `tenant:<name>`,
+`tenant:<tenant_id>:<name>`. The `org:<org_id>:<name>` prefix is
+reserved but currently rejected with `HARN-CHN-002` until org grants
+ship.
+
+#### `ChannelScope`
+
+The scope enum is:
+
+```text
+ChannelScope ::= "session" | "pipeline" | "tenant" | "org"
+```
+
+- `session` events live in a per-process in-memory log; they are
+  cleared by `reset_channel_state()` and do not cross process boundaries.
+- `pipeline` and `tenant` events use the active durable EventLog; the
+  resolver returns `HARN-CHN-001` if `pipeline:` is used without an
+  active pipeline context.
+- `org` is reserved; v1 always returns `HARN-CHN-002`.
+
+Cross-scope isolation is automatic: distinct `tenant_id`, `session_id`,
+or `pipeline_id` values resolve to distinct topics, so readers against
+the wrong scope id see an empty view. Explicit `options.session_id` or
+`options.pipeline_id` that conflict with the active runtime context
+fail with `HARN-CHN-004` rather than silently overriding.
+
+#### Idempotency and signed timestamps
+
+`options.id` makes the emit idempotent. Re-emitting the same
+(`name_resolved`, `id`) pair returns the original `event_id` with
+`duplicate: true`. The receipt's `emitted_at` field is a signed
+timestamp: HMAC-SHA-256 over `(at_ms, event_id, name_resolved, scope,
+scope_id, emitted_by)` with a per-process salt and `algorithm:
+"hmac-sha256"`. The replay oracle uses this to detect timestamp
+tampering across runs.
+
+#### `channel.emit` trigger source
+
+Trigger bindings subscribe to channel events with `provider: "channel"`,
+`kind: "channel.emit"`, and `match.events: ["channel:<selector>"]`.
+The selector accepts the same scope prefixes as `emit_channel`:
+
+```text
+ChannelSelector ::= "channel:" Name
+                  | "channel:session:" Name
+                  | "channel:pipeline:" Name
+                  | "channel:tenant:" TenantId ":" Name
+```
+
+The dispatched `TriggerEvent` carries the emit's `payload` verbatim at
+`event.provider_payload.payload`; `event.batch` is `nil` for ordinary
+single-event dispatches and populated for batched bindings (next
+section).
+
+#### `batch { count, window, key?, expire_action? }` (`BatchFilter`)
+
+A trigger binding may declare aggregation:
+
+```text
+BatchFilter ::= {
+  count: int (> 0),
+  window: DurationString,
+  key?: string,                  // dotted JSON path into payload
+  expire_action?: "fire_partial" | "discard"   // default "fire_partial"
+}
+```
+
+Semantics:
+
+- Each filter-passing event increments a per-(`binding`, `partition_key`)
+  counter. Reaching `count` invokes the handler with `event.batch`
+  populated to the buffered list and resets the counter.
+- `key` partitions counters by the stringified value at that JSON path
+  into the channel payload. Missing paths fall back to one shared
+  bucket (matches `SpawnToPool`'s "missing path = default" pattern).
+- When the window elapses without reaching `count`, `expire_action`
+  decides: `fire_partial` invokes the handler with whatever was
+  buffered; `discard` drops the buffer silently.
+- Buffers are per-process thread-local and capped at 1024 events per
+  partition. Overflow drops the oldest entries with a structured
+  `triggers.aggregation.buffer_overflow` warning.
+- Window expiration is driven by an implicit sweep at every emit and
+  by the explicit `flush_trigger_aggregations()` builtin; the latter
+  is the test affordance and pairs with `mock_time(...)` /
+  `advance_time(...)`.
+
+Malformed configs (missing fields, non-positive `count`, unknown
+`expire_action`, wrong-typed `key`) raise `HARN-CHN-005`.
+
+#### `ReminderInjectHandler`
+
+`ReminderInject(options)` (from `std/triggers`) constructs a handler-
+variant dict that, on match, injects a `SystemReminder` event (see
+`docs/src/system-reminders.md`) into the target session's transcript
+at the next turn boundary. It is the orthogonal counterpart to
+`SpawnToPool` — no spawn, no resume, no signal; the target session
+keeps running and receives the typed context at the next post-turn
+lifecycle pass.
+
+```text
+ReminderInjectHandler ::= {
+  kind: "reminder_inject",
+  target: "current" | "parent" | SessionId | (event -> SessionId?),
+  body: PromptTemplate,                    // .harn.prompt
+  tags?: list<string>,
+  ttl_turns?: int,
+  dedupe_key?: string,
+  propagate?: "none" | "session",
+  role_hint?: "user" | "developer",
+  preserve_on_compact?: bool
+}
+```
+
+`body` is rendered against `{{ event }}` (the full `TriggerEvent`),
+`{{ match }}` (`matched_at`), and `{{ batch }}` (the constituent list
+when batching is in effect). Missing target sessions are dropped
+gracefully with a `triggers.reminder_inject.audit` audit entry rather
+than failing dispatch.
+
+#### Observability
+
+Channel activity is published on three EventLog topics:
+
+| Topic | Schema | Purpose |
+|---|---|---|
+| `lifecycle.channel.audit` | `harn.channel_emit_receipt.v1`, `harn.channel_match_receipt.v1`, `harn.channel_guardrail_audit.v1` | Durable replay/audit. One receipt per emit, per match, and per guardrail verdict. |
+| `transcript.channel.lifecycle` | `transcript.channel.emit`, `transcript.channel.match` | Per-emit and per-match transcript events for live rendering. |
+| `channels.<scope>.<scope_id>.<name>` | `StoredChannelEvent` | The events themselves, addressable via `event_log.subscribe(...)`. |
+
+Every emit opens an OTel `channel.emit <name_resolved>` span; every
+match opens `channel.match <name_resolved>` and links back to the
+emit span via trace/span ids propagated on the trigger event headers
+(this propagation passes through `batch` aggregation, so a batched
+match links to all constituent emit spans).
+
+#### Replay determinism
+
+The replay oracle consumes `lifecycle.channel.audit` to detect:
+
+- `HARN-REP-CHN-001` — replay matched an `event_id` with no recorded receipt.
+- `HARN-REP-CHN-002` — payload hash drift on a replayed emit (producer-
+  side nondeterminism).
+- `HARN-REP-CHN-003` — batched match constituent ids differ across runs.
+
+See `docs/src/observability/replay-benchmarks.md` for the oracle
+interface. The user-facing reference is `docs/src/agent-channels.md`;
+runnable patterns live in `docs/src/cookbooks/channels.md`.
+
 ## Error model
 
 ### throw
@@ -4549,6 +4718,16 @@ programs.
 | `HARN-OAU-001` | A persisted sink redacted an OAuth-shaped token (transcript / receipt / OTel / system reminder). The original value still flows through to the tool — redaction is display-only. |
 | `HARN-OAU-002` | `std/oauth/client` cannot refresh because no `refresh_token` is in storage (or the server rejected the refresh). Re-run `start_authorization` / `device_flow`. |
 | `HARN-OAU-005` | `std/oauth/dynamic_registration` rejected a candidate client metadata document under RFC 7591 §2. |
+
+#### Durable agent channels diagnostics (`HARN-CHN-*`)
+
+| Code | Description |
+|---|---|
+| `HARN-CHN-001` | `pipeline:` scope used outside any active pipeline context. |
+| `HARN-CHN-002` | Cross-tenant `emit_channel` without a grant, or `org:` scope (disabled in v1 until org grants are available). |
+| `HARN-CHN-003` | Malformed channel name, scope prefix, or scope id. |
+| `HARN-CHN-004` | Scope ambiguous — explicit `options.session_id` or `options.pipeline_id` conflicts with the active runtime context. |
+| `HARN-CHN-005` | Malformed `batch` config on a `trigger_register` call (missing `count`/`window`, non-positive `count`, unknown `expire_action`, or wrong-typed `key`). |
 
 ## OAuth
 


### PR DESCRIPTION
## Summary

Closes #1880 (CH-09). Ships the user-facing reference + cookbook for the durable agent channels primitive (epic #1870). The full channel surface (CH-01..CH-08, CH-10 #2029, CH-11 #2039) has shipped with OTel + replay + guardrails; this PR is the documentation layer so users can actually adopt it.

- **`docs/src/agent-channels.md`** (new) — full reference: emit surface, scopes, idempotency, signed timestamps, `channel.emit` trigger source, `batch` aggregation, `ReminderInject` handler variant, guardrails middleware (CH-11), three observability topics, `HARN-CHN-*` diagnostic codes, and a SOTA comparison vs Inngest / Temporal / Restate / A2A.
- **`docs/src/cookbooks/channels.md`** (new) — five end-to-end recipes:
  1. Release handshake (PR agent emits → batched release agent → merge-captain subscribers).
  2. Periodic check-in via batched tool-call counting + `ReminderInject`.
  3. Multi-agent feedback loop (planner draft → reviewers critique → planner revises).
  4. Tenant-scoped pipeline progress dashboard.
  5. Cross-pipeline coordination via drain handoff.
- **`docs/llm/harn-quickref.md`** — extends the "Durable agent channels" section with the trigger + batch + ReminderInject surface, a four-row pick-the-primitive comparison table (handoffs vs triggers vs suspend/resume vs channels vs channels+batch+reminder), the `HARN-CHN-*` + `HARN-REP-CHN-*` code lists, and a guardrails one-liner.
- **`spec/HARN_SPEC.md`** — new "Durable agent channels" subsection in the Concurrency super-section with formal `ChannelScope`, `BatchFilter`, `ReminderInjectHandler` shapes, plus a `HARN-CHN-*` block in the diagnostic-code appendix. Mirrored into `docs/src/language-spec.md` via `make sync-language-spec`.
- **`docs/src/SUMMARY.md`** — wires both new pages into the Orchestration section.

## Test plan

- [x] `make lint-md` — 0 errors.
- [x] `make check-docs-snippets` — my new files pass; 4 pre-existing failures in `docs/src/diagnostics.md` (HARN-CST-004 examples from #1791) are unrelated.
- [x] `mdbook build` — clean.
- [x] `make check-language-spec` — clean after `sync-language-spec`.
- [x] `make check-highlight` / `make check-diagnostics-catalog` — clean.
- [x] `make lint-test-patterns` — no wall-clock violations.

## Cross-refs

Part of epic #1870. Depends on CH-01..CH-08, CH-10 (#2029), CH-11 (#2039). Unblocks user-facing GA.