### PR TITLE
[codex] Unify secret redaction patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Pre-0.6 highlights live in [CHANGELOG-pre-0.6.md](CHANGELOG-pre-0.6.md).
 Harn had no external users before 0.6.0, so that archive intentionally keeps
 condensed series summaries instead of full per-patch history.
 
+## Unreleased
+
+### Fixed
+
+- **Secret redaction and scanning now share one token catalog.**
+  `secret_scan`, token redaction, and provider-error sanitization now use the
+  same high-confidence secret patterns. JWTs, Bearer tokens, and full private
+  key blocks are consistently reported or scrubbed instead of drifting across
+  runtime surfaces.
+
 ## v0.8.34
 
 ### Fixed

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -60,6 +60,7 @@ pub mod run_events;
 pub mod runtime_context;
 pub mod runtime_paths;
 pub mod schema;
+pub(crate) mod secret_patterns;
 pub mod secrets;
 pub mod session_bundle;
 pub mod sessions;

--- a/crates/harn-vm/src/llm/api/errors.rs
+++ b/crates/harn-vm/src/llm/api/errors.rs
@@ -147,8 +147,11 @@ fn redact_provider_error_secrets(text: &str) -> String {
         Regex::new(r#"(?i)(bearer\s+)[^"',\s}]+"#).expect("valid bearer redaction regex")
     });
     let redacted = bearer_re.replace_all(text, "$1[redacted]");
-    secret_field_re
+    let redacted = secret_field_re
         .replace_all(&redacted, "$1[redacted]")
+        .into_owned();
+    crate::redact::current_policy()
+        .redact_string(&redacted)
         .into_owned()
 }
 
@@ -491,6 +494,23 @@ mod tests {
             "message was too long: {}",
             message.len()
         );
+    }
+
+    #[test]
+    fn provider_http_errors_use_shared_secret_pattern_redaction() {
+        let body = concat!(
+            r#"{"error":{"message":"jwt=eyJabcd.eyJefgh.signature_pad "#,
+            "-----BEGIN OPENSSH PRIVATE KEY-----\nsecret-material\n",
+            r#"-----END OPENSSH PRIVATE KEY-----"}}"#
+        );
+        let message =
+            classify_provider_http_error("openai", reqwest::StatusCode::BAD_REQUEST, None, body)
+                .message;
+
+        assert!(!message.contains("eyJabcd.eyJefgh.signature_pad"));
+        assert!(!message.contains("secret-material"));
+        assert!(message.contains("<redacted:jwt:"));
+        assert!(message.contains("<redacted:private_key_block:"));
     }
 
     #[test]

--- a/crates/harn-vm/src/redact/patterns.rs
+++ b/crates/harn-vm/src/redact/patterns.rs
@@ -2,12 +2,10 @@
 //!
 //! Each pattern is named so the replacement placeholder is
 //! `<redacted:<pattern_name>:<len>>` and audit events can attribute the
-//! redaction to a specific provider. The [`crate::stdlib::secret_scan`]
-//! module defines the canonical set of high-confidence secret regexes
-//! that the `secret_scan` builtin reports to scripts; this module
-//! borrows from that same set so a string that scanning would flag is
-//! also a string that redaction will scrub — there is one definition,
-//! not two.
+//! redaction to a specific provider. The shared
+//! [`crate::secret_patterns`] catalog is also used by the
+//! `secret_scan` builtin, so a string that scanning reports is also a
+//! string that redaction scrubs.
 //!
 //! # Custom patterns
 //!
@@ -34,6 +32,8 @@ use std::collections::BTreeMap;
 use std::sync::LazyLock;
 
 use regex::Regex;
+
+use crate::secret_patterns::DEFAULT_SECRET_PATTERN_SPECS;
 
 /// Stable identifier emitted in audit logs for every token-redaction
 /// event. Part of the OA-06 epic's compliance contract.
