### PR TITLE
[codex] Improve agent stdlib type safety

### DIFF
--- a/conformance/tests/agents/agent_loop_options.expected
+++ b/conformance/tests/agents/agent_loop_options.expected
@@ -16,3 +16,5 @@ open
 deliverable-3
 explicit
 custom
+true
+true

--- a/conformance/tests/agents/agent_loop_options.harn
+++ b/conformance/tests/agents/agent_loop_options.harn
@@ -51,4 +51,11 @@ pipeline default() {
   )
   __io_println(explicit_ledger.task_ledger.root_task)
   __io_println(explicit_ledger.task_ledger.deliverables[0].id)
+  let invalid_expose_decisions = try {
+    agent_loop_options(
+      {provider: "mock", iteration_budget: {mode: "adaptive", expose_decisions: "yes"}},
+    )
+  }
+  __io_println(is_err(invalid_expose_decisions))
+  __io_println(contains(to_string(unwrap_err(invalid_expose_decisions)), "expose_decisions"))
 }

--- a/conformance/tests/integration/agent_loop_stall_diagnostics.expected
+++ b/conformance/tests/integration/agent_loop_stall_diagnostics.expected
@@ -10,3 +10,5 @@ done
 0
 false
 0
+true
+true

--- a/conformance/tests/integration/agent_loop_stall_diagnostics.harn
+++ b/conformance/tests/integration/agent_loop_stall_diagnostics.harn
@@ -73,4 +73,22 @@ pipeline default() {
   __io_println(polling.repeated_tool_calls)
   __io_println(polling.suspected_loop)
   __io_println(len(polling.stall_warnings))
+  llm_mock_clear()
+  llm_mock({text: "Done. ##DONE##"})
+  let invalid_config = try {
+    agent_loop(
+      "Validate stall config",
+      nil,
+      {
+        provider: "mock",
+        tools: tools(),
+        tool_format: "native",
+        loop_until_done: true,
+        max_iterations: 1,
+        stall_diagnostics: {enabled: "yes"},
+      },
+    )
+  }
+  __io_println(is_err(invalid_config))
+  __io_println(contains(to_string(unwrap_err(invalid_config)), "stall_diagnostics.enabled"))
 }

--- a/crates/harn-parser/src/typechecker/inference/expressions.rs
+++ b/crates/harn-parser/src/typechecker/inference/expressions.rs
@@ -421,6 +421,13 @@ impl TypeChecker {
                     }
                     return None;
                 }
+                if Self::builtin_preserves_first_arg_type(name) {
+                    if let Some(first_type) =
+                        args.first().and_then(|arg| self.infer_type(arg, scope))
+                    {
+                        return Some(first_type);
+                    }
+                }
                 // Generic builtins (llm_call, schema_parse/check/expect):
                 // bind T by walking each arg node against the param
                 // TypeExpr, then apply bindings to the declared return
@@ -1082,6 +1089,13 @@ impl TypeChecker {
         } else {
             field_type
         })
