### PR TITLE
Add pipeline lifecycle docs (#1863)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,42 @@ condensed series summaries instead of full per-patch history.
   reduction, and the cooperative cancellation contract. Wires the
   new mdBook page into `docs/src/SUMMARY.md` under Agent runtime
   next to Agent state.
+- **Pipeline lifecycle docs (P-10, #1863).** Documents the callback-first
+  pipeline lifecycle (epic #1853). New mdBook page
+  `docs/src/pipeline-lifecycle.md` covers the lifecycle event order
+  (`PreFinish` → `on_finish` → `OnUnsettledDetected` → `PostFinish`),
+  the harness read/write surface (`unsettled_state` plus the 11 drain
+  methods), the four `OnFinish` presets (`on_finish_abandon`,
+  `on_finish_drain`, `on_finish_block_until_settled`,
+  `on_finish_handoff_to`), the six composable combinators (`compose`,
+  `first_available`, `with_telemetry`, `with_timeout`, `if_unsettled`,
+  `when`), the three `OnBudget` strategies, the full hook-event tables
+  for the finish / suspend-resume / drain gates, and a Design rationale
+  section that explains the callback-first vs enum-dispatch decision
+  with cross-refs to Temporal `wait_condition` and Restate sagas.
+  New `docs/src/cookbooks/lifecycle.md` ships five end-to-end recipes:
+  nightly settlement handoff with `on_finish_handoff_to`, custom audit
+  per drain decision via an `on_drain_decision` session hook +
+  `with_telemetry(on_finish_drain)`, long-paused agent with a
+  `post_resume` operator telemetry hook, business-hours `pre_suspend`
+  deny chain with a paired 1-turn reminder, and a replay-deterministic
+  multi-suspend test harness using `mock_time` /
+  `flush_trigger_aggregations` / `pipeline_lifecycle_audit_log_take`.
+  Adds a "Pipeline lifecycle: drain, on_finish, composable handlers"
+  section to `docs/llm/harn-quickref.md` with preset / combinator /
+  budget / hook-event tables, three common-pattern snippets (nightly
+  handoff, custom audit, clean abort), and cross-refs to the
+  suspend/resume primitive (harn#1836). Adds a Pipeline lifecycle
+  subsection to `spec/HARN_SPEC.md` with formal definitions of the
+  `Pipeline.on_finish` semantic, the `Harness` type, the `DrainAgent`
+  constrained tool surface + `HARN-DRN-001` ordering enforcement, the
+  40-event lifecycle event taxonomy, and the four replay-determinism
+  rules (cached resume input, memoized drain decisions, signed
+  timestamps, one-shot registration). Adds a "Pipeline lifecycle" +
+  "Lifecycle cookbook" entry pair to `docs/src/SUMMARY.md` and
+  re-syncs `docs/src/language-spec.md` via `make sync-language-spec`.
+  Closes the docs gap for the lifecycle epic; user-facing GA is now
+  unblocked.
 - **Pool docs + cookbook (PL-08, #1893).** Adds the user-facing
   reference + cookbook for agent pools (epic #1883). New mdBook page
   `docs/src/agent-pools.md` covers pool creation (`pool_create`

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -2707,6 +2707,125 @@ Three concentric surfaces:
   re-exports them as `lifecycle_audit_log_take` /
   `lifecycle_audit_log_snapshot`.
 
+### Pipeline lifecycle: drain, on_finish, composable handlers
+
+Every lifecycle boundary in a Harn pipeline is a callback. Presets in
+`std/lifecycle` cover the common dispositions; combinators in
+`std/lifecycle/combinators` compose them; the harness exposes a single
+read-side surface (`unsettled_state`) and a dozen write-side actions
+for custom drain logic. Full prose: `docs/src/pipeline-lifecycle.md`.
+Cookbook recipes: `docs/src/cookbooks/lifecycle.md`. Per-preset stdlib
+reference: `docs/src/stdlib/lifecycle.md`.
+
+`pipeline_on_finish(callback)` registers a `fn(harness, return_value)`
+that runs between `pre_finish` and `post_finish` on the main VM. The
+return value replaces the pipeline's return value. Registration is
+last-write-wins and one-shot per run — a stale registration cannot
+leak.
+
+`OnFinish.*` presets (`std/lifecycle`):
+
+| Preset | Behavior |
+|---|---|
+| `on_finish_abandon` | Today's default. Emits `pipeline_abandoned_unsettled` when work survives. |
+| `on_finish_drain` | Recommended. Walks unsettled buckets via `harness.spawn_settlement_agent` in canonical order with per-item `drain_decision` audits. |
+| `on_finish_block_until_settled(timeout, fallback?)` | Polls `harness.wait_for_any_settlement` until drained or timeout, then delegates to `fallback` (default `on_finish_drain`). |
+| `on_finish_handoff_to(target_pipeline, options?)` | Packages unsettled state into a typed envelope and hands it to `target_pipeline` via `harness.handoff_to`. |
+
+```harn,ignore
+import { on_finish_drain, on_finish_handoff_to, on_finish_block_until_settled } from "std/lifecycle"
+
+pipeline_on_finish(on_finish_drain)
+pipeline_on_finish(on_finish_handoff_to("nightly-drain"))
+pipeline_on_finish(on_finish_block_until_settled(30s, on_finish_drain))
+```
+
+`Combinator.*` factories (`std/lifecycle/combinators`) wrap any
+`(harness, return_value) -> return_value` callback (presets, hook
+handlers, `resume_by`, custom drain). All six are pure factories:
+
+| Combinator | Behavior |
+|---|---|
+| `compose([cb, ...])` | Sequential; threads each return value into the next. |
+| `first_available([cb, ...])` | Returns the first non-nil result. |
+| `with_telemetry(cb, span_name?)` | OTel `SpanKind::FnCall` + paired `{span_name}_started` / `_completed` / `_errored` audits. |
+| `with_timeout(cb, ms)` | Soft deadline; on overrun returns `{__timed_out, timeout_ms, elapsed_ms, return_value}` and emits `lifecycle_callback_timed_out`. |
+| `if_unsettled(cb)` | Only when `harness.unsettled_state()` is non-empty (one snapshot per call). |
+| `when(predicate, cb)` | Only when `predicate(harness, return_value)` is truthy. |
+
+```harn,ignore
+import { on_finish_drain } from "std/lifecycle"
+import { compose, if_unsettled, with_telemetry, with_timeout } from "std/lifecycle/combinators"
+
+pipeline_on_finish(
+  if_unsettled(with_telemetry(with_timeout(on_finish_drain, 30000), "drain")),
+)
+```
+
+The drain step is the per-item disposition loop behind
+`on_finish_drain`. The settlement-agent walks buckets in the
+documented order — suspended subagents → queued triggers → partial
+handoffs → in-flight LLM calls → pool pending — applying a default
+disposition (cancel / acknowledge / defer) per item and firing
+`OnDrainDecision` for each. The constrained drain tool surface is
+exposed when `__host_settlement_agent_active()` returns true. The
+loop is bounded by a per-call budget (default 5, hard-cap 20); on
+exhaustion a `drain_unsettled_remaining` audit captures the
+remainder. `harness.acknowledge_trigger` and `acknowledge_handoff`
+reject out-of-order calls with `HARN-DRN-001`.
+
+`OnBudget.*` strategies (`std/lifecycle/on_budget`) for the
+`OnBudgetThreshold` event, all `(harness, budget_state) -> result`:
+
+| Strategy | Behavior |
+|---|---|
+| `OnBudget.terminate` | Emits `budget_exceeded`; throws structured terminal error. |
+| `OnBudget.graceful_exit` | Emits `budget_graceful_exit`; returns deterministic exit envelope (no throw). |
+| `OnBudget.warn_and_continue` | Emits `budget_warn_and_continue`; injects a 1-turn `budget_warning` reminder; passes `budget_state` through. |
+
+Hook-event table for lifecycle gates (`register_session_hook`):
+
+| Event | Allow | Deny / Block | Modify | Reminder |
+|---|---|---|---|---|
+| `pre_finish` | yes | INVALID — use `OnFinish.block_until_settled` | n/a | inject only |
+| `post_finish` | yes | n/a (advisory) | n/a | inject only |
+| `on_unsettled_detected` | yes | block finish until settled | amend unsettled payload | inject only |
+| `pre_suspend` | yes | cancel suspend | rewrite reason | inject only |
+| `post_suspend` | yes | n/a | n/a | inject only |
+| `pre_resume` | yes | stay suspended | amend resume input | inject only |
+| `post_resume` | yes | n/a | n/a | inject only |
+| `pre_drain` | yes | skip drain | amend drain spec | inject only |
+| `post_drain` | yes | n/a | n/a | inject only |
+| `on_drain_decision` | yes | block tool call | rewrite tool call | inject only |
+
+Common patterns:
+
+```harn,ignore
+// Hand unsettled to a nightly settlement pipeline.
+import { on_finish_handoff_to } from "std/lifecycle"
+pipeline_on_finish(on_finish_handoff_to("nightly-settle"))
+
+// Drain with custom audit per disposition.
+import { on_finish_drain } from "std/lifecycle"
+register_session_hook("on_drain_decision", { event ->
+  external_audit_push(event)
+  return nil
+})
+pipeline_on_finish(on_finish_drain)
+
+// Abort cleanly on unsettled state (no silent loss).
+import { on_finish_block_until_settled } from "std/lifecycle"
+pipeline_on_finish(
+  on_finish_block_until_settled(60s, { harness, rv ->
+    harness.emit_audit("aborted_with_unsettled", {state: harness.unsettled_state()})
+    throw {category: "unsettled_at_finish", reason: "timeout"}
+  }),
+)
+```
+
+Cross-ref: the suspend/resume primitive that drives
+`suspended_subagents` is the agent-lifecycle entry above (harn#1836).
+
 ### Agent pools
 
 `std/lifecycle/pool` provides named, concurrency-bounded thread pools.

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -50,6 +50,8 @@
 - [Current session builtin](./stdlib/agent_session_current_id.md)
 - [Monitor stdlib](./stdlib/monitors.md)
 - [Pool stdlib](./stdlib/lifecycle-pool.md)
+- [Pipeline lifecycle](./pipeline-lifecycle.md)
+  - [Lifecycle cookbook](./cookbooks/lifecycle.md)
 - [Pipeline lifecycle presets](./stdlib/lifecycle.md)
 - [GraphQL stdlib](./stdlib/graphql.md)
 - [OAuth client + provider cookbook](./oauth.md)

--- a/docs/src/cookbooks/lifecycle.md
+++ b/docs/src/cookbooks/lifecycle.md
@@ -1,0 +1,316 @@
+# Pipeline lifecycle cookbook
+
+Five end-to-end patterns for the callback-first pipeline lifecycle
+(epic #1853). Each recipe is a complete, copy-paste starting point.
+For the surface reference see [Pipeline lifecycle](../pipeline-lifecycle.md);
+for the per-preset stdlib reference see
+[Pipeline lifecycle presets](../stdlib/lifecycle.md); for the
+LLM-friendly quickref see the "Pipeline lifecycle" section in
+`docs/llm/harn-quickref.md`.
+
+The recipes use `harn,ignore` fences because they wire up full
+multi-pipeline topologies (producer pipeline, drain pipeline, trigger
+handlers, host integration glue). Each fragment type-checks; the
+orchestration loop assumes a host that runs the constituent pipelines
+(such as `harn orchestrator`).
+
+## 1. Nightly settlement handoff
+
+A live ingest pipeline triages events synchronously up to a watermark,
+then hands deferred work off to a separate nightly settlement
+pipeline. The handoff envelope carries the unsettled snapshot; the
+nightly pipeline drains it under its own schedule and budget.
+
+```harn,ignore
+import { trigger_register } from "std/triggers"
+import { on_finish_handoff_to } from "std/lifecycle"
+
+// --- live ingest pipeline ---
+pipeline ingest(events) {
+  // Any deferred items become partial-handoff envelopes via
+  // harness.handoff_to so they show up in unsettled_state().
+  pipeline_on_finish(on_finish_handoff_to("nightly-settle", {
+    note: "live ingest deferred bucket",
+  }))
+
+  for event in events {
+    let outcome = try_process_now(event)
+    if outcome.deferred {
+      // Stage the item directly on the harness so the on_finish
+      // callback picks it up from harness.unsettled_state().
+      __handoff_to_settle(event)
+    }
+  }
+  return {status: "ingest_complete", count: len(events)}
+}
+
+// --- nightly settlement pipeline ---
+pipeline nightly_settle(envelope) {
+  let items = envelope.unsettled.partial_handoffs
+  for item in items {
+    settle_one(item.payload)
+  }
+  return {status: "settled", count: len(items)}
+}
+
+fn __handoff_to_settle(event) {
+  // The harness builtin is provided by the runtime inside any
+  // pipeline body; declared as a helper so the snippet reads
+  // top-to-bottom.
+  current_harness().handoff_to("nightly-settle", event)
+}
+```
+
+Why `on_finish_handoff_to` over emitting a channel: the handoff
+envelope carries the full unsettled snapshot, with origin and timing
+metadata, and the nightly pipeline gets the bucket in one call instead
+of replaying N channel emits. The handoff is recorded as a
+`partial_handoff_envelope` audit, so the replay oracle can verify the
+same envelope crosses both pipelines on a second run.
+
+Why a separate pipeline: the nightly run owns its own budget, hook
+chain, and on_finish policy. A failure mid-settle does not unwind the
+live ingest run, and a `pre_finish` block on the nightly pipeline
+holds finish open until the per-item drain completes.
+
+## 2. Audit every drain decision to a custom store
+
+A regulated team needs every disposition the settlement-agent loop
+makes to land in an external audit store (Splunk, BigQuery, S3), not
+just the per-run `pipeline.lifecycle.audit` topic. A
+`register_session_hook("on_drain_decision", ...)` callback observes
+each decision before it persists, and a composed `on_finish` callback
+runs the drain loop with telemetry around it.
+
+```harn,ignore
+import { on_finish_drain } from "std/lifecycle"
+import { compose, with_telemetry } from "std/lifecycle/combinators"
+
+pipeline triage(input) {
+  // 1. Mirror every drain disposition to our external store.
+  register_session_hook("on_drain_decision", { event ->
+    audit_store_push({
+      pipeline: event.pipeline_id,
+      bucket: event.bucket,
+      item_id: event.item_id,
+      disposition: event.disposition,
+      seq: event.seq,
+      at_ms: event.at_ms,
+    })
+    // Return nil to allow; we are not vetoing or rewriting.
+    return nil
+  })
+
+  // 2. Drain on finish, wrapped in an OTel span so dashboards can
+  //    pin on the duration distribution.
+  pipeline_on_finish(
+    with_telemetry(on_finish_drain, "triage_drain"),
+  )
+
+  return process(input)
+}
+
+fn audit_store_push(record) {
+  // Replace with the real client.
+  __external_audit_emit(record)
+}
+```
+
+Why a hook over inline logging in a custom on_finish: the
+`on_drain_decision` gate fires once per item the settlement-agent loop
+processes, regardless of which preset or custom callback drives the
+loop. A hook captures every disposition uniformly — including from
+future presets — without forking the drain logic.
+
+Why `with_telemetry` outside the drain: the wrapper emits
+`triage_drain_started` / `_completed` / `_errored` audit entries with
+a stable span name, so the external store sees a paired pair of
+records bracketing the per-item entries.
+
+## 3. Long-paused agent with resume-continuity reminder
+
+A research agent self-parks via `agent_await_resumption` and may
+sleep for hours. When it resumes, two things must happen exactly
+once: a continuity reminder lands on the first resumed turn (the
+runtime injects this by default), and a custom telemetry envelope
+fires so the operator dashboard shows the pause duration.
+
+```harn,ignore
+import { spawn_agent, parse_resume_conditions } from "std/agent/workers"
+
+pipeline research_runner(task) {
+  // Bracket the suspend / resume gates with telemetry. The runtime
+  // also fires its built-in `resume_continuity` reminder; this hook
+  // wraps it with structured operator telemetry.
+  register_session_hook("post_resume", { event ->
+    operator_dashboard_emit("agent.resumed", {
+      handle: event.worker.handle,
+      suspended_at_ms: event.suspended_at_ms,
+      resumed_at_ms: event.resumed_at_ms,
+      duration_ms: event.resumed_at_ms - event.suspended_at_ms,
+      reason: event.suspend_reason,
+      resume_cause: event.resume_cause,
+    })
+    return nil
+  })
+
+  let resume_when = parse_resume_conditions({
+    timeout: {duration_minutes: 240, on_timeout: "resume_with_summary"},
+    on_event: "operator.resume",
+  })
+
+  let worker = spawn_agent({
+    prompt: task,
+    system: "Pause when you need a long-running external lookup.",
+    options: {resume_when: resume_when},
+  })
+
+  return wait_agent(worker)
+}
+```
+
+Why a `post_resume` hook over polling the worker registry: the hook
+runs once per resume, on the right session, with the suspend and
+resume timestamps already paired. Polling drifts and can double-fire
+across worker restarts.
+
+Why parse `resume_when` upfront: the parsed dict is captured on the
+suspend snapshot, so a cold-restore (`harn run --resume <path>`)
+reconstitutes the same wake conditions instead of re-evaluating the
+shape at resume time.
+
+## 4. Hook-based supervision — deny suspend during business hours
+
+A SaaS team wants to prevent any agent from self-parking between 9 AM
+and 5 PM local time (so the on-call rotation can intervene with full
+context). A `pre_suspend` hook denies the suspend; the runtime keeps
+the worker running and the agent gets a reminder explaining the policy.
+
+```harn,ignore
+fn during_business_hours(now_ms) -> bool {
+  let hour = wall_clock_hour_local(now_ms)
+  return hour >= 9 && hour < 17
+}
+
+pipeline supervised_agents() {
+  register_session_hook("pre_suspend", { event ->
+    if !during_business_hours(now_ms()) {
+      return nil   // allow
+    }
+    return {
+      block: true,
+      reason: "agents may not self-park during business hours; ask on-call",
+      reminder: {
+        body: "Your suspend was denied (business-hours policy). Continue working or escalate via the on-call channel.",
+        tags: ["policy_violation", "business_hours_no_suspend"],
+        ttl_turns: 1,
+        dedupe_key: "policy.no_suspend_business_hours",
+      },
+    }
+  })
+
+  // ... rest of the setup pipeline; agents spawn under this hook
+  // chain inherit the deny policy.
+  return nil
+}
+```
+
+Why `pre_suspend` over `OnPersonaPaused`: `pre_suspend` is the
+*gate*; it can veto the suspend and keep the worker running. The
+`Paused` events fire after the suspend is already committed.
+
+Why a paired reminder: the agent that tried to self-park needs to see
+*why* it was denied, not just continue blindly. The 1-turn TTL
+ensures the reminder lands on the very next turn and then evaporates
+so it does not pollute later context.
+
+Why the dedupe key: if the agent retries the suspend three times in
+one turn, the dedupe collapses the reminder to one entry rather than
+stacking three identical bodies.
+
+## 5. Replay-deterministic test harness for a multi-suspend pipeline
+
+A pipeline suspends a worker, waits for an external event, resumes,
+suspends again, and finally drains. The conformance fixture needs to
+replay deterministically — same audit entries, same disposition order,
+same handoff envelopes — across two runs of the same pipeline.
+
+```harn,ignore
+import { mock_time, advance_time } from "std/clock"
+import { flush_trigger_aggregations } from "std/triggers/testing"
+import { pipeline_lifecycle_audit_log_take } from "std/lifecycle"
+import { on_finish_drain } from "std/lifecycle"
+import { compose, with_telemetry } from "std/lifecycle/combinators"
+
+pipeline multi_suspend_fixture() {
+  // 1. Pin wall-clock so queued_at_ms / age_ms are reproducible.
+  mock_time(1_700_000_000_000)
+
+  // 2. Capture audits via the per-run log instead of wall-clock spans.
+  pipeline_on_finish(
+    with_telemetry(on_finish_drain, "fixture_drain"),
+  )
+
+  // 3. Run the workload. Each suspend / resume / drain step records
+  //    a typed audit entry.
+  let worker = spawn_research_worker()
+  emit_external_event("operator.resume", {})
+  advance_time(60_000)
+  flush_trigger_aggregations()
+
+  let worker2 = spawn_followup_worker(worker)
+  emit_external_event("operator.resume", {})
+  advance_time(120_000)
+  flush_trigger_aggregations()
+
+  return wait_agent(worker2)
+}
+
+pipeline assert_replay_determinism() {
+  // 4. Drain the audit log; the conformance harness compares this
+  //    byte-for-byte against the recorded fixture.
+  let entries = pipeline_lifecycle_audit_log_take()
+  return {audits: entries, count: len(entries)}
+}
+```
+
+Why `mock_time` + `advance_time` over wall-clock: the harness banlist
+(`make lint-test-patterns`) prohibits `std::thread::sleep`,
+`Instant::now()` polling, and short `recv_timeout` calls in tests.
+Mocking the clock lets `queued_at_ms` and `age_ms` fields land at
+deterministic offsets that the replay oracle can compare directly.
+
+Why `flush_trigger_aggregations` before the second suspend: batched
+trigger handlers buffer events until the aggregation window closes.
+Explicit flushes turn an inherently time-driven boundary into a
+synchronous one so each step's audit entries land before the next
+step opens.
+
+Why `pipeline_lifecycle_audit_log_take` over snapshot: the take
+variant drains the log so a subsequent assertion starts from a clean
+slate. The conformance fixture asserts on the drained list as a
+whole, not on a snapshot that might include leftovers from a previous
+test.
+
+## Picking the right primitive
+
+For any of these recipes, the wrong tool is also worth knowing:
+
+- **Don't use a `post_finish` hook to block.** `post_finish` is
+  advisory; the value is already captured. Use `pre_finish` (which
+  rejects `block` and points you at the right primitive) or
+  `on_finish_block_until_settled` to delay finish until work drains.
+- **Don't write a custom drain loop unless you have to.**
+  `on_finish_drain` already walks the buckets in the canonical
+  order, respects `HARN-DRN-001` ordering enforcement, and fires
+  `on_drain_decision` per item. A custom loop has to re-derive every
+  one of those properties.
+- **Don't reach for `pre_suspend` denials to throttle suspends.**
+  The runtime emits an audit per attempt; a deny chain quickly
+  becomes noise. Use a worker-side budget (`OnBudget.terminate` or
+  `graceful_exit`) instead.
+- **Don't poll `harness.unsettled_state()` from a tight loop.** Each
+  call walks the live registries plus the event log. Use
+  `harness.wait_for_any_settlement(max_duration)` or
+  `on_finish_block_until_settled` to wait on a single coalesced
+  snapshot.

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -2265,6 +2265,177 @@ The user-facing reference is `docs/src/agent-pools.md`; the stdlib
 reference is `docs/src/stdlib/lifecycle-pool.md`; runnable patterns
 live in `docs/src/cookbooks/pools.md`.
 
+## Pipeline lifecycle
+
+Pipelines do not end the moment their declared steps return. Between
+the last statement of the pipeline body and the value the host sees,
+the runtime fires a fixed sequence of lifecycle gates and one user
+callback. The same callback shape — `fn(harness, return_value) ->
+return_value` — threads through every gate, so presets and
+combinators that work for `on_finish` also work for hook handlers,
+`resume_by` callbacks, and any custom drain logic.
+
+### Lifecycle event order
+
+When a pipeline's declared steps complete the runtime walks this
+sequence on the main VM:
+
+1. `PreFinish` — last chance to inject a reminder before the pipeline
+   value is captured. Rejects `{block: true}`; the runtime surfaces a
+   runtime error pointing at `OnFinish.block_until_settled`.
+2. The registered `on_finish` callback. Default behavior (no
+   registration) is identical to `on_finish_abandon`.
+3. `OnUnsettledDetected` — fires after the callback if any bucket in
+   `harness.unsettled_state()` is non-empty. Accepts `{block: true,
+   reason}` to delay finish until the host explicitly drains and
+   `{modify: payload}` to amend the snapshot.
+4. `PostFinish` — advisory; observe the final value, push telemetry.
+5. The value is returned to the host.
+
+Each step records `hook_call` / `hook_returned` / `hook_vetoed`
+events on the active session transcript so replay reproduces the same
+control flow.
+
+### `Pipeline.on_finish` semantic
+
+`pipeline_on_finish(callback)` is a stdlib builtin that registers a
+`fn(harness, return_value)` closure into a thread-local one-shot slot
+(`PIPELINE_ON_FINISH`). The slot is last-write-wins inside one run.
+`Vm::execute` consumes the registered callback via
+`take_pipeline_on_finish` exactly once, between the `PreFinish` and
+`OnUnsettledDetected` gates. The callback's return value replaces the
+pipeline's return value before `PostFinish` fires. On the error exit
+path the slot is cleared so a failed pipeline cannot leak its
+registration into the next run.
+
+### `Harness` type
+
+The single argument to every lifecycle callback is the harness. The
+read-side surface is `unsettled_state(): UnsettledStateSnapshot`,
+which returns a stable JSON-shaped dict with five lists:
+`suspended_subagents`, `queued_triggers`, `partial_handoffs`,
+`in_flight_llm_calls`, and `pool_pending_tasks`. The `is_empty`,
+`counts`, and `summary` derived methods accept either an already-taken
+snapshot (for callback-consistent decisions) or no argument (fresh
+snapshot per call). Producers populate buckets from live VM
+registries (suspended subagents, partial handoffs, in-flight LLM
+calls, pool pending tasks) and from event-log records (queued
+trigger inbox + worker queue items).
+
+Write-side actions:
+
+| Method | Effect |
+|---|---|
+| `resume_subagent(handle, input?)` | Resume a suspended worker; falls back to send-input for awaiting retriggerables. |
+| `cancel_subagent(handle, reason?)` | Close a suspended worker via `__host_worker_close`. |
+| `handoff_to(target_pipeline, payload?)` | Record a `PartialHandoffEnvelope` in the thread-local registry; returns `{status: "queued", envelope}`. |
+| `acknowledge_trigger(id)` | Settle a queued inbox or worker-queue item with the existing ack record. |
+| `defer_trigger(id, target_pipeline?)` | Ack the trigger and record a partial-handoff envelope (default target `deferred-triggers`). |
+| `acknowledge_handoff(envelope_id, decision?)` | Remove a partial envelope from the registry; emit `handoff_acknowledged` audit. |
+| `wait_for_any_settlement(max_duration?)` | Snapshot + return `{status, timed_out, state}`. |
+| `emit_audit(kind, payload?)` | Append a `LifecycleAuditEntry` to the per-run log and (when an EventLog is installed) the `pipeline.lifecycle.audit` topic. |
+| `finalize(disposition?)` | Stamp the run's final disposition; emit `pipeline_finalized`. |
+| `spawn_settlement_agent(unsettled, return_value)` | Hand off to the bounded settlement-agent drain loop. |
+| `current_pipeline_id()` | Run id from the current mutation session, else session id, else nil. |
+
+### `DrainAgent` constrained tool surface + ordering enforcement
+
+The settlement-agent loop (`harness.spawn_settlement_agent`) walks the
+unsettled snapshot in a fixed canonical order: suspended subagents →
+queued triggers → partial handoffs → in-flight LLM calls → pool
+pending. Each item receives a default disposition:
+
+| Bucket | Default disposition |
+|---|---|
+| `suspended_subagents` | Cancel via `harness.cancel_subagent`. |
+| `queued_triggers` | Acknowledge via `harness.acknowledge_trigger`. |
+| `partial_handoffs` | Acknowledge as `deferred` via `harness.acknowledge_handoff`. |
+| `in_flight_llm_calls` | Drain via the LLM call registry. |
+| `pool_pending_tasks` | Defer via the pool registry. |
+
+The loop is bounded by a per-call budget — default 5, configurable via
+the third arg to `spawn_settlement_agent`, hard-capped at 20. On
+exhaustion a `drain_unsettled_remaining` audit captures the
+remainder. Each disposition records a `drain_decision` lifecycle
+audit and fires the `OnDrainDecision` hook chain (`Allow` / `Block` /
+`Modify`) before persisting, so VM-side hooks observe the disposition
+before it lands.
+
+Ordering enforcement: `harness.acknowledge_trigger` and
+`harness.acknowledge_handoff` reject out-of-order calls with
+`HARN-DRN-001`. A caller (the settlement-agent loop or a future
+LLM-driven settlement variant) cannot finalize a later category while
+earlier work is still pending. `__host_settlement_agent_active()`
+returns `true` when the constrained drain tool surface is in scope so
+conformance fixtures and IDE hosts can observe the loop boundary.
+
+### Lifecycle event taxonomy
+
+The runtime exposes 40 hook events. Registration surfaces:
+`register_tool_hook` (tool events), `register_persona_hook` (persona
+events), `register_worker_hook` (worker events), and
+`register_session_hook` (session events).
+
+| Event | Category | Reminder effects |
+|---|---|---|
+| `PreToolUse`, `PostToolUse` | tool | supported |
+| `PreAgentTurn`, `PostAgentTurn` | persona | supported |
+| `WorkerSpawned`, `WorkerProgressed`, `WorkerWaitingForInput`, `WorkerSuspended`, `WorkerResumed`, `WorkerCompleted`, `WorkerFailed`, `WorkerCancelled` | worker | rejected (`HARN-RMD-002`) |
+| `PreStep`, `PostStep` | persona | supported |
+| `OnBudgetThreshold` | persona | supported |
+| `OnApprovalRequested`, `OnHandoffEmitted` | persona | supported |
+| `OnPersonaPaused`, `OnPersonaResumed` | persona | supported |
+| `SessionStart`, `SessionEnd` | session | supported |
+| `UserPromptSubmit` | session | supported, accepts `{block, reason}` |
+| `PreCompact`, `PostCompact` | session | supported |
+| `PostTurn` | session | supported |
+| `PermissionAsked`, `PermissionReplied` | session | accepts `{decision: "allow"\|"deny"\|"ask", reason}` |
+| `FileEdited` | session | supported (drained per-turn) |
+| `SessionError`, `SessionIdle` | session | supported |
+| `PreFinish` | session | supported; rejects `{block: true}` |
+| `PostFinish` | session | supported (advisory) |
+| `OnUnsettledDetected` | session | accepts `{block, reason}` and `{modify: payload}` |
+| `PreSuspend`, `PostSuspend`, `PreResume`, `PostResume` | session | suspend / resume gates |
+| `PreDrain`, `PostDrain`, `OnDrainDecision` | session | drain-loop gates |
+
+Veto-capable events accept `{block: true, reason}`. Lifecycle-gate
+events that support payload rewriting also accept `{modify: payload}`
+to amend the dispatched event before resuming the lifecycle step.
+Hook returns also accept a reminder effect (`{reminder: {...}}` or a
+bare reminder spec) on every event whose `supports_reminder_effects()`
+is true. Worker events reject reminder effects with diagnostic
+`HARN-RMD-002` because the worker dispatcher does not own a session
+transcript.
+
+### Replay determinism rules
+
+Every lifecycle decision is reproducible on a replay:
+
+1. **Cached resume input.** `harness.resume_subagent(handle, input)`
+   persists the input snapshot on the resume event so the replay
+   oracle feeds the same value back into the same worker without
+   re-reading host state.
+2. **Memoized drain decisions.** Each `drain_decision` audit captures
+   the bucket, item id, and disposition. The replay oracle consumes
+   the audit log instead of re-walking the snapshot, so a
+   non-deterministic `on_drain_decision` hook (one that consults
+   wall-clock or external state) cannot drift the second run.
+3. **Signed timestamps.** `harness.emit_audit` stamps entries with a
+   per-run monotonic `LIFECYCLE_SEQ` counter rather than wall-clock
+   time. Wall-clock fields (`queued_at_ms`, `age_ms`) come from
+   `clock_mock`-aware sources and respect `mock_time(...)` /
+   `advance_time(...)` in tests.
+4. **One-shot registration.** `pipeline_on_finish(callback)` is
+   last-write-wins; the slot is consumed exactly once per run via
+   `take_pipeline_on_finish`. The error exit path clears the slot
+   alongside the audit log, partial-handoff registry, disposition
+   slot, and seq counter, so a failed run cannot leak in-progress
+   state into the next run.
+
+The user-facing reference is `docs/src/pipeline-lifecycle.md`; the
+stdlib reference is `docs/src/stdlib/lifecycle.md`; runnable patterns
+live in `docs/src/cookbooks/lifecycle.md`.
+
 ## Error model
 
 ### throw

--- a/docs/src/pipeline-lifecycle.md
+++ b/docs/src/pipeline-lifecycle.md
@@ -1,0 +1,394 @@
+# Pipeline lifecycle
+
+Pipelines in Harn do not end the moment their declared steps return.
+Between the last statement of the pipeline body and the value the host
+sees, the runtime fires a sequence of lifecycle callbacks: `PreFinish`,
+the user-registered `on_finish` (which can transform the return value),
+`OnUnsettledDetected` (when work survives the body), and `PostFinish`.
+The same callback shape — `fn(harness, return_value) -> return_value` —
+threads through every lifecycle gate, so presets and combinators that
+work for `on_finish` also work for hook handlers, `resume_by`
+callbacks, and any custom drain logic.
+
+This page is the long-form reference. For a copy-paste quickref see the
+"Pipeline lifecycle" section in `docs/llm/harn-quickref.md`. For
+end-to-end patterns see the [lifecycle cookbook](./cookbooks/lifecycle.md).
+For the per-preset surface (`on_finish_drain`, `on_finish_abandon`,
+combinators, `OnBudget`) see [Pipeline lifecycle presets](./stdlib/lifecycle.md).
+For the suspend/resume primitive that drives `suspended_subagents` see
+the agent-lifecycle entry in the quickref (harn#1836).
+
+## Why callbacks instead of enum-dispatch
+
+The pipeline DSL could have shipped an enum-shaped option:
+
+```text
+pipeline_finish_policy: drain | abandon | block_until_settled
+```
+
+Three reasons made the callback-first shape win:
+
+1. **Composability.** Real pipelines want "wait briefly, otherwise hand
+   off to a long-running pipeline, otherwise drain immediately." With
+   an enum we would add `OneOf` and `Fallback` variants; with closures
+   it is just function composition.
+2. **Custom audit trails.** Production callers want to record
+   per-disposition decisions in their own store, not just the
+   built-in `pipeline.lifecycle.audit` topic. A callback can call
+   `harness.emit_audit(...)` *and* push to an external store; an enum
+   value cannot.
+3. **Symmetry with hooks.** Every other lifecycle gate
+   (`pre_finish`, `pre_suspend`, `on_drain_decision`, ...) is already a
+   user-supplied closure. Reusing the closure shape for the
+   pipeline-finish step keeps a single mental model — and lets the
+   `std/lifecycle/combinators` factories wrap any of them.
+
+Temporal's `wait_condition` and Restate's saga primitives use the same
+shape for the same reasons; the design here is a deliberate borrow with
+Harn-native combinator factories.
+
+## Lifecycle event order
+
+When a pipeline's declared steps complete, the runtime walks this
+sequence on the main VM:
+
+1. **`PreFinish`** — last chance to inject a reminder before the
+   pipeline value is captured. Rejects `{block: true}`; use
+   `OnFinish.block_until_settled` to gate finish on work draining.
+2. **The registered `on_finish` callback** — receives
+   `(harness, return_value)`. Its return value replaces the pipeline's
+   return value. Default behavior (no registration) is identical to
+   `on_finish_abandon`.
+3. **`OnUnsettledDetected`** — fires after the callback if any bucket
+   in `harness.unsettled_state()` is still non-empty. Accepts
+   `{block: true, reason}` to delay finish until the host explicitly
+   drains, and `{modify: payload}` to amend the snapshot.
+4. **`PostFinish`** — advisory; observe the final value, push telemetry.
+5. The value is returned to the host.
+
+Each step records `hook_call` / `hook_returned` / `hook_vetoed` events
+on the active session transcript so replay reproduces the same control
+flow.
+
+## The harness
+
+The single argument to every lifecycle callback is the `harness`. It
+exposes one read-side surface and a dozen write-side actions.
+
+### Read: unsettled state
+
+`harness.unsettled_state()` returns a stable dict with five lists:
+
+| Bucket | Producer |
+|---|---|
+| `suspended_subagents` | `agent_await_resumption` and `spawn_agent({resume_when})` (harn#1836). |
+| `queued_triggers` | Trigger inbox + worker queue event-log records. |
+| `partial_handoffs` | `harness.handoff_to(target, payload)` envelopes. |
+| `in_flight_llm_calls` | The live LLM call registry. |
+| `pool_pending_tasks` | `pool.submit(...)` tasks (queued + running). |
+
+`harness.is_empty(state?)`, `harness.counts(state?)`, and
+`harness.summary(state?)` summarize either an already-captured snapshot
+or a fresh one. Pass the snapshot you took into `is_empty` /
+`counts` / `summary` to keep one decision consistent within a callback;
+omit the argument to ask the harness for a new snapshot each call.
+
+The `std/lifecycle` module re-exports the same shape as module-level
+helpers: `unsettled_state(harness)`, `is_empty(state)`, `counts(state)`,
+`summary(state)`.
+
+### Write: drain actions
+
+| Method | Effect |
+|---|---|
+| `harness.resume_subagent(handle, input?)` | Resume a suspended worker; falls back to send-input for awaiting retriggerables. |
+| `harness.cancel_subagent(handle, reason?)` | Close a suspended worker. Returns the worker summary. |
+| `harness.handoff_to(target_pipeline, payload?)` | Record a partial-handoff envelope. Returns `{status: "queued", envelope}`. |
+| `harness.acknowledge_trigger(id)` | Settle one queued trigger inbox or worker-queue item. |
+| `harness.defer_trigger(id, target_pipeline?)` | Ack the trigger and emit a partial-handoff envelope (default target `deferred-triggers`). |
+| `harness.acknowledge_handoff(envelope_id, decision?)` | Remove a partial envelope and emit a `handoff_acknowledged` audit. |
+| `harness.wait_for_any_settlement(max_duration?)` | Snapshot + return `{status, timed_out, state}`. |
+| `harness.emit_audit(kind, payload?)` | Append a typed entry to the per-run audit log (and to `pipeline.lifecycle.audit` when an EventLog is installed). |
+| `harness.finalize(disposition?)` | Stamp the run's final disposition + emit `pipeline_finalized`. |
+| `harness.spawn_settlement_agent(unsettled, return_value)` | Hand off to the bounded settlement-agent drain loop (P-03, #1856). |
+| `harness.current_pipeline_id()` | Run id when a mutation session is installed, otherwise session id, otherwise nil. |
+
+Ordering enforcement: `acknowledge_trigger` and `acknowledge_handoff`
+reject out-of-order calls with `HARN-DRN-001`. The bucket order is
+suspended subagents → queued triggers → partial handoffs → in-flight
+LLM calls → pool pending tasks. The settlement-agent loop respects the
+same order automatically.
+
+## `OnFinish` presets
+
+Four canonical presets ship from `std/lifecycle`. Each is a pure
+function (or a pure factory returning one) with no captured state, so
+chaining and reuse are safe.
+
+### `on_finish_abandon`
+
+Reproduces today's no-callback behavior, but emits a
+`pipeline_abandoned_unsettled` audit when unsettled state is non-empty
+so the lost work is at least observable. Returns `return_value`
+unchanged.
+
+```harn
+import { on_finish_abandon } from "std/lifecycle"
+
+pipeline default() {
+  pipeline_on_finish(on_finish_abandon)
+  return "ok"
+}
+```
+
+### `on_finish_drain`
+
+The recommended default. Scans `harness.unsettled_state()` and either
+finalizes immediately (when nothing is deferred) or delegates the
+per-item disposition to `harness.spawn_settlement_agent`. The
+settlement-agent loop walks the buckets in the canonical order,
+applies a default disposition per item (cancel suspended subagents,
+acknowledge stale triggers, defer partial handoffs, drain in-flight
+LLM calls, defer pool tasks), and emits a `drain_decision` audit per
+item. The loop is bounded by a per-call budget (default 5,
+configurable up to 20); on exhaustion a `drain_unsettled_remaining`
+audit captures the remainder.
+
+```harn
+import { on_finish_drain } from "std/lifecycle"
+
+pipeline default() {
+  pipeline_on_finish(on_finish_drain)
+  return "triage complete"
+}
+```
+
+### `on_finish_block_until_settled(timeout, fallback?)`
+
+Returns a callback that polls `harness.wait_for_any_settlement` until
+everything drains or the timeout elapses. On a clean settle it emits
+`pipeline_finalized:settled_within_timeout` and returns the unchanged
+value; on timeout it emits `settlement_timeout` and delegates to the
+fallback (default `on_finish_drain`). Use this preset to make
+`PreFinish`-level blocks unnecessary.
+
+```harn
+import { on_finish_block_until_settled } from "std/lifecycle"
+
+pipeline default() {
+  pipeline_on_finish(on_finish_block_until_settled(30s))
+  return "ok"
+}
+```
+
+### `on_finish_handoff_to(target_pipeline, options?)`
+
+Returns a callback that packages the current unsettled-state snapshot
+into a typed envelope (with `origin`, `unsettled`, and any caller
+options) and hands it off via `harness.handoff_to`. When there is
+nothing unsettled, the callback short-circuits to `pipeline_finalized`
+and returns the unchanged value — the typical case where the handoff
+pipeline does not need to run at all.
+
+```harn
+import { on_finish_handoff_to } from "std/lifecycle"
+
+pipeline default() {
+  pipeline_on_finish(on_finish_handoff_to("nightly-drain"))
+  return "triage complete"
+}
+```
+
+## Callback combinators
+
+`std/lifecycle/combinators` exports six pure factories that wrap any
+`(harness, return_value) -> return_value` callback — hook handlers,
+`resume_by` callbacks, the presets above, and any custom `on_finish`
+body. All six are pure factories with no captured mutable state, so
+they nest freely.
+
+| Combinator | Behavior |
+|---|---|
+| `compose([cb, ...])` | Runs each callback in order, threading the prior return value into the next callback's `return_value`. Returns the last entry's value. |
+| `first_available([cb, ...])` | Invokes in order; returns the first non-nil result. |
+| `with_telemetry(cb, span_name?)` | Wraps with a `SpanKind::FnCall` OTel span and emits paired `{span_name}_started` / `_completed` / `_errored` audit entries. |
+| `with_timeout(cb, ms)` | Soft, clock-aware deadline. On overrun returns `{__timed_out: true, timeout_ms, elapsed_ms, return_value}` and emits `lifecycle_callback_timed_out`. |
+| `if_unsettled(cb)` | Only invokes when `harness.unsettled_state()` is non-empty (one snapshot per call). |
+| `when(predicate, cb)` | Only invokes when `predicate(harness, return_value)` is truthy; otherwise passes the inbound value through. |
+
+A realistic production chain — "wait briefly, otherwise hand off to a
+nightly settlement pipeline, otherwise drain immediately, with
+telemetry around the whole thing" — reads top-to-bottom:
+
+```harn
+import {
+  on_finish_block_until_settled,
+  on_finish_drain,
+  on_finish_handoff_to,
+} from "std/lifecycle"
+import { compose, if_unsettled, with_telemetry } from "std/lifecycle/combinators"
+
+pipeline default() {
+  pipeline_on_finish(
+    with_telemetry(
+      if_unsettled(
+        on_finish_block_until_settled(
+          30s,
+          on_finish_handoff_to("nightly-drain"),
+        ),
+      ),
+      "pipeline_finish",
+    ),
+  )
+  return "ok"
+}
+```
+
+## Budget-threshold callbacks
+
+`std/lifecycle/on_budget` ships three named callback strategies for the
+`OnBudgetThreshold` lifecycle event. Each follows the same
+`(harness, budget_state) -> result` shape, so they compose freely with
+the combinators above.
+
+| Strategy | Behavior |
+|---|---|
+| `OnBudget.terminate` | Emits `budget_exceeded`; throws `{category: "budget_exceeded", kind: "terminal", reason: "on_budget_terminate", strategy: "terminate", budget_state, message}` so the enclosing loop unwinds. |
+| `OnBudget.graceful_exit` | Emits `budget_graceful_exit`; returns `{status: "budget_exhausted", strategy: "graceful_exit", reason: "on_budget_graceful_exit", budget_state, message}`. The pipeline's `on_finish` chain can drain in-flight work and surface the envelope. |
+| `OnBudget.warn_and_continue` | Emits `budget_warn_and_continue`; injects a 1-turn `budget_warning` system_reminder via `tool_hooks_inject_reminder`; passes the original `budget_state` through unchanged. |
+
+`OnBudget()` returns the namespace dict so dotted access works after
+one import:
+
+```harn
+import { OnBudget } from "std/lifecycle/on_budget"
+import { compose, with_telemetry } from "std/lifecycle/combinators"
+
+fn audit_overage(harness, budget_state) {
+  harness.emit_audit("custom_overage_logged", {state: budget_state})
+  return budget_state
+}
+
+pipeline default() {
+  register_persona_hook(
+    "*",
+    "OnBudgetThreshold",
+    compose([OnBudget.warn_and_continue, with_telemetry(audit_overage)]),
+  )
+  return "ok"
+}
+```
+
+## Hook events
+
+Pipeline lifecycle gates fire on top of the same session-hook surface
+as the rest of the system. Register with
+`register_session_hook(event, handler)`. Veto with
+`{block: true, reason}`; amend the dispatched payload with
+`{modify: payload}`.
+
+### Pipeline-finish gates
+
+| Event | Allow | Deny / Block | Modify | Reminder |
+|---|---|---|---|---|
+| `pre_finish` | yes | INVALID — use `OnFinish.block_until_settled` | n/a | inject only |
+| `post_finish` | yes | n/a (advisory) | n/a | inject only |
+| `on_unsettled_detected` | yes | block finish until settled | amend unsettled payload | inject only |
+
+`pre_finish` rejects `{block: true}` and surfaces a runtime error
+pointing at `OnFinish.block_until_settled` so the right primitive
+fires before the value is captured.
+
+### Suspend / resume gates
+
+| Event | Allow | Deny / Block | Modify | Reminder |
+|---|---|---|---|---|
+| `pre_suspend` | yes | cancel suspend, worker keeps running | rewrite reason | inject only |
+| `post_suspend` | yes | n/a | n/a | inject only |
+| `pre_resume` | yes | stay suspended | amend resume input | inject only |
+| `post_resume` | yes | n/a | n/a | inject only |
+
+See the agent-lifecycle entry in `docs/llm/harn-quickref.md` for the
+underlying suspend/resume primitive (harn#1836).
+
+### Drain gates
+
+| Event | Allow | Deny / Block | Modify | Reminder |
+|---|---|---|---|---|
+| `pre_drain` | yes | skip drain | amend drain spec | inject only |
+| `post_drain` | yes | n/a | n/a | inject only |
+| `on_drain_decision` | yes | block tool call | rewrite tool call | inject only |
+
+`on_drain_decision` fires once per item the settlement-agent loop
+processes, so a hook can audit or override every disposition before it
+persists.
+
+### Full event table
+
+The full 40-event hook taxonomy spans tool, persona, worker, and
+session surfaces. The events most relevant to pipeline lifecycle:
+
+| Event | Scope | Notes |
+|---|---|---|
+| `PreToolUse` / `PostToolUse` | tool | `register_tool_hook` |
+| `PreAgentTurn` / `PostAgentTurn` | persona/session | persona dispatch |
+| `WorkerSpawned` / `WorkerProgressed` / `WorkerWaitingForInput` | worker | `register_worker_hook` |
+| `WorkerSuspended` / `WorkerResumed` / `WorkerCompleted` / `WorkerFailed` / `WorkerCancelled` | worker | terminal worker events |
+| `PreStep` / `PostStep` | persona | per-stage |
+| `OnBudgetThreshold` | persona | use `OnBudget.*` presets |
+| `OnApprovalRequested` / `OnHandoffEmitted` | persona | persona-loop signals |
+| `OnPersonaPaused` / `OnPersonaResumed` | persona | persona suspend |
+| `SessionStart` / `SessionEnd` | session | bracket the session |
+| `UserPromptSubmit` | session | accepts `{block, reason}` |
+| `PreCompact` / `PostCompact` | session | context maintenance |
+| `PostTurn` | session | after every agent turn |
+| `PermissionAsked` / `PermissionReplied` | session | `{decision: "allow"\|"deny"\|"ask"}` |
+| `FileEdited` | session | drained per-turn |
+| `SessionError` / `SessionIdle` | session | observability |
+| `PreFinish` / `PostFinish` | session | wraps `on_finish` |
+| `OnUnsettledDetected` | session | non-empty harness at finish |
+| `PreSuspend` / `PostSuspend` / `PreResume` / `PostResume` | session | lifecycle gates |
+| `PreDrain` / `PostDrain` / `OnDrainDecision` | session | drain-loop gates |
+
+Worker events do not support reminder effects — the runtime returns
+`HARN-RMD-002` when a worker hook tries to inject one. Use a session
+or persona hook instead.
+
+## Replay determinism
+
+Every lifecycle decision the runtime makes is recorded so a replay
+reproduces the same control flow:
+
+1. **Cached resume input.** `harness.resume_subagent(handle, input)`
+   persists the input snapshot on the resume event so the replay
+   oracle can feed the same value back into the same worker without
+   re-reading host state.
+2. **Memoized drain decisions.** Each `drain_decision` audit captures
+   the bucket, item id, and disposition. The replay oracle replays the
+   audit log instead of re-walking the snapshot, so a non-deterministic
+   `on_drain_decision` hook (e.g. one that consults wall-clock) cannot
+   drift the second run.
+3. **Signed timestamps.** `harness.emit_audit` stamps entries with a
+   per-run monotonic `seq` rather than wall-clock time, so audit
+   ordering is reproducible. Wall-clock fields (`queued_at_ms`,
+   `age_ms`) come from `clock_mock`-aware sources and respect
+   `mock_time(...)` / `advance_time(...)` in tests.
+4. **One-shot registration.** `pipeline_on_finish(callback)` is
+   last-write-wins, and the slot is consumed exactly once per run via
+   `take_pipeline_on_finish`. A stale registration cannot leak across
+   runs.
+
+## See also
+
+- [Pipeline lifecycle presets](./stdlib/lifecycle.md) — per-preset
+  surface, harness method reference.
+- [Lifecycle cookbook](./cookbooks/lifecycle.md) — five end-to-end
+  patterns (nightly handoff, custom audit, long-paused agent,
+  business-hours suspend deny, replay-deterministic test harness).
+- [Hooks](./extensibility/hooks.md) — tool, persona, and session hook
+  registration surface.
+- [Agent channels](./agent-channels.md) and [Agent pools](./agent-pools.md)
+   — sibling epics whose work surfaces in
+  `harness.unsettled_state()`.
+- The `LLM quick reference` Pipeline lifecycle section — copy-paste
+  presets, combinators, and event tables.

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -2263,6 +2263,177 @@ The user-facing reference is `docs/src/agent-pools.md`; the stdlib
 reference is `docs/src/stdlib/lifecycle-pool.md`; runnable patterns
 live in `docs/src/cookbooks/pools.md`.
 
+## Pipeline lifecycle
+
+Pipelines do not end the moment their declared steps return. Between
+the last statement of the pipeline body and the value the host sees,
+the runtime fires a fixed sequence of lifecycle gates and one user
+callback. The same callback shape — `fn(harness, return_value) ->
+return_value` — threads through every gate, so presets and
+combinators that work for `on_finish` also work for hook handlers,
+`resume_by` callbacks, and any custom drain logic.
+
+### Lifecycle event order
+
+When a pipeline's declared steps complete the runtime walks this
+sequence on the main VM:
+
+1. `PreFinish` — last chance to inject a reminder before the pipeline
+   value is captured. Rejects `{block: true}`; the runtime surfaces a
+   runtime error pointing at `OnFinish.block_until_settled`.
+2. The registered `on_finish` callback. Default behavior (no
+   registration) is identical to `on_finish_abandon`.
+3. `OnUnsettledDetected` — fires after the callback if any bucket in
+   `harness.unsettled_state()` is non-empty. Accepts `{block: true,
+   reason}` to delay finish until the host explicitly drains and
+   `{modify: payload}` to amend the snapshot.
+4. `PostFinish` — advisory; observe the final value, push telemetry.
+5. The value is returned to the host.
+
+Each step records `hook_call` / `hook_returned` / `hook_vetoed`
+events on the active session transcript so replay reproduces the same
+control flow.
+
+### `Pipeline.on_finish` semantic
+
+`pipeline_on_finish(callback)` is a stdlib builtin that registers a
+`fn(harness, return_value)` closure into a thread-local one-shot slot
+(`PIPELINE_ON_FINISH`). The slot is last-write-wins inside one run.
+`Vm::execute` consumes the registered callback via
+`take_pipeline_on_finish` exactly once, between the `PreFinish` and
+`OnUnsettledDetected` gates. The callback's return value replaces the
+pipeline's return value before `PostFinish` fires. On the error exit
+path the slot is cleared so a failed pipeline cannot leak its
+registration into the next run.
+
+### `Harness` type
+
+The single argument to every lifecycle callback is the harness. The
+read-side surface is `unsettled_state(): UnsettledStateSnapshot`,
+which returns a stable JSON-shaped dict with five lists:
+`suspended_subagents`, `queued_triggers`, `partial_handoffs`,
+`in_flight_llm_calls`, and `pool_pending_tasks`. The `is_empty`,
+`counts`, and `summary` derived methods accept either an already-taken
+snapshot (for callback-consistent decisions) or no argument (fresh
+snapshot per call). Producers populate buckets from live VM
+registries (suspended subagents, partial handoffs, in-flight LLM
+calls, pool pending tasks) and from event-log records (queued
+trigger inbox + worker queue items).
+
+Write-side actions:
+
+| Method | Effect |
+|---|---|
+| `resume_subagent(handle, input?)` | Resume a suspended worker; falls back to send-input for awaiting retriggerables. |
+| `cancel_subagent(handle, reason?)` | Close a suspended worker via `__host_worker_close`. |
+| `handoff_to(target_pipeline, payload?)` | Record a `PartialHandoffEnvelope` in the thread-local registry; returns `{status: "queued", envelope}`. |
+| `acknowledge_trigger(id)` | Settle a queued inbox or worker-queue item with the existing ack record. |
+| `defer_trigger(id, target_pipeline?)` | Ack the trigger and record a partial-handoff envelope (default target `deferred-triggers`). |
+| `acknowledge_handoff(envelope_id, decision?)` | Remove a partial envelope from the registry; emit `handoff_acknowledged` audit. |
+| `wait_for_any_settlement(max_duration?)` | Snapshot + return `{status, timed_out, state}`. |
+| `emit_audit(kind, payload?)` | Append a `LifecycleAuditEntry` to the per-run log and (when an EventLog is installed) the `pipeline.lifecycle.audit` topic. |
+| `finalize(disposition?)` | Stamp the run's final disposition; emit `pipeline_finalized`. |
+| `spawn_settlement_agent(unsettled, return_value)` | Hand off to the bounded settlement-agent drain loop. |
+| `current_pipeline_id()` | Run id from the current mutation session, else session id, else nil. |
+
+### `DrainAgent` constrained tool surface + ordering enforcement
+
+The settlement-agent loop (`harness.spawn_settlement_agent`) walks the
+unsettled snapshot in a fixed canonical order: suspended subagents →
+queued triggers → partial handoffs → in-flight LLM calls → pool
+pending. Each item receives a default disposition:
+
+| Bucket | Default disposition |
+|---|---|
+| `suspended_subagents` | Cancel via `harness.cancel_subagent`. |
+| `queued_triggers` | Acknowledge via `harness.acknowledge_trigger`. |
+| `partial_handoffs` | Acknowledge as `deferred` via `harness.acknowledge_handoff`. |
+| `in_flight_llm_calls` | Drain via the LLM call registry. |
+| `pool_pending_tasks` | Defer via the pool registry. |
+
+The loop is bounded by a per-call budget — default 5, configurable via
+the third arg to `spawn_settlement_agent`, hard-capped at 20. On
+exhaustion a `drain_unsettled_remaining` audit captures the
+remainder. Each disposition records a `drain_decision` lifecycle
+audit and fires the `OnDrainDecision` hook chain (`Allow` / `Block` /
+`Modify`) before persisting, so VM-side hooks observe the disposition
+before it lands.
+
+Ordering enforcement: `harness.acknowledge_trigger` and
+`harness.acknowledge_handoff` reject out-of-order calls with
+`HARN-DRN-001`. A caller (the settlement-agent loop or a future
+LLM-driven settlement variant) cannot finalize a later category while
+earlier work is still pending. `__host_settlement_agent_active()`
+returns `true` when the constrained drain tool surface is in scope so
+conformance fixtures and IDE hosts can observe the loop boundary.
+
+### Lifecycle event taxonomy
+
+The runtime exposes 40 hook events. Registration surfaces:
+`register_tool_hook` (tool events), `register_persona_hook` (persona
+events), `register_worker_hook` (worker events), and
+`register_session_hook` (session events).
+
+| Event | Category | Reminder effects |
+|---|---|---|
+| `PreToolUse`, `PostToolUse` | tool | supported |
+| `PreAgentTurn`, `PostAgentTurn` | persona | supported |
+| `WorkerSpawned`, `WorkerProgressed`, `WorkerWaitingForInput`, `WorkerSuspended`, `WorkerResumed`, `WorkerCompleted`, `WorkerFailed`, `WorkerCancelled` | worker | rejected (`HARN-RMD-002`) |
+| `PreStep`, `PostStep` | persona | supported |
+| `OnBudgetThreshold` | persona | supported |
+| `OnApprovalRequested`, `OnHandoffEmitted` | persona | supported |
+| `OnPersonaPaused`, `OnPersonaResumed` | persona | supported |
+| `SessionStart`, `SessionEnd` | session | supported |
+| `UserPromptSubmit` | session | supported, accepts `{block, reason}` |
+| `PreCompact`, `PostCompact` | session | supported |
+| `PostTurn` | session | supported |
+| `PermissionAsked`, `PermissionReplied` | session | accepts `{decision: "allow"\|"deny"\|"ask", reason}` |
+| `FileEdited` | session | supported (drained per-turn) |
+| `SessionError`, `SessionIdle` | session | supported |
+| `PreFinish` | session | supported; rejects `{block: true}` |
+| `PostFinish` | session | supported (advisory) |
+| `OnUnsettledDetected` | session | accepts `{block, reason}` and `{modify: payload}` |
+| `PreSuspend`, `PostSuspend`, `PreResume`, `PostResume` | session | suspend / resume gates |
+| `PreDrain`, `PostDrain`, `OnDrainDecision` | session | drain-loop gates |
+
+Veto-capable events accept `{block: true, reason}`. Lifecycle-gate
+events that support payload rewriting also accept `{modify: payload}`
+to amend the dispatched event before resuming the lifecycle step.
+Hook returns also accept a reminder effect (`{reminder: {...}}` or a
+bare reminder spec) on every event whose `supports_reminder_effects()`
+is true. Worker events reject reminder effects with diagnostic
+`HARN-RMD-002` because the worker dispatcher does not own a session
+transcript.
+
+### Replay determinism rules
+
+Every lifecycle decision is reproducible on a replay:
+
+1. **Cached resume input.** `harness.resume_subagent(handle, input)`
+   persists the input snapshot on the resume event so the replay
+   oracle feeds the same value back into the same worker without
+   re-reading host state.
+2. **Memoized drain decisions.** Each `drain_decision` audit captures
+   the bucket, item id, and disposition. The replay oracle consumes
+   the audit log instead of re-walking the snapshot, so a
+   non-deterministic `on_drain_decision` hook (one that consults
+   wall-clock or external state) cannot drift the second run.
+3. **Signed timestamps.** `harness.emit_audit` stamps entries with a
+   per-run monotonic `LIFECYCLE_SEQ` counter rather than wall-clock
+   time. Wall-clock fields (`queued_at_ms`, `age_ms`) come from
+   `clock_mock`-aware sources and respect `mock_time(...)` /
+   `advance_time(...)` in tests.
+4. **One-shot registration.** `pipeline_on_finish(callback)` is
+   last-write-wins; the slot is consumed exactly once per run via
+   `take_pipeline_on_finish`. The error exit path clears the slot
+   alongside the audit log, partial-handoff registry, disposition
+   slot, and seq counter, so a failed run cannot leak in-progress
+   state into the next run.
+
+The user-facing reference is `docs/src/pipeline-lifecycle.md`; the
+stdlib reference is `docs/src/stdlib/lifecycle.md`; runnable patterns
+live in `docs/src/cookbooks/lifecycle.md`.
+
 ## Error model
 
 ### throw


### PR DESCRIPTION
## Summary

- Closes the docs gap for the callback-first pipeline lifecycle epic (#1853, P-10). The lifecycle surface has shipped (P-01..P-09, P-11); this PR is the user-facing reference.
- Adds `docs/src/pipeline-lifecycle.md` (long-form mdBook page), `docs/src/cookbooks/lifecycle.md` (five end-to-end recipes), a "Pipeline lifecycle" section in `docs/llm/harn-quickref.md`, and a Pipeline lifecycle subsection in `spec/HARN_SPEC.md` with formal definitions of the on_finish semantic, the Harness type, the DrainAgent constrained tool surface + HARN-DRN-001 ordering enforcement, the 40-event lifecycle event taxonomy, and the four replay-determinism rules.
- Wires the new pages into `docs/src/SUMMARY.md`, re-syncs `docs/src/language-spec.md` via `make sync-language-spec`, and lands a changelog entry under `## Unreleased`.

## Test plan

- [x] `make lint-md` clean
- [x] `make check-docs-snippets` clean (569 checked, 217 skipped, 0 failed)
- [x] `mdbook build` clean
- [x] `make check-language-spec` clean (mirror in sync)
- [x] Pre-commit + pre-push hooks pass

Closes #1863.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)