### PR TITLE
ci: migrate app-id → client-id on create-github-app-token

### DIFF
--- a/.github/workflows/bump-release.yml
+++ b/.github/workflows/bump-release.yml
@@ -67,7 +67,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
+          client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -195,7 +195,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
+          client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           permission-contents: write
 


### PR DESCRIPTION
GitHub deprecated the `app-id` input on `actions/create-github-app-token` in favor of `client-id`. Same App, same private key, just the new input name. Org secret `RELEASE_APP_CLIENT_ID` is already set across the org.

Matches burin-labs/burin-code#1086 and burin-labs/harn-cloud#379.