### PR TITLE
Add instructional compaction policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ condensed series summaries instead of full per-patch history.
 
 ## Unreleased
 
+### Added
+
+- **First-class compaction instructions (#2190).** Manual session compaction,
+  transcript auto-compaction, host-triggered compaction, and `agent_loop`
+  auto-compaction now accept a typed `CompactionPolicy` with optional
+  `instructions`, `mode`, `scope`, `preserve`, `drop`,
+  `extend_default_instructions`, and `author` fields. Compaction events and
+  audit metadata record the instruction mode/source, and
+  `std/agent/autocompact` adds helper policies for bug-fix resumption, failing
+  test preservation, and retaining the current plan.
+
 ### Fixed
 
 - **Secret redaction and scanning now share one token catalog.**

--- a/README.md
+++ b/README.md
@@ -352,8 +352,10 @@ defaults, safe, prompts, catalog).
 - Automatic transcript compaction in agent loops: microcompaction snips oversized
   tool outputs, auto-compaction triggers at configurable token thresholds, and
   `compact_strategy` supports default LLM summarization, truncate fallback, or
-  custom Harn closure-based compaction. The same pipeline is exposed directly as
-  `transcript_auto_compact(...)`.
+  custom Harn closure-based compaction. Host/user compaction instructions flow
+  through the typed `CompactionPolicy` lane so `/compact <instructions>` style
+  commands can reuse runtime audit/events without bespoke prompt wiring. The
+  same pipeline is exposed directly as `transcript_auto_compact(...)`.
 - Daemon agent mode (`daemon: true`): agents stay alive waiting for
   host-injected messages instead of terminating on text-only responses, with
   adaptive idle backoff, persisted snapshots, timer/file-watch wakes, and

--- a/conformance/tests/agents/agent_runtime_features.expected
+++ b/conformance/tests/agents/agent_runtime_features.expected
@@ -16,3 +16,5 @@ true
 true
 true
 true
+true
+true

