### PR TITLE
Add needs-human autonomy class (#1792)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,31 @@ condensed series summaries instead of full per-patch history.
   formal `ChannelScope`, `BatchFilter`, `ReminderInjectHandler`
   shapes) plus the `HARN-CHN-*` block in the diagnostic appendix.
   Wires the new pages into `docs/src/SUMMARY.md` under Orchestration.
+- **`needs-human` autonomy class (T8, #1792).** Formalizes `needs-human` as
+  a first-class, transverse autonomy discipline on top of the existing
+  `AutonomyTier` (`Shadow` / `Suggest` / `ActWithApproval` / `ActAuto`).
+  Any operation tagged `needs-human` is now denied with the structured
+  `HARN-AUT-NEEDS-HUMAN` deny code regardless of the resolved tier —
+  even an `ActAuto`-tier caller cannot auto-apply a `needs-human`
+  side effect. `AutonomyPolicy` grows three additive fields for tagging:
+  `requires_human: bool` (blanket), `requires_human_agents: BTreeSet<String>`
+  (per-agent), and `requires_human_actions: BTreeSet<String>` (per-builtin
+  or per-action-class, e.g. `"write_file"` or `"fs.write"`). The dispatcher
+  emits a non-blocking approval-request with `detail.autonomy_class =
+  "needs-human"`, `detail.requires_human = true`, and `detail.deny_code =
+  "HARN-AUT-NEEDS-HUMAN"` so approval surfaces (Slack-approval, IDE,
+  portal, `hitl_pending`) can render the row distinctly from a normal
+  tier-driven approval ask. The corresponding `TrustRecord` is appended
+  with `outcome = "denied"`, `metadata.autonomy_class = "needs-human"`,
+  `metadata.requires_human = true`, `metadata.deny_code =
+  "HARN-AUT-NEEDS-HUMAN"`, and `metadata["autonomy.enforcement"] =
+  "needs_human_denied"`. The autonomy-class string mirrors
+  `RepairSafety::NeedsHuman.as_str()` from `harn-parser` so the
+  autonomy-surface and the repair-safety surface stay in lockstep with
+  E1.2 (#1747). Conformance: `conformance/tests/autonomy/autonomy_needs_human_basic.harn`
+  (per-action tag denies under `act_auto`, approval-request and trust
+  record carry the tag) and `autonomy_needs_human_blanket.harn` (blanket
+  and per-agent shapes).
 - **OAuth docs + provider cookbook (OA-08, #1909).** Adds
   `docs/src/oauth.md` as the user-facing reference for the full OAuth
   stack (`std/oauth/{providers,storage,client,device_flow,dynamic_registration,redaction}`),

--- a/conformance/tests/autonomy/autonomy_needs_human_basic.expected
+++ b/conformance/tests/autonomy/autonomy_needs_human_basic.expected
@@ -1,0 +1,13 @@
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true

--- a/conformance/tests/autonomy/autonomy_needs_human_basic.harn
+++ b/conformance/tests/autonomy/autonomy_needs_human_basic.harn
@@ -1,0 +1,61 @@
+/**
+ * `needs-human` is a transverse autonomy class: side effects tagged
+ * `needs-human` raise a structured `HARN-AUT-NEEDS-HUMAN` deny regardless
+ * of the resolved `AutonomyTier`. Even at `act_auto` (which normally
+ * auto-applies every side effect) a `needs-human`-tagged write is
+ * forbidden, a pending approval request is queued with the autonomy
+ * class flowing through `detail.autonomy_class`, and the trust-graph
+ * record carries `metadata.autonomy_class = "needs-human"` plus
+ * `metadata.requires_human = true`.
+ *
+ * Tracking: harn#1792.
+ */
+fn attempt_write(target: string) -> dict {
+  try {
+    write_file(target, "should never land")
+    return {caught: nil, wrote: true}
+  } catch (e) {
+    return {caught: to_string(e), wrote: false}
+  }
+}
+
+pipeline test(task) {
+  mkdir(".harn")
+  let unique = to_string(to_int(timestamp())) + "-" + to_string(random_int(100000, 999999))
+  let agent = "needs-human-" + unique
+  let target = path_join(".harn", "needs_human_" + unique + ".txt")
+  let outcome = with_autonomy_policy(
+    {
+      agent_id: agent,
+      autonomy_tier: "act_auto",
+      reviewers: ["ops-lead"],
+      requires_human_actions: ["fs.write"],
+    },
+    fn() { return attempt_write(target) },
+  )
+  // 1. The structured deny fired and the file was never written, even
+  //    though the resolved tier is `act_auto`.
+  println(outcome.caught != nil && !file_exists(target))
+  println(contains(outcome.caught, "HARN-AUT-NEEDS-HUMAN"))
+  println(contains(outcome.caught, "tool_rejected"))
+  // 2. A trust-graph record was appended with outcome `denied` and the
+  //    autonomy class flowing through metadata.
+  let records: list<TrustRecord> = trust_query({agent: agent, action: "fs.write"})
+  println(len(records) == 1)
+  println(records[0].outcome == "denied")
+  println(records[0].metadata.autonomy_class == "needs-human")
+  println(records[0].metadata.requires_human)
+  println(records[0].metadata.deny_code == "HARN-AUT-NEEDS-HUMAN")
+  println(records[0].metadata["autonomy.enforcement"] == "needs_human_denied")
+  // 3. An approval-request was queued with the `needs-human` tag in the
+  //    payload so reviewers can render it distinctly from a normal
+  //    tier-driven approval ask.
+  let pending = hitl_pending({}).filter({ row -> row.agent == agent })
+  println(len(pending) == 1)
+  println(pending[0].metadata.detail.autonomy_class == "needs-human")
+  println(pending[0].metadata.detail.requires_human)
+  println(pending[0].metadata.detail.deny_code == "HARN-AUT-NEEDS-HUMAN")
+  if file_exists(target) {
+    delete_file(target)
+  }
+}

--- a/conformance/tests/autonomy/autonomy_needs_human_blanket.expected
+++ b/conformance/tests/autonomy/autonomy_needs_human_blanket.expected
@@ -1,0 +1,5 @@
+true
+true
+true
+true
+true

--- a/conformance/tests/autonomy/autonomy_needs_human_blanket.harn
+++ b/conformance/tests/autonomy/autonomy_needs_human_blanket.harn
@@ -1,0 +1,54 @@
+/**
+ * The `needs-human` autonomy class can be applied via three shapes on
+ * `AutonomyPolicy`:
+ *   - blanket: `requires_human: true` (every action denies)
+ *   - per-agent: `requires_human_agents: ["a"]`
+ *   - per-action/per-class: `requires_human_actions: ["fs.write"]` (covered
+ *     by the basic fixture)
+ *
+ * This fixture exercises the first two shapes to lock the policy contract
+ * in place.
+ *
+ * Tracking: harn#1792.
+ */
+fn attempt_write(target: string) -> dict {
+  try {
+    write_file(target, "should never land")
+    return {caught: nil, wrote: true}
+  } catch (e) {
+    return {caught: to_string(e), wrote: false}
+  }
+}
+
+pipeline test(task) {
+  mkdir(".harn")
+  let unique = to_string(to_int(timestamp())) + "-" + to_string(random_int(100000, 999999))
+  // Shape 1: blanket `requires_human` flag flips the whole policy into
+  // needs-human, even when the resolved tier is `act_auto`.
+  let blanket_agent = "needs-human-blanket-" + unique
+  let blanket_target = path_join(".harn", "needs_human_blanket_" + unique + ".txt")
+  let blanket_outcome = with_autonomy_policy(
+    {agent_id: blanket_agent, autonomy_tier: "act_auto", requires_human: true},
+    fn() { return attempt_write(blanket_target) },
+  )
+  println(blanket_outcome.caught != nil && !file_exists(blanket_target))
+  println(contains(blanket_outcome.caught, "HARN-AUT-NEEDS-HUMAN"))
+  let blanket_records: list<TrustRecord> = trust_query({agent: blanket_agent, action: "fs.write"})
+  println(len(blanket_records) == 1 && blanket_records[0].metadata.autonomy_class == "needs-human")
+  // Shape 2: per-agent tag flips just one agent into needs-human while
+  // other agents under the same policy continue to auto-apply.
+  let scoped_agent = "needs-human-agent-" + unique
+  let scoped_target = path_join(".harn", "needs_human_agent_" + unique + ".txt")
+  let scoped_outcome = with_autonomy_policy(
+    {agent_id: scoped_agent, autonomy_tier: "act_auto", requires_human_agents: [scoped_agent]},
+    fn() { return attempt_write(scoped_target) },
+  )
+  println(scoped_outcome.caught != nil && !file_exists(scoped_target))
+  let scoped_records: list<TrustRecord> = trust_query({agent: scoped_agent, action: "fs.write"})
+  println(len(scoped_records) == 1 && scoped_records[0].metadata.requires_human)
+  for path in [blanket_target, scoped_target] {
+    if file_exists(path) {
+      delete_file(path)
+    }
+  }
+}

--- a/crates/harn-vm/src/autonomy.rs
+++ b/crates/harn-vm/src/autonomy.rs
@@ -1,5 +1,5 @@
 use std::cell::RefCell;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::future::Future;
 use std::pin::Pin;
 
@@ -12,6 +12,16 @@ use crate::stdlib::hitl::append_approval_request_on;
 use crate::triggers::dispatcher::current_dispatch_context;
 use crate::trust_graph::{append_trust_record, AutonomyTier, TrustOutcome, TrustRecord};
 use crate::value::{categorized_error, ErrorCategory, VmError, VmValue};
+
+/// Stable diagnostic prefix for a deny driven by the `needs-human` autonomy
+/// class. Approval surfaces (Slack, IDE, portal) match on this code to render
+/// the deny distinctly from a normal tier-based block.
+pub const HARN_AUT_NEEDS_HUMAN_CODE: &str = "HARN-AUT-NEEDS-HUMAN";
+
+/// Canonical string value of the `needs-human` autonomy class. Mirrors
+/// `RepairSafety::NeedsHuman.as_str()` from `harn-parser` so the autonomy
+/// surface and the repair-safety surface stay in lockstep.
+pub const NEEDS_HUMAN_AUTONOMY_CLASS: &str = "needs-human";
 
 thread_local! {
     static AUTONOMY_POLICY_STACK: RefCell<Vec<AutonomyPolicy>> = const { RefCell::new(Vec::new()) };
@@ -27,6 +37,21 @@ pub struct AutonomyPolicy {
     pub agent_tiers: BTreeMap<String, AutonomyTier>,
     pub agent_action_tiers: BTreeMap<String, BTreeMap<String, AutonomyTier>>,
     pub reviewers: Vec<String>,
+    /// Mark the whole policy as `needs-human`: every side-effecting builtin
+    /// covered by this policy raises a structured `HARN-AUT-NEEDS-HUMAN`
+    /// deny, regardless of the resolved `autonomy_tier`.
+    #[serde(default)]
+    pub requires_human: bool,
+    /// Per-action or per-class needs-human tags. Entries match either the
+    /// builtin name (`write_file`) or the action class (`fs.write`).
+    /// Mutually exclusive with auto-apply: an entry here always wins over
+    /// any tier resolution.
+    #[serde(default, alias = "action_requires_human")]
+    pub requires_human_actions: BTreeSet<String>,
+    /// Per-agent needs-human tags. If an agent is listed here, every side
+    /// effect it attempts is treated as needs-human.
+    #[serde(default)]
+    pub requires_human_agents: BTreeSet<String>,
 }
 
 impl AutonomyPolicy {
@@ -52,6 +77,25 @@ impl AutonomyPolicy {
             })
             .or(self.autonomy_tier)
             .or(self.tier)
+    }
+
+    /// Resolve whether a given (agent, action) is tagged `needs-human` under
+    /// this policy. Any positive signal — blanket `requires_human`, a
+    /// per-agent tag, or a per-builtin/per-class tag — flips the action into
+    /// the needs-human discipline.
+    fn is_needs_human(&self, agent_id: &str, action: &SideEffectAction) -> bool {
+        if self.requires_human {
+            return true;
+        }
+        if self.requires_human_agents.contains(agent_id) {
+            return true;
+        }
+        if self.requires_human_actions.contains(action.builtin)
+            || self.requires_human_actions.contains(action.class)
+        {
+            return true;
+        }
+        false
     }
 }
 
@@ -107,6 +151,10 @@ struct AutonomyIdentity {
     trace_id: String,
     tier: AutonomyTier,
     reviewers: Vec<String>,
+    /// Whether this (agent, action) is tagged `needs-human` by the
+    /// currently-active autonomy policy. When true the dispatcher MUST
+    /// deny auto-apply regardless of `tier`.
+    requires_human: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -142,7 +190,11 @@ pub fn needs_async_side_effect_enforcement(name: &str) -> bool {
     let Some(action) = side_effect_action_for_builtin(name) else {
         return false;
     };
-    current_identity(&action).is_some_and(|identity| identity.tier != AutonomyTier::ActAuto)
+    current_identity(&action)
+        // `needs-human` always needs the async enforcement path so the
+        // dispatcher can emit the structured deny + approval-request,
+        // even when the resolved tier is `ActAuto`.
+        .is_some_and(|identity| identity.requires_human || identity.tier != AutonomyTier::ActAuto)
 }
 
 pub fn enforce_builtin_side_effect_boxed<'a>(
@@ -256,6 +308,22 @@ pub async fn enforce_builtin_side_effect(
     let Some(identity) = current_identity(&action) else {
         return Ok(None);
     };
+    // `needs-human` is a transverse discipline: it forbids auto-apply even
+    // when the resolved tier is `ActAuto`. Check this *before* tier
+    // dispatch so no tier can ever override it.
+    if identity.requires_human {
+        emit_proposal_event(identity.tier, action, args).await?;
+        let request_id = append_needs_human_approval_request(&identity, action, args).await?;
+        append_enforcement_record(
+            &identity,
+            action,
+            args,
+            TrustOutcome::Denied,
+            Some(request_id.clone()),
+        )
+        .await?;
+        return Err(needs_human_deny_error(&identity, action, &request_id));
+    }
     match identity.tier {
         AutonomyTier::ActAuto => Ok(None),
         AutonomyTier::Shadow => {
@@ -312,11 +380,16 @@ fn current_identity(action: &SideEffectAction) -> Option<AutonomyIdentity> {
         .map(|policy| policy.reviewers.clone())
         .filter(|reviewers| !reviewers.is_empty())
         .unwrap_or_default();
+    let requires_human = scoped
+        .as_ref()
+        .map(|policy| policy.is_needs_human(&agent_id, action))
+        .unwrap_or(false);
     Some(AutonomyIdentity {
         agent_id,
         trace_id,
         tier,
         reviewers,
+        requires_human,
     })
 }
 
@@ -326,6 +399,22 @@ fn detail_for(action: SideEffectAction, args: &[VmValue]) -> JsonValue {
         "action_class": action.class,
         "args": args.iter().map(crate::llm::vm_value_to_json).collect::<Vec<_>>(),
     })
+}
+
+fn needs_human_detail(action: SideEffectAction, args: &[VmValue]) -> JsonValue {
+    let mut detail = detail_for(action, args);
+    if let Some(obj) = detail.as_object_mut() {
+        obj.insert(
+            "autonomy_class".to_string(),
+            JsonValue::String(NEEDS_HUMAN_AUTONOMY_CLASS.to_string()),
+        );
+        obj.insert("requires_human".to_string(), JsonValue::Bool(true));
+        obj.insert(
+            "deny_code".to_string(),
+            JsonValue::String(HARN_AUT_NEEDS_HUMAN_CODE.to_string()),
+        );
+    }
+    detail
 }
 
 async fn emit_proposal_event(
@@ -390,6 +479,57 @@ async fn append_nonblocking_approval_request(
     .await
 }
 
+/// Emit a non-blocking approval request tagged with the `needs-human`
+/// autonomy class. Surfaces (Slack-approval, IDE, portal) match on the
+/// `autonomy_class` field in the request payload's `detail` to render the
+/// pending row distinctly from a normal tier-driven approval ask.
+async fn append_needs_human_approval_request(
+    identity: &AutonomyIdentity,
+    action: SideEffectAction,
+    args: &[VmValue],
+) -> Result<String, VmError> {
+    let log = active_event_log().ok_or_else(|| {
+        categorized_error(
+            "needs-human autonomy class requires an active event log",
+            ErrorCategory::ToolRejected,
+        )
+    })?;
+    append_approval_request_on(
+        &log,
+        identity.agent_id.clone(),
+        identity.trace_id.clone(),
+        format!("{}#needs-human", action.class),
+        needs_human_detail(action, args),
+        identity.reviewers.clone(),
+    )
+    .await
+}
+
+/// Build the structured deny returned when a `needs-human`-tagged side
+/// effect is attempted. The message is prefixed with [`HARN_AUT_NEEDS_HUMAN_CODE`]
+/// so approval surfaces and structured-error consumers can match on a stable
+/// token rather than substring-matching the human-readable text.
+fn needs_human_deny_error(
+    identity: &AutonomyIdentity,
+    action: SideEffectAction,
+    request_id: &str,
+) -> VmError {
+    categorized_error(
+        format!(
+            "{code}: side effect `{builtin}` ({class}) is tagged `needs-human` for agent `{agent}`; \
+             auto-apply is forbidden regardless of autonomy tier `{tier}`. \
+             Approval request `{request_id}` was queued.",
+            code = HARN_AUT_NEEDS_HUMAN_CODE,
+            builtin = action.builtin,
+            class = action.class,
+            agent = identity.agent_id,
+            tier = identity.tier.as_str(),
+            request_id = request_id,
+        ),
+        ErrorCategory::ToolRejected,
+    )
+}
+
 struct ApprovalOutcome {
     request_id: Option<String>,
 }
@@ -439,14 +579,22 @@ async fn append_enforcement_record(
         identity.trace_id.clone(),
         identity.tier,
     );
-    record.metadata.insert(
-        "autonomy.enforcement".to_string(),
-        serde_json::json!(match identity.tier {
+    let enforcement = if identity.requires_human {
+        // `needs-human` always denies regardless of tier — record the
+        // distinct enforcement label so audit consumers can filter on it
+        // without re-deriving the discipline from policy snapshots.
+        "needs_human_denied"
+    } else {
+        match identity.tier {
             AutonomyTier::Shadow => "shadow_noop",
             AutonomyTier::Suggest => "suggest_approval_request",
             AutonomyTier::ActWithApproval => "approval_granted",
             AutonomyTier::ActAuto => "auto",
-        }),
+        }
+    };
+    record.metadata.insert(
+        "autonomy.enforcement".to_string(),
+        serde_json::json!(enforcement),
     );
     record
         .metadata
@@ -454,6 +602,29 @@ async fn append_enforcement_record(
     record
         .metadata
         .insert("action_class".to_string(), serde_json::json!(action.class));
+    // Every record carries an explicit autonomy class so the trust-graph
+    // record (`TrustRecord.metadata.autonomy_class`) flows downstream into
+    // approval surfaces and receipt envelopes. `needs-human` is mutually
+    // exclusive with the tier-based labels.
+    let autonomy_class = if identity.requires_human {
+        NEEDS_HUMAN_AUTONOMY_CLASS.to_string()
+    } else {
+        identity.tier.as_str().to_string()
+    };
+    record.metadata.insert(
+        "autonomy_class".to_string(),
+        serde_json::json!(autonomy_class),
+    );
+    record.metadata.insert(
+        "requires_human".to_string(),
+        serde_json::json!(identity.requires_human),
+    );
+    if identity.requires_human {
+        record.metadata.insert(
+            "deny_code".to_string(),
+            serde_json::json!(HARN_AUT_NEEDS_HUMAN_CODE),
+        );
+    }
     record.metadata.insert(
         "args".to_string(),
         serde_json::json!(args


### PR DESCRIPTION
## Summary

Formalize `needs-human` as a first-class, transverse autonomy discipline
on top of the existing `AutonomyTier` ladder (Shadow / Suggest /
ActWithApproval / ActAuto). Per the spec for #1792, the goal is that
*any* operation tagged `needs-human` is denied from auto-apply
regardless of the caller's resolved tier — even `ActAuto`. This ties
the autonomy surface to the existing `RepairSafety::NeedsHuman` class
from #1747 so the same string flows through both.

### Surface

- `AutonomyPolicy` (in `crates/harn-vm/src/autonomy.rs`) gains three
  additive fields:
  - `requires_human: bool` — blanket: the whole policy is needs-human.
  - `requires_human_agents: BTreeSet<String>` — per-agent tag.
  - `requires_human_actions: BTreeSet<String>` — per-builtin or
    per-action-class tag (matches either `"write_file"` or `"fs.write"`).
- The dispatcher (`enforce_builtin_side_effect`) checks needs-human
  **before** tier resolution. When tagged it:
  - Emits the `dispatch_proposed` event for audit parity with the
    existing tier branches.
  - Appends a non-blocking approval-request via `append_approval_request_on`
    with `detail.autonomy_class = "needs-human"`,
    `detail.requires_human = true`, and `detail.deny_code =
    "HARN-AUT-NEEDS-HUMAN"` so approval surfaces (Slack-approval, IDE,
    portal, `hitl_pending`) can render the row distinctly.
  - Appends a `TrustRecord` with `outcome = "denied"`,
    `metadata.autonomy_class = "needs-human"`,
    `metadata.requires_human = true`, `metadata.deny_code =
    "HARN-AUT-NEEDS-HUMAN"`, and `metadata["autonomy.enforcement"] =
    "needs_human_denied"`.
  - Returns a structured `categorized_error` with category
    `ErrorCategory::ToolRejected` and the `HARN-AUT-NEEDS-HUMAN`
    prefix in the message so callers can match on a stable token
    instead of substring-matching human-readable text.
- `needs_async_side_effect_enforcement` now also returns `true` when
  needs-human is in effect at `ActAuto`, so the dispatcher actually
  reaches the new branch instead of taking the auto-apply fast path.
- `append_enforcement_record` stamps `autonomy_class` and
  `requires_human` on **every** record so consumers can dispatch on the
  class without re-deriving the discipline from policy snapshots.

### Backwards compatibility

Additive only. Existing autonomy fixtures
(`conformance/tests/autonomy/autonomy_tiers_side_effects.harn`) still
pass — no default policy is needs-human.

### Deliberate cuts

- No new IDE / cloud approval UI components — out of scope per the
  spec's "Out of scope" section (defer to integration tickets).
- No new `ask_user` / `request_approval` HITL primitives — out of
  scope per the spec; tracked separately under the future HITL-primitives
  epic.
- CLI `harn fix --apply --safety needs-human` rejection lives in E1.5
  (#1752); this ticket is the cross-cutting runtime rule.

## Test plan

- [x] `cargo run --bin harn -- test conformance --filter autonomy_needs_human` — 2/2 PASS
- [x] `cargo run --bin harn -- test conformance --filter autonomy` — 5/5 PASS (no regressions to existing tiers fixture)
- [x] `cargo run --bin harn -- test conformance` — 1334/1334 PASS
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all` — clean
- [x] `make fmt-harn` / `make lint-harn` / `make lint-test-patterns` — clean
- [x] `make test` — 4509 / 4509 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)