### PR TITLE
[codex] Validate workflow iteration budgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ condensed series summaries instead of full per-patch history.
   same high-confidence secret patterns. JWTs, Bearer tokens, and full private
   key blocks are consistently reported or scrubbed instead of drifting across
   runtime surfaces.
+- **Agent-loop iteration budgets now reject invalid numeric fields.**
+  Explicit `max_iterations`, `iteration_budget.initial`,
+  `iteration_budget.max`, and adaptive `iteration_budget.extend_by` values must
+  be positive integers, and `iteration_budget.initial` cannot exceed
+  `iteration_budget.max`. Invalid workflow stage budgets now fail with a clear
+  `agent_loop` diagnostic before any provider call.
 
 ## v0.8.34
 

--- a/conformance/tests/agents/workflow_stage_options_iteration_budget.expected
+++ b/conformance/tests/agents/workflow_stage_options_iteration_budget.expected
@@ -6,3 +6,5 @@ adaptive
 40
 string
 adaptive
+true
+true

--- a/conformance/tests/agents/workflow_stage_options_iteration_budget.harn
+++ b/conformance/tests/agents/workflow_stage_options_iteration_budget.harn
@@ -1,9 +1,14 @@
-// Regression test for iteration_budget passing through workflow stage
-// options. Without this, `workflow_stage_agent_options` silently strips
-// `model_policy.iteration_budget` because it isn't in the `loop_option_keys`
-// list, leaving the per-stage agent_loop with the static `max_iterations`
-// default and no adaptive `loop_control` policy.
 import { workflow_stage_agent_options } from "std/workflow/options"
