### PR TITLE
Add strict SBOM cross-checks to harn pack verify (#2063)

### DIFF
--- a/conformance/tests/harn_pack/pack_verify_strict_sbom_mismatch.expected
+++ b/conformance/tests/harn_pack/pack_verify_strict_sbom_mismatch.expected
@@ -1,0 +1,9 @@
+true
+true
+true
+true
+true
+true
+false
+false
+verify.sbom_mismatch

--- a/conformance/tests/harn_pack/pack_verify_strict_sbom_mismatch.harn
+++ b/conformance/tests/harn_pack/pack_verify_strict_sbom_mismatch.harn
@@ -1,0 +1,63 @@
+import "../_common"
+
+pipeline default() {
+  let repo_root = exec("git", "rev-parse", "--show-toplevel").stdout.trim()
+  let harn_bin = env_or("HARN_CONFORMANCE_HARN_BIN", resolve_harn_bin(repo_root))
+  let root = path_join(temp_dir(), "harn_pack_strict_sbom_" + uuid_v7())
+  mkdir(root)
+  write_file(path_join(root, "hello.harn"), "println(\"hi\")\n")
+  let pack = exec_at(
+    root,
+    harn_bin,
+    "pack",
+    "hello.harn",
+    "--unsigned",
+    "--out",
+    path_join(root, "hello.harnpack"),
+  )
+  println(pack.success)
+  let unpack = exec_at(root, "sh", "-lc", "mkdir unpack && zstd -d -c hello.harnpack | tar -xf - -C unpack")
+  println(unpack.success)
+  let tamper = exec_at(
+    root,
+    "python3",
+    "-c",
+    "import json, pathlib, sys\nZERO = 'blake3:0000000000000000000000000000000000000000000000000000000000000000'\nmanifest = pathlib.Path(sys.argv[1])\nsbom = pathlib.Path(sys.argv[2])\nmanifest_data = json.loads(manifest.read_text())\nfor package in manifest_data['sbom']['packages']:\n    if package.get('name') == 'module:hello.harn':\n        package['package_hash_blake3'] = ZERO\n        break\nmanifest.write_text(json.dumps(manifest_data, separators=(',', ':')))\nsbom_data = json.loads(sbom.read_text())\nfor package in sbom_data['packages']:\n    if package.get('name') == 'module:hello.harn':\n        package['package_hash_blake3'] = ZERO\n        break\nsbom.write_text(json.dumps(sbom_data, separators=(',', ':')))\n",
+    path_join(root, "unpack/harnpack.json"),
+    path_join(root, "unpack/sbom.spdx.json"),
+  )
+  println(tamper.success)
+  let repack = exec_at(
+    root,
+    "sh",
+    "-lc",
+    "cd unpack && tar -cf - harnpack.json sbom.spdx.json sources bytecode | zstd -f -o ../tampered.harnpack",
+  )
+  println(repack.success)
+  let lenient = exec_at(
+    root,
+    harn_bin,
+    "pack",
+    "verify",
+    path_join(root, "tampered.harnpack"),
+    "--allow-unsigned",
+    "--json",
+  )
+  println(lenient.success)
+  let lenient_data = json_parse(lenient.stdout)
+  println(lenient_data.ok)
+  let strict = exec_at(
+    root,
+    harn_bin,
+    "pack",
+    "verify",
+    path_join(root, "tampered.harnpack"),
+    "--allow-unsigned",
+    "--strict",
+    "--json",
+  )
+  println(strict.success)
+  let strict_data = json_parse(strict.stdout)
+  println(strict_data.ok)
+  println(strict_data.error.code)
+}

--- a/crates/harn-cli/src/cli/pack.rs
+++ b/crates/harn-cli/src/cli/pack.rs
@@ -108,6 +108,12 @@ pub struct PackVerifyArgs {
     #[arg(long, default_value_t = false)]
     pub require_trusted_signer: bool,
 
+    /// Cross-check SBOM package hashes against the archive payloads
+    /// they describe when the bundle format carries a corresponding
+    /// entry.
+    #[arg(long, default_value_t = false)]
+    pub strict: bool,
+
     /// Emit a `JsonEnvelope` summary instead of a human-readable
     /// one-liner. Schema: `harn --json-schemas --command "pack verify"`.
     #[arg(long, default_value_t = false)]

--- a/crates/harn-cli/src/cli/tests.rs
+++ b/crates/harn-cli/src/cli/tests.rs
@@ -1799,6 +1799,7 @@ fn test_parses_pack_verify_subcommand() {
         "--trust-policy",
         "policy.json",
         "--require-trusted-signer",
+        "--strict",
         "--json",
     ]);
     let Command::Pack(args) = cli.command.unwrap() else {
@@ -1811,6 +1812,7 @@ fn test_parses_pack_verify_subcommand() {
     assert!(verify.allow_unsigned);
     assert_eq!(verify.trust_policy, Some(PathBuf::from("policy.json")));
     assert!(verify.require_trusted_signer);
+    assert!(verify.strict);
     assert!(verify.json);
 }
 

--- a/crates/harn-cli/src/commands/pack.rs
+++ b/crates/harn-cli/src/commands/pack.rs
@@ -1193,7 +1193,9 @@ pub fn verify(args: &PackVerifyArgs) -> Result<PackVerifyJsonData, PackError> {
 
     let mut source_map: BTreeMap<PathBuf, &HarnpackEntry> = BTreeMap::new();
     let mut bytecode_map: BTreeMap<PathBuf, &HarnpackEntry> = BTreeMap::new();
+    let mut archive_hashes: BTreeMap<PathBuf, String> = BTreeMap::new();
     for entry in contents {
+        archive_hashes.insert(entry.path.clone(), blake3_hash(&entry.bytes));
         if let Ok(rel) = entry.path.strip_prefix("sources") {
             source_map.insert(rel.to_path_buf(), entry);
         } else if let Ok(rel) = entry.path.strip_prefix("bytecode") {
@@ -1255,6 +1257,10 @@ pub fn verify(args: &PackVerifyArgs) -> Result<PackVerifyJsonData, PackError> {
         }
     }
 
+    if args.strict {
+        verify_sbom_package_hashes(manifest, &archive_hashes)?;
+    }
+
     // Cross-check the recorded signature hash against the recomputed
     // canonical hash. `verify_workflow_bundle_signature` already does
     // this for signed bundles; for unsigned bundles we report the
@@ -1287,6 +1293,92 @@ pub fn verify(args: &PackVerifyArgs) -> Result<PackVerifyJsonData, PackError> {
         module_count: manifest.transitive_modules.len(),
         content_entry_count: contents.len(),
     })
+}
+
+fn verify_sbom_package_hashes(
+    manifest: &WorkflowBundle,
+    archive_hashes: &BTreeMap<PathBuf, String>,
+) -> Result<(), PackError> {
+    let module_hashes: BTreeMap<&Path, &str> = manifest
+        .transitive_modules
+        .iter()
+        .map(|module| (module.path.as_path(), module.source_hash_blake3.as_str()))
+        .collect();
+
+    for package in &manifest.sbom.packages {
+        let Some(expected_hash) = package.package_hash_blake3.as_deref() else {
+            continue;
+        };
+
+        if let Some(rel) = package.name.strip_prefix("module:") {
+            let module_path = Path::new(rel);
+            let manifest_hash = module_hashes.get(module_path).ok_or_else(|| {
+                PackError::new(
+                    "verify.sbom_mismatch",
+                    format!(
+                        "SBOM package {} does not match any manifest transitive module",
+                        package.name
+                    ),
+                )
+            })?;
+            if *manifest_hash != expected_hash {
+                return Err(PackError::new(
+                    "verify.sbom_mismatch",
+                    format!(
+                        "SBOM package {} recorded hash {} but manifest module {} uses {}",
+                        package.name,
+                        expected_hash,
+                        module_path.display(),
+                        manifest_hash
+                    ),
+                ));
+            }
+            let source_archive_path = PathBuf::from("sources").join(module_path);
+            let archive_hash = archive_hashes.get(&source_archive_path).ok_or_else(|| {
+                PackError::new(
+                    "verify.sbom_mismatch",
+                    format!(
+                        "SBOM package {} refers to {}, but archive is missing {}",
+                        package.name,
+                        module_path.display(),
+                        source_archive_path.display()
+                    ),
+                )
+            })?;
+            if archive_hash != expected_hash {
+                return Err(PackError::new(
+                    "verify.sbom_mismatch",
+                    format!(
+                        "SBOM package {} recorded hash {} but archive {} hashes to {}",
+                        package.name,
+                        expected_hash,
+                        source_archive_path.display(),
+                        archive_hash
+                    ),
+                ));
+            }
+            continue;
+        }
+
+        let candidate_path = Path::new(&package.name);
+        let Some(archive_hash) = archive_hashes.get(candidate_path) else {
+            continue;
+        };
+        if archive_hash != expected_hash {
+            return Err(PackError::new(
+                "verify.sbom_mismatch",
+                format!(
+                    "SBOM package {} recorded hash {} but archive {} hashes to {}",
+                    package.name,
+                    expected_hash,
+                    candidate_path.display(),
+                    archive_hash
+                ),
+            ));
+        }
+    }
+
+    Ok(())
 }
 
 fn bundle_signer_fingerprint(signature: &Ed25519Signature) -> Result<String, String> {

--- a/crates/harn-cli/tests/pack_cli.rs
+++ b/crates/harn-cli/tests/pack_cli.rs
@@ -457,6 +457,7 @@ fn pack_verify_signed_bundle_passes_and_reports_signature_key() {
         allow_unsigned: false,
         trust_policy: None,
         require_trusted_signer: false,
+        strict: false,
         json: false,
     })
     .expect("verify ok on signed bundle");
@@ -485,6 +486,7 @@ fn pack_verify_unsigned_bundle_refused_without_flag_but_ok_with_flag() {
         allow_unsigned: false,
         trust_policy: None,
         require_trusted_signer: false,
+        strict: false,
         json: false,
     })
     .expect_err("unsigned bundle must refuse without --allow-unsigned");
@@ -495,6 +497,7 @@ fn pack_verify_unsigned_bundle_refused_without_flag_but_ok_with_flag() {
         allow_unsigned: true,
         trust_policy: None,
         require_trusted_signer: false,
+        strict: false,
         json: false,
     })
     .expect("verify ok on unsigned bundle with --allow-unsigned");
