### PR TITLE
Strip Harn tool metadata from strict providers

### DIFF
--- a/crates/harn-vm/src/llm/providers/openai_compat.rs
+++ b/crates/harn-vm/src/llm/providers/openai_compat.rs
@@ -215,7 +215,11 @@ impl OpenAiCompatibleProvider {
         }
         if let Some(ref tools) = opts.native_tools {
             if !tools.is_empty() {
-                body["tools"] = serde_json::json!(tools);
+                body["tools"] = serde_json::Value::Array(provider_request_tools(
+                    &opts.provider,
+                    &opts.model,
+                    tools,
+                ));
             }
         }
         if let Some(ref tc) = opts.tool_choice {
@@ -274,6 +278,52 @@ pub(crate) fn ensure_openrouter_require_parameters(body: &mut serde_json::Value)
             body["provider"] = serde_json::json!({"require_parameters": true});
         }
     }
+}
+
+fn provider_request_tools(
+    provider: &str,
+    model: &str,
+    tools: &[serde_json::Value],
+) -> Vec<serde_json::Value> {
+    let caps = crate::llm::capabilities::lookup(provider, model);
+    let has_openai_tool_search = tools
+        .iter()
+        .any(|tool| tool.get("type").and_then(serde_json::Value::as_str) == Some("tool_search"));
+    let supports_openai_tool_search_extensions = has_openai_tool_search
+        && caps.defer_loading
+        && caps.tool_search.iter().any(|variant| variant == "hosted");
+
+    tools
+        .iter()
+        .map(|tool| sanitize_openai_tool_for_request(tool, supports_openai_tool_search_extensions))
+        .collect()
+}
+
+fn sanitize_openai_tool_for_request(
+    tool: &serde_json::Value,
+    supports_openai_tool_search_extensions: bool,
+) -> serde_json::Value {
+    let mut tool = tool.clone();
+    let Some(object) = tool.as_object_mut() else {
+        return tool;
+    };
+
+    object.remove("x-harn-output-schema");
+    if !supports_openai_tool_search_extensions {
+        object.remove("defer_loading");
+        object.remove("namespace");
+        object.remove("namespaces");
+    }
+
+    if let Some(function) = object
+        .get_mut("function")
+        .and_then(serde_json::Value::as_object_mut)
+    {
+        function.remove("x-harn-output-schema");
+        function.remove("namespace");
+    }
+
+    tool
 }
 
 fn openrouter_reasoning_config(thinking: &ThinkingConfig) -> Option<serde_json::Value> {
@@ -419,6 +469,106 @@ mod tests {
         let provider = OpenAiCompatibleProvider::new("openai".to_string());
         assert!(provider.supports_defer_loading("gpt-5.4"));
         assert!(!provider.supports_defer_loading("gpt-4o"));
+    }
+
+    #[test]
+    fn cerebras_request_strips_harn_tool_extensions() {
+        let mut payload = base_request_payload();
+        payload.provider = "cerebras".to_string();
+        payload.model = "gpt-oss-120b".to_string();
+        payload.native_tools = Some(vec![json!({
+            "type": "function",
+            "namespace": "ops",
+            "defer_loading": true,
+            "function": {
+                "name": "deploy",
+                "description": "Deploy the app",
+                "namespace": "ops",
+                "x-harn-output-schema": {"type": "object"},
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "env": {"type": "string"}
+                    },
+                    "required": ["env"]
+                }
+            }
+        })]);
+
+        let body = OpenAiCompatibleProvider::build_request_body(&payload, false);
+        let tool = &body["tools"][0];
+        assert_eq!(tool["type"], "function");
+        assert!(tool.get("namespace").is_none());
+        assert!(tool.get("defer_loading").is_none());
+        assert!(tool["function"].get("namespace").is_none());
+        assert!(tool["function"].get("x-harn-output-schema").is_none());
+        assert_eq!(
+            tool["function"]["parameters"]["properties"]["env"]["type"],
+            "string"
+        );
+        let source_tool = &payload.native_tools.as_ref().expect("source tools")[0];
+        assert_eq!(source_tool["namespace"], "ops");
+        assert_eq!(
+            source_tool["function"]["x-harn-output-schema"]["type"],
+            "object"
+        );
+    }
+
+    #[test]
+    fn openai_tool_search_request_keeps_wire_extensions() {
+        let mut payload = base_request_payload();
+        payload.provider = "openai".to_string();
+        payload.model = "gpt-5.4".to_string();
+        payload.native_tools = Some(vec![
+            json!({
+                "type": "tool_search",
+                "mode": "hosted",
+                "namespaces": ["ops"],
+            }),
+            json!({
+                "type": "function",
+                "namespace": "ops",
+                "defer_loading": true,
+                "function": {
+                    "name": "deploy",
+                    "description": "Deploy the app",
+                    "x-harn-output-schema": {"type": "object"},
+                    "parameters": {"type": "object"}
+                }
+            }),
+        ]);
+
+        let body = OpenAiCompatibleProvider::build_request_body(&payload, false);
+        assert_eq!(body["tools"][0]["namespaces"], json!(["ops"]));
+        assert_eq!(body["tools"][1]["namespace"], "ops");
+        assert_eq!(body["tools"][1]["defer_loading"], true);
+        assert!(
+            body["tools"][1]["function"]
+                .get("x-harn-output-schema")
+                .is_none(),
+            "Harn output schemas stay in transcripts, not provider payloads"
+        );
+    }
+
+    #[test]
+    fn openai_regular_request_strips_tool_search_extensions_without_meta_tool() {
+        let mut payload = base_request_payload();
+        payload.provider = "openai".to_string();
+        payload.model = "gpt-5.4".to_string();
+        payload.native_tools = Some(vec![json!({
+            "type": "function",
+            "namespace": "ops",
+            "defer_loading": true,
+            "function": {
+                "name": "deploy",
+                "description": "Deploy the app",
+                "parameters": {"type": "object"}
+            }
+        })]);
+
+        let body = OpenAiCompatibleProvider::build_request_body(&payload, false);
+        assert!(body["tools"][0].get("namespace").is_none());
+        assert!(body["tools"][0].get("defer_loading").is_none());
     }
 
     #[test]

