### PR TITLE
Bump OpenTrustGraph schema to v0.1 with effect inheritance (#1778)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,39 @@ condensed series summaries instead of full per-patch history.
 
 ### Added
 
+- **OpenTrustGraph schema v0.1 (#1778).** Bumps the trust-record schema
+  discriminator from `opentrustgraph/v0` to `opentrustgraph/v0.1` and
+  reserves three additional keys under `TrustRecord.metadata`:
+  `effects_grant` (typed `EffectRecord` list extended by the parent),
+  `effects_used` (typed `EffectRecord` list the action actually
+  exercised), and `parent_record_id` (pointer at the parent record's
+  `record_id`). Verifiers can now prove that a child agent's
+  `effects_used ⊆ parent.effects_grant`, closing the receipt-chain
+  inclusion proof flagged in E5.5. Backwards compatible at the record
+  layer: `TrustRecord` deserialization still accepts the older
+  `opentrustgraph/v0` discriminator for one patch release window per
+  the new [`opentrustgraph-spec/CONFORMANCE.md` §5.1][otg-v0-1] before
+  v0 is retired. The chain hash inputs and chain-export envelope
+  (`opentrustgraph-chain/v0`) are unchanged because metadata was
+  already hash-covered. Ships the new `v0.1` JSON Schema at
+  `opentrustgraph-spec/schemas/trust-record.v0.1.schema.json`, a new
+  3-agent fixture
+  `opentrustgraph-spec/fixtures/valid/effect-inheritance-chain.json`
+  demonstrating the inheritance invariant end-to-end, and extends the
+  pure-Python reference verifier (`examples/python/verify_chain.py`) to
+  enforce the subset check. New helpers on `TrustRecord`
+  (`with_effects_grant`, `with_effects_used`, `with_parent_record_id`,
+  plus matching getters and setters) keep callers from poking at the
+  reserved metadata keys by hand. Exposes new public constants
+  (`OPENTRUSTGRAPH_SCHEMA_V0_1`, `OPENTRUSTGRAPH_ACCEPTED_SCHEMAS`,
+  `METADATA_KEY_EFFECTS_GRANT`, `METADATA_KEY_EFFECTS_USED`,
+  `METADATA_KEY_PARENT_RECORD_ID`) and the matching re-exports from
+  `harn_vm`. The harn-cloud receipt-store replatform is tracked
+  separately (paired ticket under epic #1773); both versions are
+  accepted on ingest until then.
+
+  [otg-v0-1]: https://github.com/burin-labs/harn/blob/main/opentrustgraph-spec/CONFORMANCE.md#51-v01-reserved-metadata-keys-1778
+
 - **Suspend/resume docs (S-13, #1849).** Adds the user-facing
   reference for the agent suspend/resume primitive (epic #1836). New
   mdBook page `docs/src/agent-lifecycle.md` covers the lifecycle

--- a/README.md
+++ b/README.md
@@ -8,9 +8,12 @@ workflows, policies, capabilities, and UI hooks, while Harn owns transcripts,
 context assembly, retries, tool routing, persistence, replay, and provider
 normalization.
 
-Harn also emits portable `opentrustgraph/v0` trust records for autonomy
-decisions, approval gates, and tier transitions. The public schema and fixtures
-live in [`opentrustgraph-spec/`](./opentrustgraph-spec/).
+Harn also emits portable `opentrustgraph/v0.1` trust records for autonomy
+decisions, approval gates, and tier transitions. `v0.1` adds three
+reserved `metadata` keys (`effects_grant`, `effects_used`,
+`parent_record_id`) so chain validators can prove that a child agent's
+`effects_used` stayed inside the parent's `effects_grant`. The public
+schema and fixtures live in [`opentrustgraph-spec/`](./opentrustgraph-spec/).
 
 ## Install
 

--- a/conformance/tests/trust_graph/basic_dispatch_records.harn
+++ b/conformance/tests/trust_graph/basic_dispatch_records.harn
@@ -42,7 +42,7 @@ pipeline test(task) {
   println(fired.result?.action == "github.issue.opened")
   println(fired.result?.autonomy_tier == "act_auto")
   println(len(records) == 1)
-  println(records[0].schema == "opentrustgraph/v0")
+  println(records[0].schema == "opentrustgraph/v0.1")
   println(records[0].outcome == "success" && records[0].autonomy_tier == "act_auto")
   println(records[0].trace_id == fired.result?.trace_id)
 }

--- a/conformance/tests/trust_graph/trust_graph_schema_v0_1_chain_export_unchanged.expected
+++ b/conformance/tests/trust_graph/trust_graph_schema_v0_1_chain_export_unchanged.expected
@@ -1,0 +1,3 @@
+true
+true
+true

--- a/conformance/tests/trust_graph/trust_graph_schema_v0_1_chain_export_unchanged.harn
+++ b/conformance/tests/trust_graph/trust_graph_schema_v0_1_chain_export_unchanged.harn
@@ -1,0 +1,33 @@
+import "std/triggers"
+
+/**
+ * Verifies that the v0.1 schema bump (#1778) is additive at the record
+ * metadata layer only: the chain-export envelope discriminator stays
+ * `opentrustgraph-chain/v0`, and a v0.1 record + chain still validates
+ * end-to-end. Backwards compatibility of the prior `opentrustgraph/v0`
+ * record discriminator is covered by the Rust unit test
+ * `trust_graph::tests::v0_records_still_parse_for_backward_compat`.
+ */
+pipeline test(task) {
+  let unique = to_string(to_int(timestamp())) + "-" + to_string(random_int(100000, 999999))
+  let agent_id = "trust-graph-v0-1-chain-" + unique
+  trust_graph_record(
+    {
+      agent: agent_id,
+      action: "deploy.preview",
+      approver: nil,
+      outcome: "success",
+      trace_id: "trace-" + unique,
+      autonomy_tier: "act_auto",
+      metadata: {parent_record_id: nil},
+    },
+  )
+  let report: TrustChainReport = trust_graph_verify_chain()
+  let records: list<TrustRecord> = trust_query({agent: agent_id})
+  println(report.verified)
+  println(records[0].schema == "opentrustgraph/v0.1")
+  // The new metadata keys are optional: when omitted they don't surface
+  // as record fields. parent_record_id was set to nil above so it MUST
+  // round-trip as nil (not the empty string).
+  println(records[0].metadata?.parent_record_id == nil)
+}

--- a/conformance/tests/trust_graph/trust_graph_schema_v0_1_effects_inheritance.expected
+++ b/conformance/tests/trust_graph/trust_graph_schema_v0_1_effects_inheritance.expected
@@ -1,0 +1,8 @@
+true
+true
+true
+true
+true
+true
+true
+true

--- a/conformance/tests/trust_graph/trust_graph_schema_v0_1_effects_inheritance.harn
+++ b/conformance/tests/trust_graph/trust_graph_schema_v0_1_effects_inheritance.harn
@@ -1,0 +1,71 @@
+import "std/triggers"
+
+/**
+ * Verifies the v0.1 schema bump (#1778): a 3-agent chain
+ * (parent → child → grandchild) round-trips `effects_grant`,
+ * `effects_used`, and `parent_record_id` end-to-end through the
+ * stdlib `trust_graph_record` / `trust_query` surface, and the
+ * inheritance invariant `effects_used ⊆ child.effects_grant ⊆
+ * parent.effects_grant` holds.
+ */
+pipeline test(task) {
+  let unique = to_string(to_int(timestamp())) + "-" + to_string(random_int(100000, 999999))
+  let parent_grant = [
+    {kind: {kind: "net"}, scope: "write", resource: "https://api.example"},
+    {kind: {kind: "fs"}, scope: "read", resource: "/workspace/src"},
+    {kind: {kind: "fs"}, scope: "write", resource: "/workspace/tmp"},
+  ]
+  let child_grant = [
+    {kind: {kind: "net"}, scope: "write", resource: "https://api.example"},
+    {kind: {kind: "fs"}, scope: "read", resource: "/workspace/src"},
+  ]
+  let grandchild_used = [{kind: {kind: "fs"}, scope: "read", resource: "/workspace/src"}]
+  let parent_agent = "trust-graph-v0-1-parent-" + unique
+  let child_agent = "trust-graph-v0-1-child-" + unique
+  let grandchild_agent = "trust-graph-v0-1-grandchild-" + unique
+  let parent_id: TrustEntryId = trust_graph_record(
+    {
+      agent: parent_agent,
+      action: "agent.spawn",
+      approver: nil,
+      outcome: "success",
+      trace_id: "trace-parent-" + unique,
+      autonomy_tier: "act_auto",
+      metadata: {effects_grant: parent_grant},
+    },
+  )
+  let child_id: TrustEntryId = trust_graph_record(
+    {
+      agent: child_agent,
+      action: "agent.spawn",
+      approver: nil,
+      outcome: "success",
+      trace_id: "trace-child-" + unique,
+      autonomy_tier: "act_auto",
+      metadata: {effects_grant: child_grant, parent_record_id: parent_id},
+    },
+  )
+  let _grandchild_id: TrustEntryId = trust_graph_record(
+    {
+      agent: grandchild_agent,
+      action: "fs.read",
+      approver: nil,
+      outcome: "success",
+      trace_id: "trace-grandchild-" + unique,
+      autonomy_tier: "act_auto",
+      metadata: {effects_used: grandchild_used, parent_record_id: child_id},
+    },
+  )
+  let parent: list<TrustRecord> = trust_query({agent: parent_agent})
+  let child: list<TrustRecord> = trust_query({agent: child_agent})
+  let grandchild: list<TrustRecord> = trust_query({agent: grandchild_agent})
+  let report: TrustChainReport = trust_graph_verify_chain()
+  println(len(parent) == 1 && len(child) == 1 && len(grandchild) == 1)
+  println(parent[0].schema == "opentrustgraph/v0.1")
+  println(child[0].metadata?.parent_record_id == parent_id)
+  println(grandchild[0].metadata?.parent_record_id == child_id)
+  println(len(parent[0].metadata?.effects_grant) == 3)
+  println(len(child[0].metadata?.effects_grant) == 2)
+  println(len(grandchild[0].metadata?.effects_used) == 1)
+  println(report.verified)
+}

--- a/conformance/tests/trust_graph/trust_graph_schema_v0_1_round_trip.expected
+++ b/conformance/tests/trust_graph/trust_graph_schema_v0_1_round_trip.expected
@@ -1,0 +1,4 @@
+true
+true
+true
+true

--- a/conformance/tests/trust_graph/trust_graph_schema_v0_1_round_trip.harn
+++ b/conformance/tests/trust_graph/trust_graph_schema_v0_1_round_trip.harn
@@ -1,0 +1,28 @@
+import "std/triggers"
+
+/**
+ * Verifies the v0.1 schema bump (#1778): newly-appended records carry
+ * the `opentrustgraph/v0.1` discriminator end-to-end, and the chain still
+ * verifies cleanly.
+ */
+pipeline test(task) {
+  let unique = to_string(to_int(timestamp())) + "-" + to_string(random_int(100000, 999999))
+  let agent_id = "trust-graph-v0-1-roundtrip-" + unique
+  trust_graph_record(
+    {
+      agent: agent_id,
+      action: "deploy.preview",
+      approver: nil,
+      outcome: "success",
+      trace_id: "trace-" + unique,
+      autonomy_tier: "act_auto",
+      metadata: {ticket: "INC-1"},
+    },
+  )
+  let records: list<TrustRecord> = trust_query({agent: agent_id})
+  let report: TrustChainReport = trust_graph_verify_chain()
+  println(len(records) == 1)
+  println(records[0].schema == "opentrustgraph/v0.1")
+  println(records[0].entry_hash != "")
+  println(report.verified)
+}

--- a/conformance/tests/trust_graph/trust_query_by_agent.harn
+++ b/conformance/tests/trust_graph/trust_query_by_agent.harn
@@ -11,7 +11,7 @@ pipeline test(task) {
   let failures: list<TrustRecord> = trust_query({agent: agent_a, outcome: "failure"})
   let denied: list<TrustRecord> = trust_query({agent: agent_b, outcome: "denied"})
   let suggest_records: list<TrustRecord> = trust_query({agent: agent_a, tier: "suggest"})
-  println(first.schema == "opentrustgraph/v0")
+  println(first.schema == "opentrustgraph/v0.1")
   println(second.outcome == "failure")
   println(third.autonomy_tier == "shadow")
   println(len(alpha_records) == 2)

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -285,10 +285,11 @@ pub use trust_graph::{
     summarize_trust_records, topic_for_agent, trust_score_for, verify_trust_chain, AutonomyTier,
     TrustAgentSummary, TrustChainExport, TrustChainExportMetadata, TrustChainExportProducer,
     TrustChainReport, TrustGraphRecord, TrustOutcome, TrustQueryFilters, TrustRecord,
-    TrustRecordActionKind, TrustScore, TrustTraceGroup, OPENTRUSTGRAPH_CHAIN_SCHEMA_V0,
-    OPENTRUSTGRAPH_SCHEMA_V0, TRUST_ACTION_RELEASE, TRUST_GRAPH_GLOBAL_TOPIC,
-    TRUST_GRAPH_LEGACY_GLOBAL_TOPIC, TRUST_GRAPH_LEGACY_TOPIC_PREFIX, TRUST_GRAPH_RECORDS_TOPIC,
-    TRUST_GRAPH_TOPIC_PREFIX,
+    TrustRecordActionKind, TrustScore, TrustTraceGroup, METADATA_KEY_EFFECTS_GRANT,
+    METADATA_KEY_EFFECTS_USED, METADATA_KEY_PARENT_RECORD_ID, OPENTRUSTGRAPH_ACCEPTED_SCHEMAS,
+    OPENTRUSTGRAPH_CHAIN_SCHEMA_V0, OPENTRUSTGRAPH_SCHEMA_V0, OPENTRUSTGRAPH_SCHEMA_V0_1,
+    TRUST_ACTION_RELEASE, TRUST_GRAPH_GLOBAL_TOPIC, TRUST_GRAPH_LEGACY_GLOBAL_TOPIC,
+    TRUST_GRAPH_LEGACY_TOPIC_PREFIX, TRUST_GRAPH_RECORDS_TOPIC, TRUST_GRAPH_TOPIC_PREFIX,
 };
 pub use value::*;
 pub use vm::*;

--- a/crates/harn-vm/src/trust_graph.rs
+++ b/crates/harn-vm/src/trust_graph.rs
@@ -10,10 +10,35 @@ use crate::event_log::{
     active_event_log, sanitize_topic_component, AnyEventLog, EventId, EventLog, LogError, LogEvent,
     Topic,
 };
-use crate::orchestration::CapabilityPolicy;
+use crate::orchestration::{CapabilityPolicy, EffectRecord};
 
 pub const OPENTRUSTGRAPH_SCHEMA_V0: &str = "opentrustgraph/v0";
+/// OpenTrustGraph v0.1: additive metadata schema (#1778). Adds the
+/// `effects_grant`, `effects_used`, and `parent_record_id` reserved keys
+/// under `TrustRecord.metadata` so chain validators can prove that a
+/// child agent's `effects_used ⊆ parent.effects_grant` (E5.5).
+///
+/// Backwards compatible: v0 records are still accepted (the new keys are
+/// optional). One patch release window after this bump, v0 will be
+/// dropped per `opentrustgraph-spec/CONFORMANCE.md` §5.
+pub const OPENTRUSTGRAPH_SCHEMA_V0_1: &str = "opentrustgraph/v0.1";
+/// Set of schema discriminators accepted by the v0.1 validator. v0 stays
+/// here for one patch release window before being retired.
+pub const OPENTRUSTGRAPH_ACCEPTED_SCHEMAS: &[&str] =
+    &[OPENTRUSTGRAPH_SCHEMA_V0_1, OPENTRUSTGRAPH_SCHEMA_V0];
 pub const OPENTRUSTGRAPH_CHAIN_SCHEMA_V0: &str = "opentrustgraph-chain/v0";
+
+/// Reserved metadata key for the effect grant attached to a record by its
+/// spawning parent. v0.1 addition (#1778).
+pub const METADATA_KEY_EFFECTS_GRANT: &str = "effects_grant";
+/// Reserved metadata key for the effects the recorded action actually
+/// exercised. Must be a subset of the parent's `effects_grant`. v0.1
+/// addition (#1778).
+pub const METADATA_KEY_EFFECTS_USED: &str = "effects_used";
+/// Reserved metadata key pointing at the parent record's `record_id`.
+/// Lets verifiers reconstruct the agent chain without scanning the whole
+/// stream. v0.1 addition (#1778).
+pub const METADATA_KEY_PARENT_RECORD_ID: &str = "parent_record_id";
 pub const TRUST_GRAPH_RECORDS_TOPIC: &str = "trust_graph.records";
 pub const TRUST_GRAPH_GLOBAL_TOPIC: &str = "trust_graph";
 pub const TRUST_GRAPH_LEGACY_GLOBAL_TOPIC: &str = "trust.graph";
@@ -106,7 +131,7 @@ impl TrustRecord {
         autonomy_tier: AutonomyTier,
     ) -> Self {
         Self {
-            schema: OPENTRUSTGRAPH_SCHEMA_V0.to_string(),
+            schema: OPENTRUSTGRAPH_SCHEMA_V0_1.to_string(),
             record_id: Uuid::now_v7().to_string(),
             agent: agent.into(),
             action: action.into(),
@@ -163,6 +188,87 @@ impl TrustRecord {
         );
         record
     }
+
+    /// Attach the typed effect grant a parent extended to this record. v0.1
+    /// (#1778). Empty grants are skipped so legacy `metadata` shape is
+    /// preserved when there is nothing to record.
+    pub fn with_effects_grant(mut self, effects: Vec<EffectRecord>) -> Self {
+        self.set_effects_grant(effects);
+        self
+    }
+
+    pub fn set_effects_grant(&mut self, effects: Vec<EffectRecord>) {
+        if effects.is_empty() {
+            self.metadata.remove(METADATA_KEY_EFFECTS_GRANT);
+            return;
+        }
+        self.metadata.insert(
+            METADATA_KEY_EFFECTS_GRANT.to_string(),
+            serde_json::to_value(effects).expect("EffectRecord is serializable"),
+        );
+    }
+
+    pub fn effects_grant(&self) -> Vec<EffectRecord> {
+        decode_effect_list(self.metadata.get(METADATA_KEY_EFFECTS_GRANT))
+    }
+
+    /// Attach the typed effect set the action actually exercised. v0.1
+    /// (#1778). Verifiers must check `effects_used ⊆ effects_grant` (and
+    /// transitively up the parent chain).
+    pub fn with_effects_used(mut self, effects: Vec<EffectRecord>) -> Self {
+        self.set_effects_used(effects);
+        self
+    }
+
+    pub fn set_effects_used(&mut self, effects: Vec<EffectRecord>) {
+        if effects.is_empty() {
+            self.metadata.remove(METADATA_KEY_EFFECTS_USED);
+            return;
+        }
+        self.metadata.insert(
+            METADATA_KEY_EFFECTS_USED.to_string(),
+            serde_json::to_value(effects).expect("EffectRecord is serializable"),
+        );
+    }
+
+    pub fn effects_used(&self) -> Vec<EffectRecord> {
+        decode_effect_list(self.metadata.get(METADATA_KEY_EFFECTS_USED))
+    }
+
+    /// Point this record at its parent's `record_id`. v0.1 (#1778). The
+    /// existing release-record key (`parent_trust_record_id`) is retained
+    /// for the release flow; this is the generic spawn-lineage pointer.
+    pub fn with_parent_record_id(mut self, parent_record_id: impl Into<String>) -> Self {
+        self.set_parent_record_id(Some(parent_record_id.into()));
+        self
+    }
+
+    pub fn set_parent_record_id(&mut self, parent_record_id: Option<String>) {
+        match parent_record_id {
+            Some(id) if !id.is_empty() => {
+                self.metadata.insert(
+                    METADATA_KEY_PARENT_RECORD_ID.to_string(),
+                    serde_json::Value::String(id),
+                );
+            }
+            _ => {
+                self.metadata.remove(METADATA_KEY_PARENT_RECORD_ID);
+            }
+        }
+    }
+
+    pub fn parent_record_id(&self) -> Option<String> {
+        self.metadata
+            .get(METADATA_KEY_PARENT_RECORD_ID)
+            .and_then(|value| value.as_str())
+            .map(str::to_string)
+    }
+}
+
+fn decode_effect_list(value: Option<&serde_json::Value>) -> Vec<EffectRecord> {
+    value
+        .and_then(|value| serde_json::from_value::<Vec<EffectRecord>>(value.clone()).ok())
+        .unwrap_or_default()
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -956,11 +1062,15 @@ mod tests {
 
     const RECORD_SCHEMA_JSON: &str =
         include_str!("trust_graph/schemas/trust-record.v0.schema.json");
+    const RECORD_SCHEMA_V0_1_JSON: &str =
+        include_str!("trust_graph/schemas/trust-record.v0.1.schema.json");
     const CHAIN_SCHEMA_JSON: &str = include_str!("trust_graph/schemas/trust-chain.v0.schema.json");
     const VALID_DECISION_CHAIN_JSON: &str =
         include_str!("trust_graph/fixtures/valid/decision-chain.json");
     const VALID_TIER_TRANSITION_JSON: &str =
         include_str!("trust_graph/fixtures/valid/tier-transition.json");
+    const VALID_EFFECT_INHERITANCE_CHAIN_JSON: &str =
+        include_str!("trust_graph/fixtures/valid/effect-inheritance-chain.json");
     const INVALID_TAMPERED_CHAIN_JSON: &str =
         include_str!("trust_graph/fixtures/invalid/tampered-chain.json");
     const INVALID_MISSING_APPROVAL_JSON: &str =
@@ -993,6 +1103,10 @@ mod tests {
 
         for (relative, embedded) in [
             ("schemas/trust-record.v0.schema.json", RECORD_SCHEMA_JSON),
+            (
+                "schemas/trust-record.v0.1.schema.json",
+                RECORD_SCHEMA_V0_1_JSON,
+            ),
             ("schemas/trust-chain.v0.schema.json", CHAIN_SCHEMA_JSON),
             (
                 "fixtures/valid/decision-chain.json",
@@ -1001,6 +1115,10 @@ mod tests {
             (
                 "fixtures/valid/tier-transition.json",
                 VALID_TIER_TRANSITION_JSON,
+            ),
+            (
+                "fixtures/valid/effect-inheritance-chain.json",
+                VALID_EFFECT_INHERITANCE_CHAIN_JSON,
             ),
             (
                 "fixtures/invalid/tampered-chain.json",
@@ -1277,11 +1395,24 @@ mod tests {
     #[test]
     fn opentrustgraph_schema_files_are_parseable_and_match_runtime_enums() {
         let record_schema: serde_json::Value = serde_json::from_str(RECORD_SCHEMA_JSON).unwrap();
+        let record_schema_v0_1: serde_json::Value =
+            serde_json::from_str(RECORD_SCHEMA_V0_1_JSON).unwrap();
         let chain_schema: serde_json::Value = serde_json::from_str(CHAIN_SCHEMA_JSON).unwrap();
 
         assert_eq!(
             record_schema["properties"]["schema"]["const"],
             serde_json::json!(OPENTRUSTGRAPH_SCHEMA_V0)
+        );
+        let v0_1_schema_enum = record_schema_v0_1["properties"]["schema"]["enum"]
+            .as_array()
+            .expect("v0.1 record schema declares schema as an enum");
+        assert!(
+            v0_1_schema_enum.contains(&serde_json::json!(OPENTRUSTGRAPH_SCHEMA_V0_1)),
+            "v0.1 record schema must accept {OPENTRUSTGRAPH_SCHEMA_V0_1}: {v0_1_schema_enum:?}"
+        );
+        assert!(
+            v0_1_schema_enum.contains(&serde_json::json!(OPENTRUSTGRAPH_SCHEMA_V0)),
+            "v0.1 record schema must still accept v0 (one-release back-compat): {v0_1_schema_enum:?}"
         );
         assert_eq!(
             chain_schema["properties"]["schema"]["const"],
@@ -1318,6 +1449,10 @@ mod tests {
         for (name, fixture) in [
             ("decision-chain", VALID_DECISION_CHAIN_JSON),
             ("tier-transition", VALID_TIER_TRANSITION_JSON),
+            (
+                "effect-inheritance-chain",
+                VALID_EFFECT_INHERITANCE_CHAIN_JSON,
+            ),
         ] {
             let fixture = parse_chain_fixture(fixture);
             let errors = validate_chain_fixture(&fixture);
@@ -1358,7 +1493,7 @@ mod tests {
 
     fn validate_chain_fixture(fixture: &TrustChainFixture) -> Vec<String> {
         let mut errors = Vec::new();
-        if fixture.schema != "opentrustgraph-chain/v0" {
+        if fixture.schema != OPENTRUSTGRAPH_CHAIN_SCHEMA_V0 {
             errors.push(format!("unsupported chain schema {}", fixture.schema));
         }
         if fixture.chain.topic.trim().is_empty() {
@@ -1409,7 +1544,7 @@ mod tests {
     fn validate_fixture_record_contract(index: usize, record: &TrustRecord) -> Vec<String> {
         let mut errors = Vec::new();
         let label = format!("record {index}");
-        if record.schema != OPENTRUSTGRAPH_SCHEMA_V0 {
+        if !OPENTRUSTGRAPH_ACCEPTED_SCHEMAS.contains(&record.schema.as_str()) {
             errors.push(format!("{label}: unsupported schema {}", record.schema));
         }
         if record.record_id.trim().is_empty() {
@@ -1510,5 +1645,198 @@ mod tests {
             .and_then(|signatures| signatures.as_array())
             .map(Vec::len)
             .unwrap_or(0)
+    }
+
+    // ----- OpenTrustGraph v0.1 schema bump (#1778) -----
+
+    use crate::orchestration::{EffectKind, EffectScope};
+
+    #[test]
+    fn new_trust_record_defaults_to_v0_1_schema() {
+        let record = TrustRecord::new(
+            "agent",
+            "deploy.preview",
+            None,
+            TrustOutcome::Success,
+            "trace-1",
+            AutonomyTier::Suggest,
+        );
+        assert_eq!(record.schema, OPENTRUSTGRAPH_SCHEMA_V0_1);
+    }
+
+    #[test]
+    fn v0_records_still_parse_for_backward_compat() {
+        let record_v0 = serde_json::json!({
+            "schema": "opentrustgraph/v0",
+            "record_id": "01966f4c-0f31-7b5d-b44b-f7f8e7e1d384",
+            "agent": "legacy-bot",
+            "action": "github.issue.opened",
+            "approver": null,
+            "outcome": "success",
+            "trace_id": "trace-legacy",
+            "autonomy_tier": "suggest",
+            "timestamp": "2026-04-19T18:42:11Z",
+            "cost_usd": null,
+            "chain_index": 1,
+            "previous_hash": null,
+            "entry_hash": "sha256:84facae7d56fd304e040ea18d80bd019e274ad86ddd5a4d732f3ac3d984c48ec",
+            "metadata": {"provider": "github"}
+        });
+        let decoded: TrustRecord = serde_json::from_value(record_v0).unwrap();
+        assert_eq!(decoded.schema, OPENTRUSTGRAPH_SCHEMA_V0);
+        assert!(OPENTRUSTGRAPH_ACCEPTED_SCHEMAS.contains(&decoded.schema.as_str()));
+        assert!(decoded.effects_grant().is_empty());
+        assert!(decoded.effects_used().is_empty());
+        assert!(decoded.parent_record_id().is_none());
+    }
+
+    #[test]
+    fn v0_1_effect_metadata_round_trips_through_json() {
+        let grant = vec![
+            EffectRecord::new(EffectKind::Net, EffectScope::Write)
+                .with_resource("https://api.example"),
+            EffectRecord::new(EffectKind::Fs, EffectScope::Read).with_resource("/workspace/src"),
+        ];
+        let used =
+            vec![EffectRecord::new(EffectKind::Fs, EffectScope::Read)
+                .with_resource("/workspace/src")];
+        let record = TrustRecord::new(
+            "child-agent",
+            "fs.read",
+            None,
+            TrustOutcome::Success,
+            "trace-effects-1",
+            AutonomyTier::ActAuto,
+        )
+        .with_effects_grant(grant.clone())
+        .with_effects_used(used.clone())
+        .with_parent_record_id("parent-record-001");
+
+        let encoded = serde_json::to_string(&record).unwrap();
+        let decoded: TrustRecord = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(decoded.schema, OPENTRUSTGRAPH_SCHEMA_V0_1);
+        assert_eq!(decoded.effects_grant(), grant);
+        assert_eq!(decoded.effects_used(), used);
+        assert_eq!(
+            decoded.parent_record_id().as_deref(),
+            Some("parent-record-001")
+        );
+    }
+
+    #[test]
+    fn effect_helpers_remove_keys_on_empty_input() {
+        let mut record = TrustRecord::new(
+            "agent",
+            "noop",
+            None,
+            TrustOutcome::Success,
+            "trace-1",
+            AutonomyTier::Suggest,
+        )
+        .with_effects_grant(vec![EffectRecord::new(EffectKind::Net, EffectScope::Write)])
+        .with_parent_record_id("parent-1");
+        assert!(record.metadata.contains_key(METADATA_KEY_EFFECTS_GRANT));
+        assert!(record.metadata.contains_key(METADATA_KEY_PARENT_RECORD_ID));
+
+        record.set_effects_grant(Vec::new());
+        record.set_parent_record_id(None);
+        assert!(!record.metadata.contains_key(METADATA_KEY_EFFECTS_GRANT));
+        assert!(!record.metadata.contains_key(METADATA_KEY_PARENT_RECORD_ID));
+    }
+
+    #[tokio::test]
+    async fn three_agent_chain_proves_effects_subset_inheritance() {
+        let log: Arc<AnyEventLog> = Arc::new(AnyEventLog::Memory(MemoryEventLog::new(16)));
+
+        let parent_grant = vec![
+            EffectRecord::new(EffectKind::Net, EffectScope::Write)
+                .with_resource("https://api.example"),
+            EffectRecord::new(EffectKind::Fs, EffectScope::Read).with_resource("/workspace/src"),
+            EffectRecord::new(EffectKind::Fs, EffectScope::Write).with_resource("/workspace/tmp"),
+        ];
+        let parent = append_trust_record(
+            &log,
+            &TrustRecord::new(
+                "parent",
+                "agent.spawn",
+                None,
+                TrustOutcome::Success,
+                "trace-parent",
+                AutonomyTier::ActAuto,
+            )
+            .with_effects_grant(parent_grant.clone()),
+        )
+        .await
+        .unwrap();
+
+        let child_grant = vec![
+            EffectRecord::new(EffectKind::Net, EffectScope::Write)
+                .with_resource("https://api.example"),
+            EffectRecord::new(EffectKind::Fs, EffectScope::Read).with_resource("/workspace/src"),
+        ];
+        let child = append_trust_record(
+            &log,
+            &TrustRecord::new(
+                "child",
+                "agent.spawn",
+                None,
+                TrustOutcome::Success,
+                "trace-child",
+                AutonomyTier::ActAuto,
+            )
+            .with_effects_grant(child_grant.clone())
+            .with_parent_record_id(parent.record_id.clone()),
+        )
+        .await
+        .unwrap();
+
+        let grandchild_used =
+            vec![EffectRecord::new(EffectKind::Fs, EffectScope::Read)
+                .with_resource("/workspace/src")];
+        let grandchild = append_trust_record(
+            &log,
+            &TrustRecord::new(
+                "grandchild",
+                "fs.read",
+                None,
+                TrustOutcome::Success,
+                "trace-grandchild",
+                AutonomyTier::ActAuto,
+            )
+            .with_effects_used(grandchild_used.clone())
+            .with_parent_record_id(child.record_id.clone()),
+        )
+        .await
+        .unwrap();
+
+        // grandchild.effects_used ⊆ child.effects_grant
+        for effect in &grandchild_used {
+            assert!(
+                child_grant.contains(effect),
+                "grandchild used {effect:?} not in child grant"
+            );
+        }
+        // child.effects_grant ⊆ parent.effects_grant
+        for effect in &child_grant {
+            assert!(
+                parent_grant.contains(effect),
+                "child grant {effect:?} not in parent grant"
+            );
+        }
+
+        assert_eq!(
+            grandchild.parent_record_id().as_deref(),
+            Some(child.record_id.as_str())
+        );
+        assert_eq!(
+            child.parent_record_id().as_deref(),
+            Some(parent.record_id.as_str())
+        );
+        assert!(parent.parent_record_id().is_none());
+
+        // The chain still verifies cleanly (additive metadata change).
+        let report = verify_trust_chain(&log).await.unwrap();
+        assert!(report.verified, "verification errors: {:?}", report.errors);
+        assert_eq!(report.total, 3);
     }
 }

--- a/crates/harn-vm/src/trust_graph/fixtures/valid/effect-inheritance-chain.json
+++ b/crates/harn-vm/src/trust_graph/fixtures/valid/effect-inheritance-chain.json
@@ -1,0 +1,117 @@
+{
+  "chain": {
+    "generated_at": "2026-04-19T20:33:00Z",
+    "producer": {
+      "name": "harn",
+      "version": "0.8.x"
+    },
+    "root_hash": "sha256:783dd6eb93fc13f2d42773f11693543a7f7cb2c28cef980b409c9f69830e5272",
+    "topic": "trust_graph",
+    "total": 3,
+    "verified": true
+  },
+  "records": [
+    {
+      "action": "agent.spawn",
+      "agent": "parent-orchestrator",
+      "approver": null,
+      "autonomy_tier": "act_auto",
+      "chain_index": 1,
+      "cost_usd": null,
+      "entry_hash": "sha256:0345151a3326dac3e5126efe1d903a09be8105609c62f2e6ceed3bbf2b65028f",
+      "metadata": {
+        "effects_grant": [
+          {
+            "kind": {
+              "kind": "net"
+            },
+            "resource": "https://api.example",
+            "scope": "write"
+          },
+          {
+            "kind": {
+              "kind": "fs"
+            },
+            "resource": "/workspace/src",
+            "scope": "read"
+          },
+          {
+            "kind": {
+              "kind": "fs"
+            },
+            "resource": "/workspace/tmp",
+            "scope": "write"
+          }
+        ]
+      },
+      "outcome": "success",
+      "previous_hash": null,
+      "record_id": "01966f4c-3000-7001-a000-000000000001",
+      "schema": "opentrustgraph/v0.1",
+      "timestamp": "2026-04-19T20:30:00Z",
+      "trace_id": "trace_effect_root"
+    },
+    {
+      "action": "agent.spawn",
+      "agent": "child-spawner",
+      "approver": null,
+      "autonomy_tier": "act_auto",
+      "chain_index": 2,
+      "cost_usd": null,
+      "entry_hash": "sha256:f26018404c747e059fae75d71a4c2ecf46673f14f63ee89e12f89295bb94c281",
+      "metadata": {
+        "effects_grant": [
+          {
+            "kind": {
+              "kind": "net"
+            },
+            "resource": "https://api.example",
+            "scope": "write"
+          },
+          {
+            "kind": {
+              "kind": "fs"
+            },
+            "resource": "/workspace/src",
+            "scope": "read"
+          }
+        ],
+        "parent_record_id": "01966f4c-3000-7001-a000-000000000001"
+      },
+      "outcome": "success",
+      "previous_hash": "sha256:0345151a3326dac3e5126efe1d903a09be8105609c62f2e6ceed3bbf2b65028f",
+      "record_id": "01966f4c-3001-7002-a000-000000000002",
+      "schema": "opentrustgraph/v0.1",
+      "timestamp": "2026-04-19T20:31:00Z",
+      "trace_id": "trace_effect_child"
+    },
+    {
+      "action": "fs.read",
+      "agent": "grandchild-worker",
+      "approver": null,
+      "autonomy_tier": "act_auto",
+      "chain_index": 3,
+      "cost_usd": 0.001,
+      "entry_hash": "sha256:783dd6eb93fc13f2d42773f11693543a7f7cb2c28cef980b409c9f69830e5272",
+      "metadata": {
+        "effects_used": [
+          {
+            "kind": {
+              "kind": "fs"
+            },
+            "resource": "/workspace/src",
+            "scope": "read"
+          }
+        ],
+        "parent_record_id": "01966f4c-3001-7002-a000-000000000002"
+      },
+      "outcome": "success",
+      "previous_hash": "sha256:f26018404c747e059fae75d71a4c2ecf46673f14f63ee89e12f89295bb94c281",
+      "record_id": "01966f4c-3002-7003-a000-000000000003",
+      "schema": "opentrustgraph/v0.1",
+      "timestamp": "2026-04-19T20:32:00Z",
+      "trace_id": "trace_effect_grandchild"
+    }
+  ],
+  "schema": "opentrustgraph-chain/v0"
+}

--- a/crates/harn-vm/src/trust_graph/schemas/trust-record.v0.1.schema.json
+++ b/crates/harn-vm/src/trust_graph/schemas/trust-record.v0.1.schema.json
@@ -1,0 +1,218 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/opentrustgraph/v0.1/trust-record.schema.json",
+  "title": "OpenTrustGraph TrustRecord v0.1",
+  "description": "One autonomy, approval, or control-plane event in an append-only OpenTrustGraph chain. v0.1 reserves three additional `metadata` keys (`effects_grant`, `effects_used`, `parent_record_id`) so chain validators can prove that a child agent's `effects_used ⊆ parent.effects_grant`. v0 records still validate against this schema for one patch release window (see CONFORMANCE.md §5).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "record_id",
+    "agent",
+    "action",
+    "outcome",
+    "trace_id",
+    "autonomy_tier",
+    "timestamp",
+    "chain_index",
+    "previous_hash",
+    "entry_hash",
+    "metadata"
+  ],
+  "properties": {
+    "schema": {
+      "type": "string",
+      "enum": ["opentrustgraph/v0.1", "opentrustgraph/v0"],
+      "description": "Schema discriminator. v0 is accepted for one patch release window after the v0.1 bump."
+    },
+    "record_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Globally unique record id. UUIDv7 is recommended."
+    },
+    "agent": {
+      "type": "string",
+      "minLength": 1
+    },
+    "action": {
+      "type": "string",
+      "minLength": 1
+    },
+    "approver": {
+      "type": ["string", "null"],
+      "minLength": 1,
+      "description": "Actor that satisfied the approval gate, or null when no approval gate applied."
+    },
+    "outcome": {
+      "type": "string",
+      "enum": ["success", "failure", "denied", "timeout"]
+    },
+    "trace_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "autonomy_tier": {
+      "type": "string",
+      "enum": ["shadow", "suggest", "act_with_approval", "act_auto"]
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "cost_usd": {
+      "type": ["number", "null"],
+      "minimum": 0
+    },
+    "chain_index": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "previous_hash": {
+      "type": ["string", "null"],
+      "pattern": "^(sha256:[0-9a-f]{64})$"
+    },
+    "entry_hash": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "metadata": {
+      "type": "object",
+      "description": "Runtime-specific detail bag. Consumers must preserve unknown keys. v0.1 reserves the three keys below; older consumers MAY ignore them.",
+      "properties": {
+        "effects_grant": {
+          "type": "array",
+          "description": "Typed effect set the parent extended to this record. Empty/absent means no grant tracking. Items follow the EffectRecord shape (kind, scope, optional resource).",
+          "items": { "$ref": "#/$defs/effectRecord" }
+        },
+        "effects_used": {
+          "type": "array",
+          "description": "Typed effect set the action actually exercised. Verifiers MUST check `effects_used` is a subset of `effects_grant` from the parent record referenced via `parent_record_id`.",
+          "items": { "$ref": "#/$defs/effectRecord" }
+        },
+        "parent_record_id": {
+          "type": ["string", "null"],
+          "minLength": 1,
+          "description": "Pointer at the parent record's `record_id`. null/absent for root records."
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "outcome": { "const": "success" },
+          "autonomy_tier": { "const": "act_with_approval" },
+          "metadata": {
+            "type": "object",
+            "properties": {
+              "approval": {
+                "type": "object",
+                "properties": { "required": { "const": true } },
+                "required": ["required"]
+              }
+            },
+            "required": ["approval"]
+          }
+        },
+        "required": ["outcome", "autonomy_tier", "metadata"]
+      },
+      "then": {
+        "properties": {
+          "approver": { "type": "string", "minLength": 1 },
+          "metadata": {
+            "type": "object",
+            "properties": { "approval": { "$ref": "#/$defs/approvalReceipt" } },
+            "required": ["approval"]
+          }
+        },
+        "required": ["approver"]
+      }
+    }
+  ],
+  "$defs": {
+    "approvalReceipt": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["required", "quorum", "signatures"],
+      "properties": {
+        "required": { "const": true },
+        "quorum": { "type": "integer", "minimum": 1 },
+        "signatures": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": true,
+            "required": ["reviewer", "signed_at", "signature"],
+            "properties": {
+              "reviewer": { "type": "string", "minLength": 1 },
+              "signed_at": { "type": "string", "format": "date-time" },
+              "signature": { "type": "string", "minLength": 1 }
+            }
+          }
+        }
+      }
+    },
+    "effectRecord": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "scope"],
+      "properties": {
+        "kind": {
+          "description": "Effect kind discriminator. Mirrors `EffectKind` in crates/harn-vm/src/orchestration/policy/effects.rs.",
+          "oneOf": [
+            {
+              "type": "object",
+              "required": ["kind"],
+              "properties": {
+                "kind": {
+                  "type": "string",
+                  "enum": ["stdio", "fs", "net", "spawn"]
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": ["kind"],
+              "properties": {
+                "kind": { "const": "llm" },
+                "provider": { "type": "string", "minLength": 1 },
+                "model": { "type": "string", "minLength": 1 }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": ["kind", "name"],
+              "properties": {
+                "kind": { "type": "string", "enum": ["tool", "hostcall"] },
+                "name": { "type": "string", "minLength": 1 }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": ["kind", "id"],
+              "properties": {
+                "kind": { "const": "persona" },
+                "id": { "type": "string", "minLength": 1 }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "scope": {
+          "type": "string",
+          "enum": ["read", "write", "mutate", "observe"]
+        },
+        "resource": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Opaque, statically-known target identifier (path, URL, tool id, persona id)."
+        }
+      }
+    }
+  }
+}

--- a/docs/src/portal.md
+++ b/docs/src/portal.md
@@ -119,7 +119,7 @@ client, or host integration. If Harn persisted the run, the portal can inspect
 it.
 
 For autonomy supervision, the portal's trust-graph API exposes the same
-`opentrustgraph/v0` records documented in
+`opentrustgraph/v0.1` records documented in
 [`opentrustgraph-spec/`](../../opentrustgraph-spec/). Harn Cloud receipt views
 and Burin supervision surfaces can use that artifact as the stable public
 format reference while projecting portal verification metadata into

--- a/docs/src/spec/open-trust-graph/v0.md
+++ b/docs/src/spec/open-trust-graph/v0.md
@@ -19,11 +19,16 @@ The full normative content lives in three places, each linked below:
 
 ## At a glance
 
-- **Record schema:** `opentrustgraph/v0`. One record per autonomy or
+- **Record schema:** `opentrustgraph/v0.1`. One record per autonomy or
   control-plane decision. Records carry `agent`, `action`, `approver`,
   `outcome`, `trace_id`, `autonomy_tier`, `timestamp`, `cost_usd`,
   `chain_index`, `previous_hash`, `entry_hash`, and an extensible
-  `metadata` bag.
+  `metadata` bag. `v0.1` reserves three keys at the metadata layer —
+  `effects_grant`, `effects_used`, and `parent_record_id` — so chain
+  validators can prove that a child agent's `effects_used` stayed inside
+  the parent's `effects_grant`. `opentrustgraph/v0` records still validate
+  for one patch release window per
+  [`opentrustgraph-spec/CONFORMANCE.md` §5](https://github.com/burin-labs/harn/blob/main/opentrustgraph-spec/CONFORMANCE.md#5-versioning).
 - **Chain export:** `opentrustgraph-chain/v0`. Wraps an ordered record
   list with `chain.topic`, `chain.total`, `chain.root_hash`,
   `chain.verified`, `chain.generated_at`, and `chain.producer`.

--- a/docs/src/trust-graph.md
+++ b/docs/src/trust-graph.md
@@ -13,7 +13,8 @@ explicit promotion and demotion events recorded by `harn trust promote` and
 
 Each record carries:
 
-- `schema` (`"opentrustgraph/v0"`)
+- `schema` (`"opentrustgraph/v0.1"`; v0 records still parse for one patch
+  release window — see [OpenTrustGraph CONFORMANCE.md §5][otg-versioning])
 - `record_id`
 - `agent`
 - `action`
@@ -26,7 +27,11 @@ Each record carries:
 - `chain_index`
 - `previous_hash`
 - `entry_hash`
-- `metadata`
+- `metadata` (v0.1 reserves `effects_grant`, `effects_used`, and
+  `parent_record_id` so chain validators can prove that a child agent's
+  `effects_used ⊆ parent.effects_grant`)
+
+[otg-versioning]: https://github.com/burin-labs/harn/blob/main/opentrustgraph-spec/CONFORMANCE.md#5-versioning
 
 The `trust_graph.records` projection carries the runtime query shape:
 

--- a/opentrustgraph-spec/CONFORMANCE.md
+++ b/opentrustgraph-spec/CONFORMANCE.md
@@ -1,12 +1,16 @@
-# OpenTrustGraph v0 conformance
+# OpenTrustGraph v0.1 conformance
 
 This document defines what a runtime, consumer, or verifier must do to be
-"OpenTrustGraph v0 conformant". The wording follows RFC 2119: MUST, MUST
+"OpenTrustGraph v0.1 conformant". The wording follows RFC 2119: MUST, MUST
 NOT, SHOULD, MAY.
 
 The normative artifacts are:
 
-- `schemas/trust-record.v0.schema.json` — JSON Schema for a single record.
+- `schemas/trust-record.v0.1.schema.json` — JSON Schema for a single
+  record at the current `v0.1` version. Accepts both `opentrustgraph/v0.1`
+  and `opentrustgraph/v0` discriminators during the back-compat window.
+- `schemas/trust-record.v0.schema.json` — JSON Schema for legacy `v0`
+  records. Retained for the back-compat window described in §5.
 - `schemas/trust-chain.v0.schema.json` — JSON Schema for a chain export.
 - `schemas/trust-record.v0.proto` — Protocol Buffers wire format mirror.
 - `fixtures/valid/*.json` — chains that MUST validate.
@@ -118,9 +122,47 @@ mentions either `previous_hash mismatch`, `entry_hash mismatch`, or
 ## 5. Versioning
 
 - The schema version moves with the on-disk shape. Adding a new optional
-  property is backwards compatible and remains v0.
+  property at the top level is backwards compatible. Reserving new
+  metadata keys (as `v0.1` does for `effects_grant`, `effects_used`, and
+  `parent_record_id`) is also additive and gets a minor bump.
+- A minor bump (`v0.1`) MUST stay record-shape compatible with the prior
+  minor version. Consumers MUST continue to accept the prior minor
+  version's discriminator for one patch release window after the bump
+  ships; producers MAY emit either discriminator during that window.
+  After the window, the prior discriminator MAY be rejected. The Harn
+  reference impl tracks the accepted discriminator set in
+  `OPENTRUSTGRAPH_ACCEPTED_SCHEMAS`.
 - Removing a property, renaming an enum, or changing the hash contract
   is a breaking change and MUST bump to `opentrustgraph/v1` (and
   `opentrustgraph-chain/v1` for the envelope).
 - Multiple major versions MAY coexist on the same stream; consumers
   dispatch on the `schema` discriminator.
+
+### 5.1 v0.1 reserved metadata keys (#1778)
+
+`v0.1` adds three reserved keys under `TrustRecord.metadata`. Producers
+MAY omit them; consumers MUST preserve them when re-emitting records.
+
+| Key                 | Type                          | Meaning                                                                              |
+| ------------------- | ----------------------------- | ------------------------------------------------------------------------------------ |
+| `effects_grant`     | array of `EffectRecord`       | Typed effect set the parent extended to this record at spawn time.                   |
+| `effects_used`      | array of `EffectRecord`       | Typed effect set the action actually exercised.                                      |
+| `parent_record_id`  | string (UUID) or null/absent  | Pointer at the parent record's `record_id`. `null`/absent for root records.          |
+
+`EffectRecord` follows the shape defined in
+`schemas/trust-record.v0.1.schema.json#/$defs/effectRecord`, which mirrors
+the `EffectRecord` type used by the Harn dispatcher (E5.4) for capability
+enforcement.
+
+A v0.1-conformant chain verifier MUST, in addition to §2.3, check that
+for every record `r` carrying `effects_used` and a `parent_record_id`
+referencing `p`:
+
+```text
+r.effects_used ⊆ p.effects_grant
+```
+
+Verifiers report failures with an error message containing the substring
+`effects_used escaped grant` so operators can triage them quickly. The
+subset check uses structural equality of the canonical `EffectRecord`
+shape (`kind`, `scope`, `resource`).

--- a/opentrustgraph-spec/README.md
+++ b/opentrustgraph-spec/README.md
@@ -16,14 +16,29 @@ inventing another envelope.
 
 ## Version markers
 
-- Trust record: `opentrustgraph/v0`
-- Chain export: `opentrustgraph-chain/v0`
+- Trust record: `opentrustgraph/v0.1` (current). `opentrustgraph/v0`
+  records still validate for one patch release window per
+  [`CONFORMANCE.md` §5](./CONFORMANCE.md#5-versioning).
+- Chain export: `opentrustgraph-chain/v0` (unchanged in v0.1 — the bump
+  is additive at the record metadata layer).
+
+`v0.1` reserves three additional keys under `TrustRecord.metadata`:
+`effects_grant` (typed effect list the parent extended to this record),
+`effects_used` (typed effect list the action actually exercised), and
+`parent_record_id` (pointer to the parent record's `record_id`).
+Verifiers MUST check that a child's `effects_used` is a subset of the
+parent's `effects_grant`.
 
 ## Contents
 
 - `CONFORMANCE.md`: RFC 2119 conformance requirements for producers,
   consumers, and verifiers.
-- `schemas/trust-record.v0.schema.json`: JSON Schema for one v0 trust record.
+- `schemas/trust-record.v0.1.schema.json`: JSON Schema for the current
+  v0.1 trust record. Accepts both `opentrustgraph/v0.1` and
+  `opentrustgraph/v0` discriminators.
+- `schemas/trust-record.v0.schema.json`: JSON Schema for the legacy
+  v0 trust record; retained for the back-compat window so consumers can
+  validate older records directly.
 - `schemas/trust-chain.v0.schema.json`: JSON Schema for a v0 chain export with
   chain metadata and ordered records.
 - `schemas/trust-record.v0.proto`: Protocol Buffers wire-format mirror for
@@ -34,6 +49,10 @@ inventing another envelope.
   transition and approval-backed action.
 - `fixtures/invalid/tampered-chain.json`: a chain with a self-consistent record
   hash but invalid previous-hash linkage.
+- `fixtures/valid/effect-inheritance-chain.json`: a v0.1 three-agent chain
+  (parent → child → grandchild) that demonstrates the effect-inheritance
+  invariant `effects_used ⊆ child.effects_grant ⊆ parent.effects_grant`,
+  plus `parent_record_id` linkage.
 - `fixtures/invalid/missing-approval.json`: a record that declares approval was
   required but omits the approver/signature evidence.
 - `examples/python/verify_chain.py`: reference, stdlib-only verifier in pure

--- a/opentrustgraph-spec/examples/python/verify_chain.py
+++ b/opentrustgraph-spec/examples/python/verify_chain.py
@@ -26,7 +26,11 @@ import sys
 from typing import Any, Iterator, List
 
 CHAIN_SCHEMA = "opentrustgraph-chain/v0"
-RECORD_SCHEMA = "opentrustgraph/v0"
+# v0.1 is the current record discriminator. v0 is accepted for one patch
+# release window (see CONFORMANCE.md §5).
+RECORD_SCHEMA_V0_1 = "opentrustgraph/v0.1"
+RECORD_SCHEMA_V0 = "opentrustgraph/v0"
+RECORD_SCHEMAS = {RECORD_SCHEMA_V0_1, RECORD_SCHEMA_V0}
 
 
 def _canonicalize(value: Any) -> Any:
@@ -74,10 +78,14 @@ def verify_chain(envelope: dict[str, Any]) -> List[str]:
             f"chain.total mismatch: declared {declared_total!r}, found {len(records)}"
         )
 
+    # `by_id` lets us check v0.1 effect-inheritance invariants for
+    # records that carry `parent_record_id`. Older v0 chains skip this
+    # block because no record carries the new metadata key.
+    by_id: dict[str, dict[str, Any]] = {}
     previous_hash: str | None = None
     for index, record in enumerate(records):
         label = f"record {index}"
-        if record.get("schema") != RECORD_SCHEMA:
+        if record.get("schema") not in RECORD_SCHEMAS:
             errors.append(f"{label}: unsupported record schema {record.get('schema')!r}")
         expected_index = index + 1
         if record.get("chain_index") != expected_index:
@@ -107,6 +115,35 @@ def verify_chain(envelope: dict[str, Any]) -> List[str]:
                 errors.append(f"{label}: approval required but approver is empty")
             if not signatures:
                 errors.append(f"{label}: approval required but signatures are empty")
+
+        # v0.1: when a record claims `effects_used` and points at a
+        # parent record via `parent_record_id`, the used set MUST be a
+        # subset of the parent's `effects_grant`. See CONFORMANCE.md §5.1.
+        metadata = record.get("metadata") or {}
+        parent_id = metadata.get("parent_record_id")
+        effects_used = metadata.get("effects_used") or []
+        if parent_id and effects_used:
+            parent_record = by_id.get(parent_id)
+            if parent_record is None:
+                errors.append(
+                    f"{label}: parent_record_id {parent_id!r} not found in chain"
+                )
+            else:
+                parent_grant = (parent_record.get("metadata") or {}).get(
+                    "effects_grant"
+                ) or []
+                canonical_parent_grant = [_canonicalize(e) for e in parent_grant]
+                for effect in effects_used:
+                    if _canonicalize(effect) not in canonical_parent_grant:
+                        errors.append(
+                            f"{label}: effects_used escaped grant from parent "
+                            f"{parent_id!r}: {effect!r}"
+                        )
+
+        record_id = record.get("record_id")
+        if isinstance(record_id, str) and record_id:
+            by_id[record_id] = record
+
         previous_hash = record.get("entry_hash")
 
     declared_root = chain.get("root_hash")

--- a/opentrustgraph-spec/fixtures/valid/effect-inheritance-chain.json
+++ b/opentrustgraph-spec/fixtures/valid/effect-inheritance-chain.json
@@ -1,0 +1,117 @@
+{
+  "chain": {
+    "generated_at": "2026-04-19T20:33:00Z",
+    "producer": {
+      "name": "harn",
+      "version": "0.8.x"
+    },
+    "root_hash": "sha256:783dd6eb93fc13f2d42773f11693543a7f7cb2c28cef980b409c9f69830e5272",
+    "topic": "trust_graph",
+    "total": 3,
+    "verified": true
+  },
+  "records": [
+    {
+      "action": "agent.spawn",
+      "agent": "parent-orchestrator",
+      "approver": null,
+      "autonomy_tier": "act_auto",
+      "chain_index": 1,
+      "cost_usd": null,
+      "entry_hash": "sha256:0345151a3326dac3e5126efe1d903a09be8105609c62f2e6ceed3bbf2b65028f",
+      "metadata": {
+        "effects_grant": [
+          {
+            "kind": {
+              "kind": "net"
+            },
+            "resource": "https://api.example",
+            "scope": "write"
+          },
+          {
+            "kind": {
+              "kind": "fs"
+            },
+            "resource": "/workspace/src",
+            "scope": "read"
+          },
+          {
+            "kind": {
+              "kind": "fs"
+            },
+            "resource": "/workspace/tmp",
+            "scope": "write"
+          }
+        ]
+      },
+      "outcome": "success",
+      "previous_hash": null,
+      "record_id": "01966f4c-3000-7001-a000-000000000001",
+      "schema": "opentrustgraph/v0.1",
+      "timestamp": "2026-04-19T20:30:00Z",
+      "trace_id": "trace_effect_root"
+    },
+    {
+      "action": "agent.spawn",
+      "agent": "child-spawner",
+      "approver": null,
+      "autonomy_tier": "act_auto",
+      "chain_index": 2,
+      "cost_usd": null,
+      "entry_hash": "sha256:f26018404c747e059fae75d71a4c2ecf46673f14f63ee89e12f89295bb94c281",
+      "metadata": {
+        "effects_grant": [
+          {
+            "kind": {
+              "kind": "net"
+            },
+            "resource": "https://api.example",
+            "scope": "write"
+          },
+          {
+            "kind": {
+              "kind": "fs"
+            },
+            "resource": "/workspace/src",
+            "scope": "read"
+          }
+        ],
+        "parent_record_id": "01966f4c-3000-7001-a000-000000000001"
+      },
+      "outcome": "success",
+      "previous_hash": "sha256:0345151a3326dac3e5126efe1d903a09be8105609c62f2e6ceed3bbf2b65028f",
+      "record_id": "01966f4c-3001-7002-a000-000000000002",
+      "schema": "opentrustgraph/v0.1",
+      "timestamp": "2026-04-19T20:31:00Z",
+      "trace_id": "trace_effect_child"
+    },
+    {
+      "action": "fs.read",
+      "agent": "grandchild-worker",
+      "approver": null,
+      "autonomy_tier": "act_auto",
+      "chain_index": 3,
+      "cost_usd": 0.001,
+      "entry_hash": "sha256:783dd6eb93fc13f2d42773f11693543a7f7cb2c28cef980b409c9f69830e5272",
+      "metadata": {
+        "effects_used": [
+          {
+            "kind": {
+              "kind": "fs"
+            },
+            "resource": "/workspace/src",
+            "scope": "read"
+          }
+        ],
+        "parent_record_id": "01966f4c-3001-7002-a000-000000000002"
+      },
+      "outcome": "success",
+      "previous_hash": "sha256:f26018404c747e059fae75d71a4c2ecf46673f14f63ee89e12f89295bb94c281",
+      "record_id": "01966f4c-3002-7003-a000-000000000003",
+      "schema": "opentrustgraph/v0.1",
+      "timestamp": "2026-04-19T20:32:00Z",
+      "trace_id": "trace_effect_grandchild"
+    }
+  ],
+  "schema": "opentrustgraph-chain/v0"
+}

--- a/opentrustgraph-spec/schemas/trust-record.v0.1.schema.json
+++ b/opentrustgraph-spec/schemas/trust-record.v0.1.schema.json
@@ -1,0 +1,218 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/opentrustgraph/v0.1/trust-record.schema.json",
+  "title": "OpenTrustGraph TrustRecord v0.1",
+  "description": "One autonomy, approval, or control-plane event in an append-only OpenTrustGraph chain. v0.1 reserves three additional `metadata` keys (`effects_grant`, `effects_used`, `parent_record_id`) so chain validators can prove that a child agent's `effects_used ⊆ parent.effects_grant`. v0 records still validate against this schema for one patch release window (see CONFORMANCE.md §5).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "record_id",
+    "agent",
+    "action",
+    "outcome",
+    "trace_id",
+    "autonomy_tier",
+    "timestamp",
+    "chain_index",
+    "previous_hash",
+    "entry_hash",
+    "metadata"
+  ],
+  "properties": {
+    "schema": {
+      "type": "string",
+      "enum": ["opentrustgraph/v0.1", "opentrustgraph/v0"],
+      "description": "Schema discriminator. v0 is accepted for one patch release window after the v0.1 bump."
+    },
+    "record_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Globally unique record id. UUIDv7 is recommended."
+    },
+    "agent": {
+      "type": "string",
+      "minLength": 1
+    },
+    "action": {
+      "type": "string",
+      "minLength": 1
+    },
+    "approver": {
+      "type": ["string", "null"],
+      "minLength": 1,
+      "description": "Actor that satisfied the approval gate, or null when no approval gate applied."
+    },
+    "outcome": {
+      "type": "string",
+      "enum": ["success", "failure", "denied", "timeout"]
+    },
+    "trace_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "autonomy_tier": {
+      "type": "string",
+      "enum": ["shadow", "suggest", "act_with_approval", "act_auto"]
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "cost_usd": {
+      "type": ["number", "null"],
+      "minimum": 0
+    },
+    "chain_index": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "previous_hash": {
+      "type": ["string", "null"],
+      "pattern": "^(sha256:[0-9a-f]{64})$"
+    },
+    "entry_hash": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "metadata": {
+      "type": "object",
+      "description": "Runtime-specific detail bag. Consumers must preserve unknown keys. v0.1 reserves the three keys below; older consumers MAY ignore them.",
+      "properties": {
+        "effects_grant": {
+          "type": "array",
+          "description": "Typed effect set the parent extended to this record. Empty/absent means no grant tracking. Items follow the EffectRecord shape (kind, scope, optional resource).",
+          "items": { "$ref": "#/$defs/effectRecord" }
+        },
+        "effects_used": {
+          "type": "array",
+          "description": "Typed effect set the action actually exercised. Verifiers MUST check `effects_used` is a subset of `effects_grant` from the parent record referenced via `parent_record_id`.",
+          "items": { "$ref": "#/$defs/effectRecord" }
+        },
+        "parent_record_id": {
+          "type": ["string", "null"],
+          "minLength": 1,
+          "description": "Pointer at the parent record's `record_id`. null/absent for root records."
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "outcome": { "const": "success" },
+          "autonomy_tier": { "const": "act_with_approval" },
+          "metadata": {
+            "type": "object",
+            "properties": {
+              "approval": {
+                "type": "object",
+                "properties": { "required": { "const": true } },
+                "required": ["required"]
+              }
+            },
+            "required": ["approval"]
+          }
+        },
+        "required": ["outcome", "autonomy_tier", "metadata"]
+      },
+      "then": {
+        "properties": {
+          "approver": { "type": "string", "minLength": 1 },
+          "metadata": {
+            "type": "object",
+            "properties": { "approval": { "$ref": "#/$defs/approvalReceipt" } },
+            "required": ["approval"]
+          }
+        },
+        "required": ["approver"]
+      }
+    }
+  ],
+  "$defs": {
+    "approvalReceipt": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["required", "quorum", "signatures"],
+      "properties": {
+        "required": { "const": true },
+        "quorum": { "type": "integer", "minimum": 1 },
+        "signatures": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": true,
+            "required": ["reviewer", "signed_at", "signature"],
+            "properties": {
+              "reviewer": { "type": "string", "minLength": 1 },
+              "signed_at": { "type": "string", "format": "date-time" },
+              "signature": { "type": "string", "minLength": 1 }
+            }
+          }
+        }
+      }
+    },
+    "effectRecord": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "scope"],
+      "properties": {
+        "kind": {
+          "description": "Effect kind discriminator. Mirrors `EffectKind` in crates/harn-vm/src/orchestration/policy/effects.rs.",
+          "oneOf": [
+            {
+              "type": "object",
+              "required": ["kind"],
+              "properties": {
+                "kind": {
+                  "type": "string",
+                  "enum": ["stdio", "fs", "net", "spawn"]
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": ["kind"],
+              "properties": {
+                "kind": { "const": "llm" },
+                "provider": { "type": "string", "minLength": 1 },
+                "model": { "type": "string", "minLength": 1 }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": ["kind", "name"],
+              "properties": {
+                "kind": { "type": "string", "enum": ["tool", "hostcall"] },
+                "name": { "type": "string", "minLength": 1 }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": ["kind", "id"],
+              "properties": {
+                "kind": { "const": "persona" },
+                "id": { "type": "string", "minLength": 1 }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "scope": {
+          "type": "string",
+          "enum": ["read", "write", "mutate", "observe"]
+        },
+        "resource": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Opaque, statically-known target identifier (path, URL, tool id, persona id)."
+        }
+      }
+    }
+  }
+}

--- a/spec/opentrustgraph.md
+++ b/spec/opentrustgraph.md
@@ -1,4 +1,4 @@
-# OpenTrustGraph v0
+# OpenTrustGraph v0.1
 
 `OpenTrustGraph` is a portable event schema for recording autonomy and approval
 decisions around agent dispatch. Harn emits these records onto `trust_graph`
@@ -12,12 +12,22 @@ workflow engines can adopt the same stream shape.
 Version markers:
 
 ```json
-{"schema":"opentrustgraph/v0"}
+{"schema":"opentrustgraph/v0.1"}
 ```
 
 ```json
 {"schema":"opentrustgraph-chain/v0"}
 ```
+
+`v0.1` is an additive bump over `v0`. It reserves three new keys under
+`TrustRecord.metadata` — `effects_grant`, `effects_used`, and
+`parent_record_id` — so chain validators can prove that a child agent's
+`effects_used ⊆ parent.effects_grant`. The chain hash inputs are
+unchanged because metadata was already hash-covered. `v0` records still
+parse for one patch release window per
+[`opentrustgraph-spec/CONFORMANCE.md` §5](../opentrustgraph-spec/CONFORMANCE.md#5-versioning),
+then are dropped. The chain export envelope (`opentrustgraph-chain/v0`)
+is unchanged.
 
 ## TrustRecord
 
@@ -47,7 +57,10 @@ Each dispatch or control-plane autonomy change appends one `TrustRecord`.
 
 Fields:
 
-- `schema`: schema/version discriminator. Current value: `opentrustgraph/v0`.
+- `schema`: schema/version discriminator. Current value:
+  `opentrustgraph/v0.1`. Older `opentrustgraph/v0` records still validate
+  for one patch release window per
+  [`opentrustgraph-spec/CONFORMANCE.md` §5](../opentrustgraph-spec/CONFORMANCE.md#5-versioning).
 - `record_id`: globally unique record identifier. UUIDv7 is recommended.
 - `agent`: logical agent identifier, handler id, or runtime-owned agent name.
 - `action`: action class being evaluated, such as `issue.label`,
@@ -62,7 +75,18 @@ Fields:
 - `previous_hash`: prior record's `entry_hash`, or `null` for the first record.
 - `entry_hash`: SHA-256 hash over the canonical record with `entry_hash`
   removed. Harn stores it with the `sha256:` prefix.
-- `metadata`: extensible runtime-specific detail bag.
+- `metadata`: extensible runtime-specific detail bag. `v0.1` reserves
+  three keys at this layer:
+  - `effects_grant`: typed `EffectRecord` list (`kind`, `scope`, optional
+    `resource`) the parent extended to this record.
+  - `effects_used`: typed `EffectRecord` list the action actually
+    exercised. Verifiers MUST check `effects_used ⊆ effects_grant` (taken
+    from the parent record referenced via `parent_record_id`).
+  - `parent_record_id`: pointer at the parent record's `record_id`
+    (`null`/absent for root records). The release-record flow keeps the
+    separate `parent_trust_record_id` key for the
+    [`harn release`](release.md) lineage; `parent_record_id` is the
+    generic spawn-lineage pointer.
 
 Outcome enum:
 
@@ -130,7 +154,12 @@ Fields:
 JSON is canonical. The normative wire-format files live in the public
 artifact directory:
 
+- [`opentrustgraph-spec/schemas/trust-record.v0.1.schema.json`](../opentrustgraph-spec/schemas/trust-record.v0.1.schema.json)
+  — current record schema (`v0.1`). Accepts both `opentrustgraph/v0.1`
+  and `opentrustgraph/v0` discriminators for one patch release window.
 - [`opentrustgraph-spec/schemas/trust-record.v0.schema.json`](../opentrustgraph-spec/schemas/trust-record.v0.schema.json)
+  — previous record schema (`v0`); retained for one patch release
+  window so consumers can validate legacy records.
 - [`opentrustgraph-spec/schemas/trust-chain.v0.schema.json`](../opentrustgraph-spec/schemas/trust-chain.v0.schema.json)
 - [`opentrustgraph-spec/schemas/trust-record.v0.proto`](../opentrustgraph-spec/schemas/trust-record.v0.proto)
   — Protocol Buffers mirror for runtimes that prefer a binary stream


### PR DESCRIPTION
## Summary

- Bumps the trust-record discriminator from `opentrustgraph/v0` to `opentrustgraph/v0.1` and reserves three additional `metadata` keys — `effects_grant`, `effects_used`, and `parent_record_id` — so chain validators can prove that a child agent's `effects_used` stayed inside the parent's `effects_grant`. Closes the E5.5 receipt-chain inclusion proof under epic #1773.
- Additive at the metadata layer only: the chain-export envelope (`opentrustgraph-chain/v0`) and the SHA-256 hash contract are unchanged because metadata was already hash-covered. `TrustRecord` deserialization still accepts the legacy `opentrustgraph/v0` discriminator for one patch release window per the new `opentrustgraph-spec/CONFORMANCE.md` §5.1; both versions are tracked in `OPENTRUSTGRAPH_ACCEPTED_SCHEMAS`.
- Ships the new v0.1 JSON Schema (`opentrustgraph-spec/schemas/trust-record.v0.1.schema.json`), a 3-agent `effect-inheritance-chain.json` fixture, new `TrustRecord` helpers (`with_effects_grant`, `with_effects_used`, `with_parent_record_id`, plus getters/setters), and extends the pure-Python reference verifier to enforce the subset check.

## Cuts

- harn-cloud receipt-store replatform stays a paired ticket under #1773. The validator here accepts both versions during the back-compat window so the cloud side can land independently.
- Verifier reports a single subset failure per record rather than diffing every effect — the canonical structural comparison is enough for triage and keeps the verifier readable.

## Test plan

- [x] `cargo fmt --all` + `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `make fmt-harn` + `make lint-harn` + `make lint-test-patterns`
- [x] `make gen-protocol-artifacts` + `make check-protocol-artifacts` (no manifest delta — OpenTrustGraph is not in the protocol-artifacts manifest)
- [x] `make check-bindings` (Python + Go round-trip OK)
- [x] `cargo run --bin harn -- test conformance --filter trust_graph_schema` (3 new tests, all pass)
- [x] `cargo run --bin harn -- test conformance --filter trust` (11/11)
- [x] `make conformance` (1341/1341)
- [x] `make test` (4521 passed, 2 skipped)
- [x] `make check-docs-snippets`
- [x] `python3 opentrustgraph-spec/examples/python/verify_chain.py` against every fixture (valid: verified; invalid: rejected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)