### PR TITLE
Add native Gemini tool and schema support

### DIFF
--- a/conformance/tests/integration/gemini_native_tool_calls_agent_loop.expected
+++ b/conformance/tests/integration/gemini_native_tool_calls_agent_loop.expected
@@ -1,0 +1,3 @@
+done
+1
+true

--- a/conformance/tests/integration/gemini_native_tool_calls_agent_loop.harn
+++ b/conformance/tests/integration/gemini_native_tool_calls_agent_loop.harn
@@ -1,0 +1,84 @@
+/**
+ * Mocked Gemini-native tool calls should drive normal agent_loop dispatch.
+ *
+ * The mock provider resolves capability rows from the requested model, so
+ * `provider: "mock"` plus a Gemini model exercises Gemini-shaped conversation
+ * history while staying deterministic.
+ */
+let lookups = atomic(0)
+
+fn lookup_tools() {
+  let registry = tool_registry()
+  return tool_define(
+    registry,
+    "lookup",
+    "Lookup a deterministic answer",
+    {
+      parameters: {query: {type: "string"}},
+      handler: { args ->
+        atomic_add(lookups, 1)
+        return {answer: "found:" + to_string(args.query)}
+      },
+    },
+  )
+}
+
+pipeline test(task) {
+  llm_mock_clear()
+  atomic_set(lookups, 0)
+  llm_mock(
+    {
+      provider: "mock",
+      model: "gemini-2.5-flash",
+      text: "checking",
+      tool_calls: [
+        {
+          id: "gemini_call_1",
+          name: "lookup",
+          arguments: {query: "harn"},
+          thought_signature: "opaque-gemini-signature",
+        },
+      ],
+      blocks: [
+        {type: "output_text", text: "checking", visibility: "public"},
+        {
+          type: "tool_call",
+          id: "gemini_call_1",
+          name: "lookup",
+          arguments: {query: "harn"},
+          thought_signature: "opaque-gemini-signature",
+          visibility: "internal",
+        },
+      ],
+    },
+  )
+  llm_mock({text: "##DONE##"})
+  let result = agent_loop(
+    "Use the lookup tool.",
+    nil,
+    {
+      provider: "mock",
+      model: "gemini-2.5-flash",
+      tools: lookup_tools(),
+      tool_format: "native",
+      loop_until_done: true,
+      done_sentinel: "##DONE##",
+      max_iterations: 3,
+    },
+  )
+  assert(result.status == "done", "Gemini mock agent loop finishes")
+  assert(atomic_get(lookups) == 1, "Gemini mock tool call dispatches once")
+  let calls = llm_mock_calls()
+  assert(len(calls) == 2, "agent loop makes a follow-up model turn")
+  let followup = json_stringify(calls[1].messages)
+  assert(contains(followup, "functionCall"), "assistant history preserves Gemini functionCall")
+  assert(
+    contains(followup, "tool_call_id"),
+    "tool result keeps the Gemini call id for adapter lowering",
+  )
+  assert(contains(followup, "thoughtSignature"), "Gemini thought signature is preserved")
+  assert(contains(followup, "opaque-gemini-signature"), "signature bytes are unchanged")
+  __io_println(result.status)
+  __io_println(atomic_get(lookups))
+  __io_println(contains(followup, "functionCall"))
+}

--- a/conformance/tests/integration/provider_capabilities_basic.harn
+++ b/conformance/tests/integration/provider_capabilities_basic.harn
@@ -71,6 +71,8 @@ pipeline test(task) {
   assert(!qwen35.prefers_xml_tools, "qwen3.5 does not use XML tool wrappers")
   assert(qwen35.thinking_block_style == "inline", "qwen3.5 uses inline thinking blocks")
   let gemini = provider_capabilities("gemini", "gemini-2.5-flash")
+  assert(gemini.native_tools, "gemini native route supports function declarations")
+  assert(gemini.message_wire_format == "gemini", "gemini native route uses Gemini message parts")
   assert(gemini.vision_supported, "gemini native route accepts image content")
   assert(gemini.thinking_modes[0] == "enabled", "gemini 2.5 native route exposes typed thinking")
   assert(gemini.structured_output_mode == "native_json", "gemini prefers native JSON output")

--- a/crates/harn-vm/src/llm/agent_session_host.rs
+++ b/crates/harn-vm/src/llm/agent_session_host.rs
@@ -2303,6 +2303,17 @@ mod tests {
         ));
         assert_eq!(bedrock_claude["role"], "tool_result");
         assert_eq!(bedrock_claude["tool_use_id"], "call_003");
+
+        let gemini = vm_to_json(&tool_result_message_for_provider(
+            "gemini",
+            "gemini-2.5-flash",
+            "release_run",
+            "call_004",
+            "ok",
+        ));
+        assert_eq!(gemini["role"], "tool");
+        assert_eq!(gemini["name"], "release_run");
+        assert_eq!(gemini["tool_call_id"], "call_004");
     }
 
     #[test]

