### PR TITLE
perf(vm): split Op::Call into sync/async halves

### DIFF
--- a/crates/harn-vm/src/vm/ops/call.rs
+++ b/crates/harn-vm/src/vm/ops/call.rs
@@ -580,7 +580,55 @@ impl super::super::Vm {
         Ok(())
     }
 
-    pub(super) async fn execute_call(&mut self) -> Result<(), VmError> {
+    /// Sync fast path for `Op::Call`. Peeks the callee on the stack
+    /// **before** touching `ip`; if it's a non-generator user closure with
+    /// no `@step` definition attached, it pushes the closure frame inline
+    /// and returns `Some(Ok(()))`. Otherwise returns `None` without
+    /// advancing the frame, so the caller falls through to
+    /// [`execute_call_async`] which reads the operand exactly once.
+    ///
+    /// Note: in the current compiler, user-level `f(x)` calls compile to
+    /// `Op::CallBuiltin` (name-resolved at runtime), not `Op::Call`. The
+    /// `Op::Call` opcode is emitted only for compiler-internal lowerings
+    /// (`__assert_list` for spread args, `to_string` for string
+    /// interpolation, etc.) where the callee is a `VmValue::String`. Those
+    /// take the `None` fall-through and stay on the async path. The split
+    /// is therefore a no-op on the user-closure case in current bench
+    /// fixtures; it parallels the IterNext split (#2074) so that any
+    /// future `Op::Call`-with-closure-callee emissions benefit
+    /// automatically, and keeps the dispatch tables symmetric with the
+    /// rest of the call family. The measurable wins from this idea live
+    /// behind `Op::CallBuiltin` (where `f(x)` actually dispatches) and
+    /// are filed as a separate follow-up PR per the task's
+    /// "one-shippable-change-per-PR" guidance.
+    pub(super) fn execute_call_sync(&mut self) -> Option<Result<(), VmError>> {
+        let frame = self.frames.last().unwrap();
+        let argc = frame.chunk.code[frame.ip] as usize;
+        let callee_idx = self.stack.len().checked_sub(argc + 1)?;
+        let closure = match self.stack.get(callee_idx)? {
+            VmValue::Closure(c) => c,
+            _ => return None,
+        };
+        if closure.func.is_generator {
+            return None;
+        }
+        if crate::step_runtime::step_definition_for_function(&closure.func.name).is_some() {
+            return None;
+        }
+
+        let closure = Rc::clone(closure);
+        let frame = self.frames.last_mut().unwrap();
+        frame.ip += 1;
+        let args: Vec<VmValue> = self.stack.split_off(self.stack.len() - argc);
+        let _ = self.stack.pop();
+        Some(self.push_closure_frame(&closure, &args))
+    }
+
+    /// Async slow path for `Op::Call`. Identical in behavior to the
+    /// pre-split `execute_call`. The caller (`execute_op_async`) reaches
+    /// this only after [`execute_call_sync`] returned `None` without
+    /// touching `ip`, so this path reads the argc operand exactly once.
+    pub(super) async fn execute_call_async(&mut self) -> Result<(), VmError> {
         let frame = self.frames.last_mut().unwrap();
         let argc = frame.chunk.code[frame.ip] as usize;
         frame.ip += 1;

--- a/crates/harn-vm/src/vm/ops/mod.rs
+++ b/crates/harn-vm/src/vm/ops/mod.rs
@@ -108,6 +108,12 @@ impl super::Vm {
             // we hand off to `execute_op_async` for Channel/Generator/
             // Stream/VmIter without having touched `ip`.
             Op::IterNext => return self.execute_iter_next_sync(),
+            // Call is split: the sync fast path handles non-generator
+            // user closures with no `@step` definition attached. Other
+            // callee variants (string, builtin ref, etc.) return `None`
+            // and fall through to `execute_call_async` without touching
+            // `ip`.
+            Op::Call => return self.execute_call_sync(),
             Op::Throw => self.execute_throw(),
             Op::TryCatchSetup => {
                 self.execute_try_catch_setup();
@@ -172,8 +178,7 @@ impl super::Vm {
             // `execute_op_async`. Keeping these in a single explicit arm
             // keeps the sync/async classification visible alongside the
             // sync dispatch table.
-            Op::Call
-            | Op::CallBuiltin
+            Op::CallBuiltin
             | Op::CallBuiltinSpread
             | Op::TailCall
             | Op::MethodCall
@@ -198,7 +203,7 @@ impl super::Vm {
     /// catch-all is a coverage bug between the two dispatch tables.
     pub(super) async fn execute_op_async(&mut self, op: Op) -> Result<(), VmError> {
         match op {
-            Op::Call => self.execute_call().await,
+            Op::Call => self.execute_call_async().await,
             Op::CallBuiltin => self.execute_call_builtin().await,
             Op::CallBuiltinSpread => self.execute_call_builtin_spread().await,
             Op::TailCall => self.execute_tail_call().await,


### PR DESCRIPTION
## Summary

Apply the proven sync/async dispatch split from #2072 and #2074 to the `Op::Call` opcode, mirroring the IterNext split (#2074) one level deeper in the call family.

- `execute_call_sync(&mut self) -> Option<Result<(), VmError>>` peeks the callee on the stack **before** touching `ip`; when it's a non-generator user closure with no `@step` definition attached, it pushes the closure frame inline. Other callee variants (string, builtin ref, builtin ref by id) return `None` without advancing the frame.
- `execute_call_async(&mut self) -> Result<(), VmError>` retains the previous `execute_call` body verbatim.
- Wired through `execute_op_sync` / `execute_op_async`: `Op::Call` now has its own sync arm returning `execute_call_sync()`, with the async dispatcher calling `execute_call_async` on the `None` hand-off. Coverage parity over `Op` variants is preserved.

## Honest perf summary

This split is a **no-op on current bench fixtures.** I confirmed this directly: an instrumented build counting fast-path entries on `function_call_loop.harn` reported **0 hits and 0 fallbacks** — the bench fixtures simply don't dispatch any `Op::Call` instructions.

The reason: in the current compiler, user-level `f(x)` calls compile to **`Op::CallBuiltin`** (name-resolved at runtime), not `Op::Call`. `Op::Call` itself is emitted only for compiler-internal lowerings (`__assert_list` for spread args, `to_string` for string interpolation, etc.) where the callee is a `VmValue::String` — which takes the `None` fall-through and stays on the async path. The task description's expectation that `function_call_loop`'s `step(value)` hits `Op::Call` was inverted: `step(value)` compiles to `emit_named_call`, which emits `Op::CallBuiltin` ([`compiler/expressions.rs:211`](https://github.com/burin-labs/harn/blob/main/crates/harn-vm/src/compiler/expressions.rs#L211)).

Best-of-three min_ms across 3 alternating baseline/optimized passes (`scripts/bench_vm.sh --no-build --iterations 20`):

| benchmark                  | base_min |  opt_min |  Δmin% |
|----------------------------|---------:|---------:|-------:|
| recursive_countdown        |    10.92 |     9.95 |  -8.9% |
| method_call_dispatch       |    34.70 |    32.00 |  -7.8% |
| string_interpolation_loop  |     7.04 |     6.53 |  -7.2% |
| struct_field_read          |    45.76 |    43.16 |  -5.7% |
| local_variable_lookup      |    77.22 |    72.88 |  -5.6% |
| list_map_filter            |   105.43 |   101.06 |  -4.1% |
| dict_subscript_assign      |    10.11 |     9.71 |  -4.0% |
| filter_nil_loop            |    29.12 |    28.23 |  -3.1% |
| comparison_loop            |    72.11 |    69.96 |  -3.0% |
| dict_merge_loop            |    20.71 |    20.66 |  -0.2% |
| arithmetic_loop            |    48.20 |    48.51 |  +0.6% |
| function_call_loop         |    42.69 |    43.16 |  +1.1% |
| dict_property_read         |    38.20 |    39.15 |  +2.5% |
| list_iteration             |     8.55 |     8.78 |  +2.7% |
| agent_tool_dispatch        |    47.40 |    50.98 |  +7.6% |

**All of these swings are code-layout noise from the harn-vm rebuild,** not real movements caused by this diff. Per the original task's noise-band guidance ("5-10% min_ms shifts on tight loop fixtures = noise, not a win"), neither the apparent wins on fixtures that don't emit `Op::Call` (e.g., `recursive_countdown` uses `Op::TailCall`, `method_call_dispatch` uses `Op::MethodCall`) nor the apparent losses (`agent_tool_dispatch` +7.6%) are caused by the new fast path firing.

## Why ship it then?

The split is structurally aligned with #2072 / #2074, keeps the dispatch tables symmetric across the call family (`Op::Call` → sync arm parallels `Op::IterNext` → sync arm), and sets up the pattern so any future `Op::Call`-with-closure-callee emissions benefit automatically without re-touching the dispatcher.

## Where the actual wins live (follow-up PR)

The measurable wins from this idea live behind **`Op::CallBuiltin`** — which is what `f(x)` actually dispatches through. That path is five async state machines deep (`execute_call_builtin → call_named_value → try_call_special_name → resolve_named_closure → call_user_closure → run_step_pre_hooks`), all of which return synchronously in the steady state for an untracked user closure. The task description already lists this as a stretch goal to file as a **separate follow-up PR** per the "one-shippable-change-per-PR" discipline; I'll open it next.

## Test plan

- [x] Pre-commit hooks: `cargo fmt`, clippy, markdown lint, actionlint, portal lint — all passed (clean / skipped where unchanged).
- [x] Pre-push hooks: targeted package checks, generated-file drift, Harn fmt/lint — all passed (clean / skipped where unchanged).
- [x] Microbenchmarks above; called out the noise band explicitly.
- [x] Coverage parity: both `execute_op_sync` and `execute_op_async` match arms remain exhaustive over `Op`.
- [x] No banned test patterns introduced (no test files touched).
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)