### PR TITLE
perf(vm): shrink VmValue rare payloads

### DIFF
--- a/crates/harn-cli/src/commands/run.rs
+++ b/crates/harn-cli/src/commands/run.rs
@@ -1264,11 +1264,7 @@ fn exit_code_from_return_value(value: &harn_vm::VmValue) -> i32 {
     use harn_vm::VmValue;
     match value {
         VmValue::Int(n) => (*n).clamp(0, 255) as i32,
-        VmValue::EnumVariant {
-            enum_name,
-            variant,
-            fields,
-        } if enum_name.as_ref() == "Result" && variant.as_ref() == "Err" => 1,
+        VmValue::EnumVariant(enum_variant) if enum_variant.is_variant("Result", "Err") => 1,
         _ => 0,
     }
 }
@@ -1388,18 +1384,17 @@ fn finalize_harnpack_dry_run(
 }
 
 fn render_return_value_error(value: &harn_vm::VmValue) -> String {
-    let harn_vm::VmValue::EnumVariant {
-        enum_name,
-        variant,
-        fields,
-    } = value
-    else {
+    let harn_vm::VmValue::EnumVariant(enum_variant) = value else {
         return String::new();
     };
-    if enum_name.as_ref() != "Result" || variant.as_ref() != "Err" {
+    if !enum_variant.is_variant("Result", "Err") {
         return String::new();
     }
-    let rendered = fields.first().map(|p| p.display()).unwrap_or_default();
+    let rendered = enum_variant
+        .fields
+        .first()
+        .map(|p| p.display())
+        .unwrap_or_default();
     if rendered.is_empty() {
         "error\n".to_string()
     } else if rendered.ends_with('\n') {
@@ -1476,7 +1471,7 @@ pub(crate) async fn connect_mcp_servers(
             Ok(handle) => {
                 eprintln!("[harn] mcp: connected to '{}'", server.name);
                 harn_vm::mcp_install_active(&server.name, handle.clone());
-                mcp_dict.insert(server.name.clone(), harn_vm::VmValue::McpClient(handle));
+                mcp_dict.insert(server.name.clone(), harn_vm::VmValue::mcp_client(handle));
             }
             Err(e) => {
                 eprintln!(

--- a/crates/harn-dap/src/debugger/variables.rs
+++ b/crates/harn-dap/src/debugger/variables.rs
@@ -64,20 +64,21 @@ impl Debugger {
                     (self.alloc_var_ref(children), display)
                 }
             }
-            VmValue::EnumVariant {
-                enum_name,
-                variant,
-                fields,
-            } => {
-                if fields.is_empty() {
-                    (0, format!("{enum_name}.{variant}"))
+            VmValue::EnumVariant(enum_variant) => {
+                if enum_variant.fields.is_empty() {
+                    (
+                        0,
+                        format!("{}.{}", enum_variant.enum_name, enum_variant.variant),
+                    )
                 } else {
-                    let children: Vec<(String, VmValue)> = fields
+                    let children: Vec<(String, VmValue)> = enum_variant
+                        .fields
                         .iter()
                         .enumerate()
                         .map(|(i, v)| (format!("field_{i}"), v.clone()))
                         .collect();
-                    let display = format!("{enum_name}.{variant}(...)");
+                    let display =
+                        format!("{}.{}(...)", enum_variant.enum_name, enum_variant.variant);
                     (self.alloc_var_ref(children), display)
                 }
             }

--- a/crates/harn-serve/src/adapters/acp/execute.rs
+++ b/crates/harn-serve/src/adapters/acp/execute.rs
@@ -263,7 +263,7 @@ pub(super) async fn load_host_mcp_clients(
         match harn_vm::connect_mcp_server_from_json(server).await {
             Ok(handle) => {
                 eprintln!("[harn] mcp: connected to '{}'", handle.name);
-                mcp_dict.insert(handle.name.clone(), harn_vm::VmValue::McpClient(handle));
+                mcp_dict.insert(handle.name.clone(), harn_vm::VmValue::mcp_client(handle));
             }
             Err(err) => {
                 let name = server

--- a/crates/harn-vm/src/harness.rs
+++ b/crates/harn-vm/src/harness.rs
@@ -614,7 +614,7 @@ impl Harness {
 
     /// Lower this handle into the `VmValue::Harness` payload.
     pub fn into_vm_value(self) -> crate::value::VmValue {
-        crate::value::VmValue::Harness(VmHarness {
+        crate::value::VmValue::harness(VmHarness {
             inner: self.inner,
             kind: HarnessKind::Root,
         })

--- a/crates/harn-vm/src/llm/call.rs
+++ b/crates/harn-vm/src/llm/call.rs
@@ -93,19 +93,18 @@ fn output_validation_mode(opts: &api::LlmCallOptions) -> &str {
 
 fn schema_validation_errors(result: &VmValue) -> Vec<String> {
     match result {
-        VmValue::EnumVariant {
-            enum_name,
-            variant,
-            fields,
-        } if enum_name.as_ref() == "Result" && variant.as_ref() == "Err" => fields
-            .first()
-            .and_then(|payload| payload.as_dict())
-            .and_then(|payload| payload.get("errors"))
-            .and_then(|errors| match errors {
-                VmValue::List(items) => Some(items.iter().map(|err| err.display()).collect()),
-                _ => None,
-            })
-            .unwrap_or_else(|| vec!["schema validation failed".to_string()]),
+        VmValue::EnumVariant(enum_variant) if enum_variant.is_variant("Result", "Err") => {
+            enum_variant
+                .fields
+                .first()
+                .and_then(|payload| payload.as_dict())
+                .and_then(|payload| payload.get("errors"))
+                .and_then(|errors| match errors {
+                    VmValue::List(items) => Some(items.iter().map(|err| err.display()).collect()),
+                    _ => None,
+                })
+                .unwrap_or_else(|| vec!["schema validation failed".to_string()])
+        }
         _ => Vec::new(),
     }
 }

--- a/crates/harn-vm/src/llm/schema_recover.rs
+++ b/crates/harn-vm/src/llm/schema_recover.rs
@@ -212,30 +212,29 @@ fn try_parse_and_validate(
 /// the error list from `Result.Err({errors, ...})`.
 fn extract_validation_outcome(result: &VmValue) -> Result<VmValue, Vec<String>> {
     match result {
-        VmValue::EnumVariant {
-            enum_name,
-            variant,
-            fields,
-        } if enum_name.as_ref() == "Result" => match variant.as_ref() {
-            "Ok" => Ok(fields.first().cloned().unwrap_or(VmValue::Nil)),
-            "Err" => {
-                let errors = fields
-                    .first()
-                    .and_then(|payload| payload.as_dict())
-                    .and_then(|payload| payload.get("errors"))
-                    .and_then(|errors| match errors {
-                        VmValue::List(items) => {
-                            Some(items.iter().map(|err| err.display()).collect())
-                        }
-                        _ => None,
-                    })
-                    .unwrap_or_else(|| vec!["schema validation failed".to_string()]);
-                Err(errors)
+        VmValue::EnumVariant(enum_variant) if enum_variant.has_enum_name("Result") => {
+            match enum_variant.variant.as_ref() {
+                "Ok" => Ok(enum_variant.fields.first().cloned().unwrap_or(VmValue::Nil)),
+                "Err" => {
+                    let errors = enum_variant
+                        .fields
+                        .first()
+                        .and_then(|payload| payload.as_dict())
+                        .and_then(|payload| payload.get("errors"))
+                        .and_then(|errors| match errors {
+                            VmValue::List(items) => {
+                                Some(items.iter().map(|err| err.display()).collect())
+                            }
+                            _ => None,
+                        })
+                        .unwrap_or_else(|| vec!["schema validation failed".to_string()]);
+                    Err(errors)
+                }
+                other => Err(vec![format!(
+                    "unexpected Result variant from schema validation: {other}"
+                )]),
             }
-            other => Err(vec![format!(
-                "unexpected Result variant from schema validation: {other}"
-            )]),
-        },
+        }
         _ => Err(vec!["schema validation did not return a Result".to_string()]),
     }
 }

--- a/crates/harn-vm/src/llm/stream_builtins.rs
+++ b/crates/harn-vm/src/llm/stream_builtins.rs
@@ -51,7 +51,7 @@ pub(super) async fn llm_stream_builtin(args: Vec<VmValue>) -> Result<VmValue, Vm
         receiver: Arc::new(tokio::sync::Mutex::new(rx)),
         closed,
     };
-    Ok(VmValue::Channel(handle))
+    Ok(VmValue::channel(handle))
 }
 
 fn llm_stream_chunk(
@@ -182,7 +182,7 @@ pub(super) async fn llm_stream_call_impl(args: Vec<VmValue>) -> Result<VmValue, 
         }
     });
 
-    Ok(VmValue::Stream(VmStream {
+    Ok(VmValue::stream(VmStream {
         done: Rc::new(std::cell::Cell::new(false)),
         receiver: Rc::new(tokio::sync::Mutex::new(stream_rx)),
         cancel: Some(cancel),

--- a/crates/harn-vm/src/mcp.rs
+++ b/crates/harn-vm/src/mcp.rs
@@ -1352,7 +1352,7 @@ pub fn register_mcp_builtins(vm: &mut Vm) {
         };
 
         let handle = mcp_connect_stdio_impl(&command, &cmd_args, &BTreeMap::new()).await?;
-        Ok(VmValue::McpClient(handle))
+        Ok(VmValue::mcp_client(handle))
     });
 
     // Lazy registry: ensure a registered server is booted and return its
@@ -1370,7 +1370,7 @@ pub fn register_mcp_builtins(vm: &mut Vm) {
             ))));
         }
         let handle = crate::mcp_registry::ensure_active(&name).await?;
-        Ok(VmValue::McpClient(handle))
+        Ok(VmValue::mcp_client(handle))
     });
 
     // Decrement the binder refcount for a registered server. Called by

--- a/crates/harn-vm/src/schema/tests.rs
+++ b/crates/harn-vm/src/schema/tests.rs
@@ -66,7 +66,7 @@ fn validate_additional_properties_false() {
     );
     assert!(matches!(
         result,
-        VmValue::EnumVariant { variant, .. } if variant.as_ref() == "Err"
+        VmValue::EnumVariant(enum_variant) if enum_variant.is_variant("Result", "Err")
     ));
 }
 
@@ -187,14 +187,12 @@ fn invalid_pattern_surfaces_a_clear_error() {
         ("pattern", s("[unclosed")),
     ]);
     let result = schema_result_value(&s("anything"), &schema, false);
-    let VmValue::EnumVariant {
-        variant, fields, ..
-    } = result
-    else {
+    let VmValue::EnumVariant(enum_variant) = result else {
         panic!("expected Result variant");
     };
-    assert_eq!(variant.as_ref(), "Err");
-    let payload_dict = fields
+    assert!(enum_variant.is_variant("Result", "Err"));
+    let payload_dict = enum_variant
+        .fields
         .first()
         .and_then(|value| value.as_dict().cloned())
         .expect("Err payload is a dict");

--- a/crates/harn-vm/src/stdlib/agents.rs
+++ b/crates/harn-vm/src/stdlib/agents.rs
@@ -2265,7 +2265,7 @@ mod suspend_tests {
     }
 
     fn handle_value(worker_id: &str) -> VmValue {
-        VmValue::TaskHandle(worker_id.to_string())
+        VmValue::task_handle(worker_id.to_string())
     }
 
     fn message_value(role: &str, content: &str) -> VmValue {

--- a/crates/harn-vm/src/stdlib/agents_workers/mod.rs
+++ b/crates/harn-vm/src/stdlib/agents_workers/mod.rs
@@ -262,7 +262,7 @@ pub(super) fn worker_id_from_value(value: &VmValue) -> Result<String, VmError> {
                 "agent handle dict is missing an id field".to_string(),
             )),
         },
-        VmValue::TaskHandle(id) => Ok(id.clone()),
+        VmValue::TaskHandle(id) => Ok(id.to_string()),
         _ => Err(VmError::Runtime(
             "expected agent handle or worker id".to_string(),
         )),

--- a/crates/harn-vm/src/stdlib/concurrency.rs
+++ b/crates/harn-vm/src/stdlib/concurrency.rs
@@ -490,7 +490,7 @@ async fn sync_mutex_acquire_builtin(args: Vec<VmValue>) -> Result<VmValue, VmErr
         .sync_runtime
         .acquire("mutex", &key, 1, 1, timeout_ms, vm.cancel_token.clone())
         .await?
-        .map(VmValue::SyncPermit)
+        .map(VmValue::sync_permit)
         .unwrap_or(VmValue::Nil))
 }
 
@@ -514,7 +514,7 @@ async fn sync_semaphore_acquire_builtin(args: Vec<VmValue>) -> Result<VmValue, V
             vm.cancel_token.clone(),
         )
         .await?
-        .map(VmValue::SyncPermit)
+        .map(VmValue::sync_permit)
         .unwrap_or(VmValue::Nil))
 }
 
@@ -530,7 +530,7 @@ async fn sync_gate_acquire_builtin(args: Vec<VmValue>) -> Result<VmValue, VmErro
         .sync_runtime
         .acquire("gate", &key, limit, 1, timeout_ms, vm.cancel_token.clone())
         .await?
-        .map(VmValue::SyncPermit)
+        .map(VmValue::sync_permit)
         .unwrap_or(VmValue::Nil))
 }
 
@@ -566,7 +566,7 @@ async fn sync_rwlock_acquire_builtin(args: Vec<VmValue>) -> Result<VmValue, VmEr
             vm.cancel_token.clone(),
         )
         .await?
-        .map(VmValue::SyncPermit)
+        .map(VmValue::sync_permit)
         .unwrap_or(VmValue::Nil))
 }
 
