### PR TITLE
ci: split Rust gate into parallel lint and test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,10 +49,16 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: DavidAnson/markdownlint-cli2-action@ded1f9488f68a970bc66ea5619e13e9b52e601cd # v23.2.0
 
-  rust:
-    name: Rust (lint + test)
-    # GitHub-hosted runners keep the required gate predictable while the
-    # self-hosted pool is scarce and shared by multiple repos.
+  # `make lint` and `make test` each take roughly half of the historical
+  # combined runtime (~5 min each on a warm cache), but they don't share
+  # cargo artifacts in a way the other could reuse: clippy is check-mode and
+  # nextest is full-codegen test binaries with different metadata hashes.
+  # Splitting them into parallel jobs cuts the Linux Rust critical path in
+  # half (and the merge-queue pass with it) for free. Each job gets its own
+  # rust-cache shared-key so two jobs with the same Cargo.lock don't race
+  # to overwrite each other's saves with partial target/ contents.
+  rust-lint:
+    name: Rust lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -65,14 +71,36 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         continue-on-error: true
         with:
-          shared-key: workspace
+          shared-key: workspace-lint
+          cache-bin: false
+      # `make lint` also runs `lint-no-xfail-regression`, which compiles
+      # `harn-cli` via `cargo run` just to walk conformance/ and count
+      # `@xfail:` markers. That ~1-2 min cost is paid by the harn-audit job
+      # for free (it already has harn-cli warm from `make conformance`), so
+      # the CI invocation here drops the prereq and runs just the cheap
+      # python prelude plus clippy.
+      - run: make lint-no-rust-prompt-prose
+      - run: cargo clippy --workspace --all-targets -- -D warnings
+
+  rust-test:
+    name: Rust test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+      - name: Configure Cargo to use sccache
+        run: echo "RUSTC_WRAPPER=${SCCACHE_PATH}" >> "$GITHUB_ENV"
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        continue-on-error: true
+        with:
+          shared-key: workspace-test
           cache-bin: false
       - name: Install cargo-nextest
         uses: taiki-e/install-action@c070f87102a1c75b3183910f391c1cb887fe13c8 # v2.77.6
         continue-on-error: true
         with:
           tool: nextest@0.9.133
-      - run: make lint
       - run: make test
         env:
           NEXTEST_PROFILE: ci
@@ -95,10 +123,15 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         continue-on-error: true
         with:
-          shared-key: workspace
+          shared-key: workspace-audit
           cache-bin: false
       - run: make conformance
       - run: make protocol-conformance
+      # Promoted out of `make lint` (in the rust-lint job) so the Linux
+      # critical path doesn't pay ~1-2 min to compile harn-cli from scratch
+      # just to count `@xfail:` markers. `make conformance` above already
+      # warmed target/debug/harn, so this is effectively free here.
+      - run: make lint-no-xfail-regression
       - run: make lint-harn
       - run: make fmt-harn
       # Audit gates promoted from release_gate.sh audit so a stale
@@ -291,14 +324,15 @@ jobs:
     name: CI status
     runs-on: ubuntu-latest
     if: always()
