### PR TITLE
harn test: emit user-test JUnit and JSON reports (#2146)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ condensed series summaries instead of full per-patch history.
 
 ## Unreleased
 
+### Added
+
+- **`harn test --junit`/`--json-out` now produce reports for user Harn
+  tests (#2146).** The CLI accepted both flags before but silently
+  dropped them outside the conformance path, leaving CI and perf-audit
+  consumers parsing colourised terminal output. The writer is now shared
+  across user tests and conformance: a `<testsuites>`-wrapped JUnit XML
+  with `classname`/`file` attributes for each case, and a versioned JSON
+  report (schemaVersion 1) with per-case `name`/`file`/`classname`/
+  `outcome`/`duration_ms` plus suite-level `summary`. A missing or
+  unwritable report directory now fails the run with a clear diagnostic
+  instead of succeeding silently. `--watch` rejects both flags up-front
+  since the watch loop never terminates.
+
 ### Fixed
 
 - **`harn fix` now finishes recursive migrations with invalid fixtures

--- a/crates/harn-cli/src/commands/test.rs
+++ b/crates/harn-cli/src/commands/test.rs
@@ -12,8 +12,24 @@ use crate::commands::run::{
 };
 use crate::env_guard::ScopedEnvVar;
 use crate::json_envelope::{self, JsonEnvelope, JsonError};
+use crate::test_report::{self, TestCaseReport, TestOutcome, TestReport};
 use crate::test_runner;
 use crate::{execute_with_skill_dirs, execute_with_skill_dirs_and_harness};
+
+/// Report-writing options threaded into `run_user_tests`. Each `Some`
+/// path triggers a write at end-of-run; a missing parent directory or
+/// I/O error fails the run loudly instead of silently succeeding.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct UserTestReportConfig<'a> {
+    pub junit_path: Option<&'a str>,
+    pub json_out_path: Option<&'a str>,
+}
+
+impl UserTestReportConfig<'_> {
+    pub fn is_empty(&self) -> bool {
+        self.junit_path.is_none() && self.json_out_path.is_none()
+    }
+}
 
 pub(crate) const CONFORMANCE_TEST_SCHEMA_VERSION: u32 = 1;
 
@@ -155,47 +171,34 @@ fn error_line_matches(actual_error: &str, pattern: &str) -> bool {
     }
 }
 
