### PR TITLE
Tighten callback validation and deflake tests

### DIFF
--- a/crates/harn-cli/src/commands/connect/callback.rs
+++ b/crates/harn-cli/src/commands/connect/callback.rs
@@ -6,9 +6,14 @@ use url::Url;
 
 use super::OAUTH_CALLBACK_TIMEOUT;
 
+const CALLBACK_ACCEPT_POLL_INTERVAL: Duration = Duration::from_millis(50);
+
 pub(super) fn bind_loopback_listener(redirect_uri: &str) -> Result<(TcpListener, String), String> {
     let mut parsed =
         Url::parse(redirect_uri).map_err(|error| format!("Invalid redirect URI: {error}"))?;
+    if parsed.scheme() != "http" {
+        return Err("Redirect URI must use the http scheme for the loopback listener".to_string());
+    }
     let host = parsed
         .host_str()
         .ok_or_else(|| "Redirect URI must include a host".to_string())?;
@@ -16,7 +21,7 @@ pub(super) fn bind_loopback_listener(redirect_uri: &str) -> Result<(TcpListener,
         return Err("Redirect URI must bind to 127.0.0.1 or localhost".to_string());
     }
     let port = parsed
-        .port_or_known_default()
+        .port()
         .ok_or_else(|| "Redirect URI must include a port".to_string())?;
     let listener = TcpListener::bind((host, port))
         .map_err(|error| format!("Failed to bind redirect URI {redirect_uri}: {error}"))?;
@@ -105,7 +110,7 @@ pub(super) fn wait_for_callback_query(
                 if Instant::now() >= deadline {
                     return Err("OAuth callback timed out after 5 minutes".to_string());
                 }
-                std::thread::sleep(Duration::from_millis(50));
+                std::thread::sleep(CALLBACK_ACCEPT_POLL_INTERVAL);
             }
             Err(error) => return Err(format!("Failed to accept OAuth callback: {error}")),
         }
