### PR TITLE
Expose suspended subagent DAP variables

### DIFF
--- a/crates/harn-dap/src/debugger/events.rs
+++ b/crates/harn-dap/src/debugger/events.rs
@@ -151,8 +151,23 @@ impl Debugger {
                     // IDE with no-op stopped/continued churn.
                 }
                 WorkerEvent::WorkerWaitingForInput => {
-                    self.subagent_tracker
-                        .mark_suspended(&obs.worker_id, Some("awaiting input"));
+                    let mut suspension = obs.suspension.clone().unwrap_or_else(|| {
+                        json!({
+                            "handle": obs.worker_id,
+                            "reason": "awaiting input",
+                            "resume_by_mechanism": "manual",
+                        })
+                    });
+                    if let Some(object) = suspension.as_object_mut() {
+                        object
+                            .entry("reason".to_string())
+                            .or_insert_with(|| json!("awaiting input"));
+                    }
+                    self.subagent_tracker.mark_suspended(
+                        &obs.worker_id,
+                        Some("awaiting input"),
+                        Some(suspension),
+                    );
                     let seq = self.next_seq();
                     out.push(DapResponse::event(
                         seq,
@@ -167,8 +182,11 @@ impl Debugger {
                     ));
                 }
                 WorkerEvent::WorkerSuspended => {
-                    self.subagent_tracker
-                        .mark_suspended(&obs.worker_id, obs.suspend_reason.as_deref());
+                    self.subagent_tracker.mark_suspended(
+                        &obs.worker_id,
+                        obs.suspend_reason.as_deref(),
+                        obs.suspension.clone(),
+                    );
                     let description = obs
                         .suspend_reason
                         .clone()

--- a/crates/harn-dap/src/debugger/mod.rs
+++ b/crates/harn-dap/src/debugger/mod.rs
@@ -205,7 +205,30 @@ impl Debugger {
     }
 
     fn handle_stack_trace(&mut self, msg: &DapMessage) -> Vec<DapResponse> {
-        let frames: Vec<StackFrame> = if self.vm.is_some() {
+        let requested_thread_id = msg
+            .arguments
+            .as_ref()
+            .and_then(|a| a.get("threadId"))
+            .and_then(|v| v.as_u64())
+            .unwrap_or(self.current_thread_id);
+        let frames: Vec<StackFrame> = if let Some(thread) = self
+            .subagent_tracker
+            .thread_for_id(requested_thread_id)
+            .filter(|thread| thread.suspension.is_some())
+        {
+            let reason = thread
+                .suspend_reason
+                .as_deref()
+                .filter(|reason| !reason.trim().is_empty())
+                .unwrap_or("suspended");
+            vec![StackFrame {
+                id: Self::subagent_suspension_frame_id(requested_thread_id),
+                name: format!("<suspended: {reason}>"),
+                line: self.current_line.max(1),
+                column: 1,
+                source: self.source_path.clone().map(|p| self.source_for_path(&p)),
+            }]
+        } else if self.vm.is_some() {
             let vm_frames = self
                 .vm
                 .as_ref()

--- a/crates/harn-dap/src/debugger/subagents.rs
+++ b/crates/harn-dap/src/debugger/subagents.rs
@@ -27,11 +27,10 @@
 //!
 //! ## Privacy
 //!
-//! Only public metadata — worker id, name, mode, status, parent worker
-//! id, optional human-readable suspend reason — flows through DAP. We
-//! deliberately do NOT forward `transcript`, `conditions`, or arbitrary
-//! `metadata` blobs; those can carry tool inputs that may be sensitive
-//! (issue #1867 privacy callout).
+//! DAP receives the worker identity, lineage, lifecycle status, and the
+//! structured suspension envelope needed for debugger inspection. It
+//! deliberately does not receive transcripts, resume input, or arbitrary
+//! worker metadata blobs.
 //!
 //! ## Filters
 //!
@@ -57,6 +56,7 @@ use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
 
 use harn_vm::agent_events::{AgentEvent, AgentEventSink, WildcardSinkHandle, WorkerEvent};
+use serde_json::Value;
 
 /// Stable thread ids for subagent threads start at this base. Keeps
 /// them well above the synthetic `main` (1) and the ACP session range
@@ -73,6 +73,9 @@ pub(crate) struct SubagentThread {
     /// Most-recent suspend reason. Cleared on resume / completion so
     /// the next stop description doesn't echo a stale reason.
     pub(crate) suspend_reason: Option<String>,
+    /// Structured suspension envelope exposed through DAP scopes when
+    /// the suspended subagent thread is selected.
+    pub(crate) suspension: Option<Value>,
     /// True after `thread { reason: "exited" }` has been emitted; the
     /// record sticks around briefly so a `threads` response that races
     /// with the exit can still surface the row, but no further events
@@ -91,6 +94,7 @@ pub(crate) struct SubagentObservation {
     pub(crate) status: String,
     pub(crate) parent_worker_id: Option<String>,
     pub(crate) suspend_reason: Option<String>,
+    pub(crate) suspension: Option<Value>,
 }
 
 /// Shared state between the [`SubagentEventSink`] (which mutates from
@@ -166,6 +170,7 @@ impl SubagentTracker {
                 parent_worker_id: parent_worker_id.map(str::to_string),
                 last_status: status.to_string(),
                 suspend_reason: None,
+                suspension: None,
                 exited: false,
             };
             guard.threads.insert(worker_id.to_string(), record.clone());
@@ -173,12 +178,19 @@ impl SubagentTracker {
         }
     }
 
-    /// Mark a subagent's record as suspended, attaching the reason.
-    pub(crate) fn mark_suspended(&self, worker_id: &str, reason: Option<&str>) {
+    /// Mark a subagent's record as suspended, attaching the envelope
+    /// shown in the DAP variable inspector.
+    pub(crate) fn mark_suspended(
+        &self,
+        worker_id: &str,
+        reason: Option<&str>,
+        suspension: Option<Value>,
+    ) {
         let mut guard = self.inner.lock().expect("subagent tracker poisoned");
         if let Some(thread) = guard.threads.get_mut(worker_id) {
             thread.last_status = "suspended".to_string();
             thread.suspend_reason = reason.map(str::to_string);
+            thread.suspension = suspension;
         }
     }
 
@@ -190,6 +202,7 @@ impl SubagentTracker {
         if let Some(thread) = guard.threads.get_mut(worker_id) {
             thread.last_status = "running".to_string();
             thread.suspend_reason = None;
+            thread.suspension = None;
         }
     }
 
@@ -202,6 +215,7 @@ impl SubagentTracker {
         if let Some(thread) = guard.threads.get_mut(worker_id) {
             thread.exited = true;
             thread.suspend_reason = None;
+            thread.suspension = None;
         }
     }
 
@@ -232,6 +246,15 @@ impl SubagentTracker {
     pub(crate) fn thread_id_for_worker(&self, worker_id: &str) -> Option<u64> {
         let guard = self.inner.lock().expect("subagent tracker poisoned");
         guard.threads.get(worker_id).map(|t| t.thread_id)
+    }
+
+    pub(crate) fn thread_for_id(&self, thread_id: u64) -> Option<SubagentThread> {
+        let guard = self.inner.lock().expect("subagent tracker poisoned");
+        guard
+            .threads
+            .values()
+            .find(|thread| thread.thread_id == thread_id)
+            .cloned()
     }
 
     /// Test helper — peek at the queue length without draining.
@@ -283,10 +306,10 @@ impl AgentEventSink for SubagentEventSink {
             .and_then(|v| v.as_str())
             .filter(|s| !s.is_empty())
             .map(str::to_string);
-        // Suspend reason comes from the bridge metadata blob the
-        // `emit_worker_event` builder packed in. It's intentionally
-        // restricted to the short human-readable string so we don't
-        // leak transcript / payload data through DAP.
+        let suspension = metadata
+            .get("suspension")
+            .filter(|value| value.is_object())
+            .cloned();
         let suspend_reason = metadata
             .get("suspension")
             .and_then(|v| v.get("reason"))
@@ -299,6 +322,7 @@ impl AgentEventSink for SubagentEventSink {
             status: status.clone(),
             parent_worker_id,
             suspend_reason,
+            suspension,
         };
         let mut guard = self
             .tracker
@@ -346,7 +370,20 @@ mod tests {
             metadata.insert("parent_worker_id".to_string(), json!(p));
         }
         if let Some(r) = suspend_reason {
-            metadata.insert("suspension".to_string(), json!({ "reason": r }));
+            metadata.insert(
+                "suspension".to_string(),
+                json!({
+                    "handle": worker_id,
+                    "reason": r,
+                    "conditions": {
+                        "trigger": {"provider": "github", "kind": "comment"},
+                        "timeout": {"minutes": 30},
+                    },
+                    "resume_by_mechanism": "trigger",
+                    "suspended_at": "01978f25-0000-7000-8000-000000000000",
+                    "initiator": "operator",
+                }),
+            );
         }
         AgentEvent::WorkerUpdate {
             session_id: "session-test".to_string(),
@@ -394,6 +431,10 @@ mod tests {
         assert_eq!(drained[0].event, WorkerEvent::WorkerSpawned);
         assert_eq!(drained[1].event, WorkerEvent::WorkerSuspended);
         assert_eq!(drained[1].suspend_reason.as_deref(), Some("budget"));
+        assert_eq!(
+            drained[1].suspension.as_ref().unwrap()["resume_by_mechanism"],
+            "trigger"
+        );
     }
 
     #[test]
@@ -415,7 +456,7 @@ mod tests {
     fn mark_resumed_clears_suspend_reason() {
         let tracker = SubagentTracker::new();
         tracker.upsert_thread("w1", "alpha", None, "running");
-        tracker.mark_suspended("w1", Some("backoff"));
+        tracker.mark_suspended("w1", Some("backoff"), Some(json!({"reason": "backoff"})));
         let snapshot = tracker.snapshot_threads();
         assert_eq!(snapshot[0].1.suspend_reason.as_deref(), Some("backoff"));
         tracker.mark_resumed("w1");

--- a/crates/harn-dap/src/debugger/tests.rs
+++ b/crates/harn-dap/src/debugger/tests.rs
@@ -1314,6 +1314,7 @@ mod subagent_bridge {
                     status: "running".to_string(),
                     parent_worker_id: None,
                     suspend_reason: None,
+                    suspension: None,
                 });
             guard
                 .pending
@@ -1324,6 +1325,17 @@ mod subagent_bridge {
                     status: "suspended".to_string(),
                     parent_worker_id: None,
                     suspend_reason: Some("awaiting human approval".to_string()),
+                    suspension: Some(json!({
+                        "handle": "w-1",
+                        "reason": "awaiting human approval",
+                        "conditions": {
+                            "trigger": {"provider": "github", "kind": "comment"},
+                            "timeout": {"minutes": 30},
+                        },
+                        "resume_by_mechanism": "trigger",
+                        "suspended_at": "01978f25-0000-7000-8000-000000000000",
+                        "initiator": "operator",
+                    })),
                 });
         }
 
@@ -1351,7 +1363,8 @@ mod subagent_bridge {
         let thread = dbg
             .subagent_tracker
             .upsert_thread("w-1", "researcher", None, "running");
-        dbg.subagent_tracker.mark_suspended("w-1", Some("timer"));
+        dbg.subagent_tracker
+            .mark_suspended("w-1", Some("timer"), Some(json!({"reason": "timer"})));
         {
             let mut guard = dbg.subagent_tracker.inner_for_test();
             guard
@@ -1363,6 +1376,7 @@ mod subagent_bridge {
                     status: "running".to_string(),
                     parent_worker_id: None,
                     suspend_reason: None,
+                    suspension: None,
                 });
         }
 
@@ -1395,6 +1409,7 @@ mod subagent_bridge {
                     status: "running".to_string(),
                     parent_worker_id: None,
                     suspend_reason: None,
+                    suspension: None,
                 });
         }
         let events = dbg.drain_subagent_events();
@@ -1419,8 +1434,11 @@ mod subagent_bridge {
         let child =
             dbg.subagent_tracker
                 .upsert_thread("w-2", "child-agent", Some("w-1"), "suspended");
-        dbg.subagent_tracker
-            .mark_suspended("w-2", Some("escalated to operator"));
+        dbg.subagent_tracker.mark_suspended(
+            "w-2",
+            Some("escalated to operator"),
+            Some(json!({"reason": "escalated to operator"})),
+        );
 
         let responses = dbg.handle_message(make_request(1, "threads", None));
         let body = responses[0].body.as_ref().unwrap();
@@ -1447,6 +1465,80 @@ mod subagent_bridge {
     }
 
     #[test]
+    fn suspended_subagent_thread_surfaces_stack_scope_and_variables() {
+        let mut dbg = Debugger::new();
+        let thread =
+            dbg.subagent_tracker
+                .upsert_thread("w-2", "child-agent", Some("w-1"), "suspended");
+        dbg.subagent_tracker.mark_suspended(
+            "w-2",
+            Some("waiting on review"),
+            Some(json!({
+                "handle": "w-2",
+                "reason": "waiting on review",
+                "conditions": {
+                    "trigger": {"provider": "github", "kind": "comment"},
+                    "timeout": {"minutes": 30},
+                },
+                "resume_by_mechanism": "trigger",
+                "suspended_at": "01978f25-0000-7000-8000-000000000000",
+                "initiator": "operator",
+            })),
+        );
+
+        let stack = dbg.handle_message(make_request(
+            1,
+            "stackTrace",
+            Some(json!({"threadId": thread.thread_id})),
+        ));
+        let frames = stack[0].body.as_ref().unwrap()["stackFrames"]
+            .as_array()
+            .unwrap();
+        assert_eq!(frames.len(), 1);
+        assert_eq!(frames[0]["name"], "<suspended: waiting on review>");
+        let frame_id = frames[0]["id"].as_i64().unwrap();
+
+        let scopes = dbg.handle_message(make_request(
+            2,
+            "scopes",
+            Some(json!({"frameId": frame_id})),
+        ));
+        let scope = &scopes[0].body.as_ref().unwrap()["scopes"][0];
+        assert_eq!(scope["name"], "Suspension");
+        let variables_reference = scope["variablesReference"].as_i64().unwrap();
+
+        let variables = dbg.handle_message(make_request(
+            3,
+            "variables",
+            Some(json!({"variablesReference": variables_reference})),
+        ));
+        let vars = variables[0].body.as_ref().unwrap()["variables"]
+            .as_array()
+            .unwrap();
+        let names: Vec<&str> = vars
+            .iter()
+            .map(|var| var["name"].as_str().unwrap())
+            .collect();
+        for required in [
+            "handle",
+            "conditions",
+            "resume_by_mechanism",
+            "suspended_at",
+            "initiator",
+        ] {
+            assert!(names.contains(&required), "missing {required}: {vars:?}");
+        }
+        let conditions = vars
+            .iter()
+            .find(|var| var["name"] == "conditions")
+            .expect("conditions variable");
+        assert!(
+            conditions["variablesReference"].as_i64().unwrap() > 0,
+            "conditions should be expandable: {conditions:?}"
+        );
+    }
+
+    #[test]
     fn drain_failed_emits_stopped_exception_then_thread_exited() {
         let mut dbg = Debugger::new();
         dbg.subagent_tracker
@@ -1462,6 +1554,7 @@ mod subagent_bridge {
                     status: "failed".to_string(),
                     parent_worker_id: None,
                     suspend_reason: Some("OOM in tool".to_string()),
+                    suspension: None,
                 });
         }
         let events = dbg.drain_subagent_events();
@@ -1489,6 +1582,7 @@ mod subagent_bridge {
                         status: "progressed".to_string(),
                         parent_worker_id: None,
                         suspend_reason: None,
+                        suspension: None,
                     });
             }
         }

--- a/crates/harn-dap/src/debugger/variables.rs
+++ b/crates/harn-dap/src/debugger/variables.rs
@@ -4,6 +4,9 @@ use serde_json::json;
 use super::state::{Debugger, PathSegment};
 use crate::protocol::*;
 
+const SUBAGENT_SUSPENSION_FRAME_BASE: i64 = 700_000_000;
+const SUBAGENT_SUSPENSION_SCOPE_BASE: i64 = 800_000_000;
+
 fn vm_type_name(val: &VmValue) -> &'static str {
     val.type_name()
 }
@@ -21,6 +24,45 @@ fn is_simple_identifier(expr: &str) -> bool {
 }
 
 impl Debugger {
+    pub(crate) fn subagent_suspension_frame_id(thread_id: u64) -> i64 {
+        SUBAGENT_SUSPENSION_FRAME_BASE + thread_id as i64
+    }
+
+    fn thread_id_from_suspension_frame(frame_id: i64) -> Option<u64> {
+        if !(SUBAGENT_SUSPENSION_FRAME_BASE..SUBAGENT_SUSPENSION_SCOPE_BASE).contains(&frame_id) {
+            return None;
+        }
+        let offset = frame_id - SUBAGENT_SUSPENSION_FRAME_BASE;
+        (offset > 0).then_some(offset as u64)
+    }
+
+    fn suspension_scope_ref(thread_id: u64) -> i64 {
+        SUBAGENT_SUSPENSION_SCOPE_BASE + thread_id as i64
+    }
+
+    fn thread_id_from_suspension_scope(ref_id: i64) -> Option<u64> {
+        if ref_id < SUBAGENT_SUSPENSION_SCOPE_BASE {
+            return None;
+        }
+        let offset = ref_id - SUBAGENT_SUSPENSION_SCOPE_BASE;
+        (offset > 0).then_some(offset as u64)
+    }
+
+    fn suspension_variables_for_thread(&mut self, thread_id: u64) -> Option<Vec<Variable>> {
+        let suspension = self.subagent_tracker.thread_for_id(thread_id)?.suspension?;
+        let object = suspension.as_object()?;
+        let values: Vec<(String, VmValue)> = object
+            .iter()
+            .map(|(name, value)| (name.clone(), harn_vm::json_to_vm_value(value)))
+            .collect();
+        Some(
+            values
+                .iter()
+                .map(|(name, value)| self.make_variable(name.clone(), value))
+                .collect(),
+        )
+    }
+
     pub(crate) fn alloc_var_ref(&mut self, children: Vec<(String, VmValue)>) -> i64 {
         let id = self.next_var_ref;
         self.next_var_ref += 1;
@@ -93,6 +135,34 @@ impl Debugger {
     }
 
     pub(crate) fn handle_scopes(&mut self, msg: &DapMessage) -> Vec<DapResponse> {
+        let frame_id = msg
+            .arguments
+            .as_ref()
+            .and_then(|a| a.get("frameId"))
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0);
+        if let Some(thread_id) = Self::thread_id_from_suspension_frame(frame_id) {
+            if self
+                .subagent_tracker
+                .thread_for_id(thread_id)
+                .and_then(|thread| thread.suspension)
+                .is_some()
+            {
+                let scopes = vec![Scope {
+                    name: "Suspension".to_string(),
+                    variables_reference: Self::suspension_scope_ref(thread_id),
+                    expensive: false,
+                }];
+                let seq = self.next_seq();
+                return vec![DapResponse::success(
+                    seq,
+                    msg.seq,
+                    "scopes",
+                    Some(json!({ "scopes": scopes })),
+                )];
+            }
+        }
+
         let scopes = vec![Scope {
             name: "Locals".to_string(),
             variables_reference: 1,
@@ -115,6 +185,19 @@ impl Debugger {
             .and_then(|a| a.get("variablesReference"))
             .and_then(|v| v.as_i64())
             .unwrap_or(1);
+
+        if let Some(thread_id) = Self::thread_id_from_suspension_scope(ref_id) {
+            let vars = self
+                .suspension_variables_for_thread(thread_id)
+                .unwrap_or_default();
+            let seq = self.next_seq();
+            return vec![DapResponse::success(
+                seq,
+                msg.seq,
+                "variables",
+                Some(json!({ "variables": vars })),
+            )];
+        }
 
         // Ref IDs >= 100 index `self.var_refs` (children of composite values).
         if ref_id >= 100 {

--- a/crates/harn-vm/src/stdlib/agents_workers/bridge.rs
+++ b/crates/harn-vm/src/stdlib/agents_workers/bridge.rs
@@ -5,6 +5,25 @@ use crate::orchestration::MutationSessionRecord;
 
 use super::{worker_provenance, WorkerState};
 
+fn worker_suspension_metadata(state: &WorkerState) -> Option<serde_json::Value> {
+    let suspension = state.suspension.as_ref()?;
+    Some(serde_json::json!({
+        "handle": state.id.clone(),
+        "reason": suspension.reason.clone(),
+        "conditions": suspension.conditions.clone(),
+        "initiator": suspension.initiator,
+        "suspended_at": suspension.suspended_at.clone(),
+        "suspended_at_turn": suspension.suspended_at_turn,
+        "snapshot_ref": suspension.snapshot_ref.clone(),
+        "resume_by_mechanism": if suspension.auto_resume_trigger.is_some() {
+            "trigger"
+        } else {
+            "manual"
+        },
+        "auto_resume_trigger": suspension.auto_resume_trigger.clone(),
+    }))
+}
+
 fn worker_bridge_metadata(state: &WorkerState) -> serde_json::Value {
     serde_json::json!({
         "task": state.task,
@@ -23,6 +42,7 @@ fn worker_bridge_metadata(state: &WorkerState) -> serde_json::Value {
         "child_run_path": state.child_run_path,
         "execution": state.execution,
         "snapshot_path": state.snapshot_path,
+        "suspension": worker_suspension_metadata(state),
         "audit": state.audit,
         "error": state.latest_error,
     })

--- a/crates/harn-vm/src/stdlib/agents_workers/tests.rs
+++ b/crates/harn-vm/src/stdlib/agents_workers/tests.rs
@@ -207,7 +207,7 @@ fn parse_worker_config_rejects_unknown_carry_options() {
 
 #[test]
 fn worker_summary_exposes_request_and_provenance() {
-    let state = WorkerState {
+    let mut state = WorkerState {
         id: "worker_123".to_string(),
         name: "worker".to_string(),
         task: "latest task".to_string(),
@@ -283,6 +283,29 @@ fn worker_summary_exposes_request_and_provenance() {
         serde_json::json!("session_parent")
     );
     assert_eq!(summary["task"], serde_json::json!("latest task"));
+
+    state.status = "suspended".to_string();
+    state.suspension = Some(WorkerSuspension {
+        reason: "waiting on review".to_string(),
+        initiator: SuspendInitiator::Operator,
+        suspended_at: "01978f25-0000-7000-8000-000000000000".to_string(),
+        snapshot_ref: ".harn/workers/worker_123.json".to_string(),
+        conditions: Some(serde_json::json!({
+            "trigger": {"provider": "github", "kind": "comment"},
+            "timeout": {"minutes": 30},
+        })),
+        ..Default::default()
+    });
+
+    let event_snapshot = super::bridge::worker_event_snapshot(&state);
+    let suspension = &event_snapshot.metadata["suspension"];
+    assert_eq!(suspension["handle"], serde_json::json!("worker_123"));
+    assert_eq!(suspension["reason"], serde_json::json!("waiting on review"));
+    assert_eq!(
+        suspension["resume_by_mechanism"],
+        serde_json::json!("manual")
+    );
+    assert_eq!(suspension["conditions"]["timeout"]["minutes"], 30);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- include the structured worker suspension envelope in worker bridge metadata
- preserve that envelope in the Harn DAP subagent tracker
- expose suspended subagents through synthetic stack/scopes/variables so IDE clients can inspect `Suspension` data

## Context
Supports burin-code issue #959 by providing the runtime-side DAP variables that the Burin debugger UI surfaces for paused subagents.

## Tests
- `cargo test -p harn-dap subagent_bridge --tests`
- `cargo test -p harn-dap subagents --tests`
- `cargo test -p harn-vm worker_summary_exposes_request_and_provenance --lib`
- pre-commit clippy/format checks
- pre-push targeted checks