@@ -903,7 +903,7 @@ fn channel_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmErr
     let (tx, rx) = tokio::sync::mpsc::channel(capacity);
     // The handle stays on the single-threaded VM LocalSet; VmValue itself is !Send.
     #[allow(clippy::arc_with_non_send_sync)]
-    Ok(VmValue::Channel(VmChannelHandle {
+    Ok(VmValue::channel(VmChannelHandle {
         name: Rc::from(name),
         sender: Arc::new(tx),
         receiver: Arc::new(tokio::sync::Mutex::new(rx)),
@@ -964,7 +964,7 @@ fn atomic_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmErro
         Some(VmValue::Bool(b)) => i64::from(*b),
         _ => 0,
     };
-    Ok(VmValue::Atomic(VmAtomicHandle {
+    Ok(VmValue::atomic(VmAtomicHandle {
         value: Arc::new(AtomicI64::new(initial)),
     }))
 }

--- a/crates/harn-vm/src/stdlib/event_log.rs
+++ b/crates/harn-vm/src/stdlib/event_log.rs
@@ -70,7 +70,7 @@ pub(crate) fn register_event_log_builtins(vm: &mut Vm) {
             }
         });
 
-        Ok(VmValue::Stream(VmStream {
+        Ok(VmValue::stream(VmStream {
             done: Rc::new(std::cell::Cell::new(false)),
             receiver: Rc::new(tokio::sync::Mutex::new(rx)),
             cancel: None,

--- a/crates/harn-vm/src/stdlib/iter.rs
+++ b/crates/harn-vm/src/stdlib/iter.rs
@@ -437,20 +437,13 @@ fn spawn_parallel_race_task(
 ) {
     join_set.spawn_local(async move {
         match vm.call_callable_value(&callable, &[item]).await {
-            Ok(VmValue::EnumVariant {
-                enum_name,
-                variant,
-                fields,
-            }) if enum_name.as_ref() == "Result" && variant.as_ref() == "Ok" => {
-                Ok(fields.first().cloned().unwrap_or(VmValue::Nil))
+            Ok(VmValue::EnumVariant(enum_variant)) if enum_variant.is_variant("Result", "Ok") => {
+                Ok(enum_variant.fields.first().cloned().unwrap_or(VmValue::Nil))
             }
-            Ok(VmValue::EnumVariant {
-                enum_name,
-                variant,
-                fields,
-            }) if enum_name.as_ref() == "Result" && variant.as_ref() == "Err" => {
+            Ok(VmValue::EnumVariant(enum_variant)) if enum_variant.is_variant("Result", "Err") => {
                 let mut message = String::new();
-                fields
+                enum_variant
+                    .fields
                     .first()
                     .cloned()
                     .unwrap_or(VmValue::Nil)

--- a/crates/harn-vm/src/stdlib/json_stream.rs
+++ b/crates/harn-vm/src/stdlib/json_stream.rs
@@ -644,10 +644,9 @@ fn invalid_type_start(
 
 fn schema_validation_error(value: &VmValue, schema: &VmValue, path: &str) -> Option<EarlyInvalid> {
     match schema::schema_result_value(value, schema, false) {
-        VmValue::EnumVariant {
-            variant, fields, ..
-        } if variant.as_ref() == "Err" => {
-            let reason = fields
+        VmValue::EnumVariant(enum_variant) if enum_variant.is_variant("Result", "Err") => {
+            let reason = enum_variant
+                .fields
                 .first()
                 .and_then(VmValue::as_dict)
                 .and_then(|payload| payload.get("message"))
@@ -852,7 +851,7 @@ mod tests {
 
     fn status_variant(value: &VmValue) -> String {
         match value {
-            VmValue::EnumVariant { variant, .. } => variant.to_string(),
+            VmValue::EnumVariant(enum_variant) => enum_variant.variant.to_string(),
             other => panic!("expected enum status, got {other:?}"),
         }
     }

--- a/crates/harn-vm/src/stdlib/math.rs
+++ b/crates/harn-vm/src/stdlib/math.rs
@@ -110,7 +110,7 @@ pub(crate) fn register_math_builtins(vm: &mut Vm) {
         let seed = args.first().and_then(|arg| arg.as_int()).ok_or_else(|| {
             VmError::TypeError("rng_seed(seed): seed must be an integer".to_string())
         })?;
-        Ok(VmValue::Rng(VmRngHandle {
+        Ok(VmValue::rng(VmRngHandle {
             rng: Arc::new(Mutex::new(rand::rngs::StdRng::seed_from_u64(seed as u64))),
         }))
     });

--- a/crates/harn-vm/src/stdlib/tools.rs
+++ b/crates/harn-vm/src/stdlib/tools.rs
@@ -972,7 +972,7 @@ fn synthesize_tool_spec(input: Option<&VmValue>) -> Result<SynthesizedToolSpec, 
                 ))));
             }
             let client = match config.get("mcp_client") {
-                Some(VmValue::McpClient(client)) => Some(client.clone()),
+                Some(VmValue::McpClient(client)) => Some(client.as_ref().clone()),
                 Some(VmValue::Nil) | None => None,
                 _ => {
                     return Err(VmError::Thrown(VmValue::String(Rc::from(

--- a/crates/harn-vm/src/stdlib/types.rs
+++ b/crates/harn-vm/src/stdlib/types.rs
@@ -44,34 +44,30 @@ pub(crate) fn register_type_builtins(vm: &mut Vm) {
         let val = args.first().unwrap_or(&VmValue::Nil);
         Ok(VmValue::Bool(matches!(
             val,
-            VmValue::EnumVariant { enum_name, variant, .. }
-            if enum_name.as_ref() == "Result" && variant.as_ref() == "Ok"
+            VmValue::EnumVariant(enum_variant)
+            if enum_variant.is_variant("Result", "Ok")
         )))
     });
     vm.register_builtin("is_err", |args, _out| {
         let val = args.first().unwrap_or(&VmValue::Nil);
         Ok(VmValue::Bool(matches!(
             val,
-            VmValue::EnumVariant { enum_name, variant, .. }
-            if enum_name.as_ref() == "Result" && variant.as_ref() == "Err"
+            VmValue::EnumVariant(enum_variant)
+            if enum_variant.is_variant("Result", "Err")
         )))
     });
     vm.register_builtin("unwrap", |args, _out| {
         let val = args.first().unwrap_or(&VmValue::Nil);
         match val {
-            VmValue::EnumVariant {
-                enum_name,
-                variant,
-                fields,
-            } if enum_name.as_ref() == "Result" && variant.as_ref() == "Ok" => {
-                Ok(fields.first().cloned().unwrap_or(VmValue::Nil))
+            VmValue::EnumVariant(enum_variant) if enum_variant.is_variant("Result", "Ok") => {
+                Ok(enum_variant.fields.first().cloned().unwrap_or(VmValue::Nil))
             }
-            VmValue::EnumVariant {
-                enum_name,
-                variant,
-                fields,
-            } if enum_name.as_ref() == "Result" && variant.as_ref() == "Err" => {
-                let msg = fields.first().map(|f| f.display()).unwrap_or_default();
+            VmValue::EnumVariant(enum_variant) if enum_variant.is_variant("Result", "Err") => {
+                let msg = enum_variant
+                    .fields
+                    .first()
+                    .map(|f| f.display())
+                    .unwrap_or_default();
                 Err(VmError::Runtime(format!("unwrap called on Err: {msg}")))
             }
             _ => Ok(val.clone()),
@@ -81,28 +77,20 @@ pub(crate) fn register_type_builtins(vm: &mut Vm) {
         let val = args.first().unwrap_or(&VmValue::Nil);
         let default = args.get(1).cloned().unwrap_or(VmValue::Nil);
         match val {
-            VmValue::EnumVariant {
-                enum_name,
-                variant,
-                fields,
-            } if enum_name.as_ref() == "Result" && variant.as_ref() == "Ok" => {
-                Ok(fields.first().cloned().unwrap_or(VmValue::Nil))
+            VmValue::EnumVariant(enum_variant) if enum_variant.is_variant("Result", "Ok") => {
+                Ok(enum_variant.fields.first().cloned().unwrap_or(VmValue::Nil))
             }
-            VmValue::EnumVariant {
-                enum_name, variant, ..
-            } if enum_name.as_ref() == "Result" && variant.as_ref() == "Err" => Ok(default),
+            VmValue::EnumVariant(enum_variant) if enum_variant.is_variant("Result", "Err") => {
+                Ok(default)
+            }
             _ => Ok(val.clone()),
         }
     });
     vm.register_builtin("unwrap_err", |args, _out| {
         let val = args.first().unwrap_or(&VmValue::Nil);
         match val {
-            VmValue::EnumVariant {
-                enum_name,
-                variant,
-                fields,
-            } if enum_name.as_ref() == "Result" && variant.as_ref() == "Err" => {
-                Ok(fields.first().cloned().unwrap_or(VmValue::Nil))
+            VmValue::EnumVariant(enum_variant) if enum_variant.is_variant("Result", "Err") => {
+                Ok(enum_variant.fields.first().cloned().unwrap_or(VmValue::Nil))
             }
             _ => Err(VmError::Runtime("unwrap_err called on non-Err".into())),
         }

--- a/crates/harn-vm/src/triggers/dispatcher/predicate_eval.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/predicate_eval.rs
@@ -462,26 +462,23 @@ pub(super) fn predicate_node_metadata(
 fn predicate_value_as_bool(value: VmValue) -> Result<bool, String> {
     match value {
         VmValue::Bool(result) => Ok(result),
-        VmValue::EnumVariant {
-            enum_name,
-            variant,
-            fields,
-        } if enum_name.as_ref() == "Result" && variant.as_ref() == "Ok" => match fields.first() {
-            Some(VmValue::Bool(result)) => Ok(*result),
-            Some(other) => Err(format!(
-                "predicate Result.Ok payload must be bool, got {}",
-                other.type_name()
-            )),
-            None => Err("predicate Result.Ok payload is missing".to_string()),
-        },
-        VmValue::EnumVariant {
-            enum_name,
-            variant,
-            fields,
-        } if enum_name.as_ref() == "Result" && variant.as_ref() == "Err" => Err(fields
-            .first()
-            .map(VmValue::display)
-            .unwrap_or_else(|| "predicate returned Result.Err".to_string())),
+        VmValue::EnumVariant(enum_variant) if enum_variant.is_variant("Result", "Ok") => {
+            match enum_variant.fields.first() {
+                Some(VmValue::Bool(result)) => Ok(*result),
+                Some(other) => Err(format!(
+                    "predicate Result.Ok payload must be bool, got {}",
+                    other.type_name()
+                )),
+                None => Err("predicate Result.Ok payload is missing".to_string()),
+            }
+        }
+        VmValue::EnumVariant(enum_variant) if enum_variant.is_variant("Result", "Err") => {
+            Err(enum_variant
+                .fields
+                .first()
+                .map(VmValue::display)
+                .unwrap_or_else(|| "predicate returned Result.Err".to_string()))
+        }
         other => Err(format!(
             "predicate must return bool or Result<bool, _>, got {}",
             other.type_name()

--- a/crates/harn-vm/src/typecheck.rs
+++ b/crates/harn-vm/src/typecheck.rs
@@ -143,7 +143,7 @@ fn matches_type_with_generics(
             "sync_permit" => matches!(value, VmValue::SyncPermit(_)),
             "mcp_client" => matches!(value, VmValue::McpClient(_)),
             "pair" => matches!(value, VmValue::Pair(_)),
-            "enum" => matches!(value, VmValue::EnumVariant { .. }),
+            "enum" => matches!(value, VmValue::EnumVariant(_)),
             "struct" => matches!(value, VmValue::StructInstance { .. }),
             "closure" => matches!(
                 value,
@@ -156,7 +156,7 @@ fn matches_type_with_generics(
                     value
                         .struct_name()
                         .is_some_and(|struct_name| struct_name == name)
-                        || matches!(value, VmValue::EnumVariant { enum_name, .. } if enum_name.as_ref() == name)
+                        || matches!(value, VmValue::EnumVariant(enum_variant) if enum_variant.has_enum_name(name))
                 }
             }
         },

--- a/crates/harn-vm/src/value/core.rs
+++ b/crates/harn-vm/src/value/core.rs
@@ -76,12 +76,30 @@ impl StructLayout {
     }
 }
 
+/// Runtime payload for a Harn enum variant.
+#[derive(Debug, Clone)]
+pub struct VmEnumVariant {
+    pub enum_name: Rc<str>,
+    pub variant: Rc<str>,
+    pub fields: Rc<Vec<VmValue>>,
+}
+
+impl VmEnumVariant {
+    pub fn has_enum_name(&self, enum_name: &str) -> bool {
+        self.enum_name.as_ref() == enum_name
+    }
+
+    pub fn is_variant(&self, enum_name: &str, variant: &str) -> bool {
+        self.has_enum_name(enum_name) && self.variant.as_ref() == variant
+    }
+}
+
 /// VM runtime value.
 ///
-/// Rare compound payloads use shared pointers so cloning or moving common
-/// values does not pay for the largest enum alternatives. Unsafe layouts such
-/// as NaN boxing or tagged pointers are deliberately deferred until Harn has a
-/// stronger object/heap story.
+/// Rare compound payloads use shared pointers so stack/local-slot traffic is
+/// bounded by the common scalar and pointer-sized value shapes. Unsafe layouts
+/// such as NaN boxing or tagged pointers are deliberately deferred until Harn
+/// has a stronger object/heap story.
 #[derive(Debug, Clone)]
 pub enum VmValue {
     Int(i64),
@@ -104,24 +122,20 @@ pub enum VmValue {
         name: Rc<str>,
     },
     Duration(i64),
-    EnumVariant {
-        enum_name: Rc<str>,
-        variant: Rc<str>,
-        fields: Rc<Vec<VmValue>>,
-    },
+    EnumVariant(Rc<VmEnumVariant>),
     StructInstance {
         layout: Rc<StructLayout>,
         fields: Rc<Vec<Option<VmValue>>>,
     },
-    TaskHandle(String),
-    Channel(VmChannelHandle),
-    Atomic(VmAtomicHandle),
-    Rng(VmRngHandle),
-    SyncPermit(VmSyncPermitHandle),
-    McpClient(VmMcpClientHandle),
+    TaskHandle(Rc<str>),
+    Channel(Rc<VmChannelHandle>),
+    Atomic(Rc<VmAtomicHandle>),
+    Rng(Rc<VmRngHandle>),
+    SyncPermit(Rc<VmSyncPermitHandle>),
+    McpClient(Rc<VmMcpClientHandle>),
     Set(Rc<Vec<VmValue>>),
-    Generator(VmGenerator),
-    Stream(VmStream),
+    Generator(Rc<VmGenerator>),
+    Stream(Rc<VmStream>),
     Range(VmRange),
     /// Lazy iterator handle. Single-pass, fused. See `crate::vm::iter::VmIter`.
     Iter(Rc<RefCell<crate::vm::iter::VmIter>>),
@@ -132,9 +146,9 @@ pub enum VmValue {
     Pair(Rc<(VmValue, VmValue)>),
     /// Capability handle threaded into `main(harness: Harness)`. The same
     /// variant carries the root handle and each typed sub-handle (`stdio`,
-    /// `clock`, `fs`, `env`, `random`, `net`) so they share one inline
-    /// payload but stay distinguishable via `VmHarness::kind`.
-    Harness(VmHarness),
+    /// `clock`, `fs`, `env`, `random`, `net`) so they share one value shape
+    /// but stay distinguishable via `VmHarness::kind`.
+    Harness(Rc<VmHarness>),
 }
 
 impl VmValue {
@@ -143,11 +157,47 @@ impl VmValue {
         variant: impl Into<Rc<str>>,
         fields: Vec<VmValue>,
     ) -> Self {
-        VmValue::EnumVariant {
+        VmValue::EnumVariant(Rc::new(VmEnumVariant {
             enum_name: enum_name.into(),
             variant: variant.into(),
             fields: Rc::new(fields),
-        }
+        }))
+    }
+
+    pub fn task_handle(id: impl Into<Rc<str>>) -> Self {
+        VmValue::TaskHandle(id.into())
+    }
+
+    pub fn channel(handle: VmChannelHandle) -> Self {
+        VmValue::Channel(Rc::new(handle))
+    }
+
+    pub fn atomic(handle: VmAtomicHandle) -> Self {
+        VmValue::Atomic(Rc::new(handle))
+    }
+
+    pub fn rng(handle: VmRngHandle) -> Self {
+        VmValue::Rng(Rc::new(handle))
+    }
+
+    pub fn sync_permit(handle: VmSyncPermitHandle) -> Self {
+        VmValue::SyncPermit(Rc::new(handle))
+    }
+
+    pub fn mcp_client(handle: VmMcpClientHandle) -> Self {
+        VmValue::McpClient(Rc::new(handle))
+    }
+
+    pub fn generator(generator: VmGenerator) -> Self {
+        VmValue::Generator(Rc::new(generator))
+    }
+
+    pub fn stream(stream: VmStream) -> Self {
+        VmValue::Stream(Rc::new(stream))
+    }
+
+    pub fn harness(handle: VmHarness) -> Self {
+        VmValue::Harness(Rc::new(handle))
     }
 
     pub fn struct_instance(
@@ -171,7 +221,7 @@ impl VmValue {
             VmValue::BuiltinRef(_) => true,
             VmValue::BuiltinRefId { .. } => true,
             VmValue::Duration(ms) => *ms != 0,
-            VmValue::EnumVariant { .. } => true,
+            VmValue::EnumVariant(_) => true,
             VmValue::StructInstance { .. } => true,
             VmValue::TaskHandle(_) => true,
             VmValue::Channel(_) => true,
@@ -205,7 +255,7 @@ impl VmValue {
             VmValue::BuiltinRef(_) => "builtin",
             VmValue::BuiltinRefId { .. } => "builtin",
             VmValue::Duration(_) => "duration",
-            VmValue::EnumVariant { .. } => "enum",
+            VmValue::EnumVariant(_) => "enum",
             VmValue::StructInstance { .. } => "struct",
             VmValue::TaskHandle(_) => "task_handle",
             VmValue::Channel(_) => "channel",
@@ -399,16 +449,12 @@ impl VmValue {
                     let _ = write!(out, "{}{}ms", sign, abs_ms);
                 }
             }
-            VmValue::EnumVariant {
-                enum_name,
-                variant,
-                fields,
-            } => {
-                if fields.is_empty() {
-                    let _ = write!(out, "{enum_name}.{variant}");
+            VmValue::EnumVariant(enum_variant) => {
+                if enum_variant.fields.is_empty() {
+                    let _ = write!(out, "{}.{}", enum_variant.enum_name, enum_variant.variant);
                 } else {
-                    let _ = write!(out, "{enum_name}.{variant}(");
-                    for (i, v) in fields.iter().enumerate() {
+                    let _ = write!(out, "{}.{}(", enum_variant.enum_name, enum_variant.variant);
+                    for (i, v) in enum_variant.fields.iter().enumerate() {
                         if i > 0 {
                             out.push_str(", ");
                         }

--- a/crates/harn-vm/src/value/mod.rs
+++ b/crates/harn-vm/src/value/mod.rs
@@ -4,7 +4,9 @@ mod error;
 mod handles;
 mod structural;
 
-pub use core::{struct_fields_to_map, StructLayout, VmAsyncBuiltinFn, VmBuiltinFn, VmValue};
+pub use core::{
+    struct_fields_to_map, StructLayout, VmAsyncBuiltinFn, VmBuiltinFn, VmEnumVariant, VmValue,
+};
 pub use env::{closest_match, ModuleFunctionRegistry, ModuleState, VmClosure, VmEnv};
 pub use error::{
     categorized_error, classify_error_message, error_to_category, ArgTypeMismatchError,

--- a/crates/harn-vm/src/value/structural.rs
+++ b/crates/harn-vm/src/value/structural.rs
@@ -168,22 +168,14 @@ pub fn values_equal(a: &VmValue, b: &VmValue) -> bool {
                     .zip(b.iter())
                     .all(|((k1, v1), (k2, v2))| k1 == k2 && values_equal(v1, v2))
         }
-        (
-            VmValue::EnumVariant {
-                enum_name: a_e,
-                variant: a_v,
-                fields: a_f,
-            },
-            VmValue::EnumVariant {
-                enum_name: b_e,
-                variant: b_v,
-                fields: b_f,
-            },
-        ) => {
-            a_e == b_e
-                && a_v == b_v
-                && a_f.len() == b_f.len()
-                && a_f.iter().zip(b_f.iter()).all(|(x, y)| values_equal(x, y))
+        (VmValue::EnumVariant(a), VmValue::EnumVariant(b)) => {
+            a.enum_name == b.enum_name
+                && a.variant == b.variant
+                && a.fields.len() == b.fields.len()
+                && a.fields
+                    .iter()
+                    .zip(b.fields.iter())
+                    .all(|(x, y)| values_equal(x, y))
         }
         (
             VmValue::StructInstance {

--- a/crates/harn-vm/src/value/tests.rs
+++ b/crates/harn-vm/src/value/tests.rs
@@ -5,9 +5,11 @@ use super::*;
 #[cfg(target_pointer_width = "64")]
 #[test]
 fn vm_value_layout_budget() {
-    assert_eq!(std::mem::size_of::<VmValue>(), 48);
-    assert_eq!(std::mem::size_of::<Option<VmValue>>(), 48);
+    assert_eq!(std::mem::size_of::<VmValue>(), 32);
+    assert_eq!(std::mem::size_of::<Option<VmValue>>(), 32);
+    assert_eq!(std::mem::size_of::<Rc<VmEnumVariant>>(), 8);
     assert_eq!(std::mem::size_of::<VmChannelHandle>(), 40);
+    assert_eq!(std::mem::size_of::<Rc<VmChannelHandle>>(), 8);
     assert_eq!(std::mem::size_of::<VmAtomicHandle>(), 8);
     assert_eq!(std::mem::size_of::<VmRange>(), 24);
     assert_eq!(std::mem::size_of::<VmGenerator>(), 16);

--- a/crates/harn-vm/src/vm/execution.rs
+++ b/crates/harn-vm/src/vm/execution.rs
@@ -177,8 +177,8 @@ impl Vm {
             if !handler.error_type.is_empty() {
                 // Typed catch: only match when the thrown enum's type equals the declared type.
                 let matches = match &thrown_value {
-                    VmValue::EnumVariant { enum_name, .. } => {
-                        enum_name.as_ref() == handler.error_type
+                    VmValue::EnumVariant(enum_variant) => {
+                        enum_variant.has_enum_name(&handler.error_type)
                     }
                     _ => false,
                 };

--- a/crates/harn-vm/src/vm/iter.rs
+++ b/crates/harn-vm/src/vm/iter.rs
@@ -66,11 +66,11 @@ pub enum VmIter {
     /// Unicode scalar iteration over a string.
     Chars { s: Rc<str>, byte_idx: usize },
     /// Drains a generator's yield channel.
-    Gen { gen: VmGenerator },
+    Gen { gen: Rc<VmGenerator> },
     /// Drains a stream's emit channel.
-    Stream { stream: VmStream },
+    Stream { stream: Rc<VmStream> },
     /// Reads from a channel handle.
-    Chan { handle: VmChannelHandle },
+    Chan { handle: Rc<VmChannelHandle> },
     /// Maps each item through a closure.
     Map {
         inner: Rc<RefCell<VmIter>>,

--- a/crates/harn-vm/src/vm/ops/call.rs
+++ b/crates/harn-vm/src/vm/ops/call.rs
@@ -431,7 +431,7 @@ impl super::super::Vm {
         if name == "await" {
             crate::typecheck::validate_builtin_call(name, args, None)?;
             let task_id = args.first().and_then(|a| match a {
-                VmValue::TaskHandle(id) => Some(id.clone()),
+                VmValue::TaskHandle(id) => Some(id.to_string()),
                 _ => None,
             });
             if let Some(id) = task_id {
@@ -458,7 +458,7 @@ impl super::super::Vm {
         if name == "cancel" {
             crate::typecheck::validate_builtin_call(name, args, None)?;
             if let Some(VmValue::TaskHandle(id)) = args.first() {
-                if let Some(handle) = self.spawned_tasks.remove(id) {
+                if let Some(handle) = self.spawned_tasks.remove(id.as_ref()) {
                     handle.handle.abort();
                 }
             }
@@ -469,7 +469,7 @@ impl super::super::Vm {
         if name == "cancel_graceful" {
             crate::typecheck::validate_builtin_call(name, args, None)?;
             let task_id = args.first().and_then(|a| match a {
-                VmValue::TaskHandle(id) => Some(id.clone()),
+                VmValue::TaskHandle(id) => Some(id.to_string()),
                 _ => None,
             });
             let timeout_ms = args

--- a/crates/harn-vm/src/vm/ops/collections.rs
+++ b/crates/harn-vm/src/vm/ops/collections.rs
@@ -112,11 +112,11 @@ impl super::super::Vm {
             }
             (PropertyCacheTarget::PairFirst, VmValue::Pair(p)) => Some(p.0.clone()),
             (PropertyCacheTarget::PairSecond, VmValue::Pair(p)) => Some(p.1.clone()),
-            (PropertyCacheTarget::EnumVariant, VmValue::EnumVariant { variant, .. }) => {
-                Some(VmValue::String(Rc::clone(variant)))
+            (PropertyCacheTarget::EnumVariant, VmValue::EnumVariant(enum_variant)) => {
+                Some(VmValue::String(Rc::clone(&enum_variant.variant)))
             }
-            (PropertyCacheTarget::EnumFields, VmValue::EnumVariant { fields, .. }) => {
-                Some(VmValue::List(fields.clone()))
+            (PropertyCacheTarget::EnumFields, VmValue::EnumVariant(enum_variant)) => {
+                Some(VmValue::List(Rc::clone(&enum_variant.fields)))
             }
             _ => None,
         }
@@ -150,7 +150,7 @@ impl super::super::Vm {
                 "second" => Some(PropertyCacheTarget::PairSecond),
                 _ => None,
             },
-            VmValue::EnumVariant { .. } => match name {
+            VmValue::EnumVariant(_) => match name {
                 "variant" => Some(PropertyCacheTarget::EnumVariant),
                 "fields" => Some(PropertyCacheTarget::EnumFields),
                 _ => None,
@@ -175,11 +175,9 @@ impl super::super::Vm {
                 "empty" => VmValue::Bool(s.is_empty()),
                 _ => VmValue::Nil,
             },
-            VmValue::EnumVariant {
-                variant, fields, ..
-            } => match name {
-                "variant" => VmValue::String(Rc::clone(variant)),
-                "fields" => VmValue::List(fields.clone()),
+            VmValue::EnumVariant(enum_variant) => match name {
+                "variant" => VmValue::String(Rc::clone(&enum_variant.variant)),
+                "fields" => VmValue::List(Rc::clone(&enum_variant.fields)),
                 _ => VmValue::Nil,
             },
             VmValue::StructInstance { layout, fields } => layout
@@ -198,7 +196,7 @@ impl super::super::Vm {
                 }
             },
             VmValue::Harness(handle) => match handle.sub_handle(name) {
-                Some(sub) => VmValue::Harness(sub),
+                Some(sub) => VmValue::harness(sub),
                 None if optional => VmValue::Nil,
                 None => {
                     return Err(VmError::TypeError(format!(
@@ -614,11 +612,9 @@ impl super::super::Vm {
         let variant_name = Self::const_string(&frame.chunk.constants[variant_idx])?;
         let val = self.pop()?;
         let matches = match &val {
-            VmValue::EnumVariant {
-                enum_name: en,
-                variant: vn,
-                ..
-            } => en.as_ref() == enum_name && vn.as_ref() == variant_name,
+            VmValue::EnumVariant(enum_variant) => {
+                enum_variant.is_variant(&enum_name, &variant_name)
+            }
             _ => false,
         };
         self.stack.push(val);

--- a/crates/harn-vm/src/vm/ops/exception.rs
+++ b/crates/harn-vm/src/vm/ops/exception.rs
@@ -35,14 +35,10 @@ impl super::super::Vm {
     pub(super) fn execute_try_unwrap(&mut self) -> Result<(), VmError> {
         let val = self.pop()?;
         match &val {
-            VmValue::EnumVariant {
-                enum_name,
-                variant,
-                fields,
-            } if enum_name.as_ref() == "Result" => {
-                if variant.as_ref() == "Ok" {
+            VmValue::EnumVariant(enum_variant) if enum_variant.has_enum_name("Result") => {
+                if enum_variant.is_variant("Result", "Ok") {
                     self.stack
-                        .push(fields.first().cloned().unwrap_or(VmValue::Nil));
+                        .push(enum_variant.fields.first().cloned().unwrap_or(VmValue::Nil));
                     Ok(())
                 } else {
                     Err(VmError::Return(val))
@@ -58,7 +54,7 @@ impl super::super::Vm {
     pub(super) fn execute_try_wrap_ok(&mut self) -> Result<(), VmError> {
         let val = self.pop()?;
         match &val {
-            VmValue::EnumVariant { enum_name, .. } if enum_name.as_ref() == "Result" => {
+            VmValue::EnumVariant(enum_variant) if enum_variant.has_enum_name("Result") => {
                 self.stack.push(val);
             }
             _ => {

--- a/crates/harn-vm/src/vm/ops/parallel.rs
+++ b/crates/harn-vm/src/vm/ops/parallel.rs
@@ -266,7 +266,7 @@ impl super::super::Vm {
                     cancel.subscribe(),
                     "Parallel map stream error",
                 ));
-                self.stack.push(VmValue::Stream(VmStream {
+                self.stack.push(VmValue::stream(VmStream {
                     done: Rc::new(std::cell::Cell::new(false)),
                     receiver: Rc::new(tokio::sync::Mutex::new(rx)),
                     cancel: Some(cancel),
@@ -367,7 +367,7 @@ impl super::super::Vm {
                     cancel_token,
                 },
             );
-            self.stack.push(VmValue::TaskHandle(task_id));
+            self.stack.push(VmValue::task_handle(task_id));
         } else {
             self.stack.push(VmValue::Nil);
         }

--- a/crates/harn-vm/src/vm/scope.rs
+++ b/crates/harn-vm/src/vm/scope.rs
@@ -155,7 +155,7 @@ impl Vm {
 
         if let Err(error) = crate::typecheck::validate_user_call(&closure.func, args, None) {
             let _ = tx.try_send(Err(error));
-            return VmValue::Generator(VmGenerator {
+            return VmValue::generator(VmGenerator {
                 done: Rc::new(std::cell::Cell::new(false)),
                 receiver: Rc::new(tokio::sync::Mutex::new(rx)),
             });
@@ -207,14 +207,14 @@ impl Vm {
 
         let receiver = Rc::new(tokio::sync::Mutex::new(rx));
         if closure.func.is_stream {
-            return VmValue::Stream(VmStream {
+            return VmValue::stream(VmStream {
                 done: Rc::new(std::cell::Cell::new(false)),
                 receiver,
                 cancel: None,
             });
         }
 
-        VmValue::Generator(VmGenerator {
+        VmValue::generator(VmGenerator {
             done: Rc::new(std::cell::Cell::new(false)),
             receiver,
         })

--- a/crates/harn-vm/src/vm/state.rs
+++ b/crates/harn-vm/src/vm/state.rs
@@ -110,10 +110,10 @@ pub(crate) enum IterState {
         closed: std::sync::Arc<std::sync::atomic::AtomicBool>,
     },
     Generator {
-        gen: crate::value::VmGenerator,
+        gen: std::rc::Rc<crate::value::VmGenerator>,
     },
     Stream {
-        stream: crate::value::VmStream,
+        stream: std::rc::Rc<crate::value::VmStream>,
     },
     /// Step through a lazy range without materializing a Vec.
     /// Inclusive ranges keep `end` as an actual value so `i64::MAX to i64::MAX`


### PR DESCRIPTION
Fixes #2092.

## Summary
- Box rare and large `VmValue` payloads behind `Rc`, including channels, generators, streams, MCP clients, harness handles, sync permits, atomics, and RNG state.
- Store enum variant payloads in a compact shared `VmEnumVariant` wrapper and route enum checks through helpers.
- Tighten the `VmValue` layout budget from 48 bytes to 32 bytes while preserving cross-crate behavior.

## Verification
- `cargo check -p harn-vm -p harn-cli -p harn-dap`
- `cargo clippy -p harn-vm -p harn-cli -p harn-dap --all-targets -- -D warnings`
- `cargo test -p harn-vm vm_value_layout_budget -- --nocapture`
- `cargo test -p harn-vm schema::tests:: -- --nocapture`
- `/tmp/harn-target-2c46-2092/debug/harn test conformance --filter try_expr`
- `/tmp/harn-target-2c46-2092/debug/harn test conformance --filter try_operator`
- `/tmp/harn-target-2c46-2092/debug/harn test conformance --filter enum_basic`
- `/tmp/harn-target-2c46-2092/debug/harn test conformance --filter typed_catch`
- `/tmp/harn-target-2c46-2092/debug/harn test conformance --filter enum_match`
- `/tmp/harn-target-2c46-2092/debug/harn test conformance --filter generic_structs_and_enums`
- `HARN_BIN=/tmp/harn-target-2c46-2092/debug/harn HARN_CACHE_DIR=/tmp/harn-bench-cache-2092 scripts/bench_vm.sh --no-build --iterations 1`
- Pre-commit hook: Rust fmt, workspace clippy, CI ratchets, generated highlight keyword sync
- Pre-push hook: targeted local checks, generated highlight keyword drift check
