### PR TITLE
Track local model readiness recommendations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ condensed series summaries instead of full per-patch history.
   exercises provider/model selectors across native and text tool modes, records
   normalized JSON/JSONL/Markdown artifacts, snapshots local model cleanup, and
   generates follow-up issue candidates for provider/preset abstraction leaks.
+  Local runs now also emit `local_readiness.json`, and
+  `harn providers recommend` exposes the same readiness evidence and local
+  preset ordering that `harn quickstart` consumes.
 
 - **Provider matrix lifecycle command.** Added `harn providers matrix` so the
   capability matrix docs can be regenerated and checked through the same

--- a/crates/harn-cli/data/local_model_readiness.toml
+++ b/crates/harn-cli/data/local_model_readiness.toml
@@ -1,0 +1,34 @@
+# Seed evidence for local coding-agent model recommendations.
+# `harn eval coding-agent --include-local` writes a fresher
+# `.harn-runs/coding-agent-bench/latest/local_readiness.json`; this file is
+# only the fallback when no local benchmark report exists yet.
+
+[[outcomes]]
+provider = "ollama"
+model = "devstral-small-2:24b"
+selector = "devstral-small-2"
+tool_format = "text"
+class = "passed"
+status = "passed"
+score = 100
+evidence = "First empirical coding-agent fixture passed in text-tool mode."
+
+[[outcomes]]
+provider = "ollama"
+model = "qwen3.6:35b-a3b-coding-nvfp4"
+selector = "qwen3.6-coding"
+tool_format = "text"
+class = "provider_transport_failure"
+status = "infra_error"
+score = 35
+evidence = "Initial local run hit an Ollama HTTP 500 / EOF transport path; report separately from model task quality."
+
+[[outcomes]]
+provider = "ollama"
+model = "gemma4:26b"
+selector = "ollama-gemma4"
+tool_format = "text"
+class = "behavioral_failure"
+status = "failed"
+score = 20
+evidence = "Initial local run failed behaviorally by hallucinating paths/tools in the coding-agent fixture."

--- a/crates/harn-cli/src/cli/mod.rs
+++ b/crates/harn-cli/src/cli/mod.rs
@@ -158,7 +158,7 @@ pub(crate) use provider::{
 };
 pub(crate) use providers::{
     ProvidersArgs, ProvidersCommand, ProvidersExportArgs, ProvidersMatrixArgs,
-    ProvidersRefreshArgs, ProvidersValidateArgs,
+    ProvidersRecommendArgs, ProvidersRefreshArgs, ProvidersValidateArgs,
 };
 pub(crate) use quickstart::QuickstartArgs;
 pub(crate) use routes::RoutesArgs;

--- a/crates/harn-cli/src/cli/providers.rs
+++ b/crates/harn-cli/src/cli/providers.rs
@@ -18,6 +18,8 @@ pub(crate) enum ProvidersCommand {
     Export(ProvidersExportArgs),
     /// Generate or check the provider capability matrix docs.
     Matrix(ProvidersMatrixArgs),
+    /// Recommend local provider/model presets from coding-agent readiness data.
+    Recommend(ProvidersRecommendArgs),
 }
 
 #[derive(Debug, Args)]