-    needs: [fmt, lint-md, rust, harn-audit, windows, portal, actions, e2e]
+    needs: [fmt, lint-md, rust-lint, rust-test, harn-audit, windows, portal, actions, e2e]
     steps:
       - name: Verify required CI jobs
         run: |
           declare -A results=(
             ["Format check"]="${{ needs.fmt.result }}"
             ["Markdown lint"]="${{ needs['lint-md'].result }}"
-            ["Rust (lint + test)"]="${{ needs.rust.result }}"
+            ["Rust lint"]="${{ needs['rust-lint'].result }}"
+            ["Rust test"]="${{ needs['rust-test'].result }}"
             ["Harn conformance + audit"]="${{ needs['harn-audit'].result }}"
             ["Portal frontend"]="${{ needs.portal.result }}"
             ["GitHub Actions hygiene"]="${{ needs.actions.result }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,18 @@ condensed series summaries instead of full per-patch history.
   pushes restore the previous `target/` instead of rebuilding all deps from
   scratch.
 
+### Changed
+
+- **CI: split the Linux Rust gate into parallel `Rust lint` and `Rust test`
+  jobs.** `make lint` and `make test` previously serialized in one ~11-min
+  job; splitting them into parallel jobs with their own rust-cache shared
+  keys (`workspace-lint` / `workspace-test`) lets them complete in roughly
+  half the wall time. Promoted `lint-no-xfail-regression` from `make lint`
+  to the `Harn conformance + audit` job, which already has `target/debug/harn`
+  warm from `make conformance`, so the ratchet runs in seconds instead of
+  paying for a fresh `cargo run` compile on the lint critical path. The
+  required `CI status` gate now waits on both `Rust lint` and `Rust test`.
+
 ## v0.8.30
 
 ### Fixed


### PR DESCRIPTION
## Summary

Linux Rust gate (\`Rust (lint + test)\`) has been the PR & merge-queue
critical path at ~11 min for weeks. \`make lint\` (clippy) and
\`make test\` (nextest) don't share cargo artifacts the other could
reuse — clippy is check-mode metadata, nextest is full-codegen test
binaries with different metadata hashes — so running them sequentially
just pays the full cost twice.

Split into two parallel jobs (\`Rust lint\` + \`Rust test\`) with their
own rust-cache shared-keys (\`workspace-lint\` / \`workspace-test\` so
they don't race to overwrite each other's partial \`target/\` saves).

Also moves \`lint-no-xfail-regression\` out of \`make lint\` into the
\`Harn conformance + audit\` job. That step compiles \`harn-cli\` via
\`cargo run\` just to count \`@xfail:\` markers; \`make conformance\`
above it already warmed \`target/debug/harn\`, so the ratchet runs in
seconds there instead of paying for a fresh harn-cli compile on the
lint critical path.

## Investigation

Sampled the last 4 successful CI runs on main:

| Run | Rust (lint+test) | Windows | Audit | Format |
|-----|-----------------|---------|-------|--------|
| 26232544865 | 11:51 | 8:53 | 5:21 | 2:28 |
| 26229605345 | 10:26 | 9:34 | 5:20 | 2:19 |
| 26211443585 | 8:00 | 8:00 | 3:59 | 2:24 |
| 26207917603 | 7:47 | 7:13 | 3:41 | 2:19 |

Inside the rust job, \`make lint\` was ~5:20 (2:12 preludes via
\`cargo run --quiet --bin harn\` + 3:08 clippy) and \`make test\` was
~5:31 (~5:00 build + 31s test execution). sccache showed 99% Rust hit
rate, so the floor is cargo orchestration + linking, not rustc work.
Splitting puts the two halves on different runners and drops the
critical path by ~5 min (Windows becomes the new bottleneck around
9 min).

## Coverage

- Same clippy invocation runs (\`cargo clippy --workspace --all-targets
  -- -D warnings\`) — the \`Rust lint\` job just doesn't re-wrap it in
  \`make lint\` because that target's prereqs are now elsewhere.
- Same \`make test\` invocation runs unchanged in \`Rust test\`.
- Same xfail ratchet still runs in audit (just on a job that already
  has \`target/debug/harn\` warm).
- Same \`lint-no-rust-prompt-prose\` (python) still runs in \`Rust lint\`.
- \`CI status\` aggregate now waits on both new job names.

## Risk

- Cold caches on first merge after this lands (new shared-keys); first
  PR/merge-queue run after merge will rebuild from scratch on each
  workspace-* key. Self-corrects after one main push.
- If any branch protection rule pins on the exact name \`Rust (lint + test)\`
  rather than \`CI status\`, those rules need updating. Per memory, the
  org ruleset gates on \`CI status\` only.

## Test plan

- [x] \`make lint-actions\` clean
- [x] pre-commit / pre-push hooks pass
- [ ] First PR/merge-queue run: both \`Rust lint\` and \`Rust test\`
      should appear as required checks, complete in ~5-6 min each
- [ ] \`CI status\` waits on both before going green

🤖 Generated with [Claude Code](https://claude.com/claude-code)