### PR TITLE
Add connector HTTP policy helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ condensed series summaries instead of full per-patch history.
 
 ### Added
 
+- **Connector-safe HTTP policy helpers (#2082).** `std/connectors/shared` now
+  exposes `connector_http_request`, `connector_http_json`,
+  `connector_http_header`, and `connector_http_rate_limit` so Harn package
+  authors can wrap `harness.net.request` with stable error envelopes,
+  idempotency-aware unsafe write retries, capped `Retry-After` handling, JSON
+  parse categorization, and standard rate-limit header extraction without
+  hand-rolling provider loops.
 - **`harness.net.*` access policy (#1913).** Adds the `std/net_policy`
   stdlib module so scripts can attach a per-harness allow/deny policy
   to `harness.net.*` requests: `NetPolicy.create({allow, deny,

--- a/conformance/tests/stdlib/connectors_http_policy.expected
+++ b/conformance/tests/stdlib/connectors_http_policy.expected
@@ -1,0 +1,9 @@
+get_retry:200:2
+post_no_idem:overloaded:1
+post_idem:201:2:idem-1
+preserve_idem:caller-key
+retry_after_cap:5000:1
+invalid_json:invalid_json:example
+empty_json:204:true
+rate_limit:2000:100:0:3000
+redacted:example:list:500:true

--- a/conformance/tests/stdlib/connectors_http_policy.harn
+++ b/conformance/tests/stdlib/connectors_http_policy.harn
@@ -1,0 +1,178 @@
+import {
+  connector_http_header,
+  connector_http_json,
+  connector_http_rate_limit,
+  connector_http_request,
+} from "std/connectors/shared"
+
+pipeline test(task) {
+  http_mock_clear()
+  http_mock(
+    "GET",
+    "https://api.example.com/connector/get-retry",
+    {responses: [{status: 503, body: "busy"}, {status: 200, body: "ok"}]},
+  )
+  let get_retry = connector_http_request(
+    "GET",
+    "https://api.example.com/connector/get-retry",
+    {retry: {max_attempts: 2, base_ms: 0, cap_ms: 1}},
+  )
+  let get_calls = http_mock_calls({include_sensitive: true})
+  assert_eq(get_retry.ok, true)
+  assert_eq(get_retry.status, 200)
+  assert_eq(len(get_calls), 2)
+  __io_println("get_retry:" + to_string(get_retry.status) + ":" + to_string(len(get_calls)))
+  http_mock_clear()
+  http_mock(
+    "POST",
+    "https://api.example.com/connector/post-no-idempotency",
+    {responses: [{status: 503, body: "busy"}, {status: 201, body: "created"}]},
+  )
+  let post_no_idem = connector_http_request(
+    "POST",
+    "https://api.example.com/connector/post-no-idempotency",
+    {body: "{}", retry: {max_attempts: 2, base_ms: 0, cap_ms: 1}},
+  )
+  let post_no_idem_calls = http_mock_calls({include_sensitive: true})
+  assert_eq(post_no_idem.ok, false)
+  assert_eq(post_no_idem.error.category, "overloaded")
+  assert_eq(len(post_no_idem_calls), 1)
+  __io_println(
+    "post_no_idem:" + post_no_idem.error.category + ":" + to_string(len(post_no_idem_calls)),
+  )
+  http_mock_clear()
+  http_mock(
+    "POST",
+    "https://api.example.com/connector/post-idempotency",
+    {responses: [{status: 503, body: "busy"}, {status: 201, body: "created"}]},
+  )
+  let post_idem = connector_http_request(
+    "POST",
+    "https://api.example.com/connector/post-idempotency",
+    {body: "{}", idempotency_key: "idem-1", retry: {max_attempts: 2, base_ms: 0, cap_ms: 1}},
+  )
+  let post_idem_calls = http_mock_calls({include_sensitive: true})
+  assert_eq(post_idem.ok, true)
+  assert_eq(post_idem.status, 201)
+  assert_eq(len(post_idem_calls), 2)
+  assert_eq(post_idem_calls[0].headers["idempotency-key"], "idem-1")
+  __io_println(
+    "post_idem:"
+      + to_string(post_idem.status)
+      + ":"
+      + to_string(len(post_idem_calls))
+      + ":"
+      + post_idem_calls[0].headers["idempotency-key"],
+  )
+  http_mock_clear()
+  http_mock(
+    "POST",
+    "https://api.example.com/connector/post-preserve-idempotency",
+    {status: 200, body: "ok"},
+  )
+  let preserved = connector_http_request(
+    "POST",
+    "https://api.example.com/connector/post-preserve-idempotency",
+    {
+      body: "{}",
+      headers: {"idempotency-key": "caller-key"},
+      idempotency_key: "ignored",
+      retry: {max_attempts: 1},
+    },
+  )
+  let preserved_calls = http_mock_calls({include_sensitive: true})
+  assert_eq(preserved.ok, true)
+  assert_eq(preserved_calls[0].headers["idempotency-key"], "caller-key")
+  __io_println("preserve_idem:" + preserved_calls[0].headers["idempotency-key"])
+  http_mock_clear()
+  http_mock(
+    "GET",
+    "https://api.example.com/connector/retry-after-cap",
+    {
+      responses: [{status: 429, body: "limited", headers: {"Retry-After": "5"}}, {status: 200, body: "ok"}],
+    },
+  )
+  let capped = connector_http_request(
+    "GET",
+    "https://api.example.com/connector/retry-after-cap",
+    {retry: {max_attempts: 2, base_ms: 0, cap_ms: 1}},
+  )
+  let capped_calls = http_mock_calls({include_sensitive: true})
+  assert_eq(capped.ok, false)
+  assert_eq(capped.error.category, "rate_limit")
+  assert_eq(capped.error.retry_after_ms, 5000)
+  assert_eq(len(capped_calls), 1)
+  __io_println(
+    "retry_after_cap:" + to_string(capped.error.retry_after_ms) + ":" + to_string(len(capped_calls)),
+  )
+  http_mock_clear()
+  http_mock("GET", "https://api.example.com/connector/json-invalid", {status: 200, body: "not json"})
+  let invalid_json = connector_http_json(
+    "GET",
+    "https://api.example.com/connector/json-invalid",
+    {provider: "example", operation: "parse"},
+  )
+  assert_eq(invalid_json.ok, false)
+  assert_eq(invalid_json.error.category, "invalid_json")
+  assert_eq(invalid_json.error.status, 200)
+  assert_eq(invalid_json.error.provider, "example")
+  __io_println("invalid_json:" + invalid_json.error.category + ":" + invalid_json.error.provider)
+  http_mock_clear()
+  http_mock("GET", "https://api.example.com/connector/json-empty", {status: 204, body: ""})
+  let empty_json = connector_http_json("GET", "https://api.example.com/connector/json-empty")
+  assert_eq(empty_json.ok, true)
+  assert_eq(empty_json.body, "")
+  assert_eq(empty_json.json, nil)
+  __io_println("empty_json:" + to_string(empty_json.status) + ":" + to_string(empty_json.body == ""))
+  let headers = {
+    "Retry-After": "2",
+    "RateLimit-Limit": "100",
+    "X-RateLimit-Remaining": "0",
+    "X-RateLimit-Reset": "4102444800",
+  }
+  let rate = connector_http_rate_limit({headers: headers})
+  mock_time(0)
+  let http_date_rate = connector_http_rate_limit({headers: {"Retry-After": "Thu, 01 Jan 1970 00:00:03 GMT"}})
+  unmock_time()
+  assert_eq(connector_http_header(headers, "retry-after"), "2")
+  assert_eq(rate.retry_after_ms, 2000)
+  assert_eq(rate.limit, "100")
+  assert_eq(rate.remaining, "0")
+  assert_eq(http_date_rate.retry_after_ms, 3000)
+  __io_println(
+    "rate_limit:"
+      + to_string(rate.retry_after_ms)
+      + ":"
+      + rate.limit
+      + ":"
+      + rate.remaining
+      + ":"
+      + to_string(http_date_rate.retry_after_ms),
+  )
+  http_mock_clear()
+  http_mock(
+    "GET",
+    "https://api.example.com/connector/redacted-error",
+    {status: 500, body: "provider secret payload"},
+  )
+  let redacted = connector_http_request(
+    "GET",
+    "https://api.example.com/connector/redacted-error",
+    {provider: "example", operation: "list", redact_error_body: true},
+  )
+  assert_eq(redacted.ok, false)
+  assert_eq(redacted.error.provider, "example")
+  assert_eq(redacted.error.operation, "list")
+  assert_eq(redacted.error.status, 500)
+  assert_eq(redacted.error.body, nil)
+  __io_println(
+    "redacted:"
+      + redacted.error.provider
+      + ":"
+      + redacted.error.operation
+      + ":"
+      + to_string(redacted.error.status)
+      + ":"
+      + to_string(redacted.error.body == nil),
+  )
+}

--- a/crates/harn-stdlib/src/stdlib/stdlib_connectors_shared.harn
+++ b/crates/harn-stdlib/src/stdlib/stdlib_connectors_shared.harn
@@ -70,6 +70,528 @@ fn __form_body(params) {
   return join(parts, "&")
 }
 
+fn __connector_http_pad2(value) {
+  let text = to_string(to_int(value) ?? 0)
+  if len(text) == 1 {
+    return "0" + text
+  }
+  return text
+}
+
+fn __connector_http_month_number(name) {
+  let months = {
+    apr: "04",
+    aug: "08",
+    dec: "12",
+    feb: "02",
+    jan: "01",
+    jul: "07",
+    jun: "06",
+    mar: "03",
+    may: "05",
+    nov: "11",
+    oct: "10",
+    sep: "09",
+  }
+  return months[lowercase(name)]
+}
+
+fn __connector_http_parse_http_date_ms(raw) {
+  let matches = regex_captures(
+    "^[A-Za-z]{3},\\s+(\\d{1,2})\\s+([A-Za-z]{3})\\s+(\\d{4})\\s+(\\d{2}):(\\d{2}):(\\d{2})\\s+GMT$",
+    raw,
+  )
+  if len(matches) == 0 {
+    return nil
+  }
+  let parts = matches[0].groups
+  let month = __connector_http_month_number(parts[1])
+  if month == nil {
+    return nil
+  }
+  let iso = parts[2] + "-" + month + "-" + __connector_http_pad2(parts[0])
+    + "T"
+    + parts[3]
+    + ":"
+    + parts[4]
+    + ":"
+    + parts[5]
+    + "Z"
+  let parsed = try {
+    date_parse(iso)
+  }
+  if is_err(parsed) {
+    return nil
+  }
+  let delta_seconds = to_float(unwrap(parsed)) - harness.clock.timestamp()
+  if delta_seconds <= 0.0 {
+    return 0
+  }
+  return to_int(delta_seconds * 1000.0)
+}
+
+fn __connector_http_parse_retry_after_ms(value) {
+  let raw = trim(to_string(value ?? ""))
+  if raw == "" {
+    return nil
+  }
+  let seconds = to_float(raw)
+  if seconds != nil {
+    if seconds <= 0.0 {
+      return 0
+    }
+    return to_int(seconds * 1000.0)
+  }
+  let parsed = try {
+    date_parse(raw)
+  }
+  if is_ok(parsed) {
+    let delta_seconds = to_float(unwrap(parsed)) - harness.clock.timestamp()
+    if delta_seconds <= 0.0 {
+      return 0
+    }
+    return to_int(delta_seconds * 1000.0)
+  }
+  return __connector_http_parse_http_date_ms(raw)
+}
+
+fn __connector_http_retry_options(options) {
+  let opts = options ?? {}
+  let policy = opts.retry_policy ?? opts.retry ?? {}
+  var max_attempts = to_int(policy?.max_attempts ?? opts?.max_attempts)
+  if max_attempts == nil {
+    let low_level_retries = to_int(policy?.max)
+    if low_level_retries != nil {
+      max_attempts = low_level_retries + 1
+    } else {
+      max_attempts = 1
+    }
+  }
+  var base_ms = to_int(policy?.base_ms ?? policy?.backoff_ms ?? opts?.base_ms ?? opts?.backoff_ms ?? 200)
+  if base_ms == nil || base_ms < 0 {
+    base_ms = 0
+  }
+  var cap_ms = to_int(policy?.cap_ms ?? opts?.cap_ms ?? 30000)
+  if cap_ms == nil || cap_ms < 0 {
+    cap_ms = 0
+  }
+  if max_attempts == nil || max_attempts < 1 {
+    max_attempts = 1
+  }
+  return {
+    max_attempts: max_attempts,
+    base_ms: base_ms,
+    cap_ms: cap_ms,
+    respect_retry_after: opts?.respect_retry_after ?? true,
+    retry_on: opts?.retry_on ?? policy?.retry_on ?? [408, 429, 500, 502, 503, 504],
+  }
+}
+
+fn __connector_http_retry_delay_ms(policy, attempt) {
+  var delay = policy.base_ms
+  var i = 0
+  while i < attempt {
+    delay = delay * 2
+    i = i + 1
+  }
+  if delay > policy.cap_ms {
+    return policy.cap_ms
+  }
+  return delay
+}
+
+fn __connector_http_retryable_status(status, retry_on) {
+  for candidate in retry_on ?? [] {
+    if to_int(candidate) == status {
+      return true
+    }
+  }
+  return false
+}
+
+fn __connector_http_category(status) {
+  if status == 408 {
+    return "timeout"
+  }
+  if status == 429 {
+    return "rate_limit"
+  }
+  if status == 401 {
+    return "auth"
+  }
+  if status == 403 {
+    return "permission"
+  }
+  if status == 404 {
+    return "not_found"
+  }
+  if status == 409 {
+    return "conflict"
+  }
+  if status == 503 {
+    return "overloaded"
+  }
+  if status >= 500 {
+    return "server_error"
+  }
+  return "provider_error"
+}
+
+fn __connector_http_safe_method(method) {
+  let normalized = uppercase(trim(to_string(method ?? "")))
+  return contains(["GET", "HEAD", "PUT", "DELETE", "OPTIONS"], normalized)
+}
+
+fn __connector_http_has_idempotency_key(headers) {
+  let value = connector_http_header(headers ?? {}, "Idempotency-Key")
+  return value != nil && trim(to_string(value)) != ""
+}
+
+fn __connector_http_retry_allowed(method, headers, options) {
+  if __connector_http_safe_method(method) {
+    return true
+  }
+  let normalized = uppercase(trim(to_string(method ?? "")))
+  let retry_unsafe = options?.retry_unsafe ?? false
+  if normalized == "POST" || normalized == "PATCH" {
+    return __connector_http_has_idempotency_key(headers) || retry_unsafe
+  }
+  return retry_unsafe
+}
+
+fn __connector_http_headers(options) {
+  let opts = options ?? {}
+  var headers = {}
+  for entry in (opts.headers ?? {}).entries() {
+    headers[entry.key] = entry.value
+  }
+  let idempotency_key = opts.idempotency_key
+  if idempotency_key != nil && trim(to_string(idempotency_key)) != ""
+    && !__connector_http_has_idempotency_key(headers) {
+    headers["Idempotency-Key"] = to_string(idempotency_key)
+  }
+  return headers
+}
+
+fn __connector_http_request_options(options, headers) {
+  let opts = options ?? {}
+  var out = {}
+  let internal = set(
+    [
+      "base_ms",
+      "backoff_ms",
+      "cap_ms",
+      "idempotency_key",
+      "max_attempts",
+      "operation",
+      "provider",
+      "redact_error_body",
+      "retry",
+      "retry_policy",
+      "retry_unsafe",
+    ],
+  )
+  for entry in opts.entries() {
+    if !set_contains(internal, entry.key) {
+      out[entry.key] = entry.value
+    }
+  }
+  out["headers"] = headers
+  out["retry"] = {max: 0, backoff_ms: 0}
+  return out
+}
+
+fn __connector_http_error_body(response, options) {
+  if options?.redact_error_body ?? false {
+    return nil
+  }
+  return response?.body
+}
+
+fn __connector_http_has_fields(value) {
+  return type_of(value) == "dict" && len((value ?? {}).keys()) > 0
+}
+
+fn __connector_http_error_from_response(response, options, retryable) {
+  let status = to_int(response?.status) ?? 0
+  let rate_limit = connector_http_rate_limit(response)
+  var error = {category: __connector_http_category(status), status: status, retryable: retryable}
+  if rate_limit?.retry_after_ms != nil {
+    error["retry_after_ms"] = rate_limit.retry_after_ms
+  }
+  let body = __connector_http_error_body(response, options)
+  if body != nil {
+    error["body"] = body
+  }
+  if options?.provider != nil {
+    error["provider"] = options.provider
+  }
+  if options?.operation != nil {
+    error["operation"] = options.operation
+  }
+  if __connector_http_has_fields(rate_limit) {
+    error["rate_limit"] = rate_limit
+  }
+  return error
+}
+
+fn __connector_http_error_from_exception(error, options) {
+  let message = to_string(error)
+  let lowered = lowercase(message)
+  var category = "transient_network"
+  var retryable = true
+  if contains(lowered, "egress") {
+    category = "egress_blocked"
+    retryable = false
+  } else if contains(lowered, "invalid url")
+    || contains(lowered, "url must start")
+    || contains(lowered, "invalid method")
+    || contains(lowered, "invalid header")
+    || contains(lowered, "mutually exclusive") {
+    category = "invalid_request"
+    retryable = false
+  } else if contains(lowered, "max_response_bytes") {
+    category = "body_too_large"
+    retryable = false
+  } else if contains(lowered, "timeout") || contains(lowered, "timed out") {
+    category = "timeout"
+  }
+  return filter_nil(
+    {
+      category: category,
+      retryable: retryable,
+      message: message,
+      provider: options?.provider,
+      operation: options?.operation,
+    },
+  )
+}
+
+fn __connector_http_error_envelope(response, error) {
+  var envelope = {ok: false, error: error}
+  let status = response?.status ?? error?.status
+  if status != nil {
+    envelope["status"] = status
+  }
+  if response?.headers != nil {
+    envelope["headers"] = response.headers
+  }
+  if error?.body != nil {
+    envelope["body"] = error.body
+  }
+  if error?.category != nil {
+    envelope["category"] = error.category
+  }
+  if error?.retryable != nil {
+    envelope["retryable"] = error.retryable
+  }
+  if error?.retry_after_ms != nil {
+    envelope["retry_after_ms"] = error.retry_after_ms
+  }
+  if error?.provider != nil {
+    envelope["provider"] = error.provider
+  }
+  if error?.operation != nil {
+    envelope["operation"] = error.operation
+  }
+  if __connector_http_has_fields(error?.rate_limit) {
+    envelope["rate_limit"] = error.rate_limit
+  }
+  return envelope
+}
+
+fn __connector_http_success_envelope(response) {
+  let rate_limit = connector_http_rate_limit(response)
+  var envelope = {ok: true, status: response.status, headers: response.headers ?? {}, body: response.body ?? ""}
+  if response?.final_url != nil {
+    envelope["final_url"] = response.final_url
+  }
+  if rate_limit?.retry_after_ms != nil {
+    envelope["retry_after_ms"] = rate_limit.retry_after_ms
+  }
+  if __connector_http_has_fields(rate_limit) {
+    envelope["rate_limit"] = rate_limit
+  }
+  return envelope
+}
+
+fn __connector_http_should_retry_response(response, retry_policy, retry_allowed) {
+  if !retry_allowed {
+    return false
+  }
+  if response?.ok ?? false {
+    return false
+  }
+  let status = to_int(response?.status) ?? 0
+  return __connector_http_retryable_status(status, retry_policy.retry_on)
+}
+
+fn __connector_http_sleep_before_retry(retry_policy, attempt, retry_after_ms) {
+  var delay = __connector_http_retry_delay_ms(retry_policy, attempt)
+  if retry_policy.respect_retry_after && retry_after_ms != nil {
+    if retry_after_ms > retry_policy.cap_ms {
+      return false
+    }
+    if retry_after_ms > delay {
+      delay = retry_after_ms
+    }
+  }
+  if delay > 0 {
+    harness.clock.sleep_ms(delay)
+  }
+  return true
+}
+
+/**
+ * Case-insensitive HTTP header lookup for connector request and response
+ * envelopes.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: stable
+ * @example: connector_http_header(response, "Retry-After")
+ */
+pub fn connector_http_header(headers_or_response, name) {
+  return http_header(headers_or_response ?? {}, name)
+}
+
+/**
+ * Extract the standard rate-limit headers connector packages commonly expose.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: stable
+ * @example: connector_http_rate_limit(response)
+ */
+pub fn connector_http_rate_limit(headers_or_response) {
+  let retry_after = connector_http_header(headers_or_response, "Retry-After")
+  let limit = connector_http_header(headers_or_response, "RateLimit-Limit")
+  let remaining = connector_http_header(headers_or_response, "RateLimit-Remaining")
+  let reset = connector_http_header(headers_or_response, "RateLimit-Reset")
+  let x_limit = connector_http_header(headers_or_response, "X-RateLimit-Limit")
+  let x_remaining = connector_http_header(headers_or_response, "X-RateLimit-Remaining")
+  let x_reset = connector_http_header(headers_or_response, "X-RateLimit-Reset")
+  return filter_nil(
+    {
+      retry_after: retry_after,
+      retry_after_ms: __connector_http_parse_retry_after_ms(retry_after),
+      limit: limit ?? x_limit,
+      remaining: remaining ?? x_remaining,
+      reset: reset ?? x_reset,
+      ratelimit_limit: limit,
+      ratelimit_remaining: remaining,
+      ratelimit_reset: reset,
+      x_ratelimit_limit: x_limit,
+      x_ratelimit_remaining: x_remaining,
+      x_ratelimit_reset: x_reset,
+    },
+  )
+}
+
+/**
+ * connector_http_request.
+ *
+ * @effects: [net, time]
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: stable
+ * @example: connector_http_request("GET", url, {retry: {max_attempts: 3}})
+ */
+pub fn connector_http_request(method, url, options = nil) {
+  let opts = options ?? {}
+  let resolved_method = uppercase(trim(to_string(method ?? "GET")))
+  let headers = __connector_http_headers(opts)
+  let retry_policy = __connector_http_retry_options(opts)
+  let retry_allowed = __connector_http_retry_allowed(resolved_method, headers, opts)
+  let request_options = __connector_http_request_options(opts, headers)
+  var attempt = 0
+  while attempt < retry_policy.max_attempts {
+    let result = try {
+      harness.net.request(resolved_method, url, request_options)
+    }
+    if is_err(result) {
+      let error = __connector_http_error_from_exception(unwrap_err(result), opts)
+      let error_retryable = error.retryable ?? false
+      let can_retry = retry_allowed && error_retryable && attempt + 1 < retry_policy.max_attempts
+      if !can_retry {
+        return __connector_http_error_envelope(nil, error)
+      }
+      if !__connector_http_sleep_before_retry(retry_policy, attempt, nil) {
+        return __connector_http_error_envelope(nil, error)
+      }
+      attempt = attempt + 1
+      continue
+    }
+    let response = unwrap(result)
+    if response.ok ?? false {
+      return __connector_http_success_envelope(response)
+    }
+    let should_retry = __connector_http_should_retry_response(response, retry_policy, retry_allowed)
+    let retry_after_ms = connector_http_rate_limit(response)?.retry_after_ms
+    let error = __connector_http_error_from_response(response, opts, should_retry)
+    if !should_retry || attempt + 1 >= retry_policy.max_attempts {
+      return __connector_http_error_envelope(response, error)
+    }
+    if !__connector_http_sleep_before_retry(retry_policy, attempt, retry_after_ms) {
+      return __connector_http_error_envelope(response, error)
+    }
+    attempt = attempt + 1
+  }
+  return __connector_http_error_envelope(
+    nil,
+    {
+      category: "transient_network",
+      retryable: true,
+      message: "connector_http_request exhausted without a response",
+      provider: opts?.provider,
+      operation: opts?.operation,
+    },
+  )
+}
+
+/**
+ * connector_http_json.
+ *
+ * @effects: [net, time]
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: stable
+ * @example: connector_http_json("GET", url, {retry: {max_attempts: 3}})
+ */
+pub fn connector_http_json(method, url, options = nil) {
+  let response = connector_http_request(method, url, options)
+  if !(response.ok ?? false) {
+    return response
+  }
+  if trim(to_string(response?.body ?? "")) == "" {
+    return response + {json: nil}
+  }
+  let parsed = try {
+    json_parse(response.body)
+  }
+  if is_ok(parsed) {
+    return response + {json: unwrap(parsed)}
+  }
+  let opts = options ?? {}
+  let error = filter_nil(
+    {
+      category: "invalid_json",
+      status: response.status,
+      retryable: false,
+      body: if opts?.redact_error_body ?? false {
+        nil
+      } else {
+        response.body
+      },
+      provider: opts?.provider,
+      operation: opts?.operation,
+    },
+  )
+  return __connector_http_error_envelope(response, error)
+}
+
 /**
  * oauth2_token_refresh.
  *

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -2334,6 +2334,33 @@ query_stringify([{key: "name", value: "ali ce"}])
 - `http_mock(method, url_pattern, response)` can script multiple responses
   with `{responses: [...]}` and `http_mock_calls()` records each attempt.
 
+### Connector HTTP policy
+
+Package authors should prefer `std/connectors/shared` for provider API calls:
+
+```harn
+import { connector_http_json } from "std/connectors/shared"
+
+let response = connector_http_json("POST", url, {
+  headers: {Authorization: "Bearer " + token, Accept: "application/json"},
+  body: json_stringify(payload),
+  idempotency_key: "create:" + payload.id,
+  retry: {max_attempts: 3, base_ms: 250, cap_ms: 30000},
+  provider: "example",
+  operation: "create_item",
+})
+```
+
+`connector_http_request` returns a non-throwing envelope. Success:
+`{ok: true, status, headers, body, retry_after_ms?}`. Failure:
+`{ok: false, status?, retryable, retry_after_ms?, error}` where
+`error.category` is stable for branching. `connector_http_json` adds `json` on
+valid JSON and returns `error.category == "invalid_json"` on parse failure.
+`POST`/`PATCH` retries require an existing or supplied `Idempotency-Key`, unless
+`retry_unsafe: true` is explicit. `connector_http_header` and
+`connector_http_rate_limit` cover case-insensitive header lookup plus
+`Retry-After`, `RateLimit-*`, and `X-RateLimit-*` extraction.
+
 ### Human-in-the-loop primitives
 
 `ask_user`, `request_approval`, `dual_control`, and `escalate_to` are

--- a/docs/src/connectors/authoring.md
+++ b/docs/src/connectors/authoring.md
@@ -571,6 +571,9 @@ package-level equivalent helpers:
 
 ```harn
 import {
+  connector_http_json,
+  connector_http_rate_limit,
+  connector_http_request,
   oauth2_token_refresh,
   paginate_cursor,
   rate_limit_token_bucket,
@@ -582,8 +585,58 @@ import {
 Use the Rust `verify_hmac_signed(...)` path for runtime HTTP ingress when you
 need timestamp-window checks, audit events, or a provider-specific signed
 message format. Use `std/connectors/shared` inside Harn package exports for
-local HMAC checks, JWT/JWKS verification, OAuth2 token refresh, package-local
-token buckets, and cursor pagination.
+local HMAC checks, JWT/JWKS verification, outbound HTTP policy, OAuth2 token
+refresh, package-local token buckets, and cursor pagination.
+
+## Outbound HTTP policy
+
+Connector packages should layer provider-specific request logic over
+`connector_http_request(...)` or `connector_http_json(...)` instead of
+open-coding retry loops around `harness.net.request(...)`. The raw
+`harness.net.*` APIs remain the escape hatch when a package needs exact client
+behavior; the shared policy wrapper is the default for provider API calls that
+need stable error categories, idempotency-aware retries, and rate-limit
+metadata.
+
+```harn
+import { connector_http_json } from "std/connectors/shared"
+
+fn api_json(method, url, token, body = nil, idempotency_key = nil) {
+  return connector_http_json(
+    method,
+    url,
+    {
+      provider: "example",
+      operation: "api_json",
+      headers: {Authorization: "Bearer " + token, Accept: "application/json"},
+      body: if body == nil { nil } else { json_stringify(body) },
+      idempotency_key: idempotency_key,
+      retry: {max_attempts: 3, base_ms: 250, cap_ms: 30000},
+    },
+  )
+}
+```
+
+`connector_http_request(...)` returns a non-throwing envelope. Successful
+responses contain `{ok: true, status, headers, body, retry_after_ms?}`.
+Failures contain `{ok: false, status?, retryable, retry_after_ms?, error}` where
+`error.category` is stable enough for generated SDKs and package code to branch
+on (`"rate_limit"`, `"overloaded"`, `"server_error"`, `"auth"`,
+`"permission"`, `"not_found"`, `"timeout"`, `"invalid_json"`, and transport
+categories such as `"transient_network"` or `"egress_blocked"`).
+
+The retry policy uses total-attempt semantics:
+`retry: {max_attempts, base_ms, cap_ms}`. Safe/idempotent methods (`GET`,
+`HEAD`, `PUT`, `DELETE`, `OPTIONS`) may retry retryable statuses. `POST` and
+`PATCH` retry only when an `Idempotency-Key` header is already present, when
+`options.idempotency_key` can add one, or when the caller explicitly sets
+`retry_unsafe: true`. When a provider returns a `Retry-After` value above
+`cap_ms`, the wrapper returns a retryable error with `retry_after_ms` instead of
+sleeping for a long reset window.
+
+Use `connector_http_header(...)` for case-insensitive response header lookup and
+`connector_http_rate_limit(...)` to expose `Retry-After`, `RateLimit-*`, and
+`X-RateLimit-*` metadata without repeating provider-local header scans.
 
 ## Rate limiting
 

--- a/docs/src/modules.md
+++ b/docs/src/modules.md
@@ -154,6 +154,10 @@ Connector package helpers for common provider plumbing:
 
 | Function | Description |
 |---|---|
+| `connector_http_request(method, url, options?)` | Non-throwing HTTP policy wrapper returning `{ok, status, headers, body, retry_after_ms?, error?}` with normalized retry, idempotency, and error categories |
+| `connector_http_json(method, url, options?)` | `connector_http_request` plus response JSON parsing; invalid JSON returns `error.category == "invalid_json"` |
+| `connector_http_header(headers_or_response, name)` | Case-insensitive header lookup for response envelopes or raw header dicts |
+| `connector_http_rate_limit(headers_or_response)` | Extract `Retry-After`, `RateLimit-*`, and `X-RateLimit-*` metadata, including `retry_after_ms` when parseable |
 | `verify_hmac_signature(body, signature, secret, algorithm?)` | Constant-time check for bare or `sha256=`/`sha1=` HMAC signatures |
 | `verify_jwt(token, jwks_url, options?)` | Verify a compact JWT against a JWKS URL, or `options.inline_jwks`, returning `{ok, claims, error}` |
 | `oauth2_token_refresh(client_id, client_secret, refresh_token, token_url, options?)` | Refresh an OAuth2 access token with form-encoded `grant_type=refresh_token` |


### PR DESCRIPTION
## Summary

- Add `connector_http_request`, `connector_http_json`, `connector_http_header`, and `connector_http_rate_limit` to `std/connectors/shared`.
- Normalize connector HTTP retry policy, unsafe-write idempotency gating, capped `Retry-After` handling, rate-limit metadata, redaction, and stable error categories.
- Add focused conformance coverage and connector-authoring / quickref docs.

Closes #2082.

## Verification

- `cargo run --quiet --bin harn -- test conformance --filter connectors_http_policy`
- `cargo run --quiet --bin harn -- test conformance --filter http_retry`
- `cargo run --quiet --bin harn -- test conformance --filter connectors_shared`
- `make fmt-harn`
- `make lint-harn`
- `cargo test -p harn-stdlib`
- `cargo test -p harn-vm http`
- `make check-docs-snippets`
- pre-push targeted checks