### PR TITLE
hooks: scope pre-commit clippy + batch pre-push cargo check

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -7,9 +7,16 @@ hook_dir=$(dirname "$0")
 changed=$(mktemp)
 harn_format_files=$(mktemp)
 harn_lint_files=$(mktemp)
-trap 'rm -f "$changed" "$harn_format_files" "$harn_lint_files"' EXIT
+changed_packages=$(mktemp)
+trap 'rm -f "$changed" "$harn_format_files" "$harn_lint_files" "$changed_packages"' EXIT
 hook_write_staged_files "$changed"
 hook_disable_cargo_incremental_if_release_bump staged
+
+# Track whether the python prompt-prose ratchet has already run in this
+# hook, so the Rust and ratchet blocks don't pay for it twice when both
+# patterns match (the common case for a Rust crate edit that also
+# touches scripts/ or Makefile).
+prompt_prose_done=0
 
 if hook_paths_match "$changed" "$HOOK_RUST_PATTERN"; then
   echo "=== Pre-commit: formatting Rust ==="
@@ -56,8 +63,33 @@ fi
 hook_write_staged_files "$changed"
 
 if hook_paths_match "$changed" "$HOOK_RUST_PATTERN"; then
-  echo "=== Pre-commit: running clippy ==="
-  make lint
+  # Match the intent of 63b3ebdc: pre-commit lints the *library* surface
+  # of changed packages only — fast feedback for the dev loop. Workspace
+  # `--all-targets` clippy is still enforced by the `Rust lint` CI job
+  # and by `make lint` for ad-hoc local runs; pre-push catches
+  # test-target compile errors via `cargo check --tests`.
+  echo "=== Pre-commit: lint-no-rust-prompt-prose ==="
+  make lint-no-rust-prompt-prose
+  prompt_prose_done=1
+
+  hook_write_changed_cargo_packages "$changed" "$changed_packages"
+  if hook_paths_match "$changed" '(^Cargo\.toml$|^Cargo\.lock$|^Makefile$)'; then
+    echo "=== Pre-commit: running clippy on full workspace (workspace-scope change) ==="
+    cargo clippy --workspace -- -D warnings
+  elif [ -s "$changed_packages" ]; then
+    package_flags=""
+    while IFS= read -r package; do
+      package_flags="$package_flags -p $package"
+    done < "$changed_packages"
+    # shellcheck disable=SC2086  # intentional word splitting on -p flags
+    echo "=== Pre-commit: running clippy on changed packages ($(tr '\n' ' ' < "$changed_packages")) ==="
+    cargo clippy $package_flags -- -D warnings
+  else
+    # `.rs` outside any `crates/` package (eg. top-level build script) —
+    # fall back to a workspace check rather than skip silently.
+    echo "=== Pre-commit: running clippy on full workspace (no crate package matched) ==="
+    cargo clippy --workspace -- -D warnings
+  fi
   echo "    Rust lint OK."
 else
   echo "=== Pre-commit: skipping clippy (no Rust/Cargo changes) ==="
@@ -65,7 +97,10 @@ fi
 
 if hook_paths_match "$changed" "$HOOK_RATCHET_PATTERN"; then
   echo "=== Pre-commit: checking CI ratchets ==="
-  make lint-no-rust-prompt-prose lint-no-xfail-regression
+  if [ "$prompt_prose_done" -eq 0 ]; then
+    make lint-no-rust-prompt-prose
+  fi
+  make lint-no-xfail-regression
   echo "    CI ratchets OK."
 else
   echo "=== Pre-commit: skipping CI ratchets (no protected paths changed) ==="

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -59,9 +59,15 @@ elif hook_paths_match "$changed" '(^Cargo\.toml$|^Cargo\.lock$|^Makefile$|^\.con
 elif hook_paths_match "$changed" "$HOOK_TEST_PATTERN"; then
   hook_write_changed_cargo_packages "$changed" "$changed_packages"
   if [ -s "$changed_packages" ]; then
+    # Collect all changed packages into a single `cargo check` so cargo
+    # only resolves the dep graph and re-evaluates fingerprints once,
+    # instead of paying that overhead N times in a shell loop.
+    package_flags=""
     while IFS= read -r package; do