--- a/crates/harn-vm/src/llm/tools/native.rs
+++ b/crates/harn-vm/src/llm/tools/native.rs
@@ -91,19 +91,17 @@ pub(crate) fn vm_tools_to_native(
                         // Record the flag on the Harn-side wrapper so
                         // native and client-executed tool-search paths
                         // can read it without re-walking the VmValue
-                        // tree. Non-OpenAI OpenAI-compat providers that don't
-                        // understand `defer_loading` today will return an
-                        // error when the user explicitly requests
-                        // tool_search — the capability gate in options.rs
-                        // catches that before the payload ever reaches
-                        // the provider.
+                        // tree. OpenAI-compatible request builders strip
+                        // it from providers that do not advertise native
+                        // tool-search extensions.
                         tool_json["defer_loading"] = serde_json::Value::Bool(true);
                     }
                     if let Some(ns) = namespace {
                         // OpenAI's `tool_search` meta-tool groups
                         // deferred tools by namespace. Placed on the
-                        // wrapper (alongside `type: "function"`) so the
-                        // Responses API sees it next to `defer_loading`.
+                        // wrapper (alongside `type: "function"`) so
+                        // request builders can collect the metadata
+                        // before sanitizing provider payloads.
                         tool_json["namespace"] = serde_json::Value::String(ns);
                     }
                     native_tools.push(tool_json);

--- a/crates/harn-vm/src/llm/tools/tests/native_tools.rs
+++ b/crates/harn-vm/src/llm/tools/tests/native_tools.rs
@@ -51,9 +51,10 @@ fn vm_tools_to_native_uses_model_capability_shape_for_bedrock_claude() {
 #[test]
 fn vm_tools_to_native_emits_namespace_for_openai_compat() {
     // `namespace` on a tool entry (harn#71) flows through to the
-    // OpenAI-shape wrapper alongside `defer_loading`. Anthropic
-    // receives it too — the field is harmless there (ignored by the
-    // API) and keeps replay fidelity.
+    // OpenAI-shape wrapper alongside `defer_loading`. Provider request
+    // builders may strip it from outbound HTTP bodies, but keeping it
+    // in the native tool value preserves transcript and tool-search
+    // grouping fidelity.
     let mut deferred_params = BTreeMap::new();
     deferred_params.insert("env".to_string(), vm_str("string"));
     let deferred = vm_dict(&[
@@ -82,9 +83,8 @@ fn vm_tools_to_native_emits_namespace_for_openai_compat() {
 fn vm_tools_to_native_emits_defer_loading_for_openai_compat() {
     // OpenAI-shape tools place the flag at the wrapper level (not inside
     // `function`) so harn#71's Responses-API path can read it uniformly
-    // without re-walking. Non-Anthropic providers that don't understand
-    // the flag will never actually see it — the capability gate in
-    // options.rs blocks them before the request leaves the VM.
+    // without re-walking. The OpenAI-compatible request builder strips
+    // it from providers that do not expose native tool-search extensions.
     let registry = defer_loading_registry();
     let tools = vm_tools_to_native(&registry, "openai", "gpt-5.4").expect("openai native tools");
     let deploy = tools


### PR DESCRIPTION
## Summary
- sanitize OpenAI-compatible provider request tools so Cerebras and other strict endpoints do not receive Harn-only extension fields
- keep Harn-native tool metadata in memory for transcripts and tool-search grouping
- cover Cerebras, OpenAI tool-search, and ordinary OpenAI native-tool request shapes

Closes #2149

## Verification
- cargo test -p harn-vm
- cargo test -p harn-vm openai_compat::tests -- --nocapture
- cargo test -p harn-vm llm::tools::tests::native_tools -- --nocapture
- make lint-test-patterns
- pre-commit hook
- pre-push hook