@@ -79,4 +81,20 @@ pub(crate) struct ProvidersMatrixArgs {
     /// Only include matrix rows that support the named feature.
     #[arg(long)]
     pub filter: Option<String>,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct ProvidersRecommendArgs {
+    /// Local readiness JSON or coding-agent summary JSON to read.
+    #[arg(long)]
+    pub input: Option<PathBuf>,
+    /// Coding-agent summary JSON to convert into a readiness report.
+    #[arg(long, conflicts_with = "input")]
+    pub summary: Option<PathBuf>,
+    /// Limit recommendations and outcomes to one provider id.
+    #[arg(long)]
+    pub provider: Option<String>,
+    /// Emit the structured local readiness report as JSON.
+    #[arg(long)]
+    pub json: bool,
 }

--- a/crates/harn-cli/src/cli/tests.rs
+++ b/crates/harn-cli/src/cli/tests.rs
@@ -3125,6 +3125,30 @@ fn test_parses_check_provider_matrix_args() {
 }
 
 #[test]
+fn test_parses_providers_recommend_args() {
+    let cli = Cli::parse_from([
+        "harn",
+        "providers",
+        "recommend",
+        "--input",
+        "local_readiness.json",
+        "--provider",
+        "ollama",
+        "--json",
+    ]);
+
+    let Command::Providers(args) = cli.command.unwrap() else {
+        panic!("expected providers command");
+    };
+    let ProvidersCommand::Recommend(recommend) = args.command else {
+        panic!("expected providers recommend command");
+    };
+    assert_eq!(recommend.input, Some(PathBuf::from("local_readiness.json")));
+    assert_eq!(recommend.provider.as_deref(), Some("ollama"));
+    assert!(recommend.json);
+}
+
+#[test]
 fn test_parses_check_connector_matrix_args() {
     let cli = Cli::parse_from([
         "harn",

--- a/crates/harn-cli/src/commands/eval_coding_agent.rs
+++ b/crates/harn-cli/src/commands/eval_coding_agent.rs
@@ -17,6 +17,7 @@ use crate::commands::eval_model_selector::{
 use crate::commands::local::runtime::{
     local_provider_ids, ollama_unload_model, snapshot_provider, LocalProviderSnapshot,
 };
+use crate::commands::local_readiness;
 use crate::commands::run::{execute_run, CliLlmMockMode, RunProfileOptions};
 
 const FIRST_CODING_AGENT_HARN: &str = include_str!("../../assets/evals/first_coding_agent.harn");
@@ -200,9 +201,10 @@ pub async fn run(args: EvalCodingAgentArgs) -> i32 {
         return 1;
     }
     eprintln!(
-        "wrote {}, {}, {}, and {}",
+        "wrote {}, {}, {}, {}, and {}",
         output_dir.join("summary.json").display(),
         output_dir.join("per_run.jsonl").display(),
+        output_dir.join("local_readiness.json").display(),
         output_dir.join("summary.md").display(),
         output_dir.join("followups.md").display()
     );
@@ -852,6 +854,12 @@ fn suggest_followups(
 fn write_outputs(output_dir: &Path, summary: &EvalSummary) -> Result<(), String> {
     write_json_pretty(&output_dir.join("summary.json"), summary)?;
     write_jsonl(&output_dir.join("per_run.jsonl"), &summary.runs)?;
+    let summary_value = serde_json::to_value(summary).map_err(|error| error.to_string())?;
+    let readiness = local_readiness::report_from_summary_json(
+        &summary_value,
+        output_dir.display().to_string(),
+    )?;
+    write_json_pretty(&output_dir.join("local_readiness.json"), &readiness)?;
     fs::write(output_dir.join("summary.md"), render_markdown(summary))
         .map_err(|error| error.to_string())?;
     fs::write(output_dir.join("followups.md"), render_followups(summary))

--- a/crates/harn-cli/src/commands/local_readiness.rs
+++ b/crates/harn-cli/src/commands/local_readiness.rs
@@ -1,0 +1,736 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+
+use harn_vm::llm::capabilities;
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+
+const SEED_READINESS_TOML: &str = include_str!("../../data/local_model_readiness.toml");
+const DEFAULT_REPORT_PATH: &str = ".harn-runs/coding-agent-bench/latest/local_readiness.json";
+const DEFAULT_SUMMARY_PATH: &str = ".harn-runs/coding-agent-bench/latest/summary.json";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum LocalOutcomeClass {
+    Passed,
+    ProviderTransportFailure,
+    BehavioralFailure,
+    UnsupportedCapabilityFailure,
+    Skipped,
+}
+
+impl LocalOutcomeClass {
+    fn rank(self) -> u8 {
+        match self {
+            Self::Passed => 0,
+            Self::ProviderTransportFailure => 1,
+            Self::UnsupportedCapabilityFailure => 2,
+            Self::BehavioralFailure => 3,
+            Self::Skipped => 4,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct LocalReadinessReport {
+    pub schema_version: u32,
+    pub source: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub case_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_dir: Option<String>,
+    pub recommendations: Vec<LocalModelRecommendation>,
+    pub outcomes: Vec<LocalModelOutcome>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct LocalModelRecommendation {
+    pub rank: usize,
+    pub provider: String,
+    pub model: String,
+    pub selector: String,
+    pub status: String,
+    pub recommended_tool_format: Option<String>,
+    pub score: i64,
+    pub evidence: Vec<String>,
+    pub caveats: Vec<String>,
+    pub outcome_classes: BTreeMap<String, usize>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct LocalModelOutcome {
+    pub provider: String,
+    pub model: String,
+    pub selector: String,
+    pub tool_format: String,
+    pub class: LocalOutcomeClass,
+    pub status: String,
+    pub passed: bool,
+    pub score: i64,
+    pub evidence: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cleanup_action: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cleanup_detail: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SeedReadiness {
+    outcomes: Vec<SeedOutcome>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SeedOutcome {
+    provider: String,
+    model: String,
+    selector: String,
+    tool_format: String,
+    class: LocalOutcomeClass,
+    status: String,
+    score: i64,
+    evidence: String,
+}
+
+pub(crate) fn report_from_summary_path(path: &Path) -> Result<LocalReadinessReport, String> {
+    let value = read_json(path)?;
+    report_from_summary_json(&value, path.display().to_string())
+}
+
+pub(crate) fn report_from_summary_json(
+    summary: &JsonValue,
+    source: impl Into<String>,
+) -> Result<LocalReadinessReport, String> {
+    let outcomes = summary
+        .get("runs")
+        .and_then(JsonValue::as_array)
+        .map(|runs| {
+            runs.iter()
+                .filter_map(outcome_from_run)
+                .collect::<Vec<LocalModelOutcome>>()
+        })
+        .unwrap_or_default();
+    Ok(report_from_outcomes(
+        source.into(),
+        summary
+            .get("case_id")
+            .and_then(JsonValue::as_str)
+            .map(str::to_string),
+        summary
+            .get("output_dir")
+            .and_then(JsonValue::as_str)
+            .map(str::to_string),
+        outcomes,
+    ))
+}
+
+pub(crate) fn load_report_or_summary(path: &Path) -> Result<LocalReadinessReport, String> {
+    let value = read_json(path)?;
+    if value.get("recommendations").is_some() && value.get("outcomes").is_some() {
+        serde_json::from_value(value)
+            .map_err(|error| format!("failed to parse {}: {error}", path.display()))
+    } else {
+        report_from_summary_json(&value, path.display().to_string())
+    }
+}
+
+pub(crate) fn load_default_report() -> Result<LocalReadinessReport, String> {
+    load_default_report_from_paths(
+        Path::new(DEFAULT_REPORT_PATH),
+        Path::new(DEFAULT_SUMMARY_PATH),
+    )
+}
+
+fn load_default_report_from_paths(
+    report_path: &Path,
+    summary_path: &Path,
+) -> Result<LocalReadinessReport, String> {
+    if report_path.exists() {
+        let report = load_report_or_summary(report_path)?;
+        if !report.outcomes.is_empty() {
+            return Ok(report);
+        }
+    }
+    if summary_path.exists() {
+        let report = report_from_summary_path(summary_path)?;
+        if !report.outcomes.is_empty() {
+            return Ok(report);
+        }
+    }
+    seed_report()
+}
+
+pub(crate) fn filter_report_by_provider(
+    mut report: LocalReadinessReport,
+    provider: Option<&str>,
+) -> LocalReadinessReport {
+    let Some(provider) = provider.map(str::trim).filter(|value| !value.is_empty()) else {
+        return report;
+    };
+    report
+        .outcomes
+        .retain(|outcome| outcome.provider == provider);
+    report
+        .recommendations
+        .retain(|recommendation| recommendation.provider == provider);
+    for (idx, recommendation) in report.recommendations.iter_mut().enumerate() {
+        recommendation.rank = idx + 1;
+    }
+    report
+}
+
+pub(crate) fn recommended_models_for_provider(
+    provider: &str,
+    available_models: &[String],
+) -> Vec<String> {
+    let report = load_default_report().unwrap_or_else(|_| seed_report_unchecked());
+    ordered_models_from_report(&report, provider, available_models)
+}
+
+pub(crate) fn selector_for_provider_model(
+    provider: &str,
+    model: &str,
+    tool_format: Option<&str>,
+) -> String {
+    let mut matches = harn_vm::llm_config::alias_entries()
+        .into_iter()
+        .filter(|(_, alias)| alias.provider == provider && alias.id == model)
+        .collect::<Vec<_>>();
+    matches.sort_by(|(name_a, alias_a), (name_b, alias_b)| {
+        let rank_a = alias_match_rank(name_a, alias_a.tool_format.as_deref(), tool_format);
+        let rank_b = alias_match_rank(name_b, alias_b.tool_format.as_deref(), tool_format);
+        rank_a.cmp(&rank_b).then_with(|| name_a.cmp(name_b))
+    });
+    matches
+        .into_iter()
+        .next()
+        .map(|(name, _)| name)
+        .unwrap_or_else(|| {
+            if provider == "ollama" {
+                format!("ollama:{model}")
+            } else {
+                format!("{provider}:{model}")
+            }
+        })
+}
+
+fn ordered_models_from_report(
+    report: &LocalReadinessReport,
+    provider: &str,
+    available_models: &[String],
+) -> Vec<String> {
+    let mut ordered = Vec::new();
+    for recommendation in report
+        .recommendations
+        .iter()
+        .filter(|recommendation| recommendation.provider == provider)
+    {
+        if available_models
+            .iter()
+            .any(|model| model == &recommendation.model)
+            && !ordered.iter().any(|model| model == &recommendation.model)
+        {
+            ordered.push(recommendation.model.clone());
+        }
+    }
+    for model in available_models {
+        if !ordered.iter().any(|existing| existing == model) {
+            ordered.push(model.clone());
+        }
+    }
+    ordered
+}
+
+fn alias_match_rank(
+    name: &str,
+    alias_tool_format: Option<&str>,
+    desired: Option<&str>,
+) -> (u8, u8, usize) {
+    let format_rank = match (alias_tool_format, desired) {
+        (Some(actual), Some(desired)) if actual == desired => 0,
+        (None, None) => 1,
+        (None, Some(_)) => 2,
+        (Some("text"), None) => 2,
+        (Some("native"), None) => 3,
+        _ => 4,
+    };
+    let name_rank = if name.contains("native") { 1 } else { 0 };
+    (format_rank, name_rank, name.len())
+}
+
+fn seed_report() -> Result<LocalReadinessReport, String> {
+    let seed: SeedReadiness = toml::from_str(SEED_READINESS_TOML)
+        .map_err(|error| format!("failed to parse bundled local readiness data: {error}"))?;
+    let outcomes = seed
+        .outcomes
+        .into_iter()
+        .map(|outcome| LocalModelOutcome {
+            provider: outcome.provider,
+            model: outcome.model,
+            selector: outcome.selector,
+            tool_format: outcome.tool_format,
+            class: outcome.class,
+            status: outcome.status,
+            passed: outcome.class == LocalOutcomeClass::Passed,
+            score: outcome.score,
+            evidence: outcome.evidence,
+            run_id: None,
+            cleanup_action: None,
+            cleanup_detail: None,
+        })
+        .collect();
+    Ok(report_from_outcomes(
+        "bundled_seed".to_string(),
+        Some("python-add".to_string()),
+        None,
+        outcomes,
+    ))
+}
+
+fn seed_report_unchecked() -> LocalReadinessReport {
+    seed_report().expect("bundled local readiness data must parse")
+}
+
+fn read_json(path: &Path) -> Result<JsonValue, String> {
+    let raw = fs::read_to_string(path)
+        .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
+    serde_json::from_str(&raw)
+        .map_err(|error| format!("failed to parse {}: {error}", path.display()))
+}
+
+fn outcome_from_run(run: &JsonValue) -> Option<LocalModelOutcome> {
+    let selector = run.get("selector")?;
+    let provider = selector.get("provider")?.as_str()?.to_string();
+    if !is_local_provider(&provider) {
+        return None;
+    }
+    let model = selector.get("model")?.as_str()?.to_string();
+    let tool_format = run
+        .get("tool_format")
+        .and_then(JsonValue::as_str)
+        .unwrap_or("unknown")
+        .to_string();
+    let status = run
+        .get("status")
+        .and_then(JsonValue::as_str)
+        .unwrap_or("unknown")
+        .to_string();
+    let passed = run
+        .get("passed")
+        .and_then(JsonValue::as_bool)
+        .unwrap_or(false);
+    let class = classify_run(run, &provider, &model, &tool_format, passed);
+    let cleanup = run.get("local_cleanup");
+    Some(LocalModelOutcome {
+        selector: selector_for_provider_model(&provider, &model, Some(&tool_format)),
+        provider,
+        model,
+        tool_format,
+        class,
+        status,
+        passed,
+        score: score_for_class(class, run),
+        evidence: evidence_for_run(run, class),
+        run_id: run
+            .get("run_id")
+            .and_then(JsonValue::as_str)
+            .map(str::to_string),
+        cleanup_action: cleanup
+            .and_then(|value| value.get("action"))
+            .and_then(JsonValue::as_str)
+            .map(str::to_string),
+        cleanup_detail: cleanup
+            .and_then(|value| value.get("detail"))
+            .and_then(JsonValue::as_str)
+            .map(str::to_string),
+    })
+}
+
+fn classify_run(
+    run: &JsonValue,
+    provider: &str,
+    model: &str,
+    tool_format: &str,
+    passed: bool,
+) -> LocalOutcomeClass {
+    if passed {
+        return LocalOutcomeClass::Passed;
+    }
+    if run
+        .get("skipped")
+        .and_then(JsonValue::as_bool)
+        .unwrap_or(false)
+    {
+        return LocalOutcomeClass::Skipped;
+    }
+    if capability_unsupported(provider, model, tool_format) {
+        return LocalOutcomeClass::UnsupportedCapabilityFailure;
+    }
+    let haystack = failure_text(run);
+    if looks_like_transport_failure(&haystack) {
+        return LocalOutcomeClass::ProviderTransportFailure;
+    }
+    LocalOutcomeClass::BehavioralFailure
+}
+
+fn capability_unsupported(provider: &str, model: &str, tool_format: &str) -> bool {
+    let caps = capabilities::lookup(provider, model);
+    match tool_format {
+        "native" => !caps.native_tools,
+        "text" => !caps.text_tool_wire_format_supported,
+        _ => false,
+    }
+}
+
+fn failure_text(run: &JsonValue) -> String {
+    [
+        run.get("status").and_then(JsonValue::as_str),
+        run.get("error").and_then(JsonValue::as_str),
+        run.get("stderr_excerpt").and_then(JsonValue::as_str),
+        run.get("skipped_reason").and_then(JsonValue::as_str),
+    ]
+    .into_iter()
+    .flatten()
+    .collect::<Vec<_>>()
+    .join("\n")
+    .to_ascii_lowercase()
+}
+
+fn looks_like_transport_failure(text: &str) -> bool {
+    [
+        "transport",
+        "http 5",
+        "status 5",
+        "500",
+        "502",
+        "503",
+        "504",
+        "eof",
+        "connection reset",
+        "connection refused",
+        "unreachable",
+        "timed out",
+        "timeout",
+        "broken pipe",
+    ]
+    .iter()
+    .any(|needle| text.contains(needle))
+}
+
+fn score_for_class(class: LocalOutcomeClass, run: &JsonValue) -> i64 {
+    match class {
+        LocalOutcomeClass::Passed => {
+            let iterations = run
+                .get("iterations")
+                .and_then(JsonValue::as_i64)
+                .unwrap_or(0)
+                .max(0);
+            100_i64.saturating_sub(iterations)
+        }
+        LocalOutcomeClass::ProviderTransportFailure => 35,
+        LocalOutcomeClass::UnsupportedCapabilityFailure => 10,
+        LocalOutcomeClass::BehavioralFailure => 20,
+        LocalOutcomeClass::Skipped => 0,
+    }
+}
+
+fn evidence_for_run(run: &JsonValue, class: LocalOutcomeClass) -> String {
+    let run_id = run
+        .get("run_id")
+        .and_then(JsonValue::as_str)
+        .unwrap_or("unknown-run");
+    let status = run
+        .get("status")
+        .and_then(JsonValue::as_str)
+        .unwrap_or("unknown");
+    let tool_format = run
+        .get("tool_format")
+        .and_then(JsonValue::as_str)
+        .unwrap_or("unknown");
+    let detail = run
+        .get("error")
+        .and_then(JsonValue::as_str)
+        .or_else(|| run.get("skipped_reason").and_then(JsonValue::as_str))
+        .or_else(|| run.get("stderr_excerpt").and_then(JsonValue::as_str))
+        .map(compact_detail);
+    match detail {
+        Some(detail) => format!(
+            "{run_id} {tool_format}: {status} ({}); {detail}",
+            class_key(class)
+        ),
+        None => format!("{run_id} {tool_format}: {status} ({})", class_key(class)),
+    }
+}
+
+fn compact_detail(value: &str) -> String {
+    const MAX: usize = 240;
+    let one_line = value.split_whitespace().collect::<Vec<_>>().join(" ");
+    if one_line.len() <= MAX {
+        return one_line;
+    }
+    let mut out = one_line.chars().take(MAX).collect::<String>();
+    out.push_str("...");
+    out
+}
+
+fn report_from_outcomes(
+    source: String,
+    case_id: Option<String>,
+    output_dir: Option<String>,
+    outcomes: Vec<LocalModelOutcome>,
+) -> LocalReadinessReport {
+    let recommendations = build_recommendations(&outcomes);
+    LocalReadinessReport {
+        schema_version: 1,
+        source,
+        case_id,
+        output_dir,
+        recommendations,
+        outcomes,
+    }
+}
+
+fn build_recommendations(outcomes: &[LocalModelOutcome]) -> Vec<LocalModelRecommendation> {
+    let mut grouped: BTreeMap<(String, String), Vec<&LocalModelOutcome>> = BTreeMap::new();
+    for outcome in outcomes {
+        grouped
+            .entry((outcome.provider.clone(), outcome.model.clone()))
+            .or_default()
+            .push(outcome);
+    }
+
+    let mut recommendations = grouped
+        .into_iter()
+        .map(|((provider, model), group)| recommendation_for_group(provider, model, &group))
+        .collect::<Vec<_>>();
+    recommendations.sort_by(|a, b| {
+        recommendation_status_rank(&a.status)
+            .cmp(&recommendation_status_rank(&b.status))
+            .then_with(|| b.score.cmp(&a.score))
+            .then_with(|| a.provider.cmp(&b.provider))
+            .then_with(|| a.model.cmp(&b.model))
+    });
+    for (idx, recommendation) in recommendations.iter_mut().enumerate() {
+        recommendation.rank = idx + 1;
+    }
+    recommendations
+}
+
+fn recommendation_for_group(
+    provider: String,
+    model: String,
+    outcomes: &[&LocalModelOutcome],
+) -> LocalModelRecommendation {
+    let best = outcomes
+        .iter()
+        .min_by(|a, b| {
+            a.class
+                .rank()
+                .cmp(&b.class.rank())
+                .then_with(|| b.score.cmp(&a.score))
+        })
+        .expect("non-empty group");
+    let status = if outcomes
+        .iter()
+        .any(|outcome| outcome.class == LocalOutcomeClass::Passed)
+    {
+        "recommended"
+    } else if outcomes
+        .iter()
+        .any(|outcome| outcome.class == LocalOutcomeClass::ProviderTransportFailure)
+    {
+        "provider_blocked"
+    } else if outcomes
+        .iter()
+        .all(|outcome| outcome.class == LocalOutcomeClass::Skipped)
+    {
+        "unranked"
+    } else {
+        "not_recommended"
+    };
+    let mut outcome_classes = BTreeMap::new();
+    for outcome in outcomes {
+        *outcome_classes
+            .entry(class_key(outcome.class).to_string())
+            .or_insert(0) += 1;
+    }
+    let caveats = outcomes
+        .iter()
+        .filter(|outcome| outcome.class != LocalOutcomeClass::Passed)
+        .map(|outcome| {
+            format!(
+                "{} {}: {}",
+                outcome.tool_format,
+                class_key(outcome.class),
+                outcome.evidence
+            )
+        })
+        .collect::<Vec<_>>();
+    LocalModelRecommendation {
+        rank: 0,
+        provider,
+        model,
+        selector: selector_for_provider_model(&best.provider, &best.model, Some(&best.tool_format)),
+        status: status.to_string(),
+        recommended_tool_format: (best.class == LocalOutcomeClass::Passed)
+            .then(|| best.tool_format.clone()),
+        score: outcomes
+            .iter()
+            .map(|outcome| outcome.score)
+            .max()
+            .unwrap_or(0),
+        evidence: outcomes
+            .iter()
+            .map(|outcome| outcome.evidence.clone())
+            .collect(),
+        caveats,
+        outcome_classes,
+    }
+}
+
+fn recommendation_status_rank(status: &str) -> u8 {
+    match status {
+        "recommended" => 0,
+        "provider_blocked" => 1,
+        "not_recommended" => 2,
+        "unranked" => 3,
+        _ => 4,
+    }
+}
+
+fn class_key(class: LocalOutcomeClass) -> &'static str {
+    match class {
+        LocalOutcomeClass::Passed => "passed",
+        LocalOutcomeClass::ProviderTransportFailure => "provider_transport_failure",
+        LocalOutcomeClass::BehavioralFailure => "behavioral_failure",
+        LocalOutcomeClass::UnsupportedCapabilityFailure => "unsupported_capability_failure",
+        LocalOutcomeClass::Skipped => "skipped",
+    }
+}
+
+fn is_local_provider(provider: &str) -> bool {
+    matches!(
+        provider,
+        "ollama" | "llamacpp" | "mlx" | "local" | "vllm" | "tgi"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn seed_recommends_passing_model_before_provider_blocked_model() {
+        let report = seed_report().expect("seed parses");
+        assert_eq!(report.recommendations[0].model, "devstral-small-2:24b");
+        assert_eq!(report.recommendations[0].status, "recommended");
+        assert_eq!(
+            report.recommendations[1].outcome_classes["provider_transport_failure"],
+            1
+        );
+    }
+
+    #[test]
+    fn summary_classifies_transport_and_behavioral_failures_separately() {
+        let summary = serde_json::json!({
+            "case_id": "python-add",
+            "output_dir": "out",
+            "runs": [
+                {
+                    "run_id": "ollama_devstral__text",
+                    "selector": {"provider": "ollama", "model": "devstral-small-2:24b"},
+                    "tool_format": "text",
+                    "status": "passed",
+                    "passed": true,
+                    "skipped": false,
+                    "iterations": 2
+                },
+                {
+                    "run_id": "ollama_qwen__text",
+                    "selector": {"provider": "ollama", "model": "qwen3.6:35b-a3b-coding-nvfp4"},
+                    "tool_format": "text",
+                    "status": "infra_error",
+                    "passed": false,
+                    "skipped": false,
+                    "stderr_excerpt": "Ollama returned HTTP 500: unexpected EOF"
+                },
+                {
+                    "run_id": "ollama_gemma__text",
+                    "selector": {"provider": "ollama", "model": "gemma4:26b"},
+                    "tool_format": "text",
+                    "status": "failed",
+                    "passed": false,
+                    "skipped": false,
+                    "error": "verification failed"
+                }
+            ]
+        });
+        let report = report_from_summary_json(&summary, "test").expect("report");
+        assert_eq!(report.outcomes[0].class, LocalOutcomeClass::Passed);
+        assert_eq!(
+            report.outcomes[1].class,
+            LocalOutcomeClass::ProviderTransportFailure
+        );
+        assert_eq!(
+            report.outcomes[2].class,
+            LocalOutcomeClass::BehavioralFailure
+        );
+    }
+
+    #[test]
+    fn orders_available_models_by_report_then_preserves_unknowns() {
+        let report = seed_report().expect("seed parses");
+        let available = vec![
+            "gemma4:26b".to_string(),
+            "devstral-small-2:24b".to_string(),
+            "custom:latest".to_string(),
+        ];
+        assert_eq!(
+            ordered_models_from_report(&report, "ollama", &available),
+            vec![
+                "devstral-small-2:24b".to_string(),
+                "gemma4:26b".to_string(),
+                "custom:latest".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn default_loader_ignores_empty_latest_report() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let report_path = tmp.path().join("local_readiness.json");
+        let summary_path = tmp.path().join("summary.json");
+        std::fs::write(
+            &report_path,
+            r#"{
+              "schema_version": 1,
+              "source": "empty",
+              "recommendations": [],
+              "outcomes": []
+            }"#,
+        )
+        .expect("write report");
+        std::fs::write(
+            &summary_path,
+            r#"{
+              "case_id": "python-add",
+              "runs": [{
+                "run_id": "ollama_devstral__text",
+                "selector": {"provider": "ollama", "model": "devstral-small-2:24b"},
+                "tool_format": "text",
+                "status": "passed",
+                "passed": true,
+                "skipped": false
+              }]
+            }"#,
+        )
+        .expect("write summary");
+
+        let loaded =
+            load_default_report_from_paths(&report_path, &summary_path).expect("load report");
+        assert_eq!(loaded.source, summary_path.display().to_string());
+        assert_eq!(loaded.outcomes.len(), 1);
+    }
+}

--- a/crates/harn-cli/src/commands/mod.rs
+++ b/crates/harn-cli/src/commands/mod.rs
@@ -26,6 +26,7 @@ pub(crate) mod hardware;
 pub(crate) mod init;
 pub(crate) mod json_schemas;
 pub(crate) mod local;
+pub(crate) mod local_readiness;
 pub(crate) mod mcp;
 pub(crate) mod merge_captain;
 pub(crate) mod merge_captain_mock;

--- a/crates/harn-cli/src/commands/providers.rs
+++ b/crates/harn-cli/src/commands/providers.rs
@@ -5,7 +5,8 @@ use serde_json::json;
 use tokio::process::Command;
 
 use crate::cli::{
-    ProvidersExportArgs, ProvidersMatrixArgs, ProvidersRefreshArgs, ProvidersValidateArgs,
+    ProvidersExportArgs, ProvidersMatrixArgs, ProvidersRecommendArgs, ProvidersRefreshArgs,
+    ProvidersValidateArgs,
 };
 
 pub(crate) async fn run_refresh(args: &ProvidersRefreshArgs) -> Result<(), String> {
@@ -165,6 +166,53 @@ pub(crate) fn run_matrix(args: &ProvidersMatrixArgs) -> Result<(), String> {
     fs::write(&args.output, generated)
         .map_err(|error| format!("failed to write {}: {error}", args.output.display()))?;
     println!("wrote {}", args.output.display());
+    Ok(())
+}
+
+pub(crate) fn run_recommend(args: &ProvidersRecommendArgs) -> Result<(), String> {
+    let report = if let Some(summary) = args.summary.as_deref() {
+        crate::commands::local_readiness::report_from_summary_path(summary)?
+    } else if let Some(input) = args.input.as_deref() {
+        crate::commands::local_readiness::load_report_or_summary(input)?
+    } else {
+        crate::commands::local_readiness::load_default_report()?
+    };
+    let report = crate::commands::local_readiness::filter_report_by_provider(
+        report,
+        args.provider.as_deref(),
+    );
+    if args.json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&report)
+                .map_err(|error| format!("failed to render recommendation JSON: {error}"))?
+        );
+        return Ok(());
+    }
+    println!("local provider recommendations");
+    println!("source: {}", report.source);
+    if report.recommendations.is_empty() {
+        println!("(no local model outcomes found)");
+        return Ok(());
+    }
+    for recommendation in &report.recommendations {
+        let tool = recommendation
+            .recommended_tool_format
+            .as_deref()
+            .unwrap_or("unproven");
+        println!(
+            "{}. {} {} ({}, selector {}, tools {})",
+            recommendation.rank,
+            recommendation.provider,
+            recommendation.model,
+            recommendation.status,
+            recommendation.selector,
+            tool
+        );
+        for caveat in &recommendation.caveats {
+            println!("   caveat: {caveat}");
+        }
+    }
     Ok(())
 }
 

--- a/crates/harn-cli/src/commands/quickstart.rs
+++ b/crates/harn-cli/src/commands/quickstart.rs
@@ -6,6 +6,7 @@ use std::process::Command;
 use std::time::Duration;
 
 use crate::cli::QuickstartArgs;
+use crate::commands::local_readiness;
 
 const QUICKSTART_ALIAS: &str = "quickstart";
 const PREFERRED_PROVIDERS: &[&str] = &[
@@ -18,13 +19,6 @@ const PREFERRED_PROVIDERS: &[&str] = &[
     "huggingface",
     "local",
     "mlx",
-];
-const PREFERRED_OLLAMA_MODELS: &[(&str, &str)] = &[
-    ("devstral-small-2", "devstral-small-2:24b"),
-    ("qwen3.6-coding", "qwen3.6:35b-a3b-coding-nvfp4"),
-    ("ollama-gemma4", "gemma4:26b"),
-    ("qwen3.6-35b-coding", "qwen3.6:35b-a3b-coding-nvfp4"),
-    ("qwen3.6-coding-nvfp4", "qwen3.6:35b-a3b-coding-nvfp4"),
 ];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -186,7 +180,7 @@ fn default_model_for_choice(provider: &str, model: Option<&str>, ollama: &Ollama
         return model.trim().to_string();
     }
     if provider == "ollama" {
-        if let Some(model) = preferred_ollama_selector(&ollama.available_models) {
+        if let Some(model) = recommended_ollama_selector(&ollama.available_models) {
             return model;
         }
         if let Some(model) = ollama.available_models.first() {
@@ -196,37 +190,18 @@ fn default_model_for_choice(provider: &str, model: Option<&str>, ollama: &Ollama
     harn_vm::llm_config::default_model_for_provider(provider)
 }
 
-fn preferred_ollama_selector(available_models: &[String]) -> Option<String> {
-    for (alias, id) in PREFERRED_OLLAMA_MODELS {
-        if available_models.iter().any(|model| model == id) {
-            return Some((*alias).to_string());
-        }
-    }
-    None
+fn recommended_ollama_selector(available_models: &[String]) -> Option<String> {
+    ordered_ollama_models(available_models)
+        .first()
+        .map(|model| ollama_selector_for_model(model))
 }
 
 fn ollama_selector_for_model(model: &str) -> String {
-    PREFERRED_OLLAMA_MODELS
-        .iter()
-        .find_map(|(alias, id)| (*id == model).then(|| (*alias).to_string()))
-        .unwrap_or_else(|| model.to_string())
+    local_readiness::selector_for_provider_model("ollama", model, None)
 }
 
 fn ordered_ollama_models(available_models: &[String]) -> Vec<String> {
-    let mut ordered = Vec::new();
-    for (_, id) in PREFERRED_OLLAMA_MODELS {
-        if available_models.iter().any(|model| model == id)
-            && !ordered.iter().any(|model| model == id)
-        {
-            ordered.push((*id).to_string());
-        }
-    }
-    for model in available_models {
-        if !ordered.iter().any(|existing| existing == model) {
-            ordered.push(model.clone());
-        }
-    }
-    ordered
+    local_readiness::recommended_models_for_provider("ollama", available_models)
 }
 
 fn choose_non_interactive(
@@ -1005,21 +980,14 @@ mod tests {
     }
 
     #[test]
-    fn preferred_ollama_selector_uses_current_local_coding_alias() {
-        let available = vec![
-            "llama3.2".to_string(),
-            "devstral-small-2:24b".to_string(),
-            "qwen3.6:35b-a3b-coding-nvfp4".to_string(),
-        ];
+    fn ollama_selector_for_model_uses_alias_catalog() {
         assert_eq!(
-            preferred_ollama_selector(&available).as_deref(),
-            Some("devstral-small-2")
+            ollama_selector_for_model("devstral-small-2:24b"),
+            "devstral-small-2"
         );
         assert_eq!(
-            ordered_ollama_models(&available)
-                .first()
-                .map(String::as_str),
-            Some("devstral-small-2:24b")
+            ollama_selector_for_model("qwen3.6:35b-a3b-coding-nvfp4"),
+            "qwen3.6-coding"
         );
     }
 }

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -929,6 +929,11 @@ async fn async_main() {
                     command_error(&error);
                 }
             }
+            ProvidersCommand::Recommend(recommend) => {
+                if let Err(error) = commands::providers::run_recommend(&recommend) {
+                    command_error(&error);
+                }
+            }
         },
         Command::Try(args) => commands::try_cmd::run(args).await,
         Command::Quickstart(args) => {

--- a/crates/harn-cli/tests/eval_coding_agent_cli.rs
+++ b/crates/harn-cli/tests/eval_coding_agent_cli.rs
@@ -68,6 +68,16 @@ fn mock_matrix_writes_artifacts_for_native_and_text_tools() {
 
     let per_run = fs::read_to_string(output.join("per_run.jsonl")).expect("per-run JSONL exists");
     assert_eq!(per_run.lines().count(), 2);
+    let readiness_raw =
+        fs::read_to_string(output.join("local_readiness.json")).expect("readiness exists");
+    let readiness: serde_json::Value =
+        serde_json::from_str(&readiness_raw).expect("readiness parses as JSON");
+    assert_eq!(readiness["schema_version"], 1);
+    assert_eq!(
+        readiness["outcomes"].as_array().map(Vec::len),
+        Some(0),
+        "mock-only runs should not produce local model readiness outcomes",
+    );
     assert!(output.join("mock_mock__native/summary.json").exists());
     assert!(output
         .join("mock_mock__native/transcript_events.jsonl")

--- a/docs/src/llm/coding-agent-benchmark.md
+++ b/docs/src/llm/coding-agent-benchmark.md
@@ -16,6 +16,9 @@ Artifacts are written to `.harn-runs/coding-agent-bench/latest/` by default:
 
 - `summary.json`: aggregate pass/fail, token, cost, and native/text comparison data.
 - `per_run.jsonl`: one normalized row per provider/tool-format run.
+- `local_readiness.json`: local-provider recommendation evidence derived from
+  local runs, with provider transport failures, unsupported capability
+  failures, and behavioral task failures separated.
 - `<run_id>/summary.json`: the Harn harness result for one run.
 - `<run_id>/transcript_events.jsonl`: canonical transcript events from `transcript_events(...)`.
 - `summary.md`: a readable table for sharing results.
@@ -54,6 +57,18 @@ Pass `--keep-local-after-run` to leave newly-loaded local models running.
 Non-Ollama local servers are not killed unless Harn already owns a managed PID
 through the `harn local` lifecycle commands.
 
+Turn the latest local benchmark output into a machine-readable recommendation
+surface with:
+
+```sh
+harn providers recommend --json
+```
+
+`harn providers recommend --input <path>` accepts either `local_readiness.json`
+or a raw coding-agent `summary.json`. Without an input path, it reads the latest
+benchmark report and falls back to bundled seed evidence. `harn quickstart` uses
+the same recommendation order when choosing among installed local Ollama models.
+
 ## Reading Results
 
 Use the native/text comparison table to spot provider abstraction leaks:
@@ -63,6 +78,9 @@ Use the native/text comparison table to spot provider abstraction leaks:
 - rejected tool calls followed by eventual success suggest Harn may need better
   transcript compaction, repair, or history-rewrite ergonomics for recoverable
   tool-call noise.
+- provider transport failures such as HTTP 5xx, EOF, or connection resets are
+  reported separately from model behavioral failures, so a runtime path does not
+  get blamed on the model.
 - unknown pricing on live models means the provider catalog cannot yet support
   credible cost recommendations.
 

--- a/docs/src/llm/providers.md
+++ b/docs/src/llm/providers.md
@@ -12,6 +12,11 @@ space, and GPU availability, then write starter `providers.toml`, `harn.toml`,
 and `.env` files.
 
 Run `harn models recommend` to choose a starter model for the current hardware.
+Run `harn providers recommend --json` to inspect the coding-agent readiness
+evidence that orders local provider/model presets for quickstart. The report
+reads the latest `harn eval coding-agent --include-local` output when present
+and falls back to bundled seed evidence, while keeping runtime transport
+failures separate from model task failures.
 Run `harn models install qwen3.6-coding`, `harn models install devstral-small-2`,
 or `harn models install ollama-gemma4` to resolve Harn aliases and pull the
 matching Ollama model. For non-Ollama local runtimes, `harn models install


### PR DESCRIPTION
## Summary
- add a shared local coding-agent readiness report with seeded fallback evidence and distinct provider transport, unsupported capability, behavioral, skipped, and passed classes
- emit local_readiness.json from harn eval coding-agent and add harn providers recommend for JSON/human recommendation output
- make quickstart consume the same readiness ordering for installed Ollama models and document the workflow

Closes #2241.

## Validation
- cargo check -p harn-cli
- cargo test -p harn-cli local_readiness --lib
- cargo test -p harn-cli quickstart --lib
- cargo test -p harn-cli providers_recommend --lib
- cargo test -p harn-cli --test eval_coding_agent_cli
- cargo run --quiet --bin harn -- providers recommend --json
- make lint-test-patterns
- pre-commit hook: cargo fmt, clippy for harn-cli, markdownlint
- pre-push hook: targeted local checks, markdownlint, changelog check