--- a/crates/harn-vm/src/llm/api/telemetry.rs
+++ b/crates/harn-vm/src/llm/api/telemetry.rs
@@ -38,6 +38,8 @@ pub mod source {
     pub const LLAMACPP_TIMINGS: &str = "llamacpp_timings";
     /// Anthropic Messages API — usage counts only; no timings.
     pub const ANTHROPIC_USAGE: &str = "anthropic_usage";
+    /// Google Gemini `usageMetadata` block from `generateContent`.
+    pub const GEMINI_USAGE: &str = "gemini_usage";
     /// Provider responded but we did not capture anything beyond what
     /// already lives on `LlmResult` (e.g. mock / fake providers, or a
     /// stream that finished without a usage frame).
@@ -238,6 +240,23 @@ impl ProviderTelemetry {
             .and_then(serde_json::Value::as_i64);
         telemetry.server_output_tokens = usage
             .get("output_tokens")
+            .and_then(serde_json::Value::as_i64);
+        if let Some(request_id) = request_id.filter(|value| !value.is_empty()) {
+            telemetry.request_id = Some(request_id.to_string());
+        }
+        telemetry
+    }
+
+    /// Extract Gemini `usageMetadata` counts. Cache-hit accounting stays on
+    /// `LlmResult`; telemetry keeps provider prompt/output counters plus the
+    /// request id for eval joins.
+    pub fn from_gemini_usage(usage: &serde_json::Value, request_id: Option<&str>) -> Self {
+        let mut telemetry = Self::new(source::GEMINI_USAGE);
+        telemetry.server_prompt_tokens = usage
+            .get("promptTokenCount")
+            .and_then(serde_json::Value::as_i64);
+        telemetry.server_output_tokens = usage
+            .get("candidatesTokenCount")
             .and_then(serde_json::Value::as_i64);
         if let Some(request_id) = request_id.filter(|value| !value.is_empty()) {
             telemetry.request_id = Some(request_id.to_string());

--- a/crates/harn-vm/src/llm/capabilities.rs
+++ b/crates/harn-vm/src/llm/capabilities.rs
@@ -53,7 +53,7 @@ pub struct CapabilitiesFile {
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct ProviderDefaults {
     /// Message/request/response wire format used by shared helpers.
-    /// Known values are `openai`, `anthropic`, and `ollama`.
+    /// Known values are `openai`, `anthropic`, `gemini`, and `ollama`.
     #[serde(default)]
     pub message_wire_format: Option<String>,
     /// Native tool definition wire shape. Known values are `openai`
@@ -179,7 +179,7 @@ pub struct ProviderRule {
     #[serde(default)]
     pub native_tools: Option<bool>,
     /// Message/request/response wire format used by shared helpers.
-    /// Known values are `openai`, `anthropic`, and `ollama`.
+    /// Known values are `openai`, `anthropic`, `gemini`, and `ollama`.
     #[serde(default)]
     pub message_wire_format: Option<String>,
     /// Native tool definition wire shape. Known values are `openai`
@@ -1205,7 +1205,8 @@ anthropic_beta_features = ["fine-grained-tool-streaming-2025-05-14"]
     fn mock_with_gemini_model_routes_to_gemini() {
         reset();
         let caps = lookup("mock", "gemini-2.5-flash");
-        assert_eq!(caps.message_wire_format, "openai");
+        assert_eq!(caps.message_wire_format, "gemini");
+        assert_eq!(caps.native_tool_wire_format, "openai");
         assert!(caps.prefers_xml_scaffolding);
     }
 

--- a/crates/harn-vm/src/llm/capabilities.toml
+++ b/crates/harn-vm/src/llm/capabilities.toml
@@ -23,7 +23,7 @@
 #   version_min     : [major, minor] lower bound, provider-aware parse.
 #   native_tools    : whether the model accepts native tool-call wire shape.
 #   message_wire_format:
-#                     shared helper wire format: openai, anthropic, or ollama.
+#                     shared helper wire format: openai, anthropic, gemini, or ollama.
 #   native_tool_wire_format:
 #                     native tool definition shape: openai or anthropic.
 #   defer_loading   : whether `defer_loading: true` is honored on tool defs.
@@ -117,6 +117,7 @@ frequency_penalty_supported = false
 presence_penalty_supported = false
 
 [provider_defaults.gemini]
+message_wire_format = "gemini"
 file_upload_wire_format = "gemini"
 files_api_supported = true
 
@@ -1502,6 +1503,8 @@ thinking_block_style = "reasoning_summary"
 
 [[provider.gemini]]
 model_match = "gemini-2.5*"
+native_tools = true
+structured_output = "native"
 thinking_modes = ["enabled", "adaptive", "effort"]
 vision_supported = true
 audio_supported = true
@@ -1517,6 +1520,8 @@ thinking_block_style = "reasoning_summary"
 
 [[provider.gemini]]
 model_match = "models/gemini-2.5*"
+native_tools = true
+structured_output = "native"
 thinking_modes = ["enabled", "adaptive", "effort"]
 vision_supported = true
 audio_supported = true
@@ -1532,6 +1537,8 @@ thinking_block_style = "reasoning_summary"
 
 [[provider.gemini]]
 model_match = "gemini-*"
+native_tools = true
+structured_output = "native"
 vision_supported = true
 audio_supported = true
 pdf_supported = true
@@ -1546,6 +1553,8 @@ thinking_block_style = "none"
 
 [[provider.gemini]]
 model_match = "models/gemini-*"
+native_tools = true
+structured_output = "native"
 vision_supported = true
 audio_supported = true
 pdf_supported = true

--- a/crates/harn-vm/src/llm/content.rs
+++ b/crates/harn-vm/src/llm/content.rs
@@ -450,6 +450,40 @@ pub(crate) fn gemini_parts(content: &serde_json::Value) -> Vec<serde_json::Value
         serde_json::Value::Array(blocks) => blocks
             .iter()
             .filter_map(|block| {
+                if block.get("functionCall").is_some() || block.get("functionResponse").is_some()
+                {
+                    return Some(block.clone());
+                }
+                if block.get("type").and_then(|value| value.as_str()) == Some("tool_call") {
+                    let name = block
+                        .get("name")
+                        .and_then(|value| value.as_str())
+                        .filter(|value| !value.is_empty())?;
+                    let mut function_call = serde_json::json!({
+                        "name": name,
+                        "args": block
+                            .get("arguments")
+                            .cloned()
+                            .unwrap_or_else(|| serde_json::json!({})),
+                    });
+                    if let Some(id) = block
+                        .get("id")
+                        .and_then(|value| value.as_str())
+                        .filter(|value| !value.is_empty())
+                    {
+                        function_call["id"] = serde_json::json!(id);
+                    }
+                    let mut part = serde_json::json!({ "functionCall": function_call });
+                    if let Some(signature) = block
+                        .get("thoughtSignature")
+                        .or_else(|| block.get("thought_signature"))
+                        .and_then(|value| value.as_str())
+                        .filter(|value| !value.is_empty())
+                    {
+                        part["thoughtSignature"] = serde_json::json!(signature);
+                    }
+                    return Some(part);
+                }
                 if let Ok(Some(image)) = parse_image_block(block) {
                     if let Some(data) = image.base64 {
                         return Some(serde_json::json!({
@@ -487,9 +521,25 @@ pub(crate) fn gemini_parts(content: &serde_json::Value) -> Vec<serde_json::Value
                     }
                 }
                 if let Some(text) = normalized_text_block(block) {
-                    return Some(serde_json::json!({
+                    let mut part = serde_json::json!({
                         "text": text.get("text").and_then(|value| value.as_str()).unwrap_or_default(),
-                    }));
+                    });
+                    if let Some(signature) = block
+                        .get("thoughtSignature")
+                        .or_else(|| block.get("thought_signature"))
+                        .or_else(|| {
+                            block
+                                .get("provider_metadata")
+                                .and_then(|value| value.get("gemini"))
+                                .and_then(|value| value.get("thought_signature"))
+                        })
+                        .and_then(|value| value.as_str())
+                    {
+                        if !signature.is_empty() {
+                            part["thoughtSignature"] = serde_json::json!(signature);
+                        }
+                    }
+                    return Some(part);
                 }
                 block.get("text")
                     .and_then(|value| value.as_str())

--- a/crates/harn-vm/src/llm/mock_builtins.rs
+++ b/crates/harn-vm/src/llm/mock_builtins.rs
@@ -76,6 +76,19 @@ fn llm_mock_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmEr
             ))
         }
     };
+    let blocks = match config.get("blocks") {
+        Some(VmValue::List(list)) => Some(
+            list.iter()
+                .map(helpers::vm_value_to_json)
+                .collect::<Vec<_>>(),
+        ),
+        Some(VmValue::Nil) | None => None,
+        _ => {
+            return Err(VmError::Runtime(
+                "llm_mock: blocks must be a list of response blocks".to_string(),
+            ))
+        }
+    };
 
     let match_pattern = config.get("match").and_then(|v| {
         if matches!(v, VmValue::Nil) {
@@ -122,6 +135,13 @@ fn llm_mock_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmEr
         .get("model")
         .map(|v| v.display())
         .unwrap_or_else(|| "mock".to_string());
+    let provider = config.get("provider").and_then(|v| {
+        if matches!(v, VmValue::Nil) {
+            None
+        } else {
+            Some(v.display())
+        }
+    });
 
     // Optional error injection: {error: {category, message,
     // retry_after_ms?}}. When present the mock short-circuits the
@@ -190,8 +210,8 @@ fn llm_mock_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmEr
         thinking_summary,
         stop_reason,
         model,
-        provider: None,
-        blocks: None,
+        provider,
+        blocks,
         logprobs,
         error,
     });

--- a/crates/harn-vm/src/llm/provider.rs
+++ b/crates/harn-vm/src/llm/provider.rs
@@ -253,6 +253,12 @@ pub(crate) fn provider_uses_anthropic_messages(provider: &str, model: &str) -> b
     super::capabilities::lookup(provider, model).message_wire_format == "anthropic"
 }
 
+/// Whether shared helpers should preserve Google `generateContent` message
+/// parts, including native function calls and thought signatures.
+pub(crate) fn provider_uses_gemini_messages(provider: &str, model: &str) -> bool {
+    super::capabilities::lookup(provider, model).message_wire_format == "gemini"
+}
+
 /// Whether shared helpers should use Ollama's chat message quirks.
 pub(crate) fn provider_uses_ollama_messages(provider: &str, model: &str) -> bool {
     super::capabilities::lookup(provider, model).message_wire_format == "ollama"

--- a/crates/harn-vm/src/llm/providers/common.rs
+++ b/crates/harn-vm/src/llm/providers/common.rs
@@ -67,6 +67,37 @@ pub(super) fn apply_provider_overrides(
     }
 }
 
+pub(super) fn google_function_declaration_tools(
+    tools: Option<&[serde_json::Value]>,
+) -> Option<serde_json::Value> {
+    let declarations: Vec<serde_json::Value> = tools
+        .unwrap_or_default()
+        .iter()
+        .filter_map(google_function_declaration)
+        .collect();
+    (!declarations.is_empty())
+        .then(|| serde_json::json!([{ "functionDeclarations": declarations }]))
+}
+
+fn google_function_declaration(tool: &serde_json::Value) -> Option<serde_json::Value> {
+    let function = tool.get("function").unwrap_or(tool);
+    let name = function
+        .get("name")
+        .and_then(serde_json::Value::as_str)
+        .filter(|name| !name.is_empty())?;
+    let mut declaration = serde_json::json!({ "name": name });
+    if let Some(description) = function.get("description") {
+        declaration["description"] = description.clone();
+    }
+    if let Some(parameters) = function
+        .get("parameters")
+        .or_else(|| function.get("input_schema"))
+    {
+        declaration["parameters"] = parameters.clone();
+    }
+    Some(declaration)
+}
+
 /// Parse a `(major, minor)` generation pair from the tail of a model ID after
 /// the family needle. Accepts both dotted forms (`4.7`, `5.4-preview`) and
 /// dashed forms (`4-7`, `5-4-preview`, `4-20251001`).

--- a/crates/harn-vm/src/llm/providers/gemini.rs
+++ b/crates/harn-vm/src/llm/providers/gemini.rs
@@ -3,9 +3,13 @@
 use std::rc::Rc;
 
 use crate::llm::api::{
-    DeltaSender, LlmRequestPayload, LlmResult, ProviderTelemetry, ReasoningEffort, ThinkingConfig,
+    DeltaSender, LlmRequestPayload, LlmResult, OutputFormat, ProviderTelemetry, ReasoningEffort,
+    ThinkingConfig,
 };
 use crate::llm::provider::{LlmProvider, LlmProviderChat};
+use crate::llm::providers::common::{
+    apply_provider_overrides, google_function_declaration_tools, maybe_emit_delta,
+};
 use crate::value::{VmError, VmValue};
 
 pub(crate) struct GeminiProvider;
@@ -73,16 +77,27 @@ fn gemini_thinking_budget(model: &str, thinking: &ThinkingConfig) -> Option<i64>
 impl GeminiProvider {
     pub(crate) fn build_request_body(opts: &LlmRequestPayload) -> serde_json::Value {
         let mut contents = Vec::new();
+        let mut system_parts = Vec::new();
         for message in &opts.messages {
-            let role = match message.get("role").and_then(|value| value.as_str()) {
-                Some("assistant" | "model") => "model",
+            let role = message
+                .get("role")
+                .and_then(|value| value.as_str())
+                .unwrap_or("user");
+            if role == "system" {
+                let parts = gemini_message_parts(message);
+                if !parts.is_empty() {
+                    system_parts.extend(parts);
+                }
+                continue;
+            }
+            let gemini_role = match role {
+                "assistant" | "model" => "model",
                 _ => "user",
             };
-            let content = message.get("content").unwrap_or(&serde_json::Value::Null);
-            let parts = crate::llm::content::gemini_parts(content);
+            let parts = gemini_message_parts(message);
             if !parts.is_empty() {
                 contents.push(serde_json::json!({
-                    "role": role,
+                    "role": gemini_role,
                     "parts": parts,
                 }));
             }
@@ -90,9 +105,10 @@ impl GeminiProvider {
 
         let mut body = serde_json::json!({ "contents": contents });
         if let Some(system) = opts.system.as_deref().filter(|value| !value.is_empty()) {
-            body["system_instruction"] = serde_json::json!({
-                "parts": [{"text": system}],
-            });
+            system_parts.insert(0, serde_json::json!({"text": system}));
+        }
+        if !system_parts.is_empty() {
+            body["systemInstruction"] = serde_json::json!({ "parts": system_parts });
         }
         let mut generation_config = serde_json::Map::new();
         if opts.max_tokens > 0 {
@@ -119,18 +135,32 @@ impl GeminiProvider {
                 serde_json::json!({ "thinkingBudget": budget }),
             );
         }
+        match &opts.output_format {
+            OutputFormat::Text => {}
+            OutputFormat::JsonObject => {
+                generation_config.insert(
+                    "responseMimeType".to_string(),
+                    serde_json::json!("application/json"),
+                );
+            }
+            OutputFormat::JsonSchema { schema, .. } => {
+                generation_config.insert(
+                    "responseMimeType".to_string(),
+                    serde_json::json!("application/json"),
+                );
+                generation_config.insert("responseJsonSchema".to_string(), schema.clone());
+            }
+        }
         if !generation_config.is_empty() {
             body["generationConfig"] = serde_json::Value::Object(generation_config);
         }
-        if let Some(overrides) = opts
-            .provider_overrides
-            .as_ref()
-            .and_then(|value| value.as_object())
-        {
-            for (key, value) in overrides {
-                body[key] = value.clone();
-            }
+        if let Some(tools) = google_function_declaration_tools(opts.native_tools.as_deref()) {
+            body["tools"] = tools;
         }
+        if let Some(tool_config) = gemini_tool_config(opts.tool_choice.as_ref()) {
+            body["toolConfig"] = tool_config;
+        }
+        apply_provider_overrides(&mut body, opts.provider_overrides.as_ref());
         body
     }
 
@@ -176,13 +206,145 @@ impl GeminiProvider {
             ))))
         })?;
         let result = parse_response(&json, request)?;
-        if let Some(tx) = delta_tx {
-            if !result.text.is_empty() {
-                let _ = tx.send(result.text.clone());
-            }
-        }
+        maybe_emit_delta(delta_tx, &result.text);
         Ok(result)
     }
+}
+
+fn gemini_message_parts(message: &serde_json::Value) -> Vec<serde_json::Value> {
+    if message
+        .get("role")
+        .and_then(|value| value.as_str())
+        .is_some_and(|role| role == "tool" || role == "tool_result")
+    {
+        if let Some(part) = gemini_function_response_part(message) {
+            return vec![part];
+        }
+    }
+
+    let mut parts = message
+        .get("content")
+        .map(crate::llm::content::gemini_parts)
+        .unwrap_or_default();
+    if let Some(calls) = message.get("tool_calls").and_then(|value| value.as_array()) {
+        for call in calls {
+            if let Some(part) = gemini_function_call_part(call) {
+                parts.push(part);
+            }
+        }
+    }
+    parts
+}
+
+fn gemini_function_call_part(call: &serde_json::Value) -> Option<serde_json::Value> {
+    let function = call.get("function").unwrap_or(call);
+    let name = function
+        .get("name")
+        .and_then(serde_json::Value::as_str)
+        .filter(|name| !name.is_empty())?;
+    let args = function
+        .get("arguments")
+        .and_then(|value| {
+            value
+                .as_str()
+                .and_then(|text| serde_json::from_str::<serde_json::Value>(text).ok())
+                .or_else(|| (!value.is_string()).then(|| value.clone()))
+        })
+        .or_else(|| call.get("arguments").cloned())
+        .unwrap_or_else(|| serde_json::json!({}));
+    let mut function_call = serde_json::json!({
+        "name": name,
+        "args": args,
+    });
+    if let Some(id) = call
+        .get("id")
+        .or_else(|| function.get("id"))
+        .and_then(serde_json::Value::as_str)
+        .filter(|id| !id.is_empty())
+    {
+        function_call["id"] = serde_json::json!(id);
+    }
+    let mut part = serde_json::json!({ "functionCall": function_call });
+    if let Some(signature) = call
+        .get("thought_signature")
+        .or_else(|| call.get("thoughtSignature"))
+        .and_then(serde_json::Value::as_str)
+        .filter(|signature| !signature.is_empty())
+    {
+        part["thoughtSignature"] = serde_json::json!(signature);
+    }
+    Some(part)
+}
+
+fn gemini_function_response_part(message: &serde_json::Value) -> Option<serde_json::Value> {
+    let name = message
+        .get("name")
+        .or_else(|| message.get("tool_name"))
+        .and_then(serde_json::Value::as_str)
+        .filter(|name| !name.is_empty())?;
+    let response = message
+        .get("content")
+        .map(gemini_function_response_payload)
+        .unwrap_or_else(|| serde_json::json!({}));
+    let mut function_response = serde_json::json!({
+        "name": name,
+        "response": response,
+    });
+    if let Some(id) = message
+        .get("tool_call_id")
+        .or_else(|| message.get("tool_use_id"))
+        .or_else(|| message.get("call_id"))
+        .and_then(serde_json::Value::as_str)
+        .filter(|id| !id.is_empty())
+    {
+        function_response["id"] = serde_json::json!(id);
+    }
+    Some(serde_json::json!({ "functionResponse": function_response }))
+}
+
+fn gemini_function_response_payload(content: &serde_json::Value) -> serde_json::Value {
+    match content {
+        serde_json::Value::Object(_) => content.clone(),
+        serde_json::Value::String(text) => match serde_json::from_str::<serde_json::Value>(text) {
+            Ok(serde_json::Value::Object(object)) => serde_json::Value::Object(object),
+            Ok(value) => serde_json::json!({ "result": value }),
+            Err(_) => serde_json::json!({ "result": text }),
+        },
+        serde_json::Value::Null => serde_json::json!({}),
+        other => serde_json::json!({ "result": other }),
+    }
+}
+
+fn gemini_tool_config(tool_choice: Option<&serde_json::Value>) -> Option<serde_json::Value> {
+    let choice = tool_choice?;
+    let mode = match choice {
+        serde_json::Value::String(value) => match value.as_str() {
+            "none" => "NONE",
+            "required" | "any" => "ANY",
+            _ => "AUTO",
+        },
+        serde_json::Value::Object(object) => {
+            match object.get("type").and_then(|value| value.as_str()) {
+                Some("none") => "NONE",
+                Some("function" | "tool" | "any" | "required") => "ANY",
+                _ => "AUTO",
+            }
+        }
+        _ => "AUTO",
+    };
+    let mut config = serde_json::json!({ "functionCallingConfig": { "mode": mode } });
+    if mode == "ANY" {
+        if let Some(name) = choice
+            .get("function")
+            .and_then(|value| value.get("name"))
+            .or_else(|| choice.get("name"))
+            .and_then(serde_json::Value::as_str)
+            .filter(|name| !name.is_empty())
+        {
+            config["functionCallingConfig"]["allowedFunctionNames"] = serde_json::json!([name]);
+        }
+    }
+    Some(config)
 }
 
 fn parse_response(
@@ -199,16 +361,77 @@ fn parse_response(
         )))));
     }
     let mut text = String::new();
+    let mut thinking = String::new();
     let mut blocks = Vec::new();
+    let mut tool_calls = Vec::new();
     if let Some(parts) = json["candidates"][0]["content"]["parts"].as_array() {
-        for part in parts {
+        for (idx, part) in parts.iter().enumerate() {
+            let thought_signature = part
+                .get("thoughtSignature")
+                .and_then(|value| value.as_str())
+                .filter(|value| !value.is_empty());
             if let Some(fragment) = part.get("text").and_then(|value| value.as_str()) {
-                text.push_str(fragment);
-                blocks.push(serde_json::json!({
-                    "type": "output_text",
-                    "text": fragment,
-                    "visibility": "public",
-                }));
+                if part.get("thought").and_then(|value| value.as_bool()) == Some(true) {
+                    thinking.push_str(fragment);
+                    blocks.push(serde_json::json!({
+                        "type": "reasoning",
+                        "text": fragment,
+                        "visibility": "private",
+                    }));
+                } else {
+                    text.push_str(fragment);
+                    let mut block = serde_json::json!({
+                        "type": "output_text",
+                        "text": fragment,
+                        "visibility": "public",
+                    });
+                    if let Some(signature) = thought_signature {
+                        block["provider_metadata"] = serde_json::json!({
+                            "gemini": {"thought_signature": signature}
+                        });
+                    }
+                    blocks.push(block);
+                }
+            }
+            if let Some(call) = part.get("functionCall") {
+                let Some(name) = call
+                    .get("name")
+                    .and_then(|value| value.as_str())
+                    .filter(|value| !value.is_empty())
+                else {
+                    continue;
+                };
+                let args = call
+                    .get("args")
+                    .cloned()
+                    .unwrap_or_else(|| serde_json::json!({}));
+                let id = call
+                    .get("id")
+                    .and_then(|value| value.as_str())
+                    .filter(|value| !value.is_empty())
+                    .map(str::to_string)
+                    .unwrap_or_else(|| format!("gemini_tool_{}", tool_calls.len()));
+                let mut tool_call = serde_json::json!({
+                    "id": id,
+                    "name": name,
+                    "arguments": args.clone(),
+                });
+                if let Some(signature) = thought_signature {
+                    tool_call["thought_signature"] = serde_json::json!(signature);
+                }
+                tool_calls.push(tool_call.clone());
+                let mut block = serde_json::json!({
+                    "type": "tool_call",
+                    "id": tool_call["id"].clone(),
+                    "name": name,
+                    "arguments": args,
+                    "visibility": "internal",
+                });
+                if let Some(signature) = thought_signature {
+                    block["thought_signature"] = serde_json::json!(signature);
+                }
+                block["part_index"] = serde_json::json!(idx);
+                blocks.push(block);
             }
         }
     }
@@ -218,30 +441,30 @@ fn parse_response(
     let output_tokens = json["usageMetadata"]["candidatesTokenCount"]
         .as_i64()
         .unwrap_or(0);
+    let cache_read_tokens = json["usageMetadata"]["cachedContentTokenCount"]
+        .as_i64()
+        .unwrap_or(0);
     let stop_reason = json["candidates"][0]["finishReason"]
         .as_str()
         .map(str::to_string);
-    // Gemini's REST response carries only token counts (no server-side
-    // timings) so we synthesize an OpenAI-shaped usage block and route it
-    // through the same normalizer the rest of the providers use.
-    let usage = serde_json::json!({
-        "prompt_tokens": input_tokens,
-        "completion_tokens": output_tokens,
-    });
     let request_id = json["responseId"]
         .as_str()
         .filter(|value| !value.is_empty());
-    let telemetry = ProviderTelemetry::from_openai_usage(&usage, request_id);
+    let telemetry = ProviderTelemetry::from_gemini_usage(&json["usageMetadata"], request_id);
     Ok(LlmResult {
         text,
-        tool_calls: Vec::new(),
+        tool_calls,
         input_tokens,
         output_tokens,
-        cache_read_tokens: 0,
+        cache_read_tokens,
         cache_write_tokens: 0,
         model: request.model.clone(),
         provider: request.provider.clone(),
-        thinking: None,
+        thinking: if thinking.is_empty() {
+            None
+        } else {
+            Some(thinking)
+        },
         thinking_summary: None,
         stop_reason,
         blocks,
@@ -253,7 +476,8 @@ fn parse_response(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::llm::api::ThinkingConfig;
+    use crate::llm::api::{OutputFormat, ThinkingConfig};
+    use serde_json::json;
 
     fn text_payload(model: &str, thinking: ThinkingConfig) -> LlmRequestPayload {
         LlmRequestPayload {
@@ -402,7 +626,7 @@ mod tests {
                 "file_uri": "https://example.com/image.png",
             })
         );
-        assert_eq!(body["system_instruction"]["parts"][0]["text"], "system");
+        assert_eq!(body["systemInstruction"]["parts"][0]["text"], "system");
     }
 
     #[test]
@@ -514,5 +738,166 @@ mod tests {
         assert!(legacy["generationConfig"]
             .as_object()
             .is_some_and(|config| !config.contains_key("thinkingConfig")));
+    }
+
+    #[test]
+    fn gemini_native_tools_and_structured_output_map_to_generate_content() {
+        let mut payload = text_payload("gemini-2.5-flash", ThinkingConfig::Disabled);
+        payload.native_tools = Some(vec![
+            json!({
+                "type": "function",
+                "function": {
+                    "name": "lookup",
+                    "description": "Lookup records",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"query": {"type": "string"}},
+                        "required": ["query"]
+                    }
+                }
+            }),
+            json!({
+                "type": "function",
+                "function": {
+                    "name": "summarize",
+                    "parameters": {"type": "object"}
+                }
+            }),
+        ]);
+        payload.tool_choice = Some(json!({
+            "type": "function",
+            "function": {"name": "lookup"}
+        }));
+        payload.output_format = OutputFormat::JsonSchema {
+            schema: json!({
+                "type": "object",
+                "properties": {"answer": {"type": "string"}},
+                "required": ["answer"]
+            }),
+            strict: true,
+        };
+
+        let body = GeminiProvider::build_request_body(&payload);
+
+        let declarations = body["tools"][0]["functionDeclarations"]
+            .as_array()
+            .expect("function declarations");
+        assert_eq!(declarations.len(), 2);
+        assert_eq!(declarations[0]["name"], "lookup");
+        assert_eq!(
+            declarations[0]["parameters"]["properties"]["query"]["type"],
+            "string"
+        );
+        assert_eq!(
+            body["toolConfig"]["functionCallingConfig"],
+            json!({"mode": "ANY", "allowedFunctionNames": ["lookup"]})
+        );
+        assert_eq!(
+            body["generationConfig"]["responseMimeType"],
+            "application/json"
+        );
+        assert_eq!(
+            body["generationConfig"]["responseJsonSchema"]["properties"]["answer"]["type"],
+            "string"
+        );
+    }
+
+    #[test]
+    fn gemini_history_maps_function_calls_and_tool_results() {
+        let mut payload = text_payload("gemini-2.5-flash", ThinkingConfig::Disabled);
+        payload.messages = vec![
+            json!({
+                "role": "assistant",
+                "content": [
+                    {
+                        "functionCall": {
+                            "id": "call_1",
+                            "name": "lookup",
+                            "args": {"query": "harn"}
+                        },
+                        "thoughtSignature": "opaque-signature"
+                    }
+                ]
+            }),
+            json!({
+                "role": "tool",
+                "name": "lookup",
+                "tool_call_id": "call_1",
+                "content": "{\"result\":\"ok\"}"
+            }),
+        ];
+
+        let body = GeminiProvider::build_request_body(&payload);
+
+        assert_eq!(body["contents"][0]["role"], "model");
+        assert_eq!(
+            body["contents"][0]["parts"][0]["functionCall"],
+            json!({"id": "call_1", "name": "lookup", "args": {"query": "harn"}})
+        );
+        assert_eq!(
+            body["contents"][0]["parts"][0]["thoughtSignature"],
+            "opaque-signature"
+        );
+        assert_eq!(body["contents"][1]["role"], "user");
+        assert_eq!(
+            body["contents"][1]["parts"][0]["functionResponse"],
+            json!({"id": "call_1", "name": "lookup", "response": {"result": "ok"}})
+        );
+    }
+
+    #[test]
+    fn gemini_response_extracts_text_function_calls_signatures_and_cache_usage() {
+        let request = text_payload("gemini-2.5-flash", ThinkingConfig::Disabled);
+        let response = json!({
+            "candidates": [{
+                "content": {"parts": [
+                    {"text": "checking"},
+                    {
+                        "functionCall": {
+                            "id": "call_1",
+                            "name": "lookup",
+                            "args": {"query": "harn"}
+                        },
+                        "thoughtSignature": "sig-1"
+                    },
+                    {
+                        "functionCall": {
+                            "name": "summarize",
+                            "args": {"topic": "tools"}
+                        }
+                    }
+                ]},
+                "finishReason": "STOP"
+            }],
+            "usageMetadata": {
+                "promptTokenCount": 10,
+                "candidatesTokenCount": 3,
+                "cachedContentTokenCount": 7
+            },
+            "responseId": "resp-1"
+        });
+
+        let result = parse_response(&response, &request).expect("gemini response parses");
+
+        assert_eq!(result.text, "checking");
+        assert_eq!(result.tool_calls.len(), 2);
+        assert_eq!(result.tool_calls[0]["id"], "call_1");
+        assert_eq!(result.tool_calls[0]["name"], "lookup");
+        assert_eq!(result.tool_calls[0]["arguments"]["query"], "harn");
+        assert_eq!(result.tool_calls[0]["thought_signature"], "sig-1");
+        assert_eq!(result.tool_calls[1]["id"], "gemini_tool_1");
+        assert_eq!(result.cache_read_tokens, 7);
+        assert_eq!(
+            result.telemetry.source,
+            crate::llm::api::telemetry_source::GEMINI_USAGE
+        );
+        assert_eq!(result.telemetry.request_id.as_deref(), Some("resp-1"));
+        assert!(result.blocks.iter().any(|block| {
+            block.get("type").and_then(|value| value.as_str()) == Some("tool_call")
+                && block
+                    .get("thought_signature")
+                    .and_then(|value| value.as_str())
+                    == Some("sig-1")
+        }));
     }
 }

--- a/crates/harn-vm/src/llm/providers/vertex.rs
+++ b/crates/harn-vm/src/llm/providers/vertex.rs
@@ -8,7 +8,8 @@
 use crate::llm::api::{DeltaSender, LlmRequestPayload, LlmResult};
 use crate::llm::provider::{LlmProvider, LlmProviderChat};
 use crate::llm::providers::common::{
-    apply_provider_overrides, maybe_emit_delta, request_text_content, vm_err,
+    apply_provider_overrides, google_function_declaration_tools, maybe_emit_delta,
+    request_text_content, vm_err,
 };
 use crate::url_encoding::percent_encode_component;
 use crate::value::VmError;
@@ -105,7 +106,7 @@ impl VertexProvider {
         if !generation.is_empty() {
             body["generationConfig"] = serde_json::Value::Object(generation);
         }
-        if let Some(tools) = vertex_tools(request.native_tools.as_deref()) {
+        if let Some(tools) = google_function_declaration_tools(request.native_tools.as_deref()) {
             body["tools"] = tools;
         }
         body
@@ -212,29 +213,6 @@ impl LlmProviderChat for VertexProvider {
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<LlmResult, VmError>> + 'a>> {
         Box::pin(self.chat_impl(request, delta_tx))
     }
-}
-
-fn vertex_tools(tools: Option<&[serde_json::Value]>) -> Option<serde_json::Value> {
-    let mut declarations = Vec::new();
-    for tool in tools.unwrap_or_default() {
-        let function = tool.get("function").unwrap_or(tool);
-        let Some(name) = function.get("name").and_then(|value| value.as_str()) else {
-            continue;
-        };
-        let mut declaration = serde_json::json!({ "name": name });
-        if let Some(description) = function.get("description") {
-            declaration["description"] = description.clone();
-        }
-        if let Some(parameters) = function
-            .get("parameters")
-            .or_else(|| function.get("input_schema"))
-        {
-            declaration["parameters"] = parameters.clone();
-        }
-        declarations.push(declaration);
-    }
-    (!declarations.is_empty())
-        .then(|| serde_json::json!([{ "functionDeclarations": declarations }]))
 }
 
 fn parse_vertex_response(json: &serde_json::Value, model: &str) -> Result<LlmResult, VmError> {

--- a/crates/harn-vm/src/llm/tools/messages.rs
+++ b/crates/harn-vm/src/llm/tools/messages.rs
@@ -9,6 +9,7 @@ pub(crate) fn build_assistant_tool_message(
     model: &str,
 ) -> serde_json::Value {
     let is_anthropic = super::super::provider::provider_uses_anthropic_messages(provider, model);
+    let is_gemini = super::super::provider::provider_uses_gemini_messages(provider, model);
     let is_ollama = super::super::provider::provider_uses_ollama_messages(provider, model);
     if is_anthropic {
         // Anthropic format: content blocks with text and tool_use
@@ -25,6 +26,34 @@ pub(crate) fn build_assistant_tool_message(
             }));
         }
         serde_json::json!({"role": "assistant", "content": content})
+    } else if is_gemini {
+        let mut parts = Vec::new();
+        if !text.is_empty() {
+            parts.push(serde_json::json!({"text": text}));
+        }
+        for tc in tool_calls {
+            let mut function_call = serde_json::json!({
+                "name": tc["name"],
+                "args": tc["arguments"],
+            });
+            if let Some(id) = tc.get("id").and_then(|value| value.as_str()) {
+                if !id.is_empty() {
+                    function_call["id"] = serde_json::json!(id);
+                }
+            }
+            let mut part = serde_json::json!({ "functionCall": function_call });
+            if let Some(signature) = tc
+                .get("thought_signature")
+                .or_else(|| tc.get("thoughtSignature"))
+                .and_then(|value| value.as_str())
+            {
+                if !signature.is_empty() {
+                    part["thoughtSignature"] = serde_json::json!(signature);
+                }
+            }
+            parts.push(part);
+        }
+        serde_json::json!({"role": "assistant", "content": parts})
     } else if is_ollama {
         // Ollama's chat API uses the OpenAI-style `function` envelope but
         // its request schema expects `function.arguments` to be a string.
@@ -86,7 +115,22 @@ pub(crate) fn build_assistant_response_message(
     model: &str,
 ) -> serde_json::Value {
     let mut message = if !tool_calls.is_empty() {
-        build_assistant_tool_message(text, tool_calls, provider, model)
+        if super::super::provider::provider_uses_gemini_messages(provider, model)
+            && !blocks.is_empty()
+        {
+            let content =
+                crate::llm::content::gemini_parts(&serde_json::Value::Array(blocks.to_vec()));
+            if content
+                .iter()
+                .any(|part| part.get("functionCall").is_some())
+            {
+                serde_json::json!({"role": "assistant", "content": content})
+            } else {
+                build_assistant_tool_message(text, tool_calls, provider, model)
+            }
+        } else {
+            build_assistant_tool_message(text, tool_calls, provider, model)
+        }
     } else if !blocks.is_empty() {
         serde_json::json!({
             "role": "assistant",

--- a/crates/harn-vm/src/llm/tools/tests/heredoc_and_messages.rs
+++ b/crates/harn-vm/src/llm/tools/tests/heredoc_and_messages.rs
@@ -670,6 +670,73 @@ fn assistant_tool_message_stringifies_ollama_arguments() {
 }
 
 #[test]
+fn assistant_tool_message_uses_gemini_parts_for_gemini_models() {
+    let message = build_assistant_tool_message(
+        "checking",
+        &[json!({
+            "id": "call_001",
+            "name": "read",
+            "arguments": {"path": "main.rs"},
+            "thought_signature": "opaque-signature",
+        })],
+        "gemini",
+        "gemini-2.5-flash",
+    );
+
+    assert_eq!(message["role"], "assistant");
+    assert_eq!(message["content"][0], json!({"text": "checking"}));
+    assert_eq!(
+        message["content"][1]["functionCall"],
+        json!({"id": "call_001", "name": "read", "args": {"path": "main.rs"}})
+    );
+    assert_eq!(
+        message["content"][1]["thoughtSignature"],
+        "opaque-signature"
+    );
+}
+
+#[test]
+fn assistant_response_message_preserves_gemini_block_signatures() {
+    let message = build_assistant_response_message(
+        "checking",
+        &[
+            json!({
+                "type": "output_text",
+                "text": "checking",
+                "provider_metadata": {
+                    "gemini": {"thought_signature": "text-signature"}
+                }
+            }),
+            json!({
+                "type": "tool_call",
+                "id": "call_001",
+                "name": "read",
+                "arguments": {"path": "main.rs"},
+                "thought_signature": "tool-signature",
+            }),
+        ],
+        &[json!({
+            "id": "call_001",
+            "name": "read",
+            "arguments": {"path": "main.rs"},
+            "thought_signature": "tool-signature",
+        })],
+        None,
+        "gemini",
+        "gemini-2.5-flash",
+    );
+
+    assert_eq!(message["role"], "assistant");
+    assert_eq!(message["content"][0]["text"], "checking");
+    assert_eq!(message["content"][0]["thoughtSignature"], "text-signature");
+    assert_eq!(
+        message["content"][1]["functionCall"],
+        json!({"id": "call_001", "name": "read", "args": {"path": "main.rs"}})
+    );
+    assert_eq!(message["content"][1]["thoughtSignature"], "tool-signature");
+}
+
+#[test]
 fn assistant_tool_message_uses_model_capability_shape_for_bedrock_claude() {
     let message = build_assistant_tool_message(
         "using a tool",

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -989,6 +989,15 @@ Provider auto-resolution precedence:
 | `<model>:<tag>` | `ollama` | unchanged |
 | anything else | `HARN_DEFAULT_PROVIDER` / configured default | unchanged |
 
+Native Gemini routes use Google's `generateContent` wire format directly:
+tool schemas become `functionDeclarations`, model tool requests are
+`functionCall` parts, tool observations are `functionResponse` parts, and
+JSON schemas lower to Gemini's JSON response controls. Vertex AI also serves
+Gemini models through `generateContent`, but keeps Google Cloud project /
+location and OAuth/service-account authentication. OpenAI-compatible Gemini
+routes such as OpenRouter remain OpenAI-wire routes and use OpenAI-style
+`tools`, `tool_calls`, and structured-output parameters.
+
 ### Reranking and self-certainty
 
 ```harn
@@ -1242,8 +1251,8 @@ set under `[provider_defaults.<name>]`:
 | `model_match` | glob string | Required. Matched against lowercased model ID. |
 | `version_min` | `[major, minor]` | Optional lower bound; parsed via Claude / GPT version extractors. |
 | `native_tools` | bool | Native tool-call wire shape supported. |
-| `message_wire_format` | string | Shared request/response message format: `openai`, `anthropic`, or `ollama`. |
-| `native_tool_wire_format` | string | Native tool definition shape: `openai` or `anthropic`. |
+| `message_wire_format` | string | Shared request/response message format: `openai`, `anthropic`, `gemini`, or `ollama`. |
+| `native_tool_wire_format` | string | Native tool definition shape for shared helpers: `openai` or `anthropic`. Gemini/Vertex adapters emit Google `functionDeclarations` from canonical tool definitions. |
 | `defer_loading` | bool | Provider honors `defer_loading: true` on tool defs. |
 | `tool_search` | `[string]` | Native variants (`["bm25", "regex"]` or `["hosted", "client"]`). Empty = no native support. |
 | `max_tools` | int | Cap on tool count (used by `harn lint`). |

--- a/docs/src/builtins.md
+++ b/docs/src/builtins.md
@@ -1671,7 +1671,7 @@ See [LLM calls and agent loops](llm-and-agents.md) for full documentation.
 | `llm_budget_remaining()` | — | float or nil | Remaining budget (nil if no budget set) |
 | `tiktoken_count_tokens(text, model)` | text: string, model: string | int | Count text with the selected tiktoken encoder for known OpenAI models and labeled Claude/Gemini approximations |
 | `tiktoken_tokenizer_info(model)` | model: string | dict | Return `{model, model_family, source, exact, known_model_family, encoder}` for the encoder or heuristic fallback used by a model ID |
-| `llm_mock(response)` | response: dict | nil | Queue a mock LLM response. Dict supports `text`, `tool_calls`, `logprobs`, `match` (glob), `consume_match` (consume a matched pattern instead of reusing it), `input_tokens`, `output_tokens`, `thinking`, `stop_reason`, `model`, `error: {category, message}` (short-circuits the call and surfaces as `VmError::CategorizedError` — useful for testing `llm_call_safe` envelopes and `with_rate_limit` retry loops) |
+| `llm_mock(response)` | response: dict | nil | Queue a mock LLM response. Dict supports `text`, `tool_calls`, `blocks`, `logprobs`, `match` (glob), `consume_match` (consume a matched pattern instead of reusing it), `input_tokens`, `output_tokens`, `thinking`, `stop_reason`, `provider`, `model`, `error: {category, message}` (short-circuits the call and surfaces as `VmError::CategorizedError` — useful for testing `llm_call_safe` envelopes and `with_rate_limit` retry loops) |
 | `llm_mock_calls()` | — | list | Return list of `{messages, system, tools}` for all calls made to the mock provider |
 | `llm_mock_clear()` | — | nil | Clear all queued mock responses and recorded calls |
 

--- a/docs/src/llm/providers.md
+++ b/docs/src/llm/providers.md
@@ -30,6 +30,7 @@ For model-specific feature support, see the generated
 | HuggingFace | `HF_TOKEN` or `HUGGINGFACE_API_KEY` | explicit `model` |
 | Bedrock | AWS env/profile/instance role | explicit Bedrock `model` |
 | Azure OpenAI | `AZURE_OPENAI_API_KEY` or `AZURE_OPENAI_AD_TOKEN` | deployment name in `model` |
+| Gemini API | `GEMINI_API_KEY` or `GOOGLE_API_KEY` | `gemini-2.5-flash` or explicit Gemini model ID |
 | Vertex AI | `VERTEX_AI_ACCESS_TOKEN` or `GOOGLE_APPLICATION_CREDENTIALS` | Gemini model ID |
 | Ollama | `OLLAMA_HOST` (optional) | `qwen3.6-coding` when installed, otherwise `llama3.2` |
 | Local server | `LOCAL_LLM_BASE_URL` | `LOCAL_LLM_MODEL` or explicit `model` |
@@ -150,6 +151,25 @@ Vertex AI requires a project and location. Set `VERTEX_AI_PROJECT` or
 JSON file through `GOOGLE_APPLICATION_CREDENTIALS`. Harn exchanges service
 account keys for a short-lived OAuth token with the cloud-platform scope.
 
+The native Gemini API uses Google's `generateContent` shape directly. Harn
+lowers native tools to `functionDeclarations`, records model-emitted
+`functionCall` parts, returns tool observations as `functionResponse` parts,
+and preserves Gemini thought signatures in conversation history without
+showing those opaque bytes as visible reasoning. `llm_call(..., {schema: ...})`
+uses Gemini's JSON response controls (`responseMimeType` plus JSON schema),
+and response usage maps `cachedContentTokenCount` to Harn's cache-read token
+field.
+
+Vertex AI also serves Gemini models through `generateContent`, but it is a
+Google Cloud route with OAuth/service-account authentication and project /
+location scoping. The built-in Vertex adapter shares the Google function
+declaration schema for native tool definitions while keeping its existing
+Google Cloud request envelope. OpenAI-compatible routes that serve Gemini
+model IDs, such as OpenRouter or a local proxy, remain OpenAI-wire routes:
+they use OpenAI-style `tool_calls` / `tools` and OpenAI-style structured-output
+parameters rather than Gemini `functionCall`, `functionResponse`, or
+`responseJsonSchema` parts.
+
 ### Capability matrix + `harn.toml` overrides
 
 The provider support table above is **not** hard-coded: it's the output
@@ -239,8 +259,8 @@ entry accepts these fields:
 | `model_match` | glob string | Required. Matched against the lowercased model ID. Leading/trailing `*` or a single middle `*` supported. |
 | `version_min` | `[major, minor]` | Narrows the match to a parseable version (Anthropic / OpenAI extractors). Rules where `version_min` is set but the model ID won't parse are skipped. |
 | `native_tools` | bool | Whether the provider accepts a native tool-call wire shape. |
-| `message_wire_format` | string | Shared request/response message format: `openai`, `anthropic`, or `ollama`. |
-| `native_tool_wire_format` | string | Native tool definition shape: `openai` or `anthropic`. |
+| `message_wire_format` | string | Shared request/response message format: `openai`, `anthropic`, `gemini`, or `ollama`. |
+| `native_tool_wire_format` | string | Native tool definition shape for shared helpers: `openai` or `anthropic`. Gemini and Vertex accept Harn's canonical tool definitions and their adapters emit Google `functionDeclarations`. |
 | `defer_loading` | bool | Whether `defer_loading: true` on tool definitions is honored server-side. |
 | `tool_search` | list of strings | Native `tool_search` variants, preferred first. Anthropic: `["bm25", "regex"]`. OpenAI: `["hosted", "client"]`. Empty = no native support (client fallback only). |
 | `max_tools` | int | Cap on tool count. `harn lint` will warn if a registry exceeds the smallest cap any active provider advertises. |

--- a/docs/src/provider-matrix.md
+++ b/docs/src/provider-matrix.md
@@ -40,10 +40,10 @@ Regenerate with `make gen-provider-matrix` and verify with `make check-provider-
 | `fireworks` | `*qwen3.6*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | yes | no |
 | `fireworks` | `*qwen3p6*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | yes | no |
 | `fireworks` | `*qwen*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | yes | no |
-| `gemini` | `gemini-2.5*` | `any` | `enabled,adaptive,effort` | yes | yes | yes | yes | yes | no | `xml,markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | no | no |
-| `gemini` | `models/gemini-2.5*` | `any` | `enabled,adaptive,effort` | yes | yes | yes | yes | yes | no | `xml,markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | no | no |
-| `gemini` | `gemini-*` | `any` | no | yes | yes | yes | yes | yes | no | `xml,markdown` | `native_json` | no | `system` | `json` | `none` | no | no |
-| `gemini` | `models/gemini-*` | `any` | no | yes | yes | yes | yes | yes | no | `xml,markdown` | `native_json` | no | `system` | `json` | `none` | no | no |
+| `gemini` | `gemini-2.5*` | `any` | `enabled,adaptive,effort` | yes | yes | yes | yes | yes | `native` | `xml,markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | yes | no |
+| `gemini` | `models/gemini-2.5*` | `any` | `enabled,adaptive,effort` | yes | yes | yes | yes | yes | `native` | `xml,markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | yes | no |
+| `gemini` | `gemini-*` | `any` | no | yes | yes | yes | yes | yes | `native` | `xml,markdown` | `native_json` | no | `system` | `json` | `none` | yes | no |
+| `gemini` | `models/gemini-*` | `any` | no | yes | yes | yes | yes | yes | `native` | `xml,markdown` | `native_json` | no | `system` | `json` | `none` | yes | no |
 | `huggingface` | `qwen/qwen3.6*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | yes | no |
 | `huggingface` | `qwen/qwen3-coder*` | `any` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `none` | yes | no |
 | `huggingface` | `qwen/*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | yes | no |


### PR DESCRIPTION
## Summary
- Add native Gemini generateContent support for function declarations, functionCall/functionResponse history, structured JSON schema controls, thought-signature preservation, and cached-content token usage.
- Share Google function declaration lowering with Vertex and expose Gemini message-wire capabilities in the matrix.
- Extend llm_mock to accept provider/blocks for deterministic provider-native fixtures, then add Gemini agent_loop conformance and docs comparing native Gemini, Vertex, and OpenAI-compatible routes.

## Verification
- cargo test -p harn-vm llm::providers::gemini --lib
- cargo test -p harn-vm llm::tools::tests::heredoc_and_messages --lib
- cargo test -p harn-vm llm::capabilities --lib
- cargo test -p harn-vm llm::api::telemetry --lib
- cargo run --quiet --bin harn -- test conformance --filter gemini_native_tool_calls_agent_loop
- cargo run --quiet --bin harn -- test conformance --filter provider_capabilities_basic
- make check-provider-matrix
- make lint-test-patterns
- make fmt-harn && make lint-harn
- make check-docs-snippets
- pre-commit and pre-push hooks passed

Fixes #2192