### PR TITLE
[codex] Bundle imported assets in harn pack

### DIFF
--- a/conformance/tests/harn_pack/pack_asset_exclude_secrets.expected
+++ b/conformance/tests/harn_pack/pack_asset_exclude_secrets.expected
@@ -1,0 +1,6 @@
+true
+true
+true
+pack.asset_skipped_secret
+secrets/prompt.txt
+secret_path

--- a/conformance/tests/harn_pack/pack_asset_exclude_secrets.harn
+++ b/conformance/tests/harn_pack/pack_asset_exclude_secrets.harn
@@ -1,0 +1,33 @@
+import "../_common"
+
+fn main(harness: Harness) {
+  let repo_root = exec("git", "rev-parse", "--show-toplevel").stdout.trim()
+  let harn_bin = harness.env.get_or("HARN_CONFORMANCE_HARN_BIN", resolve_harn_bin(repo_root))
+  let root = path_join(harness.fs.temp_dir(), "harn_pack_asset_secret_" + uuid_v7())
+  harness.fs.mkdir(root)
+  harness.fs.mkdir(path_join(root, "secrets"))
+  harness.fs.write_text(path_join(root, "secrets/prompt.txt"), "token={{secret}}\n")
+  harness.fs
+    .write_text(
+    path_join(root, "entry.harn"),
+    "import \"./secrets/prompt.txt\"\n__io_println(\"asset skip ok\")\n",
+  )
+  let packed = exec_at(
+    root,
+    harn_bin,
+    "pack",
+    "entry.harn",
+    "--unsigned",
+    "--exclude-secrets",
+    "--out",
+    path_join(root, "entry.harnpack"),
+    "--json",
+  )
+  harness.stdio.println(packed.success)
+  let packed_data = json_parse(packed.stdout)
+  harness.stdio.println(packed_data.ok)
+  harness.stdio.println(harness.fs.exists(path_join(root, "entry.harnpack")))
+  harness.stdio.println(packed_data.warnings[0].code)
+  harness.stdio.println(packed_data.data.manifest.metadata.skipped_assets[0].path)
+  harness.stdio.println(packed_data.data.manifest.metadata.skipped_assets[0].reason)
+}

