### PR TITLE
bench: E2 — line-tables-only debuginfo on Windows (do not merge)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,6 +191,13 @@ jobs:
     runs-on: windows-latest
     needs: changes
     if: needs.changes.outputs.windows == 'true' || github.event_name == 'push'
+    # BENCH E2: shrink dev-profile debuginfo on Windows. PDB generation is a
+    # significant fraction of Windows compile/link time; line-tables-only
+    # preserves backtraces (and the filtered nextest slice can still report
+    # source positions on failure) but skips full symbol info.
+    env:
+      CARGO_PROFILE_DEV_DEBUG: line-tables-only
+      CARGO_PROFILE_TEST_DEBUG: line-tables-only
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -201,7 +208,7 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         continue-on-error: true
         with:
-          shared-key: workspace-windows
+          shared-key: workspace-windows-bench-e2
           cache-on-failure: true
           cache-bin: false
       - name: Install cargo-nextest


### PR DESCRIPTION
Bench-only PR to trigger the Windows job under candidate E2. See commit message. Will be closed once timings are collected.