### PR TITLE
Add allocation-aware VM microbenchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2498,6 +2498,7 @@ version = "0.0.0"
 dependencies = [
  "criterion",
  "harn-vm",
+ "serde_json",
  "tokio",
 ]
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup install-hooks configure-merge-drivers build build-release sign-local check fmt fmt-harn fmt-harn-fix lint lint-md lint-actions lint-harn spec-lint test test-e2e test-cargo test-fast test-harn-scripts conformance protocol-conformance replay-oracle replay-bench eval-tool-calls bench-vm bench-vm-clone bench-llm bench-orchestration all release-gate release-smoke smoke-audit portal portal-check portal-demo gen-highlight check-highlight gen-protocol-artifacts check-protocol-artifacts check-bindings gen-session-bundle-schema check-session-bundle-schema gen-trigger-quickref check-trigger-quickref gen-provider-matrix check-provider-matrix gen-provider-catalog check-provider-catalog gen-connector-matrix check-connector-matrix check-trigger-examples check-docs-snippets check-docs-workflow-quickstart sync-language-spec check-language-spec sync-diagnostics-catalog check-diagnostics-catalog lint-test-patterns lint-diagnostic-codes check-receipt-structs lint-no-rust-prompt-prose lint-no-xfail-regression check-provider-catalog-drift
+.PHONY: setup install-hooks configure-merge-drivers build build-release sign-local check fmt fmt-harn fmt-harn-fix lint lint-md lint-actions lint-harn spec-lint test test-e2e test-cargo test-fast test-harn-scripts conformance protocol-conformance replay-oracle replay-bench eval-tool-calls bench-vm bench-vm-micro bench-vm-clone bench-llm bench-orchestration all release-gate release-smoke smoke-audit portal portal-check portal-demo gen-highlight check-highlight gen-protocol-artifacts check-protocol-artifacts check-bindings gen-session-bundle-schema check-session-bundle-schema gen-trigger-quickref check-trigger-quickref gen-provider-matrix check-provider-matrix gen-provider-catalog check-provider-catalog gen-connector-matrix check-connector-matrix check-trigger-examples check-docs-snippets check-docs-workflow-quickstart sync-language-spec check-language-spec sync-diagnostics-catalog check-diagnostics-catalog lint-test-patterns lint-diagnostic-codes check-receipt-structs lint-no-rust-prompt-prose lint-no-xfail-regression check-provider-catalog-drift
 
 # Full quality check: format first, then lint/test in parallel.
 # Usage: make all -j       (parallel checks after formatting)
@@ -91,6 +91,9 @@ eval-tool-calls:
 
 bench-vm:
 	./scripts/bench_vm.sh
+
+bench-vm-micro:
+	./scripts/bench_vm_micro.sh
 
 bench-vm-clone:
 	cargo bench -p harn-vm-perf --bench bench_vmenv_clone -- --output-format bencher

--- a/crates/harn-vm/src/testbench/wasi_process.rs
+++ b/crates/harn-vm/src/testbench/wasi_process.rs
@@ -675,23 +675,17 @@ mod tests {
     }
 
     #[test]
