### PR TITLE
perf(cli): reduce run setup cost

### DIFF
--- a/crates/harn-cli/src/commands/bench.rs
+++ b/crates/harn-cli/src/commands/bench.rs
@@ -129,7 +129,7 @@ pub(crate) async fn run_bench(path: &str, iterations: usize, profile: RunProfile
         }
 
         let mut vm = harn_vm::Vm::new();
-        harn_vm::register_vm_stdlib(&mut vm);
+        harn_vm::register_vm_stdlib_with_deferred_llm(&mut vm);
         crate::install_default_hostlib(&mut vm);
         harn_vm::register_store_builtins(&mut vm, store_base);
         harn_vm::register_metadata_builtins(&mut vm, store_base);

--- a/crates/harn-cli/src/commands/run.rs
+++ b/crates/harn-cli/src/commands/run.rs
@@ -924,7 +924,7 @@ async fn execute_run_inner(inputs: ExecuteRunInputs<'_>) -> RunOutcome {
         vm.install_interrupt_signal_token(interrupt_tokens.signal_token);
         vm.install_cancel_token(interrupt_tokens.cancel_token);
     }
-    harn_vm::register_vm_stdlib(&mut vm);
+    harn_vm::register_vm_stdlib_with_deferred_llm(&mut vm);
     crate::install_default_hostlib(&mut vm);
     let source_parent = std::path::Path::new(path)
         .parent()

