### PR TITLE
Make tool-mode parity data-driven

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ condensed series summaries instead of full per-patch history.
   Local runs now also emit `local_readiness.json`, and
   `harn providers recommend` exposes the same readiness evidence and local
   preset ordering that `harn quickstart` consumes.
+- **Native/text tool-mode parity reporting (#2242).** `harn eval coding-agent`
+  summaries now compare native and text runs by fixture, verifier result, tool
+  sequence, rejected-call recovery, and linked transcript evidence so provider
+  divergences are visible in the benchmark report.
 
 - **Provider matrix lifecycle command.** Added `harn providers matrix` so the
   capability matrix docs can be regenerated and checked through the same
@@ -69,6 +73,11 @@ condensed series summaries instead of full per-patch history.
   expansions. Cyclic local references such as `$ref: "#"` now fail
   deterministically with a Harn-level schema error instead of relying on Rust
   stack depth.
+- **Provider capability data owns tool-mode defaults (#2242).** Capability rows,
+  `provider_capabilities(...)`, the generated provider matrix, and provider
+  catalog bindings now expose `preferred_tool_format`, `tool_mode_parity`, and
+  optional parity notes. Presets use that data to route known unreliable native
+  tool modes to text tools without provider-specific branches.
 - **Bridge inject mode `wait_for_completion` renamed to `audit_only`
   (#2212).** The previous name was a footgun: reminders queued with this
   mode drain at `loop_exit` and land in the transcript audit, but the

--- a/conformance/tests/integration/provider_capabilities_basic.harn
+++ b/conformance/tests/integration/provider_capabilities_basic.harn
@@ -90,6 +90,25 @@ pipeline test(task) {
   assert(routed.defer_loading, "openrouter inherits openai defer_loading")
   assert(routed.tool_search[0] == "hosted", "openrouter inherits hosted/client variants")
   assert(routed.reasoning_none_supported, "openrouter inherits gpt-5.4 reasoning none support")
+  let deepseek32 = provider_capabilities("openrouter", "deepseek/deepseek-v3.2")
+  assert(deepseek32.native_tools, "OpenRouter DeepSeek V3.2 exposes native tools")
+  assert(deepseek32.text_tool_wire_format_supported, "OpenRouter DeepSeek V3.2 supports text tools")
+  assert(
+    deepseek32.preferred_tool_format == "text",
+    "OpenRouter DeepSeek V3.2 defaults to text tools",
+  )
+  assert(
+    deepseek32.tool_mode_parity == "native_unreliable",
+    "OpenRouter DeepSeek V3.2 records native/text non-interchangeability",
+  )
+  let qwen_coder = provider_capabilities("openrouter", "qwen/qwen3-coder-flash")
+  assert(qwen_coder.native_tools, "OpenRouter Qwen Coder advertises native tools")
+  assert(qwen_coder.text_tool_wire_format_supported, "OpenRouter Qwen Coder supports text tools")
+  assert(qwen_coder.preferred_tool_format == "text", "OpenRouter Qwen Coder defaults to text tools")
+  assert(
+    qwen_coder.tool_mode_parity == "native_unreliable",
+    "OpenRouter Qwen Coder records native/text non-interchangeability",
+  )
   // Sibling families: together, groq, deepseek, fireworks, huggingface, local.
   for family in ["together", "groq", "deepseek", "fireworks", "huggingface", "local"] {
     let caps = provider_capabilities(family, "gpt-5.4")

--- a/crates/harn-cli/src/commands/check/provider_matrix.rs
+++ b/crates/harn-cli/src/commands/check/provider_matrix.rs
@@ -20,6 +20,10 @@ const FEATURES: &[&str] = &[
     "assistant_prefill",
     "role_developer",
     "xml_tools",
+    "native_tools",
+    "text_tools",
+    "native_tool_default",
+    "text_tool_default",
     "native_json",
     "delimited_output",
     "xml_tagged_output",
@@ -47,14 +51,14 @@ pub(crate) fn generate_markdown(rows: &[ProviderCapabilityMatrixRow]) -> String 
     );
     out.push_str("Regenerate with `make gen-provider-matrix` and verify with `make check-provider-matrix`.\n\n");
     out.push_str(
-        "| Provider | Model pattern | Version min | Thinking | Vision | Audio | PDF | Streaming | Files API | JSON schema | Prompt | Output mode | Prefill | Role | Tool prompt | Thinking blocks | Tools | Cache |\n",
+        "| Provider | Model pattern | Version min | Thinking | Vision | Audio | PDF | Streaming | Files API | JSON schema | Prompt | Output mode | Prefill | Role | Tool prompt | Thinking blocks | Default tools | Native tools | Text tools | Parity | Tools | Cache |\n",
     );
     out.push_str(
-        "|---|---|---|---|---:|---:|---:|---:|---:|---|---|---|---:|---|---|---|---:|---:|\n",
+        "|---|---|---|---|---:|---:|---:|---:|---:|---|---|---|---:|---|---|---|---|---:|---:|---|---:|---:|\n",
     );
     for row in rows {
         out.push_str(&format!(
-            "| `{}` | `{}` | {} | {} | {} | {} | {} | {} | {} | {} | {} | `{}` | {} | `{}` | `{}` | `{}` | {} | {} |\n",
+            "| `{}` | `{}` | {} | {} | {} | {} | {} | {} | {} | {} | {} | `{}` | {} | `{}` | `{}` | `{}` | `{}` | {} | {} | `{}` | {} | {} |\n",
             row.provider,
             row.model,
             markdown_cell(&version_min_cell(row)),
@@ -71,6 +75,10 @@ pub(crate) fn generate_markdown(rows: &[ProviderCapabilityMatrixRow]) -> String 
             instruction_role_cell(row),
             tool_prompt_cell(row),
             row.thinking_block_style,
+            row.preferred_tool_format,
+            yes_no(row.native_tools),
+            yes_no(row.text_tools),
+            row.tool_mode_parity,
             yes_no(row.tools),
             yes_no(row.cache),
         ));
@@ -114,6 +122,10 @@ fn row_supports_feature(row: &ProviderCapabilityMatrixRow, feature: &str) -> boo
         "assistant_prefill" => row.supports_assistant_prefill,
         "role_developer" => row.prefers_role_developer,
         "xml_tools" => row.prefers_xml_tools,
+        "native_tools" => row.native_tools,
+        "text_tools" => row.text_tools,
+        "native_tool_default" => row.preferred_tool_format == "native",
+        "text_tool_default" => row.preferred_tool_format == "text",
         "native_json" => row.structured_output_mode == "native_json",
         "delimited_output" => row.structured_output_mode == "delimited",
         "xml_tagged_output" => row.structured_output_mode == "xml_tagged",
@@ -124,7 +136,7 @@ fn row_supports_feature(row: &ProviderCapabilityMatrixRow, feature: &str) -> boo
 }
 
 fn print_text(rows: &[ProviderCapabilityMatrixRow]) {
-    let table_rows: Vec<[String; 17]> = rows
+    let table_rows: Vec<[String; 21]> = rows
         .iter()
         .map(|row| {
             [
@@ -143,6 +155,10 @@ fn print_text(rows: &[ProviderCapabilityMatrixRow]) {
                 instruction_role_cell(row),
                 tool_prompt_cell(row),
                 row.thinking_block_style.clone(),
+                row.preferred_tool_format.clone(),
+                yes_no(row.native_tools).to_string(),
+                yes_no(row.text_tools).to_string(),
+                row.tool_mode_parity.clone(),
                 yes_no(row.tools).to_string(),
                 yes_no(row.cache).to_string(),
             ]
@@ -164,6 +180,10 @@ fn print_text(rows: &[ProviderCapabilityMatrixRow]) {
         "role".to_string(),
         "tool_prompt".to_string(),
         "thinking_blocks".to_string(),
+        "default_tools".to_string(),
+        "native_tools".to_string(),
+        "text_tools".to_string(),
+        "parity".to_string(),
         "tools".to_string(),
         "cache".to_string(),
     ];
@@ -304,7 +324,7 @@ mod tests {
         assert!(markdown.contains("Source of truth"));
         assert!(markdown.contains("harn providers matrix"));
         assert!(markdown.contains(
-            "| Provider | Model pattern | Version min | Thinking | Vision | Audio | PDF | Streaming | Files API | JSON schema | Prompt | Output mode | Prefill | Role | Tool prompt | Thinking blocks | Tools | Cache |"
+            "| Provider | Model pattern | Version min | Thinking | Vision | Audio | PDF | Streaming | Files API | JSON schema | Prompt | Output mode | Prefill | Role | Tool prompt | Thinking blocks | Default tools | Native tools | Text tools | Parity | Tools | Cache |"
         ));
     }
 }

--- a/crates/harn-cli/src/commands/eval_coding_agent.rs
+++ b/crates/harn-cli/src/commands/eval_coding_agent.rs
@@ -98,7 +98,7 @@ struct RunReport {
     run_id: String,
     fixture_id: String,
     fixture_name: String,
-    tool_sequence: String,
+    fixture_tool_sequence: String,
     selector: ModelSelector,
     tool_format: String,
     status: String,
@@ -107,6 +107,7 @@ struct RunReport {
     #[serde(skip_serializing_if = "Option::is_none")]
     skipped_reason: Option<String>,
     output_dir: String,
+    transcript_events_path: String,
     workspace_root: Option<String>,
     elapsed_ms: u64,
     duration_ms: u64,
@@ -117,6 +118,7 @@ struct RunReport {
     pricing_known: bool,
     tool_calls: usize,
     rejected_tool_calls: usize,
+    tool_sequence: Vec<String>,
     successful_tools: Vec<String>,
     transcript_event_count: usize,
     verification_success: bool,
@@ -142,12 +144,22 @@ struct LocalCleanupReport {
 struct FormatComparison {
     fixture_id: String,
     selector: ModelSelector,
+    native_run_id: Option<String>,
+    text_run_id: Option<String>,
+    native_evidence_path: Option<String>,
+    text_evidence_path: Option<String>,
     native_status: Option<String>,
     text_status: Option<String>,
     native_passed: Option<bool>,
     text_passed: Option<bool>,
+    verifier_match: Option<bool>,
+    tool_sequence_match: Option<bool>,
+    rejected_tool_call_delta_text_minus_native: Option<i64>,
     token_delta_text_minus_native: Option<i64>,
     iteration_delta_text_minus_native: Option<i64>,
+    equivalent: Option<bool>,
+    divergence_reasons: Vec<String>,
+    evidence_paths: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -198,6 +210,7 @@ struct EvalSummary {
     passed_runs: usize,
     failed_runs: usize,
     skipped_runs: usize,
+    diverged_comparisons: usize,
     total_cost_usd: f64,
     rollups: EvalRollups,
     runs: Vec<RunReport>,
@@ -397,7 +410,7 @@ async fn run_matrix_entry(
             run_id,
             fixture_id: fixture.id.to_string(),
             fixture_name: fixture.name.to_string(),
-            tool_sequence: fixture.tool_sequence.to_string(),
+            fixture_tool_sequence: fixture.tool_sequence.to_string(),
             selector,
             tool_format,
             status: "infra_error".to_string(),
@@ -405,6 +418,10 @@ async fn run_matrix_entry(
             skipped: false,
             skipped_reason: None,
             output_dir: run_dir.display().to_string(),
+            transcript_events_path: run_dir
+                .join("transcript_events.jsonl")
+                .display()
+                .to_string(),
             workspace_root: None,
             elapsed_ms,
             duration_ms: 0,
@@ -415,6 +432,7 @@ async fn run_matrix_entry(
             pricing_known: false,
             tool_calls: 0,
             rejected_tool_calls: 0,
+            tool_sequence: Vec::new(),
             successful_tools: Vec::new(),
             transcript_event_count: 0,
             verification_success: false,
@@ -476,7 +494,7 @@ fn report_from_summary(ctx: RunSummaryContext, summary: JsonValue) -> RunReport 
         run_id: ctx.run_id,
         fixture_id: ctx.fixture.id.to_string(),
         fixture_name: ctx.fixture.name.to_string(),
-        tool_sequence: ctx.fixture.tool_sequence.to_string(),
+        fixture_tool_sequence: ctx.fixture.tool_sequence.to_string(),
         selector: ctx.selector,
         tool_format: ctx.tool_format,
         status,
@@ -484,6 +502,11 @@ fn report_from_summary(ctx: RunSummaryContext, summary: JsonValue) -> RunReport 
         skipped: false,
         skipped_reason: None,
         output_dir: ctx.run_dir.display().to_string(),
+        transcript_events_path: ctx
+            .run_dir
+            .join("transcript_events.jsonl")
+            .display()
+            .to_string(),
         workspace_root: summary
             .get("workspace_root")
             .and_then(JsonValue::as_str)
@@ -511,6 +534,9 @@ fn report_from_summary(ctx: RunSummaryContext, summary: JsonValue) -> RunReport 
             .and_then(JsonValue::as_array)
             .map(Vec::len)
             .unwrap_or(0),
+        tool_sequence: tool_call_sequence(summary.pointer("/tools/calls"))
+            .or_else(|| non_empty_string_array(summary.pointer("/tools/successful")))
+            .unwrap_or_default(),
         successful_tools: string_array(summary.pointer("/tools/successful")),
         transcript_event_count: summary
             .get("transcript_event_count")
@@ -644,7 +670,7 @@ fn error_report(
         run_id,
         fixture_id: fixture.id.to_string(),
         fixture_name: fixture.name.to_string(),
-        tool_sequence: fixture.tool_sequence.to_string(),
+        fixture_tool_sequence: fixture.tool_sequence.to_string(),
         selector,
         tool_format,
         status: "infra_error".to_string(),
@@ -652,6 +678,10 @@ fn error_report(
         skipped: false,
         skipped_reason: None,
         output_dir: run_dir.display().to_string(),
+        transcript_events_path: run_dir
+            .join("transcript_events.jsonl")
+            .display()
+            .to_string(),
         workspace_root: None,
         elapsed_ms: 0,
         duration_ms: 0,
@@ -662,6 +692,7 @@ fn error_report(
         pricing_known: false,
         tool_calls: 0,
         rejected_tool_calls: 0,
+        tool_sequence: Vec::new(),
         successful_tools: Vec::new(),
         transcript_event_count: 0,
         verification_success: false,
@@ -684,7 +715,7 @@ fn skipped_report(
         run_id,
         fixture_id: fixture.id.to_string(),
         fixture_name: fixture.name.to_string(),
-        tool_sequence: fixture.tool_sequence.to_string(),
+        fixture_tool_sequence: fixture.tool_sequence.to_string(),
         selector,
         tool_format,
         status: "skipped".to_string(),
@@ -692,6 +723,10 @@ fn skipped_report(
         skipped: true,
         skipped_reason: Some(reason),
         output_dir: run_dir.display().to_string(),
+        transcript_events_path: run_dir
+            .join("transcript_events.jsonl")
+            .display()
+            .to_string(),
         workspace_root: None,
         elapsed_ms: 0,
         duration_ms: 0,
@@ -702,6 +737,7 @@ fn skipped_report(
         pricing_known: false,
         tool_calls: 0,
         rejected_tool_calls: 0,
+        tool_sequence: Vec::new(),
         successful_tools: Vec::new(),
         transcript_event_count: 0,
         verification_success: false,
@@ -760,7 +796,7 @@ fn fixture_definition(id: &str) -> Option<FixtureDefinition> {
 async fn resolve_models(args: &EvalCodingAgentArgs) -> Result<Vec<ModelSelector>, String> {
     let mut seen = BTreeSet::new();
     let mut out = Vec::new();
-    for raw in &args.models {
+    for raw in normalize_model_selector_args(&args.models) {
         let trimmed = raw.trim();
         if trimmed.is_empty() {
             continue;
@@ -778,6 +814,25 @@ async fn resolve_models(args: &EvalCodingAgentArgs) -> Result<Vec<ModelSelector>
         }
     }
     Ok(out)
+}
+
+fn normalize_model_selector_args(raw_models: &[String]) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut index = 0;
+    while index < raw_models.len() {
+        let current = raw_models[index].trim();
+        if current.starts_with("provider=") && index + 1 < raw_models.len() {
+            let next = raw_models[index + 1].trim();
+            if next.starts_with("model=") {
+                out.push(format!("{current},{next}"));
+                index += 2;
+                continue;
+            }
+        }
+        out.push(current.to_string());
+        index += 1;
+    }
+    out
 }
 
 async fn discover_local_models(args: &EvalCodingAgentArgs) -> Vec<ModelSelector> {
@@ -881,6 +936,10 @@ fn build_summary(
     let total_cost_usd = runs.iter().map(|run| run.cost_usd).sum();
     let rollups = build_rollups(&runs);
     let comparisons = compare_formats(&runs);
+    let diverged_comparisons = comparisons
+        .iter()
+        .filter(|comparison| !comparison.divergence_reasons.is_empty())
+        .count();
     let followups = suggest_followups(&runs, &comparisons);
     EvalSummary {
         schema_version: 2,
@@ -905,6 +964,7 @@ fn build_summary(
         passed_runs,
         failed_runs,
         skipped_runs,
+        diverged_comparisons,
         total_cost_usd,
         rollups,
         runs,
@@ -919,7 +979,7 @@ fn build_rollups(runs: &[RunReport]) -> EvalRollups {
         by_provider: rollup_by(runs, |run| run.selector.provider.clone()),
         by_model: rollup_by(runs, |run| run.selector.model.clone()),
         by_tool_format: rollup_by(runs, |run| run.tool_format.clone()),
-        by_tool_sequence: rollup_by(runs, |run| run.tool_sequence.clone()),
+        by_tool_sequence: rollup_by(runs, |run| run.fixture_tool_sequence.clone()),
     }
 }
 
@@ -956,7 +1016,7 @@ fn compare_formats(runs: &[RunReport]) -> Vec<FormatComparison> {
     for run in runs {
         grouped
             .entry(format!(
-                "{}__{}",
+                "{}\0{}",
                 run.fixture_id,
                 selector_label(&run.selector)
             ))
@@ -976,20 +1036,80 @@ fn compare_formats(runs: &[RunReport]) -> Vec<FormatComparison> {
         if native.is_none() && text.is_none() {
             continue;
         }
+        let pair = native.zip(text);
+        let mut divergence_reasons = Vec::new();
+        if let Some((native, text)) = pair {
+            if native.status != text.status {
+                divergence_reasons.push(format!(
+                    "status differs: native={} text={}",
+                    native.status, text.status
+                ));
+            }
+            if native.passed != text.passed {
+                divergence_reasons.push(format!(
+                    "pass result differs: native={} text={}",
+                    native.passed, text.passed
+                ));
+            }
+            if native.verification_success != text.verification_success {
+                divergence_reasons.push(format!(
+                    "verifier result differs: native={} text={}",
+                    native.verification_success, text.verification_success
+                ));
+            }
+            if native.tool_sequence != text.tool_sequence {
+                divergence_reasons.push(format!(
+                    "tool sequence differs: native=[{}] text=[{}]",
+                    native.tool_sequence.join(", "),
+                    text.tool_sequence.join(", ")
+                ));
+            }
+            if native.rejected_tool_calls != text.rejected_tool_calls {
+                divergence_reasons.push(format!(
+                    "rejected tool-call recovery differs: native={} text={}",
+                    native.rejected_tool_calls, text.rejected_tool_calls
+                ));
+            }
+        }
+        let evidence_paths = [native, text]
+            .into_iter()
+            .flatten()
+            .map(|run| run.transcript_events_path.clone())
+            .collect::<Vec<_>>();
         out.push(FormatComparison {
             fixture_id: first.fixture_id.clone(),
             selector: first.selector.clone(),
+            native_run_id: native.map(|run| run.run_id.clone()),
+            text_run_id: text.map(|run| run.run_id.clone()),
+            native_evidence_path: native.map(|run| run.transcript_events_path.clone()),
+            text_evidence_path: text.map(|run| run.transcript_events_path.clone()),
             native_status: native.map(|run| run.status.clone()),
             text_status: text.map(|run| run.status.clone()),
             native_passed: native.map(|run| run.passed),
             text_passed: text.map(|run| run.passed),
-            token_delta_text_minus_native: native.zip(text).map(|(native, text)| {
+            verifier_match: pair
+                .map(|(native, text)| native.verification_success == text.verification_success),
+            tool_sequence_match: pair
+                .map(|(native, text)| native.tool_sequence == text.tool_sequence),
+            rejected_tool_call_delta_text_minus_native: pair.map(|(native, text)| {
+                text.rejected_tool_calls as i64 - native.rejected_tool_calls as i64
+            }),
+            token_delta_text_minus_native: pair.map(|(native, text)| {
                 (text.input_tokens + text.output_tokens)
                     - (native.input_tokens + native.output_tokens)
             }),
-            iteration_delta_text_minus_native: native
-                .zip(text)
+            iteration_delta_text_minus_native: pair
                 .map(|(native, text)| text.iterations - native.iterations),
+            equivalent: pair.map(|(native, text)| {
+                native.status == text.status
+                    && native.passed == text.passed
+                    && native.skipped == text.skipped
+                    && native.verification_success == text.verification_success
+                    && native.tool_sequence == text.tool_sequence
+                    && native.rejected_tool_calls == text.rejected_tool_calls
+            }),
+            divergence_reasons,
+            evidence_paths,
         });
     }
     out
@@ -1030,20 +1150,28 @@ fn suggest_followups(
 
     let mismatched = comparisons
         .iter()
-        .filter(|comparison| {
-            comparison.native_passed.is_some()
-                && comparison.text_passed.is_some()
-                && comparison.native_passed != comparison.text_passed
-        })
+        .filter(|comparison| !comparison.divergence_reasons.is_empty())
         .map(|comparison| {
             format!(
-                "{}:{}",
+                "{}:{} ({})",
                 comparison.fixture_id,
-                selector_label(&comparison.selector)
+                selector_label(&comparison.selector),
+                comparison.divergence_reasons.join("; ")
             )
         })
         .collect::<Vec<_>>();
     if !mismatched.is_empty() {
+        let run_ids = comparisons
+            .iter()
+            .filter(|comparison| !comparison.divergence_reasons.is_empty())
+            .flat_map(|comparison| {
+                [
+                    comparison.native_run_id.clone(),
+                    comparison.text_run_id.clone(),
+                ]
+            })
+            .flatten()
+            .collect::<Vec<_>>();
         out.push(FollowupSuggestion {
             title: "Make native/text tool modes behaviorally interchangeable for preset harnesses"
                 .to_string(),
@@ -1052,7 +1180,7 @@ fn suggest_followups(
                 mismatched.join(", ")
             ),
             labels: vec!["agents".to_string(), "tools".to_string()],
-            run_ids: Vec::new(),
+            run_ids,
         });
     }
 
@@ -1130,32 +1258,41 @@ fn render_markdown(summary: &EvalSummary) -> String {
     );
 
     out.push_str("\n## Runs\n\n");
-    out.push_str("| fixture | run | provider | model | tool format | tool sequence | status | iterations | tokens | cost | transcript | output |\n");
-    out.push_str("|---|---|---|---|---|---|---|---:|---:|---:|---:|---|\n");
+    out.push_str("| fixture | run | provider | model | tool format | fixture sequence | tool calls | status | iterations | tokens | cost | transcript | output |\n");
+    out.push_str("|---|---|---|---|---|---|---|---|---:|---:|---:|---|---|\n");
     for run in &summary.runs {
+        let tool_sequence = if run.tool_sequence.is_empty() {
+            "-".to_string()
+        } else {
+            run.tool_sequence.join(", ").replace('|', "\\|")
+        };
         out.push_str(&format!(
-            "| `{}` | `{}` | `{}` | `{}` | `{}` | `{}` | {} | {} | {} | {:.6} | {} | `{}` |\n",
+            "| `{}` | `{}` | `{}` | `{}` | `{}` | `{}` | `{}` | {} | {} | {} | {:.6} | {} | `{}` |\n",
             run.fixture_id,
             run.run_id,
             run.selector.provider,
             run.selector.model.replace('|', "\\|"),
             run.tool_format,
-            run.tool_sequence,
+            run.fixture_tool_sequence,
+            tool_sequence,
             run.status,
             run.iterations,
             run.input_tokens + run.output_tokens,
             run.cost_usd,
-            run.transcript_event_count,
+            markdown_link(
+                &run.transcript_event_count.to_string(),
+                &run.transcript_events_path
+            ),
             run.output_dir
         ));
     }
     if !summary.comparisons.is_empty() {
         out.push_str("\n## Native/Text Comparison\n\n");
-        out.push_str("| fixture | selector | native | text | token delta | iteration delta |\n");
-        out.push_str("|---|---|---|---|---:|---:|\n");
+        out.push_str("| fixture | selector | native | text | equivalent | verifier | tools | rejected delta | token delta | iteration delta | evidence |\n");
+        out.push_str("|---|---|---|---|---|---|---|---:|---:|---:|---|\n");
         for comparison in &summary.comparisons {
             out.push_str(&format!(
-                "| `{}` | `{}` | {} | {} | {} | {} |\n",
+                "| `{}` | `{}` | {} | {} | {} | {} | {} | {} | {} | {} | {} |\n",
                 comparison.fixture_id,
                 selector_label(&comparison.selector),
                 comparison
@@ -1166,6 +1303,13 @@ fn render_markdown(summary: &EvalSummary) -> String {
                     .text_status
                     .clone()
                     .unwrap_or_else(|| "-".to_string()),
+                optional_bool_mark(comparison.equivalent),
+                optional_bool_mark(comparison.verifier_match),
+                optional_bool_mark(comparison.tool_sequence_match),
+                comparison
+                    .rejected_tool_call_delta_text_minus_native
+                    .map(|v| v.to_string())
+                    .unwrap_or_else(|| "-".to_string()),
                 comparison
                     .token_delta_text_minus_native
                     .map(|v| v.to_string())
@@ -1173,8 +1317,31 @@ fn render_markdown(summary: &EvalSummary) -> String {
                 comparison
                     .iteration_delta_text_minus_native
                     .map(|v| v.to_string())
-                    .unwrap_or_else(|| "-".to_string())
+                    .unwrap_or_else(|| "-".to_string()),
+                comparison_evidence_links(comparison)
             ));
+        }
+    }
+    let diverged = summary
+        .comparisons
+        .iter()
+        .filter(|comparison| !comparison.divergence_reasons.is_empty())
+        .collect::<Vec<_>>();
+    if !diverged.is_empty() {
+        out.push_str("\n## Native/Text Divergence Evidence\n\n");
+        for comparison in diverged {
+            out.push_str(&format!(
+                "- `{}` `{}`: {}\n",
+                comparison.fixture_id,
+                selector_label(&comparison.selector),
+                comparison.divergence_reasons.join("; ")
+            ));
+            if !comparison.evidence_paths.is_empty() {
+                out.push_str(&format!(
+                    "  Evidence: {}\n",
+                    comparison_evidence_links(comparison)
+                ));
+            }
         }
     }
     out
@@ -1243,6 +1410,60 @@ fn string_array(value: Option<&JsonValue>) -> Vec<String> {
                 .collect()
         })
         .unwrap_or_default()
+}
+
+fn non_empty_string_array(value: Option<&JsonValue>) -> Option<Vec<String>> {
+    let values = string_array(value);
+    (!values.is_empty()).then_some(values)
+}
+
+fn tool_call_sequence(value: Option<&JsonValue>) -> Option<Vec<String>> {
+    let calls = value.and_then(JsonValue::as_array)?;
+    let mut sequence = Vec::new();
+    for call in calls {
+        if let Some(name) = call
+            .get("name")
+            .or_else(|| call.get("tool_name"))
+            .and_then(JsonValue::as_str)
+        {
+            sequence.push(name.to_string());
+        }
+    }
+    (!sequence.is_empty()).then_some(sequence)
+}
+
+fn optional_bool_mark(value: Option<bool>) -> &'static str {
+    match value {
+        Some(true) => "yes",
+        Some(false) => "no",
+        None => "-",
+    }
+}
+
+fn comparison_evidence_links(comparison: &FormatComparison) -> String {
+    let mut links = Vec::new();
+    if let Some(native) = comparison.native_evidence_path.as_deref() {
+        links.push(markdown_link("native", native));
+    }
+    if let Some(text) = comparison.text_evidence_path.as_deref() {
+        links.push(markdown_link("text", text));
+    }
+    if links.is_empty() {
+        "-".to_string()
+    } else {
+        links.join("<br>")
+    }
+}
+
+fn markdown_link(label: &str, target: &str) -> String {
+    format!(
+        "[{}]({})",
+        label.replace('|', "\\|"),
+        target
+            .replace(' ', "%20")
+            .replace('(', "%28")
+            .replace(')', "%29")
+    )
 }
 
 fn reset_dir(path: &Path) -> Result<(), String> {
@@ -1388,6 +1609,25 @@ mod tests {
     }
 
     #[test]
+    fn model_selector_args_rejoin_provider_model_kv_after_clap_delimiter_split() {
+        let normalized = normalize_model_selector_args(&[
+            "mock:mock".to_string(),
+            "provider=openrouter".to_string(),
+            "model=qwen/qwen3-coder-flash".to_string(),
+            "provider=together".to_string(),
+            "model=Qwen/Qwen3-Coder-Next-FP8".to_string(),
+        ]);
+        assert_eq!(
+            normalized,
+            vec![
+                "mock:mock",
+                "provider=openrouter,model=qwen/qwen3-coder-flash",
+                "provider=together,model=Qwen/Qwen3-Coder-Next-FP8",
+            ]
+        );
+    }
+
+    #[test]
     fn markdown_escapes_model_table_pipes() {
         let selector = ModelSelector {
             selector: "provider:a|b".to_string(),
@@ -1411,6 +1651,7 @@ mod tests {
             passed_runs: 1,
             failed_runs: 0,
             skipped_runs: 0,
+            diverged_comparisons: 0,
             total_cost_usd: 0.0,
             rollups: EvalRollups {
                 by_fixture: vec![RollupReport {
@@ -1430,7 +1671,7 @@ mod tests {
                 run_id: "r".to_string(),
                 fixture_id: "python-add".to_string(),
                 fixture_name: "Python add repair".to_string(),
-                tool_sequence: "multi-tool".to_string(),
+                fixture_tool_sequence: "multi-tool".to_string(),
                 selector,
                 tool_format: "native".to_string(),
                 status: "passed".to_string(),
@@ -1438,6 +1679,7 @@ mod tests {
                 skipped: false,
                 skipped_reason: None,
                 output_dir: "out/r".to_string(),
+                transcript_events_path: "out/r/transcript_events.jsonl".to_string(),
                 workspace_root: None,
                 elapsed_ms: 1,
                 duration_ms: 1,
@@ -1448,6 +1690,7 @@ mod tests {
                 pricing_known: false,
                 tool_calls: 0,
                 rejected_tool_calls: 0,
+                tool_sequence: Vec::new(),
                 successful_tools: Vec::new(),
                 transcript_event_count: 0,
                 verification_success: true,

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -1586,6 +1586,9 @@ async fn print_model_info(args: &ModelInfoArgs) -> bool {
             "honors_chat_template_kwargs": capabilities.honors_chat_template_kwargs,
             "recommended_endpoint": capabilities.recommended_endpoint,
             "text_tool_wire_format_supported": capabilities.text_tool_wire_format_supported,
+            "preferred_tool_format": capabilities.preferred_tool_format,
+            "tool_mode_parity": capabilities.tool_mode_parity,
+            "tool_mode_parity_notes": capabilities.tool_mode_parity_notes,
         },
         "qc_default_model": harn_vm::llm_config::qc_default_model(&resolved.provider),
     });

--- a/crates/harn-cli/tests/eval_coding_agent_cli.rs
+++ b/crates/harn-cli/tests/eval_coding_agent_cli.rs
@@ -63,6 +63,41 @@ fn mock_matrix_writes_artifacts_for_native_and_text_tools() {
     assert_eq!(summary["total_runs"], 12);
     assert_eq!(summary["passed_runs"], 12);
     assert_eq!(summary["skipped_runs"], 0);
+    assert_eq!(summary["diverged_comparisons"], 0);
+    let comparisons = summary["comparisons"]
+        .as_array()
+        .expect("comparisons should be an array");
+    assert_eq!(comparisons.len(), 6);
+    let mut comparison_fixtures = comparisons
+        .iter()
+        .map(|comparison| {
+            comparison["fixture_id"]
+                .as_str()
+                .expect("comparison fixture_id")
+                .to_string()
+        })
+        .collect::<Vec<_>>();
+    comparison_fixtures.sort();
+    assert_eq!(
+        comparison_fixtures,
+        vec![
+            "cli-help-flag",
+            "docs-symbol-rename",
+            "no-tool-diagnosis",
+            "python-add",
+            "read-only-audit",
+            "test-output-first",
+        ],
+    );
+    for comparison in comparisons {
+        assert_eq!(comparison["equivalent"], true);
+        assert_eq!(comparison["verifier_match"], true);
+        assert_eq!(comparison["tool_sequence_match"], true);
+        assert_eq!(comparison["rejected_tool_call_delta_text_minus_native"], 0,);
+        assert!(comparison["evidence_paths"]
+            .as_array()
+            .is_some_and(|paths| paths.len() == 2));
+    }
     assert_eq!(
         summary
             .pointer("/rollups/by_fixture")
@@ -90,6 +125,18 @@ fn mock_matrix_writes_artifacts_for_native_and_text_tools() {
         assert!(
             row["fixture_id"].is_string(),
             "fixture_id should be present"
+        );
+        assert!(
+            row["fixture_tool_sequence"].is_string(),
+            "fixture_tool_sequence should be present"
+        );
+        assert!(
+            row["transcript_events_path"].is_string(),
+            "transcript_events_path should be present"
+        );
+        assert!(
+            row["tool_sequence"].is_array(),
+            "tool_sequence should be present"
         );
     }
     let readiness_raw =

--- a/crates/harn-vm/src/llm/agent_session_host.rs
+++ b/crates/harn-vm/src/llm/agent_session_host.rs
@@ -661,6 +661,10 @@ pub(crate) fn canonical_acp_stop_reason(
         // truncated by the provider's `max_tokens` parameter.
         return "max_turn_requests";
     }
+    canonical_provider_stop_reason(last_llm_stop_reason)
+}
+
+pub(crate) fn canonical_provider_stop_reason(last_llm_stop_reason: Option<&str>) -> &'static str {
     match last_llm_stop_reason {
         Some(reason) if reason.eq_ignore_ascii_case("max_tokens") => "max_tokens",
         Some(reason) if reason.eq_ignore_ascii_case("length") => "max_tokens",
@@ -998,6 +1002,8 @@ fn host_agent_session_record_usage_builtin(
                 "provider": provider,
                 "model": model,
                 "cost_usd": cost,
+                "provider_stop_reason": stop_reason,
+                "canonical_stop_reason": canonical_provider_stop_reason(stop_reason.as_deref()),
             })),
         ),
     );
@@ -2506,8 +2512,9 @@ mod tests {
     use serde_json::json;
 
     use super::{
-        assistant_message_from_llm_result, canonical_acp_stop_reason, initial_user_content,
-        last_assistant_text, tool_result_message_for_provider, vm_to_json,
+        assistant_message_from_llm_result, canonical_acp_stop_reason,
+        canonical_provider_stop_reason, initial_user_content, last_assistant_text,
+        tool_result_message_for_provider, vm_to_json,
     };
     use std::collections::BTreeMap;
 
@@ -2681,6 +2688,14 @@ mod tests {
             canonical_acp_stop_reason("done", 1, 50, Some("MAX_TOKENS")),
             "max_tokens"
         );
+    }
+
+    #[test]
+    fn provider_stop_reason_normalization_is_shared_with_transcripts() {
+        assert_eq!(canonical_provider_stop_reason(Some("length")), "max_tokens");
+        assert_eq!(canonical_provider_stop_reason(Some("refusal")), "refusal");
+        assert_eq!(canonical_provider_stop_reason(Some("tool_use")), "end_turn");
+        assert_eq!(canonical_provider_stop_reason(None), "end_turn");
     }
 
     #[test]

--- a/crates/harn-vm/src/llm/capabilities.rs
+++ b/crates/harn-vm/src/llm/capabilities.rs
@@ -321,6 +321,21 @@ pub struct ProviderRule {
     /// survive the provider route and return in the visible response body.
     #[serde(default)]
     pub text_tool_wire_format_supported: Option<bool>,
+    /// Preferred tool-calling mode for this provider/model route when
+    /// callers do not explicitly choose `tool_format`. This lets the
+    /// capability matrix route around known provider-native regressions
+    /// without making presets branch on model names.
+    #[serde(default)]
+    pub preferred_tool_format: Option<String>,
+    /// Empirical native/text interchangeability status for this route.
+    /// Known values are descriptive, not gates: `interchangeable`,
+    /// `native_unreliable`, `text_unreliable`, `native_only`,
+    /// `text_only`, and `unknown`.
+    #[serde(default)]
+    pub tool_mode_parity: Option<String>,
+    /// Short human-readable note explaining `tool_mode_parity`.
+    #[serde(default)]
+    pub tool_mode_parity_notes: Option<String>,
     /// In-prompt directive that disables this model's "thinking" mode when
     /// the API doesn't expose a first-class field (or exposes it
     /// inconsistently across templates / quantizations). For Qwen3 family
@@ -390,6 +405,9 @@ pub struct Capabilities {
     pub presence_penalty_supported: bool,
     pub recommended_endpoint: Option<String>,
     pub text_tool_wire_format_supported: bool,
+    pub preferred_tool_format: Option<String>,
+    pub tool_mode_parity: Option<String>,
+    pub tool_mode_parity_notes: Option<String>,
     pub thinking_disable_directive: Option<String>,
     /// Per-task auto-policy reasoning-level overrides for this route.
     /// See [`ProviderRule::auto_reasoning_overrides`].
@@ -438,6 +456,9 @@ impl Default for Capabilities {
             presence_penalty_supported: true,
             recommended_endpoint: None,
             text_tool_wire_format_supported: true,
+            preferred_tool_format: None,
+            tool_mode_parity: None,
+            tool_mode_parity_notes: None,
             thinking_disable_directive: None,
             auto_reasoning_overrides: BTreeMap::new(),
         }
@@ -468,6 +489,10 @@ pub struct ProviderCapabilityMatrixRow {
     pub prefers_role_developer: bool,
     pub prefers_xml_tools: bool,
     pub thinking_block_style: String,
+    pub native_tools: bool,
+    pub text_tools: bool,
+    pub preferred_tool_format: String,
+    pub tool_mode_parity: String,
     pub tools: bool,
     pub cache: bool,
     pub source: String,
@@ -597,7 +622,12 @@ fn rule_to_matrix_row(
             .unwrap_or_else(|| rule.requires_completion_tokens.unwrap_or(false)),
         prefers_xml_tools: rule.prefers_xml_tools.unwrap_or(false),
         thinking_block_style: rule_thinking_block_style(rule),
-        tools: rule.native_tools.unwrap_or(false),
+        native_tools: rule.native_tools.unwrap_or(false),
+        text_tools: rule.text_tool_wire_format_supported.unwrap_or(true),
+        preferred_tool_format: rule_preferred_tool_format(rule),
+        tool_mode_parity: rule_tool_mode_parity(rule),
+        tools: rule.native_tools.unwrap_or(false)
+            || rule.text_tool_wire_format_supported.unwrap_or(true),
         cache: rule.prompt_caching.unwrap_or(false),
         source: source.to_string(),
     }
@@ -771,6 +801,9 @@ fn defaults_to_caps(defaults: &ProviderDefaults) -> Capabilities {
         presence_penalty_supported: None,
         recommended_endpoint: None,
         text_tool_wire_format_supported: None,
+        preferred_tool_format: None,
+        tool_mode_parity: None,
+        tool_mode_parity_notes: None,
         thinking_disable_directive: None,
         auto_reasoning_overrides: None,
     };
@@ -854,9 +887,36 @@ fn rule_to_caps(rule: &ProviderRule, defaults: &ProviderDefaults) -> Capabilitie
             .unwrap_or(true),
         recommended_endpoint: rule.recommended_endpoint.clone(),
         text_tool_wire_format_supported: rule.text_tool_wire_format_supported.unwrap_or(true),
+        preferred_tool_format: Some(rule_preferred_tool_format(rule)),
+        tool_mode_parity: Some(rule_tool_mode_parity(rule)),
+        tool_mode_parity_notes: rule.tool_mode_parity_notes.clone(),
         thinking_disable_directive: rule.thinking_disable_directive.clone(),
         auto_reasoning_overrides: rule.auto_reasoning_overrides.clone().unwrap_or_default(),
     }
+}
+
+fn rule_preferred_tool_format(rule: &ProviderRule) -> String {
+    rule.preferred_tool_format.clone().unwrap_or_else(|| {
+        if rule.native_tools.unwrap_or(false) {
+            "native".to_string()
+        } else {
+            "text".to_string()
+        }
+    })
+}
+
+fn rule_tool_mode_parity(rule: &ProviderRule) -> String {
+    rule.tool_mode_parity.clone().unwrap_or_else(|| {
+        match (
+            rule.native_tools.unwrap_or(false),
+            rule.text_tool_wire_format_supported.unwrap_or(true),
+        ) {
+            (true, true) => "unknown".to_string(),
+            (true, false) => "native_only".to_string(),
+            (false, true) => "text_only".to_string(),
+            (false, false) => "unsupported".to_string(),
+        }
+    })
 }
 
 fn rule_structured_output(rule: &ProviderRule) -> Option<String> {
@@ -1165,9 +1225,21 @@ anthropic_beta_features = ["fine-grained-tool-streaming-2025-05-14"]
     fn openrouter_deepseek_v32_defaults_to_text_tools() {
         reset();
         let caps = lookup("openrouter", "deepseek/deepseek-v3.2");
-        assert!(!caps.native_tools);
+        assert!(caps.native_tools);
         assert!(caps.text_tool_wire_format_supported);
+        assert_eq!(caps.preferred_tool_format.as_deref(), Some("text"));
+        assert_eq!(caps.tool_mode_parity.as_deref(), Some("native_unreliable"));
         assert_eq!(caps.structured_output.as_deref(), Some("native"));
+    }
+
+    #[test]
+    fn openrouter_qwen_coder_defaults_to_text_tools() {
+        reset();
+        let caps = lookup("openrouter", "qwen/qwen3-coder-flash");
+        assert!(caps.native_tools);
+        assert!(caps.text_tool_wire_format_supported);
+        assert_eq!(caps.preferred_tool_format.as_deref(), Some("text"));
+        assert_eq!(caps.tool_mode_parity.as_deref(), Some("native_unreliable"));
     }
 
     #[test]

--- a/crates/harn-vm/src/llm/capabilities.toml
+++ b/crates/harn-vm/src/llm/capabilities.toml
@@ -77,6 +77,14 @@
 #                     openrouter or enabled.
 #   recommended_endpoint: preferred endpoint family for this route.
 #   text_tool_wire_format_supported: whether Harn text tool calls survive.
+#   preferred_tool_format:
+#                     default tool mode for this route: native or text.
+#   tool_mode_parity:
+#                     empirical native/text interchangeability status:
+#                     interchangeable, native_unreliable, text_unreliable,
+#                     native_only, text_only, unknown.
+#   tool_mode_parity_notes:
+#                     short explanation for known non-interchangeable modes.
 #   thinking_disable_directive:
 #                     in-prompt directive (e.g. "/no_think" for Qwen3 chat
 #                     templates) that disables the model's thinking mode.
@@ -1246,6 +1254,9 @@ thinking_block_style = "inline"
 [[provider.openrouter]]
 model_match = "qwen/qwen3-coder*"
 native_tools = true
+preferred_tool_format = "text"
+tool_mode_parity = "native_unreliable"
+tool_mode_parity_notes = "OpenRouter Qwen3-Coder Flash native tools exhausted the coding-agent fixture while text tools completed; default to Harn text tools for preset parity."
 structured_output = "native"
 server_parser = "none"
 honors_chat_template_kwargs = false
@@ -1448,7 +1459,10 @@ thinking_block_style = "reasoning_summary"
 
 [[provider.openrouter]]
 model_match = "deepseek/deepseek-v3.2*"
-native_tools = false
+native_tools = true
+preferred_tool_format = "text"
+tool_mode_parity = "native_unreliable"
+tool_mode_parity_notes = "OpenRouter DeepSeek V3.2 advertises native tools, but coding-agent runs observed provider-native failures; default to Harn text tools and recover DSML markers."
 thinking_modes = ["enabled", "effort"]
 prompt_caching = true
 structured_output = "native"

--- a/crates/harn-vm/src/llm/config_builtins.rs
+++ b/crates/harn-vm/src/llm/config_builtins.rs
@@ -713,6 +713,27 @@ pub(crate) fn capabilities_to_vm_value(
         "text_tool_wire_format_supported".to_string(),
         VmValue::Bool(caps.text_tool_wire_format_supported),
     );
+    dict.insert(
+        "preferred_tool_format".to_string(),
+        caps.preferred_tool_format
+            .as_deref()
+            .map(|format| VmValue::String(Rc::from(format)))
+            .unwrap_or(VmValue::Nil),
+    );
+    dict.insert(
+        "tool_mode_parity".to_string(),
+        caps.tool_mode_parity
+            .as_deref()
+            .map(|status| VmValue::String(Rc::from(status)))
+            .unwrap_or(VmValue::Nil),
+    );
+    dict.insert(
+        "tool_mode_parity_notes".to_string(),
+        caps.tool_mode_parity_notes
+            .as_deref()
+            .map(|notes| VmValue::String(Rc::from(notes)))
+            .unwrap_or(VmValue::Nil),
+    );
     // Mirrors the VM's tool-capability gate at llm_config::effective_model_capability_tags:
     // either native or text-format tool calling counts as tool-capable.
     dict.insert(

--- a/crates/harn-vm/src/llm/tools/parse/tagged.rs
+++ b/crates/harn-vm/src/llm/tools/parse/tagged.rs
@@ -268,6 +268,20 @@ fn parse_mistral_marker_calls(
         while name_start < bytes.len() && bytes[name_start].is_ascii_whitespace() {
             name_start += 1;
         }
+        if matches!(bytes.get(name_start), Some(b'[' | b'{')) {
+            match parse_mistral_json_payload(&src[name_start..], &known, calls.len()) {
+                Ok((mut parsed_calls, consumed)) => {
+                    ranges.push((start, name_start + consumed));
+                    calls.append(&mut parsed_calls);
+                    cursor = name_start + consumed;
+                }
+                Err(message) => {
+                    errors.push(message);
+                    cursor = name_start.saturating_add(1);
+                }
+            }
+            continue;
+        }
         let Some(name_len) = ident_length(&bytes[name_start..]) else {
             errors.push("Mistral [TOOL_CALLS] marker was missing a tool name.".to_string());
             cursor = name_start.saturating_add(1);
@@ -345,6 +359,78 @@ fn parse_mistral_marker_calls(
         done_marker: None,
         canonical,
     })
+}
+
+fn parse_mistral_json_payload(
+    src: &str,
+    known: &BTreeSet<String>,
+    start_index: usize,
+) -> Result<(Vec<serde_json::Value>, usize), String> {
+    let mut values = serde_json::Deserializer::from_str(src).into_iter::<serde_json::Value>();
+    let value = values
+        .next()
+        .transpose()
+        .map_err(|error| format!("Mistral [TOOL_CALLS] JSON payload did not parse: {error}."))?;
+    let Some(value) = value else {
+        return Err("Mistral [TOOL_CALLS] JSON payload was empty.".to_string());
+    };
+    let consumed = values.byte_offset();
+    let items = match value {
+        serde_json::Value::Array(items) => items,
+        item @ serde_json::Value::Object(_) => vec![item],
+        other => {
+            return Err(format!(
+                "Mistral [TOOL_CALLS] JSON payload must be an object or array, got {}.",
+                other
+            ))
+        }
+    };
+    let mut calls = Vec::new();
+    for (offset, item) in items.into_iter().enumerate() {
+        let Some(object) = item.as_object() else {
+            return Err("Mistral [TOOL_CALLS] JSON entries must be objects.".to_string());
+        };
+        let name = object
+            .get("name")
+            .or_else(|| object.get("tool_name"))
+            .and_then(|value| value.as_str())
+            .unwrap_or("");
+        if name.is_empty() {
+            return Err("Mistral [TOOL_CALLS] JSON entry was missing `name`.".to_string());
+        }
+        if !known.contains(name) {
+            return Err(format!(
+                "Unknown tool '{name}' in Mistral [TOOL_CALLS] JSON payload."
+            ));
+        }
+        let raw_args = object
+            .get("arguments")
+            .or_else(|| object.get("args"))
+            .cloned()
+            .unwrap_or_else(|| serde_json::json!({}));
+        let parsed_args = match raw_args {
+            serde_json::Value::String(text) => serde_json::from_str::<serde_json::Value>(&text)
+                .map_err(|error| {
+                    format!("Mistral [TOOL_CALLS] arguments for `{name}` did not parse: {error}.")
+                })?,
+            value => value,
+        };
+        let arguments = match parsed_args {
+            value if value.is_object() => value,
+            serde_json::Value::Null => serde_json::json!({}),
+            other => {
+                return Err(format!(
+                    "Mistral [TOOL_CALLS] arguments for `{name}` must be an object or JSON string containing an object, got {other}."
+                ))
+            }
+        };
+        calls.push(serde_json::json!({
+            "id": format!("tc_mistral_{}", start_index + offset),
+            "name": name,
+            "arguments": arguments,
+        }));
+    }
+    Ok((calls, consumed))
 }
 
 fn parse_deepseek_dsml_calls(

--- a/crates/harn-vm/src/llm/tools/tests/validation_and_tagged.rs
+++ b/crates/harn-vm/src/llm/tools/tests/validation_and_tagged.rs
@@ -148,6 +148,26 @@ fn tagged_parser_recovers_mistral_tool_markers() {
 }
 
 #[test]
+fn tagged_parser_recovers_mistral_json_tool_marker_payload() {
+    let tools = sample_tool_registry();
+    let text = "I'll inspect first.\n[TOOL_CALLS] [{\"name\":\"edit\",\"arguments\":{\"action\":\"create\",\"path\":\"a.rs\",\"content\":\"fn a() {}\"}},{\"name\":\"run\",\"arguments\":\"{\\\"command\\\":\\\"cargo test\\\"}\"}]";
+    let result = parse_text_tool_calls_with_tools(text, Some(&tools));
+
+    assert_eq!(result.calls.len(), 2);
+    assert_eq!(result.calls[0]["name"], json!("edit"));
+    assert_eq!(result.calls[0]["arguments"]["path"], json!("a.rs"));
+    assert_eq!(result.calls[1]["name"], json!("run"));
+    assert_eq!(result.calls[1]["arguments"]["command"], json!("cargo test"));
+    assert_eq!(result.prose, "I'll inspect first.");
+    assert!(
+        result.violations[0].contains("Mistral"),
+        "violation should teach canonical protocol: {:?}",
+        result.violations
+    );
+    assert_eq!(result.canonical.matches("<tool_call>").count(), 2);
+}
+
+#[test]
 fn tagged_parser_recovers_deepseek_dsml_markers() {
     let tools = sample_tool_registry();
     let text = "I'll inspect first.\n\

--- a/crates/harn-vm/src/llm_config.rs
+++ b/crates/harn-vm/src/llm_config.rs
@@ -805,7 +805,13 @@ fn default_tool_format_with_config(
             }
         }
     }
-    let capability_matrix_native = crate::llm::capabilities::lookup(provider, model).native_tools;
+    let capabilities = crate::llm::capabilities::lookup(provider, model);
+    if let Some(format) = capabilities.preferred_tool_format.as_deref() {
+        if matches!(format, "native" | "text") {
+            return format.to_string();
+        }
+    }
+    let capability_matrix_native = capabilities.native_tools;
     let legacy_provider_native = config
         .providers
         .get(provider)
@@ -1491,6 +1497,10 @@ mod tests {
         assert_eq!(default_tool_format("gemma-4-26b-a4b-it", "local"), "text");
         assert_eq!(
             default_tool_format("deepseek/deepseek-v3.2", "openrouter"),
+            "text"
+        );
+        assert_eq!(
+            default_tool_format("qwen/qwen3-coder-flash", "openrouter"),
             "text"
         );
     }

--- a/crates/harn-vm/src/provider_catalog.rs
+++ b/crates/harn-vm/src/provider_catalog.rs
@@ -140,6 +140,12 @@ pub struct ModelModalities {
 pub struct ModelToolSupport {
     pub native: bool,
     pub text: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub preferred_format: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parity: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parity_notes: Option<String>,
     pub tool_search: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_tools: Option<u32>,
@@ -562,6 +568,9 @@ pub fn schema_value() -> Value {
                 "properties": {
                     "native": {"type": "boolean"},
                     "text": {"type": "boolean"},
+                    "preferred_format": {"type": "string"},
+                    "parity": {"type": "string"},
+                    "parity_notes": {"type": "string"},
                     "tool_search": {"type": "array", "items": {"type": "string"}},
                     "max_tools": {"type": "integer", "minimum": 1}
                 },
@@ -699,6 +708,9 @@ fn catalog_model(
         tool_support: ModelToolSupport {
             native: caps.native_tools,
             text: caps.text_tool_wire_format_supported,
+            preferred_format: caps.preferred_tool_format.clone(),
+            parity: caps.tool_mode_parity.clone(),
+            parity_notes: caps.tool_mode_parity_notes.clone(),
             tool_search: caps.tool_search.clone(),
             max_tools: caps.max_tools,
         },
@@ -1069,6 +1081,9 @@ export interface HarnCatalogModel {
   tool_support: {
     native: boolean
     text: boolean
+    preferred_format?: string
+    parity?: string
+    parity_notes?: string
     tool_search: string[]
     max_tools?: number
   }
@@ -1340,12 +1355,18 @@ public struct HarnModelModalities: Codable, Sendable, Equatable {
 public struct HarnModelToolSupport: Codable, Sendable, Equatable {
     public let native: Bool
     public let text: Bool
+    public let preferredFormat: String?
+    public let parity: String?
+    public let parityNotes: String?
     public let toolSearch: [String]
     public let maxTools: Int?
 
     enum CodingKeys: String, CodingKey {
         case native
         case text
+        case preferredFormat = "preferred_format"
+        case parity
+        case parityNotes = "parity_notes"
         case toolSearch = "tool_search"
         case maxTools = "max_tools"
     }

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -1198,6 +1198,8 @@ per-project via `[[capabilities.provider.<name>]]` in `harn.toml`:
 [[capabilities.provider.my-proxy]]
 model_match = "*"
 native_tools = true
+preferred_tool_format = "native"
+tool_mode_parity = "unknown"
 tool_search = ["hosted"]
 thinking_modes = ["effort"]
 ```
@@ -1209,6 +1211,7 @@ let caps = provider_capabilities("anthropic", "claude-opus-4-7")
 // {
 //   provider: "anthropic", model: "claude-opus-4-7",
 //   native_tools: true, text_tool_wire_format_supported: true,
+//   preferred_tool_format: "native", tool_mode_parity: "unknown",
 //   tools: true, defer_loading: true,
 //   tool_search: ["bm25", "regex"], max_tools: 10000,
 //   prompt_caching: true, thinking: true,
@@ -1228,7 +1231,8 @@ let caps = provider_capabilities("anthropic", "claude-opus-4-7")
 // `caps.tools` matches Harn's own tool gate: true when the route can call
 // tools via either the native API wire shape or Harn's text wire format.
 // Inspect `native_tools` or `text_tool_wire_format_supported` directly when
-// you need to distinguish.
+// you need to distinguish. Presets use `preferred_tool_format` when it is
+// present, so known native/text divergences stay data-driven.
 
 if "bm25" in caps.tool_search {
   // opt into progressive disclosure
@@ -1251,6 +1255,10 @@ set under `[provider_defaults.<name>]`:
 | `model_match` | glob string | Required. Matched against lowercased model ID. |
 | `version_min` | `[major, minor]` | Optional lower bound; parsed via Claude / GPT version extractors. |
 | `native_tools` | bool | Native tool-call wire shape supported. |
+| `text_tool_wire_format_supported` | bool | Harn text-tool contract supported. |
+| `preferred_tool_format` | string | Default preset tool mode: `native` or `text`. |
+| `tool_mode_parity` | string | Native/text interchangeability status: `interchangeable`, `unknown`, `native_unreliable`, `text_unreliable`, `native_only`, `text_only`, or `unsupported`. |
+| `tool_mode_parity_notes` | string | Optional explanation for known non-interchangeable routes. |
 | `message_wire_format` | string | Shared request/response message format: `openai`, `anthropic`, `gemini`, or `ollama`. |
 | `native_tool_wire_format` | string | Native tool definition shape for shared helpers: `openai` or `anthropic`. Gemini/Vertex adapters emit Google `functionDeclarations` from canonical tool definitions. |
 | `defer_loading` | bool | Provider honors `defer_loading: true` on tool defs. |

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -2847,7 +2847,11 @@ effective matrix at runtime with:
 ```harn
 let caps = provider_capabilities("anthropic", "claude-opus-4-7")
 // {
-//   provider, model, native_tools, defer_loading,
+//   provider, model, native_tools, text_tool_wire_format_supported,
+//   preferred_tool_format: "native" | "text",
+//   tool_mode_parity: "interchangeable" | "unknown" | "native_unreliable" | "text_unreliable" | "native_only" | "text_only" | "unsupported",
+//   tool_mode_parity_notes: string | nil,
+//   tools, defer_loading,
 //   tool_search: [string], max_tools: int | nil,
 //   prompt_caching, thinking, thinking_modes: [string],
 //   reasoning_effort_supported, reasoning_none_supported,

--- a/docs/src/llm/providers.md
+++ b/docs/src/llm/providers.md
@@ -187,6 +187,7 @@ vendor-specific knowledge:
 let caps = provider_capabilities("anthropic", "claude-opus-4-7")
 // {
 //   native_tools: true, text_tool_wire_format_supported: true,
+//   preferred_tool_format: "native", tool_mode_parity: "unknown",
 //   tools: true, defer_loading: true,
 //   tool_search: ["bm25", "regex"], max_tools: 10000,
 //   prompt_caching: true, thinking: true, vision_supported: true,
@@ -203,6 +204,8 @@ let caps = provider_capabilities("anthropic", "claude-opus-4-7")
 // Gate on `tools` for "can this route call tools at all" — true for either
 // native or text-format tool wire. Inspect `native_tools` or
 // `text_tool_wire_format_supported` directly when you need to distinguish.
+// Presets use `preferred_tool_format` when it is present, which keeps known
+// native/text divergences in capability data instead of provider-name branches.
 if caps.tools && "bm25" in caps.tool_search {
   llm_call(prompt, sys, {
     tools: registry,
@@ -213,14 +216,15 @@ if caps.tools && "bm25" in caps.tool_search {
 
 The same matrix is the source of truth for Harn's default tool-calling
 mode. Alias-level `tool_format` still wins when set explicitly, but
-otherwise a matrix row with `native_tools = true` makes
-`agent_loop()` and `model-info` choose native provider tools for that
-provider/model route. Rows can also set `text_tool_wire_format_supported = true`
-for runtimes where Harn's text-tool contract is the reliable tool path even
-though native provider tool calls are unavailable or too flaky. Model-catalog
-display tags are derived from this matrix too; legacy `models.*.capabilities`
-entries are parsed for backwards compatibility but do not override runtime
-capability resolution.
+otherwise `preferred_tool_format` chooses `agent_loop()` and `model-info`
+tool mode for that provider/model route. Rows that do not set it infer
+`native` when `native_tools = true` and `text` otherwise. Rows can set
+`text_tool_wire_format_supported = true` for runtimes where Harn's text-tool
+contract is the reliable tool path, and can mark `tool_mode_parity` /
+`tool_mode_parity_notes` when native and text modes are known not to be
+interchangeable. Model-catalog display tags are derived from this matrix too;
+legacy `models.*.capabilities` entries are parsed for backwards compatibility
+but do not override runtime capability resolution.
 
 The matrix also records format preferences that prompt renderers can use
 without branching on provider names: XML vs. Markdown section scaffolding,
@@ -264,6 +268,10 @@ entry accepts these fields:
 | `model_match` | glob string | Required. Matched against the lowercased model ID. Leading/trailing `*` or a single middle `*` supported. |
 | `version_min` | `[major, minor]` | Narrows the match to a parseable version (Anthropic / OpenAI extractors). Rules where `version_min` is set but the model ID won't parse are skipped. |
 | `native_tools` | bool | Whether the provider accepts a native tool-call wire shape. |
+| `text_tool_wire_format_supported` | bool | Whether the provider/model route can use Harn's text-tool contract. Defaults to true for shipped rules unless disabled. |
+| `preferred_tool_format` | string | Optional preset default, `native` or `text`; inferred from `native_tools` when omitted. |
+| `tool_mode_parity` | string | Native/text interchangeability status: `interchangeable`, `unknown`, `native_unreliable`, `text_unreliable`, `native_only`, `text_only`, or `unsupported`. |
+| `tool_mode_parity_notes` | string | Optional explanation for known non-interchangeable routes. |
 | `message_wire_format` | string | Shared request/response message format: `openai`, `anthropic`, `gemini`, or `ollama`. |
 | `native_tool_wire_format` | string | Native tool definition shape for shared helpers: `openai` or `anthropic`. Gemini and Vertex accept Harn's canonical tool definitions and their adapters emit Google `functionDeclarations`. |
 | `defer_loading` | bool | Whether `defer_loading: true` on tool definitions is honored server-side. |

--- a/docs/src/provider-matrix.md
+++ b/docs/src/provider-matrix.md
@@ -9,98 +9,98 @@ This table is generated from Harn's live provider capability rules. `Model patte
 
 Regenerate with `make gen-provider-matrix` and verify with `make check-provider-matrix`.
 
-| Provider | Model pattern | Version min | Thinking | Vision | Audio | PDF | Streaming | Files API | JSON schema | Prompt | Output mode | Prefill | Role | Tool prompt | Thinking blocks | Tools | Cache |
-|---|---|---|---|---:|---:|---:|---:|---:|---|---|---|---:|---|---|---|---:|---:|
-| `anthropic` | `claude-haiku-*` | `>=4.7` | `adaptive` | yes | yes | yes | yes | yes | `tool_use` | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | yes | yes |
-| `anthropic` | `claude-opus-*` | `>=4.7` | `adaptive` | yes | yes | yes | yes | yes | `tool_use` | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | yes | yes |
-| `anthropic` | `claude-sonnet-*` | `>=4.7` | `adaptive` | yes | yes | yes | yes | yes | `tool_use` | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | yes | yes |
-| `anthropic` | `claude-haiku-*` | `>=4.5` | `enabled` | yes | yes | yes | yes | yes | `tool_use` | `xml` | `xml_tagged` | yes | `system` | `xml` | `thinking_blocks` | yes | yes |
-| `anthropic` | `claude-opus-*` | `>=4.6` | `enabled` | yes | yes | yes | yes | yes | `tool_use` | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | yes | yes |
-| `anthropic` | `claude-opus-*` | `>=4.0` | `enabled` | yes | yes | yes | yes | yes | `tool_use` | `xml` | `xml_tagged` | yes | `system` | `xml` | `thinking_blocks` | yes | yes |
-| `anthropic` | `claude-sonnet-*` | `>=4.6` | `enabled` | yes | yes | yes | yes | yes | `tool_use` | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | yes | yes |
-| `anthropic` | `claude-sonnet-*` | `>=4.0` | `enabled` | yes | yes | yes | yes | yes | `tool_use` | `xml` | `xml_tagged` | yes | `system` | `xml` | `thinking_blocks` | yes | yes |
-| `anthropic` | `anthropic/claude-haiku-*` | `>=4.7` | `adaptive` | yes | yes | yes | yes | yes | `tool_use` | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | yes | yes |
-| `anthropic` | `anthropic/claude-opus-*` | `>=4.7` | `adaptive` | yes | yes | yes | yes | yes | `tool_use` | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | yes | yes |
-| `anthropic` | `anthropic/claude-sonnet-*` | `>=4.7` | `adaptive` | yes | yes | yes | yes | yes | `tool_use` | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | yes | yes |
-| `anthropic` | `anthropic/claude-haiku-*` | `>=4.5` | `enabled` | yes | yes | yes | yes | yes | `tool_use` | `xml` | `xml_tagged` | yes | `system` | `xml` | `thinking_blocks` | yes | yes |
-| `anthropic` | `anthropic/claude-opus-*` | `>=4.6` | `enabled` | yes | yes | yes | yes | yes | `tool_use` | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | yes | yes |
-| `anthropic` | `anthropic/claude-opus-*` | `>=4.0` | `enabled` | yes | yes | yes | yes | yes | `tool_use` | `xml` | `xml_tagged` | yes | `system` | `xml` | `thinking_blocks` | yes | yes |
-| `anthropic` | `anthropic/claude-sonnet-*` | `>=4.6` | `enabled` | yes | yes | yes | yes | yes | `tool_use` | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | yes | yes |
-| `anthropic` | `anthropic/claude-sonnet-*` | `>=4.0` | `enabled` | yes | yes | yes | yes | yes | `tool_use` | `xml` | `xml_tagged` | yes | `system` | `xml` | `thinking_blocks` | yes | yes |
-| `anthropic` | `claude-*` | `any` | `enabled` | yes | yes | yes | yes | yes | `tool_use` | `xml` | `xml_tagged` | yes | `system` | `xml` | `thinking_blocks` | yes | yes |
-| `azure_openai` | `gpt-*` | `any` | no | no | no | no | yes | no | no | `markdown` | `native_json` | no | `system` | `json` | `none` | yes | no |
-| `azure_openai` | `o1*` | `any` | no | no | no | no | yes | no | no | `markdown` | `native_json` | no | `developer` | `json` | `reasoning_summary` | yes | no |
-| `azure_openai` | `o3*` | `any` | no | no | no | no | yes | no | no | `markdown` | `native_json` | no | `developer` | `json` | `reasoning_summary` | yes | no |
-| `azure_openai` | `o4*` | `any` | no | no | no | no | yes | no | no | `markdown` | `native_json` | no | `developer` | `json` | `reasoning_summary` | yes | no |
-| `bedrock` | `anthropic.claude-*` | `any` | no | no | no | no | yes | no | no | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | yes | no |
-| `bedrock` | `*claude*` | `any` | no | no | no | no | yes | no | no | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | yes | no |
-| `bedrock` | `*` | `any` | no | no | no | no | yes | no | no | `markdown` | `delimited` | no | `system` | `json` | `none` | yes | no |
-| `dashscope` | `qwen3.6*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | yes | no |
-| `dashscope` | `qwen*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | yes | no |
-| `fireworks` | `*qwen3.6*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | yes | no |
-| `fireworks` | `*qwen3p6*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | yes | no |
-| `fireworks` | `*qwen*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | yes | no |
-| `gemini` | `gemini-2.5*` | `any` | `enabled,adaptive,effort` | yes | yes | yes | yes | yes | `native` | `xml,markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | yes | no |
-| `gemini` | `models/gemini-2.5*` | `any` | `enabled,adaptive,effort` | yes | yes | yes | yes | yes | `native` | `xml,markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | yes | no |
-| `gemini` | `gemini-*` | `any` | no | yes | yes | yes | yes | yes | `native` | `xml,markdown` | `native_json` | no | `system` | `json` | `none` | yes | no |
-| `gemini` | `models/gemini-*` | `any` | no | yes | yes | yes | yes | yes | `native` | `xml,markdown` | `native_json` | no | `system` | `json` | `none` | yes | no |
-| `huggingface` | `qwen/qwen3.6*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | yes | no |
-| `huggingface` | `qwen/qwen3-coder*` | `any` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `none` | yes | no |
-| `huggingface` | `qwen/*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | yes | no |
-| `huggingface` | `deepseek-ai/deepseek-v3*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | yes | yes |
-| `llamacpp` | `*qwen3.6*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | no | no |
-| `llamacpp` | `*qwen3*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | no | no |
-| `llamacpp` | `*devstral-small-2*` | `any` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `none` | no | no |
-| `local` | `*qwen3.6*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | yes | no |
-| `local` | `*qwen3*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | yes | no |
-| `local` | `gemma-4*` | `any` | `enabled` | no | no | no | yes | no | no | `markdown` | `delimited` | no | `system` | `json` | `inline` | no | no |
-| `mlx` | `*qwen3.6*` | `any` | `enabled` | yes | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | yes | no |
-| `mlx` | `*qwen3*` | `any` | `enabled` | yes | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | yes | no |
-| `ollama` | `llava*` | `any` | no | yes | no | no | yes | no | no | `markdown` | `native_json` | no | `system` | `json` | `none` | no | no |
-| `ollama` | `bakllava*` | `any` | no | yes | no | no | yes | no | no | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | no | no |
-| `ollama` | `llama3.2-vision*` | `any` | no | yes | no | no | yes | no | no | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | no | no |
-| `ollama` | `gemma3*` | `any` | no | yes | no | no | yes | no | no | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | no | no |
-| `ollama` | `gemma4*` | `any` | no | yes | no | no | yes | no | no | `markdown` | `delimited` | no | `system` | `json` | `none` | no | no |
-| `ollama` | `qwen3.6*` | `any` | `enabled` | no | no | no | yes | no | `format_kw` | `markdown` | `delimited` | no | `system` | `json` | `inline` | no | no |
-| `ollama` | `qwen3*` | `any` | `enabled` | no | no | no | yes | no | `format_kw` | `markdown` | `delimited` | no | `system` | `json` | `inline` | yes | no |
-| `ollama` | `devstral-small-2*` | `any` | no | no | no | no | yes | no | `format_kw` | `markdown` | `delimited` | no | `system` | `json` | `none` | no | no |
-| `openai` | `gpt-4o*` | `any` | no | yes | yes | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | yes | no |
-| `openai` | `gpt-4.1*` | `any` | no | yes | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | yes | no |
-| `openai` | `gpt-*` | `>=5.4` | `effort` | yes | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | yes | no |
-| `openai` | `gpt-*` | `>=5.1` | `effort` | yes | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | yes | no |
-| `openai` | `gpt-*` | `>=5.0` | `effort` | yes | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | yes | no |
-| `openai` | `gpt-*` | `any` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | yes | no |
-| `openai` | `o1*` | `any` | `effort` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `developer` | `json` | `reasoning_summary` | yes | no |
-| `openai` | `o3*` | `any` | `effort` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `developer` | `json` | `reasoning_summary` | yes | no |
-| `openai` | `o4*` | `any` | `effort` | yes | no | no | yes | no | `native` | `markdown` | `native_json` | no | `developer` | `json` | `reasoning_summary` | yes | no |
-| `openai` | `openai/gpt-4o*` | `any` | no | yes | yes | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | yes | no |
-| `openai` | `openai/gpt-4.1*` | `any` | no | yes | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | yes | no |
-| `openai` | `openai/gpt-*` | `>=5.4` | `effort` | yes | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | yes | no |
-| `openai` | `openai/gpt-*` | `>=5.1` | `effort` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | yes | no |
-| `openai` | `openai/gpt-*` | `>=5.0` | `effort` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | yes | no |
-| `openai` | `openai/gpt-*` | `any` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | yes | no |
-| `openai` | `openai/o1*` | `any` | `effort` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `developer` | `json` | `reasoning_summary` | yes | no |
-| `openai` | `openai/o3*` | `any` | `effort` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `developer` | `json` | `reasoning_summary` | yes | no |
-| `openai` | `openai/o4*` | `any` | `effort` | yes | no | no | yes | no | `native` | `markdown` | `native_json` | no | `developer` | `json` | `reasoning_summary` | yes | no |
-| `openrouter` | `qwen/qwen3.6*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | yes | no |
-| `openrouter` | `qwen/qwen3-coder*` | `any` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `none` | yes | no |
-| `openrouter` | `qwen/*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | yes | no |
-| `openrouter` | `deepseek/deepseek-v4*` | `any` | `enabled,effort` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | yes | yes |
-| `openrouter` | `deepseek/deepseek-v3.2*` | `any` | `enabled,effort` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | no | yes |
-| `openrouter` | `deepseek/deepseek-v3*` | `any` | `enabled,effort` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | yes | yes |
-| `openrouter` | `mistralai/devstral*` | `any` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | yes | no |
-| `openrouter` | `google/gemini-2.5*` | `any` | `enabled,effort` | yes | yes | yes | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | yes | yes |
-| `openrouter` | `google/gemma-4*` | `any` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | yes | no |
-| `openrouter` | `meta-llama/llama-4*` | `any` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | yes | no |
-| `openrouter` | `meta-llama/llama-3*` | `any` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | yes | no |
-| `together` | `qwen/qwen3.6*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | yes | no |
-| `together` | `qwen/qwen3-coder*` | `any` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `none` | yes | no |
-| `together` | `qwen/*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | yes | no |
-| `together` | `deepseek-ai/deepseek-v3*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | yes | yes |
-| `together` | `openai/gpt-oss-*` | `any` | `effort` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | no | no |
-| `together` | `deepseek-ai/deepseek-v4*` | `any` | `enabled,effort` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | yes | yes |
-| `together` | `moonshotai/kimi-k2*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | yes | no |
-| `together` | `zai-org/glm-5*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | yes | no |
-| `together` | `google/gemma-4*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | yes | no |
-| `together` | `moonshotai/*` | `any` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | yes | no |
-| `vertex` | `gemini-*` | `any` | no | no | no | no | yes | no | no | `markdown` | `native_json` | no | `system` | `json` | `none` | yes | no |
+| Provider | Model pattern | Version min | Thinking | Vision | Audio | PDF | Streaming | Files API | JSON schema | Prompt | Output mode | Prefill | Role | Tool prompt | Thinking blocks | Default tools | Native tools | Text tools | Parity | Tools | Cache |
+|---|---|---|---|---:|---:|---:|---:|---:|---|---|---|---:|---|---|---|---|---:|---:|---|---:|---:|
+| `anthropic` | `claude-haiku-*` | `>=4.7` | `adaptive` | yes | yes | yes | yes | yes | `tool_use` | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
+| `anthropic` | `claude-opus-*` | `>=4.7` | `adaptive` | yes | yes | yes | yes | yes | `tool_use` | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
+| `anthropic` | `claude-sonnet-*` | `>=4.7` | `adaptive` | yes | yes | yes | yes | yes | `tool_use` | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
+| `anthropic` | `claude-haiku-*` | `>=4.5` | `enabled` | yes | yes | yes | yes | yes | `tool_use` | `xml` | `xml_tagged` | yes | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
+| `anthropic` | `claude-opus-*` | `>=4.6` | `enabled` | yes | yes | yes | yes | yes | `tool_use` | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
+| `anthropic` | `claude-opus-*` | `>=4.0` | `enabled` | yes | yes | yes | yes | yes | `tool_use` | `xml` | `xml_tagged` | yes | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
+| `anthropic` | `claude-sonnet-*` | `>=4.6` | `enabled` | yes | yes | yes | yes | yes | `tool_use` | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
+| `anthropic` | `claude-sonnet-*` | `>=4.0` | `enabled` | yes | yes | yes | yes | yes | `tool_use` | `xml` | `xml_tagged` | yes | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
+| `anthropic` | `anthropic/claude-haiku-*` | `>=4.7` | `adaptive` | yes | yes | yes | yes | yes | `tool_use` | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
+| `anthropic` | `anthropic/claude-opus-*` | `>=4.7` | `adaptive` | yes | yes | yes | yes | yes | `tool_use` | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
+| `anthropic` | `anthropic/claude-sonnet-*` | `>=4.7` | `adaptive` | yes | yes | yes | yes | yes | `tool_use` | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
+| `anthropic` | `anthropic/claude-haiku-*` | `>=4.5` | `enabled` | yes | yes | yes | yes | yes | `tool_use` | `xml` | `xml_tagged` | yes | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
+| `anthropic` | `anthropic/claude-opus-*` | `>=4.6` | `enabled` | yes | yes | yes | yes | yes | `tool_use` | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
+| `anthropic` | `anthropic/claude-opus-*` | `>=4.0` | `enabled` | yes | yes | yes | yes | yes | `tool_use` | `xml` | `xml_tagged` | yes | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
+| `anthropic` | `anthropic/claude-sonnet-*` | `>=4.6` | `enabled` | yes | yes | yes | yes | yes | `tool_use` | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
+| `anthropic` | `anthropic/claude-sonnet-*` | `>=4.0` | `enabled` | yes | yes | yes | yes | yes | `tool_use` | `xml` | `xml_tagged` | yes | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
+| `anthropic` | `claude-*` | `any` | `enabled` | yes | yes | yes | yes | yes | `tool_use` | `xml` | `xml_tagged` | yes | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
+| `azure_openai` | `gpt-*` | `any` | no | no | no | no | yes | no | no | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
+| `azure_openai` | `o1*` | `any` | no | no | no | no | yes | no | no | `markdown` | `native_json` | no | `developer` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
+| `azure_openai` | `o3*` | `any` | no | no | no | no | yes | no | no | `markdown` | `native_json` | no | `developer` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
+| `azure_openai` | `o4*` | `any` | no | no | no | no | yes | no | no | `markdown` | `native_json` | no | `developer` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
+| `bedrock` | `anthropic.claude-*` | `any` | no | no | no | no | yes | no | no | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | no |
+| `bedrock` | `*claude*` | `any` | no | no | no | no | yes | no | no | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | no |
+| `bedrock` | `*` | `any` | no | no | no | no | yes | no | no | `markdown` | `delimited` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
+| `dashscope` | `qwen3.6*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| `dashscope` | `qwen*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| `fireworks` | `*qwen3.6*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| `fireworks` | `*qwen3p6*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| `fireworks` | `*qwen*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| `gemini` | `gemini-2.5*` | `any` | `enabled,adaptive,effort` | yes | yes | yes | yes | yes | `native` | `xml,markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
+| `gemini` | `models/gemini-2.5*` | `any` | `enabled,adaptive,effort` | yes | yes | yes | yes | yes | `native` | `xml,markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
+| `gemini` | `gemini-*` | `any` | no | yes | yes | yes | yes | yes | `native` | `xml,markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
+| `gemini` | `models/gemini-*` | `any` | no | yes | yes | yes | yes | yes | `native` | `xml,markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
+| `huggingface` | `qwen/qwen3.6*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| `huggingface` | `qwen/qwen3-coder*` | `any` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
+| `huggingface` | `qwen/*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| `huggingface` | `deepseek-ai/deepseek-v3*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | yes |
+| `llamacpp` | `*qwen3.6*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `text` | no | yes | `text_only` | yes | no |
+| `llamacpp` | `*qwen3*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `text` | no | yes | `text_only` | yes | no |
+| `llamacpp` | `*devstral-small-2*` | `any` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `none` | `text` | no | yes | `text_only` | yes | no |
+| `local` | `*qwen3.6*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| `local` | `*qwen3*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| `local` | `gemma-4*` | `any` | `enabled` | no | no | no | yes | no | no | `markdown` | `delimited` | no | `system` | `json` | `inline` | `text` | no | yes | `text_only` | yes | no |
+| `mlx` | `*qwen3.6*` | `any` | `enabled` | yes | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| `mlx` | `*qwen3*` | `any` | `enabled` | yes | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| `ollama` | `llava*` | `any` | no | yes | no | no | yes | no | no | `markdown` | `native_json` | no | `system` | `json` | `none` | `text` | no | yes | `text_only` | yes | no |
+| `ollama` | `bakllava*` | `any` | no | yes | no | no | yes | no | no | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `text` | no | yes | `text_only` | yes | no |
+| `ollama` | `llama3.2-vision*` | `any` | no | yes | no | no | yes | no | no | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `text` | no | yes | `text_only` | yes | no |
+| `ollama` | `gemma3*` | `any` | no | yes | no | no | yes | no | no | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `text` | no | yes | `text_only` | yes | no |
+| `ollama` | `gemma4*` | `any` | no | yes | no | no | yes | no | no | `markdown` | `delimited` | no | `system` | `json` | `none` | `text` | no | yes | `text_only` | yes | no |
+| `ollama` | `qwen3.6*` | `any` | `enabled` | no | no | no | yes | no | `format_kw` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `text` | no | yes | `text_only` | yes | no |
+| `ollama` | `qwen3*` | `any` | `enabled` | no | no | no | yes | no | `format_kw` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | no | `native_only` | yes | no |
+| `ollama` | `devstral-small-2*` | `any` | no | no | no | no | yes | no | `format_kw` | `markdown` | `delimited` | no | `system` | `json` | `none` | `text` | no | yes | `text_only` | yes | no |
+| `openai` | `gpt-4o*` | `any` | no | yes | yes | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
+| `openai` | `gpt-4.1*` | `any` | no | yes | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
+| `openai` | `gpt-*` | `>=5.4` | `effort` | yes | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
+| `openai` | `gpt-*` | `>=5.1` | `effort` | yes | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
+| `openai` | `gpt-*` | `>=5.0` | `effort` | yes | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
+| `openai` | `gpt-*` | `any` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
+| `openai` | `o1*` | `any` | `effort` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `developer` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
+| `openai` | `o3*` | `any` | `effort` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `developer` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
+| `openai` | `o4*` | `any` | `effort` | yes | no | no | yes | no | `native` | `markdown` | `native_json` | no | `developer` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
+| `openai` | `openai/gpt-4o*` | `any` | no | yes | yes | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
+| `openai` | `openai/gpt-4.1*` | `any` | no | yes | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
+| `openai` | `openai/gpt-*` | `>=5.4` | `effort` | yes | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
+| `openai` | `openai/gpt-*` | `>=5.1` | `effort` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
+| `openai` | `openai/gpt-*` | `>=5.0` | `effort` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
+| `openai` | `openai/gpt-*` | `any` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
+| `openai` | `openai/o1*` | `any` | `effort` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `developer` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
+| `openai` | `openai/o3*` | `any` | `effort` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `developer` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
+| `openai` | `openai/o4*` | `any` | `effort` | yes | no | no | yes | no | `native` | `markdown` | `native_json` | no | `developer` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
+| `openrouter` | `qwen/qwen3.6*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| `openrouter` | `qwen/qwen3-coder*` | `any` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `none` | `text` | yes | yes | `native_unreliable` | yes | no |
+| `openrouter` | `qwen/*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| `openrouter` | `deepseek/deepseek-v4*` | `any` | `enabled,effort` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | yes |
+| `openrouter` | `deepseek/deepseek-v3.2*` | `any` | `enabled,effort` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `text` | yes | yes | `native_unreliable` | yes | yes |
+| `openrouter` | `deepseek/deepseek-v3*` | `any` | `enabled,effort` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | yes |
+| `openrouter` | `mistralai/devstral*` | `any` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
+| `openrouter` | `google/gemini-2.5*` | `any` | `enabled,effort` | yes | yes | yes | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | yes |
+| `openrouter` | `google/gemma-4*` | `any` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
+| `openrouter` | `meta-llama/llama-4*` | `any` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
+| `openrouter` | `meta-llama/llama-3*` | `any` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
+| `together` | `qwen/qwen3.6*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| `together` | `qwen/qwen3-coder*` | `any` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
+| `together` | `qwen/*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| `together` | `deepseek-ai/deepseek-v3*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | yes |
+| `together` | `openai/gpt-oss-*` | `any` | `effort` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `text` | no | yes | `text_only` | yes | no |
+| `together` | `deepseek-ai/deepseek-v4*` | `any` | `enabled,effort` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | yes |
+| `together` | `moonshotai/kimi-k2*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| `together` | `zai-org/glm-5*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| `together` | `google/gemma-4*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| `together` | `moonshotai/*` | `any` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
+| `vertex` | `gemini-*` | `any` | no | no | no | no | yes | no | no | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -2845,7 +2845,11 @@ effective matrix at runtime with:
 ```harn
 let caps = provider_capabilities("anthropic", "claude-opus-4-7")
 // {
-//   provider, model, native_tools, defer_loading,
+//   provider, model, native_tools, text_tool_wire_format_supported,
+//   preferred_tool_format: "native" | "text",
+//   tool_mode_parity: "interchangeable" | "unknown" | "native_unreliable" | "text_unreliable" | "native_only" | "text_only" | "unsupported",
+//   tool_mode_parity_notes: string | nil,
+//   tools, defer_loading,
 //   tool_search: [string], max_tools: int | nil,
 //   prompt_caching, thinking, thinking_modes: [string],
 //   reasoning_effort_supported, reasoning_none_supported,

--- a/spec/provider-catalog/HarnProviderCatalog.swift
+++ b/spec/provider-catalog/HarnProviderCatalog.swift
@@ -157,12 +157,18 @@ public struct HarnModelModalities: Codable, Sendable, Equatable {
 public struct HarnModelToolSupport: Codable, Sendable, Equatable {
     public let native: Bool
     public let text: Bool
+    public let preferredFormat: String?
+    public let parity: String?
+    public let parityNotes: String?
     public let toolSearch: [String]
     public let maxTools: Int?
 
     enum CodingKeys: String, CodingKey {
         case native
         case text
+        case preferredFormat = "preferred_format"
+        case parity
+        case parityNotes = "parity_notes"
         case toolSearch = "tool_search"
         case maxTools = "max_tools"
     }
@@ -751,6 +757,8 @@ public let harnProviderCatalogJSON = #"""
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "tool_use",
@@ -816,6 +824,8 @@ public let harnProviderCatalogJSON = #"""
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "tool_use",
@@ -881,6 +891,8 @@ public let harnProviderCatalogJSON = #"""
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "tool_use",
@@ -946,6 +958,8 @@ public let harnProviderCatalogJSON = #"""
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "tool_use",
@@ -1013,6 +1027,8 @@ public let harnProviderCatalogJSON = #"""
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": [
           "bm25",
           "regex"
@@ -1083,6 +1099,8 @@ public let harnProviderCatalogJSON = #"""
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": [
           "bm25",
           "regex"
@@ -1154,6 +1172,8 @@ public let harnProviderCatalogJSON = #"""
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": [
           "bm25",
           "regex"
@@ -1225,6 +1245,8 @@ public let harnProviderCatalogJSON = #"""
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": [
           "bm25",
           "regex"
@@ -1298,6 +1320,8 @@ public let harnProviderCatalogJSON = #"""
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": [
           "bm25",
           "regex"
@@ -1369,6 +1393,8 @@ public let harnProviderCatalogJSON = #"""
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": [
           "bm25",
           "regex"
@@ -1440,6 +1466,8 @@ public let harnProviderCatalogJSON = #"""
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": [
           "bm25",
           "regex"
@@ -1515,6 +1543,8 @@ public let harnProviderCatalogJSON = #"""
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": [
           "bm25",
           "regex"
@@ -1587,6 +1617,8 @@ public let harnProviderCatalogJSON = #"""
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": [
           "bm25",
           "regex"
@@ -1655,6 +1687,8 @@ public let harnProviderCatalogJSON = #"""
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "native",
@@ -1709,6 +1743,8 @@ public let harnProviderCatalogJSON = #"""
       "tool_support": {
         "native": false,
         "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
         "tool_search": []
       },
       "structured_output": "none",
@@ -1762,6 +1798,8 @@ public let harnProviderCatalogJSON = #"""
       "tool_support": {
         "native": false,
         "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
         "tool_search": []
       },
       "structured_output": "none",
@@ -1818,6 +1856,8 @@ public let harnProviderCatalogJSON = #"""
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "native",
@@ -1885,6 +1925,8 @@ public let harnProviderCatalogJSON = #"""
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "native",
@@ -1953,6 +1995,8 @@ public let harnProviderCatalogJSON = #"""
       "tool_support": {
         "native": false,
         "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
         "tool_search": []
       },
       "structured_output": "native",
@@ -2012,6 +2056,8 @@ public let harnProviderCatalogJSON = #"""
       "tool_support": {
         "native": false,
         "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
         "tool_search": []
       },
       "structured_output": "native",
@@ -2067,6 +2113,8 @@ public let harnProviderCatalogJSON = #"""
       "tool_support": {
         "native": false,
         "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
         "tool_search": []
       },
       "structured_output": "native",
@@ -2124,6 +2172,8 @@ public let harnProviderCatalogJSON = #"""
       "tool_support": {
         "native": false,
         "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
         "tool_search": []
       },
       "structured_output": "none",
@@ -2179,6 +2229,8 @@ public let harnProviderCatalogJSON = #"""
       "tool_support": {
         "native": false,
         "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
         "tool_search": []
       },
       "structured_output": "none",
@@ -2234,6 +2286,8 @@ public let harnProviderCatalogJSON = #"""
       "tool_support": {
         "native": false,
         "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
         "tool_search": []
       },
       "structured_output": "none",
@@ -2289,6 +2343,8 @@ public let harnProviderCatalogJSON = #"""
       "tool_support": {
         "native": false,
         "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
         "tool_search": []
       },
       "structured_output": "none",
@@ -2348,6 +2404,8 @@ public let harnProviderCatalogJSON = #"""
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "native",
@@ -2408,6 +2466,8 @@ public let harnProviderCatalogJSON = #"""
       "tool_support": {
         "native": false,
         "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
         "tool_search": []
       },
       "structured_output": "format_kw",
@@ -2464,6 +2524,8 @@ public let harnProviderCatalogJSON = #"""
       "tool_support": {
         "native": false,
         "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
         "tool_search": []
       },
       "structured_output": "none",
@@ -2515,6 +2577,8 @@ public let harnProviderCatalogJSON = #"""
       "tool_support": {
         "native": false,
         "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
         "tool_search": []
       },
       "structured_output": "none",
@@ -2571,6 +2635,8 @@ public let harnProviderCatalogJSON = #"""
       "tool_support": {
         "native": false,
         "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
         "tool_search": []
       },
       "structured_output": "format_kw",
@@ -2624,6 +2690,8 @@ public let harnProviderCatalogJSON = #"""
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "native",
@@ -2681,6 +2749,8 @@ public let harnProviderCatalogJSON = #"""
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "native",
@@ -2743,6 +2813,8 @@ public let harnProviderCatalogJSON = #"""
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "native",
@@ -2801,6 +2873,8 @@ public let harnProviderCatalogJSON = #"""
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "native",
@@ -2859,6 +2933,8 @@ public let harnProviderCatalogJSON = #"""
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "native",
@@ -2917,6 +2993,8 @@ public let harnProviderCatalogJSON = #"""
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "native",
@@ -2975,6 +3053,8 @@ public let harnProviderCatalogJSON = #"""
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "native",
@@ -3036,6 +3116,8 @@ public let harnProviderCatalogJSON = #"""
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "native",
@@ -3087,8 +3169,11 @@ public let harnProviderCatalogJSON = #"""
         ]
       },
       "tool_support": {
-        "native": false,
+        "native": true,
         "text": true,
+        "preferred_format": "text",
+        "parity": "native_unreliable",
+        "parity_notes": "OpenRouter DeepSeek V3.2 advertises native tools, but coding-agent runs observed provider-native failures; default to Harn text tools and recover DSML markers.",
         "tool_search": []
       },
       "structured_output": "native",
@@ -3152,6 +3237,8 @@ public let harnProviderCatalogJSON = #"""
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "native",
@@ -3215,6 +3302,8 @@ public let harnProviderCatalogJSON = #"""
       "tool_support": {
         "native": false,
         "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
         "tool_search": []
       },
       "structured_output": "none",
@@ -3268,6 +3357,8 @@ public let harnProviderCatalogJSON = #"""
       "tool_support": {
         "native": false,
         "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
         "tool_search": []
       },
       "structured_output": "none",
@@ -3321,6 +3412,8 @@ public let harnProviderCatalogJSON = #"""
       "tool_support": {
         "native": false,
         "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
         "tool_search": []
       },
       "structured_output": "none",
@@ -3374,6 +3467,8 @@ public let harnProviderCatalogJSON = #"""
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "native",
@@ -3428,6 +3523,9 @@ public let harnProviderCatalogJSON = #"""
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "text",
+        "parity": "native_unreliable",
+        "parity_notes": "OpenRouter Qwen3-Coder Flash native tools exhausted the coding-agent fixture while text tools completed; default to Harn text tools for preset parity.",
         "tool_search": []
       },
       "structured_output": "native",
@@ -3482,6 +3580,8 @@ public let harnProviderCatalogJSON = #"""
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "native",

--- a/spec/provider-catalog/harn-provider-catalog.ts
+++ b/spec/provider-catalog/harn-provider-catalog.ts
@@ -70,6 +70,9 @@ export interface HarnCatalogModel {
   tool_support: {
     native: boolean
     text: boolean
+    preferred_format?: string
+    parity?: string
+    parity_notes?: string
     tool_search: string[]
     max_tools?: number
   }
@@ -648,6 +651,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "tool_use",
@@ -713,6 +718,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "tool_use",
@@ -778,6 +785,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "tool_use",
@@ -843,6 +852,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "tool_use",
@@ -910,6 +921,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": [
           "bm25",
           "regex"
@@ -980,6 +993,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": [
           "bm25",
           "regex"
@@ -1051,6 +1066,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": [
           "bm25",
           "regex"
@@ -1122,6 +1139,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": [
           "bm25",
           "regex"
@@ -1195,6 +1214,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": [
           "bm25",
           "regex"
@@ -1266,6 +1287,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": [
           "bm25",
           "regex"
@@ -1337,6 +1360,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": [
           "bm25",
           "regex"
@@ -1412,6 +1437,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": [
           "bm25",
           "regex"
@@ -1484,6 +1511,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": [
           "bm25",
           "regex"
@@ -1552,6 +1581,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "native",
@@ -1606,6 +1637,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "tool_support": {
         "native": false,
         "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
         "tool_search": []
       },
       "structured_output": "none",
@@ -1659,6 +1692,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "tool_support": {
         "native": false,
         "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
         "tool_search": []
       },
       "structured_output": "none",
@@ -1715,6 +1750,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "native",
@@ -1782,6 +1819,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "native",
@@ -1850,6 +1889,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "tool_support": {
         "native": false,
         "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
         "tool_search": []
       },
       "structured_output": "native",
@@ -1909,6 +1950,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "tool_support": {
         "native": false,
         "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
         "tool_search": []
       },
       "structured_output": "native",
@@ -1964,6 +2007,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "tool_support": {
         "native": false,
         "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
         "tool_search": []
       },
       "structured_output": "native",
@@ -2021,6 +2066,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "tool_support": {
         "native": false,
         "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
         "tool_search": []
       },
       "structured_output": "none",
@@ -2076,6 +2123,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "tool_support": {
         "native": false,
         "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
         "tool_search": []
       },
       "structured_output": "none",
@@ -2131,6 +2180,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "tool_support": {
         "native": false,
         "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
         "tool_search": []
       },
       "structured_output": "none",
@@ -2186,6 +2237,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "tool_support": {
         "native": false,
         "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
         "tool_search": []
       },
       "structured_output": "none",
@@ -2245,6 +2298,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "native",
@@ -2305,6 +2360,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "tool_support": {
         "native": false,
         "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
         "tool_search": []
       },
       "structured_output": "format_kw",
@@ -2361,6 +2418,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "tool_support": {
         "native": false,
         "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
         "tool_search": []
       },
       "structured_output": "none",
@@ -2412,6 +2471,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "tool_support": {
         "native": false,
         "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
         "tool_search": []
       },
       "structured_output": "none",
@@ -2468,6 +2529,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "tool_support": {
         "native": false,
         "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
         "tool_search": []
       },
       "structured_output": "format_kw",
@@ -2521,6 +2584,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "native",
@@ -2578,6 +2643,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "native",
@@ -2640,6 +2707,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "native",
@@ -2698,6 +2767,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "native",
@@ -2756,6 +2827,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "native",
@@ -2814,6 +2887,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "native",
@@ -2872,6 +2947,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "native",
@@ -2933,6 +3010,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "native",
@@ -2984,8 +3063,11 @@ export const harnProviderCatalog: HarnProviderCatalog = {
         ]
       },
       "tool_support": {
-        "native": false,
+        "native": true,
         "text": true,
+        "preferred_format": "text",
+        "parity": "native_unreliable",
+        "parity_notes": "OpenRouter DeepSeek V3.2 advertises native tools, but coding-agent runs observed provider-native failures; default to Harn text tools and recover DSML markers.",
         "tool_search": []
       },
       "structured_output": "native",
@@ -3049,6 +3131,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "native",
@@ -3112,6 +3196,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "tool_support": {
         "native": false,
         "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
         "tool_search": []
       },
       "structured_output": "none",
@@ -3165,6 +3251,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "tool_support": {
         "native": false,
         "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
         "tool_search": []
       },
       "structured_output": "none",
@@ -3218,6 +3306,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "tool_support": {
         "native": false,
         "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
         "tool_search": []
       },
       "structured_output": "none",
@@ -3271,6 +3361,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "native",
@@ -3325,6 +3417,9 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "text",
+        "parity": "native_unreliable",
+        "parity_notes": "OpenRouter Qwen3-Coder Flash native tools exhausted the coding-agent fixture while text tools completed; default to Harn text tools for preset parity.",
         "tool_search": []
       },
       "structured_output": "native",
@@ -3379,6 +3474,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "native",

--- a/spec/provider-catalog/provider-catalog.json
+++ b/spec/provider-catalog/provider-catalog.json
@@ -507,6 +507,8 @@
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "tool_use",
@@ -572,6 +574,8 @@
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "tool_use",
@@ -637,6 +641,8 @@
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "tool_use",
@@ -702,6 +708,8 @@
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "tool_use",
@@ -769,6 +777,8 @@
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": [
           "bm25",
           "regex"
@@ -839,6 +849,8 @@
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": [
           "bm25",
           "regex"
@@ -910,6 +922,8 @@
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": [
           "bm25",
           "regex"
@@ -981,6 +995,8 @@
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": [
           "bm25",
           "regex"
@@ -1054,6 +1070,8 @@
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": [
           "bm25",
           "regex"
@@ -1125,6 +1143,8 @@
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": [
           "bm25",
           "regex"
@@ -1196,6 +1216,8 @@
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": [
           "bm25",
           "regex"
@@ -1271,6 +1293,8 @@
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": [
           "bm25",
           "regex"
@@ -1343,6 +1367,8 @@
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": [
           "bm25",
           "regex"
@@ -1411,6 +1437,8 @@
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "native",
@@ -1465,6 +1493,8 @@
       "tool_support": {
         "native": false,
         "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
         "tool_search": []
       },
       "structured_output": "none",
@@ -1518,6 +1548,8 @@
       "tool_support": {
         "native": false,
         "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
         "tool_search": []
       },
       "structured_output": "none",
@@ -1574,6 +1606,8 @@
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "native",
@@ -1641,6 +1675,8 @@
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "native",
@@ -1709,6 +1745,8 @@
       "tool_support": {
         "native": false,
         "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
         "tool_search": []
       },
       "structured_output": "native",
@@ -1768,6 +1806,8 @@
       "tool_support": {
         "native": false,
         "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
         "tool_search": []
       },
       "structured_output": "native",
@@ -1823,6 +1863,8 @@
       "tool_support": {
         "native": false,
         "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
         "tool_search": []
       },
       "structured_output": "native",
@@ -1880,6 +1922,8 @@
       "tool_support": {
         "native": false,
         "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
         "tool_search": []
       },
       "structured_output": "none",
@@ -1935,6 +1979,8 @@
       "tool_support": {
         "native": false,
         "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
         "tool_search": []
       },
       "structured_output": "none",
@@ -1990,6 +2036,8 @@
       "tool_support": {
         "native": false,
         "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
         "tool_search": []
       },
       "structured_output": "none",
@@ -2045,6 +2093,8 @@
       "tool_support": {
         "native": false,
         "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
         "tool_search": []
       },
       "structured_output": "none",
@@ -2104,6 +2154,8 @@
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "native",
@@ -2164,6 +2216,8 @@
       "tool_support": {
         "native": false,
         "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
         "tool_search": []
       },
       "structured_output": "format_kw",
@@ -2220,6 +2274,8 @@
       "tool_support": {
         "native": false,
         "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
         "tool_search": []
       },
       "structured_output": "none",
@@ -2271,6 +2327,8 @@
       "tool_support": {
         "native": false,
         "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
         "tool_search": []
       },
       "structured_output": "none",
@@ -2327,6 +2385,8 @@
       "tool_support": {
         "native": false,
         "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
         "tool_search": []
       },
       "structured_output": "format_kw",
@@ -2380,6 +2440,8 @@
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "native",
@@ -2437,6 +2499,8 @@
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "native",
@@ -2499,6 +2563,8 @@
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "native",
@@ -2557,6 +2623,8 @@
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "native",
@@ -2615,6 +2683,8 @@
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "native",
@@ -2673,6 +2743,8 @@
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "native",
@@ -2731,6 +2803,8 @@
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "native",
@@ -2792,6 +2866,8 @@
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "native",
@@ -2843,8 +2919,11 @@
         ]
       },
       "tool_support": {
-        "native": false,
+        "native": true,
         "text": true,
+        "preferred_format": "text",
+        "parity": "native_unreliable",
+        "parity_notes": "OpenRouter DeepSeek V3.2 advertises native tools, but coding-agent runs observed provider-native failures; default to Harn text tools and recover DSML markers.",
         "tool_search": []
       },
       "structured_output": "native",
@@ -2908,6 +2987,8 @@
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "native",
@@ -2971,6 +3052,8 @@
       "tool_support": {
         "native": false,
         "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
         "tool_search": []
       },
       "structured_output": "none",
@@ -3024,6 +3107,8 @@
       "tool_support": {
         "native": false,
         "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
         "tool_search": []
       },
       "structured_output": "none",
@@ -3077,6 +3162,8 @@
       "tool_support": {
         "native": false,
         "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
         "tool_search": []
       },
       "structured_output": "none",
@@ -3130,6 +3217,8 @@
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "native",
@@ -3184,6 +3273,9 @@
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "text",
+        "parity": "native_unreliable",
+        "parity_notes": "OpenRouter Qwen3-Coder Flash native tools exhausted the coding-agent fixture while text tools completed; default to Harn text tools for preset parity.",
         "tool_search": []
       },
       "structured_output": "native",
@@ -3238,6 +3330,8 @@
       "tool_support": {
         "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
       "structured_output": "native",

--- a/spec/provider-catalog/provider-catalog.schema.json
+++ b/spec/provider-catalog/provider-catalog.schema.json
@@ -421,6 +421,15 @@
         "native": {
           "type": "boolean"
         },
+        "parity": {
+          "type": "string"
+        },
+        "parity_notes": {
+          "type": "string"
+        },
+        "preferred_format": {
+          "type": "string"
+        },
         "text": {
           "type": "boolean"
         },


### PR DESCRIPTION
## Summary
- Route agent preset tool-format defaults through provider capability data, including explicit parity/default fields in catalog, matrix, docs, runtime, and generated bindings.
- Add native/text coding-agent comparison evidence to eval reports: transcript event paths, normalized tool sequences, rejected-call deltas, equivalence flags, and followup reasons.
- Recover Mistral `[TOOL_CALLS]` JSON marker payloads and persist provider/canonical stop reasons in transcript metadata.

Closes #2242

## Verification
- cargo test -p harn-vm llm::capabilities::tests
- cargo test -p harn-vm tagged_parser_recovers_mistral_json_tool_marker_payload
- cargo test -p harn-vm provider_stop_reason_normalization_is_shared_with_transcripts
- cargo test -p harn-vm test_default_tool_format_uses_capability_matrix
- cargo test -p harn-cli --test eval_coding_agent_cli mock_matrix_writes_artifacts_for_native_and_text_tools
- cargo test -p harn-cli model_selector_args_rejoin_provider_model_kv_after_clap_delimiter_split
- cargo run --quiet --bin harn -- test conformance --filter provider_capabilities_basic
- cargo run --quiet --bin harn -- fmt --check conformance/tests/integration/provider_capabilities_basic.harn crates/harn-cli/assets/evals/first_coding_agent.harn
- make check-provider-matrix
- make check-provider-catalog
- make check-provider-catalog-drift
- make check-language-spec
- make check-docs-snippets
- make lint-test-patterns
- git diff --check
- pre-commit hook
- pre-push hook

## Live eval note
- Ran coding-agent parity eval against `openrouter:qwen/qwen3-coder-flash` and Together Qwen candidates using /Users/ksinder/projects/burin-code/.env.
- OpenRouter Qwen3-Coder Flash passed in text mode and exhausted the native-mode budget; the capability matrix now routes that model to text tools by default and records native parity as unreliable.
- Together Qwen candidates returned provider model-unavailable errors in both modes, so they were not used as parity evidence.