### PR TITLE
[codex] Skip sccache for Windows release smoke

### DIFF
--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -54,7 +54,14 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+        if: matrix.platform != 'windows'
+
+      # Match build-release-binaries.yml. Windows release-smoke spends long
+      # stretches in one harn-vm rustc invocation, and the GHA sccache backend
+      # can drop that connection (`os error 10054`). Local rustc plus
+      # Swatinem/rust-cache is slower but reliable for this gate.
       - name: Configure Cargo to use sccache
+        if: matrix.platform != 'windows'
         shell: bash
         run: echo "RUSTC_WRAPPER=${SCCACHE_PATH}" >> "$GITHUB_ENV"
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1


### PR DESCRIPTION
## Summary
- disables sccache/RUSTC_WRAPPER for the Windows release-smoke matrix leg
- documents the same ghac os error 10054 failure mode already handled by the release-binary workflow

## Root cause
The v0.8.29 Windows release-smoke job failed while compiling harn-vm because the GitHub Actions sccache backend dropped the long rustc connection. build-release-binaries.yml already skipped sccache on Windows, but release-smoke.yml still enabled it.

## Verification
- git diff --check
- pre-commit GitHub Actions workflow validation
- pre-push targeted checks