### PR TITLE
Trim hot runtime call checks

### DIFF
--- a/crates/harn-vm/src/bench_internals.rs
+++ b/crates/harn-vm/src/bench_internals.rs
@@ -76,6 +76,7 @@ fn synthetic_closure(name: &str, env: VmEnv) -> VmClosure {
         is_generator: false,
         is_stream: false,
         has_rest_param: false,
+        has_runtime_type_checks: false,
     };
     VmClosure {
         func: Rc::new(func),

--- a/crates/harn-vm/src/bytecode_cache.rs
+++ b/crates/harn-vm/src/bytecode_cache.rs
@@ -51,7 +51,7 @@ pub const MAGIC: &[u8; 8] = b"HARNBC\0\0";
 
 /// On-disk format version. Bump when [`CachedChunk`] or the header
 /// layout changes in a backwards-incompatible way.
-pub const SCHEMA_VERSION: u32 = 2;
+pub const SCHEMA_VERSION: u32 = 3;
 
 /// Compile-time Harn release. Cache files written by a different release
 /// are rejected on load.

--- a/crates/harn-vm/src/chunk.rs
+++ b/crates/harn-vm/src/chunk.rs
@@ -529,6 +529,7 @@ pub struct CachedCompiledFunction {
     pub(crate) is_generator: bool,
     pub(crate) is_stream: bool,
     pub(crate) has_rest_param: bool,
+    pub(crate) has_runtime_type_checks: bool,
 }
 
 /// One parameter slot of a compiled user-defined function. Carries the
@@ -590,9 +591,18 @@ pub struct CompiledFunction {
     pub is_stream: bool,
     /// True if the last parameter is a rest parameter (`...name`).
     pub has_rest_param: bool,
+    /// True when at least one parameter has a runtime-visible type
+    /// assertion. Untyped closures dominate collection callback hot paths,
+    /// so this lets the VM skip the per-argument metadata walk after the
+    /// arity check.
+    pub has_runtime_type_checks: bool,
 }
 
 impl CompiledFunction {
+    pub(crate) fn has_runtime_type_checks_for_params(params: &[ParamSlot]) -> bool {
+        params.iter().any(|param| param.type_expr.is_some())
+    }
+
     /// Returns just the parameter names — convenience for code paths that
     /// don't care about types or defaults.
     pub fn param_names(&self) -> impl Iterator<Item = &str> {
@@ -623,6 +633,7 @@ impl CompiledFunction {
             is_generator: self.is_generator,
             is_stream: self.is_stream,
             has_rest_param: self.has_rest_param,
+            has_runtime_type_checks: self.has_runtime_type_checks,
         }
     }
 
@@ -637,6 +648,7 @@ impl CompiledFunction {
             is_generator: cached.is_generator,
             is_stream: cached.is_stream,
             has_rest_param: cached.has_rest_param,
+            has_runtime_type_checks: cached.has_runtime_type_checks,
         }
     }
 }

