### PR TITLE
Add serverless vs dedicated availability to provider catalog

### DIFF
--- a/crates/harn-vm/src/llm/api/errors.rs
+++ b/crates/harn-vm/src/llm/api/errors.rs
@@ -363,6 +363,12 @@ fn is_model_unavailable(lower: &str) -> bool {
         || lower.contains("model unavailable")
         || lower.contains("model is unavailable")
         || lower.contains("model not found")
+        || lower.contains("model_not_available")
+        // Together's wording when a route is listed in `/v1/models` but only
+        // available through a dedicated endpoint; treat like a missing model
+        // so caller fallback logic routes around it instead of surfacing a
+        // generic invalid_request to the agent.
+        || lower.contains("non-serverless model")
 }
 
 #[cfg(test)]
@@ -492,5 +498,30 @@ mod tests {
         let info = classify_llm_error(ErrorCategory::TransientNetwork, "connection reset");
         assert_eq!(info.kind, LlmErrorKind::Transient);
         assert_eq!(info.reason, LlmErrorReason::NetworkError);
+    }
+
+    #[test]
+    fn classifies_together_dedicated_only_route_as_model_unavailable() {
+        // Together returns HTTP 400 + invalid_request_error for routes
+        // listed in `/v1/models` that actually require a dedicated
+        // endpoint. The body wording is stable and distinct from a normal
+        // missing-model error, but callers' fallback logic only kicks in
+        // on `model_unavailable`, so we lift it out of `invalid_request`.
+        let body = concat!(
+            r#"{"error":{"message":"#,
+            r#""Unable to access non-serverless model Qwen/Qwen3-Coder-Next-FP8. "#,
+            r#"Please visit https://api.together.ai/models/Qwen/Qwen3-Coder-Next-FP8 "#,
+            r#"to create and start a new dedicated endpoint for the model.","#,
+            r#""type":"invalid_request_error","code":"model_not_available"}}"#,
+        );
+        let info =
+            classify_provider_http_error("together", reqwest::StatusCode::BAD_REQUEST, None, body);
+        assert_eq!(info.kind, LlmErrorKind::Terminal);
+        assert_eq!(info.reason, LlmErrorReason::ModelUnavailable);
+        assert!(
+            info.message.contains("[model_unavailable]"),
+            "msg was: {}",
+            info.message
+        );
     }
 }

--- a/crates/harn-vm/src/llm/api/ollama.rs
+++ b/crates/harn-vm/src/llm/api/ollama.rs
@@ -843,6 +843,7 @@ mod tests {
                 deprecated: false,
                 deprecation_note: None,
                 quality_tags: Vec::new(),
+                availability: crate::llm_config::ModelAvailability::default(),
             },
         );
         crate::llm_config::set_user_overrides(Some(overlay));
@@ -935,6 +936,7 @@ mod tests {
                 deprecated: false,
                 deprecation_note: None,
                 quality_tags: Vec::new(),
+                availability: crate::llm_config::ModelAvailability::default(),
             },
         );
         crate::llm_config::set_user_overrides(Some(overlay));
@@ -1178,6 +1180,7 @@ mod tests {
                 deprecated: false,
                 deprecation_note: None,
                 quality_tags: Vec::new(),
+                availability: crate::llm_config::ModelAvailability::default(),
             },
         );
         crate::llm_config::set_user_overrides(Some(overlay));

--- a/crates/harn-vm/src/llm/config_builtins.rs
+++ b/crates/harn-vm/src/llm/config_builtins.rs
@@ -936,6 +936,10 @@ fn model_def_to_vm_value(id: &str, model: &llm_config::ModelDef) -> VmValue {
         "quality_tags".to_string(),
         string_list_to_vm_value(model.quality_tags.clone()),
     );
+    dict.insert(
+        "availability".to_string(),
+        VmValue::String(Rc::from(model.availability.as_str())),
+    );
     VmValue::Dict(Rc::new(dict))
 }
 

--- a/crates/harn-vm/src/llm/cost.rs
+++ b/crates/harn-vm/src/llm/cost.rs
@@ -1002,6 +1002,7 @@ mod tests {
                 deprecated: false,
                 deprecation_note: None,
                 quality_tags: Vec::new(),
+                availability: crate::llm_config::ModelAvailability::default(),
             },
         );
         crate::llm_config::set_user_overrides(Some(overlay));

--- a/crates/harn-vm/src/llm/providers.toml
+++ b/crates/harn-vm/src/llm/providers.toml
@@ -863,6 +863,21 @@ provider = "openrouter"
 context_window = 262144
 capabilities = ["tools", "streaming"]
 pricing = { input_per_mtok = 0.22, output_per_mtok = 1.80 }
