### PR TITLE
Install harness in ACP pipeline VMs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Pre-0.6 highlights live in [CHANGELOG-pre-0.6.md](CHANGELOG-pre-0.6.md).
 Harn had no external users before 0.6.0, so that archive intentionally keeps
 condensed series summaries instead of full per-patch history.
 
+## v0.8.30
+
+### Fixed
+
+- **ACP pipeline VMs now install the `harness` capability handle (#2118).**
+  File-backed ACP sessions now match `harn run`/`harn test` by installing a fresh
+  `harness` global before each prompt execution, so stdlib helpers such as
+  `std/config::env_int` and migrated pipeline code that calls
+  `harness.stdio.*` work under embedded Burin lightweight pipelines.
+
 ## v0.8.29
 
 ### Fixed

--- a/crates/harn-serve/src/adapters/acp/execute.rs
+++ b/crates/harn-serve/src/adapters/acp/execute.rs
@@ -117,6 +117,7 @@ pub(super) async fn execute_chunk(
         vm
     };
 
+    vm.set_harness(harn_vm::Harness::real());
     vm.set_global("prompt", harn_vm::VmValue::String(Rc::from(prompt.text)));
     vm.set_global(
         "prompt_content",

--- a/crates/harn-serve/src/adapters/acp/tests/sessions.rs
+++ b/crates/harn-serve/src/adapters/acp/tests/sessions.rs
@@ -640,6 +640,49 @@ async fn acp_session_close_cancels_pending_host_bridge_call() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn acp_file_backed_pipeline_installs_harness_global() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let pipeline_path = dir.path().join("harness.harn");
+            std::fs::write(
+                &pipeline_path,
+                r#"
+import { env_int } from "std/config"
+
+pipeline default(task) {
+  __io_println(env_int("HARN_ACP_HARNESS_REGRESSION_UNSET", 7))
+  harness.stdio.println("via-harness")
+}"#,
+            )
+            .expect("write pipeline");
+
+            let (request_tx, mut response_rx, server, session_id) =
+                start_acp_code_session_with_config(
+                    AcpServerConfig::for_pipeline(pipeline_path.to_string_lossy().to_string()),
+                    serde_json::json!(dir.path()),
+                )
+                .await;
+
+            let output = run_prompt_with_project_capability(
+                &request_tx,
+                &mut response_rx,
+                &session_id,
+                3,
+                "hello",
+                false,
+            )
+            .await;
+            assert_eq!(output, "7\nvia-harness\n");
+
+            drop(request_tx);
+            server.await.expect("ACP channel server task");
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn acp_file_backed_vm_baseline_keeps_prompt_turns_isolated() {
     let local = tokio::task::LocalSet::new();
     local


### PR DESCRIPTION
## Summary
- install a fresh `harness` global before each ACP prompt pipeline execution
- add an ACP regression test covering `std/config::env_int` and `harness.stdio.println`
- document the v0.8.30 fix in the changelog

## Verification
- `cargo test -p harn-serve acp_file_backed_pipeline_installs_harness_global -- --nocapture`
- `cargo test -p harn-serve acp_file_backed_vm_baseline_keeps_prompt_turns_isolated -- --nocapture`
- `cargo test -p harn-serve adapters::acp::tests`
- pre-commit: rustfmt, workspace clippy, markdownlint
- pre-push: targeted local checks, markdownlint