--- a/conformance/tests/agents/agent_runtime_features.harn
+++ b/conformance/tests/agents/agent_runtime_features.harn
@@ -1,3 +1,8 @@
+import {
+  compact_preserving_test_failures,
+  compact_retaining_current_plan,
+} from "std/agent/autocompact"
+
 fn list_tools() {
   var tools = tool_registry()
   tools = tool_define(
@@ -59,6 +64,19 @@ pipeline test(task) {
     },
   )
   __io_println(custom_compacted[0].content.contains("custom compact 2"))
+  let policy_compacted = transcript_auto_compact(
+    base_messages,
+    {
+      keep_last: 1,
+      token_threshold: 1,
+      compact_strategy: "custom",
+      compact_callback: { archived, _reminders, policy -> {summary: "policy compact " + policy.mode + " " + policy.preserve[0]} },
+      policy: compact_preserving_test_failures({author: "host"}),
+    },
+  )
+  __io_println(
+    policy_compacted[0].content.contains("policy compact preserve_test_failures failing test names"),
+  )
   let loop_compacted = agent_loop(
     "Inspect the workspace",
     "You are helpful",
@@ -67,14 +85,36 @@ pipeline test(task) {
       tools: list_tools(),
       tool_format: "native",
       max_iterations: 2,
-      auto_compact: true,
+      auto_compact: compact_retaining_current_plan({author: "host"}),
       compact_threshold: 1,
       compact_keep_last: 1,
       compact_strategy: "custom",
-      compact_callback: { archived -> {summary: "loop compact " + to_string(len(archived))} },
+      compact_callback: { archived, _reminders, policy -> {summary: "loop compact " + policy.mode + " " + to_string(len(archived))} },
     },
   )
-  __io_println(transcript_summary(loop_compacted?.transcript).contains("loop compact"))
+  __io_println(
+    transcript_summary(loop_compacted?.transcript).contains("loop compact retain_current_plan"),
+  )
+  let request_compacted = agent_loop(
+    "Inspect the workspace",
+    "You are helpful",
+    {
+      provider: "mock",
+      tools: list_tools(),
+      tool_format: "native",
+      max_iterations: 2,
+      auto_compact: {
+        compaction_request: {mode: "resume_request", policy: {instructions: "Keep host state.", author: "host"}},
+      },
+      compact_threshold: 1,
+      compact_keep_last: 1,
+      compact_strategy: "custom",
+      compact_callback: { archived, _reminders, policy -> {summary: "request compact " + policy.mode + " " + policy.author + " " + to_string(len(archived))} },
+    },
+  )
+  __io_println(
+    transcript_summary(request_compacted?.transcript).contains("request compact resume_request host"),
+  )
   let stopped_after_tool_turn = agent_loop(
     "Inspect the workspace",
     "You are helpful",

--- a/conformance/tests/agents/agent_session_compact_policy.expected
+++ b/conformance/tests/agents/agent_session_compact_policy.expected
@@ -1,0 +1,6 @@
+true
+true
+true
+true
+true
+2

--- a/conformance/tests/agents/agent_session_compact_policy.harn
+++ b/conformance/tests/agents/agent_session_compact_policy.harn
@@ -1,0 +1,30 @@
+import { compact_for_bug_fix_resumption } from "std/agent/autocompact"
+
+pipeline test(task) {
+  let session = agent_session_open("host-compact-policy")
+  agent_session_inject(session, {role: "user", content: "Investigate the parser regression."})
+  agent_session_inject(
+    session,
+    {role: "assistant", content: "The root cause is likely in diagnostic recovery."},
+  )
+  agent_session_inject(session, {role: "user", content: "Keep the failing tests and next command."})
+  let kept = agent_session_compact(
+    session,
+    {
+      keep_last: 1,
+      token_threshold: 1,
+      compact_strategy: "custom",
+      custom_compactor: { archived, _reminders, policy -> {summary: "host compact " + policy.mode + " " + policy.author + " " + to_string(len(archived))} },
+      policy: compact_for_bug_fix_resumption({author: "host"}),
+    },
+  )
+  let snapshot = agent_session_snapshot(session)
+  let events = transcript_events_by_kind(snapshot, "compaction")
+  let event = events[0]
+  __io_println(transcript_summary(snapshot).contains("host compact bug_fix_resumption host 2"))
+  __io_println(event.metadata?.mode == "host")
+  __io_println(event.metadata?.instruction_mode == "extend")
+  __io_println(event.metadata?.instruction_source == "host")
+  __io_println(event.metadata?.compaction_policy?.instructions.contains("bug fix"))
+  __io_println(kept)
+}

--- a/conformance/tests/stdlib/compact_transcript.expected
+++ b/conformance/tests/stdlib/compact_transcript.expected
@@ -13,3 +13,10 @@ true
 true
 true
 true
+true
+true
+true
+true
+true
+true
+true

--- a/conformance/tests/stdlib/compact_transcript.harn
+++ b/conformance/tests/stdlib/compact_transcript.harn
@@ -46,6 +46,43 @@ pipeline test(task) {
   let prompt = llm_calls[0].messages[0].content
   __io_println(prompt.contains("Compact prompt from asset."))
   __io_println(prompt.contains("Archived count: 2"))
+  llm_mock_clear()
+  llm_mock({text: "policy extension summary"})
+  let policy_extended = transcript_compact(
+    base,
+    {
+      provider: "mock",
+      strategy: "llm",
+      keep_last: 1,
+      instructions: "Preserve parser TODOs.",
+      author: "host",
+    },
+  )
+  let extended_prompt = llm_mock_calls()[0].messages[0].content
+  let extended_event = transcript_events_by_kind(policy_extended, "compaction")[0]
+  __io_println(extended_prompt.contains("Additional compaction instructions"))
+  __io_println(extended_event.metadata?.instruction_mode == "extend")
+  __io_println(extended_event.metadata?.instruction_source == "host")
+  __io_println(extended_event.metadata?.compaction_policy?.instructions == "Preserve parser TODOs.")
+  llm_mock_clear()
+  llm_mock({text: "policy replacement summary"})
+  let policy_replaced = transcript_compact(
+    base,
+    {
+      provider: "mock",
+      strategy: "llm",
+      keep_last: 1,
+      instructions: "Only keep failing verification details.",
+      extend_default_instructions: false,
+    },
+  )
+  let replacement_prompt = llm_mock_calls()[0].messages[0].content
+  __io_println(replacement_prompt.contains("according to these instructions"))
+  __io_println(!replacement_prompt.contains("Preserve goals, constraints"))
+  __io_println(
+    transcript_events_by_kind(policy_replaced, "compaction")[0].metadata?.instruction_mode
+      == "replace",
+  )
   let stream_session = agent_session_open("compact-stream-session")
   agent_session_inject(stream_session, {role: "user", content: "one"})
   agent_session_inject(stream_session, {role: "assistant", content: "two"})

--- a/crates/harn-parser/src/builtin_signatures/signatures/shapes.rs
+++ b/crates/harn-parser/src/builtin_signatures/signatures/shapes.rs
@@ -341,8 +341,41 @@ pub(crate) const AGENT_SESSION_SEED_OPTS: Ty = Ty::Shape(&[
 ]);
 
 /// `agent_session_compact` `opts?` argument.
+pub(crate) const COMPACTION_POLICY: Ty = Ty::Shape(&[
+    ShapeFieldDescriptor::optional("instructions", TY_STRING),
+    ShapeFieldDescriptor::optional("mode", TY_STRING),
+    ShapeFieldDescriptor::optional("scope", TY_STRING),
+    ShapeFieldDescriptor::optional("preserve", TY_STRING_OR_LIST),
+    ShapeFieldDescriptor::optional("drop", TY_STRING_OR_LIST),
+    ShapeFieldDescriptor::optional("extend_default_instructions", TY_BOOL),
+    ShapeFieldDescriptor::optional("author", TY_STRING),
+]);
+
+pub(crate) const COMPACTION_REQUEST: Ty = Ty::Shape(&[
+    ShapeFieldDescriptor::optional("mode", TY_STRING),
+    ShapeFieldDescriptor::optional("policy", COMPACTION_POLICY),
+]);
+
 pub(crate) const AGENT_SESSION_COMPACT_OPTS: Ty = Ty::Shape(&[
     ShapeFieldDescriptor::optional("keep_last", TY_INT),
+    ShapeFieldDescriptor::optional("token_threshold", TY_INT),
+    ShapeFieldDescriptor::optional("tool_output_max_chars", TY_INT),
+    ShapeFieldDescriptor::optional("compact_strategy", TY_STRING),
+    ShapeFieldDescriptor::optional("hard_limit_tokens", TY_INT),
+    ShapeFieldDescriptor::optional("hard_limit_strategy", TY_STRING),
+    ShapeFieldDescriptor::optional("custom_compactor", TY_CLOSURE),
+    ShapeFieldDescriptor::optional("mask_callback", TY_CLOSURE),
+    ShapeFieldDescriptor::optional("compress_callback", TY_CLOSURE),
+    ShapeFieldDescriptor::optional("policy", COMPACTION_POLICY),
+    ShapeFieldDescriptor::optional("compaction_policy", COMPACTION_POLICY),
+    ShapeFieldDescriptor::optional("compaction_request", COMPACTION_REQUEST),
+    ShapeFieldDescriptor::optional("instructions", TY_STRING),
+    ShapeFieldDescriptor::optional("mode", TY_STRING),
+    ShapeFieldDescriptor::optional("scope", TY_STRING),
+    ShapeFieldDescriptor::optional("preserve", TY_STRING_OR_LIST),
+    ShapeFieldDescriptor::optional("drop", TY_STRING_OR_LIST),
+    ShapeFieldDescriptor::optional("extend_default_instructions", TY_BOOL),
+    ShapeFieldDescriptor::optional("author", TY_STRING),
     ShapeFieldDescriptor::optional("system", TY_STRING),
     ShapeFieldDescriptor::optional("model", TY_STRING),
     ShapeFieldDescriptor::optional("provider", TY_STRING),

--- a/crates/harn-serve/src/adapters/acp/events.rs
+++ b/crates/harn-serve/src/adapters/acp/events.rs
@@ -540,6 +540,9 @@ impl AgentEventSink for AcpAgentEventSink {
                 estimated_tokens_before,
                 estimated_tokens_after,
                 snapshot_asset_id,
+                instruction_mode,
+                instruction_source,
+                compaction_policy,
             } => {
                 let mut update = serde_json::json!({
                     "sessionUpdate": "transcript_compacted",
@@ -569,6 +572,21 @@ impl AgentEventSink for AcpAgentEventSink {
                         None => serde_json::Value::Null,
                     },
                 );
+                if let Some(instruction_mode) = instruction_mode {
+                    harn_meta.insert(
+                        "instructionMode".to_string(),
+                        serde_json::Value::String(instruction_mode.clone()),
+                    );
+                }
+                if let Some(instruction_source) = instruction_source {
+                    harn_meta.insert(
+                        "instructionSource".to_string(),
+                        serde_json::Value::String(instruction_source.clone()),
+                    );
+                }
+                if let Some(compaction_policy) = compaction_policy {
+                    harn_meta.insert("compactionPolicy".to_string(), compaction_policy.clone());
+                }
                 merge_harn_meta(&mut update, harn_meta);
                 self.write_notification(serde_json::json!({
                     "sessionId": session_id,

--- a/crates/harn-serve/src/adapters/acp/events/tests.rs
+++ b/crates/harn-serve/src/adapters/acp/events/tests.rs
@@ -172,6 +172,13 @@ fn extension_fixture_events() -> Vec<AgentEvent> {
             estimated_tokens_before: 100,
             estimated_tokens_after: 40,
             snapshot_asset_id: Some("asset-1".to_string()),
+            instruction_mode: Some("extend".to_string()),
+            instruction_source: Some("host".to_string()),
+            compaction_policy: Some(serde_json::json!({
+                "instructions": "Preserve failing tests.",
+                "instruction_mode": "extend",
+                "instruction_source": "host"
+            })),
         },
         AgentEvent::ReminderEmitted {
             session_id: "session-1".to_string(),
@@ -785,6 +792,9 @@ async fn forwarded_agent_events_serialize_as_session_updates() {
             estimated_tokens_before: 100,
             estimated_tokens_after: 40,
             snapshot_asset_id: Some("asset-1".to_string()),
+            instruction_mode: None,
+            instruction_source: None,
+            compaction_policy: None,
         },
         AgentEvent::Handoff {
             session_id: "session-1".to_string(),
@@ -1293,6 +1303,9 @@ async fn vendor_extension_session_update_fields_live_under_meta_harn() {
                 "estimatedTokensBefore",
                 "estimatedTokensAfter",
                 "snapshotAssetId",
+                "instructionMode",
+                "instructionSource",
+                "compactionPolicy",
             ],
         ),
         ("reminder_emitted", &["reminder"]),

--- a/crates/harn-serve/tests/fixtures/acp/session_update_extensions.json
+++ b/crates/harn-serve/tests/fixtures/acp/session_update_extensions.json
@@ -100,8 +100,15 @@
         "_meta": {
           "harn": {
             "archivedMessages": 3,
+            "compactionPolicy": {
+              "instruction_mode": "extend",
+              "instruction_source": "host",
+              "instructions": "Preserve failing tests."
+            },
             "estimatedTokensAfter": 40,
             "estimatedTokensBefore": 100,
+            "instructionMode": "extend",
+            "instructionSource": "host",
             "mode": "auto",
             "snapshotAssetId": "asset-1",
             "strategy": "summary"

--- a/crates/harn-stdlib/src/lib.rs
+++ b/crates/harn-stdlib/src/lib.rs
@@ -738,6 +738,12 @@ pub const STDLIB_PROMPT_ASSETS: &[StdlibPromptAsset] = &[
         path: "orchestration/prompts/compaction_summary.harn.prompt",
         source: include_str!("stdlib/orchestration/prompts/compaction_summary.harn.prompt"),
     },
+    StdlibPromptAsset {
+        path: "orchestration/prompts/compaction_policy_replacement.harn.prompt",
+        source: include_str!(
+            "stdlib/orchestration/prompts/compaction_policy_replacement.harn.prompt"
+        ),
+    },
 ];
 
 pub fn get_stdlib_source(module: &str) -> Option<&'static str> {
@@ -1041,6 +1047,7 @@ mod tests {
             "std/agent/prompts/completion_judge_default.harn.prompt",
             "std/workflow/prompts/stage.harn.prompt",
             "std/orchestration/prompts/compaction_summary.harn.prompt",
+            "std/orchestration/prompts/compaction_policy_replacement.harn.prompt",
         ] {
             assert!(
                 get_stdlib_prompt_asset(path).is_some(),

--- a/crates/harn-stdlib/src/stdlib/agent/autocompact.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/autocompact.harn
@@ -29,6 +29,121 @@ fn __compaction_engine_strategy(label) {
   return "observation_mask"
 }
 
+fn __compaction_policy_list(value) {
+  if type_of(value) == "list" {
+    return value
+  }
+  if type_of(value) == "string" && value != "" {
+    return [value]
+  }
+  return []
+}
+
+fn __has_compaction_policy(policy) {
+  if type_of(policy) != "dict" {
+    return false
+  }
+  return policy?.instructions != nil
+    || policy?.mode != nil
+    || policy?.scope != nil
+    || len(__compaction_policy_list(policy?.preserve)) > 0
+    || len(__compaction_policy_list(policy?.drop)) > 0
+    || policy?.extend_default_instructions != nil
+    || policy?.author != nil
+}
+
+fn __compaction_policy_merge_fields(policy, fields) {
+  if type_of(fields) != "dict" {
+    return policy
+  }
+  var merged = policy
+  if fields?.instructions != nil {
+    merged = merged + {instructions: fields.instructions}
+  }
+  if fields?.mode != nil {
+    merged = merged + {mode: fields.mode}
+  }
+  if fields?.scope != nil {
+    merged = merged + {scope: fields.scope}
+  }
+  if fields?.preserve != nil {
+    merged = merged + {preserve: fields.preserve}
+  }
+  if fields?.drop != nil {
+    merged = merged + {drop: fields.drop}
+  }
+  if fields?.extend_default_instructions != nil {
+    merged = merged + {extend_default_instructions: fields.extend_default_instructions}
+  }
+  if fields?.author != nil {
+    merged = merged + {author: fields.author}
+  }
+  return merged
+}
+
+fn __compaction_policy_from_options(opts) {
+  if type_of(opts) != "dict" {
+    return nil
+  }
+  let nested = opts?.policy ?? opts?.compaction_policy ?? opts?.compaction_request
+  var policy = if type_of(nested?.policy) == "dict" {
+    nested.policy
+  } else if type_of(nested) == "dict" {
+    nested
+  } else {
+    {}
+  }
+  policy = __compaction_policy_merge_fields(policy, nested)
+  policy = __compaction_policy_merge_fields(policy, opts)
+  let preserve = __compaction_policy_list(opts?.preserve ?? policy?.preserve)
+  if len(preserve) > 0 {
+    policy = policy + {preserve: preserve}
+  }
+  let drop_items = __compaction_policy_list(opts?.drop ?? policy?.drop)
+  if len(drop_items) > 0 {
+    policy = policy + {drop: drop_items}
+  }
+  if !__has_compaction_policy(policy) {
+    return nil
+  }
+  return policy
+}
+
+fn __compaction_instruction_mode(policy) {
+  if type_of(policy) != "dict" {
+    return "default"
+  }
+  let has_directives = policy?.instructions != nil
+    || len(__compaction_policy_list(policy?.preserve)) > 0
+    || len(__compaction_policy_list(policy?.drop)) > 0
+  if !has_directives {
+    return "default"
+  }
+  if type_of(policy?.extend_default_instructions) == "bool" && !policy.extend_default_instructions {
+    return "replace"
+  }
+  return "extend"
+}
+
+fn __compaction_policy_event_fields(policy) {
+  if type_of(policy) != "dict" {
+    return {instruction_mode: "default"}
+  }
+  var fields = {
+    instruction_mode: __compaction_instruction_mode(policy),
+    compaction_policy: policy
+      + {instruction_mode: __compaction_instruction_mode(policy)},
+  }
+  if type_of(policy?.author) == "string" && policy.author != "" {
+    fields = fields
+      + {
+      instruction_source: policy.author,
+      compaction_policy: fields.compaction_policy + {instruction_source: policy.author},
+    }
+  }
+  return fields
+}
+
 fn __compaction_keep_last(opts) {
   let cfg = opts?.compaction
   if type_of(cfg) == "dict" {
@@ -71,6 +186,12 @@ fn __compact_options(opts, engine_strategy, keep_last) {
   }
   if !contains(compact_opts.keys(), "model") && opts?.model != nil {
     compact_opts = compact_opts + {model: opts.model}
+  }
+  let policy = __compaction_policy_from_options(compact_opts)
+    ?? __compaction_policy_from_options({policy: opts?.compaction_policy})
+    ?? __compaction_policy_from_options({policy: opts?.compaction?.policy})
+  if policy != nil && !contains(compact_opts.keys(), "policy") {
+    compact_opts = compact_opts + {policy: policy}
   }
   return compact_opts
 }
@@ -119,6 +240,140 @@ fn __compaction_enabled(opts) {
 }
 
 /**
+ * compaction_policy.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: compaction_policy("Preserve failing tests.", {author: "host"})
+ */
+pub fn compaction_policy(instructions = nil, opts = nil) {
+  var base = if type_of(instructions) == "dict" && opts == nil {
+    instructions
+  } else if type_of(opts) == "dict" {
+    opts
+  } else {
+    {}
+  }
+  if type_of(instructions) == "string" && instructions != "" {
+    base = base + {instructions: instructions}
+  }
+  var policy = __compaction_policy_from_options(base)
+  if policy == nil {
+    return {}
+  }
+  if policy?.extend_default_instructions == nil {
+    policy = policy + {extend_default_instructions: true}
+  }
+  return policy
+}
+
+/**
+ * compact_for_bug_fix_resumption.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: compact_for_bug_fix_resumption({author: "host"})
+ */
+pub fn compact_for_bug_fix_resumption(opts = nil) {
+  let base = if type_of(opts) == "dict" {
+    opts
+  } else {
+    {}
+  }
+  let extra = if type_of(base?.instructions) == "string" && base.instructions != "" {
+    "\n" + base.instructions
+  } else {
+    ""
+  }
+  return compaction_policy(
+    "Shape the summary so a follow-on agent can resume the bug fix quickly. Preserve the root cause, changed files, failing and passing checks, remaining hypotheses, and the next concrete command to run."
+      + extra,
+    base
+      + {
+      mode: base?.mode ?? "bug_fix_resumption",
+      preserve: base?.preserve
+        ?? ["root cause", "changed files", "test failures", "verification commands", "next action"],
+    },
+  )
+}
+
+/**
+ * compact_preserving_test_failures.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: compact_preserving_test_failures()
+ */
+pub fn compact_preserving_test_failures(opts = nil) {
+  let base = if type_of(opts) == "dict" {
+    opts
+  } else {
+    {}
+  }
+  let extra = if type_of(base?.instructions) == "string" && base.instructions != "" {
+    "\n" + base.instructions
+  } else {
+    ""
+  }
+  return compaction_policy(
+    "Preserve exact failing test names, commands, error messages, stack traces, exit codes, and any suspected regression window. Drop repetitive build output that does not help reproduce the failure."
+      + extra,
+    base
+      + {
+      mode: base?.mode ?? "preserve_test_failures",
+      preserve: base?.preserve
+        ?? ["failing test names", "commands", "error messages", "stack traces", "exit codes"],
+      drop: base?.drop ?? ["repetitive build output"],
+    },
+  )
+}
+
+/**
+ * compact_retaining_current_plan.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: compact_retaining_current_plan({author: "host"})
+ */
+pub fn compact_retaining_current_plan(opts = nil) {
+  let base = if type_of(opts) == "dict" {
+    opts
+  } else {
+    {}
+  }
+  let extra = if type_of(base?.instructions) == "string" && base.instructions != "" {
+    "\n" + base.instructions
+  } else {
+    ""
+  }
+  return compaction_policy(
+    "Retain the current plan, completed steps, in-progress step, blockers, assumptions, verification status, and remaining concrete actions."
+      + extra,
+    base
+      + {
+      mode: base?.mode ?? "retain_current_plan",
+      preserve: base?.preserve
+        ?? [
+        "current plan",
+        "completed steps",
+        "in-progress step",
+        "blockers",
+        "verification status",
+        "remaining actions",
+      ],
+    },
+  )
+}
+
+/**
  * agent_autocompact_if_needed.
  *
  * @effects: [host]
@@ -146,6 +401,8 @@ pub fn agent_autocompact_if_needed(session, opts) {
   let keep_last = __compaction_keep_last(opts)
   let compact_opts = __compact_options(opts, engine_strategy, keep_last)
   let messages = __host_agent_session_messages(session.session_id)
+  let policy = __compaction_policy_from_options(compact_opts)
+  let policy_fields = __compaction_policy_event_fields(policy)
   let pre_payload = {
     session: {id: session.session_id},
     strategy: if policy_label != "" {
@@ -156,17 +413,24 @@ pub fn agent_autocompact_if_needed(session, opts) {
     engine_strategy: engine_strategy,
     message_count: len(messages),
     keep_last: keep_last ?? 0,
+    estimated_tokens_before: estimate_tokens(messages),
   }
+    + policy_fields
   let pre_control = __host_fire_session_hook("pre_compact", pre_payload)
   if pre_control?.control == "block" {
     return nil
   }
   let compacted = transcript_auto_compact(messages, compact_opts)
   let summary = __auto_compact_summary(messages, compacted)
-  let archived = len(messages) - len(compacted)
+  let archived = if summary != "" {
+    len(messages) - len(compacted) + 1
+  } else {
+    0
+  }
   if archived > 0 {
     __host_agent_session_replace_messages(session.session_id, compacted, summary)
     let metadata = {
+      mode: "auto",
       strategy: if policy_label != "" {
         policy_label
       } else {
@@ -176,7 +440,10 @@ pub fn agent_autocompact_if_needed(session, opts) {
       archived_messages: archived,
       new_summary_len: len(summary),
       keep_last: keep_last ?? 0,
+      estimated_tokens_before: estimate_tokens(messages),
+      estimated_tokens_after: estimate_tokens(compacted),
     }
+      + policy_fields
     agent_record_compaction(session.session_id, metadata)
     let post_payload = pre_payload
       + {
@@ -184,7 +451,9 @@ pub fn agent_autocompact_if_needed(session, opts) {
       new_summary_len: len(summary),
       remaining_messages: len(compacted),
       summary: summary,
+      estimated_tokens_after: estimate_tokens(compacted),
     }
+      + policy_fields
     __host_fire_session_hook("post_compact", post_payload)
     agent_reminder_providers_fire(session.session_id, "post_compact", post_payload, opts)
   }

--- a/crates/harn-stdlib/src/stdlib/orchestration/prompts/compaction_policy_replacement.harn.prompt
+++ b/crates/harn-stdlib/src/stdlib/orchestration/prompts/compaction_policy_replacement.harn.prompt
@@ -1,0 +1,9 @@
+Compact the archived conversation according to these instructions:
+{{ directives }}
+
+Archived message count: {{ archived_count }}
+
+Conversation:
+{{ formatted_messages }}
+
+Output only the compacted summary text. Do not quote or repeat the compaction instructions unless they explicitly request a model-visible note.

--- a/crates/harn-vm/src/agent_events.rs
+++ b/crates/harn-vm/src/agent_events.rs
@@ -548,6 +548,12 @@ pub enum AgentEvent {
         estimated_tokens_before: usize,
         estimated_tokens_after: usize,
         snapshot_asset_id: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        instruction_mode: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        instruction_source: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        compaction_policy: Option<serde_json::Value>,
     },
     /// Emitted when a pending `system_reminder` is rendered into the
     /// next provider request. ACP clients show these in a reminder lane

--- a/crates/harn-vm/src/llm/agent_session_host.rs
+++ b/crates/harn-vm/src/llm/agent_session_host.rs
@@ -1563,6 +1563,38 @@ fn host_agent_record_compaction_builtin(
         .get("iteration")
         .and_then(serde_json::Value::as_u64)
         .unwrap_or(0) as usize;
+    let mode = payload_json
+        .get("mode")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("auto")
+        .to_string();
+    let strategy = payload_json
+        .get("strategy")
+        .or_else(|| payload_json.get("engine_strategy"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    let estimated_tokens_before = payload_json
+        .get("estimated_tokens_before")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0) as usize;
+    let estimated_tokens_after = payload_json
+        .get("estimated_tokens_after")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0) as usize;
+    let snapshot_asset_id = payload_json
+        .get("snapshot_asset_id")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string);
+    let instruction_mode = payload_json
+        .get("instruction_mode")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string);
+    let instruction_source = payload_json
+        .get("instruction_source")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string);
+    let compaction_policy = payload_json.get("compaction_policy").cloned();
     super::trace::emit_agent_event(super::trace::AgentTraceEvent::ContextCompaction {
         archived_messages,
         new_summary_len,
@@ -1576,6 +1608,18 @@ fn host_agent_record_compaction_builtin(
         Some(payload_json),
     );
     let _ = crate::agent_sessions::append_event(&session_id, event);
+    crate::llm::emit_live_agent_event_sync(&crate::agent_events::AgentEvent::TranscriptCompacted {
+        session_id,
+        mode,
+        strategy,
+        archived_messages,
+        estimated_tokens_before,
+        estimated_tokens_after,
+        snapshot_asset_id,
+        instruction_mode,
+        instruction_source,
+        compaction_policy,
+    });
     Ok(VmValue::Nil)
 }
 

--- a/crates/harn-vm/src/orchestration/compaction.rs
+++ b/crates/harn-vm/src/orchestration/compaction.rs
@@ -3,6 +3,8 @@
 use std::collections::BTreeMap;
 use std::rc::Rc;
 
+use serde::{Deserialize, Serialize};
+
 use crate::llm::{vm_call_llm_full, vm_value_to_json};
 use crate::value::{VmError, VmValue};
 
@@ -33,6 +35,382 @@ pub fn compact_strategy_name(strategy: &CompactStrategy) -> &'static str {
         CompactStrategy::Custom => "custom",
         CompactStrategy::ObservationMask => "observation_mask",
     }
+}
+
+const COMPACTION_POLICY_KEYS: &[&str] = &[
+    "instructions",
+    "mode",
+    "scope",
+    "preserve",
+    "drop",
+    "extend_default_instructions",
+    "author",
+];
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct CompactionPolicy {
+    pub instructions: Option<String>,
+    pub mode: Option<String>,
+    pub scope: Option<String>,
+    pub preserve: Vec<String>,
+    #[serde(rename = "drop")]
+    pub drop_items: Vec<String>,
+    pub extend_default_instructions: Option<bool>,
+    pub author: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct CompactionRequest {
+    pub mode: Option<String>,
+    pub policy: CompactionPolicy,
+}
+
+impl CompactionPolicy {
+    pub fn has_metadata(&self) -> bool {
+        self.instructions.is_some()
+            || self.mode.is_some()
+            || self.scope.is_some()
+            || !self.preserve.is_empty()
+            || !self.drop_items.is_empty()
+            || self.extend_default_instructions.is_some()
+            || self.author.is_some()
+    }
+
+    fn has_prompt_directives(&self) -> bool {
+        self.instructions
+            .as_deref()
+            .is_some_and(|value| !value.trim().is_empty())
+            || !self.preserve.is_empty()
+            || !self.drop_items.is_empty()
+    }
+
+    pub fn instruction_mode(&self) -> &'static str {
+        if !self.has_prompt_directives() {
+            "default"
+        } else if self.extend_default_instructions == Some(false) {
+            "replace"
+        } else {
+            "extend"
+        }
+    }
+
+    pub fn instruction_source(&self) -> Option<&str> {
+        self.author
+            .as_deref()
+            .filter(|author| !author.trim().is_empty())
+    }
+
+    pub fn metadata_json(&self) -> Option<serde_json::Value> {
+        if !self.has_metadata() {
+            return None;
+        }
+        let mut map = serde_json::Map::new();
+        if let Some(instructions) = self.instructions.as_ref() {
+            map.insert(
+                "instructions".to_string(),
+                serde_json::Value::String(instructions.clone()),
+            );
+        }
+        if let Some(mode) = self.mode.as_ref() {
+            map.insert("mode".to_string(), serde_json::Value::String(mode.clone()));
+        }
+        if let Some(scope) = self.scope.as_ref() {
+            map.insert(
+                "scope".to_string(),
+                serde_json::Value::String(scope.clone()),
+            );
+        }
+        if !self.preserve.is_empty() {
+            map.insert(
+                "preserve".to_string(),
+                serde_json::to_value(&self.preserve).unwrap_or_default(),
+            );
+        }
+        if !self.drop_items.is_empty() {
+            map.insert(
+                "drop".to_string(),
+                serde_json::to_value(&self.drop_items).unwrap_or_default(),
+            );
+        }
+        if let Some(extend_default_instructions) = self.extend_default_instructions {
+            map.insert(
+                "extend_default_instructions".to_string(),
+                serde_json::Value::Bool(extend_default_instructions),
+            );
+        }
+        if let Some(author) = self.author.as_ref() {
+            map.insert(
+                "author".to_string(),
+                serde_json::Value::String(author.clone()),
+            );
+        }
+        map.insert(
+            "instruction_mode".to_string(),
+            serde_json::Value::String(self.instruction_mode().to_string()),
+        );
+        if let Some(source) = self.instruction_source() {
+            map.insert(
+                "instruction_source".to_string(),
+                serde_json::Value::String(source.to_string()),
+            );
+        }
+        Some(serde_json::Value::Object(map))
+    }
+
+    fn prompt_directives(&self) -> Option<String> {
+        if !self.has_prompt_directives() {
+            return None;
+        }
+        let mut parts = Vec::new();
+        if let Some(instructions) = self
+            .instructions
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            parts.push(instructions.to_string());
+        }
+        if !self.preserve.is_empty() {
+            parts.push(format!("Preserve: {}.", self.preserve.join("; ")));
+        }
+        if !self.drop_items.is_empty() {
+            parts.push(format!("Drop: {}.", self.drop_items.join("; ")));
+        }
+        Some(parts.join("\n"))
+    }
+
+    fn is_model_visible_scope(&self) -> bool {
+        matches!(
+            self.scope.as_deref(),
+            Some("model_visible" | "summary" | "transcript")
+        )
+    }
+}
+
+pub fn compaction_policy_option_keys() -> &'static [&'static str] {
+    COMPACTION_POLICY_KEYS
+}
+
+pub fn compaction_policy_to_vm_value(policy: &CompactionPolicy) -> VmValue {
+    let mut map = BTreeMap::new();
+    if let Some(instructions) = policy.instructions.as_ref() {
+        map.insert(
+            "instructions".to_string(),
+            VmValue::String(Rc::from(instructions.clone())),
+        );
+    }
+    if let Some(mode) = policy.mode.as_ref() {
+        map.insert("mode".to_string(), VmValue::String(Rc::from(mode.clone())));
+    }
+    if let Some(scope) = policy.scope.as_ref() {
+        map.insert(
+            "scope".to_string(),
+            VmValue::String(Rc::from(scope.clone())),
+        );
+    }
+    map.insert(
+        "preserve".to_string(),
+        VmValue::List(Rc::new(
+            policy
+                .preserve
+                .iter()
+                .map(|item| VmValue::String(Rc::from(item.clone())))
+                .collect(),
+        )),
+    );
+    map.insert(
+        "drop".to_string(),
+        VmValue::List(Rc::new(
+            policy
+                .drop_items
+                .iter()
+                .map(|item| VmValue::String(Rc::from(item.clone())))
+                .collect(),
+        )),
+    );
+    if let Some(extend_default_instructions) = policy.extend_default_instructions {
+        map.insert(
+            "extend_default_instructions".to_string(),
+            VmValue::Bool(extend_default_instructions),
+        );
+    }
+    if let Some(author) = policy.author.as_ref() {
+        map.insert(
+            "author".to_string(),
+            VmValue::String(Rc::from(author.clone())),
+        );
+    }
+    VmValue::Dict(Rc::new(map))
+}
+
+pub fn parse_compaction_policy_options(
+    options: Option<&BTreeMap<String, VmValue>>,
+    builtin: &str,
+) -> Result<CompactionPolicy, VmError> {
+    let mut policy = options
+        .and_then(|map| {
+            map.get("policy")
+                .or_else(|| map.get("compaction_policy"))
+                .or_else(|| map.get("compaction_request"))
+        })
+        .map(|value| parse_compaction_policy_value(value, builtin))
+        .transpose()?
+        .unwrap_or_default();
+    if let Some(options) = options {
+        apply_compaction_policy_fields(&mut policy, options, builtin)?;
+    }
+    Ok(policy)
+}
+
+fn parse_compaction_policy_value(
+    value: &VmValue,
+    builtin: &str,
+) -> Result<CompactionPolicy, VmError> {
+    match value {
+        VmValue::Nil => Ok(CompactionPolicy::default()),
+        VmValue::Dict(map) => {
+            if let Some(nested) = map
+                .get("policy")
+                .or_else(|| map.get("compaction_policy"))
+                .or_else(|| map.get("compaction_request"))
+            {
+                let mut policy = parse_compaction_policy_value(nested, builtin)?;
+                apply_compaction_policy_fields(&mut policy, map, builtin)?;
+                Ok(policy)
+            } else {
+                let mut policy = CompactionPolicy::default();
+                apply_compaction_policy_fields(&mut policy, map, builtin)?;
+                Ok(policy)
+            }
+        }
+        other => Err(VmError::Runtime(format!(
+            "{builtin}: compaction policy must be a dict or nil, got {}",
+            other.type_name()
+        ))),
+    }
+}
+
+fn apply_compaction_policy_fields(
+    policy: &mut CompactionPolicy,
+    map: &BTreeMap<String, VmValue>,
+    builtin: &str,
+) -> Result<(), VmError> {
+    if let Some(value) = optional_policy_string(map, "instructions", builtin)? {
+        policy.instructions = Some(value);
+    }
+    if let Some(value) = optional_policy_string(map, "mode", builtin)? {
+        policy.mode = Some(value);
+    }
+    if let Some(value) = optional_policy_string(map, "scope", builtin)? {
+        policy.scope = Some(value);
+    }
+    if map.contains_key("preserve") {
+        policy.preserve = policy_string_list(map.get("preserve"), builtin, "preserve")?;
+    }
+    if map.contains_key("drop") {
+        policy.drop_items = policy_string_list(map.get("drop"), builtin, "drop")?;
+    }
+    if let Some(value) = optional_policy_bool(map, "extend_default_instructions", builtin)? {
+        policy.extend_default_instructions = Some(value);
+    }
+    if let Some(value) = optional_policy_string(map, "author", builtin)? {
+        policy.author = Some(value);
+    }
+    Ok(())
+}
+
+fn optional_policy_string(
+    map: &BTreeMap<String, VmValue>,
+    key: &str,
+    builtin: &str,
+) -> Result<Option<String>, VmError> {
+    match map.get(key) {
+        None | Some(VmValue::Nil) => Ok(None),
+        Some(VmValue::String(text)) => {
+            let trimmed = text.trim();
+            if trimmed.is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(trimmed.to_string()))
+            }
+        }
+        Some(other) => Err(VmError::Runtime(format!(
+            "{builtin}: compaction policy `{key}` must be a string, got {}",
+            other.type_name()
+        ))),
+    }
+}
+
+fn optional_policy_bool(
+    map: &BTreeMap<String, VmValue>,
+    key: &str,
+    builtin: &str,
+) -> Result<Option<bool>, VmError> {
+    match map.get(key) {
+        None | Some(VmValue::Nil) => Ok(None),
+        Some(VmValue::Bool(value)) => Ok(Some(*value)),
+        Some(other) => Err(VmError::Runtime(format!(
+            "{builtin}: compaction policy `{key}` must be a bool, got {}",
+            other.type_name()
+        ))),
+    }
+}
+
+fn policy_string_list(
+    value: Option<&VmValue>,
+    builtin: &str,
+    key: &str,
+) -> Result<Vec<String>, VmError> {
+    match value {
+        None | Some(VmValue::Nil) => Ok(Vec::new()),
+        Some(VmValue::String(text)) => {
+            let trimmed = text.trim();
+            if trimmed.is_empty() {
+                Ok(Vec::new())
+            } else {
+                Ok(vec![trimmed.to_string()])
+            }
+        }
+        Some(VmValue::List(items)) => items
+            .iter()
+            .map(|item| match item {
+                VmValue::String(text) => Ok(text.trim().to_string()),
+                other => Err(VmError::Runtime(format!(
+                    "{builtin}: compaction policy `{key}` entries must be strings, got {}",
+                    other.type_name()
+                ))),
+            })
+            .filter_map(|result| match result {
+                Ok(value) if value.is_empty() => None,
+                other => Some(other),
+            })
+            .collect(),
+        Some(other) => Err(VmError::Runtime(format!(
+            "{builtin}: compaction policy `{key}` must be a string or list, got {}",
+            other.type_name()
+        ))),
+    }
+}
+
+pub fn compaction_policy_metadata_fields(
+    policy: &CompactionPolicy,
+) -> Vec<(&'static str, serde_json::Value)> {
+    let mut fields = vec![(
+        "instruction_mode",
+        serde_json::Value::String(policy.instruction_mode().to_string()),
+    )];
+    if let Some(source) = policy.instruction_source() {
+        fields.push((
+            "instruction_source",
+            serde_json::Value::String(source.to_string()),
+        ));
+    }
+    if let Some(policy_json) = policy.metadata_json() {
+        fields.push(("compaction_policy", policy_json));
+    }
+    fields
 }
 
 /// Configuration for automatic transcript compaction in agent loops.
@@ -91,6 +469,10 @@ pub struct AutoCompactConfig {
     /// broader than the engine strategy, e.g. `hybrid` lowers to LLM
     /// summarization plus truncate fallback.
     pub policy_strategy: String,
+    /// Host/user-supplied instructions that guide compaction without
+    /// becoming part of the compacted transcript unless `scope` explicitly
+    /// asks for model-visible policy text.
+    pub policy: CompactionPolicy,
 }
 
 impl Default for AutoCompactConfig {
@@ -109,6 +491,7 @@ impl Default for AutoCompactConfig {
             compress_callback: None,
             summarize_prompt: None,
             policy_strategy: compact_strategy_name(&CompactStrategy::ObservationMask).to_string(),
+            policy: CompactionPolicy::default(),
         }
     }
 }
@@ -355,6 +738,7 @@ async fn llm_compaction_summary(
     archived_count: usize,
     llm_opts: &crate::llm::api::LlmCallOptions,
     summarize_prompt: Option<&str>,
+    policy: &CompactionPolicy,
 ) -> Result<String, VmError> {
     let mut compact_opts = llm_opts.clone();
     let formatted = format_compaction_messages(old_messages);
@@ -366,7 +750,8 @@ async fn llm_compaction_summary(
     compact_opts.response_format = None;
     compact_opts.json_schema = None;
     compact_opts.output_schema = None;
-    let prompt = render_llm_compaction_prompt(summarize_prompt, &formatted, archived_count)?;
+    let prompt =
+        render_llm_compaction_prompt(summarize_prompt, &formatted, archived_count, policy)?;
     compact_opts.messages = vec![serde_json::json!({
         "role": "user",
         "content": prompt,
@@ -390,7 +775,11 @@ fn render_llm_compaction_prompt(
     summarize_prompt: Option<&str>,
     formatted: &str,
     archived_count: usize,
+    policy: &CompactionPolicy,
 ) -> Result<String, VmError> {
+    if policy.has_prompt_directives() && policy.extend_default_instructions == Some(false) {
+        return render_replacement_compaction_prompt(policy, formatted, archived_count);
+    }
     let mut bindings = BTreeMap::new();
     bindings.insert(
         "formatted_messages".to_string(),
@@ -401,15 +790,54 @@ fn render_llm_compaction_prompt(
         VmValue::Int(archived_count as i64),
     );
     let Some(path) = summarize_prompt.filter(|path| !path.trim().is_empty()) else {
-        return crate::stdlib::template::render_stdlib_prompt_asset(
+        let prompt = crate::stdlib::template::render_stdlib_prompt_asset(
             "orchestration/prompts/compaction_summary.harn.prompt",
             Some(&bindings),
-        );
+        )?;
+        return Ok(extend_compaction_prompt(prompt, policy));
     };
 
     let asset = crate::stdlib::template::TemplateAsset::render_target(path)
         .map_err(|error| VmError::Runtime(format!("compaction summarize_prompt: {error}")))?;
-    crate::stdlib::template::render_asset_result(&asset, Some(&bindings)).map_err(VmError::from)
+    let prompt = crate::stdlib::template::render_asset_result(&asset, Some(&bindings))
+        .map_err(VmError::from)?;
+    Ok(extend_compaction_prompt(prompt, policy))
+}
+
+fn render_replacement_compaction_prompt(
+    policy: &CompactionPolicy,
+    formatted: &str,
+    archived_count: usize,
+) -> Result<String, VmError> {
+    let directives = policy.prompt_directives().unwrap_or_default();
+    let mut bindings = BTreeMap::new();
+    bindings.insert(
+        "directives".to_string(),
+        VmValue::String(Rc::from(directives)),
+    );
+    bindings.insert(
+        "formatted_messages".to_string(),
+        VmValue::String(Rc::from(formatted.to_string())),
+    );
+    bindings.insert(
+        "archived_count".to_string(),
+        VmValue::Int(archived_count as i64),
+    );
+    crate::stdlib::template::render_stdlib_prompt_asset(
+        "orchestration/prompts/compaction_policy_replacement.harn.prompt",
+        Some(&bindings),
+    )
+}
+
+fn extend_compaction_prompt(mut prompt: String, policy: &CompactionPolicy) -> String {
+    let Some(directives) = policy.prompt_directives() else {
+        return prompt;
+    };
+    prompt.push_str(
+        "\n\nAdditional compaction instructions: use these directives to shape the summary, but do not quote this section unless it explicitly requests a model-visible note.\n",
+    );
+    prompt.push_str(&directives);
+    prompt
 }
 
 async fn custom_compaction_summary(
@@ -417,6 +845,7 @@ async fn custom_compaction_summary(
     archived_count: usize,
     callback: &VmValue,
     reminders: &[VmValue],
+    policy: &CompactionPolicy,
 ) -> Result<String, VmError> {
     let Some(VmValue::Closure(closure)) = Some(callback.clone()) else {
         return Err(VmError::Runtime(
@@ -434,7 +863,14 @@ async fn custom_compaction_summary(
             .map(crate::stdlib::json_to_vm_value)
             .collect(),
     ));
-    let result = if closure.func.params.len() >= 2 || closure.func.has_rest_param {
+    let result = if policy.has_metadata()
+        && (closure.func.params.len() >= 3 || closure.func.has_rest_param)
+    {
+        let reminders_vm = VmValue::List(Rc::new(reminders.to_vec()));
+        let policy_vm = compaction_policy_to_vm_value(policy);
+        vm.call_closure_pub(&closure, &[messages_vm, reminders_vm, policy_vm])
+            .await
+    } else if closure.func.params.len() >= 2 || closure.func.has_rest_param {
         let reminders_vm = VmValue::List(Rc::new(reminders.to_vec()));
         vm.call_closure_pub(&closure, &[messages_vm, reminders_vm])
             .await
@@ -549,17 +985,31 @@ async fn invoke_mask_callback(
         .collect())
 }
 
-/// Apply a single compaction strategy to a list of archived messages.
-async fn apply_compaction_strategy(
-    strategy: &CompactStrategy,
-    old_messages: &[serde_json::Value],
+struct CompactionStrategyInputs<'a> {
+    strategy: &'a CompactStrategy,
+    old_messages: &'a [serde_json::Value],
     archived_count: usize,
-    llm_opts: Option<&crate::llm::api::LlmCallOptions>,
-    custom_compactor: Option<&VmValue>,
-    custom_compactor_reminders: &[VmValue],
-    mask_callback: Option<&VmValue>,
-    summarize_prompt: Option<&str>,
-) -> Result<String, VmError> {
+    llm_opts: Option<&'a crate::llm::api::LlmCallOptions>,
+    custom_compactor: Option<&'a VmValue>,
+    custom_compactor_reminders: &'a [VmValue],
+    mask_callback: Option<&'a VmValue>,
+    summarize_prompt: Option<&'a str>,
+    policy: &'a CompactionPolicy,
+}
+
+/// Apply a single compaction strategy to a list of archived messages.
+async fn apply_compaction_strategy(input: CompactionStrategyInputs<'_>) -> Result<String, VmError> {
+    let CompactionStrategyInputs {
+        strategy,
+        old_messages,
+        archived_count,
+        llm_opts,
+        custom_compactor,
+        custom_compactor_reminders,
+        mask_callback,
+        summarize_prompt,
+        policy,
+    } = input;
     match strategy {
         CompactStrategy::Truncate => Ok(truncate_compaction_summary(old_messages, archived_count)),
         CompactStrategy::Llm => {
@@ -572,6 +1022,7 @@ async fn apply_compaction_strategy(
                     )
                 })?,
                 summarize_prompt,
+                policy,
             )
             .await
         }
@@ -586,6 +1037,7 @@ async fn apply_compaction_strategy(
                     )
                 })?,
                 custom_compactor_reminders,
+                policy,
             )
             .await
         }
@@ -655,16 +1107,17 @@ pub(crate) async fn auto_compact_messages(
     let old_messages: Vec<_> = messages.drain(compact_start..split_at).collect();
     let archived_count = old_messages.len();
 
-    let mut summary = apply_compaction_strategy(
-        &config.compact_strategy,
-        &old_messages,
+    let mut summary = apply_compaction_strategy(CompactionStrategyInputs {
+        strategy: &config.compact_strategy,
+        old_messages: &old_messages,
         archived_count,
         llm_opts,
-        config.custom_compactor.as_ref(),
-        &config.custom_compactor_reminders,
-        config.mask_callback.as_ref(),
-        config.summarize_prompt.as_deref(),
-    )
+        custom_compactor: config.custom_compactor.as_ref(),
+        custom_compactor_reminders: &config.custom_compactor_reminders,
+        mask_callback: config.mask_callback.as_ref(),
+        summarize_prompt: config.summarize_prompt.as_deref(),
+        policy: &config.policy,
+    })
     .await?;
 
     if let Some(hard_limit) = config.hard_limit_tokens {
@@ -677,19 +1130,22 @@ pub(crate) async fn auto_compact_messages(
                 "role": "user",
                 "content": summary,
             })];
-            summary = apply_compaction_strategy(
-                &config.hard_limit_strategy,
-                &tier1_as_messages,
+            summary = apply_compaction_strategy(CompactionStrategyInputs {
+                strategy: &config.hard_limit_strategy,
+                old_messages: &tier1_as_messages,
                 archived_count,
                 llm_opts,
-                config.custom_compactor.as_ref(),
-                &config.custom_compactor_reminders,
-                None,
-                config.summarize_prompt.as_deref(),
-            )
+                custom_compactor: config.custom_compactor.as_ref(),
+                custom_compactor_reminders: &config.custom_compactor_reminders,
+                mask_callback: None,
+                summarize_prompt: config.summarize_prompt.as_deref(),
+                policy: &config.policy,
+            })
             .await?;
         }
     }
+
+    summary = apply_model_visible_policy(summary, &config.policy);
 
     messages.insert(
         compact_start,
@@ -699,6 +1155,18 @@ pub(crate) async fn auto_compact_messages(
         }),
     );
     Ok(Some(summary))
+}
+
+fn apply_model_visible_policy(mut summary: String, policy: &CompactionPolicy) -> String {
+    if !policy.is_model_visible_scope() {
+        return summary;
+    }
+    let Some(directives) = policy.prompt_directives() else {
+        return summary;
+    };
+    summary.push_str("\n\n[compaction instructions]\n");
+    summary.push_str(&directives);
+    summary
 }
 
 #[cfg(test)]
@@ -770,6 +1238,37 @@ mod tests {
             estimate_message_tokens(&messages) >= 100,
             "structured content must not count as zero"
         );
+    }
+
+    #[test]
+    fn compaction_policy_instructions_extend_by_default() {
+        let policy = CompactionPolicy {
+            instructions: Some("Keep the failing test names.".to_string()),
+            ..Default::default()
+        };
+        let prompt = render_llm_compaction_prompt(None, "[user] old context", 1, &policy)
+            .expect("prompt renders");
+
+        assert_eq!(policy.instruction_mode(), "extend");
+        assert!(prompt.contains("Preserve goals, constraints"));
+        assert!(prompt.contains("Additional compaction instructions"));
+        assert!(prompt.contains("Keep the failing test names."));
+    }
+
+    #[test]
+    fn compaction_policy_can_replace_default_instructions() {
+        let policy = CompactionPolicy {
+            instructions: Some("Only keep repro steps.".to_string()),
+            extend_default_instructions: Some(false),
+            ..Default::default()
+        };
+        let prompt = render_llm_compaction_prompt(None, "[user] old context", 1, &policy)
+            .expect("prompt renders");
+
+        assert_eq!(policy.instruction_mode(), "replace");
+        assert!(prompt.contains("according to these instructions"));
+        assert!(prompt.contains("Only keep repro steps."));
+        assert!(!prompt.contains("Preserve goals, constraints"));
     }
 
     #[test]

--- a/crates/harn-vm/src/orchestration/records/persistence.rs
+++ b/crates/harn-vm/src/orchestration/records/persistence.rs
@@ -364,6 +364,18 @@ pub(super) fn compaction_events_from_transcript(
                         snapshot_path: persisted_path
                             .map(|path| path.to_string_lossy().into_owned()),
                         available,
+                        instruction_mode: metadata
+                            .and_then(|value| value.get("instruction_mode"))
+                            .and_then(|value| value.as_str())
+                            .unwrap_or_default()
+                            .to_string(),
+                        instruction_source: metadata
+                            .and_then(|value| value.get("instruction_source"))
+                            .and_then(|value| value.as_str())
+                            .map(str::to_string),
+                        compaction_policy: metadata
+                            .and_then(|value| value.get("compaction_policy"))
+                            .cloned(),
                     }
                 })
                 .collect()

--- a/crates/harn-vm/src/orchestration/records/types.rs
+++ b/crates/harn-vm/src/orchestration/records/types.rs
@@ -297,6 +297,9 @@ pub struct CompactionEventRecord {
     pub snapshot_location: String,
     pub snapshot_path: Option<String>,
     pub available: bool,
+    pub instruction_mode: String,
+    pub instruction_source: Option<String>,
+    pub compaction_policy: Option<serde_json::Value>,
 }
 
 #[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]

--- a/crates/harn-vm/src/stdlib/agent_sessions.rs
+++ b/crates/harn-vm/src/stdlib/agent_sessions.rs
@@ -649,9 +649,27 @@ async fn agent_session_compact_builtin(args: Vec<VmValue>) -> Result<VmValue, Vm
     };
     let config = build_compact_config(&opts_dict)?;
     let mut messages = agent_sessions::messages_json(&id);
-    crate::orchestration::auto_compact_messages(&mut messages, &config, None).await?;
+    let original_message_count = messages.len();
+    let estimated_tokens_before = crate::orchestration::estimate_message_tokens(&messages);
+    let summary = crate::orchestration::auto_compact_messages(&mut messages, &config, None).await?;
     let kept = messages.len();
-    agent_sessions::replace_messages(&id, &messages);
+    if let Some(summary) = summary {
+        let estimated_tokens_after = crate::orchestration::estimate_message_tokens(&messages);
+        let archived_messages = original_message_count
+            .saturating_sub(messages.len())
+            .saturating_add(1);
+        agent_sessions::replace_messages_with_summary(&id, &messages, Some(&summary));
+        record_agent_session_compaction(
+            &id,
+            &config,
+            archived_messages,
+            estimated_tokens_before,
+            estimated_tokens_after,
+            summary.len(),
+        );
+    } else {
+        agent_sessions::replace_messages(&id, &messages);
+    }
     Ok(VmValue::Int(kept as i64))
 }
 
@@ -665,6 +683,16 @@ const COMPACT_OPT_KEYS: &[&str] = &[
     "custom_compactor",
     "mask_callback",
     "compress_callback",
+    "policy",
+    "compaction_policy",
+    "compaction_request",
+    "instructions",
+    "mode",
+    "scope",
+    "preserve",
+    "drop",
+    "extend_default_instructions",
+    "author",
 ];
 
 fn build_compact_config(
@@ -678,7 +706,13 @@ fn build_compact_config(
             )));
         }
     }
-    let mut cfg = crate::orchestration::AutoCompactConfig::default();
+    let mut cfg = crate::orchestration::AutoCompactConfig {
+        policy: crate::orchestration::parse_compaction_policy_options(
+            Some(opts),
+            "agent_session_compact",
+        )?,
+        ..Default::default()
+    };
     if let Some(v) = compact_usize_opt(opts, "keep_last")? {
         cfg.keep_last = v;
     }
@@ -690,6 +724,8 @@ fn build_compact_config(
     }
     if let Some(VmValue::String(s)) = opts.get("compact_strategy") {
         cfg.compact_strategy = crate::orchestration::parse_compact_strategy(s)?;
+        cfg.policy_strategy =
+            crate::orchestration::compact_strategy_name(&cfg.compact_strategy).to_string();
     }
     if let Some(v) = compact_usize_opt(opts, "hard_limit_tokens")? {
         cfg.hard_limit_tokens = Some(v);
@@ -722,6 +758,52 @@ fn build_compact_config(
         cfg.compress_callback = Some(v);
     }
     Ok(cfg)
+}
+
+fn record_agent_session_compaction(
+    id: &str,
+    config: &crate::orchestration::AutoCompactConfig,
+    archived_messages: usize,
+    estimated_tokens_before: usize,
+    estimated_tokens_after: usize,
+    new_summary_len: usize,
+) {
+    let mut metadata = serde_json::json!({
+        "mode": "host",
+        "strategy": &config.policy_strategy,
+        "engine_strategy": crate::orchestration::compact_strategy_name(&config.compact_strategy),
+        "archived_messages": archived_messages,
+        "estimated_tokens_before": estimated_tokens_before,
+        "estimated_tokens_after": estimated_tokens_after,
+        "new_summary_len": new_summary_len,
+        "keep_last": config.keep_last,
+    });
+    if let Some(map) = metadata.as_object_mut() {
+        for (key, value) in crate::orchestration::compaction_policy_metadata_fields(&config.policy)
+        {
+            map.insert(key.to_string(), value);
+        }
+    }
+    let event = crate::llm::helpers::transcript_event(
+        "compaction",
+        "system",
+        "internal",
+        "",
+        Some(metadata.clone()),
+    );
+    let _ = agent_sessions::append_event(id, event);
+    crate::llm::emit_live_agent_event_sync(&crate::agent_events::AgentEvent::TranscriptCompacted {
+        session_id: id.to_string(),
+        mode: "host".to_string(),
+        strategy: config.policy_strategy.clone(),
+        archived_messages,
+        estimated_tokens_before,
+        estimated_tokens_after,
+        snapshot_asset_id: None,
+        instruction_mode: Some(config.policy.instruction_mode().to_string()),
+        instruction_source: config.policy.instruction_source().map(str::to_string),
+        compaction_policy: config.policy.metadata_json(),
+    });
 }
 
 fn compact_usize_opt(

--- a/crates/harn-vm/src/stdlib/transcript_compact.rs
+++ b/crates/harn-vm/src/stdlib/transcript_compact.rs
@@ -11,7 +11,7 @@ use crate::llm::helpers::{
 };
 use crate::orchestration::{
     auto_compact_messages, compact_strategy_name, estimate_message_tokens, AutoCompactConfig,
-    CompactStrategy,
+    CompactStrategy, CompactionPolicy,
 };
 use crate::orchestration::{HookControl, HookEvent};
 use crate::stdlib::json_to_vm_value;
@@ -40,6 +40,7 @@ struct TranscriptCompactOptions {
     summarize_prompt: Option<String>,
     summary: Option<String>,
     custom_compactor: Option<VmValue>,
+    policy: CompactionPolicy,
 }
 
 async fn compact_transcript_impl(
@@ -57,6 +58,7 @@ async fn compact_transcript_impl(
         hard_limit_strategy: options.strategy.clone(),
         summarize_prompt: options.summarize_prompt.clone(),
         custom_compactor: options.custom_compactor.clone(),
+        policy: options.policy.clone(),
         ..Default::default()
     };
     if let Some(target_tokens) = options.target_tokens {
@@ -151,7 +153,7 @@ async fn compact_transcript_impl(
     let mut assets = transcript_asset_list(transcript)?;
     assets.push(snapshot_asset);
 
-    let metadata = serde_json::json!({
+    let mut metadata = serde_json::json!({
         "mode": "manual",
         "strategy": compact_strategy_name(&options.strategy),
         "keep_last": options.keep_last,
@@ -165,6 +167,7 @@ async fn compact_transcript_impl(
         "reminders_deduped": reminder_report.deduped.len(),
         "reminders_preserved": reminder_report.preserved_count,
     });
+    add_compaction_policy_metadata(&mut metadata, &options.policy);
     let mut extra_events = reminder_report.preserved_events;
     extra_events.push(transcript_event(
         "compaction",
@@ -188,6 +191,9 @@ async fn compact_transcript_impl(
             estimated_tokens_before,
             estimated_tokens_after,
             snapshot_asset_id: Some(snapshot_asset_id.clone()),
+            instruction_mode: Some(options.policy.instruction_mode().to_string()),
+            instruction_source: options.policy.instruction_source().map(str::to_string),
+            compaction_policy: options.policy.metadata_json(),
         })
         .await;
 
@@ -241,6 +247,9 @@ fn compact_hook_payload(
     let Some(map) = payload.as_object_mut() else {
         return payload;
     };
+    for (key, value) in crate::orchestration::compaction_policy_metadata_fields(&options.policy) {
+        map.insert(key.to_string(), value);
+    }
     if let Some(value) = remaining_messages {
         map.insert("remaining_messages".to_string(), serde_json::json!(value));
     }
@@ -499,6 +508,10 @@ fn parse_options(
         summarize_prompt: None,
         summary: None,
         custom_compactor: None,
+        policy: crate::orchestration::parse_compaction_policy_options(
+            options,
+            "transcript_compact",
+        )?,
     };
     if let Some(value) = options
         .and_then(|dict| {
@@ -570,6 +583,15 @@ fn parse_options(
     Ok(parsed)
 }
 
+fn add_compaction_policy_metadata(metadata: &mut serde_json::Value, policy: &CompactionPolicy) {
+    let Some(map) = metadata.as_object_mut() else {
+        return;
+    };
+    for (key, value) in crate::orchestration::compaction_policy_metadata_fields(policy) {
+        map.insert(key.to_string(), value);
+    }
+}
+
 fn build_snapshot_asset(
     transcript: &VmValue,
     options: &TranscriptCompactOptions,
@@ -577,6 +599,40 @@ fn build_snapshot_asset(
     estimated_tokens_before: usize,
     estimated_tokens_after: usize,
 ) -> VmValue {
+    let mut asset_metadata = BTreeMap::from([
+        (
+            "strategy".to_string(),
+            VmValue::String(Rc::from(compact_strategy_name(&options.strategy))),
+        ),
+        (
+            "archived_messages".to_string(),
+            VmValue::Int(archived_messages as i64),
+        ),
+        (
+            "estimated_tokens_before".to_string(),
+            VmValue::Int(estimated_tokens_before as i64),
+        ),
+        (
+            "estimated_tokens_after".to_string(),
+            VmValue::Int(estimated_tokens_after as i64),
+        ),
+        (
+            "instruction_mode".to_string(),
+            VmValue::String(Rc::from(options.policy.instruction_mode())),
+        ),
+    ]);
+    if let Some(policy_json) = options.policy.metadata_json() {
+        asset_metadata.insert(
+            "compaction_policy".to_string(),
+            crate::stdlib::json_to_vm_value(&policy_json),
+        );
+    }
+    if let Some(source) = options.policy.instruction_source() {
+        asset_metadata.insert(
+            "instruction_source".to_string(),
+            VmValue::String(Rc::from(source)),
+        );
+    }
     let asset = VmValue::Dict(Rc::new(BTreeMap::from([
         (
             "id".to_string(),
@@ -600,24 +656,7 @@ fn build_snapshot_asset(
         ("data".to_string(), transcript.clone()),
         (
             "metadata".to_string(),
-            VmValue::Dict(Rc::new(BTreeMap::from([
-                (
-                    "strategy".to_string(),
-                    VmValue::String(Rc::from(compact_strategy_name(&options.strategy))),
-                ),
-                (
-                    "archived_messages".to_string(),
-                    VmValue::Int(archived_messages as i64),
-                ),
-                (
-                    "estimated_tokens_before".to_string(),
-                    VmValue::Int(estimated_tokens_before as i64),
-                ),
-                (
-                    "estimated_tokens_after".to_string(),
-                    VmValue::Int(estimated_tokens_after as i64),
-                ),
-            ]))),
+            VmValue::Dict(Rc::new(asset_metadata)),
         ),
     ])));
     normalize_transcript_asset(&asset)

--- a/crates/harn-vm/src/stdlib/workflow/compact.rs
+++ b/crates/harn-vm/src/stdlib/workflow/compact.rs
@@ -80,7 +80,13 @@ pub(super) async fn transcript_auto_compact_builtin(
         }
     };
     let options = args.get(1).and_then(|v| v.as_dict()).cloned();
-    let mut config = crate::orchestration::AutoCompactConfig::default();
+    let mut config = crate::orchestration::AutoCompactConfig {
+        policy: crate::orchestration::parse_compaction_policy_options(
+            options.as_ref(),
+            "transcript_auto_compact",
+        )?,
+        ..Default::default()
+    };
     if let Some(v) = options
         .as_ref()
         .and_then(|o| o.get("keep_first"))

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -1529,6 +1529,35 @@ the default ranker uses keyword overlap against `query`. Workflow
 nodes may set `context_assembler: {...}` to route the stage's selected
 artifacts through this builtin before the prompt is rendered.
 
+### Compaction policies
+
+Compaction entrypoints accept a typed host/user instruction lane through
+`policy`, `compaction_policy`, `compaction_request`, or the direct fields
+`instructions`, `mode`, `scope`, `preserve`, `drop`,
+`extend_default_instructions`, and `author`.
+
+```harn
+import {compact_preserving_test_failures} from "std/agent/autocompact"
+
+let compacted = transcript_auto_compact(messages, {
+  keep_last: 1,
+  token_threshold: 1,
+  policy: compact_preserving_test_failures({author: "host"})
+})
+```
+
+Omitting `extend_default_instructions` or setting it to `true` appends the
+instructions to Harn's default summary guidance; `false` replaces it.
+Host-only instructions are kept in
+`compaction` event metadata (`instruction_mode`, `instruction_source`,
+`compaction_policy`) and are not copied into the next model-visible summary
+unless `scope` is `"model_visible"`, `"summary"`, or `"transcript"`.
+
+Helper policies in `std/agent/autocompact`:
+`compaction_policy(...)`, `compact_for_bug_fix_resumption(...)`,
+`compact_preserving_test_failures(...)`, and
+`compact_retaining_current_plan(...)`.
+
 ## Reminders
 
 System reminders are typed, ephemeral `system_reminder` transcript events
@@ -2263,7 +2292,8 @@ Lifecycle builtins (all hard-error on unknown ids except `exists`,
   `truncate_to_last`, `drop_tool_calls`, `rename_session`, `validate`,
   `provider`, `model`.
 - `agent_session_compact(id, opts)` — supports LLM/truncate/observation-mask/custom
-  compaction and errors on unknown option keys.
+  compaction, accepts the same compaction policy fields as
+  `transcript_auto_compact`, and errors on unknown option keys.
 - `agent_session_length(id)` / `_snapshot(id)` / `_ancestry(id)` for read-only inspection.
 
 ### Daemon wrappers

--- a/docs/src/bridge-protocol.md
+++ b/docs/src/bridge-protocol.md
@@ -107,7 +107,7 @@ that route on it keep working unchanged. Concretely:
 | `log`                  | `level`, `message`, `fields`                                                                                                           |
 | `fs_watch`             | `subscriptionId`, `events`                                                                                                             |
 | `worker_update`        | `workerId`, `workerName`, `workerTask`, `workerMode`, `event`, `status`, `terminal`, `metadata`, `audit`                               |
-| `transcript_compacted` | `mode`, `strategy`, `archivedMessages`, `estimatedTokensBefore`, `estimatedTokensAfter`, `snapshotAssetId`                             |
+| `transcript_compacted` | `mode`, `strategy`, `archivedMessages`, `estimatedTokensBefore`, `estimatedTokensAfter`, `snapshotAssetId`, `instructionMode`, `instructionSource`, `compactionPolicy` |
 | `handoff`              | `handoffId`, `artifactId`, `handoff`                                                                                                   |
 | `skill_activated`      | `skillName`, `iteration`, `reason`                                                                                                     |
 | `skill_deactivated`    | `skillName`, `iteration`                                                                                                               |

--- a/docs/src/llm/agent_loop.md
+++ b/docs/src/llm/agent_loop.md
@@ -244,10 +244,11 @@ Same as `llm_call`, plus additional options:
 | `wake_interval_ms` | int | nil | Fixed timer wake interval for daemon loops |
 | `watch_paths` | list/string | nil | Files to poll for mtime changes while idle |
 | `consolidate_on_idle` | bool | `false` | Run transcript auto-compaction before persisting an idle daemon snapshot |
-| `compaction` | string/dict/bool | `{strategy: "hybrid", keep_last_n: 10}` | Agent-loop context-window policy. Use `"none"` or `false` to disable; `"truncate"`, `"summarize_middle"`, `"summarize_all"`, or `"hybrid"` to choose policy |
+| `compaction` | string/dict/bool | `{strategy: "hybrid", keep_last_n: 10}` | Agent-loop context-window policy. Use `"none"` or `false` to disable; `"truncate"`, `"summarize_middle"`, `"summarize_all"`, or `"hybrid"` to choose policy. Dict policies may include `policy` / `compaction_policy` with compaction instructions |
 | `compact_threshold` | int | model-aware | Estimated input-token threshold for compaction. Harn lowers this from the provider/model context window when known |
 | `compact_keep_first` | int | `0` | Prompt-visible messages to keep verbatim before the compaction summary. The system prompt is always kept separately |
 | `compact_keep_last` | int | strategy default | Prompt-visible messages to keep verbatim after the compaction summary |
+| `auto_compact` | bool/dict | nil | Auto-compaction options. Dict values may include the same compaction policy fields as `compaction` |
 | `idle_watchdog_attempts` | int | nil (disabled) | Max consecutive idle-wait ticks that may return no wake reason before the daemon terminates with `status = "watchdog"`. Guards against a misconfigured daemon (e.g. bridge never signals, no timer, no watch paths) hanging the session silently |
 | `context_callback` | closure | nil | Per-turn hook that can rewrite prompt-visible `messages` and/or the effective `system` prompt before the next LLM call |
 | `context_filter` | closure | nil | Alias for `context_callback` |
@@ -349,8 +350,40 @@ Available strategies:
 
 Compaction emits `TranscriptCompacted` live events and transcript
 `compaction` events with `strategy`, `engine_strategy`,
-`estimated_tokens_before`, and `estimated_tokens_after`, so replay tools can
-verify which policy ran.
+`estimated_tokens_before`, `estimated_tokens_after`, `instruction_mode`,
+`instruction_source`, and `compaction_policy`, so replay tools can verify which
+policy and host/user instruction lane ran.
+
+Hosts can attach first-class compaction instructions without building custom
+prompt concatenation. The typed `CompactionPolicy` shape accepts
+`instructions`, `mode`, `scope`, `preserve`, `drop`,
+`extend_default_instructions`, and `author`. Omitting
+`extend_default_instructions` or setting it to `true` appends host/user guidance
+after Harn's default compaction rules; `false` replaces the default guidance.
+Host-only instructions stay in event and audit metadata and are not copied into
+the next model-visible summary unless `scope` is `"model_visible"`,
+`"summary"`, or `"transcript"`.
+
+```harn
+import {compact_for_bug_fix_resumption} from "std/agent/autocompact"
+
+let result = agent_loop(task, system, {
+  provider: "mock",
+  compact_threshold: 1,
+  compact_strategy: "custom",
+  auto_compact: {
+    policy: compact_for_bug_fix_resumption({author: "host"})
+  },
+  compact_callback: { archived, _reminders, policy ->
+    {summary: "resume with " + policy.mode + " over " + to_string(len(archived)) + " messages"}
+  },
+})
+```
+
+Stdlib helpers cover common host commands:
+`compaction_policy(...)`, `compact_for_bug_fix_resumption(...)`,
+`compact_preserving_test_failures(...)`, and
+`compact_retaining_current_plan(...)`.
 
 | Profile | `max_iterations` | `max_nudges` | `tool_retries` | `llm_retries` | `schema_retries` |
 |---|---:|---:|---:|---:|---:|

--- a/docs/src/llm/streaming.md
+++ b/docs/src/llm/streaming.md
@@ -70,7 +70,9 @@ let compacted = transcript_compact(second.transcript, {
 
 Use `transcript_summarize()` when you want Harn to create a fresh summary with
 an LLM, or `transcript_compact()` when you want the runtime compaction engine
-outside the `agent_loop` path.
+outside the `agent_loop` path. `transcript_compact()` accepts the same
+`CompactionPolicy` instruction fields as agent-loop auto-compaction, so hosts
+can route `/compact <instructions>` through one audited path.
 
 Transcript helpers also expose the canonical event model:
 

--- a/docs/src/spec/harn-extensions/v1.md
+++ b/docs/src/spec/harn-extensions/v1.md
@@ -104,7 +104,7 @@ Harn extension session updates keep the `sessionUpdate` discriminator at
 | `log` | `level`, `message`, `fields` | Stable v1 |
 | `fs_watch` | `subscriptionId`, `events` | Stable v1 |
 | `worker_update` | `workerId`, `workerName`, `workerTask`, `workerMode`, `event`, `status`, `terminal`, `metadata`, `audit` | Stable v1 |
-| `transcript_compacted` | `mode`, `strategy`, `archivedMessages`, `estimatedTokensBefore`, `estimatedTokensAfter`, `snapshotAssetId` | Stable v1 |
+| `transcript_compacted` | `mode`, `strategy`, `archivedMessages`, `estimatedTokensBefore`, `estimatedTokensAfter`, `snapshotAssetId`, `instructionMode`, `instructionSource`, `compactionPolicy` | Stable v1 |
 | `handoff` | `handoffId`, `artifactId`, `handoff` | Stable v1 |
 | `skill_activated` | `skillName`, `iteration`, `reason` | Stable v1 |
 | `skill_deactivated` | `skillName`, `iteration` | Stable v1 |


### PR DESCRIPTION
## Summary

- Add first-class `CompactionPolicy` / `CompactionRequest` parsing and typed builtin shapes for manual, auto, and host-triggered compaction.
- Thread policy metadata through compaction events, run observability records, live agent events, and ACP `_meta.harn` session updates.
- Add stdlib helper policies for bug-fix resumption, preserving test failures, and retaining current plans, plus docs and conformance coverage.

Closes #2190

## Verification

- `cargo check -p harn-serve`
- `cargo clippy -p harn-parser -p harn-serve -p harn-stdlib -p harn-vm --all-targets --all-features -- -D warnings`
- `cargo test -p harn-vm --lib compaction_policy_ -- --nocapture`
- `cargo test -p harn-stdlib key_stdlib_prompt_assets_resolve -- --nocapture`
- `cargo test -p harn-serve session_update -- --nocapture`
- `make conformance`
- `make check-docs-snippets`
- `make protocol-conformance`
- `make fmt-harn`
- `make lint-harn`
- `make lint-test-patterns`
- `make lint-no-rust-prompt-prose`
- pre-commit and pre-push hooks