### PR TITLE
Honor catalog provider for direct model IDs in model-info

### DIFF
--- a/crates/harn-vm/src/llm_config.rs
+++ b/crates/harn-vm/src/llm_config.rs
@@ -475,6 +475,14 @@ fn infer_provider_with_config(
     if model_id.starts_with("huggingface:") || model_id.starts_with("hf:") {
         return crate::llm::provider::ProviderInference::builtin("huggingface");
     }
+    // Exact catalog rows are the most authoritative declaration of where
+    // a model is hosted: any pattern-based inference rule is necessarily
+    // less specific than `[models."<id>"].provider = "<name>"`. Catalogs
+    // include user overlays, so users can still re-home a model by
+    // setting a catalog entry in their own providers.toml.
+    if let Some(model) = config.models.get(model_id) {
+        return crate::llm::provider::ProviderInference::builtin(model.provider.clone());
+    }
     for rule in &config.inference_rules {
         if let Some(exact) = &rule.exact {
             if model_id == exact {
@@ -1063,6 +1071,66 @@ mod tests {
                 None => std::env::remove_var("HARN_DEFAULT_PROVIDER"),
             }
         }
+    }
+
+    #[test]
+    fn test_direct_catalog_model_id_resolves_to_catalog_provider() {
+        // Bare model IDs that the embedded catalog hosts on Cerebras must
+        // not be misrouted by the generic `gpt-*` / single-slash inference
+        // fallbacks. Regression for harn#2142 (model-info routed
+        // `gpt-oss-120b` to openai, breaking Burin TUI credential checks).
+        let _guard = crate::llm::env_lock().lock().expect("env lock");
+        let prev_default_provider = std::env::var("HARN_DEFAULT_PROVIDER").ok();
+        unsafe {
+            std::env::remove_var("HARN_DEFAULT_PROVIDER");
+        }
+
+        for model in ["gpt-oss-120b", "llama-3.3-70b", "qwen-3-coder-480b"] {
+            assert_eq!(
+                infer_provider(model),
+                "cerebras",
+                "{model} should route to its catalog provider"
+            );
+            let resolved = resolve_model_info(model);
+            assert_eq!(resolved.id, model);
+            assert_eq!(resolved.provider, "cerebras");
+        }
+
+        unsafe {
+            match prev_default_provider {
+                Some(value) => std::env::set_var("HARN_DEFAULT_PROVIDER", value),
+                None => std::env::remove_var("HARN_DEFAULT_PROVIDER"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_user_catalog_overlay_re_homes_model_provider() {
+        // Users can re-home a built-in model by overlaying a catalog row;
+        // the exact-match catalog lookup must honor overlays as well as the
+        // embedded TOML.
+        reset_overrides();
+        let mut overlay = ProvidersConfig::default();
+        overlay.models.insert(
+            "gpt-4o".to_string(),
+            ModelDef {
+                name: "GPT-4o via OpenRouter".to_string(),
+                provider: "openrouter".to_string(),
+                context_window: 128_000,
+                runtime_context_window: None,
+                stream_timeout: None,
+                capabilities: Vec::new(),
+                pricing: None,
+                deprecated: false,
+                deprecation_note: None,
+                quality_tags: Vec::new(),
+            },
+        );
+        set_user_overrides(Some(overlay));
+
+        assert_eq!(infer_provider("gpt-4o"), "openrouter");
+
+        reset_overrides();
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `harn model-info gpt-oss-120b` was returning `provider = openai` via the generic `gpt-*` prefix fallback, while the embedded catalog row for `gpt-oss-120b` declares `provider = cerebras`. Burin TUI trusted the top-level `provider` for credential checks and rejected valid `CEREBRAS_API_KEY` setups while prompting for `OPENAI_API_KEY`.
- Fix in `infer_provider_with_config`: look up `config.models[model_id].provider` immediately after the transport-prefix early returns. An exact catalog row is strictly more specific than any pattern-based inference rule and is the right declaration of where a model is hosted.
- The catalog includes user overlays, so users can re-home a built-in model (e.g. point `gpt-4o` at `openrouter`) by adding `[models."gpt-4o"]` to their own `providers.toml`. New test pins that behavior.

Fixes #2142.

## Verification

- `cargo test -p harn-vm` — 2427 unit tests pass, including two new regressions:
  - `test_direct_catalog_model_id_resolves_to_catalog_provider` covers `gpt-oss-120b`, `llama-3.3-70b`, `qwen-3-coder-480b`.
  - `test_user_catalog_overlay_re_homes_model_provider` covers user-supplied overlays.
- `cargo run -p harn-cli -- model-info gpt-oss-120b` now reports `"provider":"cerebras"` matching `"catalog":{"provider":"cerebras",...}`.
- `cargo test -p harn-serve` and the rest of `harn-cli` pass. Three pre-existing failures in `crates/harn-cli/tests/bytecode_cache.rs` reproduce on `origin/main` unrelated to this change and have been flagged separately.

## Test plan

- [x] `cargo test -p harn-vm`
- [x] `cargo run -p harn-cli -- model-info gpt-oss-120b` matches `catalog.provider`

🤖 Generated with [Claude Code](https://claude.com/claude-code)