### PR TITLE
harn test: adaptive scheduler with bounded workers and per-test annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,17 @@ condensed series summaries instead of full per-patch history.
   unwritable report directory now fails the run with a clear diagnostic
   instead of succeeding silently. `--watch` rejects both flags up-front
   since the watch loop never terminates.
+- **`harn test --parallel` now uses an adaptive scheduler with a bounded worker
+  pool (#2144).** Tests are scheduled at per-pipeline granularity rather than
+  per file, so a single slow file no longer holds the run hostage. Worker count
+  is set with `--jobs/-j` (or `HARN_TEST_JOBS`) and defaults to available
+  parallelism capped at 8 to bound system load. The runner front-loads the
+  slowest tests using a persisted `.harn/test-timings.json` cache so future
+  runs balance themselves. Two new attributes tune the scheduler when isolation
+  is required: `@serial(group: "name")` serializes tests sharing a fixture, and
+  `@heavy(threads: N)` reserves `N` worker permits so expensive tests do not
+  oversubscribe the pool. The selected worker count and scheduling mode are
+  printed at the top of every run.
 
 ### Fixed
 

--- a/crates/harn-cli/src/cli/test.rs
+++ b/crates/harn-cli/src/cli/test.rs
@@ -35,6 +35,11 @@ pub(crate) struct TestArgs {
     /// Run user tests concurrently where supported.
     #[arg(long)]
     pub parallel: bool,
+    /// Maximum number of concurrent test workers. Defaults to available
+    /// parallelism, capped to keep system load bounded. Also honored via
+    /// the `HARN_TEST_JOBS` env var. Ignored unless `--parallel` is set.
+    #[arg(long = "jobs", short = 'j', value_name = "N", env = "HARN_TEST_JOBS")]
+    pub jobs: Option<usize>,
     /// Re-run user tests when watched files change.
     #[arg(long)]
     pub watch: bool,

--- a/crates/harn-cli/src/commands/test.rs
+++ b/crates/harn-cli/src/commands/test.rs
@@ -31,6 +31,20 @@ impl UserTestReportConfig<'_> {
     }
 }
 
+/// Per-invocation knobs for `harn test <dir>` and `harn test --watch`.
+/// Bundled so call sites share one parameter shape and the runner
+/// signatures stay readable as new flags accrete.
+#[derive(Clone, Copy)]
+pub(crate) struct UserTestRunArgs<'a> {
+    pub filter: Option<&'a str>,
+    pub timeout_ms: u64,
+    pub parallel: bool,
+    pub jobs: Option<usize>,
+    pub verbose: bool,
+    pub timing: bool,
+    pub cli_skill_dirs: &'a [PathBuf],
+}
+
 pub(crate) const CONFORMANCE_TEST_SCHEMA_VERSION: u32 = 1;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -1520,15 +1534,18 @@ fn user_test_progress(verbose: bool) -> test_runner::TestRunProgress {
             total_tests,
             total_files,
             parallel,
+            workers,
         } => {
             if total_tests > 0 {
-                let mode = if parallel { "parallel" } else { "sequential" };
+                let mode = if parallel { "dynamic" } else { "sequential" };
                 println!(
-                    "Running {} test{} from {} file{} ({mode})...\n",
+                    "Running {} test{} from {} file{} with {} worker{} ({mode} scheduling)\n",
                     total_tests,
                     if total_tests == 1 { "" } else { "s" },
                     total_files,
                     if total_files == 1 { "" } else { "s" },
+                    workers,
+                    if workers == 1 { "" } else { "s" },
                 );
             }
         }
@@ -1537,25 +1554,17 @@ fn user_test_progress(verbose: bool) -> test_runner::TestRunProgress {
             total_files,
         } => {
             println!(
-                "\x1b[33mwarning\x1b[0m: large suite discovered ({total_tests} tests across {total_files} files); running sequentially. Use `--parallel` for file-level concurrency.\n"
+                "\x1b[33mwarning\x1b[0m: large suite discovered ({total_tests} tests across {total_files} files); running sequentially. Use `--parallel` to enable the bounded worker pool.\n"
             );
-        }
-        test_runner::TestRunEvent::FileStarted {
-            file,
-            file_index,
-            total_files,
-            test_count,
-        } => {
-            println!("  RUN   file {file_index}/{total_files} {file} ({test_count} tests)");
         }
         test_runner::TestRunEvent::TestStarted {
             name,
             file,
             test_index,
-            total_tests_in_file,
+            total_tests,
         } => {
             if verbose {
-                println!("    RUN   {name} [{file}] ({test_index}/{total_tests_in_file})");
+                println!("    RUN   {name} [{file}] ({test_index}/{total_tests})");
             }
         }
         test_runner::TestRunEvent::TestFinished(result) => {
@@ -1770,29 +1779,20 @@ fn print_user_test_timing(summary: &test_runner::TestSummary) {
     }
 }
 
