### PR TITLE
Tag intentionally-rejected const examples as harn,ignore

### DIFF
--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-CST-001.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-CST-001.md
@@ -11,7 +11,7 @@ exceeds `MAX_STEPS` (default 100,000), evaluation is aborted with this
 diagnostic. The cap is enforced on every step, not amortized, so a
 hostile or accidental quadratic expression cannot stall the compiler.
 
-```harn
+```harn,ignore
 // Rejected (would expand far beyond the step budget):
 const HUGE = sum_to(1_000_000)
 ```

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-CST-003.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-CST-003.md
@@ -12,7 +12,7 @@ effect. Even a syntactically reachable call into one of those surfaces
 is rejected before evaluation runs — the const-eval sandbox refuses to
 mediate I/O or non-determinism.
 
-```harn
+```harn,ignore
 // Rejected:
 const X = read_file("/etc/passwd")
 const Y = env("HOME")

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-CST-004.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-CST-004.md
@@ -11,7 +11,7 @@ overflow on a literal arithmetic, division by zero, indexing past the
 end of a literal list, an undefined identifier the const-eval
 environment cannot resolve, or a type mismatch on a binary operator.
 
-```harn
+```harn,ignore
 // Rejected at compile time:
 const ZERO = 1 / 0
 const OOB = [1, 2, 3][9]

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-MET-001.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-MET-001.md
@@ -13,17 +13,24 @@ construct (spawn / parallel / select / try / yield / emit / await), a
 loop, an assignment, or any builtin outside the curated const-friendly
 allowlist.
 
-```harn
-// Rejected:
+Rejected:
+
+```harn,ignore
 const Z = harness.clock.now()              // host capability
 const W = spawn { 1 }                      // runtime construct
 const Q = some_user_fn()                   // user function call
+```
 
-// Accepted:
+Accepted:
+
+```harn
 const X: int = 5 + 3
-const Y: string = "hello-${X}"
+const Y: string = format("hello-{}", X)
 const NS: list = [1, 2, X]
 const COUNT: int = len([1, 2, 3])
+
+// reads to silence the unused-variable lint in the example
+let _ = [X, Y, NS, COUNT]
 ```
 
 ## How to fix

--- a/docs/src/diagnostics.md
+++ b/docs/src/diagnostics.md
@@ -5522,17 +5522,24 @@ construct (spawn / parallel / select / try / yield / emit / await), a
 loop, an assignment, or any builtin outside the curated const-friendly
 allowlist.
 
-```harn
-// Rejected:
+Rejected:
+
+```harn,ignore
 const Z = harness.clock.now()              // host capability
 const W = spawn { 1 }                      // runtime construct
 const Q = some_user_fn()                   // user function call
+```
 
-// Accepted:
+Accepted:
+
+```harn
 const X: int = 5 + 3
-const Y: string = "hello-${X}"
+const Y: string = format("hello-{}", X)
 const NS: list = [1, 2, X]
 const COUNT: int = len([1, 2, 3])
+
+// reads to silence the unused-variable lint in the example
+let _ = [X, Y, NS, COUNT]
 ```
 
 #### How to fix
@@ -5566,7 +5573,7 @@ exceeds `MAX_STEPS` (default 100,000), evaluation is aborted with this
 diagnostic. The cap is enforced on every step, not amortized, so a
 hostile or accidental quadratic expression cannot stall the compiler.
 
-```harn
+```harn,ignore
 // Rejected (would expand far beyond the step budget):
 const HUGE = sum_to(1_000_000)
 ```
@@ -5627,7 +5634,7 @@ effect. Even a syntactically reachable call into one of those surfaces
 is rejected before evaluation runs — the const-eval sandbox refuses to
 mediate I/O or non-determinism.
 
-```harn
+```harn,ignore
 // Rejected:
 const X = read_file("/etc/passwd")
 const Y = env("HOME")
@@ -5664,7 +5671,7 @@ overflow on a literal arithmetic, division by zero, indexing past the
 end of a literal list, an undefined identifier the const-eval
 environment cannot resolve, or a type mismatch on a binary operator.
 
-```harn
+```harn,ignore
 // Rejected at compile time:
 const ZERO = 1 / 0
 const OOB = [1, 2, 3][9]


### PR DESCRIPTION
## Summary

Fix the pre-existing 4 docs-snippet check failures introduced when T7 const-eval (#1791, PR #2040) landed.

`docs/src/diagnostics.md` is regenerated from `crates/harn-parser/src/diagnostic_codes/explanations/HARN-*.md`. Four of T7's new explanation blocks demonstrate INTENTIONALLY-REJECTED const initializers (HARN-MET-001, HARN-CST-001, HARN-CST-003, HARN-CST-004). The snippet runner can't tell that the "// Rejected:" comment is the spec — it tries to compile every untagged `harn` block and trips on the failures.

## Changes

- Tag the "Rejected:" blocks in HARN-{MET,CST}-001/003/004 explanations as `harn,ignore`.
- HARN-MET-001 originally mixed Rejected + Accepted in one block; split into two so the Accepted block stays validated.
- Fixed HARN-MET-001 "Accepted" example: `"hello-${X}"` triggers HARN-MET-001 itself (interpolated expressions aren't const-eligible); switched to `format("hello-{}", X)` per T7's allowlist. Added a `let _ = [X, Y, NS, COUNT]` read to silence unused-variable lint.
- Regenerated `docs/src/diagnostics.md` + `docs/diagnostics-catalog.json`.

## Test plan

- [x] `make sync-diagnostics-catalog` clean
- [x] `make check-docs-snippets` — 563 checked, 188 skipped, 0 failed (was 4 failed)
- [x] `make check-diagnostics-catalog` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)