### PR TITLE
perf(vm): split Op::TailCall into sync/async halves (#2088)

### DIFF
--- a/crates/harn-vm/src/vm/ops/call.rs
+++ b/crates/harn-vm/src/vm/ops/call.rs
@@ -831,7 +831,143 @@ impl super::super::Vm {
         self.call_named_value(&name, args, Some(id)).await
     }
 
-    pub(super) async fn execute_tail_call(&mut self) -> Result<(), VmError> {
+    /// Sync TCO body shared between [`execute_tail_call_sync`] and
+    /// [`execute_tail_call_async`]: validate arity/types, reuse the current
+    /// frame's stack base and saved env, then push the callee's frame in
+    /// place. Callers must have already advanced `ip`, popped the callee,
+    /// and confirmed neither the current frame nor the callee is tracked
+    /// (so PreStep/PostStep boundaries aren't elided by TCO).
+    fn perform_tail_call_tco(
+        &mut self,
+        closure: Rc<VmClosure>,
+        args: Vec<VmValue>,
+    ) -> Result<(), VmError> {
+        crate::typecheck::validate_user_call(&closure.func, &args, None)?;
+        if closure.func.is_generator {
+            // Generators cannot be tail-call optimized.
+            let gen = self.create_generator(&closure, &args);
+            return Err(VmError::Return(gen));
+        }
+        let mut call_env = self.closure_call_env_for_current_frame(&closure);
+        // TCO: reuse the current frame's stack_base / saved_env.
+        let popped = self.frames.pop().unwrap();
+        let stack_base = popped.stack_base;
+        let parent_env = popped.saved_env;
+
+        if let Some(ref dir) = popped.saved_source_dir {
+            crate::stdlib::set_thread_source_dir(dir);
+        }
+
+        self.stack.truncate(stack_base);
+
+        let saved_source_dir = if let Some(ref dir) = closure.source_dir {
+            let prev = crate::stdlib::process::VM_SOURCE_DIR.with(|sd| sd.borrow().clone());
+            crate::stdlib::set_thread_source_dir(dir);
+            prev
+        } else {
+            None
+        };
+
+        call_env.push_scope();
+        let debugger = self.debugger_attached();
+        let initial_env = if debugger {
+            Some(call_env.clone())
+        } else {
+            None
+        };
+        self.env = call_env;
+        let mut local_slots = Self::fresh_local_slots(&closure.func.chunk);
+        Self::bind_param_slots(&mut local_slots, &closure.func, &args, false);
+        let initial_local_slots = if debugger {
+            Some(local_slots.clone())
+        } else {
+            None
+        };
+
+        // Inherit the popped frame's iterator depth so iterators pushed by
+        // for-loops inside the caller (`return f(...)` from inside
+        // `for x in xs { ... }`) get torn down when the tail-called callee
+        // eventually returns, instead of leaking into the caller's caller.
+        let saved_iterator_depth = popped.saved_iterator_depth;
+        self.iterators.truncate(saved_iterator_depth);
+        let argc = args.len();
+        self.frames.push(CallFrame {
+            chunk: Rc::clone(&closure.func.chunk),
+            ip: 0,
+            stack_base,
+            saved_env: parent_env,
+            initial_env,
+            initial_local_slots,
+            saved_iterator_depth,
+            fn_name: closure.func.name.clone(),
+            argc,
+            saved_source_dir,
+            module_functions: closure.module_functions.clone(),
+            module_state: closure.module_state.clone(),
+            local_slots,
+            local_scope_base: self.env.scope_depth().saturating_sub(1),
+            local_scope_depth: 0,
+        });
+        Ok(())
+    }
+
+    /// Sync fast path for `Op::TailCall`. Peeks the callee on the stack
+    /// **before** touching `ip`; if it resolves to a non-generator user
+    /// closure and neither the current frame nor the callee is tracked
+    /// by the persona/step registries, it performs the TCO frame reuse
+    /// inline and returns `Some(Ok(()))`. Anything that needs the slow
+    /// path (non-resolvable callee, generator, tracked frame, tracked
+    /// callee) returns `None` without touching `ip`, so the caller falls
+    /// through to [`execute_tail_call_async`] which reads the argc
+    /// operand exactly once.
+    ///
+    /// Both direct `Closure` callees and the `String` form emitted by
+    /// `compile_return_stmt` (`Op::Constant <name>` + `Op::TailCall`) are
+    /// handled here: [`Vm::resolve_named_closure`] is itself synchronous,
+    /// so the steady-state user-level tail call — the only shape
+    /// `recursive_countdown.harn` exercises — stays on the sync path.
+    ///
+    /// The tracked-function guards mirror the async path's check at the
+    /// top of [`execute_tail_call_async`]: persona/step lifecycle state
+    /// is frame-owned, and TCO that elides a frame must not skip the
+    /// PreStep/PostStep hook boundaries that a non-tail call would
+    /// observe.
+    pub(super) fn execute_tail_call_sync(&mut self) -> Option<Result<(), VmError>> {
+        let frame = self.frames.last().unwrap();
+        if crate::step_runtime::is_tracked_function(&frame.fn_name) {
+            return None;
+        }
+        let argc = frame.chunk.code[frame.ip] as usize;
+        let callee_idx = self.stack.len().checked_sub(argc + 1)?;
+        let resolved = match self.stack.get(callee_idx)? {
+            VmValue::Closure(c) => Ok(Rc::clone(c)),
+            VmValue::String(name) => Err(Rc::clone(name)),
+            _ => return None,
+        };
+        let closure = match resolved {
+            Ok(closure) => closure,
+            Err(name) => self.resolve_named_closure(&name)?,
+        };
+        if closure.func.is_generator {
+            return None;
+        }
+        if crate::step_runtime::is_tracked_function(&closure.func.name) {
+            return None;
+        }
+
+        let frame = self.frames.last_mut().unwrap();
+        frame.ip += 1;
+        let args: Vec<VmValue> = self.stack.split_off(self.stack.len() - argc);
+        let _ = self.stack.pop();
+        Some(self.perform_tail_call_tco(closure, args))
+    }
+
+    /// Async slow path for `Op::TailCall`. Identical in behavior to the
+    /// pre-split `execute_tail_call`. The caller (`execute_op_async`)
+    /// reaches this only after [`execute_tail_call_sync`] returned `None`
+    /// without touching `ip`, so this path reads the argc operand exactly
+    /// once.
+    pub(super) async fn execute_tail_call_async(&mut self) -> Result<(), VmError> {
         let frame = self.frames.last_mut().unwrap();
         let argc = frame.chunk.code[frame.ip] as usize;
         frame.ip += 1;
@@ -861,73 +997,7 @@ impl super::super::Vm {
                 return Ok(());
             }
 
-            crate::typecheck::validate_user_call(&closure.func, &args, None)?;
-            if closure.func.is_generator {
-                // Generators cannot be tail-call optimized.
-                let gen = self.create_generator(&closure, &args);
-                return Err(VmError::Return(gen));
-            }
-            let mut call_env = self.closure_call_env_for_current_frame(&closure);
-            // TCO: reuse the current frame's stack_base / saved_env.
-            let popped = self.frames.pop().unwrap();
-            let stack_base = popped.stack_base;
-            let parent_env = popped.saved_env;
-
-            if let Some(ref dir) = popped.saved_source_dir {
-                crate::stdlib::set_thread_source_dir(dir);
-            }
-
-            self.stack.truncate(stack_base);
-
-            let saved_source_dir = if let Some(ref dir) = closure.source_dir {
-                let prev = crate::stdlib::process::VM_SOURCE_DIR.with(|sd| sd.borrow().clone());
-                crate::stdlib::set_thread_source_dir(dir);
-                prev
-            } else {
-                None
-            };
-
-            call_env.push_scope();
-            let debugger = self.debugger_attached();
-            let initial_env = if debugger {
-                Some(call_env.clone())
-            } else {
-                None
-            };
-            self.env = call_env;
-            let mut local_slots = Self::fresh_local_slots(&closure.func.chunk);
-            Self::bind_param_slots(&mut local_slots, &closure.func, &args, false);
-            let initial_local_slots = if debugger {
-                Some(local_slots.clone())
-            } else {
-                None
-            };
-
-            // Inherit the popped frame's iterator depth so iterators
-            // pushed by for-loops inside the caller (`return f(...)` from
-            // inside `for x in xs { ... }`) get torn down when the
-            // tail-called callee eventually returns, instead of leaking
-            // into the caller's caller.
-            let saved_iterator_depth = popped.saved_iterator_depth;
-            self.iterators.truncate(saved_iterator_depth);
-            let argc = args.len();
-            self.frames.push(CallFrame {
-                chunk: Rc::clone(&closure.func.chunk),
-                ip: 0,
-                stack_base,
-                saved_env: parent_env,
-                initial_env,
-                initial_local_slots,
-                saved_iterator_depth,
-                fn_name: closure.func.name.clone(),
-                argc,
-                saved_source_dir,
-                module_functions: closure.module_functions.clone(),
-                module_state: closure.module_state.clone(),
-                local_slots,
-                local_scope_base: self.env.scope_depth().saturating_sub(1),
-                local_scope_depth: 0,
-            });
+            self.perform_tail_call_tco(closure, args)?;
         } else {
             match callee {
                 VmValue::String(name) => {

--- a/crates/harn-vm/src/vm/ops/mod.rs
+++ b/crates/harn-vm/src/vm/ops/mod.rs
@@ -122,6 +122,12 @@ impl super::Vm {
             // frame inline. Builtins and the listed escape hatches fall
             // through to `execute_call_builtin_async` with `ip` untouched.
             Op::CallBuiltin => return self.execute_call_builtin_sync(),
+            // TailCall is split: the sync fast path handles the
+            // steady-state user-closure tail call inline (TCO frame
+            // reuse). Tracked-function frames/callees, generators, and
+            // string/builtin-ref callees return `None` and fall through
+            // to `execute_tail_call_async`.
+            Op::TailCall => return self.execute_tail_call_sync(),
             Op::Throw => self.execute_throw(),
             Op::TryCatchSetup => {
                 self.execute_try_catch_setup();
@@ -187,7 +193,6 @@ impl super::Vm {
             // keeps the sync/async classification visible alongside the
             // sync dispatch table.
             Op::CallBuiltinSpread
-            | Op::TailCall
             | Op::MethodCall
             | Op::MethodCallOpt
             | Op::Pipe
@@ -213,7 +218,7 @@ impl super::Vm {
             Op::Call => self.execute_call_async().await,
             Op::CallBuiltin => self.execute_call_builtin_async().await,
             Op::CallBuiltinSpread => self.execute_call_builtin_spread().await,
-            Op::TailCall => self.execute_tail_call().await,
+            Op::TailCall => self.execute_tail_call_async().await,
             Op::MethodCall => self.execute_method_call(false).await,
             Op::MethodCallOpt => self.execute_method_call(true).await,
             Op::IterNext => self.execute_iter_next_async().await,


### PR DESCRIPTION
Closes #2088.

## Summary

Apply the proven sync/async dispatch split (#2072 / #2074 / #2080) to `Op::TailCall`. Unlike the earlier `Op::Call` split which didn't fire on any current bench fixture, the `Op::TailCall` split **does** fire on `recursive_countdown.harn` because `compile_return_stmt` emits `Op::Constant <name>` + `Op::TailCall` and `resolve_named_closure` is itself synchronous — so the steady-state user-level tail call stays on the sync path end-to-end.

- `execute_tail_call_sync(&mut self) -> Option<Result<(), VmError>>` peeks the callee on the stack **before** touching `ip`; if it resolves to a non-generator user closure and neither the current frame nor the callee is tracked by the persona/step registries, it performs the TCO frame reuse inline and returns `Some(Ok(()))`. Other shapes (non-resolvable callee, generator, tracked frame, tracked callee) return `None` without touching `ip`.
- `execute_tail_call_async(&mut self) -> Result<(), VmError>` is the renamed pre-split body. It delegates the (synchronous) TCO body to the shared `perform_tail_call_tco` helper instead of inlining it, so both dispatch paths walk the same frame-reuse code.
- Wired through `execute_op_sync` / `execute_op_async`. Coverage parity over `Op` variants preserved.

## Bench

Best-of-three min_ms across 3 alternating base/opt passes, `scripts/bench_vm.sh --no-build --iterations 30`:

| benchmark                  | base_min |  opt_min |  Δmin% |
|----------------------------|---------:|---------:|-------:|
| recursive_countdown        |    11.49 |    10.85 |  -5.6% |
| dict_subscript_assign      |    11.18 |    10.76 |  -3.8% |
| dict_merge_loop            |    23.57 |    22.87 |  -3.0% |
| dict_property_read         |    41.75 |    40.86 |  -2.1% |
| comparison_loop            |    75.33 |    74.26 |  -1.4% |
| struct_field_read          |    45.79 |    45.36 |  -0.9% |
| filter_nil_loop            |    31.42 |    31.16 |  -0.8% |
| arithmetic_loop            |    49.83 |    49.67 |  -0.3% |
| method_call_dispatch       |    36.34 |    36.50 |  +0.4% |
| local_variable_lookup      |    79.87 |    80.40 |  +0.7% |
| function_call_loop         |    47.90 |    48.55 |  +1.4% |
| list_map_filter            |   106.30 |   107.98 |  +1.6% |
| agent_tool_dispatch        |    54.42 |    55.68 |  +2.3% |
| string_interpolation_loop  |     7.26 |     7.57 |  +4.3% |
| list_iteration             |    10.37 |     9.49 |  -8.5% |

`recursive_countdown` lands at **-5.6%**, inside the issue's predicted 3-8% band. Confirmed across a follow-up 5 alternating runs at 50 iterations: opt faster in every single run, mean Δmin -6.3% (10.63-11.76 ms opt vs 11.24-12.51 ms base). The other fixtures don't emit `Op::TailCall`, so their movements are code-layout noise within the established ±5-10% noise band on tight loop fixtures.

## Implementation note (why the sync fast path actually fires here)

The earlier `Op::Call` split (#2080) found that user-level `f(x)` compiles to `Op::CallBuiltin`, so its sync arm never sees a closure callee in current fixtures. `Op::TailCall` has a different shape: `compile_return_stmt` ([crates/harn-vm/src/compiler/statements.rs:218-225](https://github.com/burin-labs/harn/blob/main/crates/harn-vm/src/compiler/statements.rs#L218-L225)) emits `Op::Constant <name>` + args + `Op::TailCall <argc>`, and the runtime resolves the name via `resolve_named_closure` — which is fully sync. The sync arm here therefore peeks the `String` callee, resolves it inline, and only bails to the async path on the four shapes that actually need `.await`: tracked-frame, tracked-callee, generator, non-resolvable callee.

## Test plan

- [x] `cargo run --bin harn -- test conformance` — 1381 passed, 0 failed.
- [x] `cargo nextest run -p harn-vm` — 2436 passed, 2 skipped.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (via pre-commit hook).
- [x] `cargo fmt --check` (clean).
- [x] Microbenchmarks above; called out noise band explicitly.
- [x] Coverage parity: both `execute_op_sync` and `execute_op_async` match arms remain exhaustive over `Op`.
- [x] No banned test patterns introduced (no test files touched).
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)