### PR TITLE
Reject harnpack bundles from untrusted signers (#2062)

### DIFF
--- a/conformance/tests/harn_pack/pack_verify_untrusted_signer.expected
+++ b/conformance/tests/harn_pack/pack_verify_untrusted_signer.expected
@@ -1,0 +1,5 @@
+true
+true
+false
+false
+verify.untrusted_signer

--- a/conformance/tests/harn_pack/pack_verify_untrusted_signer.harn
+++ b/conformance/tests/harn_pack/pack_verify_untrusted_signer.harn
@@ -1,0 +1,61 @@
+import "../_common"
+
+pipeline default() {
+  let repo_root = exec("git", "rev-parse", "--show-toplevel").stdout.trim()
+  let harn_bin = env_or("HARN_CONFORMANCE_HARN_BIN", resolve_harn_bin(repo_root))
+  let root = path_join(temp_dir(), "harn_pack_untrusted_signer_" + uuid_v7())
+  mkdir(root)
+  write_file(path_join(root, "hello.harn"), "println(\"signed\")\n")
+  write_file(
+    path_join(root, "release-key.pem"),
+    "-----BEGIN PRIVATE KEY-----\nMC4CAQAwBQYDK2VwBCIEIDmsNDO8iZqiMmA/b7I7lwGXNKe68o+gDno6R5riUcDC\n-----END PRIVATE KEY-----\n",
+  )
+  let pack = exec_at(
+    root,
+    harn_bin,
+    "pack",
+    "hello.harn",
+    "--sign",
+    "--key",
+    path_join(root, "release-key.pem"),
+    "--out",
+    path_join(root, "hello.harnpack"),
+  )
+  println(pack.success)
+  let permissive = exec_at(root, harn_bin, "pack", "verify", path_join(root, "hello.harnpack"), "--json")
+  let permissive_data = json_parse(permissive.stdout)
+  let signer = permissive_data.data.key_id
+  let signers = path_join(root, "signers")
+  mkdir(signers)
+  println(
+    exec_at(
+      root,
+      "openssl",
+      "pkey",
+      "-in",
+      path_join(root, "release-key.pem"),
+      "-pubout",
+      "-out",
+      path_join(signers, signer + ".pub"),
+    ).success,
+  )
+  write_file(
+    path_join(root, "trust-policy.json"),
+    json_stringify({signer_registry_url: signers, trusted_signers: ["not-the-real-signer"]}),
+  )
+  let verify = exec_at(
+    root,
+    harn_bin,
+    "pack",
+    "verify",
+    path_join(root, "hello.harnpack"),
+    "--require-trusted-signer",
+    "--trust-policy",
+    path_join(root, "trust-policy.json"),
+    "--json",
+  )
+  println(verify.success)
+  let verify_data = json_parse(verify.stdout)
+  println(verify_data.ok)
+  println(verify_data.error.code)
+}

--- a/crates/harn-cli/src/cli/pack.rs
+++ b/crates/harn-cli/src/cli/pack.rs
@@ -96,6 +96,18 @@ pub struct PackVerifyArgs {
     #[arg(long, default_value_t = false)]
     pub allow_unsigned: bool,
 
+    /// JSON trust policy describing the signer registry URL and
+    /// optional trusted signer allowlist to enforce during
+    /// verification.
+    #[arg(long, value_name = "PATH")]
+    pub trust_policy: Option<PathBuf>,
+
+    /// Require the bundle signer to resolve from the trusted signer
+    /// registry and, when `--trust-policy` supplies a
+    /// `trusted_signers` allowlist, appear in that allowlist too.
+    #[arg(long, default_value_t = false)]
+    pub require_trusted_signer: bool,
+
     /// Emit a `JsonEnvelope` summary instead of a human-readable
     /// one-liner. Schema: `harn --json-schemas --command "pack verify"`.
     #[arg(long, default_value_t = false)]

--- a/crates/harn-cli/src/cli/tests.rs
+++ b/crates/harn-cli/src/cli/tests.rs
@@ -1765,6 +1765,9 @@ fn test_parses_pack_verify_subcommand() {
         "verify",
         "bundle.harnpack",
         "--allow-unsigned",
+        "--trust-policy",
+        "policy.json",
+        "--require-trusted-signer",
         "--json",
     ]);
     let Command::Pack(args) = cli.command.unwrap() else {
@@ -1775,6 +1778,8 @@ fn test_parses_pack_verify_subcommand() {
     };
     assert_eq!(verify.bundle, PathBuf::from("bundle.harnpack"));
     assert!(verify.allow_unsigned);
+    assert_eq!(verify.trust_policy, Some(PathBuf::from("policy.json")));
+    assert!(verify.require_trusted_signer);
     assert!(verify.json);
 }
 

--- a/crates/harn-cli/src/commands/pack.rs
+++ b/crates/harn-cli/src/commands/pack.rs
@@ -16,6 +16,7 @@ use std::path::{Component, Path, PathBuf};
 use std::process;
 
 use ed25519_dalek::Signer;
+use ed25519_dalek::VerifyingKey;
 use harn_parser::DiagnosticSeverity;
 use harn_vm::bytecode_cache;
 use harn_vm::module_artifact;
@@ -1020,6 +1021,8 @@ pub fn verify_json_schema() -> serde_json::Value {
                     "bundle_hash",
                     "signature_present",
                     "signature_verified",
+                    "recorded_bundle_hash",
+                    "key_id",
                     "schema_version",
                     "entrypoint",
                     "module_count",
@@ -1115,6 +1118,12 @@ pub fn verify(args: &PackVerifyArgs) -> Result<PackVerifyJsonData, PackError> {
         )
     })?;
 
