### PR TITLE
Improve harn test progress and restore agent contract tests

### DIFF
--- a/crates/harn-cli/src/commands/test.rs
+++ b/crates/harn-cli/src/commands/test.rs
@@ -1514,7 +1514,77 @@ pub(crate) async fn run_conformance_tests(
     }
 }
 
-fn print_test_results(summary: &test_runner::TestSummary) {
+#[derive(Debug, Clone, Copy)]
+struct UserTestOutputOptions {
+    timing: bool,
+    progress: bool,
+}
+
+fn user_test_progress(verbose: bool) -> test_runner::TestRunProgress {
+    std::sync::Arc::new(move |event| match event {
+        test_runner::TestRunEvent::SuiteDiscovered {
+            total_tests,
+            total_files,
+            parallel,
+        } => {
+            if total_tests > 0 {
+                let mode = if parallel { "parallel" } else { "sequential" };
+                println!(
+                    "Running {} test{} from {} file{} ({mode})...\n",
+                    total_tests,
+                    if total_tests == 1 { "" } else { "s" },
+                    total_files,
+                    if total_files == 1 { "" } else { "s" },
+                );
+            }
+        }
+        test_runner::TestRunEvent::LargeSequentialSuite {
+            total_tests,
+            total_files,
+        } => {
+            println!(
+                "\x1b[33mwarning\x1b[0m: large suite discovered ({total_tests} tests across {total_files} files); running sequentially. Use `--parallel` for file-level concurrency.\n"
+            );
+        }
+        test_runner::TestRunEvent::FileStarted {
+            file,
+            file_index,
+            total_files,
+            test_count,
+        } => {
+            println!("  RUN   file {file_index}/{total_files} {file} ({test_count} tests)");
+        }
+        test_runner::TestRunEvent::TestStarted {
+            name,
+            file,
+            test_index,
+            total_tests_in_file,
+        } => {
+            if verbose {
+                println!("    RUN   {name} [{file}] ({test_index}/{total_tests_in_file})");
+            }
+        }
+        test_runner::TestRunEvent::TestFinished(result) => {
+            if result.passed {
+                println!(
+                    "  \x1b[32mPASS\x1b[0m  {} [{}] ({} ms)",
+                    result.name, result.file, result.duration_ms
+                );
+            } else {
+                println!("  \x1b[31mFAIL\x1b[0m  {} [{}]", result.name, result.file);
+                if verbose {
+                    if let Some(err) = &result.error {
+                        for line in err.lines() {
+                            println!("        {line}");
+                        }
+                    }
+                }
+            }
+        }
+    })
+}
+
+fn print_test_results(summary: &test_runner::TestSummary, options: UserTestOutputOptions) {
     let file_count = summary
         .results
         .iter()
@@ -1522,7 +1592,7 @@ fn print_test_results(summary: &test_runner::TestSummary) {
         .collect::<std::collections::HashSet<_>>()
         .len();
 
-    if summary.total > 0 {
+    if !options.progress && summary.total > 0 {
         println!(
             "Running {} test{} from {} file{}...\n",
             summary.total,
@@ -1532,17 +1602,19 @@ fn print_test_results(summary: &test_runner::TestSummary) {
         );
     }
 
-    for result in &summary.results {
-        if result.passed {
-            println!(
-                "  \x1b[32mPASS\x1b[0m  {} [{}] ({} ms)",
-                result.name, result.file, result.duration_ms
-            );
-        } else {
-            println!("  \x1b[31mFAIL\x1b[0m  {} [{}]", result.name, result.file);
-            if let Some(err) = &result.error {
-                for line in err.lines() {
-                    println!("        {line}");
+    if !options.progress {
+        for result in &summary.results {
+            if result.passed {
+                println!(
+                    "  \x1b[32mPASS\x1b[0m  {} [{}] ({} ms)",
+                    result.name, result.file, result.duration_ms
+                );
+            } else {
+                println!("  \x1b[31mFAIL\x1b[0m  {} [{}]", result.name, result.file);
+                if let Some(err) = &result.error {
+                    for line in err.lines() {
+                        println!("        {line}");
+                    }
                 }
             }
         }
@@ -1562,6 +1634,106 @@ fn print_test_results(summary: &test_runner::TestSummary) {
             summary.passed, summary.total, summary.duration_ms
         );
     }
+
+    if options.timing {
+        print_user_test_timing(summary);
+    }
+
+    if options.progress && summary.failed > 0 {
+        println!();
+        println!("Failures:");
+        for result in summary.results.iter().filter(|result| !result.passed) {
+            if let Some(err) = &result.error {
+                println!("  {} [{}]", result.name, result.file);
+                for line in err.lines() {
+                    println!("        {line}");
+                }
+            }
+        }
+    }
+}
+
+fn print_user_test_timing(summary: &test_runner::TestSummary) {
+    if summary.total == 0 {
+        return;
+    }
+
+    println!();
+    println!("Total time: {} ms", summary.duration_ms);
+
+    let mut durations = summary
+        .results
+        .iter()
+        .map(|result| result.duration_ms)
+        .collect::<Vec<_>>();
+    durations.sort();
+
+    if !durations.is_empty() {
+        let n = durations.len();
+        let p50 = durations[n * 50 / 100];
+        let p95 = durations[n * 95 / 100];
+        let p99 = durations[(n * 99 / 100).min(n - 1)];
+        let avg = durations.iter().sum::<u64>() / n as u64;
+        println!("Per-test: avg={avg} ms  p50={p50} ms  p95={p95} ms  p99={p99} ms");
+    }
+
+    let mut by_test = summary.results.iter().collect::<Vec<_>>();
+    by_test.sort_by_key(|result| std::cmp::Reverse(result.duration_ms));
+    let top_test_count = by_test.len().min(10);
+    if top_test_count > 0 {
+        println!();
+        println!("Slowest {top_test_count} tests:");
+        for result in &by_test[..top_test_count] {
+            println!(
+                "  {:>6} ms  {} [{}]",
+                result.duration_ms, result.name, result.file
+            );
+        }
+    }
+
+    let mut file_totals = BTreeMap::<&str, u64>::new();
+    for result in &summary.results {
+        *file_totals.entry(result.file.as_str()).or_default() += result.duration_ms;
+    }
+    let mut by_file = file_totals.into_iter().collect::<Vec<_>>();
+    by_file.sort_by_key(|(_, duration_ms)| std::cmp::Reverse(*duration_ms));
+    let top_file_count = by_file.len().min(10);
+    if top_file_count > 0 {
+        println!();
+        println!("Slowest {top_file_count} files:");
+        for (file, duration_ms) in &by_file[..top_file_count] {
+            println!("  {duration_ms:>6} ms  {file}");
+        }
+    }
+}
+
+async fn run_user_tests_once(
+    path: &Path,
+    filter: Option<&str>,
+    timeout_ms: u64,
+    parallel: bool,
+    verbose: bool,
+    timing: bool,
+    cli_skill_dirs: &[PathBuf],
+) -> test_runner::TestSummary {
+    let progress = user_test_progress(verbose);
+    let summary = test_runner::run_tests_with_progress(
+        path,
+        filter,
+        timeout_ms,
+        parallel,
+        cli_skill_dirs,
+        Some(progress),
+    )
+    .await;
+    print_test_results(
+        &summary,
+        UserTestOutputOptions {
+            timing,
+            progress: true,
+        },
+    );
+    summary
 }
 
 pub(crate) async fn run_user_tests(
@@ -1569,6 +1741,8 @@ pub(crate) async fn run_user_tests(
     filter: Option<&str>,
     timeout_ms: u64,
     parallel: bool,
+    verbose: bool,
+    timing: bool,
     cli_skill_dirs: &[PathBuf],
 ) {
     let path = PathBuf::from(path_str);
@@ -1576,8 +1750,16 @@ pub(crate) async fn run_user_tests(
         eprintln!("Path not found: {path_str}");
         process::exit(1);
     }
-    let summary = test_runner::run_tests(&path, filter, timeout_ms, parallel, cli_skill_dirs).await;
-    print_test_results(&summary);
+    let summary = run_user_tests_once(
+        &path,
+        filter,
+        timeout_ms,
+        parallel,
+        verbose,
+        timing,
+        cli_skill_dirs,
+    )
+    .await;
     if summary.failed > 0 {
         process::exit(1);
     }
@@ -1929,6 +2111,8 @@ pub(crate) async fn run_watch_tests(
     filter: Option<&str>,
     timeout_ms: u64,
     parallel: bool,
+    verbose: bool,
+    timing: bool,
     cli_skill_dirs: &[PathBuf],
 ) {
     use notify::{Config, RecommendedWatcher, RecursiveMode, Watcher};
@@ -1943,8 +2127,16 @@ pub(crate) async fn run_watch_tests(
 
     println!("Watching {path_str} for changes... (Ctrl+C to stop)\n");
 
-    let summary = test_runner::run_tests(&path, filter, timeout_ms, parallel, cli_skill_dirs).await;
-    print_test_results(&summary);
+    run_user_tests_once(
+        &path,
+        filter,
+        timeout_ms,
+        parallel,
+        verbose,
+        timing,
+        cli_skill_dirs,
+    )
+    .await;
 
     let (tx, rx) = mpsc::channel();
     let mut watcher = RecommendedWatcher::new(tx, Config::default()).unwrap_or_else(|e| {
@@ -1973,10 +2165,16 @@ pub(crate) async fn run_watch_tests(
                 while rx.recv_timeout(Duration::from_millis(100)).is_ok() {}
 
                 println!("\n\x1b[2m--- file changed, re-running tests ---\x1b[0m\n");
-                let summary =
-                    test_runner::run_tests(&path, filter, timeout_ms, parallel, cli_skill_dirs)
-                        .await;
-                print_test_results(&summary);
+                run_user_tests_once(
+                    &path,
+                    filter,
+                    timeout_ms,
+                    parallel,
+                    verbose,
+                    timing,
+                    cli_skill_dirs,
+                )
+                .await;
             }
             Ok(Err(e)) => {
                 eprintln!("Watch error: {e}");

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -19,8 +19,8 @@ pub use harn_skills::{get_embedded_skill, list_embedded_skills, EmbeddedSkill, S
 
 use clap::{error::ErrorKind, CommandFactory, Parser as ClapParser};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
-use std::{env, fs, process, thread};
+use std::sync::{Arc, Once};
+use std::{env, fs, panic, process, thread};
 
 use cli::{
     Cli, Command, CompletionShell, EvalCommand, MergeCaptainCommand, MergeCaptainMockCommand,
@@ -34,6 +34,8 @@ use harn_parser::{DiagnosticSeverity, Parser, TypeChecker};
 
 pub const CLI_RUNTIME_STACK_SIZE: usize = 16 * 1024 * 1024;
 
+static BROKEN_PIPE_PANIC_HOOK: Once = Once::new();
+
 #[cfg(feature = "hostlib")]
 pub(crate) fn install_default_hostlib(vm: &mut harn_vm::Vm) {
     let _ = harn_hostlib::install_default(vm);
@@ -45,6 +47,8 @@ pub(crate) fn install_default_hostlib(_vm: &mut harn_vm::Vm) {}
 /// Entry point used by `src/main.rs`. Hosts the CLI runtime thread and
 /// drives the async dispatcher in `async_main`.
 pub fn run() {
+    install_broken_pipe_panic_hook();
+
     let handle = thread::Builder::new()
         .name("harn-cli".to_string())
         .stack_size(CLI_RUNTIME_STACK_SIZE)
@@ -64,8 +68,40 @@ pub fn run() {
         });
 
     if let Err(payload) = handle.join() {
+        if is_broken_pipe_panic_payload(payload.as_ref()) {
+            process::exit(0);
+        }
         std::panic::resume_unwind(payload);
     }
+}
+
+fn install_broken_pipe_panic_hook() {
+    BROKEN_PIPE_PANIC_HOOK.call_once(|| {
+        let previous = panic::take_hook();
+        panic::set_hook(Box::new(move |info| {
+            if is_broken_pipe_panic_payload(info.payload()) {
+                return;
+            }
+            previous(info);
+        }));
+    });
+}
+
+fn is_broken_pipe_panic_payload(payload: &(dyn std::any::Any + Send)) -> bool {
+    let message = if let Some(message) = payload.downcast_ref::<String>() {
+        message.as_str()
+    } else if let Some(message) = payload.downcast_ref::<&str>() {
+        message
+    } else {
+        return false;
+    };
+
+    let print_failure = message.contains("failed printing to stdout")
+        || message.contains("failed printing to stderr");
+    let broken_pipe = message.contains("Broken pipe")
+        || message.contains("os error 32")
+        || message.contains("EPIPE");
+    print_failure && broken_pipe
 }
 
 async fn async_main() {
@@ -785,6 +821,8 @@ async fn async_main() {
                             args.filter.as_deref(),
                             args.timeout,
                             args.parallel,
+                            args.verbose,
+                            args.timing,
                             &cli_skill_dirs,
                         )
                         .await;
@@ -794,6 +832,8 @@ async fn async_main() {
                             args.filter.as_deref(),
                             args.timeout,
                             args.parallel,
+                            args.verbose,
+                            args.timing,
                             &cli_skill_dirs,
                         )
                         .await;
@@ -815,6 +855,8 @@ async fn async_main() {
                             args.filter.as_deref(),
                             args.timeout,
                             args.parallel,
+                            args.verbose,
+                            args.timing,
                             &cli_skill_dirs,
                         )
                         .await;
@@ -824,6 +866,8 @@ async fn async_main() {
                             args.filter.as_deref(),
                             args.timeout,
                             args.parallel,
+                            args.verbose,
+                            args.timing,
                             &cli_skill_dirs,
                         )
                         .await;
@@ -2901,7 +2945,10 @@ fn connector_secret_namespace(base_dir: &Path) -> String {
 
 #[cfg(test)]
 mod main_tests {
-    use super::{normalize_serve_args, should_install_default_connector_clients};
+    use super::{
+        is_broken_pipe_panic_payload, normalize_serve_args,
+        should_install_default_connector_clients,
+    };
     use std::path::Path;
 
     #[test]
@@ -2964,5 +3011,17 @@ mod main_tests {
             "__io_println(1)",
             Some(Path::new("examples/demo.harn"))
         ));
+    }
+
+    #[test]
+    fn broken_pipe_print_panic_is_classified_as_clean_consumer_close() {
+        let payload = String::from("failed printing to stdout: Broken pipe (os error 32)");
+        assert!(is_broken_pipe_panic_payload(&payload));
+    }
+
+    #[test]
+    fn unrelated_panic_is_not_classified_as_broken_pipe() {
+        let payload = String::from("assertion failed: expected true");
+        assert!(!is_broken_pipe_panic_payload(&payload));
     }
 }

--- a/crates/harn-cli/src/test_runner.rs
+++ b/crates/harn-cli/src/test_runner.rs
@@ -1,11 +1,13 @@
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::Instant;
 
 use harn_lexer::Lexer;
-use harn_parser::{Node, Parser};
+use harn_parser::{Node, Parser, SNode};
 
 use crate::env_guard::ScopedEnvVar;
 
+#[derive(Clone, Debug)]
 pub struct TestResult {
     pub name: String,
     pub file: String,
@@ -14,6 +16,7 @@ pub struct TestResult {
     pub duration_ms: u64,
 }
 
+#[derive(Clone, Debug)]
 pub struct TestSummary {
     pub results: Vec<TestResult>,
     pub passed: usize,
@@ -21,6 +24,37 @@ pub struct TestSummary {
     pub total: usize,
     pub duration_ms: u64,
 }
+
+#[derive(Clone, Debug)]
+pub enum TestRunEvent {
+    SuiteDiscovered {
+        total_tests: usize,
+        total_files: usize,
+        parallel: bool,
+    },
+    LargeSequentialSuite {
+        total_tests: usize,
+        total_files: usize,
+    },
+    FileStarted {
+        file: String,
+        file_index: usize,
+        total_files: usize,
+        test_count: usize,
+    },
+    TestStarted {
+        name: String,
+        file: String,
+        test_index: usize,
+        total_tests_in_file: usize,
+    },
+    TestFinished(TestResult),
+}
+
+pub type TestRunProgress = Arc<dyn Fn(TestRunEvent) + Send + Sync>;
+
+const LARGE_SEQUENTIAL_TEST_THRESHOLD: usize = 50;
+const LARGE_SEQUENTIAL_FILE_THRESHOLD: usize = 10;
 
 fn canonicalize_existing_path(path: &Path) -> PathBuf {
     path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
@@ -30,14 +64,19 @@ fn test_execution_cwd() -> PathBuf {
     std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
 }
 
-/// Run all test_* pipelines in a single source file using the VM.
-pub async fn run_test_file(
-    path: &Path,
-    filter: Option<&str>,
-    timeout_ms: u64,
-    execution_cwd: Option<&Path>,
-    cli_skill_dirs: &[PathBuf],
-) -> Result<Vec<TestResult>, String> {
+struct ParsedTestFile {
+    source: String,
+    program: Vec<SNode>,
+    test_names: Vec<String>,
+}
+
+#[derive(Clone)]
+struct TestFilePlan {
+    file: PathBuf,
+    test_count: usize,
+}
+
+fn parse_test_file(path: &Path, filter: Option<&str>) -> Result<ParsedTestFile, String> {
     let source = std::fs::read_to_string(path)
         .map_err(|e| format!("Failed to read {}: {e}", path.display()))?;
 
@@ -45,8 +84,17 @@ pub async fn run_test_file(
     let tokens = lexer.tokenize().map_err(|e| format!("{e}"))?;
     let mut parser = Parser::new(tokens);
     let program = parser.parse().map_err(|e| format!("{e}"))?;
+    let test_names = discover_test_names(&program, filter);
 
-    let test_names: Vec<String> = program
+    Ok(ParsedTestFile {
+        source,
+        program,
+        test_names,
+    })
+}
+
+fn discover_test_names(program: &[SNode], filter: Option<&str>) -> Vec<String> {
+    program
         .iter()
         .filter_map(|snode| {
             // Recognize either:
@@ -72,11 +120,54 @@ pub async fn run_test_file(
             }
             Some(name)
         })
-        .collect();
+        .collect()
+}
+
+fn emit_progress(progress: &Option<TestRunProgress>, event: TestRunEvent) {
+    if let Some(callback) = progress {
+        callback(event);
+    }
+}
+
+fn push_result(
+    results: &mut Vec<TestResult>,
+    result: TestResult,
+    progress: &Option<TestRunProgress>,
+) {
+    emit_progress(progress, TestRunEvent::TestFinished(result.clone()));
+    results.push(result);
+}
+
+fn should_warn_large_sequential_suite(total_tests: usize, total_files: usize) -> bool {
+    total_tests >= LARGE_SEQUENTIAL_TEST_THRESHOLD || total_files >= LARGE_SEQUENTIAL_FILE_THRESHOLD
+}
+
+async fn run_test_file_with_progress(
+    path: &Path,
+    filter: Option<&str>,
+    timeout_ms: u64,
+    execution_cwd: Option<&Path>,
+    cli_skill_dirs: &[PathBuf],
+    progress: Option<TestRunProgress>,
+) -> Result<Vec<TestResult>, String> {
+    let ParsedTestFile {
+        source,
+        program,
+        test_names,
+    } = parse_test_file(path, filter)?;
 
     let mut results = Vec::new();
 
-    for test_name in &test_names {
+    for (test_index, test_name) in test_names.iter().enumerate() {
+        emit_progress(
+            &progress,
+            TestRunEvent::TestStarted {
+                name: test_name.clone(),
+                file: path.display().to_string(),
+                test_index: test_index + 1,
+                total_tests_in_file: test_names.len(),
+            },
+        );
         harn_vm::reset_thread_local_state();
 
         let start = Instant::now();
@@ -84,13 +175,17 @@ pub async fn run_test_file(
         let chunk = match harn_vm::Compiler::new().compile_named(&program, test_name) {
             Ok(c) => c,
             Err(e) => {
-                results.push(TestResult {
-                    name: test_name.clone(),
-                    file: path.display().to_string(),
-                    passed: false,
-                    error: Some(format!("Compile error: {e}")),
-                    duration_ms: 0,
-                });
+                push_result(
+                    &mut results,
+                    TestResult {
+                        name: test_name.clone(),
+                        file: path.display().to_string(),
+                        passed: false,
+                        error: Some(format!("Compile error: {e}")),
+                        duration_ms: 0,
+                    },
+                    &progress,
+                );
                 continue;
             }
         };
@@ -170,36 +265,67 @@ pub async fn run_test_file(
 
         match result {
             Ok(Ok(_)) => {
-                results.push(TestResult {
-                    name: test_name.clone(),
-                    file: path.display().to_string(),
-                    passed: true,
-                    error: None,
-                    duration_ms: duration,
-                });
+                push_result(
+                    &mut results,
+                    TestResult {
+                        name: test_name.clone(),
+                        file: path.display().to_string(),
+                        passed: true,
+                        error: None,
+                        duration_ms: duration,
+                    },
+                    &progress,
+                );
             }
             Ok(Err(e)) => {
-                results.push(TestResult {
-                    name: test_name.clone(),
-                    file: path.display().to_string(),
-                    passed: false,
-                    error: Some(e),
-                    duration_ms: duration,
-                });
+                push_result(
+                    &mut results,
+                    TestResult {
+                        name: test_name.clone(),
+                        file: path.display().to_string(),
+                        passed: false,
+                        error: Some(e),
+                        duration_ms: duration,
+                    },
+                    &progress,
+                );
             }
             Err(_) => {
-                results.push(TestResult {
-                    name: test_name.clone(),
-                    file: path.display().to_string(),
-                    passed: false,
-                    error: Some(format!("timed out after {timeout_ms}ms")),
-                    duration_ms: timeout_ms,
-                });
+                push_result(
+                    &mut results,
+                    TestResult {
+                        name: test_name.clone(),
+                        file: path.display().to_string(),
+                        passed: false,
+                        error: Some(format!("timed out after {timeout_ms}ms")),
+                        duration_ms: timeout_ms,
+                    },
+                    &progress,
+                );
             }
         }
     }
 
     Ok(results)
+}
+
+/// Run all test_* pipelines in a single source file using the VM.
+pub async fn run_test_file(
+    path: &Path,
+    filter: Option<&str>,
+    timeout_ms: u64,
+    execution_cwd: Option<&Path>,
+    cli_skill_dirs: &[PathBuf],
+) -> Result<Vec<TestResult>, String> {
+    run_test_file_with_progress(
+        path,
+        filter,
+        timeout_ms,
+        execution_cwd,
+        cli_skill_dirs,
+        None,
+    )
+    .await
 }
 
 /// Discover and run tests in a file or directory.
@@ -209,6 +335,17 @@ pub async fn run_tests(
     timeout_ms: u64,
     parallel: bool,
     cli_skill_dirs: &[PathBuf],
+) -> TestSummary {
+    run_tests_with_progress(path, filter, timeout_ms, parallel, cli_skill_dirs, None).await
+}
+
+pub async fn run_tests_with_progress(
+    path: &Path,
+    filter: Option<&str>,
+    timeout_ms: u64,
+    parallel: bool,
+    cli_skill_dirs: &[PathBuf],
+    progress: Option<TestRunProgress>,
 ) -> TestSummary {
     // Default LLM provider to "mock" in test mode unless caller overrides.
     let _default_llm_provider = ScopedEnvVar::set_if_unset("HARN_LLM_PROVIDER", "mock");
@@ -223,60 +360,139 @@ pub async fn run_tests(
     } else {
         vec![canonical_target]
     };
+    let file_plans = files
+        .into_iter()
+        .map(|file| {
+            let test_count = parse_test_file(&file, filter)
+                .map(|parsed| parsed.test_names.len())
+                .unwrap_or(0);
+            TestFilePlan { file, test_count }
+        })
+        .collect::<Vec<_>>();
+    let total_tests = file_plans.iter().map(|plan| plan.test_count).sum();
+    let total_files = file_plans.iter().filter(|plan| plan.test_count > 0).count();
+    emit_progress(
+        &progress,
+        TestRunEvent::SuiteDiscovered {
+            total_tests,
+            total_files,
+            parallel,
+        },
+    );
+    if !parallel && should_warn_large_sequential_suite(total_tests, total_files) {
+        emit_progress(
+            &progress,
+            TestRunEvent::LargeSequentialSuite {
+                total_tests,
+                total_files,
+            },
+        );
+    }
 
     if parallel {
         let mut handles = Vec::new();
-        for file in files {
+        let mut progress_file_index = 0;
+        for plan in file_plans {
             let filter = filter.map(|s| s.to_string());
             let cli_skill_dirs = cli_skill_dirs.to_vec();
+            let progress = progress.clone();
+            if plan.test_count > 0 {
+                progress_file_index += 1;
+                emit_progress(
+                    &progress,
+                    TestRunEvent::FileStarted {
+                        file: plan.file.display().to_string(),
+                        file_index: progress_file_index,
+                        total_files,
+                        test_count: plan.test_count,
+                    },
+                );
+            }
             handles.push(tokio::task::spawn_blocking(move || {
-                let execution_cwd = file
+                let execution_cwd = plan
+                    .file
                     .parent()
                     .filter(|parent| !parent.as_os_str().is_empty())
                     .map(Path::to_path_buf);
                 run_test_file_on_isolated_thread(
-                    &file,
+                    &plan.file,
                     filter.as_deref(),
                     timeout_ms,
                     execution_cwd.as_deref(),
                     &cli_skill_dirs,
+                    None,
                 )
             }));
         }
         for handle in handles {
             match handle.await {
-                Ok(Ok(r)) => all_results.extend(r),
-                Ok(Err(e)) => all_results.push(TestResult {
-                    name: "<file error>".to_string(),
-                    file: String::new(),
-                    passed: false,
-                    error: Some(e),
-                    duration_ms: 0,
-                }),
-                Err(e) => all_results.push(TestResult {
-                    name: "<join error>".to_string(),
-                    file: String::new(),
-                    passed: false,
-                    error: Some(format!("{e}")),
-                    duration_ms: 0,
-                }),
-            }
-        }
-    } else {
-        for file in &files {
-            let execution_cwd = file
-                .parent()
-                .filter(|parent| !parent.as_os_str().is_empty());
-            match run_test_file(file, filter, timeout_ms, execution_cwd, cli_skill_dirs).await {
-                Ok(results) => all_results.extend(results),
-                Err(e) => {
-                    all_results.push(TestResult {
+                Ok(Ok(r)) => {
+                    for result in &r {
+                        emit_progress(&progress, TestRunEvent::TestFinished(result.clone()));
+                    }
+                    all_results.extend(r);
+                }
+                Ok(Err(e)) => {
+                    let result = TestResult {
                         name: "<file error>".to_string(),
-                        file: file.display().to_string(),
+                        file: String::new(),
                         passed: false,
                         error: Some(e),
                         duration_ms: 0,
-                    });
+                    };
+                    push_result(&mut all_results, result, &progress);
+                }
+                Err(e) => {
+                    let result = TestResult {
+                        name: "<join error>".to_string(),
+                        file: String::new(),
+                        passed: false,
+                        error: Some(format!("{e}")),
+                        duration_ms: 0,
+                    };
+                    push_result(&mut all_results, result, &progress);
+                }
+            }
+        }
+    } else {
+        let mut progress_file_index = 0;
+        for plan in &file_plans {
+            if plan.test_count > 0 {
+                progress_file_index += 1;
+                emit_progress(
+                    &progress,
+                    TestRunEvent::FileStarted {
+                        file: plan.file.display().to_string(),
+                        file_index: progress_file_index,
+                        total_files,
+                        test_count: plan.test_count,
+                    },
+                );
+            }
+            let execution_cwd = plan
+                .file
+                .parent()
+                .filter(|parent| !parent.as_os_str().is_empty());
+            match run_test_file_with_progress(
+                &plan.file,
+                filter,
+                timeout_ms,
+                execution_cwd,
+                cli_skill_dirs,
+                progress.clone(),
+            )
+            .await
+            {
+                Ok(results) => all_results.extend(results),
+                Err(e) => {
+                    let result = TestResult {
+                        name: "<file error>".to_string(),
+                        file: plan.file.display().to_string(),
+                        passed: false,
+                        error: Some(e),
+                        duration_ms: 0,
+                    };
+                    push_result(&mut all_results, result, &progress);
                 }
             }
         }
@@ -301,17 +517,19 @@ fn run_test_file_on_isolated_thread(
     timeout_ms: u64,
     execution_cwd: Option<&Path>,
     cli_skill_dirs: &[PathBuf],
+    progress: Option<TestRunProgress>,
 ) -> Result<Vec<TestResult>, String> {
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
         .map_err(|error| format!("failed to start test runtime: {error}"))?;
-    runtime.block_on(run_test_file(
+    runtime.block_on(run_test_file_with_progress(
         file,
         filter,
         timeout_ms,
         execution_cwd,
         cli_skill_dirs,
+        progress,
     ))
 }
 
@@ -337,9 +555,13 @@ fn discover_test_files(dir: &Path) -> Vec<PathBuf> {
 
 #[cfg(test)]
 mod tests {
-    use super::{discover_test_files, run_tests};
+    use super::{
+        discover_test_files, run_tests, run_tests_with_progress,
+        should_warn_large_sequential_suite, TestRunEvent, TestRunProgress,
+    };
     use std::fs;
     use std::path::Path;
+    use std::sync::{Arc, Mutex};
 
     struct TempTestDir {
         inner: tempfile::TempDir,
@@ -389,6 +611,72 @@ mod tests {
         assert!(files
             .iter()
             .any(|path| path.ends_with("suite/annotated.harn")));
+    }
+
+    #[test]
+    fn large_sequential_suite_warning_threshold_is_conservative() {
+        assert!(!should_warn_large_sequential_suite(49, 9));
+        assert!(should_warn_large_sequential_suite(50, 1));
+        assert!(should_warn_large_sequential_suite(1, 10));
+    }
+
+    #[tokio::test]
+    async fn run_tests_emits_progress_events() {
+        let _env_guard = crate::tests::common::env_lock::lock_env().lock().await;
+        let temp = TempTestDir::new();
+        temp.write(
+            "suite/test_progress.harn",
+            r#"
+pipeline test_alpha(task) {
+  assert_eq(1, 1)
+}
+
+pipeline test_beta(task) {
+  assert_eq(2, 2)
+}
+"#,
+        );
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let captured = Arc::clone(&events);
+        let progress: TestRunProgress = Arc::new(move |event| {
+            captured.lock().unwrap().push(event);
+        });
+
+        let summary = run_tests_with_progress(
+            &temp.path().join("suite"),
+            None,
+            1_000,
+            false,
+            &[],
+            Some(progress),
+        )
+        .await;
+        let events = events.lock().unwrap();
+
+        assert_eq!(summary.failed, 0);
+        assert_eq!(summary.passed, 2);
+        assert!(matches!(
+            events.first(),
+            Some(TestRunEvent::SuiteDiscovered {
+                total_tests: 2,
+                total_files: 1,
+                parallel: false
+            })
+        ));
+        let file_started = events
+            .iter()
+            .position(|event| matches!(event, TestRunEvent::FileStarted { .. }))
+            .expect("file start event");
+        let test_started = events
+            .iter()
+            .position(|event| matches!(event, TestRunEvent::TestStarted { .. }))
+            .expect("test start event");
+        let test_finished = events
+            .iter()
+            .position(|event| matches!(event, TestRunEvent::TestFinished(_)))
+            .expect("test finished event");
+        assert!(file_started < test_started);
+        assert!(test_started < test_finished);
     }
 
     #[tokio::test]

--- a/crates/harn-cli/tests/check_fmt_json_cli.rs
+++ b/crates/harn-cli/tests/check_fmt_json_cli.rs
@@ -1,6 +1,7 @@
 //! End-to-end coverage for `harn check --json` and `harn fmt --json`.
 
-use std::process::Command;
+use std::io::{BufRead, BufReader};
+use std::process::{Command, Stdio};
 
 use harn_cli::tests::common::json_envelope::assert_envelope;
 
@@ -96,6 +97,45 @@ fn check_json_reports_success_and_diagnostics() {
             .iter()
             .any(|diag| diag["code"].as_str().unwrap_or("").starts_with("HARN-TYP-")),
         "expected a type diagnostic: {parsed}"
+    );
+}
+
+#[test]
+fn check_json_exits_successfully_when_stdout_consumer_closes_early() {
+    let temp = tempfile::TempDir::new().expect("tempdir");
+    for index in 0..300 {
+        let script = temp.path().join(format!("case_{index:03}.harn"));
+        std::fs::write(
+            &script,
+            format!("pipeline main(task) {{\n  return {index}\n}}\n"),
+        )
+        .expect("write script");
+    }
+
+    let mut child = Command::new(binary_path())
+        .args(["check", "--json", temp.path().to_str().unwrap()])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn harn check --json");
+
+    let stdout = child.stdout.take().expect("stdout pipe");
+    let mut reader = BufReader::new(stdout);
+    let mut first_line = String::new();
+    reader.read_line(&mut first_line).expect("read first line");
+    drop(reader);
+
+    let output = child.wait_with_output().expect("wait for harn check");
+    assert!(
+        output.status.success(),
+        "consumer-close should be a clean exit\nstatus: {}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("failed printing to stdout"),
+        "broken pipe panic leaked to stderr:\n{stderr}"
     );
 }
 

--- a/crates/harn-cli/tests/user_test_cli.rs
+++ b/crates/harn-cli/tests/user_test_cli.rs
@@ -1,0 +1,64 @@
+//! End-to-end coverage for user `harn test` runner output.
+
+use std::process::Command;
+
+fn binary_path() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_BIN_EXE_harn"))
+}
+
+#[test]
+fn user_tests_emit_progress_and_timing_summary() {
+    let temp = tempfile::TempDir::new().expect("tempdir");
+    let suite = temp.path().join("suite");
+    std::fs::create_dir_all(&suite).expect("create suite");
+    std::fs::write(
+        suite.join("test_alpha.harn"),
+        r#"
+pipeline test_alpha(task) {
+  assert_eq(1, 1)
+}
+"#,
+    )
+    .expect("write alpha");
+    std::fs::write(
+        suite.join("test_beta.harn"),
+        r#"
+pipeline test_beta(task) {
+  assert_eq(2, 2)
+}
+"#,
+    )
+    .expect("write beta");
+
+    let output = Command::new(binary_path())
+        .args([
+            "test",
+            suite.to_str().unwrap(),
+            "--verbose",
+            "--timing",
+            "--timeout",
+            "10000",
+        ])
+        .output()
+        .expect("spawn harn test");
+
+    assert!(
+        output.status.success(),
+        "stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Running 2 tests from 2 files (sequential)"));
+    assert!(stdout.contains("RUN   file 1/2"));
+    assert!(stdout.contains("RUN   test_alpha"));
+    assert!(stdout.contains("PASS"));
+    assert!(stdout.contains("Slowest 2 tests:"));
+    assert!(stdout.contains("Slowest 2 files:"));
+
+    let first_file = stdout.find("RUN   file 1/2").expect("file progress");
+    let first_pass = stdout.find("PASS").expect("pass output");
+    assert!(
+        first_file < first_pass,
+        "file progress should be emitted before completed test results:\n{stdout}"
+    );
+}

--- a/crates/harn-vm/src/stdlib/agents_sub_agent.rs
+++ b/crates/harn-vm/src/stdlib/agents_sub_agent.rs
@@ -988,7 +988,6 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
-    #[ignore = "child session tool_format claim not yet wired through Harn-driven loop — tracked in #1236"]
     async fn execute_sub_agent_uses_child_transcript_and_appends_parent_events() {
         crate::agent_sessions::reset_session_store();
         reset_llm_mock_state();

--- a/crates/harn-vm/tests/agent_sessions.rs
+++ b/crates/harn-vm/tests/agent_sessions.rs
@@ -101,7 +101,6 @@ pipeline main(task) {
 }
 
 #[test]
-#[ignore = "tool_format claim/contract enforcement not yet wired through Harn-driven loop — tracked in #1236"]
 fn agent_loop_rejects_tool_format_switch_on_same_session() {
     let lines = out(r#"
 pipeline main(task) {

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -271,6 +271,7 @@ harn test conformance tests/stdlib/     # run a conformance subtree
 harn test tests/                       # run user tests in directory
 harn test tests/ --filter "auth*"      # filter by pattern
 harn test tests/ --parallel            # run tests concurrently
+harn test tests/ --parallel --timing   # show progress and slowest tests/files
 harn test tests/ --watch               # re-run on file changes
 harn test conformance --verbose        # show per-test timing
 harn test conformance --timing         # show timing summary without verbose failures

--- a/docs/src/dev/testing.md
+++ b/docs/src/dev/testing.md
@@ -273,6 +273,7 @@ The script searches files under `crates/**/tests/**/*.rs`,
 | `while … Instant::now()` | Wall-clock polling loop; flaky under load | `EventLog::subscribe()` + `timeout` |
 | `SystemTime::now()` in tests | Real wall-clock timestamp; non-reproducible | `MockClock` or injected timestamp |
 | `recv_timeout(Duration::from_millis(…))` | Busy-wait with a short literal timeout | `tokio::time::timeout` with event channel |
+| `#[ignore]` outside slow harn-cli integration tests | Hides regressions behind default-suite skips | run the test by default, or move subprocess coverage to the harn-cli E2E profile |
 | copied conformance subprocess wait helpers | Drifts retry ceilings and diagnostics between fixtures | import `conformance/tests/_common.harn` |
 | `random_int(20000, 45000)` for server ports | Races with other tests and local services | bind port `0` and read the readiness log |
 | `sleep(<literal>)` / `time.sleep(<literal>)` in `.harn` fixtures (outside `mock_time(...)`) | Wall-clock burn that races against scheduler load | wrap in `mock_time(...)` / `unmock_time()` and let the unified clock auto-advance, or add the file to `CONFORMANCE_REAL_TIME_ALLOWLIST` with justification |

--- a/scripts/lint_test_patterns.sh
+++ b/scripts/lint_test_patterns.sh
@@ -268,6 +268,21 @@ while IFS= read -r file; do
   done < <(grep -n "spawn_orchestrator(" "$file" 2>/dev/null || true)
 done < "$TEST_FILES_TMP"
 
+echo "--- #[ignore] outside slow harn-cli integration tests ---"
+while IFS= read -r file; do
+  case "${file#"$ROOT_DIR/"}" in
+    crates/harn-cli/tests/*)
+      continue
+      ;;
+  esac
+  while IFS= read -r hit; do
+    [[ -z "$hit" ]] && continue
+    echo "  $hit"
+    echo "    hint: Default-suite Rust tests must run by default. Move slow subprocess coverage to the harn-cli E2E profile instead of using #[ignore]."
+    violations=$((violations + 1))
+  done < <(grep -n "#\\[ignore" "$file" 2>/dev/null || true)
+done < "$TEST_FILES_TMP"
+
 echo "--- copied conformance subprocess wait helpers ---"
 check_harn_helper_pattern() {
   local pattern="$1"


### PR DESCRIPTION
Fixes #2137

Summary:
- Add progress events/output for user `harn test` discovery, file starts, optional verbose test starts, and completed results so large suites show early activity.
- Warn when a large selected suite is running sequentially and point users at `--parallel`.
- Add `--timing` summaries for user tests with total runtime, percentiles, slowest tests, and slowest files.
- Treat stdout/stderr broken-pipe print panics as clean consumer-close exits, with integration coverage for `harn check --json`.
- Activate the two stale `harn-vm` tool-format contract tests that were still ignored after the Harn agent-loop cutover.
- Add a `lint-test-patterns` guard and docs guidance so default-suite Rust tests cannot silently add `#[ignore]` outside the slow `harn-cli` integration lane.

PR/Context:
- PR #1155 introduced the session tool-format contract and intended these tests to enforce it.
- PR #1234 temporarily ignored them during the Harn agent-loop migration; both now pass in default mode.
- Notion search was unavailable in this environment (`Auth required`), so this used local blame/history, GitHub PR context, and cross-repo code search.

Verification:
- `cargo fmt --check`
- `cargo check -p harn-cli`
- `cargo test -p harn-cli test_runner --lib`
- `cargo test -p harn-cli --test user_test_cli -- --nocapture`
- `cargo test -p harn-cli --test check_fmt_json_cli -- --nocapture`
- `cargo test -p harn-cli broken_pipe --lib`
- `cargo test -p harn-vm agent_loop_rejects_tool_format_switch_on_same_session --test agent_sessions -- --nocapture`
- `cargo test -p harn-vm execute_sub_agent_uses_child_transcript_and_appends_parent_events --lib -- --nocapture`
- `make lint-test-patterns`
- `make check-docs-snippets`
- `make test` (4697 passed, 0 skipped)
