### PR TITLE
Fix 10+ correctness and cleanup bugs across vm, parser, serve, hostlib

### DIFF
--- a/.githooks/lib.sh
+++ b/.githooks/lib.sh
@@ -170,6 +170,17 @@ hook_write_changed_cargo_packages() {
         crate=${crate%%/*}
         manifest="crates/$crate/Cargo.toml"
         if [ -f "$manifest" ]; then
+          # Skip crates listed in the workspace `exclude = [...]` line.
+          # `cargo check -p <name>` cannot target them, so gating the
+          # push on those crates produces a "did not match any packages"
+          # error. Match against the workspace's exclude line directly
+          # rather than parsing all the way to a `]` (the harn workspace
+          # writes it inline on a single line).
+          if [ -f "Cargo.toml" ] && \
+             grep -E '^exclude *= *\[' Cargo.toml \
+               | grep -Fq "\"crates/$crate\""; then
+            continue
+          fi
           package=$(awk -F '"' '/^name = / { print $2; exit }' "$manifest")
           [ -n "$package" ] && printf '%s\n' "$package" >> "$output"
         fi

--- a/conformance/tests/strings/string_methods.expected
+++ b/conformance/tests/strings/string_methods.expected
@@ -6,3 +6,7 @@
 [harn] true
 [harn] false
 [harn] el
+[harn] []
+[harn] [hello]
+[harn] []
+[harn] [hello world]

--- a/conformance/tests/strings/string_methods.harn
+++ b/conformance/tests/strings/string_methods.harn
@@ -7,4 +7,9 @@ pipeline test(task) {
   log("hello".ends_with("lo"))
   log("hello".ends_with("xy"))
   log("hello".substring(1, 3))
+  // Negative / out-of-range indices clamp to [0, len]; end < start yields "".
+  log("[" + "hello world".substring(0, -1) + "]")
+  log("[" + "hello world".substring(-3, 5) + "]")
+  log("[" + "hello world".substring(2, -3) + "]")
+  log("[" + "hello world".substring(0, 100) + "]")
 }

--- a/crates/harn-cli/src/commands/try_cmd.rs
+++ b/crates/harn-cli/src/commands/try_cmd.rs
@@ -1,9 +1,11 @@
 //! `harn try "<prompt>"` — minimal agent_loop convenience wrapper.
 //!
 //! Internally synthesizes a one-line Harn script and routes through the
-//! existing run pipeline. Once `with_retry` from `std/llm/handlers` lands
-//! (Task #5), the script can swap raw `llm_retries` for the composable
-//! caller; today we use the option directly.
+//! existing run pipeline. Uses the `llm_retries` agent_loop option
+//! directly because the synthesized script is meant to stay readable as
+//! a single line; users who want composable middleware should write a
+//! script with `with_retry(default_llm_caller(), {...})` from
+//! `std/llm/handlers` instead.
 
 use std::collections::HashSet;
 use std::fs;
@@ -24,11 +26,9 @@ pub(crate) async fn run(args: TryArgs) {
 
     let escaped = escape_for_harn_string(&args.prompt);
     let max_iters = args.max_iterations;
-    // TODO: switch to with_retry from std/llm/handlers once Task #5 lands.
-    // We deliberately omit a `tools` option here because the registered-tool
-    // contract requires schemas, not bare identifiers, and `harn try` is meant
-    // to be a zero-config smoke test. Users can drop into `harn run` for
-    // tool-augmented loops.
+    // No `tools` option: the registered-tool contract requires schemas,
+    // not bare identifiers, and `harn try` is meant to be a zero-config
+    // smoke test. Users can drop into `harn run` for tool-augmented loops.
     let script = format!(
         "let result = agent_loop(\"{escaped}\", nil, {{\n    max_iterations: {max_iters},\n    llm_retries: 2\n}})\nprintln(result.text)\n"
     );

--- a/crates/harn-cli/src/test_runner.rs
+++ b/crates/harn-cli/src/test_runner.rs
@@ -281,9 +281,9 @@ pub async fn run_tests(
         }
     }
 
-    let passed = all_results.iter().filter(|r| r.passed).count();
-    let failed = all_results.iter().filter(|r| !r.passed).count();
     let total = all_results.len();
+    let passed = all_results.iter().filter(|r| r.passed).count();
+    let failed = total - passed;
 
     TestSummary {
         results: all_results,

--- a/crates/harn-hostlib/src/code_index/walker.rs
+++ b/crates/harn-hostlib/src/code_index/walker.rs
@@ -153,10 +153,7 @@ pub(crate) fn is_sensitive(path: &Path) -> bool {
     if BASE_CONTAINS.iter().any(|s| base.contains(s)) {
         return true;
     }
-    let parts: Vec<&str> = lower.split('/').collect();
-    parts
-        .iter()
-        .any(|part| SENSITIVE_DIRS.contains(&part.to_string().as_str()))
+    lower.split('/').any(|part| SENSITIVE_DIRS.contains(&part))
 }
 
 const EXACT_SENSITIVE: &[&str] = &[

--- a/crates/harn-hostlib/src/tools/inspect_test_results.rs
+++ b/crates/harn-hostlib/src/tools/inspect_test_results.rs
@@ -18,10 +18,9 @@ use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Mutex;
+use std::sync::{LazyLock, Mutex};
 
 use harn_vm::VmValue;
-use once_cell::sync::Lazy;
 
 use crate::error::HostlibError;
 use crate::tools::payload::{optional_bool, require_dict_arg, require_string};
@@ -109,7 +108,7 @@ struct HandleStore {
     entries: BTreeMap<String, RawArtifacts>,
 }
 
-static STORE: Lazy<Mutex<HandleStore>> = Lazy::new(|| Mutex::new(HandleStore::default()));
+static STORE: LazyLock<Mutex<HandleStore>> = LazyLock::new(|| Mutex::new(HandleStore::default()));
 static HANDLE_COUNTER: AtomicU64 = AtomicU64::new(1);
 
 /// Cache `artifacts` and return the opaque `result_handle` for them.

--- a/crates/harn-parser/src/diagnostic.rs
+++ b/crates/harn-parser/src/diagnostic.rs
@@ -342,8 +342,8 @@ fn render_diagnostic_inner(input: RenderDiagnostic<'_>) -> String {
         width = gutter_width + 1,
     ));
 
-    let source_line_opt = source.lines().nth(line_num.wrapping_sub(1));
-    if let Some(source_line) = source_line_opt.filter(|_| line_num > 0) {
+    let source_line_opt = line_num.checked_sub(1).and_then(|n| source.lines().nth(n));
+    if let Some(source_line) = source_line_opt {
         out.push_str(&format!(
             "{:>width$} {gutter} {source_line}\n",
             line_num,
@@ -522,11 +522,7 @@ fn render_related_span(
         width = gutter_width + 1,
     ));
 
-    if let Some(source_line) = source
-        .lines()
-        .nth(line_num.wrapping_sub(1))
-        .filter(|_| line_num > 0)
-    {
+    if let Some(source_line) = line_num.checked_sub(1).and_then(|n| source.lines().nth(n)) {
         out.push_str(&format!(
             "{:>width$} {gutter} {source_line}\n",
             line_num,

--- a/crates/harn-serve/src/adapters/api.rs
+++ b/crates/harn-serve/src/adapters/api.rs
@@ -1264,12 +1264,13 @@ async fn truncate_session(
             messages.truncate(keep_first);
         }
         let canceled_task_id = inner.active_task_by_session.remove(&session_id);
+        let now = now_rfc3339();
         let canceled_task = canceled_task_id.and_then(|task_id| {
             let task = inner.tasks.get_mut(&task_id)?;
             if task.get("status").and_then(Value::as_str) != Some("CANCELED") {
                 task["status"] = json!("CANCELED");
-                task["updated_at"] = json!(now_rfc3339());
-                task["canceled_at"] = json!(now_rfc3339());
+                task["updated_at"] = json!(&now);
+                task["canceled_at"] = json!(&now);
             }
             Some((task_id, task.clone()))
         });
@@ -1279,7 +1280,7 @@ async fn truncate_session(
         if session.get("state").and_then(Value::as_str) != Some("CLOSED") {
             session["state"] = json!("IDLE");
         }
-        session["updated_at"] = json!(now_rfc3339());
+        session["updated_at"] = json!(now);
         (session.clone(), canceled_task)
     };
     if let Some((task_id, task)) = canceled_task {
@@ -1546,10 +1547,11 @@ async fn submit_task_inner(
             let mut inner = task_state.inner.lock().expect("api state poisoned");
             if let Some(task) = inner.tasks.get_mut(&task_id) {
                 if task.get("status").and_then(Value::as_str) != Some("CANCELED") {
+                    let now = now_rfc3339();
                     task["status"] = json!(status);
-                    task["updated_at"] = json!(now_rfc3339());
+                    task["updated_at"] = json!(&now);
                     if status == "COMPLETED" {
-                        task["completed_at"] = json!(now_rfc3339());
+                        task["completed_at"] = json!(now);
                         task["outcome_id"] = json!(format!("outcome_{task_id}"));
                     } else {
                         task["failure"] = json!({
@@ -1633,9 +1635,10 @@ async fn cancel_task(
                 .and_then(Value::as_str)
                 .unwrap_or_default()
                 .to_string();
+            let now = now_rfc3339();
             task["status"] = json!("CANCELED");
-            task["updated_at"] = json!(now_rfc3339());
-            task["canceled_at"] = json!(now_rfc3339());
+            task["updated_at"] = json!(&now);
+            task["canceled_at"] = json!(now);
             (session_id, task.clone())
         };
         inner.active_task_by_session.remove(&session_id);

--- a/crates/harn-vm/src/llm/tool_search_score.rs
+++ b/crates/harn-vm/src/llm/tool_search_score.rs
@@ -233,20 +233,13 @@ fn score_regex(pattern: &str, candidates: &[Candidate], max_results: usize) -> V
 }
 
 fn score_hybrid(query: &str, candidates: &[Candidate], max_results: usize) -> Vec<RankedTool> {
-    let field = score_field_weighted(
-        query,
-        candidates,
-        max_results.saturating_mul(4).max(max_results),
-    );
-    let lists = vec![
-        score_bm25(
-            query,
-            candidates,
-            max_results.saturating_mul(4).max(max_results),
-        ),
-        field.clone(),
-        field,
-    ];
+    // Pull 4x the requested fan-out from each ranker so the fusion has
+    // room to reorder beyond the top-N from any single list.
+    let pool = max_results.saturating_mul(4);
+    let field = score_field_weighted(query, candidates, pool);
+    // Field-weighted ranking is included twice to bias the fused order
+    // toward exact-name/path matches over BM25's bag-of-tokens score.
+    let lists = vec![score_bm25(query, candidates, pool), field.clone(), field];
     reciprocal_rank_fuse(lists, candidates, max_results)
 }
 

--- a/crates/harn-vm/src/skills/source.rs
+++ b/crates/harn-vm/src/skills/source.rs
@@ -488,7 +488,7 @@ pub fn skill_entry_to_vm(skill: &Skill) -> crate::value::VmValue {
     if let Some(dir) = &skill.skill_dir {
         entry.insert(
             "skill_dir".to_string(),
-            VmValue::String(Rc::from(dir.display().to_string().as_str())),
+            VmValue::String(Rc::from(dir.display().to_string())),
         );
     }
     entry.insert(

--- a/crates/harn-vm/src/stdlib/process.rs
+++ b/crates/harn-vm/src/stdlib/process.rs
@@ -357,15 +357,11 @@ fn vm_output_to_value(output: std::process::Output) -> VmValue {
     let mut result = BTreeMap::new();
     result.insert(
         "stdout".to_string(),
-        VmValue::String(Rc::from(
-            String::from_utf8_lossy(&output.stdout).to_string().as_str(),
-        )),
+        VmValue::String(Rc::from(String::from_utf8_lossy(&output.stdout).as_ref())),
     );
     result.insert(
         "stderr".to_string(),
-        VmValue::String(Rc::from(
-            String::from_utf8_lossy(&output.stderr).to_string().as_str(),
-        )),
+        VmValue::String(Rc::from(String::from_utf8_lossy(&output.stderr).as_ref())),
     );
     result.insert(
         "status".to_string(),

--- a/crates/harn-vm/src/vm/iter.rs
+++ b/crates/harn-vm/src/vm/iter.rs
@@ -254,7 +254,9 @@ impl VmIter {
                 let rest = &s[*byte_idx..];
                 if let Some(c) = rest.chars().next() {
                     *byte_idx += c.len_utf8();
-                    Ok(Some(VmValue::String(Rc::from(c.to_string().as_str()))))
+                    let mut buf = [0u8; 4];
+                    let encoded = c.encode_utf8(&mut buf);
+                    Ok(Some(VmValue::String(Rc::from(&*encoded))))
                 } else {
                     *self = VmIter::Exhausted;
                     Ok(None)

--- a/crates/harn-vm/src/vm/methods/string.rs
+++ b/crates/harn-vm/src/vm/methods/string.rs
@@ -36,10 +36,11 @@ impl crate::vm::Vm {
             "lowercase" => Ok(VmValue::String(Rc::from(s.to_lowercase()))),
             "uppercase" => Ok(VmValue::String(Rc::from(s.to_uppercase()))),
             "substring" => {
-                let start = args.first().and_then(|a| a.as_int()).unwrap_or(0);
                 let len = s.chars().count() as i64;
-                let start = start.max(0).min(len) as usize;
-                let end = args.get(1).and_then(|a| a.as_int()).unwrap_or(len).min(len) as usize;
+                let start = args.first().and_then(|a| a.as_int()).unwrap_or(0);
+                let end = args.get(1).and_then(|a| a.as_int()).unwrap_or(len);
+                let start = start.clamp(0, len) as usize;
+                let end = end.clamp(0, len) as usize;
                 let end = end.max(start);
                 let substr: String = s.chars().skip(start).take(end - start).collect();
                 Ok(VmValue::String(Rc::from(substr)))
@@ -105,8 +106,8 @@ impl crate::vm::Vm {
                     .map(|byte_pos| s[..byte_pos].chars().count() as i64);
                 Ok(VmValue::Int(idx.unwrap_or(-1)))
             }
-            "lower" | "to_lower" => Ok(VmValue::String(Rc::from(s.to_lowercase().as_str()))),
-            "upper" | "to_upper" => Ok(VmValue::String(Rc::from(s.to_uppercase().as_str()))),
+            "lower" | "to_lower" => Ok(VmValue::String(Rc::from(s.to_lowercase()))),
+            "upper" | "to_upper" => Ok(VmValue::String(Rc::from(s.to_uppercase()))),
             "len" => Ok(VmValue::Int(s.chars().count() as i64)),
             _ => Err(VmError::Runtime(format!("string has no method `{method}`"))),
         }

--- a/crates/harn-wasm/src/lib.rs
+++ b/crates/harn-wasm/src/lib.rs
@@ -62,7 +62,7 @@ pub fn execute_pure_component(source: &str) -> Result<String, JsError> {
 pub fn tokenize(source: &str) -> Result<String, JsError> {
     let mut lexer = Lexer::new(source);
     let tokens = lexer.tokenize().map_err(|e| JsError::new(&e.to_string()))?;
-    let token_strs: Vec<String> = tokens.iter().map(|t| format!("{}", t.kind)).collect();
+    let token_strs: Vec<String> = tokens.iter().map(|t| t.kind.to_string()).collect();
     Ok(serde_json::to_string(&token_strs).unwrap_or_default())
 }
 


### PR DESCRIPTION
## Summary

Behaviour-changing fixes:

- **`String.substring(start, end)`** returns the entire string when `end`
  is negative because the `i64 → usize` cast wraps to a huge value instead
  of clamping. Clamp `end` the same way `start` already was, add
  conformance coverage for negative / reversed / out-of-range bounds.
  ([`crates/harn-vm/src/vm/methods/string.rs`](crates/harn-vm/src/vm/methods/string.rs))
- **`harn-parser` diagnostic rendering** previously rendered no source
  line for `line_num == 0` but only after a full O(n) `lines().nth(usize::MAX)`
  scan from `wrapping_sub(1)`. Switch to `checked_sub` so we skip the
  iteration entirely on the missing-line path. Two call sites.
  ([`crates/harn-parser/src/diagnostic.rs`](crates/harn-parser/src/diagnostic.rs))
- **`harn-serve` API** wrote timestamp pairs (`updated_at` / `canceled_at`
  / `completed_at`) as two separate `now_rfc3339()` calls so the two
  fields could disagree by a nanosecond and break downstream ordering
  invariants. Compute once, reuse.
  ([`crates/harn-serve/src/adapters/api.rs`](crates/harn-serve/src/adapters/api.rs))
- **Pre-push hook** crashed when a worktree-excluded crate
  (`crates/harn-wasm`) was touched: `cargo check -p harn-wasm` always
  errors "did not match any packages." Skip crates listed in the
  workspace `exclude = [...]` line.
  ([`.githooks/lib.sh`](.githooks/lib.sh))

DRY / cleanup pass on the same touched files (matching the "find 10
bugs + improve code quality" framing of the task):

- Drop `to_string().as_str()` round-trips in `process`, `walker`,
  `skills/source`, `vm/methods/string`, `vm/iter` — `Rc::from(String)`
  and a stack `encode_utf8` buffer are direct.
- `harn-cli/test_runner` iterated the results vec twice to count
  pass/fail; derive `failed = total - passed` instead.
- `harn-hostlib/inspect_test_results` swap `once_cell::sync::Lazy` for
  the std `LazyLock` (Rust 1.95 toolchain has it).
- `harn-cli/try_cmd` had a stale `TODO` pointing at "Task #5" /
  `with_retry`, which already ships in `std/llm/handlers`; refresh the
  comment to describe the current design.
- `harn-vm/llm/tool_search_score::score_hybrid` had
  `.saturating_mul(4).max(max_results)` (redundant, since `4·x ≥ x`);
  pull the pool size into a named local and explain the double-weighting
  of the field ranker vs BM25.

## Test plan

- [x] `cargo test -p harn-vm --lib` (2384 pass)
- [x] `cargo test -p harn-parser --lib` (331 pass)
- [x] `cargo test -p harn-cli --lib` (650 pass)
- [x] `cargo test -p harn-hostlib --lib` (165 pass)
- [x] `harn test conformance --filter string_methods` (2/2 pass with
      new cases for negative / out-of-range substring bounds)
- [x] `cargo clippy -p harn-vm -p harn-cli -p harn-hostlib -p harn-parser
      -p harn-serve` (clean)
- [x] `cargo fmt --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)