### PR TITLE
Fix invalid numeric bounds in stdlib and hostlib

### DIFF
--- a/crates/harn-hostlib/src/code_index/builtins.rs
+++ b/crates/harn-hostlib/src/code_index/builtins.rs
@@ -23,8 +23,8 @@ use super::trigram;
 use super::versions::EditOp;
 use crate::error::HostlibError;
 use crate::tools::args::{
-    build_dict, dict_arg, optional_bool, optional_int, optional_int_list, optional_string,
-    optional_string_list, require_int, require_string, str_value,
+    build_dict, dict_arg, optional_bool, optional_int_list, optional_string, optional_string_list,
+    require_string, str_value,
 };
 
 /// Shared, mutable cell carrying the (at most one) live workspace index.
@@ -87,14 +87,7 @@ pub(super) fn run_query(index: &SharedIndex, args: &[VmValue]) -> Result<VmValue
         });
     }
     let case_sensitive = optional_bool(BUILTIN_QUERY, dict, "case_sensitive", false)?;
-    let max_results = optional_int(BUILTIN_QUERY, dict, "max_results", 100)?;
-    if max_results < 1 {
-        return Err(HostlibError::InvalidParameter {
-            builtin: BUILTIN_QUERY,
-            param: "max_results",
-            message: "must be >= 1".to_string(),
-        });
-    }
+    let max_results = optional_positive_usize(BUILTIN_QUERY, dict, "max_results")?.unwrap_or(100);
     let scope = optional_string_list(BUILTIN_QUERY, dict, "scope")?;
 
     let guard = index.lock().expect("code_index mutex poisoned");
@@ -129,10 +122,9 @@ pub(super) fn run_query(index: &SharedIndex, args: &[VmValue]) -> Result<VmValue
             .cmp(&a.match_count)
             .then_with(|| a.path.cmp(&b.path))
     });
