### PR TITLE
[codex] Fix stdlib polish issues

### DIFF
--- a/conformance/tests/stdlib/csv_builtins.harn
+++ b/conformance/tests/stdlib/csv_builtins.harn
@@ -16,4 +16,14 @@ pipeline test(task) {
   // round-trip list rows
   let listy = csv_stringify([["a", "b"], ["c", "d"]])
   log(listy)
+  let multi_delimiter = try {
+    csv_parse("a||b\n", {delimiter: "||"})
+  }
+  assert(is_err(multi_delimiter))
+  assert(contains(to_string(unwrap_err(multi_delimiter)), "exactly one ASCII"))
+  let unicode_delimiter = try {
+    csv_stringify([["a", "b"]], {delimiter: "é"})
+  }
+  assert(is_err(unicode_delimiter))
+  assert(contains(to_string(unwrap_err(unicode_delimiter)), "exactly one ASCII"))
 }

--- a/crates/harn-cli/src/commands/portal/dlq.rs
+++ b/crates/harn-cli/src/commands/portal/dlq.rs
@@ -229,36 +229,45 @@ pub(super) async fn bulk_purge(
     let entries = select_bulk_entries(state, request).await?;
     let dry_run = request.dry_run.unwrap_or(false);
     let rate_limit_per_second = sanitize_rate_limit(request.rate_limit_per_second);
+    let matched_count = entries.len();
+    if dry_run {
+        return Ok(PortalDlqBulkResponse {
+            operation: "purge".to_string(),
+            dry_run,
+            matched_count,
+            accepted_count: 0,
+            skipped_count: matched_count,
+            rate_limit_per_second,
+            jobs: Vec::new(),
+            entries: entries.into_iter().map(redacted_dlq_entry).collect(),
+        });
+    }
+
     let mut purged = Vec::new();
-    if !dry_run {
-        let total = entries.len();
-        for (index, mut entry) in entries.clone().into_iter().enumerate() {
-            entry.state = "discarded".to_string();
-            entry.attempt_history.push(PortalDlqAttempt {
-                attempt: entry.attempt_history.len() as u32 + 1,
-                at: now_rfc3339(),
-                status: "discarded".to_string(),
-                error: None,
-            });
-            append_portal_entry(state, &entry, "dlq_entry").await?;
-            purged.push(entry);
-            if index + 1 < total {
-                tokio::time::sleep(Duration::from_secs_f64(1.0 / rate_limit_per_second)).await;
-            }
+    let total = matched_count;
+    for (index, mut entry) in entries.into_iter().enumerate() {
+        entry.state = "discarded".to_string();
+        entry.attempt_history.push(PortalDlqAttempt {
+            attempt: entry.attempt_history.len() as u32 + 1,
+            at: now_rfc3339(),
+            status: "discarded".to_string(),
+            error: None,
+        });
+        append_portal_entry(state, &entry, "dlq_entry").await?;
+        purged.push(entry);
+        if index + 1 < total {
+            tokio::time::sleep(Duration::from_secs_f64(1.0 / rate_limit_per_second)).await;
         }
     }
     Ok(PortalDlqBulkResponse {
         operation: "purge".to_string(),
         dry_run,
-        matched_count: entries.len(),
-        accepted_count: if dry_run { 0 } else { purged.len() },
-        skipped_count: if dry_run { entries.len() } else { 0 },
+        matched_count,
+        accepted_count: purged.len(),
+        skipped_count: 0,
         rate_limit_per_second,
         jobs: Vec::new(),
-        entries: if dry_run { entries } else { purged }
-            .into_iter()
-            .map(redacted_dlq_entry)
-            .collect(),
+        entries: purged.into_iter().map(redacted_dlq_entry).collect(),
     })
 }
 
@@ -802,7 +811,7 @@ fn parse_time_ms(raw: &str) -> Result<i64, String> {
 fn parse_time_ms_ok(raw: &str) -> Option<i64> {
     OffsetDateTime::parse(raw, &Rfc3339)
         .ok()
-        .map(|time| time.unix_timestamp().saturating_mul(1000))
+        .and_then(|time| i64::try_from(time.unix_timestamp_nanos() / 1_000_000).ok())
 }
 
 fn now_rfc3339() -> String {
@@ -886,5 +895,13 @@ mod tests {
         )
         .unwrap();
         assert_eq!(filtered.len(), 1);
+    }
+
+    #[test]
+    fn parse_time_ms_preserves_rfc3339_milliseconds() {
+        assert_eq!(
+            parse_time_ms("2026-04-24T10:00:00.123Z").unwrap(),
+            1_777_024_800_123
+        );
     }
 }

--- a/crates/harn-vm/src/stdlib/csv.rs
+++ b/crates/harn-vm/src/stdlib/csv.rs
@@ -20,12 +20,27 @@ fn opt_bool(opts: Option<&BTreeMap<String, VmValue>>, key: &str, default: bool) 
     .unwrap_or(default)
 }
 
-fn opt_char(opts: Option<&BTreeMap<String, VmValue>>, key: &str, default: u8) -> u8 {
-    opts.and_then(|d| match d.get(key) {
-        Some(VmValue::String(s)) if !s.is_empty() => Some(s.as_bytes()[0]),
-        _ => None,
-    })
-    .unwrap_or(default)
+fn opt_delimiter(
+    opts: Option<&BTreeMap<String, VmValue>>,
+    key: &str,
+    default: u8,
+    builtin: &str,
+) -> Result<u8, VmError> {
+    let Some(value) = opts.and_then(|d| d.get(key)) else {
+        return Ok(default);
+    };
+    let VmValue::String(raw) = value else {
+        return Err(VmError::Thrown(VmValue::String(Rc::from(format!(
+            "{builtin}: {key} must be a string"
+        )))));
+    };
+    let bytes = raw.as_bytes();
+    if bytes.len() != 1 || !bytes[0].is_ascii() {
+        return Err(VmError::Thrown(VmValue::String(Rc::from(format!(
+            "{builtin}: {key} must be exactly one ASCII character"
+        )))));
+    }
+    Ok(bytes[0])
 }
 
 pub(crate) fn register_csv_builtins(vm: &mut Vm) {
@@ -36,7 +51,7 @@ pub(crate) fn register_csv_builtins(vm: &mut Vm) {
             _ => None,
         });
         let has_headers = opt_bool(opts, "headers", false);
-        let delimiter = opt_char(opts, "delimiter", b',');
+        let delimiter = opt_delimiter(opts, "delimiter", b',', "csv_parse")?;
 
         let mut reader = csv::ReaderBuilder::new()
             .has_headers(has_headers)
@@ -89,7 +104,7 @@ pub(crate) fn register_csv_builtins(vm: &mut Vm) {
             _ => None,
         });
         let want_headers = opt_bool(opts, "headers", false);
-        let delimiter = opt_char(opts, "delimiter", b',');
+        let delimiter = opt_delimiter(opts, "delimiter", b',', "csv_stringify")?;
 
         let mut wtr = csv::WriterBuilder::new()
             .delimiter(delimiter)
@@ -145,8 +160,69 @@ pub(crate) fn register_csv_builtins(vm: &mut Vm) {
         let bytes = wtr.into_inner().map_err(|e| {
             VmError::Thrown(VmValue::String(Rc::from(format!("csv_stringify: {e}"))))
         })?;
-        Ok(VmValue::String(Rc::from(
-            String::from_utf8(bytes).unwrap_or_default(),
-        )))
+        String::from_utf8(bytes)
+            .map(|text| VmValue::String(Rc::from(text)))
+            .map_err(|error| {
+                VmError::Thrown(VmValue::String(Rc::from(format!("csv_stringify: {error}"))))
+            })
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn vm() -> Vm {
+        let mut vm = Vm::new();
+        register_csv_builtins(&mut vm);
+        vm
+    }
+
+    fn call(vm: &mut Vm, name: &str, args: Vec<VmValue>) -> Result<VmValue, VmError> {
+        let f = vm.builtins.get(name).unwrap().clone();
+        let mut out = String::new();
+        f(&args, &mut out)
+    }
+
+    fn string(value: &str) -> VmValue {
+        VmValue::String(Rc::from(value))
+    }
+
+    fn list(items: Vec<VmValue>) -> VmValue {
+        VmValue::List(Rc::new(items))
+    }
+
+    fn dict(items: impl IntoIterator<Item = (&'static str, VmValue)>) -> VmValue {
+        VmValue::Dict(Rc::new(
+            items
+                .into_iter()
+                .map(|(key, value)| (key.to_string(), value))
+                .collect(),
+        ))
+    }
+
+    #[test]
+    fn csv_stringify_rejects_non_ascii_delimiter() {
+        let mut vm = vm();
+        let rows = list(vec![list(vec![string("a"), string("b")])]);
+        let options = dict([("delimiter", string("é"))]);
+        let error = call(&mut vm, "csv_stringify", vec![rows, options])
+            .expect_err("delimiter must be a single ASCII byte");
+        assert!(
+            error.to_string().contains("delimiter"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn csv_parse_rejects_multi_character_delimiter() {
+        let mut vm = vm();
+        let options = dict([("delimiter", string("||"))]);
+        let error = call(&mut vm, "csv_parse", vec![string("a||b\n"), options])
+            .expect_err("delimiter must be one character");
+        assert!(
+            error.to_string().contains("exactly one ASCII"),
+            "unexpected error: {error}"
+        );
+    }
 }

--- a/crates/harn-vm/src/stdlib/math.rs
+++ b/crates/harn-vm/src/stdlib/math.rs
@@ -245,52 +245,15 @@ pub(crate) fn register_math_builtins(vm: &mut Vm) {
     vm.register_builtin("variance", |args, _out| {
         let values = non_empty_numeric_list_arg(args, "variance")?;
         let sample = args.get(1).is_some_and(VmValue::is_truthy);
-        if sample && values.len() < 2 {
-            return Err(VmError::Runtime(
-                "sample variance requires at least 2 values".to_string(),
-            ));
-        }
-        let mean = values.iter().sum::<f64>() / values.len() as f64;
-        let total = values
-            .iter()
-            .map(|value| {
-                let delta = value - mean;
-                delta * delta
-            })
-            .sum::<f64>();
-        let denom = if sample {
-            values.len() - 1
-        } else {
-            values.len()
-        };
-        Ok(VmValue::Float(total / denom as f64))
+        Ok(VmValue::Float(variance_for(&values, sample, "variance")?))
     });
 
     vm.register_builtin("stddev", |args, _out| {
-        let variance = {
-            let values = non_empty_numeric_list_arg(args, "stddev")?;
-            let sample = args.get(1).is_some_and(VmValue::is_truthy);
-            if sample && values.len() < 2 {
-                return Err(VmError::Runtime(
-                    "sample variance requires at least 2 values".to_string(),
-                ));
-            }
-            let mean = values.iter().sum::<f64>() / values.len() as f64;
-            let total = values
-                .iter()
-                .map(|value| {
-                    let delta = value - mean;
-                    delta * delta
-                })
-                .sum::<f64>();
-            let denom = if sample {
-                values.len() - 1
-            } else {
-                values.len()
-            };
-            total / denom as f64
-        };
-        Ok(VmValue::Float(variance.sqrt()))
+        let values = non_empty_numeric_list_arg(args, "stddev")?;
+        let sample = args.get(1).is_some_and(VmValue::is_truthy);
+        Ok(VmValue::Float(
+            variance_for(&values, sample, "stddev")?.sqrt(),
+        ))
     });
 
     register_unary_float(vm, "sin", f64::sin);
@@ -429,6 +392,28 @@ fn non_empty_numeric_list_arg(args: &[VmValue], label: &str) -> Result<Vec<f64>,
     Ok(values)
 }
 
+fn variance_for(values: &[f64], sample: bool, label: &str) -> Result<f64, VmError> {
+    if sample && values.len() < 2 {
+        return Err(VmError::Runtime(format!(
+            "sample {label} requires at least 2 values"
+        )));
+    }
+    let mean = values.iter().sum::<f64>() / values.len() as f64;
+    let total = values
+        .iter()
+        .map(|value| {
+            let delta = value - mean;
+            delta * delta
+        })
+        .sum::<f64>();
+    let denom = if sample {
+        values.len() - 1
+    } else {
+        values.len()
+    };
+    Ok(total / denom as f64)
+}
+
 fn finite_float_to_i64(n: f64) -> Result<i64, VmError> {
     if !n.is_finite() {
         return Err(VmError::Runtime(
@@ -491,5 +476,14 @@ mod tests {
         let error = call(&mut vm, "floor", vec![VmValue::Float(f64::INFINITY)])
             .expect_err("infinite float cannot become int");
         assert!(error.to_string().contains("non-finite"));
+    }
+
+    #[test]
+    fn stddev_sample_error_names_stddev() {
+        let mut vm = vm();
+        let values = VmValue::List(Rc::new(vec![VmValue::Int(1)]));
+        let error = call(&mut vm, "stddev", vec![values, VmValue::Bool(true)])
+            .expect_err("sample stddev needs at least two values");
+        assert!(error.to_string().contains("sample stddev"));
     }
 }

--- a/crates/harn-vm/src/stdlib/path.rs
+++ b/crates/harn-vm/src/stdlib/path.rs
@@ -9,7 +9,7 @@
 use std::collections::BTreeMap;
 use std::rc::Rc;
 
-use crate::value::{VmError, VmValue};
+use crate::value::VmValue;
 use crate::vm::Vm;
 use crate::workspace_path::{classify_workspace_path, normalize_workspace_path, WorkspacePathInfo};
 
@@ -363,9 +363,6 @@ pub(crate) fn register_path_helper_builtins(vm: &mut Vm) {
                 .collect(),
         )))
     });
-
-    // Silence unused-import warnings if VmError becomes unused in a future refactor.
-    let _ = std::marker::PhantomData::<VmError>;
 }
 
 #[cfg(test)]

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -2310,9 +2310,10 @@ csv_stringify([{name: "alice", age: 30}], {headers: true})
 // → "age,name\n30,alice\n"
 ```
 
-Options: `headers: bool` (default false), `delimiter: ","`. Without
-headers, `csv_parse` returns list-of-lists; with headers, list of
-dicts (keys are sorted on stringify for determinism).
+Options: `headers: bool` (default false), `delimiter: ","` as one
+ASCII character. Without headers, `csv_parse` returns list-of-lists;
+with headers, list of dicts (keys are sorted on stringify for
+determinism).
 
 ### URL parsing
 


### PR DESCRIPTION
## Summary
- validate CSV delimiters as exactly one ASCII character and report CSV writer UTF-8 failures instead of returning an empty string
- preserve RFC3339 millisecond precision in portal DLQ timestamp filters and avoid cloning bulk-purge entries
- share variance/stddev calculation logic and remove a path stdlib import/comment hack

## Tests
- `CARGO_TARGET_DIR=/tmp/harn-target-a02c-polish cargo test -p harn-vm stdlib::csv::tests --lib`
- `CARGO_TARGET_DIR=/tmp/harn-target-a02c-polish cargo test -p harn-vm stdlib::math::tests --lib`
- `CARGO_TARGET_DIR=/tmp/harn-target-a02c-polish cargo test -p harn-cli commands::portal::dlq::tests --lib`
- `CARGO_TARGET_DIR=/tmp/harn-target-a02c-polish cargo run --quiet --bin harn -- test conformance --filter csv_builtins`
- `CARGO_TARGET_DIR=/tmp/harn-target-a02c-polish cargo run --quiet --bin harn -- lint conformance/tests/stdlib/csv_builtins.harn`
- `make lint-test-patterns`
- pre-commit hook