### PR TITLE
Trigger drift workflow on merge_group to unblock queue

### DIFF
--- a/.github/workflows/release-pr-drift-check.yml
+++ b/.github/workflows/release-pr-drift-check.yml
@@ -29,6 +29,15 @@ on:
     branches: [main]
     paths:
       - CHANGELOG.md
+  # Required-status-check gating: the org-level `release drift required`
+  # ruleset names `drift` as a required check on the default branch, which
+  # means the merge queue waits for this job to produce a status on every
+  # merge_group ref. Without this trigger the queue stalls indefinitely.
+  # In merge_group context the workflow runs as a no-op pass — the queue's
+  # own auto-rebase already handles CHANGELOG drift for non-release PRs,
+  # and a release PR in queue has already been drift-checked at PR-event
+  # time.
+  merge_group:
 
 permissions:
   contents: read
@@ -36,7 +45,7 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: release-pr-drift-${{ github.event.pull_request.number || github.sha }}
+  group: release-pr-drift-${{ github.event.pull_request.number || github.event.merge_group.head_sha || github.sha }}
   cancel-in-progress: true
 
 jobs:
@@ -69,6 +78,13 @@ jobs:
               echo '[]' > targets.json
               echo "Head ref '$PR_HEAD_REF' is not a release branch; nothing to check." >> "$GITHUB_STEP_SUMMARY"
             fi
+          elif [ "$EVENT" = "merge_group" ]; then
+            # No-op in queue context. The `drift` status check exists so
+            # the required-status-check ruleset has something to gate on
+            # for every merge_group ref; the actual drift comparison runs
+            # on PR-event and push-to-main events.
+            echo '[]' > targets.json
+            echo "merge_group event — drift check is a no-op pass." >> "$GITHUB_STEP_SUMMARY"
           else
             gh pr list \
               --repo "$GITHUB_REPOSITORY" \


### PR DESCRIPTION
## Summary

The `release drift required` ruleset (id 16571690) requires a `drift` status check on `~DEFAULT_BRANCH`, which the merge queue evaluates on every `merge_group` ref. The drift workflow only triggered on `pull_request` and `push` events, so on `merge_group` no check ever posted — the queue waited indefinitely.

This adds `merge_group:` to the trigger set and an explicit no-op branch in the target-identification step. The actual drift comparison still runs on PR-event and push-to-main events; in queue context the workflow is a fast no-op pass so the required check is satisfied and the queue advances.

Symptom this fixes: 7 PRs are currently stuck in the queue at status `AWAITING_CHECKS`, all underlying CI green, none progressing. Estimated merge times keep extending because the queue can't confirm `drift` ever posted.

## Test plan

- [x] `make lint-actions` clean.
- [ ] After merge: confirm a `merge_group` event triggers this workflow and a `drift` check posts as success on the merge_group ref.
- [ ] Confirm the queue drains the existing backlog after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)