### PR TITLE
Add VM vectorcall callback ABI

### DIFF
--- a/crates/harn-vm/Cargo.toml
+++ b/crates/harn-vm/Cargo.toml
@@ -131,3 +131,7 @@ harness = false
 [[bench]]
 name = "vm_adaptive_inline_cache"
 harness = false
+
+[[bench]]
+name = "callable_vectorcall"
+harness = false

--- a/crates/harn-vm/benches/callable_vectorcall.rs
+++ b/crates/harn-vm/benches/callable_vectorcall.rs
@@ -1,0 +1,100 @@
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::hint::black_box;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use harn_lexer::Lexer;
+use harn_parser::Parser;
+use harn_vm::{register_vm_stdlib, Chunk, Compiler, Vm, VmValue};
+
+struct CountingAllocator;
+
+static COUNT_ALLOCATIONS: AtomicBool = AtomicBool::new(false);
+static ALLOCATIONS: AtomicUsize = AtomicUsize::new(0);
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        if COUNT_ALLOCATIONS.load(Ordering::Relaxed) {
+            ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+        }
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+}
+
+#[global_allocator]
+static GLOBAL: CountingAllocator = CountingAllocator;
+
+fn list_literal<T: std::fmt::Display>(items: impl IntoIterator<Item = T>) -> String {
+    items
+        .into_iter()
+        .map(|item| item.to_string())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn compile(source: &str) -> Chunk {
+    let mut lexer = Lexer::new(source);
+    let tokens = lexer.tokenize().expect("bench source lexes");
+    let mut parser = Parser::new(tokens);
+    let program = parser.parse().expect("bench source parses");
+    Compiler::new()
+        .compile(&program)
+        .expect("bench source compiles")
+}
+
+fn execute_counted(rt: &tokio::runtime::Runtime, chunk: &Chunk) -> (VmValue, usize) {
+    ALLOCATIONS.store(0, Ordering::Relaxed);
+    COUNT_ALLOCATIONS.store(true, Ordering::Relaxed);
+    let result = rt.block_on(async {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let mut vm = Vm::new();
+                register_vm_stdlib(&mut vm);
+                vm.execute(chunk).await.expect("bench source executes")
+            })
+            .await
+    });
+    COUNT_ALLOCATIONS.store(false, Ordering::Relaxed);
+    (result, ALLOCATIONS.load(Ordering::Relaxed))
+}
+
+fn callback_chunks() -> (Chunk, Chunk) {
+    let numbers = list_literal(0..256);
+    let words = list_literal((0..256).map(|index| format!("\"field_{index}\"")));
+    let closure_source = format!(
+        "pipeline default(task) {{ let out = [{numbers}].map({{ x -> x + 1 }})\nreturn len(out) }}"
+    );
+    let builtin_source = format!(
+        "pipeline default(task) {{ let out = [{words}].map(snake_to_camel)\nreturn len(out) }}"
+    );
+    (compile(&closure_source), compile(&builtin_source))
+}
+
+fn list_callback_dispatch(c: &mut Criterion) {
+    let (closure_chunk, builtin_chunk) = callback_chunks();
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .expect("tokio runtime");
+
+    c.bench_function("vm_list_map_closure_callback_vectorcall", |b| {
+        b.iter(|| {
+            let (result, allocations) = execute_counted(&rt, black_box(&closure_chunk));
+            black_box((result, allocations))
+        });
+    });
+
+    c.bench_function("vm_list_map_builtin_callback_vectorcall", |b| {
+        b.iter(|| {
+            let (result, allocations) = execute_counted(&rt, black_box(&builtin_chunk));
+            black_box((result, allocations))
+        });
+    });
+}
+
+criterion_group!(benches, list_callback_dispatch);
+criterion_main!(benches);

--- a/crates/harn-vm/src/channel_guardrails.rs
+++ b/crates/harn-vm/src/channel_guardrails.rs
@@ -432,7 +432,7 @@ async fn evaluate_custom(
     let payload_vm = crate::stdlib::json_to_vm_value(payload);
     let context_vm = crate::stdlib::json_to_vm_value(context);
     let result = vm
-        .call_callable_value(scan_fn, &[payload_vm, context_vm])
+        .call_callable_two(scan_fn, &payload_vm, &context_vm)
         .await?;
     parse_custom_verdict(&result)
 }