-    let max = max_results as usize;
-    let truncated = hits.len() > max;
+    let truncated = hits.len() > max_results;
     if truncated {
-        hits.truncate(max);
+        hits.truncate(max_results);
     }
     Ok(build_dict([
         (
@@ -301,7 +293,7 @@ pub(super) fn run_id_to_path(
     args: &[VmValue],
 ) -> Result<VmValue, HostlibError> {
     let raw = dict_arg(BUILTIN_ID_TO_PATH, args)?;
-    let id = require_int(BUILTIN_ID_TO_PATH, raw.as_ref(), "file_id")? as FileId;
+    let id = require_positive_file_id(BUILTIN_ID_TO_PATH, raw.as_ref(), "file_id")?;
     let guard = index.lock().expect("code_index mutex poisoned");
     let path = guard
         .as_ref()
@@ -338,8 +330,12 @@ pub(super) fn run_file_meta(
     let Some(state) = guard.as_ref() else {
         return Ok(VmValue::Nil);
     };
-    let id_opt: Option<FileId> = if let Some(VmValue::Int(n)) = dict.get("file_id") {
-        Some(*n as FileId)
+    let id_opt: Option<FileId> = if dict.contains_key("file_id") {
+        Some(require_positive_file_id(
+            BUILTIN_FILE_META,
+            dict,
+            "file_id",
+        )?)
     } else if let Some(VmValue::String(p)) = dict.get("path") {
         state.lookup_path(p)
     } else {
@@ -403,28 +399,8 @@ pub(super) fn run_read_range(
     let raw = dict_arg(BUILTIN_READ_RANGE, args)?;
     let dict = raw.as_ref();
     let path = require_string(BUILTIN_READ_RANGE, dict, "path")?;
-    let start = match dict.get("start") {
-        None | Some(VmValue::Nil) => None,
-        Some(VmValue::Int(n)) => Some(*n),
-        Some(other) => {
-            return Err(HostlibError::InvalidParameter {
-                builtin: BUILTIN_READ_RANGE,
-                param: "start",
-                message: format!("expected integer, got {}", other.type_name()),
-            });
-        }
-    };
-    let end = match dict.get("end") {
-        None | Some(VmValue::Nil) => None,
-        Some(VmValue::Int(n)) => Some(*n),
-        Some(other) => {
-            return Err(HostlibError::InvalidParameter {
-                builtin: BUILTIN_READ_RANGE,
-                param: "end",
-                message: format!("expected integer, got {}", other.type_name()),
-            });
-        }
-    };
+    let start = optional_positive_i64(BUILTIN_READ_RANGE, dict, "start")?;
+    let end = optional_positive_i64(BUILTIN_READ_RANGE, dict, "end")?;
     let guard = index.lock().expect("code_index mutex poisoned");
     let abs = match guard.as_ref() {
         Some(state) => {
@@ -513,18 +489,18 @@ pub(super) fn run_trigram_query(
     let raw = dict_arg(BUILTIN_TRIGRAM_QUERY, args)?;
     let dict = raw.as_ref();
     let trigrams_raw = optional_int_list(BUILTIN_TRIGRAM_QUERY, dict, "trigrams")?;
-    let max_files = match dict.get("max_files") {
-        None | Some(VmValue::Nil) => None,
-        Some(VmValue::Int(n)) => Some(*n as usize),
-        Some(other) => {
+    let max_files = optional_positive_usize(BUILTIN_TRIGRAM_QUERY, dict, "max_files")?;
+    let mut trigrams = Vec::with_capacity(trigrams_raw.len());
+    for n in trigrams_raw {
+        if n < 0 {
             return Err(HostlibError::InvalidParameter {
                 builtin: BUILTIN_TRIGRAM_QUERY,
-                param: "max_files",
-                message: format!("expected integer, got {}", other.type_name()),
-            })
+                param: "trigrams",
+                message: "entries must be >= 0".to_string(),
+            });
         }
-    };
-    let trigrams: Vec<u32> = trigrams_raw.into_iter().map(|n| n as u32).collect();
+        trigrams.push(n as u32);
+    }
     let guard = index.lock().expect("code_index mutex poisoned");
     let mut ids: Vec<FileId> = match guard.as_ref() {
         Some(state) => state.trigrams.query(&trigrams).into_iter().collect(),
@@ -576,7 +552,7 @@ pub(super) fn run_word_get(index: &SharedIndex, args: &[VmValue]) -> Result<VmVa
 pub(super) fn run_deps_get(index: &SharedIndex, args: &[VmValue]) -> Result<VmValue, HostlibError> {
     let raw = dict_arg(BUILTIN_DEPS_GET, args)?;
     let dict = raw.as_ref();
-    let id = require_int(BUILTIN_DEPS_GET, dict, "file_id")? as FileId;
+    let id = require_positive_file_id(BUILTIN_DEPS_GET, dict, "file_id")?;
     let direction = optional_string(BUILTIN_DEPS_GET, dict, "direction")?
         .unwrap_or_else(|| "importers".to_string());
     let guard = index.lock().expect("code_index mutex poisoned");
@@ -608,7 +584,7 @@ pub(super) fn run_outline_get(
     args: &[VmValue],
 ) -> Result<VmValue, HostlibError> {
     let raw = dict_arg(BUILTIN_OUTLINE_GET, args)?;
-    let id = require_int(BUILTIN_OUTLINE_GET, raw.as_ref(), "file_id")? as FileId;
+    let id = require_positive_file_id(BUILTIN_OUTLINE_GET, raw.as_ref(), "file_id")?;
     let guard = index.lock().expect("code_index mutex poisoned");
     let symbols: Vec<VmValue> = match guard.as_ref().and_then(|s| s.files.get(&id)) {
         Some(file) => file
@@ -646,18 +622,8 @@ pub(super) fn run_changes_since(
 ) -> Result<VmValue, HostlibError> {
     let raw = dict_arg(BUILTIN_CHANGES_SINCE, args)?;
     let dict = raw.as_ref();
-    let seq = optional_int(BUILTIN_CHANGES_SINCE, dict, "seq", 0)?.max(0) as u64;
-    let limit = match dict.get("limit") {
-        None | Some(VmValue::Nil) => None,
-        Some(VmValue::Int(n)) => Some(*n as usize),
-        Some(other) => {
-            return Err(HostlibError::InvalidParameter {
-                builtin: BUILTIN_CHANGES_SINCE,
-                param: "limit",
-                message: format!("expected integer, got {}", other.type_name()),
-            })
-        }
-    };
+    let seq = optional_non_negative_u64(BUILTIN_CHANGES_SINCE, dict, "seq", 0)?;
+    let limit = optional_positive_usize(BUILTIN_CHANGES_SINCE, dict, "limit")?;
     let guard = index.lock().expect("code_index mutex poisoned");
     let records = match guard.as_ref() {
         Some(state) => state.versions.changes_since(seq, limit),
@@ -687,13 +653,13 @@ pub(super) fn run_version_record(
 ) -> Result<VmValue, HostlibError> {
     let raw = dict_arg(BUILTIN_VERSION_RECORD, args)?;
     let dict = raw.as_ref();
-    let agent_id = require_int(BUILTIN_VERSION_RECORD, dict, "agent_id")? as AgentId;
+    let agent_id = require_non_negative_u64(BUILTIN_VERSION_RECORD, dict, "agent_id")?;
     let path = require_string(BUILTIN_VERSION_RECORD, dict, "path")?;
     let op_str =
         optional_string(BUILTIN_VERSION_RECORD, dict, "op")?.unwrap_or_else(|| "write".to_string());
     let op = EditOp::parse(&op_str).unwrap_or(EditOp::Write);
     let hash = parse_hash(BUILTIN_VERSION_RECORD, dict, "hash")?;
-    let size = optional_int(BUILTIN_VERSION_RECORD, dict, "size", 0)?.max(0) as u64;
+    let size = optional_non_negative_u64(BUILTIN_VERSION_RECORD, dict, "size", 0)?;
     let now = now_unix_ms();
     let mut guard = index.lock().expect("code_index mutex poisoned");
     let state = ensure_state(BUILTIN_VERSION_RECORD, &mut guard)?;
@@ -715,17 +681,7 @@ pub(super) fn run_agent_register(
     let dict = raw.as_ref();
     let name = optional_string(BUILTIN_AGENT_REGISTER, dict, "name")?
         .unwrap_or_else(|| "agent".to_string());
-    let requested_id = match dict.get("agent_id") {
-        None | Some(VmValue::Nil) => None,
-        Some(VmValue::Int(n)) => Some(*n as AgentId),
-        Some(other) => {
-            return Err(HostlibError::InvalidParameter {
-                builtin: BUILTIN_AGENT_REGISTER,
-                param: "agent_id",
-                message: format!("expected integer, got {}", other.type_name()),
-            })
-        }
-    };
+    let requested_id = optional_positive_u64(BUILTIN_AGENT_REGISTER, dict, "agent_id")?;
     let now = now_unix_ms();
     let mut guard = index.lock().expect("code_index mutex poisoned");
     let state = ensure_state(BUILTIN_AGENT_REGISTER, &mut guard)?;
@@ -741,7 +697,7 @@ pub(super) fn run_agent_heartbeat(
     args: &[VmValue],
 ) -> Result<VmValue, HostlibError> {
     let raw = dict_arg(BUILTIN_AGENT_HEARTBEAT, args)?;
-    let id = require_int(BUILTIN_AGENT_HEARTBEAT, raw.as_ref(), "agent_id")? as AgentId;
+    let id = require_positive_u64(BUILTIN_AGENT_HEARTBEAT, raw.as_ref(), "agent_id")?;
     let now = now_unix_ms();
     let mut guard = index.lock().expect("code_index mutex poisoned");
     let state = ensure_state(BUILTIN_AGENT_HEARTBEAT, &mut guard)?;
@@ -754,7 +710,7 @@ pub(super) fn run_agent_unregister(
     args: &[VmValue],
 ) -> Result<VmValue, HostlibError> {
     let raw = dict_arg(BUILTIN_AGENT_UNREGISTER, args)?;
-    let id = require_int(BUILTIN_AGENT_UNREGISTER, raw.as_ref(), "agent_id")? as AgentId;
+    let id = require_positive_u64(BUILTIN_AGENT_UNREGISTER, raw.as_ref(), "agent_id")?;
     let mut guard = index.lock().expect("code_index mutex poisoned");
     let state = ensure_state(BUILTIN_AGENT_UNREGISTER, &mut guard)?;
     state.agents.unregister(id);
@@ -764,19 +720,9 @@ pub(super) fn run_agent_unregister(
 pub(super) fn run_lock_try(index: &SharedIndex, args: &[VmValue]) -> Result<VmValue, HostlibError> {
     let raw = dict_arg(BUILTIN_LOCK_TRY, args)?;
     let dict = raw.as_ref();
-    let agent_id = require_int(BUILTIN_LOCK_TRY, dict, "agent_id")? as AgentId;
+    let agent_id = require_positive_u64(BUILTIN_LOCK_TRY, dict, "agent_id")?;
     let path = require_string(BUILTIN_LOCK_TRY, dict, "path")?;
-    let ttl = match dict.get("ttl_ms") {
-        None | Some(VmValue::Nil) => None,
-        Some(VmValue::Int(n)) => Some(*n),
-        Some(other) => {
-            return Err(HostlibError::InvalidParameter {
-                builtin: BUILTIN_LOCK_TRY,
-                param: "ttl_ms",
-                message: format!("expected integer, got {}", other.type_name()),
-            })
-        }
-    };
+    let ttl = optional_positive_i64(BUILTIN_LOCK_TRY, dict, "ttl_ms")?;
     let now = now_unix_ms();
     let mut guard = index.lock().expect("code_index mutex poisoned");
     let state = ensure_state(BUILTIN_LOCK_TRY, &mut guard)?;
@@ -805,7 +751,7 @@ pub(super) fn run_lock_release(
 ) -> Result<VmValue, HostlibError> {
     let raw = dict_arg(BUILTIN_LOCK_RELEASE, args)?;
     let dict = raw.as_ref();
-    let agent_id = require_int(BUILTIN_LOCK_RELEASE, dict, "agent_id")? as AgentId;
+    let agent_id = require_positive_u64(BUILTIN_LOCK_RELEASE, dict, "agent_id")?;
     let path = require_string(BUILTIN_LOCK_RELEASE, dict, "path")?;
     let mut guard = index.lock().expect("code_index mutex poisoned");
     let state = ensure_state(BUILTIN_LOCK_RELEASE, &mut guard)?;
@@ -903,7 +849,12 @@ fn parse_hash(
 ) -> Result<u64, HostlibError> {
     match dict.get(key) {
         None | Some(VmValue::Nil) => Ok(0),
-        Some(VmValue::Int(n)) => Ok(*n as u64),
+        Some(VmValue::Int(n)) if *n >= 0 => Ok(*n as u64),
+        Some(VmValue::Int(n)) => Err(HostlibError::InvalidParameter {
+            builtin,
+            param: key,
+            message: format!("must be >= 0, got {n}"),
+        }),
         Some(VmValue::String(s)) => s
             .parse::<u64>()
             .map_err(|_| HostlibError::InvalidParameter {
@@ -919,6 +870,124 @@ fn parse_hash(
                 other.type_name()
             ),
         }),
+    }
+}
+
+fn require_positive_u64(
+    builtin: &'static str,
+    dict: &BTreeMap<String, VmValue>,
+    key: &'static str,
+) -> Result<u64, HostlibError> {
+    let raw = require_non_negative_u64(builtin, dict, key)?;
+    if raw == 0 {
+        return Err(HostlibError::InvalidParameter {
+            builtin,
+            param: key,
+            message: "must be >= 1".to_string(),
+        });
+    }
+    Ok(raw)
+}
+
+fn require_positive_file_id(
+    builtin: &'static str,
+    dict: &BTreeMap<String, VmValue>,
+    key: &'static str,
+) -> Result<FileId, HostlibError> {
+    let raw = require_positive_u64(builtin, dict, key)?;
+    FileId::try_from(raw).map_err(|_| HostlibError::InvalidParameter {
+        builtin,
+        param: key,
+        message: "does not fit in file id".to_string(),
+    })
+}
+
+fn require_non_negative_u64(
+    builtin: &'static str,
+    dict: &BTreeMap<String, VmValue>,
+    key: &'static str,
+) -> Result<u64, HostlibError> {
+    match dict.get(key) {
+        Some(VmValue::Int(n)) if *n >= 0 => Ok(*n as u64),
+        Some(VmValue::Float(f)) if f.fract() == 0.0 && *f >= 0.0 => Ok(*f as u64),
+        Some(VmValue::Int(n)) => Err(HostlibError::InvalidParameter {
+            builtin,
+            param: key,
+            message: format!("must be >= 0, got {n}"),
+        }),
+        Some(other) => Err(HostlibError::InvalidParameter {
+            builtin,
+            param: key,
+            message: format!("expected integer, got {}", other.type_name()),
+        }),
+        None => Err(HostlibError::MissingParameter {
+            builtin,
+            param: key,
+        }),
+    }
+}
+
+fn optional_positive_u64(
+    builtin: &'static str,
+    dict: &BTreeMap<String, VmValue>,
+    key: &'static str,
+) -> Result<Option<u64>, HostlibError> {
+    match dict.get(key) {
+        None | Some(VmValue::Nil) => Ok(None),
+        Some(_) => require_positive_u64(builtin, dict, key).map(Some),
+    }
+}
+
+fn optional_non_negative_u64(
+    builtin: &'static str,
+    dict: &BTreeMap<String, VmValue>,
+    key: &'static str,
+    default: u64,
+) -> Result<u64, HostlibError> {
+    match dict.get(key) {
+        None | Some(VmValue::Nil) => Ok(default),
+        Some(_) => require_non_negative_u64(builtin, dict, key),
+    }
+}
+
+fn optional_positive_i64(
+    builtin: &'static str,
+    dict: &BTreeMap<String, VmValue>,
+    key: &'static str,
+) -> Result<Option<i64>, HostlibError> {
+    match dict.get(key) {
+        None | Some(VmValue::Nil) => Ok(None),
+        Some(VmValue::Int(n)) if *n >= 1 => Ok(Some(*n)),
+        Some(VmValue::Float(f)) if f.fract() == 0.0 && *f >= 1.0 => Ok(Some(*f as i64)),
+        Some(VmValue::Int(n)) => Err(HostlibError::InvalidParameter {
+            builtin,
+            param: key,
+            message: format!("must be >= 1, got {n}"),
+        }),
+        Some(other) => Err(HostlibError::InvalidParameter {
+            builtin,
+            param: key,
+            message: format!("expected integer, got {}", other.type_name()),
+        }),
+    }
+}
+
+fn optional_positive_usize(
+    builtin: &'static str,
+    dict: &BTreeMap<String, VmValue>,
+    key: &'static str,
+) -> Result<Option<usize>, HostlibError> {
+    match optional_positive_u64(builtin, dict, key)? {
+        Some(value) => {
+            usize::try_from(value)
+                .map(Some)
+                .map_err(|_| HostlibError::InvalidParameter {
+                    builtin,
+                    param: key,
+                    message: "does not fit in usize".to_string(),
+                })
+        }
+        None => Ok(None),
     }
 }
 

--- a/crates/harn-hostlib/src/tools/args.rs
+++ b/crates/harn-hostlib/src/tools/args.rs
@@ -112,27 +112,6 @@ pub fn optional_int(
     }
 }
 
-/// Required integer field. Errors if the key is missing or not an int.
-pub fn require_int(
-    builtin: &'static str,
-    dict: &BTreeMap<String, VmValue>,
-    key: &'static str,
-) -> Result<i64, HostlibError> {
-    match dict.get(key) {
-        Some(VmValue::Int(n)) => Ok(*n),
-        Some(VmValue::Float(f)) if f.fract() == 0.0 => Ok(*f as i64),
-        Some(other) => Err(HostlibError::InvalidParameter {
-            builtin,
-            param: key,
-            message: format!("expected integer, got {}", other.type_name()),
-        }),
-        None => Err(HostlibError::MissingParameter {
-            builtin,
-            param: key,
-        }),
-    }
-}
-
 /// Optional list of strings. Missing/`Nil` returns `Vec::new()`.
 pub fn optional_string_list(
     builtin: &'static str,

--- a/crates/harn-hostlib/tests/code_index_live_state.rs
+++ b/crates/harn-hostlib/tests/code_index_live_state.rs
@@ -600,6 +600,109 @@ fn changes_since_respects_limit() {
     assert_eq!(extract_list(&limited).len(), 2);
 }
 
+#[test]
+fn code_index_rejects_schema_invalid_numeric_bounds() {
+    let dir = workspace();
+    let (registry, _) = build();
+    rebuild_in(dir.path(), &registry);
+
+    let cases = [
+        (
+            "hostlib_code_index_id_to_path",
+            dict(&[("file_id", VmValue::Int(0))]),
+            "file_id",
+        ),
+        (
+            "hostlib_code_index_query",
+            dict(&[
+                ("needle", VmValue::String(Rc::from("main"))),
+                ("max_results", VmValue::Int(0)),
+            ]),
+            "max_results",
+        ),
+        (
+            "hostlib_code_index_read_range",
+            dict(&[
+                ("path", VmValue::String(Rc::from("src/main.ts"))),
+                ("start", VmValue::Int(0)),
+            ]),
+            "start",
+        ),
+        (
+            "hostlib_code_index_file_meta",
+            dict(&[("file_id", VmValue::Int(0))]),
+            "file_id",
+        ),
+        (
+            "hostlib_code_index_trigram_query",
+            dict(&[("trigrams", VmValue::List(Rc::new(vec![VmValue::Int(-1)])))]),
+            "trigrams",
+        ),
+        (
+            "hostlib_code_index_trigram_query",
+            dict(&[
+                ("trigrams", VmValue::List(Rc::new(Vec::new()))),
+                ("max_files", VmValue::Int(0)),
+            ]),
+            "max_files",
+        ),
+        (
+            "hostlib_code_index_changes_since",
+            dict(&[("seq", VmValue::Int(-1))]),
+            "seq",
+        ),
+        (
+            "hostlib_code_index_changes_since",
+            dict(&[("limit", VmValue::Int(0))]),
+            "limit",
+        ),
+        (
+            "hostlib_code_index_version_record",
+            dict(&[
+                ("agent_id", VmValue::Int(-1)),
+                ("path", VmValue::String(Rc::from("src/main.ts"))),
+            ]),
+            "agent_id",
+        ),
+        (
+            "hostlib_code_index_version_record",
+            dict(&[
+                ("agent_id", VmValue::Int(1)),
+                ("path", VmValue::String(Rc::from("src/main.ts"))),
+                ("hash", VmValue::Int(-1)),
+            ]),
+            "hash",
+        ),
+        (
+            "hostlib_code_index_agent_register",
+            dict(&[("agent_id", VmValue::Int(0))]),
+            "agent_id",
+        ),
+        (
+            "hostlib_code_index_lock_try",
+            dict(&[
+                ("agent_id", VmValue::Int(1)),
+                ("path", VmValue::String(Rc::from("src/main.ts"))),
+                ("ttl_ms", VmValue::Int(0)),
+            ]),
+            "ttl_ms",
+        ),
+    ];
+
+    for (name, payload, expected_param) in cases {
+        let err = match try_call(&registry, name, payload) {
+            Ok(value) => panic!("{name} accepted invalid {expected_param}: {value:?}"),
+            Err(error) => error,
+        };
+        match err {
+            harn_hostlib::HostlibError::InvalidParameter { param, .. } => {
+                assert_eq!(param, expected_param, "{name}");
+            }
+            other => panic!("{name} returned wrong error for {expected_param}: {other:?}"),
+        }
+    }
+}
+
 // === Agent registry + locks ===
 
 #[test]

--- a/crates/harn-vm/src/stdlib/agent_sessions.rs
+++ b/crates/harn-vm/src/stdlib/agent_sessions.rs
@@ -679,23 +679,20 @@ fn build_compact_config(
         }
     }
     let mut cfg = crate::orchestration::AutoCompactConfig::default();
-    if let Some(v) = opts.get("keep_last").and_then(|v| v.as_int()) {
-        if v < 0 {
-            return Err(err("agent_session_compact: `keep_last` must be >= 0"));
-        }
-        cfg.keep_last = v as usize;
+    if let Some(v) = compact_usize_opt(opts, "keep_last")? {
+        cfg.keep_last = v;
     }
-    if let Some(v) = opts.get("token_threshold").and_then(|v| v.as_int()) {
-        cfg.token_threshold = v as usize;
+    if let Some(v) = compact_usize_opt(opts, "token_threshold")? {
+        cfg.token_threshold = v;
     }
-    if let Some(v) = opts.get("tool_output_max_chars").and_then(|v| v.as_int()) {
-        cfg.tool_output_max_chars = v as usize;
+    if let Some(v) = compact_usize_opt(opts, "tool_output_max_chars")? {
+        cfg.tool_output_max_chars = v;
     }
     if let Some(VmValue::String(s)) = opts.get("compact_strategy") {
         cfg.compact_strategy = crate::orchestration::parse_compact_strategy(s)?;
     }
-    if let Some(v) = opts.get("hard_limit_tokens").and_then(|v| v.as_int()) {
-        cfg.hard_limit_tokens = Some(v as usize);
+    if let Some(v) = compact_usize_opt(opts, "hard_limit_tokens")? {
+        cfg.hard_limit_tokens = Some(v);
     }
     if let Some(VmValue::String(s)) = opts.get("hard_limit_strategy") {
         cfg.hard_limit_strategy = crate::orchestration::parse_compact_strategy(s)?;
@@ -727,8 +724,29 @@ fn build_compact_config(
     Ok(cfg)
 }
 
+fn compact_usize_opt(
+    opts: &BTreeMap<String, VmValue>,
+    key: &'static str,
+) -> Result<Option<usize>, VmError> {
+    let Some(value) = opts.get(key) else {
+        return Ok(None);
+    };
+    let Some(raw) = value.as_int() else {
+        return Err(err(format!(
+            "agent_session_compact: `{key}` must be an int"
+        )));
+    };
+    if raw < 0 {
+        return Err(err(format!("agent_session_compact: `{key}` must be >= 0")));
+    }
+    Ok(Some(raw as usize))
+}
+
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
+    use super::build_compact_config;
     use crate::value::VmValue;
 
     fn call_current_id_builtin() -> VmValue {
@@ -763,5 +781,20 @@ mod tests {
         let current = call_current_id_builtin();
         crate::agent_sessions::pop_current_session();
         assert!(matches!(current, VmValue::String(value) if value.as_ref() == "unit-test-session"));
+    }
+
+    #[test]
+    fn compact_config_rejects_negative_numeric_options() {
+        for key in [
+            "keep_last",
+            "token_threshold",
+            "tool_output_max_chars",
+            "hard_limit_tokens",
+        ] {
+            let mut opts = BTreeMap::new();
+            opts.insert(key.to_string(), VmValue::Int(-1));
+            let err = build_compact_config(&opts).expect_err("negative option must fail");
+            assert!(err.to_string().contains(key), "{err}");
+        }
     }
 }

--- a/crates/harn-vm/src/stdlib/concurrency.rs
+++ b/crates/harn-vm/src/stdlib/concurrency.rs
@@ -765,12 +765,11 @@ async fn mailbox_open_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     let vm = current_async_vm("mailbox_open")?;
     let shared_runtime = vm.shared_state_runtime.clone();
     let (scoped, options) = scoped_from_open_args(&vm, &args, "mailbox_open", "name")?;
-    let capacity = options
+    let capacity_arg = options
         .as_ref()
-        .and_then(|opts| opts.get("capacity").and_then(VmValue::as_int))
-        .or_else(|| args.get(1).and_then(VmValue::as_int))
-        .unwrap_or(256)
-        .max(1) as usize;
+        .and_then(|opts| opts.get("capacity"))
+        .or_else(|| args.get(1));
+    let capacity = optional_positive_usize_arg(capacity_arg, 256, "mailbox_open", "capacity")?;
     Ok(shared_runtime.open_mailbox(scoped, capacity))
 }
 
@@ -898,8 +897,7 @@ fn channel_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmErr
         .first()
         .map(|a| a.display())
         .unwrap_or_else(|| "default".to_string());
-    let capacity = args.get(1).and_then(|a| a.as_int()).unwrap_or(256) as usize;
-    let capacity = capacity.max(1);
+    let capacity = optional_positive_usize_arg(args.get(1), 256, "channel", "capacity")?;
     let (tx, rx) = tokio::sync::mpsc::channel(capacity);
     // The handle stays on the single-threaded VM LocalSet; VmValue itself is !Send.
     #[allow(clippy::arc_with_non_send_sync)]
@@ -1242,8 +1240,9 @@ fn circuit_breaker_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValu
         .first()
         .map(|a| a.display())
         .unwrap_or_else(|| "default".to_string());
-    let threshold = args.get(1).and_then(|a| a.as_int()).unwrap_or(5) as usize;
-    let reset_ms = args.get(2).and_then(|a| a.as_int()).unwrap_or(30000) as u64;
+    let threshold = optional_positive_usize_arg(args.get(1), 5, "circuit_breaker", "threshold")?;
+    let reset_ms =
+        optional_non_negative_u64_arg(args.get(2), 30000, "circuit_breaker", "reset_ms")?;
     CIRCUITS.with(|circuits| {
         circuits.borrow_mut().insert(
             name.clone(),
@@ -1256,6 +1255,40 @@ fn circuit_breaker_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValu
         );
     });
     Ok(VmValue::String(Rc::from(name)))
+}
+
+fn optional_positive_usize_arg(
+    value: Option<&VmValue>,
+    default: usize,
+    builtin: &str,
+    key: &str,
+) -> Result<usize, VmError> {
+    match value {
+        None | Some(VmValue::Nil) => Ok(default),
+        Some(VmValue::Int(n)) if *n >= 1 => Ok(*n as usize),
+        Some(VmValue::Int(_)) => Err(VmError::Runtime(format!("{builtin}: {key} must be >= 1"))),
+        Some(other) => Err(VmError::Runtime(format!(
+            "{builtin}: {key} must be an int, got {}",
+            other.type_name()
+        ))),
+    }
+}
+
+fn optional_non_negative_u64_arg(
+    value: Option<&VmValue>,
+    default: u64,
+    builtin: &str,
+    key: &str,
+) -> Result<u64, VmError> {
+    match value {
+        None | Some(VmValue::Nil) => Ok(default),
+        Some(VmValue::Int(n)) if *n >= 0 => Ok(*n as u64),
+        Some(VmValue::Int(_)) => Err(VmError::Runtime(format!("{builtin}: {key} must be >= 0"))),
+        Some(other) => Err(VmError::Runtime(format!(
+            "{builtin}: {key} must be an int, got {}",
+            other.type_name()
+        ))),
+    }
 }
 
 fn circuit_check_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
@@ -1375,6 +1408,14 @@ mod tests {
 
     fn s(v: &str) -> VmValue {
         VmValue::String(Rc::from(v))
+    }
+
+    #[test]
+    fn channel_rejects_invalid_capacity() {
+        let mut vm = vm();
+        let err = call(&mut vm, "channel", vec![s("bad_channel"), VmValue::Int(0)])
+            .expect_err("zero capacity must fail");
+        assert!(err.to_string().contains("capacity"));
     }
 
     #[test]
@@ -1525,6 +1566,26 @@ mod tests {
         let mut vm = vm();
         let state = call(&mut vm, "circuit_check", vec![s("nonexistent")]).unwrap();
         assert_eq!(state.display(), "closed");
+    }
+
+    #[test]
+    fn circuit_breaker_rejects_invalid_numeric_config() {
+        let mut vm = vm();
+        let threshold_err = call(
+            &mut vm,
+            "circuit_breaker",
+            vec![s("bad_threshold"), VmValue::Int(0)],
+        )
+        .expect_err("zero threshold must fail");
+        assert!(threshold_err.to_string().contains("threshold"));
+
+        let reset_err = call(
+            &mut vm,
+            "circuit_breaker",
+            vec![s("bad_reset"), VmValue::Int(1), VmValue::Int(-1)],
+        )
+        .expect_err("negative reset must fail");
+        assert!(reset_err.to_string().contains("reset_ms"));
     }
 
     #[test]

--- a/crates/harn-vm/src/stdlib/workflow/compact.rs
+++ b/crates/harn-vm/src/stdlib/workflow/compact.rs
@@ -46,14 +46,23 @@ pub(super) fn microcompact_builtin(
     let text = args.first().map(|a| a.display()).unwrap_or_default();
     let max_chars = args
         .get(1)
-        .and_then(|v| match v {
-            VmValue::Int(n) => Some(*n as usize),
-            _ => None,
-        })
+        .map(|v| non_negative_usize(v, "microcompact", "max_chars"))
+        .transpose()?
         .unwrap_or(20_000);
     Ok(VmValue::String(Rc::from(
         crate::orchestration::microcompact_tool_output(&text, max_chars),
     )))
+}
+
+fn non_negative_usize(value: &VmValue, builtin: &str, key: &str) -> Result<usize, VmError> {
+    match value {
+        VmValue::Int(n) if *n >= 0 => Ok(*n as usize),
+        VmValue::Int(_) => Err(VmError::Runtime(format!("{builtin}: `{key}` must be >= 0"))),
+        other => Err(VmError::Runtime(format!(
+            "{builtin}: `{key}` must be an int, got {}",
+            other.type_name()
+        ))),
+    }
 }
 
 pub(super) async fn transcript_auto_compact_builtin(
@@ -75,38 +84,42 @@ pub(super) async fn transcript_auto_compact_builtin(
     if let Some(v) = options
         .as_ref()
         .and_then(|o| o.get("keep_first"))
-        .and_then(|v| v.as_int())
+        .map(|v| non_negative_usize(v, "transcript_auto_compact", "keep_first"))
+        .transpose()?
     {
-        config.keep_first = v.max(0) as usize;
+        config.keep_first = v;
     }
     let threshold = options.as_ref().and_then(|o| {
         o.get("token_threshold")
-            .or_else(|| o.get("compact_threshold"))
-            .and_then(|v| v.as_int())
+            .map(|v| ("token_threshold", v))
+            .or_else(|| o.get("compact_threshold").map(|v| ("compact_threshold", v)))
     });
-    if let Some(v) = threshold {
-        config.token_threshold = v.max(0) as usize;
+    if let Some((key, v)) = threshold {
+        config.token_threshold = non_negative_usize(v, "transcript_auto_compact", key)?;
     }
     if let Some(v) = options
         .as_ref()
         .and_then(|o| o.get("tool_output_max_chars"))
-        .and_then(|v| v.as_int())
+        .map(|v| non_negative_usize(v, "transcript_auto_compact", "tool_output_max_chars"))
+        .transpose()?
     {
-        config.tool_output_max_chars = v.max(0) as usize;
+        config.tool_output_max_chars = v;
     }
     if let Some(v) = options
         .as_ref()
         .and_then(|o| o.get("keep_last"))
-        .and_then(|v| v.as_int())
+        .map(|v| non_negative_usize(v, "transcript_auto_compact", "keep_last"))
+        .transpose()?
     {
-        config.keep_last = v.max(0) as usize;
+        config.keep_last = v;
     }
     if let Some(v) = options
         .as_ref()
         .and_then(|o| o.get("hard_limit_tokens"))
-        .and_then(|v| v.as_int())
+        .map(|v| non_negative_usize(v, "transcript_auto_compact", "hard_limit_tokens"))
+        .transpose()?
     {
-        config.hard_limit_tokens = Some(v.max(0) as usize);
+        config.hard_limit_tokens = Some(v);
     }
     if let Some(strategy) = options
         .as_ref()
@@ -156,4 +169,20 @@ pub(super) async fn transcript_auto_compact_builtin(
             .map(crate::stdlib::json_to_vm_value)
             .collect(),
     )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn microcompact_rejects_negative_limit() {
+        let mut out = String::new();
+        let err = microcompact_builtin(
+            &[VmValue::String(Rc::from("hello")), VmValue::Int(-1)],
+            &mut out,
+        )
+        .expect_err("negative limits must fail");
+        assert!(err.to_string().contains("max_chars"));
+    }
 }

--- a/crates/harn-vm/src/stdlib/workflow/hooks.rs
+++ b/crates/harn-vm/src/stdlib/workflow/hooks.rs
@@ -21,10 +21,19 @@ pub(super) fn register_tool_hook_builtin(
         .map(|v| v.display())
         .unwrap_or_else(|| "*".to_string());
     let deny_reason = config.get("deny").map(|v| v.display());
-    let max_output = config.get("max_output").and_then(|v| match v {
-        VmValue::Int(n) => Some(*n as usize),
-        _ => None,
-    });
+    let max_output = config
+        .get("max_output")
+        .map(|v| match v {
+            VmValue::Int(n) if *n >= 0 => Ok(*n as usize),
+            VmValue::Int(_) => Err(VmError::Runtime(
+                "register_tool_hook: max_output must be >= 0".to_string(),
+            )),
+            other => Err(VmError::Runtime(format!(
+                "register_tool_hook: max_output must be an int, got {}",
+                other.type_name()
+            ))),
+        })
+        .transpose()?;
     let pre_handler = match config.get("pre") {
         Some(VmValue::Closure(closure)) => Some(closure.clone()),
         Some(VmValue::Nil) | None => None,
@@ -493,4 +502,32 @@ pub(super) async fn drain_file_edits_builtin(args: Vec<VmValue>) -> Result<VmVal
         paths.push(VmValue::String(Rc::from(edit.path)));
     }
     Ok(VmValue::List(Rc::new(paths)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dict(entries: &[(&str, VmValue)]) -> VmValue {
+        VmValue::Dict(Rc::new(
+            entries
+                .iter()
+                .map(|(key, value)| ((*key).to_string(), value.clone()))
+                .collect(),
+        ))
+    }
+
+    #[test]
+    fn register_tool_hook_rejects_negative_max_output() {
+        let mut out = String::new();
+        let err = register_tool_hook_builtin(
+            &[dict(&[
+                ("pattern", VmValue::String(Rc::from("*"))),
+                ("max_output", VmValue::Int(-1)),
+            ])],
+            &mut out,
+        )
+        .expect_err("negative max_output must fail");
+        assert!(err.to_string().contains("max_output"));
+    }
 }


### PR DESCRIPTION
## Summary
- Reject invalid numeric bounds in VM workflow compacting, hook output limiting, agent-session compaction, channels, mailboxes, and circuit breakers instead of silently clamping, defaulting, or wrapping.
- Align code-index host builtins with their schemas for positive/non-negative IDs, limits, offsets, sequence numbers, hashes, and TTLs.
- Consolidate code-index numeric parsing helpers and add regression coverage for schema-invalid numeric inputs.

## Bugs fixed
- Negative microcompact max_chars no longer wraps to a huge usize.
- transcript_auto_compact numeric options now reject negative and non-int values.
- register_tool_hook max_output now rejects negative and non-int values.
- agent_session_compact token/limit options no longer wrap negative values.
- circuit_breaker rejects threshold 0 and negative reset_ms.
- channel and mailbox_open reject invalid capacities instead of coercing/wrapping.
- code-index file IDs, agent IDs, max_results, max_files, seq, limit, size, hash, and ttl_ms now enforce schema bounds.
- file_meta no longer casts invalid file_id values to unsigned IDs.

## Verification
- cargo fmt --all
- cargo test -p harn-vm --lib rejects
- cargo test -p harn-hostlib --test code_index_live_state code_index_rejects_schema_invalid_numeric_bounds
- CARGO_TARGET_DIR=/tmp/harn-e4ce-target cargo check --workspace --all-targets
- make lint-test-patterns
- pre-commit hook: cargo clippy --workspace --all-targets -- -D warnings
- pre-push targeted local checks