### PR TITLE
[codex] Add VM adaptive inline cache specialization

### DIFF
--- a/crates/harn-vm/Cargo.toml
+++ b/crates/harn-vm/Cargo.toml
@@ -127,3 +127,7 @@ harness = false
 [[bench]]
 name = "flow_predicate_union"
 harness = false
+
+[[bench]]
+name = "vm_adaptive_inline_cache"
+harness = false

--- a/crates/harn-vm/benches/vm_adaptive_inline_cache.rs
+++ b/crates/harn-vm/benches/vm_adaptive_inline_cache.rs
@@ -1,0 +1,81 @@
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use harn_vm::{compile_source, register_vm_stdlib, Chunk, Vm};
+
+fn run_chunk(rt: &tokio::runtime::Runtime, chunk: &Chunk) -> String {
+    rt.block_on(async {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let mut vm = Vm::new();
+                register_vm_stdlib(&mut vm);
+                let result = vm.execute(chunk).await.expect("bench script runs");
+                black_box(result);
+                vm.output().to_string()
+            })
+            .await
+    })
+}
+
+fn bench_stable_integer_add_and_closure_call(c: &mut Criterion) {
+    let chunk = compile_source(
+        r#"pipeline t(task) {
+fn erase(x) {
+  return x
+}
+var i = erase(0)
+var total = erase(0)
+while i < erase(200) {
+  total = total + i
+  i = i + erase(1)
+}
+return total
+}"#,
+    )
+    .expect("compile stable adaptive cache fixture");
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+
+    c.bench_function("vm_adaptive_cache_stable_int_add_and_call", |b| {
+        b.iter(|| black_box(run_chunk(&rt, &chunk)))
+    });
+}
+
+fn bench_mixed_numeric_add_deopt(c: &mut Criterion) {
+    let chunk = compile_source(
+        r#"pipeline t(task) {
+fn erase(x) {
+  return x
+}
+let values = [erase(1), erase(2), erase(3), erase(4.0), erase(5.0)]
+var total = erase(0)
+var i = 0
+while i < 40 {
+  for value in values {
+    total = total + value
+  }
+  i = i + 1
+}
+return total
+}"#,
+    )
+    .expect("compile mixed adaptive cache fixture");
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+
+    c.bench_function("vm_adaptive_cache_mixed_numeric_deopt", |b| {
+        b.iter(|| black_box(run_chunk(&rt, &chunk)))
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_stable_integer_add_and_closure_call,
+    bench_mixed_numeric_add_deopt
+);
+criterion_main!(benches);

--- a/crates/harn-vm/src/chunk.rs
+++ b/crates/harn-vm/src/chunk.rs
@@ -380,13 +380,15 @@ pub enum Constant {
     Duration(i64),
 }
 
-/// Monomorphic inline-cache state for bytecode instructions that repeatedly
-/// resolve the same property or builtin method. Cache guards are intentionally
-/// conservative: each entry is tied to the instruction's name constant index
-/// and a single receiver shape. Harn collection values are immutable or
-/// copy-on-write at the VM level, so receiver-kind caches do not need
-/// invalidation. Struct field caches guard on the field name at the cached
-/// slot before reading the indexed field.
+/// Runtime-only inline-cache state for bytecode instructions that repeatedly
+/// see the same dynamic shape. Lookup caches stay monomorphic on a name and
+/// receiver shape. Adaptive caches warm on a stable operand or call target,
+/// then fall back through the generic opcode and replace or reset state when
+/// the observed shape changes.
+///
+/// This vector is intentionally excluded from [`CachedChunk`]: bytecode cache
+/// artifacts keep the slot layout but start with empty runtime feedback in each
+/// process.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum InlineCacheEntry {
     Empty,
@@ -399,7 +401,121 @@ pub(crate) enum InlineCacheEntry {
         argc: usize,
         target: MethodCacheTarget,
     },
+    AdaptiveBinary {
+        op: AdaptiveBinaryOp,
+        state: AdaptiveBinaryState,
+    },
+    DirectCall {
+        state: DirectCallState,
+    },
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AdaptiveBinaryOp {
+    Add,
+    Sub,
+    Mul,
+    Div,
+    Mod,
+    Equal,
+    NotEqual,
+    Less,
+    Greater,
+    LessEqual,
+    GreaterEqual,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum AdaptiveBinaryState {
+    Warmup {
+        shape: BinaryShape,
+        hits: u8,
+    },
+    Specialized {
+        shape: BinaryShape,
+        hits: u64,
+        misses: u64,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BinaryShape {
+    Int,
+    Float,
+    Bool,
+    String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum DirectCallState {
+    Warmup {
+        argc: usize,
+        target: DirectCallTarget,
+        hits: u8,
+    },
+    Specialized {
+        argc: usize,
+        target: DirectCallTarget,
+        hits: u64,
+        misses: u64,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum DirectCallTarget {
+    Closure(Rc<crate::value::VmClosure>),
+}
+
+impl PartialEq for DirectCallTarget {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Closure(left), Self::Closure(right)) => Rc::ptr_eq(left, right),
+        }
+    }
+}
+
+impl Eq for DirectCallTarget {}
+
+impl PartialEq for DirectCallState {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (
+                Self::Warmup {
+                    argc: left_argc,
+                    target: left_target,
+                    hits: left_hits,
+                },
+                Self::Warmup {
+                    argc: right_argc,
+                    target: right_target,
+                    hits: right_hits,
+                },
+            ) => left_argc == right_argc && left_target == right_target && left_hits == right_hits,
+            (
+                Self::Specialized {
+                    argc: left_argc,
+                    target: left_target,
+                    hits: left_hits,
+                    misses: left_misses,
+                },
+                Self::Specialized {
+                    argc: right_argc,
+                    target: right_target,
+                    hits: right_hits,
+                    misses: right_misses,
+                },
+            ) => {
+                left_argc == right_argc
+                    && left_target == right_target
+                    && left_hits == right_hits
+                    && left_misses == right_misses
+            }
+            _ => false,
+        }
+    }
+}
+
+impl Eq for DirectCallState {}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum PropertyCacheTarget {
@@ -690,9 +806,13 @@ impl Chunk {
     /// Emit a single-byte instruction.
     pub fn emit(&mut self, op: Op, line: u32) {
         let col = self.current_col;
+        let op_offset = self.code.len();
         self.code.push(op as u8);
         self.lines.push(line);
         self.columns.push(col);
+        if is_adaptive_binary_op(op) {
+            self.register_inline_cache(op_offset);
+        }
     }
 
     /// Emit an instruction with a u16 argument.
@@ -719,12 +839,16 @@ impl Chunk {
     /// Emit an instruction with a u8 argument.
     pub fn emit_u8(&mut self, op: Op, arg: u8, line: u32) {
         let col = self.current_col;
+        let op_offset = self.code.len();
         self.code.push(op as u8);
         self.code.push(arg);
         self.lines.push(line);
         self.lines.push(line);
         self.columns.push(col);
         self.columns.push(col);
+        if matches!(op, Op::Call) {
+            self.register_inline_cache(op_offset);
+        }
     }
 
     /// Emit a direct builtin call.
@@ -736,6 +860,7 @@ impl Chunk {
         line: u32,
     ) {
         let col = self.current_col;
+        let op_offset = self.code.len();
         self.code.push(Op::CallBuiltin as u8);
         self.code.extend_from_slice(&id.raw().to_be_bytes());
         self.code.push((name_idx >> 8) as u8);
@@ -745,6 +870,7 @@ impl Chunk {
             self.lines.push(line);
             self.columns.push(col);
         }
+        self.register_inline_cache(op_offset);
     }
 
     /// Emit a direct builtin spread call.
@@ -1301,6 +1427,23 @@ impl Chunk {
         }
         out
     }
+}
+
+fn is_adaptive_binary_op(op: Op) -> bool {
+    matches!(
+        op,
+        Op::Add
+            | Op::Sub
+            | Op::Mul
+            | Op::Div
+            | Op::Mod
+            | Op::Equal
+            | Op::NotEqual
+            | Op::Less
+            | Op::Greater
+            | Op::LessEqual
+            | Op::GreaterEqual
+    )
 }
 
 impl Default for Chunk {

--- a/crates/harn-vm/src/vm/ops/arithmetic.rs
+++ b/crates/harn-vm/src/vm/ops/arithmetic.rs
@@ -1,6 +1,9 @@
 use std::rc::Rc;
 
-use crate::value::{VmError, VmValue};
+use crate::chunk::{AdaptiveBinaryOp, AdaptiveBinaryState, BinaryShape, InlineCacheEntry};
+use crate::value::{compare_values, values_equal, VmError, VmValue};
+
+const ADAPTIVE_QUICKEN_THRESHOLD: u8 = 3;
 
 impl super::super::Vm {
     fn push_binary_result(
@@ -15,23 +18,23 @@ impl super::super::Vm {
     }
 
     pub(super) fn execute_add(&mut self) -> Result<(), VmError> {
-        self.push_binary_result(Self::add)
+        self.execute_adaptive_binary(AdaptiveBinaryOp::Add)
     }
 
     pub(super) fn execute_sub(&mut self) -> Result<(), VmError> {
-        self.push_binary_result(Self::sub)
+        self.execute_adaptive_binary(AdaptiveBinaryOp::Sub)
     }
 
     pub(super) fn execute_mul(&mut self) -> Result<(), VmError> {
-        self.push_binary_result(Self::mul)
+        self.execute_adaptive_binary(AdaptiveBinaryOp::Mul)
     }
 
     pub(super) fn execute_div(&mut self) -> Result<(), VmError> {
-        self.push_binary_result(Self::div)
+        self.execute_adaptive_binary(AdaptiveBinaryOp::Div)
     }
 
     pub(super) fn execute_mod(&mut self) -> Result<(), VmError> {
-        self.push_binary_result(Self::modulo)
+        self.execute_adaptive_binary(AdaptiveBinaryOp::Mod)
     }
 
     pub(super) fn execute_pow(&mut self) -> Result<(), VmError> {
@@ -51,6 +54,246 @@ impl super::super::Vm {
             }
         });
         Ok(())
+    }
+
+    pub(super) fn execute_adaptive_binary(&mut self, op: AdaptiveBinaryOp) -> Result<(), VmError> {
+        let (cache_slot, cache_entry) = {
+            let frame = self.frames.last().unwrap();
+            let op_offset = frame.ip.saturating_sub(1);
+            let cache_slot = frame.chunk.inline_cache_slot(op_offset);
+            let cache_entry = cache_slot
+                .map(|slot| frame.chunk.inline_cache_entry(slot))
+                .unwrap_or(InlineCacheEntry::Empty);
+            (cache_slot, cache_entry)
+        };
+
+        let b = self.pop()?;
+        let a = self.pop()?;
+        let shape = BinaryShape::for_values(op, &a, &b);
+
+        let result = if let Some((result, next_entry)) =
+            Self::try_specialized_binary(op, &cache_entry, &a, &b)
+        {
+            if let Some(slot) = cache_slot {
+                let frame = self.frames.last().unwrap();
+                frame.chunk.set_inline_cache_entry(slot, next_entry);
+            }
+            result
+        } else {
+            let result = Self::generic_binary_result(self, op, a, b)?;
+            if let (Some(slot), Some(shape)) = (cache_slot, shape) {
+                let next_entry = Self::next_adaptive_binary_entry(op, cache_entry, shape);
+                let frame = self.frames.last().unwrap();
+                frame.chunk.set_inline_cache_entry(slot, next_entry);
+            }
+            result
+        };
+
+        self.stack.push(result);
+        Ok(())
+    }
+
+    fn try_specialized_binary(
+        op: AdaptiveBinaryOp,
+        cache: &InlineCacheEntry,
+        a: &VmValue,
+        b: &VmValue,
+    ) -> Option<(VmValue, InlineCacheEntry)> {
+        let InlineCacheEntry::AdaptiveBinary {
+            op: cached_op,
+            state:
+                AdaptiveBinaryState::Specialized {
+                    shape,
+                    hits,
+                    misses,
+                },
+        } = cache
+        else {
+            return None;
+        };
+        if *cached_op != op || Some(*shape) != BinaryShape::for_values(op, a, b) {
+            return None;
+        }
+        let result = Self::specialized_binary_result(op, *shape, a, b)?;
+        Some((
+            result,
+            InlineCacheEntry::AdaptiveBinary {
+                op,
+                state: AdaptiveBinaryState::Specialized {
+                    shape: *shape,
+                    hits: hits.saturating_add(1),
+                    misses: *misses,
+                },
+            },
+        ))
+    }
+
+    fn next_adaptive_binary_entry(
+        op: AdaptiveBinaryOp,
+        previous: InlineCacheEntry,
+        shape: BinaryShape,
+    ) -> InlineCacheEntry {
+        let state = match previous {
+            InlineCacheEntry::AdaptiveBinary {
+                op: cached_op,
+                state:
+                    AdaptiveBinaryState::Warmup {
+                        shape: cached,
+                        hits,
+                    },
+            } if cached_op == op && cached == shape => {
+                let hits = hits.saturating_add(1);
+                if hits >= ADAPTIVE_QUICKEN_THRESHOLD {
+                    AdaptiveBinaryState::Specialized {
+                        shape,
+                        hits: hits as u64,
+                        misses: 0,
+                    }
+                } else {
+                    AdaptiveBinaryState::Warmup { shape, hits }
+                }
+            }
+            InlineCacheEntry::AdaptiveBinary {
+                op: cached_op,
+                state:
+                    AdaptiveBinaryState::Specialized {
+                        shape: cached,
+                        hits,
+                        misses,
+                    },
+            } if cached_op == op && cached == shape => AdaptiveBinaryState::Specialized {
+                shape,
+                hits: hits.saturating_add(1),
+                misses,
+            },
+            InlineCacheEntry::AdaptiveBinary {
+                op: cached_op,
+                state: AdaptiveBinaryState::Specialized { misses: 0, .. },
+            } if cached_op == op => AdaptiveBinaryState::Specialized {
+                shape,
+                hits: 1,
+                misses: 1,
+            },
+            _ => AdaptiveBinaryState::Warmup { shape, hits: 1 },
+        };
+        InlineCacheEntry::AdaptiveBinary { op, state }
+    }
+
+    fn generic_binary_result(
+        vm: &Self,
+        op: AdaptiveBinaryOp,
+        a: VmValue,
+        b: VmValue,
+    ) -> Result<VmValue, VmError> {
+        match op {
+            AdaptiveBinaryOp::Add => vm.add(a, b),
+            AdaptiveBinaryOp::Sub => vm.sub(a, b),
+            AdaptiveBinaryOp::Mul => vm.mul(a, b),
+            AdaptiveBinaryOp::Div => vm.div(a, b),
+            AdaptiveBinaryOp::Mod => vm.modulo(a, b),
+            AdaptiveBinaryOp::Equal => Ok(VmValue::Bool(values_equal(&a, &b))),
+            AdaptiveBinaryOp::NotEqual => Ok(VmValue::Bool(!values_equal(&a, &b))),
+            AdaptiveBinaryOp::Less => Ok(VmValue::Bool(compare_values(&a, &b) < 0)),
+            AdaptiveBinaryOp::Greater => Ok(VmValue::Bool(compare_values(&a, &b) > 0)),
+            AdaptiveBinaryOp::LessEqual => Ok(VmValue::Bool(compare_values(&a, &b) <= 0)),
+            AdaptiveBinaryOp::GreaterEqual => Ok(VmValue::Bool(compare_values(&a, &b) >= 0)),
+        }
+    }
+
+    fn specialized_binary_result(
+        op: AdaptiveBinaryOp,
+        shape: BinaryShape,
+        a: &VmValue,
+        b: &VmValue,
+    ) -> Option<VmValue> {
+        match (op, shape, a, b) {
+            (AdaptiveBinaryOp::Add, BinaryShape::Int, VmValue::Int(x), VmValue::Int(y)) => {
+                Some(VmValue::Int(x.wrapping_add(*y)))
+            }
+            (AdaptiveBinaryOp::Sub, BinaryShape::Int, VmValue::Int(x), VmValue::Int(y)) => {
+                Some(VmValue::Int(x.wrapping_sub(*y)))
+            }
+            (AdaptiveBinaryOp::Mul, BinaryShape::Int, VmValue::Int(x), VmValue::Int(y)) => {
+                Some(VmValue::Int(x.wrapping_mul(*y)))
+            }
+            (AdaptiveBinaryOp::Div, BinaryShape::Int, VmValue::Int(_), VmValue::Int(0))
+            | (AdaptiveBinaryOp::Mod, BinaryShape::Int, VmValue::Int(_), VmValue::Int(0)) => None,
+            (AdaptiveBinaryOp::Div, BinaryShape::Int, VmValue::Int(x), VmValue::Int(y)) => {
+                Some(VmValue::Int(x / y))
+            }
+            (AdaptiveBinaryOp::Mod, BinaryShape::Int, VmValue::Int(x), VmValue::Int(y)) => {
+                Some(VmValue::Int(x % y))
+            }
+            (AdaptiveBinaryOp::Add, BinaryShape::Float, VmValue::Float(x), VmValue::Float(y)) => {
+                Some(VmValue::Float(x + y))
+            }
+            (AdaptiveBinaryOp::Sub, BinaryShape::Float, VmValue::Float(x), VmValue::Float(y)) => {
+                Some(VmValue::Float(x - y))
+            }
+            (AdaptiveBinaryOp::Mul, BinaryShape::Float, VmValue::Float(x), VmValue::Float(y)) => {
+                Some(VmValue::Float(x * y))
+            }
+            (AdaptiveBinaryOp::Div, BinaryShape::Float, VmValue::Float(x), VmValue::Float(y)) => {
+                Some(VmValue::Float(x / y))
+            }
+            (AdaptiveBinaryOp::Mod, BinaryShape::Float, VmValue::Float(_), VmValue::Float(0.0)) => {
+                None
+            }
+            (AdaptiveBinaryOp::Mod, BinaryShape::Float, VmValue::Float(x), VmValue::Float(y)) => {
+                Some(VmValue::Float(x % y))
+            }
+            (_, BinaryShape::Int, VmValue::Int(x), VmValue::Int(y)) => {
+                let ordering = match x.cmp(y) {
+                    std::cmp::Ordering::Less => -1,
+                    std::cmp::Ordering::Equal => 0,
+                    std::cmp::Ordering::Greater => 1,
+                };
+                Self::specialized_ordering_result(op, ordering, x == y)
+            }
+            (_, BinaryShape::Float, VmValue::Float(x), VmValue::Float(y)) => {
+                let ordering = if x < y {
+                    -1
+                } else if x > y {
+                    1
+                } else {
+                    0
+                };
+                Self::specialized_ordering_result(op, ordering, x == y)
+            }
+            (_, BinaryShape::Bool, VmValue::Bool(x), VmValue::Bool(y)) => {
+                Self::specialized_equality_result(op, x == y)
+            }
+            (_, BinaryShape::String, VmValue::String(x), VmValue::String(y)) => {
+                Self::specialized_equality_result(op, x == y)
+            }
+            _ => None,
+        }
+    }
+
+    fn specialized_ordering_result(
+        op: AdaptiveBinaryOp,
+        ordering: i8,
+        equal: bool,
+    ) -> Option<VmValue> {
+        let result = match op {
+            AdaptiveBinaryOp::Equal => equal,
+            AdaptiveBinaryOp::NotEqual => !equal,
+            AdaptiveBinaryOp::Less => ordering < 0,
+            AdaptiveBinaryOp::Greater => ordering > 0,
+            AdaptiveBinaryOp::LessEqual => ordering <= 0,
+            AdaptiveBinaryOp::GreaterEqual => ordering >= 0,
+            _ => return None,
+        };
+        Some(VmValue::Bool(result))
+    }
+
+    fn specialized_equality_result(op: AdaptiveBinaryOp, equal: bool) -> Option<VmValue> {
+        let result = match op {
+            AdaptiveBinaryOp::Equal => equal,
+            AdaptiveBinaryOp::NotEqual => !equal,
+            _ => return None,
+        };
+        Some(VmValue::Bool(result))
     }
 
     pub(super) fn execute_add_int(&mut self) -> Result<(), VmError> {
@@ -291,6 +534,26 @@ impl super::super::Vm {
                 a.type_name(),
                 b.type_name()
             ))),
+        }
+    }
+}
+
+impl BinaryShape {
+    fn for_values(op: AdaptiveBinaryOp, a: &VmValue, b: &VmValue) -> Option<Self> {
+        match (a, b) {
+            (VmValue::Int(_), VmValue::Int(_)) => Some(Self::Int),
+            (VmValue::Float(_), VmValue::Float(_)) => Some(Self::Float),
+            (VmValue::Bool(_), VmValue::Bool(_))
+                if matches!(op, AdaptiveBinaryOp::Equal | AdaptiveBinaryOp::NotEqual) =>
+            {
+                Some(Self::Bool)
+            }
+            (VmValue::String(_), VmValue::String(_))
+                if matches!(op, AdaptiveBinaryOp::Equal | AdaptiveBinaryOp::NotEqual) =>
+            {
+                Some(Self::String)
+            }
+            _ => None,
         }
     }
 }