@@ -544,6 +547,7 @@ fn pack_verify_tampered_signed_bundle_fails() {
         allow_unsigned: true,
         trust_policy: None,
         require_trusted_signer: false,
+        strict: false,
         json: false,
     })
     .expect_err("tampered bundle must fail verification");
@@ -567,6 +571,7 @@ fn pack_verify_json_envelope_round_trips_schema() {
         allow_unsigned: true,
         trust_policy: None,
         require_trusted_signer: false,
+        strict: false,
         json: true,
     });
     let value = serde_json::to_value(&envelope).unwrap();
@@ -631,6 +636,7 @@ fn pack_verify_require_trusted_signer_rejects_signer_outside_policy_allowlist() 
             allow_unsigned: false,
             trust_policy: Some(policy),
             require_trusted_signer: true,
+            strict: false,
             json: false,
         })
         .expect_err("unexpected signer must fail the trust policy");
@@ -638,6 +644,57 @@ fn pack_verify_require_trusted_signer_rejects_signer_outside_policy_allowlist() 
         assert_eq!(err.code, "verify.untrusted_signer");
         assert!(err.message.contains("trusted_signers allowlist"));
     });
+}
+
+#[test]
+fn pack_verify_strict_rejects_tampered_sbom_module_hash() {
+    let workdir = TempDir::new().unwrap();
+    let entry = workdir.path().join("hello.harn");
+    fs::write(&entry, "println(\"hi\")\n").unwrap();
+    let out = workdir.path().join("hello.harnpack");
+    build_pack(&pack_args(entry.clone(), out.clone()));
+
+    let mut archive = read_harnpack(&fs::read(&out).unwrap()).unwrap();
+    let module_package = archive
+        .manifest
+        .sbom
+        .packages
+        .iter_mut()
+        .find(|package| package.name == "module:hello.harn")
+        .expect("module package present");
+    module_package.package_hash_blake3 =
+        Some("blake3:0000000000000000000000000000000000000000000000000000000000000000".to_string());
+    let sbom_entry = archive
+        .contents
+        .iter_mut()
+        .find(|entry| entry.path == Path::new(pack::PACK_SBOM_ARCHIVE_PATH))
+        .expect("sbom entry present");
+    sbom_entry.bytes = serde_json::to_vec(&archive.manifest.sbom).unwrap();
+    let tampered =
+        harn_vm::orchestration::build_harnpack(&archive.manifest, &archive.contents).unwrap();
+    fs::write(&out, &tampered).unwrap();
+
+    pack::verify(&PackVerifyArgs {
+        bundle: out.clone(),
+        allow_unsigned: true,
+        trust_policy: None,
+        require_trusted_signer: false,
+        strict: false,
+        json: false,
+    })
+    .expect("non-strict verify ignores SBOM-only drift");
+
+    let err = pack::verify(&PackVerifyArgs {
+        bundle: out,
+        allow_unsigned: true,
+        trust_policy: None,
+        require_trusted_signer: false,
+        strict: true,
+        json: false,
+    })
+    .expect_err("strict verify must reject SBOM package hash drift");
+    assert_eq!(err.code, "verify.sbom_mismatch");
+    assert!(err.message.contains("module:hello.harn"));
 }
 
 #[test]