+availability = "serverless"
+
+# Together lists Qwen3-Coder-Next-FP8 in GET /v1/models alongside its
+# serverless catalog, but normal chat-completion calls fail with
+# `model_not_available` and instruct the caller to create a dedicated
+# endpoint. Carry the catalog row so price/route metadata is preserved,
+# but mark `availability = "dedicated"` so hosts don't surface it as a
+# one-click serverless option.
+[models."Qwen/Qwen3-Coder-Next-FP8"]
+name = "Qwen3 Coder Next FP8 (Together, dedicated)"
+provider = "together"
+context_window = 262144
+capabilities = ["tools", "streaming"]
+pricing = { input_per_mtok = 0.18, output_per_mtok = 0.18 }
+availability = "dedicated"
 
 [models."deepseek/deepseek-v3.2"]
 name = "DeepSeek V3.2"

--- a/crates/harn-vm/src/llm_config.rs
+++ b/crates/harn-vm/src/llm_config.rs
@@ -252,6 +252,50 @@ pub struct ModelDef {
     pub deprecation_note: Option<String>,
     #[serde(default)]
     pub quality_tags: Vec<String>,
+    /// Whether the model can be reached over a normal API-key serverless call,
+    /// or only via a dedicated/provisioned endpoint that the caller must spin
+    /// up out-of-band. Providers like Together list dedicated-only routes
+    /// alongside serverless ones in `/v1/models`, so this metadata lets clients
+    /// avoid presenting them as one-click options.
+    #[serde(default)]
+    pub availability: ModelAvailability,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ModelAvailability {
+    /// Reachable through the provider's normal API-key path with no extra
+    /// setup. The default for cataloged hosted/local models: by cataloging a
+    /// row we are claiming the route works out of the box.
+    #[default]
+    Serverless,
+    /// Requires the caller to provision a dedicated endpoint before requests
+    /// will succeed. The catalog row exists for selection/pricing UI, but
+    /// hosts must not auto-route to it.
+    Dedicated,
+    /// Availability is not known ahead of time. Used for routes that were
+    /// surfaced dynamically (e.g. through `/v1/models`) without a static
+    /// claim from Harn or the user.
+    Unknown,
+}
+
+impl ModelAvailability {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Serverless => "serverless",
+            Self::Dedicated => "dedicated",
+            Self::Unknown => "unknown",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "serverless" => Some(Self::Serverless),
+            "dedicated" => Some(Self::Dedicated),
+            "unknown" => Some(Self::Unknown),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -1124,6 +1168,7 @@ mod tests {
                 deprecated: false,
                 deprecation_note: None,
                 quality_tags: Vec::new(),
+                availability: ModelAvailability::default(),
             },
         );
         set_user_overrides(Some(overlay));
@@ -1460,6 +1505,7 @@ mod tests {
                 deprecated: false,
                 deprecation_note: None,
                 quality_tags: Vec::new(),
+                availability: ModelAvailability::default(),
             },
         );
         overlay
@@ -1623,6 +1669,76 @@ mod tests {
             }
             if let Some(rate) = pricing.cache_write_per_mtok {
                 assert!(rate >= 0.0, "{id}: negative cache_write rate {rate}");
+            }
+        }
+    }
+
+    #[test]
+    fn model_availability_parses_known_strings() {
+        assert_eq!(
+            ModelAvailability::parse("serverless"),
+            Some(ModelAvailability::Serverless)
+        );
+        assert_eq!(
+            ModelAvailability::parse("dedicated"),
+            Some(ModelAvailability::Dedicated)
+        );
+        assert_eq!(
+            ModelAvailability::parse("unknown"),
+            Some(ModelAvailability::Unknown)
+        );
+        assert_eq!(ModelAvailability::parse("provisioned"), None);
+        for value in [
+            ModelAvailability::Serverless,
+            ModelAvailability::Dedicated,
+            ModelAvailability::Unknown,
+        ] {
+            assert_eq!(ModelAvailability::parse(value.as_str()), Some(value));
+        }
+    }
+
+    #[test]
+    fn embedded_catalog_marks_together_dedicated_route_as_dedicated() {
+        let config = default_config();
+        let model = config
+            .models
+            .get("Qwen/Qwen3-Coder-Next-FP8")
+            .expect("Together Qwen3 Coder Next FP8 is cataloged");
+        assert_eq!(model.provider, "together");
+        assert_eq!(model.availability, ModelAvailability::Dedicated);
+    }
+
+    #[test]
+    fn embedded_catalog_dedicated_models_are_not_targeted_by_tier_aliases() {
+        // A dedicated-only model behind a tier alias would silently fail
+        // every serverless caller; the catalog must keep those routes
+        // separated.
+        let config = default_config();
+        let dedicated: std::collections::BTreeSet<(&str, &str)> = config
+            .models
+            .iter()
+            .filter(|(_, model)| model.availability == ModelAvailability::Dedicated)
+            .map(|(id, model)| (model.provider.as_str(), id.as_str()))
+            .collect();
+        for (name, alias) in &config.aliases {
+            if matches!(
+                name.as_str(),
+                "frontier"
+                    | "mid"
+                    | "small"
+                    | "tier/frontier"
+                    | "tier/mid"
+                    | "tier/small"
+                    | "sonnet"
+                    | "opus"
+                    | "haiku"
+            ) {
+                assert!(
+                    !dedicated.contains(&(alias.provider.as_str(), alias.id.as_str())),
+                    "tier alias `{name}` targets dedicated-only route `{}/{}`",
+                    alias.provider,
+                    alias.id,
+                );
             }
         }
     }

