### PR TITLE
Fix mock arch leak in harness.system.platform()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -486,6 +486,19 @@ condensed series summaries instead of full per-patch history.
   HARN-DRN-001 contract (xfail threshold drops from 1 to 0). Part of
   epic #1853 (declarative agent lifecycle).
 
+### Fixed
+
+- **`harness.system.platform()` mock arch leak.** The mock-mode
+  `platform()` snapshot in `vm/methods/harness.rs` was reading the host
+  CPU architecture via `std::env::consts::ARCH` instead of a fixed
+  placeholder, so the `harness/system_basic` conformance fixture passed
+  on the Apple Silicon dev machines that recorded it (`aarch64`) but
+  failed on the x86_64 Linux CI runners. Mock mode now returns a
+  deterministic `"arch": "mock"` matching the rest of the snapshot
+  (`os`, `kernel`, `hostname`, …), so the fixture is portable across
+  architectures. The real (non-mock) `platform_snapshot()` still
+  returns the live host arch.
+
 ## v0.8.27
 
 ### Added

--- a/conformance/tests/harness/system_basic.harness.json
+++ b/conformance/tests/harness/system_basic.harness.json
@@ -10,7 +10,7 @@
     {"sub_handle": "stdio", "method": "println", "args": ["0"]},
     {"sub_handle": "stdio", "method": "println", "args": ["unknown"]},
     {"sub_handle": "stdio", "method": "println", "args": ["mock"]},
-    {"sub_handle": "stdio", "method": "println", "args": ["aarch64"]}
+    {"sub_handle": "stdio", "method": "println", "args": ["mock"]}
   ],
-  "expect_stdio": "dict\n1\nmock-cpu\n0\nunknown\nmock\naarch64\n"
+  "expect_stdio": "dict\n1\nmock-cpu\n0\nunknown\nmock\nmock\n"
 }

--- a/crates/harn-vm/src/vm/methods/harness.rs
+++ b/crates/harn-vm/src/vm/methods/harness.rs
@@ -380,7 +380,7 @@ impl crate::vm::Vm {
                     "temperature" => serde_json::json!({"components": []}),
                     "platform" => serde_json::json!({
                         "os": "mock",
-                        "arch": std::env::consts::ARCH,
+                        "arch": "mock",
                         "version": "mock",
                         "kernel": "mock",
                         "long_os_version": "mock",


### PR DESCRIPTION
## Summary

- Mock-mode `harness.system.platform()` returned `std::env::consts::ARCH` instead of a deterministic placeholder. The `harness/system_basic` conformance fixture passed on aarch64 dev machines but failed on x86_64 Linux CI runners (and would break any new arch tomorrow).
- Mock mode now returns `"arch": "mock"` like the rest of the snapshot (`os`, `kernel`, `hostname`). Real (non-mock) `platform_snapshot()` still returns the live host arch.
- Unblocks release PR #2034 (currently red on this fixture).

## Test plan

- [x] `cargo run --bin harn -- test conformance --filter system_basic` — passes.
- [x] `make check-docs-snippets` — 0 failed.
- [x] Pre-commit (fmt + clippy + ratchets + markdown lint) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)