--- a/docs/src/workflow-bundles.md
+++ b/docs/src/workflow-bundles.md
@@ -92,6 +92,11 @@ on any mismatch and emits structured error codes (`verify.signature_failed`,
 `verify.recorded_hash_mismatch`, `verify.archive_failed`,
 `verify.unsigned`).
 
+Pass `--strict` to additionally cross-check SBOM package hashes against the
+archive payloads they describe when the bundle format carries a corresponding
+entry. Today that primarily hardens `module:*` SBOM rows and surfaces drift as
+`verify.sbom_mismatch`.
+
 By default, unsigned bundles fail verification. Pass `--allow-unsigned` to
 accept a bundle without an Ed25519 signature (useful in local development).
 


### PR DESCRIPTION
## Summary
- add `harn pack verify --strict` to cross-check SBOM package hashes against the bundle payloads they describe
- emit `verify.sbom_mismatch` when a module SBOM row drifts out of sync with the manifest or archive
- cover the behavior in both Rust integration tests and conformance, and document the new strict mode

## Verification
- `cargo test -p harn-cli test_parses_pack_verify_subcommand`
- `cargo test -p harn-cli --test pack_cli`
- `target/debug/harn test conformance --filter pack_verify_strict_sbom_mismatch`

Refs #2063.
Stacked on #2060.