-      cargo check -p "$package" --tests
+      package_flags="$package_flags -p $package"
     done < "$changed_packages"
+    # shellcheck disable=SC2086  # intentional word splitting on -p flags
+    cargo check $package_flags --tests
   else
     echo "=== Pre-push: skipping Cargo check (no changed crate packages) ==="
   fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,22 @@ condensed series summaries instead of full per-patch history.
   warm from `make conformance`, so the ratchet runs in seconds instead of
   paying for a fresh `cargo run` compile on the lint critical path. The
   required `CI status` gate now waits on both `Rust lint` and `Rust test`.
+- **Pre-commit hook: scope clippy to changed packages.** Restores the
+  intent of 63b3ebdc — `make lint` was re-invoking
+  `cargo clippy --workspace --all-targets` on every Rust touch via the
+  pre-commit hook, even for a one-file edit inside a single crate. The
+  hook now runs `cargo clippy -p <pkg> -- -D warnings` for the staged
+  crate(s) only, with a workspace-scope fallback when `Cargo.toml`,
+  `Cargo.lock`, or the root `Makefile` change. Workspace `--all-targets`
+  clippy still runs in the `Rust lint` CI job and on ad-hoc `make lint`.
+- **Pre-commit hook: deduplicate the `lint-no-rust-prompt-prose` ratchet
+  step** when both the Rust pattern and the ratchet pattern match the
+  staged change set.
+- **Pre-push hook: batch per-package `cargo check` into one invocation.**
+  When multiple crates changed, the hook now runs
+  `cargo check -p A -p B ... --tests` once instead of looping
+  N invocations, so cargo only resolves the dep graph and re-evaluates
+  fingerprints once.
 
 ## v0.8.30
 


### PR DESCRIPTION
## Summary

Restore the intent of 63b3ebdc — pre-commit was supposed to lint only
the *library* surface of changed packages for fast feedback, with full
workspace `--all-targets` clippy left to CI. Later ratchet additions to
`make lint` (e.g. #1281's xfail count) quietly brought the slowness
back because the hook called `make lint`. Move the hook to invoke clippy
directly with package scoping, and leave `make lint` itself unchanged
so ad-hoc local runs and CI keep full coverage.

## Changes

### Pre-commit (\`.githooks/pre-commit\`)
- Replace \`make lint\` with:
  - \`make lint-no-rust-prompt-prose\` (python; ~5s; fast regardless)
  - \`cargo clippy -p <pkg> -- -D warnings\` for the staged crate(s), or
  - \`cargo clippy --workspace -- -D warnings\` when \`Cargo.toml\`,
    \`Cargo.lock\`, or root \`Makefile\` change (cross-crate effects can't
    be locally scoped), or for \`.rs\` files outside any crate.
- Dedupe \`lint-no-rust-prompt-prose\` when the ratchet block also runs.

### Pre-push (\`.githooks/pre-push\`)
- Collapse the per-changed-package \`cargo check\` loop into one
  \`cargo check -p A -p B ... --tests\` so cargo resolves the dep graph
  once instead of N times.

## Coverage preserved

- Workspace \`--all-targets\` clippy still runs in the \`Rust lint\` CI job
  (#2123) and \`make lint\` for ad-hoc local runs.
- Test-target compile errors are still caught: pre-push runs
  \`cargo check --tests\` on the same scoped package set.
- Ratchets (\`lint-no-xfail-regression\`, \`lint-no-rust-prompt-prose\`)
  still gate at pre-commit when the ratchet paths change.

## Risk

Per-package clippy doesn't see cross-crate API-usage lints triggered by
a downstream crate's source. Those are uncommon (clippy lints are mostly
intra-function), and the CI \`Rust lint\` job runs the full
\`--workspace --all-targets\` set on every PR & merge_group push.

## Test plan

- [x] \`sh -n\` syntax check on both hooks
- [x] pre-commit/pre-push hooks both passed on this PR's own commits
- [ ] Land and confirm next PR with a single-crate edit shows a
      \`clippy -p <crate>\` invocation instead of \`--workspace --all-targets\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)