### PR TITLE
perf(vm): split iter_next into sync/async halves

### DIFF
--- a/crates/harn-vm/src/vm/ops/iter.rs
+++ b/crates/harn-vm/src/vm/ops/iter.rs
@@ -87,7 +87,93 @@ impl super::super::Vm {
         Ok(())
     }
 
-    pub(super) async fn execute_iter_next(&mut self) -> Result<(), VmError> {
+    /// Sync fast path for the `for-in` step opcode. Handles the Vec / Dict /
+    /// Range / no-iterator-active arms inline (the >99% case in real Harn
+    /// programs), returning `Some(Ok(()))` on a normal step or
+    /// `Some(Err(_))` on a runtime error.
+    ///
+    /// Returns `None` without touching `ip` when the active iterator
+    /// requires `.await` (Channel / Generator / Stream / VmIter); the
+    /// caller must fall through to [`execute_iter_next_async`]. Keeping
+    /// `ip` untouched on the async hand-off lets the async path read the
+    /// same operand the sync path would have, with no rewinding gymnastics.
+    pub(super) fn execute_iter_next_sync(&mut self) -> Option<Result<(), VmError>> {
+        // Classify the iterator variant before reading the bytecode operand.
+        // Channel/Generator/Stream/VmIter all suspend on a receiver lock or
+        // a host-side iterator, so they belong on the async path. Leaving
+        // `ip` untouched on hand-off means `execute_iter_next_async` reads
+        // the operand exactly once.
+        match self.iterators.last() {
+            None
+            | Some(super::super::IterState::Vec { .. })
+            | Some(super::super::IterState::Dict { .. })
+            | Some(super::super::IterState::Range { .. }) => {}
+            Some(_) => return None,
+        }
+
+        let frame = self.frames.last_mut().unwrap();
+        let target = frame.chunk.read_u16(frame.ip) as usize;
+        frame.ip += 2;
+
+        match self.iterators.last_mut() {
+            Some(super::super::IterState::Vec { items, idx }) => {
+                if *idx < items.len() {
+                    let item = items[*idx].clone();
+                    *idx += 1;
+                    self.stack.push(item);
+                } else {
+                    self.iterators.pop();
+                    let frame = self.frames.last_mut().unwrap();
+                    frame.ip = target;
+                }
+            }
+            Some(super::super::IterState::Dict { entries, keys, idx }) => {
+                if *idx < keys.len() {
+                    let key = &keys[*idx];
+                    let value = entries.get(key).cloned().unwrap_or(VmValue::Nil);
+                    let entry_key = VmValue::String(Rc::from(key.as_str()));
+                    *idx += 1;
+                    self.stack.push(VmValue::Dict(Rc::new(BTreeMap::from([
+                        ("key".to_string(), entry_key),
+                        ("value".to_string(), value),
+                    ]))));
+                } else {
+                    self.iterators.pop();
+                    let frame = self.frames.last_mut().unwrap();
+                    frame.ip = target;
+                }
+            }
+            Some(super::super::IterState::Range {
+                next,
+                end,
+                inclusive,
+                done,
+            }) => {
+                if let Some(v) = range_next(next, *end, *inclusive, done) {
+                    self.stack.push(VmValue::Int(v));
+                } else {
+                    self.iterators.pop();
+                    let frame = self.frames.last_mut().unwrap();
+                    frame.ip = target;
+                }
+            }
+            None => {
+                let frame = self.frames.last_mut().unwrap();
+                frame.ip = target;
+            }
+            // The variant guard above already routed Channel/Generator/
+            // Stream/VmIter to the async path before we touched `ip`.
+            Some(_) => unreachable!("async iterator variant reached sync path"),
+        }
+        Some(Ok(()))
+    }
+
+    /// Async slow path for `for-in` step. Handles Channel / Generator /
+    /// Stream / VmIter — the four iterator variants that actually suspend.
+    /// Reading the jump-on-exhaustion `target` (and advancing `ip`) happens
+    /// here so the sync fast path can return early without consuming
+    /// bytecode when it sees an async-only iterator state.
+    pub(super) async fn execute_iter_next_async(&mut self) -> Result<(), VmError> {
         let frame = self.frames.last_mut().unwrap();
         let target = frame.chunk.read_u16(frame.ip) as usize;
         frame.ip += 2;
@@ -109,49 +195,52 @@ impl super::super::Vm {
                     frame.ip = target;
                 }
             }
-        } else if let Some(state) = self.iterators.last_mut() {
-            match state {
-                super::super::IterState::Vec { items, idx } => {
-                    if *idx < items.len() {
-                        let item = items[*idx].clone();
-                        *idx += 1;
-                        self.stack.push(item);
-                    } else {
+            return Ok(());
+        }
+
+        match self.iterators.last_mut() {
+            Some(super::super::IterState::Channel { receiver, closed }) => {
+                let rx = receiver.clone();
+                let is_closed = closed.load(std::sync::atomic::Ordering::Relaxed);
+                let mut guard = rx.lock().await;
+                // Closed sender: drain without blocking.
+                let item = if is_closed {
+                    guard.try_recv().ok()
+                } else {
+                    guard.recv().await
+                };
+                match item {
+                    Some(val) => {
+                        self.stack.push(val);
+                    }
+                    None => {
+                        drop(guard);
                         self.iterators.pop();
                         let frame = self.frames.last_mut().unwrap();
                         frame.ip = target;
                     }
                 }
-                super::super::IterState::Dict { entries, keys, idx } => {
-                    if *idx < keys.len() {
-                        let key = &keys[*idx];
-                        let value = entries.get(key).cloned().unwrap_or(VmValue::Nil);
-                        *idx += 1;
-                        self.stack.push(VmValue::Dict(Rc::new(BTreeMap::from([
-                            ("key".to_string(), VmValue::String(Rc::from(key.as_str()))),
-                            ("value".to_string(), value),
-                        ]))));
-                    } else {
-                        self.iterators.pop();
-                        let frame = self.frames.last_mut().unwrap();
-                        frame.ip = target;
-                    }
-                }
-                super::super::IterState::Channel { receiver, closed } => {
-                    let rx = receiver.clone();
-                    let is_closed = closed.load(std::sync::atomic::Ordering::Relaxed);
+            }
+            Some(super::super::IterState::Generator { gen }) => {
+                if gen.done.get() {
+                    self.iterators.pop();
+                    let frame = self.frames.last_mut().unwrap();
+                    frame.ip = target;
+                } else {
+                    let rx = gen.receiver.clone();
                     let mut guard = rx.lock().await;
-                    // Closed sender: drain without blocking.
-                    let item = if is_closed {
-                        guard.try_recv().ok()
-                    } else {
-                        guard.recv().await
-                    };
-                    match item {
-                        Some(val) => {
+                    match guard.recv().await {
+                        Some(Ok(val)) => {
                             self.stack.push(val);
                         }
+                        Some(Err(error)) => {
+                            gen.done.set(true);
+                            drop(guard);
+                            self.iterators.pop();
+                            return Err(error);
+                        }
                         None => {
+                            gen.done.set(true);
                             drop(guard);
                             self.iterators.pop();
                             let frame = self.frames.last_mut().unwrap();
@@ -159,83 +248,53 @@ impl super::super::Vm {
                         }
                     }
                 }
-                super::super::IterState::Range {
-                    next,
-                    end,
-                    inclusive,
-                    done,
-                } => {
-                    if let Some(v) = range_next(next, *end, *inclusive, done) {
-                        self.stack.push(VmValue::Int(v));
-                    } else {
-                        self.iterators.pop();
-                        let frame = self.frames.last_mut().unwrap();
-                        frame.ip = target;
-                    }
-                }
-                super::super::IterState::Generator { gen } => {
-                    if gen.done.get() {
-                        self.iterators.pop();
-                        let frame = self.frames.last_mut().unwrap();
-                        frame.ip = target;
-                    } else {
-                        let rx = gen.receiver.clone();
-                        let mut guard = rx.lock().await;
-                        match guard.recv().await {
-                            Some(Ok(val)) => {
-                                self.stack.push(val);
-                            }
-                            Some(Err(error)) => {
-                                gen.done.set(true);
-                                drop(guard);
-                                self.iterators.pop();
-                                return Err(error);
-                            }
-                            None => {
-                                gen.done.set(true);
-                                drop(guard);
-                                self.iterators.pop();
-                                let frame = self.frames.last_mut().unwrap();
-                                frame.ip = target;
-                            }
+            }
+            Some(super::super::IterState::Stream { stream }) => {
+                if stream.done.get() {
+                    self.iterators.pop();
+                    let frame = self.frames.last_mut().unwrap();
+                    frame.ip = target;
+                } else {
+                    let rx = stream.receiver.clone();
+                    let mut guard = rx.lock().await;
+                    match guard.recv().await {
+                        Some(Ok(val)) => {
+                            self.stack.push(val);
+                        }
+                        Some(Err(error)) => {
+                            stream.done.set(true);
+                            drop(guard);
+                            self.iterators.pop();
+                            return Err(error);
+                        }
+                        None => {
+                            stream.done.set(true);
+                            drop(guard);
+                            self.iterators.pop();
+                            let frame = self.frames.last_mut().unwrap();
+                            frame.ip = target;
                         }
                     }
-                }
-                super::super::IterState::Stream { stream } => {
-                    if stream.done.get() {
-                        self.iterators.pop();
-                        let frame = self.frames.last_mut().unwrap();
-                        frame.ip = target;
-                    } else {
-                        let rx = stream.receiver.clone();
-                        let mut guard = rx.lock().await;
-                        match guard.recv().await {
-                            Some(Ok(val)) => {
-                                self.stack.push(val);
-                            }
-                            Some(Err(error)) => {
-                                stream.done.set(true);
-                                drop(guard);
-                                self.iterators.pop();
-                                return Err(error);
-                            }
-                            None => {
-                                stream.done.set(true);
-                                drop(guard);
-                                self.iterators.pop();
-                                let frame = self.frames.last_mut().unwrap();
-                                frame.ip = target;
-                            }
-                        }
-                    }
-                }
-                super::super::IterState::VmIter { .. } => {
-                    unreachable!("VmIter state handled before this match");
                 }
             }
-        } else {
-            let frame = self.frames.last_mut().unwrap();
-            frame.ip = target;
+            // VmIter was handled above; sync variants belong on the sync
+            // path; an empty iterator stack would have been routed to the
+            // sync path too. Reaching this branch means the sync/async
+            // classification in `execute_iter_next_sync` drifted from the
+            // arms above.
+            _ => {
+                debug_assert!(
+                    false,
+                    "execute_iter_next_async reached non-async iterator state — \
+                     dispatch tables in execute_iter_next_sync / execute_iter_next_async \
+                     are out of sync"
+                );
+                return Err(VmError::Runtime(
+                    "internal VM dispatch error: iter_next async slow path \
+                     reached a non-async iterator state"
+                        .into(),
+                ));
+            }
         }
         Ok(())
     }

--- a/crates/harn-vm/src/vm/ops/mod.rs
+++ b/crates/harn-vm/src/vm/ops/mod.rs
@@ -103,6 +103,11 @@ impl super::Vm {
                 Ok(())
             }
             Op::IterInit => self.execute_iter_init(),
+            // IterNext is a split opcode: the sync fast path handles
+            // Vec/Dict/Range/empty iterators inline; if it returns `None`
+            // we hand off to `execute_op_async` for Channel/Generator/
+            // Stream/VmIter without having touched `ip`.
+            Op::IterNext => return self.execute_iter_next_sync(),
             Op::Throw => self.execute_throw(),
             Op::TryCatchSetup => {
                 self.execute_try_catch_setup();
@@ -173,7 +178,6 @@ impl super::Vm {
             | Op::TailCall
             | Op::MethodCall
             | Op::MethodCallOpt
-            | Op::IterNext
             | Op::Pipe
             | Op::Parallel
             | Op::ParallelMap
@@ -200,7 +204,7 @@ impl super::Vm {
             Op::TailCall => self.execute_tail_call().await,
             Op::MethodCall => self.execute_method_call(false).await,
             Op::MethodCallOpt => self.execute_method_call(true).await,
-            Op::IterNext => self.execute_iter_next().await,
+            Op::IterNext => self.execute_iter_next_async().await,
             Op::Pipe => self.execute_pipe().await,
             Op::Parallel => self.execute_parallel().await,
             Op::ParallelMap => self.execute_parallel_map().await,


### PR DESCRIPTION
## Summary

- Apply the proven sync/async dispatch split from #2072 one level down,
  inside the `IterNext` opcode.
- Vec / Dict / Range iterators (the dominant for-in paths) now skip the
  async state machine entirely; only Channel / Generator / Stream /
  VmIter still suspend.
- `list_iteration` -11.2%, `dict_merge_loop` -5.3%, `dict_subscript_assign`
  -3.2% on min_ms; everything else stays inside a ±2.5% noise band.

## Why

`execute_iter_next` was an `async fn` even though only 4 of its 7
iterator variants actually `.await` anything. Every `for x in
range(...)` or `for x in list` iteration paid the full async future
state-machine cost — needlessly, since the inner loop runs millions of
times per program. The dispatcher's sync/async split (#2072) couldn't
route around it because `IterNext` itself was opaquely async.

## Design

- `execute_iter_next_sync(&mut self) -> Option<Result<(), VmError>>`
  peeks the active iterator variant **before** touching `ip`. Sync
  variants (Vec / Dict / Range / empty) flow through `Some(Ok(()))`;
  async variants return `None` without consuming bytecode so the async
  path reads the operand exactly once.
- `execute_iter_next_async(&mut self) -> Result<(), VmError>` retains
  the Channel / Generator / Stream / VmIter arms verbatim.
- Wired through the existing `execute_op_sync` / `execute_op_async`
  pair: `IterNext` now has its own sync arm that returns
  `execute_iter_next_sync()`, with the async dispatcher calling
  `execute_iter_next_async` on the `None` hand-off. Coverage drift is
  caught by a `debug_assert!` plus a release-mode `VmError::Runtime` in
  the async arm's catch-all, matching #2072's pattern.
- The previous `execute_iter_next` back-compat wrapper had no remaining
  callers after the dispatcher rewire (the slow path goes through
  `execute_op` which now classifies via `execute_op_sync` / `_async`
  directly), so it's removed.

## Benchmarks

Apple M5 Pro, 3 alternating baseline/optimized passes,
`bench_vm.sh --no-build --iterations 20`, min-of-min ms across passes:

| benchmark                  | base_min |  opt_min |  Δmin% |
|----------------------------|---------:|---------:|-------:|
| list_iteration             |     9.29 |     8.25 | -11.2% |
| dict_merge_loop            |    21.75 |    20.60 |  -5.3% |
| method_call_dispatch       |    34.19 |    32.40 |  -5.2% |
| dict_subscript_assign      |    10.03 |     9.71 |  -3.2% |
| arithmetic_loop            |    47.46 |    46.27 |  -2.5% |
| struct_field_read          |    42.01 |    41.37 |  -1.5% |
| function_call_loop         |    41.65 |    41.23 |  -1.0% |
| comparison_loop            |    70.83 |    70.34 |  -0.7% |
| agent_tool_dispatch        |    48.88 |    48.58 |  -0.6% |
| recursive_countdown        |    10.18 |    10.15 |  -0.3% |
| dict_property_read         |    37.53 |    37.54 |  +0.0% |
| local_variable_lookup      |    70.24 |    70.45 |  +0.3% |
| filter_nil_loop            |    28.07 |    28.22 |  +0.5% |
| list_map_filter            |   100.44 |   101.39 |  +0.9% |
| string_interpolation_loop  |     6.46 |     6.53 |  +1.1% |

The four iterator-heavy fixtures (list_iteration, dict_merge_loop,
dict_subscript_assign, plus incidentally method_call_dispatch through
shared code-layout effects in the same `harn_vm` rebuild) move >3%.
The other fixtures don't hit `IterNext` on their hot paths and stay
within a ±2.5% noise band. No regressions outside noise.

## Test plan

- [x] `cargo test -p harn-vm --lib` — 2384 passed, 0 failed
- [x] `cargo clippy -p harn-vm --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check -p harn-vm` — clean
- [x] `harn test conformance` — 1353 passed, 26 pre-existing infra
  failures (identical set on baseline binary; all require
  `target/debug/harn`, the mcp helper, or external spawn helpers not
  present in this worktree)
- [x] Microbenchmarks above
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)