+    let trust_policy = args
+        .trust_policy
+        .as_deref()
+        .map(skill_provenance::load_trust_policy)
+        .transpose()
+        .map_err(|err| PackError::new("verify.trust_policy_failed", err))?;
     let signature_present = manifest.signature.is_some();
     let mut signature_verified = false;
     let mut key_id = None;
@@ -1122,7 +1131,56 @@ pub fn verify(args: &PackVerifyArgs) -> Result<PackVerifyJsonData, PackError> {
         key_id = signature.key_id.clone();
         verify_workflow_bundle_signature(manifest, contents)
             .map_err(|err| PackError::new("verify.signature_failed", err.message.clone()))?;
+        if args.require_trusted_signer {
+            let signer_fingerprint = bundle_signer_fingerprint(signature).map_err(|err| {
+                PackError::new(
+                    "verify.signature_failed",
+                    format!("invalid bundle signer: {err}"),
+                )
+            })?;
+            match skill_provenance::check_trusted_signer(&signer_fingerprint, trust_policy.as_ref())
+                .map_err(|err| PackError::new("verify.trust_policy_failed", err))?
+            {
+                skill_provenance::TrustedSignerStatus::Trusted => {}
+                skill_provenance::TrustedSignerStatus::MissingSigner => {
+                    return Err(PackError::new(
+                        "verify.untrusted_signer",
+                        format!(
+                            "bundle {} was signed by {}, but that signer is not present in the trusted signer registry",
+                            args.bundle.display(),
+                            signer_fingerprint
+                        ),
+                    ));
+                }
+                skill_provenance::TrustedSignerStatus::UntrustedSigner => {
+                    return Err(PackError::new(
+                        "verify.untrusted_signer",
+                        format!(
+                            "bundle {} was signed by {}, which is not in the trust policy's trusted_signers allowlist",
+                            args.bundle.display(),
+                            signer_fingerprint
+                        ),
+                    ));
+                }
+            }
+        }
         signature_verified = true;
+        key_id.get_or_insert(
+            signer_fingerprint_from_public_key(&signature.public_key).map_err(|err| {
+                PackError::new(
+                    "verify.signature_failed",
+                    format!("invalid bundle signer: {err}"),
+                )
+            })?,
+        );
+    } else if args.require_trusted_signer {
+        return Err(PackError::new(
+            "verify.untrusted_signer",
+            format!(
+                "bundle {} is unsigned and cannot satisfy --require-trusted-signer",
+                args.bundle.display()
+            ),
+        ));
     } else if !args.allow_unsigned {
         return Err(PackError::new(
             "verify.unsigned",
@@ -1229,4 +1287,40 @@ pub fn verify(args: &PackVerifyArgs) -> Result<PackVerifyJsonData, PackError> {
         module_count: manifest.transitive_modules.len(),
         content_entry_count: contents.len(),
     })
+}
+
+fn bundle_signer_fingerprint(signature: &Ed25519Signature) -> Result<String, String> {
+    match signature.key_id.as_deref() {
+        Some(key_id) if !key_id.trim().is_empty() => Ok(key_id.to_string()),
+        _ => signer_fingerprint_from_public_key(&signature.public_key),
+    }
+}
+
+fn signer_fingerprint_from_public_key(public_key_hex: &str) -> Result<String, String> {
+    let public_key_bytes = decode_hex_32(public_key_hex)?;
+    let verifying_key = VerifyingKey::from_bytes(&public_key_bytes).map_err(|error| {
+        format!("workflow bundle signature public_key is invalid Ed25519: {error}")
+    })?;
+    Ok(skill_provenance::fingerprint_for_key(&verifying_key))
+}
+
+fn decode_hex_32(raw: &str) -> Result<[u8; 32], String> {
+    let trimmed = raw.trim();
+    if trimmed.len() != 64 {
+        return Err(format!(
+            "workflow bundle signature public_key must be 64 hex characters, found {}",
+            trimmed.len()
+        ));
+    }
+    let mut bytes = [0_u8; 32];
+    for (idx, slot) in bytes.iter_mut().enumerate() {
+        let start = idx * 2;
+        let end = start + 2;
+        *slot = u8::from_str_radix(&trimmed[start..end], 16).map_err(|error| {
+            format!(
+                "workflow bundle signature public_key contains invalid hex at byte {idx}: {error}"
+            )
+        })?;
+    }
+    Ok(bytes)
 }

--- a/crates/harn-cli/src/skill_provenance.rs
+++ b/crates/harn-cli/src/skill_provenance.rs
@@ -47,6 +47,14 @@ pub(crate) struct VerifyOptions {
     pub allowed_endorsers: Vec<String>,
 }
 
+#[derive(Debug, Clone, Default, Deserialize)]
+pub(crate) struct TrustPolicy {
+    #[serde(default, alias = "registry_url")]
+    pub signer_registry_url: Option<String>,
+    #[serde(default)]
+    pub trusted_signers: Vec<String>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum VerificationStatus {
     Verified,
@@ -607,6 +615,36 @@ pub(crate) fn configured_registry_url(anchor: Option<&Path>) -> Option<String> {
         }
     }
     load_skills_config(anchor).and_then(|resolved| resolved.config.signer_registry_url)
+}
+
+pub(crate) fn load_trust_policy(path: &Path) -> Result<TrustPolicy, String> {
+    let raw = fs::read_to_string(path)
+        .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
+    serde_json::from_str(&raw)
+        .map_err(|error| format!("failed to parse trust policy {}: {error}", path.display()))
+}
+
+pub(crate) enum TrustedSignerStatus {
+    Trusted,
+    MissingSigner,
+    UntrustedSigner,
+}
+
+pub(crate) fn check_trusted_signer(
+    fingerprint: &str,
+    policy: Option<&TrustPolicy>,
+) -> Result<TrustedSignerStatus, String> {
+    let registry_url = policy.and_then(|policy| policy.signer_registry_url.as_deref());
+    let Some(_) = resolve_verifying_key(fingerprint, registry_url)? else {
+        return Ok(TrustedSignerStatus::MissingSigner);
+    };
+    if policy.is_some_and(|policy| {
+        !policy.trusted_signers.is_empty()
+            && !policy.trusted_signers.iter().any(|id| id == fingerprint)
+    }) {
+        return Ok(TrustedSignerStatus::UntrustedSigner);
+    }
+    Ok(TrustedSignerStatus::Trusted)
 }
 
 pub(crate) fn signature_path_for(skill_path: &Path) -> PathBuf {

--- a/crates/harn-cli/tests/pack_cli.rs
+++ b/crates/harn-cli/tests/pack_cli.rs
@@ -10,6 +10,8 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use ed25519_dalek::pkcs8::{spki::der::pem::LineEnding, DecodePrivateKey, EncodePublicKey};
+use ed25519_dalek::SigningKey;
 use harn_cli::cli::{PackArgs, PackVerifyArgs};
 use harn_cli::commands::pack;
 use harn_cli::commands::pack::BuildArgs;
@@ -22,6 +24,14 @@ use tempfile::TempDir;
 use tokio::runtime::Builder;
 
 const TEST_ED25519_PRIVATE_KEY: &str = "-----BEGIN PRIVATE KEY-----\nMC4CAQAwBQYDK2VwBCIEIDmsNDO8iZqiMmA/b7I7lwGXNKe68o+gDno6R5riUcDC\n-----END PRIVATE KEY-----\n";
+
+fn test_public_key_pem() -> String {
+    let signing_key = SigningKey::from_pkcs8_pem(TEST_ED25519_PRIVATE_KEY).unwrap();
+    signing_key
+        .verifying_key()
+        .to_public_key_pem(LineEnding::LF)
+        .unwrap()
+}
 
 fn build_args_from_pack(args: &PackArgs) -> BuildArgs {
     BuildArgs {
@@ -445,6 +455,8 @@ fn pack_verify_signed_bundle_passes_and_reports_signature_key() {
     let report = pack::verify(&PackVerifyArgs {
         bundle: out.clone(),
         allow_unsigned: false,
+        trust_policy: None,
+        require_trusted_signer: false,
         json: false,
     })
     .expect("verify ok on signed bundle");
@@ -471,6 +483,8 @@ fn pack_verify_unsigned_bundle_refused_without_flag_but_ok_with_flag() {
     let strict = pack::verify(&PackVerifyArgs {
         bundle: out.clone(),
         allow_unsigned: false,
+        trust_policy: None,
+        require_trusted_signer: false,
         json: false,
     })
     .expect_err("unsigned bundle must refuse without --allow-unsigned");
@@ -479,6 +493,8 @@ fn pack_verify_unsigned_bundle_refused_without_flag_but_ok_with_flag() {
     let lenient = pack::verify(&PackVerifyArgs {
         bundle: out.clone(),
         allow_unsigned: true,
+        trust_policy: None,
+        require_trusted_signer: false,
         json: false,
     })
     .expect("verify ok on unsigned bundle with --allow-unsigned");
@@ -526,6 +542,8 @@ fn pack_verify_tampered_signed_bundle_fails() {
     let err = pack::verify(&PackVerifyArgs {
         bundle: out.clone(),
         allow_unsigned: true,
+        trust_policy: None,
+        require_trusted_signer: false,
         json: false,
     })
     .expect_err("tampered bundle must fail verification");
@@ -547,6 +565,8 @@ fn pack_verify_json_envelope_round_trips_schema() {
     let envelope = pack::verify_to_envelope(&PackVerifyArgs {
         bundle: out.clone(),
         allow_unsigned: true,
+        trust_policy: None,
+        require_trusted_signer: false,
         json: true,
     });
     let value = serde_json::to_value(&envelope).unwrap();
@@ -561,6 +581,63 @@ fn pack_verify_json_envelope_round_trips_schema() {
     assert_eq!(value["data"]["signature_present"], false);
     assert_eq!(value["data"]["signature_verified"], false);
     assert!(value["data"]["module_count"].as_u64().unwrap() >= 1);
+}
+
+#[test]
+fn pack_verify_require_trusted_signer_rejects_signer_outside_policy_allowlist() {
+    let runtime = Builder::new_current_thread().enable_all().build().unwrap();
+    runtime.block_on(async {
+        let _cwd_guard = cwd_lock::lock_cwd_async().await;
+        harn_vm::reset_thread_local_state();
+
+        let workdir = TempDir::new().unwrap();
+        let signers_dir = workdir.path().join("signers");
+        fs::create_dir_all(&signers_dir).unwrap();
+        let entry = workdir.path().join("hello.harn");
+        fs::write(&entry, "println(\"signed\")\n").unwrap();
+        let key = workdir.path().join("release-key.pem");
+        fs::write(&key, TEST_ED25519_PRIVATE_KEY).unwrap();
+        let out = workdir.path().join("hello.harnpack");
+
+        let outcome = pack::build(&BuildArgs {
+            entrypoint: entry.clone(),
+            out: Some(out.clone()),
+            upgrade: None,
+            sign: true,
+            key: Some(key),
+            unsigned: false,
+            exclude_secrets: false,
+            json: false,
+        })
+        .expect("pack succeeds");
+        let signer_fingerprint = outcome.json.signature.key_id.clone().unwrap();
+        fs::write(
+            signers_dir.join(format!("{signer_fingerprint}.pub")),
+            test_public_key_pem(),
+        )
+        .unwrap();
+        let policy = workdir.path().join("trust-policy.json");
+        fs::write(
+            &policy,
+            format!(
+                r#"{{"signer_registry_url":"{}","trusted_signers":["not-the-real-signer"]}}"#,
+                signers_dir.display()
+            ),
+        )
+        .unwrap();
+
+        let err = pack::verify(&PackVerifyArgs {
+            bundle: out,
+            allow_unsigned: false,
+            trust_policy: Some(policy),
+            require_trusted_signer: true,
+            json: false,
+        })
+        .expect_err("unexpected signer must fail the trust policy");
+
+        assert_eq!(err.code, "verify.untrusted_signer");
+        assert!(err.message.contains("trusted_signers allowlist"));
+    });
 }
 
 #[test]

--- a/docs/src/workflow-bundles.md
+++ b/docs/src/workflow-bundles.md
@@ -95,6 +95,19 @@ on any mismatch and emits structured error codes (`verify.signature_failed`,
 By default, unsigned bundles fail verification. Pass `--allow-unsigned` to
 accept a bundle without an Ed25519 signature (useful in local development).
 
+For compliance gates, pass `--require-trusted-signer` to require that the
+bundle signer resolve from the trusted signer registry. Add
+`--trust-policy policy.json` to layer a JSON allowlist on top:
+
+```json
+{
+  "signer_registry_url": "./signers",
+  "trusted_signers": ["<sha256-fingerprint>"]
+}
+```
+
+When that gate fails, the verifier exits with `verify.untrusted_signer`.
+
 `harn pack verify --json` emits a `JsonEnvelope` with the recomputed
 `bundle_hash`, signature presence/verification flags, signing key fingerprint,
 and per-bundle counts (`module_count`, `content_entry_count`). The schema is


### PR DESCRIPTION
## Summary
- add `harn pack verify --trust-policy` and `--require-trusted-signer`
- reuse skill provenance trust policy + signer registry resolution for bundle verification
- add integration, conformance, and docs coverage for `verify.untrusted_signer`

## Testing
- cargo fmt --all
- cargo test -p harn-cli test_parses_pack_verify_subcommand
- target/debug/deps/pack_cli-87d798fd9c3a2e5f
- target/debug/harn test conformance --filter pack_verify_untrusted_signer
- ./.githooks/pre-commit
- git push (pre-push hook passed)

Stacked on top of #2060 while the pack branch is still merging.