### PR TITLE
Centralize VM runtime limits

### DIFF
--- a/crates/harn-vm/src/agent_sessions.rs
+++ b/crates/harn-vm/src/agent_sessions.rs
@@ -24,11 +24,12 @@ use std::future::Future;
 use std::rc::Rc;
 use std::time::Instant;
 
+use crate::runtime_limits::RuntimeLimits;
 use crate::value::VmValue;
 
 /// Default cap on concurrent sessions per VM thread. Beyond this the
 /// least-recently-accessed session is evicted on the next `open`.
-pub const DEFAULT_SESSION_CAP: usize = 128;
+pub const DEFAULT_SESSION_CAP: usize = RuntimeLimits::DEFAULT.max_agent_sessions;
 
 pub struct SessionState {
     pub id: String,

--- a/crates/harn-vm/src/channels.rs
+++ b/crates/harn-vm/src/channels.rs
@@ -10,11 +10,12 @@ use crate::event_log::{
     EventId, EventLog, LogEvent, Topic,
 };
 use crate::llm::vm_value_to_json;
+use crate::runtime_limits::RuntimeLimits;
 use crate::triggers::event::{ChannelEventPayload, KnownProviderPayload};
 use crate::triggers::{ProviderId, ProviderPayload, SignatureStatus, TenantId, TriggerEvent};
 use crate::value::{VmError, VmValue};
 
-const CHANNEL_QUEUE_DEPTH: usize = 128;
+const CHANNEL_QUEUE_DEPTH: usize = RuntimeLimits::DEFAULT.default_event_log_queue_depth;
 const CHANNEL_EVENT_KIND: &str = "channel.emit";
 const IDEMPOTENCY_HEADER: &str = "harn.channel.id";
 const NAME_HEADER: &str = "harn.channel.name";

--- a/crates/harn-vm/src/compiler/optimizer.rs
+++ b/crates/harn-vm/src/compiler/optimizer.rs
@@ -3,10 +3,12 @@ use std::rc::Rc;
 
 use harn_parser::{DictEntry, Node, SNode};
 
+use crate::runtime_limits::RuntimeLimits;
 use crate::value::{compare_values, values_equal, VmValue};
 
-const MAX_FOLDED_STRING_BYTES: usize = 64 * 1024;
-const MAX_FOLDED_COLLECTION_ITEMS: usize = 4_096;
+const MAX_FOLDED_STRING_BYTES: usize = RuntimeLimits::DEFAULT.max_constant_folded_string_bytes;
+const MAX_FOLDED_COLLECTION_ITEMS: usize =
+    RuntimeLimits::DEFAULT.max_constant_folded_collection_items;
 
 pub(super) fn fold_constant_expr(expr: &SNode) -> Option<SNode> {
     if !is_constant_fold_candidate(&expr.node) {

--- a/crates/harn-vm/src/event_log/mod.rs
+++ b/crates/harn-vm/src/event_log/mod.rs
@@ -12,6 +12,8 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::{broadcast, mpsc};
 use tokio_stream::wrappers::ReceiverStream;
 
+use crate::runtime_limits::RuntimeLimits;
+
 pub type EventId = u64;
 
 pub const HARN_EVENT_LOG_BACKEND_ENV: &str = "HARN_EVENT_LOG_BACKEND";
@@ -324,7 +326,7 @@ impl EventLogConfig {
         let queue_depth = std::env::var(HARN_EVENT_LOG_QUEUE_DEPTH_ENV)
             .ok()
             .and_then(|value| value.parse::<usize>().ok())
-            .unwrap_or(128)
+            .unwrap_or(RuntimeLimits::DEFAULT.default_event_log_queue_depth)
             .max(1);
 
         let file_dir = match std::env::var(HARN_EVENT_LOG_DIR_ENV) {

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -58,6 +58,7 @@ pub mod record_filter;
 pub mod redact;
 pub mod run_events;
 pub mod runtime_context;
+pub mod runtime_limits;
 pub mod runtime_paths;
 pub mod schema;
 pub(crate) mod secret_patterns;
@@ -210,6 +211,10 @@ pub use receipts::{
     RedactionClass, RECEIPT_SCHEMA_ID, RECEIPT_SCHEMA_JSON, RECEIPT_SCHEMA_VERSION,
 };
 pub use record_filter::{normalize_record_filter_expression, CompiledRecordFilter};
+pub use runtime_limits::{
+    RuntimeLimitDescription, RuntimeLimitEntry, RuntimeLimits, RuntimeLimitsReport,
+    RUNTIME_LIMIT_DESCRIPTIONS,
+};
 pub use schema::json_to_vm_value;
 pub use sessions::{
     CreateSession, ExpireSession, Session, SessionAttributes, SessionError, SessionStore,

--- a/crates/harn-vm/src/llm/cache.rs
+++ b/crates/harn-vm/src/llm/cache.rs
@@ -10,6 +10,7 @@ use rusqlite::{params, Connection, OptionalExtension};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
+use crate::runtime_limits::RuntimeLimits;
 use crate::stdlib::clock::now_wall_ms;
 use crate::stdlib::registration::{
     register_builtin_group, register_deferred_builtin_group, BuiltinGroup, SyncBuiltin,
@@ -19,7 +20,7 @@ use crate::vm::{Vm, VmBuiltinArity};
 
 const DEFAULT_NAMESPACE: &str = "default";
 const DEFAULT_TTL_SECONDS: u64 = 600;
-const DEFAULT_MAX_ENTRIES: usize = 256;
+const DEFAULT_MAX_ENTRIES: usize = RuntimeLimits::DEFAULT.max_std_cache_entries;
 const SQLITE_CREATE_TABLE: &str = concat!(
     "CREATE TABLE IF NOT EXISTS cache_entries (",
     "namespace TEXT NOT NULL,",

--- a/crates/harn-vm/src/llm/call.rs
+++ b/crates/harn-vm/src/llm/call.rs
@@ -2,6 +2,7 @@ use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::rc::Rc;
 
+use crate::runtime_limits::RuntimeLimits;
 use crate::stdlib::{json_to_vm_value, schema_result_value};
 use crate::value::{VmError, VmValue};
 
@@ -250,9 +251,9 @@ pub(crate) fn build_schema_nudge(
     }
 }
 
-const SCHEMA_NUDGE_MAX_DEPTH: usize = 3;
-const SCHEMA_NUDGE_MAX_LINES: usize = 8;
-const SCHEMA_NUDGE_MAX_KEYS: usize = 16;
+const SCHEMA_NUDGE_MAX_DEPTH: usize = RuntimeLimits::DEFAULT.max_schema_nudge_depth;
+const SCHEMA_NUDGE_MAX_LINES: usize = RuntimeLimits::DEFAULT.max_schema_nudge_lines;
+const SCHEMA_NUDGE_MAX_KEYS: usize = RuntimeLimits::DEFAULT.max_schema_nudge_keys;
 
 fn collect_schema_shape_lines(
     schema: &serde_json::Value,

--- a/crates/harn-vm/src/orchestration/policy/mod.rs
+++ b/crates/harn-vm/src/orchestration/policy/mod.rs
@@ -12,6 +12,7 @@ use std::thread_local;
 
 use serde::{Deserialize, Serialize};
 
+use crate::runtime_limits::RuntimeLimits;
 use crate::tool_annotations::{SideEffectLevel, ToolAnnotations};
 use crate::value::{VmError, VmValue};
 use crate::workspace_path::{classify_workspace_path, WorkspacePathInfo};
@@ -574,7 +575,7 @@ pub fn builtin_ceiling() -> CapabilityPolicy {
         capabilities: BTreeMap::new(),
         workspace_roots: Vec::new(),
         side_effect_level: Some("network".to_string()),
-        recursion_limit: Some(8),
+        recursion_limit: Some(RuntimeLimits::DEFAULT.max_nested_execution_depth),
         tool_arg_constraints: Vec::new(),
         tool_annotations: BTreeMap::new(),
         sandbox_profile: SandboxProfile::Worktree,

--- a/crates/harn-vm/src/runtime_limits.rs
+++ b/crates/harn-vm/src/runtime_limits.rs
@@ -1,0 +1,313 @@
+//! Central runtime ceilings for VM execution and stdlib resource guards.
+//!
+//! These limits are intentionally concrete fields instead of a stringly-typed
+//! config map. Most are internal guardrails for adversarial recursion, memory
+//! growth, or prompt/debug helper expansion. Hosts can report the effective
+//! profile through [`RuntimeLimits::report`], but these defaults are not a
+//! broad user-facing configuration surface.
+
+use serde::Serialize;
+
+/// Fixed resource and recursion ceilings used by the VM/runtime layer.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+pub struct RuntimeLimits {
+    /// Maximum nested Harn call frames before the VM raises stack overflow.
+    pub max_vm_frames: usize,
+    /// Maximum nested `.harn.prompt` include depth.
+    pub max_template_include_depth: usize,
+    /// Maximum parsed template assets kept in the per-thread template cache.
+    pub max_template_parse_cache_entries: usize,
+    /// Maximum UTF-8 file reads kept in the per-thread stdlib file cache.
+    pub max_file_text_cache_entries: usize,
+    /// Maximum memoized `json_parse` inputs kept per VM thread.
+    pub max_json_parse_cache_entries: usize,
+    /// Default maximum entries for the persistent `std/cache` backends.
+    pub max_std_cache_entries: usize,
+    /// Maximum compiled regex entries kept per VM thread.
+    pub max_regex_cache_entries: usize,
+    /// Maximum compiled JSON-schema `pattern` regexes kept process-wide.
+    pub max_schema_pattern_cache_entries: usize,
+    /// Default queue depth for memory/file/sqlite event-log subscribers.
+    pub default_event_log_queue_depth: usize,
+    /// Default concurrent agent-session cap per VM thread.
+    pub max_agent_sessions: usize,
+    /// Maximum directory descent for project fingerprint discovery.
+    pub max_project_fingerprint_depth: usize,
+    /// Maximum collection items the compiler may materialize while folding constants.
+    pub max_constant_folded_collection_items: usize,
+    /// Maximum string bytes the compiler may materialize while folding constants.
+    pub max_constant_folded_string_bytes: usize,
+    /// Default Harn-side nested-execution budget installed by the builtin policy ceiling.
+    pub max_nested_execution_depth: usize,
+    /// Maximum schema nesting shown in LLM schema-correction nudges.
+    pub max_schema_nudge_depth: usize,
+    /// Maximum schema lines shown in LLM schema-correction nudges.
+    pub max_schema_nudge_lines: usize,
+    /// Maximum object keys listed in LLM schema-correction nudges.
+    pub max_schema_nudge_keys: usize,
+}
+
+impl RuntimeLimits {
+    /// Default profile preserving the legacy hard-coded ceilings.
+    pub const DEFAULT: Self = Self {
+        max_vm_frames: 512,
+        max_template_include_depth: 32,
+        max_template_parse_cache_entries: 128,
+        max_file_text_cache_entries: 256,
+        max_json_parse_cache_entries: 128,
+        max_std_cache_entries: 256,
+        max_regex_cache_entries: 128,
+        max_schema_pattern_cache_entries: 256,
+        default_event_log_queue_depth: 128,
+        max_agent_sessions: 128,
+        max_project_fingerprint_depth: 4,
+        max_constant_folded_collection_items: 4_096,
+        max_constant_folded_string_bytes: 64 * 1024,
+        max_nested_execution_depth: 8,
+        max_schema_nudge_depth: 3,
+        max_schema_nudge_lines: 8,
+        max_schema_nudge_keys: 16,
+    };
+
+    /// Return the value for a named limit.
+    pub fn value(&self, name: &str) -> Option<usize> {
+        Some(match name {
+            "max_vm_frames" => self.max_vm_frames,
+            "max_template_include_depth" => self.max_template_include_depth,
+            "max_template_parse_cache_entries" => self.max_template_parse_cache_entries,
+            "max_file_text_cache_entries" => self.max_file_text_cache_entries,
+            "max_json_parse_cache_entries" => self.max_json_parse_cache_entries,
+            "max_std_cache_entries" => self.max_std_cache_entries,
+            "max_regex_cache_entries" => self.max_regex_cache_entries,
+            "max_schema_pattern_cache_entries" => self.max_schema_pattern_cache_entries,
+            "default_event_log_queue_depth" => self.default_event_log_queue_depth,
+            "max_agent_sessions" => self.max_agent_sessions,
+            "max_project_fingerprint_depth" => self.max_project_fingerprint_depth,
+            "max_constant_folded_collection_items" => self.max_constant_folded_collection_items,
+            "max_constant_folded_string_bytes" => self.max_constant_folded_string_bytes,
+            "max_nested_execution_depth" => self.max_nested_execution_depth,
+            "max_schema_nudge_depth" => self.max_schema_nudge_depth,
+            "max_schema_nudge_lines" => self.max_schema_nudge_lines,
+            "max_schema_nudge_keys" => self.max_schema_nudge_keys,
+            _ => return None,
+        })
+    }
+
+    /// Build a host-readable report for the effective limit profile.
+    pub fn report(&self) -> RuntimeLimitsReport {
+        RuntimeLimitsReport {
+            entries: RUNTIME_LIMIT_DESCRIPTIONS
+                .iter()
+                .map(|description| RuntimeLimitEntry {
+                    name: description.name,
+                    value: self
+                        .value(description.name)
+                        .expect("runtime limit description must name a RuntimeLimits field"),
+                    user_visible: description.user_visible,
+                    host_configurable: description.host_configurable,
+                    protects: description.protects,
+                })
+                .collect(),
+        }
+    }
+}
+
+impl Default for RuntimeLimits {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}
+
+/// Host/debug report for an effective runtime-limits profile.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct RuntimeLimitsReport {
+    pub entries: Vec<RuntimeLimitEntry>,
+}
+
+/// One documented runtime limit with its effective value.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct RuntimeLimitEntry {
+    pub name: &'static str,
+    pub value: usize,
+    pub user_visible: bool,
+    pub host_configurable: bool,
+    pub protects: &'static str,
+}
+
+/// Static documentation for every runtime limit field.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct RuntimeLimitDescription {
+    pub name: &'static str,
+    pub user_visible: bool,
+    pub host_configurable: bool,
+    pub protects: &'static str,
+}
+
+pub const RUNTIME_LIMIT_DESCRIPTIONS: &[RuntimeLimitDescription] = &[
+    RuntimeLimitDescription {
+        name: "max_vm_frames",
+        user_visible: true,
+        host_configurable: false,
+        protects: "prevents unbounded Harn function recursion from exhausting the VM stack",
+    },
+    RuntimeLimitDescription {
+        name: "max_template_include_depth",
+        user_visible: true,
+        host_configurable: false,
+        protects: "bounds recursive prompt-template includes after cycle detection",
+    },
+    RuntimeLimitDescription {
+        name: "max_template_parse_cache_entries",
+        user_visible: false,
+        host_configurable: false,
+        protects: "bounds per-thread memory held by parsed prompt-template assets",
+    },
+    RuntimeLimitDescription {
+        name: "max_file_text_cache_entries",
+        user_visible: false,
+        host_configurable: false,
+        protects: "bounds per-thread memory held by cached UTF-8 file reads",
+    },
+    RuntimeLimitDescription {
+        name: "max_json_parse_cache_entries",
+        user_visible: false,
+        host_configurable: false,
+        protects: "bounds per-thread memory held by memoized JSON parse inputs and values",
+    },
+    RuntimeLimitDescription {
+        name: "max_std_cache_entries",
+        user_visible: true,
+        host_configurable: false,
+        protects: "bounds retained entries in std/cache memory, filesystem, and sqlite backends",
+    },
+    RuntimeLimitDescription {
+        name: "max_regex_cache_entries",
+        user_visible: false,
+        host_configurable: false,
+        protects: "bounds per-thread memory held by compiled stdlib regex patterns",
+    },
+    RuntimeLimitDescription {
+        name: "max_schema_pattern_cache_entries",
+        user_visible: false,
+        host_configurable: false,
+        protects: "bounds process-wide memory held by compiled JSON-schema pattern regexes",
+    },
+    RuntimeLimitDescription {
+        name: "default_event_log_queue_depth",
+        user_visible: true,
+        host_configurable: true,
+        protects: "bounds queued subscriber notifications for memory, file, and sqlite event logs",
+    },
+    RuntimeLimitDescription {
+        name: "max_agent_sessions",
+        user_visible: true,
+        host_configurable: false,
+        protects: "bounds concurrent first-class agent sessions stored on one VM thread",
+    },
+    RuntimeLimitDescription {
+        name: "max_project_fingerprint_depth",
+        user_visible: false,
+        host_configurable: false,
+        protects: "bounds project fingerprint discovery in large or adversarial directory trees",
+    },
+    RuntimeLimitDescription {
+        name: "max_constant_folded_collection_items",
+        user_visible: false,
+        host_configurable: false,
+        protects: "prevents compile-time constant folding from materializing huge collections",
+    },
+    RuntimeLimitDescription {
+        name: "max_constant_folded_string_bytes",
+        user_visible: false,
+        host_configurable: false,
+        protects: "prevents compile-time constant folding from materializing huge strings",
+    },
+    RuntimeLimitDescription {
+        name: "max_nested_execution_depth",
+        user_visible: true,
+        host_configurable: false,
+        protects: "bounds nested agent loops, sub-agents, workers, and workflow stages",
+    },
+    RuntimeLimitDescription {
+        name: "max_schema_nudge_depth",
+        user_visible: false,
+        host_configurable: false,
+        protects: "keeps schema-retry correction prompts compact for deeply nested schemas",
+    },
+    RuntimeLimitDescription {
+        name: "max_schema_nudge_lines",
+        user_visible: false,
+        host_configurable: false,
+        protects: "keeps schema-retry correction prompts from growing with wide schemas",
+    },
+    RuntimeLimitDescription {
+        name: "max_schema_nudge_keys",
+        user_visible: false,
+        host_configurable: false,
+        protects: "keeps schema-retry object-key previews compact for wide objects",
+    },
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_runtime_limits_match_legacy_values() {
+        let limits = RuntimeLimits::default();
+        assert_eq!(limits.max_vm_frames, 512);
+        assert_eq!(limits.max_template_include_depth, 32);
+        assert_eq!(limits.max_template_parse_cache_entries, 128);
+        assert_eq!(limits.max_file_text_cache_entries, 256);
+        assert_eq!(limits.max_json_parse_cache_entries, 128);
+        assert_eq!(limits.max_std_cache_entries, 256);
+        assert_eq!(limits.max_regex_cache_entries, 128);
+        assert_eq!(limits.max_schema_pattern_cache_entries, 256);
+        assert_eq!(limits.default_event_log_queue_depth, 128);
+        assert_eq!(limits.max_agent_sessions, 128);
+        assert_eq!(limits.max_project_fingerprint_depth, 4);
+        assert_eq!(limits.max_constant_folded_collection_items, 4_096);
+        assert_eq!(limits.max_constant_folded_string_bytes, 64 * 1024);
+        assert_eq!(limits.max_nested_execution_depth, 8);
+        assert_eq!(limits.max_schema_nudge_depth, 3);
+        assert_eq!(limits.max_schema_nudge_lines, 8);
+        assert_eq!(limits.max_schema_nudge_keys, 16);
+    }
+
+    #[test]
+    fn runtime_limit_report_documents_every_field() {
+        let report = RuntimeLimits::default().report();
+        let names = report
+            .entries
+            .iter()
+            .map(|entry| entry.name)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            names,
+            vec![
+                "max_vm_frames",
+                "max_template_include_depth",
+                "max_template_parse_cache_entries",
+                "max_file_text_cache_entries",
+                "max_json_parse_cache_entries",
+                "max_std_cache_entries",
+                "max_regex_cache_entries",
+                "max_schema_pattern_cache_entries",
+                "default_event_log_queue_depth",
+                "max_agent_sessions",
+                "max_project_fingerprint_depth",
+                "max_constant_folded_collection_items",
+                "max_constant_folded_string_bytes",
+                "max_nested_execution_depth",
+                "max_schema_nudge_depth",
+                "max_schema_nudge_lines",
+                "max_schema_nudge_keys",
+            ]
+        );
+        assert!(report.entries.iter().all(|entry| entry.value > 0));
+        assert!(report
+            .entries
+            .iter()
+            .all(|entry| !entry.protects.is_empty()));
+    }
+}

--- a/crates/harn-vm/src/schema/validate.rs
+++ b/crates/harn-vm/src/schema/validate.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex, OnceLock};
 
+use crate::runtime_limits::RuntimeLimits;
 use crate::value::{values_equal, StructLayout, VmValue};
 
 use super::canonicalize::resolve_canonical_ref;
@@ -17,7 +18,7 @@ use super::{child_path, index_path, location_label, schema_bool, schema_i64, sch
 // and recompiling them on every value validated showed up as a hot-path
 // allocation cost. Cap the cache so adversarial schemas can't grow memory
 // unboundedly.
-const PATTERN_CACHE_LIMIT: usize = 256;
+const PATTERN_CACHE_LIMIT: usize = RuntimeLimits::DEFAULT.max_schema_pattern_cache_entries;
 
 #[derive(Clone)]
 enum PatternEntry {

--- a/crates/harn-vm/src/stdlib/event_log.rs
+++ b/crates/harn-vm/src/stdlib/event_log.rs
@@ -7,10 +7,11 @@ use crate::event_log::{
     active_event_log, install_memory_for_current_thread, EventLog, LogEvent, Topic,
 };
 use crate::llm::vm_value_to_json;
+use crate::runtime_limits::RuntimeLimits;
 use crate::value::{VmError, VmStream, VmValue};
 use crate::vm::Vm;
 
-const EVENT_LOG_QUEUE_DEPTH: usize = 128;
+const EVENT_LOG_QUEUE_DEPTH: usize = RuntimeLimits::DEFAULT.default_event_log_queue_depth;
 
 pub(crate) fn register_event_log_builtins(vm: &mut Vm) {
     register_event_log_namespace(vm);

--- a/crates/harn-vm/src/stdlib/fs.rs
+++ b/crates/harn-vm/src/stdlib/fs.rs
@@ -5,6 +5,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::SystemTime;
 use std::{cell::RefCell, thread_local};
 
+use crate::runtime_limits::RuntimeLimits;
 use crate::stdlib::registration::{register_builtin_group, BuiltinGroup, SyncBuiltin};
 use crate::testbench::overlay_fs::helpers as overlay;
 use crate::value::{VmError, VmValue};
@@ -14,7 +15,7 @@ thread_local! {
     static FILE_TEXT_CACHE: RefCell<BTreeMap<PathBuf, FileTextCacheEntry>> = const { RefCell::new(BTreeMap::new()) };
 }
 
-const FILE_TEXT_CACHE_MAX_ENTRIES: usize = 256;
+const FILE_TEXT_CACHE_MAX_ENTRIES: usize = RuntimeLimits::DEFAULT.max_file_text_cache_entries;
 
 const FS_SYNC_PRIMITIVES: &[SyncBuiltin] = &[
     SyncBuiltin::new("read_file", read_file_builtin)

--- a/crates/harn-vm/src/stdlib/git.rs
+++ b/crates/harn-vm/src/stdlib/git.rs
@@ -9,12 +9,13 @@ use uuid::Uuid;
 use crate::event_log::{
     active_event_log, install_memory_for_current_thread, EventLog, LogEvent, Topic,
 };
+use crate::runtime_limits::RuntimeLimits;
 use crate::trust_graph::{AutonomyTier, TrustOutcome, TrustRecord};
 use crate::value::{VmError, VmValue};
 use crate::vm::Vm;
 
 const GIT_RECEIPTS_TOPIC: &str = "stdlib.git.receipts";
-const EVENT_LOG_QUEUE_DEPTH: usize = 128;
+const EVENT_LOG_QUEUE_DEPTH: usize = RuntimeLimits::DEFAULT.default_event_log_queue_depth;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum GitMutation {

--- a/crates/harn-vm/src/stdlib/hitl.rs
+++ b/crates/harn-vm/src/stdlib/hitl.rs
@@ -16,6 +16,7 @@ use crate::event_log::{
     active_event_log, install_default_for_base_dir, install_memory_for_current_thread, AnyEventLog,
     EventLog, LogEvent, Topic,
 };
+use crate::runtime_limits::RuntimeLimits;
 use crate::schema::schema_expect_value;
 use crate::stdlib::host::dispatch_mock_host_call;
 use crate::stdlib::waitpoint::{
@@ -27,7 +28,7 @@ use crate::triggers::dispatcher::current_dispatch_context;
 use crate::value::{categorized_error, ErrorCategory, VmError, VmValue};
 use crate::vm::{clone_async_builtin_child_vm, Vm};
 
-const HITL_EVENT_LOG_QUEUE_DEPTH: usize = 128;
+const HITL_EVENT_LOG_QUEUE_DEPTH: usize = RuntimeLimits::DEFAULT.default_event_log_queue_depth;
 const HITL_APPROVAL_TIMEOUT_MS: u64 = 24 * 60 * 60 * 1000;
 const HITL_QUESTION_TIMEOUT_MS: u64 = 24 * 60 * 60 * 1000;
 

--- a/crates/harn-vm/src/stdlib/json.rs
+++ b/crates/harn-vm/src/stdlib/json.rs
@@ -1,6 +1,7 @@
 use std::rc::Rc;
 use std::{cell::RefCell, collections::BTreeMap, thread_local};
 
+use crate::runtime_limits::RuntimeLimits;
 use crate::schema;
 use crate::stdlib::json_query;
 use crate::value::{VmError, VmValue};
@@ -10,7 +11,7 @@ use crate::vm::Vm;
 /// its key plus the parsed value tree, so the cache can grow large quickly
 /// when a script feeds varied JSON. Mirror the regex-cache bound so the
 /// VM's per-thread parse caches share a predictable ceiling.
-const JSON_PARSE_CACHE_LIMIT: usize = 128;
+const JSON_PARSE_CACHE_LIMIT: usize = RuntimeLimits::DEFAULT.max_json_parse_cache_entries;
 
 thread_local! {
     static JSON_PARSE_CACHE: RefCell<BTreeMap<String, VmValue>> = const { RefCell::new(BTreeMap::new()) };

--- a/crates/harn-vm/src/stdlib/monitors.rs
+++ b/crates/harn-vm/src/stdlib/monitors.rs
@@ -14,6 +14,7 @@ use crate::event_log::{
     active_event_log, install_memory_for_current_thread, AnyEventLog, EventLog, LogEvent, Topic,
 };
 use crate::llm::vm_value_to_json;
+use crate::runtime_limits::RuntimeLimits;
 use crate::triggers::dispatcher::{
     current_dispatch_context, current_dispatch_is_replay, current_dispatch_wait_lease,
 };
@@ -21,7 +22,7 @@ use crate::triggers::TRIGGER_INBOX_ENVELOPES_TOPIC;
 use crate::value::{VmClosure, VmError, VmValue};
 use crate::vm::{clone_async_builtin_child_vm, Vm};
 
-const MONITOR_EVENT_LOG_QUEUE_DEPTH: usize = 128;
+const MONITOR_EVENT_LOG_QUEUE_DEPTH: usize = RuntimeLimits::DEFAULT.default_event_log_queue_depth;
 pub(crate) const MONITOR_WAITS_TOPIC: &str = "monitor.waits";
 
 thread_local! {

--- a/crates/harn-vm/src/stdlib/pool.rs
+++ b/crates/harn-vm/src/stdlib/pool.rs
@@ -27,6 +27,7 @@ use std::sync::Arc;
 use crate::event_log::{
     active_event_log, install_memory_for_current_thread, EventLog, LogEvent, Topic,
 };
+use crate::runtime_limits::RuntimeLimits;
 use crate::stdlib::registration::{
     async_builtin, register_builtin_group, AsyncBuiltin, BuiltinGroup, SyncBuiltin,
 };
@@ -45,7 +46,7 @@ const DEFAULT_MAX_CONCURRENT: usize = 1;
 const POOL_TYPE: &str = "pool";
 const POOL_TASK_TYPE: &str = "pool_task";
 const POOL_AUDIT_TOPIC: &str = "lifecycle.pool.audit";
-const POOL_EVENT_LOG_QUEUE_DEPTH: usize = 128;
+const POOL_EVENT_LOG_QUEUE_DEPTH: usize = RuntimeLimits::DEFAULT.default_event_log_queue_depth;
 
 /// On-disk root for pipeline-scope pool state. Mirrors the channel scope
 /// convention (`.harn/...`) so durable artifacts stay co-located with the

--- a/crates/harn-vm/src/stdlib/project.rs
+++ b/crates/harn-vm/src/stdlib/project.rs
@@ -6,6 +6,7 @@ use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use ignore::WalkBuilder;
 use sha2::{Digest, Sha256};
 
+use crate::runtime_limits::RuntimeLimits;
 use crate::value::{VmError, VmValue};
 use crate::vm::Vm;
 
@@ -40,7 +41,7 @@ const FINGERPRINT_SKIP_DIRS: &[&str] = &[
     "target",
     "venv",
 ];
-const PROJECT_FINGERPRINT_MAX_DEPTH: usize = 4;
+const PROJECT_FINGERPRINT_MAX_DEPTH: usize = RuntimeLimits::DEFAULT.max_project_fingerprint_depth;
 const PROJECT_LANGUAGE_ORDER: &[&str] = &["rust", "typescript", "python", "go", "swift", "ruby"];
 const PROJECT_FRAMEWORK_ORDER: &[&str] = &["axum", "next", "react", "django", "fastapi", "rails"];
 const PROJECT_PACKAGE_MANAGER_ORDER: &[&str] = &[

--- a/crates/harn-vm/src/stdlib/regex.rs
+++ b/crates/harn-vm/src/stdlib/regex.rs
@@ -2,8 +2,11 @@ use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap};
 use std::rc::Rc;
 
+use crate::runtime_limits::RuntimeLimits;
 use crate::value::{VmError, VmValue};
 use crate::vm::Vm;
+
+const REGEX_CACHE_LIMIT: usize = RuntimeLimits::DEFAULT.max_regex_cache_entries;
 
 thread_local! {
     static REGEX_CACHE: RefCell<HashMap<String, regex::Regex>> = RefCell::new(HashMap::new());
@@ -19,7 +22,7 @@ fn get_cached_regex(pattern: &str, flags: &str) -> Result<regex::Regex, VmError>
         let re = build_regex(pattern, flags).map_err(|e| {
             VmError::Thrown(VmValue::String(Rc::from(format!("Invalid regex: {e}"))))
         })?;
-        if cache.len() >= 128 {
+        if cache.len() >= REGEX_CACHE_LIMIT {
             cache.clear();
         }
         cache.insert(cache_key, re.clone());

--- a/crates/harn-vm/src/stdlib/review.rs
+++ b/crates/harn-vm/src/stdlib/review.rs
@@ -7,6 +7,7 @@ use sha2::Digest;
 
 use crate::event_log::{active_event_log, install_memory_for_current_thread, AnyEventLog};
 use crate::llm::{execute_llm_call, extract_llm_options, vm_value_to_json};
+use crate::runtime_limits::RuntimeLimits;
 use crate::stdlib::secret_scan::{audit_secret_scan_active, scan_content, SecretFinding};
 use crate::triggers::dispatcher::current_dispatch_context;
 use crate::trust_graph::{append_trust_record, AutonomyTier, TrustOutcome, TrustRecord};
@@ -15,7 +16,7 @@ use crate::vm::Vm;
 
 const DEFAULT_MAX_ROUNDS: usize = 1;
 const MAX_MAX_ROUNDS: usize = 5;
-const REVIEW_EVENT_LOG_QUEUE_DEPTH: usize = 128;
+const REVIEW_EVENT_LOG_QUEUE_DEPTH: usize = RuntimeLimits::DEFAULT.default_event_log_queue_depth;
 const REVIEW_ACTION: &str = "pr.self_review";
 const DEFAULT_MODEL_TIER: &str = "small";
 

--- a/crates/harn-vm/src/stdlib/template/assets.rs
+++ b/crates/harn-vm/src/stdlib/template/assets.rs
@@ -6,8 +6,9 @@ use std::rc::Rc;
 use super::ast::Node;
 use super::error::TemplateError;
 use super::parser::parse;
+use crate::runtime_limits::RuntimeLimits;
 
-const TEMPLATE_CACHE_CAP: usize = 128;
+const TEMPLATE_CACHE_CAP: usize = RuntimeLimits::DEFAULT.max_template_parse_cache_entries;
 
 #[derive(Debug, Clone)]
 pub(crate) struct TemplateAsset {

--- a/crates/harn-vm/src/stdlib/template/render.rs
+++ b/crates/harn-vm/src/stdlib/template/render.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 use std::rc::Rc;
 
+use crate::runtime_limits::RuntimeLimits;
 use crate::value::{values_equal, VmValue};
 
 use super::ast::{BinOp, Expr, IfBranch, Node, PathSeg, UnOp};
@@ -274,11 +275,12 @@ fn render_node(
                     format!("circular include detected: {chain} → {}", asset.id),
                 ));
             }
-            if rc.include_stack.len() >= 32 {
+            let max_depth = RuntimeLimits::DEFAULT.max_template_include_depth;
+            if rc.include_stack.len() >= max_depth {
                 return Err(TemplateError::new(
                     *line,
                     *col,
-                    "include depth exceeded (32 levels)",
+                    format!("include depth exceeded ({max_depth} levels)"),
                 ));
             }
             let mut child_bindings = scope.flatten();

--- a/crates/harn-vm/src/stdlib/triggers_stdlib.rs
+++ b/crates/harn-vm/src/stdlib/triggers_stdlib.rs
@@ -11,6 +11,7 @@ use uuid::Uuid;
 use crate::event_log::{
     active_event_log, install_memory_for_current_thread, EventLog, LogEvent, Topic,
 };
+use crate::runtime_limits::RuntimeLimits;
 use crate::triggers::dispatcher::current_dispatch_context;
 use crate::triggers::dispatcher::DEFAULT_MAX_ATTEMPTS;
 use crate::triggers::registry::{AgentScope, TargetExpr};
@@ -36,7 +37,7 @@ use crate::TriggerPredicateBudget;
 
 const ACTION_GRAPH_TOPIC: &str = "observability.action_graph";
 const TRIGGER_EVENTS_TOPIC: &str = "triggers.events";
-const TRIGGER_EVENT_LOG_QUEUE_DEPTH: usize = 128;
+const TRIGGER_EVENT_LOG_QUEUE_DEPTH: usize = RuntimeLimits::DEFAULT.default_event_log_queue_depth;
 
 thread_local! {
     static AUTO_RESUME_TIMEOUTS: RefCell<BTreeMap<String, tokio::task::JoinHandle<()>>> =

--- a/crates/harn-vm/src/stdlib/waitpoint.rs
+++ b/crates/harn-vm/src/stdlib/waitpoint.rs
@@ -14,6 +14,7 @@ use crate::event_log::{
     active_event_log, install_memory_for_current_thread, sanitize_topic_component, AnyEventLog,
     EventLog, LogEvent, Topic,
 };
+use crate::runtime_limits::RuntimeLimits;
 use crate::triggers::dispatcher::{
     current_dispatch_context, current_dispatch_is_replay, DispatchContext,
 };
@@ -21,7 +22,7 @@ use crate::triggers::registry::{resolve_live_or_as_of, RecordedTriggerBinding};
 use crate::value::{categorized_error, ErrorCategory, VmError, VmValue};
 use crate::vm::{clone_async_builtin_child_vm, Vm};
 
-const WAITPOINT_EVENT_LOG_QUEUE_DEPTH: usize = 128;
+const WAITPOINT_EVENT_LOG_QUEUE_DEPTH: usize = RuntimeLimits::DEFAULT.default_event_log_queue_depth;
 const WAITPOINT_WAITS_TOPIC: &str = "waitpoint.waits";
 pub const WAITPOINT_RESUME_TOPIC: &str = "waitpoint.resumes";
 const TRIGGER_EVENTS_TOPIC: &str = "triggers.events";

--- a/crates/harn-vm/src/stdlib/waitpoints.rs
+++ b/crates/harn-vm/src/stdlib/waitpoints.rs
@@ -13,6 +13,7 @@ use crate::event_log::{
     active_event_log, install_memory_for_current_thread, AnyEventLog, EventLog,
 };
 use crate::llm::vm_value_to_json;
+use crate::runtime_limits::RuntimeLimits;
 use crate::triggers::dispatcher::{current_dispatch_context, current_dispatch_wait_lease};
 use crate::value::{VmError, VmValue};
 use crate::vm::clone_async_builtin_child_vm;
@@ -24,7 +25,7 @@ use crate::waitpoints::{
     WaitpointWaitStartRecord, WaitpointWaitStatus,
 };
 
-const WAITPOINT_EVENT_LOG_QUEUE_DEPTH: usize = 128;
+const WAITPOINT_EVENT_LOG_QUEUE_DEPTH: usize = RuntimeLimits::DEFAULT.default_event_log_queue_depth;
 
 thread_local! {
     static WAITPOINT_ID_SEQUENCE: RefCell<SequenceState> = RefCell::new(SequenceState::default());

--- a/crates/harn-vm/src/triggers/webhook_intake.rs
+++ b/crates/harn-vm/src/triggers/webhook_intake.rs
@@ -44,6 +44,7 @@ use crate::connectors::MetricsRegistry;
 use crate::event_log::{
     active_event_log, install_memory_for_current_thread, EventLog, LogEvent, Topic,
 };
+use crate::runtime_limits::RuntimeLimits;
 use crate::triggers::inbox::InboxIndex;
 
 /// Default delivery-id retention used when callers omit the field. Matches the
@@ -51,7 +52,7 @@ use crate::triggers::inbox::InboxIndex;
 pub const DEFAULT_DEDUPE_TTL_SECS: u64 = 24 * 60 * 60;
 /// Topic the substrate appends `webhook_intake_rejected` audit events on.
 pub const REJECTION_TOPIC: &str = "triggers.webhook_intake.rejections";
-const INTAKE_EVENT_LOG_QUEUE_DEPTH: usize = 128;
+const INTAKE_EVENT_LOG_QUEUE_DEPTH: usize = RuntimeLimits::DEFAULT.default_event_log_queue_depth;
 
 /// Identifier of a registered intake. Stable for the lifetime of the process,
 /// or until `webhook_intake_deregister` is called.

--- a/crates/harn-vm/src/vm/scope.rs
+++ b/crates/harn-vm/src/vm/scope.rs
@@ -5,8 +5,6 @@ use crate::value::{VmClosure, VmEnv, VmError, VmValue};
 use super::{CallArgs, CallFrame, LocalSlot, Vm};
 
 impl Vm {
-    pub(crate) const MAX_FRAMES: usize = 512;
-
     /// Build the call-time env for a closure invocation.
     ///
     /// Harn is **lexically scoped for data**: a closure sees exactly the
@@ -174,7 +172,7 @@ impl Vm {
         closure: &VmClosure,
         args: &CallArgs<'_>,
     ) -> Result<(), VmError> {
-        if self.frames.len() >= Self::MAX_FRAMES {
+        if self.frames.len() >= self.runtime_limits.max_vm_frames {
             return Err(VmError::StackOverflow);
         }
         let (local_slots, initial_local_slots) =
@@ -206,7 +204,7 @@ impl Vm {
                 "invalid call argument stack range".to_string(),
             ));
         }
-        if self.frames.len() >= Self::MAX_FRAMES {
+        if self.frames.len() >= self.runtime_limits.max_vm_frames {
             self.stack.truncate(stack_truncate_to);
             return Err(VmError::StackOverflow);
         }

--- a/crates/harn-vm/src/vm/state.rs
+++ b/crates/harn-vm/src/vm/state.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use crate::chunk::{Chunk, ChunkRef, Constant};
+use crate::runtime_limits::RuntimeLimits;
 use crate::value::{
     ModuleFunctionRegistry, VmAsyncBuiltinFn, VmBuiltinFn, VmEnv, VmError, VmTaskHandle, VmValue,
 };
@@ -249,6 +250,8 @@ pub struct Vm {
     pub(crate) globals: Rc<BTreeMap<String, VmValue>>,
     /// Optional debugger hook invoked when execution advances to a new source line.
     pub(crate) debug_hook: Option<Box<DebugHook>>,
+    /// Effective runtime ceilings for this VM execution.
+    pub(crate) runtime_limits: RuntimeLimits,
 }
 
 /// Reusable VM baseline for hosts that need many clean executions with the
@@ -272,6 +275,7 @@ pub struct VmBaseline {
     project_root: Option<std::path::PathBuf>,
     globals: Rc<BTreeMap<String, VmValue>>,
     denied_builtins: Rc<HashSet<String>>,
+    runtime_limits: RuntimeLimits,
 }
 
 impl VmBaseline {
@@ -289,6 +293,7 @@ impl VmBaseline {
             project_root: vm.project_root.clone(),
             globals: Rc::clone(&vm.globals),
             denied_builtins: Rc::clone(&vm.denied_builtins),
+            runtime_limits: vm.runtime_limits,
         }
     }
 
@@ -351,6 +356,7 @@ impl VmBaseline {
             project_root: self.project_root.clone(),
             globals: Rc::clone(&self.globals),
             debug_hook: None,
+            runtime_limits: self.runtime_limits,
         };
 
         crate::stdlib::rebind_execution_state_builtins(&mut vm);
@@ -566,11 +572,22 @@ impl Vm {
             project_root: None,
             globals: Rc::new(BTreeMap::new()),
             debug_hook: None,
+            runtime_limits: RuntimeLimits::default(),
         }
     }
 
     pub fn baseline(&self) -> VmBaseline {
         VmBaseline::from_vm(self)
+    }
+
+    /// Return the effective runtime limit profile for this VM.
+    pub fn runtime_limits(&self) -> RuntimeLimits {
+        self.runtime_limits
+    }
+
+    /// Return a host/debug report describing the VM's effective runtime limits.
+    pub fn runtime_limit_report(&self) -> crate::RuntimeLimitsReport {
+        self.runtime_limits.report()
     }
 
     /// Returns true if any debugging affordance is active — DAP hook,
@@ -703,6 +720,7 @@ impl Vm {
             project_root: self.project_root.clone(),
             globals: Rc::clone(&self.globals),
             debug_hook: None,
+            runtime_limits: self.runtime_limits,
         }
     }
 
@@ -898,6 +916,22 @@ mod tests {
             .globals
             .get("stable_global")
             .is_some_and(|value| value.display() == "baseline"));
+    }
+
+    #[test]
+    fn vm_reports_effective_runtime_limits() {
+        let vm = Vm::new();
+
+        assert_eq!(vm.runtime_limits(), RuntimeLimits::default());
+        assert_eq!(
+            vm.runtime_limit_report().entries.len(),
+            crate::RUNTIME_LIMIT_DESCRIPTIONS.len()
+        );
+        assert_eq!(vm.child_vm().runtime_limits(), vm.runtime_limits());
+        assert_eq!(
+            vm.baseline().instantiate().runtime_limits(),
+            vm.runtime_limits()
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]


### PR DESCRIPTION
## Summary
- add a documented `RuntimeLimits` profile and public VM/runtime report path
- route VM frame depth, prompt-template, event-log queue, parse/cache, agent-session, project fingerprint, optimizer, and schema-nudge limits through the profile
- add default-value and VM inheritance/report tests so accidental limit drift is visible

## Verification
- `cargo test -p harn-vm`
- pre-commit hook: formatting, prompt prose ratchet, changed-package clippy, CI ratchets, highlight keyword drift
- pre-push hook: targeted local checks and generated highlight keyword drift

Closes #2201