### PR TITLE
Implement git-tag package publish flow

### DIFF
--- a/crates/harn-cli/src/cli/mod.rs
+++ b/crates/harn-cli/src/cli/mod.rs
@@ -435,11 +435,7 @@ SCRIPTING
     Lock,
     /// Manage Harn package caches and integrity verification.
     Package(PackageArgs),
-    /// Prepare a package manifest and bundle for publication. Validates
-    /// `harn.toml` and produces a publishable archive locally; remote
-    /// registry submission is not yet implemented (the resulting
-    /// archive can be installed via `harn add <repo-or-path>` in the
-    /// meantime).
+    /// Publish a package by tagging the source repo and opening a package-index PR.
     Publish(PublishArgs),
     /// List and inspect durable agent persona manifests.
     Persona(PersonaArgs),

--- a/crates/harn-cli/src/cli/package.rs
+++ b/crates/harn-cli/src/cli/package.rs
@@ -230,10 +230,25 @@ pub(crate) struct PackageInfoArgs {
 pub(crate) struct PublishArgs {
     /// Package directory, harn.toml, or file under the package. Defaults to cwd.
     pub package: Option<PathBuf>,
-    /// Required until registry submission support lands.
+    /// Validate and print the tag command plus package-index diff without pushing.
     #[arg(long)]
     pub dry_run: bool,
-    /// Package registry index URL or path to report as the submission target.
+    /// Git remote to tag and push. Defaults to origin.
+    #[arg(long, default_value = "origin")]
+    pub remote: String,
+    /// GitHub repository that owns the package index.
+    #[arg(long, default_value = "burin-labs/harn-cloud")]
+    pub index_repo: String,
+    /// Package-index TOML path inside --index-repo.
+    #[arg(long, default_value = "package-index/harn-package-index.toml")]
+    pub index_path: PathBuf,
+    /// Registry package name to update. Defaults to [package].name.
+    #[arg(long)]
+    pub registry_name: Option<String>,
+    /// Push the git tag but leave the package-index PR to the maintainer.
+    #[arg(long)]
+    pub skip_index_pr: bool,
+    /// Compatibility label for the registry/index target shown in reports.
     #[arg(long, value_name = "URL|PATH")]
     pub registry: Option<String>,
     /// Emit JSON instead of a human-readable report.

--- a/crates/harn-cli/src/cli/tests.rs
+++ b/crates/harn-cli/src/cli/tests.rs
@@ -8,9 +8,9 @@ use super::{
     OrchestratorCommand, OrchestratorDeployProvider, OrchestratorLogFormat,
     OrchestratorQueueCommand, OrchestratorTenantCommand, PackageArtifactsCommand,
     PackageCacheCommand, PackageCommand, PackageScaffoldCommand, PersonaCommand, ProjectTemplate,
-    ProviderToolProbeModeArg, ProvidersCommand, RunsCommand, SessionCommand, SkillCommand,
-    SkillKeyCommand, SkillTrustCommand, SkillsCommand, ToolCommand, TraceCommand, TriggerCommand,
-    TrustCommand, TrustOutcomeArg, TrustTierArg,
+    ProviderToolProbeModeArg, ProvidersCommand, PublishArgs, RunsCommand, SessionCommand,
+    SkillCommand, SkillKeyCommand, SkillTrustCommand, SkillsCommand, ToolCommand, TraceCommand,
+    TriggerCommand, TrustCommand, TrustOutcomeArg, TrustTierArg,
 };
 use clap::{CommandFactory, Parser};
 
@@ -2080,6 +2080,52 @@ fn test_parses_package_cache_subcommands() {
         panic!("expected package cache verify");
     };
     assert!(verify.materialized);
+}
+
+#[test]
+fn test_parses_publish_git_tag_flow_options() {
+    let cli = Cli::parse_from([
+        "harn",
+        "publish",
+        "pkg",
+        "--dry-run",
+        "--remote",
+        "upstream",
+        "--index-repo",
+        "burin-labs/harn-cloud",
+        "--index-path",
+        "package-index/harn-package-index.toml",
+        "--registry-name",
+        "@burin/acme-lib",
+        "--skip-index-pr",
+        "--json",
+    ]);
+    let Command::Publish(PublishArgs {
+        package,
+        dry_run,
+        remote,
+        index_repo,
+        index_path,
+        registry_name,
+        skip_index_pr,
+        json,
+        ..
+    }) = cli.command.unwrap()
+    else {
+        panic!("expected publish command");
+    };
+
+    assert_eq!(package, Some(PathBuf::from("pkg")));
+    assert!(dry_run);
+    assert_eq!(remote, "upstream");
+    assert_eq!(index_repo, "burin-labs/harn-cloud");
+    assert_eq!(
+        index_path,
+        PathBuf::from("package-index/harn-package-index.toml")
+    );
+    assert_eq!(registry_name.as_deref(), Some("@burin/acme-lib"));
+    assert!(skip_index_pr);
+    assert!(json);
 }
 
 #[test]

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -1212,6 +1212,11 @@ async fn async_main() {
         Command::Publish(args) => package::publish_package(
             args.package.as_deref(),
             args.dry_run,
+            &args.remote,
+            &args.index_repo,
+            &args.index_path,
+            args.registry_name.as_deref(),
+            args.skip_index_pr,
             args.registry.as_deref(),
             args.json,
         ),

--- a/crates/harn-cli/src/package/package_ops.rs
+++ b/crates/harn-cli/src/package/package_ops.rs
@@ -1,5 +1,6 @@
 use super::errors::PackageError;
 use super::*;
+use base64::Engine as _;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct PackageCheckReport {
@@ -67,7 +68,47 @@ pub struct PackagePublishReport {
     pub registry: String,
     pub artifact_dir: String,
     pub files: Vec<String>,
+    pub tag: String,
+    pub sha: String,
+    pub remote: String,
+    pub index_repo: String,
+    pub index_path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub index_pr_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tag_command: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub index_diff: Option<String>,
     pub check: PackageCheckReport,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct PackagePublishOptions<'a> {
+    pub(crate) dry_run: bool,
+    pub(crate) remote: &'a str,
+    pub(crate) index_repo: &'a str,
+    pub(crate) index_path: &'a Path,
+    pub(crate) registry_name: Option<&'a str>,
+    pub(crate) skip_index_pr: bool,
+    pub(crate) registry: Option<&'a str>,
+}
+
+#[derive(Debug, Clone)]
+struct PackagePublishPlan {
+    repo_root: PathBuf,
+    package_name: String,
+    registry_name: String,
+    version: String,
+    tag: String,
+    sha: String,
+    git: String,
+    remote: String,
+    index_repo: String,
+    index_path: PathBuf,
+    updated_index_content: String,
+    index_diff: String,
+    tag_command: String,
+    pack: PackagePackReport,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -165,15 +206,29 @@ pub fn generate_package_docs(anchor: Option<&Path>, output: Option<&Path>, check
     }
 }
 
-pub fn publish_package(anchor: Option<&Path>, dry_run: bool, registry: Option<&str>, json: bool) {
-    if !dry_run {
-        eprintln!(
-            "error: registry submission is not enabled yet; use `harn publish --dry-run` to validate the package and inspect the artifact"
-        );
-        process::exit(1);
-    }
+#[allow(clippy::too_many_arguments)]
+pub fn publish_package(
+    anchor: Option<&Path>,
+    dry_run: bool,
+    remote: &str,
+    index_repo: &str,
+    index_path: &Path,
+    registry_name: Option<&str>,
+    skip_index_pr: bool,
+    registry: Option<&str>,
+    json: bool,
+) {
+    let options = PackagePublishOptions {
+        dry_run,
+        remote,
+        index_repo,
+        index_path,
+        registry_name,
+        skip_index_pr,
+        registry,
+    };
 
-    match publish_package_impl(anchor, registry) {
+    match publish_package_impl(anchor, &options) {
         Ok(report) => {
             if json {
                 println!(
@@ -182,7 +237,22 @@ pub fn publish_package(anchor: Option<&Path>, dry_run: bool, registry: Option<&s
                         .unwrap_or_else(|error| format!(r#"{{"error":"{error}"}}"#))
                 );
             } else {
-                println!("Dry-run publish to {} succeeded.", report.registry);
+                if report.dry_run {
+                    println!("Publish dry run to {} succeeded.", report.registry);
+                } else {
+                    println!("Published {}.", report.tag);
+                }
+                println!("tag: {}", report.tag);
+                println!("sha: {}", report.sha);
+                if let Some(command) = report.tag_command.as_deref() {
+                    println!("tag command: {command}");
+                }
+                if let Some(diff) = report.index_diff.as_deref() {
+                    println!("\nindex diff:\n{diff}");
+                }
+                if let Some(url) = report.index_pr_url.as_deref() {
+                    println!("index PR: {url}");
+                }
                 println!("artifact: {}", report.artifact_dir);
                 println!("files: {}", report.files.len());
             }
@@ -691,17 +761,752 @@ pub(crate) fn generate_package_docs_impl(
 
 pub(crate) fn publish_package_impl(
     anchor: Option<&Path>,
-    registry: Option<&str>,
+    options: &PackagePublishOptions<'_>,
 ) -> Result<PackagePublishReport, PackageError> {
-    let pack = pack_package_impl(anchor, None, true)?;
-    let registry = resolve_configured_registry_source(registry)?;
+    let registry = options
+        .registry
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| {
+            format!(
+                "{}/{}",
+                options.index_repo.trim(),
+                normalized_relative_path(options.index_path)
+            )
+        });
+    let index_content = if options.skip_index_pr {
+        String::new()
+    } else {
+        fetch_package_index_from_github(options.index_repo, options.index_path)?
+    };
+    let mut plan = prepare_publish_plan(anchor, options, index_content, &registry)?;
+    if !options.dry_run && !options.skip_index_pr {
+        ensure_github_repo_writeable(options.index_repo)?;
+    }
+    let index_pr_url = if options.dry_run {
+        None
+    } else {
+        execute_publish_plan(&mut plan, options.skip_index_pr)?
+    };
+
     Ok(PackagePublishReport {
-        dry_run: true,
+        dry_run: options.dry_run,
         registry,
-        artifact_dir: pack.artifact_dir,
-        files: pack.files,
-        check: pack.check,
+        artifact_dir: plan.pack.artifact_dir,
+        files: plan.pack.files,
+        tag: plan.tag,
+        sha: plan.sha,
+        remote: plan.remote,
+        index_repo: plan.index_repo,
+        index_path: normalized_relative_path(&plan.index_path),
+        index_pr_url,
+        tag_command: Some(plan.tag_command),
+        index_diff: if options.skip_index_pr {
+            None
+        } else {
+            Some(plan.index_diff)
+        },
+        check: plan.pack.check,
     })
+}
+
+fn prepare_publish_plan(
+    anchor: Option<&Path>,
+    options: &PackagePublishOptions<'_>,
+    index_content: String,
+    registry: &str,
+) -> Result<PackagePublishPlan, PackageError> {
+    let pack = pack_package_impl(anchor, None, true)?;
+    let ctx = load_manifest_context_for_anchor(anchor)?;
+    let package_info = ctx
+        .manifest
+        .package
+        .as_ref()
+        .ok_or_else(|| PackageError::Ops("[package] metadata is required".to_string()))?;
+    let package_name = pack
+        .check
+        .name
+        .clone()
+        .ok_or_else(|| PackageError::Ops("[package].name is required".to_string()))?;
+    let version = pack
+        .check
+        .version
+        .clone()
+        .ok_or_else(|| PackageError::Ops("[package].version is required".to_string()))?;
+    let registry_name = options
+        .registry_name
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .unwrap_or(&package_name)
+        .to_string();
+    if !is_valid_registry_package_name(&registry_name) {
+        return Err(PackageError::Validation(format!(
+            "invalid registry package name '{registry_name}'; use names like @burin/notion-sdk or acme-lib"
+        )));
+    }
+
+    let repo_root = git_output(&ctx.dir, ["rev-parse", "--show-toplevel"])?;
+    let repo_root = PathBuf::from(repo_root.trim());
+    ensure_git_worktree_clean(&repo_root)?;
+    let sha = git_output(&repo_root, ["rev-parse", "HEAD"])?
+        .trim()
+        .to_string();
+    let remote = options.remote.trim();
+    if remote.is_empty() {
+        return Err(PackageError::Ops("--remote cannot be empty".to_string()));
+    }
+    let remote_url = git_output(&repo_root, ["remote", "get-url", remote])?
+        .trim()
+        .to_string();
+    let git = normalize_git_url(&remote_url)?;
+    let tag = format!("v{version}");
+    ensure_tag_available(&repo_root, remote, &tag)?;
+    ensure_changelog_entry(&ctx.dir.join("CHANGELOG.md"), &version)?;
+
+    let (updated_index_content, index_diff) = if options.skip_index_pr {
+        (index_content.clone(), String::new())
+    } else {
+        let entry = render_registry_version_entry(&version, &git, &tag, &sha, &package_name)?;
+        let updated = add_registry_version_entry(
+            &index_content,
+            package_info,
+            &pack.check,
+            &registry_name,
+            &entry,
+            &version,
+            &git,
+        )?;
+        parse_package_registry_index(registry, &updated)?;
+        let diff = render_unified_diff(
+            &index_content,
+            &updated,
+            &normalized_relative_path(options.index_path),
+        )?;
+        (updated, diff)
+    };
+
+    Ok(PackagePublishPlan {
+        repo_root: repo_root.clone(),
+        package_name,
+        registry_name,
+        version,
+        tag: tag.clone(),
+        sha,
+        git,
+        remote: remote.to_string(),
+        index_repo: options.index_repo.trim().to_string(),
+        index_path: options.index_path.to_path_buf(),
+        updated_index_content,
+        index_diff,
+        tag_command: format!(
+            "git -C {} tag {tag} && git -C {} push {remote} refs/tags/{tag}",
+            shell_quote_path(&repo_root),
+            shell_quote_path(&repo_root)
+        ),
+        pack,
+    })
+}
+
+fn execute_publish_plan(
+    plan: &mut PackagePublishPlan,
+    skip_index_pr: bool,
+) -> Result<Option<String>, PackageError> {
+    run_git_checked(&plan.repo_root, ["tag", plan.tag.as_str()])?;
+    run_git_checked(
+        &plan.repo_root,
+        [
+            "push",
+            plan.remote.as_str(),
+            &format!("refs/tags/{}", plan.tag),
+        ],
+    )?;
+    if skip_index_pr {
+        return Ok(None);
+    }
+    create_index_pull_request(plan).map(Some)
+}
+
+fn create_index_pull_request(plan: &PackagePublishPlan) -> Result<String, PackageError> {
+    let temp = tempfile::tempdir()
+        .map_err(|error| PackageError::Ops(format!("failed to create temp dir: {error}")))?;
+    let checkout = temp.path().join("index");
+    let base_branch = github_default_branch(&plan.index_repo)?;
+    run_command_checked(
+        Path::new("."),
+        "gh",
+        [
+            "repo",
+            "clone",
+            plan.index_repo.as_str(),
+            checkout.to_string_lossy().as_ref(),
+            "--",
+            "--depth",
+            "1",
+            "--branch",
+            base_branch.as_str(),
+        ],
+    )?;
+    let branch = format!(
+        "harn-publish/{}-{}",
+        sanitize_branch_segment(&plan.package_name),
+        sanitize_branch_segment(&plan.version)
+    );
+    run_git_checked(&checkout, ["switch", "-c", branch.as_str()])?;
+    let index_path = checkout.join(&plan.index_path);
+    if let Some(parent) = index_path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|error| format!("failed to create {}: {error}", parent.display()))?;
+    }
+    fs::write(&index_path, &plan.updated_index_content)
+        .map_err(|error| format!("failed to write {}: {error}", index_path.display()))?;
+    run_git_checked(
+        &checkout,
+        ["add", normalized_relative_path(&plan.index_path).as_str()],
+    )?;
+    run_git_checked(
+        &checkout,
+        [
+            "commit",
+            "-m",
+            &format!(
+                "Add {} {} to package index",
+                plan.registry_name, plan.version
+            ),
+        ],
+    )?;
+    run_git_checked(&checkout, ["push", "-u", "origin", branch.as_str()])?;
+    let body = format!(
+        "Adds `{}` version `{}` to the Harn package index.\n\nSource tag: `{}`\nSource SHA: `{}`\nSource git: `{}`\n",
+        plan.registry_name, plan.version, plan.tag, plan.sha, plan.git
+    );
+    let body_path = temp.path().join("pr-body.md");
+    fs::write(&body_path, body)
+        .map_err(|error| format!("failed to write {}: {error}", body_path.display()))?;
+    let output = run_command_output(
+        Path::new("."),
+        "gh",
+        [
+            "pr",
+            "create",
+            "--repo",
+            plan.index_repo.as_str(),
+            "--base",
+            base_branch.as_str(),
+            "--head",
+            branch.as_str(),
+            "--title",
+            &format!(
+                "Add {} {} to package index",
+                plan.registry_name, plan.version
+            ),
+            "--body-file",
+            body_path.to_string_lossy().as_ref(),
+        ],
+    )?;
+    Ok(output.trim().to_string())
+}
+
+fn github_default_branch(index_repo: &str) -> Result<String, PackageError> {
+    let branch = run_command_output(
+        Path::new("."),
+        "gh",
+        [
+            "repo",
+            "view",
+            index_repo.trim(),
+            "--json",
+            "defaultBranchRef",
+            "--jq",
+            ".defaultBranchRef.name",
+        ],
+    )?;
+    let branch = branch.trim();
+    if branch.is_empty() {
+        Err(PackageError::Registry(format!(
+            "failed to resolve default branch for {index_repo}"
+        )))
+    } else {
+        Ok(branch.to_string())
+    }
+}
+
+fn fetch_package_index_from_github(
+    index_repo: &str,
+    index_path: &Path,
+) -> Result<String, PackageError> {
+    ensure_gh_available()?;
+    let api_path = format!(
+        "repos/{}/contents/{}",
+        index_repo.trim(),
+        normalized_relative_path(index_path)
+    );
+    let content = run_command_output(
+        Path::new("."),
+        "gh",
+        ["api", api_path.as_str(), "--jq", ".content"],
+    )?;
+    let encoded = content.replace(['\n', '\r'], "");
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(encoded.as_bytes())
+        .map_err(|error| {
+            PackageError::Registry(format!(
+                "failed to decode package index from {index_repo}: {}: {error}",
+                index_path.display()
+            ))
+        })?;
+    String::from_utf8(bytes).map_err(|error| {
+        PackageError::Registry(format!(
+            "package index {} in {index_repo} is not UTF-8: {error}",
+            index_path.display()
+        ))
+    })
+}
+
+fn ensure_gh_available() -> Result<(), PackageError> {
+    which::which("gh").map(|_| ()).map_err(|_| {
+        PackageError::Registry(
+            "gh is required to read or update the package index but was not found in PATH"
+                .to_string(),
+        )
+    })
+}
+
+fn ensure_github_repo_writeable(index_repo: &str) -> Result<(), PackageError> {
+    let permission = run_command_output(
+        Path::new("."),
+        "gh",
+        [
+            "repo",
+            "view",
+            index_repo.trim(),
+            "--json",
+            "viewerPermission",
+            "--jq",
+            ".viewerPermission",
+        ],
+    )?;
+    let permission = permission.trim();
+    if matches!(permission, "ADMIN" | "MAINTAIN" | "WRITE") {
+        Ok(())
+    } else {
+        Err(PackageError::Registry(format!(
+            "current gh auth has {permission} permission on {index_repo}; WRITE, MAINTAIN, or ADMIN is required to open the package-index PR"
+        )))
+    }
+}
+
+fn ensure_git_worktree_clean(repo: &Path) -> Result<(), PackageError> {
+    let status = git_output(repo, ["status", "--porcelain"])?;
+    if status.trim().is_empty() {
+        Ok(())
+    } else {
+        Err(PackageError::Ops(format!(
+            "working tree must be clean before publishing:\n{}",
+            status.trim_end()
+        )))
+    }
+}
+
+fn ensure_tag_available(repo: &Path, remote: &str, tag: &str) -> Result<(), PackageError> {
+    if git_status(
+        repo,
+        [
+            "rev-parse",
+            "--verify",
+            "--quiet",
+            &format!("refs/tags/{tag}"),
+        ],
+    )?
+    .success()
+    {
+        return Err(PackageError::Ops(format!(
+            "git tag {tag} already exists locally"
+        )));
+    }
+    let status = git_status(
+        repo,
+        [
+            "ls-remote",
+            "--exit-code",
+            "--tags",
+            remote,
+            &format!("refs/tags/{tag}"),
+        ],
+    )?;
+    if status.success() {
+        return Err(PackageError::Ops(format!(
+            "git tag {tag} already exists on remote {remote}"
+        )));
+    }
+    if status.code() == Some(2) {
+        return Ok(());
+    }
+    Err(PackageError::Ops(format!(
+        "failed to check whether tag {tag} exists on remote {remote}"
+    )))
+}
+
+fn ensure_changelog_entry(path: &Path, version: &str) -> Result<(), PackageError> {
+    let content = fs::read_to_string(path)
+        .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
+    if changelog_has_nonempty_entry(&content, version) {
+        Ok(())
+    } else {
+        Err(PackageError::Validation(format!(
+            "{} must contain a non-empty entry for version {version}",
+            path.display()
+        )))
+    }
+}
+
+fn changelog_has_nonempty_entry(content: &str, version: &str) -> bool {
+    let escaped = regex::escape(version);
+    let heading = Regex::new(&format!(
+        r"(?m)^#{{1,6}}\s+(?:\[?v?{}\]?)(?:\s|$|[-(])",
+        escaped
+    ))
+    .expect("valid changelog heading regex");
+    let Some(found) = heading.find(content) else {
+        return false;
+    };
+    let rest = &content[found.end()..];
+    let entry = rest
+        .lines()
+        .take_while(|line| !line.trim_start().starts_with('#'))
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with("<!--"))
+        .collect::<Vec<_>>();
+    !entry.is_empty()
+}
+
+fn add_registry_version_entry(
+    content: &str,
+    package_info: &PackageInfo,
+    report: &PackageCheckReport,
+    registry_name: &str,
+    version_entry: &str,
+    version: &str,
+    git: &str,
+) -> Result<String, PackageError> {
+    let snapshot = parse_publish_index_snapshot(content)?;
+    if let Some(package) = snapshot
+        .packages
+        .iter()
+        .find(|package| package.name == registry_name)
+    {
+        if package
+            .versions
+            .iter()
+            .any(|entry| entry.version == version)
+        {
+            return Err(PackageError::Registry(format!(
+                "package index already contains {registry_name}@{version}"
+            )));
+        }
+        return insert_version_entry(content, registry_name, version_entry);
+    }
+
+    let mut updated = content.trim_end().to_string();
+    updated.push_str("\n\n");
+    updated.push_str(&render_registry_package_block(
+        package_info,
+        report,
+        registry_name,
+        git,
+        version_entry,
+    )?);
+    Ok(updated)
+}
+
+fn insert_version_entry(
+    content: &str,
+    registry_name: &str,
+    version_entry: &str,
+) -> Result<String, PackageError> {
+    let starts = package_block_offsets(content);
+    for (idx, start) in starts.iter().enumerate() {
+        let end = starts.get(idx + 1).copied().unwrap_or(content.len());
+        let block = &content[*start..end];
+        if block_has_registry_name(block, registry_name) {
+            let mut updated = String::with_capacity(content.len() + version_entry.len() + 2);
+            updated.push_str(content[..end].trim_end());
+            updated.push_str("\n\n");
+            updated.push_str(version_entry.trim_end());
+            updated.push('\n');
+            updated.push_str(&content[end..]);
+            return Ok(updated);
+        }
+    }
+    Err(PackageError::Registry(format!(
+        "failed to locate package index block for {registry_name}"
+    )))
+}
+
+fn package_block_offsets(content: &str) -> Vec<usize> {
+    let mut offsets = Vec::new();
+    let mut cursor = 0;
+    for line in content.split_inclusive('\n') {
+        if line.trim() == "[[package]]" {
+            offsets.push(cursor);
+        }
+        cursor += line.len();
+    }
+    if cursor < content.len() && content[cursor..].trim() == "[[package]]" {
+        offsets.push(cursor);
+    }
+    offsets
+}
+
+fn block_has_registry_name(block: &str, registry_name: &str) -> bool {
+    let literal = match toml_string_literal(registry_name) {
+        Ok(literal) => literal,
+        Err(_) => return false,
+    };
+    block.lines().any(|line| {
+        let line = line.trim();
+        line.strip_prefix("name")
+            .and_then(|rest| rest.trim_start().strip_prefix('='))
+            .is_some_and(|value| value.trim() == literal)
+    })
+}
+
+#[derive(Debug, Deserialize)]
+struct PublishIndexSnapshot {
+    #[serde(default, rename = "package")]
+    packages: Vec<PublishIndexPackageSnapshot>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PublishIndexPackageSnapshot {
+    name: String,
+    #[serde(default, rename = "version")]
+    versions: Vec<PublishIndexVersionSnapshot>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PublishIndexVersionSnapshot {
+    version: String,
+}
+
+fn parse_publish_index_snapshot(content: &str) -> Result<PublishIndexSnapshot, PackageError> {
+    toml::from_str(content)
+        .map_err(|error| PackageError::Registry(format!("failed to parse package index: {error}")))
+}
+
+fn render_registry_package_block(
+    package_info: &PackageInfo,
+    report: &PackageCheckReport,
+    registry_name: &str,
+    git: &str,
+    version_entry: &str,
+) -> Result<String, PackageError> {
+    let mut out = String::new();
+    out.push_str("[[package]]\n");
+    push_toml_string_field(&mut out, "name", registry_name)?;
+    if let Some(description) = package_info.description.as_deref() {
+        push_toml_string_field(&mut out, "description", description)?;
+    }
+    push_toml_string_field(
+        &mut out,
+        "repository",
+        package_info.repository.as_deref().unwrap_or(git),
+    )?;
+    if let Some(license) = package_info.license.as_deref() {
+        push_toml_string_field(&mut out, "license", license)?;
+    }
+    if let Some(harn) = package_info.harn.as_deref() {
+        push_toml_string_field(&mut out, "harn", harn)?;
+    }
+    if !report.exports.is_empty() {
+        let exports = report
+            .exports
+            .iter()
+            .map(|export| toml_string_literal(&export.name))
+            .collect::<Result<Vec<_>, _>>()?
+            .join(", ");
+        out.push_str(&format!("exports = [{exports}]\n"));
+    }
+    if let Some(docs_url) = package_info.docs_url.as_deref() {
+        push_toml_string_field(&mut out, "docs_url", docs_url)?;
+    }
+    push_toml_string_field(&mut out, "provenance", git)?;
+    out.push('\n');
+    out.push_str(version_entry.trim_end());
+    out.push('\n');
+    Ok(out)
+}
+
+fn render_registry_version_entry(
+    version: &str,
+    git: &str,
+    tag: &str,
+    sha: &str,
+    package_name: &str,
+) -> Result<String, PackageError> {
+    let provenance =
+        github_tag_url(git, tag).unwrap_or_else(|| format!("{git}/releases/tag/{tag}"));
+    let mut out = String::new();
+    out.push_str("[[package.version]]\n");
+    push_toml_string_field(&mut out, "version", version)?;
+    push_toml_string_field(&mut out, "git", git)?;
+    push_toml_string_field(&mut out, "rev", sha)?;
+    push_toml_string_field(&mut out, "tag", tag)?;
+    push_toml_string_field(&mut out, "sha", sha)?;
+    push_toml_string_field(&mut out, "package", package_name)?;
+    push_toml_string_field(&mut out, "provenance", &provenance)?;
+    Ok(out)
+}
+
+fn github_tag_url(git: &str, tag: &str) -> Option<String> {
+    let url = Url::parse(git).ok()?;
+    let host = url.host_str()?;
+    if host != "github.com" {
+        return None;
+    }
+    let path = url.path().trim_matches('/');
+    let mut segments = path.split('/');
+    let owner = segments.next()?;
+    let repo = segments.next()?;
+    Some(format!(
+        "https://github.com/{owner}/{repo}/releases/tag/{tag}"
+    ))
+}
+
+fn push_toml_string_field(out: &mut String, key: &str, value: &str) -> Result<(), PackageError> {
+    out.push_str(key);
+    out.push_str(" = ");
+    out.push_str(&toml_string_literal(value)?);
+    out.push('\n');
+    Ok(())
+}
+
+fn toml_string_literal(value: &str) -> Result<String, PackageError> {
+    let mut out = String::with_capacity(value.len() + 2);
+    out.push('"');
+    for ch in value.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            ch if ch.is_control() => {
+                out.push_str(&format!("\\u{:04X}", ch as u32));
+            }
+            ch => out.push(ch),
+        }
+    }
+    out.push('"');
+    Ok(out)
+}
+
+fn render_unified_diff(old: &str, new: &str, label: &str) -> Result<String, PackageError> {
+    let temp = tempfile::tempdir()
+        .map_err(|error| PackageError::Ops(format!("failed to create temp dir: {error}")))?;
+    let old_path = temp.path().join("old");
+    let new_path = temp.path().join("new");
+    fs::write(&old_path, old).map_err(|error| format!("failed to write diff input: {error}"))?;
+    fs::write(&new_path, new).map_err(|error| format!("failed to write diff input: {error}"))?;
+    let output = process::Command::new("git")
+        .args(["diff", "--no-index", "--"])
+        .arg(&old_path)
+        .arg(&new_path)
+        .output()
+        .map_err(|error| {
+            PackageError::Ops(format!("failed to render package-index diff: {error}"))
+        })?;
+    if !output.status.success() && output.status.code() != Some(1) {
+        return Err(PackageError::Ops(format!(
+            "failed to render package-index diff: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )));
+    }
+    let mut diff = String::from_utf8_lossy(&output.stdout).into_owned();
+    let old_display = old_path.display().to_string();
+    let new_display = new_path.display().to_string();
+    diff = diff.replace(&format!("--- {old_display}"), &format!("--- a/{label}"));
+    diff = diff.replace(&format!("+++ {new_display}"), &format!("+++ b/{label}"));
+    Ok(diff)
+}
+
+fn git_output<const N: usize>(repo: &Path, args: [&str; N]) -> Result<String, PackageError> {
+    run_command_output(repo, "git", args)
+}
+
+fn git_status<const N: usize>(
+    repo: &Path,
+    args: [&str; N],
+) -> Result<process::ExitStatus, PackageError> {
+    process::Command::new("git")
+        .current_dir(repo)
+        .args(args)
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_INDEX_FILE")
+        .output()
+        .map(|output| output.status)
+        .map_err(|error| PackageError::Ops(format!("failed to run git: {error}")))
+}
+
+fn run_git_checked<const N: usize>(repo: &Path, args: [&str; N]) -> Result<(), PackageError> {
+    run_command_checked(repo, "git", args)
+}
+
+fn run_command_checked<const N: usize>(
+    cwd: &Path,
+    program: &str,
+    args: [&str; N],
+) -> Result<(), PackageError> {
+    run_command_output(cwd, program, args).map(|_| ())
+}
+
+fn run_command_output<const N: usize>(
+    cwd: &Path,
+    program: &str,
+    args: [&str; N],
+) -> Result<String, PackageError> {
+    let output = process::Command::new(program)
+        .current_dir(cwd)
+        .args(args)
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_INDEX_FILE")
+        .output()
+        .map_err(|error| PackageError::Ops(format!("failed to run {program}: {error}")))?;
+    if !output.status.success() {
+        return Err(PackageError::Ops(format!(
+            "{} failed: {}",
+            program,
+            String::from_utf8_lossy(&output.stderr).trim_end()
+        )));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+fn sanitize_branch_segment(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.') {
+                ch
+            } else {
+                '-'
+            }
+        })
+        .collect()
+}
+
+fn shell_quote_path(path: &Path) -> String {
+    let raw = path.display().to_string();
+    if raw
+        .bytes()
+        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'/' | b'.' | b'-' | b'_'))
+    {
+        raw
+    } else {
+        format!("'{}'", raw.replace('\'', "'\\''"))
+    }
 }
 
 pub(crate) fn load_manifest_context_for_anchor(
@@ -1877,6 +2682,144 @@ mod tests {
         );
     }
 
+    #[test]
+    fn publish_dry_run_builds_tag_command_and_index_diff() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_publishable_package(tmp.path());
+        write_release_changelog(tmp.path(), "0.1.0");
+        let _remote = init_publishable_repo(tmp.path());
+        let index = r#"version = 1
+
+[[package]]
+name = "acme-lib"
+repository = "https://github.com/acme/acme-lib"
+
+[[package.version]]
+version = "0.0.1"
+git = "https://github.com/acme/acme-lib"
+rev = "deadbeef"
+
+[[package]]
+name = "other-lib"
+repository = "https://github.com/acme/other-lib"
+
+[[package.version]]
+version = "1.0.0"
+git = "https://github.com/acme/other-lib"
+rev = "feedface"
+"#;
+        let index_path = Path::new("package-index/harn-package-index.toml");
+        let options = PackagePublishOptions {
+            dry_run: true,
+            remote: "origin",
+            index_repo: "burin-labs/harn-cloud",
+            index_path,
+            registry_name: None,
+            skip_index_pr: false,
+            registry: None,
+        };
+
+        let plan =
+            prepare_publish_plan(Some(tmp.path()), &options, index.to_string(), "fixture").unwrap();
+
+        assert!(plan.tag_command.contains("git -C"));
+        assert!(plan.tag_command.contains("tag v0.1.0"));
+        assert!(plan.index_diff.contains("+version = \"0.1.0\""));
+        assert!(plan.index_diff.contains("+tag = \"v0.1.0\""));
+        assert!(plan
+            .index_diff
+            .contains(&format!("+rev = \"{}\"", plan.sha)));
+        assert!(plan
+            .index_diff
+            .contains(&format!("+sha = \"{}\"", plan.sha)));
+        let acme_pos = plan
+            .updated_index_content
+            .find("name = \"acme-lib\"")
+            .unwrap();
+        let other_pos = plan
+            .updated_index_content
+            .find("name = \"other-lib\"")
+            .unwrap();
+        let new_version_pos = plan
+            .updated_index_content
+            .find("version = \"0.1.0\"")
+            .unwrap();
+        assert!(acme_pos < new_version_pos && new_version_pos < other_pos);
+    }
+
+    #[test]
+    fn publish_preflight_rejects_existing_tag_and_missing_changelog_entry() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_publishable_package(tmp.path());
+        let _remote = init_publishable_repo(tmp.path());
+        let index_path = Path::new("package-index/harn-package-index.toml");
+        let options = PackagePublishOptions {
+            dry_run: true,
+            remote: "origin",
+            index_repo: "burin-labs/harn-cloud",
+            index_path,
+            registry_name: None,
+            skip_index_pr: false,
+            registry: None,
+        };
+
+        let missing_changelog = prepare_publish_plan(
+            Some(tmp.path()),
+            &options,
+            "version = 1\n".to_string(),
+            "fixture",
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(missing_changelog.contains("CHANGELOG.md"));
+
+        write_release_changelog(tmp.path(), "0.1.0");
+        run_git(tmp.path(), &["add", "CHANGELOG.md"]);
+        run_git(tmp.path(), &["commit", "-m", "add changelog"]);
+        run_git(tmp.path(), &["tag", "v0.1.0"]);
+
+        let existing_tag = prepare_publish_plan(
+            Some(tmp.path()),
+            &options,
+            "version = 1\n".to_string(),
+            "fixture",
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(existing_tag.contains("already exists locally"));
+    }
+
+    #[test]
+    fn publish_preflight_rejects_dirty_worktree() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_publishable_package(tmp.path());
+        write_release_changelog(tmp.path(), "0.1.0");
+        let _remote = init_publishable_repo(tmp.path());
+        fs::write(tmp.path().join("scratch.txt"), "dirty\n").unwrap();
+        let index_path = Path::new("package-index/harn-package-index.toml");
+        let options = PackagePublishOptions {
+            dry_run: true,
+            remote: "origin",
+            index_repo: "burin-labs/harn-cloud",
+            index_path,
+            registry_name: None,
+            skip_index_pr: false,
+            registry: None,
+        };
+
+        let error = prepare_publish_plan(
+            Some(tmp.path()),
+            &options,
+            "version = 1\n".to_string(),
+            "fixture",
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains("working tree must be clean"));
+        assert!(error.contains("scratch.txt"));
+    }
+
     #[cfg(unix)]
     #[test]
     fn package_pack_does_not_follow_symlinked_files() {
@@ -2123,5 +3066,45 @@ name = "consumer"
         assert_eq!(package.exports.skills[0].name, "review");
         assert_eq!(package.permissions, vec!["tool:read_only"]);
         assert_eq!(package.host_requirements, vec!["workspace.read_text"]);
+    }
+
+    fn write_release_changelog(root: &Path, version: &str) {
+        fs::write(
+            root.join("CHANGELOG.md"),
+            format!("# Changelog\n\n## {version}\n\n- Initial release.\n"),
+        )
+        .unwrap();
+    }
+
+    fn init_publishable_repo(root: &Path) -> tempfile::TempDir {
+        let init = test_git_command(root)
+            .args(["init", "-b", "main"])
+            .output()
+            .unwrap();
+        if !init.status.success() {
+            run_git(root, &["init"]);
+        }
+        run_git(root, &["config", "user.email", "tests@example.com"]);
+        run_git(root, &["config", "user.name", "Harn Tests"]);
+        run_git(root, &["config", "core.hooksPath", "/dev/null"]);
+        run_git(root, &["add", "."]);
+        run_git(root, &["commit", "-m", "initial"]);
+
+        let remote = tempfile::tempdir().unwrap();
+        let bare = remote.path().join("origin.git");
+        let output = test_git_command(root)
+            .args(["init", "--bare", bare.to_string_lossy().as_ref()])
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git init --bare failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        run_git(
+            root,
+            &["remote", "add", "origin", bare.to_string_lossy().as_ref()],
+        );
+        remote
     }
 }

--- a/crates/harn-cli/src/package/registry.rs
+++ b/crates/harn-cli/src/package/registry.rs
@@ -48,6 +48,10 @@ pub(crate) struct RegistryPackageVersion {
     #[serde(default)]
     rev: Option<String>,
     #[serde(default)]
+    tag: Option<String>,
+    #[serde(default)]
+    sha: Option<String>,
+    #[serde(default)]
     branch: Option<String>,
     #[serde(default)]
     package: Option<String>,
@@ -542,12 +546,6 @@ pub(crate) fn read_registry_source(source: &str) -> Result<String, PackageError>
     response.text().map_err(|error| {
         PackageError::Registry(format!("failed to read package registry response: {error}"))
     })
-}
-
-pub(crate) fn resolve_configured_registry_source(
-    explicit: Option<&str>,
-) -> Result<String, PackageError> {
-    PackageWorkspace::from_current_dir()?.resolve_registry_source(explicit)
 }
 
 pub(crate) fn is_valid_registry_segment(segment: &str) -> bool {

--- a/docs/src/package-authoring.md
+++ b/docs/src/package-authoring.md
@@ -106,6 +106,7 @@ cd echo-connector
 harn connector test .
 harn package docs
 harn publish --dry-run
+harn publish
 ```
 
 Connector packages use `harn connector test .` as the CI gate. It runs package
@@ -212,9 +213,13 @@ harn package pack --dry-run
 harn package pack
 ```
 
-`harn publish --dry-run` runs the same publish-readiness checks and reports the
-registry target that would receive the submission. Real registry submission is
-reserved for the registry/index workflow.
+`harn publish --dry-run` runs the publish-readiness checks and prints the git
+tag command plus the package-index diff that would be proposed. `harn publish`
+requires a clean git worktree, a non-empty `CHANGELOG.md` entry for the package
+version, and an unused `vX.Y.Z` tag. It then tags and pushes the configured
+remote, and opens a PR against the configured package index. Use
+`--skip-index-pr` to push only the tag when the index entry should be composed
+manually.
 
 ## Lockfile provenance
 


### PR DESCRIPTION
## Summary
- implement `harn publish` as a GitHub-as-CDN flow: package preflight, `vX.Y.Z` tag planning/push, and package-index PR creation
- keep `--dry-run` useful by printing the tag command and package-index diff; add `--skip-index-pr`, `--remote`, `--index-repo`, `--index-path`, and `--registry-name`
- document the new publish behavior and extend registry version metadata with tag/SHA fields

Closes #2156

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p harn-cli --lib`
- `cargo clippy -p harn-cli --lib --tests -- -D warnings`
- `cargo run --quiet --bin harn -- publish --help | sed -n '1,40p'`\n- pre-commit and pre-push hooks passed\n