### PR TITLE
Add shared incremental analysis cache

### DIFF
--- a/crates/harn-cli/src/commands/check/analysis.rs
+++ b/crates/harn-cli/src/commands/check/analysis.rs
@@ -1,0 +1,102 @@
+use std::path::Path;
+
+use harn_parser::analysis::{
+    AnalysisDatabase, AnalysisError, SourceId, SourceVersion, TypeCheckConfig, TypeCheckOutput,
+};
+
+use crate::package::CheckConfig;
+
+#[derive(Debug)]
+pub(crate) enum FileAnalysisError {
+    Read(std::io::Error),
+    Analysis(AnalysisError),
+}
+
+pub(crate) fn analyze_file(
+    analysis: &mut AnalysisDatabase,
+    path: &Path,
+    config: &CheckConfig,
+    module_graph: &harn_modules::ModuleGraph,
+) -> Result<TypeCheckOutput, FileAnalysisError> {
+    let source = std::fs::read_to_string(path).map_err(FileAnalysisError::Read)?;
+    let id = SourceId::path(path);
+    analysis.set_source(id.clone(), source, SourceVersion(1));
+    analysis
+        .typecheck(&id, typecheck_config(path, config, module_graph))
+        .map_err(FileAnalysisError::Analysis)
+}
+
+pub(crate) fn typecheck_config(
+    path: &Path,
+    config: &CheckConfig,
+    module_graph: &harn_modules::ModuleGraph,
+) -> TypeCheckConfig {
+    TypeCheckConfig::new()
+        .with_strict_types(config.strict_types)
+        .with_imported_names(module_graph.imported_names_for_file(path))
+        .with_imported_type_decls(
+            module_graph
+                .imported_type_declarations_for_file(path)
+                .unwrap_or_default(),
+        )
+        .with_imported_callable_decls(
+            module_graph
+                .imported_callable_declarations_for_file(path)
+                .unwrap_or_default(),
+        )
+}
+
+pub(crate) fn render_file_analysis_error_or_exit(path: &str, error: FileAnalysisError) -> ! {
+    match error {
+        FileAnalysisError::Read(error) => {
+            eprintln!("Error reading {path}: {error}");
+        }
+        FileAnalysisError::Analysis(AnalysisError::Lex { source, error }) => {
+            let diagnostic = harn_parser::diagnostic::render_diagnostic_with_code(
+                &source,
+                path,
+                &span_from_lexer_error(&error),
+                "error",
+                harn_parser::diagnostic::lexer_error_code(&error),
+                &error.to_string(),
+                Some("here"),
+                None,
+            );
+            eprint!("{diagnostic}");
+        }
+        FileAnalysisError::Analysis(AnalysisError::Parse { source, errors }) => {
+            for error in &errors {
+                let diagnostic = harn_parser::diagnostic::render_diagnostic_with_code(
+                    &source,
+                    path,
+                    &span_from_parser_error(error),
+                    "error",
+                    harn_parser::diagnostic::parser_error_code(error),
+                    &harn_parser::diagnostic::parser_error_message(error),
+                    Some(harn_parser::diagnostic::parser_error_label(error)),
+                    harn_parser::diagnostic::parser_error_help(error),
+                );
+                eprint!("{diagnostic}");
+            }
+        }
+        FileAnalysisError::Analysis(AnalysisError::MissingSource(id)) => {
+            eprintln!("missing analysis source {}", id.as_str());
+        }
+    }
+    std::process::exit(1);
+}
+
+pub(crate) fn span_from_lexer_error(error: &harn_lexer::LexerError) -> harn_lexer::Span {
+    match error {
+        harn_lexer::LexerError::UnexpectedCharacter(_, span)
+        | harn_lexer::LexerError::UnterminatedString(span)
+        | harn_lexer::LexerError::UnterminatedBlockComment(span) => *span,
+    }
+}
+
+pub(crate) fn span_from_parser_error(error: &harn_parser::ParserError) -> harn_lexer::Span {
+    match error {
+        harn_parser::ParserError::Unexpected { span, .. }
+        | harn_parser::ParserError::UnexpectedEof { span, .. } => *span,
+    }
+}

--- a/crates/harn-cli/src/commands/check/check_cmd.rs
+++ b/crates/harn-cli/src/commands/check/check_cmd.rs
@@ -1,12 +1,16 @@
 use std::path::Path;
 
 use harn_lint::LintSeverity;
-use harn_parser::{DiagnosticSeverity, PipelineError, TypeChecker};
+use harn_parser::analysis::{AnalysisDatabase, AnalysisError};
+use harn_parser::DiagnosticSeverity;
 use serde::Serialize;
 
 use crate::package::{CheckConfig, PreflightSeverity};
-use crate::parse_source_file;
 
+use super::analysis::{
+    analyze_file, render_file_analysis_error_or_exit, span_from_lexer_error,
+    span_from_parser_error, FileAnalysisError,
+};
 use super::outcome::{print_lint_diagnostics, CommandOutcome};
 use super::preflight::{collect_preflight_diagnostics, is_preflight_allowed};
 
