### PR TITLE
[codex] Refresh OpenRouter structured routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ Pre-0.6 highlights live in [CHANGELOG-pre-0.6.md](CHANGELOG-pre-0.6.md).
 Harn had no external users before 0.6.0, so that archive intentionally keeps
 condensed series summaries instead of full per-patch history.
 
+## Unreleased
+
+### Fixed
+
+- **OpenRouter structured-output routing.** Refreshes OpenRouter capability
+  rules for current DeepSeek V4, Devstral, Llama 4, and Gemma 4 families;
+  preserves `schema_stream_aborted` error categories across off-thread LLM
+  calls; emits `top_k` only when the selected route supports it; and requests
+  OpenRouter `provider.require_parameters` whenever schemas or `top_k` must be
+  honored by the routed backend.
+
 ## v0.8.28
 
 ### Added

--- a/crates/harn-vm/src/llm/api.rs
+++ b/crates/harn-vm/src/llm/api.rs
@@ -22,7 +22,7 @@ mod transport;
 
 use std::rc::Rc;
 
-use crate::value::{VmError, VmValue};
+use crate::value::{ErrorCategory, VmError, VmValue};
 
 use super::mock::{
     fixture_hash, get_replay_mode, load_fixture, mock_llm_response, record_cli_llm_result,
@@ -68,6 +68,56 @@ pub(crate) use thinking::{split_openai_thinking_blocks, ThinkingStreamSplitter};
 pub(crate) use transport::vm_call_llm_api_with_body;
 
 use transport::vm_call_llm_api;
+
+#[derive(Debug, Clone)]
+struct OffthreadLlmError {
+    message: String,
+    category: Option<ErrorCategory>,
+}
+
+impl OffthreadLlmError {
+    fn from_vm_error(err: VmError) -> Self {
+        match err {
+            VmError::CategorizedError { message, category } => Self {
+                message,
+                category: Some(category),
+            },
+            VmError::Thrown(VmValue::String(message)) => {
+                Self::from_display_message(message.to_string())
+            }
+            other => Self::from_display_message(other.to_string()),
+        }
+    }
+
+    fn from_display_message(message: String) -> Self {
+        if let Some((category, stripped)) = parse_displayed_categorized_error(&message) {
+            return Self {
+                message: stripped.to_string(),
+                category: Some(category),
+            };
+        }
+        Self {
+            message,
+            category: None,
+        }
+    }
+
+    fn into_vm_error(self) -> VmError {
+        match self.category {
+            Some(category) => VmError::CategorizedError {
+                message: self.message,
+                category,
+            },
+            None => VmError::Thrown(VmValue::String(Rc::from(self.message))),
+        }
+    }
+}
+
+fn parse_displayed_categorized_error(message: &str) -> Option<(ErrorCategory, &str)> {
+    let body = message.strip_prefix("Error [")?;
+    let (category, rest) = body.split_once("]: ")?;
+    Some((ErrorCategory::parse(category), rest))
+}
 
 /// Execute an LLM call. Always goes through the streaming path with a
 /// discarding receiver so all callers share one code path for status/error
@@ -134,7 +184,7 @@ pub(crate) async fn vm_call_llm_full_streaming_offthread(
             "llm_call background task failed: {join_err}"
         ))))
     })?
