### PR TITLE
Package registry: GitHub-Pages default + semver/bare-alias add + peeled tags (#2157)

### DIFF
--- a/crates/harn-cli/src/package/mod.rs
+++ b/crates/harn-cli/src/package/mod.rs
@@ -19,7 +19,8 @@ const CONTENT_HASH_FILE: &str = ".harn-content-hash";
 const CACHE_METADATA_FILE: &str = ".harn-package-cache.toml";
 const HARN_CACHE_DIR_ENV: &str = "HARN_CACHE_DIR";
 const HARN_PACKAGE_REGISTRY_ENV: &str = "HARN_PACKAGE_REGISTRY";
-const DEFAULT_PACKAGE_REGISTRY_URL: &str = "https://packages.harnlang.com/index.toml";
+const DEFAULT_PACKAGE_REGISTRY_URL: &str =
+    "https://burin-labs.github.io/harn-cloud/package-index/harn-package-index.toml";
 const CACHE_METADATA_VERSION: u32 = 1;
 const LOCK_FILE_VERSION: u32 = 4;
 const REGISTRY_INDEX_VERSION: u32 = 1;

--- a/crates/harn-cli/src/package/registry.rs
+++ b/crates/harn-cli/src/package/registry.rs
@@ -1178,12 +1178,32 @@ pub(crate) fn resolve_git_commit(
         .into());
     }
     let stdout = String::from_utf8_lossy(&output.stdout);