@@ -75,70 +75,15 @@ impl std::fmt::Debug for NamedPattern {
 /// audit attribution when multiple patterns would match the same
 /// substring — earlier patterns win.
 pub static DEFAULT_PATTERNS: LazyLock<Vec<NamedPattern>> = LazyLock::new(|| {
-    vec![
-        // JWT — three base64url segments separated by `.`. Required
-        // prefix `eyJ` keeps the regex from chewing arbitrary
-        // dotted base64.
-        NamedPattern {
-            name: "jwt",
-            regex: Regex::new(r"\beyJ[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]{4,}\b")
-                .expect("jwt regex compiles"),
-        },
-        // GitHub OAuth / app installation tokens (ghp_, gho_, ghu_,
-        // ghs_, ghr_).
-        NamedPattern {
-            name: "github_token",
-            regex: Regex::new(r"\bgh[pousr]_[A-Za-z0-9]{36,255}\b")
-                .expect("github_token regex compiles"),
-        },
-        // GitHub fine-grained personal access token.
-        NamedPattern {
-            name: "github_pat_fine",
-            regex: Regex::new(r"\bgithub_pat_[A-Za-z0-9_]{20,255}\b")
-                .expect("github_pat_fine regex compiles"),
-        },
-        // Slack tokens (xoxb / xoxp / xoxa / xoxs / xoxr).
-        NamedPattern {
-            name: "slack_token",
-            regex: Regex::new(r"\bxox[abprs]-[A-Za-z0-9-]{10,255}\b")
-                .expect("slack_token regex compiles"),
-        },
-        // AWS access key ids (gitleaks family).
-        NamedPattern {
-            name: "aws_access_key",
-            regex: Regex::new(r"\b(?:AKIA|ASIA|AGPA|AIDA|ANPA|AROA|AIPA)[A-Z0-9]{16}\b")
-                .expect("aws_access_key regex compiles"),
-        },
-        // GitLab personal access token.
-        NamedPattern {
-            name: "gitlab_token",
-            regex: Regex::new(r"\bglpat-[A-Za-z0-9_-]{20,255}\b")
-                .expect("gitlab_token regex compiles"),
-        },
-        // npm access token.
-        NamedPattern {
-            name: "npm_token",
-            regex: Regex::new(r"\bnpm_[A-Za-z0-9]{36}\b").expect("npm_token regex compiles"),
-        },
-        // OpenAI / Anthropic-style sk- keys (long, project, etc).
-        NamedPattern {
-            name: "openai_key",
-            regex: Regex::new(r"\bsk-[A-Za-z0-9_-]{20,255}\b").expect("openai_key regex compiles"),
-        },
-        // Stripe live/test keys.
-        NamedPattern {
-            name: "stripe_key",
-            regex: Regex::new(r"\b(?:rk|sk)_(?:live|test)_[0-9A-Za-z]{16,255}\b")
-                .expect("stripe_key regex compiles"),
-        },
-        // `Authorization: Bearer <token>` header form as well as
-        // bare `Bearer xyz` substrings in free text.
-        NamedPattern {
-            name: "bearer_token",
-            regex: Regex::new(r"(?i)\bBearer\s+[A-Za-z0-9._\-+/=]{12,}")
-                .expect("bearer_token regex compiles"),
-        },
-    ]
+    DEFAULT_SECRET_PATTERN_SPECS
+        .iter()
+        .map(|spec| NamedPattern {
+            name: spec.redaction_name,
+            regex: Regex::new(spec.regex).unwrap_or_else(|error| {
+                panic!("invalid {} secret regex: {error}", spec.redaction_name)
+            }),
+        })
+        .collect()
 });
 
 thread_local! {
@@ -411,6 +356,16 @@ mod tests {
     }
 
     #[test]
+    fn replaces_private_key_blocks() {
+        run_clean();
+        let input =
+            "-----BEGIN OPENSSH PRIVATE KEY-----\nsecret-material\n-----END OPENSSH PRIVATE KEY-----";
+        let out = scan_secret_patterns(input, crate::redact::REDACTED_PLACEHOLDER);
+        assert!(out.contains("<redacted:private_key_block:"));
+        assert!(!out.contains("secret-material"));
+    }
+
+    #[test]
     fn custom_pattern_redacts_and_is_introspectable() {
         run_clean();
         register_custom_pattern("acme_token", r"\bACME-[A-Z0-9]{8}\b").unwrap();
@@ -485,6 +440,7 @@ mod tests {
         assert!(names.contains(&"github_pat_fine"));
         assert!(names.contains(&"slack_token"));
         assert!(names.contains(&"aws_access_key"));
+        assert!(names.contains(&"private_key_block"));
         assert!(names.contains(&"bearer_token"));
     }
 }

--- a/crates/harn-vm/src/secret_patterns.rs
+++ b/crates/harn-vm/src/secret_patterns.rs
@@ -1,0 +1,90 @@
+/// Shared high-confidence secret pattern catalog used by both redaction
+/// and the `secret_scan` builtin.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct SecretPatternSpec {
+    pub redaction_name: &'static str,
+    pub detector: &'static str,
+    pub source: &'static str,
+    pub title: &'static str,
+    pub regex: &'static str,
+}
+
+pub(crate) const DEFAULT_SECRET_PATTERN_SPECS: &[SecretPatternSpec] = &[
+    SecretPatternSpec {
+        redaction_name: "jwt",
+        detector: "jwt-token",
+        source: "harn-redaction",
+        title: "JWT token",
+        regex: r"\beyJ[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]{4,}\b",
+    },
+    SecretPatternSpec {
+        redaction_name: "github_token",
+        detector: "github-token",
+        source: "gitleaks",
+        title: "GitHub token",
+        regex: r"\bgh[pousr]_[A-Za-z0-9]{36,255}\b",
+    },
+    SecretPatternSpec {
+        redaction_name: "github_pat_fine",
+        detector: "github-fine-grained-token",
+        source: "gitleaks",
+        title: "GitHub fine-grained personal access token",
+        regex: r"\bgithub_pat_[A-Za-z0-9_]{20,255}\b",
+    },
+    SecretPatternSpec {
+        redaction_name: "slack_token",
+        detector: "slack-token",
+        source: "trufflehog",
+        title: "Slack token",
+        regex: r"\bxox[abprs]-[A-Za-z0-9-]{10,255}\b",
+    },
+    SecretPatternSpec {
+        redaction_name: "aws_access_key",
+        detector: "aws-access-key-id",
+        source: "gitleaks",
+        title: "AWS access key id",
+        regex: r"\b(?:AKIA|ASIA|AGPA|AIDA|ANPA|AROA|AIPA)[A-Z0-9]{16}\b",
+    },
+    SecretPatternSpec {
+        redaction_name: "gitlab_token",
+        detector: "gitlab-token",
+        source: "detect-secrets",
+        title: "GitLab personal access token",
+        regex: r"\bglpat-[A-Za-z0-9_-]{20,255}\b",
+    },
+    SecretPatternSpec {
+        redaction_name: "npm_token",
+        detector: "npm-token",
+        source: "detect-secrets",
+        title: "npm access token",
+        regex: r"\bnpm_[A-Za-z0-9]{36}\b",
+    },
+    SecretPatternSpec {
+        redaction_name: "openai_key",
+        detector: "openai-api-key",
+        source: "detect-secrets",
+        title: "OpenAI API key",
+        regex: r"\bsk-[A-Za-z0-9_-]{20,255}\b",
+    },
+    SecretPatternSpec {
+        redaction_name: "stripe_key",
+        detector: "stripe-secret-key",
+        source: "trufflehog",
+        title: "Stripe secret or restricted key",
+        regex: r"\b(?:rk|sk)_(?:live|test)_[0-9A-Za-z]{16,255}\b",
+    },
+    SecretPatternSpec {
+        redaction_name: "private_key_block",
+        detector: "private-key-block",
+        source: "detect-secrets",
+        title: "Private key block",
+        regex: r"(?s)-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----",
+    },
+    SecretPatternSpec {
+        redaction_name: "bearer_token",
+        detector: "bearer-token",
+        source: "harn-redaction",
+        title: "Bearer token",
+        regex: r"(?i)\bBearer\s+[A-Za-z0-9._\-+/=]{12,}",
+    },
+];

--- a/crates/harn-vm/src/stdlib/secret_scan.rs
+++ b/crates/harn-vm/src/stdlib/secret_scan.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use sha2::Digest;
 
 use crate::event_log::{active_event_log, EventLog, LogEvent, Topic};
+use crate::secret_patterns::{SecretPatternSpec, DEFAULT_SECRET_PATTERN_SPECS};
 use crate::value::{VmError, VmValue};
 use crate::vm::Vm;
 
@@ -27,69 +28,20 @@ pub struct SecretFinding {
 }
 
 struct SecretRule {
-    detector: &'static str,
-    source: &'static str,
-    title: &'static str,
+    spec: &'static SecretPatternSpec,
     regex: Regex,
 }
 
 static SECRET_RULES: LazyLock<Vec<SecretRule>> = LazyLock::new(|| {
-    vec![
-        SecretRule {
-            detector: "aws-access-key-id",
-            source: "gitleaks",
-            title: "AWS access key id",
-            regex: Regex::new(r"\b(?:AKIA|ASIA|AGPA|AIDA|ANPA|AROA|AIPA)[A-Z0-9]{16}\b").unwrap(),
-        },
-        SecretRule {
-            detector: "github-token",
-            source: "gitleaks",
-            title: "GitHub token",
-            regex: Regex::new(r"\bgh(?:p|o|u|s|r)_[A-Za-z0-9]{36,255}\b").unwrap(),
-        },
-        SecretRule {
-            detector: "github-fine-grained-token",
-            source: "gitleaks",
-            title: "GitHub fine-grained personal access token",
-            regex: Regex::new(r"\bgithub_pat_[A-Za-z0-9_]{20,255}\b").unwrap(),
-        },
-        SecretRule {
-            detector: "gitlab-token",
-            source: "detect-secrets",
-            title: "GitLab personal access token",
-            regex: Regex::new(r"\bglpat-[A-Za-z0-9_-]{20,255}\b").unwrap(),
-        },
-        SecretRule {
-            detector: "npm-token",
-            source: "detect-secrets",
-            title: "npm access token",
-            regex: Regex::new(r"\bnpm_[A-Za-z0-9]{36}\b").unwrap(),
-        },
-        SecretRule {
-            detector: "openai-api-key",
-            source: "detect-secrets",
-            title: "OpenAI API key",
-            regex: Regex::new(r"\bsk-[A-Za-z0-9_-]{20,255}\b").unwrap(),
-        },
-        SecretRule {
-            detector: "slack-token",
-            source: "trufflehog",
-            title: "Slack token",
-            regex: Regex::new(r"\bxox(?:a|b|p|r|s)-[A-Za-z0-9-]{10,255}\b").unwrap(),
-        },
-        SecretRule {
-            detector: "stripe-secret-key",
-            source: "trufflehog",
-            title: "Stripe secret or restricted key",
-            regex: Regex::new(r"\b(?:rk|sk)_(?:live|test)_[0-9A-Za-z]{16,255}\b").unwrap(),
-        },
-        SecretRule {
-            detector: "private-key-block",
-            source: "detect-secrets",
-            title: "Private key block",
-            regex: Regex::new(r"(?m)^-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----$").unwrap(),
-        },
-    ]
+    DEFAULT_SECRET_PATTERN_SPECS
+        .iter()
+        .map(|spec| SecretRule {
+            spec,
+            regex: Regex::new(spec.regex).unwrap_or_else(|error| {
+                panic!("invalid {} secret scan regex: {error}", spec.detector)
+            }),
+        })
+        .collect()
 });
 
 static HIGH_ENTROPY_ASSIGNMENT_RULE: LazyLock<Regex> = LazyLock::new(|| {
@@ -108,9 +60,9 @@ pub fn scan_content(content: &str) -> Vec<SecretFinding> {
             findings.push(build_finding(
                 content,
                 &line_starts,
-                rule.detector,
-                rule.source,
-                rule.title,
+                rule.spec.detector,
+                rule.spec.source,
+                rule.spec.title,
                 mat.start(),
                 mat.end(),
                 mat.as_str(),
@@ -384,9 +336,27 @@ config = { client_secret: "QWxhZGRpbjpPcGVuU2VzYW1lQWNjZXNzVG9rZW4=" }
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].detector, "private-key-block");
         assert_eq!(
+            findings[0].end_offset - findings[0].start_offset,
+            "-----BEGIN OPENSSH PRIVATE KEY-----\nZXhhbXBsZQ==\n-----END OPENSSH PRIVATE KEY-----"
+                .len()
+        );
+        assert_eq!(
             findings[0].redacted,
             "-----BEGIN OPENSSH PRIVATE KEY----- …"
         );
+    }
+
+    #[test]
+    fn scan_content_covers_redaction_only_token_shapes() {
+        let findings = scan_content(
+            "Authorization: Bearer abcDEFghi123_-+/=xyz\njwt=eyJabcd.eyJefgh.signature_pad\n",
+        );
+        let detectors = findings
+            .iter()
+            .map(|finding| finding.detector.as_str())
+            .collect::<BTreeSet<_>>();
+        assert!(detectors.contains("bearer-token"));
+        assert!(detectors.contains("jwt-token"));
     }
 
     #[tokio::test(flavor = "current_thread")]


### PR DESCRIPTION
## Summary
- centralize the high-confidence secret regex catalog shared by token redaction and `secret_scan`
- add missing JWT, Bearer token, and full private-key block coverage to `secret_scan` and default string redaction
- run provider HTTP error summaries through the shared free-form secret scanner after key/value redaction

## Root Cause
`secret_scan` and runtime redaction carried separate regex lists, so documented coverage drifted and private-key blocks were only partially detected by scanning while not being scrubbed by the default string scanner. Provider error summaries had a third sanitization path that missed the shared token shapes.

## Verification
- `cargo test -p harn-vm secret_scan`
- `cargo test -p harn-vm redact::patterns::tests`
- `cargo test -p harn-vm provider_http_errors`
- `cargo clippy --workspace --all-targets`
- `make lint-test-patterns`
- `make test`
- pre-commit and pre-push hooks