### PR TITLE
ci: drop sccache on Windows job (~25% faster)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,13 +191,21 @@ jobs:
     runs-on: windows-latest
     needs: changes
     if: needs.changes.outputs.windows == 'true' || github.event_name == 'push'
+    # Drop sccache on the Windows job. PR #2114 documented 0% cache-hit
+    # rate on the harn-vm Windows compile plus periodic `os error 10054`
+    # failures where the GHA backend dropped the rmeta upload mid-rustc.
+    # build-release-binaries.yml and release-smoke.yml already skip
+    # sccache on Windows. Swatinem/rust-cache stays in place.
+    #
+    # Bench on PRs #2127 (E2 line-tables-only), #2128 (E1 this change),
+    # #2129 (E3 both) — compile+test step, warm-cache rerun:
+    #     baseline 8:29 → this PR 6:21 (~25% saved).
+    # Pairing this with `CARGO_PROFILE_DEV_DEBUG=line-tables-only` (E3)
+    # was tested and actually regressed Windows compile time vs E1 alone,
+    # so the dev-debug override is not applied here.
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-      - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
-      - name: Configure Cargo to use sccache
-        shell: bash
-        run: echo "RUSTC_WRAPPER=${SCCACHE_PATH}" >> "$GITHUB_ENV"
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         continue-on-error: true
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,16 @@ condensed series summaries instead of full per-patch history.
   `cargo check -p A -p B ... --tests` once instead of looping
   N invocations, so cargo only resolves the dep graph and re-evaluates
   fingerprints once.
+- **CI: speed up the Windows Rust gate (compile+test ~8:29 → ~6:21 warm).**
+  Drop the `mozilla-actions/sccache-action` wrapper on the `windows-latest`
+  job. PR #2114 already documented a 0% hit rate on the harn-vm Windows
+  compile plus intermittent `os error 10054` failures from the GHA backend
+  dropping long rustc uploads; `build-release-binaries.yml` and
+  `release-smoke.yml` already skip sccache on Windows. Swatinem rust-cache
+  continues to warm `target/` across runs. Benchmarked on bench PRs
+  #2127/#2128/#2129: Windows compile+test step drops from ~8:29 warm to
+  ~6:21 warm. A paired `CARGO_PROFILE_DEV_DEBUG=line-tables-only` override
+  was tested and actually regressed compile time, so it is not applied.
 
 ## v0.8.31
 


### PR DESCRIPTION
## Summary

Drop the `mozilla-actions/sccache-action` wrapper on the `windows-latest` CI job. PR #2114 documented a 0% Windows hit rate on the harn-vm compile plus intermittent `os error 10054` failures from the GHA backend dropping long rustc uploads. `build-release-binaries.yml` and `release-smoke.yml` already skip sccache on Windows — this completes the trifecta for the per-PR gate. Swatinem rust-cache stays in place.

## Empirical bench

Three candidates were benched against current main on the Windows job's compile+test step:

| Candidate | Cold cache | Warm cache |
|---|---|---|
| Baseline (current main, run 26236018467) | n/a | 8:29 |
| **E1: drop sccache only (this PR)** | **12:43** | **6:21** |
| E2: `CARGO_PROFILE_DEV_DEBUG=line-tables-only` only | 16:22 | 13:12 |
| E3: both E1 and E2 | 14:09 | 9:47 |

Wall-clock effect:

- Baseline warm: 10:09 (run 26236018467)
- E1 warm: 7:27 (run 26262690304, attempt 2)

Net: ~2:42 saved on every Windows-touching PR's critical path. After #2123 split the Linux Rust gate into parallel ~3-min jobs, Windows became the bottleneck — this brings it back in line.

## What didn't work

I initially expected `CARGO_PROFILE_(DEV|TEST)_DEBUG=line-tables-only` to help (Windows PDB generation is known-slow). The bench shows the opposite: the line-tables-only override regresses compile time in both with-sccache (E2) and without-sccache (E3) configurations vs the same setup with full debug. Not applied here.

## Cost on this merge

Minimal — the `workspace-windows` rust-cache key is unchanged, sccache wasn't producing hits anyway, and the build itself doesn't change. The first post-merge run should see a normal warm cache.

## Test plan

- [x] Bench runs E1/E2/E3 all passed Windows filtered nextest slice + harn smoke.
- [ ] This PR's own CI passes.

Bench branches closed: #2127 (E2), #2128 (E1), #2129 (E3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)