--- a/crates/harn-vm/src/event_log/mod.rs
+++ b/crates/harn-vm/src/event_log/mod.rs
@@ -355,6 +355,7 @@ impl EventLogConfig {
 
 thread_local! {
     static ACTIVE_EVENT_LOG: RefCell<Option<Arc<AnyEventLog>>> = const { RefCell::new(None) };
+    static PENDING_DEFAULT_EVENT_LOG: RefCell<Option<EventLogConfig>> = const { RefCell::new(None) };
 }
 
 pub fn install_default_for_base_dir(base_dir: &Path) -> Result<Arc<AnyEventLog>, LogError> {
@@ -363,13 +364,30 @@ pub fn install_default_for_base_dir(base_dir: &Path) -> Result<Arc<AnyEventLog>,
     ACTIVE_EVENT_LOG.with(|slot| {
         *slot.borrow_mut() = Some(log.clone());
     });
+    PENDING_DEFAULT_EVENT_LOG.with(|slot| {
+        *slot.borrow_mut() = None;
+    });
     Ok(log)
+}
+
+pub fn install_lazy_default_for_base_dir(base_dir: &Path) -> Result<(), LogError> {
+    let config = EventLogConfig::for_base_dir(base_dir)?;
+    let has_active = ACTIVE_EVENT_LOG.with(|slot| slot.borrow().is_some());
+    if !has_active {
+        PENDING_DEFAULT_EVENT_LOG.with(|slot| {
+            *slot.borrow_mut() = Some(config);
+        });
+    }
+    Ok(())
 }
 
 pub fn install_memory_for_current_thread(queue_depth: usize) -> Arc<AnyEventLog> {
     let log = Arc::new(AnyEventLog::Memory(MemoryEventLog::new(queue_depth.max(1))));
     ACTIVE_EVENT_LOG.with(|slot| {
         *slot.borrow_mut() = Some(log.clone());
+    });
+    PENDING_DEFAULT_EVENT_LOG.with(|slot| {
+        *slot.borrow_mut() = None;
     });
     log
 }
@@ -378,15 +396,32 @@ pub fn install_active_event_log(log: Arc<AnyEventLog>) -> Arc<AnyEventLog> {
     ACTIVE_EVENT_LOG.with(|slot| {
         *slot.borrow_mut() = Some(log.clone());
     });
+    PENDING_DEFAULT_EVENT_LOG.with(|slot| {
+        *slot.borrow_mut() = None;
+    });
     log
 }
 
 pub fn active_event_log() -> Option<Arc<AnyEventLog>> {
-    ACTIVE_EVENT_LOG.with(|slot| slot.borrow().clone())
+    if let Some(log) = ACTIVE_EVENT_LOG.with(|slot| slot.borrow().clone()) {
+        return Some(log);
+    }
+
+    let config = PENDING_DEFAULT_EVENT_LOG.with(|slot| slot.borrow_mut().take())?;
+    match open_event_log(&config) {
+        Ok(log) => Some(install_active_event_log(log)),
+        Err(error) => {
+            crate::events::log_warn("event_log.init", &error.to_string());
+            None
+        }
+    }
 }
 
 pub fn reset_active_event_log() {
     ACTIVE_EVENT_LOG.with(|slot| {
+        *slot.borrow_mut() = None;
+    });
+    PENDING_DEFAULT_EVENT_LOG.with(|slot| {
         *slot.borrow_mut() = None;
     });
 }
@@ -1980,6 +2015,21 @@ mod tests {
     use super::*;
     use futures::StreamExt;
     use rand::{rngs::StdRng, RngExt, SeedableRng};
+
+    #[test]
+    fn lazy_default_event_log_opens_on_first_access() {
+        reset_active_event_log();
+        let dir = tempfile::tempdir().unwrap();
+
+        install_lazy_default_for_base_dir(dir.path()).unwrap();
+        assert!(ACTIVE_EVENT_LOG.with(|slot| slot.borrow().is_none()));
+        assert!(PENDING_DEFAULT_EVENT_LOG.with(|slot| slot.borrow().is_some()));
+
+        let _log = active_event_log().expect("lazy event log should open on demand");
+        assert!(ACTIVE_EVENT_LOG.with(|slot| slot.borrow().is_some()));
+        assert!(PENDING_DEFAULT_EVENT_LOG.with(|slot| slot.borrow().is_none()));
+        reset_active_event_log();
+    }
 
     async fn exercise_basic_backend(log: Arc<AnyEventLog>) {
         let topic = Topic::new("trigger.inbox").unwrap();

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -238,6 +238,7 @@ pub use stdlib::workflow_messages::{
 };
 pub use stdlib::{
     register_agent_stdlib, register_core_stdlib, register_io_stdlib, register_vm_stdlib,
+    register_vm_stdlib_with_deferred_llm,
 };
 pub use store::register_store_builtins;
 pub use tenant::{

--- a/crates/harn-vm/src/llm/agent_config.rs
+++ b/crates/harn-vm/src/llm/agent_config.rs
@@ -3,8 +3,12 @@
 
 use std::rc::Rc;
 
-use crate::stdlib::harn_entry::register_harn_entrypoint_category;
-use crate::stdlib::registration::{register_builtin_group, BuiltinGroup, SyncBuiltin};
+use crate::stdlib::harn_entry::{
+    register_deferred_harn_entrypoint_category, register_harn_entrypoint_category,
+};
+use crate::stdlib::registration::{
+    register_builtin_group, register_deferred_builtin_group, BuiltinGroup, SyncBuiltin,
+};
 use crate::value::{VmError, VmValue};
 use crate::vm::{Vm, VmBuiltinArity, VmBuiltinMetadata};
 
@@ -294,6 +298,10 @@ pub(crate) fn register_agent_loop(vm: &mut Vm) {
     register_harn_entrypoint_category(vm, AGENT_STDLIB_ENTRYPOINT_CATEGORY);
 }
 
+pub(crate) fn register_deferred_agent_loop(vm: &mut Vm, registrar: fn(&mut Vm)) {
+    register_deferred_harn_entrypoint_category(vm, AGENT_STDLIB_ENTRYPOINT_CATEGORY, registrar);
+}
+
 pub fn register_agent_loop_with_bridge(vm: &mut Vm, bridge: Rc<crate::bridge::HostBridge>) {
     super::agent_runtime::install_current_host_bridge(bridge);
     register_harn_entrypoint_category(vm, AGENT_STDLIB_ENTRYPOINT_CATEGORY);
@@ -301,6 +309,10 @@ pub fn register_agent_loop_with_bridge(vm: &mut Vm, bridge: Rc<crate::bridge::Ho
 
 pub(crate) fn register_agent_control_primitives(vm: &mut Vm) {
     register_builtin_group(vm, AGENT_CONTROL_GROUP);
+}
+
+pub(crate) fn register_deferred_agent_control_primitives(vm: &mut Vm, registrar: fn(&mut Vm)) {
+    register_deferred_builtin_group(vm, AGENT_CONTROL_GROUP, registrar);
 }
 
 fn agent_subscribe_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {

--- a/crates/harn-vm/src/llm/agent_session_host.rs
+++ b/crates/harn-vm/src/llm/agent_session_host.rs
@@ -15,7 +15,9 @@ use crate::orchestration::{
     pop_approval_policy, pop_execution_policy, push_approval_policy, push_command_policy,
     push_execution_policy, CapabilityPolicy, ToolApprovalPolicy,
 };
-use crate::stdlib::registration::{register_builtin_group, BuiltinGroup, SyncBuiltin};
+use crate::stdlib::registration::{
+    register_builtin_group, register_deferred_builtin_group, BuiltinGroup, SyncBuiltin,
+};
 use crate::value::{VmError, VmValue};
 use crate::vm::{Vm, VmBuiltinArity, VmBuiltinMetadata};
 
@@ -2104,6 +2106,21 @@ const HOST_SESSION_PRIMITIVES_SYNC: &[SyncBuiltin] = &[
 const HOST_SESSION_PRIMITIVES_GROUP: BuiltinGroup<'static> = BuiltinGroup::new()
     .category("agent.host")
     .sync(HOST_SESSION_PRIMITIVES_SYNC);
+
+pub fn register_deferred_agent_session_host_primitives(vm: &mut Vm, registrar: fn(&mut Vm)) {
+    register_deferred_builtin_group(vm, HOST_SESSION_PRIMITIVES_GROUP, registrar);
+    for name in [
+        HOST_SESSION_INIT,
+        HOST_SESSION_FINALIZE,
+        HOST_AGENT_EMIT_EVENT,
+        HOST_SKILL_SCORE,
+        HOST_AUTONOMY_BUDGET_CHECK,
+        HOST_SESSION_DRAIN_BRIDGE_INJECTIONS,
+        HOST_DAEMON_WAIT,
+    ] {
+        vm.register_deferred_builtin(name, registrar);
+    }
+}
 
 pub fn register_agent_session_host_primitives(vm: &mut Vm) {
     register_builtin_group(vm, HOST_SESSION_PRIMITIVES_GROUP);

--- a/crates/harn-vm/src/llm/cache.rs
+++ b/crates/harn-vm/src/llm/cache.rs
@@ -11,7 +11,9 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::stdlib::clock::now_wall_ms;
-use crate::stdlib::registration::{register_builtin_group, BuiltinGroup, SyncBuiltin};
+use crate::stdlib::registration::{
+    register_builtin_group, register_deferred_builtin_group, BuiltinGroup, SyncBuiltin,
+};
 use crate::value::{VmError, VmValue};
 use crate::vm::{Vm, VmBuiltinArity};
 
@@ -92,6 +94,16 @@ pub(crate) fn register_cache_builtins(vm: &mut Vm) {
         BuiltinGroup::new()
             .category("cache")
             .sync(CACHE_SYNC_PRIMITIVES),
+    );
+}
+
+pub(crate) fn register_deferred_cache_builtins(vm: &mut Vm, registrar: fn(&mut Vm)) {
+    register_deferred_builtin_group(
+        vm,
+        BuiltinGroup::new()
+            .category("cache")
+            .sync(CACHE_SYNC_PRIMITIVES),
+        registrar,
     );
 }
 

--- a/crates/harn-vm/src/llm/config_builtins.rs
+++ b/crates/harn-vm/src/llm/config_builtins.rs
@@ -4,7 +4,8 @@ use std::rc::Rc;
 use crate::llm_config;
 use crate::stdlib::json_to_vm_value;
 use crate::stdlib::registration::{
-    async_builtin, register_builtin_groups, AsyncBuiltin, BuiltinGroup, SyncBuiltin,
+    async_builtin, register_builtin_groups, register_deferred_builtin_groups, AsyncBuiltin,
+    BuiltinGroup, SyncBuiltin,
 };
 use crate::value::{VmError, VmValue};
 use crate::vm::{Vm, VmBuiltinArity};
@@ -14,6 +15,10 @@ use super::helpers::vm_value_to_json;
 /// Register config-based LLM builtins (llm_infer_provider, llm_resolve_model, etc.).
 pub(crate) fn register_config_builtins(vm: &mut Vm) {
     register_builtin_groups(vm, LLM_CONFIG_GROUPS);
+}
+
+pub(crate) fn register_deferred_config_builtins(vm: &mut Vm, registrar: fn(&mut Vm)) {
+    register_deferred_builtin_groups(vm, LLM_CONFIG_GROUPS, registrar);
 }
 
 const LLM_CONFIG_SYNC_BUILTINS: &[SyncBuiltin] = &[

--- a/crates/harn-vm/src/llm/conversation.rs
+++ b/crates/harn-vm/src/llm/conversation.rs
@@ -27,6 +27,46 @@ const INJECT_REMINDER_KEYS: &[&str] = &[
     "role_hint",
 ];
 const CLEAR_REMINDER_KEYS: &[&str] = &["id", "tag", "dedupe_key"];
+
+const CONVERSATION_BUILTIN_NAMES: &[&str] = &[
+    "conversation",
+    "transcript",
+    "transcript.inject_reminder",
+    "transcript.clear_reminders",
+    "transcript_from_messages",
+    "transcript_messages",
+    "transcript_assets",
+    "transcript_add_asset",
+    "transcript_events",
+    "transcript_reminder_event",
+    "transcript_suspension_event",
+    "transcript_resumption_event",
+    "transcript_drain_decision_event",
+    "transcript_summary",
+    "transcript_id",
+    "transcript_render_visible",
+    "transcript_render_full",
+    "transcript_summarize",
+    "transcript_export",
+    "transcript_import",
+    "transcript_fork",
+    "transcript_reset",
+    "transcript_archive",
+    "transcript_abandon",
+    "transcript_resume",
+    "add_message",
+    "add_user",
+    "add_assistant",
+    "add_system",
+    "add_tool_result",
+];
+
+pub(crate) fn register_deferred_conversation_builtins(vm: &mut Vm, registrar: fn(&mut Vm)) {
+    for name in CONVERSATION_BUILTIN_NAMES {
+        vm.register_deferred_builtin(name, registrar);
+    }
+}
+
 /// Extract and validate a transcript dict from the first argument.
 fn require_transcript<'a>(
     args: &'a [VmValue],

--- a/crates/harn-vm/src/llm/cost.rs
+++ b/crates/harn-vm/src/llm/cost.rs
@@ -518,6 +518,24 @@ pub(crate) fn record_llm_usage_for_provider(
     accumulate_cost_for_provider(provider, model, input_tokens, output_tokens)
 }
 
+const COST_BUILTIN_NAMES: &[&str] = &[
+    "llm_cost",
+    "llm_pricing",
+    "llm_format_usd",
+    "llm_compare_costs",
+    "llm_session_cost",
+    "llm_budget",
+    "llm_budget_remaining",
+    "tiktoken_count_tokens",
+    "tiktoken_tokenizer_info",
+];
+
+pub(crate) fn register_deferred_cost_builtins(vm: &mut Vm, registrar: fn(&mut Vm)) {
+    for name in COST_BUILTIN_NAMES {
+        vm.register_deferred_builtin(name, registrar);
+    }
+}
+
 pub(crate) fn register_cost_builtins(vm: &mut Vm) {
     vm.register_builtin("llm_cost", |args, _out| {
         let model = args.first().map(|a| a.display()).unwrap_or_default();

--- a/crates/harn-vm/src/llm/mock_builtins.rs
+++ b/crates/harn-vm/src/llm/mock_builtins.rs
@@ -1,7 +1,9 @@
 use std::rc::Rc;
 
 use crate::stdlib::json_to_vm_value;
-use crate::stdlib::registration::{register_builtin_group, BuiltinGroup, SyncBuiltin};
+use crate::stdlib::registration::{
+    register_builtin_group, register_deferred_builtin_group, BuiltinGroup, SyncBuiltin,
+};
 use crate::value::{VmError, VmValue};
 use crate::vm::{Vm, VmBuiltinArity};
 
@@ -37,6 +39,10 @@ const LLM_MOCK_PRIMITIVES: BuiltinGroup<'static> = BuiltinGroup::new()
 /// Register llm_mock / llm_mock_calls / llm_mock_clear builtins.
 pub(super) fn register_llm_mock_builtins(vm: &mut Vm) {
     register_builtin_group(vm, LLM_MOCK_PRIMITIVES);
+}
+
+pub(super) fn register_deferred_llm_mock_builtins(vm: &mut Vm, registrar: fn(&mut Vm)) {
+    register_deferred_builtin_group(vm, LLM_MOCK_PRIMITIVES, registrar);
 }
 
 fn llm_mock_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -170,7 +170,8 @@ pub(crate) fn ensure_real_llm_allowed(provider: &str) -> Result<(), crate::value
 }
 
 use crate::stdlib::registration::{
-    async_builtin, register_builtin_groups, AsyncBuiltin, BuiltinGroup, SyncBuiltin,
+    async_builtin, register_builtin_groups, register_deferred_builtin_groups, AsyncBuiltin,
+    BuiltinGroup, SyncBuiltin,
 };
 use crate::value::{VmError, VmValue};
 use crate::vm::{Vm, VmBuiltinArity};
@@ -584,7 +585,6 @@ async fn llm_completion_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> 
 
 /// Register LLM builtins on a VM.
 pub fn register_llm_builtins(vm: &mut Vm) {
-    rate_limit::init_from_config();
     agent_config::register_agent_control_primitives(vm);
     register_builtin_groups(vm, LLM_RUNTIME_PRIMITIVE_GROUPS);
     agent_config::register_agent_loop(vm);
@@ -599,11 +599,31 @@ pub fn register_llm_builtins(vm: &mut Vm) {
     transcript_stats::register_transcript_builtins(vm);
 }
 
+/// Register LLM builtin names without installing their handlers. The first
+/// resolution of any deferred name installs the complete LLM surface.
+pub(crate) fn register_deferred_llm_builtins(vm: &mut Vm) {
+    agent_config::register_deferred_agent_control_primitives(vm, register_llm_builtins);
+    register_deferred_builtin_groups(vm, LLM_RUNTIME_PRIMITIVE_GROUPS, register_llm_builtins);
+    agent_config::register_deferred_agent_loop(vm, register_llm_builtins);
+    agent_session_host::register_deferred_agent_session_host_primitives(vm, register_llm_builtins);
+
+    conversation::register_deferred_conversation_builtins(vm, register_llm_builtins);
+    cache::register_deferred_cache_builtins(vm, register_llm_builtins);
+    config_builtins::register_deferred_config_builtins(vm, register_llm_builtins);
+    cost::register_deferred_cost_builtins(vm, register_llm_builtins);
+    rerank::register_deferred_rerank_builtins(vm, register_llm_builtins);
+    mock_builtins::register_deferred_llm_mock_builtins(vm, register_llm_builtins);
+    transcript_stats::register_deferred_transcript_builtins(vm, register_llm_builtins);
+}
+
 #[cfg(test)]
 mod tests {
     use super::api::LlmCallOptions;
     use super::call::{build_schema_nudge, compute_validation_errors, SchemaNudge};
-    use super::{execute_llm_call, reset_llm_state, structured_output_errors};
+    use super::{
+        execute_llm_call, register_deferred_llm_builtins, register_llm_builtins, reset_llm_state,
+        structured_output_errors,
+    };
     use crate::llm::mock;
     use crate::value::VmValue;
     use std::rc::Rc;
@@ -662,6 +682,67 @@ mod tests {
             structural_experiment: None,
             applied_structural_experiment: None,
         }
+    }
+
+    #[test]
+    fn deferred_llm_builtins_install_on_first_resolution() {
+        let mut vm = crate::Vm::new();
+        crate::register_vm_stdlib_with_deferred_llm(&mut vm);
+
+        assert!(!vm
+            .builtin_names()
+            .iter()
+            .any(|name| name == "llm_rate_limit"));
+        assert!(vm.ensure_deferred_builtin("llm_rate_limit"));
+        assert!(vm
+            .builtin_names()
+            .iter()
+            .any(|name| name == "llm_rate_limit"));
+        assert!(vm.builtin_names().iter().any(|name| name == "llm_call"));
+    }
+
+    #[test]
+    fn deferred_sync_llm_builtin_installs_on_direct_call() {
+        mock::reset_llm_mock_state();
+        let chunk = crate::compile_source("llm_mock({text: \"ok\"})\n").expect("compile");
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+
+        runtime.block_on(async {
+            let local = tokio::task::LocalSet::new();
+            local
+                .run_until(async {
+                    let mut vm = crate::Vm::new();
+                    crate::register_vm_stdlib_with_deferred_llm(&mut vm);
+                    vm.execute(&chunk).await.expect("execute");
+                    assert!(mock::builtin_llm_mock_active());
+                    assert!(vm.builtin_names().iter().any(|name| name == "llm_mock"));
+                })
+                .await;
+        });
+        mock::reset_llm_mock_state();
+    }
+
+    #[test]
+    fn deferred_llm_builtin_names_match_eager_registration() {
+        let mut eager = crate::Vm::new();
+        register_llm_builtins(&mut eager);
+        let eager_names = eager
+            .builtin_names()
+            .into_iter()
+            .collect::<std::collections::BTreeSet<_>>();
+
+        let mut deferred = crate::Vm::new();
+        register_deferred_llm_builtins(&mut deferred);
+        let deferred_names = deferred
+            .deferred_builtin_registrars
+            .keys()
+            .cloned()
+            .collect::<std::collections::BTreeSet<_>>();
+
+        assert_eq!(deferred_names, eager_names);
     }
 
     #[test]

--- a/crates/harn-vm/src/llm/rate_limit.rs
+++ b/crates/harn-vm/src/llm/rate_limit.rs
@@ -10,7 +10,7 @@
 //! 2. Environment variables — `HARN_RATE_LIMIT_<PROVIDER>=<rpm>`
 //! 3. Runtime — `llm_rate_limit("provider", {rpm: N})` builtin
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::collections::{HashMap, VecDeque};
 use std::time::{Duration, Instant};
 
@@ -57,6 +57,7 @@ impl SlidingWindow {
 
 thread_local! {
     static LIMITERS: RefCell<HashMap<String, SlidingWindow>> = RefCell::new(HashMap::new());
+    static INITIALIZED_FROM_CONFIG: Cell<bool> = const { Cell::new(false) };
 }
 
 /// Load rate limits from provider config and environment variables.
@@ -65,6 +66,7 @@ pub(crate) fn init_from_config() {
     let config = crate::llm_config::load_config();
     LIMITERS.with(|limiters| {
         let mut map = limiters.borrow_mut();
+        map.clear();
         for (name, pdef) in &config.providers {
             if let Some(rpm) = pdef.rpm {
                 if rpm > 0 {
@@ -89,10 +91,19 @@ pub(crate) fn init_from_config() {
             }
         }
     }
+    INITIALIZED_FROM_CONFIG.with(|initialized| initialized.set(true));
+}
+
+fn ensure_initialized_from_config() {
+    if INITIALIZED_FROM_CONFIG.with(Cell::get) {
+        return;
+    }
+    init_from_config();
 }
 
 /// Set or update the rate limit for a provider at runtime.
 pub(crate) fn set_rate_limit(provider: &str, rpm: u32) {
+    ensure_initialized_from_config();
     LIMITERS.with(|limiters| {
         limiters
             .borrow_mut()
@@ -102,6 +113,7 @@ pub(crate) fn set_rate_limit(provider: &str, rpm: u32) {
 
 /// Remove the rate limit for a provider.
 pub(crate) fn clear_rate_limit(provider: &str) {
+    ensure_initialized_from_config();
     LIMITERS.with(|limiters| {
         limiters.borrow_mut().remove(provider);
     });
@@ -109,6 +121,7 @@ pub(crate) fn clear_rate_limit(provider: &str) {
 
 /// Query the current RPM limit for a provider. Returns `None` if unlimited.
 pub(crate) fn get_rate_limit(provider: &str) -> Option<u32> {
+    ensure_initialized_from_config();
     LIMITERS.with(|limiters| limiters.borrow().get(provider).map(|sw| sw.max_requests))
 }
 
@@ -116,6 +129,7 @@ pub(crate) fn get_rate_limit(provider: &str) -> Option<u32> {
 /// Returns immediately if no limit is configured or the window has capacity.
 /// When throttled, yields to the tokio scheduler so other tasks can run.
 pub(crate) async fn acquire_permit(provider: &str) {
+    ensure_initialized_from_config();
     loop {
         let wait = LIMITERS.with(|limiters| {
             let mut map = limiters.borrow_mut();
@@ -148,6 +162,7 @@ pub(crate) async fn acquire_permit(provider: &str) {
 /// Reset all rate limiter state. Used between test runs.
 pub(crate) fn reset_rate_limit_state() {
     LIMITERS.with(|limiters| limiters.borrow_mut().clear());
+    INITIALIZED_FROM_CONFIG.with(|initialized| initialized.set(false));
 }
 
 #[cfg(test)]

--- a/crates/harn-vm/src/llm/rerank.rs
+++ b/crates/harn-vm/src/llm/rerank.rs
@@ -1,7 +1,8 @@
 use std::rc::Rc;
 
 use crate::stdlib::registration::{
-    async_builtin, register_builtin_group, AsyncBuiltin, BuiltinGroup,
+    async_builtin, register_builtin_group, register_deferred_builtin_group, AsyncBuiltin,
+    BuiltinGroup,
 };
 use crate::value::{VmError, VmValue};
 use crate::vm::{Vm, VmBuiltinArity};
@@ -11,6 +12,10 @@ const SELF_CERTAINTY_PROMPT_SUFFIX: &str = "\n</text>";
 
 pub(crate) fn register_rerank_builtins(vm: &mut Vm) {
     register_builtin_group(vm, RERANK_PRIMITIVES);
+}
+
+pub(crate) fn register_deferred_rerank_builtins(vm: &mut Vm, registrar: fn(&mut Vm)) {
+    register_deferred_builtin_group(vm, RERANK_PRIMITIVES, registrar);
 }
 
 const RERANK_ASYNC_PRIMITIVES: &[AsyncBuiltin] =

--- a/crates/harn-vm/src/llm/transcript_stats.rs
+++ b/crates/harn-vm/src/llm/transcript_stats.rs
@@ -8,6 +8,12 @@ use std::rc::Rc;
 use crate::value::VmValue;
 use crate::vm::Vm;
 
+pub(crate) fn register_deferred_transcript_builtins(vm: &mut Vm, registrar: fn(&mut Vm)) {
+    for name in ["transcript_stats", "transcript_events_by_kind"] {
+        vm.register_deferred_builtin(name, registrar);
+    }
+}
+
 pub(crate) fn register_transcript_builtins(vm: &mut Vm) {
     vm.register_builtin("transcript_stats", |args, _out| {
         let transcript = args.first().cloned().unwrap_or(VmValue::Nil);

--- a/crates/harn-vm/src/stdlib.rs
+++ b/crates/harn-vm/src/stdlib.rs
@@ -84,7 +84,7 @@ mod web;
 pub mod workflow_messages;
 
 use crate::http::register_http_builtins;
-use crate::llm::register_llm_builtins;
+use crate::llm::{register_deferred_llm_builtins, register_llm_builtins};
 use crate::mcp::register_mcp_builtins;
 use crate::mcp_server::register_mcp_server_builtins;
 use crate::vm::Vm;
@@ -153,8 +153,7 @@ pub fn register_io_stdlib(vm: &mut Vm) {
     tui::register_tui_builtins(vm);
 }
 
-/// Register agent builtins (requires network access and async runtime).
-pub fn register_agent_stdlib(vm: &mut Vm) {
+fn register_agent_stdlib_before_llm(vm: &mut Vm) {
     concurrency::register_concurrency_builtins(vm);
     connectors::register_connector_builtins(vm);
     review::register_review_builtins(vm);
@@ -183,10 +182,25 @@ pub fn register_agent_stdlib(vm: &mut Vm) {
     assemble::register_assemble_context_builtin(vm);
     crate::egress::register_egress_builtins(vm);
     register_http_builtins(vm);
-    register_llm_builtins(vm);
+}
+
+fn register_agent_stdlib_after_llm(vm: &mut Vm) {
     register_mcp_builtins(vm);
     register_mcp_server_builtins(vm);
     crate::step_runtime::register_step_builtins(vm);
+}
+
+/// Register agent builtins (requires network access and async runtime).
+pub fn register_agent_stdlib(vm: &mut Vm) {
+    register_agent_stdlib_before_llm(vm);
+    register_llm_builtins(vm);
+    register_agent_stdlib_after_llm(vm);
+}
+
+fn register_agent_stdlib_with_deferred_llm(vm: &mut Vm) {
+    register_agent_stdlib_before_llm(vm);
+    register_deferred_llm_builtins(vm);
+    register_agent_stdlib_after_llm(vm);
 }
 
 /// Register all standard builtins on a VM (core + io + agent).
@@ -194,6 +208,13 @@ pub fn register_vm_stdlib(vm: &mut Vm) {
     register_core_stdlib(vm);
     register_io_stdlib(vm);
     register_agent_stdlib(vm);
+}
+
+/// Register the stdlib shape used by latency-sensitive CLI execution.
+pub fn register_vm_stdlib_with_deferred_llm(vm: &mut Vm) {
+    register_core_stdlib(vm);
+    register_io_stdlib(vm);
+    register_agent_stdlib_with_deferred_llm(vm);
 }
 
 pub(crate) fn rebind_execution_state_builtins(vm: &mut Vm) {

--- a/crates/harn-vm/src/stdlib/harn_entry.rs
+++ b/crates/harn-vm/src/stdlib/harn_entry.rs
@@ -31,6 +31,24 @@ pub(crate) fn register_harn_entrypoint_category(vm: &mut Vm, category: &str) {
     }
 }
 
+pub(crate) fn register_deferred_harn_entrypoint_category(
+    vm: &mut Vm,
+    category: &str,
+    registrar: fn(&mut Vm),
+) {
+    for module in harn_stdlib::entrypoint_modules() {
+        if module.category != category {
+            continue;
+        }
+        let Some(module_name) = module.import_path.strip_prefix("std/") else {
+            continue;
+        };
+        for export in harn_stdlib::public_functions_for_module(module_name) {
+            vm.register_deferred_builtin(&export.name, registrar);
+        }
+    }
+}
+
 fn arity_for_export(export: &harn_stdlib::StdlibPublicFunction) -> VmBuiltinArity {
     if export.variadic {
         VmBuiltinArity::Variadic

--- a/crates/harn-vm/src/stdlib/registration.rs
+++ b/crates/harn-vm/src/stdlib/registration.rs
@@ -53,6 +53,10 @@ macro_rules! builtin_kind {
                 self
             }
 
+            pub(crate) const fn name(&self) -> &'static str {
+                self.name
+            }
+
             fn metadata(&self, default_category: Option<&'static str>) -> VmBuiltinMetadata {
                 let mut metadata = VmBuiltinMetadata::$meta_ctor(self.name);
                 if let Some(signature) = self.signature {
@@ -137,5 +141,28 @@ pub(crate) fn register_builtin_group(vm: &mut Vm, group: BuiltinGroup<'_>) {
 pub(crate) fn register_builtin_groups(vm: &mut Vm, groups: &[BuiltinGroup<'_>]) {
     for group in groups {
         register_builtin_group(vm, *group);
+    }
+}
+
+pub(crate) fn register_deferred_builtin_group(
+    vm: &mut Vm,
+    group: BuiltinGroup<'_>,
+    registrar: fn(&mut Vm),
+) {
+    for builtin in group.sync {
+        vm.register_deferred_builtin(builtin.name(), registrar);
+    }
+    for builtin in group.async_ {
+        vm.register_deferred_builtin(builtin.name(), registrar);
+    }
+}
+
+pub(crate) fn register_deferred_builtin_groups(
+    vm: &mut Vm,
+    groups: &[BuiltinGroup<'_>],
+    registrar: fn(&mut Vm),
+) {
+    for group in groups {
+        register_deferred_builtin_group(vm, *group, registrar);
     }
 }

--- a/crates/harn-vm/src/store.rs
+++ b/crates/harn-vm/src/store.rs
@@ -140,10 +140,8 @@ fn json_to_vm(jv: &serde_json::Value) -> VmValue {
 /// on first mutation. In bridge mode, register these **before** bridge
 /// builtins so the host can override them.
 pub fn register_store_builtins(vm: &mut Vm, base_dir: &Path) {
-    if crate::event_log::active_event_log().is_none() {
-        if let Err(error) = crate::event_log::install_default_for_base_dir(base_dir) {
-            crate::events::log_warn("event_log.init", &error.to_string());
-        }
+    if let Err(error) = crate::event_log::install_lazy_default_for_base_dir(base_dir) {
+        crate::events::log_warn("event_log.init", &error.to_string());
     }
     let state = Rc::new(RefCell::new(StoreState::new(base_dir)));
 

--- a/crates/harn-vm/src/vm/dispatch.rs
+++ b/crates/harn-vm/src/vm/dispatch.rs
@@ -139,6 +139,7 @@ impl Vm {
         Rc::make_mut(&mut self.builtins).insert(name.to_string(), Rc::new(f));
         Rc::make_mut(&mut self.builtin_metadata)
             .insert(name.to_string(), VmBuiltinMetadata::sync(name.to_string()));
+        Rc::make_mut(&mut self.deferred_builtin_registrars).remove(name);
         self.refresh_builtin_id(name);
     }
 
@@ -151,6 +152,7 @@ impl Vm {
         Rc::make_mut(&mut self.builtins).insert(name.clone(), Rc::new(f));
         Rc::make_mut(&mut self.builtin_metadata)
             .insert(name.clone(), metadata.with_kind(VmBuiltinKind::Sync));
+        Rc::make_mut(&mut self.deferred_builtin_registrars).remove(&name);
         self.refresh_builtin_id(&name);
     }
 
@@ -180,6 +182,7 @@ impl Vm {
             name.to_string(),
             VmBuiltinMetadata::async_builtin(name.to_string()),
         );
+        Rc::make_mut(&mut self.deferred_builtin_registrars).remove(name);
         self.refresh_builtin_id(name);
     }
 
@@ -197,7 +200,26 @@ impl Vm {
             .insert(name.clone(), Rc::new(move |args| Box::pin(f(args))));
         Rc::make_mut(&mut self.builtin_metadata)
             .insert(name.clone(), metadata.with_kind(VmBuiltinKind::Async));
+        Rc::make_mut(&mut self.deferred_builtin_registrars).remove(&name);
         self.refresh_builtin_id(&name);
+    }
+
+    /// Register a builtin name whose implementation should be installed only
+    /// if a script actually resolves that name.
+    pub(crate) fn register_deferred_builtin(&mut self, name: &str, registrar: fn(&mut Vm)) {
+        if self.builtins.contains_key(name) || self.async_builtins.contains_key(name) {
+            return;
+        }
+        Rc::make_mut(&mut self.deferred_builtin_registrars).insert(name.to_string(), registrar);
+    }
+
+    pub(crate) fn ensure_deferred_builtin(&mut self, name: &str) -> bool {
+        let Some(registrar) = self.deferred_builtin_registrars.get(name).copied() else {
+            return false;
+        };
+        registrar(self);
+        Rc::make_mut(&mut self.deferred_builtin_registrars).remove(name);
+        self.builtins.contains_key(name) || self.async_builtins.contains_key(name)
     }
 
     pub(crate) fn registered_builtin_id(&self, name: &str) -> Option<BuiltinId> {
@@ -343,6 +365,7 @@ impl Vm {
                 category: ErrorCategory::ToolRejected,
             }));
         }
+        self.ensure_deferred_builtin(name);
         let builtin = match self.resolve_sync_builtin_id_or_name(direct_id, name)? {
             Ok(builtin) => builtin,
             Err(error) => return Some(Err(error)),
@@ -368,6 +391,7 @@ impl Vm {
                 category: ErrorCategory::ToolRejected,
             }));
         }
+        self.ensure_deferred_builtin(name);
         let builtin = match self.resolve_sync_builtin_id_or_name(direct_id, name)? {
             Ok(builtin) => builtin,
             Err(error) => return Some(Err(error)),
@@ -427,6 +451,8 @@ impl Vm {
             return result;
         }
 
+        self.ensure_deferred_builtin(name);
+
         if let Some(id) = direct_id {
             if let Some(entry) = self.builtins_by_id.get(&id).cloned() {
                 if entry.name.as_ref() == name {
@@ -457,6 +483,7 @@ impl Vm {
                 .builtins
                 .keys()
                 .chain(self.async_builtins.keys())
+                .chain(self.deferred_builtin_registrars.keys())
                 .map(|s| s.as_str());
             if let Some(suggestion) = crate::value::closest_match(name, all_builtins) {
                 return Err(VmError::Runtime(format!(

--- a/crates/harn-vm/src/vm/ops/stack.rs
+++ b/crates/harn-vm/src/vm/ops/stack.rs
@@ -74,6 +74,16 @@ impl super::super::Vm {
             // Collided IDs cannot use the direct index, but remain valid callbacks.
             self.stack
                 .push(VmValue::BuiltinRef(Rc::from(name.as_str())));
+        } else if self.ensure_deferred_builtin(&name) {
+            if let Some(id) = self.registered_builtin_id(&name) {
+                self.stack.push(VmValue::BuiltinRefId {
+                    id,
+                    name: Rc::from(name.as_str()),
+                });
+            } else {
+                self.stack
+                    .push(VmValue::BuiltinRef(Rc::from(name.as_str())));
+            }
         } else {
             let mut all_vars = self.visible_variables();
             for (k, v) in self.globals.iter() {
@@ -83,6 +93,7 @@ impl super::super::Vm {
             let mut candidates: Vec<String> = all_vars.keys().cloned().collect();
             candidates.extend(self.builtins.keys().cloned());
             candidates.extend(self.async_builtins.keys().cloned());
+            candidates.extend(self.deferred_builtin_registrars.keys().cloned());
             if let Some(suggestion) =
                 crate::value::closest_match(&name, candidates.iter().map(|s| s.as_str()))
             {

--- a/crates/harn-vm/src/vm/state.rs
+++ b/crates/harn-vm/src/vm/state.rs
@@ -141,6 +141,8 @@ pub(crate) struct VmBuiltinEntry {
     pub(crate) dispatch: VmBuiltinDispatch,
 }
 
+pub(crate) type DeferredBuiltinRegistrar = fn(&mut Vm);
+
 /// The Harn bytecode virtual machine.
 pub struct Vm {
     pub(crate) stack: Vec<VmValue>,
@@ -155,6 +157,8 @@ pub struct Vm {
     /// IDs with detected name collisions. Collided names safely fall back to
     /// the authoritative name-keyed lookup path.
     pub(crate) builtin_id_collisions: Rc<HashSet<BuiltinId>>,
+    /// Builtins whose registration can be deferred until first use.
+    pub(crate) deferred_builtin_registrars: Rc<BTreeMap<String, DeferredBuiltinRegistrar>>,
     /// Iterator state for for-in loops.
     pub(crate) iterators: Vec<IterState>,
     /// Call frame stack.
@@ -261,6 +265,7 @@ pub struct VmBaseline {
     builtin_metadata: Rc<BTreeMap<String, VmBuiltinMetadata>>,
     builtins_by_id: Rc<BTreeMap<BuiltinId, VmBuiltinEntry>>,
     builtin_id_collisions: Rc<HashSet<BuiltinId>>,
+    deferred_builtin_registrars: Rc<BTreeMap<String, DeferredBuiltinRegistrar>>,
     source_dir: Option<std::path::PathBuf>,
     source_file: Option<String>,
     source_text: Option<String>,
@@ -277,6 +282,7 @@ impl VmBaseline {
             builtin_metadata: Rc::clone(&vm.builtin_metadata),
             builtins_by_id: Rc::clone(&vm.builtins_by_id),
             builtin_id_collisions: Rc::clone(&vm.builtin_id_collisions),
+            deferred_builtin_registrars: Rc::clone(&vm.deferred_builtin_registrars),
             source_dir: vm.source_dir.clone(),
             source_file: vm.source_file.clone(),
             source_text: vm.source_text.clone(),
@@ -304,6 +310,7 @@ impl VmBaseline {
             builtin_metadata: Rc::clone(&self.builtin_metadata),
             builtins_by_id: Rc::clone(&self.builtins_by_id),
             builtin_id_collisions: Rc::clone(&self.builtin_id_collisions),
+            deferred_builtin_registrars: Rc::clone(&self.deferred_builtin_registrars),
             iterators: Vec::new(),
             frames: Vec::new(),
             exception_handlers: Vec::new(),
@@ -513,6 +520,7 @@ impl Vm {
             builtin_metadata: Rc::new(BTreeMap::new()),
             builtins_by_id: Rc::new(BTreeMap::new()),
             builtin_id_collisions: Rc::new(HashSet::new()),
+            deferred_builtin_registrars: Rc::new(BTreeMap::new()),
             iterators: Vec::new(),
             frames: Vec::new(),
             exception_handlers: Vec::new(),
@@ -649,6 +657,7 @@ impl Vm {
             builtin_metadata: Rc::clone(&self.builtin_metadata),
             builtins_by_id: Rc::clone(&self.builtins_by_id),
             builtin_id_collisions: Rc::clone(&self.builtin_id_collisions),
+            deferred_builtin_registrars: Rc::clone(&self.deferred_builtin_registrars),
             iterators: Vec::new(),
             frames: Vec::new(),
             exception_handlers: Vec::new(),


### PR DESCRIPTION
Fixes #2094.

## Summary
- add a VM deferred-builtin registry and use it to defer the LLM stdlib surface in `harn run` / `harn bench` setup
- lazily load LLM rate-limit config and default event-log storage
- add coverage to keep deferred LLM builtin names in sync with eager registration

## Verification
- cargo test -p harn-vm deferred_llm -- --nocapture
- CARGO_TARGET_DIR=/tmp/harn-target-issue2094 cargo run --quiet --bin harn -- test conformance --filter llm_rate_limit
- CARGO_TARGET_DIR=/tmp/harn-target-issue2094 cargo run --quiet --bin harn -- test conformance --filter mock_llm
- make lint-test-patterns
- CARGO_TARGET_DIR=/tmp/harn-target-issue2094 CARGO_BUILD_JOBS=2 cargo build --release --bin harn
- release warm run_setup samples for perf/vm/function_call_loop.harn: 4, 1, 1, 1, 1 ms before rebase; 18, 1, 1 ms after rebase
- pre-commit hook: cargo fmt, clippy --workspace --all-targets, ratchets, highlight sync
- pre-push hook: targeted local checks, highlight drift
