### PR TITLE
[codex] Fix Windows smoke script stdio

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,7 @@ jobs:
       - name: Smoke test harn run
         shell: bash
         run: |
-          echo 'pipeline main() { println("ok") }' > smoke.harn
+          echo 'fn main(harness: Harness) { harness.stdio.println("ok") }' > smoke.harn
           ./target/debug/harn.exe run smoke.harn
 
   portal:

--- a/.github/workflows/windows-nightly.yml
+++ b/.github/workflows/windows-nightly.yml
@@ -63,5 +63,5 @@ jobs:
       - name: Smoke test harn run
         shell: bash
         run: |
-          echo 'pipeline main() { println("ok") }' > smoke.harn
+          echo 'fn main(harness: Harness) { harness.stdio.println("ok") }' > smoke.harn
           ./target/debug/harn.exe run smoke.harn


### PR DESCRIPTION
## Summary

- Update CI and Windows nightly smoke Harn scripts to use `fn main(harness: Harness)` and `harness.stdio.println`.
- Fixes the Windows CI failure introduced by the ambient stdio migration.

## Validation

- `make lint-actions`
- `CARGO_TARGET_DIR=/tmp/harn-target-ci-smoke cargo run --quiet --bin harn -- check <temp smoke.harn>`
- pre-commit hook: GitHub Actions workflow lint
- pre-push hook: targeted checks