-    let commit = stdout
+    pick_ls_remote_commit(&stdout)
+        .map(str::to_string)
+        .ok_or_else(|| format!("could not resolve {requested} from {url}").into())
+}
+
+/// Pick the commit SHA from `git ls-remote` output.
+///
+/// Annotated tags surface as two refs: `refs/tags/X` (the tag object) and
+/// `refs/tags/X^{}` (the commit the tag points at). Prefer the peeled form so
+/// the lockfile records the commit SHA, not the tag-object SHA — checking out
+/// the tag object still recovers the commit, but the SHA recorded in the lock
+/// is less surprising and round-trips through normal git commands.
+fn pick_ls_remote_commit(stdout: &str) -> Option<&str> {
+    let parsed: Vec<(&str, &str)> = stdout
         .lines()
-        .filter_map(|line| line.split_whitespace().next())
-        .find(|value| is_full_git_sha(value))
-        .ok_or_else(|| format!("could not resolve {requested} from {url}"))?;
-    Ok(commit.to_string())
+        .filter_map(|line| {
+            let mut parts = line.split_whitespace();
+            let sha = parts.next()?;
+            let refname = parts.next().unwrap_or("");
+            is_full_git_sha(sha).then_some((sha, refname))
+        })
+        .collect();
+    parsed
+        .iter()
+        .find_map(|(sha, refname)| refname.ends_with("^{}").then_some(*sha))
+        .or_else(|| parsed.first().map(|(sha, _)| *sha))
 }
 
 pub(crate) fn clone_git_commit_to(
@@ -1797,6 +1817,35 @@ pub fn show_package_registry_info(spec: &str, registry: Option<&str>, json: bool
 mod tests {
     use super::*;
     use crate::package::test_support::*;
+
+    #[test]
+    fn pick_ls_remote_commit_prefers_peeled_tag_over_tag_object() {
+        // Real-world example from notion-sdk-harn v0.1.0: the tag is
+        // annotated, so ls-remote returns both the tag-object SHA and the
+        // commit it points at.
+        let output = "\
+963b6e8acfdf030a9b922bc5a73e010758ff47da\trefs/tags/v0.1.0\n\
+bad580c5fbe8ede612b2748ad98606642ce2fc02\trefs/tags/v0.1.0^{}\n";
+        assert_eq!(
+            pick_ls_remote_commit(output),
+            Some("bad580c5fbe8ede612b2748ad98606642ce2fc02"),
+        );
+    }
+
+    #[test]
+    fn pick_ls_remote_commit_falls_back_to_first_match_for_lightweight_tags() {
+        let output = "\
+abc123abc123abc123abc123abc123abc1234567\trefs/tags/v0.0.1\n";
+        assert_eq!(
+            pick_ls_remote_commit(output),
+            Some("abc123abc123abc123abc123abc123abc1234567"),
+        );
+    }
+
+    #[test]
+    fn pick_ls_remote_commit_returns_none_on_empty_output() {
+        assert_eq!(pick_ls_remote_commit(""), None);
+    }
 
     #[test]
     fn compute_content_hash_ignores_git_and_hash_marker() {

--- a/crates/harn-cli/src/package/registry.rs
+++ b/crates/harn-cli/src/package/registry.rs
@@ -530,6 +530,21 @@ pub(crate) fn read_registry_source(source: &str) -> Result<String, PackageError>
         "http" | "https" => {}
         other => return Err(format!("unsupported package registry URL scheme: {other}").into()),
     }
+    // `reqwest::blocking` builds its own current-thread tokio runtime and
+    // panics if dropped from inside an already-running tokio runtime — which
+    // is exactly what `harn add` / `harn install` do today. Hop onto a fresh
+    // OS thread so the blocking client's lifetime is fully outside any
+    // ambient runtime.
+    let source_owned = source.to_string();
+    std::thread::scope(|scope| {
+        scope
+            .spawn(move || fetch_registry_blocking(url, &source_owned))
+            .join()
+            .map_err(|_| PackageError::Registry("registry fetch thread panicked".to_string()))?
+    })
+}
+
+fn fetch_registry_blocking(url: Url, source: &str) -> Result<String, PackageError> {
     let response = reqwest::blocking::Client::builder()
         .timeout(Duration::from_secs(20))
         .build()
@@ -804,16 +819,45 @@ fn normalize_partial_version(raw: &str) -> String {
     trimmed.to_string()
 }
 
+/// Look up a registry package by either its scoped registry name
+/// (`@burin/notion-sdk`) or any `[[package.version]].package` alias
+/// (`notion-sdk-harn`). Bare-name lookup falls back to the alias so
+/// `harn add notion-sdk-harn@0.1.0` works the same as the scoped form.
+fn lookup_registry_package<'a>(
+    index: &'a PackageRegistryIndex,
+    name: &str,
+) -> Result<&'a RegistryPackage, PackageError> {
+    if let Some(package) = index.packages.iter().find(|package| package.name == name) {
+        return Ok(package);
+    }
+    let matches: Vec<&RegistryPackage> = index
+        .packages
+        .iter()
+        .filter(|package| {
+            package
+                .versions
+                .iter()
+                .any(|entry| entry.package.as_deref() == Some(name))
+        })
+        .collect();
+    match matches.as_slice() {
+        [package] => Ok(package),
+        [] => Err(format!("package registry does not contain {name}").into()),
+        many => Err(format!(
+            "package alias {name} is ambiguous in the registry — found {} packages; use the scoped name (e.g. {})",
+            many.len(),
+            many[0].name,
+        )
+        .into()),
+    }
+}
+
 pub(crate) fn find_registry_package_version(
     index: &PackageRegistryIndex,
     name: &str,
     version: Option<&str>,
 ) -> Result<RegistryPackageInfo, PackageError> {
-    let package = index
-        .packages
-        .iter()
-        .find(|package| package.name == name)
-        .ok_or_else(|| format!("package registry does not contain {name}"))?;
+    let package = lookup_registry_package(index, name)?;
     let selected_version = match version {
         Some(version) => Some(
             package
@@ -836,11 +880,7 @@ pub(crate) fn find_registry_package_version_matching(
     name: &str,
     requirement: &str,
 ) -> Result<RegistryPackageInfo, PackageError> {
-    let package = index
-        .packages
-        .iter()
-        .find(|package| package.name == name)
-        .ok_or_else(|| format!("package registry does not contain {name}"))?;
+    let package = lookup_registry_package(index, name)?;
     let req = parse_registry_version_req(requirement)?;
     let selected_version = package
         .versions
@@ -918,7 +958,15 @@ pub(crate) fn registry_dependency_from_spec_in(
         .into());
     };
     let registry_source = workspace.resolve_registry_source(registry)?;
-    let info = package_registry_info_in(workspace, &format!("{name}@{version}"), registry)?;
+    let (_, index) = load_package_registry_in(workspace, registry)?;
+    // Accept both exact versions (`@1.2.3`) and semver constraints
+    // (`@^0.1`, `@~1.4`, `@>=1,<2`). The latter resolve to the highest
+    // matching unyanked entry.
+    let info = if is_exact_semver(version) {
+        find_registry_package_version(&index, name, Some(version))?
+    } else {
+        find_registry_package_version_matching(&index, name, version)?
+    };
     let selected = info
         .selected_version
         .ok_or_else(|| format!("package registry does not contain {name}@{version}"))?;
@@ -934,6 +982,7 @@ pub(crate) fn registry_dependency_from_spec_in(
     let alias = alias.unwrap_or(package_name.as_str()).to_string();
     let tag = selected.tag;
     let rev = if tag.is_some() { None } else { selected.rev };
+    let resolved_version = selected.version.clone();
     Ok((
         alias.clone(),
         Dependency::Table(Box::new(DepTable {
@@ -943,11 +992,18 @@ pub(crate) fn registry_dependency_from_spec_in(
             branch: selected.branch,
             package: (alias != package_name).then_some(package_name),
             registry: Some(registry_source),
-            registry_name: Some(name.to_string()),
-            registry_version: Some(version.to_string()),
+            // Store the canonical scoped registry name (e.g. `@burin/notion-sdk`)
+            // even when the user typed the bare alias (`notion-sdk-harn`) so
+            // re-resolves stay anchored to the same registry row.
+            registry_name: Some(info.package.name.clone()),
+            registry_version: Some(resolved_version),
             ..DepTable::default()
         })),
     ))
+}
+
+fn is_exact_semver(spec: &str) -> bool {
+    parse_registry_semver(spec).is_ok()
 }
 
 pub(crate) fn registry_dependency_from_manifest_constraint_in(
@@ -2086,6 +2142,55 @@ abc123abc123abc123abc123abc123abc1234567\trefs/tags/v0.0.1\n";
             .join("acme-lib")
             .join("lib.harn")
             .is_file());
+    }
+
+    #[test]
+    fn add_registry_dependency_accepts_bare_alias_and_semver_range() {
+        // Covers the literal acceptance from the free-tier package-manager
+        // epic (harn#2157): `harn add notion-sdk-harn@^0.1` should resolve
+        // even though the registry-side name is `@burin/notion-sdk`.
+        let (_repo_tmp, repo, _branch) = create_git_package_repo();
+        let project_tmp = tempfile::tempdir().unwrap();
+        let root = project_tmp.path();
+        let registry_path = root.join("index.toml");
+        let workspace =
+            TestWorkspace::new(root).with_registry_source(registry_path.display().to_string());
+        let git = normalize_git_url(repo.to_string_lossy().as_ref()).unwrap();
+        write_package_registry_index(&registry_path, "@burin/acme-lib", &git, "acme-lib");
+        fs::create_dir_all(root.join(".git")).unwrap();
+        fs::write(
+            root.join(MANIFEST),
+            r#"
+    [package]
+    name = "workspace"
+    version = "0.1.0"
+    "#,
+        )
+        .unwrap();
+
+        // Bare alias + semver range. Highest matching unyanked version wins.
+        add_package_to(
+            workspace.env(),
+            "acme-lib@^1",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+        let manifest = fs::read_to_string(root.join(MANIFEST)).unwrap();
+        assert!(
+            manifest.contains("registry_name = \"@burin/acme-lib\""),
+            "bare-alias add must record the canonical scoped registry name: {manifest}"
+        );
+        assert!(
+            manifest.contains("registry_version = \"1.0.0\""),
+            "semver range must resolve to the highest matching exact version: {manifest}"
+        );
     }
 
     #[test]

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -5936,8 +5936,13 @@ registry index again.
 
 ```toml
 [registry]
-url = "https://packages.harnlang.com/index.toml"
+url = "https://burin-labs.github.io/harn-cloud/package-index/harn-package-index.toml"
 ```
+
+The default URL points at the free-tier GitHub-Pages-hosted index in
+`burin-labs/harn-cloud`; the deployed `harn-cloud-gateway` mirrors the same
+content at `/index.toml`. Override per-project via `[registry] url = ...`
+in `harn.toml`, or globally via `HARN_PACKAGE_REGISTRY`.
 
 Registry index format:
 

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -5934,8 +5934,13 @@ registry index again.
 
 ```toml
 [registry]
-url = "https://packages.harnlang.com/index.toml"
+url = "https://burin-labs.github.io/harn-cloud/package-index/harn-package-index.toml"
 ```
+
+The default URL points at the free-tier GitHub-Pages-hosted index in
+`burin-labs/harn-cloud`; the deployed `harn-cloud-gateway` mirrors the same
+content at `/index.toml`. Override per-project via `[registry] url = ...`
+in `harn.toml`, or globally via `HARN_PACKAGE_REGISTRY`.
 
 Registry index format:
 


### PR DESCRIPTION
## Summary

Wraps up the CLI side of the [free-tier package-manager v1 epic](https://github.com/burin-labs/harn/issues/2157). After this lands, the literal acceptance from the epic — `harn add notion-sdk-harn@^0.1` — resolves, downloads, and locks end-to-end against the GitHub-Pages CDN, with no harn-cloud-gateway deployment.

### CLI changes

1. **Default `DEFAULT_PACKAGE_REGISTRY_URL` flips to the Pages CDN** at `https://burin-labs.github.io/harn-cloud/package-index/harn-package-index.toml`. Project-level `[registry] url = ...` and `HARN_PACKAGE_REGISTRY` still take precedence; `harn-cloud-gateway` continues mirroring the file at `/index.toml`, so the eventual cutover is a one-flag change via `HARN_CLOUD_PACKAGE_INDEX_REDIRECT_URL`.

2. **`resolve_git_commit` prefers the peeled tag SHA.** Annotated tags (e.g. the freshly cut `notion-sdk-harn v0.1.0`) surface twice in `git ls-remote` — once as the tag-object SHA, once as `refs/tags/X^{}` pointing at the commit. The resolver now picks the peeled form so lockfiles record the commit users actually get from `git rev-parse vX.Y.Z^{commit}`.

3. **`harn add` semver ranges.** `registry_dependency_from_spec_in` was string-matching exact versions only. It now tries `parse_registry_semver` first and falls back to `find_registry_package_version_matching` for `@^X.Y` / `@~X.Y` / `@>=X,<Y` constraints — same operator set already accepted in manifest `version = "..."` deps.

4. **`harn add` bare-alias fallback.** The harn-cloud index uses scoped names (`@burin/notion-sdk`) but the epic acceptance names the package by its publish identity (`notion-sdk-harn`). A new `lookup_registry_package` helper accepts either; when the user types the alias, the resolver pulls the canonical scoped name out of the matching `[[package]]` row and writes that into `registry_name` so re-resolves stay anchored.

5. **Panic-free registry HTTP fetch.** `read_registry_source` was building a `reqwest::blocking::Client` from inside the CLI's multi-threaded tokio runtime, which panicked on drop in source builds (`Cannot drop a runtime in a context where blocking is not allowed`). It now runs on a fresh scoped OS thread so the inner runtime's lifetime is fully outside any ambient async context.

6. Spec + language docs point at the new URL with a short note on overriding.

### Test plan

- [x] `cargo test -p harn-cli --lib` (703 tests, +1 covering the bare-alias + semver-range path end-to-end against a fixture index, +3 covering peeled-tag selection).
- [x] Live end-to-end from a fresh checkout against the merged harn-cloud Pages site:
  ```
  $ harn init scratch && cd scratch
  $ harn add notion-sdk-harn@^0.1
  Added notion-sdk-harn to harn.toml.
  Installed 2 package(s).
  ```
  Lockfile pins `commit = "bad580c5..."` (the peeled commit for `v0.1.0`).
- [x] `harn add @burin/notion-sdk@0.1.0` (released-CLI form) also works.

Closes the CLI side of [harn-cloud#374](https://github.com/burin-labs/harn-cloud/issues/374). Closes [#2175](https://github.com/burin-labs/harn/issues/2175). Wraps [#2157](https://github.com/burin-labs/harn/issues/2157).

🤖 Generated with [Claude Code](https://claude.com/claude-code)