--- a/crates/harn-vm/src/provider_catalog.rs
+++ b/crates/harn-vm/src/provider_catalog.rs
@@ -11,7 +11,9 @@ use serde::Serialize;
 use serde_json::{json, Value};
 
 use crate::llm;
-use crate::llm_config::{self, AliasDef, AliasToolCallingDef, ModelDef, ModelPricing, ProviderDef};
+use crate::llm_config::{
+    self, AliasDef, AliasToolCallingDef, ModelAvailability, ModelDef, ModelPricing, ProviderDef,
+};
 
 pub const PROVIDER_CATALOG_SCHEMA_VERSION: u32 = 2;
 pub const PROVIDER_CATALOG_SCHEMA_ID: &str =
@@ -105,8 +107,27 @@ pub struct CatalogModel {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pricing: Option<ModelPricing>,
     pub deprecation: ModelDeprecation,
+    pub availability: ModelAvailabilityStatus,
     pub quality_tags: Vec<String>,
     pub capability_tags: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ModelAvailabilityStatus {
+    Serverless,
+    Dedicated,
+    Unknown,
+}
+
+impl From<ModelAvailability> for ModelAvailabilityStatus {
+    fn from(value: ModelAvailability) -> Self {
+        match value {
+            ModelAvailability::Serverless => Self::Serverless,
+            ModelAvailability::Dedicated => Self::Dedicated,
+            ModelAvailability::Unknown => Self::Unknown,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -355,10 +376,24 @@ pub fn validate_artifact(artifact: &ProviderCatalogArtifact) -> ProviderCatalogV
         }
     }
 
+    let dedicated_pairs: BTreeSet<(&str, &str)> = artifact
+        .models
+        .iter()
+        .filter(|model| model.availability == ModelAvailabilityStatus::Dedicated)
+        .map(|model| (model.provider.as_str(), model.id.as_str()))
+        .collect();
     for alias in &artifact.aliases {
         if !model_pairs.contains(&(alias.provider.as_str(), alias.model_id.as_str())) {
             result.errors.push(format!(
                 "alias {} targets {}/{} without a catalog row",
+                alias.name, alias.provider, alias.model_id
+            ));
+        }
+        if is_tier_alias(&alias.name)
+            && dedicated_pairs.contains(&(alias.provider.as_str(), alias.model_id.as_str()))
+        {
+            result.warnings.push(format!(
+                "tier alias {} targets dedicated-only model {}/{}; serverless callers will fail until the dedicated endpoint is provisioned",
                 alias.name, alias.provider, alias.model_id
             ));
         }
@@ -486,6 +521,7 @@ pub fn schema_value() -> Value {
                     "reasoning",
                     "prompt_cache",
                     "deprecation",
+                    "availability",
                     "quality_tags",
                     "capability_tags"
                 ],
@@ -505,6 +541,7 @@ pub fn schema_value() -> Value {
                     "prompt_cache": {"type": "boolean"},
                     "pricing": {"$ref": "#/$defs/pricing"},
                     "deprecation": {"$ref": "#/$defs/deprecation"},
+                    "availability": {"enum": ["serverless", "dedicated", "unknown"]},
                     "quality_tags": {"type": "array", "items": {"type": "string"}},
                     "capability_tags": {"type": "array", "items": {"type": "string"}}
                 },
@@ -692,6 +729,7 @@ fn catalog_model(
             },
             note: model.deprecation_note.clone(),
         },
+        availability: ModelAvailabilityStatus::from(model.availability),
         quality_tags,
         capability_tags: model.capabilities.clone(),
         id,
@@ -928,6 +966,21 @@ fn is_local_provider(provider: &str) -> bool {
     )
 }
 
+fn is_tier_alias(name: &str) -> bool {
+    matches!(
+        name,
+        "frontier"
+            | "mid"
+            | "small"
+            | "tier/frontier"
+            | "tier/mid"
+            | "tier/small"
+            | "sonnet"
+            | "opus"
+            | "haiku"
+    )
+}
+
 fn title_case(id: &str) -> String {
     id.split('_')
         .map(|part| {
@@ -1039,6 +1092,7 @@ export interface HarnCatalogModel {
   prompt_cache: boolean
   pricing?: HarnModelPricing
   deprecation: { status: "active" | "deprecated"; note?: string }
+  availability: "serverless" | "dedicated" | "unknown"
   quality_tags: string[]
   capability_tags: string[]
 }
@@ -1252,6 +1306,7 @@ public struct HarnCatalogModel: Codable, Sendable, Equatable {
     public let promptCache: Bool
     public let pricing: HarnModelPricing?
     public let deprecation: HarnModelDeprecation
+    public let availability: String
     public let qualityTags: [String]
     public let capabilityTags: [String]
 
@@ -1271,6 +1326,7 @@ public struct HarnCatalogModel: Codable, Sendable, Equatable {
         case promptCache = "prompt_cache"
         case pricing
         case deprecation
+        case availability
         case qualityTags = "quality_tags"
         case capabilityTags = "capability_tags"
     }
@@ -1487,6 +1543,90 @@ quality_tags = ["experiment"]
             .expect("private model is exported");
         assert_eq!(model.aliases, vec!["private-fast"]);
         assert_eq!(model.quality_tags, vec!["experiment"]);
+    }
+
+    #[test]
+    fn cataloged_models_default_to_serverless_availability() {
+        llm_config::clear_user_overrides();
+        let catalog = artifact();
+        let qwen_dedicated = catalog
+            .models
+            .iter()
+            .find(|model| model.id == "Qwen/Qwen3-Coder-Next-FP8")
+            .expect("Together dedicated route is exported");
+        assert_eq!(
+            qwen_dedicated.availability,
+            ModelAvailabilityStatus::Dedicated
+        );
+
+        let bundled_serverless = catalog
+            .models
+            .iter()
+            .find(|model| model.id == "qwen/qwen3-coder")
+            .expect("OpenRouter Qwen3 Coder is exported");
+        assert_eq!(
+            bundled_serverless.availability,
+            ModelAvailabilityStatus::Serverless
+        );
+    }
+
+    #[test]
+    fn tier_alias_targeting_dedicated_model_emits_warning() {
+        let _guard = install_overlay(
+            r#"
+[providers.together_test]
+display_name = "Together (test)"
+base_url = "https://api.together.xyz/v1"
+auth_style = "bearer"
+auth_env = "TOGETHER_AI_API_KEY"
+chat_endpoint = "/chat/completions"
+
+[aliases.frontier]
+id = "Qwen/Test-Dedicated-Only"
+provider = "together_test"
+
+[models."Qwen/Test-Dedicated-Only"]
+name = "Qwen Dedicated Only"
+provider = "together_test"
+context_window = 8192
+availability = "dedicated"
+"#,
+        );
+        let report = validate_current();
+        assert!(
+            report.warnings.iter().any(|message| {
+                message.contains("tier alias frontier") && message.contains("dedicated-only model")
+            }),
+            "expected dedicated-alias warning, got {:?}",
+            report.warnings
+        );
+    }
+
+    #[test]
+    fn overlay_parses_availability_strings() {
+        let _guard = install_overlay(
+            r#"
+[providers.experiment_co]
+display_name = "Experiment Co"
+base_url = "https://example.test/v1"
+auth_style = "bearer"
+auth_env = "EXPERIMENT_API_KEY"
+chat_endpoint = "/chat/completions"
+
+[models."exp/discovered"]
+name = "Discovered Route"
+provider = "experiment_co"
+context_window = 4096
+availability = "unknown"
+"#,
+        );
+        let catalog = artifact();
+        let model = catalog
+            .models
+            .iter()
+            .find(|model| model.id == "exp/discovered")
+            .expect("overlay model is exported");
+        assert_eq!(model.availability, ModelAvailabilityStatus::Unknown);
     }
 
     #[test]

--- a/docs/src/llm/provider-catalog-refresh.md
+++ b/docs/src/llm/provider-catalog-refresh.md
@@ -44,7 +44,8 @@ downstream hosts do not need to parse Harn internals:
 
 - `provider-catalog.json` — normalized providers, models, aliases,
   variants, QC defaults, capabilities, pricing, deprecation metadata,
-  endpoint/auth metadata, and provider caveats;
+  serverless-vs-dedicated availability, endpoint/auth metadata, and
+  provider caveats;
 - `provider-catalog.schema.json` — JSON Schema for the catalog
   contract;
 - `harn-provider-catalog.ts` — TypeScript types plus compatibility

--- a/docs/src/llm/providers.md
+++ b/docs/src/llm/providers.md
@@ -475,6 +475,33 @@ llm_call("...", nil, {model: "claude-sonnet-4-5-20241022"})
 The `HARN_LLM_MODEL` environment variable sets the default model when none
 is specified in the script.
 
+### Serverless vs. dedicated routes
+
+Each catalog row carries an `availability` field that distinguishes the
+provider's serverless surface from routes that require a dedicated
+endpoint:
+
+| value | meaning |
+|---|---|
+| `serverless` | Reachable through the provider's normal API-key path. The default for cataloged rows. |
+| `dedicated` | Listed by the provider but only callable once the caller has provisioned a dedicated endpoint (e.g. some Together `/v1/models` entries). Hosts must not auto-route to it. |
+| `unknown` | Surfaced dynamically (e.g. from `/v1/models`) without a static claim from Harn or the user. |
+
+Override the field in `harn.toml` overlays when shipping a provider
+adapter for routes that need explicit provisioning:
+
+```toml
+[models."Qwen/Qwen3-Coder-Next-FP8"]
+name = "Qwen3 Coder Next FP8 (dedicated)"
+provider = "together"
+context_window = 262144
+availability = "dedicated"
+```
+
+A runtime call that hits a non-serverless Together route also classifies
+as `model_unavailable` (not the generic `invalid_request`) so fallback
+logic can route around the dedicated-only model.
+
 ## Rate limiting
 
 Harn supports per-provider rate limiting (requests per minute):

--- a/spec/provider-catalog/HarnProviderCatalog.swift
+++ b/spec/provider-catalog/HarnProviderCatalog.swift
@@ -123,6 +123,7 @@ public struct HarnCatalogModel: Codable, Sendable, Equatable {
     public let promptCache: Bool
     public let pricing: HarnModelPricing?
     public let deprecation: HarnModelDeprecation
+    public let availability: String
     public let qualityTags: [String]
     public let capabilityTags: [String]
 
@@ -142,6 +143,7 @@ public struct HarnCatalogModel: Codable, Sendable, Equatable {
         case promptCache = "prompt_cache"
         case pricing
         case deprecation
+        case availability
         case qualityTags = "quality_tags"
         case capabilityTags = "capability_tags"
     }
@@ -780,6 +782,7 @@ public let harnProviderCatalogJSON = #"""
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -844,6 +847,7 @@ public let harnProviderCatalogJSON = #"""
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -908,6 +912,7 @@ public let harnProviderCatalogJSON = #"""
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -972,6 +977,7 @@ public let harnProviderCatalogJSON = #"""
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -1042,6 +1048,7 @@ public let harnProviderCatalogJSON = #"""
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -1112,6 +1119,7 @@ public let harnProviderCatalogJSON = #"""
         "status": "deprecated",
         "note": "Superseded by claude-opus-4-7. No formal sunset yet; switch when convenient."
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -1182,6 +1190,7 @@ public let harnProviderCatalogJSON = #"""
         "status": "deprecated",
         "note": "Sunset 2026-06-15 per Anthropic deprecations page. Replaced by claude-opus-4-7."
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -1251,6 +1260,7 @@ public let harnProviderCatalogJSON = #"""
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -1323,6 +1333,7 @@ public let harnProviderCatalogJSON = #"""
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -1394,6 +1405,7 @@ public let harnProviderCatalogJSON = #"""
         "status": "deprecated",
         "note": "Sunset 2026-06-15 per Anthropic deprecations page. Replaced by claude-sonnet-4-6."
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -1464,6 +1476,7 @@ public let harnProviderCatalogJSON = #"""
         "status": "deprecated",
         "note": "Sunset 2026-05-15 per Anthropic deprecations page. Replaced by claude-sonnet-4-6."
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -1537,6 +1550,7 @@ public let harnProviderCatalogJSON = #"""
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [
         "frontier"
       ],
@@ -1608,6 +1622,7 @@ public let harnProviderCatalogJSON = #"""
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -1669,6 +1684,7 @@ public let harnProviderCatalogJSON = #"""
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -1722,6 +1738,7 @@ public let harnProviderCatalogJSON = #"""
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -1774,6 +1791,7 @@ public let harnProviderCatalogJSON = #"""
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -1833,6 +1851,7 @@ public let harnProviderCatalogJSON = #"""
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -1898,6 +1917,7 @@ public let harnProviderCatalogJSON = #"""
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -1956,6 +1976,7 @@ public let harnProviderCatalogJSON = #"""
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [
         "local"
       ],
@@ -2014,6 +2035,7 @@ public let harnProviderCatalogJSON = #"""
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [
         "local"
       ],
@@ -2068,6 +2090,7 @@ public let harnProviderCatalogJSON = #"""
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [
         "local"
       ],
@@ -2124,6 +2147,7 @@ public let harnProviderCatalogJSON = #"""
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [
         "local"
       ],
@@ -2178,6 +2202,7 @@ public let harnProviderCatalogJSON = #"""
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [
         "local"
       ],
@@ -2232,6 +2257,7 @@ public let harnProviderCatalogJSON = #"""
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [
         "local"
       ],
@@ -2286,6 +2312,7 @@ public let harnProviderCatalogJSON = #"""
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [
         "local"
       ],
@@ -2344,6 +2371,7 @@ public let harnProviderCatalogJSON = #"""
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [
         "local"
       ],
@@ -2401,6 +2429,7 @@ public let harnProviderCatalogJSON = #"""
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [
         "local"
       ],
@@ -2456,6 +2485,7 @@ public let harnProviderCatalogJSON = #"""
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [
         "local"
       ],
@@ -2506,6 +2536,7 @@ public let harnProviderCatalogJSON = #"""
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [
         "local"
       ],
@@ -2563,6 +2594,7 @@ public let harnProviderCatalogJSON = #"""
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [
         "local"
       ],
@@ -2620,6 +2652,7 @@ public let harnProviderCatalogJSON = #"""
         "status": "deprecated",
         "note": "Superseded by gpt-5 family. Listed for cost-attribution backfill only."
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -2676,6 +2709,7 @@ public let harnProviderCatalogJSON = #"""
         "status": "deprecated",
         "note": "API sunset 2026-02-17 per OpenAI deprecations page. Switch to gpt-5-mini for cheap routing or gpt-5 for frontier."
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -2736,6 +2770,7 @@ public let harnProviderCatalogJSON = #"""
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [
         "balanced"
       ],
@@ -2795,6 +2830,7 @@ public let harnProviderCatalogJSON = #"""
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -2852,6 +2888,7 @@ public let harnProviderCatalogJSON = #"""
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -2909,6 +2946,7 @@ public let harnProviderCatalogJSON = #"""
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -2966,6 +3004,7 @@ public let harnProviderCatalogJSON = #"""
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -3021,6 +3060,7 @@ public let harnProviderCatalogJSON = #"""
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [
         "small"
       ],
@@ -3081,6 +3121,7 @@ public let harnProviderCatalogJSON = #"""
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -3143,6 +3184,7 @@ public let harnProviderCatalogJSON = #"""
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -3202,6 +3244,7 @@ public let harnProviderCatalogJSON = #"""
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -3254,6 +3297,7 @@ public let harnProviderCatalogJSON = #"""
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -3306,6 +3350,7 @@ public let harnProviderCatalogJSON = #"""
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -3358,6 +3403,7 @@ public let harnProviderCatalogJSON = #"""
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -3411,6 +3457,61 @@ public let harnProviderCatalogJSON = #"""
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "structured_output"
+      ]
+    },
+    {
+      "id": "Qwen/Qwen3-Coder-Next-FP8",
+      "name": "Qwen3 Coder Next FP8 (Together, dedicated)",
+      "provider": "together",
+      "aliases": [],
+      "context_window": 262144,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "delimited",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "none"
+      },
+      "reasoning": {
+        "modes": [],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "pricing": {
+        "input_per_mtok": 0.18,
+        "output_per_mtok": 0.18,
+        "cache_read_per_mtok": null,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "dedicated",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -3662,8 +3763,8 @@ public let harnProviderCatalogJSON = #"""
       "id": "cheap",
       "label": "Cheap",
       "description": "Lowest known hosted input+output token price.",
-      "model_id": "gemini-2.5-flash",
-      "provider": "gemini",
+      "model_id": "Qwen/Qwen3-Coder-Next-FP8",
+      "provider": "together",
       "source": "catalog"
     },
     {

--- a/spec/provider-catalog/harn-provider-catalog.ts
+++ b/spec/provider-catalog/harn-provider-catalog.ts
@@ -93,6 +93,7 @@ export interface HarnCatalogModel {
   prompt_cache: boolean
   pricing?: HarnModelPricing
   deprecation: { status: "active" | "deprecated"; note?: string }
+  availability: "serverless" | "dedicated" | "unknown"
   quality_tags: string[]
   capability_tags: string[]
 }
@@ -678,6 +679,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -742,6 +744,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -806,6 +809,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -870,6 +874,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -940,6 +945,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -1010,6 +1016,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
         "status": "deprecated",
         "note": "Superseded by claude-opus-4-7. No formal sunset yet; switch when convenient."
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -1080,6 +1087,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
         "status": "deprecated",
         "note": "Sunset 2026-06-15 per Anthropic deprecations page. Replaced by claude-opus-4-7."
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -1149,6 +1157,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -1221,6 +1230,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -1292,6 +1302,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
         "status": "deprecated",
         "note": "Sunset 2026-06-15 per Anthropic deprecations page. Replaced by claude-sonnet-4-6."
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -1362,6 +1373,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
         "status": "deprecated",
         "note": "Sunset 2026-05-15 per Anthropic deprecations page. Replaced by claude-sonnet-4-6."
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -1435,6 +1447,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [
         "frontier"
       ],
@@ -1506,6 +1519,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -1567,6 +1581,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -1620,6 +1635,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -1672,6 +1688,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -1731,6 +1748,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -1796,6 +1814,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -1854,6 +1873,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [
         "local"
       ],
@@ -1912,6 +1932,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [
         "local"
       ],
@@ -1966,6 +1987,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [
         "local"
       ],
@@ -2022,6 +2044,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [
         "local"
       ],
@@ -2076,6 +2099,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [
         "local"
       ],
@@ -2130,6 +2154,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [
         "local"
       ],
@@ -2184,6 +2209,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [
         "local"
       ],
@@ -2242,6 +2268,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [
         "local"
       ],
@@ -2299,6 +2326,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [
         "local"
       ],
@@ -2354,6 +2382,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [
         "local"
       ],
@@ -2404,6 +2433,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [
         "local"
       ],
@@ -2461,6 +2491,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [
         "local"
       ],
@@ -2518,6 +2549,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
         "status": "deprecated",
         "note": "Superseded by gpt-5 family. Listed for cost-attribution backfill only."
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -2574,6 +2606,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
         "status": "deprecated",
         "note": "API sunset 2026-02-17 per OpenAI deprecations page. Switch to gpt-5-mini for cheap routing or gpt-5 for frontier."
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -2634,6 +2667,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [
         "balanced"
       ],
@@ -2693,6 +2727,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -2750,6 +2785,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -2807,6 +2843,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -2864,6 +2901,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -2919,6 +2957,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [
         "small"
       ],
@@ -2979,6 +3018,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -3041,6 +3081,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -3100,6 +3141,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -3152,6 +3194,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -3204,6 +3247,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -3256,6 +3300,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -3309,6 +3354,61 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "structured_output"
+      ]
+    },
+    {
+      "id": "Qwen/Qwen3-Coder-Next-FP8",
+      "name": "Qwen3 Coder Next FP8 (Together, dedicated)",
+      "provider": "together",
+      "aliases": [],
+      "context_window": 262144,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "delimited",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "none"
+      },
+      "reasoning": {
+        "modes": [],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "pricing": {
+        "input_per_mtok": 0.18,
+        "output_per_mtok": 0.18,
+        "cache_read_per_mtok": null,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "dedicated",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -3560,8 +3660,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "id": "cheap",
       "label": "Cheap",
       "description": "Lowest known hosted input+output token price.",
-      "model_id": "gemini-2.5-flash",
-      "provider": "gemini",
+      "model_id": "Qwen/Qwen3-Coder-Next-FP8",
+      "provider": "together",
       "source": "catalog"
     },
     {

--- a/spec/provider-catalog/provider-catalog.json
+++ b/spec/provider-catalog/provider-catalog.json
@@ -538,6 +538,7 @@
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -602,6 +603,7 @@
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -666,6 +668,7 @@
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -730,6 +733,7 @@
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -800,6 +804,7 @@
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -870,6 +875,7 @@
         "status": "deprecated",
         "note": "Superseded by claude-opus-4-7. No formal sunset yet; switch when convenient."
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -940,6 +946,7 @@
         "status": "deprecated",
         "note": "Sunset 2026-06-15 per Anthropic deprecations page. Replaced by claude-opus-4-7."
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -1009,6 +1016,7 @@
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -1081,6 +1089,7 @@
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -1152,6 +1161,7 @@
         "status": "deprecated",
         "note": "Sunset 2026-06-15 per Anthropic deprecations page. Replaced by claude-sonnet-4-6."
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -1222,6 +1232,7 @@
         "status": "deprecated",
         "note": "Sunset 2026-05-15 per Anthropic deprecations page. Replaced by claude-sonnet-4-6."
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -1295,6 +1306,7 @@
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [
         "frontier"
       ],
@@ -1366,6 +1378,7 @@
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -1427,6 +1440,7 @@
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -1480,6 +1494,7 @@
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -1532,6 +1547,7 @@
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -1591,6 +1607,7 @@
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -1656,6 +1673,7 @@
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -1714,6 +1732,7 @@
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [
         "local"
       ],
@@ -1772,6 +1791,7 @@
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [
         "local"
       ],
@@ -1826,6 +1846,7 @@
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [
         "local"
       ],
@@ -1882,6 +1903,7 @@
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [
         "local"
       ],
@@ -1936,6 +1958,7 @@
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [
         "local"
       ],
@@ -1990,6 +2013,7 @@
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [
         "local"
       ],
@@ -2044,6 +2068,7 @@
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [
         "local"
       ],
@@ -2102,6 +2127,7 @@
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [
         "local"
       ],
@@ -2159,6 +2185,7 @@
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [
         "local"
       ],
@@ -2214,6 +2241,7 @@
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [
         "local"
       ],
@@ -2264,6 +2292,7 @@
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [
         "local"
       ],
@@ -2321,6 +2350,7 @@
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [
         "local"
       ],
@@ -2378,6 +2408,7 @@
         "status": "deprecated",
         "note": "Superseded by gpt-5 family. Listed for cost-attribution backfill only."
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -2434,6 +2465,7 @@
         "status": "deprecated",
         "note": "API sunset 2026-02-17 per OpenAI deprecations page. Switch to gpt-5-mini for cheap routing or gpt-5 for frontier."
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -2494,6 +2526,7 @@
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [
         "balanced"
       ],
@@ -2553,6 +2586,7 @@
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -2610,6 +2644,7 @@
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -2667,6 +2702,7 @@
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -2724,6 +2760,7 @@
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -2779,6 +2816,7 @@
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [
         "small"
       ],
@@ -2839,6 +2877,7 @@
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -2901,6 +2940,7 @@
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -2960,6 +3000,7 @@
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -3012,6 +3053,7 @@
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -3064,6 +3106,7 @@
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -3116,6 +3159,7 @@
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -3169,6 +3213,61 @@
       "deprecation": {
         "status": "active"
       },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "structured_output"
+      ]
+    },
+    {
+      "id": "Qwen/Qwen3-Coder-Next-FP8",
+      "name": "Qwen3 Coder Next FP8 (Together, dedicated)",
+      "provider": "together",
+      "aliases": [],
+      "context_window": 262144,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "delimited",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "none"
+      },
+      "reasoning": {
+        "modes": [],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "pricing": {
+        "input_per_mtok": 0.18,
+        "output_per_mtok": 0.18,
+        "cache_read_per_mtok": null,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "dedicated",
       "quality_tags": [],
       "capability_tags": [
         "streaming",
@@ -3420,8 +3519,8 @@
       "id": "cheap",
       "label": "Cheap",
       "description": "Lowest known hosted input+output token price.",
-      "model_id": "gemini-2.5-flash",
-      "provider": "gemini",
+      "model_id": "Qwen/Qwen3-Coder-Next-FP8",
+      "provider": "together",
       "source": "catalog"
     },
     {

--- a/spec/provider-catalog/provider-catalog.schema.json
+++ b/spec/provider-catalog/provider-catalog.schema.json
@@ -196,6 +196,13 @@
           },
           "type": "array"
         },
+        "availability": {
+          "enum": [
+            "serverless",
+            "dedicated",
+            "unknown"
+          ]
+        },
         "capability_tags": {
           "items": {
             "type": "string"
@@ -270,6 +277,7 @@
         "reasoning",
         "prompt_cache",
         "deprecation",
+        "availability",
         "quality_tags",
         "capability_tags"
       ],


### PR DESCRIPTION
## Summary
- Adds a typed `availability` field (`serverless` | `dedicated` | `unknown`) to `ModelDef`, propagates it through `CatalogModel`, the catalog JSON schema, and the TypeScript / Swift bindings under `spec/provider-catalog/`.
- Tags `Qwen/Qwen3-Coder-Next-FP8` (Together) as `dedicated` and emits a `validate_artifact` warning whenever a tier alias (`frontier` / `mid` / `small` / `sonnet` / `opus` / `haiku`) targets a dedicated-only route, so the catalog can't silently route serverless callers into provisioned-only models again.
- Reclassifies the matching Together runtime response (HTTP 400 + "Unable to access non-serverless model …") as `model_unavailable` rather than the generic `invalid_request`, so existing fallback / re-route logic in `agent_loop` kicks in instead of bubbling the error to the agent.

Fixes #2143.

## Test plan
- [x] `cargo test -p harn-vm --lib` (2438 tests, all passing — adds 5 new tests covering the metadata round-trip, catalog defaults, the dedicated-alias warning, and the Together error classifier)
- [x] `cargo clippy -p harn-vm --tests --no-deps` clean
- [x] `cargo run --quiet --bin harn -- providers validate --check-artifacts` regenerates and re-validates the JSON / schema / TS / Swift bindings
- [x] `cargo run --quiet --bin harn -- run scripts/update_provider_catalog.harn -- --check` (drift workflow) passes