### PR TITLE
ci(release): skip sccache on Windows for release binary builds

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -150,8 +150,15 @@ jobs:
           toolchain: stable
 
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+        if: matrix.target != 'x86_64-pc-windows-msvc'
 
+      # Skip sccache on Windows: the GHA cache backend repeatedly drops the
+      # connection during the long single-rustc-call harn-vm compile
+      # (`os error 10054`), so harn-vm grew past a reliability threshold on
+      # ghac for Windows runners. Local rustc + Swatinem/rust-cache still
+      # cover incremental warmth for repeat builds.
       - name: Configure Cargo to use sccache
+        if: matrix.target != 'x86_64-pc-windows-msvc'
         shell: bash
         run: echo "RUSTC_WRAPPER=${SCCACHE_PATH}" >> "$GITHUB_ENV"
 


### PR DESCRIPTION
## Summary

- Skip `mozilla-actions/sccache-action` install and `RUSTC_WRAPPER=sccache` export on the `x86_64-pc-windows-msvc` leg of `build-release-binaries.yml`.
- Other targets keep sccache; `Swatinem/rust-cache` still warms cargo `target/` across runs.

## Why

The v0.8.28 release run (https://github.com/burin-labs/harn/actions/runs/26202867069) failed twice in a row on the Windows binary build with identical errors:

```
sccache: error: failed to execute compile
sccache: caused by: error reading compile response from server
sccache: caused by: Failed to read response header
sccache: caused by: An existing connection was forcibly closed by the remote host. (os error 10054)
error: could not compile `harn-vm` (lib)
```

Two reruns died at the same point in the `harn-vm` rustc invocation. v0.8.27 succeeded on the same workflow, so the diff is `harn-vm` itself growing past a reliability threshold for the GHA-cache (`ghac`) sccache backend on Windows runners. fail-fast on the matrix cancels the other targets.

The Windows-only sccache `Cache hits` were 0% in the failing runs (the single large rmeta upload is exactly the failure point), so removing the wrapper costs no realized hit rate and frees Windows to use plain rustc with cargo's own incremental + the per-target `Swatinem/rust-cache` shared key.

## Test plan

- [ ] CI: `actionlint` and pre-commit GitHub Actions workflow check (already green locally).
- [ ] Cut v0.8.29 (workflow change only — version-bump PR + tag follow this fix) and verify all five matrix targets build and upload artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)