### PR TITLE
Add suspend/resume docs (#1849)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,37 @@ condensed series summaries instead of full per-patch history.
 
 ### Added
 
+- **Suspend/resume docs (S-13, #1849).** Adds the user-facing
+  reference for the agent suspend/resume primitive (epic #1836). New
+  mdBook page `docs/src/agent-lifecycle.md` covers the lifecycle
+  builtins (`suspend_agent`, `resume_agent`,
+  `parse_resume_conditions`, `agent_await_resumption`,
+  `agent_lifecycle_tools`), the `ResumeConditions` shape (trigger /
+  timeout / on_event), self-park mid-loop, parent-driven
+  pause/resume via `subagent_pause` / `subagent_resume`, conditioned
+  resume with trigger + timeout, the four `ResumeBy.*` callbacks and
+  the `default_resume_by(...)` policy, transcript continuity (the
+  single-shot `resume_continuity` system reminder vs
+  `continue_transcript: false`), top-level loop cold-restore via
+  `harn run --resume <snapshot_path>`, daemon idle as a degenerate
+  case, the `HARN-SUS-*` diagnostic codes, and the cooperative-pause
+  gotchas. Replaces the terse "Agent lifecycle tools" subsection in
+  `docs/llm/harn-quickref.md` with an expanded "Agent lifecycle:
+  pause, resume, self-park" section that lists the three model-facing
+  tools, ships three executable snippets (self-park, parent-driven,
+  conditioned), summarizes resume responsibility and `ResumeBy.*`,
+  documents transcript continuity, and surfaces the gotchas.
+  Adds an "Agent lifecycle (suspend/resume)" section to
+  `spec/HARN_SPEC.md` with the formal state machine
+  (`running -> suspended -> running / closed -> done`), the
+  `Suspension` / `ResumeConditions` /
+  `AgentAwaitResumptionRequest` shapes, the four canonical
+  `ResumeBy.*` presets with `default_resume_by(...)` decision tree,
+  the `PreSuspend` / `PostSuspend` / `PreResume` / `PostResume` hook
+  contract, the top-level cold-restore contract, the daemon-idle
+  reduction, and the cooperative cancellation contract. Wires the
+  new mdBook page into `docs/src/SUMMARY.md` under Agent runtime
+  next to Agent state.
 - **Pool docs + cookbook (PL-08, #1893).** Adds the user-facing
   reference + cookbook for agent pools (epic #1883). New mdBook page
   `docs/src/agent-pools.md` covers pool creation (`pool_create`

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -1697,29 +1697,121 @@ dict and return `false`, `true`, `{grant: "once"}`, or `{grant: "session"}`.
 Child agents still intersect with the parent capability policy; escalation
 cannot widen a parent ceiling.
 
-### Agent lifecycle tools
+### Agent lifecycle: pause, resume, self-park
 
-`agent_loop(...)` registers `agent_await_resumption(reason, conditions?)` as a
-model-facing lifecycle tool. When the loop is running inside a worker, that call
-is intercepted before normal tool dispatch, validates `conditions` with
-`parse_resume_conditions(...)`, suspends the worker, and returns
-`status: "suspended"` with `handle`, `reason`, `initiator: "self"`,
-`conditions`, and `iterations_completed`.
+`spawn_agent`, `wait_agent`, `resume_agent`, `suspend_agent`, and
+`list_agents` from `std/agent/workers` are the script-level lifecycle
+surface for delegated work. Layered on top, `agent_loop(...)` exposes a
+model-facing **lifecycle tool** so the agent can park itself between turns
+and so a parent loop can pause/resume children. Full reference:
+`docs/src/agent-lifecycle.md`.
 
-Parent-side tools are gated by subagent capability. Pass `subagents: true` or
-`subagent_tools: true` in loop options, or call
-`agent_lifecycle_tools(registry, {subagents: true})`, to expose:
+Three model-facing tools:
 
 | Tool | Use |
 |---|---|
-| `subagent_pause(handle, reason)` | Pause a running child after its current turn settles |
-| `subagent_resume(handle, input?, continue_transcript? = true)` | Resume a suspended child |
-| `agent_await_resumption(reason, conditions?)` | Let the current worker self-park |
+| `agent_await_resumption(reason, conditions?)` | The current worker self-parks. Registered automatically by `agent_loop(...)`. |
+| `subagent_pause(handle, reason)` | Parent loop pauses a running child after its current turn settles. Opt-in via `subagents: true`. |
+| `subagent_resume(handle, input?, continue_transcript? = true)` | Parent loop resumes a suspended child. Opt-in via `subagents: true`. |
 
-Lifecycle invocations emit `tool_call_audit` telemetry with initiator and reason
-metadata. Top-level loops use the same tool surface: `agent_loop(...)` returns a
-`status: "suspended"` payload with a persisted `handle.snapshot_path`, and the
-CLI can cold-restore it with `harn run --resume <snapshot_path>`.
+When the model calls `agent_await_resumption(...)` inside an `agent_loop`
+running as a worker, the call is intercepted *before* normal tool dispatch:
+the loop validates `conditions` with `parse_resume_conditions(...)`,
+persists a snapshot, emits `WorkerSuspended`, and returns
+`{status: "suspended", handle, reason, initiator: "self", conditions,
+iterations_completed}` to the parent. Lifecycle calls emit
+`tool_call_audit` telemetry with `initiator` (one of `"self"`, `"parent"`,
+`"operator"`, `"triggered"`) and the supplied `reason`.
+
+Top-level loops use the same shape: a root `agent_loop(...)` that parks
+returns `status: "suspended"` with `handle.snapshot_path`, and the CLI
+cold-restores it with `harn run --resume <snapshot_path>`.
+
+```harn,ignore
+// Self-park mid-loop until a review approval lands or 30 minutes pass.
+import { agent_await_resumption } from "std/agent/workers"
+
+let result = agent_loop("Wait for the maintainer's review.", nil, {
+  provider: "openai",
+  model: "gpt-5",
+  tool_format: "native",
+})
+
+if result.status == "suspended" {
+  println(result.reason)               // model-supplied
+  println(result.handle.snapshot_path) // resumable snapshot on disk
+}
+```
+
+```harn,ignore
+// Parent-driven pause/resume of a background child.
+let handle = sub_agent_run("Draft the changelog.", {
+  background: true,
+  provider: "openai",
+})
+suspend_agent(handle, "operator pulled context")
+// ... other work ...
+resume_agent(handle, "Pick up where you left off.")
+let final = wait_agent(handle)
+```
+
+```harn,ignore
+// Conditioned self-park: trigger + timeout.
+agent_await_resumption("waiting on review", {
+  trigger: {
+    kind: "review.approved",
+    provider: "github",
+    match: {events: ["review.approved"]},
+  },
+  timeout: {duration_minutes: 30, on_timeout: "resume_with_summary"},
+})
+```
+
+Resume responsibility is named by an optional `resume_by` callback (third
+arg to `agent_await_resumption`). The four presets in `std/agent/resume_by`
+are `ResumeBy.parent_llm`, `ResumeBy.local_runtime`, `ResumeBy.cloud_harness`,
+and `ResumeBy.pipeline_drain`. They compose with
+`std/lifecycle/combinators::first_available`. `default_resume_by(...)`
+picks one based on whether `conditions` were supplied and whether a cloud
+session is bound:
+
+- `conditions == nil` → `ResumeBy.parent_llm`
+- `conditions != nil`, no cloud session → `ResumeBy.local_runtime`
+- `conditions != nil`, cloud session → `first_handled([cloud_harness, local_runtime])`
+
+Transcript continuity: `resume_agent(...)` defaults to
+`continue_transcript: true` — the resumed worker keeps its full transcript
+and the runtime injects a single-shot `system_reminder` with
+`dedupe_key: "resume_continuity"` summarizing the gap. Pass
+`continue_transcript: false` to restart from the prior summary plus new
+input only.
+
+Daemon idle is a degenerate case: `agent_loop(..., {daemon: true})` and
+the `daemon_*` stdlib wrappers (see `docs/src/llm/agent_loop.md#daemon-stdlib-wrappers`)
+internally call `agent_await_resumption(...)` when no wake source is
+queued. The snapshot carries daemon-specific fields
+(`pending_event_count`, `wake_interval_ms`, `watch_paths`) alongside the
+standard suspend metadata, so `daemon_resume(path)` cold-restores the
+loop identically.
+
+Common gotchas:
+
+- **Suspend is cooperative**, not preemptive. The flag is honored at the
+  next turn boundary — not mid-tool-call, not mid-LLM-request. Cap
+  long-running tools with `tool_call_timeout`.
+- **Conditions are optional.** A bare `agent_await_resumption("waiting")`
+  parks the worker open; only the parent agent, an operator, or
+  `resume_agent(...)` can wake it.
+- **Snapshots survive process restart.** Both the snapshot file and any
+  registered trigger conditions are durable. `harn run --resume <path>`
+  rehydrates the worker in a fresh process.
+- **Double-resume is detected** (`HARN-SUS-006`); the second caller can
+  retry against the now-running handle.
+- **Closing a suspended worker is terminal** — a later `resume_agent`
+  raises `HARN-SUS-010`.
+
+Diagnostic codes for the suspend/resume namespace are `HARN-SUS-001..010`
+— see `docs/src/agent-lifecycle.md#diagnostic-codes` for the full table.
 
 ### Durable agent channels
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -74,6 +74,7 @@
 - [Sessions](./sessions.md)
 - [Session bundles](./session-bundles.md)
 - [Agent state](./agent-state.md)
+- [Agent lifecycle: suspend, resume, self-park](./agent-lifecycle.md)
 - [Memory](./memory.md)
 - [Transcript architecture](./transcript-architecture.md)
 - [System reminders](./system-reminders.md)

--- a/docs/src/agent-lifecycle.md
+++ b/docs/src/agent-lifecycle.md
@@ -1,0 +1,399 @@
+# Agent lifecycle: suspend, resume, self-park
+
+Harn agents are not just one-shot calls — they are cooperatively schedulable
+units that can park mid-loop, persist a resumable snapshot, and resume later
+in the same process, a different process, or another machine. This page is
+the long-form reference for the suspend/resume primitive: when to reach for
+it, who owns the resume responsibility, and how transcript continuity works
+across the pause.
+
+For a one-screen LLM quickref see the "Agent lifecycle: pause, resume,
+self-park" section in `docs/llm/harn-quickref.md`. For the upstream protocol
+contributions that mirror this surface see
+[ACP `session/suspend`](./protocol-contributions/acp-session-suspend.md) and
+[A2A `TaskState.PAUSED`](./protocol-contributions/a2a-paused-state.md).
+
+## When to suspend
+
+Suspend/resume is one of several ways Harn lets an agent yield. Pick the
+narrowest one that fits.
+
+| Goal | Use | Why |
+|---|---|---|
+| End the loop because the work is done | Natural completion (`status: "done"`) | No state to preserve. The transcript is final. |
+| Cap tokens or wall-clock time | `max_iterations`, `token_budget`, `autonomy_budget` | Budgeting is policy, not a checkpoint. The loop terminates with `status: "budget_exhausted"` or `status: "approval_required"`. |
+| Wait for one specific external event | **Suspend/resume** with `agent_await_resumption(reason, conditions)` | Park the agent, declare what should wake it, keep the transcript. |
+| Park indefinitely until an operator resumes by hand | **Suspend/resume** with `agent_await_resumption(reason)` (no conditions) | Parent agent or operator owns the resume; no trigger gets registered. |
+| Park one agent while another runs to completion | Parent-driven `subagent_pause(handle, reason)` plus `subagent_resume(handle)` | The parent loop owns when the child resumes. |
+| Background-run an agent and rejoin it later | `spawn_agent({background: true})` + `wait_agent(handle)` | The agent is *running*, not parked. Use suspend/resume only when the agent itself should yield CPU. |
+
+Two anti-patterns worth calling out:
+
+- **Suspend is not a sleep.** The runtime does not poll for resume — it
+  registers conditions (when present) with the trigger dispatcher, persists
+  a snapshot, and exits the loop frame. A polling sleep keeps the worker
+  alive on a thread; suspend releases it. If you want fixed-cadence wakeup,
+  pass `conditions.timeout: {duration_minutes: N}`.
+- **Suspend is cooperative.** A suspend request flips a flag that is
+  honored at the next turn boundary. Tool calls and LLM requests in flight
+  finish first. A worker that does not return to a turn boundary (e.g. an
+  infinite shell command in a single tool) will never observe the request.
+
+## The lifecycle surface
+
+The suspend/resume primitive ships as three builtin layers:
+
+1. **Script-level** — `suspend_agent`, `resume_agent`, `parse_resume_conditions`,
+   `agent_await_resumption` from `std/agent/workers`. Operators and parent
+   pipelines call these directly.
+2. **Model-facing tools** — `agent_loop(...)` automatically exposes
+   `agent_await_resumption` as a callable tool to the model so an agent can
+   self-park. Pass `subagents: true` to also expose `subagent_pause` and
+   `subagent_resume`.
+3. **Resume-responsibility callbacks** — `ResumeBy.parent_llm`,
+   `ResumeBy.local_runtime`, `ResumeBy.cloud_harness`, and
+   `ResumeBy.pipeline_drain` from `std/agent/resume_by` name *who* owns
+   resuming the suspended agent. The runtime calls `default_resume_by(...)`
+   when the script does not supply one.
+
+### Builtins
+
+| Function | Purpose |
+|---|---|
+| `suspend_agent(worker, reason?, options?)` | Cooperatively suspend a running worker. Persists a resumable snapshot, emits a `WorkerSuspended` lifecycle event, returns `status: "suspended"` with `suspension` metadata. Idempotent on already-suspended workers. |
+| `resume_agent(worker_or_snapshot, input?, continue_transcript?)` | Resume a suspended worker, optionally with new input. `continue_transcript` defaults to `true` (full transcript preserved); pass `false` to resume from prior summary plus new input only. Accepts either a live handle or a persisted snapshot dict. |
+| `agent_await_resumption(reason, conditions?, resume_by?)` | Build the normalized lifecycle-tool request. Inside an `agent_loop` running as a worker, the loop intercepts this call structurally and routes it through the same suspend path as `suspend_agent`. |
+| `parse_resume_conditions(conditions?)` | Validate and normalize a `ResumeConditions` dict without spawning a worker. Useful for input validation in handlers and pre-flight checks. |
+| `agent_lifecycle_tools(registry?, options?)` | Decorate a tool registry with `agent_await_resumption` (always) and, when `subagents: true`, `subagent_pause` / `subagent_resume`. `agent_loop` calls this internally; scripts compose it when they build registries by hand. |
+
+### Resume conditions
+
+`ResumeConditions` is the shared shape consumed by both `agent_await_resumption`
+and `spawn_agent({options: {resume_when: ...}})`:
+
+```text
+{
+  trigger?:  TriggerSpec,    // any std/triggers trigger spec
+  timeout?:  {duration_minutes: int, on_timeout?: string},
+  on_event?: string,         // EventLog topic name
+}
+```
+
+All three fields are optional. When all are omitted the worker is parked
+"open" — only the parent agent, an operator, or `resume_agent(...)` can
+wake it. `parse_resume_conditions(nil)` returns `nil`; bad input raises
+`HARN-SUS-002` with the failing field path.
+
+`timeout.on_timeout` defaults to `"resume_with_summary"` and accepts
+`"fail"` or `"resume_with_input"`. `trigger` is validated by the same
+trigger-spec parser used by `trigger_register(...)`, so any provider that
+works as a trigger source works as a resume condition.
+
+## Self-park mid-loop
+
+When `agent_loop(...)` exposes `agent_await_resumption` as a model tool,
+the model can park itself between turns. The loop intercepts the call
+*before* normal tool dispatch, validates conditions, persists a snapshot,
+and returns a structured result to the parent (or the direct caller, for
+top-level loops):
+
+```harn,ignore
+import { agent_await_resumption } from "std/agent/workers"
+
+let result = agent_loop("Wait for the maintainer's review.", nil, {
+  provider: "openai",
+  model: "gpt-5",
+  tool_format: "native",
+  // agent_await_resumption is registered automatically.
+})
+
+// The model decided to park; `result.status == "suspended"`.
+if result.status == "suspended" {
+  println(result.reason)                      // model-supplied
+  println(result.initiator)                   // "self"
+  println(result.conditions?.timeout?.duration_minutes)
+  println(result.handle.snapshot_path)        // persisted snapshot
+}
+```
+
+`status: "suspended"` carries `handle`, `reason`, `initiator` (one of
+`"self"`, `"parent"`, `"operator"`, `"triggered"`), `conditions`, and
+`iterations_completed` (turns finished before the park). The handle is a
+resumable worker reference; the snapshot is a JSON document on disk.
+
+Restore the snapshot from the CLI in a fresh process:
+
+```bash
+harn run --resume .harn/workers/worker_01HF...json
+```
+
+`harn run --resume <path>` rehydrates the worker, replays the resume-
+continuity reminder onto the next turn, and continues the loop in the same
+session.
+
+## Parent-driven pause and resume
+
+For multi-agent setups, the parent loop owns pause/resume of its children.
+Pass `subagents: true` (or `subagent_tools: true`) to `agent_loop(...)` to
+expose `subagent_pause` and `subagent_resume` as model-callable tools:
+
+```harn,ignore
+import { agent_lifecycle_tools } from "std/agent/workers"
+
+let parent_registry = agent_lifecycle_tools(tool_registry(), {subagents: true})
+
+agent_loop("Coordinate the review.", nil, {
+  tools: parent_registry,
+  subagents: true,
+  provider: "openai",
+})
+```
+
+The parent's model can now call:
+
+| Tool | Effect |
+|---|---|
+| `subagent_pause(handle, reason)` | Pause a running child after its current turn settles. Idempotent on already-suspended children. |
+| `subagent_resume(handle, input?, continue_transcript? = true)` | Resume a suspended child with optional new input. |
+
+Scripts can drive the same lifecycle directly without going through the
+model:
+
+```harn,ignore
+let handle = sub_agent_run("Draft the changelog.", {
+  background: true,
+  provider: "openai",
+})
+
+let snapshot = suspend_agent(handle, "operator pulled context")
+// ... do other work ...
+let resumed = resume_agent(handle, "Pick up where you left off.")
+let final = wait_agent(handle)
+println(final.status)         // "done"
+println(final.has_transcript) // true — transcript continuity preserved
+```
+
+`subagent_pause` and `subagent_resume` emit `tool_call_audit` telemetry
+with `initiator: "parent"` so the trust graph can distinguish parent-
+driven pauses from self-parks.
+
+## Conditioned resume
+
+Pair `agent_await_resumption` with `conditions` to declare what should
+wake the parked agent. The runtime registers the trigger (if any) with
+the local dispatcher and persists the conditions alongside the snapshot
+so they survive restart:
+
+```harn,ignore
+import { agent_await_resumption } from "std/agent/workers"
+
+// Self-park until either a review approval lands OR 30 minutes pass.
+let request = agent_await_resumption("waiting on review", {
+  trigger: {
+    kind: "review.approved",
+    provider: "github",
+    match: {events: ["review.approved"]},
+  },
+  timeout: {
+    duration_minutes: 30,
+    on_timeout: "resume_with_summary",
+  },
+})
+```
+
+`on_timeout` semantics:
+
+- `"resume_with_summary"` (default) — resume with a system reminder
+  summarizing what happened during the wait.
+- `"fail"` — terminate the worker with `status: "failed"`.
+- `"resume_with_input"` — resume with a caller-supplied input string.
+
+`spawn_agent({options: {resume_when: ...}})` accepts the same shape so a
+worker can be born already parked:
+
+```harn,ignore
+import { parse_resume_conditions, spawn_agent } from "std/agent/workers"
+
+let resume_when = parse_resume_conditions({
+  trigger: {
+    kind: "channel.emit",
+    provider: "channel",
+    match: {events: ["channel:pr.merged"]},
+  },
+  timeout: {duration_minutes: 60, on_timeout: "fail"},
+})
+
+spawn_agent({
+  task: "Cut a release once the PR merges.",
+  node: {
+    kind: "subagent",
+    mode: "llm",
+    model_policy: {provider: "openai", model: "gpt-5"},
+    output_contract: {output_kinds: ["summary"]},
+  },
+  options: {resume_when: resume_when},
+})
+```
+
+## Resume responsibility (`ResumeBy.*`)
+
+Every suspension has exactly one resume owner. The optional `resume_by`
+argument on `agent_await_resumption` names that owner with a callback:
+
+| Callback | When it runs |
+|---|---|
+| `ResumeBy.parent_llm` | Parent agent's LLM resumes the child via `subagent_resume`. The default when no `conditions` are present. |
+| `ResumeBy.local_runtime` | Local trigger dispatcher registers `conditions.trigger` and calls `resume_agent` on fire. The default when `conditions` are present and no cloud session is bound. |
+| `ResumeBy.cloud_harness` | The harn-cloud webhook receiver persists the suspension across process restart and resumes when the configured event lands. Selected when a cloud session is bound. |
+| `ResumeBy.pipeline_drain` | The enclosing pipeline's drain step owns the resume responsibility. Use inside lifecycle combinators. |
+
+Each callback is a pure closure `(harness, suspension) -> {handled, mechanism}`
+so they compose with `first_available(...)`, `compose(...)`, and the rest of
+`std/lifecycle/combinators`:
+
+```harn,ignore
+import { ResumeBy, first_handled } from "std/agent/resume_by"
+
+let RB = ResumeBy()
+let chain = first_handled([RB.cloud_harness, RB.local_runtime, RB.parent_llm])
+
+let request = agent_await_resumption(
+  "wait for upstream merge",
+  {trigger: {kind: "channel.emit", provider: "channel", match: {events: ["channel:upstream.merged"]}}},
+  chain,
+)
+```
+
+`default_resume_by(...)` mirrors the runtime's default policy and is
+publicly exported so scripts can call it explicitly:
+
+- `conditions == nil` → `ResumeBy.parent_llm`
+- `conditions != nil`, no cloud session → `ResumeBy.local_runtime`
+- `conditions != nil`, cloud session → `first_handled([cloud_harness, local_runtime])`
+
+Every resolved dispatch emits a `resume_by_dispatched` audit through
+`harness.emit_audit`. Declined entries (e.g. `cloud_harness` with no
+cloud session) emit `resume_by_declined`. Both surface through
+`lifecycle_audit_log_take()` for tests and observability.
+
+## Transcript continuity
+
+By default a resumed worker carries its full transcript forward. The
+runtime injects a single-shot `system_reminder` with `dedupe_key:
+"resume_continuity"` describing the gap, the suspend reason, and (when
+available) what fired the resume. The reminder is consumed on the next
+turn and does not re-apply on subsequent suspends.
+
+Set `continue_transcript: false` on `resume_agent(...)` to drop the
+recorded turns and restart from the prior summary plus new input:
+
+```harn,ignore
+// Discard the long deliberation transcript; restart from a clean state
+// with a fresh prompt.
+resume_agent(handle, "Try a completely different approach.", false)
+```
+
+This is the right call when the previous deliberation hit a dead-end and
+you want the model to think from first principles, not "patch over" the
+prior reasoning.
+
+## Top-level loops and `--resume`
+
+A root `agent_loop(...)` — one called from a pipeline or `harn run`
+script, not as a child of another agent — uses the same suspend path. On
+self-park the runtime persists a snapshot under `.harn/workers/worker_*.json`
+and returns `status: "suspended"` to the caller. The CLI can cold-restore
+that snapshot in any subsequent process:
+
+```bash
+# First run: agent parks itself, prints the snapshot path.
+harn run scripts/triage.harn
+# status=suspended
+# snapshot=.harn/workers/worker_01HFEX...json
+
+# Later, in a fresh process:
+harn run --resume .harn/workers/worker_01HFEX...json --json
+# {"event_type": "done", "value": {"status": "done", ...}}
+```
+
+`--resume` accepts both absolute and script-relative snapshot paths. The
+resumed loop emits its final value as a JSON event when `--json` is set
+so callers can pipeline it without parsing prose output.
+
+## Daemon idle is a degenerate case
+
+`agent_loop(..., {daemon: true})` and the
+[daemon stdlib wrappers](./stdlib/daemon.md) build on the same primitive.
+When a daemon idles waiting for a trigger event or a wake-interval tick,
+the stdlib records an `agent_await_resumption` request internally and
+parks the loop. Daemon-specific snapshot fields
+(`pending_event_count`, `queued_event_count`, `inflight_event`,
+`wake_interval_ms`, `watch_paths`) are persisted alongside the standard
+suspend metadata.
+
+That means daemons can be cold-restored with `daemon_resume(path)` the
+same way a parked agent can be cold-restored with `harn run --resume`.
+
+See [Agent loops — Daemon stdlib wrappers](./llm/agent_loop.md#daemon-stdlib-wrappers)
+for the daemon-specific surface.
+
+## Diagnostic codes
+
+| Code | Meaning |
+|---|---|
+| `HARN-SUS-001` | `suspend_agent` was called on a worker that is not running. |
+| `HARN-SUS-002` | `ResumeConditions` validation failed. |
+| `HARN-SUS-003` | `resume_agent` was called on a live worker that is not suspended. |
+| `HARN-SUS-004` | A resume snapshot was missing, stale, unreadable, or version-incompatible. |
+| `HARN-SUS-005` | `agent_await_resumption` was invoked outside `agent_loop` structural handling (e.g. called directly as a tool handler). |
+| `HARN-SUS-006` | A concurrent resume changed the worker before resume completed. |
+| `HARN-SUS-007` | `conditions.trigger` could not be registered with the trigger dispatcher. |
+| `HARN-SUS-008` | A timeout fired or was configured with an unsupported `on_timeout` action. |
+| `HARN-SUS-009` | Resume input failed `agent_loop` input validation. |
+| `HARN-SUS-010` | A worker closed while suspended rejected a later resume. |
+
+The diagnostic catalog at [Diagnostic codes catalog](./diagnostics.md) is
+authoritative; the table above lists only the `HARN-SUS-*` namespace.
+
+## Gotchas
+
+- **Suspend is cooperative, not preemptive.** `suspend_agent(...)` flips
+  a flag; the worker exits the loop frame at the next turn boundary, not
+  inside a tool call or LLM request. Workers that never return to a turn
+  boundary will never observe the request. Cap long-running tools with
+  `tool_call_timeout` (see [Long-running tools](./long-running-tools.md)).
+- **Conditions are optional.** A bare `agent_await_resumption("waiting")`
+  parks the worker open — only the parent agent or an operator can wake
+  it. Add `conditions` only when the agent itself knows what should fire
+  the resume.
+- **Snapshots survive process restart.** Both the snapshot file
+  (`.harn/workers/worker_*.json`) and any registered trigger conditions
+  are durable. A fresh process can load the snapshot with
+  `resume_agent(snapshot)` or `harn run --resume <path>` and continue.
+  When a cloud session is bound, `ResumeBy.cloud_harness` keeps the
+  registration in harn-cloud so the resume crosses machines.
+- **Double-resume is detected.** Concurrent `resume_agent` calls on the
+  same handle raise `HARN-SUS-006`; the second caller observes the race
+  and can retry against the now-running handle. See the
+  `suspend_double_resume_race` conformance test for the exact contract.
+- **Closing a suspended worker is terminal.** `close_agent(handle)` on a
+  suspended worker marks the snapshot rejected; a later `resume_agent`
+  raises `HARN-SUS-010`. Closing is the correct call when the operator
+  has decided the work is no longer relevant.
+
+## See also
+
+- [LLM quick reference](./docs/llm/harn-quickref.md) — "Agent lifecycle:
+  pause, resume, self-park" section.
+- [Agent loops](./llm/agent_loop.md) — full `agent_loop` reference.
+- [Daemon stdlib](./stdlib/daemon.md) — daemon-mode wrappers built on
+  suspend/resume.
+- [Agent channels](./agent-channels.md) — the durable pub/sub primitive
+  that pairs naturally with `agent_await_resumption(reason,
+  conditions.trigger: {kind: "channel.emit", ...})`.
+- [ACP `session/suspend` RFC](./protocol-contributions/acp-session-suspend.md)
+  and [A2A `TaskState.PAUSED` RFC](./protocol-contributions/a2a-paused-state.md)
+  — upstream protocol companions.
+- Conformance fixtures under `conformance/tests/agents/` — `suspend_*.harn`,
+  `agent_await_resumption.harn`, `agent_top_level_await_resumption_cli.harn`,
+  and `resume_by_*.harn` exercise every contract documented here.

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -5157,6 +5157,249 @@ applied with transaction-local `set_config(name, value, true)` for RLS
 policies. Schema migrations are host-owned; Harn does not maintain a migration
 ledger.
 
+## Agent lifecycle (suspend/resume)
+
+Agent workers are cooperatively schedulable. A running worker may yield —
+mid-loop, at a turn boundary — to be resumed later in the same process,
+a different process, or on another machine. The primitive is shared by
+script-driven suspends, model-driven self-parks via the
+`agent_await_resumption` lifecycle tool, and the daemon idle path.
+
+User-facing reference: `docs/src/agent-lifecycle.md`. Upstream protocol
+companions are documented at
+`docs/src/protocol-contributions/acp-session-suspend.md` and
+`docs/src/protocol-contributions/a2a-paused-state.md`.
+
+### Lifecycle states
+
+A worker observes a strict state machine:
+
+```text
+            spawn_agent
+                |
+                v
+  +---------+ suspend_agent / agent_await_resumption +-----------+
+  | running | -----------------------------------------> | suspended |
+  +---------+                                            +-----------+
+       ^                                                     |
+       |             resume_agent / subagent_resume          |
+       +-----------------------------------------------------+
+       |                                                     |
+       | natural completion                                  | close_agent
+       v                                                     v
+  +---------+                                            +-----------+
+  |  done   |                                            |  closed   |
+  +---------+                                            +-----------+
+```
+
+Transitions:
+
+- `running -> suspended`: cooperative. `suspend_agent` flips the
+  worker's suspend flag; the worker honors it at the next turn boundary
+  (after the current LLM call and tool dispatch settle). A snapshot is
+  persisted before the state flips. Idempotent: a second `suspend_agent`
+  on an already-suspended worker returns the current summary unchanged
+  and does not re-emit `WorkerSuspended`.
+- `suspended -> running`: `resume_agent(handle_or_snapshot, input?,
+  continue_transcript?)` rehydrates the worker. Concurrent resumes raise
+  `HARN-SUS-006`; the second caller may retry against the now-running
+  handle.
+- `running -> done`: natural completion through `agent_loop` end
+  conditions; emits `WorkerCompleted`.
+- `suspended -> closed`: `close_agent` marks the snapshot rejected;
+  later resume attempts raise `HARN-SUS-010`.
+
+Invalid transitions raise specific diagnostics:
+
+| From | Op | Diagnostic |
+|---|---|---|
+| `closed`, `done` | `suspend_agent` | `HARN-SUS-001` |
+| `running` | `resume_agent` | `HARN-SUS-003` |
+| `closed` (snapshot rejected) | `resume_agent` | `HARN-SUS-010` |
+
+### `Suspension`
+
+A `Suspension` is the canonical payload returned to the parent (or
+direct caller) when a worker parks:
+
+```text
+Suspension = {
+  status:                "suspended",            // discriminator
+  handle:                WorkerHandle,           // resumable reference
+  reason:                string,                 // operator / model-supplied
+  initiator:             "self" | "parent" | "operator" | "triggered",
+  conditions:            ResumeConditions | nil,
+  iterations_completed:  int,                    // completed loop turns
+  suspended_at:          string,                 // RFC3339 timestamp
+  suspended_at_turn:     int | nil,              // loop turn index, when known
+  snapshot_path:         string,                 // persisted snapshot
+  resume_by_mechanism:   string | nil,           // e.g. "ResumeBy.parent_llm"
+  auto_resume_trigger:   string | nil,           // registered trigger id
+}
+```
+
+Top-level `agent_loop(...)` returns the same shape with `handle` set to
+the persisted snapshot. The CLI cold-restores it with `harn run --resume
+<snapshot_path>`. The runtime never persists transcript text, resume
+input, or condition payloads in the `Suspension` envelope itself —
+sensitive content stays in the worker snapshot and the transcript store.
+
+### `ResumeConditions`
+
+`ResumeConditions` declares what may wake a suspended worker. All three
+fields are optional:
+
+```text
+ResumeConditions = {
+  trigger?:  TriggerSpec,
+  timeout?:  {duration_minutes: int, on_timeout?: TimeoutAction},
+  on_event?: string,
+}
+
+TimeoutAction = "resume_with_summary" | "fail" | "resume_with_input"
+```
+
+- `trigger` is validated by the same trigger-spec parser used by
+  `trigger_register(...)`. Any provider that works as a trigger source
+  (`github`, `slack`, `cron`, `channel`, `webhook`, etc.) works as a
+  resume condition. Registration failures raise `HARN-SUS-007`.
+- `timeout.duration_minutes` must be a positive integer.
+  `timeout.on_timeout` defaults to `"resume_with_summary"`. Unsupported
+  values raise `HARN-SUS-008`.
+- `on_event` must be a non-empty EventLog topic name.
+
+`parse_resume_conditions(nil)` returns `nil`. Invalid input raises
+`HARN-SUS-002` with the failing field path. A worker with no conditions
+is parked "open" — only the parent agent, an operator, or an explicit
+`resume_agent(...)` call can wake it.
+
+### `agent_await_resumption`
+
+`agent_await_resumption(reason, conditions?, resume_by?)` returns a
+normalized `AgentAwaitResumptionRequest`:
+
+```text
+AgentAwaitResumptionRequest = {
+  reason:     string,                                   // trimmed, non-empty
+  conditions: ResumeConditions | nil,
+  resume_by:  (harness, suspension) -> dict | nil,
+}
+```
+
+Empty or whitespace-only `reason` raises `HARN-SUS-005`. The function
+itself is pure validation; the structural integration happens inside
+`agent_loop(...)`:
+
+- When called from inside an `agent_loop` running as a worker, the loop
+  intercepts the request *before* normal tool dispatch, persists a
+  snapshot, and returns the `Suspension` payload to the parent.
+- When called from outside that structural integration (e.g. as a
+  direct tool handler), it raises `HARN-SUS-005`.
+
+### Resume responsibility (`ResumeBy.*`)
+
+Every suspension has exactly one resume owner. The optional `resume_by`
+argument is a callback with signature
+`(harness, Suspension) -> {handled: bool, mechanism: string, reason?: string}`.
+
+Four canonical presets live in `std/agent/resume_by`:
+
+| Preset | Behavior |
+|---|---|
+| `ResumeBy.parent_llm` | Always returns `{handled: true, mechanism: "ResumeBy.parent_llm"}`. The parent agent's LLM owns the resume via `subagent_resume`. |
+| `ResumeBy.local_runtime` | Registers `conditions.trigger` with the in-process trigger dispatcher. Declines with `{handled: false, reason: "no_conditions"}` when no conditions are present. |
+| `ResumeBy.cloud_harness` | Registers the suspension with the harn-cloud webhook receiver for durability across process restart. Declines with `{handled: false, reason: "no_cloud_session"}` when no cloud session is bound. |
+| `ResumeBy.pipeline_drain` | Always returns `{handled: true, mechanism: "ResumeBy.pipeline_drain"}`. The enclosing pipeline's drain step owns the resume. |
+
+Presets compose with `std/lifecycle/combinators::first_available`
+(re-exported as `first_handled` in `std/agent/resume_by`). When the
+script omits `resume_by`, the runtime calls `default_resume_by(...)`:
+
+- `conditions == nil` → `ResumeBy.parent_llm`
+- `conditions != nil`, no cloud session → `ResumeBy.local_runtime`
+- `conditions != nil`, cloud session → `first_handled([cloud_harness, local_runtime])`
+
+Every resolved dispatch emits a `resume_by_dispatched` audit through
+`harness.emit_audit`. Declined entries emit `resume_by_declined`. A
+callback that returns `{handled: false}` or throws falls back to
+`ResumeBy.parent_llm` so the parent agent is always the safety net.
+Audits surface through `lifecycle_audit_log_take()`.
+
+### Transcript continuity
+
+`resume_agent(worker_or_snapshot, input? = nil, continue_transcript? = true)`
+controls how the resumed worker sees the prior loop:
+
+- `continue_transcript: true` (default) — the full transcript is
+  preserved. The runtime injects a single-shot `system_reminder` event
+  with `dedupe_key: "resume_continuity"` summarizing the suspension
+  reason, the gap, and the resume cause. The reminder is consumed on the
+  first resumed turn and is *not* re-applied on subsequent suspends of
+  the same worker.
+- `continue_transcript: false` — the worker resumes from the prior
+  transcript summary plus the new input only. Useful when the previous
+  deliberation reached a dead-end and the next turn should think from
+  first principles.
+
+Resume input validation failures raise `HARN-SUS-009`.
+
+### Lifecycle hooks
+
+Suspend and resume fire structured hook events around the state
+transition:
+
+- `PreSuspend` (advisory; supports `Allow`/`Deny` decisions). A `Deny`
+  cancels the suspend; the worker remains `running` and the operator
+  receives `pre_suspend_denied` audit metadata.
+- `PostSuspend` (advisory only; runs after the snapshot is persisted
+  and the `WorkerSuspended` event is emitted).
+- `PreResume` / `PostResume` (analogous; `PreResume` Deny cancels the
+  resume and the worker remains `suspended`).
+
+Hook payloads carry the structured suspend metadata (handle, reason,
+initiator, condition presence flags) without exposing transcript text or
+resume-input contents.
+
+### Top-level loops
+
+A root `agent_loop(...)` (one called from a pipeline or `harn run`
+script, not as a child) uses the same suspend path. On self-park the
+runtime persists a snapshot under `.harn/workers/worker_*.json` and
+returns the `Suspension` shape to the caller. The CLI restores it in any
+subsequent process:
+
+```text
+harn run --resume <snapshot_path>
+```
+
+`--resume` accepts absolute or script-relative paths. `--json` emits the
+final value as a structured event when the resumed loop terminates.
+
+### Daemon idle
+
+`agent_loop(..., {daemon: true})` and the `daemon_*` stdlib wrappers
+internally call `agent_await_resumption(...)` when no wake source
+(messages, `agent/resume` notification, `wake_interval_ms`, watched
+paths) is queued. The persisted snapshot extends the standard suspend
+metadata with daemon-specific fields (`pending_event_count`,
+`queued_event_count`, `inflight_event`, `wake_interval_ms`,
+`watch_paths`, `event_queue_capacity`). `daemon_resume(path)` cold-
+restores the loop identically.
+
+### Cooperative cancellation contract
+
+Suspend is cooperative, not preemptive. The runtime flips the worker's
+suspend flag; the loop honors it only at a turn boundary (after the
+current LLM call and tool dispatch settle). Workers that do not return
+to a turn boundary — e.g. a tool that blocks forever inside a single
+call — never observe the request. Bounded execution of long-running
+tools is the caller's responsibility (`tool_call_timeout`,
+`async_tool_run`, etc.).
+
+This is the same cooperative model as `agent_loop`'s natural completion
+gate: state transitions happen at boundaries the runtime owns, not
+inside opaque calls the model issued.
+
 ## Host shell discovery
 
 The `process` host capability owns shell discovery and shell-mode invocation.

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -5155,6 +5155,249 @@ applied with transaction-local `set_config(name, value, true)` for RLS
 policies. Schema migrations are host-owned; Harn does not maintain a migration
 ledger.
 
+## Agent lifecycle (suspend/resume)
+
+Agent workers are cooperatively schedulable. A running worker may yield —
+mid-loop, at a turn boundary — to be resumed later in the same process,
+a different process, or on another machine. The primitive is shared by
+script-driven suspends, model-driven self-parks via the
+`agent_await_resumption` lifecycle tool, and the daemon idle path.
+
+User-facing reference: `docs/src/agent-lifecycle.md`. Upstream protocol
+companions are documented at
+`docs/src/protocol-contributions/acp-session-suspend.md` and
+`docs/src/protocol-contributions/a2a-paused-state.md`.
+
+### Lifecycle states
+
+A worker observes a strict state machine:
+
+```text
+            spawn_agent
+                |
+                v
+  +---------+ suspend_agent / agent_await_resumption +-----------+
+  | running | -----------------------------------------> | suspended |
+  +---------+                                            +-----------+
+       ^                                                     |
+       |             resume_agent / subagent_resume          |
+       +-----------------------------------------------------+
+       |                                                     |
+       | natural completion                                  | close_agent
+       v                                                     v
+  +---------+                                            +-----------+
+  |  done   |                                            |  closed   |
+  +---------+                                            +-----------+
+```
+
+Transitions:
+
+- `running -> suspended`: cooperative. `suspend_agent` flips the
+  worker's suspend flag; the worker honors it at the next turn boundary
+  (after the current LLM call and tool dispatch settle). A snapshot is
+  persisted before the state flips. Idempotent: a second `suspend_agent`
+  on an already-suspended worker returns the current summary unchanged
+  and does not re-emit `WorkerSuspended`.
+- `suspended -> running`: `resume_agent(handle_or_snapshot, input?,
+  continue_transcript?)` rehydrates the worker. Concurrent resumes raise
+  `HARN-SUS-006`; the second caller may retry against the now-running
+  handle.
+- `running -> done`: natural completion through `agent_loop` end
+  conditions; emits `WorkerCompleted`.
+- `suspended -> closed`: `close_agent` marks the snapshot rejected;
+  later resume attempts raise `HARN-SUS-010`.
+
+Invalid transitions raise specific diagnostics:
+
+| From | Op | Diagnostic |
+|---|---|---|
+| `closed`, `done` | `suspend_agent` | `HARN-SUS-001` |
+| `running` | `resume_agent` | `HARN-SUS-003` |
+| `closed` (snapshot rejected) | `resume_agent` | `HARN-SUS-010` |
+
+### `Suspension`
+
+A `Suspension` is the canonical payload returned to the parent (or
+direct caller) when a worker parks:
+
+```text
+Suspension = {
+  status:                "suspended",            // discriminator
+  handle:                WorkerHandle,           // resumable reference
+  reason:                string,                 // operator / model-supplied
+  initiator:             "self" | "parent" | "operator" | "triggered",
+  conditions:            ResumeConditions | nil,
+  iterations_completed:  int,                    // completed loop turns
+  suspended_at:          string,                 // RFC3339 timestamp
+  suspended_at_turn:     int | nil,              // loop turn index, when known
+  snapshot_path:         string,                 // persisted snapshot
+  resume_by_mechanism:   string | nil,           // e.g. "ResumeBy.parent_llm"
+  auto_resume_trigger:   string | nil,           // registered trigger id
+}
+```
+
+Top-level `agent_loop(...)` returns the same shape with `handle` set to
+the persisted snapshot. The CLI cold-restores it with `harn run --resume
+<snapshot_path>`. The runtime never persists transcript text, resume
+input, or condition payloads in the `Suspension` envelope itself —
+sensitive content stays in the worker snapshot and the transcript store.
+
+### `ResumeConditions`
+
+`ResumeConditions` declares what may wake a suspended worker. All three
+fields are optional:
+
+```text
+ResumeConditions = {
+  trigger?:  TriggerSpec,
+  timeout?:  {duration_minutes: int, on_timeout?: TimeoutAction},
+  on_event?: string,
+}
+
+TimeoutAction = "resume_with_summary" | "fail" | "resume_with_input"
+```
+
+- `trigger` is validated by the same trigger-spec parser used by
+  `trigger_register(...)`. Any provider that works as a trigger source
+  (`github`, `slack`, `cron`, `channel`, `webhook`, etc.) works as a
+  resume condition. Registration failures raise `HARN-SUS-007`.
+- `timeout.duration_minutes` must be a positive integer.
+  `timeout.on_timeout` defaults to `"resume_with_summary"`. Unsupported
+  values raise `HARN-SUS-008`.
+- `on_event` must be a non-empty EventLog topic name.
+
+`parse_resume_conditions(nil)` returns `nil`. Invalid input raises
+`HARN-SUS-002` with the failing field path. A worker with no conditions
+is parked "open" — only the parent agent, an operator, or an explicit
+`resume_agent(...)` call can wake it.
+
+### `agent_await_resumption`
+
+`agent_await_resumption(reason, conditions?, resume_by?)` returns a
+normalized `AgentAwaitResumptionRequest`:
+
+```text
+AgentAwaitResumptionRequest = {
+  reason:     string,                                   // trimmed, non-empty
+  conditions: ResumeConditions | nil,
+  resume_by:  (harness, suspension) -> dict | nil,
+}
+```
+
+Empty or whitespace-only `reason` raises `HARN-SUS-005`. The function
+itself is pure validation; the structural integration happens inside
+`agent_loop(...)`:
+
+- When called from inside an `agent_loop` running as a worker, the loop
+  intercepts the request *before* normal tool dispatch, persists a
+  snapshot, and returns the `Suspension` payload to the parent.
+- When called from outside that structural integration (e.g. as a
+  direct tool handler), it raises `HARN-SUS-005`.
+
+### Resume responsibility (`ResumeBy.*`)
+
+Every suspension has exactly one resume owner. The optional `resume_by`
+argument is a callback with signature
+`(harness, Suspension) -> {handled: bool, mechanism: string, reason?: string}`.
+
+Four canonical presets live in `std/agent/resume_by`:
+
+| Preset | Behavior |
+|---|---|
+| `ResumeBy.parent_llm` | Always returns `{handled: true, mechanism: "ResumeBy.parent_llm"}`. The parent agent's LLM owns the resume via `subagent_resume`. |
+| `ResumeBy.local_runtime` | Registers `conditions.trigger` with the in-process trigger dispatcher. Declines with `{handled: false, reason: "no_conditions"}` when no conditions are present. |
+| `ResumeBy.cloud_harness` | Registers the suspension with the harn-cloud webhook receiver for durability across process restart. Declines with `{handled: false, reason: "no_cloud_session"}` when no cloud session is bound. |
+| `ResumeBy.pipeline_drain` | Always returns `{handled: true, mechanism: "ResumeBy.pipeline_drain"}`. The enclosing pipeline's drain step owns the resume. |
+
+Presets compose with `std/lifecycle/combinators::first_available`
+(re-exported as `first_handled` in `std/agent/resume_by`). When the
+script omits `resume_by`, the runtime calls `default_resume_by(...)`:
+
+- `conditions == nil` → `ResumeBy.parent_llm`
+- `conditions != nil`, no cloud session → `ResumeBy.local_runtime`
+- `conditions != nil`, cloud session → `first_handled([cloud_harness, local_runtime])`
+
+Every resolved dispatch emits a `resume_by_dispatched` audit through
+`harness.emit_audit`. Declined entries emit `resume_by_declined`. A
+callback that returns `{handled: false}` or throws falls back to
+`ResumeBy.parent_llm` so the parent agent is always the safety net.
+Audits surface through `lifecycle_audit_log_take()`.
+
+### Transcript continuity
+
+`resume_agent(worker_or_snapshot, input? = nil, continue_transcript? = true)`
+controls how the resumed worker sees the prior loop:
+
+- `continue_transcript: true` (default) — the full transcript is
+  preserved. The runtime injects a single-shot `system_reminder` event
+  with `dedupe_key: "resume_continuity"` summarizing the suspension
+  reason, the gap, and the resume cause. The reminder is consumed on the
+  first resumed turn and is *not* re-applied on subsequent suspends of
+  the same worker.
+- `continue_transcript: false` — the worker resumes from the prior
+  transcript summary plus the new input only. Useful when the previous
+  deliberation reached a dead-end and the next turn should think from
+  first principles.
+
+Resume input validation failures raise `HARN-SUS-009`.
+
+### Lifecycle hooks
+
+Suspend and resume fire structured hook events around the state
+transition:
+
+- `PreSuspend` (advisory; supports `Allow`/`Deny` decisions). A `Deny`
+  cancels the suspend; the worker remains `running` and the operator
+  receives `pre_suspend_denied` audit metadata.
+- `PostSuspend` (advisory only; runs after the snapshot is persisted
+  and the `WorkerSuspended` event is emitted).
+- `PreResume` / `PostResume` (analogous; `PreResume` Deny cancels the
+  resume and the worker remains `suspended`).
+
+Hook payloads carry the structured suspend metadata (handle, reason,
+initiator, condition presence flags) without exposing transcript text or
+resume-input contents.
+
+### Top-level loops
+
+A root `agent_loop(...)` (one called from a pipeline or `harn run`
+script, not as a child) uses the same suspend path. On self-park the
+runtime persists a snapshot under `.harn/workers/worker_*.json` and
+returns the `Suspension` shape to the caller. The CLI restores it in any
+subsequent process:
+
+```text
+harn run --resume <snapshot_path>
+```
+
+`--resume` accepts absolute or script-relative paths. `--json` emits the
+final value as a structured event when the resumed loop terminates.
+
+### Daemon idle
+
+`agent_loop(..., {daemon: true})` and the `daemon_*` stdlib wrappers
+internally call `agent_await_resumption(...)` when no wake source
+(messages, `agent/resume` notification, `wake_interval_ms`, watched
+paths) is queued. The persisted snapshot extends the standard suspend
+metadata with daemon-specific fields (`pending_event_count`,
+`queued_event_count`, `inflight_event`, `wake_interval_ms`,
+`watch_paths`, `event_queue_capacity`). `daemon_resume(path)` cold-
+restores the loop identically.
+
+### Cooperative cancellation contract
+
+Suspend is cooperative, not preemptive. The runtime flips the worker's
+suspend flag; the loop honors it only at a turn boundary (after the
+current LLM call and tool dispatch settle). Workers that do not return
+to a turn boundary — e.g. a tool that blocks forever inside a single
+call — never observe the request. Bounded execution of long-running
+tools is the caller's responsibility (`tool_call_timeout`,
+`async_tool_run`, etc.).
+
+This is the same cooperative model as `agent_loop`'s natural completion
+gate: state transitions happen at boundaries the runtime owns, not
+inside opaque calls the model issued.
+
 ## Host shell discovery
 
 The `process` host capability owns shell discovery and shell-mode invocation.


### PR DESCRIPTION
## Summary

Documents the agent suspend/resume primitive across all three user-facing surfaces (S-13 of epic #1836). Closes #1849.

- **New mdBook page** `docs/src/agent-lifecycle.md` covers the lifecycle builtins (`suspend_agent`, `resume_agent`, `parse_resume_conditions`, `agent_await_resumption`, `agent_lifecycle_tools`), the `ResumeConditions` shape (trigger / timeout / on_event), self-park mid-loop, parent-driven `subagent_pause` / `subagent_resume`, conditioned resume, the four `ResumeBy.*` callbacks and `default_resume_by(...)` decision tree, transcript continuity (the single-shot `resume_continuity` system reminder vs `continue_transcript: false`), top-level cold-restore via `harn run --resume`, daemon idle as a degenerate case, the `HARN-SUS-*` diagnostic codes, and the cooperative-pause gotchas. Wired into `docs/src/SUMMARY.md` under Agent runtime next to Agent state.
- **LLM quickref** `docs/llm/harn-quickref.md` — replaces the terse "Agent lifecycle tools" subsection with an expanded "Agent lifecycle: pause, resume, self-park" section that lists the three model-facing tools, ships three executable snippets (self-park, parent-driven, conditioned), summarizes `ResumeBy.*`, documents transcript continuity, and surfaces the gotchas.
- **Spec** `spec/HARN_SPEC.md` — new "Agent lifecycle (suspend/resume)" section with the formal state machine, `Suspension` / `ResumeConditions` / `AgentAwaitResumptionRequest` shapes, the four canonical `ResumeBy.*` presets with the `default_resume_by(...)` decision tree, the `PreSuspend` / `PostSuspend` / `PreResume` / `PostResume` hook contract, the top-level cold-restore contract, the daemon-idle reduction, and the cooperative cancellation contract. `docs/src/language-spec.md` regenerated via `make sync-language-spec`.

No code changes — docs-only delivery for an already-shipped primitive (S-01..S-12, S-14, S-17, S-18 are all already on `main`).

## Test plan

- [x] `make check-docs-snippets` clean (563 checked, 0 failed)
- [x] `make lint-md` clean (462 files, 0 errors)
- [x] `mdbook build` clean
- [x] `make sync-language-spec` regenerates `docs/src/language-spec.md` without drift (pre-push mirror check passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)