--- a/crates/harn-vm/src/compiler/closures.rs
+++ b/crates/harn-vm/src/compiler/closures.rs
@@ -38,16 +38,20 @@ impl Compiler {
         fn_compiler.chunk.emit(Op::Nil, self.line);
         fn_compiler.chunk.emit(Op::Return, self.line);
 
+        let param_slots = crate::chunk::ParamSlot::vec_from_typed(params);
+        let has_runtime_type_checks =
+            CompiledFunction::has_runtime_type_checks_for_params(&param_slots);
         let func = CompiledFunction {
             name: name.to_string(),
             type_params: type_params.iter().map(|param| param.name.clone()).collect(),
             nominal_type_names: fn_compiler.nominal_type_names(),
-            params: crate::chunk::ParamSlot::vec_from_typed(params),
+            params: param_slots,
             default_start: TypedParam::default_start(params),
             chunk: Rc::new(fn_compiler.chunk),
             is_generator: is_gen,
             is_stream,
             has_rest_param: params.last().is_some_and(|p| p.rest),
+            has_runtime_type_checks,
         };
         let fn_idx = self.chunk.functions.len();
         self.chunk.functions.push(Rc::new(func));
@@ -82,16 +86,20 @@ impl Compiler {
         }
         fn_compiler.chunk.emit(Op::Return, self.line);
 
+        let param_slots = crate::chunk::ParamSlot::vec_from_typed(params);
+        let has_runtime_type_checks =
+            CompiledFunction::has_runtime_type_checks_for_params(&param_slots);
         let func = CompiledFunction {
             name: name.to_string(),
             type_params: Vec::new(),
             nominal_type_names: fn_compiler.nominal_type_names(),
-            params: crate::chunk::ParamSlot::vec_from_typed(params),
+            params: param_slots,
             default_start: TypedParam::default_start(params),
             chunk: Rc::new(fn_compiler.chunk),
             is_generator: false,
             is_stream: false,
             has_rest_param: params.last().is_some_and(|p| p.rest),
+            has_runtime_type_checks,
         };
         let fn_idx = self.chunk.functions.len();
         self.chunk.functions.push(Rc::new(func));
@@ -363,16 +371,20 @@ impl Compiler {
         }
         fn_compiler.chunk.emit(Op::Return, self.line);
 
+        let param_slots = crate::chunk::ParamSlot::vec_from_typed(params);
+        let has_runtime_type_checks =
+            CompiledFunction::has_runtime_type_checks_for_params(&param_slots);
         let func = CompiledFunction {
             name: "<closure>".to_string(),
             type_params: Vec::new(),
             nominal_type_names: fn_compiler.nominal_type_names(),
-            params: crate::chunk::ParamSlot::vec_from_typed(params),
+            params: param_slots,
             default_start: TypedParam::default_start(params),
             chunk: Rc::new(fn_compiler.chunk),
             is_generator: is_gen,
             is_stream: false,
             has_rest_param: false,
+            has_runtime_type_checks,
         };
         let fn_idx = self.chunk.functions.len();
         self.chunk.functions.push(Rc::new(func));

--- a/crates/harn-vm/src/compiler/concurrency.rs
+++ b/crates/harn-vm/src/compiler/concurrency.rs
@@ -64,16 +64,20 @@ impl Compiler {
         }
         fn_compiler.compile_block(body)?;
         fn_compiler.chunk.emit(Op::Return, self.line);
+        let param_slots = crate::chunk::ParamSlot::vec_from_typed(&typed_params);
+        let has_runtime_type_checks =
+            CompiledFunction::has_runtime_type_checks_for_params(&param_slots);
         let func = CompiledFunction {
             name: fn_name.to_string(),
             type_params: Vec::new(),
             nominal_type_names: fn_compiler.nominal_type_names(),
-            params: crate::chunk::ParamSlot::vec_from_typed(&typed_params),
+            params: param_slots,
             default_start: None,
             chunk: Rc::new(fn_compiler.chunk),
             is_generator: false,
             is_stream: false,
             has_rest_param: false,
+            has_runtime_type_checks,
         };
         let fn_idx = self.chunk.functions.len();
         self.chunk.functions.push(Rc::new(func));
@@ -106,6 +110,7 @@ impl Compiler {
             is_generator: false,
             is_stream: false,
             has_rest_param: false,
+            has_runtime_type_checks: false,
         };
         let fn_idx = self.chunk.functions.len();
         self.chunk.functions.push(Rc::new(func));

--- a/crates/harn-vm/src/compiler/decls.rs
+++ b/crates/harn-vm/src/compiler/decls.rs
@@ -108,16 +108,20 @@ impl Compiler {
                 fn_compiler.chunk.emit(Op::Nil, self.line);
                 fn_compiler.chunk.emit(Op::Return, self.line);
 
+                let param_slots = crate::chunk::ParamSlot::vec_from_typed(params);
+                let has_runtime_type_checks =
+                    CompiledFunction::has_runtime_type_checks_for_params(&param_slots);
                 let func = CompiledFunction {
                     name: format!("{}.{}", type_name, name),
                     type_params: type_params.iter().map(|param| param.name.clone()).collect(),
                     nominal_type_names: fn_compiler.nominal_type_names(),
-                    params: crate::chunk::ParamSlot::vec_from_typed(params),
+                    params: param_slots,
                     default_start: TypedParam::default_start(params),
                     chunk: Rc::new(fn_compiler.chunk),
                     is_generator: false,
                     is_stream: false,
                     has_rest_param: false,
+                    has_runtime_type_checks,
                 };
                 let fn_idx = self.chunk.functions.len();
                 self.chunk.functions.push(Rc::new(func));
@@ -168,16 +172,20 @@ impl Compiler {
         fn_compiler.chunk.emit_u8(Op::Call, 3, self.line);
         fn_compiler.chunk.emit(Op::Return, self.line);
 
+        let param_slots = crate::chunk::ParamSlot::vec_from_typed(&params);
+        let has_runtime_type_checks =
+            CompiledFunction::has_runtime_type_checks_for_params(&param_slots);
         let func = CompiledFunction {
             name: name.to_string(),
             type_params: Vec::new(),
             nominal_type_names: fn_compiler.nominal_type_names(),
-            params: crate::chunk::ParamSlot::vec_from_typed(&params),
+            params: param_slots,
             default_start: None,
             chunk: Rc::new(fn_compiler.chunk),
             is_generator: false,
             is_stream: false,
             has_rest_param: false,
+            has_runtime_type_checks,
         };
         let fn_idx = self.chunk.functions.len();
         self.chunk.functions.push(Rc::new(func));

--- a/crates/harn-vm/src/compiler/state.rs
+++ b/crates/harn-vm/src/compiler/state.rs
@@ -1182,16 +1182,20 @@ impl Compiler {
         fn_compiler.chunk.emit(Op::Nil, 0);
         fn_compiler.chunk.emit(Op::Return, 0);
         fn_compiler.chunk.source_file = source_file;
+        let param_slots = crate::chunk::ParamSlot::vec_from_typed(params);
+        let has_runtime_type_checks =
+            CompiledFunction::has_runtime_type_checks_for_params(&param_slots);
         Ok(CompiledFunction {
             name: String::new(),
             type_params: type_params.iter().map(|param| param.name.clone()).collect(),
             nominal_type_names: fn_compiler.nominal_type_names(),
-            params: crate::chunk::ParamSlot::vec_from_typed(params),
+            params: param_slots,
             default_start: TypedParam::default_start(params),
             chunk: Rc::new(fn_compiler.chunk),
             is_generator: is_gen,
             is_stream: false,
             has_rest_param: false,
+            has_runtime_type_checks,
         })
     }
 

--- a/crates/harn-vm/src/mcp_server/tests.rs
+++ b/crates/harn-vm/src/mcp_server/tests.rs
@@ -25,6 +25,7 @@ fn empty_closure(name: &str) -> VmClosure {
             is_generator: false,
             is_stream: false,
             has_rest_param: false,
+            has_runtime_type_checks: false,
         }),
         env: VmEnv::new(),
         source_dir: None,

--- a/crates/harn-vm/src/step_runtime.rs
+++ b/crates/harn-vm/src/step_runtime.rs
@@ -14,7 +14,7 @@
 //! `crates/harn-vm/src/llm/`, `crates/harn-vm/src/vm/`, and the compiler
 //! stay focused.
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::collections::BTreeMap;
 use std::rc::Rc;
 
@@ -161,6 +161,8 @@ thread_local! {
         const { RefCell::new(BTreeMap::new()) };
     static PERSONA_REGISTRY: RefCell<BTreeMap<String, Rc<PersonaDefinition>>> =
         const { RefCell::new(BTreeMap::new()) };
+    static STEP_REGISTRY_LEN: Cell<usize> = const { Cell::new(0) };
+    static PERSONA_REGISTRY_LEN: Cell<usize> = const { Cell::new(0) };
     static PERSONA_STACK: RefCell<Vec<ActivePersona>> = const { RefCell::new(Vec::new()) };
     static STEP_STACK: RefCell<Vec<ActiveStep>> = const { RefCell::new(Vec::new()) };
     static COMPLETED_STEPS: RefCell<Vec<CompletedStep>> = const { RefCell::new(Vec::new()) };
@@ -173,29 +175,54 @@ thread_local! {
 pub fn reset_thread_local_state() {
     STEP_REGISTRY.with(|r| r.borrow_mut().clear());
     PERSONA_REGISTRY.with(|r| r.borrow_mut().clear());
+    STEP_REGISTRY_LEN.with(|len| len.set(0));
+    PERSONA_REGISTRY_LEN.with(|len| len.set(0));
     PERSONA_STACK.with(|s| s.borrow_mut().clear());
     STEP_STACK.with(|s| s.borrow_mut().clear());
     COMPLETED_STEPS.with(|c| c.borrow_mut().clear());
     PERSONA_HOOKS.with(|h| h.borrow_mut().clear());
 }
 
+#[inline]
+fn step_registry_empty() -> bool {
+    STEP_REGISTRY_LEN.with(|len| len.get() == 0)
+}
+
+#[inline]
+fn persona_registry_empty() -> bool {
+    PERSONA_REGISTRY_LEN.with(|len| len.get() == 0)
+}
+
+#[inline]
+fn tracked_registries_empty() -> bool {
+    step_registry_empty() && persona_registry_empty()
+}
+
 /// Bind a `@step` function name to its declared metadata. Idempotent: a
 /// second call replaces the prior definition (matches re-evaluation
 /// semantics of `harn run` and the conformance harness).
 pub fn register_step(function: &str, definition: StepDefinition) {
-    STEP_REGISTRY.with(|registry| {
+    let inserted = STEP_REGISTRY.with(|registry| {
         registry
             .borrow_mut()
-            .insert(function.to_string(), Rc::new(definition));
+            .insert(function.to_string(), Rc::new(definition))
+            .is_none()
     });
+    if inserted {
+        STEP_REGISTRY_LEN.with(|len| len.set(len.get() + 1));
+    }
 }
 
 pub fn register_persona(function: &str, definition: PersonaDefinition) {
-    PERSONA_REGISTRY.with(|registry| {
+    let inserted = PERSONA_REGISTRY.with(|registry| {
         registry
             .borrow_mut()
-            .insert(function.to_string(), Rc::new(definition));
+            .insert(function.to_string(), Rc::new(definition))
+            .is_none()
     });
+    if inserted {
+        PERSONA_REGISTRY_LEN.with(|len| len.set(len.get() + 1));
+    }
 }
 
 pub fn register_persona_from_dict(args: Vec<VmValue>) -> Result<VmValue, VmError> {
@@ -442,11 +469,19 @@ pub fn restore_active_context(snapshot: ActiveContextSnapshot) {
 }
 
 pub fn is_tracked_function(function_name: &str) -> bool {
-    STEP_REGISTRY.with(|registry| registry.borrow().contains_key(function_name))
-        || PERSONA_REGISTRY.with(|registry| registry.borrow().contains_key(function_name))
+    if tracked_registries_empty() {
+        return false;
+    }
+    (!step_registry_empty()
+        && STEP_REGISTRY.with(|registry| registry.borrow().contains_key(function_name)))
+        || (!persona_registry_empty()
+            && PERSONA_REGISTRY.with(|registry| registry.borrow().contains_key(function_name)))
 }
 
 pub fn step_definition_for_function(function_name: &str) -> Option<Rc<StepDefinition>> {
+    if step_registry_empty() {
+        return None;
+    }
     STEP_REGISTRY.with(|registry| registry.borrow().get(function_name).cloned())
 }
 
@@ -537,6 +572,9 @@ pub fn matching_hooks(
 }
 
 pub fn maybe_push_active_persona(function_name: &str, frame_depth: usize) -> bool {
+    if persona_registry_empty() {
+        return false;
+    }
     let definition =
         PERSONA_REGISTRY.with(|registry| registry.borrow().get(function_name).cloned());
     let Some(definition) = definition else {
@@ -556,6 +594,9 @@ pub fn maybe_push_active_persona(function_name: &str, frame_depth: usize) -> boo
 /// can record that fact. Called from `Vm::push_closure_frame` after the
 /// new frame has been added.
 pub fn maybe_push_active_step(function_name: &str, frame_depth: usize, args: &[VmValue]) -> bool {
+    if step_registry_empty() {
+        return false;
+    }
     let definition = STEP_REGISTRY.with(|registry| registry.borrow().get(function_name).cloned());
     let Some(definition) = definition else {
         return false;
@@ -1005,6 +1046,39 @@ mod tests {
         fresh_state();
         assert!(!maybe_push_active_step("not_a_step", 1, &[]));
         assert!(active_step_frame_depth().is_none());
+    }
+
+    #[test]
+    fn tracked_registry_empty_fast_path_tracks_registrations_and_reset() {
+        fresh_state();
+        assert!(tracked_registries_empty());
+        assert!(!is_tracked_function("plan_step"));
+
+        register_step(
+            "plan_step",
+            StepDefinition {
+                name: "plan".to_string(),
+                function: "plan_step".to_string(),
+                ..StepDefinition::default()
+            },
+        );
+        assert!(!tracked_registries_empty());
+        assert!(is_tracked_function("plan_step"));
+        assert!(step_definition_for_function("plan_step").is_some());
+
+        register_step(
+            "plan_step",
+            StepDefinition {
+                name: "plan_v2".to_string(),
+                function: "plan_step".to_string(),
+                ..StepDefinition::default()
+            },
+        );
+        assert!(is_tracked_function("plan_step"));
+
+        fresh_state();
+        assert!(tracked_registries_empty());
+        assert!(!is_tracked_function("plan_step"));
     }
 
     #[test]

--- a/crates/harn-vm/src/typecheck.rs
+++ b/crates/harn-vm/src/typecheck.rs
@@ -273,6 +273,10 @@ pub fn validate_user_call(
         })));
     }
 
+    if !func.has_runtime_type_checks {
+        return Ok(());
+    }
+
     for (i, value) in args.iter().enumerate() {
         let Some(slot) = user_param_for_arg(func, i) else {
             continue;
@@ -406,6 +410,7 @@ fn arity_expect_for(func: &CompiledFunction) -> ArityExpect {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::chunk::Chunk;
     use std::rc::Rc;
 
     fn vm_int(n: i64) -> VmValue {
@@ -422,6 +427,30 @@ mod tests {
 
     fn ty_string() -> TypeExpr {
         TypeExpr::Named("string".into())
+    }
+
+    fn param_slot(name: &str, type_expr: Option<TypeExpr>) -> ParamSlot {
+        ParamSlot {
+            name: name.to_string(),
+            type_expr,
+            has_default: false,
+        }
+    }
+
+    fn compiled_function(params: Vec<ParamSlot>) -> CompiledFunction {
+        let has_runtime_type_checks = CompiledFunction::has_runtime_type_checks_for_params(&params);
+        CompiledFunction {
+            name: "f".to_string(),
+            type_params: Vec::new(),
+            nominal_type_names: Vec::new(),
+            params,
+            default_start: None,
+            chunk: Rc::new(Chunk::new()),
+            is_generator: false,
+            is_stream: false,
+            has_rest_param: false,
+            has_runtime_type_checks,
+        }
     }
 
     #[test]
@@ -524,5 +553,25 @@ mod tests {
             }
             other => panic!("expected ArgTypeMismatch, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn validate_user_call_skips_param_walk_for_untyped_function() {
+        let func = compiled_function(vec![param_slot("value", None)]);
+
+        validate_user_call(&func, &[vm_string("anything")], None).unwrap();
+
+        let err = validate_user_call(&func, &[], None).unwrap_err();
+        assert!(matches!(err, VmError::ArityMismatch(_)));
+    }
+
+    #[test]
+    fn validate_user_call_checks_typed_function() {
+        let func = compiled_function(vec![param_slot("value", Some(ty_int()))]);
+
+        validate_user_call(&func, &[vm_int(1)], None).unwrap();
+
+        let err = validate_user_call(&func, &[vm_string("bad")], None).unwrap_err();
+        assert!(matches!(err, VmError::Runtime(_) | VmError::TypeError(_)));
     }
 }


### PR DESCRIPTION
## Summary

- Cache whether compiled user functions have parameter type metadata that requires runtime validation, so untyped callback-heavy functions return after arity validation.
- Add empty-registry fast paths for step/persona runtime lookups, avoiding per-call registry map probes in ordinary scripts with no tracked functions.
- Bump the bytecode cache schema so cached compiled functions round-trip the new metadata safely.

## Validation

- `CARGO_TARGET_DIR=/tmp/harn-perf-hotspots-test-target cargo test -p harn-vm tracked_registry_empty_fast_path --lib`
- `CARGO_TARGET_DIR=/tmp/harn-perf-hotspots-test-target cargo test -p harn-vm validate_user_call --lib`
- `CARGO_TARGET_DIR=/tmp/harn-perf-hotspots-test-target cargo test -p harn-vm --lib`
- `cargo fmt --check`
- `CARGO_TARGET_DIR=/tmp/harn-perf-hotspots-test-target cargo run --quiet --bin harn -- test conformance --filter types/shape_runtime_validation`
- `make lint-test-patterns`
- pre-commit hook: changed-package clippy for `harn-vm`
- pre-push hook: targeted local checks

## Notes

I also tested a closure-environment counter for skipping late-binding scans, but dropped it because the added state did not justify itself under repeated fixture checks.