### PR TITLE
perf(vm): split sync method-call dispatch

### DIFF
--- a/crates/harn-vm/src/vm/methods/dict.rs
+++ b/crates/harn-vm/src/vm/methods/dict.rs
@@ -4,34 +4,25 @@ use std::rc::Rc;
 use crate::value::{VmError, VmValue};
 
 impl crate::vm::Vm {
-    pub(super) async fn call_dict_method(
-        &mut self,
+    pub(super) fn call_dict_method_sync(
         map: &Rc<BTreeMap<String, VmValue>>,
         method: &str,
         args: &[VmValue],
-    ) -> Result<VmValue, VmError> {
-        if matches!(map.get("_namespace"), Some(VmValue::String(_))) {
-            if let Some(callable) = map.get(method).filter(|v| Self::is_callable_value(v)) {
-                return self.call_callable_value(callable, args).await;
-            }
+    ) -> Option<Result<VmValue, VmError>> {
+        if matches!(map.get("_namespace"), Some(VmValue::String(_)))
+            && map.get(method).is_some_and(Self::is_callable_value)
+        {
+            return None;
         }
-        match method {
+
+        let result = match method {
             "keys" => Ok(VmValue::List(Rc::new(
                 map.keys()
                     .map(|k| VmValue::String(Rc::from(k.as_str())))
                     .collect(),
             ))),
             "values" => Ok(VmValue::List(Rc::new(map.values().cloned().collect()))),
-            "entries" => Ok(VmValue::List(Rc::new(
-                map.iter()
-                    .map(|(k, v)| {
-                        VmValue::Dict(Rc::new(BTreeMap::from([
-                            ("key".to_string(), VmValue::String(Rc::from(k.as_str()))),
-                            ("value".to_string(), v.clone()),
-                        ])))
-                    })
-                    .collect(),
-            ))),
+            "entries" => Ok(VmValue::List(Rc::new(Self::dict_entries(map)))),
             "count" => Ok(VmValue::Int(map.len() as i64)),
             "has" => Ok(VmValue::Bool(map.contains_key(
                 &args.first().map(|a| a.display()).unwrap_or_default(),
@@ -39,10 +30,10 @@ impl crate::vm::Vm {
             "merge" => {
                 if let Some(VmValue::Dict(other)) = args.first() {
                     if map.is_empty() {
-                        return Ok(VmValue::Dict(Rc::clone(other)));
+                        return Some(Ok(VmValue::Dict(Rc::clone(other))));
                     }
                     if other.is_empty() {
-                        return Ok(VmValue::Dict(Rc::clone(map)));
+                        return Some(Ok(VmValue::Dict(Rc::clone(map))));
                     }
                     let mut result = (**map).clone();
                     result.extend(other.iter().map(|(k, v)| (k.clone(), v.clone())));
@@ -51,46 +42,11 @@ impl crate::vm::Vm {
                     Ok(VmValue::Dict(Rc::clone(map)))
                 }
             }
-            "map_values" => {
-                if let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) {
-                    let mut result = BTreeMap::new();
-                    for (k, v) in map.iter() {
-                        let mapped = self.call_callable_value(callable, &[v.clone()]).await?;
-                        result.insert(k.clone(), mapped);
-                    }
-                    Ok(VmValue::Dict(Rc::new(result)))
-                } else {
-                    Ok(VmValue::Nil)
+            "map_values" | "rekey" | "map_keys" | "filter" => {
+                if args.first().is_some_and(Self::is_callable_value) {
+                    return None;
                 }
-            }
-            "rekey" | "map_keys" => {
-                if let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) {
-                    let mut result = BTreeMap::new();
-                    for (k, v) in map.iter() {
-                        let new_key = self
-                            .call_callable_value(callable, &[VmValue::String(Rc::from(k.as_str()))])
-                            .await?;
-                        let new_key_str = new_key.display();
-                        result.insert(new_key_str, v.clone());
-                    }
-                    Ok(VmValue::Dict(Rc::new(result)))
-                } else {
-                    Ok(VmValue::Nil)
-                }
-            }
-            "filter" => {
-                if let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) {
-                    let mut result = BTreeMap::new();
-                    for (k, v) in map.iter() {
-                        let keep = self.call_callable_value(callable, &[v.clone()]).await?;
-                        if keep.is_truthy() {
-                            result.insert(k.clone(), v.clone());
-                        }
-                    }
-                    Ok(VmValue::Dict(Rc::new(result)))
-                } else {
-                    Ok(VmValue::Nil)
-                }
+                Ok(VmValue::Nil)
             }
             "remove" => {
                 let key = args.first().map(|a| a.display()).unwrap_or_default();
@@ -103,21 +59,73 @@ impl crate::vm::Vm {
                 let default = args.get(1).cloned().unwrap_or(VmValue::Nil);
                 Ok(map.get(&key).cloned().unwrap_or(default))
             }
-            // Iter-style sinks: identity for `to_dict`, list of entries
-            // for `to_list`. Mirrors the eager versions in stdlib so
-            // `dict.filter(...).to_dict()` and `dict.entries()` /
-            // `dict.to_list()` behave consistently.
             "to_dict" => Ok(VmValue::Dict(Rc::clone(map))),
-            "to_list" => Ok(VmValue::List(Rc::new(
-                map.iter()
-                    .map(|(k, v)| {
-                        VmValue::Dict(Rc::new(BTreeMap::from([
-                            ("key".to_string(), VmValue::String(Rc::from(k.as_str()))),
-                            ("value".to_string(), v.clone()),
-                        ])))
-                    })
-                    .collect(),
-            ))),
+            "to_list" => Ok(VmValue::List(Rc::new(Self::dict_entries(map)))),
+            _ => {
+                if map.get(method).is_some_and(Self::is_callable_value) {
+                    return None;
+                }
+                Err(VmError::Runtime(format!("dict has no method `{method}`")))
+            }
+        };
+        Some(result)
+    }
+
+    pub(super) async fn call_dict_method(
+        &mut self,
+        map: &Rc<BTreeMap<String, VmValue>>,
+        method: &str,
+        args: &[VmValue],
+    ) -> Result<VmValue, VmError> {
+        if let Some(result) = Self::call_dict_method_sync(map, method, args) {
+            return result;
+        }
+
+        if matches!(map.get("_namespace"), Some(VmValue::String(_))) {
+            if let Some(callable) = map.get(method).filter(|v| Self::is_callable_value(v)) {
+                return self.call_callable_value(callable, args).await;
+            }
+        }
+
+        match method {
+            "map_values" => {
+                let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) else {
+                    return Ok(VmValue::Nil);
+                };
+                let mut result = BTreeMap::new();
+                for (k, v) in map.iter() {
+                    let mapped = self.call_callable_value(callable, &[v.clone()]).await?;
+                    result.insert(k.clone(), mapped);
+                }
+                Ok(VmValue::Dict(Rc::new(result)))
+            }
+            "rekey" | "map_keys" => {
+                let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) else {
+                    return Ok(VmValue::Nil);
+                };
+                let mut result = BTreeMap::new();
+                for (k, v) in map.iter() {
+                    let new_key = self
+                        .call_callable_value(callable, &[VmValue::String(Rc::from(k.as_str()))])
+                        .await?;
+                    let new_key_str = new_key.display();
+                    result.insert(new_key_str, v.clone());
+                }
+                Ok(VmValue::Dict(Rc::new(result)))
+            }
+            "filter" => {
+                let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) else {
+                    return Ok(VmValue::Nil);
+                };
+                let mut result = BTreeMap::new();
+                for (k, v) in map.iter() {
+                    let keep = self.call_callable_value(callable, &[v.clone()]).await?;
+                    if keep.is_truthy() {
+                        result.insert(k.clone(), v.clone());
+                    }
+                }
+                Ok(VmValue::Dict(Rc::new(result)))
+            }
             _ => {
                 if let Some(callable) = map.get(method).filter(|v| Self::is_callable_value(v)) {
                     self.call_callable_value(callable, args).await
@@ -126,5 +134,16 @@ impl crate::vm::Vm {
                 }
             }
         }
+    }
+
+    fn dict_entries(map: &BTreeMap<String, VmValue>) -> Vec<VmValue> {
+        map.iter()
+            .map(|(k, v)| {
+                VmValue::Dict(Rc::new(BTreeMap::from([
+                    ("key".to_string(), VmValue::String(Rc::from(k.as_str()))),
+                    ("value".to_string(), v.clone()),
+                ])))
+            })
+            .collect()
     }
 }

--- a/crates/harn-vm/src/vm/methods/dispatch.rs
+++ b/crates/harn-vm/src/vm/methods/dispatch.rs
@@ -5,36 +5,56 @@ use crate::value::{VmError, VmValue};
 use crate::vm::iter::iter_from_value;
 
 impl crate::vm::Vm {
-    pub(in crate::vm) fn call_method<'a>(
+    pub(in crate::vm) fn call_method_sync(
+        obj: &VmValue,
+        method: &str,
+        args: &[VmValue],
+    ) -> Option<Result<VmValue, VmError>> {
+        if method == "iter"
+            && matches!(
+                obj,
+                VmValue::List(_)
+                    | VmValue::Set(_)
+                    | VmValue::Dict(_)
+                    | VmValue::String(_)
+                    | VmValue::Generator(_)
+                    | VmValue::Stream(_)
+                    | VmValue::Channel(_)
+                    | VmValue::Iter(_)
+            )
+        {
+            return Some(iter_from_value(obj.clone()));
+        }
+
+        match obj {
+            VmValue::String(s) => Some(Self::call_string_method(s, method, args)),
+            VmValue::List(items) => Self::call_list_method_sync(items, method, args),
+            VmValue::Dict(map) => Self::call_dict_method_sync(map, method, args),
+            VmValue::Set(items) => Self::call_set_method_sync(items, method, args),
+            VmValue::Int(_) | VmValue::Float(_) => {
+                Some(Self::call_number_method(obj, method, args))
+            }
+            VmValue::Range(r) => Self::call_range_method_sync(obj, r, method, args),
+            _ => None,
+        }
+    }
+
+    pub(in crate::vm) fn call_method_async<'a>(
         &'a mut self,
         obj: VmValue,
         method: &'a str,
         args: &'a [VmValue],
     ) -> Pin<Box<dyn Future<Output = Result<VmValue, VmError>> + 'a>> {
         Box::pin(async move {
-            if method == "iter"
-                && matches!(
-                    &obj,
-                    VmValue::List(_)
-                        | VmValue::Set(_)
-                        | VmValue::Dict(_)
-                        | VmValue::String(_)
-                        | VmValue::Generator(_)
-                        | VmValue::Stream(_)
-                        | VmValue::Channel(_)
-                        | VmValue::Iter(_)
-                )
-            {
-                return iter_from_value(obj);
+            if let Some(result) = Self::call_method_sync(&obj, method, args) {
+                return result;
             }
 
             match &obj {
-                VmValue::String(s) => self.call_string_method(s, method, args),
                 VmValue::List(items) => self.call_list_method(items, method, args).await,
                 VmValue::Dict(map) => self.call_dict_method(map, method, args).await,
                 VmValue::Set(items) => self.call_set_method(items, method, args).await,
                 VmValue::Range(r) => self.call_range_method(&obj, r, method, args).await,
-                VmValue::Int(_) | VmValue::Float(_) => self.call_number_method(&obj, method, args),
                 VmValue::StructInstance { .. } => {
                     self.call_struct_instance_method(&obj, method, args).await
                 }

--- a/crates/harn-vm/src/vm/methods/list.rs
+++ b/crates/harn-vm/src/vm/methods/list.rs
@@ -4,125 +4,42 @@ use std::rc::Rc;
 use crate::value::{compare_values, values_equal, VmError, VmValue};
 
 impl crate::vm::Vm {
-    pub(super) async fn call_list_method(
-        &mut self,
+    pub(super) fn call_list_method_sync(
         items: &Rc<Vec<VmValue>>,
         method: &str,
         args: &[VmValue],
-    ) -> Result<VmValue, VmError> {
-        match method {
+    ) -> Option<Result<VmValue, VmError>> {
+        let result = match method {
             "count" => Ok(VmValue::Int(items.len() as i64)),
             "empty" => Ok(VmValue::Bool(items.is_empty())),
-            "map" => {
-                if let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) {
-                    let mut results = Vec::with_capacity(items.len());
-                    for item in items.iter() {
-                        results.push(self.call_callable_value(callable, &[item.clone()]).await?);
-                    }
-                    Ok(VmValue::List(Rc::new(results)))
-                } else {
-                    Ok(VmValue::Nil)
-                }
-            }
-            "filter" => {
-                if let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) {
-                    let mut results = Vec::with_capacity(items.len());
-                    for item in items.iter() {
-                        let result = self.call_callable_value(callable, &[item.clone()]).await?;
-                        if result.is_truthy() {
-                            results.push(item.clone());
-                        }
-                    }
-                    Ok(VmValue::List(Rc::new(results)))
-                } else {
-                    Ok(VmValue::Nil)
-                }
-            }
-            "reduce" => {
-                if args.len() >= 2 && Self::is_callable_value(&args[1]) {
-                    let callable = &args[1].clone();
-                    let mut acc = args[0].clone();
-                    for item in items.iter() {
-                        acc = self
-                            .call_callable_value(callable, &[acc, item.clone()])
-                            .await?;
-                    }
-                    return Ok(acc);
+            "map" | "filter" | "find" | "flat_map" | "sort_by" | "partition" | "group_by" => {
+                if args.first().is_some_and(Self::is_callable_value) {
+                    return None;
                 }
                 Ok(VmValue::Nil)
             }
-            "find" => {
-                if let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) {
-                    for item in items.iter() {
-                        let result = self.call_callable_value(callable, &[item.clone()]).await?;
-                        if result.is_truthy() {
-                            return Ok(item.clone());
-                        }
-                    }
+            "reduce" => {
+                if args.len() >= 2 && Self::is_callable_value(&args[1]) {
+                    return None;
                 }
                 Ok(VmValue::Nil)
             }
             "any" => {
-                if let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) {
-                    for item in items.iter() {
-                        let result = self.call_callable_value(callable, &[item.clone()]).await?;
-                        if result.is_truthy() {
-                            return Ok(VmValue::Bool(true));
-                        }
-                    }
-                    Ok(VmValue::Bool(false))
-                } else {
-                    Ok(VmValue::Bool(false))
+                if args.first().is_some_and(Self::is_callable_value) {
+                    return None;
                 }
+                Ok(VmValue::Bool(false))
             }
             "all" | "every" | "all?" => {
-                if let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) {
-                    for item in items.iter() {
-                        let result = self.call_callable_value(callable, &[item.clone()]).await?;
-                        if !result.is_truthy() {
-                            return Ok(VmValue::Bool(false));
-                        }
-                    }
-                    Ok(VmValue::Bool(true))
-                } else {
-                    Ok(VmValue::Bool(true))
+                if args.first().is_some_and(Self::is_callable_value) {
+                    return None;
                 }
-            }
-            "flat_map" => {
-                if let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) {
-                    let mut results = Vec::with_capacity(items.len());
-                    for item in items.iter() {
-                        let result = self.call_callable_value(callable, &[item.clone()]).await?;
-                        if let VmValue::List(inner) = result {
-                            results.extend(inner.iter().cloned());
-                        } else {
-                            results.push(result);
-                        }
-                    }
-                    Ok(VmValue::List(Rc::new(results)))
-                } else {
-                    Ok(VmValue::Nil)
-                }
+                Ok(VmValue::Bool(true))
             }
             "sort" => {
                 let mut sorted: Vec<VmValue> = items.iter().cloned().collect();
                 sorted.sort_by(|a, b| compare_values(a, b).cmp(&0));
                 Ok(VmValue::List(Rc::new(sorted)))
-            }
-            "sort_by" => {
-                if let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) {
-                    let mut keyed: Vec<(VmValue, VmValue)> = Vec::new();
-                    for item in items.iter() {
-                        let key = self.call_callable_value(callable, &[item.clone()]).await?;
-                        keyed.push((item.clone(), key));
-                    }
-                    keyed.sort_by(|(_, ka), (_, kb)| compare_values(ka, kb).cmp(&0));
-                    Ok(VmValue::List(Rc::new(
-                        keyed.into_iter().map(|(v, _)| v).collect(),
-                    )))
-                } else {
-                    Ok(VmValue::Nil)
-                }
             }
             "reverse" => {
                 let mut rev: Vec<VmValue> = items.iter().cloned().collect();
@@ -182,14 +99,14 @@ impl crate::vm::Vm {
                 let start = if start_raw < 0 {
                     (len + start_raw).max(0) as usize
                 } else {
-                    (start_raw.min(len)) as usize
+                    start_raw.min(len) as usize
                 };
                 let end = if args.len() > 1 {
                     let end_raw = args[1].as_int().unwrap_or(len);
                     if end_raw < 0 {
                         (len + end_raw).max(0) as usize
                     } else {
-                        (end_raw.min(len)) as usize
+                        end_raw.min(len) as usize
                     }
                 } else {
                     len as usize
@@ -245,7 +162,7 @@ impl crate::vm::Vm {
             }
             "min" => {
                 if items.is_empty() {
-                    return Ok(VmValue::Nil);
+                    return Some(Ok(VmValue::Nil));
                 }
                 let mut min_val = items[0].clone();
                 for item in &items[1..] {
@@ -257,7 +174,7 @@ impl crate::vm::Vm {
             }
             "max" => {
                 if items.is_empty() {
-                    return Ok(VmValue::Nil);
+                    return Some(Ok(VmValue::Nil));
                 }
                 let mut max_val = items[0].clone();
                 for item in &items[1..] {
@@ -291,26 +208,14 @@ impl crate::vm::Vm {
                 Ok(VmValue::List(Rc::new(new_list)))
             }
             "none" | "none?" => {
-                if let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) {
-                    for item in items.iter() {
-                        let result = self.call_callable_value(callable, &[item.clone()]).await?;
-                        if result.is_truthy() {
-                            return Ok(VmValue::Bool(false));
-                        }
-                    }
-                    Ok(VmValue::Bool(true))
-                } else {
-                    Ok(VmValue::Bool(items.is_empty()))
+                if args.first().is_some_and(Self::is_callable_value) {
+                    return None;
                 }
+                Ok(VmValue::Bool(items.is_empty()))
             }
             "find_index" => {
-                if let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) {
-                    for (i, item) in items.iter().enumerate() {
-                        let result = self.call_callable_value(callable, &[item.clone()]).await?;
-                        if result.is_truthy() {
-                            return Ok(VmValue::Int(i as i64));
-                        }
-                    }
+                if args.first().is_some_and(Self::is_callable_value) {
+                    return None;
                 }
                 Ok(VmValue::Int(-1))
             }
@@ -336,43 +241,6 @@ impl crate::vm::Vm {
                     None => Ok(items.last().cloned().unwrap_or(VmValue::Nil)),
                 }
             }
-            "partition" => {
-                if let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) {
-                    let mut truthy = Vec::new();
-                    let mut falsy = Vec::new();
-                    for item in items.iter() {
-                        let result = self.call_callable_value(callable, &[item.clone()]).await?;
-                        if result.is_truthy() {
-                            truthy.push(item.clone());
-                        } else {
-                            falsy.push(item.clone());
-                        }
-                    }
-                    Ok(VmValue::List(Rc::new(vec![
-                        VmValue::List(Rc::new(truthy)),
-                        VmValue::List(Rc::new(falsy)),
-                    ])))
-                } else {
-                    Ok(VmValue::Nil)
-                }
-            }
-            "group_by" => {
-                if let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) {
-                    let mut groups: BTreeMap<String, Vec<VmValue>> = BTreeMap::new();
-                    for item in items.iter() {
-                        let key = self.call_callable_value(callable, &[item.clone()]).await?;
-                        let key_str = key.display();
-                        groups.entry(key_str).or_default().push(item.clone());
-                    }
-                    let result: BTreeMap<String, VmValue> = groups
-                        .into_iter()
-                        .map(|(k, v)| (k, VmValue::List(Rc::new(v))))
-                        .collect();
-                    Ok(VmValue::Dict(Rc::new(result)))
-                } else {
-                    Ok(VmValue::Nil)
-                }
-            }
             "chunk" | "each_slice" => {
                 let size = args.first().and_then(|a| a.as_int()).unwrap_or(1).max(1) as usize;
                 let chunks: Vec<VmValue> = items
@@ -381,40 +249,11 @@ impl crate::vm::Vm {
                     .collect();
                 Ok(VmValue::List(Rc::new(chunks)))
             }
-            "min_by" => {
+            "min_by" | "max_by" => {
                 if items.is_empty() {
-                    return Ok(VmValue::Nil);
-                }
-                if let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) {
-                    let mut best = items[0].clone();
-                    let mut best_key = self.call_callable_value(callable, &[best.clone()]).await?;
-                    for item in &items[1..] {
-                        let key = self.call_callable_value(callable, &[item.clone()]).await?;
-                        if compare_values(&key, &best_key) < 0 {
-                            best = item.clone();
-                            best_key = key;
-                        }
-                    }
-                    Ok(best)
-                } else {
                     Ok(VmValue::Nil)
-                }
-            }
-            "max_by" => {
-                if items.is_empty() {
-                    return Ok(VmValue::Nil);
-                }
-                if let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) {
-                    let mut best = items[0].clone();
-                    let mut best_key = self.call_callable_value(callable, &[best.clone()]).await?;
-                    for item in &items[1..] {
-                        let key = self.call_callable_value(callable, &[item.clone()]).await?;
-                        if compare_values(&key, &best_key) > 0 {
-                            best = item.clone();
-                            best_key = key;
-                        }
-                    }
-                    Ok(best)
+                } else if args.first().is_some_and(Self::is_callable_value) {
+                    return None;
                 } else {
                     Ok(VmValue::Nil)
                 }
@@ -431,7 +270,7 @@ impl crate::vm::Vm {
                 let size = args.first().and_then(|a| a.as_int()).unwrap_or(2).max(1) as usize;
                 let step = args.get(1).and_then(|a| a.as_int()).unwrap_or(1).max(1) as usize;
                 if size > items.len() {
-                    return Ok(VmValue::List(Rc::new(Vec::new())));
+                    return Some(Ok(VmValue::List(Rc::new(Vec::new()))));
                 }
                 let mut windows = Vec::new();
                 let mut start = 0;
@@ -450,10 +289,6 @@ impl crate::vm::Vm {
                 }
                 Ok(VmValue::Dict(Rc::new(counts)))
             }
-            // Iter-style sinks behave as identities/conversions when
-            // the receiver is already eager. Lets `xs.filter(...).to_list()`
-            // work uniformly whether `filter` returned an `iter` or a
-            // `list`.
             "to_list" => Ok(VmValue::List(Rc::clone(items))),
             "to_set" => {
                 let mut out: Vec<VmValue> = Vec::with_capacity(items.len());
@@ -463,6 +298,218 @@ impl crate::vm::Vm {
                     }
                 }
                 Ok(VmValue::Set(Rc::new(out)))
+            }
+            _ => Err(VmError::Runtime(format!("list has no method `{method}`"))),
+        };
+        Some(result)
+    }
+
+    pub(super) async fn call_list_method(
+        &mut self,
+        items: &Rc<Vec<VmValue>>,
+        method: &str,
+        args: &[VmValue],
+    ) -> Result<VmValue, VmError> {
+        if let Some(result) = Self::call_list_method_sync(items, method, args) {
+            return result;
+        }
+
+        match method {
+            "map" => {
+                let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) else {
+                    return Ok(VmValue::Nil);
+                };
+                let mut results = Vec::with_capacity(items.len());
+                for item in items.iter() {
+                    results.push(self.call_callable_value(callable, &[item.clone()]).await?);
+                }
+                Ok(VmValue::List(Rc::new(results)))
+            }
+            "filter" => {
+                let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) else {
+                    return Ok(VmValue::Nil);
+                };
+                let mut results = Vec::with_capacity(items.len());
+                for item in items.iter() {
+                    let result = self.call_callable_value(callable, &[item.clone()]).await?;
+                    if result.is_truthy() {
+                        results.push(item.clone());
+                    }
+                }
+                Ok(VmValue::List(Rc::new(results)))
+            }
+            "reduce" => {
+                let Some(callable) = args.get(1).filter(|v| Self::is_callable_value(v)).cloned()
+                else {
+                    return Ok(VmValue::Nil);
+                };
+                let mut acc = args.first().cloned().unwrap_or(VmValue::Nil);
+                for item in items.iter() {
+                    acc = self
+                        .call_callable_value(&callable, &[acc, item.clone()])
+                        .await?;
+                }
+                Ok(acc)
+            }
+            "find" => {
+                let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) else {
+                    return Ok(VmValue::Nil);
+                };
+                for item in items.iter() {
+                    let result = self.call_callable_value(callable, &[item.clone()]).await?;
+                    if result.is_truthy() {
+                        return Ok(item.clone());
+                    }
+                }
+                Ok(VmValue::Nil)
+            }
+            "any" => {
+                let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) else {
+                    return Ok(VmValue::Bool(false));
+                };
+                for item in items.iter() {
+                    let result = self.call_callable_value(callable, &[item.clone()]).await?;
+                    if result.is_truthy() {
+                        return Ok(VmValue::Bool(true));
+                    }
+                }
+                Ok(VmValue::Bool(false))
+            }
+            "all" | "every" | "all?" => {
+                let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) else {
+                    return Ok(VmValue::Bool(true));
+                };
+                for item in items.iter() {
+                    let result = self.call_callable_value(callable, &[item.clone()]).await?;
+                    if !result.is_truthy() {
+                        return Ok(VmValue::Bool(false));
+                    }
+                }
+                Ok(VmValue::Bool(true))
+            }
+            "flat_map" => {
+                let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) else {
+                    return Ok(VmValue::Nil);
+                };
+                let mut results = Vec::with_capacity(items.len());
+                for item in items.iter() {
+                    let result = self.call_callable_value(callable, &[item.clone()]).await?;
+                    if let VmValue::List(inner) = result {
+                        results.extend(inner.iter().cloned());
+                    } else {
+                        results.push(result);
+                    }
+                }
+                Ok(VmValue::List(Rc::new(results)))
+            }
+            "sort_by" => {
+                let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) else {
+                    return Ok(VmValue::Nil);
+                };
+                let mut keyed: Vec<(VmValue, VmValue)> = Vec::new();
+                for item in items.iter() {
+                    let key = self.call_callable_value(callable, &[item.clone()]).await?;
+                    keyed.push((item.clone(), key));
+                }
+                keyed.sort_by(|(_, ka), (_, kb)| compare_values(ka, kb).cmp(&0));
+                Ok(VmValue::List(Rc::new(
+                    keyed.into_iter().map(|(v, _)| v).collect(),
+                )))
+            }
+            "none" | "none?" => {
+                let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) else {
+                    return Ok(VmValue::Bool(items.is_empty()));
+                };
+                for item in items.iter() {
+                    let result = self.call_callable_value(callable, &[item.clone()]).await?;
+                    if result.is_truthy() {
+                        return Ok(VmValue::Bool(false));
+                    }
+                }
+                Ok(VmValue::Bool(true))
+            }
+            "find_index" => {
+                let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) else {
+                    return Ok(VmValue::Int(-1));
+                };
+                for (i, item) in items.iter().enumerate() {
+                    let result = self.call_callable_value(callable, &[item.clone()]).await?;
+                    if result.is_truthy() {
+                        return Ok(VmValue::Int(i as i64));
+                    }
+                }
+                Ok(VmValue::Int(-1))
+            }
+            "partition" => {
+                let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) else {
+                    return Ok(VmValue::Nil);
+                };
+                let mut truthy = Vec::new();
+                let mut falsy = Vec::new();
+                for item in items.iter() {
+                    let result = self.call_callable_value(callable, &[item.clone()]).await?;
+                    if result.is_truthy() {
+                        truthy.push(item.clone());
+                    } else {
+                        falsy.push(item.clone());
+                    }
+                }
+                Ok(VmValue::List(Rc::new(vec![
+                    VmValue::List(Rc::new(truthy)),
+                    VmValue::List(Rc::new(falsy)),
+                ])))
+            }
+            "group_by" => {
+                let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) else {
+                    return Ok(VmValue::Nil);
+                };
+                let mut groups: BTreeMap<String, Vec<VmValue>> = BTreeMap::new();
+                for item in items.iter() {
+                    let key = self.call_callable_value(callable, &[item.clone()]).await?;
+                    let key_str = key.display();
+                    groups.entry(key_str).or_default().push(item.clone());
+                }
+                let result: BTreeMap<String, VmValue> = groups
+                    .into_iter()
+                    .map(|(k, v)| (k, VmValue::List(Rc::new(v))))
+                    .collect();
+                Ok(VmValue::Dict(Rc::new(result)))
+            }
+            "min_by" => {
+                if items.is_empty() {
+                    return Ok(VmValue::Nil);
+                }
+                let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) else {
+                    return Ok(VmValue::Nil);
+                };
+                let mut best = items[0].clone();
+                let mut best_key = self.call_callable_value(callable, &[best.clone()]).await?;
+                for item in &items[1..] {
+                    let key = self.call_callable_value(callable, &[item.clone()]).await?;
+                    if compare_values(&key, &best_key) < 0 {
+                        best = item.clone();
+                        best_key = key;
+                    }
+                }
+                Ok(best)
+            }
+            "max_by" => {
+                if items.is_empty() {
+                    return Ok(VmValue::Nil);
+                }
+                let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) else {
+                    return Ok(VmValue::Nil);
+                };
+                let mut best = items[0].clone();
+                let mut best_key = self.call_callable_value(callable, &[best.clone()]).await?;
+                for item in &items[1..] {
+                    let key = self.call_callable_value(callable, &[item.clone()]).await?;
+                    if compare_values(&key, &best_key) > 0 {
+                        best = item.clone();
+                        best_key = key;
+                    }
+                }
+                Ok(best)
             }
             _ => Err(VmError::Runtime(format!("list has no method `{method}`"))),
         }

--- a/crates/harn-vm/src/vm/methods/number.rs
+++ b/crates/harn-vm/src/vm/methods/number.rs
@@ -2,7 +2,6 @@ use crate::value::{VmError, VmValue};
 
 impl crate::vm::Vm {
     pub(super) fn call_number_method(
-        &mut self,
         _obj: &VmValue,
         _method: &str,
         _args: &[VmValue],

--- a/crates/harn-vm/src/vm/methods/range.rs
+++ b/crates/harn-vm/src/vm/methods/range.rs
@@ -2,14 +2,13 @@ use crate::value::{VmError, VmRange, VmValue};
 use crate::vm::iter::iter_from_value;
 
 impl crate::vm::Vm {
-    pub(super) async fn call_range_method(
-        &mut self,
+    pub(super) fn call_range_method_sync(
         obj: &VmValue,
         r: &VmRange,
         method: &str,
         args: &[VmValue],
-    ) -> Result<VmValue, VmError> {
-        match method {
+    ) -> Option<Result<VmValue, VmError>> {
+        let result = match method {
             "len" | "count" => Ok(VmValue::Int(r.len())),
             "empty" => Ok(VmValue::Bool(r.is_empty())),
             "contains" => {
@@ -23,10 +22,29 @@ impl crate::vm::Vm {
             "first" => Ok(r.first().map(VmValue::Int).unwrap_or(VmValue::Nil)),
             "last" => Ok(r.last().map(VmValue::Int).unwrap_or(VmValue::Nil)),
             "to_string" => Ok(VmValue::String(std::rc::Rc::from(obj.display()))),
-            _ => {
-                let lifted = iter_from_value(obj.clone())?;
-                self.call_method(lifted, method, args).await
-            }
+            _ => return None,
+        };
+        Some(result)
+    }
+
+    pub(super) async fn call_range_method(
+        &mut self,
+        obj: &VmValue,
+        r: &VmRange,
+        method: &str,
+        args: &[VmValue],
+    ) -> Result<VmValue, VmError> {
+        if let Some(result) = Self::call_range_method_sync(obj, r, method, args) {
+            return result;
+        }
+
+        let lifted = iter_from_value(obj.clone())?;
+        match lifted {
+            VmValue::Iter(handle) => self.call_iter_method(&handle, method, args).await,
+            other => Err(VmError::TypeError(format!(
+                "value of type {} has no method `{method}`",
+                other.type_name()
+            ))),
         }
     }
 }

--- a/crates/harn-vm/src/vm/methods/set.rs
+++ b/crates/harn-vm/src/vm/methods/set.rs
@@ -3,13 +3,12 @@ use std::rc::Rc;
 use crate::value::{values_equal, VmError, VmValue};
 
 impl crate::vm::Vm {
-    pub(super) async fn call_set_method(
-        &mut self,
+    pub(super) fn call_set_method_sync(
         items: &Rc<Vec<VmValue>>,
         method: &str,
         args: &[VmValue],
-    ) -> Result<VmValue, VmError> {
-        match method {
+    ) -> Option<Result<VmValue, VmError>> {
+        let result = match method {
             "count" | "len" => Ok(VmValue::Int(items.len() as i64)),
             "empty" => Ok(VmValue::Bool(items.is_empty())),
             "contains" => {
@@ -122,59 +121,89 @@ impl crate::vm::Vm {
             }
             "to_list" => Ok(VmValue::List(Rc::new(items.to_vec()))),
             "to_set" => Ok(VmValue::Set(Rc::clone(items))),
-            "map" => {
-                if let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) {
-                    let mut result = Vec::new();
-                    for item in items.iter() {
-                        let mapped = self.call_callable_value(callable, &[item.clone()]).await?;
-                        if !result.iter().any(|x| values_equal(x, &mapped)) {
-                            result.push(mapped);
-                        }
-                    }
-                    Ok(VmValue::Set(Rc::new(result)))
-                } else {
-                    Ok(VmValue::Nil)
+            "map" | "filter" => {
+                if args.first().is_some_and(Self::is_callable_value) {
+                    return None;
                 }
-            }
-            "filter" => {
-                if let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) {
-                    let mut result = Vec::new();
-                    for item in items.iter() {
-                        let keep = self.call_callable_value(callable, &[item.clone()]).await?;
-                        if keep.is_truthy() {
-                            result.push(item.clone());
-                        }
-                    }
-                    Ok(VmValue::Set(Rc::new(result)))
-                } else {
-                    Ok(VmValue::Nil)
-                }
+                Ok(VmValue::Nil)
             }
             "any" => {
-                if let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) {
-                    for item in items.iter() {
-                        let result = self.call_callable_value(callable, &[item.clone()]).await?;
-                        if result.is_truthy() {
-                            return Ok(VmValue::Bool(true));
-                        }
-                    }
-                    Ok(VmValue::Bool(false))
-                } else {
-                    Ok(VmValue::Bool(false))
+                if args.first().is_some_and(Self::is_callable_value) {
+                    return None;
                 }
+                Ok(VmValue::Bool(false))
             }
             "all" | "every" => {
-                if let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) {
-                    for item in items.iter() {
-                        let result = self.call_callable_value(callable, &[item.clone()]).await?;
-                        if !result.is_truthy() {
-                            return Ok(VmValue::Bool(false));
-                        }
-                    }
-                    Ok(VmValue::Bool(true))
-                } else {
-                    Ok(VmValue::Bool(true))
+                if args.first().is_some_and(Self::is_callable_value) {
+                    return None;
                 }
+                Ok(VmValue::Bool(true))
+            }
+            _ => Err(VmError::Runtime(format!("set has no method `{method}`"))),
+        };
+        Some(result)
+    }
+
+    pub(super) async fn call_set_method(
+        &mut self,
+        items: &Rc<Vec<VmValue>>,
+        method: &str,
+        args: &[VmValue],
+    ) -> Result<VmValue, VmError> {
+        if let Some(result) = Self::call_set_method_sync(items, method, args) {
+            return result;
+        }
+
+        match method {
+            "map" => {
+                let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) else {
+                    return Ok(VmValue::Nil);
+                };
+                let mut result = Vec::new();
+                for item in items.iter() {
+                    let mapped = self.call_callable_value(callable, &[item.clone()]).await?;
+                    if !result.iter().any(|x| values_equal(x, &mapped)) {
+                        result.push(mapped);
+                    }
+                }
+                Ok(VmValue::Set(Rc::new(result)))
+            }
+            "filter" => {
+                let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) else {
+                    return Ok(VmValue::Nil);
+                };
+                let mut result = Vec::new();
+                for item in items.iter() {
+                    let keep = self.call_callable_value(callable, &[item.clone()]).await?;
+                    if keep.is_truthy() {
+                        result.push(item.clone());
+                    }
+                }
+                Ok(VmValue::Set(Rc::new(result)))
+            }
+            "any" => {
+                let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) else {
+                    return Ok(VmValue::Bool(false));
+                };
+                for item in items.iter() {
+                    let result = self.call_callable_value(callable, &[item.clone()]).await?;
+                    if result.is_truthy() {
+                        return Ok(VmValue::Bool(true));
+                    }
+                }
+                Ok(VmValue::Bool(false))
+            }
+            "all" | "every" => {
+                let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) else {
+                    return Ok(VmValue::Bool(true));
+                };
+                for item in items.iter() {
+                    let result = self.call_callable_value(callable, &[item.clone()]).await?;
+                    if !result.is_truthy() {
+                        return Ok(VmValue::Bool(false));
+                    }
+                }
+                Ok(VmValue::Bool(true))
             }
             _ => Err(VmError::Runtime(format!("set has no method `{method}`"))),
         }

--- a/crates/harn-vm/src/vm/methods/string.rs
+++ b/crates/harn-vm/src/vm/methods/string.rs
@@ -4,7 +4,6 @@ use crate::value::{VmError, VmValue};
 
 impl crate::vm::Vm {
     pub(super) fn call_string_method(
-        &mut self,
         s: &Rc<str>,
         method: &str,
         args: &[VmValue],

--- a/crates/harn-vm/src/vm/ops/call.rs
+++ b/crates/harn-vm/src/vm/ops/call.rs
@@ -1186,22 +1186,124 @@ impl super::super::Vm {
                 Self::const_string(&frame.chunk.constants[name_idx as usize])?
             };
             let cache_target = Self::method_cache_target(&obj, &method, argc);
-            let args = self.take_stack_args_from(args_start)?;
-            self.stack.truncate(obj_idx);
-            let result = self.call_method(obj, &method, &args).await?;
+            let result = if let Some(result) =
+                Self::call_method_sync(&obj, &method, &self.stack[args_start..])
+            {
+                self.stack.truncate(obj_idx);
+                result?
+            } else {
+                let args = self.take_stack_args_from(args_start)?;
+                self.stack.truncate(obj_idx);
+                self.call_method_async(obj, &method, &args).await?
+            };
             if let (Some(slot), Some(target)) = (cache_slot, cache_target) {
                 let frame = self.frames.last().unwrap();
                 frame.chunk.set_inline_cache_entry(
                     slot,
                     InlineCacheEntry::Method {
                         name_idx,
-                        argc: args.len(),
+                        argc,
                         target,
                     },
                 );
             }
             self.stack.push(result);
         }
+        Ok(())
+    }
+
+    /// Completes method calls that do not need to suspend. Returning `None`
+    /// leaves the frame and operand stack untouched for the async fallback.
+    pub(super) fn execute_method_call_sync(
+        &mut self,
+        optional: bool,
+    ) -> Option<Result<(), VmError>> {
+        let (name_idx, argc, cache_slot, cache_entry) = {
+            let frame = self.frames.last().unwrap();
+            let op_offset = frame.ip.saturating_sub(1);
+            let name_idx = frame.chunk.read_u16(frame.ip);
+            let argc = frame.chunk.code[frame.ip + 2] as usize;
+            let cache_slot = frame.chunk.inline_cache_slot(op_offset);
+            let cache_entry = cache_slot
+                .map(|slot| frame.chunk.inline_cache_entry(slot))
+                .unwrap_or(InlineCacheEntry::Empty);
+            (name_idx, argc, cache_slot, cache_entry)
+        };
+
+        let args_start = match self.stack.len().checked_sub(argc) {
+            Some(args_start) => args_start,
+            None => return Some(Err(VmError::StackUnderflow)),
+        };
+        let obj_idx = match args_start.checked_sub(1) {
+            Some(obj_idx) => obj_idx,
+            None => return Some(Err(VmError::StackUnderflow)),
+        };
+        let obj = &self.stack[obj_idx];
+
+        if optional && matches!(obj, VmValue::Nil) {
+            return Some(self.finish_method_call_sync(
+                argc,
+                Ok(VmValue::Nil),
+                name_idx,
+                None,
+                None,
+            ));
+        }
+
+        if let Some(result) =
+            Self::try_cached_method(&cache_entry, name_idx, argc, obj, &self.stack[args_start..])
+        {
+            return Some(self.finish_method_call_sync(argc, Ok(result), name_idx, None, None));
+        }
+
+        let (result, cache_target) = {
+            let frame = self.frames.last().unwrap();
+            let method = match Self::const_str(&frame.chunk.constants[name_idx as usize]) {
+                Ok(method) => method,
+                Err(err) => {
+                    return Some(self.finish_method_call_sync(argc, Err(err), name_idx, None, None))
+                }
+            };
+            let args = &self.stack[args_start..];
+            let result = Self::call_method_sync(obj, method, args)?;
+            let cache_target = Self::method_cache_target(obj, method, argc);
+            (result, cache_target)
+        };
+
+        Some(self.finish_method_call_sync(argc, result, name_idx, cache_slot, cache_target))
+    }
+
+    fn finish_method_call_sync(
+        &mut self,
+        argc: usize,
+        result: Result<VmValue, VmError>,
+        name_idx: u16,
+        cache_slot: Option<usize>,
+        cache_target: Option<MethodCacheTarget>,
+    ) -> Result<(), VmError> {
+        let frame = self.frames.last_mut().unwrap();
+        frame.ip += 3;
+
+        let obj_idx = self
+            .stack
+            .len()
+            .checked_sub(argc + 1)
+            .ok_or(VmError::StackUnderflow)?;
+        self.stack.truncate(obj_idx);
+
+        let result = result?;
+        if let (Some(slot), Some(target)) = (cache_slot, cache_target) {
+            let frame = self.frames.last().unwrap();
+            frame.chunk.set_inline_cache_entry(
+                slot,
+                InlineCacheEntry::Method {
+                    name_idx,
+                    argc,
+                    target,
+                },
+            );
+        }
+        self.stack.push(result);
         Ok(())
     }
 
@@ -1237,7 +1339,11 @@ impl super::super::Vm {
                 Self::const_string(&frame.chunk.constants[name_idx as usize])?
             };
             let cache_target = Self::method_cache_target(&obj, &method, args.len());
-            let result = self.call_method(obj, &method, &args).await?;
+            let result = if let Some(result) = Self::call_method_sync(&obj, &method, &args) {
+                result?
+            } else {
+                self.call_method_async(obj, &method, &args).await?
+            };
             if let (Some(slot), Some(target)) = (cache_slot, cache_target) {
                 let frame = self.frames.last().unwrap();
                 frame.chunk.set_inline_cache_entry(

--- a/crates/harn-vm/src/vm/ops/mod.rs
+++ b/crates/harn-vm/src/vm/ops/mod.rs
@@ -128,6 +128,12 @@ impl super::Vm {
             // string/builtin-ref callees return `None` and fall through
             // to `execute_tail_call_async`.
             Op::TailCall => return self.execute_tail_call_sync(),
+            // MethodCall is split: optional-nil receivers, inline-cache
+            // hits, and receiver methods that are known to be synchronous
+            // complete here. Callback-taking collection methods and host
+            // capability methods fall through with `ip` untouched.
+            Op::MethodCall => return self.execute_method_call_sync(false),
+            Op::MethodCallOpt => return self.execute_method_call_sync(true),
             Op::Throw => self.execute_throw(),
             Op::TryCatchSetup => {
                 self.execute_try_catch_setup();
@@ -193,8 +199,6 @@ impl super::Vm {
             // keeps the sync/async classification visible alongside the
             // sync dispatch table.
             Op::CallBuiltinSpread
-            | Op::MethodCall
-            | Op::MethodCallOpt
             | Op::Pipe
             | Op::Parallel
             | Op::ParallelMap


### PR DESCRIPTION
## Summary
- split method dispatch into a sync fast path plus boxed async fallback
- route MethodCall/MethodCallOpt through sync execution for optional nil, inline-cache hits, and known sync receiver methods
- move pure list/dict/set/range receiver methods into sync helpers while preserving callable-backed async behavior

Closes #2087

## Verification
- cargo fmt --check
- CARGO_TARGET_DIR=/tmp/harn-target-2087 cargo check -p harn-vm
- CARGO_TARGET_DIR=/tmp/harn-target-2087 cargo nextest run -p harn-vm
- CARGO_TARGET_DIR=/tmp/harn-target-2087 cargo clippy -p harn-vm --all-targets -- -D warnings
- repository pre-commit hook: workspace clippy and configured gates
- repository pre-push hook: targeted local checks
- targeted conformance fixtures for list/dict/set/range/iter sinks
- full conformance: 1381 passed, 0 failed, 0 skipped

## Benchmarks
- /tmp/harn-target-2087/release/harn bench --iterations 20 perf/vm/method_call_dispatch.harn: mean 32.74 ms
- /tmp/harn-target-2087/release/harn bench --iterations 20 perf/vm/list_map_filter.harn: mean 83.06 ms