### PR TITLE
[codex] Update Harness entrypoint docs and skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,10 @@ concurrency primitives (`parallel each` / `parallel settle` with `max_concurrent
 `llm_call` options table (including `schema_retries` + `provider: "auto"`), and the gotchas
 that repeatedly trip up first-time scripters.
 
+For new scripts, default to the explicit entrypoint form
+`fn main(harness: Harness) { ... }` and route capability access through
+`harness.*` (for example `harness.stdio.println("hi")`).
+
 - In-repo: `docs/llm/harn-quickref.md`
 - Trigger/orchestrator add-on: `docs/llm/harn-triggers-quickref.md`
 - Canonical URL: <https://harnlang.com/docs/llm/harn-quickref.html>

--- a/crates/harn-skills/src/corpus/harn-language/SKILL.md
+++ b/crates/harn-skills/src/corpus/harn-language/SKILL.md
@@ -16,6 +16,8 @@ Pair it with [[harn-testing]] for fixtures and [[harn-diagnostics]] for user-fac
 - Read `docs/llm/harn-quickref.md` before editing `.harn` files.
 - Use `docs/llm/harn-triggers-quickref.md` when trigger manifests are involved.
 - Treat `spec/HARN_SPEC.md` as the canonical language reference.
+- Default new script entrypoints to `fn main(harness: Harness) { ... }` and
+  route side effects through `harness.*`.
 - Edit `spec/HARN_SPEC.md`, not `docs/src/language-spec.md`, for spec changes.
 - Regenerate generated spec docs with `make sync-language-spec`.
 - Check user-visible behavior with conformance fixtures under `conformance/tests/`.

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -39,9 +39,13 @@ logs and progress always go to stderr.
 ## Files and execution
 
 - File extension: `.harn`.
-- Entry points: a file can either declare `pipeline default() { ... }`
-  (pipeline mode — `compile_top_level_declarations` runs first, then
-  the pipeline body) or be a bare script with top-level statements.
+- Entry points:
+  - Preferred capability-aware script entrypoint:
+    `fn main(harness: Harness) { ... }`.
+  - Workflow entrypoint: `pipeline default() { ... }` (pipeline mode —
+    `compile_top_level_declarations` runs first, then the pipeline
+    body).
+  - Bare script with top-level statements for tiny one-off files.
 - Run: `harn run script.harn`.
 - Inline: `harn run -e 'log("hi")'`. The snippet is wrapped in
   `pipeline main(task) { ... }`; leading `import "..."` /

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -113,7 +113,9 @@ harn completions fish > ~/.config/fish/completions/harn.fish
 Create a file called `hello.harn`:
 
 ```harn
-log("Hello, world!")
+fn main(harness: Harness) {
+  harness.stdio.println("Hello, world!")
+}
 ```
 
 Run it:
@@ -122,14 +124,20 @@ Run it:
 harn run hello.harn
 ```
 
-That's it. Harn files can contain top-level code without any boilerplate.
-The above is an **implicit pipeline** -- the runtime wraps your top-level
-statements automatically.
+That's it. For capability-aware scripts, `fn main(harness: Harness)` is the
+canonical entrypoint: the runtime passes in the script's `Harness` handle and
+you route side effects through `harness.*`.
+
+Harn still supports top-level code without boilerplate. For tiny one-off
+snippets, the runtime can wrap top-level statements as an **implicit pipeline**,
+but the explicit `main(harness: Harness)` form is the recommended starting
+point once a script needs stdio, clock, filesystem, env, random, or network
+access.
 
 ## Adding a pipeline
 
-For larger programs, organize code into named pipelines. The runtime
-executes the `default` pipeline (or the first one declared):
+For larger workflow-style programs, organize code into named pipelines. The
+runtime executes the `default` pipeline (or the first one declared):
 
 ```harn
 pipeline default(task) {


### PR DESCRIPTION
## Summary
- update onboarding and quickref entrypoint guidance to prefer `fn main(harness: Harness)` for capability-aware scripts
- align repo/skill author guidance with the Harness entrypoint convention
- keep `harn run -e` documentation accurate as a `pipeline main(task)` wrapper for inline snippets

## Verification
- `HARN_BIN=/private/tmp/harn-1772/target/debug/harn ./scripts/check_docs_snippets.sh`
- `npx markdownlint-cli2 AGENTS.md docs/src/getting-started.md docs/llm/harn-quickref.md crates/harn-skills/src/corpus/harn-language/SKILL.md`