@@ -122,10 +127,22 @@ pub(super) fn parse_callback_request(
     let request_line = lines
         .next()
         .ok_or_else(|| "OAuth callback request was empty".to_string())?;
-    let path_and_query = request_line
-        .split_whitespace()
-        .nth(1)
+    let mut request_parts = request_line.split_whitespace();
+    let method = request_parts
+        .next()
         .ok_or_else(|| "OAuth callback request line was invalid".to_string())?;
+    if method != "GET" {
+        return Err("OAuth callback request must use GET".to_string());
+    }
+    let path_and_query = request_parts
+        .next()
+        .ok_or_else(|| "OAuth callback request line was invalid".to_string())?;
+    let version = request_parts
+        .next()
+        .ok_or_else(|| "OAuth callback request line was invalid".to_string())?;
+    if !version.starts_with("HTTP/") || request_parts.next().is_some() {
+        return Err("OAuth callback request line was invalid".to_string());
+    }
     let origin = lines.find_map(|line| {
         let (name, value) = line.split_once(':')?;
         name.eq_ignore_ascii_case("origin")
@@ -167,7 +184,7 @@ pub(super) fn loopback_origin(url: &Url) -> Result<String, String> {
         .host_str()
         .ok_or_else(|| "Redirect URI must include a host".to_string())?;
     let port = url
-        .port_or_known_default()
+        .port()
         .ok_or_else(|| "Redirect URI must include a port".to_string())?;
     Ok(format!("{}://{}:{}", url.scheme(), host, port))
 }

--- a/crates/harn-cli/src/commands/connect/tests.rs
+++ b/crates/harn-cli/src/commands/connect/tests.rs
@@ -264,6 +264,20 @@ fn loopback_listener_rewrites_zero_port() {
 }
 
 #[test]
+fn loopback_listener_rejects_non_http_redirect_uri() {
+    let error = bind_loopback_listener("https://127.0.0.1:0/oauth/callback").unwrap_err();
+
+    assert!(error.contains("http scheme"));
+}
+
+#[test]
+fn loopback_listener_requires_explicit_port() {
+    let error = bind_loopback_listener("http://127.0.0.1/oauth/callback").unwrap_err();
+
+    assert!(error.contains("include a port"));
+}
+
+#[test]
 fn callback_request_rejects_wrong_origin() {
     let request =
         "GET /oauth/callback?code=abc&state=xyz HTTP/1.1\r\nOrigin: http://evil.example\r\n\r\n";
@@ -275,6 +289,36 @@ fn callback_request_rejects_wrong_origin() {
     )
     .unwrap_err();
     assert!(error.contains("Origin"));
+}
+
+#[test]
+fn callback_request_requires_get_method() {
+    let request =
+        "POST /oauth/callback?code=abc&state=xyz HTTP/1.1\r\nOrigin: http://127.0.0.1:49152\r\n\r\n";
+    let error = parse_callback_request(
+        request,
+        "/oauth/callback",
+        Some("xyz"),
+        "http://127.0.0.1:49152",
+    )
+    .unwrap_err();
+
+    assert!(error.contains("must use GET"));
+}
+
+#[test]
+fn callback_request_rejects_malformed_request_line() {
+    let request =
+        "GET /oauth/callback?code=abc&state=xyz HTTP/1.1 extra\r\nOrigin: http://127.0.0.1:49152\r\n\r\n";
+    let error = parse_callback_request(
+        request,
+        "/oauth/callback",
+        Some("xyz"),
+        "http://127.0.0.1:49152",
+    )
+    .unwrap_err();
+
+    assert!(error.contains("request line"));
 }
 
 #[test]

--- a/crates/harn-cli/src/test_runner.rs
+++ b/crates/harn-cli/src/test_runner.rs
@@ -339,30 +339,21 @@ fn discover_test_files(dir: &Path) -> Vec<PathBuf> {
 mod tests {
     use super::{discover_test_files, run_tests};
     use std::fs;
-    use std::path::{Path, PathBuf};
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use std::path::Path;
 
     struct TempTestDir {
-        path: PathBuf,
+        inner: tempfile::TempDir,
     }
 
     impl TempTestDir {
         fn new() -> Self {
-            let unique = format!(
-                "harn-test-runner-{}-{}",
-                std::process::id(),
-                SystemTime::now()
-                    .duration_since(UNIX_EPOCH)
-                    .unwrap()
-                    .as_nanos()
-            );
-            let path = std::env::temp_dir().join(unique);
-            fs::create_dir_all(&path).unwrap();
-            Self { path }
+            Self {
+                inner: tempfile::tempdir().unwrap(),
+            }
         }
 
         fn write(&self, relative: &str, contents: &str) {
-            let path = self.path.join(relative);
+            let path = self.path().join(relative);
             if let Some(parent) = path.parent() {
                 fs::create_dir_all(parent).unwrap();
             }
@@ -370,13 +361,7 @@ mod tests {
         }
 
         fn path(&self) -> &Path {
-            &self.path
-        }
-    }
-
-    impl Drop for TempTestDir {
-        fn drop(&mut self) {
-            let _ = fs::remove_dir_all(&self.path);
+            self.inner.path()
         }
     }
 

--- a/crates/harn-hostlib/tests/scanner_e2e.rs
+++ b/crates/harn-hostlib/tests/scanner_e2e.rs
@@ -14,7 +14,6 @@
 
 use std::fs;
 use std::path::Path;
-use std::time::SystemTime;
 
 use harn_hostlib::scanner::{
     scan_incremental, scan_project, scan_project_with_git, FileRecord, GitCapabilities,
@@ -123,12 +122,10 @@ edition = "2024"
     );
 }
 
-fn touch_after(path: &Path, base: SystemTime) {
-    // Force a modification time strictly after `base` so the incremental
-    // scanner's mtime check picks the file up regardless of filesystem
-    // resolution.
-    let new_mtime = base + std::time::Duration::from_secs(60);
-    let _ = filetime::set_file_mtime(path, filetime::FileTime::from_system_time(new_mtime));
+fn touch_after_snapshot(path: &Path, snapshot_max_mtime_ms: i64) {
+    let base_secs = snapshot_max_mtime_ms.max(0).div_euclid(1_000);
+    let new_mtime = filetime::FileTime::from_unix_time(base_secs.saturating_add(60), 0);
+    filetime::set_file_mtime(path, new_mtime).unwrap();
 }
 
 #[derive(Default)]
@@ -296,7 +293,12 @@ fn scan_incremental_picks_up_added_and_removed_files() {
 
     let initial = scan_project(tmp.path(), ScanProjectOptions::default());
     let token = initial.snapshot_token.clone();
-    let baseline = SystemTime::now();
+    let snapshot_max_mtime_ms = initial
+        .files
+        .iter()
+        .map(|file| file.last_modified_unix_ms)
+        .max()
+        .unwrap_or(0);
 
     // Add a new source file and remove an existing one.
     write(
@@ -305,7 +307,10 @@ fn scan_incremental_picks_up_added_and_removed_files() {
         "pub struct OrdersService;\n",
     );
     fs::remove_file(tmp.path().join("src/lib/helpers.ts")).unwrap();
-    touch_after(&tmp.path().join("src/routes/orders.rs"), baseline);
+    touch_after_snapshot(
+        &tmp.path().join("src/routes/orders.rs"),
+        snapshot_max_mtime_ms,
+    );
 
     let scan = scan_incremental(&token, None, ScanProjectOptions::default());
     assert!(scan.delta.added.iter().any(|p| p == "src/routes/orders.rs"));

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -1139,13 +1139,14 @@ harn connect --refresh notion
 harn connect --revoke slack
 ```
 
-OAuth provider commands use a loopback callback bound to `127.0.0.1`. The
-default redirect URI uses port `0`, so Harn selects a random free localhost
-port and sends that exact URI in the authorization request. PKCE S256 is always
-enabled. Generic OAuth discovers protected-resource and authorization-server
-metadata when explicit endpoints are not supplied, attempts dynamic client
-registration when available, and sends the `resource` parameter to both the
-authorization and token endpoints.
+OAuth provider commands use a plaintext HTTP loopback callback bound to
+`127.0.0.1` or `localhost`. The default redirect URI uses port `0`, so Harn
+selects a random free localhost port and sends that exact URI in the
+authorization request; custom redirect URIs must also include an explicit port.
+PKCE S256 is always enabled. Generic OAuth discovers protected-resource and
+authorization-server metadata when explicit endpoints are not supplied, attempts
+dynamic client registration when available, and sends the `resource` parameter
+to both the authorization and token endpoints.
 
 `harn connect <provider>` is available for providers registered in the nearest
 `harn.toml` `[[providers]]` table with `oauth = { ... }` metadata. CLI flags

--- a/docs/src/orchestrator/oauth.md
+++ b/docs/src/orchestrator/oauth.md
@@ -110,11 +110,13 @@ harn connect github \
 
 ## Callback server
 
-OAuth and GitHub App setup callbacks bind only to `127.0.0.1` or `localhost`.
-The default redirect URI uses port `0`, so Harn chooses a random free local port
-and sends that concrete URI in the authorization request. Callback listeners are
-single-use and time out after five minutes. If a callback request includes an
-`Origin` header, Harn requires it to match the redirect origin.
+OAuth and GitHub App setup callbacks use plaintext HTTP and bind only to
+`127.0.0.1` or `localhost`. The default redirect URI uses port `0`, so Harn
+chooses a random free local port and sends that concrete URI in the
+authorization request; custom redirect URIs must also include an explicit port.
+Callback listeners are single-use and time out after five minutes. If a callback
+request includes an `Origin` header, Harn requires it to match the redirect
+origin.
 
 ## OAuth guarantees
 


### PR DESCRIPTION
## Summary

- tighten local OAuth/GitHub callback handling to require plaintext HTTP loopback redirect URIs with explicit ports
- reject non-GET and malformed callback request lines before accepting authorization results
- replace wall-clock-derived test temp paths and scanner mtime baselines with deterministic fixtures
- document the callback URI contract in the CLI and orchestrator OAuth docs

## Validation

- `CARGO_TARGET_DIR=/tmp/harn-606b-target cargo test -p harn-cli commands::connect::tests -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-606b-target cargo test -p harn-cli test_runner::tests -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-606b-target cargo test -p harn-hostlib scan_incremental_picks_up_added_and_removed_files -- --nocapture`
- `make lint-test-patterns`
- `npx markdownlint-cli2 docs/src/cli-reference.md docs/src/orchestrator/oauth.md`
- `cargo fmt --check`
- pre-commit hook: changed-package clippy + full markdown lint
- pre-push hook: targeted local checks + full markdown lint