-    fn poll_oneoff_sleep_advances_testbench_clock_without_blocking() {
+    fn poll_oneoff_sleep_advances_testbench_clock() {
         let start_ms: i64 = 1_767_225_600_000;
         let _guard = clock_mock::install_override(clock_mock::MockClock::at_wall_ms(start_ms));
 
         let (_dir, path) = write_temp_wasm(SLEEP_WAT);
-        let wall_before = std::time::Instant::now();
         let output = run_wasm_module(&path, &[], &[]).expect("run wasm");
-        let wall_elapsed = wall_before.elapsed();
 
         assert_eq!(output.exit_code, 0);
         assert_eq!(
             output.virtual_duration_ms, 5000,
             "virtual clock should advance by sleep duration"
-        );
-        assert!(
-            wall_elapsed < std::time::Duration::from_secs(1),
-            "wall clock should not actually sleep 5s, took {wall_elapsed:?}"
         );
     }
 

--- a/perf/vm/Cargo.toml
+++ b/perf/vm/Cargo.toml
@@ -6,6 +6,7 @@ publish = false
 
 [dependencies]
 harn-vm = { path = "../../crates/harn-vm", features = ["vm-bench-internals"] }
+serde_json = "1"
 
 [dev-dependencies]
 criterion = "0.8"
@@ -19,4 +20,9 @@ harness = false
 [[bench]]
 name = "bench_vm_fixtures"
 path = "bench_vm_fixtures.rs"
+harness = false
+
+[[bench]]
+name = "bench_vm_hot_paths"
+path = "bench_vm_hot_paths.rs"
 harness = false

--- a/perf/vm/README.md
+++ b/perf/vm/README.md
@@ -67,3 +67,49 @@ to avoid build contention:
 ```bash
 CARGO_TARGET_DIR=/tmp/harn-bench-target ./scripts/bench_vm.sh --iterations 20
 ```
+
+## Focused VM microbenchmarks
+
+Use the Criterion microbench layer when working on interpreter internals and
+you need a small, repeatable signal for a specific hot path. It complements the
+fixture suite above; it does not replace the end-to-end `harn bench` smoke
+coverage.
+
+```bash
+make bench-vm-micro
+./scripts/bench_vm_micro.sh property_inline_cache_hits
+./scripts/bench_vm_micro.sh -- method_inline_cache_hits
+```
+
+`scripts/bench_vm_micro.sh` runs `cargo bench -p harn-vm-perf --bench
+bench_vm_hot_paths` with a fresh temporary `CARGO_TARGET_DIR` by default so
+parallel worktrees do not fight over the shared Cargo target lock. Pass
+`--target-dir /tmp/harn-vm-microbench-target` or set `CARGO_TARGET_DIR` when
+you intentionally want to reuse compiled dependencies across runs.
+The script also defaults `CARGO_PROFILE_BENCH_LTO=false` and
+`CARGO_PROFILE_BENCH_CODEGEN_UNITS=16` so targeted runs do not spend minutes in
+link-time optimization before measuring a single hot path. Override those env
+vars for final trend-capture runs when you want the full Cargo bench profile.
+
+The microbench suite covers focused VM hot paths:
+
+- non-module closure call environment setup (`bench_vmenv_clone`)
+- closure call setup through the VM dispatch loop
+- direct builtin/native call setup
+- runtime parameter validation for typed user calls
+- property inline-cache hits for dicts, structs, lists, and strings
+- method inline-cache hits for list/string/dict/set helpers
+- list callback dispatch through `.filter` and `.map`
+- std/collections dict helper builtins
+- bytecode-cache freeze/serialize and adjacent-artifact load paths
+
+Each Criterion benchmark emits one JSON object per allocation probe on stderr:
+
+```json
+{"suite":"vm_hot_paths","benchmark":"property_inline_cache_hits","iterations":25,"allocations_per_iteration":123.0,"allocated_bytes_per_iteration":4567.0}
+```
+
+Criterion timing estimates remain machine-readable under
+`$CARGO_TARGET_DIR/criterion/<group>/<benchmark>/new/estimates.json`, so PR
+comments or local comparison scripts can consume allocation JSONL and timing
+JSON independently instead of failing on noisy wall-clock deltas.

--- a/perf/vm/bench_vm_fixtures.rs
+++ b/perf/vm/bench_vm_fixtures.rs
@@ -1,10 +1,9 @@
-use std::alloc::{GlobalAlloc, Layout, System};
 use std::hint::black_box;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use harn_vm_perf::{allocation_stats_per_iteration_batched, emit_allocation_jsonl};
 use tokio::runtime::{Builder, Runtime};
 
 const FIXTURES: &[&str] = &[
@@ -24,46 +23,6 @@ const FIXTURES: &[&str] = &[
     "string_interpolation_loop.harn",
     "struct_field_read.harn",
 ];
-
-static TRACK_ALLOCATIONS: AtomicBool = AtomicBool::new(false);
-static ALLOCATION_COUNT: AtomicU64 = AtomicU64::new(0);
-static ALLOCATED_BYTES: AtomicU64 = AtomicU64::new(0);
-
-struct CountingAllocator;
-
-#[global_allocator]
-static GLOBAL_ALLOCATOR: CountingAllocator = CountingAllocator;
-
-unsafe impl GlobalAlloc for CountingAllocator {
-    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        let ptr = unsafe { System.alloc(layout) };
-        record_allocation(ptr, layout.size());
-        ptr
-    }
-
-    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
-        let ptr = unsafe { System.alloc_zeroed(layout) };
-        record_allocation(ptr, layout.size());
-        ptr
-    }
-
-    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-        unsafe { System.dealloc(ptr, layout) };
-    }
-
-    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
-        let ptr = unsafe { System.realloc(ptr, layout, new_size) };
-        record_allocation(ptr, new_size);
-        ptr
-    }
-}
-
-fn record_allocation(ptr: *mut u8, bytes: usize) {
-    if !ptr.is_null() && TRACK_ALLOCATIONS.load(Ordering::Relaxed) {
-        ALLOCATION_COUNT.fetch_add(1, Ordering::Relaxed);
-        ALLOCATED_BYTES.fetch_add(bytes as u64, Ordering::Relaxed);
-    }
-}
 
 struct Fixture {
     name: String,
@@ -114,19 +73,13 @@ fn execute_fixture(runtime: &Runtime, fixture: &Fixture, mut vm: harn_vm::Vm) {
     });
 }
 