-fn xml_escape(s: &str) -> String {
-    s.replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-        .replace('"', "&quot;")
-        .replace('\'', "&apos;")
-}
-
-fn write_junit_xml(path: &str, results: &[(String, bool, String, u64)], announce: bool) {
-    let total = results.len();
-    let failures = results.iter().filter(|r| !r.1).count();
-    let total_time: f64 = results.iter().map(|r| r.3 as f64 / 1000.0).sum();
-
-    let mut xml = String::new();
-    xml.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
-    xml.push_str(&format!(
-        "<testsuite name=\"harn\" tests=\"{total}\" failures=\"{failures}\" time=\"{total_time:.3}\">\n"
-    ));
-    for (name, passed, error_msg, duration_ms) in results {
-        let time = *duration_ms as f64 / 1000.0;
-        let escaped_name = xml_escape(name);
-        xml.push_str(&format!(
-            "  <testcase name=\"{escaped_name}\" time=\"{time:.3}\""
-        ));
-        if *passed {
-            xml.push_str(" />\n");
-        } else {
-            xml.push_str(">\n");
-            let escaped = xml_escape(error_msg);
-            xml.push_str(&format!(
-                "    <failure message=\"test failed\">{escaped}</failure>\n"
-            ));
-            xml.push_str("  </testcase>\n");
+/// Write a JUnit XML report or exit non-zero with a clear diagnostic.
+/// Centralised so every `harn test` mode fails loudly on bad paths
+/// (issue #2146).
+fn write_junit_xml_or_exit(path: &str, report: &TestReport, announce: bool) {
+    match test_report::write_junit(path, report) {
+        Ok(written) => {
+            if announce {
+                println!("JUnit XML written to {}", written.display());
+            }
+        }
+        Err(error) => {
+            eprintln!("{error}");
+            process::exit(1);
         }
     }
-    xml.push_str("</testsuite>\n");
+}
 
-    if let Err(e) = fs::write(path, &xml) {
-        eprintln!("Failed to write JUnit XML to {path}: {e}");
-    } else if announce {
-        println!("JUnit XML written to {path}");
+fn write_user_test_json_or_exit(path: &str, report: &TestReport, announce: bool) {
+    match test_report::write_json(path, report) {
+        Ok(written) => {
+            if announce {
+                println!("JSON report written to {}", written.display());
+            }
+        }
+        Err(error) => {
+            eprintln!("{error}");
+            process::exit(1);
+        }
     }
 }
 
@@ -1270,7 +1273,7 @@ pub(crate) async fn run_conformance_tests(
     let mut errors: Vec<String> = Vec::new();
     let mut json_results: Vec<ConformanceJsonResult> = Vec::new();
     let mut json_summary = ConformanceJsonSummary::default();
-    let mut junit_results: Vec<(String, bool, String, u64)> = Vec::new();
+    let mut report = TestReport::new("conformance", Some(&suite_root));
 
     let harn_files = match resolve_conformance_selection(&suite_root, selection) {
         Ok(files) => files,
@@ -1363,16 +1366,18 @@ pub(crate) async fn run_conformance_tests(
                 outcome,
                 ConformanceJsonOutcome::Pass | ConformanceJsonOutcome::XfailExpected
             );
-            junit_results.push((
-                rel_path.clone(),
-                junit_passed,
-                if junit_passed {
-                    String::new()
+            report.push(TestCaseReport {
+                name: rel_path.clone(),
+                file: rel_path.clone(),
+                classname: rel_path.clone(),
+                outcome: if junit_passed {
+                    TestOutcome::Passed
                 } else {
-                    message.clone().unwrap_or_default()
+                    TestOutcome::Failed
                 },
-                evaluation.duration_ms,
-            ));
+                duration_ms: evaluation.duration_ms,
+                message: if junit_passed { None } else { message.clone() },
+            });
             json_results.push(ConformanceJsonResult {
                 name: rel_path.clone(),
                 outcome,
@@ -1392,12 +1397,14 @@ pub(crate) async fn run_conformance_tests(
             } else {
                 println!("  \x1b[32mPASS\x1b[0m  {rel_path}");
             }
-            junit_results.push((
-                rel_path.clone(),
-                true,
-                String::new(),
-                evaluation.duration_ms,
-            ));
+            report.push(TestCaseReport {
+                name: rel_path.clone(),
+                file: rel_path.clone(),
+                classname: rel_path.clone(),
+                outcome: TestOutcome::Passed,
+                duration_ms: evaluation.duration_ms,
+                message: None,
+            });
             passed += 1;
         } else {
             if show_timing {
@@ -1412,16 +1419,24 @@ pub(crate) async fn run_conformance_tests(
                 .message
                 .unwrap_or_else(|| format!("{rel_path}: failed without diagnostic message"));
             errors.push(msg.clone());
-            junit_results.push((rel_path.clone(), false, msg, evaluation.duration_ms));
+            report.push(TestCaseReport {
+                name: rel_path.clone(),
+                file: rel_path.clone(),
+                classname: rel_path.clone(),
+                outcome: TestOutcome::Failed,
+                duration_ms: evaluation.duration_ms,
+                message: Some(msg),
+            });
             failed += 1;
         }
     }
 
     let total_duration_ms = suite_start.elapsed().as_millis() as u64;
+    report.set_duration_ms(total_duration_ms);
 
     if options.json {
         if let Some(path) = junit_path {
-            write_junit_xml(path, &junit_results, false);
+            write_junit_xml_or_exit(path, &report, false);
         }
         let snapshot_key = conformance_snapshot_key(&suite_root, &selected_harn_files);
         let ok = json_summary.is_success();
@@ -1476,32 +1491,11 @@ pub(crate) async fn run_conformance_tests(
         println!();
         println!("Total time: {total_duration_ms} ms");
 
-        let mut durations: Vec<u64> = junit_results.iter().map(|r| r.3).collect();
-        durations.sort();
-
-        if !durations.is_empty() {
-            let n = durations.len();
-            let p50 = durations[n * 50 / 100];
-            let p95 = durations[n * 95 / 100];
-            let p99 = durations[(n * 99 / 100).min(n - 1)];
-            let avg = durations.iter().sum::<u64>() / n as u64;
-            println!("Per-test: avg={avg} ms  p50={p50} ms  p95={p95} ms  p99={p99} ms");
-        }
-
-        let mut by_time: Vec<&(String, bool, String, u64)> = junit_results.iter().collect();
-        by_time.sort_by_key(|entry| std::cmp::Reverse(entry.3));
-        let top_n = by_time.len().min(10);
-        if top_n > 0 {
-            println!();
-            println!("Slowest {top_n} tests:");
-            for entry in &by_time[..top_n] {
-                println!("  {:>6} ms  {}", entry.3, entry.0);
-            }
-        }
+        print_per_test_timing(&report);
     }
 
     if let Some(path) = junit_path {
-        write_junit_xml(path, &junit_results, true);
+        write_junit_xml_or_exit(path, &report, true);
     }
 
     if !errors.is_empty() {
@@ -1582,6 +1576,75 @@ fn user_test_progress(verbose: bool) -> test_runner::TestRunProgress {
             }
         }
     })
+}
+
+/// Print avg/p50/p95/p99 and the slowest-10 from a finalized
+/// [`TestReport`]. Used by the conformance path; the user-test path
+/// has its own variant that also groups by file (see
+/// [`print_user_test_timing`]).
+fn print_per_test_timing(report: &TestReport) {
+    let mut durations: Vec<u64> = report.cases.iter().map(|c| c.duration_ms).collect();
+    if durations.is_empty() {
+        return;
+    }
+    durations.sort();
+    let n = durations.len();
+    let p50 = durations[n * 50 / 100];
+    let p95 = durations[n * 95 / 100];
+    let p99 = durations[(n * 99 / 100).min(n - 1)];
+    let avg = durations.iter().sum::<u64>() / n as u64;
+    println!("Per-test: avg={avg} ms  p50={p50} ms  p95={p95} ms  p99={p99} ms");
+
+    let mut by_time: Vec<&TestCaseReport> = report.cases.iter().collect();
+    by_time.sort_by_key(|case| std::cmp::Reverse(case.duration_ms));
+    let top_n = by_time.len().min(10);
+    if top_n > 0 {
+        println!();
+        println!("Slowest {top_n} tests:");
+        for case in &by_time[..top_n] {
+            println!("  {:>6} ms  {}", case.duration_ms, case.name);
+        }
+    }
+}
+
+/// Convert a [`TestSummary`] (raw runner output) into the
+/// machine-readable [`TestReport`] shape consumed by `--junit` and
+/// `--json-out`. File paths are made relative to `suite_root` so CI
+/// uploads and snapshot diffs are portable across machines.
+fn user_test_report_from_summary(
+    suite_root: &Path,
+    summary: &test_runner::TestSummary,
+) -> TestReport {
+    let mut report = TestReport::new("user", Some(suite_root));
+    for result in &summary.results {
+        let outcome = if result.passed {
+            TestOutcome::Passed
+        } else if result
+            .error
+            .as_deref()
+            .is_some_and(|msg| msg.starts_with("timed out after"))
+        {
+            TestOutcome::TimedOut
+        } else {
+            TestOutcome::Failed
+        };
+        let file_path = PathBuf::from(&result.file);
+        let relative = file_path
+            .strip_prefix(suite_root)
+            .ok()
+            .map(logical_path)
+            .unwrap_or_else(|| result.file.clone());
+        report.push(TestCaseReport {
+            name: result.name.clone(),
+            file: relative.clone(),
+            classname: relative,
+            outcome,
+            duration_ms: result.duration_ms,
+            message: result.error.clone(),
+        });
+    }
+    report.set_duration_ms(summary.duration_ms);
+    report
 }
 
 fn print_test_results(summary: &test_runner::TestSummary, options: UserTestOutputOptions) {
@@ -1744,11 +1807,20 @@ pub(crate) async fn run_user_tests(
     verbose: bool,
     timing: bool,
     cli_skill_dirs: &[PathBuf],
+    report_config: UserTestReportConfig<'_>,
 ) {
     let path = PathBuf::from(path_str);
     if !path.exists() {
         eprintln!("Path not found: {path_str}");
         process::exit(1);
+    }
+    if !report_config.is_empty() {
+        if let Some(p) = report_config.junit_path {
+            preflight_report_path(p);
+        }
+        if let Some(p) = report_config.json_out_path {
+            preflight_report_path(p);
+        }
     }
     let summary = run_user_tests_once(
         &path,
@@ -1760,8 +1832,39 @@ pub(crate) async fn run_user_tests(
         cli_skill_dirs,
     )
     .await;
+
+    if !report_config.is_empty() {
+        let suite_root = path.canonicalize().unwrap_or(path.clone());
+        let report = user_test_report_from_summary(&suite_root, &summary);
+        if let Some(p) = report_config.junit_path {
+            write_junit_xml_or_exit(p, &report, true);
+        }
+        if let Some(p) = report_config.json_out_path {
+            write_user_test_json_or_exit(p, &report, true);
+        }
+    }
+
     if summary.failed > 0 {
         process::exit(1);
+    }
+}
+
+/// Validate report destinations before running the suite so a typo
+/// in the output path is caught up-front rather than after a long
+/// test run. Mirrors the post-run write check inside the writers but
+/// short-circuits "I just spent 10 minutes running tests and got no
+/// report" cases.
+fn preflight_report_path(path: &str) {
+    let buf = PathBuf::from(path);
+    if let Some(parent) = buf.parent().filter(|p| !p.as_os_str().is_empty()) {
+        if !parent.exists() {
+            eprintln!("report directory does not exist: {}", parent.display());
+            process::exit(1);
+        }
+        if !parent.is_dir() {
+            eprintln!("report directory is not a directory: {}", parent.display());
+            process::exit(1);
+        }
     }
 }
 

--- a/crates/harn-cli/src/json_envelope.rs
+++ b/crates/harn-cli/src/json_envelope.rs
@@ -207,6 +207,13 @@ pub fn catalog() -> Vec<SchemaEntry> {
             schema_json: None,
         },
         SchemaEntry {
+            command: "test --json-out",
+            schema_version: crate::test_report::USER_TEST_REPORT_SCHEMA_VERSION,
+            description:
+                "User-test report (`--json-out`): per-case name/file/classname/outcome/duration plus suite-level summary.",
+            schema_json: None,
+        },
+        SchemaEntry {
             command: "time run",
             schema_version: crate::commands::time::TIME_RUN_SCHEMA_VERSION,
             description:

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -11,6 +11,7 @@ pub mod package;
 mod provider_bootstrap;
 pub mod skill_loader;
 pub mod skill_provenance;
+pub mod test_report;
 pub mod test_runner;
 #[doc(hidden)]
 pub mod tests;
@@ -662,6 +663,11 @@ async fn async_main() {
             }
         }
         Command::Test(args) => {
+            if args.watch && (args.junit.is_some() || args.json_out.is_some()) {
+                command_error(
+                    "`harn test --watch` cannot combine with --junit or --json-out; the watch loop never terminates so the report would never be written",
+                );
+            }
             if args.target.as_deref() == Some("agents-conformance") {
                 if args.selection.is_some() {
                     command_error(
@@ -835,6 +841,10 @@ async fn async_main() {
                             args.verbose,
                             args.timing,
                             &cli_skill_dirs,
+                            commands::test::UserTestReportConfig {
+                                junit_path: args.junit.as_deref(),
+                                json_out_path: args.json_out.as_deref(),
+                            },
                         )
                         .await;
                     }
@@ -869,6 +879,10 @@ async fn async_main() {
                             args.verbose,
                             args.timing,
                             &cli_skill_dirs,
+                            commands::test::UserTestReportConfig {
+                                junit_path: args.junit.as_deref(),
+                                json_out_path: args.json_out.as_deref(),
+                            },
                         )
                         .await;
                     }

--- a/crates/harn-cli/src/test_report.rs
+++ b/crates/harn-cli/src/test_report.rs
@@ -1,0 +1,320 @@
+//! Machine-readable test reports for `harn test`.
+//!
+//! User and conformance suites both feed the same writer so the JUnit
+//! XML and `--json-out` payloads have a single source of truth. CI
+//! systems get a uniform schema; performance audits get per-file and
+//! per-test timing without scraping ANSI-coloured terminal output.
+//!
+//! The writers fail loudly: a missing or unwritable destination
+//! returns an error so the CLI can exit non-zero rather than silently
+//! succeed (issue #2146).
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+
+pub const USER_TEST_REPORT_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TestOutcome {
+    Passed,
+    Failed,
+    TimedOut,
+    Skipped,
+}
+
+impl TestOutcome {
+    fn is_failure(self) -> bool {
+        matches!(self, TestOutcome::Failed | TestOutcome::TimedOut)
+    }
+
+    fn is_skipped(self) -> bool {
+        matches!(self, TestOutcome::Skipped)
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TestCaseReport {
+    pub name: String,
+    pub file: String,
+    pub classname: String,
+    pub outcome: TestOutcome,
+    pub duration_ms: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct TestReportSummary {
+    pub total: u64,
+    pub passed: u64,
+    pub failed: u64,
+    pub timed_out: u64,
+    pub skipped: u64,
+}
+
+impl TestReportSummary {
+    fn record(&mut self, outcome: TestOutcome) {
+        self.total += 1;
+        match outcome {
+            TestOutcome::Passed => self.passed += 1,
+            TestOutcome::Failed => self.failed += 1,
+            TestOutcome::TimedOut => self.timed_out += 1,
+            TestOutcome::Skipped => self.skipped += 1,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TestReport {
+    #[serde(rename = "schemaVersion")]
+    pub schema_version: u32,
+    pub suite: String,
+    pub root: Option<String>,
+    pub duration_ms: u64,
+    pub summary: TestReportSummary,
+    pub cases: Vec<TestCaseReport>,
+}
+
+impl TestReport {
+    pub fn new(suite: impl Into<String>, root: Option<&Path>) -> Self {
+        Self {
+            schema_version: USER_TEST_REPORT_SCHEMA_VERSION,
+            suite: suite.into(),
+            root: root.map(|p| p.display().to_string()),
+            duration_ms: 0,
+            summary: TestReportSummary::default(),
+            cases: Vec::new(),
+        }
+    }
+
+    pub fn push(&mut self, case: TestCaseReport) {
+        self.summary.record(case.outcome);
+        self.cases.push(case);
+    }
+
+    pub fn set_duration_ms(&mut self, duration_ms: u64) {
+        self.duration_ms = duration_ms;
+    }
+}
+
+fn xml_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&apos;")
+}
+
+fn ensure_parent_writable(path: &Path) -> Result<(), String> {
+    let parent = path.parent().filter(|p| !p.as_os_str().is_empty());
+    if let Some(parent) = parent {
+        if !parent.exists() {
+            return Err(format!(
+                "report directory does not exist: {}",
+                parent.display()
+            ));
+        }
+        if !parent.is_dir() {
+            return Err(format!(
+                "report directory is not a directory: {}",
+                parent.display()
+            ));
+        }
+    }
+    Ok(())
+}
+
+pub fn write_junit(path: &str, report: &TestReport) -> Result<PathBuf, String> {
+    let path_buf = PathBuf::from(path);
+    ensure_parent_writable(&path_buf)?;
+
+    let suite_time = report.duration_ms as f64 / 1000.0;
+    let suite_name = xml_escape(&report.suite);
+    let tests = report.summary.total;
+    let failures = report.summary.failed + report.summary.timed_out;
+    let skipped = report.summary.skipped;
+
+    let mut xml = String::new();
+    xml.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+    xml.push_str(&format!(
+        "<testsuites name=\"{suite_name}\" tests=\"{tests}\" failures=\"{failures}\" skipped=\"{skipped}\" time=\"{suite_time:.3}\">\n"
+    ));
+    xml.push_str(&format!(
+        "  <testsuite name=\"{suite_name}\" tests=\"{tests}\" failures=\"{failures}\" skipped=\"{skipped}\" time=\"{suite_time:.3}\">\n"
+    ));
+    for case in &report.cases {
+        let time = case.duration_ms as f64 / 1000.0;
+        let escaped_name = xml_escape(&case.name);
+        let escaped_classname = xml_escape(&case.classname);
+        let escaped_file = xml_escape(&case.file);
+        xml.push_str(&format!(
+            "    <testcase name=\"{escaped_name}\" classname=\"{escaped_classname}\" file=\"{escaped_file}\" time=\"{time:.3}\""
+        ));
+        if case.outcome == TestOutcome::Passed {
+            xml.push_str(" />\n");
+            continue;
+        }
+        xml.push_str(">\n");
+        let body = case.message.as_deref().unwrap_or_default();
+        let escaped_body = xml_escape(body);
+        if case.outcome.is_skipped() {
+            xml.push_str(&format!("      <skipped message=\"{escaped_body}\" />\n"));
+        } else if case.outcome.is_failure() {
+            let kind = if matches!(case.outcome, TestOutcome::TimedOut) {
+                "timeout"
+            } else {
+                "AssertionError"
+            };
+            xml.push_str(&format!(
+                "      <failure type=\"{kind}\" message=\"test failed\">{escaped_body}</failure>\n"
+            ));
+        }
+        xml.push_str("    </testcase>\n");
+    }
+    xml.push_str("  </testsuite>\n");
+    xml.push_str("</testsuites>\n");
+
+    fs::write(&path_buf, &xml).map_err(|error| {
+        format!(
+            "failed to write JUnit XML to {}: {error}",
+            path_buf.display()
+        )
+    })?;
+    Ok(path_buf)
+}
+
+pub fn write_json(path: &str, report: &TestReport) -> Result<PathBuf, String> {
+    let path_buf = PathBuf::from(path);
+    ensure_parent_writable(&path_buf)?;
+    let rendered = serde_json::to_string_pretty(report)
+        .map_err(|error| format!("failed to serialize test report JSON: {error}"))?;
+    fs::write(&path_buf, rendered).map_err(|error| {
+        format!(
+            "failed to write JSON report to {}: {error}",
+            path_buf.display()
+        )
+    })?;
+    Ok(path_buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_report() -> TestReport {
+        let mut report = TestReport::new("user", None);
+        report.push(TestCaseReport {
+            name: "test_alpha".into(),
+            file: "suite/a.harn".into(),
+            classname: "suite/a.harn".into(),
+            outcome: TestOutcome::Passed,
+            duration_ms: 12,
+            message: None,
+        });
+        report.push(TestCaseReport {
+            name: "test_beta".into(),
+            file: "suite/b.harn".into(),
+            classname: "suite/b.harn".into(),
+            outcome: TestOutcome::Failed,
+            duration_ms: 34,
+            message: Some("expected 1 == 2".into()),
+        });
+        report.push(TestCaseReport {
+            name: "test_gamma".into(),
+            file: "suite/c.harn".into(),
+            classname: "suite/c.harn".into(),
+            outcome: TestOutcome::TimedOut,
+            duration_ms: 30_000,
+            message: Some("timed out after 30000ms".into()),
+        });
+        report.push(TestCaseReport {
+            name: "test_delta".into(),
+            file: "suite/d.harn".into(),
+            classname: "suite/d.harn".into(),
+            outcome: TestOutcome::Skipped,
+            duration_ms: 0,
+            message: Some("xfail: flaky".into()),
+        });
+        report.set_duration_ms(100);
+        report
+    }
+
+    #[test]
+    fn summary_counts_outcomes() {
+        let report = sample_report();
+        assert_eq!(report.summary.total, 4);
+        assert_eq!(report.summary.passed, 1);
+        assert_eq!(report.summary.failed, 1);
+        assert_eq!(report.summary.timed_out, 1);
+        assert_eq!(report.summary.skipped, 1);
+    }
+
+    #[test]
+    fn write_junit_renders_failure_and_skip() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("report.xml");
+        let report = sample_report();
+        write_junit(path.to_str().unwrap(), &report).unwrap();
+        let xml = std::fs::read_to_string(&path).unwrap();
+        assert!(xml.contains("<testsuites"));
+        assert!(xml.contains(r#"tests="4" failures="2" skipped="1""#));
+        assert!(xml.contains(r#"name="test_alpha""#));
+        assert!(xml.contains(r#"<failure type="AssertionError""#));
+        assert!(xml.contains(r#"<failure type="timeout""#));
+        assert!(xml.contains("<skipped"));
+    }
+
+    #[test]
+    fn write_json_round_trips_through_serde() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("report.json");
+        let report = sample_report();
+        write_json(path.to_str().unwrap(), &report).unwrap();
+        let text = std::fs::read_to_string(&path).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(value["schemaVersion"], USER_TEST_REPORT_SCHEMA_VERSION);
+        assert_eq!(value["summary"]["total"], 4);
+        assert_eq!(value["summary"]["passed"], 1);
+        assert_eq!(value["summary"]["failed"], 1);
+        assert_eq!(value["summary"]["timed_out"], 1);
+        assert_eq!(value["summary"]["skipped"], 1);
+        let cases = value["cases"].as_array().unwrap();
+        assert_eq!(cases.len(), 4);
+        assert_eq!(cases[0]["outcome"], "passed");
+        assert_eq!(cases[1]["outcome"], "failed");
+        assert_eq!(cases[2]["outcome"], "timed_out");
+        assert_eq!(cases[3]["outcome"], "skipped");
+    }
+
+    #[test]
+    fn missing_parent_directory_returns_error() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("does/not/exist/report.xml");
+        let err = write_junit(path.to_str().unwrap(), &sample_report()).unwrap_err();
+        assert!(
+            err.contains("report directory does not exist"),
+            "unexpected error: {err}"
+        );
+        let err = write_json(path.to_str().unwrap(), &sample_report()).unwrap_err();
+        assert!(
+            err.contains("report directory does not exist"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn parent_must_be_a_directory() {
+        let temp = tempfile::tempdir().unwrap();
+        let parent = temp.path().join("notadir");
+        std::fs::write(&parent, "x").unwrap();
+        let path = parent.join("report.xml");
+        let err = write_junit(path.to_str().unwrap(), &sample_report()).unwrap_err();
+        assert!(
+            err.contains("is not a directory"),
+            "unexpected error: {err}"
+        );
+    }
+}

--- a/crates/harn-cli/tests/user_test_reports_cli.rs
+++ b/crates/harn-cli/tests/user_test_reports_cli.rs
@@ -1,0 +1,190 @@
+//! End-to-end coverage for `harn test --junit` / `--json-out` on user
+//! Harn tests. Regression guard for issue #2146: the CLI used to accept
+//! both flags but silently drop them for user-test runs.
+
+mod test_util;
+
+use std::process::Output;
+
+use serde_json::Value;
+use tempfile::TempDir;
+use test_util::process::harn_e2e_command;
+
+const PASS_PIPELINE: &str = "pipeline test_pass(task) {\n  log(\"ok\")\n}\n";
+const FAIL_PIPELINE: &str = "pipeline test_fail(task) {\n  assert_eq(1, 2)\n}\n";
+
+fn write_fixture(root: &std::path::Path, relative: &str, source: &str) {
+    let path = root.join(relative);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).expect("create fixture dir");
+    }
+    std::fs::write(&path, source).expect("write fixture");
+}
+
+fn run_test(temp: &TempDir, extra: &[&str]) -> Output {
+    let mut args = vec!["test", "suite", "--timeout", "10000"];
+    args.extend_from_slice(extra);
+    harn_e2e_command()
+        .current_dir(temp.path())
+        .args(&args)
+        .output()
+        .expect("spawn harn test")
+}
+
+#[ignore = "binary surface — moves to slow E2E/smoke job (issue #1069)"]
+#[test]
+fn junit_and_json_out_written_for_passing_user_tests() {
+    let temp = TempDir::new().expect("tempdir");
+    write_fixture(temp.path(), "suite/test_pass.harn", PASS_PIPELINE);
+
+    let junit = temp.path().join("report.xml");
+    let json_out = temp.path().join("report.json");
+
+    let output = run_test(
+        &temp,
+        &[
+            "--junit",
+            junit.to_str().unwrap(),
+            "--json-out",
+            json_out.to_str().unwrap(),
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "exit={:?} stderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(junit.is_file(), "JUnit report was not written");
+    assert!(json_out.is_file(), "JSON report was not written");
+
+    let xml = std::fs::read_to_string(&junit).expect("read JUnit");
+    assert!(
+        xml.contains("<testsuites"),
+        "missing testsuites wrapper: {xml}"
+    );
+    assert!(
+        xml.contains(r#"name="test_pass""#),
+        "missing testcase name: {xml}"
+    );
+    assert!(
+        xml.contains(r#"failures="0""#),
+        "expected zero failures: {xml}"
+    );
+
+    let json: Value = serde_json::from_str(&std::fs::read_to_string(&json_out).expect("read JSON"))
+        .expect("parse JSON");
+    assert_eq!(json["schemaVersion"], 1);
+    assert_eq!(json["summary"]["total"], 1);
+    assert_eq!(json["summary"]["passed"], 1);
+    assert_eq!(json["summary"]["failed"], 0);
+    assert_eq!(json["cases"][0]["name"], "test_pass");
+    assert_eq!(json["cases"][0]["outcome"], "passed");
+}
+
+#[ignore = "binary surface — moves to slow E2E/smoke job (issue #1069)"]
+#[test]
+fn junit_and_json_out_capture_failures_with_exit_code_one() {
+    let temp = TempDir::new().expect("tempdir");
+    write_fixture(temp.path(), "suite/test_pass.harn", PASS_PIPELINE);
+    write_fixture(temp.path(), "suite/test_fail.harn", FAIL_PIPELINE);
+
+    let junit = temp.path().join("report.xml");
+    let json_out = temp.path().join("report.json");
+
+    let output = run_test(
+        &temp,
+        &[
+            "--junit",
+            junit.to_str().unwrap(),
+            "--json-out",
+            json_out.to_str().unwrap(),
+        ],
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "expected exit 1 on failure, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let xml = std::fs::read_to_string(&junit).expect("read JUnit");
+    assert!(
+        xml.contains(r#"failures="1""#),
+        "expected 1 failure in XML: {xml}"
+    );
+    assert!(
+        xml.contains("<failure"),
+        "expected <failure> element in XML: {xml}"
+    );
+
+    let json: Value = serde_json::from_str(&std::fs::read_to_string(&json_out).expect("read JSON"))
+        .expect("parse JSON");
+    assert_eq!(json["summary"]["total"], 2);
+    assert_eq!(json["summary"]["passed"], 1);
+    assert_eq!(json["summary"]["failed"], 1);
+    let cases = json["cases"].as_array().expect("cases array");
+    let fail_case = cases
+        .iter()
+        .find(|c| c["name"] == "test_fail")
+        .expect("missing failing case");
+    assert_eq!(fail_case["outcome"], "failed");
+    assert!(
+        fail_case["message"].as_str().is_some_and(|m| !m.is_empty()),
+        "failure message missing: {fail_case}"
+    );
+}
+
+#[ignore = "binary surface — moves to slow E2E/smoke job (issue #1069)"]
+#[test]
+fn unwritable_report_path_fails_loudly_before_running_tests() {
+    let temp = TempDir::new().expect("tempdir");
+    write_fixture(temp.path(), "suite/test_pass.harn", PASS_PIPELINE);
+
+    let bad = temp.path().join("does/not/exist/report.xml");
+    let output = run_test(&temp, &["--junit", bad.to_str().unwrap()]);
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "expected exit 1 when report directory is missing, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("report directory does not exist"),
+        "expected diagnostic about missing directory, got: {stderr}"
+    );
+    assert!(
+        !bad.exists(),
+        "no partial JUnit file should have been written"
+    );
+}
+
+#[ignore = "binary surface — moves to slow E2E/smoke job (issue #1069)"]
+#[test]
+fn watch_mode_rejects_report_flags() {
+    let temp = TempDir::new().expect("tempdir");
+    write_fixture(temp.path(), "suite/test_pass.harn", PASS_PIPELINE);
+
+    let junit = temp.path().join("report.xml");
+    let output = harn_e2e_command()
+        .current_dir(temp.path())
+        .args([
+            "test",
+            "suite",
+            "--watch",
+            "--junit",
+            junit.to_str().unwrap(),
+        ])
+        .output()
+        .expect("spawn harn test --watch --junit");
+    assert!(
+        !output.status.success(),
+        "expected --watch + --junit combination to be rejected"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--watch"),
+        "expected diagnostic mentioning --watch, got: {stderr}"
+    );
+}

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -286,13 +286,14 @@ harn test agents-conformance --target http://localhost:8080 --api-key "$KEY"
 | `--target <url>` | Harness base URL for `harn test agents-conformance` |
 | `--api-key <key>` | Bearer API key for `harn test agents-conformance` |
 | `--category <name>` | Agents conformance category to run; repeatable or comma-separated |
-| `--json` / `--json-out <path>` | Emit or write the agents conformance leaderboard-shaped JSON report |
+| `--json` | Emit conformance results as JSON to stdout, or the agents-conformance leaderboard report |
+| `--json-out <path>` | Write user-test results (or the agents-conformance report) to a JSON file; schemaVersion 1 |
 | `--workspace-id <id>` / `--session-id <id>` | Reuse existing Harness resources for agents conformance setup |
 | `--parallel` | Run tests concurrently |
-| `--watch` | Re-run tests on file changes |
+| `--watch` | Re-run tests on file changes (mutually exclusive with `--junit` / `--json-out`) |
 | `--verbose` / `-v` | Show per-test timing and detailed failures |
 | `--timing` | Show per-test timing plus summary statistics |
-| `--junit <path>` | Write JUnit XML report |
+| `--junit <path>` | Write JUnit XML report for user tests or conformance; missing or unwritable destinations fail loudly |
 | `--timeout <ms>` | Per-test timeout in milliseconds (default: 30000) |
 | `--record` | Record LLM responses to `.harn-fixtures/` |
 | `--replay` | Replay recorded LLM responses |

--- a/scripts/lint_test_patterns.sh
+++ b/scripts/lint_test_patterns.sh
@@ -148,6 +148,7 @@ is_e2e_subprocess_path() {
     crates/harn-cli/tests/run_exit_codes.rs | \
     crates/harn-cli/tests/skills_cli.rs | \
     crates/harn-cli/tests/trigger_replay_cli.rs | \
+    crates/harn-cli/tests/user_test_reports_cli.rs | \
     crates/harn-cli/tests/orchestrator_http.rs | \
     crates/harn-cli/tests/orchestrator_http/* | \
     crates/harn-cli/tests/support/mcp.rs | \


### PR DESCRIPTION
## Summary

- Add a shared `test_report` module (`crates/harn-cli/src/test_report.rs`) that writes both JUnit XML and a versioned JSON report (schemaVersion 1) for conformance and user-test runs.
- Thread `--junit <path>` and `--json-out <path>` through `harn test <dir>` so user-test runs actually produce reports instead of silently dropping the flags.
- Fail the run with a clear diagnostic (and exit 1) when the report directory is missing or unwritable, before tests even start.
- Reject `--watch` combined with `--junit`/`--json-out` up-front (the watch loop never terminates).

## Background

During the `burin-code` Harn test-speed audit, [this command](https://github.com/burin-labs/harn/issues/2146) silently succeeded without ever writing the JUnit file:

```sh
./scripts/harnw test Sources/BurinCore/Resources/pipelines/tests/ \
  --timeout 30000 --parallel --timing \
  --junit /tmp/burin-harn-timing/full-after-unified-split.xml
```

The CLI plumbing only routed `--junit` into the conformance path; user-test runs went through `run_user_tests`, which never received the path. Performance audits had to scrape colourised terminal output to rank slow tests.

## What changed

| Surface | Before | After |
|---|---|---|
| `harn test <dir> --junit X.xml` | silently ignored | writes `<testsuites>`-wrapped XML with classname/file attrs |
| `harn test <dir> --json-out X.json` | silently ignored | writes versioned JSON: per-case name/file/classname/outcome/duration plus suite-level summary |
| Missing/unwritable report directory | succeeds silently | exits 1 with `report directory does not exist: …` |
| `harn test --watch --junit X.xml` | accepted, then never written | rejected at parse time |
| `harn test conformance --junit X.xml` | flat `<testsuite>` | shares the new `<testsuites>` writer (more standard JUnit, no consumer breakage) |

Schema registered in the `--json-schemas` catalog as `test --json-out` (schemaVersion 1).

## Test plan

- [x] `cargo test -p harn-cli --lib` (677 pass) — covers the new `test_report` module unit tests (round-trip JSON, JUnit XML rendering of failures/skip/timeout, missing-parent error path, non-directory error path).
- [x] `cargo test -p harn-cli --test user_test_reports_cli -- --ignored` — 4 new end-to-end tests:
  - passing run writes both reports with expected shape;
  - failing run exits 1 and captures the failure in both reports;
  - missing parent directory aborts before running tests;
  - `--watch + --junit` is rejected with a clear diagnostic.
- [x] `cargo test -p harn-cli --test conformance_json_cli` (3 pass) — verifies the conformance refactor didn't regress.
- [x] `cargo test -p harn-cli --test json_schemas_cli` (3 pass) — schema catalog still consistent.
- [x] `cargo clippy -p harn-cli --tests -- -D warnings` clean.
- [x] Smoke test on a temp dir matching the burin-code repro: both files are written; flagging a missing directory prints `report directory does not exist: /nope/missing` and exits 1.

Closes #2146.

🤖 Generated with [Claude Code](https://claude.com/claude-code)