### PR TITLE
Add pool docs + cookbook (#1893)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,39 @@ condensed series summaries instead of full per-patch history.
 
 ### Added
 
+- **Pool docs + cookbook (PL-08, #1893).** Adds the user-facing
+  reference + cookbook for agent pools (epic #1883). New mdBook page
+  `docs/src/agent-pools.md` covers pool creation (`pool_create`
+  options, the handle shape), submit semantics (priority, fairness
+  key, idempotency, task-handle shape), the four queue strategies
+  (`fifo`, `priority`, `lifo`, `fair_round_robin`), backpressure
+  policies (`backpressure_queue` with `block_submitter` /
+  `drop_oldest` / `drop_newest` / `fail_submitter`, `fail_fast`,
+  `ring_buffer`), the four durability scopes (`session`, `pipeline`,
+  `tenant`, `org`) with the pipeline reload + `stale_after_ms`
+  contract, the `SpawnToPool` trigger handler, inspection surface
+  (`pool.size`, `pool.snapshot`, `pool_get`, `pool_list`,
+  `harness.unsettled_state().pool_pending_tasks`), the
+  `lifecycle.pool.audit` topic + OTel spans, the `HARN-POL-*`
+  diagnostic codes, a pick-the-right-primitive table
+  (`parallel each` vs pool vs scope tiers), and a SOTA comparison
+  table (Temporal, Inngest, Restate) explaining the design rationale.
+  New `docs/src/cookbooks/pools.md` ships four end-to-end recipes:
+  rate-limited webhook processor with per-source fair queue +
+  ring-buffer overflow, GPU-routed inference pool sized to the GPU
+  count with `scope: "tenant"` for harn-cloud worker-tier routing,
+  cross-customer fairness with 20-wide pool +
+  `fair_round_robin("tenant_id")`, and a burst absorber for nightly
+  batch jobs with a 50000-deep queue + idempotency keyed by
+  `(date, customer)`. Expands the "Agent pools" section in
+  `docs/llm/harn-quickref.md` with the full submit-option set,
+  queue-strategy + backpressure tables, scope tiers, the
+  `SpawnToPool` snippet, and cross-references. Adds an "Agent pools"
+  subsection to `spec/HARN_SPEC.md` (with formal `PoolHandle`,
+  `PoolTaskHandle`, `QueueStrategy`, `Backpressure`, `PoolScope`, and
+  `SpawnToPoolHandler` shapes) plus the `HARN-POL-*` block in the
+  diagnostic appendix. Wires the new pages into `docs/src/SUMMARY.md`
+  under Orchestration next to Agent channels.
 - **Suspend/resume protocol contribution RFCs (S-12, #1848).** Authors
   two new upstream-proposal documents under
   `docs/src/protocol-contributions/`: ACP `session/suspend` +

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -2615,9 +2615,13 @@ Three concentric surfaces:
   re-exports them as `lifecycle_audit_log_take` /
   `lifecycle_audit_log_snapshot`.
 
-### Agent Pools
+### Agent pools
 
-`std/lifecycle/pool` provides named, concurrency-bounded pools:
+`std/lifecycle/pool` provides named, concurrency-bounded thread pools.
+One named pool, one shared concurrency budget across every submitter.
+Use a pool when many independent call sites need to share a cap; use
+`parallel each ... with { max_concurrent: N }` when one call site
+needs a local cap.
 
 ```harn
 import { Backpressure, fair_round_robin, pool_create, pool_wait } from "std/lifecycle/pool"
@@ -2630,16 +2634,95 @@ let pool = pool_create({
   backpressure: backpressure.queue(100, "fail_submitter"),
 })
 
-let handle = pool.submit({ -> agent_loop("review", {provider: "mock"}) }, {tenant_id: "acme"})
+let handle = pool.submit({ -> agent_loop("review", "You are a reviewer.") }, {
+  tenant_id: "acme",
+  priority: 10,
+  idempotency_key: "review-pr-1984",
+})
 let result = pool_wait(handle)
 ```
+
+Pick-the-right-primitive:
+
+| Need | Use |
+|---|---|
+| Bound concurrency at one call site | `parallel each ... with { max_concurrent }` |
+| Bound concurrency across many call sites in one process | Pool, `scope: "session"` (default) |
+| Bound across pipeline runs that survive restart | Pool, `scope: "pipeline"` (state in `.harn/pools/`) |
+| Bound across tenants/orgs (cloud) | Pool, `scope: "tenant"` / `"org"` (host-routed; harn-cloud#306) |
+| Route trigger events through a shared budget | `SpawnToPool` handler (see below) |
+
+Queue strategies (factories from `std/lifecycle/pool`):
+
+| Factory | Behavior |
+|---|---|
+| `fifo()` | Oldest queued first. |
+| `priority()` | Highest submit `priority` first, FIFO tiebreak. Default. |
+| `lifo()` | Newest queued first. |
+| `fair_round_robin(key = "key")` | Partition by `options.<key>` on submit; round-robin across distinct partitions. Missing field shares a default partition. |
 
 Backpressure descriptors are `backpressure.queue(max_depth, on_full)`,
 `backpressure.fail_fast`, and `backpressure.ring_buffer(capacity)`.
 `on_full` accepts `block_submitter`, `drop_oldest`, `drop_newest`, or
-`fail_submitter`. Drop policies return rejected task handles and emit
-`pool_drop` audit events on `lifecycle.pool.audit`; fail paths raise
-`HARN-POL-001` or `HARN-POL-002`.
+`fail_submitter`. Drop policies return rejected task handles
+(`status: "rejected"`, `rejection_reason`, `rejection_policy`) and
+emit `pool_drop` audits on `lifecycle.pool.audit`; fail paths raise
+`HARN-POL-001` (`fail_submitter`) or `HARN-POL-002` (`fail_fast`).
+
+Submit options:
+
+| Option | Notes |
+|---|---|
+| `priority` | int; higher dequeues sooner under `priority()`. |
+| `key` | string; generic fairness key for `fair_round_robin("key")`. |
+| custom key (e.g. `tenant_id`) | When using `fair_round_robin("tenant_id")`, pass the partition under that name. |
+| `idempotency_key` | Two submits with the same `(pool_id, key)` return the *same* task handle. Pipeline-scope pools persist the index so resubmit after restart short-circuits. |
+
+`pool.submit` returns a task handle (`_type: "pool_task"`) with `id`,
+`pool`, `pool_id`, `status`, `submitted_at`, `key`, `priority`, and
+(when terminal) `result` / `error` / `rejection_reason`.
+`pool_wait(handle)` (or a list of handles) blocks until terminal and
+returns the final snapshot. `wait_agent(handle)` from
+`std/agent/workers` recognises pool task handles transparently.
+
+Inspection: `pool.size()`, `pool.snapshot()` (full dict with
+`active`, `queued`, `completed`, `failed`, `rejected`,
+`blocked_submitters`, `total`, selected `queue` / `backpressure`,
+per-task list, original `config`), `pool_get(name_or_id)`,
+`pool_list()`. Pipeline-scope pools also reload in-flight tasks past
+`stale_after_ms` as re-enqueued attempts; `pool_simulate_restart()`
+drops the in-process registry for conformance tests.
+
+Route trigger events through a pool with the `SpawnToPool` handler
+variant from `std/triggers` (one trigger, one drain rate):
+
+```harn,ignore
+import { trigger_register, SpawnToPool } from "std/triggers"
+
+trigger_register({
+  id: "webhook-router",
+  kind: "channel.emit",
+  provider: "channel",
+  match: {events: ["channel:webhook.received"]},
+  handler: SpawnToPool({
+    pool: "webhook-work",
+    key_from: "provider_payload.payload.source",
+    priority_from: "provider_payload.payload.urgency",
+    task_factory: { event -> { -> handle_webhook(event) } },
+  }),
+})
+```
+
+`key_from` / `priority_from` are dotted JSON paths into the trigger
+event. Missing paths fall back to the default partition and `0`
+priority. The dispatcher records the resulting pool task id on the
+match receipt so replay verifies the same event mapped to the same
+task across runs.
+
+Full prose: `docs/src/agent-pools.md`. Cookbook recipes (webhook
+rate-limit, GPU pool, cross-customer fairness, burst absorber):
+`docs/src/cookbooks/pools.md`. Stdlib API reference:
+`docs/src/stdlib/lifecycle-pool.md`.
 
 ```harn
 register_session_hook("user_prompt_submit", { event ->

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -118,6 +118,8 @@
 - [Webhook intake substrate](./triggers/webhook-intake.md)
 - [Agent channels](./agent-channels.md)
   - [Channel cookbook](./cookbooks/channels.md)
+- [Agent pools](./agent-pools.md)
+  - [Pool cookbook](./cookbooks/pools.md)
 - [Orchestrator](./orchestrator.md)
 - [Hot reload](./orchestrator/hot-reload.md)
 - [Orchestrator DLQ management](./orchestrator/dlq.md)

--- a/docs/src/agent-pools.md
+++ b/docs/src/agent-pools.md
@@ -1,0 +1,408 @@
+# Agent pools
+
+Agent pools are named, concurrency-bounded thread pools for agent work.
+Use a pool when many independently-submitted tasks need to share **one**
+concurrency budget — capping how many PR-review agents run at once,
+fairly draining a per-customer queue, throttling a provider's API tier,
+or routing trigger events through a shared dispatcher.
+
+This page covers the pool surface end to end. For a one-screen LLM
+quickref see the "Agent pools" section in
+`docs/llm/harn-quickref.md`. For runnable patterns see
+[Pool cookbook](./cookbooks/pools.md). The stdlib API reference (every
+exported builtin, option dict, and return shape) lives at
+[Pool stdlib](./stdlib/lifecycle-pool.md).
+
+## When to use a pool
+
+Pools are one of several ways to bound concurrency in Harn. Pick the
+narrowest one that fits.
+
+| Goal | Use | Why |
+|---|---|---|
+| Bound concurrency at one call site | `parallel each ... with { max_concurrent: N }` | Local, no registry, lives and dies with the parallel block. |
+| Bound concurrency across many call sites in one pipeline | **Pool**, scope `"session"` | One named budget shared by every `pool.submit` in the process. No durability. |
+| Bound concurrency across pipeline runs that survive restart | **Pool**, scope `"pipeline"` | JSONL state in `.harn/pools/` survives crashes; pending tasks resume on next start. |
+| Bound concurrency across tenants/orgs (cloud) | **Pool**, scope `"tenant"` / `"org"` | Host-routed (harn-cloud, #306). Accepted at API level; today fails with a clear host-routed diagnostic. |
+| Route trigger events through a shared concurrency budget | **Pool** + `SpawnToPool` handler | One trigger per provider, one pool draining them at a fixed rate. |
+| Block on a cap inside one task | A semaphore (`std/sync`) | Pools are *task-shaped*; semaphores are *thread-shaped*. |
+
+Three anti-patterns worth calling out:
+
+- **Pools are not message queues.** They submit *closures*, not data.
+  If you need a typed mailbox between tasks, use the in-process
+  `channel(...)` primitive (see `docs/src/concurrency.md`).
+- **Pools are not durable workflows.** Pipeline-scope pools persist
+  *queued* and *in-flight* state so the pool survives restart, but the
+  task closures themselves are not journalled. A task killed mid-run
+  re-enqueues as a fresh attempt — at-least-once, not exactly-once.
+  Idempotent task bodies are your responsibility.
+- **Pools are not fan-out triggers.** One submit runs one closure.
+  Use a `channel.emit` trigger when many subscribers should react to
+  one event.
+
+## Create a pool
+
+`pool_create(options?)` allocates a new pool, registers it under
+`options.name`, and returns a handle:
+
+```harn,ignore
+import { pool_create } from "std/lifecycle/pool"
+
+let pool = pool_create({
+  name: "pr-review",
+  max_concurrent: 5,
+})
+```
+
+Names must be unique within a `(scope, scope_id)` pair. Re-creating
+the same `(scope, scope_id, name)` returns the existing handle (with
+the same id) so reload-after-restart is idempotent.
+
+The returned handle is a dict with:
+
+```text
+{
+  _type: "pool",
+  id: string,                 // deterministic per (scope, scope_id, name)
+  name: string,
+  max_concurrent: int,
+  scope: "session" | "pipeline" | "tenant" | "org",
+  created_at: string,
+  // callable methods (closures over the pool id)
+  submit: (closure, options?) -> task_handle,
+  size: () -> int,
+  snapshot: () -> dict,
+}
+```
+
+### Options
+
+| Option | Type | Default | Notes |
+|---|---|---|---|
+| `name` | string | auto-generated | Visible in `pool_list()` and snapshots. Used for `pool_get(name)`. |
+| `max_concurrent` | int | `1` | Hard cap on simultaneously running tasks. Must be `>= 1`. |
+| `queue` | dict / string | `priority()` | Queue strategy descriptor (see [Queue strategies](#queue-strategies)). |
+| `backpressure` | dict / string | unbounded | Backpressure descriptor (see [Backpressure](#backpressure)). `nil` keeps the queue unbounded. |
+| `scope` | string | `"session"` | Durability scope: `"session"`, `"pipeline"`, `"tenant"`, or `"org"`. |
+| `pipeline_id` | string | active pipeline id | Required for `scope: "pipeline"` when not running inside a pipeline. |
+| `stale_after_ms` | int / duration | `30000` | Pipeline scope: a `Running` task with no heartbeat in this window is re-enqueued on reload. |
+
+`pool_get(name_or_id)` looks up an existing pool and returns `nil` when
+not found. `pool_list()` returns every pool registered in the current
+runtime.
+
+## Submit work
+
+`pool.submit(closure, options?)` enqueues a zero-arg closure. The pool
+spawns a worker the moment a slot is free; everything else queues
+according to the pool's queue strategy and backpressure policy.
+
+```harn,ignore
+let handle = pool.submit({ ->
+  return agent_loop("review this PR", "You are a careful reviewer.")
+}, {
+  priority: 10,
+  tenant_id: "acme",
+  idempotency_key: "review-pr-1984",
+})
+```
+
+### Submit options
+
+| Option | Type | Notes |
+|---|---|---|
+| `priority` | int | Higher dequeues sooner under `priority()`. Defaults to `0`. Ignored by other strategies (still recorded). |
+| `key` | string | Generic fairness key under `fair_round_robin("key")`. Also stamped on the task snapshot for observability. |
+| custom key (e.g. `tenant_id`) | string | When using `fair_round_robin("tenant_id")`, pass the partition value under that name. |
+| `idempotency_key` | string | Two submits with the same key return the *same* task handle. The second call short-circuits to the first task's terminal snapshot. |
+
+### Task handle
+
+Each `submit` returns a task handle (`_type: "pool_task"`):
+
+```text
+{
+  _type: "pool_task",
+  id: string,
+  pool: string,
+  pool_id: string,
+  submitted_at: string,
+  status: "queued" | "running" | "completed" | "failed" | "rejected",
+  key: string | nil,
+  priority: int,
+  // populated when terminal:
+  result: any,
+  error: string | nil,
+  rejection_reason: string | nil,   // when status == "rejected"
+  rejection_policy: string | nil,   // "fail_fast" | "fail_submitter" | "drop_oldest" | "drop_newest"
+}
+```
+
+Rejected handles never run. The terminal snapshot carries
+`rejection_reason` and `rejection_policy` so callers can branch without
+catching an error.
+
+## Wait on a task
+
+`pool_wait(handle)` blocks until the task reaches a terminal state and
+returns the final task snapshot. Passing a list of handles waits for
+all of them:
+
+```harn,ignore
+import { pool_wait } from "std/lifecycle/pool"
+
+let handles = [pool.submit(work_a), pool.submit(work_b), pool.submit(work_c)]
+let outcomes = pool_wait(handles)
+```
+
+`wait_agent(handle)` from `std/agent/workers` recognises pool task
+handles transparently, so user code that already waits on worker
+handles does not need to learn a second waiter API.
+
+## Queue strategies
+
+`std/lifecycle/pool` exports four strategy factories. Pass the result
+as `pool_create({queue: <strategy>})`:
+
+| Function | Behavior |
+|---|---|
+| `fifo()` | Dequeue oldest queued task first. Ignores submit priority. |
+| `priority()` | Dequeue highest submit-time `priority` first; equal priorities stay FIFO. Default. |
+| `lifo()` | Dequeue newest queued task first. |
+| `fair_round_robin(key = "key")` | Partition queued tasks by the submit option named by `key`, then rotate across distinct values while preserving FIFO inside each partition. |
+
+```harn,ignore
+import { QueueStrategy, pool_create } from "std/lifecycle/pool"
+
+let queue = QueueStrategy()
+let pool = pool_create({
+  name: "tenant-work",
+  max_concurrent: 4,
+  queue: queue.fair_round_robin("tenant_id"),
+})
+```
+
+`QueueStrategy()` is just sugar — it returns
+`{fifo, priority, lifo, fair_round_robin}` for callers that prefer
+dotted access after a single import.
+
+### Fair round-robin partitioning
+
+`fair_round_robin(key_field)` reads `options.<key_field>` on every
+submit. Submits that omit the field share one "default" partition so
+they do not starve. The runtime walks distinct partitions in stable
+order, dequeuing one task per visit, until every queue is drained.
+
+Two tenants with 100 tasks each interleave 1-for-1: tenant A's task 1,
+tenant B's task 1, tenant A's task 2, tenant B's task 2, and so on. A
+third tenant joining mid-drain slides into the rotation at its next
+turn.
+
+## Backpressure
+
+`std/lifecycle/pool` exports three backpressure factories plus the
+`Backpressure()` namespace helper:
+
+| Function | Behavior |
+|---|---|
+| `backpressure_queue(max_depth, on_full = "block_submitter")` | Bounds queued tasks at `max_depth`. `on_full` is one of `"block_submitter"`, `"drop_oldest"`, `"drop_newest"`, or `"fail_submitter"`. |
+| `fail_fast()` | Rejects any submit that cannot start immediately. No queue is retained. |
+| `ring_buffer(capacity)` | Retains the newest `capacity` queued tasks by evicting the oldest queued task on overflow. |
+
+```harn,ignore
+import { Backpressure, pool_create } from "std/lifecycle/pool"
+
+let bp = Backpressure()
+let pool = pool_create({
+  name: "webhook-intake",
+  max_concurrent: 10,
+  backpressure: bp.ring_buffer(100),
+})
+```
+
+`on_full` policies:
+
+| Policy | Effect |
+|---|---|
+| `"block_submitter"` | The submitting fiber parks until a slot is free. Default for `backpressure_queue`. |
+| `"drop_oldest"` | Pop the oldest queued task as a `rejected` handle and accept the new submit. Emits `pool_drop` audit. |
+| `"drop_newest"` | Reject the new submit as a `rejected` handle. Emits `pool_drop` audit. |
+| `"fail_submitter"` | Raise `HARN-POL-001` at the submit call site. The caller can catch and retry. |
+
+`fail_fast()` raises `HARN-POL-002` synchronously when no worker slot
+is free. `drop_oldest`, `drop_newest`, and `ring_buffer` are the
+*silent* drop policies: the submit returns a handle whose terminal
+snapshot has `status: "rejected"`, `rejection_reason`, and
+`rejection_policy`, and a `pool_drop` audit lands on the
+`lifecycle.pool.audit` EventLog topic.
+
+## Scopes and durability
+
+A pool's `scope` decides where its state lives.
+
+| Scope | State | Survives | Notes |
+|---|---|---|---|
+| `"session"` | In-memory thread-local registry. | Process lifetime. | Default. Zero I/O. |
+| `"pipeline"` | JSONL append-log under `.harn/pools/<pipeline_id>__<pool_name>.jsonl`. | Process restart, within one pipeline. | Pending queue + in-flight task metadata reload on next `pool_create({scope: "pipeline", ...})`. |
+| `"tenant"` | Host-routed (harn-cloud, [#306](https://github.com/burin-labs/harn-cloud/issues/306)). | Tenant lifetime, cross-pipeline. | Currently fails with a `host-routed (harn-cloud) — not wired` diagnostic. |
+| `"org"` | Host-routed. | Org lifetime, cross-tenant. | Currently fails with a `host-routed (harn-cloud) — not wired` diagnostic. |
+
+### Pipeline scope on reload
+
+When a pipeline-scope pool reloads after a restart:
+
+1. The JSONL log is replayed to reconstruct queued + in-flight tasks.
+2. Any task whose `heartbeat_at_ms` is older than `stale_after_ms`
+   (default 30s) is treated as crashed and re-enqueued at the front
+   of its partition.
+3. Tasks with `idempotency_key` short-circuit on resubmit: the second
+   `pool.submit(closure, {idempotency_key: "..."})` returns the
+   previously recorded terminal snapshot instead of running again.
+
+The log is compacted opportunistically: when reload sees
+`max_concurrent + |queue| + |terminal-since-compaction|` exceed an
+internal threshold, the next `pool_create` rewrites the log with only
+live state.
+
+`pool_simulate_restart()` drops the in-process registry without
+touching disk, so pipeline-scope pools can be exercised under
+conformance tests by re-calling `pool_create(...)` and asserting the
+queue rehydrates.
+
+## Idempotency
+
+`options.idempotency_key` on `pool.submit` makes the submission
+idempotent. Two submits with the same `(pool_id, idempotency_key)`
+return the *same* task handle:
+
+```harn,ignore
+let first = pool.submit({ -> review(pr) }, {idempotency_key: "review-pr-1984"})
+let second = pool.submit({ -> review(pr) }, {idempotency_key: "review-pr-1984"})
+println(first.id == second.id)   // true
+```
+
+This is load-bearing for pipeline-scope pools: a worker that crashed
+mid-submit can re-enter with the same key and pick up the previously
+recorded outcome instead of double-running the closure.
+
+## Trigger composition: `SpawnToPool`
+
+A `channel.emit` trigger (or any trigger source) can route matched
+events into a named pool instead of spawning a fresh worker per event.
+Use the `SpawnToPool` handler variant from `std/triggers`:
+
+```harn,ignore
+import { trigger_register, SpawnToPool } from "std/triggers"
+import { pool_create, fair_round_robin } from "std/lifecycle/pool"
+
+let pool = pool_create({
+  name: "webhook-work",
+  max_concurrent: 10,
+  queue: fair_round_robin("source"),
+})
+
+trigger_register({
+  id: "webhook-router",
+  kind: "channel.emit",
+  provider: "channel",
+  match: {events: ["channel:webhook.received"]},
+  handler: SpawnToPool({
+    pool: "webhook-work",
+    priority_from: "provider_payload.payload.urgency",
+    key_from: "provider_payload.payload.source",
+    task_factory: { event -> { -> handle_webhook(event) } },
+  }),
+})
+```
+
+`SpawnToPool` options:
+
+| Option | Notes |
+|---|---|
+| `pool` | Name (or id) of the pool to submit into. The pool must already exist; missing pools land in `trigger.dlq`. |
+| `priority_from` | Dotted JSON path into the trigger event. Resolved to an int and passed as `options.priority`. Missing path falls back to `0`. |
+| `key_from` | Dotted JSON path resolved to a string and passed as `options.key` (and as the partition value for `fair_round_robin`). Missing path falls back to the default partition. |
+| `task_factory` | Closure `event -> closure`. Builds the per-event zero-arg closure the pool submits. |
+
+Each dispatched event becomes one `pool.submit` call. The trigger
+dispatcher records the resulting task id on the match receipt so
+replay can verify the same event mapped to the same pool task across
+runs.
+
+## Inspection
+
+| Surface | Purpose |
+|---|---|
+| `pool.size()` | Live count of active + queued tasks. Excludes terminal-state tasks. |
+| `pool.snapshot()` | Full dict: `active`, `queued`, `completed`, `failed`, `rejected`, `blocked_submitters`, `total`, selected `queue`, selected `backpressure`, `scope`, `scope_id`, `stale_after_ms`, the per-task list, and the original `config` so dashboards can show "what was configured". |
+| `pool_get(name_or_id)` | Lookup by name. Returns `nil` when missing. |
+| `pool_list()` | Every pool registered on the current runtime. |
+| `harness.unsettled_state().pool_pending_tasks` | Pipeline-lifecycle integration: lists tasks blocking pipeline finalization. See [pipeline lifecycle](./stdlib/lifecycle.md). |
+
+## Observability
+
+Pools produce one observable stream end-to-end:
+
+| Topic | Purpose | Records |
+|---|---|---|
+| `lifecycle.pool.audit` | Durable audit. Receipts for create, submit, dispatch, terminal, and drop. | `pool_create`, `pool_submit`, `pool_dispatch`, `pool_complete`, `pool_drop` |
+
+OTel spans wrap every submit (`pool.submit <pool_name>`) and every
+dispatch (`pool.dispatch <pool_name>`). The dispatch span links back
+to the submit span via `set_span_link` (#1858) so traces across the
+async boundary stay stitched even when the queue holds tasks for
+minutes.
+
+The pool task snapshot carries `submitted_by` (the caller's
+`workflow_id`, `agent_session_id`, or `worker_id`, falling back to
+`"user"`) so audit consumers can attribute work back to its origin.
+
+## Diagnostic codes
+
+| Code | When |
+|---|---|
+| `HARN-POL-001` | A `backpressure_queue(..., "fail_submitter")` pool was full at submit time. |
+| `HARN-POL-002` | A `fail_fast()` pool had no immediate capacity at submit time. |
+
+Drop policies (`drop_oldest`, `drop_newest`, `ring_buffer`) do **not**
+raise — they emit a `pool_drop` audit and return a `rejected` task
+handle. Errors raised inside the closure surface as
+`status: "failed"` with the error message on the task snapshot.
+
+## Design rationale
+
+Pools close a gap between Harn's two existing concurrency tools.
+`parallel each ... with { max_concurrent: N }` bounds one call site;
+spawned workers carry one budget per spawn. Neither lets *many
+independent submitters* share *one* budget across a pipeline or
+process, which is exactly what rate-limiting an LLM tier or fairly
+draining a multi-tenant queue requires.
+
+| System | Per-callsite bound | Shared budget across submitters | Fair multi-tenant queue | Durable across restart |
+|---|---|---|---|---|
+| Temporal `ChildWorkflowOptions` | Limited (per workflow) | No first-class primitive | No | Yes |
+| Inngest `concurrency` keys | Yes | Yes (per key) | Yes (`concurrency.key`) | Yes |
+| Restate keyed services | Yes | Yes (per key) | Yes (per key) | Yes |
+| **Harn pools** | `parallel each` | **`pool_create + pool.submit`** | **`fair_round_robin(key)`** | **`scope: "pipeline"`** |
+
+The wager is that agent orchestration needs all four — local bounds,
+shared bounds, fair partitioning, and restart-safe queues — and that
+hosting them in one primitive (named pools with pluggable queue +
+backpressure descriptors) keeps the trust boundary (Harn owns the
+queue and audit; hosts own remote execution) and the replay model
+(`lifecycle.pool.audit` is the byte-comparable spec) intact.
+
+Cross-references:
+
+- [Pool cookbook](./cookbooks/pools.md) — four end-to-end recipes
+  (rate-limited webhook processor, GPU-routed inference, cross-customer
+  fairness, burst absorber).
+- [Pool stdlib](./stdlib/lifecycle-pool.md) — exhaustive builtin and
+  option reference.
+- [Triggers](./triggers.md) — the general trigger surface that
+  `SpawnToPool` plugs into.
+- [Pipeline lifecycle presets](./stdlib/lifecycle.md) — pool tasks
+  surface in `harness.unsettled_state().pool_pending_tasks`.
+- Issue [#1883](https://github.com/burin-labs/harn/issues/1883) — the
+  epic this primitive lands under.

--- a/docs/src/cookbooks/pools.md
+++ b/docs/src/cookbooks/pools.md
@@ -1,0 +1,282 @@
+# Pool cookbook
+
+Four end-to-end patterns for agent pools (#1883). Each recipe is a
+complete, copy-paste starting point. For the surface reference see
+[Agent pools](../agent-pools.md); for the LLM-friendly quickref see
+the "Agent pools" section in `docs/llm/harn-quickref.md`.
+
+The recipes use `harn,ignore` fences because they wire up full
+multi-pipeline topologies (producer pipeline, pool-draining pipeline,
+and trigger handlers). Each fragment type-checks; the orchestration
+loop assumes a host that runs the constituent pipelines (such as
+`harn orchestrator`).
+
+## 1. Rate-limited webhook processor
+
+Every webhook source posts to a single `channel:webhook.received`
+channel. A pool with `max_concurrent: 10`, a per-source fair queue,
+and a `ring_buffer(500)` overflow policy drains them. Bursty senders
+cannot starve quieter ones; an unbounded spike drops the oldest
+queued task (a `pool_drop` audit lands on `lifecycle.pool.audit`) but
+never the actively-running ones.
+
+```harn,ignore
+import { trigger_register, SpawnToPool } from "std/triggers"
+import { Backpressure, fair_round_robin, pool_create } from "std/lifecycle/pool"
+
+pipeline webhook_intake_setup() {
+  let bp = Backpressure()
+
+  // One named pool, shared across every webhook source.
+  pool_create({
+    name: "webhook-work",
+    max_concurrent: 10,
+    queue: fair_round_robin("source"),
+    backpressure: bp.ring_buffer(500),
+    scope: "pipeline",
+  })
+
+  // Generic webhook connector emits `channel:webhook.received` for
+  // every inbound payload. Route the channel into the pool.
+  trigger_register({
+    id: "webhook-router",
+    kind: "channel.emit",
+    provider: "channel",
+    match: {events: ["channel:webhook.received"]},
+    handler: SpawnToPool({
+      pool: "webhook-work",
+      key_from: "provider_payload.payload.source",
+      priority_from: "provider_payload.payload.urgency",
+      task_factory: { event ->
+        let payload = event.provider_payload.payload
+        return { -> process_webhook(payload) }
+      },
+    }),
+  })
+}
+
+fn process_webhook(payload) {
+  // Idempotent handler — see recipe 4 for the durable-key pattern.
+  return upsert_event(payload.source, payload.body)
+}
+```
+
+Why a pool over per-source rate limiters: ten sources times one
+limiter each is ten queues with no shared budget. A single pool with
+`fair_round_robin("source")` enforces both the *global* cap (ten
+workers, period) and *per-source* fairness in one primitive.
+
+Why `ring_buffer(500)` over `block_submitter`: blocking the webhook
+intake fiber stalls the entire connector. Dropping the oldest queued
+task is the correct backpressure shape for an overloaded webhook
+endpoint — the audit trail tells you who got dropped, and the
+underlying retry policy of the sender re-delivers later.
+
+Why `scope: "pipeline"`: the connector pipeline restarts on every
+deploy. Pipeline scope reloads queued tasks from
+`.harn/pools/<pipeline_id>__webhook-work.jsonl` so an in-flight burst
+does not vanish on restart.
+
+## 2. GPU-routed inference pool
+
+A multi-tenant inference service has four GPUs. Each inference call
+must run on exactly one GPU; the pool's `max_concurrent` is sized to
+the GPU count and the worker tier is pinned via the harn-cloud worker
+selector. Tenants share the budget fairly, and any cross-tenant burst
+queues rather than spilling onto non-GPU hosts.
+
+```harn,ignore
+import { trigger_register, SpawnToPool } from "std/triggers"
+import { Backpressure, fair_round_robin, pool_create, pool_wait } from "std/lifecycle/pool"
+
+pipeline inference_pool_setup() {
+  let bp = Backpressure()
+  let gpu_count = 4   // discovered from the host worker tier in real deployments
+
+  pool_create({
+    name: "gpu-inference",
+    max_concurrent: gpu_count,
+    queue: fair_round_robin("tenant_id"),
+    backpressure: bp.queue(1000, "fail_submitter"),
+    scope: "tenant",   // harn-cloud routes to the GPU-tier worker pool
+  })
+
+  trigger_register({
+    id: "inference-router",
+    kind: "channel.emit",
+    provider: "channel",
+    match: {events: ["channel:inference.requested"]},
+    handler: SpawnToPool({
+      pool: "gpu-inference",
+      key_from: "provider_payload.payload.tenant_id",
+      task_factory: { event ->
+        let req = event.provider_payload.payload
+        return { ->
+          // Per-request closure; runs on a GPU-tier worker because the
+          // pool's scope routes through the harn-cloud GPU worker tier.
+          return run_gpu_inference(req.model, req.prompt, req.params)
+        }
+      },
+    }),
+  })
+}
+
+// Synchronous caller path that wraps the trigger flow for in-process use.
+pipeline inference_call(tenant_id, model, prompt, params) {
+  let pool = pool_get("gpu-inference")
+  let handle = pool.submit({ ->
+    return run_gpu_inference(model, prompt, params)
+  }, {tenant_id: tenant_id})
+
+  return pool_wait(handle).result
+}
+```
+
+Why one pool over per-GPU pools: rebalancing across four pools when
+one tenant is idle is your problem; rebalancing within one pool is
+the runtime's. `max_concurrent: 4` plus `fair_round_robin` gives both
+the hard cap and the dynamic balance for free.
+
+Why `fail_submitter` over `block_submitter`: an inference request that
+backs up for more than ~1000 deep is almost certainly going to time
+out at the caller anyway. Failing fast with `HARN-POL-001` lets the
+caller pick a fallback model or shed load deliberately.
+
+Why `scope: "tenant"`: the pool routes through harn-cloud's GPU
+worker tier (#306). Today this fails with a `host-routed (harn-cloud)
+— not wired` diagnostic; you can run the same code with
+`scope: "session"` for local development and flip the scope at deploy
+time.
+
+## 3. Cross-customer fairness
+
+A SaaS backend runs per-customer agent tasks (PR review, doc gen,
+test triage). Without fairness, a single noisy customer's batch of
+500 PRs starves every other customer for hours. `fair_round_robin`
+on the customer id flips the worst case from "one customer drains
+the queue" to "all active customers interleave one task at a time."
+
+```harn,ignore
+import { trigger_register, SpawnToPool } from "std/triggers"
+import { Backpressure, fair_round_robin, pool_create } from "std/lifecycle/pool"
+
+pipeline tenant_work_setup() {
+  let bp = Backpressure()
+
+  pool_create({
+    name: "tenant-agents",
+    max_concurrent: 20,
+    queue: fair_round_robin("tenant_id"),
+    backpressure: bp.queue(5000, "block_submitter"),
+    scope: "pipeline",
+  })
+
+  // Direct submits from a connector loop.
+  trigger_register({
+    id: "tenant-agent-router",
+    kind: "channel.emit",
+    provider: "channel",
+    match: {events: ["channel:agent_task.requested"]},
+    handler: SpawnToPool({
+      pool: "tenant-agents",
+      key_from: "provider_payload.payload.tenant_id",
+      priority_from: "provider_payload.payload.priority",
+      task_factory: { event ->
+        let req = event.provider_payload.payload
+        return { -> run_agent_task(req.tenant_id, req.task_kind, req.input) }
+      },
+    }),
+  })
+}
+
+fn run_agent_task(tenant_id, kind, input) {
+  return agent_loop(input, "You are the " + kind + " agent.")
+}
+```
+
+Tenant A submits 500 tasks, tenant B submits 10. Under FIFO, tenant
+B's first task waits behind 500 of tenant A's; under
+`fair_round_robin("tenant_id")`, tenant B's first task runs on the
+*second* free slot. Once tenant B drains, tenant A keeps the full 20
+workers to itself.
+
+Why `block_submitter` over a drop policy: cross-customer fairness only
+matters when *both* customers have work to submit. Blocking the
+submitter at 5000 queued is a backstop against runaway producers
+without losing any work.
+
+Why `scope: "pipeline"`: the queue depth at restart can be tens of
+thousands of tasks. Pipeline scope reloads them and resumes
+draining; the per-task idempotency key (see recipe 4) catches the
+brief window where in-flight tasks are re-enqueued.
+
+## 4. Burst absorber for nightly batch jobs
+
+A nightly cron triggers thousands of report-generation tasks. They
+need to all *eventually* run, but only a few at a time to avoid
+saturating a downstream SaaS API. A small `max_concurrent` plus a
+large queue depth turns a "thundering herd" into a slow drain.
+
+```harn,ignore
+import { trigger_register, SpawnToPool } from "std/triggers"
+import { Backpressure, fifo, pool_create, pool_wait } from "std/lifecycle/pool"
+
+pipeline nightly_report_setup() {
+  let bp = Backpressure()
+
+  pool_create({
+    name: "nightly-reports",
+    max_concurrent: 3,                       // small drain rate
+    queue: fifo(),                           // run in submission order
+    backpressure: bp.queue(50000, "fail_submitter"),  // large absorber
+    scope: "pipeline",
+  })
+
+  // Cron-triggered fan-out: one submit per customer report.
+  trigger_register({
+    id: "nightly-report-cron",
+    kind: "cron",
+    provider: "cron",
+    match: {schedule: "0 2 * * *"},          // 02:00 UTC nightly
+    handler: { event ->
+      let pool = pool_get("nightly-reports")
+      let customers = list_active_customers()
+      for customer in customers {
+        // Idempotency key = (run date, customer). A retry of the cron
+        // for the same date short-circuits to the same task handle
+        // instead of double-running.
+        let key = event.occurred_at_date + ":" + customer.id
+        pool.submit({ ->
+          return generate_report(customer.id, event.occurred_at_date)
+        }, {idempotency_key: key})
+      }
+    },
+  })
+}
+
+fn generate_report(customer_id, run_date) {
+  let data = fetch_customer_data(customer_id, run_date)   // slow SaaS call
+  return upload_report(customer_id, run_date, data)
+}
+```
+
+Why `fifo` over `priority`: every report has the same priority; ties
+under `priority()` are FIFO anyway, but `fifo()` documents intent and
+saves the priority comparator on every dequeue.
+
+Why a 50000-deep queue: nightly cron can fan out tens of thousands of
+tasks in a single burst. A small queue would force the cron handler
+to either block or drop; either is the wrong shape for a once-a-night
+job. The queue absorbs the burst and drains it across the rest of
+the night at 3-at-a-time.
+
+Why `idempotency_key`: the cron may retry if the orchestrator
+restarts mid-handler. Without the key, every customer would get two
+reports for the same date. With `(date, customer_id)` as the key,
+the second submit returns the first task's handle and the closure
+runs exactly once per night per customer.
+
+Why `scope: "pipeline"`: the orchestrator can restart mid-night and
+the remaining queue picks back up where it left off. Pipeline scope
+plus idempotency keys is the canonical "at-least-once with
+deduplication" pattern.

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -2080,6 +2080,191 @@ See `docs/src/observability/replay-benchmarks.md` for the oracle
 interface. The user-facing reference is `docs/src/agent-channels.md`;
 runnable patterns live in `docs/src/cookbooks/channels.md`.
 
+### Agent pools
+
+Agent pools (epic #1883) are named, concurrency-bounded thread pools
+for agent work. They sit between `parallel each ... with {
+max_concurrent: N }` (a local, call-site bound) and host worker tiers
+(a deployment-time bound), filling the "many independent submitters
+share one budget" gap. Pools are exposed through `std/lifecycle/pool`
+and the host-call group registered at
+`crates/harn-vm/src/stdlib/pool.rs`.
+
+#### `Pool`
+
+```text
+PoolHandle ::= {
+  _type: "pool",
+  id: string,                 // deterministic = sha256(scope || scope_id || name)
+  name: string,
+  max_concurrent: int (>= 1),
+  scope: PoolScope,
+  created_at: ISO8601String,
+  submit: (closure, options?) -> PoolTaskHandle,
+  size: () -> int,
+  snapshot: () -> PoolSnapshot,
+}
+
+PoolScope ::= "session" | "pipeline" | "tenant" | "org"
+```
+
+`pool_create(options?)` allocates a handle; `pool_get(name_or_id)`
+returns an existing one or `nil`; `pool_list()` enumerates the
+runtime registry. Re-creating the same `(scope, scope_id, name)` is
+idempotent and returns the existing handle, so reload across process
+restart binds to the same id.
+
+#### `PoolTaskHandle`
+
+```text
+PoolTaskHandle ::= {
+  _type: "pool_task",
+  id: string,
+  pool: string,                       // pool name
+  pool_id: string,
+  status: "queued" | "running" | "completed" | "failed" | "rejected",
+  submitted_at: ISO8601String,
+  priority: int,
+  key: string | nil,
+  // terminal-only:
+  result: any,
+  error: string | nil,
+  rejection_reason: string | nil,
+  rejection_policy: string | nil      // "fail_fast" | "fail_submitter" | "drop_oldest" | "drop_newest"
+}
+```
+
+`pool_wait(handle_or_handles)` blocks until terminal and returns the
+final snapshot (or list of snapshots). `wait_agent(handle)` from
+`std/agent/workers` accepts pool task handles transparently by
+matching on `_type == "pool_task"`.
+
+#### Queue strategies
+
+`pool_create({queue: <descriptor>})` selects how the pool dequeues
+work when a worker slot frees:
+
+```text
+QueueStrategy ::= {_type: "queue_strategy", kind: "fifo" | "priority" | "lifo" | "fair_round_robin", key?: string}
+```
+
+Semantics:
+
+- `fifo` — oldest queued first, ignoring submit `priority`.
+- `priority` (default) — highest submit `priority` first, FIFO
+  tiebreak.
+- `lifo` — newest queued first.
+- `fair_round_robin{key}` — partition queued tasks by the
+  stringified value at `options.<key>` on each submit. Missing field
+  shares one default partition. The runtime walks distinct
+  partitions in stable order, dequeuing one task per visit; FIFO
+  inside a partition.
+
+Factories (`std/lifecycle/pool`): `fifo()`, `priority()`, `lifo()`,
+`fair_round_robin(key = "key")`. `QueueStrategy()` returns the four
+as a dict for dotted access.
+
+#### Backpressure
+
+`pool_create({backpressure: <descriptor>})` bounds the queue and
+selects the overflow policy:
+
+```text
+Backpressure ::= {_type: "backpressure", kind: "queue" | "fail_fast" | "ring_buffer", max_depth?: int, on_full?: OnFullPolicy, capacity?: int}
+
+OnFullPolicy ::= "block_submitter" | "drop_oldest" | "drop_newest" | "fail_submitter"
+```
+
+Semantics:
+
+- `queue{max_depth, on_full}` — bound queued tasks at `max_depth`.
+  `block_submitter` (default) parks the submitting fiber until a
+  slot frees. `drop_oldest` evicts the oldest queued task as a
+  `rejected` handle and accepts the new submit. `drop_newest`
+  rejects the new submit. `fail_submitter` raises `HARN-POL-001` at
+  the submit call site.
+- `fail_fast{}` — raise `HARN-POL-002` synchronously when no worker
+  slot is immediately free; no queue is retained.
+- `ring_buffer{capacity}` — retain the newest `capacity` queued
+  tasks by evicting the oldest queued task on overflow.
+
+Drop policies (`drop_oldest`, `drop_newest`, `ring_buffer`) emit a
+`pool_drop` audit on `lifecycle.pool.audit` with the pool name,
+evicted task id, policy, queue depth, and max depth. The submitter
+sees a task handle whose terminal snapshot is
+`{status: "rejected", rejection_reason, rejection_policy}`.
+
+#### Scopes and durability
+
+| Scope | Storage | Survives | Notes |
+|---|---|---|---|
+| `session` | In-memory thread-local registry. | Process lifetime. | Default. Zero I/O. |
+| `pipeline` | JSONL append-log under `.harn/pools/<pipeline_id>__<pool_name>.jsonl`. | Process restart, within one pipeline. | Pending queue + in-flight task metadata reload on next `pool_create({scope: "pipeline", ...})`. |
+| `tenant`, `org` | Host-routed (harn-cloud, [#306][harn-cloud-306]). | Tenant / org lifetime. | Currently rejected with a `host-routed (harn-cloud) — not wired` diagnostic. |
+
+[harn-cloud-306]: https://github.com/burin-labs/harn-cloud/issues/306
+
+On pipeline-scope reload, any `Running` task whose `heartbeat_at_ms`
+is older than `stale_after_ms` (default 30000 ms; configurable via
+`opts.stale_after_ms`) is re-enqueued at the head of its partition.
+The store compacts opportunistically when
+`max_concurrent + |queue| + |terminal-since-compaction|` exceeds an
+internal threshold. `pool_simulate_restart()` drops the in-process
+registry without touching disk and is the conformance affordance for
+reload tests.
+
+#### Idempotency
+
+`pool.submit(closure, {idempotency_key: K, ...})` short-circuits when
+`(pool_id, K)` already exists in the idempotency index. The second
+call returns the *same* task handle (`id` matches the first) and, if
+the first task is terminal, the terminal snapshot. Pipeline-scope
+pools persist the index so resubmit across restart preserves the
+contract.
+
+#### `spawn_to_pool` trigger handler
+
+A trigger binding may route matched events into a named pool by
+declaring a `SpawnToPool` handler (from `std/triggers`):
+
+```text
+SpawnToPoolHandler ::= {
+  kind: "spawn_to_pool",
+  pool: string,                             // pool name or id
+  task_factory: (event -> closure),         // builds the per-event closure
+  priority_from?: string,                   // dotted JSON path; missing -> 0
+  key_from?: string                         // dotted JSON path; missing -> default partition
+}
+```
+
+The dispatcher resolves `pool` via `pool_get`, invokes
+`task_factory(event)`, and submits the resulting closure under the
+pool's queue strategy + backpressure policy. The resulting pool task
+id is recorded on the trigger match receipt so the replay oracle can
+verify the same event maps to the same task across runs. A missing
+pool name lands in `trigger.dlq`.
+
+#### Observability
+
+Pool activity is published on one EventLog topic:
+
+| Topic | Records |
+|---|---|
+| `lifecycle.pool.audit` | `pool_create`, `pool_submit`, `pool_dispatch`, `pool_complete`, `pool_drop` |
+
+Every submit opens an OTel `pool.submit <pool_name>` span; every
+dispatch opens `pool.dispatch <pool_name>` and links back to the
+submit span via `set_span_link` (#1858) so async-boundary traces
+remain stitched.
+
+Pool tasks surface in pipeline lifecycle drains:
+`harness.unsettled_state().pool_pending_tasks` lists tasks blocking
+pipeline finalization (see `docs/src/stdlib/lifecycle.md`).
+
+The user-facing reference is `docs/src/agent-pools.md`; the stdlib
+reference is `docs/src/stdlib/lifecycle-pool.md`; runnable patterns
+live in `docs/src/cookbooks/pools.md`.
+
 ## Error model
 
 ### throw
@@ -4730,6 +4915,13 @@ programs.
 | `HARN-CHN-003` | Malformed channel name, scope prefix, or scope id. |
 | `HARN-CHN-004` | Scope ambiguous — explicit `options.session_id` or `options.pipeline_id` conflicts with the active runtime context. |
 | `HARN-CHN-005` | Malformed `batch` config on a `trigger_register` call (missing `count`/`window`, non-positive `count`, unknown `expire_action`, or wrong-typed `key`). |
+
+#### Agent pool diagnostics (`HARN-POL-*`)
+
+| Code | Description |
+|---|---|
+| `HARN-POL-001` | A `backpressure_queue(..., "fail_submitter")` pool was full at submit time. Drop policies do not raise — they return a `rejected` task handle and emit a `pool_drop` audit on `lifecycle.pool.audit`. |
+| `HARN-POL-002` | A `fail_fast()` pool had no immediate capacity at submit time. The submitter receives the error synchronously; no task is enqueued. |
 
 ## OAuth
 

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -2078,6 +2078,191 @@ See `docs/src/observability/replay-benchmarks.md` for the oracle
 interface. The user-facing reference is `docs/src/agent-channels.md`;
 runnable patterns live in `docs/src/cookbooks/channels.md`.
 
+### Agent pools
+
+Agent pools (epic #1883) are named, concurrency-bounded thread pools
+for agent work. They sit between `parallel each ... with {
+max_concurrent: N }` (a local, call-site bound) and host worker tiers
+(a deployment-time bound), filling the "many independent submitters
+share one budget" gap. Pools are exposed through `std/lifecycle/pool`
+and the host-call group registered at
+`crates/harn-vm/src/stdlib/pool.rs`.
+
+#### `Pool`
+
+```text
+PoolHandle ::= {
+  _type: "pool",
+  id: string,                 // deterministic = sha256(scope || scope_id || name)
+  name: string,
+  max_concurrent: int (>= 1),
+  scope: PoolScope,
+  created_at: ISO8601String,
+  submit: (closure, options?) -> PoolTaskHandle,
+  size: () -> int,
+  snapshot: () -> PoolSnapshot,
+}
+
+PoolScope ::= "session" | "pipeline" | "tenant" | "org"
+```
+
+`pool_create(options?)` allocates a handle; `pool_get(name_or_id)`
+returns an existing one or `nil`; `pool_list()` enumerates the
+runtime registry. Re-creating the same `(scope, scope_id, name)` is
+idempotent and returns the existing handle, so reload across process
+restart binds to the same id.
+
+#### `PoolTaskHandle`
+
+```text
+PoolTaskHandle ::= {
+  _type: "pool_task",
+  id: string,
+  pool: string,                       // pool name
+  pool_id: string,
+  status: "queued" | "running" | "completed" | "failed" | "rejected",
+  submitted_at: ISO8601String,
+  priority: int,
+  key: string | nil,
+  // terminal-only:
+  result: any,
+  error: string | nil,
+  rejection_reason: string | nil,
+  rejection_policy: string | nil      // "fail_fast" | "fail_submitter" | "drop_oldest" | "drop_newest"
+}
+```
+
+`pool_wait(handle_or_handles)` blocks until terminal and returns the
+final snapshot (or list of snapshots). `wait_agent(handle)` from
+`std/agent/workers` accepts pool task handles transparently by
+matching on `_type == "pool_task"`.
+
+#### Queue strategies
+
+`pool_create({queue: <descriptor>})` selects how the pool dequeues
+work when a worker slot frees:
+
+```text
+QueueStrategy ::= {_type: "queue_strategy", kind: "fifo" | "priority" | "lifo" | "fair_round_robin", key?: string}
+```
+
+Semantics:
+
+- `fifo` — oldest queued first, ignoring submit `priority`.
+- `priority` (default) — highest submit `priority` first, FIFO
+  tiebreak.
+- `lifo` — newest queued first.
+- `fair_round_robin{key}` — partition queued tasks by the
+  stringified value at `options.<key>` on each submit. Missing field
+  shares one default partition. The runtime walks distinct
+  partitions in stable order, dequeuing one task per visit; FIFO
+  inside a partition.
+
+Factories (`std/lifecycle/pool`): `fifo()`, `priority()`, `lifo()`,
+`fair_round_robin(key = "key")`. `QueueStrategy()` returns the four
+as a dict for dotted access.
+
+#### Backpressure
+
+`pool_create({backpressure: <descriptor>})` bounds the queue and
+selects the overflow policy:
+
+```text
+Backpressure ::= {_type: "backpressure", kind: "queue" | "fail_fast" | "ring_buffer", max_depth?: int, on_full?: OnFullPolicy, capacity?: int}
+
+OnFullPolicy ::= "block_submitter" | "drop_oldest" | "drop_newest" | "fail_submitter"
+```
+
+Semantics:
+
+- `queue{max_depth, on_full}` — bound queued tasks at `max_depth`.
+  `block_submitter` (default) parks the submitting fiber until a
+  slot frees. `drop_oldest` evicts the oldest queued task as a
+  `rejected` handle and accepts the new submit. `drop_newest`
+  rejects the new submit. `fail_submitter` raises `HARN-POL-001` at
+  the submit call site.
+- `fail_fast{}` — raise `HARN-POL-002` synchronously when no worker
+  slot is immediately free; no queue is retained.
+- `ring_buffer{capacity}` — retain the newest `capacity` queued
+  tasks by evicting the oldest queued task on overflow.
+
+Drop policies (`drop_oldest`, `drop_newest`, `ring_buffer`) emit a
+`pool_drop` audit on `lifecycle.pool.audit` with the pool name,
+evicted task id, policy, queue depth, and max depth. The submitter
+sees a task handle whose terminal snapshot is
+`{status: "rejected", rejection_reason, rejection_policy}`.
+
+#### Scopes and durability
+
+| Scope | Storage | Survives | Notes |
+|---|---|---|---|
+| `session` | In-memory thread-local registry. | Process lifetime. | Default. Zero I/O. |
+| `pipeline` | JSONL append-log under `.harn/pools/<pipeline_id>__<pool_name>.jsonl`. | Process restart, within one pipeline. | Pending queue + in-flight task metadata reload on next `pool_create({scope: "pipeline", ...})`. |
+| `tenant`, `org` | Host-routed (harn-cloud, [#306][harn-cloud-306]). | Tenant / org lifetime. | Currently rejected with a `host-routed (harn-cloud) — not wired` diagnostic. |
+
+[harn-cloud-306]: https://github.com/burin-labs/harn-cloud/issues/306
+
+On pipeline-scope reload, any `Running` task whose `heartbeat_at_ms`
+is older than `stale_after_ms` (default 30000 ms; configurable via
+`opts.stale_after_ms`) is re-enqueued at the head of its partition.
+The store compacts opportunistically when
+`max_concurrent + |queue| + |terminal-since-compaction|` exceeds an
+internal threshold. `pool_simulate_restart()` drops the in-process
+registry without touching disk and is the conformance affordance for
+reload tests.
+
+#### Idempotency
+
+`pool.submit(closure, {idempotency_key: K, ...})` short-circuits when
+`(pool_id, K)` already exists in the idempotency index. The second
+call returns the *same* task handle (`id` matches the first) and, if
+the first task is terminal, the terminal snapshot. Pipeline-scope
+pools persist the index so resubmit across restart preserves the
+contract.
+
+#### `spawn_to_pool` trigger handler
+
+A trigger binding may route matched events into a named pool by
+declaring a `SpawnToPool` handler (from `std/triggers`):
+
+```text
+SpawnToPoolHandler ::= {
+  kind: "spawn_to_pool",
+  pool: string,                             // pool name or id
+  task_factory: (event -> closure),         // builds the per-event closure
+  priority_from?: string,                   // dotted JSON path; missing -> 0
+  key_from?: string                         // dotted JSON path; missing -> default partition
+}
+```
+
+The dispatcher resolves `pool` via `pool_get`, invokes
+`task_factory(event)`, and submits the resulting closure under the
+pool's queue strategy + backpressure policy. The resulting pool task
+id is recorded on the trigger match receipt so the replay oracle can
+verify the same event maps to the same task across runs. A missing
+pool name lands in `trigger.dlq`.
+
+#### Observability
+
+Pool activity is published on one EventLog topic:
+
+| Topic | Records |
+|---|---|
+| `lifecycle.pool.audit` | `pool_create`, `pool_submit`, `pool_dispatch`, `pool_complete`, `pool_drop` |
+
+Every submit opens an OTel `pool.submit <pool_name>` span; every
+dispatch opens `pool.dispatch <pool_name>` and links back to the
+submit span via `set_span_link` (#1858) so async-boundary traces
+remain stitched.
+
+Pool tasks surface in pipeline lifecycle drains:
+`harness.unsettled_state().pool_pending_tasks` lists tasks blocking
+pipeline finalization (see `docs/src/stdlib/lifecycle.md`).
+
+The user-facing reference is `docs/src/agent-pools.md`; the stdlib
+reference is `docs/src/stdlib/lifecycle-pool.md`; runnable patterns
+live in `docs/src/cookbooks/pools.md`.
+
 ## Error model
 
 ### throw
@@ -4728,6 +4913,13 @@ programs.
 | `HARN-CHN-003` | Malformed channel name, scope prefix, or scope id. |
 | `HARN-CHN-004` | Scope ambiguous — explicit `options.session_id` or `options.pipeline_id` conflicts with the active runtime context. |
 | `HARN-CHN-005` | Malformed `batch` config on a `trigger_register` call (missing `count`/`window`, non-positive `count`, unknown `expire_action`, or wrong-typed `key`). |
+
+#### Agent pool diagnostics (`HARN-POL-*`)
+
+| Code | Description |
+|---|---|
+| `HARN-POL-001` | A `backpressure_queue(..., "fail_submitter")` pool was full at submit time. Drop policies do not raise — they return a `rejected` task handle and emit a `pool_drop` audit on `lifecycle.pool.audit`. |
+| `HARN-POL-002` | A `fail_fast()` pool had no immediate capacity at submit time. The submitter receives the error synchronously; no task is enqueued. |
 
 ## OAuth
 


### PR DESCRIPTION
## Summary

Closes #1893 (PL-08 under epic #1883). Pool surface is feature-complete — this is the user-facing reference.

- New mdBook page `docs/src/agent-pools.md`: pool creation (handle shape + options), submit semantics (priority, fairness key, idempotency, task-handle shape), four queue strategies, backpressure policies, four scope/durability tiers + pipeline-reload contract, `SpawnToPool` trigger composition, inspection surface, `lifecycle.pool.audit` + OTel spans, `HARN-POL-*` diagnostics. Includes a pick-the-right-primitive table and a SOTA comparison (Temporal, Inngest, Restate).
- New cookbook `docs/src/cookbooks/pools.md` with four end-to-end recipes: rate-limited webhook processor (per-source fair queue + ring-buffer), GPU-routed inference (sized to GPU count, `scope: "tenant"`), cross-customer fairness (`fair_round_robin("tenant_id")`), and burst absorber for nightly batch jobs (large queue + `(date, customer)` idempotency keys).
- Expanded "Agent pools" section in `docs/llm/harn-quickref.md` with full submit options, queue/backpressure tables, scope tiers, the `SpawnToPool` snippet, and cross-references.
- New "Agent pools" subsection in `spec/HARN_SPEC.md` with formal `PoolHandle`, `PoolTaskHandle`, `QueueStrategy`, `Backpressure`, `PoolScope`, and `SpawnToPoolHandler` shapes, plus the `HARN-POL-*` block in the diagnostic appendix.
- Wired the new pages into `docs/src/SUMMARY.md` under Orchestration.

## Test plan

- [x] `make check-docs-snippets` — 563 checked, 0 failed
- [x] `make lint-md` — 461 files, 0 errors
- [x] `make spec-lint` — clean
- [x] `make check-language-spec` — mirror in sync
- [x] `mdbook build` — clean

Generated with Claude Code (Opus 4.7 1M context).