@@ -85,6 +89,7 @@ impl CheckReport {
 }
 
 pub(crate) fn check_file_inner(
+    analysis: &mut AnalysisDatabase,
     path: &Path,
     config: &CheckConfig,
     externally_imported_names: &std::collections::HashSet<String>,
@@ -92,6 +97,7 @@ pub(crate) fn check_file_inner(
     check_invariants: bool,
 ) -> CommandOutcome {
     check_file_report_inner(
+        analysis,
         path,
         config,
         externally_imported_names,
@@ -103,6 +109,7 @@ pub(crate) fn check_file_inner(
 }
 
 pub(crate) fn check_file_report(
+    analysis: &mut AnalysisDatabase,
     path: &Path,
     config: &CheckConfig,
     externally_imported_names: &std::collections::HashSet<String>,
@@ -110,6 +117,7 @@ pub(crate) fn check_file_report(
     check_invariants: bool,
 ) -> CheckFileReport {
     check_file_report_inner(
+        analysis,
         path,
         config,
         externally_imported_names,
@@ -120,6 +128,7 @@ pub(crate) fn check_file_report(
 }
 
 fn check_file_report_inner(
+    analysis: &mut AnalysisDatabase,
     path: &Path,
     config: &CheckConfig,
     externally_imported_names: &std::collections::HashSet<String>,
@@ -128,32 +137,24 @@ fn check_file_report_inner(
     emit_text: bool,
 ) -> CheckFileReport {
     let path_str = path.to_string_lossy().into_owned();
-    let (source, program) = if emit_text {
-        parse_source_file(&path_str)
-    } else {
-        match parse_source_for_report(&path_str) {
-            Ok(parsed) => parsed,
-            Err(report) => return report,
+    let output = match analyze_file(analysis, path, config, module_graph) {
+        Ok(output) => output,
+        Err(error) => {
+            if emit_text {
+                render_file_analysis_error_or_exit(&path_str, error);
+            }
+            return file_analysis_error_report(&path_str, error);
         }
     };
+    let source = output.source;
+    let program = output.program;
 
     let mut has_error = false;
     let mut has_warning = false;
     let mut diagnostic_count = 0;
     let mut diagnostics = Vec::new();
 
-    let mut checker = TypeChecker::with_strict_types(config.strict_types);
-    if let Some(imported) = module_graph.imported_names_for_file(path) {
-        checker = checker.with_imported_names(imported);
-    }
-    if let Some(imported) = module_graph.imported_type_declarations_for_file(path) {
-        checker = checker.with_imported_type_decls(imported);
-    }
-    if let Some(imported) = module_graph.imported_callable_declarations_for_file(path) {
-        checker = checker.with_imported_callable_decls(imported);
-    }
-    let type_diagnostics = checker.check_with_source(&program, &source);
-    for diag in &type_diagnostics {
+    for diag in &output.diagnostics {
         if harn_lint::type_diagnostic_lint_disabled(diag, &config.disable_rules) {
             continue;
         }
@@ -317,64 +318,70 @@ fn lint_severity_label(severity: LintSeverity) -> &'static str {
     }
 }
 
-fn check_span(span: harn_lexer::Span) -> CheckSpan {
+pub(crate) fn check_span(span: harn_lexer::Span) -> CheckSpan {
     CheckSpan {
         start: span.start,
         end: span.end,
     }
 }
 
-fn parse_source_for_report(
-    path: &str,
-) -> Result<(String, Vec<harn_parser::SNode>), CheckFileReport> {
-    let source = std::fs::read_to_string(path).map_err(|error| CheckFileReport {
-        path: path.to_string(),
-        status: CheckFileStatus::Error,
-        diagnostics: vec![CheckDiagnostic {
-            source: "io",
-            severity: "error",
-            code: None,
-            message: format!("Error reading {path}: {error}"),
-            span: None,
-            help: None,
-        }],
-    })?;
-    let program = harn_parser::parse_source(&source)
-        .map_err(|error| parse_diagnostic_report(path, &source, error))?;
-    Ok((source, program))
+fn file_analysis_error_report(path: &str, error: FileAnalysisError) -> CheckFileReport {
+    match error {
+        FileAnalysisError::Read(error) => CheckFileReport {
+            path: path.to_string(),
+            status: CheckFileStatus::Error,
+            diagnostics: vec![CheckDiagnostic {
+                source: "io",
+                severity: "error",
+                code: None,
+                message: format!("Error reading {path}: {error}"),
+                span: None,
+                help: None,
+            }],
+        },
+        FileAnalysisError::Analysis(error) => analysis_diagnostic_report(path, error),
+    }
 }
 
-fn parse_diagnostic_report(path: &str, _source: &str, error: PipelineError) -> CheckFileReport {
-    let span = error.span().copied();
-    let diagnostic = match error {
-        PipelineError::Lex(error) => CheckDiagnostic {
-            source: "lexer",
-            severity: "error",
-            code: Some(harn_parser::diagnostic::lexer_error_code(&error).to_string()),
-            message: error.to_string(),
-            span: span.map(check_span),
-            help: None,
-        },
-        PipelineError::Parse(error) => CheckDiagnostic {
-            source: "parser",
-            severity: "error",
-            code: Some(harn_parser::diagnostic::parser_error_code(&error).to_string()),
-            message: harn_parser::diagnostic::parser_error_message(&error),
-            span: span.map(check_span),
-            help: harn_parser::diagnostic::parser_error_help(&error).map(str::to_string),
-        },
-        PipelineError::TypeCheck(error) => CheckDiagnostic {
-            source: "type",
-            severity: type_severity_label(error.severity),
-            code: Some(error.code.to_string()),
-            message: error.message.clone(),
-            span: error.span.map(check_span),
-            help: error.help.clone(),
-        },
-    };
+fn analysis_diagnostic_report(path: &str, error: AnalysisError) -> CheckFileReport {
+    let diagnostic = check_diagnostic_from_analysis_error(error);
     CheckFileReport {
         path: path.to_string(),
         status: CheckFileStatus::Error,
         diagnostics: vec![diagnostic],
+    }
+}
+
+pub(crate) fn check_diagnostic_from_analysis_error(error: AnalysisError) -> CheckDiagnostic {
+    match error {
+        AnalysisError::MissingSource(id) => CheckDiagnostic {
+            source: "analysis",
+            severity: "error",
+            code: None,
+            message: format!("missing analysis source {}", id.as_str()),
+            span: None,
+            help: None,
+        },
+        AnalysisError::Lex { error, .. } => CheckDiagnostic {
+            source: "lexer",
+            severity: "error",
+            code: Some(harn_parser::diagnostic::lexer_error_code(&error).to_string()),
+            message: error.to_string(),
+            span: Some(check_span(span_from_lexer_error(&error))),
+            help: None,
+        },
+        AnalysisError::Parse { errors, .. } => {
+            let error = errors
+                .first()
+                .expect("analysis parse errors should include at least one error");
+            CheckDiagnostic {
+                source: "parser",
+                severity: "error",
+                code: Some(harn_parser::diagnostic::parser_error_code(error).to_string()),
+                message: harn_parser::diagnostic::parser_error_message(error),
+                span: Some(check_span(span_from_parser_error(error))),
+                help: harn_parser::diagnostic::parser_error_help(error).map(str::to_string),
+            }
+        }
     }
 }

--- a/crates/harn-cli/src/commands/check/lint.rs
+++ b/crates/harn-cli/src/commands/check/lint.rs
@@ -3,14 +3,15 @@ use std::path::Path;
 use std::process;
 
 use harn_lint::LintSeverity;
-use harn_parser::{TypeChecker, TypeDiagnostic};
+use harn_parser::analysis::AnalysisDatabase;
 
 use crate::package::CheckConfig;
-use crate::parse_source_file;
 
+use super::analysis::{analyze_file, render_file_analysis_error_or_exit};
 use super::outcome::{print_lint_diagnostics, CommandOutcome};
 
 pub(crate) fn lint_file_inner(
+    analysis: &mut AnalysisDatabase,
     path: &Path,
     config: &CheckConfig,
     externally_imported_names: &HashSet<String>,
@@ -20,7 +21,10 @@ pub(crate) fn lint_file_inner(
     persona_step_allowlist: &[String],
 ) -> CommandOutcome {
     let path_str = path.to_string_lossy().into_owned();
-    let (source, program) = parse_source_file(&path_str);
+    let output = analyze_file(analysis, path, config, module_graph)
+        .unwrap_or_else(|error| render_file_analysis_error_or_exit(&path_str, error));
+    let source = output.source;
+    let program = output.program;
 
     let options = harn_lint::LintOptions {
         file_path: Some(path),
@@ -38,9 +42,8 @@ pub(crate) fn lint_file_inner(
         path,
         &options,
     );
-    let type_diags = type_check_for_lint(path, config, module_graph, &program, &source);
     diagnostics.extend(harn_lint::lint_diagnostics_from_type_diagnostics(
-        &type_diags,
+        &output.diagnostics,
         &config.disable_rules,
     ));
 
@@ -63,6 +66,7 @@ pub(crate) fn lint_file_inner(
 /// Apply autofix edits from lint and type-check diagnostics and write back to disk.
 /// Returns the number of fixes applied.
 pub(crate) fn lint_fix_file(
+    analysis: &mut AnalysisDatabase,
     path: &Path,
     config: &CheckConfig,
     externally_imported_names: &HashSet<String>,
@@ -72,7 +76,10 @@ pub(crate) fn lint_fix_file(
     persona_step_allowlist: &[String],
 ) -> usize {
     let path_str = path.to_string_lossy().into_owned();
-    let (source, program) = parse_source_file(&path_str);
+    let output = analyze_file(analysis, path, config, module_graph)
+        .unwrap_or_else(|error| render_file_analysis_error_or_exit(&path_str, error));
+    let source = output.source;
+    let program = output.program;
 
     let options = harn_lint::LintOptions {
         file_path: Some(path),
@@ -91,13 +98,12 @@ pub(crate) fn lint_fix_file(
         &options,
     );
 
-    let type_diags = type_check_for_lint(path, config, module_graph, &program, &source);
-
     let mut edits: Vec<&harn_lexer::FixEdit> = lint_diags
         .iter()
         .filter_map(|d| d.fix.as_ref())
         .chain(
-            type_diags
+            output
+                .diagnostics
                 .iter()
                 .filter(|d| !harn_lint::type_diagnostic_lint_disabled(d, &config.disable_rules))
                 .filter_map(|d| d.fix.as_ref()),
@@ -138,7 +144,10 @@ pub(crate) fn lint_fix_file(
 
     println!("{path_str}: applied {applied} fix(es)");
 
-    let (source2, program2) = parse_source_file(&path_str);
+    let output2 = analyze_file(analysis, path, config, module_graph)
+        .unwrap_or_else(|error| render_file_analysis_error_or_exit(&path_str, error));
+    let source2 = output2.source;
+    let program2 = output2.program;
     let mut remaining = harn_lint::lint_with_module_graph(
         &program2,
         &config.disable_rules,
@@ -148,9 +157,8 @@ pub(crate) fn lint_fix_file(
         path,
         &options,
     );
-    let type_remaining = type_check_for_lint(path, config, module_graph, &program2, &source2);
     remaining.extend(harn_lint::lint_diagnostics_from_type_diagnostics(
-        &type_remaining,
+        &output2.diagnostics,
         &config.disable_rules,
     ));
     if !remaining.is_empty() {
@@ -185,26 +193,6 @@ pub(crate) fn path_is_stdlib_source(path: &Path) -> bool {
         }
     }
     false
-}
-
-fn type_check_for_lint(
-    path: &Path,
-    config: &CheckConfig,
-    module_graph: &harn_modules::ModuleGraph,
-    program: &[harn_parser::SNode],
-    source: &str,
-) -> Vec<TypeDiagnostic> {
-    let mut checker = TypeChecker::with_strict_types(config.strict_types);
-    if let Some(imported) = module_graph.imported_names_for_file(path) {
-        checker = checker.with_imported_names(imported);
-    }
-    if let Some(imported) = module_graph.imported_type_declarations_for_file(path) {
-        checker = checker.with_imported_type_decls(imported);
-    }
-    if let Some(imported) = module_graph.imported_callable_declarations_for_file(path) {
-        checker = checker.with_imported_callable_decls(imported);
-    }
-    checker.check_with_source(program, source)
 }
 
 #[cfg(test)]

--- a/crates/harn-cli/src/commands/check/lint_report.rs
+++ b/crates/harn-cli/src/commands/check/lint_report.rs
@@ -13,13 +13,15 @@ use std::collections::HashSet;
 use std::path::Path;
 
 use harn_lint::LintSeverity;
-use harn_parser::{DiagnosticSeverity, TypeChecker, TypeDiagnostic};
+use harn_parser::analysis::AnalysisDatabase;
 use serde::Serialize;
 
 use crate::package::CheckConfig;
-use crate::parse_source_file;
 
-use super::check_cmd::{CheckDiagnostic, CheckFileStatus, CheckSpan};
+use super::analysis::{analyze_file, FileAnalysisError};
+use super::check_cmd::{
+    check_diagnostic_from_analysis_error, check_span, CheckDiagnostic, CheckFileStatus,
+};
 use super::lint::path_is_stdlib_source;
 use super::outcome::CommandOutcome;
 
@@ -86,6 +88,7 @@ impl LintReport {
 /// stderr rendering and captures every diagnostic into a serializable
 /// shape.
 pub(crate) fn lint_file_report(
+    analysis: &mut AnalysisDatabase,
     path: &Path,
     config: &CheckConfig,
     externally_imported_names: &HashSet<String>,
@@ -95,65 +98,12 @@ pub(crate) fn lint_file_report(
     persona_step_allowlist: &[String],
 ) -> LintFileReport {
     let path_str = path.to_string_lossy().into_owned();
-    let source = match std::fs::read_to_string(&path_str) {
-        Ok(text) => text,
-        Err(error) => {
-            return LintFileReport {
-                path: path_str.clone(),
-                status: CheckFileStatus::Error,
-                diagnostics: vec![CheckDiagnostic {
-                    source: "io",
-                    severity: "error",
-                    code: None,
-                    message: format!("Error reading {path_str}: {error}"),
-                    span: None,
-                    help: None,
-                }],
-                fixable: 0,
-                fixed: 0,
-            };
-        }
+    let output = match analyze_file(analysis, path, config, module_graph) {
+        Ok(output) => output,
+        Err(error) => return file_analysis_error_report(path_str, error),
     };
-
-    let program = match harn_parser::parse_source(&source) {
-        Ok(program) => program,
-        Err(error) => {
-            let span = error.span().copied();
-            let diagnostic = match error {
-                harn_parser::PipelineError::Lex(error) => CheckDiagnostic {
-                    source: "lexer",
-                    severity: "error",
-                    code: Some(harn_parser::diagnostic::lexer_error_code(&error).to_string()),
-                    message: error.to_string(),
-                    span: span.map(check_span),
-                    help: None,
-                },
-                harn_parser::PipelineError::Parse(error) => CheckDiagnostic {
-                    source: "parser",
-                    severity: "error",
-                    code: Some(harn_parser::diagnostic::parser_error_code(&error).to_string()),
-                    message: harn_parser::diagnostic::parser_error_message(&error),
-                    span: span.map(check_span),
-                    help: harn_parser::diagnostic::parser_error_help(&error).map(str::to_string),
-                },
-                harn_parser::PipelineError::TypeCheck(error) => CheckDiagnostic {
-                    source: "type",
-                    severity: type_severity_label(error.severity),
-                    code: Some(error.code.to_string()),
-                    message: error.message.clone(),
-                    span: error.span.map(check_span),
-                    help: error.help.clone(),
-                },
-            };
-            return LintFileReport {
-                path: path_str,
-                status: CheckFileStatus::Error,
-                diagnostics: vec![diagnostic],
-                fixable: 0,
-                fixed: 0,
-            };
-        }
-    };
+    let source = output.source;
+    let program = output.program;
 
     let options = harn_lint::LintOptions {
         file_path: Some(path),
@@ -171,9 +121,10 @@ pub(crate) fn lint_file_report(
         path,
         &options,
     );
-    let type_diags = type_check_for_lint(path, config, module_graph, &program, &source);
-    let type_lint_diagnostics =
-        harn_lint::lint_diagnostics_from_type_diagnostics(&type_diags, &config.disable_rules);
+    let type_lint_diagnostics = harn_lint::lint_diagnostics_from_type_diagnostics(
+        &output.diagnostics,
+        &config.disable_rules,
+    );
 
     let mut has_error = false;
     let mut has_warning = false;
@@ -235,33 +186,6 @@ pub(crate) fn lint_file_report(
     }
 }
 
-fn type_check_for_lint(
-    path: &Path,
-    config: &CheckConfig,
-    module_graph: &harn_modules::ModuleGraph,
-    program: &[harn_parser::SNode],
-    source: &str,
-) -> Vec<TypeDiagnostic> {
-    let mut checker = TypeChecker::with_strict_types(config.strict_types);
-    if let Some(imported) = module_graph.imported_names_for_file(path) {
-        checker = checker.with_imported_names(imported);
-    }
-    if let Some(imported) = module_graph.imported_type_declarations_for_file(path) {
-        checker = checker.with_imported_type_decls(imported);
-    }
-    if let Some(imported) = module_graph.imported_callable_declarations_for_file(path) {
-        checker = checker.with_imported_callable_decls(imported);
-    }
-    checker.check_with_source(program, source)
-}
-
-fn type_severity_label(severity: DiagnosticSeverity) -> &'static str {
-    match severity {
-        DiagnosticSeverity::Error => "error",
-        DiagnosticSeverity::Warning => "warning",
-    }
-}
-
 fn lint_severity_label(severity: LintSeverity) -> &'static str {
     match severity {
         LintSeverity::Info => "info",
@@ -270,18 +194,23 @@ fn lint_severity_label(severity: LintSeverity) -> &'static str {
     }
 }
 
-fn check_span(span: harn_lexer::Span) -> CheckSpan {
-    CheckSpan {
-        start: span.start,
-        end: span.end,
+fn file_analysis_error_report(path: String, error: FileAnalysisError) -> LintFileReport {
+    let diagnostic = match error {
+        FileAnalysisError::Read(error) => CheckDiagnostic {
+            source: "io",
+            severity: "error",
+            code: None,
+            message: format!("Error reading {path}: {error}"),
+            span: None,
+            help: None,
+        },
+        FileAnalysisError::Analysis(error) => check_diagnostic_from_analysis_error(error),
+    };
+    LintFileReport {
+        path,
+        status: CheckFileStatus::Error,
+        diagnostics: vec![diagnostic],
+        fixable: 0,
+        fixed: 0,
     }
-}
-
-/// Suppress the `parse_source_file` helper's `eprintln!` rendering by
-/// going through the file system directly. Kept as an
-/// underscore-prefixed alias for symmetry with the human path which
-/// uses [`parse_source_file`] for its richer diagnostic printing.
-#[allow(dead_code)]
-fn _ensure_parse_helper_imported() {
-    let _ = parse_source_file;
 }

--- a/crates/harn-cli/src/commands/check/mod.rs
+++ b/crates/harn-cli/src/commands/check/mod.rs
@@ -1,3 +1,4 @@
+mod analysis;
 mod bundle;
 mod check_cmd;
 mod config;
@@ -17,6 +18,9 @@ mod template_lint;
 #[cfg(test)]
 mod tests;
 
+pub(crate) use analysis::{
+    analyze_file, span_from_lexer_error, span_from_parser_error, FileAnalysisError,
+};
 pub(crate) use bundle::build_bundle_manifest;
 pub(crate) use check_cmd::{
     check_file_inner, check_file_report, CheckReport, CHECK_SCHEMA_VERSION,

--- a/crates/harn-cli/src/commands/check/tests.rs
+++ b/crates/harn-cli/src/commands/check/tests.rs
@@ -9,11 +9,12 @@ use harn_parser::{Parser, SNode};
 use crate::package::CheckConfig;
 
 use super::bundle::build_bundle_manifest;
-use super::check_cmd::check_file_inner;
+use super::check_cmd::{check_file_inner, check_file_report};
 use super::config::collect_harn_targets;
 use super::config::{build_module_graph, collect_cross_file_imports};
 use super::host_capabilities::parse_host_capability_value;
 use super::lint::lint_file_inner;
+use super::lint_report::lint_file_report;
 use super::preflight::{collect_preflight_diagnostics, is_preflight_allowed};
 
 fn parse_program(source: &str) -> Vec<SNode> {
@@ -788,7 +789,9 @@ fn handler() {
     let files = vec![file.clone()];
     let module_graph = build_module_graph(&files);
     let cross_file_imports = collect_cross_file_imports(&module_graph);
+    let mut analysis = harn_parser::analysis::AnalysisDatabase::new();
     let outcome = check_file_inner(
+        &mut analysis,
         &file,
         &CheckConfig::default(),
         &cross_file_imports,
@@ -835,7 +838,9 @@ pipeline main() {
     let files = vec![file.clone()];
     let module_graph = build_module_graph(&files);
     let cross_file_imports = collect_cross_file_imports(&module_graph);
+    let mut analysis = harn_parser::analysis::AnalysisDatabase::new();
     let outcome = check_file_inner(
+        &mut analysis,
         &file,
         &CheckConfig::default(),
         &cross_file_imports,
@@ -869,7 +874,9 @@ fn handler() {
     let files = vec![file.clone()];
     let module_graph = build_module_graph(&files);
     let cross_file_imports = collect_cross_file_imports(&module_graph);
+    let mut analysis = harn_parser::analysis::AnalysisDatabase::new();
     let outcome = check_file_inner(
+        &mut analysis,
         &file,
         &CheckConfig::default(),
         &cross_file_imports,
@@ -903,7 +910,9 @@ fn _handler(client) {
     let files = vec![file.clone()];
     let module_graph = build_module_graph(&files);
     let cross_file_imports = collect_cross_file_imports(&module_graph);
+    let mut analysis = harn_parser::analysis::AnalysisDatabase::new();
     let outcome = check_file_inner(
+        &mut analysis,
         &file,
         &CheckConfig::default(),
         &cross_file_imports,
@@ -955,7 +964,9 @@ fn _handler() {
     let files = vec![file.clone()];
     let module_graph = build_module_graph(&files);
     let cross_file_imports = collect_cross_file_imports(&module_graph);
+    let mut analysis = harn_parser::analysis::AnalysisDatabase::new();
     let outcome = check_file_inner(
+        &mut analysis,
         &file,
         &CheckConfig::default(),
         &cross_file_imports,
@@ -1470,7 +1481,9 @@ pipeline main(task) {
     let files = vec![file.clone()];
     let module_graph = build_module_graph(&files);
     let cross_file_imports = collect_cross_file_imports(&module_graph);
+    let mut analysis = harn_parser::analysis::AnalysisDatabase::new();
     let outcome = lint_file_inner(
+        &mut analysis,
         &file,
         &CheckConfig::default(),
         &cross_file_imports,
@@ -1483,6 +1496,64 @@ pipeline main(task) {
         outcome.has_warning,
         "type-aware lint should surface through `harn lint`"
     );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn check_and_lint_json_share_typecheck_cache() {
+    let dir = unique_temp_dir("harn-check-shared-analysis");
+    std::fs::create_dir_all(&dir).unwrap();
+    let file = dir.join("main.harn");
+    std::fs::write(
+        &file,
+        r#"
+pipeline main() {
+  let x = 1
+  log(x)
+}
+"#,
+    )
+    .unwrap();
+
+    let files = vec![file.clone()];
+    let module_graph = build_module_graph(&files);
+    let cross_file_imports = collect_cross_file_imports(&module_graph);
+    let mut analysis = harn_parser::analysis::AnalysisDatabase::new();
+    let config = CheckConfig::default();
+
+    let check_report = check_file_report(
+        &mut analysis,
+        &file,
+        &config,
+        &cross_file_imports,
+        &module_graph,
+        false,
+    );
+    assert!(matches!(
+        check_report.status,
+        super::check_cmd::CheckFileStatus::Ok
+    ));
+    let after_check = analysis.stats();
+
+    let lint_report = lint_file_report(
+        &mut analysis,
+        &file,
+        &config,
+        &cross_file_imports,
+        &module_graph,
+        false,
+        None,
+        &[],
+    );
+    assert!(matches!(
+        lint_report.status,
+        super::check_cmd::CheckFileStatus::Ok
+    ));
+    let after_lint = analysis.stats();
+
+    assert_eq!(after_check.typecheck_runs, 1);
+    assert_eq!(after_lint.typecheck_runs, 1);
+    assert_eq!(after_lint.parse_runs, after_check.parse_runs);
     let _ = std::fs::remove_dir_all(&dir);
 }
 

--- a/crates/harn-cli/src/commands/contracts.rs
+++ b/crates/harn-cli/src/commands/contracts.rs
@@ -125,6 +125,7 @@ fn bundle_contract_value(args: &ContractsBundleArgs) -> (serde_json::Value, bool
     if args.verify {
         let module_graph = check::build_module_graph(&files);
         let cross_file_imports = check::collect_cross_file_imports(&module_graph);
+        let mut analysis = harn_parser::analysis::AnalysisDatabase::new();
         for file in &files {
             let mut file_config = package::load_check_config(Some(file));
             if let Some(path) = args.host_capabilities.as_ref() {
@@ -134,6 +135,7 @@ fn bundle_contract_value(args: &ContractsBundleArgs) -> (serde_json::Value, bool
                 file_config.bundle_root = Some(path.clone());
             }
             let outcome = check::check_file_inner(
+                &mut analysis,
                 file,
                 &file_config,
                 &cross_file_imports,

--- a/crates/harn-cli/src/commands/fix.rs
+++ b/crates/harn-cli/src/commands/fix.rs
@@ -5,9 +5,10 @@ use std::path::Path;
 
 use harn_lexer::{FixEdit, Span};
 use harn_lint::LintSeverity;
+use harn_parser::analysis::{AnalysisDatabase, AnalysisError};
 use harn_parser::{
-    visit, BindingPattern, DiagnosticCode as Code, DiagnosticSeverity, Node, PipelineError, Repair,
-    RepairSafety, SNode, TypeChecker, TypeExpr, TypedParam,
+    visit, BindingPattern, DiagnosticCode as Code, DiagnosticSeverity, Node, Repair, RepairSafety,
+    SNode, TypeExpr, TypedParam,
 };
 use serde::Serialize;
 
@@ -382,10 +383,12 @@ fn build_plan_with_options(
 
     let module_graph = commands::check::build_module_graph(&files);
     let cross_file_imports = commands::check::collect_cross_file_imports(&module_graph);
+    let mut analysis = AnalysisDatabase::new();
     let mut candidates = Vec::new();
     let mut skipped_files = Vec::new();
     for file in &files {
         if let Err(skipped) = collect_file_candidates(
+            &mut analysis,
             file,
             safety_ceiling,
             &cross_file_imports,
@@ -595,21 +598,29 @@ fn count_remaining_diagnostics(target: &Path) -> Result<RemainingDiagnostics, St
     let files = commands::check::collect_harn_targets(&target_refs);
     let module_graph = commands::check::build_module_graph(&files);
     let cross_file_imports = commands::check::collect_cross_file_imports(&module_graph);
+    let mut analysis = AnalysisDatabase::new();
     let mut count = 0;
     let mut skipped_files = Vec::new();
 
     for file in &files {
-        let (source, program) = match parse_fix_source_file(file) {
-            Ok(parsed) => parsed,
-            Err(skipped) => {
-                skipped_files.push(skipped);
-                continue;
-            }
-        };
         let mut config = package::load_check_config(Some(file));
         commands::check::apply_harn_lint_config(file, &mut config);
+        let output =
+            match commands::check::analyze_file(&mut analysis, file, &config, &module_graph) {
+                Ok(output) => output,
+                Err(skipped) => {
+                    skipped_files.push(skipped_file_from_analysis_error(
+                        file.to_string_lossy().into_owned(),
+                        skipped,
+                    ));
+                    continue;
+                }
+            };
+        let source = output.source;
+        let program = output.program;
 
-        count += type_check(file, &config, &module_graph, &program, &source)
+        count += output
+            .diagnostics
             .iter()
             .filter(|diag| !harn_lint::type_diagnostic_lint_disabled(diag, &config.disable_rules))
             .count();
@@ -652,6 +663,7 @@ fn count_remaining_diagnostics(target: &Path) -> Result<RemainingDiagnostics, St
 }
 
 fn collect_file_candidates(
+    analysis: &mut AnalysisDatabase,
     file: &Path,
     safety_ceiling: Option<RepairSafety>,
     cross_file_imports: &HashSet<String>,
@@ -660,12 +672,14 @@ fn collect_file_candidates(
     out: &mut Vec<RepairCandidate>,
 ) -> Result<(), SkippedFileWire> {
     let path_str = file.to_string_lossy().into_owned();
-    let (source, program) = parse_fix_source_file(file)?;
     let mut config = package::load_check_config(Some(file));
     commands::check::apply_harn_lint_config(file, &mut config);
+    let output = commands::check::analyze_file(analysis, file, &config, module_graph)
+        .map_err(|error| skipped_file_from_analysis_error(path_str.clone(), error))?;
+    let source = output.source;
+    let program = output.program;
 
-    let type_diagnostics = type_check(file, &config, module_graph, &program, &source);
-    for diag in &type_diagnostics {
+    for diag in &output.diagnostics {
         if harn_lint::type_diagnostic_lint_disabled(diag, &config.disable_rules) {
             continue;
         }
@@ -731,61 +745,64 @@ fn collect_file_candidates(
     Ok(())
 }
 
-fn parse_fix_source_file(file: &Path) -> Result<(String, Vec<SNode>), SkippedFileWire> {
-    let path = file.to_string_lossy().into_owned();
-    let source = std::fs::read_to_string(file).map_err(|error| SkippedFileWire {
-        path: path.clone(),
-        reason: "read_error",
-        diagnostics: vec![SkippedFileDiagnosticWire {
-            source: "io",
-            severity: "error",
-            code: None,
-            message: format!("failed to read {path}: {error}"),
-            span: None,
-            help: None,
-        }],
-    })?;
-    let program = harn_parser::parse_source(&source)
-        .map_err(|error| skipped_file_from_pipeline_error(path, error))?;
-    Ok((source, program))
-}
-
-fn skipped_file_from_pipeline_error(path: String, error: PipelineError) -> SkippedFileWire {
-    let span = error.span().copied().map(SpanWire::from);
+fn skipped_file_from_analysis_error(
+    path: String,
+    error: commands::check::FileAnalysisError,
+) -> SkippedFileWire {
     let (reason, diagnostic) = match error {
-        PipelineError::Lex(error) => (
+        commands::check::FileAnalysisError::Read(error) => (
+            "read_error",
+            SkippedFileDiagnosticWire {
+                source: "io",
+                severity: "error",
+                code: None,
+                message: format!("failed to read {path}: {error}"),
+                span: None,
+                help: None,
+            },
+        ),
+        commands::check::FileAnalysisError::Analysis(AnalysisError::MissingSource(id)) => (
+            "analysis_error",
+            SkippedFileDiagnosticWire {
+                source: "analysis",
+                severity: "error",
+                code: None,
+                message: format!("missing analysis source {}", id.as_str()),
+                span: None,
+                help: None,
+            },
+        ),
+        commands::check::FileAnalysisError::Analysis(AnalysisError::Lex { error, .. }) => (
             "lex_error",
             SkippedFileDiagnosticWire {
                 source: "lexer",
                 severity: "error",
                 code: Some(harn_parser::diagnostic::lexer_error_code(&error).to_string()),
                 message: error.to_string(),
-                span,
+                span: Some(SpanWire::from(commands::check::span_from_lexer_error(
+                    &error,
+                ))),
                 help: None,
             },
         ),
-        PipelineError::Parse(error) => (
-            "parse_error",
-            SkippedFileDiagnosticWire {
-                source: "parser",
-                severity: "error",
-                code: Some(harn_parser::diagnostic::parser_error_code(&error).to_string()),
-                message: harn_parser::diagnostic::parser_error_message(&error),
-                span,
-                help: harn_parser::diagnostic::parser_error_help(&error).map(str::to_string),
-            },
-        ),
-        PipelineError::TypeCheck(error) => (
-            "type_error",
-            SkippedFileDiagnosticWire {
-                source: "typecheck",
-                severity: severity_label(error.severity),
-                code: Some(error.code.to_string()),
-                message: error.message,
-                span: error.span.map(SpanWire::from),
-                help: error.help,
-            },
-        ),
+        commands::check::FileAnalysisError::Analysis(AnalysisError::Parse { errors, .. }) => {
+            let error = errors
+                .first()
+                .expect("analysis parse errors should include at least one error");
+            (
+                "parse_error",
+                SkippedFileDiagnosticWire {
+                    source: "parser",
+                    severity: "error",
+                    code: Some(harn_parser::diagnostic::parser_error_code(error).to_string()),
+                    message: harn_parser::diagnostic::parser_error_message(error),
+                    span: Some(SpanWire::from(commands::check::span_from_parser_error(
+                        error,
+                    ))),
+                    help: harn_parser::diagnostic::parser_error_help(error).map(str::to_string),
+                },
+            )
+        }
     };
     SkippedFileWire {
         path,
@@ -1444,26 +1461,6 @@ fn collect_preflight_candidates(
             edits: Vec::new(),
         });
     }
-}
-
-fn type_check(
-    path: &Path,
-    config: &CheckConfig,
-    module_graph: &harn_modules::ModuleGraph,
-    program: &[SNode],
-    source: &str,
-) -> Vec<harn_parser::TypeDiagnostic> {
-    let mut checker = TypeChecker::with_strict_types(config.strict_types);
-    if let Some(imported) = module_graph.imported_names_for_file(path) {
-        checker = checker.with_imported_names(imported);
-    }
-    if let Some(imported) = module_graph.imported_type_declarations_for_file(path) {
-        checker = checker.with_imported_type_decls(imported);
-    }
-    if let Some(imported) = module_graph.imported_callable_declarations_for_file(path) {
-        checker = checker.with_imported_callable_decls(imported);
-    }
-    checker.check_with_source(program, source)
 }
 
 fn repair_allowed(repair: &Repair, safety_ceiling: Option<RepairSafety>) -> bool {

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -393,6 +393,7 @@ async fn async_main() {
             }
             let module_graph = commands::check::build_module_graph(&files);
             let cross_file_imports = commands::check::collect_cross_file_imports(&module_graph);
+            let mut analysis = harn_parser::analysis::AnalysisDatabase::new();
             let mut should_fail = false;
             let mut json_files = Vec::new();
             for file in &files {
@@ -411,6 +412,7 @@ async fn async_main() {
                 }
                 if args.json {
                     let report = commands::check::check_file_report(
+                        &mut analysis,
                         file,
                         &config,
                         &cross_file_imports,
@@ -421,6 +423,7 @@ async fn async_main() {
                     json_files.push(report);
                 } else {
                     let outcome = commands::check::check_file_inner(
+                        &mut analysis,
                         file,
                         &config,
                         &cross_file_imports,
@@ -508,6 +511,7 @@ async fn async_main() {
             }
             let module_graph = commands::check::build_module_graph(&files);
             let cross_file_imports = commands::check::collect_cross_file_imports(&module_graph);
+            let mut analysis = harn_parser::analysis::AnalysisDatabase::new();
             if args.json {
                 // `--json` always reports without modifying source — `--fix`
                 // is intentionally orthogonal to structured output so agents
@@ -525,6 +529,7 @@ async fn async_main() {
                     let persona_step_allowlist =
                         commands::check::harn_lint_persona_step_allowlist(file);
                     let report = commands::check::lint_file_report(
+                        &mut analysis,
                         file,
                         &config,
                         &cross_file_imports,
@@ -569,6 +574,7 @@ async fn async_main() {
                     let persona_step_allowlist =
                         commands::check::harn_lint_persona_step_allowlist(file);
                     commands::check::lint_fix_file(
+                        &mut analysis,
                         file,
                         &config,
                         &cross_file_imports,
@@ -600,6 +606,7 @@ async fn async_main() {
                     let persona_step_allowlist =
                         commands::check::harn_lint_persona_step_allowlist(file);
                     let outcome = commands::check::lint_file_inner(
+                        &mut analysis,
                         file,
                         &config,
                         &cross_file_imports,

--- a/crates/harn-lsp/src/document.rs
+++ b/crates/harn-lsp/src/document.rs
@@ -1,5 +1,7 @@
-use harn_lexer::Lexer;
-use harn_parser::{Parser, SNode, TypeChecker};
+use harn_parser::analysis::{
+    AnalysisDatabase, AnalysisError, SourceId, SourceVersion, TypeCheckConfig,
+};
+use harn_parser::SNode;
 use tower_lsp::lsp_types::*;
 
 use crate::helpers::{
@@ -9,6 +11,9 @@ use crate::symbols::{build_symbol_table, SymbolInfo};
 
 pub(crate) struct DocumentState {
     pub(crate) source: String,
+    analysis: AnalysisDatabase,
+    source_id: SourceId,
+    version: SourceVersion,
     pub(crate) cached_ast: Option<Vec<SNode>>,
     pub(crate) symbols: Vec<SymbolInfo>,
     pub(crate) diagnostics: Vec<Diagnostic>,
@@ -21,8 +26,14 @@ pub(crate) struct DocumentState {
 
 impl DocumentState {
     pub(crate) fn new(source: String) -> Self {
+        let mut analysis = AnalysisDatabase::new();
+        let source_id = SourceId::new("document");
+        analysis.set_source(source_id.clone(), source.clone(), SourceVersion(1));
         let mut state = Self {
             source,
+            analysis,
+            source_id,
+            version: SourceVersion(1),
             cached_ast: None,
             symbols: Vec::new(),
             diagnostics: Vec::new(),
@@ -38,6 +49,9 @@ impl DocumentState {
 
     pub(crate) fn update_source(&mut self, source: String) {
         self.source = source;
+        self.version = SourceVersion(self.version.0 + 1);
+        self.analysis
+            .set_source(self.source_id.clone(), self.source.clone(), self.version);
         self.dirty = true;
     }
 
@@ -54,32 +68,30 @@ impl DocumentState {
         self.symbols.clear();
         self.cached_ast = None;
 
-        let mut lexer = Lexer::new(&self.source);
-        let tokens = match lexer.tokenize() {
-            Ok(t) => t,
-            Err(e) => {
-                self.diagnostics.push(lexer_error_to_diagnostic(&e));
-                self.dirty = false;
-                return;
-            }
-        };
-
-        // Parse with recovery so every error surfaces, not just the first.
-        let mut parser = Parser::new(tokens);
-        let program = match parser.parse() {
-            Ok(p) => p,
-            Err(_) => {
-                for e in parser.all_errors() {
-                    self.diagnostics.push(parser_error_to_diagnostic(e));
+        let analysis = match self
+            .analysis
+            .typecheck(&self.source_id, TypeCheckConfig::new())
+        {
+            Ok(analysis) => analysis,
+            Err(error) => {
+                match error {
+                    AnalysisError::Lex { error, .. } => {
+                        self.diagnostics.push(lexer_error_to_diagnostic(&error));
+                    }
+                    AnalysisError::Parse { errors, .. } => {
+                        for error in &errors {
+                            self.diagnostics.push(parser_error_to_diagnostic(error));
+                        }
+                    }
+                    AnalysisError::MissingSource(_) => {}
                 }
                 self.dirty = false;
                 return;
             }
         };
-
-        // Source is required here so the checker can emit autofix text and inlay hints.
-        let (type_diags, inlay_hints) = TypeChecker::new().check_with_hints(&program, &self.source);
-        self.inlay_hints = inlay_hints;
+        let program = analysis.program;
+        let type_diags = analysis.diagnostics;
+        self.inlay_hints = analysis.inlay_hints;
         for diag in &type_diags {
             let severity = match diag.severity {
                 harn_parser::DiagnosticSeverity::Error => DiagnosticSeverity::ERROR,
@@ -177,6 +189,20 @@ mod tests {
             !state.diagnostics.is_empty(),
             "invalid source should produce diagnostics after reparse"
         );
+    }
+
+    #[test]
+    fn unchanged_document_reuses_analysis_cache() {
+        let mut state = DocumentState::new("pipeline default(task) { log(1) }\n".to_string());
+        let initial = state.analysis.stats();
+
+        state.update_source("pipeline default(task) { log(1) }\n".to_string());
+        state.reparse_if_dirty();
+
+        let after = state.analysis.stats();
+        assert_eq!(after.lex_runs, initial.lex_runs);
+        assert_eq!(after.parse_runs, initial.parse_runs);
+        assert_eq!(after.typecheck_runs, initial.typecheck_runs);
     }
 
     #[test]

--- a/crates/harn-parser/src/analysis.rs
+++ b/crates/harn-parser/src/analysis.rs
@@ -1,0 +1,465 @@
+use std::collections::{HashMap, HashSet};
+use std::hash::{Hash, Hasher};
+use std::path::Path;
+
+use harn_lexer::{Lexer, LexerError, Token};
+
+use crate::InlayHintInfo;
+use crate::{Parser, ParserError, SNode, TypeChecker, TypeDiagnostic};
+
+/// Stable source identity used by the incremental analysis cache.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SourceId(String);
+
+impl SourceId {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    pub fn path(path: &Path) -> Self {
+        Self(path.to_string_lossy().into_owned())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Monotonic caller-owned version for a source input.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SourceVersion(pub u64);
+
+/// Deterministic content digest for a source input.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SourceDigest(u64);
+
+impl SourceDigest {
+    pub fn from_source(source: &str) -> Self {
+        let mut hash = 0xcbf29ce484222325u64;
+        for byte in source.as_bytes() {
+            hash ^= u64::from(*byte);
+            hash = hash.wrapping_mul(0x100000001b3);
+        }
+        Self(hash)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SourceUpdate {
+    Inserted,
+    Changed,
+    Unchanged,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct AnalysisStats {
+    pub lex_runs: usize,
+    pub parse_runs: usize,
+    pub typecheck_runs: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct ParseOutput {
+    pub source: String,
+    pub program: Vec<SNode>,
+}
+
+#[derive(Debug, Clone)]
+pub struct TypeCheckOutput {
+    pub source: String,
+    pub program: Vec<SNode>,
+    pub diagnostics: Vec<TypeDiagnostic>,
+    pub inlay_hints: Vec<InlayHintInfo>,
+}
+
+#[derive(Debug, Clone)]
+pub enum AnalysisError {
+    MissingSource(SourceId),
+    Lex {
+        source: String,
+        error: LexerError,
+    },
+    Parse {
+        source: String,
+        errors: Vec<ParserError>,
+    },
+}
+
+impl AnalysisError {
+    pub fn source(&self) -> Option<&str> {
+        match self {
+            AnalysisError::MissingSource(_) => None,
+            AnalysisError::Lex { source, .. } | AnalysisError::Parse { source, .. } => Some(source),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct TypeCheckConfig {
+    pub strict_types: bool,
+    pub imported_names: Option<HashSet<String>>,
+    pub imported_type_decls: Vec<SNode>,
+    pub imported_callable_decls: Vec<SNode>,
+}
+
+impl TypeCheckConfig {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_strict_types(mut self, strict_types: bool) -> Self {
+        self.strict_types = strict_types;
+        self
+    }
+
+    pub fn with_imported_names(mut self, imported_names: Option<HashSet<String>>) -> Self {
+        self.imported_names = imported_names;
+        self
+    }
+
+    pub fn with_imported_type_decls(mut self, imported_type_decls: Vec<SNode>) -> Self {
+        self.imported_type_decls = imported_type_decls;
+        self
+    }
+
+    pub fn with_imported_callable_decls(mut self, imported_callable_decls: Vec<SNode>) -> Self {
+        self.imported_callable_decls = imported_callable_decls;
+        self
+    }
+
+    fn cache_key(&self) -> TypeCheckCacheKey {
+        let mut imported_names = self
+            .imported_names
+            .as_ref()
+            .map(|names| names.iter().cloned().collect::<Vec<_>>());
+        if let Some(names) = &mut imported_names {
+            names.sort();
+        }
+        TypeCheckCacheKey {
+            strict_types: self.strict_types,
+            imported_names,
+            imported_type_decls_digest: debug_digest(&self.imported_type_decls),
+            imported_callable_decls_digest: debug_digest(&self.imported_callable_decls),
+        }
+    }
+
+    fn build_checker(&self) -> TypeChecker {
+        let mut checker = TypeChecker::with_strict_types(self.strict_types);
+        if let Some(imported) = self.imported_names.clone() {
+            checker = checker.with_imported_names(imported);
+        }
+        if !self.imported_type_decls.is_empty() {
+            checker = checker.with_imported_type_decls(self.imported_type_decls.clone());
+        }
+        if !self.imported_callable_decls.is_empty() {
+            checker = checker.with_imported_callable_decls(self.imported_callable_decls.clone());
+        }
+        checker
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct TypeCheckCacheKey {
+    strict_types: bool,
+    imported_names: Option<Vec<String>>,
+    imported_type_decls_digest: u64,
+    imported_callable_decls_digest: u64,
+}
+
+#[derive(Debug, Clone)]
+struct CachedTypeCheck {
+    diagnostics: Vec<TypeDiagnostic>,
+    inlay_hints: Vec<InlayHintInfo>,
+}
+
+#[derive(Debug, Clone)]
+struct SourceEntry {
+    source: String,
+    version: SourceVersion,
+    digest: SourceDigest,
+    tokens: Option<Result<Vec<Token>, LexerError>>,
+    program: Option<Result<Vec<SNode>, Vec<ParserError>>>,
+    typechecks: HashMap<TypeCheckCacheKey, CachedTypeCheck>,
+}
+
+impl SourceEntry {
+    fn new(source: String, version: SourceVersion, digest: SourceDigest) -> Self {
+        Self {
+            source,
+            version,
+            digest,
+            tokens: None,
+            program: None,
+            typechecks: HashMap::new(),
+        }
+    }
+
+    fn replace_source(&mut self, source: String, version: SourceVersion, digest: SourceDigest) {
+        self.source = source;
+        self.version = version;
+        self.digest = digest;
+        self.tokens = None;
+        self.program = None;
+        self.typechecks.clear();
+    }
+}
+
+/// Persistent query cache for lexing, parsing, and type checking Harn sources.
+#[derive(Debug, Default)]
+pub struct AnalysisDatabase {
+    entries: HashMap<SourceId, SourceEntry>,
+    stats: AnalysisStats,
+}
+
+impl AnalysisDatabase {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn stats(&self) -> AnalysisStats {
+        self.stats.clone()
+    }
+
+    pub fn set_source(
+        &mut self,
+        id: SourceId,
+        source: String,
+        version: SourceVersion,
+    ) -> SourceUpdate {
+        let digest = SourceDigest::from_source(&source);
+        match self.entries.get_mut(&id) {
+            None => {
+                self.entries
+                    .insert(id, SourceEntry::new(source, version, digest));
+                SourceUpdate::Inserted
+            }
+            Some(entry) if entry.digest == digest => {
+                entry.version = version;
+                SourceUpdate::Unchanged
+            }
+            Some(entry) => {
+                entry.replace_source(source, version, digest);
+                SourceUpdate::Changed
+            }
+        }
+    }
+
+    pub fn parse(&mut self, id: &SourceId) -> Result<ParseOutput, AnalysisError> {
+        let mut lexed = false;
+        let mut parsed_now = false;
+        let entry = self.entry_mut(id)?;
+        if entry.tokens.is_none() {
+            lexed = true;
+            let mut lexer = Lexer::new(&entry.source);
+            entry.tokens = Some(lexer.tokenize());
+        }
+        let tokens = match entry.tokens.as_ref().expect("tokens initialized") {
+            Ok(tokens) => tokens.clone(),
+            Err(error) => {
+                let source = entry.source.clone();
+                let error = error.clone();
+                if lexed {
+                    self.stats.lex_runs += 1;
+                }
+                return Err(AnalysisError::Lex { source, error });
+            }
+        };
+
+        if entry.program.is_none() {
+            parsed_now = true;
+            let mut parser = Parser::new(tokens);
+            entry.program = Some(match parser.parse() {
+                Ok(program) => Ok(program),
+                Err(error) => {
+                    let mut errors = parser.all_errors().to_vec();
+                    if errors.is_empty() {
+                        errors.push(error);
+                    }
+                    Err(errors)
+                }
+            });
+        }
+
+        let result = match entry.program.as_ref().expect("program initialized") {
+            Ok(program) => Ok(ParseOutput {
+                source: entry.source.clone(),
+                program: program.clone(),
+            }),
+            Err(errors) => Err(AnalysisError::Parse {
+                source: entry.source.clone(),
+                errors: errors.clone(),
+            }),
+        };
+        if lexed {
+            self.stats.lex_runs += 1;
+        }
+        if parsed_now {
+            self.stats.parse_runs += 1;
+        }
+        result
+    }
+
+    pub fn typecheck(
+        &mut self,
+        id: &SourceId,
+        config: TypeCheckConfig,
+    ) -> Result<TypeCheckOutput, AnalysisError> {
+        let parsed = self.parse(id)?;
+        let key = config.cache_key();
+        if let Some(cached) = self
+            .entries
+            .get(id)
+            .expect("parse verified source entry")
+            .typechecks
+            .get(&key)
+        {
+            return Ok(TypeCheckOutput {
+                source: parsed.source,
+                program: parsed.program,
+                diagnostics: cached.diagnostics.clone(),
+                inlay_hints: cached.inlay_hints.clone(),
+            });
+        }
+
+        self.stats.typecheck_runs += 1;
+        let (diagnostics, inlay_hints) = config
+            .build_checker()
+            .check_with_hints(&parsed.program, &parsed.source);
+        let cached = CachedTypeCheck {
+            diagnostics: diagnostics.clone(),
+            inlay_hints: inlay_hints.clone(),
+        };
+        self.entries
+            .get_mut(id)
+            .expect("parse verified source entry")
+            .typechecks
+            .insert(key, cached);
+        Ok(TypeCheckOutput {
+            source: parsed.source,
+            program: parsed.program,
+            diagnostics,
+            inlay_hints,
+        })
+    }
+
+    fn entry_mut(&mut self, id: &SourceId) -> Result<&mut SourceEntry, AnalysisError> {
+        self.entries
+            .get_mut(id)
+            .ok_or_else(|| AnalysisError::MissingSource(id.clone()))
+    }
+}
+
+fn debug_digest<T: std::fmt::Debug>(value: &T) -> u64 {
+    let mut hasher = StableHasher::default();
+    format!("{value:?}").hash(&mut hasher);
+    hasher.finish()
+}
+
+#[derive(Default)]
+struct StableHasher(u64);
+
+impl Hasher for StableHasher {
+    fn finish(&self) -> u64 {
+        self.0
+    }
+
+    fn write(&mut self, bytes: &[u8]) {
+        let mut hash = if self.0 == 0 {
+            0xcbf29ce484222325u64
+        } else {
+            self.0
+        };
+        for byte in bytes {
+            hash ^= u64::from(*byte);
+            hash = hash.wrapping_mul(0x100000001b3);
+        }
+        self.0 = hash;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::DiagnosticSeverity;
+
+    fn source_id() -> SourceId {
+        SourceId::new("test.harn")
+    }
+
+    #[test]
+    fn parse_reuses_cached_program_for_unchanged_source() {
+        let mut db = AnalysisDatabase::new();
+        let id = source_id();
+        assert_eq!(
+            db.set_source(id.clone(), "let x = 1\n".to_string(), SourceVersion(1)),
+            SourceUpdate::Inserted
+        );
+        db.parse(&id).expect("initial parse");
+        db.parse(&id).expect("cached parse");
+        assert_eq!(db.stats().lex_runs, 1);
+        assert_eq!(db.stats().parse_runs, 1);
+
+        assert_eq!(
+            db.set_source(id.clone(), "let x = 1\n".to_string(), SourceVersion(2)),
+            SourceUpdate::Unchanged
+        );
+        db.parse(&id).expect("same digest parse");
+        assert_eq!(db.stats().lex_runs, 1);
+        assert_eq!(db.stats().parse_runs, 1);
+    }
+
+    #[test]
+    fn source_change_invalidates_parse_and_typecheck_outputs() {
+        let mut db = AnalysisDatabase::new();
+        let id = source_id();
+        db.set_source(id.clone(), "let x = 1\n".to_string(), SourceVersion(1));
+        db.typecheck(&id, TypeCheckConfig::new())
+            .expect("initial check");
+        assert_eq!(
+            db.set_source(id.clone(), "let x = 2\n".to_string(), SourceVersion(2)),
+            SourceUpdate::Changed
+        );
+        db.typecheck(&id, TypeCheckConfig::new())
+            .expect("changed check");
+        assert_eq!(db.stats().lex_runs, 2);
+        assert_eq!(db.stats().parse_runs, 2);
+        assert_eq!(db.stats().typecheck_runs, 2);
+    }
+
+    #[test]
+    fn typecheck_cache_is_keyed_by_options() {
+        let mut db = AnalysisDatabase::new();
+        let id = source_id();
+        db.set_source(
+            id.clone(),
+            "pipeline main() {\n  let x = read_file(\"a\")\n  log(x.foo)\n}\n".to_string(),
+            SourceVersion(1),
+        );
+        db.typecheck(&id, TypeCheckConfig::new())
+            .expect("default check");
+        db.typecheck(&id, TypeCheckConfig::new())
+            .expect("cached default check");
+        db.typecheck(&id, TypeCheckConfig::new().with_strict_types(true))
+            .expect("strict check");
+        assert_eq!(db.stats().typecheck_runs, 2);
+    }
+
+    #[test]
+    fn typecheck_diagnostics_are_cached_with_hints() {
+        let mut db = AnalysisDatabase::new();
+        let id = source_id();
+        db.set_source(
+            id.clone(),
+            "pipeline main() {\n  let x: int = \"nope\"\n}\n".to_string(),
+            SourceVersion(1),
+        );
+        let first = db.typecheck(&id, TypeCheckConfig::new()).expect("check");
+        let second = db.typecheck(&id, TypeCheckConfig::new()).expect("cached");
+        assert!(first
+            .diagnostics
+            .iter()
+            .any(|diag| diag.severity == DiagnosticSeverity::Error));
+        assert_eq!(first.diagnostics.len(), second.diagnostics.len());
+        assert_eq!(db.stats().typecheck_runs, 1);
+    }
+}

--- a/crates/harn-parser/src/lib.rs
+++ b/crates/harn-parser/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod analysis;
 mod ast;
 pub mod ast_json;
 pub mod builtin_signatures;


### PR DESCRIPTION
## Summary
- add a shared harn_parser::analysis cache for source identity, digest/version invalidation, parse output, and typecheck output
- route LSP document analysis plus harn check/lint/fix through the shared analysis boundary
- add deterministic cache reuse/invalidation tests for parser, LSP, and CLI paths

Closes #2152.

## Verification
- cargo check -p harn-cli -p harn-lsp
- cargo test -p harn-parser analysis::tests --quiet
- cargo test -p harn-lsp document::tests --quiet
- CARGO_BUILD_JOBS=1 cargo test -p harn-cli --lib commands::check::tests --quiet
- CARGO_BUILD_JOBS=1 cargo test -p harn-cli --lib commands::fix::tests --quiet
- pre-commit changed-package clippy hook
- pre-push targeted local checks