### PR TITLE
perf(typechecker): share scope parent via Rc to make typecheck linear (#2093)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,6 +178,20 @@ condensed series summaries instead of full per-patch history.
   `bindings/thread-harness-needs-param` surface-changing repair when a new
   `harness: Harness` parameter is required.
 
+- **Linear typecheck scaling on large files (#2093).** Restructures
+  `TypeScope.parent` from `Box<TypeScope>` (deep-cloned on every scope
+  entry) to `Rc<TypeScope>` so child scope creation is an `Rc::clone`
+  rather than a recursive copy of the parent chain. Each function /
+  pipeline body now enters its scope via a refcount bump against the
+  shared root, and non-generic call sites skip the per-call
+  `call_scope.clone()` by borrowing the caller's scope directly.
+  Cold-start typecheck phase on a synthetic file with one-line fns and
+  500 call sites in the main pipeline drops from previously
+  super-linear to flat O(n): 500 fns 69 ms → 3 ms (23×), 2000 fns
+  438 ms → 6 ms (73×), 5000 fns 2.18 s → 14 ms (156×), 10000 fns
+  8.27 s → 29 ms (285×). LSP re-typecheck on save and `harn check` in
+  pre-commit on large projects pick up the same speedup.
+
 ## v0.8.27
 
 ### Added

--- a/crates/harn-parser/src/typechecker/inference/calls.rs
+++ b/crates/harn-parser/src/typechecker/inference/calls.rs
@@ -291,14 +291,21 @@ impl TypeChecker {
             }
         }
 
-        let call_scope = if sig.type_params.is_empty() {
-            scope.clone()
+        // `call_scope` only needs to differ from `scope` when the callee
+        // declares its own generic type params (which must be visible while
+        // we check this call's arguments). The common case — calling a
+        // non-generic builtin — borrows `scope` directly, sparing a clone
+        // per call. Otherwise we allocate a child that adds those names.
+        let call_scope_owned;
+        let call_scope: &TypeScope = if sig.type_params.is_empty() {
+            scope
         } else {
             let mut s = scope.child();
             for tp_name in sig.type_params {
                 s.generic_type_params.insert((*tp_name).to_string());
             }
-            s
+            call_scope_owned = s;
+            &call_scope_owned
         };
 
         let type_param_names = sig.type_param_names();
@@ -343,13 +350,13 @@ impl TypeChecker {
                         param.name,
                         &expected,
                         arg,
-                        &call_scope,
+                        call_scope,
                     );
                 }
-                let compatible = self.types_compatible(&expected, actual, &call_scope)
+                let compatible = self.types_compatible(&expected, actual, call_scope)
                     || (param.optional
                         && without_nil(actual).is_none_or(|non_nil| {
-                            self.types_compatible(&expected, &non_nil, &call_scope)
+                            self.types_compatible(&expected, &non_nil, call_scope)
                         }));
                 if !compatible {
                     self.type_mismatch_at(
@@ -359,7 +366,7 @@ impl TypeChecker {
                         actual,
                         arg.span,
                         (None, Some(arg.span)),
-                        &call_scope,
+                        call_scope,
                     );
                 }
             }
@@ -1208,16 +1215,20 @@ impl TypeChecker {
                     );
                 }
             }
-            // Build a scope that includes the function's generic type params
-            // so they are treated as compatible with any concrete type.
-            let call_scope = if sig.type_param_names.is_empty() {
-                scope.clone()
+            // Most callees have no generic type params and can reuse the
+            // caller's scope by reference. The branch with a child scope
+            // is only allocated when generic names need to be visible
+            // during arg checking.
+            let call_scope_owned;
+            let call_scope: &TypeScope = if sig.type_param_names.is_empty() {
+                scope
             } else {
                 let mut s = scope.child();
                 for tp_name in &sig.type_param_names {
                     s.generic_type_params.insert(tp_name.clone());
                 }
-                s
+                call_scope_owned = s;
+                &call_scope_owned
             };
             let mut type_bindings: BTreeMap<String, TypeExpr> = BTreeMap::new();
             let type_param_set: std::collections::BTreeSet<String> =
@@ -1256,9 +1267,9 @@ impl TypeChecker {
                             param_name,
                             &expected,
                             arg,
-                            &call_scope,
+                            call_scope,
                         );
-                        if !self.types_compatible(&expected, actual, &call_scope) {
+                        if !self.types_compatible(&expected, actual, call_scope) {
                             self.type_mismatch_at(
                                 Code::ArgumentTypeMismatch,
                                 format!("argument {} `{}`", i + 1, param_name),
@@ -1271,7 +1282,7 @@ impl TypeChecker {
                                     }),
                                     Some(arg.span),
                                 ),
-                                &call_scope,
+                                call_scope,
                             );
                         }
                     }