+    }
+
+    fn builtin_preserves_first_arg_type(name: &str) -> bool {
+        matches!(
+            name,
+            "add_assistant" | "add_message" | "add_system" | "add_tool_result" | "add_user"
+        )
     }
 
     pub(in crate::typechecker) fn check_unnecessary_safe_property_access(

--- a/crates/harn-parser/src/typechecker/tests/typing.rs
+++ b/crates/harn-parser/src/typechecker/tests/typing.rs
@@ -137,6 +137,19 @@ fn test_rest_param_binding_is_list_of_declared_type() {
 }
 
 #[test]
+fn test_transcript_append_builtins_preserve_input_container_type() {
+    let errs = errors(
+        r#"pipeline t(task) {
+  var built = transcript({workflow: "demo"})
+  built = add_user(built, [{type: "text", text: "hello", visibility: "public"}])
+  built = add_assistant(built, [{type: "output_text", text: "done", visibility: "public"}])
+  let messages = transcript_messages(built)
+}"#,
+    );
+    assert!(errs.is_empty(), "unexpected errors: {errs:?}");
+}
+
+#[test]
 fn test_unnecessary_safe_navigation_warns_on_non_nil_receiver() {
     let diagnostics = check_source_with_source(
         r#"

--- a/crates/harn-stdlib/src/lib.rs
+++ b/crates/harn-stdlib/src/lib.rs
@@ -326,6 +326,18 @@ pub const STDLIB_SOURCES: &[StdlibSource] = &[
         source: include_str!("stdlib/agent/progress.harn"),
     },
     StdlibSource {
+        module: "agent/required_tools",
+        source: include_str!("stdlib/agent/required_tools.harn"),
+    },
+    StdlibSource {
+        module: "agent/stall",
+        source: include_str!("stdlib/agent/stall.harn"),
+    },
+    StdlibSource {
+        module: "agent/control",
+        source: include_str!("stdlib/agent/control.harn"),
+    },
+    StdlibSource {
         module: "agent/loop",
         source: include_str!("stdlib/agent/loop.harn"),
     },

--- a/crates/harn-stdlib/src/stdlib/agent/control.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/control.harn
@@ -1,0 +1,358 @@
+import { agent_emit_event } from "std/agent/state"
+
+type AgentLoopCommandAction = "none" | "extend" | "stop"
+
+type AgentLoopCommand = {
+  action: AgentLoopCommandAction,
+  by: int,
+  until: int,
+  reason: string,
+  status: string,
+}
+
+type AgentLoopBudget = {
+  mode: string,
+  initial: int,
+  max: int,
+  extend_by: int,
+  expose_decisions: bool,
+}
+
+type AgentLoopBudgetDecision = {
+  iteration: int,
+  action: string,
+  old_limit: int,
+  new_limit: int,
+  reason: string,
+  status: string,
+}
+
+type AgentLoopCommandApplication = {
+  stop: bool,
+  final_status: string,
+  stop_reason: string?,
+  current_max: int,
+  extensions_used: int,
+  decisions: list<AgentLoopBudgetDecision>,
+}
+
+type AgentLoopState = {
+  iteration: int,
+  budget: dict,
+  turn: dict,
+  session: dict,
+  completion: dict,
+  progress: dict,
+}
+
+fn __agent_loop_state(args) -> AgentLoopState {
+  let current_limit = args.current_limit
+  let iteration = args.iteration
+  let remaining = if iteration >= current_limit {
+    0
+  } else {
+    current_limit - iteration
+  }
+  let missing = args.missing_required_tools
+  return {
+    iteration: iteration,
+    budget: {
+      current_limit: current_limit,
+      max: args.budget_max,
+      remaining: remaining,
+      extension_count: args.extensions_used,
+    },
+    turn: {
+      tool_call_count: args.turn_tool_count,
+      successful_tool_names: args.turn_successful,
+      rejected_tool_names: args.turn_rejected,
+      text_chars: args.turn_text_chars,
+      native_fallback_used: args.turn_native_fallback_used,
+    },
+    session: {
+      successful_tool_names: args.session_successful,
+      rejected_tool_names: args.session_rejected,
+      required_tools_satisfied: len(missing) == 0,
+      required_tools_missing: missing,
+    },
+    completion: {
+      proposed: args.completion_proposed,
+      vetoed: args.completion_vetoed,
+      verdict: args.completion_verdict,
+      feedback: args.completion_feedback,
+    },
+    progress: {changed: args.progress_changed, summary: args.progress_summary},
+  }
+}
+
+fn __agent_default_loop_control(state: AgentLoopState) {
+  if state.budget.remaining > 0 {
+    return nil
+  }
+  if state.completion.vetoed {
+    return {action: "extend", reason: "completion gate vetoed"}
+  }
+  if !state.session.required_tools_satisfied {
+    return {action: "extend", reason: "required tools missing"}
+  }
+  if state.progress.changed && state.turn.tool_call_count > 0 {
+    return {action: "extend", reason: "recent turn made progress"}
+  }
+  return nil
+}
+
+fn __agent_interpret_loop_command(command) -> AgentLoopCommand {
+  if command == nil {
+    return {action: "none", by: 0, until: 0, reason: "", status: ""}
+  }
+  if type_of(command) != "dict" {
+    throw "agent_loop: loop_control must return nil or a dict; got " + type_of(command)
+  }
+  let action = command?.action ?? "none"
+  if action != "none" && action != "extend" && action != "stop" {
+    throw "agent_loop: loop_control action must be \"none\", \"extend\", or \"stop\"; got "
+      + to_string(action)
+  }
+  let by = command?.by ?? 0
+  if type_of(by) != "int" {
+    throw "agent_loop: loop_control `by` must be an integer; got " + type_of(by)
+  }
+  let until = command?.until ?? 0
+  if type_of(until) != "int" {
+    throw "agent_loop: loop_control `until` must be an integer; got " + type_of(until)
+  }
+  return {action: action, by: by, until: until, reason: command?.reason ?? "", status: command?.status ?? ""}
+}
+
+/**
+ * agent_loop_control_invoke normalizes a custom or adaptive loop command.
+ *
+ * @effects: [agent]
+ * @allocation: heap
+ * @errors: [agent_loop]
+ * @api_stability: experimental
+ * @example: agent_loop_control_invoke(opts, budget, state)
+ */
+pub fn agent_loop_control_invoke(opts, budget: AgentLoopBudget, state: AgentLoopState) -> AgentLoopCommand {
+  let policy = opts?.loop_control
+  if policy != nil {
+    return __agent_interpret_loop_command(policy(state))
+  }
+  if budget.mode == "adaptive" {
+    return __agent_interpret_loop_command(__agent_default_loop_control(state))
+  }
+  return __agent_interpret_loop_command(nil)
+}
+
+fn __agent_apply_extension(command: AgentLoopCommand, budget: AgentLoopBudget, current_max: int) {
+  let cap = budget.max
+  let target = if command.until > 0 {
+    command.until
+  } else {
+    let by = if command.by > 0 {
+      command.by
+    } else {
+      budget.extend_by
+    }
+    current_max + by
+  }
+  let bounded = if target > cap {
+    cap
+  } else {
+    target
+  }
+  if bounded <= current_max {
+    return {extended: false, new_limit: current_max, delta: 0}
+  }
+  return {extended: true, new_limit: bounded, delta: bounded - current_max}
+}
+
+fn __agent_record_budget_decision(
+  decisions: list<AgentLoopBudgetDecision>,
+  iteration: int,
+  action: string,
+  old_limit: int,
+  new_limit: int,
+  reason: string,
+  status: string,
+) -> list<AgentLoopBudgetDecision> {
+  return decisions
+    .push(
+    {
+      iteration: iteration,
+      action: action,
+      old_limit: old_limit,
+      new_limit: new_limit,
+      reason: reason,
+      status: status,
+    },
+  )
+}
+
+fn __agent_progress_summary_text(completion_vetoed: bool, tool_count: int, visible_text: string) -> string {
+  if completion_vetoed {
+    return "completion gate vetoed"
+  }
+  if tool_count > 0 {
+    return "executed " + to_string(tool_count) + " tool call(s)"
+  }
+  if trim(visible_text) != "" {
+    return "produced visible text"
+  }
+  return "no progress signal"
+}
+
+/**
+ * agent_loop_snapshot_state builds the loop-control state callback payload.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: agent_loop_snapshot_state(args)
+ */
+pub fn agent_loop_snapshot_state(args) -> AgentLoopState {
+  let verdict = args.verdict
+  let completion_vetoed = verdict != nil && verdict?.vetoed
+  let completion_verdict = if verdict == nil {
+    nil
+  } else {
+    verdict?.verdict
+  }
+  let completion_feedback = if verdict == nil {
+    nil
+  } else {
+    verdict?.feedback
+  }
+  let visible_text = args.visible_text
+  let tool_count = args.tool_count
+  let turn_successful = args.turn_successful
+  let progress_changed = tool_count > 0 || len(turn_successful) > 0
+    || trim(visible_text) != ""
+  let progress_summary = __agent_progress_summary_text(completion_vetoed, tool_count, visible_text)
+  return __agent_loop_state(
+    {
+      iteration: args.iteration,
+      current_limit: args.current_limit,
+      budget_max: args.budget_max,
+      extensions_used: args.extensions_used,
+      turn_tool_count: tool_count,
+      turn_successful: turn_successful,
+      turn_rejected: args.turn_rejected,
+      turn_text_chars: len(visible_text),
+      turn_native_fallback_used: args.turn_native_fallback_used,
+      session_successful: args.session_successful,
+      session_rejected: args.session_rejected,
+      missing_required_tools: args.missing_required_tools,
+      completion_proposed: args.completion_proposed,
+      completion_vetoed: completion_vetoed,
+      completion_verdict: completion_verdict,
+      completion_feedback: completion_feedback,
+      progress_changed: progress_changed,
+      progress_summary: progress_summary,
+    },
+  )
+}
+
+/**
+ * agent_loop_apply_command applies a normalized command to the loop budget.
+ *
+ * @effects: [agent]
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: agent_loop_apply_command(state)
+ */
+pub fn agent_loop_apply_command(state) -> AgentLoopCommandApplication {
+  let command = state.command
+  let session_id = state.session_id
+  let iteration = state.iteration
+  let current_max = state.current_max
+  let budget = state.budget
+  if command.action == "stop" {
+    let stop_status = if command.status != "" {
+      command.status
+    } else {
+      "stopped"
+    }
+    let stop_reason = if command.reason != "" {
+      command.reason
+    } else {
+      "loop_control"
+    }
+    let decisions = __agent_record_budget_decision(
+      state.decisions,
+      iteration,
+      "stop",
+      current_max,
+      current_max,
+      command.reason,
+      stop_status,
+    )
+    agent_emit_event(
+      session_id,
+      "loop_control_decision",
+      {
+        iteration: iteration,
+        action: "stop",
+        old_limit: current_max,
+        new_limit: current_max,
+        reason: command.reason,
+        status: stop_status,
+      },
+    )
+    return {
+      stop: true,
+      final_status: stop_status,
+      stop_reason: stop_reason,
+      current_max: current_max,
+      extensions_used: state.extensions_used,
+      decisions: decisions,
+    }
+  }
+  if command.action == "extend" {
+    let applied = __agent_apply_extension(command, budget, current_max)
+    if applied.extended {
+      let old_limit = current_max
+      let new_limit = applied.new_limit
+      let extensions_used = state.extensions_used + 1
+      let decisions = __agent_record_budget_decision(
+        state.decisions,
+        iteration,
+        "extend",
+        old_limit,
+        new_limit,
+        command.reason,
+        "",
+      )
+      agent_emit_event(
+        session_id,
+        "loop_control_decision",
+        {
+          iteration: iteration,
+          action: "extend",
+          old_limit: old_limit,
+          new_limit: new_limit,
+          reason: command.reason,
+          status: "",
+        },
+      )
+      return {
+        stop: false,
+        final_status: "",
+        stop_reason: nil,
+        current_max: new_limit,
+        extensions_used: extensions_used,
+        decisions: decisions,
+      }
+    }
+  }
+  return {
+    stop: false,
+    final_status: "",
+    stop_reason: nil,
+    current_max: current_max,
+    extensions_used: state.extensions_used,
+    decisions: state.decisions,
+  }
+}

--- a/crates/harn-stdlib/src/stdlib/agent/loop.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/loop.harn
@@ -1,6 +1,11 @@
 // @harn-entrypoint-category agent.stdlib
 import { agent_autocompact_if_needed } from "std/agent/autocompact"
 import { agent_budget_post_call_blocked, agent_budget_pre_call_blocked } from "std/agent/budget"
+import {
+  agent_loop_apply_command,
+  agent_loop_control_invoke,
+  agent_loop_snapshot_state,
+} from "std/agent/control"
 import { agent_daemon_snapshot, agent_daemon_step } from "std/agent/daemon"
 import { agent_verify_or_continue } from "std/agent/judge"
 import { agent_mcp_bootstrap_if_needed } from "std/agent/mcp"
@@ -10,7 +15,19 @@ import { agent_build_turn_messages, agent_build_turn_system } from "std/agent/pr
 import { agent_dispatch_tool_batch, agent_dispatch_tool_call } from "std/agent/primitives"
 import { agent_progress_apply_options } from "std/agent/progress"
 import { native_tool_contract_feedback_prompt } from "std/agent/prompts"
+import {
+  agent_required_tools_enforce,
+  agent_required_tools_inject_feedback,
+  agent_required_tools_missing_from_session,
+} from "std/agent/required_tools"
 import { agent_skills_match } from "std/agent/skills"
+import {
+  agent_stall_apply_result,
+  agent_stall_done_judge_due,
+  agent_stall_initial_state,
+  agent_stall_inject_feedback,
+  agent_stall_observe_tool_calls,
+} from "std/agent/stall"
 import {
   agent_emit_event,
   agent_record_native_tool_fallback,
@@ -474,59 +491,6 @@ fn __agent_loop_await_resumption_top_level(session, iteration, call, parsed, opt
   }
 }
 
-fn __stall_diagnostics_config(value) {
-  if value == nil {
-    return {enabled: false}
-  }
-  if type_of(value) == "bool" {
-    return {
-      enabled: value,
-      threshold: 3,
-      inject_feedback: true,
-      max_feedback: 1,
-      exempt_tools: [],
-      include_arguments: false,
-    }
-  }
-  if type_of(value) != "dict" {
-    throw "agent_loop: `stall_diagnostics` must be a dict, bool, or nil; got " + type_of(value)
-  }
-  let enabled = value?.enabled
-  let resolved_enabled = if enabled == nil {
-    true
-  } else {
-    enabled
-  }
-  let threshold = value?.threshold ?? 3
-  let safe_threshold = if type_of(threshold) == "int" && threshold >= 2 {
-    threshold
-  } else {
-    3
-  }
-  let max_feedback = value?.max_feedback ?? 1
-  let safe_max_feedback = if type_of(max_feedback) == "int" && max_feedback >= 0 {
-    max_feedback
-  } else {
-    1
-  }
-  return {
-    enabled: resolved_enabled,
-    threshold: safe_threshold,
-    inject_feedback: value?.inject_feedback ?? true,
-    max_feedback: safe_max_feedback,
-    exempt_tools: value?.exempt_tools ?? value?.allow_repeated_tools ?? [],
-    include_arguments: value?.include_arguments ?? false,
-  }
-}
-
-fn __stall_initial_state() {
-  return {last_signature: "", streak: 0, warnings: [], repeated_tool_calls: 0, feedback_count: 0}
-}
-
-fn __stall_reset_state(state) {
-  return state + {last_signature: "", streak: 0}
-}
-
 fn __tool_call_name(call) {
   return to_string(call?.name ?? call?.tool_name ?? "")
 }
@@ -537,157 +501,6 @@ fn __tool_call_args(call) {
     return raw
   }
   return {}
-}
-
-fn __tool_call_signature(call) {
-  let args_text = json_stringify(__tool_call_args(call))
-  return __tool_call_name(call) + "\n" + args_text
-}
-
-fn __stall_feedback_text(warning) {
-  return "Stall diagnostic: the last "
-    + to_string(warning.repeat_count)
-    + " tool calls repeated `"
-    + warning.tool_name
-    + "` with identical arguments. Use different evidence, finish, or explain why another identical call is necessary before repeating it."
-}
-
-fn __stall_warning_record(iteration, tool_name, args, signature, repeat_count, config) {
-  let args_text = json_stringify(args)
-  var record = {
-    iteration: iteration,
-    tool_name: tool_name,
-    repeat_count: repeat_count,
-    threshold: config.threshold,
-    arguments_digest: "sha256:" + sha256(args_text),
-    signature_digest: "sha256:" + sha256(signature),
-  }
-  if config.include_arguments {
-    record = record + {arguments: args}
-  }
-  return record
-}
-
-fn __stall_inject_feedback(session_id, warning, config, state) {
-  let wants_feedback = config.inject_feedback ?? true
-  let should_feedback = wants_feedback && state.feedback_count < config.max_feedback
-  if should_feedback {
-    agent_session_inject_feedback(session_id, "stall_diagnostics", __stall_feedback_text(warning))
-    return state + {feedback_count: state.feedback_count + 1}
-  }
-  return state
-}
-
-fn __stall_maybe_emit(session_id, warning, config, state, defer_feedback) {
-  agent_emit_event(session_id, "agent_loop_stall_warning", warning)
-  if defer_feedback {
-    return {state: state, warning: warning, feedback_deferred: true}
-  }
-  return {
-    state: __stall_inject_feedback(session_id, warning, config, state),
-    warning: warning,
-    feedback_deferred: false,
-  }
-}
-
-fn __stall_observe_tool_calls(session_id, tool_calls, iteration, raw_config, state, defer_feedback) {
-  let config = __stall_diagnostics_config(raw_config)
-  if !config.enabled {
-    return {state: state, enabled: false, warning: nil, feedback_deferred: false, config: config}
-  }
-  if len(tool_calls) == 0 {
-    return {
-      state: __stall_reset_state(state),
-      enabled: true,
-      warning: nil,
-      feedback_deferred: false,
-      config: config,
-    }
-  }
-  var next_state = state
-  var emitted_warning = nil
-  var feedback_deferred = false
-  for call in tool_calls {
-    let tool_name = __tool_call_name(call)
-    if tool_name == "" || contains(config.exempt_tools, tool_name) {
-      next_state = __stall_reset_state(next_state)
-      continue
-    }
-    let signature = __tool_call_signature(call)
-    let streak = if signature == next_state.last_signature {
-      next_state.streak + 1
-    } else {
-      1
-    }
-    let repeated = if streak > 1 {
-      next_state.repeated_tool_calls + 1
-    } else {
-      next_state.repeated_tool_calls
-    }
-    next_state = next_state
-      + {last_signature: signature, streak: streak, repeated_tool_calls: repeated}
-    if streak == config.threshold {
-      let warning = __stall_warning_record(iteration, tool_name, __tool_call_args(call), signature, streak, config)
-      let emitted = __stall_maybe_emit(session_id, warning, config, next_state, defer_feedback)
-      next_state = emitted.state
-      if emitted_warning == nil {
-        emitted_warning = warning
-      }
-      feedback_deferred = feedback_deferred || emitted?.feedback_deferred ?? false
-      next_state = next_state + {warnings: next_state.warnings.push(warning)}
-    }
-  }
-  return {
-    state: next_state,
-    enabled: true,
-    warning: emitted_warning,
-    feedback_deferred: feedback_deferred,
-    config: config,
-  }
-}
-
-fn __apply_stall_result(result, stall_enabled, stall_state) {
-  if !stall_enabled && len(stall_state.warnings) == 0 {
-    return result
-  }
-  return result
-    + {
-    repeated_tool_calls: stall_state.repeated_tool_calls,
-    stall_warnings: stall_state.warnings,
-    suspected_loop: len(stall_state.warnings) > 0,
-  }
-}
-
-fn __done_judge_stall_cadence(opts) {
-  let judge = opts?.done_judge
-  if type_of(judge) != "dict" {
-    return nil
-  }
-  let cadence = judge?.cadence
-  if type_of(cadence) != "dict" || cadence?.when != "stalled" {
-    return nil
-  }
-  return cadence
-}
-
-fn __done_judge_stall_due(opts, invocations, turn_number) {
-  let cadence = __done_judge_stall_cadence(opts)
-  if cadence == nil {
-    return false
-  }
-  let max_invocations = cadence?.max_invocations
-  if max_invocations != nil && invocations >= max_invocations {
-    return false
-  }
-  let min_iterations = cadence?.min_iterations_before_first
-  if min_iterations != nil && turn_number <= min_iterations {
-    return false
-  }
-  let every = cadence?.every
-  if every != nil && turn_number % every != 0 {
-    return false
-  }
-  return true
 }
 
 fn __native_fallback_feedback(policy, fallback_index) {
@@ -1063,110 +876,6 @@ fn __turn_info_payload(llm_result, tool_count, visible_text) {
   }
 }
 
-fn __requirement_satisfied(requirement, successful) {
-  if type_of(requirement) == "list" {
-    for candidate in requirement {
-      if contains(successful, candidate) {
-        return true
-      }
-    }
-    return false
-  }
-  return contains(successful, requirement)
-}
-
-fn __requirement_label(requirement) {
-  if type_of(requirement) == "list" {
-    return join(requirement, "|")
-  }
-  return to_string(requirement)
-}
-
-fn __missing_required_successful_tools(result, opts) {
-  let required = opts?.require_successful_tools
-  if required == nil || len(required) == 0 {
-    return []
-  }
-  let successful = result?.tools?.successful ?? []
-  var missing = []
-  for requirement in required {
-    if !__requirement_satisfied(requirement, successful) {
-      missing = missing.push(__requirement_label(requirement))
-    }
-  }
-  return missing
-}
-
-fn __required_tools_friction_event(result, opts, missing) {
-  let session_id = to_string(result?.session_id ?? "")
-  var recurrence = ["missing_required_tools=" + to_string(len(missing))]
-  if opts?.persona != nil {
-    recurrence = recurrence.push("persona=" + to_string(opts.persona))
-  }
-  return {
-    kind: "tool_gap",
-    source: "agent_loop.require_successful_tools",
-    actor: opts?.persona,
-    run_id: if session_id == "" {
-      nil
-    } else {
-      session_id
-    },
-    redacted_summary: "agent_loop completed without invoking required tool(s): "
-      + join(missing, ", "),
-    recurrence_hints: recurrence,
-    metadata: {
-      missing_required_tools: missing,
-      successful_tool_names: result?.tools?.successful ?? [],
-      iterations: result?.llm?.iterations ?? 0,
-      preset_kind: opts?._preset_kind,
-    },
-  }
-}
-
-fn __require_successful_tools_envelope(result, missing, iterations) {
-  return {
-    schema_version: 1,
-    kind: "missing_required_tools",
-    reason: "Required tool(s) did not succeed",
-    missing: missing,
-    successful_tool_names: result?.tools?.successful ?? [],
-    iterations: iterations,
-  }
-}
-
-fn __maybe_emit_required_tools_friction(result, opts, missing) {
-  let event = __required_tools_friction_event(result, opts, missing)
-  let _ = try {
-    friction_record(event)
-  }
-  let session_id = to_string(result?.session_id ?? "")
-  if session_id != "" {
-    let _ = try {
-      agent_emit_event(session_id, "require_successful_tools_violation", event)
-    }
-  }
-}
-
-fn __enforce_required_successful_tools(result, opts) {
-  let missing = __missing_required_successful_tools(result, opts)
-  if len(missing) == 0 {
-    return result
-  }
-  let iterations = result?.llm?.iterations ?? 0
-  let envelope = __require_successful_tools_envelope(result, missing, iterations)
-  __maybe_emit_required_tools_friction(result, opts, missing)
-  return result
-    + {
-    status: "failed",
-    final_status: "failed",
-    stop_reason: "missing_required_tools",
-    missing_required_tools: missing,
-    error: "Required tools did not succeed: " + join(missing, ", "),
-    error_envelope: envelope,
-  }
-}
-
 fn __agent_loop_finalize_failed(session, iteration) {
   try {
     agent_session_finalize(
@@ -1241,320 +950,6 @@ fn __agent_loop_suspend_checkpoint(session, iteration) {
   return payload
 }
 
-fn __requirement_missing(requirement, successful) {
-  if type_of(requirement) == "list" {
-    for candidate in requirement {
-      if contains(successful, candidate) {
-        return false
-      }
-    }
-    return true
-  }
-  return !contains(successful, requirement)
-}
-
-fn __required_tools_missing_list(opts, successful_tools_seen) {
-  let required = opts?.require_successful_tools
-  if required == nil || len(required) == 0 {
-    return []
-  }
-  var missing = []
-  for requirement in required {
-    if __requirement_missing(requirement, successful_tools_seen) {
-      let label = if type_of(requirement) == "list" {
-        join(requirement, "|")
-      } else {
-        to_string(requirement)
-      }
-      missing = missing.push(label)
-    }
-  }
-  return missing
-}
-
-fn __required_tools_feedback(missing) {
-  return "Required tool(s) have not succeeded yet: "
-    + join(missing, ", ")
-    + ". Continue working and call the missing required tool(s) before finalizing."
-}
-
-fn __build_loop_state(args) {
-  let current_limit = args.current_limit
-  let iteration = args.iteration
-  let remaining = if iteration >= current_limit {
-    0
-  } else {
-    current_limit - iteration
-  }
-  let missing = args.missing_required_tools
-  return {
-    iteration: iteration,
-    budget: {
-      current_limit: current_limit,
-      max: args.budget_max,
-      remaining: remaining,
-      extension_count: args.extensions_used,
-    },
-    turn: {
-      tool_call_count: args.turn_tool_count,
-      successful_tool_names: args.turn_successful,
-      rejected_tool_names: args.turn_rejected,
-      text_chars: args.turn_text_chars,
-      native_fallback_used: args.turn_native_fallback_used,
-    },
-    session: {
-      successful_tool_names: args.session_successful,
-      rejected_tool_names: args.session_rejected,
-      required_tools_satisfied: len(missing) == 0,
-      required_tools_missing: missing,
-    },
-    completion: {
-      proposed: args.completion_proposed,
-      vetoed: args.completion_vetoed,
-      verdict: args.completion_verdict,
-      feedback: args.completion_feedback,
-    },
-    progress: {changed: args.progress_changed, summary: args.progress_summary},
-  }
-}
-
-fn __default_loop_control(state) {
-  if state.budget.remaining > 0 {
-    return nil
-  }
-  if state.completion.vetoed {
-    return {action: "extend", reason: "completion gate vetoed"}
-  }
-  if !state.session.required_tools_satisfied {
-    return {action: "extend", reason: "required tools missing"}
-  }
-  if state.progress.changed && state.turn.tool_call_count > 0 {
-    return {action: "extend", reason: "recent turn made progress"}
-  }
-  return nil
-}
-
-fn __interpret_loop_command(command) {
-  if command == nil {
-    return {action: "none", by: 0, until: 0, reason: "", status: ""}
-  }
-  if type_of(command) != "dict" {
-    throw "agent_loop: loop_control must return nil or a dict; got " + type_of(command)
-  }
-  let action = command?.action ?? "none"
-  if action != "none" && action != "extend" && action != "stop" {
-    throw "agent_loop: loop_control action must be \"none\", \"extend\", or \"stop\"; got "
-      + to_string(action)
-  }
-  let by = command?.by ?? 0
-  if type_of(by) != "int" {
-    throw "agent_loop: loop_control `by` must be an integer; got " + type_of(by)
-  }
-  let until = command?.until ?? 0
-  if type_of(until) != "int" {
-    throw "agent_loop: loop_control `until` must be an integer; got " + type_of(until)
-  }
-  return {action: action, by: by, until: until, reason: command?.reason ?? "", status: command?.status ?? ""}
-}
-
-fn __loop_control_invoke(opts, budget, state) {
-  let policy = opts?.loop_control
-  if policy != nil {
-    return __interpret_loop_command(policy(state))
-  }
-  if budget?.mode == "adaptive" {
-    return __interpret_loop_command(__default_loop_control(state))
-  }
-  return __interpret_loop_command(nil)
-}
-
-fn __apply_extension(command, budget, current_max) {
-  let cap = budget?.max ?? current_max
-  let target = if command.until > 0 {
-    command.until
-  } else {
-    let by = if command.by > 0 {
-      command.by
-    } else {
-      budget?.extend_by ?? 0
-    }
-    current_max + by
-  }
-  let bounded = if target > cap {
-    cap
-  } else {
-    target
-  }
-  if bounded <= current_max {
-    return {extended: false, new_limit: current_max, delta: 0}
-  }
-  return {extended: true, new_limit: bounded, delta: bounded - current_max}
-}
-
-fn __record_budget_decision(decisions, iteration, action, old_limit, new_limit, reason, status) {
-  return decisions
-    .push(
-    {
-      iteration: iteration,
-      action: action,
-      old_limit: old_limit,
-      new_limit: new_limit,
-      reason: reason,
-      status: status,
-    },
-  )
-}
-
-fn __progress_summary_text(completion_vetoed, tool_count, visible_text) {
-  if completion_vetoed {
-    return "completion gate vetoed"
-  }
-  if tool_count > 0 {
-    return "executed " + to_string(tool_count) + " tool call(s)"
-  }
-  if trim(visible_text) != "" {
-    return "produced visible text"
-  }
-  return "no progress signal"
-}
-
-fn __snapshot_loop_state(args) {
-  let verdict = args.verdict
-  let completion_vetoed = verdict != nil && verdict?.vetoed
-  let completion_verdict = if verdict == nil {
-    nil
-  } else {
-    verdict?.verdict
-  }
-  let completion_feedback = if verdict == nil {
-    nil
-  } else {
-    verdict?.feedback
-  }
-  let visible_text = args.visible_text
-  let tool_count = args.tool_count
-  let turn_successful = args.turn_successful
-  let progress_changed = tool_count > 0 || len(turn_successful) > 0
-    || trim(visible_text) != ""
-  let progress_summary = __progress_summary_text(completion_vetoed, tool_count, visible_text)
-  return __build_loop_state(
-    {
-      iteration: args.iteration,
-      current_limit: args.current_limit,
-      budget_max: args.budget_max,
-      extensions_used: args.extensions_used,
-      turn_tool_count: tool_count,
-      turn_successful: turn_successful,
-      turn_rejected: args.turn_rejected,
-      turn_text_chars: len(visible_text),
-      turn_native_fallback_used: args.turn_native_fallback_used,
-      session_successful: args.session_successful,
-      session_rejected: args.session_rejected,
-      missing_required_tools: args.missing_required_tools,
-      completion_proposed: args.completion_proposed,
-      completion_vetoed: completion_vetoed,
-      completion_verdict: completion_verdict,
-      completion_feedback: completion_feedback,
-      progress_changed: progress_changed,
-      progress_summary: progress_summary,
-    },
-  )
-}
-
-fn __apply_loop_command(state) {
-  let command = state.command
-  let session_id = state.session_id
-  let iteration = state.iteration
-  let current_max = state.current_max
-  let budget = state.budget
-  if command.action == "stop" {
-    let stop_status = if command.status != "" {
-      command.status
-    } else {
-      "stopped"
-    }
-    let stop_reason = if command.reason != "" {
-      command.reason
-    } else {
-      "loop_control"
-    }
-    let decisions = __record_budget_decision(
-      state.decisions,
-      iteration,
-      "stop",
-      current_max,
-      current_max,
-      command.reason,
-      stop_status,
-    )
-    agent_emit_event(
-      session_id,
-      "loop_control_decision",
-      {
-        iteration: iteration,
-        action: "stop",
-        old_limit: current_max,
-        new_limit: current_max,
-        reason: command.reason,
-        status: stop_status,
-      },
-    )
-    return {
-      stop: true,
-      final_status: stop_status,
-      stop_reason: stop_reason,
-      current_max: current_max,
-      extensions_used: state.extensions_used,
-      decisions: decisions,
-    }
-  }
-  if command.action == "extend" {
-    let applied = __apply_extension(command, budget, current_max)
-    if applied.extended {
-      let old_limit = current_max
-      let new_limit = applied.new_limit
-      let extensions_used = state.extensions_used + 1
-      let decisions = __record_budget_decision(
-        state.decisions,
-        iteration,
-        "extend",
-        old_limit,
-        new_limit,
-        command.reason,
-        "",
-      )
-      agent_emit_event(
-        session_id,
-        "loop_control_decision",
-        {
-          iteration: iteration,
-          action: "extend",
-          old_limit: old_limit,
-          new_limit: new_limit,
-          reason: command.reason,
-          status: "",
-        },
-      )
-      return {
-        stop: false,
-        final_status: "",
-        stop_reason: nil,
-        current_max: new_limit,
-        extensions_used: extensions_used,
-        decisions: decisions,
-      }
-    }
-  }
-  return {
-    stop: false,
-    final_status: "",
-    stop_reason: nil,
-    current_max: current_max,
-    extensions_used: state.extensions_used,
-    decisions: state.decisions,
-  }
-}
-
 fn __agent_loop_drain_bridge_step(session_id) {
   let immediate = agent_session_drain_bridge_injections(session_id, "interrupt_immediate")
   let finish_step = agent_session_drain_bridge_injections(session_id, "finish_step")
@@ -1614,7 +1009,7 @@ fn __agent_loop_run(message, session, initial_opts) {
     var successful_tools_seen = []
     var rejected_tools_seen = []
     var suspend_result = nil
-    var stall_state = __stall_initial_state()
+    var stall_state = agent_stall_initial_state()
     var stall_enabled_seen = false
     let max_verify_attempts = opts?.max_verify_attempts ?? 20
     let budget = opts?.iteration_budget
@@ -1721,8 +1116,8 @@ fn __agent_loop_run(message, session, initial_opts) {
         stop_reason = "suspended"
         break
       }
-      let stall_judge_due = __done_judge_stall_due(turn_opts, done_judge_invocations, turn_index + 1)
-      let stall_observation = __stall_observe_tool_calls(
+      let stall_judge_due = agent_stall_done_judge_due(turn_opts, done_judge_invocations, turn_index + 1)
+      let stall_observation = agent_stall_observe_tool_calls(
         session.session_id,
         tool_calls,
         turn_index + 1,
@@ -1732,7 +1127,8 @@ fn __agent_loop_run(message, session, initial_opts) {
       )
       stall_state = stall_observation.state
       stall_enabled_seen = stall_enabled_seen || stall_observation.enabled
-      if stall_judge_due && stall_observation?.warning != nil {
+      let stall_warning = stall_observation.warning
+      if stall_judge_due && stall_warning != nil {
         let stall_verify_opts = turn_opts
           + {_done_judge_due: true, _done_judge_trigger: "stalled"}
         let stall_verdict = agent_verify_or_continue(session, stall_verify_opts, "stalled", visible_text, turn_index + 1)
@@ -1740,10 +1136,10 @@ fn __agent_loop_run(message, session, initial_opts) {
           done_judge_invocations = done_judge_invocations + 1
         }
         if stall_verdict.vetoed {
-          if stall_observation?.feedback_deferred ?? false {
-            stall_state = __stall_inject_feedback(
+          if stall_observation.feedback_deferred {
+            stall_state = agent_stall_inject_feedback(
               session.session_id,
-              stall_observation.warning,
+              stall_warning,
               stall_observation.config,
               stall_state,
             )
@@ -1798,8 +1194,8 @@ fn __agent_loop_run(message, session, initial_opts) {
         stop_reason = "max_nudges"
         break
       }
-      let missing_required_for_loop = __required_tools_missing_list(opts, successful_tools_seen)
-      let cadence_loop_state = __snapshot_loop_state(
+      let missing_required_for_loop = agent_required_tools_missing_from_session(opts, successful_tools_seen)
+      let cadence_loop_state = agent_loop_snapshot_state(
         {
           iteration: iteration,
           current_limit: current_max,
@@ -1857,13 +1253,9 @@ fn __agent_loop_run(message, session, initial_opts) {
             should_continue = true
           }
         }
-        let missing_now = __required_tools_missing_list(opts, successful_tools_seen)
+        let missing_now = agent_required_tools_missing_from_session(opts, successful_tools_seen)
         if !should_continue && len(missing_now) > 0 {
-          agent_session_inject_feedback(
-            session.session_id,
-            "required_tools",
-            __required_tools_feedback(missing_now),
-          )
+          agent_required_tools_inject_feedback(session.session_id, missing_now)
           should_continue = true
         }
         if !should_continue {
@@ -1871,7 +1263,7 @@ fn __agent_loop_run(message, session, initial_opts) {
           break
         }
       }
-      let loop_state = __snapshot_loop_state(
+      let loop_state = agent_loop_snapshot_state(
         {
           iteration: iteration,
           current_limit: current_max,
@@ -1889,8 +1281,8 @@ fn __agent_loop_run(message, session, initial_opts) {
           verdict: verdict_record,
         },
       )
-      let command = __loop_control_invoke(opts, budget, loop_state)
-      let applied = __apply_loop_command(
+      let command = agent_loop_control_invoke(opts, budget, loop_state)
+      let applied = agent_loop_apply_command(
         {
           command: command,
           session_id: session.session_id,
@@ -1934,11 +1326,11 @@ fn __agent_loop_run(message, session, initial_opts) {
       },
     )
     session_finalized = true
-    let result_with_stalls = __apply_stall_result(result, stall_enabled_seen, stall_state)
+    let result_with_stalls = agent_stall_apply_result(result, stall_enabled_seen, stall_state)
     let enforced = if suspend_result != nil {
       result_with_stalls
     } else {
-      __enforce_required_successful_tools(result_with_stalls, opts)
+      agent_required_tools_enforce(result_with_stalls, opts)
     }
     var final_result = enforced
     if budget.expose_decisions {

--- a/crates/harn-stdlib/src/stdlib/agent/postturn.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/postturn.harn
@@ -151,7 +151,7 @@ fn __native_completion_context(opts, has_tool_calls, text) {
  * the model is "done" but has emitted ZERO tool_calls so far this
  * session (successful OR rejected — a failed tool call still shows
  * the model engaged the tool channel). This is the documented Qwen3
- * thinking + native tools failure signature (QwenLM/Qwen3.6 #89):
+ * thinking + native tools failure signature:
  * reasoning trace narrates tool intent ("let me run git..."), but
  * the structured tool_calls channel emits nothing at all. Once the
  * model has used the tool channel even once (even unsuccessfully),

--- a/crates/harn-stdlib/src/stdlib/agent/required_tools.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/required_tools.harn
@@ -1,0 +1,197 @@
+import { agent_emit_event, agent_session_inject_feedback } from "std/agent/state"
+
+type AgentRequiredToolRequirement = string | list<string>
+
+type AgentRequiredToolsEnvelope = {
+  schema_version: int,
+  kind: "missing_required_tools",
+  reason: string,
+  missing: list<string>,
+  successful_tool_names: list<string>,
+  iterations: int,
+}
+
+fn __agent_required_tool_satisfied(requirement: AgentRequiredToolRequirement, successful: list) -> bool {
+  if type_of(requirement) == "list" {
+    for candidate in requirement {
+      if contains(successful, candidate) {
+        return true
+      }
+    }
+    return false
+  }
+  return contains(successful, requirement)
+}
+
+fn __agent_required_tool_missing(requirement: AgentRequiredToolRequirement, successful: list) -> bool {
+  return !__agent_required_tool_satisfied(requirement, successful)
+}
+
+fn __agent_required_tool_label(requirement) -> string {
+  if type_of(requirement) == "list" {
+    return join(requirement, "|")
+  }
+  return to_string(requirement)
+}
+
+fn __agent_required_tools_from_options(opts) -> list {
+  let required = opts?.require_successful_tools
+  if required == nil {
+    return []
+  }
+  return required
+}
+
+/**
+ * agent_required_tools_missing_from_result returns missing required tools.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: agent_required_tools_missing_from_result(result, opts)
+ */
+pub fn agent_required_tools_missing_from_result(result: dict, opts) -> list<string> {
+  let required = __agent_required_tools_from_options(opts)
+  if len(required) == 0 {
+    return []
+  }
+  let successful = result?.tools?.successful ?? []
+  var missing = []
+  for requirement in required {
+    if !__agent_required_tool_satisfied(requirement, successful) {
+      missing = missing.push(__agent_required_tool_label(requirement))
+    }
+  }
+  return missing
+}
+
+/**
+ * agent_required_tools_missing_from_session returns missing accumulated tools.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: agent_required_tools_missing_from_session(opts, successful_tools_seen)
+ */
+pub fn agent_required_tools_missing_from_session(opts, successful_tools_seen: list) -> list<string> {
+  let required = __agent_required_tools_from_options(opts)
+  if len(required) == 0 {
+    return []
+  }
+  var missing = []
+  for requirement in required {
+    if __agent_required_tool_missing(requirement, successful_tools_seen) {
+      missing = missing.push(__agent_required_tool_label(requirement))
+    }
+  }
+  return missing
+}
+
+fn __agent_required_tools_friction_event(result: dict, opts, missing: list<string>) -> dict {
+  let session_id = to_string(result?.session_id ?? "")
+  var recurrence = ["missing_required_tools=" + to_string(len(missing))]
+  if opts?.persona != nil {
+    recurrence = recurrence.push("persona=" + to_string(opts.persona))
+  }
+  return {
+    kind: "tool_gap",
+    source: "agent_loop.require_successful_tools",
+    actor: opts?.persona,
+    run_id: if session_id == "" {
+      nil
+    } else {
+      session_id
+    },
+    redacted_summary: "agent_loop completed without invoking required tool(s): "
+      + join(missing, ", "),
+    recurrence_hints: recurrence,
+    metadata: {
+      missing_required_tools: missing,
+      successful_tool_names: result?.tools?.successful ?? [],
+      iterations: result?.llm?.iterations ?? 0,
+      preset_kind: opts?._preset_kind,
+    },
+  }
+}
+
+fn __agent_required_tools_envelope(result: dict, missing: list<string>, iterations: int) -> AgentRequiredToolsEnvelope {
+  return {
+    schema_version: 1,
+    kind: "missing_required_tools",
+    reason: "Required tool(s) did not succeed",
+    missing: missing,
+    successful_tool_names: result?.tools?.successful ?? [],
+    iterations: iterations,
+  }
+}
+
+fn __agent_required_tools_emit_friction(result: dict, opts, missing: list<string>) {
+  let event = __agent_required_tools_friction_event(result, opts, missing)
+  let _ = try {
+    friction_record(event)
+  }
+  let session_id = to_string(result?.session_id ?? "")
+  if session_id != "" {
+    let _ = try {
+      agent_emit_event(session_id, "require_successful_tools_violation", event)
+    }
+  }
+}
+
+/**
+ * agent_required_tools_enforce fails results that missed required tools.
+ *
+ * @effects: [agent]
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: agent_required_tools_enforce(result, opts)
+ */
+pub fn agent_required_tools_enforce(result: dict, opts) -> dict {
+  let missing = agent_required_tools_missing_from_result(result, opts)
+  if len(missing) == 0 {
+    return result
+  }
+  let iterations = result?.llm?.iterations ?? 0
+  let envelope = __agent_required_tools_envelope(result, missing, iterations)
+  __agent_required_tools_emit_friction(result, opts, missing)
+  return result
+    + {
+    status: "failed",
+    final_status: "failed",
+    stop_reason: "missing_required_tools",
+    missing_required_tools: missing,
+    error: "Required tools did not succeed: " + join(missing, ", "),
+    error_envelope: envelope,
+  }
+}
+
+/**
+ * agent_required_tools_feedback builds feedback for missing required tools.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: agent_required_tools_feedback(["run_tests"])
+ */
+pub fn agent_required_tools_feedback(missing: list<string>) -> string {
+  return "Required tool(s) have not succeeded yet: "
+    + join(missing, ", ")
+    + ". Continue working and call the missing required tool(s) before finalizing."
+}
+
+/**
+ * agent_required_tools_inject_feedback injects missing-tool feedback.
+ *
+ * @effects: [agent]
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: agent_required_tools_inject_feedback(session_id, missing)
+ */
+pub fn agent_required_tools_inject_feedback(session_id: string, missing: list<string>) {
+  agent_session_inject_feedback(session_id, "required_tools", agent_required_tools_feedback(missing))
+}

--- a/crates/harn-stdlib/src/stdlib/agent/resume_by.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/resume_by.harn
@@ -1,29 +1,29 @@
 /**
- * std/agent/resume_by — explicit resume-responsibility callbacks (S-14, harn#1864).
+ * std/agent/resume_by — explicit resume-responsibility callbacks.
  *
- * Replaces the legacy "infer resume responsibility from `conditions`"
- * dispatch with a callback-first surface (per epic #1853). Each preset
- * is a pure closure with signature `(harness, suspension) -> dict` so it
- * composes cleanly with every `std/lifecycle/combinators` helper.
+ * Each preset is a pure closure with signature `(harness, suspension) ->
+ * ResumeByDispatchResult` so it composes cleanly with every
+ * `std/lifecycle/combinators` helper.
  *
  * Import:
  *   import { ResumeBy, default_resume_by } from "std/agent/resume_by"
  *
  * Conventions:
- *   - Callbacks return a result dict shaped
- *     `{handled: bool, mechanism: string, reason?: string}`. The
- *     `mechanism` string is propagated to the suspension envelope as
- *     `resume_by_mechanism` so transcripts, replay, and audits all
- *     reference the same canonical name.
+ *   - Callbacks return `{handled: bool, mechanism: string, reason?: string}`.
+ *     The `mechanism` string is propagated to the suspension envelope as
+ *     `resume_by_mechanism` so transcripts, replay, and audits all reference
+ *     the same canonical name.
  *   - `handled: false` means the callback declined (e.g.
  *     `ResumeBy.cloud_harness` with no cloud session); composed chains
  *     such as `first_available(...)` continue to the next entry.
  *   - The runtime emits a `resume_by_dispatched` audit through
  *     `harness.emit_audit` on every handled invocation so behaviour is
  *     observable from `lifecycle_audit_log_take()`.
- *
- * Tracking: harn#1864 (S-14), harn#1836 (epic), harn#1853 (callback-first).
  */
+type ResumeByDispatchResult = {handled: bool, mechanism: string, reason?: string}
+
+type ResumeByCallback = fn(Harness, dict) -> ResumeByDispatchResult | dict | nil
+
 /**
  * first_handled walks `callbacks` in order with `(harness, suspension)`
  * and returns the first result whose `handled` field is `true`. This is
@@ -40,7 +40,7 @@
  * @api_stability: experimental
  * @example: first_handled([ResumeBy().cloud_harness, ResumeBy().local_runtime])
  */
-pub fn first_handled(callbacks) {
+pub fn first_handled(callbacks) -> ResumeByCallback {
   return { harness, suspension ->
     if type_of(callbacks) != "list" || len(callbacks) == 0 {
       return nil
@@ -111,9 +111,8 @@ fn __resume_by_cloud_session(harness) {
  * use it as the terminal entry in a `first_available(...)` chain.
  *
  * Emits a `resume_by_dispatched` audit with the suspension handle and
- * reason; downstream wiring to actually inject the parent-side reminder
- * lands when the harness exposes `emit_to_parent_transcript`
- * (tracked alongside harn#1853).
+ * reason. Parent-side reminder delivery is handled by the host surface that
+ * owns the parent transcript.
  *
  * @effects: [host]
  * @allocation: heap
@@ -121,14 +120,14 @@ fn __resume_by_cloud_session(harness) {
  * @api_stability: experimental
  * @example: resume_by_parent_llm(harness, suspension)
  */
-pub fn resume_by_parent_llm(harness, suspension) {
+pub fn resume_by_parent_llm(harness, suspension) -> ResumeByDispatchResult {
   __resume_by_emit(harness, suspension, "ResumeBy.parent_llm")
   return {handled: true, mechanism: "ResumeBy.parent_llm"}
 }
 
 /**
  * resume_by_local_runtime registers the suspension's resume conditions
- * with the in-process trigger dispatcher (#152). Declines with
+ * with the in-process trigger dispatcher. Declines with
  * `{handled: false, reason: "no_conditions"}` when no conditions are
  * present — the parent LLM must resume in that case.
  *
@@ -138,7 +137,7 @@ pub fn resume_by_parent_llm(harness, suspension) {
  * @api_stability: experimental
  * @example: resume_by_local_runtime(harness, suspension)
  */
-pub fn resume_by_local_runtime(harness, suspension) {
+pub fn resume_by_local_runtime(harness, suspension) -> ResumeByDispatchResult {
   if !__resume_by_has_conditions(suspension) {
     __resume_by_emit_declined(harness, suspension, "ResumeBy.local_runtime", "no_conditions")
     return {handled: false, mechanism: "ResumeBy.local_runtime", reason: "no_conditions"}
@@ -164,7 +163,7 @@ pub fn resume_by_local_runtime(harness, suspension) {
  * @api_stability: experimental
  * @example: resume_by_cloud_harness(harness, suspension)
  */
-pub fn resume_by_cloud_harness(harness, suspension) {
+pub fn resume_by_cloud_harness(harness, suspension) -> ResumeByDispatchResult {
   let session = __resume_by_cloud_session(harness)
   if session == nil {
     __resume_by_emit_declined(harness, suspension, "ResumeBy.cloud_harness", "no_cloud_session")
@@ -181,7 +180,7 @@ pub fn resume_by_cloud_harness(harness, suspension) {
 
 /**
  * resume_by_pipeline_drain defers the suspension to the enclosing
- * pipeline's drain step (#1853). Always returns
+ * pipeline's drain step. Always returns
  * `{handled: true, mechanism: "ResumeBy.pipeline_drain"}` so the
  * drain step owns the resume responsibility from there on.
  *
@@ -191,7 +190,7 @@ pub fn resume_by_cloud_harness(harness, suspension) {
  * @api_stability: experimental
  * @example: resume_by_pipeline_drain(harness, suspension)
  */
-pub fn resume_by_pipeline_drain(harness, suspension) {
+pub fn resume_by_pipeline_drain(harness, suspension) -> ResumeByDispatchResult {
   __resume_by_emit(harness, suspension, "ResumeBy.pipeline_drain")
   return {handled: true, mechanism: "ResumeBy.pipeline_drain"}
 }
@@ -242,7 +241,7 @@ pub fn ResumeBy() {
  * @api_stability: experimental
  * @example: default_resume_by({conditions: cond, harness: harness})
  */
-pub fn default_resume_by(opts = nil) {
+pub fn default_resume_by(opts = nil) -> ResumeByCallback {
   let conditions = opts?.conditions
   let harness = opts?.harness
   let has_conditions = if conditions == nil {
@@ -275,7 +274,7 @@ pub fn default_resume_by(opts = nil) {
  * @api_stability: experimental
  * @example: invoke_resume_by(callback, harness, suspension)
  */
-pub fn invoke_resume_by(callback, harness, suspension) {
+pub fn invoke_resume_by(callback, harness, suspension) -> ResumeByDispatchResult | dict {
   let cb = if callback == nil {
     resume_by_parent_llm
   } else {
@@ -289,12 +288,12 @@ pub fn invoke_resume_by(callback, harness, suspension) {
       harness
         .emit_audit(
         "resume_by_errored",
-        __resume_by_payload(suspension, "callback", {error: to_string(outcome)}),
+        __resume_by_payload(suspension, "callback", {error: to_string(unwrap_err(outcome))}),
       )
     }
     nil
   } else {
-    outcome
+    unwrap(outcome)
   }
   if resolved == nil || !resolved?.handled {
     if harness != nil {

--- a/crates/harn-stdlib/src/stdlib/agent/stall.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/stall.harn
@@ -1,0 +1,353 @@
+import { agent_emit_event, agent_session_inject_feedback } from "std/agent/state"
+
+type AgentStallConfig = {
+  enabled: bool,
+  threshold: int,
+  inject_feedback: bool,
+  max_feedback: int,
+  exempt_tools: list,
+  include_arguments: bool,
+}
+
+type AgentStallWarning = {
+  iteration: int,
+  tool_name: string,
+  repeat_count: int,
+  threshold: int,
+  arguments_digest: string,
+  signature_digest: string,
+  arguments?: dict,
+}
+
+type AgentStallState = {
+  last_signature: string,
+  streak: int,
+  warnings: list<AgentStallWarning>,
+  repeated_tool_calls: int,
+  feedback_count: int,
+}
+
+type AgentStallObservation = {
+  state: AgentStallState,
+  enabled: bool,
+  warning: AgentStallWarning?,
+  feedback_deferred: bool,
+  config: AgentStallConfig,
+}
+
+fn __agent_stall_bool(value, fallback: bool, field: string) -> bool {
+  if value == nil {
+    return fallback
+  }
+  if type_of(value) == "bool" {
+    return value
+  }
+  throw "agent_loop: stall_diagnostics." + field + " must be a bool; got " + type_of(value)
+}
+
+fn __agent_stall_list(value, field: string) -> list {
+  if value == nil {
+    return []
+  }
+  if type_of(value) == "list" {
+    return value
+  }
+  throw "agent_loop: stall_diagnostics." + field + " must be a list; got " + type_of(value)
+}
+
+fn __agent_stall_config(value) -> AgentStallConfig {
+  if value == nil {
+    return {
+      enabled: false,
+      threshold: 3,
+      inject_feedback: true,
+      max_feedback: 1,
+      exempt_tools: [],
+      include_arguments: false,
+    }
+  }
+  if type_of(value) == "bool" {
+    return {
+      enabled: value,
+      threshold: 3,
+      inject_feedback: true,
+      max_feedback: 1,
+      exempt_tools: [],
+      include_arguments: false,
+    }
+  }
+  if type_of(value) != "dict" {
+    throw "agent_loop: `stall_diagnostics` must be a dict, bool, or nil; got " + type_of(value)
+  }
+  let threshold = value?.threshold ?? 3
+  let max_feedback = value?.max_feedback ?? 1
+  let exempt_tools = if value?.exempt_tools != nil {
+    __agent_stall_list(value.exempt_tools, "exempt_tools")
+  } else {
+    __agent_stall_list(value?.allow_repeated_tools, "allow_repeated_tools")
+  }
+  return {
+    enabled: __agent_stall_bool(value?.enabled, true, "enabled"),
+    threshold: if type_of(threshold) == "int" && threshold >= 2 {
+      threshold
+    } else {
+      3
+    },
+    inject_feedback: __agent_stall_bool(value?.inject_feedback, true, "inject_feedback"),
+    max_feedback: if type_of(max_feedback) == "int" && max_feedback >= 0 {
+      max_feedback
+    } else {
+      1
+    },
+    exempt_tools: exempt_tools,
+    include_arguments: __agent_stall_bool(value?.include_arguments, false, "include_arguments"),
+  }
+}
+
+/**
+ * agent_stall_initial_state creates repeated-tool-call diagnostic state.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: agent_stall_initial_state()
+ */
+pub fn agent_stall_initial_state() -> AgentStallState {
+  return {last_signature: "", streak: 0, warnings: [], repeated_tool_calls: 0, feedback_count: 0}
+}
+
+fn __agent_stall_reset_state(state: AgentStallState) -> AgentStallState {
+  return state + {last_signature: "", streak: 0}
+}
+
+fn __agent_tool_call_name(call) -> string {
+  return to_string(call?.name ?? call?.tool_name ?? "")
+}
+
+fn __agent_tool_call_args(call) -> dict {
+  let raw = call?.arguments ?? call?.tool_args
+  if type_of(raw) == "dict" {
+    return raw
+  }
+  return {}
+}
+
+fn __agent_tool_call_signature(call) -> string {
+  let args_text = json_stringify(__agent_tool_call_args(call))
+  return __agent_tool_call_name(call) + "\n" + args_text
+}
+
+fn __agent_stall_feedback_text(warning: AgentStallWarning) -> string {
+  return "Stall diagnostic: the last "
+    + to_string(warning.repeat_count)
+    + " tool calls repeated `"
+    + warning.tool_name
+    + "` with identical arguments. Use different evidence, finish, or explain why another identical call is necessary before repeating it."
+}
+
+fn __agent_stall_warning_record(
+  iteration: int,
+  tool_name: string,
+  args: dict,
+  signature: string,
+  repeat_count: int,
+  config: AgentStallConfig,
+) -> AgentStallWarning {
+  let args_text = json_stringify(args)
+  var record = {
+    iteration: iteration,
+    tool_name: tool_name,
+    repeat_count: repeat_count,
+    threshold: config.threshold,
+    arguments_digest: "sha256:" + sha256(args_text),
+    signature_digest: "sha256:" + sha256(signature),
+  }
+  if config.include_arguments {
+    record = record + {arguments: args}
+  }
+  return record
+}
+
+/**
+ * agent_stall_inject_feedback injects bounded stall feedback.
+ *
+ * @effects: [agent]
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: agent_stall_inject_feedback(session_id, warning, config, state)
+ */
+pub fn agent_stall_inject_feedback(
+  session_id: string,
+  warning: AgentStallWarning,
+  config: AgentStallConfig,
+  state: AgentStallState,
+) -> AgentStallState {
+  let wants_feedback = config.inject_feedback ?? true
+  let should_feedback = wants_feedback && state.feedback_count < config.max_feedback
+  if should_feedback {
+    agent_session_inject_feedback(session_id, "stall_diagnostics", __agent_stall_feedback_text(warning))
+    return state + {feedback_count: state.feedback_count + 1}
+  }
+  return state
+}
+
+fn __agent_stall_maybe_emit(
+  session_id: string,
+  warning: AgentStallWarning,
+  config: AgentStallConfig,
+  state: AgentStallState,
+  defer_feedback: bool,
+) {
+  agent_emit_event(session_id, "agent_loop_stall_warning", warning)
+  if defer_feedback {
+    return {state: state, warning: warning, feedback_deferred: true}
+  }
+  return {
+    state: agent_stall_inject_feedback(session_id, warning, config, state),
+    warning: warning,
+    feedback_deferred: false,
+  }
+}
+
+/**
+ * agent_stall_observe_tool_calls detects repeated identical tool calls.
+ *
+ * @effects: [agent]
+ * @allocation: heap
+ * @errors: [agent_loop]
+ * @api_stability: experimental
+ * @example: agent_stall_observe_tool_calls(session_id, calls, iteration, config, state, true)
+ */
+pub fn agent_stall_observe_tool_calls(
+  session_id: string,
+  tool_calls: list,
+  iteration: int,
+  raw_config,
+  state: AgentStallState,
+  defer_feedback: bool,
+) -> AgentStallObservation {
+  let config = __agent_stall_config(raw_config)
+  if !config.enabled {
+    return {state: state, enabled: false, warning: nil, feedback_deferred: false, config: config}
+  }
+  if len(tool_calls) == 0 {
+    return {
+      state: __agent_stall_reset_state(state),
+      enabled: true,
+      warning: nil,
+      feedback_deferred: false,
+      config: config,
+    }
+  }
+  var next_state = state
+  var emitted_warning = nil
+  var feedback_deferred = false
+  for call in tool_calls {
+    let tool_name = __agent_tool_call_name(call)
+    if tool_name == "" || contains(config.exempt_tools, tool_name) {
+      next_state = __agent_stall_reset_state(next_state)
+      continue
+    }
+    let signature = __agent_tool_call_signature(call)
+    let streak = if signature == next_state.last_signature {
+      next_state.streak + 1
+    } else {
+      1
+    }
+    let repeated = if streak > 1 {
+      next_state.repeated_tool_calls + 1
+    } else {
+      next_state.repeated_tool_calls
+    }
+    next_state = next_state
+      + {last_signature: signature, streak: streak, repeated_tool_calls: repeated}
+    if streak == config.threshold {
+      let warning = __agent_stall_warning_record(
+        iteration,
+        tool_name,
+        __agent_tool_call_args(call),
+        signature,
+        streak,
+        config,
+      )
+      let emitted = __agent_stall_maybe_emit(session_id, warning, config, next_state, defer_feedback)
+      next_state = emitted.state
+      if emitted_warning == nil {
+        emitted_warning = warning
+      }
+      feedback_deferred = feedback_deferred || emitted?.feedback_deferred ?? false
+      next_state = next_state + {warnings: next_state.warnings.push(warning)}
+    }
+  }
+  return {
+    state: next_state,
+    enabled: true,
+    warning: emitted_warning,
+    feedback_deferred: feedback_deferred,
+    config: config,
+  }
+}
+
+/**
+ * agent_stall_apply_result adds stall diagnostics to an agent-loop result.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: agent_stall_apply_result(result, enabled, state)
+ */
+pub fn agent_stall_apply_result(result: dict, stall_enabled: bool, stall_state: AgentStallState) -> dict {
+  if !stall_enabled && len(stall_state.warnings) == 0 {
+    return result
+  }
+  return result
+    + {
+    repeated_tool_calls: stall_state.repeated_tool_calls,
+    stall_warnings: stall_state.warnings,
+    suspected_loop: len(stall_state.warnings) > 0,
+  }
+}
+
+fn __agent_done_judge_stall_cadence(opts) {
+  let judge = opts?.done_judge
+  if type_of(judge) != "dict" {
+    return nil
+  }
+  let cadence = judge?.cadence
+  if type_of(cadence) != "dict" || cadence?.when != "stalled" {
+    return nil
+  }
+  return cadence
+}
+
+/**
+ * agent_stall_done_judge_due decides whether the stall done judge is due.
+ *
+ * @effects: []
+ * @allocation: stack
+ * @errors: []
+ * @api_stability: experimental
+ * @example: agent_stall_done_judge_due(opts, 0, 3)
+ */
+pub fn agent_stall_done_judge_due(opts, invocations: int, turn_number: int) -> bool {
+  let cadence = __agent_done_judge_stall_cadence(opts)
+  if cadence == nil {
+    return false
+  }
+  let max_invocations = cadence?.max_invocations
+  if max_invocations != nil && invocations >= max_invocations {
+    return false
+  }
+  let min_iterations = cadence?.min_iterations_before_first
+  if min_iterations != nil && turn_number <= min_iterations {
+    return false
+  }
+  let every = cadence?.every
+  if every != nil && turn_number % every != 0 {
+    return false
+  }
+  return true
+}

--- a/crates/harn-stdlib/src/stdlib/agent/workers.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/workers.harn
@@ -8,7 +8,15 @@ type ResumeTimeoutSpec = {duration_minutes: int, on_timeout: ResumeTimeoutAction
 
 type ResumeConditions = {trigger: dict?, timeout: ResumeTimeoutSpec?, on_event: string?}
 
-type AgentAwaitResumptionRequest = {reason: string, conditions: ResumeConditions?}
+type ResumeByResult = {handled: bool, mechanism: string, reason?: string}
+
+type ResumeByCallback = fn(Harness, dict) -> ResumeByResult | dict | nil
+
+type AgentAwaitResumptionRequest = {
+  reason: string,
+  conditions: ResumeConditions?,
+  resume_by?: ResumeByCallback,
+}
 
 fn __agent_option_keys() {
   return [
@@ -72,11 +80,11 @@ pub fn agent(name, config = nil) {
  * @api_stability: experimental
  * @example: agent_name(agent)
  */
-pub fn agent_name(agent) {
-  if type_of(agent) != "dict" {
+pub fn agent_name(spec) {
+  if type_of(spec) != "dict" {
     throw "agent_name: argument must be an agent"
   }
-  return agent?.name
+  return spec?.name
 }
 
 /**
@@ -88,12 +96,12 @@ pub fn agent_name(agent) {
  * @api_stability: experimental
  * @example: agent_config(agent, prompt)
  */
-pub fn agent_config(agent, prompt) {
-  if type_of(agent) != "dict" || agent?._type != "agent" {
+pub fn agent_config(spec, prompt) {
+  if type_of(spec) != "dict" || spec?._type != "agent" {
     throw "agent_config: first argument must be an agent (created with agent())"
   }
-  let options = pick_keys(agent, __agent_option_keys(), {drop_nil: true})
-  return {prompt: prompt, system: agent?.system, options: options}
+  let options = pick_keys(spec, __agent_option_keys(), {drop_nil: true})
+  return {prompt: prompt, system: spec?.system, options: options}
 }
 
 fn __worker_dict(value) {
@@ -388,8 +396,8 @@ pub fn parse_resume_conditions(conditions = nil) -> ResumeConditions? {
  * daemon idle metadata.
  *
  * The optional `resume_by` argument names the callback that owns this
- * suspension's resume responsibility (S-14, harn#1864). Pass any
- * `(harness, suspension) -> {handled, mechanism}` closure — typically
+ * suspension's resume responsibility. Pass any `(harness, suspension) ->
+ * {handled, mechanism}` closure — typically
  * one of the four `ResumeBy.*` presets from `std/agent/resume_by`, or a
  * `first_available(...)` chain. When omitted, the runtime calls
  * `default_resume_by(...)` to pick a sensible default based on the

--- a/crates/harn-stdlib/src/stdlib/stdlib_agents.harn
+++ b/crates/harn-stdlib/src/stdlib/stdlib_agents.harn
@@ -161,7 +161,8 @@ pub fn verify_command(config) {
   let output = host_call("process.exec", {mode: "shell", command: config?.command, shell_id: shell?.id})
   var ok = output?.success
   if config?.expect_status != nil {
-    ok = output?.exit_code ?? output?.legacy_status ?? output?.status == config?.expect_status
+    let actual_status = output?.exit_code ?? output?.legacy_status ?? output?.status
+    ok = actual_status == config.expect_status
   }
   if config?.expect_text != nil {
     ok = ok && contains(output?.combined ?? "", config?.expect_text)
@@ -1248,61 +1249,25 @@ pub fn workflow_result_text(result) {
   return json_stringify(raw)
 }
 
-/**
- * workflow_result_transcript.
- *
- * @effects: []
- * @allocation: heap
- * @errors: []
- * @api_stability: stable
- * @example: workflow_result_transcript(task, workflow_name, result, metadata)
- */
-pub fn workflow_result_transcript(task, workflow_name, result, metadata) {
-  let existing = result?.run?.transcript ?? result?.transcript ?? result?.result?.transcript
-  if existing {
-    return existing
-  }
-  var built = transcript(metadata ?? {} + {workflow: workflow_name})
+fn __workflow_existing_transcript(result) {
+  return result?.run?.transcript ?? result?.transcript ?? result?.result?.transcript
+}
+
+fn __workflow_build_transcript(task, workflow_name, text: string, metadata) {
+  let base_metadata = metadata ?? {}
+  let transcript_metadata = base_metadata + {workflow: workflow_name}
+  var built = transcript(transcript_metadata)
   if task {
     built = add_user(built, [{type: "text", text: task, visibility: "public"}])
   }
-  let text = workflow_result_text(result)
   if text {
     built = add_assistant(built, [{type: "output_text", text: text, visibility: "public"}])
   }
   return built
 }
 
-/**
- * workflow_result_run.
- *
- * @effects: []
- * @allocation: heap
- * @errors: []
- * @api_stability: stable
- * @example: workflow_result_run(task, workflow_name, result, artifacts, options)
- */
-pub fn workflow_result_run(task, workflow_name, result, artifacts, options) {
-  let base_run = if result?._type == "run_record" {
-    result
-  } else {
-    result?.run ?? {}
-  }
-  let text = workflow_result_text(result)
-  let metadata = base_run?.metadata ?? {} + options?.metadata ?? {}
-  let transcript = if result?.run?.transcript ?? result?.transcript ?? result?.result?.transcript {
-    result?.run?.transcript ?? result?.transcript ?? result?.result?.transcript
-  } else {
-    var built = transcript(metadata ?? {} + {workflow: workflow_name})
-    if task {
-      built = add_user(built, [{type: "text", text: task, visibility: "public"}])
-    }
-    if text {
-      built = add_assistant(built, [{type: "output_text", text: text, visibility: "public"}])
-    }
-    built
-  }
-  var run_artifacts = base_run?.artifacts ?? result?.artifacts ?? artifacts ?? []
+fn __workflow_result_artifacts(existing, text: string, workflow_name) {
+  var run_artifacts = existing ?? []
   var has_visible_result_artifact = false
   if text {
     for item in run_artifacts {
@@ -1327,6 +1292,60 @@ pub fn workflow_result_run(task, workflow_name, result, artifacts, options) {
       ]
     }
   }
+  return run_artifacts
+}
+
+fn __workflow_result_metadata(base_run, options) {
+  let base_metadata = base_run?.metadata ?? {}
+  let option_metadata = options?.metadata ?? {}
+  return base_metadata + option_metadata
+}
+
+/**
+ * workflow_result_transcript.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: stable
+ * @example: workflow_result_transcript(task, workflow_name, result, metadata)
+ */
+pub fn workflow_result_transcript(task, workflow_name, result, metadata) {
+  let existing = __workflow_existing_transcript(result)
+  if existing {
+    return existing
+  }
+  let text = workflow_result_text(result)
+  return __workflow_build_transcript(task, workflow_name, text, metadata)
+}
+
+/**
+ * workflow_result_run.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: stable
+ * @example: workflow_result_run(task, workflow_name, result, artifacts, options)
+ */
+pub fn workflow_result_run(task, workflow_name, result, artifacts, options) {
+  let base_run = if result?._type == "run_record" {
+    result
+  } else {
+    result?.run ?? {}
+  }
+  let text = workflow_result_text(result)
+  let metadata = __workflow_result_metadata(base_run, options)
+  let transcript = if __workflow_existing_transcript(result) {
+    __workflow_existing_transcript(result)
+  } else {
+    __workflow_build_transcript(task, workflow_name, text, metadata)
+  }
+  let run_artifacts = __workflow_result_artifacts(
+    base_run?.artifacts ?? result?.artifacts ?? artifacts,
+    text,
+    workflow_name,
+  )
   return run_record(
     base_run
       + {
@@ -1358,44 +1377,17 @@ pub fn workflow_result_persist(task, workflow_name, result, artifacts, options) 
     result?.run ?? {}
   }
   let text = workflow_result_text(result)
-  let metadata = base_run?.metadata ?? {} + options?.metadata ?? {}
-  let transcript = if result?.run?.transcript ?? result?.transcript ?? result?.result?.transcript {
-    result?.run?.transcript ?? result?.transcript ?? result?.result?.transcript
+  let metadata = __workflow_result_metadata(base_run, options)
+  let transcript = if __workflow_existing_transcript(result) {
+    __workflow_existing_transcript(result)
   } else {
-    var built = transcript(metadata ?? {} + {workflow: workflow_name})
-    if task {
-      built = add_user(built, [{type: "text", text: task, visibility: "public"}])
-    }
-    if text {
-      built = add_assistant(built, [{type: "output_text", text: text, visibility: "public"}])
-    }
-    built
+    __workflow_build_transcript(task, workflow_name, text, metadata)
   }
-  var run_artifacts = base_run?.artifacts ?? result?.artifacts ?? artifacts ?? []
-  var has_visible_result_artifact = false
-  if text {
-    for item in run_artifacts {
-      if item?.text == text {
-        has_visible_result_artifact = true
-      }
-    }
-    if !has_visible_result_artifact {
-      run_artifacts = run_artifacts
-        + [
-        artifact(
-          {
-            kind: "summary",
-            title: "Visible result",
-            text: text,
-            source: workflow_name,
-            freshness: "fresh",
-            relevance: 1.0,
-            metadata: {visibility: "public"},
-          },
-        ),
-      ]
-    }
-  }
+  let run_artifacts = __workflow_result_artifacts(
+    base_run?.artifacts ?? result?.artifacts ?? artifacts,
+    text,
+    workflow_name,
+  )
   let run = run_record(
     base_run
       + {

--- a/crates/harn-vm/src/stdlib/agents.rs
+++ b/crates/harn-vm/src/stdlib/agents.rs
@@ -26,8 +26,8 @@ use self::agents_workers::{
     parse_worker_config, persist_worker_state_snapshot, reset_worker_registry, spawn_worker_task,
     with_worker_state, worker_event_snapshot, worker_id_from_value, worker_request_for_config,
     worker_snapshot_path, worker_summary, worker_trigger_payload_text, worker_wait_blocks,
-    SuspendInitiator, WorkerCarryPolicy, WorkerConfig, WorkerExecutionProfile, WorkerState,
-    WorkerSuspension, WORKER_REGISTRY,
+    SuspendInitiator, WorkerCarryPolicy, WorkerConfig, WorkerExecutionProfile, WorkerInit,
+    WorkerState, WorkerSuspension, WORKER_REGISTRY,
 };
 use self::sub_agent::{execute_sub_agent, parse_sub_agent_request};
 use crate::agent_events::WorkerEvent;
@@ -220,8 +220,8 @@ impl Drop for LifecycleSpanGuard {
     }
 }
 
-/// S-18 (harn#1867): apply the canonical attribute bag to a suspension
-/// lifecycle span. Kept in one helper so suspend_agent_builtin and
+/// Apply the canonical attribute bag to a suspension lifecycle span.
+/// Kept in one helper so suspend_agent_builtin and
 /// top_level_agent_suspend_builtin emit identically shaped spans for
 /// OTel exporters and downstream queries.
 ///
@@ -240,9 +240,8 @@ fn annotate_suspension_span(
     has_conditions: bool,
 ) {
     span.set_metadata("worker_id", serde_json::json!(worker_id));
-    // `handle` is the canonical OTel attribute name per the issue spec
-    // (#1867 acceptance criteria); we keep `worker_id` for back-compat
-    // with the P-05/P-06 attributes already shipped.
+    // `handle` is the canonical OTel attribute name for suspension spans;
+    // `worker_id` remains for consumers that join against worker events.
     span.set_metadata("handle", serde_json::json!(worker_id));
     span.set_metadata("reason", serde_json::json!(reason));
     span.set_metadata(
@@ -251,10 +250,8 @@ fn annotate_suspension_span(
     );
     span.set_metadata("has_conditions", serde_json::json!(has_conditions));
     if let Some(pipeline_span_link) = pipeline_span_link {
-        // `pipeline_id` is the issue's spec-level attribute; we use the
-        // active pipeline span's id since worker state does not carry a
-        // distinct pipeline identifier. `pipeline_span_id` is preserved
-        // for back-compat with the P-05 attribute.
+        // Worker state does not carry a distinct pipeline identifier, so the
+        // active pipeline span id is the stable cross-span join key.
         span.set_metadata(
             "pipeline_span_id",
             serde_json::json!(pipeline_span_link.span_id),
@@ -266,8 +263,8 @@ fn annotate_suspension_span(
     }
 }
 
-/// S-18 (harn#1867): apply the canonical attribute bag to a resume
-/// lifecycle span. Booleans describe the shape of the resume (transcript
+/// Apply the canonical attribute bag to a resume lifecycle span.
+/// Booleans describe the shape of the resume (transcript
 /// continuity, fresh resume input) without exposing transcript text or
 /// the resume payload itself.
 fn annotate_resume_span(
@@ -464,40 +461,52 @@ async fn sub_agent_run_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
         return Ok(crate::stdlib::json_to_vm_value(&result.payload));
     }
 
-    let worker_id = next_worker_id();
-    let created_at = uuid::Uuid::now_v7().to_string();
-    let mut audit = agents_workers::inherited_worker_audit("sub_agent");
-    audit.worker_id = Some(worker_id.clone());
     let execution = request.execution;
     let worker_policy = request.worker_policy;
     let mut carry_policy = request.carry_policy;
     carry_policy.policy = worker_policy;
     let spec = request.spec;
-    let worker_name = spec.name.clone();
-    let worker_task = spec.task.clone();
-    let mut config = WorkerConfig::SubAgent {
-        spec: Box::new(spec),
+    let init = WorkerInit {
+        name: spec.name.clone(),
+        task: spec.task.clone(),
+        config: WorkerConfig::SubAgent {
+            spec: Box::new(spec),
+        },
+        wait: false,
+        carry_policy,
+        execution,
+        audit: agents_workers::inherited_worker_audit("sub_agent"),
     };
-    ensure_worker_config_session_ids(&mut config, &worker_id);
-    let original_request = worker_request_for_config(&worker_task, &config);
-    let state = Rc::new(RefCell::new(WorkerState {
+    let state = fresh_worker_state(next_worker_id(), init);
+    finalize_and_run_worker(state, false, "sub_agent worker").await
+}
+
+fn fresh_worker_state(worker_id: String, mut init: WorkerInit) -> Rc<RefCell<WorkerState>> {
+    let created_at = uuid::Uuid::now_v7().to_string();
+    ensure_worker_config_session_ids(&mut init.config, &worker_id);
+    let mode = worker_mode_label(&init.config).to_string();
+    let mut audit = init.audit.normalize();
+    audit.worker_id = Some(worker_id.clone());
+    audit.execution_kind = Some(mode.clone());
+    let request = worker_request_for_config(&init.task, &init.config);
+    Rc::new(RefCell::new(WorkerState {
         id: worker_id.clone(),
-        name: worker_name,
-        task: worker_task.clone(),
+        name: init.name,
+        task: init.task.clone(),
         status: "running".to_string(),
         created_at: created_at.clone(),
         started_at: created_at,
         finished_at: None,
         awaiting_started_at: None,
         awaiting_since: None,
-        mode: "sub_agent".to_string(),
-        history: vec![worker_task],
-        config,
+        mode,
+        history: vec![init.task],
+        config: init.config,
         handle: None,
         cancel_token: Arc::new(AtomicBool::new(false)),
         suspend_signal: Arc::new(AtomicBool::new(false)),
         suspension: None,
-        request: original_request,
+        request,
         latest_payload: None,
         latest_error: None,
         transcript: None,
@@ -506,20 +515,15 @@ async fn sub_agent_run_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
         parent_stage_id: None,
         child_run_id: None,
         child_run_path: None,
-        carry_policy,
-        execution,
+        carry_policy: init.carry_policy,
+        execution: init.execution,
         snapshot_path: worker_snapshot_path(&worker_id),
         audit,
-    }));
-    finalize_and_run_worker(state, false, "sub_agent worker").await
+    }))
 }
 
-/// Persist + register + spawn a freshly-built worker, optionally block until
-/// it reaches a terminal state, and return the worker summary dict.
-///
-/// Shared by `spawn_agent_builtin` (background or `wait: true`) and
-/// `sub_agent_run_builtin` (background) so persistence / registry / task
-/// spawn / summary stay in one place.
+/// Persist, register, and spawn a freshly-built worker. Optionally block until
+/// it reaches a terminal state before returning the worker summary dict.
 async fn finalize_and_run_worker(
     state: Rc<RefCell<WorkerState>>,
     wait_for_terminal: bool,
@@ -554,47 +558,10 @@ async fn spawn_agent_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     let config = args
         .first()
         .ok_or_else(|| VmError::Runtime("spawn_agent: missing config".to_string()))?;
-    let mut init = parse_worker_config(config)?;
-    let worker_id = next_worker_id();
-    let created_at = uuid::Uuid::now_v7().to_string();
-    ensure_worker_config_session_ids(&mut init.config, &worker_id);
-    let mode = worker_mode_label(&init.config).to_string();
-    let mut audit = init.audit.clone().normalize();
-    audit.worker_id = Some(worker_id.clone());
-    audit.execution_kind = Some(mode.clone());
-    let original_request = worker_request_for_config(&init.task, &init.config);
-    let state = Rc::new(RefCell::new(WorkerState {
-        id: worker_id.clone(),
-        name: init.name,
-        task: init.task.clone(),
-        status: "running".to_string(),
-        created_at: created_at.clone(),
-        started_at: created_at,
-        finished_at: None,
-        awaiting_started_at: None,
-        awaiting_since: None,
-        mode,
-        history: vec![init.task],
-        config: init.config,
-        handle: None,
-        cancel_token: Arc::new(AtomicBool::new(false)),
-        suspend_signal: Arc::new(AtomicBool::new(false)),
-        suspension: None,
-        request: original_request,
-        latest_payload: None,
-        latest_error: None,
-        transcript: None,
-        artifacts: Vec::new(),
-        parent_worker_id: None,
-        parent_stage_id: None,
-        child_run_id: None,
-        child_run_path: None,
-        carry_policy: init.carry_policy,
-        execution: init.execution,
-        snapshot_path: worker_snapshot_path(&worker_id),
-        audit,
-    }));
-    finalize_and_run_worker(state, init.wait, "spawn_agent worker").await
+    let init = parse_worker_config(config)?;
+    let wait = init.wait;
+    let state = fresh_worker_state(next_worker_id(), init);
+    finalize_and_run_worker(state, wait, "spawn_agent worker").await
 }
 
 async fn send_input_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
@@ -681,11 +648,11 @@ async fn worker_trigger_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> 
     with_worker_state(&worker_id, |state| worker_summary(&state.borrow()))
 }
 
-/// Cooperative suspend (harn#1837 / S-01).
+/// Cooperatively suspend a running worker.
 ///
 /// Sets the worker's `suspend_signal` flag — the `agent_loop` honors this
-/// at the next turn boundary (S-02) — records suspension metadata,
-/// persists a snapshot, and emits a `WorkerSuspended` lifecycle event.
+/// at the next turn boundary — records suspension metadata, persists a
+/// snapshot, and emits a `WorkerSuspended` lifecycle event.
 ///
 /// Idempotent: calling on an already-suspended worker returns the
 /// existing summary without re-emitting the event or re-persisting the
@@ -712,8 +679,8 @@ async fn suspend_agent_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
         .cloned();
     let conditions = conditions_value.as_ref().map(crate::llm::vm_value_to_json);
 
-    // PreSuspend lifecycle gate (harn#1859). Allow/Deny (cancel suspend,
-    // worker keeps running)/Modify (rewrite reason)/Reminder.
+    // PreSuspend lifecycle gate. Block cancels the suspend and leaves the
+    // worker running; Modify can rewrite the public reason.
     let pre_payload = serde_json::json!({
         "event": crate::orchestration::HookEvent::PreSuspend.as_str(),
         "worker": { "id": &worker_id },
@@ -731,7 +698,7 @@ async fn suspend_agent_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
         crate::orchestration::HookControl::Block {
             reason: block_reason,
         } => {
-            // PreSuspend Deny: cancel suspend, return current summary.
+            // Blocked suspend: leave the worker running and return its summary.
             return with_worker_state(&worker_id, |state| {
                 let mut summary = worker_summary(&state.borrow())?;
                 if let VmValue::Dict(map) = &mut summary {
@@ -780,13 +747,11 @@ async fn suspend_agent_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
             format!("suspend {}", worker.id),
             Vec::new(),
         );
-        // S-18 (harn#1867): attach the structured suspend metadata that
-        // OTel consumers need to render a paused agent without joining
-        // back to the worker registry. `reason` and `initiator` are already
-        // public via WorkerSuspended events and PreSuspend/PostSuspend
-        // hook payloads; we deliberately do NOT include transcript
-        // content, resume_input, or condition payloads (see issue #1867
-        // privacy callout).
+        // OTel consumers need enough metadata to render a paused agent
+        // without joining back to the worker registry. `reason` and
+        // `initiator` are already public via worker events and lifecycle hook
+        // payloads; transcript content, resume input, and condition payloads
+        // stay out of span attributes.
         annotate_suspension_span(
             &span,
             &worker.id,
@@ -843,8 +808,8 @@ async fn suspend_agent_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
             span.end();
         }
         emit_worker_event(&snapshot, crate::agent_events::WorkerEvent::WorkerSuspended).await?;
-        // PostSuspend lifecycle event (harn#1859). Advisory only; the
-        // snapshot has already been persisted by persist_worker_state_snapshot.
+        // PostSuspend hooks are advisory; the snapshot has already been
+        // persisted by persist_worker_state_snapshot.
         let post_payload = serde_json::json!({
             "event": crate::orchestration::HookEvent::PostSuspend.as_str(),
             "worker": { "id": &worker_id },
@@ -894,8 +859,8 @@ impl PanicSuspendOutcome {
     }
 }
 
-/// CH-10 (#1910) panic-broadcast helper. Cooperative-suspend a single
-/// worker as part of an `InterruptAndSuspend` trigger dispatch.
+/// Cooperatively suspend one worker as part of an `InterruptAndSuspend`
+/// trigger dispatch.
 ///
 /// Behavior parallels `suspend_agent_builtin` minus the
 /// `PreSuspend`/`PostSuspend` lifecycle hooks and the auto-resume trigger
@@ -903,8 +868,8 @@ impl PanicSuspendOutcome {
 /// approval/turn-boundary contract — wiring it through the hook gate would
 /// let one rogue PreSuspend Deny block the org-wide emergency. The
 /// suspension envelope carries the panic `reason` verbatim and uses
-/// `SuspendInitiator::Triggered` (the closest fit on the existing receipts
-/// schema; no schema bump required to ship this variant).
+/// `SuspendInitiator::Triggered`, which matches the trigger-owned suspend
+/// path already understood by receipts.
 ///
 /// Returns the structured outcome so the dispatcher can build the per-worker
 /// audit entries; returns `Err(...)` only on persistence/event-emission
@@ -973,12 +938,11 @@ pub(crate) async fn panic_suspend_worker(
     Ok(outcome)
 }
 
-/// CH-10 (#1910): enumerate every worker id currently registered in the
-/// local worker registry. Used by `InterruptAndSuspend` to materialize the
+/// Enumerate every worker id currently registered in the local worker
+/// registry. Used by `InterruptAndSuspend` to materialize the
 /// `AgentScope::All` target list. Ordering is the registry's stable
 /// `BTreeMap` iteration order so a panic broadcast is deterministic across
-/// replays — the dispatcher's audit log records the same worker order on
-/// re-run.
+/// replays.
 pub(crate) fn all_registered_worker_ids() -> Vec<String> {
     WORKER_REGISTRY.with(|registry| registry.borrow().keys().cloned().collect())
 }
@@ -1018,8 +982,8 @@ async fn top_level_agent_suspend_builtin(args: Vec<VmValue>) -> Result<VmValue, 
         format!("suspend {worker_id}"),
         Vec::new(),
     );
-    // S-18 (harn#1867): mirror the metadata captured in
-    // `suspend_agent_builtin` for top-level (script-level) suspensions.
+    // Mirror `suspend_agent_builtin` metadata for top-level script
+    // suspensions.
     // The initiator for the top-level path is always `SelfInitiated`
     // because only the active agent loop can drive the synchronous
     // checkpoint return path.
@@ -1594,8 +1558,8 @@ async fn warm_resume_worker(
     mut options: WorkerResumeOptions,
 ) -> Result<VmValue, VmError> {
     join_checkpointed_worker_handle(state.clone()).await?;
-    // PreResume lifecycle gate (harn#1859). Allow/Deny (stay suspended)/
-    // Modify (amend resume input)/Reminder.
+    // PreResume lifecycle gate. Block keeps the worker suspended; Modify can
+    // amend the resume input before the transcript policy runs.
     let pre_worker_id = state.borrow().id.clone();
     let pre_payload = serde_json::json!({
         "event": crate::orchestration::HookEvent::PreResume.as_str(),
@@ -1615,7 +1579,7 @@ async fn warm_resume_worker(
     {
         crate::orchestration::HookControl::Allow => {}
         crate::orchestration::HookControl::Block { reason } => {
-            // PreResume Deny: do not transition out of suspended.
+            // Blocked resume: do not transition out of suspended.
             let mut summary = worker_summary(&state.borrow())?;
             if let VmValue::Dict(map) = &mut summary {
                 let mut entries = (**map).clone();
@@ -1676,11 +1640,10 @@ async fn warm_resume_worker(
         format!("resume {worker_id}"),
         span_links,
     );
-    // S-18 (harn#1867): annotate the resume span with the per-resume
-    // shape (initiator, transcript continuity, presence of fresh input)
-    // and a count of the linked-not-parented prior spans. We do NOT
-    // include the resume_input value itself — it can contain transcript
-    // text or user data — only a boolean flag.
+    // Annotate the resume span with its shape (initiator, transcript
+    // continuity, fresh input) and prior-span link count. The resume input can
+    // contain transcript text or user data, so the span records only whether
+    // fresh input exists.
     annotate_resume_span(
         &resume_span,
         &worker_id,
@@ -1730,8 +1693,7 @@ async fn warm_resume_worker(
     if crate::vm::clone_async_builtin_child_vm().is_some() {
         respawn_worker_task(state.clone())?;
     }
-    // PostResume lifecycle event (harn#1859). Advisory only; the turn is
-    // about to start.
+    // PostResume hooks are advisory; the resumed turn is about to start.
     let post_payload = serde_json::json!({
         "event": crate::orchestration::HookEvent::PostResume.as_str(),
         "worker": { "id": &worker_id },
@@ -3165,8 +3127,8 @@ mod suspend_tests {
         crate::tracing::reset_tracing();
     }
 
-    /// S-18 (harn#1867): verify the suspension / resume spans carry the
-    /// documented attribute bag (`handle`, `reason`, `initiator`,
+    /// Verify the suspension and resume spans carry the documented attribute
+    /// bag (`handle`, `reason`, `initiator`,
     /// `pipeline_id` on suspend; `handle`, `initiator`,
     /// `continue_transcript`, `had_resume_input`,
     /// `linked_suspension_count` on resume). These attributes let OTel
@@ -3223,7 +3185,7 @@ mod suspend_tests {
                 .get("worker_id")
                 .and_then(|v| v.as_str()),
             Some(worker_id.as_str()),
-            "suspend span preserves back-compat worker_id"
+            "suspend span exposes worker_id"
         );
         assert_eq!(
             suspension.metadata.get("reason").and_then(|v| v.as_str()),
@@ -3251,7 +3213,7 @@ mod suspend_tests {
                 .get("pipeline_span_id")
                 .and_then(|v| v.as_str()),
             Some(pipeline_span_id.to_string()).as_deref(),
-            "back-compat pipeline_span_id is present"
+            "pipeline_span_id is present"
         );
         assert_eq!(
             suspension


### PR DESCRIPTION
## Summary

- Split the large `std/agent/loop` helper surface into typed `control`, `required_tools`, and `stall` modules, then registered those modules in the embedded stdlib.
- Added explicit Harn callback/result types for resume ownership and worker resumption, plus stricter runtime validation for stall diagnostics and adaptive budget decision exposure.
- Taught parser type inference that transcript append builtins preserve the input transcript container type.
- DRYed workflow result transcript/run construction and consolidated fresh worker initialization in the Rust agent runtime.
- Cleaned stale issue-number comments in the touched agent paths.

## Validation

- `cargo fmt --check`
- `make fmt-harn`
- `make lint-harn`
- `make lint-test-patterns`
- `cargo test -p harn-parser test_transcript_append_builtins_preserve_input_container_type`
- `cargo test -p harn-vm agents`
- `make test`
- `make conformance`
- pre-commit hook
- pre-push hook