+
+fn print_budget_error(options: dict, expected: string) {
+  let result = try {
+    agent_loop("budget validation probe", nil, options)
+    "no_error"
+  } catch (e) {
+    to_string(e)
+  }
+  __io_println(contains(result, expected))
+}
 
 pipeline default() {
   let opts = workflow_stage_agent_options(
@@ -25,13 +30,9 @@ pipeline default() {
   __io_println(budget?.initial)
   __io_println(budget?.max)
   __io_println(budget?.extend_by)
-  // The static cap remains so older agent_loop paths that haven't moved
-  // to iteration_budget still see a bound.
+  // Keep the scalar cap visible for tooling that summarizes loop limits
+  // without interpreting the structured budget.
   __io_println(opts.agent_loop_options?.max_iterations)
-  // String-form sugar should also propagate verbatim — `agent_preset`
-  // applies its kind-specific defaults and produces a dict, but callers
-  // that pass a literal "adaptive" / "fixed" still survive the
-  // round-trip without coercion.
   let sugar = workflow_stage_agent_options(
     {
       mode: "agent",
@@ -42,4 +43,28 @@ pipeline default() {
   )
   __io_println(type_of(sugar.agent_loop_options?.iteration_budget))
   __io_println(sugar.agent_loop_options?.iteration_budget)
+  let invalid_mode = workflow_stage_agent_options(
+    {
+      mode: "agent",
+      has_tools: true,
+      model_policy: {provider: "mock", iteration_budget: {mode: "unbounded", max: 4}},
+      host: {default_tool_format: "native"},
+    },
+  )
+  print_budget_error(
+    invalid_mode.agent_loop_options,
+    "agent_loop: iteration_budget.mode must be \"fixed\" or \"adaptive\"",
+  )
+  let invalid_max = workflow_stage_agent_options(
+    {
+      mode: "agent",
+      has_tools: true,
+      model_policy: {provider: "mock", iteration_budget: {mode: "adaptive", initial: 1, max: 0}},
+      host: {default_tool_format: "native"},
+    },
+  )
+  print_budget_error(
+    invalid_max.agent_loop_options,
+    "agent_loop: `iteration_budget.max` must be a positive integer; got 0",
+  )
 }

--- a/crates/harn-stdlib/src/stdlib/agent/options.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/options.harn
@@ -201,15 +201,15 @@ fn __validate_done_judge_cadence(value) {
   }
 }
 
-fn __positive_int_default(value, fallback) {
+fn __positive_int_budget_field(value, fallback, label) {
   if value == nil {
     return fallback
   }
   if type_of(value) != "int" {
-    throw "agent_loop: iteration_budget numeric fields must be integers; got " + type_of(value)
+    throw "agent_loop: `" + label + "` must be a positive integer; got " + type_of(value)
   }
   if value < 1 {
-    return fallback
+    throw "agent_loop: `" + label + "` must be a positive integer; got " + to_string(value)
   }
   return value
 }
@@ -324,7 +324,7 @@ fn __normalize_iteration_budget(opts) {
     raw
   }
   if user_budget == nil {
-    let cap = __positive_int_default(legacy, 50)
+    let cap = __positive_int_budget_field(legacy, 50, "max_iterations")
     return {mode: "fixed", initial: cap, max: cap, extend_by: 0, expose_decisions: false}
   }
   if type_of(user_budget) != "dict" {
@@ -337,7 +337,7 @@ fn __normalize_iteration_budget(opts) {
       + to_string(mode)
   }
   let legacy_cap = if legacy != nil {
-    __positive_int_default(legacy, 50)
+    __positive_int_budget_field(legacy, 50, "max_iterations")
   } else {
     nil
   }
@@ -348,7 +348,7 @@ fn __normalize_iteration_budget(opts) {
   } else {
     50
   }
-  let max_cap = __positive_int_default(user_budget?.max, max_default)
+  let max_cap = __positive_int_budget_field(user_budget?.max, max_default, "iteration_budget.max")
   let initial_default = if mode == "adaptive" {
     let candidate = max_cap / 4
     if candidate < 1 {
@@ -359,16 +359,23 @@ fn __normalize_iteration_budget(opts) {
   } else {
     max_cap
   }
-  var initial = __positive_int_default(user_budget?.initial, initial_default)
+  let initial = __positive_int_budget_field(user_budget?.initial, initial_default, "iteration_budget.initial")
   if initial > max_cap {
-    initial = max_cap
+    throw "agent_loop: `iteration_budget.initial` must be less than or equal to `iteration_budget.max`; got initial="
+      + to_string(initial)
+      + ", max="
+      + to_string(max_cap)
   }
   let extend_by = if mode == "adaptive" {
-    __positive_int_default(user_budget?.extend_by, 2)
+    __positive_int_budget_field(user_budget?.extend_by, 2, "iteration_budget.extend_by")
   } else {
     0
   }
   let expose_decisions = if user_budget?.expose_decisions != nil {
+    if type_of(user_budget.expose_decisions) != "bool" {
+      throw "agent_loop: `iteration_budget.expose_decisions` must be a bool; got "
+        + type_of(user_budget.expose_decisions)
+    }
     user_budget.expose_decisions
   } else {
     mode == "adaptive"

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -1686,6 +1686,14 @@ override the profile:
 | `verifier` | 5 | 0 | 0 | 2 | 3 |
 | `completer` | 1 | 0 | 0 | 2 | 0 |
 
+Use `iteration_budget: {mode, initial, max, extend_by}` when a loop should
+start with a small cap and extend only while making progress. `max_iterations`
+is equivalent to a fixed budget; if both are present, `iteration_budget.max`
+wins. Explicit `max_iterations`, `initial`, `max`, and adaptive `extend_by`
+values must be positive integers, and `initial <= max`. Workflow stage
+`model_policy` accepts the same `iteration_budget` shape and passes it through
+to the per-stage `agent_loop`.
+
 Pass `stop_after_successful_tools: ["name", ...]` to terminate the loop
 the moment any of those tools is dispatched successfully. Same shape as
 Vercel AI SDK's `stopWhen: hasToolCall(name)` and OpenAI Agents SDK's

--- a/docs/src/llm/agent_loop.md
+++ b/docs/src/llm/agent_loop.md
@@ -385,6 +385,9 @@ Fields:
 `max_iterations: N` and `iteration_budget: {mode: "fixed", initial: N, max: N}`
 are equivalent. Passing both `iteration_budget` and `max_iterations` is allowed;
 the budget's `max` wins for the host's autonomy/ACP tracking.
+Explicit `max_iterations`, `initial`, `max`, and adaptive `extend_by` values
+must be positive integers, and `initial` must be less than or equal to `max`;
+invalid fields raise an `agent_loop` error before the first provider call.
 
 ### loop_control policy
 

--- a/docs/src/workflow-runtime.md
+++ b/docs/src/workflow-runtime.md
@@ -197,6 +197,13 @@ log(run.path)
 log(run.run.stages)
 ```
 
+Agent-backed stages pass `model_policy.iteration_budget` directly into the
+per-stage `agent_loop`. Treat that structured budget as the source of truth for
+adaptive or fixed loop limits; scripts no longer need to copy that cap into
+`max_iterations`. `max_iterations` remains accepted as a scalar fixed cap, and
+when both fields are present `iteration_budget.max` is the cap used by the agent
+loop. Invalid budget fields fail at loop startup instead of being ignored.
+
 `verify` nodes can also run deterministic checks without an LLM loop:
 
 ```harn,ignore


### PR DESCRIPTION
## Summary
- reject explicit non-positive agent-loop budget fields instead of silently defaulting them
- extend workflow-stage budget conformance coverage to assert invalid budgets fail before provider calls
- document workflow migration guidance for using model_policy.iteration_budget directly

Closes #2194.

## Verification
- cargo run --quiet --bin harn -- test conformance --filter workflow_stage_options_iteration_budget
- cargo run --quiet --bin harn -- test conformance --filter agent_loop_adaptive_budget
- cargo run --quiet --bin harn -- test conformance --filter agent_preset_options
- cargo run --quiet --bin harn -- test conformance --filter workflow_stage_options
- make fmt-harn
- make lint-harn
- make lint-test-patterns
- make check-docs-snippets
- cargo test -p harn-vm iteration_budget
- cargo test -p harn-vm orchestration
- make test