-    .map_err(|message| VmError::Thrown(VmValue::String(Rc::from(message))))?;
+    .map_err(OffthreadLlmError::into_vm_error)?;
     super::cost::record_llm_usage_for_provider(
         &result.provider,
         &result.model,
@@ -217,16 +267,12 @@ async fn vm_call_llm_full_inner_request(
     super::ensure_real_llm_allowed(&request.provider)?;
     request.emit_reminder_lifecycle();
 
-    let result = vm_call_llm_api(request, delta_tx).await;
-
-    // Surface the error as a String so it can cross the off-thread await.
-    let primary_message = result.as_ref().err().map(ToString::to_string);
-    let result = match (result, primary_message) {
-        (Ok(r), _) => r,
-        (Err(_), Some(message)) => try_fallback_provider(request, message)
-            .await
-            .map_err(|msg| VmError::Thrown(VmValue::String(Rc::from(msg))))?,
-        (Err(_), None) => unreachable!("error branch must capture a message"),
+    let result = match vm_call_llm_api(request, delta_tx).await {
+        Ok(result) => result,
+        Err(primary_error) => match try_fallback_provider(request).await {
+            Some(result) => result,
+            None => return Err(primary_error),
+        },
     };
 
     if replay_mode == LlmReplayMode::Record {
@@ -241,7 +287,7 @@ async fn vm_call_llm_full_inner_request(
 async fn vm_call_llm_full_inner_offthread(
     request: &LlmRequestPayload,
     delta_tx: Option<DeltaSender>,
-) -> Result<LlmResult, String> {
+) -> Result<LlmResult, OffthreadLlmError> {
     if let Some(result) = super::trigger_predicate::lookup_cached_result(request) {
         record_cli_llm_result(&result);
         return Ok(result);
@@ -257,7 +303,7 @@ async fn vm_call_llm_full_inner_offthread(
             &request.model,
             request.cache,
         )
-        .map_err(|e| e.to_string())?;
+        .map_err(OffthreadLlmError::from_vm_error)?;
         super::trigger_predicate::note_result(request, &result);
         record_cli_llm_result(&result);
         return Ok(result);
@@ -267,7 +313,7 @@ async fn vm_call_llm_full_inner_offthread(
         let result = crate::llm::fake::FakeLlmProvider
             .chat_impl(request, delta_tx)
             .await
-            .map_err(|e| e.to_string())?;
+            .map_err(OffthreadLlmError::from_vm_error)?;
         super::trigger_predicate::note_result(request, &result);
         record_cli_llm_result(&result);
         return Ok(result);
@@ -282,18 +328,29 @@ async fn vm_call_llm_full_inner_offthread(
                 super::trigger_predicate::note_result(request, result);
             })
             .ok_or_else(|| {
-                format!("No fixture found for LLM call (hash: {hash}). Run with --record first.")
+                OffthreadLlmError::from_display_message(format!(
+                    "No fixture found for LLM call (hash: {hash}). Run with --record first."
+                ))
             });
     }
 
-    super::ensure_real_llm_allowed(&request.provider).map_err(|err| err.to_string())?;
+    super::ensure_real_llm_allowed(&request.provider).map_err(OffthreadLlmError::from_vm_error)?;
 
-    let result = vm_call_llm_api(request, delta_tx)
-        .await
-        .map_err(|err| err.to_string());
-    let result = match result {
-        Ok(result) => result,
-        Err(message) => try_fallback_provider(request, message).await?,
+    let primary_error = match vm_call_llm_api(request, delta_tx).await {
+        Ok(result) => {
+            if replay_mode == LlmReplayMode::Record {
+                save_fixture(&hash, &result);
+            }
+            super::trigger_predicate::note_result(request, &result);
+            record_cli_llm_result(&result);
+            return Ok(result);
+        }
+        Err(primary_error) => OffthreadLlmError::from_vm_error(primary_error),
+    };
+
+    let result = match try_fallback_provider(request).await {
+        Some(result) => result,
+        None => return Err(primary_error),
     };
 
     if replay_mode == LlmReplayMode::Record {
@@ -305,13 +362,8 @@ async fn vm_call_llm_full_inner_offthread(
     Ok(result)
 }
 
-/// Attempt the request on the configured fallback provider.  Returns the
-/// original `primary_message` as the error if no fallback is available or
-/// the fallback also fails.
-async fn try_fallback_provider(
-    request: &LlmRequestPayload,
-    primary_message: String,
-) -> Result<LlmResult, String> {
+/// Attempt the request on the configured fallback provider.
+async fn try_fallback_provider(request: &LlmRequestPayload) -> Option<LlmResult> {
     for route in &request.route_fallbacks {
         if route.provider == request.provider && route.model == request.model {
             continue;
@@ -328,7 +380,7 @@ async fn try_fallback_provider(
             continue;
         }
         if let Ok(result) = vm_call_llm_api(&fb_request, None).await {
-            return Ok(result);
+            return Some(result);
         }
     }
 
@@ -348,7 +400,7 @@ async fn try_fallback_provider(
         }
     }
     if fallback_providers.is_empty() {
-        return Err(primary_message);
+        return None;
     }
 
     for fallback_provider in fallback_providers {
@@ -363,11 +415,11 @@ async fn try_fallback_provider(
             continue;
         }
         if let Ok(result) = vm_call_llm_api(&fb_request, None).await {
-            return Ok(result);
+            return Some(result);
         }
     }
 
-    Err(primary_message)
+    None
 }
 
 #[cfg(test)]
@@ -542,6 +594,26 @@ mod tests {
         let message = err.to_string();
         assert!(message.contains("HARN_LLM_CALLS_DISABLED"), "{message}");
         assert!(message.contains("provider `local`"), "{message}");
+    }
+
+    #[test]
+    fn offthread_error_preserves_schema_stream_abort_category() {
+        let abort = super::SchemaStreamAbort {
+            provider: "openrouter".to_string(),
+            model: "mistralai/devstral-small".to_string(),
+            reason: "expected JSON value, got '`'".to_string(),
+            path: "$".to_string(),
+            chunks_consumed: 1,
+        };
+
+        let err = super::OffthreadLlmError::from_vm_error(abort.into_vm_error()).into_vm_error();
+        let parsed = super::parse_schema_stream_abort(&err)
+            .expect("schema stream abort must survive off-thread conversion");
+
+        assert_eq!(parsed.provider, "openrouter");
+        assert_eq!(parsed.model, "mistralai/devstral-small");
+        assert_eq!(parsed.path, "$");
+        assert_eq!(parsed.chunks_consumed, 1);
     }
 
     #[test]

--- a/crates/harn-vm/src/llm/api/transport.rs
+++ b/crates/harn-vm/src/llm/api/transport.rs
@@ -300,6 +300,11 @@ async fn vm_call_llm_api_with_body_inner(
             }
         }
     }
+    if provider == "openrouter"
+        && (body.get("response_format").is_some() || body.get("top_k").is_some())
+    {
+        crate::llm::providers::openai_compat::ensure_openrouter_require_parameters(&mut body);
+    }
 
     if let Some(messages) = body.get("messages").and_then(|value| value.as_array()) {
         debug_log_message_shapes(

--- a/crates/harn-vm/src/llm/capabilities.rs
+++ b/crates/harn-vm/src/llm/capabilities.rs
@@ -1122,6 +1122,25 @@ anthropic_beta_features = ["fine-grained-tool-streaming-2025-05-14"]
     }
 
     #[test]
+    fn openrouter_structured_routes_cover_current_open_models() {
+        reset();
+        for model in [
+            "deepseek/deepseek-v4-flash",
+            "mistralai/devstral-small",
+            "meta-llama/llama-4-scout",
+        ] {
+            let caps = lookup("openrouter", model);
+            assert!(caps.native_tools, "{model} should expose native tools");
+            assert_eq!(caps.structured_output.as_deref(), Some("native"));
+            assert_eq!(caps.structured_output_mode, "native_json");
+        }
+        assert!(lookup("openrouter", "deepseek/deepseek-v4-flash").top_k_supported);
+        assert!(lookup("openrouter", "meta-llama/llama-4-scout").top_k_supported);
+        assert!(!lookup("openrouter", "mistralai/devstral-small").top_k_supported);
+        assert!(lookup("openrouter", "google/gemma-4-26b-a4b-it").top_k_supported);
+    }
+
+    #[test]
     fn bedrock_claude_uses_anthropic_wire_capabilities() {
         reset();
         let caps = lookup("bedrock", "anthropic.claude-3-5-sonnet-20240620-v1:0");

--- a/crates/harn-vm/src/llm/capabilities.toml
+++ b/crates/harn-vm/src/llm/capabilities.toml
@@ -1389,11 +1389,12 @@ prefers_xml_tools = false
 thinking_block_style = "inline"
 
 [[provider.openrouter]]
-model_match = "deepseek/deepseek-v3*"
+model_match = "deepseek/deepseek-v4*"
 native_tools = true
 thinking_modes = ["enabled", "effort"]
 prompt_caching = true
 structured_output = "native"
+top_k_supported = true
 server_parser = "none"
 honors_chat_template_kwargs = false
 prefers_xml_scaffolding = false
@@ -1403,6 +1404,37 @@ supports_assistant_prefill = false
 prefers_role_developer = false
 prefers_xml_tools = false
 thinking_block_style = "reasoning_summary"
+
+[[provider.openrouter]]
+model_match = "deepseek/deepseek-v3*"
+native_tools = true
+thinking_modes = ["enabled", "effort"]
+prompt_caching = true
+structured_output = "native"
+top_k_supported = true
+server_parser = "none"
+honors_chat_template_kwargs = false
+prefers_xml_scaffolding = false
+prefers_markdown_scaffolding = true
+structured_output_mode = "native_json"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = false
+thinking_block_style = "reasoning_summary"
+
+[[provider.openrouter]]
+model_match = "mistralai/devstral*"
+native_tools = true
+structured_output = "native"
+server_parser = "none"
+honors_chat_template_kwargs = false
+prefers_xml_scaffolding = false
+prefers_markdown_scaffolding = true
+structured_output_mode = "native_json"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = false
+thinking_block_style = "none"
 
 # ---------- Google Gemini + Gemma 4 (via OpenRouter) -------------------------
 #
@@ -1490,6 +1522,7 @@ thinking_block_style = "none"
 model_match = "google/gemma-4*"
 native_tools = true
 structured_output = "native"
+top_k_supported = true
 prefers_xml_scaffolding = false
 prefers_markdown_scaffolding = true
 structured_output_mode = "native_json"
@@ -1505,6 +1538,19 @@ thinking_block_style = "none"
 # without per-call workarounds. (Discovered while running the #1698 go/no-go
 # cell — `meta-llama/llama-3.3-70b-instruct` was previously rejected at the
 # capability gate even though every upstream provider supports it.)
+[[provider.openrouter]]
+model_match = "meta-llama/llama-4*"
+native_tools = true
+structured_output = "native"
+top_k_supported = true
+prefers_xml_scaffolding = false
+prefers_markdown_scaffolding = true
+structured_output_mode = "native_json"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = false
+thinking_block_style = "none"
+
 [[provider.openrouter]]
 model_match = "meta-llama/llama-3*"
 native_tools = true

--- a/crates/harn-vm/src/llm/providers/openai_compat.rs
+++ b/crates/harn-vm/src/llm/providers/openai_compat.rs
@@ -150,6 +150,9 @@ impl OpenAiCompatibleProvider {
         if let Some(top_p) = opts.top_p {
             body["top_p"] = serde_json::json!(top_p);
         }
+        if let Some(top_k) = opts.top_k.filter(|_| caps.top_k_supported) {
+            body["top_k"] = serde_json::json!(top_k);
+        }
         if opts.logprobs {
             body["logprobs"] = serde_json::json!(true);
             if let Some(top_logprobs) = opts.top_logprobs.filter(|value| *value > 0) {
@@ -205,6 +208,11 @@ impl OpenAiCompatibleProvider {
                 });
             }
         }
+        if opts.provider == "openrouter"
+            && (body.get("response_format").is_some() || body.get("top_k").is_some())
+        {
+            ensure_openrouter_require_parameters(&mut body);
+        }
         if let Some(ref tools) = opts.native_tools {
             if !tools.is_empty() {
                 body["tools"] = serde_json::json!(tools);
@@ -251,6 +259,20 @@ impl OpenAiCompatibleProvider {
             false, // is_ollama
         )
         .await
+    }
+}
+
+pub(crate) fn ensure_openrouter_require_parameters(body: &mut serde_json::Value) {
+    match body.get_mut("provider") {
+        Some(serde_json::Value::Object(provider)) => {
+            provider
+                .entry("require_parameters".to_string())
+                .or_insert_with(|| serde_json::json!(true));
+        }
+        Some(_) => {}
+        None => {
+            body["provider"] = serde_json::json!({"require_parameters": true});
+        }
     }
 }
 
@@ -667,6 +689,53 @@ thinking_modes = ["enabled"]
             body["response_format"]["json_schema"]["strict"],
             serde_json::json!(false)
         );
+    }
+
+    #[test]
+    fn openrouter_structured_output_requires_supported_parameters() {
+        let mut payload = base_request_payload();
+        payload.output_format = crate::llm::api::OutputFormat::JsonSchema {
+            schema: serde_json::json!({
+                "type": "object",
+                "properties": {"answer": {"type": "string"}},
+                "required": ["answer"],
+            }),
+            strict: true,
+        };
+
+        let body = OpenAiCompatibleProvider::build_request_body(&payload, false);
+
+        assert_eq!(body["provider"]["require_parameters"], true);
+    }
+
+    #[test]
+    fn openrouter_require_parameters_preserves_provider_preferences() {
+        let mut body = serde_json::json!({
+            "model": "google/gemma-4-26b-a4b-it",
+            "messages": [],
+            "response_format": {"type": "json_schema"},
+            "provider": {"order": ["Fireworks"], "sort": "throughput"},
+        });
+
+        ensure_openrouter_require_parameters(&mut body);
+
+        assert_eq!(body["provider"]["order"][0], "Fireworks");
+        assert_eq!(body["provider"]["sort"], "throughput");
+        assert_eq!(body["provider"]["require_parameters"], true);
+    }
+
+    #[test]
+    fn openrouter_emits_top_k_only_when_capability_allows() {
+        let mut payload = base_request_payload();
+        payload.model = "google/gemma-4-26b-a4b-it".to_string();
+        payload.top_k = Some(64);
+        let body = OpenAiCompatibleProvider::build_request_body(&payload, false);
+        assert_eq!(body["top_k"].as_i64(), Some(64));
+        assert_eq!(body["provider"]["require_parameters"], true);
+
+        payload.model = "mistralai/devstral-small".to_string();
+        let body = OpenAiCompatibleProvider::build_request_body(&payload, false);
+        assert!(body.get("top_k").is_none());
     }
 
     fn base_request_payload() -> LlmRequestPayload {

--- a/docs/src/provider-matrix.md
+++ b/docs/src/provider-matrix.md
@@ -85,9 +85,12 @@ Regenerate with `make gen-provider-matrix` and verify with `make check-provider-
 | `openrouter` | `qwen/qwen3.6*` | `any` | `enabled,effort` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | yes | no |
 | `openrouter` | `qwen/qwen3-coder*` | `any` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `none` | yes | no |
 | `openrouter` | `qwen/*` | `any` | `enabled,effort` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | yes | no |
+| `openrouter` | `deepseek/deepseek-v4*` | `any` | `enabled,effort` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | yes | yes |
 | `openrouter` | `deepseek/deepseek-v3*` | `any` | `enabled,effort` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | yes | yes |
+| `openrouter` | `mistralai/devstral*` | `any` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | yes | no |
 | `openrouter` | `google/gemini-2.5*` | `any` | `enabled,effort` | yes | yes | yes | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | yes | yes |
 | `openrouter` | `google/gemma-4*` | `any` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | yes | no |
+| `openrouter` | `meta-llama/llama-4*` | `any` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | yes | no |
 | `openrouter` | `meta-llama/llama-3*` | `any` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | yes | no |
 | `together` | `qwen/qwen3.6*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | yes | no |
 | `together` | `qwen/qwen3-coder*` | `any` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `none` | yes | no |


### PR DESCRIPTION
## Summary
- mark current OpenRouter DeepSeek V4, Devstral, Llama 4, and Gemma 4 routes with the structured-output/top_k capabilities advertised by OpenRouter
- emit OpenRouter `provider.require_parameters = true` when structured output or top_k is required, while preserving caller provider preferences
- preserve typed schema-stream-abort errors across the off-thread LLM path so schema retries see the right category

## Root Cause
The Burin enrichment smoke failures were not prompt/tool-call failures. OpenRouter metadata advertises `response_format` / `structured_outputs` for the failing models, but Harn routed several of them through prompt-mode structured output. For streaming schema aborts, the off-thread path also stringified categorized VM errors, so retry logic lost `schema_stream_aborted`. Separately, top_k was not emitted for OpenAI-compatible providers and OpenRouter routing was not constrained to endpoints that honor required params.

## Verification
- `git diff --check`
- `cargo fmt --check`
- `CARGO_TARGET_DIR=/tmp/harn-target-openrouter-fix cargo test -p harn-vm openrouter`
- `CARGO_TARGET_DIR=/tmp/harn-target-openrouter-fix cargo test -p harn-vm offthread_error_preserves_schema_stream_abort_category`
- `CARGO_TARGET_DIR=/tmp/harn-target-openrouter-fix-provider cargo test -p harn-vm provider_catalog`
- `CARGO_TARGET_DIR=/tmp/harn-target-openrouter-fix cargo build -p harn-cli`
- Burin live smoke with patched Harn: top 6 OpenRouter enrichment candidates all schema-pass, including `or-llama-scout`, `or-devstral`, and `or-deepseek-v4-flash`

OpenRouter references checked: https://openrouter.ai/api/v1/models and https://openrouter.ai/docs/guides/features/structured-outputs