--- a/crates/harn-parser/src/typechecker/inference/decls.rs
+++ b/crates/harn-parser/src/typechecker/inference/decls.rs
@@ -143,7 +143,7 @@ impl TypeChecker {
         is_stream: bool,
         expected_span: Span,
     ) {
-        let mut fn_scope = self.scope.child();
+        let mut fn_scope = TypeScope::child_of(&self.scope);
         // Register generic type parameters so they are treated as compatible
         // with any concrete type during type checking.
         for tp in type_params {

--- a/crates/harn-parser/src/typechecker/inference/entry.rs
+++ b/crates/harn-parser/src/typechecker/inference/entry.rs
@@ -6,6 +6,8 @@
 //! declaration order don't trip the strict cross-module undefined-name
 //! check.
 
+use std::rc::Rc;
+
 use crate::ast::*;
 use crate::diagnostic_codes::Code;
 
@@ -20,17 +22,21 @@ impl TypeChecker {
         mut self,
         program: &[SNode],
     ) -> (Vec<TypeDiagnostic>, Vec<InlayHintInfo>) {
-        Self::register_declarations_into(&mut self.scope, &self.imported_type_decls);
-        Self::register_imported_callable_signatures_into(
-            &mut self.scope,
-            &self.imported_callable_decls,
-        );
+        // Pre-pass mutations: nobody else holds an `Rc` to `self.scope`
+        // yet, so `Rc::make_mut` resolves to a direct `&mut TypeScope`
+        // without copying. Once body children start to share the root
+        // (via `child_of(&self.scope)`), the refcount climbs above 1 and
+        // any further `make_mut` would copy — but at that point we don't
+        // mutate `self.scope` directly, only its children.
+        let scope_mut = Rc::make_mut(&mut self.scope);
+        Self::register_declarations_into(scope_mut, &self.imported_type_decls);
+        Self::register_imported_callable_signatures_into(scope_mut, &self.imported_callable_decls);
         // First pass: collect declarations (type/enum/struct/interface) into scope
         // before type-checking bodies so forward references resolve.
-        Self::register_declarations_into(&mut self.scope, program);
+        Self::register_declarations_into(scope_mut, program);
         for snode in program {
             if let Node::Pipeline { body, .. } = &snode.node {
-                Self::register_declarations_into(&mut self.scope, body);
+                Self::register_declarations_into(scope_mut, body);
             }
         }
         // Pre-register every top-level `fn`/`pipeline`/`tool` name so a
@@ -39,7 +45,7 @@ impl TypeChecker {
         // it as undefined. Signatures populated here are overwritten
         // when the body is actually walked; this pass only needs the
         // name to exist so `check_call`'s resolvability check passes.
-        Self::register_callable_placeholders(&mut self.scope, program);
+        Self::register_callable_placeholders(scope_mut, program);
 
         // Pre-pass: index `@deprecated` attributes on top-level fn decls so
         // `check_call` (and the standalone deprecation visitor below) can
@@ -86,7 +92,7 @@ impl TypeChecker {
                     body,
                     ..
                 } => {
-                    let mut child = self.scope.child();
+                    let mut child = TypeScope::child_of(&self.scope);
                     for p in params {
                         child.define_var(p, None);
                         child.clear_nil_widenable(p);
@@ -130,7 +136,7 @@ impl TypeChecker {
                             .collect(),
                         has_rest: params.last().is_some_and(|p| p.rest),
                     };
-                    self.scope.define_fn(name, sig);
+                    Rc::make_mut(&mut self.scope).define_fn(name, sig);
                     if name == "main" {
                         self.check_main_signature(params, snode.span);
                     }
@@ -145,18 +151,29 @@ impl TypeChecker {
                     );
                 }
                 _ => {
-                    let mut scope = self.scope.clone();
+                    // Top-level statements that aren't fn/pipeline decls
+                    // (e.g. bare `let` bindings). Type-check in a child
+                    // scope, then promote newly defined names back onto
+                    // the root so subsequent top-level nodes see them.
+                    //
+                    // Destructure to move the maps out and drop the
+                    // child's `Rc` reference to the parent before calling
+                    // `Rc::make_mut`; otherwise the live child clone would
+                    // force `make_mut` to copy the root scope.
+                    let mut scope = TypeScope::child_of(&self.scope);
                     self.check_node(snode, &mut scope);
-                    // Promote top-level definitions out of the temporary scope.
-                    for (name, ty) in scope.vars {
-                        self.scope.vars.entry(name).or_insert(ty);
+                    let TypeScope {
+                        vars,
+                        mutable_vars,
+                        nil_widenable_vars,
+                        ..
+                    } = scope;
+                    let root = Rc::make_mut(&mut self.scope);
+                    for (name, ty) in vars {
+                        root.vars.entry(name).or_insert(ty);
                     }
-                    for name in scope.mutable_vars {
-                        self.scope.mutable_vars.insert(name);
-                    }
-                    for (name, enabled) in scope.nil_widenable_vars {
-                        self.scope.nil_widenable_vars.insert(name, enabled);
-                    }
+                    root.mutable_vars.extend(mutable_vars);
+                    root.nil_widenable_vars.extend(nil_widenable_vars);
                 }
             }
         }

--- a/crates/harn-parser/src/typechecker/mod.rs
+++ b/crates/harn-parser/src/typechecker/mod.rs
@@ -1,4 +1,5 @@
 use std::collections::HashSet;
+use std::rc::Rc;
 
 use crate::ast::*;
 use crate::builtin_signatures;
@@ -95,7 +96,12 @@ pub enum DiagnosticSeverity {
 /// The static type checker.
 pub struct TypeChecker {
     diagnostics: Vec<TypeDiagnostic>,
-    scope: TypeScope,
+    /// Root scope shared by every child scope created during the walk.
+    /// `Rc` lets fn/pipeline body entries take a refcount bump instead of
+    /// deep-cloning the entire scope chain. Mutations during the pre-pass
+    /// (and the top-level non-callable arm) go through `Rc::make_mut`,
+    /// which is O(1) while the refcount is 1.
+    scope: Rc<TypeScope>,
     source: Option<String>,
     hints: Vec<InlayHintInfo>,
     /// When true, flag unvalidated boundary-API values used in field access.
@@ -152,7 +158,7 @@ impl TypeChecker {
     pub fn new() -> Self {
         Self {
             diagnostics: Vec::new(),
-            scope: TypeScope::new(),
+            scope: Rc::new(TypeScope::new()),
             source: None,
             hints: Vec::new(),
             strict_types: false,
@@ -172,7 +178,7 @@ impl TypeChecker {
     pub fn with_strict_types(strict: bool) -> Self {
         Self {
             diagnostics: Vec::new(),
-            scope: TypeScope::new(),
+            scope: Rc::new(TypeScope::new()),
             source: None,
             hints: Vec::new(),
             strict_types: strict,

--- a/crates/harn-parser/src/typechecker/scope.rs
+++ b/crates/harn-parser/src/typechecker/scope.rs
@@ -7,6 +7,7 @@
 //! gradual-typing alias (`InferredType`) and the variance polarity tracker.
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::rc::Rc;
 
 use crate::ast::*;
 use crate::builtin_signatures;
@@ -122,7 +123,11 @@ pub(super) struct TypeScope {
     /// type is a best-effort guess, and historical scripts treat them like
     /// loose dicts.
     pub(super) annotated_vars: BTreeSet<String>,
-    pub(super) parent: Option<Box<TypeScope>>,
+    /// Lexical parent. Held by `Rc` so creating a child scope is an
+    /// `Rc::clone` (constant time) rather than a deep clone of the entire
+    /// parent chain. Lookups walk this chain by shared reference; no
+    /// mutation ever travels through it.
+    pub(super) parent: Option<Rc<TypeScope>>,
 }
 
 /// Method signature extracted from an impl block (for interface checking).
@@ -211,7 +216,24 @@ impl TypeScope {
         scope
     }
 
+    /// Create a child scope. Wraps `self` in a fresh `Rc` for use as the
+    /// child's parent; prefer [`TypeScope::child_of`] whenever a parent
+    /// `Rc` is already available, since that turns scope entry into an
+    /// `Rc::clone` (constant time) regardless of parent chain depth.
     pub(super) fn child(&self) -> Self {
+        Self::child_with_parent(Rc::new(self.clone()))
+    }
+
+    /// Create a child scope that shares an existing `Rc<TypeScope>` as
+    /// its parent. This is the hot path for entering function / pipeline
+    /// bodies, where many siblings share the same root scope: the root
+    /// is wrapped in an `Rc` once and every child entry is then an
+    /// `Rc::clone` rather than a deep clone of the root's tables.
+    pub(super) fn child_of(parent: &Rc<TypeScope>) -> Self {
+        Self::child_with_parent(Rc::clone(parent))
+    }
+
+    fn child_with_parent(parent: Rc<TypeScope>) -> Self {
         Self {
             vars: BTreeMap::new(),
             functions: BTreeMap::new(),
@@ -229,7 +251,7 @@ impl TypeScope {
             untyped_sources: BTreeMap::new(),
             unknown_ruled_out: BTreeMap::new(),
             annotated_vars: BTreeSet::new(),
-            parent: Some(Box::new(self.clone())),
+            parent: Some(parent),
         }
     }
 


### PR DESCRIPTION
## Summary

- Restructures `TypeScope.parent` from `Box<TypeScope>` (deep-cloned on every scope entry) to `Rc<TypeScope>` so child scope creation is an `Rc::clone` instead of a recursive copy of the parent chain.
- Adds `TypeScope::child_of(&Rc<TypeScope>)` for the hot path where many sibling children share the root scope (top-level walk + `check_fn_body`). The non-`Rc` `child(&self)` slow path stays for deeper-nested call sites inside bodies.
- Also drops the per-call `scope.clone()` in `calls.rs` when the callee has no generic type params — `call_scope` now borrows the caller's scope by reference, sparing one `TypeScope` clone per function call.

Closes #2093.

## Why

`crates/harn-parser/src/typechecker/scope.rs:214` did `parent: Some(Box::new(self.clone()))` on every scope entry, so the cost of entering a child scope at depth D was O(sum of map sizes from root to D). For a file with N top-level decls, each fn body entry cloned the root scope's `functions` map (N entries), making cold-start typecheck super-linear in N. The same shape recurred in `calls.rs`, where each call site cloned the caller's scope before checking arguments.

## Numbers

Cold-start typecheck phase on `pipeline main` with one-line fns and 500 calls in the body, release build, same machine:

| File size | Pre-fix typecheck | Post-fix typecheck | Speedup |
|---:|---:|---:|---:|
| 500 fns / 1003 lines | 69 ms | 3 ms | 23× |
| 2000 fns / 2503 lines | 438 ms | 6 ms | 73× |
| 5000 fns / 5503 lines | 2.18 s | 14 ms | 156× |
| 10000 fns / 10503 lines | 8.27 s | 29 ms | 285× |

Pre-fix scaling was super-linear (\~O(n^1.6)); post-fix scaling is flat O(n).

LSP re-typecheck on save and `harn check` in pre-commit on large projects pick up the same speedup.

## Verification

- [x] `cargo test -p harn-parser --lib` — 331 passed
- [x] `cargo test -p harn-vm --lib` — 2388 passed
- [x] `cargo test -p harn-cli --lib` — 658 passed
- [x] `cargo test -p harn-lsp` — 40 passed
- [x] `target/debug/harn test conformance` — 1381 passed, 0 failed
- [x] `cargo clippy -p harn-parser -- -D warnings`
- [x] `cargo fmt --check`
- [x] `make lint-md`
- [x] Apples-to-apples benchmark with stash/rebuild cycle on the same release binary; results match the table above.

## Test plan

- [ ] CI green
- [ ] Auto-merge on green