-async fn run_user_tests_once(
-    path: &Path,
-    filter: Option<&str>,
-    timeout_ms: u64,
-    parallel: bool,
-    verbose: bool,
-    timing: bool,
-    cli_skill_dirs: &[PathBuf],
-) -> test_runner::TestSummary {
-    let progress = user_test_progress(verbose);
-    let summary = test_runner::run_tests_with_progress(
-        path,
-        filter,
-        timeout_ms,
-        parallel,
-        cli_skill_dirs,
-        Some(progress),
-    )
-    .await;
+async fn run_user_tests_once(path: &Path, args: UserTestRunArgs<'_>) -> test_runner::TestSummary {
+    let options = test_runner::RunOptions {
+        filter: args.filter.map(str::to_owned),
+        timeout_ms: args.timeout_ms,
+        parallel: args.parallel,
+        jobs: args.jobs,
+        cli_skill_dirs: args.cli_skill_dirs.to_vec(),
+        progress: Some(user_test_progress(args.verbose)),
+    };
+    let summary = test_runner::run_tests_with_options(path, &options).await;
     print_test_results(
         &summary,
         UserTestOutputOptions {
-            timing,
+            timing: args.timing,
             progress: true,
         },
     );
@@ -1801,12 +1801,7 @@ async fn run_user_tests_once(
 
 pub(crate) async fn run_user_tests(
     path_str: &str,
-    filter: Option<&str>,
-    timeout_ms: u64,
-    parallel: bool,
-    verbose: bool,
-    timing: bool,
-    cli_skill_dirs: &[PathBuf],
+    args: UserTestRunArgs<'_>,
     report_config: UserTestReportConfig<'_>,
 ) {
     let path = PathBuf::from(path_str);
@@ -1822,16 +1817,7 @@ pub(crate) async fn run_user_tests(
             preflight_report_path(p);
         }
     }
-    let summary = run_user_tests_once(
-        &path,
-        filter,
-        timeout_ms,
-        parallel,
-        verbose,
-        timing,
-        cli_skill_dirs,
-    )
-    .await;
+    let summary = run_user_tests_once(&path, args).await;
 
     if !report_config.is_empty() {
         let suite_root = path.canonicalize().unwrap_or(path.clone());
@@ -2209,15 +2195,7 @@ pub(crate) async fn run_conformance_determinism_tests(
     );
 }
 
-pub(crate) async fn run_watch_tests(
-    path_str: &str,
-    filter: Option<&str>,
-    timeout_ms: u64,
-    parallel: bool,
-    verbose: bool,
-    timing: bool,
-    cli_skill_dirs: &[PathBuf],
-) {
+pub(crate) async fn run_watch_tests(path_str: &str, args: UserTestRunArgs<'_>) {
     use notify::{Config, RecommendedWatcher, RecursiveMode, Watcher};
     use std::sync::mpsc;
     use std::time::Duration;
@@ -2230,16 +2208,7 @@ pub(crate) async fn run_watch_tests(
 
     println!("Watching {path_str} for changes... (Ctrl+C to stop)\n");
 
-    run_user_tests_once(
-        &path,
-        filter,
-        timeout_ms,
-        parallel,
-        verbose,
-        timing,
-        cli_skill_dirs,
-    )
-    .await;
+    run_user_tests_once(&path, args).await;
 
     let (tx, rx) = mpsc::channel();
     let mut watcher = RecommendedWatcher::new(tx, Config::default()).unwrap_or_else(|e| {
@@ -2268,16 +2237,7 @@ pub(crate) async fn run_watch_tests(
                 while rx.recv_timeout(Duration::from_millis(100)).is_ok() {}
 
                 println!("\n\x1b[2m--- file changed, re-running tests ---\x1b[0m\n");
-                run_user_tests_once(
-                    &path,
-                    filter,
-                    timeout_ms,
-                    parallel,
-                    verbose,
-                    timing,
-                    cli_skill_dirs,
-                )
-                .await;
+                run_user_tests_once(&path, args).await;
             }
             Ok(Err(e)) => {
                 eprintln!("Watch error: {e}");

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -821,32 +821,29 @@ async fn async_main() {
                         command_error(
                             "only `harn test conformance` accepts a second positional target",
                         );
-                    } else if args.watch {
-                        commands::test::run_watch_tests(
-                            t,
-                            args.filter.as_deref(),
-                            args.timeout,
-                            args.parallel,
-                            args.verbose,
-                            args.timing,
-                            &cli_skill_dirs,
-                        )
-                        .await;
                     } else {
-                        commands::test::run_user_tests(
-                            t,
-                            args.filter.as_deref(),
-                            args.timeout,
-                            args.parallel,
-                            args.verbose,
-                            args.timing,
-                            &cli_skill_dirs,
-                            commands::test::UserTestReportConfig {
-                                junit_path: args.junit.as_deref(),
-                                json_out_path: args.json_out.as_deref(),
-                            },
-                        )
-                        .await;
+                        let run_args = commands::test::UserTestRunArgs {
+                            filter: args.filter.as_deref(),
+                            timeout_ms: args.timeout,
+                            parallel: args.parallel,
+                            jobs: args.jobs,
+                            verbose: args.verbose,
+                            timing: args.timing,
+                            cli_skill_dirs: &cli_skill_dirs,
+                        };
+                        if args.watch {
+                            commands::test::run_watch_tests(t, run_args).await;
+                        } else {
+                            commands::test::run_user_tests(
+                                t,
+                                run_args,
+                                commands::test::UserTestReportConfig {
+                                    junit_path: args.junit.as_deref(),
+                                    json_out_path: args.json_out.as_deref(),
+                                },
+                            )
+                            .await;
+                        }
                     }
                 } else {
                     let test_dir = if PathBuf::from("tests").is_dir() {
@@ -859,26 +856,21 @@ async fn async_main() {
                             "only `harn test conformance` accepts a second positional target",
                         );
                     }
+                    let run_args = commands::test::UserTestRunArgs {
+                        filter: args.filter.as_deref(),
+                        timeout_ms: args.timeout,
+                        parallel: args.parallel,
+                        jobs: args.jobs,
+                        verbose: args.verbose,
+                        timing: args.timing,
+                        cli_skill_dirs: &cli_skill_dirs,
+                    };
                     if args.watch {
-                        commands::test::run_watch_tests(
-                            &test_dir,
-                            args.filter.as_deref(),
-                            args.timeout,
-                            args.parallel,
-                            args.verbose,
-                            args.timing,
-                            &cli_skill_dirs,
-                        )
-                        .await;
+                        commands::test::run_watch_tests(&test_dir, run_args).await;
                     } else {
                         commands::test::run_user_tests(
                             &test_dir,
-                            args.filter.as_deref(),
-                            args.timeout,
-                            args.parallel,
-                            args.verbose,
-                            args.timing,
-                            &cli_skill_dirs,
+                            run_args,
                             commands::test::UserTestReportConfig {
                                 junit_path: args.junit.as_deref(),
                                 json_out_path: args.json_out.as_deref(),

--- a/crates/harn-cli/src/test_runner.rs
+++ b/crates/harn-cli/src/test_runner.rs
@@ -1,9 +1,12 @@
+use std::collections::{BTreeMap, HashSet};
+use std::fs;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, Condvar, Mutex};
+use std::thread;
 use std::time::Instant;
 
 use harn_lexer::Lexer;
-use harn_parser::{Node, Parser, SNode};
+use harn_parser::{Attribute, Node, Parser, SNode};
 
 use crate::env_guard::ScopedEnvVar;
 
@@ -31,22 +34,17 @@ pub enum TestRunEvent {
         total_tests: usize,
         total_files: usize,
         parallel: bool,
+        workers: usize,
     },
     LargeSequentialSuite {
         total_tests: usize,
         total_files: usize,
     },
-    FileStarted {
-        file: String,
-        file_index: usize,
-        total_files: usize,
-        test_count: usize,
-    },
     TestStarted {
         name: String,
         file: String,
         test_index: usize,
-        total_tests_in_file: usize,
+        total_tests: usize,
     },
     TestFinished(TestResult),
 }
@@ -55,6 +53,59 @@ pub type TestRunProgress = Arc<dyn Fn(TestRunEvent) + Send + Sync>;
 
 const LARGE_SEQUENTIAL_TEST_THRESHOLD: usize = 50;
 const LARGE_SEQUENTIAL_FILE_THRESHOLD: usize = 10;
+const DEFAULT_PARALLEL_JOBS_CAP: usize = 8;
+const TIMINGS_CACHE_RELATIVE_PATH: &str = ".harn/test-timings.json";
+const HARN_TEST_JOBS_ENV: &str = "HARN_TEST_JOBS";
+
+/// Options that shape how a user-test suite is discovered and executed.
+///
+/// Held separately from the positional path so call sites (one-shot run,
+/// `--watch`, persona doctor) can share the same scheduler without
+/// keyword-argument explosion at the call sites.
+#[derive(Clone, Default)]
+pub struct RunOptions {
+    pub filter: Option<String>,
+    pub timeout_ms: u64,
+    /// When false, the scheduler runs with a single worker, preserving the
+    /// historical "everything sequential" semantics that `harn test`
+    /// defaulted to before `--parallel` was introduced.
+    pub parallel: bool,
+    /// Explicit worker limit (`-j`/`--jobs`). `None` defaults to the
+    /// available parallelism, capped by a small constant when running in
+    /// parallel mode. Ignored when `parallel = false`.
+    pub jobs: Option<usize>,
+    pub cli_skill_dirs: Vec<PathBuf>,
+    /// Optional progress callback. When set, the runner emits events as
+    /// the suite progresses; consumers (CLI, dev mode) render output.
+    pub progress: Option<TestRunProgress>,
+}
+
+impl RunOptions {
+    pub fn new(timeout_ms: u64) -> Self {
+        Self {
+            timeout_ms,
+            ..Default::default()
+        }
+    }
+}
+
+/// A single executable test discovered during scan. Workers compile and
+/// run each case in isolation; the parsed program is shared by `Arc` so
+/// large suites parse exactly once.
+#[derive(Clone)]
+struct TestCase {
+    file: PathBuf,
+    name: String,
+    source: Arc<String>,
+    program: Arc<Vec<SNode>>,
+    /// Optional serial group — tests with the same group never run
+    /// concurrently with each other, even if workers are idle. Used for
+    /// shared fixtures.
+    serial_group: Option<String>,
+    /// Number of workers this test reserves while running. Capped at the
+    /// pool size during discovery so heavy tests still get scheduled.
+    weight: usize,
+}
 
 fn canonicalize_existing_path(path: &Path) -> PathBuf {
     path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
@@ -64,268 +115,14 @@ fn test_execution_cwd() -> PathBuf {
     std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
 }
 
-struct ParsedTestFile {
-    source: String,
-    program: Vec<SNode>,
-    test_names: Vec<String>,
-}
-
-#[derive(Clone)]
-struct TestFilePlan {
-    file: PathBuf,
-    test_count: usize,
-}
-
-fn parse_test_file(path: &Path, filter: Option<&str>) -> Result<ParsedTestFile, String> {
-    let source = std::fs::read_to_string(path)
-        .map_err(|e| format!("Failed to read {}: {e}", path.display()))?;
-
-    let mut lexer = Lexer::new(&source);
-    let tokens = lexer.tokenize().map_err(|e| format!("{e}"))?;
-    let mut parser = Parser::new(tokens);
-    let program = parser.parse().map_err(|e| format!("{e}"))?;
-    let test_names = discover_test_names(&program, filter);
-
-    Ok(ParsedTestFile {
-        source,
-        program,
-        test_names,
-    })
-}
-
-fn discover_test_names(program: &[SNode], filter: Option<&str>) -> Vec<String> {
-    program
-        .iter()
-        .filter_map(|snode| {
-            // Recognize either:
-            //  - the legacy naming convention: `pipeline test_*`
-            //  - the explicit `@test` attribute on a Pipeline (declarative)
-            let (has_test_attr, decl_node) = match &snode.node {
-                Node::AttributedDecl { attributes, inner } => {
-                    (attributes.iter().any(|a| a.name == "test"), inner.as_ref())
-                }
-                _ => (false, snode),
-            };
-            let name = match &decl_node.node {
-                Node::Pipeline { name, .. } => name.clone(),
-                _ => return None,
-            };
-            if !(has_test_attr || name.starts_with("test_")) {
-                return None;
-            }
-            if let Some(pattern) = filter {
-                if !name.contains(pattern) {
-                    return None;
-                }
-            }
-            Some(name)
-        })
-        .collect()
-}
-
 fn emit_progress(progress: &Option<TestRunProgress>, event: TestRunEvent) {
     if let Some(callback) = progress {
         callback(event);
     }
 }
 
-fn push_result(
-    results: &mut Vec<TestResult>,
-    result: TestResult,
-    progress: &Option<TestRunProgress>,
-) {
-    emit_progress(progress, TestRunEvent::TestFinished(result.clone()));
-    results.push(result);
-}
-
 fn should_warn_large_sequential_suite(total_tests: usize, total_files: usize) -> bool {
     total_tests >= LARGE_SEQUENTIAL_TEST_THRESHOLD || total_files >= LARGE_SEQUENTIAL_FILE_THRESHOLD
-}
-
-async fn run_test_file_with_progress(
-    path: &Path,
-    filter: Option<&str>,
-    timeout_ms: u64,
-    execution_cwd: Option<&Path>,
-    cli_skill_dirs: &[PathBuf],
-    progress: Option<TestRunProgress>,
-) -> Result<Vec<TestResult>, String> {
-    let ParsedTestFile {
-        source,
-        program,
-        test_names,
-    } = parse_test_file(path, filter)?;
-
-    let mut results = Vec::new();
-
-    for (test_index, test_name) in test_names.iter().enumerate() {
-        emit_progress(
-            &progress,
-            TestRunEvent::TestStarted {
-                name: test_name.clone(),
-                file: path.display().to_string(),
-                test_index: test_index + 1,
-                total_tests_in_file: test_names.len(),
-            },
-        );
-        harn_vm::reset_thread_local_state();
-
-        let start = Instant::now();
-
-        let chunk = match harn_vm::Compiler::new().compile_named(&program, test_name) {
-            Ok(c) => c,
-            Err(e) => {
-                push_result(
-                    &mut results,
-                    TestResult {
-                        name: test_name.clone(),
-                        file: path.display().to_string(),
-                        passed: false,
-                        error: Some(format!("Compile error: {e}")),
-                        duration_ms: 0,
-                    },
-                    &progress,
-                );
-                continue;
-            }
-        };
-
-        let local = tokio::task::LocalSet::new();
-        let path_str = path.display().to_string();
-        let timeout = std::time::Duration::from_millis(timeout_ms);
-        let execution_cwd = execution_cwd
-            .map(Path::to_path_buf)
-            .unwrap_or_else(test_execution_cwd);
-        let result = tokio::time::timeout(
-            timeout,
-            local.run_until(async {
-                let mut vm = harn_vm::Vm::new();
-                harn_vm::register_vm_stdlib(&mut vm);
-                crate::install_default_hostlib(&mut vm);
-                let source_parent = path.parent().unwrap_or(std::path::Path::new("."));
-                let project_root = harn_vm::stdlib::process::find_project_root(source_parent);
-                let store_base = project_root.as_deref().unwrap_or(source_parent);
-                let source_dir = source_parent.to_string_lossy().into_owned();
-                harn_vm::register_store_builtins(&mut vm, store_base);
-                harn_vm::register_metadata_builtins(&mut vm, store_base);
-                let pipeline_name = path.file_stem().and_then(|s| s.to_str()).unwrap_or("test");
-                harn_vm::register_checkpoint_builtins(&mut vm, store_base, pipeline_name);
-                vm.set_source_info(&path_str, &source);
-                harn_vm::stdlib::process::set_thread_execution_context(Some(
-                    harn_vm::orchestration::RunExecutionRecord {
-                        cwd: Some(execution_cwd.to_string_lossy().into_owned()),
-                        source_dir: Some(source_dir),
-                        env: std::collections::BTreeMap::new(),
-                        adapter: None,
-                        repo_path: None,
-                        worktree_path: None,
-                        branch: None,
-                        base_ref: None,
-                        cleanup: None,
-                    },
-                ));
-                if let Some(ref root) = project_root {
-                    vm.set_project_root(root);
-                }
-                if let Some(parent) = path.parent() {
-                    if !parent.as_os_str().is_empty() {
-                        vm.set_source_dir(parent);
-                    }
-                }
-                let loaded =
-                    crate::skill_loader::load_skills(&crate::skill_loader::SkillLoaderInputs {
-                        cli_dirs: cli_skill_dirs.to_vec(),
-                        source_path: Some(path.to_path_buf()),
-                    });
-                crate::skill_loader::emit_loader_warnings(&loaded.loader_warnings);
-                crate::skill_loader::install_skills_global(&mut vm, &loaded);
-                let extensions = crate::package::load_runtime_extensions(path);
-                crate::package::install_runtime_extensions(&extensions);
-                crate::package::install_manifest_triggers(&mut vm, &extensions)
-                    .await
-                    .map_err(|error| format!("failed to install manifest triggers: {error}"))?;
-                crate::package::install_manifest_hooks(&mut vm, &extensions)
-                    .await
-                    .map_err(|error| format!("failed to install manifest hooks: {error}"))?;
-                vm.set_harness(harn_vm::Harness::real());
-                let result = match vm.execute(&chunk).await {
-                    Ok(val) => Ok(val),
-                    Err(e) => {
-                        let formatted = vm.format_runtime_error(&e);
-                        Err(formatted)
-                    }
-                };
-                harn_vm::egress::reset_egress_policy_for_host();
-                result
-            }),
-        )
-        .await;
-
-        let duration = start.elapsed().as_millis() as u64;
-
-        match result {
-            Ok(Ok(_)) => {
-                push_result(
-                    &mut results,
-                    TestResult {
-                        name: test_name.clone(),
-                        file: path.display().to_string(),
-                        passed: true,
-                        error: None,
-                        duration_ms: duration,
-                    },
-                    &progress,
-                );
-            }
-            Ok(Err(e)) => {
-                push_result(
-                    &mut results,
-                    TestResult {
-                        name: test_name.clone(),
-                        file: path.display().to_string(),
-                        passed: false,
-                        error: Some(e),
-                        duration_ms: duration,
-                    },
-                    &progress,
-                );
-            }
-            Err(_) => {
-                push_result(
-                    &mut results,
-                    TestResult {
-                        name: test_name.clone(),
-                        file: path.display().to_string(),
-                        passed: false,
-                        error: Some(format!("timed out after {timeout_ms}ms")),
-                        duration_ms: timeout_ms,
-                    },
-                    &progress,
-                );
-            }
-        }
-    }
-
-    Ok(results)
-}
-
-/// Run all test_* pipelines in a single source file using the VM.
-pub async fn run_test_file(
-    path: &Path,
-    filter: Option<&str>,
-    timeout_ms: u64,
-    execution_cwd: Option<&Path>,
-    cli_skill_dirs: &[PathBuf],
-) -> Result<Vec<TestResult>, String> {
-    run_test_file_with_progress(
-        path,
-        filter,
-        timeout_ms,
-        execution_cwd,
-        cli_skill_dirs,
-        None,
-    )
-    .await
 }
 
 /// Discover and run tests in a file or directory.
@@ -336,9 +133,18 @@ pub async fn run_tests(
     parallel: bool,
     cli_skill_dirs: &[PathBuf],
 ) -> TestSummary {
-    run_tests_with_progress(path, filter, timeout_ms, parallel, cli_skill_dirs, None).await
+    let options = RunOptions {
+        filter: filter.map(str::to_owned),
+        timeout_ms,
+        parallel,
+        jobs: None,
+        cli_skill_dirs: cli_skill_dirs.to_vec(),
+        progress: None,
+    };
+    run_tests_with_options(path, &options).await
 }
 
+/// Backwards-compatible progress-emitting entry point.
 pub async fn run_tests_with_progress(
     path: &Path,
     filter: Option<&str>,
@@ -347,160 +153,79 @@ pub async fn run_tests_with_progress(
     cli_skill_dirs: &[PathBuf],
     progress: Option<TestRunProgress>,
 ) -> TestSummary {
+    let options = RunOptions {
+        filter: filter.map(str::to_owned),
+        timeout_ms,
+        parallel,
+        jobs: None,
+        cli_skill_dirs: cli_skill_dirs.to_vec(),
+        progress,
+    };
+    run_tests_with_options(path, &options).await
+}
+
+/// Run tests with full control over scheduling, worker count, and
+/// progress reporting. Workers and scheduling mode are reported via
+/// `TestRunEvent::SuiteDiscovered` so consumers can render their own
+/// banner instead of the runner printing to stdout directly.
+pub async fn run_tests_with_options(path: &Path, options: &RunOptions) -> TestSummary {
     // Default LLM provider to "mock" in test mode unless caller overrides.
     let _default_llm_provider = ScopedEnvVar::set_if_unset("HARN_LLM_PROVIDER", "mock");
     let _disable_llm_calls = ScopedEnvVar::set(harn_vm::llm::LLM_CALLS_DISABLED_ENV, "1");
 
     let start = Instant::now();
-    let mut all_results = Vec::new();
 
     let canonical_target = canonicalize_existing_path(path);
     let files = if canonical_target.is_dir() {
         discover_test_files(&canonical_target)
     } else {
-        vec![canonical_target]
+        vec![canonical_target.clone()]
     };
-    let file_plans = files
-        .into_iter()
-        .map(|file| {
-            let test_count = parse_test_file(&file, filter)
-                .map(|parsed| parsed.test_names.len())
-                .unwrap_or(0);
-            TestFilePlan { file, test_count }
-        })
-        .collect::<Vec<_>>();
-    let total_tests = file_plans.iter().map(|plan| plan.test_count).sum();
-    let total_files = file_plans.iter().filter(|plan| plan.test_count > 0).count();
+
+    let workers = resolve_workers(options);
+    let timings_path = timings_cache_path(&canonical_target);
+    let timings = timings_path
+        .as_deref()
+        .map(load_timings_cache)
+        .unwrap_or_default();
+
+    let discovery = discover_test_cases(&files, options.filter.as_deref(), workers);
+
     emit_progress(
-        &progress,
+        &options.progress,
         TestRunEvent::SuiteDiscovered {
-            total_tests,
-            total_files,
-            parallel,
+            total_tests: discovery.cases.len(),
+            total_files: discovery.files_with_tests,
+            parallel: options.parallel,
+            workers,
         },
     );
-    if !parallel && should_warn_large_sequential_suite(total_tests, total_files) {
+    if workers == 1
+        && should_warn_large_sequential_suite(discovery.cases.len(), discovery.files_with_tests)
+    {
         emit_progress(
-            &progress,
+            &options.progress,
             TestRunEvent::LargeSequentialSuite {
-                total_tests,
-                total_files,
+                total_tests: discovery.cases.len(),
+                total_files: discovery.files_with_tests,
             },
         );
     }
 
-    if parallel {
-        let mut handles = Vec::new();
-        let mut progress_file_index = 0;
-        for plan in file_plans {
-            let filter = filter.map(|s| s.to_string());
-            let cli_skill_dirs = cli_skill_dirs.to_vec();
-            let progress = progress.clone();
-            if plan.test_count > 0 {
-                progress_file_index += 1;
-                emit_progress(
-                    &progress,
-                    TestRunEvent::FileStarted {
-                        file: plan.file.display().to_string(),
-                        file_index: progress_file_index,
-                        total_files,
-                        test_count: plan.test_count,
-                    },
-                );
-            }
-            handles.push(tokio::task::spawn_blocking(move || {
-                let execution_cwd = plan
-                    .file
-                    .parent()
-                    .filter(|parent| !parent.as_os_str().is_empty())
-                    .map(Path::to_path_buf);
-                run_test_file_on_isolated_thread(
-                    &plan.file,
-                    filter.as_deref(),
-                    timeout_ms,
-                    execution_cwd.as_deref(),
-                    &cli_skill_dirs,
-                    None,
-                )
-            }));
-        }
-        for handle in handles {
-            match handle.await {
-                Ok(Ok(r)) => {
-                    for result in &r {
-                        emit_progress(&progress, TestRunEvent::TestFinished(result.clone()));
-                    }
-                    all_results.extend(r);
-                }
-                Ok(Err(e)) => {
-                    let result = TestResult {
-                        name: "<file error>".to_string(),
-                        file: String::new(),
-                        passed: false,
-                        error: Some(e),
-                        duration_ms: 0,
-                    };
-                    push_result(&mut all_results, result, &progress);
-                }
-                Err(e) => {
-                    let result = TestResult {
-                        name: "<join error>".to_string(),
-                        file: String::new(),
-                        passed: false,
-                        error: Some(format!("{e}")),
-                        duration_ms: 0,
-                    };
-                    push_result(&mut all_results, result, &progress);
-                }
-            }
-        }
-    } else {
-        let mut progress_file_index = 0;
-        for plan in &file_plans {
-            if plan.test_count > 0 {
-                progress_file_index += 1;
-                emit_progress(
-                    &progress,
-                    TestRunEvent::FileStarted {
-                        file: plan.file.display().to_string(),
-                        file_index: progress_file_index,
-                        total_files,
-                        test_count: plan.test_count,
-                    },
-                );
-            }
-            let execution_cwd = plan
-                .file
-                .parent()
-                .filter(|parent| !parent.as_os_str().is_empty());
-            match run_test_file_with_progress(
-                &plan.file,
-                filter,
-                timeout_ms,
-                execution_cwd,
-                cli_skill_dirs,
-                progress.clone(),
-            )
-            .await
-            {
-                Ok(results) => all_results.extend(results),
-                Err(e) => {
-                    let result = TestResult {
-                        name: "<file error>".to_string(),
-                        file: plan.file.display().to_string(),
-                        passed: false,
-                        error: Some(e),
-                        duration_ms: 0,
-                    };
-                    push_result(&mut all_results, result, &progress);
-                }
-            }
-        }
-    }
+    let mut cases = discovery.cases;
+    sort_cases_longest_first(&mut cases, &timings);
+
+    let mut all_results = discovery.discovery_errors;
+    let total_tests = cases.len();
+    all_results.extend(execute_cases(cases, workers, options, total_tests).await);
 
     let total = all_results.len();
     let passed = all_results.iter().filter(|r| r.passed).count();
     let failed = total - passed;
+
+    if let Some(path) = timings_path.as_deref() {
+        update_timings_cache(path, timings, &all_results);
+    }
 
     TestSummary {
         results: all_results,
@@ -511,37 +236,580 @@ pub async fn run_tests_with_progress(
     }
 }
 
-fn run_test_file_on_isolated_thread(
-    file: &Path,
+/// Backwards-compatible single-file API used by `harn dev`.
+///
+/// Runs every test in one file on the current thread. The new scheduler
+/// uses per-test worker threads, but `harn dev` re-runs a single module
+/// in the foreground after each rebuild — the queueing machinery would
+/// add latency without parallelism to gain back, so we keep this path
+/// minimal.
+pub async fn run_test_file(
+    path: &Path,
     filter: Option<&str>,
     timeout_ms: u64,
     execution_cwd: Option<&Path>,
     cli_skill_dirs: &[PathBuf],
-    progress: Option<TestRunProgress>,
 ) -> Result<Vec<TestResult>, String> {
-    let runtime = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .map_err(|error| format!("failed to start test runtime: {error}"))?;
-    runtime.block_on(run_test_file_with_progress(
-        file,
-        filter,
-        timeout_ms,
-        execution_cwd,
-        cli_skill_dirs,
-        progress,
-    ))
+    let source =
+        fs::read_to_string(path).map_err(|e| format!("Failed to read {}: {e}", path.display()))?;
+    let program = parse_program(&source)?;
+    let source = Arc::new(source);
+    let program = Arc::new(program);
+
+    let cases = extract_cases_from_program(path, &source, &program, filter, usize::MAX);
+
+    let mut results = Vec::with_capacity(cases.len());
+    let execution_cwd = execution_cwd
+        .map(Path::to_path_buf)
+        .unwrap_or_else(test_execution_cwd);
+    for case in cases {
+        results.push(execute_case(&case, &execution_cwd, timeout_ms, cli_skill_dirs).await);
+    }
+    Ok(results)
+}
+
+fn resolve_workers(options: &RunOptions) -> usize {
+    if !options.parallel {
+        return 1;
+    }
+    if let Some(jobs) = options.jobs {
+        return jobs.max(1);
+    }
+    if let Ok(raw) = std::env::var(HARN_TEST_JOBS_ENV) {
+        if let Ok(parsed) = raw.trim().parse::<usize>() {
+            if parsed >= 1 {
+                return parsed;
+            }
+        }
+    }
+    let detected = thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1);
+    detected.clamp(1, DEFAULT_PARALLEL_JOBS_CAP)
+}
+
+struct Discovery {
+    cases: Vec<TestCase>,
+    files_with_tests: usize,
+    discovery_errors: Vec<TestResult>,
+}
+
+fn discover_test_cases(files: &[PathBuf], filter: Option<&str>, workers: usize) -> Discovery {
+    let mut cases = Vec::new();
+    let mut files_with_tests = 0usize;
+    let mut discovery_errors = Vec::new();
+
+    for file in files {
+        let source = match fs::read_to_string(file) {
+            Ok(s) => s,
+            Err(e) => {
+                discovery_errors.push(TestResult {
+                    name: "<file error>".to_string(),
+                    file: file.display().to_string(),
+                    passed: false,
+                    error: Some(format!("Failed to read {}: {e}", file.display())),
+                    duration_ms: 0,
+                });
+                continue;
+            }
+        };
+
+        let program = match parse_program(&source) {
+            Ok(p) => p,
+            Err(e) => {
+                discovery_errors.push(TestResult {
+                    name: "<file error>".to_string(),
+                    file: file.display().to_string(),
+                    passed: false,
+                    error: Some(e),
+                    duration_ms: 0,
+                });
+                continue;
+            }
+        };
+
+        let source = Arc::new(source);
+        let program = Arc::new(program);
+        let file_cases = extract_cases_from_program(file, &source, &program, filter, workers);
+        if !file_cases.is_empty() {
+            files_with_tests += 1;
+            cases.extend(file_cases);
+        }
+    }
+
+    Discovery {
+        cases,
+        files_with_tests,
+        discovery_errors,
+    }
+}
+
+fn parse_program(source: &str) -> Result<Vec<SNode>, String> {
+    let mut lexer = Lexer::new(source);
+    let tokens = lexer.tokenize().map_err(|e| format!("{e}"))?;
+    let mut parser = Parser::new(tokens);
+    parser.parse().map_err(|e| format!("{e}"))
+}
+
+fn extract_cases_from_program(
+    file: &Path,
+    source: &Arc<String>,
+    program: &Arc<Vec<SNode>>,
+    filter: Option<&str>,
+    workers: usize,
+) -> Vec<TestCase> {
+    let mut cases = Vec::new();
+    for snode in program.iter() {
+        let Some(meta) = inspect_test_pipeline(snode) else {
+            continue;
+        };
+        if let Some(pattern) = filter {
+            if !meta.name.contains(pattern) {
+                continue;
+            }
+        }
+        // Cap heavy weight so a single annotated test never deadlocks
+        // when the pool is smaller than the requested concurrency.
+        let weight = meta.weight.min(workers).max(1);
+        cases.push(TestCase {
+            file: file.to_path_buf(),
+            name: meta.name,
+            source: Arc::clone(source),
+            program: Arc::clone(program),
+            serial_group: meta.serial_group,
+            weight,
+        });
+    }
+    cases
+}
+
+struct PipelineMeta {
+    name: String,
+    serial_group: Option<String>,
+    weight: usize,
+}
+
+fn inspect_test_pipeline(snode: &SNode) -> Option<PipelineMeta> {
+    // Pipelines marked `@test`, or named `test_*`, are user tests. The
+    // companion attributes `@serial` and `@heavy` only tune the scheduler
+    // and never make a non-test pipeline discoverable on their own.
+    let (attributes, inner) = match &snode.node {
+        Node::AttributedDecl { attributes, inner } => (attributes.as_slice(), inner.as_ref()),
+        _ => (&[][..], snode),
+    };
+    let name = match &inner.node {
+        Node::Pipeline { name, .. } => name.clone(),
+        _ => return None,
+    };
+    let has_test_attr = attributes.iter().any(|a| a.name == "test");
+    if !has_test_attr && !name.starts_with("test_") {
+        return None;
+    }
+    let serial_group = attributes
+        .iter()
+        .find(|a| a.name == "serial")
+        .map(serial_group_for);
+    let weight = attributes
+        .iter()
+        .find(|a| a.name == "heavy")
+        .and_then(heavy_weight_for)
+        .unwrap_or(1);
+    Some(PipelineMeta {
+        name,
+        serial_group,
+        weight,
+    })
+}
+
+fn serial_group_for(attr: &Attribute) -> String {
+    attr.string_arg("group")
+        .unwrap_or_else(|| "__default__".to_string())
+}
+
+fn heavy_weight_for(attr: &Attribute) -> Option<usize> {
+    attr.args
+        .iter()
+        .find(|a| a.name.as_deref() == Some("threads"))
+        .and_then(|a| match &a.value.node {
+            Node::IntLiteral(n) if *n >= 1 => Some(*n as usize),
+            _ => None,
+        })
+}
+
+fn sort_cases_longest_first(cases: &mut [TestCase], timings: &BTreeMap<String, u64>) {
+    // Sort ascending so the slowest tests sit at the tail and get popped
+    // first by workers. New (unmeasured) tests share the bottom of the
+    // queue alongside the fastest known ones — they'll appear in stable
+    // file/name order, and once they get their first timing they'll
+    // float up to where they belong.
+    cases.sort_by(|a, b| {
+        let key_a = timings_key(&a.file, &a.name);
+        let key_b = timings_key(&b.file, &b.name);
+        let dur_a = timings.get(&key_a).copied().unwrap_or(0);
+        let dur_b = timings.get(&key_b).copied().unwrap_or(0);
+        dur_a
+            .cmp(&dur_b)
+            .then_with(|| a.file.cmp(&b.file))
+            .then_with(|| a.name.cmp(&b.name))
+    });
+}
+
+fn timings_key(file: &Path, name: &str) -> String {
+    format!("{}::{}", file.display(), name)
+}
+
+fn timings_cache_path(target: &Path) -> Option<PathBuf> {
+    // Anchor the cache at the project root if discoverable, otherwise at
+    // the directory the suite was launched from. The cache is shared
+    // across runs in the same workspace, so a per-suite cache would
+    // fragment timings whenever a user runs a subset.
+    let probe_root = if target.is_dir() {
+        target.to_path_buf()
+    } else {
+        target.parent()?.to_path_buf()
+    };
+    let root = harn_vm::stdlib::process::find_project_root(&probe_root)
+        .unwrap_or_else(|| probe_root.clone());
+    Some(root.join(TIMINGS_CACHE_RELATIVE_PATH))
+}
+
+fn load_timings_cache(path: &Path) -> BTreeMap<String, u64> {
+    let Ok(contents) = fs::read_to_string(path) else {
+        return BTreeMap::new();
+    };
+    serde_json::from_str::<BTreeMap<String, u64>>(&contents).unwrap_or_default()
+}
+
+fn update_timings_cache(path: &Path, mut existing: BTreeMap<String, u64>, results: &[TestResult]) {
+    for result in results {
+        if result.name == "<file error>" || result.name == "<join error>" {
+            continue;
+        }
+        existing.insert(
+            timings_key(Path::new(&result.file), &result.name),
+            result.duration_ms,
+        );
+    }
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+    if let Ok(serialized) = serde_json::to_string(&existing) {
+        let _ = fs::write(path, serialized);
+    }
+}
+
+async fn execute_cases(
+    cases: Vec<TestCase>,
+    workers: usize,
+    options: &RunOptions,
+    total_tests: usize,
+) -> Vec<TestResult> {
+    if cases.is_empty() {
+        return Vec::new();
+    }
+    let completed = Arc::new(Mutex::new(0usize));
+    if workers <= 1 {
+        let mut results = Vec::with_capacity(cases.len());
+        for case in cases {
+            let cwd = case_execution_cwd(&case);
+            let test_index = next_test_index(&completed);
+            emit_progress(
+                &options.progress,
+                TestRunEvent::TestStarted {
+                    name: case.name.clone(),
+                    file: case.file.display().to_string(),
+                    test_index,
+                    total_tests,
+                },
+            );
+            let result =
+                execute_case(&case, &cwd, options.timeout_ms, &options.cli_skill_dirs).await;
+            emit_progress(
+                &options.progress,
+                TestRunEvent::TestFinished(result.clone()),
+            );
+            results.push(result);
+        }
+        return results;
+    }
+
+    let queue = Arc::new(Mutex::new(cases));
+    let gate = Arc::new(ResourceGate::new(workers));
+    let results: Arc<Mutex<Vec<TestResult>>> = Arc::new(Mutex::new(Vec::new()));
+
+    let mut handles = Vec::with_capacity(workers);
+    for worker_idx in 0..workers {
+        let queue = Arc::clone(&queue);
+        let gate = Arc::clone(&gate);
+        let results = Arc::clone(&results);
+        let completed = Arc::clone(&completed);
+        let timeout_ms = options.timeout_ms;
+        let cli_skill_dirs = options.cli_skill_dirs.clone();
+        let progress = options.progress.clone();
+        let handle = thread::Builder::new()
+            .name(format!("harn-test-worker-{worker_idx}"))
+            .spawn(move || {
+                let runtime = match tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                {
+                    Ok(rt) => rt,
+                    Err(error) => {
+                        results.lock().unwrap().push(TestResult {
+                            name: "<worker error>".to_string(),
+                            file: String::new(),
+                            passed: false,
+                            error: Some(format!("failed to start test runtime: {error}")),
+                            duration_ms: 0,
+                        });
+                        return;
+                    }
+                };
+                // Cases are sorted ascending by historical duration; popping
+                // from the tail gives this worker the slowest unclaimed
+                // test, which front-loads long poles and prevents workers
+                // from stranding on quick tests at the end of the run.
+                while let Some(case) = queue.lock().unwrap().pop() {
+                    let _guard = gate.acquire(case.weight, case.serial_group.as_deref());
+                    let cwd = case_execution_cwd(&case);
+                    let test_index = next_test_index(&completed);
+                    emit_progress(
+                        &progress,
+                        TestRunEvent::TestStarted {
+                            name: case.name.clone(),
+                            file: case.file.display().to_string(),
+                            test_index,
+                            total_tests,
+                        },
+                    );
+                    let result =
+                        runtime.block_on(execute_case(&case, &cwd, timeout_ms, &cli_skill_dirs));
+                    emit_progress(&progress, TestRunEvent::TestFinished(result.clone()));
+                    results.lock().unwrap().push(result);
+                }
+            })
+            .expect("spawning a harn-test worker thread should succeed");
+        handles.push(handle);
+    }
+
+    for handle in handles {
+        let _ = handle.join();
+    }
+
+    // All workers have joined, so this Arc holds the only remaining
+    // reference. The lock-and-clone fallback survives the unlikely case
+    // where a panic-unwind kept an extra reference alive.
+    Arc::try_unwrap(results)
+        .map(|m| m.into_inner().unwrap_or_default())
+        .unwrap_or_else(|arc| arc.lock().unwrap().clone())
+}
+
+fn next_test_index(counter: &Mutex<usize>) -> usize {
+    let mut guard = counter.lock().unwrap();
+    *guard += 1;
+    *guard
+}
+
+fn case_execution_cwd(case: &TestCase) -> PathBuf {
+    case.file
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .map(Path::to_path_buf)
+        .unwrap_or_else(test_execution_cwd)
+}
+
+/// Coordinates worker permits and serial-group exclusivity without
+/// requiring an async lock — workers are dedicated OS threads, so a
+/// classic Mutex+Condvar gate keeps everything off the tokio scheduler.
+struct ResourceGate {
+    state: Mutex<GateState>,
+    cond: Condvar,
+    capacity: usize,
+}
+
+struct GateState {
+    available: usize,
+    busy_groups: HashSet<String>,
+}
+
+struct GateGuard<'a> {
+    gate: &'a ResourceGate,
+    weight: usize,
+    group: Option<String>,
+}
+
+impl ResourceGate {
+    fn new(capacity: usize) -> Self {
+        Self {
+            state: Mutex::new(GateState {
+                available: capacity,
+                busy_groups: HashSet::new(),
+            }),
+            cond: Condvar::new(),
+            capacity,
+        }
+    }
+
+    fn acquire(&self, weight: usize, group: Option<&str>) -> GateGuard<'_> {
+        let weight = weight.min(self.capacity).max(1);
+        let mut state = self.state.lock().unwrap();
+        loop {
+            let group_free = group.is_none_or(|g| !state.busy_groups.contains(g));
+            if state.available >= weight && group_free {
+                state.available -= weight;
+                if let Some(g) = group {
+                    state.busy_groups.insert(g.to_string());
+                }
+                return GateGuard {
+                    gate: self,
+                    weight,
+                    group: group.map(str::to_owned),
+                };
+            }
+            state = self.cond.wait(state).unwrap();
+        }
+    }
+}
+
+impl Drop for GateGuard<'_> {
+    fn drop(&mut self) {
+        let mut state = self.gate.state.lock().unwrap();
+        state.available += self.weight;
+        if let Some(group) = self.group.as_deref() {
+            state.busy_groups.remove(group);
+        }
+        self.gate.cond.notify_all();
+    }
+}
+
+async fn execute_case(
+    case: &TestCase,
+    execution_cwd: &Path,
+    timeout_ms: u64,
+    cli_skill_dirs: &[PathBuf],
+) -> TestResult {
+    harn_vm::reset_thread_local_state();
+
+    let start = Instant::now();
+
+    let chunk = match harn_vm::Compiler::new().compile_named(&case.program, &case.name) {
+        Ok(c) => c,
+        Err(e) => {
+            return TestResult {
+                name: case.name.clone(),
+                file: case.file.display().to_string(),
+                passed: false,
+                error: Some(format!("Compile error: {e}")),
+                duration_ms: 0,
+            };
+        }
+    };
+
+    let local = tokio::task::LocalSet::new();
+    let timeout = std::time::Duration::from_millis(timeout_ms);
+    let file_display = case.file.display().to_string();
+    let result = tokio::time::timeout(
+        timeout,
+        local.run_until(async {
+            let mut vm = harn_vm::Vm::new();
+            harn_vm::register_vm_stdlib(&mut vm);
+            crate::install_default_hostlib(&mut vm);
+            let source_parent = case.file.parent().unwrap_or(Path::new("."));
+            let project_root = harn_vm::stdlib::process::find_project_root(source_parent);
+            let store_base = project_root.as_deref().unwrap_or(source_parent);
+            let source_dir = source_parent.to_string_lossy().into_owned();
+            harn_vm::register_store_builtins(&mut vm, store_base);
+            harn_vm::register_metadata_builtins(&mut vm, store_base);
+            let pipeline_name = case
+                .file
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("test");
+            harn_vm::register_checkpoint_builtins(&mut vm, store_base, pipeline_name);
+            vm.set_source_info(&file_display, &case.source);
+            harn_vm::stdlib::process::set_thread_execution_context(Some(
+                harn_vm::orchestration::RunExecutionRecord {
+                    cwd: Some(execution_cwd.to_string_lossy().into_owned()),
+                    source_dir: Some(source_dir),
+                    env: BTreeMap::new(),
+                    adapter: None,
+                    repo_path: None,
+                    worktree_path: None,
+                    branch: None,
+                    base_ref: None,
+                    cleanup: None,
+                },
+            ));
+            if let Some(ref root) = project_root {
+                vm.set_project_root(root);
+            }
+            if let Some(parent) = case.file.parent() {
+                if !parent.as_os_str().is_empty() {
+                    vm.set_source_dir(parent);
+                }
+            }
+            let loaded =
+                crate::skill_loader::load_skills(&crate::skill_loader::SkillLoaderInputs {
+                    cli_dirs: cli_skill_dirs.to_vec(),
+                    source_path: Some(case.file.clone()),
+                });
+            crate::skill_loader::emit_loader_warnings(&loaded.loader_warnings);
+            crate::skill_loader::install_skills_global(&mut vm, &loaded);
+            let extensions = crate::package::load_runtime_extensions(&case.file);
+            crate::package::install_runtime_extensions(&extensions);
+            crate::package::install_manifest_triggers(&mut vm, &extensions)
+                .await
+                .map_err(|error| format!("failed to install manifest triggers: {error}"))?;
+            crate::package::install_manifest_hooks(&mut vm, &extensions)
+                .await
+                .map_err(|error| format!("failed to install manifest hooks: {error}"))?;
+            vm.set_harness(harn_vm::Harness::real());
+            let result = match vm.execute(&chunk).await {
+                Ok(val) => Ok(val),
+                Err(e) => Err(vm.format_runtime_error(&e)),
+            };
+            harn_vm::egress::reset_egress_policy_for_host();
+            result
+        }),
+    )
+    .await;
+
+    let duration = start.elapsed().as_millis() as u64;
+
+    match result {
+        Ok(Ok(_)) => TestResult {
+            name: case.name.clone(),
+            file: file_display,
+            passed: true,
+            error: None,
+            duration_ms: duration,
+        },
+        Ok(Err(e)) => TestResult {
+            name: case.name.clone(),
+            file: file_display,
+            passed: false,
+            error: Some(e),
+            duration_ms: duration,
+        },
+        Err(_) => TestResult {
+            name: case.name.clone(),
+            file: file_display,
+            passed: false,
+            error: Some(format!("timed out after {timeout_ms}ms")),
+            duration_ms: timeout_ms,
+        },
+    }
 }
 
 fn discover_test_files(dir: &Path) -> Vec<PathBuf> {
     let mut files = Vec::new();
-    if let Ok(entries) = std::fs::read_dir(dir) {
+    if let Ok(entries) = fs::read_dir(dir) {
         for entry in entries.flatten() {
             let path = entry.path();
             if path.is_dir() {
                 files.extend(discover_test_files(&path));
             } else if path.extension().is_some_and(|e| e == "harn") {
-                if let Ok(content) = std::fs::read_to_string(&path) {
+                if let Ok(content) = fs::read_to_string(&path) {
                     if content.contains("test_") || content.contains("@test") {
                         files.push(canonicalize_existing_path(&path));
                     }
@@ -555,13 +823,10 @@ fn discover_test_files(dir: &Path) -> Vec<PathBuf> {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        discover_test_files, run_tests, run_tests_with_progress,
-        should_warn_large_sequential_suite, TestRunEvent, TestRunProgress,
-    };
-    use std::fs;
-    use std::path::Path;
-    use std::sync::{Arc, Mutex};
+    use super::*;
+
+    use std::sync::Arc;
+    use std::time::Duration;
 
     struct TempTestDir {
         inner: tempfile::TempDir,
@@ -595,9 +860,6 @@ mod tests {
         temp.write("suite/annotated.harn", "@test\npipeline annotated(task) {}");
         temp.write("suite/ignore.harn", "pipeline build(task) {}");
 
-        // Pass an absolute path rather than mutating process-wide cwd — the
-        // other test_runner test asserts cwd preservation, and mutating it
-        // from two tests concurrently causes cross-test flakiness.
         let files = discover_test_files(&temp.path().join("suite"));
 
         assert_eq!(files.len(), 3);
@@ -611,72 +873,6 @@ mod tests {
         assert!(files
             .iter()
             .any(|path| path.ends_with("suite/annotated.harn")));
-    }
-
-    #[test]
-    fn large_sequential_suite_warning_threshold_is_conservative() {
-        assert!(!should_warn_large_sequential_suite(49, 9));
-        assert!(should_warn_large_sequential_suite(50, 1));
-        assert!(should_warn_large_sequential_suite(1, 10));
-    }
-
-    #[tokio::test]
-    async fn run_tests_emits_progress_events() {
-        let _env_guard = crate::tests::common::env_lock::lock_env().lock().await;
-        let temp = TempTestDir::new();
-        temp.write(
-            "suite/test_progress.harn",
-            r#"
-pipeline test_alpha(task) {
-  assert_eq(1, 1)
-}
-
-pipeline test_beta(task) {
-  assert_eq(2, 2)
-}
-"#,
-        );
-        let events = Arc::new(Mutex::new(Vec::new()));
-        let captured = Arc::clone(&events);
-        let progress: TestRunProgress = Arc::new(move |event| {
-            captured.lock().unwrap().push(event);
-        });
-
-        let summary = run_tests_with_progress(
-            &temp.path().join("suite"),
-            None,
-            1_000,
-            false,
-            &[],
-            Some(progress),
-        )
-        .await;
-        let events = events.lock().unwrap();
-
-        assert_eq!(summary.failed, 0);
-        assert_eq!(summary.passed, 2);
-        assert!(matches!(
-            events.first(),
-            Some(TestRunEvent::SuiteDiscovered {
-                total_tests: 2,
-                total_files: 1,
-                parallel: false
-            })
-        ));
-        let file_started = events
-            .iter()
-            .position(|event| matches!(event, TestRunEvent::FileStarted { .. }))
-            .expect("file start event");
-        let test_started = events
-            .iter()
-            .position(|event| matches!(event, TestRunEvent::TestStarted { .. }))
-            .expect("test start event");
-        let test_finished = events
-            .iter()
-            .position(|event| matches!(event, TestRunEvent::TestFinished(_)))
-            .expect("test finished event");
-        assert!(file_started < test_started);
-        assert!(test_started < test_finished);
     }
 
     #[tokio::test]
@@ -769,5 +965,257 @@ pipeline test_cli_skills(task) {
 
         assert_eq!(summary.failed, 0, "{:?}", summary.results[0].error);
         assert_eq!(summary.passed, 1);
+    }
+
+    #[test]
+    fn resolve_workers_honors_explicit_jobs() {
+        let mut opts = RunOptions::new(1_000);
+        opts.parallel = true;
+        opts.jobs = Some(3);
+        assert_eq!(resolve_workers(&opts), 3);
+    }
+
+    #[test]
+    fn resolve_workers_returns_one_when_not_parallel() {
+        let mut opts = RunOptions::new(1_000);
+        opts.parallel = false;
+        opts.jobs = Some(8);
+        assert_eq!(resolve_workers(&opts), 1);
+    }
+
+    #[test]
+    fn sort_cases_longest_first_uses_historical_durations() {
+        let source = Arc::new(String::new());
+        let program = Arc::new(Vec::new());
+        let mk = |name: &str| TestCase {
+            file: PathBuf::from("tests/a.harn"),
+            name: name.to_string(),
+            source: Arc::clone(&source),
+            program: Arc::clone(&program),
+            serial_group: None,
+            weight: 1,
+        };
+        let mut cases = vec![mk("test_quick"), mk("test_slow"), mk("test_medium")];
+        let mut timings = BTreeMap::new();
+        timings.insert("tests/a.harn::test_slow".to_string(), 5_000);
+        timings.insert("tests/a.harn::test_medium".to_string(), 1_000);
+
+        sort_cases_longest_first(&mut cases, &timings);
+
+        // Slowest tests live at the tail so workers pop them first.
+        let order: Vec<&str> = cases.iter().map(|c| c.name.as_str()).collect();
+        assert_eq!(order, vec!["test_quick", "test_medium", "test_slow"]);
+    }
+
+    #[test]
+    fn resource_gate_serializes_same_group() {
+        let gate = Arc::new(ResourceGate::new(4));
+        let trace = Arc::new(Mutex::new(Vec::<&'static str>::new()));
+
+        let g_a = {
+            let trace = Arc::clone(&trace);
+            let gate = Arc::clone(&gate);
+            thread::spawn(move || {
+                let _guard = gate.acquire(1, Some("login"));
+                trace.lock().unwrap().push("a-start");
+                thread::sleep(Duration::from_millis(50));
+                trace.lock().unwrap().push("a-end");
+            })
+        };
+        // Give thread A time to grab the lock first.
+        thread::sleep(Duration::from_millis(10));
+        let g_b = {
+            let trace = Arc::clone(&trace);
+            let gate = Arc::clone(&gate);
+            thread::spawn(move || {
+                let _guard = gate.acquire(1, Some("login"));
+                trace.lock().unwrap().push("b-start");
+                trace.lock().unwrap().push("b-end");
+            })
+        };
+        g_a.join().unwrap();
+        g_b.join().unwrap();
+
+        let trace = trace.lock().unwrap();
+        // B must not start until A ends.
+        let a_end = trace.iter().position(|t| *t == "a-end").unwrap();
+        let b_start = trace.iter().position(|t| *t == "b-start").unwrap();
+        assert!(a_end < b_start, "B started before A finished: {trace:?}");
+    }
+
+    #[test]
+    fn resource_gate_allows_independent_groups_in_parallel() {
+        let gate = Arc::new(ResourceGate::new(4));
+        let _guard_a = gate.acquire(1, Some("alpha"));
+        // Acquiring beta should not block — the other group is unrelated.
+        let acquired = std::sync::Mutex::new(false);
+        thread::scope(|s| {
+            s.spawn(|| {
+                let _ = gate.acquire(1, Some("beta"));
+                *acquired.lock().unwrap() = true;
+            });
+        });
+        assert!(*acquired.lock().unwrap());
+    }
+
+    #[test]
+    fn resource_gate_caps_heavy_weight_at_capacity() {
+        // A test that asks for more than the pool size must still be
+        // schedulable rather than deadlocking.
+        let gate = Arc::new(ResourceGate::new(2));
+        let _g = gate.acquire(99, None);
+        // Available is now 0; another single-weight task must still wait.
+        let started = Arc::new(Mutex::new(false));
+        let inner = Arc::clone(&started);
+        let gate2 = Arc::clone(&gate);
+        let handle = thread::spawn(move || {
+            let _guard = gate2.acquire(1, None);
+            *inner.lock().unwrap() = true;
+        });
+        thread::sleep(Duration::from_millis(20));
+        assert!(!*started.lock().unwrap(), "should still be waiting");
+        drop(_g);
+        handle.join().unwrap();
+        assert!(*started.lock().unwrap());
+    }
+
+    #[tokio::test]
+    async fn parallel_scheduler_runs_heavy_tests_without_oversubscribing() {
+        // Heavy(2) should never run concurrently with another test when
+        // the pool only has two workers — there are no spare permits.
+        let _env_guard = crate::tests::common::env_lock::lock_env().lock().await;
+        let temp = TempTestDir::new();
+        temp.write(
+            "suite/test_heavy.harn",
+            r#"
+@test
+@heavy(threads: 2)
+pipeline test_heavy_one(task) {}
+
+@test
+pipeline test_light(task) {}
+"#,
+        );
+
+        let opts = RunOptions {
+            filter: None,
+            timeout_ms: 5_000,
+            parallel: true,
+            jobs: Some(2),
+            cli_skill_dirs: vec![],
+            progress: None,
+        };
+        let summary = run_tests_with_options(&temp.path().join("suite"), &opts).await;
+        assert_eq!(summary.failed, 0, "{:?}", summary.results);
+        assert_eq!(summary.total, 2);
+    }
+
+    #[tokio::test]
+    async fn parallel_scheduler_handles_serial_group_annotation() {
+        let _env_guard = crate::tests::common::env_lock::lock_env().lock().await;
+        let temp = TempTestDir::new();
+        temp.write(
+            "suite/test_serial.harn",
+            r#"
+@test
+@serial(group: "fixture")
+pipeline test_serial_one(task) {}
+
+@test
+@serial(group: "fixture")
+pipeline test_serial_two(task) {}
+"#,
+        );
+
+        let opts = RunOptions {
+            filter: None,
+            timeout_ms: 5_000,
+            parallel: true,
+            jobs: Some(4),
+            cli_skill_dirs: vec![],
+            progress: None,
+        };
+        let summary = run_tests_with_options(&temp.path().join("suite"), &opts).await;
+        assert_eq!(summary.failed, 0, "{:?}", summary.results);
+        assert_eq!(summary.passed, 2);
+    }
+
+    #[tokio::test]
+    async fn parallel_scheduler_persists_timings_cache() {
+        let _env_guard = crate::tests::common::env_lock::lock_env().lock().await;
+        let temp = TempTestDir::new();
+        temp.write(
+            "suite/test_timed.harn",
+            r#"
+@test
+pipeline test_first(task) {}
+
+@test
+pipeline test_second(task) {}
+"#,
+        );
+
+        let opts = RunOptions {
+            filter: None,
+            timeout_ms: 5_000,
+            parallel: true,
+            jobs: Some(2),
+            cli_skill_dirs: vec![],
+            progress: None,
+        };
+        let summary = run_tests_with_options(&temp.path().join("suite"), &opts).await;
+        assert_eq!(summary.passed, 2);
+        let cache = temp.path().join("suite/.harn/test-timings.json");
+        assert!(cache.exists(), "expected timings cache at {cache:?}");
+        let stored: BTreeMap<String, u64> =
+            serde_json::from_str(&fs::read_to_string(&cache).unwrap()).unwrap();
+        assert!(
+            stored.keys().any(|key| key.contains("test_first")),
+            "expected timings for test_first in {stored:?}"
+        );
+        assert!(
+            stored.keys().any(|key| key.contains("test_second")),
+            "expected timings for test_second in {stored:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn parallel_scheduler_emits_progress_events() {
+        let _env_guard = crate::tests::common::env_lock::lock_env().lock().await;
+        let temp = TempTestDir::new();
+        temp.write(
+            "suite/test_events.harn",
+            r#"
+@test
+pipeline test_a(task) {}
+
+@test
+pipeline test_b(task) {}
+"#,
+        );
+
+        let events: Arc<Mutex<Vec<&'static str>>> = Arc::new(Mutex::new(Vec::new()));
+        let events_for_progress = Arc::clone(&events);
+        let progress: TestRunProgress = Arc::new(move |event| {
+            events_for_progress.lock().unwrap().push(match event {
+                TestRunEvent::SuiteDiscovered { .. } => "suite",
+                TestRunEvent::LargeSequentialSuite { .. } => "large-seq",
+                TestRunEvent::TestStarted { .. } => "started",
+                TestRunEvent::TestFinished(_) => "finished",
+            });
+        });
+        let opts = RunOptions {
+            filter: None,
+            timeout_ms: 5_000,
+            parallel: true,
+            jobs: Some(2),
+            cli_skill_dirs: vec![],
+            progress: Some(progress),
+        };
+        let _ = run_tests_with_options(&temp.path().join("suite"), &opts).await;
+        let events = events.lock().unwrap();
+        assert_eq!(events.first().copied(), Some("suite"));
+        assert_eq!(events.iter().filter(|e| **e == "started").count(), 2);
+        assert_eq!(events.iter().filter(|e| **e == "finished").count(), 2);
     }
 }

--- a/crates/harn-parser/src/typechecker/inference/statements.rs
+++ b/crates/harn-parser/src/typechecker/inference/statements.rs
@@ -1889,7 +1889,7 @@ impl TypeChecker {
             match attr.name.as_str() {
                 "deprecated" | "test" | "complexity" | "acp_tool" | "acp_skill" | "invariant"
                 | "deterministic" | "semantic" | "archivist" | "retroactive" | "persona"
-                | "step" | "trigger" | "handoff" | "budget" | "command" => {}
+                | "step" | "trigger" | "handoff" | "budget" | "command" | "serial" | "heavy" => {}
                 other => {
                     self.warning_at(
                         Code::UnknownAttribute,
@@ -1941,6 +1941,18 @@ impl TypeChecker {
                 self.warning_at(
                     Code::InvalidAttributeTarget,
                     "`@command` only applies to pipeline declarations".to_string(),
+                    attr.span,
+                );
+            }
+            if matches!(attr.name.as_str(), "serial" | "heavy")
+                && !matches!(inner.node, Node::Pipeline { .. })
+            {
+                self.warning_at(
+                    Code::InvalidAttributeTarget,
+                    format!(
+                        "`@{}` only applies to pipeline declarations (use on `@test` or `test_*` pipelines)",
+                        attr.name
+                    ),
                     attr.span,
                 );
             }
@@ -2053,6 +2065,8 @@ impl TypeChecker {
             "budget" => self.validate_budget_args(attr),
             "deprecated" => self.validate_deprecated_args(attr),
             "command" => self.validate_command_args(attr),
+            "serial" => self.validate_serial_args(attr),
+            "heavy" => self.validate_heavy_args(attr),
             "test" if !attr.args.is_empty() => {
                 self.warning_at(
                     Code::InvalidAttributeArgument,
@@ -2400,6 +2414,61 @@ impl TypeChecker {
                 continue;
             };
             self.expect_budget_value("@budget", name, &arg.value, arg.span);
+        }
+    }
+
+    fn validate_serial_args(&mut self, attr: &Attribute) {
+        // `@serial` may be bare or take a single `group: "name"` arg.
+        const KNOWN_KEYS: &[&str] = &["group"];
+        for arg in &attr.args {
+            let Some(name) = self.require_named_arg("@serial", arg) else {
+                continue;
+            };
+            if !KNOWN_KEYS.contains(&name) {
+                self.warning_at(
+                    Code::InvalidAttributeArgument,
+                    format!("unknown `@serial` argument `{name}`; expected one of {KNOWN_KEYS:?}"),
+                    arg.span,
+                );
+                continue;
+            }
+            self.expect_symbol_like("@serial", name, &arg.value, arg.span);
+        }
+    }
+
+    fn validate_heavy_args(&mut self, attr: &Attribute) {
+        // `@heavy` requires a positive integer `threads` arg.
+        const KNOWN_KEYS: &[&str] = &["threads"];
+        let mut has_threads = false;
+        for arg in &attr.args {
+            let Some(name) = self.require_named_arg("@heavy", arg) else {
+                continue;
+            };
+            if !KNOWN_KEYS.contains(&name) {
+                self.warning_at(
+                    Code::InvalidAttributeArgument,
+                    format!("unknown `@heavy` argument `{name}`; expected one of {KNOWN_KEYS:?}"),
+                    arg.span,
+                );
+                continue;
+            }
+            if name == "threads" {
+                has_threads = true;
+                if !matches!(arg.value.node, Node::IntLiteral(n) if n >= 1) {
+                    self.warning_at(
+                        Code::InvalidAttributeArgument,
+                        "`@heavy(threads: ...)` must be a positive integer".to_string(),
+                        arg.span,
+                    );
+                }
+            }
+        }
+        if !has_threads {
+            self.warning_at(
+                Code::InvalidAttributeArgument,
+                "`@heavy(...)` must specify `threads: <positive int>`".to_string(),
+                attr.span,
+            );
         }
     }
 

--- a/crates/harn-parser/src/typechecker/tests/typing.rs
+++ b/crates/harn-parser/src/typechecker/tests/typing.rs
@@ -306,6 +306,90 @@ fn deploy_activate() -> string { return "ready" }
 }
 
 #[test]
+fn test_test_scheduler_attributes_are_recognized_and_validated() {
+    let warns = warnings(
+        r#"
+@test
+@serial(group: "shared-fixture")
+pipeline test_login_first(task) {}
+
+@test
+@heavy(threads: 2)
+pipeline test_full_rebuild(task) {}
+
+@test
+@serial
+pipeline test_bare_serial(task) {}
+"#,
+    );
+    assert!(
+        warns
+            .iter()
+            .all(|warning| !warning.contains("unknown attribute")
+                && !warning.contains("only applies")
+                && !warning.contains("@serial")
+                && !warning.contains("@heavy")),
+        "test scheduler attributes should validate cleanly: {warns:?}"
+    );
+}
+
+#[test]
+fn test_heavy_attribute_requires_positive_int_threads() {
+    let warns = warnings(
+        r#"
+@test
+@heavy
+pipeline test_missing_threads(task) {}
+
+@test
+@heavy(threads: 0)
+pipeline test_zero_threads(task) {}
+
+@test
+@heavy(threads: "lots")
+pipeline test_string_threads(task) {}
+"#,
+    );
+    assert!(
+        warns.iter().any(|w| w.contains("must specify `threads:")),
+        "expected missing-threads warning, got {warns:?}"
+    );
+    assert!(
+        warns
+            .iter()
+            .filter(|w| w.contains("must be a positive integer"))
+            .count()
+            == 2,
+        "expected two positive-int warnings (for 0 and \"lots\"), got {warns:?}"
+    );
+}
+
+#[test]
+fn test_serial_heavy_attributes_warn_on_non_pipeline_targets() {
+    let warns = warnings(
+        r#"
+@serial(group: "fixture")
+fn helper(x) -> int { return x }
+
+@heavy(threads: 2)
+fn other_helper() -> int { return 0 }
+"#,
+    );
+    assert!(
+        warns
+            .iter()
+            .any(|w| w.contains("`@serial` only applies to pipeline declarations")),
+        "expected @serial target warning, got {warns:?}"
+    );
+    assert!(
+        warns
+            .iter()
+            .any(|w| w.contains("`@heavy` only applies to pipeline declarations")),
+        "expected @heavy target warning, got {warns:?}"
+    );
+}
+
+#[test]
 fn test_durable_persona_annotations_are_recognized_and_validated() {
     let warns = warnings(
         r#"

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -511,6 +511,8 @@ pub fn compute(x: int) -> int { return x + 1 }
 |---|---|
 | `@deprecated(since: "X", use: "Y")` | Type-check warning at every call site (both args optional). |
 | `@test` | Marks a `pipeline` as a test. `harn test` discovers it alongside the legacy `test_*` naming convention. |
+| `@serial(group: "name")` | Test-scheduler hint: tests sharing the group are run serially under `--parallel`. Bare `@serial` shares a default group. |
+| `@heavy(threads: N)` | Test-scheduler hint: the test reserves `N` worker permits under `--parallel` so it never oversubscribes the pool. |
 | `@complexity(allow)` | Suppresses the `cyclomatic-complexity` lint warning on this fn. |
 | `@invariant("fs.writes", "src/**")` | Checked only by `harn check --invariants`. Current built-ins: `fs.writes`, `budget.remaining`, `approval.reachability`. `harn explain --invariant <name> <handler> <file>` prints the violating CFG path. |
 | `@acp_tool(name: "X", kind: "edit", side_effect_level: "mutation", ...)` | Compiles to `tool_define(...)` with the fn as the handler and the named args (minus `name`) lifted into `annotations`. `name` defaults to the fn name. |

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -270,8 +270,9 @@ harn test conformance tests/language/arithmetic.harn # run one conformance file
 harn test conformance tests/stdlib/     # run a conformance subtree
 harn test tests/                       # run user tests in directory
 harn test tests/ --filter "auth*"      # filter by pattern
-harn test tests/ --parallel            # run tests concurrently
+harn test tests/ --parallel            # run tests concurrently with bounded workers
 harn test tests/ --parallel --timing   # show progress and slowest tests/files
+harn test tests/ --parallel -j 4       # pin worker count (also via HARN_TEST_JOBS)
 harn test tests/ --watch               # re-run on file changes
 harn test conformance --verbose        # show per-test timing
 harn test conformance --timing         # show timing summary without verbose failures
@@ -289,7 +290,8 @@ harn test agents-conformance --target http://localhost:8080 --api-key "$KEY"
 | `--json` | Emit conformance results as JSON to stdout, or the agents-conformance leaderboard report |
 | `--json-out <path>` | Write user-test results (or the agents-conformance report) to a JSON file; schemaVersion 1 |
 | `--workspace-id <id>` / `--session-id <id>` | Reuse existing Harness resources for agents conformance setup |
-| `--parallel` | Run tests concurrently |
+| `--parallel` | Run tests concurrently with a bounded worker pool. Slow tests are front-loaded using historical timings from `.harn/test-timings.json` |
+| `--jobs <N>` / `-j <N>` | Maximum concurrent workers (also `HARN_TEST_JOBS`). Defaults to available parallelism, capped at 8 |
 | `--watch` | Re-run tests on file changes (mutually exclusive with `--junit` / `--json-out`) |
 | `--verbose` / `-v` | Show per-test timing and detailed failures |
 | `--timing` | Show per-test timing plus summary statistics |


### PR DESCRIPTION
Closes #2144.

## Summary

- Replaces the file-granular `--parallel` scheduler with a per-pipeline worker pool that has bounded concurrency (`--jobs/-j`, `HARN_TEST_JOBS`, default = available parallelism capped at 8). Tests are sorted longest-first using a persisted `.harn/test-timings.json` cache so future runs front-load long poles instead of stranding workers on quick tests at the end of a run.
- Introduces two scheduler-tuning attributes for user tests:
  - `@serial(group: "name")` — tests sharing a group never run concurrently. Useful for shared fixtures, lock files, or external resources that cannot be multiplexed.
  - `@heavy(threads: N)` — the test reserves `N` worker permits while running so a single heavy test does not oversubscribe the pool.
- Emits the worker count and scheduling mode via `TestRunEvent::SuiteDiscovered` so consumers (CLI, dev mode) render the banner; CLI now prints `Running N tests from M files with W workers (sequential|dynamic scheduling)` at the top of every run.
- Honors the existing `verbose`/`timing` summaries and `LargeSequentialSuite` warning, but the warning now points at `--parallel` enabling the new bounded pool rather than file-level concurrency.

## Why this matters

burin-code's `harn test` suite needed manual file splitting to keep the runner balanced (see #2137, #2144). Per-pipeline scheduling removes that dependency on file shape, and bounding workers eliminates the runaway `sys` time the old strategy produced. Suite authors who genuinely need exclusion now express it via `@serial`/`@heavy` instead of through file layout.

## Test plan

- [x] `cargo test -p harn-cli --lib test_runner` covers worker bounds, serial groups, heavy weights, timings persistence, and progress-event emission.
- [x] `cargo test -p harn-parser test_scheduler_attributes test_heavy_attribute test_serial_heavy` covers `@serial`/`@heavy` typechecker validation.
- [x] `cargo test -p harn-cli --lib` (684 tests) passes.
- [x] Manual smoke: `target/debug/harn test ~/projects/burin-code/Sources/BurinCore/Resources/pipelines/tests/contracts --parallel` reports the new top-of-run banner and the suite passes end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)