--- a/crates/harn-vm/src/vm/ops/call.rs
+++ b/crates/harn-vm/src/vm/ops/call.rs
@@ -2,12 +2,14 @@ use std::future::Future;
 use std::pin::Pin;
 use std::rc::Rc;
 
-use crate::chunk::{InlineCacheEntry, MethodCacheTarget};
+use crate::chunk::{DirectCallState, DirectCallTarget, InlineCacheEntry, MethodCacheTarget};
 use crate::orchestration::HookEvent;
 use crate::value::{values_equal, VmClosure, VmError, VmJoinHandle, VmTaskHandle, VmValue};
 use crate::BuiltinId;
 
 use super::super::CallFrame;
+
+const DIRECT_CALL_QUICKEN_THRESHOLD: u8 = 3;
 
 struct AwaitingTask {
     task: Option<VmTaskHandle>,
@@ -725,25 +727,133 @@ impl super::super::Vm {
     /// leaves `ip` untouched so [`execute_call_async`] can read the operand
     /// exactly once.
     pub(super) fn execute_call_sync(&mut self) -> Option<Result<(), VmError>> {
-        let frame = self.frames.last().unwrap();
-        let argc = frame.chunk.code[frame.ip] as usize;
-        let callee_idx = self.stack.len().checked_sub(argc + 1)?;
-        let closure = match self.stack.get(callee_idx)? {
-            VmValue::Closure(c) => c,
-            _ => return None,
+        let (argc, cache_slot, cache_entry) = {
+            let frame = self.frames.last().unwrap();
+            let op_offset = frame.ip.saturating_sub(1);
+            let argc = frame.chunk.code[frame.ip] as usize;
+            let cache_slot = frame.chunk.inline_cache_slot(op_offset);
+            let cache_entry = cache_slot
+                .map(|slot| frame.chunk.inline_cache_entry(slot))
+                .unwrap_or(InlineCacheEntry::Empty);
+            (argc, cache_slot, cache_entry)
         };
-        if closure.func.is_generator {
-            return None;
-        }
-        if crate::step_runtime::step_definition_for_function(&closure.func.name).is_some() {
+        let callee_idx = self.stack.len().checked_sub(argc + 1)?;
+        let closure = match self.try_cached_direct_call(&cache_entry, argc, callee_idx) {
+            Some(closure) => closure,
+            None => match self.stack.get(callee_idx)? {
+                VmValue::Closure(c) => Rc::clone(c),
+                _ => return None,
+            },
+        };
+        if !Self::direct_call_cacheable(&closure) {
             return None;
         }
 
-        let closure = Rc::clone(closure);
+        if let Some(slot) = cache_slot {
+            let next_entry = Self::next_direct_call_entry(
+                cache_entry,
+                argc,
+                DirectCallTarget::Closure(Rc::clone(&closure)),
+            );
+            let frame = self.frames.last().unwrap();
+            frame.chunk.set_inline_cache_entry(slot, next_entry);
+        }
+
         let frame = self.frames.last_mut().unwrap();
         frame.ip += 1;
         let args_start = self.stack.len() - argc;
         Some(self.push_closure_frame_from_stack_args(&closure, args_start, callee_idx))
+    }
+
+    fn direct_call_cacheable(closure: &VmClosure) -> bool {
+        !closure.func.is_generator
+            && crate::step_runtime::step_definition_for_function(&closure.func.name).is_none()
+    }
+
+    fn try_cached_direct_call(
+        &self,
+        cache: &InlineCacheEntry,
+        argc: usize,
+        callee_idx: usize,
+    ) -> Option<Rc<VmClosure>> {
+        let InlineCacheEntry::DirectCall {
+            state:
+                DirectCallState::Specialized {
+                    argc: cached_argc,
+                    target: DirectCallTarget::Closure(cached_closure),
+                    ..
+                },
+        } = cache
+        else {
+            return None;
+        };
+        if *cached_argc != argc {
+            return None;
+        }
+        let VmValue::Closure(callee) = self.stack.get(callee_idx)? else {
+            return None;
+        };
+        if !Rc::ptr_eq(cached_closure, callee) {
+            return None;
+        }
+        Some(Rc::clone(cached_closure))
+    }
+
+    fn next_direct_call_entry(
+        previous: InlineCacheEntry,
+        argc: usize,
+        target: DirectCallTarget,
+    ) -> InlineCacheEntry {
+        let state = match previous {
+            InlineCacheEntry::DirectCall {
+                state:
+                    DirectCallState::Warmup {
+                        argc: cached_argc,
+                        target: cached_target,
+                        hits,
+                    },
+            } if cached_argc == argc && cached_target == target => {
+                let hits = hits.saturating_add(1);
+                if hits >= DIRECT_CALL_QUICKEN_THRESHOLD {
+                    DirectCallState::Specialized {
+                        argc,
+                        target,
+                        hits: hits as u64,
+                        misses: 0,
+                    }
+                } else {
+                    DirectCallState::Warmup { argc, target, hits }
+                }
+            }
+            InlineCacheEntry::DirectCall {
+                state:
+                    DirectCallState::Specialized {
+                        argc: cached_argc,
+                        target: cached_target,
+                        hits,
+                        misses,
+                    },
+            } if cached_argc == argc && cached_target == target => DirectCallState::Specialized {
+                argc,
+                target,
+                hits: hits.saturating_add(1),
+                misses,
+            },
+            InlineCacheEntry::DirectCall {
+                state: DirectCallState::Specialized { misses: 0, .. },
+            } => DirectCallState::Specialized {
+                argc,
+                target,
+                hits: 1,
+                misses: 1,
+            },
+            _ => DirectCallState::Warmup {
+                argc,
+                target,
+                hits: 1,
+            },
+        };
+        InlineCacheEntry::DirectCall { state }
     }
 
     /// Async path for `Op::Call`. Arguments stay on the VM stack until the
@@ -853,9 +963,18 @@ impl super::super::Vm {
     /// resolves synchronously in the hot case but still pays the
     /// future-state-machine tax.
     pub(super) fn execute_call_builtin_sync(&mut self) -> Option<Result<(), VmError>> {
+        let (name_idx, argc, cache_slot, cache_entry) = {
+            let frame = self.frames.last().unwrap();
+            let op_offset = frame.ip.saturating_sub(1);
+            let name_idx = frame.chunk.read_u16(frame.ip + 8) as usize;
+            let argc = frame.chunk.code[frame.ip + 10] as usize;
+            let cache_slot = frame.chunk.inline_cache_slot(op_offset);
+            let cache_entry = cache_slot
+                .map(|slot| frame.chunk.inline_cache_entry(slot))
+                .unwrap_or(InlineCacheEntry::Empty);
+            (name_idx, argc, cache_slot, cache_entry)
+        };
         let frame = self.frames.last().unwrap();
-        let name_idx = frame.chunk.read_u16(frame.ip + 8) as usize;
-        let argc = frame.chunk.code[frame.ip + 10] as usize;
         let name = Self::const_str(&frame.chunk.constants[name_idx]).ok()?;
 
         // Names handled by `try_call_special_name` are runtime constructs
@@ -866,18 +985,55 @@ impl super::super::Vm {
             return None;
         }
 
-        let closure = self.resolve_named_closure(name)?;
-        if closure.func.is_generator {
+        let closure = match self.try_cached_named_direct_call(&cache_entry, name, argc) {
+            Some(closure) => closure,
+            None => self.resolve_named_closure(name)?,
+        };
+        if !Self::direct_call_cacheable(&closure) {
             return None;
         }
-        if crate::step_runtime::step_definition_for_function(&closure.func.name).is_some() {
-            return None;
+
+        if let Some(slot) = cache_slot {
+            let next_entry = Self::next_direct_call_entry(
+                cache_entry,
+                argc,
+                DirectCallTarget::Closure(Rc::clone(&closure)),
+            );
+            let frame = self.frames.last().unwrap();
+            frame.chunk.set_inline_cache_entry(slot, next_entry);
         }
 
         let frame = self.frames.last_mut().unwrap();
         frame.ip += 11;
         let args_start = self.stack.len().checked_sub(argc)?;
         Some(self.push_closure_frame_from_stack_args(&closure, args_start, args_start))
+    }
+
+    fn try_cached_named_direct_call(
+        &self,
+        cache: &InlineCacheEntry,
+        name: &str,
+        argc: usize,
+    ) -> Option<Rc<VmClosure>> {
+        let InlineCacheEntry::DirectCall {
+            state:
+                DirectCallState::Specialized {
+                    argc: cached_argc,
+                    target: DirectCallTarget::Closure(cached_closure),
+                    ..
+                },
+        } = cache
+        else {
+            return None;
+        };
+        if *cached_argc != argc {
+            return None;
+        }
+        let resolved = self.resolve_named_closure(name)?;
+        if !Rc::ptr_eq(cached_closure, &resolved) {
+            return None;
+        }
+        Some(Rc::clone(cached_closure))
     }
 
     /// Async path for `Op::CallBuiltin`. Arguments stay on the VM stack

--- a/crates/harn-vm/src/vm/ops/comparison.rs
+++ b/crates/harn-vm/src/vm/ops/comparison.rs
@@ -1,6 +1,7 @@
 use std::rc::Rc;
 
-use crate::value::{compare_values, values_equal, VmError, VmValue};
+use crate::chunk::AdaptiveBinaryOp;
+use crate::value::{values_equal, VmError, VmValue};
 
 impl super::super::Vm {
     fn push_compare_result(
@@ -14,27 +15,27 @@ impl super::super::Vm {
     }
 
     pub(super) fn execute_equal(&mut self) -> Result<(), VmError> {
-        self.push_compare_result(|a, b| Ok(values_equal(&a, &b)))
+        self.execute_adaptive_binary(AdaptiveBinaryOp::Equal)
     }
 
     pub(super) fn execute_not_equal(&mut self) -> Result<(), VmError> {
-        self.push_compare_result(|a, b| Ok(!values_equal(&a, &b)))
+        self.execute_adaptive_binary(AdaptiveBinaryOp::NotEqual)
     }
 
     pub(super) fn execute_less(&mut self) -> Result<(), VmError> {
-        self.push_compare_result(|a, b| Ok(compare_values(&a, &b) < 0))
+        self.execute_adaptive_binary(AdaptiveBinaryOp::Less)
     }
 
     pub(super) fn execute_greater(&mut self) -> Result<(), VmError> {
-        self.push_compare_result(|a, b| Ok(compare_values(&a, &b) > 0))
+        self.execute_adaptive_binary(AdaptiveBinaryOp::Greater)
     }
 
     pub(super) fn execute_less_equal(&mut self) -> Result<(), VmError> {
-        self.push_compare_result(|a, b| Ok(compare_values(&a, &b) <= 0))
+        self.execute_adaptive_binary(AdaptiveBinaryOp::LessEqual)
     }
 
     pub(super) fn execute_greater_equal(&mut self) -> Result<(), VmError> {
-        self.push_compare_result(|a, b| Ok(compare_values(&a, &b) >= 0))
+        self.execute_adaptive_binary(AdaptiveBinaryOp::GreaterEqual)
     }
 
     pub(super) fn execute_contains(&mut self) -> Result<(), VmError> {

--- a/crates/harn-vm/src/vm/tests_runtime.rs
+++ b/crates/harn-vm/src/vm/tests_runtime.rs
@@ -6,7 +6,10 @@ use std::time::Duration;
 
 use crate::compiler::{Compiler, CompilerOptions};
 use crate::stdlib::register_vm_stdlib;
-use crate::{Chunk, InlineCacheEntry, MethodCacheTarget, PropertyCacheTarget, VmError, VmValue};
+use crate::{
+    AdaptiveBinaryOp, AdaptiveBinaryState, BinaryShape, Chunk, DirectCallState, InlineCacheEntry,
+    MethodCacheTarget, PropertyCacheTarget, VmError, VmValue,
+};
 use harn_lexer::Lexer;
 use harn_parser::Parser;
 
@@ -749,6 +752,142 @@ log(total)
             "missing {target:?} in {entries:?}"
         );
     }
+}
+
+#[test]
+fn test_adaptive_inline_cache_specializes_generic_integer_add_site() {
+    let (chunk, out, _) = run_harn_with_chunk(
+        r#"pipeline t(task) {
+fn erase(x) {
+  return x
+}
+var i = erase(0)
+var total = erase(0)
+while i < erase(8) {
+  total = total + i
+  i = i + erase(1)
+}
+log(total)
+}"#,
+    );
+
+    assert_eq!(out.trim_end(), "[harn] 28");
+    let entries = chunk.inline_cache_entries();
+    assert!(
+        entries.iter().any(|entry| matches!(
+            entry,
+            InlineCacheEntry::AdaptiveBinary {
+                op: AdaptiveBinaryOp::Add,
+                state: AdaptiveBinaryState::Specialized {
+                    shape: BinaryShape::Int,
+                    hits,
+                    ..
+                },
+            } if *hits >= 3
+        )),
+        "{entries:?}"
+    );
+}
+
+#[test]
+fn test_adaptive_inline_cache_deoptimizes_mixed_binary_shapes() {
+    let (chunk, out, _) = run_harn_with_chunk(
+        r#"pipeline t(task) {
+fn erase(x) {
+  return x
+}
+let values = [erase(1), erase(2), erase(3), erase(4.0), erase(5.0)]
+var acc = erase(0)
+for value in values {
+  acc = acc + value
+}
+log(acc)
+}"#,
+    );
+
+    assert_eq!(out.trim_end(), "[harn] 15.0");
+    let entries = chunk.inline_cache_entries();
+    assert!(
+        entries.iter().any(|entry| matches!(
+            entry,
+            InlineCacheEntry::AdaptiveBinary {
+                op: AdaptiveBinaryOp::Add,
+                state: AdaptiveBinaryState::Specialized {
+                    shape: BinaryShape::Float,
+                    misses: 1,
+                    ..
+                },
+            }
+        )),
+        "{entries:?}"
+    );
+}
+
+#[test]
+fn test_adaptive_inline_cache_specializes_named_closure_call_site() {
+    let (chunk, out, _) = run_harn_with_chunk(
+        r#"pipeline t(task) {
+fn inc(x) {
+  return x + 1
+}
+var i = 0
+var total = 0
+while i < 8 {
+  total = total + inc(i)
+  i = i + 1
+}
+log(total)
+}"#,
+    );
+
+    assert_eq!(out.trim_end(), "[harn] 36");
+    let entries = chunk.inline_cache_entries();
+    assert!(
+        entries.iter().any(|entry| matches!(
+            entry,
+            InlineCacheEntry::DirectCall {
+                state: DirectCallState::Specialized { hits, .. },
+            } if *hits >= 3
+        )),
+        "{entries:?}"
+    );
+}
+
+#[test]
+fn test_adaptive_inline_cache_deoptimizes_rebound_closure_call_site() {
+    let (chunk, out, _) = run_harn_with_chunk(
+        r#"pipeline t(task) {
+fn inc(x) {
+  return x + 1
+}
+fn dec(x) {
+  return x - 1
+}
+var op = inc
+var i = 0
+var total = 0
+while i < 5 {
+  if i == 3 {
+    op = dec
+  }
+  total = total + op(10)
+  i = i + 1
+}
+log(total)
+}"#,
+    );
+
+    assert_eq!(out.trim_end(), "[harn] 51");
+    let entries = chunk.inline_cache_entries();
+    assert!(
+        entries.iter().any(|entry| matches!(
+            entry,
+            InlineCacheEntry::DirectCall {
+                state: DirectCallState::Specialized { misses: 1, .. },
+            }
+        )),
+        "{entries:?}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- extend VM inline-cache feedback to generic binary arithmetic/comparison opcodes
- add conservative direct-call quickening for stable first-class and named closure call sites
- keep adaptive cache state runtime-only while preserving bytecode-cache slot layout
- add runtime coverage for specialization and deoptimization plus Criterion fixtures for hot stable and mixed-shape paths

Closes #2151

## Verification
- cargo fmt --check
- git diff --check HEAD~1 HEAD
- cargo test -p harn-vm --lib
- cargo test -p harn-vm --bench vm_adaptive_inline_cache --no-run
- pre-commit hook: Rust formatting, prompt-prose lint, harn-vm clippy
- pre-push hook: targeted local checks