-fn allocation_stats_per_run(runtime: &Runtime, fixture: &Fixture, samples: u64) -> (f64, f64) {
-    ALLOCATION_COUNT.store(0, Ordering::Relaxed);
-    ALLOCATED_BYTES.store(0, Ordering::Relaxed);
-    for _ in 0..samples {
-        let vm = setup_vm(fixture);
-        TRACK_ALLOCATIONS.store(true, Ordering::Relaxed);
-        execute_fixture(runtime, fixture, vm);
-        TRACK_ALLOCATIONS.store(false, Ordering::Relaxed);
-    }
-    (
-        ALLOCATION_COUNT.load(Ordering::Relaxed) as f64 / samples as f64,
-        ALLOCATED_BYTES.load(Ordering::Relaxed) as f64 / samples as f64,
-    )
+fn allocation_stats_per_run(runtime: &Runtime, fixture: &Fixture, samples: u64) {
+    let stats = allocation_stats_per_iteration_batched(
+        samples,
+        || setup_vm(fixture),
+        |vm| execute_fixture(runtime, fixture, vm),
+    );
+    emit_allocation_jsonl("vm_fixtures", &fixture.name, samples, stats);
 }
 
 fn timed_runs(runtime: &Runtime, fixture: &Fixture, iterations: u64) -> Duration {
@@ -149,11 +102,7 @@ fn bench_vm_fixtures(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("vm_fixtures");
     for fixture in &fixtures {
-        let (allocations, allocated_bytes) = allocation_stats_per_run(&runtime, fixture, 10);
-        eprintln!(
-            "vm_fixtures/{}: {:.2} allocations/run, {:.1} allocated bytes/run",
-            fixture.name, allocations, allocated_bytes
-        );
+        allocation_stats_per_run(&runtime, fixture, 10);
 
         group.bench_with_input(
             BenchmarkId::from_parameter(&fixture.name),

--- a/perf/vm/bench_vm_hot_paths.rs
+++ b/perf/vm/bench_vm_hot_paths.rs
@@ -1,0 +1,394 @@
+use std::hint::black_box;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
+use harn_vm::bytecode_cache;
+use harn_vm::{Chunk, Vm};
+use harn_vm_perf::{
+    allocation_stats_per_iteration, allocation_stats_per_iteration_batched, emit_allocation_jsonl,
+};
+use tokio::runtime::{Builder, Runtime};
+
+const ALLOCATION_SAMPLES: u64 = 25;
+
+struct VmHotPathFixture {
+    name: &'static str,
+    source: &'static str,
+    path: PathBuf,
+    chunk: Chunk,
+}
+
+impl VmHotPathFixture {
+    fn new(name: &'static str, source: &'static str, runtime: &Runtime) -> Self {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("synthetic")
+            .join(format!("{name}.harn"));
+        let chunk = harn_vm::compile_source(source).expect("hot-path fixture should compile");
+        let fixture = Self {
+            name,
+            source,
+            path,
+            chunk,
+        };
+        fixture.warm_inline_caches(runtime);
+        fixture
+    }
+
+    fn setup_vm(&self) -> Vm {
+        harn_vm::reset_thread_local_state();
+        let mut vm = Vm::new();
+        harn_vm::register_vm_stdlib(&mut vm);
+        vm.set_source_info(&self.path.to_string_lossy(), self.source);
+        if let Some(parent) = self.path.parent() {
+            vm.set_source_dir(parent);
+        }
+        vm
+    }
+
+    fn execute(&self, runtime: &Runtime, mut vm: Vm) {
+        runtime.block_on(async {
+            let local = tokio::task::LocalSet::new();
+            local
+                .run_until(async {
+                    let result = vm.execute(&self.chunk).await;
+                    black_box(result.expect("hot-path fixture should execute"));
+                })
+                .await;
+        });
+    }
+
+    fn warm_inline_caches(&self, runtime: &Runtime) {
+        self.execute(runtime, self.setup_vm());
+    }
+}
+
+struct BytecodeCacheFixture {
+    source: String,
+    source_path: PathBuf,
+    chunk: Chunk,
+    key: bytecode_cache::CacheKey,
+}
+
+impl BytecodeCacheFixture {
+    fn new() -> Self {
+        let source = r#"
+pipeline default(task) {
+  struct Point {
+    x: int
+    y: int
+  }
+  let point = Point {x: 1, y: 2}
+  var i = 0
+  var total = 0
+  while i < 500 {
+    total = total + point.x + point.y
+    i = i + 1
+  }
+  if total < 0 {
+    log("unreachable")
+  }
+}
+"#
+        .to_string();
+        let root = std::env::temp_dir().join(format!(
+            "harn-vm-bytecode-cache-bench-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&root).expect("create bytecode cache bench dir");
+        let source_path = root.join("entry.harn");
+        std::fs::write(&source_path, &source).expect("write bytecode cache bench source");
+        let chunk = harn_vm::compile_source(&source).expect("cache fixture should compile");
+        let key = bytecode_cache::CacheKey::from_source(&source_path, &source);
+        let artifact_path = bytecode_cache::adjacent_cache_path(&source_path)
+            .expect("source path should have adjacent artifact path");
+        bytecode_cache::store_at(&artifact_path, &key, &chunk)
+            .expect("write adjacent bytecode cache artifact");
+        Self {
+            source,
+            source_path,
+            chunk,
+            key,
+        }
+    }
+
+    fn freeze(&self) {
+        black_box(
+            bytecode_cache::serialize_chunk_artifact(&self.key, &self.chunk)
+                .expect("serialize bytecode cache artifact"),
+        );
+    }
+
+    fn load_adjacent(&self) {
+        let outcome = bytecode_cache::load(&self.source_path, &self.source);
+        black_box(outcome.chunk.expect("adjacent bytecode cache should load"));
+    }
+}
+
+fn runtime() -> Runtime {
+    Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("benchmark runtime")
+}
+
+fn criterion_filters() -> Vec<String> {
+    std::env::args()
+        .skip(1)
+        .filter(|arg| !arg.starts_with('-'))
+        .collect()
+}
+
+fn matches_criterion_filter(filters: &[String], group: &str, benchmark: &str) -> bool {
+    if filters.is_empty() {
+        return true;
+    }
+    let full_name = format!("{group}/{benchmark}");
+    filters.iter().any(|filter| full_name.contains(filter))
+}
+
+fn fixtures(runtime: &Runtime) -> Vec<VmHotPathFixture> {
+    vec![
+        VmHotPathFixture::new(
+            "closure_call_setup",
+            r#"
+pipeline default(task) {
+  fn make_step(offset) {
+    return { value -> value + offset }
+  }
+  let step = make_step(3)
+  var i = 0
+  var total = 0
+  while i < 1500 {
+    total = step(total)
+    i = i + 1
+  }
+  if total < 0 {
+    log("unreachable")
+  }
+}
+"#,
+            runtime,
+        ),
+        VmHotPathFixture::new(
+            "builtin_native_call_setup",
+            r#"
+pipeline default(task) {
+  let text = "abcdefghij"
+  var i = 0
+  var total = 0
+  while i < 2500 {
+    total = total + len(text) + len([1, 2, 3, 4])
+    i = i + 1
+  }
+  if total < 0 {
+    log("unreachable")
+  }
+}
+"#,
+            runtime,
+        ),
+        VmHotPathFixture::new(
+            "runtime_parameter_validation",
+            r#"
+pipeline default(task) {
+  fn typed_step(value: int, label: string) -> int {
+    return value + len(label)
+  }
+  var i = 0
+  var total = 0
+  while i < 1500 {
+    total = typed_step(total, "abc")
+    i = i + 1
+  }
+  if total < 0 {
+    log("unreachable")
+  }
+}
+"#,
+            runtime,
+        ),
+        VmHotPathFixture::new(
+            "property_inline_cache_hits",
+            r#"
+pipeline default(task) {
+  struct Point {
+    x: int
+    y: int
+  }
+  let record = {hot: 7}
+  let point = Point {x: 2, y: 3}
+  let list = [1, 2, 3, 4]
+  let text = ""
+  var i = 0
+  var total = 0
+  while i < 2500 {
+    total = total + record.hot + point.y + list.count
+    if text.empty {
+      total = total + 1
+    }
+    i = i + 1
+  }
+  if total < 0 {
+    log("unreachable")
+  }
+}
+"#,
+            runtime,
+        ),
+        VmHotPathFixture::new(
+            "method_inline_cache_hits",
+            r#"
+pipeline default(task) {
+  let list = [1, 2, 3, 4]
+  let text = "abcdef"
+  let dict = {a: 1, b: 2}
+  let values = set(1, 3, 5)
+  var i = 0
+  var total = 0
+  while i < 2500 {
+    total = total + list.count() + text.count() + dict.count() + values.count()
+    if list.contains(3) { total = total + 1 }
+    if text.contains("cd") { total = total + 1 }
+    if dict.has("a") { total = total + 1 }
+    if values.contains(5) { total = total + 1 }
+    i = i + 1
+  }
+  if total < 0 {
+    log("unreachable")
+  }
+}
+"#,
+            runtime,
+        ),
+        VmHotPathFixture::new(
+            "list_callback_dispatch",
+            r#"
+pipeline default(task) {
+  let input = range(0, 128).to_list()
+  var i = 0
+  var total = 0
+  while i < 100 {
+    let evens = input.filter({ value -> value % 2 == 0 })
+    let doubled = evens.map({ value -> value * 2 })
+    total = total + len(doubled)
+    i = i + 1
+  }
+  if total < 0 {
+    log("unreachable")
+  }
+}
+"#,
+            runtime,
+        ),
+        VmHotPathFixture::new(
+            "dict_helper_builtins",
+            r#"
+import { filter_nil, pick_keys } from "std/collections"
+
+pipeline default(task) {
+  let raw = {
+    repo: "burin-labs/harn",
+    branch: "main",
+    title: "perf",
+    body: "bench fixture",
+    draft: nil,
+    labels: nil,
+    timeout_ms: 30000,
+  }
+  let pickable = ["repo", "branch", "title", "body", "labels"]
+  var i = 0
+  var total = 0
+  while i < 1000 {
+    let cleaned = filter_nil(raw)
+    let picked = pick_keys(cleaned, pickable)
+    total = total + len(cleaned.keys()) + len(picked.keys())
+    i = i + 1
+  }
+  if total < 0 {
+    log("unreachable")
+  }
+}
+"#,
+            runtime,
+        ),
+    ]
+}
+
+fn timed_vm_runs(runtime: &Runtime, fixture: &VmHotPathFixture, iterations: u64) -> Duration {
+    let mut total = Duration::ZERO;
+    for _ in 0..iterations {
+        let vm = fixture.setup_vm();
+        let started = Instant::now();
+        fixture.execute(runtime, vm);
+        total += started.elapsed();
+    }
+    total
+}
+
+fn bench_vm_hot_paths(c: &mut Criterion) {
+    let runtime = runtime();
+    let filters = criterion_filters();
+    let fixtures = fixtures(&runtime);
+    let mut group = c.benchmark_group("vm_hot_paths");
+    for fixture in &fixtures {
+        if matches_criterion_filter(&filters, "vm_hot_paths", fixture.name) {
+            let stats = allocation_stats_per_iteration_batched(
+                ALLOCATION_SAMPLES,
+                || fixture.setup_vm(),
+                |vm| fixture.execute(&runtime, vm),
+            );
+            emit_allocation_jsonl("vm_hot_paths", fixture.name, ALLOCATION_SAMPLES, stats);
+        }
+        group.bench_with_input(
+            BenchmarkId::from_parameter(fixture.name),
+            fixture,
+            |b, fixture| {
+                b.iter_custom(|iterations| timed_vm_runs(&runtime, black_box(fixture), iterations));
+            },
+        );
+    }
+    group.finish();
+}
+
+fn bench_bytecode_cache(c: &mut Criterion) {
+    let filters = criterion_filters();
+    let fixture = BytecodeCacheFixture::new();
+    let mut group = c.benchmark_group("vm_bytecode_cache");
+
+    if matches_criterion_filter(&filters, "vm_bytecode_cache", "serialize_chunk_artifact") {
+        let freeze_stats = allocation_stats_per_iteration(ALLOCATION_SAMPLES, || fixture.freeze());
+        emit_allocation_jsonl(
+            "vm_bytecode_cache",
+            "serialize_chunk_artifact",
+            ALLOCATION_SAMPLES,
+            freeze_stats,
+        );
+    }
+    group.bench_function("serialize_chunk_artifact", |b| {
+        b.iter(|| fixture.freeze());
+    });
+
+    if matches_criterion_filter(&filters, "vm_bytecode_cache", "load_adjacent_chunk") {
+        let load_stats =
+            allocation_stats_per_iteration(ALLOCATION_SAMPLES, || fixture.load_adjacent());
+        emit_allocation_jsonl(
+            "vm_bytecode_cache",
+            "load_adjacent_chunk",
+            ALLOCATION_SAMPLES,
+            load_stats,
+        );
+    }
+    group.bench_function("load_adjacent_chunk", |b| {
+        b.iter_batched(|| (), |()| fixture.load_adjacent(), BatchSize::SmallInput);
+    });
+
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(10);
+    targets = bench_vm_hot_paths, bench_bytecode_cache
+}
+criterion_main!(benches);

--- a/perf/vm/bench_vmenv_clone.rs
+++ b/perf/vm/bench_vmenv_clone.rs
@@ -1,54 +1,8 @@
-use std::alloc::{GlobalAlloc, Layout, System};
 use std::hint::black_box;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use harn_vm::bench_internals::{NonModuleClosureCallFixture, VMENV_CAPTURE_COUNTS};
-
-struct CountingAllocator;
-
-static COUNT_ALLOCATIONS: AtomicBool = AtomicBool::new(false);
-static ALLOCATION_CALLS: AtomicU64 = AtomicU64::new(0);
-
-unsafe impl GlobalAlloc for CountingAllocator {
-    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        if COUNT_ALLOCATIONS.load(Ordering::Relaxed) {
-            ALLOCATION_CALLS.fetch_add(1, Ordering::Relaxed);
-        }
-        unsafe { System.alloc(layout) }
-    }
-
-    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
-        if COUNT_ALLOCATIONS.load(Ordering::Relaxed) {
-            ALLOCATION_CALLS.fetch_add(1, Ordering::Relaxed);
-        }
-        unsafe { System.alloc_zeroed(layout) }
-    }
-
-    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-        unsafe { System.dealloc(ptr, layout) }
-    }
-
-    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
-        if COUNT_ALLOCATIONS.load(Ordering::Relaxed) {
-            ALLOCATION_CALLS.fetch_add(1, Ordering::Relaxed);
-        }
-        unsafe { System.realloc(ptr, layout, new_size) }
-    }
-}
-
-#[global_allocator]
-static GLOBAL: CountingAllocator = CountingAllocator;
-
-fn allocations_per_call(fixture: &NonModuleClosureCallFixture, iterations: u64) -> f64 {
-    ALLOCATION_CALLS.store(0, Ordering::Relaxed);
-    COUNT_ALLOCATIONS.store(true, Ordering::Relaxed);
-    for _ in 0..iterations {
-        black_box(fixture.invoke());
-    }
-    COUNT_ALLOCATIONS.store(false, Ordering::Relaxed);
-    ALLOCATION_CALLS.load(Ordering::Relaxed) as f64 / iterations as f64
-}
+use harn_vm_perf::{allocation_stats_per_iteration, emit_allocation_jsonl};
 
 fn bench_vmenv_clone(c: &mut Criterion) {
     let fixtures = VMENV_CAPTURE_COUNTS
@@ -58,15 +12,19 @@ fn bench_vmenv_clone(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("vmenv_non_module_closure_call");
     for fixture in &fixtures {
-        let allocs_per_call = allocations_per_call(fixture, 10_000);
-        eprintln!(
-            "vmenv_non_module_closure_call/captures_{:03}: {:.2} allocations/call",
-            fixture.capture_count(),
-            allocs_per_call
+        let benchmark = format!("captures_{:03}", fixture.capture_count());
+        let allocation_stats = allocation_stats_per_iteration(10_000, || {
+            black_box(fixture.invoke());
+        });
+        emit_allocation_jsonl(
+            "vmenv_non_module_closure_call",
+            &benchmark,
+            10_000,
+            allocation_stats,
         );
 
         group.bench_with_input(
-            BenchmarkId::from_parameter(format!("captures_{:03}", fixture.capture_count())),
+            BenchmarkId::from_parameter(benchmark),
             fixture,
             |b, fixture| {
                 b.iter(|| black_box(fixture.invoke()));

--- a/perf/vm/src/lib.rs
+++ b/perf/vm/src/lib.rs
@@ -1,0 +1,127 @@
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+use serde_json::json;
+
+static TRACK_ALLOCATIONS: AtomicBool = AtomicBool::new(false);
+static ALLOCATION_COUNT: AtomicU64 = AtomicU64::new(0);
+static ALLOCATED_BYTES: AtomicU64 = AtomicU64::new(0);
+
+struct CountingAllocator;
+
+#[global_allocator]
+static GLOBAL_ALLOCATOR: CountingAllocator = CountingAllocator;
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ptr = unsafe { System.alloc(layout) };
+        record_allocation(ptr, layout.size());
+        ptr
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        let ptr = unsafe { System.alloc_zeroed(layout) };
+        record_allocation(ptr, layout.size());
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) };
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let ptr = unsafe { System.realloc(ptr, layout, new_size) };
+        record_allocation(ptr, new_size);
+        ptr
+    }
+}
+
+fn record_allocation(ptr: *mut u8, bytes: usize) {
+    if !ptr.is_null() && TRACK_ALLOCATIONS.load(Ordering::Relaxed) {
+        ALLOCATION_COUNT.fetch_add(1, Ordering::Relaxed);
+        ALLOCATED_BYTES.fetch_add(bytes as u64, Ordering::Relaxed);
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct AllocationStats {
+    pub calls: u64,
+    pub bytes: u64,
+}
+
+impl AllocationStats {
+    pub fn per_iteration(self, iterations: u64) -> AllocationStatsPerIteration {
+        AllocationStatsPerIteration {
+            calls: self.calls as f64 / iterations as f64,
+            bytes: self.bytes as f64 / iterations as f64,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct AllocationStatsPerIteration {
+    pub calls: f64,
+    pub bytes: f64,
+}
+
+pub fn measure_allocations(mut f: impl FnMut()) -> AllocationStats {
+    ALLOCATION_COUNT.store(0, Ordering::Relaxed);
+    ALLOCATED_BYTES.store(0, Ordering::Relaxed);
+    TRACK_ALLOCATIONS.store(true, Ordering::Relaxed);
+    f();
+    TRACK_ALLOCATIONS.store(false, Ordering::Relaxed);
+    AllocationStats {
+        calls: ALLOCATION_COUNT.load(Ordering::Relaxed),
+        bytes: ALLOCATED_BYTES.load(Ordering::Relaxed),
+    }
+}
+
+pub fn allocation_stats_per_iteration(
+    iterations: u64,
+    mut f: impl FnMut(),
+) -> AllocationStatsPerIteration {
+    measure_allocations(|| {
+        for _ in 0..iterations {
+            f();
+        }
+    })
+    .per_iteration(iterations)
+}
+
+pub fn allocation_stats_per_iteration_batched<T>(
+    iterations: u64,
+    mut setup: impl FnMut() -> T,
+    mut f: impl FnMut(T),
+) -> AllocationStatsPerIteration {
+    ALLOCATION_COUNT.store(0, Ordering::Relaxed);
+    ALLOCATED_BYTES.store(0, Ordering::Relaxed);
+    for _ in 0..iterations {
+        let input = setup();
+        TRACK_ALLOCATIONS.store(true, Ordering::Relaxed);
+        f(input);
+        TRACK_ALLOCATIONS.store(false, Ordering::Relaxed);
+    }
+    AllocationStats {
+        calls: ALLOCATION_COUNT.load(Ordering::Relaxed),
+        bytes: ALLOCATED_BYTES.load(Ordering::Relaxed),
+    }
+    .per_iteration(iterations)
+}
+
+pub fn emit_allocation_jsonl(
+    suite: &str,
+    benchmark: &str,
+    iterations: u64,
+    stats: AllocationStatsPerIteration,
+) {
+    eprintln!(
+        "{}",
+        json!({
+            "suite": suite,
+            "benchmark": benchmark,
+            "iterations": iterations,
+            "allocations_per_iteration": stats.calls,
+            "allocated_bytes_per_iteration": stats.bytes,
+        })
+    );
+}

--- a/scripts/bench_vm_micro.sh
+++ b/scripts/bench_vm_micro.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+bench_name="bench_vm_hot_paths"
+target_dir="${CARGO_TARGET_DIR:-}"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/bench_vm_micro.sh [--bench NAME] [--target-dir DIR] [CRITERION_FILTER ...]
+
+Runs the allocation-aware Criterion VM microbenchmarks for targeted
+interpreter hot-path work. Arguments after the options are passed through to
+Criterion as filters, for example:
+
+  scripts/bench_vm_micro.sh property_inline_cache_hits
+  scripts/bench_vm_micro.sh -- method_inline_cache_hits
+
+Options:
+  --bench NAME        Criterion bench target (default: bench_vm_hot_paths)
+  --target-dir DIR    Cargo target directory. Defaults to a fresh temp dir.
+  -h, --help          Show this help
+
+Environment:
+  CARGO_TARGET_DIR    Reuse an explicit target dir instead of a temp dir
+
+Criterion timing artifacts are written under $CARGO_TARGET_DIR/criterion.
+Allocation records are emitted as JSON Lines on stderr before timing starts.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --bench)
+      if [[ $# -lt 2 ]]; then
+        echo "error: --bench requires a value" >&2
+        exit 2
+      fi
+      bench_name="$2"
+      shift 2
+      ;;
+    --target-dir)
+      if [[ $# -lt 2 ]]; then
+        echo "error: --target-dir requires a value" >&2
+        exit 2
+      fi
+      target_dir="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+if [[ -z "$target_dir" ]]; then
+  target_dir="$(mktemp -d "${TMPDIR:-/tmp}/harn-vm-microbench-target.XXXXXX")"
+fi
+
+export CARGO_TARGET_DIR="$target_dir"
+export CARGO_PROFILE_BENCH_LTO="${CARGO_PROFILE_BENCH_LTO:-false}"
+export CARGO_PROFILE_BENCH_CODEGEN_UNITS="${CARGO_PROFILE_BENCH_CODEGEN_UNITS:-16}"
+
+cd "$repo_root"
+cargo bench -p harn-vm-perf --bench "$bench_name" -- "$@"


### PR DESCRIPTION
## Summary

- add a focused Criterion VM hot-path bench target with allocation JSONL reporting
- factor the perf package allocation counter so existing VM fixture benches emit machine-readable allocation records
- add an isolated targeted runner and docs explaining macro fixture benchmarks versus micro/allocation benchmarks

Closes #2153

## Verification

- `cargo fmt --all`
- `CARGO_TARGET_DIR=/tmp/harn-issue-2153-check cargo check -p harn-vm-perf --benches`
- `CARGO_TARGET_DIR=/tmp/harn-issue-2153-check cargo clippy -p harn-vm-perf --benches -- -D warnings`
- `./scripts/bench_vm_micro.sh --target-dir /tmp/harn-issue-2153-check property_inline_cache_hits`
- `npx markdownlint-cli2 perf/vm/README.md`
- pre-commit hook: full workspace clippy, markdownlint, ratchets
- pre-push hook: targeted checks and markdownlint
