### PR TITLE
Use harness fs glob in stdlib helper

### DIFF
--- a/crates/harn-stdlib/src/stdlib/stdlib_fs.harn
+++ b/crates/harn-stdlib/src/stdlib/stdlib_fs.harn
@@ -236,7 +236,7 @@ pub fn touch(path: string) {
  * @example: find_files(root, pattern, options)
  */
 pub fn find_files(root: string, pattern: string, options = {}) -> list<string> {
-  let matches = glob(pattern, {base: root, long_running: options?.long_running ?? false})
+  let matches = harness.fs.glob(pattern, {base: root, long_running: options?.long_running ?? false})
   if options?.relative ?? false {
     return matches.map({ path -> relative_path(root, path) }).to_list()
   }


### PR DESCRIPTION
## Summary
- route std/fs find_files through harness.fs.glob instead of the deprecated ambient glob builtin
- remove the last HARN-LNT-052..057 diagnostic from the stdlib ambient capability audit

## Verification
- CARGO_TARGET_DIR=/tmp/harn-target-stdlib-glob make fmt-harn
- CARGO_TARGET_DIR=/tmp/harn-target-stdlib-glob make lint-harn
- CARGO_TARGET_DIR=/tmp/harn-target-stdlib-glob cargo run --quiet --bin harn -- lint crates/harn-stdlib/src/stdlib/stdlib_fs.harn
- CARGO_TARGET_DIR=/tmp/harn-target-stdlib-glob cargo run --quiet --bin harn -- lint --json crates/harn-stdlib/src/stdlib | rg 'HARN-LNT-05[2-7]' -c || true
- CARGO_TARGET_DIR=/tmp/harn-target-stdlib-glob cargo run --quiet --bin harn -- lint --json experiments/burin-mini | rg 'HARN-LNT-05[2-7]' -c || true
- git diff --check