--- a/crates/harn-cli/src/cli/pack.rs
+++ b/crates/harn-cli/src/cli/pack.rs
@@ -8,7 +8,8 @@ pub struct PackArgs {
     #[command(subcommand)]
     pub command: Option<PackCommand>,
 
-    /// Entrypoint `.harn` file to pack. Transitive imports under the
+    /// Entrypoint `.harn` file to pack. Transitive Harn modules and
+    /// non-Harn assets referenced by import directives under the
     /// entrypoint's directory are bundled alongside it.
     ///
     /// When `harn pack` is invoked without a subcommand, this positional
@@ -55,11 +56,9 @@ pub struct PackArgs {
     /// module set without any secret filtering. Pass `--exclude-secrets`
     /// from CI or release pipelines that share bundles externally.
     ///
-    /// Today the static module walk is rooted at the entrypoint
-    /// directory and only pulls in `.harn` files; the gate primarily
-    /// blocks an entrypoint that itself looks like a secret-bearing
-    /// path and is wired so the CLI / JSON surface stays stable when
-    /// asset bundling lands.
+    /// The same gate skips imported non-Harn assets that match the
+    /// secret heuristic and reports each skipped asset as a structured
+    /// JSON warning plus `manifest.metadata.skipped_assets`.
     #[arg(long, default_value_t = false, conflicts_with = "include_secrets")]
     pub exclude_secrets: bool,
 

--- a/crates/harn-cli/src/commands/pack.rs
+++ b/crates/harn-cli/src/commands/pack.rs
@@ -30,11 +30,11 @@ use harn_vm::orchestration::{
 };
 use harn_vm::Compiler;
 use harn_vm::{AutonomyTier, TrustRecord};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::cli::{PackArgs, PackCommand, PackVerifyArgs};
 use crate::command_error;
-use crate::json_envelope::{to_string_pretty, JsonEnvelope, JsonOutput};
+use crate::json_envelope::{to_string_pretty, JsonEnvelope, JsonOutput, JsonWarning};
 use crate::parse_source_file;
 use crate::skill_provenance;
 
@@ -76,13 +76,18 @@ pub struct PackDebugSymbolMetadata {
     pub total_bytes: u64,
 }
 
-struct PackJsonOutput(PackJsonData);
+struct PackJsonOutput {
+    data: PackJsonData,
+    warnings: Vec<JsonWarning>,
+}
 
 impl JsonOutput for PackJsonOutput {
     const SCHEMA_VERSION: u32 = PACK_SCHEMA_VERSION;
     type Data = PackJsonData;
     fn into_envelope(self) -> JsonEnvelope<Self::Data> {
-        JsonEnvelope::ok(Self::SCHEMA_VERSION, self.0)
+        let mut envelope = JsonEnvelope::ok(Self::SCHEMA_VERSION, self.data);
+        envelope.warnings = self.warnings;
+        envelope
     }
 }
 
@@ -108,9 +113,16 @@ pub fn run(args: PackArgs) {
     match build(&build_args) {
         Ok(outcome) => {
             if build_args.json {
-                let envelope = PackJsonOutput(outcome.json).into_envelope();
+                let envelope = PackJsonOutput {
+                    data: outcome.json,
+                    warnings: outcome.warnings,
+                }
+                .into_envelope();
                 println!("{}", to_string_pretty(&envelope));
             } else {
+                for warning in &outcome.warnings {
+                    eprintln!("warning[{}]: {}", warning.code, warning.message);
+                }
                 println!(
                     "wrote {} ({} bytes, bundle_hash {})",
                     outcome.output_path.display(),
@@ -152,7 +164,11 @@ pub fn run_to_envelope(args: &PackArgs) -> JsonEnvelope<PackJsonData> {
         json: args.json,
     };
     match build(&build_args) {
-        Ok(outcome) => PackJsonOutput(outcome.json).into_envelope(),
+        Ok(outcome) => PackJsonOutput {
+            data: outcome.json,
+            warnings: outcome.warnings,
+        }
+        .into_envelope(),
         Err(err) => JsonEnvelope::err(PACK_SCHEMA_VERSION, err.code, err.message),
     }
 }
@@ -239,6 +255,7 @@ pub struct PackOutcome {
     pub output_path: PathBuf,
     pub size_bytes: u64,
     pub json: PackJsonData,
+    pub warnings: Vec<JsonWarning>,
 }
 
 #[derive(Debug)]
@@ -350,14 +367,22 @@ pub fn build(args: &BuildArgs) -> Result<PackOutcome, PackError> {
     };
 
     let graph = harn_modules::build(std::slice::from_ref(&entrypoint));
-    let mut module_paths = graph.module_paths();
+    let mut graph_paths = graph.module_paths();
     // The entrypoint is always present in the graph; ensure deterministic order.
+    graph_paths.sort();
+    let mut module_paths: Vec<PathBuf> = graph_paths
+        .iter()
+        .filter(|path| is_harn_module_path(path))
+        .cloned()
+        .collect();
     module_paths.sort();
 
     let mut transitive_modules = Vec::new();
     let mut contents = Vec::new();
     let mut sbom_packages = Vec::new();
     let mut sbom_relationships = Vec::new();
+    let mut warnings = Vec::new();
+    let mut skipped_assets = Vec::new();
     let mut debug_symbol_metadata = PackDebugSymbolMetadata {
         harnbc_count: 0,
         total_bytes: 0,
@@ -501,6 +526,49 @@ pub fn build(args: &BuildArgs) -> Result<PackOutcome, PackError> {
         });
     }
 
+    for asset in discover_import_assets(&graph, &module_paths, &project_root) {
+        if args.exclude_secrets && path_looks_like_secret(&asset.path) {
+            warnings.push(JsonWarning {
+                code: "pack.asset_skipped_secret".to_string(),
+                message: format!(
+                    "skipped imported asset {} because it matches a secret-bearing path pattern",
+                    asset.rel.display()
+                ),
+            });
+            skipped_assets.push(SkippedAsset {
+                path: asset.rel.clone(),
+                reason: "secret_path".to_string(),
+            });
+            continue;
+        }
+
+        let bytes = std::fs::read(&asset.path).map_err(|err| {
+            PackError::new(
+                "asset.read_failed",
+                format!(
+                    "failed to read imported asset {}: {err}",
+                    asset.path.display()
+                ),
+            )
+        })?;
+        let asset_hash = blake3_hash(&bytes);
+        contents.push(HarnpackEntry::new(
+            PathBuf::from("sources").join(&asset.rel),
+            bytes,
+        ));
+        sbom_packages.push(SBOMPackage {
+            name: format!("asset:{}", asset.rel.display()),
+            version: Some(harn_version.clone()),
+            package_hash_blake3: Some(asset_hash),
+            license: None,
+        });
+        sbom_relationships.push(SBOMRelationship {
+            from: format!("entrypoint:{}", entrypoint_rel.display()),
+            to: format!("asset:{}", asset.rel.display()),
+            relationship_type: "depends_on".to_string(),
+        });
+    }
+
     if transitive_modules.is_empty() {
         return Err(PackError::new(
             "pack.no_modules",
@@ -578,6 +646,17 @@ pub fn build(args: &BuildArgs) -> Result<PackOutcome, PackError> {
         },
         prior.as_ref(),
     );
+    if !skipped_assets.is_empty() {
+        bundle.metadata.insert(
+            "skipped_assets".to_string(),
+            serde_json::to_value(&skipped_assets).map_err(|err| {
+                PackError::new(
+                    "pack.metadata_failed",
+                    format!("failed to render skipped asset metadata: {err}"),
+                )
+            })?,
+        );
+    }
     sort_sbom_doc(&mut bundle.sbom);
     let sbom_bytes = serde_json::to_vec_pretty(&bundle.sbom).map_err(|err| {
         PackError::new(
@@ -638,6 +717,7 @@ pub fn build(args: &BuildArgs) -> Result<PackOutcome, PackError> {
             debug_symbol_metadata,
             manifest: bundle,
         },
+        warnings,
     })
 }
 
@@ -765,6 +845,58 @@ fn sbom_summary(bundle: &WorkflowBundle) -> PackSbomSummary {
         providers,
         tools: bundle.tool_manifest.len(),
     }
+}
+
+#[derive(Debug)]
+struct ImportedAsset {
+    path: PathBuf,
+    rel: PathBuf,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct SkippedAsset {
+    path: PathBuf,
+    reason: String,
+}
+
+fn discover_import_assets(
+    graph: &harn_modules::ModuleGraph,
+    module_paths: &[PathBuf],
+    project_root: &Path,
+) -> Vec<ImportedAsset> {
+    let mut assets = BTreeMap::<PathBuf, ImportedAsset>::new();
+    for module_path in module_paths {
+        if module_path.to_string_lossy().starts_with("<std>/") {
+            continue;
+        }
+        for import in graph.imports_for_module(module_path) {
+            let Some(resolved_path) = import.resolved_path else {
+                continue;
+            };
+            if is_harn_module_path(&resolved_path) {
+                continue;
+            }
+            let canonical = resolved_path
+                .canonicalize()
+                .unwrap_or_else(|_| resolved_path.clone());
+            let rel = relativize(project_root, &canonical).unwrap_or_else(|| {
+                canonical
+                    .file_name()
+                    .map(PathBuf::from)
+                    .unwrap_or_else(|| canonical.clone())
+            });
+            assets.entry(canonical.clone()).or_insert(ImportedAsset {
+                path: canonical,
+                rel,
+            });
+        }
+    }
+    assets.into_values().collect()
+}
+
+fn is_harn_module_path(path: &Path) -> bool {
+    path.to_string_lossy().starts_with("<std>/")
+        || path.extension().and_then(|ext| ext.to_str()) == Some("harn")
 }
 
 fn sort_sbom_doc(sbom: &mut SBOMDoc) {
@@ -1353,6 +1485,34 @@ fn verify_sbom_package_hashes(
                         package.name,
                         expected_hash,
                         source_archive_path.display(),
+                        archive_hash
+                    ),
+                ));
+            }
+            continue;
+        }
+
+        if let Some(rel) = package.name.strip_prefix("asset:") {
+            let asset_archive_path = PathBuf::from("sources").join(rel);
+            let archive_hash = archive_hashes.get(&asset_archive_path).ok_or_else(|| {
+                PackError::new(
+                    "verify.sbom_mismatch",
+                    format!(
+                        "SBOM package {} refers to {}, but archive is missing {}",
+                        package.name,
+                        rel,
+                        asset_archive_path.display()
+                    ),
+                )
+            })?;
+            if archive_hash != expected_hash {
+                return Err(PackError::new(
+                    "verify.sbom_mismatch",
+                    format!(
+                        "SBOM package {} recorded hash {} but archive {} hashes to {}",
+                        package.name,
+                        expected_hash,
+                        asset_archive_path.display(),
                         archive_hash
                     ),
                 ));

--- a/crates/harn-cli/tests/pack_cli.rs
+++ b/crates/harn-cli/tests/pack_cli.rs
@@ -197,6 +197,56 @@ fn pack_resolves_transitive_imports() {
 }
 
 #[test]
+fn pack_bundles_non_harn_assets_from_imports() {
+    let workdir = TempDir::new().unwrap();
+    let prompts = workdir.path().join("prompts");
+    fs::create_dir_all(&prompts).unwrap();
+    fs::write(prompts.join("template.txt"), "Hello, {{name}}\n").unwrap();
+    fs::write(
+        workdir.path().join("lib.harn"),
+        "pub fn greet() -> string { return \"howdy\" }\n",
+    )
+    .unwrap();
+    let entry = workdir.path().join("entry.harn");
+    fs::write(
+        &entry,
+        "import { greet } from \"./lib\"\nimport \"./prompts/template.txt\"\nprintln(greet())\n",
+    )
+    .unwrap();
+    let out = workdir.path().join("entry.harnpack");
+
+    run_pack(&pack_args(entry.clone(), out.clone()));
+
+    let archive = read_harnpack(&fs::read(&out).unwrap()).unwrap();
+    assert!(archive
+        .contents
+        .iter()
+        .any(|entry| entry.path == Path::new("sources/prompts/template.txt")));
+    assert!(archive.manifest.sbom.packages.iter().any(|package| {
+        package.name == "asset:prompts/template.txt"
+            && package
+                .package_hash_blake3
+                .as_deref()
+                .is_some_and(|hash| hash.starts_with("blake3:"))
+    }));
+    assert!(archive
+        .manifest
+        .sbom
+        .relationships
+        .iter()
+        .any(|relationship| {
+            relationship.from == "entrypoint:entry.harn"
+                && relationship.to == "asset:prompts/template.txt"
+                && relationship.relationship_type == "depends_on"
+        }));
+    assert!(archive
+        .manifest
+        .transitive_modules
+        .iter()
+        .all(|module| module.path != Path::new("prompts/template.txt")));
+}
+
+#[test]
 fn pack_json_envelope_carries_pack_schema() {
     let workdir = TempDir::new().unwrap();
     let entry = workdir.path().join("hello.harn");
@@ -698,6 +748,54 @@ fn pack_verify_strict_rejects_tampered_sbom_module_hash() {
 }
 
 #[test]
+fn pack_verify_strict_rejects_tampered_sbom_asset_hash() {
+    let workdir = TempDir::new().unwrap();
+    let prompts = workdir.path().join("prompts");
+    fs::create_dir_all(&prompts).unwrap();
+    fs::write(prompts.join("template.txt"), "asset body\n").unwrap();
+    let entry = workdir.path().join("hello.harn");
+    fs::write(
+        &entry,
+        "import \"./prompts/template.txt\"\nprintln(\"hi\")\n",
+    )
+    .unwrap();
+    let out = workdir.path().join("hello.harnpack");
+    build_pack(&pack_args(entry.clone(), out.clone()));
+
+    let mut archive = read_harnpack(&fs::read(&out).unwrap()).unwrap();
+    let asset_package = archive
+        .manifest
+        .sbom
+        .packages
+        .iter_mut()
+        .find(|package| package.name == "asset:prompts/template.txt")
+        .expect("asset package present");
+    asset_package.package_hash_blake3 =
+        Some("blake3:0000000000000000000000000000000000000000000000000000000000000000".to_string());
+    let sbom_entry = archive
+        .contents
+        .iter_mut()
+        .find(|entry| entry.path == Path::new(pack::PACK_SBOM_ARCHIVE_PATH))
+        .expect("sbom entry present");
+    sbom_entry.bytes = serde_json::to_vec(&archive.manifest.sbom).unwrap();
+    let tampered =
+        harn_vm::orchestration::build_harnpack(&archive.manifest, &archive.contents).unwrap();
+    fs::write(&out, &tampered).unwrap();
+
+    let err = pack::verify(&PackVerifyArgs {
+        bundle: out,
+        allow_unsigned: true,
+        trust_policy: None,
+        require_trusted_signer: false,
+        strict: true,
+        json: false,
+    })
+    .expect_err("strict verify must reject SBOM asset hash drift");
+    assert_eq!(err.code, "verify.sbom_mismatch");
+    assert!(err.message.contains("asset:prompts/template.txt"));
+}
+
+#[test]
 fn pack_exclude_secrets_blocks_entrypoint_with_dotenv_name() {
     let workdir = TempDir::new().unwrap();
     let entry = workdir.path().join(".env.harn");
@@ -722,6 +820,62 @@ fn pack_exclude_secrets_blocks_entrypoint_with_dotenv_name() {
     });
     assert_eq!(err.code, "pack.secret_blocked");
     assert!(!out.exists(), "blocked bundle must not be written");
+}
+
+#[test]
+fn pack_exclude_secrets_skips_imported_assets_with_warning() {
+    let workdir = TempDir::new().unwrap();
+    let secrets = workdir.path().join("secrets");
+    fs::create_dir_all(&secrets).unwrap();
+    fs::write(secrets.join("prompt.txt"), "token={{secret}}\n").unwrap();
+    let entry = workdir.path().join("entry.harn");
+    fs::write(&entry, "import \"./secrets/prompt.txt\"\nprintln(\"ok\")\n").unwrap();
+    let out = workdir.path().join("entry.harnpack");
+
+    let envelope = Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(async {
+            let _cwd_guard = cwd_lock::lock_cwd_async().await;
+            harn_vm::reset_thread_local_state();
+            pack::run_to_envelope(&PackArgs {
+                command: None,
+                entrypoint: Some(entry.clone()),
+                out: Some(out.clone()),
+                upgrade: None,
+                sign: false,
+                key: None,
+                unsigned: true,
+                exclude_secrets: true,
+                include_secrets: false,
+                json: true,
+            })
+        });
+
+    let value = serde_json::to_value(&envelope).unwrap();
+    assert_eq!(value["ok"], true);
+    assert_eq!(value["warnings"][0]["code"], "pack.asset_skipped_secret");
+    assert_eq!(
+        value["data"]["manifest"]["metadata"]["skipped_assets"][0]["path"],
+        "secrets/prompt.txt"
+    );
+    assert_eq!(
+        value["data"]["manifest"]["metadata"]["skipped_assets"][0]["reason"],
+        "secret_path"
+    );
+
+    let archive = read_harnpack(&fs::read(&out).unwrap()).unwrap();
+    assert!(!archive
+        .contents
+        .iter()
+        .any(|entry| entry.path == Path::new("sources/secrets/prompt.txt")));
+    assert!(!archive
+        .manifest
+        .sbom
+        .packages
+        .iter()
+        .any(|package| package.name == "asset:secrets/prompt.txt"));
 }
 
 fn release_records(

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -1969,10 +1969,11 @@ harn remove my-lib
 Build a `.harnpack` run bundle from a Harn entrypoint
 ([#1781][issue-1781]). The bundle is a deterministic tar.zst archive
 containing a v2 `WorkflowBundle` manifest (`harnpack.json`), every
-transitively-imported `.harn` source under `sources/`, every module's
-precompiled `.harnbc`/`.harnmod` artifact under `bytecode/`, a
-provider-catalog hash + stdlib version pin, an archived SPDX-lite 2.3
-SBOM (`sbom.spdx.json`), and an optional Ed25519 signature slot.
+transitively-imported `.harn` source and non-Harn import asset under
+`sources/`, every module's precompiled `.harnbc`/`.harnmod` artifact
+under `bytecode/`, a provider-catalog hash + stdlib version pin, an
+archived SPDX-lite 2.3 SBOM (`sbom.spdx.json`), and an optional
+Ed25519 signature slot.
 
 ```bash
 harn pack examples/hello.harn
@@ -2002,6 +2003,11 @@ canonical bundle hash, embeds the signature in the manifest, and appends an
 OpenTrustGraph `release` record. `--unsigned` skips the manifest signature but
 still appends the release record at autonomy tier `suggest`; this is also the
 default when neither signing flag is provided.
+
+`--exclude-secrets` refuses secret-looking entrypoints and skips imported
+non-Harn assets whose paths match `.env`, `.env.*`, `*.pem`, `*.key`,
+`credentials*`, or a `secrets/` directory. Skipped assets are reported as
+`JsonEnvelope.warnings` entries and in `manifest.metadata.skipped_assets`.
 
 [issue-1781]: https://github.com/burin-labs/harn/issues/1781
 

--- a/docs/src/workflow-bundles.md
+++ b/docs/src/workflow-bundles.md
@@ -75,11 +75,12 @@ signature but still appends the release record at autonomy tier `suggest`.
 path, archive size, signature presence, SBOM counts, bytecode/debug-symbol
 metadata, and the full manifest.
 
-`harn pack --exclude-secrets` refuses to bundle entrypoints (or, once asset
-bundling lands, transitive paths) that match a conservative secret-bearing
-glob: `.env`, `.env.*`, `*.pem`, `*.key`, `credentials*`, and any path under a
-`secrets/` directory. Pass `--include-secrets` to be explicit about the
-default behavior in release pipelines.
+`harn pack --exclude-secrets` refuses to bundle entrypoints and skips imported
+non-Harn assets that match a conservative secret-bearing glob: `.env`,
+`.env.*`, `*.pem`, `*.key`, `credentials*`, and any path under a `secrets/`
+directory. Skipped assets are reported as structured JSON warnings and in
+`manifest.metadata.skipped_assets`. Pass `--include-secrets` to be explicit
+about the default behavior in release pipelines.
 
 ### Verifying a `.harnpack`
 


### PR DESCRIPTION
## Summary

- Bundle non-Harn files referenced by import directives into `sources/` alongside Harn modules.
- Add `asset:<path>` SBOM packages/relationships and strict verify coverage for asset hashes.
- Make `--exclude-secrets` skip imported secret-looking assets with JSON warnings and `manifest.metadata.skipped_assets`.
- Update CLI/workflow bundle docs and add harn_pack conformance coverage.

Fixes #2061

## Validation

- `CARGO_TARGET_DIR=/tmp/harn-target-2061 cargo test -p harn-cli --test pack_cli`
- `HARN_CONFORMANCE_HARN_BIN=/tmp/harn-target-2061/debug/harn CARGO_TARGET_DIR=/tmp/harn-target-2061 /tmp/harn-target-2061/debug/harn test conformance --filter harn_pack`
- pre-commit hook: Rust fmt, affected Harn fmt/lint, clippy, CI ratchets, markdown lint
- pre-push hook: targeted local checks, affected Harn fmt/lint, markdown lint