--- a/crates/harn-vm/src/stdlib/collections.rs
+++ b/crates/harn-vm/src/stdlib/collections.rs
@@ -101,7 +101,7 @@ pub(crate) fn register_collection_builtins(vm: &mut Vm) {
         let mut vm = current_async_vm("group_by")?;
         let mut groups: BTreeMap<String, Vec<VmValue>> = BTreeMap::new();
         for item in items.iter() {
-            let key = vm.call_callable_value(callable, &[item.clone()]).await?;
+            let key = vm.call_callable_one(callable, item).await?;
             groups.entry(key.display()).or_default().push(item.clone());
         }
         Ok(VmValue::Dict(Rc::new(
@@ -127,7 +127,7 @@ pub(crate) fn register_collection_builtins(vm: &mut Vm) {
         let mut matched = Vec::new();
         let mut no_match = Vec::new();
         for item in items.iter() {
-            let result = vm.call_callable_value(callable, &[item.clone()]).await?;
+            let result = vm.call_callable_one(callable, item).await?;
             if result.is_truthy() {
                 matched.push(item.clone());
             } else {
@@ -155,7 +155,7 @@ pub(crate) fn register_collection_builtins(vm: &mut Vm) {
         let mut seen = HashSet::new();
         let mut out = Vec::new();
         for item in items.iter() {
-            let key = vm.call_callable_value(callable, &[item.clone()]).await?;
+            let key = vm.call_callable_one(callable, item).await?;
             if seen.insert(value_structural_hash_key(&key)) {
                 out.push(item.clone());
             }
@@ -177,7 +177,7 @@ pub(crate) fn register_collection_builtins(vm: &mut Vm) {
         let mut vm = current_async_vm("flat_map")?;
         let mut out = Vec::new();
         for item in items.iter() {
-            match vm.call_callable_value(callable, &[item.clone()]).await? {
+            match vm.call_callable_one(callable, item).await? {
                 VmValue::List(inner) => out.extend(inner.iter().cloned()),
                 other => out.push(other),
             }

--- a/crates/harn-vm/src/stdlib/iter.rs
+++ b/crates/harn-vm/src/stdlib/iter.rs
@@ -327,7 +327,7 @@ pub(crate) fn register_iter_builtins(vm: &mut Vm) {
         })?;
         loop {
             match next_handle(&inner, &mut vm).await? {
-                Some(v) => acc = vm.call_callable_value(&f, &[acc, v]).await?,
+                Some(v) => acc = vm.call_callable_two(&f, &acc, &v).await?,
                 None => return Ok(acc),
             }
         }
@@ -436,7 +436,7 @@ fn spawn_parallel_race_task(
     item: VmValue,
 ) {
     join_set.spawn_local(async move {
-        match vm.call_callable_value(&callable, &[item]).await {
+        match vm.call_callable_one(&callable, &item).await {
             Ok(VmValue::EnumVariant(enum_variant)) if enum_variant.is_variant("Result", "Ok") => {
                 Ok(enum_variant.fields.first().cloned().unwrap_or(VmValue::Nil))
             }

--- a/crates/harn-vm/src/stdlib/pool.rs
+++ b/crates/harn-vm/src/stdlib/pool.rs
@@ -2493,7 +2493,7 @@ fn spawn_task(pool: Rc<RefCell<PoolEntry>>, pending: PendingTask) {
 
     tokio::task::spawn_local(async move {
         let outcome = child_vm
-            .call_closure(&closure, &[])
+            .call_closure_args(&closure, crate::vm::CallArgs::Empty)
             .await
             .map_err(|error| error.to_string());
         finalize_task(&pool, &state, outcome);

--- a/crates/harn-vm/src/stdlib/testing.rs
+++ b/crates/harn-vm/src/stdlib/testing.rs
@@ -36,7 +36,7 @@ pub(crate) fn register_testing_builtins(vm: &mut Vm) {
         let mut vm = crate::vm::clone_async_builtin_child_vm().ok_or_else(|| {
             VmError::Runtime("__testing_call_body: builtin requires VM execution context".to_string())
         })?;
-        let result = vm.call_callable_value(&body, &call_args).await;
+        let result = vm.call_callable_owned(&body, call_args).await;
         crate::vm::forward_child_output_to_parent(&vm.take_output());
         result
     });

--- a/crates/harn-vm/src/stdlib/tool_hooks.rs
+++ b/crates/harn-vm/src/stdlib/tool_hooks.rs
@@ -462,12 +462,8 @@ async fn invoke_rule_pattern(
         callable if Vm::is_callable_value(callable) => {
             let mut vm = crate::vm::clone_async_builtin_child_vm()
                 .ok_or_else(|| err("tool_hooks_match: builtin requires VM execution context"))?;
-            let result = vm
-                .call_callable_value(
-                    callable,
-                    &[VmValue::String(Rc::from(command)), context.clone()],
-                )
-                .await?;
+            let command = VmValue::String(Rc::from(command));
+            let result = vm.call_callable_two(callable, &command, context).await?;
             Ok(result.is_truthy())
         }
         other => Err(err(format!(

--- a/crates/harn-vm/src/typecheck.rs
+++ b/crates/harn-vm/src/typecheck.rs
@@ -30,6 +30,7 @@ use harn_parser::TypeExpr;
 
 use crate::chunk::{CompiledFunction, ParamSlot};
 use crate::value::{ArgTypeMismatchError, ArityExpect, ArityMismatchError, VmError, VmValue};
+use crate::vm::CallArgs;
 
 /// Validate that `value` satisfies `expected`. Returns `Ok(())` when the
 /// value is acceptable, otherwise an [`VmError::ArgTypeMismatch`] tagged
@@ -250,6 +251,14 @@ fn matches_type_with_generics(
 pub fn validate_user_call(
     func: &CompiledFunction,
     args: &[VmValue],
+    span: Option<Span>,
+) -> Result<(), VmError> {
+    validate_user_call_args(func, &CallArgs::Slice(args), span)
+}
+
+pub(crate) fn validate_user_call_args(
+    func: &CompiledFunction,
+    args: &CallArgs<'_>,
     span: Option<Span>,
 ) -> Result<(), VmError> {
     let total = func.params.len();

--- a/crates/harn-vm/src/vm/call_args.rs
+++ b/crates/harn-vm/src/vm/call_args.rs
@@ -1,0 +1,102 @@
+use crate::value::VmValue;
+
+/// Borrowed callable arguments for VM-internal dispatch.
+///
+/// The hot callback path is dominated by zero-, one-, and two-argument calls.
+/// Keeping those shapes explicit lets closure binding and sync builtin dispatch
+/// avoid materializing a temporary `Vec<VmValue>`.
+pub(crate) enum CallArgs<'a> {
+    Empty,
+    One(&'a VmValue),
+    Two(&'a VmValue, &'a VmValue),
+    Slice(&'a [VmValue]),
+    Owned(Vec<VmValue>),
+}
+
+impl<'a> CallArgs<'a> {
+    pub(crate) fn len(&self) -> usize {
+        match self {
+            Self::Empty => 0,
+            Self::One(_) => 1,
+            Self::Two(_, _) => 2,
+            Self::Slice(args) => args.len(),
+            Self::Owned(args) => args.len(),
+        }
+    }
+
+    pub(crate) fn get(&self, index: usize) -> Option<&VmValue> {
+        match self {
+            Self::Empty => None,
+            Self::One(arg) => (index == 0).then_some(*arg),
+            Self::Two(first, second) => match index {
+                0 => Some(*first),
+                1 => Some(*second),
+                _ => None,
+            },
+            Self::Slice(args) => args.get(index),
+            Self::Owned(args) => args.get(index),
+        }
+    }
+
+    pub(crate) fn iter(&self) -> CallArgsIter<'_> {
+        CallArgsIter {
+            args: self,
+            index: 0,
+        }
+    }
+
+    pub(crate) fn into_vec(self) -> Vec<VmValue> {
+        match self {
+            Self::Empty => Vec::new(),
+            Self::One(arg) => vec![arg.clone()],
+            Self::Two(first, second) => vec![first.clone(), second.clone()],
+            Self::Slice(args) => args.to_vec(),
+            Self::Owned(args) => args,
+        }
+    }
+
+    pub(crate) fn to_vec_from(&self, start: usize) -> Vec<VmValue> {
+        match self {
+            Self::Empty | Self::One(_) | Self::Two(_, _) => {
+                self.iter().skip(start).cloned().collect()
+            }
+            Self::Slice(args) => args.get(start..).unwrap_or(&[]).to_vec(),
+            Self::Owned(args) => args.get(start..).unwrap_or(&[]).to_vec(),
+        }
+    }
+
+    pub(crate) fn with_slice<R>(&self, f: impl FnOnce(&[VmValue]) -> R) -> R {
+        match self {
+            Self::Empty => f(&[]),
+            Self::One(arg) => f(std::slice::from_ref(*arg)),
+            Self::Two(first, second) => {
+                let args = [(*first).clone(), (*second).clone()];
+                f(&args)
+            }
+            Self::Slice(args) => f(args),
+            Self::Owned(args) => f(args),
+        }
+    }
+}
+
+pub(crate) struct CallArgsIter<'a> {
+    args: &'a CallArgs<'a>,
+    index: usize,
+}
+
+impl<'a> Iterator for CallArgsIter<'a> {
+    type Item = &'a VmValue;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let value = self.args.get(self.index);
+        self.index += usize::from(value.is_some());
+        value
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.args.len().saturating_sub(self.index);
+        (remaining, Some(remaining))
+    }
+}
+
+impl ExactSizeIterator for CallArgsIter<'_> {}

--- a/crates/harn-vm/src/vm/dispatch.rs
+++ b/crates/harn-vm/src/vm/dispatch.rs
@@ -5,7 +5,9 @@ use crate::value::{ErrorCategory, VmBuiltinFn, VmClosure, VmError, VmValue};
 use crate::BuiltinId;
 
 use super::async_builtin::CURRENT_ASYNC_BUILTIN_CHILD_VM;
-use super::{ScopeSpan, Vm, VmBuiltinDispatch, VmBuiltinEntry, VmBuiltinKind, VmBuiltinMetadata};
+use super::{
+    CallArgs, ScopeSpan, Vm, VmBuiltinDispatch, VmBuiltinEntry, VmBuiltinKind, VmBuiltinMetadata,
+};
 
 impl Vm {
     fn builtin_span_kind(name: &str) -> Option<crate::tracing::SpanKind> {
@@ -260,12 +262,22 @@ impl Vm {
         closure: &VmClosure,
         args: &[VmValue],
     ) -> Result<VmValue, VmError> {
+        self.call_closure_args(closure, CallArgs::Slice(args)).await
+    }
+
+    pub(crate) async fn call_closure_args(
+        &mut self,
+        closure: &VmClosure,
+        args: CallArgs<'_>,
+    ) -> Result<VmValue, VmError> {
         let saved_handlers = std::mem::take(&mut self.exception_handlers);
         let active_context = (!crate::step_runtime::is_tracked_function(&closure.func.name))
             .then(crate::step_runtime::take_active_context);
 
         let target_frame_depth = self.frames.len();
-        let result = match self.push_closure_frame(closure, args) {
+        let frame_result = self.push_closure_frame_args(closure, &args);
+        drop(args);
+        let result = match frame_result {
             Ok(()) => self.drive_until_frame_depth(target_frame_depth).await,
             Err(e) => Err(e),
         };
@@ -287,18 +299,67 @@ impl Vm {
         callable: &VmValue,
         args: &[VmValue],
     ) -> Result<VmValue, VmError> {
+        self.call_callable_args(callable, CallArgs::Slice(args))
+            .await
+    }
+
+    pub(crate) async fn call_callable_owned(
+        &mut self,
+        callable: &VmValue,
+        args: Vec<VmValue>,
+    ) -> Result<VmValue, VmError> {
+        self.call_callable_args(callable, CallArgs::Owned(args))
+            .await
+    }
+
+    pub(crate) async fn call_callable_zero(
+        &mut self,
+        callable: &VmValue,
+    ) -> Result<VmValue, VmError> {
+        self.call_callable_args(callable, CallArgs::Empty).await
+    }
+
+    pub(crate) async fn call_callable_one(
+        &mut self,
+        callable: &VmValue,
+        arg: &VmValue,
+    ) -> Result<VmValue, VmError> {
+        self.call_callable_args(callable, CallArgs::One(arg)).await
+    }
+
+    pub(crate) async fn call_callable_two(
+        &mut self,
+        callable: &VmValue,
+        first: &VmValue,
+        second: &VmValue,
+    ) -> Result<VmValue, VmError> {
+        self.call_callable_args(callable, CallArgs::Two(first, second))
+            .await
+    }
+
+    pub(crate) async fn call_callable_args(
+        &mut self,
+        callable: &VmValue,
+        args: CallArgs<'_>,
+    ) -> Result<VmValue, VmError> {
         match callable {
-            VmValue::Closure(closure) => self.call_closure(closure, args).await,
+            VmValue::Closure(closure) => self.call_closure_args(closure, args).await,
             VmValue::BuiltinRef(name) => {
                 if !crate::autonomy::needs_async_side_effect_enforcement(name) {
-                    if let Some(result) = self.call_sync_builtin_by_ref(name, args) {
+                    if let Some(result) = self.call_sync_builtin_by_ref_args(name, &args) {
                         return result;
                     }
                 }
-                self.call_named_builtin(name, args.to_vec()).await
+                self.call_named_builtin(name, args.into_vec()).await
             }
             VmValue::BuiltinRefId { id, name } => {
-                self.call_builtin_id_or_name(*id, name, args.to_vec()).await
+                if let Some(result) =
+                    self.try_call_sync_builtin_id_or_name_args(Some(*id), name, &args)
+                {
+                    return result;
+                }
+                self.call_builtin_id_or_name(*id, name, args.into_vec())
+                    .await
             }
             other => Err(VmError::TypeError(format!(
                 "expected callable, got {}",
@@ -307,12 +368,12 @@ impl Vm {
         }
     }
 
-    fn call_sync_builtin_by_ref(
+    fn call_sync_builtin_by_ref_args(
         &mut self,
         name: &str,
-        args: &[VmValue],
+        args: &CallArgs<'_>,
     ) -> Option<Result<VmValue, VmError>> {
-        self.try_call_sync_builtin_id_or_name(None, name, args)
+        self.try_call_sync_builtin_id_or_name_args(None, name, args)
     }
 
     /// Returns true if `v` is callable via `call_callable_value`.
@@ -353,11 +414,11 @@ impl Vm {
         self.call_builtin_impl(name, args, Some(id)).await
     }
 
-    pub(crate) fn try_call_sync_builtin_id_or_name(
+    pub(crate) fn try_call_sync_builtin_id_or_name_args(
         &mut self,
         direct_id: Option<BuiltinId>,
         name: &str,
-        args: &[VmValue],
+        args: &CallArgs<'_>,
     ) -> Option<Result<VmValue, VmError>> {
         if self.denied_builtins.contains(name) {
             return Some(Err(VmError::CategorizedError {
@@ -372,11 +433,11 @@ impl Vm {
         };
         let _span =
             Self::builtin_span_kind(name).map(|kind| ScopeSpan::new(kind, name.to_string()));
-        if let Err(error) = self.validate_sync_builtin_args(name, args) {
+        if let Err(error) = args.with_slice(|slice| self.validate_sync_builtin_args(name, slice)) {
             return Some(Err(error));
         }
 
-        Some(builtin(args, &mut self.output))
+        Some(args.with_slice(|slice| builtin(slice, &mut self.output)))
     }
 
     pub(crate) fn try_call_sync_builtin_id_or_name_from_stack_args(

--- a/crates/harn-vm/src/vm/interrupts.rs
+++ b/crates/harn-vm/src/vm/interrupts.rs
@@ -130,7 +130,7 @@ impl Vm {
                 let saved_interrupt_deadline = self.interrupt_handler_deadline;
                 self.interrupt_handler_deadline = graceful_timeout_ms
                     .and_then(|ms| Instant::now().checked_add(Duration::from_millis(ms)));
-                let handler_result = self.call_callable_value(&handler, &[]).await;
+                let handler_result = self.call_callable_zero(&handler).await;
                 self.interrupt_handler_deadline = saved_interrupt_deadline;
                 if let Err(error) = handler_result {
                     result = Err(error);

--- a/crates/harn-vm/src/vm/iter.rs
+++ b/crates/harn-vm/src/vm/iter.rs
@@ -317,7 +317,7 @@ impl VmIter {
                         Ok(None)
                     }
                     Some(v) => {
-                        let out = vm.call_callable_value(&f, &[v]).await?;
+                        let out = vm.call_callable_one(&f, &v).await?;
                         Ok(Some(out))
                     }
                 }
@@ -331,7 +331,7 @@ impl VmIter {
                         Ok(None)
                     }
                     Some(v) => {
-                        vm.call_callable_value(&f, &[v.clone()]).await?;
+                        vm.call_callable_one(&f, &v).await?;
                         Ok(Some(v))
                     }
                 }
@@ -346,7 +346,7 @@ impl VmIter {
                             return Ok(None);
                         }
                         Some(v) => {
-                            let keep = vm.call_callable_value(&p, &[v.clone()]).await?;
+                            let keep = vm.call_callable_one(&p, &v).await?;
                             if keep.is_truthy() {
                                 return Ok(Some(v));
                             }
@@ -363,7 +363,7 @@ impl VmIter {
                         Ok(None)
                     }
                     Some(v) => {
-                        let next_acc = vm.call_callable_value(&f, &[acc.clone(), v]).await?;
+                        let next_acc = vm.call_callable_two(&f, acc, &v).await?;
                         *acc = next_acc.clone();
                         Ok(Some(next_acc))
                     }
@@ -386,7 +386,7 @@ impl VmIter {
                             return Ok(None);
                         }
                         Some(v) => {
-                            let result = vm.call_callable_value(&f, &[v]).await?;
+                            let result = vm.call_callable_one(&f, &v).await?;
                             let lifted = iter_from_value(result)?;
                             if let VmValue::Iter(h) = lifted {
                                 *cur = Some(h);
@@ -453,7 +453,7 @@ impl VmIter {
                         Ok(None)
                     }
                     Some(v) => {
-                        let keep = vm.call_callable_value(&p, &[v.clone()]).await?;
+                        let keep = vm.call_callable_one(&p, &v).await?;
                         if keep.is_truthy() {
                             Ok(Some(v))
                         } else {
@@ -472,7 +472,7 @@ impl VmIter {
                         Ok(None)
                     }
                     Some(v) => {
-                        let stop = vm.call_callable_value(&p, &[v.clone()]).await?;
+                        let stop = vm.call_callable_one(&p, &v).await?;
                         if stop.is_truthy() {
                             *self = VmIter::Exhausted;
                             Ok(None)
@@ -502,7 +502,7 @@ impl VmIter {
                             return Ok(None);
                         }
                         Some(v) => {
-                            let drop_it = vm.call_callable_value(&p, &[v.clone()]).await?;
+                            let drop_it = vm.call_callable_one(&p, &v).await?;
                             if !drop_it.is_truthy() {
                                 *primed = true;
                                 return Ok(Some(v));
@@ -923,7 +923,7 @@ impl VmIter {
             VmIter::Map { inner, f } => {
                 let f = f.clone();
                 match try_next_ready(inner, vm).await? {
-                    Some(v) => Ok(Some(vm.call_callable_value(&f, &[v]).await?)),
+                    Some(v) => Ok(Some(vm.call_callable_one(&f, &v).await?)),
                     None => {
                         if is_exhausted_handle(inner) {
                             *self = VmIter::Exhausted;
@@ -936,7 +936,7 @@ impl VmIter {
                 let f = f.clone();
                 match try_next_ready(inner, vm).await? {
                     Some(v) => {
-                        vm.call_callable_value(&f, &[v.clone()]).await?;
+                        vm.call_callable_one(&f, &v).await?;
                         Ok(Some(v))
                     }
                     None => {
@@ -952,7 +952,7 @@ impl VmIter {
                 loop {
                     match try_next_ready(inner, vm).await? {
                         Some(v) => {
-                            let keep = vm.call_callable_value(&p, &[v.clone()]).await?;
+                            let keep = vm.call_callable_one(&p, &v).await?;
                             if keep.is_truthy() {
                                 return Ok(Some(v));
                             }
@@ -970,7 +970,7 @@ impl VmIter {
                 let f = f.clone();
                 match try_next_ready(inner, vm).await? {
                     Some(v) => {
-                        let next_acc = vm.call_callable_value(&f, &[acc.clone(), v]).await?;
+                        let next_acc = vm.call_callable_two(&f, acc, &v).await?;
                         *acc = next_acc.clone();
                         Ok(Some(next_acc))
                     }
@@ -998,7 +998,7 @@ impl VmIter {
                     }
                     match try_next_ready(inner, vm).await? {
                         Some(v) => {
-                            let result = vm.call_callable_value(&f, &[v]).await?;
+                            let result = vm.call_callable_one(&f, &v).await?;
                             *cur = Some(iter_handle_from_value(result)?);
                         }
                         None => {
@@ -1035,7 +1035,7 @@ impl VmIter {
                 let p = p.clone();
                 match try_next_ready(inner, vm).await? {
                     Some(v) => {
-                        let stop = vm.call_callable_value(&p, &[v.clone()]).await?;
+                        let stop = vm.call_callable_one(&p, &v).await?;
                         if stop.is_truthy() {
                             *self = VmIter::Exhausted;
                             Ok(None)

--- a/crates/harn-vm/src/vm/methods/dict.rs
+++ b/crates/harn-vm/src/vm/methods/dict.rs
@@ -94,7 +94,7 @@ impl crate::vm::Vm {
                 };
                 let mut result = BTreeMap::new();
                 for (k, v) in map.iter() {
-                    let mapped = self.call_callable_value(callable, &[v.clone()]).await?;
+                    let mapped = self.call_callable_one(callable, v).await?;
                     result.insert(k.clone(), mapped);
                 }
                 Ok(VmValue::Dict(Rc::new(result)))
@@ -105,9 +105,8 @@ impl crate::vm::Vm {
                 };
                 let mut result = BTreeMap::new();
                 for (k, v) in map.iter() {
-                    let new_key = self
-                        .call_callable_value(callable, &[VmValue::String(Rc::from(k.as_str()))])
-                        .await?;
+                    let key = VmValue::String(Rc::from(k.as_str()));
+                    let new_key = self.call_callable_one(callable, &key).await?;
                     let new_key_str = new_key.display();
                     result.insert(new_key_str, v.clone());
                 }
@@ -119,7 +118,7 @@ impl crate::vm::Vm {
                 };
                 let mut result = BTreeMap::new();
                 for (k, v) in map.iter() {
-                    let keep = self.call_callable_value(callable, &[v.clone()]).await?;
+                    let keep = self.call_callable_one(callable, v).await?;
                     if keep.is_truthy() {
                         result.insert(k.clone(), v.clone());
                     }

--- a/crates/harn-vm/src/vm/methods/iter.rs
+++ b/crates/harn-vm/src/vm/methods/iter.rs
@@ -304,7 +304,7 @@ impl crate::vm::Vm {
                     match item {
                         None => return Ok(acc),
                         Some(v) => {
-                            acc = self.call_callable_value(&f, &[acc, v]).await?;
+                            acc = self.call_callable_two(&f, &acc, &v).await?;
                         }
                     }
                 }
@@ -334,7 +334,7 @@ impl crate::vm::Vm {
                     match item {
                         None => return Ok(VmValue::Bool(false)),
                         Some(v) => {
-                            let r = self.call_callable_value(&p, &[v]).await?;
+                            let r = self.call_callable_one(&p, &v).await?;
                             if r.is_truthy() {
                                 return Ok(VmValue::Bool(true));
                             }
@@ -353,7 +353,7 @@ impl crate::vm::Vm {
                     match item {
                         None => return Ok(VmValue::Bool(true)),
                         Some(v) => {
-                            let r = self.call_callable_value(&p, &[v]).await?;
+                            let r = self.call_callable_one(&p, &v).await?;
                             if !r.is_truthy() {
                                 return Ok(VmValue::Bool(false));
                             }
@@ -374,7 +374,7 @@ impl crate::vm::Vm {
                     match item {
                         None => return Ok(VmValue::Nil),
                         Some(v) => {
-                            let r = self.call_callable_value(&p, &[v.clone()]).await?;
+                            let r = self.call_callable_one(&p, &v).await?;
                             if r.is_truthy() {
                                 return Ok(v);
                             }
@@ -395,7 +395,7 @@ impl crate::vm::Vm {
                     match item {
                         None => return Ok(VmValue::Nil),
                         Some(v) => {
-                            self.call_callable_value(&f, &[v]).await?;
+                            self.call_callable_one(&f, &v).await?;
                         }
                     }
                 }

--- a/crates/harn-vm/src/vm/methods/list.rs
+++ b/crates/harn-vm/src/vm/methods/list.rs
@@ -321,7 +321,7 @@ impl crate::vm::Vm {
                 };
                 let mut results = Vec::with_capacity(items.len());
                 for item in items.iter() {
-                    results.push(self.call_callable_value(callable, &[item.clone()]).await?);
+                    results.push(self.call_callable_one(callable, item).await?);
                 }
                 Ok(VmValue::List(Rc::new(results)))
             }
@@ -331,7 +331,7 @@ impl crate::vm::Vm {
                 };
                 let mut results = Vec::with_capacity(items.len());
                 for item in items.iter() {
-                    let result = self.call_callable_value(callable, &[item.clone()]).await?;
+                    let result = self.call_callable_one(callable, item).await?;
                     if result.is_truthy() {
                         results.push(item.clone());
                     }
@@ -345,9 +345,7 @@ impl crate::vm::Vm {
                 };
                 let mut acc = args.first().cloned().unwrap_or(VmValue::Nil);
                 for item in items.iter() {
-                    acc = self
-                        .call_callable_value(&callable, &[acc, item.clone()])
-                        .await?;
+                    acc = self.call_callable_two(&callable, &acc, item).await?;
                 }
                 Ok(acc)
             }
@@ -356,7 +354,7 @@ impl crate::vm::Vm {
                     return Ok(VmValue::Nil);
                 };
                 for item in items.iter() {
-                    let result = self.call_callable_value(callable, &[item.clone()]).await?;
+                    let result = self.call_callable_one(callable, item).await?;
                     if result.is_truthy() {
                         return Ok(item.clone());
                     }
@@ -368,7 +366,7 @@ impl crate::vm::Vm {
                     return Ok(VmValue::Bool(false));
                 };
                 for item in items.iter() {
-                    let result = self.call_callable_value(callable, &[item.clone()]).await?;
+                    let result = self.call_callable_one(callable, item).await?;
                     if result.is_truthy() {
                         return Ok(VmValue::Bool(true));
                     }
@@ -380,7 +378,7 @@ impl crate::vm::Vm {
                     return Ok(VmValue::Bool(true));
                 };
                 for item in items.iter() {
-                    let result = self.call_callable_value(callable, &[item.clone()]).await?;
+                    let result = self.call_callable_one(callable, item).await?;
                     if !result.is_truthy() {
                         return Ok(VmValue::Bool(false));
                     }
@@ -393,7 +391,7 @@ impl crate::vm::Vm {
                 };
                 let mut results = Vec::with_capacity(items.len());
                 for item in items.iter() {
-                    let result = self.call_callable_value(callable, &[item.clone()]).await?;
+                    let result = self.call_callable_one(callable, item).await?;
                     if let VmValue::List(inner) = result {
                         results.extend(inner.iter().cloned());
                     } else {
@@ -408,7 +406,7 @@ impl crate::vm::Vm {
                 };
                 let mut keyed: Vec<(VmValue, VmValue)> = Vec::new();
                 for item in items.iter() {
-                    let key = self.call_callable_value(callable, &[item.clone()]).await?;
+                    let key = self.call_callable_one(callable, item).await?;
                     keyed.push((item.clone(), key));
                 }
                 keyed.sort_by(|(_, ka), (_, kb)| compare_values(ka, kb).cmp(&0));
@@ -421,7 +419,7 @@ impl crate::vm::Vm {
                     return Ok(VmValue::Bool(items.is_empty()));
                 };
                 for item in items.iter() {
-                    let result = self.call_callable_value(callable, &[item.clone()]).await?;
+                    let result = self.call_callable_one(callable, item).await?;
                     if result.is_truthy() {
                         return Ok(VmValue::Bool(false));
                     }
@@ -433,7 +431,7 @@ impl crate::vm::Vm {
                     return Ok(VmValue::Int(-1));
                 };
                 for (i, item) in items.iter().enumerate() {
-                    let result = self.call_callable_value(callable, &[item.clone()]).await?;
+                    let result = self.call_callable_one(callable, item).await?;
                     if result.is_truthy() {
                         return Ok(VmValue::Int(i as i64));
                     }
@@ -447,7 +445,7 @@ impl crate::vm::Vm {
                 let mut truthy = Vec::new();
                 let mut falsy = Vec::new();
                 for item in items.iter() {
-                    let result = self.call_callable_value(callable, &[item.clone()]).await?;
+                    let result = self.call_callable_one(callable, item).await?;
                     if result.is_truthy() {
                         truthy.push(item.clone());
                     } else {
@@ -465,7 +463,7 @@ impl crate::vm::Vm {
                 };
                 let mut groups: BTreeMap<String, Vec<VmValue>> = BTreeMap::new();
                 for item in items.iter() {
-                    let key = self.call_callable_value(callable, &[item.clone()]).await?;
+                    let key = self.call_callable_one(callable, item).await?;
                     let key_str = key.display();
                     groups.entry(key_str).or_default().push(item.clone());
                 }
@@ -483,9 +481,9 @@ impl crate::vm::Vm {
                     return Ok(VmValue::Nil);
                 };
                 let mut best = items[0].clone();
-                let mut best_key = self.call_callable_value(callable, &[best.clone()]).await?;
+                let mut best_key = self.call_callable_one(callable, &best).await?;
                 for item in &items[1..] {
-                    let key = self.call_callable_value(callable, &[item.clone()]).await?;
+                    let key = self.call_callable_one(callable, item).await?;
                     if compare_values(&key, &best_key) < 0 {
                         best = item.clone();
                         best_key = key;
@@ -501,9 +499,9 @@ impl crate::vm::Vm {
                     return Ok(VmValue::Nil);
                 };
                 let mut best = items[0].clone();
-                let mut best_key = self.call_callable_value(callable, &[best.clone()]).await?;
+                let mut best_key = self.call_callable_one(callable, &best).await?;
                 for item in &items[1..] {
-                    let key = self.call_callable_value(callable, &[item.clone()]).await?;
+                    let key = self.call_callable_one(callable, item).await?;
                     if compare_values(&key, &best_key) > 0 {
                         best = item.clone();
                         best_key = key;

--- a/crates/harn-vm/src/vm/methods/set.rs
+++ b/crates/harn-vm/src/vm/methods/set.rs
@@ -161,7 +161,7 @@ impl crate::vm::Vm {
                 };
                 let mut result = Vec::new();
                 for item in items.iter() {
-                    let mapped = self.call_callable_value(callable, &[item.clone()]).await?;
+                    let mapped = self.call_callable_one(callable, item).await?;
                     if !result.iter().any(|x| values_equal(x, &mapped)) {
                         result.push(mapped);
                     }
@@ -174,7 +174,7 @@ impl crate::vm::Vm {
                 };
                 let mut result = Vec::new();
                 for item in items.iter() {
-                    let keep = self.call_callable_value(callable, &[item.clone()]).await?;
+                    let keep = self.call_callable_one(callable, item).await?;
                     if keep.is_truthy() {
                         result.push(item.clone());
                     }
@@ -186,7 +186,7 @@ impl crate::vm::Vm {
                     return Ok(VmValue::Bool(false));
                 };
                 for item in items.iter() {
-                    let result = self.call_callable_value(callable, &[item.clone()]).await?;
+                    let result = self.call_callable_one(callable, item).await?;
                     if result.is_truthy() {
                         return Ok(VmValue::Bool(true));
                     }
@@ -198,7 +198,7 @@ impl crate::vm::Vm {
                     return Ok(VmValue::Bool(true));
                 };
                 for item in items.iter() {
-                    let result = self.call_callable_value(callable, &[item.clone()]).await?;
+                    let result = self.call_callable_one(callable, item).await?;
                     if !result.is_truthy() {
                         return Ok(VmValue::Bool(false));
                     }

--- a/crates/harn-vm/src/vm/mod.rs
+++ b/crates/harn-vm/src/vm/mod.rs
@@ -1,5 +1,6 @@
 mod async_builtin;
 mod builtin;
+mod call_args;
 mod debug;
 mod dispatch;
 mod execution;
@@ -27,6 +28,7 @@ pub use debug::{DebugAction, DebugState};
 pub use modules::resolve_module_import_path;
 pub use state::{Vm, VmBaseline};
 
+pub(crate) use call_args::CallArgs;
 pub(crate) use state::{
     CallFrame, ExceptionHandler, InterruptHandler, IterState, LocalSlot, ScopeSpan,
     VmBuiltinDispatch, VmBuiltinEntry,

--- a/crates/harn-vm/src/vm/ops/call.rs
+++ b/crates/harn-vm/src/vm/ops/call.rs
@@ -7,7 +7,7 @@ use crate::orchestration::HookEvent;
 use crate::value::{values_equal, VmClosure, VmError, VmJoinHandle, VmTaskHandle, VmValue};
 use crate::BuiltinId;
 
-use super::super::CallFrame;
+use super::super::{CallArgs, CallFrame};
 
 const DIRECT_CALL_QUICKEN_THRESHOLD: u8 = 3;
 
@@ -339,7 +339,9 @@ impl super::super::Vm {
     ) -> Pin<Box<dyn Future<Output = Result<VmValue, VmError>> + 'a>> {
         Box::pin(async move {
             let snapshot = crate::step_runtime::take_active_context();
-            let result = self.call_closure(handler, &[payload]).await;
+            let result = self
+                .call_closure_args(handler, CallArgs::One(&payload))
+                .await;
             crate::step_runtime::restore_active_context(snapshot);
             result
         })

--- a/crates/harn-vm/src/vm/ops/parallel.rs
+++ b/crates/harn-vm/src/vm/ops/parallel.rs
@@ -5,6 +5,8 @@ use std::time::{Duration, Instant};
 
 use crate::value::{VmError, VmStream, VmStreamCancel, VmTaskHandle, VmValue};
 
+use super::super::CallArgs;
+
 /// Decode the `cap_val` stack operand pushed by `parallel ... with
 /// { max_concurrent: N }`. A value of `0` (emitted when no option was
 /// given) and any negative integer both mean "unlimited"; returning
@@ -166,8 +168,9 @@ impl super::super::Vm {
                 );
                 let closure = closure.clone();
                 futures.push(async move {
+                    let arg = VmValue::Int(i as i64);
                     let result = child
-                        .call_closure(&closure, &[VmValue::Int(i as i64)])
+                        .call_closure_args(&closure, CallArgs::One(&arg))
                         .await?;
                     Ok::<(VmValue, String), VmError>((result, std::mem::take(&mut child.output)))
                 });
@@ -210,7 +213,9 @@ impl super::super::Vm {
                     let closure = closure.clone();
                     let item = item.clone();
                     futures.push(async move {
-                        let result = child.call_closure(&closure, &[item]).await?;
+                        let result = child
+                            .call_closure_args(&closure, CallArgs::One(&item))
+                            .await?;
                         Ok::<(VmValue, String), VmError>((
                             result,
                             std::mem::take(&mut child.output),
@@ -254,7 +259,11 @@ impl super::super::Vm {
                     );
                     let closure = closure.clone();
                     let item = item.clone();
-                    futures.push(async move { child.call_closure(&closure, &[item]).await });
+                    futures.push(async move {
+                        child
+                            .call_closure_args(&closure, CallArgs::One(&item))
+                            .await
+                    });
                 }
 
                 let (tx, rx) = tokio::sync::mpsc::channel::<Result<VmValue, VmError>>(1);
@@ -301,7 +310,9 @@ impl super::super::Vm {
                     let closure = closure.clone();
                     let item = item.clone();
                     futures.push(async move {
-                        let result = child.call_closure(&closure, &[item]).await;
+                        let result = child
+                            .call_closure_args(&closure, CallArgs::One(&item))
+                            .await;
                         let output = std::mem::take(&mut child.output);
                         (result, output)
                     });
@@ -357,7 +368,7 @@ impl super::super::Vm {
             let cancel_token = Arc::new(std::sync::atomic::AtomicBool::new(false));
             child.cancel_token = Some(cancel_token.clone());
             let handle = tokio::task::spawn_local(async move {
-                let result = child.call_closure(&closure, &[]).await?;
+                let result = child.call_closure_args(&closure, CallArgs::Empty).await?;
                 Ok((result, std::mem::take(&mut child.output)))
             });
             self.spawned_tasks.insert(

--- a/crates/harn-vm/src/vm/scope.rs
+++ b/crates/harn-vm/src/vm/scope.rs
@@ -2,7 +2,7 @@ use std::rc::Rc;
 
 use crate::value::{VmClosure, VmEnv, VmError, VmValue};
 
-use super::{CallFrame, LocalSlot, Vm};
+use super::{CallArgs, CallFrame, LocalSlot, Vm};
 
 impl Vm {
     pub(crate) const MAX_FRAMES: usize = 512;
@@ -69,9 +69,17 @@ impl Vm {
         closure: &VmClosure,
         args: &[VmValue],
     ) -> Result<(Vec<LocalSlot>, Option<Vec<LocalSlot>>), VmError> {
-        crate::typecheck::validate_user_call(&closure.func, args, None)?;
+        self.prepare_closure_local_slots_args(closure, &CallArgs::Slice(args))
+    }
+
+    fn prepare_closure_local_slots_args(
+        &self,
+        closure: &VmClosure,
+        args: &CallArgs<'_>,
+    ) -> Result<(Vec<LocalSlot>, Option<Vec<LocalSlot>>), VmError> {
+        crate::typecheck::validate_user_call_args(&closure.func, args, None)?;
         let mut local_slots = Self::fresh_local_slots(&closure.func.chunk);
-        Self::bind_param_slots(&mut local_slots, &closure.func, args, false);
+        Self::bind_param_slots_args(&mut local_slots, &closure.func, args, false);
         let initial_local_slots = if self.debugger_attached() {
             Some(local_slots.clone())
         } else {
@@ -158,11 +166,32 @@ impl Vm {
         closure: &VmClosure,
         args: &[VmValue],
     ) -> Result<(), VmError> {
+        self.push_closure_frame_args(closure, &CallArgs::Slice(args))
+    }
+
+    pub(crate) fn push_closure_frame_args(
+        &mut self,
+        closure: &VmClosure,
+        args: &CallArgs<'_>,
+    ) -> Result<(), VmError> {
         if self.frames.len() >= Self::MAX_FRAMES {
             return Err(VmError::StackOverflow);
         }
-        let (local_slots, initial_local_slots) = self.prepare_closure_local_slots(closure, args)?;
-        self.enter_closure_frame(closure, args.len(), local_slots, initial_local_slots, args);
+        let (local_slots, initial_local_slots) =
+            self.prepare_closure_local_slots_args(closure, args)?;
+        let step_args =
+            if crate::step_runtime::step_definition_for_function(&closure.func.name).is_some() {
+                args.to_vec_from(0)
+            } else {
+                Vec::new()
+            };
+        self.enter_closure_frame(
+            closure,
+            args.len(),
+            local_slots,
+            initial_local_slots,
+            &step_args,
+        );
         Ok(())
     }
 

--- a/crates/harn-vm/src/vm/state.rs
+++ b/crates/harn-vm/src/vm/state.rs
@@ -377,22 +377,27 @@ impl Vm {
         args: &[VmValue],
         synced: bool,
     ) {
+        Self::bind_param_slots_args(slots, func, &super::CallArgs::Slice(args), synced);
+    }
+
+    pub(crate) fn bind_param_slots_args(
+        slots: &mut [LocalSlot],
+        func: &crate::chunk::CompiledFunction,
+        args: &super::CallArgs<'_>,
+        synced: bool,
+    ) {
         let param_count = func.params.len();
         for (i, _param) in func.params.iter().enumerate() {
             if i >= slots.len() {
                 break;
             }
             if func.has_rest_param && i == param_count - 1 {
-                let rest_args = if i < args.len() {
-                    args[i..].to_vec()
-                } else {
-                    Vec::new()
-                };
+                let rest_args = args.to_vec_from(i);
                 slots[i].value = VmValue::List(Rc::new(rest_args));
                 slots[i].initialized = true;
                 slots[i].synced = synced;
-            } else if i < args.len() {
-                slots[i].value = args[i].clone();
+            } else if let Some(arg) = args.get(i) {
+                slots[i].value = arg.clone();
                 slots[i].initialized = true;
                 slots[i].synced = synced;
             }


### PR DESCRIPTION
## Summary

- Add a VM-internal `CallArgs` argument view for zero-, one-, two-, slice-, and owned callable arguments.
- Route closure binding, user-call typechecking, sync builtin callback dispatch, and hot collection/iterator callback sites through fixed-arity callable entrypoints.
- Add Criterion coverage for list callback dispatch through both closure and builtin-reference callbacks, including per-run allocation counting.

Closes #2150.

## Verification

- `git diff --check`
- `make lint-test-patterns`
- `RUSTC_WRAPPER= CARGO_TARGET_DIR=/tmp/harn-target-issue-2150 cargo check -p harn-vm`
- `RUSTC_WRAPPER= CARGO_TARGET_DIR=/tmp/harn-target-issue-2150 cargo check -p harn-vm --bench callable_vectorcall`
- `RUSTC_WRAPPER= CARGO_TARGET_DIR=/tmp/harn-target-issue-2150 cargo test -p harn-vm --lib`
- `RUSTC_WRAPPER= CARGO_TARGET_DIR=/tmp/harn-target-issue-2150 cargo test -p harn-vm test_list_ -- --nocapture`
- `RUSTC_WRAPPER= CARGO_TARGET_DIR=/tmp/harn-target-issue-2150 cargo test -p harn-vm test_direct_builtin_callback_uses_builtin_ref_id -- --nocapture`
- `RUSTC_WRAPPER= CARGO_TARGET_DIR=/tmp/harn-target-issue-2150 cargo run --quiet --bin harn -- test conformance --filter list_map`
- `RUSTC_WRAPPER= CARGO_TARGET_DIR=/tmp/harn-target-issue-2150 cargo run --quiet --bin harn -- test conformance --filter stdlib_dict_rekey`
- pre-commit hook: format, prompt-prose lint, changed-package clippy, highlight keyword sync
- pre-push hook: targeted local checks, generated highlight keyword check
