### PR TITLE
perf(vm): split Op::CallBuiltin into sync/async halves

### DIFF
--- a/crates/harn-vm/src/vm/ops/call.rs
+++ b/crates/harn-vm/src/vm/ops/call.rs
@@ -724,7 +724,71 @@ impl super::super::Vm {
         Ok(())
     }
 
-    pub(super) async fn execute_call_builtin(&mut self) -> Result<(), VmError> {
+    /// Sync fast path for `Op::CallBuiltin` — the opcode user-level `f(x)`
+    /// calls compile to via [`Compiler::emit_named_call`]. Peeks the
+    /// operand (`u64 id + u16 name_idx + u8 argc` = 11 bytes) without
+    /// touching `ip`; if the name resolves to a regular non-generator
+    /// user closure with no `@step` definition attached, pushes the
+    /// closure frame inline and returns `Some(Ok(()))`. Returns `None`
+    /// without advancing the frame when the call needs the async path
+    /// (special-name builtins like `await`/`cancel`, generators, step-
+    /// decorated functions, or names that resolve to a registered
+    /// builtin instead of a user closure).
+    ///
+    /// Mirrors [`execute_call_sync`] and [`execute_iter_next_sync`]:
+    /// since `ip` is untouched on the `None` hand-off, the async path
+    /// reads the operand exactly once. Collapses the same five-async-
+    /// state-machine chain (`execute_call_builtin` →
+    /// `call_named_value` → `try_call_special_name` →
+    /// `resolve_named_closure` → `call_user_closure` →
+    /// `run_step_pre_hooks`) that the steady-state untracked
+    /// user-closure call would otherwise traverse, each of which
+    /// resolves synchronously in the hot case but still pays the
+    /// future-state-machine tax.
+    pub(super) fn execute_call_builtin_sync(&mut self) -> Option<Result<(), VmError>> {
+        let frame = self.frames.last().unwrap();
+        let name_idx = frame.chunk.read_u16(frame.ip + 8) as usize;
+        let argc = frame.chunk.code[frame.ip + 10] as usize;
+        let name = Self::const_str(&frame.chunk.constants[name_idx]).ok()?;
+
+        // Names handled by `try_call_special_name` are runtime constructs
+        // (`await`, `cancel`, ...) that must run on the async path even if
+        // the user happens to define a function with the same name —
+        // matching the async dispatcher's first-check semantics.
+        if matches!(
+            name,
+            "await"
+                | "cancel"
+                | "cancel_graceful"
+                | "is_cancelled"
+                | "__signal_on_interrupt"
+                | "__signal_off_interrupt"
+                | "__signal_interrupted"
+                | "__signal_raise"
+        ) {
+            return None;
+        }
+
+        let closure = self.resolve_named_closure(name)?;
+        if closure.func.is_generator {
+            return None;
+        }
+        if crate::step_runtime::step_definition_for_function(&closure.func.name).is_some() {
+            return None;
+        }
+
+        let frame = self.frames.last_mut().unwrap();
+        frame.ip += 11;
+        let args: Vec<VmValue> = self.stack.split_off(self.stack.len().saturating_sub(argc));
+        Some(self.push_closure_frame(&closure, &args))
+    }
+
+    /// Async slow path for `Op::CallBuiltin`. Identical in behavior to
+    /// the pre-split `execute_call_builtin`. The caller
+    /// (`execute_op_async`) reaches this only after
+    /// [`execute_call_builtin_sync`] returned `None` without touching
+    /// `ip`, so this path reads the operand exactly once.
+    pub(super) async fn execute_call_builtin_async(&mut self) -> Result<(), VmError> {
         let frame = self.frames.last_mut().unwrap();
         let id = BuiltinId::from_raw(frame.chunk.read_u64(frame.ip));
         frame.ip += 8;

--- a/crates/harn-vm/src/vm/ops/mod.rs
+++ b/crates/harn-vm/src/vm/ops/mod.rs
@@ -114,6 +114,14 @@ impl super::Vm {
             // and fall through to `execute_call_async` without touching
             // `ip`.
             Op::Call => return self.execute_call_sync(),
+            // CallBuiltin is the opcode `f(x)` compiles to and the
+            // actual hot dispatch for user closures. The sync fast path
+            // peeks the name from the inline operand, skips
+            // runtime-construct names (`await`/`cancel`/...), generators,
+            // and `@step`-decorated functions, then pushes the closure
+            // frame inline. Builtins and the listed escape hatches fall
+            // through to `execute_call_builtin_async` with `ip` untouched.
+            Op::CallBuiltin => return self.execute_call_builtin_sync(),
             Op::Throw => self.execute_throw(),
             Op::TryCatchSetup => {
                 self.execute_try_catch_setup();
@@ -178,8 +186,7 @@ impl super::Vm {
             // `execute_op_async`. Keeping these in a single explicit arm
             // keeps the sync/async classification visible alongside the
             // sync dispatch table.
-            Op::CallBuiltin
-            | Op::CallBuiltinSpread
+            Op::CallBuiltinSpread
             | Op::TailCall
             | Op::MethodCall
             | Op::MethodCallOpt
@@ -204,7 +211,7 @@ impl super::Vm {
     pub(super) async fn execute_op_async(&mut self, op: Op) -> Result<(), VmError> {
         match op {
             Op::Call => self.execute_call_async().await,
-            Op::CallBuiltin => self.execute_call_builtin().await,
+            Op::CallBuiltin => self.execute_call_builtin_async().await,
             Op::CallBuiltinSpread => self.execute_call_builtin_spread().await,
             Op::TailCall => self.execute_tail_call().await,
             Op::MethodCall => self.execute_method_call(false).await,


### PR DESCRIPTION
## Summary

Closes #2085. Applies the proven sync/async dispatch split from #2072,
#2074, and #2080 to `Op::CallBuiltin` — the opcode user-level `f(x)`
calls compile to via `emit_named_call`, and the actual hot dispatch
for steady-state user closure calls.

- `execute_call_builtin_sync(&mut self) -> Option<Result<(), VmError>>`
  peeks the inline operand (`u64 id + u16 name_idx + u8 argc` = 11 bytes)
  without touching `ip`. When the name resolves to a regular non-generator
  user closure with no `@step` definition attached, it pushes the closure
  frame inline and returns `Some(Ok(()))`. Returns `None` without advancing
  `ip` for special-name builtins (`await`, `cancel`, `cancel_graceful`,
  `is_cancelled`, `__signal_*`), generators, step-decorated functions, or
  names that resolve to a registered builtin instead of a user closure.
- `execute_call_builtin_async(&mut self) -> Result<(), VmError>` retains
  the previous `execute_call_builtin` body verbatim. The caller reaches
  it only on the `None` hand-off, so the operand is read exactly once
  across the two paths.
- Wired through `execute_op_sync` / `execute_op_async`: coverage parity
  over `Op` variants is preserved by the exhaustive sync match.

Collapses the five-async-state-machine chain (`execute_call_builtin →
call_named_value → try_call_special_name → resolve_named_closure →
call_user_closure → run_step_pre_hooks`) that the steady-state untracked
user-closure call traverses on every `f(x)`. Each of those `.await`s
resolves synchronously in the hot case but still pays the
future-state-machine tax.

## Perf

Best-of-three `min_ms` across 3 alternating baseline/optimized passes
(`scripts/bench_vm.sh --no-build --iterations 20`):

| benchmark                  | base_min |  opt_min |   Δmin% |
|----------------------------|---------:|---------:|--------:|
| function_call_loop         |    70.21 |    62.38 |  **-11.2%** |
| dict_property_read         |    59.61 |    55.57 |   -6.8% |
| struct_field_read          |    62.85 |    59.90 |   -4.7% |
| local_variable_lookup      |   117.13 |   111.76 |   -4.6% |
| dict_subscript_assign      |    15.74 |    15.30 |   -2.8% |
| string_interpolation_loop  |    10.13 |     9.89 |   -2.4% |
| filter_nil_loop            |    44.45 |    43.41 |   -2.3% |
| method_call_dispatch       |    52.09 |    51.29 |   -1.5% |
| list_iteration             |    14.59 |    14.41 |   -1.2% |
| list_map_filter            |   149.87 |   149.24 |   -0.4% |
| recursive_countdown        |    15.30 |    15.49 |   +1.2% |
| arithmetic_loop            |    67.71 |    68.86 |   +1.7% |
| dict_merge_loop            |    32.33 |    33.25 |   +2.8% |
| comparison_loop            |   101.21 |   104.83 |   +3.6% |
| agent_tool_dispatch        |    85.05 |    88.24 |   +3.8% |

`function_call_loop` lands at **-11.2%** — squarely inside the 5-15%
band predicted by #2085 and on the fixture this opcode actually
dispatches. Wins flow naturally to call-heavy fixtures
(`dict_property_read`, `struct_field_read`, `local_variable_lookup`)
that drive user-level helpers like `__assert_*`. The remaining swings
sit within the code-layout-noise band identified by #2080.

Benches were collected on a release build with LTO disabled (host
machine constraints); both baselines and optimized binaries used the
same profile so the relative comparison is valid.

## Test plan

- [x] `cargo nextest run -p harn-vm` — 2436/2436 pass, 2 skipped.
- [x] `cargo run --bin harn -- test conformance` — 1381/1381 pass.
  Existing `await(handle)` / generator / `@step` conformance fixtures
  give continuous coverage of every async fall-through arm.
- [x] `cargo clippy -p harn-vm --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --check -p harn-vm` — clean.
- [x] Pre-push hook (targeted package checks, gen-file drift) — clean.
- [x] Coverage parity: `execute_op_sync` / `execute_op_async` match
  arms remain exhaustive over `Op`.
- [x] No banned test patterns introduced (no test files touched).
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)