### PR TITLE
Teach lint-diagnostic-codes about Met/Cst categories

### DIFF
--- a/crates/harn-parser/src/typechecker/inference/statements.rs
+++ b/crates/harn-parser/src/typechecker/inference/statements.rs
@@ -615,16 +615,27 @@ impl TypeChecker {
                     }
                     Err(err) => {
                         use crate::const_eval::ConstEvalErrorKind as K;
-                        let code = match err.kind {
-                            K::Disallowed => Code::ConstEvalDisallowedExpression,
-                            K::StepLimit => Code::ConstEvalStepLimit,
-                            K::RecursionLimit => Code::ConstEvalRecursionLimit,
-                            K::SandboxViolation => Code::ConstEvalSandboxViolation,
-                            K::RuntimeError => Code::ConstEvalRuntimeError,
-                        };
                         let message =
                             format!("const `{name}` initializer rejected: {}", err.detail);
-                        self.error_at(code, message, err.span);
+                        match err.kind {
+                            K::Disallowed => self.error_at(
+                                Code::ConstEvalDisallowedExpression,
+                                message,
+                                err.span,
+                            ),
+                            K::StepLimit => {
+                                self.error_at(Code::ConstEvalStepLimit, message, err.span)
+                            }
+                            K::RecursionLimit => {
+                                self.error_at(Code::ConstEvalRecursionLimit, message, err.span)
+                            }
+                            K::SandboxViolation => {
+                                self.error_at(Code::ConstEvalSandboxViolation, message, err.span)
+                            }
+                            K::RuntimeError => {
+                                self.error_at(Code::ConstEvalRuntimeError, message, err.span)
+                            }
+                        }
                     }
                 }
             }

--- a/scripts/check_diagnostic_codes.py
+++ b/scripts/check_diagnostic_codes.py
@@ -28,6 +28,8 @@ CATEGORIES = {
     "Rcv",
     "Mat",
     "Pol",
+    "Met",
+    "Cst",
 }
 HELPERS = [
     "error_at_with_help",
@@ -118,6 +120,8 @@ def category_code(category: str) -> str:
         "Rcv": "RCV",
         "Mat": "MAT",
         "Pol": "POL",
+        "Met": "MET",
+        "Cst": "CST",
     }[category]
 
 


### PR DESCRIPTION
## Summary

T7 (#1791) added two new diagnostic categories (`Met` for `ConstEvalDisallowedExpression`, `Cst` for the four ConstEval* runtime variants) but the static lint at \`scripts/check_diagnostic_codes.py\` only knew about the original 18. Result: \`lint-diagnostic-codes\` has been red on every CI run since #2040 landed.

## Changes

1. Add \`Met\` and \`Cst\` to the \`CATEGORIES\` set + the \`category_code\` map in the lint script.
2. Refactor the const-eval error-emission path in \`crates/harn-parser/src/typechecker/inference/statements.rs\` so each match branch passes a literal \`Code::*\` to \`self.error_at\` instead of binding it to a variable. The lint forbids variable indirection because it bypasses the literal-check that ties every error site to a registered diagnostic code.

## Test plan

- [x] \`make lint-diagnostic-codes\` clean (was 5 errors)
- [x] \`cargo check --package harn-parser\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)