### PR TITLE
Fix scheduled CI filter and skill frontmatter portability

### DIFF
--- a/crates/harn-skills/src/lib.rs
+++ b/crates/harn-skills/src/lib.rs
@@ -259,12 +259,7 @@ fn parse_disk_skill(path: &Path) -> Result<DiskSkill, SkillDiscoveryError> {
 }
 
 fn split_disk_frontmatter(source: &str) -> Option<(&str, &str)> {
-    let after_open = source.strip_prefix("---\n")?;
-    let close_offset = after_open.find("\n---\n")?;
-    Some((
-        &after_open[..close_offset],
-        &after_open[close_offset + "\n---\n".len()..],
-    ))
+    split_frontmatter_parts(source)
 }
 
 fn parse_disk_frontmatter(
@@ -310,16 +305,40 @@ fn require_disk_field(
 }
 
 fn split_frontmatter(source: &'static str) -> (&'static str, &'static str) {
-    let Some(after_open) = source.strip_prefix("---\n") else {
+    let Some((after_open, line_ending)) = split_opening_frontmatter(source) else {
         panic!("embedded skill source is missing opening frontmatter delimiter");
     };
-    let Some(close_offset) = after_open.find("\n---\n") else {
+    let Some((frontmatter, body)) = split_closing_frontmatter(after_open, line_ending) else {
         panic!("embedded skill source is missing closing frontmatter delimiter");
     };
-    (
+    (frontmatter, body)
+}
+
+fn split_frontmatter_parts(source: &str) -> Option<(&str, &str)> {
+    let (after_open, line_ending) = split_opening_frontmatter(source)?;
+    split_closing_frontmatter(after_open, line_ending)
+}
+
+fn split_opening_frontmatter(source: &str) -> Option<(&str, &str)> {
+    if let Some(after_open) = source.strip_prefix("---\n") {
+        Some((after_open, "\n"))
+    } else if let Some(after_open) = source.strip_prefix("---\r\n") {
+        Some((after_open, "\r\n"))
+    } else {
+        None
+    }
+}
+
+fn split_closing_frontmatter<'a>(
+    after_open: &'a str,
+    line_ending: &str,
+) -> Option<(&'a str, &'a str)> {
+    let close = format!("{line_ending}---{line_ending}");
+    let close_offset = after_open.find(&close)?;
+    Some((
         &after_open[..close_offset],
-        &after_open[close_offset + "\n---\n".len()..],
-    )
+        &after_open[close_offset + close.len()..],
+    ))
 }
 
 fn parse_frontmatter(frontmatter: &'static str) -> SkillFrontmatter {
@@ -416,7 +435,7 @@ mod tests {
     fn source_round_trips_to_frontmatter_and_body() {
         for skill in list_embedded_skills() {
             assert!(
-                skill.source.starts_with("---\n"),
+                split_frontmatter_parts(skill.source).is_some(),
                 "{} source missing opening fence",
                 skill.name
             );
@@ -431,6 +450,19 @@ mod tests {
                 skill.name
             );
         }
+    }
+
+    #[test]
+    fn frontmatter_split_accepts_crlf_sources() {
+        let source = "---\r\nname: crlf\r\n---\r\n# Body\r\n";
+        let (frontmatter, body) = split_frontmatter_parts(source).expect("CRLF frontmatter");
+        assert_eq!(frontmatter, "name: crlf");
+        assert_eq!(body, "# Body\r\n");
+    }
+
+    #[test]
+    fn frontmatter_split_rejects_missing_closing_fence() {
+        assert!(split_frontmatter_parts("---\nname: missing\n# Body\n").is_none());
     }
 
     #[test]

--- a/scripts/nextest_filters_from_paths.sh
+++ b/scripts/nextest_filters_from_paths.sh
@@ -21,8 +21,12 @@
 #     or shared helpers (e.g. support/, test_util/) — check for the
 #     sibling .rs entry to tell them apart.
 #
-#   crates/<pkg>/...                      → package(<pkg>)
+#   crates/<pkg>/...                      → package(<workspace package name>)
 #     Unit tests in src/ or any other crate-local change.
+#
+#   crates/<pkg>/... for workspace-excluded crates is ignored. Those
+#     packages are not discoverable by `cargo nextest run --workspace`,
+#     so including them would make nextest reject the whole filterset.
 #
 # Designed to be called from the flake-detection CI workflow.
 
@@ -35,7 +39,61 @@ fi
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 declare -A seen
+declare -A workspace_packages
 filters=()
+
+load_workspace_packages() {
+    if ! command -v python3 >/dev/null 2>&1; then
+        return 0
+    fi
+
+    while IFS=$'\t' read -r member package; do
+        [[ -z "$member" || -z "$package" ]] && continue
+        workspace_packages["$member"]="$package"
+    done < <(python3 - "$repo_root" <<'PY'
+import fnmatch
+import pathlib
+import sys
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    sys.exit(0)
+
+root = pathlib.Path(sys.argv[1])
+with (root / "Cargo.toml").open("rb") as handle:
+    workspace = tomllib.load(handle).get("workspace", {})
+
+members = workspace.get("members", [])
+excludes = workspace.get("exclude", [])
+
+def is_excluded(relative_path: str) -> bool:
+    return any(fnmatch.fnmatch(relative_path, pattern) for pattern in excludes)
+
+for pattern in members:
+    matches = sorted(root.glob(pattern))
+    if not matches and "*" not in pattern:
+        matches = [root / pattern]
+    for member_path in matches:
+        manifest = member_path / "Cargo.toml"
+        if not manifest.is_file():
+            continue
+        relative = member_path.relative_to(root).as_posix()
+        if is_excluded(relative):
+            continue
+        with manifest.open("rb") as handle:
+            package = tomllib.load(handle).get("package", {})
+        name = package.get("name")
+        if name:
+            print(f"{relative}\t{name}")
+PY
+    )
+}
+
+workspace_package_for_crate_dir() {
+    local crate_dir="$1"
+    printf '%s' "${workspace_packages[$crate_dir]-}"
+}
 
 add_filter() {
     local f="$1"
@@ -45,6 +103,8 @@ add_filter() {
     fi
 }
 
+load_workspace_packages
+
 for path in "$@"; do
     # Strip leading ./ and skip blank entries.
     path="${path#./}"
@@ -52,15 +112,19 @@ for path in "$@"; do
 
     # crates/<pkg>/tests/<name>.rs — top-level integration test binary.
     if [[ "$path" =~ ^crates/([^/]+)/tests/([^/]+)\.rs$ ]]; then
+        pkg="$(workspace_package_for_crate_dir "crates/${BASH_REMATCH[1]}")"
+        [[ -z "$pkg" ]] && continue
         add_filter "binary(${BASH_REMATCH[2]})"
         continue
     fi
 
     # crates/<pkg>/tests/<dir>/... — module file or shared support directory.
     if [[ "$path" =~ ^crates/([^/]+)/tests/([^/]+)/ ]]; then
-        pkg="${BASH_REMATCH[1]}"
+        crate_dir="${BASH_REMATCH[1]}"
         dir="${BASH_REMATCH[2]}"
-        if [[ -f "${repo_root}/crates/${pkg}/tests/${dir}.rs" ]]; then
+        pkg="$(workspace_package_for_crate_dir "crates/${crate_dir}")"
+        [[ -z "$pkg" ]] && continue
+        if [[ -f "${repo_root}/crates/${crate_dir}/tests/${dir}.rs" ]]; then
             add_filter "binary(${dir})"
         else
             add_filter "package(${pkg})"
@@ -70,7 +134,9 @@ for path in "$@"; do
 
     # crates/<pkg>/... — unit tests in src/ or any other package file.
     if [[ "$path" =~ ^crates/([^/]+)/ ]]; then
-        add_filter "package(${BASH_REMATCH[1]})"
+        pkg="$(workspace_package_for_crate_dir "crates/${BASH_REMATCH[1]}")"
+        [[ -z "$pkg" ]] && continue
+        add_filter "package(${pkg})"
         continue
     fi
 done

--- a/scripts/release_smoke.sh
+++ b/scripts/release_smoke.sh
@@ -175,7 +175,7 @@ smoke_provider_matrix() {
 smoke_watch_boot() {
   local watch_log="$TMP_ROOT/watch.log"
   local watch_target="$TMP_ROOT/watch_target.harn"
-  printf 'pipeline default() {\n  println("watch boot")\n}\n' >"$watch_target"
+  printf 'fn main(harness: Harness) {\n  harness.stdio.println("watch boot")\n}\n' >"$watch_target"
   "$HARN" watch "$watch_target" >"$watch_log" 2>&1 &
   local watch_pid=$!
   # 30 iterations × 0.5 s = 15 s timeout. Generous on a cold runner


### PR DESCRIPTION
## Summary
- accept CRLF frontmatter delimiters when parsing embedded and disk Harn skills, preserving the original dumped source bytes
- derive flake-detection nextest package filters from actual Cargo workspace members
- skip workspace-excluded crate paths such as `crates/harn-wasm` so `cargo nextest run --workspace -E ...` receives a valid filterset

## Root cause
- Windows nightly checked out embedded `SKILL.md` files with CRLF line endings, but `harn-skills` required exact `---\n` delimiters.
- Flake detection diffed `crates/**/*.rs`, including `crates/harn-wasm`, even though `harn-wasm` is excluded from the Cargo workspace. That generated `package(harn-wasm)`, which nextest rejected before running any tests.

## Verification
- `cargo fmt --check`
- `cargo test -p harn-skills`
- `cargo nextest run -p harn-skills --profile flake-detection`
- `bash -n scripts/nextest_filters_from_paths.sh`
- `./scripts/nextest_filters_from_paths.sh crates/harn-wasm/src/lib.rs crates/harn-skills/src/lib.rs crates/harn-cli/tests/run_exit_codes.rs`
- `FILTER=$(./scripts/nextest_filters_from_paths.sh crates/harn-wasm/src/lib.rs crates/harn-skills/src/lib.rs); cargo nextest list --workspace -E "$FILTER"`
- pre-commit hook: `cargo clippy --workspace --all-targets -- -D warnings`
- pre-push hook: targeted touched Rust checks
